### PR TITLE
fix(protocol-designer): allow moving labware on top of adapters

### DIFF
--- a/components/src/atoms/ListButton/ListButton.stories.tsx
+++ b/components/src/atoms/ListButton/ListButton.stories.tsx
@@ -58,6 +58,7 @@ const Template = (args: ListButtonComponentProps): JSX.Element => {
         <ListButtonAccordionContainer id="mainAccordionContainer">
           <>
             <CustomizeExpandButton
+              enableStackingFF={false}
               key="buttonNested"
               allowInputField={false}
               loadName="mockloadname0"
@@ -80,6 +81,7 @@ const Template = (args: ListButtonComponentProps): JSX.Element => {
                 >
                   <>
                     <CustomizeExpandButton
+                      enableStackingFF={false}
                       allowInputField={false}
                       loadName="mockloadname1"
                       isSelected={nestedButtonValue === 'radio button1'}
@@ -96,6 +98,7 @@ const Template = (args: ListButtonComponentProps): JSX.Element => {
                     ) : null}
                   </>
                   <CustomizeExpandButton
+                    enableStackingFF={false}
                     allowInputField={false}
                     loadName="mockloadname2"
                     isSelected={nestedButtonValue === 'radio button2'}
@@ -106,6 +109,7 @@ const Template = (args: ListButtonComponentProps): JSX.Element => {
                     }}
                   />
                   <CustomizeExpandButton
+                    enableStackingFF={false}
                     allowInputField={false}
                     loadName="mockloadname3"
                     isSelected={nestedButtonValue === 'radio button3'}
@@ -121,6 +125,7 @@ const Template = (args: ListButtonComponentProps): JSX.Element => {
           </>
           <>
             <CustomizeExpandButton
+              enableStackingFF={false}
               key="buttonNonNested"
               allowInputField={false}
               loadName="mockloadname4"

--- a/components/src/molecules/CustomizeExpandButton/__tests__/CustomizeExpandButton.test.tsx
+++ b/components/src/molecules/CustomizeExpandButton/__tests__/CustomizeExpandButton.test.tsx
@@ -26,6 +26,7 @@ describe('CustomizeExpandButton', () => {
 
   beforeEach(() => {
     props = {
+      enableStackingFF: true,
       buttonText: 'mock text',
       buttonValue: 'mockValue',
       onChange: vi.fn(),

--- a/components/src/molecules/CustomizeExpandButton/index.tsx
+++ b/components/src/molecules/CustomizeExpandButton/index.tsx
@@ -25,6 +25,7 @@ export interface StackingProps {
 }
 
 interface CustomizeExpandButtonProps extends StyleProps {
+  enableStackingFF: boolean
   allowInputField: boolean
   loadName: string
   buttonText: string
@@ -50,6 +51,7 @@ export function CustomizeExpandButton(
     stackingProps,
     allowInputField,
     loadName,
+    enableStackingFF,
   } = props
   const isLid =
     stackingProps != null &&
@@ -85,7 +87,7 @@ export function CustomizeExpandButton(
           <StyledText desktopStyle="bodyDefaultRegular">
             {buttonText}
           </StyledText>
-          {stackingProps != null && isSelected ? (
+          {stackingProps != null && enableStackingFF && isSelected ? (
             <Flex
               flexDirection={DIRECTION_COLUMN}
               backgroundColor={COLORS.blue10}

--- a/protocol-designer/src/components/organisms/SelectLabwareModal/index.tsx
+++ b/protocol-designer/src/components/organisms/SelectLabwareModal/index.tsx
@@ -432,6 +432,7 @@ export function SelectLabwareModal(
                   {filteredLabwareByCategory[CUSTOM_CATEGORY].map(
                     ({ uri }, index) => (
                       <CustomizeExpandButton
+                        enableStackingFF={enableStacking}
                         loadName={customLabwareDefs[uri].parameters.loadName}
                         allowInputField={onFlexStacker}
                         key={`${index}_${uri}`}
@@ -537,6 +538,7 @@ export function SelectLabwareModal(
                                   key={`${index}_${category}_${loadName}`}
                                 >
                                   <CustomizeExpandButton
+                                    enableStackingFF={enableStacking}
                                     loadName={loadName}
                                     allowInputField={
                                       onFlexStacker ||
@@ -611,6 +613,9 @@ export function SelectLabwareModal(
                                                     defs[tiprackDefUri]
                                                   return (
                                                     <CustomizeExpandButton
+                                                      enableStackingFF={
+                                                        enableStacking
+                                                      }
                                                       loadName={loadName}
                                                       allowInputField={false}
                                                       key={`${index}_${category}_${loadName}_${tiprackDefUri}`}
@@ -665,6 +670,30 @@ export function SelectLabwareModal(
                                                     null && slot !== 'offDeck'
                                                     ? {
                                                         ...stackingPropsShared,
+                                                        checkboxCaption: t(
+                                                          'with_lid',
+                                                          {
+                                                            name:
+                                                              defs[
+                                                                stackingLabwareDefUri
+                                                              ].metadata
+                                                                .displayName,
+                                                          }
+                                                        ),
+                                                        checked:
+                                                          selectedLidLabware !=
+                                                          null,
+                                                        onCheckboxChange: () => {
+                                                          dispatch(
+                                                            selectLid({
+                                                              labwareDefURI:
+                                                                selectedLidLabware ===
+                                                                stackingLabwareDefUri
+                                                                  ? null
+                                                                  : stackingLabwareDefUri,
+                                                            })
+                                                          )
+                                                        },
                                                         inputCaption: t(
                                                           'valid_range',
                                                           {
@@ -700,6 +729,9 @@ export function SelectLabwareModal(
 
                                                 return (
                                                   <CustomizeExpandButton
+                                                    enableStackingFF={
+                                                      enableStacking
+                                                    }
                                                     loadName={
                                                       nestedDef.parameters
                                                         .loadName

--- a/protocol-designer/src/top-selectors/labware-locations/index.ts
+++ b/protocol-designer/src/top-selectors/labware-locations/index.ts
@@ -18,6 +18,7 @@ import {
 } from '@opentrons/shared-data'
 import {
   COLUMN_4_SLOTS,
+  getSlotInLocationStack,
   getTopLocationInStack,
 } from '@opentrons/step-generation'
 
@@ -185,11 +186,19 @@ export const getUnoccupiedLabwareLocationOptions: Selector<
 
     const unoccupiedAdapterOptions = Object.entries(labware).reduce<Option[]>(
       (acc, [labwareId, labwareOnDeck]) => {
-        const labwareOnAdapter = Object.values(labware).find(
-          temporalProperties =>
-            getTopLocationInStack(temporalProperties.stack) === labwareId
+        const hasLabwareAboveAdapter = Object.values(labware).reduce(
+          (acc, temporalProperties) => {
+            if (temporalProperties.stack.includes(labwareId)) {
+              const topId = getTopLocationInStack(temporalProperties.stack)
+              if (topId !== labwareId) {
+                return true
+              }
+            }
+            return acc
+          },
+          false
         )
-        const adapterSlot = getTopLocationInStack(labwareOnDeck.stack)
+        const adapterSlot = getSlotInLocationStack(labwareOnDeck.stack)
         const modIdWithAdapter = Object.keys(modules).find(modId =>
           labwareOnDeck.stack.includes(modId)
         )
@@ -204,7 +213,8 @@ export const getUnoccupiedLabwareLocationOptions: Selector<
             : 'unknown module'
         const moduleSlotInfo = modSlot ?? 'unknown slot'
         const adapterSlotInfo = adapterSlot ?? 'unknown adapter'
-        return labwareOnAdapter == null && isAdapter
+
+        return isAdapter && !hasLabwareAboveAdapter
           ? [
               ...acc,
               {
@@ -223,7 +233,7 @@ export const getUnoccupiedLabwareLocationOptions: Selector<
     const unoccupiedModuleOptions = Object.entries(modules).reduce<Option[]>(
       (acc, [modId, modOnDeck]) => {
         const moduleHasLabware = Object.entries(labware).some(
-          ([_, lwOnDeck]) => lwOnDeck.stack[0] === modId
+          ([_, lwOnDeck]) => lwOnDeck.stack[lwOnDeck.stack.length - 2] === modId
         )
         const type = moduleEntities[modId].type
         const slot = modOnDeck.slot

--- a/protocol-designer/src/top-selectors/labware-locations/index.ts
+++ b/protocol-designer/src/top-selectors/labware-locations/index.ts
@@ -186,17 +186,10 @@ export const getUnoccupiedLabwareLocationOptions: Selector<
 
     const unoccupiedAdapterOptions = Object.entries(labware).reduce<Option[]>(
       (acc, [labwareId, labwareOnDeck]) => {
-        const hasLabwareAboveAdapter = Object.values(labware).reduce(
-          (acc, temporalProperties) => {
-            if (temporalProperties.stack.includes(labwareId)) {
-              const topId = getTopLocationInStack(temporalProperties.stack)
-              if (topId !== labwareId) {
-                return true
-              }
-            }
-            return acc
-          },
-          false
+        const hasLabwareAboveAdapter = Object.values(labware).some(
+          ({ stack }) =>
+            stack.includes(labwareId) &&
+            getTopLocationInStack(stack) !== labwareId
         )
         const adapterSlot = getSlotInLocationStack(labwareOnDeck.stack)
         const modIdWithAdapter = Object.keys(modules).find(modId =>


### PR DESCRIPTION
closes RQA-4247

# Overview

This PR fixes a bug where you couldn't move a labware onto an adapter and also removes the checkbox for adding a TC lid to a labware on an adapter in the select labware modal

## Test Plan and Hands on Testing

Upload the attached protocol and try to move the tough plate to the adapter on the temperature module and see that it moves correctly.

Also, if you try to add the 96-well aluminum block on a temperature module with a 96 well plate during deck setup, you shouldn't see the checkbox option to add the TC lid when the stacking capabilities FF is turned off.

[untitled (100).json](https://github.com/user-attachments/files/20616808/untitled.100.json)

## Changelog

- fix logic for showing stacking capabilities and for moving labware on to adapters

## Risk assessment

low
