### PR TITLE
chore: Fix `make teardown-py` and `make clean-py` using outdated shared-data sub-make commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,10 @@ teardown-py: $(PYTHON_TEARDOWN_TARGETS)
 %-py-teardown: %-py-clean
 	$(MAKE) -C $* teardown
 
+# Specialize the %-py-teardown pattern rule above to account for the Makefile duopoly in shared-data.
+$(SHARED_DATA_DIR)-py-teardown: $(SHARED_DATA_DIR)-py-clean
+	$(MAKE) -C $(SHARED_DATA_DIR) teardown-py
+
 # clean all project output
 .PHONY: clean
 clean: clean-js clean-py
@@ -116,6 +120,10 @@ clean-py: $(PYTHON_CLEAN_TARGETS)
 
 %-py-clean:
 	$(MAKE) -C $* clean
+
+# Specialize the %-py-clean pattern rule above to account for the Makefile duopoly in shared-data.
+$(SHARED_DATA_DIR)-py-clean:
+	$(MAKE) -C $(SHARED_DATA_DIR) clean-py
 
 .PHONY: deploy-py
 deploy-py: export twine_repository_url = $(twine_repository_url)


### PR DESCRIPTION
# Overview

After PR #18377/#18538, `make teardown-py` was failing:

* It was delegating to `make -C shared-data teardown`, which does not exist. It needs to be `make -C shared-data teardown-py` now.
* It was delegating to `make -C shared-data clean`, which does not do the right thing. It cleans both JS and Python. We want `clean-py` for just Python.

## Test Plan and Hands on Testing

* [x] Test them locally and make sure they run the correct sub-make commands now.

## Review requests

None in particular.

## Risk assessment

Low.