### PR TITLE
feat(api): remove positioning warnings

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/transfer_components_executor.py
+++ b/api/src/opentrons/protocol_api/core/engine/transfer_components_executor.py
@@ -194,7 +194,6 @@ class TransferComponentsExecutor:
                     location_type="submerge start",
                     pipetting_action=post_submerge_action,
                 ),
-                logger=log,
             )
         else:
             submerge_start_location = self._target_location
@@ -370,7 +369,6 @@ class TransferComponentsExecutor:
                 location_type="retract end",
                 pipetting_action="aspirate",
             ),
-            logger=log,
         )
         self._instrument.move_to(
             location=retract_location,
@@ -475,7 +473,6 @@ class TransferComponentsExecutor:
                     location_type="retract end",
                     pipetting_action="dispense",
                 ),
-                logger=log,
             )
             self._instrument.move_to(
                 location=retract_location,
@@ -628,7 +625,6 @@ class TransferComponentsExecutor:
                 location_type="retract end",
                 pipetting_action="dispense",
             ),
-            logger=log,
         )
         self._instrument.move_to(
             location=retract_location,

--- a/api/src/opentrons/protocols/advanced_control/transfers/transfer_liquid_utils.py
+++ b/api/src/opentrons/protocols/advanced_control/transfers/transfer_liquid_utils.py
@@ -11,7 +11,6 @@ from opentrons.protocol_engine.state._well_math import (
 from opentrons.types import NozzleMapInterface, NozzleConfigurationType
 
 if TYPE_CHECKING:
-    from logging import Logger
     from opentrons.types import Location
     from opentrons.protocol_api.core.engine import WellCore
     from opentrons.protocol_api.labware import Well, Labware

--- a/api/src/opentrons/protocols/advanced_control/transfers/transfer_liquid_utils.py
+++ b/api/src/opentrons/protocols/advanced_control/transfers/transfer_liquid_utils.py
@@ -28,14 +28,12 @@ def raise_if_location_inside_liquid(
     well_location: Location,
     well_core: WellCore,
     location_check_descriptors: LocationCheckDescriptors,
-    logger: Logger,
 ) -> None:
     """Raise an error if the location in question would be inside the liquid.
 
     This checker will raise an error if:
     - the location in question is below the target well location during aspirate/dispense or,
     - if we can find the liquid height AND the location in question is below this height.
-      If we can't find the liquid height, then we simply log a warning and no error is raised.
     """
     if location.point.z < well_location.point.z:
         raise RuntimeError(
@@ -48,6 +46,9 @@ def raise_if_location_inside_liquid(
         liquid_height_from_bottom = well_core.current_liquid_height()
     except LiquidHeightUnknownError:
         liquid_height_from_bottom = None
+    # Raise an error only when LPD is enabled or when liquids are
+    # loaded in protocols using `load_liquid`.
+    # Do nothing if we can't be sure of the target position with respect to the liquid.
     if isinstance(liquid_height_from_bottom, (int, float)):
         if liquid_height_from_bottom + well_core.get_bottom(0).z > location.point.z:
             raise RuntimeError(
@@ -55,18 +56,6 @@ def raise_if_location_inside_liquid(
                 f" inside the liquid in well {well_core.get_display_name()} when it should be outside"
                 f"(above) the liquid."
             )
-    else:
-        # We could raise an error here but that would restrict the use of
-        # liquid classes-based transfer to only when LPD is enabled or when liquids are
-        # loaded in protocols using `load_liquid`. This can be quite restrictive
-        # so we will not raise but just log a warning.
-        logger.warning(
-            f"Could not verify height of liquid in well {well_core.get_display_name()}, either"
-            f" because the liquid in this well has not been probed or because"
-            f" liquid was not loaded in this well using `load_liquid`."
-            f" Proceeding without verifying if {location_check_descriptors.location_type}"
-            f" location is outside the liquid."
-        )
 
 
 def group_wells_for_multi_channel_transfer(

--- a/api/tests/opentrons/protocol_api/core/engine/test_transfer_components_executor.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_transfer_components_executor.py
@@ -1,6 +1,6 @@
 """Tests for complex commands executor."""
 import pytest
-from decoy import Decoy, matchers
+from decoy import Decoy
 from opentrons_shared_data.liquid_classes.liquid_class_definition import (
     LiquidClassSchemaV1,
     PositionReference,

--- a/api/tests/opentrons/protocol_api/core/engine/test_transfer_components_executor.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_transfer_components_executor.py
@@ -130,7 +130,6 @@ def test_submerge(
                 location_type="submerge start",
                 pipetting_action="aspirate",
             ),
-            logger=matchers.Anything(),
         ),
         mock_instrument_core.move_to(
             location=Location(Point(x=2, y=4, z=7), labware=None),
@@ -201,7 +200,6 @@ def test_submerge_without_starting_air_gap(
                 location_type="submerge start",
                 pipetting_action="aspirate",
             ),
-            logger=matchers.Anything(),
         ),
         mock_instrument_core.move_to(
             location=Location(Point(x=2, y=4, z=7), labware=None),
@@ -312,7 +310,6 @@ def test_submerge_raises_when_submerge_point_is_invalid(
                 location_type="submerge start",
                 pipetting_action="aspirate",
             ),
-            logger=matchers.Anything(),
         )
     ).then_raise(RuntimeError("Oh no!"))
     with pytest.raises(RuntimeError, match="Oh no!"):
@@ -756,7 +753,6 @@ def test_retract_after_aspiration(
                 location_type="retract end",
                 pipetting_action="aspirate",
             ),
-            logger=matchers.Anything(),
         ),
         mock_instrument_core.move_to(
             location=Location(Point(x=4, y=4, z=4), labware=None),
@@ -818,7 +814,6 @@ def test_post_aspirate_retract_raises_when_retract_point_is_invalid(
                 location_type="retract end",
                 pipetting_action="aspirate",
             ),
-            logger=matchers.Anything(),
         )
     ).then_raise(RuntimeError("Oh no!"))
     with pytest.raises(RuntimeError, match="Oh no!"):
@@ -1689,7 +1684,6 @@ def test_retract_after_dispense_raises_for_invalid_retract_point(
                 location_type="retract end",
                 pipetting_action="dispense",
             ),
-            logger=matchers.Anything(),
         )
     ).then_raise(RuntimeError("Oh no!"))
     with pytest.raises(RuntimeError, match="Oh no!"):
@@ -1768,7 +1762,6 @@ def test_multi_dispense_retract_after_dispense_without_conditioning_volume_or_bl
                 location_type="retract end",
                 pipetting_action="dispense",
             ),
-            logger=matchers.Anything(),
         ),
         mock_instrument_core.move_to(
             location=Location(Point(3, 5, 4), labware=None),
@@ -1883,7 +1876,6 @@ def test_multi_dispense_retract_after_dispense_with_blowout_without_conditioning
                 location_type="retract end",
                 pipetting_action="dispense",
             ),
-            logger=matchers.Anything(),
         ),
         mock_instrument_core.move_to(
             location=Location(Point(3, 5, 4), labware=None),
@@ -1972,7 +1964,6 @@ def test_multi_dispense_retract_raises_for_invalid_retract_point(
                 location_type="retract end",
                 pipetting_action="dispense",
             ),
-            logger=matchers.Anything(),
         )
     ).then_raise(RuntimeError("Oh no!"))
     with pytest.raises(RuntimeError, match="Oh no!"):

--- a/api/tests/opentrons/protocols/advanced_control/transfers/test_transfer_liquid_utils.py
+++ b/api/tests/opentrons/protocols/advanced_control/transfers/test_transfer_liquid_utils.py
@@ -9,7 +9,6 @@ from opentrons.hardware_control.nozzle_manager import NozzleMap
 from opentrons.protocol_engine.types.liquid_level_detection import (
     LiquidTrackingType,
 )
-from opentrons.protocol_engine.errors import LiquidHeightUnknownError
 from opentrons.types import Location, Point
 from opentrons.protocol_api.core.engine import WellCore
 from opentrons.protocol_api.labware import Well, Labware
@@ -198,7 +197,6 @@ def test_raise_only_if_pip_location_below_target(
 ) -> None:
     """It should raise appropriately based on heights of given location and target location."""
     well_core = decoy.mock(cls=WellCore)
-    logger = decoy.mock(cls=Logger)
     decoy.when(well_core.current_liquid_height()).then_return(0)
     decoy.when(well_core.get_bottom(0)).then_return(Point(0, 0, 0))
     with expected_raise:

--- a/api/tests/opentrons/protocols/advanced_control/transfers/test_transfer_liquid_utils.py
+++ b/api/tests/opentrons/protocols/advanced_control/transfers/test_transfer_liquid_utils.py
@@ -1,6 +1,5 @@
 """Tests for transfer_liquid_utils."""
 import pytest
-from logging import Logger
 from decoy import Decoy
 from typing import ContextManager, Any
 from contextlib import nullcontext as does_not_raise
@@ -208,7 +207,6 @@ def test_raise_only_if_pip_location_below_target(
             well_location=well_location,
             well_core=well_core,
             location_check_descriptors=location_descriptors,
-            logger=logger,
         )
 
 
@@ -265,8 +263,6 @@ def test_raise_only_if_pip_location_inside_liquid(
         location_type="retract end",
         pipetting_action="aspirate",
     )
-    logger = decoy.mock(cls=Logger)
-
     decoy.when(well_core.current_liquid_height()).then_return(liquid_height)
     decoy.when(well_core.get_bottom(0)).then_return(well_bottom)
     decoy.when(well_core.get_display_name()).then_return("Well A1 of test_labware")
@@ -276,41 +272,7 @@ def test_raise_only_if_pip_location_inside_liquid(
             well_location=well_location,
             well_core=well_core,
             location_check_descriptors=location_descriptors,
-            logger=logger,
         )
-
-
-def test_log_warning_if_pip_location_cannot_be_validated(
-    decoy: Decoy,
-) -> None:
-    """It should log a warning if we don't have access to liquid height."""
-    pip_location = Location(point=Point(1, 2, 3), labware=None)
-    well_location = Location(point=Point(1, 1, 1), labware=None)
-    well_core = decoy.mock(cls=WellCore)
-    location_descriptors = LocationCheckDescriptors(
-        location_type="retract end",
-        pipetting_action="aspirate",
-    )
-    logger = decoy.mock(cls=Logger)
-
-    decoy.when(well_core.current_liquid_height()).then_raise(LiquidHeightUnknownError())
-    decoy.when(well_core.get_bottom(0)).then_return(Point(0, 0, 0))
-    decoy.when(well_core.get_display_name()).then_return("Well A1 of test_labware")
-    raise_if_location_inside_liquid(
-        location=pip_location,
-        well_location=well_location,
-        well_core=well_core,
-        location_check_descriptors=location_descriptors,
-        logger=logger,
-    )
-    decoy.verify(
-        logger.warning(
-            "Could not verify height of liquid in well Well A1 of test_labware, either"
-            " because the liquid in this well has not been probed or because"
-            " liquid was not loaded in this well using `load_liquid`."
-            " Proceeding without verifying if retract end location is outside the liquid."
-        )
-    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes AUTH-1782

# Overview

Consensus from internal users has been that the warnings are too verbose and are not really helpful. So removing them.

AUTH-1978 to follow shortly

## Test Plan and Hands on Testing

Updated unit tests. On-robot testing not needed

## Review requests

- any last minute discoveries that might actually benefit from the warnings?

## Risk assessment
None practically. Only removes warnings.

