### PR TITLE
fix(app,protocol-designer): Mute <video> tags to prevent interrupting Bluetooth audio

### DIFF
--- a/app/src/organisms/Desktop/CalibrateTipLength/index.tsx
+++ b/app/src/organisms/Desktop/CalibrateTipLength/index.tsx
@@ -208,6 +208,7 @@ function TipLengthCalibrationComplete(
           max-height: 15rem;
         `}
         autoPlay={true}
+        muted={true}
         loop={true}
         controls={false}
       >

--- a/app/src/organisms/Desktop/CalibrationPanels/MeasureNozzle.tsx
+++ b/app/src/organisms/Desktop/CalibrationPanels/MeasureNozzle.tsx
@@ -157,6 +157,7 @@ export function MeasureNozzle(props: CalibrationPanelProps): JSX.Element {
                 max-height: 15rem;
               `}
               autoPlay={true}
+              muted={true}
               loop={true}
               controls={false}
             >

--- a/app/src/organisms/Desktop/CalibrationPanels/MeasureTip.tsx
+++ b/app/src/organisms/Desktop/CalibrationPanels/MeasureTip.tsx
@@ -156,6 +156,7 @@ export function MeasureTip(props: CalibrationPanelProps): JSX.Element {
                 max-height: 15rem;
               `}
               autoPlay={true}
+              muted={true}
               loop={true}
               controls={false}
             >

--- a/app/src/organisms/Desktop/CalibrationPanels/SaveXYPoint.tsx
+++ b/app/src/organisms/Desktop/CalibrationPanels/SaveXYPoint.tsx
@@ -240,6 +240,7 @@ export function SaveXYPoint(props: CalibrationPanelProps): JSX.Element | null {
                 max-height: 15rem;
               `}
               autoPlay={true}
+              muted={true}
               loop={true}
               controls={false}
               aria-label={`${mount} ${

--- a/app/src/organisms/Desktop/CalibrationPanels/SaveZPoint.tsx
+++ b/app/src/organisms/Desktop/CalibrationPanels/SaveZPoint.tsx
@@ -121,6 +121,7 @@ export function SaveZPoint(props: CalibrationPanelProps): JSX.Element {
                 max-height: 15rem;
               `}
               autoPlay={true}
+              muted={true}
               loop={true}
               controls={false}
               aria-label={`${mount} ${

--- a/app/src/organisms/Desktop/CalibrationPanels/TipPickUp.tsx
+++ b/app/src/organisms/Desktop/CalibrationPanels/TipPickUp.tsx
@@ -85,6 +85,7 @@ export function TipPickUp(props: CalibrationPanelProps): JSX.Element {
                 max-height: 15rem;
               `}
               autoPlay={true}
+              muted={true}
               loop={true}
               controls={false}
             >

--- a/app/src/organisms/Desktop/Devices/ChangePipette/LevelPipette.tsx
+++ b/app/src/organisms/Desktop/Devices/ChangePipette/LevelPipette.tsx
@@ -40,6 +40,7 @@ export function LevelingVideo(props: {
         margin-left: ${SPACING.spacing16};
       `}
       autoPlay={true}
+      muted={true}
       loop={true}
       controls={true}
     >

--- a/app/src/organisms/DropTipWizardFlows/steps/BeforeBeginning.tsx
+++ b/app/src/organisms/DropTipWizardFlows/steps/BeforeBeginning.tsx
@@ -172,6 +172,7 @@ function DropTipOption({
           max-width: 8.96rem;
         `}
         autoPlay={true}
+        muted={true}
         loop={true}
         controls={false}
         aria-label={flowType}

--- a/app/src/organisms/ErrorRecoveryFlows/shared/ReleaseLabware.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/ReleaseLabware.tsx
@@ -86,6 +86,7 @@ export function ReleaseLabware({
         <Flex css={ANIMATION_CONTAINER_STYLE}>
           <video
             autoPlay={true}
+            muted={true}
             loop={true}
             controls={false}
             role="presentation"

--- a/app/src/organisms/GripperWizardFlows/MountGripper.tsx
+++ b/app/src/organisms/GripperWizardFlows/MountGripper.tsx
@@ -135,6 +135,7 @@ export const MountGripper = (
             max-height: 20rem;
           `}
           autoPlay={true}
+          muted={true}
           loop={true}
           controls={false}
           aria-label="connect and screw in gripper"

--- a/app/src/organisms/GripperWizardFlows/MovePin.tsx
+++ b/app/src/organisms/GripperWizardFlows/MovePin.tsx
@@ -156,6 +156,7 @@ export const MovePin = (props: MovePinProps): JSX.Element | null => {
               max-height: 100%;
             `}
             autoPlay={true}
+            muted={true}
             loop={true}
             controls={false}
             aria-label="calibrating front jaw"
@@ -169,6 +170,7 @@ export const MovePin = (props: MovePinProps): JSX.Element | null => {
       buttonText: t('begin_calibration'),
       prepImage: (
         <video
+          muted={true}
           css={css`
             max-width: 100%;
             max-height: 20rem;
@@ -187,6 +189,7 @@ export const MovePin = (props: MovePinProps): JSX.Element | null => {
       inProgressImage: (
         <Flex height="10.2rem" paddingTop={SPACING.spacing4}>
           <video
+            muted={true}
             css={css`
               max-width: 100%;
               max-height: 100%;
@@ -205,6 +208,7 @@ export const MovePin = (props: MovePinProps): JSX.Element | null => {
       buttonText: t('continue_calibration'),
       prepImage: (
         <video
+          muted={true}
           css={css`
             max-width: 100%;
             max-height: 20rem;
@@ -225,6 +229,7 @@ export const MovePin = (props: MovePinProps): JSX.Element | null => {
       buttonText: t('complete_calibration'),
       prepImage: (
         <video
+          muted={true}
           css={css`
             max-width: 100%;
             max-height: 20rem;

--- a/app/src/organisms/GripperWizardFlows/UnmountGripper.tsx
+++ b/app/src/organisms/GripperWizardFlows/UnmountGripper.tsx
@@ -145,6 +145,7 @@ export const UnmountGripper = (
             max-height: 20rem;
           `}
           autoPlay={true}
+          muted={true}
           loop={true}
           controls={false}
           aria-label="unscrew and disconnect gripper"

--- a/app/src/organisms/ModuleWizardFlows/AttachProbe.tsx
+++ b/app/src/organisms/ModuleWizardFlows/AttachProbe.tsx
@@ -83,6 +83,7 @@ export const AttachProbe = (props: AttachProbeProps): JSX.Element | null => {
           max-height: 100%;
         `}
         autoPlay={true}
+        muted={true}
         loop={true}
         controls={false}
       >

--- a/app/src/organisms/ModuleWizardFlows/DetachProbe.tsx
+++ b/app/src/organisms/ModuleWizardFlows/DetachProbe.tsx
@@ -53,6 +53,7 @@ export const DetachProbe = (
           max-height: 100%;
         `}
         autoPlay={true}
+        muted={true}
         loop={true}
         controls={false}
       >

--- a/app/src/organisms/ModuleWizardFlows/InstallShuttle.tsx
+++ b/app/src/organisms/ModuleWizardFlows/InstallShuttle.tsx
@@ -42,6 +42,7 @@ export const InstallShuttle = (
           max-height: 100%;
         `}
         autoPlay={true}
+        muted={true}
         loop={true}
         controls={false}
       >

--- a/app/src/organisms/ModuleWizardFlows/PlaceAdapter.tsx
+++ b/app/src/organisms/ModuleWizardFlows/PlaceAdapter.tsx
@@ -191,6 +191,7 @@ export const PlaceAdapter = (props: PlaceAdapterProps): JSX.Element | null => {
           max-height: 100%;
         `}
         autoPlay={true}
+        muted={true}
         loop={true}
         controls={false}
       >

--- a/app/src/organisms/PipetteWizardFlows/AttachProbe.tsx
+++ b/app/src/organisms/PipetteWizardFlows/AttachProbe.tsx
@@ -148,6 +148,7 @@ export const AttachProbe = (props: AttachProbeProps): JSX.Element | null => {
           max-height: 100%;
         `}
         autoPlay={true}
+        muted={true}
         loop={true}
         controls={false}
         data-testid={src}

--- a/app/src/organisms/PipetteWizardFlows/utils.tsx
+++ b/app/src/organisms/PipetteWizardFlows/utils.tsx
@@ -88,6 +88,7 @@ export function getPipetteAnimations(
           : `12rem`};
       `}
       autoPlay={true}
+      muted={true}
       loop={true}
       controls={false}
       data-testid={
@@ -128,6 +129,7 @@ export function getPipetteAnimations96(
   }
   return (
     <video
+      muted={true}
       css={css`
         padding-top: ${SPACING.spacing4};
         max-width: 100%;

--- a/protocol-designer/src/pages/Onboarding/WizardBody.tsx
+++ b/protocol-designer/src/pages/Onboarding/WizardBody.tsx
@@ -190,6 +190,7 @@ export function WizardBody(props: WizardBodyProps): JSX.Element {
                 border-radius: ${BORDERS.borderRadius16};
               `}
               autoPlay
+              muted={true}
               key={`video-${subStepNumber ?? 1}`}
               loop={false}
               controls={false}


### PR DESCRIPTION
## Overview

Closes EXEC-1588.

I don't fully understand what's going on here, but I suspect it's something like this:

1. Navigating around the desktop app makes animations, implemented with `<video>` tags, appear and disappear.
2. Something about that is tricking the browser, or maybe the operating system, into thinking that you've started watching media on your computer. To play that media's audio, it wrenches control of your headphones away from the other connected device, and whatever that other device was playing cuts out. Even though none of our animations actually have audio.

Adding a `muted` attribute to every `<video>` tag in the codebase seems to fix it.

## Test Plan and Hands on Testing

* [x] Do the test plan in EXEC-1588.

## Review requests

* Did I miss any?
* None of these are actually intended to have sound, right?

## Risk assessment

Low.
