### PR TITLE
feat(step-generation): use new Python mix() `aspirate_flow_rate`/`dispense_flow_rate` arguments

### DIFF
--- a/protocol-designer/src/timelineMiddleware/__tests__/generateRobotStateTimeline.test.ts
+++ b/protocol-designer/src/timelineMiddleware/__tests__/generateRobotStateTimeline.test.ts
@@ -330,13 +330,9 @@ mock_pipette_p300_multi.drop_tip()
       // Step c:
       `
 mock_pipette.pick_up_tip(location=mock_tip_rack_1)
-mock_pipette.flow_rate.aspirate = 3.78
-mock_pipette.flow_rate.dispense = 3.78
 mock_pipette.mix(...)
 mock_pipette.drop_tip()
 mock_pipette.pick_up_tip(location=mock_tip_rack_1)
-mock_pipette.flow_rate.aspirate = 3.78
-mock_pipette.flow_rate.dispense = 3.78
 mock_pipette.mix(...)
 mock_pipette.drop_tip()
 `.trim(),

--- a/step-generation/src/__tests__/mix.test.ts
+++ b/step-generation/src/__tests__/mix.test.ts
@@ -107,30 +107,30 @@ describe('mix: change tip', () => {
       `
 mock_pipette.drop_tip()
 mock_pipette.pick_up_tip(location=mock_tip_rack_1)
-mock_pipette.flow_rate.aspirate = 2.1
-mock_pipette.flow_rate.dispense = 2.2
 mock_pipette.mix(
     repetitions=2,
     volume=5,
     location=mock_source_plate["A1"].bottom(z=3.2),
+    aspirate_flow_rate=2.1,
+    dispense_flow_rate=2.2,
 )
 mock_pipette.drop_tip()
 mock_pipette.pick_up_tip(location=mock_tip_rack_1)
-mock_pipette.flow_rate.aspirate = 2.1
-mock_pipette.flow_rate.dispense = 2.2
 mock_pipette.mix(
     repetitions=2,
     volume=5,
     location=mock_source_plate["B1"].bottom(z=3.2),
+    aspirate_flow_rate=2.1,
+    dispense_flow_rate=2.2,
 )
 mock_pipette.drop_tip()
 mock_pipette.pick_up_tip(location=mock_tip_rack_1)
-mock_pipette.flow_rate.aspirate = 2.1
-mock_pipette.flow_rate.dispense = 2.2
 mock_pipette.mix(
     repetitions=2,
     volume=5,
     location=mock_source_plate["C1"].bottom(z=3.2),
+    aspirate_flow_rate=2.1,
+    dispense_flow_rate=2.2,
 )`.trimStart()
     )
   })
@@ -392,12 +392,12 @@ describe('mix: advanced options', () => {
         `
 mock_pipette.drop_tip()
 mock_pipette.pick_up_tip(location=mock_tip_rack_1)
-mock_pipette.flow_rate.aspirate = 2.1
-mock_pipette.flow_rate.dispense = 2.2
 mock_pipette.mix(
     repetitions=2,
     volume=8,
     location=mock_source_plate["A1"].bottom(z=3.2).move(types.Point(y=1)),
+    aspirate_flow_rate=2.1,
+    dispense_flow_rate=2.2,
     aspirate_delay=10,
     dispense_delay=12,
     final_push_out=2,
@@ -407,12 +407,12 @@ mock_pipette.blow_out(mock_dest_plate["A1"].top(z=3.3))
 mock_pipette.touch_tip(mock_source_plate["A1"], v_offset=-3.4)
 mock_pipette.drop_tip()
 mock_pipette.pick_up_tip(location=mock_tip_rack_1)
-mock_pipette.flow_rate.aspirate = 2.1
-mock_pipette.flow_rate.dispense = 2.2
 mock_pipette.mix(
     repetitions=2,
     volume=8,
     location=mock_source_plate["B1"].bottom(z=3.2).move(types.Point(y=1)),
+    aspirate_flow_rate=2.1,
+    dispense_flow_rate=2.2,
     aspirate_delay=10,
     dispense_delay=12,
     final_push_out=2,
@@ -422,12 +422,12 @@ mock_pipette.blow_out(mock_dest_plate["A1"].top(z=3.3))
 mock_pipette.touch_tip(mock_source_plate["B1"], v_offset=-3.4)
 mock_pipette.drop_tip()
 mock_pipette.pick_up_tip(location=mock_tip_rack_1)
-mock_pipette.flow_rate.aspirate = 2.1
-mock_pipette.flow_rate.dispense = 2.2
 mock_pipette.mix(
     repetitions=2,
     volume=8,
     location=mock_source_plate["C1"].bottom(z=3.2).move(types.Point(y=1)),
+    aspirate_flow_rate=2.1,
+    dispense_flow_rate=2.2,
     aspirate_delay=10,
     dispense_delay=12,
     final_push_out=2,
@@ -459,36 +459,36 @@ mock_pipette.touch_tip(mock_source_plate["C1"], v_offset=-3.4)
       `
 mock_pipette.drop_tip()
 mock_pipette.pick_up_tip(location=mock_tip_rack_1)
-mock_pipette.flow_rate.aspirate = 2.1
-mock_pipette.flow_rate.dispense = 2.2
 mock_pipette.mix(
     repetitions=2,
     volume=8,
     location=mock_source_plate["A1"].bottom(z=3.2).move(types.Point(x=1, y=1)),
+    aspirate_flow_rate=2.1,
+    dispense_flow_rate=2.2,
 )
 mock_pipette.flow_rate.blow_out = 2.3
 mock_pipette.blow_out(mock_dest_plate["A1"].top(z=3.3))
 mock_pipette.touch_tip(mock_source_plate["A1"], v_offset=-3.4)
 mock_pipette.drop_tip()
 mock_pipette.pick_up_tip(location=mock_tip_rack_1)
-mock_pipette.flow_rate.aspirate = 2.1
-mock_pipette.flow_rate.dispense = 2.2
 mock_pipette.mix(
     repetitions=2,
     volume=8,
     location=mock_source_plate["B1"].bottom(z=3.2).move(types.Point(x=1, y=1)),
+    aspirate_flow_rate=2.1,
+    dispense_flow_rate=2.2,
 )
 mock_pipette.flow_rate.blow_out = 2.3
 mock_pipette.blow_out(mock_dest_plate["A1"].top(z=3.3))
 mock_pipette.touch_tip(mock_source_plate["B1"], v_offset=-3.4)
 mock_pipette.drop_tip()
 mock_pipette.pick_up_tip(location=mock_tip_rack_1)
-mock_pipette.flow_rate.aspirate = 2.1
-mock_pipette.flow_rate.dispense = 2.2
 mock_pipette.mix(
     repetitions=2,
     volume=8,
     location=mock_source_plate["C1"].bottom(z=3.2).move(types.Point(x=1, y=1)),
+    aspirate_flow_rate=2.1,
+    dispense_flow_rate=2.2,
 )
 mock_pipette.flow_rate.blow_out = 2.3
 mock_pipette.blow_out(mock_dest_plate["A1"].top(z=3.3))

--- a/step-generation/src/commandCreators/compound/mix.ts
+++ b/step-generation/src/commandCreators/compound/mix.ts
@@ -99,6 +99,8 @@ const makePythonCommandCreator: (args: {
     `repetitions=${times}`,
     `volume=${volume}`,
     ...(locationPythonArg != null ? [locationPythonArg] : []),
+    `aspirate_flow_rate=${aspirateFlowRateUlSec}`,
+    `dispense_flow_rate=${dispenseFlowRateUlSec}`,
     ...(aspirateDelaySeconds != null && aspirateDelaySeconds !== 0
       ? [`aspirate_delay=${aspirateDelaySeconds}`]
       : []),
@@ -111,10 +113,9 @@ const makePythonCommandCreator: (args: {
     commands: [],
     //  Note: we do not support mix in trashBin or wasteChute so location
     //  will always be a well
-    python:
-      `${pipettePythonName}.flow_rate.aspirate = ${aspirateFlowRateUlSec}\n` +
-      `${pipettePythonName}.flow_rate.dispense = ${dispenseFlowRateUlSec}\n` +
-      `${pipettePythonName}.mix(\n${indentPyLines(pythonArgs.join(',\n'))},\n)`,
+    python: `${pipettePythonName}.mix(\n${indentPyLines(
+      pythonArgs.join(',\n')
+    )},\n)`,
   }
 }
 


### PR DESCRIPTION
# Overview

We recently added the new arguments `aspirate_flow_rate` and `dispense_flow_rate` to the Python API `mix()` function. Now PD step-generation can set the flow rates directly for a Mix step, instead of overriding the pipette's default flow rates. AUTH-1097 AUTH-1624

Before:
```
mock_pipette.flow_rate.aspirate = 2.1
mock_pipette.flow_rate.dispense = 2.2
mock_pipette.mix(...)
```

After:
```
mock_pipette.mix(
    ...,
    aspirate_flow_rate=2.1,
    dispense_flow_rate=2.2,
)
```

## Test Plan and Hands on Testing

Updated unit tests.

## Risk assessment

Low.