### PR TITLE
fix(api): Flex Stacker simplify prepare_for_action() 

### DIFF
--- a/api/src/opentrons/hardware_control/modules/flex_stacker.py
+++ b/api/src/opentrons/hardware_control/modules/flex_stacker.py
@@ -420,14 +420,6 @@ class FlexStacker(mod_abc.AbstractModule):
 
         # Move platform along the X then Z axis
         await self._move_and_home_axis(StackerAxis.X, Direction.RETRACT, OFFSET_MD)
-
-        # TODO: (AA 2025-04-03) - The EVT Flex Stacker hardware has issues
-        # reading the platform sensor on the extended side. This is a temporary
-        # workaround to avoid the sensor check on the extended side and should be
-        # removed once dvt hardware is available. We should move this check
-        # to `prepare_for_action` instead
-        await self.verify_shuttle_location(PlatformState.RETRACTED)
-
         await self._move_and_home_axis(StackerAxis.Z, Direction.EXTEND, OFFSET_SM)
 
         # Transfer
@@ -456,13 +448,6 @@ class FlexStacker(mod_abc.AbstractModule):
         offset = OFFSET_MD if labware_height < MEDIUM_LABWARE_Z_LIMIT else OFFSET_LG * 2
         distance = MAX_TRAVEL[StackerAxis.Z] - (labware_height / 2) - offset
         await self._move_and_home_axis(StackerAxis.X, Direction.RETRACT, OFFSET_MD)
-
-        # TODO: (AA 2025-04-03) - The EVT Flex Stacker hardware has issues
-        # reading the platform sensor on the extended side. This is a temporary
-        # workaround to avoid the sensor check on the extended side and should be
-        # removed once dvt hardware is available. We should move this check
-        # to `prepare_for_action` instead
-        await self.verify_shuttle_location(PlatformState.RETRACTED)
 
         if enforce_shuttle_lw_sensing:
             await self.verify_shuttle_labware_presence(Direction.RETRACT, True)
@@ -502,10 +487,6 @@ class FlexStacker(mod_abc.AbstractModule):
 
     async def _prepare_for_action(self) -> bool:
         """Helper to prepare axis for dispensing or storing labware."""
-        # TODO: check if we need to home first
-        await self.home_axis(StackerAxis.X, Direction.EXTEND)
-        await self.home_axis(StackerAxis.Z, Direction.RETRACT)
-        await self.close_latch()
         await self.verify_shuttle_location(PlatformState.EXTENDED)
         return True
 


### PR DESCRIPTION
# Overview
This PR removes temporary workarounds that were added to the Flex Stacker hardware controller during EVT.

* We no longer check for a platform in the retracted X direction, since `prepare_for_action()` already verifies the extended side.
* We now assume that all axes are homed prior to calling dispense_labware or store_labware, so prepare_for_action() only needs to verify that the platform is in the expected position. Removing the unnecessary movements in `prepare_for_action()` should make debugging easier. 

