### PR TITLE
refactor(api): rename liquid class API methods

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/protocol.py
+++ b/api/src/opentrons/protocol_api/core/engine/protocol.py
@@ -1095,7 +1095,7 @@ class ProtocolCore(
         )
 
     def get_liquid_class(self, name: str, version: int) -> LiquidClass:
-        """Define a liquid class for use in transfer functions."""
+        """Fetch a liquid class for use in transfer functions."""
         try:
             # Check if we have already loaded this liquid class' definition
             liquid_class_def = self._liquid_class_def_cache[(name, version)]

--- a/api/src/opentrons/protocol_api/core/engine/protocol.py
+++ b/api/src/opentrons/protocol_api/core/engine/protocol.py
@@ -1095,7 +1095,7 @@ class ProtocolCore(
         )
 
     def get_liquid_class(self, name: str, version: int) -> LiquidClass:
-        """Fetch a liquid class for use in transfer functions."""
+        """Get an instance of a built-in liquid class."""
         try:
             # Check if we have already loaded this liquid class' definition
             liquid_class_def = self._liquid_class_def_cache[(name, version)]

--- a/api/src/opentrons/protocol_api/core/engine/protocol.py
+++ b/api/src/opentrons/protocol_api/core/engine/protocol.py
@@ -1094,7 +1094,7 @@ class ProtocolCore(
             display_color=(liquid.displayColor.root if liquid.displayColor else None),
         )
 
-    def define_liquid_class(self, name: str, version: int) -> LiquidClass:
+    def get_liquid_class(self, name: str, version: int) -> LiquidClass:
         """Define a liquid class for use in transfer functions."""
         try:
             # Check if we have already loaded this liquid class' definition

--- a/api/src/opentrons/protocol_api/core/legacy/legacy_protocol_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy/legacy_protocol_core.py
@@ -600,7 +600,7 @@ class LegacyProtocolCore(
         assert False, "define_liquid only supported on engine core"
 
     def get_liquid_class(self, name: str, version: int) -> LiquidClass:
-        """Define a liquid class."""
+        """Get an instance of a built-in liquid class."""
         assert False, "define_liquid_class is only supported on engine core"
 
     def get_labware_location(

--- a/api/src/opentrons/protocol_api/core/legacy/legacy_protocol_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy/legacy_protocol_core.py
@@ -599,7 +599,7 @@ class LegacyProtocolCore(
         """Define a liquid to load into a well."""
         assert False, "define_liquid only supported on engine core"
 
-    def define_liquid_class(self, name: str, version: int) -> LiquidClass:
+    def get_liquid_class(self, name: str, version: int) -> LiquidClass:
         """Define a liquid class."""
         assert False, "define_liquid_class is only supported on engine core"
 

--- a/api/src/opentrons/protocol_api/core/protocol.py
+++ b/api/src/opentrons/protocol_api/core/protocol.py
@@ -311,8 +311,8 @@ class AbstractProtocol(
         """Define a liquid to load into a well."""
 
     @abstractmethod
-    def define_liquid_class(self, name: str, version: int) -> LiquidClass:
-        """Define a liquid class for use in transfer functions."""
+    def get_liquid_class(self, name: str, version: int) -> LiquidClass:
+        """Return a liquid class for use in transfer functions."""
 
     @abstractmethod
     def get_labware_location(

--- a/api/src/opentrons/protocol_api/core/protocol.py
+++ b/api/src/opentrons/protocol_api/core/protocol.py
@@ -312,7 +312,7 @@ class AbstractProtocol(
 
     @abstractmethod
     def get_liquid_class(self, name: str, version: int) -> LiquidClass:
-        """Return a liquid class for use in transfer functions."""
+        """Get an instance of a built-in liquid class."""
 
     @abstractmethod
     def get_labware_location(

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -1377,7 +1377,7 @@ class ProtocolContext(CommandPublisher):
         name: str,
     ) -> LiquidClass:
         """
-        Get a liquid class instance for use in the protocol.
+        Get an instance of a built-in liquid class for use in the protocol.
 
         Args:
             name: Name of an Opentrons-defined liquid class.

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -1371,19 +1371,21 @@ class ProtocolContext(CommandPublisher):
             display_color=display_color,
         )
 
-    @requires_version(2, 23)
+    @requires_version(2, 24)
     def get_liquid_class(
         self,
         name: str,
     ) -> LiquidClass:
         """
         Get a liquid class instance for use in the protocol.
-        ..
-            This is intended for Opentrons internal use only and is not a guaranteed API.
 
-        :meta private:
+        Args:
+            name: Name of an Opentrons-defined liquid class.
+
+        Raises:
+            LiquidClassDefinitionDoesNotExist: if the specified liquid class does not exist.
         """
-        return self._core.define_liquid_class(name=name, version=DEFAULT_LC_VERSION)
+        return self._core.get_liquid_class(name=name, version=DEFAULT_LC_VERSION)
 
     @requires_version(2, 24)
     def define_custom_liquid_class(

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -1372,12 +1372,12 @@ class ProtocolContext(CommandPublisher):
         )
 
     @requires_version(2, 23)
-    def define_liquid_class(
+    def get_liquid_class(
         self,
         name: str,
     ) -> LiquidClass:
         """
-        Define a liquid class for use in the protocol.
+        Get a liquid class instance for use in the protocol.
         ..
             This is intended for Opentrons internal use only and is not a guaranteed API.
 

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -1382,8 +1382,7 @@ class ProtocolContext(CommandPublisher):
         Args:
             name: Name of an Opentrons-defined liquid class.
 
-        Raises:
-            LiquidClassDefinitionDoesNotExist: if the specified liquid class does not exist.
+        :raises: ``LiquidClassDefinitionDoesNotExist``: if the specified liquid class does not exist.
         """
         return self._core.get_liquid_class(name=name, version=DEFAULT_LC_VERSION)
 

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -1388,7 +1388,7 @@ class ProtocolContext(CommandPublisher):
         return self._core.get_liquid_class(name=name, version=DEFAULT_LC_VERSION)
 
     @requires_version(2, 24)
-    def define_custom_liquid_class(
+    def define_liquid_class(
         self,
         name: str,
         properties: Dict[str, Dict[str, TransferPropertiesDict]],

--- a/api/tests/opentrons/protocol_api/core/engine/test_protocol_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_protocol_core.py
@@ -1876,13 +1876,13 @@ def test_define_liquid_class(
     decoy.when(liquid_classes.load_definition("water", version=123)).then_return(
         minimal_liquid_class_def1
     )
-    assert subject.define_liquid_class("water", 123) == expected_liquid_class
+    assert subject.get_liquid_class("water", 123) == expected_liquid_class
 
     # Test that different version number works
     decoy.when(liquid_classes.load_definition("water", version=456)).then_return(
         minimal_liquid_class_def2
     )
-    different_liquid_class = subject.define_liquid_class("water", 456)
+    different_liquid_class = subject.get_liquid_class("water", 456)
     assert different_liquid_class.name == "water2"
     assert different_liquid_class.display_name == "water 2"
 
@@ -1890,7 +1890,7 @@ def test_define_liquid_class(
     decoy.when(liquid_classes.load_definition("water", version=123)).then_return(
         minimal_liquid_class_def2
     )
-    assert subject.define_liquid_class("water", 123) == expected_liquid_class
+    assert subject.get_liquid_class("water", 123) == expected_liquid_class
 
 
 def test_get_labware_location_deck_slot(

--- a/api/tests/opentrons/protocol_api/test_protocol_context.py
+++ b/api/tests/opentrons/protocol_api/test_protocol_context.py
@@ -1813,7 +1813,7 @@ def test_define_new_custom_liquid_class_from_dict(
     minimal_transfer_properties_dict: Dict[str, Dict[str, TransferPropertiesDict]],
 ) -> None:
     """It should define a custom liquid class."""
-    my_liquid_class = subject.define_custom_liquid_class(
+    my_liquid_class = subject.define_liquid_class(
         name="my_liquid",
         properties=minimal_transfer_properties_dict,
         display_name="My liquid",
@@ -1857,7 +1857,7 @@ def test_customize_existing_liquid_class(
         == 4
     )
 
-    my_liquid_class = subject.define_custom_liquid_class(
+    my_liquid_class = subject.define_liquid_class(
         name="my_liquid",
         properties=minimal_transfer_properties_dict,
         base_liquid_class=existing_glycerol_class,
@@ -1878,7 +1878,7 @@ def test_customize_existing_liquid_class(
     )
 
     # Test that new entries are created for pipettes and tipracks not present in the base liquid class
-    lc_with_custom_pip_n_tip = subject.define_custom_liquid_class(
+    lc_with_custom_pip_n_tip = subject.define_liquid_class(
         name="my_liquid_2",
         properties=custom_pip_n_tip_transfer_properties_dict,
         base_liquid_class=existing_glycerol_class,
@@ -1899,7 +1899,7 @@ def test_customize_existing_liquid_class(
             "opentrons/opentrons_flex_96_tiprack_50ul/1"
         ]
     }
-    lc_with_new_tip_entry = subject.define_custom_liquid_class(
+    lc_with_new_tip_entry = subject.define_liquid_class(
         name="my_liquid_3",
         properties=modified_custom_dict,
         base_liquid_class=lc_with_custom_pip_n_tip,

--- a/api/tests/opentrons/protocol_api/test_protocol_context.py
+++ b/api/tests/opentrons/protocol_api/test_protocol_context.py
@@ -1797,7 +1797,7 @@ def test_define_liquid_class(
     expected_liquid_class = LiquidClass(
         _name="volatile_100", _display_name="volatile 100%", _by_pipette_setting={}
     )
-    decoy.when(mock_core.define_liquid_class("volatile_90", 1)).then_return(
+    decoy.when(mock_core.get_liquid_class("volatile_90", 1)).then_return(
         expected_liquid_class
     )
     decoy.when(mock_core.robot_type).then_return(robot_type)

--- a/api/tests/opentrons/protocol_api/test_protocol_context.py
+++ b/api/tests/opentrons/protocol_api/test_protocol_context.py
@@ -1801,7 +1801,7 @@ def test_define_liquid_class(
         expected_liquid_class
     )
     decoy.when(mock_core.robot_type).then_return(robot_type)
-    assert subject.define_liquid_class("volatile_90") == expected_liquid_class
+    assert subject.get_liquid_class("volatile_90") == expected_liquid_class
 
 
 @pytest.mark.parametrize("robot_type", ["OT-2 Standard", "OT-3 Standard"])

--- a/api/tests/opentrons/protocol_api_integration/test_liquid_classes.py
+++ b/api/tests/opentrons/protocol_api_integration/test_liquid_classes.py
@@ -20,7 +20,7 @@ def test_liquid_class_creation_and_property_fetching(
     tiprack = simulated_protocol_context.load_labware(
         "opentrons_flex_96_tiprack_50ul", "D1"
     )
-    water = simulated_protocol_context.define_liquid_class("water")
+    water = simulated_protocol_context.get_liquid_class("water")
 
     assert water.name == "water"
     assert water.display_name == "Aqueous"
@@ -44,7 +44,7 @@ def test_liquid_class_creation_and_property_fetching(
         water.display_name = "bar"  # type: ignore
 
     with pytest.raises(ValueError, match="Liquid class definition not found"):
-        simulated_protocol_context.define_liquid_class("non-existent-liquid")
+        simulated_protocol_context.get_liquid_class("non-existent-liquid")
 
 
 @pytest.mark.ot3_only

--- a/api/tests/opentrons/protocol_api_integration/test_liquid_classes.py
+++ b/api/tests/opentrons/protocol_api_integration/test_liquid_classes.py
@@ -9,7 +9,7 @@ from opentrons_shared_data.liquid_classes.types import TransferPropertiesDict
 
 @pytest.mark.ot3_only
 @pytest.mark.parametrize(
-    "simulated_protocol_context", [("2.23", "Flex")], indirect=True
+    "simulated_protocol_context", [("2.24", "Flex")], indirect=True
 )
 def test_liquid_class_creation_and_property_fetching(
     simulated_protocol_context: ProtocolContext,

--- a/api/tests/opentrons/protocol_api_integration/test_liquid_classes.py
+++ b/api/tests/opentrons/protocol_api_integration/test_liquid_classes.py
@@ -61,7 +61,7 @@ def test_custom_liquid_class_creation_and_property_fetching(
     tiprack = simulated_protocol_context.load_labware(
         "opentrons_flex_96_tiprack_50ul", "D1"
     )
-    custom_water = simulated_protocol_context.define_custom_liquid_class(
+    custom_water = simulated_protocol_context.define_liquid_class(
         name="water_50",
         properties=minimal_transfer_properties_dict,
         display_name="Custom Aqueous",

--- a/api/tests/opentrons/protocol_api_integration/test_transfer_with_liquid_classes.py
+++ b/api/tests/opentrons/protocol_api_integration/test_transfer_with_liquid_classes.py
@@ -15,7 +15,7 @@ from opentrons.protocols.advanced_control.transfers.common import (
 
 @pytest.mark.ot3_only
 @pytest.mark.parametrize(
-    "simulated_protocol_context", [("2.23", "Flex")], indirect=True
+    "simulated_protocol_context", [("2.24", "Flex")], indirect=True
 )
 def test_water_transfer_with_volume_more_than_tip_max(
     simulated_protocol_context: ProtocolContext,
@@ -87,7 +87,7 @@ def test_water_transfer_with_volume_more_than_tip_max(
 
 @pytest.mark.ot3_only
 @pytest.mark.parametrize(
-    "simulated_protocol_context", [("2.23", "Flex")], indirect=True
+    "simulated_protocol_context", [("2.24", "Flex")], indirect=True
 )
 def test_order_of_water_transfer_steps(
     simulated_protocol_context: ProtocolContext,
@@ -238,7 +238,7 @@ def test_order_of_water_transfer_steps(
 
 @pytest.mark.ot3_only
 @pytest.mark.parametrize(
-    "simulated_protocol_context", [("2.23", "Flex")], indirect=True
+    "simulated_protocol_context", [("2.24", "Flex")], indirect=True
 )
 def test_order_of_water_transfer_steps_with_new_tip_per_destination(
     simulated_protocol_context: ProtocolContext,
@@ -357,7 +357,7 @@ def test_order_of_water_transfer_steps_with_new_tip_per_destination(
 
 @pytest.mark.ot3_only
 @pytest.mark.parametrize(
-    "simulated_protocol_context", [("2.23", "Flex")], indirect=True
+    "simulated_protocol_context", [("2.24", "Flex")], indirect=True
 )
 def test_order_of_water_transfer_steps_with_return_tip(
     simulated_protocol_context: ProtocolContext,
@@ -512,7 +512,7 @@ def test_order_of_water_transfer_steps_with_return_tip(
 
 @pytest.mark.ot3_only
 @pytest.mark.parametrize(
-    "simulated_protocol_context", [("2.23", "Flex")], indirect=True
+    "simulated_protocol_context", [("2.24", "Flex")], indirect=True
 )
 def test_order_of_water_transfer_steps_with_no_new_tips(
     simulated_protocol_context: ProtocolContext,
@@ -639,7 +639,7 @@ def test_order_of_water_transfer_steps_with_no_new_tips(
 
 @pytest.mark.ot3_only
 @pytest.mark.parametrize(
-    "simulated_protocol_context", [("2.23", "Flex")], indirect=True
+    "simulated_protocol_context", [("2.24", "Flex")], indirect=True
 )
 def test_order_of_water_consolidate_steps(
     simulated_protocol_context: ProtocolContext,
@@ -769,7 +769,7 @@ def test_order_of_water_consolidate_steps(
 
 @pytest.mark.ot3_only
 @pytest.mark.parametrize(
-    "simulated_protocol_context", [("2.23", "Flex")], indirect=True
+    "simulated_protocol_context", [("2.24", "Flex")], indirect=True
 )
 def test_order_of_water_consolidate_steps_larger_volume_than_tip(
     simulated_protocol_context: ProtocolContext,
@@ -910,7 +910,7 @@ def test_order_of_water_consolidate_steps_larger_volume_than_tip(
 
 @pytest.mark.ot3_only
 @pytest.mark.parametrize(
-    "simulated_protocol_context", [("2.23", "Flex")], indirect=True
+    "simulated_protocol_context", [("2.24", "Flex")], indirect=True
 )
 def test_order_of_water_consolidate_steps_with_no_new_tips(
     simulated_protocol_context: ProtocolContext,
@@ -1028,7 +1028,7 @@ def test_order_of_water_consolidate_steps_with_no_new_tips(
 
 @pytest.mark.ot3_only
 @pytest.mark.parametrize(
-    "simulated_protocol_context", [("2.23", "Flex")], indirect=True
+    "simulated_protocol_context", [("2.24", "Flex")], indirect=True
 )
 def test_order_of_water_consolidate_steps_with_return_tip(
     simulated_protocol_context: ProtocolContext,
@@ -1160,7 +1160,7 @@ def test_order_of_water_consolidate_steps_with_return_tip(
 
 @pytest.mark.ot3_only
 @pytest.mark.parametrize(
-    "simulated_protocol_context", [("2.23", "Flex")], indirect=True
+    "simulated_protocol_context", [("2.24", "Flex")], indirect=True
 )
 def test_water_distribution_with_volume_more_than_tip_max(
     simulated_protocol_context: ProtocolContext,
@@ -1220,7 +1220,7 @@ def test_water_distribution_with_volume_more_than_tip_max(
 
 @pytest.mark.ot3_only
 @pytest.mark.parametrize(
-    "simulated_protocol_context", [("2.23", "Flex")], indirect=True
+    "simulated_protocol_context", [("2.24", "Flex")], indirect=True
 )
 def test_order_of_water_distribution_steps_using_multi_dispense(
     simulated_protocol_context: ProtocolContext,
@@ -1380,7 +1380,7 @@ def test_order_of_water_distribution_steps_using_multi_dispense(
 
 @pytest.mark.ot3_only
 @pytest.mark.parametrize(
-    "simulated_protocol_context", [("2.23", "Flex")], indirect=True
+    "simulated_protocol_context", [("2.24", "Flex")], indirect=True
 )
 @pytest.mark.parametrize(
     ["distribute_volume", "multi_dispense_props_present"],
@@ -1542,7 +1542,7 @@ def test_order_of_water_distribute_steps_using_one_to_one_transfers(
 
 @pytest.mark.ot3_only
 @pytest.mark.parametrize(
-    "simulated_protocol_context", [("2.23", "Flex")], indirect=True
+    "simulated_protocol_context", [("2.24", "Flex")], indirect=True
 )
 def test_order_of_water_distribution_steps_using_mixed_dispense(
     simulated_protocol_context: ProtocolContext,
@@ -1742,7 +1742,7 @@ def test_order_of_water_distribution_steps_using_mixed_dispense(
 
 @pytest.mark.ot3_only
 @pytest.mark.parametrize(
-    "simulated_protocol_context", [("2.23", "Flex")], indirect=True
+    "simulated_protocol_context", [("2.24", "Flex")], indirect=True
 )
 def test_water_distribute_steps_with_return_tip(
     simulated_protocol_context: ProtocolContext,
@@ -1816,7 +1816,7 @@ def test_water_distribute_steps_with_return_tip(
 
 @pytest.mark.ot3_only
 @pytest.mark.parametrize(
-    "simulated_protocol_context", [("2.23", "Flex")], indirect=True
+    "simulated_protocol_context", [("2.24", "Flex")], indirect=True
 )
 def test_water_distribution_raises_error_for_disposal_vol_without_blowout(
     simulated_protocol_context: ProtocolContext,
@@ -1851,7 +1851,7 @@ def test_water_distribution_raises_error_for_disposal_vol_without_blowout(
 
 @pytest.mark.ot3_only
 @pytest.mark.parametrize(
-    "simulated_protocol_context", [("2.23", "Flex")], indirect=True
+    "simulated_protocol_context", [("2.24", "Flex")], indirect=True
 )
 @pytest.mark.parametrize(
     ["new_tip", "expected_number_of_calls"],
@@ -1903,7 +1903,7 @@ def test_water_transfer_with_lpd(
 
 @pytest.mark.ot3_only
 @pytest.mark.parametrize(
-    "simulated_protocol_context", [("2.23", "Flex")], indirect=True
+    "simulated_protocol_context", [("2.24", "Flex")], indirect=True
 )
 @pytest.mark.parametrize(
     "new_tip",
@@ -1954,7 +1954,7 @@ def test_water_transfer_does_lpd_only_once_for_a_source_well(
 
 @pytest.mark.ot3_only
 @pytest.mark.parametrize(
-    "simulated_protocol_context", [("2.23", "Flex")], indirect=True
+    "simulated_protocol_context", [("2.24", "Flex")], indirect=True
 )
 def test_water_distribution_with_lpd(
     simulated_protocol_context: ProtocolContext,
@@ -2006,7 +2006,7 @@ def test_water_distribution_with_lpd(
 
 @pytest.mark.ot3_only
 @pytest.mark.parametrize(
-    "simulated_protocol_context", [("2.23", "Flex")], indirect=True
+    "simulated_protocol_context", [("2.24", "Flex")], indirect=True
 )
 def test_incompatible_transfers_skip_probing_even_with_lpd_on(
     simulated_protocol_context: ProtocolContext,
@@ -2083,7 +2083,7 @@ def test_incompatible_transfers_skip_probing_even_with_lpd_on(
 
 @pytest.mark.ot3_only
 @pytest.mark.parametrize(
-    "simulated_protocol_context", [("2.23", "Flex")], indirect=True
+    "simulated_protocol_context", [("2.24", "Flex")], indirect=True
 )
 def test_water_transfer_with_multi_channel_pipette(
     simulated_protocol_context: ProtocolContext,
@@ -2140,7 +2140,7 @@ def test_water_transfer_with_multi_channel_pipette(
 
 @pytest.mark.ot3_only
 @pytest.mark.parametrize(
-    "simulated_protocol_context", [("2.23", "Flex")], indirect=True
+    "simulated_protocol_context", [("2.24", "Flex")], indirect=True
 )
 def test_raises_no_tips_available_error(
     simulated_protocol_context: ProtocolContext,

--- a/api/tests/opentrons/protocol_api_integration/test_transfer_with_liquid_classes.py
+++ b/api/tests/opentrons/protocol_api_integration/test_transfer_with_liquid_classes.py
@@ -40,7 +40,7 @@ def test_water_transfer_with_volume_more_than_tip_max(
         "armadillo_96_wellplate_200ul_pcr_full_skirt", "C2"
     )
 
-    water = simulated_protocol_context.define_liquid_class("water")
+    water = simulated_protocol_context.get_liquid_class("water")
     with mock.patch.object(
         InstrumentCore,
         "pick_up_tip",
@@ -112,7 +112,7 @@ def test_order_of_water_transfer_steps(
         "armadillo_96_wellplate_200ul_pcr_full_skirt", "C2"
     )
 
-    water = simulated_protocol_context.define_liquid_class("water")
+    water = simulated_protocol_context.get_liquid_class("water")
     with (
         mock.patch.object(
             InstrumentCore,
@@ -255,7 +255,7 @@ def test_order_of_water_transfer_steps_with_new_tip_per_destination(
         "nest_96_wellplate_200ul_flat", "C3"
     )
 
-    water = simulated_protocol_context.define_liquid_class("water")
+    water = simulated_protocol_context.get_liquid_class("water")
     with (
         mock.patch.object(
             InstrumentCore,
@@ -382,7 +382,7 @@ def test_order_of_water_transfer_steps_with_return_tip(
         "armadillo_96_wellplate_200ul_pcr_full_skirt", "C2"
     )
 
-    water = simulated_protocol_context.define_liquid_class("water")
+    water = simulated_protocol_context.get_liquid_class("water")
     with (
         mock.patch.object(
             InstrumentCore,
@@ -537,7 +537,7 @@ def test_order_of_water_transfer_steps_with_no_new_tips(
         "armadillo_96_wellplate_200ul_pcr_full_skirt", "C2"
     )
 
-    water = simulated_protocol_context.define_liquid_class("water")
+    water = simulated_protocol_context.get_liquid_class("water")
     pipette_50.pick_up_tip()
     with (
         mock.patch.object(
@@ -664,7 +664,7 @@ def test_order_of_water_consolidate_steps(
         "armadillo_96_wellplate_200ul_pcr_full_skirt", "C2"
     )
 
-    water = simulated_protocol_context.define_liquid_class("water")
+    water = simulated_protocol_context.get_liquid_class("water")
     with (
         mock.patch.object(
             InstrumentCore,
@@ -794,7 +794,7 @@ def test_order_of_water_consolidate_steps_larger_volume_than_tip(
         "armadillo_96_wellplate_200ul_pcr_full_skirt", "C2"
     )
 
-    water = simulated_protocol_context.define_liquid_class("water")
+    water = simulated_protocol_context.get_liquid_class("water")
     with (
         mock.patch.object(
             InstrumentCore,
@@ -935,7 +935,7 @@ def test_order_of_water_consolidate_steps_with_no_new_tips(
         "armadillo_96_wellplate_200ul_pcr_full_skirt", "C2"
     )
 
-    water = simulated_protocol_context.define_liquid_class("water")
+    water = simulated_protocol_context.get_liquid_class("water")
     pipette_50.pick_up_tip()
     with (
         mock.patch.object(
@@ -1053,7 +1053,7 @@ def test_order_of_water_consolidate_steps_with_return_tip(
         "armadillo_96_wellplate_200ul_pcr_full_skirt", "C2"
     )
 
-    water = simulated_protocol_context.define_liquid_class("water")
+    water = simulated_protocol_context.get_liquid_class("water")
     with (
         mock.patch.object(
             InstrumentCore,
@@ -1180,7 +1180,7 @@ def test_water_distribution_with_volume_more_than_tip_max(
         "armadillo_96_wellplate_200ul_pcr_full_skirt", "C2"
     )
 
-    water = simulated_protocol_context.define_liquid_class("water")
+    water = simulated_protocol_context.get_liquid_class("water")
     water_props = water.get_for(pipette_1k, tiprack)
     water_props.multi_dispense.retract.blowout.location = "destination"  # type: ignore[union-attr]
     water_props.multi_dispense.retract.blowout.flow_rate = pipette_1k.flow_rate.blow_out  # type: ignore[union-attr]
@@ -1240,7 +1240,7 @@ def test_order_of_water_distribution_steps_using_multi_dispense(
         "armadillo_96_wellplate_200ul_pcr_full_skirt", "C2"
     )
 
-    water = simulated_protocol_context.define_liquid_class("water")
+    water = simulated_protocol_context.get_liquid_class("water")
     water_props = water.get_for(pipette_1k, tiprack)
     water_props.multi_dispense.retract.blowout.location = "destination"  # type: ignore[union-attr]
     water_props.multi_dispense.retract.blowout.flow_rate = pipette_1k.flow_rate.blow_out  # type: ignore[union-attr]
@@ -1408,7 +1408,7 @@ def test_order_of_water_distribute_steps_using_one_to_one_transfers(
     arma_plate = simulated_protocol_context.load_labware(
         "armadillo_96_wellplate_200ul_pcr_full_skirt", "C2"
     )
-    water = simulated_protocol_context.define_liquid_class("water")
+    water = simulated_protocol_context.get_liquid_class("water")
     water_props = water.get_for(pipette_50, tiprack)
     if not multi_dispense_props_present:
         water_props._multi_dispense = None
@@ -1562,7 +1562,7 @@ def test_order_of_water_distribution_steps_using_mixed_dispense(
         "armadillo_96_wellplate_200ul_pcr_full_skirt", "C2"
     )
 
-    water = simulated_protocol_context.define_liquid_class("water")
+    water = simulated_protocol_context.get_liquid_class("water")
     water_props = water.get_for(pipette_1k, tiprack)
     assert water_props.multi_dispense is not None
     water_props.multi_dispense.retract.blowout.location = "destination"  # type: ignore[assignment]
@@ -1767,7 +1767,7 @@ def test_water_distribute_steps_with_return_tip(
     arma_plate = simulated_protocol_context.load_labware(
         "armadillo_96_wellplate_200ul_pcr_full_skirt", "C2"
     )
-    water = simulated_protocol_context.define_liquid_class("water")
+    water = simulated_protocol_context.get_liquid_class("water")
 
     with (
         mock.patch.object(
@@ -1832,7 +1832,7 @@ def test_water_distribution_raises_error_for_disposal_vol_without_blowout(
     nest_plate = simulated_protocol_context.load_labware(
         "nest_96_wellplate_200ul_flat", "C3"
     )
-    water = simulated_protocol_context.define_liquid_class("water")
+    water = simulated_protocol_context.get_liquid_class("water")
     water_props = water.get_for(pipette_1k, tiprack)
     water_props.multi_dispense.retract.blowout.enabled = False  # type: ignore[union-attr]
     with pytest.raises(
@@ -1879,7 +1879,7 @@ def test_water_transfer_with_lpd(
     arma_plate = simulated_protocol_context.load_labware(
         "armadillo_96_wellplate_200ul_pcr_full_skirt", "C2"
     )
-    water = simulated_protocol_context.define_liquid_class("water")
+    water = simulated_protocol_context.get_liquid_class("water")
 
     with (
         mock.patch.object(
@@ -1930,7 +1930,7 @@ def test_water_transfer_does_lpd_only_once_for_a_source_well(
     arma_plate = simulated_protocol_context.load_labware(
         "armadillo_96_wellplate_200ul_pcr_full_skirt", "C2"
     )
-    water = simulated_protocol_context.define_liquid_class("water")
+    water = simulated_protocol_context.get_liquid_class("water")
 
     with (
         mock.patch.object(
@@ -1977,7 +1977,7 @@ def test_water_distribution_with_lpd(
         "armadillo_96_wellplate_200ul_pcr_full_skirt", "C2"
     )
 
-    water = simulated_protocol_context.define_liquid_class("water")
+    water = simulated_protocol_context.get_liquid_class("water")
     water_props = water.get_for(pipette_1k, tiprack)
     assert water_props.multi_dispense is not None
     water_props.multi_dispense.retract.blowout.location = "destination"  # type: ignore[assignment]
@@ -2029,7 +2029,7 @@ def test_incompatible_transfers_skip_probing_even_with_lpd_on(
         "armadillo_96_wellplate_200ul_pcr_full_skirt", "C2"
     )
 
-    water = simulated_protocol_context.define_liquid_class("water")
+    water = simulated_protocol_context.get_liquid_class("water")
     water_props = water.get_for(pipette_1k, tiprack)
     assert water_props.multi_dispense is not None
     water_props.multi_dispense.retract.blowout.location = "destination"  # type: ignore[assignment]
@@ -2108,7 +2108,7 @@ def test_water_transfer_with_multi_channel_pipette(
         "armadillo_96_wellplate_200ul_pcr_full_skirt", "C2"
     )
 
-    water = simulated_protocol_context.define_liquid_class("water")
+    water = simulated_protocol_context.get_liquid_class("water")
     with (
         mock.patch.object(
             InstrumentCore,
@@ -2162,7 +2162,7 @@ def test_raises_no_tips_available_error(
     arma_plate = simulated_protocol_context.load_labware(
         "armadillo_96_wellplate_200ul_pcr_full_skirt", "C2"
     )
-    water = simulated_protocol_context.define_liquid_class("water")
+    water = simulated_protocol_context.get_liquid_class("water")
     expected_error_msg = (
         "No tip available among the tipracks assigned for flex_1channel_50:"
         " \\['Opentrons Flex 96 Tip Rack 50 µL in D1', 'Opentrons Flex 96 Tip Rack 50 µL in D2'\\]"


### PR DESCRIPTION
# Overview

After various discussions we decided to rename the liquid class API methods:
`define_liquid_class` -> `get_liquid_class`
`define_custom_liquid_class` -> `define_liquid_class`

This PR makes that change

## Review requests

- I've updated the API version required for using `get_liquid_class` as v2.24. Are we okay with that? I think it doesn't make sense to keep it 2.23 because technically, 2.23 had a `define_liquid_class` and not `get..`.

## Risk assessment

None for production code. Refactor only. Internal stakeholders who have been using liquid classes will need to update their protocols and API versions. 
