### PR TITLE
fix(api): sanitize labware label to fix ot2 lpc

### DIFF
--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -177,7 +177,7 @@ class ModuleContext(CommandPublisher):
 
         labware_core = self._protocol_core.load_labware(
             load_name=name,
-            label=label,
+            label=label if label is None else str(label),
             namespace=namespace,
             version=version,
             location=load_location,
@@ -246,7 +246,10 @@ class ModuleContext(CommandPublisher):
         """
         _log.warning("load_labware_by_name is deprecated. Use load_labware instead.")
         return self.load_labware(
-            name=name, label=label, namespace=namespace, version=version
+            name=name,
+            label=label,
+            namespace=namespace,
+            version=version,
         )
 
     @requires_version(2, 15)

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -499,7 +499,7 @@ class ProtocolContext(CommandPublisher):
         labware_core = self._core.load_labware(
             load_name=load_name,
             location=load_location,
-            label=label,
+            label=label if label is None else str(label),
             namespace=namespace,
             version=version,
         )

--- a/api/src/opentrons/protocol_runner/legacy_command_mapper.py
+++ b/api/src/opentrons/protocol_runner/legacy_command_mapper.py
@@ -651,8 +651,7 @@ class LegacyCommandMapper:
         )
         command_id = f"commands.LOAD_LABWARE-{count}"
         labware_id = f"labware-{count}"
-
-        succeeded_command = pe_commands.LoadLabware.model_construct(
+        succeeded_command = pe_commands.LoadLabware(
             id=command_id,
             key=command_id,
             status=pe_commands.CommandStatus.SUCCEEDED,

--- a/api/tests/opentrons/protocol_api/test_module_context.py
+++ b/api/tests/opentrons/protocol_api/test_module_context.py
@@ -1,4 +1,5 @@
 """Tests for Protocol API module contexts."""
+
 from typing import cast
 
 import pytest
@@ -110,6 +111,49 @@ def test_load_labware(
     result = subject.load_labware(
         name="Infinite Tip Rack",
         label="it doesn't run out",
+        namespace="ideal",
+        version=101,
+    )
+
+    assert isinstance(result, Labware)
+    assert result.name == "Full Name"
+    assert result.api_version == api_version
+    decoy.verify(mock_core_map.add(mock_labware_core, result), times=1)
+
+
+@pytest.mark.parametrize("api_version", [APIVersion(2, 1234)])
+@pytest.mark.parametrize(
+    "label,sanitized_label", [(7, "7"), ("hi", "hi"), (None, None)]
+)
+def test_load_labware_sanitizes_label(
+    decoy: Decoy,
+    mock_protocol_core: ProtocolCore,
+    mock_core_map: LoadedCoreMap,
+    mock_core: ModuleCore,
+    api_version: APIVersion,
+    label: str | None,
+    sanitized_label: str | None,
+    subject: ModuleContext,
+) -> None:
+    """It should load labware by load parameters."""
+    mock_labware_core = decoy.mock(cls=LabwareCore)
+
+    decoy.when(
+        mock_protocol_core.load_labware(
+            load_name="infinite tip rack",
+            label=sanitized_label,
+            namespace="ideal",
+            version=101,
+            location=mock_core,
+        )
+    ).then_return(mock_labware_core)
+
+    decoy.when(mock_labware_core.get_name()).then_return("Full Name")
+    decoy.when(mock_labware_core.get_well_columns()).then_return([])
+
+    result = subject.load_labware(
+        name="Infinite Tip Rack",
+        label=label,
         namespace="ideal",
         version=101,
     )

--- a/api/tests/opentrons/protocol_api/test_protocol_context.py
+++ b/api/tests/opentrons/protocol_api/test_protocol_context.py
@@ -1,4 +1,5 @@
 """Tests for the ProtocolContext public interface."""
+
 import inspect
 from typing import cast, Dict
 
@@ -453,6 +454,57 @@ def test_load_labware(
         load_name="UPPERCASE_LABWARE",
         location=42,
         label="some_display_name",
+        namespace="some_namespace",
+        version=1337,
+    )
+
+    assert isinstance(result, Labware)
+    assert result.name == "Full Name"
+
+    decoy.verify(mock_core_map.add(mock_labware_core, result), times=1)
+
+
+@pytest.mark.parametrize(
+    "label,sanitized_label", [(7, "7"), (None, None), ("hi", "hi")]
+)
+def test_load_labware_sanitizes_label(
+    decoy: Decoy,
+    mock_core: ProtocolCore,
+    mock_core_map: LoadedCoreMap,
+    api_version: APIVersion,
+    label: str | None,  # think of this like a typecast
+    sanitized_label: str | None,
+    subject: ProtocolContext,
+) -> None:
+    """It should stringify labels unless they are None."""
+    mock_labware_core = decoy.mock(cls=LabwareCore)
+
+    decoy.when(mock_validation.ensure_lowercase_name("UPPERCASE_LABWARE")).then_return(
+        "lowercase_labware"
+    )
+    decoy.when(mock_core.robot_type).then_return("OT-3 Standard")
+    decoy.when(
+        mock_validation.ensure_and_convert_deck_slot(42, api_version, "OT-3 Standard")
+    ).then_return(DeckSlotName.SLOT_5)
+
+    decoy.when(
+        mock_core.load_labware(
+            load_name="lowercase_labware",
+            location=DeckSlotName.SLOT_5,
+            label=sanitized_label,
+            namespace="some_namespace",
+            version=1337,
+        )
+    ).then_return(mock_labware_core)
+
+    decoy.when(mock_labware_core.get_name()).then_return("Full Name")
+    decoy.when(mock_labware_core.get_display_name()).then_return("Display Name")
+    decoy.when(mock_labware_core.get_well_columns()).then_return([])
+
+    result = subject.load_labware(
+        load_name="UPPERCASE_LABWARE",
+        location=42,
+        label=label,
         namespace="some_namespace",
         version=1337,
     )


### PR DESCRIPTION
Labware labels are passed through from the protocol api all the way to
the commands and eventually the client with little actual
_functionality_ dependent on their types or their values. That means
that the only thing that checks them is pydantic model validation, and
if you avoid that - as the legacy command mapper does by using
model_construct() - then other downstream things won't be happy.

In this case, OT-2 LPC starts its session by echoing commands it reads
from the robot analysis back out to a maintenance run. When a client
uses HTTP to create commands, pydantic model validation _does_ run, and
it would fail, and this wasn't an anticipated error scenario because,
well, it's echoed from the protocol! But the incorrect data made it
through.

Another way to handle this would be to do pydantic model validation on
the protocol inputs, but that would break any old protocols that
implicitly depended on this working. Compatibility! Also IMO it's silly
that we enforce this if the entire system works just fine if you give it
an integer.

Closes RESC-423

## testing
- [x] on an ot2, upload a protocol that calls `load_labware(..., label=7)` and start lpc. it shouldn't give you a 422
    - [x] also analysis should say `"7"` as the label

Note that if you're doing this on a real machine and using a protocol you've used before you may need to aggressively prune cached analysis, runs, and protocols.
