### PR TITLE
fix(protocol-designer): fix hover behavior for timeline step

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/StepContainer.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/StepContainer.tsx
@@ -230,7 +230,7 @@ export function StepContainer(props: StepContainerProps): JSX.Element {
       )}
       <Flex
         id={stepId}
-        {...(isStepAfterError
+        {...(!isStepAfterError
           ? {
               onMouseEnter,
               onMouseLeave,


### PR DESCRIPTION
# Overview

I accidentally flipped the logic for handling undefined `onMouseEnter/Leave` props in `StepContainer`. This PR fixes the ternary that resulted in bad hover behavior.

## Test Plan and Hands on Testing

create or upload a protocol and verify that hovering timeline steps above any timeline error results in robot state being reflected for that step

## Changelog

- fix logic for when to pass `onMouseEnter/Leave` callback props

## Review requests

see test plan

## Risk assessment
low