### PR TITLE
fix(app): ensure 'blowout' and 'blowoutInPlace' commands with overpressure errors are handled in ER

### DIFF
--- a/app/src/organisms/ErrorRecoveryFlows/utils/__tests__/getErrorKind.test.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/utils/__tests__/getErrorKind.test.ts
@@ -33,6 +33,16 @@ describe('getErrorKind', () => {
       expectedError: ERROR_KINDS.OVERPRESSURE_WHILE_DISPENSING,
     },
     {
+      commandType: 'blowout',
+      errorType: DEFINED_ERROR_TYPES.OVERPRESSURE,
+      expectedError: ERROR_KINDS.OVERPRESSURE_WHILE_DISPENSING,
+    },
+    {
+      commandType: 'blowOutInPlace',
+      errorType: DEFINED_ERROR_TYPES.OVERPRESSURE,
+      expectedError: ERROR_KINDS.OVERPRESSURE_WHILE_DISPENSING,
+    },
+    {
       commandType: 'dropTip',
       errorType: DEFINED_ERROR_TYPES.TIP_PHYSICALLY_ATTACHED,
       expectedError: ERROR_KINDS.TIP_DROP_FAILED,

--- a/app/src/organisms/ErrorRecoveryFlows/utils/getErrorKind.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/utils/getErrorKind.ts
@@ -1,7 +1,6 @@
-import { ERROR_KINDS, DEFINED_ERROR_TYPES } from '../constants'
-
-import type { ErrorKind } from '../types'
 import type { FailedCommandBySource } from '/app/organisms/ErrorRecoveryFlows/hooks'
+import { DEFINED_ERROR_TYPES, ERROR_KINDS } from '../constants'
+import type { ErrorKind } from '../types'
 
 /**
  * Given server-side information about a failed command,
@@ -19,45 +18,45 @@ export function getErrorKind(
   const errorType = failedCommandByRunRecord?.error?.errorType
 
   if (Boolean(errorIsDefined)) {
-    if (
-      commandType === 'prepareToAspirate' &&
-      errorType === DEFINED_ERROR_TYPES.OVERPRESSURE
-    ) {
-      return ERROR_KINDS.OVERPRESSURE_PREPARE_TO_ASPIRATE
-    } else if (
-      (commandType === 'aspirate' || commandType === 'aspirateInPlace') &&
-      errorType === DEFINED_ERROR_TYPES.OVERPRESSURE
-    ) {
-      return ERROR_KINDS.OVERPRESSURE_WHILE_ASPIRATING
-    } else if (
-      (commandType === 'dispense' || commandType === 'dispenseInPlace') &&
-      errorType === DEFINED_ERROR_TYPES.OVERPRESSURE
-    ) {
-      return ERROR_KINDS.OVERPRESSURE_WHILE_DISPENSING
-    } else if (
-      commandType === 'liquidProbe' &&
-      errorType === DEFINED_ERROR_TYPES.LIQUID_NOT_FOUND
-    ) {
-      return ERROR_KINDS.NO_LIQUID_DETECTED
-    } else if (
-      commandType === 'pickUpTip' &&
-      errorType === DEFINED_ERROR_TYPES.TIP_PHYSICALLY_MISSING
-    ) {
-      return ERROR_KINDS.TIP_NOT_DETECTED
-    } else if (
-      (commandType === 'dropTip' || commandType === 'dropTipInPlace') &&
-      errorType === DEFINED_ERROR_TYPES.TIP_PHYSICALLY_ATTACHED
-    ) {
-      return ERROR_KINDS.TIP_DROP_FAILED
-    } else if (
-      commandType === 'moveLabware' &&
-      errorType === DEFINED_ERROR_TYPES.GRIPPER_MOVEMENT
-    ) {
-      return ERROR_KINDS.GRIPPER_ERROR
-    } else if (errorType === DEFINED_ERROR_TYPES.STALL_OR_COLLISION) {
-      return ERROR_KINDS.STALL_OR_COLLISION
+    switch (errorType) {
+      case DEFINED_ERROR_TYPES.OVERPRESSURE:
+        // The recovery flow varies dependent on the exact failed command.
+        switch (commandType) {
+          case 'prepareToAspirate':
+            return ERROR_KINDS.OVERPRESSURE_PREPARE_TO_ASPIRATE
+          case 'aspirate':
+          case 'aspirateInPlace': {
+            return ERROR_KINDS.OVERPRESSURE_WHILE_ASPIRATING
+          }
+          case 'dispense':
+          case 'dispenseInPlace':
+          case 'blowout':
+          case 'blowOutInPlace':
+            return ERROR_KINDS.OVERPRESSURE_WHILE_DISPENSING
+          default: {
+            console.error(`Unhandled overpressure command ${commandType}`)
+            return ERROR_KINDS.GENERAL_ERROR
+          }
+        }
+      case DEFINED_ERROR_TYPES.LIQUID_NOT_FOUND:
+        return ERROR_KINDS.NO_LIQUID_DETECTED
+      case DEFINED_ERROR_TYPES.TIP_PHYSICALLY_MISSING:
+        return ERROR_KINDS.TIP_NOT_DETECTED
+      case DEFINED_ERROR_TYPES.TIP_PHYSICALLY_ATTACHED:
+        return ERROR_KINDS.TIP_DROP_FAILED
+      case DEFINED_ERROR_TYPES.GRIPPER_MOVEMENT:
+        return ERROR_KINDS.GRIPPER_ERROR
+      case DEFINED_ERROR_TYPES.STALL_OR_COLLISION:
+        return ERROR_KINDS.STALL_OR_COLLISION
+      default: {
+        console.error(`Unhandled error type ${errorType}`)
+        return ERROR_KINDS.GENERAL_ERROR
+      }
     }
+  } else {
+    console.warn(
+      `Run status is "awaiting for recovery", but error is not defined: ${failedCommandByRunRecord}`
+    )
+    return ERROR_KINDS.GENERAL_ERROR
   }
-
-  return ERROR_KINDS.GENERAL_ERROR
 }


### PR DESCRIPTION
Closes [RABR-775](https://opentrons.atlassian.net/browse/RABR-775)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

In ER, we gate the recovery flow by the `errorKind`, which is contingent upon whether the error is defined, the error type, and the command type. For overpressure errors, we care about the command type, because this determines exactly which recovery flow to show, and they all share the same overpressure error type.

However, for error types that are not "overpressure", there is only ever one possible recovery flow to show, and we therefore don't need to gate by command type. Not gating by command type means that every time a new command is added with a specific error type, the app doesn't need to be updated to handle it, which is great.

This PR addresses a bug in which `blowout` and `blowoutInPlace` were not routing to the "overpressure while dispensing" recovery flow, cleaning up the `commandType` logic for the reasons mentioned above. 

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- Entirely covered by testing.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Failed Blowout and blowoutInPlace commands yield the correct "overpressure while dispensing" recovery flow.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
basically none - we're covered by existing and new testing here.
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RABR-775]: https://opentrons.atlassian.net/browse/RABR-775?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ