### PR TITLE
increase 96ch Z speed during retract/submerge from 4mm/sec to 10mm/sec

### DIFF
--- a/shared-data/liquid-class/definitions/1/glycerol_50.json
+++ b/shared-data/liquid-class/definitions/1/glycerol_50.json
@@ -17,7 +17,7 @@
                 "y": 0,
                 "z": 2
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -32,7 +32,7 @@
                 "y": 0,
                 "z": 2
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "touchTip": {
                 "enable": false,
@@ -88,7 +88,7 @@
                 "y": 0,
                 "z": 2
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -103,7 +103,7 @@
                 "y": 0,
                 "z": 2
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": false
@@ -163,7 +163,7 @@
                 "y": 0,
                 "z": 2
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -178,7 +178,7 @@
                 "y": 0,
                 "z": 2
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": false
@@ -245,7 +245,7 @@
                 "y": 0,
                 "z": 2
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -260,7 +260,7 @@
                 "y": 0,
                 "z": 2
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "touchTip": {
                 "enable": false,
@@ -316,7 +316,7 @@
                 "y": 0,
                 "z": 2
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -331,7 +331,7 @@
                 "y": 0,
                 "z": 2
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": false
@@ -391,7 +391,7 @@
                 "y": 0,
                 "z": 2
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -406,7 +406,7 @@
                 "y": 0,
                 "z": 2
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": false
@@ -473,7 +473,7 @@
                 "y": 0,
                 "z": 2
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -488,7 +488,7 @@
                 "y": 0,
                 "z": 2
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "touchTip": {
                 "enable": false,
@@ -544,7 +544,7 @@
                 "y": 0,
                 "z": 2
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -559,7 +559,7 @@
                 "y": 0,
                 "z": 2
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": false
@@ -618,7 +618,7 @@
                 "y": 0,
                 "z": 2
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -633,7 +633,7 @@
                 "y": 0,
                 "z": 2
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": false
@@ -695,7 +695,7 @@
                 "y": 0,
                 "z": 2
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -710,7 +710,7 @@
                 "y": 0,
                 "z": 2
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "touchTip": {
                 "enable": false,
@@ -766,7 +766,7 @@
                 "y": 0,
                 "z": 2
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -781,7 +781,7 @@
                 "y": 0,
                 "z": 2
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": false
@@ -836,7 +836,7 @@
                 "y": 0,
                 "z": 2
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -851,7 +851,7 @@
                 "y": 0,
                 "z": 2
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": false
@@ -913,7 +913,7 @@
                 "y": 0,
                 "z": 2
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -928,7 +928,7 @@
                 "y": 0,
                 "z": 2
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "touchTip": {
                 "enable": false,
@@ -984,7 +984,7 @@
                 "y": 0,
                 "z": 2
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -999,7 +999,7 @@
                 "y": 0,
                 "z": 2
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": false
@@ -1054,7 +1054,7 @@
                 "y": 0,
                 "z": 2
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -1069,7 +1069,7 @@
                 "y": 0,
                 "z": 2
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": false
@@ -1136,7 +1136,7 @@
                 "y": 0,
                 "z": 2
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -1151,7 +1151,7 @@
                 "y": 0,
                 "z": 2
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "touchTip": {
                 "enable": false,
@@ -1207,7 +1207,7 @@
                 "y": 0,
                 "z": 2
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -1222,7 +1222,7 @@
                 "y": 0,
                 "z": 2
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": false
@@ -1281,7 +1281,7 @@
                 "y": 0,
                 "z": 2
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -1296,7 +1296,7 @@
                 "y": 0,
                 "z": 2
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": false
@@ -1358,7 +1358,7 @@
                 "y": 0,
                 "z": 2
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -1373,7 +1373,7 @@
                 "y": 0,
                 "z": 2
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "touchTip": {
                 "enable": false,
@@ -1429,7 +1429,7 @@
                 "y": 0,
                 "z": 2
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -1444,7 +1444,7 @@
                 "y": 0,
                 "z": 2
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": false
@@ -1499,7 +1499,7 @@
                 "y": 0,
                 "z": 2
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -1514,7 +1514,7 @@
                 "y": 0,
                 "z": 2
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": false
@@ -1576,7 +1576,7 @@
                 "y": 0,
                 "z": 2
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -1591,7 +1591,7 @@
                 "y": 0,
                 "z": 2
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "touchTip": {
                 "enable": false,
@@ -1647,7 +1647,7 @@
                 "y": 0,
                 "z": 2
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -1662,7 +1662,7 @@
                 "y": 0,
                 "z": 2
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": false
@@ -1717,7 +1717,7 @@
                 "y": 0,
                 "z": 2
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -1732,7 +1732,7 @@
                 "y": 0,
                 "z": 2
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": false
@@ -1799,7 +1799,7 @@
                 "y": 0,
                 "z": 2
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -1814,7 +1814,7 @@
                 "y": 0,
                 "z": 2
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "touchTip": {
                 "enable": false,
@@ -1870,7 +1870,7 @@
                 "y": 0,
                 "z": 2
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -1885,7 +1885,7 @@
                 "y": 0,
                 "z": 2
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": false
@@ -1948,7 +1948,7 @@
                 "y": 0,
                 "z": 2
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -1963,7 +1963,7 @@
                 "y": 0,
                 "z": 2
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": false
@@ -2029,7 +2029,7 @@
                 "y": 0,
                 "z": 2
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -2044,7 +2044,7 @@
                 "y": 0,
                 "z": 2
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "touchTip": {
                 "enable": false,
@@ -2100,7 +2100,7 @@
                 "y": 0,
                 "z": 2
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -2115,7 +2115,7 @@
                 "y": 0,
                 "z": 2
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": false
@@ -2170,7 +2170,7 @@
                 "y": 0,
                 "z": 2
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -2185,7 +2185,7 @@
                 "y": 0,
                 "z": 2
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": false
@@ -2247,7 +2247,7 @@
                 "y": 0,
                 "z": 2
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -2262,7 +2262,7 @@
                 "y": 0,
                 "z": 2
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "touchTip": {
                 "enable": false,
@@ -2319,7 +2319,7 @@
                 "y": 0,
                 "z": 2
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -2334,7 +2334,7 @@
                 "y": 0,
                 "z": 2
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": false
@@ -2389,7 +2389,7 @@
                 "y": 0,
                 "z": 2
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -2404,7 +2404,7 @@
                 "y": 0,
                 "z": 2
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": false


### PR DESCRIPTION
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing

<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog

<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment

<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
