### PR TITLE
feat(protocol-designer, step-generation): add logic to getTransferPlanAndReferenceVolumes

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/FlowRateField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/FlowRateField.tsx
@@ -116,12 +116,12 @@ export function FlowRateField(props: FlowRateFieldProps): JSX.Element {
   const [referenceVolumeFlowRate, referenceVolumeCorrection] =
     flowRateType === 'aspirate'
       ? [
-          referenceVolumesForByVolumeInterpolation?.flowRateAspirate,
-          referenceVolumesForByVolumeInterpolation?.correctionAspirate,
+          referenceVolumesForByVolumeInterpolation?.flowRate.aspirate,
+          referenceVolumesForByVolumeInterpolation?.correction.aspirate,
         ]
       : [
-          referenceVolumesForByVolumeInterpolation?.flowRateDispense,
-          referenceVolumesForByVolumeInterpolation?.correctionDispense,
+          referenceVolumesForByVolumeInterpolation?.flowRate.dispense,
+          referenceVolumesForByVolumeInterpolation?.correction.dispense,
         ]
   const correctionVolume =
     referenceVolumeCorrection != null && liquidClassValuesForTip != null

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/utils.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/utils.ts
@@ -448,7 +448,7 @@ const getSubmergeRetractFields = (args: {
     'airGapByVolume' in submergeRetractLookup &&
     !(liquidHandlingAction === 'aspirate' && isConditioningVolumeEnabled)
       ? getByVolumeField({
-          volume: volumes.airGap,
+          volume: volumes.airGap[liquidHandlingAction],
           byVolume: submergeRetractLookup.airGapByVolume,
           field: 'airGap',
           prefix: liquidHandlingAction,
@@ -772,7 +772,7 @@ const getLiquidClassValuesMoveLiquid = (args: {
   )
   const aspirateOffsetFields = getOffsetFields(aspirateOffset, 'aspirate')
   const aspirateFlowRateFields = getFlowRateFields(
-    byVolumeLookup.flowRateAspirate,
+    byVolumeLookup.flowRate.aspirate,
     aspirateFlowRateByVolume,
     'aspirate'
   )
@@ -787,7 +787,7 @@ const getLiquidClassValuesMoveLiquid = (args: {
   )
   const dispenseOffsetFields = getOffsetFields(dispenseOffset, 'dispense')
   const dispenseFlowRateFields = getFlowRateFields(
-    byVolumeLookup.flowRateDispense,
+    byVolumeLookup.flowRate.dispense,
     dispenseFlowRateByVolume,
     'dispense'
   )

--- a/step-generation/src/utils/__tests__/misc.test.ts
+++ b/step-generation/src/utils/__tests__/misc.test.ts
@@ -61,12 +61,19 @@ describe('getTransferPlanAndReferenceVolumes', () => {
     })
     expect(result).toEqual({
       referenceVolumes: {
-        airGap: 5,
-        correctionAspirate: 5,
-        correctionDispense: 5,
+        airGap: {
+          aspirate: 5,
+          dispense: 0,
+        },
+        correction: {
+          aspirate: 5,
+          dispense: 5,
+        },
+        flowRate: {
+          aspirate: 5,
+          dispense: 5,
+        },
         pushOut: 5,
-        flowRateAspirate: 5,
-        flowRateDispense: 5,
       },
       multiWellHandling: {
         isSupported: false,
@@ -85,12 +92,11 @@ describe('getTransferPlanAndReferenceVolumes', () => {
       conditioningByVolume: null,
       disposalByVolume: null,
     })
-    expect(result.referenceVolumes.airGap).toBeCloseTo(7.5)
-    expect(result.referenceVolumes.correctionAspirate).toBeCloseTo(7.5)
-    expect(result.referenceVolumes.correctionDispense).toBeCloseTo(7.5)
-    expect(result.referenceVolumes.pushOut).toBeCloseTo(7.5)
-    expect(result.referenceVolumes.flowRateAspirate).toBeCloseTo(7.5)
-    expect(result.referenceVolumes.flowRateDispense).toBeCloseTo(7.5)
+    expect(result.referenceVolumes.airGap.aspirate).toBeCloseTo(7.5)
+    expect(result.referenceVolumes.correction.aspirate).toBeCloseTo(7.5)
+    expect(result.referenceVolumes.correction.dispense).toBeCloseTo(7.5)
+    expect(result.referenceVolumes.flowRate.aspirate).toBeCloseTo(7.5)
+    expect(result.referenceVolumes.flowRate.dispense).toBeCloseTo(7.5)
     expect(result.multiWellHandling.isSupported).toBe(false)
   })
 
@@ -105,12 +111,11 @@ describe('getTransferPlanAndReferenceVolumes', () => {
       conditioningByVolume: null,
       disposalByVolume: null,
     })
-    expect(result.referenceVolumes.airGap).toBeCloseTo(7.5)
-    expect(result.referenceVolumes.correctionAspirate).toBeCloseTo(7.5)
-    expect(result.referenceVolumes.correctionDispense).toBeCloseTo(7.5)
-    expect(result.referenceVolumes.pushOut).toBeCloseTo(7.5)
-    expect(result.referenceVolumes.flowRateAspirate).toBeCloseTo(7.5)
-    expect(result.referenceVolumes.flowRateDispense).toBeCloseTo(7.5)
+    expect(result.referenceVolumes.airGap.aspirate).toBeCloseTo(7.5)
+    expect(result.referenceVolumes.correction.aspirate).toBeCloseTo(7.5)
+    expect(result.referenceVolumes.correction.dispense).toBeCloseTo(7.5)
+    expect(result.referenceVolumes.flowRate.aspirate).toBeCloseTo(7.5)
+    expect(result.referenceVolumes.flowRate.dispense).toBeCloseTo(7.5)
     expect(result.multiWellHandling.isSupported).toBe(false)
   })
 
@@ -125,12 +130,11 @@ describe('getTransferPlanAndReferenceVolumes', () => {
       conditioningByVolume: null,
       disposalByVolume: null,
     })
-    expect(result.referenceVolumes.airGap).toBeCloseTo(5)
-    expect(result.referenceVolumes.correctionAspirate).toBeCloseTo(5)
-    expect(result.referenceVolumes.correctionDispense).toBeCloseTo(5)
-    expect(result.referenceVolumes.pushOut).toBeCloseTo(5)
-    expect(result.referenceVolumes.flowRateAspirate).toBeCloseTo(5)
-    expect(result.referenceVolumes.flowRateDispense).toBeCloseTo(5)
+    expect(result.referenceVolumes.airGap.aspirate).toBeCloseTo(5)
+    expect(result.referenceVolumes.correction.aspirate).toBeCloseTo(5)
+    expect(result.referenceVolumes.correction.dispense).toBeCloseTo(5)
+    expect(result.referenceVolumes.flowRate.aspirate).toBeCloseTo(5)
+    expect(result.referenceVolumes.flowRate.dispense).toBeCloseTo(5)
     expect(result.multiWellHandling.isSupported).toBe(false)
   })
 
@@ -147,12 +151,19 @@ describe('getTransferPlanAndReferenceVolumes', () => {
     })
     expect(result).toEqual({
       referenceVolumes: {
-        airGap: 9,
-        correctionAspirate: 9,
-        correctionDispense: 9,
+        airGap: {
+          aspirate: 9,
+          dispense: 0,
+        },
+        correction: {
+          aspirate: 9,
+          dispense: 9,
+        },
+        flowRate: {
+          aspirate: 3,
+          dispense: 9,
+        },
         pushOut: 9,
-        flowRateAspirate: 3,
-        flowRateDispense: 9,
       },
       multiWellHandling: {
         isSupported: true,
@@ -172,7 +183,7 @@ describe('getTransferPlanAndReferenceVolumes', () => {
       conditioningByVolume: null,
       disposalByVolume: null,
     })
-    expect(result.referenceVolumes.airGap).toBe(8)
+    expect(result.referenceVolumes.airGap.aspirate).toBe(8)
     expect(result.multiWellHandling.numWellsToFitInTip).toBe(2)
   })
 
@@ -187,7 +198,7 @@ describe('getTransferPlanAndReferenceVolumes', () => {
       conditioningByVolume: null,
       disposalByVolume: null,
     })
-    expect(result.referenceVolumes.airGap).toBe(8)
+    expect(result.referenceVolumes.airGap.aspirate).toBe(8)
     expect(result.multiWellHandling.numWellsToFitInTip).toBe(2)
   })
 
@@ -208,14 +219,15 @@ describe('getTransferPlanAndReferenceVolumes', () => {
         [40, 4],
       ],
     })
-    expect(result.referenceVolumes.airGap).toBe(30 + 3)
-    expect(result.referenceVolumes.correctionAspirate).toBe(30 + 7.5 + 3)
-    expect(result.referenceVolumes.correctionDispense).toBe(10)
+    expect(result.referenceVolumes.airGap.aspirate).toBe(30 + 3)
+    expect(result.referenceVolumes.airGap.dispense).toBe(20 + 2)
+    expect(result.referenceVolumes.correction.aspirate).toBe(30 + 7.5 + 3)
+    expect(result.referenceVolumes.correction.dispense).toBe(10)
     expect(result.referenceVolumes.pushOut).toBe(10)
     expect(result.referenceVolumes.conditioning).toBe(30)
     expect(result.referenceVolumes.disposal).toBe(30)
-    expect(result.referenceVolumes.flowRateAspirate).toBe(30 + 7.5 + 3)
-    expect(result.referenceVolumes.flowRateDispense).toBe(10)
+    expect(result.referenceVolumes.flowRate.aspirate).toBe(30 + 7.5 + 3)
+    expect(result.referenceVolumes.flowRate.dispense).toBe(10)
     expect(result.multiWellHandling.isSupported).toBe(true)
     expect(result.multiWellHandling.numWellsToFitInTip).toBe(3)
   })
@@ -237,14 +249,14 @@ describe('getTransferPlanAndReferenceVolumes', () => {
         [7, 3],
       ],
     })
-    expect(result.referenceVolumes.airGap).toBe(6 + 2)
-    expect(result.referenceVolumes.correctionAspirate).toBe(6 + 1 + 2)
-    expect(result.referenceVolumes.correctionDispense).toBe(3)
+    expect(result.referenceVolumes.airGap.aspirate).toBe(6 + 2)
+    expect(result.referenceVolumes.airGap.dispense).toBe(3 + 1)
+    expect(result.referenceVolumes.correction.aspirate).toBe(6 + 1 + 2)
+    expect(result.referenceVolumes.correction.dispense).toBe(3)
     expect(result.referenceVolumes.pushOut).toBe(3)
     expect(result.referenceVolumes.conditioning).toBe(6)
     expect(result.referenceVolumes.disposal).toBe(6)
-    expect(result.referenceVolumes.flowRateAspirate).toBe(6 + 1 + 2)
-    expect(result.referenceVolumes.flowRateDispense).toBe(3)
+    expect(result.referenceVolumes.flowRate.aspirate).toBe(6 + 1 + 2)
     expect(result.multiWellHandling.isSupported).toBe(true)
     expect(result.multiWellHandling.numWellsToFitInTip).toBe(2)
   })
@@ -266,14 +278,14 @@ describe('getTransferPlanAndReferenceVolumes', () => {
         [7, 3],
       ],
     })
-    expect(result.referenceVolumes.airGap).toBe(6 + 2)
-    expect(result.referenceVolumes.correctionAspirate).toBe(6 + 1 + 2)
-    expect(result.referenceVolumes.correctionDispense).toBe(3)
+    expect(result.referenceVolumes.airGap.aspirate).toBe(6 + 2)
+    expect(result.referenceVolumes.airGap.dispense).toBe(3 + 1)
+    expect(result.referenceVolumes.correction.aspirate).toBe(6 + 1 + 2)
+    expect(result.referenceVolumes.correction.dispense).toBe(3)
     expect(result.referenceVolumes.pushOut).toBe(3)
     expect(result.referenceVolumes.conditioning).toBe(6)
     expect(result.referenceVolumes.disposal).toBe(6)
-    expect(result.referenceVolumes.flowRateAspirate).toBe(6 + 1 + 2)
-    expect(result.referenceVolumes.flowRateDispense).toBe(3)
+    expect(result.referenceVolumes.flowRate.aspirate).toBe(6 + 1 + 2)
     expect(result.multiWellHandling.isSupported).toBe(true)
     expect(result.multiWellHandling.numWellsToFitInTip).toBe(2)
   })
@@ -316,7 +328,7 @@ describe('getTransferPlanAndReferenceVolumes', () => {
       conditioningByVolume: null,
       disposalByVolume: null,
     })
-    expect(result.referenceVolumes.airGap).toBe(1)
+    expect(result.referenceVolumes.airGap.aspirate).toBe(1)
   })
 
   it('should use default liquids if lowVolumeDefault is not defined', () => {
@@ -339,6 +351,6 @@ describe('getTransferPlanAndReferenceVolumes', () => {
       conditioningByVolume: null,
       disposalByVolume: null,
     })
-    expect(result.referenceVolumes.airGap).toBe(0.8)
+    expect(result.referenceVolumes.airGap.aspirate).toBe(0.8)
   })
 })

--- a/step-generation/src/utils/misc.ts
+++ b/step-generation/src/utils/misc.ts
@@ -952,16 +952,18 @@ const _getTotalVolumeForMultiDispense = (
 }
 
 export interface ReferenceVolumes {
-  airGap: number
-  correctionAspirate: number
-  correctionDispense: number
   pushOut: number
-  flowRateAspirate: number
-  flowRateDispense: number
+  airGap: ValueByLiquidHandlingType
+  correction: ValueByLiquidHandlingType
+  flowRate: ValueByLiquidHandlingType
   conditioning?: number
   disposal?: number
 }
 
+interface ValueByLiquidHandlingType {
+  aspirate: number
+  dispense: number
+}
 export const getTransferPlanAndReferenceVolumes = (args: {
   pipetteSpecs: PipetteV2Specs
   tiprackDefinition: LabwareDefinition2 | null
@@ -1042,12 +1044,19 @@ export const getTransferPlanAndReferenceVolumes = (args: {
     const volumePerAspiration = volume / numAspirations
     return {
       referenceVolumes: {
-        airGap: volumePerAspiration,
-        correctionAspirate: volumePerAspiration,
-        correctionDispense: volumePerAspiration,
+        airGap: {
+          aspirate: volumePerAspiration,
+          dispense: 0,
+        },
+        correction: {
+          aspirate: volumePerAspiration,
+          dispense: volumePerAspiration,
+        },
         pushOut: volumePerAspiration,
-        flowRateAspirate: volumePerAspiration,
-        flowRateDispense: volumePerAspiration,
+        flowRate: {
+          aspirate: volumePerAspiration,
+          dispense: volumePerAspiration,
+        },
       },
       multiWellHandling: {
         isSupported: false,
@@ -1073,27 +1082,41 @@ export const getTransferPlanAndReferenceVolumes = (args: {
     }
     return {
       referenceVolumes: {
-        airGap: _getTotalVolumeForMultiDispense(
-          totalVolumeForMultiDispense,
-          conditioningByVolume ?? [],
-          disposalByVolume ?? [],
-          false
-        ),
-        correctionAspirate: _getTotalVolumeForMultiDispense(
-          totalVolumeForMultiDispense,
-          conditioningByVolume ?? [],
-          disposalByVolume ?? []
-        ),
-        correctionDispense: volume,
+        airGap: {
+          aspirate: _getTotalVolumeForMultiDispense(
+            totalVolumeForMultiDispense,
+            conditioningByVolume ?? [],
+            disposalByVolume ?? [],
+            false
+          ),
+          dispense: _getTotalVolumeForMultiDispense(
+            // here, we interpolate the post-dispense air gap volume based on the total volume in the tip
+            // after the first dispense
+            (numDestinationsPerAspiration - 1) * volume,
+            conditioningByVolume ?? [],
+            disposalByVolume ?? [],
+            false
+          ),
+        },
+        correction: {
+          aspirate: _getTotalVolumeForMultiDispense(
+            totalVolumeForMultiDispense,
+            conditioningByVolume ?? [],
+            disposalByVolume ?? []
+          ),
+          dispense: volume,
+        },
+        flowRate: {
+          aspirate: _getTotalVolumeForMultiDispense(
+            totalVolumeForMultiDispense,
+            conditioningByVolume ?? [],
+            disposalByVolume ?? []
+          ),
+          dispense: volume,
+        },
         pushOut: volume,
         conditioning: totalVolumeForMultiDispense,
         disposal: totalVolumeForMultiDispense,
-        flowRateAspirate: _getTotalVolumeForMultiDispense(
-          totalVolumeForMultiDispense,
-          conditioningByVolume ?? [],
-          disposalByVolume ?? []
-        ),
-        flowRateDispense: volume,
       },
       multiWellHandling: {
         isSupported: true,
@@ -1106,12 +1129,21 @@ export const getTransferPlanAndReferenceVolumes = (args: {
   const volumeTotalAspiration = maxSourcesPerAspiration * volume
   return {
     referenceVolumes: {
-      airGap: volumeTotalAspiration,
-      correctionAspirate: volumeTotalAspiration,
-      correctionDispense: volumeTotalAspiration,
+      airGap: {
+        // here, we interpolate the post-aspirate air gap volume based on the total volume in the tip
+        // after the final aspiration
+        aspirate: volumeTotalAspiration,
+        dispense: 0,
+      },
       pushOut: volumeTotalAspiration,
-      flowRateAspirate: volume,
-      flowRateDispense: volumeTotalAspiration,
+      correction: {
+        aspirate: volumeTotalAspiration,
+        dispense: volumeTotalAspiration,
+      },
+      flowRate: {
+        aspirate: volume,
+        dispense: volumeTotalAspiration,
+      },
     },
     multiWellHandling: {
       isSupported: true,


### PR DESCRIPTION
# Overview

Updates `step-generation` util `getTransferPlanAndReferenceVolumes` to return most accurate reference volumes for aspirate and dispense properties.

### Context

The util `getTransferPlanAndReferenceVolumes` in `step-generation` takes various parameters of a PD transfer, including number of sources/destinations, path, volume, pipette, tiprack, and liquid class, and returns a calculated transfer plan for the parameters, as well the reference volumes on which to interpolate various by-volume properties for the liquid class— in other words, the x-values to lookup on the liquid class definition's by-volume curves.

Some of these volumes are straightforward. For example, in a transfer with a single path (n wells-to-n wells), we interpolate all by-volume properties (post-aspirate air gap, flow rate, correction volumes) based on the transfer volume, or split transfer volume if the full volume cannot be accommodated in the tip.

However, the volume on which to interpolate is not as straightforward to represent as a constant number in other scenarios. For example, post-dispense air gap should be interpolated based on the volume of liquid in the tip at the time of the air gap. If we specify a multi-dispense path, it becomes apparent that the volume on which to interpolate varies from well to well— that is, the volume in the tip after the first dispense is higher than that after the second dispense, and so on.

In order to respect the constant air gap value entered by the user in the PD step form for post-dispense air gap in this case, we cannot find the correct interpolated post-dispense air gap value after each dispense "behind the scenes." To provide an accurate option for the user to start with, we have settled as a team on presenting the interpolated by-volume post-dispense air gap for multi-dispense transfers interpolated on the _volume remaining in the tip after the first dispense_. Similarly, for post-aspirate air gap in multi-aspirate transfers, we will present the value interpolated on the _planned maximum total aspiration volume for the largest "chunk" of aspirations_.

As part of this update, I break some of the reference volume keys into objects with `aspirate` and `dispense` property reference volumes for clarity, and wire them up appropriately in our `handleFormChange` utils.

## Changelog

- update `getTransferPlanAndReferenceVolumes` according to description above
- correctly access nested reference volume properties in `FlowRateField` and PD `handleFormChange` utils
- update tests

## Review requests

Please read through the description and check out the refactored `getTransferPlanAndReferenceVolumes` util to make sure it makes sense.

## Risk assessment

low-medium. These changes should only serve to make our presented by-volume interpolated constant values more accurate in PD step forms
