### PR TITLE
test(app): fix distribute test for quick transfer step commands

### DIFF
--- a/app/src/organisms/ODD/QuickTransferFlow/__tests__/utils/quickTransferStepCommands.test.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/__tests__/utils/quickTransferStepCommands.test.ts
@@ -353,7 +353,7 @@ pipette.drop_tip()
       dispenseRetractZOffset: 0,
       dispenseRetractPositionReference: POSITION_REFERENCE_BOTTOM,
       blowoutOffsetFromTopMm: -1,
-      blowoutLocation: 'source',
+      blowoutLocation: SOURCE_WELL_BLOWOUT_DESTINATION,
       mixBeforeAspirate: null,
       tipRack: 'fixture/fixture_flex_96_tiprack_1000ul/1',
       pipette: 'mockPipette',
@@ -417,6 +417,9 @@ pipette.move_to(mock_labware_2["B1"].bottom())
 pipette.move_to(mock_labware_2["B1"].bottom())
 pipette.dispense(volume=10, flow_rate=80)
 pipette.move_to(mock_labware_2["B1"].bottom())
+pipette.move_to(mock_labware_1["A1"].top())
+pipette.flow_rate.blow_out = 50
+pipette.blow_out()
 pipette.drop_tip()
 `.trim()
     )


### PR DESCRIPTION
Fixes distribute test for quick transfer step commands. We needed to use the constant for `'source_well'` as `SOURCE_WELL_BLOWOUT_DESTINATION` rather than string literal `'source'`

Also adds correct commands for moving back to source well and blowing out there in Python commands