### PR TITLE
fix(hardware-testing): old liquid class method in gravimetric script

### DIFF
--- a/hardware-testing/hardware_testing/gravimetric/protocol_replacement/gravimetric.py
+++ b/hardware-testing/hardware_testing/gravimetric/protocol_replacement/gravimetric.py
@@ -25,7 +25,7 @@ from opentrons.config import infer_config_base_dir
 from opentrons.types import Point
 
 metadata = {"protocolName": "Gravimetric QC"}
-requirements = {"robotType": "Flex", "apiLevel": "2.23"}
+requirements = {"robotType": "Flex", "apiLevel": "2.24"}
 
 SCALE_SECONDS_TO_TRUE_STABILIZE = 60 * 3
 
@@ -222,7 +222,7 @@ class FixtureSettings:
         source_well = ctx.load_labware(labware_on_scale, slot_scale)[
             labware_on_scale_well_name
         ]
-        liquid_class = ctx.define_liquid_class(liquid_name)
+        liquid_class = ctx.get_liquid_class(liquid_name)
         liquid = ctx.define_liquid(liquid_name, liquid_desc, liquid_col)
         source_well.load_liquid(liquid, liquid_vol_estimate)
 

--- a/hardware-testing/hardware_testing/gravimetric/protocol_replacement/gravimetric.py
+++ b/hardware-testing/hardware_testing/gravimetric/protocol_replacement/gravimetric.py
@@ -21,11 +21,12 @@ from opentrons_shared_data.liquid_classes.liquid_class_definition import Coordin
 from opentrons.protocol_api.core.engine import (
     transfer_components_executor as tx_comps_executor,
 )
+from opentrons.protocols.api_support.definitions import MAX_SUPPORTED_VERSION
 from opentrons.config import infer_config_base_dir
 from opentrons.types import Point
 
 metadata = {"protocolName": "Gravimetric QC"}
-requirements = {"robotType": "Flex", "apiLevel": "2.24"}
+requirements = {"robotType": "Flex", "apiLevel": str(MAX_SUPPORTED_VERSION)}
 
 SCALE_SECONDS_TO_TRUE_STABILIZE = 60 * 3
 


### PR DESCRIPTION
# Overview

Updates the gravimetric test script to use the new `get_liquid_class()` function and makes it use the latest API version always.

## Review requests

Is it okay to update the API version of the script?

## Risk assessment

None for production code. 
High for testing code if updating the api version is going to have a big impact on testing. If not, then low-none risk.
