### PR TITLE
fix(protocol-designer): remove `updatePatchPathField`

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/PathField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/PathField.tsx
@@ -120,8 +120,6 @@ const getSubtitle = (
 
 export function PathField(props: PathFieldProps): JSX.Element {
   const {
-    aspirate_airGap_checkbox,
-    aspirate_airGap_volume,
     aspirate_wells,
     changeTip,
     dispense_wells,
@@ -138,8 +136,6 @@ export function PathField(props: PathFieldProps): JSX.Element {
   const pipetteEntities = useSelector(stepFormSelectors.getPipetteEntities)
   const disabledPathMap = getDisabledPathMap(
     {
-      aspirate_airGap_checkbox,
-      aspirate_airGap_volume,
       aspirate_wells,
       changeTip,
       dispense_wells,

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.ts
@@ -23,7 +23,6 @@ import {
   getChannels,
   getDefaultWells,
   getMaxDisposalVolumeForMultidispense,
-  volumeInCapacityForMulti,
 } from './utils'
 
 import type { NozzleConfigurationStyle } from '@opentrons/shared-data'
@@ -133,45 +132,6 @@ const wellRatioUpdatesMap = [
   },
 ]
 const wellRatioUpdater = makeConditionalPatchUpdater(wellRatioUpdatesMap)
-export function updatePatchPathField(
-  patch: FormPatch,
-  rawForm: FormData,
-  pipetteEntities: PipetteEntities
-): FormPatch {
-  const { id, stepType, ...stepData } = rawForm
-  const appliedPatch = { ...(stepData as FormPatch), ...patch }
-  const { path, changeTip } = appliedPatch
-
-  if (path == null) {
-    // invalid well ratio - fall back to 'single'
-    return { ...patch, path: 'single' }
-  }
-
-  let pipetteCapacityExceeded = false
-
-  if (
-    appliedPatch.volume != null &&
-    typeof appliedPatch.pipette === 'string' &&
-    appliedPatch.pipette in pipetteEntities
-  ) {
-    pipetteCapacityExceeded = !volumeInCapacityForMulti(
-      // @ts-expect-error(sa, 2021-6-14): appliedPatch is not of type FormData, address in #3161
-      appliedPatch,
-      pipetteEntities
-    )
-  }
-
-  // changeTip value incompatible with next path value
-  const incompatiblePath =
-    (changeTip === 'perSource' && path === 'multiAspirate') ||
-    (changeTip === 'perDest' && path === 'multiDispense')
-
-  if (pipetteCapacityExceeded || incompatiblePath) {
-    return { ...patch, path: 'single' }
-  }
-
-  return patch
-}
 
 const updatePatchOnLabwareChange = (
   patch: FormPatch,
@@ -764,7 +724,6 @@ export function dependentFieldsUpdateMoveLiquid(
     chainPatch =>
       updatePatchOnPipetteChange(chainPatch, rawForm, pipetteEntities),
     chainPatch => updatePatchOnWellRatioChange(chainPatch, rawForm),
-    chainPatch => updatePatchPathField(chainPatch, rawForm, pipetteEntities),
     chainPatch =>
       updatePatchDisposalVolumeFields(chainPatch, rawForm, pipetteEntities),
     chainPatch =>

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/test/moveLiquid.test.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/test/moveLiquid.test.ts
@@ -187,14 +187,9 @@ describe('path should update...', () => {
                 volume: '1',
               }
             )
-            const pathPatch =
-              path === expectedPath ? {} : { path: expectedPath }
 
-            const volumeChangeExpected = { volume, ...pathPatch }
-            const airGapChangeExpected = {
-              aspirate_airGap_volume,
-              ...pathPatch,
-            }
+            const volumeChangeExpected = { volume }
+            const airGapChangeExpected = { aspirate_airGap_volume }
             expect(airGapChange).toMatchObject(airGapChangeExpected)
             expect(volumeChange).toMatchObject(volumeChangeExpected)
           })


### PR DESCRIPTION
# Overview

Here, we remove the `updatePatchPathField` from `dependentFieldsUpdateMoveLiquid`.

#### Context

In the times of single-page step form PD, we wired up a patch during form updates that would reset the path from `multiAspirate` or `multiDispense` to `single` if advanced settings were configured such that multiAspirate or multiDispense are not possible. Here's an example:
- P300 pipette with 300µl tips
- 2x destination wells
- `multiDispense` path
- per-sample volume of 140µl
- aspirate air gap of 30µl **

In this scenario, without air gap (or disposal volume), we can comfortably aspirate 280µl, and dispense 140µl into each of our 2 destinations. However, with air gap, we can no longer accommodate both samples-worth of volume _with_ air gap— this total volume would be 140 + 140 + 30 = 310µl > 300µl tip volume. So, previously, when this air gap was configured such that the tip volume was exceeded and `multiDispense` was not possible, the path would flip back to `single`.

The trouble is that in our new step form design, air gap configuration comes on page 3 of the step form, while the path is configured on page 1! A user would select `multiDispense` on page 1, add an air gap on page 3, save, and not realize the path has flipped back to `single`.

After speaking with the API team, we resolved to remove the patch such that the form always carries the user's selected path regardless of the tip's capacity, and determine the if the form's path is valid for its corresponding step generation command creator (`single` -> `transfer`, `multiAspirate` -> `consolidate`, or `multiDispense` -> `distribute`) in `moveLiquidFormToArgs` (see: `checkedPath`). This is to ensure we don't encounter errors in step generation in `distribute` or `consolidate` if multi-dispense or -aspiration, respectively, or is not possible. The downside is that we generate the Python API method `transfer_with_liquid_class` rather than `distribute_with_liquid_class` or `consolidate_with_liquid_class` in this scenario, but we determined it is the least of all evils at this stage of 8.5.0 development.

In a post-release followup, I will refactor `distribute` and `consolidate` command creator logic to allow non multi-aspiration/dispense behavior so that the most accurate Python is emitted.

Closes AUTH-1987

## Changelog

- remove path patch described above
- remove air gap check in `getDisabledPathMap` implementation in `PathField`

## Risk assessment

lowish