### PR TITLE
fix(protocol-designer): auto-populate the drop tip location if applicable

### DIFF
--- a/protocol-designer/src/step-forms/reducers/index.ts
+++ b/protocol-designer/src/step-forms/reducers/index.ts
@@ -396,13 +396,41 @@ export const savedStepForms = (
       return mapValues(
         savedStepForms,
         (form: FormData): FormData => {
-          const updatedLocation = omit(form[locationUpdate] || {}, id)
+          if (form.stepType === 'manualIntervention') {
+            const updatedLocation = omit(form[locationUpdate] || {}, id)
 
-          return {
-            ...form,
-            [locationUpdate]:
-              Object.keys(updatedLocation).length > 0 ? updatedLocation : {},
+            return {
+              ...form,
+              [locationUpdate]:
+                Object.keys(updatedLocation).length > 0 ? updatedLocation : {},
+            }
+          } else if (id.includes(form.dropTip_location as string)) {
+            return {
+              ...form,
+              ...handleFormChange(
+                {
+                  dropTip_location: null,
+                },
+                form,
+                _getPipetteEntitiesRootState(rootState),
+                _getLabwareEntitiesRootState(rootState)
+              ),
+            }
+          } else if (id.includes(form.newLocation as string)) {
+            return {
+              ...form,
+              ...handleFormChange(
+                {
+                  newLocation: null,
+                },
+                form,
+                _getPipetteEntitiesRootState(rootState),
+                _getLabwareEntitiesRootState(rootState)
+              ),
+            }
           }
+
+          return form
         }
       )
     }
@@ -668,7 +696,6 @@ export const savedStepForms = (
         return { ...savedForm, ...deleteLabwareUpdate }
       })
     }
-
     case 'DELETE_PIPETTES': {
       // remove references to pipettes that have been deleted
       const deletedPipetteIds = action.payload

--- a/protocol-designer/src/step-forms/reducers/index.ts
+++ b/protocol-designer/src/step-forms/reducers/index.ts
@@ -377,16 +377,39 @@ export const savedStepForms = (
       const prevInitialDeckSetupStep =
         savedStepForms[INITIAL_DECK_SETUP_STEP_ID]
       const locationUpdate = `${name}LocationUpdate`
-      return {
-        ...savedStepForms,
-        [INITIAL_DECK_SETUP_STEP_ID]: {
-          ...prevInitialDeckSetupStep,
-          [locationUpdate]: {
-            ...prevInitialDeckSetupStep[locationUpdate],
-            [id]: location,
-          },
-        },
-      }
+      return mapValues(
+        savedStepForms,
+        (form: FormData): FormData => {
+          if (form.stepType === 'manualIntervention') {
+            return {
+              ...form,
+              [INITIAL_DECK_SETUP_STEP_ID]: {
+                ...prevInitialDeckSetupStep,
+                [locationUpdate]: {
+                  ...prevInitialDeckSetupStep[locationUpdate],
+                  [id]: location,
+                },
+              },
+            }
+          } else if (
+            form.dropTip_location == null &&
+            (name === 'trashBin' || name === 'wasteChute')
+          ) {
+            return {
+              ...form,
+              ...handleFormChange(
+                {
+                  dropTip_location: id,
+                },
+                form,
+                _getPipetteEntitiesRootState(rootState),
+                _getLabwareEntitiesRootState(rootState)
+              ),
+            }
+          }
+          return form
+        }
+      )
     }
     case 'DELETE_DECK_FIXTURE': {
       const { id } = action.payload


### PR DESCRIPTION
closes RQA-4239

# Overview

We've run into this bug a lot and i've had different methods for unblocking it but my final solution is this lol. if you delete a trash bin/waste chute that is used in a step, the forms will update the drop tip location to `null`. then if you add a trash bin/waste chute and there are drop tip locations === `null` in the forms, it will auto populate.

## Test Plan and Hands on Testing

Upload a protocol with pipetting steps
delete the trash bin/waste chute
see all the timeline errors
add a trash bin/waste chute
see the timeline errors go away

## Changelog

- add to the step form reducer to properly remove the deleted entity and add it back for trash bin/waste chute only drop tip location only.

## Risk assessment

low
