### PR TITLE
fix(components): fix alignment of `ListItemDescriptor`

### DIFF
--- a/components/src/atoms/ListButton/ListButton.stories.tsx
+++ b/components/src/atoms/ListButton/ListButton.stories.tsx
@@ -1,12 +1,11 @@
 import * as React from 'react'
 
-import { StyledText } from '../..'
+import { CustomizeExpandButton, StyledText } from '../..'
 import { STYLE_PROPS } from '../../primitives'
 import { ListButton as ListButtonComponent } from './index'
 import {
   ListButtonAccordion,
   ListButtonAccordionContainer,
-  ListButtonRadioButton,
 } from './ListButtonChildren/index'
 
 import type { Meta, StoryObj } from '@storybook/react'
@@ -58,8 +57,10 @@ const Template = (args: ListButtonComponentProps): JSX.Element => {
       >
         <ListButtonAccordionContainer id="mainAccordionContainer">
           <>
-            <ListButtonRadioButton
+            <CustomizeExpandButton
               key="buttonNested"
+              allowInputField={false}
+              loadName="mockloadname0"
               isSelected={buttonValue === 'radio button nested'}
               buttonValue="radio button nested"
               buttonText="Radio button, click to expand nested accordion"
@@ -78,7 +79,9 @@ const Template = (args: ListButtonComponentProps): JSX.Element => {
                   isExpanded={buttonValue === 'radio button nested'}
                 >
                   <>
-                    <ListButtonRadioButton
+                    <CustomizeExpandButton
+                      allowInputField={false}
+                      loadName="mockloadname1"
                       isSelected={nestedButtonValue === 'radio button1'}
                       buttonValue="radio button1"
                       buttonText="nested button"
@@ -92,7 +95,9 @@ const Template = (args: ListButtonComponentProps): JSX.Element => {
                       </StyledText>
                     ) : null}
                   </>
-                  <ListButtonRadioButton
+                  <CustomizeExpandButton
+                    allowInputField={false}
+                    loadName="mockloadname2"
                     isSelected={nestedButtonValue === 'radio button2'}
                     buttonValue="radio button2"
                     buttonText="nested button 2"
@@ -100,7 +105,9 @@ const Template = (args: ListButtonComponentProps): JSX.Element => {
                       setNestedButtonValue('radio button2')
                     }}
                   />
-                  <ListButtonRadioButton
+                  <CustomizeExpandButton
+                    allowInputField={false}
+                    loadName="mockloadname3"
                     isSelected={nestedButtonValue === 'radio button3'}
                     buttonValue="radio button3"
                     buttonText="nested button 3"
@@ -113,8 +120,10 @@ const Template = (args: ListButtonComponentProps): JSX.Element => {
             ) : null}
           </>
           <>
-            <ListButtonRadioButton
+            <CustomizeExpandButton
               key="buttonNonNested"
+              allowInputField={false}
+              loadName="mockloadname4"
               isSelected={buttonValue === 'radio button non nest'}
               buttonValue="radio button non nest"
               buttonText="Radio button without nested"

--- a/components/src/atoms/ListItem/ListItemChildren/ListItemDescriptor.tsx
+++ b/components/src/atoms/ListItem/ListItemChildren/ListItemDescriptor.tsx
@@ -1,6 +1,6 @@
 import { Flex } from '../../../primitives'
 import {
-  ALIGN_FLEX_START,
+  ALIGN_CENTER,
   DIRECTION_COLUMN,
   DIRECTION_ROW,
   JUSTIFY_FLEX_START,
@@ -35,7 +35,7 @@ export const ListItemDescriptor = (
       flexDirection={changeFlexDirection ? DIRECTION_COLUMN : DIRECTION_ROW}
       gridGap={SPACING.spacing8}
       width="100%"
-      alignItems={ALIGN_FLEX_START}
+      alignItems={ALIGN_CENTER}
       justifyContent={justifyContent}
       padding={type === 'default' ? SPACING.spacing4 : SPACING.spacing12}
     >


### PR DESCRIPTION
# Overview

Change `alignItems` prop from flex start to center

## Test Plan and Hands on Testing

- create or upload a protocol with liquids and navigate to Protocol Overview > Liquid Definitions
- verify that description is aligned center

Before  
<img width="535" alt="Screenshot 2025-05-27 at 5 12 37 PM" src="https://github.com/user-attachments/assets/b3279f36-61a0-4b16-ad54-8f4067ea57cc" />


After  
<img width="542" alt="Screenshot 2025-05-27 at 5 12 02 PM" src="https://github.com/user-attachments/assets/2ee818dc-6c24-44e7-8b39-ac1523cade5f" />

## Changelog

- fix `alignItems` prop

## Review requests

see test plan

## Risk assessment

low