### PR TITLE
fix(protocol-designer): allow deletion of a liquid even if its not in…

### DIFF
--- a/protocol-designer/release-notes.md
+++ b/protocol-designer/release-notes.md
@@ -38,6 +38,7 @@ Use Opentrons-verified liquid classes to automatically define transfer settings 
 - If multiple labware end up in the same slot at the same time due to deleting/rearranging steps, an error appears on the protocol timeline.
 - If a Heater-Shaker step is created with a a heater set and a timer, the protocol will now wait until the temperature is reached before counting down the timer.
 - If the timer of a Heater-Shaker step is toggled on and off, the timer input field no longer errors.
+- Successfully delete a defined liquid that has not been assigned to any location.
 
 Running a protocol created in Protocol Designer now requires Opentrons App version 8.5.0 or newer.
 

--- a/protocol-designer/src/assets/localization/en/modal.json
+++ b/protocol-designer/src/assets/localization/en/modal.json
@@ -95,8 +95,9 @@
       "body10": "If multiple labware end up in the same slot at the same time due to deleting/rearranging steps, an error appears on the protocol timeline.",
       "body11": "If a Heater-Shaker step is created with a a heater set and a timer, the protocol will now wait until the temperature is reached before counting down the timer.",
       "body12": "If the timer of a Heater-Shaker step is toggled on and off, the timer input field no longer errors.",
-      "body13": "All protocols now require Opentrons App version 8.5.0+ to run.",
-      "body14": "For more information, see the <link1>Protocol Designer Instruction Manual</link1>."
+      "body13": "Successfully delete a defined liquid that has not been assigned to any location.",
+      "body14": "All protocols now require Opentrons App version 8.5.0+ to run.",
+      "body15": "For more information, see the <link1>Protocol Designer Instruction Manual</link1>."
     }
   },
   "labware_selection": {

--- a/protocol-designer/src/components/organisms/AnnouncementModal/announcements.tsx
+++ b/protocol-designer/src/components/organisms/AnnouncementModal/announcements.tsx
@@ -71,6 +71,7 @@ const EIGHT_FIVE_ZERO_RELEASE_BULLET_POINTS = [
   '10',
   '11',
   '12',
+  '13',
 ]
 
 export const useAnnouncements = (): Announcement[] => {
@@ -612,7 +613,7 @@ export const useAnnouncements = (): Announcement[] => {
           </Flex>
           <Flex gridGap={SPACING.spacing4} flexDirection={DIRECTION_COLUMN}>
             <StyledText desktopStyle="bodyDefaultRegular">
-              {t('announcements.liquidClassAndPythonExport.body13')}
+              {t('announcements.liquidClassAndPythonExport.body14')}
             </StyledText>
             <StyledText desktopStyle="bodyDefaultRegular">
               <Trans
@@ -627,7 +628,7 @@ export const useAnnouncements = (): Announcement[] => {
                     />
                   ),
                 }}
-                i18nKey="announcements.liquidClassAndPythonExport.body14"
+                i18nKey="announcements.liquidClassAndPythonExport.body15"
               />
             </StyledText>
           </Flex>

--- a/protocol-designer/src/labware-ingred/actions/actions.ts
+++ b/protocol-designer/src/labware-ingred/actions/actions.ts
@@ -148,17 +148,13 @@ export const deleteLiquidGroup: (
   const liquidEntities = getLiquidEntities(getState())
   const liquidIsOnDeck = allLiquidGroups.includes(liquidGroupId)
 
-  if (!Object.keys(allLiquidGroups).includes(liquidGroupId)) {
-    return
-  }
-
   const okToDelete = liquidIsOnDeck
     ? global.confirm(
         'This liquid has been placed on the deck, are you sure you want to delete it?'
       )
     : true
-
   if (!okToDelete) {
+    console.error(`problem with deleting liquid id ${liquidGroupId}`)
     return
   }
 


### PR DESCRIPTION
… use

closes RQA-4199

# Overview

Fixes bug that prevented you from deleting a liquid that was not added to any well

## Test Plan and Hands on Testing

Try deleting both liquids and see that they delete correctly. the one that is assigned will render the global.confirm modal.

[liquidTesting.json](https://github.com/user-attachments/files/20414435/liquidTesting.json)

## Changelog

- delete unneeded if statement
- add bug fix to release notes and announcement modal

## Risk assessment

low
