### PR TITLE
fix(api): improve Flex Stacker shuttle homing routine

### DIFF
--- a/api/src/opentrons/hardware_control/modules/flex_stacker.py
+++ b/api/src/opentrons/hardware_control/modules/flex_stacker.py
@@ -520,11 +520,11 @@ class FlexStacker(mod_abc.AbstractModule):
         await self._reader.get_limit_switch_status()
         await self._reader.get_platform_sensor_state()
 
-        """Z axis is unknown, lets move it up in case it is holding a labware"""
+        # Z axis is unknown, lets move it up in case it is holding a labware
         if self.limit_switch_status[StackerAxis.Z] == StackerAxisState.UNKNOWN:
             await self.home_axis(StackerAxis.Z, Direction.EXTEND)
 
-        """Z must now be either extended or retracted, move on to the X"""
+        # Z must now be either extended or retracted, move on to the X
         if (
             self.platform_state == PlatformState.UNKNOWN
             or self.limit_switch_status[StackerAxis.X] == StackerAxisState.UNKNOWN
@@ -534,13 +534,12 @@ class FlexStacker(mod_abc.AbstractModule):
             else:
                 await self.home_axis(StackerAxis.X, Direction.EXTEND)
 
-        """Z+X must now be either extended or retracted, move on to the latch"""
+        # Z+X must now be either extended or retracted, move on to the latch
         if not ignore_latch:
             await self.close_latch()
 
-        """Retract X if it's not already"""
+        # Finally, retract Z and extend X if they are not already
         await self.home_axis(StackerAxis.Z, Direction.RETRACT)
-        """Extend X if it's not already"""
         await self.home_axis(StackerAxis.X, Direction.EXTEND)
 
     async def labware_detected(self, axis: StackerAxis, direction: Direction) -> bool:

--- a/api/src/opentrons/hardware_control/modules/flex_stacker.py
+++ b/api/src/opentrons/hardware_control/modules/flex_stacker.py
@@ -518,16 +518,29 @@ class FlexStacker(mod_abc.AbstractModule):
         """
         await self._reader.get_installation_detected()
         await self._reader.get_limit_switch_status()
-        # we should always be able to home the X axis first
-        await self.home_axis(StackerAxis.X, Direction.RETRACT)
-        # If latch is open, we must first close it
-        if not ignore_latch and self.latch_state == LatchState.OPENED:
-            if self.limit_switch_status[StackerAxis.Z] != StackerAxisState.RETRACTED:
-                # it was likely in the middle of a dispense/store command
-                # z should be moved up before we can safely close the latch
-                await self.home_axis(StackerAxis.Z, Direction.EXTEND)
+        await self._reader.get_platform_sensor_state()
+
+        """Z axis is unknown, lets move it up in case it is holding a labware"""
+        if self.limit_switch_status[StackerAxis.Z] == StackerAxisState.UNKNOWN:
+            await self.home_axis(StackerAxis.Z, Direction.EXTEND)
+
+        """Z must now be either extended or retracted, move on to the X"""
+        if (
+            self.platform_state == PlatformState.UNKNOWN
+            or self.limit_switch_status[StackerAxis.X] == StackerAxisState.UNKNOWN
+        ):
+            if self.limit_switch_status[StackerAxis.Z] == StackerAxisState.EXTENDED:
+                await self.home_axis(StackerAxis.X, Direction.RETRACT)
+            else:
+                await self.home_axis(StackerAxis.X, Direction.EXTEND)
+
+        """Z+X must now be either extended or retracted, move on to the latch"""
+        if not ignore_latch:
             await self.close_latch()
+
+        """Retract X if it's not already"""
         await self.home_axis(StackerAxis.Z, Direction.RETRACT)
+        """Extend X if it's not already"""
         await self.home_axis(StackerAxis.X, Direction.EXTEND)
 
     async def labware_detected(self, axis: StackerAxis, direction: Direction) -> bool:


### PR DESCRIPTION
# Overview
Before the platform sensor implementation, we defensively homed the Flex Stacker to prevent platform collisions. This involved always retracting the X-axis first, which was annoying because it moved in the opposite direction of its home position. Now that we have platform sensor data, we can make fewer assumptions and home the stacker more intelligently.


