### PR TITLE
fix(protocol-designer): don't show errors until attempting to save/continue

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepFormToolbox.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepFormToolbox.tsx
@@ -242,7 +242,8 @@ export function StepFormToolbox(props: StepFormToolboxProps): JSX.Element {
     hydratedForm,
     t,
     visibleFormErrors,
-    showFormErrors
+    showFormErrors,
+    currentFormIsPresaved
   )
 
   const [isRename, setIsRename] = useState<boolean>(false)

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepFormToolbox.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepFormToolbox.tsx
@@ -241,7 +241,8 @@ export function StepFormToolbox(props: StepFormToolboxProps): JSX.Element {
     handleChangeFormInput,
     hydratedForm,
     t,
-    visibleFormErrors
+    visibleFormErrors,
+    showFormErrors
   )
 
   const [isRename, setIsRename] = useState<boolean>(false)

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/utils.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/utils.ts
@@ -304,7 +304,8 @@ export const makeSingleEditFieldProps = (
   handleChangeFormInput: (name: string, value: unknown) => void,
   hydratedForm: HydratedFormData,
   t: any,
-  visibleFormErrors: StepFormErrors
+  visibleFormErrors: StepFormErrors,
+  showFormErrors: boolean
 ): FieldPropsByName => {
   const { blur, focus } = focusHandlers
   const fieldNames: string[] = Object.keys(
@@ -316,7 +317,7 @@ export const makeSingleEditFieldProps = (
       : false
     const value = formData ? formData[name] : null
     const mappedErrorsToField =
-      visibleFormErrors?.length > 0
+      visibleFormErrors?.length > 0 && showFormErrors
         ? getFormErrorsMappedToField(visibleFormErrors)
         : {}
 

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/utils.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/utils.ts
@@ -305,7 +305,8 @@ export const makeSingleEditFieldProps = (
   hydratedForm: HydratedFormData,
   t: any,
   visibleFormErrors: StepFormErrors,
-  showFormErrors: boolean
+  showFormErrors: boolean,
+  currentFormIsPresaved: boolean
 ): FieldPropsByName => {
   const { blur, focus } = focusHandlers
   const fieldNames: string[] = Object.keys(
@@ -317,7 +318,8 @@ export const makeSingleEditFieldProps = (
       : false
     const value = formData ? formData[name] : null
     const mappedErrorsToField =
-      visibleFormErrors?.length > 0 && showFormErrors
+      visibleFormErrors?.length > 0 &&
+      (showFormErrors || !currentFormIsPresaved)
         ? getFormErrorsMappedToField(visibleFormErrors)
         : {}
 

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/utils.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/utils.ts
@@ -318,15 +318,19 @@ export const makeSingleEditFieldProps = (
       : false
     const value = formData ? formData[name] : null
     const mappedErrorsToField =
-      visibleFormErrors?.length > 0 &&
-      (showFormErrors || !currentFormIsPresaved)
+      visibleFormErrors?.length > 0
         ? getFormErrorsMappedToField(visibleFormErrors)
         : {}
 
     //  NOTE: some fields can have multiple errors, but we
     //  will always just show the first one until they're all
     //  resolved
-    const error = mappedErrorsToField[name]?.[0]?.title
+    const error = mappedErrorsToField[name]?.[0]
+    const errorTitle =
+      error != null &&
+      (showFormErrors || (!currentFormIsPresaved && error.showOnReopen))
+        ? error.title
+        : null
     const updateValue = (value: unknown): void => {
       handleChangeFormInput(name, value)
     }
@@ -349,7 +353,7 @@ export const makeSingleEditFieldProps = (
 
     const fieldProps: FieldProps = {
       disabled,
-      errorToShow: error,
+      errorToShow: errorTitle,
       name,
       updateValue,
       value,

--- a/protocol-designer/src/steplist/formLevel/errors.ts
+++ b/protocol-designer/src/steplist/formLevel/errors.ts
@@ -86,16 +86,19 @@ const INCOMPATIBLE_ASPIRATE_LABWARE: FormError = {
   title: 'Selected aspirate labware is incompatible with pipette',
   dependentFields: ['aspirate_labware', 'pipette'],
   location: 'form',
+  showOnReopen: true,
 }
 const INCOMPATIBLE_DISPENSE_LABWARE: FormError = {
   title: 'Selected dispense labware is incompatible with pipette',
   dependentFields: ['dispense_labware', 'pipette'],
   location: 'form',
+  showOnReopen: true,
 }
 const INCOMPATIBLE_LABWARE: FormError = {
   title: 'Selected labware is incompatible with pipette',
   dependentFields: ['labware', 'pipette'],
   location: 'form',
+  showOnReopen: true,
 }
 const PAUSE_TYPE_REQUIRED: FormError = {
   title:
@@ -118,17 +121,20 @@ const VOLUME_TOO_HIGH = (pipetteCapacity: number): FormError => ({
   title: `Volume is greater than maximum pipette/tip volume (${pipetteCapacity} ul)`,
   dependentFields: ['pipette', 'volume'],
   location: 'form',
+  showOnReopen: true,
 })
 
 const WELL_RATIO_MOVE_LIQUID: FormError = {
   title: 'Well selection must be 1 to many, many to 1, or N to N',
   dependentFields: ['aspirate_wells', 'dispense_wells'],
   location: 'form',
+  showOnReopen: true,
 }
 const WELL_RATIO_MOVE_LIQUID_INTO_WASTE_CHUTE: FormError = {
   title: 'Well selection must be many to 1, or 1 to 1',
   dependentFields: ['aspirate_wells'],
   location: 'form',
+  showOnReopen: true,
 }
 const MAGNET_ACTION_TYPE_REQUIRED: FormError = {
   title: 'Action type must be either engage or disengage',
@@ -223,6 +229,7 @@ const PAUSE_MODULE_REQUIRED: FormError = {
   title: 'Select a module',
   dependentFields: ['moduleId', 'pauseAction'],
   location: 'field',
+  showOnReopen: true,
 }
 const PAUSE_TEMP_REQUIRED: FormError = {
   title: 'Pause temperature required',
@@ -241,59 +248,69 @@ const LABWARE_TO_MOVE_REQUIRED: FormError = {
   title: 'Labware required',
   dependentFields: ['labware'],
   location: 'field',
+  showOnReopen: true,
 }
 const NEW_LABWARE_LOCATION_REQUIRED: FormError = {
   title: 'New location required',
   dependentFields: ['newLocation'],
   location: 'field',
+  showOnReopen: true,
 }
 const ASPIRATE_WELLS_REQUIRED: FormError = {
   title: 'Choose wells',
   dependentFields: ['aspirate_wells'],
   location: 'field',
   page: 0,
+  showOnReopen: true,
 }
 const DISPENSE_WELLS_REQUIRED: FormError = {
   title: 'Choose wells',
   dependentFields: ['dispense_wells'],
   location: 'field',
   page: 0,
+  showOnReopen: true,
 }
 const MIX_WELLS_REQUIRED: FormError = {
   title: 'Choose wells',
   dependentFields: ['wells'],
   location: 'field',
   page: 0,
+  showOnReopen: true,
 }
 const VOLUME_REQUIRED: FormError = {
   title: 'Volume required',
   dependentFields: ['volume'],
   location: 'field',
   page: 0,
+  showOnReopen: true,
 }
 const TIMES_REQUIRED: FormError = {
   title: 'Enter an integer value greater than 0',
   dependentFields: ['times'],
   location: 'field',
   page: 0,
+  showOnReopen: true,
 }
 const ASPIRATE_LABWARE_REQUIRED: FormError = {
   title: 'Labware required',
   dependentFields: ['aspirate_labware'],
   location: 'field',
   page: 0,
+  showOnReopen: true,
 }
 const DISPENSE_LABWARE_REQUIRED: FormError = {
   title: 'Labware required',
   dependentFields: ['dispense_labware'],
   location: 'field',
   page: 0,
+  showOnReopen: true,
 }
 const MIX_LABWARE_REQUIRED: FormError = {
   title: 'Labware required',
   dependentFields: ['labware'],
   location: 'field',
   page: 0,
+  showOnReopen: true,
 }
 const ASPIRATE_MIX_TIMES_REQUIRED: FormError = {
   title: 'Enter an integer value greater than 0',
@@ -400,12 +417,14 @@ const ABSORBANCE_READER_MODULE_ID_REQUIRED: FormError = {
   dependentFields: ['moduleId'],
   location: 'field',
   page: 0,
+  showOnReopen: true,
 }
 const MAGNETIC_MODULE_ID_REQUIRED: FormError = {
   title: 'Module required',
   dependentFields: ['moduleId'],
   location: 'field',
   page: 0,
+  showOnReopen: true,
 }
 const ASPIRATE_TOUCH_TIP_SPEED_REQUIRED: FormError = {
   title: 'Touch tip speed required',
@@ -482,29 +501,34 @@ const VOLUME_OUT_OF_RANGE: FormError = {
   dependentFields: ['volume'],
   location: 'field',
   page: 0,
+  showOnReopen: true,
 }
 const VOLUME_UNDER_MINIMUM: FormError = {
   title: RANGE_TITLE,
   dependentFields: ['volume'],
   location: 'field',
   page: 0,
+  showOnReopen: true,
 }
 const MESSAGE_REQUIRED: FormError = {
   title: 'Message required',
   dependentFields: ['message'],
   location: 'field',
+  showOnReopen: true,
 }
 const PIPETTE_REQUIRED: FormError = {
   title: 'Pipette required',
   dependentFields: ['pipette'],
   location: 'field',
   page: 0,
+  showOnReopen: true,
 }
 const TIPRACK_REQUIRED: FormError = {
   title: 'Tiprack required',
   dependentFields: ['tiprack'],
   location: 'field',
   page: 0,
+  showOnReopen: true,
 }
 const TARGET_TEMPERATURE_RANGE: FormError = {
   title: RANGE_TITLE,

--- a/protocol-designer/src/steplist/formLevel/errors.ts
+++ b/protocol-designer/src/steplist/formLevel/errors.ts
@@ -77,6 +77,7 @@ export interface FormError {
   page?: number
   //  for mix and moveLiquid tools
   tab?: LiquidHandlingTab
+  showOnReopen?: boolean
 }
 
 const RANGE_TITLE = 'Enter a value within the specified range'
@@ -154,6 +155,7 @@ const MODULE_ID_REQUIRED: FormError = {
     'Module is required. Ensure the appropriate module is present on the deck and selected for this step',
   dependentFields: ['moduleId'],
   location: 'field',
+  showOnReopen: true,
 }
 const TARGET_TEMPERATURE_REQUIRED: FormError = {
   title: 'Temperature required',

--- a/protocol-designer/src/steplist/formLevel/moveLabwareFormErrors.ts
+++ b/protocol-designer/src/steplist/formLevel/moveLabwareFormErrors.ts
@@ -65,6 +65,7 @@ export const getMoveLabwareFormErrors = (
           title: errorString,
           dependentProfileFields: ['newLocation'],
           location: 'field',
+          showOnReopen: true,
         },
       ] as ProfileFormError[])
     : []

--- a/protocol-designer/src/steplist/formLevel/profileErrors.ts
+++ b/protocol-designer/src/steplist/formLevel/profileErrors.ts
@@ -17,6 +17,7 @@ export interface ProfileFormError {
   location: FormErrorLocationType
   body?: ReactNode
   page?: number
+  showOnReopen?: boolean
 }
 type ProfileFormErrorKey = 'INVALID_PROFILE_DURATION'
 const PROFILE_FORM_ERRORS: Record<ProfileFormErrorKey, ProfileFormError> = {


### PR DESCRIPTION
# Overview

Fixes logic for showing form errors, especially when reopening an errored-out saved form. We previously used a state variable for whether or not to show the form errors, such that they would only show if a user tried to continue/save a form containing an error. After a large error handling [refactor](https://github.com/Opentrons/opentrons/pull/18437) was merged, this state was unused, such that errors would show automatically when reopening a form. 

This PR adds logic to the `makeSingleEditFieldProps` util to show form errors in the following scenarios:
1. the error is due to the field being required, and the form is saved and reopened
2. the error is of any type, the form is pre-saved or saved, and the user attempts to continue or save

I also wire up a new optional property of the form error to specify whether or not to show the error upon reopening in scenario 1 above.

Closes RQA-4280

## Test Plan and Hands on Testing

- create a protocol with a heater-shaker
- make a heater-shaker step with at least one toggle field left un-toggled (heater, shaker field)
- delete the heater shaker from deck hardware
- open the errored heater shaker step and see that the module dropdown field shows an error immediately
- toggle a field that was toggled off initially, but leave the exposed input field empty
- click save
- see that the input field revealed by the toggle is now erroring

## Changelog

- consider `showFormErrors` state variable and saved/pre-saved form state in `makeSingleEditFieldProps`
- expand form-level errors to include `showOnReopen` property

## Review requests

see test plan. the same logic for `showOnReopen` should extend to all fields that should show errors when reopening a saved form (think module required, pipette required, etc.)

## Risk assessment

low