### PR TITLE
fix(app): During stacker error recovery use Protocol Engine labware quantity

### DIFF
--- a/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useFailedLabwareUtils.test.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useFailedLabwareUtils.test.tsx
@@ -1,7 +1,6 @@
 import { renderHook } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 
-import { NozzleLayoutValues, RunCurrentState } from '@opentrons/api-client'
 import { FLEX_STACKER_MODULE_V1 } from '@opentrons/shared-data'
 
 import { DEFINED_ERROR_TYPES, ERROR_KINDS } from '../../constants'
@@ -14,7 +13,7 @@ import {
   useRelevantFailedLwLocations,
 } from '../useFailedLabwareUtils'
 
-import type { RunCommandSummary } from '@opentrons/api-client'
+import type { RunCommandSummary, RunCurrentState } from '@opentrons/api-client'
 
 vi.mock('@opentrons/shared-data', async () => {
   const actual = await vi.importActual('@opentrons/shared-data')
@@ -289,52 +288,6 @@ describe('getFailedLabwareQuantity', () => {
     },
   }
 
-  const runCommands = {
-    data: [
-      {
-        id: 'set-stored-labware-1',
-        commandType: 'flexStacker/setStoredLabware',
-        params: {
-          initialCount: 2,
-        },
-      } as any,
-      {
-        id: 'retrive-id-1',
-        commandType: 'flexStacker/retrieve',
-        params: {
-          moduleId: 'module-id',
-        },
-      } as any,
-      {
-        id: 'retrive-id-2',
-        commandType: 'flexStacker/retrieve',
-        params: {
-          moduleId: 'module-id',
-        },
-      } as any,
-      {
-        id: 'set-stored-labware',
-        commandType: 'flexStacker/setStoredLabware',
-        params: {
-          initialCount: 5,
-        },
-      } as any,
-      {
-        id: 'retrive-id',
-        commandType: 'flexStacker/retrieve',
-        params: {
-          moduleId: 'module-id',
-        },
-      } as any,
-      { ...failedRetriveCommand },
-    ] as RunCommandSummary[],
-    meta: {
-      totalLength: 10,
-      pageLength: 1,
-    },
-    links: {},
-  }
-
   it('should return the quantity for stacker error kinds', () => {
     const errors = [
       ERROR_KINDS.STACKER_SHUTTLE_MISSING,
@@ -437,14 +390,6 @@ describe('getFailedLabwareQuantity', () => {
   })
 
   it('should return 0 if there is no commands in list', () => {
-    const emptyRunCommands = {
-      data: [{ ...failedRetriveCommand }] as RunCommandSummary[],
-      meta: {
-        totalLength: 10,
-        pageLength: 1,
-      },
-      links: {},
-    }
     const failedLocalRetriveCommand = {
       byRunRecord: {
         ...failedCommand,

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useFailedLabwareUtils.test.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useFailedLabwareUtils.test.tsx
@@ -13,7 +13,7 @@ import {
   useRelevantFailedLwLocations,
 } from '../useFailedLabwareUtils'
 
-import type { RunCommandSummary, RunCurrentState } from '@opentrons/api-client'
+import type { RunCurrentState } from '@opentrons/api-client'
 
 vi.mock('@opentrons/shared-data', async () => {
   const actual = await vi.importActual('@opentrons/shared-data')
@@ -278,15 +278,6 @@ describe('getFailedLabwareQuantity', () => {
       moduleId: 'module-id',
     },
   } as any
-
-  const failedRetriveCommand = {
-    ...failedCommand,
-    commandType: 'flexStacker/retrieve',
-    error: {
-      isDefined: true,
-      errorType: DEFINED_ERROR_TYPES.STACKER_STALL,
-    },
-  }
 
   it('should return the quantity for stacker error kinds', () => {
     const errors = [

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useFailedLabwareUtils.test.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useFailedLabwareUtils.test.tsx
@@ -1,6 +1,7 @@
 import { renderHook } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 
+import { NozzleLayoutValues, RunCurrentState } from '@opentrons/api-client'
 import { FLEX_STACKER_MODULE_V1 } from '@opentrons/shared-data'
 
 import { DEFINED_ERROR_TYPES, ERROR_KINDS } from '../../constants'
@@ -342,62 +343,44 @@ describe('getFailedLabwareQuantity', () => {
     ]
     errors.forEach(errorType => {
       const failedLocalRetriveCommand = {
-        ...failedCommand,
-        commandType: 'flexStacker/retrieve',
-        error: {
-          isDefined: true,
-          errorType,
+        byRunRecord: {
+          ...failedCommand,
+          error: { errorType: 'SOME_UNHANDLED_ERROR' },
+        },
+        byAnalysis: {
+          ...failedCommand,
+          error: { errorType: 'SOME_UNHANDLED_ERROR' },
         },
       }
-      const localRunCommands = {
-        data: [
-          {
-            id: 'set-stored-labware-1',
-            commandType: 'flexStacker/setStoredLabware',
-            params: {
-              initialCount: 2,
+
+      const currentRunState = {
+        data: {
+          estopEngaged: false,
+          activeNozzleLayouts: {
+            abc: {
+              startingNozzle: 'A1',
+              activeNozzles: ['A1'],
+              config: 'single',
             },
-          } as any,
-          {
-            id: 'retrive-id-1',
-            commandType: 'flexStacker/retrieve',
-            params: {
-              moduleId: 'module-id',
+          },
+          tipStates: { abc: { hasTip: false } },
+          placeLabwareState: undefined,
+          flexStackerStates: {
+            'module-id': {
+              primaryLabwareURI: 'huh',
+              adapterLabwareURI: 'whu',
+              lidLabwareURI: 'buh',
+              count: 4,
+              maxCount: 5,
             },
-          } as any,
-          {
-            id: 'retrive-id-2',
-            commandType: 'flexStacker/retrieve',
-            params: {
-              moduleId: 'module-id',
-            },
-          } as any,
-          {
-            id: 'set-stored-labware',
-            commandType: 'flexStacker/setStoredLabware',
-            params: {
-              initialCount: 5,
-            },
-          } as any,
-          {
-            id: 'retrive-id',
-            commandType: 'flexStacker/retrieve',
-            params: {
-              moduleId: 'module-id',
-            },
-          } as any,
-          { ...failedLocalRetriveCommand },
-        ] as RunCommandSummary[],
-        meta: {
-          totalLength: 10,
-          pageLength: 1,
+          },
         },
-        links: {},
+        links: { lastCompleted: { id: 'test', href: 'test2' } },
       }
+
       const result = getFailedLabwareQuantity(
-        localRunCommands,
         failedLocalRetriveCommand,
-        errorType
+        currentRunState as RunCurrentState
       )
       expect(result).toEqual(4)
     })
@@ -409,67 +392,45 @@ describe('getFailedLabwareQuantity', () => {
       ERROR_KINDS.STACKER_HOPPER_EMPTY,
       ERROR_KINDS.STACKER_STALLED,
     ]
-    errors.forEach(errorType => {
+    errors.forEach(errorKind => {
       const failedLocalRetriveCommand = {
-        ...failedCommand,
-        commandType: 'flexStacker/retrieve',
-        error: {
-          isDefined: true,
-          errorType,
+        byRunRecord: {
+          ...failedCommand,
+          error: { errorType: errorKind },
+        },
+        byAnalysis: {
+          ...failedCommand,
+          error: { errorType: errorKind },
         },
       }
-      const localRunCommands = {
-        data: [
-          {
-            id: 'set-stored-labware-1',
-            commandType: 'flexStacker/setStoredLabware',
-            params: {
-              initialCount: 2,
+
+      const currentRunState = {
+        data: {
+          estopEngaged: false,
+          activeNozzleLayouts: {
+            abc: {
+              startingNozzle: 'A1',
+              activeNozzles: ['A1'],
+              config: 'single',
             },
-          } as any,
-          {
-            id: 'retrive-id-1',
-            commandType: 'flexStacker/retrieve',
-            params: {
-              moduleId: 'module-id',
+          },
+          tipStates: { abc: { hasTip: false } },
+          placeLabwareState: undefined,
+          flexStackerStates: {
+            'module-id': {
+              primaryLabwareURI: 'huh',
+              adapterLabwareURI: 'whu',
+              lidLabwareURI: 'buh',
+              count: 4,
+              maxCount: 5,
             },
-          } as any,
-          {
-            id: 'retrive-id-2',
-            commandType: 'flexStacker/retrieve',
-            params: {
-              moduleId: 'module-id',
-            },
-          } as any,
-          {
-            id: 'set-stored-labware',
-            commandType: 'flexStacker/setStoredLabware',
-            params: {
-              initialCount: 5,
-            },
-          } as any,
-          {
-            id: 'retrive-id',
-            commandType: 'flexStacker/retrieve',
-            params: {
-              moduleId: 'module-id',
-            },
-            result: {
-              primaryLocationSequence: [1, 2, 3, 4],
-            },
-          } as any,
-          { ...failedLocalRetriveCommand },
-        ] as RunCommandSummary[],
-        meta: {
-          totalLength: 10,
-          pageLength: 1,
+          },
         },
-        links: {},
+        links: { lastCompleted: { id: 'test', href: 'test2' } },
       }
       const result = getFailedLabwareQuantity(
-        localRunCommands,
         failedLocalRetriveCommand,
-        errorType
+        currentRunState as RunCurrentState
       )
       expect(result).toEqual(4)
     })
@@ -484,37 +445,55 @@ describe('getFailedLabwareQuantity', () => {
       },
       links: {},
     }
+    const failedLocalRetriveCommand = {
+      byRunRecord: {
+        ...failedCommand,
+        error: { errorType: ERROR_KINDS.STACKER_STALLED },
+      },
+      byAnalysis: {
+        ...failedCommand,
+        error: { errorType: ERROR_KINDS.STACKER_STALLED },
+      },
+    }
+
+    const currentRunState = {
+      data: {
+        estopEngaged: false,
+        activeNozzleLayouts: {
+          abc: {
+            startingNozzle: 'A1',
+            activeNozzles: ['A1'],
+            config: 'single',
+          },
+        },
+        tipStates: { abc: { hasTip: false } },
+        placeLabwareState: undefined,
+        flexStackerStates: {
+          'module-id': {
+            primaryLabwareURI: 'huh',
+            adapterLabwareURI: 'whu',
+            lidLabwareURI: 'buh',
+            count: 0,
+            maxCount: 5,
+          },
+        },
+      },
+      links: { lastCompleted: { id: 'test', href: 'test2' } },
+    }
     const result = getFailedLabwareQuantity(
-      emptyRunCommands,
-      failedRetriveCommand,
-      ERROR_KINDS.STACKER_STALLED
+      failedLocalRetriveCommand,
+      currentRunState as RunCurrentState
     )
     expect(result).toEqual(0)
   })
 
   it('should return null if there is no runCommands', () => {
-    const result = getFailedLabwareQuantity(
-      undefined,
-      failedRetriveCommand,
-      ERROR_KINDS.STACKER_STALLED
-    )
-    expect(result).toBeNull()
-  })
+    const failedLocalRetriveCommand = null
 
-  it('should return null for unhandled error kinds', () => {
-    const failedMoveLabwareCommand = {
-      ...failedCommand,
-      commandType: 'flexStacker/moveLabware',
-      error: {
-        isDefined: true,
-        errorType: DEFINED_ERROR_TYPES.GRIPPER_MOVEMENT,
-      },
-    }
-
+    const currentRunState = undefined
     const result = getFailedLabwareQuantity(
-      runCommands,
-      failedMoveLabwareCommand,
-      ERROR_KINDS.GRIPPER_ERROR
+      failedLocalRetriveCommand,
+      currentRunState
     )
     expect(result).toBeNull()
   })

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useERUtils.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useERUtils.ts
@@ -1,6 +1,9 @@
 import { useMemo } from 'react'
 
-import { useInstrumentsQuery } from '@opentrons/react-api-client'
+import {
+  useInstrumentsQuery,
+  useRunCurrentState,
+} from '@opentrons/react-api-client'
 
 import { useRecoveryAnalytics } from '/app/redux-resources/analytics'
 import { getRunningStepCountsFrom } from '/app/resources/protocols'
@@ -90,6 +93,7 @@ export function useERUtils({
 }: ERUtilsProps): ERUtilsResults {
   const { data: attachedInstruments } = useInstrumentsQuery()
   const { data: runRecord } = useNotifyRunQuery(runId)
+  const { data: runCurrentState } = useRunCurrentState(runId)
   // TODO(jh, 06-04-24): Refactor the utilities that derive info
   // from runCommands once the server yields that info directly on an existing/new endpoint. We'll still need this with a
   // pageLength of 1 though for stepCount things.
@@ -162,6 +166,7 @@ export function useERUtils({
     failedPipetteInfo,
     runRecord,
     runCommands,
+    runCurrentState,
   })
 
   const recoveryCommands = useRecoveryCommands({

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useFailedLabwareUtils.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useFailedLabwareUtils.ts
@@ -5,9 +5,7 @@ import without from 'lodash/without'
 import {
   getLabwareDisplayLocation,
   getLoadedLabware,
-  KEYS_BY_COMMAND_TYPE,
 } from '@opentrons/components'
-import { useRunCurrentState } from '@opentrons/react-api-client'
 import {
   FLEX_ROBOT_TYPE,
   getAllLabwareDefs,
@@ -18,7 +16,12 @@ import {
 import { ERROR_KINDS, STACKER_ERROR_KINDS } from '../constants'
 import { getErrorKind } from '../utils'
 
-import type { CommandsData, PipetteData, Run } from '@opentrons/api-client'
+import type {
+  CommandsData,
+  PipetteData,
+  Run,
+  RunCurrentState,
+} from '@opentrons/api-client'
 import type {
   DisplayLocationSlotOnlyParams,
   WellGroup,
@@ -28,7 +31,6 @@ import type {
   DispenseRunTimeCommand,
   Failed,
   FlexStackerRetrieveRunTimeCommand,
-  FlexStackerStoreRunTimeCommand,
   LabwareDefinition,
   LabwareLocation,
   LiquidProbeRunTimeCommand,
@@ -49,6 +51,7 @@ interface UseFailedLabwareUtilsProps {
   failedPipetteInfo: PipetteData | null
   runCommands?: CommandsData
   runRecord?: Run
+  runCurrentState?: RunCurrentState
 }
 
 interface RelevantFailedLabwareLocations {
@@ -100,6 +103,7 @@ export function useFailedLabwareUtils({
   failedPipetteInfo,
   runCommands,
   runRecord,
+  runCurrentState,
 }: UseFailedLabwareUtilsProps): UseFailedLabwareUtilsResult {
   const failedCommandByRunRecord = failedCommand?.byRunRecord ?? null
   const errorKind = getErrorKind(failedCommand)
@@ -164,7 +168,10 @@ export function useFailedLabwareUtils({
     errorKind,
   })
 
-  const labwareQuantity = getFailedLabwareQuantity(failedCommand, runRecord)
+  const labwareQuantity = getFailedLabwareQuantity(
+    failedCommand,
+    runCurrentState
+  )
 
   return {
     ...tipSelectionUtils,
@@ -339,10 +346,9 @@ function useTipSelectionUtils(
 
 export function getFailedLabwareQuantity(
   failedCommand: FailedCommandBySource | null,
-  runRecord: Run | undefined
+  runCurrentState: RunCurrentState | undefined
 ): number | null {
-  if (runRecord != undefined && failedCommand != null) {
-    const { data: runCurrentState } = useRunCurrentState(runRecord.data.id)
+  if (runCurrentState != undefined && failedCommand != null) {
     if ('moduleId' in failedCommand.byRunRecord.params) {
       const flexStacker =
         runCurrentState?.data.flexStackerStates?.[

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useFailedLabwareUtils.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useFailedLabwareUtils.ts
@@ -5,7 +5,9 @@ import without from 'lodash/without'
 import {
   getLabwareDisplayLocation,
   getLoadedLabware,
+  KEYS_BY_COMMAND_TYPE,
 } from '@opentrons/components'
+import { useRunCurrentState } from '@opentrons/react-api-client'
 import {
   FLEX_ROBOT_TYPE,
   getAllLabwareDefs,
@@ -162,11 +164,7 @@ export function useFailedLabwareUtils({
     errorKind,
   })
 
-  const labwareQuantity = getFailedLabwareQuantity(
-    runCommands,
-    recentRelevantFailedLabwareCmd,
-    errorKind
-  )
+  const labwareQuantity = getFailedLabwareQuantity(failedCommand, runRecord)
 
   return {
     ...tipSelectionUtils,
@@ -340,70 +338,22 @@ function useTipSelectionUtils(
 }
 
 export function getFailedLabwareQuantity(
-  runCommands: CommandsData | undefined,
-  recentRelevantFailedLabwareCmd: FailedCommandRelevantLabware,
-  errorKind: ErrorKind
+  failedCommand: FailedCommandBySource | null,
+  runRecord: Run | undefined
 ): number | null {
-  if (STACKER_ERROR_KINDS.includes(errorKind) && runCommands != null) {
-    const failedCommandIndex = runCommands?.data.findIndex(
-      x => x.id === recentRelevantFailedLabwareCmd?.id
-    )
-
-    const commandsBeforefailedCmd = runCommands?.data.slice(
-      0,
-      failedCommandIndex ?? 0
-    )
-
-    const storeOrRetrieveLabwareLast = commandsBeforefailedCmd?.findLast(
-      (
-        cmd
-      ): cmd is
-        | FlexStackerRetrieveRunTimeCommand
-        | FlexStackerStoreRunTimeCommand =>
-        cmd.commandType === 'flexStacker/retrieve' ||
-        cmd.commandType === 'flexStacker/store'
-    )
-    if (
-      storeOrRetrieveLabwareLast != null &&
-      'result' in storeOrRetrieveLabwareLast
-    ) {
-      return storeOrRetrieveLabwareLast.commandType === 'flexStacker/retrieve'
-        ? storeOrRetrieveLabwareLast?.result?.primaryLocationSequence.length ??
-            0
-        : storeOrRetrieveLabwareLast?.result
-            ?.eventualDestinationLocationSequence?.length ?? 0
-    }
-    // in case there is no result calculate based on setStoredLabware count
-    else {
-      const setStoredLabwareLast = commandsBeforefailedCmd?.findLast(
-        cmd => cmd.commandType === 'flexStacker/setStoredLabware'
-      )
-      const setStoredLabwareLastIndex = commandsBeforefailedCmd?.findLastIndex(
-        cmd => cmd.commandType === 'flexStacker/setStoredLabware'
-      )
-      const itemsToCheck = commandsBeforefailedCmd?.slice(
-        setStoredLabwareLastIndex ?? 0,
-        failedCommandIndex ?? 0
-      )
-
-      if (
-        setStoredLabwareLast != null &&
-        'initialCount' in setStoredLabwareLast.params
-      ) {
-        const total = setStoredLabwareLast?.params.initialCount ?? 0
-        const retreiveCmds =
-          itemsToCheck?.filter(
-            cmd => cmd.commandType === 'flexStacker/retrieve'
-          ).length ?? 0
-        const storeCmds =
-          itemsToCheck?.filter(cmd => cmd.commandType === 'flexStacker/store')
-            .length ?? 0
-        return total - retreiveCmds + storeCmds
-      } else {
-        return 0
+  if (runRecord != undefined && failedCommand != null) {
+    const { data: runCurrentState } = useRunCurrentState(runRecord.data.id)
+    if ('moduleId' in failedCommand.byRunRecord.params) {
+      const flexStacker =
+        runCurrentState?.data.flexStackerStates?.[
+          failedCommand.byRunRecord.params.moduleId
+        ]
+      if (flexStacker) {
+        return flexStacker.count
       }
     }
   }
+
   return null
 }
 

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useFailedLabwareUtils.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useFailedLabwareUtils.ts
@@ -348,7 +348,7 @@ export function getFailedLabwareQuantity(
   failedCommand: FailedCommandBySource | null,
   runCurrentState: RunCurrentState | undefined
 ): number | null {
-  if (runCurrentState != undefined && failedCommand != null) {
+  if (runCurrentState !== undefined && failedCommand !== null) {
     if ('moduleId' in failedCommand.byRunRecord.params) {
       const flexStacker =
         runCurrentState?.data.flexStackerStates?.[


### PR DESCRIPTION
# Overview
Covers RQA-4290

Originally the client was iterating through Store/Retrieve commands to determine how much labware remained. This would become desynchronized if multiple error recovery events would occur during a protocol run. Instead this PR switches to using the Protocol Engine stacker labware count, which will be accurate regardless of what steps have occurred. 

## Test Plan and Hands on Testing

- [x] Run on Flex with stacker "loaded" with 6 tip racks (leave the stacker empty). Request several retrieves, and through each error recovery step ensure that the labware count to load reduces each time as expected.

## Changelog
Swapped the command tracking logic in `getFailedLabwareQuantity` with data pulled from the `get_current_state` endpoint.

## Review requests
Anywhere else we think we might want to make this kind of change?

## Risk assessment
Low - fixes new stacker behavior.