### PR TITLE
fix(protocol-designer): prevent duplicating into the TC slots

### DIFF
--- a/protocol-designer/src/labware-ingred/utils.ts
+++ b/protocol-designer/src/labware-ingred/utils.ts
@@ -1,6 +1,7 @@
 import {
   FIXED_TRASH_ID,
   FLEX_MODULE_ADDRESSABLE_AREAS,
+  FLEX_STACKER_ADDRESSABLE_AREAS,
   getAreSlotsAdjacent,
   getDeckDefFromRobotType,
   getIsLabwareAboveHeight,
@@ -66,7 +67,8 @@ export function getNextAvailableDeckSlot(
       isSlotEmpty = false
     } else if (
       moduleSlots.includes(slot.id) ||
-      FLEX_MODULE_ADDRESSABLE_AREAS.includes(slot.id)
+      FLEX_MODULE_ADDRESSABLE_AREAS.includes(slot.id) ||
+      FLEX_STACKER_ADDRESSABLE_AREAS.includes(slot.id)
     ) {
       isSlotEmpty = false
       //  return slot as full if slot is adjacent to heater-shaker for ot-2 and taller than 53mm

--- a/protocol-designer/src/labware-ingred/utils.ts
+++ b/protocol-designer/src/labware-ingred/utils.ts
@@ -41,7 +41,8 @@ export function getNextAvailableDeckSlot(
     .filter(module => module.slot)
     .map(mod => mod.slot)
   if (hasTC) {
-    moduleSlots = [...moduleSlots, '8', '10', '11']
+    //  encompass all TC slots for both robots since they're different
+    moduleSlots = [...moduleSlots, '8', '10', '11', 'A1']
   }
 
   return deckDef.locations.addressableAreas.find(slot => {


### PR DESCRIPTION
closes RQA-4268

# Overview

Fix allowing to duplicate into the TC slots

## Test Plan and Hands on Testing

Create a protocol with a TC and keep duplicating the tiprack until the deck is full and see that it wont duplicate into the TC

## Changelog

- add A1 to the list of full slots if TC is added

## Risk assessment

low
