### PR TITLE
refactor(api): rename visit_every_well argument in liquid class transfers

### DIFF
--- a/api/src/opentrons/protocol_api/_transfer_liquid_validation.py
+++ b/api/src/opentrons/protocol_api/_transfer_liquid_validation.py
@@ -33,7 +33,7 @@ def verify_and_normalize_transfer_args(
     last_tip_picked_up_from: Optional[Well],
     tip_racks: List[Labware],
     nozzle_map: NozzleMapInterface,
-    target_all_wells: bool,
+    group_wells_for_multi_channel: bool,
     current_volume: float,
     trash_location: Union[Location, Well, Labware, TrashBin, WasteChute],
 ) -> TransferInfo:
@@ -43,7 +43,7 @@ def verify_and_normalize_transfer_args(
     else:
         # If trash bin or waste chute, set this to empty to have less isinstance checks after this
         flat_dests_list = []
-    if not target_all_wells and nozzle_map.tip_count > 1:
+    if group_wells_for_multi_channel and nozzle_map.tip_count > 1:
         flat_sources_list = tx_liquid_utils.group_wells_for_multi_channel_transfer(
             flat_sources_list, nozzle_map
         )

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1827,9 +1827,9 @@ class InstrumentContext(publisher.CommandPublisher):
             tips. Depending on the liquid class, the pipette may also blow out liquid here.
         :param return_tip: Whether to drop used tips in their original locations
             in the tip rack, instead of the trash.
-        :param group_wells: For multi-channel transfers only. If set to True group together contiguous wells
-            given into a single transfer step, taking into account the tip configuration. If False, target
-            each well given with the primary nozzle. Defaults to True.
+        :param group_wells: For multi-channel transfers only. If set to ``True``, group together contiguous wells
+            given into a single transfer step, taking into account the tip configuration. If ``False``, target
+            each well given with the primary nozzle. Defaults to ``True``.
 
         :meta private:
         """
@@ -1946,9 +1946,9 @@ class InstrumentContext(publisher.CommandPublisher):
             tips. Depending on the liquid class, the pipette may also blow out liquid here.
         :param return_tip: Whether to drop used tips in their original locations
             in the tip rack, instead of the trash.
-        :param group_wells: For multi-channel transfers only. If set to True group together contiguous wells
-            given into a single transfer step, taking into account the tip configuration. If False, target
-            each well given with the primary nozzle. Defaults to True.
+        :param group_wells: For multi-channel transfers only. If set to ``True``, group together contiguous wells
+            given into a single transfer step, taking into account the tip configuration. If ``False``, target
+            each well given with the primary nozzle. Defaults to ``True``.
 
         :meta private:
         """
@@ -2072,9 +2072,9 @@ class InstrumentContext(publisher.CommandPublisher):
             tips. Depending on the liquid class, the pipette may also blow out liquid here.
         :param return_tip: Whether to drop used tips in their original locations
             in the tip rack, instead of the trash.
-        :param group_wells: For multi-channel transfers only. If set to True group together contiguous wells
-            given into a single transfer step, taking into account the tip configuration. If False, target
-            each well given with the primary nozzle. Defaults to True.
+        :param group_wells: For multi-channel transfers only. If set to ``True``, group together contiguous wells
+            given into a single transfer step, taking into account the tip configuration. If ``False``, target
+            each well given with the primary nozzle. Defaults to ``True``.
 
         :meta private:
         """

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1827,6 +1827,9 @@ class InstrumentContext(publisher.CommandPublisher):
             tips. Depending on the liquid class, the pipette may also blow out liquid here.
         :param return_tip: Whether to drop used tips in their original locations
             in the tip rack, instead of the trash.
+        :param group_wells: For multi-channel transfers only. If set to True group together contiguous wells
+            given into a single transfer step, taking into account the tip configuration. If False, target
+            each well given with the primary nozzle. Defaults to True.
 
         :meta private:
         """
@@ -1943,6 +1946,9 @@ class InstrumentContext(publisher.CommandPublisher):
             tips. Depending on the liquid class, the pipette may also blow out liquid here.
         :param return_tip: Whether to drop used tips in their original locations
             in the tip rack, instead of the trash.
+        :param group_wells: For multi-channel transfers only. If set to True group together contiguous wells
+            given into a single transfer step, taking into account the tip configuration. If False, target
+            each well given with the primary nozzle. Defaults to True.
 
         :meta private:
         """
@@ -2066,6 +2072,9 @@ class InstrumentContext(publisher.CommandPublisher):
             tips. Depending on the liquid class, the pipette may also blow out liquid here.
         :param return_tip: Whether to drop used tips in their original locations
             in the tip rack, instead of the trash.
+        :param group_wells: For multi-channel transfers only. If set to True group together contiguous wells
+            given into a single transfer step, taking into account the tip configuration. If False, target
+            each well given with the primary nozzle. Defaults to True.
 
         :meta private:
         """

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1794,7 +1794,7 @@ class InstrumentContext(publisher.CommandPublisher):
             Union[types.Location, labware.Well, TrashBin, WasteChute]
         ] = None,
         return_tip: bool = False,
-        visit_every_well: bool = False,
+        group_wells: bool = True,
     ) -> InstrumentContext:
         """Move a particular type of liquid from one well or group of wells to another.
 
@@ -1844,7 +1844,7 @@ class InstrumentContext(publisher.CommandPublisher):
             last_tip_picked_up_from=self._last_tip_picked_up_from,
             tip_racks=self._tip_racks,
             nozzle_map=self._core.get_nozzle_map(),
-            target_all_wells=visit_every_well,
+            group_wells_for_multi_channel=group_wells,
             current_volume=self.current_volume,
             trash_location=(
                 trash_location if trash_location is not None else self.trash_container
@@ -1913,7 +1913,7 @@ class InstrumentContext(publisher.CommandPublisher):
             Union[types.Location, labware.Well, TrashBin, WasteChute]
         ] = None,
         return_tip: bool = False,
-        visit_every_well: bool = False,
+        group_wells: bool = True,
     ) -> InstrumentContext:
         """
         Distribute a particular type of liquid from one well to a group of wells.
@@ -1960,7 +1960,7 @@ class InstrumentContext(publisher.CommandPublisher):
             last_tip_picked_up_from=self._last_tip_picked_up_from,
             tip_racks=self._tip_racks,
             nozzle_map=self._core.get_nozzle_map(),
-            target_all_wells=visit_every_well,
+            group_wells_for_multi_channel=group_wells,
             current_volume=self.current_volume,
             trash_location=(
                 trash_location if trash_location is not None else self.trash_container
@@ -2035,7 +2035,7 @@ class InstrumentContext(publisher.CommandPublisher):
             Union[types.Location, labware.Well, TrashBin, WasteChute]
         ] = None,
         return_tip: bool = False,
-        visit_every_well: bool = False,
+        group_wells: bool = True,
     ) -> InstrumentContext:
         """
         Consolidate a particular type of liquid from a group of wells to one well.
@@ -2083,7 +2083,7 @@ class InstrumentContext(publisher.CommandPublisher):
             last_tip_picked_up_from=self._last_tip_picked_up_from,
             tip_racks=self._tip_racks,
             nozzle_map=self._core.get_nozzle_map(),
-            target_all_wells=visit_every_well,
+            group_wells_for_multi_channel=group_wells,
             current_volume=self.current_volume,
             trash_location=(
                 trash_location if trash_location is not None else self.trash_container


### PR DESCRIPTION
# Overview

This PR renames the `visit_every_well` argument of the three liquid class transfers to `group_well`, reversing the boolean logic as well for this argument.

When you do a transfer, distribute, or consolidate with liquid classes now, and you have a multi-channel pipette, we will automatically attempt to group together contiguous wells for a 96 plate (or near-contiguous for a 384 well plate) into a single transfer. This is both smarter and more strict than the old transfers, which only supported 8-channels, not full 96-channel configuration or a partial full-row configuration on a 96-channel, and worked by dropping any well that was not in the first row of the labware. It is stricter in that if you do not include each well that would be targeted, or if you include extra wells, the protocol will raise an error.

To revert to the current behavior of single well-target methods like `aspirate` and `dispense`, an optional argument of `visit_every_well` was added, where if `True` causes the primary nozzle to unconditionally visit each well given. But because in both scenarios the pipettes "visits" every well, this was deemed confusing and not straightforward in describing the behavior. It has now been renamed `group_wells`, and now that being `False` reverts to the non-grouping behavior.

## Test Plan and Hands on Testing

Simple variable name refactor and boolean switching so existing unit tests are sufficient.

## Changelog

- Renamed `visit_every_well` to `group_wells` and reversed boolean logic
- Added doc-strings to each of the three transfer methods

## Review requests

The doc-string explanation could probably use some massaging, otherwise everything else is very straightforward.

## Risk assessment

Low.