### PR TITLE
chore: release note for #18495

### DIFF
--- a/app-shell/build/release-notes.md
+++ b/app-shell/build/release-notes.md
@@ -14,6 +14,7 @@ The 8.4.1 hotfix release fixes two issues:
 
 - Placing a Magnetic Block in slot C2 no longer prevents Labware Position Check from running.
 - Existing labware offsets are no longer doubled during Labware Position Check.
+- The app no longer crashes during run setup when using certain custom labware.
 
 ---
 


### PR DESCRIPTION

# Overview

Adds #18495 to the release notes for the 8.4.1 hotfix.

## Changelog

+1 line

## Review requests

This should only merge after the fix does, naturally.

## Risk assessment

zip