### PR TITLE
fix(protocol-designer): fix whitescreen bug in MoveLiquidSummary

### DIFF
--- a/protocol-designer/src/components/organisms/StepSummary/MixSummary.tsx
+++ b/protocol-designer/src/components/organisms/StepSummary/MixSummary.tsx
@@ -11,7 +11,7 @@ import {
 } from '@opentrons/components'
 
 import { getLiquidDisplay } from './getLiquidDisplay'
-import { getWellsForStepSummary } from './utils'
+import { getLiquidIdsForStepSummary, getWellsForStepSummary } from './utils'
 
 import type {
   LabwareEntities,
@@ -45,16 +45,11 @@ export function MixSummary(props: MixSummaryProps): JSX.Element {
   } = currentStep
   const mixLabwareDisplayName = labwareNicknamesById[mixLabwareId]
   const mixWells: string[] = mix_wells
-  const liquidIds =
-    liquidState.labware[mixLabwareId] != null
-      ? [
-          ...new Set(
-            mixWells.flatMap(well =>
-              Object.keys(liquidState.labware[mixLabwareId][well])
-            )
-          ),
-        ]
-      : []
+  const liquidIds = getLiquidIdsForStepSummary(
+    liquidState,
+    mixLabwareId as string,
+    mixWells
+  )
   const liquidInfo = liquidIds.map(id => liquidEntities[id])
   const mixWellsDisplay = getWellsForStepSummary(
     mixWells,

--- a/protocol-designer/src/components/organisms/StepSummary/MoveLiquidSummary.tsx
+++ b/protocol-designer/src/components/organisms/StepSummary/MoveLiquidSummary.tsx
@@ -9,10 +9,9 @@ import {
   Tag,
   WRAP,
 } from '@opentrons/components'
-import { AIR } from '@opentrons/step-generation'
 
 import { getLiquidDisplay } from './getLiquidDisplay'
-import { getWellsForStepSummary } from './utils'
+import { getLiquidIdsForStepSummary, getWellsForStepSummary } from './utils'
 
 import type {
   AdditionalEquipmentEntities,
@@ -75,17 +74,10 @@ export function MoveLiquidSummary(props: MoveLiquidSummaryProps): JSX.Element {
     moveLiquidType = 'distribute'
   }
 
-  const liquidIds = Array.from(
-    aspirateWells.reduce<Set<string>>((acc, well) => {
-      for (const [liquidId, { volume }] of Object.entries(
-        liquidState.labware[aspirate_labware][well]
-      )) {
-        if (liquidId !== AIR && volume > 0) {
-          acc.add(liquidId)
-        }
-      }
-      return acc
-    }, new Set<string>())
+  const liquidIds = getLiquidIdsForStepSummary(
+    liquidState,
+    aspirate_labware as string,
+    aspirateWells
   )
 
   const liquidInfo = liquidIds.map(id => liquidEntities[id])

--- a/protocol-designer/src/components/organisms/StepSummary/MoveLiquidSummary.tsx
+++ b/protocol-designer/src/components/organisms/StepSummary/MoveLiquidSummary.tsx
@@ -9,6 +9,7 @@ import {
   Tag,
   WRAP,
 } from '@opentrons/components'
+import { AIR } from '@opentrons/step-generation'
 
 import { getLiquidDisplay } from './getLiquidDisplay'
 import { getWellsForStepSummary } from './utils'
@@ -74,16 +75,19 @@ export function MoveLiquidSummary(props: MoveLiquidSummaryProps): JSX.Element {
     moveLiquidType = 'distribute'
   }
 
-  const liquidIds =
-    liquidState.labware[aspirate_labware] != null
-      ? [
-          ...new Set(
-            aspirateWells.flatMap(well =>
-              Object.keys(liquidState.labware[aspirate_labware][well])
-            )
-          ),
-        ]
-      : []
+  const liquidIds = Array.from(
+    aspirateWells.reduce<Set<string>>((acc, well) => {
+      for (const [liquidId, { volume }] of Object.entries(
+        liquidState.labware[aspirate_labware][well]
+      )) {
+        if (liquidId !== AIR && volume > 0) {
+          acc.add(liquidId)
+        }
+      }
+      return acc
+    }, new Set<string>())
+  )
+
   const liquidInfo = liquidIds.map(id => liquidEntities[id])
   const liquidDisplay = getLiquidDisplay(liquidInfo, t)
 

--- a/protocol-designer/src/components/organisms/StepSummary/__tests__/utils.test.ts
+++ b/protocol-designer/src/components/organisms/StepSummary/__tests__/utils.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest'
+
+import { AIR } from '@opentrons/step-generation'
+
+import { getLiquidIdsForStepSummary } from '../utils'
+
+const MOCK_LABWARE_ID = 'mockLabwareId'
+
+describe('getLiquidIdsForStepSummary', () => {
+  it('should return empty array when no liquids present', () => {
+    const liquidState = {
+      labware: {
+        [MOCK_LABWARE_ID]: {
+          A1: {},
+          A2: {},
+        },
+      },
+    }
+    const result = getLiquidIdsForStepSummary(
+      liquidState as any,
+      MOCK_LABWARE_ID,
+      ['A1', 'A2']
+    )
+    expect(result).toEqual([])
+  })
+
+  it('should return unique liquid IDs with volume > 0', () => {
+    const liquidState = {
+      labware: {
+        [MOCK_LABWARE_ID]: {
+          A1: {
+            liquid0: { volume: 10 },
+            liquid1: { volume: 20 },
+          },
+          A2: {
+            liquid0: { volume: 15 },
+            liquid2: { volume: 25 },
+          },
+        },
+      },
+    }
+    const result = getLiquidIdsForStepSummary(
+      liquidState as any,
+      MOCK_LABWARE_ID,
+      ['A1', 'A2']
+    )
+    expect(result).toEqual(['liquid0', 'liquid1', 'liquid2'])
+  })
+
+  it('should exclude AIR liquid ID', () => {
+    const liquidState = {
+      labware: {
+        [MOCK_LABWARE_ID]: {
+          A1: {
+            [AIR]: { volume: 10 },
+            liquid0: { volume: 20 },
+          },
+        },
+      },
+    }
+    const result = getLiquidIdsForStepSummary(
+      liquidState as any,
+      MOCK_LABWARE_ID,
+      ['A1']
+    )
+    expect(result).toEqual(['liquid0'])
+  })
+
+  it('should exclude liquids with volume <= 0', () => {
+    const liquidState = {
+      labware: {
+        [MOCK_LABWARE_ID]: {
+          A1: {
+            liquid0: { volume: 0 },
+            liquid1: { volume: -5 },
+            liquid2: { volume: 10 },
+          },
+        },
+      },
+    }
+    const result = getLiquidIdsForStepSummary(
+      liquidState as any,
+      MOCK_LABWARE_ID,
+      ['A1']
+    )
+    expect(result).toEqual(['liquid2'])
+  })
+
+  it('should handle multiple wells with different liquids', () => {
+    const liquidState = {
+      labware: {
+        [MOCK_LABWARE_ID]: {
+          A1: {
+            liquid0: { volume: 10 },
+            liquid1: { volume: 20 },
+          },
+          B1: {
+            liquid2: { volume: 15 },
+            liquid3: { volume: 25 },
+          },
+        },
+      },
+    }
+    const result = getLiquidIdsForStepSummary(
+      liquidState as any,
+      MOCK_LABWARE_ID,
+      ['A1', 'B1']
+    )
+    expect(result).toEqual(['liquid0', 'liquid1', 'liquid2', 'liquid3'])
+  })
+})

--- a/protocol-designer/src/components/organisms/StepSummary/utils.ts
+++ b/protocol-designer/src/components/organisms/StepSummary/utils.ts
@@ -1,6 +1,10 @@
 import first from 'lodash/first'
 import last from 'lodash/last'
 
+import { AIR } from '@opentrons/step-generation'
+
+import type { RobotState } from '@opentrons/step-generation'
+
 export const getWellsForStepSummary = (
   targetWells: string[],
   labwareWells: string[]
@@ -16,4 +20,23 @@ export const getWellsForStepSummary = (
   return isInOrder
     ? `${first(targetWells)}-${last(targetWells)}`
     : `${targetWells.length} wells`
+}
+
+export const getLiquidIdsForStepSummary = (
+  liquidState: RobotState['liquidState'],
+  labwareId: string,
+  wells: string[]
+): string[] => {
+  return Array.from(
+    wells.reduce<Set<string>>((acc, well) => {
+      for (const [liquidId, { volume }] of Object.entries(
+        liquidState.labware[labwareId]?.[well] ?? {}
+      )) {
+        if (liquidId !== AIR && volume > 0) {
+          acc.add(liquidId)
+        }
+      }
+      return acc
+    }, new Set<string>())
+  )
 }


### PR DESCRIPTION
# Overview

This PR fixes the logic for getting valid liquid IDs for `MoveLiquidSummary` and `MixSummary`. We should filter for liquid IDs in the implicated wells on 1) not being air, and 2) having non-zero volume. The fix resolves a whitescreen when duplicating a step with one of these 2 step types.

## Test Plan and Hands on Testing

1) create or upload a PD protocol with a move liquid and mix step ([example](https://github.com/user-attachments/files/20510395/master.json))
2) duplicate move liquid step
3) click the duplicated step to select and verify that no white screen occurs
4) repeat 2 and 3 with mix step

## Changelog

- update logic for getting liquid IDs from moveLiquid/mix step and refactor to util
- wire up in `MoveLiquidSummary` and `MixSummary`
- add tests

## Review requests

see test plan

## Risk assessment

low