### PR TITLE
feat(protocol-designer): wire up load liquid class commands in file creator

### DIFF
--- a/protocol-designer/src/file-data/selectors/fileCreator.ts
+++ b/protocol-designer/src/file-data/selectors/fileCreator.ts
@@ -142,7 +142,8 @@ export const createJSONFile: Selector<ProtocolFile> = createSelector(
       labwareEntities,
       labwareNicknamesById,
       liquidEntities,
-      ingredLocations
+      ingredLocations,
+      savedStepForms
     )
 
     const name = fileMetadata.protocolName || 'untitled'

--- a/protocol-designer/src/file-data/selectors/utils.ts
+++ b/protocol-designer/src/file-data/selectors/utils.ts
@@ -8,6 +8,7 @@ import {
   uuid,
 } from '@opentrons/step-generation'
 
+import { getLoadLiquidClassCommands } from '../../load-file/migration/utils/getLoadLiquidClassCommands'
 import { getLoadLiquidCommands } from '../../load-file/migration/utils/getLoadLiquidCommands'
 
 import type {
@@ -32,6 +33,7 @@ import type {
   TimelineFrame,
 } from '@opentrons/step-generation'
 import type { Labware, Modules, Pipettes } from '../../file-types'
+import type { SavedStepFormState } from '../../step-forms/reducers'
 
 interface MappedPipettes {
   [pipetteId: string]: { name: PipetteName }
@@ -44,7 +46,8 @@ export const getLoadCommands = (
   labwareEntities: LabwareEntities,
   labwareNicknamesById: Record<string, string>,
   liquidEntities: LiquidEntities,
-  ingredLocations: LabwareLiquidState
+  ingredLocations: LabwareLiquidState,
+  savedStepForms: SavedStepFormState
 ): CreateCommand[] => {
   const pipettes: MappedPipettes = mapValues(
     initialRobotState.pipettes,
@@ -178,6 +181,11 @@ export const getLoadCommands = (
     ingredLocations
   )
 
+  const loadLiquidClassCommands = getLoadLiquidClassCommands(
+    pipetteEntities,
+    savedStepForms
+  )
+
   const loadModuleCommands = map(
     initialRobotState.modules,
     (
@@ -206,6 +214,7 @@ export const getLoadCommands = (
     ...loadAdapterCommands,
     ...loadLabwareCommands,
     ...loadLiquidCommands,
+    ...loadLiquidClassCommands,
   ]
 }
 

--- a/protocol-designer/src/load-file/migration/utils/__tests__/getLoadLiquidClassCommands.test.ts
+++ b/protocol-designer/src/load-file/migration/utils/__tests__/getLoadLiquidClassCommands.test.ts
@@ -1,0 +1,198 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { getAllLiquidClassDefs } from '@opentrons/shared-data'
+
+import { getLoadLiquidClassCommands } from '../getLoadLiquidClassCommands'
+
+import type { LiquidClass } from '@opentrons/shared-data'
+import type { PipetteEntities } from '@opentrons/step-generation'
+import type { SavedStepFormState } from '../../../../step-forms/reducers'
+
+vi.mock('@opentrons/shared-data', async () => {
+  const actual = await vi.importActual('@opentrons/shared-data')
+  return {
+    ...actual,
+    getAllLiquidClassDefs: vi.fn(),
+  }
+})
+
+const MOCK_PIPETTE_ENTITIES = ({
+  mockPipette1: {
+    spec: {
+      channels: 1,
+      liquids: { default: { maxVolume: 1000 } },
+    },
+  },
+} as unknown) as PipetteEntities
+
+const MOCK_SAVED_STEP_FORMS = ({
+  step0: {
+    pipette: 'mockPipette1',
+    liquidClass: 'mockLiquidClass1',
+    tipRack: 'mockTipRack1',
+    stepType: 'moveLiquid',
+    id: 'step0',
+  },
+  step1: {
+    pipette: 'mockPipette1',
+    liquidClass: 'mockLiquidClass2',
+    tipRack: 'mockTipRack3',
+    stepType: 'mix',
+    id: 'step1',
+  },
+} as unknown) as SavedStepFormState
+
+const mockLiquidClasses = {
+  mockLiquidClass1: {
+    byPipette: [
+      {
+        pipetteModel: 'flex_1channel_1000',
+        byTipType: [
+          {
+            tiprack: 'mockTipRack1',
+          },
+          {
+            tiprack: 'mockTipRack2',
+          },
+        ],
+      },
+    ],
+  },
+  mockLiquidClass2: {
+    byPipette: [
+      {
+        pipetteModel: 'flex_1channel_1000',
+        byTipType: [
+          {
+            tiprack: 'mockTipRack3',
+          },
+          {
+            tiprack: 'mockTipRack4',
+          },
+        ],
+      },
+    ],
+  },
+}
+
+describe('getLoadLiquidClassCommands', () => {
+  beforeEach(() => {
+    vi.mocked(getAllLiquidClassDefs).mockReturnValue(
+      (mockLiquidClasses as unknown) as Record<string, LiquidClass>
+    )
+  })
+
+  it('returns load commands for each liquid class in the step forms', () => {
+    const result = getLoadLiquidClassCommands(
+      MOCK_PIPETTE_ENTITIES,
+      MOCK_SAVED_STEP_FORMS
+    )
+    expect(result).toEqual([
+      {
+        key: expect.any(String),
+        commandType: 'loadLiquidClass' as const,
+        params: {
+          liquidClassRecord: {
+            tiprack: 'mockTipRack1',
+            liquidClassName: 'mockLiquidClass1',
+            pipetteModel: 'flex_1channel_1000',
+          },
+        },
+      },
+      {
+        key: expect.any(String),
+        commandType: 'loadLiquidClass' as const,
+        params: {
+          liquidClassRecord: {
+            tiprack: 'mockTipRack3',
+            liquidClassName: 'mockLiquidClass2',
+            pipetteModel: 'flex_1channel_1000',
+          },
+        },
+      },
+    ])
+  })
+
+  it('returns load commands for only unique liquid classes in the step forms', () => {
+    const result = getLoadLiquidClassCommands(MOCK_PIPETTE_ENTITIES, {
+      ...MOCK_SAVED_STEP_FORMS,
+      step2: {
+        stepType: 'moveLiquid',
+        id: 'step2',
+        pipette: 'mockPipette1',
+        liquidClass: 'mockLiquidClass2',
+        tipRack: 'mockTipRack3',
+      },
+    })
+    expect(result).toEqual([
+      {
+        key: expect.any(String),
+        commandType: 'loadLiquidClass' as const,
+        params: {
+          liquidClassRecord: {
+            tiprack: 'mockTipRack1',
+            liquidClassName: 'mockLiquidClass1',
+            pipetteModel: 'flex_1channel_1000',
+          },
+        },
+      },
+      {
+        key: expect.any(String),
+        commandType: 'loadLiquidClass' as const,
+        params: {
+          liquidClassRecord: {
+            tiprack: 'mockTipRack3',
+            liquidClassName: 'mockLiquidClass2',
+            pipetteModel: 'flex_1channel_1000',
+          },
+        },
+      },
+    ])
+  })
+
+  it('returns does not load liquid classes if the liquid class does not contain a pipette match', () => {
+    const result = getLoadLiquidClassCommands(MOCK_PIPETTE_ENTITIES, {
+      ...MOCK_SAVED_STEP_FORMS,
+      step1: {
+        ...MOCK_SAVED_STEP_FORMS.step1,
+        pipette: 'badPipette',
+      },
+    })
+    expect(result).toEqual([
+      {
+        key: expect.any(String),
+        commandType: 'loadLiquidClass' as const,
+        params: {
+          liquidClassRecord: {
+            tiprack: 'mockTipRack1',
+            liquidClassName: 'mockLiquidClass1',
+            pipetteModel: 'flex_1channel_1000',
+          },
+        },
+      },
+    ])
+  })
+
+  it('returns does not load liquid classes if the liquid class does not contain a tiprack match', () => {
+    const result = getLoadLiquidClassCommands(MOCK_PIPETTE_ENTITIES, {
+      ...MOCK_SAVED_STEP_FORMS,
+      step1: {
+        ...MOCK_SAVED_STEP_FORMS.step1,
+        tipRack: 'badTipRack',
+      },
+    })
+    expect(result).toEqual([
+      {
+        key: expect.any(String),
+        commandType: 'loadLiquidClass' as const,
+        params: {
+          liquidClassRecord: {
+            tiprack: 'mockTipRack1',
+            liquidClassName: 'mockLiquidClass1',
+            pipetteModel: 'flex_1channel_1000',
+          },
+        },
+      },
+    ])
+  })
+})

--- a/protocol-designer/src/load-file/migration/utils/getLoadLiquidClassCommands.ts
+++ b/protocol-designer/src/load-file/migration/utils/getLoadLiquidClassCommands.ts
@@ -1,0 +1,60 @@
+import {
+  getAllLiquidClassDefs,
+  getFlexNameConversion,
+} from '@opentrons/shared-data'
+
+import { uuid } from '../../../utils'
+
+import type { LoadLiquidClassCreateCommand } from '@opentrons/shared-data'
+import type { PipetteEntities } from '@opentrons/step-generation'
+import type { SavedStepFormState } from '../../../step-forms/reducers'
+
+export const getLoadLiquidClassCommands = (
+  pipetteEntities: PipetteEntities,
+  savedStepForms: SavedStepFormState
+): LoadLiquidClassCreateCommand[] => {
+  const loadedLiquidClasses = new Set<string>()
+  const loadLiquidClassCommands = Object.values(savedStepForms).reduce<
+    LoadLiquidClassCreateCommand[]
+  >((acc, stepForm) => {
+    if ('liquidClass' in stepForm) {
+      const { pipette, liquidClass: rawLiquidClass, tipRack } = stepForm
+      const liquidClass = rawLiquidClass as string
+      const pipetteEntity = pipetteEntities[pipette]
+      if (pipetteEntity == null) {
+        return acc
+      }
+      const { spec: pipetteSpecs } = pipetteEntity
+      const pipetteModel = getFlexNameConversion(pipetteSpecs)
+      const byTipTypeSettings =
+        liquidClass != null
+          ? getAllLiquidClassDefs()
+              [liquidClass]?.byPipette.find(
+                pipetteObject => pipetteObject.pipetteModel === pipetteModel
+              )
+              ?.byTipType.find(({ tiprack }) => tiprack === tipRack)
+          : null
+
+      if (byTipTypeSettings != null && !loadedLiquidClasses.has(liquidClass)) {
+        loadedLiquidClasses.add(liquidClass)
+        return [
+          ...acc,
+          {
+            key: uuid(),
+            commandType: 'loadLiquidClass' as const,
+            params: {
+              liquidClassRecord: {
+                ...byTipTypeSettings,
+                liquidClassName: liquidClass,
+                pipetteModel,
+              },
+            },
+          },
+        ]
+      }
+    }
+    return acc
+  }, [])
+
+  return loadLiquidClassCommands
+}

--- a/protocol-designer/src/load-file/migration/utils/getLoadLiquidClassCommands.ts
+++ b/protocol-designer/src/load-file/migration/utils/getLoadLiquidClassCommands.ts
@@ -26,6 +26,10 @@ export const getLoadLiquidClassCommands = (
       }
       const { spec: pipetteSpecs } = pipetteEntity
       const pipetteModel = getFlexNameConversion(pipetteSpecs)
+
+      // creating a unique string to avoid duplicate loadLiquidClass commands
+      // for the same liquid class, pipette model, and tip rack
+      const uniqueString = `${liquidClass}-${pipetteModel}-${tipRack}`
       const byTipTypeSettings =
         liquidClass != null
           ? getAllLiquidClassDefs()
@@ -35,8 +39,8 @@ export const getLoadLiquidClassCommands = (
               ?.byTipType.find(({ tiprack }) => tiprack === tipRack)
           : null
 
-      if (byTipTypeSettings != null && !loadedLiquidClasses.has(liquidClass)) {
-        loadedLiquidClasses.add(liquidClass)
+      if (byTipTypeSettings != null && !loadedLiquidClasses.has(uniqueString)) {
+        loadedLiquidClasses.add(uniqueString)
         return [
           ...acc,
           {

--- a/protocol-designer/src/pages/ProtocolOverview/ScrubberContainer.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/ScrubberContainer.tsx
@@ -19,6 +19,7 @@ import {
   getInitialDeckSetup,
   getInvariantContext,
   getLiquidEntities,
+  getSavedStepForms,
 } from '../../step-forms/selectors'
 import { getLabwareNicknamesById } from '../../ui/labware/selectors'
 import { uuid } from '../../utils'
@@ -44,6 +45,7 @@ export function ScrubberContainer(): JSX.Element | null {
   const ingredientLocations = useSelector(ingredSelectors.getLiquidsByLabwareId)
   const invariantContext = useSelector(getInvariantContext)
   const initialDeckSetup = useSelector(getInitialDeckSetup)
+  const savedStepForms = useSelector(getSavedStepForms)
 
   if (robotType === OT2_ROBOT_TYPE) {
     return null
@@ -59,7 +61,8 @@ export function ScrubberContainer(): JSX.Element | null {
     labwareEntities,
     labwareNickNames,
     liquidEntities,
-    ingredientLocations
+    ingredientLocations,
+    savedStepForms
   )
   const nonLoadCommands = flatMap(
     robotStateTimeline.timeline,


### PR DESCRIPTION
# Overview


This PR adds load liquid class commands during JSON file creation. Note that we only load liquid classes that are selected in step forms, not necessarily liquid classes that are assigned to liquids in the application. Also, each unique liquid class is only loaded once at most, regardless of how many times it is used in moveLiquid or mix step forms.

Closes AUTH-1381

## Test Plan and Hands on Testing

- create or upload a protocol with some moveLiquid/mix step that use liquid classes
- export JSON and verify the `loadLiquidClass` commands for the utilized liquid classes
- verify that analysis succeeds in the app

## Changelog

- add utility for getting commands for loading unique liquid class records (by liquid class, pipette, and tiprack) based on use in saved step forms (move liquid and mix)
- wire up utility in `fileCreator`
- add tests

## Review requests

see test plan

## Risk assessment

low