### PR TITLE
ci(enhance): app GitHub workflow reusable actions

### DIFF
--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -36,14 +36,14 @@ on:
       - '*.json'
       - 'yarn.lock'
       - 'scripts/**'
-  workflow_dispatch:
+  workflow_dispatch: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.ref_name != 'edge' || github.run_id}}-${{ github.ref_type != 'tag' || github.run_id }}
   cancel-in-progress: true
 
 env:
-  CI: true
+  CI: "true"
   _APP_DEPLOY_BUCKET_ROBOTSTACK: builds.opentrons.com
   _APP_DEPLOY_FOLDER_ROBOTSTACK: app
   _APP_DEPLOY_BUCKET_OT3: ot3-development.builds.opentrons.com
@@ -57,33 +57,8 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: 'actions/checkout@v4'
-      - uses: 'actions/setup-node@v4'
-        with:
-          node-version: '22.11.0'
-      - name: 'install udev'
-        run: |
-          # WORKAROUND: Remove microsoft debian repo due to https://github.com/microsoft/linux-package-repositories/issues/130. Remove line below after it is resolved
-          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
-          sudo apt-get update && sudo apt-get install libudev-dev
-      - name: 'set complex environment variables'
-        id: 'set-vars'
-        uses: actions/github-script@v6
-        with:
-          script: |
-            const { buildComplexEnvVars } = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/utils.js`)
-            buildComplexEnvVars(core, context)
-      - name: 'cache yarn cache'
-        uses: actions/cache@v3
-        with:
-          path: |
-            ${{ github.workspace }}/.npm-cache/_prebuild
-            ${{ github.workspace }}/.yarn-cache
-          key: js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
-      - name: 'setup-js'
-        run: |
-          npm config set cache ${{ github.workspace }}/.npm-cache
-          yarn config set cache-folder ${{ github.workspace }}/.yarn-cache
-          make setup-js
+      - uses: ./.github/actions/js/setup
+      - uses: ./.github/actions/environment/complex-variables
       - name: 'test frontend packages'
         run: |
           make -C app test-cov
@@ -108,45 +83,14 @@ jobs:
       - uses: 'actions/checkout@v4'
         with:
           fetch-depth: 0
-      # https://github.com/actions/checkout/issues/290
-      - name: 'Fix actions/checkout odd handling of tags'
-        if: startsWith(github.ref, 'refs/tags')
-        run: |
-          git fetch -f origin ${{ github.ref }}:${{ github.ref }}
-          git checkout ${{ github.ref }}
-      - uses: 'actions/setup-node@v4'
-        with:
-          node-version: '22.11.0'
+      - uses: ./.github/actions/git/resolve-tag
+      - uses: ./.github/actions/js/setup
+      - uses: ./.github/actions/environment/complex-variables
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
       - name: check make version
         run: make --version
-      - name: 'install libudev and libsystemd'
-        if: startsWith(matrix.os, 'ubuntu')
-        run: |
-          # WORKAROUND: Remove microsoft debian repo due to https://github.com/microsoft/linux-package-repositories/issues/130. Remove line below after it is resolved
-          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
-          sudo apt-get update && sudo apt-get install libudev-dev
-      - name: 'set complex environment variables'
-        id: 'set-vars'
-        uses: actions/github-script@v6
-        with:
-          script: |
-            const { buildComplexEnvVars } = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/utils.js`)
-            buildComplexEnvVars(core, context)
-      - name: 'cache yarn cache'
-        uses: actions/cache@v3
-        with:
-          path: |
-            ${{ github.workspace }}/.npm-cache/_prebuild
-            ${{ github.workspace }}/.yarn-cache
-          key: js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
-      - name: setup-js
-        run: |
-          npm config set cache ${{ github.workspace }}/.npm-cache
-          yarn config set cache-folder ${{ github.workspace }}/.yarn-cache
-          make setup-js
       - name: 'test native(er) packages'
         run: make test-js-internal tests="${{matrix.shell}}/src" cov_opts="--coverage=true"
       - name: 'Upload coverage report'
@@ -264,46 +208,14 @@ jobs:
       - uses: 'actions/checkout@v4'
         with:
           fetch-depth: 0
-      # https://github.com/actions/checkout/issues/290
-      - name: 'Fix actions/checkout odd handling of tags'
-        if: startsWith(github.ref, 'refs/tags')
-        run: |
-          git fetch -f origin ${{ github.ref }}:${{ github.ref }}
-          git checkout ${{ github.ref }}
-      - uses: 'actions/setup-node@v4'
-        with:
-          node-version: '22.11.0'
+      - uses: ./.github/actions/git/resolve-tag
+      - uses: ./.github/actions/js/setup
+      - uses: ./.github/actions/environment/complex-variables
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
       - name: check make version
         run: make --version
-      - name: 'install libudev and libsystemd'
-        if: startsWith(matrix.os, 'ubuntu')
-        run: |
-          # WORKAROUND: Remove microsoft debian repo due to https://github.com/microsoft/linux-package-repositories/issues/130. Remove line below after it is resolved
-          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
-          sudo apt-get update && sudo apt-get install libudev-dev
-      - name: 'set complex environment variables'
-        id: 'set-vars'
-        uses: actions/github-script@v6
-        with:
-          script: |
-            const { buildComplexEnvVars } = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/utils.js`)
-            buildComplexEnvVars(core, context)
-      - name: 'cache yarn cache'
-        uses: actions/cache@v3
-        with:
-          path: |
-            ${{ github.workspace }}/.npm-cache/_prebuild
-            ${{ github.workspace }}/.yarn-cache
-          key: js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
-      - name: setup-js
-        run: |
-          npm config set cache ${{ github.workspace }}/.npm-cache
-          yarn config set cache-folder ${{ github.workspace }}/.yarn-cache
-          make setup-js
-
       - name: 'Configure Windows code signing environment'
         if: startsWith(matrix.os, 'windows') && contains(needs.determine-build-type.outputs.type, 'release')
         shell: bash
@@ -491,40 +403,9 @@ jobs:
         uses: 'actions/checkout@v4'
         with:
           path: ./monorepo
-      # https://github.com/actions/checkout/issues/290
-      - name: 'Fix actions/checkout odd handling of tags'
-        if: startsWith(github.ref, 'refs/tags')
-        run: |
-          cd ./monorepo
-          git fetch -f origin ${{ github.ref }}:${{ github.ref }}
-          git checkout ${{ github.ref }}
-      - uses: 'actions/setup-node@v4'
-        with:
-          node-version: '22.11.0'
-      - name: 'install udev'
-        run: |
-          # WORKAROUND: Remove microsoft debian repo due to https://github.com/microsoft/linux-package-repositories/issues/130. Remove line below after it is resolved
-          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
-          sudo apt-get update && sudo apt-get install libudev-dev
-      - name: 'set complex environment variables'
-        id: 'set-vars'
-        uses: actions/github-script@v6
-        with:
-          script: |
-            const { buildComplexEnvVars } = require(`${process.env.GITHUB_WORKSPACE}/monorepo/.github/workflows/utils.js`)
-            buildComplexEnvVars(core, context)
-      - name: 'cache yarn cache'
-        uses: actions/cache@v3
-        with:
-          path: |
-            ${{ github.workspace }}/.npm-cache/_prebuild
-            ${{ github.workspace }}/.yarn-cache
-      - name: 'setup-js'
-        run: |
-          npm config set cache ${{ github.workspace }}/.npm-cache
-          yarn config set cache-folder ${{ github.workspace }}/.yarn-cache
-          cd monorepo
-          make setup-js
+      - uses: ./.github/actions/git/resolve-tag
+      - uses: ./.github/actions/js/setup
+      - uses: ./.github/actions/environment/complex-variables
       - name: 'update internal-releases releases.json'
         if: needs.determine-build-type.outputs.type == 'release' && contains(fromJSON(needs.determine-build-type.outputs.variants), 'internal-release')
         run: |

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -83,9 +83,7 @@ jobs:
       - uses: 'actions/checkout@v4'
         with:
           fetch-depth: 0
-      - uses: ./.github/actions/git/resolve-tag
       - uses: ./.github/actions/js/setup
-      - uses: ./.github/actions/environment/complex-variables
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
@@ -208,9 +206,7 @@ jobs:
       - uses: 'actions/checkout@v4'
         with:
           fetch-depth: 0
-      - uses: ./.github/actions/git/resolve-tag
       - uses: ./.github/actions/js/setup
-      - uses: ./.github/actions/environment/complex-variables
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
@@ -403,9 +399,7 @@ jobs:
         uses: 'actions/checkout@v4'
         with:
           path: ./monorepo
-      - uses: ./.github/actions/git/resolve-tag
       - uses: ./.github/actions/js/setup
-      - uses: ./.github/actions/environment/complex-variables
       - name: 'update internal-releases releases.json'
         if: needs.determine-build-type.outputs.type == 'release' && contains(fromJSON(needs.determine-build-type.outputs.variants), 'internal-release')
         run: |

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -58,7 +58,6 @@ jobs:
     steps:
       - uses: 'actions/checkout@v4'
       - uses: ./.github/actions/js/setup
-      - uses: ./.github/actions/environment/complex-variables
       - name: 'test frontend packages'
         run: |
           make -C app test-cov


### PR DESCRIPTION
## Overview

Instead of repeated code, use the shared actions.  This includes caching simplification as we no longer need the anything custom.  The GitHub UI allows cache deletions now.

These steps have been running for months in `.github/workflows/pd-test-build-deploy.yaml`