### PR TITLE
fix(protocol-designer): fix fields for BatchEditMix/MoveLiquidTools

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/BatchEditToolbox/BatchEditMixTools.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/BatchEditToolbox/BatchEditMixTools.tsx
@@ -112,6 +112,7 @@ export function BatchEditMixTools(props: BatchEditMixToolsProps): JSX.Element {
             xField="mix_x_position"
             yField="mix_y_position"
             labwareId={getLabwareIdForPositioningField('mix_mmFromBottom')}
+            referenceField="mix_position_reference"
           />
           <Divider marginY="0" />
         </>
@@ -119,7 +120,7 @@ export function BatchEditMixTools(props: BatchEditMixToolsProps): JSX.Element {
       <Flex
         flexDirection={DIRECTION_COLUMN}
         padding={`0 ${SPACING.spacing16}`}
-        gridGap={SPACING.spacing8}
+        gridGap={SPACING.spacing4}
       >
         <StyledText desktopStyle="bodyDefaultSemiBold">
           {t('protocol_steps:advanced_settings')}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/BatchEditToolbox/BatchEditMoveLiquidTools.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/BatchEditToolbox/BatchEditMoveLiquidTools.tsx
@@ -112,12 +112,13 @@ export function BatchEditMoveLiquidTools(
         labwareId={getLabwareIdForPositioningField(
           addFieldNamePrefix('mmFromBottom')
         )}
+        referenceField={`${tab}_position_reference`}
       />
       <Divider marginY="0" />
       <Flex
         flexDirection={DIRECTION_COLUMN}
         padding={`0 ${SPACING.spacing16}`}
-        gridGap={SPACING.spacing8}
+        gridGap={SPACING.spacing4}
       >
         <StyledText desktopStyle="bodyDefaultSemiBold">
           {t('protocol_steps:advanced_settings')}
@@ -180,14 +181,6 @@ export function BatchEditMoveLiquidTools(
                 title={t('protocol_steps:delay_duration')}
                 {...propsForFields[`${tab}_delay_seconds`]}
                 units={t('application:units.seconds')}
-              />
-              <PositionField
-                prefix={tab}
-                propsForFields={propsForFields}
-                zField={`${tab}_delay_mmFromBottom`}
-                labwareId={getLabwareIdForPositioningField(
-                  addFieldNamePrefix('delay_mmFromBottom')
-                )}
               />
             </Flex>
           ) : null}


### PR DESCRIPTION
# Overview

Removes deprecated fields and fixes position field for batch edit toolbox for mix and move liquid steps

Closes AUTH-971

## Test Plan and Hands on Testing

#### move liquid
- create or open a protocol with multiple move liquid steps
- click one step to select, then control + click the other step to open move liquid batch edit toolbox
- verify that position field has a non-null reference position (top/bottom/center)
- open `delay` checkbox and verify that no delay position exists— only delay duration

Before  
![Screenshot 2025-05-28 at 9 09 31 AM](https://github.com/user-attachments/assets/973ed52c-f178-479b-aaf8-9c0a8c521703)

After  
![Screenshot 2025-05-28 at 9 07 44 AM](https://github.com/user-attachments/assets/ce503541-fe85-4545-b0ab-2317f6e85727)

#### mix
- create or open a protocol with multiple mix steps
- click one step to select, then control + click the other step to open mix batch edit toolbox
- verify that position field has a non-null reference position (top/bottom/center)

Before  
![Screenshot 2025-05-28 at 9 09 00 AM](https://github.com/user-attachments/assets/25755c37-3c28-4e9e-9dcd-654eaceb1f8e)

After  
![Screenshot 2025-05-28 at 9 08 43 AM](https://github.com/user-attachments/assets/9b3e7761-ddbe-43c7-a260-e8661c12b8c0)

## Changelog

- remove deprecated delay position field in move liquid batch edit toolbox
- pass reference position field to position field component in move liquid and mix toolboxes

## Review requests

see tests plan

## Risk assessment

low