### PR TITLE
fix(protocol-designer): don't filter 'none' liquid class option

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/hooks.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/hooks.ts
@@ -164,6 +164,10 @@ export const useSupportedLiquidClassOptions = (
   const supportedOptions = liquidClassOptions.reduce<LiquidClassOption[]>(
     (acc, option) => {
       const liquidClass = liquidClasses[option.value]
+      if (liquidClass == null) {
+        // 'none' option
+        return [...acc, option]
+      }
       const byTipLookup = liquidClass?.byPipette
         .find(({ pipetteModel }) => pipetteModel === pipetteName)
         ?.byTipType.find(({ tiprack }) => tiprack === tipRack)


### PR DESCRIPTION
# Overview

Fix bug in `useSupportedLiquidClassOption` in which I accidentally filter out "Don't use a liquid class" option. This option should always be present.

## Test Plan and Hands on Testing

- open or create a transfer/mix step in a Flex protocol
- proceed to second page for liquid class selection and verify that "Don't use a liquid class" option is present

#### Before 

<img width="335" alt="Screenshot 2025-06-09 at 3 35 20 PM" src="https://github.com/user-attachments/assets/c6628176-c695-4908-905f-fc5e8057d91d" />

#### After 

<img width="321" alt="Screenshot 2025-06-09 at 3 34 25 PM" src="https://github.com/user-attachments/assets/02988d56-303d-4ddf-8af7-85d0b0e01601" />

## Changelog

- fix bug in `useSupportedLiquidClassOption` to always allow "none" option

## Review requests

see test plan

## Risk assessment

low
