### PR TITLE
fix(cypress): verify before export in migration test

### DIFF
--- a/protocol-designer/cypress/support/Import.ts
+++ b/protocol-designer/cypress/support/Import.ts
@@ -57,7 +57,13 @@ export const verifyImportProtocolPage = (protocol: TestFile): void => {
     cy.contains(ContentStrings.protocolMetadata).should('be.visible')
     cy.contains(ContentStrings.instruments).should('be.visible')
     cy.contains(ContentStrings.protocolStartingDeck).should('be.visible')
-    cy.contains(String(protocolRead.metadata.protocolName)).should('be.visible')
+    if (!protocolRead.metadata.protocolName) {
+      cy.contains('Some name!').should('be.visible')
+    } else {
+      cy.contains(String(protocolRead.metadata.protocolName)).should(
+        'be.visible'
+      )
+    }
   })
 }
 
@@ -82,15 +88,13 @@ export const migrateAndMatchSnapshot = ({
       .click({ force: true })
   }
 
-  cy.get('button')
-    .contains('Edit protocol', { matchCase: false })
-    .click({ force: true })
+  verifyImportProtocolPage(uploadProtocol)
+  cy.contains('Edit protocol').click()
 
   cy.screenshot('protocol-designer/migration-snapshot', {
     capture: 'viewport',
     overwrite: true,
   })
-  // cypres back button
 
   cy.get(LocatorStrings.exportProtocol).click({ force: true })
 

--- a/protocol-designer/cypress/support/Import.ts
+++ b/protocol-designer/cypress/support/Import.ts
@@ -82,6 +82,16 @@ export const migrateAndMatchSnapshot = ({
       .click({ force: true })
   }
 
+  cy.get('button')
+    .contains('Edit protocol', { matchCase: false })
+    .click({ force: true })
+
+  cy.screenshot('protocol-designer/migration-snapshot', {
+    capture: 'viewport',
+    overwrite: true,
+  })
+  // cypres back button
+
   cy.get(LocatorStrings.exportProtocol).click({ force: true })
 
   const expectedProtocol: TestFile = getTestFile(expectedTestFile)


### PR DESCRIPTION
## Race Condition

My guess is this is some sort of race condition where sometimes export was getting clicked before the protocol loaded fully
and then this modal was being displayed when it should not???
```js
const exportWarningModalElement = useBlockingHint({
    hintKey: 'no_commands',
    enabled: showModalWithWarning,
    content: content,
    handleCancel: cancelExportWarning,
    handleContinue: proceedExport,
  })
```
So my fix is to add protocol import verification and take a screen shot before clicking export.
It now seems to work every time and the modal never shows.