### PR TITLE
fix(docs): mkdocs warnings in Flex manual

### DIFF
--- a/docs/flex-manual/docs/glossary.md
+++ b/docs/flex-manual/docs/glossary.md
@@ -38,7 +38,7 @@ A metal pin you attach to the *gripper's jaws* during gripper calibration. See t
 
 ##### Calibration probe
 
-A metal collar you attach to the *nozzle* of a pipette during pipette calibration, module calibration, and *Labware Position Check*. See the [Pipette calibration section][pipette-calibration] in the System Description chapter and the [Module calibration section][module-calibration] in the Modules chapter. See also the [Labware Position Check section][labware-position-check] of the Software and Operation chapter.
+A metal collar you attach to the *nozzle* of a pipette during pipette calibration, module calibration, and *Labware Position Check*. See the [Pipette calibration section][pipette-calibration] in the System Description chapter and the [Module calibration section][module-calibration] in the Modules chapter. See also the [Labware Position Check section](software-operation.md#labware-position-check) of the Software and Operation chapter.
 
 ##### Calibration square
 
@@ -86,7 +86,7 @@ The mechanism that automatically pushes tips off the *nozzle* of a pipette. See 
 
 ##### Emergency Stop Pendant
 
-An external accessory that you press to stop the robot immediately. Also referred to as the E-stop. See the [Emergency Stop Pendant section][emergency-stop-pendant] in the System Description chapter.
+An external accessory that you press to stop the robot immediately. Also referred to as the E-stop. See the [Emergency Stop Pendant section](system-description.md#emergency-stop-pendant) in the System Description chapter.
 
 ##### Expansion slot
 
@@ -166,7 +166,7 @@ Positional data that is created and stored by running *Labware Position Check*. 
 
 ##### Labware Position Check
 
-A guided process to visually check and adjust pipette movement relative to a piece of labware, with a resolution of 0.1 mm. See the [Labware Position Check section][labware-position-check] in the Software and Operation chapter.
+A guided process to visually check and adjust pipette movement relative to a piece of labware, with a resolution of 0.1 mm. See the [Labware Position Check section](software-operation.md#labware-position-check) in the Software and Operation chapter.
 
 ##### Lift handles
 
@@ -202,7 +202,7 @@ The working end of a pipette. Flex pipettes pick up disposable tips by pressing 
 
 ##### Opentrons App
 
-Software used to control a Flex (or other Opentrons robots) from a laptop or desktop computer. The Opentrons App is available for Mac, Windows, and Linux. See the [Opentrons App section][opentrons-app] in the Software and Operation chapter.
+Software used to control a Flex (or other Opentrons robots) from a laptop or desktop computer. The Opentrons App is available for Mac, Windows, and Linux. See the [Opentrons App section](software-operation.md#opentrons-app) in the Software and Operation chapter.
 
 ##### Paddle
 
@@ -230,11 +230,11 @@ An automated task or procedure you program to run on Opentrons robots, including
 
 ##### Protocol Designer
 
-A web-based, no-code tool for developing *JSON protocols* that run on Opentrons robots, including Opentrons Flex. See the [Protocol Designer section][protocol-designer] in the Protocol Development chapter and <https://designer.opentrons.com>.
+A web-based, no-code tool for developing *JSON protocols* that run on Opentrons robots, including Opentrons Flex. See the [Protocol Designer section](protocol-development.md#protocol-designer) in the Protocol Development chapter and <https://designer.opentrons.com>.
 
 ##### Protocol Library
 
-A public, searchable library that hosts protocols authored by Opentrons or by members of the Opentrons community. See the [Protocol Library section][protocol-library] in the Protocol Development chapter and <https://library.opentrons.com>.
+A public, searchable library that hosts protocols authored by Opentrons or by members of the Opentrons community. See the [Protocol Library section](protocol-development.md#protocol-library) in the Protocol Development chapter and <https://library.opentrons.com>.
 
 ##### Protocol run
 
@@ -246,7 +246,7 @@ A protocol script written using the Opentrons *Python Protocol API*. See the [Wr
 
 ##### Python Protocol API
 
-A Python package that exposes a wide range of liquid handling features on Opentrons robots. See the [Python Protocol API section][python-protocol-api] in the Protocol Development chapter and the online [Opentrons Python Protocol API documentation](https://docs.opentrons.com/v2/).
+A Python package that exposes a wide range of liquid handling features on Opentrons robots. See the [Python Protocol API section](protocol-development.md#python-protocol-api) in the Protocol Development chapter and the online [Opentrons Python Protocol API documentation](https://docs.opentrons.com/v2/).
 
 ##### Removable deck slot
 
@@ -266,11 +266,11 @@ Fixed clear panels on the right and left sides of the robot.
 
 ##### Staging area
 
-The right-hand side of the *deck* (column 4), which is only accessible by the *gripper*. This area requires special *staging area slots* for use. See the [Staging area section][staging-area] in the System Description chapter.
+The right-hand side of the *deck* (column 4), which is only accessible by the *gripper*. This area requires special *staging area slots* for use. See the [Staging area section](system-description.md#staging-area) in the System Description chapter.
 
 ##### Staging area slot
 
-Staging area slots are ANSI/SLAS compatible deck pieces that replace the standard slots in column 3 (A3 to D3) and extend a new slot into the *staging area*. You can install a single slot or a maximum of four slots to create a new column (A4 to D4) along the right side of the *deck*. See the [Staging area section][staging-area] in the System Description chapter.
+Staging area slots are ANSI/SLAS compatible deck pieces that replace the standard slots in column 3 (A3 to D3) and extend a new slot into the *staging area*. You can install a single slot or a maximum of four slots to create a new column (A4 to D4) along the right side of the *deck*. See the [Staging area section](system-description.md#staging-area) in the System Description chapter.
 
 ##### Status light
 

--- a/docs/flex-manual/docs/introduction.md
+++ b/docs/flex-manual/docs/introduction.md
@@ -132,11 +132,11 @@ potential injury or harm.
 
 | Symbol   | Description  |
 | :------- | :----------- |
-| ![Symbol for warning](../images/regulatory-marks/warning-label-caution.svg "Warning") | **Warning:** Alerts users to <ul><li>Potentially hazardous conditions.</li><li>Actions that may result in personal injury or death.</li></ul>                             |
-| ![Symbol for caution](../images/regulatory-marks/warning-label-caution.svg "Caution")  | **Caution:** Cautions users against <ul><li>Damage to the equipment.</li><li>Lost or corrupted data.</li><li>Unrecoverable interruption of the operation being performed.</li></ul> |
-| ![Symbol for electrical shock](../images/regulatory-marks/warning-label-electrical-shock.svg "Electrical shock")  | **Electrical shock:** Identifies instrument components that might pose a risk of electrical shock if the instrument is handled improperly.                                |
-| ![Symbol for hot surface](../images/regulatory-marks/warning-label-hot-surface.svg "Hot surface")  | **Hot surface:** Identifies instrument components that pose a risk of personal injury due to high heat/temperatures if the instrument is handled improperly.              |
-| ![Symbol for pinch point](../images/regulatory-marks/warning-label-pinch-point.svg "Pinch point")  | **Pinch point:** Identifies instrument components that can pose a risk of personal injury when in motion.                                                                  |
+| ![Symbol for warning](images/regulatory-marks/warning-label-caution.svg "Warning") | **Warning:** Alerts users to <ul><li>Potentially hazardous conditions.</li><li>Actions that may result in personal injury or death.</li></ul>                             |
+| ![Symbol for caution](images/regulatory-marks/warning-label-caution.svg "Caution")  | **Caution:** Cautions users against <ul><li>Damage to the equipment.</li><li>Lost or corrupted data.</li><li>Unrecoverable interruption of the operation being performed.</li></ul> |
+| ![Symbol for electrical shock](images/regulatory-marks/warning-label-electrical-shock.svg "Electrical shock")  | **Electrical shock:** Identifies instrument components that might pose a risk of electrical shock if the instrument is handled improperly.                                |
+| ![Symbol for hot surface](images/regulatory-marks/warning-label-hot-surface.svg "Hot surface")  | **Hot surface:** Identifies instrument components that pose a risk of personal injury due to high heat/temperatures if the instrument is handled improperly.              |
+| ![Symbol for pinch point](images/regulatory-marks/warning-label-pinch-point.svg "Pinch point")  | **Pinch point:** Identifies instrument components that can pose a risk of personal injury when in motion.                                                                  |
 
 
 You will find the following labels on the Flex:
@@ -163,9 +163,9 @@ Always observe the following electrical safety warnings:
 
 | Symbol   | Description  |
 | :------- | :----------- |
-| ![Symbol for warning](../images/regulatory-marks/warning-label-caution.svg "Warning") | Plug the robot into a grounded, Class 1 circuit. See the [Power Connection section][power-connection] in the System Description chapter.                                                                                |
-| ![Symbol for electrical shock](../images/regulatory-marks/warning-label-electrical-shock.svg "Electrical shock") | Do not connect (plug in), disconnect (unplug), or use AC power cables if: <ul><li>The cable is frayed or damaged.</li><li>Other attached cables, cords, or receptacles are frayed or damaged.</li></ul> Using damaged power cords can cause an electric shock hazard resulting in serious injury or damage to the robot.                                                           |
-| ![Symbol for warning](../images/regulatory-marks/warning-label-caution.svg "Warning") | Do not replace the AC power cable unless at the direction of Opentrons Support.                                                                                            |
+| ![Symbol for warning](images/regulatory-marks/warning-label-caution.svg "Warning") | Plug the robot into a grounded, Class 1 circuit. See the [Power Connection section][power-connection] in the System Description chapter.                                                                                |
+| ![Symbol for electrical shock](images/regulatory-marks/warning-label-electrical-shock.svg "Electrical shock") | Do not connect (plug in), disconnect (unplug), or use AC power cables if: <ul><li>The cable is frayed or damaged.</li><li>Other attached cables, cords, or receptacles are frayed or damaged.</li></ul> Using damaged power cords can cause an electric shock hazard resulting in serious injury or damage to the robot.                                                           |
+| ![Symbol for warning](images/regulatory-marks/warning-label-caution.svg "Warning") | Do not replace the AC power cable unless at the direction of Opentrons Support.                                                                                            |
 
 For more information on electrical requirements, see the [Power Consumption section][power-consumption] of the Installation and Relocation chapter.
 
@@ -175,11 +175,11 @@ Always observe the following additional safety warnings:
 
 | Symbol   | Description  |
 | :------- | :----------- |
-| ![Symbol for warning](../images/regulatory-marks/warning-label-caution.svg "Warning") | Opentrons Flex has not been certified for use with explosive or flammable liquids. Do not load plates, tubes, or vials containing explosive or flammable liquids into the robot or otherwise operate the instrument with explosive or flammable liquids in the enclosure. |
-| ![Symbol for warning](../images/regulatory-marks/warning-label-caution.svg "Warning") | Use good laboratory practices and follow the manufacturer's precautions when working with chemicals. Opentrons is not responsible or liable for any damages because of, or as a result of, the use of hazardous chemicals.           |
-| ![Symbol for warning](../images/regulatory-marks/warning-label-caution.svg "Warning") | The Flex weighs 88.5 kg (195 lbs). As a result, it requires two people to lift and move it safely. See the [Relocation section][relocation] in the Installation and Relocation chapter.                                                                        |
-| ![Symbol for warning](../images/regulatory-marks/warning-label-caution.svg "Warning") | The Flex should be placed on a surface capable of supporting its weight of 88.5 kg (195 lbs) with sufficient surface area to accommodate the robot plus its minimum clearance distance (20 cm/8 in). See the in the Installation and Relocation chapter. |
-| ![Symbol for warning](../images/regulatory-marks/warning-label-caution.svg "Warning") | The Flex can emit vibrations while in operation. Place the robot on a surface that is sturdy, level, and water-resistant with cross-bracing or welded joints. See the in the Installation and Relocation chapter.                |
+| ![Symbol for warning](images/regulatory-marks/warning-label-caution.svg "Warning") | Opentrons Flex has not been certified for use with explosive or flammable liquids. Do not load plates, tubes, or vials containing explosive or flammable liquids into the robot or otherwise operate the instrument with explosive or flammable liquids in the enclosure. |
+| ![Symbol for warning](images/regulatory-marks/warning-label-caution.svg "Warning") | Use good laboratory practices and follow the manufacturer's precautions when working with chemicals. Opentrons is not responsible or liable for any damages because of, or as a result of, the use of hazardous chemicals.           |
+| ![Symbol for warning](images/regulatory-marks/warning-label-caution.svg "Warning") | The Flex weighs 88.5 kg (195 lbs). As a result, it requires two people to lift and move it safely. See the [Relocation section][relocation] in the Installation and Relocation chapter.                                                                        |
+| ![Symbol for warning](images/regulatory-marks/warning-label-caution.svg "Warning") | The Flex should be placed on a surface capable of supporting its weight of 88.5 kg (195 lbs) with sufficient surface area to accommodate the robot plus its minimum clearance distance (20 cm/8 in). See the in the Installation and Relocation chapter. |
+| ![Symbol for warning](images/regulatory-marks/warning-label-caution.svg "Warning") | The Flex can emit vibrations while in operation. Place the robot on a surface that is sturdy, level, and water-resistant with cross-bracing or welded joints. See the in the Installation and Relocation chapter.                |
 
 ### Safety cautions
 
@@ -187,8 +187,8 @@ To help protect the Flex from damage, follow these precautions:
 
 | Symbol   | Description  |
 | :------- | :----------- |
-| ![Symbol for warning](../images/regulatory-marks/warning-label-caution.svg "Warning") | Use labware that is ANSI/SLAS-compliant or approved by Opentrons. See the [Labware chapter](labware.md). |
-| ![Symbol for warning](../images/regulatory-marks/warning-label-caution.svg "Warning") | Keep corrosive materials, agents, or otherwise damaging materials away from the robot.|
+| ![Symbol for warning](images/regulatory-marks/warning-label-caution.svg "Warning") | Use labware that is ANSI/SLAS-compliant or approved by Opentrons. See the [Labware chapter](labware.md). |
+| ![Symbol for warning](images/regulatory-marks/warning-label-caution.svg "Warning") | Keep corrosive materials, agents, or otherwise damaging materials away from the robot.|
 
 ### Biological safety
 
@@ -260,9 +260,7 @@ Opentrons is dedicated to adhering to the EU Directive on Waste Electrical and E
 
 Opentrons products that fall under the WEEE directive are labeled with the <img src="../images/regulatory-marks/WEEE.svg" style="height: 1.25em;"> symbol, signifying that they should not be thrown away with regular household waste but must be collected and handled separately.
 
-If you or your business have Opentrons products that are at end of life
-or need to be discarded for a separate purpose, contact Opentrons for
-proper disposal and recycling.
+If you or your business have Opentrons products that are at end of life or need to be discarded for a separate purpose, contact Opentrons for proper disposal and recycling.
 
 ### Wi-Fi precertification
 

--- a/docs/flex-manual/docs/modules.md
+++ b/docs/flex-manual/docs/modules.md
@@ -2,7 +2,7 @@
 
 Opentrons Flex integrates with a number of Opentrons hardware modules. All modules are peripherals that occupy deck slots, and most are controlled by the robot over a USB connection.
 
-This chapter describes the functions and physical specifications of modules that are compatible with the Opentrons Flex system, as well as how to attach and calibrate them. For further details on module setup and use, consult the manuals for the individual modules. For details on integrating modules into your protocols, see the [Protocol Designer section][protocol-designer] of the Protocol Development chapter or the online [Python Protocol API documentation](https://docs.opentrons.com/v2/).
+This chapter describes the functions and physical specifications of modules that are compatible with the Opentrons Flex system, as well as how to attach and calibrate them. For further details on module setup and use, consult the manuals for the individual modules. For details on integrating modules into your protocols, see the [Protocol Designer section](protocol-development.md#protocol-designer) of the Protocol Development chapter or the online [Python Protocol API documentation](https://docs.opentrons.com/v2/).
 
 ## Supported modules
 

--- a/docs/flex-manual/docs/preface.md
+++ b/docs/flex-manual/docs/preface.md
@@ -24,7 +24,7 @@ If you prefer a guided approach, this manual is structured so you can follow it 
 
     - [Appendix B: Additional Documentation](additional-documentation.md) points you to even more resources for Opentrons products and writing code to control Flex.
     
-    - [Appendix C: Open-Source Software](open-sourcs-software.md) explains how Opentrons software is hosted on GitHub as a resource for both developers and non-developers.
+    - [Appendix C: Open-Source Software](open-source-software.md) explains how Opentrons software is hosted on GitHub as a resource for both developers and non-developers.
     
     - [Appendix D: Support and Contact Information](support-contact-information.md) lists how to get in touch with Opentrons if you need assistance beyond what our documentation provides.
 

--- a/docs/flex-manual/docs/software-operation.md
+++ b/docs/flex-manual/docs/software-operation.md
@@ -289,7 +289,7 @@ Flex provides a protocol recovery path for the following error conditions.
 | General errors | A catch-all category for other errors. | <ul><li>Retry step.</li><li>Skip to next step.</li><li>Cancel protocol run.</li></ul> |
 
 !!! note
-    The tip presence sensor is disabled for [partial tip pickup](system-description/#partial-tip-pickup) of 1, 2, or 3 tips. In these configurations, Flex cannot detect tip pickup errors and will not present error recovery options if the pipette fails to pick up the tips. The run will continue unless and until another error occurs.
+    The tip presence sensor is disabled for [partial tip pickup](system-description.md#partial-tip-pickup) of 1, 2, or 3 tips. In these configurations, Flex cannot detect tip pickup errors and will not present error recovery options if the pipette fails to pick up the tips. The run will continue unless and until another error occurs.
 
 You can view the status of a finished protocol and review any resolved errors on the run completion screen.
 

--- a/docs/flex-manual/docs/software-operation.md
+++ b/docs/flex-manual/docs/software-operation.md
@@ -289,7 +289,7 @@ Flex provides a protocol recovery path for the following error conditions.
 | General errors | A catch-all category for other errors. | <ul><li>Retry step.</li><li>Skip to next step.</li><li>Cancel protocol run.</li></ul> |
 
 !!! note
-    The tip presence sensor is disabled for [partial tip pickup][partial-tip-pickup] of 1, 2, or 3 tips. In these configurations, Flex cannot detect tip pickup errors and will not present error recovery options if the pipette fails to pick up the tips. The run will continue unless and until another error occurs.
+    The tip presence sensor is disabled for [partial tip pickup](system-description/#partial-tip-pickup) of 1, 2, or 3 tips. In these configurations, Flex cannot detect tip pickup errors and will not present error recovery options if the pipette fails to pick up the tips. The run will continue unless and until another error occurs.
 
 You can view the status of a finished protocol and review any resolved errors on the run completion screen.
 


### PR DESCRIPTION
# Overview

Cleans up some mkdocs warnings present in the first commited version of the Flex manual.

## Test Plan and Hands on Testing

`make -C docs build-flex-manual` gives INFO level output only.

## Changelog

- Disambiguate links to non-unique headers (use `[header](page.md#header)` instead of `[header][header]`).
- Remove working but redundant `../` in image paths.

## Review requests

All fixed up?

## Risk assessment

nil point docs