### PR TITLE
fix(protocol-designer): allow for waste chute addition when labware i…

### DIFF
--- a/protocol-designer/src/components/organisms/HardwareConfigurator/AddFixtureModal.tsx
+++ b/protocol-designer/src/components/organisms/HardwareConfigurator/AddFixtureModal.tsx
@@ -189,18 +189,16 @@ export function AddFixtureModal(props: AddFixtureModalProps): JSX.Element {
       makeSnackbar(t('add_gripper_for_plate') as string)
       //  block thermocycler from being added if there is something in slot A1
     } else if (
-      (addedCutoutConfigs.some(
+      addedCutoutConfigs.some(
         cutoutConfig => cutoutConfig.type === THERMOCYCLER_MODULE_V2
       ) &&
-        (Object.values(modules).some(
-          module => module.cutoutId === 'cutoutA1'
+      (Object.values(modules).some(module => module.cutoutId === 'cutoutA1') ||
+        Object.values(fixtures).some(
+          fixture => fixture.cutoutId === 'cutoutA1'
         ) ||
-          Object.values(fixtures).some(
-            fixture => fixture.cutoutId === 'cutoutA1'
-          ))) ||
-      Object.values(labware).some(
-        lw => getSlotInLocationStack(lw.stack) === 'A1'
-      )
+        Object.values(labware).some(
+          lw => getSlotInLocationStack(lw.stack) === 'A1'
+        ))
     ) {
       makeSnackbar(t('thermocycler_blocked') as string)
     } else {


### PR DESCRIPTION
…n slot A1

closes RQA-4224

# Overview

Fix the `()` in the if statement so modules/fixtures can be added to other places on the deck when there is a labware in slot 1

## Test Plan and Hands on Testing

drag the tiprack to slot A1 then try to add a waste chute. see that the waste chute correctly adds.

## Changelog

- fix logic, `()` were off

## Risk assessment

low