### PR TITLE
fix(step-generation): wire up nozzles for replaceTip used in mix

### DIFF
--- a/step-generation/src/commandCreators/compound/mix.ts
+++ b/step-generation/src/commandCreators/compound/mix.ts
@@ -271,6 +271,7 @@ export const mix: CommandCreator<MixArgs> = (
     xOffset,
     yOffset,
     finalPushOut,
+    nozzles,
   } = data
 
   const aspirateDelaySeconds = data.aspirateDelaySeconds ?? 0
@@ -373,6 +374,7 @@ export const mix: CommandCreator<MixArgs> = (
             pipette,
             dropTipLocation,
             tipRack,
+            nozzles: nozzles ?? undefined,
           }),
         ]
       }

--- a/step-generation/src/commandCreators/compound/mix.ts
+++ b/step-generation/src/commandCreators/compound/mix.ts
@@ -374,7 +374,7 @@ export const mix: CommandCreator<MixArgs> = (
             pipette,
             dropTipLocation,
             tipRack,
-            nozzles: nozzles ?? undefined,
+            ...(nozzles != null ? { nozzles } : {}),
           }),
         ]
       }

--- a/step-generation/src/robotStateSelectors.ts
+++ b/step-generation/src/robotStateSelectors.ts
@@ -118,7 +118,7 @@ export function getNextTiprack(
       `cannot getNextTiprack, no pipette entity for pipette "${pipetteId}"`
     )
   }
-
+console.log('nozzles', nozzles)
   // filter out unmounted or non-compatible tiprack models
   const sortedTipracksIds = sortLabwareBySlot(robotState.labware).filter(
     labwareId => {
@@ -135,6 +135,7 @@ export function getNextTiprack(
     }
   )
   const is96Channel = pipetteEntity.spec.channels === 96
+  console.log('sortedTipracksIds', sortedTipracksIds)
   const filteredSortedTipRackIdsFor96Channel = sortedTipracksIds.filter(
     tiprackId => {
       const tipRackLocation = robotState.labware[tiprackId].stack[1]
@@ -147,6 +148,10 @@ export function getNextTiprack(
 
       return nozzles === ALL ? has96TiprackAdapterId : !has96TiprackAdapterId
     }
+  )
+  console.log(
+    'filteredSortedTipRackIdsFor96Channel',
+    filteredSortedTipRackIdsFor96Channel
   )
   const firstAvailableTiprack = (is96Channel
     ? filteredSortedTipRackIdsFor96Channel

--- a/step-generation/src/robotStateSelectors.ts
+++ b/step-generation/src/robotStateSelectors.ts
@@ -118,7 +118,7 @@ export function getNextTiprack(
       `cannot getNextTiprack, no pipette entity for pipette "${pipetteId}"`
     )
   }
-console.log('nozzles', nozzles)
+
   // filter out unmounted or non-compatible tiprack models
   const sortedTipracksIds = sortLabwareBySlot(robotState.labware).filter(
     labwareId => {
@@ -135,7 +135,6 @@ console.log('nozzles', nozzles)
     }
   )
   const is96Channel = pipetteEntity.spec.channels === 96
-  console.log('sortedTipracksIds', sortedTipracksIds)
   const filteredSortedTipRackIdsFor96Channel = sortedTipracksIds.filter(
     tiprackId => {
       const tipRackLocation = robotState.labware[tiprackId].stack[1]
@@ -148,10 +147,6 @@ console.log('nozzles', nozzles)
 
       return nozzles === ALL ? has96TiprackAdapterId : !has96TiprackAdapterId
     }
-  )
-  console.log(
-    'filteredSortedTipRackIdsFor96Channel',
-    filteredSortedTipRackIdsFor96Channel
   )
   const firstAvailableTiprack = (is96Channel
     ? filteredSortedTipRackIdsFor96Channel


### PR DESCRIPTION
closes RQA-4275

# Overview

Fix bug where the `mix` step wouldn't return any tips for a 96-channel full tip pick up because we forgot to wire in the nozzles arg 👻 

## Test Plan and Hands on Testing

Upload attached protocol in the bug ticket and see that there are no timeline errors

## Changelog

- wire up nozzles arg

## Risk assessment
low
