### PR TITLE
feat(components, protocol-designer) Add BasicButton to Helix

### DIFF
--- a/components/src/atoms/buttons/BasicButton.tsx
+++ b/components/src/atoms/buttons/BasicButton.tsx
@@ -1,0 +1,80 @@
+import styled from 'styled-components'
+
+import { COLORS } from '../../helix-design-system'
+import { SPACING, TYPOGRAPHY } from '../../ui-style-constants'
+import { StyledText } from '../StyledText/StyledText'
+
+import type { MouseEvent, ReactNode } from 'react'
+
+interface BasicButtonProps {
+  children: ReactNode // Children prop to allow any ReactNode content
+  onClick: (event: MouseEvent<HTMLButtonElement>) => void // Function to handle button click events
+  isDisabled?: boolean // Optional prop to control button aria-disabled
+  underLine?: boolean // Optional prop to control underline styling
+  tabIndex?: number // Optional prop for tab index
+}
+
+export function BasicButton({
+  children,
+  onClick,
+  isDisabled = false,
+  underLine = false,
+  tabIndex = 0,
+  ...props
+}: BasicButtonProps): JSX.Element {
+  const handleButtonClick = (event: MouseEvent<HTMLButtonElement>): void => {
+    if (isDisabled) {
+      event.preventDefault()
+      return
+    }
+    if (onClick != null) {
+      onClick(event)
+    }
+  }
+
+  return (
+    <StyledButton
+      onClick={handleButtonClick}
+      aria-disabled={isDisabled || undefined}
+      underLine={underLine}
+      tabIndex={tabIndex}
+      {...props}
+    >
+      <StyledText desktopStyle="bodyDefaultRegular">{children}</StyledText>
+    </StyledButton>
+  )
+}
+
+const StyledButton = styled.button<{
+  underLine?: boolean
+  'aria-disabled'?: boolean
+}>`
+  background: none;
+  border: none;
+  padding: 0;
+
+  color: ${props => (props['aria-disabled'] ? COLORS.grey40 : COLORS.black90)};
+  cursor: ${props => (props['aria-disabled'] ? 'not-allowed' : 'pointer')};
+
+  text-decoration: ${props =>
+    props.underLine ? TYPOGRAPHY.textDecorationUnderline : 'none'};
+
+  ${props =>
+    !props['aria-disabled']
+      ? `
+        &:hover {
+          color: ${COLORS.blue50};
+        }
+
+        &:focus-visible {
+          color: ${COLORS.blue50};
+          outline: 2px solid ${COLORS.blue50};
+          outline-offset: ${SPACING.spacing4};
+        }
+      `
+      : undefined}
+
+  &[aria-disabled="true"] {
+    outline: none;
+  }
+`

--- a/components/src/atoms/buttons/BasicButton.tsx
+++ b/components/src/atoms/buttons/BasicButton.tsx
@@ -1,13 +1,14 @@
 import styled from 'styled-components'
 
 import { COLORS } from '../../helix-design-system'
+import { CURSOR_NOT_ALLOWED, CURSOR_POINTER } from '../../styles/cursor'
 import { SPACING, TYPOGRAPHY } from '../../ui-style-constants'
 import { StyledText } from '../StyledText/StyledText'
 
-import type { MouseEvent, ReactNode } from 'react'
+import type { MouseEvent } from 'react'
 
 interface BasicButtonProps {
-  children: ReactNode // Children prop to allow any ReactNode content
+  children: string // Content of basic button
   onClick: (event: MouseEvent<HTMLButtonElement>) => void // Function to handle button click events
   isDisabled?: boolean // Optional prop to control button aria-disabled
   underLine?: boolean // Optional prop to control underline styling
@@ -34,8 +35,9 @@ export function BasicButton({
 
   return (
     <StyledButton
+      data-testid={`basic_button_${children}`}
       onClick={handleButtonClick}
-      aria-disabled={isDisabled || undefined}
+      aria-disabled={isDisabled}
       underLine={underLine}
       tabIndex={tabIndex}
       {...props}
@@ -54,7 +56,8 @@ const StyledButton = styled.button<{
   padding: 0;
 
   color: ${props => (props['aria-disabled'] ? COLORS.grey40 : COLORS.black90)};
-  cursor: ${props => (props['aria-disabled'] ? 'not-allowed' : 'pointer')};
+  cursor: ${props =>
+    props['aria-disabled'] ? CURSOR_NOT_ALLOWED : CURSOR_POINTER};
 
   text-decoration: ${props =>
     props.underLine ? TYPOGRAPHY.textDecorationUnderline : 'none'};

--- a/components/src/atoms/buttons/BasicButton.tsx
+++ b/components/src/atoms/buttons/BasicButton.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components'
 import { COLORS } from '../../helix-design-system'
 import { Icon } from '../../icons'
 import { Flex } from '../../primitives'
+import { ALIGN_CENTER } from '../../styles'
 import { CURSOR_NOT_ALLOWED, CURSOR_POINTER } from '../../styles/cursor'
 import { SPACING, TYPOGRAPHY } from '../../ui-style-constants'
 import { StyledText } from '../StyledText/StyledText'
@@ -48,7 +49,7 @@ export function BasicButton({
       {...props}
     >
       {iconName != null ? (
-        <Flex alignItems="center" gap={SPACING.spacing8}>
+        <Flex alignItems={ALIGN_CENTER} gap={SPACING.spacing8}>
           <Icon
             name={iconName}
             size="1.25rem"

--- a/components/src/atoms/buttons/BasicButton.tsx
+++ b/components/src/atoms/buttons/BasicButton.tsx
@@ -1,11 +1,14 @@
 import styled from 'styled-components'
 
 import { COLORS } from '../../helix-design-system'
+import { Icon } from '../../icons'
+import { Flex } from '../../primitives'
 import { CURSOR_NOT_ALLOWED, CURSOR_POINTER } from '../../styles/cursor'
 import { SPACING, TYPOGRAPHY } from '../../ui-style-constants'
 import { StyledText } from '../StyledText/StyledText'
 
 import type { MouseEvent } from 'react'
+import type { IconName } from '../../icons'
 
 interface BasicButtonProps {
   children: string // Content of basic button
@@ -13,6 +16,7 @@ interface BasicButtonProps {
   isDisabled?: boolean // Optional prop to control button aria-disabled
   underLine?: boolean // Optional prop to control underline styling
   tabIndex?: number // Optional prop for tab index
+  iconName?: IconName // Optional prop for icon
 }
 
 export function BasicButton({
@@ -21,6 +25,7 @@ export function BasicButton({
   isDisabled = false,
   underLine = false,
   tabIndex = 0,
+  iconName,
   ...props
 }: BasicButtonProps): JSX.Element {
   const handleButtonClick = (event: MouseEvent<HTMLButtonElement>): void => {
@@ -42,7 +47,18 @@ export function BasicButton({
       tabIndex={tabIndex}
       {...props}
     >
-      <StyledText desktopStyle="bodyDefaultRegular">{children}</StyledText>
+      {iconName != null ? (
+        <Flex alignItems="center" gap={SPACING.spacing8}>
+          <Icon
+            name={iconName}
+            size="1.25rem"
+            data-testid={`basic_button_${iconName}`}
+          />
+          <StyledText desktopStyle="bodyDefaultRegular">{children}</StyledText>
+        </Flex>
+      ) : (
+        <StyledText desktopStyle="bodyDefaultRegular">{children}</StyledText>
+      )}
     </StyledButton>
   )
 }
@@ -53,7 +69,7 @@ const StyledButton = styled.button<{
 }>`
   background: none;
   border: none;
-  padding: 0;
+  padding: ${SPACING.spacing4};
 
   color: ${props => (props['aria-disabled'] ? COLORS.grey40 : COLORS.black90)};
   cursor: ${props =>

--- a/components/src/atoms/buttons/__tests__/BasicButton.test.tsx
+++ b/components/src/atoms/buttons/__tests__/BasicButton.test.tsx
@@ -34,6 +34,13 @@ describe('BasicButton', () => {
     expect(button).toHaveStyle(`text-decoration: none`)
   })
 
+  it('renders basic button with icon', async () => {
+    props.iconName = 'alert'
+    render(props)
+    screen.getByTestId('basic_button_alert')
+    screen.getByRole('button', { name: 'basic button' })
+  })
+
   // TODO: need to update '@testing-library/user-event' v14+
   // it('has hover styles when not disabled', async () => {
   //   render(props)

--- a/components/src/atoms/buttons/__tests__/BasicButton.test.tsx
+++ b/components/src/atoms/buttons/__tests__/BasicButton.test.tsx
@@ -1,0 +1,80 @@
+import { fireEvent, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { COLORS } from '../../../helix-design-system'
+import { CURSOR_NOT_ALLOWED, CURSOR_POINTER } from '../../../styles/cursor'
+import { renderWithProviders } from '../../../testing/utils'
+import { TYPOGRAPHY } from '../../../ui-style-constants'
+import { BasicButton } from '../BasicButton'
+
+import type { ComponentProps } from 'react'
+
+const render = (props: ComponentProps<typeof BasicButton>) => {
+  return renderWithProviders(<BasicButton {...props} />)
+}
+
+describe('BasicButton', () => {
+  let props: ComponentProps<typeof BasicButton>
+
+  beforeEach(() => {
+    props = {
+      children: 'basic button',
+      onClick: vi.fn(),
+      isDisabled: false,
+      underLine: false,
+    }
+  })
+
+  it('renders basic button with text', async () => {
+    render(props)
+    const button = screen.getByRole('button', { name: 'basic button' })
+    expect(button).toHaveAttribute('aria-disabled', 'false')
+    expect(button).toHaveStyle(`cursor: ${CURSOR_POINTER}`)
+    expect(button).toHaveStyle(`color: ${COLORS.black90}`)
+    expect(button).toHaveStyle(`text-decoration: none`)
+  })
+
+  // TODO: need to update '@testing-library/user-event' v14+
+  // it('has hover styles when not disabled', async () => {
+  //   render(props)
+  //   const button = screen.getByRole('button', { name: 'basic button' })
+  //   await userEvent.hover(button)
+  //   expect(button).toHaveStyle(`color: ${COLORS.blue50}`)
+  // })
+
+  it('calls onClick when clicked', () => {
+    render(props)
+    const button = screen.getByRole('button', { name: 'basic button' })
+    fireEvent.click(button)
+    expect(props.onClick).toHaveBeenCalled()
+  })
+
+  it('renders basic button with text and aria-disabled', () => {
+    props.isDisabled = true
+    render(props)
+    const button = screen.getByRole('button', { name: 'basic button' })
+    expect(button).toHaveAttribute('aria-disabled', 'true')
+    expect(button).toHaveStyle(`cursor: ${CURSOR_NOT_ALLOWED}`)
+    expect(button).toHaveStyle(`color: ${COLORS.grey40}`)
+  })
+
+  it('renders basic button with text and underline', () => {
+    props.underLine = true
+    render(props)
+    const button = screen.getByRole('button', { name: 'basic button' })
+    expect(button).toHaveAttribute('aria-disabled', 'false')
+    expect(button).toHaveStyle(`cursor: ${CURSOR_POINTER}`)
+    expect(button).toHaveStyle(`color: ${COLORS.black90}`)
+    expect(button).toHaveStyle(
+      `text-decoration: ${TYPOGRAPHY.textDecorationUnderline}`
+    )
+  })
+
+  it('has hover styles when not disabled', () => {
+    render(props)
+    const button = screen.getByRole('button', { name: 'basic button' })
+    expect(button).toHaveStyle(`color: ${COLORS.black90}`)
+    expect(button).toHaveAttribute('aria-disabled', 'false')
+    expect(button).toHaveStyle(`cursor: ${CURSOR_POINTER}`)
+  })
+})

--- a/components/src/atoms/buttons/buttons.stories.tsx
+++ b/components/src/atoms/buttons/buttons.stories.tsx
@@ -1,8 +1,10 @@
 import { Flex, STYLE_PROPS } from '../../primitives'
 import { DIRECTION_ROW } from '../../styles'
 import { SPACING } from '../../ui-style-constants'
+import { StyledText } from '../StyledText'
 import { AlertPrimaryButton as AlertPrimaryButtonComponent } from './AlertPrimaryButton'
 import { AltPrimaryButton as AltPrimaryButtonComponent } from './AltPrimaryButton'
+import { BasicButton as BasicButtonComponent } from './BasicButton'
 import { PrimaryButton as PrimaryButtonComponent } from './PrimaryButton'
 import { SecondaryButton as SecondaryButtonComponent } from './SecondaryButton'
 
@@ -79,6 +81,26 @@ export const AltPrimaryButton: StoryObj<typeof AltPrimaryButtonComponent> = {
   render: args => (
     <Flex>
       <AltPrimaryButtonComponent {...args} />
+    </Flex>
+  ),
+}
+
+export const BasicButton: StoryObj<typeof BasicButtonComponent> = {
+  args: {
+    children: 'basic button',
+  },
+  argTypes: {
+    underLine: {
+      control: {
+        type: 'boolean',
+      },
+      description:
+        'Toggles the underline style for the button text (BasicButton only).',
+    },
+  },
+  render: args => (
+    <Flex flexDirection={DIRECTION_ROW} gridGap={SPACING.spacing16}>
+      <BasicButtonComponent {...args} />
     </Flex>
   ),
 }

--- a/components/src/atoms/buttons/buttons.stories.tsx
+++ b/components/src/atoms/buttons/buttons.stories.tsx
@@ -1,3 +1,4 @@
+import { ICON_DATA_BY_NAME } from '../../icons/icon-data'
 import { Flex, STYLE_PROPS } from '../../primitives'
 import { DIRECTION_ROW } from '../../styles'
 import { SPACING } from '../../ui-style-constants'
@@ -95,6 +96,14 @@ export const BasicButton: StoryObj<typeof BasicButtonComponent> = {
       },
       description:
         'Toggles the underline style for the button text (BasicButton only).',
+    },
+    iconName: {
+      options: Object.keys(ICON_DATA_BY_NAME),
+      control: {
+        type: 'select',
+      },
+      description:
+        'Optional icon to display alongside the button text (BasicButton only).',
     },
   },
   render: args => (

--- a/components/src/atoms/buttons/buttons.stories.tsx
+++ b/components/src/atoms/buttons/buttons.stories.tsx
@@ -1,7 +1,6 @@
 import { Flex, STYLE_PROPS } from '../../primitives'
 import { DIRECTION_ROW } from '../../styles'
 import { SPACING } from '../../ui-style-constants'
-import { StyledText } from '../StyledText'
 import { AlertPrimaryButton as AlertPrimaryButtonComponent } from './AlertPrimaryButton'
 import { AltPrimaryButton as AltPrimaryButtonComponent } from './AltPrimaryButton'
 import { BasicButton as BasicButtonComponent } from './BasicButton'

--- a/components/src/atoms/buttons/index.ts
+++ b/components/src/atoms/buttons/index.ts
@@ -1,4 +1,5 @@
 export * from './AlertPrimaryButton'
+export * from './BasicButton'
 export * from './EmptySelectorButton'
 export * from './LargeButton'
 export * from './PrimaryButton'

--- a/protocol-designer/src/components/organisms/Navigation/index.tsx
+++ b/protocol-designer/src/components/organisms/Navigation/index.tsx
@@ -1,3 +1,4 @@
+import { useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 import { useLocation, useNavigate } from 'react-router-dom'
@@ -5,7 +6,7 @@ import styled from 'styled-components'
 
 import {
   ALIGN_CENTER,
-  Btn,
+  BasicButton,
   COLORS,
   CURSOR_POINTER,
   Flex,
@@ -17,7 +18,6 @@ import {
 import { actions as loadFileActions } from '../../../load-file'
 import { getHasUnsavedChanges } from '../../../load-file/selectors'
 import { toggleNewProtocolModal } from '../../../navigation/actions'
-import { LINK_BUTTON_STYLE } from '../../atoms'
 import { SettingsIcon } from '../SettingsIcon'
 
 import type { ChangeEvent } from 'react'
@@ -28,6 +28,7 @@ export function Navigation(): JSX.Element | null {
   const location = useLocation()
   const navigate = useNavigate()
   const dispatch: ThunkDispatch<any> = useDispatch()
+  const fileInputRef = useRef<HTMLInputElement>(null)
   const loadFile = (fileChangeEvent: ChangeEvent<HTMLInputElement>): void => {
     dispatch(loadFileActions.loadProtocolFile(fileChangeEvent))
     dispatch(toggleNewProtocolModal(false))
@@ -41,6 +42,12 @@ export function Navigation(): JSX.Element | null {
       window.confirm(t('alert:confirm_create_new') as string)
     ) {
       navigate('/createNew', { state: { modalResetKey: Date.now() } })
+    }
+  }
+
+  const handleImport = (): void => {
+    if (fileInputRef.current != null) {
+      fileInputRef.current.click()
     }
   }
 
@@ -58,18 +65,15 @@ export function Navigation(): JSX.Element | null {
         </StyledText>
       </Flex>
       <Flex gridGap={SPACING.spacing40} alignItems={ALIGN_CENTER}>
-        <Btn onClick={handleCreateNew} css={LINK_BUTTON_STYLE}>
-          <StyledText desktopStyle="bodyDefaultRegular">
-            {t('create_new')}
-          </StyledText>
-        </Btn>
+        <BasicButton onClick={handleCreateNew}>{t('create_new')}</BasicButton>
         <StyledLabel>
-          <Flex css={LINK_BUTTON_STYLE}>
-            <StyledText desktopStyle="bodyDefaultRegular">
-              {t('import')}
-            </StyledText>
-          </Flex>
-          <input type="file" onChange={loadFile} aria-label={t('import')} />
+          <BasicButton onClick={handleImport}>{t('import')}</BasicButton>
+          <input
+            type="file"
+            onChange={loadFile}
+            aria-label={t('import')}
+            ref={fileInputRef}
+          />
         </StyledLabel>
         {location.pathname === '/createNew' ? null : <SettingsIcon />}
       </Flex>

--- a/protocol-designer/src/components/organisms/Navigation/index.tsx
+++ b/protocol-designer/src/components/organisms/Navigation/index.tsx
@@ -82,7 +82,6 @@ export function Navigation(): JSX.Element | null {
 }
 
 const StyledLabel = styled.label`
-  height: 1.25rem;
   cursor: ${CURSOR_POINTER};
   input[type='file'] {
     display: none;

--- a/protocol-designer/src/components/organisms/Settings/AppInfo.tsx
+++ b/protocol-designer/src/components/organisms/Settings/AppInfo.tsx
@@ -2,19 +2,16 @@ import { useTranslation } from 'react-i18next'
 
 import {
   ALIGN_CENTER,
-  Btn,
+  BasicButton,
   DIRECTION_COLUMN,
   Flex,
   JUSTIFY_SPACE_BETWEEN,
-  Link as LinkComponent,
   ListItem,
   SPACING,
   StyledText,
-  TYPOGRAPHY,
 } from '@opentrons/components'
 
 import { DOC_URL } from '..'
-import { LINK_BUTTON_STYLE } from '../../atoms'
 
 import type { Dispatch, SetStateAction } from 'react'
 
@@ -27,6 +24,10 @@ export function AppInfo({
 }: AppInfoProps): JSX.Element {
   const { t } = useTranslation('shared')
   const pdVersion = process.env.OT_PD_VERSION
+
+  const handleSoftwareManualClick = (): void => {
+    window.open(DOC_URL, '_blank')
+  }
 
   return (
     <Flex
@@ -51,31 +52,17 @@ export function AppInfo({
           <StyledText desktopStyle="bodyDefaultRegular">{pdVersion}</StyledText>
         </Flex>
         <Flex gridGap={SPACING.spacing16} alignItems={ALIGN_CENTER}>
-          <LinkComponent
-            css={LINK_BUTTON_STYLE}
-            textDecoration={TYPOGRAPHY.textDecorationUnderline}
-            href={DOC_URL}
-            external
-            padding={SPACING.spacing4}
-          >
-            <StyledText desktopStyle="bodyDefaultRegular">
-              {t('software_manual')}
-            </StyledText>
-          </LinkComponent>
-
-          <Btn
-            css={LINK_BUTTON_STYLE}
-            textDecoration={TYPOGRAPHY.textDecorationUnderline}
+          <BasicButton onClick={handleSoftwareManualClick} underLine>
+            {t('software_manual')}
+          </BasicButton>
+          <BasicButton
             onClick={() => {
               setShowAnnouncementModal(true)
             }}
-            data-testid="AnnouncementModal_viewReleaseNotesButton"
-            padding={SPACING.spacing4}
+            underLine
           >
-            <StyledText desktopStyle="bodyDefaultRegular">
-              {t('release_notes')}
-            </StyledText>
-          </Btn>
+            {t('release_notes')}
+          </BasicButton>
         </Flex>
       </ListItem>
     </Flex>

--- a/protocol-designer/src/components/organisms/Settings/UserSettings.tsx
+++ b/protocol-designer/src/components/organisms/Settings/UserSettings.tsx
@@ -3,7 +3,7 @@ import { useDispatch } from 'react-redux'
 
 import {
   ALIGN_CENTER,
-  Btn,
+  BasicButton,
   COLORS,
   DIRECTION_COLUMN,
   Flex,
@@ -11,7 +11,6 @@ import {
   ListItem,
   SPACING,
   StyledText,
-  TYPOGRAPHY,
 } from '@opentrons/components'
 
 import { actions as featureFlagActions } from '../../../feature-flags'
@@ -69,19 +68,15 @@ export function UserSettings({
             </StyledText>
           </Flex>
         </Flex>
-        <Btn
-          disabled={!canClearHintDismissals}
-          textDecoration={
-            canClearHintDismissals ? TYPOGRAPHY.textDecorationUnderline : 'none'
-          }
+        <BasicButton
           onClick={() => dispatch(tutorialActions.clearAllHintDismissals())}
+          underLine={canClearHintDismissals}
+          isDisabled={!canClearHintDismissals}
         >
-          <StyledText desktopStyle="bodyDefaultRegular">
-            {canClearHintDismissals
-              ? t('shared:reset')
-              : t('shared:no_hints_to_restore')}
-          </StyledText>
-        </Btn>
+          {canClearHintDismissals
+            ? t('shared:reset')
+            : t('shared:no_hints_to_restore')}
+        </BasicButton>
       </ListItem>
       {userFacingFlags.map(flag => (
         <ListItem

--- a/protocol-designer/src/components/organisms/Settings/__tests__/AppInfo.test.tsx
+++ b/protocol-designer/src/components/organisms/Settings/__tests__/AppInfo.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, screen } from '@testing-library/react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { AppInfo } from '..'
 import { renderWithProviders } from '../../../../__testing-utils__'
@@ -15,26 +15,34 @@ const render = (props: ComponentProps<typeof AppInfo>) => {
 }
 
 const mockSetShowAnnouncementModal = vi.fn()
+const mockWindowOpen = vi.fn()
+vi.stubGlobal('window.open', mockWindowOpen)
 
 describe('AppInfo', () => {
   let props: ComponentProps<typeof AppInfo>
+  let windowOpenSpy: any
   beforeEach(() => {
     props = {
       setShowAnnouncementModal: mockSetShowAnnouncementModal,
     }
+    windowOpenSpy = vi.spyOn(window, 'open').mockImplementation(vi.fn())
+  })
+
+  afterEach(() => {
+    windowOpenSpy.mockRestore()
+    vi.clearAllMocks()
   })
   it('renders the app info section', () => {
     render(props)
     screen.getByText('App Info')
     screen.getByText('Protocol designer version')
     screen.getByText('fake_PD_version')
-    expect(
-      screen
-        .getByRole('link', {
-          name: 'Software manual',
-        })
-        .getAttribute('href')
-    ).toBe(DOC_URL)
+    const windowOpenButton = screen.getByRole('button', {
+      name: 'Software manual',
+    })
+    screen.debug(windowOpenButton)
+    fireEvent.click(windowOpenButton)
+    expect(window.open).toHaveBeenCalledWith(DOC_URL, '_blank')
     screen.getByRole('button', { name: 'Release notes' })
   })
   it('should call the setShowAnnouncementModal when the release notes button is clicked', () => {

--- a/protocol-designer/src/pages/Landing/index.tsx
+++ b/protocol-designer/src/pages/Landing/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 import { NavLink, useNavigate } from 'react-router-dom'
@@ -6,6 +6,7 @@ import styled from 'styled-components'
 
 import {
   ALIGN_CENTER,
+  BasicButton,
   COLORS,
   CURSOR_POINTER,
   DIRECTION_COLUMN,
@@ -19,7 +20,6 @@ import {
 } from '@opentrons/components'
 
 import { getHasOptedIn } from '../../analytics/selectors'
-import { LINK_BUTTON_STYLE } from '../../components/atoms'
 import { EndUserAgreementFooter } from '../../components/molecules'
 import { AnnouncementModal } from '../../components/organisms'
 import { useAnnouncements } from '../../components/organisms/AnnouncementModal/announcements'
@@ -46,6 +46,7 @@ export function Landing(): JSX.Element {
   const [showAnnouncementModal, setShowAnnouncementModal] = useState<boolean>(
     false
   )
+  const fileInputRef = useRef<HTMLInputElement>(null)
   const { hasOptedIn, appVersion } = useSelector(getHasOptedIn)
   const { bakeToast, eatToast } = useKitchen()
   const announcements = useAnnouncements()
@@ -94,6 +95,12 @@ export function Landing(): JSX.Element {
 
   const loadFile = (fileChangeEvent: ChangeEvent<HTMLInputElement>): void => {
     dispatch(loadFileActions.loadProtocolFile(fileChangeEvent))
+  }
+
+  const handleImportClick = (): void => {
+    if (fileInputRef.current != null) {
+      fileInputRef.current.click()
+    }
   }
 
   return (
@@ -150,12 +157,15 @@ export function Landing(): JSX.Element {
           />
         </StyledNavLink>
         <StyledLabel>
-          <Flex css={LINK_BUTTON_STYLE}>
-            <StyledText desktopStyle="bodyLargeRegular">
-              {t('import_existing_protocol')}
-            </StyledText>
-          </Flex>
-          <input type="file" onChange={loadFile} />
+          <BasicButton onClick={handleImportClick} underLine>
+            {t('import_existing_protocol')}
+          </BasicButton>
+          <StyledInput
+            type="file"
+            onChange={loadFile}
+            ref={fileInputRef}
+            aria-label={t('import')}
+          />
         </StyledLabel>
       </Flex>
       <EndUserAgreementFooter />
@@ -181,4 +191,8 @@ const ButtonText = styled.span`
 const StyledNavLink = styled(NavLink)<ComponentProps<typeof NavLink>>`
   color: ${COLORS.white};
   text-decoration: none;
+`
+
+const StyledInput = styled.input`
+  display: none;
 `

--- a/protocol-designer/src/pages/Settings/__tests__/Settings.test.tsx
+++ b/protocol-designer/src/pages/Settings/__tests__/Settings.test.tsx
@@ -63,9 +63,7 @@ describe('Settings', () => {
       <div>mock AnnouncementModal</div>
     )
     render()
-    fireEvent.click(
-      screen.getByTestId('AnnouncementModal_viewReleaseNotesButton')
-    )
+    fireEvent.click(screen.getByTestId('basic_button_Release notes'))
     screen.getByText('mock AnnouncementModal')
   })
   it('renders the hints button and calls to dismiss them when text is pressed', () => {


### PR DESCRIPTION
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
add BasicButton to Helix

design
https://www.figma.com/design/1ot18My22DALIcjdLl5LJh/Helix-Design-System?node-id=6560-4986&m=dev

Right now, this component doesn't have a test. I will add the test after [the poll](https://opentrons.slack.com/archives/C6PF2M2LC/p1748995696478009) and [Mel's answer](https://www.figma.com/design/1ot18My22DALIcjdLl5LJh?node-id=6560-4985&m=dev#1284307212).

answers from Mel
- the text size is always same
- icon needs to support what we have
- for Desktop app, the existing UIs will be replaced with BasicButton

close RUXD-2333 and RQA-4246

Storybook
https://s3-us-west-2.amazonaws.com/opentrons-components/feat_add-basic-button-for-pd/index.html?path=/docs/helix-abouthelix--docs

This component will be used in PD initially.

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- go to s3 link or run `make -C componetns dev`
- go to Helix atoms -> buttons -> BasicButton
check the button is alinged with the design
isDisabled works as expect -> false: aria-disabled="false" and clickable / true: aria-disabled="true" and not clickable
aria-disabled should be shown up in button tag in devtools
hover works as expect
underLine works as expect
icon is shown up when set an icon name
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Add BasicButton component
- Replace link buttons with BasicButton
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests
For BasicButton, I do not use Btn to avoid increasing the migration cost.

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
should be low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
