### PR TITLE
fix(protocol-designer): revert liquid schema to v1

### DIFF
--- a/protocol-designer/fixtures/protocol/8/doItAllV3MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/doItAllV3MigratedToV8.json
@@ -2665,13 +2665,12 @@
       }
     }
   },
-  "liquidSchemaId": "opentronsLiquidSchemaV2",
+  "liquidSchemaId": "opentronsLiquidSchemaV1",
   "liquids": {
     "0": {
       "displayName": "Water",
       "description": "",
-      "displayColor": "#b925ff",
-      "liquidClass": null
+      "displayColor": "#b925ff"
     }
   },
   "commandSchemaId": "opentronsCommandSchemaV10",

--- a/protocol-designer/fixtures/protocol/8/doItAllV4MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/doItAllV4MigratedToV8.json
@@ -2689,13 +2689,12 @@
       }
     }
   },
-  "liquidSchemaId": "opentronsLiquidSchemaV2",
+  "liquidSchemaId": "opentronsLiquidSchemaV1",
   "liquids": {
     "0": {
       "displayName": "Water",
       "description": "",
-      "displayColor": "#b925ff",
-      "liquidClass": null
+      "displayColor": "#b925ff"
     }
   },
   "commandSchemaId": "opentronsCommandSchemaV10",

--- a/protocol-designer/fixtures/protocol/8/doItAllV7MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/doItAllV7MigratedToV8.json
@@ -4059,19 +4059,17 @@
       }
     }
   },
-  "liquidSchemaId": "opentronsLiquidSchemaV2",
+  "liquidSchemaId": "opentronsLiquidSchemaV1",
   "liquids": {
     "0": {
       "displayName": "Water",
       "description": "",
-      "displayColor": "#b925ff",
-      "liquidClass": null
+      "displayColor": "#b925ff"
     },
     "1": {
       "displayName": "Samples",
       "description": "",
-      "displayColor": "#ffd600",
-      "liquidClass": null
+      "displayColor": "#ffd600"
     }
   },
   "commandSchemaId": "opentronsCommandSchemaV10",

--- a/protocol-designer/fixtures/protocol/8/doItAllV8.json
+++ b/protocol-designer/fixtures/protocol/8/doItAllV8.json
@@ -3585,19 +3585,17 @@
       }
     }
   },
-  "liquidSchemaId": "opentronsLiquidSchemaV2",
+  "liquidSchemaId": "opentronsLiquidSchemaV1",
   "liquids": {
     "0": {
       "displayName": "h20",
       "description": "",
-      "displayColor": "#b925ff",
-      "liquidClass": null
+      "displayColor": "#b925ff"
     },
     "1": {
       "displayName": "sample",
       "description": "",
-      "displayColor": "#ffd600",
-      "liquidClass": null
+      "displayColor": "#ffd600"
     }
   },
   "commandSchemaId": "opentronsCommandSchemaV10",

--- a/protocol-designer/fixtures/protocol/8/example_1_1_0MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/example_1_1_0MigratedToV8.json
@@ -3572,19 +3572,17 @@
       }
     }
   },
-  "liquidSchemaId": "opentronsLiquidSchemaV2",
+  "liquidSchemaId": "opentronsLiquidSchemaV1",
   "liquids": {
     "0": {
       "displayName": "samples",
       "description": "",
-      "displayColor": "#b925ff",
-      "liquidClass": null
+      "displayColor": "#b925ff"
     },
     "1": {
       "displayName": "dna",
       "description": "",
-      "displayColor": "#ffd600",
-      "liquidClass": null
+      "displayColor": "#ffd600"
     }
   },
   "commandSchemaId": "opentronsCommandSchemaV10",

--- a/protocol-designer/fixtures/protocol/8/newAdvancedSettingsAndMultiTemp.json
+++ b/protocol-designer/fixtures/protocol/8/newAdvancedSettingsAndMultiTemp.json
@@ -3650,7 +3650,7 @@
       }
     }
   },
-  "liquidSchemaId": "opentronsLiquidSchemaV2",
+  "liquidSchemaId": "opentronsLiquidSchemaV1",
   "liquids": {},
   "commandSchemaId": "opentronsCommandSchemaV10",
   "commands": [

--- a/protocol-designer/fixtures/protocol/8/ninetySixChannelFullAndColumn.json
+++ b/protocol-designer/fixtures/protocol/8/ninetySixChannelFullAndColumn.json
@@ -2390,7 +2390,7 @@
       }
     }
   },
-  "liquidSchemaId": "opentronsLiquidSchemaV2",
+  "liquidSchemaId": "opentronsLiquidSchemaV1",
   "liquids": {},
   "commandSchemaId": "opentronsCommandSchemaV10",
   "commands": [

--- a/protocol-designer/fixtures/protocol/8/thermocyclerOnOt2V7MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/thermocyclerOnOt2V7MigratedToV8.json
@@ -2266,13 +2266,12 @@
       }
     }
   },
-  "liquidSchemaId": "opentronsLiquidSchemaV2",
+  "liquidSchemaId": "opentronsLiquidSchemaV1",
   "liquids": {
     "0": {
       "displayName": "123",
       "description": "",
-      "displayColor": "#b925ff",
-      "liquidClass": null
+      "displayColor": "#b925ff"
     }
   },
   "commandSchemaId": "opentronsCommandSchemaV10",

--- a/protocol-designer/src/file-data/selectors/fileCreator.ts
+++ b/protocol-designer/src/file-data/selectors/fileCreator.ts
@@ -40,7 +40,7 @@ import type {
   CommandV10Mixin,
   CreateCommand,
   LabwareV2Mixin,
-  LiquidV2Mixin,
+  LiquidV1Mixin,
   OT2RobotMixin,
   OT3RobotMixin,
   ProtocolBase,
@@ -196,7 +196,7 @@ export const createFile: Selector<ProtocolFile> = createSelector(
       },
     }
 
-    const liquids: LiquidV2Mixin['liquids'] = reduce(
+    const liquids: LiquidV1Mixin['liquids'] = reduce(
       liquidEntities,
       (acc, liquidData, liquidId) => {
         return {
@@ -205,7 +205,6 @@ export const createFile: Selector<ProtocolFile> = createSelector(
             displayName: liquidData.displayName,
             description: liquidData.description ?? '',
             displayColor: liquidData.displayColor ?? swatchColors(liquidId),
-            liquidClass: liquidData.liquidClass ?? null,
           },
         }
       },
@@ -245,8 +244,8 @@ export const createFile: Selector<ProtocolFile> = createSelector(
       labwareDefinitions,
     }
 
-    const liquidV2Mixin: LiquidV2Mixin = {
-      liquidSchemaId: 'opentronsLiquidSchemaV2',
+    const liquidV2Mixin: LiquidV1Mixin = {
+      liquidSchemaId: 'opentronsLiquidSchemaV1',
       liquids,
     }
 

--- a/protocol-designer/src/load-file/migration/8_5_0.ts
+++ b/protocol-designer/src/load-file/migration/8_5_0.ts
@@ -20,7 +20,6 @@ import { getMigratedPositionFromTop } from './utils/getMigrationPositionFromTop'
 
 import type {
   LabwareDefinition2,
-  LiquidV2Mixin,
   LoadLabwareCreateCommand,
   PipetteV2Specs,
   ProtocolFile,
@@ -44,13 +43,7 @@ const getMigratedBlowoutFlowRate = (
 export const migrateFile = (
   appData: ProtocolFile<PDMetadata>
 ): ProtocolFile<PDMetadata> => {
-  const {
-    designerApplication,
-    commands,
-    labwareDefinitions,
-    robot,
-    liquids,
-  } = appData
+  const { designerApplication, commands, labwareDefinitions, robot } = appData
   if (designerApplication == null || designerApplication?.data == null) {
     throw Error('The designerApplication key in your file is corrupt.')
   }
@@ -302,19 +295,6 @@ export const migrateFile = (
     {}
   )
 
-  const migratedLiquidsWithLiquidClass = Object.entries(liquids).reduce<
-    LiquidV2Mixin['liquids']
-  >((acc, [liquidId, liquid]) => {
-    acc[liquidId] = {
-      ...liquid,
-      liquidClass: null,
-    }
-    return acc
-  }, {})
-  const liquidV2Mixin: LiquidV2Mixin = {
-    liquidSchemaId: 'opentronsLiquidSchemaV2',
-    liquids: migratedLiquidsWithLiquidClass,
-  }
   return {
     ...appData,
     metadata: {
@@ -333,6 +313,5 @@ export const migrateFile = (
         },
       },
     },
-    ...liquidV2Mixin,
   }
 }

--- a/shared-data/protocol/types/schemaV8/index.ts
+++ b/shared-data/protocol/types/schemaV8/index.ts
@@ -89,18 +89,6 @@ export interface LiquidV1Mixin {
   }
 }
 
-export interface LiquidV2Mixin {
-  liquidSchemaId: 'opentronsLiquidSchemaV2'
-  liquids: {
-    [liquidId: string]: {
-      displayName: string
-      description: string
-      liquidClass: string | null
-      displayColor?: string
-    }
-  }
-}
-
 export interface RobotStructure {
   model: string
   deckId: string
@@ -147,7 +135,7 @@ export type ProtocolFile<
 > = ProtocolBase<DesignerApplicationData> &
   (OT2RobotMixin | OT3RobotMixin) &
   LabwareV2Mixin &
-  (LiquidV1Mixin | LiquidV2Mixin) &
+  LiquidV1Mixin &
   (
     | CommandV8Mixin
     | CommandV9Mixin


### PR DESCRIPTION
# Overview

I previously updated the protocol v8 top level `liquids` key to a new v2 schema, which extended the liquid v1 schema by a new optional `liquidClass` key. However, this change will not be ready in the robot stack at the time of PD 8.5 release, so I am reverting the change temporarily. I will add the key back in a followup targeting `edge`.

## Test Plan and Hands on Testing

Most of this should be covered by the migration tests! Practically, you can import/create a protocol on PD built off this branch, export, and try running in the app 

## Changelog

- revert migration for top level protocol `liquids` key
- revert liquid class addition in `createFile`
- remove `liquidSchemaV2`

## Review requests

see test plan

## Risk assessment

lowish