### PR TITLE
fix(app): LPC using stacker icon instead of stacked icon

### DIFF
--- a/app/src/organisms/Desktop/Devices/HistoricalProtocolRunDrawer.tsx
+++ b/app/src/organisms/Desktop/Devices/HistoricalProtocolRunDrawer.tsx
@@ -23,7 +23,6 @@ import {
 } from '@opentrons/components'
 import { useCsvFileQuery } from '@opentrons/react-api-client'
 import {
-  FLEX_STACKER_MODULE_TYPE,
   getLabwareDefURI,
   getLabwareDisplayName,
   getLoadedLabwareDefinitionsByUri,
@@ -273,9 +272,7 @@ export function HistoricalProtocolRunDrawer(
                     seq => seq.kind === 'onLabware'
                   ) && (
                     <DeckInfoLabel
-                      iconName={
-                        MODULE_ICON_NAME_BY_TYPE[FLEX_STACKER_MODULE_TYPE]
-                      }
+                      iconName="stacked"
                       key="stacked-icon"
                     />
                   )}

--- a/app/src/organisms/Desktop/Devices/HistoricalProtocolRunDrawer.tsx
+++ b/app/src/organisms/Desktop/Devices/HistoricalProtocolRunDrawer.tsx
@@ -270,12 +270,7 @@ export function HistoricalProtocolRunDrawer(
                   <DeckInfoLabel deckLabel={slotName} />
                   {offset.locationSequence?.some(
                     seq => seq.kind === 'onLabware'
-                  ) && (
-                    <DeckInfoLabel
-                      iconName="stacked"
-                      key="stacked-icon"
-                    />
-                  )}
+                  ) && <DeckInfoLabel iconName="stacked" key="stacked-icon" />}
                   {offset.location.moduleModel && (
                     <DeckInfoLabel
                       iconName={

--- a/app/src/organisms/LabwareOffsetsDeckInfoLabels/index.tsx
+++ b/app/src/organisms/LabwareOffsetsDeckInfoLabels/index.tsx
@@ -34,10 +34,7 @@ export function LabwareOffsetsDeckInfoLabels({
     <Flex gridGap={SPACING.spacing4}>
       <DeckInfoLabel deckLabel={slotCopy} />
       {isLabwareInLwStackup() && (
-        <DeckInfoLabel
-          iconName='stacked'
-          key="stacked-icon"
-        />
+        <DeckInfoLabel iconName="stacked" key="stacked-icon" />
       )}
       {closestBeneathModuleModel != null && (
         <DeckInfoLabel

--- a/app/src/organisms/LabwareOffsetsDeckInfoLabels/index.tsx
+++ b/app/src/organisms/LabwareOffsetsDeckInfoLabels/index.tsx
@@ -4,7 +4,7 @@ import {
   MODULE_ICON_NAME_BY_TYPE,
   SPACING,
 } from '@opentrons/components'
-import { FLEX_STACKER_MODULE_TYPE, getModuleType } from '@opentrons/shared-data'
+import { getModuleType } from '@opentrons/shared-data'
 
 import type { LocationSpecificOffsetDetails } from '/app/redux/protocol-runs'
 
@@ -35,7 +35,7 @@ export function LabwareOffsetsDeckInfoLabels({
       <DeckInfoLabel deckLabel={slotCopy} />
       {isLabwareInLwStackup() && (
         <DeckInfoLabel
-          iconName={MODULE_ICON_NAME_BY_TYPE[FLEX_STACKER_MODULE_TYPE]}
+          iconName='stacked'
           key="stacked-icon"
         />
       )}


### PR DESCRIPTION
fix RQA-4205
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->
When displaying the labware location for offsets in LPC (including historical offsets, offset modal on ODD, and offset section in desktop protocol setup) we were using the stacker module icon instead of the "stacked" icon
## Test Plan and Hands on Testing
See that we now show the stacked icon instead of the stacker icon (before and after)
<img width="878" alt="Screenshot 2025-05-28 at 5 33 15 PM" src="https://github.com/user-attachments/assets/ed9d6304-8b5e-4934-94e5-5d6e98d62cd2" />
<img width="886" alt="Screenshot 2025-05-28 at 5 52 40 PM" src="https://github.com/user-attachments/assets/87ab3428-109c-4759-811c-871204693d13" />

<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
Use 'stacked' icon in `DeckInfoLabel` for `HistoricalProtocolRunDrawer` and `LabwareOffsetsDeckInfoLabels`
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests
Does this cover all locations? I did a global search for the previous icon pattern and these were the only two matches so I think it is!
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
Low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
