### PR TITLE
fix(api, shared-data): Allow tough universal lid to stack universally

### DIFF
--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[2b866b03f3][Flex_S_v2_21_P1000_96_GRIP_HS_MB_TC_TM_Smoke].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[2b866b03f3][Flex_S_v2_21_P1000_96_GRIP_HS_MB_TC_TM_Smoke].json
@@ -1262,6 +1262,14 @@
             "brand": "Opentrons",
             "brandId": []
           },
+          "compatibleParentLabware": [
+            "armadillo_96_wellplate_200ul_pcr_full_skirt",
+            "biorad_96_wellplate_200ul_pcr",
+            "opentrons_96_wellplate_200ul_pcr_full_skirt",
+            "opentrons_flex_deck_riser",
+            "opentrons_tough_pcr_auto_sealing_lid",
+            "protocol_engine_lid_stack_object"
+          ],
           "cornerOffsetFromSlot": {
             "x": 0,
             "y": 0,
@@ -1430,6 +1438,14 @@
             "brand": "Opentrons",
             "brandId": []
           },
+          "compatibleParentLabware": [
+            "armadillo_96_wellplate_200ul_pcr_full_skirt",
+            "biorad_96_wellplate_200ul_pcr",
+            "opentrons_96_wellplate_200ul_pcr_full_skirt",
+            "opentrons_flex_deck_riser",
+            "opentrons_tough_pcr_auto_sealing_lid",
+            "protocol_engine_lid_stack_object"
+          ],
           "cornerOffsetFromSlot": {
             "x": 0,
             "y": 0,
@@ -1602,6 +1618,14 @@
             "brand": "Opentrons",
             "brandId": []
           },
+          "compatibleParentLabware": [
+            "armadillo_96_wellplate_200ul_pcr_full_skirt",
+            "biorad_96_wellplate_200ul_pcr",
+            "opentrons_96_wellplate_200ul_pcr_full_skirt",
+            "opentrons_flex_deck_riser",
+            "opentrons_tough_pcr_auto_sealing_lid",
+            "protocol_engine_lid_stack_object"
+          ],
           "cornerOffsetFromSlot": {
             "x": 0,
             "y": 0,
@@ -1778,6 +1802,14 @@
             "brand": "Opentrons",
             "brandId": []
           },
+          "compatibleParentLabware": [
+            "armadillo_96_wellplate_200ul_pcr_full_skirt",
+            "biorad_96_wellplate_200ul_pcr",
+            "opentrons_96_wellplate_200ul_pcr_full_skirt",
+            "opentrons_flex_deck_riser",
+            "opentrons_tough_pcr_auto_sealing_lid",
+            "protocol_engine_lid_stack_object"
+          ],
           "cornerOffsetFromSlot": {
             "x": 0,
             "y": 0,
@@ -1958,6 +1990,14 @@
             "brand": "Opentrons",
             "brandId": []
           },
+          "compatibleParentLabware": [
+            "armadillo_96_wellplate_200ul_pcr_full_skirt",
+            "biorad_96_wellplate_200ul_pcr",
+            "opentrons_96_wellplate_200ul_pcr_full_skirt",
+            "opentrons_flex_deck_riser",
+            "opentrons_tough_pcr_auto_sealing_lid",
+            "protocol_engine_lid_stack_object"
+          ],
           "cornerOffsetFromSlot": {
             "x": 0,
             "y": 0,

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[7d16d5dbf0][Flex_X_v2_21_tc_lids_wrong_target].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[7d16d5dbf0][Flex_X_v2_21_tc_lids_wrong_target].json
@@ -2032,6 +2032,14 @@
             "brand": "Opentrons",
             "brandId": []
           },
+          "compatibleParentLabware": [
+            "armadillo_96_wellplate_200ul_pcr_full_skirt",
+            "biorad_96_wellplate_200ul_pcr",
+            "opentrons_96_wellplate_200ul_pcr_full_skirt",
+            "opentrons_flex_deck_riser",
+            "opentrons_tough_pcr_auto_sealing_lid",
+            "protocol_engine_lid_stack_object"
+          ],
           "cornerOffsetFromSlot": {
             "x": 0,
             "y": 0,
@@ -2199,6 +2207,14 @@
             "brand": "Opentrons",
             "brandId": []
           },
+          "compatibleParentLabware": [
+            "armadillo_96_wellplate_200ul_pcr_full_skirt",
+            "biorad_96_wellplate_200ul_pcr",
+            "opentrons_96_wellplate_200ul_pcr_full_skirt",
+            "opentrons_flex_deck_riser",
+            "opentrons_tough_pcr_auto_sealing_lid",
+            "protocol_engine_lid_stack_object"
+          ],
           "cornerOffsetFromSlot": {
             "x": 0,
             "y": 0,
@@ -2370,6 +2386,14 @@
             "brand": "Opentrons",
             "brandId": []
           },
+          "compatibleParentLabware": [
+            "armadillo_96_wellplate_200ul_pcr_full_skirt",
+            "biorad_96_wellplate_200ul_pcr",
+            "opentrons_96_wellplate_200ul_pcr_full_skirt",
+            "opentrons_flex_deck_riser",
+            "opentrons_tough_pcr_auto_sealing_lid",
+            "protocol_engine_lid_stack_object"
+          ],
           "cornerOffsetFromSlot": {
             "x": 0,
             "y": 0,
@@ -2545,6 +2569,14 @@
             "brand": "Opentrons",
             "brandId": []
           },
+          "compatibleParentLabware": [
+            "armadillo_96_wellplate_200ul_pcr_full_skirt",
+            "biorad_96_wellplate_200ul_pcr",
+            "opentrons_96_wellplate_200ul_pcr_full_skirt",
+            "opentrons_flex_deck_riser",
+            "opentrons_tough_pcr_auto_sealing_lid",
+            "protocol_engine_lid_stack_object"
+          ],
           "cornerOffsetFromSlot": {
             "x": 0,
             "y": 0,
@@ -2724,6 +2756,14 @@
             "brand": "Opentrons",
             "brandId": []
           },
+          "compatibleParentLabware": [
+            "armadillo_96_wellplate_200ul_pcr_full_skirt",
+            "biorad_96_wellplate_200ul_pcr",
+            "opentrons_96_wellplate_200ul_pcr_full_skirt",
+            "opentrons_flex_deck_riser",
+            "opentrons_tough_pcr_auto_sealing_lid",
+            "protocol_engine_lid_stack_object"
+          ],
           "cornerOffsetFromSlot": {
             "x": 0,
             "y": 0,

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[99c15c6c62][Flex_S_v2_21_tc_lids_happy_path].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[99c15c6c62][Flex_S_v2_21_tc_lids_happy_path].json
@@ -118,6 +118,14 @@
             "brand": "Opentrons",
             "brandId": []
           },
+          "compatibleParentLabware": [
+            "armadillo_96_wellplate_200ul_pcr_full_skirt",
+            "biorad_96_wellplate_200ul_pcr",
+            "opentrons_96_wellplate_200ul_pcr_full_skirt",
+            "opentrons_flex_deck_riser",
+            "opentrons_tough_pcr_auto_sealing_lid",
+            "protocol_engine_lid_stack_object"
+          ],
           "cornerOffsetFromSlot": {
             "x": 0,
             "y": 0,
@@ -285,6 +293,14 @@
             "brand": "Opentrons",
             "brandId": []
           },
+          "compatibleParentLabware": [
+            "armadillo_96_wellplate_200ul_pcr_full_skirt",
+            "biorad_96_wellplate_200ul_pcr",
+            "opentrons_96_wellplate_200ul_pcr_full_skirt",
+            "opentrons_flex_deck_riser",
+            "opentrons_tough_pcr_auto_sealing_lid",
+            "protocol_engine_lid_stack_object"
+          ],
           "cornerOffsetFromSlot": {
             "x": 0,
             "y": 0,
@@ -456,6 +472,14 @@
             "brand": "Opentrons",
             "brandId": []
           },
+          "compatibleParentLabware": [
+            "armadillo_96_wellplate_200ul_pcr_full_skirt",
+            "biorad_96_wellplate_200ul_pcr",
+            "opentrons_96_wellplate_200ul_pcr_full_skirt",
+            "opentrons_flex_deck_riser",
+            "opentrons_tough_pcr_auto_sealing_lid",
+            "protocol_engine_lid_stack_object"
+          ],
           "cornerOffsetFromSlot": {
             "x": 0,
             "y": 0,

--- a/api/src/opentrons/protocol_engine/commands/load_labware.py
+++ b/api/src/opentrons/protocol_engine/commands/load_labware.py
@@ -165,25 +165,6 @@ class LoadLabwareImplementation(
                 top_labware_definition=loaded_labware.definition,
                 bottom_labware_id=verified_location.labwareId,
             )
-            # Validate load location is valid for lids
-            if labware_validation.validate_definition_is_lid(
-                definition=loaded_labware.definition
-            ):
-                # This parent is assumed to be compatible, unless the lid enumerates
-                # all its compatible parents and this parent is missing from the list.
-                parent_is_incompatible = (
-                    loaded_labware.definition.compatibleParentLabware is not None
-                    and self._state_view.labware.get_load_name(
-                        verified_location.labwareId
-                    )
-                    not in loaded_labware.definition.compatibleParentLabware
-                )
-
-                if parent_is_incompatible:
-                    raise ValueError(
-                        f"Labware Lid {params.loadName} may not be loaded on parent labware"
-                        f" {self._state_view.labware.get_display_name(verified_location.labwareId)}."
-                    )
 
         # Validate labware for the absorbance reader
         if self._is_loading_to_module(

--- a/api/src/opentrons/protocol_engine/resources/labware_validation.py
+++ b/api/src/opentrons/protocol_engine/resources/labware_validation.py
@@ -50,10 +50,10 @@ def validate_labware_can_be_stacked(
     """Validate that the labware being loaded onto is in the above labware's stackingOffsetWithLabware definition."""
     return (
         below_labware_load_name in top_labware_definition.stackingOffsetWithLabware
-        and top_labware_definition.compatibleParentLabware is not None
-    ) or (
-        "default" in top_labware_definition.stackingOffsetWithLabware
-        and top_labware_definition.compatibleParentLabware is None
+        or (
+            "default" in top_labware_definition.stackingOffsetWithLabware
+            and top_labware_definition.compatibleParentLabware is None
+        )
     )
 
 

--- a/api/src/opentrons/protocol_engine/resources/labware_validation.py
+++ b/api/src/opentrons/protocol_engine/resources/labware_validation.py
@@ -48,7 +48,10 @@ def validate_labware_can_be_stacked(
     top_labware_definition: LabwareDefinition, below_labware_load_name: str
 ) -> bool:
     """Validate that the labware being loaded onto is in the above labware's stackingOffsetWithLabware definition."""
-    return below_labware_load_name in top_labware_definition.stackingOffsetWithLabware
+    return (
+        below_labware_load_name in top_labware_definition.stackingOffsetWithLabware
+        or "default" in top_labware_definition.stackingOffsetWithLabware
+    )
 
 
 def validate_labware_can_be_ondeck(definition: LabwareDefinition) -> bool:

--- a/api/src/opentrons/protocol_engine/resources/labware_validation.py
+++ b/api/src/opentrons/protocol_engine/resources/labware_validation.py
@@ -50,7 +50,10 @@ def validate_labware_can_be_stacked(
     """Validate that the labware being loaded onto is in the above labware's stackingOffsetWithLabware definition."""
     return (
         below_labware_load_name in top_labware_definition.stackingOffsetWithLabware
-        or "default" in top_labware_definition.stackingOffsetWithLabware
+        or (
+            "default" in top_labware_definition.stackingOffsetWithLabware
+            and top_labware_definition.compatibleParentLabware is None
+        )
     )
 
 

--- a/api/src/opentrons/protocol_engine/resources/labware_validation.py
+++ b/api/src/opentrons/protocol_engine/resources/labware_validation.py
@@ -50,10 +50,10 @@ def validate_labware_can_be_stacked(
     """Validate that the labware being loaded onto is in the above labware's stackingOffsetWithLabware definition."""
     return (
         below_labware_load_name in top_labware_definition.stackingOffsetWithLabware
-        or (
-            "default" in top_labware_definition.stackingOffsetWithLabware
-            and top_labware_definition.compatibleParentLabware is None
-        )
+        and top_labware_definition.compatibleParentLabware is not None
+    ) or (
+        "default" in top_labware_definition.stackingOffsetWithLabware
+        and top_labware_definition.compatibleParentLabware is None
     )
 
 

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -1131,6 +1131,18 @@ class LabwareView:
             raise errors.LabwareCannotBeStackedError(
                 f"Labware {top_labware_definition.parameters.loadName} cannot be loaded onto labware {below_labware.loadName}"
             )
+        elif (
+            labware_validation.validate_definition_is_lid(top_labware_definition)
+            and top_labware_definition.compatibleParentLabware is not None
+            and self.get_load_name(bottom_labware_id)
+            not in top_labware_definition.compatibleParentLabware
+        ):
+            # This parent is assumed to be compatible, unless the lid enumerates
+            # all its compatible parents and this parent is missing from the list.
+            raise ValueError(
+                f"Labware Lid {top_labware_definition.parameters.loadName} may not be loaded on parent labware"
+                f" {self.get_display_name(bottom_labware_id)}."
+            )
         elif isinstance(below_labware.location, ModuleLocation):
             below_definition = self.get_definition(labware_id=below_labware.id)
             if not labware_validation.validate_definition_is_adapter(

--- a/shared-data/labware/definitions/2/opentrons_tough_pcr_auto_sealing_lid/1.json
+++ b/shared-data/labware/definitions/2/opentrons_tough_pcr_auto_sealing_lid/1.json
@@ -83,6 +83,14 @@
     }
   },
   "stackLimit": 5,
+  "compatibleParentLabware": [
+    "armadillo_96_wellplate_200ul_pcr_full_skirt",
+    "opentrons_96_wellplate_200ul_pcr_full_skirt",
+    "opentrons_tough_pcr_auto_sealing_lid",
+    "biorad_96_wellplate_200ul_pcr",
+    "opentrons_flex_deck_riser",
+    "protocol_engine_lid_stack_object"
+  ],
   "gripForce": 15,
   "gripHeightFromLabwareBottom": 7.91,
   "gripperOffsets": {

--- a/shared-data/labware/definitions/2/opentrons_tough_universal_lid/1.json
+++ b/shared-data/labware/definitions/2/opentrons_tough_universal_lid/1.json
@@ -47,9 +47,24 @@
       "x": 0,
       "y": 0,
       "z": 6.6
+    },
+    "opentrons_96_wellplate_200ul_pcr_full_skirt": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "protocol_engine_lid_stack_object": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "opentrons_tough_universal_lid": {
+      "x": 0,
+      "y": 0,
+      "z": 0
     }
   },
-  "stackLimit": 1,
+  "stackLimit": 2,
   "gripForce": 10,
   "gripHeightFromLabwareBottom": 5.3,
   "gripperOffsets": {

--- a/shared-data/labware/definitions/2/opentrons_tough_universal_lid/1.json
+++ b/shared-data/labware/definitions/2/opentrons_tough_universal_lid/1.json
@@ -51,7 +51,7 @@
     "opentrons_96_wellplate_200ul_pcr_full_skirt": {
       "x": 0,
       "y": 0,
-      "z": 0
+      "z": 7.1
     },
     "protocol_engine_lid_stack_object": {
       "x": 0,
@@ -61,10 +61,10 @@
     "opentrons_tough_universal_lid": {
       "x": 0,
       "y": 0,
-      "z": 0
+      "z": 0.8
     }
   },
-  "stackLimit": 2,
+  "stackLimit": 5,
   "gripForce": 10,
   "gripHeightFromLabwareBottom": 5.3,
   "gripperOffsets": {


### PR DESCRIPTION
# Overview
Covers RABR-777

Update the way we validate stacking of labware to ensure that a labware which utilizes the "default" stacking offset flag and DOES NOT include a compatible parent list can stack on any labware.

Universal Lid Stacking offset of 0.8mm based on overall height of 8.8mm - stacked measured height of 8.0mm:
![image (1)](https://github.com/user-attachments/assets/15574a30-ad65-4698-81b5-bb644a203993)



## Test Plan and Hands on Testing
- [x] The following protocol should pass analysis and run on a robot:
```
from opentrons.protocol_api import ProtocolContext

metadata = {
    "protocolName": "Tip rack basic labware stuff",
    "author": "Opentrons <protocols@opentrons.com>",
}
requirements = {
    "robotType": "Flex",
    "apiLevel": "2.23",
}

def run(protocol: ProtocolContext) -> None:
    trash = protocol.load_trash_bin("A3")
    universal_stack = protocol.load_lid_stack(load_name="opentrons_tough_universal_lid", location="A1", quantity=2)
    plate = protocol.load_labware("nest_96_wellplate_200ul_flat", "B2")
    plate2 = protocol.load_labware("nest_96_wellplate_200ul_flat", "B3", lid="opentrons_tough_universal_lid")
    protocol.move_lid(plate2, trash, True)
    protocol.move_lid(universal_stack, plate, True)
    protocol.move_lid(universal_stack, plate2, True)
```

## Changelog
- Updated the parent labware validation to pass for defaults
- Update the universal lid definition to give it stacking offsets for the lid stack object, opentrons well plate, and themselves

## Review requests
Is the risk assessment below a big red flag?

## Risk assessment
Medium to low. Currently this means that new labware made (and this one) with a default stacking offset and no compatible parents can go on ANYTHING. This means we can use it on tipracks, and tube racks, and all the horrible shapes therein. 