### PR TITLE
feat(protocol-designer): add 8.5.0 migration modal

### DIFF
--- a/protocol-designer/cypress/e2e/migrations.cy.ts
+++ b/protocol-designer/cypress/e2e/migrations.cy.ts
@@ -29,20 +29,20 @@ describe('Protocol fixtures migrate and match snapshots', () => {
       title: 'doItAllV3 (schema 3, PD version 4.0.0) -> PD 8.5.x, schema 8',
       importTestFile: TestFilePath.DoItAllV3V4,
       expectedTestFile: TestFilePath.DoItAllV3MigratedToV8,
-      migrationModal: 'v8.1',
+      migrationModal: 'v8.5',
     },
     {
       title: 'doItAllV4 (schema 4, PD version 4.0.0) -> PD 8.5.x, schema 8',
       importTestFile: TestFilePath.DoItAllV4V4,
       expectedTestFile: TestFilePath.DoItAllV4MigratedToV8,
-      migrationModal: 'v8.1',
+      migrationModal: 'v8.5',
     },
     {
       title:
         'doItAllv7MigratedToV8 (schema 7, PD version 8.0.0) -> should migrate to 8.5.x, schema 8',
       importTestFile: TestFilePath.DoItAllV7,
       expectedTestFile: TestFilePath.DoItAllV7MigratedToV8,
-      migrationModal: 'v8.1',
+      migrationModal: 'v8.5',
     },
     {
       title:
@@ -70,7 +70,7 @@ describe('Protocol fixtures migrate and match snapshots', () => {
         'thermocycler on Ot2 (schema 7, PD version 7.0.0) -> should migrate to 8.5.x, schema 8',
       importTestFile: TestFilePath.ThermocyclerOnOt2V7,
       expectedTestFile: TestFilePath.ThermocyclerOnOt2V7MigratedToV8,
-      migrationModal: 'v8.1',
+      migrationModal: 'v8.5',
     },
   ]
 

--- a/protocol-designer/cypress/e2e/migrations.cy.ts
+++ b/protocol-designer/cypress/e2e/migrations.cy.ts
@@ -23,7 +23,7 @@ describe('Protocol fixtures migrate and match snapshots', () => {
       title: 'example_1_1_0 (schema 1, PD version 1.1.1) -> PD 8.5.x, schema 8',
       importTestFile: TestFilePath.Example_1_1_0,
       expectedTestFile: TestFilePath.Example_1_1_0V8,
-      migrationModal: 'newLabwareDefs',
+      migrationModal: 'v8.5',
     },
     {
       title: 'doItAllV3 (schema 3, PD version 4.0.0) -> PD 8.5.x, schema 8',

--- a/protocol-designer/cypress/e2e/migrations.cy.ts
+++ b/protocol-designer/cypress/e2e/migrations.cy.ts
@@ -23,65 +23,65 @@ describe('Protocol fixtures migrate and match snapshots', () => {
       title: 'example_1_1_0 (schema 1, PD version 1.1.1) -> PD 8.5.x, schema 8',
       importTestFile: TestFilePath.Example_1_1_0,
       expectedTestFile: TestFilePath.Example_1_1_0V8,
-      migrationModal: 'v8.5',
+      showMigrationModal: true,
     },
     {
       title: 'doItAllV3 (schema 3, PD version 4.0.0) -> PD 8.5.x, schema 8',
       importTestFile: TestFilePath.DoItAllV3V4,
       expectedTestFile: TestFilePath.DoItAllV3MigratedToV8,
-      migrationModal: 'v8.5',
+      showMigrationModal: true,
     },
     {
       title: 'doItAllV4 (schema 4, PD version 4.0.0) -> PD 8.5.x, schema 8',
       importTestFile: TestFilePath.DoItAllV4V4,
       expectedTestFile: TestFilePath.DoItAllV4MigratedToV8,
-      migrationModal: 'v8.5',
+      showMigrationModal: true,
     },
     {
       title:
         'doItAllv7MigratedToV8 (schema 7, PD version 8.0.0) -> should migrate to 8.5.x, schema 8',
       importTestFile: TestFilePath.DoItAllV7,
       expectedTestFile: TestFilePath.DoItAllV7MigratedToV8,
-      migrationModal: 'v8.5',
+      showMigrationModal: true,
     },
     {
       title:
         '96-channel full and column schema 8 -> should migrate to 8.5.x, schema 8',
       importTestFile: TestFilePath.NinetySixChannelFullAndColumn,
       expectedTestFile: TestFilePath.NinetySixChannelFullAndColumn,
-      migrationModal: null,
+      showMigrationModal: false,
     },
     {
       title:
         'doItAllV8 flex robot -> reimported, should migrate to 8.5.x, schema 8',
       importTestFile: TestFilePath.DoItAllV8,
       expectedTestFile: TestFilePath.DoItAllV8,
-      migrationModal: null,
+      showMigrationModal: false,
     },
     {
       title:
         'new advanced settings with multi temp => reimported, should not migrate and stay at 8.5.x, schema 8',
       importTestFile: TestFilePath.NewAdvancedSettingsAndMultiTemp,
       expectedTestFile: TestFilePath.NewAdvancedSettingsAndMultiTemp,
-      migrationModal: null,
+      showMigrationModal: false,
     },
     {
       title:
         'thermocycler on Ot2 (schema 7, PD version 7.0.0) -> should migrate to 8.5.x, schema 8',
       importTestFile: TestFilePath.ThermocyclerOnOt2V7,
       expectedTestFile: TestFilePath.ThermocyclerOnOt2V7MigratedToV8,
-      migrationModal: 'v8.5',
+      showMigrationModal: true,
     },
   ]
 
   testCases.forEach(
-    ({ title, importTestFile, expectedTestFile, migrationModal }) => {
+    ({ title, importTestFile, expectedTestFile, showMigrationModal }) => {
       it(title, () => {
         migrateAndMatchSnapshot({
           title,
           importTestFile,
           expectedTestFile,
-          migrationModal,
+          showMigrationModal,
         })
       })
     }

--- a/protocol-designer/cypress/support/Import.ts
+++ b/protocol-designer/cypress/support/Import.ts
@@ -11,7 +11,7 @@ export interface MigrateTestCase {
   title: string
   importTestFile: TestFilePath
   expectedTestFile: TestFilePath
-  migrationModal: 'newLabwareDefs' | 'v8.1' | 'v8.5' | 'noBehaviorChange' | null
+  showMigrationModal: boolean
 }
 
 export const ContentStrings = {
@@ -73,21 +73,12 @@ export const verifyImportProtocolPage = (protocol: TestFile): void => {
 export const migrateAndMatchSnapshot = ({
   importTestFile,
   expectedTestFile,
-  migrationModal,
+  showMigrationModal,
 }: MigrateTestCase): void => {
   const uploadProtocol: TestFile = getTestFile(importTestFile)
   cy.importProtocol(uploadProtocol.path)
 
-  if (migrationModal !== null) {
-    if (migrationModal === 'v8.5') {
-      cy.get('div').contains(ContentStrings.v8_5).should('exist')
-    } else if (migrationModal === 'v8.1') {
-      cy.get('div').contains(ContentStrings.v8_1).should('exist')
-    } else if (migrationModal === 'newLabwareDefs') {
-      cy.get('div').contains(ContentStrings.newLabwareDefs).should('exist')
-    } else if (migrationModal === 'noBehaviorChange') {
-      cy.get('div').contains(ContentStrings.noBehaviorChange).should('exist')
-    }
+  if (showMigrationModal) {
     cy.get('button')
       .contains(ContentStrings.importButton, { matchCase: false })
       .click({ force: true })

--- a/protocol-designer/cypress/support/Import.ts
+++ b/protocol-designer/cypress/support/Import.ts
@@ -11,12 +11,14 @@ export interface MigrateTestCase {
   title: string
   importTestFile: TestFilePath
   expectedTestFile: TestFilePath
-  migrationModal: 'newLabwareDefs' | 'v8.1' | 'noBehaviorChange' | null
+  migrationModal: 'newLabwareDefs' | 'v8.1' | 'v8.5' | 'noBehaviorChange' | null
 }
 
 export const ContentStrings = {
   newLabwareDefs: 'Update protocol to use new labware definitions',
   v8_1: 'The default dispense height is now 1 mm from the bottom of the well',
+  v8_5:
+    'Your protocol will be automatically updated to the latest version. We recommend making a separate copy of your file before importing.',
   noBehaviorChange:
     'We have added new features since the last time this protocol was updated, but have not made any changes to existing protocol behavior',
   exportButton: 'Export JSON',
@@ -26,6 +28,7 @@ export const ContentStrings = {
     'Your protocol was made in an older version of Protocol Designer',
   confirmButton: 'Confirm',
   cancelButton: 'Cancel',
+  importButton: 'Import',
   protocolMetadata: 'Protocol Metadata',
   instruments: 'Instruments',
   liquidDefinitions: 'Liquid Definitions',
@@ -46,9 +49,9 @@ export const verifyOldProtocolModal = (): void => {
       cy.contains(ContentStrings.migrationModal)
         .should('exist')
         .and('be.visible')
-      cy.contains(ContentStrings.confirmButton).should('be.visible')
+      cy.contains(ContentStrings.importButton).should('be.visible')
       cy.contains(ContentStrings.cancelButton).should('be.visible')
-      cy.contains(ContentStrings.confirmButton).click({ force: true })
+      cy.contains(ContentStrings.importButton).click({ force: true })
     })
 }
 
@@ -76,7 +79,9 @@ export const migrateAndMatchSnapshot = ({
   cy.importProtocol(uploadProtocol.path)
 
   if (migrationModal !== null) {
-    if (migrationModal === 'v8.1') {
+    if (migrationModal === 'v8.5') {
+      cy.get('div').contains(ContentStrings.v8_5).should('exist')
+    } else if (migrationModal === 'v8.1') {
       cy.get('div').contains(ContentStrings.v8_1).should('exist')
     } else if (migrationModal === 'newLabwareDefs') {
       cy.get('div').contains(ContentStrings.newLabwareDefs).should('exist')
@@ -84,7 +89,7 @@ export const migrateAndMatchSnapshot = ({
       cy.get('div').contains(ContentStrings.noBehaviorChange).should('exist')
     }
     cy.get('button')
-      .contains(ContentStrings.confirmButton, { matchCase: false })
+      .contains(ContentStrings.importButton, { matchCase: false })
       .click({ force: true })
   }
 

--- a/protocol-designer/src/assets/localization/en/shared.json
+++ b/protocol-designer/src/assets/localization/en/shared.json
@@ -73,6 +73,9 @@
       "body2": "The default dispense height is now 1 mm from the bottom of the well, instead of 0.5 mm. All dispense commands without a custom height will change to use the new default height.",
       "body3": "Additionally, blowout actions now precede touch tip actions. The new order affects all dispenses that include both actions."
     },
+    "toV8_5Migration": {
+      "body1": "Your protocol will be automatically updated to the latest version. We recommend making a separate copy of your file before importing."
+    },
     "toV8Migration": {
       "body1": "Your protocol will be automatically updated to the latest version.",
       "body2": "Protocol Designer no longer supports aspirate or mix actions in a trash bin. If your protocol contains these actions, an error icon will appear next to them in the Protocol Timeline. To resolve the error, choose another location for aspirating or mixing.",

--- a/protocol-designer/src/assets/localization/en/shared.json
+++ b/protocol-designer/src/assets/localization/en/shared.json
@@ -63,38 +63,8 @@
   "magneticmoduletype": "Magnetic Module",
   "migration_header": "Your protocol was made in an older version of Protocol Designer",
   "migrations": {
-    "noBehaviorChange": {
-      "body1": "Your protocol will be automatically updated to the latest version.",
-      "body2": "We have added new features since the last time this protocol was updated, but have not made any changes to existing protocol behavior. Because of this we do not expect any changes in how the robot will execute this protocol. To be safe we will still recommend keeping a separate copy of the file you just imported.",
-      "body3": "As always, please contact us with any questions or feedback."
-    },
-    "toV8_1Migration": {
-      "body1": "Your protocol will be automatically updated to the latest version.",
-      "body2": "The default dispense height is now 1 mm from the bottom of the well, instead of 0.5 mm. All dispense commands without a custom height will change to use the new default height.",
-      "body3": "Additionally, blowout actions now precede touch tip actions. The new order affects all dispenses that include both actions."
-    },
-    "toV8_5Migration": {
-      "body1": "Your protocol will be automatically updated to the latest version. We recommend making a separate copy of your file before importing."
-    },
-    "toV8Migration": {
-      "body1": "Your protocol will be automatically updated to the latest version.",
-      "body2": "Protocol Designer no longer supports aspirate or mix actions in a trash bin. If your protocol contains these actions, an error icon will appear next to them in the Protocol Timeline. To resolve the error, choose another location for aspirating or mixing.",
-      "body3": "Additionally, we have addressed a bug where blow out speeds were slower than expected. Your protocol will automatically update the flow rates unless they were specifically initialized.",
-      "body4": "As always, please contact us with any questions or feedback."
-    },
     "generic": {
-      "body1": "Your protocol will be automatically updated to the latest version. Please note that the updated file will be incompatible with older versions of the Protocol Designer. We recommend making a separate copy of the file that you just imported before continuing.",
-      "body2": "Updating the file may make changes to liquid handling actions. Please review your file in the Protocol Designer",
-      "body3": "As always, please contact us with any questions or feedback."
-    },
-    "toV3Migration": {
-      "title": "Update protocol to use new labware definitions",
-      "body1": "<strong>To import your file successfully, you must update your protocol to use the new labware definitions. </strong>Your protocol was made using an older version of Protocol Designer. Since then, Protocol Designer has been improved to include new labware definitions which are more accurate and reliable.",
-      "body2": "What this means for you protocol",
-      "body3": "Updating your protocol to use the new labware definitions will consequently require you to re-calibrate all labware in your protocol prior to running it on your robot. We recommend you try a dry run or one with water to ensure everything is working as expected.",
-      "body4": "What happens if you don't update",
-      "body5": "If you choose not to update, you will still be able to run your protocol as usual with older labware, however you will not be able to make further updates to this protocol using the Protocol Designer.",
-      "body6": "Please note that in order to run the updated protocol on your robot successfully, the OT-2 App and robot are required to be updated to version 3.10.0 or higher."
+      "body1": "Your protocol will be automatically updated to the latest version. We recommend making a separate copy of your file before importing."
     }
   },
   "magneticBlockAndStagingArea": "{{module}} with Staging Area",

--- a/protocol-designer/src/components/organisms/FileUploadMessagesModal/__tests__/FileUploadMessagesModal.test.tsx
+++ b/protocol-designer/src/components/organisms/FileUploadMessagesModal/__tests__/FileUploadMessagesModal.test.tsx
@@ -34,6 +34,25 @@ describe('FileUploadMessagesModal', () => {
       'Protocol Designer only accepts JSON and Python protocol files created with Protocol Designer. Upload a valid file to continue.'
     )
   })
+  it('renders modal for a migration to v8.5', () => {
+    vi.mocked(getFileUploadMessages).mockReturnValue({
+      isError: false,
+      messageKey: 'DID_MIGRATE',
+      migrationsRan: ['8.5.0'],
+    })
+    render()
+    screen.getByText(
+      'Your protocol was made in an older version of Protocol Designer'
+    )
+    screen.getByText(
+      'Your protocol will be automatically updated to the latest version. We recommend making a separate copy of your file before importing.'
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Import' }))
+    expect(vi.mocked(dismissFileUploadMessage)).toHaveBeenCalled()
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(vi.mocked(undoLoadFile)).toHaveBeenCalled()
+  })
+
   it('renders modal for a migration', () => {
     vi.mocked(getFileUploadMessages).mockReturnValue({
       isError: false,
@@ -47,7 +66,7 @@ describe('FileUploadMessagesModal', () => {
     screen.getByText(
       'Your protocol will be automatically updated to the latest version.'
     )
-    fireEvent.click(screen.getByRole('button', { name: 'Confirm' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Import' }))
     expect(vi.mocked(dismissFileUploadMessage)).toHaveBeenCalled()
     fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
     expect(vi.mocked(undoLoadFile)).toHaveBeenCalled()

--- a/protocol-designer/src/components/organisms/FileUploadMessagesModal/__tests__/FileUploadMessagesModal.test.tsx
+++ b/protocol-designer/src/components/organisms/FileUploadMessagesModal/__tests__/FileUploadMessagesModal.test.tsx
@@ -34,7 +34,7 @@ describe('FileUploadMessagesModal', () => {
       'Protocol Designer only accepts JSON and Python protocol files created with Protocol Designer. Upload a valid file to continue.'
     )
   })
-  it('renders modal for a migration to v8.5', () => {
+  it('renders modal for a migration', () => {
     vi.mocked(getFileUploadMessages).mockReturnValue({
       isError: false,
       messageKey: 'DID_MIGRATE',
@@ -46,25 +46,6 @@ describe('FileUploadMessagesModal', () => {
     )
     screen.getByText(
       'Your protocol will be automatically updated to the latest version. We recommend making a separate copy of your file before importing.'
-    )
-    fireEvent.click(screen.getByRole('button', { name: 'Import' }))
-    expect(vi.mocked(dismissFileUploadMessage)).toHaveBeenCalled()
-    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
-    expect(vi.mocked(undoLoadFile)).toHaveBeenCalled()
-  })
-
-  it('renders modal for a migration', () => {
-    vi.mocked(getFileUploadMessages).mockReturnValue({
-      isError: false,
-      messageKey: 'DID_MIGRATE',
-      migrationsRan: ['8.1.0'],
-    })
-    render()
-    screen.getByText(
-      'Your protocol was made in an older version of Protocol Designer'
-    )
-    screen.getByText(
-      'Your protocol will be automatically updated to the latest version.'
     )
     fireEvent.click(screen.getByRole('button', { name: 'Import' }))
     expect(vi.mocked(dismissFileUploadMessage)).toHaveBeenCalled()

--- a/protocol-designer/src/components/organisms/FileUploadMessagesModal/__tests__/utils.test.ts
+++ b/protocol-designer/src/components/organisms/FileUploadMessagesModal/__tests__/utils.test.ts
@@ -4,53 +4,10 @@ import { getMigrationMessage } from '../utils'
 
 const tMock = (key: string) => key
 
-describe('modalContents', () => {
-  describe('getMigrationMessage', () => {
-    it('should return the v3 migration message when migrating to v3', () => {
-      const migrationsList = [
-        ['3.0.0'],
-        ['3.0.0', '4.0.0'],
-        ['3.0.0', '4.0.0', '5.0.0'],
-        ['3.0.0', '4.0.0', '5.0.0', '5.1.0'],
-        ['3.0.0', '4.0.0', '5.0.0', '5.1.0, 5.2.0'],
-      ]
-      migrationsList.forEach(migrations => {
-        expect(
-          JSON.stringify(
-            getMigrationMessage({ migrationsRan: migrations, t: tMock })
-          )
-        ).toEqual(expect.stringContaining('migrations.toV3Migration.title'))
-      })
-    })
-    it('should return the "no behavior change message" when migrating from v5.x to 6', () => {
-      const migrationsList = [
-        ['5.0.0'],
-        ['5.0.0', '5.1.0'],
-        ['5.0.0', '5.1.0', '5.2.0'],
-      ]
-      migrationsList.forEach(migrations => {
-        expect(
-          JSON.stringify(
-            getMigrationMessage({ migrationsRan: migrations, t: tMock })
-          )
-        ).toEqual(expect.stringContaining('migrations.noBehaviorChange.body1'))
-      })
-    })
-    it('should return the generic migration modal when a v4 migration or v7 migration is required', () => {
-      const migrationsList = [
-        ['4.0.0'],
-        ['4.0.0', '5.0.0'],
-        ['4.0.0', '5.0.0', '5.1.0'],
-        ['4.0.0', '5.0.0', '5.1.0, 5.2.0'],
-        ['6.0.0', '6.1.0', '6.2.0', '6.2.1', '6.2.2'],
-      ]
-      migrationsList.forEach(migrations => {
-        expect(
-          JSON.stringify(
-            getMigrationMessage({ migrationsRan: migrations, t: tMock })
-          )
-        ).toEqual(expect.stringContaining('migrations.generic.body1'))
-      })
-    })
+describe('getMigrationMessage', () => {
+  it('should return the generic migration message when migrating', () => {
+    expect(JSON.stringify(getMigrationMessage({ t: tMock }))).toEqual(
+      expect.stringContaining('migrations.generic.body1')
+    )
   })
 })

--- a/protocol-designer/src/components/organisms/FileUploadMessagesModal/index.tsx
+++ b/protocol-designer/src/components/organisms/FileUploadMessagesModal/index.tsx
@@ -33,10 +33,21 @@ export function FileUploadMessagesModal(): JSX.Element | null {
   }
 
   const { title, body } = modalContents
+
+  const isMigration = title === t('migration_header')
+
   const showButtons =
     title !== t('invalid_json_file') &&
     title !== t('incorrect_file_header') &&
     title !== t('incorrect_python_file_header')
+
+  const handleClose = (): void => {
+    if (isMigration) {
+      dispatch(undoLoadFile())
+    } else {
+      dismissModal()
+    }
+  }
 
   return (
     <Modal
@@ -44,9 +55,7 @@ export function FileUploadMessagesModal(): JSX.Element | null {
       type={message?.isError ? 'error' : 'info'}
       title={title}
       closeOnOutsideClick
-      onClose={() => {
-        dispatch(undoLoadFile())
-      }}
+      onClose={handleClose}
       footer={
         showButtons && (
           <Flex
@@ -61,7 +70,9 @@ export function FileUploadMessagesModal(): JSX.Element | null {
             >
               {t('cancel')}
             </SecondaryButton>
-            <PrimaryButton onClick={dismissModal}>{t('import')}</PrimaryButton>
+            <PrimaryButton onClick={dismissModal}>
+              {isMigration ? t('import') : t('confirm')}
+            </PrimaryButton>
           </Flex>
         )
       }

--- a/protocol-designer/src/components/organisms/FileUploadMessagesModal/index.tsx
+++ b/protocol-designer/src/components/organisms/FileUploadMessagesModal/index.tsx
@@ -44,7 +44,9 @@ export function FileUploadMessagesModal(): JSX.Element | null {
       type={message?.isError ? 'error' : 'info'}
       title={title}
       closeOnOutsideClick
-      onClose={dismissModal}
+      onClose={() => {
+        dispatch(undoLoadFile())
+      }}
       footer={
         showButtons && (
           <Flex
@@ -59,7 +61,7 @@ export function FileUploadMessagesModal(): JSX.Element | null {
             >
               {t('cancel')}
             </SecondaryButton>
-            <PrimaryButton onClick={dismissModal}>{t('confirm')}</PrimaryButton>
+            <PrimaryButton onClick={dismissModal}>{t('import')}</PrimaryButton>
           </Flex>
         )
       }

--- a/protocol-designer/src/components/organisms/FileUploadMessagesModal/utils.tsx
+++ b/protocol-designer/src/components/organisms/FileUploadMessagesModal/utils.tsx
@@ -1,4 +1,4 @@
-import { Trans, useTranslation } from 'react-i18next'
+import { useTranslation } from 'react-i18next'
 
 import {
   COLORS,
@@ -14,11 +14,6 @@ import type { FileUploadMessage } from '../../../load-file'
 export interface ModalContents {
   title: string
   body: ReactNode
-}
-
-interface ModalProps {
-  t: any
-  errorMessage?: string | null
 }
 
 interface InvalidModalProps {
@@ -75,182 +70,20 @@ const invalidJsonModal = (props: InvalidModalProps): ModalContents => {
   }
 }
 
-export const getGenericDidMigrateMessage = (
-  props: ModalProps
-): ModalContents => {
+export const getMigrationMessage = (props: { t: any }): ModalContents => {
   const { t } = props
 
   return {
     title: t('migration_header'),
+
     body: (
       <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing4}>
         <StyledText desktopStyle="bodyDefaultRegular">
           {t('migrations.generic.body1')}
         </StyledText>
-        <StyledText desktopStyle="bodyDefaultRegular">
-          {t('migrations.generic.body2')}
-        </StyledText>
-        <StyledText desktopStyle="bodyDefaultRegular">
-          {t('migrations.generic.body3')}
-        </StyledText>
       </Flex>
     ),
   }
-}
-
-export const getNoBehaviorChangeMessage = (
-  props: ModalProps
-): ModalContents => {
-  const { t } = props
-
-  return {
-    title: t('migration_header'),
-    body: (
-      <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing4}>
-        <StyledText desktopStyle="bodyDefaultRegular">
-          {t('migrations.noBehaviorChange.body1')}
-        </StyledText>
-        <StyledText desktopStyle="bodyDefaultRegular">
-          {t('migrations.noBehaviorChange.body2')}
-        </StyledText>
-        <StyledText desktopStyle="bodyDefaultRegular">
-          {t('migrations.noBehaviorChange.body3')}
-        </StyledText>
-      </Flex>
-    ),
-  }
-}
-
-export const getToV8MigrationMessage = (props: ModalProps): ModalContents => {
-  const { t } = props
-
-  return {
-    title: t('migration_header'),
-    body: (
-      <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing4}>
-        <StyledText desktopStyle="bodyDefaultRegular">
-          {t('migrations.toV8Migration.body1')}
-        </StyledText>
-        <StyledText desktopStyle="bodyDefaultRegular">
-          {t('migrations.toV8Migration.body2')}
-        </StyledText>
-        <StyledText desktopStyle="bodyDefaultRegular">
-          {t('migrations.toV8Migration.body3')}
-        </StyledText>
-        <StyledText desktopStyle="bodyDefaultRegular">
-          {t('migrations.toV8Migration.body4')}
-        </StyledText>
-      </Flex>
-    ),
-  }
-}
-
-export const getToV8_1MigrationMessage = (props: ModalProps): ModalContents => {
-  const { t } = props
-
-  return {
-    title: t('migration_header'),
-
-    body: (
-      <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing4}>
-        <StyledText desktopStyle="bodyDefaultRegular">
-          {t('migrations.toV8_1Migration.body1')}
-        </StyledText>
-        <StyledText desktopStyle="bodyDefaultRegular">
-          {t('migrations.toV8_1Migration.body2')}
-        </StyledText>
-        <StyledText desktopStyle="bodyDefaultRegular">
-          {t('migrations.toV8_1Migration.body3')}
-        </StyledText>
-      </Flex>
-    ),
-  }
-}
-
-export const getToV8_5MigrationMessage = (props: ModalProps): ModalContents => {
-  const { t } = props
-
-  return {
-    title: t('migration_header'),
-
-    body: (
-      <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing4}>
-        <StyledText desktopStyle="bodyDefaultRegular">
-          {t('migrations.toV8_5Migration.body1')}
-        </StyledText>
-      </Flex>
-    ),
-  }
-}
-
-export const getToV3MigrationMessage = (props: ModalProps): ModalContents => {
-  const { t } = props
-
-  return {
-    title: t('migrations.toV3Migration.title'),
-    body: (
-      <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing4}>
-        <StyledText desktopStyle="bodyDefaultRegular">
-          <Trans
-            t={t}
-            i18nKey="migrations.toV3Migration.body1"
-            components={{ strong: <strong /> }}
-          />
-        </StyledText>
-        <StyledText desktopStyle="bodyDefaultRegular">
-          {t('migrations.toV3Migration.body2')}
-        </StyledText>
-        <StyledText desktopStyle="bodyDefaultRegular">
-          {t('migrations.toV3Migration.body3')}
-        </StyledText>
-        <StyledText desktopStyle="bodyDefaultRegular">
-          {t('migrations.toV3Migration.body4')}
-        </StyledText>
-        <StyledText desktopStyle="bodyDefaultRegular">
-          {t('migrations.toV3Migration.body5')}
-        </StyledText>
-        <StyledText desktopStyle="bodyDefaultRegular">
-          {t('migrations.toV3Migration.body6')}
-        </StyledText>
-      </Flex>
-    ),
-  }
-}
-
-interface MigrationMessageProps {
-  migrationsRan: string[]
-  t: any
-}
-
-export const getMigrationMessage = (
-  props: MigrationMessageProps
-): ModalContents => {
-  const { t, migrationsRan } = props
-
-  if (migrationsRan.includes('3.0.0')) {
-    return getToV3MigrationMessage({ t })
-  }
-  const noBehaviorMigrations = [
-    ['5.0.0'],
-    ['5.0.0', '5.1.0'],
-    ['5.0.0', '5.1.0', '5.2.0'],
-  ]
-  if (
-    noBehaviorMigrations.some(migrationList =>
-      migrationsRan.every(migration => migrationList.includes(migration))
-    )
-  ) {
-    return getNoBehaviorChangeMessage({ t })
-  }
-  if (migrationsRan.includes('8.5.0')) {
-    return getToV8_5MigrationMessage({ t })
-  } else if (migrationsRan.includes('8.1.0')) {
-    return getToV8_1MigrationMessage({ t })
-  } else if (migrationsRan.includes('8.0.0')) {
-    return getToV8MigrationMessage({ t })
-  }
-
-  return getGenericDidMigrateMessage({ t })
 }
 
 interface FileUploadModalContentsProps {
@@ -293,7 +126,6 @@ export function useFileUploadModalContents(
   switch (uploadResponse.messageKey) {
     case 'DID_MIGRATE':
       return getMigrationMessage({
-        migrationsRan: uploadResponse.migrationsRan,
         t,
       })
     default: {

--- a/protocol-designer/src/components/organisms/FileUploadMessagesModal/utils.tsx
+++ b/protocol-designer/src/components/organisms/FileUploadMessagesModal/utils.tsx
@@ -167,6 +167,22 @@ export const getToV8_1MigrationMessage = (props: ModalProps): ModalContents => {
   }
 }
 
+export const getToV8_5MigrationMessage = (props: ModalProps): ModalContents => {
+  const { t } = props
+
+  return {
+    title: t('migration_header'),
+
+    body: (
+      <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing4}>
+        <StyledText desktopStyle="bodyDefaultRegular">
+          {t('migrations.toV8_5Migration.body1')}
+        </StyledText>
+      </Flex>
+    ),
+  }
+}
+
 export const getToV3MigrationMessage = (props: ModalProps): ModalContents => {
   const { t } = props
 
@@ -226,7 +242,9 @@ export const getMigrationMessage = (
   ) {
     return getNoBehaviorChangeMessage({ t })
   }
-  if (migrationsRan.includes('8.1.0')) {
+  if (migrationsRan.includes('8.5.0')) {
+    return getToV8_5MigrationMessage({ t })
+  } else if (migrationsRan.includes('8.1.0')) {
     return getToV8_1MigrationMessage({ t })
   } else if (migrationsRan.includes('8.0.0')) {
     return getToV8MigrationMessage({ t })


### PR DESCRIPTION
# Overview

This PR adds copy for 8.5.0 migration modal and wires it up. It also updates the copy for import confirmation from "Confirm" to "Import", and updates tests accordingly.

Note that much of the logic determining which migration modal to show has been removed and simplified to show the latest migration content.

Closes AUTH-1975

## Test Plan and Hands on Testing

- import a pre-8.5.0 PD protocol and verify that the import modal copy matches that specified on the linked ticket


## Review requests

see test plan

## Risk assessment

low