### PR TITLE
fix(protocol-designer): account for dispensing into trash

### DIFF
--- a/protocol-designer/src/load-file/migration/8_5_0.ts
+++ b/protocol-designer/src/load-file/migration/8_5_0.ts
@@ -83,7 +83,7 @@ export const migrateFile = (
       const isDispenseLabwareTouchtipDisabled =
         labwareDefinitions[dispenseLabwareUri]?.parameters.quirks?.includes(
           'touchTipDisabled'
-        ) ?? false
+        ) ?? true
       const matchingAspirateLabwareWellDepth = getMigratedPositionFromTop(
         labwareDefinitions,
         loadLabwareCommands,

--- a/protocol-designer/src/load-file/migration/8_5_0.ts
+++ b/protocol-designer/src/load-file/migration/8_5_0.ts
@@ -79,10 +79,11 @@ export const migrateFile = (
         aspirateLabwareUri
       ].parameters.quirks?.includes('touchTipDisabled')
       const dispenseLabwareUri =
-        equipmentLoadInfoFromCommands.labware[dispense_labware].labwareDefURI
-      const isDispenseLabwareTouchtipDisabled = labwareDefinitions[
-        dispenseLabwareUri
-      ].parameters.quirks?.includes('touchTipDisabled')
+        equipmentLoadInfoFromCommands.labware[dispense_labware]?.labwareDefURI
+      const isDispenseLabwareTouchtipDisabled =
+        labwareDefinitions[dispenseLabwareUri]?.parameters.quirks?.includes(
+          'touchTipDisabled'
+        ) ?? false
       const matchingAspirateLabwareWellDepth = getMigratedPositionFromTop(
         labwareDefinitions,
         loadLabwareCommands,

--- a/protocol-designer/src/load-file/migration/8_5_0.ts
+++ b/protocol-designer/src/load-file/migration/8_5_0.ts
@@ -80,10 +80,15 @@ export const migrateFile = (
       ].parameters.quirks?.includes('touchTipDisabled')
       const dispenseLabwareUri =
         equipmentLoadInfoFromCommands.labware[dispense_labware]?.labwareDefURI
+
       const isDispenseLabwareTouchtipDisabled =
-        labwareDefinitions[dispenseLabwareUri]?.parameters.quirks?.includes(
-          'touchTipDisabled'
-        ) ?? true
+        //  dispense is in a waste chute/trash bin
+        labwareDefinitions[dispenseLabwareUri] == null
+          ? true
+          : labwareDefinitions[dispenseLabwareUri].parameters.quirks?.includes(
+              'touchTipDisabled'
+            )
+
       const matchingAspirateLabwareWellDepth = getMigratedPositionFromTop(
         labwareDefinitions,
         loadLabwareCommands,


### PR DESCRIPTION
closes RQA-4240

# Overview

The error was that the touch tip logic wasn't accounting for dispensing into a trash bin or waste chute. so the fix is to add extra precautions to account for that 

## Test Plan and Hands on Testing

Make sure the 2 protocols attach properly import

[flex smoke 8.4.2.json](https://github.com/user-attachments/files/20579056/flex.smoke.8.4.2.json)
[flex smoke 8.4.json](https://github.com/user-attachments/files/20579057/flex.smoke.8.4.json)



## Changelog

add null protections and default to true since you can't touch tip in a waste chute/trash bin

## Risk assessment

low
