### PR TITLE
refactor(components,app,protocol-designer): Shared wrapper around <video>

### DIFF
--- a/app/src/organisms/Desktop/CalibrateTipLength/index.tsx
+++ b/app/src/organisms/Desktop/CalibrateTipLength/index.tsx
@@ -5,7 +5,11 @@ import { useTranslation } from 'react-i18next'
 import { useQueryClient } from 'react-query'
 import { css } from 'styled-components'
 
-import { ModalShell, useConditionalConfirm } from '@opentrons/components'
+import {
+  AnimationVideo,
+  ModalShell,
+  useConditionalConfirm,
+} from '@opentrons/components'
 import { useHost } from '@opentrons/react-api-client'
 import { getPipetteModelSpecs } from '@opentrons/shared-data'
 
@@ -201,19 +205,15 @@ function TipLengthCalibrationComplete(
 
   const visualAid =
     calBlock != null ? (
-      <video
+      <AnimationVideo
         key={blockRemovalAssetBySlot[calBlock.slot]}
         css={css`
           max-width: 100%;
           max-height: 15rem;
         `}
-        autoPlay={true}
-        muted={true}
-        loop={true}
-        controls={false}
       >
         <source src={blockRemovalAssetBySlot[calBlock.slot]} />
-      </video>
+      </AnimationVideo>
     ) : null
 
   return (

--- a/app/src/organisms/Desktop/CalibrationPanels/MeasureNozzle.tsx
+++ b/app/src/organisms/Desktop/CalibrationPanels/MeasureNozzle.tsx
@@ -6,6 +6,7 @@ import { css } from 'styled-components'
 import {
   ALIGN_FLEX_END,
   ALIGN_STRETCH,
+  AnimationVideo,
   Box,
   DIRECTION_COLUMN,
   Flex,
@@ -150,19 +151,15 @@ export function MeasureNozzle(props: CalibrationPanelProps): JSX.Element {
             </LegacyStyledText>
           </Flex>
           <Box flex="1">
-            <video
+            <AnimationVideo
               key={demoAsset}
               css={css`
                 max-width: 100%;
                 max-height: 15rem;
               `}
-              autoPlay={true}
-              muted={true}
-              loop={true}
-              controls={false}
             >
               <source src={demoAsset} />
-            </video>
+            </AnimationVideo>
           </Box>
         </Flex>
         <JogControls

--- a/app/src/organisms/Desktop/CalibrationPanels/MeasureTip.tsx
+++ b/app/src/organisms/Desktop/CalibrationPanels/MeasureTip.tsx
@@ -5,6 +5,7 @@ import { css } from 'styled-components'
 import {
   ALIGN_FLEX_END,
   ALIGN_STRETCH,
+  AnimationVideo,
   Box,
   DIRECTION_COLUMN,
   Flex,
@@ -149,19 +150,15 @@ export function MeasureTip(props: CalibrationPanelProps): JSX.Element {
             </LegacyStyledText>
           </Flex>
           <Box flex="1">
-            <video
+            <AnimationVideo
               key={demoAsset}
               css={css`
                 max-width: 100%;
                 max-height: 15rem;
               `}
-              autoPlay={true}
-              muted={true}
-              loop={true}
-              controls={false}
             >
               <source src={demoAsset} />
-            </video>
+            </AnimationVideo>
           </Box>
         </Flex>
         <JogControls

--- a/app/src/organisms/Desktop/CalibrationPanels/SaveXYPoint.tsx
+++ b/app/src/organisms/Desktop/CalibrationPanels/SaveXYPoint.tsx
@@ -5,6 +5,7 @@ import { css } from 'styled-components'
 import {
   ALIGN_FLEX_END,
   ALIGN_STRETCH,
+  AnimationVideo,
   Box,
   DIRECTION_COLUMN,
   Flex,
@@ -233,22 +234,18 @@ export function SaveXYPoint(props: CalibrationPanelProps): JSX.Element | null {
             </LegacyStyledText>
           </Flex>
           <Box flex="1">
-            <video
+            <AnimationVideo
               key={String(demoAsset)}
               css={css`
                 max-width: 100%;
                 max-height: 15rem;
               `}
-              autoPlay={true}
-              muted={true}
-              loop={true}
-              controls={false}
               aria-label={`${mount} ${
                 isMulti ? 'multi' : 'single'
               } channel pipette moving to slot ${slotNumber}`}
             >
               <source src={demoAsset} />
-            </video>
+            </AnimationVideo>
           </Box>
         </Flex>
         <JogControls

--- a/app/src/organisms/Desktop/CalibrationPanels/SaveZPoint.tsx
+++ b/app/src/organisms/Desktop/CalibrationPanels/SaveZPoint.tsx
@@ -5,6 +5,7 @@ import { css } from 'styled-components'
 import {
   ALIGN_FLEX_END,
   ALIGN_STRETCH,
+  AnimationVideo,
   Box,
   DIRECTION_COLUMN,
   Flex,
@@ -114,22 +115,18 @@ export function SaveZPoint(props: CalibrationPanelProps): JSX.Element {
             />
           </Flex>
           <Box flex="1">
-            <video
+            <AnimationVideo
               key={demoAsset}
               css={css`
                 max-width: 100%;
                 max-height: 15rem;
               `}
-              autoPlay={true}
-              muted={true}
-              loop={true}
-              controls={false}
               aria-label={`${mount} ${
                 isMulti ? 'multi' : 'single'
               } channel pipette moving to slot 5`}
             >
               <source src={demoAsset} />
-            </video>
+            </AnimationVideo>
           </Box>
         </Flex>
         <JogControls

--- a/app/src/organisms/Desktop/CalibrationPanels/TipPickUp.tsx
+++ b/app/src/organisms/Desktop/CalibrationPanels/TipPickUp.tsx
@@ -4,6 +4,7 @@ import { css } from 'styled-components'
 import {
   ALIGN_FLEX_END,
   ALIGN_STRETCH,
+  AnimationVideo,
   Box,
   DIRECTION_COLUMN,
   Flex,
@@ -78,19 +79,15 @@ export function TipPickUp(props: CalibrationPanelProps): JSX.Element {
             />
           </Flex>
           <Box flex="1">
-            <video
+            <AnimationVideo
               key={demoAsset}
               css={css`
                 max-width: 100%;
                 max-height: 15rem;
               `}
-              autoPlay={true}
-              muted={true}
-              loop={true}
-              controls={false}
             >
               <source src={demoAsset} />
-            </video>
+            </AnimationVideo>
           </Box>
         </Flex>
         <JogControls jog={jog} />

--- a/app/src/organisms/Desktop/Devices/ChangePipette/LevelPipette.tsx
+++ b/app/src/organisms/Desktop/Devices/ChangePipette/LevelPipette.tsx
@@ -2,6 +2,7 @@ import { Trans, useTranslation } from 'react-i18next'
 import { css } from 'styled-components'
 
 import {
+  AnimationVideo,
   DIRECTION_COLUMN,
   DIRECTION_ROW,
   Flex,
@@ -32,20 +33,16 @@ export function LevelingVideo(props: {
   ).href
 
   return (
-    <video
+    <AnimationVideo
       css={css`
         width: 275px;
         max-height: 270px;
         margin-top: ${SPACING.spacing16};
         margin-left: ${SPACING.spacing16};
       `}
-      autoPlay={true}
-      muted={true}
-      loop={true}
-      controls={true}
     >
       <source src={video} />
-    </video>
+    </AnimationVideo>
   )
 }
 

--- a/app/src/organisms/DropTipWizardFlows/steps/BeforeBeginning.tsx
+++ b/app/src/organisms/DropTipWizardFlows/steps/BeforeBeginning.tsx
@@ -4,6 +4,7 @@ import { css } from 'styled-components'
 
 import {
   ALIGN_CENTER,
+  AnimationVideo,
   BORDERS,
   COLORS,
   CURSOR_POINTER,
@@ -167,18 +168,14 @@ function DropTipOption({
           : UNSELECTED_OPTIONS_STYLE
       }
     >
-      <video
+      <AnimationVideo
         css={css`
           max-width: 8.96rem;
         `}
-        autoPlay={true}
-        muted={true}
-        loop={true}
-        controls={false}
         aria-label={flowType}
       >
         <source src={videoSrc} />
-      </video>
+      </AnimationVideo>
       <LegacyStyledText as="h3">{text}</LegacyStyledText>
     </Flex>
   )

--- a/app/src/organisms/ErrorRecoveryFlows/shared/ReleaseLabware.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/ReleaseLabware.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from 'react-i18next'
 import { css } from 'styled-components'
 
 import {
+  AnimationVideo,
   DIRECTION_COLUMN,
   Flex,
   InlineNotification,
@@ -84,19 +85,12 @@ export function ReleaseLabware({
           />
         </Flex>
         <Flex css={ANIMATION_CONTAINER_STYLE}>
-          <video
-            autoPlay={true}
-            muted={true}
-            loop={true}
-            controls={false}
-            role="presentation"
-            css={ANIMATION_STYLE}
-          >
+          <AnimationVideo role="presentation" css={ANIMATION_STYLE}>
             <source
               src={gripperReleaseAnimation}
               data-testid="gripper-animation"
             />
-          </video>
+          </AnimationVideo>
         </Flex>
       </TwoColumn>
       <RecoveryFooterButtons

--- a/app/src/organisms/GripperWizardFlows/MountGripper.tsx
+++ b/app/src/organisms/GripperWizardFlows/MountGripper.tsx
@@ -6,6 +6,7 @@ import { css } from 'styled-components'
 import {
   ALIGN_CENTER,
   ALIGN_FLEX_END,
+  AnimationVideo,
   Btn,
   COLORS,
   Flex,
@@ -129,19 +130,15 @@ export const MountGripper = (
     <GenericWizardTile
       header={t('branded:connect_and_screw_in_gripper')}
       rightHandBody={
-        <video
+        <AnimationVideo
           css={css`
             max-width: 100%;
             max-height: 20rem;
           `}
-          autoPlay={true}
-          muted={true}
-          loop={true}
-          controls={false}
           aria-label="connect and screw in gripper"
         >
           <source src={mountGripper} />
-        </video>
+        </AnimationVideo>
       }
       bodyText={
         <LegacyStyledText as="p">

--- a/app/src/organisms/GripperWizardFlows/MovePin.tsx
+++ b/app/src/organisms/GripperWizardFlows/MovePin.tsx
@@ -2,6 +2,7 @@ import { Trans, useTranslation } from 'react-i18next'
 import { css } from 'styled-components'
 
 import {
+  AnimationVideo,
   COLORS,
   Flex,
   LegacyStyledText,
@@ -150,76 +151,60 @@ export const MovePin = (props: MovePinProps): JSX.Element | null => {
       inProgressText: t('stand_back_gripper_is_calibrating'),
       inProgressImage: (
         <Flex height="10.2rem" paddingTop={SPACING.spacing4}>
-          <video
+          <AnimationVideo
             css={css`
               max-width: 100%;
               max-height: 100%;
             `}
-            autoPlay={true}
-            muted={true}
-            loop={true}
-            controls={false}
             aria-label="calibrating front jaw"
           >
             <source src={calibratingFrontJaw} />
-          </video>
+          </AnimationVideo>
         </Flex>
       ),
       header: t('insert_pin_into_front_jaw'),
       body: t('move_pin_from_storage_to_front_jaw'),
       buttonText: t('begin_calibration'),
       prepImage: (
-        <video
-          muted={true}
+        <AnimationVideo
           css={css`
             max-width: 100%;
             max-height: 20rem;
           `}
-          autoPlay={true}
-          loop={true}
-          controls={false}
           aria-label="move calibration pin from storage location to front jaw"
         >
           <source src={movePinStorageToFront} />
-        </video>
+        </AnimationVideo>
       ),
     },
     [MOVE_PIN_FROM_FRONT_JAW_TO_REAR_JAW]: {
       inProgressText: t('stand_back_gripper_is_calibrating'),
       inProgressImage: (
         <Flex height="10.2rem" paddingTop={SPACING.spacing4}>
-          <video
-            muted={true}
+          <AnimationVideo
             css={css`
               max-width: 100%;
               max-height: 100%;
             `}
-            autoPlay={true}
-            loop={true}
-            controls={false}
             aria-label="calibrating rear jaw"
           >
             <source src={calibratingRearJaw} />
-          </video>
+          </AnimationVideo>
         </Flex>
       ),
       header: t('insert_pin_into_rear_jaw'),
       body: t('move_pin_from_front_to_rear_jaw'),
       buttonText: t('continue_calibration'),
       prepImage: (
-        <video
-          muted={true}
+        <AnimationVideo
           css={css`
             max-width: 100%;
             max-height: 20rem;
           `}
-          autoPlay={true}
-          loop={true}
-          controls={false}
           aria-label="move calibration pin from front jaw to rear jaw"
         >
           <source src={movePinFrontToRear} />
-        </video>
+        </AnimationVideo>
       ),
     },
     [REMOVE_PIN_FROM_REAR_JAW]: {
@@ -228,19 +213,15 @@ export const MovePin = (props: MovePinProps): JSX.Element | null => {
       body: t('move_pin_from_rear_jaw_to_storage'),
       buttonText: t('complete_calibration'),
       prepImage: (
-        <video
-          muted={true}
+        <AnimationVideo
           css={css`
             max-width: 100%;
             max-height: 20rem;
           `}
-          autoPlay={true}
-          loop={true}
-          controls={false}
           aria-label="move calibration rear jaw to storage"
         >
           <source src={movePinRearToStorage} />
-        </video>
+        </AnimationVideo>
       ),
     },
   }

--- a/app/src/organisms/GripperWizardFlows/UnmountGripper.tsx
+++ b/app/src/organisms/GripperWizardFlows/UnmountGripper.tsx
@@ -6,6 +6,7 @@ import { css } from 'styled-components'
 import {
   ALIGN_CENTER,
   ALIGN_FLEX_END,
+  AnimationVideo,
   Btn,
   COLORS,
   Flex,
@@ -139,19 +140,15 @@ export const UnmountGripper = (
     <GenericWizardTile
       header={t('branded:loosen_screws_and_detach')}
       rightHandBody={
-        <video
+        <AnimationVideo
           css={css`
             max-width: 100%;
             max-height: 20rem;
           `}
-          autoPlay={true}
-          muted={true}
-          loop={true}
-          controls={false}
           aria-label="unscrew and disconnect gripper"
         >
           <source src={unmountGripper} />
-        </video>
+        </AnimationVideo>
       }
       bodyText={
         <LegacyStyledText as="p">

--- a/app/src/organisms/ModuleWizardFlows/AttachProbe.tsx
+++ b/app/src/organisms/ModuleWizardFlows/AttachProbe.tsx
@@ -2,6 +2,7 @@ import { Trans, useTranslation } from 'react-i18next'
 import { css } from 'styled-components'
 
 import {
+  AnimationVideo,
   Banner,
   Flex,
   LegacyStyledText,
@@ -77,18 +78,14 @@ export const AttachProbe = (props: AttachProbeProps): JSX.Element | null => {
 
   const pipetteAttachProbeVid = (
     <Flex height="13.25rem" paddingTop={SPACING.spacing4}>
-      <video
+      <AnimationVideo
         css={css`
           max-width: 100%;
           max-height: 100%;
         `}
-        autoPlay={true}
-        muted={true}
-        loop={true}
-        controls={false}
       >
         <source src={pipetteAttachProbeVideoSource} />
-      </video>
+      </AnimationVideo>
     </Flex>
   )
 

--- a/app/src/organisms/ModuleWizardFlows/DetachProbe.tsx
+++ b/app/src/organisms/ModuleWizardFlows/DetachProbe.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from 'react-i18next'
 import { css } from 'styled-components'
 
 import {
+  AnimationVideo,
   Flex,
   LegacyStyledText,
   RESPONSIVENESS,
@@ -47,18 +48,14 @@ export const DetachProbe = (
 
   const pipetteDetachProbeVid = (
     <Flex height="13.25rem" paddingTop={SPACING.spacing4}>
-      <video
+      <AnimationVideo
         css={css`
           max-width: 100%;
           max-height: 100%;
         `}
-        autoPlay={true}
-        muted={true}
-        loop={true}
-        controls={false}
       >
         <source src={pipetteDetachProbeVideoSource} />
-      </video>
+      </AnimationVideo>
     </Flex>
   )
 

--- a/app/src/organisms/ModuleWizardFlows/InstallShuttle.tsx
+++ b/app/src/organisms/ModuleWizardFlows/InstallShuttle.tsx
@@ -2,6 +2,7 @@ import { Trans, useTranslation } from 'react-i18next'
 import { css } from 'styled-components'
 
 import {
+  AnimationVideo,
   Flex,
   LegacyStyledText,
   RESPONSIVENESS,
@@ -36,18 +37,14 @@ export const InstallShuttle = (
 
   const shuttleInstallVid = (
     <Flex height="13.25rem" paddingTop={SPACING.spacing4}>
-      <video
+      <AnimationVideo
         css={css`
           max-width: 100%;
           max-height: 100%;
         `}
-        autoPlay={true}
-        muted={true}
-        loop={true}
-        controls={false}
       >
         <source src={videoPlaceholder} />
-      </video>
+      </AnimationVideo>
     </Flex>
   )
 

--- a/app/src/organisms/ModuleWizardFlows/PlaceAdapter.tsx
+++ b/app/src/organisms/ModuleWizardFlows/PlaceAdapter.tsx
@@ -3,6 +3,7 @@ import { css } from 'styled-components'
 import { v4 as uuidv4 } from 'uuid'
 
 import {
+  AnimationVideo,
   Flex,
   LegacyStyledText,
   RESPONSIVENESS,
@@ -185,18 +186,14 @@ export const PlaceAdapter = (props: PlaceAdapterProps): JSX.Element | null => {
 
   const placeAdapterVid = (
     <Flex height="13.25rem" paddingTop={SPACING.spacing4}>
-      <video
+      <AnimationVideo
         css={css`
           max-width: 100%;
           max-height: 100%;
         `}
-        autoPlay={true}
-        muted={true}
-        loop={true}
-        controls={false}
       >
         <source src={attachAdapterVideoSrc} />
-      </video>
+      </AnimationVideo>
     </Flex>
   )
 

--- a/app/src/organisms/PipetteWizardFlows/AttachProbe.tsx
+++ b/app/src/organisms/PipetteWizardFlows/AttachProbe.tsx
@@ -3,6 +3,7 @@ import { Trans, useTranslation } from 'react-i18next'
 import { css } from 'styled-components'
 
 import {
+  AnimationVideo,
   Banner,
   COLORS,
   Flex,
@@ -142,19 +143,15 @@ export const AttachProbe = (props: AttachProbeProps): JSX.Element | null => {
 
   const pipetteProbeVid = (
     <Flex height="10.2rem" paddingTop={SPACING.spacing4}>
-      <video
+      <AnimationVideo
         css={css`
           max-width: 100%;
           max-height: 100%;
         `}
-        autoPlay={true}
-        muted={true}
-        loop={true}
-        controls={false}
         data-testid={src}
       >
         <source src={src} />
-      </video>
+      </AnimationVideo>
     </Flex>
   )
 

--- a/app/src/organisms/PipetteWizardFlows/utils.tsx
+++ b/app/src/organisms/PipetteWizardFlows/utils.tsx
@@ -1,6 +1,6 @@
 import { css } from 'styled-components'
 
-import { SPACING } from '@opentrons/components'
+import { AnimationVideo, SPACING } from '@opentrons/components'
 import { LEFT, RIGHT } from '@opentrons/shared-data'
 
 import attachLeft18 from '/app/assets/videos/pipette-wizard-flows/Pipette_Attach_1_8_L.webm'
@@ -78,7 +78,7 @@ export function getPipetteAnimations(
   }
 
   return (
-    <video
+    <AnimationVideo
       css={css`
         padding-top: ${SPACING.spacing4};
         width: 100%;
@@ -87,10 +87,6 @@ export function getPipetteAnimations(
           ? `18rem`
           : `12rem`};
       `}
-      autoPlay={true}
-      muted={true}
-      loop={true}
-      controls={false}
       data-testid={
         section === SECTIONS.ATTACH_PROBE || section === SECTIONS.DETACH_PROBE
           ? sourceProbe
@@ -104,7 +100,7 @@ export function getPipetteAnimations(
             : sourcePipette
         }
       />
-    </video>
+    </AnimationVideo>
   )
 }
 
@@ -128,19 +124,15 @@ export function getPipetteAnimations96(
     src = flowType === FLOWS.ATTACH ? zAxisAttach96 : zAxisDetach96
   }
   return (
-    <video
-      muted={true}
+    <AnimationVideo
       css={css`
         padding-top: ${SPACING.spacing4};
         max-width: 100%;
         max-height: 12rem;
       `}
-      autoPlay={true}
-      loop={true}
-      controls={false}
       data-testid={src}
     >
       <source src={src} />
-    </video>
+    </AnimationVideo>
   )
 }

--- a/components/src/atoms/AnimationVideo/__tests__/AnimationVideo.test.tsx
+++ b/components/src/atoms/AnimationVideo/__tests__/AnimationVideo.test.tsx
@@ -5,7 +5,7 @@ import { AnimationVideo } from '..'
 
 describe('AnimationVideo', () => {
   it('should have default props', () => {
-    render(<AnimationVideo data-testid="subject"></AnimationVideo>)
+    render(<AnimationVideo data-testid="subject" />)
     const videoNode = screen.getByTestId('subject')
     expect(videoNode).toHaveAttribute('autoplay')
     expect(videoNode).toHaveAttribute('loop')
@@ -14,13 +14,7 @@ describe('AnimationVideo', () => {
   })
 
   it('should merge default props with custom props', () => {
-    render(
-      <AnimationVideo
-        data-testid="subject"
-        preload="auto"
-        loop={false}
-      ></AnimationVideo>
-    )
+    render(<AnimationVideo data-testid="subject" preload="auto" loop={false} />)
     const videoNode = screen.getByTestId('subject')
     expect(videoNode).toHaveAttribute('autoplay')
     expect(videoNode).not.toHaveAttribute('loop') // Default overridden by custom.

--- a/components/src/atoms/AnimationVideo/__tests__/AnimationVideo.test.tsx
+++ b/components/src/atoms/AnimationVideo/__tests__/AnimationVideo.test.tsx
@@ -7,7 +7,6 @@ describe('AnimationVideo', () => {
 	it('should have default props', () => {
 		render(<AnimationVideo data-testid="subject"></AnimationVideo>)
 		const videoNode = screen.getByTestId('subject')
-		// expect(videoNode).toHaveClass('video')
 		expect(videoNode).toHaveAttribute('autoplay')
 		expect(videoNode).toHaveAttribute('loop')
 		expect(videoNode).not.toHaveAttribute('controls')
@@ -23,7 +22,6 @@ describe('AnimationVideo', () => {
 			></AnimationVideo>
 		)
 		const videoNode = screen.getByTestId('subject')
-		// expect(videoNode).toHaveClass('video')
 		expect(videoNode).toHaveAttribute('autoplay')
 		expect(videoNode).not.toHaveAttribute('loop') // Default overridden by custom.
 		expect(videoNode).not.toHaveAttribute('controls')

--- a/components/src/atoms/AnimationVideo/__tests__/AnimationVideo.test.tsx
+++ b/components/src/atoms/AnimationVideo/__tests__/AnimationVideo.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { AnimationVideo } from '..'
+
+describe('AnimationVideo', () => {
+	it('should have default props', () => {
+		render(<AnimationVideo data-testid="subject"></AnimationVideo>)
+		const videoNode = screen.getByTestId('subject')
+		// expect(videoNode).toHaveClass('video')
+		expect(videoNode).toHaveAttribute('autoplay')
+		expect(videoNode).toHaveAttribute('loop')
+		expect(videoNode).not.toHaveAttribute('controls')
+		expect((videoNode as HTMLVideoElement).muted).toBeTruthy()
+	})
+
+	it('should merge default props with custom props', () => {
+		render(
+			<AnimationVideo
+				data-testid="subject"
+				preload="auto"
+				loop={false}
+			></AnimationVideo>
+		)
+		const videoNode = screen.getByTestId('subject')
+		// expect(videoNode).toHaveClass('video')
+		expect(videoNode).toHaveAttribute('autoplay')
+		expect(videoNode).not.toHaveAttribute('loop') // Default overridden by custom.
+		expect(videoNode).not.toHaveAttribute('controls')
+		expect((videoNode as HTMLVideoElement).muted).toBeTruthy()
+		expect(videoNode).toHaveAttribute('preload', 'auto') // Custom-only.
+	})
+
+	it('should render children', () => {
+		render(
+			<AnimationVideo>
+				<source data-testid="source1"></source>
+				<source data-testid="source2"></source>
+			</AnimationVideo>
+		)
+		screen.getByTestId('source1')
+		screen.getByTestId('source2')
+	})
+})

--- a/components/src/atoms/AnimationVideo/__tests__/AnimationVideo.test.tsx
+++ b/components/src/atoms/AnimationVideo/__tests__/AnimationVideo.test.tsx
@@ -4,39 +4,39 @@ import { describe, expect, it } from 'vitest'
 import { AnimationVideo } from '..'
 
 describe('AnimationVideo', () => {
-	it('should have default props', () => {
-		render(<AnimationVideo data-testid="subject"></AnimationVideo>)
-		const videoNode = screen.getByTestId('subject')
-		expect(videoNode).toHaveAttribute('autoplay')
-		expect(videoNode).toHaveAttribute('loop')
-		expect(videoNode).not.toHaveAttribute('controls')
-		expect((videoNode as HTMLVideoElement).muted).toBeTruthy()
-	})
+  it('should have default props', () => {
+    render(<AnimationVideo data-testid="subject"></AnimationVideo>)
+    const videoNode = screen.getByTestId('subject')
+    expect(videoNode).toHaveAttribute('autoplay')
+    expect(videoNode).toHaveAttribute('loop')
+    expect(videoNode).not.toHaveAttribute('controls')
+    expect((videoNode as HTMLVideoElement).muted).toBeTruthy()
+  })
 
-	it('should merge default props with custom props', () => {
-		render(
-			<AnimationVideo
-				data-testid="subject"
-				preload="auto"
-				loop={false}
-			></AnimationVideo>
-		)
-		const videoNode = screen.getByTestId('subject')
-		expect(videoNode).toHaveAttribute('autoplay')
-		expect(videoNode).not.toHaveAttribute('loop') // Default overridden by custom.
-		expect(videoNode).not.toHaveAttribute('controls')
-		expect((videoNode as HTMLVideoElement).muted).toBeTruthy()
-		expect(videoNode).toHaveAttribute('preload', 'auto') // Custom-only.
-	})
+  it('should merge default props with custom props', () => {
+    render(
+      <AnimationVideo
+        data-testid="subject"
+        preload="auto"
+        loop={false}
+      ></AnimationVideo>
+    )
+    const videoNode = screen.getByTestId('subject')
+    expect(videoNode).toHaveAttribute('autoplay')
+    expect(videoNode).not.toHaveAttribute('loop') // Default overridden by custom.
+    expect(videoNode).not.toHaveAttribute('controls')
+    expect((videoNode as HTMLVideoElement).muted).toBeTruthy()
+    expect(videoNode).toHaveAttribute('preload', 'auto') // Custom-only.
+  })
 
-	it('should render children', () => {
-		render(
-			<AnimationVideo>
-				<source data-testid="source1"></source>
-				<source data-testid="source2"></source>
-			</AnimationVideo>
-		)
-		screen.getByTestId('source1')
-		screen.getByTestId('source2')
-	})
+  it('should render children', () => {
+    render(
+      <AnimationVideo>
+        <source data-testid="source1"></source>
+        <source data-testid="source2"></source>
+      </AnimationVideo>
+    )
+    screen.getByTestId('source1')
+    screen.getByTestId('source2')
+  })
 })

--- a/components/src/atoms/AnimationVideo/index.tsx
+++ b/components/src/atoms/AnimationVideo/index.tsx
@@ -20,7 +20,7 @@ export function AnimationVideo(props: AnimationVideoProps): JSX.Element {
     // It prevents the browser from trying to play audio on connected Bluetooth
     // headphones, which would interrupt audio coming from other devices.
     //
-    // Bcause of some React nonsense, the rendered DOM node will not have a `muted`
+    // Because of some React nonsense, the rendered DOM node will not have a `muted`
     // attribute, but its `muted` property will be true, which is good enough.
     // https://github.com/facebook/react/issues/10389
     muted = true,

--- a/components/src/atoms/AnimationVideo/index.tsx
+++ b/components/src/atoms/AnimationVideo/index.tsx
@@ -34,8 +34,7 @@ export function AnimationVideo(props: AnimationVideoProps): JSX.Element {
       muted={muted}
       controls={controls}
       {...restProps}
-    >
-      {/* Child <source> rendered via {...restProps} spreading above. */}
-    </video>
+      // Child <source>s rendered via {...restProps} spreading above.
+    />
   )
 }

--- a/components/src/atoms/AnimationVideo/index.tsx
+++ b/components/src/atoms/AnimationVideo/index.tsx
@@ -13,22 +13,29 @@ export type AnimationVideoProps = ComponentProps<'video'>
  * ```
  */
 export function AnimationVideo(props: AnimationVideoProps): JSX.Element {
+  const {
+    autoPlay = true,
+    loop = true,
+    // Our animations don't have audio, but we apparently need to pass `muted` anyway.
+    // It prevents the browser from trying to play audio on connected Bluetooth
+    // headphones, which would interrupt audio coming from other devices.
+    //
+    // Bcause of some React nonsense, the rendered DOM node will not have a `muted`
+    // attribute, but its `muted` property will be true, which is good enough.
+    // https://github.com/facebook/react/issues/10389
+    muted = true,
+    controls = false,
+    ...restProps
+  } = props
   return (
     <video
-      autoPlay
-      loop
-      // Our animations don't have audio, but we apparently need to pass `muted` anyway.
-      // It prevents the browser from trying to play audio on connected Bluetooth
-      // headphones, which would interrupt audio coming from other devices.
-      //
-      // Bcause of some React nonsense, the rendered DOM node will not have a `muted`
-      // attribute, but its `muted` property will be true, which is good enough.
-      // https://github.com/facebook/react/issues/10389
-      muted
-      controls={false}
-      {...props}
+      autoPlay={autoPlay}
+      loop={loop}
+      muted={muted}
+      controls={controls}
+      {...restProps}
     >
-      {/* Child <source> rendered via {...props} spreading above. */}
+      {/* Child <source> rendered via {...restProps} spreading above. */}
     </video>
   )
 }

--- a/components/src/atoms/AnimationVideo/index.tsx
+++ b/components/src/atoms/AnimationVideo/index.tsx
@@ -1,0 +1,31 @@
+import type { ComponentProps } from 'react'
+
+export type AnimationVideoProps = ComponentProps<'video'>
+
+/**
+ * A `<video>` tag with default props for showing a looping animation.
+ *
+ * @example
+ * ```jsx
+ * <AnimationVideo>
+ *   <source src="foo.webm" />
+ * </AnimationVideo>
+ * ```
+ */
+export function AnimationVideo(props: AnimationVideoProps): JSX.Element {
+  return (
+    <video
+      autoPlay
+      loop
+      // Our animations don't have audio in the first place, but we apparently need to
+      // pass `muted` anyway. It prevents the browser from trying to play audio on
+      // connected Bluetooth headphones, which interrupts audio coming from other
+      // devices.
+      muted
+      controls={false}
+      {...props}
+    >
+      {/* Child <source> rendered via {...props} spreading above. */}
+    </video>
+  )
+}

--- a/components/src/atoms/AnimationVideo/index.tsx
+++ b/components/src/atoms/AnimationVideo/index.tsx
@@ -17,10 +17,13 @@ export function AnimationVideo(props: AnimationVideoProps): JSX.Element {
     <video
       autoPlay
       loop
-      // Our animations don't have audio in the first place, but we apparently need to
-      // pass `muted` anyway. It prevents the browser from trying to play audio on
-      // connected Bluetooth headphones, which interrupts audio coming from other
-      // devices.
+      // Our animations don't have audio, but we apparently need to pass `muted` anyway.
+      // It prevents the browser from trying to play audio on connected Bluetooth
+      // headphones, which would interrupt audio coming from other devices.
+      //
+      // Bcause of some React nonsense, the rendered DOM node will not have a `muted`
+      // attribute, but its `muted` property will be true, which is good enough.
+      // https://github.com/facebook/react/issues/10389
       muted
       controls={false}
       {...props}

--- a/components/src/atoms/index.ts
+++ b/components/src/atoms/index.ts
@@ -1,3 +1,4 @@
+export * from './AnimationVideo'
 export * from './buttons'
 export * from './Checkbox'
 export * from './CheckboxField'

--- a/protocol-designer/src/pages/Onboarding/WizardBody.tsx
+++ b/protocol-designer/src/pages/Onboarding/WizardBody.tsx
@@ -5,6 +5,7 @@ import { css } from 'styled-components'
 import {
   ALIGN_CENTER,
   ALIGN_END,
+  AnimationVideo,
   BORDERS,
   Btn,
   COLORS,
@@ -181,7 +182,7 @@ export function WizardBody(props: WizardBodyProps): JSX.Element {
           `}
         >
           {robotType === FLEX_ROBOT_TYPE || stepNumber === 1 ? (
-            <video
+            <AnimationVideo
               preload="auto"
               css={css`
                 width: 100%;
@@ -189,15 +190,11 @@ export function WizardBody(props: WizardBodyProps): JSX.Element {
                 object-fit: cover;
                 border-radius: ${BORDERS.borderRadius16};
               `}
-              autoPlay
-              muted={true}
               key={`video-${subStepNumber ?? 1}`}
-              loop={false}
-              controls={false}
               aria-label={`onboarding animation for page ${stepNumber}`}
             >
               <source src={asset ?? ''} type="video/webm" />
-            </video>
+            </AnimationVideo>
           ) : (
             <img
               src={OT2_GIFS[stepNumber]}


### PR DESCRIPTION
## Overview

This follows up on feedback from PR #18459, closing EXEC-1589.

## Test Plan and Hands on Testing

* [x] Looked at a video in the desktop app and made sure it still behaves as before.

## Changelog

* Add an `AnimationVideo` component to `components/atoms/`. It is like `<video>` except it has defaults for `loop`, `autoplay`, and `muted`. (And `controls=false` for clarity, though that's also `<video>`'s default.)
* Rewrite all `<video>` tags in the codebase to use it.

## Review requests

Lots of stuff because idk what I'm doing:

- Is there a better name than `AnimationVideo`?
- I placed this in `components/atoms/`. Is that where this belongs?
- Are the tests idiomatic?
- Is the thing where I'm merging props, including `children`, a good way to implement this wrapper?
- I haven't added a story because it would need a video asset to play. I didn't want to copy a placeholder video into `components/assets` because we wouldn't want it to get bundled with the production `components` release. Does that make sense? Is there a better way to accomplish this?

## Risk assessment

Low.
