### PR TITLE
fix(protocol-designer): create_deck_fixture step form reducer to prop…

### DIFF
--- a/protocol-designer/src/step-forms/reducers/index.ts
+++ b/protocol-designer/src/step-forms/reducers/index.ts
@@ -377,39 +377,33 @@ export const savedStepForms = (
       const prevInitialDeckSetupStep =
         savedStepForms[INITIAL_DECK_SETUP_STEP_ID]
       const locationUpdate = `${name}LocationUpdate`
-      return mapValues(
-        savedStepForms,
-        (form: FormData): FormData => {
-          if (form.stepType === 'manualIntervention') {
-            return {
-              ...form,
-              [INITIAL_DECK_SETUP_STEP_ID]: {
-                ...prevInitialDeckSetupStep,
-                [locationUpdate]: {
-                  ...prevInitialDeckSetupStep[locationUpdate],
-                  [id]: location,
-                },
-              },
-            }
-          } else if (
-            form.dropTip_location == null &&
-            (name === 'trashBin' || name === 'wasteChute')
-          ) {
-            return {
-              ...form,
-              ...handleFormChange(
-                {
-                  dropTip_location: id,
-                },
-                form,
-                _getPipetteEntitiesRootState(rootState),
-                _getLabwareEntitiesRootState(rootState)
-              ),
-            }
+      return mapValues(savedStepForms, (savedForm: FormData, formId) => {
+        if (formId === INITIAL_DECK_SETUP_STEP_ID) {
+          return {
+            ...prevInitialDeckSetupStep,
+            [locationUpdate]: {
+              ...prevInitialDeckSetupStep[locationUpdate],
+              [id]: location,
+            },
           }
-          return form
+        } else if (
+          savedForm.dropTip_location == null &&
+          (name === 'trashBin' || name === 'wasteChute')
+        ) {
+          return {
+            ...savedForm,
+            ...handleFormChange(
+              {
+                dropTip_location: id,
+              },
+              savedForm,
+              _getPipetteEntitiesRootState(rootState),
+              _getLabwareEntitiesRootState(rootState)
+            ),
+          }
         }
-      )
+        return savedForm
+      })
     }
     case 'DELETE_DECK_FIXTURE': {
       const { id } = action.payload


### PR DESCRIPTION
…erly populate trash

closes RQA-4249

# Overview

The logic to fix a different bug caused this bug! the reducer is now correctly populating the `-LocationUpdates` for trash bin and waste chute and staging area

## Test Plan and Hands on Testing

Create a protocol with no steps. export. re-import. see that the trash bin persists.

## Changelog

- fix logic for populating the fields in the reducer when adding a deck fixture

## Risk assessment

low
