### PR TITLE
feat(shared-data): ibidi lid definition

### DIFF
--- a/abr-testing/abr_testing/protocols/test_protocols/labware_def_checker.py
+++ b/abr-testing/abr_testing/protocols/test_protocols/labware_def_checker.py
@@ -32,8 +32,12 @@ def add_parameters(parameters: ParameterContext) -> None:
                 "display_name": "ibidi96 SqrWellFltBtmPlt300µL",
                 "value": "ibidi_96_square_well_plate_300ul",
             },
+            {
+                "display_name": "ibidi lid",
+                "value": "ibidi_96_square_well_plate_300ul_lid",
+            },
         ],
-        default="axygen_96_wellplate_500ul",
+        default="ibidi_96_square_well_plate_300ul_lid",
     )
     parameters.add_bool(
         variable_name="heater_shaker",
@@ -49,9 +53,15 @@ def run(protocol: ProtocolContext) -> None:
     heater_shaker_enabled = protocol.params.heater_shaker  # type: ignore[attr-defined]
 
     # Lid loading
-    if labware_type == "corning_96_wellplate_360ul_lid":
+    if labware_type == "ibidi_96_square_well_plate_300ul_lid":
         protocol.load_lid_stack(labware_type, "C3", 1)
         labware = protocol.load_labware("ibidi_96_square_well_plate_300ul", "D3")
+        for _ in range(3):
+            protocol.move_lid("C3", labware, use_gripper=True)
+            protocol.move_lid(labware, "C3", use_gripper=True)
+    elif labware_type == "corning_96_wellplate_360ul_lid":
+        protocol.load_lid_stack(labware_type, "C3", 1)
+        labware = protocol.load_labware("corning_96_wellplate_360ul_flat", "D3")
         for _ in range(3):
             protocol.move_lid("C3", labware, use_gripper=True)
             protocol.move_lid(labware, "C3", use_gripper=True)

--- a/shared-data/labware/definitions/2/ibidi_96_square_well_plate_300ul_lid/1.json
+++ b/shared-data/labware/definitions/2/ibidi_96_square_well_plate_300ul_lid/1.json
@@ -2,19 +2,19 @@
   "allowedRoles": ["labware", "lid"],
   "ordering": [],
   "brand": {
-    "brand": "Corning",
+    "brand": "ibidi",
     "brandId": []
   },
   "metadata": {
-    "displayName": "Corning 96 Wellplate 360ul Lid",
+    "displayName": "ibidi 96 Square Well Flat Bottom Plate 300 µL Lid",
     "displayCategory": "lid",
     "displayVolumeUnits": "\u00b5L",
     "tags": []
   },
   "dimensions": {
     "xDimension": 127,
-    "yDimension": 85,
-    "zDimension": 10
+    "yDimension": 84.5,
+    "zDimension": 6.95
   },
   "wells": {},
   "groups": [
@@ -26,35 +26,33 @@
   "cornerOffsetFromSlot": {
     "x": 0,
     "y": 0,
-    "z": -0.71
+    "z": 0
   },
   "parameters": {
     "format": "irregular",
     "quirks": ["stackingMaxFive"],
     "isTiprack": false,
     "isMagneticModuleCompatible": false,
-    "loadName": "corning_96_wellplate_360ul_lid"
+    "loadName": "ibidi_96_square_well_plate_300ul_lid"
   },
   "namespace": "opentrons",
   "version": 1,
   "schemaVersion": 2,
-  "stackingOffsetWithModule": {
-    "thermocyclerModuleV2": {
-      "x": 0,
-      "y": 0,
-      "z": 0
-    }
-  },
   "stackingOffsetWithLabware": {
     "default": {
       "x": 0,
       "y": 0,
       "z": 8.193
     },
-    "corning_96_wellplate_360ul_flat": {
+    "ibidi_96_square_well_plate_300ul_lid": {
       "x": 0,
       "y": 0,
-      "z": 6.5
+      "z": 1.2
+    },
+    "ibidi_96_square_well_plate_300ul": {
+      "x": 0,
+      "y": 0,
+      "z": 4.75
     },
     "opentrons_flex_deck_riser": {
       "x": 0,
@@ -69,7 +67,7 @@
   },
   "stackLimit": 5,
   "gripForce": 10,
-  "gripHeightFromLabwareBottom": 7,
+  "gripHeightFromLabwareBottom": 5,
   "gripperOffsets": {
     "default": {
       "pickUpOffset": {


### PR DESCRIPTION
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

ibidi Lid Definition and corning plate fixes

## Test Plan and Hands on Testing

Tested with protocol `abr-testing/abr_testing/protocols/test_protocols/labware_def_checker.py`

## Changelog

- Added ibidi lid definition
- corrected offsets in corning lid definition: removed ability to stack on plates other than corning plate to prevent users from using the wrong lid, corrected display name, 
- adding testing capabilities for the lid to the ibidi plate

## Review requests

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment

<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
