### PR TITLE
fix(app): do not select a default location that contains a fixture

### DIFF
--- a/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useLPCLabwareInfo/getLPCLabwareInfoFrom/__tests__/getDefaultOffsetForLabware.test.ts
+++ b/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useLPCLabwareInfo/getLPCLabwareInfoFrom/__tests__/getDefaultOffsetForLabware.test.ts
@@ -1,7 +1,11 @@
 import { vi, it, describe, expect } from 'vitest'
 
 import { ANY_LOCATION } from '@opentrons/api-client'
-import { C2_ADDRESSABLE_AREA, getLabwareDefURI } from '@opentrons/shared-data'
+import {
+  C3_ADDRESSABLE_AREA,
+  C2_ADDRESSABLE_AREA,
+  getLabwareDefURI,
+} from '@opentrons/shared-data'
 
 import { getDefaultOffsetDetailsForLabware } from '../getDefaultOffsetForLabware'
 import { OFFSET_KIND_DEFAULT } from '/app/redux/protocol-runs'
@@ -25,7 +29,27 @@ describe('getDefaultOffsetDetailsForLabware', () => {
   const ADAPTER_URI = 'opentrons/adapter-1'
 
   const MOCK_LW_LOC_COMBOS = [
-    { definitionUri: LABWARE_URI, labwareId: LABWARE_ID },
+    {
+      definitionUri: LABWARE_URI,
+      labwareId: LABWARE_ID,
+      addressableAreaName: 'A1',
+      closestBeneathModuleId: null,
+    },
+  ]
+
+  const MOCK_LW_LOC_COMBOS_WITH_MODULE = [
+    {
+      definitionUri: LABWARE_URI,
+      labwareId: LABWARE_ID,
+      addressableAreaName: 'A1',
+      closestBeneathModuleId: 'module-123',
+    },
+    {
+      definitionUri: 'other-labware',
+      labwareId: 'other-labware-id',
+      addressableAreaName: 'B2',
+      closestBeneathModuleId: null,
+    },
   ]
 
   const MOCK_OFFSET: StoredLabwareOffset = {
@@ -74,7 +98,7 @@ describe('getDefaultOffsetDetailsForLabware', () => {
     modules: [],
   }
 
-  const MOCK_PROTOCOL_DATA_WITH_MODULES = {
+  const MOCK_PROTOCOL_DATA_WITH_C2_MODULE = {
     labware: [
       {
         id: ADAPTER_ID,
@@ -84,9 +108,6 @@ describe('getDefaultOffsetDetailsForLabware', () => {
     modules: [
       {
         location: { slotName: 'C2' },
-      },
-      {
-        location: { slotName: 'A1' },
       },
     ],
   }
@@ -235,59 +256,61 @@ describe('getDefaultOffsetDetailsForLabware', () => {
     expect(result.locationDetails.addressableAreaName).toBe(C2_ADDRESSABLE_AREA)
   })
 
-  it('should use alternative slot when C2 is occupied by a module', () => {
+  it('should find first location with no module when C2 is occupied', () => {
     const result = getDefaultOffsetDetailsForLabware({
       uri: LABWARE_URI,
-      lwLocInfo: MOCK_LW_LOC_COMBOS,
+      lwLocInfo: MOCK_LW_LOC_COMBOS_WITH_MODULE,
       currentOffsets: [],
       labwareDefs: [MOCK_LABWARE_DEF],
       locationSpecificOffsetDetails: [],
-      protocolData: MOCK_PROTOCOL_DATA_WITH_MODULES,
+      protocolData: MOCK_PROTOCOL_DATA_WITH_C2_MODULE,
     } as any)
 
-    expect(result.locationDetails.addressableAreaName).not.toBe(
-      C2_ADDRESSABLE_AREA
-    )
-    expect([
-      'A2',
-      'A3',
-      'B1',
-      'B2',
-      'B3',
-      'C1',
-      'C3',
-      'D1',
-      'D2',
-      'D3',
-    ]).toContain(result.locationDetails.addressableAreaName)
+    expect(result.locationDetails.addressableAreaName).toBe('B2')
   })
 
-  it('should fallback to C2 when all slots are occupied', () => {
-    const protocolDataWithAllModules = {
-      labware: [],
-      modules: [
-        { location: { slotName: 'A1' } },
-        { location: { slotName: 'A2' } },
-        { location: { slotName: 'A3' } },
-        { location: { slotName: 'B1' } },
-        { location: { slotName: 'B2' } },
-        { location: { slotName: 'B3' } },
-        { location: { slotName: 'C1' } },
-        { location: { slotName: 'C2' } },
-        { location: { slotName: 'C3' } },
-        { location: { slotName: 'D1' } },
-        { location: { slotName: 'D2' } },
-        { location: { slotName: 'D3' } },
-      ],
-    }
+  it('should fallback to C3 when C2 is occupied and no locations without modules are found', () => {
+    const lwLocInfoAllWithModules = [
+      {
+        definitionUri: LABWARE_URI,
+        labwareId: LABWARE_ID,
+        addressableAreaName: 'A1' as any,
+        closestBeneathModuleId: 'module-1',
+      },
+      {
+        definitionUri: 'other-labware',
+        labwareId: 'other-labware-id',
+        addressableAreaName: 'B2' as any,
+        closestBeneathModuleId: 'module-2',
+      },
+    ]
 
+    const result = getDefaultOffsetDetailsForLabware({
+      uri: LABWARE_URI,
+      lwLocInfo: lwLocInfoAllWithModules,
+      currentOffsets: [],
+      labwareDefs: [MOCK_LABWARE_DEF],
+      locationSpecificOffsetDetails: [],
+      protocolData: MOCK_PROTOCOL_DATA_WITH_C2_MODULE,
+    } as any)
+
+    expect(result.locationDetails.addressableAreaName).toBe(C3_ADDRESSABLE_AREA)
+  })
+
+  it('should return C2 when C2 is not occupied by modules', () => {
     const result = getDefaultOffsetDetailsForLabware({
       uri: LABWARE_URI,
       lwLocInfo: MOCK_LW_LOC_COMBOS,
       currentOffsets: [],
       labwareDefs: [MOCK_LABWARE_DEF],
       locationSpecificOffsetDetails: [],
-      protocolData: protocolDataWithAllModules,
+      protocolData: {
+        labware: [],
+        modules: [
+          { location: { slotName: 'A1' } },
+          { location: { slotName: 'B1' } },
+        ],
+      },
     } as any)
 
     expect(result.locationDetails.addressableAreaName).toBe(C2_ADDRESSABLE_AREA)

--- a/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useLPCLabwareInfo/getLPCLabwareInfoFrom/getDefaultOffsetForLabware.ts
+++ b/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useLPCLabwareInfo/getLPCLabwareInfoFrom/getDefaultOffsetForLabware.ts
@@ -1,28 +1,23 @@
-import head from 'lodash/head'
-
 import { ANY_LOCATION } from '@opentrons/api-client'
 import {
-  A1_ADDRESSABLE_AREA,
-  B1_ADDRESSABLE_AREA,
   C2_ADDRESSABLE_AREA,
+  C3_ADDRESSABLE_AREA,
   getLabwareDefURI,
-  STANDARD_FLEX_SLOTS,
-  THERMOCYCLER_MODULE_V1,
-  THERMOCYCLER_MODULE_V2,
 } from '@opentrons/shared-data'
 
 import { OFFSET_KIND_DEFAULT } from '/app/redux/protocol-runs'
 
 import type {
-  FlexAddressableAreaName,
-  LabwareDefinition2,
-} from '@opentrons/shared-data'
-import type {
   DefaultOffsetDetails,
+  LabwareLocationInfo,
   LabwareModuleStackupDetails,
   LocationSpecificOffsetDetails,
 } from '/app/redux/protocol-runs'
 import type { GetLPCLabwareInfoForURI } from '.'
+import type {
+  FlexAddressableAreaName,
+  LabwareDefinition2,
+} from '@opentrons/shared-data'
 
 interface GetDefaultOffsetDetailsForLabwareParams
   extends GetLPCLabwareInfoForURI {
@@ -55,7 +50,10 @@ export function getDefaultOffsetDetailsForLabware(
       definitionUri: uri,
       kind: OFFSET_KIND_DEFAULT,
       // We always do default offset LPCing in this slot.
-      addressableAreaName: getValidDefaultOffsetLocation(params.protocolData),
+      addressableAreaName: getValidDefaultOffsetLocation(
+        params.lwLocInfo,
+        params.protocolData
+      ),
       lwOffsetLocSeq: ANY_LOCATION,
       closestBeneathAdapterId,
       // The only labware present on deck when configuring the default offset is the top-most labware itself.
@@ -151,29 +149,22 @@ function getFirstAdapterIdFrom(
 // NOTE: This util is meant to be temporary until product/design devise
 // an alternative method for default offset location selection.
 function getValidDefaultOffsetLocation(
+  lwLocInfo: LabwareLocationInfo[],
   protocolData: GetStackingInfoParams['protocolData']
 ): FlexAddressableAreaName {
-  const validLocations = new Set<FlexAddressableAreaName>(
-    STANDARD_FLEX_SLOTS as FlexAddressableAreaName[]
-  )
+  const isSlotC2Unavailable =
+    protocolData?.modules.some(
+      mod => mod.location.slotName === C2_ADDRESSABLE_AREA
+    ) ?? false
 
-  protocolData?.modules.forEach(mod => {
-    if (
-      mod.model === THERMOCYCLER_MODULE_V2 ||
-      mod.model === THERMOCYCLER_MODULE_V1
-    ) {
-      validLocations.delete(A1_ADDRESSABLE_AREA)
-      validLocations.delete(B1_ADDRESSABLE_AREA)
-    } else {
-      const slotName = mod.location.slotName as FlexAddressableAreaName
-      validLocations.delete(slotName)
-    }
-  })
-
-  if (validLocations.has(C2_ADDRESSABLE_AREA)) {
-    return C2_ADDRESSABLE_AREA
+  if (isSlotC2Unavailable) {
+    // Given all the LPC-able labware, find the first slot in which no module is
+    // loaded beneath that labware.
+    const locationWithNoModule = lwLocInfo.find(
+      aLwLocInfo => aLwLocInfo.closestBeneathModuleId == null
+    )
+    return locationWithNoModule?.addressableAreaName ?? C3_ADDRESSABLE_AREA
   } else {
-    // The fallback should never occur in practice.
-    return head(Array.from(validLocations)) ?? C2_ADDRESSABLE_AREA
+    return C2_ADDRESSABLE_AREA
   }
 }


### PR DESCRIPTION
Closes [RQA-4243](https://opentrons.atlassian.net/browse/RQA-4243)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

It's insufficient to only check module locations for the presence of an object on the deck, because doing so doesn't consider fixtures. Let's make things simpler: if a module is known to be in C2, using the LPC-able labware, let's find the labware that doesn't have a module beneath it and use that one. This does mean that there is less consistency between protocols when selecting the default offset location, but at least we know it's an open slot and doesn't require adjusting deck config.

### Current Behavior

![image](https://github.com/user-attachments/assets/be881bcb-0cfd-4b9c-b2b6-b4323208ae8e)

### Fixed Behavior

<img width="752" alt="Screenshot 2025-06-03 at 3 29 42 PM" src="https://github.com/user-attachments/assets/f0adeb99-8b3b-4106-8536-8142721df55b" />

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- See photos.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- A fixture is no longer a possible default offset location during LPC.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-4243]: https://opentrons.atlassian.net/browse/RQA-4243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ