### PR TITLE
feat(api): allow stacker overlap offset override and fix labware height calcuations for stacker movement

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/module_core.py
+++ b/api/src/opentrons/protocol_api/core/engine/module_core.py
@@ -839,19 +839,19 @@ class FlexStackerCore(ModuleCore, AbstractFlexStackerCore[LabwareCore]):
         labwares: _CoreTrio,
         overlap_offset: float | None = None,
     ) -> int:
-        definitions = [
-            x.get_engine_definition()
-            for x in [labwares.adapter, labwares.primary, labwares.lid]
-            if x is not None
-        ]
+        definitions = self._engine_client.state.labware.stacker_labware_pool_to_ordered_list(
+            labwares.primary.get_engine_definition(),
+            labwares.lid.get_engine_definition() if labwares.lid else None,
+            labwares.adapter.get_engine_definition() if labwares.adapter else None,
+        )
         pool_height = self._engine_client.state.geometry.get_height_of_labware_stack(
             definitions
         )
         pool_overlap = (
             overlap_offset
             if overlap_offset is not None
-            else self._engine_client.state.labware.get_labware_overlap_offsets(
-                definitions[-1], definitions[0].parameters.loadName
+            else self._engine_client.state.labware.get_stacker_labware_pool_overlap(
+                definitions
             ).z
         )
         return self._engine_client.state.modules.stacker_max_pool_count_by_height(

--- a/api/src/opentrons/protocol_api/core/engine/module_core.py
+++ b/api/src/opentrons/protocol_api/core/engine/module_core.py
@@ -908,6 +908,7 @@ class FlexStackerCore(ModuleCore, AbstractFlexStackerCore[LabwareCore]):
     def set_stored_labware_items(
         self,
         labware: Sequence[LabwareCore],
+        stacking_offset_z: float | None = None,
     ) -> None:
         """Configure the stacker to contain a set of labware."""
         core_groups = [self._core_groups_from_primary_core(core) for core in labware]
@@ -927,6 +928,7 @@ class FlexStackerCore(ModuleCore, AbstractFlexStackerCore[LabwareCore]):
                 primaryLabware=self._ssld_from_core(core_groups[0].primary),
                 lidLabware=self._ssld_from_core(core_groups[0].lid),
                 adapterLabware=self._ssld_from_core(core_groups[0].adapter),
+                poolOverlapOverride=stacking_offset_z,
             )
         )
 
@@ -942,6 +944,7 @@ class FlexStackerCore(ModuleCore, AbstractFlexStackerCore[LabwareCore]):
         adapter_namespace: str | None,
         adapter_version: int | None,
         count: int | None,
+        stacking_offset_z: float | None = None,
     ) -> None:
         """Configure the kind of labware that the stacker stores."""
 
@@ -997,5 +1000,6 @@ class FlexStackerCore(ModuleCore, AbstractFlexStackerCore[LabwareCore]):
                 primaryLabware=main_labware,
                 lidLabware=lid_labware,
                 adapterLabware=adapter_labware,
+                poolOverlapOverride=stacking_offset_z,
             )
         )

--- a/api/src/opentrons/protocol_api/core/engine/module_core.py
+++ b/api/src/opentrons/protocol_api/core/engine/module_core.py
@@ -852,7 +852,7 @@ class FlexStackerCore(ModuleCore, AbstractFlexStackerCore[LabwareCore]):
         pool_overlap = (
             overlap_offset
             if overlap_offset is not None
-            else self._engine_client.state.labware.get_stacker_labware_pool_overlap(
+            else self._engine_client.state.labware.get_stacker_labware_overlap_offset(
                 definitions
             ).z
         )

--- a/api/src/opentrons/protocol_api/core/engine/module_core.py
+++ b/api/src/opentrons/protocol_api/core/engine/module_core.py
@@ -928,7 +928,7 @@ class FlexStackerCore(ModuleCore, AbstractFlexStackerCore[LabwareCore]):
     def set_stored_labware_items(
         self,
         labware: Sequence[LabwareCore],
-        stacking_offset_z: float | None = None,
+        stacking_offset_z: float | None,
     ) -> None:
         """Configure the stacker to contain a set of labware."""
         core_groups = [self._core_groups_from_primary_core(core) for core in labware]

--- a/api/src/opentrons/protocol_api/core/engine/module_core.py
+++ b/api/src/opentrons/protocol_api/core/engine/module_core.py
@@ -824,12 +824,21 @@ class FlexStackerCore(ModuleCore, AbstractFlexStackerCore[LabwareCore]):
     def get_current_storable_labware(self) -> int:
         """Get the amount of space currently available for labware."""
         max_lw = self.get_max_storable_labware()
+        if max_lw is None:
+            location = self._engine_client.state.modules.get_location(self._module_id)
+            raise FlexStackerLabwarePoolNotYetDefinedError(
+                message=f"The Flex Stacker in {location} has not been configured yet and cannot be filled."
+            )
         current = len(
             self._engine_client.state.modules.stacker_contained_labware(self._module_id)
         )
         return max_lw - current
 
-    def _predict_storable_count(self, labwares: _CoreTrio) -> int:
+    def _predict_storable_count(
+        self,
+        labwares: _CoreTrio,
+        overlap_offset: float | None = None,
+    ) -> int:
         definitions = [
             x.get_engine_definition()
             for x in [labwares.adapter, labwares.primary, labwares.lid]
@@ -838,23 +847,38 @@ class FlexStackerCore(ModuleCore, AbstractFlexStackerCore[LabwareCore]):
         pool_height = self._engine_client.state.geometry.get_height_of_labware_stack(
             definitions
         )
-        overlap = self._engine_client.state.labware.get_labware_overlap_offsets(
-            definitions[-1], definitions[0].parameters.loadName
+        pool_overlap = (
+            overlap_offset
+            if overlap_offset is not None
+            else self._engine_client.state.labware.get_labware_overlap_offsets(
+                definitions[-1], definitions[0].parameters.loadName
+            ).z
         )
         return self._engine_client.state.modules.stacker_max_pool_count_by_height(
-            self._module_id, pool_height, overlap.z
+            self._module_id, pool_height, pool_overlap
         )
 
     def get_max_storable_labware_from_list(
         self,
         labware: Sequence[LabwareCore],
+        overlap_offset: float | None = None,
     ) -> Sequence[LabwareCore]:
         """Limit the passed list to how many labware can fit in a stacker."""
         if not labware:
             return labware
-        max_count = self._predict_storable_count(
-            self._core_groups_from_primary_core(labware[0])
-        )
+        max_count: int
+        try:
+            # if the stacker has been configured, make sure the provided overlap
+            # offset, if any, matches the configured one
+            max_count = self.get_max_storable_labware()
+            if overlap_offset is not None:
+                self._engine_client.state.modules.validate_stacker_overlap_offset(
+                    self._module_id, overlap_offset
+                )
+        except FlexStackerLabwarePoolNotYetDefinedError:
+            max_count = self._predict_storable_count(
+                self._core_groups_from_primary_core(labware[0]), overlap_offset
+            )
         return labware[:max_count]
 
     def get_current_storable_labware_from_list(
@@ -864,14 +888,8 @@ class FlexStackerCore(ModuleCore, AbstractFlexStackerCore[LabwareCore]):
         """Limit the passed list to how many labware can fit in the stacker right now."""
         if not labware:
             return labware
-        max_count = self._predict_storable_count(
-            self._core_groups_from_primary_core(labware[0])
-        )
-        current = len(
-            self._engine_client.state.modules.stacker_contained_labware(self._module_id)
-        )
-        total = max_count - current
-        return labware[:total]
+        storable = self.get_current_storable_labware()
+        return labware[:storable]
 
     def get_stored_labware(self) -> Sequence[LabwareCore]:
         """Get the currently-stored primary labware from the stacker."""

--- a/api/src/opentrons/protocol_api/core/engine/module_core.py
+++ b/api/src/opentrons/protocol_api/core/engine/module_core.py
@@ -839,10 +839,12 @@ class FlexStackerCore(ModuleCore, AbstractFlexStackerCore[LabwareCore]):
         labwares: _CoreTrio,
         overlap_offset: float | None = None,
     ) -> int:
-        definitions = self._engine_client.state.labware.stacker_labware_pool_to_ordered_list(
-            labwares.primary.get_engine_definition(),
-            labwares.lid.get_engine_definition() if labwares.lid else None,
-            labwares.adapter.get_engine_definition() if labwares.adapter else None,
+        definitions = (
+            self._engine_client.state.labware.stacker_labware_pool_to_ordered_list(
+                labwares.primary.get_engine_definition(),
+                labwares.lid.get_engine_definition() if labwares.lid else None,
+                labwares.adapter.get_engine_definition() if labwares.adapter else None,
+            )
         )
         pool_height = self._engine_client.state.geometry.get_height_of_labware_stack(
             definitions

--- a/api/src/opentrons/protocol_api/core/module.py
+++ b/api/src/opentrons/protocol_api/core/module.py
@@ -435,6 +435,7 @@ class AbstractFlexStackerCore(
     def set_stored_labware_items(
         self,
         labware: Sequence[LabwareCoreType],
+        stacking_offset_z: float | None = None,
     ) -> None:
         """Configure the stacker to contain a set of labware."""
 
@@ -477,5 +478,6 @@ class AbstractFlexStackerCore(
         adapter_namespace: str | None,
         adapter_version: int | None,
         count: int | None,
+        stacking_offset_z: float | None = None,
     ) -> None:
         """Configure the kind of labware that the stacker stores."""

--- a/api/src/opentrons/protocol_api/core/module.py
+++ b/api/src/opentrons/protocol_api/core/module.py
@@ -435,7 +435,7 @@ class AbstractFlexStackerCore(
     def set_stored_labware_items(
         self,
         labware: Sequence[LabwareCoreType],
-        stacking_offset_z: float | None = None,
+        stacking_offset_z: float | None,
     ) -> None:
         """Configure the stacker to contain a set of labware."""
 

--- a/api/src/opentrons/protocol_api/core/module.py
+++ b/api/src/opentrons/protocol_api/core/module.py
@@ -451,6 +451,7 @@ class AbstractFlexStackerCore(
     def get_max_storable_labware_from_list(
         self,
         labware: Sequence[LabwareCoreType],
+        overlap_offset: float | None = None,
     ) -> Sequence[LabwareCoreType]:
         """Limit the passed list to how many labware can fit in a stacker."""
 

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -1166,7 +1166,9 @@ class FlexStackerContext(ModuleContext):
 
     @requires_version(2, 24)
     def get_max_storable_labware_from_list(
-        self, labware: list[Labware]
+        self,
+        labware: list[Labware],
+        stacking_offset_z: float | None = None,
     ) -> list[Labware]:
         """Limit a list of labware instances to the number that can be stored in a Flex Stacker.
 
@@ -1183,22 +1185,31 @@ class FlexStackerContext(ModuleContext):
         can hold and will not change as labware is added or removed. To limit a list of labware to
         the amount that will currently fit in the Flex Stacker, use
         :py:meth:`.get_current_storable_labware_from_list`.
+
+        .. note::
+
+            If a stacking offset is provided, make sure the same value is used when
+            configuring the Flex Stacker with :py:meth:`.set_stored_labware_items`.
+
+            See :py:meth:`.set_stored_labware_items` for more details on stacking offset.
+
         """
         return self._cores_to_labware(
             self._core.get_max_storable_labware_from_list(
-                self._labware_to_cores(labware)
-            )
+                self._labware_to_cores(labware), stacking_offset_z
+            ),
         )
 
     @requires_version(2, 24)
     def get_current_storable_labware_from_list(
         self, labware: list[Labware]
     ) -> list[Labware]:
-        """Limit a list of labware instances to the number that the Flex Stacker currently has space for.
+        """Limit a list of labware instances to the number that the Flex Stacker currently has space for,
+        based on the labware that is already stored in the Flex Stacker.
 
         You can use this function to take a list of labware and return the elements that the
         stacker can currently store from it. The returned list is then guaranteed to be suitable
-        for passing to :py:meth:`.fill` or :py:meth:`.set_stored_labware_items`.
+        for passing to :py:meth:`.fill`.
 
         The number of elements in the returned list will change as labware is added to or removed from
         the Flex Stacker. To get a list limited to the overall maximum number of labware the Flex Stacker
@@ -1254,24 +1265,25 @@ class FlexStackerContext(ModuleContext):
         :param labware: A list of labware to load into the stacker.
         :param stacking_offset_z: Stacking offset in mm between labware units to override the
             calculated value from labware definitions.
-        
-        .. note::
-        The stacking offset is the amount of vertical overlap (in mm) between the bottomside of a
-        labware unit and the topside of the unit below. This offset is used to determine how many
-        units can fit in the stacker and calculates the Z position of the shuttle when retrieving
-        or storing labware. The stacking offset is calculated automatically from the labware
-        definitions, but you can override it by providing a value here.
 
-        There are four possible stacking configurations, each with a different way of calculating
-        the stacking offset:
-        - Bare labware: labware (bottomside) overlaps with labware (topside)
-        - Labware on adapter: the adapter (bottomside) of the upper unit overlaps with labware (topside)
-            of the unit below.
-        - Labware with lid: the labware (bottomside) of the upper unit overlaps the lid (topside)
-            of the unit below.
-        - Labware with lid and adapter: the adapter (bottomside) of the upper unit overlaps the
-            lid (topside) of the unit below.
-            
+        .. note::
+
+            The stacking offset is the amount of vertical overlap (in mm) between the bottomside of a
+            labware unit and the topside of the unit below. This offset is used to determine how many
+            units can fit in the stacker and calculates the Z position of the shuttle when retrieving
+            or storing labware. The stacking offset is calculated automatically from the labware
+            definitions, but you can override it by providing a value here.
+
+            There are four possible stacking configurations, each with a different way of calculating
+            the stacking offset:
+            - Bare labware: labware (bottomside) overlaps with labware (topside)
+            - Labware on adapter: the adapter (bottomside) of the upper unit overlaps with labware (topside)
+                of the unit below.
+            - Labware with lid: the labware (bottomside) of the upper unit overlaps the lid (topside)
+                of the unit below.
+            - Labware with lid and adapter: the adapter (bottomside) of the upper unit overlaps the
+                lid (topside) of the unit below.
+
         """
         self._core.set_stored_labware_items(
             self._labware_to_cores(labware),
@@ -1320,23 +1332,24 @@ class FlexStackerContext(ModuleContext):
             labware that the Flex Stacker is capable of storing.
         :param stacking_offset_z: Stacking offset in mm between labware units to override the
             calculated value from labware definitions.
-        
-        .. note::
-        The stacking offset is the amount of vertical overlap (in mm) between the bottomside of a
-        labware unit and the topside of the unit below. This offset is used to determine how many
-        units can fit in the stacker and calculates the Z position of the shuttle when retrieving
-        or storing labware. The stacking offset is calculated automatically from the labware
-        definitions, but you can override it by providing a value here.
 
-        There are four possible stacking configurations, each with a different way of calculating
-        the stacking offset:
-        - Bare labware: labware (bottomside) overlaps with labware (topside)
-        - Labware on adapter: the adapter (bottomside) of the upper unit overlaps with labware (topside)
-            of the unit below.
-        - Labware with lid: the labware (bottomside) of the upper unit overlaps the lid (topside)
-            of the unit below.
-        - Labware with lid and adapter: the adapter (bottomside) of the upper unit overlaps the
-            lid (topside) of the unit below.
+        .. note::
+
+            The stacking offset is the amount of vertical overlap (in mm) between the bottomside of a
+            labware unit and the topside of the unit below. This offset is used to determine how many
+            units can fit in the stacker and calculates the Z position of the shuttle when retrieving
+            or storing labware. The stacking offset is calculated automatically from the labware
+            definitions, but you can override it by providing a value here.
+
+            There are four possible stacking configurations, each with a different way of calculating
+            the stacking offset:
+            - Bare labware: labware (bottomside) overlaps with labware (topside)
+            - Labware on adapter: the adapter (bottomside) of the upper unit overlaps with labware (topside)
+                of the unit below.
+            - Labware with lid: the labware (bottomside) of the upper unit overlaps the lid (topside)
+                of the unit below.
+            - Labware with lid and adapter: the adapter (bottomside) of the upper unit overlaps the
+                lid (topside) of the unit below.
 
         """
         self._core.set_stored_labware(

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -1244,7 +1244,7 @@ class FlexStackerContext(ModuleContext):
     def set_stored_labware_items(
         self,
         labware: list[Labware],
-        stacking_offset_z: float | None = None,
+        stacking_offset_z: float | None,
     ) -> None:
         """Configure a Flex Stacker by providing an initial list of stored labware objects.
 

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -1252,11 +1252,26 @@ class FlexStackerContext(ModuleContext):
           will fit, use the return value of :py:method:`.get_max_storable_labware_from_list`.
 
         :param labware: A list of labware to load into the stacker.
-        :param stacking_offset_z: The amount of overlap between the labware when stacked
-            on top of each other. This is used to determine the max number of labware that
-            the Flex Stacker can store. The API uses the stacking offsets defined in
-            the labware definition, but you can override this by providing a value here.
+        :param stacking_offset_z: Stacking offset in mm between labware units to override the
+            calculated value from labware definitions.
+        
+        .. note::
+        The stacking offset is the amount of vertical overlap (in mm) between the bottomside of a
+        labware unit and the topside of the unit below. This offset is used to determine how many
+        units can fit in the stacker and calculates the Z position of the shuttle when retrieving
+        or storing labware. The stacking offset is calculated automatically from the labware
+        definitions, but you can override it by providing a value here.
 
+        There are four possible stacking configurations, each with a different way of calculating
+        the stacking offset:
+        - Bare labware: labware (bottomside) overlaps with labware (topside)
+        - Labware on adapter: the adapter (bottomside) of the upper unit overlaps with labware (topside)
+            of the unit below.
+        - Labware with lid: the labware (bottomside) of the upper unit overlaps the lid (topside)
+            of the unit below.
+        - Labware with lid and adapter: the adapter (bottomside) of the upper unit overlaps the
+            lid (topside) of the unit below.
+            
         """
         self._core.set_stored_labware_items(
             self._labware_to_cores(labware),
@@ -1303,10 +1318,25 @@ class FlexStackerContext(ModuleContext):
         :param count: The number of labware that the Flex Stacker should start the protocol
             storing. If not specified, this will be the maximum amount of this kind of
             labware that the Flex Stacker is capable of storing.
-        :param stacking_offset_z: The amount of overlap between the labware when stacked
-            on top of each other. This is used to determine the max number of labware that
-            the Flex Stacker can store. The API uses the stacking offsets defined in
-            the labware definition, but you can override this by providing a value here.
+        :param stacking_offset_z: Stacking offset in mm between labware units to override the
+            calculated value from labware definitions.
+        
+        .. note::
+        The stacking offset is the amount of vertical overlap (in mm) between the bottomside of a
+        labware unit and the topside of the unit below. This offset is used to determine how many
+        units can fit in the stacker and calculates the Z position of the shuttle when retrieving
+        or storing labware. The stacking offset is calculated automatically from the labware
+        definitions, but you can override it by providing a value here.
+
+        There are four possible stacking configurations, each with a different way of calculating
+        the stacking offset:
+        - Bare labware: labware (bottomside) overlaps with labware (topside)
+        - Labware on adapter: the adapter (bottomside) of the upper unit overlaps with labware (topside)
+            of the unit below.
+        - Labware with lid: the labware (bottomside) of the upper unit overlaps the lid (topside)
+            of the unit below.
+        - Labware with lid and adapter: the adapter (bottomside) of the upper unit overlaps the
+            lid (topside) of the unit below.
 
         """
         self._core.set_stored_labware(

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -1230,7 +1230,11 @@ class FlexStackerContext(ModuleContext):
         return self._core.get_current_storable_labware()
 
     @requires_version(2, 24)
-    def set_stored_labware_items(self, labware: list[Labware]) -> None:
+    def set_stored_labware_items(
+        self,
+        labware: list[Labware],
+        stacking_offset_z: float | None = None,
+    ) -> None:
         """Configure a Flex Stacker by providing an initial list of stored labware objects.
 
         The kind of labware stored by the Flex Stacker will be calculated from the list of labware
@@ -1248,8 +1252,16 @@ class FlexStackerContext(ModuleContext):
           will fit, use the return value of :py:method:`.get_max_storable_labware_from_list`.
 
         :param labware: A list of labware to load into the stacker.
+        :param stacking_offset_z: The amount of overlap between the labware when stacked
+            on top of each other. This is used to determine the max number of labware that
+            the Flex Stacker can store. The API uses the stacking offsets defined in
+            the labware definition, but you can override this by providing a value here.
+
         """
-        self._core.set_stored_labware_items(self._labware_to_cores(labware))
+        self._core.set_stored_labware_items(
+            self._labware_to_cores(labware),
+            stacking_offset_z=stacking_offset_z,
+        )
 
     @requires_version(2, 23)
     def set_stored_labware(
@@ -1260,6 +1272,7 @@ class FlexStackerContext(ModuleContext):
         adapter: str | None = None,
         lid: str | None = None,
         count: int | None = None,
+        stacking_offset_z: float | None = None,
     ) -> None:
         """Configure what kind of labware the Flex Stacker will store.
 
@@ -1290,6 +1303,10 @@ class FlexStackerContext(ModuleContext):
         :param count: The number of labware that the Flex Stacker should start the protocol
             storing. If not specified, this will be the maximum amount of this kind of
             labware that the Flex Stacker is capable of storing.
+        :param stacking_offset_z: The amount of overlap between the labware when stacked
+            on top of each other. This is used to determine the max number of labware that
+            the Flex Stacker can store. The API uses the stacking offsets defined in
+            the labware definition, but you can override this by providing a value here.
 
         """
         self._core.set_stored_labware(
@@ -1303,6 +1320,7 @@ class FlexStackerContext(ModuleContext):
             adapter_namespace=namespace,
             adapter_version=version,
             count=count,
+            stacking_offset_z=stacking_offset_z,
         )
 
     @requires_version(2, 23)

--- a/api/src/opentrons/protocol_engine/commands/flex_stacker/retrieve.py
+++ b/api/src/opentrons/protocol_engine/commands/flex_stacker/retrieve.py
@@ -225,9 +225,6 @@ class RetrieveImpl(AbstractCommandImpl[RetrieveParams, _ExecuteReturn]):
                 f"Cannot retrieve a labware from Flex Stacker in {location} if the carriage is occupied"
             )
 
-        labware_height = self._state_view.geometry.get_height_of_stacker_labware_pool(
-            params.moduleId
-        )
         to_retrieve = stacker_state.contained_labware_bottom_first[0]
         remaining = stacker_state.contained_labware_bottom_first[1:]
 
@@ -271,7 +268,9 @@ class RetrieveImpl(AbstractCommandImpl[RetrieveParams, _ExecuteReturn]):
         if stacker_hw is not None:
             try:
                 stacker_hw.set_stacker_identify(True)
-                await stacker_hw.dispense_labware(labware_height=labware_height)
+                await stacker_hw.dispense_labware(
+                    labware_height=stacker_state.get_pool_height_minus_overlap()
+                )
             except (
                 FlexStackerStallError,
                 FlexStackerShuttleMissingError,

--- a/api/src/opentrons/protocol_engine/commands/flex_stacker/set_stored_labware.py
+++ b/api/src/opentrons/protocol_engine/commands/flex_stacker/set_stored_labware.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 from typing import Optional, Literal, TYPE_CHECKING, Annotated
-from opentrons.protocols.api_support import definitions
 from typing_extensions import Type
 
 from pydantic import BaseModel, Field
@@ -206,7 +205,7 @@ class SetStoredLabwareImpl(
             )
 
         pool_definitions = (
-            self._state_view._labware.stacker_labware_pool_to_ordered_list(
+            self._state_view.labware.stacker_labware_pool_to_ordered_list(
                 labware_def, lid_def, adapter_def
             )
         )
@@ -218,7 +217,7 @@ class SetStoredLabwareImpl(
         pool_overlap = (
             params.poolOverlapOverride
             if params.poolOverlapOverride
-            else self._state_view._labware.get_stacker_labware_pool_overlap(
+            else self._state_view.labware.get_stacker_labware_overlap_offset(
                 pool_definitions
             ).z
         )

--- a/api/src/opentrons/protocol_engine/commands/flex_stacker/set_stored_labware.py
+++ b/api/src/opentrons/protocol_engine/commands/flex_stacker/set_stored_labware.py
@@ -80,6 +80,14 @@ class SetStoredLabwareParams(BaseModel):
         None,
         description=INITIAL_STORED_LABWARE_DESCRIPTION,
     )
+    poolOverlapOverride: Optional[float] = Field(
+        None,
+        description=(
+            "Override for the Z stacking overlap of the labware pool. If not "
+            "provided, the protocol engine will calculate the overlap based on "
+            "the stacking offsets provided in the labware definitions."
+        ),
+    )
 
 
 class SetStoredLabwareResult(BaseModel):
@@ -207,14 +215,18 @@ class SetStoredLabwareImpl(
             x for x in [lid_def, labware_def, adapter_def] if x is not None
         ]
 
-        overlap = self._state_view._labware.get_labware_overlap_offsets(
-            pool_definitions[-1], pool_definitions[0].parameters.loadName
+        z_overlap = (
+            params.poolOverlapOverride
+            if params.poolOverlapOverride
+            else self._state_view._labware.get_labware_overlap_offsets(
+                pool_definitions[-1], pool_definitions[0].parameters.loadName
+            ).z
         )
 
         max_pool_count = self._state_view.modules.stacker_max_pool_count_by_height(
             params.moduleId,
             pool_height,
-            overlap.z,
+            z_overlap,
         )
         groups_to_load = build_ids_to_fill(
             params.adapterLabware is not None,
@@ -239,7 +251,7 @@ class SetStoredLabwareImpl(
         state_update = state_update.update_flex_stacker_labware_pool_definition(
             params.moduleId,
             max_pool_count,
-            overlap.z,
+            z_overlap,
             labware_def,
             adapter_def,
             lid_def,

--- a/api/src/opentrons/protocol_engine/commands/flex_stacker/set_stored_labware.py
+++ b/api/src/opentrons/protocol_engine/commands/flex_stacker/set_stored_labware.py
@@ -215,7 +215,7 @@ class SetStoredLabwareImpl(
             x for x in [lid_def, labware_def, adapter_def] if x is not None
         ]
 
-        z_overlap = (
+        pool_overlap = (
             params.poolOverlapOverride
             if params.poolOverlapOverride
             else self._state_view._labware.get_labware_overlap_offsets(
@@ -226,7 +226,7 @@ class SetStoredLabwareImpl(
         max_pool_count = self._state_view.modules.stacker_max_pool_count_by_height(
             params.moduleId,
             pool_height,
-            z_overlap,
+            pool_overlap,
         )
         groups_to_load = build_ids_to_fill(
             params.adapterLabware is not None,
@@ -251,7 +251,8 @@ class SetStoredLabwareImpl(
         state_update = state_update.update_flex_stacker_labware_pool_definition(
             params.moduleId,
             max_pool_count,
-            z_overlap,
+            pool_overlap,
+            pool_height,
             labware_def,
             adapter_def,
             lid_def,

--- a/api/src/opentrons/protocol_engine/commands/flex_stacker/set_stored_labware.py
+++ b/api/src/opentrons/protocol_engine/commands/flex_stacker/set_stored_labware.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 from typing import Optional, Literal, TYPE_CHECKING, Annotated
+from opentrons.protocols.api_support import definitions
 from typing_extensions import Type
 
 from pydantic import BaseModel, Field
@@ -204,22 +205,21 @@ class SetStoredLabwareImpl(
                 version=params.adapterLabware.version,
             )
 
-        self._state_view.labware.raise_if_stacker_labware_pool_is_not_valid(
-            labware_def, lid_def, adapter_def
+        pool_definitions = (
+            self._state_view._labware.stacker_labware_pool_to_ordered_list(
+                labware_def, lid_def, adapter_def
+            )
         )
 
         pool_height = self._state_view.geometry.get_height_of_labware_stack(
-            [x for x in [lid_def, labware_def, adapter_def] if x is not None]
+            pool_definitions
         )
-        pool_definitions = [
-            x for x in [lid_def, labware_def, adapter_def] if x is not None
-        ]
 
         pool_overlap = (
             params.poolOverlapOverride
             if params.poolOverlapOverride
-            else self._state_view._labware.get_labware_overlap_offsets(
-                pool_definitions[-1], pool_definitions[0].parameters.loadName
+            else self._state_view._labware.get_stacker_labware_pool_overlap(
+                pool_definitions
             ).z
         )
 

--- a/api/src/opentrons/protocol_engine/commands/flex_stacker/store.py
+++ b/api/src/opentrons/protocol_engine/commands/flex_stacker/store.py
@@ -200,15 +200,13 @@ class StoreImpl(AbstractCommandImpl[StoreParams, _ExecuteReturn]):
         # Allow propagation of ModuleNotAttachedError.
         stacker_hw = self._equipment.get_module_hardware_api(stacker_state.module_id)
 
-        stack_height = self._state_view.geometry.get_height_of_labware_stack(
-            pool_definitions
-        )
-
         state_update = update_types.StateUpdate()
         try:
             if stacker_hw is not None:
                 stacker_hw.set_stacker_identify(True)
-                await stacker_hw.store_labware(labware_height=stack_height)
+                await stacker_hw.store_labware(
+                    labware_height=stacker_state.get_pool_height_minus_overlap()
+                )
         except FlexStackerStallError as e:
             return DefinedErrorData(
                 public=FlexStackerStallOrCollisionError(

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -1187,8 +1187,7 @@ class LabwareView:
     def get_stacker_labware_overlap_offset(
         self, definitions: list[LabwareDefinition]
     ) -> OverlapOffset:
-        """
-        Get the overlap amount between each labware pool.
+        """Get the overlap amount between each labware pool.
 
         The definitions must be in top-first order, ideally created by
         `stacker_labware_pool_to_ordered_list`.

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -1162,6 +1162,41 @@ class LabwareView:
                     f"Labware {adapter_labware_definition.parameters.loadName} cannot be used as an adapter for {primary_labware_definition.parameters.loadName}"
                 )
 
+    def stacker_labware_pool_to_ordered_list(
+        self,
+        primary_labware_definition: LabwareDefinition,
+        lid_labware_definition: LabwareDefinition | None,
+        adapter_labware_definition: LabwareDefinition | None,
+    ) -> List[LabwareDefinition]:
+        """Get the pool definitions in the top-first order suitable for geometry calculations."""
+        self.raise_if_stacker_labware_pool_is_not_valid(
+            primary_labware_definition,
+            lid_labware_definition,
+            adapter_labware_definition,
+        )
+        return [
+            x
+            for x in [
+                lid_labware_definition,
+                primary_labware_definition,
+                adapter_labware_definition,
+            ]
+            if x is not None
+        ]
+
+    def get_stacker_labware_pool_overlap(
+        self, definitions: list[LabwareDefinition]
+    ) -> OverlapOffset:
+        """
+        Get the overlap amount between each labware pool.
+
+        The definitions must be in top-first order, ideally created by
+        `stacker_labware_pool_to_ordered_list`.
+        """
+        return self.get_labware_overlap_offsets(
+            definitions[-1], definitions[0].parameters.loadName
+        )
+
     def raise_if_labware_cannot_be_stacked(  # noqa: C901
         self, top_labware_definition: LabwareDefinition, bottom_labware_id: str
     ) -> None:

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -1184,7 +1184,7 @@ class LabwareView:
             if x is not None
         ]
 
-    def get_stacker_labware_pool_overlap(
+    def get_stacker_labware_overlap_offset(
         self, definitions: list[LabwareDefinition]
     ) -> OverlapOffset:
         """

--- a/api/src/opentrons/protocol_engine/state/module_substates/flex_stacker_substate.py
+++ b/api/src/opentrons/protocol_engine/state/module_substates/flex_stacker_substate.py
@@ -80,13 +80,9 @@ class FlexStackerSubState:
             defs.append(self.pool_adapter_definition)
         return defs
 
-    def get_pool_overlap(self) -> float:
-        """Get the pool overlap value."""
-        return self.pool_overlap
-
-    def get_pool_height(self) -> float:
-        """Get the pool height value."""
-        return self.pool_height
+    def get_pool_height_minus_overlap(self) -> float:
+        """Get the height used in dispense/store action."""
+        return self.pool_height - self.pool_overlap
 
     def get_contained_labware(self) -> list[StackerStoredLabwareGroup]:
         """Get the labware inside the hopper."""

--- a/api/src/opentrons/protocol_engine/state/module_substates/flex_stacker_substate.py
+++ b/api/src/opentrons/protocol_engine/state/module_substates/flex_stacker_substate.py
@@ -97,6 +97,10 @@ class FlexStackerSubState:
             return None
         return self.max_pool_count
 
+    def get_pool_overlap(self) -> float:
+        """Get the overlap of the currently-configured labware."""
+        return self.pool_overlap
+
     def get_pool_definition(self) -> StackerPoolDefinition | None:
         """Get the labware definitions of the stacker pool."""
         if not self.pool_primary_definition:

--- a/api/src/opentrons/protocol_engine/state/module_substates/flex_stacker_substate.py
+++ b/api/src/opentrons/protocol_engine/state/module_substates/flex_stacker_substate.py
@@ -29,6 +29,7 @@ class FlexStackerSubState:
     pool_adapter_definition: LabwareDefinition | None
     pool_lid_definition: LabwareDefinition | None
     max_pool_count: int
+    pool_height: float
     pool_overlap: float
     contained_labware_bottom_first: list[StackerStoredLabwareGroup]
 
@@ -41,12 +42,14 @@ class FlexStackerSubState:
         pool_lid_definition = self.pool_lid_definition
         max_pool_count = self.max_pool_count
         pool_overlap = self.pool_overlap
+        pool_height = self.pool_height
         if update.pool_constraint != NO_CHANGE:
             max_pool_count = update.pool_constraint.max_pool_count
             pool_primary_definition = update.pool_constraint.primary_definition
             pool_adapter_definition = update.pool_constraint.adapter_definition
             pool_lid_definition = update.pool_constraint.lid_definition
             pool_overlap = update.pool_constraint.pool_overlap
+            pool_height = update.pool_constraint.pool_height
 
         contained_labware = self.contained_labware_bottom_first
 
@@ -61,6 +64,7 @@ class FlexStackerSubState:
             contained_labware_bottom_first=contained_labware,
             max_pool_count=max_pool_count,
             pool_overlap=pool_overlap,
+            pool_height=pool_height,
         )
 
     def get_pool_definition_ordered_list(self) -> list[LabwareDefinition] | None:
@@ -75,6 +79,14 @@ class FlexStackerSubState:
         if self.pool_adapter_definition is not None:
             defs.append(self.pool_adapter_definition)
         return defs
+
+    def get_pool_overlap(self) -> float:
+        """Get the pool overlap value."""
+        return self.pool_overlap
+
+    def get_pool_height(self) -> float:
+        """Get the pool height value."""
+        return self.pool_height
 
     def get_contained_labware(self) -> list[StackerStoredLabwareGroup]:
         """Get the labware inside the hopper."""

--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -1482,3 +1482,17 @@ class ModuleView:
         """Get the max stored labware in this stacker configuration."""
         substate = self.get_flex_stacker_substate(module_id)
         return substate.get_max_pool_count()
+
+    def validate_stacker_overlap_offset(
+        self,
+        module_id: str,
+        overlap_offset: float,
+    ) -> None:
+        """The overlap offset provided should match the stacker configuration."""
+        substate = self.get_flex_stacker_substate(module_id)
+        configured = substate.get_pool_overlap()
+        if not math.isclose(overlap_offset, configured, rel_tol=1e-9):
+            raise ValueError(
+                f"Provided overlap offset {overlap_offset} does not match "
+                f"configured {configured}."
+            )

--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -391,6 +391,7 @@ class ModuleStore(HasState[ModuleState], HandlesActions):
                 contained_labware_bottom_first=[],
                 max_pool_count=0,
                 pool_overlap=0,
+                pool_height=0,
             )
 
     def _update_additional_slots_occupied_by_thermocycler(

--- a/api/src/opentrons/protocol_engine/state/update_types.py
+++ b/api/src/opentrons/protocol_engine/state/update_types.py
@@ -358,6 +358,7 @@ class FlexStackerPoolConstraint:
 
     max_pool_count: int
     pool_overlap: float
+    pool_height: float
     primary_definition: LabwareDefinition
     lid_definition: LabwareDefinition | None
     adapter_definition: LabwareDefinition | None
@@ -824,6 +825,7 @@ class StateUpdate:
         module_id: str,
         max_count: int,
         pool_overlap: float,
+        pool_height: float,
         primary_definition: LabwareDefinition,
         adapter_definition: LabwareDefinition | None,
         lid_definition: LabwareDefinition | None,
@@ -836,6 +838,7 @@ class StateUpdate:
             pool_constraint=FlexStackerPoolConstraint(
                 max_pool_count=max_count,
                 pool_overlap=pool_overlap,
+                pool_height=pool_height,
                 primary_definition=primary_definition,
                 lid_definition=lid_definition,
                 adapter_definition=adapter_definition,

--- a/api/tests/opentrons/protocol_api/core/engine/test_flex_stacker_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_flex_stacker_core.py
@@ -527,7 +527,7 @@ def test_set_stored_labware_items_happypath_primary_only(
         decoy.when(primary.labware_id).then_return(f"primary-{idx}")
     primary_definition = _prime_definition(decoy, "primary")
     decoy.when(primary_cores[0].get_engine_definition()).then_return(primary_definition)
-    subject.set_stored_labware_items(primary_cores)
+    subject.set_stored_labware_items(primary_cores, None)
     decoy.verify(
         mock_engine_client.execute_command(
             cmd.flex_stacker.SetStoredLabwareParams(
@@ -573,7 +573,7 @@ def test_set_stored_labware_items_happypath_no_adapter(
     lid_definition = _prime_definition(decoy, "lid")
     decoy.when(primary_cores[0].get_engine_definition()).then_return(primary_definition)
     decoy.when(lid_cores[0].get_engine_definition()).then_return(lid_definition)
-    subject.set_stored_labware_items(primary_cores)
+    subject.set_stored_labware_items(primary_cores, None)
     decoy.verify(
         mock_engine_client.execute_command(
             cmd.flex_stacker.SetStoredLabwareParams(
@@ -621,7 +621,7 @@ def test_set_stored_labware_items_happypath_no_lid(
     adapter_definition = _prime_definition(decoy, "adapter")
     decoy.when(primary_cores[0].get_engine_definition()).then_return(primary_definition)
     decoy.when(adapter_cores[0].get_engine_definition()).then_return(adapter_definition)
-    subject.set_stored_labware_items(primary_cores)
+    subject.set_stored_labware_items(primary_cores, None)
     decoy.verify(
         mock_engine_client.execute_command(
             cmd.flex_stacker.SetStoredLabwareParams(
@@ -677,7 +677,7 @@ def test_set_stored_labware_items_happypath_all_elements(
     decoy.when(primary_cores[0].get_engine_definition()).then_return(primary_definition)
     decoy.when(adapter_cores[0].get_engine_definition()).then_return(adapter_definition)
     decoy.when(lid_cores[0].get_engine_definition()).then_return(lid_definition)
-    subject.set_stored_labware_items(primary_cores)
+    subject.set_stored_labware_items(primary_cores, None)
     decoy.verify(
         mock_engine_client.execute_command(
             cmd.flex_stacker.SetStoredLabwareParams(
@@ -714,7 +714,7 @@ def test_set_stored_items_labware_fails_if_empty(
 ) -> None:
     """It should fail if given an empty list."""
     with pytest.raises(CommandPreconditionViolated):
-        subject.set_stored_labware_items([])
+        subject.set_stored_labware_items([], None)
 
 
 def test_fill_items_happypath(

--- a/api/tests/opentrons/protocol_api/core/engine/test_flex_stacker_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_flex_stacker_core.py
@@ -381,7 +381,7 @@ def test_get_max_storable_labware_from_list_full_group(
     )
 
 
-def test_get_current_storable_labware_from_list_primary_only(
+def test_get_current_storable_labware_from_list_primary(
     decoy: Decoy,
     mock_engine_client: EngineClient,
     mock_protocol_core: ProtocolCore,

--- a/api/tests/opentrons/protocol_api/core/engine/test_flex_stacker_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_flex_stacker_core.py
@@ -142,6 +142,7 @@ def test_set_stored_labware_all_elements(
         adapter_namespace="adapter-namespace",
         adapter_version=2,
         count=5,
+        stacking_offset_z=2.0,
     )
     decoy.verify(
         mock_engine_client.execute_command(
@@ -161,6 +162,7 @@ def test_set_stored_labware_all_elements(
                     namespace="adapter-namespace-verified",
                     version=20,
                 ),
+                poolOverlapOverride=2.0,
             )
         )
     )

--- a/api/tests/opentrons/protocol_api/core/engine/test_flex_stacker_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_flex_stacker_core.py
@@ -224,13 +224,44 @@ def test_get_current_storable_labware_from_empty_list(subject: FlexStackerCore) 
     assert subject.get_current_storable_labware_from_list([]) == []
 
 
-def test_get_max_storable_labware_from_list_primary_only(
+@pytest.mark.parametrize("overlap_override", [None, sentinel.override_value])
+def test_get_max_storable_labware_from_list_configured(
+    decoy: Decoy,
+    mock_engine_client: EngineClient,
+    mock_protocol_core: ProtocolCore,
+    subject: FlexStackerCore,
+    overlap_override: float | None,
+) -> None:
+    """It should use the substate's max pool count."""
+    cores = [decoy.mock(cls=LabwareCore) for _ in range(5)]
+    decoy.when(
+        mock_engine_client.state.modules.stacker_max_pool_count("1234")
+    ).then_return(3)
+    assert (
+        subject.get_max_storable_labware_from_list(cores, overlap_override) == cores[:3]
+    )
+    # If an overlap override is specified, it should be passed to the engine to make
+    # sure the value matches the substate's value
+    decoy.verify(
+        mock_engine_client.state.modules.validate_stacker_overlap_offset(
+            "1234", sentinel.override_value
+        ),
+        times=1 if overlap_override is not None else 0,
+    )
+
+
+def test_get_max_storable_labware_from_list_unconfigured_primary_only(
     decoy: Decoy,
     mock_engine_client: EngineClient,
     mock_protocol_core: ProtocolCore,
     subject: FlexStackerCore,
 ) -> None:
     """It should marshal labware and ask the engine."""
+    # the stacker has not been configured, so it should return None
+    decoy.when(
+        mock_engine_client.state.modules.stacker_max_pool_count("1234")
+    ).then_return(None)
+
     cores = [decoy.mock(cls=LabwareCore) for _ in range(5)]
     decoy.when(mock_protocol_core.get_labware_location(cores[0])).then_return(OFF_DECK)
     decoy.when(mock_protocol_core.get_labware_on_labware(cores[0])).then_return(None)
@@ -239,12 +270,17 @@ def test_get_max_storable_labware_from_list_primary_only(
     decoy.when(cores[0].get_engine_definition()).then_return(primary_def)
     decoy.when(primary_def.parameters.loadName).then_return("mock-load-name")
     decoy.when(
+        mock_engine_client.state.labware.stacker_labware_pool_to_ordered_list(
+            primary_labware_definition=primary_def,
+            lid_labware_definition=None,
+            adapter_labware_definition=None,
+        )
+    ).then_return([primary_def])
+    decoy.when(
         mock_engine_client.state.geometry.get_height_of_labware_stack([primary_def])
     ).then_return(10)
     decoy.when(
-        mock_engine_client.state.labware.get_labware_overlap_offsets(
-            primary_def, "mock-load-name"
-        )
+        mock_engine_client.state.labware.get_stacker_labware_pool_overlap([primary_def])
     ).then_return(OverlapOffset(x=0, y=0, z=2))
     decoy.when(
         mock_engine_client.state.modules.stacker_max_pool_count_by_height("1234", 10, 2)
@@ -252,13 +288,18 @@ def test_get_max_storable_labware_from_list_primary_only(
     assert subject.get_max_storable_labware_from_list(cores) == cores[:3]
 
 
-def test_get_max_storable_labware_from_list_no_lid(
+def test_get_max_storable_labware_from_list_unconfigured_no_lid(
     decoy: Decoy,
     mock_engine_client: EngineClient,
     mock_protocol_core: ProtocolCore,
     subject: FlexStackerCore,
 ) -> None:
     """It should marshal labware and ask the engine."""
+    # the stacker has not been configured, so it should return None
+    decoy.when(
+        mock_engine_client.state.modules.stacker_max_pool_count("1234")
+    ).then_return(None)
+
     primary_cores = [decoy.mock(cls=LabwareCore) for _ in range(5)]
     adapter_cores = [decoy.mock(cls=LabwareCore) for _ in range(5)]
     decoy.when(mock_protocol_core.get_labware_location(primary_cores[0])).then_return(
@@ -276,13 +317,20 @@ def test_get_max_storable_labware_from_list_no_lid(
     decoy.when(adapter_cores[0].get_engine_definition()).then_return(adapter_def)
     decoy.when(adapter_def.parameters.loadName).then_return("mock-adapter-name")
     decoy.when(
+        mock_engine_client.state.labware.stacker_labware_pool_to_ordered_list(
+            primary_labware_definition=primary_def,
+            adapter_labware_definition=adapter_def,
+            lid_labware_definition=None,
+        )
+    ).then_return([primary_def, adapter_def])
+    decoy.when(
         mock_engine_client.state.geometry.get_height_of_labware_stack(
-            [adapter_def, primary_def]
+            [primary_def, adapter_def]
         )
     ).then_return(16)
     decoy.when(
-        mock_engine_client.state.labware.get_labware_overlap_offsets(
-            primary_def, "mock-adapter-name"
+        mock_engine_client.state.labware.get_stacker_labware_pool_overlap(
+            [primary_def, adapter_def]
         )
     ).then_return(OverlapOffset(x=0, y=0, z=3.0))
     decoy.when(
@@ -295,13 +343,18 @@ def test_get_max_storable_labware_from_list_no_lid(
     )
 
 
-def test_get_max_storable_labware_from_list_no_adapter(
+def test_get_max_storable_labware_from_list_unconfigured_no_adapter(
     decoy: Decoy,
     mock_engine_client: EngineClient,
     mock_protocol_core: ProtocolCore,
     subject: FlexStackerCore,
 ) -> None:
     """It should marshal labware and ask the engine."""
+    # the stacker has not been configured, so it should return None
+    decoy.when(
+        mock_engine_client.state.modules.stacker_max_pool_count("1234")
+    ).then_return(None)
+
     primary_cores = [decoy.mock(cls=LabwareCore) for _ in range(5)]
     lid_cores = [decoy.mock(cls=LabwareCore) for _ in range(5)]
     decoy.when(mock_protocol_core.get_labware_location(primary_cores[0])).then_return(
@@ -319,13 +372,20 @@ def test_get_max_storable_labware_from_list_no_adapter(
     decoy.when(lid_cores[0].get_engine_definition()).then_return(lid_def)
     decoy.when(primary_def.parameters.loadName).then_return("mock-primary-name")
     decoy.when(
+        mock_engine_client.state.labware.stacker_labware_pool_to_ordered_list(
+            primary_labware_definition=primary_def,
+            lid_labware_definition=lid_def,
+            adapter_labware_definition=None,
+        )
+    ).then_return([lid_def, primary_def])
+    decoy.when(
         mock_engine_client.state.geometry.get_height_of_labware_stack(
-            [primary_def, lid_def]
+            [lid_def, primary_def]
         )
     ).then_return(11)
     decoy.when(
-        mock_engine_client.state.labware.get_labware_overlap_offsets(
-            lid_def, "mock-primary-name"
+        mock_engine_client.state.labware.get_stacker_labware_pool_overlap(
+            [lid_def, primary_def]
         )
     ).then_return(OverlapOffset(x=0, y=0, z=1.0))
     decoy.when(
@@ -338,7 +398,7 @@ def test_get_max_storable_labware_from_list_no_adapter(
     )
 
 
-def test_get_max_storable_labware_from_list_full_group(
+def test_get_max_storable_labware_from_list_unconfigured_full_group(
     decoy: Decoy,
     mock_engine_client: EngineClient,
     mock_protocol_core: ProtocolCore,
@@ -366,13 +426,20 @@ def test_get_max_storable_labware_from_list_full_group(
     decoy.when(lid_cores[0].get_engine_definition()).then_return(lid_def)
     decoy.when(adapter_def.parameters.loadName).then_return("mock-adapter-name")
     decoy.when(
+        mock_engine_client.state.labware.stacker_labware_pool_to_ordered_list(
+            primary_labware_definition=primary_def,
+            lid_labware_definition=lid_def,
+            adapter_labware_definition=adapter_def,
+        )
+    ).then_return([lid_def, primary_def, adapter_def])
+    decoy.when(
         mock_engine_client.state.geometry.get_height_of_labware_stack(
-            [adapter_def, primary_def, lid_def]
+            [lid_def, primary_def, adapter_def]
         )
     ).then_return(20)
     decoy.when(
-        mock_engine_client.state.labware.get_labware_overlap_offsets(
-            lid_def, "mock-adapter-name"
+        mock_engine_client.state.labware.get_stacker_labware_pool_overlap(
+            [lid_def, primary_def, adapter_def]
         )
     ).then_return(OverlapOffset(x=0, y=0, z=2))
     decoy.when(
@@ -383,7 +450,7 @@ def test_get_max_storable_labware_from_list_full_group(
     )
 
 
-def test_get_current_storable_labware_from_list_primary(
+def test_get_current_storable_labware_from_list_primary_happypath(
     decoy: Decoy,
     mock_engine_client: EngineClient,
     mock_protocol_core: ProtocolCore,
@@ -391,28 +458,13 @@ def test_get_current_storable_labware_from_list_primary(
 ) -> None:
     """It should marshal labware and ask the engine."""
     cores = [decoy.mock(cls=LabwareCore) for _ in range(5)]
-    decoy.when(mock_protocol_core.get_labware_location(cores[0])).then_return(OFF_DECK)
-    decoy.when(mock_protocol_core.get_labware_on_labware(cores[0])).then_return(None)
-    decoy.when(cores[0].labware_id).then_return("core-0")
-    primary_def = decoy.mock(cls=LabwareDefinition2)
-    decoy.when(cores[0].get_engine_definition()).then_return(primary_def)
-    decoy.when(primary_def.parameters.loadName).then_return("mock-load-name")
     decoy.when(
-        mock_engine_client.state.geometry.get_height_of_labware_stack([primary_def])
-    ).then_return(10)
-    decoy.when(
-        mock_engine_client.state.labware.get_labware_overlap_offsets(
-            primary_def, "mock-load-name"
-        )
-    ).then_return(OverlapOffset(x=0, y=0, z=2))
-    decoy.when(
-        mock_engine_client.state.modules.stacker_max_pool_count_by_height("1234", 10, 2)
-    ).then_return(3)
-
+        mock_engine_client.state.modules.stacker_max_pool_count("1234")
+    ).then_return(5)
     decoy.when(
         mock_engine_client.state.modules.stacker_contained_labware("1234")
     ).then_return([sentinel.lw1, sentinel.lw2])
-    assert subject.get_current_storable_labware_from_list(cores) == cores[:1]
+    assert subject.get_current_storable_labware_from_list(cores) == cores[:3]
 
 
 def test_get_current_storable_labware_happypath(

--- a/api/tests/opentrons/protocol_api/core/engine/test_flex_stacker_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_flex_stacker_core.py
@@ -280,7 +280,9 @@ def test_get_max_storable_labware_from_list_unconfigured_primary_only(
         mock_engine_client.state.geometry.get_height_of_labware_stack([primary_def])
     ).then_return(10)
     decoy.when(
-        mock_engine_client.state.labware.get_stacker_labware_pool_overlap([primary_def])
+        mock_engine_client.state.labware.get_stacker_labware_overlap_offset(
+            [primary_def]
+        )
     ).then_return(OverlapOffset(x=0, y=0, z=2))
     decoy.when(
         mock_engine_client.state.modules.stacker_max_pool_count_by_height("1234", 10, 2)
@@ -329,7 +331,7 @@ def test_get_max_storable_labware_from_list_unconfigured_no_lid(
         )
     ).then_return(16)
     decoy.when(
-        mock_engine_client.state.labware.get_stacker_labware_pool_overlap(
+        mock_engine_client.state.labware.get_stacker_labware_overlap_offset(
             [primary_def, adapter_def]
         )
     ).then_return(OverlapOffset(x=0, y=0, z=3.0))
@@ -384,7 +386,7 @@ def test_get_max_storable_labware_from_list_unconfigured_no_adapter(
         )
     ).then_return(11)
     decoy.when(
-        mock_engine_client.state.labware.get_stacker_labware_pool_overlap(
+        mock_engine_client.state.labware.get_stacker_labware_overlap_offset(
             [lid_def, primary_def]
         )
     ).then_return(OverlapOffset(x=0, y=0, z=1.0))
@@ -438,7 +440,7 @@ def test_get_max_storable_labware_from_list_unconfigured_full_group(
         )
     ).then_return(20)
     decoy.when(
-        mock_engine_client.state.labware.get_stacker_labware_pool_overlap(
+        mock_engine_client.state.labware.get_stacker_labware_overlap_offset(
             [lid_def, primary_def, adapter_def]
         )
     ).then_return(OverlapOffset(x=0, y=0, z=2))

--- a/api/tests/opentrons/protocol_api/test_flex_stacker_context.py
+++ b/api/tests/opentrons/protocol_api/test_flex_stacker_context.py
@@ -1,6 +1,5 @@
 """Tests for Protocol API Flex Stacker contexts."""
 
-from numpy import stack
 import pytest
 from decoy import Decoy, matchers
 
@@ -128,7 +127,9 @@ def test_set_stored_labware(
     decoy: Decoy, mock_core: FlexStackerCore, subject: FlexStackerContext
 ) -> None:
     """It should route arguments appropriately."""
-    subject.set_stored_labware("load_name", "namespace", 1, "adapter", "lid", 2, stacking_offset_z=1.0)
+    subject.set_stored_labware(
+        "load_name", "namespace", 1, "adapter", "lid", 2, stacking_offset_z=1.0
+    )
     decoy.verify(
         mock_core.set_stored_labware(
             main_load_name="load_name",
@@ -173,10 +174,10 @@ def test_get_max_storable_labware_from_list(
         )
         for core in base_cores
     ]
-    decoy.when(mock_core.get_max_storable_labware_from_list(base_cores)).then_return(
-        base_cores[:3]
-    )
-    assert subject.get_max_storable_labware_from_list(base_lw) == base_lw[:3]
+    decoy.when(
+        mock_core.get_max_storable_labware_from_list(base_cores, 1.0)
+    ).then_return(base_cores[:3])
+    assert subject.get_max_storable_labware_from_list(base_lw, 1.0) == base_lw[:3]
 
 
 @pytest.mark.parametrize(

--- a/api/tests/opentrons/protocol_api/test_flex_stacker_context.py
+++ b/api/tests/opentrons/protocol_api/test_flex_stacker_context.py
@@ -1,5 +1,6 @@
 """Tests for Protocol API Flex Stacker contexts."""
 
+from numpy import stack
 import pytest
 from decoy import Decoy, matchers
 
@@ -127,7 +128,7 @@ def test_set_stored_labware(
     decoy: Decoy, mock_core: FlexStackerCore, subject: FlexStackerContext
 ) -> None:
     """It should route arguments appropriately."""
-    subject.set_stored_labware("load_name", "namespace", 1, "adapter", "lid", 2)
+    subject.set_stored_labware("load_name", "namespace", 1, "adapter", "lid", 2, stacking_offset_z=1.0)
     decoy.verify(
         mock_core.set_stored_labware(
             main_load_name="load_name",
@@ -140,6 +141,7 @@ def test_set_stored_labware(
             adapter_namespace="namespace",
             adapter_version=1,
             count=2,
+            stacking_offset_z=1.0,
         )
     )
 
@@ -323,5 +325,5 @@ def test_set_stored_labware_items(
         )
         for core in base_cores
     ]
-    subject.set_stored_labware_items(base_lw)
-    decoy.verify(mock_core.set_stored_labware_items(base_cores))
+    subject.set_stored_labware_items(base_lw, stacking_offset_z=1.0)
+    decoy.verify(mock_core.set_stored_labware_items(base_cores, 1.0))

--- a/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_common.py
+++ b/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_common.py
@@ -2135,6 +2135,7 @@ def test_build_retrieve_labware_move_updates(
         pool_lid_definition=sentinel.pool_lid_definition,
         max_pool_count=3,
         pool_overlap=1,
+        pool_height=0,
         contained_labware_bottom_first=[group],
     )
     decoy.when(

--- a/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_empty.py
+++ b/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_empty.py
@@ -111,6 +111,7 @@ async def test_empty_happypath(
         contained_labware_bottom_first=current_stored,
         max_pool_count=3,
         pool_overlap=0,
+        pool_height=0,
     )
     decoy.when(state_view.modules.get_flex_stacker_substate(module_id)).then_return(
         stacker_state
@@ -188,6 +189,7 @@ async def test_empty_requires_constrained_pool(
         contained_labware_bottom_first=_contained_labware(3),
         max_pool_count=5,
         pool_overlap=0,
+        pool_height=0,
     )
     decoy.when(state_view.modules.get_flex_stacker_substate(module_id)).then_return(
         stacker_state
@@ -229,6 +231,7 @@ async def test_pause_strategy_pauses(
         contained_labware_bottom_first=_contained_labware(current_count),
         max_pool_count=5,
         pool_overlap=0,
+        pool_height=0,
     )
     decoy.when(state_view.modules.get_flex_stacker_substate(module_id)).then_return(
         stacker_state

--- a/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_fill.py
+++ b/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_fill.py
@@ -101,6 +101,7 @@ async def test_fill_by_count_exceeding_max(
         contained_labware_bottom_first=current_stored,
         max_pool_count=max_pool_count,
         pool_overlap=0,
+        pool_height=0,
     )
     decoy.when(state_view.modules.get_flex_stacker_substate(module_id)).then_return(
         stacker_state
@@ -150,6 +151,7 @@ async def test_fill_by_count_happypath(
         contained_labware_bottom_first=current_stored,
         max_pool_count=max_pool_count,
         pool_overlap=0,
+        pool_height=0,
     )
     decoy.when(state_view.modules.get_flex_stacker_substate(module_id)).then_return(
         stacker_state
@@ -278,6 +280,7 @@ async def test_fill_requires_constrained_pool(
         contained_labware_bottom_first=_contained_labware(3),
         max_pool_count=0,
         pool_overlap=0,
+        pool_height=0,
     )
     decoy.when(state_view.modules.get_flex_stacker_substate(module_id)).then_return(
         stacker_state
@@ -320,6 +323,7 @@ async def test_pause_strategy_pauses(
         contained_labware_bottom_first=beginning_contained_labware,
         max_pool_count=max_pool_count,
         pool_overlap=0,
+        pool_height=0,
     )
     decoy.when(state_view.modules.get_flex_stacker_substate(module_id)).then_return(
         stacker_state

--- a/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_retrieve.py
+++ b/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_retrieve.py
@@ -170,8 +170,8 @@ async def test_retrieve_primary_only(
         pool_lid_definition=None,
         contained_labware_bottom_first=_contained_labware(1),
         max_pool_count=5,
-        pool_overlap=0,
-        pool_height=0,
+        pool_overlap=6,
+        pool_height=10,
     )
     decoy.when(
         state_view.labware.get_uri_from_definition(flex_50uL_tiprack)
@@ -198,10 +198,6 @@ async def test_retrieve_primary_only(
     ).then_return(
         LabwareOffset.model_construct(id="offset-id-1")  # type: ignore[call-arg]
     )
-
-    decoy.when(
-        state_view.geometry.get_height_of_stacker_labware_pool(stacker_id)
-    ).then_return(4)
 
     _prep_stacker_own_location(decoy, state_view, stacker_id)
 
@@ -255,8 +251,8 @@ async def test_retrieve_primary_and_lid(
         pool_lid_definition=tiprack_lid_def,
         contained_labware_bottom_first=_contained_labware(2, with_lid=True),
         max_pool_count=5,
-        pool_overlap=0,
-        pool_height=0,
+        pool_overlap=2,
+        pool_height=10,
     )
     decoy.when(
         state_view.modules.get_flex_stacker_substate(module_id=stacker_id)
@@ -300,11 +296,8 @@ async def test_retrieve_primary_and_lid(
             ],
         )
     ).then_return(None)
-    decoy.when(
-        state_view.geometry.get_height_of_stacker_labware_pool(stacker_id)
-    ).then_return(8)
-
     _prep_stacker_own_location(decoy, state_view, stacker_id)
+
     result = await subject.execute(data)
 
     decoy.verify(await stacker_hardware.dispense_labware(labware_height=8), times=1)
@@ -375,8 +368,8 @@ async def test_retrieve_primary_and_adapter(
         pool_lid_definition=None,
         contained_labware_bottom_first=_contained_labware(2, with_adapter=True),
         max_pool_count=5,
-        pool_overlap=0,
-        pool_height=0,
+        pool_overlap=3,
+        pool_height=15,
     )
     decoy.when(
         state_view.modules.get_flex_stacker_substate(module_id=stacker_id)
@@ -422,9 +415,6 @@ async def test_retrieve_primary_and_adapter(
     ).then_return(
         LabwareOffset.model_construct(id="offset-id-2")  # type: ignore[call-arg]
     )
-    decoy.when(
-        state_view.geometry.get_height_of_stacker_labware_pool(stacker_id)
-    ).then_return(12)
 
     _prep_stacker_own_location(decoy, state_view, stacker_id)
     result = await subject.execute(data)
@@ -503,8 +493,8 @@ async def test_retrieve_primary_adapter_and_lid(
             2, with_lid=True, with_adapter=True
         ),
         max_pool_count=5,
-        pool_overlap=0,
-        pool_height=0,
+        pool_overlap=4,
+        pool_height=20,
     )
     decoy.when(
         state_view.modules.get_flex_stacker_substate(module_id=stacker_id)
@@ -570,10 +560,6 @@ async def test_retrieve_primary_adapter_and_lid(
             ],
         )
     ).then_return(None)
-
-    decoy.when(
-        state_view.geometry.get_height_of_stacker_labware_pool(stacker_id)
-    ).then_return(16)
 
     _prep_stacker_own_location(decoy, state_view, stacker_id)
     result = await subject.execute(data)
@@ -714,16 +700,12 @@ async def test_retrieve_raises_recoverable_error(
         pool_lid_definition=None,
         contained_labware_bottom_first=_contained_labware(1),
         max_pool_count=999,
-        pool_overlap=0,
-        pool_height=0,
+        pool_overlap=4,
+        pool_height=20,
     )
     decoy.when(
         state_view.modules.get_flex_stacker_substate(module_id=stacker_id)
     ).then_return(fs_module_substate)
-
-    decoy.when(
-        state_view.geometry.get_height_of_stacker_labware_pool(stacker_id)
-    ).then_return(16)
 
     _prep_stacker_own_location(decoy, state_view, stacker_id)
 

--- a/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_retrieve.py
+++ b/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_retrieve.py
@@ -138,6 +138,7 @@ async def test_retrieve_raises_when_empty(
         contained_labware_bottom_first=[],
         max_pool_count=5,
         pool_overlap=0,
+        pool_height=0,
     )
     decoy.when(
         state_view.modules.get_flex_stacker_substate(module_id=stacker_id)
@@ -170,6 +171,7 @@ async def test_retrieve_primary_only(
         contained_labware_bottom_first=_contained_labware(1),
         max_pool_count=5,
         pool_overlap=0,
+        pool_height=0,
     )
     decoy.when(
         state_view.labware.get_uri_from_definition(flex_50uL_tiprack)
@@ -254,6 +256,7 @@ async def test_retrieve_primary_and_lid(
         contained_labware_bottom_first=_contained_labware(2, with_lid=True),
         max_pool_count=5,
         pool_overlap=0,
+        pool_height=0,
     )
     decoy.when(
         state_view.modules.get_flex_stacker_substate(module_id=stacker_id)
@@ -373,6 +376,7 @@ async def test_retrieve_primary_and_adapter(
         contained_labware_bottom_first=_contained_labware(2, with_adapter=True),
         max_pool_count=5,
         pool_overlap=0,
+        pool_height=0,
     )
     decoy.when(
         state_view.modules.get_flex_stacker_substate(module_id=stacker_id)
@@ -500,6 +504,7 @@ async def test_retrieve_primary_adapter_and_lid(
         ),
         max_pool_count=5,
         pool_overlap=0,
+        pool_height=0,
     )
     decoy.when(
         state_view.modules.get_flex_stacker_substate(module_id=stacker_id)
@@ -710,6 +715,7 @@ async def test_retrieve_raises_recoverable_error(
         contained_labware_bottom_first=_contained_labware(1),
         max_pool_count=999,
         pool_overlap=0,
+        pool_height=0,
     )
     decoy.when(
         state_view.modules.get_flex_stacker_substate(module_id=stacker_id)

--- a/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_set_stored_labware.py
+++ b/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_set_stored_labware.py
@@ -75,7 +75,7 @@ def subject(
             ),
             FlexStackerPoolConstraint(
                 max_pool_count=10,
-                pool_overlap=0,
+                pool_overlap=5.0,
                 pool_height=sentinel.pool_height,
                 primary_definition=sentinel.primary_definition,
                 lid_definition=sentinel.lid_definition,
@@ -153,7 +153,7 @@ def subject(
             None,
             FlexStackerPoolConstraint(
                 max_pool_count=10,
-                pool_overlap=0,
+                pool_overlap=5.0,
                 pool_height=sentinel.pool_height,
                 primary_definition=sentinel.primary_definition,
                 lid_definition=None,
@@ -192,7 +192,7 @@ def subject(
             ),
             FlexStackerPoolConstraint(
                 max_pool_count=10,
-                pool_overlap=0,
+                pool_overlap=5.0,
                 primary_definition=sentinel.primary_definition,
                 lid_definition=sentinel.lid_definition,
                 adapter_definition=None,
@@ -247,7 +247,7 @@ def subject(
             None,
             FlexStackerPoolConstraint(
                 max_pool_count=10,
-                pool_overlap=0,
+                pool_overlap=5.0,
                 pool_height=sentinel.pool_height,
                 primary_definition=sentinel.primary_definition,
                 lid_definition=None,
@@ -372,20 +372,6 @@ async def test_set_stored_labware_happypath(
         ).then_return((tiprack_adapter_def, sentinel.unused))
         adapter_definition = tiprack_adapter_def
 
-    decoy.when(
-        state_view.geometry.get_height_of_labware_stack(
-            [
-                x
-                for x in [
-                    lid_definition,
-                    flex_50uL_tiprack,
-                    adapter_definition,
-                ]
-                if x is not None
-            ]
-        )
-    ).then_return(sentinel.pool_height)
-
     for labware_group in initial_stored_labware:
         decoy.when(
             state_view.labware.known(labware_group.primaryLabwareId)
@@ -444,43 +430,39 @@ async def test_set_stored_labware_happypath(
             ).then_return(labware_group.lidLabwareId)
             offset_ids_by_id[labware_group.lidLabwareId] = None
 
-    if lid_labware and adapter_labware:
-        decoy.when(
-            state_view._labware.get_labware_overlap_offsets(
-                adapter_definition, tiprack_lid_def.parameters.loadName
-            )
-        ).then_return(OverlapOffset(x=0, y=0, z=0))
-    elif lid_labware:
-        decoy.when(
-            state_view._labware.get_labware_overlap_offsets(
-                flex_50uL_tiprack, tiprack_lid_def.parameters.loadName
-            )
-        ).then_return(OverlapOffset(x=0, y=0, z=0))
-    elif adapter_labware:
-        decoy.when(
-            state_view._labware.get_labware_overlap_offsets(
-                adapter_definition, flex_50uL_tiprack.parameters.loadName
-            )
-        ).then_return(OverlapOffset(x=0, y=0, z=0))
-    else:
-        decoy.when(
-            state_view._labware.get_labware_overlap_offsets(
-                flex_50uL_tiprack, flex_50uL_tiprack.parameters.loadName
-            )
-        ).then_return(OverlapOffset(x=0, y=0, z=0))
+    ordered_definitions = [
+        x
+        for x in [
+            lid_definition,
+            flex_50uL_tiprack,
+            adapter_definition,
+        ]
+        if x is not None
+    ]
+
+    decoy.when(
+        state_view.labware.stacker_labware_pool_to_ordered_list(
+            primary_labware_definition=flex_50uL_tiprack,
+            lid_labware_definition=lid_definition,
+            adapter_labware_definition=adapter_definition,
+        )
+    ).then_return(ordered_definitions)
+
+    decoy.when(
+        state_view.geometry.get_height_of_labware_stack(ordered_definitions)
+    ).then_return(sentinel.pool_height)
+
+    decoy.when(
+        state_view.labware.get_stacker_labware_overlap_offset(ordered_definitions)
+    ).then_return(OverlapOffset(x=0, y=0, z=5.0))
 
     decoy.when(
         state_view.modules.stacker_max_pool_count_by_height(
-            module_id, sentinel.pool_height, 0.0
+            module_id, sentinel.pool_height, 5.0
         )
     ).then_return(10)
 
     result = await subject.execute(params)
-    decoy.verify(
-        state_view.labware.raise_if_stacker_labware_pool_is_not_valid(
-            flex_50uL_tiprack, lid_definition, adapter_definition
-        )
-    )
 
     assert result == SuccessData(
         public=SetStoredLabwareResult.model_construct(
@@ -630,11 +612,8 @@ async def test_set_stored_labware_requires_empty_hopper(
     ],
 )
 @pytest.mark.parametrize(
-    "default_overlap, overlap_override, actual_value_used",
-    [
-        (10.0, None, 10.0),
-        (10.0, 5.0, 5.0),
-    ],
+    "overlap_override",
+    [None, 5.0],
 )
 async def test_set_stored_labware_limits_count(
     input_count: int | None,
@@ -647,9 +626,7 @@ async def test_set_stored_labware_limits_count(
     subject: SetStoredLabwareImpl,
     model_utils: ModelUtils,
     flex_50uL_tiprack: LabwareDefinition,
-    default_overlap: float,
     overlap_override: float | None,
-    actual_value_used: float,
 ) -> None:
     """It should default and limit the input count."""
     module_id = "module-id"
@@ -692,18 +669,26 @@ async def test_set_stored_labware_limits_count(
     )
 
     decoy.when(
-        state_view._labware.get_labware_overlap_offsets(
-            flex_50uL_tiprack, "opentrons_flex_96_filtertiprack_50ul"
+        state_view.labware.stacker_labware_pool_to_ordered_list(
+            flex_50uL_tiprack,
+            None,
+            None,
         )
-    ).then_return(OverlapOffset(x=0, y=0, z=default_overlap))
+    ).then_return([flex_50uL_tiprack])
 
     decoy.when(
         state_view.geometry.get_height_of_labware_stack([flex_50uL_tiprack])
     ).then_return(sentinel.pool_height)
 
     decoy.when(
+        state_view.labware.get_stacker_labware_overlap_offset([flex_50uL_tiprack])
+    ).then_return(OverlapOffset(x=0, y=0, z=10.0))
+
+    decoy.when(
         state_view.modules.stacker_max_pool_count_by_height(
-            module_id, sentinel.pool_height, actual_value_used
+            module_id,
+            sentinel.pool_height,
+            10.0 if overlap_override is None else overlap_override,
         )
     ).then_return(2)
 
@@ -792,7 +777,7 @@ async def test_set_stored_labware_limits_count(
                 module_id=module_id,
                 pool_constraint=FlexStackerPoolConstraint(
                     max_pool_count=2,
-                    pool_overlap=actual_value_used,
+                    pool_overlap=overlap_override or 10.0,
                     pool_height=sentinel.pool_height,
                     primary_definition=flex_50uL_tiprack,
                     lid_definition=None,
@@ -895,9 +880,15 @@ async def test_set_stored_labware_exceeding_max(
     )
 
     decoy.when(
-        state_view._labware.get_labware_overlap_offsets(
-            flex_50uL_tiprack, "opentrons_flex_96_filtertiprack_50ul"
+        state_view.labware.stacker_labware_pool_to_ordered_list(
+            flex_50uL_tiprack,
+            None,
+            None,
         )
+    ).then_return([flex_50uL_tiprack])
+
+    decoy.when(
+        state_view.labware.get_stacker_labware_overlap_offset([flex_50uL_tiprack])
     ).then_return(OverlapOffset(x=0, y=0, z=0))
 
     decoy.when(

--- a/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_set_stored_labware.py
+++ b/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_set_stored_labware.py
@@ -76,7 +76,7 @@ def subject(
             FlexStackerPoolConstraint(
                 max_pool_count=10,
                 pool_overlap=0,
-                pool_height=0,
+                pool_height=sentinel.pool_height,
                 primary_definition=sentinel.primary_definition,
                 lid_definition=sentinel.lid_definition,
                 adapter_definition=sentinel.adapter_definition,
@@ -154,7 +154,7 @@ def subject(
             FlexStackerPoolConstraint(
                 max_pool_count=10,
                 pool_overlap=0,
-                pool_height=0,
+                pool_height=sentinel.pool_height,
                 primary_definition=sentinel.primary_definition,
                 lid_definition=None,
                 adapter_definition=None,
@@ -196,7 +196,7 @@ def subject(
                 primary_definition=sentinel.primary_definition,
                 lid_definition=sentinel.lid_definition,
                 adapter_definition=None,
-                pool_height=0,
+                pool_height=sentinel.pool_height,
             ),
             [
                 StackerStoredLabwareGroup(
@@ -248,7 +248,7 @@ def subject(
             FlexStackerPoolConstraint(
                 max_pool_count=10,
                 pool_overlap=0,
-                pool_height=0,
+                pool_height=sentinel.pool_height,
                 primary_definition=sentinel.primary_definition,
                 lid_definition=None,
                 adapter_definition=sentinel.adapter_definition,
@@ -629,6 +629,13 @@ async def test_set_stored_labware_requires_empty_hopper(
         ),
     ],
 )
+@pytest.mark.parametrize(
+    "default_overlap, overlap_override, actual_value_used",
+    [
+        (10.0, None, 10.0),
+        (10.0, 5.0, 5.0),
+    ],
+)
 async def test_set_stored_labware_limits_count(
     input_count: int | None,
     input_labware: list[StackerStoredLabwareGroup] | None,
@@ -640,6 +647,9 @@ async def test_set_stored_labware_limits_count(
     subject: SetStoredLabwareImpl,
     model_utils: ModelUtils,
     flex_50uL_tiprack: LabwareDefinition,
+    default_overlap: float,
+    overlap_override: float | None,
+    actual_value_used: float,
 ) -> None:
     """It should default and limit the input count."""
     module_id = "module-id"
@@ -654,6 +664,7 @@ async def test_set_stored_labware_limits_count(
         adapterLabware=None,
         initialCount=input_count,
         initialStoredLabware=input_labware,
+        poolOverlapOverride=overlap_override,
     )
     for i in range(len(output_labware)):
         decoy.when(model_utils.generate_id()).then_return(f"labware-{i+1}")
@@ -684,7 +695,7 @@ async def test_set_stored_labware_limits_count(
         state_view._labware.get_labware_overlap_offsets(
             flex_50uL_tiprack, "opentrons_flex_96_filtertiprack_50ul"
         )
-    ).then_return(OverlapOffset(x=0, y=0, z=0))
+    ).then_return(OverlapOffset(x=0, y=0, z=default_overlap))
 
     decoy.when(
         state_view.geometry.get_height_of_labware_stack([flex_50uL_tiprack])
@@ -692,9 +703,10 @@ async def test_set_stored_labware_limits_count(
 
     decoy.when(
         state_view.modules.stacker_max_pool_count_by_height(
-            module_id, sentinel.pool_height, 0.0
+            module_id, sentinel.pool_height, actual_value_used
         )
     ).then_return(2)
+
     # we need to control multiple return values from generate_id and it doesnt take
     # an argument so we can do this iter side-effecting thing
     labware_ids = iter(("labware-1", "labware-2"))
@@ -780,8 +792,8 @@ async def test_set_stored_labware_limits_count(
                 module_id=module_id,
                 pool_constraint=FlexStackerPoolConstraint(
                     max_pool_count=2,
-                    pool_overlap=0,
-                    pool_height=0,
+                    pool_overlap=actual_value_used,
+                    pool_height=sentinel.pool_height,
                     primary_definition=flex_50uL_tiprack,
                     lid_definition=None,
                     adapter_definition=None,

--- a/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_set_stored_labware.py
+++ b/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_set_stored_labware.py
@@ -76,6 +76,7 @@ def subject(
             FlexStackerPoolConstraint(
                 max_pool_count=10,
                 pool_overlap=0,
+                pool_height=0,
                 primary_definition=sentinel.primary_definition,
                 lid_definition=sentinel.lid_definition,
                 adapter_definition=sentinel.adapter_definition,
@@ -153,6 +154,7 @@ def subject(
             FlexStackerPoolConstraint(
                 max_pool_count=10,
                 pool_overlap=0,
+                pool_height=0,
                 primary_definition=sentinel.primary_definition,
                 lid_definition=None,
                 adapter_definition=None,
@@ -194,6 +196,7 @@ def subject(
                 primary_definition=sentinel.primary_definition,
                 lid_definition=sentinel.lid_definition,
                 adapter_definition=None,
+                pool_height=0,
             ),
             [
                 StackerStoredLabwareGroup(
@@ -245,6 +248,7 @@ def subject(
             FlexStackerPoolConstraint(
                 max_pool_count=10,
                 pool_overlap=0,
+                pool_height=0,
                 primary_definition=sentinel.primary_definition,
                 lid_definition=None,
                 adapter_definition=sentinel.adapter_definition,
@@ -338,6 +342,7 @@ async def test_set_stored_labware_happypath(
             contained_labware_bottom_first=[],
             max_pool_count=0,
             pool_overlap=0,
+            pool_height=0,
         )
     )
     decoy.when(
@@ -573,6 +578,7 @@ async def test_set_stored_labware_requires_empty_hopper(
             ],
             max_pool_count=6,
             pool_overlap=0,
+            pool_height=0,
         )
     )
     with pytest.raises(FlexStackerNotLogicallyEmptyError):
@@ -661,6 +667,7 @@ async def test_set_stored_labware_limits_count(
             contained_labware_bottom_first=[],
             max_pool_count=0,
             pool_overlap=0,
+            pool_height=0,
         )
     )
     decoy.when(
@@ -774,6 +781,7 @@ async def test_set_stored_labware_limits_count(
                 pool_constraint=FlexStackerPoolConstraint(
                     max_pool_count=2,
                     pool_overlap=0,
+                    pool_height=0,
                     primary_definition=flex_50uL_tiprack,
                     lid_definition=None,
                     adapter_definition=None,
@@ -861,6 +869,7 @@ async def test_set_stored_labware_exceeding_max(
             contained_labware_bottom_first=[],
             max_pool_count=0,
             pool_overlap=0,
+            pool_height=0,
         )
     )
     decoy.when(

--- a/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_store.py
+++ b/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_store.py
@@ -93,6 +93,7 @@ async def test_store_raises_if_full(
         contained_labware_bottom_first=_contained_labware(3),
         max_pool_count=3,
         pool_overlap=0,
+        pool_height=0,
     )
     decoy.when(
         state_view.modules.get_flex_stacker_substate(module_id=stacker_id)
@@ -123,6 +124,7 @@ async def test_store_raises_if_carriage_logically_empty(
         contained_labware_bottom_first=_contained_labware(1),
         max_pool_count=5,
         pool_overlap=0,
+        pool_height=0,
     )
     decoy.when(
         state_view.modules.get_flex_stacker_substate(module_id=stacker_id)
@@ -164,6 +166,7 @@ async def test_store_raises_if_not_configured(
         contained_labware_bottom_first=_contained_labware(contained_labware_count),
         max_pool_count=max_pool_count,
         pool_overlap=0,
+        pool_height=0,
     )
     decoy.when(
         state_view.modules.get_flex_stacker_substate(module_id=stacker_id)
@@ -219,6 +222,7 @@ async def test_store_raises_if_stall(
         contained_labware_bottom_first=[],
         max_pool_count=999,
         pool_overlap=0,
+        pool_height=0,
     )
 
     decoy.when(
@@ -394,6 +398,7 @@ async def test_store_raises_if_labware_does_not_match(
         contained_labware_bottom_first=[],
         max_pool_count=5,
         pool_overlap=0,
+        pool_height=0,
     )
 
     decoy.when(
@@ -462,6 +467,7 @@ async def test_store(
         contained_labware_bottom_first=_contained_labware(1),
         max_pool_count=5,
         pool_overlap=0,
+        pool_height=0,
     )
 
     decoy.when(

--- a/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_store.py
+++ b/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_store.py
@@ -221,8 +221,8 @@ async def test_store_raises_if_stall(
         pool_lid_definition=None,
         contained_labware_bottom_first=[],
         max_pool_count=999,
-        pool_overlap=0,
-        pool_height=0,
+        pool_overlap=6,
+        pool_height=10,
     )
 
     decoy.when(
@@ -238,9 +238,6 @@ async def test_store_raises_if_stall(
     decoy.when(state_view.labware.get_definition("labware-id")).then_return(
         flex_50uL_tiprack
     )
-    decoy.when(
-        state_view.geometry.get_height_of_labware_stack([flex_50uL_tiprack])
-    ).then_return(4)
 
     decoy.when(state_view.geometry.get_location_sequence("labware-id")).then_return(
         [
@@ -466,8 +463,8 @@ async def test_store(
         pool_lid_definition=None,
         contained_labware_bottom_first=_contained_labware(1),
         max_pool_count=5,
-        pool_overlap=0,
-        pool_height=0,
+        pool_overlap=6,
+        pool_height=10,
     )
 
     decoy.when(
@@ -483,10 +480,6 @@ async def test_store(
     decoy.when(state_view.labware.get_definition("labware-id")).then_return(
         flex_50uL_tiprack
     )
-    decoy.when(
-        state_view.geometry.get_height_of_labware_stack([flex_50uL_tiprack])
-    ).then_return(4)
-
     decoy.when(state_view.geometry.get_location_sequence("labware-id")).then_return(
         [
             OnModuleLocationSequenceComponent(moduleId=stacker_id),

--- a/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_unsafe_stacker_close_latch.py
+++ b/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_unsafe_stacker_close_latch.py
@@ -48,6 +48,7 @@ async def test_close_latch_command(
         contained_labware_bottom_first=[],
         max_pool_count=0,
         pool_overlap=0,
+        pool_height=0,
     )
     decoy.when(
         state_view.modules.get_flex_stacker_substate(module_id=stacker_id)

--- a/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_unsafe_stacker_open_latch.py
+++ b/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_unsafe_stacker_open_latch.py
@@ -48,6 +48,7 @@ async def test_open_latch_command(
         contained_labware_bottom_first=[],
         max_pool_count=0,
         pool_overlap=0,
+        pool_height=0,
     )
     decoy.when(
         state_view.modules.get_flex_stacker_substate(module_id=stacker_id)

--- a/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_unsafe_stacker_prepare_shuttle.py
+++ b/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_unsafe_stacker_prepare_shuttle.py
@@ -56,6 +56,7 @@ async def test_home_command(
         contained_labware_bottom_first=[],
         max_pool_count=0,
         pool_overlap=0,
+        pool_height=0,
     )
     decoy.when(
         state_view.modules.get_flex_stacker_substate(module_id=stacker_id)
@@ -91,6 +92,7 @@ async def test_home_command_with_stall_detected(
         contained_labware_bottom_first=[],
         max_pool_count=0,
         pool_overlap=0,
+        pool_height=0,
     )
     decoy.when(
         state_view.modules.get_flex_stacker_substate(module_id=stacker_id)

--- a/api/tests/opentrons/protocol_engine/commands/unsafe/test_unsafe_manual_retrieve.py
+++ b/api/tests/opentrons/protocol_engine/commands/unsafe/test_unsafe_manual_retrieve.py
@@ -139,6 +139,7 @@ async def test_manual_retrieve_raises_when_empty(
         contained_labware_bottom_first=[],
         max_pool_count=5,
         pool_overlap=0,
+        pool_height=0,
     )
     decoy.when(
         state_view.modules.get_flex_stacker_substate(module_id=stacker_id)
@@ -171,6 +172,7 @@ async def test_manual_retrieve_primary_only(
         contained_labware_bottom_first=_contained_labware(2),
         max_pool_count=5,
         pool_overlap=0,
+        pool_height=0,
     )
     decoy.when(
         state_view.modules.get_flex_stacker_substate(module_id=stacker_id)
@@ -246,6 +248,7 @@ async def test_manual_retrieve_primary_and_lid(
         contained_labware_bottom_first=_contained_labware(2, with_lid=True),
         max_pool_count=5,
         pool_overlap=0,
+        pool_height=0,
     )
     decoy.when(
         state_view.modules.get_flex_stacker_substate(module_id=stacker_id)
@@ -347,6 +350,7 @@ async def test_manual_retrieve_primary_and_adapter(
         contained_labware_bottom_first=_contained_labware(2, with_adapter=True),
         max_pool_count=5,
         pool_overlap=0,
+        pool_height=0,
     )
     decoy.when(
         state_view.modules.get_flex_stacker_substate(module_id=stacker_id)
@@ -452,6 +456,7 @@ async def test_manual_retrieve_primary_adapter_and_lid(
         ),
         max_pool_count=5,
         pool_overlap=0,
+        pool_height=0,
     )
     decoy.when(
         state_view.modules.get_flex_stacker_substate(module_id=stacker_id)
@@ -607,6 +612,7 @@ async def test_manual_retrieve_fails_due_to_platform_state(
         contained_labware_bottom_first=_contained_labware(1),
         max_pool_count=999,
         pool_overlap=0,
+        pool_height=0,
     )
     decoy.when(
         state_view.modules.get_flex_stacker_substate(module_id=stacker_id)

--- a/api/tests/opentrons/protocol_engine/state/test_flex_stacker_state.py
+++ b/api/tests/opentrons/protocol_engine/state/test_flex_stacker_state.py
@@ -125,6 +125,7 @@ def test_add_module_action(
         contained_labware_bottom_first=[],
         max_pool_count=0,
         pool_overlap=0,
+        pool_height=0,
     )
 
 
@@ -173,6 +174,7 @@ def test_get_labware_definition_list(
         contained_labware_bottom_first=[],
         max_pool_count=5,
         pool_overlap=0,
+        pool_height=0,
     )
     assert subject.get_pool_definition_ordered_list() == result
 
@@ -203,6 +205,7 @@ def test_get_contained_labware() -> None:
         ],
         max_pool_count=5,
         pool_overlap=0,
+        pool_height=0,
     )
     assert subject.get_contained_labware() == [
         StackerStoredLabwareGroup(

--- a/api/tests/opentrons/protocol_engine/state/test_labware_view_old.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_view_old.py
@@ -1514,7 +1514,7 @@ def test_raise_if_labware_cannot_be_stacked_on_labware_on_adapter() -> None:
 
 
 @pytest.mark.parametrize(
-    argnames=["primary_def", "lid_def", "adapter_def", "exception"],
+    argnames=["primary_def", "lid_def", "adapter_def", "exception", "ordered_list"],
     argvalues=[
         pytest.param(
             LabwareDefinition2.model_construct(  # type: ignore[call-arg]
@@ -1538,6 +1538,7 @@ def test_raise_if_labware_cannot_be_stacked_on_labware_on_adapter() -> None:
                 ),
             ),
             does_not_raise(),
+            ["lid", "primary", "adapter"],
             id="all-valid-and-present",
         ),
         pytest.param(
@@ -1556,6 +1557,7 @@ def test_raise_if_labware_cannot_be_stacked_on_labware_on_adapter() -> None:
                 ),
             ),
             does_not_raise(),
+            ["primary", "adapter"],
             id="adapter-valid-and-present",
         ),
         pytest.param(
@@ -1575,6 +1577,7 @@ def test_raise_if_labware_cannot_be_stacked_on_labware_on_adapter() -> None:
             ),
             None,
             does_not_raise(),
+            ["lid", "primary"],
             id="lid-valid-and-present",
         ),
         pytest.param(
@@ -1588,6 +1591,7 @@ def test_raise_if_labware_cannot_be_stacked_on_labware_on_adapter() -> None:
             None,
             None,
             does_not_raise(),
+            ["primary"],
             id="primary-only",
         ),
         pytest.param(
@@ -1612,6 +1616,7 @@ def test_raise_if_labware_cannot_be_stacked_on_labware_on_adapter() -> None:
                 ),
             ),
             pytest.raises(errors.LabwareCannotBeStackedError),
+            None,
             id="lid-may-not-stack-on-primary",
         ),
         pytest.param(
@@ -1636,6 +1641,7 @@ def test_raise_if_labware_cannot_be_stacked_on_labware_on_adapter() -> None:
                 ),
             ),
             pytest.raises(errors.LabwareCannotBeStackedError),
+            None,
             id="primary-may-not-stack-on-adapter",
         ),
         pytest.param(
@@ -1660,6 +1666,7 @@ def test_raise_if_labware_cannot_be_stacked_on_labware_on_adapter() -> None:
                 ),
             ),
             pytest.raises(errors.LabwareCannotBeStackedError),
+            None,
             id="adapter-wrong-role",
         ),
         pytest.param(
@@ -1684,6 +1691,7 @@ def test_raise_if_labware_cannot_be_stacked_on_labware_on_adapter() -> None:
                 ),
             ),
             pytest.raises(errors.LabwareCannotBeStackedError),
+            None,
             id="lid-wrong-role",
         ),
     ],
@@ -1693,6 +1701,7 @@ def test_stacker_labware_pool_passes_or_raises(
     lid_def: LabwareDefinition | None,
     adapter_def: LabwareDefinition | None,
     exception: ContextManager[None],
+    ordered_list: List[str] | None,
 ) -> None:
     """It should raise if a stacker labware pool configuration is invalid."""
     subject = get_labware_view()
@@ -1700,6 +1709,12 @@ def test_stacker_labware_pool_passes_or_raises(
         subject.raise_if_stacker_labware_pool_is_not_valid(
             primary_def, lid_def, adapter_def
         )
+    if exception is does_not_raise():
+        result = subject.stacker_labware_pool_to_ordered_list(
+            primary_def, lid_def, adapter_def
+        )
+        result_load_names = [labware_def.parameters.loadName for labware_def in result]
+        assert result_load_names == ordered_list
 
 
 @pytest.mark.parametrize(

--- a/robot-server/tests/runs/router/test_base_router.py
+++ b/robot-server/tests/runs/router/test_base_router.py
@@ -885,6 +885,7 @@ async def test_get_current_state_success(
                 StackerStoredLabwareGroup(primaryLabwareId="heeheehoohoo")
             ],
             pool_overlap=0,
+            pool_height=0,
         ),
     }
 

--- a/shared-data/command/schemas/14.json
+++ b/shared-data/command/schemas/14.json
@@ -5073,6 +5073,19 @@
           "title": "Moduleid",
           "type": "string"
         },
+        "poolOverlapOverride": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Override for the Z stacking overlap of the labware pool. If not provided, the protocol engine will calculate the overlap based on the stacking offsets provided in the labware definitions.",
+          "title": "Pooloverlapoverride"
+        },
         "primaryLabware": {
           "$ref": "#/$defs/StackerStoredLabwareDetails",
           "description": "The details of the primary labware (i.e. not the lid or adapter, if any) stored in the stacker."


### PR DESCRIPTION
# Overview
The original objective of this PR is to allow user to supply an overlap offset of the labware stack during Flex Stacker configuration. This offset, currently calculated from labware definition, affects:
1. the total number the labware can be stored inside the hopper,
2. how far the shuttle would have to travel in the Z-axis during labware storage and retrieval.

While building this feature, I realized our shuttle movements were using incorrect labware heights because we hadn’t factored in the overlap value. We’re fixing that here too—apologies for the sizable diff! 

# Changelog
1. Added `stacking_offset_z` to `SetStoredLabware` protocol engine command to allow overriding the calculated stacking offset with a user-defined value
2. Updated docstrings in `module_context.py` to clarify the purpose of the stacking offset and provide detailed explanations of stacking configurations
4. Added validation for the provided stacking offset override in `module_context.get_max_storable_labware_from_list()` if the stacker already has configuration
5. Modified `module_context.get_current_storable_labware_from_list()` to behave similarly as `get_current_storable_labware()`, so that it checks the module substate to determine how many more can fit inside the hopper and should raise an error if the stacker hasn't been configured
6. Added `LabwareView.stacker_labware_pool_to_ordered_list()` to make use of the `raise_if_stacker_labware_pool_is_not_valid` function to create the proper list of labware in the correct, top-first order
7. Refactored overlap and height calculations to use `stacker_labware_pool_to_ordered_list` and `get_stacker_labware_overlap_offset` to ensure accuracy and consistency across the engine calculations and module context-level prediction
8. Corrected the height value to be passed down to the flex stacker controller in `retrieve.py` and `store.py` using the calls to `FlexStackerSubstate.get_pool_height_minus_overlap()`
