### PR TITLE
fix(protocol-designer): highlight correct nozzles for 96-channel part…

### DIFF
--- a/protocol-designer/src/top-selectors/substep-highlight.ts
+++ b/protocol-designer/src/top-selectors/substep-highlight.ts
@@ -113,10 +113,7 @@ function _getSelectedWellsForStep(
       const pipetteSpec =
         invariantContext.pipetteEntities[pipetteId]?.spec || {}
       let channels = pipetteSpec.channels
-      if (
-        stepArgs.commandCreatorFnName === 'mix' ||
-        stepArgs.commandCreatorFnName === 'transfer'
-      ) {
+      if ('nozzles' in stepArgs) {
         if (stepArgs.nozzles === COLUMN) {
           channels = 8
         } else if (stepArgs.nozzles === SINGLE) {


### PR DESCRIPTION
…ial tip

closes RQA-4266

# Overview

Fixes bug where a distribute and consolidate wasn't highlighting the correct number of tips used in a the step for a 96-channel 8-channel pick up. Before, it only shows transfer and mix but forgot consolidate and distribute

## Test Plan and Hands on Testing

upload this protocol. highlight over the steps and see that the correct wells/tips are highlighted for 96-channel 8 nozzle pick up

```
import json
from contextlib import nullcontext as pd_step
from opentrons import protocol_api, types

metadata = {
    "created": "2025-06-12T15:28:33.865Z",
    "lastModified": "2025-06-12T15:47:03.771Z",
    "protocolDesigner": "8.4.4",
    "source": "Protocol Designer",
}

requirements = {
    "robotType": "Flex",
    "apiLevel": "2.24",
}

def run(protocol: protocol_api.ProtocolContext) -> None:
    # Load Adapters:
    adapter_1 = protocol.load_adapter(
        "opentrons_flex_96_tiprack_adapter",
        location="C2",
        namespace="opentrons",
        version=1,
    )

    # Load Labware:
    tip_rack_1 = protocol.load_labware(
        "opentrons_flex_96_tiprack_50ul",
        location="B1",
        namespace="opentrons",
        version=1,
    )
    well_plate_1 = protocol.load_labware(
        "biorad_96_wellplate_200ul_pcr",
        location="D1",
        namespace="opentrons",
        version=3,
    )
    well_plate_2 = protocol.load_labware(
        "biorad_96_wellplate_200ul_pcr",
        location="D2",
        label="Bio-Rad 96 Well Plate 200 µL PCR (1)",
        namespace="opentrons",
        version=3,
    )
    well_plate_3 = protocol.load_labware(
        "biorad_96_wellplate_200ul_pcr",
        location="D3",
        label="Bio-Rad 96 Well Plate 200 µL PCR (2)",
        namespace="opentrons",
        version=3,
    )

    # Load Pipettes:
    pipette = protocol.load_instrument("flex_96channel_1000", tip_racks=[tip_rack_1])

    # Load Trash Bins:
    trash_bin_1 = protocol.load_trash_bin("A3")

    # PROTOCOL STEPS

    # Step 1:
    pipette.configure_nozzle_layout(protocol_api.COLUMN, start="A12")
    pipette.pick_up_tip(location=tip_rack_1)
    pipette.move_to(well_plate_2["A12"].top(z=2))
    pipette.prepare_to_aspirate()
    pipette.move_to(well_plate_2["A12"].top(z=2))
    pipette.move_to(well_plate_2["A12"].bottom(z=2), speed=35)
    pipette.aspirate(volume=20, flow_rate=200)
    pipette.move_to(well_plate_2["A12"].top(z=2), speed=35)
    pipette.move_to(well_plate_3["A1"].top(z=2))
    pipette.move_to(well_plate_3["A1"].bottom(z=2), speed=35)
    pipette.dispense(volume=10, flow_rate=200, push_out=0)
    pipette.move_to(well_plate_3["A1"].top(z=2), speed=35)
    pipette.move_to(well_plate_3["A2"].top(z=2))
    pipette.move_to(well_plate_3["A2"].bottom(z=2), speed=35)
    pipette.dispense(volume=10, flow_rate=200, push_out=20)
    pipette.move_to(well_plate_3["A2"].top(z=2), speed=35)
    pipette.drop_tip()

    # Step 2:
    pipette.pick_up_tip(location=tip_rack_1)
    pipette.move_to(well_plate_1["A11"].top(z=2))
    pipette.prepare_to_aspirate()
    pipette.move_to(well_plate_1["A11"].top(z=2))
    pipette.move_to(well_plate_1["A11"].bottom(z=2), speed=35)
    pipette.aspirate(volume=10, flow_rate=200)
    pipette.move_to(well_plate_1["A11"].top(z=2), speed=35)
    pipette.move_to(well_plate_1["A12"].top(z=2))
    pipette.move_to(well_plate_1["A12"].top(z=2))
    pipette.move_to(well_plate_1["A12"].bottom(z=2), speed=35)
    pipette.aspirate(volume=10, flow_rate=200)
    pipette.move_to(well_plate_1["A12"].top(z=2), speed=35)
    pipette.move_to(well_plate_2["A12"].top(z=2))
    pipette.move_to(well_plate_2["A12"].top(z=2), speed=35)
    pipette.move_to(well_plate_2["A12"].top(z=2))
    pipette.move_to(well_plate_2["A12"].bottom(z=2), speed=35)
    pipette.dispense(volume=20, flow_rate=200, push_out=20)
    pipette.drop_tip()

DESIGNER_APPLICATION = """{"robot":{"model":"OT-3 Standard"},"designerApplication":{"name":"opentrons/protocol-designer","version":"8.5.0","data":{"pipetteTiprackAssignments":{"5eaf777b-4a61-4f0d-8db8-fe13a1702b85":["opentrons/opentrons_flex_96_tiprack_50ul/1"]},"dismissedWarnings":{"form":[],"timeline":[]},"ingredients":{},"ingredLocations":{"d48d151b-f152-41aa-9afc-c1ed064944c9:opentrons/biorad_96_wellplate_200ul_pcr/3":{},"88ff11e7-1fbe-4b41-8d6f-6f382e908c7a:opentrons/biorad_96_wellplate_200ul_pcr/3":{}},"savedStepForms":{"__INITIAL_DECK_SETUP_STEP__":{"stepType":"manualIntervention","id":"__INITIAL_DECK_SETUP_STEP__","labwareLocationUpdate":{"ba8948ad-31ad-4d49-a7af-e3574f673cc0:opentrons/opentrons_flex_96_tiprack_adapter/1":"C2","daaf4f71-64a8-4818-9835-9f9ac3fc5257:opentrons/opentrons_flex_96_tiprack_50ul/1":"B1","27c7ec3b-23af-42c7-99f8-02464199a278:opentrons/biorad_96_wellplate_200ul_pcr/3":"D1","d48d151b-f152-41aa-9afc-c1ed064944c9:opentrons/biorad_96_wellplate_200ul_pcr/3":"D2","88ff11e7-1fbe-4b41-8d6f-6f382e908c7a:opentrons/biorad_96_wellplate_200ul_pcr/3":"D3"},"pipetteLocationUpdate":{"5eaf777b-4a61-4f0d-8db8-fe13a1702b85":"left"},"moduleLocationUpdate":{},"trashBinLocationUpdate":{"bf16685f-4659-42fe-9dea-94966b47c2b0:trashBin":"cutoutA3"},"wasteChuteLocationUpdate":{},"stagingAreaLocationUpdate":{},"gripperLocationUpdate":{}},"7cb6a722-6e91-47fa-a09a-5d189550f99e":{"id":"7cb6a722-6e91-47fa-a09a-5d189550f99e","stepType":"moveLiquid","stepName":"transfer","stepDetails":"","stepNumber":0,"aspirate_airGap_checkbox":false,"aspirate_airGap_volume":"","aspirate_delay_checkbox":false,"aspirate_delay_mmFromBottom":null,"aspirate_delay_seconds":"1","aspirate_flowRate":"200","aspirate_labware":"d48d151b-f152-41aa-9afc-c1ed064944c9:opentrons/biorad_96_wellplate_200ul_pcr/3","aspirate_mix_checkbox":false,"aspirate_mix_times":"","aspirate_mix_volume":"","aspirate_mmFromBottom":2,"aspirate_position_reference":"well-bottom","aspirate_retract_delay_seconds":"","aspirate_retract_mmFromBottom":2,"aspirate_retract_speed":"35","aspirate_retract_x_position":0,"aspirate_retract_y_position":0,"aspirate_retract_position_reference":"well-top","aspirate_submerge_delay_seconds":"","aspirate_submerge_speed":"35","aspirate_submerge_mmFromBottom":2,"aspirate_submerge_x_position":0,"aspirate_submerge_y_position":0,"aspirate_submerge_position_reference":"well-top","aspirate_touchTip_checkbox":false,"aspirate_touchTip_mmFromTop":-1,"aspirate_touchTip_speed":"30","aspirate_touchTip_mmFromEdge":"0.5","aspirate_wellOrder_first":"t2b","aspirate_wellOrder_second":"l2r","aspirate_wells_grouped":false,"aspirate_wells":["A12"],"aspirate_x_position":0,"aspirate_y_position":0,"blowout_checkbox":false,"blowout_flowRate":"null","blowout_location":null,"blowout_z_offset":0,"changeTip":"always","conditioning_checkbox":false,"conditioning_volume":"","dispense_airGap_checkbox":false,"dispense_airGap_volume":"","dispense_delay_checkbox":false,"dispense_delay_mmFromBottom":null,"dispense_delay_seconds":"1","dispense_flowRate":"200","dispense_labware":"88ff11e7-1fbe-4b41-8d6f-6f382e908c7a:opentrons/biorad_96_wellplate_200ul_pcr/3","dispense_mix_checkbox":false,"dispense_mix_times":null,"dispense_mix_volume":null,"dispense_mmFromBottom":2,"dispense_position_reference":"well-bottom","dispense_retract_delay_seconds":"","dispense_retract_mmFromBottom":2,"dispense_retract_speed":"35","dispense_retract_x_position":0,"dispense_retract_y_position":0,"dispense_retract_position_reference":"well-top","dispense_submerge_delay_seconds":"","dispense_submerge_speed":"35","dispense_submerge_mmFromBottom":2,"dispense_submerge_x_position":0,"dispense_submerge_y_position":0,"dispense_submerge_position_reference":"well-top","dispense_touchTip_checkbox":false,"dispense_touchTip_mmFromTop":-1,"dispense_touchTip_speed":"30","dispense_touchTip_mmFromEdge":"0.5","dispense_wellOrder_first":"t2b","dispense_wellOrder_second":"l2r","dispense_wells":["A1","A2"],"dispense_x_position":0,"dispense_y_position":0,"disposalVolume_checkbox":false,"disposalVolume_volume":"","dropTip_location":"bf16685f-4659-42fe-9dea-94966b47c2b0:trashBin","liquidClassesSupported":true,"liquidClass":"none","nozzles":"COLUMN","path":"multiDispense","pipette":"5eaf777b-4a61-4f0d-8db8-fe13a1702b85","preWetTip":false,"pushOut_checkbox":true,"pushOut_volume":"20","tipRack":"opentrons/opentrons_flex_96_tiprack_50ul/1","volume":"10"},"65dbc399-7e96-409f-870b-9c3dcfacc067":{"id":"65dbc399-7e96-409f-870b-9c3dcfacc067","stepType":"moveLiquid","stepName":"transfer","stepDetails":"","stepNumber":0,"aspirate_airGap_checkbox":false,"aspirate_airGap_volume":"","aspirate_delay_checkbox":false,"aspirate_delay_mmFromBottom":null,"aspirate_delay_seconds":"1","aspirate_flowRate":"200","aspirate_labware":"27c7ec3b-23af-42c7-99f8-02464199a278:opentrons/biorad_96_wellplate_200ul_pcr/3","aspirate_mix_checkbox":false,"aspirate_mix_times":null,"aspirate_mix_volume":null,"aspirate_mmFromBottom":2,"aspirate_position_reference":"well-bottom","aspirate_retract_delay_seconds":"","aspirate_retract_mmFromBottom":2,"aspirate_retract_speed":"35","aspirate_retract_x_position":0,"aspirate_retract_y_position":0,"aspirate_retract_position_reference":"well-top","aspirate_submerge_delay_seconds":"","aspirate_submerge_speed":"35","aspirate_submerge_mmFromBottom":2,"aspirate_submerge_x_position":0,"aspirate_submerge_y_position":0,"aspirate_submerge_position_reference":"well-top","aspirate_touchTip_checkbox":false,"aspirate_touchTip_mmFromTop":-1,"aspirate_touchTip_speed":"30","aspirate_touchTip_mmFromEdge":"0.5","aspirate_wellOrder_first":"t2b","aspirate_wellOrder_second":"l2r","aspirate_wells_grouped":false,"aspirate_wells":["A11","A12"],"aspirate_x_position":0,"aspirate_y_position":0,"blowout_checkbox":false,"blowout_flowRate":"null","blowout_location":null,"blowout_z_offset":0,"changeTip":"always","conditioning_checkbox":false,"conditioning_volume":"","dispense_airGap_checkbox":false,"dispense_airGap_volume":"","dispense_delay_checkbox":false,"dispense_delay_mmFromBottom":null,"dispense_delay_seconds":"1","dispense_flowRate":"200","dispense_labware":"d48d151b-f152-41aa-9afc-c1ed064944c9:opentrons/biorad_96_wellplate_200ul_pcr/3","dispense_mix_checkbox":false,"dispense_mix_times":"","dispense_mix_volume":"","dispense_mmFromBottom":2,"dispense_position_reference":"well-bottom","dispense_retract_delay_seconds":"","dispense_retract_mmFromBottom":2,"dispense_retract_speed":"35","dispense_retract_x_position":0,"dispense_retract_y_position":0,"dispense_retract_position_reference":"well-top","dispense_submerge_delay_seconds":"","dispense_submerge_speed":"35","dispense_submerge_mmFromBottom":2,"dispense_submerge_x_position":0,"dispense_submerge_y_position":0,"dispense_submerge_position_reference":"well-top","dispense_touchTip_checkbox":false,"dispense_touchTip_mmFromTop":-1,"dispense_touchTip_speed":"30","dispense_touchTip_mmFromEdge":"0.5","dispense_wellOrder_first":"t2b","dispense_wellOrder_second":"l2r","dispense_wells":["A12"],"dispense_x_position":0,"dispense_y_position":0,"disposalVolume_checkbox":false,"disposalVolume_volume":"","dropTip_location":"bf16685f-4659-42fe-9dea-94966b47c2b0:trashBin","liquidClassesSupported":true,"liquidClass":"none","nozzles":"COLUMN","path":"multiAspirate","pipette":"5eaf777b-4a61-4f0d-8db8-fe13a1702b85","preWetTip":false,"pushOut_checkbox":true,"pushOut_volume":"20","tipRack":"opentrons/opentrons_flex_96_tiprack_50ul/1","volume":"10"}},"orderedStepIds":["7cb6a722-6e91-47fa-a09a-5d189550f99e","65dbc399-7e96-409f-870b-9c3dcfacc067"],"pipettes":{"5eaf777b-4a61-4f0d-8db8-fe13a1702b85":{"pipetteName":"p1000_96"}},"modules":{},"labware":{"ba8948ad-31ad-4d49-a7af-e3574f673cc0:opentrons/opentrons_flex_96_tiprack_adapter/1":{"displayName":"Opentrons Flex 96 Tip Rack Adapter","labwareDefURI":"opentrons/opentrons_flex_96_tiprack_adapter/1"},"daaf4f71-64a8-4818-9835-9f9ac3fc5257:opentrons/opentrons_flex_96_tiprack_50ul/1":{"displayName":"Opentrons Flex 96 Tip Rack 50 µL","labwareDefURI":"opentrons/opentrons_flex_96_tiprack_50ul/1"},"27c7ec3b-23af-42c7-99f8-02464199a278:opentrons/biorad_96_wellplate_200ul_pcr/3":{"displayName":"Bio-Rad 96 Well Plate 200 µL PCR","labwareDefURI":"opentrons/biorad_96_wellplate_200ul_pcr/3"},"d48d151b-f152-41aa-9afc-c1ed064944c9:opentrons/biorad_96_wellplate_200ul_pcr/3":{"displayName":"Bio-Rad 96 Well Plate 200 µL PCR (1)","labwareDefURI":"opentrons/biorad_96_wellplate_200ul_pcr/3"},"88ff11e7-1fbe-4b41-8d6f-6f382e908c7a:opentrons/biorad_96_wellplate_200ul_pcr/3":{"displayName":"Bio-Rad 96 Well Plate 200 µL PCR (2)","labwareDefURI":"opentrons/biorad_96_wellplate_200ul_pcr/3"}}}},"metadata":{"protocolName":"","author":"","description":"","source":"Protocol Designer","created":1749742113865,"lastModified":1749743223771}}"""
```

## Changelog

- check if nozzles in step args

## Risk assessment

low
