### PR TITLE
fix(app): blink led when there is only one module attached.

### DIFF
--- a/app/src/organisms/ModuleWizardFlows/SelectModule.tsx
+++ b/app/src/organisms/ModuleWizardFlows/SelectModule.tsx
@@ -154,6 +154,7 @@ export const SelectModule = (props: SelectModuleProps): JSX.Element | null => {
       >
         <PrimaryButton
           onClick={() => {
+            sendIdentifyModule(mod, true)
             handleStartSetup(mod)
           }}
         >


### PR DESCRIPTION
# Overview

Blink the module when there is only one new module added, as the logic for the multi-module setup screen works differently.

## Test Plan and Hands on Testing

- [x] Make sure the module blinks when there's only one new module

## Changelog

- Blink module when clicking on the continue button in module setup

## Review requests
## Risk assessment
