### PR TITLE
feat(step-generation, shared-data): use correct flow rates for air gaps and mixes

### DIFF
--- a/shared-data/js/helpers/__tests__/liquidClasses.test.ts
+++ b/shared-data/js/helpers/__tests__/liquidClasses.test.ts
@@ -5,7 +5,7 @@ import {
   getFlexNameConversion,
   linearInterpolate,
 } from '../..'
-import { getCorrectionVolume } from '../liquidClasses'
+import { getByVolumeValue } from '../liquidClasses'
 
 vi.mock('../..')
 
@@ -73,7 +73,7 @@ const MOCK_LIQUID_CLASS_DEFS = {
   },
 } as any
 
-describe('getCorrectionVolume', () => {
+describe('getByVolumeValue', () => {
   let args: any
   beforeEach(() => {
     vi.mocked(getAllLiquidClassDefs).mockReturnValue(MOCK_LIQUID_CLASS_DEFS)
@@ -84,6 +84,8 @@ describe('getCorrectionVolume', () => {
       tiprackDefUri: MOCK_TIPRACK_DEF_URI,
       targetVolume: 40,
       liquidHandlingAction: 'aspirate',
+      byVolumeProperty: 'correctionByVolume',
+      defaultValue: 0,
     }
   })
   describe('calling liquid class with defined multiDispense object', () => {
@@ -91,7 +93,7 @@ describe('getCorrectionVolume', () => {
       args = { ...args, liquidClass: 'waterV1' }
     })
     it('calls interpolation with correct values for water > aspirate', () => {
-      getCorrectionVolume({
+      getByVolumeValue({
         ...args,
         liquidHandlingAction: 'aspirate',
       })
@@ -101,7 +103,7 @@ describe('getCorrectionVolume', () => {
       ])
     })
     it('calls interpolation with water values for water > singleDispense', () => {
-      getCorrectionVolume({
+      getByVolumeValue({
         ...args,
         liquidHandlingAction: 'singleDispense',
       })
@@ -111,7 +113,7 @@ describe('getCorrectionVolume', () => {
       ])
     })
     it('calls interpolation with water values for water > multiDispense', () => {
-      getCorrectionVolume({
+      getByVolumeValue({
         ...args,
         liquidHandlingAction: 'multiDispense',
       })
@@ -127,12 +129,12 @@ describe('getCorrectionVolume', () => {
     })
     it('returns 0 for water values for unknown pipette', () => {
       vi.mocked(getFlexNameConversion).mockReturnValue(MOCK_UNKNOWN_PIPETTE_ID)
-      const result = getCorrectionVolume(args)
+      const result = getByVolumeValue(args)
       expect(result).toEqual(0)
     })
     it('returns 0 for water values for unknown tiprack', () => {
       vi.mocked(getFlexNameConversion).mockReturnValue(MOCK_PIPETTE_ID)
-      const result = getCorrectionVolume({
+      const result = getByVolumeValue({
         ...args,
         tiprackDefUri: MOCK_UNKNOWN_TIPRACK_DEF_URI,
       })
@@ -140,11 +142,11 @@ describe('getCorrectionVolume', () => {
     })
   })
   it('returns 0 if no liquid class passed', () => {
-    const result = getCorrectionVolume(args)
+    const result = getByVolumeValue(args)
     expect(result).toEqual(0)
   })
   it('calls interpolation with water values for unknown liquid class', () => {
-    getCorrectionVolume({
+    getByVolumeValue({
       ...args,
       liquidClass: MOCK_UNKNOWN_LIQUID_CLASS,
       liquidHandlingAction: 'aspirate',
@@ -155,7 +157,7 @@ describe('getCorrectionVolume', () => {
     ])
   })
   it('calls interpolation for singleDispense if multiDispense values not found', () => {
-    getCorrectionVolume({
+    getByVolumeValue({
       ...args,
       liquidClass: 'ethanol70',
       liquidHandlingAction: 'multiDispense',

--- a/shared-data/js/helpers/liquidClasses.ts
+++ b/shared-data/js/helpers/liquidClasses.ts
@@ -6,37 +6,40 @@ import {
 
 import type { PipetteV2Specs } from '..'
 
-export const getCorrectionVolume = (args: {
+export const getByVolumeValue = (args: {
   liquidClass: string | null
   pipetteSpecs: PipetteV2Specs
   tiprackDefUri: string
   targetVolume: number
   liquidHandlingAction: 'aspirate' | 'singleDispense' | 'multiDispense'
-}): number => {
+  byVolumeProperty: 'correctionByVolume' | 'flowRateByVolume'
+  defaultValue?: number | null
+}): number | null => {
   const {
     liquidClass,
     pipetteSpecs,
     tiprackDefUri,
     targetVolume,
     liquidHandlingAction,
+    byVolumeProperty,
+    defaultValue = null,
   } = args
+
   const allLiquidClassDefs = getAllLiquidClassDefs()
 
   if (liquidClass == null) {
-    return 0
+    return defaultValue
   }
   const convertedPipetteName = getFlexNameConversion(pipetteSpecs)
   const liquidClassDef =
     allLiquidClassDefs[liquidClass] ?? allLiquidClassDefs.waterV1
-  const liquidClassValuesForPipette = liquidClassDef.byPipette.find(
-    ({ pipetteModel }) => convertedPipetteName === pipetteModel
-  )
-  const liquidClassValuesForTip = liquidClassValuesForPipette?.byTipType.find(
-    ({ tiprack }) => tiprack === tiprackDefUri
-  )
+  const liquidClassValuesForTip = liquidClassDef.byPipette
+    .find(({ pipetteModel }) => convertedPipetteName === pipetteModel)
+    ?.byTipType.find(({ tiprack }) => tiprack === tiprackDefUri)
   if (liquidClassValuesForTip == null) {
-    return 0
+    return defaultValue
   }
+
   const liquidHandlingObject =
     liquidHandlingAction === 'multiDispense' &&
     !('multiDispense' in liquidClassValuesForTip)
@@ -44,13 +47,11 @@ export const getCorrectionVolume = (args: {
       : liquidClassValuesForTip[liquidHandlingAction]
 
   if (liquidHandlingObject == null) {
-    return 0
+    return defaultValue
   }
-  const { correctionByVolume } = liquidHandlingObject
+  const byVolume = liquidHandlingObject[byVolumeProperty]
   return (
-    linearInterpolate(
-      targetVolume,
-      correctionByVolume as Array<[number, number]>
-    ) ?? 0
+    linearInterpolate(targetVolume, byVolume as Array<[number, number]>) ??
+    defaultValue
   )
 }

--- a/step-generation/src/commandCreators/compound/consolidate.ts
+++ b/step-generation/src/commandCreators/compound/consolidate.ts
@@ -4,7 +4,7 @@ import flatMap from 'lodash/flatMap'
 import {
   ALL,
   getAllLiquidClassDefs,
-  getCorrectionVolume,
+  getByVolumeValue,
   getFlexNameConversion,
   getMmFromBottom,
   GRIPPER_WASTE_CHUTE_ADDRESSABLE_AREA,
@@ -334,13 +334,16 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
           }),
         ]
       : []
-  const aspirateCorrectionVolumeForDispenseAirGap = getCorrectionVolume({
-    liquidClass,
-    pipetteSpecs,
-    tiprackDefUri: tipRack,
-    targetVolume: dispenseAirGapVolume,
-    liquidHandlingAction: 'aspirate',
-  })
+  const aspirateCorrectionVolumeForDispenseAirGap =
+    getByVolumeValue({
+      liquidClass,
+      pipetteSpecs,
+      tiprackDefUri: tipRack,
+      targetVolume: dispenseAirGapVolume,
+      liquidHandlingAction: 'aspirate',
+      byVolumeProperty: 'correctionByVolume',
+      defaultValue: 0,
+    }) ?? 0
   const delayAfterDispenseCommands =
     dispenseDelay != null
       ? [
@@ -349,6 +352,47 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
           }),
         ]
       : []
+
+  const aspirateAirGapAspirateFlowRate =
+    getByVolumeValue({
+      liquidClass,
+      pipetteSpecs,
+      tiprackDefUri: tipRack,
+      targetVolume: aspirateAirGapVolume,
+      liquidHandlingAction: 'aspirate',
+      byVolumeProperty: 'flowRateByVolume',
+      defaultValue: null,
+    }) ?? aspirateFlowRateUlSec
+  const aspirateAirGapDispenseFlowRate =
+    getByVolumeValue({
+      liquidClass,
+      pipetteSpecs,
+      tiprackDefUri: tipRack,
+      targetVolume: aspirateAirGapVolume,
+      liquidHandlingAction: 'singleDispense',
+      byVolumeProperty: 'flowRateByVolume',
+      defaultValue: null,
+    }) ?? dispenseFlowRateUlSec
+  const dispenseAirGapAspirateFlowRate =
+    getByVolumeValue({
+      liquidClass,
+      pipetteSpecs,
+      tiprackDefUri: tipRack,
+      targetVolume: dispenseAirGapVolume,
+      liquidHandlingAction: 'aspirate',
+      byVolumeProperty: 'flowRateByVolume',
+      defaultValue: null,
+    }) ?? aspirateFlowRateUlSec
+  const dispenseAirGapDispenseFlowRate =
+    getByVolumeValue({
+      liquidClass,
+      pipetteSpecs,
+      tiprackDefUri: tipRack,
+      targetVolume: dispenseAirGapVolume,
+      liquidHandlingAction: 'singleDispense',
+      byVolumeProperty: 'flowRateByVolume',
+      defaultValue: null,
+    }) ?? dispenseFlowRateUlSec
 
   const commandCreators = flatMap(
     sourceWellChunks,
@@ -369,7 +413,7 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
               curryCommandCreator(airGapInPlace, {
                 pipetteId: pipette,
                 volume: dispenseAirGapVolume,
-                flowRate: aspirateFlowRateUlSec,
+                flowRate: dispenseAirGapAspirateFlowRate,
                 ...(aspirateCorrectionVolumeForDispenseAirGap > 0
                   ? {
                       correctionVolume: aspirateCorrectionVolumeForDispenseAirGap,
@@ -436,10 +480,13 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
         (sourceWell: string, wellIndex: number): CurriedCommandCreator[] => {
           const isFirstWellInChunk = wellIndex === 0
           let airGapInTip = 0
+          let airGapDispenseFlowRate = dispenseFlowRateUlSec
           if (isFirstWellInChunk && !changeTipNow && !isFirstChunk) {
             airGapInTip = dispenseAirGapVolume
+            airGapDispenseFlowRate = dispenseAirGapDispenseFlowRate
           } else if (!isFirstWellInChunk) {
             airGapInTip = aspirateAirGapVolume
+            airGapDispenseFlowRate = aspirateAirGapDispenseFlowRate
           }
           const aspirateSubmergeLocation: WellLocation = {
             origin:
@@ -463,15 +510,16 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
               z: aspirateRetractZOffset,
             },
           }
-          const dispenseCorrectionVolumeForDispenseAirGap = getCorrectionVolume(
-            {
+          const dispenseCorrectionVolumeForDispenseAirGap =
+            getByVolumeValue({
               liquidClass,
               pipetteSpecs,
               tiprackDefUri: tipRack,
               targetVolume: airGapInTip,
               liquidHandlingAction: 'singleDispense',
-            }
-          )
+              byVolumeProperty: 'correctionByVolume',
+              defaultValue: 0,
+            }) ?? 0
           const configureForVolumeAndPrepareToAspirateCommands: CurriedCommandCreator[] = isFirstWellInChunk
             ? [
                 ...(LOW_VOLUME_PIPETTES.includes(
@@ -495,7 +543,7 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
                   curryCommandCreator(dispenseInPlace, {
                     pipetteId: pipette,
                     volume: airGapInTip,
-                    flowRate: dispenseFlowRateUlSec,
+                    flowRate: airGapDispenseFlowRate,
                     ...(dispenseCorrectionVolumeForDispenseAirGap > 0
                       ? {
                           correctionVolume: dispenseCorrectionVolumeForDispenseAirGap,
@@ -594,22 +642,23 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
                   : []),
               ]
             : []
-          const aspirateCorrectionVolumeForAspirateAirGap = getCorrectionVolume(
-            {
+          const aspirateCorrectionVolumeForAspirateAirGap =
+            getByVolumeValue({
               liquidClass,
               pipetteSpecs,
               tiprackDefUri: tipRack,
               targetVolume: aspirateAirGapVolume,
               liquidHandlingAction: 'aspirate',
-            }
-          )
+              byVolumeProperty: 'correctionByVolume',
+              defaultValue: 0,
+            }) ?? 0
           const airGapAfterAspirateRetractCommands =
             aspirateAirGapVolume > 0
               ? [
                   curryCommandCreator(airGapInPlace, {
                     pipetteId: pipette,
                     volume: aspirateAirGapVolume,
-                    flowRate: aspirateFlowRateUlSec,
+                    flowRate: aspirateAirGapAspirateFlowRate,
                     ...(aspirateCorrectionVolumeForAspirateAirGap > 0
                       ? {
                           correctionVolume: aspirateCorrectionVolumeForAspirateAirGap,
@@ -619,15 +668,16 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
                   ...delayAfterAspirateCommands,
                 ]
               : []
-          const aspirateCorrectionVolumeForSampleAspiration = getCorrectionVolume(
-            {
+          const aspirateCorrectionVolumeForSampleAspiration =
+            getByVolumeValue({
               liquidClass,
               pipetteSpecs,
               tiprackDefUri: tipRack,
               targetVolume: volume,
               liquidHandlingAction: 'aspirate',
-            }
-          )
+              byVolumeProperty: 'correctionByVolume',
+              defaultValue: 0,
+            }) ?? 0
           const aspirateCommands = [
             curryCommandCreator(aspirateInPlace, {
               pipetteId: pipette,
@@ -701,20 +751,23 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
               }),
             ]
 
-      const dispenseCorrectionVolumeForAspirateAirGap = getCorrectionVolume({
-        liquidClass,
-        pipetteSpecs,
-        tiprackDefUri: tipRack,
-        targetVolume: aspirateAirGapVolume,
-        liquidHandlingAction: 'singleDispense',
-      })
+      const dispenseCorrectionVolumeForAspirateAirGap =
+        getByVolumeValue({
+          liquidClass,
+          pipetteSpecs,
+          tiprackDefUri: tipRack,
+          targetVolume: aspirateAirGapVolume,
+          liquidHandlingAction: 'singleDispense',
+          byVolumeProperty: 'correctionByVolume',
+          defaultValue: 0,
+        }) ?? 0
       const voidAirGapAtDispenseWellCommands =
         aspirateAirGapVolume > 0
           ? [
               curryCommandCreator(dispenseInPlace, {
                 pipetteId: pipette,
                 volume: aspirateAirGapVolume,
-                flowRate: dispenseFlowRateUlSec,
+                flowRate: aspirateAirGapDispenseFlowRate,
                 pushOut: 0,
                 correctionVolume: dispenseCorrectionVolumeForAspirateAirGap,
               }),
@@ -761,13 +814,16 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
             ]
           : []
 
-      const dispenseCorrectionForTotalDispense = getCorrectionVolume({
-        liquidClass,
-        pipetteSpecs,
-        tiprackDefUri: tipRack,
-        targetVolume: totalSampleDispenseVolume,
-        liquidHandlingAction: 'singleDispense',
-      })
+      const dispenseCorrectionForTotalDispense =
+        getByVolumeValue({
+          liquidClass,
+          pipetteSpecs,
+          tiprackDefUri: tipRack,
+          targetVolume: totalSampleDispenseVolume,
+          liquidHandlingAction: 'singleDispense',
+          byVolumeProperty: 'correctionByVolume',
+          defaultValue: 0,
+        }) ?? 0
       // don't push out if mixing in destination
       const effectivePushOut = mixInDestination != null ? 0 : pushOut
       const dispenseCommands = [
@@ -780,14 +836,38 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
         }),
         ...delayAfterDispenseCommands,
       ]
+      const mixAspirateFlowRate =
+        (mixInDestination != null
+          ? getByVolumeValue({
+              liquidClass,
+              pipetteSpecs,
+              tiprackDefUri: tipRack,
+              targetVolume: mixInDestination.volume,
+              liquidHandlingAction: 'aspirate',
+              byVolumeProperty: 'flowRateByVolume',
+              defaultValue: null,
+            })
+          : aspirateFlowRateUlSec) ?? aspirateFlowRateUlSec
+      const mixDispenseFlowRate =
+        (mixInDestination != null
+          ? getByVolumeValue({
+              liquidClass,
+              pipetteSpecs,
+              tiprackDefUri: tipRack,
+              targetVolume: mixInDestination.volume,
+              liquidHandlingAction: 'singleDispense',
+              byVolumeProperty: 'flowRateByVolume',
+              defaultValue: null,
+            })
+          : dispenseFlowRateUlSec) ?? dispenseFlowRateUlSec
       const mixInDestinationCommands =
         mixInDestination != null
           ? mixInPlaceUtil({
               pipette,
               volume: mixInDestination.volume,
               times: mixInDestination.times,
-              aspirateFlowRateUlSec,
-              dispenseFlowRateUlSec,
+              aspirateFlowRateUlSec: mixAspirateFlowRate,
+              dispenseFlowRateUlSec: mixDispenseFlowRate,
               aspirateDelaySeconds: aspirateDelay?.seconds,
               dispenseDelaySeconds: dispenseDelay?.seconds,
               finalPushOut: pushOut,

--- a/step-generation/src/commandCreators/compound/distribute.ts
+++ b/step-generation/src/commandCreators/compound/distribute.ts
@@ -4,7 +4,7 @@ import flatMap from 'lodash/flatMap'
 import {
   ALL,
   getAllLiquidClassDefs,
-  getCorrectionVolume,
+  getByVolumeValue,
   getFlexNameConversion,
   getMmFromBottom,
   GRIPPER_WASTE_CHUTE_ADDRESSABLE_AREA,
@@ -374,6 +374,48 @@ export const distribute: CommandCreator<DistributeArgs> = (
       z: dispenseRetractZOffset,
     },
   }
+
+  const aspirateAirGapAspirateFlowRate =
+    getByVolumeValue({
+      liquidClass,
+      pipetteSpecs,
+      tiprackDefUri: tipRack,
+      targetVolume: aspirateAirGapVolume,
+      liquidHandlingAction: 'aspirate',
+      byVolumeProperty: 'flowRateByVolume',
+      defaultValue: null,
+    }) ?? aspirateFlowRateUlSec
+  const aspirateAirGapDispenseFlowRate =
+    getByVolumeValue({
+      liquidClass,
+      pipetteSpecs,
+      tiprackDefUri: tipRack,
+      targetVolume: aspirateAirGapVolume,
+      liquidHandlingAction: 'multiDispense',
+      byVolumeProperty: 'flowRateByVolume',
+      defaultValue: null,
+    }) ?? dispenseFlowRateUlSec
+  const dispenseAirGapAspirateFlowRate =
+    getByVolumeValue({
+      liquidClass,
+      pipetteSpecs,
+      tiprackDefUri: tipRack,
+      targetVolume: dispenseAirGapVolume,
+      liquidHandlingAction: 'aspirate',
+      byVolumeProperty: 'flowRateByVolume',
+      defaultValue: null,
+    }) ?? aspirateFlowRateUlSec
+  const dispenseAirGapDispenseFlowRate =
+    getByVolumeValue({
+      liquidClass,
+      pipetteSpecs,
+      tiprackDefUri: tipRack,
+      targetVolume: dispenseAirGapVolume,
+      liquidHandlingAction: 'multiDispense',
+      byVolumeProperty: 'flowRateByVolume',
+      defaultValue: null,
+    }) ?? dispenseFlowRateUlSec
+
   const destWellChunks = chunk(destWells, numWellsToFitInTip)
   const commandCreators = flatMap(
     destWellChunks,
@@ -425,13 +467,16 @@ export const distribute: CommandCreator<DistributeArgs> = (
           pipetteId: pipette,
         }),
       ]
-      const dispenseCorrectionVolumeForDispenseAirGap = getCorrectionVolume({
-        liquidClass,
-        pipetteSpecs,
-        tiprackDefUri: tipRack,
-        targetVolume: dispenseAirGapVolume,
-        liquidHandlingAction: 'multiDispense',
-      })
+      const dispenseCorrectionVolumeForDispenseAirGap =
+        getByVolumeValue({
+          liquidClass,
+          pipetteSpecs,
+          tiprackDefUri: tipRack,
+          targetVolume: dispenseAirGapVolume,
+          liquidHandlingAction: 'multiDispense',
+          byVolumeProperty: 'correctionByVolume',
+          defaultValue: 0,
+        }) ?? 0
       const voidDispenseAirGapCommand =
         dispenseAirGapVolume > 0 &&
         !changeTipNow &&
@@ -442,7 +487,7 @@ export const distribute: CommandCreator<DistributeArgs> = (
               curryCommandCreator(dispenseInPlace, {
                 pipetteId: pipette,
                 volume: dispenseAirGapVolume,
-                flowRate: dispenseFlowRateUlSec,
+                flowRate: dispenseAirGapDispenseFlowRate,
                 ...(dispenseCorrectionVolumeForDispenseAirGap > 0
                   ? {
                       correctionVolume: dispenseCorrectionVolumeForDispenseAirGap,
@@ -572,20 +617,23 @@ export const distribute: CommandCreator<DistributeArgs> = (
               : []),
           ]
         : []
-      const aspirateCorrectionVolumeForAspirateAirGap = getCorrectionVolume({
-        liquidClass,
-        pipetteSpecs,
-        tiprackDefUri: tipRack,
-        targetVolume: aspirateAirGapVolume,
-        liquidHandlingAction: 'aspirate',
-      })
+      const aspirateCorrectionVolumeForAspirateAirGap =
+        getByVolumeValue({
+          liquidClass,
+          pipetteSpecs,
+          tiprackDefUri: tipRack,
+          targetVolume: aspirateAirGapVolume,
+          liquidHandlingAction: 'aspirate',
+          byVolumeProperty: 'correctionByVolume',
+          defaultValue: 0,
+        }) ?? 0
       const airGapAfterAspirateRetractCommands =
         aspirateAirGapVolume > 0
           ? [
               curryCommandCreator(airGapInPlace, {
                 pipetteId: pipette,
                 volume: aspirateAirGapVolume,
-                flowRate: aspirateFlowRateUlSec,
+                flowRate: aspirateAirGapAspirateFlowRate,
                 ...(aspirateCorrectionVolumeForAspirateAirGap > 0
                   ? {
                       correctionVolume: aspirateCorrectionVolumeForAspirateAirGap,
@@ -595,25 +643,29 @@ export const distribute: CommandCreator<DistributeArgs> = (
               ...delayAfterAspirateCommands,
             ]
           : []
-      const aspirateCorrectionVolumeForTotalAspiration = getCorrectionVolume({
-        liquidClass,
-        pipetteSpecs,
-        tiprackDefUri: tipRack,
-        targetVolume:
-          totalSampleAspirateVolume +
-          (disposalVolume ?? 0) +
-          (conditioningVolume ?? 0),
-        liquidHandlingAction: 'aspirate',
-      })
-      const dispenseCorrectionVolumeForConditioningVolume = getCorrectionVolume(
-        {
+      const aspirateCorrectionVolumeForTotalAspiration =
+        getByVolumeValue({
+          liquidClass,
+          pipetteSpecs,
+          tiprackDefUri: tipRack,
+          targetVolume:
+            totalSampleAspirateVolume +
+            (disposalVolume ?? 0) +
+            (conditioningVolume ?? 0),
+          liquidHandlingAction: 'aspirate',
+          byVolumeProperty: 'correctionByVolume',
+          defaultValue: 0,
+        }) ?? 0
+      const dispenseCorrectionVolumeForConditioningVolume =
+        getByVolumeValue({
           liquidClass,
           pipetteSpecs,
           tiprackDefUri: tipRack,
           targetVolume: conditioningVolume ?? 0,
           liquidHandlingAction: 'multiDispense',
-        }
-      )
+          byVolumeProperty: 'correctionByVolume',
+          defaultValue: 0,
+        }) ?? 0
       const dispenseConditioningVolumeCommands =
         conditioningVolume != null && conditioningVolume > 0
           ? [
@@ -668,22 +720,28 @@ export const distribute: CommandCreator<DistributeArgs> = (
           const isOverallUltimateDispense = isLastChunk && isLastWellInChunk
 
           let airGapInTip = 0
+          let airGapDispenseFlowRate = dispenseFlowRateUlSec
           if (isFirstWellInChunk && aspirateAirGapVolume > 0) {
             airGapInTip = aspirateAirGapVolume
+            airGapDispenseFlowRate = aspirateAirGapDispenseFlowRate
           } else if (
             !isFirstWellInChunk &&
             dispenseAirGapVolume > 0 &&
             (conditioningVolume == null || conditioningVolume === 0)
           ) {
             airGapInTip = dispenseAirGapVolume
+            airGapDispenseFlowRate = dispenseAirGapDispenseFlowRate
           }
-          const dispenseCorrectionVolumeForAirGap = getCorrectionVolume({
-            liquidClass,
-            pipetteSpecs,
-            tiprackDefUri: tipRack,
-            targetVolume: airGapInTip,
-            liquidHandlingAction: 'multiDispense',
-          })
+          const dispenseCorrectionVolumeForAirGap =
+            getByVolumeValue({
+              liquidClass,
+              pipetteSpecs,
+              tiprackDefUri: tipRack,
+              targetVolume: airGapInTip,
+              liquidHandlingAction: 'multiDispense',
+              byVolumeProperty: 'correctionByVolume',
+              defaultValue: 0,
+            }) ?? 0
           const dispenseSubmergeCommands =
             destinationWell != null
               ? [
@@ -698,7 +756,7 @@ export const distribute: CommandCreator<DistributeArgs> = (
                         curryCommandCreator(dispenseInPlace, {
                           pipetteId: pipette,
                           volume: airGapInTip,
-                          flowRate: dispenseFlowRateUlSec,
+                          flowRate: airGapDispenseFlowRate,
                           pushOut: 0,
                           correctionVolume: dispenseCorrectionVolumeForAirGap,
                         }),
@@ -747,13 +805,16 @@ export const distribute: CommandCreator<DistributeArgs> = (
           // don't push out if mixing in destination
           const effectivePushOut =
             disposalVolume === 0 && isLastWellInChunk ? pushOut : 0
-          const dispenseCorrectionVolumeForDestination = getCorrectionVolume({
-            liquidClass,
-            pipetteSpecs,
-            tiprackDefUri: tipRack,
-            targetVolume: volume,
-            liquidHandlingAction: 'multiDispense',
-          })
+          const dispenseCorrectionVolumeForDestination =
+            getByVolumeValue({
+              liquidClass,
+              pipetteSpecs,
+              tiprackDefUri: tipRack,
+              targetVolume: volume,
+              liquidHandlingAction: 'multiDispense',
+              byVolumeProperty: 'correctionByVolume',
+              defaultValue: 0,
+            }) ?? 0
           const dispenseCommands = [
             curryCommandCreator(dispenseInPlace, {
               pipetteId: pipette,
@@ -796,15 +857,16 @@ export const distribute: CommandCreator<DistributeArgs> = (
                 }),
               ]
             : []
-          const aspirateCorrectionVolumeForDispenseAirGap = getCorrectionVolume(
-            {
+          const aspirateCorrectionVolumeForDispenseAirGap =
+            getByVolumeValue({
               liquidClass,
               pipetteSpecs,
               tiprackDefUri: tipRack,
               targetVolume: dispenseAirGapVolume,
               liquidHandlingAction: 'aspirate',
-            }
-          )
+              byVolumeProperty: 'correctionByVolume',
+              defaultValue: 0,
+            }) ?? 0
           const getAirGapAfterDispenseCommands = (
             considerUltimateSubtransfer: boolean
           ): CurriedCommandCreator[] =>
@@ -828,7 +890,7 @@ export const distribute: CommandCreator<DistributeArgs> = (
                   curryCommandCreator(airGapInPlace, {
                     pipetteId: pipette,
                     volume: dispenseAirGapVolume,
-                    flowRate: aspirateFlowRateUlSec,
+                    flowRate: dispenseAirGapAspirateFlowRate,
                     ...(aspirateCorrectionVolumeForDispenseAirGap > 0
                       ? {
                           correctionVolume: aspirateCorrectionVolumeForDispenseAirGap,

--- a/step-generation/src/commandCreators/compound/mix.ts
+++ b/step-generation/src/commandCreators/compound/mix.ts
@@ -1,7 +1,7 @@
 import flatMap from 'lodash/flatMap'
 
 import {
-  getCorrectionVolume,
+  getByVolumeValue,
   GRIPPER_WASTE_CHUTE_ADDRESSABLE_AREA,
   LOW_VOLUME_PIPETTES,
   WELL_ORIGIN_BOTTOM,
@@ -172,20 +172,26 @@ export const mixInPlaceUtil = (args: {
 
   const pipetteSpecs = invariantContext.pipetteEntities[pipette].spec
 
-  const correctionVolumeAspirate = getCorrectionVolume({
-    liquidClass,
-    pipetteSpecs,
-    tiprackDefUri: tiprack,
-    targetVolume: volume,
-    liquidHandlingAction: 'aspirate',
-  })
-  const correctionVolumeDispense = getCorrectionVolume({
-    liquidClass,
-    pipetteSpecs,
-    tiprackDefUri: tiprack,
-    targetVolume: volume,
-    liquidHandlingAction: 'singleDispense',
-  })
+  const correctionVolumeAspirate =
+    getByVolumeValue({
+      liquidClass,
+      pipetteSpecs,
+      tiprackDefUri: tiprack,
+      targetVolume: volume,
+      liquidHandlingAction: 'aspirate',
+      byVolumeProperty: 'correctionByVolume',
+      defaultValue: 0,
+    }) ?? 0
+  const correctionVolumeDispense =
+    getByVolumeValue({
+      liquidClass,
+      pipetteSpecs,
+      tiprackDefUri: tiprack,
+      targetVolume: volume,
+      liquidHandlingAction: 'singleDispense',
+      byVolumeProperty: 'correctionByVolume',
+      defaultValue: 0,
+    }) ?? 0
 
   const moveToWellCommands: CurriedCommandCreator[] =
     moveToWellParams != null

--- a/step-generation/src/commandCreators/compound/transfer.ts
+++ b/step-generation/src/commandCreators/compound/transfer.ts
@@ -2,7 +2,7 @@ import assert from 'assert'
 import zip from 'lodash/zip'
 
 import {
-  getCorrectionVolume,
+  getByVolumeValue,
   getMmFromBottom,
   GRIPPER_WASTE_CHUTE_ADDRESSABLE_AREA,
   LOW_VOLUME_PIPETTES,
@@ -306,21 +306,27 @@ export const transfer: CommandCreator<TransferArgs> = (
     pythonName: pythonPipetteName,
   } = pipetteEntities[args.pipette]
 
-  const dispenseCorrectionVolumeForSubtransferTarget = getCorrectionVolume({
-    liquidClass: args.liquidClass,
-    pipetteSpecs,
-    tiprackDefUri: args.tipRack,
-    targetVolume: subTransferVol,
-    liquidHandlingAction: 'singleDispense',
-  })
+  const dispenseCorrectionVolumeForSubtransferTarget =
+    getByVolumeValue({
+      liquidClass: args.liquidClass,
+      pipetteSpecs,
+      tiprackDefUri: args.tipRack,
+      targetVolume: subTransferVol,
+      liquidHandlingAction: 'singleDispense',
+      byVolumeProperty: 'correctionByVolume',
+      defaultValue: 0,
+    }) ?? 0
 
-  const aspirateCorrectionVolumeForSubtransferTarget = getCorrectionVolume({
-    liquidClass: args.liquidClass,
-    pipetteSpecs,
-    tiprackDefUri: args.tipRack,
-    targetVolume: subTransferVol,
-    liquidHandlingAction: 'aspirate',
-  })
+  const aspirateCorrectionVolumeForSubtransferTarget =
+    getByVolumeValue({
+      liquidClass: args.liquidClass,
+      pipetteSpecs,
+      tiprackDefUri: args.tipRack,
+      targetVolume: subTransferVol,
+      liquidHandlingAction: 'aspirate',
+      byVolumeProperty: 'correctionByVolume',
+      defaultValue: 0,
+    }) ?? 0
 
   /** needed for python generation! > */
   const destTrashPipetteName =
@@ -375,6 +381,46 @@ export const transfer: CommandCreator<TransferArgs> = (
   })
   /** < until here */
 
+  const aspirateAirGapAspirateFlowRate =
+    getByVolumeValue({
+      liquidClass,
+      pipetteSpecs,
+      tiprackDefUri: tipRack,
+      targetVolume: aspirateAirGapVol,
+      liquidHandlingAction: 'aspirate',
+      byVolumeProperty: 'flowRateByVolume',
+      defaultValue: null,
+    }) ?? aspirateFlowRateUlSec
+  const aspirateAirGapDispenseFlowRate =
+    getByVolumeValue({
+      liquidClass,
+      pipetteSpecs,
+      tiprackDefUri: tipRack,
+      targetVolume: aspirateAirGapVol,
+      liquidHandlingAction: 'singleDispense',
+      byVolumeProperty: 'flowRateByVolume',
+      defaultValue: null,
+    }) ?? dispenseFlowRateUlSec
+  const dispenseAirGapAspirateFlowRate =
+    getByVolumeValue({
+      liquidClass,
+      pipetteSpecs,
+      tiprackDefUri: tipRack,
+      targetVolume: dispenseAirGapVol,
+      liquidHandlingAction: 'aspirate',
+      byVolumeProperty: 'flowRateByVolume',
+      defaultValue: null,
+    }) ?? aspirateFlowRateUlSec
+  const dispenseAirGapDispenseFlowRate =
+    getByVolumeValue({
+      liquidClass,
+      pipetteSpecs,
+      tiprackDefUri: tipRack,
+      targetVolume: dispenseAirGapVol,
+      liquidHandlingAction: 'singleDispense',
+      byVolumeProperty: 'flowRateByVolume',
+      defaultValue: null,
+    }) ?? dispenseFlowRateUlSec
   // @ts-expect-error(SA, 2021-05-05): zip can return undefined so this really should be Array<[string | undefined, string | undefined]>
   const sourceDestPairs: Array<[string, string | null]> = zip(
     sourceWells,
@@ -493,15 +539,16 @@ export const transfer: CommandCreator<TransferArgs> = (
               pipetteId: pipette,
             }),
           ]
-          const dispenseCorrectionVolumeForDispenseAirGap = getCorrectionVolume(
-            {
+          const dispenseCorrectionVolumeForDispenseAirGap =
+            getByVolumeValue({
               liquidClass,
               pipetteSpecs,
               tiprackDefUri: tipRack,
               targetVolume: dispenseAirGapVol,
               liquidHandlingAction: 'singleDispense',
-            }
-          )
+              byVolumeProperty: 'correctionByVolume',
+              defaultValue: 0,
+            }) ?? 0
           const voidDispenseAirGapCommand =
             dispenseAirGapVol > 0 &&
             !changeTipNow &&
@@ -510,7 +557,7 @@ export const transfer: CommandCreator<TransferArgs> = (
                   curryWithoutPython(dispenseInPlace, {
                     pipetteId: pipette,
                     volume: dispenseAirGapVol,
-                    flowRate: dispenseFlowRateUlSec,
+                    flowRate: dispenseAirGapDispenseFlowRate,
                     ...(dispenseCorrectionVolumeForDispenseAirGap > 0
                       ? {
                           correctionVolume: dispenseCorrectionVolumeForDispenseAirGap,
@@ -630,22 +677,23 @@ export const transfer: CommandCreator<TransferArgs> = (
                   : []),
               ]
             : []
-          const aspirateCorrectionVolumeForAspirateAirGap = getCorrectionVolume(
-            {
+          const aspirateCorrectionVolumeForAspirateAirGap =
+            getByVolumeValue({
               liquidClass,
               pipetteSpecs,
               tiprackDefUri: tipRack,
               targetVolume: aspirateAirGapVol,
               liquidHandlingAction: 'aspirate',
-            }
-          )
+              byVolumeProperty: 'correctionByVolume',
+              defaultValue: 0,
+            }) ?? 0
           const airGapAfterAspirateRetractCommands =
             aspirateAirGapVol > 0
               ? [
                   curryWithoutPython(airGapInPlace, {
                     pipetteId: pipette,
                     volume: aspirateAirGapVol,
-                    flowRate: aspirateFlowRateUlSec,
+                    flowRate: aspirateAirGapAspirateFlowRate,
                     ...(aspirateCorrectionVolumeForAspirateAirGap > 0
                       ? {
                           correctionVolume: aspirateCorrectionVolumeForAspirateAirGap,
@@ -695,15 +743,17 @@ export const transfer: CommandCreator<TransferArgs> = (
                   }),
                 ]
               : []
-          const dispenseCorrectionVolumeForAspirateAirGap = getCorrectionVolume(
-            {
+          const dispenseCorrectionVolumeForAspirateAirGap =
+            getByVolumeValue({
               liquidClass,
               pipetteSpecs,
               tiprackDefUri: tipRack,
               targetVolume: aspirateAirGapVol,
               liquidHandlingAction: 'singleDispense',
-            }
-          )
+              byVolumeProperty: 'correctionByVolume',
+              defaultValue: 0,
+            }) ?? 0
+
           const dispenseSubmergeCommands =
             destinationWell != null
               ? [
@@ -718,7 +768,7 @@ export const transfer: CommandCreator<TransferArgs> = (
                         curryWithoutPython(dispenseInPlace, {
                           pipetteId: pipette,
                           volume: aspirateAirGapVol,
-                          flowRate: dispenseFlowRateUlSec,
+                          flowRate: aspirateAirGapDispenseFlowRate,
                           pushOut: 0,
                           ...(dispenseCorrectionVolumeForAspirateAirGap > 0
                             ? {
@@ -834,15 +884,16 @@ export const transfer: CommandCreator<TransferArgs> = (
             pipetteId: pipette,
             flowRate: blowoutFlowRateUlSec,
           })
-          const aspirateCorrectionVolumeForDispenseAirGap = getCorrectionVolume(
-            {
+          const aspirateCorrectionVolumeForDispenseAirGap =
+            getByVolumeValue({
               liquidClass,
               pipetteSpecs,
               tiprackDefUri: tipRack,
               targetVolume: dispenseAirGapVol,
               liquidHandlingAction: 'aspirate',
-            }
-          )
+              byVolumeProperty: 'correctionByVolume',
+              defaultValue: 0,
+            }) ?? 0
 
           const getAirGapAfterDispenseCommands = (
             considerUltimateSubtransfer: boolean
@@ -857,7 +908,7 @@ export const transfer: CommandCreator<TransferArgs> = (
                   curryWithoutPython(airGapInPlace, {
                     pipetteId: pipette,
                     volume: dispenseAirGapVol,
-                    flowRate: aspirateFlowRateUlSec,
+                    flowRate: dispenseAirGapAspirateFlowRate,
                     ...(aspirateCorrectionVolumeForDispenseAirGap > 0
                       ? {
                           correctionVolume: aspirateCorrectionVolumeForDispenseAirGap,


### PR DESCRIPTION
# Overview

This PR uses the interpolated liquid class flow rate values for air gap and mix aspirates and dispenses in moveLiquid compound command creators (transfer, consolidate, distribute). It also extends a shared data liquid classes util to return correction or flow rate by volume interpolated values.

## Test Plan and Hands on Testing

Please just review logic. There's not much to test in practice outside of @ddcc4 's local diff checker for Python API vs. step-generation commands emitted

## Changelog

- abstract liquid class utility to get interpolated correction volumes or flow rates
- wire up in `transfer`, `distribute`, `consolidate`, and `mix` compound command creators

## Review requests

- see test plan

## Risk assessment

lowish 