### PR TITLE
chore: Exclude venv dirs from flake8

### DIFF
--- a/abr-testing/.flake8
+++ b/abr-testing/.flake8
@@ -1,5 +1,7 @@
 [flake8]
 
+extend-exclude = venv .venv
+
 # set line-length for future black support
 # https://github.com/psf/black/blob/master/docs/compatible_configs.md
 max-line-length = 100

--- a/api/.flake8
+++ b/api/.flake8
@@ -1,5 +1,7 @@
 [flake8]
 
+extend-exclude = venv .venv
+
 # max cyclomatic complexity
 max-complexity = 9
 

--- a/g-code-testing/.flake8
+++ b/g-code-testing/.flake8
@@ -1,5 +1,7 @@
 [flake8]
 
+extend-exclude = venv .venv
+
 # max cyclomatic complexity
 max-complexity = 9
 

--- a/hardware-testing/.flake8
+++ b/hardware-testing/.flake8
@@ -1,5 +1,7 @@
 [flake8]
 
+extend-exclude = venv .venv
+
 # set line-length for future black support
 # https://github.com/psf/black/blob/master/docs/compatible_configs.md
 max-line-length = 100

--- a/hardware/.flake8
+++ b/hardware/.flake8
@@ -1,5 +1,7 @@
 [flake8]
 
+extend-exclude = venv .venv
+
 # max cyclomatic complexity
 max-complexity = 9
 

--- a/performance-metrics/.flake8
+++ b/performance-metrics/.flake8
@@ -1,5 +1,7 @@
 [flake8]
 
+extend-exclude = venv .venv
+
 # max cyclomatic complexity
 max-complexity = 9
 

--- a/robot-server/.flake8
+++ b/robot-server/.flake8
@@ -1,6 +1,9 @@
 [flake8]
 
-extend-exclude = venv .venv
+extend-exclude =
+    venv .venv
+    # Ignore Python Protocol API files that are used as opaque test input.
+    tests/integration/persistence_snapshots/
 
 # max cyclomatic complexity
 max-complexity = 9
@@ -35,6 +38,4 @@ per-file-ignores =
     tests/service/*:ANN,D
     tests/conftest.py:ANN,D
 
-# Ignore Python Protocol API files that are used as opaque test input.
-extend-exclude =
-    tests/integration/persistence_snapshots/
+

--- a/robot-server/.flake8
+++ b/robot-server/.flake8
@@ -1,5 +1,7 @@
 [flake8]
 
+extend-exclude = venv .venv
+
 # max cyclomatic complexity
 max-complexity = 9
 

--- a/server-utils/.flake8
+++ b/server-utils/.flake8
@@ -1,5 +1,7 @@
 [flake8]
 
+extend-exclude = venv .venv
+
 # max cyclomatic complexity
 max-complexity = 9
 

--- a/shared-data/.flake8
+++ b/shared-data/.flake8
@@ -1,5 +1,7 @@
 [flake8]
 
+extend-exclude = venv .venv
+
 # max cyclomatic complexity
 max-complexity = 9
 

--- a/system-server/.flake8
+++ b/system-server/.flake8
@@ -1,5 +1,7 @@
 [flake8]
 
+extend-exclude = venv .venv
+
 # max cyclomatic complexity
 max-complexity = 9
 

--- a/test-data-generation/.flake8
+++ b/test-data-generation/.flake8
@@ -1,5 +1,7 @@
 [flake8]
 
+extend-exclude = venv .venv
+
 # max cyclomatic complexity
 max-complexity = 9
 

--- a/update-server/.flake8
+++ b/update-server/.flake8
@@ -1,5 +1,7 @@
 [flake8]
 
+extend-exclude = venv .venv
+
 # max cyclomatic complexity
 max-complexity = 9
 

--- a/usb-bridge/.flake8
+++ b/usb-bridge/.flake8
@@ -1,5 +1,7 @@
 [flake8]
 
+extend-exclude = venv .venv
+
 # max cyclomatic complexity
 max-complexity = 9
 


### PR DESCRIPTION
## Overview

Pipenv creates Python virtual environments for us. [Depending on how you have it configured](https://pipenv.pypa.io/en/latest/virtualenv.html#project-local-virtual-environments), it either places those somewhere out-of-tree (the default), or in-tree like `robot-server/.venv`.

(I think in-tree is better because it's easy for editors to auto-discover, it can't get orphaned, and it behaves sanely if you `rm -rf opentrons` and do a fresh `git clone`.)

Separately, some of our Python projects run `flake8 .`. If you happen to have a `.venv` in-tree, Flake8 will erroneously descend into it and try to lint all of our dependencies' source code, which takes a long time and then prints a zillion errors.

This fixes it by excluding `.venv` from `flake8 .`. I think Flake8 ought to do this by default, [but, well](https://github.com/PyCQA/flake8/pull/1839).

## Test Plan and Hands on Testing

* [x] It works locally.

## Review requests

None.

## Risk assessment

No risk.
