### PR TITLE
feat(api): allow setting a fixed override to '..byVolume' properties

### DIFF
--- a/api/src/opentrons/protocol_api/_liquid_properties.py
+++ b/api/src/opentrons/protocol_api/_liquid_properties.py
@@ -62,7 +62,7 @@ class LiquidHandlingPropertyByVolume:
                 interp(validated_volume, self._sorted_volumes, self._sorted_values)
             )
 
-    def set_fixed_override(self, value: float) -> None:
+    def set_for_all_volumes(self, value: float) -> None:
         """Override all existing volume-dependent values with the given value."""
         self.clear_values()
         self.set_for_volume(0, value)

--- a/api/src/opentrons/protocol_api/_liquid_properties.py
+++ b/api/src/opentrons/protocol_api/_liquid_properties.py
@@ -62,6 +62,11 @@ class LiquidHandlingPropertyByVolume:
                 interp(validated_volume, self._sorted_volumes, self._sorted_values)
             )
 
+    def set_fixed_override(self, value: float) -> None:
+        """Override all existing volume-dependent values with the given value."""
+        self.clear_values()
+        self.set_for_volume(0, value)
+
     def set_for_volume(self, volume: float, value: float) -> None:
         """Add a new volume and value for the property for the interpolation curve."""
         validated_volume = validation.ensure_positive_float(volume)

--- a/api/tests/opentrons/protocol_api/test_liquid_class_properties.py
+++ b/api/tests/opentrons/protocol_api/test_liquid_class_properties.py
@@ -454,8 +454,8 @@ def test_liquid_handling_property_by_volume() -> None:
     assert subject.get_for_volume(1000) == 250.0
 
     # Test fixed overrides
-    subject.set_fixed_override(4321)
-    for volume in (0, 1, 10, 100):
+    subject.set_for_all_volumes(4321)
+    for volume in (0, 1, 7, 100):
         assert subject.get_for_volume(volume) == 4321
 
     # Test resetting to default

--- a/api/tests/opentrons/protocol_api/test_liquid_class_properties.py
+++ b/api/tests/opentrons/protocol_api/test_liquid_class_properties.py
@@ -453,6 +453,22 @@ def test_liquid_handling_property_by_volume() -> None:
     assert subject.get_for_volume(1) == 50.0
     assert subject.get_for_volume(1000) == 250.0
 
+    # Test fixed overrides
+    subject.set_fixed_override(4321)
+    for volume in (0, 1, 10, 100):
+        assert subject.get_for_volume(volume) == 4321
+
+    # Test resetting to default
+    subject.reset_values()
+    assert subject.as_dict() == {5.0: 50, 10.0: 250}
+    assert subject.get_for_volume(7) == 130.0
+
+    # Test clearing all values
+    subject.clear_values()
+    assert subject.as_dict() == {}
+    with pytest.raises(ValueError, match="No properties found for any volumes"):
+        subject.get_for_volume(7)
+
 
 def test_non_existent_property_raises_error() -> None:
     """It should raise an attribute error if the set property does not exist."""


### PR DESCRIPTION
Closes AUTH-1654

# Overview

Adds a method `LiquidHandlingPropertyByVolume.set_fixed_override()` which overrides the existing 'by volume' values with the provided value

You would use this in a protocol like this-
```
water = simulated_protocol_context.define_liquid_class("water")
water_props = water.get_for(pipette_50, tiprack)

# Set flow rate of 20uL/sec for all volumes
water_props.aspirate.flow_rate_by_volume.set_for_all_volumes(20)
```

## Test Plan and Hands on Testing

Added unit/ smoke tests. Should be enough

## Review requests

- any objections to the method name?

## Risk assessment

Low-None. Very small addition to functionality that doesn't change any existing behavior.
