### PR TITLE
fix(app): fix LPC error when loading a module into C2

### DIFF
--- a/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useLPCLabwareInfo/getLPCLabwareInfoFrom/__tests__/getDefaultOffsetForLabware.test.ts
+++ b/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useLPCLabwareInfo/getLPCLabwareInfoFrom/__tests__/getDefaultOffsetForLabware.test.ts
@@ -1,6 +1,7 @@
 import { vi, it, describe, expect } from 'vitest'
+
 import { ANY_LOCATION } from '@opentrons/api-client'
-import { getLabwareDefURI } from '@opentrons/shared-data'
+import { C2_ADDRESSABLE_AREA, getLabwareDefURI } from '@opentrons/shared-data'
 
 import { getDefaultOffsetDetailsForLabware } from '../getDefaultOffsetForLabware'
 import { OFFSET_KIND_DEFAULT } from '/app/redux/protocol-runs'
@@ -70,6 +71,24 @@ describe('getDefaultOffsetDetailsForLabware', () => {
         definitionUri: ADAPTER_URI,
       },
     ],
+    modules: [],
+  }
+
+  const MOCK_PROTOCOL_DATA_WITH_MODULES = {
+    labware: [
+      {
+        id: ADAPTER_ID,
+        definitionUri: ADAPTER_URI,
+      },
+    ],
+    modules: [
+      {
+        location: { slotName: 'C2' },
+      },
+      {
+        location: { slotName: 'A1' },
+      },
+    ],
   }
 
   it('should return default offset details with minimal params', () => {
@@ -89,7 +108,7 @@ describe('getDefaultOffsetDetailsForLabware', () => {
         labwareId: LABWARE_ID,
         definitionUri: LABWARE_URI,
         kind: OFFSET_KIND_DEFAULT,
-        addressableAreaName: 'C2',
+        addressableAreaName: C2_ADDRESSABLE_AREA,
         lwOffsetLocSeq: ANY_LOCATION,
         closestBeneathAdapterId: undefined,
         lwModOnlyStackupDetails: [
@@ -201,5 +220,76 @@ describe('getDefaultOffsetDetailsForLabware', () => {
     } as any)
 
     expect(result.locationDetails.closestBeneathAdapterId).toBeUndefined()
+  })
+
+  it('should use C2 when available and no modules are present', () => {
+    const result = getDefaultOffsetDetailsForLabware({
+      uri: LABWARE_URI,
+      lwLocInfo: MOCK_LW_LOC_COMBOS,
+      currentOffsets: [],
+      labwareDefs: [MOCK_LABWARE_DEF],
+      locationSpecificOffsetDetails: [],
+      protocolData: MOCK_PROTOCOL_DATA,
+    } as any)
+
+    expect(result.locationDetails.addressableAreaName).toBe(C2_ADDRESSABLE_AREA)
+  })
+
+  it('should use alternative slot when C2 is occupied by a module', () => {
+    const result = getDefaultOffsetDetailsForLabware({
+      uri: LABWARE_URI,
+      lwLocInfo: MOCK_LW_LOC_COMBOS,
+      currentOffsets: [],
+      labwareDefs: [MOCK_LABWARE_DEF],
+      locationSpecificOffsetDetails: [],
+      protocolData: MOCK_PROTOCOL_DATA_WITH_MODULES,
+    } as any)
+
+    expect(result.locationDetails.addressableAreaName).not.toBe(
+      C2_ADDRESSABLE_AREA
+    )
+    expect([
+      'A2',
+      'A3',
+      'B1',
+      'B2',
+      'B3',
+      'C1',
+      'C3',
+      'D1',
+      'D2',
+      'D3',
+    ]).toContain(result.locationDetails.addressableAreaName)
+  })
+
+  it('should fallback to C2 when all slots are occupied', () => {
+    const protocolDataWithAllModules = {
+      labware: [],
+      modules: [
+        { location: { slotName: 'A1' } },
+        { location: { slotName: 'A2' } },
+        { location: { slotName: 'A3' } },
+        { location: { slotName: 'B1' } },
+        { location: { slotName: 'B2' } },
+        { location: { slotName: 'B3' } },
+        { location: { slotName: 'C1' } },
+        { location: { slotName: 'C2' } },
+        { location: { slotName: 'C3' } },
+        { location: { slotName: 'D1' } },
+        { location: { slotName: 'D2' } },
+        { location: { slotName: 'D3' } },
+      ],
+    }
+
+    const result = getDefaultOffsetDetailsForLabware({
+      uri: LABWARE_URI,
+      lwLocInfo: MOCK_LW_LOC_COMBOS,
+      currentOffsets: [],
+      labwareDefs: [MOCK_LABWARE_DEF],
+      locationSpecificOffsetDetails: [],
+      protocolData: protocolDataWithAllModules,
+    } as any)
+
+    expect(result.locationDetails.addressableAreaName).toBe(C2_ADDRESSABLE_AREA)
   })
 })

--- a/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useLPCLabwareInfo/getLPCLabwareInfoFrom/getDefaultOffsetForLabware.ts
+++ b/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useLPCLabwareInfo/getLPCLabwareInfoFrom/getDefaultOffsetForLabware.ts
@@ -1,13 +1,26 @@
+import head from 'lodash/head'
+
 import { ANY_LOCATION } from '@opentrons/api-client'
-import { getLabwareDefURI } from '@opentrons/shared-data'
+import {
+  A1_ADDRESSABLE_AREA,
+  B1_ADDRESSABLE_AREA,
+  C2_ADDRESSABLE_AREA,
+  getLabwareDefURI,
+  STANDARD_FLEX_SLOTS,
+  THERMOCYCLER_MODULE_V1,
+  THERMOCYCLER_MODULE_V2,
+} from '@opentrons/shared-data'
 
 import { OFFSET_KIND_DEFAULT } from '/app/redux/protocol-runs'
 
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type {
+  FlexAddressableAreaName,
+  LabwareDefinition2,
+} from '@opentrons/shared-data'
 import type {
   DefaultOffsetDetails,
-  LocationSpecificOffsetDetails,
   LabwareModuleStackupDetails,
+  LocationSpecificOffsetDetails,
 } from '/app/redux/protocol-runs'
 import type { GetLPCLabwareInfoForURI } from '.'
 
@@ -42,7 +55,7 @@ export function getDefaultOffsetDetailsForLabware(
       definitionUri: uri,
       kind: OFFSET_KIND_DEFAULT,
       // We always do default offset LPCing in this slot.
-      addressableAreaName: 'C2',
+      addressableAreaName: getValidDefaultOffsetLocation(params.protocolData),
       lwOffsetLocSeq: ANY_LOCATION,
       closestBeneathAdapterId,
       // The only labware present on deck when configuring the default offset is the top-most labware itself.
@@ -127,4 +140,40 @@ function getFirstAdapterIdFrom(
   return lsOffsets.find(
     lsOffset => lsOffset.locationDetails.closestBeneathAdapterId != null
   )?.locationDetails.closestBeneathAdapterId
+}
+
+// Find a valid location for setting a default offset slot.
+// A slot is valid if it does not contain a module.
+// This util works under the assumption that modules cannot be added or removed
+// from the deck mid-protocol run and that currently there is at least one
+// slot on the deck without a module (true as of 8.4.0, since launching LPC requires
+// the presence of a tiprack, which must occupy a non-module deck slot).
+// NOTE: This util is meant to be temporary until product/design devise
+// an alternative method for default offset location selection.
+function getValidDefaultOffsetLocation(
+  protocolData: GetStackingInfoParams['protocolData']
+): FlexAddressableAreaName {
+  const validLocations = new Set<FlexAddressableAreaName>(
+    STANDARD_FLEX_SLOTS as FlexAddressableAreaName[]
+  )
+
+  protocolData?.modules.forEach(mod => {
+    if (
+      mod.model === THERMOCYCLER_MODULE_V2 ||
+      mod.model === THERMOCYCLER_MODULE_V1
+    ) {
+      validLocations.delete(A1_ADDRESSABLE_AREA)
+      validLocations.delete(B1_ADDRESSABLE_AREA)
+    } else {
+      const slotName = mod.location.slotName as FlexAddressableAreaName
+      validLocations.delete(slotName)
+    }
+  })
+
+  if (validLocations.has(C2_ADDRESSABLE_AREA)) {
+    return C2_ADDRESSABLE_AREA
+  } else {
+    // The fallback should never occur in practice.
+    return head(Array.from(validLocations)) ?? C2_ADDRESSABLE_AREA
+  }
 }

--- a/app/src/redux/protocol-runs/types/lpc/offsets.ts
+++ b/app/src/redux/protocol-runs/types/lpc/offsets.ts
@@ -73,7 +73,7 @@ export type OffsetLocationDetails =
 
 export interface DefaultOffsetLocationDetails
   extends BaseOffsetLocationDetails {
-  addressableAreaName: 'C2'
+  addressableAreaName: FlexAddressableAreaName
   kind: 'default'
   lwOffsetLocSeq: typeof ANY_LOCATION
   hardCodedOffsetId?: undefined


### PR DESCRIPTION
Closes [RESC-461](https://opentrons.atlassian.net/browse/RESC-461)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Loading a module, aka the mag block, into slot C2 causes LPC to error out when setting a default offset. Product + Design are working on a longer term solution, but in the interim, we want to include something for 8.5. 

This PR selects a default offset location for LPC based on slots that we know do not contain a module. We preferentially select C2 if available. There are some assumptions we have to make for this logic to hold:

- Modules can't be swapped during a protocol run.
- There is always at least deck slot without a module loaded. This is true in our current understanding of the world, since all protocols that can possible do LPC require interacting with a tip rack, and these are not accessible by a pipette unless they are located directly on a standard (not staging area) deck slot.

There are many ways one could approach that would be more robust (primarily by looking at the `deckConfig`), but in 8.5, we don't have access to the nice new deck utils that would make our lives a bit easier as they exist on `edge`. It's not a simple copy-paste of these either, since the deck is remarkably different on `edge`, so I think this strategy is sufficient for now. 

We may very well might implement a different approach based on Product + Design LPC prioritization for 8.5/6, so we just need something that will work if we ship nothing else.

<img width="743" alt="Screenshot 2025-06-02 at 9 10 38 AM" src="https://github.com/user-attachments/assets/0c967be1-44da-4303-9b56-928bdae45216" />

_Default offset location when C2 is occupied_

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- Verified C2 still available for standard protocols.
- Tested the following protocol as an example edge case:
```
from opentrons import protocol_api, types


requirements = {
    "apiLevel": "2.18",
    "robotType": "Flex",
}


def run(protocol: protocol_api.ProtocolContext) -> None:
    magnetic_block = protocol.load_module(module_name="magneticBlockV1", location="C2")
    magnetic_block2 = protocol.load_module(module_name="magneticBlockV1", location="C1")
    magnetic_block3 = protocol.load_module(module_name="magneticBlockV1", location="C3")
    magnetic_block4 = protocol.load_module(module_name="magneticBlockV1", location="A1")
    magnetic_block5 = protocol.load_module(module_name="magneticBlockV1", location="A2")
    magnetic_block6 = protocol.load_module(module_name="magneticBlockV1", location="A3")
    magnetic_block7 = protocol.load_module(module_name="magneticBlockV1", location="B1")
    magnetic_block8 = protocol.load_module(module_name="magneticBlockV1", location="B2")
    magnetic_block9 = protocol.load_module(module_name="magneticBlockV1", location="B3")
    magnetic_block10 = protocol.load_module(module_name="magneticBlockV1", location="D1")
    magnetic_block11 = protocol.load_module(module_name="magneticBlockV1", location="D2")

    tip_rack = protocol.load_labware("opentrons_flex_96_tiprack_1000ul", "D3")
    well_plate = magnetic_block.load_labware("nest_96_wellplate_100ul_pcr_full_skirt")

    pipette = protocol.load_instrument("flex_1channel_1000", mount="left")

    pipette.pick_up_tip(tip_rack["A12"])

    for _ in range(10):
        pipette.aspirate(pipette.max_volume, well_plate["A1"])
        pipette.dispense(pipette.max_volume, well_plate["A2"])
```
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed LPC erroring during default offset calibration when a module is loaded into slot C2.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests
- Does the logic outlined above/in the code comment seem sound?
- The slot name for a module's `location` is _always_ a standard deck slot, assuming the module is loaded into a deck slot, yeah?
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
- low, pretty straightforward, only adds more optionality.
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RESC-461]: https://opentrons.atlassian.net/browse/RESC-461?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ