### PR TITLE
fix(protocol-designer): default top labware amount to 1 in reducer

### DIFF
--- a/protocol-designer/src/labware-ingred/reducers/index.ts
+++ b/protocol-designer/src/labware-ingred/reducers/index.ts
@@ -332,7 +332,11 @@ export const zoomedInSlotInfo = (
         ...state,
         selectedTopLabware: {
           labwareDefURI,
-          amount: state.selectedTopLabware.amount,
+          // defaults amount to 1 if labware is selected
+          amount:
+            labwareDefURI != null && state.selectedTopLabware.amount === 0
+              ? 1
+              : state.selectedTopLabware.amount,
         },
       }
     }


### PR DESCRIPTION
closes RQA-4274

# Overview

Fixes a bug with the `SELECT_TOP_LABWARE` reducer where the amount was getting set to 0 instead of 1 at a minimum.

## Test Plan and Hands on Testing

Create a protocol with a 96-channel
drag the tiprack to another slot
zoom into the tiprack adapter
click to add a tiprack on top of the adapter
see that the tiprack is properly added

## Changelog

- fix reducer logic for the top labware amount

## Risk assessment

low