### PR TITLE
feat(api): save gripper jaw width to robot fs

### DIFF
--- a/api/src/opentrons/calibration_storage/ot3/gripper_offset.py
+++ b/api/src/opentrons/calibration_storage/ot3/gripper_offset.py
@@ -106,7 +106,7 @@ def save_gripper_jaw_width_data(
         cal_status_model = v1.CalibrationStatus()
 
     gripper_jaw_width = v1.GripperJawWidthModel(
-        encoder_position_at_jaw_closed=encoder_position_at_jaw_closed,
+        encoderPositionAtJawClosed=encoder_position_at_jaw_closed,
         lastModified=utc_now(),
         source=local_types.SourceType.user,
         status=cal_status_model,

--- a/api/src/opentrons/calibration_storage/ot3/gripper_offset.py
+++ b/api/src/opentrons/calibration_storage/ot3/gripper_offset.py
@@ -65,6 +65,34 @@ def save_gripper_calibration(
     io.save_to_file(gripper_dir, gripper_id, gripper_calibration)
 
 
+# Save Gripper Jaw Width Data
+
+
+def save_gripper_jaw_width_data(
+    encoder_position_at_jaw_closed: float,
+    gripper_id: str,
+    cal_status: Optional[
+        Union[local_types.CalibrationStatus, v1.CalibrationStatus]
+    ] = None,
+) -> None:
+    gripper_jaw_width_dir = config.get_opentrons_path("gripper_jaw_width_dir")
+
+    if isinstance(cal_status, local_types.CalibrationStatus):
+        cal_status_model = v1.CalibrationStatus(**asdict(cal_status))
+    elif isinstance(cal_status, v1.CalibrationStatus):
+        cal_status_model = cal_status
+    else:
+        cal_status_model = v1.CalibrationStatus()
+
+    gripper_jaw_width = v1.GripperJawWidthModel(
+        encoder_position_at_jaw_closed=encoder_position_at_jaw_closed,
+        lastModified=utc_now(),
+        source=local_types.SourceType.user,
+        status=cal_status_model,
+    )
+    io.save_to_file(gripper_jaw_width_dir, gripper_id, gripper_jaw_width)
+
+
 # Get Gripper Offset Calibrations
 
 
@@ -83,6 +111,24 @@ def get_gripper_calibration_offset(
         return v1.InstrumentOffsetModel(
             **io.read_cal_file(gripper_calibration_filepath)
         )
+    except FileNotFoundError:
+        return None
+    except (json.JSONDecodeError, ValidationError):
+        return None
+
+
+# Get Gripper Jaw Width
+
+
+def get_gripper_jaw_width_data(gripper_id: str) -> Optional[v1.GripperJawWidthModel]:
+    """Return the requested gripper jaw width data."""
+    if not config.feature_flags.enable_ot3_hardware_controller():
+        raise NotImplementedError("Gripper jaw width data only available on the OT-3.")
+    try:
+        gripper_jaw_width_filepath = (
+            config.get_opentrons_path("gripper_jaw_width_dir") / f"{gripper_id}.json"
+        )
+        return v1.GripperJawWidthModel(**io.read_cal_file(gripper_jaw_width_filepath))
     except FileNotFoundError:
         return None
     except (json.JSONDecodeError, ValidationError):

--- a/api/src/opentrons/calibration_storage/ot3/gripper_offset.py
+++ b/api/src/opentrons/calibration_storage/ot3/gripper_offset.py
@@ -37,6 +37,27 @@ def clear_gripper_calibration_offsets() -> None:
     io._remove_json_files_in_directories(offset_dir)
 
 
+# Delete Gripper Jaw Width Calibration
+
+
+def delete_gripper_jaw_width_data_file(gripper: str) -> None:
+    """
+    Delete gripper jaw width data file based on gripper serial number
+
+    :param gripper: gripper serial number
+    """
+    offset_path = config.get_opentrons_path("gripper_jaw_width_dir") / f"{gripper}.json"
+    io.delete_file(offset_path)
+
+
+def clear_gripper_jaw_width_data() -> None:
+    """
+    Delete all gripper jaw width data files.
+    """
+    offset_dir = config.get_opentrons_path("gripper_jaw_width_dir")
+    io._remove_json_files_in_directories(offset_dir)
+
+
 # Save Gripper Offset Calibrations
 
 

--- a/api/src/opentrons/calibration_storage/ot3/models/v1.py
+++ b/api/src/opentrons/calibration_storage/ot3/models/v1.py
@@ -82,7 +82,7 @@ class InstrumentOffsetModel(BaseModel):
 
 
 class GripperJawWidthModel(BaseModel):
-    encoder_position_at_jaw_closed: float = Field(
+    encoderPositionAtJawClosed: float = Field(
         ..., description="The encoder position when the gripper jaw is closed."
     )
     lastModified: DatetimeType = Field(

--- a/api/src/opentrons/calibration_storage/ot3/models/v1.py
+++ b/api/src/opentrons/calibration_storage/ot3/models/v1.py
@@ -81,6 +81,22 @@ class InstrumentOffsetModel(BaseModel):
     )
 
 
+class GripperJawWidthModel(BaseModel):
+    encoder_position_at_jaw_closed: float = Field(
+        ..., description="The encoder position when the gripper jaw is closed."
+    )
+    lastModified: DatetimeType = Field(
+        ..., description="The last time this instrument was calibrated."
+    )
+    source: types.SourceType = Field(
+        default=types.SourceType.factory, description="The source of calibration."
+    )
+    status: CalibrationStatus = Field(
+        default_factory=CalibrationStatus,
+        description="The status of the calibration data.",
+    )
+
+
 class ModuleOffsetModel(BaseModel):
     offset: Point = Field(..., description="Module offset found from calibration.")
     mount: OT3Mount = Field(..., description="The mount used to calibrate this module.")

--- a/api/src/opentrons/config/__init__.py
+++ b/api/src/opentrons/config/__init__.py
@@ -287,6 +287,13 @@ CONFIG_ELEMENTS = (
         "The dir where gripper calibration is stored",
     ),
     ConfigElement(
+        "gripper_jaw_width_dir",
+        "Gripper Jaw Width Directory",
+        Path("robot") / "gripper_jaw",
+        ConfigElementType.DIR,
+        "The dir where gripper jaw width data is stored",
+    ),
+    ConfigElement(
         "module_calibration_dir",
         "Module Calibration Directory",
         Path("robot") / "modules",

--- a/api/src/opentrons/config/__init__.py
+++ b/api/src/opentrons/config/__init__.py
@@ -289,7 +289,7 @@ CONFIG_ELEMENTS = (
     ConfigElement(
         "gripper_jaw_width_dir",
         "Gripper Jaw Width Directory",
-        Path("robot") / "gripper_jaw",
+        Path("robot") / "gripper_jaw_width_data",
         ConfigElementType.DIR,
         "The dir where gripper jaw width data is stored",
     ),

--- a/api/src/opentrons/config/reset.py
+++ b/api/src/opentrons/config/reset.py
@@ -175,6 +175,7 @@ def reset_pipette_offset(robot_type: RobotTypeEnum) -> None:
 
 def reset_gripper_offset() -> None:
     gripper_offset.clear_gripper_calibration_offsets()
+    gripper_offset.clear_gripper_jaw_width_data()
 
 
 def reset_tip_length_calibrations(robot_type: RobotTypeEnum) -> None:

--- a/api/src/opentrons/hardware_control/instruments/ot3/gripper.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/gripper.py
@@ -228,16 +228,16 @@ class Gripper(AbstractInstrument[GripperDefinition]):
         if self._encoder_position_at_jaw_closed is not None:
             return True
         else:
-            gripper_jaw_width_data = load_gripper_jaw_width(gripper_id=self._gripper_id)
-            if gripper_jaw_width_data.encoder_position_at_jaw_closed is not None:
+            load_gripper_jaw_width_data = load_gripper_jaw_width(
+                gripper_id=self._gripper_id
+            )
+            if load_gripper_jaw_width_data.encoder_position_at_jaw_closed is not None:
                 # update class members with data from the robot
                 self.update_jaw_open_position_from_closed_position(
-                    jaw_at_closed=gripper_jaw_width_data.encoder_position_at_jaw_closed
+                    jaw_at_closed=load_gripper_jaw_width_data.encoder_position_at_jaw_closed
                 )
                 return True
         return False
-
-        return self._jaw_max_offset is not None
 
     def reset_offset(self, to_default: bool) -> None:
         """Tempoarily reset the gripper offsets to default values."""

--- a/api/src/opentrons/hardware_control/instruments/ot3/gripper.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/gripper.py
@@ -3,9 +3,6 @@ from __future__ import annotations
 """ Classes and functions for gripper state tracking
 """
 import logging
-import sys
-import os
-import pprint
 from typing import Any, Optional, Set, Dict, Tuple, Final
 
 from opentrons.types import Point

--- a/api/src/opentrons/hardware_control/instruments/ot3/gripper.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/gripper.py
@@ -22,6 +22,7 @@ from .instrument_calibration import (
     save_gripper_jaw_width_data,
     load_gripper_jaw_width,
 )
+
 from ..instrument_abc import AbstractInstrument
 from opentrons.hardware_control.dev_types import AttachedGripper, GripperDict
 from opentrons_shared_data.errors.exceptions import (
@@ -196,6 +197,7 @@ class Gripper(AbstractInstrument[GripperDefinition]):
         """
         if jaw_at_closed is None:
             self._encoder_position_at_jaw_closed = jaw_at_closed
+            self._jaw_max_offset = None
             return
         jaw_min = self._config.geometry.jaw_width["min"]
         jaw_nominal_max = self._config.geometry.jaw_width["max"]

--- a/api/src/opentrons/hardware_control/instruments/ot3/gripper.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/gripper.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 """ Classes and functions for gripper state tracking
 """
 import logging
+import sys
+import os
+import pprint
 from typing import Any, Optional, Set, Dict, Tuple, Final
 
 from opentrons.types import Point

--- a/api/src/opentrons/hardware_control/instruments/ot3/gripper.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/gripper.py
@@ -19,6 +19,8 @@ from .instrument_calibration import (
     GripperCalibrationOffset,
     load_gripper_calibration_offset,
     save_gripper_calibration_offset,
+    save_gripper_jaw_width_data,
+    load_gripper_jaw_width,
 )
 from ..instrument_abc import AbstractInstrument
 from opentrons.hardware_control.dev_types import AttachedGripper, GripperDict
@@ -85,6 +87,7 @@ class Gripper(AbstractInstrument[GripperDefinition]):
             f"loaded: {self._model}, gripper offset: {self._calibration_offset}"
         )
         self._jaw_max_offset = jaw_max_offset
+        self._encoder_position_at_jaw_closed: Optional[float] = None
 
     @property
     def grip_force_profile(self) -> GripForceProfile:
@@ -191,6 +194,7 @@ class Gripper(AbstractInstrument[GripperDefinition]):
         is closed, and then altering the logical open position so that it is whatever it needs
         to be for the logical closed position to be the same as the config.
         """
+
         jaw_min = self._config.geometry.jaw_width["min"]
         jaw_nominal_max = self._config.geometry.jaw_width["max"]
         if (
@@ -205,16 +209,33 @@ class Gripper(AbstractInstrument[GripperDefinition]):
                     "nominal-displacement": str(jaw_nominal_max - jaw_min),
                 },
             )
-
+        save_gripper_jaw_width_data(
+            gripper_id=self._gripper_id,
+            encoder_position_at_closed=jaw_at_closed,
+        )
         self._jaw_max_offset = jaw_min - (jaw_nominal_max - (jaw_at_closed * 2))
+        self._encoder_position_at_jaw_closed = jaw_at_closed
         self._log.info(
             f"Gripper max jaw offset is now {self._jaw_max_offset} from input position {jaw_at_closed}"
         )
 
     @property
     def has_jaw_width_calibration(self) -> bool:
+        if self._encoder_position_at_jaw_closed is not None:
+            return True
+        else:
+            gripper_jaw_width_data = load_gripper_jaw_width(gripper_id=self._gripper_id)
+            if gripper_jaw_width_data.encoder_position_at_jaw_closed is not None:
+                # update class members with data from the robot
+                self.update_jaw_open_position_from_closed_position(
+                    jaw_at_closed=gripper_jaw_width_data.encoder_position_at_jaw_closed
+                )
+                return True
+        return False
+
         return self._jaw_max_offset is not None
 
+    # might have to replicate this for jaw_width
     def reset_offset(self, to_default: bool) -> None:
         """Tempoarily reset the gripper offsets to default values."""
         if to_default:

--- a/api/src/opentrons/hardware_control/instruments/ot3/gripper.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/gripper.py
@@ -184,7 +184,7 @@ class Gripper(AbstractInstrument[GripperDefinition]):
         return None
 
     def update_jaw_open_position_from_closed_position(
-        self, jaw_at_closed: float
+        self, jaw_at_closed: float | None
     ) -> None:
         """Update the estimation of the jaw position at open based on reading it at closed.
 
@@ -194,7 +194,9 @@ class Gripper(AbstractInstrument[GripperDefinition]):
         is closed, and then altering the logical open position so that it is whatever it needs
         to be for the logical closed position to be the same as the config.
         """
-
+        if jaw_at_closed is None:
+            self._encoder_position_at_jaw_closed = jaw_at_closed
+            return
         jaw_min = self._config.geometry.jaw_width["min"]
         jaw_nominal_max = self._config.geometry.jaw_width["max"]
         if (
@@ -235,7 +237,6 @@ class Gripper(AbstractInstrument[GripperDefinition]):
 
         return self._jaw_max_offset is not None
 
-    # might have to replicate this for jaw_width
     def reset_offset(self, to_default: bool) -> None:
         """Tempoarily reset the gripper offsets to default values."""
         if to_default:
@@ -244,6 +245,16 @@ class Gripper(AbstractInstrument[GripperDefinition]):
             self._calibration_offset = load_gripper_calibration_offset(
                 gripper_id=self._gripper_id
             )
+
+    def reset_jaw_width_calibration(self, to_default: bool) -> None:
+        """Temporarily reset the gripper jaw width measurement."""
+        if to_default:
+            loaded_jaw_width_data = load_gripper_jaw_width(gripper_id=None)
+        else:
+            loaded_jaw_width_data = load_gripper_jaw_width(gripper_id=self._gripper_id)
+        self.update_jaw_open_position_from_closed_position(
+            jaw_at_closed=loaded_jaw_width_data.encoder_position_at_jaw_closed
+        )
 
     def save_offset(self, delta: Point) -> GripperCalibrationOffset:
         """Save a new gripper offset."""

--- a/api/src/opentrons/hardware_control/instruments/ot3/gripper.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/gripper.py
@@ -55,7 +55,6 @@ class Gripper(AbstractInstrument[GripperDefinition]):
         config: GripperDefinition,
         gripper_cal_offset: GripperCalibrationOffset,
         gripper_id: str,
-        jaw_max_offset: Optional[float] = None,
     ) -> None:
         self._config = config
         self._model = config.model
@@ -87,7 +86,6 @@ class Gripper(AbstractInstrument[GripperDefinition]):
         self._log.info(
             f"loaded: {self._model}, gripper offset: {self._calibration_offset}"
         )
-        self._jaw_max_offset = jaw_max_offset
         self._encoder_position_at_jaw_closed: Optional[float] = None
 
     @property
@@ -114,6 +112,22 @@ class Gripper(AbstractInstrument[GripperDefinition]):
     @property
     def max_allowed_grip_error(self) -> float:
         return self._geometry.max_allowed_grip_error
+
+    @property
+    def _jaw_min(self) -> float:
+        return self._config.geometry.jaw_width["min"]
+
+    @property
+    def _jaw_nominal_max(self) -> float:
+        return self._config.geometry.jaw_width["max"]
+
+    @property
+    def _jaw_max_offset(self) -> float | None:
+        if self._encoder_position_at_jaw_closed is None:
+            return None
+        return self._jaw_min - (
+            self._jaw_nominal_max - (self._encoder_position_at_jaw_closed * 2)
+        )
 
     @property
     def max_jaw_width(self) -> float:
@@ -197,12 +211,9 @@ class Gripper(AbstractInstrument[GripperDefinition]):
         """
         if jaw_at_closed is None:
             self._encoder_position_at_jaw_closed = jaw_at_closed
-            self._jaw_max_offset = None
             return
-        jaw_min = self._config.geometry.jaw_width["min"]
-        jaw_nominal_max = self._config.geometry.jaw_width["max"]
         if (
-            abs((jaw_at_closed * 2) - (jaw_nominal_max - jaw_min))
+            abs((jaw_at_closed * 2) - (self._jaw_nominal_max - self._jaw_min))
             > MAX_ACCEPTABLE_JAW_DISPLACEMENT
         ):
             raise MotionFailedError(
@@ -210,14 +221,13 @@ class Gripper(AbstractInstrument[GripperDefinition]):
                 detail={
                     "type": "gripper-jaw-calibration-out-of-bounds",
                     "actual-displacement": str(jaw_at_closed * 2),
-                    "nominal-displacement": str(jaw_nominal_max - jaw_min),
+                    "nominal-displacement": str(self._jaw_nominal_max - self._jaw_min),
                 },
             )
         save_gripper_jaw_width_data(
             gripper_id=self._gripper_id,
             encoder_position_at_closed=jaw_at_closed,
         )
-        self._jaw_max_offset = jaw_min - (jaw_nominal_max - (jaw_at_closed * 2))
         self._encoder_position_at_jaw_closed = jaw_at_closed
         self._log.info(
             f"Gripper max jaw offset is now {self._jaw_max_offset} from input position {jaw_at_closed}"
@@ -249,7 +259,7 @@ class Gripper(AbstractInstrument[GripperDefinition]):
             )
 
     def reset_jaw_width_calibration(self, to_default: bool) -> None:
-        """Temporarily reset the gripper jaw width measurement."""
+        """Reset the gripper jaw width measurement in the protocol engine."""
         if to_default:
             loaded_jaw_width_data = load_gripper_jaw_width(gripper_id=None)
         else:
@@ -366,7 +376,6 @@ def _reload_gripper(
                     new_config,
                     cal_offset,
                     attached_instr._gripper_id,
-                    None,
                 ),
                 False,
             )

--- a/api/src/opentrons/hardware_control/instruments/ot3/gripper_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/gripper_handler.py
@@ -51,7 +51,6 @@ class GripperHandler:
             og_gripper.config,
             load_gripper_calibration_offset(og_gripper.gripper_id),
             og_gripper.gripper_id,
-            og_gripper._jaw_max_offset,
         )
         self._gripper = new_gripper
 

--- a/api/src/opentrons/hardware_control/instruments/ot3/gripper_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/gripper_handler.py
@@ -73,6 +73,7 @@ class GripperHandler:
         """
         gripper = self.get_gripper()
         gripper.reset_offset(to_default)
+        gripper.reset_jaw_width_calibration(to_default)
 
     def save_instrument_offset(self, delta: Point) -> GripperCalibrationOffset:
         """
@@ -82,13 +83,6 @@ class GripperHandler:
         gripper = self.get_gripper()
         self._log.info(f"Saving gripper {gripper.gripper_id} offset: {delta}")
         return gripper.save_offset(delta)
-
-    def reset_gripper_jaw_width_data(self, to_default: bool) -> None:
-        """
-        Temporarily reset the gripper jaw width calibration default value.
-        """
-        gripper = self.get_gripper()
-        gripper.reset_offset(to_default)
 
     def get_critical_point(self, cp_override: Optional[CriticalPoint] = None) -> Point:
         if not self._gripper:

--- a/api/src/opentrons/hardware_control/instruments/ot3/gripper_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/gripper_handler.py
@@ -56,6 +56,7 @@ class GripperHandler:
         self._gripper = new_gripper
 
     async def reset(self) -> None:
+        # TODO(cm): do we want to reset the gripper jaw width here as well?
         self._gripper = None
 
     @property
@@ -81,6 +82,13 @@ class GripperHandler:
         gripper = self.get_gripper()
         self._log.info(f"Saving gripper {gripper.gripper_id} offset: {delta}")
         return gripper.save_offset(delta)
+
+    def reset_gripper_jaw_width_data(self, to_default: bool) -> None:
+        """
+        Temporarily reset the gripper jaw width calibration default value.
+        """
+        gripper = self.get_gripper()
+        gripper.reset_offset(to_default)
 
     def get_critical_point(self, cp_override: Optional[CriticalPoint] = None) -> Point:
         if not self._gripper:

--- a/api/src/opentrons/hardware_control/instruments/ot3/gripper_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/gripper_handler.py
@@ -56,7 +56,6 @@ class GripperHandler:
         self._gripper = new_gripper
 
     async def reset(self) -> None:
-        # TODO(cm): do we want to reset the gripper jaw width here as well?
         self._gripper = None
 
     @property

--- a/api/src/opentrons/hardware_control/instruments/ot3/instrument_calibration.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/instrument_calibration.py
@@ -1,5 +1,4 @@
 import typing
-import os
 from typing_extensions import Literal, Final
 from dataclasses import dataclass, field
 from datetime import datetime

--- a/api/src/opentrons/hardware_control/instruments/ot3/instrument_calibration.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/instrument_calibration.py
@@ -164,7 +164,7 @@ def load_gripper_jaw_width(
         gripper_jaw_width_data = gripper_offset.get_gripper_jaw_width_data(gripper_id)
         if gripper_jaw_width_data:
             return GripperJawWidthData(
-                encoder_position_at_jaw_closed=gripper_jaw_width_data.encoder_position_at_jaw_closed,
+                encoder_position_at_jaw_closed=gripper_jaw_width_data.encoderPositionAtJawClosed,
                 source=gripper_jaw_width_data.source,
                 status=cal_top_types.CalibrationStatus(
                     markedAt=gripper_jaw_width_data.status.markedAt,

--- a/api/src/opentrons/hardware_control/instruments/ot3/instrument_calibration.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/instrument_calibration.py
@@ -1,4 +1,5 @@
 import typing
+import os
 from typing_extensions import Literal, Final
 from dataclasses import dataclass, field
 from datetime import datetime

--- a/api/src/opentrons/hardware_control/instruments/ot3/instrument_calibration.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/instrument_calibration.py
@@ -73,6 +73,16 @@ class GripperCalibrationOffset:
     last_modified: typing.Optional[datetime] = None
 
 
+@dataclass
+class GripperJawWidthData:
+    """Store gripper jaw width information on the robot fs."""
+
+    source: SourceType
+    status: CalibrationStatus
+    encoder_position_at_jaw_closed: typing.Optional[float] = None
+    last_modified: typing.Optional[datetime] = None
+
+
 def load_pipette_offset(
     pip_id: typing.Optional[str], mount: OT3Mount
 ) -> PipetteOffsetByPipetteMount:
@@ -140,6 +150,39 @@ def load_gripper_calibration_offset(
                 ),
             )
     return grip_cal_obj
+
+
+def load_gripper_jaw_width(
+    gripper_id: typing.Optional[str],
+) -> GripperJawWidthData:
+    grip_jaw_width_obj = GripperJawWidthData(
+        encoder_position_at_jaw_closed=None,
+        source=SourceType.default,
+        status=CalibrationStatus(),
+    )
+    if gripper_id and ff.enable_ot3_hardware_controller():
+        gripper_jaw_width_data = gripper_offset.get_gripper_jaw_width_data(gripper_id)
+        if gripper_jaw_width_data:
+            return GripperJawWidthData(
+                encoder_position_at_jaw_closed=gripper_jaw_width_data.encoder_position_at_jaw_closed,
+                source=gripper_jaw_width_data.source,
+                status=cal_top_types.CalibrationStatus(
+                    markedAt=gripper_jaw_width_data.status.markedAt,
+                    markedBad=gripper_jaw_width_data.status.markedBad,
+                    source=gripper_jaw_width_data.status.source,
+                ),
+            )
+    return grip_jaw_width_obj
+
+
+def save_gripper_jaw_width_data(
+    gripper_id: typing.Optional[str], encoder_position_at_closed: float
+) -> None:
+    if gripper_id and ff.enable_ot3_hardware_controller():
+        gripper_offset.save_gripper_jaw_width_data(
+            encoder_position_at_jaw_closed=encoder_position_at_closed,
+            gripper_id=gripper_id,
+        )
 
 
 def save_gripper_calibration_offset(

--- a/api/src/opentrons/hardware_control/ot3_calibration.py
+++ b/api/src/opentrons/hardware_control/ot3_calibration.py
@@ -802,6 +802,7 @@ async def calibrate_gripper(
     offset = gripper_pin_offsets_mean(front=offset_front, rear=offset_rear)
     LOG.info(f"Gripper calibration offset: {offset}")
     await hcapi.save_instrument_offset(OT3Mount.GRIPPER, offset)
+    await hcapi.home_gripper_jaw(recalibrate_jaw_width=True)
     return offset
 
 

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -937,14 +937,17 @@ class OT3API(
             axes = list(Axis.ot3_mount_axes())
         await self.home(axes)
 
-    async def _do_home_and_maybe_calibrate_gripper_jaw(self) -> None:
+    async def _do_home_and_maybe_calibrate_gripper_jaw(
+        self,
+        recalibrate_jaw_width: bool = False,
+    ) -> None:
         gripper = self._gripper_handler.get_gripper()
         self._log.info("Homing gripper jaw.")
         dc = self._gripper_handler.get_duty_cycle_by_grip_force(
             gripper.default_home_force
         )
         await self._ungrip(duty_cycle=dc)
-        if not gripper.has_jaw_width_calibration:
+        if recalibrate_jaw_width or not gripper.has_jaw_width_calibration:
             self._log.info("Calibrating gripper jaw.")
             await self._grip(
                 duty_cycle=dc, expected_displacement=gripper.max_jaw_displacement()
@@ -953,10 +956,13 @@ class OT3API(
             gripper.update_jaw_open_position_from_closed_position(jaw_at_closed)
             await self._ungrip(duty_cycle=dc)
 
-    async def home_gripper_jaw(self) -> None:
+    async def home_gripper_jaw(
+        self,
+        recalibrate_jaw_width: bool = False,
+    ) -> None:
         """Home the jaw of the gripper."""
         try:
-            await self._do_home_and_maybe_calibrate_gripper_jaw()
+            await self._do_home_and_maybe_calibrate_gripper_jaw(recalibrate_jaw_width)
         except GripperNotPresentError:
             pass
 

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -2552,9 +2552,6 @@ class OT3API(
         else:
             self._pipette_handler.reset_instrument_offset(checked_mount, to_default)
 
-    async def reset_gripper_jaw_width_data(self, to_default: bool = True) -> None:
-        self._gripper_handler.reset_gripper_jaw_width_data(to_default)
-
     async def save_instrument_offset(
         self, mount: Union[top_types.Mount, OT3Mount], delta: top_types.Point
     ) -> Union[GripperCalibrationOffset, PipetteOffsetSummary]:

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -2552,6 +2552,9 @@ class OT3API(
         else:
             self._pipette_handler.reset_instrument_offset(checked_mount, to_default)
 
+    async def reset_gripper_jaw_width_data(self, to_default: bool = True) -> None:
+        self._gripper_handler.reset_gripper_jaw_width_data(to_default)
+
     async def save_instrument_offset(
         self, mount: Union[top_types.Mount, OT3Mount], delta: top_types.Point
     ) -> Union[GripperCalibrationOffset, PipetteOffsetSummary]:

--- a/api/src/opentrons/hardware_control/protocols/gripper_controller.py
+++ b/api/src/opentrons/hardware_control/protocols/gripper_controller.py
@@ -14,7 +14,7 @@ class GripperController(Protocol):
     ) -> None:
         ...
 
-    async def home_gripper_jaw(self) -> None:
+    async def home_gripper_jaw(self, recalibrate_jaw_width: bool = False) -> None:
         ...
 
     async def ungrip(self, force_newtons: Optional[float] = None) -> None:

--- a/api/tests/opentrons/calibration_storage/test_gripper_offset.py
+++ b/api/tests/opentrons/calibration_storage/test_gripper_offset.py
@@ -19,12 +19,8 @@ def starting_calibration_data(
     """
     gripper.save_gripper_calibration(Point(1, 1, 1), "gripper1")
     gripper.save_gripper_calibration(Point(1, 2, 1), "gripper2")
-    gripper.save_gripper_jaw_width_data(
-        15.5, "gripper1"
-    )
-    gripper.save_gripper_jaw_width_data(
-        15.5, "gripper2"
-    )
+    gripper.save_gripper_jaw_width_data(15.5, "gripper1")
+    gripper.save_gripper_jaw_width_data(15.5, "gripper2")
 
 
 def test_delete_all_gripper_calibration(starting_calibration_data: typing.Any) -> None:

--- a/api/tests/opentrons/calibration_storage/test_gripper_offset.py
+++ b/api/tests/opentrons/calibration_storage/test_gripper_offset.py
@@ -61,6 +61,19 @@ def test_save_gripper_calibration(
     assert gripper_offset.offset == Point(1, 1, 1)
 
 
+def test_save_gripper_jaw_width(
+    ot_config_tempdir: typing.Any, enable_ot3_hardware_controller: typing.Any
+) -> None:
+    """
+    Test saving gripper jaw calibrations.
+    """
+    assert gripper.get_gripper_jaw_width_data("gripper1") is None
+    gripper.save_gripper_jaw_width_data(15.44, "gripper1")
+    gripper_offset = gripper.get_gripper_jaw_width_data("gripper1")
+    assert gripper_offset is not None
+    assert gripper_offset.encoderPositionAtJawClosed == 15.44
+
+
 def test_get_gripper_calibration(
     starting_calibration_data: typing.Any, enable_ot3_hardware_controller: typing.Any
 ) -> None:
@@ -71,6 +84,21 @@ def test_get_gripper_calibration(
     assert gripper_data is not None
     assert gripper_data == models.v1.InstrumentOffsetModel(
         offset=Point(1, 1, 1),
+        lastModified=gripper_data.lastModified,
+        source=cs_types.SourceType.user,
+    )
+
+
+def test_get_gripper_jaw_width(
+    starting_calibration_data: typing.Any, enable_ot3_hardware_controller: typing.Any
+) -> None:
+    """
+    Test ability to get a gripper jaw calibration schema.
+    """
+    gripper_data = gripper.get_gripper_jaw_width_data("gripper1")
+    assert gripper_data is not None
+    assert gripper_data == models.v1.GripperJawWidthModel(
+        encoderPositionAtJawClosed=15.5,
         lastModified=gripper_data.lastModified,
         source=cs_types.SourceType.user,
     )

--- a/api/tests/opentrons/calibration_storage/test_gripper_offset.py
+++ b/api/tests/opentrons/calibration_storage/test_gripper_offset.py
@@ -19,6 +19,12 @@ def starting_calibration_data(
     """
     gripper.save_gripper_calibration(Point(1, 1, 1), "gripper1")
     gripper.save_gripper_calibration(Point(1, 2, 1), "gripper2")
+    gripper.save_gripper_jaw_width_data(
+        15.5, "gripper1"
+    )
+    gripper.save_gripper_jaw_width_data(
+        15.5, "gripper2"
+    )
 
 
 def test_delete_all_gripper_calibration(starting_calibration_data: typing.Any) -> None:
@@ -27,9 +33,14 @@ def test_delete_all_gripper_calibration(starting_calibration_data: typing.Any) -
     """
     assert gripper.get_gripper_calibration_offset("gripper1") is not None
     assert gripper.get_gripper_calibration_offset("gripper2") is not None
+    assert gripper.get_gripper_jaw_width_data("gripper1") is not None
+    assert gripper.get_gripper_jaw_width_data("gripper2") is not None
     gripper.clear_gripper_calibration_offsets()
+    gripper.clear_gripper_jaw_width_data()
     assert gripper.get_gripper_calibration_offset("gripper1") is None
     assert gripper.get_gripper_calibration_offset("gripper2") is None
+    assert gripper.get_gripper_jaw_width_data("gripper1") is None
+    assert gripper.get_gripper_jaw_width_data("gripper2") is None
 
 
 def test_delete_gripper_calibration(starting_calibration_data: typing.Any) -> None:

--- a/api/tests/opentrons/hardware_control/instruments/test_instrument_calibration.py
+++ b/api/tests/opentrons/hardware_control/instruments/test_instrument_calibration.py
@@ -17,12 +17,18 @@ from opentrons_shared_data.labware.labware_definition import (
 
 
 from opentrons import calibration_storage, types as top_types
+from opentrons.config import feature_flags
+
 from opentrons.calibration_storage import helpers as calibration_storage_helpers
 from opentrons.calibration_storage.ot2.models import v1 as v1_models
+from opentrons.calibration_storage.ot3.models import v1 as ot3_models
 from opentrons.hardware_control.instruments.ot2 import instrument_calibration as subject
 from opentrons.hardware_control.instruments.ot3 import (
     instrument_calibration as subject_ot3,
 )
+
+SourceType = calibration_storage.types.SourceType
+CalibrationStatus = calibration_storage.types.CalibrationStatus
 
 
 @pytest.fixture(autouse=True)
@@ -41,6 +47,40 @@ def _use_mock_calibration_storage(
         calibration_storage_helpers, inspect.isfunction
     ):
         monkeypatch.setattr(calibration_storage_helpers, name, decoy.mock(func=func))
+
+    monkeypatch.setattr(
+        feature_flags,
+        "enable_ot3_hardware_controller",
+        decoy.mock(func=feature_flags.enable_ot3_hardware_controller),
+    )
+    monkeypatch.setattr(
+        calibration_storage.ot3.gripper_offset,
+        "get_gripper_jaw_width_data",
+        decoy.mock(
+            func=calibration_storage.ot3.gripper_offset.get_gripper_jaw_width_data
+        ),
+    )
+    monkeypatch.setattr(
+        calibration_storage.ot3.gripper_offset,
+        "get_gripper_calibration_offset",
+        decoy.mock(
+            func=calibration_storage.ot3.gripper_offset.get_gripper_calibration_offset
+        ),
+    )
+    monkeypatch.setattr(
+        calibration_storage.ot3.gripper_offset,
+        "save_gripper_jaw_width_data",
+        decoy.mock(
+            func=calibration_storage.ot3.gripper_offset.save_gripper_jaw_width_data
+        ),
+    )
+    monkeypatch.setattr(
+        calibration_storage.ot3.gripper_offset,
+        "save_gripper_calibration",
+        decoy.mock(
+            func=calibration_storage.ot3.gripper_offset.save_gripper_calibration
+        ),
+    )
 
 
 @pytest.fixture
@@ -152,3 +192,117 @@ def test_instrument_consistency_check_ot3(
             top_types.Mount.RIGHT: right,
         }
         assert result[0].limit == 4.0
+
+
+@pytest.mark.parametrize("gripper_id", ["phoney_baloney_gripper", None])
+@pytest.mark.parametrize("loaded_encoder_val", [14.44444])
+def test_load_gripper_jaw_width(
+    gripper_id: str | None, decoy: Decoy, loaded_encoder_val: float
+) -> None:
+    default_return_val = subject_ot3.GripperJawWidthData(
+        encoder_position_at_jaw_closed=None,
+        source=SourceType.default,
+        status=CalibrationStatus(),
+    )
+    _time = datetime.now()
+    loaded_data = ot3_models.GripperJawWidthModel(
+        encoderPositionAtJawClosed=loaded_encoder_val,
+        source=SourceType.default,
+        status=ot3_models.CalibrationStatus(),
+        lastModified=_time,
+    )
+    nondefault_return_val = subject_ot3.GripperJawWidthData(
+        encoder_position_at_jaw_closed=loaded_encoder_val,
+        source=SourceType.default,
+        status=CalibrationStatus(markedBad=False, source=None, markedAt=None),
+    )
+    decoy.when(feature_flags.enable_ot3_hardware_controller()).then_return(True)
+    decoy.when(
+        calibration_storage.ot3.gripper_offset.get_gripper_jaw_width_data(
+            "phoney_baloney_gripper"
+        )
+    ).then_return(loaded_data)
+    gripper_jaw_width = subject_ot3.load_gripper_jaw_width(gripper_id=gripper_id)
+    if gripper_id is None:
+        assert gripper_jaw_width == default_return_val
+    else:
+        if loaded_encoder_val is None:
+            assert gripper_jaw_width == default_return_val
+        else:
+            assert gripper_jaw_width == nondefault_return_val
+
+
+@pytest.mark.parametrize("gripper_id", ["phoney_baloney_gripper", None])
+@pytest.mark.parametrize(
+    "loaded_offset", [top_types.Point(0.1, -3.2, 1.5), top_types.Point(0, 0, 0)]
+)
+def test_load_gripper_calibration_offset(
+    gripper_id: str | None, decoy: Decoy, loaded_offset: top_types.Point
+) -> None:
+    _time = datetime.now()
+    default_return_val = subject_ot3.GripperCalibrationOffset(
+        offset=top_types.Point(x=0.0, y=0.0, z=0.0),
+        source=SourceType.default,
+        status=CalibrationStatus(markedBad=False, source=None, markedAt=None),
+        last_modified=None,
+    )
+    nondefault_return_val = subject_ot3.GripperCalibrationOffset(
+        offset=loaded_offset,
+        source=SourceType.default,
+        status=CalibrationStatus(markedBad=False, source=None, markedAt=None),
+        last_modified=_time,
+    )
+
+    loaded_data = ot3_models.InstrumentOffsetModel(
+        offset=loaded_offset,
+        lastModified=_time,
+        source=SourceType.default,
+        status=ot3_models.CalibrationStatus(),
+    )
+    decoy.when(feature_flags.enable_ot3_hardware_controller()).then_return(True)
+    decoy.when(
+        calibration_storage.ot3.gripper_offset.get_gripper_calibration_offset(
+            "phoney_baloney_gripper"
+        )
+    ).then_return(loaded_data)
+    gripper_offset = subject_ot3.load_gripper_calibration_offset(gripper_id=gripper_id)
+    if gripper_id is None:
+        assert gripper_offset == default_return_val
+    else:
+        if loaded_offset is None:
+            assert gripper_offset == default_return_val
+        else:
+            assert gripper_offset == nondefault_return_val
+
+
+@pytest.mark.parametrize("gripper_id", ["phoney_baloney_gripper", None])
+@pytest.mark.parametrize("encoder_val", [14.44444])
+def test_save_gripper_jaw_width_data(
+    gripper_id: str | None, decoy: Decoy, encoder_val: float
+) -> None:
+    decoy.when(feature_flags.enable_ot3_hardware_controller()).then_return(True)
+    subject_ot3.save_gripper_jaw_width_data(
+        gripper_id=gripper_id, encoder_position_at_closed=encoder_val
+    )
+    decoy.verify(
+        calibration_storage.ot3.gripper_offset.save_gripper_jaw_width_data(
+            encoder_position_at_jaw_closed=encoder_val,
+            gripper_id="phoney_baloney_gripper",
+        ),
+        times=1 if gripper_id is not None else 0,
+    )
+
+
+@pytest.mark.parametrize("gripper_id", ["phoney_baloney_gripper", None])
+@pytest.mark.parametrize("delta", [top_types.Point(x=1, y=2, z=3)])
+def test_save_gripper_calibration_offset(
+    gripper_id: str | None, decoy: Decoy, delta: top_types.Point
+) -> None:
+    decoy.when(feature_flags.enable_ot3_hardware_controller()).then_return(True)
+    subject_ot3.save_gripper_calibration_offset(gripper_id=gripper_id, delta=delta)
+    decoy.verify(
+        calibration_storage.ot3.gripper_offset.save_gripper_calibration(
+            delta, "phoney_baloney_gripper"
+        ),
+        times=1 if gripper_id is not None else 0,
+    )

--- a/api/tests/opentrons/hardware_control/test_gripper.py
+++ b/api/tests/opentrons/hardware_control/test_gripper.py
@@ -136,7 +136,6 @@ def test_reload_instrument_cal_ot3(fake_offset: GripperCalibrationOffset) -> Non
         fake_gripper_conf,
         fake_offset,
         "fakeid123",
-        jaw_max_offset=15,
     )
     # if only calibration is changed
     new_cal = instrument_calibration.GripperCalibrationOffset(
@@ -164,7 +163,6 @@ def test_reload_instrument_cal_ot3_conf_changed(
         fake_gripper_conf,
         fake_offset,
         "fakeid123",
-        jaw_max_offset=15,
     )
     new_conf = fake_gripper_conf.model_copy(
         update={

--- a/api/tests/opentrons/hardware_control/test_gripper.py
+++ b/api/tests/opentrons/hardware_control/test_gripper.py
@@ -1,5 +1,7 @@
-from typing import Optional, Callable, TYPE_CHECKING
+from typing import Optional, Callable
 import pytest
+from unittest import mock
+from datetime import datetime
 
 from opentrons.types import Point
 from opentrons.calibration_storage import types as cal_types
@@ -9,26 +11,29 @@ from opentrons.config import gripper_config
 from opentrons_shared_data.gripper import GripperModel
 from opentrons_shared_data.errors.exceptions import MotionFailedError
 
-if TYPE_CHECKING:
-    from opentrons.hardware_control.instruments.ot3.instrument_calibration import (
-        GripperCalibrationOffset,
-    )
+from opentrons.hardware_control.instruments.ot3.instrument_calibration import (
+    GripperCalibrationOffset,
+    GripperJawWidthData,
+)
 
 fake_gripper_conf = gripper_config.load(GripperModel.v1)
 
 
 @pytest.mark.ot3_only
 @pytest.fixture
-def fake_offset() -> "GripperCalibrationOffset":
-    from opentrons.hardware_control.instruments.ot3.instrument_calibration import (
-        load_gripper_calibration_offset,
-    )
+def fake_offset() -> GripperCalibrationOffset:
 
-    return load_gripper_calibration_offset("fakeid123")
+    return instrument_calibration.load_gripper_calibration_offset("fakeid123")
 
 
 @pytest.mark.ot3_only
-def test_id_get_added_to_dict(fake_offset: "GripperCalibrationOffset") -> None:
+@pytest.fixture
+def fake_jaw_cal() -> GripperJawWidthData:
+    return instrument_calibration.load_gripper_jaw_width("fakeid123")
+
+
+@pytest.mark.ot3_only
+def test_id_get_added_to_dict(fake_offset: GripperCalibrationOffset) -> None:
     gripr = gripper.Gripper(fake_gripper_conf, fake_offset, "fakeid123")
     assert gripr.as_dict()["gripper_id"] == "fakeid123"
 
@@ -53,14 +58,14 @@ def test_id_get_added_to_dict(fake_offset: "GripperCalibrationOffset") -> None:
 def test_critical_point(
     override: Optional[CriticalPoint],
     result_accessor: Callable[[gripper.Gripper], Point],
-    fake_offset: "GripperCalibrationOffset",
+    fake_offset: GripperCalibrationOffset,
 ) -> None:
     gripr = gripper.Gripper(fake_gripper_conf, fake_offset, "fakeid123")
     assert gripr.critical_point(override) == result_accessor(gripr)
 
 
 @pytest.mark.ot3_only
-def test_load_gripper_cal_offset(fake_offset: "GripperCalibrationOffset") -> None:
+def test_load_gripper_cal_offset(fake_offset: GripperCalibrationOffset) -> None:
     gripr = gripper.Gripper(fake_gripper_conf, fake_offset, "fakeid123")
     # if offset data do not exist, loaded values should match DEFAULT
     assert gripr._calibration_offset.offset == Point(
@@ -68,8 +73,68 @@ def test_load_gripper_cal_offset(fake_offset: "GripperCalibrationOffset") -> Non
     )
 
 
+# need a test for update_open_position_from_closed_position
+
+
 @pytest.mark.ot3_only
-def test_reload_instrument_cal_ot3(fake_offset: "GripperCalibrationOffset") -> None:
+def test_gripper_default_jaw_width_calibration(
+    fake_jaw_cal: GripperJawWidthData,
+    fake_offset: GripperCalibrationOffset,
+) -> None:
+    gripr = gripper.Gripper(fake_gripper_conf, fake_offset, "fakeid123")
+    assert gripr._jaw_max_offset is None
+    assert gripr._encoder_position_at_jaw_closed is None
+
+
+@pytest.mark.parametrize("loaded_encoder_pos", [24.4, None])
+@pytest.mark.parametrize("existing_encoder_pos", [24.4, None])
+@pytest.mark.ot3_only
+def test_gripper_has_jaw_width_calibration(
+    fake_jaw_cal: GripperJawWidthData,
+    fake_offset: GripperCalibrationOffset,
+    loaded_encoder_pos: float,
+    existing_encoder_pos: float,
+) -> None:
+
+    gripr = gripper.Gripper(fake_gripper_conf, fake_offset, "fakeid123")
+    gripr._encoder_position_at_jaw_closed = existing_encoder_pos
+    with mock.patch(
+        "opentrons.hardware_control.instruments.ot3.gripper.load_gripper_jaw_width",
+        return_value=GripperJawWidthData(
+            source=fake_jaw_cal.source,
+            status=fake_jaw_cal.status,
+            encoder_position_at_jaw_closed=loaded_encoder_pos,
+            last_modified=datetime.now(),
+        ),
+        autospec=True,
+    ) as fake_load_jaw_width:
+        has_cal = gripr.has_jaw_width_calibration
+        mock_save_gripper_jaw_width_data = mock.Mock()
+        mock.patch(
+            "opentrons.hardware_control.instruments.ot3.gripper.save_gripper_jaw_width_data",
+            return_value=mock_save_gripper_jaw_width_data(),
+        )
+        # if gripper._encoder_position_at_jaw_closed has no value:
+        if existing_encoder_pos is None:
+            # gripper should try to load jaw width from the robot fs
+            fake_load_jaw_width.assert_called_once()
+            if loaded_encoder_pos is None:
+                assert has_cal is False
+            else:
+                # if robot fs has gripper jaw width data,
+                # it should get saved to the gripper object and has_cal return true
+                mock_save_gripper_jaw_width_data.assert_called_once()
+                assert has_cal is True
+        # if gripper._encoder_position_at_jaw_closed has a value:
+        else:
+            # gripper doesn't try to load from the robot and returns true
+            fake_load_jaw_width.assert_not_called()
+            assert has_cal is True
+            mock_save_gripper_jaw_width_data.assert_called_once()
+
+
+@pytest.mark.ot3_only
+def test_reload_instrument_cal_ot3(fake_offset: GripperCalibrationOffset) -> None:
     old_gripper = gripper.Gripper(
         fake_gripper_conf,
         fake_offset,
@@ -96,7 +161,7 @@ def test_reload_instrument_cal_ot3(fake_offset: "GripperCalibrationOffset") -> N
 
 @pytest.mark.ot3_only
 def test_reload_instrument_cal_ot3_conf_changed(
-    fake_offset: "GripperCalibrationOffset",
+    fake_offset: GripperCalibrationOffset,
 ) -> None:
     old_gripper = gripper.Gripper(
         fake_gripper_conf,

--- a/api/tests/opentrons/hardware_control/test_gripper.py
+++ b/api/tests/opentrons/hardware_control/test_gripper.py
@@ -73,9 +73,6 @@ def test_load_gripper_cal_offset(fake_offset: GripperCalibrationOffset) -> None:
     )
 
 
-# need a test for update_open_position_from_closed_position
-
-
 @pytest.mark.ot3_only
 def test_gripper_default_jaw_width_calibration(
     fake_jaw_cal: GripperJawWidthData,

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -39,6 +39,7 @@ from opentrons.hardware_control.instruments.ot3.gripper_handler import GripperHa
 from opentrons.hardware_control.instruments.ot3.instrument_calibration import (
     GripperCalibrationOffset,
     PipetteOffsetByPipetteMount,
+    GripperJawWidthData
 )
 from opentrons.hardware_control.instruments.ot3.pipette_handler import (
     OT3PipetteHandler,
@@ -1602,44 +1603,56 @@ async def test_gripper_action_works_with_gripper(
     gripper = managed_obj._gripper_handler._gripper
     assert gripper
     calibration_offset = 5
-    gripper._jaw_max_offset = None if needs_calibration else calibration_offset
-    await ot3_hardware.home_gripper_jaw()
-    if needs_calibration:
-        assert mock_ungrip.call_count == 2
-        mock_grip.assert_called_once()
-    else:
+    with patch(
+        "opentrons.hardware_control.instruments.ot3.gripper.load_gripper_jaw_width",
+        return_value=GripperJawWidthData(
+            source=SourceType.default,
+            status=CalibrationStatus(),
+            encoder_position_at_jaw_closed=None if needs_calibration else 16.555,
+            last_modified=None,
+        ),
+        autospec=True,
+    ):
+        gripper._jaw_max_offset = None if needs_calibration else calibration_offset
+        gripper._encoder_position_at_jaw_closed = None if needs_calibration else 18.5
+        await ot3_hardware.home_gripper_jaw()
+        if needs_calibration:
+            assert mock_ungrip.call_count == 2
+            mock_grip.assert_called_once()
+        else:
+            mock_ungrip.assert_called_once()
+        mock_ungrip.reset_mock()
+        mock_grip.reset_mock()
+        gripper._jaw_max_offset = None if needs_calibration else 5
+        gripper._encoder_position_at_jaw_closed = None if needs_calibration else 18.5
+        await ot3_hardware.home([Axis.G])
+        if needs_calibration:
+            assert mock_ungrip.call_count == 2
+            mock_grip.assert_called_once()
+        else:
+            mock_ungrip.assert_called_once()
+
+        mock_grip.reset_mock()
+        mock_ungrip.reset_mock()
+        await ot3_hardware.grip(5.0)
+        expected_displacement = 16.0
+        if not needs_calibration:
+            expected_displacement += calibration_offset / 2
+        mock_grip.assert_called_once_with(
+            duty_cycle=gc.duty_cycle_by_force(5.0, gripper_config.grip_force_profile),
+            expected_displacement=expected_displacement,
+            stay_engaged=True,
+        )
+
+        await ot3_hardware.ungrip()
         mock_ungrip.assert_called_once()
-    mock_ungrip.reset_mock()
-    mock_grip.reset_mock()
-    gripper._jaw_max_offset = None if needs_calibration else 5
-    await ot3_hardware.home([Axis.G])
-    if needs_calibration:
-        assert mock_ungrip.call_count == 2
-        mock_grip.assert_called_once()
-    else:
-        mock_ungrip.assert_called_once()
 
-    mock_grip.reset_mock()
-    mock_ungrip.reset_mock()
-    await ot3_hardware.grip(5.0)
-    expected_displacement = 16.0
-    if not needs_calibration:
-        expected_displacement += calibration_offset / 2
-    mock_grip.assert_called_once_with(
-        duty_cycle=gc.duty_cycle_by_force(5.0, gripper_config.grip_force_profile),
-        expected_displacement=expected_displacement,
-        stay_engaged=True,
-    )
+        with pytest.raises(ValueError, match="Setting gripper jaw width out of bounds"):
+            await ot3_hardware.hold_jaw_width(200)
+        mock_hold_jaw_width.reset_mock()
 
-    await ot3_hardware.ungrip()
-    mock_ungrip.assert_called_once()
-
-    with pytest.raises(ValueError, match="Setting gripper jaw width out of bounds"):
-        await ot3_hardware.hold_jaw_width(200)
-    mock_hold_jaw_width.reset_mock()
-
-    await ot3_hardware.hold_jaw_width(80)
-    mock_hold_jaw_width.assert_called_once()
+        await ot3_hardware.hold_jaw_width(80)
+        mock_hold_jaw_width.assert_called_once()
 
 
 async def test_gripper_move_fails_with_no_gripper(

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -1616,7 +1616,6 @@ async def test_gripper_action_works_with_gripper(
         ),
         autospec=True,
     ):
-        gripper._jaw_max_offset = None if needs_calibration else calibration_offset
         gripper._encoder_position_at_jaw_closed = (
             None if needs_calibration else fake_jaw_encoder_val
         )
@@ -1628,7 +1627,6 @@ async def test_gripper_action_works_with_gripper(
             mock_ungrip.assert_called_once()
         mock_ungrip.reset_mock()
         mock_grip.reset_mock()
-        gripper._jaw_max_offset = None if needs_calibration else 5
         gripper._encoder_position_at_jaw_closed = (
             None if needs_calibration else fake_jaw_encoder_val
         )
@@ -1666,7 +1664,6 @@ async def test_gripper_action_works_with_gripper(
         # specified
         mock_ungrip.reset_mock()
         mock_grip.reset_mock()
-        gripper._jaw_max_offset = None if needs_calibration else 5
         gripper._encoder_position_at_jaw_closed = (
             None if needs_calibration else fake_jaw_encoder_val
         )

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -1661,6 +1661,19 @@ async def test_gripper_action_works_with_gripper(
         await ot3_hardware.hold_jaw_width(80)
         mock_hold_jaw_width.assert_called_once()
 
+        # test that recalibrate_jaw_width works regardless of
+        # gripper jaw width values if recalibrate_jaw_width is
+        # specified
+        mock_ungrip.reset_mock()
+        mock_grip.reset_mock()
+        gripper._jaw_max_offset = None if needs_calibration else 5
+        gripper._encoder_position_at_jaw_closed = (
+            None if needs_calibration else fake_jaw_encoder_val
+        )
+        await ot3_hardware.home_gripper_jaw(recalibrate_jaw_width=True)
+        assert mock_ungrip.call_count == 2
+        mock_grip.assert_called_once()
+
 
 async def test_gripper_move_fails_with_no_gripper(
     ot3_hardware: ThreadManager[OT3API],

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -39,7 +39,7 @@ from opentrons.hardware_control.instruments.ot3.gripper_handler import GripperHa
 from opentrons.hardware_control.instruments.ot3.instrument_calibration import (
     GripperCalibrationOffset,
     PipetteOffsetByPipetteMount,
-    GripperJawWidthData
+    GripperJawWidthData,
 )
 from opentrons.hardware_control.instruments.ot3.pipette_handler import (
     OT3PipetteHandler,
@@ -1603,18 +1603,23 @@ async def test_gripper_action_works_with_gripper(
     gripper = managed_obj._gripper_handler._gripper
     assert gripper
     calibration_offset = 5
+    fake_jaw_encoder_val = 18.5
     with patch(
         "opentrons.hardware_control.instruments.ot3.gripper.load_gripper_jaw_width",
         return_value=GripperJawWidthData(
             source=SourceType.default,
             status=CalibrationStatus(),
-            encoder_position_at_jaw_closed=None if needs_calibration else 16.555,
+            encoder_position_at_jaw_closed=None
+            if needs_calibration
+            else fake_jaw_encoder_val,
             last_modified=None,
         ),
         autospec=True,
     ):
         gripper._jaw_max_offset = None if needs_calibration else calibration_offset
-        gripper._encoder_position_at_jaw_closed = None if needs_calibration else 18.5
+        gripper._encoder_position_at_jaw_closed = (
+            None if needs_calibration else fake_jaw_encoder_val
+        )
         await ot3_hardware.home_gripper_jaw()
         if needs_calibration:
             assert mock_ungrip.call_count == 2
@@ -1624,7 +1629,9 @@ async def test_gripper_action_works_with_gripper(
         mock_ungrip.reset_mock()
         mock_grip.reset_mock()
         gripper._jaw_max_offset = None if needs_calibration else 5
-        gripper._encoder_position_at_jaw_closed = None if needs_calibration else 18.5
+        gripper._encoder_position_at_jaw_closed = (
+            None if needs_calibration else fake_jaw_encoder_val
+        )
         await ot3_hardware.home([Axis.G])
         if needs_calibration:
             assert mock_ungrip.call_count == 2

--- a/shared-data/python/pyproject.toml
+++ b/shared-data/python/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta:__legacy__"

--- a/shared-data/python/pyproject.toml
+++ b/shared-data/python/pyproject.toml
@@ -1,3 +1,0 @@
-[build-system]
-requires = ["setuptools", "wheel"]
-build-backend = "setuptools.build_meta:__legacy__"


### PR DESCRIPTION
## Overview
Gripper speedup alert [💀 ](https://emojis.wiki/skull/)🚨[ 🚧 ](https://emojis.wiki/construction/)⚠️

Due to mechanical tolerances in the 'grip' axis on the robot, each individual gripper needs to run a calibration routine in order to determine its max width and be able to establish position tracking. This routine has the gripper jaw open all the way until the limit switch is triggered, and then close all the way. The software assumes that the distance between the two gripper paddles is 60mm when closed. It then uses the encoder value at the position the gripper is found to be closed to calculate the max jaw width of the specific gripper that's on the robot. 

The problem is that this value lives in the hardware controller, and therefore is wiped from existence any time `OT3API` is reset. We can reduce the number of times this routine happens by storing the gripper jaw calibration result to the robot file system and looking it up, if the gripper doesn't already have it. 

## Changelog

- create a new file that will live adjacent to gripper z-calibration called `gripper_jaw_width_data`. This will store the encoder value at the gripper's closed position
- add handlers to store and access this the same way that regular gripper calibration data is handled
- in `Gripper::has_jaw_width_calibration`, look for data in this file, and return true + update the `Gripper` instance at hand if it's there
- clear the jaw width data files on the robot in the same way that's done for existing gripper calibration

## Testing
- [x] some unit tests
- [x] the robot populates `/data/robot` with a `gripper_jaw_width_data` folder and also data files if not already present
- [x] if gripper calibration runs, jaw width calibration runs again and unconditionally updates the file on the robot
- [x] at the start of a protocol, the gipper doesn't grip and ungrip if this data is present on the robot fs, and does if that data is not there