### PR TITLE
refactor(step-generation): remove version number from load labware & …

### DIFF
--- a/protocol-designer/src/file-data/__tests__/createFile.test.ts
+++ b/protocol-designer/src/file-data/__tests__/createFile.test.ts
@@ -166,14 +166,12 @@ def run(protocol: protocol_api.ProtocolContext) -> None:
         location="1",
         label="Opentrons 96 Tip Rack 10 µL",
         namespace="opentrons",
-        version=1,
     )
     mock_python_name_3 = protocol.load_labware(
         "fixture_96_plate",
         location="7",
         label="NEST 96 Well Plate 100 µL PCR Full Skirt",
         namespace="opentrons",
-        version=1,
     )
 
     # Load Pipettes:

--- a/step-generation/src/__tests__/pythonFileUtils.test.ts
+++ b/step-generation/src/__tests__/pythonFileUtils.test.ts
@@ -213,7 +213,6 @@ describe('getLoadAdapters', () => {
 adapter_1 = magnetic_block_1.load_adapter(
     "fixture_flex_96_tiprack_adapter",
     namespace="opentrons",
-    version=1,
 )
 adapter_2 = protocol.load_adapter_from_definition(
     CUSTOM_LABWARE["fixture/fixture_flex_96_tiprack_adapter/1"],
@@ -239,12 +238,10 @@ well_plate_1 = adapter_2.load_labware(
     "fixture_96_plate",
     label="reagent plate",
     namespace="opentrons",
-    version=1,
 )
 well_plate_2 = magnetic_block_2.load_labware(
     "fixture_96_plate",
     namespace="opentrons",
-    version=1,
 )
 well_plate_3 = protocol.load_labware_from_definition(
     CUSTOM_LABWARE["fixture/fixture_96_plate/1"],
@@ -277,7 +274,6 @@ well_plate_5 = protocol.load_labware(
     "fixture_96_plate",
     location=protocol_api.OFF_DECK,
     namespace="opentrons",
-    version=1,
 )`.trimStart()
       )
     })

--- a/step-generation/src/utils/pythonFileUtils.ts
+++ b/step-generation/src/utils/pythonFileUtils.ts
@@ -132,7 +132,10 @@ export function getLoadAdapters(
           `${formatPyStr(parameters.loadName)}`,
           ...(locationArg ? [locationArg] : []),
           `namespace=${formatPyStr(namespace)}`,
-          `version=${version}`,
+          //  NOTE: temporarily removing version number
+          //  until PD migrated labware defs to the latest version
+          //  upon re-import
+          // `version=${version}`,
         ].join(',\n')
         return (
           `${pythonName} = ${parentName}.load_adapter(\n` +
@@ -201,7 +204,10 @@ export function getLoadLabware(
           ...(locationArg ? [locationArg] : []),
           ...(labelArg ? [labelArg] : []),
           `namespace=${formatPyStr(namespace)}`,
-          `version=${version}`,
+          //  NOTE: temporarily removing version number
+          //  until PD migrated labware defs to the latest version
+          //  upon re-import
+          // `version=${version}`,
         ].join(',\n')
         return (
           `${pythonName} = ${parentName}.load_labware(\n` +

--- a/step-generation/src/utils/pythonFileUtils.ts
+++ b/step-generation/src/utils/pythonFileUtils.ts
@@ -110,7 +110,7 @@ export function getLoadAdapters(
   const pythonAdapters = Object.values(adapterEntities)
     .map(adapter => {
       const { id, def, pythonName } = adapter
-      const { parameters, namespace, version } = def
+      const { parameters, namespace } = def
       // 2nd item in stack is the slot the adapter is on
       const adapterSlot = labwareRobotState[id].stack[1]
       const onModule = moduleEntities[adapterSlot] != null
@@ -172,7 +172,7 @@ export function getLoadLabware(
   const pythonLabware = Object.values(labwareEntities)
     .map(labware => {
       const { id, def, pythonName } = labware
-      const { metadata, parameters, namespace, version } = def
+      const { metadata, parameters, namespace } = def
       const hasNickname =
         labwareNicknamesById[id] != null &&
         labwareNicknamesById[id] !== metadata.displayName


### PR DESCRIPTION
…adapter

# Overview

This is a temporary fix that addresses the issue where the labware definitions are missing the inner well geometry. When the version number is removed, i believe PE automatically uses the latest labware definition version.

In a follow up post-8.5.0 release, we should refactor PD to migrate labwares to the latest versions when importing an older protocol: [here](https://opentrons.atlassian.net/browse/AUTH-1997) is the ticket to address that.

## Test Plan and Hands on Testing

Review code. i already smoke tested but you can smoke test as well 😄 

## Changelog

- temp comment out the version numbers and fix tests

## Risk assessment

low
