### PR TITLE
refactor(protocol-designer): hardcode release version in to prevent i…

### DIFF
--- a/protocol-designer/src/file-data/__tests__/createFile.test.ts
+++ b/protocol-designer/src/file-data/__tests__/createFile.test.ts
@@ -286,7 +286,7 @@ CUSTOM_LABWARE = json.loads("""{"fixture/fixture_trash/1":{"ordering":[["A1"]],"
             },
           },
         },
-        version: 'fake_PD_version',
+        version: '8.5.0',
         name: 'opentrons/protocol-designer',
       },
       robot: { model: OT2_ROBOT_TYPE },

--- a/protocol-designer/src/file-data/selectors/fileCreator.ts
+++ b/protocol-designer/src/file-data/selectors/fileCreator.ts
@@ -359,7 +359,11 @@ export const createFile: Selector<PDPythonFile> = createSelector(
       },
       designerApplication: {
         name: 'opentrons/protocol-designer',
-        version: applicationVersion,
+        // NOTE: hardcoding in the version like this could be tricky since we
+        // will have to remember to update the version with every release. But this solves
+        // the issues where you have to manually update when importing back to PD, before the release
+        // since using `applicationVersion` means that the version is tied to the release tag.
+        version: '8.5.0',
         data: {
           pipetteTiprackAssignments: mapValues(
             pipetteEntities,

--- a/protocol-designer/src/file-data/selectors/fileCreator.ts
+++ b/protocol-designer/src/file-data/selectors/fileCreator.ts
@@ -12,6 +12,7 @@ import {
   OT2_STANDARD_MODEL,
 } from '@opentrons/shared-data'
 import {
+  PD_APPLICATION_VERSION,
   pythonCustomLabwareDict,
   pythonDefRun,
   pythonImports,
@@ -363,7 +364,7 @@ export const createFile: Selector<PDPythonFile> = createSelector(
         // will have to remember to update the version with every release. But this solves
         // the issues where you have to manually update when importing back to PD, before the release
         // since using `applicationVersion` means that the version is tied to the release tag.
-        version: '8.5.0',
+        version: PD_APPLICATION_VERSION,
         data: {
           pipetteTiprackAssignments: mapValues(
             pipetteEntities,

--- a/step-generation/src/utils/pythonFileUtils.ts
+++ b/step-generation/src/utils/pythonFileUtils.ts
@@ -34,6 +34,7 @@ import type {
 } from '../types'
 
 const PAPI_VERSION = '2.24' // latest version from api/src/opentrons/protocols/api_support/definitions.py
+export const PD_APPLICATION_VERSION = '8.5.0' // latest PD version to insert into DESIGNER_APPLICATION blob
 
 export function pythonImports(): string {
   return [


### PR DESCRIPTION
…mport issues

# Overview

We have this issue with exporting and importing JSON too. Basically, the version number of the exported `python` is tied to the release tag. This means that until we make the `8.5.0` release tag, you'll have to manually update the version number of the python protocol every time you want to import back into PD -in order to avoid unnecessarily trying to migrate. This is annoying and i decided to hard-code it in for now. BUT lmk what you think.

Here are the pros of this method:
1. you won't have to manually update the release version in the `DESIGNER_APPLICATION` blob when you reimport into PD, which isn't very user-friendly for folks internally who are not devs.
2. you'll still have a record of the alphas the python protocol was made in because the python metadata blob includes the PD version via the release tag: `protocolDesigner: process.env.OT_PD_VERSION,`

Cons:
1. since its hardcoded, we need to remember to manually update it with future releases

## Test Plan and Hands on Testing

Import a python protocol made with PD on the `chore_release-pd-8.5.0` branch and see that it fails importing due to the version number = `8.4.4` (this is because it incorrectly tries to go through a migration)

Import a python protocol made with PD on this branch and see that it succeeds when re-importing (this is because the version number is now `8.5.0`

## Changelog

- hardcode version number

## Risk assessment

low
