### PR TITLE
fix(api): current volume calculation in hardware controller

### DIFF
--- a/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
@@ -665,6 +665,7 @@ class OT3PipetteHandler:
             return None
 
         if is_full_dispense:
+            disp_vol = instrument.current_volume
             if push_out is None:
                 push_out_ul = instrument.push_out_volume
             else:


### PR DESCRIPTION
Closes AUTH-1952

# Overview

When calculating current pipette volumes following liquid handling commands, the hardware controller does floating point math. This was resulting in small python-specific floating point errors which were essentially negligible in all practical sense but were causing `==` comparisons to fail.

For the specific bug reported above, this floating point error was making the pipette's `current_volume` to be a value that's 'very close to' zero, but not zero, after doing a full dispense. This was preventing the harware controller from properly executing a `prepare_for_aspirate()` as it needs the current volume to be `0`.

So, this PR prevents the bug from happening by making sure that the final pipette volume after a full dispense gets saved as `0uL`

## Test Plan and Hands on Testing

Re-simulated the failing gravimetric script and made sure it completes correctly.

## Review requests

Anything else I've missed?

## Risk assessment

Low- bug fix only
