### PR TITLE
chore(app-shell): disable windows signing better

### DIFF
--- a/app-shell/electron-builder.config.js
+++ b/app-shell/electron-builder.config.js
@@ -67,12 +67,12 @@ module.exports = async () => ({
     target: ['nsis'],
     icon: project === 'robot-stack' ? 'build/icon.ico' : 'build/three.ico',
     forceCodeSigning: WINDOWS_SIGN,
-    azureSignOptions: {
+    azureSignOptions: WINDOWS_SIGN ? {
       publisherName: 'OPENTRONS LABWORKS INC.',
       codeSigningAccountName: 'desktop-app-signing',
       certificateProfileName: 'OpentronsDesktopApp',
       endpoint: 'https://eus.codesigning.azure.net',
-    },
+    } : undefined,
   },
   nsis: {
     oneClick: false,

--- a/app-shell/electron-builder.config.js
+++ b/app-shell/electron-builder.config.js
@@ -67,12 +67,14 @@ module.exports = async () => ({
     target: ['nsis'],
     icon: project === 'robot-stack' ? 'build/icon.ico' : 'build/three.ico',
     forceCodeSigning: WINDOWS_SIGN,
-    azureSignOptions: WINDOWS_SIGN ? {
-      publisherName: 'OPENTRONS LABWORKS INC.',
-      codeSigningAccountName: 'desktop-app-signing',
-      certificateProfileName: 'OpentronsDesktopApp',
-      endpoint: 'https://eus.codesigning.azure.net',
-    } : undefined,
+    azureSignOptions: WINDOWS_SIGN
+      ? {
+          publisherName: 'OPENTRONS LABWORKS INC.',
+          codeSigningAccountName: 'desktop-app-signing',
+          certificateProfileName: 'OpentronsDesktopApp',
+          endpoint: 'https://eus.codesigning.azure.net',
+        }
+      : undefined,
   },
   nsis: {
     oneClick: false,


### PR DESCRIPTION
Setting forceCodeSigning=false means that builds won't fail if "the app would not be signed", but I think that means "if you haven't specified signing details", not "the shell call to sign the executables fails" - if the latter happens, the build fails anyway. So if we're not signing, just don't even specify the sign options.
