### PR TITLE
feat(step-generation): remove `pd_step` step wrapper

### DIFF
--- a/protocol-designer/src/file-data/__tests__/createFile.test.ts
+++ b/protocol-designer/src/file-data/__tests__/createFile.test.ts
@@ -141,7 +141,6 @@ describe('createFile selector', () => {
     expect(result.pythonProtocol).toBe(
       `
 import json
-from contextlib import nullcontext as pd_step
 from opentrons import protocol_api, types
 
 metadata = {

--- a/step-generation/src/utils/pythonFileUtils.ts
+++ b/step-generation/src/utils/pythonFileUtils.ts
@@ -37,11 +37,7 @@ const PAPI_VERSION = '2.24' // latest version from api/src/opentrons/protocols/a
 export const PD_APPLICATION_VERSION = '8.5.0' // latest PD version to insert into DESIGNER_APPLICATION blob
 
 export function pythonImports(): string {
-  return [
-    'import json',
-    'from contextlib import nullcontext as pd_step',
-    'from opentrons import protocol_api, types',
-  ].join('\n')
+  return ['import json', 'from opentrons import protocol_api, types'].join('\n')
 }
 
 export function pythonMetadata(


### PR DESCRIPTION
# Overview

We had defined a `pd_step` context manager so that we could group Python commands from the same PD step together, and so that we could emit fields from PD that are not expressible in the Python API (step name, step description, step form parameters, etc.). We were planning to use it like this:
```
with pd_step(name="My Mix Step", description="Mix very well", ...):
  pipette_left.pick_up_tip()
  pipette_left.mix(...)
```

However, command annotations serve the same purpose, and command annotations will also provide a context manager for grouping steps. So I'm removing our `pd_step` context manager.

Command annotations are not available in the public API yet, but we'll just wait for it and use it when it's available.

## Test Plan and Hands on Testing

Updated unit tests.

## Risk assessment

Low. Feature has never been released publicly.