### PR TITLE
fix(shared-data): Z noise during 96ch submerge/retract (glycerol only)

### DIFF
--- a/api/tests/opentrons/protocol_api/test_protocol_context.py
+++ b/api/tests/opentrons/protocol_api/test_protocol_context.py
@@ -1900,13 +1900,13 @@ def test_customize_existing_liquid_class(
         existing_glycerol_class.get_for(
             "flex_1channel_50", "opentrons/opentrons_flex_96_tiprack_50ul/1"
         ).aspirate.submerge.speed
-        == 10
+        == 4
     )
     assert (
         existing_glycerol_class.get_for(
             "flex_8channel_50", "opentrons/opentrons_flex_96_tiprack_50ul/1"
         ).aspirate.submerge.speed
-        == 10
+        == 4
     )
 
     my_liquid_class = subject.define_liquid_class(
@@ -1926,7 +1926,7 @@ def test_customize_existing_liquid_class(
         my_liquid_class.get_for(
             "flex_8channel_50", "opentrons/opentrons_flex_96_tiprack_50ul/1"
         ).aspirate.submerge.speed
-        == 10
+        == 4
     )
 
     # Test that new entries are created for pipettes and tipracks not present in the base liquid class

--- a/api/tests/opentrons/protocol_api/test_protocol_context.py
+++ b/api/tests/opentrons/protocol_api/test_protocol_context.py
@@ -1900,13 +1900,13 @@ def test_customize_existing_liquid_class(
         existing_glycerol_class.get_for(
             "flex_1channel_50", "opentrons/opentrons_flex_96_tiprack_50ul/1"
         ).aspirate.submerge.speed
-        == 4
+        == 10
     )
     assert (
         existing_glycerol_class.get_for(
             "flex_8channel_50", "opentrons/opentrons_flex_96_tiprack_50ul/1"
         ).aspirate.submerge.speed
-        == 4
+        == 10
     )
 
     my_liquid_class = subject.define_liquid_class(
@@ -1926,7 +1926,7 @@ def test_customize_existing_liquid_class(
         my_liquid_class.get_for(
             "flex_8channel_50", "opentrons/opentrons_flex_96_tiprack_50ul/1"
         ).aspirate.submerge.speed
-        == 4
+        == 10
     )
 
     # Test that new entries are created for pipettes and tipracks not present in the base liquid class

--- a/shared-data/liquid-class/definitions/1/glycerol_50/1.json
+++ b/shared-data/liquid-class/definitions/1/glycerol_50/1.json
@@ -21,7 +21,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -38,7 +38,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "touchTip": {
                 "enable": false,
@@ -99,7 +99,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -116,7 +116,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": false,
@@ -185,7 +185,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -202,7 +202,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": true,
@@ -273,7 +273,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -290,7 +290,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "touchTip": {
                 "enable": false,
@@ -351,7 +351,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -368,7 +368,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": false,
@@ -437,7 +437,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -454,7 +454,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": true,
@@ -530,7 +530,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -547,7 +547,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "touchTip": {
                 "enable": false,
@@ -608,7 +608,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -625,7 +625,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": false,
@@ -694,7 +694,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -711,7 +711,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": true,
@@ -782,7 +782,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -799,7 +799,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "touchTip": {
                 "enable": false,
@@ -860,7 +860,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -877,7 +877,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": false,
@@ -946,7 +946,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -963,7 +963,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": true,
@@ -1039,7 +1039,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -1056,7 +1056,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "touchTip": {
                 "enable": false,
@@ -1117,7 +1117,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -1134,7 +1134,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": false,
@@ -1202,7 +1202,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -1219,7 +1219,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": true,
@@ -1290,7 +1290,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -1307,7 +1307,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "touchTip": {
                 "enable": false,
@@ -1368,7 +1368,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -1385,7 +1385,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": false,
@@ -1453,7 +1453,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -1470,7 +1470,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": true,
@@ -1541,7 +1541,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -1558,7 +1558,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "touchTip": {
                 "enable": false,
@@ -1619,7 +1619,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -1636,7 +1636,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": false,
@@ -1700,7 +1700,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -1717,7 +1717,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": true,
@@ -1788,7 +1788,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -1805,7 +1805,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "touchTip": {
                 "enable": false,
@@ -1866,7 +1866,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -1883,7 +1883,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": false,
@@ -1947,7 +1947,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -1964,7 +1964,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": true,
@@ -2035,7 +2035,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -2052,7 +2052,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "touchTip": {
                 "enable": false,
@@ -2113,7 +2113,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -2130,7 +2130,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": false,
@@ -2194,7 +2194,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -2211,7 +2211,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": true,
@@ -2282,7 +2282,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -2299,7 +2299,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "touchTip": {
                 "enable": false,
@@ -2360,7 +2360,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -2377,7 +2377,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": false,
@@ -2441,7 +2441,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -2458,7 +2458,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": true,
@@ -2534,7 +2534,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -2551,7 +2551,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "touchTip": {
                 "enable": false,
@@ -2612,7 +2612,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -2629,7 +2629,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": false,
@@ -2697,7 +2697,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -2714,7 +2714,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": true,
@@ -2785,7 +2785,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -2802,7 +2802,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "touchTip": {
                 "enable": false,
@@ -2863,7 +2863,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -2880,7 +2880,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": false,
@@ -2948,7 +2948,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -2965,7 +2965,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": true,
@@ -3036,7 +3036,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -3053,7 +3053,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "touchTip": {
                 "enable": false,
@@ -3114,7 +3114,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -3131,7 +3131,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": false,
@@ -3195,7 +3195,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -3212,7 +3212,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": true,
@@ -3283,7 +3283,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -3300,7 +3300,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "touchTip": {
                 "enable": false,
@@ -3361,7 +3361,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -3378,7 +3378,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": false,
@@ -3442,7 +3442,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -3459,7 +3459,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": true,
@@ -3530,7 +3530,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -3547,7 +3547,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "touchTip": {
                 "enable": false,
@@ -3608,7 +3608,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -3625,7 +3625,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": false,
@@ -3689,7 +3689,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -3706,7 +3706,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": true,
@@ -3777,7 +3777,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -3794,7 +3794,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "touchTip": {
                 "enable": false,
@@ -3855,7 +3855,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -3872,7 +3872,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": false,
@@ -3936,7 +3936,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -3953,7 +3953,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": true,
@@ -4029,7 +4029,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -4046,7 +4046,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "touchTip": {
                 "enable": false,
@@ -4107,7 +4107,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -4124,7 +4124,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": false,
@@ -4196,7 +4196,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -4213,7 +4213,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": true,
@@ -4288,7 +4288,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -4305,7 +4305,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "touchTip": {
                 "enable": false,
@@ -4366,7 +4366,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -4383,7 +4383,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": false,
@@ -4455,7 +4455,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -4472,7 +4472,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": true,
@@ -4547,7 +4547,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -4564,7 +4564,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "touchTip": {
                 "enable": false,
@@ -4625,7 +4625,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -4642,7 +4642,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": false,
@@ -4706,7 +4706,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -4723,7 +4723,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": true,
@@ -4794,7 +4794,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -4811,7 +4811,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "touchTip": {
                 "enable": false,
@@ -4872,7 +4872,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -4889,7 +4889,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": false,
@@ -4953,7 +4953,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -4970,7 +4970,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": true,
@@ -5041,7 +5041,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -5058,7 +5058,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "touchTip": {
                 "enable": false,
@@ -5120,7 +5120,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -5137,7 +5137,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": false,
@@ -5201,7 +5201,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -5218,7 +5218,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": true,
@@ -5289,7 +5289,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -5306,7 +5306,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "touchTip": {
                 "enable": false,
@@ -5368,7 +5368,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -5385,7 +5385,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": false,
@@ -5449,7 +5449,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "delay": {
                 "enable": false,
                 "params": {
@@ -5466,7 +5466,7 @@
                   "z": 2
                 }
               },
-              "speed": 4,
+              "speed": 10,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": true,

--- a/shared-data/liquid-class/definitions/1/glycerol_50/1.json
+++ b/shared-data/liquid-class/definitions/1/glycerol_50/1.json
@@ -21,7 +21,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "delay": {
                 "enable": false,
                 "params": {
@@ -38,7 +38,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "touchTip": {
                 "enable": false,
@@ -99,7 +99,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "delay": {
                 "enable": false,
                 "params": {
@@ -116,7 +116,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": false,
@@ -185,7 +185,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "delay": {
                 "enable": false,
                 "params": {
@@ -202,7 +202,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": true,
@@ -273,7 +273,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "delay": {
                 "enable": false,
                 "params": {
@@ -290,7 +290,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "touchTip": {
                 "enable": false,
@@ -351,7 +351,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "delay": {
                 "enable": false,
                 "params": {
@@ -368,7 +368,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": false,
@@ -437,7 +437,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "delay": {
                 "enable": false,
                 "params": {
@@ -454,7 +454,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": true,
@@ -530,7 +530,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "delay": {
                 "enable": false,
                 "params": {
@@ -547,7 +547,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "touchTip": {
                 "enable": false,
@@ -608,7 +608,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "delay": {
                 "enable": false,
                 "params": {
@@ -625,7 +625,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": false,
@@ -694,7 +694,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "delay": {
                 "enable": false,
                 "params": {
@@ -711,7 +711,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": true,
@@ -782,7 +782,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "delay": {
                 "enable": false,
                 "params": {
@@ -799,7 +799,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "touchTip": {
                 "enable": false,
@@ -860,7 +860,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "delay": {
                 "enable": false,
                 "params": {
@@ -877,7 +877,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": false,
@@ -946,7 +946,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "delay": {
                 "enable": false,
                 "params": {
@@ -963,7 +963,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": true,
@@ -1039,7 +1039,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "delay": {
                 "enable": false,
                 "params": {
@@ -1056,7 +1056,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "touchTip": {
                 "enable": false,
@@ -1117,7 +1117,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "delay": {
                 "enable": false,
                 "params": {
@@ -1134,7 +1134,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": false,
@@ -1202,7 +1202,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "delay": {
                 "enable": false,
                 "params": {
@@ -1219,7 +1219,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": true,
@@ -1290,7 +1290,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "delay": {
                 "enable": false,
                 "params": {
@@ -1307,7 +1307,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "touchTip": {
                 "enable": false,
@@ -1368,7 +1368,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "delay": {
                 "enable": false,
                 "params": {
@@ -1385,7 +1385,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": false,
@@ -1453,7 +1453,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "delay": {
                 "enable": false,
                 "params": {
@@ -1470,7 +1470,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": true,
@@ -1541,7 +1541,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "delay": {
                 "enable": false,
                 "params": {
@@ -1558,7 +1558,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "touchTip": {
                 "enable": false,
@@ -1619,7 +1619,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "delay": {
                 "enable": false,
                 "params": {
@@ -1636,7 +1636,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": false,
@@ -1700,7 +1700,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "delay": {
                 "enable": false,
                 "params": {
@@ -1717,7 +1717,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": true,
@@ -1788,7 +1788,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "delay": {
                 "enable": false,
                 "params": {
@@ -1805,7 +1805,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "touchTip": {
                 "enable": false,
@@ -1866,7 +1866,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "delay": {
                 "enable": false,
                 "params": {
@@ -1883,7 +1883,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": false,
@@ -1947,7 +1947,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "delay": {
                 "enable": false,
                 "params": {
@@ -1964,7 +1964,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": true,
@@ -2035,7 +2035,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "delay": {
                 "enable": false,
                 "params": {
@@ -2052,7 +2052,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "touchTip": {
                 "enable": false,
@@ -2113,7 +2113,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "delay": {
                 "enable": false,
                 "params": {
@@ -2130,7 +2130,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": false,
@@ -2194,7 +2194,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "delay": {
                 "enable": false,
                 "params": {
@@ -2211,7 +2211,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": true,
@@ -2282,7 +2282,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "delay": {
                 "enable": false,
                 "params": {
@@ -2299,7 +2299,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "touchTip": {
                 "enable": false,
@@ -2360,7 +2360,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "delay": {
                 "enable": false,
                 "params": {
@@ -2377,7 +2377,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": false,
@@ -2441,7 +2441,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "delay": {
                 "enable": false,
                 "params": {
@@ -2458,7 +2458,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": true,
@@ -2534,7 +2534,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "delay": {
                 "enable": false,
                 "params": {
@@ -2551,7 +2551,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "touchTip": {
                 "enable": false,
@@ -2612,7 +2612,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "delay": {
                 "enable": false,
                 "params": {
@@ -2629,7 +2629,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": false,
@@ -2697,7 +2697,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "delay": {
                 "enable": false,
                 "params": {
@@ -2714,7 +2714,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": true,
@@ -2785,7 +2785,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "delay": {
                 "enable": false,
                 "params": {
@@ -2802,7 +2802,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "touchTip": {
                 "enable": false,
@@ -2863,7 +2863,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "delay": {
                 "enable": false,
                 "params": {
@@ -2880,7 +2880,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": false,
@@ -2948,7 +2948,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "delay": {
                 "enable": false,
                 "params": {
@@ -2965,7 +2965,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": true,
@@ -3036,7 +3036,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "delay": {
                 "enable": false,
                 "params": {
@@ -3053,7 +3053,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "touchTip": {
                 "enable": false,
@@ -3114,7 +3114,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "delay": {
                 "enable": false,
                 "params": {
@@ -3131,7 +3131,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": false,
@@ -3195,7 +3195,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "delay": {
                 "enable": false,
                 "params": {
@@ -3212,7 +3212,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": true,
@@ -3283,7 +3283,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "delay": {
                 "enable": false,
                 "params": {
@@ -3300,7 +3300,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "touchTip": {
                 "enable": false,
@@ -3361,7 +3361,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "delay": {
                 "enable": false,
                 "params": {
@@ -3378,7 +3378,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": false,
@@ -3442,7 +3442,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "delay": {
                 "enable": false,
                 "params": {
@@ -3459,7 +3459,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": true,
@@ -3530,7 +3530,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "delay": {
                 "enable": false,
                 "params": {
@@ -3547,7 +3547,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "touchTip": {
                 "enable": false,
@@ -3608,7 +3608,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "delay": {
                 "enable": false,
                 "params": {
@@ -3625,7 +3625,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": false,
@@ -3689,7 +3689,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "delay": {
                 "enable": false,
                 "params": {
@@ -3706,7 +3706,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": true,
@@ -3777,7 +3777,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "delay": {
                 "enable": false,
                 "params": {
@@ -3794,7 +3794,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "touchTip": {
                 "enable": false,
@@ -3855,7 +3855,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "delay": {
                 "enable": false,
                 "params": {
@@ -3872,7 +3872,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": false,
@@ -3936,7 +3936,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "delay": {
                 "enable": false,
                 "params": {
@@ -3953,7 +3953,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": true,
@@ -5306,7 +5306,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "touchTip": {
                 "enable": false,
@@ -5368,7 +5368,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "delay": {
                 "enable": false,
                 "params": {
@@ -5385,7 +5385,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": false,
@@ -5449,7 +5449,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "delay": {
                 "enable": false,
                 "params": {
@@ -5466,7 +5466,7 @@
                   "z": 2
                 }
               },
-              "speed": 10,
+              "speed": 4,
               "airGapByVolume": [[0.0, 0.0]],
               "blowout": {
                 "enable": true,


### PR DESCRIPTION
[update Jun 17] ready to merge

# Overview

This PR fixes a loud noise heard during submerge/retract for the 96ch when pipetting `glycerol_50` liquid-class. The issue is fixed by increasing the Z axis speed from `4` mm/sec to `10` mm/sec.

Background: The 96ch uses `1.5` amps during Z moves, while the 1ch and 8ch use `1.0` amps, and so that 50% increase in power is causing any already existing resonant speeds in a machine to be much louder. The Flex is pretty resonant, and resonances are more likely to peak at lower speeds.

## Test Plan and Hands on Testing

HW-Testing will be testing the following:

- [x] `5` uL using `T50`
- [x] `5` uL using `T200`
- [x] `10` uL using `T1000`

Only the smallest volumes per-tip are needed to be tested. This is because the risk of retracting faster is that more liquid may be adhering to the outside of the tip, affecting the gravimetric test results. That extra amount of liquid adhering to the outside of the tip has a larger affect on our smallest target volumes (because they would be proportionally bigger relative to the target volume). So if we can pass our smallest target volumes per tip-type, then we can be confident all higher target volumes for that tip will have a smaller error.
