### PR TITLE
fix(protocol-designer,step-generation): fix reference volumes in `getLiquidClassValuesMoveLiquid`

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/FlowRateField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/FlowRateField.tsx
@@ -71,6 +71,26 @@ export function FlowRateField(props: FlowRateFieldProps): JSX.Element {
       ({ labwareDefURI }) => labwareDefURI === tiprack
     )?.def ?? null
 
+  let airGapByVolume: Array<[number, number]> = []
+  // no air gap included for mix step
+  if (formData?.stepType === 'moveLiquid') {
+    if (flowRateType === 'aspirate') {
+      airGapByVolume =
+        (liquidClassValuesForTip?.aspirate.retract.airGapByVolume as Array<
+          [number, number]
+        >) ?? []
+    } else if (flowRateType === 'dispense') {
+      airGapByVolume =
+        formData?.stepType === 'moveLiquid' &&
+        formData.path === 'multiDispense' &&
+        liquidClassValuesForTip != null &&
+        'multiDispense' in liquidClassValuesForTip
+          ? (liquidClassValuesForTip.multiDispense?.retract
+              .airGapByVolume as Array<[number, number]>) ?? []
+          : (liquidClassValuesForTip?.singleDispense.retract
+              .airGapByVolume as Array<[number, number]>) ?? []
+    }
+  }
   // if form type is 'mix', we will use single path
   const referenceVolumesForByVolumeInterpolation =
     pipette != null && tiprackDef != null && formData != null
@@ -90,10 +110,7 @@ export function FlowRateField(props: FlowRateFieldProps): JSX.Element {
             (liquidClassValuesForTip?.multiDispense?.disposalByVolume as Array<
               [number, number]
             >) ?? null,
-          aspirateAirGap:
-            formData.aspirate_airGap_checkbox === true
-              ? formData.aspirate_airGap_volume
-              : null,
+          aspirateAirGapByVolume: airGapByVolume,
         }).referenceVolumes
       : null
   const [referenceVolumeFlowRate, referenceVolumeCorrection] =

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/utils.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/utils.ts
@@ -35,6 +35,7 @@ import type {
   AdditionalEquipmentEntities,
   LabwareEntities,
   PipetteEntities,
+  ReferenceVolumes,
 } from '@opentrons/step-generation'
 import type { FormData, PathOption, StepFieldName } from '../../../form-types'
 import type {
@@ -403,7 +404,7 @@ const getByVolumeField = (args: {
 
 const getSubmergeRetractFields = (args: {
   submergeRetractLookup: Submerge | RetractAspirate | RetractDispense
-  volume: number
+  volumes: ReferenceVolumes
   liquidHandlingAction: LiquidHandlingTab
   tipMovement: 'submerge' | 'retract'
   additionalEquipmentEntities?: AdditionalEquipmentEntities
@@ -412,7 +413,7 @@ const getSubmergeRetractFields = (args: {
 }): Record<string, any> => {
   const {
     submergeRetractLookup,
-    volume,
+    volumes,
     liquidHandlingAction,
     tipMovement,
     additionalEquipmentEntities,
@@ -439,7 +440,7 @@ const getSubmergeRetractFields = (args: {
   const airGapFields =
     'airGapByVolume' in submergeRetractLookup && !isConditioningVolumeEnabled
       ? getByVolumeField({
-          volume,
+          volume: volumes.airGap,
           byVolume: submergeRetractLookup.airGapByVolume,
           field: 'airGap',
           prefix: liquidHandlingAction,
@@ -728,13 +729,12 @@ const getLiquidClassValuesMoveLiquid = (args: {
     tiprackDefinition,
     conditioningByVolume,
     disposalByVolume,
-    volume: Number(rawForm.volume),
+    volume,
     path: rawForm.path as PathOption,
     numDispenseWells: rawForm.dispense_wells.length,
-    aspirateAirGap:
-      rawForm.aspirate_airGap_checkbox === true
-        ? Number(rawForm.aspirate_airGap_volume)
-        : null,
+    aspirateAirGapByVolume: aspirate.retract.airGapByVolume as Array<
+      [number, number]
+    >,
   }).referenceVolumes
   // top-level aspirate fields
   const aspiratePositionReferenceFields = getPositionReferenceFields(
@@ -795,7 +795,7 @@ const getLiquidClassValuesMoveLiquid = (args: {
   // aspirate/dispense submerge fields
   const aspirateSubmergeFields = getSubmergeRetractFields({
     submergeRetractLookup: aspirate.submerge,
-    volume: Number(volume),
+    volumes: byVolumeLookup,
     liquidHandlingAction: 'aspirate',
     tipMovement: 'submerge',
     additionalEquipmentEntities,
@@ -805,7 +805,7 @@ const getLiquidClassValuesMoveLiquid = (args: {
       path === 'multiDispense' && multiDispense != null
         ? multiDispense.submerge
         : singleDispense.submerge,
-    volume: Number(volume),
+    volumes: byVolumeLookup,
     liquidHandlingAction: 'dispense',
     tipMovement: 'submerge',
   })
@@ -813,7 +813,7 @@ const getLiquidClassValuesMoveLiquid = (args: {
   // aspirate/dispense retract fields
   const aspirateRetractFields = getSubmergeRetractFields({
     submergeRetractLookup: aspirate.retract,
-    volume: Number(volume),
+    volumes: byVolumeLookup,
     liquidHandlingAction: 'aspirate',
     tipMovement: 'retract',
     isConditioningVolumeEnabled,
@@ -823,7 +823,7 @@ const getLiquidClassValuesMoveLiquid = (args: {
       path === 'multiDispense' && multiDispense != null
         ? multiDispense.retract
         : singleDispense.retract,
-    volume: Number(volume),
+    volumes: byVolumeLookup,
     liquidHandlingAction: 'dispense',
     tipMovement: 'retract',
     additionalEquipmentEntities,

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/moveLiquidFormToArgs.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/moveLiquidFormToArgs.ts
@@ -119,6 +119,8 @@ const getCheckedPath = (
           volume,
           path,
           numDispenseWells: hydratedFormData.dispense_wells.length,
+          aspirateAirGapByVolume: liquidClassValuesForTip.aspirate.retract
+            .airGapByVolume as Array<[number, number]>,
           conditioningByVolume: null,
           disposalByVolume: null,
         })
@@ -128,6 +130,8 @@ const getCheckedPath = (
           volume,
           path,
           numDispenseWells: hydratedFormData.dispense_wells.length,
+          aspirateAirGapByVolume: liquidClassValuesForTip.aspirate.retract
+            .airGapByVolume as Array<[number, number]>,
           conditioningByVolume:
             (liquidClassValuesForTip.multiDispense
               ?.conditioningByVolume as Array<[number, number]>) ?? null,

--- a/step-generation/src/commandCreators/compound/consolidate.ts
+++ b/step-generation/src/commandCreators/compound/consolidate.ts
@@ -200,7 +200,7 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
     spec: pipetteSpecs,
     name: pipetteName,
   } = invariantContext.pipetteEntities[pipette]
-  const multiDispenseValuesForTip = getAllLiquidClassDefs()
+  const liquidClassValuesForTip = getAllLiquidClassDefs()
     [
       liquidClass === NONE_LIQUID_CLASS_NAME || liquidClass == null
         ? WATER_LIQUID_CLASS_NAME
@@ -208,17 +208,18 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
     ].byPipette?.find(
       ({ pipetteModel }) => (pipetteModel = getFlexNameConversion(pipetteSpecs))
     )
-    ?.byTipType.find(({ tiprack }) => tiprack === tiprackDefUri)?.multiDispense
+    ?.byTipType.find(({ tiprack }) => tiprack === tiprackDefUri)
+  const { aspirate } = liquidClassValuesForTip ?? {}
   const { multiWellHandling } = getTransferPlanAndReferenceVolumes({
     pipetteSpecs,
     tiprackDefinition,
     volume,
     path: 'multiAspirate',
     numDispenseWells: sourceWells.length,
-    conditioningByVolume: (multiDispenseValuesForTip?.conditioningByVolume ??
-      []) as Array<[number, number]>,
-    disposalByVolume: (multiDispenseValuesForTip?.disposalByVolume ??
-      []) as Array<[number, number]>,
+    aspirateAirGapByVolume:
+      (aspirate?.retract.airGapByVolume as Array<[number, number]>) ?? [],
+    conditioningByVolume: null,
+    disposalByVolume: null,
   })
 
   const { numWellsToFitInTip } = multiWellHandling

--- a/step-generation/src/commandCreators/compound/distribute.ts
+++ b/step-generation/src/commandCreators/compound/distribute.ts
@@ -211,7 +211,7 @@ export const distribute: CommandCreator<DistributeArgs> = (
     spec: pipetteSpecs,
     name: pipetteName,
   } = invariantContext.pipetteEntities[pipette]
-  const multiDispenseValuesForTip = getAllLiquidClassDefs()
+  const liquidClassValuesForTip = getAllLiquidClassDefs()
     [
       liquidClass === NONE_LIQUID_CLASS_NAME || liquidClass == null
         ? WATER_LIQUID_CLASS_NAME
@@ -219,18 +219,22 @@ export const distribute: CommandCreator<DistributeArgs> = (
     ].byPipette?.find(
       ({ pipetteModel }) => (pipetteModel = getFlexNameConversion(pipetteSpecs))
     )
-    ?.byTipType.find(({ tiprack }) => tiprack === tiprackDefUri)?.multiDispense
+    ?.byTipType.find(({ tiprack }) => tiprack === tiprackDefUri)
+  const { aspirate, multiDispense } = liquidClassValuesForTip ?? {}
   const { multiWellHandling } = getTransferPlanAndReferenceVolumes({
     pipetteSpecs,
     tiprackDefinition,
     volume,
     path: 'multiDispense',
     numDispenseWells: destWells.length,
-    conditioningByVolume: (multiDispenseValuesForTip?.conditioningByVolume ??
-      []) as Array<[number, number]>,
-    disposalByVolume: (multiDispenseValuesForTip?.disposalByVolume ??
-      []) as Array<[number, number]>,
-    aspirateAirGap: aspirateAirGapVolume,
+    conditioningByVolume: (multiDispense?.conditioningByVolume ?? []) as Array<
+      [number, number]
+    >,
+    disposalByVolume: (multiDispense?.disposalByVolume ?? []) as Array<
+      [number, number]
+    >,
+    aspirateAirGapByVolume:
+      (aspirate?.retract.airGapByVolume as Array<[number, number]>) ?? [],
   })
   const { numWellsToFitInTip } = multiWellHandling
 

--- a/step-generation/src/utils/__tests__/misc.test.ts
+++ b/step-generation/src/utils/__tests__/misc.test.ts
@@ -55,6 +55,7 @@ describe('getTransferPlanAndReferenceVolumes', () => {
       volume: 5,
       path: 'single',
       numDispenseWells: 1,
+      aspirateAirGapByVolume: [],
       conditioningByVolume: null,
       disposalByVolume: null,
     })
@@ -80,6 +81,7 @@ describe('getTransferPlanAndReferenceVolumes', () => {
       volume: 15,
       path: 'single',
       numDispenseWells: 1,
+      aspirateAirGapByVolume: [],
       conditioningByVolume: null,
       disposalByVolume: null,
     })
@@ -99,6 +101,7 @@ describe('getTransferPlanAndReferenceVolumes', () => {
       volume: 15,
       path: 'single',
       numDispenseWells: 1,
+      aspirateAirGapByVolume: [],
       conditioningByVolume: null,
       disposalByVolume: null,
     })
@@ -111,6 +114,26 @@ describe('getTransferPlanAndReferenceVolumes', () => {
     expect(result.multiWellHandling.isSupported).toBe(false)
   })
 
+  it('should handle volumes exceeding tiprack max volume for single path with air gap', () => {
+    const result = getTransferPlanAndReferenceVolumes({
+      pipetteSpecs: MOCK_P300_SPECS,
+      tiprackDefinition: fixtureTiprack10ul,
+      volume: 10,
+      path: 'single',
+      numDispenseWells: 1,
+      aspirateAirGapByVolume: [[10, 2]],
+      conditioningByVolume: null,
+      disposalByVolume: null,
+    })
+    expect(result.referenceVolumes.airGap).toBeCloseTo(5)
+    expect(result.referenceVolumes.correctionAspirate).toBeCloseTo(5)
+    expect(result.referenceVolumes.correctionDispense).toBeCloseTo(5)
+    expect(result.referenceVolumes.pushOut).toBeCloseTo(5)
+    expect(result.referenceVolumes.flowRateAspirate).toBeCloseTo(5)
+    expect(result.referenceVolumes.flowRateDispense).toBeCloseTo(5)
+    expect(result.multiWellHandling.isSupported).toBe(false)
+  })
+
   it('should return correct values for multiAspirate path', () => {
     const result = getTransferPlanAndReferenceVolumes({
       pipetteSpecs: MOCK_P10_SPECS,
@@ -118,6 +141,7 @@ describe('getTransferPlanAndReferenceVolumes', () => {
       volume: 3,
       path: 'multiAspirate',
       numDispenseWells: 1,
+      aspirateAirGapByVolume: [],
       conditioningByVolume: null,
       disposalByVolume: null,
     })
@@ -144,6 +168,7 @@ describe('getTransferPlanAndReferenceVolumes', () => {
       volume: 4,
       path: 'multiAspirate',
       numDispenseWells: 1,
+      aspirateAirGapByVolume: [],
       conditioningByVolume: null,
       disposalByVolume: null,
     })
@@ -158,6 +183,7 @@ describe('getTransferPlanAndReferenceVolumes', () => {
       volume: 4,
       path: 'multiAspirate',
       numDispenseWells: 1,
+      aspirateAirGapByVolume: [],
       conditioningByVolume: null,
       disposalByVolume: null,
     })
@@ -172,6 +198,7 @@ describe('getTransferPlanAndReferenceVolumes', () => {
       volume: 10,
       path: 'multiDispense',
       numDispenseWells: 3,
+      aspirateAirGapByVolume: [],
       conditioningByVolume: [
         [20, 5],
         [40, 10],
@@ -200,6 +227,7 @@ describe('getTransferPlanAndReferenceVolumes', () => {
       volume: 3,
       path: 'multiDispense',
       numDispenseWells: 4,
+      aspirateAirGapByVolume: [],
       conditioningByVolume: [
         [5, 0],
         [7, 2],
@@ -228,6 +256,7 @@ describe('getTransferPlanAndReferenceVolumes', () => {
       volume: 3,
       path: 'multiDispense',
       numDispenseWells: 4,
+      aspirateAirGapByVolume: [],
       conditioningByVolume: [
         [5, 0],
         [7, 2],
@@ -256,6 +285,7 @@ describe('getTransferPlanAndReferenceVolumes', () => {
       volume: 6,
       path: 'multiDispense',
       numDispenseWells: 2,
+      aspirateAirGapByVolume: [],
       conditioningByVolume: [[10, 1]],
       disposalByVolume: [[10, 0.5]],
     })
@@ -282,6 +312,7 @@ describe('getTransferPlanAndReferenceVolumes', () => {
       volume: 1,
       path: 'single',
       numDispenseWells: 1,
+      aspirateAirGapByVolume: [],
       conditioningByVolume: null,
       disposalByVolume: null,
     })
@@ -304,6 +335,7 @@ describe('getTransferPlanAndReferenceVolumes', () => {
       volume: 0.8,
       path: 'single',
       numDispenseWells: 1,
+      aspirateAirGapByVolume: [],
       conditioningByVolume: null,
       disposalByVolume: null,
     })

--- a/step-generation/src/utils/misc.ts
+++ b/step-generation/src/utils/misc.ts
@@ -953,26 +953,28 @@ const _getTotalVolumeForMultiDispense = (
   )
 }
 
+export interface ReferenceVolumes {
+  airGap: number
+  correctionAspirate: number
+  correctionDispense: number
+  pushOut: number
+  flowRateAspirate: number
+  flowRateDispense: number
+  conditioning?: number
+  disposal?: number
+}
+
 export const getTransferPlanAndReferenceVolumes = (args: {
   pipetteSpecs: PipetteV2Specs
   tiprackDefinition: LabwareDefinition2 | null
   volume: number
   path: PathOption
   numDispenseWells: number
+  aspirateAirGapByVolume: Array<[number, number]>
   conditioningByVolume: Array<[number, number]> | null
   disposalByVolume: Array<[number, number]> | null
-  aspirateAirGap?: number | null
 }): {
-  referenceVolumes: {
-    airGap: number
-    correctionAspirate: number
-    correctionDispense: number
-    pushOut: number
-    flowRateAspirate: number
-    flowRateDispense: number
-    conditioning?: number
-    disposal?: number
-  }
+  referenceVolumes: ReferenceVolumes
   multiWellHandling: {
     isSupported: boolean
     numWellsToFitInTip?: number
@@ -986,7 +988,7 @@ export const getTransferPlanAndReferenceVolumes = (args: {
     conditioningByVolume,
     disposalByVolume,
     numDispenseWells,
-    aspirateAirGap,
+    aspirateAirGapByVolume,
   } = args
   const { liquids } = pipetteSpecs
   const isInLowVolumeMode =
@@ -996,25 +998,34 @@ export const getTransferPlanAndReferenceVolumes = (args: {
     : liquids.default.maxVolume
   const maxWorkingVolumeTip = tiprackDefinition?.wells.A1.totalLiquidVolume
   const maxWorkingVolume =
-    (maxWorkingVolumeTip == null
+    maxWorkingVolumeTip == null
       ? maxWorkingVolumePipette
-      : Math.min(maxWorkingVolumePipette, maxWorkingVolumeTip)) -
-    (aspirateAirGap ?? 0)
-  const numAspirations = Math.ceil(volume / maxWorkingVolume)
+      : Math.min(maxWorkingVolumePipette, maxWorkingVolumeTip)
   const minVolumeForMultiAspirateDispense = volume * 2
+  const conditioningVolumeForMultiAspirateDispense =
+    conditioningByVolume != null
+      ? linearInterpolate(
+          minVolumeForMultiAspirateDispense,
+          conditioningByVolume
+        ) ?? 0
+      : 0
   const isMultiDispenseAvailable =
     conditioningByVolume != null &&
     disposalByVolume != null &&
     maxWorkingVolume >=
       minVolumeForMultiAspirateDispense +
-        (linearInterpolate(
-          minVolumeForMultiAspirateDispense,
-          conditioningByVolume
-        ) ?? 0) +
+        conditioningVolumeForMultiAspirateDispense +
         (linearInterpolate(
           minVolumeForMultiAspirateDispense,
           disposalByVolume
-        ) ?? 0)
+        ) ?? 0) +
+        // don't take air gap into account if conditioning volume is present
+        (conditioningVolumeForMultiAspirateDispense === 0
+          ? linearInterpolate(
+              minVolumeForMultiAspirateDispense,
+              aspirateAirGapByVolume
+            ) ?? 0
+          : 0)
   const isMultiAspirateAvailable =
     maxWorkingVolume > minVolumeForMultiAspirateDispense
 
@@ -1024,6 +1035,12 @@ export const getTransferPlanAndReferenceVolumes = (args: {
     (path === 'multiDispense' && !isMultiDispenseAvailable) ||
     (path === 'multiAspirate' && !isMultiAspirateAvailable)
   ) {
+    const aspirateAirGapAtSpecifiedVolume =
+      linearInterpolate(volume, aspirateAirGapByVolume) ?? 0
+    // split if target volume + air gap volume > maxWorkingVolume
+    const numAspirations = Math.ceil(
+      (volume + aspirateAirGapAtSpecifiedVolume) / maxWorkingVolume
+    )
     const volumePerAspiration = volume / numAspirations
     return {
       referenceVolumes: {


### PR DESCRIPTION
# Overview

This PR ensures that we utilize the transfer plan reference volumes when populating the moveLiquid advanced settings page. When populating the advanced settings in `getLiquidClassValueMoveLiquid`, we must use the effective tip volume, whether split for a single path, or inclusive of many source/destination volumes for a multiDispense/Aspirate.

## Test Plan and Hands on Testing

This is a little tricky to test in practice. I wrote/updated some new test cases. I recommend trying out David's test case as an example, where we know there should be air gap employed for split volumes:
- 50ul single-channel
- 50ul tips
- 99µl volume
- single path
- ethanol liquid class
- should yield an aspirate air gap of 0.5ul (interpolated between [45, 5] and [50, 0] at 49.5ul target after splitting

## Changelog

- correctly access reference volumes _after necessary splitting_ in `getLiquidClassValueMoveLiquid`
- use interpolated air gap volume in `getLiquidClassValueMoveLiquid` to determine transfer plan
- update unit tests

## Review requests

see test plan

## Risk assessment

low-medium. fixes bug but shouldn't break anything new!