### PR TITLE
feat(shared-data): include command v11 - v13 command mixin types

### DIFF
--- a/shared-data/protocol/types/schemaV8/index.ts
+++ b/shared-data/protocol/types/schemaV8/index.ts
@@ -1,12 +1,12 @@
 import type { CreateCommand } from '../../../command/types'
+import type { CommandAnnotation } from '../../../commandAnnotation/types'
 import type {
-  LoadedPipette,
+  Liquid,
   LoadedLabware,
   LoadedModule,
-  Liquid,
+  LoadedPipette,
   RunTimeParameter,
 } from '../../../js'
-import type { CommandAnnotation } from '../../../commandAnnotation/types'
 import type { LabwareDefinition2, RobotType } from '../../../js/types'
 import type { RunTimeCommand } from '../schemaV8'
 
@@ -29,6 +29,21 @@ export interface CommandV9Mixin {
 
 export interface CommandV10Mixin {
   commandSchemaId: 'opentronsCommandSchemaV10'
+  commands: CreateCommand[]
+}
+
+export interface CommandV11Mixin {
+  commandSchemaId: 'opentronsCommandSchemaV11'
+  commands: CreateCommand[]
+}
+
+export interface CommandV12Mixin {
+  commandSchemaId: 'opentronsCommandSchemaV12'
+  commands: CreateCommand[]
+}
+
+export interface CommandV13Mixin {
+  commandSchemaId: 'opentronsCommandSchemaV13'
   commands: CreateCommand[]
 }
 
@@ -121,7 +136,14 @@ export type ProtocolFile<
   (OT2RobotMixin | OT3RobotMixin) &
   LabwareV2Mixin &
   LiquidV1Mixin &
-  (CommandV8Mixin | CommandV9Mixin | CommandV10Mixin) &
+  (
+    | CommandV8Mixin
+    | CommandV9Mixin
+    | CommandV10Mixin
+    | CommandV11Mixin
+    | CommandV12Mixin
+    | CommandV13Mixin
+  ) &
   CommandAnnotationV1Mixin
 
 export type ProtocolStructure = ProtocolBase<{}> &


### PR DESCRIPTION
# Overview

This is so the `ProtocolFile` type for protocol schema v8 supports all the correct command schemas. I don't think this actually affects anything since the app doesn't directly use this type i don't think, but its a good idea to keep the types up to date.

## Test Plan and Hands on Testing

review the code

## Changelog

- add the mixins for command schema 11 -> 13

## Risk assessment

low
