### PR TITLE
ci(app): electron builder Windows signing workaround

### DIFF
--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -233,8 +233,8 @@ jobs:
             try {
               Invoke-TrustedSigning `
                 -Endpoint 'https://eus.codesigning.azure.net/' `
-                -CertificateProfileName '${{secrets.AZURE_TENANT_ID}}' `
-                -CodeSigningAccountName '${{secrets.AZURE_CLIENT_ID}}' `
+                -CertificateProfileName 'dummyName' `
+                -CodeSigningAccountName 'dummyName' `
                 -TimestampRfc3161 'http://timestamp.acs.microsoft.com' `
                 -TimestampDigest 'SHA256' `
                 -FileDigest 'SHA256' `

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -222,6 +222,7 @@ jobs:
           make -C app dist
 
       - name: Install and Invoke TrustedSigning @0.5.3 on dummy executable
+        # Work around from https://github.com/electron-userland/electron-builder/issues/9076#issuecomment-2855541018
         if: startsWith(matrix.os, 'windows') && contains(needs.determine-build-type.outputs.type, 'release')
         shell: pwsh
         run: |
@@ -230,6 +231,7 @@ jobs:
             $dummyExePath = Join-Path -Path $env:GITHUB_WORKSPACE -ChildPath "dummy.exe"
             Set-Content -Path $dummyExePath -Value "This is a dummy executable for testing purposes."
             # Invoke Trusted Signing on the dummy executable
+            # Necessary to force dependency resolution
             try {
               Invoke-TrustedSigning `
                 -Endpoint 'https://eus.codesigning.azure.net/' `

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -221,6 +221,13 @@ jobs:
         run: |
           make -C app dist
 
+      - name: Install TrustedSigning module @ 0.5.0
+        if: startsWith(matrix.os, 'windows') && contains(needs.determine-build-type.outputs.type, 'release')
+        shell: pwsh
+        run: |
+          Install-Module -Name TrustedSigning -RequiredVersion 0.5.0 -Force -Repository PSGallery
+          Get-Module -ListAvailable -Name TrustedSigning
+
       # build the desktop app and deploy it
       - name: 'build ${{matrix.variant}} app for ${{ matrix.os }}'
         if: matrix.target == 'desktop'

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -230,14 +230,20 @@ jobs:
             $dummyExePath = Join-Path -Path $env:GITHUB_WORKSPACE -ChildPath "dummy.exe"
             Set-Content -Path $dummyExePath -Value "This is a dummy executable for testing purposes."
             # Invoke Trusted Signing on the dummy executable
-            Invoke-TrustedSigning `
-              -Endpoint 'https://eus.codesigning.azure.net/' `
-              -CertificateProfileName '${{secrets.AZURE_TENANT_ID}}' `
-              -CodeSigningAccountName '${{secrets.AZURE_CLIENT_ID}}' `
-              -TimestampRfc3161 'http://timestamp.acs.microsoft.com' `
-              -TimestampDigest 'SHA256' `
-              -FileDigest 'SHA256' `
-              -Files $dummyExePath
+            try {
+              Invoke-TrustedSigning `
+                -Endpoint 'https://eus.codesigning.azure.net/' `
+                -CertificateProfileName '${{secrets.AZURE_TENANT_ID}}' `
+                -CodeSigningAccountName '${{secrets.AZURE_CLIENT_ID}}' `
+                -TimestampRfc3161 'http://timestamp.acs.microsoft.com' `
+                -TimestampDigest 'SHA256' `
+                -FileDigest 'SHA256' `
+                -Files $dummyExePath
+            } catch {
+              Write-Host "Invoke-TrustedSigning failed: $($_.Exception.Message)"
+              # Prevent the script from exiting with a non-zero status
+              exit 0
+            }
 
       # build the desktop app and deploy it
       - name: 'build ${{matrix.variant}} app for ${{ matrix.os }}'

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -221,12 +221,22 @@ jobs:
         run: |
           make -C app dist
 
-      - name: Install TrustedSigning module @ 0.5.0
+      - name: Invoke Trusted Signing on dummy executable
         if: startsWith(matrix.os, 'windows') && contains(needs.determine-build-type.outputs.type, 'release')
         shell: pwsh
         run: |
-          Install-Module -Name TrustedSigning -RequiredVersion 0.5.0 -Force -Repository PSGallery
-          Get-Module -ListAvailable -Name TrustedSigning
+            # Create a dummy executable file
+            $dummyExePath = Join-Path -Path $env:GITHUB_WORKSPACE -ChildPath "dummy.exe"
+            Set-Content -Path $dummyExePath -Value "This is a dummy executable for testing purposes."
+            # Invoke Trusted Signing on the dummy executable
+            Invoke-TrustedSigning `
+              -Endpoint 'https://eus.codesigning.azure.net/' `
+              -CertificateProfileName '${{secrets.AZURE_TENANT_ID}}' `
+              -CodeSigningAccountName '${{secrets.AZURE_CLIENT_ID}}' `
+              -TimestampRfc3161 'http://timestamp.acs.microsoft.com' `
+              -TimestampDigest 'SHA256' `
+              -FileDigest 'SHA256' `
+              -Files $dummyExePath
 
       # build the desktop app and deploy it
       - name: 'build ${{matrix.variant}} app for ${{ matrix.os }}'

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -221,10 +221,11 @@ jobs:
         run: |
           make -C app dist
 
-      - name: Invoke Trusted Signing on dummy executable
+      - name: Install and Invoke TrustedSigning @0.5.3 on dummy executable
         if: startsWith(matrix.os, 'windows') && contains(needs.determine-build-type.outputs.type, 'release')
         shell: pwsh
         run: |
+            Install-Module -Name TrustedSigning -RequiredVersion 0.5.3 -Force -Repository PSGallery
             # Create a dummy executable file
             $dummyExePath = Join-Path -Path $env:GITHUB_WORKSPACE -ChildPath "dummy.exe"
             Set-Content -Path $dummyExePath -Value "This is a dummy executable for testing purposes."


### PR DESCRIPTION
# Overview

There’s an issue in Electron Builder/TrustedSigning that causes an error when installing the required tooling for code signing. Windows signing fails.  I don't know how the build I did against edge PR ever even worked. 
<https://github.com/electron-userland/electron-builder/issues/9076>

@y3rsh is ok with this pain using a beta and does not want to fall back to using DigiCert.  **BUT** it will require diligence.

## Solution

The work around comes from 
<https://github.com/electron-userland/electron-builder/issues/9076#issuecomment-2855541018>

1. Before the electron builder runs, install `TrustedSigning` at the specific version Electron Builder wants
2. Invoke this tool on a single dummy.exe just like Electron Builder will be invoking it on our files.
3. The dependencies needed for this type of signing are automatically installed. 
4. The signing fails as expected but all the tools for signing are ready for electron builder in the next step, sidestepping the issue.

## Test Plan and Hands on Testing

- [x] Successful build and sign using the work around <https://github.com/Opentrons/opentrons/actions/runs/15357038874/job/43218143087>
- [x] Add a comment in the Workflow

## Review requests

I considered directly trying to install the dependencies... but I think it seems best to leave that to `TrustedSigning`. So the invoke is necessary.
```
        Build tools package installed: False
	Trusted signing package installed: False
	Sign CLI package installed: False
	Installing required dependencies.
		Found existing package source: https://www.nuget.org/api/v2/
		Installing package: Microsoft.Windows.SDK.BuildTools 10.0.22621.3233
		Installing package: Microsoft.Trusted.Signing.Client 1.0.53
		Installing package: sign 0.9.1-beta.2[44]
```
