### PR TITLE
refactor(components): Delete dead `getRobotCoordsFromDOMCoords()` code

### DIFF
--- a/components/src/hardware-sim/Deck/RobotWorkSpace.tsx
+++ b/components/src/hardware-sim/Deck/RobotWorkSpace.tsx
@@ -11,10 +11,6 @@ import type { StyleProps } from '../../primitives'
 
 export interface RobotWorkSpaceRenderProps {
   deckSlotsById: { [slotId: string]: DeckSlot }
-  getRobotCoordsFromDOMCoords: (
-    domX: number,
-    domY: number
-  ) => { x: number; y: number }
 }
 
 export interface RobotWorkSpaceProps extends StyleProps {
@@ -26,8 +22,6 @@ export interface RobotWorkSpaceProps extends StyleProps {
   showDeckLayers?: boolean
   id?: string
 }
-
-type GetRobotCoordsFromDOMCoords = RobotWorkSpaceRenderProps['getRobotCoordsFromDOMCoords']
 
 export function RobotWorkSpace(props: RobotWorkSpaceProps): JSX.Element | null {
   const {
@@ -41,22 +35,6 @@ export function RobotWorkSpace(props: RobotWorkSpaceProps): JSX.Element | null {
   } = props
   const wrapperRef = useRef<SVGSVGElement>(null)
 
-  // NOTE: getScreenCTM in Chrome a DOMMatrix type,
-  // in Firefox the same fn returns a deprecated SVGMatrix.
-  // Until Firefox fixes this and conforms to SVG2 draft,
-  // it will suffer from inverted y behavior (ignores css transform)
-  const getRobotCoordsFromDOMCoords: GetRobotCoordsFromDOMCoords = (x, y) => {
-    if (!wrapperRef.current) return { x: 0, y: 0 }
-
-    const cursorPoint = wrapperRef.current.createSVGPoint()
-
-    cursorPoint.x = x
-    cursorPoint.y = y
-
-    return cursorPoint.matrixTransform(
-      wrapperRef.current.getScreenCTM()?.inverse()
-    )
-  }
   if (!deckDef && !viewBox) return null
 
   let wholeDeckViewBox
@@ -93,7 +71,7 @@ export function RobotWorkSpace(props: RobotWorkSpaceProps): JSX.Element | null {
             robotType={OT2_ROBOT_TYPE}
           />
         ) : null}
-        {children?.({ deckSlotsById, getRobotCoordsFromDOMCoords })}
+        {children?.({ deckSlotsById })}
       </g>
     </Svg>
   )


### PR DESCRIPTION
## Overview

This is [pretty old code](https://github.com/Opentrons/opentrons/pull/3517) with a pretty old comment relating to a Firefox bug. I have no idea if that Firefox bug is still a problem or even how to test it. Fortunately, though, this code doesn't seem to be used anywhere, so we can just delete it.

## Review requests

Any reason to keep it?

## Risk assessment

Low-risk as long as CI passes.