### PR TITLE
chore(ci): automated chore_release PR cascade

### DIFF
--- a/.github/workflows/chore-release-pr-automation.yaml
+++ b/.github/workflows/chore-release-pr-automation.yaml
@@ -25,35 +25,19 @@ jobs:
             --branch-list "${{ vars.CHORE_RELEASE_BRANCHES }}" \
             --target-branch "${{ github.event.pull_request.base.ref }}" \
             --output-file "$GITHUB_ENV"
-      - name: Display summary of inputs and downstream branches
-        run: |
-          echo "| Input                              | Value                         |" >> $GITHUB_STEP_SUMMARY
-          echo "|------------------------------------|-------------------------------|" >> $GITHUB_STEP_SUMMARY
-          echo "| vars.CHORE_RELEASE_BRANCHES        | ${{ vars.CHORE_RELEASE_BRANCHES }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| github.event.pull_request.base.ref | ${{ github.event.pull_request.base.ref }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| downstream_branches                | $downstream_branches          |" >> $GITHUB_STEP_SUMMARY
-          echo "| should_create_prs                  | $should_create_prs            |" >> $GITHUB_STEP_SUMMARY
-          echo "| github.event_name                  | ${{ github.event_name }}      |" >> $GITHUB_STEP_SUMMARY
-          echo "| github.actor                       | ${{ github.actor }}           |" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          if [ "$downstream_branches_display" = "-" ] || [ "$should_create_prs_display" != "true" ]; then
-              echo "### No downstream PRs to open." >> $GITHUB_STEP_SUMMARY
-          else
-              echo "### Downstream PRs should be opened for:" >> $GITHUB_STEP_SUMMARY
-              echo "\`$downstream_branches_display\`" >> $GITHUB_STEP_SUMMARY
-          fi
 
       - name: Open downstream PRs
         if: env.should_create_prs == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          for branch in $(echo "$downstream_branches" | tr ',' ' '); do
+          IFS=, 
+          for branch in $downstream_branches; do
             pr_url=$(gh pr create \
               --base "$branch" \
               --head "${{ github.event.pull_request.head.ref }}" \
               --title "${{ github.event.pull_request.title }} into $branch" \
-              --body "Automated PR of #${{ github.event.pull_request.number }} into downstream branch: $branch." \
+              --body "${{ github.event.pull_request.body }} \
               --assignee "${{ github.event.pull_request.user.login }}" \
               --repo "$GITHUB_REPOSITORY" 2>/dev/null || true)
             if [ -n "$pr_url" ]; then

--- a/.github/workflows/chore-release-pr-automation.yaml
+++ b/.github/workflows/chore-release-pr-automation.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Determine downstream chore release PRs and necessity
         id: downstream
         run: |
-          python scripts/chore_release_pr.py \
+          python scripts/chore_release_pr_gen.py \
             --branch-list "${{ vars.CHORE_RELEASE_BRANCHES }}" \
             --target-branch "${{ github.event.pull_request.base.ref }}" \
             --output-file "$GITHUB_ENV"

--- a/.github/workflows/chore-release-pr-automation.yaml
+++ b/.github/workflows/chore-release-pr-automation.yaml
@@ -13,9 +13,7 @@ on:
                 description: 'Target branch for testing'
                 required: true
                 default: 'chore_release-8.5.0'
-    push:
-        branches:
-            - 'hydra-20250609'
+
 
 jobs:
   handle-chore-release:
@@ -64,10 +62,12 @@ jobs:
           echo "| chore_release_branches | $chore_release_branches_display |" >> $GITHUB_STEP_SUMMARY
           echo "| target_branch          | $target_branch_display         |" >> $GITHUB_STEP_SUMMARY
           echo "| downstream_branches    | $downstream_branches_display   |" >> $GITHUB_STEP_SUMMARY
-
+          echo "| github.event_name      | ${{ github.event_name }}         |" >> $GITHUB_STEP_SUMMARY
+          echo "| github.actor           | ${{ github.actor }}              |" >> $GITHUB_STEP_SUMMARY
+          echo "\n"
           if [ "$downstream_branches_display" = "-" ]; then
-            echo "\n### No downstream PRs to open." >> $GITHUB_STEP_SUMMARY
+            echo "### No downstream PRs to open." >> $GITHUB_STEP_SUMMARY
           else
-            echo "\n### Downstream PRs should be opened for:" >> $GITHUB_STEP_SUMMARY
+            echo "### Downstream PRs should be opened for:" >> $GITHUB_STEP_SUMMARY
             echo "\`$downstream_branches_display\`" >> $GITHUB_STEP_SUMMARY
           fi

--- a/.github/workflows/chore-release-pr-automation.yaml
+++ b/.github/workflows/chore-release-pr-automation.yaml
@@ -2,7 +2,8 @@ name: Chore Release PR Automation
 
 on:
   pull_request:
-    types: [opened, reopened]
+    # edited is necessary so this runs if a PR is re-targeted
+    types: [opened, reopened, edited]
 
 jobs:
   handle-chore-release:

--- a/.github/workflows/chore-release-pr-automation.yaml
+++ b/.github/workflows/chore-release-pr-automation.yaml
@@ -35,7 +35,7 @@ jobs:
           echo "| should_create_prs                  | $should_create_prs            |" >> $GITHUB_STEP_SUMMARY
           echo "| github.event_name                  | ${{ github.event_name }}      |" >> $GITHUB_STEP_SUMMARY
           echo "| github.actor                       | ${{ github.actor }}           |" >> $GITHUB_STEP_SUMMARY
-          echo "\n" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
           if [ "$downstream_branches_display" = "-" ] || [ "$should_create_prs_display" != "true" ]; then
               echo "### No downstream PRs to open." >> $GITHUB_STEP_SUMMARY
           else

--- a/.github/workflows/chore-release-pr-automation.yaml
+++ b/.github/workflows/chore-release-pr-automation.yaml
@@ -37,7 +37,7 @@ jobs:
               --base "$branch" \
               --head "${{ github.event.pull_request.head.ref }}" \
               --title "${{ github.event.pull_request.title }} into $branch" \
-              --body "${{ github.event.pull_request.body }} \
+              --body "Created from #${{ github.event.pull_request.number }} \n ${{ github.event.pull_request.body }}" \
               --assignee "${{ github.event.pull_request.user.login }}" \
               --repo "$GITHUB_REPOSITORY" 2>/dev/null || true)
             if [ -n "$pr_url" ]; then

--- a/.github/workflows/chore-release-pr-automation.yaml
+++ b/.github/workflows/chore-release-pr-automation.yaml
@@ -1,0 +1,70 @@
+name: Chore Release PR Automation
+
+on:
+    pull_request:
+        types: [opened, reopened]
+    workflow_dispatch:
+        inputs:
+            chore_release_branches:
+                description: 'Comma-separated list of chore release branches'
+                required: true
+                default: 'chore_release-8.5.0,chore_release-pd-8.5.0'
+            target_branch:
+                description: 'Target branch for testing'
+                required: true
+                default: 'chore_release-8.5.0'
+
+jobs:
+  handle-chore-release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Set variables for branch and target
+        id: set-vars
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "chore_release_branches=${{ github.event.inputs.chore_release_branches }}" >> $GITHUB_ENV
+            echo "target_branch=${{ github.event.inputs.target_branch }}" >> $GITHUB_ENV
+          else
+            echo "chore_release_branches=${{ secrets.CHORE_RELEASE_BRANCHES }}" >> $GITHUB_ENV
+            echo "target_branch=${{ github.event.pull_request.base.ref }}" >> $GITHUB_ENV
+          fi
+
+      - name: Determine downstream chore release PRs
+        id: downstream
+        run: |
+          python scripts/chore_release_pr_gen.py \
+            --branch-list "$chore_release_branches" \
+            --target-branch "$target_branch" \
+            --output-file "$GITHUB_ENV"
+
+      - name: Display summary of inputs and downstream branches
+        run: |
+          # Set variables for display, using dash if empty
+          chore_release_branches_display="$chore_release_branches"
+          if [ -z "$chore_release_branches_display" ]; then chore_release_branches_display='-'; fi
+          target_branch_display="$target_branch"
+          if [ -z "$target_branch_display" ]; then target_branch_display='-'; fi
+          downstream_branches_display="$downstream_branches"
+          if [ -z "$downstream_branches_display" ]; then downstream_branches_display='-'; fi
+
+          echo "| Input                  | Value                    |" >> $GITHUB_STEP_SUMMARY
+          echo "|------------------------|--------------------------|" >> $GITHUB_STEP_SUMMARY
+          echo "| chore_release_branches | $chore_release_branches_display |" >> $GITHUB_STEP_SUMMARY
+          echo "| target_branch          | $target_branch_display         |" >> $GITHUB_STEP_SUMMARY
+          echo "| downstream_branches    | $downstream_branches_display   |" >> $GITHUB_STEP_SUMMARY
+
+          if [ "$downstream_branches_display" = "-" ]; then
+            echo "\n### No downstream PRs to open." >> $GITHUB_STEP_SUMMARY
+          else
+            echo "\n### Downstream PRs should be opened for:" >> $GITHUB_STEP_SUMMARY
+            echo "\`$downstream_branches_display\`" >> $GITHUB_STEP_SUMMARY
+          fi

--- a/.github/workflows/chore-release-pr-automation.yaml
+++ b/.github/workflows/chore-release-pr-automation.yaml
@@ -13,6 +13,9 @@ on:
                 description: 'Target branch for testing'
                 required: true
                 default: 'chore_release-8.5.0'
+    push:
+        branches:
+            - 'hydra-20250609'
 
 jobs:
   handle-chore-release:

--- a/.github/workflows/chore-release-pr-automation.yaml
+++ b/.github/workflows/chore-release-pr-automation.yaml
@@ -1,19 +1,8 @@
 name: Chore Release PR Automation
 
 on:
-    pull_request:
-        types: [opened, reopened]
-    workflow_dispatch:
-        inputs:
-            chore_release_branches:
-                description: 'Comma-separated list of chore release branches'
-                required: true
-                default: 'chore_release-8.5.0,chore_release-pd-8.5.0'
-            target_branch:
-                description: 'Target branch for testing'
-                required: true
-                default: 'chore_release-8.5.0'
-
+  pull_request:
+    types: [opened, reopened]
 
 jobs:
   handle-chore-release:
@@ -28,46 +17,47 @@ jobs:
         with:
           python-version: '3.10'
 
-      - name: Set variables for branch and target
-        id: set-vars
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "chore_release_branches=${{ github.event.inputs.chore_release_branches }}" >> $GITHUB_ENV
-            echo "target_branch=${{ github.event.inputs.target_branch }}" >> $GITHUB_ENV
-          else
-            echo "chore_release_branches=${{ secrets.CHORE_RELEASE_BRANCHES }}" >> $GITHUB_ENV
-            echo "target_branch=${{ github.event.pull_request.base.ref }}" >> $GITHUB_ENV
-          fi
-
-      - name: Determine downstream chore release PRs
+      - name: Determine downstream chore release PRs and necessity
         id: downstream
         run: |
-          python scripts/chore_release_pr_gen.py \
-            --branch-list "$chore_release_branches" \
-            --target-branch "$target_branch" \
+          python scripts/chore_release_pr.py \
+            --branch-list "${{ vars.CHORE_RELEASE_BRANCHES }}" \
+            --target-branch "${{ github.event.pull_request.base.ref }}" \
             --output-file "$GITHUB_ENV"
-
       - name: Display summary of inputs and downstream branches
         run: |
-          # Set variables for display, using dash if empty
-          chore_release_branches_display="$chore_release_branches"
-          if [ -z "$chore_release_branches_display" ]; then chore_release_branches_display='-'; fi
-          target_branch_display="$target_branch"
-          if [ -z "$target_branch_display" ]; then target_branch_display='-'; fi
-          downstream_branches_display="$downstream_branches"
-          if [ -z "$downstream_branches_display" ]; then downstream_branches_display='-'; fi
-
-          echo "| Input                  | Value                    |" >> $GITHUB_STEP_SUMMARY
-          echo "|------------------------|--------------------------|" >> $GITHUB_STEP_SUMMARY
-          echo "| chore_release_branches | $chore_release_branches_display |" >> $GITHUB_STEP_SUMMARY
-          echo "| target_branch          | $target_branch_display         |" >> $GITHUB_STEP_SUMMARY
-          echo "| downstream_branches    | $downstream_branches_display   |" >> $GITHUB_STEP_SUMMARY
-          echo "| github.event_name      | ${{ github.event_name }}         |" >> $GITHUB_STEP_SUMMARY
-          echo "| github.actor           | ${{ github.actor }}              |" >> $GITHUB_STEP_SUMMARY
-          echo "\n"
-          if [ "$downstream_branches_display" = "-" ]; then
-            echo "### No downstream PRs to open." >> $GITHUB_STEP_SUMMARY
+          echo "| Input                              | Value                         |" >> $GITHUB_STEP_SUMMARY
+          echo "|------------------------------------|-------------------------------|" >> $GITHUB_STEP_SUMMARY
+          echo "| vars.CHORE_RELEASE_BRANCHES        | ${{ vars.CHORE_RELEASE_BRANCHES }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| github.event.pull_request.base.ref | ${{ github.event.pull_request.base.ref }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| downstream_branches                | $downstream_branches          |" >> $GITHUB_STEP_SUMMARY
+          echo "| should_create_prs                  | $should_create_prs            |" >> $GITHUB_STEP_SUMMARY
+          echo "| github.event_name                  | ${{ github.event_name }}      |" >> $GITHUB_STEP_SUMMARY
+          echo "| github.actor                       | ${{ github.actor }}           |" >> $GITHUB_STEP_SUMMARY
+          echo "\n" >> $GITHUB_STEP_SUMMARY
+          if [ "$downstream_branches_display" = "-" ] || [ "$should_create_prs_display" != "true" ]; then
+              echo "### No downstream PRs to open." >> $GITHUB_STEP_SUMMARY
           else
-            echo "### Downstream PRs should be opened for:" >> $GITHUB_STEP_SUMMARY
-            echo "\`$downstream_branches_display\`" >> $GITHUB_STEP_SUMMARY
+              echo "### Downstream PRs should be opened for:" >> $GITHUB_STEP_SUMMARY
+              echo "\`$downstream_branches_display\`" >> $GITHUB_STEP_SUMMARY
           fi
+
+      - name: Open downstream PRs
+        if: env.should_create_prs == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          for branch in $(echo "$downstream_branches" | tr ',' ' '); do
+            pr_url=$(gh pr create \
+              --base "$branch" \
+              --head "${{ github.event.pull_request.head.ref }}" \
+              --title "${{ github.event.pull_request.title }} into $branch" \
+              --body "Automated PR of #${{ github.event.pull_request.number }} into downstream branch: $branch." \
+              --assignee "${{ github.event.pull_request.user.login }}" \
+              --repo "$GITHUB_REPOSITORY" 2>/dev/null || true)
+            if [ -n "$pr_url" ]; then
+              echo "Opened PR to $branch: $pr_url" >> $GITHUB_STEP_SUMMARY
+            else
+              echo "PR already exists or failed for $branch" >> $GITHUB_STEP_SUMMARY
+            fi
+          done

--- a/scripts/chore_release_pr_gen.py
+++ b/scripts/chore_release_pr_gen.py
@@ -61,27 +61,26 @@ def write_output(downstream_str: str, should_create_prs: str, output_file: str):
     else:
         output_stream = open(output_file, "w")
 
+    lines = [
+        "| Input                              | Value                         |",
+        "|------------------------------------|-------------------------------|",
+        f"| vars.CHORE_RELEASE_BRANCHES        | {os.environ.get('CHORE_RELEASE_BRANCHES', '')} |",
+        f"| github.event.pull_request.base.ref | {os.environ.get('PR_TARGET_BRANCH', '')} |",
+        f"| downstream_branches                | {downstream_str}          |",
+        f"| should_create_prs                  | {should_create_prs}            |",
+        f"| github.event_name                  | {os.environ.get('GITHUB_EVENT_NAME', '')}      |",
+        f"| github.actor                       | {os.environ.get('GITHUB_ACTOR', '')}           |",
+        "",
+    ]
+    if not downstream_str:
+        lines.append("### No downstream PRs to open.")
+    else:
+        lines.append("### Downstream PRs should be opened for:")
+        lines.append(f"`{downstream_str}`")
+
     with output_stream as f:
         for line in output_lines:
             f.write(line + "\n")
-
-        lines = [
-            "| Input                              | Value                         |",
-            "|------------------------------------|-------------------------------|",
-            f"| vars.CHORE_RELEASE_BRANCHES        | {os.environ.get('CHORE_RELEASE_BRANCHES', '')} |",
-            f"| github.event.pull_request.base.ref | {os.environ.get('PR_TARGET_BRANCH', '')} |",
-            f"| downstream_branches                | {downstream_str}          |",
-            f"| should_create_prs                  | {should_create_prs}            |",
-            f"| github.event_name                  | {os.environ.get('GITHUB_EVENT_NAME', '')}      |",
-            f"| github.actor                       | {os.environ.get('GITHUB_ACTOR', '')}           |",
-            "",
-        ]
-        if not downstream_str:
-            lines.append("### No downstream PRs to open.")
-        else:
-            lines.append("### Downstream PRs should be opened for:")
-            lines.append(f"`{downstream_str}`")
-
         if summary_file and is_ci:
             with open(summary_file, "a") as f:
                 for line in lines:

--- a/scripts/chore_release_pr_gen.py
+++ b/scripts/chore_release_pr_gen.py
@@ -1,7 +1,19 @@
+"""
+This script generates a list of downstream branches for a given branch list and target branch.
+Run locally with:
+python chore_release_pr_gen.py --branch-list "branch1, branch2, branch3" --target-branch "branch2"
+outputs:
+downstream_branches=branch3
+should_create_prs=true
+"""
+
 import argparse
 import os
+import sys
 from typing import List
 import unittest
+
+is_ci = os.environ.get("CI") == "true"
 
 
 def parse_branch_list(branch_list_str: str) -> List[str]:
@@ -36,6 +48,49 @@ def get_downstream_branches(
     return branch_list[index + 1 :]
 
 
+def write_output(downstream_str: str, should_create_prs: str, output_file: str):
+    summary_file = os.environ.get("GITHUB_STEP_SUMMARY")
+
+    output_lines = [
+        f"downstream_branches={downstream_str}",
+        f"should_create_prs={should_create_prs}",
+    ]
+
+    if output_file == "-":
+        output_stream = sys.stdout
+    else:
+        output_stream = open(output_file, "w")
+
+    with output_stream as f:
+        for line in output_lines:
+            f.write(line + "\n")
+
+        lines = [
+            "| Input                              | Value                         |",
+            "|------------------------------------|-------------------------------|",
+            f"| vars.CHORE_RELEASE_BRANCHES        | {os.environ.get('CHORE_RELEASE_BRANCHES', '')} |",
+            f"| github.event.pull_request.base.ref | {os.environ.get('PR_TARGET_BRANCH', '')} |",
+            f"| downstream_branches                | {downstream_str}          |",
+            f"| should_create_prs                  | {should_create_prs}            |",
+            f"| github.event_name                  | {os.environ.get('GITHUB_EVENT_NAME', '')}      |",
+            f"| github.actor                       | {os.environ.get('GITHUB_ACTOR', '')}           |",
+            "",
+        ]
+        if not downstream_str:
+            lines.append("### No downstream PRs to open.")
+        else:
+            lines.append("### Downstream PRs should be opened for:")
+            lines.append(f"`{downstream_str}`")
+
+        if summary_file and is_ci:
+            with open(summary_file, "a") as f:
+                for line in lines:
+                    f.write(line + "\n")
+        else:
+            for line in lines:
+                print(line)
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -48,7 +103,10 @@ def main():
         "--target-branch", type=str, required=False, help="Branch this PR is targeting"
     )
     parser.add_argument(
-        "--output-file", type=str, help="Write outputs to this file for GitHub Actions"
+        "--output-file",
+        type=str,
+        default="-",
+        help="Write outputs to this file for GitHub Actions. Use '-' for stdout.",
     )
     args = parser.parse_args()
 
@@ -60,25 +118,11 @@ def main():
     downstream_str = ",".join(downstream)
     should_create_prs = "true" if downstream else "false"
 
-    # Output for GitHub Actions
-    output_lines = [
-        f"downstream_branches={downstream_str}",
-        f"should_create_prs={should_create_prs}",
-    ]
-
-    if args.output_file:
-        with open(args.output_file, "a") as f:
-            for line in output_lines:
-                f.write(line + "\n")
-    else:
-        # For local/manual runs
-        for line in output_lines:
-            print(f"::set-output name={line}")
+    write_output(downstream_str, should_create_prs, args.output_file)
 
 
 # ============================================================
 # Unit tests for the get_downstream_branches function
-# cd scripts
 # python chore_release_pr_gen.py test
 # ============================================================
 

--- a/scripts/chore_release_pr_gen.py
+++ b/scripts/chore_release_pr_gen.py
@@ -5,39 +5,64 @@ from typing import List
 DEFAULT_BRANCH = "edge"
 
 def parse_branch_list(branch_list_str: str) -> List[str]:
+    """Splits a comma-separated branch list into a clean Python list."""
     return [b.strip() for b in branch_list_str.split(",") if b.strip()]
 
-def get_downstream_branches(branch_list: List[str], target_branch: str) -> List[str]:
+def get_downstream_branches(branch_list: List[str], target_branch: str, default_branch: str = DEFAULT_BRANCH) -> List[str]:
+    """
+    Returns all branches after target_branch in branch_list (the order in the input matters!).
+    If target_branch is present and not the default branch:
+      - downstream = [all after target, except default branch]
+      - then default branch is appended (if target isn't default already)
+    If not present or target is default branch: returns []
+    """
     try:
         idx = branch_list.index(target_branch)
     except ValueError:
         return []
     downstream = branch_list[idx + 1 :]
-    if target_branch in branch_list:
-        if DEFAULT_BRANCH in downstream:
-            downstream = [b for b in downstream if b != DEFAULT_BRANCH]
-        downstream.append(DEFAULT_BRANCH)
+    # Remove default_branch if present downstream
+    # This is a clean way to:
+    # - set the default branch at the end
+    # - handle someone including the default branch in the branch_list
+    # - set downstream to [] if target_branch is the default, as it is in most cases
+    downstream = [b for b in downstream if b != default_branch]
+    # Append default_branch if target_branch is not already the default
+    if target_branch != default_branch:
+        downstream.append(default_branch)
     return downstream
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--branch-list", type=str, required=False)
-    parser.add_argument("--target-branch", type=str, required=False)
-    parser.add_argument("--output-file", type=str)
+    parser.add_argument("--branch-list", type=str, required=False, help="Comma-separated branch list in stream order")
+    parser.add_argument("--target-branch", type=str, required=False, help="Branch this PR is targeting")
+    parser.add_argument("--output-file", type=str, help="Write outputs to this file for GitHub Actions")
+    parser.add_argument("--default-branch", type=str, required=False, default=DEFAULT_BRANCH, help="The default branch name")
     args = parser.parse_args()
 
     branch_list_str = args.branch_list or os.environ.get("CHORE_RELEASE_BRANCHES", "")
     target_branch = args.target_branch or os.environ.get("PR_TARGET_BRANCH", "")
+    default_branch = args.default_branch or os.environ.get("DEFAULT_BRANCH", DEFAULT_BRANCH)
 
     branch_list = parse_branch_list(branch_list_str)
-    downstream = get_downstream_branches(branch_list, target_branch)
+    downstream = get_downstream_branches(branch_list, target_branch, default_branch)
     downstream_str = ",".join(downstream)
+    should_create_prs = "true" if downstream else "false"
+
+    # Output for GitHub Actions
+    output_lines = [
+        f"downstream_branches={downstream_str}",
+        f"should_create_prs={should_create_prs}",
+    ]
 
     if args.output_file:
         with open(args.output_file, "a") as f:
-            f.write(f"downstream_branches={downstream_str}\n")
+            for line in output_lines:
+                f.write(line + "\n")
     else:
-        print(f"::set-output name=downstream_branches::{downstream_str}")
+        # For local/manual runs
+        for line in output_lines:
+            print(f"::set-output name={line}")
 
 if __name__ == "__main__":
     main()

--- a/scripts/chore_release_pr_gen.py
+++ b/scripts/chore_release_pr_gen.py
@@ -1,0 +1,43 @@
+import argparse
+import os
+from typing import List
+
+DEFAULT_BRANCH = "edge"
+
+def parse_branch_list(branch_list_str: str) -> List[str]:
+    return [b.strip() for b in branch_list_str.split(",") if b.strip()]
+
+def get_downstream_branches(branch_list: List[str], target_branch: str) -> List[str]:
+    try:
+        idx = branch_list.index(target_branch)
+    except ValueError:
+        return []
+    downstream = branch_list[idx + 1 :]
+    if target_branch in branch_list:
+        if DEFAULT_BRANCH in downstream:
+            downstream = [b for b in downstream if b != DEFAULT_BRANCH]
+        downstream.append(DEFAULT_BRANCH)
+    return downstream
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--branch-list", type=str, required=False)
+    parser.add_argument("--target-branch", type=str, required=False)
+    parser.add_argument("--output-file", type=str)
+    args = parser.parse_args()
+
+    branch_list_str = args.branch_list or os.environ.get("CHORE_RELEASE_BRANCHES", "")
+    target_branch = args.target_branch or os.environ.get("PR_TARGET_BRANCH", "")
+
+    branch_list = parse_branch_list(branch_list_str)
+    downstream = get_downstream_branches(branch_list, target_branch)
+    downstream_str = ",".join(downstream)
+
+    if args.output_file:
+        with open(args.output_file, "a") as f:
+            f.write(f"downstream_branches={downstream_str}\n")
+    else:
+        print(f"::set-output name=downstream_branches::{downstream_str}")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/chore_release_pr_gen.py
+++ b/scripts/chore_release_pr_gen.py
@@ -1,51 +1,62 @@
 import argparse
 import os
 from typing import List
+import unittest
 
-DEFAULT_BRANCH = "edge"
 
 def parse_branch_list(branch_list_str: str) -> List[str]:
     """Splits a comma-separated branch list into a clean Python list."""
     return [b.strip() for b in branch_list_str.split(",") if b.strip()]
 
-def get_downstream_branches(branch_list: List[str], target_branch: str, default_branch: str = DEFAULT_BRANCH) -> List[str]:
+
+def get_downstream_branches(
+    branch_list: List[str],
+    target_branch: str,
+) -> List[str]:
     """
-    Returns all branches after target_branch in branch_list (the order in the input matters!).
-    If target_branch is present and not the default branch:
-      - downstream = [all after target, except default branch]
-      - then default branch is appended (if target isn't default already)
-    If not present or target is default branch: returns []
+    Returns all branches after target_branch in branch_list
+    (the order in the input matters!).
+    If target_branch is the last branch, returns [].
     """
+    if not branch_list:
+        raise ValueError(
+            "Branch list cannot be empty! Please check repository variable."
+        )
+    if not target_branch:
+        raise ValueError("Target branch cannot be empty!")
+
     try:
-        idx = branch_list.index(target_branch)
+        index = branch_list.index(target_branch)
     except ValueError:
+        # Not in the branch list, return empty list
         return []
-    downstream = branch_list[idx + 1 :]
-    # Remove default_branch if present downstream
-    # This is a clean way to:
-    # - set the default branch at the end
-    # - handle someone including the default branch in the branch_list
-    # - set downstream to [] if target_branch is the default, as it is in most cases
-    downstream = [b for b in downstream if b != default_branch]
-    # Append default_branch if target_branch is not already the default
-    if target_branch != default_branch:
-        downstream.append(default_branch)
-    return downstream
+    # Slicing the last element
+    # As will be the case for us in most PRs, is safe.
+    # There is no error, the result is []
+    return branch_list[index + 1 :]
+
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--branch-list", type=str, required=False, help="Comma-separated branch list in stream order")
-    parser.add_argument("--target-branch", type=str, required=False, help="Branch this PR is targeting")
-    parser.add_argument("--output-file", type=str, help="Write outputs to this file for GitHub Actions")
-    parser.add_argument("--default-branch", type=str, required=False, default=DEFAULT_BRANCH, help="The default branch name")
+    parser.add_argument(
+        "--branch-list",
+        type=str,
+        required=False,
+        help="Comma-separated branch list in stream order",
+    )
+    parser.add_argument(
+        "--target-branch", type=str, required=False, help="Branch this PR is targeting"
+    )
+    parser.add_argument(
+        "--output-file", type=str, help="Write outputs to this file for GitHub Actions"
+    )
     args = parser.parse_args()
 
     branch_list_str = args.branch_list or os.environ.get("CHORE_RELEASE_BRANCHES", "")
     target_branch = args.target_branch or os.environ.get("PR_TARGET_BRANCH", "")
-    default_branch = args.default_branch or os.environ.get("DEFAULT_BRANCH", DEFAULT_BRANCH)
 
     branch_list = parse_branch_list(branch_list_str)
-    downstream = get_downstream_branches(branch_list, target_branch, default_branch)
+    downstream = get_downstream_branches(branch_list, target_branch)
     downstream_str = ",".join(downstream)
     should_create_prs = "true" if downstream else "false"
 
@@ -64,5 +75,54 @@ def main():
         for line in output_lines:
             print(f"::set-output name={line}")
 
+
+# ============================================================
+# Unit tests for the get_downstream_branches function
+# cd scripts
+# python chore_release_pr_gen.py test
+# ============================================================
+
+hotfix = "chore_release-8.4.1"
+isolation = "chore_release-8.5.0"
+pd = "chore_release-pd-8.5.0"
+default = "edge"
+other = "main"
+
+branches = [hotfix, isolation, pd, default]
+
+
+class TestGetDownstreamBranches(unittest.TestCase):
+
+    def test_middle_branch(self):
+        self.assertEqual(get_downstream_branches(branches, isolation), [pd, default])
+
+    def test_first_branch(self):
+        self.assertEqual(
+            get_downstream_branches(branches, hotfix), [isolation, pd, default]
+        )
+
+    def test_last_branch(self):
+        self.assertEqual(get_downstream_branches(branches, default), [])
+
+    def test_not_in_list(self):
+        self.assertEqual(get_downstream_branches(branches, other), [])
+
+    def test_empty_branch_list(self):
+        with self.assertRaises(ValueError):
+            get_downstream_branches([], hotfix)
+
+    def test_empty_target_branch(self):
+        with self.assertRaises(ValueError):
+            get_downstream_branches(branches, "")
+
+    def test_single_element(self):
+        self.assertEqual(get_downstream_branches([default], default), [])
+
+
 if __name__ == "__main__":
-    main()
+    import sys
+
+    if len(sys.argv) > 1 and sys.argv[1] == "test":
+        unittest.main(argv=[sys.argv[0]])
+    else:
+        main()


### PR DESCRIPTION
## Overview

```
on:
  pull_request:
    types: [opened, reopened]
```
- Identify PRs targeting active chore release branches which are actively kept up to date in repository variables.
<img width="1358" alt="image" src="https://github.com/user-attachments/assets/930c8f16-8cff-4529-9ce5-91a3d98f063a" />

- Determine upstream branches handling `edge` as the default branch and terminating downstream branch. 
- Print info to the workflow summary
- Auto-generate and assign the new PRs for each downstream branch.