### PR TITLE
fix(api): add math operators for SimulatedProbeResult

### DIFF
--- a/api/src/opentrons/protocol_engine/types/liquid_level_detection.py
+++ b/api/src/opentrons/protocol_engine/types/liquid_level_detection.py
@@ -53,51 +53,61 @@ class SimulatedProbeResult(BaseModel):
     def __mul__(
         self, other: float | int | SimulatedProbeResult
     ) -> float | SimulatedProbeResult:
+        """Bypass multiplication and just return self."""
         return self
 
     def __rmul__(
         self, other: float | int | SimulatedProbeResult
     ) -> float | SimulatedProbeResult:
+        """Bypass multiplication and just return self."""
         return self
 
     def __truediv__(
         self, other: float | int | SimulatedProbeResult
     ) -> float | SimulatedProbeResult:
+        """Bypass division and just return self."""
         return self
 
     def __rtruediv__(
         self, other: float | int | SimulatedProbeResult
     ) -> float | SimulatedProbeResult:
+        """Bypass division and just return self."""
         return self
 
     def __pow__(
         self, other: float | int | SimulatedProbeResult
     ) -> float | SimulatedProbeResult:
+        """Bypass exponent math and just return self."""
         return self
 
     def __rpow__(
         self, other: float | int | SimulatedProbeResult
     ) -> float | SimulatedProbeResult:
+        """Bypass exponent math and just return self."""
         return self
 
     def __mod__(
         self, other: float | int | SimulatedProbeResult
     ) -> float | SimulatedProbeResult:
+        """Bypass modulus and just return self."""
         return self
 
     def __rmod__(
         self, other: float | int | SimulatedProbeResult
     ) -> float | SimulatedProbeResult:
+        """Bypass modulus and just return self."""
         return self
 
     def __floordiv__(
         self, other: float | int | SimulatedProbeResult
     ) -> float | SimulatedProbeResult:
+        """Bypass floor division and just return self."""
         return self
 
     def __rfloordiv__(
         self, other: float | int | SimulatedProbeResult
     ) -> float | SimulatedProbeResult:
+        """Bypass floor division and just return self."""
         return self
 
     def __gt__(self, other: float | int | SimulatedProbeResult) -> bool:

--- a/api/src/opentrons/protocol_engine/types/liquid_level_detection.py
+++ b/api/src/opentrons/protocol_engine/types/liquid_level_detection.py
@@ -27,42 +27,92 @@ class SimulatedProbeResult(BaseModel):
         return data
 
     def __add__(
-        self, other: float | SimulatedProbeResult
+        self, other: float | int | SimulatedProbeResult
     ) -> float | SimulatedProbeResult:
         """Bypass addition and just return self."""
         return self
 
     def __sub__(
-        self, other: float | SimulatedProbeResult
+        self, other: float | int | SimulatedProbeResult
     ) -> float | SimulatedProbeResult:
         """Bypass subtraction and just return self."""
         return self
 
     def __radd__(
-        self, other: float | SimulatedProbeResult
+        self, other: float | int | SimulatedProbeResult
     ) -> float | SimulatedProbeResult:
         """Bypass addition and just return self."""
         return self
 
     def __rsub__(
-        self, other: float | SimulatedProbeResult
+        self, other: float | int | SimulatedProbeResult
     ) -> float | SimulatedProbeResult:
         """Bypass subtraction and just return self."""
         return self
 
-    def __gt__(self, other: float | SimulatedProbeResult) -> bool:
+    def __mul__(
+        self, other: float | int | SimulatedProbeResult
+    ) -> float | SimulatedProbeResult:
+        return self
+
+    def __rmul__(
+        self, other: float | int | SimulatedProbeResult
+    ) -> float | SimulatedProbeResult:
+        return self
+
+    def __truediv__(
+        self, other: float | int | SimulatedProbeResult
+    ) -> float | SimulatedProbeResult:
+        return self
+
+    def __rtruediv__(
+        self, other: float | int | SimulatedProbeResult
+    ) -> float | SimulatedProbeResult:
+        return self
+
+    def __pow__(
+        self, other: float | int | SimulatedProbeResult
+    ) -> float | SimulatedProbeResult:
+        return self
+
+    def __rpow__(
+        self, other: float | int | SimulatedProbeResult
+    ) -> float | SimulatedProbeResult:
+        return self
+
+    def __mod__(
+        self, other: float | int | SimulatedProbeResult
+    ) -> float | SimulatedProbeResult:
+        return self
+
+    def __rmod__(
+        self, other: float | int | SimulatedProbeResult
+    ) -> float | SimulatedProbeResult:
+        return self
+
+    def __floordiv__(
+        self, other: float | int | SimulatedProbeResult
+    ) -> float | SimulatedProbeResult:
+        return self
+
+    def __rfloordiv__(
+        self, other: float | int | SimulatedProbeResult
+    ) -> float | SimulatedProbeResult:
+        return self
+
+    def __gt__(self, other: float | int | SimulatedProbeResult) -> bool:
         """Bypass 'greater than' and just return self."""
         return True
 
-    def __lt__(self, other: float | SimulatedProbeResult) -> bool:
+    def __lt__(self, other: float | int | SimulatedProbeResult) -> bool:
         """Bypass 'less than' and just return self."""
         return False
 
-    def __ge__(self, other: float | SimulatedProbeResult) -> bool:
+    def __ge__(self, other: float | int | SimulatedProbeResult) -> bool:
         """Bypass 'greater than or eaqual to' and just return self."""
         return True
 
-    def __le__(self, other: float | SimulatedProbeResult) -> bool:
+    def __le__(self, other: float | int | SimulatedProbeResult) -> bool:
         """Bypass 'less than or equal to' and just return self."""
         return False
 

--- a/api/tests/opentrons/protocol_engine/test_types.py
+++ b/api/tests/opentrons/protocol_engine/test_types.py
@@ -74,3 +74,26 @@ def test_roundtrips_well_info_summary(height: LiquidTrackingType | None) -> None
         assert isinstance(outp.probed_volume, SimulatedProbeResult)
     else:
         assert outp == inp
+
+
+@pytest.mark.parametrize("op_1", [SimulatedProbeResult(), 100.0, -5])
+@pytest.mark.parametrize("op_2", [SimulatedProbeResult(), 100.0, -5])
+def test_simulated_probe_result_operand_math(op_1: LiquidTrackingType, op_2: LiquidTrackingType) -> None:
+    _error = None
+    try:
+        r = op_1 + op_2
+        r = op_1 - op_2
+        r = op_1 / op_2
+        r = op_1 * op_2
+        r = op_1 ** op_2
+        r = op_1 // op_2
+        r = op_1 % op_2
+        r = op_1 % op_2
+        r = op_1 < op_2
+        r = op_1 > op_2
+        r = op_1 >= op_2
+        r = op_1 <= op_2
+        r = op_1 == op_2
+    except Exception as _e:
+        _error = _e
+    assert _error is None

--- a/api/tests/opentrons/protocol_engine/test_types.py
+++ b/api/tests/opentrons/protocol_engine/test_types.py
@@ -78,14 +78,16 @@ def test_roundtrips_well_info_summary(height: LiquidTrackingType | None) -> None
 
 @pytest.mark.parametrize("op_1", [SimulatedProbeResult(), 100.0, -5])
 @pytest.mark.parametrize("op_2", [SimulatedProbeResult(), 100.0, -5])
-def test_simulated_probe_result_operand_math(op_1: LiquidTrackingType, op_2: LiquidTrackingType) -> None:
+def test_simulated_probe_result_operand_math(
+    op_1: LiquidTrackingType, op_2: LiquidTrackingType
+) -> None:
     _error = None
     try:
         r = op_1 + op_2
         r = op_1 - op_2
         r = op_1 / op_2
         r = op_1 * op_2
-        r = op_1 ** op_2
+        r = op_1**op_2
         r = op_1 // op_2
         r = op_1 % op_2
         r = op_1 % op_2

--- a/api/tests/opentrons/protocol_engine/test_types.py
+++ b/api/tests/opentrons/protocol_engine/test_types.py
@@ -92,7 +92,6 @@ def test_simulated_probe_result_operand_math(
         r = op_1**op_2
         r = op_1 // op_2
         r = op_1 % op_2
-        r = op_1 % op_2
         r = op_1 < op_2
         r = op_1 > op_2
         r = op_1 >= op_2

--- a/api/tests/opentrons/protocol_engine/test_types.py
+++ b/api/tests/opentrons/protocol_engine/test_types.py
@@ -81,7 +81,9 @@ def test_roundtrips_well_info_summary(height: LiquidTrackingType | None) -> None
 def test_simulated_probe_result_operand_math(
     op_1: LiquidTrackingType, op_2: LiquidTrackingType
 ) -> None:
+    """Ensure that math operators can be used with SimulatedProbeResult."""
     _error = None
+    r: LiquidTrackingType | None = None
     try:
         r = op_1 + op_2
         r = op_1 - op_2
@@ -99,3 +101,4 @@ def test_simulated_probe_result_operand_math(
     except Exception as _e:
         _error = _e
     assert _error is None
+    assert r is not None


### PR DESCRIPTION
## Overview
We should have overridden more math magic methods (ᴍᴀɢɪᴄ ᴍᴀᴛʜᴏᴅs) to the `SimulatedProbeResult` class. This fixes that + adds a test.

## Review Requests
Did I miss any operators? 