### PR TITLE
feat(protocol-designer): filter liquid class options and show warning

### DIFF
--- a/protocol-designer/src/constants.ts
+++ b/protocol-designer/src/constants.ts
@@ -257,3 +257,5 @@ export const CHANNELS_MAPPED_TO_MAX_SPEED: Record<
     },
   },
 }
+
+export const MINIMUM_LIQUID_CLASS_VOLUME = 1

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MixTools/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MixTools/index.tsx
@@ -12,7 +12,10 @@ import {
   getLabwareEntities,
   getPipetteEntities,
 } from '../../../../../../step-forms/selectors'
-import { useAssignLiquidClass } from '../MoveLiquidTools/hooks'
+import {
+  useAssignLiquidClass,
+  useSupportedLiquidClassOptions,
+} from '../MoveLiquidTools/hooks'
 import { LiquidClassesStepTools } from '../MoveLiquidTools/LiquidClassesStepTools'
 import { FirstStepMixTools } from './FirstStepMixTools'
 import { SecondStepMixTools } from './SecondStepMixTools'
@@ -57,6 +60,11 @@ export function MixTools(
     propsForFields.liquidClass.updateValue
   )
 
+  const orderedSupportedLiquidClassOptions = useSupportedLiquidClassOptions(
+    orderedLiquidClassOptions,
+    formData
+  )
+
   const stepComponents: Record<number, () => JSX.Element> = {
     0: () => (
       <FirstStepMixTools
@@ -76,7 +84,7 @@ export function MixTools(
             propsForFields={propsForFields}
             setShowFormErrors={setShowFormErrors}
             formData={formData}
-            orderedLiquidClassOptions={orderedLiquidClassOptions}
+            orderedLiquidClassOptions={orderedSupportedLiquidClassOptions}
             type="mix"
           />
         ) : (

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/hooks.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/hooks.ts
@@ -2,7 +2,10 @@ import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 
-import { getAllLiquidClassDefs } from '@opentrons/shared-data'
+import {
+  getAllLiquidClassDefs,
+  getFlexNameConversion,
+} from '@opentrons/shared-data'
 
 import {
   getCurrentFormIsPresaved,
@@ -15,6 +18,7 @@ import { getAllWellsFromPrimaryWells } from '../../../../../../steplist/formLeve
 import { getAllWellContentsForActiveItem } from '../../../../../../top-selectors/well-contents'
 import { getShouldUpdateForLiquidClass } from '../../utils'
 
+import type { PathOption } from '@opentrons/step-generation'
 import type { FormData } from '../../../../../../form-types'
 
 export interface LiquidClassOption {
@@ -132,4 +136,47 @@ export function useAssignLiquidClass(
   }, [formData[wellsField], formData[labwareField]])
 
   return orderedLiquidClassOptions
+}
+
+const MINIMUM_LIQUID_CLASS_VOLUME = 1
+
+export const useSupportedLiquidClassOptions = (
+  liquidClassOptions: LiquidClassOption[],
+  formData: FormData
+): LiquidClassOption[] => {
+  const { pipette, tipRack, volume: rawVolume } = formData
+  const path = 'path' in formData ? (formData.path as PathOption) : null // handle mix or move liquid forms
+  const pipetteEntities = useSelector(getPipetteEntities)
+  const liquidClasses = getAllLiquidClassDefs()
+  const pipetteEntity = pipetteEntities[pipette]
+
+  // early exit if pipette is not found to be permissive (not practical)
+  if (pipetteEntity == null) {
+    console.warn('No pipette found')
+    return liquidClassOptions
+  }
+
+  const pipetteName = getFlexNameConversion(pipetteEntity.spec)
+  const volume = Number(rawVolume)
+  if (volume < MINIMUM_LIQUID_CLASS_VOLUME) {
+    return []
+  }
+
+  const supportedOptions = liquidClassOptions.reduce<LiquidClassOption[]>(
+    (acc, option) => {
+      const liquidClass = liquidClasses[option.value]
+      const byTipLookup = liquidClass?.byPipette
+        .find(({ pipetteModel }) => pipetteModel === pipetteName)
+        ?.byTipType.find(({ tiprack }) => tiprack === tipRack)
+      if (
+        byTipLookup == null ||
+        (path === 'multiDispense' && !('multiDispense' in byTipLookup))
+      ) {
+        return acc
+      }
+      return [...acc, option]
+    },
+    []
+  )
+  return supportedOptions
 }

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/hooks.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/hooks.ts
@@ -7,6 +7,7 @@ import {
   getFlexNameConversion,
 } from '@opentrons/shared-data'
 
+import { MINIMUM_LIQUID_CLASS_VOLUME } from '../../../../../../constants'
 import {
   getCurrentFormIsPresaved,
   getCurrentFormUnsavedChangedFields,
@@ -137,8 +138,6 @@ export function useAssignLiquidClass(
 
   return orderedLiquidClassOptions
 }
-
-const MINIMUM_LIQUID_CLASS_VOLUME = 1
 
 export const useSupportedLiquidClassOptions = (
   liquidClassOptions: LiquidClassOption[],

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/index.tsx
@@ -5,7 +5,7 @@ import { FLEX_ROBOT_TYPE } from '@opentrons/shared-data'
 import { getEnableLiquidClasses } from '../../../../../../feature-flags/selectors'
 import { getRobotType } from '../../../../../../file-data/selectors'
 import { FirstStepMoveLiquidTools } from './FirstStepMoveLiquidTools'
-import { useAssignLiquidClass } from './hooks'
+import { useAssignLiquidClass, useSupportedLiquidClassOptions } from './hooks'
 import { LiquidClassesStepTools } from './LiquidClassesStepTools'
 import { SecondStepsMoveLiquidTools } from './SecondStepsMoveLiquidTools'
 
@@ -27,6 +27,11 @@ export function MoveLiquidTools(props: StepFormProps): JSX.Element {
     'aspirate_wells',
     propsForFields.liquidClass.updateValue
   )
+
+  const orderedSupportedLiquidClassOptions = useSupportedLiquidClassOptions(
+    orderedLiquidClassOptions,
+    formData
+  )
   const robotType = useSelector(getRobotType)
 
   const renderStepComponent = (): JSX.Element => {
@@ -47,7 +52,7 @@ export function MoveLiquidTools(props: StepFormProps): JSX.Element {
                 formData={formData}
                 setShowFormErrors={setShowFormErrors}
                 type="transfer"
-                orderedLiquidClassOptions={orderedLiquidClassOptions}
+                orderedLiquidClassOptions={orderedSupportedLiquidClassOptions}
               />
             ) : (
               <SecondStepsMoveLiquidTools

--- a/protocol-designer/src/pages/ProtocolOverview/index.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/index.tsx
@@ -94,6 +94,7 @@ export function ProtocolOverview(): JSX.Element {
   )
   const { timeline } = useSelector(fileSelectors.getRobotStateTimeline)
   const hasCommands = timeline.length > 0
+  console.log(hasCommands)
   const dispatch: ThunkDispatch<any> = useDispatch()
   const [showMaterialsListModal, setShowMaterialsListModal] = useState<boolean>(
     false

--- a/protocol-designer/src/pages/ProtocolOverview/index.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/index.tsx
@@ -94,7 +94,7 @@ export function ProtocolOverview(): JSX.Element {
   )
   const { timeline } = useSelector(fileSelectors.getRobotStateTimeline)
   const hasCommands = timeline.length > 0
-  console.log(hasCommands)
+
   const dispatch: ThunkDispatch<any> = useDispatch()
   const [showMaterialsListModal, setShowMaterialsListModal] = useState<boolean>(
     false

--- a/protocol-designer/src/steplist/formLevel/index.ts
+++ b/protocol-designer/src/steplist/formLevel/index.ts
@@ -74,6 +74,7 @@ import {
 import {
   belowPipetteMinimumVolume,
   composeWarnings,
+  incompatibleLiquidClass,
   maxDispenseWellVolume,
   minAspirateAirGapVolume,
   minDispenseAirGapVolume,
@@ -179,7 +180,8 @@ const stepFormHelperMap: {
     ),
     getWarnings: composeWarnings(
       belowPipetteMinimumVolume,
-      mixTipPositionInTube
+      mixTipPositionInTube,
+      incompatibleLiquidClass
     ),
   },
   pause: {
@@ -233,7 +235,8 @@ const stepFormHelperMap: {
       minDisposalVolume,
       minAspirateAirGapVolume,
       minDispenseAirGapVolume,
-      tipPositionInTube
+      tipPositionInTube,
+      incompatibleLiquidClass
     ),
   },
   magnet: {

--- a/protocol-designer/src/steplist/formLevel/test/warnings.test.ts
+++ b/protocol-designer/src/steplist/formLevel/test/warnings.test.ts
@@ -1,18 +1,31 @@
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { fixture24Tuberack, fixture96Plate } from '@opentrons/shared-data'
+import {
+  fixture24Tuberack,
+  fixture96Plate,
+  getAllLiquidClassDefs,
+} from '@opentrons/shared-data'
 
 import {
   _minAirGapVolume,
   belowPipetteMinimumVolume,
+  incompatibleLiquidClass,
   maxDispenseWellVolume,
   minDisposalVolume,
   mixTipPositionInTube,
   tipPositionInTube,
 } from '../warnings'
 
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition2, LiquidClass } from '@opentrons/shared-data'
 import type { LabwareEntity } from '@opentrons/step-generation'
+
+vi.mock('@opentrons/shared-data', async () => {
+  const actual = await vi.importActual('@opentrons/shared-data')
+  return {
+    ...actual,
+    getAllLiquidClassDefs: vi.fn(),
+  }
+})
 
 type CheckboxFields = 'aspirate_airGap_checkbox' | 'dispense_airGap_checkbox'
 type VolumeFields = 'aspirate_airGap_volume' | 'dispense_airGap_volume'
@@ -336,5 +349,107 @@ describe('Max dispense well volume', () => {
       expect(tipPositionInTube(fields as any)).toBe(null)
       expect(mixTipPositionInTube(fields as any)).toBe(null)
     })
+  })
+})
+
+const MOCK_GLYCEROL = {
+  liquidClassName: 'glycerol50V1',
+  byPipette: [
+    {
+      pipetteModel: 'flex_1channel_1000',
+      byTipType: [
+        {
+          tiprack: 'opentrons/opentrons_flex_96_tiprack_1000ul/1',
+          aspirate: {},
+          singleDispense: {},
+          multiDispense: {},
+        },
+      ],
+    },
+  ],
+} as LiquidClass
+const MOCK_WATER = {
+  liquidClassName: 'waterV1',
+  byPipette: [
+    {
+      pipetteModel: 'flex_1channel_1000',
+      byTipType: [
+        {
+          tiprack: 'opentrons/opentrons_flex_96_tiprack_1000ul/1',
+          aspirate: {},
+          singleDispense: {},
+          multiDispense: {},
+        },
+      ],
+    },
+  ],
+} as LiquidClass
+describe('class compatibility', () => {
+  let fields: any
+  beforeEach(() => {
+    fields = {
+      pipette: {
+        spec: { channels: 1, liquids: { default: { maxVolume: 1000 } } },
+      },
+      tipRack: 'opentrons/opentrons_flex_96_tiprack_1000ul/1',
+      liquidClass: 'glycerol_50',
+      path: 'singleDispense',
+    }
+    vi.mocked(getAllLiquidClassDefs).mockReturnValue({
+      glycerol_50: MOCK_GLYCEROL,
+      water: MOCK_WATER,
+    })
+  })
+
+  it('should return null if the liquid class is compatible with the pipette, tips, volume, and path', () => {
+    expect(incompatibleLiquidClass(fields)).toBe(null)
+  })
+  it('should return liquid classes incompatible with the pipette warning if pipette incompatible with all liquid classes', () => {
+    fields = {
+      ...fields,
+      pipette: {
+        spec: { channels: 2, liquids: { default: { maxVolume: 1000 } } },
+      },
+    }
+    expect(incompatibleLiquidClass(fields)?.type).toBe(
+      'INCOMPATIBLE_ALL_PIPETTE'
+    )
+  })
+  it('should return liquid classes incompatible with the pipette warning if pipette incompatible with some liquid classes', () => {
+    vi.mocked(getAllLiquidClassDefs).mockReturnValue({
+      water: MOCK_WATER,
+      glycerol_50: { ...MOCK_GLYCEROL, byPipette: [] },
+    })
+    expect(incompatibleLiquidClass(fields)?.type).toBe(
+      'INCOMPATIBLE_SOME_PIPETTE'
+    )
+  })
+  it('should return liquid classes incompatible with the pipette warning if tiprack incompatible with all liquid classes', () => {
+    fields = {
+      ...fields,
+      tipRack: 'badTiprack',
+    }
+    expect(incompatibleLiquidClass(fields)?.type).toBe(
+      'INCOMPATIBLE_TIP_RACK_ALL'
+    )
+  })
+  it('should return liquid classes incompatible with the pipette warning if tiprack incompatible with some liquid classes', () => {
+    vi.mocked(getAllLiquidClassDefs).mockReturnValue({
+      water: MOCK_WATER,
+      glycerol_50: {
+        ...MOCK_GLYCEROL,
+        byPipette: [{ pipetteModel: 'flex_1channel_1000', byTipType: [] }],
+      },
+    })
+    expect(incompatibleLiquidClass(fields)?.type).toBe(
+      'INCOMPATIBLE_TIP_RACK_SOME'
+    )
+  })
+  it('should return liquid classes incompatible with the pipette warning if pipette incompatible with all liquid classes', () => {
+    fields = {
+      ...fields,
+      volume: 0.01,
+    }
+    expect(incompatibleLiquidClass(fields)?.type).toBe('LOW_VOLUME_TRANSFER')
   })
 })

--- a/protocol-designer/src/steplist/formLevel/warnings.tsx
+++ b/protocol-designer/src/steplist/formLevel/warnings.tsx
@@ -262,31 +262,33 @@ export const _incompatibleSomeTipRackWarning = (): FormWarning => ({
   dependentFields: ['pipette', 'tipRack'],
   location: 'form',
 })
-type ReasonForWarning =
-  | 'pipetteAll'
-  | 'pipetteSome'
-  | 'tipRackAll'
-  | 'tipRackSome'
-  | 'volume'
-  | 'path'
+
+enum ReasonForWarning {
+  PipetteAll = 'PIPETTE_ALL',
+  PipetteSome = 'PIPETTE_SOME',
+  TipRackAll = 'TIP_RACK_ALL',
+  TipRackSome = 'TIP_RACK_SOME',
+  Volume = 'VOLUME',
+  Path = 'PATH',
+}
 const priorityMap: Record<ReasonForWarning, number> = {
-  pipetteAll: 0,
-  tipRackAll: 1,
-  pipetteSome: 2,
-  tipRackSome: 3,
-  volume: 4,
-  path: 5,
+  [ReasonForWarning.PipetteAll]: 0,
+  [ReasonForWarning.TipRackAll]: 1,
+  [ReasonForWarning.PipetteSome]: 2,
+  [ReasonForWarning.TipRackSome]: 3,
+  [ReasonForWarning.Volume]: 4,
+  [ReasonForWarning.Path]: 5,
 }
 const mappedLiquidClassReasonToWarning: Record<
   ReasonForWarning,
   () => FormWarning
 > = {
-  pipetteAll: _incompatibleAllPipetteWarning,
-  pipetteSome: _incompatibleSomePipetteWarning,
-  tipRackAll: _incompatibleAllTipRackWarning,
-  tipRackSome: _incompatibleSomeTipRackWarning,
-  volume: _lowVolumeTransferWarning,
-  path: _incompatiblePipettePathWarning,
+  [ReasonForWarning.PipetteAll]: _incompatibleAllPipetteWarning,
+  [ReasonForWarning.PipetteSome]: _incompatibleSomePipetteWarning,
+  [ReasonForWarning.TipRackAll]: _incompatibleAllTipRackWarning,
+  [ReasonForWarning.TipRackSome]: _incompatibleSomeTipRackWarning,
+  [ReasonForWarning.Volume]: _lowVolumeTransferWarning,
+  [ReasonForWarning.Path]: _incompatiblePipettePathWarning,
 }
 export const incompatibleLiquidClass: (
   fields: HydratedMoveLiquidFormData | HydratedMixFormData
@@ -314,7 +316,7 @@ export const incompatibleLiquidClass: (
       ({ pipetteModel }) => pipetteModel === pipetteName
     )
     if (pipetteObject == null) {
-      updatedReasonForWarning('pipetteSome')
+      updatedReasonForWarning(ReasonForWarning.PipetteSome)
       numIncompatibleLiquidClassesForPipette += 1
       return
     }
@@ -324,27 +326,24 @@ export const incompatibleLiquidClass: (
     )
 
     if (tipRackObject == null) {
-      updatedReasonForWarning('tipRackSome')
+      updatedReasonForWarning(ReasonForWarning.TipRackSome)
       numIncompatibleLiquidClassesForTiprack += 1
       return
     }
     if (path === 'multiDispense' && !('multiDispense' in tipRackObject)) {
-      updatedReasonForWarning('path')
+      updatedReasonForWarning(ReasonForWarning.Path)
     }
   })
 
   if (volume < MINIMUM_LIQUID_CLASS_VOLUME) {
-    updatedReasonForWarning('volume')
+    updatedReasonForWarning(ReasonForWarning.Volume)
   }
 
-  if (
-    numIncompatibleLiquidClassesForPipette === Object.keys(liquidClasses).length
-  ) {
-    reasonForWarning = 'pipetteAll'
-  } else if (
-    numIncompatibleLiquidClassesForTiprack === Object.keys(liquidClasses).length
-  ) {
-    reasonForWarning = 'tipRackAll'
+  const numLiquidClasses = Object.keys(liquidClasses).length
+  if (numIncompatibleLiquidClassesForPipette === numLiquidClasses) {
+    reasonForWarning = ReasonForWarning.PipetteAll
+  } else if (numIncompatibleLiquidClassesForTiprack === numLiquidClasses) {
+    reasonForWarning = ReasonForWarning.TipRackAll
   }
 
   return reasonForWarning != null

--- a/protocol-designer/src/steplist/formLevel/warnings.tsx
+++ b/protocol-designer/src/steplist/formLevel/warnings.tsx
@@ -4,6 +4,8 @@ import {
   getWellTotalVolume,
 } from '@opentrons/shared-data'
 
+import { MINIMUM_LIQUID_CLASS_VOLUME } from '../../constants'
+
 import type { LabwareDefinition2 } from '@opentrons/shared-data'
 import type { PathOption } from '@opentrons/step-generation'
 import type {
@@ -33,8 +35,6 @@ export type FormWarningType =
 export type FormWarning = FormError & {
   type: FormWarningType
 }
-
-const MINIMUM_LIQUID_CLASS_VOLUME = 1
 
 const belowMinAirGapVolumeWarning = (min: number): FormWarning => ({
   type: 'BELOW_MIN_AIR_GAP_VOLUME',

--- a/protocol-designer/src/steplist/formLevel/warnings.tsx
+++ b/protocol-designer/src/steplist/formLevel/warnings.tsx
@@ -235,14 +235,14 @@ export const _incompatiblePipettePathWarning = (): FormWarning => ({
   location: 'form',
 })
 
-export const _incompatibleAllPipetteLabwareWarning = (): FormWarning => ({
+export const _incompatibleAllPipetteWarning = (): FormWarning => ({
   type: 'INCOMPATIBLE_ALL_PIPETTE',
   title: `The selected pipette is incompatible with liquid classes.`,
   dependentFields: ['pipette', 'tipRack'],
   location: 'form',
 })
 
-export const _incompatibleSomePipetteLabwareWarning = (): FormWarning => ({
+export const _incompatibleSomePipetteWarning = (): FormWarning => ({
   type: 'INCOMPATIBLE_SOME_PIPETTE',
   title: `The selected pipette is incompatible with some liquid classes.`,
   dependentFields: ['pipette', 'tipRack'],
@@ -281,8 +281,8 @@ const mappedLiquidClassReasonToWarning: Record<
   ReasonForWarning,
   () => FormWarning
 > = {
-  pipetteAll: _incompatibleAllPipetteLabwareWarning,
-  pipetteSome: _incompatibleSomePipetteLabwareWarning,
+  pipetteAll: _incompatibleAllPipetteWarning,
+  pipetteSome: _incompatibleSomePipetteWarning,
   tipRackAll: _incompatibleAllTipRackWarning,
   tipRackSome: _incompatibleSomeTipRackWarning,
   volume: _lowVolumeTransferWarning,

--- a/protocol-designer/src/steplist/formLevel/warnings.tsx
+++ b/protocol-designer/src/steplist/formLevel/warnings.tsx
@@ -1,6 +1,11 @@
-import { getWellTotalVolume } from '@opentrons/shared-data'
+import {
+  getAllLiquidClassDefs,
+  getFlexNameConversion,
+  getWellTotalVolume,
+} from '@opentrons/shared-data'
 
 import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { PathOption } from '@opentrons/step-generation'
 import type {
   HydratedFormData,
   HydratedMixFormData,
@@ -16,13 +21,20 @@ export type FormWarningType =
   | 'BELOW_MIN_AIR_GAP_VOLUME'
   | 'BELOW_MIN_DISPOSAL_VOLUME'
   | 'BELOW_PIPETTE_MINIMUM_VOLUME'
-  | 'OVER_MAX_WELL_VOLUME'
+  | 'INCOMPATIBLE_ALL_PIPETTE'
+  | 'INCOMPATIBLE_PIPETTE_PATH'
+  | 'INCOMPATIBLE_SOME_PIPETTE'
+  | 'INCOMPATIBLE_TIP_RACK_ALL'
+  | 'INCOMPATIBLE_TIP_RACK_SOME'
+  | 'LOW_VOLUME_TRANSFER'
   | 'MIX_TIP_POSITIONED_LOW_IN_TUBE'
+  | 'OVER_MAX_WELL_VOLUME'
   | 'TIP_POSITIONED_LOW_IN_TUBE'
-
 export type FormWarning = FormError & {
   type: FormWarningType
 }
+
+const MINIMUM_LIQUID_CLASS_VOLUME = 1
 
 const belowMinAirGapVolumeWarning = (min: number): FormWarning => ({
   type: 'BELOW_MIN_AIR_GAP_VOLUME',
@@ -208,6 +220,137 @@ export const minDispenseAirGapVolume: (
   'dispense_airGap_checkbox',
   'dispense_airGap_volume'
 )
+
+export const _lowVolumeTransferWarning = (): FormWarning => ({
+  type: 'LOW_VOLUME_TRANSFER',
+  title: `Transfer volumes of ${MINIMUM_LIQUID_CLASS_VOLUME} µL or less are incompatible with liquid classes.`,
+  dependentFields: ['volume'],
+  location: 'form',
+})
+
+export const _incompatiblePipettePathWarning = (): FormWarning => ({
+  type: 'INCOMPATIBLE_PIPETTE_PATH',
+  title: 'The selected pipette path is incompatible with some liquid classes.',
+  dependentFields: ['path', 'pipette', 'tipRack'],
+  location: 'form',
+})
+
+export const _incompatibleAllPipetteLabwareWarning = (): FormWarning => ({
+  type: 'INCOMPATIBLE_ALL_PIPETTE',
+  title: `The selected pipette is incompatible with liquid classes.`,
+  dependentFields: ['pipette', 'tipRack'],
+  location: 'form',
+})
+
+export const _incompatibleSomePipetteLabwareWarning = (): FormWarning => ({
+  type: 'INCOMPATIBLE_SOME_PIPETTE',
+  title: `The selected pipette is incompatible with some liquid classes.`,
+  dependentFields: ['pipette', 'tipRack'],
+  location: 'form',
+})
+
+export const _incompatibleAllTipRackWarning = (): FormWarning => ({
+  type: 'INCOMPATIBLE_TIP_RACK_ALL',
+  title: `The selected tiprack is incompatible with all liquid classes.`,
+  dependentFields: ['pipette', 'tipRack'],
+  location: 'form',
+})
+
+export const _incompatibleSomeTipRackWarning = (): FormWarning => ({
+  type: 'INCOMPATIBLE_TIP_RACK_SOME',
+  title: `The selected tiprack is incompatible with some liquid classes.`,
+  dependentFields: ['pipette', 'tipRack'],
+  location: 'form',
+})
+type ReasonForWarning =
+  | 'pipetteAll'
+  | 'pipetteSome'
+  | 'tipRackAll'
+  | 'tipRackSome'
+  | 'volume'
+  | 'path'
+const priorityMap: Record<ReasonForWarning, number> = {
+  pipetteAll: 0,
+  tipRackAll: 1,
+  pipetteSome: 2,
+  tipRackSome: 3,
+  volume: 4,
+  path: 5,
+}
+const mappedLiquidClassReasonToWarning: Record<
+  ReasonForWarning,
+  () => FormWarning
+> = {
+  pipetteAll: _incompatibleAllPipetteLabwareWarning,
+  pipetteSome: _incompatibleSomePipetteLabwareWarning,
+  tipRackAll: _incompatibleAllTipRackWarning,
+  tipRackSome: _incompatibleSomeTipRackWarning,
+  volume: _lowVolumeTransferWarning,
+  path: _incompatiblePipettePathWarning,
+}
+export const incompatibleLiquidClass: (
+  fields: HydratedMoveLiquidFormData | HydratedMixFormData
+) => FormWarning | null = formData => {
+  const { pipette, tipRack, volume: rawVolume } = formData
+  const liquidClasses = getAllLiquidClassDefs()
+
+  const pipetteName = getFlexNameConversion(pipette.spec)
+  const volume = Number(rawVolume)
+  const path = 'path' in formData ? (formData.path as PathOption) : null
+
+  let reasonForWarning: ReasonForWarning | null = null
+  let numIncompatibleLiquidClassesForPipette = 0
+  let numIncompatibleLiquidClassesForTiprack = 0
+  const updatedReasonForWarning = (newReason: ReasonForWarning): void => {
+    if (
+      reasonForWarning == null ||
+      priorityMap[newReason] < priorityMap[reasonForWarning]
+    ) {
+      reasonForWarning = newReason
+    }
+  }
+  Object.values(liquidClasses).forEach(liquidClass => {
+    const pipetteObject = liquidClass.byPipette.find(
+      ({ pipetteModel }) => pipetteModel === pipetteName
+    )
+    if (pipetteObject == null) {
+      updatedReasonForWarning('pipetteSome')
+      numIncompatibleLiquidClassesForPipette += 1
+      return
+    }
+
+    const tipRackObject = pipetteObject.byTipType.find(
+      ({ tiprack }) => tiprack === tipRack
+    )
+
+    if (tipRackObject == null) {
+      updatedReasonForWarning('tipRackSome')
+      numIncompatibleLiquidClassesForTiprack += 1
+      return
+    }
+    if (path === 'multiDispense' && !('multiDispense' in tipRackObject)) {
+      updatedReasonForWarning('path')
+    }
+  })
+
+  if (volume < MINIMUM_LIQUID_CLASS_VOLUME) {
+    updatedReasonForWarning('volume')
+  }
+
+  if (
+    numIncompatibleLiquidClassesForPipette === Object.keys(liquidClasses).length
+  ) {
+    reasonForWarning = 'pipetteAll'
+  } else if (
+    numIncompatibleLiquidClassesForTiprack === Object.keys(liquidClasses).length
+  ) {
+    reasonForWarning = 'tipRackAll'
+  }
+
+  return reasonForWarning != null
+    ? mappedLiquidClassReasonToWarning[reasonForWarning]()
+    : null
+}
 
 /*******************
  **     Helpers    **


### PR DESCRIPTION
# Overview

This PR wires up liquid class filtering based on form field selection on page 1 of moveLiquid and mix forms. It also wires up the warning logic for showing why some (if any) liquid classes are disabled based on those selections and for prioritizing which warning should show if there are multiple reasons for disabling.

Closes AUTH-1530

## Test Plan and Hands on Testing

Currently, all of our liquid classes support all Flex pipette, tip, and path combos (cool!), so we can only test the low volume (sub-1µl) property in practice.

Please also take a look at the logic in the new warnings.

## Changelog

- add new form warnings for liquid class incompatibility, including logic for determining warning priority
- add hook for filtering for only compatible liquid classes in moveLiquid and mix forms
- add tests

## Review requests

see test plan

## Risk assessment

low. the only scenario where liquid classes should be incompatible as of now are 1) OT-2 and 2) low volume