### PR TITLE
refactor(protocol-designer): app version required now 8.5.0

### DIFF
--- a/protocol-designer/src/pages/ProtocolOverview/ProtocolMetadata.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/ProtocolMetadata.tsx
@@ -19,7 +19,7 @@ import {
   LINK_BUTTON_STYLE,
 } from '../../components/atoms'
 
-const REQUIRED_APP_VERSION = '8.4.0'
+const REQUIRED_APP_VERSION = '8.5.0'
 
 type MetadataInfo = Array<{
   author?: string

--- a/protocol-designer/src/pages/ProtocolOverview/__tests__/ProtocolMetadata.test.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/__tests__/ProtocolMetadata.test.tsx
@@ -45,7 +45,7 @@ describe('ProtocolMetadata', () => {
     screen.getByText('Protocol Metadata')
     screen.getByText('Edit')
     screen.getByText('Required app version')
-    screen.getByText('8.4.0 or higher')
+    screen.getByText('8.5.0 or higher')
   })
 
   it('should render protocol metadata', () => {


### PR DESCRIPTION
closes AUTH-1631

# Overview

update app required

<img width="776" alt="Screenshot 2025-05-23 at 08 27 19" src="https://github.com/user-attachments/assets/a69dbcde-971b-4c8a-8c4d-b33c9f0eaee0" />

## Test Plan and Hands on Testing

check that app required in the protocol metadata section is 8.5.0 or higher

## Changelog

update app version required

## Risk assessment

low