### PR TITLE
feat(protocol-designer, step-generation): support moving stacks and top item of stack

### DIFF
--- a/components/src/molecules/DropdownMenu/index.tsx
+++ b/components/src/molecules/DropdownMenu/index.tsx
@@ -310,12 +310,14 @@ export function DropdownMenu(props: DropdownMenuProps): JSX.Element {
                   : TYPOGRAPHY.pRegular};
               `}
             >
-              <StyledText
-                desktopStyle="captionRegular"
-                css={LINE_CLAMP_TEXT_STYLE(1)}
-              >
-                {currentOption.name}
-              </StyledText>
+              {currentOption.deckLabel !== currentOption.name ? (
+                <StyledText
+                  desktopStyle="captionRegular"
+                  css={LINE_CLAMP_TEXT_STYLE(1)}
+                >
+                  {currentOption.name}
+                </StyledText>
+              ) : null}
             </Flex>
           </Flex>
           <Icon
@@ -363,12 +365,14 @@ export function DropdownMenu(props: DropdownMenuProps): JSX.Element {
                       flexDirection={DIRECTION_COLUMN}
                       gridGap={option.subtext != null ? SPACING.spacing4 : '0'}
                     >
-                      <StyledText
-                        desktopStyle="captionRegular"
-                        css={LINE_CLAMP_TEXT_STYLE(3, true)}
-                      >
-                        {option.name}
-                      </StyledText>
+                      {option.deckLabel !== option.name ? (
+                        <StyledText
+                          desktopStyle="captionRegular"
+                          css={LINE_CLAMP_TEXT_STYLE(3, true)}
+                        >
+                          {option.name}
+                        </StyledText>
+                      ) : null}
                       <StyledText
                         desktopStyle="captionRegular"
                         color={COLORS.grey60}

--- a/protocol-designer/src/assets/localization/en/protocol_steps.json
+++ b/protocol-designer/src/assets/localization/en/protocol_steps.json
@@ -183,6 +183,7 @@
   "touch_tip_position": "Touch tip position from top",
   "transfer": "Transfer",
   "unknown_module": "Unknown module",
+  "unoccupied_stack": "Stack of {{name}}",
   "valid_range": "Must be between 0.1 and {{max}} {{unit}}",
   "view_details": "View details",
   "volume_per_well": "Volume per well",

--- a/protocol-designer/src/components/molecules/DropdownStepFormField/index.tsx
+++ b/protocol-designer/src/components/molecules/DropdownStepFormField/index.tsx
@@ -137,12 +137,14 @@ export function DropdownStepFormField(
                 flexDirection={DIRECTION_COLUMN}
                 gridGap={options[0].subtext != null ? SPACING.spacing4 : '0'}
               >
-                <StyledText
-                  desktopStyle="captionRegular"
-                  css={LINE_CLAMP_TEXT_STYLE(3, true)}
-                >
-                  {options[0].name}
-                </StyledText>
+                {options[0].name !== options[0].deckLabel ? (
+                  <StyledText
+                    desktopStyle="captionRegular"
+                    css={LINE_CLAMP_TEXT_STYLE(3, true)}
+                  >
+                    {options[0].name}
+                  </StyledText>
+                ) : null}
                 <StyledText
                   desktopStyle="captionRegular"
                   color={COLORS.black70}

--- a/protocol-designer/src/components/organisms/LabwareCard/index.tsx
+++ b/protocol-designer/src/components/organisms/LabwareCard/index.tsx
@@ -20,13 +20,13 @@ import {
   Tag,
   TYPOGRAPHY,
 } from '@opentrons/components'
-import { getSlotInLocationStack } from '@opentrons/step-generation'
 
 import { getEnableStacking } from '../../../feature-flags/selectors'
 import { openIngredientSelector } from '../../../labware-ingred/actions'
 import { getDeckSetupForActiveItem } from '../../../top-selectors/labware-locations'
 import * as wellContentsSelectors from '../../../top-selectors/well-contents'
 import { getLabwareNicknamesById } from '../../../ui/labware/selectors'
+import { getAllLabwareIdsOfCertainURIOnStack } from '../../../utils'
 import { LINK_BUTTON_STYLE } from '../../atoms'
 import { LabwareCardOverflowMenu } from '../LabwareCardOverflowMenu'
 import { getLiquidIdsOnLabware } from '../utils'
@@ -48,14 +48,9 @@ export function LabwareCard(props: LabwareCardProps): JSX.Element {
   const { def } = labware
   const enableStacking = useSelector(getEnableStacking)
   const { labware: deckSetupLabware } = useSelector(getDeckSetupForActiveItem)
-  const allLabwareIdsOnStack = Object.values(deckSetupLabware).reduce<string[]>(
-    (acc, { labwareDefURI, stack, id }) => {
-      return labwareDefURI === labware.labwareDefURI &&
-        getSlotInLocationStack(stack) === getSlotInLocationStack(labware.stack)
-        ? [...acc, id]
-        : acc
-    },
-    []
+  const allLabwareIdsOnStack = getAllLabwareIdsOfCertainURIOnStack(
+    deckSetupLabware,
+    labware
   )
   const nickNames = useSelector(getLabwareNicknamesById)
   const allWellContentsForActiveItem = useSelector(

--- a/protocol-designer/src/constants.ts
+++ b/protocol-designer/src/constants.ts
@@ -1,34 +1,13 @@
 import mapValues from 'lodash/mapValues'
 
-import {
-  ABSORBANCE_READER_TYPE,
-  ABSORBANCE_READER_V1,
-  FLEX_ROBOT_TYPE,
-  HEATERSHAKER_MODULE_TYPE,
-  HEATERSHAKER_MODULE_V1,
-  MAGNETIC_BLOCK_TYPE,
-  MAGNETIC_BLOCK_V1,
-  MAGNETIC_MODULE_TYPE,
-  MAGNETIC_MODULE_V1,
-  MAGNETIC_MODULE_V2,
-  OT2_ROBOT_TYPE,
-  TEMPERATURE_MODULE_TYPE,
-  TEMPERATURE_MODULE_V1,
-  TEMPERATURE_MODULE_V2,
-  THERMOCYCLER_MODULE_TYPE,
-  THERMOCYCLER_MODULE_V1,
-  THERMOCYCLER_MODULE_V2,
-} from '@opentrons/shared-data'
+import { FLEX_ROBOT_TYPE, OT2_ROBOT_TYPE } from '@opentrons/shared-data'
 
 import type {
   CutoutId,
-  DeckSlot as DeckDefSlot,
   LabwareDefinition2,
-  ModuleModel,
-  ModuleType,
   RobotType,
 } from '@opentrons/shared-data'
-import type { DeckSlot, WellVolumes } from './types'
+import type { WellVolumes } from './types'
 
 export const getMaxVolumes = (def: LabwareDefinition2): WellVolumes =>
   mapValues(def.wells, well => well.totalLiquidVolume)
@@ -42,26 +21,6 @@ export const FIXED_TRASH_ID: 'fixedTrash' = 'fixedTrash'
 export const STD_SLOT_X_DIM = 128
 export const STD_SLOT_Y_DIM = 86
 export const STD_SLOT_DIVIDER_WIDTH = 4
-// PD-specific slots that don't exist in deck definition.
-// These have no visual representation on the deck themselves,
-// but may contain certain specific items that span (eg thermocycler)
-export const SPAN7_8_10_11_SLOT: 'span7_8_10_11' = 'span7_8_10_11'
-export const TC_SPAN_SLOTS: DeckSlot[] = ['7', '8', '10', '11']
-export const PSEUDO_DECK_SLOTS: Record<DeckSlot, DeckDefSlot> = {
-  [SPAN7_8_10_11_SLOT]: {
-    displayName: 'Spanning slot',
-    id: SPAN7_8_10_11_SLOT,
-    position: [0.0, 181.0, 0.0],
-    // shares origin with OT2 standard slot 7
-    matingSurfaceUnitVector: [-1, 1, -1],
-    boundingBox: {
-      xDimension: STD_SLOT_X_DIM * 2 + STD_SLOT_DIVIDER_WIDTH,
-      yDimension: STD_SLOT_Y_DIM * 2 + STD_SLOT_DIVIDER_WIDTH,
-      zDimension: 0,
-    },
-    compatibleModules: [THERMOCYCLER_MODULE_TYPE],
-  },
-}
 export const START_TERMINAL_TITLE = 'STARTING DECK STATE'
 export const END_TERMINAL_TITLE = 'FINAL DECK STATE'
 // special ID for invisible deck setup step-form
@@ -95,74 +54,7 @@ export const MIN_TC_DURATION_SECONDS = 0
 export const MAX_TC_DURATION_SECONDS = 60
 export const MIN_TC_PROFILE_VOLUME = 0
 export const MAX_TC_PROFILE_VOLUME = 100
-// @ts-expect-error Flex stacker not yet supported in PD
-export const MODELS_FOR_MODULE_TYPE: Record<
-  ModuleType,
-  Array<{
-    name: string
-    value: ModuleModel
-    disabled?: boolean
-  }>
-> = {
-  [MAGNETIC_MODULE_TYPE]: [
-    {
-      name: 'GEN1',
-      value: MAGNETIC_MODULE_V1,
-    },
-    {
-      name: 'GEN2',
-      value: MAGNETIC_MODULE_V2,
-    },
-  ],
-  [TEMPERATURE_MODULE_TYPE]: [
-    {
-      name: 'GEN1',
-      value: TEMPERATURE_MODULE_V1,
-    },
-    {
-      name: 'GEN2',
-      value: TEMPERATURE_MODULE_V2,
-    },
-  ],
-  [THERMOCYCLER_MODULE_TYPE]: [
-    {
-      name: 'GEN1',
-      value: THERMOCYCLER_MODULE_V1,
-    },
-    {
-      name: 'GEN2',
-      value: THERMOCYCLER_MODULE_V2,
-    },
-  ],
-  [HEATERSHAKER_MODULE_TYPE]: [
-    {
-      name: 'GEN1',
-      value: HEATERSHAKER_MODULE_V1,
-    },
-  ],
-  [MAGNETIC_BLOCK_TYPE]: [
-    {
-      name: 'GEN1',
-      value: MAGNETIC_BLOCK_V1,
-    },
-  ],
-  [ABSORBANCE_READER_TYPE]: [
-    {
-      name: 'GEN1',
-      value: ABSORBANCE_READER_V1,
-    },
-  ],
-}
 
-// @ts-expect-error Flex stacker not yet supported in PD
-export const DEFAULT_MODEL_FOR_MODULE_TYPE: Record<ModuleType, ModuleModel> = {
-  [MAGNETIC_MODULE_TYPE]: MAGNETIC_MODULE_V2,
-  [TEMPERATURE_MODULE_TYPE]: TEMPERATURE_MODULE_V2,
-  [THERMOCYCLER_MODULE_TYPE]: THERMOCYCLER_MODULE_V2,
-  [HEATERSHAKER_MODULE_TYPE]: HEATERSHAKER_MODULE_V1,
-  [MAGNETIC_BLOCK_TYPE]: MAGNETIC_BLOCK_V1,
-  [ABSORBANCE_READER_TYPE]: ABSORBANCE_READER_V1,
-}
 // Values for pauseAction field
 export const PAUSE_UNTIL_RESUME: 'untilResume' = 'untilResume'
 export const PAUSE_UNTIL_TIME: 'untilTime' = 'untilTime'

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/LabwareField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/LabwareField.tsx
@@ -12,7 +12,7 @@ export function LabwareField(props: FieldProps): JSX.Element {
   const { name } = props
   const { i18n, t } = useTranslation(['protocol_steps', 'application'])
   const disposalOptions = useSelector(getDisposalOptions)
-  const options = useLabwareDropdownOptions('labware')
+  const options = useLabwareDropdownOptions('labware', false)
   const dispatch = useDispatch()
 
   const allOptions =

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLabwareTools/LabwareLocationField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLabwareTools/LabwareLocationField.tsx
@@ -5,13 +5,17 @@ import { WASTE_CHUTE_CUTOUT } from '@opentrons/shared-data'
 import { getSlotInLocationStack } from '@opentrons/step-generation'
 
 import { DropdownStepFormField } from '../../../../../../components/molecules'
+import { getEnableStacking } from '../../../../../../feature-flags/selectors'
 import { getAdditionalEquipmentEntities } from '../../../../../../step-forms/selectors'
 import {
+  getDeckSetupForActiveItem,
   getRobotStateAtActiveItem,
   getUnoccupiedLabwareLocationOptions,
 } from '../../../../../../top-selectors/labware-locations'
 import { hoverSelection } from '../../../../../../ui/steps/actions/actions'
+import { getUnoccupiedStackOptions } from '../../../../utils'
 
+import type { Option } from '../../../../../../top-selectors/labware-locations'
 import type { FieldProps } from '../../types'
 
 interface LabwareLocationFieldProps extends FieldProps {
@@ -24,20 +28,30 @@ export function LabwareLocationField(
 ): JSX.Element {
   const { t } = useTranslation(['form', 'protocol_steps'])
   const { labware, useGripper } = props
+  const enableStacking = useSelector(getEnableStacking)
   const additionalEquipmentEntities = useSelector(
     getAdditionalEquipmentEntities
   )
+  const { labware: deckSetupLabware } = useSelector(getDeckSetupForActiveItem)
   const dispatch = useDispatch()
   const robotState = useSelector(getRobotStateAtActiveItem)
+  const unoccupiedLabwareStackOptions: Option[] =
+    robotState && enableStacking
+      ? getUnoccupiedStackOptions(robotState, deckSetupLabware, labware, t)
+      : []
   const isLabwareOffDeck =
     labware != null
       ? getSlotInLocationStack(robotState?.labware[labware]?.stack ?? []) ===
         'offDeck'
       : false
 
-  let unoccupiedLabwareLocationsOptions =
+  const unoccupiedLabwareLocationsOptionsSelector =
     useSelector(getUnoccupiedLabwareLocationOptions) ?? []
 
+  let unoccupiedLabwareLocationsOptions = [
+    ...unoccupiedLabwareStackOptions,
+    ...unoccupiedLabwareLocationsOptionsSelector,
+  ]
   if (useGripper || isLabwareOffDeck) {
     unoccupiedLabwareLocationsOptions = unoccupiedLabwareLocationsOptions.filter(
       option => option.value !== 'offDeck'

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLabwareTools/MoveLabwareField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLabwareTools/MoveLabwareField.tsx
@@ -7,8 +7,11 @@ import { useLabwareDropdownOptions } from '../../../../utils'
 
 import type { FieldProps } from '../../types'
 
-export function MoveLabwareField(props: FieldProps): JSX.Element {
-  const options = useLabwareDropdownOptions('moveLabware')
+interface MoveLabwareFieldProps extends FieldProps {
+  useGripper: boolean
+}
+export function MoveLabwareField(props: MoveLabwareFieldProps): JSX.Element {
+  const options = useLabwareDropdownOptions('moveLabware', props.useGripper)
   const dispatch = useDispatch()
   const { t } = useTranslation(['protocol_steps', 'application'])
   return (

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLabwareTools/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLabwareTools/index.tsx
@@ -55,7 +55,7 @@ export function MoveLabwareTools(props: StepFormProps): JSX.Element {
       ) : null}
       <MoveLabwareField
         {...propsForFields.labware}
-        errorToShow={getFormLevelError('labware', mappedErrorsToField)}
+        useGripper={propsForFields.useGripper.value === true}
       />
       <Divider marginY="0" />
       <LabwareLocationField

--- a/protocol-designer/src/pages/Designer/__tests__/utils.test.ts
+++ b/protocol-designer/src/pages/Designer/__tests__/utils.test.ts
@@ -14,10 +14,14 @@ import {
   _sortLabwareDropdownOptions,
   formatTime,
   getSlotInformation,
+  getUnoccupiedStackOptions,
 } from '../utils'
 
 import type { LabwareDefinition2 } from '@opentrons/shared-data'
-import type { AdditionalEquipmentName } from '@opentrons/step-generation'
+import type {
+  AdditionalEquipmentName,
+  RobotState,
+} from '@opentrons/step-generation'
 import type { AllTemporalPropertiesForTimelineFrame } from '../../../step-forms'
 
 const mockLabOnDeck1 = {
@@ -259,5 +263,48 @@ describe('_sortLabwareDropdownOptions', () => {
   it('should handle {} case', () => {
     const result = _sortLabwareDropdownOptions([])
     expect(result).toEqual([])
+  })
+})
+
+const mockT = (key: string) => key
+
+describe('getUnoccupiedStackOptions', () => {
+  const mockRobotState: RobotState = {
+    labware: { labId: { stack: ['labId', 'mockHsId', 'D1'] } },
+    pipettes: {},
+    modules: {},
+    tipState: {} as any,
+    liquidState: {} as any,
+  }
+
+  it('should render a labware on a stack', () => {
+    const mockLabware: AllTemporalPropertiesForTimelineFrame['labware'] = {
+      labId: mockLabOnDeck1Flex,
+      labId2: {
+        ...mockLabOnDeck2Flex,
+        def: {
+          ...fixture96Plate,
+          compatibleParentLabware: [fixtureTiprackAdapter.parameters.loadName],
+        } as LabwareDefinition2,
+      },
+      labId3: mockLabOnStagingArea,
+    }
+    expect(
+      getUnoccupiedStackOptions(mockRobotState, mockLabware, 'labId2', mockT)
+    ).toEqual([
+      {
+        name: 'Fixture Flex 96 Tip Rack Adapter',
+        value: 'labId',
+        deckLabel: 'D1',
+      },
+    ])
+  })
+  it('should render no labware', () => {
+    const mockLabware: AllTemporalPropertiesForTimelineFrame['labware'] = {
+      labId: mockLabOnDeck1Flex,
+    }
+    expect(
+      getUnoccupiedStackOptions(mockRobotState, mockLabware, 'labId', mockT)
+    ).toEqual([])
   })
 })

--- a/protocol-designer/src/pages/Designer/utils.ts
+++ b/protocol-designer/src/pages/Designer/utils.ts
@@ -310,16 +310,14 @@ export const useLabwareDropdownOptions = (
       const isOffDeck = deckSlot === 'offDeck'
 
       //  show full stack option if moving labware manually
-      const bottomOfStackOption: DropdownOption[] =
+      const bottomOfStackOption: DropdownOption | null =
         showStackOption && bottomOfStack != null
-          ? [
-              {
-                name: t('unoccupied_stack', { name: nickName }),
-                value: bottomOfStack,
-                deckLabel: latestSlot,
-              },
-            ]
-          : []
+          ? {
+              name: t('unoccupied_stack', { name: nickName }),
+              value: bottomOfStack,
+              deckLabel: latestSlot,
+            }
+          : null
       const restOfOptions: DropdownOption[] =
         isAdapter ||
         isLabwareInWasteChute ||
@@ -339,7 +337,10 @@ export const useLabwareDropdownOptions = (
       //  filter out moving adapters, and labware in
       //  waste chute for moveLabware, labware off-deck and
       //  labware that is a tiprack for the labware dropdown only
-      return [...restOfOptions, ...bottomOfStackOption]
+      return [
+        ...restOfOptions,
+        ...(bottomOfStackOption != null ? [bottomOfStackOption] : []),
+      ]
     },
     []
   )

--- a/protocol-designer/src/pages/Designer/utils.ts
+++ b/protocol-designer/src/pages/Designer/utils.ts
@@ -9,7 +9,10 @@ import {
   TC_MODULE_LOCATION_OT3,
   THERMOCYCLER_MODULE_TYPE,
 } from '@opentrons/shared-data'
-import { getSlotInLocationStack } from '@opentrons/step-generation'
+import {
+  getFullStackFromLabwares,
+  getSlotInLocationStack,
+} from '@opentrons/step-generation'
 
 import { getRobotType } from '../../file-data/selectors'
 import { getLabwareEntities } from '../../step-forms/selectors'
@@ -31,6 +34,7 @@ import type {
   AdditionalEquipmentName,
   DeckSlot,
   LabwareEntity,
+  RobotState,
 } from '@opentrons/step-generation'
 import type {
   AllTemporalPropertiesForTimelineFrame,
@@ -38,6 +42,7 @@ import type {
   LabwareOnDeck,
   ModuleOnDeck,
 } from '../../step-forms'
+import type { Option } from '../../top-selectors/labware-locations'
 import type { Fixture } from './DeckSetup/constants'
 
 export const TIPRACK_LID_LOADNAME = 'opentrons_flex_tiprack_lid'
@@ -242,16 +247,16 @@ const getNickname = (
   activeDeckSetup: AllTemporalPropertiesForTimelineFrame,
   labwareId: string,
   robotType: RobotType
-): string => {
+): { nickName: string; latestSlot: string } => {
   const { modules } = activeDeckSetup
   const stack = activeDeckSetup.labware[labwareId].stack
   const latestSlot = resolveSlotLocation(modules, stack, robotType)
 
   let nickName: string = nicknamesById[labwareId]
   if (latestSlot != null && latestSlot !== 'offDeck') {
-    nickName = `${nicknamesById[labwareId]} in ${latestSlot}`
+    nickName = nicknamesById[labwareId]
   }
-  return nickName
+  return { nickName, latestSlot }
 }
 
 export const useLabwareDropdownOptions = (
@@ -275,7 +280,7 @@ export const useLabwareDropdownOptions = (
 
       const isAdapter =
         labwareEntity.def.allowedRoles?.includes('adapter') ?? false
-      const nickName = getNickname(
+      const { nickName, latestSlot } = getNickname(
         nicknamesById,
         activeDeckSetup,
         labwareId,
@@ -297,10 +302,61 @@ export const useLabwareDropdownOptions = (
             {
               name: nickName,
               value: labwareId,
+              deckLabel: isOffDeck ? 'Off-deck' : latestSlot,
             },
           ]
     },
     []
   )
   return _sortLabwareDropdownOptions(moveLabwareOptions)
+}
+
+//  used for LabwareLocationField dropdown
+export const getUnoccupiedStackOptions = (
+  robotState: RobotState,
+  deckSetupLabware: AllTemporalPropertiesForTimelineFrame['labware'],
+  labwareIdFromDropdown: string,
+  t: any
+): Option[] => {
+  if (deckSetupLabware[labwareIdFromDropdown] == null) {
+    return []
+  }
+
+  const { def } = deckSetupLabware[labwareIdFromDropdown]
+  const labwareCompatibleParentLabware = def.compatibleParentLabware
+
+  return Object.entries(robotState.labware).reduce<Option[]>(
+    (acc, [labwareId, temporalLabwareOnDeck]) => {
+      const slot = getSlotInLocationStack(temporalLabwareOnDeck.stack)
+      const fullStack = getFullStackFromLabwares(robotState.labware, slot)
+      const labwareOnDeck = deckSetupLabware[labwareId]
+      const isTopOfStack = fullStack[0] === labwareId
+      const { def: labwareOnDeckDef } = labwareOnDeck
+      const { displayName } = labwareOnDeckDef.metadata
+      const { loadName } = labwareOnDeckDef.parameters
+
+      const isCompatible = labwareCompatibleParentLabware?.includes(loadName)
+      const isNotCurrentLabware = labwareId !== labwareIdFromDropdown
+
+      if (isTopOfStack && isCompatible && isNotCurrentLabware) {
+        const similarLabwareStackIds = getAllLabwareIdsOfCertainURIOnStack(
+          deckSetupLabware,
+          labwareOnDeck
+        )
+        acc.push({
+          name:
+            similarLabwareStackIds.length > 1
+              ? t('protocol_steps:unoccupied_stack', {
+                  name: displayName,
+                })
+              : displayName,
+          value: labwareId,
+          deckLabel: slot,
+        })
+      }
+
+      return acc
+    },
+    []
+  )
 }

--- a/protocol-designer/src/pages/Designer/utils.ts
+++ b/protocol-designer/src/pages/Designer/utils.ts
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 import { reduce } from 'lodash'
 
@@ -249,8 +250,8 @@ const getLabwareInfo = (
   labwareId: string,
   robotType: RobotType
 ): { nickName: string; latestSlot: string } => {
-  const { modules } = activeDeckSetup
-  const stack = activeDeckSetup.labware[labwareId].stack
+  const { modules, labware } = activeDeckSetup
+  const stack = labware[labwareId].stack
   const latestSlot = resolveSlotLocation(modules, stack, robotType)
 
   return { nickName: nicknamesById[labwareId], latestSlot }
@@ -260,8 +261,10 @@ export const useLabwareDropdownOptions = (
   type: 'moveLabware' | 'labware',
   usingGripper: boolean
 ): DropdownOption[] => {
+  const { t } = useTranslation('protocol_steps')
   const labwareEntities = useSelector(getLabwareEntities)
   const activeDeckSetup = useSelector(getDeckSetupForActiveItem)
+  const { labware: deckSetupLabware } = activeDeckSetup
   const nicknamesById = useSelector(getLabwareNicknamesById)
   const robotType = useSelector(getRobotType)
   const labwareOptions = reduce(
@@ -271,53 +274,52 @@ export const useLabwareDropdownOptions = (
       labwareEntity: LabwareEntity,
       labwareId: string
     ): DropdownOption[] => {
-      const deckSlot = getSlotInLocationStack(
-        activeDeckSetup.labware[labwareId].stack
-      )
+      const { def } = labwareEntity
+      const deckSlot = getSlotInLocationStack(deckSetupLabware[labwareId].stack)
       const fullStackFromLabwares = getFullStackFromLabwares(
-        activeDeckSetup.labware,
+        deckSetupLabware,
         deckSlot
       )
       const labwareStack = fullStackFromLabwares.filter(
         id =>
-          activeDeckSetup.labware[id] != null &&
-          !activeDeckSetup.labware[id].def.allowedRoles?.includes('adapter')
+          deckSetupLabware[id] != null &&
+          !deckSetupLabware[id].def.allowedRoles?.includes('adapter')
       )
-      const allowStacking =
-        activeDeckSetup.labware[labwareId].def.stackLimit != null &&
-        activeDeckSetup.labware[labwareId].def.stackLimit > 1
+      const labwareStackLength = labwareStack.length - 1
+      const allowStacking = def.stackLimit != null && def.stackLimit > 1
       const showStackOption = !usingGripper && type === 'moveLabware'
 
       const isTopOfStack = fullStackFromLabwares[0] === labwareId
       const isBottomOfStack =
-        labwareStack[labwareStack.length - 1] === labwareId && allowStacking
+        labwareStack[labwareStackLength] === labwareId &&
+        allowStacking &&
+        labwareStack.length > 1
       const bottomOfStack = isBottomOfStack
-        ? labwareStack[labwareStack.length - 1]
+        ? labwareStack[labwareStackLength]
         : null
       const isLabwareInWasteChute = deckSlot === 'gripperWasteChute'
 
-      const isAdapter =
-        labwareEntity.def.allowedRoles?.includes('adapter') ?? false
+      const isAdapter = def.allowedRoles?.includes('adapter') ?? false
       const { nickName, latestSlot } = getLabwareInfo(
         nicknamesById,
         activeDeckSetup,
         labwareId,
         robotType
       )
-      const isTiprack = getIsTiprack(labwareEntity.def)
+      const isTiprack = getIsTiprack(def)
       const isOffDeck = deckSlot === 'offDeck'
 
+      //  show full stack option if moving labware manually
       const bottomOfStackOption: DropdownOption[] =
         showStackOption && bottomOfStack != null
           ? [
               {
-                name: `Stack of ${nickName}`,
+                name: t('unoccupied_stack', { name: nickName }),
                 value: bottomOfStack,
                 deckLabel: latestSlot,
               },
             ]
           : []
-      console.log('bottomOfStackOption',labwareStack,  bottomOfStackOption)
       const restOfOptions: DropdownOption[] =
         isAdapter ||
         isLabwareInWasteChute ||
@@ -369,9 +371,11 @@ export const getUnoccupiedStackOptions = (
       const { loadName } = labwareOnDeckDef.parameters
 
       const isCompatible = labwareCompatibleParentLabware?.includes(loadName)
-      const isNotCurrentLabware = labwareId !== labwareIdFromDropdown
+      const isNotCurrentLabwareStack = !fullStack.includes(
+        labwareIdFromDropdown
+      )
 
-      if (isTopOfStack && isCompatible && isNotCurrentLabware) {
+      if (isTopOfStack && isCompatible && isNotCurrentLabwareStack) {
         const similarLabwareStackIds = getAllLabwareIdsOfCertainURIOnStack(
           deckSetupLabware,
           labwareOnDeck

--- a/protocol-designer/src/pages/Designer/utils.ts
+++ b/protocol-designer/src/pages/Designer/utils.ts
@@ -283,12 +283,17 @@ export const useLabwareDropdownOptions = (
           activeDeckSetup.labware[id] != null &&
           !activeDeckSetup.labware[id].def.allowedRoles?.includes('adapter')
       )
-      const bottomOfStack = labwareStack[labwareStack.length - 1]
-
+      const allowStacking =
+        activeDeckSetup.labware[labwareId].def.stackLimit != null &&
+        activeDeckSetup.labware[labwareId].def.stackLimit > 1
       const showStackOption = !usingGripper && type === 'moveLabware'
-      console.log(showStackOption, bottomOfStack)
-      const isTopOfStack = fullStackFromLabwares[0] === labwareId
 
+      const isTopOfStack = fullStackFromLabwares[0] === labwareId
+      const isBottomOfStack =
+        labwareStack[labwareStack.length - 1] === labwareId && allowStacking
+      const bottomOfStack = isBottomOfStack
+        ? labwareStack[labwareStack.length - 1]
+        : null
       const isLabwareInWasteChute = deckSlot === 'gripperWasteChute'
 
       const isAdapter =
@@ -311,8 +316,8 @@ export const useLabwareDropdownOptions = (
                 deckLabel: latestSlot,
               },
             ]
-          : acc
-
+          : []
+      console.log('bottomOfStackOption',labwareStack,  bottomOfStackOption)
       const restOfOptions: DropdownOption[] =
         isAdapter ||
         isLabwareInWasteChute ||

--- a/protocol-designer/src/pages/Designer/utils.ts
+++ b/protocol-designer/src/pages/Designer/utils.ts
@@ -19,6 +19,7 @@ import { getLabwareEntities } from '../../step-forms/selectors'
 import { getDeckSetupForActiveItem } from '../../top-selectors/labware-locations'
 import { getLabwareNicknamesById } from '../../ui/labware/selectors'
 import {
+  getAllLabwareIdsOfCertainURIOnStack,
   getFullStackFromLabwaresOnDeck,
   getStagingAreaAddressableAreas,
 } from '../../utils'
@@ -242,7 +243,7 @@ function resolveSlotLocation(
   }
 }
 
-const getNickname = (
+const getLabwareInfo = (
   nicknamesById: Record<string, string>,
   activeDeckSetup: AllTemporalPropertiesForTimelineFrame,
   labwareId: string,
@@ -252,21 +253,18 @@ const getNickname = (
   const stack = activeDeckSetup.labware[labwareId].stack
   const latestSlot = resolveSlotLocation(modules, stack, robotType)
 
-  let nickName: string = nicknamesById[labwareId]
-  if (latestSlot != null && latestSlot !== 'offDeck') {
-    nickName = nicknamesById[labwareId]
-  }
-  return { nickName, latestSlot }
+  return { nickName: nicknamesById[labwareId], latestSlot }
 }
 
 export const useLabwareDropdownOptions = (
-  type: 'moveLabware' | 'labware'
+  type: 'moveLabware' | 'labware',
+  usingGripper: boolean
 ): DropdownOption[] => {
   const labwareEntities = useSelector(getLabwareEntities)
   const activeDeckSetup = useSelector(getDeckSetupForActiveItem)
   const nicknamesById = useSelector(getLabwareNicknamesById)
   const robotType = useSelector(getRobotType)
-  const moveLabwareOptions = reduce(
+  const labwareOptions = reduce(
     labwareEntities,
     (
       acc: DropdownOption[],
@@ -276,11 +274,26 @@ export const useLabwareDropdownOptions = (
       const deckSlot = getSlotInLocationStack(
         activeDeckSetup.labware[labwareId].stack
       )
+      const fullStackFromLabwares = getFullStackFromLabwares(
+        activeDeckSetup.labware,
+        deckSlot
+      )
+      const labwareStack = fullStackFromLabwares.filter(
+        id =>
+          activeDeckSetup.labware[id] != null &&
+          !activeDeckSetup.labware[id].def.allowedRoles?.includes('adapter')
+      )
+      const bottomOfStack = labwareStack[labwareStack.length - 1]
+
+      const showStackOption = !usingGripper && type === 'moveLabware'
+      console.log(showStackOption, bottomOfStack)
+      const isTopOfStack = fullStackFromLabwares[0] === labwareId
+
       const isLabwareInWasteChute = deckSlot === 'gripperWasteChute'
 
       const isAdapter =
         labwareEntity.def.allowedRoles?.includes('adapter') ?? false
-      const { nickName, latestSlot } = getNickname(
+      const { nickName, latestSlot } = getLabwareInfo(
         nicknamesById,
         activeDeckSetup,
         labwareId,
@@ -289,26 +302,41 @@ export const useLabwareDropdownOptions = (
       const isTiprack = getIsTiprack(labwareEntity.def)
       const isOffDeck = deckSlot === 'offDeck'
 
+      const bottomOfStackOption: DropdownOption[] =
+        showStackOption && bottomOfStack != null
+          ? [
+              {
+                name: `Stack of ${nickName}`,
+                value: bottomOfStack,
+                deckLabel: latestSlot,
+              },
+            ]
+          : acc
+
+      const restOfOptions: DropdownOption[] =
+        isAdapter ||
+        isLabwareInWasteChute ||
+        (type === 'labware' && isTiprack) ||
+        isOffDeck ||
+        !isTopOfStack
+          ? acc
+          : [
+              ...acc,
+              {
+                name: nickName,
+                value: labwareId,
+                deckLabel: latestSlot,
+              },
+            ]
+
       //  filter out moving adapters, and labware in
       //  waste chute for moveLabware, labware off-deck and
       //  labware that is a tiprack for the labware dropdown only
-      return isAdapter ||
-        isLabwareInWasteChute ||
-        (type === 'labware' && isTiprack) ||
-        isOffDeck
-        ? acc
-        : [
-            ...acc,
-            {
-              name: nickName,
-              value: labwareId,
-              deckLabel: isOffDeck ? 'Off-deck' : latestSlot,
-            },
-          ]
+      return [...restOfOptions, ...bottomOfStackOption]
     },
     []
   )
-  return _sortLabwareDropdownOptions(moveLabwareOptions)
+  return _sortLabwareDropdownOptions(labwareOptions)
 }
 
 //  used for LabwareLocationField dropdown

--- a/protocol-designer/src/step-forms/test/reducers.test.ts
+++ b/protocol-designer/src/step-forms/test/reducers.test.ts
@@ -7,11 +7,7 @@ import {
   THERMOCYCLER_MODULE_TYPE,
 } from '@opentrons/shared-data'
 
-import {
-  INITIAL_DECK_SETUP_STEP_ID,
-  PAUSE_UNTIL_TEMP,
-  SPAN7_8_10_11_SLOT,
-} from '../../constants'
+import { INITIAL_DECK_SETUP_STEP_ID, PAUSE_UNTIL_TEMP } from '../../constants'
 import { moveDeckItem } from '../../labware-ingred/actions'
 import { handleFormChange } from '../../steplist/formLevel/handleFormChange'
 import { PRESAVED_STEP_ID } from '../../steplist/types'
@@ -993,19 +989,6 @@ describe('savedStepForms reducer: initial deck setup step', () => {
         action: SavedStepFormsActions
         expectedModuleId: string
       }> = [
-        {
-          testName: 'create TC -> override TC step module id',
-          action: {
-            type: 'CREATE_MODULE',
-            payload: {
-              id: 'NewTCId',
-              slot: SPAN7_8_10_11_SLOT,
-              type: THERMOCYCLER_MODULE_TYPE,
-              model: 'thermocyclerModuleV1',
-            },
-          },
-          expectedModuleId: 'NewTCId',
-        },
         {
           testName: 'create temp mod -> DO NOT override TC step module id',
           action: {

--- a/protocol-designer/src/steplist/fieldLevel/index.ts
+++ b/protocol-designer/src/steplist/fieldLevel/index.ts
@@ -89,15 +89,13 @@ const getLabwareOrAdditionalEquipmentEntity = (
   } else return null
 }
 
-const getIsAdapterLocation = (
+const getIsStackingLocation = (
   newLocation: string,
   labwareEntities: LabwareEntities
 ): boolean => {
-  if (labwareEntities[newLocation] == null) return false
-  return (
-    labwareEntities[newLocation].def.allowedRoles?.includes('adapter') ?? false
-  )
+  return labwareEntities[newLocation] != null
 }
+
 const getIsAdditionalEquipmentLocation = (
   newLocation: string,
   wasteChuteEntities: WasteChuteEntities,
@@ -137,7 +135,7 @@ const getLabwareLocation = (
     return { moduleId: newLocationString }
   } else if (
     newLocationString != null &&
-    getIsAdapterLocation(newLocationString, state.labwareEntities)
+    getIsStackingLocation(newLocationString, state.labwareEntities)
   ) {
     return { labwareId: newLocationString }
   } else if (

--- a/protocol-designer/src/top-selectors/labware-locations/index.ts
+++ b/protocol-designer/src/top-selectors/labware-locations/index.ts
@@ -21,6 +21,7 @@ import {
   getTopLocationInStack,
 } from '@opentrons/step-generation'
 
+import { OFFDECK } from '../../constants'
 import { selectors as fileDataSelectors } from '../../file-data'
 import { getRobotType } from '../../file-data/selectors'
 import { selectors as stepFormSelectors } from '../../step-forms'
@@ -285,7 +286,7 @@ export const getUnoccupiedLabwareLocationOptions: Selector<
       .map(slotId => ({ name: slotId, value: slotId, deckLabel: slotId }))
     const offDeck = {
       name: 'Off-deck',
-      value: 'offDeck',
+      value: OFFDECK,
       deckLabel: 'Off-deck',
     }
     const wasteChuteSlot = {

--- a/protocol-designer/src/top-selectors/labware-locations/index.ts
+++ b/protocol-designer/src/top-selectors/labware-locations/index.ts
@@ -46,7 +46,7 @@ import type { RobotState } from '@opentrons/step-generation'
 import type { AllTemporalPropertiesForTimelineFrame } from '../../step-forms'
 import type { Selector } from '../../types'
 
-interface Option {
+export interface Option {
   name: string
   value: string
   deckLabel: string

--- a/protocol-designer/src/top-selectors/labware-locations/index.ts
+++ b/protocol-designer/src/top-selectors/labware-locations/index.ts
@@ -49,6 +49,7 @@ import type { Selector } from '../../types'
 interface Option {
   name: string
   value: string
+  deckLabel: string
 }
 
 export const getRobotStateAtActiveItem: Selector<RobotState | null> = createSelector(
@@ -210,9 +211,11 @@ export const getUnoccupiedLabwareLocationOptions: Selector<
               {
                 name:
                   modIdWithAdapter != null
-                    ? `${moduleUnderAdapter} on ${moduleSlotInfo} with ${adapterDisplayName}`
-                    : `${adapterSlotInfo} with ${adapterDisplayName}`,
+                    ? `${moduleUnderAdapter} with ${adapterDisplayName}`
+                    : adapterDisplayName,
                 value: labwareId,
+                deckLabel:
+                  modIdWithAdapter != null ? moduleSlotInfo : adapterSlotInfo,
               },
             ]
           : acc
@@ -237,10 +240,9 @@ export const getUnoccupiedLabwareLocationOptions: Selector<
           : [
               ...acc,
               {
-                name: `${getModuleDisplayName(
-                  moduleEntities[modId].model
-                )} on ${tcLocations != null ? tcLocations : slot}`,
+                name: getModuleDisplayName(moduleEntities[modId].model),
                 value: modId,
+                deckLabel: tcLocations != null ? tcLocations : slot,
               },
             ]
       },
@@ -280,11 +282,16 @@ export const getUnoccupiedLabwareLocationOptions: Selector<
           !FLEX_STACKER_ADDRESSABLE_AREAS.includes(slotId)
         )
       })
-      .map(slotId => ({ name: slotId, value: slotId }))
-    const offDeck = { name: 'Off-deck', value: 'offDeck' }
+      .map(slotId => ({ name: slotId, value: slotId, deckLabel: slotId }))
+    const offDeck = {
+      name: 'Off-deck',
+      value: 'offDeck',
+      deckLabel: 'Off-deck',
+    }
     const wasteChuteSlot = {
       name: 'Waste Chute in D3',
       value: WASTE_CHUTE_CUTOUT,
+      deckLabel: 'D3',
     }
 
     return hasWasteChute

--- a/protocol-designer/src/utils/__tests__/utils.test.ts
+++ b/protocol-designer/src/utils/__tests__/utils.test.ts
@@ -1,10 +1,17 @@
 import { describe, expect, it } from 'vitest'
 
+import { fixture96Plate, LabwareDefinition2 } from '@opentrons/shared-data'
+
 import {
+  getAllLabwareIdsOfCertainURIOnStack,
   getMaxConditioningVolume,
   getMaxPushOutVolume,
   removeOpentronsPhrases,
 } from '..'
+import {
+  AllTemporalPropertiesForTimelineFrame,
+  LabwareOnDeck,
+} from '../../step-forms'
 
 describe('removeOpentronsPhrases', () => {
   it('should remove "Opentrons Flex 96"', () => {
@@ -244,5 +251,77 @@ describe('getMaxConditioningVolume', () => {
 
     const result = getMaxConditioningVolume(args)
     expect(result).toBe(200 - 10)
+  })
+})
+
+describe('getAllLabwareIdsOfCertainURIOnStack', () => {
+  it('returns an 1 item in string when there are no duplicates on the stack', () => {
+    const mockDeckSetupLabware: AllTemporalPropertiesForTimelineFrame['labware'] = {
+      labware: {
+        stack: ['labware', 'adapter', 'module', 'A2'],
+        id: 'labware',
+        def: fixture96Plate as LabwareDefinition2,
+        pythonName: 'mockPythonName',
+        labwareDefURI: 'mockLabwareDefUri',
+      },
+      adapter: {
+        stack: ['adapter', 'module', 'A2'],
+        id: 'adapter',
+        def: fixture96Plate as LabwareDefinition2,
+        pythonName: 'mockPythonName',
+        labwareDefURI: 'mockAdapterDefUri',
+      },
+    }
+    const mockLabwareOnDeck: LabwareOnDeck = {
+      stack: ['labware', 'adapter', 'module', 'A2'],
+      id: 'labware',
+      def: fixture96Plate as LabwareDefinition2,
+      pythonName: 'mockPythonName',
+      labwareDefURI: 'mockLabwareDefUri',
+    }
+    expect(
+      getAllLabwareIdsOfCertainURIOnStack(
+        mockDeckSetupLabware,
+        mockLabwareOnDeck
+      )
+    ).toEqual(['labware'])
+  })
+  it('returns an 3 items in string when there are duplicates on the stack', () => {
+    const mockDeckSetupLabware: AllTemporalPropertiesForTimelineFrame['labware'] = {
+      labware: {
+        stack: ['labware', 'module', 'A2'],
+        id: 'labware',
+        def: fixture96Plate as LabwareDefinition2,
+        pythonName: 'mockPythonName',
+        labwareDefURI: 'mockLabwareDefUri',
+      },
+      labware2: {
+        stack: ['labware2', 'labware', 'module', 'A2'],
+        id: 'labware2',
+        def: fixture96Plate as LabwareDefinition2,
+        pythonName: 'mockPythonName',
+        labwareDefURI: 'mockLabwareDefUri',
+      },
+      labware3: {
+        stack: ['labware3', 'labware2', 'labware', 'module', 'A2'],
+        id: 'labware3',
+        def: fixture96Plate as LabwareDefinition2,
+        pythonName: 'mockPythonName',
+        labwareDefURI: 'mockLabwareDefUri',
+      },
+    }
+    const mockLabwareOnDeck: LabwareOnDeck = {
+      stack: ['labware', 'adapter', 'module', 'A2'],
+      id: 'labware',
+      def: fixture96Plate as LabwareDefinition2,
+      pythonName: 'mockPythonName',
+      labwareDefURI: 'mockLabwareDefUri',
+    }
+    expect(
+      getAllLabwareIdsOfCertainURIOnStack(
+        mockDeckSetupLabware,
+        mockLabwareOnDeck
+      )
+    ).toEqual(['labware', 'labware2', 'labware3'])
   })
 })

--- a/protocol-designer/src/utils/__tests__/utils.test.ts
+++ b/protocol-designer/src/utils/__tests__/utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { fixture96Plate, LabwareDefinition2 } from '@opentrons/shared-data'
+import { fixture96Plate } from '@opentrons/shared-data'
 
 import {
   getAllLabwareIdsOfCertainURIOnStack,
@@ -8,7 +8,9 @@ import {
   getMaxPushOutVolume,
   removeOpentronsPhrases,
 } from '..'
-import {
+
+import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type {
   AllTemporalPropertiesForTimelineFrame,
   LabwareOnDeck,
 } from '../../step-forms'

--- a/protocol-designer/src/utils/index.ts
+++ b/protocol-designer/src/utils/index.ts
@@ -12,7 +12,10 @@ import {
   makeWellSetHelpers,
   STAGING_AREA_RIGHT_SLOT_FIXTURE,
 } from '@opentrons/shared-data'
-import { PROTOCOL_CONTEXT_NAME } from '@opentrons/step-generation'
+import {
+  getSlotInLocationStack,
+  PROTOCOL_CONTEXT_NAME,
+} from '@opentrons/step-generation'
 
 import type { WellGroup } from '@opentrons/components'
 import type {
@@ -464,5 +467,21 @@ export const getHasTrash = (
 ): boolean => {
   return Object.values(additionalEquipment).some(
     ae => ae.name === 'trashBin' || ae.name === 'wasteChute'
+  )
+}
+
+export const getAllLabwareIdsOfCertainURIOnStack = (
+  deckSetupLabware: AllTemporalPropertiesForTimelineFrame['labware'],
+  labwareOnDeck: LabwareOnDeck
+): string[] => {
+  return Object.values(deckSetupLabware).reduce<string[]>(
+    (acc, { labwareDefURI, stack, id }) => {
+      return labwareDefURI === labwareOnDeck.labwareDefURI &&
+        getSlotInLocationStack(stack) ===
+          getSlotInLocationStack(labwareOnDeck.stack)
+        ? [...acc, id]
+        : acc
+    },
+    []
   )
 }

--- a/step-generation/src/getNextRobotStateAndWarnings/forMoveLabware.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/forMoveLabware.ts
@@ -17,9 +17,9 @@ export function forMoveLabware(
     initialDeckSlot
   )
   const index = fullStackFromLabwares.indexOf(labwareId)
-  const restOfStack = index !== -1 ? fullStackFromLabwares.slice(0, index) : []
+  const labwareToMove = fullStackFromLabwares.slice(0, index + 1) // includes labwareId you're moving
 
-  const newLocationStack = [labwareId]
+  const newLocationStack: string[] = []
   if (newLocation === 'offDeck' || newLocation === 'systemLocation') {
     newLocationStack.push(newLocation)
   } else if ('moduleId' in newLocation) {
@@ -32,17 +32,14 @@ export function forMoveLabware(
   } else if ('labwareId' in newLocation) {
     const labwareId = newLocation.labwareId
     const labwareIdStack = labware[labwareId].stack
-    newLocationStack.push(labwareId, ...labwareIdStack)
+    newLocationStack.push(...labwareIdStack)
   } else if ('addressableAreaName' in newLocation) {
     newLocationStack.push(newLocation.addressableAreaName)
   }
-
-  // robotState.labware[labwareId].stack = [...restOfStack, ...newLocationStack]
-  fullStackFromLabwares.forEach((id, i) => {
+  labwareToMove.forEach((id, i) => {
     if (labware[id] != null) {
-      const idStackSuffix =
-        index !== -1 ? fullStackFromLabwares.slice(0, i) : [] // part after this labware
-      robotState.labware[id].stack = [...idStackSuffix, ...newLocationStack]
+      const stackBelow = labwareToMove.slice(i + 1) // what's under labware you're moving
+      robotState.labware[id].stack = [id, ...stackBelow, ...newLocationStack]
     }
   })
 }

--- a/step-generation/src/getNextRobotStateAndWarnings/forMoveLabware.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/forMoveLabware.ts
@@ -1,3 +1,5 @@
+import { getFullStackFromLabwares, getSlotInLocationStack } from '../utils'
+
 import type { MoveLabwareParams } from '@opentrons/shared-data'
 import type { InvariantContext, RobotStateAndWarnings } from '../types'
 
@@ -9,6 +11,13 @@ export function forMoveLabware(
   const { labwareId, newLocation } = params
   const { robotState } = robotStateAndWarnings
   const { modules, labware } = robotState
+  const initialDeckSlot = getSlotInLocationStack(labware[labwareId].stack)
+  const fullStackFromLabwares = getFullStackFromLabwares(
+    labware,
+    initialDeckSlot
+  )
+  const index = fullStackFromLabwares.indexOf(labwareId)
+  const restOfStack = index !== -1 ? fullStackFromLabwares.slice(0, index) : []
 
   const newLocationStack = [labwareId]
   if (newLocation === 'offDeck' || newLocation === 'systemLocation') {
@@ -28,5 +37,12 @@ export function forMoveLabware(
     newLocationStack.push(newLocation.addressableAreaName)
   }
 
-  robotState.labware[labwareId].stack = newLocationStack
+  // robotState.labware[labwareId].stack = [...restOfStack, ...newLocationStack]
+  fullStackFromLabwares.forEach((id, i) => {
+    if (labware[id] != null) {
+      const idStackSuffix =
+        index !== -1 ? fullStackFromLabwares.slice(0, i) : [] // part after this labware
+      robotState.labware[id].stack = [...idStackSuffix, ...newLocationStack]
+    }
+  })
 }


### PR DESCRIPTION
closes AUTH-1929, partially closes AUTH-1071

# Overview

This PR allows for moving labware to and from a stack and moving a whole stack if you don't have the gripper selected. This is the final piece needed to unblock EXEC from Flex stacker development

## Test Plan and Hands on Testing

- turn on the stacking capabilities FF
- upload the attached protocol. 
- create a step to move the TC lid from the stack to an empty slot (with gripper)
- create a step to move the TC lid stack to an empty slot (without gripper should reveal "stack of..." option)
- create a step to move one the TC lid you moved by itself back to the stack (with gripper, the new location dropdown should include "stack of...")
- see that robot state updates correctly

[TestingMovingTCLids.json](https://github.com/user-attachments/files/20511702/TestingMovingTCLids.json)


## Changelog

- delete unused constants in the top level PD constant file
- refactor `forMoveLabware` to update all the stacks when moving a stack or item to a stack
- fix the hydrated `newLocation` to account for stacks
- extend the dropdowns to include the deck location
- add `getUnoccupiedStackOptions` to include stack option
- refactor `useLabwareDropdownOptions` to take stacking into account

## Risk assessment

low, behind ff