### PR TITLE
feat(protocol-designer): remove liquid classes from OT-2 UI

### DIFF
--- a/protocol-designer/src/components/organisms/DefineLiquidsModal/index.tsx
+++ b/protocol-designer/src/components/organisms/DefineLiquidsModal/index.tsx
@@ -22,9 +22,13 @@ import {
   TYPOGRAPHY,
   useOnClickOutside,
 } from '@opentrons/components'
-import { getSortedLiquidClassDefs } from '@opentrons/shared-data'
+import {
+  FLEX_ROBOT_TYPE,
+  getSortedLiquidClassDefs,
+} from '@opentrons/shared-data'
 
 import { getEnableLiquidClasses } from '../../../feature-flags/selectors'
+import { getRobotType } from '../../../file-data/selectors'
 import * as labwareIngredActions from '../../../labware-ingred/actions'
 import { selectors as labwareIngredSelectors } from '../../../labware-ingred/selectors'
 import { HandleEnter, LINE_CLAMP_TEXT_STYLE } from '../../atoms'
@@ -70,6 +74,7 @@ export function DefineLiquidsModal(
     labwareIngredSelectors.allIngredientGroupFields
   )
   const enableLiquidClasses = useSelector(getEnableLiquidClasses)
+  const robotType = useSelector(getRobotType)
   const sortedLiquidClassDefs = getSortedLiquidClassDefs()
 
   const liquidGroupId = selectedLiquidGroupState.liquidGroupId
@@ -235,7 +240,7 @@ export function DefineLiquidsModal(
                     height="4.75rem"
                   />
                 </Flex>
-                {enableLiquidClasses ? (
+                {enableLiquidClasses && robotType === FLEX_ROBOT_TYPE ? (
                   <LiquidClassDropdown
                     control={control}
                     setValue={setValue}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepFormToolbox.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepFormToolbox.tsx
@@ -17,6 +17,7 @@ import {
   Toolbox,
   TYPOGRAPHY,
 } from '@opentrons/components'
+import { FLEX_ROBOT_TYPE } from '@opentrons/shared-data'
 
 import { analyticsEvent } from '../../../../analytics/actions'
 import {
@@ -34,7 +35,10 @@ import { useKitchen } from '../../../../components/organisms/Kitchen/hooks'
 import { RenameStepModal } from '../../../../components/organisms/RenameStepModal'
 import { getFormWarningsForSelectedStep } from '../../../../dismiss/selectors'
 import { getEnableLiquidClasses } from '../../../../feature-flags/selectors'
-import { getRobotStateTimeline } from '../../../../file-data/selectors'
+import {
+  getRobotStateTimeline,
+  getRobotType,
+} from '../../../../file-data/selectors'
 import { stepIconsByType } from '../../../../form-types'
 import {
   getAdditionalEquipmentEntities,
@@ -73,6 +77,7 @@ import {
 } from './utils'
 
 import type { ComponentType } from 'react'
+import type { RobotType } from '@opentrons/shared-data'
 import type { AnalyticsEvent } from '../../../../analytics/mixpanel'
 import type { FormData, StepType } from '../../../../form-types'
 import type { FormWarningType } from '../../../../steplist'
@@ -169,6 +174,7 @@ export function StepFormToolbox(props: StepFormToolboxProps): JSX.Element {
   const enableLiquidClasses = useSelector(getEnableLiquidClasses)
   const currentFormIsPresaved = useSelector(getCurrentFormIsPresaved)
   const savedStepForm = useSelector(getSavedStepForms)[formData.id]
+  const robotType = useSelector(getRobotType)
 
   // state used to track fields that have been confirmed through the modal but before saving the step form
   const [confirmedFieldUpdates, setConfirmedFieldUpdates] = useState<
@@ -273,7 +279,8 @@ export function StepFormToolbox(props: StepFormToolboxProps): JSX.Element {
   const numStepFormPages = getStepFormNumPages(
     formData.stepType,
     enableReadOrInitialization != null,
-    enableLiquidClasses
+    enableLiquidClasses,
+    robotType
   )
   const isMultiStepToolbox =
     formData.stepType === 'absorbanceReader'
@@ -510,12 +517,13 @@ export function StepFormToolbox(props: StepFormToolboxProps): JSX.Element {
 const getStepFormNumPages = (
   stepType: StepType,
   enableReadOrInitialization: boolean,
-  enableLiquidClasses: boolean
+  enableLiquidClasses: boolean,
+  robotType: RobotType
 ): number => {
   switch (stepType) {
     case 'mix':
     case 'moveLiquid':
-      return enableLiquidClasses ? 3 : 2
+      return enableLiquidClasses && robotType === FLEX_ROBOT_TYPE ? 3 : 2
     case 'thermocycler':
       return 2
     case 'absorbanceReader':

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MixTools/__tests__/MixTools.test.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MixTools/__tests__/MixTools.test.tsx
@@ -1,7 +1,11 @@
 import { screen } from '@testing-library/react'
 import { beforeEach, describe, it, vi } from 'vitest'
 
-import { fixture96Plate } from '@opentrons/shared-data'
+import {
+  fixture96Plate,
+  FLEX_ROBOT_TYPE,
+  OT2_ROBOT_TYPE,
+} from '@opentrons/shared-data'
 
 import { MixTools } from '..'
 import { renderWithProviders } from '../../../../../../../__testing-utils__'
@@ -10,6 +14,7 @@ import {
   getEnablePartialTipSupport,
   getEnableReturnTip,
 } from '../../../../../../../feature-flags/selectors'
+import { getRobotType } from '../../../../../../../file-data/selectors'
 import {
   getLabwareEntities,
   getPipetteEntities,
@@ -26,6 +31,7 @@ import type { StepFormErrors } from '../../../../../../../steplist'
 
 vi.mock('../../../../../../../step-forms/selectors')
 vi.mock('../../../../../../../feature-flags/selectors')
+vi.mock('../../../../../../../file-data/selectors')
 vi.mock('../../../utils')
 vi.mock('../FirstStepMixTools')
 vi.mock('../SecondStepMixTools')
@@ -85,6 +91,7 @@ describe('MixToolFirstStep', () => {
     vi.mocked(LiquidClassesStepTools).mockReturnValue(
       <div>mock LiquidClassesStepTools</div>
     )
+    vi.mocked(getRobotType).mockReturnValue(FLEX_ROBOT_TYPE)
   })
 
   it('renders FirstStepMixTools when toolboxStep is 0', () => {
@@ -104,10 +111,18 @@ describe('MixToolFirstStep', () => {
     screen.getByText('mock SecondStepMixTools')
   })
 
-  it('renders LiquidClassesStepTools when toolboxStep is 1 and enableLiquidClasses is true', () => {
+  it('renders LiquidClassesStepTools when toolboxStep is 1 and enableLiquidClasses is true and robot is Flex', () => {
     props.toolboxStep = 1
     vi.mocked(getEnableLiquidClasses).mockReturnValue(true)
     render(props)
     screen.getByText('mock LiquidClassesStepTools')
+  })
+
+  it('renders LiquidClassesStepTools when toolboxStep is 1 and enableLiquidClasses is true and robot is OT-2', () => {
+    props.toolboxStep = 1
+    vi.mocked(getEnableLiquidClasses).mockReturnValue(true)
+    vi.mocked(getRobotType).mockReturnValue(OT2_ROBOT_TYPE)
+    render(props)
+    screen.getByText('mock SecondStepMixTools')
   })
 })

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MixTools/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MixTools/index.tsx
@@ -1,10 +1,13 @@
 import { useSelector } from 'react-redux'
 
+import { FLEX_ROBOT_TYPE } from '@opentrons/shared-data'
+
 import {
   getEnableLiquidClasses,
   getEnablePartialTipSupport,
   getEnableReturnTip,
 } from '../../../../../../feature-flags/selectors'
+import { getRobotType } from '../../../../../../file-data/selectors'
 import {
   getLabwareEntities,
   getPipetteEntities,
@@ -37,6 +40,7 @@ export function MixTools(
   const enablePartialTip = useSelector(getEnablePartialTipSupport)
   const labwares = useSelector(getLabwareEntities)
   const enableLiquidClasses = useSelector(getEnableLiquidClasses)
+  const robotType = useSelector(getRobotType)
 
   const pickUpTipLocationValue = propsForFields.pickUpTip_location?.value
   const userSelectedPickUpTipLocation =
@@ -73,7 +77,7 @@ export function MixTools(
     ),
     1: () => (
       <>
-        {enableLiquidClasses ? (
+        {enableLiquidClasses && robotType === FLEX_ROBOT_TYPE ? (
           <LiquidClassesStepTools
             propsForFields={propsForFields}
             setShowFormErrors={setShowFormErrors}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/__tests__/MoveLiquidTools.test.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/__tests__/MoveLiquidTools.test.tsx
@@ -1,9 +1,12 @@
 import { screen } from '@testing-library/react'
 import { beforeEach, describe, it, vi } from 'vitest'
 
+import { FLEX_ROBOT_TYPE, OT2_ROBOT_TYPE } from '@opentrons/shared-data'
+
 import { MoveLiquidTools } from '../'
 import { renderWithProviders } from '../../../../../../../__testing-utils__'
 import { getEnableLiquidClasses } from '../../../../../../../feature-flags/selectors'
+import { getRobotType } from '../../../../../../../file-data/selectors'
 import { getLiquidEntities } from '../../../../../../../step-forms/selectors'
 import { FirstStepMoveLiquidTools } from '../FirstStepMoveLiquidTools'
 import { LiquidClassesStepTools } from '../LiquidClassesStepTools'
@@ -14,6 +17,7 @@ import type { FormData } from '../../../../../../../form-types'
 import type { StepFormErrors } from '../../../../../../../steplist'
 
 vi.mock('../../../../../../../feature-flags/selectors')
+vi.mock('../../../../../../../file-data/selectors')
 vi.mock('../../../../../../../step-forms/selectors')
 vi.mock('../FirstStepMoveLiquidTools')
 vi.mock('../SecondStepsMoveLiquidTools')
@@ -42,6 +46,7 @@ describe('MoveLiquidTools', () => {
     }
     vi.mocked(getEnableLiquidClasses).mockReturnValue(false)
     vi.mocked(getLiquidEntities).mockReturnValue({})
+    vi.mocked(getRobotType).mockReturnValue(FLEX_ROBOT_TYPE)
 
     vi.mocked(FirstStepMoveLiquidTools).mockReturnValue(
       <div>mock FirstStepMoveLiquidTools</div>
@@ -65,10 +70,18 @@ describe('MoveLiquidTools', () => {
     screen.getByText('mock SecondStepsMoveLiquidTools')
   })
 
-  it('renders LiquidClassesStepMoveLiquidTools when feature flag is on', () => {
+  it('renders LiquidClassesStepMoveLiquidTools when feature flag is on and robot is Flex', () => {
     vi.mocked(getEnableLiquidClasses).mockReturnValue(true)
     props.toolboxStep = 1
     render(props)
     screen.getByText('mock LiquidClassesStepMoveLiquidTools')
+  })
+
+  it('renders SecondStepsMoveLiquidTools when feature flag is on but robot is OT-2', () => {
+    vi.mocked(getEnableLiquidClasses).mockReturnValue(true)
+    vi.mocked(getRobotType).mockReturnValue(OT2_ROBOT_TYPE)
+    props.toolboxStep = 1
+    render(props)
+    screen.getByText('mock SecondStepsMoveLiquidTools')
   })
 })

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/index.tsx
@@ -1,6 +1,9 @@
 import { useSelector } from 'react-redux'
 
+import { FLEX_ROBOT_TYPE } from '@opentrons/shared-data'
+
 import { getEnableLiquidClasses } from '../../../../../../feature-flags/selectors'
+import { getRobotType } from '../../../../../../file-data/selectors'
 import { FirstStepMoveLiquidTools } from './FirstStepMoveLiquidTools'
 import { useAssignLiquidClass } from './hooks'
 import { LiquidClassesStepTools } from './LiquidClassesStepTools'
@@ -26,6 +29,7 @@ export function MoveLiquidTools(props: StepFormProps): JSX.Element {
     'aspirate_wells',
     propsForFields.liquidClass.updateValue
   )
+  const robotType = useSelector(getRobotType)
 
   const renderStepComponent = (): JSX.Element => {
     switch (toolboxStep) {
@@ -40,7 +44,7 @@ export function MoveLiquidTools(props: StepFormProps): JSX.Element {
       case 1:
         return (
           <>
-            {enableLiquidClasses ? (
+            {enableLiquidClasses && robotType === FLEX_ROBOT_TYPE ? (
               <LiquidClassesStepTools
                 propsForFields={propsForFields}
                 formData={formData}


### PR DESCRIPTION
# Overview

This PR removes liquid classes from OT-2 PD protocols UI in 1) defining liquids, 2) move liquid step forms, and 3) mix step forms

Closes AUTH-1893, Closes AUTH-1891

## Test Plan and Hands on Testing

#### Step forms
- create or import OT-2 protocol
- create or open a move liquid step
- click through steps and verify that 1) step counter at top of toolbox is out of 2 instead of 3, and 2) there is no liquid class step
- repeat with mix step

#### Defining Liquids
- create or import OT-2 protocol
- open or define a liquid
- verify that there is no liquid class dropdown component in the definition modal

## Changelog

- check robot type in addition to liquid class FF in `StepFormToolbox`, `MoveLiquidTools`, `MixTools`, and `DefineLiquidsModal`
- fix tests for step form toolboxes

## Review requests

see test plan

## Risk assessment

Low