### PR TITLE
refactor(app,components): Simplifications to CalibrationBlockRender

### DIFF
--- a/app/src/organisms/Desktop/CalibrationPanels/CalibrationLabwareRender.tsx
+++ b/app/src/organisms/Desktop/CalibrationPanels/CalibrationLabwareRender.tsx
@@ -1,13 +1,8 @@
 import {
-  C_MED_DARK_GRAY,
-  C_MED_GRAY,
-  C_MED_LIGHT_GRAY,
-  FONT_WEIGHT_SEMIBOLD,
+  CalibrationBlockRender,
   LabwareNameOverlay,
   LabwareRender,
   RobotCoordsForeignDiv,
-  RobotCoordsText,
-  TYPOGRAPHY,
 } from '@opentrons/components'
 import {
   getIsTiprack,
@@ -18,9 +13,6 @@ import {
 import styles from './styles.module.css'
 
 import type { CoordinateTuple, LabwareDefinition } from '@opentrons/shared-data'
-
-const SHORT = 'SHORT'
-const TALL = 'TALL'
 
 interface CalibrationLabwareRenderProps {
   labwareDef: LabwareDefinition
@@ -65,110 +57,4 @@ export function CalibrationLabwareRender(
       }
     </g>
   )
-}
-
-function CalibrationBlockRender(props: {
-  labwareDef: LabwareDefinition
-}): JSX.Element | null {
-  const { labwareDef } = props
-  const dimensions = getSchema2Dimensions(labwareDef)
-
-  switch (labwareDef.parameters.loadName) {
-    case 'opentrons_calibrationblock_short_side_right': {
-      return (
-        <>
-          <rect
-            width={dimensions.xDimension}
-            height={dimensions.yDimension}
-            rx="10"
-            ry="10"
-            x={0}
-            y={0}
-            fill={C_MED_DARK_GRAY}
-          />
-          <rect
-            width={dimensions.xDimension / 2}
-            height={dimensions.yDimension}
-            rx="10"
-            ry="10"
-            x={0}
-            y={0}
-            fill={C_MED_GRAY}
-          />
-          <g transform="rotate(270)">
-            <RobotCoordsText
-              x={-55}
-              y={5}
-              fill={C_MED_LIGHT_GRAY}
-              fontSize={TYPOGRAPHY.fontSizeCaption}
-              fontWeight={FONT_WEIGHT_SEMIBOLD}
-            >
-              {TALL}
-            </RobotCoordsText>
-          </g>
-          <g transform="rotate(90)">
-            <RobotCoordsText
-              x={25}
-              y={-dimensions.xDimension + 5}
-              fill={C_MED_LIGHT_GRAY}
-              fontSize={TYPOGRAPHY.fontSizeCaption}
-              fontWeight={FONT_WEIGHT_SEMIBOLD}
-            >
-              {SHORT}
-            </RobotCoordsText>
-          </g>
-        </>
-      )
-    }
-    case 'opentrons_calibrationblock_short_side_left': {
-      return (
-        <>
-          <rect
-            width={dimensions.xDimension}
-            height={dimensions.yDimension}
-            rx="10"
-            ry="10"
-            x={0}
-            y={0}
-            fill={C_MED_DARK_GRAY}
-          />
-          <rect
-            width={dimensions.xDimension / 2}
-            height={dimensions.yDimension}
-            rx="10"
-            ry="10"
-            x={dimensions.xDimension / 2}
-            y={0}
-            fill={C_MED_GRAY}
-          />
-          <g transform="rotate(270)">
-            <RobotCoordsText
-              x={-55}
-              y={5}
-              fill={C_MED_LIGHT_GRAY}
-              fontSize={TYPOGRAPHY.fontSizeCaption}
-              fontWeight={FONT_WEIGHT_SEMIBOLD}
-            >
-              {SHORT}
-            </RobotCoordsText>
-          </g>
-          <g transform="rotate(90)">
-            <RobotCoordsText
-              x={30}
-              y={-dimensions.xDimension + 5}
-              fill={C_MED_LIGHT_GRAY}
-              fontSize={TYPOGRAPHY.fontSizeCaption}
-              fontWeight={FONT_WEIGHT_SEMIBOLD}
-            >
-              {TALL}
-            </RobotCoordsText>
-          </g>
-        </>
-      )
-    }
-    default: {
-      // should never reach this case
-      return null
-    }
-  }
 }

--- a/app/src/organisms/Desktop/CalibrationPanels/CalibrationLabwareRender.tsx
+++ b/app/src/organisms/Desktop/CalibrationPanels/CalibrationLabwareRender.tsx
@@ -36,48 +36,47 @@ export function CalibrationLabwareRender(
   const dimensions = getSchema2Dimensions(labwareDef)
   const isTiprack = getIsTiprack(labwareDef)
 
-  // TODO: we can change this boolean to check to isCalibrationBlock instead of isTiprack to render any labware
-  return isTiprack ? (
+  return (
     <g
       transform={`translate(${String(slotDefPosition?.[0])}, ${String(
         slotDefPosition?.[1]
       )})`}
     >
-      <LabwareRender definition={labwareDef} />
-      <RobotCoordsForeignDiv
-        width={dimensions.xDimension}
-        height={dimensions.yDimension}
-        x={0}
-        y={0 - dimensions.yDimension}
-        transformWithSVG
-        innerDivProps={{ className: styles.labware_ui_wrapper }}
-      >
-        {/* title is capitalized by CSS, and "µL" capitalized is "ML" */}
-        <LabwareNameOverlay title={title.replace('µL', 'uL')} />
-      </RobotCoordsForeignDiv>
+      {
+        // TODO: we can change this boolean to check to isCalibrationBlock instead of isTiprack to render any labware
+        isTiprack ? (
+          <>
+            <LabwareRender definition={labwareDef} />
+            <RobotCoordsForeignDiv
+              width={dimensions.xDimension}
+              height={dimensions.yDimension}
+              x={0}
+              y={0 - dimensions.yDimension}
+              transformWithSVG
+              innerDivProps={{ className: styles.labware_ui_wrapper }}
+            >
+              {/* title is capitalized by CSS, and "µL" capitalized is "ML" */}
+              <LabwareNameOverlay title={title.replace('µL', 'uL')} />
+            </RobotCoordsForeignDiv>
+          </>
+        ) : (
+          <CalibrationBlockRender labwareDef={labwareDef} />
+        )
+      }
     </g>
-  ) : (
-    <CalibrationBlockRender
-      labwareDef={labwareDef}
-      slotDefPosition={slotDefPosition}
-    />
   )
 }
 
-export function CalibrationBlockRender(
-  props: CalibrationLabwareRenderProps
-): JSX.Element | null {
-  const { labwareDef, slotDefPosition } = props
+function CalibrationBlockRender(props: {
+  labwareDef: LabwareDefinition
+}): JSX.Element | null {
+  const { labwareDef } = props
   const dimensions = getSchema2Dimensions(labwareDef)
 
   switch (labwareDef.parameters.loadName) {
     case 'opentrons_calibrationblock_short_side_right': {
       return (
-        <g
-          transform={`translate(${String(slotDefPosition?.[0])}, ${String(
-            slotDefPosition?.[1]
-          )})`}
-        >
+        <>
           <rect
             width={dimensions.xDimension}
             height={dimensions.yDimension}
@@ -118,16 +117,12 @@ export function CalibrationBlockRender(
               {SHORT}
             </RobotCoordsText>
           </g>
-        </g>
+        </>
       )
     }
     case 'opentrons_calibrationblock_short_side_left': {
       return (
-        <g
-          transform={`translate(${String(slotDefPosition?.[0])}, ${String(
-            slotDefPosition?.[1]
-          )})`}
-        >
+        <>
           <rect
             width={dimensions.xDimension}
             height={dimensions.yDimension}
@@ -168,7 +163,7 @@ export function CalibrationBlockRender(
               {TALL}
             </RobotCoordsText>
           </g>
-        </g>
+        </>
       )
     }
     default: {

--- a/components/src/hardware-sim/Labware/CalibrationBlockRender.stories.tsx
+++ b/components/src/hardware-sim/Labware/CalibrationBlockRender.stories.tsx
@@ -16,6 +16,7 @@ const DEFS_BY_URI = Object.fromEntries(
 )
 
 const meta: Meta<typeof CalibrationBlockRender> = {
+  title: 'Library/Molecules/Simulation/CalibrationBlockRender',
   component: CalibrationBlockRender,
   decorators: [
     (Story, context) => {

--- a/components/src/hardware-sim/Labware/CalibrationBlockRender.stories.tsx
+++ b/components/src/hardware-sim/Labware/CalibrationBlockRender.stories.tsx
@@ -14,7 +14,7 @@ const DEFS_BY_URI = Object.fromEntries(
 )
 
 
-const meta = {
+const meta: Meta<typeof CalibrationBlockRender> = {
   component: CalibrationBlockRender,
   decorators: [
     (Story, context) => {
@@ -28,7 +28,7 @@ const meta = {
       </RobotWorkSpace>
     }
   ]
-} satisfies Meta<typeof CalibrationBlockRender>
+}
 
 export default meta;
 type Story = StoryObj<typeof meta>

--- a/components/src/hardware-sim/Labware/CalibrationBlockRender.stories.tsx
+++ b/components/src/hardware-sim/Labware/CalibrationBlockRender.stories.tsx
@@ -1,47 +1,48 @@
 import { getAllDefinitions, getSchema2Dimensions } from '@opentrons/shared-data'
+
 import { RobotWorkSpace } from '../Deck'
 import { CalibrationBlockRender } from './CalibrationBlockRender'
 
 import type { Meta, StoryObj } from '@storybook/react'
 
-const LOAD_NAMES = ["opentrons_calibrationblock_short_side_left", "opentrons_calibrationblock_short_side_right"]
+const LOAD_NAMES = [
+  'opentrons_calibrationblock_short_side_left',
+  'opentrons_calibrationblock_short_side_right',
+]
 const DEFS_BY_URI = Object.fromEntries(
-  Object.entries(
-    getAllDefinitions()
-  ).filter(
-    ([uri, def]) => LOAD_NAMES.includes(def.parameters.loadName)
+  Object.entries(getAllDefinitions()).filter(([uri, def]) =>
+    LOAD_NAMES.includes(def.parameters.loadName)
   )
 )
-
 
 const meta: Meta<typeof CalibrationBlockRender> = {
   component: CalibrationBlockRender,
   decorators: [
     (Story, context) => {
-      const {labwareDef} = context.args
+      const { labwareDef } = context.args
       // todo(mm, 2025-06-05): Update viewBox to account for labware schema 3.
-      const {xDimension, yDimension} = getSchema2Dimensions(labwareDef)
+      const { xDimension, yDimension } = getSchema2Dimensions(labwareDef)
       const viewBox = `0 0 ${xDimension} ${yDimension}`
 
-      return <RobotWorkSpace viewBox={viewBox}>
-        {() => <Story />}
-      </RobotWorkSpace>
-    }
-  ]
+      return (
+        <RobotWorkSpace viewBox={viewBox}>{() => <Story />}</RobotWorkSpace>
+      )
+    },
+  ],
 }
 
-export default meta;
+export default meta
 type Story = StoryObj<typeof meta>
 
 export const Primary: Story = {
   args: {
-    labwareDef: Object.keys(DEFS_BY_URI)[0]
+    labwareDef: Object.keys(DEFS_BY_URI)[0],
   },
   argTypes: {
     labwareDef: {
       options: Object.keys(DEFS_BY_URI),
       defaultValue: Object.keys(DEFS_BY_URI)[0],
-      mapping: DEFS_BY_URI
-    }
-  }
+      mapping: DEFS_BY_URI,
+    },
+  },
 }

--- a/components/src/hardware-sim/Labware/CalibrationBlockRender.stories.tsx
+++ b/components/src/hardware-sim/Labware/CalibrationBlockRender.stories.tsx
@@ -41,7 +41,6 @@ export const Primary: Story = {
   argTypes: {
     labwareDef: {
       options: Object.keys(DEFS_BY_URI),
-      defaultValue: Object.keys(DEFS_BY_URI)[0],
       mapping: DEFS_BY_URI,
     },
   },

--- a/components/src/hardware-sim/Labware/CalibrationBlockRender.stories.tsx
+++ b/components/src/hardware-sim/Labware/CalibrationBlockRender.stories.tsx
@@ -1,0 +1,47 @@
+import { getAllDefinitions, getSchema2Dimensions } from '@opentrons/shared-data'
+import { RobotWorkSpace } from '../Deck'
+import { CalibrationBlockRender } from './CalibrationBlockRender'
+
+import type { Meta, StoryObj } from '@storybook/react'
+
+const LOAD_NAMES = ["opentrons_calibrationblock_short_side_left", "opentrons_calibrationblock_short_side_right"]
+const DEFS_BY_URI = Object.fromEntries(
+  Object.entries(
+    getAllDefinitions()
+  ).filter(
+    ([uri, def]) => LOAD_NAMES.includes(def.parameters.loadName)
+  )
+)
+
+
+const meta = {
+  component: CalibrationBlockRender,
+  decorators: [
+    (Story, context) => {
+      const {labwareDef} = context.args
+      // todo(mm, 2025-06-05): Update viewBox to account for labware schema 3.
+      const {xDimension, yDimension} = getSchema2Dimensions(labwareDef)
+      const viewBox = `0 0 ${xDimension} ${yDimension}`
+
+      return <RobotWorkSpace viewBox={viewBox}>
+        {() => <Story />}
+      </RobotWorkSpace>
+    }
+  ]
+} satisfies Meta<typeof CalibrationBlockRender>
+
+export default meta;
+type Story = StoryObj<typeof meta>
+
+export const Primary: Story = {
+  args: {
+    labwareDef: Object.keys(DEFS_BY_URI)[0]
+  },
+  argTypes: {
+    labwareDef: {
+      options: Object.keys(DEFS_BY_URI),
+      defaultValue: Object.keys(DEFS_BY_URI)[0],
+      mapping: DEFS_BY_URI
+    }
+  }
+}

--- a/components/src/hardware-sim/Labware/CalibrationBlockRender.tsx
+++ b/components/src/hardware-sim/Labware/CalibrationBlockRender.tsx
@@ -47,10 +47,10 @@ export function CalibrationBlockRender(
             y={0}
             fill={C_MED_GRAY}
           />
-          <g transform="rotate(270)">
+          <g transform="rotate(270, 5, 55)">
             <RobotCoordsText
-              x={-55}
-              y={5}
+              x={5}
+              y={55}
               fill={C_MED_LIGHT_GRAY}
               fontSize={TYPOGRAPHY.fontSizeCaption}
               fontWeight={FONT_WEIGHT_SEMIBOLD}
@@ -58,10 +58,10 @@ export function CalibrationBlockRender(
               {TALL}
             </RobotCoordsText>
           </g>
-          <g transform="rotate(90)">
+          <g transform={`rotate(90, ${dimensions.xDimension - 5}, 25)`}>
             <RobotCoordsText
-              x={25}
-              y={-dimensions.xDimension + 5}
+              x={dimensions.xDimension - 5}
+              y={25}
               fill={C_MED_LIGHT_GRAY}
               fontSize={TYPOGRAPHY.fontSizeCaption}
               fontWeight={FONT_WEIGHT_SEMIBOLD}
@@ -93,10 +93,10 @@ export function CalibrationBlockRender(
             y={0}
             fill={C_MED_GRAY}
           />
-          <g transform="rotate(270)">
+          <g transform="rotate(270, 5, 55)">
             <RobotCoordsText
-              x={-55}
-              y={5}
+              x={5}
+              y={55}
               fill={C_MED_LIGHT_GRAY}
               fontSize={TYPOGRAPHY.fontSizeCaption}
               fontWeight={FONT_WEIGHT_SEMIBOLD}
@@ -104,10 +104,10 @@ export function CalibrationBlockRender(
               {SHORT}
             </RobotCoordsText>
           </g>
-          <g transform="rotate(90)">
+          <g transform={`rotate(90, ${dimensions.xDimension - 5}, 30)`}>
             <RobotCoordsText
-              x={30}
-              y={-dimensions.xDimension + 5}
+              x={dimensions.xDimension - 5}
+              y={30}
               fill={C_MED_LIGHT_GRAY}
               fontSize={TYPOGRAPHY.fontSizeCaption}
               fontWeight={FONT_WEIGHT_SEMIBOLD}

--- a/components/src/hardware-sim/Labware/CalibrationBlockRender.tsx
+++ b/components/src/hardware-sim/Labware/CalibrationBlockRender.tsx
@@ -1,3 +1,5 @@
+import { getSchema2Dimensions } from '@opentrons/shared-data'
+
 import {
   C_MED_DARK_GRAY,
   C_MED_GRAY,
@@ -5,8 +7,7 @@ import {
   FONT_WEIGHT_SEMIBOLD,
   RobotCoordsText,
   TYPOGRAPHY,
-} from '@opentrons/components'
-import { getSchema2Dimensions } from '@opentrons/shared-data'
+} from '../..'
 
 import type { LabwareDefinition } from '@opentrons/shared-data'
 

--- a/components/src/hardware-sim/Labware/CalibrationBlockRender.tsx
+++ b/components/src/hardware-sim/Labware/CalibrationBlockRender.tsx
@@ -15,6 +15,8 @@ import type { LabwareDefinition } from '@opentrons/shared-data'
 const SHORT = 'SHORT'
 const TALL = 'TALL'
 
+const TEXT_MARGIN = 5
+
 interface CalibrationBlockRenderProps {
   labwareDef: LabwareDefinition
 }
@@ -47,10 +49,17 @@ export function CalibrationBlockRender(
             y={0}
             fill={C_MED_GRAY}
           />
-          <g transform="rotate(270, 5, 55)">
+          <g
+            transform={`rotate(
+              270,
+              ${TEXT_MARGIN},
+              ${dimensions.yDimension / 2}
+            )`}
+          >
             <RobotCoordsText
-              x={5}
-              y={55}
+              x={TEXT_MARGIN}
+              y={dimensions.yDimension / 2}
+              textAnchor="middle"
               fill={C_MED_LIGHT_GRAY}
               fontSize={TYPOGRAPHY.fontSizeCaption}
               fontWeight={FONT_WEIGHT_SEMIBOLD}
@@ -58,10 +67,17 @@ export function CalibrationBlockRender(
               {TALL}
             </RobotCoordsText>
           </g>
-          <g transform={`rotate(90, ${dimensions.xDimension - 5}, 25)`}>
+          <g
+            transform={`rotate(
+              90,
+              ${dimensions.xDimension - TEXT_MARGIN},
+              ${dimensions.yDimension / 2}
+            )`}
+          >
             <RobotCoordsText
-              x={dimensions.xDimension - 5}
-              y={25}
+              x={dimensions.xDimension - TEXT_MARGIN}
+              y={dimensions.yDimension / 2}
+              textAnchor="middle"
               fill={C_MED_LIGHT_GRAY}
               fontSize={TYPOGRAPHY.fontSizeCaption}
               fontWeight={FONT_WEIGHT_SEMIBOLD}
@@ -93,10 +109,17 @@ export function CalibrationBlockRender(
             y={0}
             fill={C_MED_GRAY}
           />
-          <g transform="rotate(270, 5, 55)">
+          <g
+            transform={`rotate(
+              270,
+              ${TEXT_MARGIN},
+              ${dimensions.yDimension / 2}
+            )`}
+          >
             <RobotCoordsText
-              x={5}
-              y={55}
+              x={TEXT_MARGIN}
+              y={dimensions.yDimension / 2}
+              textAnchor="middle"
               fill={C_MED_LIGHT_GRAY}
               fontSize={TYPOGRAPHY.fontSizeCaption}
               fontWeight={FONT_WEIGHT_SEMIBOLD}
@@ -104,10 +127,17 @@ export function CalibrationBlockRender(
               {SHORT}
             </RobotCoordsText>
           </g>
-          <g transform={`rotate(90, ${dimensions.xDimension - 5}, 30)`}>
+          <g
+            transform={`rotate(
+              90,
+              ${dimensions.xDimension - TEXT_MARGIN},
+              ${dimensions.yDimension / 2}
+            )`}
+          >
             <RobotCoordsText
-              x={dimensions.xDimension - 5}
-              y={30}
+              x={dimensions.xDimension - TEXT_MARGIN}
+              y={dimensions.yDimension / 2}
+              textAnchor="middle"
               fill={C_MED_LIGHT_GRAY}
               fontSize={TYPOGRAPHY.fontSizeCaption}
               fontWeight={FONT_WEIGHT_SEMIBOLD}

--- a/components/src/hardware-sim/Labware/CalibrationBlockRender.tsx
+++ b/components/src/hardware-sim/Labware/CalibrationBlockRender.tsx
@@ -1,0 +1,124 @@
+import {
+  C_MED_DARK_GRAY,
+  C_MED_GRAY,
+  C_MED_LIGHT_GRAY,
+  FONT_WEIGHT_SEMIBOLD,
+  RobotCoordsText,
+  TYPOGRAPHY,
+} from '@opentrons/components'
+import { getSchema2Dimensions } from '@opentrons/shared-data'
+
+import type { LabwareDefinition } from '@opentrons/shared-data'
+
+const SHORT = 'SHORT'
+const TALL = 'TALL'
+
+interface CalibrationBlockRenderProps {
+  labwareDef: LabwareDefinition
+}
+
+export function CalibrationBlockRender(
+  props: CalibrationBlockRenderProps
+): JSX.Element | null {
+  const { labwareDef } = props
+  const dimensions = getSchema2Dimensions(labwareDef)
+
+  switch (labwareDef.parameters.loadName) {
+    case 'opentrons_calibrationblock_short_side_right': {
+      return (
+        <>
+          <rect
+            width={dimensions.xDimension}
+            height={dimensions.yDimension}
+            rx="10"
+            ry="10"
+            x={0}
+            y={0}
+            fill={C_MED_DARK_GRAY}
+          />
+          <rect
+            width={dimensions.xDimension / 2}
+            height={dimensions.yDimension}
+            rx="10"
+            ry="10"
+            x={0}
+            y={0}
+            fill={C_MED_GRAY}
+          />
+          <g transform="rotate(270)">
+            <RobotCoordsText
+              x={-55}
+              y={5}
+              fill={C_MED_LIGHT_GRAY}
+              fontSize={TYPOGRAPHY.fontSizeCaption}
+              fontWeight={FONT_WEIGHT_SEMIBOLD}
+            >
+              {TALL}
+            </RobotCoordsText>
+          </g>
+          <g transform="rotate(90)">
+            <RobotCoordsText
+              x={25}
+              y={-dimensions.xDimension + 5}
+              fill={C_MED_LIGHT_GRAY}
+              fontSize={TYPOGRAPHY.fontSizeCaption}
+              fontWeight={FONT_WEIGHT_SEMIBOLD}
+            >
+              {SHORT}
+            </RobotCoordsText>
+          </g>
+        </>
+      )
+    }
+    case 'opentrons_calibrationblock_short_side_left': {
+      return (
+        <>
+          <rect
+            width={dimensions.xDimension}
+            height={dimensions.yDimension}
+            rx="10"
+            ry="10"
+            x={0}
+            y={0}
+            fill={C_MED_DARK_GRAY}
+          />
+          <rect
+            width={dimensions.xDimension / 2}
+            height={dimensions.yDimension}
+            rx="10"
+            ry="10"
+            x={dimensions.xDimension / 2}
+            y={0}
+            fill={C_MED_GRAY}
+          />
+          <g transform="rotate(270)">
+            <RobotCoordsText
+              x={-55}
+              y={5}
+              fill={C_MED_LIGHT_GRAY}
+              fontSize={TYPOGRAPHY.fontSizeCaption}
+              fontWeight={FONT_WEIGHT_SEMIBOLD}
+            >
+              {SHORT}
+            </RobotCoordsText>
+          </g>
+          <g transform="rotate(90)">
+            <RobotCoordsText
+              x={30}
+              y={-dimensions.xDimension + 5}
+              fill={C_MED_LIGHT_GRAY}
+              fontSize={TYPOGRAPHY.fontSizeCaption}
+              fontWeight={FONT_WEIGHT_SEMIBOLD}
+            >
+              {TALL}
+            </RobotCoordsText>
+          </g>
+        </>
+      )
+    }
+    default: {
+      // should never reach this case
+      return null
+    }
+  }
+}

--- a/components/src/hardware-sim/Labware/CalibrationBlockRender.tsx
+++ b/components/src/hardware-sim/Labware/CalibrationBlockRender.tsx
@@ -10,6 +10,8 @@ import { getSchema2Dimensions } from '@opentrons/shared-data'
 
 import type { LabwareDefinition } from '@opentrons/shared-data'
 
+// These strings match what's physically etched on the calibration block,
+// so they probably shouldn't be localized.
 const SHORT = 'SHORT'
 const TALL = 'TALL'
 

--- a/components/src/hardware-sim/Labware/CalibrationBlockRender.tsx
+++ b/components/src/hardware-sim/Labware/CalibrationBlockRender.tsx
@@ -19,9 +19,18 @@ const TALL = 'TALL'
 const TEXT_MARGIN = 5
 
 interface CalibrationBlockRenderProps {
+  /**
+   * Must be a calibration block definition, e.g.
+   * opentrons_calibrationblock_short_side_left or ..._short_side_right.
+   */
   labwareDef: LabwareDefinition
 }
 
+/**
+ * Render a top-down view of an OT-2 calibration block. This displays features specific
+ * to calibration blocks, which the more general <Labware> component doesn't know
+ * about.
+ */
 export function CalibrationBlockRender(
   props: CalibrationBlockRenderProps
 ): JSX.Element | null {

--- a/components/src/hardware-sim/Labware/CalibrationBlockRender.tsx
+++ b/components/src/hardware-sim/Labware/CalibrationBlockRender.tsx
@@ -151,6 +151,9 @@ export function CalibrationBlockRender(
     }
     default: {
       // should never reach this case
+      console.warn(
+        '<CalibrationBlockRender> given a non-calibration-block labware definition. Rendering nothing.'
+      )
       return null
     }
   }

--- a/components/src/hardware-sim/Labware/index.ts
+++ b/components/src/hardware-sim/Labware/index.ts
@@ -1,4 +1,5 @@
 export * from './labwareInternals/index'
+export * from './CalibrationBlockRender'
 export * from './LabwareRender'
 export * from './Labware'
 


### PR DESCRIPTION
## Overview

Some refactors and light fixes to simplify the `CalibrationBlockRender` component. This component is used in OT-2 calibration flows to render a top-down view of the [calibration block](https://insights.opentrons.com/hubfs/Products/Modules/Calibration%20Block%20Manual.pdf).

Helps with EXEC-1573.

<img width="396" alt="Screenshot 2025-06-05 at 6 39 22 PM" src="https://github.com/user-attachments/assets/82c8a591-4750-4061-894a-ea8e4f0b7b31" />

## Test Plan and Hands on Testing

* [x] Check both calibration block definitions in the new Storybook story.
* [x] Make sure the block still shows up in the right place in the deck map in the OT-2 calibration flows.

## Changelog

Notable changes:

* Move the component from `app` to `components/hardware-sim`. This lets us make a Storybook story for it, and it lets us keep it next to the spiritually similar `LabwareAdapter` component.

* Simplify the way we position the rotated "SHORT" and "TALL" labels.

  Formerly, they were positioned in outer space, and then an SVG `rotate()` transform swung them in a wide arc around the labware origin to land in their final position. So you had to choose the outer-space coordinates carefully, and you'd have to reason through things like x- and y-coordinates being swapped. Now, we position the text where we want it and rotate it in-place.

* Exactly vertically align the middle of the "SHORT" and "TALL" labels to the middle of the labware.

  The former code was positioning the labels by their edge and seemingly trying to align them by hard-coded offsets, which was visibly off-center once you noticed it.

## Review requests

Baby's 1st Storybook story. See questions below.

## Risk assessment

Low. Easy to test.
