### PR TITLE
fix(labware-creator): Fix the preview viewbox not updating when it needs to

### DIFF
--- a/labware-library/src/labware-creator/components/ConditionalLabwareRender.tsx
+++ b/labware-library/src/labware-creator/components/ConditionalLabwareRender.tsx
@@ -84,7 +84,14 @@ const PopulatedPreview = (props: {
   ])
 
   return (
-    <RobotWorkSpace viewBox={bBox == null ? '0 0 0 0' : calculateViewBox(bBox)}>
+    <RobotWorkSpace
+      viewBox={
+        // If we haven't calculated a zoom-to-fit viewBox yet, we can use any arbitrary
+        // value. Our useLayoutEffect will ensure it gets replaced with a real value
+        // before the user sees it.
+        bBox == null ? '0 0 0 0' : calculateViewBox(bBox)
+      }
+    >
       {() => <LabwareRender definition={definition} gRef={gRef} />}
     </RobotWorkSpace>
   )

--- a/labware-library/src/labware-creator/components/ConditionalLabwareRender.tsx
+++ b/labware-library/src/labware-creator/components/ConditionalLabwareRender.tsx
@@ -34,6 +34,8 @@ const calculateViewBox = (bBox: DOMRect): string => {
 }
 
 const areBBoxesEqual = (a: DOMRect | null, b: DOMRect | null): boolean => {
+  // isEqual appears to always return false for native DOMRects/SVGRects,
+  // so we need to break them down into primitives.
   return isEqual(
     {
       x: a?.x,

--- a/labware-library/src/labware-creator/components/ConditionalLabwareRender.tsx
+++ b/labware-library/src/labware-creator/components/ConditionalLabwareRender.tsx
@@ -76,7 +76,9 @@ const PopulatedPreview = (props: {
   // Once the viewBox is re-calculated, we use setState to force a re-render.
   useLayoutEffect((): void => {
     const nextBBox = gRef.current?.getBBox()
-    if (!areBBoxesEqual(bBox, nextBBox)) updateBBox(nextBBox)
+    if (!areBBoxesEqual(bBox, nextBBox)) { 
+       updateBBox(nextBBox)
+    }
   }, [
     bBox,
     // This dep array needs to include anything that can affect the contents of the rendered SVG.

--- a/labware-library/src/labware-creator/components/ConditionalLabwareRender.tsx
+++ b/labware-library/src/labware-creator/components/ConditionalLabwareRender.tsx
@@ -1,4 +1,5 @@
 import { useLayoutEffect, useRef, useState } from 'react'
+import { isEqual } from 'lodash'
 
 import {
   LabwareOutline,
@@ -19,74 +20,100 @@ interface Props {
   definition: LabwareDefinition2 | null
 }
 
-const calculateViewBox = (args: {
-  bBox: DOMRect | undefined
-  xDim: number
-  yDim: number
-}): string => {
-  const { bBox, xDim, yDim } = args
-
+const calculateViewBox = (bBox: DOMRect): string => {
   // by-eye margin to make sure there is no visual clipping
   const MARGIN = 5
 
   // calculate viewBox such that SVG is zoomed and panned with the bBox fully in view,
   // in a "zoom to fit" manner, plus some visual margin to prevent clipping
-  return `${(bBox?.x ?? 0) - MARGIN} ${(bBox?.y ?? 0) - MARGIN} ${
-    xDim + MARGIN * 2
-  } ${yDim + MARGIN * 2}`
+  const x = bBox.x - MARGIN
+  const y = bBox.y - MARGIN
+  const xDimension = bBox.width + MARGIN * 2
+  const yDimension = bBox.height + MARGIN * 2
+  return `${x} ${y} ${xDimension} ${yDimension}`
+}
+
+const areBBoxesEqual = (
+  a: DOMRect | undefined,
+  b: DOMRect | undefined
+): boolean => {
+  return isEqual(
+    {
+      x: a?.x,
+      y: a?.y,
+      width: a?.width,
+      height: a?.height,
+    },
+    {
+      x: b?.x,
+      y: b?.y,
+      width: b?.width,
+      height: b?.height,
+    }
+  )
 }
 
 export const ConditionalLabwareRender = (props: Props): JSX.Element => {
   const { definition } = props
+  return definition === null ? (
+    <Placeholder />
+  ) : (
+    <PopulatedPreview definition={definition} />
+  )
+}
+
+const PopulatedPreview = (props: {
+  definition: LabwareDefinition2
+}): JSX.Element => {
+  const { definition } = props
   const gRef = useRef<SVGGElement>(null)
   const [bBox, updateBBox] = useState<DOMRect | undefined>(
-    gRef.current ? gRef.current.getBBox() : undefined
+    gRef.current?.getBBox()
   )
 
   // In order to implement "zoom to fit", we're calculating the desired viewBox based on getBBox of the child.
   // So we have to actually render the child to get its bounding box. After that, we re-calculate the viewBox.
   // Once the viewBox is re-calculated, we use setState to force a re-render.
-  const nextBBox = gRef.current?.getBBox()
   useLayoutEffect((): void => {
-    if (
-      nextBBox != null &&
-      (nextBBox.width !== bBox?.width || nextBBox.height !== bBox?.height)
-    ) {
-      updateBBox(nextBBox)
-    }
-  }, [bBox?.height, bBox?.width, nextBBox])
-
-  const xDim =
-    definition != null
-      ? bBox?.width ?? definition.dimensions.xDimension
-      : DEFAULT_X_DIMENSION
-  const yDim =
-    definition != null
-      ? bBox?.height ?? definition.dimensions.yDimension
-      : DEFAULT_Y_DIMENSION
+    const nextBBox = gRef.current?.getBBox()
+    if (!areBBoxesEqual(bBox, nextBBox)) updateBBox(nextBBox)
+  }, [
+    bBox,
+    // This dep array needs to include anything that can affect the contents of the rendered SVG.
+    definition,
+  ])
 
   return (
-    <RobotWorkSpace viewBox={calculateViewBox({ bBox, xDim, yDim })}>
-      {() =>
-        definition != null ? (
-          <LabwareRender definition={definition} gRef={gRef} />
-        ) : (
-          <>
-            <LabwareOutline />
-            <RobotCoordsForeignDiv
-              x={0}
-              y={0}
-              width={xDim}
-              height={yDim}
-              innerDivProps={{ className: styles.error_text_wrapper }}
-            >
-              <div className={styles.error_text}>
-                Add missing info to see labware preview
-              </div>
-            </RobotCoordsForeignDiv>
-          </>
-        )
-      }
+    <RobotWorkSpace viewBox={bBox == null ? '0 0 0 0' : calculateViewBox(bBox)}>
+      {() => <LabwareRender definition={definition} gRef={gRef} />}
+    </RobotWorkSpace>
+  )
+}
+
+const Placeholder = (): JSX.Element => {
+  return (
+    <RobotWorkSpace
+      viewBox={`0 0 ${DEFAULT_X_DIMENSION} ${DEFAULT_Y_DIMENSION}`}
+    >
+      {() => (
+        <>
+          <LabwareOutline
+            width={DEFAULT_X_DIMENSION}
+            height={DEFAULT_Y_DIMENSION}
+          />
+          <RobotCoordsForeignDiv
+            x={0}
+            y={0}
+            width={DEFAULT_X_DIMENSION}
+            height={DEFAULT_Y_DIMENSION}
+            innerDivProps={{ className: styles.error_text_wrapper }}
+          >
+            <div className={styles.error_text}>
+              Add missing info to see labware preview
+            </div>
+          </RobotCoordsForeignDiv>
+        </>
+      )}
     </RobotWorkSpace>
   )
 }

--- a/labware-library/src/labware-creator/components/ConditionalLabwareRender.tsx
+++ b/labware-library/src/labware-creator/components/ConditionalLabwareRender.tsx
@@ -1,5 +1,5 @@
 import { useLayoutEffect, useRef, useState } from 'react'
-import { isEqual } from 'lodash'
+import isEqual  from 'lodash/isEqual'
 
 import {
   LabwareOutline,

--- a/labware-library/src/labware-creator/components/ConditionalLabwareRender.tsx
+++ b/labware-library/src/labware-creator/components/ConditionalLabwareRender.tsx
@@ -33,10 +33,7 @@ const calculateViewBox = (bBox: DOMRect): string => {
   return `${x} ${y} ${xDimension} ${yDimension}`
 }
 
-const areBBoxesEqual = (
-  a: DOMRect | undefined,
-  b: DOMRect | undefined
-): boolean => {
+const areBBoxesEqual = (a: DOMRect | null, b: DOMRect | null): boolean => {
   return isEqual(
     {
       x: a?.x,
@@ -67,17 +64,17 @@ const PopulatedPreview = (props: {
 }): JSX.Element => {
   const { definition } = props
   const gRef = useRef<SVGGElement>(null)
-  const [bBox, updateBBox] = useState<DOMRect | undefined>(
-    gRef.current?.getBBox()
+  const [bBox, updateBBox] = useState<DOMRect | null>(
+    gRef.current?.getBBox() ?? null
   )
 
   // In order to implement "zoom to fit", we're calculating the desired viewBox based on getBBox of the child.
   // So we have to actually render the child to get its bounding box. After that, we re-calculate the viewBox.
   // Once the viewBox is re-calculated, we use setState to force a re-render.
   useLayoutEffect((): void => {
-    const nextBBox = gRef.current?.getBBox()
-    if (!areBBoxesEqual(bBox, nextBBox)) { 
-       updateBBox(nextBBox)
+    const nextBBox = gRef.current?.getBBox() ?? null
+    if (!areBBoxesEqual(bBox, nextBBox)) {
+      updateBBox(nextBBox)
     }
   }, [
     bBox,

--- a/labware-library/src/labware-creator/components/ConditionalLabwareRender.tsx
+++ b/labware-library/src/labware-creator/components/ConditionalLabwareRender.tsx
@@ -1,5 +1,5 @@
 import { useLayoutEffect, useRef, useState } from 'react'
-import isEqual  from 'lodash/isEqual'
+import isEqual from 'lodash/isEqual'
 
 import {
   LabwareOutline,


### PR DESCRIPTION
## Overview

This fixes a few intertwined issues with the preview at the bottom of Labware Creator not zooming and panning to show the whole labware like it's intended to, closing EXEC-1607. It also tries to simplify the code, which helps with EXEC-1573.

There is another bug here specifically related to the labware width and height fields, EXEC-1600. I'm not addressing that one in this PR.

## Test Plan and Hands on Testing

See test plan in EXEC-1607.

## Changelog

* Fix: Find the SVG dimensions *after* we render the SVG, not *before.*

  We're using `useLayoutEffect` to render the SVG, find its dimensions, and rerender it with a `viewBox` based on those dimensions before the browser repaints the screen. That's all good so far.

  But we were finding the dimensions (`getBBox()`) *outside* the `useLayoutEffect()`, which meant we were getting the dimensions of the SVG as it existed before we started rendering, not the new SVG that we just rendered. This basically caused our `viewBox` value to always lag behind our actual SVG contents by one render.

* Fix: Update the viewbox if its x- or y-offset changes. Formerly, we were only updating it if its width or height changed.

* Refactor: Fully separate the empty-state placeholder from the populated-state preview so there's no chance of their dimensions affecting each other.

* Refactor: Simplify the dummy `viewBox` value that's used in the first render, before we've measured the SVG and computed an actual value. Formerly, it fell back to the labware definition's `dimensions` and then to standard slot dimensions. Now, we just use a hard-coded `0 0 0 0` because it's completely arbitrary and gets instantaneously replaced by a real measured value.

## Review requests

None in particular.

## Risk assessment

Medium. Hairy `useLayoutEffect` code can cause infinite rerenders.