### PR TITLE
fix(protocol-designer): fix buggy step drag behavior

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/DraggableSteps.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/DraggableSteps.tsx
@@ -73,8 +73,10 @@ function DragDropStep(props: DragDropStepProps): JSX.Element {
       },
       drop: (item: DropType) => {
         const draggedId = item.stepId
-        if (draggedId !== stepId) {
-          const overIndex = findStepIndex(stepId)
+        const draggedIndex = findStepIndex(draggedId)
+        const overIndex = findStepIndex(stepId)
+        // if hovering the step immediately below, don't move (the preview bar is at the step's current position)
+        if (draggedIndex !== overIndex && draggedIndex !== overIndex - 1) {
           moveStep(draggedId, overIndex)
         }
       },
@@ -127,10 +129,15 @@ export function DraggableSteps(props: DraggableStepsProps): JSX.Element | null {
       ...orderedStepIds.slice(0, currentIndex),
       ...orderedStepIds.slice(currentIndex + 1, orderedStepIds.length),
     ]
+    // need to account for whether we are dragging onto a step above or below the current step
+    const reinsertOffset = currentIndex < targetIndex ? 1 : 0
     const currentReinserted = [
-      ...currentRemoved.slice(0, targetIndex),
+      ...currentRemoved.slice(0, targetIndex - reinsertOffset),
       stepId,
-      ...currentRemoved.slice(targetIndex, currentRemoved.length),
+      ...currentRemoved.slice(
+        targetIndex - reinsertOffset,
+        currentRemoved.length
+      ),
     ]
     if (confirm(t('confirm_reorder') as string)) {
       reorderSteps(currentReinserted)

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/StepContainer.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/StepContainer.tsx
@@ -230,13 +230,24 @@ export function StepContainer(props: StepContainerProps): JSX.Element {
       )}
       <Flex
         id={stepId}
-        {...{
-          onMouseEnter: isStepAfterError ? undefined : onMouseEnter,
-          onMouseLeave: isStepAfterError ? undefined : onMouseLeave,
-        }}
+        {...(isStepAfterError
+          ? {
+              onMouseEnter,
+              onMouseLeave,
+            }
+          : {})}
         gridGap={SPACING.spacing4}
         flexDirection={DIRECTION_COLUMN}
       >
+        {dragHovered ? (
+          <Divider
+            marginY="0"
+            height="0.25rem"
+            width="100%"
+            backgroundColor={COLORS.blue50}
+            borderRadius={BORDERS.borderRadius2}
+          />
+        ) : null}
         <Box
           role="button"
           data-testid={`StepContainer_${stepId}`}
@@ -301,15 +312,6 @@ export function StepContainer(props: StepContainerProps): JSX.Element {
             ) : null}
           </Flex>
         </Box>
-        {dragHovered ? (
-          <Divider
-            marginY="0"
-            height="0.25rem"
-            width="100%"
-            backgroundColor={COLORS.blue50}
-            borderRadius={BORDERS.borderRadius2}
-          />
-        ) : null}
       </Flex>
       {stepId != null &&
       openedOverflowMenuId === stepId &&


### PR DESCRIPTION
# Overview

This PR fixes step drag preview and drop behavior. Previously, behavior didn't work correctly when dragging a step earlier in the timeline— the reinsertion index was 1 later than what the preview bar indicated.

## Test Plan and Hands on Testing

#### Before 
https://github.com/user-attachments/assets/b514bfab-1330-422d-bd0b-aad7d6508f5e

#### After 
https://github.com/user-attachments/assets/b9b040c7-e7f4-490c-99d5-4b797ab49d43

## Changelog

- fix logic for when to invoke `moveStep`
- fix positioning for preview bar such that the drop location matches the preview bar location

## Review requests

see test plan

## Risk assessment

low