### PR TITLE
refactor(protocol-designer): fix when fields are dirty and update error state

### DIFF
--- a/protocol-designer/src/components/organisms/Alerts/FormAlerts.tsx
+++ b/protocol-designer/src/components/organisms/Alerts/FormAlerts.tsx
@@ -31,6 +31,7 @@ import type { ProfileFormError } from '../../../steplist/formLevel/profileErrors
 import type { MakeAlert } from './types'
 
 interface FormAlertsProps {
+  currentFormIsPresaved: boolean
   showFormErrors: boolean
   focusedField?: StepFieldName | null
   dirtyFields?: StepFieldName[]
@@ -43,7 +44,13 @@ interface WarningType {
 }
 
 function FormAlertsComponent(props: FormAlertsProps): JSX.Element | null {
-  const { showFormErrors, focusedField, dirtyFields, page } = props
+  const {
+    currentFormIsPresaved,
+    showFormErrors,
+    focusedField,
+    dirtyFields,
+    page,
+  } = props
 
   const { t } = useTranslation('alert')
   const dispatch = useDispatch()
@@ -80,6 +87,7 @@ function FormAlertsComponent(props: FormAlertsProps): JSX.Element | null {
     dirtyFields: dirtyFields ?? [],
     errors: formLevelErrorsForUnsavedForm,
     page,
+    currentFormIsPresaved,
     showErrors: showFormErrors,
   })
 

--- a/protocol-designer/src/components/organisms/Alerts/__tests__/FormAlerts.test.tsx
+++ b/protocol-designer/src/components/organisms/Alerts/__tests__/FormAlerts.test.tsx
@@ -42,6 +42,7 @@ describe('FormAlerts', () => {
       focusedField: null,
       dirtyFields: [],
       showFormErrors: false,
+      currentFormIsPresaved: false,
       page: 0,
     }
     vi.mocked(getFormLevelErrorsForUnsavedForm).mockReturnValue([])

--- a/protocol-designer/src/form-types.ts
+++ b/protocol-designer/src/form-types.ts
@@ -307,7 +307,7 @@ export interface HydratedMoveLiquidFormData extends AnnotationFields {
   aspirate_touchTip_mmFromEdge?: number | null
   aspirate_touchTip_mmFromTop?: number | null
   aspirate_touchTip_speed?: number | null
-  aspirate_wells_grouped?: boolean | null
+  aspirate_wells_grouped?: boolean | null //  TODO: deprecate this?
   aspirate_x_position?: number | null
   aspirate_y_position?: number | null
   aspirate_position_reference: PositionReference
@@ -407,7 +407,6 @@ export type HydratedMagnetFormData = AnnotationFields & {
   id: string
   magnetAction: MagnetAction
   moduleId: string
-  stepDetails: string | null
   stepType: 'magnet'
 }
 export interface HydratedTemperatureFormData extends AnnotationFields {

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepFormToolbox.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepFormToolbox.tsx
@@ -45,6 +45,7 @@ import {
   getCurrentFormIsPresaved,
   getDynamicFieldFormErrorsForUnsavedForm,
   getFormLevelErrorsForUnsavedForm,
+  getFormLevelWarningsPerStep,
   getInvariantContext,
   getSavedStepForms,
 } from '../../../../step-forms/selectors'
@@ -169,6 +170,7 @@ export function StepFormToolbox(props: StepFormToolboxProps): JSX.Element {
   const formLevelErrorsForUnsavedForm = useSelector(
     getFormLevelErrorsForUnsavedForm
   )
+
   const dynamicFormLevelErrorsForUnsavedForm = useSelector(
     getDynamicFieldFormErrorsForUnsavedForm
   ).map(error => ({
@@ -198,7 +200,6 @@ export function StepFormToolbox(props: StepFormToolboxProps): JSX.Element {
       return formData[field] !== referenceObjectForField[field]
     }
   )
-
   const moduleId = formData.moduleId
   const enableReadOrInitialization = useAbsorbanceReaderCommandType(
     moduleId as string | null
@@ -233,7 +234,8 @@ export function StepFormToolbox(props: StepFormToolboxProps): JSX.Element {
       ...dynamicFormLevelErrorsForUnsavedForm,
     ],
     page: toolboxStep,
-    showErrors: !currentFormIsPresaved || showFormErrors,
+    currentFormIsPresaved,
+    showErrors: showFormErrors,
   })
   const propsForFields = makeSingleEditFieldProps(
     focusHandlers,
@@ -507,7 +509,8 @@ export function StepFormToolbox(props: StepFormToolboxProps): JSX.Element {
           <FormAlerts
             focusedField={focusedField}
             dirtyFields={dirtyFields}
-            showFormErrors={!currentFormIsPresaved || showFormErrors}
+            currentFormIsPresaved={currentFormIsPresaved}
+            showFormErrors={showFormErrors}
             page={toolboxStep}
           />
           <ToolsComponent

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepFormToolbox.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepFormToolbox.tsx
@@ -45,7 +45,6 @@ import {
   getCurrentFormIsPresaved,
   getDynamicFieldFormErrorsForUnsavedForm,
   getFormLevelErrorsForUnsavedForm,
-  getFormLevelWarningsPerStep,
   getInvariantContext,
   getSavedStepForms,
 } from '../../../../step-forms/selectors'

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepFormToolbox.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepFormToolbox.tsx
@@ -205,9 +205,11 @@ export function StepFormToolbox(props: StepFormToolboxProps): JSX.Element {
     moduleId as string | null
   )
   const [toolboxStep, setToolboxStep] = useState<number>(0)
-  const [showFormErrors, setShowFormErrors] = useState<boolean>(false)
+  //  TODO: refactor this state. We could add it to redux's unsavedForm state
+  //  but its a bit tricky since some forms need to reset it upon field changes
+  //  and not upon pressing "save"
+  const [showFormErrors, setShowFormErrorsInNewField] = useState<boolean>(false)
   const [tab, setTab] = useState<LiquidHandlingTab>('aspirate')
-
   // state used to determine if user has seen advanced settings page (relevant for presaved forms)
   const [
     hasSeenAdvancedSettings,
@@ -366,7 +368,7 @@ export function StepFormToolbox(props: StepFormToolboxProps): JSX.Element {
       dispatch(selectDropdownItem({ selection: null, mode: 'clear' }))
       dispatch(hoverSelection({ id: null, text: null }))
     } else {
-      setShowFormErrors(true)
+      setShowFormErrorsInNewField(true)
       if (tab === 'aspirate' && isDispenseError && !isAspirateError) {
         setTab('dispense')
       }
@@ -392,9 +394,9 @@ export function StepFormToolbox(props: StepFormToolboxProps): JSX.Element {
     } else if (isMultiStepToolbox && toolboxStep < numStepFormPages - 1) {
       if (!isErrorOnCurrentPage) {
         setToolboxStep(prevStep => prevStep + 1)
-        setShowFormErrors(false)
+        setShowFormErrorsInNewField(false)
       } else {
-        setShowFormErrors(true)
+        setShowFormErrorsInNewField(true)
       }
       handleScrollToTop()
     } else {
@@ -474,7 +476,7 @@ export function StepFormToolbox(props: StepFormToolboxProps): JSX.Element {
                 width="100%"
                 onClick={() => {
                   setToolboxStep(currStep => currStep - 1)
-                  setShowFormErrors(false)
+                  setShowFormErrorsInNewField(false)
                   handleScrollToTop()
                 }}
               >
@@ -521,7 +523,7 @@ export function StepFormToolbox(props: StepFormToolboxProps): JSX.Element {
               toolboxStep,
               showFormErrors,
               focusedField,
-              setShowFormErrors,
+              setShowFormErrorsInNewField,
               tab,
               setTab,
             }}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MixTools/__tests__/MixTools.test.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MixTools/__tests__/MixTools.test.tsx
@@ -56,7 +56,7 @@ describe('MixToolFirstStep', () => {
       toolboxStep: 0,
       tab: 'aspirate',
       setTab: vi.fn(),
-      setShowFormErrors: vi.fn(),
+      setShowFormErrorsInNewField: vi.fn(),
     }
     vi.mocked(getLabwareEntities).mockReturnValue({
       labwareId: {

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MixTools/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MixTools/index.tsx
@@ -34,7 +34,7 @@ export function MixTools(
     toolboxStep,
     tab,
     setTab,
-    setShowFormErrors,
+    setShowFormErrorsInNewField,
   } = props
   const pipettes = useSelector(getPipetteEntities)
   const enableReturnTip = useSelector(getEnableReturnTip)
@@ -82,7 +82,7 @@ export function MixTools(
         {enableLiquidClasses && robotType === FLEX_ROBOT_TYPE ? (
           <LiquidClassesStepTools
             propsForFields={propsForFields}
-            setShowFormErrors={setShowFormErrors}
+            setShowFormErrorsInNewField={setShowFormErrorsInNewField}
             formData={formData}
             orderedLiquidClassOptions={orderedSupportedLiquidClassOptions}
             type="mix"

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/LiquidClassesStepTools.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/LiquidClassesStepTools.tsx
@@ -17,14 +17,14 @@ interface LiquidClassesStepToolsProps {
   propsForFields: FieldPropsByName
   formData: FormData
   orderedLiquidClassOptions: LiquidClassOption[]
-  setShowFormErrors?: Dispatch<SetStateAction<boolean>>
+  setShowFormErrorsInNewField?: Dispatch<SetStateAction<boolean>>
   type: 'mix' | 'transfer'
 }
 
 export const LiquidClassesStepTools = ({
   propsForFields,
   formData,
-  setShowFormErrors,
+  setShowFormErrorsInNewField,
   type,
   orderedLiquidClassOptions,
 }: LiquidClassesStepToolsProps): JSX.Element => {
@@ -55,7 +55,7 @@ export const LiquidClassesStepTools = ({
               key={name}
               onChange={(e: ChangeEvent<any>) => {
                 propsForFields.liquidClass.updateValue(e.target.value)
-                setShowFormErrors?.(false)
+                setShowFormErrorsInNewField?.(false)
               }}
               buttonLabel={name}
               buttonValue={value}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/SecondStepsMoveLiquidTools.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/SecondStepsMoveLiquidTools.tsx
@@ -59,7 +59,7 @@ interface SecondStepsMoveLiquidToolsProps {
   formData: FormData
   tab: LiquidHandlingTab
   setTab: Dispatch<SetStateAction<LiquidHandlingTab>>
-  setShowFormErrors?: Dispatch<SetStateAction<boolean>>
+  setShowFormErrorsInNewField?: Dispatch<SetStateAction<boolean>>
 }
 
 export const SecondStepsMoveLiquidTools = ({
@@ -67,7 +67,7 @@ export const SecondStepsMoveLiquidTools = ({
   formData,
   tab,
   setTab,
-  setShowFormErrors,
+  setShowFormErrorsInNewField,
 }: SecondStepsMoveLiquidToolsProps): JSX.Element => {
   const { t, i18n } = useTranslation(['protocol_steps', 'form', 'tooltip'])
   const toolsComponentRef = useRef<HTMLDivElement | null>(null)
@@ -117,7 +117,7 @@ export const SecondStepsMoveLiquidTools = ({
     isActive: tab === 'aspirate',
     onClick: () => {
       setTab('aspirate')
-      setShowFormErrors?.(false)
+      setShowFormErrorsInNewField?.(false)
     },
   }
   const dispenseTab = {
@@ -125,7 +125,7 @@ export const SecondStepsMoveLiquidTools = ({
     isActive: tab === 'dispense',
     onClick: () => {
       setTab('dispense')
-      setShowFormErrors?.(false)
+      setShowFormErrorsInNewField?.(false)
     },
   }
 

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/index.tsx
@@ -16,7 +16,7 @@ export function MoveLiquidTools(props: StepFormProps): JSX.Element {
     toolboxStep,
     propsForFields,
     formData,
-    setShowFormErrors,
+    setShowFormErrorsInNewField,
     tab,
     setTab,
   } = props
@@ -50,7 +50,7 @@ export function MoveLiquidTools(props: StepFormProps): JSX.Element {
               <LiquidClassesStepTools
                 propsForFields={propsForFields}
                 formData={formData}
-                setShowFormErrors={setShowFormErrors}
+                setShowFormErrorsInNewField={setShowFormErrorsInNewField}
                 type="transfer"
                 orderedLiquidClassOptions={orderedSupportedLiquidClassOptions}
               />
@@ -60,7 +60,7 @@ export function MoveLiquidTools(props: StepFormProps): JSX.Element {
                 formData={formData}
                 tab={tab}
                 setTab={setTab}
-                setShowFormErrors={setShowFormErrors}
+                setShowFormErrorsInNewField={setShowFormErrorsInNewField}
               />
             )}
           </>
@@ -72,7 +72,7 @@ export function MoveLiquidTools(props: StepFormProps): JSX.Element {
             formData={formData}
             tab={tab}
             setTab={setTab}
-            setShowFormErrors={setShowFormErrors}
+            setShowFormErrorsInNewField={setShowFormErrorsInNewField}
           />
         )
       default:

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/PauseTools/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/PauseTools/index.tsx
@@ -33,7 +33,7 @@ import type { ChangeEvent } from 'react'
 import type { StepFormProps } from '../../types'
 
 export function PauseTools(props: StepFormProps): JSX.Element {
-  const { propsForFields, setShowFormErrors } = props
+  const { propsForFields, setShowFormErrorsInNewField } = props
 
   const tempModuleLabwareOptions = useSelector(
     uiModuleSelectors.getTemperatureLabwareOptions
@@ -90,7 +90,7 @@ export function PauseTools(props: StepFormProps): JSX.Element {
         <RadioButton
           onChange={(e: ChangeEvent<any>) => {
             propsForFields.pauseAction.updateValue(e.currentTarget.value)
-            setShowFormErrors?.(false)
+            setShowFormErrorsInNewField?.(false)
           }}
           buttonLabel={t(
             'form:step_edit_form.field.pauseAction.options.untilResume'
@@ -102,7 +102,7 @@ export function PauseTools(props: StepFormProps): JSX.Element {
         <RadioButton
           onChange={(e: ChangeEvent<any>) => {
             propsForFields.pauseAction.updateValue(e.currentTarget.value)
-            setShowFormErrors?.(false)
+            setShowFormErrorsInNewField?.(false)
           }}
           buttonLabel={t(
             'form:step_edit_form.field.pauseAction.options.untilTime'
@@ -114,7 +114,7 @@ export function PauseTools(props: StepFormProps): JSX.Element {
         <RadioButton
           onChange={(e: ChangeEvent<any>) => {
             propsForFields.pauseAction.updateValue(e.currentTarget.value)
-            setShowFormErrors?.(false)
+            setShowFormErrorsInNewField?.(false)
           }}
           buttonLabel={t(
             'form:step_edit_form.field.pauseAction.options.untilTemperature'

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/ThermocyclerTools/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/ThermocyclerTools/index.tsx
@@ -24,7 +24,7 @@ export function ThermocyclerTools(props: StepFormProps): JSX.Element {
     toolboxStep,
     showFormErrors = true,
     focusedField,
-    setShowFormErrors,
+    setShowFormErrorsInNewField,
   } = props
   const { t } = useTranslation(['form', 'application'])
   const [contentType, setContentType] = useState<ThermocyclerContentType>(
@@ -47,7 +47,7 @@ export function ThermocyclerTools(props: StepFormProps): JSX.Element {
           onChange={() => {
             setContentType('thermocyclerState')
             propsForFields.thermocyclerFormType.updateValue('thermocyclerState')
-            setShowFormErrors?.(false)
+            setShowFormErrorsInNewField?.(false)
           }}
           isSelected={contentType === 'thermocyclerState'}
         />
@@ -62,7 +62,7 @@ export function ThermocyclerTools(props: StepFormProps): JSX.Element {
             propsForFields.thermocyclerFormType.updateValue(
               'thermocyclerProfile'
             )
-            setShowFormErrors?.(false)
+            setShowFormErrorsInNewField?.(false)
           }}
           isSelected={contentType === 'thermocyclerProfile'}
         />

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/index.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { connect } from 'react-redux'
+import { connect, useSelector } from 'react-redux'
 
 import { useConditionalConfirm } from '@opentrons/components'
 import { getModuleDisplayName } from '@opentrons/shared-data'
@@ -15,7 +15,11 @@ import {
   getHydratedForm,
   selectors as stepFormSelectors,
 } from '../../../../step-forms'
-import { getInvariantContext } from '../../../../step-forms/selectors'
+import {
+  getInvariantContext,
+  getLabwareEntities,
+  getPipetteEntities,
+} from '../../../../step-forms/selectors'
 import { actions } from '../../../../steplist'
 import { actions as stepsActions } from '../../../../ui/steps'
 import { StepFormToolbox } from './StepFormToolbox'
@@ -63,10 +67,19 @@ function StepFormManager(props: StepFormManagerProps): JSX.Element | null {
     saveStepForm,
     invariantContext,
   } = props
+  const pipetteEntities = useSelector(getPipetteEntities)
+  const labwareEntities = useSelector(getLabwareEntities)
   const [focusedField, setFocusedField] = useState<string | null>(null)
   const [dirtyFields, setDirtyFields] = useState<StepFieldName[]>(
-    getDirtyFields(isNewStep, formData)
+    getDirtyFields(
+      isNewStep,
+      formData?.stepType ?? 'unknown step type',
+      pipetteEntities,
+      labwareEntities,
+      formData
+    )
   )
+
   const handleBlur = (fieldName: StepFieldName): void => {
     if (fieldName === focusedField) {
       setFocusedField(null)
@@ -117,6 +130,7 @@ function StepFormManager(props: StepFormManagerProps): JSX.Element | null {
     return null
   }
   const hydratedForm = getHydratedForm(formData, invariantContext)
+
   const focusHandlers = {
     focusedField,
     dirtyFields,

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/types.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/types.ts
@@ -31,7 +31,7 @@ export interface StepFormProps {
   toolboxStep: number
   showFormErrors: boolean
   focusedField?: string | null
-  setShowFormErrors?: Dispatch<SetStateAction<boolean>>
+  setShowFormErrorsInNewField?: Dispatch<SetStateAction<boolean>>
   tab: LiquidHandlingTab
   setTab: Dispatch<SetStateAction<LiquidHandlingTab>>
 }

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/utils.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/utils.ts
@@ -1,6 +1,4 @@
-import { hydrate } from 'react-dom'
 import difference from 'lodash/difference'
-import isEqual from 'lodash/isEqual'
 import startCase from 'lodash/startCase'
 import without from 'lodash/without'
 
@@ -11,11 +9,7 @@ import {
 } from '@opentrons/step-generation'
 
 import { i18n } from '../../../../assets/localization'
-import {
-  ABSORBANCE_READER_INITIALIZE_MODE_SINGLE,
-  PAUSE_UNTIL_TEMP,
-  PAUSE_UNTIL_TIME,
-} from '../../../../constants'
+import { PAUSE_UNTIL_TEMP, PAUSE_UNTIL_TIME } from '../../../../constants'
 import { PROFILE_CYCLE } from '../../../../form-types'
 import {
   getDefaultsForStepType,
@@ -34,7 +28,6 @@ import type {
   PathOption,
   ProfileItem,
   StepFieldName,
-  StepIdType,
   StepType,
 } from '../../../../form-types'
 import type { FormError } from '../../../../steplist/formLevel'
@@ -116,7 +109,7 @@ export const getDirtyFields = (
           setHeaterShakerTemperature,
           targetHeaterShakerTemperature,
         } = formData
-        let heaterShakerDirtyFields = ['moduleId']
+        const heaterShakerDirtyFields = ['moduleId']
         if (heaterShakerSetTimer && heaterShakerTimer == null) {
           heaterShakerDirtyFields.push('heaterShakerTimer')
         }
@@ -134,7 +127,7 @@ export const getDirtyFields = (
       }
       case 'magnet': {
         const { engageHeight, magnetAction } = formData
-        let magnetDirtyFields = ['moduleId']
+        const magnetDirtyFields = ['moduleId']
         if (magnetAction === 'engage' && engageHeight == null) {
           magnetDirtyFields.push('engageHeight')
         }
@@ -143,7 +136,7 @@ export const getDirtyFields = (
       }
       case 'temperature': {
         const { setTemperature, targetTemperature } = formData
-        let temperatureDirtyFields = ['moduleId']
+        const temperatureDirtyFields = ['moduleId']
         if (setTemperature === 'true' && targetTemperature == null) {
           temperatureDirtyFields.push('targetTemperature')
         }
@@ -152,7 +145,7 @@ export const getDirtyFields = (
       }
       case 'pause': {
         const { pauseAction } = formData
-        let pauseDirtyFields = []
+        const pauseDirtyFields = []
         if (pauseAction === PAUSE_UNTIL_TEMP) {
           pauseDirtyFields.push('pauseTime')
           pauseDirtyFields.push('pauseTemperature')
@@ -165,7 +158,7 @@ export const getDirtyFields = (
       }
       case 'absorbanceReader': {
         const { absorbanceReaderFormType } = formData
-        let absorbanceReaderDirtyFields = ['moduleId']
+        const absorbanceReaderDirtyFields = ['moduleId']
         if (absorbanceReaderFormType == null) {
           absorbanceReaderDirtyFields.push('absorbanceReaderFormType')
         } else if (absorbanceReaderFormType === 'absorbanceReaderLid') {
@@ -188,7 +181,7 @@ export const getDirtyFields = (
           lidTargetTemp,
           thermocyclerFormType,
         } = formData
-        let themocyclerDirtyFields = ['moduleId']
+        const themocyclerDirtyFields = ['moduleId']
         if (blockIsActive && blockTargetTemp == null) {
           themocyclerDirtyFields.push('blockTargetTemp')
         }
@@ -222,7 +215,7 @@ export const getDirtyFields = (
           pushOut_volume,
           pushOut_checkbox,
         } = formData
-        let mixDirtyFields = [
+        const mixDirtyFields = [
           'pipette',
           'tipRack',
           'volume',
@@ -287,7 +280,7 @@ export const getDirtyFields = (
           conditioning_checkbox,
           conditioning_volume,
         } = formData
-        let moveLiquidDirtyFields = [
+        const moveLiquidDirtyFields = [
           'pipette',
           'tipRack',
           'volume',

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/utils.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/utils.ts
@@ -1,3 +1,4 @@
+import { hydrate } from 'react-dom'
 import difference from 'lodash/difference'
 import isEqual from 'lodash/isEqual'
 import startCase from 'lodash/startCase'
@@ -10,6 +11,11 @@ import {
 } from '@opentrons/step-generation'
 
 import { i18n } from '../../../../assets/localization'
+import {
+  ABSORBANCE_READER_INITIALIZE_MODE_SINGLE,
+  PAUSE_UNTIL_TEMP,
+  PAUSE_UNTIL_TIME,
+} from '../../../../constants'
 import { PROFILE_CYCLE } from '../../../../form-types'
 import {
   getDefaultsForStepType,
@@ -17,13 +23,18 @@ import {
 } from '../../../../steplist/formLevel'
 
 import type { DropdownOption } from '@opentrons/components'
-import type { PipetteEntity } from '@opentrons/step-generation'
+import type {
+  LabwareEntities,
+  PipetteEntities,
+  PipetteEntity,
+} from '@opentrons/step-generation'
 import type {
   FormData,
   HydratedFormData,
   PathOption,
   ProfileItem,
   StepFieldName,
+  StepIdType,
   StepType,
 } from '../../../../form-types'
 import type { FormError } from '../../../../steplist/formLevel'
@@ -80,33 +91,311 @@ export function getBlowoutLocationOptionsForForm(args: {
 // TODO: type fieldNames, don't use `string`
 export const getDirtyFields = (
   isNewStep: boolean,
+  stepType: string,
+  pipetteEntities: PipetteEntities,
+  labwareEntities: LabwareEntities,
   formData?: FormData | null
 ): string[] => {
-  let dirtyFields = []
+  let dirtyFields: string[] = []
 
-  if (formData == null) {
+  if (formData == null || isNewStep) {
     return []
-  }
-
-  if (!isNewStep) {
-    dirtyFields = Object.keys(formData)
   } else {
-    const data = formData
-    // new step, but may have auto-populated fields.
-    // "Dirty" any fields that differ from default new form values
-    const defaultFormData = getDefaultsForStepType(formData.stepType)
-    dirtyFields = Object.keys(defaultFormData).reduce(
-      (acc: string[], fieldName: StepFieldName) => {
-        const currentValue = data[fieldName]
-        const initialValue = defaultFormData[fieldName]
-        return isEqual(currentValue, initialValue) ? acc : [...acc, fieldName]
-      },
-      []
-    )
+    switch (formData.stepType) {
+      case 'moveLabware':
+      case 'comment': {
+        dirtyFields = Object.keys(formData)
+        break
+      }
+      case 'heaterShaker': {
+        const {
+          heaterShakerSetTimer,
+          heaterShakerTimer,
+          setShake,
+          targetSpeed,
+          setHeaterShakerTemperature,
+          targetHeaterShakerTemperature,
+        } = formData
+        let heaterShakerDirtyFields = ['moduleId']
+        if (heaterShakerSetTimer && heaterShakerTimer == null) {
+          heaterShakerDirtyFields.push('heaterShakerTimer')
+        }
+        if (setShake && targetSpeed == null) {
+          heaterShakerDirtyFields.push('targetSpeed')
+        }
+        if (
+          setHeaterShakerTemperature &&
+          targetHeaterShakerTemperature == null
+        ) {
+          heaterShakerDirtyFields.push('targetHeaterShakerTemperature')
+        }
+        dirtyFields = heaterShakerDirtyFields
+        break
+      }
+      case 'magnet': {
+        const { engageHeight, magnetAction } = formData
+        let magnetDirtyFields = ['moduleId']
+        if (magnetAction === 'engage' && engageHeight == null) {
+          magnetDirtyFields.push('engageHeight')
+        }
+        dirtyFields = magnetDirtyFields
+        break
+      }
+      case 'temperature': {
+        const { setTemperature, targetTemperature } = formData
+        let temperatureDirtyFields = ['moduleId']
+        if (setTemperature === 'true' && targetTemperature == null) {
+          temperatureDirtyFields.push('targetTemperature')
+        }
+        dirtyFields = temperatureDirtyFields
+        break
+      }
+      case 'pause': {
+        const { pauseAction } = formData
+        let pauseDirtyFields = []
+        if (pauseAction === PAUSE_UNTIL_TEMP) {
+          pauseDirtyFields.push('pauseTime')
+          pauseDirtyFields.push('pauseTemperature')
+          pauseDirtyFields.push('moduleId')
+        } else if (pauseAction === PAUSE_UNTIL_TIME) {
+          pauseDirtyFields.push('pauseTime')
+        }
+        dirtyFields = pauseDirtyFields
+        break
+      }
+      case 'absorbanceReader': {
+        const { absorbanceReaderFormType } = formData
+        let absorbanceReaderDirtyFields = ['moduleId']
+        if (absorbanceReaderFormType == null) {
+          absorbanceReaderDirtyFields.push('absorbanceReaderFormType')
+        } else if (absorbanceReaderFormType === 'absorbanceReaderLid') {
+          absorbanceReaderDirtyFields.push('lidOpen')
+        } else if (absorbanceReaderFormType === 'absorbanceReaderRead') {
+          absorbanceReaderDirtyFields.push('fileName')
+        }
+        dirtyFields = absorbanceReaderDirtyFields
+        break
+      }
+      case 'thermocycler': {
+        const {
+          blockTargetTemp,
+          lidIsActiveHold,
+          lidTargetTempHold,
+          lidIsActive,
+          blockTargetTempHold,
+          blockIsActive,
+          blockIsActiveHold,
+          lidTargetTemp,
+          thermocyclerFormType,
+        } = formData
+        let themocyclerDirtyFields = ['moduleId']
+        if (blockIsActive && blockTargetTemp == null) {
+          themocyclerDirtyFields.push('blockTargetTemp')
+        }
+        if (lidIsActive && lidTargetTemp == null) {
+          themocyclerDirtyFields.push('lidTargetTemp')
+        }
+        if (thermocyclerFormType === 'thermocyclerProfile') {
+          themocyclerDirtyFields.push('profileVolume')
+          themocyclerDirtyFields.push('profileTargetLidTemp')
+          if (blockIsActiveHold && blockTargetTempHold == null) {
+            themocyclerDirtyFields.push('blockTargetTempHold')
+          }
+          if (lidIsActiveHold && lidTargetTempHold == null) {
+            themocyclerDirtyFields.push('lidTargetTempHold')
+          }
+        }
+        dirtyFields = themocyclerDirtyFields
+        break
+      }
+      case 'mix': {
+        const {
+          pipette,
+          aspirate_delay_checkbox,
+          dispense_delay_checkbox,
+          blowout_location,
+          blowout_checkbox,
+          aspirate_delay_seconds,
+          dispense_delay_seconds,
+          mix_touchTip_checkbox,
+          mix_touchTip_mmFromTop,
+          pushOut_volume,
+          pushOut_checkbox,
+        } = formData
+        let mixDirtyFields = [
+          'pipette',
+          'tipRack',
+          'volume',
+          'wells',
+          'dropTip_location',
+          'times',
+          'labware',
+          'changeTip',
+        ]
+        if (pipetteEntities[pipette].spec.channels > 1) {
+          mixDirtyFields.push('nozzles')
+        }
+        if (aspirate_delay_checkbox && aspirate_delay_seconds == null) {
+          mixDirtyFields.push('aspirate_delay_seconds')
+        }
+        if (blowout_checkbox && blowout_location == null) {
+          mixDirtyFields.push('blowout_location')
+        }
+        if (dispense_delay_checkbox && dispense_delay_seconds == null) {
+          mixDirtyFields.push('dispense_delay_seconds')
+        }
+        if (mix_touchTip_checkbox && mix_touchTip_mmFromTop == null) {
+          mixDirtyFields.push('mix_touchTip_mmFromTop')
+        }
+        if (pushOut_checkbox && pushOut_volume == null) {
+          mixDirtyFields.push('pushOut_volume')
+        }
+        dirtyFields = mixDirtyFields
+        break
+      }
+      case 'moveLiquid': {
+        const {
+          dispense_labware,
+          pipette,
+          pushOut_checkbox,
+          pushOut_volume,
+          aspirate_mix_checkbox,
+          aspirate_mix_times,
+          aspirate_mix_volume,
+          aspirate_delay_checkbox,
+          aspirate_delay_seconds,
+          aspirate_touchTip_checkbox,
+          aspirate_touchTip_speed,
+          aspirate_touchTip_mmFromEdge,
+          aspirate_airGap_checkbox,
+          aspirate_airGap_volume,
+          dispense_delay_checkbox,
+          dispense_delay_seconds,
+          dispense_mix_checkbox,
+          dispense_mix_times,
+          dispense_mix_volume,
+          blowout_checkbox,
+          blowout_location,
+          blowout_flowRate,
+          dispense_touchTip_checkbox,
+          dispense_touchTip_speed,
+          dispense_touchTip_mmFromEdge,
+          dispense_airGap_checkbox,
+          dispense_airGap_volume,
+          disposalVolume_checkbox,
+          disposalVolume_volume,
+          conditioning_checkbox,
+          conditioning_volume,
+        } = formData
+        let moveLiquidDirtyFields = [
+          'pipette',
+          'tipRack',
+          'volume',
+          'aspirate_wells',
+          'dropTip_location',
+          'dispense_labware',
+          'aspirate_labware',
+          'changeTip',
+          'aspirate_submerge_delay_seconds',
+          'aspirate_submerge_speed',
+          'aspirate_retract_delay_seconds',
+          'aspirate_retract_speed',
+          'dispense_submerge_delay_seconds',
+          'dispense_submerge_speed',
+          'dispense_retract_delay_seconds',
+          'dispense_retract_speed',
+        ]
+        if (
+          dispense_labware != null &&
+          labwareEntities[dispense_labware] != null
+        ) {
+          moveLiquidDirtyFields.push('dispense_wells')
+        }
+        if (pipetteEntities[pipette].spec.channels > 1) {
+          moveLiquidDirtyFields.push('nozzles')
+        }
+        if (pushOut_checkbox && pushOut_volume == null) {
+          moveLiquidDirtyFields.push('pushOut_volume')
+        }
+        if (
+          aspirate_mix_checkbox &&
+          (aspirate_mix_times == null || aspirate_mix_volume == null)
+        ) {
+          moveLiquidDirtyFields.push('aspirate_mix_times')
+          moveLiquidDirtyFields.push('aspirate_mix_volume')
+        }
+        if (aspirate_delay_checkbox && aspirate_delay_seconds == null) {
+          moveLiquidDirtyFields.push('aspirate_delay_seconds')
+        }
+        if (
+          aspirate_touchTip_checkbox &&
+          (aspirate_touchTip_speed == null ||
+            aspirate_touchTip_mmFromEdge == null)
+        ) {
+          moveLiquidDirtyFields.push('aspirate_touchTip_mmFromEdge')
+          moveLiquidDirtyFields.push('aspirate_touchTip_speed')
+        }
+        if (aspirate_airGap_checkbox && aspirate_airGap_volume == null) {
+          moveLiquidDirtyFields.push('aspirate_airGap_volume')
+        }
+        if (dispense_delay_checkbox && dispense_delay_seconds == null) {
+          moveLiquidDirtyFields.push('dispense_delay_seconds')
+        }
+        if (
+          dispense_mix_checkbox &&
+          (dispense_mix_volume == null || dispense_mix_times == null)
+        ) {
+          moveLiquidDirtyFields.push('dispense_mix_volume')
+          moveLiquidDirtyFields.push('dispense_mix_times')
+        }
+        if (
+          blowout_checkbox &&
+          (blowout_location == null || blowout_flowRate == null)
+        ) {
+          moveLiquidDirtyFields.push('blowout_location')
+          moveLiquidDirtyFields.push('blowout_flowRate')
+        }
+        if (
+          dispense_touchTip_checkbox &&
+          (dispense_touchTip_speed == null ||
+            dispense_touchTip_mmFromEdge == null)
+        ) {
+          moveLiquidDirtyFields.push('dispense_touchTip_speed')
+          moveLiquidDirtyFields.push('dispense_touchTip_mmFromEdge')
+        }
+        if (dispense_airGap_checkbox && dispense_airGap_volume == null) {
+          moveLiquidDirtyFields.push('dispense_airGap_volume')
+        }
+        if (disposalVolume_checkbox && disposalVolume_volume == null) {
+          moveLiquidDirtyFields.push('disposalVolume_volume')
+        }
+        if (conditioning_checkbox && conditioning_volume == null) {
+          moveLiquidDirtyFields.push('conditioning_volume')
+        }
+        dirtyFields = moveLiquidDirtyFields
+        break
+      }
+
+      //  NOTE: this is only hit if a new form type is created and we
+      //  haven't wired up the dirty fields yet
+      default: {
+        dirtyFields = []
+        console.error(
+          `the dirty fields have not been added yet for ${stepType}`
+        )
+      }
+    }
   }
 
   // exclude form "metadata" (not really fields)
-  return without(dirtyFields, 'stepType', 'id')
+  return without(
+    dirtyFields,
+    'stepType',
+    'id',
+    'stepDetails',
+    'stepNumber',
+    'stepName'
+  )
 }
 
 export const getIsErrorOnCurrentPage = (args: {
@@ -121,18 +410,33 @@ export const getVisibleFormErrors = (args: {
   focusedField?: string | null
   dirtyFields: string[]
   errors: StepFormErrors
-  showErrors?: boolean
   page: number
+  currentFormIsPresaved: boolean
+  showErrors?: boolean
 }): StepFormErrors => {
-  const { focusedField, errors, page = 0, showErrors } = args
+  const {
+    focusedField,
+    errors,
+    page = 0,
+    showErrors,
+    dirtyFields,
+    currentFormIsPresaved,
+  } = args
   return errors.filter(error => {
     const dependentFieldsAreNotFocused = !error.dependentFields.includes(
       // @ts-expect-error(sa, 2021-6-22): focusedField might be undefined
       focusedField
     )
-
+    const dependentFieldsAreDirty =
+      difference(error.dependentFields, dirtyFields).length === 0
     const isPageImplicated = error.page != null ? page === error.page : true
-    return isPageImplicated && dependentFieldsAreNotFocused && showErrors
+    return (
+      isPageImplicated &&
+      dependentFieldsAreNotFocused &&
+      (!currentFormIsPresaved
+        ? dependentFieldsAreDirty || showErrors
+        : showErrors)
+    )
   })
 }
 export const getVisibleFormWarnings = (args: {

--- a/protocol-designer/src/steplist/formLevel/errors.ts
+++ b/protocol-designer/src/steplist/formLevel/errors.ts
@@ -105,12 +105,12 @@ const PAUSE_TYPE_REQUIRED: FormError = {
 const TIME_PARAM_REQUIRED: FormError = {
   title: 'Must include hours, minutes, or seconds',
   dependentFields: ['pauseAction', 'pauseTime'],
-  location: 'form',
+  location: 'field',
 }
 const PAUSE_TEMP_PARAM_REQUIRED: FormError = {
   title: 'Temperature is required',
   dependentFields: ['pauseAction', 'pauseTemperature'],
-  location: 'form',
+  location: 'field',
 }
 
 const VOLUME_TOO_HIGH = (pipetteCapacity: number): FormError => ({

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdatePause.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdatePause.ts
@@ -18,14 +18,7 @@ const updatePatchOnPauseTemperatureChange = (
   if (fieldHasChanged(rawForm, patch, 'pauseAction')) {
     return {
       ...patch,
-      ...getDefaultFields(
-        'pauseTemperature',
-        'pauseHour',
-        'pauseMinute',
-        'pauseSecond',
-        'pauseTime',
-        'moduleId'
-      ),
+      ...getDefaultFields('pauseTemperature', 'pauseTime', 'moduleId'),
     }
   }
 


### PR DESCRIPTION
closes RQA-4280

# Overview

This fixes a bug where if you opened a form that was previously made and toggle something, the error for the input field that is revealed does not appear.

This required a bit of a refactor but i'd say the form errors in PD can still be refactored more - but it'll take some time so we can do that for PD 8.6 hopefully.

## Test Plan and Hands on Testing

Create a protocol with a heater shaker
make a heater-shaker step
delete the heater shaker
open the heater shaker step and see that the module id dropdown errors
toggle something on, and see that the input field revealed by the toggle does not error
click save
see that the input field revealed by the toggle is now erroring
there should be 2 errors

## Changelog

- extend logic for `getDirtyFields` to return dirty fields only if they are required (this was highly annoying to add in but its needed to adhere to the form error pattern that design wants - it's annoying that its another thing we have to add on to when we create new fields and new form types)
- added a few comments to explain where we need to further refactor, mainly the `showFormErrors` state should probably be moved and cleaned up? but its a bit tricky since our forms have various behaviors to reset and show errors.

## Risk assessment

medium-ish affects all form errors
