### PR TITLE
fix(protocol-designer): fix logic for mapping dispense air gap

### DIFF
--- a/protocol-designer/src/steplist/formLevel/handleFormChange/utils.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/utils.ts
@@ -417,8 +417,8 @@ const getSubmergeRetractFields = (args: {
     liquidHandlingAction,
     tipMovement,
     additionalEquipmentEntities,
-    isDisposalVolumeEnabled = true,
-    isConditioningVolumeEnabled = true,
+    isDisposalVolumeEnabled = false,
+    isConditioningVolumeEnabled = false,
   } = args
 
   // all common submerge and retract fields
@@ -438,7 +438,8 @@ const getSubmergeRetractFields = (args: {
 
   // retract fields
   const airGapFields =
-    'airGapByVolume' in submergeRetractLookup && !isConditioningVolumeEnabled
+    'airGapByVolume' in submergeRetractLookup &&
+    !(liquidHandlingAction === 'aspirate' && isConditioningVolumeEnabled)
       ? getByVolumeField({
           volume: volumes.airGap,
           byVolume: submergeRetractLookup.airGapByVolume,
@@ -789,8 +790,10 @@ const getLiquidClassValuesMoveLiquid = (args: {
         })
       : {}
 
-  const isConditioningVolumeEnabled = conditioningFields.conditioning_volume > 0
-  const isDisposalVolumeEnabled = disposalFields.disposalVolume_volume > 0
+  const isConditioningVolumeEnabled =
+    conditioningFields.conditioning_volume > 0 && path === 'multiDispense'
+  const isDisposalVolumeEnabled =
+    disposalFields.disposalVolume_volume > 0 && path === 'multiDispense'
 
   // aspirate/dispense submerge fields
   const aspirateSubmergeFields = getSubmergeRetractFields({


### PR DESCRIPTION
# Overview

Fixes a bug in `getLiquidClassValuesMoveLiquid` where air gap for dispense retract from the liquid class definition was bypassed and not correctly mapped to its corresponding form fields. We should only disable air gap for multiDispense aspirate retract where conditioning volume is enabled

## Test Plan and Hands on Testing

- create a new transfer step for a p50 pipette with 50µl tips, transfer volume < 50µl
- select 'volatile' liquid class
- navigate to advanced dispense settings, scroll down, and verify that air gap is expanded and populated with the interpolated value

## Changelog

- ensure dispenses correctly retrieve get air gap and populate in dispense air gap fields in `getLiquidClassValuesMoveLiquid`

## Review requests

- see test plan

## Risk assessment

low