### PR TITLE
test(api): Minor improvements to a Hypothesis test

### DIFF
--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -525,7 +525,6 @@ async def test_gantry_load_transform(
     load_configs: LoadConfigs,
     load: GantryLoad,
 ) -> None:
-
     for pair in load_configs:
         if pair[0] == OT3Mount.GRIPPER:
             gripper_config = gc.load(pair[1]["model"])
@@ -918,7 +917,6 @@ async def test_liquid_probe(
     with patch.object(
         hardware_backend, "liquid_probe", AsyncMock(spec=hardware_backend.liquid_probe)
     ) as mock_liquid_probe:
-
         # make sure aspirate while sensing reverses direction
         mock_liquid_probe.return_value = 140
         fake_settings_aspirate = LiquidProbeSettings(
@@ -1012,7 +1010,6 @@ async def test_liquid_probe_plunger_moves(
     with patch.object(
         hardware_backend, "liquid_probe", AsyncMock(spec=hardware_backend.liquid_probe)
     ) as mock_liquid_probe:
-
         mock_liquid_probe.side_effect = [
             PipetteLiquidNotFoundError,
             PipetteLiquidNotFoundError,
@@ -1122,7 +1119,6 @@ async def test_liquid_probe_mount_moves(
     with patch.object(
         hardware_backend, "liquid_probe", AsyncMock(spec=hardware_backend.liquid_probe)
     ):
-
         fake_max_z_dist = 10.0
         config = ot3_hardware.config.liquid_sense
         mount_speed = config.mount_speed
@@ -1569,7 +1565,6 @@ async def test_gripper_action_works_with_gripper(
     gripper_present: None,
     needs_calibration: bool,
 ) -> None:
-
     gripper_config = gc.load(GripperModel.v1)
     instr_data = AttachedGripper(config=gripper_config, id="test")
     ot3_hardware._backend._attached_instruments[OT3Mount.GRIPPER] = {
@@ -1998,7 +1993,6 @@ async def test_move_axes(
     input_position: Dict[Axis, float],
     expected_move_pos: OrderedDict[Axis, float],
 ) -> None:
-
     await ot3_hardware.move_axes(position=input_position)
     mock_check_motor.return_value = True
 
@@ -2019,7 +2013,6 @@ async def test_move_expect_stall_flag(
     mock_backend_move: AsyncMock,
     expect_stalls: bool,
 ) -> None:
-
     expected = HWStopCondition.stall if expect_stalls else HWStopCondition.none
 
     await ot3_hardware.move_to(Mount.LEFT, Point(0, 0, 0), expect_stalls=expect_stalls)
@@ -2303,7 +2296,6 @@ async def test_update_position_estimation(
 async def test_refresh_positions(
     ot3_hardware: ThreadManager[OT3API], hardware_backend: OT3Simulator
 ) -> None:
-
     ot3_hardware._current_position.clear()
     ot3_hardware._encoder_position.clear()
 
@@ -2320,7 +2312,6 @@ async def test_refresh_positions(
         "update_encoder_position",
         AsyncMock(spec=hardware_backend.update_encoder_position),
     ) as mock_encoder:
-
         mock_pos.return_value = {ax: 100 for ax in Axis}
         mock_encoder.return_value = {ax: 99 for ax in Axis}
 
@@ -2392,7 +2383,6 @@ async def test_home_axis(
             wraps=hardware_backend.update_motor_estimation,
         ),
     ) as mock_estimate:
-
         await ot3_hardware._home_axis(axis)
 
         if not stepper_ok and encoder_ok:

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -774,6 +774,11 @@ async def test_blow_out_position(
     load_configs: Dict[OT3Mount, PipetteLoadConfig],
     blowout_volume: float,
 ) -> None:
+    # Each Hypothesis example will share the same ot3_hardware value (they are all
+    # within "a single function", as the function-scoped ot3_hardware fixture sees it).
+    # Do our best to isolate them.
+    await ot3_hardware.reset()
+
     liquid_class = LiquidClasses.default
     for mount, configs in load_configs.items():
         if configs["channels"] == 96:

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -817,6 +817,7 @@ async def test_blow_out_position(
         HealthCheck.filter_too_much,
     ],
     max_examples=20,
+    deadline=400,
 )
 async def test_blow_out_error(
     ot3_hardware: ThreadManager[OT3API],

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -810,11 +810,10 @@ async def test_blow_out_position(
 
 
 @pytest.mark.parametrize("load_configs", load_pipette_configs)
-@given(blowout_volume=strategies.floats(min_value=0, max_value=300))
+@given(data=strategies.data())
 @settings(
     suppress_health_check=[
         HealthCheck.function_scoped_fixture,
-        HealthCheck.filter_too_much,
     ],
     max_examples=20,
     deadline=400,
@@ -823,8 +822,13 @@ async def test_blow_out_error(
     ot3_hardware: ThreadManager[OT3API],
     mock_backend_get_tip_status: AsyncMock,
     load_configs: Dict[OT3Mount, PipetteLoadConfig],
-    blowout_volume: float,
+    data: strategies.DataObject,
 ) -> None:
+    # Each Hypothesis example will share the same ot3_hardware value (they are all
+    # within "a single function", as the function-scoped ot3_hardware fixture sees it).
+    # Do our best to isolate them.
+    await ot3_hardware.reset()
+
     liquid_class = LiquidClasses.default
     for mount, configs in load_configs.items():
         if configs["channels"] == 96:
@@ -840,7 +844,10 @@ async def test_blow_out_error(
         max_input_vol = (
             max_allowed_input_distance * instr_data["config"].shaft_ul_per_mm
         )
-        assume(blowout_volume > max_input_vol)
+
+        blowout_volume = data.draw(
+            strategies.floats(min_value=max_input_vol, exclude_min=True)
+        )
 
         # check that blowout does not allow input values that would blow out too far
         with pytest.raises(CommandParameterLimitViolated):


### PR DESCRIPTION
## Changelog

* `.reset()` the hardware API between tests, as a basic effort towards test isolation. The normal mechanism for test isolation, Pytest fixtures, does not coexist well with Hypothesis. (That's the `suppress_health_check=[HealthCheck.function_scoped_fixture]` thing.)
* Consistently use a test timeout of 400 ms, matching another test in this file. @ddcc4 had a recent CI failure where it took 297 ms.

  I think newer Hypothesis versions automatically disable the timeout entirely when run on CI, so I don't think we should go too far with trying to tune timeouts, but this seems fine for now.
* Tweak the way that we generate Hypothesis examples to resolve a "filtering too much" error. Instead of generating a bunch of candidate `blowout_volume`s and throwing away the ones that we don't want, only generate the ones we want in the first place.

  This technique won't work *all* the time (see the note [in the docs](https://hypothesis.readthedocs.io/en/latest/tutorial/custom-strategies.html#mixing-data-generation-and-test-code)), but it works here.

## Review requests

Does the `.reset()` thing seem right?

## Risk assessment

Low.