### PR TITLE
fix(app): only call `identifyModule` on flex stacker

### DIFF
--- a/app/src/organisms/ModuleWizardFlows/SelectModule.tsx
+++ b/app/src/organisms/ModuleWizardFlows/SelectModule.tsx
@@ -23,7 +23,7 @@ import {
   SimpleWizardBodyContainer,
 } from '/app/molecules/SimpleWizardBody'
 
-import { useSendIdentifyModule } from './hooks'
+import { useSendIdentifyStacker } from './hooks'
 
 import type { AttachedModule } from '@opentrons/api-client'
 
@@ -59,7 +59,7 @@ export function SelectModule(props: SelectModuleProps): JSX.Element {
       : availableModules
 
   const isSingleModule = newModules.length === 1
-  const sendIdentifyModule = useSendIdentifyModule()
+  const sendIdentifyStacker = useSendIdentifyStacker()
   const [stackerNotInstalled, setStackerNotInstalled] = useState(false)
 
   const getModuleNameAndPort = (module: AttachedModule): ModuleNameAndPort => {
@@ -76,7 +76,7 @@ export function SelectModule(props: SelectModuleProps): JSX.Element {
   useEffect(() => {
     if (isSingleModule) {
       setSelectedModule(newModules[0])
-      sendIdentifyModule(newModules[0], true)
+      sendIdentifyStacker(newModules[0], true)
     }
   }, [isSingleModule])
 
@@ -84,12 +84,12 @@ export function SelectModule(props: SelectModuleProps): JSX.Element {
   const handleModuleSelected = (serialNumber: string): void => {
     // stop blinking previous module
     if (selectedModule != null) {
-      sendIdentifyModule(selectedModule, false)
+      sendIdentifyStacker(selectedModule, false)
     }
     // blink new module
     for (const mod of newModules) {
       if (mod.serialNumber === serialNumber) {
-        sendIdentifyModule(mod, true)
+        sendIdentifyStacker(mod, true)
         setSelectedModule(mod)
         break
       }
@@ -103,7 +103,7 @@ export function SelectModule(props: SelectModuleProps): JSX.Element {
         module.moduleType === 'flexStackerModuleType' &&
         !module.data.installDetected
       ) {
-        sendIdentifyModule(module, true, 'red')
+        sendIdentifyStacker(module, true, 'red')
         setStackerNotInstalled(true)
         return
       }
@@ -116,7 +116,7 @@ export function SelectModule(props: SelectModuleProps): JSX.Element {
   const handleTryAgain = (): void => {
     if (selectedModule != null) {
       // Start blinking module, otherwise stop if multiple are available.
-      sendIdentifyModule(selectedModule, isSingleModule)
+      sendIdentifyStacker(selectedModule, isSingleModule)
       // Clear the selected module
       if (!isSingleModule) {
         setSelectedModule(null)

--- a/app/src/organisms/ModuleWizardFlows/Success.tsx
+++ b/app/src/organisms/ModuleWizardFlows/Success.tsx
@@ -18,7 +18,7 @@ import { useGetNewModules } from '/app/App/hooks'
 import { SmallButton } from '/app/atoms/buttons'
 import { SimpleWizardBody } from '/app/molecules/SimpleWizardBody'
 
-import { useSendIdentifyModule } from './hooks'
+import { useSendIdentifyStacker } from './hooks'
 
 import type { AttachedModule } from '@opentrons/api-client'
 import type { ModuleSetupWizardStepProps } from './types'
@@ -48,14 +48,14 @@ export function Success(props: SuccessProps): JSX.Element {
     setSelectedModule,
   } = props
   const { t } = useTranslation('module_wizard_flows')
-  const sendIdentifyModule = useSendIdentifyModule()
+  const sendIdentifyStacker = useSendIdentifyStacker()
   const moduleDisplayName = getModuleDisplayName(attachedModule.moduleModel)
   const newModules = useGetNewModules()
 
   const handleOnClick = (restart: boolean): void => {
     if (restart) {
       setSelectedModule(null)
-      sendIdentifyModule(attachedModule, false)
+      sendIdentifyStacker(attachedModule, false)
       restartSetup()
       return
     }

--- a/app/src/organisms/ModuleWizardFlows/UpdateFirmware.tsx
+++ b/app/src/organisms/ModuleWizardFlows/UpdateFirmware.tsx
@@ -20,7 +20,7 @@ import {
   SUCCESS,
 } from '/app/redux/robot-api'
 
-import { useSendIdentifyModule } from './hooks'
+import { useSendIdentifyStacker } from './hooks'
 
 import type { AttachedModule } from '@opentrons/api-client'
 import type { Dispatch, State } from '/app/redux/types'
@@ -47,7 +47,7 @@ export function UpdateFirmware(props: UpdateFirmwareProps): JSX.Element {
   const { t } = useTranslation('module_wizard_flows')
 
   const dispatch = useDispatch<Dispatch>()
-  const sendIdentifyModule = useSendIdentifyModule()
+  const sendIdentifyStacker = useSendIdentifyStacker()
   const [getLatestRequestId, handleModuleApiRequests] = useModuleApiRequests()
   const moduleSerialNumber = props.attachedModule.serialNumber
   const [
@@ -78,7 +78,7 @@ export function UpdateFirmware(props: UpdateFirmwareProps): JSX.Element {
         clearTimeout(moduleRequestTimeoutId)
       }
       setIsModuleUpdating(false)
-      sendIdentifyModule(matchingModule, true, 'blue')
+      sendIdentifyStacker(matchingModule, true, 'blue')
       patchModuleAfterUpdate(matchingModule)
       proceed()
     }

--- a/app/src/organisms/ModuleWizardFlows/__tests__/UpdateFirmware.test.tsx
+++ b/app/src/organisms/ModuleWizardFlows/__tests__/UpdateFirmware.test.tsx
@@ -18,7 +18,7 @@ import {
   useDispatchApiRequest,
 } from '/app/redux/robot-api'
 
-import { useSendIdentifyModule } from '../hooks'
+import { useSendIdentifyStacker } from '../hooks'
 import { UpdateFirmware } from '../UpdateFirmware'
 
 import type { ComponentProps } from 'react'
@@ -45,7 +45,7 @@ const render = (props: ComponentProps<typeof UpdateFirmware>) => {
 describe('UpdateFirmware', () => {
   let dispatchApiRequest: DispatchApiRequestType
   let handleModuleApiRequests: (robotName: string, serial: string) => void
-  let sendIdentifyModule: (
+  let sendIdentifyStacker: (
     module: AttachedModule,
     start: boolean,
     color?: IdentifyColor
@@ -55,7 +55,7 @@ describe('UpdateFirmware', () => {
     vi.useFakeTimers()
     dispatchApiRequest = vi.fn()
     handleModuleApiRequests = vi.fn()
-    sendIdentifyModule = vi.fn()
+    sendIdentifyStacker = vi.fn()
     props = {
       proceed: vi.fn(),
       goBack: vi.fn(),
@@ -84,7 +84,7 @@ describe('UpdateFirmware', () => {
       dispatchApiRequest,
       [LAST_ID],
     ])
-    vi.mocked(useSendIdentifyModule).mockReturnValue(sendIdentifyModule)
+    vi.mocked(useSendIdentifyStacker).mockReturnValue(sendIdentifyStacker)
   })
 
   afterEach(() => {

--- a/app/src/organisms/ModuleWizardFlows/hooks.tsx
+++ b/app/src/organisms/ModuleWizardFlows/hooks.tsx
@@ -20,19 +20,23 @@ export function useSendIdentifyModule(): sendIdentifyModuleType {
       start: boolean,
       color: IdentifyColor | null = null
     ) => {
-      createLiveCommand({
-        command: {
-          commandType: 'identifyModule',
-          params: {
-            model: module.moduleModel,
-            moduleId: module.id,
-            start,
-            ...(color != null ? { color } : {}),
+      // Only send identify command for flex stacker modules,
+      // other module types are not currently supported
+      if (module.moduleType === 'flexStackerModuleType') {
+        createLiveCommand({
+          command: {
+            commandType: 'identifyModule',
+            params: {
+              model: module.moduleModel,
+              moduleId: module.id,
+              start,
+              ...(color != null ? { color } : {}),
+            },
           },
-        },
-      }).catch(error => {
-        console.log(error.message)
-      })
+        }).catch(error => {
+          console.log(error.message)
+        })
+      }
     },
     [createLiveCommand]
   )

--- a/app/src/organisms/ModuleWizardFlows/hooks.tsx
+++ b/app/src/organisms/ModuleWizardFlows/hooks.tsx
@@ -11,10 +11,10 @@ type sendIdentifyModuleType = (
   color?: IdentifyColor
 ) => void
 
-export function useSendIdentifyModule(): sendIdentifyModuleType {
+export function useSendIdentifyStacker(): sendIdentifyModuleType {
   const { createLiveCommand } = useCreateLiveCommandMutation()
 
-  const sendIdentifyModule = useCallback(
+  const sendIdentifyStacker = useCallback(
     (
       module: AttachedModule,
       start: boolean,
@@ -36,9 +36,13 @@ export function useSendIdentifyModule(): sendIdentifyModuleType {
         }).catch(error => {
           console.log(error.message)
         })
+      } else {
+        console.warn(
+          `Module type ${module.moduleType} does not support identify command`
+        )
       }
     },
     [createLiveCommand]
   )
-  return sendIdentifyModule
+  return sendIdentifyStacker
 }

--- a/app/src/organisms/ModuleWizardFlows/index.tsx
+++ b/app/src/organisms/ModuleWizardFlows/index.tsx
@@ -16,7 +16,7 @@ import { BeforeBeginning } from './BeforeBeginning'
 import { CloseDoor } from './CloseStackerDoor'
 import { SECTIONS } from './constants'
 import { DetachProbe } from './DetachProbe'
-import { useSendIdentifyModule } from './hooks'
+import { useSendIdentifyStacker } from './hooks'
 import { InstallShuttle } from './InstallShuttle'
 import { ModuleWizardScreen } from './ModuleWizardScreen'
 import { PlaceAdapter } from './PlaceAdapter'
@@ -70,7 +70,7 @@ export function ModuleWizardFlows(
     }
   }, [])
 
-  const sendIdentifyModule = useSendIdentifyModule()
+  const sendIdentifyStacker = useSendIdentifyStacker()
   const [selectedModule, setSelectedModule] = useState<AttachedModule | null>(
     null
   )
@@ -93,7 +93,7 @@ export function ModuleWizardFlows(
         isModuleUpdating={wizardFlowBaseProps.isModuleUpdating}
         handleCleanUpAndClose={() => {
           if (selectedModule != null) {
-            sendIdentifyModule(selectedModule, false)
+            sendIdentifyStacker(selectedModule, false)
           }
           handleCleanUpAndClose()
         }}

--- a/app/src/organisms/ModuleWizardFlows/useModuleSetupWizard.ts
+++ b/app/src/organisms/ModuleWizardFlows/useModuleSetupWizard.ts
@@ -17,7 +17,7 @@ import {
 } from '/app/resources/runs'
 
 import { ACTIONS } from './constants'
-import { useSendIdentifyModule } from './hooks'
+import { useSendIdentifyStacker } from './hooks'
 import { moduleSetupWizardReducer } from './moduleSetupWizardReducer'
 
 import type { SetStateAction } from 'react'
@@ -71,7 +71,7 @@ export function useModuleSetupWizard(
 ): UseModuleSetupWizardResult {
   const { closeFlow, attachedModuleOnLaunch, onComplete } = params
   const isOnDevice = useSelector(getIsOnDevice)
-  const sendIdentifyModule = useSendIdentifyModule()
+  const sendIdentifyStacker = useSendIdentifyStacker()
   const [state, dispatch] = useReducer(moduleSetupWizardReducer, {
     currentStepIndex: 0,
     currentStep: null,
@@ -150,7 +150,7 @@ export function useModuleSetupWizard(
 
   const handleCleanUpAndClose = (): void => {
     setIsExiting(true)
-    if (attachedModule != null) sendIdentifyModule(attachedModule, false)
+    if (attachedModule != null) sendIdentifyStacker(attachedModule, false)
     if (maintenanceRunId == null) handleClose()
     else {
       chainRunCommands(


### PR DESCRIPTION
This PR updates the `useSendIdentifyModule` hook to ensure that the `identifyModule` command is sent only for flex stacker modules. Calling `identifyModule` on unsupported modules (any non-stacker modules, for now) raises an error causes module setup flow to fail. 

Fixes RQA-4261