### PR TITLE
fix(protocol-designer): allow to delete and re-add thermocycler

### DIFF
--- a/protocol-designer/src/components/organisms/HardwareConfigurator/index.tsx
+++ b/protocol-designer/src/components/organisms/HardwareConfigurator/index.tsx
@@ -57,10 +57,16 @@ export function HardwareConfigurator(
       const hasModule = Object.values(modules).some(
         module => module.cutoutId === cutoutId
       )
+      //  since we are adding cutoutA1 in moduleConfig if
+      //  there is a TC
+      const hasTCAndCutoutA1 =
+        Object.values(modules).some(
+          module => module.type === THERMOCYCLER_MODULE_TYPE
+        ) && cutoutId === 'cutoutA1'
       const hasFixture = Object.values(fixtures).some(
         fixture => fixture.cutoutId === cutoutId
       )
-      return !hasModule && !hasFixture
+      return !hasModule && !hasFixture && !hasTCAndCutoutA1
     }
   )
   const moduleConfig: DeckConfiguration = Object.values(modules).flatMap(

--- a/protocol-designer/src/components/organisms/utils.ts
+++ b/protocol-designer/src/components/organisms/utils.ts
@@ -111,7 +111,7 @@ export const getLabwareCompatibleForEditHardware = (
     } else if (labwareDefB1 != null) {
       labwareCompatible = getLabwareIsCompatible(labwareDefB1, moduleType)
     } else {
-      labwareCompatible = false
+      labwareCompatible = true
     }
   } else if (labwareDef != null && moduleType != null) {
     labwareCompatible = getLabwareIsCompatible(labwareDef, moduleType)


### PR DESCRIPTION
closes RQA-4230

# Overview

Fix logic in the util and also avoid having cutoutA1 twice in the deck config

## Test Plan and Hands on Testing

Test adding a thermocycler, deleting it and adding it again in the onboarding flow

## Changelog

- filter out cutoutA1 from appearing twice in the config when adding a TC
- fix util logic to be true by default

## Risk assessment

low
