### PR TITLE
refactor(shared-data): update labwareInterface dimensions for select modules

### DIFF
--- a/shared-data/js/types.ts
+++ b/shared-data/js/types.ts
@@ -528,10 +528,10 @@ export interface ModuleDimensions {
   overLabwareHeight: number
   xDimension: number
   yDimension: number
+  labwareInterfaceXDimension: number
+  labwareInterfaceYDimension: number
   footprintXDimension?: number
   footprintYDimension?: number
-  labwareInterfaceXDimension?: number
-  labwareInterfaceYDimension?: number
   lidHeight?: number
 }
 

--- a/shared-data/js/types.ts
+++ b/shared-data/js/types.ts
@@ -528,10 +528,10 @@ export interface ModuleDimensions {
   overLabwareHeight: number
   xDimension: number
   yDimension: number
-  labwareInterfaceXDimension: number
-  labwareInterfaceYDimension: number
   footprintXDimension?: number
   footprintYDimension?: number
+  labwareInterfaceXDimension?: number
+  labwareInterfaceYDimension?: number
   lidHeight?: number
 }
 

--- a/shared-data/module/definitions/3/absorbanceReaderV1.json
+++ b/shared-data/module/definitions/3/absorbanceReaderV1.json
@@ -13,8 +13,8 @@
     "lidHeight": 60.0,
     "xDimension": 155.3,
     "yDimension": 95.5,
-    "labwareInterfaceXDimension": 127.8,
-    "labwareInterfaceYDimension": 85.5
+    "labwareInterfaceXDimension": 127.76,
+    "labwareInterfaceYDimension": 85.48
   },
   "cornerOffsetFromSlot": {
     "x": -4.875,

--- a/shared-data/module/definitions/3/magneticBlockV1.json
+++ b/shared-data/module/definitions/3/magneticBlockV1.json
@@ -14,8 +14,8 @@
     "yDimension": 94,
     "footprintXDimension": 127.75,
     "footprintYDimension": 85.75,
-    "labwareInterfaceXDimension": 128,
-    "labwareInterfaceYDimension": 86
+    "labwareInterfaceXDimension": 127.75,
+    "labwareInterfaceYDimension": 85.75
   },
   "cornerOffsetFromSlot": {
     "x": -4.125,

--- a/shared-data/module/definitions/3/thermocyclerModuleV2.json
+++ b/shared-data/module/definitions/3/thermocyclerModuleV2.json
@@ -13,8 +13,8 @@
     "lidHeight": 61.7,
     "xDimension": 172,
     "yDimension": 245.2,
-    "labwareInterfaceXDimension": 128,
-    "labwareInterfaceYDimension": 86
+    "labwareInterfaceXDimension": 127.76,
+    "labwareInterfaceYDimension": 85.48
   },
   "cornerOffsetFromSlot": {
     "x": -22.125,

--- a/shared-data/module/schemas/3.json
+++ b/shared-data/module/schemas/3.json
@@ -109,11 +109,11 @@
         "yDimension": { "type": "number" },
         "footprintXDimension": {
           "type": "number",
-          "description": "The x dimension of the module's top-most plane."
+          "description": "The x dimension of the module's bottom-most plane."
         },
         "footprintYDimension": {
           "type": "number",
-          "description": "The y dimension of the module's top-most plane."
+          "description": "The y dimension of the module's bottom-most plane."
         },
         "labwareInterfaceXDimension": {
           "type": "number",

--- a/shared-data/module/schemas/3.json
+++ b/shared-data/module/schemas/3.json
@@ -107,10 +107,22 @@
         "lidHeight": { "type": "number" },
         "xDimension": { "type": "number" },
         "yDimension": { "type": "number" },
-        "footprintXDimension": { "type": "number" },
-        "footprintYDimension": { "type": "number" },
-        "labwareInterfaceXDimension": { "type": "number" },
-        "labwareInterfaceYDimension": { "type": "number" },
+        "footprintXDimension": {
+          "type": "number",
+          "description": "The x dimension of the module's top-most plane."
+        },
+        "footprintYDimension": {
+          "type": "number",
+          "description": "The y dimension of the module's top-most plane."
+        },
+        "labwareInterfaceXDimension": {
+          "type": "number",
+          "description": "The x dimension of the module's interaction plane (where labware is placed)."
+        },
+        "labwareInterfaceYDimension": {
+          "type": "number",
+          "description": "The y dimension of the module's interaction plane (where labware is placed)."
+        },
         "maxStackerFillHeight": { "type": "number" },
         "maxStackerRetrievableHeight": { "type": "number" }
       }


### PR DESCRIPTION
Works towards [EXEC-77](https://opentrons.atlassian.net/browse/EXEC-77)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Module definitions contain a `dimensions` key which includes `labwareInterfaceXDimension` and `labwareInterfaceYDimension`, which based on their usages (which are app only rendering concerns, currently), seem to indicate the dimensions of the module's interaction plane. 

Because locating features will make use of these dimensions (and therefore the api layer), we want to ensure they are as accurate as possible since they will impact real positioning. Consulting hardware diagrams, for many modules, these dimensions are exactly standard deck slot dimensions, but that isn't true for all of them, so let's update those.

There's a separate undocumented property, `footprintX/YDimension` that I've added some documentation to based on it's usage (it's only used in PD for some render transformations).
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- Effectively no risk, but I did run the app and look at some deck maps with modules.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Updated `labwareInterfaceX/YDimension` for certain modules.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
effectively none. These changes offset some of the app rendered modules by like 1 pixel at the very most, and probably not even that. 
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[EXEC-77]: https://opentrons.atlassian.net/browse/EXEC-77?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ