### PR TITLE
fix(protocol-designer): unselect the highlighted item when existing m…

### DIFF
--- a/protocol-designer/src/components/organisms/ConfirmDeleteModal/index.tsx
+++ b/protocol-designer/src/components/organisms/ConfirmDeleteModal/index.tsx
@@ -1,5 +1,6 @@
 import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
+import { useDispatch } from 'react-redux'
 
 import {
   AlertPrimaryButton,
@@ -13,9 +14,11 @@ import {
   StyledText,
 } from '@opentrons/components'
 
+import { selectDropdownItem } from '../../../ui/steps/actions/actions'
 import { getMainPagePortalEl } from '../Portal'
 
 import type { MouseEvent } from 'react'
+import type { ThunkDispatch } from '../../../types'
 
 export const DELETE_PROFILE_CYCLE: 'deleteProfileCycle' = 'deleteProfileCycle'
 export const CLOSE_STEP_FORM_WITH_CHANGES: 'closeStepFormWithChanges' =
@@ -45,12 +48,22 @@ interface Props {
 export function ConfirmDeleteModal(props: Props): JSX.Element {
   const { i18n, t } = useTranslation(['modal', 'button'])
   const { modalType, onCancelClick, onContinueClick } = props
+  const dispatch = useDispatch<ThunkDispatch<any>>()
   const cancelCopy = i18n.format(t('button:cancel'), 'capitalize')
   const continueCopy = i18n.format(
     t(`confirm_delete_modal.${modalType}.confirm_button`, t('button:continue')),
     'capitalize'
   )
 
+  const handleContinueClick = (e: MouseEvent): void => {
+    onContinueClick(e)
+    dispatch(
+      selectDropdownItem({
+        selection: null,
+        mode: 'clear',
+      })
+    )
+  }
   return createPortal(
     <Modal
       marginLeft="0"
@@ -69,7 +82,11 @@ export function ConfirmDeleteModal(props: Props): JSX.Element {
               {cancelCopy}
             </StyledText>
           </SecondaryButton>
-          <AlertPrimaryButton onClick={onContinueClick}>
+          <AlertPrimaryButton
+            onClick={(e: MouseEvent) => {
+              handleContinueClick(e)
+            }}
+          >
             <StyledText desktopStyle="bodyDefaultSemiBold">
               {continueCopy}
             </StyledText>

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/index.tsx
@@ -147,7 +147,6 @@ function StepFormManager(props: StepFormManagerProps): JSX.Element | null {
 
   return (
     <>
-      {/* TODO: update these modals to match new modal design */}
       {showConfirmDeleteModal && (
         <ConfirmDeleteModal
           modalType={DELETE_STEP_FORM}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/ConnectedStepInfo.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/ConnectedStepInfo.tsx
@@ -198,7 +198,6 @@ export function ConnectedStepInfo(props: ConnectedStepInfoProps): JSX.Element {
 
   return (
     <>
-      {/* TODO: update this modal */}
       {showConfirmationDoubleClick && (
         <ConfirmDeleteModal
           modalType={getModalType()}
@@ -206,7 +205,6 @@ export function ConnectedStepInfo(props: ConnectedStepInfoProps): JSX.Element {
           onCancelClick={cancelDoubleClick}
         />
       )}
-      {/* TODO: update this modal */}
       {showConfirmation && (
         <ConfirmDeleteModal
           modalType={getModalType()}


### PR DESCRIPTION
…id-step

closes AUTH-1920

# Overview

Fixes a bug where if you clicked on the starting deck when in the middle of the step, the highlight labware doesn't properly go away. A form of this bug exists in production right now

## Test Plan and Hands on Testing

Create a protocol and add a labware to the deck. start creating a transfer step - select on the labware to aspirate from. then click 'x" at the top of the transfer form and hit "confirm" deleting. see that the labware that was highlight is no longer highlighted.

## Changelog

- dispatch to unhighlight the selected item when confirming to delete or move away from the step

## Risk assessment

low
