### PR TITLE
refactor(step-generation, app): generate get_liquid_class() from step…

### DIFF
--- a/app/src/organisms/ODD/QuickTransferFlow/utils/pythonDef.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/utils/pythonDef.ts
@@ -100,7 +100,6 @@ export function pythonDef(
     pipetteEntities,
     wasteChuteEntities,
     trashBinEntities,
-    liquidEntities,
   } = invariantContext
   const { labware, pipettes } = initialRobotState
   const sections: string[] = [
@@ -111,7 +110,9 @@ export function pythonDef(
       getLoadTrashBins(trashBinEntities),
       getLoadWasteChute(wasteChuteEntities),
     ],
-    getLoadLiquidClasses(liquidEntities),
+    getLoadLiquidClasses(
+      stepArgs?.liquidClass != null ? [stepArgs.liquidClass] : []
+    ),
     quickTransferStepCommands({
       stepArgs,
       invariantContext,

--- a/app/src/organisms/ODD/QuickTransferFlow/utils/pythonDef.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/utils/pythonDef.ts
@@ -111,7 +111,9 @@ export function pythonDef(
       getLoadWasteChute(wasteChuteEntities),
     ],
     getLoadLiquidClasses(
-      stepArgs?.liquidClass != null ? [stepArgs.liquidClass] : []
+      stepArgs?.liquidClass != null && stepArgs?.liquidClass !== 'none'
+        ? [stepArgs.liquidClass]
+        : []
     ),
     quickTransferStepCommands({
       stepArgs,

--- a/protocol-designer/src/file-data/selectors/fileCreator.ts
+++ b/protocol-designer/src/file-data/selectors/fileCreator.ts
@@ -8,6 +8,7 @@ import { createSelector } from 'reselect'
 import {
   FLEX_ROBOT_TYPE,
   FLEX_STANDARD_DECKID,
+  NONE_LIQUID_CLASS_NAME,
   OT2_STANDARD_DECKID,
   OT2_STANDARD_MODEL,
 } from '@opentrons/shared-data'
@@ -353,9 +354,18 @@ export const createFile: Selector<PDPythonFile> = createSelector(
       ).map(([liquidId, { pythonName, ...rest }]) => [liquidId, rest])
     )
 
-    const allLiquidClassesFromForms: string[] = Object.values(savedStepForms)
-      .filter(stepForm => 'liquidClass' in stepForm)
-      ?.map(stepForm => stepForm.liquidClass)
+    const allLiquidClassesFromForms = Array.from(
+      Object.values(savedStepForms).reduce<Set<string>>((acc, stepForm) => {
+        if (
+          'liquidClass' in stepForm &&
+          stepForm.liquidClass != null &&
+          stepForm.liquidClass !== NONE_LIQUID_CLASS_NAME
+        ) {
+          acc.add(stepForm.liquidClass as string)
+        }
+        return acc
+      }, new Set())
+    )
 
     const designerApplication: PythonDesignerApplication = {
       robot: {

--- a/protocol-designer/src/file-data/selectors/fileCreator.ts
+++ b/protocol-designer/src/file-data/selectors/fileCreator.ts
@@ -354,7 +354,7 @@ export const createFile: Selector<PDPythonFile> = createSelector(
       ).map(([liquidId, { pythonName, ...rest }]) => [liquidId, rest])
     )
 
-    const allLiquidClassesFromForms = Array.from(
+    const allUniqueLiquidClassesFromForms = Array.from(
       Object.values(savedStepForms).reduce<Set<string>>((acc, stepForm) => {
         if (
           'liquidClass' in stepForm &&
@@ -407,7 +407,7 @@ export const createFile: Selector<PDPythonFile> = createSelector(
           ingredLocations,
           labwareNicknamesById,
           robotType,
-          allLiquidClassesFromForms
+          allUniqueLiquidClassesFromForms
         ),
         pythonCustomLabwareDict(invariantContext.labwareEntities),
       ]

--- a/protocol-designer/src/file-data/selectors/fileCreator.ts
+++ b/protocol-designer/src/file-data/selectors/fileCreator.ts
@@ -353,6 +353,10 @@ export const createFile: Selector<PDPythonFile> = createSelector(
       ).map(([liquidId, { pythonName, ...rest }]) => [liquidId, rest])
     )
 
+    const allLiquidClassesFromForms: string[] = Object.values(savedStepForms)
+      .filter(stepForm => 'liquidClass' in stepForm)
+      ?.map(stepForm => stepForm.liquidClass)
+
     const designerApplication: PythonDesignerApplication = {
       robot: {
         model: robotType,
@@ -392,7 +396,8 @@ export const createFile: Selector<PDPythonFile> = createSelector(
           robotStateTimeline,
           ingredLocations,
           labwareNicknamesById,
-          robotType
+          robotType,
+          allLiquidClassesFromForms
         ),
         pythonCustomLabwareDict(invariantContext.labwareEntities),
       ]

--- a/step-generation/src/__tests__/pythonFileUtils.test.ts
+++ b/step-generation/src/__tests__/pythonFileUtils.test.ts
@@ -518,20 +518,32 @@ waste_chute = protocol.load_waste_chute()`.trimStart()
 })
 
 describe('getLoadLiquidClasses', () => {
-  it('should load a liquid class for each liquid class types', () => {
-    const liquid3 = 'liquid3'
-    mockLiquidEntities = {
-      ...mockLiquidEntities,
-      [liquid3]: {
-        liquidGroupId: liquid3,
-        pythonName: 'liquid_3',
-        description: '',
-        displayName: 'honey',
-        displayColor: 'mock display color 3',
+  it('should load a liquid class for each liquid class types with duplicate liquid classes and other steps', () => {
+    const mockStepForms = {
+      id: {
+        stepType: 'moveLiquid',
+        liquidClass: WATER_LIQUID_CLASS_NAME,
+      },
+      id2: {
+        stepType: 'moveLabware',
+      },
+      id3: {
+        stepType: 'moveLiquid',
+        liquidClass: ETHANOL_LIQUID_CLASS_NAME,
+      },
+      id4: {
+        stepType: 'mix',
+        liquidClass: GLYCEROL_LIQUID_CLASS_NAME,
+      },
+      id5: {
+        stepType: 'mix',
         liquidClass: GLYCEROL_LIQUID_CLASS_NAME,
       },
     }
-    expect(getLoadLiquidClasses(mockLiquidEntities)).toBe(
+    const liquidClassses = Object.values(mockStepForms)
+      .filter(step => 'liquidClass' in step)
+      ?.map(step => step.liquidClass)
+    expect(getLoadLiquidClasses(liquidClassses)).toBe(
       `
 # Load Liquid Classes:
 water_v1 = protocol.get_liquid_class("water")

--- a/step-generation/src/__tests__/pythonFileUtils.test.ts
+++ b/step-generation/src/__tests__/pythonFileUtils.test.ts
@@ -519,36 +519,21 @@ waste_chute = protocol.load_waste_chute()`.trimStart()
 
 describe('getLoadLiquidClasses', () => {
   it('should load a liquid class for each liquid class types with duplicate liquid classes and other steps', () => {
-    const mockStepForms = {
-      id: {
-        stepType: 'moveLiquid',
-        liquidClass: WATER_LIQUID_CLASS_NAME,
-      },
-      id2: {
-        stepType: 'moveLabware',
-      },
-      id3: {
-        stepType: 'moveLiquid',
-        liquidClass: ETHANOL_LIQUID_CLASS_NAME,
-      },
-      id4: {
-        stepType: 'mix',
-        liquidClass: GLYCEROL_LIQUID_CLASS_NAME,
-      },
-      id5: {
-        stepType: 'mix',
-        liquidClass: GLYCEROL_LIQUID_CLASS_NAME,
-      },
-    }
-    const liquidClassses = Object.values(mockStepForms)
-      .filter(step => 'liquidClass' in step)
-      ?.map(step => step.liquidClass)
-    expect(getLoadLiquidClasses(liquidClassses)).toBe(
+    expect(
+      getLoadLiquidClasses([
+        WATER_LIQUID_CLASS_NAME,
+        ETHANOL_LIQUID_CLASS_NAME,
+        GLYCEROL_LIQUID_CLASS_NAME,
+        GLYCEROL_LIQUID_CLASS_NAME,
+        'none',
+      ])
+    ).toBe(
       `
 # Load Liquid Classes:
 water_v1 = protocol.get_liquid_class("water")
 ethanol_80_v1 = protocol.get_liquid_class("ethanol_80")
-glycerol_50_v1 = protocol.get_liquid_class("glycerol_50")`.trimStart()
+glycerol_50_v1 = protocol.get_liquid_class("glycerol_50")
+`.trimStart()
     )
   })
 })

--- a/step-generation/src/__tests__/pythonFileUtils.test.ts
+++ b/step-generation/src/__tests__/pythonFileUtils.test.ts
@@ -407,7 +407,7 @@ pipette = protocol.load_instrument("flex_96channel_1000")`.trimStart()
 
 const liquid1 = 'liquid1'
 const liquid2 = 'liquid2'
-let mockLiquidEntities: LiquidEntities = {
+const mockLiquidEntities: LiquidEntities = {
   [liquid1]: {
     liquidGroupId: liquid1,
     pythonName: 'liquid_1',

--- a/step-generation/src/__tests__/pythonFileUtils.test.ts
+++ b/step-generation/src/__tests__/pythonFileUtils.test.ts
@@ -518,22 +518,19 @@ waste_chute = protocol.load_waste_chute()`.trimStart()
 })
 
 describe('getLoadLiquidClasses', () => {
-  it('should load a liquid class for each liquid class types with duplicate liquid classes and other steps', () => {
+  it('should load a liquid class for each liquid class types', () => {
     expect(
       getLoadLiquidClasses([
         WATER_LIQUID_CLASS_NAME,
         ETHANOL_LIQUID_CLASS_NAME,
         GLYCEROL_LIQUID_CLASS_NAME,
-        GLYCEROL_LIQUID_CLASS_NAME,
-        'none',
       ])
     ).toBe(
       `
 # Load Liquid Classes:
 water_v1 = protocol.get_liquid_class("water")
 ethanol_80_v1 = protocol.get_liquid_class("ethanol_80")
-glycerol_50_v1 = protocol.get_liquid_class("glycerol_50")
-`.trimStart()
+glycerol_50_v1 = protocol.get_liquid_class("glycerol_50")`.trimStart()
     )
   })
 })

--- a/step-generation/src/utils/pythonFileUtils.ts
+++ b/step-generation/src/utils/pythonFileUtils.ts
@@ -318,9 +318,7 @@ export function getLoadLiquidClasses(
   )
   const pythonLoadLiquidClasses = uniqueLiquidClassesFromForms
     .map(liquidClass => {
-      // we check that liquidClass is not null earlier but i got a check error
-      // without specifying it here
-      if (liquidClass == null) {
+      if (liquidClass == null || liquidClass === 'none') {
         return ''
       }
       return `${getPythonLiquidClassName(

--- a/step-generation/src/utils/pythonFileUtils.ts
+++ b/step-generation/src/utils/pythonFileUtils.ts
@@ -313,12 +313,9 @@ export function getLoadLiquidClasses(
   allLiquidClassesFromForms: string[]
 ): string {
   const allLiquidClassDefs = getAllLiquidClassDefs()
-  const uniqueLiquidClassesFromForms = Array.from(
-    new Set(allLiquidClassesFromForms)
-  )
-  const pythonLoadLiquidClasses = uniqueLiquidClassesFromForms
+  const pythonLoadLiquidClasses = allLiquidClassesFromForms
     .map(liquidClass => {
-      if (liquidClass == null || liquidClass === 'none') {
+      if (liquidClass == null) {
         return ''
       }
       return `${getPythonLiquidClassName(
@@ -329,7 +326,7 @@ export function getLoadLiquidClasses(
     })
     .join('\n')
 
-  return uniqueLiquidClassesFromForms.length > 0
+  return allLiquidClassesFromForms.length > 0
     ? `# Load Liquid Classes:\n${pythonLoadLiquidClasses}`
     : ''
 }

--- a/step-generation/src/utils/pythonFileUtils.ts
+++ b/step-generation/src/utils/pythonFileUtils.ts
@@ -310,10 +310,10 @@ export function getLoadLiquids(
 }
 
 export function getLoadLiquidClasses(
-  allLiquidClassesFromForms: string[]
+  allUniqueLiquidClassesFromForms: string[]
 ): string {
   const allLiquidClassDefs = getAllLiquidClassDefs()
-  const pythonLoadLiquidClasses = allLiquidClassesFromForms
+  const pythonLoadLiquidClasses = allUniqueLiquidClassesFromForms
     .map(liquidClass => {
       if (liquidClass == null) {
         return ''
@@ -326,7 +326,7 @@ export function getLoadLiquidClasses(
     })
     .join('\n')
 
-  return allLiquidClassesFromForms.length > 0
+  return allUniqueLiquidClassesFromForms.length > 0
     ? `# Load Liquid Classes:\n${pythonLoadLiquidClasses}`
     : ''
 }
@@ -376,7 +376,7 @@ export function pythonDefRun(
   liquidsByLabwareId: LabwareLiquidState,
   labwareNicknamesById: Record<string, string>,
   robotType: RobotType,
-  allLiquidClassesFromForms: string[]
+  allUniqueLiquidClassesFromForms: string[]
 ): string {
   const {
     moduleEntities,
@@ -405,7 +405,7 @@ export function pythonDefRun(
       : []),
     getDefineLiquids(liquidEntities),
     getLoadLiquids(liquidsByLabwareId, liquidEntities, labwareEntities),
-    getLoadLiquidClasses(allLiquidClassesFromForms),
+    getLoadLiquidClasses(allUniqueLiquidClassesFromForms),
     stepCommands(robotStateTimeline),
   ]
   const functionBody =

--- a/step-generation/src/utils/pythonFileUtils.ts
+++ b/step-generation/src/utils/pythonFileUtils.ts
@@ -309,13 +309,14 @@ export function getLoadLiquids(
   return pythonLoadLiquids ? `# Load Liquids:\n${pythonLoadLiquids}` : ''
 }
 
-export function getLoadLiquidClasses(liquidEntities: LiquidEntities): string {
+export function getLoadLiquidClasses(
+  allLiquidClassesFromForms: string[]
+): string {
   const allLiquidClassDefs = getAllLiquidClassDefs()
-  const allLiquidClasses = Object.values(liquidEntities)
-    .map(liquid => liquid.liquidClass)
-    .filter(liquidClass => liquidClass != null)
-  const uniqueLiquidClasses = Array.from(new Set(allLiquidClasses))
-  const pythonLoadLiquidClasses = uniqueLiquidClasses
+  const uniqueLiquidClassesFromForms = Array.from(
+    new Set(allLiquidClassesFromForms)
+  )
+  const pythonLoadLiquidClasses = uniqueLiquidClassesFromForms
     .map(liquidClass => {
       // we check that liquidClass is not null earlier but i got a check error
       // without specifying it here
@@ -330,7 +331,7 @@ export function getLoadLiquidClasses(liquidEntities: LiquidEntities): string {
     })
     .join('\n')
 
-  return uniqueLiquidClasses.length > 0
+  return uniqueLiquidClassesFromForms.length > 0
     ? `# Load Liquid Classes:\n${pythonLoadLiquidClasses}`
     : ''
 }
@@ -379,7 +380,8 @@ export function pythonDefRun(
   robotStateTimeline: Timeline,
   liquidsByLabwareId: LabwareLiquidState,
   labwareNicknamesById: Record<string, string>,
-  robotType: RobotType
+  robotType: RobotType,
+  allLiquidClassesFromForms: string[]
 ): string {
   const {
     moduleEntities,
@@ -408,7 +410,7 @@ export function pythonDefRun(
       : []),
     getDefineLiquids(liquidEntities),
     getLoadLiquids(liquidsByLabwareId, liquidEntities, labwareEntities),
-    getLoadLiquidClasses(liquidEntities),
+    getLoadLiquidClasses(allLiquidClassesFromForms),
     stepCommands(robotStateTimeline),
   ]
   const functionBody =


### PR DESCRIPTION
… forms

# Overview

Upon talking with @ncdiehl11, i realized that the `get_liquid_class()` should be based off of the liquid class selected in the step forms itself other than the liquid class assigned to the liquid. this is because the assigned liquid is the default and you can still change the liquid class type in the step form. so the step form liquid class is most accurate.

## Test Plan and Hands on Testing

Test that the `get_liquid_class()` command generated is based off of the liquid class step form and not liquid entities

## Changelog

- refactor how we are getting the liquid class info for get_liquid_class() for both PD and QT

## Risk assessment

low
