### PR TITLE
fix(protocol-designer): fix empty slots for ot-2

### DIFF
--- a/protocol-designer/src/step-forms/utils/index.ts
+++ b/protocol-designer/src/step-forms/utils/index.ts
@@ -5,7 +5,9 @@ import values from 'lodash/values'
 import {
   FLEX_ROBOT_TYPE,
   GEN_ONE_MULTI_PIPETTES,
+  getCutoutDisplayName,
   getPipetteSpecsV2,
+  OT2_CUTOUT_BY_SLOT_ID,
   OT2_ROBOT_TYPE,
   THERMOCYCLER_MODULE_TYPE,
   THERMOCYCLER_MODULE_V2,
@@ -83,21 +85,6 @@ const MOVABLE_TRASH_CUTOUTS = [
     slot: 'D3',
   },
 ]
-
-const slotToCutoutOt2Map: { [key: string]: string } = {
-  '1': 'cutout1',
-  '2': 'cutout2',
-  '3': 'cutout3',
-  '4': 'cutout4',
-  '5': 'cutout5',
-  '6': 'cutout6',
-  '7': 'cutout7',
-  '8': 'cutout8',
-  '9': 'cutout9',
-  '10': 'cutout10',
-  '11': 'cutout11',
-  '12': 'cutout12',
-}
 
 export function getIdsInRange<T extends string | number>(
   orderedIds: T[],
@@ -191,7 +178,7 @@ export const getSlotIsEmpty = (
     Object.values(initialDeckSetup.additionalEquipmentOnDeck).some(
       ae =>
         (ae.name === 'trashBin' || ae.name === 'wasteChute') &&
-        ae.location.split('cutout')[1] === slot
+        getCutoutDisplayName(ae.location as CutoutId) === slot
     ) &&
     discountTrash
   ) {
@@ -199,7 +186,7 @@ export const getSlotIsEmpty = (
   }
   const modulesInSlot = values(initialDeckSetup.modules).filter(
     (moduleOnDeck: ModuleOnDeck) => {
-      const mappedCutout = slotToCutoutOt2Map[slot]
+      const mappedCutout = OT2_CUTOUT_BY_SLOT_ID[slot]
       return mappedCutout != null
         ? moduleOnDeck.slot === slot
         : slot.includes(moduleOnDeck.slot)

--- a/protocol-designer/src/step-forms/utils/index.ts
+++ b/protocol-designer/src/step-forms/utils/index.ts
@@ -184,9 +184,9 @@ export const getSlotIsEmpty = (
   ) {
     return false
   }
+  const mappedCutout = OT2_CUTOUT_BY_SLOT_ID[slot]
   const modulesInSlot = values(initialDeckSetup.modules).filter(
     (moduleOnDeck: ModuleOnDeck) => {
-      const mappedCutout = OT2_CUTOUT_BY_SLOT_ID[slot]
       return mappedCutout != null
         ? moduleOnDeck.slot === slot
         : slot.includes(moduleOnDeck.slot)

--- a/protocol-designer/src/step-forms/utils/index.ts
+++ b/protocol-designer/src/step-forms/utils/index.ts
@@ -11,7 +11,10 @@ import {
   THERMOCYCLER_MODULE_V2,
   WASTE_CHUTE_CUTOUT,
 } from '@opentrons/shared-data'
-import { getCutoutIdByAddressableArea } from '@opentrons/step-generation'
+import {
+  getCutoutIdByAddressableArea,
+  getSlotInLocationStack,
+} from '@opentrons/step-generation'
 
 import { hydrateField } from '../../steplist/fieldLevel'
 
@@ -194,28 +197,27 @@ export const getSlotIsEmpty = (
     Object.values(initialDeckSetup.additionalEquipmentOnDeck).some(
       ae =>
         (ae.name === 'trashBin' || ae.name === 'wasteChute') &&
-        ae.location.includes(slot)
+        ae.location.split('cutout')[1] === slot
     ) &&
     discountTrash
   ) {
     return false
   }
-
-  return (
-    [
-      ...values(initialDeckSetup.modules).filter(
-        (moduleOnDeck: ModuleOnDeck) => {
-          const cutoutForSlotOt2 = slotToCutoutOt2Map[slot]
-          return cutoutForSlotOt2 != null
-            ? moduleOnDeck.slot === slot
-            : slot.includes(moduleOnDeck.slot)
-        }
-      ),
-      ...values(initialDeckSetup.labware).filter((labware: LabwareOnDeckType) =>
-        labware.stack.includes(slot)
-      ),
-    ].length === 0
+  const modulesInSlot = values(initialDeckSetup.modules).filter(
+    (moduleOnDeck: ModuleOnDeck) => {
+      const mappedCutout = slotToCutoutOt2Map[slot]
+      return mappedCutout != null
+        ? moduleOnDeck.slot === slot
+        : slot.includes(moduleOnDeck.slot)
+    }
   )
+
+  const labwareInSlot = values(initialDeckSetup.labware).filter(
+    (labware: LabwareOnDeckType) =>
+      getSlotInLocationStack(labware.stack) === slot
+  )
+
+  return modulesInSlot.length === 0 && labwareInSlot.length === 0
 }
 
 export const getIsCrashablePipetteSelected = (

--- a/protocol-designer/src/step-forms/utils/index.ts
+++ b/protocol-designer/src/step-forms/utils/index.ts
@@ -185,15 +185,9 @@ export const getSlotIsEmpty = (
   slot: string,
   discountTrash: boolean
 ): boolean => {
-  //  special-casing the TC's slot A1 for the Flex
+  //  filter out trash slots only when selecting slot but not when
+  //  dragging/dropping
   if (
-    slot === 'cutoutA1' &&
-    Object.values(initialDeckSetup.modules).find(
-      module => module.type === THERMOCYCLER_MODULE_TYPE
-    )
-  ) {
-    return false
-  } else if (
     Object.values(initialDeckSetup.additionalEquipmentOnDeck).some(
       ae =>
         (ae.name === 'trashBin' || ae.name === 'wasteChute') &&


### PR DESCRIPTION
closes AUTH-1917

# Overview

Fix bug where you couldn't select on slot 1 of the ot-2

## Test Plan and Hands on Testing

Create an ot-2 protocol and try to select to add something to slot 1, see that its selectable

## Changelog

clean up the `getSlotEmpty` util and remove unused logic

## Risk assessment

low
