### PR TITLE
feat(app): Don't crash when we encounter labware schema 3

### DIFF
--- a/api-client/src/maintenance_runs/createMaintenanceRunLabwareDefinition.ts
+++ b/api-client/src/maintenance_runs/createMaintenanceRunLabwareDefinition.ts
@@ -1,9 +1,6 @@
 import { POST, request } from '../request'
 
-import type {
-  LabwareDefinition2,
-  LabwareDefinition3,
-} from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 import type { ResponsePromise } from '../request'
 import type { HostConfig } from '../types'
 import type { LabwareDefinitionSummary } from './types'
@@ -11,12 +8,9 @@ import type { LabwareDefinitionSummary } from './types'
 export function createMaintenanceRunLabwareDefinition(
   config: HostConfig,
   maintenanceRunId: string,
-  data: LabwareDefinition2 | LabwareDefinition3
+  data: LabwareDefinition
 ): ResponsePromise<LabwareDefinitionSummary> {
-  return request<
-    LabwareDefinitionSummary,
-    { data: LabwareDefinition2 | LabwareDefinition3 }
-  >(
+  return request<LabwareDefinitionSummary, { data: LabwareDefinition }>(
     POST,
     `/maintenance_runs/${maintenanceRunId}/labware_definitions`,
     { data },

--- a/api-client/src/runs/createLabwareDefinition.ts
+++ b/api-client/src/runs/createLabwareDefinition.ts
@@ -1,6 +1,6 @@
 import { POST, request } from '../request'
 
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 import type { ResponsePromise } from '../request'
 import type { HostConfig } from '../types'
 
@@ -11,10 +11,10 @@ export interface CreateLabwareDefinitionResponsePayload {
 export function createLabwareDefinition(
   config: HostConfig,
   runId: string,
-  data: LabwareDefinition2
+  data: LabwareDefinition
 ): ResponsePromise<CreateLabwareDefinitionResponsePayload> {
   return request<
     CreateLabwareDefinitionResponsePayload,
-    { data: LabwareDefinition2 }
+    { data: LabwareDefinition }
   >(POST, `/runs/${runId}/labware_definitions`, { data }, config)
 }

--- a/api-client/src/runs/types.ts
+++ b/api-client/src/runs/types.ts
@@ -1,7 +1,5 @@
 import type {
-  LabwareDefinition1,
-  LabwareDefinition2,
-  LabwareDefinition3,
+  LabwareDefinition,
   Liquid,
   LoadedLabware,
   LoadedModule,
@@ -96,7 +94,7 @@ export interface LabwareOffset {
 }
 
 export interface RunLoadedLabwareDefinitions {
-  data: Array<LabwareDefinition1 | LabwareDefinition2 | LabwareDefinition3>
+  data: LabwareDefinition[]
 }
 
 export interface Run {

--- a/app-shell/src/labware/__tests__/validation.test.ts
+++ b/app-shell/src/labware/__tests__/validation.test.ts
@@ -4,6 +4,7 @@ import {
   fixture96Plate as uncheckedLabwareA,
   fixture12Trough as uncheckedLabwareB,
 } from '@opentrons/shared-data'
+import { fixture_corning_24_plate as uncheckedLabwareC } from '@opentrons/shared-data/labware/fixtures/3'
 
 import { validateLabwareFiles, validateNewLabwareFile } from '../validation'
 
@@ -12,6 +13,7 @@ import type { LabwareDefinition } from '@opentrons/shared-data'
 
 const validLabwareA = uncheckedLabwareA as LabwareDefinition
 const validLabwareB = uncheckedLabwareB as LabwareDefinition
+const validLabwareC = uncheckedLabwareC as LabwareDefinition
 
 describe('validateLabwareFiles', () => {
   it('handles unparseable and invalid labware files', () => {
@@ -38,6 +40,7 @@ describe('validateLabwareFiles', () => {
     const files = [
       { filename: 'a.json', data: uncheckedLabwareA, modified: Date.now() },
       { filename: 'b.json', data: uncheckedLabwareB, modified: Date.now() },
+      { filename: 'b.json', data: uncheckedLabwareC, modified: Date.now() },
     ]
 
     expect(validateLabwareFiles(files)).toEqual([
@@ -52,6 +55,12 @@ describe('validateLabwareFiles', () => {
         filename: 'b.json',
         modified: expect.any(Number),
         definition: validLabwareB,
+      },
+      {
+        type: 'VALID_LABWARE_FILE',
+        filename: 'c.json',
+        modified: expect.any(Number),
+        definition: validLabwareC,
       },
     ])
   })

--- a/app-shell/src/labware/__tests__/validation.test.ts
+++ b/app-shell/src/labware/__tests__/validation.test.ts
@@ -8,10 +8,10 @@ import {
 import { validateLabwareFiles, validateNewLabwareFile } from '../validation'
 
 import type { CheckedLabwareFile } from '@opentrons/app/src/redux/custom-labware/types'
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 
-const validLabwareA = uncheckedLabwareA as LabwareDefinition2
-const validLabwareB = uncheckedLabwareB as LabwareDefinition2
+const validLabwareA = uncheckedLabwareA as LabwareDefinition
+const validLabwareB = uncheckedLabwareB as LabwareDefinition
 
 describe('validateLabwareFiles', () => {
   it('handles unparseable and invalid labware files', () => {

--- a/app-shell/src/labware/__tests__/validation.test.ts
+++ b/app-shell/src/labware/__tests__/validation.test.ts
@@ -40,7 +40,7 @@ describe('validateLabwareFiles', () => {
     const files = [
       { filename: 'a.json', data: uncheckedLabwareA, modified: Date.now() },
       { filename: 'b.json', data: uncheckedLabwareB, modified: Date.now() },
-      { filename: 'b.json', data: uncheckedLabwareC, modified: Date.now() },
+      { filename: 'c.json', data: uncheckedLabwareC, modified: Date.now() },
     ]
 
     expect(validateLabwareFiles(files)).toEqual([

--- a/app-shell/src/labware/definitions.ts
+++ b/app-shell/src/labware/definitions.ts
@@ -37,7 +37,7 @@ export function parseLabwareFiles(
       try {
         const data = JSON.parse(filesOrContent)
         const modified = Date.now()
-        const filename = `${data.parameters?.loadName}.json` ?? 'unknown_file'
+        const filename = `${data?.parameters?.loadName}.json` ?? 'unknown_file'
 
         resolve([{ filename, modified, data }])
       } catch (error) {
@@ -60,7 +60,7 @@ export function parseLabwareFiles(
   } else {
     return Promise.reject(
       new Error(
-        'Invalid input: expected an inported file or data from App Labware Creator'
+        'Invalid input: expected an imported file or data from App Labware Creator'
       )
     )
   }

--- a/app-shell/src/labware/validation.ts
+++ b/app-shell/src/labware/validation.ts
@@ -21,18 +21,18 @@ import type {
   UncheckedLabwareFile,
 } from '@opentrons/app/src/redux/custom-labware/types'
 import type {
-  LabwareDefinition2,
+  LabwareDefinition,
   LabwareDefinition3,
 } from '@opentrons/shared-data'
 
 const ajv = new Ajv()
 
 // todo(mm, 2025-05-13): When we have ajv>=7, add a type parameter like
-// `ajv.compile<LabwareDefinition2>(...)` so we don't have to make our own type guards.
+// `ajv.compile<LabwareDefinition>(...)` so we don't have to make our own type guards.
 const ajvValidateSchema2 = ajv.compile(labwareSchemaV2 as object)
 const ajvValidateSchema3 = ajv.compile(labwareSchemaV3 as object)
 
-function isValidSchema2(data: unknown): data is LabwareDefinition2 {
+function isValidSchema2(data: unknown): data is LabwareDefinition {
   const result = ajvValidateSchema2(data)
   return typeof result === 'boolean' && result
 }
@@ -45,9 +45,7 @@ function isValidSchema3(data: unknown): data is LabwareDefinition3 {
 // TODO(mc, 2019-10-21): this code is somewhat duplicated with stuff in
 // shared-data, but the shared-data validation function isn't geared towards
 // this use case because it either throws or passes invalid files; align them
-function validateLabwareDefinition(
-  data: unknown
-): LabwareDefinition2 | LabwareDefinition3 | null {
+function validateLabwareDefinition(data: unknown): LabwareDefinition | null {
   const schemaVersion = safeGetSchemaVersion(data)
   if (schemaVersion === 3) {
     return isValidSchema3(data) ? data : null

--- a/app-shell/src/labware/validation.ts
+++ b/app-shell/src/labware/validation.ts
@@ -3,7 +3,8 @@ import sortBy from 'lodash/sortBy'
 
 import {
   getLabwareDefIsStandard,
-  labwareSchemaV2 as labwareSchema,
+  labwareSchemaV2,
+  labwareSchemaV3,
   validateCustomLabwareHelper,
 } from '@opentrons/shared-data'
 
@@ -19,17 +20,48 @@ import type {
   CheckedLabwareFile,
   UncheckedLabwareFile,
 } from '@opentrons/app/src/redux/custom-labware/types'
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type {
+  LabwareDefinition2,
+  LabwareDefinition3,
+} from '@opentrons/shared-data'
 
 const ajv = new Ajv()
-const validateDefinition = ajv.compile(labwareSchema)
+
+// todo(mm, 2025-05-13): When we have ajv>=7, add a type parameter like
+// `ajv.compile<LabwareDefinition2>(...)` so we don't have to make our own type guards.
+const ajvValidateSchema2 = ajv.compile(labwareSchemaV2 as object)
+const ajvValidateSchema3 = ajv.compile(labwareSchemaV3 as object)
+
+function isValidSchema2(data: unknown): data is LabwareDefinition2 {
+  const result = ajvValidateSchema2(data)
+  return typeof result === 'boolean' && result
+}
+
+function isValidSchema3(data: unknown): data is LabwareDefinition3 {
+  const result = ajvValidateSchema3(data)
+  return typeof result === 'boolean' && result
+}
 
 // TODO(mc, 2019-10-21): this code is somewhat duplicated with stuff in
 // shared-data, but the shared-data validation function isn't geared towards
 // this use case because it either throws or passes invalid files; align them
-const validateLabwareDefinition = (data: any): LabwareDefinition2 | null =>
-  // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-  validateDefinition(data) ? data : null
+function validateLabwareDefinition(
+  data: unknown
+): LabwareDefinition2 | LabwareDefinition3 | null {
+  const schemaVersion = safeGetSchemaVersion(data)
+  if (schemaVersion === 3) {
+    return isValidSchema3(data) ? data : null
+  } else if (schemaVersion === 2) {
+    return isValidSchema2(data) ? data : null
+  } else return null
+}
+
+function safeGetSchemaVersion(maybeLabwareDefinition: unknown): number | null {
+  const maybeSchemaVersion: unknown = (maybeLabwareDefinition as any)
+    ?.schemaVersion
+  if (typeof maybeSchemaVersion === 'number') return maybeSchemaVersion
+  return null
+}
 
 // validate a collection of unchecked labware files
 export function validateLabwareFiles(

--- a/app-shell/vite.config.mts
+++ b/app-shell/vite.config.mts
@@ -59,6 +59,9 @@ export default defineConfig(
           '@opentrons/usb-bridge/node-client': path.resolve(
             '../usb-bridge/node-client/src/index.ts'
           ),
+          '@opentrons/shared-data/labware/fixtures/3': path.resolve(
+            '../shared-data/labware/fixtures/3/index.ts'
+          ),
         },
       },
     }

--- a/app/src/assets/labware/__tests__/findLabware.test.ts
+++ b/app/src/assets/labware/__tests__/findLabware.test.ts
@@ -5,7 +5,7 @@ import { fixtureTiprack10ul, fixtureTiprack300ul } from '@opentrons/shared-data'
 import { findLabwareDefWithCustom } from '../findLabware'
 import { getLatestLabwareDef } from '../getLabware'
 
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 
 vi.mock('../getLabware', async importOriginal => {
   const actual = await importOriginal<typeof getLatestLabwareDef>()
@@ -15,22 +15,22 @@ vi.mock('../getLabware', async importOriginal => {
   }
 })
 
-const fixtureTipRack10ul = fixtureTiprack10ul as LabwareDefinition2
+const fixtureTipRack10ul = fixtureTiprack10ul as LabwareDefinition
 
 const fixtureTipRack10ulCustomBeta = {
   ...fixtureTiprack10ul,
   namespace: 'custom_beta',
-} as LabwareDefinition2
+} as LabwareDefinition
 
 const fixtureTipRack10ulVersion2 = {
   ...fixtureTiprack10ul,
   version: 2,
-} as LabwareDefinition2
+} as LabwareDefinition
 
 const fixtureTipRack300ulOpentrons = {
   ...fixtureTiprack300ul,
   namespace: 'opentrons',
-} as LabwareDefinition2
+} as LabwareDefinition
 
 describe('findLabwareDefWithCustom', () => {
   afterEach(() => {
@@ -129,7 +129,7 @@ describe('findLabwareDefWithCustom', () => {
           spec.namespace,
           spec.loadName,
           spec.version,
-          spec.customLabware as LabwareDefinition2[]
+          spec.customLabware as LabwareDefinition[]
         )
       ).toEqual(spec.expect)
     })

--- a/app/src/assets/labware/findLabware.ts
+++ b/app/src/assets/labware/findLabware.ts
@@ -2,7 +2,7 @@ import head from 'lodash/head'
 
 import { getLatestLabwareDef } from './getLabware'
 
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 
 // TODO(mc, 2021-05-19): this function does not filter by namespace
 // nor version. Instead, it short-circuits as soon as it finds a loadName match
@@ -11,8 +11,8 @@ function filterLabwareDefinitions(
   namespace: string | null,
   loadName: string | null,
   version: string | null,
-  customLabware: LabwareDefinition2[]
-): LabwareDefinition2 | null {
+  customLabware: LabwareDefinition[]
+): LabwareDefinition | null {
   return (
     head(
       customLabware.filter(
@@ -29,8 +29,8 @@ export function findLabwareDefWithCustom(
   namespace: string | null,
   loadName: string | null,
   version: string | null,
-  customLabware: LabwareDefinition2[]
-): LabwareDefinition2 | null {
+  customLabware: LabwareDefinition[]
+): LabwareDefinition | null {
   return namespace === 'opentrons'
     ? getLatestLabwareDef(loadName)
     : filterLabwareDefinitions(namespace, loadName, version, customLabware)

--- a/app/src/assets/labware/getLabware.ts
+++ b/app/src/assets/labware/getLabware.ts
@@ -4,8 +4,8 @@ import {
 } from '@opentrons/shared-data'
 
 import type {
+  LabwareDefinition,
   LabwareDefinition1,
-  LabwareDefinition2,
 } from '@opentrons/shared-data'
 
 export function getLegacyLabwareDef(
@@ -19,7 +19,7 @@ export function getLegacyLabwareDef(
 
 export function getLatestLabwareDef(
   loadName: string | null | undefined
-): LabwareDefinition2 | null {
+): LabwareDefinition | null {
   const def = Object.values(getLatestDefinitions()).find(
     d => d.parameters.loadName === loadName
   )

--- a/app/src/local-resources/labware/types.ts
+++ b/app/src/local-resources/labware/types.ts
@@ -1,6 +1,6 @@
 import type {
   LabwareBrand,
-  LabwareDefinition2 as LabwareDefinition,
+  LabwareDefinition,
   LabwareWellGroupMetadata,
   LabwareWellShapeProperties,
   LoadedLabware,

--- a/app/src/local-resources/labware/utils/__mocks__/getAllDefs.ts
+++ b/app/src/local-resources/labware/utils/__mocks__/getAllDefs.ts
@@ -3,7 +3,7 @@ import path from 'path'
 import glob from 'glob'
 import { vi } from 'vitest'
 
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 
 // require all definitions in the labware/definitions/2 directory
 // require.context is webpack-specific method
@@ -15,8 +15,8 @@ const DEFS_FIXTURE_PATTERN = path.join(
 const allDefs: unknown[] = glob.sync(DEFS_FIXTURE_PATTERN).map(require)
 
 export const getAllDefs = vi.fn(() =>
-  (allDefs as LabwareDefinition2[]).reduce(
-    (acc, def: LabwareDefinition2): Record<string, LabwareDefinition2> => ({
+  (allDefs as LabwareDefinition[]).reduce(
+    (acc, def: LabwareDefinition): Record<string, LabwareDefinition> => ({
       ...acc,
       [def.namespace]: def,
     }),

--- a/app/src/local-resources/labware/utils/getAllDefinitions.ts
+++ b/app/src/local-resources/labware/utils/getAllDefinitions.ts
@@ -4,15 +4,15 @@ import { LABWAREV2_DO_NOT_LIST } from '@opentrons/shared-data'
 
 import { getAllDefs } from './getAllDefs'
 
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 
 const getOnlyLatestDefs = (
-  labwareList: LabwareDefinition2[]
-): LabwareDefinition2[] => {
+  labwareList: LabwareDefinition[]
+): LabwareDefinition[] => {
   // group by namespace + loadName
   const labwareDefGroups: {
-    [groupKey: string]: LabwareDefinition2[]
-  } = groupBy<LabwareDefinition2>(
+    [groupKey: string]: LabwareDefinition[]
+  } = groupBy<LabwareDefinition>(
     labwareList,
     d => `${d.namespace}/${d.parameters.loadName}`
   )
@@ -25,9 +25,9 @@ const getOnlyLatestDefs = (
   })
 }
 
-export function getAllDefinitions(): LabwareDefinition2[] {
+export function getAllDefinitions(): LabwareDefinition[] {
   const allDefs = getAllDefs().filter(
-    (d: LabwareDefinition2) =>
+    (d: LabwareDefinition) =>
       // eslint-disable-next-line @typescript-eslint/prefer-includes
       LABWAREV2_DO_NOT_LIST.indexOf(d.parameters.loadName) === -1
   )

--- a/app/src/local-resources/labware/utils/getAllDefs.ts
+++ b/app/src/local-resources/labware/utils/getAllDefs.ts
@@ -1,7 +1,7 @@
 import { getAllDefinitions } from '@opentrons/shared-data'
 
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 
-export function getAllDefs(): LabwareDefinition2[] {
+export function getAllDefs(): LabwareDefinition[] {
   return Object.values(getAllDefinitions())
 }

--- a/app/src/molecules/Command/Command.tsx
+++ b/app/src/molecules/Command/Command.tsx
@@ -18,7 +18,7 @@ import { CommandIcon } from './CommandIcon'
 
 import type { CommandTextData, StyleProps } from '@opentrons/components'
 import type {
-  LabwareDefinition2,
+  LabwareDefinition,
   RobotType,
   RunTimeCommand,
 } from '@opentrons/shared-data'
@@ -41,7 +41,7 @@ interface SkeletonCommandProps extends FundamentalProps {
 interface NonSkeletonCommandProps extends FundamentalProps {
   state: NonSkeletonCommandState
   command: RunTimeCommand
-  allRunDefs: LabwareDefinition2[]
+  allRunDefs: LabwareDefinition[]
   commandTextData: CommandTextData
 }
 

--- a/app/src/molecules/InterventionModal/CategorizedStepContent.tsx
+++ b/app/src/molecules/InterventionModal/CategorizedStepContent.tsx
@@ -13,7 +13,7 @@ import { Command, CommandIndex } from '../Command'
 
 import type { CommandTextData } from '@opentrons/components'
 import type {
-  LabwareDefinition2,
+  LabwareDefinition,
   RobotType,
   RunTimeCommand,
 } from '@opentrons/shared-data'
@@ -27,7 +27,7 @@ export interface CommandWithIndex {
 export interface CategorizedStepContentProps {
   robotType: RobotType
   commandTextData: CommandTextData | null
-  allRunDefs: LabwareDefinition2[]
+  allRunDefs: LabwareDefinition[]
   topCategoryHeadline: string
   topCategory: NonSkeletonCommandState
   topCategoryCommand: CommandWithIndex | null
@@ -52,7 +52,7 @@ type MappedState =
       command: RunTimeCommand
       state: NonSkeletonCommandState
       commandTextData: CommandTextData
-      allRunDefs: LabwareDefinition2[]
+      allRunDefs: LabwareDefinition[]
     }
   | typeof EMPTY_COMMAND
 
@@ -60,7 +60,7 @@ const commandAndState = (
   command: CommandWithIndex | null,
   state: NonSkeletonCommandState,
   commandTextData: CommandTextData | null,
-  allRunDefs: LabwareDefinition2[]
+  allRunDefs: LabwareDefinition[]
 ): MappedState =>
   command == null || commandTextData == null
     ? EMPTY_COMMAND

--- a/app/src/molecules/InterventionModal/DeckMapContent.stories.tsx
+++ b/app/src/molecules/InterventionModal/DeckMapContent.stories.tsx
@@ -23,40 +23,40 @@ import { TwoColumn } from './TwoColumn'
 
 import type { Meta, StoryObj } from '@storybook/react'
 import type * as React from 'react'
-import type { LabwareDefinition2, ModuleLocation } from '@opentrons/shared-data'
+import type { LabwareDefinition, ModuleLocation } from '@opentrons/shared-data'
 
 const DEFAULT_MODULES_ON_DECK = [
   {
     moduleLocation: { slotName: 'B1' },
     moduleModel: THERMOCYCLER_MODULE_V2,
-    nestedLabwareDef: fixture96Plate as LabwareDefinition2,
+    nestedLabwareDef: fixture96Plate as LabwareDefinition,
     innerProps: { lidMotorState: 'open' },
   },
   {
     moduleLocation: { slotName: 'D1' },
     moduleModel: TEMPERATURE_MODULE_V2,
-    nestedLabwareDef: fixture96Plate as LabwareDefinition2,
+    nestedLabwareDef: fixture96Plate as LabwareDefinition,
   },
   {
     moduleLocation: { slotName: 'B3' },
     moduleModel: HEATERSHAKER_MODULE_V1,
-    nestedLabwareDef: fixture96Plate as LabwareDefinition2,
+    nestedLabwareDef: fixture96Plate as LabwareDefinition,
   },
   {
     moduleLocation: { slotName: 'D2' },
     moduleModel: MAGNETIC_BLOCK_V1,
-    nestedLabwareDef: fixture96Plate as LabwareDefinition2,
+    nestedLabwareDef: fixture96Plate as LabwareDefinition,
   },
 ]
 
 const DEFAULT_LABWARE_ON_DECK = [
   {
     labwareLocation: { slotName: 'C2' },
-    definition: fixture96Plate as LabwareDefinition2,
+    definition: fixture96Plate as LabwareDefinition,
   },
   {
     labwareLocation: { slotName: 'C3' },
-    definition: fixtureTiprack1000ul as LabwareDefinition2,
+    definition: fixtureTiprack1000ul as LabwareDefinition,
   },
 ]
 

--- a/app/src/molecules/InterventionModal/DeckMapContent.tsx
+++ b/app/src/molecules/InterventionModal/DeckMapContent.tsx
@@ -11,6 +11,10 @@ import {
   RobotCoordsForeignDiv,
   useDeckLocationSelect,
 } from '@opentrons/components'
+import {
+  getSchema2CornerOffsetFromSlot,
+  getSchema2Dimensions,
+} from '@opentrons/shared-data'
 
 import type { ComponentProps } from 'react'
 import type {
@@ -122,13 +126,15 @@ export function LabwareHighlight({
   highlight: boolean
   definition: LabwareDefinition
 }): JSX.Element {
-  const width = definition.dimensions.xDimension
-  const height = definition.dimensions.yDimension
+  const { xDimension: width, yDimension: height } = getSchema2Dimensions(
+    definition
+  )
+  const cornerOffsetFromSlot = getSchema2CornerOffsetFromSlot(definition)
 
   return (
     <RobotCoordsForeignDiv
-      x={definition.cornerOffsetFromSlot.x}
-      y={definition.cornerOffsetFromSlot.y}
+      x={cornerOffsetFromSlot.x}
+      y={cornerOffsetFromSlot.y}
       {...{ width, height }}
       innerDivProps={{
         display: DISPLAY_FLEX,

--- a/app/src/molecules/InterventionModal/DeckMapContent.tsx
+++ b/app/src/molecules/InterventionModal/DeckMapContent.tsx
@@ -14,7 +14,7 @@ import {
 
 import type { ComponentProps } from 'react'
 import type {
-  LabwareDefinition2,
+  LabwareDefinition,
   LabwareLocation,
   ModuleLocation,
   RobotType,
@@ -120,7 +120,7 @@ export function LabwareHighlight({
   definition,
 }: {
   highlight: boolean
-  definition: LabwareDefinition2
+  definition: LabwareDefinition
 }): JSX.Element {
   const width = definition.dimensions.xDimension
   const height = definition.dimensions.yDimension

--- a/app/src/molecules/LabwareOffsetSnippet/createSnippet/buildLoadCommandCopy.ts
+++ b/app/src/molecules/LabwareOffsetSnippet/createSnippet/buildLoadCommandCopy.ts
@@ -93,6 +93,8 @@ function handleLoadLabwareCommand(
       adapterVariableById
     )
 
+    // todo(mm, 2025-05-19): What is this adding over just using loadedLabware.definitionUri?
+    // Is the lookup into labwareDefinitions load-bearing for some safety thing?
     const labwareDefUri = getLabwareDefinitionUri(
       labwareId,
       labware,

--- a/app/src/molecules/LiquidDetailCard/LiquidCardList.tsx
+++ b/app/src/molecules/LiquidDetailCard/LiquidCardList.tsx
@@ -9,11 +9,11 @@ import { getIsOnDevice } from '/app/redux/config'
 import { LiquidDetailCard } from './LiquidDetailCard'
 
 import type { Dispatch, SetStateAction } from 'react'
-import type { LabwareDefinition2, ParsedLiquid } from '@opentrons/shared-data'
+import type { LabwareDefinition, ParsedLiquid } from '@opentrons/shared-data'
 import type { LabwareByLiquidId } from '/app/transformations/commands'
 
 interface LiquidCardListProps {
-  selectedLabwareDefinition: LabwareDefinition2
+  selectedLabwareDefinition: LabwareDefinition
   selectedLiquidId: string | undefined
   setSelectedLiquidId: Dispatch<SetStateAction<string | undefined>>
   liquidsInLoadOrder: ParsedLiquid[]

--- a/app/src/organisms/Desktop/CalibrationPanels/CalibrationLabwareRender.tsx
+++ b/app/src/organisms/Desktop/CalibrationPanels/CalibrationLabwareRender.tsx
@@ -13,16 +13,13 @@ import { getIsTiprack, getLabwareDisplayName } from '@opentrons/shared-data'
 
 import styles from './styles.module.css'
 
-import type {
-  CoordinateTuple,
-  LabwareDefinition2,
-} from '@opentrons/shared-data'
+import type { CoordinateTuple, LabwareDefinition } from '@opentrons/shared-data'
 
 const SHORT = 'SHORT'
 const TALL = 'TALL'
 
 interface CalibrationLabwareRenderProps {
-  labwareDef: LabwareDefinition2
+  labwareDef: LabwareDefinition
   slotDefPosition: CoordinateTuple | null
 }
 

--- a/app/src/organisms/Desktop/CalibrationPanels/CalibrationLabwareRender.tsx
+++ b/app/src/organisms/Desktop/CalibrationPanels/CalibrationLabwareRender.tsx
@@ -9,7 +9,11 @@ import {
   RobotCoordsText,
   TYPOGRAPHY,
 } from '@opentrons/components'
-import { getIsTiprack, getLabwareDisplayName } from '@opentrons/shared-data'
+import {
+  getIsTiprack,
+  getLabwareDisplayName,
+  getSchema2Dimensions,
+} from '@opentrons/shared-data'
 
 import styles from './styles.module.css'
 
@@ -29,6 +33,7 @@ export function CalibrationLabwareRender(
   const { labwareDef, slotDefPosition } = props
 
   const title = getLabwareDisplayName(labwareDef)
+  const dimensions = getSchema2Dimensions(labwareDef)
   const isTiprack = getIsTiprack(labwareDef)
 
   // TODO: we can change this boolean to check to isCalibrationBlock instead of isTiprack to render any labware
@@ -40,10 +45,10 @@ export function CalibrationLabwareRender(
     >
       <LabwareRender definition={labwareDef} />
       <RobotCoordsForeignDiv
-        width={labwareDef.dimensions.xDimension}
-        height={labwareDef.dimensions.yDimension}
+        width={dimensions.xDimension}
+        height={dimensions.yDimension}
         x={0}
-        y={0 - labwareDef.dimensions.yDimension}
+        y={0 - dimensions.yDimension}
         transformWithSVG
         innerDivProps={{ className: styles.labware_ui_wrapper }}
       >
@@ -63,6 +68,7 @@ export function CalibrationBlockRender(
   props: CalibrationLabwareRenderProps
 ): JSX.Element | null {
   const { labwareDef, slotDefPosition } = props
+  const dimensions = getSchema2Dimensions(labwareDef)
 
   switch (labwareDef.parameters.loadName) {
     case 'opentrons_calibrationblock_short_side_right': {
@@ -73,8 +79,8 @@ export function CalibrationBlockRender(
           )})`}
         >
           <rect
-            width={labwareDef.dimensions.xDimension}
-            height={labwareDef.dimensions.yDimension}
+            width={dimensions.xDimension}
+            height={dimensions.yDimension}
             rx="10"
             ry="10"
             x={0}
@@ -82,8 +88,8 @@ export function CalibrationBlockRender(
             fill={C_MED_DARK_GRAY}
           />
           <rect
-            width={labwareDef.dimensions.xDimension / 2}
-            height={labwareDef.dimensions.yDimension}
+            width={dimensions.xDimension / 2}
+            height={dimensions.yDimension}
             rx="10"
             ry="10"
             x={0}
@@ -104,7 +110,7 @@ export function CalibrationBlockRender(
           <g transform="rotate(90)">
             <RobotCoordsText
               x={25}
-              y={-labwareDef.dimensions.xDimension + 5}
+              y={-dimensions.xDimension + 5}
               fill={C_MED_LIGHT_GRAY}
               fontSize={TYPOGRAPHY.fontSizeCaption}
               fontWeight={FONT_WEIGHT_SEMIBOLD}
@@ -123,8 +129,8 @@ export function CalibrationBlockRender(
           )})`}
         >
           <rect
-            width={labwareDef.dimensions.xDimension}
-            height={labwareDef.dimensions.yDimension}
+            width={dimensions.xDimension}
+            height={dimensions.yDimension}
             rx="10"
             ry="10"
             x={0}
@@ -132,11 +138,11 @@ export function CalibrationBlockRender(
             fill={C_MED_DARK_GRAY}
           />
           <rect
-            width={labwareDef.dimensions.xDimension / 2}
-            height={labwareDef.dimensions.yDimension}
+            width={dimensions.xDimension / 2}
+            height={dimensions.yDimension}
             rx="10"
             ry="10"
-            x={labwareDef.dimensions.xDimension / 2}
+            x={dimensions.xDimension / 2}
             y={0}
             fill={C_MED_GRAY}
           />
@@ -154,7 +160,7 @@ export function CalibrationBlockRender(
           <g transform="rotate(90)">
             <RobotCoordsText
               x={30}
-              y={-labwareDef.dimensions.xDimension + 5}
+              y={-dimensions.xDimension + 5}
               fill={C_MED_LIGHT_GRAY}
               fontSize={TYPOGRAPHY.fontSizeCaption}
               fontWeight={FONT_WEIGHT_SEMIBOLD}

--- a/app/src/organisms/Desktop/CalibrationPanels/ChooseTipRack.tsx
+++ b/app/src/organisms/Desktop/CalibrationPanels/ChooseTipRack.tsx
@@ -35,14 +35,14 @@ import { ChosenTipRackRender } from './ChosenTipRackRender'
 
 import type { MultiValue, SingleValue } from 'react-select'
 import type { SelectOption, SelectOptionOrGroup } from '@opentrons/components'
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 import type { TipLengthCalibration } from '/app/redux/calibration/api-types'
 import type { Mount } from '/app/redux/pipettes/types'
 import type { CalibrationLabware } from '/app/redux/sessions/types'
 import type { State } from '/app/redux/types'
 
 interface TipRackInfo {
-  definition: LabwareDefinition2
+  definition: LabwareDefinition
   calibration: TipLengthCalibration | null
 }
 
@@ -52,7 +52,7 @@ export type TipRackMap = Partial<{
 
 const EQUIPMENT_POLL_MS = 5000
 
-function formatOptionsFromLabwareDef(lw: LabwareDefinition2): SelectOption {
+function formatOptionsFromLabwareDef(lw: LabwareDefinition): SelectOption {
   return {
     value: getLabwareDefURI(lw),
     label: lw.metadata.displayName,
@@ -61,11 +61,11 @@ function formatOptionsFromLabwareDef(lw: LabwareDefinition2): SelectOption {
 interface ChooseTipRackProps {
   tipRack: CalibrationLabware
   mount: Mount
-  chosenTipRack: LabwareDefinition2 | null
-  handleChosenTipRack: (arg: LabwareDefinition2 | null) => unknown
+  chosenTipRack: LabwareDefinition | null
+  handleChosenTipRack: (arg: LabwareDefinition | null) => unknown
   closeModal: () => unknown
   robotName?: string | null
-  defaultTipracks?: LabwareDefinition2[] | null
+  defaultTipracks?: LabwareDefinition[] | null
 }
 
 export function ChooseTipRack(props: ChooseTipRackProps): JSX.Element {

--- a/app/src/organisms/Desktop/CalibrationPanels/Introduction/index.tsx
+++ b/app/src/organisms/Desktop/CalibrationPanels/Introduction/index.tsx
@@ -22,7 +22,7 @@ import { TRASH_BIN_LOAD_NAME } from '../constants'
 import { Body } from './Body'
 import { InvalidationWarning } from './InvalidationWarning'
 
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 import type { CalibrationPanelProps } from '../types'
 
 const TRASH_BIN = 'Removable black plastic trash bin'
@@ -41,11 +41,11 @@ export function Introduction(props: CalibrationPanelProps): JSX.Element {
   const { t } = useTranslation('robot_calibration')
 
   const [showChooseTipRack, setShowChooseTipRack] = useState(false)
-  const [chosenTipRack, setChosenTipRack] = useState<LabwareDefinition2 | null>(
+  const [chosenTipRack, setChosenTipRack] = useState<LabwareDefinition | null>(
     null
   )
 
-  const handleChosenTipRack = (value: LabwareDefinition2 | null): void => {
+  const handleChosenTipRack = (value: LabwareDefinition | null): void => {
     value != null && setChosenTipRack(value)
   }
   const uniqueTipRacks = new Set(

--- a/app/src/organisms/Desktop/CalibrationPanels/types.ts
+++ b/app/src/organisms/Desktop/CalibrationPanels/types.ts
@@ -1,4 +1,4 @@
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 import type { Mount } from '/app/redux/pipettes/types'
 import type {
   CalibrationCheckComparisonByPipette,
@@ -29,7 +29,7 @@ export interface CalibrationPanelProps {
   activePipette?: CalibrationCheckInstrument
   robotName?: string | null
   supportedCommands?: SessionCommandString[] | null
-  defaultTipracks?: LabwareDefinition2[] | null
+  defaultTipracks?: LabwareDefinition[] | null
   calInvalidationHandler?: () => void
   allowChangeTipRack?: boolean
 }

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/LabwareInfoOverlay.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/LabwareInfoOverlay.tsx
@@ -17,7 +17,7 @@ import {
   TYPOGRAPHY,
 } from '@opentrons/components'
 
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 
 interface LabwareInfoProps {
   displayName: string
@@ -70,7 +70,7 @@ const LabwareInfo = (props: LabwareInfoProps): JSX.Element | null => {
 }
 
 interface LabwareInfoOverlayProps {
-  definition: LabwareDefinition2
+  definition: LabwareDefinition
   labwareId: string
   displayName: string
   runId: string

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/LabwareInfoOverlay.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/LabwareInfoOverlay.tsx
@@ -16,6 +16,10 @@ import {
   SPACING,
   TYPOGRAPHY,
 } from '@opentrons/components'
+import {
+  getSchema2CornerOffsetFromSlot,
+  getSchema2Dimensions,
+} from '@opentrons/shared-data'
 
 import type { LabwareDefinition } from '@opentrons/shared-data'
 
@@ -92,13 +96,15 @@ export const LabwareInfoOverlay = (
     yOffset,
   } = props
 
-  const width = definition.dimensions.xDimension
-  const height = definition.dimensions.yDimension
+  const cornerOffsetFromSlot = getSchema2CornerOffsetFromSlot(definition)
+  const dimensions = getSchema2Dimensions(definition)
+
   return (
     <RobotCoordsForeignDiv
-      x={definition.cornerOffsetFromSlot.x + (xOffset ?? 0)}
-      y={definition.cornerOffsetFromSlot.y + (yOffset ?? 0)}
-      {...{ width, height }}
+      x={cornerOffsetFromSlot.x + (xOffset ?? 0)}
+      y={cornerOffsetFromSlot.y + (yOffset ?? 0)}
+      width={dimensions.xDimension}
+      height={dimensions.yDimension}
       innerDivProps={{
         display: DISPLAY_FLEX,
         flexDirection: DIRECTION_COLUMN,

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabware/LabwareListItem.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabware/LabwareListItem.tsx
@@ -28,6 +28,8 @@ import {
 import { useCreateLiveCommandMutation } from '@opentrons/react-api-client'
 import {
   getModuleType,
+  getSchema2CornerOffsetFromSlot,
+  getSchema2Dimensions,
   HEATERSHAKER_MODULE_TYPE,
   MAGNETIC_MODULE_TYPE,
   THERMOCYCLER_MODULE_TYPE,
@@ -393,9 +395,12 @@ function StandaloneLabware(props: {
   definition: LabwareDefinition
 }): JSX.Element {
   const { definition } = props
+  const cornerOffsetFromSlot = getSchema2CornerOffsetFromSlot(definition)
+  const dimensions = getSchema2Dimensions(definition)
+
   return (
     <LabwareThumbnail
-      viewBox={`${definition.cornerOffsetFromSlot.x} ${definition.cornerOffsetFromSlot.y} ${definition.dimensions.xDimension} ${definition.dimensions.yDimension}`}
+      viewBox={`${cornerOffsetFromSlot.x} ${cornerOffsetFromSlot.y} ${dimensions.xDimension} ${dimensions.yDimension}`}
     >
       <LabwareRender
         definition={definition}

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabware/LabwareListItem.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabware/LabwareListItem.tsx
@@ -46,7 +46,7 @@ import type { MouseEvent } from 'react'
 import type {
   HeaterShakerCloseLatchCreateCommand,
   HeaterShakerOpenLatchCreateCommand,
-  LabwareDefinition2,
+  LabwareDefinition,
   ModuleType,
 } from '@opentrons/shared-data'
 import type { ModuleRenderInfoForProtocol } from '/app/resources/runs'
@@ -390,7 +390,7 @@ const LabwareThumbnail = styled.svg`
 `
 
 function StandaloneLabware(props: {
-  definition: LabwareDefinition2
+  definition: LabwareDefinition
 }): JSX.Element {
   const { definition } = props
   return (

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabware/SlotDetailModal.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabware/SlotDetailModal.tsx
@@ -18,7 +18,11 @@ import {
   Tag,
   TYPOGRAPHY,
 } from '@opentrons/components'
-import { parseLiquidsInLoadOrder } from '@opentrons/shared-data'
+import {
+  getSchema2CornerOffsetFromSlot,
+  getSchema2Dimensions,
+  parseLiquidsInLoadOrder,
+} from '@opentrons/shared-data'
 
 import { LabwareStackContents } from '/app/molecules/LabwareStackContents'
 import { LiquidCardList } from '/app/molecules/LiquidDetailCard'
@@ -86,6 +90,10 @@ export const SlotDetailModal = (
   )
 
   const labwareDefinition = definitionsByURI[selectedLabware.definitionUri]
+  const labwareCornerOffsetFromSlot = getSchema2CornerOffsetFromSlot(
+    labwareDefinition
+  )
+  const labwareDimensions = getSchema2Dimensions(labwareDefinition)
 
   const commands = protocolData?.commands ?? []
   const liquids = parseLiquidsInLoadOrder(
@@ -221,7 +229,7 @@ export const SlotDetailModal = (
               ) : null}
             </Flex>
             <LabwareThumbnail
-              viewBox={`${labwareDefinition.cornerOffsetFromSlot.x} ${labwareDefinition.cornerOffsetFromSlot.y} ${labwareDefinition.dimensions.xDimension} ${labwareDefinition.dimensions.yDimension}`}
+              viewBox={`${labwareCornerOffsetFromSlot.x} ${labwareCornerOffsetFromSlot.y} ${labwareDimensions.xDimension} ${labwareDimensions.yDimension}`}
               width={
                 selectedLiquidId != null && isVariedStack ? '20rem' : '29rem'
               }

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabware/__tests__/LabwareListItem.test.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabware/__tests__/LabwareListItem.test.tsx
@@ -20,7 +20,7 @@ import { SecureLabwareModal } from '../SecureLabwareModal'
 
 import type { ComponentProps } from 'react'
 import type {
-  LabwareDefinition2,
+  LabwareDefinition,
   ModuleModel,
   ModuleType,
 } from '@opentrons/shared-data'
@@ -30,7 +30,7 @@ import type { ModuleRenderInfoForProtocol } from '/app/resources/runs'
 vi.mock('../SecureLabwareModal')
 vi.mock('@opentrons/react-api-client')
 
-const mockAdapterDef = opentrons96PcrAdapterV1 as LabwareDefinition2
+const mockAdapterDef = opentrons96PcrAdapterV1 as LabwareDefinition
 const mockAdapterId = 'mockAdapterId'
 const mockNestedLabwareDisplayName = 'nested labware display name'
 const mockLocationInfo = {

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabware/__tests__/OffDeckLabwareList.test.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabware/__tests__/OffDeckLabwareList.test.tsx
@@ -9,7 +9,7 @@ import { LabwareListItem } from '../LabwareListItem'
 import { OffDeckLabwareList } from '../OffDeckLabwareList'
 
 import type { ComponentProps } from 'react'
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 
 vi.mock('../LabwareListItem')
 
@@ -49,7 +49,7 @@ describe('OffDeckLabwareList', () => {
         },
       ],
       isFlex: false,
-      definitionsByURI: { 'mock def uri': {} as LabwareDefinition2 },
+      definitionsByURI: { 'mock def uri': {} as LabwareDefinition },
       setSelectedStack: vi.fn(),
     })
     screen.getByText('Additional Off-Deck Labware')

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabware/__tests__/SetupLabwareMap.test.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabware/__tests__/SetupLabwareMap.test.tsx
@@ -23,7 +23,7 @@ import { SetupLabwareMap } from '../SetupLabwareMap'
 import type { ComponentProps } from 'react'
 import type {
   CompletedProtocolAnalysis,
-  LabwareDefinition2,
+  LabwareDefinition,
   ModuleModel,
   ModuleType,
 } from '@opentrons/shared-data'
@@ -137,7 +137,7 @@ describe('SetupLabwareMap', () => {
   it.skip('should render a deck WITH labware and WITHOUT modules', () => {
     vi.mocked(getLabwareRenderInfo).mockReturnValue({
       '300_ul_tiprack_id': {
-        labwareDef: fixtureTiprack300ul as LabwareDefinition2,
+        labwareDef: fixtureTiprack300ul as LabwareDefinition,
         displayName: 'fresh tips',
         x: MOCK_300_UL_TIPRACK_COORDS[0],
         y: MOCK_300_UL_TIPRACK_COORDS[1],
@@ -174,7 +174,7 @@ describe('SetupLabwareMap', () => {
   it.skip('should render a deck WITH labware and WITH modules', () => {
     vi.mocked(getLabwareRenderInfo).mockReturnValue({
       [MOCK_300_UL_TIPRACK_ID]: {
-        labwareDef: fixtureTiprack300ul as LabwareDefinition2,
+        labwareDef: fixtureTiprack300ul as LabwareDefinition,
         displayName: 'fresh tips',
         x: MOCK_300_UL_TIPRACK_COORDS[0],
         y: MOCK_300_UL_TIPRACK_COORDS[1],

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/SetupTipLengthCalibrationButton.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/SetupTipLengthCalibrationButton.tsx
@@ -28,14 +28,14 @@ import { useRunHasStarted } from '/app/resources/runs'
 import { useDeckCalibrationData } from '../hooks'
 
 import type { Mount } from '@opentrons/components'
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 
 export interface SetupTipLengthCalibrationButtonProps {
   robotName: string
   runId: string
   hasCalibrated: boolean
   mount: Mount
-  tipRackDefinition: LabwareDefinition2
+  tipRackDefinition: LabwareDefinition
   isExtendedPipOffset: boolean
   disabled: boolean
 }

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/__tests__/LabwareInfoOverlay.test.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/__tests__/LabwareInfoOverlay.test.tsx
@@ -9,7 +9,7 @@ import { i18n } from '/app/i18n'
 import { LabwareInfoOverlay } from '../LabwareInfoOverlay'
 
 import type { ComponentProps } from 'react'
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 
 const render = (props: ComponentProps<typeof LabwareInfoOverlay>) => {
   return renderWithProviders(
@@ -29,7 +29,7 @@ describe('LabwareInfoOverlay', () => {
   let props: ComponentProps<typeof LabwareInfoOverlay>
   beforeEach(() => {
     props = {
-      definition: fixtureTiprack300ul as LabwareDefinition2,
+      definition: fixtureTiprack300ul as LabwareDefinition,
       displayName: 'fresh tips',
       labwareId: MOCK_LABWARE_ID,
       runId: MOCK_RUN_ID,

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/__tests__/SetupTipLengthCalibrationButton.test.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/__tests__/SetupTipLengthCalibrationButton.test.tsx
@@ -16,7 +16,7 @@ import { mockTipLengthCalLauncher } from '../../hooks/__fixtures__/taskListFixtu
 import { SetupTipLengthCalibrationButton } from '../SetupTipLengthCalibrationButton'
 
 import type { ComponentProps } from 'react'
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 
 vi.mock('@opentrons/components/src/hooks')
 vi.mock('/app/organisms/RunTimeControl/hooks')
@@ -38,7 +38,7 @@ describe('SetupTipLengthCalibrationButton', () => {
     robotName = ROBOT_NAME,
     runId = RUN_ID,
     hasCalibrated = false,
-    tipRackDefinition = fixtureTiprack300ul as LabwareDefinition2,
+    tipRackDefinition = fixtureTiprack300ul as LabwareDefinition,
     isExtendedPipOffset = false,
   }: Partial<ComponentProps<typeof SetupTipLengthCalibrationButton>> = {}) => {
     return renderWithProviders(

--- a/app/src/organisms/Desktop/Devices/constants.ts
+++ b/app/src/organisms/Desktop/Devices/constants.ts
@@ -2,14 +2,14 @@ import { getPipetteNameSpecs } from '@opentrons/shared-data'
 
 import { getLatestLabwareDef } from '/app/assets/labware/getLabware'
 
-import type { LabwareDefinition2, PipetteName } from '@opentrons/shared-data'
+import type { LabwareDefinition, PipetteName } from '@opentrons/shared-data'
 
 export const RUN_LOG_WINDOW_SIZE = 60 // number of command items rendered at a time
 
 // NOTE: this map is a duplicate of the TIP_RACK_LOOKUP_BY_MAX_VOL
 // found at robot_server/robot/calibration/constants.py
 const TIP_RACK_LOOKUP_BY_MAX_VOL: {
-  [maxVol: string]: LabwareDefinition2['parameters']['loadName']
+  [maxVol: string]: LabwareDefinition['parameters']['loadName']
 } = {
   10: 'opentrons_96_tiprack_10ul',
   20: 'opentrons_96_tiprack_20ul',
@@ -20,7 +20,7 @@ const TIP_RACK_LOOKUP_BY_MAX_VOL: {
 
 export function getDefaultTiprackDefForPipetteName(
   pipetteName: PipetteName
-): LabwareDefinition2 | null {
+): LabwareDefinition | null {
   const pipetteNameSpecs = getPipetteNameSpecs(pipetteName)
   if (pipetteNameSpecs != null) {
     return getLatestLabwareDef(

--- a/app/src/organisms/Desktop/Labware/LabwareCard/index.tsx
+++ b/app/src/organisms/Desktop/Labware/LabwareCard/index.tsx
@@ -22,6 +22,8 @@ import {
 import {
   getLabwareDefIsStandard,
   getLabwareDisplayName,
+  getSchema2CornerOffsetFromSlot,
+  getSchema2Dimensions,
 } from '@opentrons/shared-data'
 
 import { UNIVERSAL_FLAT_ADAPTER_X_DIMENSION } from '../LabwareDetails/Gallery'
@@ -41,10 +43,14 @@ export function LabwareCard(props: LabwareCardProps): JSX.Element {
   const displayName = getLabwareDisplayName(definition)
   const displayCategory = startCase(definition.metadata.displayCategory)
   const isCustomDefinition = !getLabwareDefIsStandard(definition)
+
+  const cornerOffsetFromSlot = getSchema2CornerOffsetFromSlot(definition)
+  const dimensions = getSchema2Dimensions(definition)
+
   const xDimensionOverride =
     definition.parameters.loadName === 'opentrons_universal_flat_adapter'
       ? UNIVERSAL_FLAT_ADAPTER_X_DIMENSION
-      : definition.dimensions.xDimension
+      : dimensions.xDimension
 
   return (
     <Box
@@ -64,7 +70,7 @@ export function LabwareCard(props: LabwareCardProps): JSX.Element {
     >
       <Box id="LabwareCard_labwareImage" marginRight={SPACING.spacing24}>
         <RobotWorkSpace
-          viewBox={`${definition.cornerOffsetFromSlot.x} ${definition.cornerOffsetFromSlot.y} ${xDimensionOverride} ${definition.dimensions.yDimension}`}
+          viewBox={`${cornerOffsetFromSlot.x} ${cornerOffsetFromSlot.y} ${xDimensionOverride} ${dimensions.yDimension}`}
         >
           {() => <LabwareRender definition={definition} />}
         </RobotWorkSpace>

--- a/app/src/organisms/Desktop/Labware/LabwareDetails/Dimensions.tsx
+++ b/app/src/organisms/Desktop/Labware/LabwareDetails/Dimensions.tsx
@@ -6,7 +6,7 @@ import { Box, getFootprintDiagram, SPACING } from '@opentrons/components'
 import { ExpandingTitle } from './StyledComponents/ExpandingTitle'
 import { LabeledValue } from './StyledComponents/LabeledValue'
 
-import type { LabwareDefinition2 as LabwareDefinition } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 
 const toFixed = (n: number): string => round(n, 2).toFixed(2)
 

--- a/app/src/organisms/Desktop/Labware/LabwareDetails/Dimensions.tsx
+++ b/app/src/organisms/Desktop/Labware/LabwareDetails/Dimensions.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from 'react-i18next'
 import round from 'lodash/round'
 
 import { Box, getFootprintDiagram, SPACING } from '@opentrons/components'
+import { getSchema2Dimensions } from '@opentrons/shared-data'
 
 import { ExpandingTitle } from './StyledComponents/ExpandingTitle'
 import { LabeledValue } from './StyledComponents/LabeledValue'
@@ -20,7 +21,9 @@ export function Dimensions(props: DimensionsProps): JSX.Element {
   const { t } = useTranslation('labware_details')
   const { definition, irregular, insertCategory } = props
   const { displayCategory } = definition.metadata
-  const { xDimension, yDimension, zDimension } = definition.dimensions
+  const { xDimension, yDimension, zDimension } = getSchema2Dimensions(
+    definition
+  )
   const dimensions = [
     { label: t('length'), value: toFixed(xDimension) },
     { label: t('width'), value: toFixed(yDimension) },
@@ -30,8 +33,8 @@ export function Dimensions(props: DimensionsProps): JSX.Element {
   const diagram = getFootprintDiagram({
     category: displayCategory,
     guideType: 'footprint',
-    insertCategory: insertCategory,
-    irregular: irregular,
+    insertCategory,
+    irregular,
   })?.map((src, index) => <img width="250px" src={src} key={index} />)
 
   return (

--- a/app/src/organisms/Desktop/Labware/LabwareDetails/Gallery.tsx
+++ b/app/src/organisms/Desktop/Labware/LabwareDetails/Gallery.tsx
@@ -11,6 +11,10 @@ import {
   SPACING,
   SPACING_AUTO,
 } from '@opentrons/components'
+import {
+  getSchema2CornerOffsetFromSlot,
+  getSchema2Dimensions,
+} from '@opentrons/shared-data'
 
 import { labwareImages } from './labware-images'
 
@@ -24,11 +28,10 @@ export interface GalleryProps {
 
 export function Gallery(props: GalleryProps): JSX.Element {
   const { definition } = props
-  const {
-    parameters: params,
-    dimensions: dims,
-    cornerOffsetFromSlot,
-  } = definition
+  const { parameters: params } = definition
+  const dims = getSchema2Dimensions(definition)
+  const cornerOffsetFromSlot = getSchema2CornerOffsetFromSlot(definition)
+
   const xDimension =
     params.loadName === 'opentrons_universal_flat_adapter'
       ? 127.4

--- a/app/src/organisms/Desktop/Labware/LabwareDetails/Gallery.tsx
+++ b/app/src/organisms/Desktop/Labware/LabwareDetails/Gallery.tsx
@@ -14,7 +14,7 @@ import {
 
 import { labwareImages } from './labware-images'
 
-import type { LabwareDefinition2 as LabwareDefinition } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 
 export const UNIVERSAL_FLAT_ADAPTER_X_DIMENSION = 127.4
 

--- a/app/src/organisms/Desktop/Labware/LabwareDetails/InsertDetails.tsx
+++ b/app/src/organisms/Desktop/Labware/LabwareDetails/InsertDetails.tsx
@@ -12,7 +12,7 @@ import { ManufacturerDetails } from './ManufacturerDetails'
 import { WellDimensions } from './WellDimensions'
 import { WellProperties } from './WellProperties'
 
-import type { LabwareDefinition2 as LabwareDefinition } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 
 export interface InsertDetailsProps {
   definition: LabwareDefinition

--- a/app/src/organisms/Desktop/Labware/LabwareDetails/WellProperties.tsx
+++ b/app/src/organisms/Desktop/Labware/LabwareDetails/WellProperties.tsx
@@ -14,7 +14,7 @@ import {
 import { getDisplayVolume } from '@opentrons/shared-data'
 
 import type {
-  LabwareDefinition2 as LabwareDefinition,
+  LabwareDefinition,
   LabwareVolumeUnits,
 } from '@opentrons/shared-data'
 import type { LabwareWellGroupProperties } from '/app/local-resources/labware'

--- a/app/src/organisms/Desktop/Labware/LabwareDetails/helpers/labels.ts
+++ b/app/src/organisms/Desktop/Labware/LabwareDetails/helpers/labels.ts
@@ -1,6 +1,6 @@
 import uniqBy from 'lodash/uniqBy'
 
-import type { LabwareDefinition2 as LabwareDefinition } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 import type { LabwareWellGroupProperties } from '/app/local-resources/labware'
 
 const WELL_TYPE_BY_CATEGORY = {

--- a/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps.tsx
+++ b/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps.tsx
@@ -23,7 +23,7 @@ import { CommandIcon } from '/app/molecules/Command'
 
 import type {
   CompletedProtocolAnalysis,
-  LabwareDefinition2,
+  LabwareDefinition,
   ProtocolAnalysisOutput,
   RunTimeCommand,
 } from '@opentrons/shared-data'
@@ -135,7 +135,7 @@ interface AnnotatedGroupProps {
   analysis: ProtocolAnalysisOutput | CompletedProtocolAnalysis
   stepNumber: string
   isHighlighted: boolean
-  allRunDefs: LabwareDefinition2[]
+  allRunDefs: LabwareDefinition[]
 }
 function AnnotatedGroup(props: AnnotatedGroupProps): JSX.Element {
   const {
@@ -231,7 +231,7 @@ interface IndividualCommandProps {
   analysis: ProtocolAnalysisOutput | CompletedProtocolAnalysis
   stepNumber: string
   isHighlighted: boolean
-  allRunDefs: LabwareDefinition2[]
+  allRunDefs: LabwareDefinition[]
 }
 function IndividualCommand({
   command,

--- a/app/src/organisms/Desktop/RobotSettingsCalibration/CalibrationDetails/utils.ts
+++ b/app/src/organisms/Desktop/RobotSettingsCalibration/CalibrationDetails/utils.ts
@@ -4,13 +4,13 @@ import { getLabwareDisplayName } from '@opentrons/shared-data'
 
 import { findLabwareDefWithCustom } from '/app/assets/labware/findLabware'
 
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 
 const UNKNOWN_CUSTOM_LABWARE = 'unknown custom tiprack'
 
 export function getDisplayNameForTipRack(
   tiprackUri: string,
-  customLabware: LabwareDefinition2[]
+  customLabware: LabwareDefinition[]
 ): string {
   const [namespace, loadName] = tiprackUri ? tiprackUri.split('/') : ['', '']
   const definition = findLabwareDefWithCustom(

--- a/app/src/organisms/ErrorRecoveryFlows/ErrorRecoveryWizard.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/ErrorRecoveryWizard.tsx
@@ -32,7 +32,7 @@ import {
 } from './shared'
 import { getErrorKind } from './utils'
 
-import type { LabwareDefinition2, RobotType } from '@opentrons/shared-data'
+import type { LabwareDefinition, RobotType } from '@opentrons/shared-data'
 import type { UseRecoveryAnalyticsResult } from '/app/redux-resources/analytics'
 import type { ErrorRecoveryFlowsProps } from '.'
 import type { ERUtilsResults, useRetainedFailedCommandBySource } from './hooks'
@@ -71,7 +71,7 @@ export type ErrorRecoveryWizardProps = ErrorRecoveryFlowsProps &
     isOnDevice: boolean
     analytics: UseRecoveryAnalyticsResult<RecoveryRoute, RouteStep>
     failedCommand: ReturnType<typeof useRetainedFailedCommandBySource>
-    allRunDefs: LabwareDefinition2[]
+    allRunDefs: LabwareDefinition[]
   }
 
 export function ErrorRecoveryWizard(

--- a/app/src/organisms/ErrorRecoveryFlows/RecoverySplash.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RecoverySplash.tsx
@@ -38,7 +38,7 @@ import { useErrorName } from './hooks'
 import { RecoveryInterventionModal, StepInfo } from './shared'
 import { getErrorKind } from './utils'
 
-import type { LabwareDefinition2, RobotType } from '@opentrons/shared-data'
+import type { LabwareDefinition, RobotType } from '@opentrons/shared-data'
 import type { UseRecoveryAnalyticsResult } from '/app/redux-resources/analytics'
 import type { ErrorRecoveryFlowsProps } from '.'
 import type {
@@ -71,7 +71,7 @@ type RecoverySplashProps = ErrorRecoveryFlowsProps &
     resumePausedRecovery: boolean
     toggleERWizAsActiveUser: UseRecoveryTakeoverResult['toggleERWizAsActiveUser']
     analytics: UseRecoveryAnalyticsResult<RecoveryRoute, RouteStep>
-    allRunDefs: LabwareDefinition2[]
+    allRunDefs: LabwareDefinition[]
   }
 export function RecoverySplash(props: RecoverySplashProps): JSX.Element | null {
   const {

--- a/app/src/organisms/ErrorRecoveryFlows/__fixtures__/index.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/__fixtures__/index.ts
@@ -9,7 +9,7 @@ import { mockRobotSideAnalysis } from '/app/molecules/Command/__fixtures__'
 
 import { RECOVERY_MAP } from '../constants'
 
-import type { LabwareDefinition2, LoadedLabware } from '@opentrons/shared-data'
+import type { LabwareDefinition, LoadedLabware } from '@opentrons/shared-data'
 import type { FailedCommand, RecoveryContentProps } from '../types'
 
 export const mockFailedCommand: FailedCommand = {
@@ -42,7 +42,7 @@ export const mockFailedCommand: FailedCommand = {
   notes: [],
 }
 
-const mockAdapterDef = opentrons96PcrAdapterV1 as LabwareDefinition2
+const mockAdapterDef = opentrons96PcrAdapterV1 as LabwareDefinition
 
 export const mockPickUpTipLabware: LoadedLabware = {
   id: 'MOCK_PickUpTipLabware_ID',

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useDeckMapUtils.test.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useDeckMapUtils.test.ts
@@ -22,7 +22,7 @@ import {
   updateLabwareInModules,
 } from '../useDeckMapUtils'
 
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 
 vi.mock('@opentrons/shared-data', async importOriginal => {
   const actual = await importOriginal<typeof getLoadedLabwareDefinitionsByUri>()
@@ -36,8 +36,8 @@ vi.mock('@opentrons/shared-data', async importOriginal => {
 vi.mock('@opentrons/components')
 
 describe('getRunCurrentModulesOnDeck', () => {
-  const mockLabwareDef: LabwareDefinition2 = {
-    ...(fixture96Plate as LabwareDefinition2),
+  const mockLabwareDef: LabwareDefinition = {
+    ...(fixture96Plate as LabwareDefinition),
     metadata: {
       displayName: 'Mock Labware Definition',
       displayCategory: 'wellPlate',
@@ -119,8 +119,8 @@ describe('getRunCurrentModulesOnDeck', () => {
 })
 
 describe('getRunCurrentLabwareOnDeck', () => {
-  const mockLabwareDef: LabwareDefinition2 = {
-    ...(fixture96Plate as LabwareDefinition2),
+  const mockLabwareDef: LabwareDefinition = {
+    ...(fixture96Plate as LabwareDefinition),
     metadata: {
       displayName: 'Mock Labware Definition',
       displayCategory: 'wellPlate',
@@ -341,8 +341,8 @@ describe('getRunCurrentModulesInfo', () => {
 })
 
 describe('getRunCurrentLabwareInfo', () => {
-  const mockLabwareDef: LabwareDefinition2 = {
-    ...(fixture96Plate as LabwareDefinition2),
+  const mockLabwareDef: LabwareDefinition = {
+    ...(fixture96Plate as LabwareDefinition),
     metadata: {
       displayName: 'Mock Labware Definition',
       displayCategory: 'wellPlate',
@@ -571,8 +571,8 @@ describe('getIsLabwareMatch', () => {
 })
 
 describe('updateLabwareInModules', () => {
-  const mockLabwareDef: LabwareDefinition2 = {
-    ...(fixture96Plate as LabwareDefinition2),
+  const mockLabwareDef: LabwareDefinition = {
+    ...(fixture96Plate as LabwareDefinition),
     metadata: {
       displayName: 'Mock Labware Definition',
       displayCategory: 'wellPlate',

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useDeckMapUtils.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useDeckMapUtils.ts
@@ -22,7 +22,7 @@ import type { Run } from '@opentrons/api-client'
 import type {
   CutoutConfigProtocolSpec,
   DeckDefinition,
-  LabwareDefinition2,
+  LabwareDefinition,
   LabwareDefinitionsByUri,
   LabwareLocation,
   LoadedLabware,
@@ -54,7 +54,7 @@ export interface UseDeckMapUtilsResult {
   labwareOnDeck: RunCurrentLabwareOnDeck[]
   loadedLabware: LoadedLabware[]
   loadedModules: LoadedModule[]
-  movedLabwareDef: LabwareDefinition2 | null
+  movedLabwareDef: LabwareDefinition | null
   moduleRenderInfo: RunModuleInfo[]
   labwareRenderInfo: RunLabwareInfo[]
   highlightLabwareEventuallyIn: string[]
@@ -177,7 +177,7 @@ interface RunCurrentModulesOnDeck {
     | {
         lidMotorState?: undefined
       }
-  nestedLabwareDef: LabwareDefinition2 | null
+  nestedLabwareDef: LabwareDefinition | null
 }
 
 // Builds the necessary module object expected by BaseDeck.
@@ -215,7 +215,7 @@ export function getRunCurrentModulesOnDeck({
 
 interface RunCurrentLabwareOnDeck {
   labwareLocation: LabwareLocation
-  definition: LabwareDefinition2
+  definition: LabwareDefinition
 }
 // Builds the necessary labware object expected by BaseDeck.
 // Note that while this highlights all labware in the failed labware slot, the result is later filtered to render
@@ -259,7 +259,7 @@ export function getRunCurrentLabwareOnDeck({
 interface RunCurrentModuleInfo {
   moduleId: string
   moduleDef: ModuleDefinition
-  nestedLabwareDef: LabwareDefinition2 | null
+  nestedLabwareDef: LabwareDefinition | null
   nestedLabwareSlotName: string
   slotName: string
 }
@@ -327,7 +327,7 @@ export const getRunCurrentModulesInfo = ({
 }
 
 interface RunCurrentLabwareInfo {
-  labwareDef: LabwareDefinition2
+  labwareDef: LabwareDefinition
   labwareLocation: LabwareLocation
   slotName: string
 }
@@ -403,7 +403,7 @@ export function getRunCurrentLabwareInfo({
 const getLabwareDefinition = (
   labware: LoadedLabware,
   protocolLabwareDefinitionsByUri: LabwareDefinitionsByUri
-): LabwareDefinition2 => {
+): LabwareDefinition => {
   if (labware.id === 'fixedTrash') {
     return getFixedTrashLabwareDefinition()
   } else {

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useERUtils.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useERUtils.ts
@@ -23,7 +23,7 @@ import { useRecoveryToasts } from './useRecoveryToasts'
 import { useRouteUpdateActions } from './useRouteUpdateActions'
 import { useShowDoorInfo } from './useShowDoorInfo'
 
-import type { LabwareDefinition2, RobotType } from '@opentrons/shared-data'
+import type { LabwareDefinition, RobotType } from '@opentrons/shared-data'
 import type { UseRecoveryAnalyticsResult } from '/app/redux-resources/analytics'
 import type { StepCounts } from '/app/resources/protocols/hooks'
 import type { ErrorRecoveryFlowsProps } from '..'
@@ -50,7 +50,7 @@ export type ERUtilsProps = Omit<ErrorRecoveryFlowsProps, 'failedCommand'> & {
   robotType: RobotType
   failedCommand: ReturnType<typeof useRetainedFailedCommandBySource>
   isActiveUser: UseRecoveryTakeoverResult['isActiveUser']
-  allRunDefs: LabwareDefinition2[]
+  allRunDefs: LabwareDefinition[]
 }
 
 export interface ERUtilsResults {

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useFailedLabwareUtils.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useFailedLabwareUtils.ts
@@ -27,7 +27,7 @@ import type {
   Failed,
   FlexStackerRetrieveRunTimeCommand,
   FlexStackerStoreRunTimeCommand,
-  LabwareDefinition2,
+  LabwareDefinition,
   LabwareLocation,
   LiquidProbeRunTimeCommand,
   LoadedLabware,
@@ -271,7 +271,7 @@ function getRelevantPickUpTipCommand(
 interface UseTipSelectionUtilsResult {
   /* Always returns null if the relevant labware is not relevant to tip pick up. */
   selectedTipLocations: WellGroup | null
-  tipSelectorDef: LabwareDefinition2
+  tipSelectorDef: LabwareDefinition
   selectTips: (tipGroup: WellGroup) => void
   deselectTips: (locations: string[]) => void
   areTipsSelected: boolean

--- a/app/src/organisms/ErrorRecoveryFlows/shared/ErrorDetailsModal.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/ErrorDetailsModal.tsx
@@ -25,7 +25,7 @@ import { StepInfo } from './StepInfo'
 
 import type { ReactNode } from 'react'
 import type { IconProps } from '@opentrons/components'
-import type { LabwareDefinition2, RobotType } from '@opentrons/shared-data'
+import type { LabwareDefinition, RobotType } from '@opentrons/shared-data'
 import type { OddModalHeaderBaseProps } from '/app/molecules/OddModal/types'
 import type { ErrorRecoveryFlowsProps } from '..'
 import type { ERUtilsResults, useRetainedFailedCommandBySource } from '../hooks'
@@ -54,7 +54,7 @@ type ErrorDetailsModalProps = Omit<
     robotType: RobotType
     desktopType: DesktopSizeType
     failedCommand: ReturnType<typeof useRetainedFailedCommandBySource>
-    allRunDefs: LabwareDefinition2[]
+    allRunDefs: LabwareDefinition[]
   }
 
 export function ErrorDetailsModal(props: ErrorDetailsModalProps): JSX.Element {

--- a/app/src/organisms/InterventionModal/LabwareDisabledOverlay.tsx
+++ b/app/src/organisms/InterventionModal/LabwareDisabledOverlay.tsx
@@ -1,4 +1,5 @@
 import { COLORS } from '@opentrons/components'
+import { getSchema2Dimensions } from '@opentrons/shared-data'
 
 import type { LabwareDefinition } from '@opentrons/shared-data'
 
@@ -8,24 +9,24 @@ interface LabwareDisabledOverlayProps {
 export function LabwareDisabledOverlay({
   definition,
 }: LabwareDisabledOverlayProps): JSX.Element {
+  const { xDimension, yDimension } = getSchema2Dimensions(definition)
+
   return (
     <g>
       <rect
         data-testid="overlay_rect"
         x={0}
         y={0}
-        width={definition.dimensions.xDimension}
-        height={definition.dimensions.yDimension}
+        width={xDimension}
+        height={yDimension}
         rx={6}
         fill={COLORS.white}
         fillOpacity={0.9}
       />
       <path
         data-testid="overlay_icon"
-        transform={`translate(${
-          definition.dimensions.xDimension / 2 - 22.25
-        }, ${
-          definition.dimensions.yDimension / 2 - 22.25
+        transform={`translate(${xDimension / 2 - 22.25}, ${
+          yDimension / 2 - 22.25
         }) rotate(90, 22.25, 22.25) scale(2)`}
         d="M3.79834 19.46C1.87784 17.5093 0.692857 14.8323 0.692857 11.8785C0.692857 5.90992 5.53138 1.0714 11.5 1.0714C17.4686 1.0714 22.3071 5.90992 22.3071 11.8785C22.3071 17.8472 17.4686 22.6857 11.5 22.6857C8.71384 22.6857 6.17393 21.6314 4.25749 19.8999L19.5123 4.64514L19.0627 4.19562L3.79834 19.46Z"
         stroke={COLORS.red50}

--- a/app/src/organisms/InterventionModal/LabwareDisabledOverlay.tsx
+++ b/app/src/organisms/InterventionModal/LabwareDisabledOverlay.tsx
@@ -1,9 +1,9 @@
 import { COLORS } from '@opentrons/components'
 
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 
 interface LabwareDisabledOverlayProps {
-  definition: LabwareDefinition2
+  definition: LabwareDefinition
 }
 export function LabwareDisabledOverlay({
   definition,

--- a/app/src/organisms/InterventionModal/__fixtures__/index.ts
+++ b/app/src/organisms/InterventionModal/__fixtures__/index.ts
@@ -6,7 +6,7 @@ import {
 
 import type { RunData } from '@opentrons/api-client'
 import type {
-  LabwareDefinition2,
+  LabwareDefinition,
   LabwareDefinitionsByUri,
   Liquid,
   LoadedLabware,
@@ -167,7 +167,7 @@ export const mockLabwareDefinition = ({
     zDimension: 15.7,
     xDimension: 127.76,
   },
-} as unknown) as LabwareDefinition2
+} as unknown) as LabwareDefinition
 
 export const mockLabwareDefinitionsByUri = {
   'opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1': mockLabwareDefinition,

--- a/app/src/organisms/InterventionModal/__tests__/LabwareDisabledOverlay.test.tsx
+++ b/app/src/organisms/InterventionModal/__tests__/LabwareDisabledOverlay.test.tsx
@@ -5,14 +5,14 @@ import { COLORS } from '@opentrons/components'
 
 import { LabwareDisabledOverlay } from '../LabwareDisabledOverlay'
 
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 
 const mockLabwareDef = {
   dimensions: {
     xDimension: 84,
     yDimension: 42,
   },
-} as LabwareDefinition2
+} as LabwareDefinition
 
 describe('LabwareDisabledOverlay', () => {
   it("renders correctly for a given labware definition's dimensions", () => {

--- a/app/src/organisms/InterventionModal/__tests__/LabwareDisabledOverlay.test.tsx
+++ b/app/src/organisms/InterventionModal/__tests__/LabwareDisabledOverlay.test.tsx
@@ -8,6 +8,7 @@ import { LabwareDisabledOverlay } from '../LabwareDisabledOverlay'
 import type { LabwareDefinition } from '@opentrons/shared-data'
 
 const mockLabwareDef = {
+  schemaVersion: 2,
   dimensions: {
     xDimension: 84,
     yDimension: 42,

--- a/app/src/organisms/InterventionModal/__tests__/utils.test.ts
+++ b/app/src/organisms/InterventionModal/__tests__/utils.test.ts
@@ -2,6 +2,7 @@ import deepClone from 'lodash/cloneDeep'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
+  getSchema2Dimensions,
   getSlotHasMatingSurfaceUnitVector,
   ot2DeckDefV5,
 } from '@opentrons/shared-data'
@@ -175,7 +176,7 @@ describe('getRunLabwareRenderInfo', () => {
     expect(labwareInfo?.x).toEqual(0)
     expect(labwareInfo?.y).toEqual(
       ot2DeckDefV5.cornerOffsetFromOrigin[1] -
-        mockLabwareDefinition.dimensions.yDimension
+        getSchema2Dimensions(mockLabwareDefinition).yDimension
     )
   })
 

--- a/app/src/organisms/InterventionModal/utils/getRunLabwareRenderInfo.ts
+++ b/app/src/organisms/InterventionModal/utils/getRunLabwareRenderInfo.ts
@@ -1,5 +1,6 @@
 import {
   getPositionFromSlotId,
+  getSchema2Dimensions,
   getSlotHasMatingSurfaceUnitVector,
 } from '@opentrons/shared-data'
 
@@ -61,13 +62,12 @@ export function getRunLabwareRenderInfo(
             ]
           : acc
       } else {
+        const { yDimension } = getSchema2Dimensions(labwareDef)
         return [
           ...acc,
           {
             x: 0,
-            y:
-              deckDef.cornerOffsetFromOrigin[1] -
-              labwareDef.dimensions.yDimension,
+            y: deckDef.cornerOffsetFromOrigin[1] - yDimension,
             labwareId: labware.id,
             labwareDef,
           },

--- a/app/src/organisms/InterventionModal/utils/getRunLabwareRenderInfo.ts
+++ b/app/src/organisms/InterventionModal/utils/getRunLabwareRenderInfo.ts
@@ -6,14 +6,14 @@ import {
 import type { RunData } from '@opentrons/api-client'
 import type {
   DeckDefinition,
-  LabwareDefinition2,
+  LabwareDefinition,
   LabwareDefinitionsByUri,
 } from '@opentrons/shared-data'
 
 export interface RunLabwareInfo {
   x: number
   y: number
-  labwareDef: LabwareDefinition2
+  labwareDef: LabwareDefinition
   labwareId: string
 }
 

--- a/app/src/organisms/InterventionModal/utils/getRunModuleRenderInfo.ts
+++ b/app/src/organisms/InterventionModal/utils/getRunModuleRenderInfo.ts
@@ -7,7 +7,7 @@ import {
 import type { RunData } from '@opentrons/api-client'
 import type {
   DeckDefinition,
-  LabwareDefinition2,
+  LabwareDefinition,
   LabwareDefinitionsByUri,
   ModuleDefinition,
 } from '@opentrons/shared-data'
@@ -17,7 +17,7 @@ export interface RunModuleInfo {
   x: number
   y: number
   moduleDef: ModuleDefinition
-  nestedLabwareDef: LabwareDefinition2 | null
+  nestedLabwareDef: LabwareDefinition | null
   nestedLabwareId: string | null
 }
 

--- a/app/src/organisms/LabwarePositionCheck/LPCFlows/LPCFlows.tsx
+++ b/app/src/organisms/LabwarePositionCheck/LPCFlows/LPCFlows.tsx
@@ -4,7 +4,7 @@ import type { LabwareOffset } from '@opentrons/api-client'
 import type {
   CompletedProtocolAnalysis,
   DeckConfiguration,
-  LabwareDefinition2,
+  LabwareDefinition,
   RobotType,
 } from '@opentrons/shared-data'
 import type { useLPCAnalytics } from '/app/organisms/LabwarePositionCheck'
@@ -21,7 +21,7 @@ export interface LPCFlowsProps {
   runId: string
   robotType: RobotType
   deckConfig: DeckConfiguration
-  labwareDefs: LabwareDefinition2[]
+  labwareDefs: LabwareDefinition[]
   labwareInfo: LPCLabwareInfo
   analysis: CompletedProtocolAnalysis
   protocolName: string

--- a/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useInitLPCStore/index.ts
+++ b/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useInitLPCStore/index.ts
@@ -13,7 +13,7 @@ import type { Run, StoredLabwareOffset } from '@opentrons/api-client'
 import type {
   CompletedProtocolAnalysis,
   DeckConfiguration,
-  LabwareDefinition2,
+  LabwareDefinition,
 } from '@opentrons/shared-data'
 import type { LPCLabwareInfo, LPCWizardState } from '/app/redux/protocol-runs'
 import type { State } from '/app/redux/types'
@@ -24,7 +24,7 @@ export interface UseLPCInitialStateProps {
   analysis: CompletedProtocolAnalysis | null
   protocolName: string | undefined
   maintenanceRunId: string | null
-  labwareDefs: LabwareDefinition2[]
+  labwareDefs: LabwareDefinition[]
   labwareInfo: LPCLabwareInfo
   deckConfig: DeckConfiguration | undefined
   isFlex: boolean

--- a/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useLPCLabwareInfo/getLPCLabwareInfoFrom/getDefaultOffsetForLabware.ts
+++ b/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useLPCLabwareInfo/getLPCLabwareInfoFrom/getDefaultOffsetForLabware.ts
@@ -3,7 +3,7 @@ import { getLabwareDefURI } from '@opentrons/shared-data'
 
 import { OFFSET_KIND_DEFAULT } from '/app/redux/protocol-runs'
 
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 import type {
   DefaultOffsetDetails,
   LabwareModuleStackupDetails,
@@ -117,7 +117,7 @@ function getRequiresAdapterId(
   return requiresAdapter(matchingDef)
 }
 
-function requiresAdapter(def: LabwareDefinition2 | null): boolean {
+function requiresAdapter(def: LabwareDefinition | null): boolean {
   return def?.parameters.quirks?.includes('stackingOnly') ?? false
 }
 

--- a/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useLPCLabwareInfo/getLPCLabwareInfoFrom/index.ts
+++ b/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useLPCLabwareInfo/getLPCLabwareInfoFrom/index.ts
@@ -11,7 +11,7 @@ import { getLocationSpecificOffsetDetailsForLabware } from './getLocationSpecifi
 import type { StoredLabwareOffset } from '@opentrons/api-client'
 import type {
   CompletedProtocolAnalysis,
-  LabwareDefinition2,
+  LabwareDefinition,
 } from '@opentrons/shared-data'
 import type {
   LabwareLocationInfo,
@@ -94,7 +94,7 @@ function getDisplayNameFromUri({
 }: GetLPCLabwareInfoForURI): string {
   const matchedDef = labwareDefs?.find(
     def => getLabwareDefURI(def) === uri
-  ) as LabwareDefinition2
+  ) as LabwareDefinition
 
   if (!!!matchedDef) {
     console.warn(

--- a/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useLPCLabwareInfo/getUniqueValidLwLocationInfoByAnalysis/getLPCUniqValidLabwareLocationInfo/__tests__/appendUniqValidLocCombo.test.ts
+++ b/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useLPCLabwareInfo/getUniqueValidLwLocationInfoByAnalysis/getLPCUniqValidLabwareLocationInfo/__tests__/appendUniqValidLocCombo.test.ts
@@ -4,7 +4,7 @@ import { getLabwareDefURI } from '@opentrons/shared-data'
 
 import { appendUniqValidLocCombo } from '../appendUniqValidLocCombo'
 
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 import type { LabwareLocationInfoWithLocSeq } from '..'
 
 vi.mock('@opentrons/shared-data', () => ({
@@ -20,24 +20,24 @@ describe('appendUniqValidLocCombo', () => {
   const MODULE_MODEL = 'thermocyclerModuleV2'
   const ADDRESSABLE_AREA = 'B1'
 
-  const BASIC_LABWARE_DEF: LabwareDefinition2 = {
+  const BASIC_LABWARE_DEF: LabwareDefinition = {
     metadata: { displayName: 'Basic Labware' },
-  } as LabwareDefinition2
+  } as LabwareDefinition
 
-  const LID_LABWARE_DEF: LabwareDefinition2 = {
+  const LID_LABWARE_DEF: LabwareDefinition = {
     metadata: { displayName: 'Lid Labware' },
     allowedRoles: ['lid'],
-  } as LabwareDefinition2
+  } as LabwareDefinition
 
-  const ADAPTER_LABWARE_DEF: LabwareDefinition2 = {
+  const ADAPTER_LABWARE_DEF: LabwareDefinition = {
     metadata: { displayName: 'Adapter Labware' },
     allowedRoles: ['adapter'],
-  } as LabwareDefinition2
+  } as LabwareDefinition
 
-  const SYSTEM_LABWARE_DEF: LabwareDefinition2 = {
+  const SYSTEM_LABWARE_DEF: LabwareDefinition = {
     metadata: { displayName: 'System Labware' },
     allowedRoles: ['system'],
-  } as LabwareDefinition2
+  } as LabwareDefinition
 
   const BASIC_LOCATION_COMBO: LabwareLocationInfoWithLocSeq = {
     labwareId: LABWARE_ID,
@@ -77,7 +77,7 @@ describe('appendUniqValidLocCombo', () => {
 
   it('should return unchanged accumulator when combo is null', () => {
     const acc: LabwareLocationInfoWithLocSeq[] = [BASIC_LOCATION_COMBO]
-    const lwDefs: LabwareDefinition2[] = [BASIC_LABWARE_DEF]
+    const lwDefs: LabwareDefinition[] = [BASIC_LABWARE_DEF]
 
     const result = appendUniqValidLocCombo(acc, lwDefs, null)
 
@@ -86,7 +86,7 @@ describe('appendUniqValidLocCombo', () => {
 
   it('should append valid and unique combo to accumulator', () => {
     const acc: LabwareLocationInfoWithLocSeq[] = []
-    const lwDefs: LabwareDefinition2[] = [BASIC_LABWARE_DEF]
+    const lwDefs: LabwareDefinition[] = [BASIC_LABWARE_DEF]
 
     const result = appendUniqValidLocCombo(acc, lwDefs, BASIC_LOCATION_COMBO)
 
@@ -95,7 +95,7 @@ describe('appendUniqValidLocCombo', () => {
 
   it('should not append combo that already exists in accumulator', () => {
     const acc: LabwareLocationInfoWithLocSeq[] = [BASIC_LOCATION_COMBO]
-    const lwDefs: LabwareDefinition2[] = [BASIC_LABWARE_DEF]
+    const lwDefs: LabwareDefinition[] = [BASIC_LABWARE_DEF]
 
     const result = appendUniqValidLocCombo(acc, lwDefs, BASIC_LOCATION_COMBO)
 
@@ -104,7 +104,7 @@ describe('appendUniqValidLocCombo', () => {
 
   it('should not append combo with same offset sequence and definition URI', () => {
     const acc: LabwareLocationInfoWithLocSeq[] = [BASIC_LOCATION_COMBO]
-    const lwDefs: LabwareDefinition2[] = [BASIC_LABWARE_DEF]
+    const lwDefs: LabwareDefinition[] = [BASIC_LABWARE_DEF]
 
     const similarCombo: LabwareLocationInfoWithLocSeq = {
       ...BASIC_LOCATION_COMBO,
@@ -118,7 +118,7 @@ describe('appendUniqValidLocCombo', () => {
 
   it('should not append combo when labware definition is not found', () => {
     const acc: LabwareLocationInfoWithLocSeq[] = []
-    const lwDefs: LabwareDefinition2[] = []
+    const lwDefs: LabwareDefinition[] = []
 
     const result = appendUniqValidLocCombo(acc, lwDefs, BASIC_LOCATION_COMBO)
 
@@ -127,7 +127,7 @@ describe('appendUniqValidLocCombo', () => {
 
   it('should not append combo with lid role', () => {
     const acc: LabwareLocationInfoWithLocSeq[] = []
-    const lwDefs: LabwareDefinition2[] = [LID_LABWARE_DEF]
+    const lwDefs: LabwareDefinition[] = [LID_LABWARE_DEF]
 
     const lidCombo: LabwareLocationInfoWithLocSeq = {
       ...BASIC_LOCATION_COMBO,
@@ -141,7 +141,7 @@ describe('appendUniqValidLocCombo', () => {
 
   it('should not append combo with adapter role', () => {
     const acc: LabwareLocationInfoWithLocSeq[] = []
-    const lwDefs: LabwareDefinition2[] = [ADAPTER_LABWARE_DEF]
+    const lwDefs: LabwareDefinition[] = [ADAPTER_LABWARE_DEF]
 
     const adapterCombo: LabwareLocationInfoWithLocSeq = {
       ...BASIC_LOCATION_COMBO,
@@ -155,7 +155,7 @@ describe('appendUniqValidLocCombo', () => {
 
   it('should not append combo with system role', () => {
     const acc: LabwareLocationInfoWithLocSeq[] = []
-    const lwDefs: LabwareDefinition2[] = [SYSTEM_LABWARE_DEF]
+    const lwDefs: LabwareDefinition[] = [SYSTEM_LABWARE_DEF]
 
     const systemCombo: LabwareLocationInfoWithLocSeq = {
       ...BASIC_LOCATION_COMBO,
@@ -169,7 +169,7 @@ describe('appendUniqValidLocCombo', () => {
 
   it('should not append combo with empty offset location sequence', () => {
     const acc: LabwareLocationInfoWithLocSeq[] = []
-    const lwDefs: LabwareDefinition2[] = [BASIC_LABWARE_DEF]
+    const lwDefs: LabwareDefinition[] = [BASIC_LABWARE_DEF]
 
     const comboWithEmptyOffsetLocSeq: LabwareLocationInfoWithLocSeq = {
       ...BASIC_LOCATION_COMBO,
@@ -187,7 +187,7 @@ describe('appendUniqValidLocCombo', () => {
 
   it('should not append combo with notOnDeck kind', () => {
     const acc: LabwareLocationInfoWithLocSeq[] = []
-    const lwDefs: LabwareDefinition2[] = [BASIC_LABWARE_DEF]
+    const lwDefs: LabwareDefinition[] = [BASIC_LABWARE_DEF]
 
     const notOnDeckCombo: LabwareLocationInfoWithLocSeq = {
       ...BASIC_LOCATION_COMBO,
@@ -204,7 +204,7 @@ describe('appendUniqValidLocCombo', () => {
 
   it('should not append combo with inStackerHopper kind', () => {
     const acc: LabwareLocationInfoWithLocSeq[] = []
-    const lwDefs: LabwareDefinition2[] = [BASIC_LABWARE_DEF]
+    const lwDefs: LabwareDefinition[] = [BASIC_LABWARE_DEF]
 
     const inStackerHopperCombo: LabwareLocationInfoWithLocSeq = {
       ...BASIC_LOCATION_COMBO,
@@ -221,7 +221,7 @@ describe('appendUniqValidLocCombo', () => {
 
   it('should not append combo in staging area', () => {
     const acc: LabwareLocationInfoWithLocSeq[] = []
-    const lwDefs: LabwareDefinition2[] = [BASIC_LABWARE_DEF]
+    const lwDefs: LabwareDefinition[] = [BASIC_LABWARE_DEF]
 
     const stagingAreaCombo: LabwareLocationInfoWithLocSeq = {
       ...BASIC_LOCATION_COMBO,
@@ -241,7 +241,7 @@ describe('appendUniqValidLocCombo', () => {
 
   it('should append valid combo with allowed roles that are not lid, adapter, or system', () => {
     const acc: LabwareLocationInfoWithLocSeq[] = []
-    const otherRoleLabwareDef: LabwareDefinition2 = {
+    const otherRoleLabwareDef: LabwareDefinition = {
       metadata: { displayName: 'Other Role Labware' },
       allowedRoles: ['tipRack'],
     } as any
@@ -254,7 +254,7 @@ describe('appendUniqValidLocCombo', () => {
       }
     })
 
-    const lwDefs: LabwareDefinition2[] = [otherRoleLabwareDef]
+    const lwDefs: LabwareDefinition[] = [otherRoleLabwareDef]
 
     const otherRoleCombo: LabwareLocationInfoWithLocSeq = {
       ...BASIC_LOCATION_COMBO,

--- a/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useLPCLabwareInfo/getUniqueValidLwLocationInfoByAnalysis/getLPCUniqValidLabwareLocationInfo/appendUniqValidLocCombo.ts
+++ b/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useLPCLabwareInfo/getUniqueValidLwLocationInfoByAnalysis/getLPCUniqValidLabwareLocationInfo/appendUniqValidLocCombo.ts
@@ -6,7 +6,7 @@ import {
 } from '@opentrons/shared-data'
 
 import type {
-  LabwareDefinition2,
+  LabwareDefinition,
   LabwareLocationSequence,
 } from '@opentrons/shared-data'
 import type { LabwareLocationInfoWithLocSeq } from '.'
@@ -15,7 +15,7 @@ import type { LabwareLocationInfoWithLocSeq } from '.'
 // and "valid".
 export function appendUniqValidLocCombo(
   acc: LabwareLocationInfoWithLocSeq[],
-  lwDefs: LabwareDefinition2[],
+  lwDefs: LabwareDefinition[],
   combo: LabwareLocationInfoWithLocSeq | null
 ): LabwareLocationInfoWithLocSeq[] {
   if (combo == null) {
@@ -36,7 +36,7 @@ export function appendUniqValidLocCombo(
 // A combo is "valid" if it is LPC-able.
 // We should know that we are dealing strictly with labware at this point!
 function isValidLocCombo(
-  lwDefs: LabwareDefinition2[],
+  lwDefs: LabwareDefinition[],
   combo: LabwareLocationInfoWithLocSeq
 ): boolean {
   const lwDef = lwDefs.find(

--- a/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useLPCLabwareInfo/getUniqueValidLwLocationInfoByAnalysis/getLPCUniqValidLabwareLocationInfo/index.ts
+++ b/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useLPCLabwareInfo/getUniqueValidLwLocationInfoByAnalysis/getLPCUniqValidLabwareLocationInfo/index.ts
@@ -5,7 +5,7 @@ import { getMoveLabwareLocationCombo } from './getMoveLabwareLocationCombo'
 
 import type {
   CompletedProtocolAnalysis,
-  LabwareDefinition2,
+  LabwareDefinition,
   LabwareLocationSequence,
 } from '@opentrons/shared-data'
 import type { LabwareLocationInfo } from '/app/redux/protocol-runs'
@@ -18,7 +18,7 @@ export interface LabwareLocationInfoWithLocSeq extends LabwareLocationInfo {
 // See helper utilities for what constitutes "unique" and "valid".
 export function getLPCUniqValidLabwareLocationInfo(
   protocolData: CompletedProtocolAnalysis | null,
-  lwDefs: LabwareDefinition2[]
+  lwDefs: LabwareDefinition[]
 ): LabwareLocationInfo[] {
   const { commands, labware, modules = [] } = protocolData ?? {
     labware: [],

--- a/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useLPCLabwareInfo/getUniqueValidLwLocationInfoByAnalysis/index.ts
+++ b/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useLPCLabwareInfo/getUniqueValidLwLocationInfoByAnalysis/index.ts
@@ -6,14 +6,14 @@ import { getLPCUniqValidLabwareLocationInfo } from './getLPCUniqValidLabwareLoca
 
 import type {
   CompletedProtocolAnalysis,
-  LabwareDefinition2,
+  LabwareDefinition,
   RobotType,
 } from '@opentrons/shared-data'
 import type { LabwareLocationInfo } from '/app/redux/protocol-runs'
 
 export interface GetUniqueValidLwLocationInfoByAnalysisParams {
   protocolData: CompletedProtocolAnalysis | null
-  labwareDefs: LabwareDefinition2[] | null
+  labwareDefs: LabwareDefinition[] | null
 }
 
 export function getUniqueValidLwLocationInfoByAnalysis({

--- a/app/src/organisms/LabwarePositionCheck/__fixtures__/mockLabwareDef.ts
+++ b/app/src/organisms/LabwarePositionCheck/__fixtures__/mockLabwareDef.ts
@@ -1,9 +1,9 @@
 import { fixture96Plate } from '@opentrons/shared-data'
 
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 
-export const mockLabwareDef: LabwareDefinition2 = {
-  ...(fixture96Plate as LabwareDefinition2),
+export const mockLabwareDef: LabwareDefinition = {
+  ...(fixture96Plate as LabwareDefinition),
   metadata: {
     displayName: 'Mock Labware Definition',
     displayCategory: 'wellPlate',

--- a/app/src/organisms/LabwarePositionCheck/__fixtures__/mockTipRackDef.ts
+++ b/app/src/organisms/LabwarePositionCheck/__fixtures__/mockTipRackDef.ts
@@ -1,9 +1,9 @@
 import { fixtureTiprack10ul } from '@opentrons/shared-data'
 
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 
-export const mockTipRackDef: LabwareDefinition2 = {
-  ...(fixtureTiprack10ul as LabwareDefinition2),
+export const mockTipRackDef: LabwareDefinition = {
+  ...(fixtureTiprack10ul as LabwareDefinition),
   metadata: {
     displayName: 'Mock TipRack Definition',
     displayCategory: 'tipRack',

--- a/app/src/organisms/LabwarePositionCheck/steps/HandleLabware/EditOffset/CheckLabware/LPCLabwareJogRender.tsx
+++ b/app/src/organisms/LabwarePositionCheck/steps/HandleLabware/EditOffset/CheckLabware/LPCLabwareJogRender.tsx
@@ -25,7 +25,7 @@ import {
   selectSelectedLwDef,
 } from '/app/redux/protocol-runs'
 
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 import type { EditOffsetContentProps } from '/app/organisms/LabwarePositionCheck/steps/HandleLabware/EditOffset'
 
 // TODO(jh, 03-12-25): Standardize viewboxes.
@@ -36,9 +36,7 @@ export function LPCLabwareJogRender({
 }: EditOffsetContentProps): JSX.Element {
   const pipetteName =
     useSelector(selectActivePipette(runId))?.pipetteName ?? 'p1000_single'
-  const itemLwDef = useSelector(
-    selectSelectedLwDef(runId)
-  ) as LabwareDefinition2
+  const itemLwDef = useSelector(selectSelectedLwDef(runId)) as LabwareDefinition
 
   return (
     <Flex css={RENDER_CONTAINER_STYLE}>

--- a/app/src/organisms/LabwarePositionCheck/steps/HandleLabware/EditOffset/PrepareLabware/LPCDeck.tsx
+++ b/app/src/organisms/LabwarePositionCheck/steps/HandleLabware/EditOffset/PrepareLabware/LPCDeck.tsx
@@ -21,7 +21,7 @@ import {
 } from '/app/redux/protocol-runs'
 
 import type { LabwareOnDeck, ModuleOnDeck } from '@opentrons/components'
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 import type { EditOffsetContentProps } from '/app/organisms/LabwarePositionCheck/steps/HandleLabware/EditOffset'
 import type {
   LPCWizardState,
@@ -46,7 +46,7 @@ export function LPCDeck({ runId }: EditOffsetContentProps): JSX.Element {
   ) as SelectedLwOverview
   const labwareDef = useSelector(
     selectSelectedLwDef(runId)
-  ) as LabwareDefinition2
+  ) as LabwareDefinition
   const adapterLwDef = useSelector(selectSelectedLwAdapterDef(runId))
 
   const offsetLocationDetails = selectedLwInfo.offsetLocationDetails as OffsetLocationDetails

--- a/app/src/organisms/LegacyApplyHistoricOffsets/LegacyLabwareOffsetTable.tsx
+++ b/app/src/organisms/LegacyApplyHistoricOffsets/LegacyLabwareOffsetTable.tsx
@@ -8,7 +8,7 @@ import { getDisplayLocation } from '/app/organisms/LegacyLabwarePositionCheck/ut
 import { formatTimestamp } from '/app/transformations/runs'
 
 import type { TFunction } from 'i18next'
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 import type { OffsetCandidate } from './hooks/useOffsetCandidatesForAnalysis'
 
 const OffsetTable = styled('table')`
@@ -36,7 +36,7 @@ const OffsetTableDatum = styled('td')`
 
 interface LegacyLabwareOffsetTableProps {
   offsetCandidates: OffsetCandidate[]
-  labwareDefinitions: LabwareDefinition2[]
+  labwareDefinitions: LabwareDefinition[]
 }
 
 export function LegacyLabwareOffsetTable(

--- a/app/src/organisms/LegacyApplyHistoricOffsets/__tests__/ApplyHistoricOffsets.test.tsx
+++ b/app/src/organisms/LegacyApplyHistoricOffsets/__tests__/ApplyHistoricOffsets.test.tsx
@@ -12,7 +12,7 @@ import { LegacyApplyHistoricOffsets } from '..'
 
 import type { ComponentProps } from 'react'
 import type * as OpentronsComponents from '@opentrons/components'
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 import type { OffsetCandidate } from '../hooks/useOffsetCandidatesForAnalysis'
 
 vi.mock('@opentrons/components', async importOriginal => {
@@ -25,8 +25,8 @@ vi.mock('@opentrons/components', async importOriginal => {
 vi.mock('/app/redux/config')
 vi.mock('/app/organisms/LegacyLabwarePositionCheck/utils/labware')
 
-const mockLabwareDef = fixture96Plate as LabwareDefinition2
-const mockAdapterDef = opentrons96PcrAdapterV1 as LabwareDefinition2
+const mockLabwareDef = fixture96Plate as LabwareDefinition
+const mockAdapterDef = opentrons96PcrAdapterV1 as LabwareDefinition
 
 const mockFirstCandidate: OffsetCandidate = {
   id: 'first_offset_id',

--- a/app/src/organisms/LegacyApplyHistoricOffsets/__tests__/LabwareOffsetTable.test.tsx
+++ b/app/src/organisms/LegacyApplyHistoricOffsets/__tests__/LabwareOffsetTable.test.tsx
@@ -9,11 +9,11 @@ import { i18n } from '/app/i18n'
 import { LegacyLabwareOffsetTable } from '../LegacyLabwareOffsetTable'
 
 import type { ComponentProps } from 'react'
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 import type { OffsetCandidate } from '../hooks/useOffsetCandidatesForAnalysis'
 
-const mockLabwareDef = fixture96Plate as LabwareDefinition2
-const mockAdapterDef = fixtureTiprackAdapter as LabwareDefinition2
+const mockLabwareDef = fixture96Plate as LabwareDefinition
+const mockAdapterDef = fixtureTiprackAdapter as LabwareDefinition
 
 const mockFirstCandidate: OffsetCandidate = {
   id: 'first_offset_id',

--- a/app/src/organisms/LegacyApplyHistoricOffsets/hooks/__tests__/getLabwareLocationCombos.test.ts
+++ b/app/src/organisms/LegacyApplyHistoricOffsets/hooks/__tests__/getLabwareLocationCombos.test.ts
@@ -8,10 +8,10 @@ import {
 
 import { getLegacyLabwareLocationCombos } from '../getLegacyLabwareLocationCombos'
 
-import type { LabwareDefinition2, RunTimeCommand } from '@opentrons/shared-data'
+import type { LabwareDefinition, RunTimeCommand } from '@opentrons/shared-data'
 
-const mockAdapterDef = opentrons96PcrAdapterV1 as LabwareDefinition2
-const mockLabwareDef = fixtureTiprack300ul as LabwareDefinition2
+const mockAdapterDef = opentrons96PcrAdapterV1 as LabwareDefinition
+const mockLabwareDef = fixtureTiprack300ul as LabwareDefinition
 const mockLoadLabwareCommands: RunTimeCommand[] = [
   {
     key: 'CommandKey0',

--- a/app/src/organisms/LegacyApplyHistoricOffsets/hooks/__tests__/useOffsetCandidatesForAnalysis.test.tsx
+++ b/app/src/organisms/LegacyApplyHistoricOffsets/hooks/__tests__/useOffsetCandidatesForAnalysis.test.tsx
@@ -15,7 +15,7 @@ import { useAllHistoricOffsets } from '../useAllHistoricOffsets'
 import { useOffsetCandidatesForAnalysis } from '../useOffsetCandidatesForAnalysis'
 
 import type { FunctionComponent, ReactNode } from 'react'
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 import type { OffsetCandidate } from '../useOffsetCandidatesForAnalysis'
 
 vi.mock('../useAllHistoricOffsets')
@@ -24,7 +24,7 @@ vi.mock('@opentrons/shared-data')
 vi.mock('/app/resources/runs')
 vi.mock('/app/resources/useNotifyDataReady')
 
-const mockLabwareDef = fixtureTiprack300ul as LabwareDefinition2
+const mockLabwareDef = fixtureTiprack300ul as LabwareDefinition
 
 const mockFirstCandidate: OffsetCandidate = {
   id: 'first_offset_id',

--- a/app/src/organisms/LegacyLabwarePositionCheck/IntroScreen/index.tsx
+++ b/app/src/organisms/LegacyLabwarePositionCheck/IntroScreen/index.tsx
@@ -38,7 +38,7 @@ import type { Dispatch } from 'react'
 import type { LabwareOffset } from '@opentrons/api-client'
 import type {
   CompletedProtocolAnalysis,
-  LabwareDefinition2,
+  LabwareDefinition,
 } from '@opentrons/shared-data'
 import type { Jog } from '/app/molecules/JogControls'
 import type { useChainRunCommands } from '/app/resources/runs'
@@ -158,7 +158,7 @@ const VIEW_OFFSETS_BUTTON_STYLE = css`
 `
 interface ViewOffsetsProps {
   existingOffsets: LabwareOffset[]
-  labwareDefinitions: LabwareDefinition2[]
+  labwareDefinitions: LabwareDefinition[]
 }
 function ViewOffsets(props: ViewOffsetsProps): JSX.Element {
   const { existingOffsets, labwareDefinitions } = props

--- a/app/src/organisms/LegacyLabwarePositionCheck/JogToWell.tsx
+++ b/app/src/organisms/LegacyLabwarePositionCheck/JogToWell.tsx
@@ -48,7 +48,7 @@ import { LiveOffsetValue } from './LiveOffsetValue'
 import type { ReactNode } from 'react'
 import type { VectorOffset } from '@opentrons/api-client'
 import type { WellStroke } from '@opentrons/components'
-import type { LabwareDefinition2, PipetteName } from '@opentrons/shared-data'
+import type { LabwareDefinition, PipetteName } from '@opentrons/shared-data'
 import type { Jog } from '/app/molecules/JogControls'
 
 const DECK_MAP_VIEWBOX = '-10 -10 150 105'
@@ -61,7 +61,7 @@ interface JogToWellProps {
   handleGoBack: () => void
   handleJog: Jog
   pipetteName: PipetteName
-  labwareDef: LabwareDefinition2
+  labwareDef: LabwareDefinition
   header: ReactNode
   body: ReactNode
   initialPosition: VectorOffset

--- a/app/src/organisms/LegacyLabwarePositionCheck/PrepareSpace.tsx
+++ b/app/src/organisms/LegacyLabwarePositionCheck/PrepareSpace.tsx
@@ -27,7 +27,7 @@ import { useNotifyDeckConfigurationQuery } from '/app/resources/deck_configurati
 import type { ReactNode } from 'react'
 import type {
   CompletedProtocolAnalysis,
-  LabwareDefinition2,
+  LabwareDefinition,
   RobotType,
 } from '@opentrons/shared-data'
 import type { CheckLabwareStep } from './types'
@@ -60,7 +60,7 @@ interface PrepareSpaceProps extends Omit<CheckLabwareStep, 'section'> {
     | 'PICK_UP_TIP'
     | 'RETURN_TIP'
     | 'CHECK_POSITIONS'
-  labwareDef: LabwareDefinition2
+  labwareDef: LabwareDefinition
   protocolData: CompletedProtocolAnalysis
   confirmPlacement: () => void
   onSkip: () => void

--- a/app/src/organisms/LegacyLabwarePositionCheck/ResultsSummary.tsx
+++ b/app/src/organisms/LegacyLabwarePositionCheck/ResultsSummary.tsx
@@ -50,7 +50,7 @@ import type {
 } from '@opentrons/api-client'
 import type {
   CompletedProtocolAnalysis,
-  LabwareDefinition2,
+  LabwareDefinition,
 } from '@opentrons/shared-data'
 import type { ResultsSummaryStep, WorkingOffset } from './types'
 
@@ -231,7 +231,7 @@ const ScrollContainer = styled(Flex)`
 
 interface OffsetTableProps {
   offsets: LegacyLabwareOffsetCreateData[]
-  labwareDefinitions: LabwareDefinition2[]
+  labwareDefinitions: LabwareDefinition[]
 }
 
 const OffsetTable = (props: OffsetTableProps): JSX.Element => {

--- a/app/src/organisms/LegacyLabwarePositionCheck/TerseOffsetTable.stories.tsx
+++ b/app/src/organisms/LegacyLabwarePositionCheck/TerseOffsetTable.stories.tsx
@@ -18,7 +18,7 @@ import { TerseOffsetTable } from './ResultsSummary'
 
 import type { Meta, Story } from '@storybook/react'
 import type * as React from 'react'
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 
 export default {
   title: 'ODD/Organisms/TerseOffsetTable',
@@ -61,47 +61,47 @@ export const Basic = Template.bind({})
 Basic.args = {
   offsets: [
     {
-      definitionUri: getLabwareDefURI(fixture12Trough as LabwareDefinition2),
+      definitionUri: getLabwareDefURI(fixture12Trough as LabwareDefinition),
       location: { slotName: 'A1' },
       vector: { x: 1, y: 2, z: 3 },
     },
     {
-      definitionUri: getLabwareDefURI(fixture12Trough as LabwareDefinition2),
+      definitionUri: getLabwareDefURI(fixture12Trough as LabwareDefinition),
       location: { slotName: 'A2' },
       vector: { x: 1, y: 2, z: 3 },
     },
     {
-      definitionUri: getLabwareDefURI(fixture12Trough as LabwareDefinition2),
+      definitionUri: getLabwareDefURI(fixture12Trough as LabwareDefinition),
       location: { slotName: 'A3' },
       vector: { x: 1, y: 2, z: 3 },
     },
     {
-      definitionUri: getLabwareDefURI(fixture12Trough as LabwareDefinition2),
+      definitionUri: getLabwareDefURI(fixture12Trough as LabwareDefinition),
       location: { slotName: 'B1' },
       vector: { x: 1, y: 2, z: 3 },
     },
     {
-      definitionUri: getLabwareDefURI(fixture12Trough as LabwareDefinition2),
+      definitionUri: getLabwareDefURI(fixture12Trough as LabwareDefinition),
       location: { slotName: 'B2' },
       vector: { x: 1, y: 2, z: 3 },
     },
     {
-      definitionUri: getLabwareDefURI(fixture12Trough as LabwareDefinition2),
+      definitionUri: getLabwareDefURI(fixture12Trough as LabwareDefinition),
       location: { slotName: 'B3' },
       vector: { x: 1, y: 2, z: 3 },
     },
     {
-      definitionUri: getLabwareDefURI(fixture12Trough as LabwareDefinition2),
+      definitionUri: getLabwareDefURI(fixture12Trough as LabwareDefinition),
       location: { slotName: 'C1' },
       vector: { x: 1, y: 2, z: 3 },
     },
     {
-      definitionUri: getLabwareDefURI(fixture12Trough as LabwareDefinition2),
+      definitionUri: getLabwareDefURI(fixture12Trough as LabwareDefinition),
       location: { slotName: 'C2' },
       vector: { x: 1, y: 2, z: 3 },
     },
     {
-      definitionUri: getLabwareDefURI(fixture12Trough as LabwareDefinition2),
+      definitionUri: getLabwareDefURI(fixture12Trough as LabwareDefinition),
       location: { slotName: 'C3' },
       vector: { x: 1, y: 2, z: 3 },
     },

--- a/app/src/organisms/LegacyLabwarePositionCheck/__fixtures__/mockLabwareDef.ts
+++ b/app/src/organisms/LegacyLabwarePositionCheck/__fixtures__/mockLabwareDef.ts
@@ -1,9 +1,9 @@
 import { fixture96Plate } from '@opentrons/shared-data'
 
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 
-export const mockLabwareDef: LabwareDefinition2 = {
-  ...(fixture96Plate as LabwareDefinition2),
+export const mockLabwareDef: LabwareDefinition = {
+  ...(fixture96Plate as LabwareDefinition),
   metadata: {
     displayName: 'Mock Labware Definition',
     displayCategory: 'wellPlate',

--- a/app/src/organisms/LegacyLabwarePositionCheck/__fixtures__/mockTipRackDef.ts
+++ b/app/src/organisms/LegacyLabwarePositionCheck/__fixtures__/mockTipRackDef.ts
@@ -1,9 +1,9 @@
 import { fixtureTiprack10ul } from '@opentrons/shared-data'
 
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 
-export const mockTipRackDef: LabwareDefinition2 = {
-  ...(fixtureTiprack10ul as LabwareDefinition2),
+export const mockTipRackDef: LabwareDefinition = {
+  ...(fixtureTiprack10ul as LabwareDefinition),
   metadata: {
     displayName: 'Mock TipRack Definition',
     displayCategory: 'tipRack',

--- a/app/src/organisms/LegacyLabwarePositionCheck/types.ts
+++ b/app/src/organisms/LegacyLabwarePositionCheck/types.ts
@@ -3,7 +3,7 @@ import type {
   VectorOffset,
 } from '@opentrons/api-client'
 import type { useCreateCommandMutation } from '@opentrons/react-api-client'
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 import type { SECTIONS } from './constants'
 
 export type LabwarePositionCheckStep =
@@ -108,7 +108,7 @@ export interface WorkingOffset {
 }
 
 export interface LabwareToOrder {
-  definition: LabwareDefinition2
+  definition: LabwareDefinition
   labwareId: string
   slot: string
 }

--- a/app/src/organisms/LegacyLabwarePositionCheck/utils/doesPipetteVisitAllTipracks.ts
+++ b/app/src/organisms/LegacyLabwarePositionCheck/utils/doesPipetteVisitAllTipracks.ts
@@ -6,7 +6,7 @@ import {
 } from '/app/transformations/commands'
 
 import type {
-  LabwareDefinition2,
+  LabwareDefinition,
   LoadedLabware,
   RunTimeCommand,
 } from '@opentrons/shared-data'
@@ -14,7 +14,7 @@ import type {
 export const doesPipetteVisitAllTipracks = (
   pipetteId: string,
   labware: LoadedLabware[],
-  labwareDefinitions: Record<string, LabwareDefinition2>,
+  labwareDefinitions: Record<string, LabwareDefinition>,
   commands: RunTimeCommand[]
 ): boolean => {
   const numberOfTipracks = labware.reduce(

--- a/app/src/organisms/LegacyLabwarePositionCheck/utils/getDisplayLocation.ts
+++ b/app/src/organisms/LegacyLabwarePositionCheck/utils/getDisplayLocation.ts
@@ -7,11 +7,11 @@ import {
 
 import type { i18n, TFunction } from 'i18next'
 import type { LegacyLabwareOffsetLocation } from '@opentrons/api-client'
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 
 export function getDisplayLocation(
   location: LegacyLabwareOffsetLocation,
-  labwareDefinitions: LabwareDefinition2[],
+  labwareDefinitions: LabwareDefinition[],
   t: TFunction,
   i18n: i18n,
   slotOnly?: boolean

--- a/app/src/organisms/LegacyLabwarePositionCheck/utils/labware.ts
+++ b/app/src/organisms/LegacyLabwarePositionCheck/utils/labware.ts
@@ -11,7 +11,7 @@ import { getModuleInitialLoadInfo } from '/app/transformations/commands'
 
 import type {
   CompletedProtocolAnalysis,
-  LabwareDefinition2,
+  LabwareDefinition,
   LabwareLocation,
   LoadLabwareRunTimeCommand,
   PickUpTipRunTimeCommand,
@@ -52,7 +52,7 @@ interface Labware {
 
 export const getTiprackIdsInOrder = (
   labware: Labware,
-  labwareDefinitions: Record<string, LabwareDefinition2>,
+  labwareDefinitions: Record<string, LabwareDefinition>,
   commands: RunTimeCommand[]
 ): string[] => {
   const unorderedTipracks = reduce<typeof labware, LabwareToOrder[]>(
@@ -262,7 +262,7 @@ export const getAllUniqLocationsForLabware = (
 export function getLabwareDef(
   labwareId: string,
   protocolData: CompletedProtocolAnalysis
-): LabwareDefinition2 | undefined {
+): LabwareDefinition | undefined {
   const labwareDefUri = protocolData.labware.find(l => l.id === labwareId)
     ?.definitionUri
   const labwareDefinitions = getLabwareDefinitionsFromCommands(

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupLabware/LabwareLiquidsDetailModal.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupLabware/LabwareLiquidsDetailModal.tsx
@@ -7,7 +7,11 @@ import {
   LabwareRender,
   SPACING,
 } from '@opentrons/components'
-import { parseLiquidsInLoadOrder } from '@opentrons/shared-data'
+import {
+  getSchema2CornerOffsetFromSlot,
+  getSchema2Dimensions,
+  parseLiquidsInLoadOrder,
+} from '@opentrons/shared-data'
 
 import { LiquidCardList } from '/app/molecules/LiquidDetailCard'
 import { OddModal } from '/app/molecules/OddModal'
@@ -72,6 +76,11 @@ export const LabwareLiquidsDetailModal = (
     selectedLiquidId
   )
 
+  const labwareCornerOffsetFromSlot = getSchema2CornerOffsetFromSlot(
+    labwareDefinition
+  )
+  const labwareDimensions = getSchema2Dimensions(labwareDefinition)
+
   const liquidIds = filteredLiquidsInLoadOrder.map(liquid => liquid.id)
   const disabledLiquidIds = liquidIds.filter(id => id !== selectedLiquidId)
   const labwareRender = (
@@ -105,7 +114,7 @@ export const LabwareLiquidsDetailModal = (
       <Flex justifyContent={JUSTIFY_SPACE_BETWEEN} gridGap={SPACING.spacing32}>
         <Flex>
           <LabwareThumbnail
-            viewBox={`${labwareDefinition.cornerOffsetFromSlot.x} ${labwareDefinition.cornerOffsetFromSlot.y} ${labwareDefinition.dimensions.xDimension} ${labwareDefinition.dimensions.yDimension}`}
+            viewBox={`${labwareCornerOffsetFromSlot.x} ${labwareCornerOffsetFromSlot.y} ${labwareDimensions.xDimension} ${labwareDimensions.yDimension}`}
           >
             {labwareRender}
           </LabwareThumbnail>

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupLabware/LabwareLiquidsDetailModal.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupLabware/LabwareLiquidsDetailModal.tsx
@@ -20,7 +20,7 @@ import {
 
 import type {
   CompletedProtocolAnalysis,
-  LabwareDefinition2,
+  LabwareDefinition,
 } from '@opentrons/shared-data'
 import type { LabwareByLiquidId } from '/app/transformations/commands'
 
@@ -30,7 +30,7 @@ interface LabwareLiquidsDetailModalProps {
   mostRecentAnalysis: CompletedProtocolAnalysis
   closeModal: () => void
   labwareByLiquidId: LabwareByLiquidId
-  labwareDefinition: LabwareDefinition2
+  labwareDefinition: LabwareDefinition
   stackPosition?: number
 }
 

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupLabware/SetupLabwareStackView.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupLabware/SetupLabwareStackView.tsx
@@ -18,6 +18,10 @@ import {
   Tag,
   truncateString,
 } from '@opentrons/components'
+import {
+  getSchema2CornerOffsetFromSlot,
+  getSchema2Dimensions,
+} from '@opentrons/shared-data'
 
 import { LabwareStackContents } from '/app/molecules/LabwareStackContents'
 import { ODDBackButton } from '/app/molecules/ODDBackButton'
@@ -88,6 +92,10 @@ export function SetupLabwareStackView({
   const hasLiquids = Object.keys(wellFill).length > 0
   const labwareDefinition =
     labwareDefinitionsByURI[selectedLabware.definitionUri]
+  const labwareCornerOffsetFromSlot = getSchema2CornerOffsetFromSlot(
+    labwareDefinition
+  )
+  const labwareDimensions = getSchema2Dimensions(labwareDefinition)
 
   return (
     <>
@@ -174,7 +182,7 @@ export function SetupLabwareStackView({
             </StyledText>
           ) : null}
           <LabwareThumbnail
-            viewBox={`${labwareDefinition.cornerOffsetFromSlot.x} ${labwareDefinition.cornerOffsetFromSlot.y} ${labwareDefinition.dimensions.xDimension} ${labwareDefinition.dimensions.yDimension}`}
+            viewBox={`${labwareCornerOffsetFromSlot.x} ${labwareCornerOffsetFromSlot.y} ${labwareDimensions.xDimension} ${labwareDimensions.yDimension}`}
           >
             <g
               onClick={() => {

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupLabware/__tests__/LabwareMapView.test.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupLabware/__tests__/LabwareMapView.test.tsx
@@ -17,7 +17,7 @@ import type { ComponentProps } from 'react'
 import type {
   CompletedProtocolAnalysis,
   getSimplestDeckConfigForProtocol,
-  LabwareDefinition2,
+  LabwareDefinition,
   ModuleModel,
 } from '@opentrons/shared-data'
 
@@ -70,7 +70,7 @@ describe('LabwareMapView', () => {
     const mockLabwareOnDeck = [
       {
         labwareLocation: { slotName: 'C1' },
-        definition: fixtureTiprack300ul as LabwareDefinition2,
+        definition: fixtureTiprack300ul as LabwareDefinition,
         topLabwareId: '300_ul_tiprack_id',
         onLabwareClick: expect.any(Function),
         labwareChildren: null,
@@ -81,7 +81,7 @@ describe('LabwareMapView', () => {
         moduleModel: 'heaterShakerModuleV1' as ModuleModel,
         moduleLocation: { slotName: 'B1' },
         nestedLabwareDef: mockProtocolModuleInfo[0]
-          .nestedLabwareDef as LabwareDefinition2,
+          .nestedLabwareDef as LabwareDefinition,
         onLabwareClick: expect.any(Function),
         moduleChildren: null,
         innerProps: {},
@@ -98,7 +98,7 @@ describe('LabwareMapView', () => {
       .thenReturn(<div>mock base deck</div>)
     vi.mocked(getLabwareRenderInfo).mockReturnValue({
       '300_ul_tiprack_id': {
-        labwareDef: fixtureTiprack300ul as LabwareDefinition2,
+        labwareDef: fixtureTiprack300ul as LabwareDefinition,
         displayName: 'fresh tips',
         x: MOCK_300_UL_TIPRACK_COORDS[0],
         y: MOCK_300_UL_TIPRACK_COORDS[1],

--- a/app/src/organisms/ODD/QuickTransferFlow/SelectDestLabware.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/SelectDestLabware.tsx
@@ -18,7 +18,7 @@ import { ChildNavigation } from '/app/organisms/ODD/ChildNavigation'
 import { getCompatibleLabwareByCategory } from './utils'
 
 import type { ComponentProps, Dispatch } from 'react'
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 import type { SmallButton } from '/app/atoms/buttons'
 import type { LabwareFilter } from '/app/local-resources/labware'
 import type {
@@ -49,7 +49,7 @@ export function SelectDestLabware(
   }
   const [selectedCategory, setSelectedCategory] = useState<LabwareFilter>('all')
   const [selectedLabware, setSelectedLabware] = useState<
-    LabwareDefinition2 | 'source' | undefined
+    LabwareDefinition | 'source' | undefined
   >(state.destination)
 
   if (state.pipette == null) return null

--- a/app/src/organisms/ODD/QuickTransferFlow/SelectDestLabware.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/SelectDestLabware.tsx
@@ -18,7 +18,7 @@ import { ChildNavigation } from '/app/organisms/ODD/ChildNavigation'
 import { getCompatibleLabwareByCategory } from './utils'
 
 import type { ComponentProps, Dispatch } from 'react'
-import type { LabwareDefinition } from '@opentrons/shared-data'
+import type { LabwareDefinition2 } from '@opentrons/shared-data'
 import type { SmallButton } from '/app/atoms/buttons'
 import type { LabwareFilter } from '/app/local-resources/labware'
 import type {
@@ -49,12 +49,12 @@ export function SelectDestLabware(
   }
   const [selectedCategory, setSelectedCategory] = useState<LabwareFilter>('all')
   const [selectedLabware, setSelectedLabware] = useState<
-    LabwareDefinition | 'source' | undefined
+    LabwareDefinition2 | 'source' | undefined
   >(state.destination)
 
   if (state.pipette == null) return null
 
-  const compatibleLabwareDefinitions = getCompatibleLabwareByCategory(
+  const compatibleLabwareDefinition2s = getCompatibleLabwareByCategory(
     state.pipette.channels,
     selectedCategory
   )
@@ -126,7 +126,7 @@ export function SelectDestLabware(
               }}
             />
           ) : null}
-          {compatibleLabwareDefinitions?.map(definition => {
+          {compatibleLabwareDefinition2s?.map(definition => {
             return definition.metadata.displayName != null ? (
               <RadioButton
                 key={`${selectedCategory}-${definition.metadata.displayName}`}

--- a/app/src/organisms/ODD/QuickTransferFlow/SelectSourceLabware.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/SelectSourceLabware.tsx
@@ -18,7 +18,7 @@ import { ChildNavigation } from '/app/organisms/ODD/ChildNavigation'
 import { getCompatibleLabwareByCategory } from './utils'
 
 import type { ComponentProps, Dispatch } from 'react'
-import type { LabwareDefinition } from '@opentrons/shared-data'
+import type { LabwareDefinition2 } from '@opentrons/shared-data'
 import type { SmallButton } from '/app/atoms/buttons'
 import type { LabwareFilter } from '/app/local-resources/labware'
 import type {
@@ -50,12 +50,12 @@ export function SelectSourceLabware(
   const [selectedCategory, setSelectedCategory] = useState<LabwareFilter>('all')
 
   const [selectedLabware, setSelectedLabware] = useState<
-    LabwareDefinition | undefined
+    LabwareDefinition2 | undefined
   >(state.source)
 
   if (state.pipette == null) return null
 
-  const compatibleLabwareDefinitions = getCompatibleLabwareByCategory(
+  const compatibleLabwareDefinition2s = getCompatibleLabwareByCategory(
     state.pipette.channels,
     selectedCategory
   )
@@ -113,7 +113,7 @@ export function SelectSourceLabware(
           flexDirection={DIRECTION_COLUMN}
           marginTop="175px"
         >
-          {compatibleLabwareDefinitions?.map(definition => {
+          {compatibleLabwareDefinition2s?.map(definition => {
             return definition.metadata.displayName != null ? (
               <RadioButton
                 key={`${selectedCategory}-${definition.metadata.displayName}`}

--- a/app/src/organisms/ODD/QuickTransferFlow/SelectSourceLabware.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/SelectSourceLabware.tsx
@@ -18,7 +18,7 @@ import { ChildNavigation } from '/app/organisms/ODD/ChildNavigation'
 import { getCompatibleLabwareByCategory } from './utils'
 
 import type { ComponentProps, Dispatch } from 'react'
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 import type { SmallButton } from '/app/atoms/buttons'
 import type { LabwareFilter } from '/app/local-resources/labware'
 import type {
@@ -50,7 +50,7 @@ export function SelectSourceLabware(
   const [selectedCategory, setSelectedCategory] = useState<LabwareFilter>('all')
 
   const [selectedLabware, setSelectedLabware] = useState<
-    LabwareDefinition2 | undefined
+    LabwareDefinition | undefined
   >(state.source)
 
   if (state.pipette == null) return null

--- a/app/src/organisms/ODD/QuickTransferFlow/SelectTipRack.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/SelectTipRack.tsx
@@ -12,7 +12,7 @@ import { getAllDefinitions } from '@opentrons/shared-data'
 import { ChildNavigation } from '/app/organisms/ODD/ChildNavigation'
 
 import type { ComponentProps, Dispatch } from 'react'
-import type { LabwareDefinition } from '@opentrons/shared-data'
+import type { LabwareDefinition2 } from '@opentrons/shared-data'
 import type { SmallButton } from '/app/atoms/buttons'
 import type {
   QuickTransferWizardAction,
@@ -31,12 +31,12 @@ export function SelectTipRack(props: SelectTipRackProps): JSX.Element {
   const { onNext, onBack, exitButtonProps, state, dispatch } = props
   const { i18n, t } = useTranslation(['quick_transfer', 'shared'])
 
-  const allLabwareDefinitionsByUri = getAllDefinitions()
+  const allLabwareDefinition2sByUri = getAllDefinitions()
   const selectedPipetteDefaultTipracks =
     state.pipette?.liquids.default.defaultTipracks ?? []
 
   const [selectedTipRack, setSelectedTipRack] = useState<
-    LabwareDefinition | undefined
+    LabwareDefinition2 | undefined
   >(state.tipRack)
 
   const handleClickNext = (): void => {
@@ -68,7 +68,7 @@ export function SelectTipRack(props: SelectTipRackProps): JSX.Element {
         width="100%"
       >
         {selectedPipetteDefaultTipracks.map(tipRack => {
-          const tipRackDef = allLabwareDefinitionsByUri[tipRack]
+          const tipRackDef = allLabwareDefinition2sByUri[tipRack]
 
           return tipRackDef != null ? (
             <RadioButton

--- a/app/src/organisms/ODD/QuickTransferFlow/SelectTipRack.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/SelectTipRack.tsx
@@ -12,7 +12,7 @@ import { getAllDefinitions } from '@opentrons/shared-data'
 import { ChildNavigation } from '/app/organisms/ODD/ChildNavigation'
 
 import type { ComponentProps, Dispatch } from 'react'
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 import type { SmallButton } from '/app/atoms/buttons'
 import type {
   QuickTransferWizardAction,
@@ -36,7 +36,7 @@ export function SelectTipRack(props: SelectTipRackProps): JSX.Element {
     state.pipette?.liquids.default.defaultTipracks ?? []
 
   const [selectedTipRack, setSelectedTipRack] = useState<
-    LabwareDefinition2 | undefined
+    LabwareDefinition | undefined
   >(state.tipRack)
 
   const handleClickNext = (): void => {

--- a/app/src/organisms/ODD/QuickTransferFlow/__tests__/utils/quickTransferStepCommands.test.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/__tests__/utils/quickTransferStepCommands.test.ts
@@ -10,7 +10,7 @@ import { SOURCE_WELL_BLOWOUT_DESTINATION } from '@opentrons/step-generation'
 
 import { quickTransferStepCommands } from '../../utils/pythonDef'
 
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 import type {
   ConsolidateArgs,
   DistributeArgs,
@@ -36,7 +36,7 @@ const mockInvariantContext: InvariantContext = {
     mockPipette: {
       name: 'p1000_single_flex',
       id: 'mockPipette',
-      tiprackLabwareDef: [fixtureTiprack1000ul] as LabwareDefinition2[],
+      tiprackLabwareDef: [fixtureTiprack1000ul] as LabwareDefinition[],
       tiprackDefURI: ['fixture/fixture_flex_96_tiprack_1000ul/1'],
       spec: fixtureP1000SingleV2Specs,
       pythonName: 'pipette',
@@ -46,19 +46,19 @@ const mockInvariantContext: InvariantContext = {
     mockSourceLabware: {
       id: 'mockSourceLabware',
       labwareDefURI: 'mockDefUri',
-      def: fixture96Plate as LabwareDefinition2,
+      def: fixture96Plate as LabwareDefinition,
       pythonName: 'mock_labware_1',
     },
     mockDestLabware: {
       id: 'mockDestLabware',
       labwareDefURI: 'mockDefUri',
-      def: fixture96Plate as LabwareDefinition2,
+      def: fixture96Plate as LabwareDefinition,
       pythonName: 'mock_labware_2',
     },
     mockTiprack: {
       id: 'mockTiprack',
       labwareDefURI: 'fixture/fixture_flex_96_tiprack_1000ul/1',
-      def: fixtureTiprack1000ul as LabwareDefinition2,
+      def: fixtureTiprack1000ul as LabwareDefinition,
       pythonName: 'mock_tiprack_1',
     },
   },

--- a/app/src/organisms/ODD/QuickTransferFlow/__tests__/utils/quickTransferStepCommands.test.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/__tests__/utils/quickTransferStepCommands.test.ts
@@ -10,7 +10,7 @@ import { SOURCE_WELL_BLOWOUT_DESTINATION } from '@opentrons/step-generation'
 
 import { quickTransferStepCommands } from '../../utils/pythonDef'
 
-import type { LabwareDefinition } from '@opentrons/shared-data'
+import type { LabwareDefinition2 } from '@opentrons/shared-data'
 import type {
   ConsolidateArgs,
   DistributeArgs,
@@ -36,7 +36,7 @@ const mockInvariantContext: InvariantContext = {
     mockPipette: {
       name: 'p1000_single_flex',
       id: 'mockPipette',
-      tiprackLabwareDef: [fixtureTiprack1000ul] as LabwareDefinition[],
+      tiprackLabwareDef: [fixtureTiprack1000ul] as LabwareDefinition2[],
       tiprackDefURI: ['fixture/fixture_flex_96_tiprack_1000ul/1'],
       spec: fixtureP1000SingleV2Specs,
       pythonName: 'pipette',
@@ -46,19 +46,19 @@ const mockInvariantContext: InvariantContext = {
     mockSourceLabware: {
       id: 'mockSourceLabware',
       labwareDefURI: 'mockDefUri',
-      def: fixture96Plate as LabwareDefinition,
+      def: fixture96Plate as LabwareDefinition2,
       pythonName: 'mock_labware_1',
     },
     mockDestLabware: {
       id: 'mockDestLabware',
       labwareDefURI: 'mockDefUri',
-      def: fixture96Plate as LabwareDefinition,
+      def: fixture96Plate as LabwareDefinition2,
       pythonName: 'mock_labware_2',
     },
     mockTiprack: {
       id: 'mockTiprack',
       labwareDefURI: 'fixture/fixture_flex_96_tiprack_1000ul/1',
-      def: fixtureTiprack1000ul as LabwareDefinition,
+      def: fixtureTiprack1000ul as LabwareDefinition2,
       pythonName: 'mock_tiprack_1',
     },
   },

--- a/app/src/organisms/ODD/QuickTransferFlow/types.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/types.ts
@@ -1,7 +1,7 @@
 import type { Mount } from '@opentrons/api-client'
 import type {
   CutoutConfig,
-  LabwareDefinition,
+  LabwareDefinition2,
   LiquidClass,
   PipetteV2Specs,
 } from '@opentrons/shared-data'
@@ -17,10 +17,10 @@ import type {
 export interface QuickTransferWizardState {
   pipette?: PipetteV2Specs
   mount?: Mount
-  tipRack?: LabwareDefinition
-  source?: LabwareDefinition
+  tipRack?: LabwareDefinition2
+  source?: LabwareDefinition2
   sourceWells?: string[]
-  destination?: LabwareDefinition | 'source'
+  destination?: LabwareDefinition2 | 'source'
   destinationWells?: string[]
   transferType?: TransferType
   volume?: number
@@ -52,10 +52,10 @@ export interface SettingItem {
 export interface QuickTransferSummaryState {
   pipette: PipetteV2Specs
   mount: Mount
-  tipRack: LabwareDefinition
-  source: LabwareDefinition
+  tipRack: LabwareDefinition2
+  source: LabwareDefinition2
   sourceWells: string[]
-  destination: LabwareDefinition | 'source'
+  destination: LabwareDefinition2 | 'source'
   destinationWells: string[]
   transferType: TransferType
   volume: number
@@ -244,11 +244,11 @@ interface SelectPipetteAction {
 }
 interface SelectTipRackAction {
   type: typeof ACTIONS.SELECT_TIP_RACK
-  tipRack: LabwareDefinition
+  tipRack: LabwareDefinition2
 }
 interface SetSourceLabwareAction {
   type: typeof ACTIONS.SET_SOURCE_LABWARE
-  labware: LabwareDefinition
+  labware: LabwareDefinition2
 }
 interface SetSourceWellsAction {
   type: typeof ACTIONS.SET_SOURCE_WELLS
@@ -256,7 +256,7 @@ interface SetSourceWellsAction {
 }
 interface SetDestLabwareAction {
   type: typeof ACTIONS.SET_DEST_LABWARE
-  labware: LabwareDefinition | 'source'
+  labware: LabwareDefinition2 | 'source'
 }
 interface SetDestWellsAction {
   type: typeof ACTIONS.SET_DEST_WELLS

--- a/app/src/organisms/ODD/QuickTransferFlow/types.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/types.ts
@@ -1,7 +1,7 @@
 import type { Mount } from '@opentrons/api-client'
 import type {
   CutoutConfig,
-  LabwareDefinition2,
+  LabwareDefinition,
   LiquidClass,
   PipetteV2Specs,
 } from '@opentrons/shared-data'
@@ -17,10 +17,10 @@ import type {
 export interface QuickTransferWizardState {
   pipette?: PipetteV2Specs
   mount?: Mount
-  tipRack?: LabwareDefinition2
-  source?: LabwareDefinition2
+  tipRack?: LabwareDefinition
+  source?: LabwareDefinition
   sourceWells?: string[]
-  destination?: LabwareDefinition2 | 'source'
+  destination?: LabwareDefinition | 'source'
   destinationWells?: string[]
   transferType?: TransferType
   volume?: number
@@ -52,10 +52,10 @@ export interface SettingItem {
 export interface QuickTransferSummaryState {
   pipette: PipetteV2Specs
   mount: Mount
-  tipRack: LabwareDefinition2
-  source: LabwareDefinition2
+  tipRack: LabwareDefinition
+  source: LabwareDefinition
   sourceWells: string[]
-  destination: LabwareDefinition2 | 'source'
+  destination: LabwareDefinition | 'source'
   destinationWells: string[]
   transferType: TransferType
   volume: number
@@ -244,11 +244,11 @@ interface SelectPipetteAction {
 }
 interface SelectTipRackAction {
   type: typeof ACTIONS.SELECT_TIP_RACK
-  tipRack: LabwareDefinition2
+  tipRack: LabwareDefinition
 }
 interface SetSourceLabwareAction {
   type: typeof ACTIONS.SET_SOURCE_LABWARE
-  labware: LabwareDefinition2
+  labware: LabwareDefinition
 }
 interface SetSourceWellsAction {
   type: typeof ACTIONS.SET_SOURCE_WELLS
@@ -256,7 +256,7 @@ interface SetSourceWellsAction {
 }
 interface SetDestLabwareAction {
   type: typeof ACTIONS.SET_DEST_LABWARE
-  labware: LabwareDefinition2 | 'source'
+  labware: LabwareDefinition | 'source'
 }
 interface SetDestWellsAction {
   type: typeof ACTIONS.SET_DEST_WELLS

--- a/app/src/organisms/ODD/QuickTransferFlow/utils/createQuickTransferFile.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/utils/createQuickTransferFile.ts
@@ -28,7 +28,7 @@ import type {
   CreateCommand,
   CutoutId,
   DeckConfiguration,
-  LabwareDefinition,
+  LabwareDefinition2,
   LabwareV2Mixin,
   LiquidV1Mixin,
   LoadLabwareCreateCommand,
@@ -228,7 +228,7 @@ export function createQuickTransferFile(
 
   const labwareDefinitions = Object.values(
     invariantContext.labwareEntities
-  ).reduce<Record<string, LabwareDefinition>>((acc, entity) => {
+  ).reduce<Record<string, LabwareDefinition2>>((acc, entity) => {
     return { ...acc, [entity.labwareDefURI]: entity.def }
   }, {})
 

--- a/app/src/organisms/ODD/QuickTransferFlow/utils/createQuickTransferFile.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/utils/createQuickTransferFile.ts
@@ -28,7 +28,7 @@ import type {
   CreateCommand,
   CutoutId,
   DeckConfiguration,
-  LabwareDefinition2,
+  LabwareDefinition,
   LabwareV2Mixin,
   LiquidV1Mixin,
   LoadLabwareCreateCommand,
@@ -228,7 +228,7 @@ export function createQuickTransferFile(
 
   const labwareDefinitions = Object.values(
     invariantContext.labwareEntities
-  ).reduce<Record<string, LabwareDefinition2>>((acc, entity) => {
+  ).reduce<Record<string, LabwareDefinition>>((acc, entity) => {
     return { ...acc, [entity.labwareDefURI]: entity.def }
   }, {})
 

--- a/app/src/organisms/ODD/QuickTransferFlow/utils/generateQuickTransferArgs.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/utils/generateQuickTransferArgs.ts
@@ -23,7 +23,7 @@ import {
 import type {
   CutoutConfig,
   DeckConfiguration,
-  LabwareDefinition2,
+  LabwareDefinition,
   NozzleConfigurationStyle,
   PipetteName,
 } from '@opentrons/shared-data'
@@ -51,7 +51,7 @@ const adapter96ChannelDefUri = 'opentrons/opentrons_flex_96_tiprack_adapter/1'
 
 function getOrderedWells(
   unorderedWells: string[],
-  labwareDef: LabwareDefinition2
+  labwareDef: LabwareDefinition
 ): string[] {
   const allWellsOrdered = orderWells(labwareDef.ordering, 't2b', 'l2r')
   return intersection(allWellsOrdered, unorderedWells)

--- a/app/src/organisms/ODD/QuickTransferFlow/utils/getCompatibleLabwareByCategory.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/utils/getCompatibleLabwareByCategory.ts
@@ -9,13 +9,13 @@ import {
   SINGLE_CHANNEL_COMPATIBLE_LABWARE,
 } from '../constants'
 
-import type { LabwareDefinition } from '@opentrons/shared-data'
+import type { LabwareDefinition2 } from '@opentrons/shared-data'
 import type { LabwareFilter } from '/app/local-resources/labware'
 
 export function getCompatibleLabwareByCategory(
   pipetteChannels: 1 | 8 | 96,
   category: LabwareFilter
-): LabwareDefinition[] | undefined {
+): LabwareDefinition2[] | undefined {
   const allLabwareDefinitions = getAllDefinitions(LABWAREV2_DO_NOT_LIST)
   let compatibleLabwareUris: string[] = SINGLE_CHANNEL_COMPATIBLE_LABWARE
   if (pipetteChannels === 8) {
@@ -25,7 +25,7 @@ export function getCompatibleLabwareByCategory(
   }
 
   const compatibleLabwareDefinitions = compatibleLabwareUris.reduce<
-    LabwareDefinition[]
+    LabwareDefinition2[]
   >((acc, defUri) => {
     return [...acc, allLabwareDefinitions[defUri]]
   }, [])

--- a/app/src/organisms/ODD/QuickTransferFlow/utils/getCompatibleLabwareByCategory.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/utils/getCompatibleLabwareByCategory.ts
@@ -9,13 +9,13 @@ import {
   SINGLE_CHANNEL_COMPATIBLE_LABWARE,
 } from '../constants'
 
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 import type { LabwareFilter } from '/app/local-resources/labware'
 
 export function getCompatibleLabwareByCategory(
   pipetteChannels: 1 | 8 | 96,
   category: LabwareFilter
-): LabwareDefinition2[] | undefined {
+): LabwareDefinition[] | undefined {
   const allLabwareDefinitions = getAllDefinitions(LABWAREV2_DO_NOT_LIST)
   let compatibleLabwareUris: string[] = SINGLE_CHANNEL_COMPATIBLE_LABWARE
   if (pipetteChannels === 8) {
@@ -25,7 +25,7 @@ export function getCompatibleLabwareByCategory(
   }
 
   const compatibleLabwareDefinitions = compatibleLabwareUris.reduce<
-    LabwareDefinition2[]
+    LabwareDefinition[]
   >((acc, defUri) => {
     return [...acc, allLabwareDefinitions[defUri]]
   }, [])

--- a/app/src/organisms/ODD/QuickTransferFlow/utils/getInitialSummaryState.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/utils/getInitialSummaryState.ts
@@ -7,7 +7,7 @@ import {
 import type { Mount } from '@opentrons/api-client'
 import type {
   DeckConfiguration,
-  LabwareDefinition,
+  LabwareDefinition2,
   LiquidClass,
   PipetteV2Specs,
 } from '@opentrons/shared-data'
@@ -22,10 +22,10 @@ interface InitialSummaryStateProps {
   state: {
     pipette: PipetteV2Specs
     mount: Mount
-    tipRack: LabwareDefinition
-    source: LabwareDefinition
+    tipRack: LabwareDefinition2
+    source: LabwareDefinition2
     sourceWells: string[]
-    destination: LabwareDefinition | 'source'
+    destination: LabwareDefinition2 | 'source'
     destinationWells: string[]
     transferType: TransferType
     volume: number

--- a/app/src/organisms/ODD/QuickTransferFlow/utils/getInitialSummaryState.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/utils/getInitialSummaryState.ts
@@ -7,7 +7,7 @@ import {
 import type { Mount } from '@opentrons/api-client'
 import type {
   DeckConfiguration,
-  LabwareDefinition2,
+  LabwareDefinition,
   LiquidClass,
   PipetteV2Specs,
 } from '@opentrons/shared-data'
@@ -22,10 +22,10 @@ interface InitialSummaryStateProps {
   state: {
     pipette: PipetteV2Specs
     mount: Mount
-    tipRack: LabwareDefinition2
-    source: LabwareDefinition2
+    tipRack: LabwareDefinition
+    source: LabwareDefinition
     sourceWells: string[]
-    destination: LabwareDefinition2 | 'source'
+    destination: LabwareDefinition | 'source'
     destinationWells: string[]
     transferType: TransferType
     volume: number

--- a/app/src/organisms/ODD/QuickTransferFlow/utils/getSelectedWellCount.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/utils/getSelectedWellCount.ts
@@ -1,8 +1,8 @@
-import type { LabwareDefinition2, PipetteV2Specs } from '@opentrons/shared-data'
+import type { LabwareDefinition, PipetteV2Specs } from '@opentrons/shared-data'
 
 export function getSelectedWellCount(
   pipette: PipetteV2Specs,
-  labware: LabwareDefinition2,
+  labware: LabwareDefinition,
   wells: string[]
 ): number {
   if (pipette.channels === 1) {

--- a/app/src/organisms/ODD/RunningProtocol/CurrentRunningProtocolCommand.tsx
+++ b/app/src/organisms/ODD/RunningProtocol/CurrentRunningProtocolCommand.tsx
@@ -32,7 +32,7 @@ import { StopButton } from './StopButton'
 import type { RunCommandSummary, RunStatus } from '@opentrons/api-client'
 import type {
   CompletedProtocolAnalysis,
-  LabwareDefinition2,
+  LabwareDefinition,
   RobotType,
   RunTimeCommand,
 } from '@opentrons/shared-data'
@@ -124,7 +124,7 @@ interface CurrentRunningProtocolCommandProps {
   lastAnimatedCommand: string | null
   lastRunCommand: RunCommandSummary | null
   updateLastAnimatedCommand: (newCommandKey: string) => void
-  allRunDefs: LabwareDefinition2[]
+  allRunDefs: LabwareDefinition[]
   protocolName?: string
   currentRunCommandIndex?: number
 }

--- a/app/src/organisms/ODD/RunningProtocol/RunningProtocolCommandList.tsx
+++ b/app/src/organisms/ODD/RunningProtocol/RunningProtocolCommandList.tsx
@@ -34,7 +34,7 @@ import type { ViewportListRef } from 'react-viewport-list'
 import type { RunStatus } from '@opentrons/api-client'
 import type {
   CompletedProtocolAnalysis,
-  LabwareDefinition2,
+  LabwareDefinition,
   RobotType,
 } from '@opentrons/shared-data'
 import type { TrackProtocolRunEvent } from '/app/redux-resources/analytics'
@@ -79,7 +79,7 @@ interface RunningProtocolCommandListProps {
   robotAnalyticsData: RobotAnalyticsData | null
   protocolName?: string
   currentRunCommandIndex?: number
-  allRunDefs: LabwareDefinition2[]
+  allRunDefs: LabwareDefinition[]
 }
 
 export function RunningProtocolCommandList({

--- a/app/src/organisms/ProtocolDeck/LabwareInfo.tsx
+++ b/app/src/organisms/ProtocolDeck/LabwareInfo.tsx
@@ -17,7 +17,7 @@ import {
 } from '@opentrons/components'
 
 import type { ReactNode } from 'react'
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 
 const labwareDisplayNameStyle = css`
   ${TYPOGRAPHY.labelSemiBold}
@@ -29,7 +29,7 @@ const labwareDisplayNameStyle = css`
   -webkit-box-orient: vertical;
 `
 export function LabwareInfo(props: {
-  def: LabwareDefinition2
+  def: LabwareDefinition
   children: ReactNode
 }): JSX.Element {
   const width = props.def.dimensions.xDimension

--- a/app/src/organisms/ProtocolDeck/LabwareInfo.tsx
+++ b/app/src/organisms/ProtocolDeck/LabwareInfo.tsx
@@ -15,6 +15,7 @@ import {
   Text,
   TYPOGRAPHY,
 } from '@opentrons/components'
+import { getSchema2Dimensions } from '@opentrons/shared-data'
 
 import type { ReactNode } from 'react'
 import type { LabwareDefinition } from '@opentrons/shared-data'
@@ -32,8 +33,9 @@ export function LabwareInfo(props: {
   def: LabwareDefinition
   children: ReactNode
 }): JSX.Element {
-  const width = props.def.dimensions.xDimension
-  const height = props.def.dimensions.yDimension
+  const { xDimension: width, yDimension: height } = getSchema2Dimensions(
+    props.def
+  )
   return (
     <RobotCoordsForeignDiv
       x={0}

--- a/app/src/organisms/TerseOffsetTable/index.tsx
+++ b/app/src/organisms/TerseOffsetTable/index.tsx
@@ -22,11 +22,11 @@ import {
 } from '@opentrons/shared-data'
 
 import type { LegacyLabwareOffsetCreateData } from '@opentrons/api-client'
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 
 export interface TerseOffsetTableProps {
   offsets: LegacyLabwareOffsetCreateData[]
-  labwareDefinitions: LabwareDefinition2[]
+  labwareDefinitions: LabwareDefinition[]
 }
 
 // Very similar to the OffsetTable, but abbreviates certain things to be optimized

--- a/app/src/organisms/WellSelection/Selection384Wells.tsx
+++ b/app/src/organisms/WellSelection/Selection384Wells.tsx
@@ -17,15 +17,12 @@ import { IconButton } from '/app/atoms/buttons/IconButton'
 
 import type { Dispatch, ReactNode, SetStateAction } from 'react'
 import type { WellGroup } from '@opentrons/components'
-import type {
-  LabwareDefinition2,
-  PipetteChannels,
-} from '@opentrons/shared-data'
+import type { LabwareDefinition, PipetteChannels } from '@opentrons/shared-data'
 
 interface Selection384WellsProps {
   allSelectedWells: WellGroup
   channels: PipetteChannels
-  definition: LabwareDefinition2
+  definition: LabwareDefinition
   deselectWells: (wells: string[]) => void
   labwareRender: ReactNode
   selectWells: (wellGroup: WellGroup) => unknown

--- a/app/src/organisms/WellSelection/index.tsx
+++ b/app/src/organisms/WellSelection/index.tsx
@@ -14,14 +14,14 @@ import {
 
 import type { WellFill, WellGroup, WellStroke } from '@opentrons/components'
 import type {
-  LabwareDefinition2,
+  LabwareDefinition,
   NozzleLayoutDetails,
   PipetteChannels,
 } from '@opentrons/shared-data'
 import type { GenericRect } from './types'
 
 interface WellSelectionProps {
-  definition: LabwareDefinition2
+  definition: LabwareDefinition
   deselectWells: (wells: string[]) => void
   /* The actual wells that are clicked. */
   selectedPrimaryWells: WellGroup

--- a/app/src/pages/ODD/ProtocolDetails/__tests__/Labware.test.tsx
+++ b/app/src/pages/ODD/ProtocolDetails/__tests__/Labware.test.tsx
@@ -15,7 +15,7 @@ import { useRequiredProtocolLabware } from '/app/resources/protocols'
 import { Labware } from '../Labware'
 
 import type { ComponentProps } from 'react'
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 
 vi.mock('/app/resources/protocols')
 
@@ -37,20 +37,20 @@ describe('Labware', () => {
       .calledWith(MOCK_PROTOCOL_ID)
       .thenReturn([
         {
-          labwareDef: fixtureTiprack10ul as LabwareDefinition2,
+          labwareDef: fixtureTiprack10ul as LabwareDefinition,
           lidDisplayName: 'tiprack lid',
           quantity: 1,
         },
         {
-          labwareDef: fixtureTiprack300ul as LabwareDefinition2,
+          labwareDef: fixtureTiprack300ul as LabwareDefinition,
           quantity: 2,
         },
         {
-          labwareDef: fixture96Plate as LabwareDefinition2,
+          labwareDef: fixture96Plate as LabwareDefinition,
           quantity: 1,
         },
         {
-          labwareDef: fixtureTiprack10ul as LabwareDefinition2,
+          labwareDef: fixtureTiprack10ul as LabwareDefinition,
           quantity: 1,
         },
       ])

--- a/app/src/pages/ODD/QuickTransferDetails/__tests__/Labware.test.tsx
+++ b/app/src/pages/ODD/QuickTransferDetails/__tests__/Labware.test.tsx
@@ -15,7 +15,7 @@ import { useRequiredProtocolLabware } from '/app/resources/protocols'
 import { Labware } from '../Labware'
 
 import type { ComponentProps } from 'react'
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 
 vi.mock('/app/resources/protocols')
 
@@ -37,19 +37,19 @@ describe('Labware', () => {
       .calledWith(MOCK_PROTOCOL_ID)
       .thenReturn([
         {
-          labwareDef: fixtureTiprack10ul as LabwareDefinition2,
+          labwareDef: fixtureTiprack10ul as LabwareDefinition,
           quantity: 2,
         },
         {
-          labwareDef: fixtureTiprack300ul as LabwareDefinition2,
+          labwareDef: fixtureTiprack300ul as LabwareDefinition,
           quantity: 1,
         },
         {
-          labwareDef: fixture96Plate as LabwareDefinition2,
+          labwareDef: fixture96Plate as LabwareDefinition,
           quantity: 1,
         },
         {
-          labwareDef: fixtureTiprack10ul as LabwareDefinition2,
+          labwareDef: fixtureTiprack10ul as LabwareDefinition,
           quantity: 1,
         },
       ])

--- a/app/src/redux/custom-labware/__fixtures__/index.ts
+++ b/app/src/redux/custom-labware/__fixtures__/index.ts
@@ -1,8 +1,8 @@
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 import type { LabwareWellGroupProperties } from '/app/local-resources/labware'
 import type * as Types from '../types'
 
-export const mockDefinition: LabwareDefinition2 = {
+export const mockDefinition: LabwareDefinition = {
   version: 1,
   schemaVersion: 2,
   namespace: 'custom',
@@ -75,7 +75,7 @@ export const mockDuplicateLabware: Types.DuplicateLabwareFile = {
   },
 }
 
-export const mockTipRackDefinition: LabwareDefinition2 = {
+export const mockTipRackDefinition: LabwareDefinition = {
   version: 1,
   schemaVersion: 2,
   namespace: 'custom',
@@ -124,7 +124,7 @@ export const mockRectangularLabwareWellGroupProperties: LabwareWellGroupProperti
   brand: { brand: 'Opentrons' },
 }
 
-export const mockOpentronsLabwareDetailsDefinition: LabwareDefinition2 = {
+export const mockOpentronsLabwareDetailsDefinition: LabwareDefinition = {
   version: 1,
   schemaVersion: 2,
   namespace: 'opentrons',

--- a/app/src/redux/custom-labware/selectors.ts
+++ b/app/src/redux/custom-labware/selectors.ts
@@ -6,7 +6,7 @@ import { getIsTiprack } from '@opentrons/shared-data'
 
 import { getConfig } from '../config'
 
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 import type { State } from '../types'
 import type {
   CheckedLabwareFile,
@@ -88,13 +88,13 @@ export const getListLabwareErrorMessage = (state: State): null | string =>
 
 export const getCustomLabwareDefinitions: (
   state: State
-) => LabwareDefinition2[] = createSelector(getValidCustomLabware, labware =>
+) => LabwareDefinition[] = createSelector(getValidCustomLabware, labware =>
   labware.map(lw => lw.definition)
 )
 
 export const getCustomTipRackDefinitions: (
   state: State
-) => LabwareDefinition2[] = createSelector(
+) => LabwareDefinition[] = createSelector(
   getCustomLabwareDefinitions,
   labware => labware.filter(lw => getIsTiprack(lw))
 )

--- a/app/src/redux/custom-labware/types.ts
+++ b/app/src/redux/custom-labware/types.ts
@@ -1,4 +1,4 @@
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 
 // common types
 
@@ -8,7 +8,7 @@ interface LabwareFileProps {
 }
 
 interface ValidatedLabwareProps extends LabwareFileProps {
-  definition: LabwareDefinition2
+  definition: LabwareDefinition
 }
 
 export interface UncheckedLabwareFile extends LabwareFileProps {

--- a/app/src/redux/pipettes/types.ts
+++ b/app/src/redux/pipettes/types.ts
@@ -1,6 +1,6 @@
 import type { PipetteData } from '@opentrons/api-client'
 import type {
-  LabwareDefinition2,
+  LabwareDefinition,
   PipetteChannels,
   PipetteModel,
   PipetteModelSpecs,
@@ -252,7 +252,7 @@ export type ProtocolPipettesMatchByMount = {
 export interface TipRackCalibrationData {
   displayName: string
   lastModifiedDate: string | null
-  tipRackDef: LabwareDefinition2
+  tipRackDef: LabwareDefinition
 }
 
 export interface ProtocolPipetteTipRackCalData {

--- a/app/src/redux/protocol-runs/selectors/lpc/labware/info.ts
+++ b/app/src/redux/protocol-runs/selectors/lpc/labware/info.ts
@@ -16,7 +16,7 @@ import {
 } from '../transforms'
 
 import type { Selector } from 'reselect'
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 import type {
   ConflictTimestampInfo,
   LPCFlowType,
@@ -160,7 +160,7 @@ export const selectIsSelectedLwTipRack = (
 // Returns the labware definition for the user-selected labware, if any.
 export const selectSelectedLwDef = (
   runId: string
-): Selector<State, LabwareDefinition2 | null> =>
+): Selector<State, LabwareDefinition | null> =>
   createSelector(
     (state: State) =>
       state.protocolRuns[runId]?.lpc?.labwareInfo.selectedLabware,
@@ -186,7 +186,7 @@ export const selectSelectedLwDef = (
 
 export const selectSelectedLwAdapterDef = (
   runId: string
-): Selector<State, LabwareDefinition2 | null> =>
+): Selector<State, LabwareDefinition | null> =>
   createSelector(
     (state: State) =>
       state.protocolRuns[runId]?.lpc?.labwareInfo.selectedLabware,

--- a/app/src/redux/protocol-runs/selectors/lpc/transforms.ts
+++ b/app/src/redux/protocol-runs/selectors/lpc/transforms.ts
@@ -15,7 +15,7 @@ import {
 import type { TFunction } from 'i18next'
 import type {
   CompletedProtocolAnalysis,
-  LabwareDefinition2,
+  LabwareDefinition,
 } from '@opentrons/shared-data'
 import type {
   DefaultOffsetDetails,
@@ -58,14 +58,14 @@ export const getFlexSlotNameOnly = (
 export interface GetLabwareDefsForLPCParams {
   labwareId: string
   loadedLabware: CompletedProtocolAnalysis['labware']
-  labwareDefs: LabwareDefinition2[]
+  labwareDefs: LabwareDefinition[]
 }
 
 export const getItemLabwareDef = ({
   labwareId,
   loadedLabware,
   labwareDefs,
-}: GetLabwareDefsForLPCParams): LabwareDefinition2 | null => {
+}: GetLabwareDefsForLPCParams): LabwareDefinition | null => {
   const labwareDefUri =
     loadedLabware.find(l => l.id === labwareId)?.definitionUri ?? null
 
@@ -105,7 +105,7 @@ export const getSelectedLabwareWithOffsetDetails = (
 export const getSelectedLabwareDefFrom = (
   runId: string,
   state: State
-): LabwareDefinition2 | null => {
+): LabwareDefinition | null => {
   const selectedLabware =
     state.protocolRuns[runId]?.lpc?.labwareInfo.selectedLabware
   const labwareDefs = state?.protocolRuns[runId]?.lpc?.labwareDefs

--- a/app/src/redux/protocol-runs/types/lpc/store.ts
+++ b/app/src/redux/protocol-runs/types/lpc/store.ts
@@ -1,7 +1,7 @@
 import type {
   CompletedProtocolAnalysis,
   DeckConfiguration,
-  LabwareDefinition2,
+  LabwareDefinition,
 } from '@opentrons/shared-data'
 import type {
   HANDLE_LW_SUBSTEP,
@@ -15,7 +15,7 @@ export interface LPCWizardState {
   activePipetteId: string
   labwareInfo: LPCLabwareInfo
   protocolData: CompletedProtocolAnalysis
-  labwareDefs: LabwareDefinition2[]
+  labwareDefs: LabwareDefinition[]
   deckConfig: DeckConfiguration
   protocolName: string
   maintenanceRunId: string | null

--- a/app/src/redux/sessions/calibration-check/types.ts
+++ b/app/src/redux/sessions/calibration-check/types.ts
@@ -1,4 +1,4 @@
-import type { LabwareDefinition2, PipetteModel } from '@opentrons/shared-data'
+import type { LabwareDefinition, PipetteModel } from '@opentrons/shared-data'
 import type { Mount } from '../../pipettes/types'
 import type { CalibrationLabware } from '../types'
 // calibration check session types
@@ -60,7 +60,7 @@ export interface CalibrationCheckInstrument {
   tipRackDisplay: string
   tipRackUri: string
   serial: string
-  defaultTipracks: LabwareDefinition2[]
+  defaultTipracks: LabwareDefinition[]
 }
 
 export interface CalibrationCheckComparison {

--- a/app/src/redux/sessions/deck-calibration/types.ts
+++ b/app/src/redux/sessions/deck-calibration/types.ts
@@ -1,6 +1,6 @@
 // deck calibration types
 
-import type { LabwareDefinition2, PipetteModel } from '@opentrons/shared-data'
+import type { LabwareDefinition, PipetteModel } from '@opentrons/shared-data'
 import type {
   DECK_STEP_CALIBRATION_COMPLETE,
   DECK_STEP_INSPECTING_TIP,
@@ -31,7 +31,7 @@ export interface DeckCalibrationInstrument {
   tipLength: number
   mount: string
   serial: string
-  defaultTipracks: LabwareDefinition2[]
+  defaultTipracks: LabwareDefinition[]
 }
 
 export interface DeckCalibrationSessionDetails {

--- a/app/src/redux/sessions/pipette-offset-calibration/types.ts
+++ b/app/src/redux/sessions/pipette-offset-calibration/types.ts
@@ -1,5 +1,5 @@
 // pipette offset calibration types
-import type { LabwareDefinition2, PipetteModel } from '@opentrons/shared-data'
+import type { LabwareDefinition, PipetteModel } from '@opentrons/shared-data'
 import type {
   PIP_OFFSET_STEP_CALIBRATION_COMPLETE,
   PIP_OFFSET_STEP_INSPECTING_TIP,
@@ -30,7 +30,7 @@ export interface PipetteOffsetCalibrationInstrument {
   tipLength: number
   mount: string
   serial: string
-  defaultTipracks: LabwareDefinition2[]
+  defaultTipracks: LabwareDefinition[]
 }
 
 export interface PipetteOffsetCalibrationSessionParams {
@@ -38,7 +38,7 @@ export interface PipetteOffsetCalibrationSessionParams {
   // this will be false for pipette offset cal
   shouldRecalibrateTipLength: boolean
   hasCalibrationBlock: boolean
-  tipRackDefinition: LabwareDefinition2 | null
+  tipRackDefinition: LabwareDefinition | null
 }
 
 export interface PipetteOffsetCalibrationSessionDetails {

--- a/app/src/redux/sessions/tip-length-calibration/types.ts
+++ b/app/src/redux/sessions/tip-length-calibration/types.ts
@@ -1,5 +1,5 @@
 // tip length calibration types
-import type { LabwareDefinition2, PipetteModel } from '@opentrons/shared-data'
+import type { LabwareDefinition, PipetteModel } from '@opentrons/shared-data'
 import type {
   TIP_LENGTH_STEP_CALIBRATION_COMPLETE,
   TIP_LENGTH_STEP_INSPECTING_TIP,
@@ -26,13 +26,13 @@ export interface TipLengthCalibrationInstrument {
   tipLength: number
   mount: string
   serial: string
-  defaultTipracks: LabwareDefinition2[]
+  defaultTipracks: LabwareDefinition[]
 }
 
 export interface TipLengthCalibrationSessionParams {
   mount: string
   hasCalibrationBlock: boolean
-  tipRackDefinition: LabwareDefinition2
+  tipRackDefinition: LabwareDefinition
 }
 
 export interface TipLengthCalibrationSessionDetails {

--- a/app/src/redux/sessions/types.ts
+++ b/app/src/redux/sessions/types.ts
@@ -1,4 +1,4 @@
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 import type {
   RobotApiRequestMeta,
   RobotApiV2ErrorResponseBody,
@@ -75,7 +75,7 @@ export type VectorTuple = [number, number, number]
 export type SessionCommandData =
   | { vector: VectorTuple }
   | { hasBlock: boolean }
-  | { tiprackDefinition: LabwareDefinition2 }
+  | { tiprackDefinition: LabwareDefinition }
   | {}
 
 export interface SessionCommandParams {
@@ -326,5 +326,5 @@ export interface CalibrationLabware {
   namespace: string
   version: number
   isTiprack: boolean
-  definition: LabwareDefinition2
+  definition: LabwareDefinition
 }

--- a/app/src/resources/protocols/hooks/__fixtures__/index.ts
+++ b/app/src/resources/protocols/hooks/__fixtures__/index.ts
@@ -1,6 +1,6 @@
 import { fixtureTiprack300ul } from '@opentrons/shared-data'
 
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 
 export const PROTOCOL_ID = 'fake_protocol_id'
 export const MOCK_RTP_DATA = [
@@ -82,7 +82,7 @@ export const MOCK_RTP_DATA = [
     default: 'none',
   },
 ]
-export const mockLabwareDef = fixtureTiprack300ul as LabwareDefinition2
+export const mockLabwareDef = fixtureTiprack300ul as LabwareDefinition
 export const PROTOCOL_ANALYSIS = {
   id: 'fake analysis',
   status: 'completed',

--- a/app/src/resources/protocols/hooks/__tests__/useRequiredProtocolLabware.test.ts
+++ b/app/src/resources/protocols/hooks/__tests__/useRequiredProtocolLabware.test.ts
@@ -55,10 +55,6 @@ describe('useRequiredProtocolLabware', () => {
     expect(result.current[0].labwareDef.metadata.displayName).toEqual(
       '300ul Tiprack FIXTURE'
     )
-    expect(result.current[0].labwareDef.dimensions.xDimension).toBe(127.76)
-    expect(result.current[0].labwareDef.metadata.displayName).toEqual(
-      '300ul Tiprack FIXTURE'
-    )
   })
 
   it('should return empty array when there is no match with protocol id', () => {

--- a/app/src/resources/runs/__tests__/useRunLoadedLabwareDefintionsByUri.test.ts
+++ b/app/src/resources/runs/__tests__/useRunLoadedLabwareDefintionsByUri.test.ts
@@ -6,11 +6,11 @@ import { fixture96Plate } from '@opentrons/shared-data'
 
 import { useRunLoadedLabwareDefinitionsByUri } from '/app/resources/runs'
 
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 
 vi.mock('@opentrons/react-api-client')
 
-const mockLabwareDef = fixture96Plate as LabwareDefinition2
+const mockLabwareDef = fixture96Plate as LabwareDefinition
 
 describe('useRunLoadedLabwareDefinitionsByUri', () => {
   beforeEach(() => {

--- a/app/src/resources/runs/__tests__/useRunPipetteInfoByMount.test.tsx
+++ b/app/src/resources/runs/__tests__/useRunPipetteInfoByMount.test.tsx
@@ -68,7 +68,7 @@ const TIP_LENGTH_CALIBRATIONS = [
   mockTipLengthCalibration2,
 ]
 
-const tiprack10ul = _tiprack10ul as SharedData.LabwareDefinition2
+const tiprack10ul = _tiprack10ul as SharedData.LabwareDefinition
 const modifiedSimpleV6Protocol = ({
   ..._uncastedModifiedSimpleV6Protocol,
   labware: [

--- a/app/src/resources/runs/useRunLoadedLabwareDefinitionsByUri.ts
+++ b/app/src/resources/runs/useRunLoadedLabwareDefinitionsByUri.ts
@@ -29,12 +29,9 @@ export function useRunLoadedLabwareDefinitionsByUri(
     if (data == null) {
       return null
     } else {
-      // @ts-expect-error TODO(jh, 10-12-24): Update the app's typing to support LabwareDefinition3.
-      data?.data.forEach((def: LabwareDefinition) => {
-        if ('schemaVersion' in def) {
-          const lwUri = getLabwareDefURI(def)
-          result[lwUri] = def
-        }
+      data.data.forEach((def: LabwareDefinition) => {
+        const lwUri = getLabwareDefURI(def)
+        result[lwUri] = def
       })
 
       return result

--- a/app/src/resources/runs/useRunLoadedLabwareDefinitionsByUri.ts
+++ b/app/src/resources/runs/useRunLoadedLabwareDefinitionsByUri.ts
@@ -9,12 +9,9 @@ import type {
   HostConfig,
   RunLoadedLabwareDefinitions,
 } from '@opentrons/api-client'
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 
-export type RunLoadedLabwareDefinitionsByUri = Record<
-  string,
-  LabwareDefinition2
->
+export type RunLoadedLabwareDefinitionsByUri = Record<string, LabwareDefinition>
 
 // Returns a record of labware definitions keyed by URI for the labware that
 // has been loaded with a "loadLabware" command. Errors if the run is not the current run.
@@ -27,13 +24,13 @@ export function useRunLoadedLabwareDefinitionsByUri(
   const { data } = useRunLoadedLabwareDefinitions(runId, options, hostOverride)
 
   return useMemo(() => {
-    const result: Record<string, LabwareDefinition2> = {}
+    const result: Record<string, LabwareDefinition> = {}
 
     if (data == null) {
       return null
     } else {
       // @ts-expect-error TODO(jh, 10-12-24): Update the app's typing to support LabwareDefinition3.
-      data?.data.forEach((def: LabwareDefinition2) => {
+      data?.data.forEach((def: LabwareDefinition) => {
         if ('schemaVersion' in def) {
           const lwUri = getLabwareDefURI(def)
           result[lwUri] = def

--- a/app/src/resources/runs/useRunPipetteInfoByMount.ts
+++ b/app/src/resources/runs/useRunPipetteInfoByMount.ts
@@ -17,7 +17,7 @@ import {
 import { useMostRecentCompletedAnalysis } from './useMostRecentCompletedAnalysis'
 
 import type {
-  LabwareDefinition2,
+  LabwareDefinition,
   LoadPipetteRunTimeCommand,
   PickUpTipRunTimeCommand,
 } from '@opentrons/shared-data'
@@ -68,8 +68,8 @@ export function useRunPipetteInfoByMount(
       const requestedPipetteName = pipetteName
       const pipetteSpecs = getPipetteNameSpecs(requestedPipetteName)
       if (pipetteSpecs != null) {
-        const tipRackDefs: LabwareDefinition2[] = pickUpTipCommands.reduce<
-          LabwareDefinition2[]
+        const tipRackDefs: LabwareDefinition[] = pickUpTipCommands.reduce<
+          LabwareDefinition[]
         >((acc, command) => {
           if (loadCommand.result?.pipetteId === command.params?.pipetteId) {
             const tipRack = labware.find(

--- a/app/src/transformations/analysis/__tests__/getLabwareOffsetLocation.test.tsx
+++ b/app/src/transformations/analysis/__tests__/getLabwareOffsetLocation.test.tsx
@@ -16,7 +16,7 @@ import { getLegacyLabwareOffsetLocation } from '../getLegacyLabwareOffsetLocatio
 
 import type {
   CompletedProtocolAnalysis,
-  LabwareDefinition2,
+  LabwareDefinition,
   LoadedLabware,
   LoadedModule,
 } from '@opentrons/shared-data'
@@ -24,7 +24,7 @@ import type {
 vi.mock('/app/transformations/commands')
 
 const protocolWithTC = (multiple_tipacks_with_tc as unknown) as CompletedProtocolAnalysis
-const mockAdapterDef = opentrons96PcrAdapterV1 as LabwareDefinition2
+const mockAdapterDef = opentrons96PcrAdapterV1 as LabwareDefinition
 const mockAdapterId = 'mockAdapterId'
 const TCModelInProtocol = 'thermocyclerModuleV1'
 const MOCK_SLOT = '2'

--- a/app/src/transformations/analysis/getLabwareInSlots.ts
+++ b/app/src/transformations/analysis/getLabwareInSlots.ts
@@ -2,7 +2,7 @@ import { getInitialLoadedLabwareByAdapter } from '/app/transformations/commands'
 
 import type {
   CompletedProtocolAnalysis,
-  LabwareDefinition2,
+  LabwareDefinition,
   LoadLabwareRunTimeCommand,
   LoadLidRunTimeCommand,
   LoadLidStackRunTimeCommand,
@@ -12,14 +12,14 @@ import type {
 
 interface LabwareInSlot {
   labwareId: string
-  labwareDef: LabwareDefinition2
+  labwareDef: LabwareDefinition
   labwareNickName: string | null
   location: { slotName: string }
 }
 
 interface LabwareWithDef {
   labwareId: string
-  labwareDef: LabwareDefinition2
+  labwareDef: LabwareDefinition
   labwareNickName: string | null
 }
 

--- a/app/src/transformations/analysis/getLabwareRenderInfo.ts
+++ b/app/src/transformations/analysis/getLabwareRenderInfo.ts
@@ -3,7 +3,7 @@ import { getPositionFromSlotId } from '@opentrons/shared-data'
 import type {
   CompletedProtocolAnalysis,
   DeckDefinition,
-  LabwareDefinition2,
+  LabwareDefinition,
   LoadLabwareRunTimeCommand,
   LoadLidRunTimeCommand,
   LoadLidStackRunTimeCommand,
@@ -15,7 +15,7 @@ export interface LabwareRenderInfoById {
     x: number
     y: number
     z: number
-    labwareDef: LabwareDefinition2
+    labwareDef: LabwareDefinition
     displayName: string | null
     slotName: string
   }

--- a/app/src/transformations/analysis/getProtocolModulesInfo.ts
+++ b/app/src/transformations/analysis/getProtocolModulesInfo.ts
@@ -10,7 +10,7 @@ import { getModuleInitialLoadInfo } from '../commands'
 import type {
   CompletedProtocolAnalysis,
   DeckDefinition,
-  LabwareDefinition2,
+  LabwareDefinition,
   LoadLabwareRunTimeCommand,
   ModuleDefinition,
   ProtocolAnalysisOutput,
@@ -22,7 +22,7 @@ export interface ProtocolModuleInfo {
   y: number
   z: number
   moduleDef: ModuleDefinition
-  nestedLabwareDef: LabwareDefinition2 | null
+  nestedLabwareDef: LabwareDefinition | null
   nestedLabwareDisplayName: string | null
   nestedLabwareId: string | null
   protocolLoadOrder: number

--- a/app/src/transformations/commands/hooks/__tests__/useMissingProtocolHardware.test.tsx
+++ b/app/src/transformations/commands/hooks/__tests__/useMissingProtocolHardware.test.tsx
@@ -25,7 +25,7 @@ import type { Protocol } from '@opentrons/api-client'
 import type {
   CompletedProtocolAnalysis,
   DeckConfiguration,
-  LabwareDefinition2,
+  LabwareDefinition,
 } from '@opentrons/shared-data'
 
 vi.mock('@opentrons/react-api-client')
@@ -110,7 +110,7 @@ const mockRTPData = [
     default: 'none',
   },
 ]
-const mockLabwareDef = fixtureTiprack300ul as LabwareDefinition2
+const mockLabwareDef = fixtureTiprack300ul as LabwareDefinition
 const PROTOCOL_ANALYSIS = {
   id: 'fake analysis',
   status: 'completed',

--- a/app/src/transformations/commands/transformations/getLabwareDefinitionsByURIForProtocol.ts
+++ b/app/src/transformations/commands/transformations/getLabwareDefinitionsByURIForProtocol.ts
@@ -2,7 +2,7 @@ import { getLabwareDefURI } from '@opentrons/shared-data'
 
 import type {
   FlexStackerSetStoredLabwareRunTimeCommand,
-  LabwareDefinition2,
+  LabwareDefinition,
   LoadLabwareRunTimeCommand,
   LoadLidRunTimeCommand,
   LoadLidStackRunTimeCommand,
@@ -10,12 +10,12 @@ import type {
 } from '@opentrons/shared-data'
 
 export interface LabwareDefinitionsByURI {
-  [labwareDefURI: string]: LabwareDefinition2
+  [labwareDefURI: string]: LabwareDefinition
 }
 
 const defPair = (
-  maybeDef?: LabwareDefinition2
-): Record<string, LabwareDefinition2> =>
+  maybeDef?: LabwareDefinition
+): Record<string, LabwareDefinition> =>
   maybeDef == null ? {} : { [getLabwareDefURI(maybeDef)]: maybeDef }
 
 export function getLabwareDefinitionsByURIForProtocol(

--- a/app/src/transformations/commands/transformations/getLabwareSetupItemGroups.ts
+++ b/app/src/transformations/commands/transformations/getLabwareSetupItemGroups.ts
@@ -3,7 +3,7 @@ import partition from 'lodash/partition'
 import { getLabwareDisplayName } from '@opentrons/shared-data'
 
 import type {
-  LabwareDefinition2,
+  LabwareDefinition,
   LabwareLocation,
   LoadModuleRunTimeCommand,
   ModuleLocation,
@@ -12,7 +12,7 @@ import type {
 } from '@opentrons/shared-data'
 
 export interface LabwareSetupItem {
-  definition: LabwareDefinition2
+  definition: LabwareDefinition
   nickName: string | null
   initialLocation: LabwareLocation
   moduleModel: ModuleModel | null

--- a/app/src/transformations/commands/transformations/getNestedLabwareInfo.ts
+++ b/app/src/transformations/commands/transformations/getNestedLabwareInfo.ts
@@ -1,5 +1,5 @@
 import type {
-  LabwareDefinition2,
+  LabwareDefinition,
   LoadLabwareRunTimeCommand,
   LoadModuleRunTimeCommand,
   RunTimeCommand,
@@ -10,7 +10,7 @@ export interface NestedLabwareInfo {
   nestedLabwareDisplayName: string
   //    shared location between labware and adapter
   sharedSlotId: string
-  nestedLabwareDefinition?: LabwareDefinition2
+  nestedLabwareDefinition?: LabwareDefinition
   nestedLabwareNickName?: string
 }
 export function getNestedLabwareInfo(

--- a/app/src/transformations/commands/transformations/getRequiredLabwareDetailsFromLoadCommands.ts
+++ b/app/src/transformations/commands/transformations/getRequiredLabwareDetailsFromLoadCommands.ts
@@ -3,7 +3,7 @@ import { getLabwareDefURI } from '@opentrons/shared-data'
 import type {
   FlexStackerFillRunTimeCommand,
   FlexStackerSetStoredLabwareRunTimeCommand,
-  LabwareDefinition2,
+  LabwareDefinition,
   LoadLabwareRunTimeCommand,
   LoadLidRunTimeCommand,
   LoadLidStackRunTimeCommand,
@@ -11,7 +11,7 @@ import type {
 } from '@opentrons/shared-data'
 
 export interface RequiredLabwareDetails {
-  labwareDef: LabwareDefinition2
+  labwareDef: LabwareDefinition
   quantity: number
   lidDisplayName?: string
 }

--- a/app/src/transformations/commands/transformations/getSlotLabwareDefinition.ts
+++ b/app/src/transformations/commands/transformations/getSlotLabwareDefinition.ts
@@ -1,9 +1,9 @@
-import type { LabwareDefinition2, RunTimeCommand } from '@opentrons/shared-data'
+import type { LabwareDefinition, RunTimeCommand } from '@opentrons/shared-data'
 
 export function getSlotLabwareDefinition(
   labwareId: string,
   commands?: RunTimeCommand[]
-): LabwareDefinition2 {
+): LabwareDefinition {
   const loadLabwareCommands = commands?.filter(
     command => command.commandType === 'loadLabware'
   )

--- a/app/src/transformations/commands/transformations/getStackedItemsOnStartingDeck.ts
+++ b/app/src/transformations/commands/transformations/getStackedItemsOnStartingDeck.ts
@@ -19,7 +19,7 @@ import type {
   CutoutId,
   FlexStackerFillRunTimeCommand,
   FlexStackerSetStoredLabwareRunTimeCommand,
-  LabwareDefinition2,
+  LabwareDefinition,
   LoadedLabware,
   LoadedModule,
   LoadLabwareRunTimeCommand,
@@ -139,7 +139,7 @@ export function getStackedItemsOnStartingDeck(
             const offDeckItem = {
               labwareId: labwareId,
               definitionUri: getLabwareDefURI(
-                command.result?.definition as LabwareDefinition2
+                command.result?.definition as LabwareDefinition
               ),
               displayName:
                 command.result?.definition?.metadata.displayName ?? '',
@@ -279,7 +279,7 @@ export function getStackedItemsOnStartingDeck(
             return {
               labwareId: lidId,
               definitionUri: getLabwareDefURI(
-                command.result?.definition as LabwareDefinition2
+                command.result?.definition as LabwareDefinition
               ),
               displayName:
                 command.result?.definition?.metadata.displayName ?? '',

--- a/app/src/transformations/protocols/__tests__/getLabwareDefinitionUri.test.ts
+++ b/app/src/transformations/protocols/__tests__/getLabwareDefinitionUri.test.ts
@@ -4,12 +4,12 @@ import { getLabwareDefURI } from '@opentrons/shared-data'
 
 import { getLabwareDefinitionUri } from '../getLabwareDefinitionUri'
 
-import type { LabwareDefinition2, LoadedLabware } from '@opentrons/shared-data'
+import type { LabwareDefinition, LoadedLabware } from '@opentrons/shared-data'
 
 vi.mock('@opentrons/shared-data')
 
 const MOCK_DEFINITION_URI = 'some_labware_definition_uri'
-const MOCK_DEF: LabwareDefinition2 = {} as any
+const MOCK_DEF: LabwareDefinition = {} as any
 
 describe('getLabwareDefinitionUri', () => {
   beforeEach(() => {

--- a/app/src/transformations/protocols/__tests__/getLabwareDefinitionUri.test.ts
+++ b/app/src/transformations/protocols/__tests__/getLabwareDefinitionUri.test.ts
@@ -4,12 +4,12 @@ import { getLabwareDefURI } from '@opentrons/shared-data'
 
 import { getLabwareDefinitionUri } from '../getLabwareDefinitionUri'
 
-import type { LabwareDefinition, LoadedLabware } from '@opentrons/shared-data'
+import type { LabwareDefinition2, LoadedLabware } from '@opentrons/shared-data'
 
 vi.mock('@opentrons/shared-data')
 
 const MOCK_DEFINITION_URI = 'some_labware_definition_uri'
-const MOCK_DEF: LabwareDefinition = {} as any
+const MOCK_DEF: LabwareDefinition2 = {} as any
 
 describe('getLabwareDefinitionUri', () => {
   beforeEach(() => {

--- a/app/src/transformations/protocols/getLabwareDefinitionUri.ts
+++ b/app/src/transformations/protocols/getLabwareDefinitionUri.ts
@@ -1,12 +1,14 @@
 import { getLabwareDefURI } from '@opentrons/shared-data'
 
-import type { LoadedLabware, ProtocolFile } from '@opentrons/shared-data'
+import type { LabwareDefinition, LoadedLabware } from '@opentrons/shared-data'
 
 // Delete this util once there is a better identifier for labware offsets on the backend
 export function getLabwareDefinitionUri(
   labwareId: string,
   labware: LoadedLabware[],
-  labwareDefinitions: ProtocolFile<{}>['labwareDefinitions']
+  labwareDefinitions: {
+    [definitionUri: string]: LabwareDefinition
+  }
 ): string {
   const labwareDefinitionUri = labware.find(item => item.id === labwareId)
     ?.definitionUri

--- a/components/src/hardware-sim/BaseDeck/BaseDeck.stories.tsx
+++ b/components/src/hardware-sim/BaseDeck/BaseDeck.stories.tsx
@@ -19,7 +19,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import type * as React from 'react'
 import type {
   DeckConfiguration,
-  LabwareDefinition2,
+  LabwareDefinition,
 } from '@opentrons/shared-data'
 
 const meta: Meta<React.ComponentProps<typeof BaseDeckComponent>> = {
@@ -54,34 +54,34 @@ export const BaseDeck: Story = {
     labwareOnDeck: [
       {
         labwareLocation: { slotName: 'C2' },
-        definition: fixture96Plate as LabwareDefinition2,
+        definition: fixture96Plate as LabwareDefinition,
       },
       {
         labwareLocation: { slotName: 'C3' },
-        definition: fixtureTiprack1000ul as LabwareDefinition2,
+        definition: fixtureTiprack1000ul as LabwareDefinition,
       },
     ],
     modulesOnDeck: [
       {
         moduleLocation: { slotName: 'B1' },
         moduleModel: THERMOCYCLER_MODULE_V2,
-        nestedLabwareDef: fixture96Plate as LabwareDefinition2,
+        nestedLabwareDef: fixture96Plate as LabwareDefinition,
         innerProps: { lidMotorState: 'open' },
       },
       {
         moduleLocation: { slotName: 'D1' },
         moduleModel: TEMPERATURE_MODULE_V2,
-        nestedLabwareDef: fixture96Plate as LabwareDefinition2,
+        nestedLabwareDef: fixture96Plate as LabwareDefinition,
       },
       {
         moduleLocation: { slotName: 'B3' },
         moduleModel: HEATERSHAKER_MODULE_V1,
-        nestedLabwareDef: fixture96Plate as LabwareDefinition2,
+        nestedLabwareDef: fixture96Plate as LabwareDefinition,
       },
       {
         moduleLocation: { slotName: 'D2' },
         moduleModel: MAGNETIC_BLOCK_V1,
-        nestedLabwareDef: fixture96Plate as LabwareDefinition2,
+        nestedLabwareDef: fixture96Plate as LabwareDefinition,
       },
     ],
     darkFill: 'rebeccapurple',

--- a/components/src/hardware-sim/BaseDeck/BaseDeck.tsx
+++ b/components/src/hardware-sim/BaseDeck/BaseDeck.tsx
@@ -40,7 +40,7 @@ import type { ComponentProps, ReactNode } from 'react'
 import type {
   CutoutFixtureId,
   DeckConfiguration,
-  LabwareDefinition2,
+  LabwareDefinition,
   LabwareLocation,
   ModuleLocation,
   ModuleModel,
@@ -53,7 +53,7 @@ import type { StagingAreaLocation } from './StagingAreaFixture'
 
 export interface LabwareOnDeck {
   labwareLocation: LabwareLocation
-  definition: LabwareDefinition2
+  definition: LabwareDefinition
   wellFill?: WellFill
   missingTips?: WellGroup
   /** generic prop to render self-positioned children for each labware */
@@ -67,7 +67,7 @@ export interface LabwareOnDeck {
 export interface ModuleOnDeck {
   moduleModel: ModuleModel
   moduleLocation: ModuleLocation
-  nestedLabwareDef?: LabwareDefinition2 | null
+  nestedLabwareDef?: LabwareDefinition | null
   nestedLabwareWellFill?: WellFill
   innerProps?: ComponentProps<typeof Module>['innerProps']
   /** generic prop to render self-positioned children for each module */
@@ -79,7 +79,7 @@ export interface ModuleOnDeck {
   hopperLabware?: HopperLabwareProps
 }
 export interface HopperLabwareProps {
-  hopperLabwareDef: LabwareDefinition2 | null
+  hopperLabwareDef: LabwareDefinition | null
   hopperLabwareWellFill: WellFill
   hopperOnLabwareClick: () => void
   hopperHighlightLabware: boolean

--- a/components/src/hardware-sim/Deck/FlexTrash.tsx
+++ b/components/src/hardware-sim/Deck/FlexTrash.tsx
@@ -1,6 +1,8 @@
 import {
   FLEX_ROBOT_TYPE,
   getDeckDefFromRobotType,
+  getSchema2CornerOffsetFromSlot,
+  getSchema2Dimensions,
   opentrons1Trash3200MlFixedV1 as trashLabwareDef,
 } from '@opentrons/shared-data'
 
@@ -70,11 +72,10 @@ export const FlexTrash = ({
   } = deckDefinition.locations.addressableAreas[0].boundingBox
 
   // adjust for dimensions from trash definition
-  const {
-    x: xAdjustment,
-    y: yAdjustment,
-  } = trashLabwareDef.cornerOffsetFromSlot
-  const { xDimension, yDimension } = trashLabwareDef.dimensions
+  const { x: xAdjustment, y: yAdjustment } = getSchema2CornerOffsetFromSlot(
+    trashLabwareDef
+  )
+  const { xDimension, yDimension } = getSchema2Dimensions(trashLabwareDef)
 
   // rotate trash 180 degrees in column 1
   const rotateDegrees =

--- a/components/src/hardware-sim/Deck/MoveLabwareOnDeck.stories.tsx
+++ b/components/src/hardware-sim/Deck/MoveLabwareOnDeck.stories.tsx
@@ -13,7 +13,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import type * as React from 'react'
 import type {
   DeckConfiguration,
-  LabwareDefinition2,
+  LabwareDefinition,
 } from '@opentrons/shared-data'
 
 const meta: Meta<React.ComponentProps<typeof MoveLabwareOnDeckComponent>> = {
@@ -78,7 +78,7 @@ const FLEX_SIMPLEST_DECK_CONFIG: DeckConfiguration = [
 export const MoveLabwareOnDeck: Story = {
   render: args => (
     <MoveLabwareOnDeckComponent
-      movedLabwareDef={fixture96Plate as LabwareDefinition2}
+      movedLabwareDef={fixture96Plate as LabwareDefinition}
       initialLabwareLocation={args.initialLabwareLocation}
       finalLabwareLocation={args.finalLabwareLocation}
       loadedModules={[]}

--- a/components/src/hardware-sim/Deck/MoveLabwareOnDeck.tsx
+++ b/components/src/hardware-sim/Deck/MoveLabwareOnDeck.tsx
@@ -6,6 +6,8 @@ import {
   getDeckDefFromRobotType,
   getModuleDef2,
   getPositionFromSlotId,
+  getSchema2CornerOffsetFromSlot,
+  getSchema2Dimensions,
 } from '@opentrons/shared-data'
 
 import { COLORS } from '../../helix-design-system'
@@ -171,11 +173,13 @@ export function MoveLabwareOnDeck(
     0,
   ]
 
+  const cornerOffsetFromSlot = getSchema2CornerOffsetFromSlot(movedLabwareDef)
+
   const offDeckPosition = {
     x: slotPosition[0],
     y:
       deckDef.cornerOffsetFromOrigin[1] -
-      movedLabwareDef.dimensions.xDimension -
+      getSchema2Dimensions(movedLabwareDef).xDimension -
       SPLASH_Y_BUFFER_MM,
   }
   const initialPosition =
@@ -232,7 +236,7 @@ export function MoveLabwareOnDeck(
       {backgroundItems}
       <AnimatedG style={{ x: springProps.x, y: springProps.y }}>
         <g
-          transform={`translate(${movedLabwareDef.cornerOffsetFromSlot.x}, ${movedLabwareDef.cornerOffsetFromSlot.y})`}
+          transform={`translate(${cornerOffsetFromSlot.x}, ${cornerOffsetFromSlot.y})`}
         >
           <LabwareRender definition={movedLabwareDef} highlight={true} />
           <AnimatedG style={{ opacity: springProps.splashOpacity }}>

--- a/components/src/hardware-sim/Deck/MoveLabwareOnDeck.tsx
+++ b/components/src/hardware-sim/Deck/MoveLabwareOnDeck.tsx
@@ -17,7 +17,7 @@ import type { ReactNode } from 'react'
 import type {
   DeckConfiguration,
   DeckDefinition,
-  LabwareDefinition2,
+  LabwareDefinition,
   LabwareLocation,
   LoadedLabware,
   LoadedModule,
@@ -133,7 +133,7 @@ const SPLASH_Y_BUFFER_MM = 10
 
 interface MoveLabwareOnDeckProps extends StyleProps {
   robotType: RobotType
-  movedLabwareDef: LabwareDefinition2
+  movedLabwareDef: LabwareDefinition
   initialLabwareLocation: LabwareLocation
   finalLabwareLocation: LabwareLocation
   loadedModules: LoadedModule[]

--- a/components/src/hardware-sim/Labware/Labware.tsx
+++ b/components/src/hardware-sim/Labware/Labware.tsx
@@ -2,6 +2,11 @@ import { Fragment, memo } from 'react'
 import map from 'lodash/map'
 import styled from 'styled-components'
 
+import {
+  getSchema2CornerOffsetFromSlot,
+  getSchema2Dimensions,
+} from '@opentrons/shared-data'
+
 import { COLORS } from '../../helix-design-system'
 import { LabwareAdapter, labwareAdapterLoadNames } from './LabwareAdapter'
 import {
@@ -98,12 +103,12 @@ export const Labware = (props: LabwareProps): JSX.Element => {
     wellStroke = {},
   } = props
 
-  const cornerOffsetFromSlot = definition.cornerOffsetFromSlot
+  const cornerOffsetFromSlot = getSchema2CornerOffsetFromSlot(definition)
   const labwareLoadName = definition.parameters.loadName
 
   if (labwareAdapterLoadNames.includes(labwareLoadName)) {
     const { shouldRotateAdapterOrientation = false } = props
-    const { xDimension, yDimension } = definition.dimensions
+    const { xDimension, yDimension } = getSchema2Dimensions(definition)
 
     return (
       <g

--- a/components/src/hardware-sim/Labware/Labware.tsx
+++ b/components/src/hardware-sim/Labware/Labware.tsx
@@ -12,7 +12,7 @@ import {
 } from './labwareInternals'
 
 import type { RefObject } from 'react'
-import type { LabwareDefinition2, LabwareWell } from '@opentrons/shared-data'
+import type { LabwareDefinition, LabwareWell } from '@opentrons/shared-data'
 import type { LabwareAdapterLoadName } from './LabwareAdapter'
 import type {
   HighlightedWellLabels,
@@ -23,7 +23,7 @@ import type {
 
 export interface LabwareProps {
   /** Labware definition to render */
-  definition: LabwareDefinition2
+  definition: LabwareDefinition
   /** Opional Prop for labware on heater shakers sitting on right side of the deck */
   shouldRotateAdapterOrientation?: boolean
   /** boolean to show well labels */

--- a/components/src/hardware-sim/Labware/LabwareAdapter/index.tsx
+++ b/components/src/hardware-sim/Labware/LabwareAdapter/index.tsx
@@ -8,7 +8,7 @@ import { OpentronsFlex96TiprackAdapter } from './OpentronsFlex96TiprackAdapter'
 import { OpentronsToughPCRAutoSealingLid } from './OpentronsToughPCRAutoSealingLid'
 import { OpentronsUniversalFlatAdapter } from './OpentronsUniversalFlatAdapter'
 
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 
 const LABWARE_ADAPTER_LOADNAME_PATHS = {
   opentrons_96_deep_well_adapter: Opentrons96DeepWellAdapter,
@@ -27,7 +27,7 @@ export const labwareAdapterLoadNames = Object.keys(
 
 export interface LabwareAdapterProps {
   labwareLoadName: LabwareAdapterLoadName
-  definition?: LabwareDefinition2
+  definition?: LabwareDefinition
   highlight?: boolean
   highlightShadow?: boolean
 }

--- a/components/src/hardware-sim/Labware/LabwareRender.stories.tsx
+++ b/components/src/hardware-sim/Labware/LabwareRender.stories.tsx
@@ -12,23 +12,23 @@ import { LabwareRender } from './LabwareRender'
 
 import type { Meta, Story } from '@storybook/react'
 import type * as React from 'react'
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 
-const fixture96Plate = _fixture96Plate as LabwareDefinition2
-const fixture24Tuberack = _fixture24Tuberack as LabwareDefinition2
-const fixture12Trough = _fixture12Trough as LabwareDefinition2
+const fixture96Plate = _fixture96Plate as LabwareDefinition
+const fixture24Tuberack = _fixture24Tuberack as LabwareDefinition
+const fixture12Trough = _fixture12Trough as LabwareDefinition
 
-const fixtureTiprack10 = _fixtureTiprack10ul as LabwareDefinition2
-const fixtureTiprack300 = _fixtureTiprack300ul as LabwareDefinition2
-const fixtureTiprack1000 = _fixtureTiprack1000ul as LabwareDefinition2
+const fixtureTiprack10 = _fixtureTiprack10ul as LabwareDefinition
+const fixtureTiprack300 = _fixtureTiprack300ul as LabwareDefinition
+const fixtureTiprack1000 = _fixtureTiprack1000ul as LabwareDefinition
 
-const labwareDefMap: Record<string, LabwareDefinition2> = {
+const labwareDefMap: Record<string, LabwareDefinition> = {
   [fixture96Plate.metadata.displayName]: fixture96Plate,
   [fixture24Tuberack.metadata.displayName]: fixture24Tuberack,
   [fixture12Trough.metadata.displayName]: fixture12Trough,
 }
 
-const tipRackDefMap: Record<string, LabwareDefinition2> = {
+const tipRackDefMap: Record<string, LabwareDefinition> = {
   [fixtureTiprack10.metadata.displayName]: fixtureTiprack10,
   [fixtureTiprack300.metadata.displayName]: fixtureTiprack300,
   [fixtureTiprack1000.metadata.displayName]: fixtureTiprack1000,

--- a/components/src/hardware-sim/Labware/LabwareRender.tsx
+++ b/components/src/hardware-sim/Labware/LabwareRender.tsx
@@ -1,3 +1,8 @@
+import {
+  getSchema2CornerOffsetFromSlot,
+  getSchema2Dimensions,
+} from '@opentrons/shared-data'
+
 import { LabwareAdapter, labwareAdapterLoadNames } from './LabwareAdapter'
 import {
   FilledWells,
@@ -66,12 +71,12 @@ export interface LabwareRenderProps {
 export const LabwareRender = (props: LabwareRenderProps): JSX.Element => {
   const { gRef, definition } = props
 
-  const cornerOffsetFromSlot = definition.cornerOffsetFromSlot
+  const cornerOffsetFromSlot = getSchema2CornerOffsetFromSlot(definition)
   const labwareLoadName = definition.parameters.loadName
 
   if (labwareAdapterLoadNames.includes(labwareLoadName)) {
     const { shouldRotateAdapterOrientation } = props
-    const { xDimension, yDimension } = props.definition.dimensions
+    const { xDimension, yDimension } = getSchema2Dimensions(definition)
 
     return (
       <g

--- a/components/src/hardware-sim/Labware/LabwareRender.tsx
+++ b/components/src/hardware-sim/Labware/LabwareRender.tsx
@@ -9,7 +9,7 @@ import {
 
 import type { CSSProperties } from 'styled-components'
 import type { RefObject } from 'react'
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 import type { LabwareAdapterLoadName } from './LabwareAdapter'
 import type {
   HighlightedWellLabels,
@@ -28,7 +28,7 @@ export type WellLabelOption = keyof typeof WELL_LABEL_OPTIONS
 
 export interface LabwareRenderProps {
   /** Labware definition to render */
-  definition: LabwareDefinition2
+  definition: LabwareDefinition
   /** Opional Prop for labware on heater shakers sitting on right side of the deck */
   shouldRotateAdapterOrientation?: boolean
   /** option to show well labels inside or outside of labware outline */

--- a/components/src/hardware-sim/Labware/__tests__/Labware.test.tsx
+++ b/components/src/hardware-sim/Labware/__tests__/Labware.test.tsx
@@ -11,11 +11,11 @@ import {
   LabwareWellLabelsComponent as LabwareWellLabels,
 } from '../labwareInternals'
 
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 
 vi.mock('../labwareInternals')
 
-const troughFixture12 = fixture12Trough as LabwareDefinition2
+const troughFixture12 = fixture12Trough as LabwareDefinition
 
 describe('Labware', () => {
   beforeEach(() => {

--- a/components/src/hardware-sim/Labware/__tests__/LabwareRender.test.tsx
+++ b/components/src/hardware-sim/Labware/__tests__/LabwareRender.test.tsx
@@ -12,11 +12,11 @@ import {
 } from '../labwareInternals'
 import { LabwareRender, WELL_LABEL_OPTIONS } from '../LabwareRender'
 
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 
 vi.mock('../labwareInternals')
 
-const troughFixture12 = fixture12Trough as LabwareDefinition2
+const troughFixture12 = fixture12Trough as LabwareDefinition
 
 describe('LabwareRender', () => {
   beforeEach(() => {

--- a/components/src/hardware-sim/Labware/labwareInternals/FilledWells.tsx
+++ b/components/src/hardware-sim/Labware/labwareInternals/FilledWells.tsx
@@ -6,10 +6,10 @@ import { Well } from './Well'
 
 import type { CSSProperties } from 'styled-components'
 import type { MemoExoticComponent, ReactNode } from 'react'
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 
 export interface FilledWellsProps {
-  definition: LabwareDefinition2
+  definition: LabwareDefinition
   fillByWell: Record<string, CSSProperties['fill']>
   strokeColor?: string
 }

--- a/components/src/hardware-sim/Labware/labwareInternals/LabwareOutline.tsx
+++ b/components/src/hardware-sim/Labware/labwareInternals/LabwareOutline.tsx
@@ -1,4 +1,8 @@
-import { SLOT_RENDER_HEIGHT, SLOT_RENDER_WIDTH } from '@opentrons/shared-data'
+import {
+  getSchema2Dimensions,
+  SLOT_RENDER_HEIGHT,
+  SLOT_RENDER_WIDTH,
+} from '@opentrons/shared-data'
 
 import { COLORS } from '../../../helix-design-system'
 import { getTiprackBackgroundColor } from './getTiprackBackgroundColor'
@@ -40,10 +44,11 @@ export function LabwareOutline(props: LabwareOutlineProps): JSX.Element {
     fill,
     showRadius = true,
   } = props
-  const {
-    parameters = { isTiprack, loadName: '' },
-    dimensions = { xDimension: width, yDimension: height },
-  } = definition ?? {}
+  const { parameters = { isTiprack, loadName: '' } } = definition ?? {}
+  const dimensions =
+    definition === undefined
+      ? { xDimension: width, yDimension: height }
+      : getSchema2Dimensions(definition)
 
   let backgroundFill
   if (fill != null) {

--- a/components/src/hardware-sim/Labware/labwareInternals/LabwareOutline.tsx
+++ b/components/src/hardware-sim/Labware/labwareInternals/LabwareOutline.tsx
@@ -5,11 +5,11 @@ import { getTiprackBackgroundColor } from './getTiprackBackgroundColor'
 
 import type { CSSProperties } from 'styled-components'
 import type { SVGProps } from 'react'
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 
 export interface LabwareOutlineProps {
   /** Labware definition to outline */
-  definition?: LabwareDefinition2
+  definition?: LabwareDefinition
   /** x dimension in mm of this labware, used if definition doesn't supply dimensions, defaults to 127.76 */
   width?: number
   /** y dimension in mm of this labware, used if definition doesn't supply dimensions, defaults to 85.48 */

--- a/components/src/hardware-sim/Labware/labwareInternals/LabwareWellLabels.tsx
+++ b/components/src/hardware-sim/Labware/labwareInternals/LabwareWellLabels.tsx
@@ -5,7 +5,7 @@ import { TYPOGRAPHY } from '../../../ui-style-constants'
 import { RobotCoordsText } from '../../Deck'
 
 import type { MemoExoticComponent } from 'react'
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 import type { HighlightedWellLabels } from './types'
 
 // magic layout numbers to make the letters close to the edges of the labware
@@ -14,13 +14,13 @@ const LETTER_COLUMN_X_ADJUSTMENT = -4
 const NUMBER_COLUMN_Y_ADJUSTMENT = 2
 
 interface LabwareWellLabelsProps {
-  definition: LabwareDefinition2
+  definition: LabwareDefinition
   highlightedWellLabels?: HighlightedWellLabels
   wellLabelColor?: string
 }
 
 const Labels = (props: {
-  definition: LabwareDefinition2
+  definition: LabwareDefinition
   wells: string[]
   isLetterColumn?: boolean
   highlightedWellLabels?: HighlightedWellLabels

--- a/components/src/hardware-sim/Labware/labwareInternals/StaticLabware.tsx
+++ b/components/src/hardware-sim/Labware/labwareInternals/StaticLabware.tsx
@@ -10,12 +10,12 @@ import { Well } from './Well'
 
 import type { CSSProperties } from 'styled-components'
 import type { MemoExoticComponent } from 'react'
-import type { LabwareDefinition2, LabwareWell } from '@opentrons/shared-data'
+import type { LabwareDefinition, LabwareWell } from '@opentrons/shared-data'
 import type { WellMouseEvent, WellStroke } from './types'
 
 export interface StaticLabwareProps {
   /** Labware definition to render */
-  definition: LabwareDefinition2
+  definition: LabwareDefinition
   /** Add thicker blurred blue border to labware, defaults to false */
   highlight?: boolean
   /** adds a drop shadow to the highlight border */

--- a/components/src/hardware-sim/Labware/labwareInternals/StrokedWells.tsx
+++ b/components/src/hardware-sim/Labware/labwareInternals/StrokedWells.tsx
@@ -6,10 +6,10 @@ import { Well } from './Well'
 
 import type { CSSProperties } from 'styled-components'
 import type { MemoExoticComponent, ReactNode } from 'react'
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 
 export interface StrokedWellProps {
-  definition: LabwareDefinition2
+  definition: LabwareDefinition
   strokeByWell: Record<string, CSSProperties['stroke']>
 }
 

--- a/components/src/hardware-sim/Labware/labwareInternals/StyledWells.tsx
+++ b/components/src/hardware-sim/Labware/labwareInternals/StyledWells.tsx
@@ -4,7 +4,7 @@ import { COLORS } from '../../../helix-design-system'
 import { Well } from './Well'
 
 import type { CSSProperties, MemoExoticComponent } from 'react'
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 import type { WellGroup } from './types'
 
 type WellContents =
@@ -16,7 +16,7 @@ type WellContents =
   | 'selectedWell'
 export interface StyledWellProps {
   wellContents: WellContents
-  definition: LabwareDefinition2
+  definition: LabwareDefinition
   wells: WellGroup
 }
 

--- a/components/src/hardware-sim/Labware/labwareInternals/WellLabels.tsx
+++ b/components/src/hardware-sim/Labware/labwareInternals/WellLabels.tsx
@@ -1,5 +1,7 @@
 import { memo } from 'react'
 
+import { getSchema2Dimensions } from '@opentrons/shared-data'
+
 import { COLORS } from '../../../helix-design-system'
 import { C_BLACK, C_BLUE } from '../../../styles/colors'
 import { RobotCoordsText } from '../../Deck'
@@ -61,7 +63,7 @@ const Labels = (props: {
             y={
               props.isLetterColumn === true
                 ? well.y
-                : props.definition.dimensions.yDimension -
+                : getSchema2Dimensions(props.definition).yDimension -
                   NUMBER_COLUMN_Y_FROM_TOP
             }
             style={{

--- a/components/src/hardware-sim/Labware/labwareInternals/WellLabels.tsx
+++ b/components/src/hardware-sim/Labware/labwareInternals/WellLabels.tsx
@@ -6,7 +6,7 @@ import { RobotCoordsText } from '../../Deck'
 import { WELL_LABEL_OPTIONS } from '../LabwareRender'
 
 import type { MemoExoticComponent } from 'react'
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 import type { WellLabelOption } from '../LabwareRender'
 import type { HighlightedWellLabels } from './types'
 
@@ -18,14 +18,14 @@ const LETTER_COLUMN_X_OUTSIDE = -4
 const NUMBER_COLUMN_Y_FROM_TOP_OUTSIDE = -5
 
 export interface WellLabelsProps {
-  definition: LabwareDefinition2
+  definition: LabwareDefinition
   wellLabelOption: WellLabelOption
   highlightedWellLabels?: HighlightedWellLabels
   wellLabelColor?: string
 }
 
 const Labels = (props: {
-  definition: LabwareDefinition2
+  definition: LabwareDefinition
   wells: string[]
   wellLabelOption: WellLabelOption
   isLetterColumn?: boolean

--- a/components/src/hardware-sim/Labware/labwareInternals/__tests__/LabwareWellLabels.test.tsx
+++ b/components/src/hardware-sim/Labware/labwareInternals/__tests__/LabwareWellLabels.test.tsx
@@ -7,9 +7,9 @@ import { fixture12Trough as _fixture12Trough } from '@opentrons/shared-data'
 
 import { LabwareWellLabels } from '../LabwareWellLabels'
 
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 
-const troughFixture12 = _fixture12Trough as LabwareDefinition2
+const troughFixture12 = _fixture12Trough as LabwareDefinition
 
 describe('LabwareWellLabels', () => {
   it('should render well labels', () => {

--- a/components/src/hardware-sim/Labware/labwareInternals/__tests__/StrokedWells.test.tsx
+++ b/components/src/hardware-sim/Labware/labwareInternals/__tests__/StrokedWells.test.tsx
@@ -8,11 +8,11 @@ import { fixture12Trough } from '@opentrons/shared-data'
 import { StrokedWells } from '../StrokedWells'
 import { WellComponent as Well } from '../Well'
 
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 
 vi.mock('../Well')
 
-const troughFixture12 = fixture12Trough as LabwareDefinition2
+const troughFixture12 = fixture12Trough as LabwareDefinition
 
 describe('StrokedWells', () => {
   it('should render a series of wells with the given stroke', () => {

--- a/components/src/hardware-sim/Labware/labwareInternals/__tests__/WellLabels.test.tsx
+++ b/components/src/hardware-sim/Labware/labwareInternals/__tests__/WellLabels.test.tsx
@@ -8,9 +8,9 @@ import { fixture12Trough as _fixture12Trough } from '@opentrons/shared-data'
 import { WELL_LABEL_OPTIONS } from '../../LabwareRender'
 import { WellLabels } from '../WellLabels'
 
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 
-const troughFixture12 = _fixture12Trough as LabwareDefinition2
+const troughFixture12 = _fixture12Trough as LabwareDefinition
 
 describe('WellLabels', () => {
   it('should render well labels outside of the labware', () => {

--- a/components/src/hardware-sim/Module/Module.stories.tsx
+++ b/components/src/hardware-sim/Module/Module.stories.tsx
@@ -16,7 +16,7 @@ import { RobotCoordinateSpace } from '../RobotCoordinateSpace'
 import { Module as ModuleComponent } from './'
 
 import type { Meta, Story } from '@storybook/react'
-import type { LabwareDefinition2, ModuleModel } from '@opentrons/shared-data'
+import type { LabwareDefinition, ModuleModel } from '@opentrons/shared-data'
 
 const moduleModels: ModuleModel[] = [
   TEMPERATURE_MODULE_V2,
@@ -49,7 +49,7 @@ const Template: Story<{
         orientation={args.orientation}
       >
         {args.hasLabware ? (
-          <LabwareRender definition={fixture96Plate as LabwareDefinition2} />
+          <LabwareRender definition={fixture96Plate as LabwareDefinition} />
         ) : null}
       </ModuleComponent>
     </RobotCoordinateSpace>

--- a/components/src/hardware-sim/Pipette/PipetteRender.stories.tsx
+++ b/components/src/hardware-sim/Pipette/PipetteRender.stories.tsx
@@ -7,7 +7,7 @@ import { LabwareRender } from '../Labware'
 import { PipetteRender } from './'
 
 import type { Meta, Story } from '@storybook/react'
-import type { LabwareDefinition2, PipetteName } from '@opentrons/shared-data'
+import type { LabwareDefinition, PipetteName } from '@opentrons/shared-data'
 
 const DECK_MAP_VIEWBOX = '0 -140 230 230'
 
@@ -18,7 +18,7 @@ const axygenReservoir90ml = getAllLabwareDefs().axygen1Reservoir90MlV1
 const opentrons6TuberackNest50mlConical = getAllLabwareDefs()
   .opentrons6TuberackNest50MlConicalV1
 
-const labwareDefMap: Record<string, LabwareDefinition2> = {
+const labwareDefMap: Record<string, LabwareDefinition> = {
   [opentrons300UlTiprack.metadata.displayName]: opentrons300UlTiprack,
   [opentrons10UlTiprack.metadata.displayName]: opentrons10UlTiprack,
   [nest12Reservoir15ml.metadata.displayName]: nest12Reservoir15ml,

--- a/components/src/hardware-sim/Pipette/PipetteRender.tsx
+++ b/components/src/hardware-sim/Pipette/PipetteRender.tsx
@@ -13,10 +13,10 @@ import {
 import { EightEmanatingNozzles } from './EightEmanatingNozzles'
 import { EmanatingNozzle } from './EmanatingNozzle'
 
-import type { LabwareDefinition2, PipetteName } from '@opentrons/shared-data'
+import type { LabwareDefinition, PipetteName } from '@opentrons/shared-data'
 
 interface PipetteRenderProps {
-  labwareDef: LabwareDefinition2
+  labwareDef: LabwareDefinition
   pipetteName: PipetteName
   usingMetalProbe?: boolean
 }

--- a/components/src/hardware-sim/Pipette/__tests__/PipetteRender.test.tsx
+++ b/components/src/hardware-sim/Pipette/__tests__/PipetteRender.test.tsx
@@ -16,13 +16,13 @@ import { EmanatingNozzle } from '../EmanatingNozzle'
 import { PipetteRender } from '../PipetteRender'
 
 import type { ComponentProps } from 'react'
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 
 vi.mock('../../Deck/RobotCoordsForeignDiv')
 vi.mock('../EmanatingNozzle')
 vi.mock('../EightEmanatingNozzles')
 
-const fixtureTiprack300Ul = _fixtureTiprack300ul as LabwareDefinition2
+const fixtureTiprack300Ul = _fixtureTiprack300ul as LabwareDefinition
 
 const render = (props: ComponentProps<typeof PipetteRender>) => {
   return renderWithProviders(<PipetteRender {...props} />)[0]

--- a/components/src/organisms/CommandText/__tests__/CommandText.test.tsx
+++ b/components/src/organisms/CommandText/__tests__/CommandText.test.tsx
@@ -23,7 +23,7 @@ import type {
   DispenseRunTimeCommand,
   DropTipInPlaceRunTimeCommand,
   DropTipRunTimeCommand,
-  LabwareDefinition2,
+  LabwareDefinition,
   LoadLabwareRunTimeCommand,
   LoadLiquidClassRunTimeCommand,
   LoadLiquidRunTimeCommand,
@@ -589,7 +589,7 @@ describe('CommandText', () => {
             labwareId: 'mockId',
             definition: {
               metadata: { displayName: 'mock displayName' },
-            } as LabwareDefinition2,
+            } as LabwareDefinition,
             offset: { x: 0, y: 0, z: 0 },
           },
           status: 'queued',

--- a/components/src/organisms/CommandText/index.tsx
+++ b/components/src/organisms/CommandText/index.tsx
@@ -9,7 +9,7 @@ import { useCommandTextString } from './useCommandTextString'
 
 import type { ComponentProps } from 'react'
 import type {
-  LabwareDefinition2,
+  LabwareDefinition,
   RobotType,
   RunTimeCommand,
 } from '@opentrons/shared-data'
@@ -36,7 +36,7 @@ type STProps = LegacySTProps | ModernSTProps
 
 interface BaseProps extends StyleProps {
   command: RunTimeCommand
-  allRunDefs: LabwareDefinition2[]
+  allRunDefs: LabwareDefinition[]
   commandTextData: CommandTextData
   robotType: RobotType
   isOnDevice?: boolean

--- a/components/src/organisms/CommandText/useCommandTextString/index.ts
+++ b/components/src/organisms/CommandText/useCommandTextString/index.ts
@@ -4,7 +4,7 @@ import * as utils from './utils'
 
 import type { TFunction } from 'i18next'
 import type {
-  LabwareDefinition2,
+  LabwareDefinition,
   RobotType,
   RunTimeCommand,
 } from '@opentrons/shared-data'
@@ -19,7 +19,7 @@ export * from './utils'
 
 export interface UseCommandTextStringParams {
   command: RunTimeCommand | null
-  allRunDefs: LabwareDefinition2[]
+  allRunDefs: LabwareDefinition[]
   commandTextData: CommandTextData | null
   robotType: RobotType
 }

--- a/components/src/organisms/CommandText/useCommandTextString/utils/__tests__/getFinalLabwareLocation.test.ts
+++ b/components/src/organisms/CommandText/useCommandTextString/utils/__tests__/getFinalLabwareLocation.test.ts
@@ -4,7 +4,7 @@ import { fixtureTiprack10ul } from '@opentrons/shared-data'
 
 import { getFinalLabwareLocation } from '../getFinalLabwareLocation'
 
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 
 describe('getFinalLabwareLocation', () => {
   it('calculates labware location after only load_labware', () => {
@@ -23,7 +23,7 @@ describe('getFinalLabwareLocation', () => {
           },
           result: {
             labwareId,
-            definition: fixtureTiprack10ul as LabwareDefinition2,
+            definition: fixtureTiprack10ul as LabwareDefinition,
             offset: { x: 1, y: 2, z: 3 },
           },
           status: 'succeeded',
@@ -51,7 +51,7 @@ describe('getFinalLabwareLocation', () => {
           },
           result: {
             labwareId,
-            definition: fixtureTiprack10ul as LabwareDefinition2,
+            definition: fixtureTiprack10ul as LabwareDefinition,
             offset: { x: 1, y: 2, z: 3 },
           },
           status: 'succeeded',
@@ -93,7 +93,7 @@ describe('getFinalLabwareLocation', () => {
           },
           result: {
             labwareId,
-            definition: fixtureTiprack10ul as LabwareDefinition2,
+            definition: fixtureTiprack10ul as LabwareDefinition,
             offset: { x: 1, y: 2, z: 3 },
           },
           status: 'succeeded',

--- a/components/src/organisms/CommandText/useCommandTextString/utils/commandText/getFlexStackerCommandText.ts
+++ b/components/src/organisms/CommandText/useCommandTextString/utils/commandText/getFlexStackerCommandText.ts
@@ -8,8 +8,7 @@ import type {
   FlexStackerRetrieveRunTimeCommand,
   FlexStackerSetStoredLabwareRunTimeCommand,
   FlexStackerStoreRunTimeCommand,
-  LabwareDefinition2,
-  LabwareDefinition3,
+  LabwareDefinition,
   RunTimeCommand,
 } from '@opentrons/shared-data'
 import type { HandlesCommands } from '../types'
@@ -40,8 +39,7 @@ type GetFlexStackerCommandText = HandlesCommands<HandledCommands>
 
 const getLabwareDisplayName = (labwareUri: string, allRunDefs: any): string => {
   const currentLabwareDef = allRunDefs.find(
-    (def: LabwareDefinition2 | LabwareDefinition3) =>
-      getLabwareDefURI(def) === labwareUri
+    (def: LabwareDefinition) => getLabwareDefURI(def) === labwareUri
   )
   return currentLabwareDef?.metadata.displayName ?? null
 }

--- a/components/src/organisms/CommandText/useCommandTextString/utils/getLabwareDefinitionsFromCommands.ts
+++ b/components/src/organisms/CommandText/useCommandTextString/utils/getLabwareDefinitionsFromCommands.ts
@@ -1,7 +1,7 @@
 import { getLabwareDefURI } from '@opentrons/shared-data'
 
 import type {
-  LabwareDefinition2,
+  LabwareDefinition,
   LoadLabwareRunTimeCommand,
   LoadLidRunTimeCommand,
   RunTimeCommand,
@@ -10,8 +10,8 @@ import type {
 // Note: This is an O(n) operation.
 export function getLabwareDefinitionsFromCommands(
   commands: RunTimeCommand[]
-): LabwareDefinition2[] {
-  return commands.reduce<LabwareDefinition2[]>(
+): LabwareDefinition[] {
+  return commands.reduce<LabwareDefinition[]>(
     (acc, command) => [
       ...getLabwareDefinitionFromCommand(command, acc),
       ...acc,
@@ -21,11 +21,11 @@ export function getLabwareDefinitionsFromCommands(
 }
 
 function getNewLabwareDefinitions(
-  newDefinitions: Array<LabwareDefinition2 | null | undefined>,
-  knownDefinitions: LabwareDefinition2[]
-): LabwareDefinition2[] {
+  newDefinitions: Array<LabwareDefinition | null | undefined>,
+  knownDefinitions: LabwareDefinition[]
+): LabwareDefinition[] {
   return newDefinitions.filter(
-    (maybeNewDef): maybeNewDef is LabwareDefinition2 =>
+    (maybeNewDef): maybeNewDef is LabwareDefinition =>
       maybeNewDef != null &&
       !knownDefinitions.some(
         knownDef => getLabwareDefURI(knownDef) === getLabwareDefURI(maybeNewDef)
@@ -40,8 +40,8 @@ const isLoadCommand = (
 
 function getLabwareDefinitionFromCommand(
   command: RunTimeCommand,
-  known: LabwareDefinition2[]
-): LabwareDefinition2[] {
+  known: LabwareDefinition[]
+): LabwareDefinition[] {
   if (isLoadCommand(command)) {
     return getNewLabwareDefinitions([command.result?.definition], known)
   }

--- a/components/src/organisms/CommandText/useCommandTextString/utils/getLabwareLocation.tsx
+++ b/components/src/organisms/CommandText/useCommandTextString/utils/getLabwareLocation.tsx
@@ -15,7 +15,7 @@ import { getModuleModel } from './getModuleModel'
 import type {
   AddressableAreaName,
   CutoutId,
-  LabwareDefinition2,
+  LabwareDefinition,
   LabwareLocation,
   LabwareLocationSequence,
   ModuleModel,
@@ -49,11 +49,11 @@ export interface SequenceSlotOnlyParams extends SequenceBaseParams {
   detailLevel: 'slot-only'
 }
 export interface LocationFullParams extends BaseParams {
-  allRunDefs: LabwareDefinition2[]
+  allRunDefs: LabwareDefinition[]
   detailLevel?: 'full'
 }
 export interface SequenceFullParams extends SequenceBaseParams {
-  allRunDefs: LabwareDefinition2[]
+  allRunDefs: LabwareDefinition[]
   detailLevel?: 'full'
 }
 

--- a/components/src/organisms/CommandText/useCommandTextString/utils/getLabwareName.ts
+++ b/components/src/organisms/CommandText/useCommandTextString/utils/getLabwareName.ts
@@ -2,7 +2,7 @@ import { getLabwareDefURI, getLabwareDisplayName } from '@opentrons/shared-data'
 
 import { getLoadedLabware } from './getLoadedLabware'
 
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 import type { LoadedLabwares } from './types'
 
 const FIXED_TRASH_DEF_URIS = [
@@ -13,7 +13,7 @@ const FIXED_TRASH_DEF_URIS = [
 const LID_STACK_OBJECT_LOADNAME = 'protocol_engine_lid_stack_object'
 
 export interface GetLabwareNameParams {
-  allRunDefs: LabwareDefinition2[]
+  allRunDefs: LabwareDefinition[]
   loadedLabwares: LoadedLabwares
   labwareId: string
 }

--- a/components/src/organisms/ProtocolTimelineScrubber/CommandItem.tsx
+++ b/components/src/organisms/ProtocolTimelineScrubber/CommandItem.tsx
@@ -11,7 +11,7 @@ import { getCommandTextData } from './utils'
 
 import type {
   CompletedProtocolAnalysis,
-  LabwareDefinition2,
+  LabwareDefinition,
   ProtocolAnalysisOutput,
   RobotType,
   RunTimeCommand,
@@ -24,7 +24,7 @@ interface CommandItemProps {
   setCurrentCommandIndex: (index: number) => void
   analysis: CompletedProtocolAnalysis | ProtocolAnalysisOutput
   robotType: RobotType
-  allRunDefs: LabwareDefinition2[]
+  allRunDefs: LabwareDefinition[]
 }
 export function CommandItem({
   index,

--- a/components/src/organisms/ProtocolTimelineScrubber/utils.ts
+++ b/components/src/organisms/ProtocolTimelineScrubber/utils.ts
@@ -8,7 +8,7 @@ import { COLORS } from '../../helix-design-system'
 
 import type {
   CompletedProtocolAnalysis,
-  LabwareDefinition2,
+  LabwareDefinition,
   ProtocolAnalysisOutput,
   RunTimeCommand,
 } from '@opentrons/shared-data'
@@ -41,7 +41,7 @@ export type ContentsByWell = {
 
 const MIXED_WELL_COLOR = COLORS.grey50
 
-function getAllWellsForLabware(def: LabwareDefinition2): string[] {
+function getAllWellsForLabware(def: LabwareDefinition): string[] {
   return Object.keys(def.wells)
 }
 
@@ -64,7 +64,7 @@ function _wellContentsForWell(
 
 export function _wellContentsForLabware(
   labwareLiquids: SingleLabwareLiquidState,
-  labwareDef: LabwareDefinition2
+  labwareDef: LabwareDefinition
 ): ContentsByWell {
   const allWellsForContainer = getAllWellsForLabware(labwareDef)
   return reduce(

--- a/labware-library/src/labware-creator/index.tsx
+++ b/labware-library/src/labware-creator/index.tsx
@@ -16,10 +16,7 @@ import {
   ModalShell,
   PrimaryButton,
 } from '@opentrons/components'
-import {
-  getAllDefinitions,
-  labwareSchemaV2 as labwareSchema,
-} from '@opentrons/shared-data'
+import { getAllDefinitions, labwareSchemaV2 } from '@opentrons/shared-data'
 
 import { reportEvent } from '../analytics'
 import { reportErrors } from './analyticsUtils'
@@ -74,8 +71,11 @@ import type {
 } from './fields'
 import type { LabwareCreatorErrors } from './formLevelValidation'
 
+// todo(mm, 2025-05-16): Deduplicate with app and shared-data for schema 3 support and
+// better type-guarding.
 const ajv = new Ajv()
-const validateLabwareSchema = ajv.compile(labwareSchema)
+const validateLabwareSchema2 = ajv.compile(labwareSchemaV2)
+
 type WizardStep =
   | 'intro'
   | 'regularity'
@@ -284,13 +284,13 @@ export const LabwareCreator = (props: LabwareCreatorProps): JSX.Element => {
             return
           }
 
-          if (!Boolean(validateLabwareSchema(parsedLabwareDef))) {
-            console.warn(validateLabwareSchema.errors)
+          if (!Boolean(validateLabwareSchema2(parsedLabwareDef))) {
+            console.warn(validateLabwareSchema2.errors)
 
             setImportError({
               key: 'INVALID_LABWARE_DEF',
               // @ts-expect-error(IL, 2021-03-24): ajv def mixup
-              messages: validateLabwareSchema.errors.map(
+              messages: validateLabwareSchema2.errors.map(
                 ajvError =>
                   `${ajvError.schemaPath}: ${
                     // eslint-disable-next-line @typescript-eslint/restrict-template-expressions

--- a/opentrons-ai-client/src/molecules/LabwareDiagram/index.tsx
+++ b/opentrons-ai-client/src/molecules/LabwareDiagram/index.tsx
@@ -2,13 +2,13 @@ import { css } from 'styled-components'
 
 import { labwareImages } from './labware-images'
 
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 
 const IMAGE_MAX_WIDTH = '96px'
 export function LabwareDiagram({
   def,
 }: {
-  def: LabwareDefinition2
+  def: LabwareDefinition
 }): JSX.Element | undefined {
   const labwareSrc: string = labwareImages[def.parameters.loadName]?.[0] ?? ''
 

--- a/opentrons-ai-client/src/organisms/LabwareModal/index.tsx
+++ b/opentrons-ai-client/src/organisms/LabwareModal/index.tsx
@@ -26,7 +26,7 @@ import { LABWARES_FIELD_NAME } from '../LabwareLiquidsSection'
 import type { ChangeEvent } from 'react'
 import type {
   LabwareDefByDefURI,
-  LabwareDefinition2,
+  LabwareDefinition,
 } from '@opentrons/shared-data'
 import type { DisplayLabware } from '../LabwareLiquidsSection'
 
@@ -60,13 +60,10 @@ export function LabwareModal({
 
   const defs = getOnlyLatestDefs()
 
-  const labwareByCategory: Record<
-    string,
-    LabwareDefinition2[]
-  > = useMemo(() => {
+  const labwareByCategory: Record<string, LabwareDefinition[]> = useMemo(() => {
     const groupedLabware = reduce<
       LabwareDefByDefURI,
-      Record<string, LabwareDefinition2[]>
+      Record<string, LabwareDefinition[]>
     >(
       defs,
       (acc, def) => {

--- a/opentrons-ai-client/src/resources/utils/labware.ts
+++ b/opentrons-ai-client/src/resources/utils/labware.ts
@@ -9,7 +9,7 @@ import {
 
 import type {
   LabwareDefByDefURI,
-  LabwareDefinition2,
+  LabwareDefinition,
 } from '@opentrons/shared-data'
 
 let _definitions: LabwareDefByDefURI | null = null
@@ -31,7 +31,7 @@ export function getOnlyLatestDefs(): LabwareDefByDefURI {
   if (!_latestDefs) {
     const allDefs = getAllDefinitions()
     const allURIs = Object.keys(allDefs)
-    const labwareDefGroups: Record<string, LabwareDefinition2[]> = groupBy(
+    const labwareDefGroups: Record<string, LabwareDefinition[]> = groupBy(
       allURIs.map((uri: string) => allDefs[uri]),
       d => `${d.namespace}/${d.parameters.loadName}`
     )

--- a/opentrons-ai-client/src/resources/utils/labware.ts
+++ b/opentrons-ai-client/src/resources/utils/labware.ts
@@ -8,15 +8,15 @@ import {
 } from '@opentrons/shared-data'
 
 import type {
-  LabwareDefByDefURI,
+  LabwareDef2ByDefURI,
   LabwareDefinition,
 } from '@opentrons/shared-data'
 
-let _definitions: LabwareDefByDefURI | null = null
+let _definitions: LabwareDef2ByDefURI | null = null
 
 const BLOCK_LIST = [...RETIRED_LABWARE, ...LABWAREV2_DO_NOT_LIST]
 
-export function getAllDefinitions(): LabwareDefByDefURI {
+export function getAllDefinitions(): LabwareDef2ByDefURI {
   if (_definitions == null) {
     _definitions = _getAllDefinitions(BLOCK_LIST)
   }
@@ -26,8 +26,8 @@ export function getAllDefinitions(): LabwareDefByDefURI {
 // filter out all but the latest version of each labware
 // NOTE: this is similar to labware-library's getOnlyLatestDefs, but this one
 // has the {labwareDefURI: def} shape, instead of an array of labware defs
-let _latestDefs: LabwareDefByDefURI | null = null
-export function getOnlyLatestDefs(): LabwareDefByDefURI {
+let _latestDefs: LabwareDef2ByDefURI | null = null
+export function getOnlyLatestDefs(): LabwareDef2ByDefURI {
   if (!_latestDefs) {
     const allDefs = getAllDefinitions()
     const allURIs = Object.keys(allDefs)

--- a/protocol-designer/src/components/organisms/Labware/SingleLabware.tsx
+++ b/protocol-designer/src/components/organisms/Labware/SingleLabware.tsx
@@ -1,8 +1,16 @@
 import { LabwareRender, RobotWorkSpace } from '@opentrons/components'
 
 import type { ComponentProps } from 'react'
+import type { LabwareDefinition2 } from '@opentrons/shared-data'
 
-type Props = ComponentProps<typeof LabwareRender>
+// todo(mm, 2025-05-16):
+// LabwareRender accepts LabwareDefinition2 | LabwareDefinition3.
+// We're not ready to deal with LabwareDefinition3 here yet because we haven't figured
+// out how to port the viewbox calculation. This should be just
+// ComponentProps<typeof LabwareRender> once we do.
+type Props = Omit<ComponentProps<typeof LabwareRender>, 'definition'> & {
+  definition: LabwareDefinition2
+}
 
 /** Avoid boilerplate for viewbox-based-on-labware-dimensions */
 export function SingleLabware(props: Props): JSX.Element {

--- a/protocol-designer/src/load-file/migration/7_0_0.ts
+++ b/protocol-designer/src/load-file/migration/7_0_0.ts
@@ -7,8 +7,8 @@ import { uuid } from '../../utils'
 import { getAdapterAndLabwareSplitInfo } from './utils/getAdapterAndLabwareSplitInfo'
 
 import type {
+  LabwareDef2ByDefURI,
   LabwareDefinition2,
-  LabwareDefinitionsByUri,
   LoadLiquidCreateCommand,
   ProtocolFileV6,
 } from '@opentrons/shared-data'
@@ -187,9 +187,9 @@ export const migrateFile = (
 
       return [loadAdapterCommand, loadLabwareCommand]
     })
-  const newLabwareDefinitions: LabwareDefinitionsByUri = Object.keys(
+  const newLabwareDefinitions: LabwareDef2ByDefURI = Object.keys(
     labwareDefinitions
-  ).reduce((acc: LabwareDefinitionsByUri, defId: string) => {
+  ).reduce((acc: LabwareDef2ByDefURI, defId: string) => {
     const labwareDefinition = labwareDefinitions[defId]
     if (labwareDefinition == null) {
       console.error(
@@ -213,7 +213,7 @@ export const migrateFile = (
     .filter(
       (command): command is LoadLabwareCommandV6 =>
         command.commandType === 'loadLabware' &&
-        getIsAdapter(command.params.labwareId) === false
+        !getIsAdapter(command.params.labwareId)
     )
     .map(command => {
       const labwareId = command.params.labwareId

--- a/protocol-designer/src/pages/Onboarding/utils.tsx
+++ b/protocol-designer/src/pages/Onboarding/utils.tsx
@@ -5,13 +5,13 @@ import {
 } from '@opentrons/shared-data'
 
 import type {
-  LabwareDefByDefURI,
+  LabwareDef2ByDefURI,
   LabwareDefinition2,
   PipetteName,
 } from '@opentrons/shared-data'
 
 interface TiprackOptionsProps {
-  allLabware: LabwareDefByDefURI
+  allLabware: LabwareDef2ByDefURI
   allowAllTipracks: boolean
   selectedPipetteName?: string | null
 }

--- a/react-api-client/src/maintenance_runs/useCreateMaintenanceRunLabwareDefinitionMutation.ts
+++ b/react-api-client/src/maintenance_runs/useCreateMaintenanceRunLabwareDefinitionMutation.ts
@@ -13,14 +13,11 @@ import type {
   HostConfig,
   LabwareDefinitionSummary,
 } from '@opentrons/api-client'
-import type {
-  LabwareDefinition2,
-  LabwareDefinition3,
-} from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 
 interface CreateMaintenanceRunLabwareDefinitionMutateParams {
   maintenanceRunId: string
-  labwareDef: LabwareDefinition2 | LabwareDefinition3
+  labwareDef: LabwareDefinition
 }
 
 export type UseCreateLabwareDefinitionMutationResult = UseMutationResult<

--- a/react-api-client/src/runs/__tests__/useCreateLabwareDefinitionMutation.test.tsx
+++ b/react-api-client/src/runs/__tests__/useCreateLabwareDefinitionMutation.test.tsx
@@ -9,7 +9,7 @@ import { useCreateLabwareDefinitionMutation } from '../useCreateLabwareDefinitio
 
 import type * as React from 'react'
 import type { HostConfig } from '@opentrons/api-client'
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 
 vi.mock('@opentrons/api-client')
 vi.mock('../../api/useHost')
@@ -19,7 +19,7 @@ const RUN_ID = 'run_id'
 
 describe('useCreateLabwareDefinitionMutation hook', () => {
   let wrapper: React.FunctionComponent<{ children: React.ReactNode }>
-  let labwareDefinition: LabwareDefinition2
+  let labwareDefinition: LabwareDefinition
 
   beforeEach(() => {
     const queryClient = new QueryClient()

--- a/react-api-client/src/runs/useCreateLabwareDefinitionMutation.ts
+++ b/react-api-client/src/runs/useCreateLabwareDefinitionMutation.ts
@@ -9,11 +9,11 @@ import type {
   CreateLabwareDefinitionResponsePayload,
   HostConfig,
 } from '@opentrons/api-client'
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition } from '@opentrons/shared-data'
 
 interface CreateLabwareDefinitionParams {
   runId: string
-  data: LabwareDefinition2
+  data: LabwareDefinition
 }
 
 export type UseCreateLabwareDefinitionMutationResult = UseMutationResult<

--- a/shared-data/command/types/module.ts
+++ b/shared-data/command/types/module.ts
@@ -3,7 +3,7 @@ import type {
   CommonCommandRunTimeInfo,
   RunCommandFlexStackerError,
 } from '.'
-import type { LabwareDefinition2 } from '../../js'
+import type { LabwareDefinition } from '../../js'
 import type { LabwareLocationSequence } from './setup'
 
 export type ModuleRunTimeCommand =
@@ -446,9 +446,9 @@ export interface FlexStackerSetStoredLabwareRunTimeCommand
   extends FlexStackerSetStoredLabwareCreateCommand,
     CommonCommandRunTimeInfo {
   result?: {
-    primaryLabwareDefinition: LabwareDefinition2
-    lidLabwareDefinition?: LabwareDefinition2 | null
-    adapterLabwareDefinition?: LabwareDefinition2 | null
+    primaryLabwareDefinition: LabwareDefinition
+    lidLabwareDefinition?: LabwareDefinition | null
+    adapterLabwareDefinition?: LabwareDefinition | null
     count: number
     storedLabware: FlexStackerStoredLabwareGroup[]
   } & StackerStoredLabwareLocationSequences

--- a/shared-data/command/types/setup.ts
+++ b/shared-data/command/types/setup.ts
@@ -3,7 +3,7 @@ import type {
   AspirateProperties,
   CommonCommandCreateInfo,
   CommonCommandRunTimeInfo,
-  LabwareDefinition2,
+  LabwareDefinition,
   LabwareOffset,
   ModuleModel,
   MultiDispenseProperties,
@@ -222,7 +222,7 @@ interface LoadLabwareParams {
 }
 interface LoadLabwareResult {
   labwareId: string
-  definition: LabwareDefinition2
+  definition: LabwareDefinition
   // todo(mm, 2024-08-19): This does not match the server-returned offsetId field.
   // Confirm nothing client-side is trying to use this, then replace it with offsetId.
   offset: LabwareOffset
@@ -318,8 +318,8 @@ interface LoadLidStackParams {
 interface LoadLidStackResult {
   stackLabwareId: string
   labwareIds: string[]
-  definition?: LabwareDefinition2
-  lidStackDefinition: LabwareDefinition2
+  definition?: LabwareDefinition
+  lidStackDefinition: LabwareDefinition
   location: LabwareLocation
   stackLocationSequence?: LabwareLocationSequence
   locationSequences?: LabwareLocationSequence[]
@@ -334,6 +334,6 @@ export interface LoadLidParams {
 
 interface LoadLidResult {
   labwareId: string
-  definition: LabwareDefinition2
+  definition: LabwareDefinition
   locationSequence?: LabwareLocationSequence
 }

--- a/shared-data/js/__tests__/getWellNamePerMultiTip.test.ts
+++ b/shared-data/js/__tests__/getWellNamePerMultiTip.test.ts
@@ -7,13 +7,13 @@ import fixture_384_plate from '../../labware/fixtures/2/fixture_384_plate.json'
 import fixture_trash from '../../labware/fixtures/2/fixture_trash.json'
 import { getWellNamePerMultiTip } from '../helpers/getWellNamePerMultiTip'
 
-import type { LabwareDefinition2 } from '../types'
+import type { LabwareDefinition } from '../types'
 
-const fixtureTrash = fixture_trash as LabwareDefinition2
-const fixture96Plate = fixture_96_plate as LabwareDefinition2
-const fixture384Plate = fixture_384_plate as LabwareDefinition2
-const fixture12Trough = fixture_12_trough as LabwareDefinition2
-const fixture24Tuberack = fixture_24_tuberack as LabwareDefinition2
+const fixtureTrash = fixture_trash as LabwareDefinition
+const fixture96Plate = fixture_96_plate as LabwareDefinition
+const fixture384Plate = fixture_384_plate as LabwareDefinition
+const fixture12Trough = fixture_12_trough as LabwareDefinition
+const fixture24Tuberack = fixture_24_tuberack as LabwareDefinition
 const EIGHT_CHANNEL = 8
 
 describe('96 plate', () => {

--- a/shared-data/js/getLabware.ts
+++ b/shared-data/js/getLabware.ts
@@ -7,8 +7,8 @@ import {
 } from './constants'
 
 import type {
+  LabwareDefinition,
   LabwareDefinition1,
-  LabwareDefinition2,
   WellDefinition,
 } from './types'
 
@@ -90,7 +90,7 @@ export function getIsLabwareV1Tiprack(def: LabwareDefinition1): boolean {
   return Boolean(def?.metadata?.isTiprack)
 }
 
-export function getIsTiprack(labwareDef: LabwareDefinition2): boolean {
+export function getIsTiprack(labwareDef: LabwareDefinition): boolean {
   return labwareDef.parameters.isTiprack
 }
 
@@ -115,7 +115,7 @@ const _SHORT_MM_LABWARE_DEF_LOADNAMES = [
 const ENGAGE_HEIGHT_OFFSET = -4
 
 export function getLabwareDefaultEngageHeight(
-  labwareDef: LabwareDefinition2
+  labwareDef: LabwareDefinition
 ): number | null {
   const rawEngageHeight: number | null | undefined =
     labwareDef.parameters.magneticModuleEngageHeight

--- a/shared-data/js/helpers/__tests__/getFixedTrashLabwareDefinition.test.ts
+++ b/shared-data/js/helpers/__tests__/getFixedTrashLabwareDefinition.test.ts
@@ -3,12 +3,12 @@ import { describe, expect, it } from 'vitest'
 import fixedTrashUncasted from '../../../labware/definitions/2/opentrons_1_trash_3200ml_fixed/1.json'
 import { getFixedTrashLabwareDefinition } from '../index'
 
-import type { LabwareDefinition2 } from '../..'
+import type { LabwareDefinition } from '../..'
 
 describe('getFixedTrashLabwareDefinition', () => {
   it(`should return the fixed trash labware defition`, () => {
     expect(getFixedTrashLabwareDefinition()).toEqual(
-      (fixedTrashUncasted as unknown) as LabwareDefinition2
+      (fixedTrashUncasted as unknown) as LabwareDefinition
     )
   })
 })

--- a/shared-data/js/helpers/__tests__/labwareSchemaShims.test.ts
+++ b/shared-data/js/helpers/__tests__/labwareSchemaShims.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+
+import { getSchema2Dimensions } from '../..'
+
+import type { LabwareDefinition2, LabwareDefinition3 } from '../..'
+
+describe('labwareSchemaShims', () => {
+  describe('getSchema2Dimensions()', () => {
+    it('should handle schema 2 definitions', () => {
+      const definition: Partial<LabwareDefinition2> = {
+        schemaVersion: 2,
+        dimensions: {
+          xDimension: 12.34,
+          yDimension: 56.78,
+          zDimension: 90.12,
+        },
+      }
+      const result = getSchema2Dimensions(definition as LabwareDefinition2)
+      expect(result).toStrictEqual({
+        xDimension: 12.34,
+        yDimension: 56.78,
+        zDimension: 90.12,
+      })
+    })
+    it('should handle schema 3 definitions', () => {
+      const definition: Partial<LabwareDefinition3> = {
+        schemaVersion: 3,
+        extents: {
+          total: {
+            backLeftBottom: {
+              x: -0.1,
+              y: 2.0,
+              z: -0.3,
+            },
+            frontRightTop: {
+              x: 1.0,
+              y: -0.2,
+              z: 3.0,
+            },
+          },
+          footprint: {} as any,
+        },
+      }
+      const result = getSchema2Dimensions(definition as LabwareDefinition3)
+      expect(result).toStrictEqual({
+        xDimension: 1.1,
+        yDimension: 2.2,
+        zDimension: 3.3,
+      })
+    })
+  })
+})

--- a/shared-data/js/helpers/__tests__/wellSets.test.ts
+++ b/shared-data/js/helpers/__tests__/wellSets.test.ts
@@ -13,13 +13,13 @@ import {
 import { findWellAt } from '../getWellNamePerMultiTip'
 import { makeWellSetHelpers } from '../wellSets'
 
-import type { LabwareDefinition2 } from '../../types'
+import type { LabwareDefinition } from '../../types'
 import type { WellSetHelpers } from '../wellSets'
 
-const fixture12Trough = fixture_12_trough as LabwareDefinition2
-const fixture96Plate = fixture_96_plate as LabwareDefinition2
-const fixture384Plate = fixture_384_plate as LabwareDefinition2
-const fixtureOverlappyWellplate = fixture_overlappy_wellplate as LabwareDefinition2
+const fixture12Trough = fixture_12_trough as LabwareDefinition
+const fixture96Plate = fixture_96_plate as LabwareDefinition
+const fixture384Plate = fixture_384_plate as LabwareDefinition
+const fixtureOverlappyWellplate = fixture_overlappy_wellplate as LabwareDefinition
 const EIGHT_CHANNEL = 8
 const NINETY_SIX_CHANNEL = 96
 const wellsForReservoir = [

--- a/shared-data/js/helpers/getFixedTrashLabwareDefinition.ts
+++ b/shared-data/js/helpers/getFixedTrashLabwareDefinition.ts
@@ -1,8 +1,8 @@
 import fixedTrashUncasted from '../../labware/definitions/2/opentrons_1_trash_3200ml_fixed/1.json'
 
-import type { LabwareDefinition2 } from '..'
+import type { LabwareDefinition } from '..'
 
-export function getFixedTrashLabwareDefinition(): LabwareDefinition2 {
-  const LabwareDefinition2 = (fixedTrashUncasted as unknown) as LabwareDefinition2
-  return LabwareDefinition2
+export function getFixedTrashLabwareDefinition(): LabwareDefinition {
+  const LabwareDefinition = (fixedTrashUncasted as unknown) as LabwareDefinition
+  return LabwareDefinition
 }

--- a/shared-data/js/helpers/getLoadedLabwareDefinitionsByUri.ts
+++ b/shared-data/js/helpers/getLoadedLabwareDefinitionsByUri.ts
@@ -1,9 +1,9 @@
 import { getLabwareDefURI } from '.'
 
-import type { LabwareDefinition2, RunTimeCommand } from '..'
+import type { LabwareDefinition, RunTimeCommand } from '..'
 
 export interface LabwareDefinitionsByUri {
-  [defURI: string]: LabwareDefinition2
+  [defURI: string]: LabwareDefinition
 }
 
 export function getLoadedLabwareDefinitionsByUri(
@@ -15,7 +15,7 @@ export function getLoadedLabwareDefinitionsByUri(
       command.commandType === 'loadLid' ||
       command.commandType === 'loadLidStack'
     ) {
-      const labwareDef: LabwareDefinition2 | undefined =
+      const labwareDef: LabwareDefinition | undefined =
         command.result?.definition
       if (labwareDef == null) {
         console.warn(

--- a/shared-data/js/helpers/getTipTypeFromTipRackDefinition.ts
+++ b/shared-data/js/helpers/getTipTypeFromTipRackDefinition.ts
@@ -1,7 +1,7 @@
-import type { LabwareDefinition2 } from '..'
+import type { LabwareDefinition } from '..'
 
 export function getTipTypeFromTipRackDefinition(
-  tipRackDef: LabwareDefinition2
+  tipRackDef: LabwareDefinition
 ): string {
   const tipVolume = Object.values(tipRackDef.wells)[0].totalLiquidVolume
   const tipType = `t${tipVolume}`

--- a/shared-data/js/helpers/getWellNamePerMultiTip.ts
+++ b/shared-data/js/helpers/getWellNamePerMultiTip.ts
@@ -3,7 +3,7 @@ import range from 'lodash/range'
 import { get96Channel384WellPlateWells } from './get96Channel384WellPlateWells'
 import { getLabwareHasQuirk, orderWells, sortWells } from './index'
 
-import type { LabwareDefinition2 } from '../types'
+import type { LabwareDefinition } from '../types'
 
 // TODO Ian 2018-03-13 pull pipette offsets/positions from some pipette definitions data
 const OFFSET_8_CHANNEL = 9 // offset in mm between tips
@@ -11,7 +11,7 @@ const OFFSET_8_CHANNEL = 9 // offset in mm between tips
 const MULTICHANNEL_TIP_SPAN = OFFSET_8_CHANNEL * (8 - 1) // length in mm from first to last tip of multichannel
 
 export function findWellAt(
-  labwareDef: LabwareDefinition2,
+  labwareDef: LabwareDefinition,
   x: number,
   y: number
 ): string | null | undefined {
@@ -38,7 +38,7 @@ export function findWellAt(
 
 // "topWellName" means well at the "top" of the column we're accessing: usually A row, or B row for 384-format
 export function getWellNamePerMultiTip(
-  labwareDef: LabwareDefinition2,
+  labwareDef: LabwareDefinition,
   topWellName: string,
   channels: 8 | 96
 ): string[] | null {

--- a/shared-data/js/helpers/getWellTotalVolume.ts
+++ b/shared-data/js/helpers/getWellTotalVolume.ts
@@ -1,7 +1,7 @@
-import type { LabwareDefinition2 } from '../types'
+import type { LabwareDefinition } from '../types'
 
 export const getWellTotalVolume = (
-  labwareDef: LabwareDefinition2,
+  labwareDef: LabwareDefinition,
   wellName: string
 ): number | null | undefined => {
   const well = labwareDef.wells[wellName]

--- a/shared-data/js/helpers/index.ts
+++ b/shared-data/js/helpers/index.ts
@@ -49,6 +49,7 @@ export * from './sortRunTimeParameters'
 export * from './parseAddressableArea'
 export * from './validateCustomLabwareHelper'
 export * from './getWellRangeForLiquidLabwarePair'
+export * from './labwareSchemaShims'
 
 export const getLabwareDefIsStandard = (def: LabwareDefinition): boolean =>
   def?.namespace === OPENTRONS_LABWARE_NAMESPACE

--- a/shared-data/js/helpers/index.ts
+++ b/shared-data/js/helpers/index.ts
@@ -4,6 +4,7 @@ import standardOt2DeckDef from '../../deck/definitions/5/ot2_standard.json'
 import standardFlexDeckDef from '../../deck/definitions/5/ot3_standard.json'
 import { OPENTRONS_LABWARE_NAMESPACE } from '../constants'
 import { getAllLiquidClassDefs } from '../liquidClasses'
+import { getSchema2Dimensions } from './labwareSchemaShims'
 
 import type { AddressableAreaName, CutoutId } from '../../deck/types/schemaV5'
 import type {
@@ -379,7 +380,7 @@ export const getAreSlotsAdjacent = (
 export const getIsLabwareAboveHeight = (
   labwareDef: LabwareDefinition,
   height: number
-): boolean => labwareDef.dimensions.zDimension > height
+): boolean => getSchema2Dimensions(labwareDef).zDimension > height
 
 export const getAdapterName = (labwareLoadname: string): ThermalAdapterName => {
   let adapterName: ThermalAdapterName = 'Universal Flat Adapter'

--- a/shared-data/js/helpers/index.ts
+++ b/shared-data/js/helpers/index.ts
@@ -8,8 +8,7 @@ import { getAllLiquidClassDefs } from '../liquidClasses'
 import type { AddressableAreaName, CutoutId } from '../../deck/types/schemaV5'
 import type {
   DeckDefinition,
-  LabwareDefinition2,
-  LabwareDefinition3,
+  LabwareDefinition,
   LiquidClass,
   ModuleModel,
   RobotType,
@@ -51,12 +50,10 @@ export * from './parseAddressableArea'
 export * from './validateCustomLabwareHelper'
 export * from './getWellRangeForLiquidLabwarePair'
 
-export const getLabwareDefIsStandard = (def: LabwareDefinition2): boolean =>
+export const getLabwareDefIsStandard = (def: LabwareDefinition): boolean =>
   def?.namespace === OPENTRONS_LABWARE_NAMESPACE
 
-export const getLabwareDefURI = (
-  def: LabwareDefinition2 | LabwareDefinition3
-): string =>
+export const getLabwareDefURI = (def: LabwareDefinition): string =>
   constructLabwareDefURI(
     def.namespace,
     def.parameters.loadName,
@@ -120,7 +117,7 @@ export const RETIRED_LABWARE = [
 ]
 
 export const getLabwareDisplayName = (
-  labwareDef: LabwareDefinition2
+  labwareDef: LabwareDefinition
 ): string => {
   const { displayName } = labwareDef.metadata
 
@@ -134,7 +131,7 @@ export const getLabwareDisplayName = (
   return displayName
 }
 
-export const getTiprackVolume = (labwareDef: LabwareDefinition2): number => {
+export const getTiprackVolume = (labwareDef: LabwareDefinition): number => {
   console.assert(
     labwareDef.parameters.isTiprack,
     `getTiprackVolume expected a tiprack labware ${getLabwareDefURI(
@@ -151,7 +148,7 @@ export const getTiprackVolume = (labwareDef: LabwareDefinition2): number => {
 }
 
 export function getLabwareHasQuirk(
-  labwareDef: LabwareDefinition2,
+  labwareDef: LabwareDefinition,
   quirk: string
 ): boolean {
   const quirks = labwareDef.parameters.quirks
@@ -228,7 +225,7 @@ export function splitWellsOnColumn(sortedArray: string[]): string[][] {
 }
 
 export const getWellDepth = (
-  labwareDef: LabwareDefinition2,
+  labwareDef: LabwareDefinition,
   well: string
 ): number => labwareDef.wells[well].depth
 
@@ -236,7 +233,7 @@ export const getWellDepth = (
 // Assumes all wells have same offset because multi-offset not yet supported.
 // TODO: Ian 2019-07-13 return {[string: well]: offset} to support multi-offset
 export const getWellsDepth = (
-  labwareDef: LabwareDefinition2,
+  labwareDef: LabwareDefinition,
   wells: string[]
 ): number => {
   const offsets = wells.map(well => getWellDepth(labwareDef, well))
@@ -257,7 +254,7 @@ export const getWellsDepth = (
 type XYPlaneDimension = 'x' | 'y'
 
 export const getWellDimension = (
-  labwareDef: LabwareDefinition2,
+  labwareDef: LabwareDefinition,
   wells: string[],
   position: XYPlaneDimension
 ): number => {
@@ -274,7 +271,7 @@ export const getWellDimension = (
 }
 
 export const getMinXYDimension = (
-  labwareDef: LabwareDefinition2,
+  labwareDef: LabwareDefinition,
   wells: string[]
 ): number | null => {
   return (
@@ -379,7 +376,7 @@ export const getAreSlotsAdjacent = (
   getAreSlotsVerticallyAdjacent(slotNameA, slotNameB)
 
 export const getIsLabwareAboveHeight = (
-  labwareDef: LabwareDefinition2,
+  labwareDef: LabwareDefinition,
   height: number
 ): boolean => labwareDef.dimensions.zDimension > height
 

--- a/shared-data/js/helpers/labwareInference.ts
+++ b/shared-data/js/helpers/labwareInference.ts
@@ -6,7 +6,7 @@ import uniqWith from 'lodash/uniqWith'
 
 import type {
   LabwareBrand,
-  LabwareDefinition2,
+  LabwareDefinition,
   LabwareWell,
   LabwareWellGroupMetadata,
   LabwareWellShapeProperties,
@@ -27,7 +27,7 @@ export interface LabwareWellGroupProperties {
 const ROUNDING_PRECISION = 2
 
 export function getUniqueWellProperties(
-  definition: LabwareDefinition2
+  definition: LabwareDefinition
 ): LabwareWellGroupProperties[] {
   const { groups, wells, dimensions } = definition
 

--- a/shared-data/js/helpers/labwareInference.ts
+++ b/shared-data/js/helpers/labwareInference.ts
@@ -4,6 +4,8 @@ import sortedUniq from 'lodash/sortedUniq'
 import uniq from 'lodash/uniq'
 import uniqWith from 'lodash/uniqWith'
 
+import { getSchema2Dimensions } from './labwareSchemaShims'
+
 import type {
   LabwareBrand,
   LabwareDefinition,
@@ -29,7 +31,7 @@ const ROUNDING_PRECISION = 2
 export function getUniqueWellProperties(
   definition: LabwareDefinition
 ): LabwareWellGroupProperties[] {
-  const { groups, wells, dimensions } = definition
+  const { groups, wells } = definition
 
   return groups.map(group => {
     const wellProps = group.wells.map(n => wells[n])
@@ -49,6 +51,7 @@ export function getUniqueWellProperties(
 
     const xStart = wellProps[0]?.x ?? 0
     const yStart = wellProps[0]?.y ?? 0
+    const { yDimension } = getSchema2Dimensions(definition)
 
     return {
       metadata: group.metadata,
@@ -56,7 +59,7 @@ export function getUniqueWellProperties(
       xSpacing: getSpacingIfUniform(wellProps, 'x'),
       ySpacing: getSpacingIfUniform(wellProps, 'y'),
       xOffsetFromLeft: xStart,
-      yOffsetFromTop: round(dimensions.yDimension - yStart, ROUNDING_PRECISION),
+      yOffsetFromTop: round(yDimension - yStart, ROUNDING_PRECISION),
       wellCount: wellProps.length,
       depth: getIfConsistent(wellDepths),
       totalLiquidVolume: getIfConsistent(wellVolumes),

--- a/shared-data/js/helpers/labwareSchemaShims.ts
+++ b/shared-data/js/helpers/labwareSchemaShims.ts
@@ -1,0 +1,61 @@
+/** Compatibility shims to ease transitioning between with labware schemas 2 and 3. */
+
+import type { LabwareDefinition, LabwareDefinition2 } from '../types'
+
+/** Return dimensions of the total labware bounding box in the style of labware schema 2. */
+export function getSchema2Dimensions(
+  definition: LabwareDefinition
+): LabwareDefinition2['dimensions'] {
+  if (definition.schemaVersion === 2) {
+    return definition.dimensions
+  } else {
+    const { backLeftBottom, frontRightTop } = definition.extents.total
+    const xDimension = frontRightTop.x - backLeftBottom.x
+    const yDimension = backLeftBottom.y - frontRightTop.y
+    const zDimension = frontRightTop.z - backLeftBottom.z
+    return { xDimension, yDimension, zDimension }
+  }
+}
+
+/**
+ * Return a definition's cornerOffsetFromSlot in the style of labware schema 2.
+ *
+ * @deprecated This is probably an inherently wrong interface to attempt, for a couple
+ * reasons.
+ *
+ * FIRST, depending on what the call site does with this, it might expect the return
+ * value to be either:
+ *
+ * - The vector from the (-x, -y) corner of the parent slot to the (-x, -y) corner of
+ *   the labware
+ * - The vector from the (-x, -y) corner of the parent slot to the origin of the
+ *   labware
+ *
+ * In labware schema 2, these were the same thing, but not in schema 3.
+ *
+ * SECOND, in labware schema 2, how a child labware sits on its parent is almost
+ * entirely a function of the child's definition. In labware schema 3, it is
+ * much more dependent on information only available in the parent. For example, to
+ * line up a child's well A1 with a parent's well A1, we need to know where the
+ * parent's well A1 is. (Schema 2 just did not attempt to support that).
+ *
+ * For schema-2 definitions, this will return cornerOffsetFromSlot as-is.
+ *
+ * For schema-3 definitions, this currently returns the placeholder (12, 34, 56), which
+ * is certainly wrong and will cause all manner of visual mayhem, but at least it's
+ * wrong in an obvious way and it unblocks importing schema-3 definitions. Solving this
+ * properly is call-site-dependent, as described above.
+ */
+export function getSchema2CornerOffsetFromSlot(
+  definition: LabwareDefinition
+): LabwareDefinition2['cornerOffsetFromSlot'] {
+  if (definition.schemaVersion === 2) {
+    return definition.cornerOffsetFromSlot
+  } else {
+    return {
+      x: 12,
+      y: 34,
+      z: 56,
+    }
+  }
+}

--- a/shared-data/js/helpers/parseProtocolCommands.ts
+++ b/shared-data/js/helpers/parseProtocolCommands.ts
@@ -14,7 +14,7 @@ import type {
 } from '../../command/types'
 import type { PipetteName } from '../pipettes'
 import type {
-  LabwareDefinition2,
+  LabwareDefinition,
   Liquid,
   LoadedLabware,
   LoadedModule,
@@ -146,7 +146,7 @@ export function getTopLabwareInfo(
   currentStackHeight: number = 0
 ): {
   topLabwareId: string
-  topLabwareDefinition?: LabwareDefinition2
+  topLabwareDefinition?: LabwareDefinition
   topLabwareDisplayName?: string
 } {
   const nestedCommand = loadLabwareCommands.find(

--- a/shared-data/js/helpers/validateCustomLabwareHelper.ts
+++ b/shared-data/js/helpers/validateCustomLabwareHelper.ts
@@ -1,4 +1,4 @@
-import type { LabwareDefinition2 } from '..'
+import type { LabwareDefinition } from '..'
 
 /**
  * This function is used to help validate that the wells and ordering matches in
@@ -8,7 +8,7 @@ import type { LabwareDefinition2 } from '..'
  * @returns A boolean for if they exist
  */
 export const validateCustomLabwareHelper = (
-  definition?: LabwareDefinition2 | null
+  definition?: LabwareDefinition | null
 ): boolean => {
   if (definition == null) {
     return false

--- a/shared-data/js/helpers/wellSets.ts
+++ b/shared-data/js/helpers/wellSets.ts
@@ -17,7 +17,7 @@ import { get96Channel384WellPlateWells, getLabwareDefURI, orderWells } from '.'
 import { getWellNamePerMultiTip } from './getWellNamePerMultiTip'
 
 import type {
-  LabwareDefinition2,
+  LabwareDefinition,
   NozzleLayoutConfig,
   PipetteV2Specs,
 } from '../types'
@@ -26,7 +26,7 @@ type WellSetByPrimaryWell = string[][]
 
 // Compute all well sets for a labware def (non-memoized)
 function _getAllWellSetsForLabware(
-  labwareDef: LabwareDefinition2
+  labwareDef: LabwareDefinition
 ): WellSetByPrimaryWell {
   const allWells: string[] = Object.keys(labwareDef.wells)
 
@@ -52,7 +52,7 @@ export interface NozzleLayoutDetails {
 }
 
 export interface WellSetForMultiChannelParams {
-  labwareDef: LabwareDefinition2
+  labwareDef: LabwareDefinition
   wellName: string
   channels: 8 | 96
   pipetteNozzleDetails?: NozzleLayoutDetails
@@ -61,7 +61,7 @@ export interface WellSetForMultiChannelParams {
 // creates memoized getAllWellSetsForLabware + getWellSetForMultichannel fns.
 export interface WellSetHelpers {
   getAllWellSetsForLabware: (
-    labwareDef: LabwareDefinition2
+    labwareDef: LabwareDefinition
   ) => WellSetByPrimaryWell
 
   /** Given a well for a labware, returns the well set it belongs to (or null)
@@ -78,7 +78,7 @@ export interface WellSetHelpers {
 
   canPipetteUseLabware: (
     pipetteSpec: PipetteV2Specs,
-    labwareDef?: LabwareDefinition2,
+    labwareDef?: LabwareDefinition,
     trashName?: string
   ) => boolean
 }
@@ -86,13 +86,13 @@ export interface WellSetHelpers {
 export const makeWellSetHelpers = (): WellSetHelpers => {
   const cache: Partial<{
     [labwareDefURI: string]: {
-      labwareDef: LabwareDefinition2
+      labwareDef: LabwareDefinition
       wellSetByPrimaryWell: WellSetByPrimaryWell
     } | null
   }> = {}
 
   const getAllWellSetsForLabware = (
-    labwareDef: LabwareDefinition2
+    labwareDef: LabwareDefinition
   ): WellSetByPrimaryWell => {
     const labwareDefURI = getLabwareDefURI(labwareDef)
     const c = cache[labwareDefURI]
@@ -217,7 +217,7 @@ export const makeWellSetHelpers = (): WellSetHelpers => {
 
   const canPipetteUseLabware = (
     pipetteSpec: PipetteV2Specs,
-    labwareDef?: LabwareDefinition2,
+    labwareDef?: LabwareDefinition,
     trashName?: string
   ): boolean => {
     if (pipetteSpec.channels === 1 || trashName != null) {

--- a/shared-data/js/labware.ts
+++ b/shared-data/js/labware.ts
@@ -13,8 +13,8 @@ import labwareSchemaV3 from '../labware/schemas/3.json'
 
 import type {
   LabwareDefByDefURI,
+  LabwareDefinition,
   LabwareDefinition1,
-  LabwareDefinition2,
   LabwareDefinition3,
   LegacyLabwareDefByName,
 } from './types'
@@ -23,9 +23,7 @@ import type {
 // that instead, but using it gives me obscure "TypeError: getLabwareDefURI is not a function"
 // errors in certain test files. Some kind of circular dependency problem? Some kind of
 // mocking problem?
-function getLabwareDefURI(
-  def: LabwareDefinition2 | LabwareDefinition3
-): string {
+function getLabwareDefURI(def: LabwareDefinition): string {
   return `${def.namespace}/${def.parameters.loadName}/${def.version}`
 }
 
@@ -38,7 +36,7 @@ const schema1DefinitionsByPath: Record<
 })
 const schema2DefinitionsByPath: Record<
   string,
-  LabwareDefinition2
+  LabwareDefinition
 > = import.meta.glob('../labware/definitions/2/*/*.json', {
   eager: true,
   import: 'default',
@@ -76,7 +74,7 @@ const schema3DefinitionsByURI = Object.fromEntries(
 // getAllDefinitions() is that getAllDefinitions() has potentially dangerous caching
 // behavior (see the todo comment there). Delete this in favor of getAllDefinitions()
 // when that's resolved.
-export const getAllLabwareDefs = (): Record<string, LabwareDefinition2> =>
+export const getAllLabwareDefs = (): Record<string, LabwareDefinition> =>
   schema2DefinitionsByURI
 
 let _definitions: LabwareDefByDefURI | null = null
@@ -88,7 +86,7 @@ export function getAllDefinitions(
   if (_definitions == null) {
     _definitions = Object.values(
       getAllLabwareDefs()
-    ).reduce<LabwareDefByDefURI>((acc, labwareDef: LabwareDefinition2) => {
+    ).reduce<LabwareDefByDefURI>((acc, labwareDef: LabwareDefinition) => {
       const labwareDefURI = getLabwareDefURI(labwareDef)
       return blockList.includes(labwareDef.parameters.loadName)
         ? acc

--- a/shared-data/js/labware.ts
+++ b/shared-data/js/labware.ts
@@ -9,6 +9,7 @@ import fixtureTiprack10ul from '../labware/fixtures/2/fixture_tiprack_10_ul.json
 import fixtureTiprack300ul from '../labware/fixtures/2/fixture_tiprack_300_ul.json'
 import fixtureTrash from '../labware/fixtures/2/fixture_trash.json'
 import labwareSchemaV2 from '../labware/schemas/2.json'
+import labwareSchemaV3 from '../labware/schemas/3.json'
 
 import type {
   LabwareDefByDefURI,
@@ -104,6 +105,7 @@ export function getAllLegacyDefinitions(): LegacyLabwareDefByName {
 
 export {
   labwareSchemaV2,
+  labwareSchemaV3,
   fixture96Plate,
   fixture12Trough,
   fixture24Tuberack,

--- a/shared-data/js/labware.ts
+++ b/shared-data/js/labware.ts
@@ -12,9 +12,10 @@ import labwareSchemaV2 from '../labware/schemas/2.json'
 import labwareSchemaV3 from '../labware/schemas/3.json'
 
 import type {
-  LabwareDefByDefURI,
+  LabwareDef2ByDefURI,
   LabwareDefinition,
   LabwareDefinition1,
+  LabwareDefinition2,
   LabwareDefinition3,
   LegacyLabwareDefByName,
 } from './types'
@@ -36,7 +37,7 @@ const schema1DefinitionsByPath: Record<
 })
 const schema2DefinitionsByPath: Record<
   string,
-  LabwareDefinition
+  LabwareDefinition2
 > = import.meta.glob('../labware/definitions/2/*/*.json', {
   eager: true,
   import: 'default',
@@ -74,19 +75,19 @@ const schema3DefinitionsByURI = Object.fromEntries(
 // getAllDefinitions() is that getAllDefinitions() has potentially dangerous caching
 // behavior (see the todo comment there). Delete this in favor of getAllDefinitions()
 // when that's resolved.
-export const getAllLabwareDefs = (): Record<string, LabwareDefinition> =>
+export const getAllLabwareDefs = (): Record<string, LabwareDefinition2> =>
   schema2DefinitionsByURI
 
-let _definitions: LabwareDefByDefURI | null = null
+let _definitions: LabwareDef2ByDefURI | null = null
 export function getAllDefinitions(
   blockList: string[] = []
-): LabwareDefByDefURI {
+): LabwareDef2ByDefURI {
   // todo(mm, 2025-02-27): This looks suspicious: if we're called twice with two
   // different blockList values, we'll return the same results for both.
   if (_definitions == null) {
     _definitions = Object.values(
       getAllLabwareDefs()
-    ).reduce<LabwareDefByDefURI>((acc, labwareDef: LabwareDefinition) => {
+    ).reduce<LabwareDef2ByDefURI>((acc, labwareDef: LabwareDefinition2) => {
       const labwareDefURI = getLabwareDefURI(labwareDef)
       return blockList.includes(labwareDef.parameters.loadName)
         ? acc

--- a/shared-data/js/labwareTools/__tests__/createIrregularLabware.test.ts
+++ b/shared-data/js/labwareTools/__tests__/createIrregularLabware.test.ts
@@ -12,7 +12,7 @@ import fixture_irregular_example_1 from '../../../labware/fixtures/2/fixture_irr
 import { sortWells, splitWellsOnColumn } from '../../helpers/index'
 
 import type { IrregularLabwareProps } from '..'
-import type { LabwareDefinition2, LabwareWellProperties } from '../../types'
+import type { LabwareDefinition, LabwareWellProperties } from '../../types'
 
 // NOTE: loadName needs to be replaced here b/c fixture has a non-default loadName
 const exampleLabware1 = {
@@ -21,7 +21,7 @@ const exampleLabware1 = {
     ...fixture_irregular_example_1.parameters,
     loadName: 'generic_55_tuberack_50x3ml_5x10ml',
   },
-} as LabwareDefinition2
+} as LabwareDefinition
 
 describe('test helper functions', () => {
   it('Well name generated correctly', () => {
@@ -97,7 +97,7 @@ describe('test helper functions', () => {
 })
 
 describe('test createIrregularLabware function', () => {
-  let labware1: LabwareDefinition2
+  let labware1: LabwareDefinition
   let labware1Args: IrregularLabwareProps
 
   beforeEach(() => {

--- a/shared-data/js/labwareTools/__tests__/createLabware.test.ts
+++ b/shared-data/js/labwareTools/__tests__/createLabware.test.ts
@@ -8,7 +8,7 @@ import fixture_regular_example_2 from '../../../labware/fixtures/2/fixture_regul
 
 import type { RegularLabwareProps } from '..'
 import type {
-  LabwareDefinition,
+  LabwareDefinition2,
   LabwareOffset,
   LabwareWellProperties,
 } from '../../types'
@@ -20,7 +20,7 @@ const exampleLabware1 = {
     ...fixture_regular_example_1.parameters,
     loadName: 'opentrons_2_wellplate_100ul',
   },
-} as LabwareDefinition
+} as LabwareDefinition2
 
 const exampleLabware2 = {
   ...fixture_regular_example_2,
@@ -28,11 +28,11 @@ const exampleLabware2 = {
     ...fixture_regular_example_2.parameters,
     loadName: 'generic_6_wellplate_1ml',
   },
-} as LabwareDefinition
+} as LabwareDefinition2
 
 describe('createLabware', () => {
-  let labware1: LabwareDefinition
-  let labware2: LabwareDefinition
+  let labware1: LabwareDefinition2
+  let labware2: LabwareDefinition2
   let labware2Args: RegularLabwareProps
   let well1: LabwareWellProperties
   let well2: LabwareWellProperties

--- a/shared-data/js/labwareTools/__tests__/createLabware.test.ts
+++ b/shared-data/js/labwareTools/__tests__/createLabware.test.ts
@@ -8,7 +8,7 @@ import fixture_regular_example_2 from '../../../labware/fixtures/2/fixture_regul
 
 import type { RegularLabwareProps } from '..'
 import type {
-  LabwareDefinition2,
+  LabwareDefinition,
   LabwareOffset,
   LabwareWellProperties,
 } from '../../types'
@@ -20,7 +20,7 @@ const exampleLabware1 = {
     ...fixture_regular_example_1.parameters,
     loadName: 'opentrons_2_wellplate_100ul',
   },
-} as LabwareDefinition2
+} as LabwareDefinition
 
 const exampleLabware2 = {
   ...fixture_regular_example_2,
@@ -28,11 +28,11 @@ const exampleLabware2 = {
     ...fixture_regular_example_2.parameters,
     loadName: 'generic_6_wellplate_1ml',
   },
-} as LabwareDefinition2
+} as LabwareDefinition
 
 describe('createLabware', () => {
-  let labware1: LabwareDefinition2
-  let labware2: LabwareDefinition2
+  let labware1: LabwareDefinition
+  let labware2: LabwareDefinition
   let labware2Args: RegularLabwareProps
   let well1: LabwareWellProperties
   let well2: LabwareWellProperties

--- a/shared-data/js/labwareTools/index.ts
+++ b/shared-data/js/labwareTools/index.ts
@@ -15,7 +15,7 @@ import {
 
 import type {
   LabwareBrand as Brand,
-  LabwareDefinition2 as Definition,
+  LabwareDefinition as Definition,
   LabwareDimensions as Dimensions,
   LabwareWellProperties as InputWell,
   LabwareOffset,

--- a/shared-data/js/labwareTools/index.ts
+++ b/shared-data/js/labwareTools/index.ts
@@ -15,7 +15,9 @@ import {
 
 import type {
   LabwareBrand as Brand,
-  LabwareDefinition as Definition,
+  // todo(mm, 2025-05-13): We probably want these functions to be able to emit
+  // LabwareDefinition3, too. https://opentrons.atlassian.net/browse/EXEC-1491
+  LabwareDefinition2 as Definition,
   LabwareDimensions as Dimensions,
   LabwareWellProperties as InputWell,
   LabwareOffset,
@@ -57,6 +59,8 @@ type InputWellGroup = Omit<WellGroup, 'wells'>
 export interface BaseLabwareProps {
   metadata: Metadata
   parameters: InputParams
+  // todo(mm, 2025-05-13): dimensions is currently coupled to LabwareDefinition2.
+  // Replace it with something that works with LabwareDefinition3.
   dimensions: Dimensions
   brand?: Brand
   version?: number

--- a/shared-data/js/types.ts
+++ b/shared-data/js/types.ts
@@ -309,6 +309,10 @@ export interface LabwareDefinition3 {
   innerLabwareGeometry?: Record<string, InnerWellGeometry> | null
 }
 
+// LabwareDefinition1 deliberately excluded.
+// I'm pretty sure nothing in the frontend needs to deal with it anymore.
+export type LabwareDefinition = LabwareDefinition2 | LabwareDefinition3
+
 export interface LabwareDefByDefURI {
   [defUri: string]: LabwareDefinition2
 }

--- a/shared-data/js/types.ts
+++ b/shared-data/js/types.ts
@@ -314,7 +314,7 @@ export interface LabwareDefinition3 {
 export type LabwareDefinition = LabwareDefinition2 | LabwareDefinition3
 
 export interface LabwareDefByDefURI {
-  [defUri: string]: LabwareDefinition2
+  [defUri: string]: LabwareDefinition
 }
 export interface LegacyLabwareDefByName {
   [name: string]: LabwareDefinition1

--- a/shared-data/js/types.ts
+++ b/shared-data/js/types.ts
@@ -313,8 +313,8 @@ export interface LabwareDefinition3 {
 // I'm pretty sure nothing in the frontend needs to deal with it anymore.
 export type LabwareDefinition = LabwareDefinition2 | LabwareDefinition3
 
-export interface LabwareDefByDefURI {
-  [defUri: string]: LabwareDefinition
+export interface LabwareDef2ByDefURI {
+  [defUri: string]: LabwareDefinition2
 }
 export interface LegacyLabwareDefByName {
   [name: string]: LabwareDefinition1

--- a/shared-data/labware/fixtures/3/fixture_corning_24_plate.json
+++ b/shared-data/labware/fixtures/3/fixture_corning_24_plate.json
@@ -16,7 +16,7 @@
   },
   "schemaVersion": 3,
   "version": 3,
-  "namespace": "opentrons",
+  "namespace": "fixture",
   "metadata": {
     "displayName": "Corning 24 Well Plate 3.4 mL Flat",
     "displayVolumeUnits": "mL",

--- a/shared-data/labware/fixtures/3/index.ts
+++ b/shared-data/labware/fixtures/3/index.ts
@@ -1,0 +1,4 @@
+import fixture_2_plate from './fixture_2_plate.json'
+import fixture_corning_24_plate from './fixture_corning_24_plate.json'
+
+export { fixture_2_plate, fixture_corning_24_plate }

--- a/step-generation/src/utils/constructInvariantContextFromRunCommands.ts
+++ b/step-generation/src/utils/constructInvariantContextFromRunCommands.ts
@@ -28,19 +28,29 @@ export function constructInvariantContextFromRunCommands(
     (acc: InvariantContext, command: RunTimeCommand) => {
       if (command.commandType === 'loadLabware' && command.result != null) {
         const result = command.result
-        const labwareEntities: LabwareEntities = {
-          ...acc.labwareEntities,
-          [result.labwareId]: {
-            id: result.labwareId,
-            labwareDefURI: getLabwareDefURI(result.definition),
-            def: result.definition,
-            //  ProtocolTimelineScrubber won't need access to pythonNames
-            pythonName: 'n/a',
-          },
-        }
-        return {
-          ...acc,
-          labwareEntities,
+
+        if (result.definition.schemaVersion === 2) {
+          const labwareEntities: LabwareEntities = {
+            ...acc.labwareEntities,
+            [result.labwareId]: {
+              id: result.labwareId,
+              labwareDefURI: getLabwareDefURI(result.definition),
+              def: result.definition,
+              //  ProtocolTimelineScrubber won't need access to pythonNames
+              pythonName: 'n/a',
+            },
+          }
+          return {
+            ...acc,
+            labwareEntities,
+          }
+        } else {
+          // todo(mm, 2025-05-16):
+          // loadLabware commands from the backend can have schema 3 labware definitions.
+          // step-generation, and this function by extension, are not prepared to handle
+          // schema 3 yet. Just ignore those definitions for now.
+          // See also the loadPipette handling, below.
+          return acc
         }
       } else if (
         command.commandType === 'loadModule' &&
@@ -79,10 +89,11 @@ export function constructInvariantContextFromRunCommands(
               c.result.labwareId === labwareId
           ) ?? null
 
-        const tiprackLabwareDef =
-          matchingCommand != null && matchingCommand.result != null
-            ? matchingCommand.result.definition ?? null
-            : null
+        let tiprackLabwareDef = matchingCommand?.result?.definition ?? null
+        // We're not prepared to handle labware schema 3 yet. See the todo comment
+        // in the loadLabware handling, above.
+        if (tiprackLabwareDef?.schemaVersion === 3) tiprackLabwareDef = null
+
         const specs: any = getPipetteSpecsV2(command.params.pipetteName)
 
         const pipetteEntities: PipetteEntities = {

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -59,6 +59,9 @@ export default defineConfig({
       '@opentrons/shared-data/labware/fixtures/2': path.resolve(
         './shared-data/labware/fixtures/2/index.ts'
       ),
+      '@opentrons/shared-data/labware/fixtures/3': path.resolve(
+        './shared-data/labware/fixtures/3/index.ts'
+      ),
       '@opentrons/shared-data': path.resolve('./shared-data/js/index.ts'),
       '@opentrons/step-generation': path.resolve(
         './step-generation/src/index.ts'

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -35,6 +35,9 @@ export default mergeConfig(
         '@opentrons/shared-data/labware/fixtures/2': path.resolve(
           './shared-data/labware/fixtures/2/index.ts'
         ),
+        '@opentrons/shared-data/labware/fixtures/3': path.resolve(
+          './shared-data/labware/fixtures/3/index.ts'
+        ),
         '@opentrons/shared-data': path.resolve('./shared-data/js/index.ts'),
         '@opentrons/step-generation': path.resolve(
           './step-generation/src/index.ts'


### PR DESCRIPTION
## Overview

This closes RQA-3998 and takes a step towards EXEC-1278.

## Test Plan and Hands on Testing

* [x] Analyze a protocol that uses labware schema 3 in the desktop app.
* [x] Import a schema 3 custom labware definition into the desktop app.

## Changelog

This basically does a mass search-and-replace of `LabwareDefinition2` -> `LabwareDefinition2 | LabwareDefinition3`.

Much of the time, this has no behavioral effect.

However, a lot of places in the frontend do math on the labware's `cornerOffsetFromSlot` and `dimensions`. Those are the two things that have changed so far from schema 2 to 3. (The other big change is "locating features", which hasn't happened yet.) All of that math needs to be evaluated on a case-by-case basis and ported to the schema 3 way of doing things, replacing `cornerOffsetFromSlot` and `dimensions` with `extents`.

**For scope reasons, this PR does not do that thinking. This PR naively shims the math, knowingly causing visual errors:**

<img width="489" alt="Screenshot 2025-05-20 at 4 18 43 PM" src="https://github.com/user-attachments/assets/80735b21-093d-4f8e-a37c-3eea502e5784" />

The idea is to do just enough to allow us to import custom schema-3 labware, and to run protocols that use schema-3 labware. This makes testing easier, especially backend testing.

The rendering will be fixed in follow-up work.

The projects affected in this way are these:

* app (both desktop and ODD)
* components
* shared-data

Whereas these projects are, for now, remaining pinned to schema 2, for scope reasons:

* labware-library
* labware-creator
* step-generation
* Quick Transfer Protocols (because they're based on step-generation)
* protocol-designer

## Review requests

Am I glossing over anything that deserves closer attention?

## Risk assessment

Low.