### PR TITLE
refactor(shared-data, api): require `locatingFeaturesAsParent` for module defs

### DIFF
--- a/api/src/opentrons/protocol_engine/types/module.py
+++ b/api/src/opentrons/protocol_engine/types/module.py
@@ -208,9 +208,8 @@ class ModuleDefinition(BaseModel):
         description="Offsets to use for labware movement using gripper",
     )
 
-    # TODO(jh, 06-13-25): This should absolutely be required after EXEC-212 closes.
     locatingFeaturesAsParent: Optional[LocatingFeatures] = Field(
-        default=None,
+        ...,
         description="List of explict locating features when this module acts as the parent in a labware stackup",
     )
 

--- a/api/src/opentrons/protocol_engine/types/module.py
+++ b/api/src/opentrons/protocol_engine/types/module.py
@@ -208,7 +208,7 @@ class ModuleDefinition(BaseModel):
         description="Offsets to use for labware movement using gripper",
     )
 
-    locatingFeaturesAsParent: Optional[LocatingFeatures] = Field(
+    locatingFeaturesAsParent: LocatingFeatures = Field(
         ...,
         description="List of explict locating features when this module acts as the parent in a labware stackup",
     )

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -787,6 +787,7 @@ def minimal_module_def() -> ModuleDefinitionV3:
         "moduleType": "temperatureModuleType",
         "model": "temperatureModuleV1",
         "labwareOffset": {"x": -0.15, "y": -0.15, "z": 80.09},
+        "locatingFeaturesAsParent": {},
         "dimensions": {
             "bareOverallHeight": 84,
             "overLabwareHeight": 0,

--- a/shared-data/module/schemas/3.json
+++ b/shared-data/module/schemas/3.json
@@ -61,6 +61,7 @@
     "model",
     "labwareOffset",
     "cornerOffsetFromSlot",
+    "locatingFeaturesAsParent",
     "dimensions",
     "calibrationPoint",
     "displayName",

--- a/shared-data/python/opentrons_shared_data/module/types.py
+++ b/shared-data/python/opentrons_shared_data/module/types.py
@@ -4,7 +4,7 @@ for modules
 """
 
 from typing import Any, Dict, List, Union
-from typing_extensions import Literal, TypedDict, Optional
+from typing_extensions import Literal, TypedDict
 
 from opentrons_shared_data.labware.types import LocatingFeatures
 
@@ -115,7 +115,7 @@ ModuleDefinitionV3 = TypedDict(
         "model": ModuleModel,
         "labwareOffset": ModuleLabwareOffset,
         "cornerOffsetFromSlot": CornerOffsetFromSlot,
-        "locatingFeaturesAsParent": Optional[LocatingFeatures],
+        "locatingFeaturesAsParent": LocatingFeatures,
         "dimensions": ModuleDimensions,
         "calibrationPoint": ModuleCalibrationPointOffsetWithZ,
         "config": Dict[str, int],


### PR DESCRIPTION
Works towards [EXEC-77](https://opentrons.atlassian.net/browse/EXEC-77)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

In https://github.com/Opentrons/opentrons/pull/18628, we wanted to require `locatingFeaturesAsParent` for module definitions, but we couldn't (see comments in PR discussion), so we marked the field as optional and followed up with https://github.com/Opentrons/opentrons/pull/18639. Now that the module definition debacle is resolved, we can make the field required as originally intended.

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- Does CI pass?
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- `locatingFeaturesAsParent` is required for module definitions.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
none, we don't do anything with this field yet
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[EXEC-77]: https://opentrons.atlassian.net/browse/EXEC-77?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ