### PR TITLE
fix(step-generation): extend unreachable temp timeline error to heate…

### DIFF
--- a/protocol-designer/fixtures/protocol/7/doItAllV7.json
+++ b/protocol-designer/fixtures/protocol/7/doItAllV7.json
@@ -4,7 +4,7 @@
     "author": "",
     "description": "",
     "created": 1689346890165,
-    "lastModified": 1748883341671,
+    "lastModified": 1750265944021,
     "category": null,
     "subcategory": null,
     "tags": []
@@ -13,7 +13,7 @@
     "name": "opentrons/protocol-designer",
     "version": "7.0.2",
     "data": {
-      "_internalAppBuildDate": "Thu, 16 Nov 2023 21:38:20 GMT",
+      "_internalAppBuildDate": "Thu, 19 Oct 2023 15:55:26 GMT",
       "defaultValues": {
         "aspirate_mmFromBottom": 1,
         "dispense_mmFromBottom": 0.5,
@@ -411,10 +411,26 @@
           "stepType": "moveLiquid",
           "stepName": "transfer",
           "stepDetails": ""
+        },
+        "eb7e45cb-aa84-4321-a7a5-799d9474ddda": {
+          "id": "eb7e45cb-aa84-4321-a7a5-799d9474ddda",
+          "stepType": "heaterShaker",
+          "stepName": "heater-shaker",
+          "stepDetails": "",
+          "moduleId": "c19dffa3-cb34-4702-bcf6-dcea786257d1:heaterShakerModuleType",
+          "setHeaterShakerTemperature": true,
+          "targetHeaterShakerTemperature": "40",
+          "targetSpeed": null,
+          "setShake": null,
+          "latchOpen": false,
+          "heaterShakerSetTimer": null,
+          "heaterShakerTimerMinutes": null,
+          "heaterShakerTimerSeconds": null
         }
       },
       "orderedStepIds": [
         "d6db5e5d-98cf-4f19-abbb-2f1406a389c7",
+        "eb7e45cb-aa84-4321-a7a5-799d9474ddda",
         "8b105da1-63d9-49f1-b370-5c74e01aa188",
         "236ab92a-24e3-42d8-bad5-cd4cdae9a4c4",
         "2d5ee9a5-c405-4dbc-a57e-2603d709c03d",
@@ -1465,7 +1481,7 @@
       "ordering": [],
       "brand": { "brand": "Opentrons", "brandId": [] },
       "metadata": {
-        "displayName": "TEEEST",
+        "displayName": "Opentrons 96 Flat Bottom Adapter",
         "displayCategory": "adapter",
         "displayVolumeUnits": "µL",
         "tags": []
@@ -3871,7 +3887,7 @@
   "schemaVersion": 7,
   "commands": [
     {
-      "key": "f2b81e36-6cf2-4c1f-8241-bac252d9f052",
+      "key": "8577c1dd-db96-4e72-941e-a33be2647e8e",
       "commandType": "loadPipette",
       "params": {
         "pipetteName": "p1000_single_flex",
@@ -3880,7 +3896,7 @@
       }
     },
     {
-      "key": "b4975d4c-d367-41c6-b40e-4c17fe2796b8",
+      "key": "14fcb153-58ec-4f77-87e1-b40584fa2a99",
       "commandType": "loadPipette",
       "params": {
         "pipetteName": "p50_multi_flex",
@@ -3889,7 +3905,7 @@
       }
     },
     {
-      "key": "aa2c700e-2729-4ffa-ae09-68498e20f44e",
+      "key": "1d5c9142-97e9-412d-98ed-1b7758ca29f5",
       "commandType": "loadModule",
       "params": {
         "model": "magneticBlockV1",
@@ -3898,7 +3914,7 @@
       }
     },
     {
-      "key": "33e6b860-a024-420e-9979-f0908569f343",
+      "key": "b8732401-4666-4a72-b9f9-7775cee648f7",
       "commandType": "loadModule",
       "params": {
         "model": "heaterShakerModuleV1",
@@ -3907,7 +3923,7 @@
       }
     },
     {
-      "key": "eeb93fcb-fe80-45bd-9b19-8e059c09c1a8",
+      "key": "2893ab78-8beb-4cc4-9403-1e04d870e152",
       "commandType": "loadModule",
       "params": {
         "model": "temperatureModuleV2",
@@ -3916,7 +3932,7 @@
       }
     },
     {
-      "key": "279b5209-feed-494b-86d1-7e4697285b5b",
+      "key": "4d6e19a9-6f2e-443d-be15-64badb8de4ae",
       "commandType": "loadModule",
       "params": {
         "model": "thermocyclerModuleV2",
@@ -3925,10 +3941,10 @@
       }
     },
     {
-      "key": "db68c2ff-0f82-4501-9bf0-661e8b1e0010",
+      "key": "aef9c7ee-cc99-4861-9677-93682ecda15f",
       "commandType": "loadLabware",
       "params": {
-        "displayName": "Opentrons 96 Flat Bottom Heater-Shaker Adapter",
+        "displayName": "Opentrons 96 Flat Bottom Adapter",
         "labwareId": "d95bb3be-b453-457c-a947-bd03dc8e56b9:opentrons/opentrons_96_flat_bottom_adapter/1",
         "loadName": "opentrons_96_flat_bottom_adapter",
         "namespace": "opentrons",
@@ -3939,7 +3955,7 @@
       }
     },
     {
-      "key": "504df0bc-8048-40d8-9b70-cdbf10a2f043",
+      "key": "2a816f08-edbe-4f1c-9ddd-6beb98706918",
       "commandType": "loadLabware",
       "params": {
         "displayName": "Opentrons Flex 96 Filter Tip Rack 50 µL",
@@ -3951,7 +3967,7 @@
       }
     },
     {
-      "key": "6327d095-0b2a-4748-b190-ff40970c0f12",
+      "key": "6396678c-4cbb-421a-a5ba-759f81558802",
       "commandType": "loadLabware",
       "params": {
         "displayName": "NEST 96 Well Plate 100 µL PCR Full Skirt",
@@ -3965,7 +3981,7 @@
       }
     },
     {
-      "key": "0a857c25-44bd-4b94-abbd-07f711a193ef",
+      "key": "af345884-1b0b-4073-bb22-5925dc0c69fb",
       "commandType": "loadLabware",
       "params": {
         "displayName": "Opentrons 24 Well Aluminum Block with NEST 1.5 mL Snapcap",
@@ -3979,7 +3995,7 @@
       }
     },
     {
-      "key": "fc60cbda-7c35-49ad-a99d-93bf1433cd4d",
+      "key": "a2a652a2-baf9-4f73-89b9-2c2614820670",
       "commandType": "loadLabware",
       "params": {
         "displayName": "NEST 96 Well Plate 200 µL Flat",
@@ -3994,7 +4010,7 @@
     },
     {
       "commandType": "loadLiquid",
-      "key": "06b11cab-ee77-4055-b2e3-248b75a4578a",
+      "key": "3bd85cf4-83ab-42a3-8ecc-b91ffaf9ea06",
       "params": {
         "liquidId": "1",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -4003,7 +4019,7 @@
     },
     {
       "commandType": "loadLiquid",
-      "key": "f1941fad-b36b-4d1c-b576-fcca0ef23ba1",
+      "key": "aefd0f61-bf56-4c0d-a52c-880e7a000e59",
       "params": {
         "liquidId": "0",
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
@@ -4021,15 +4037,30 @@
     },
     {
       "commandType": "temperatureModule/setTargetTemperature",
-      "key": "a6c52f96-b261-4b09-8c61-40e9b66c4be6",
+      "key": "2e37f0bf-5979-49dd-b3bb-35895d934666",
       "params": {
         "moduleId": "ef44ad7f-0fd9-46d6-8bc0-c70785644cc8:temperatureModuleType",
         "celsius": 4
       }
     },
     {
+      "commandType": "heaterShaker/closeLabwareLatch",
+      "key": "bdaa7020-7389-4b08-a73d-94aafd5fae0f",
+      "params": {
+        "moduleId": "c19dffa3-cb34-4702-bcf6-dcea786257d1:heaterShakerModuleType"
+      }
+    },
+    {
+      "commandType": "heaterShaker/setTargetTemperature",
+      "key": "be3bb267-ee83-47aa-9870-8ab9b546b20b",
+      "params": {
+        "moduleId": "c19dffa3-cb34-4702-bcf6-dcea786257d1:heaterShakerModuleType",
+        "celsius": 40
+      }
+    },
+    {
       "commandType": "heaterShaker/waitForTemperature",
-      "key": "9f8590da-7051-45ea-92a7-eee6055a2150",
+      "key": "293a4d31-65c7-44fd-8b18-b8517176afc7",
       "params": {
         "moduleId": "c19dffa3-cb34-4702-bcf6-dcea786257d1:heaterShakerModuleType",
         "celsius": 4
@@ -4037,14 +4068,14 @@
     },
     {
       "commandType": "thermocycler/closeLid",
-      "key": "3d6e2354-fb41-4ca8-8cdc-ef11248aff36",
+      "key": "5a417f44-e4f0-4d54-871e-8ea22c639e3b",
       "params": {
         "moduleId": "627b7a27-5bb7-46de-a530-67af45652e3b:thermocyclerModuleType"
       }
     },
     {
       "commandType": "thermocycler/setTargetLidTemperature",
-      "key": "049c4984-fcae-4020-8f81-ac580b4e572e",
+      "key": "e4111d2e-1406-46a2-8f0c-7b2b7bbd90af",
       "params": {
         "moduleId": "627b7a27-5bb7-46de-a530-67af45652e3b:thermocyclerModuleType",
         "celsius": 40
@@ -4052,14 +4083,14 @@
     },
     {
       "commandType": "thermocycler/waitForLidTemperature",
-      "key": "6ad7cb02-4529-45f4-aac9-8b30583860be",
+      "key": "ee29025a-49ba-4c4d-b1d4-a1e641742c53",
       "params": {
         "moduleId": "627b7a27-5bb7-46de-a530-67af45652e3b:thermocyclerModuleType"
       }
     },
     {
       "commandType": "thermocycler/runProfile",
-      "key": "6fefde1f-302a-4dd0-90fd-b19a6d7816d8",
+      "key": "84af6bb4-6ed4-4b75-a8d6-d1edb446176e",
       "params": {
         "moduleId": "627b7a27-5bb7-46de-a530-67af45652e3b:thermocyclerModuleType",
         "profile": [
@@ -4071,28 +4102,28 @@
     },
     {
       "commandType": "thermocycler/deactivateBlock",
-      "key": "ac2d99a8-9b0a-4c58-a746-df5d8fe707a3",
+      "key": "64e9962e-b76f-4d64-a5d2-324006922697",
       "params": {
         "moduleId": "627b7a27-5bb7-46de-a530-67af45652e3b:thermocyclerModuleType"
       }
     },
     {
       "commandType": "thermocycler/deactivateLid",
-      "key": "4e444217-e499-4ca5-a890-5c48e218cb06",
+      "key": "c12326f0-6124-4527-abe8-aa0595a0ddaa",
       "params": {
         "moduleId": "627b7a27-5bb7-46de-a530-67af45652e3b:thermocyclerModuleType"
       }
     },
     {
       "commandType": "thermocycler/openLid",
-      "key": "19009954-ee5d-462b-abda-8a18fe434e44",
+      "key": "ad5126c5-a12b-4fbf-bd78-5f97df4f34e2",
       "params": {
         "moduleId": "627b7a27-5bb7-46de-a530-67af45652e3b:thermocyclerModuleType"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "c9eff358-6e06-41df-a5d8-d0779dbd082d",
+      "key": "4e6314b4-bc50-432c-a666-d484770a5d50",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -4101,7 +4132,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "34685397-4ac0-4ed7-8db5-d61b48704581",
+      "key": "60535a10-d4a6-4a26-9d76-a7ad9e43cd66",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4113,7 +4144,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "94a8f207-c198-4bbb-b69f-97d6b95065f1",
+      "key": "4a16f2e5-fb75-4978-865e-910d43b1baad",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4125,7 +4156,7 @@
     },
     {
       "commandType": "dropTip",
-      "key": "29e8ec7d-42e1-40b0-bcdf-8bd7beefd9f6",
+      "key": "0ad2c4a2-68b7-45c4-a40e-785faa910064",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "fixedTrash",
@@ -4134,7 +4165,7 @@
     },
     {
       "commandType": "pickUpTip",
-      "key": "2b7e9b23-0fda-44b9-91f4-138817a7ca83",
+      "key": "7f98df5c-e997-4f2a-8a1e-417cf2c2c694",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -4143,7 +4174,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "eb634a83-da09-4b2d-99ea-0f46ca84ecb4",
+      "key": "46314e69-7813-489d-8369-d0f0cd92fa44",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4155,7 +4186,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "71fdba40-02c1-44a6-807c-a2a720c507eb",
+      "key": "084cd889-0f2e-474c-9a99-45ffee9dc119",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4167,7 +4198,7 @@
     },
     {
       "commandType": "dropTip",
-      "key": "ca46880e-3947-4756-a639-355bd8c89e9b",
+      "key": "75aa581e-091b-48da-86c9-f80fe0414b81",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "fixedTrash",
@@ -4176,7 +4207,7 @@
     },
     {
       "commandType": "pickUpTip",
-      "key": "7f9e2e46-b960-416d-858c-8893c9a5d5a4",
+      "key": "dabcdb88-4df6-434f-ad6b-ae31e0326a95",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -4185,7 +4216,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "f249f8a8-1c3e-4559-866c-5b2be460b8d4",
+      "key": "d013a366-09e7-4600-8336-6450607549e8",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4197,7 +4228,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "30d4e7e7-017f-4664-be38-5895c04a2288",
+      "key": "ea0fe127-e44a-48a2-b128-2a9c80d2e4eb",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4209,7 +4240,7 @@
     },
     {
       "commandType": "dropTip",
-      "key": "2dd0ff42-f59b-4ca9-86bf-bba270d8ca74",
+      "key": "627b333d-96e2-4945-8439-2c0c43e07a1c",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "fixedTrash",
@@ -4218,7 +4249,7 @@
     },
     {
       "commandType": "pickUpTip",
-      "key": "99bd75f5-1151-409c-b5a5-0a1390c3254f",
+      "key": "eec98a15-8e21-4a42-ac07-f84585873f1a",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -4227,7 +4258,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "3a95a586-d4d3-40e2-8682-d55471830d25",
+      "key": "8ae1edb3-d456-4697-9352-afa92fd25949",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4239,7 +4270,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "2cbeb2e5-580a-40c2-a3c4-50738de1dd4a",
+      "key": "80ba2356-c0ed-4ccd-acee-7ccb54548f0d",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4251,7 +4282,7 @@
     },
     {
       "commandType": "dropTip",
-      "key": "62bbf798-b3e1-4628-802e-de70eb2c7bb7",
+      "key": "5f880e72-ff10-460f-8762-2af8a71e6118",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "fixedTrash",
@@ -4260,7 +4291,7 @@
     },
     {
       "commandType": "pickUpTip",
-      "key": "6f58b711-0e98-459a-8974-363496ae7172",
+      "key": "55a6a106-a6dc-4967-bd0f-7414019bfd3a",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -4269,7 +4300,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "596f5fb0-4c10-4d91-a29a-4e9dcc8efe89",
+      "key": "9a27b63e-547c-4d20-9e0a-9f3457b70844",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4281,7 +4312,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "515754a0-550e-44e3-9bcd-6ccea352e17d",
+      "key": "2fabf8af-f7bd-4280-9be2-7adab9b4656b",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4293,7 +4324,7 @@
     },
     {
       "commandType": "dropTip",
-      "key": "453658b9-8806-4452-86ef-f65dc9884dbc",
+      "key": "cc31c8cc-cfde-4800-90d1-51b9d3b8954a",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "fixedTrash",
@@ -4302,7 +4333,7 @@
     },
     {
       "commandType": "pickUpTip",
-      "key": "8312e299-07fc-4a32-9ace-2d4251c167fa",
+      "key": "a10b2a7b-e092-4549-a74f-ddfeebf69f40",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -4311,7 +4342,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "a1867734-778b-4a55-bfa9-0c48821b09e1",
+      "key": "87ee846b-4248-45e2-a263-faaa6ea47a17",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4323,7 +4354,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "58631b7e-6457-483c-b180-1ef7b6286c42",
+      "key": "0c5b491f-c49b-46ef-9a7b-6fea4984aca4",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4335,7 +4366,7 @@
     },
     {
       "commandType": "dropTip",
-      "key": "2c1cce5b-c1ee-4270-8d87-446176cb940a",
+      "key": "d38fc033-d3c3-4a48-960e-842facecd346",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "fixedTrash",
@@ -4344,7 +4375,7 @@
     },
     {
       "commandType": "pickUpTip",
-      "key": "ba8bef3c-f2a5-4a93-874d-d465a018de54",
+      "key": "dba4358e-0e05-4f7e-808d-ffeaac4055a6",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -4353,7 +4384,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "4e3aa613-2959-4ca3-a2be-28f6d2d7848d",
+      "key": "c72ef855-f399-4c73-870f-babd6f494b36",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4365,7 +4396,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "374030e1-8ca0-46d4-a459-6e8f4a46d6b0",
+      "key": "a3f78974-2e00-490c-98d0-1475effa3cc4",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4377,7 +4408,7 @@
     },
     {
       "commandType": "dropTip",
-      "key": "fb90e1cf-f52a-42e3-acd5-23b65e949ce7",
+      "key": "d4aba92f-6d39-49a2-8337-0827a0ec695a",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "fixedTrash",
@@ -4386,7 +4417,7 @@
     },
     {
       "commandType": "pickUpTip",
-      "key": "35dc4525-7cb2-4abb-9eff-810d57414c44",
+      "key": "4f2a48c8-05b5-4c07-bf92-226b198804f9",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -4395,7 +4426,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "34cdf0ad-0636-4579-9995-38ad888fd8e7",
+      "key": "63eae390-ba89-4690-9493-83cd727d3f51",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4407,7 +4438,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "f6fba0b5-1ef8-4948-b04e-e8836e6457f2",
+      "key": "4b2cab7b-9c43-4811-88eb-973f7378db0c",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4419,7 +4450,7 @@
     },
     {
       "commandType": "dropTip",
-      "key": "74a581cf-fbd9-4245-bc8c-e844bc332c62",
+      "key": "eeceb272-9df9-4884-b8c0-d0123254a107",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "fixedTrash",
@@ -4428,7 +4459,7 @@
     },
     {
       "commandType": "pickUpTip",
-      "key": "cc0b3240-78cd-4f5f-bf8a-d9fff2b176c4",
+      "key": "c7f27975-62fc-40a3-ae09-d8324b3bbb29",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -4437,7 +4468,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "96751cb2-ad96-4d50-ac05-36030451021d",
+      "key": "689d227c-e5bf-4e03-8622-5259abc55b66",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4449,7 +4480,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "ba97e74e-04ca-4381-b040-52413069626c",
+      "key": "e900c3ff-b848-4670-bd26-c01eaaa563fa",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4461,7 +4492,7 @@
     },
     {
       "commandType": "dropTip",
-      "key": "acb1954d-212a-459e-9431-749b08d18aac",
+      "key": "e2efdff9-ea80-4495-a72f-e21f0d9227bc",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "fixedTrash",
@@ -4470,7 +4501,7 @@
     },
     {
       "commandType": "pickUpTip",
-      "key": "a3ecbedd-74d6-4c31-ad57-eb6da3141a70",
+      "key": "30dcefac-3209-4263-afb5-539e87fb40a6",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -4479,7 +4510,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "6d9e52e6-825a-4279-9c11-3ccddb9065d6",
+      "key": "62c54ae2-8aad-406b-96a2-a09855543b4e",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4491,7 +4522,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "522c8308-db4a-481f-a90a-2257c1c7e12f",
+      "key": "94380bef-bec7-49dc-b937-4e5dcfec0673",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4503,7 +4534,7 @@
     },
     {
       "commandType": "dropTip",
-      "key": "ca8df034-337c-4af9-938b-8149d1d40ed4",
+      "key": "a6c5a543-ce23-4e20-a260-2c55dd8751ea",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "fixedTrash",
@@ -4512,7 +4543,7 @@
     },
     {
       "commandType": "pickUpTip",
-      "key": "4693af2b-98fb-4f99-958e-72dd2567f3b6",
+      "key": "d09cebc0-2c38-4009-a7a2-985c35224f49",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -4521,7 +4552,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "84f4bbf4-ad0f-49af-89b8-aa8274248487",
+      "key": "e6196eee-42f6-4b0c-bd74-23f7e1575654",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4533,7 +4564,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "021b79da-6e99-4ccd-b93e-464bb219b39f",
+      "key": "8c4f72cb-b24a-45cb-9a93-736ef0c2013f",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4545,7 +4576,7 @@
     },
     {
       "commandType": "dropTip",
-      "key": "9bceb2c9-096a-4b9a-b359-34daf583a1b5",
+      "key": "da640055-9601-4675-9e5c-53656de14505",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "fixedTrash",
@@ -4554,7 +4585,7 @@
     },
     {
       "commandType": "pickUpTip",
-      "key": "98af1ec5-21af-430a-94b3-6e1457005264",
+      "key": "7ac9ee12-9f44-419b-97d6-92054c50811d",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -4563,7 +4594,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "2893deb4-1c85-4651-895b-e973d75b7ba4",
+      "key": "82d04fd0-e71c-4615-bbfe-f402872e339c",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4575,7 +4606,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "542bb570-46ce-4939-9c05-306f6eb28061",
+      "key": "b4a1bd14-c69d-4deb-a547-cb26be82b83e",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4587,7 +4618,7 @@
     },
     {
       "commandType": "dropTip",
-      "key": "739d67e9-87d3-4e1e-b2b0-a458fc416cce",
+      "key": "b09262f7-a774-4205-a55f-a750c887de5e",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "fixedTrash",
@@ -4596,7 +4627,7 @@
     },
     {
       "commandType": "pickUpTip",
-      "key": "22ccf990-b56f-413c-8eef-7268ecf7c442",
+      "key": "3dd38912-3676-488f-9577-fc68528cb6ea",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -4605,7 +4636,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "94a075ad-192e-4021-9566-8fbafbc1082a",
+      "key": "4cf48ca6-8799-4769-8a43-cf70e86007fe",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4617,7 +4648,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "de753c02-0027-495c-bbfb-6c3379125a2c",
+      "key": "78ecb44a-2f57-4253-a166-40fd74e7122c",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4629,7 +4660,7 @@
     },
     {
       "commandType": "dropTip",
-      "key": "b80bfacc-57eb-4178-b5c7-0e9de60a47ce",
+      "key": "6b550e91-d32e-4692-a610-945feea022b0",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "fixedTrash",
@@ -4638,7 +4669,7 @@
     },
     {
       "commandType": "pickUpTip",
-      "key": "bc1a6bf1-5630-4937-b578-f8a46a5c82dd",
+      "key": "cdce1ffa-7d5c-42bb-a425-87be1b3addb7",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -4647,7 +4678,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "ae479513-a870-4900-8876-4d5d60988d1c",
+      "key": "f87cffe7-6c89-4ae1-8012-17307de19e08",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4659,7 +4690,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "0afa24f1-df0f-4695-b460-5fba0a32b7fe",
+      "key": "b06016f3-c072-4cfa-8da8-468994d20d68",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4671,7 +4702,7 @@
     },
     {
       "commandType": "dropTip",
-      "key": "f9cd5b0e-d868-4948-b575-ab5c9340d6eb",
+      "key": "c99170d6-b8eb-4e3d-a237-9944b4f8bed7",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "fixedTrash",
@@ -4680,7 +4711,7 @@
     },
     {
       "commandType": "pickUpTip",
-      "key": "4e9e239d-9ee8-46e1-b044-86d9b12f4a1b",
+      "key": "a80cf57c-5cdd-481c-bfe9-b7d765f44eec",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -4689,7 +4720,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "ce328984-a6bb-4110-823b-d3908c641dbd",
+      "key": "e15f4c1d-8bce-4307-9945-ee3062c62d41",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4701,7 +4732,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "ea647989-dbb9-4bf7-862a-350ae6c94c68",
+      "key": "4db65897-65b6-4782-9104-3c2e29ee4655",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4713,7 +4744,7 @@
     },
     {
       "commandType": "dropTip",
-      "key": "b6185c51-bd49-48cb-865b-3604c9eafefa",
+      "key": "8e89f08f-e605-473a-ba1c-ea62cf66f874",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "fixedTrash",
@@ -4722,7 +4753,7 @@
     },
     {
       "commandType": "pickUpTip",
-      "key": "07c87bfa-0277-4f79-bc50-d15938efbbbd",
+      "key": "c01bb659-717a-4689-a0f5-24c0d01bb077",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -4731,7 +4762,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "2dfb9d7a-93ce-400c-a3d8-88c21dec4187",
+      "key": "67da6396-2808-43a2-b54e-de3c33c3b190",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4743,7 +4774,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "00a44586-1789-4295-9994-f14a374b4fdb",
+      "key": "81aa8984-5f92-4d61-8218-cdc30261df47",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4755,7 +4786,7 @@
     },
     {
       "commandType": "dropTip",
-      "key": "719bb86c-ca9b-4fa2-97b5-a14cdfaa5d56",
+      "key": "2e3a1e64-7dba-41b2-9376-fb75462f89cf",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "fixedTrash",
@@ -4764,7 +4795,7 @@
     },
     {
       "commandType": "pickUpTip",
-      "key": "53174769-f668-4666-bacf-8b6ee211b89e",
+      "key": "74dbd6ec-b1a1-481e-90d5-b3e644266e23",
       "params": {
         "pipetteId": "6d1e53c3-2db3-451b-ad60-3fe13781a193",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -4773,7 +4804,7 @@
     },
     {
       "commandType": "configureForVolume",
-      "key": "6dc39d10-13d3-401a-8aac-807b1f557528",
+      "key": "395890da-fafa-411e-8e25-5b9e248d0ed1",
       "params": {
         "pipetteId": "6d1e53c3-2db3-451b-ad60-3fe13781a193",
         "volume": 10
@@ -4781,7 +4812,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "fe748764-0229-43ce-9373-fd518f01c51d",
+      "key": "742bad6d-b2c9-4651-a98a-d86a27217e70",
       "params": {
         "pipetteId": "6d1e53c3-2db3-451b-ad60-3fe13781a193",
         "volume": 10,
@@ -4793,7 +4824,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "d7daa27a-3da2-434b-ab39-6207772ec92c",
+      "key": "e88e4c66-6675-4e49-9603-cfe7b8124c1a",
       "params": {
         "pipetteId": "6d1e53c3-2db3-451b-ad60-3fe13781a193",
         "volume": 10,
@@ -4805,7 +4836,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "35cf9b07-9e0e-487b-9736-50ba7b522a9b",
+      "key": "c81e7022-84b8-4d46-afe2-2887f97c9675",
       "params": {
         "pipetteId": "6d1e53c3-2db3-451b-ad60-3fe13781a193",
         "volume": 10,
@@ -4817,7 +4848,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "7f0a6135-e68e-4929-b84f-6fb734a41433",
+      "key": "5b62a24b-01e8-4008-a75d-5417f4a1540c",
       "params": {
         "pipetteId": "6d1e53c3-2db3-451b-ad60-3fe13781a193",
         "volume": 10,
@@ -4829,7 +4860,7 @@
     },
     {
       "commandType": "dropTip",
-      "key": "9ffb0a14-9d0c-4ade-83f9-0bc4c39b3945",
+      "key": "9a1ab410-e705-43c4-8beb-4fab43c28b49",
       "params": {
         "pipetteId": "6d1e53c3-2db3-451b-ad60-3fe13781a193",
         "labwareId": "fixedTrash",
@@ -4838,7 +4869,7 @@
     },
     {
       "commandType": "moveLabware",
-      "key": "957fefe6-c4a8-401d-b4ee-863ff15c0960",
+      "key": "adb801d9-7ad1-4f28-85d0-469e25c42ab1",
       "params": {
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
         "strategy": "usingGripper",
@@ -4847,12 +4878,12 @@
     },
     {
       "commandType": "waitForDuration",
-      "key": "867fed5e-4585-4611-b863-2879f9e10010",
+      "key": "c95218eb-a2ab-4d6b-9c48-629e26bac56a",
       "params": { "seconds": 60, "message": "" }
     },
     {
       "commandType": "moveLabware",
-      "key": "27d8bf40-8733-4297-bcb0-d28e8e57f0f3",
+      "key": "1b758075-1918-4a00-b28c-6be4a1fa474a",
       "params": {
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
         "strategy": "usingGripper",
@@ -4861,21 +4892,21 @@
     },
     {
       "commandType": "heaterShaker/closeLabwareLatch",
-      "key": "638e7f0f-bd2d-4345-a3de-5151e4800b80",
+      "key": "67e4e3d8-d9d5-442c-9a32-fabd1a5c1ebb",
       "params": {
         "moduleId": "c19dffa3-cb34-4702-bcf6-dcea786257d1:heaterShakerModuleType"
       }
     },
     {
       "commandType": "heaterShaker/deactivateHeater",
-      "key": "3c88875d-eed5-4f9a-b4c2-4605870c7dca",
+      "key": "717ac55a-91bf-43e5-867b-c42b0874b136",
       "params": {
         "moduleId": "c19dffa3-cb34-4702-bcf6-dcea786257d1:heaterShakerModuleType"
       }
     },
     {
       "commandType": "heaterShaker/setAndWaitForShakeSpeed",
-      "key": "c45c58bb-7c86-4e7f-970b-0da295c60132",
+      "key": "1f42b106-638a-4950-81d2-abac1dff501a",
       "params": {
         "moduleId": "c19dffa3-cb34-4702-bcf6-dcea786257d1:heaterShakerModuleType",
         "rpm": 500
@@ -4883,28 +4914,28 @@
     },
     {
       "commandType": "heaterShaker/deactivateHeater",
-      "key": "71574815-2adb-4271-a88b-653ecc76b751",
+      "key": "67651eb8-bd18-4e13-b1a5-61650ebd6f95",
       "params": {
         "moduleId": "c19dffa3-cb34-4702-bcf6-dcea786257d1:heaterShakerModuleType"
       }
     },
     {
       "commandType": "heaterShaker/deactivateShaker",
-      "key": "10c290a6-6e4f-4644-8574-efdaf4a908bf",
+      "key": "83ba4970-ed26-4e98-b9ed-71a685568863",
       "params": {
         "moduleId": "c19dffa3-cb34-4702-bcf6-dcea786257d1:heaterShakerModuleType"
       }
     },
     {
       "commandType": "heaterShaker/openLabwareLatch",
-      "key": "7ba23948-576c-45ab-9e7c-da56dcb2670a",
+      "key": "6108d3b8-8b1f-48b6-b002-5c94b7e8c89a",
       "params": {
         "moduleId": "c19dffa3-cb34-4702-bcf6-dcea786257d1:heaterShakerModuleType"
       }
     },
     {
       "commandType": "moveLabware",
-      "key": "51b4fde8-114f-4aee-9555-f0798163d730",
+      "key": "860ea6a7-bebd-41df-95ff-5f6fb73de673",
       "params": {
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
         "strategy": "manualMoveWithPause",
@@ -4913,14 +4944,14 @@
     },
     {
       "commandType": "temperatureModule/deactivate",
-      "key": "6c7d8133-49db-438d-a158-a64b2e1a2555",
+      "key": "caf3f3fa-a7c2-424c-9463-7f4bd2b3d112",
       "params": {
         "moduleId": "ef44ad7f-0fd9-46d6-8bc0-c70785644cc8:temperatureModuleType"
       }
     },
     {
       "commandType": "moveLabware",
-      "key": "4a6c73bf-982c-4e0a-bd26-9ece56e52bc6",
+      "key": "98aa72b0-42eb-400c-b8eb-f5e3dab5dcfc",
       "params": {
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
         "strategy": "manualMoveWithPause",
@@ -4929,7 +4960,7 @@
     },
     {
       "commandType": "pickUpTip",
-      "key": "dfef554d-0720-4f62-9347-63cf11633191",
+      "key": "c4bb740d-4199-4293-a4a7-f2d4b0d35ec4",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -4938,7 +4969,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "926d10e7-d949-40a1-9231-9656f751a2af",
+      "key": "dc02a2d6-6910-4636-9876-c788808d767e",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 5,
@@ -4950,7 +4981,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "ce58903e-eda6-4048-97d9-b7b930e98e69",
+      "key": "36153266-e8a7-4a58-bc6d-872b7b2d1ba9",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 5,
@@ -4962,7 +4993,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "d55fc874-720b-47b6-9c98-3e30198be7c6",
+      "key": "74d8eefe-7f06-4a73-8c05-dc8d2178fe39",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 5,
@@ -4974,7 +5005,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "1e2a076d-35dd-413f-918e-b6e1800c8ace",
+      "key": "2ec23659-ff8a-40d4-8602-b54905eefb10",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 5,
@@ -4986,7 +5017,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "2c88ea92-afa8-45f6-a1f9-49e015ebd277",
+      "key": "e716c4af-509b-4606-938b-067cde1aac06",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 5,
@@ -4998,7 +5029,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "6af56d87-e77b-4a9d-bdd7-fcd929dc57c1",
+      "key": "bbcac8ee-8322-4cb6-9bb7-d8fb1b730720",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 5,
@@ -5010,7 +5041,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "7f565fea-d4d4-4f11-810b-d169f7a398d3",
+      "key": "0d743ab0-3de2-4be7-bb9c-e4b72f5af7b8",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 5,
@@ -5022,7 +5053,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "716d05ed-6b29-4d9c-8a2d-08d4124d5ecc",
+      "key": "89027002-2f3f-4efc-b1bf-f1b9b0acacc5",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 5,
@@ -5034,7 +5065,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "776188fe-0b42-4852-a236-d8dae03b75f9",
+      "key": "81de5198-9e0c-4521-b99f-bd91a4ea6ee8",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 5,
@@ -5046,7 +5077,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "a27cf370-dc71-4b1a-9e21-fd6f27e8fc42",
+      "key": "04d8853f-7738-485c-a709-f012252dbeb1",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 5,
@@ -5058,7 +5089,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "73a8b73b-6dbf-4644-b416-4324b1f8ea0c",
+      "key": "7352e7d1-c1b2-4853-9f8a-6da1089081c2",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -5070,7 +5101,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "9fb77390-e4dc-49ac-ad9b-4559bc34aead",
+      "key": "8265e9b0-a8c7-41a9-b3e0-236e15b36a3b",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 5,
@@ -5082,7 +5113,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "d142fb3c-ad1a-4e5f-a60e-6972ff914644",
+      "key": "85efa61a-f037-4f29-8e17-ca0bb83c1d81",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 5,
@@ -5094,7 +5125,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "83425d0a-5806-4093-b897-847292b0efa2",
+      "key": "b8e2417c-b87f-495f-9784-1fef22c7d038",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 5,
@@ -5106,7 +5137,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "e9b534df-0eeb-4303-8cad-54c4a188820d",
+      "key": "a7c459e5-f1c6-40e5-83db-493c99d8bbc1",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 5,
@@ -5118,7 +5149,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "353a4ac2-f3f4-48dc-b16a-1bef4fc84fc7",
+      "key": "b5f79964-da39-43fd-a8d0-aa3c8a57051e",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 5,
@@ -5130,7 +5161,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "c539a634-0c3d-48d1-98b9-eedbb85156fa",
+      "key": "93a4ba47-824d-4905-b3a4-f82f6f32a896",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 5,
@@ -5142,7 +5173,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "8647896c-7c67-406c-b6c9-676b3bb2a72f",
+      "key": "9fef51da-b66b-4bef-b80e-4a160da15236",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 5,
@@ -5154,7 +5185,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "ab984530-a463-49fd-be27-daf08540a337",
+      "key": "40f003d0-f6e4-435e-9e86-b786270754d5",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 5,
@@ -5166,7 +5197,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "2bd28d8e-633b-49da-be41-3b8da7d953ea",
+      "key": "c204d5fe-5234-4c41-bc3b-be56703856e6",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 5,
@@ -5178,7 +5209,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "795f7215-bce6-4af2-a83d-36372458ee6a",
+      "key": "0e00af3b-8545-41a2-9945-5932a64a027a",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 5,
@@ -5190,7 +5221,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "8ed3d003-406c-47c4-8754-d571fe21a9d9",
+      "key": "cb0f9615-9134-4d65-ae88-3f5fcdc8a58f",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -5202,7 +5233,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "2744e2b5-0f7c-4635-996c-5c878ac61e6d",
+      "key": "630f842c-29cf-45e3-a2e1-5b4ef84466cd",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 5,
@@ -5214,7 +5245,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "58eedb05-9d76-4091-950d-f6b803bda3f9",
+      "key": "4171336e-2f10-4e99-a91a-d1f0fe5229ce",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 5,
@@ -5226,7 +5257,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "0e3b5639-ba39-4742-a642-accb12c23196",
+      "key": "fb3ecbf7-def1-4b4d-8f70-4dac158d4a6c",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 5,
@@ -5238,7 +5269,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "ab4dac3f-80e4-4ca4-88f6-1c0534405c0b",
+      "key": "4bf7faaa-c8b4-44a5-bba7-d70d157f9d2b",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 5,
@@ -5250,7 +5281,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "328a681e-49ef-4464-990f-3be483d101e5",
+      "key": "e55faa43-f34f-4a38-9f1d-00335565e67d",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 5,
@@ -5262,7 +5293,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "e58a963b-1110-4d1f-98c5-8930a6660ef5",
+      "key": "1c207643-0a33-48b7-a654-6d444734196b",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 25,
@@ -5274,7 +5305,7 @@
     },
     {
       "commandType": "dropTip",
-      "key": "23224a53-a96e-4b9b-be07-e9a87f454f77",
+      "key": "d330791e-22e9-4dc6-9c83-a24444e65681",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "fixedTrash",

--- a/protocol-designer/fixtures/protocol/7/doItAllV7.json
+++ b/protocol-designer/fixtures/protocol/7/doItAllV7.json
@@ -3944,7 +3944,7 @@
       "key": "aef9c7ee-cc99-4861-9677-93682ecda15f",
       "commandType": "loadLabware",
       "params": {
-        "displayName": "Opentrons 96 Flat Bottom Adapter",
+        "displayName": "Opentrons 96 Flat Bottom Heater-Shaker Adapter",
         "labwareId": "d95bb3be-b453-457c-a947-bd03dc8e56b9:opentrons/opentrons_96_flat_bottom_adapter/1",
         "loadName": "opentrons_96_flat_bottom_adapter",
         "namespace": "opentrons",

--- a/protocol-designer/fixtures/protocol/8/doItAllV7MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/doItAllV7MigratedToV8.json
@@ -605,7 +605,7 @@
       },
       "labware": {
         "d95bb3be-b453-457c-a947-bd03dc8e56b9:opentrons/opentrons_96_flat_bottom_adapter/1": {
-          "displayName": "Opentrons 96 Flat Bottom Adapter",
+          "displayName": "Opentrons 96 Flat Bottom Heater-Shaker Adapter",
           "labwareDefURI": "opentrons/opentrons_96_flat_bottom_adapter/1"
         },
         "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1": {

--- a/protocol-designer/fixtures/protocol/8/doItAllV7MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/doItAllV7MigratedToV8.json
@@ -6,7 +6,7 @@
     "author": "",
     "description": "",
     "created": 1689346890165,
-    "lastModified": 1748982160513,
+    "lastModified": 1750266007878,
     "source": "Protocol Designer",
     "category": null,
     "subcategory": null,
@@ -16,7 +16,7 @@
     "name": "opentrons/protocol-designer",
     "version": "8.5.0",
     "data": {
-      "_internalAppBuildDate": "Tue, 03 Jun 2025 20:00:35 GMT",
+      "_internalAppBuildDate": "Wed, 18 Jun 2025 16:49:26 GMT",
       "pipetteTiprackAssignments": {
         "2e7c6344-58ab-465c-b542-489883cb63fe": [
           "opentrons/opentrons_flex_96_filtertiprack_50ul/1"
@@ -119,12 +119,12 @@
             "6d1e53c3-2db3-451b-ad60-3fe13781a193": "right"
           },
           "trashBinLocationUpdate": {
-            "b857dbdc-b5db-4c29-ac10-d13cc5aca69c:trashBin": "cutoutA3"
+            "d5c2faa5-d6e1-4762-85e5-07b47dd6e96e:trashBin": "cutoutA3"
           },
           "wasteChuteLocationUpdate": {},
           "stagingAreaLocationUpdate": {},
           "gripperLocationUpdate": {
-            "c7a8ac95-025d-4855-a96f-3c759a24e0f1:gripper": "mounted"
+            "20d44c68-d53e-43c9-b5c6-868c460b0d8d:gripper": "mounted"
           },
           "stepType": "manualIntervention",
           "id": "__INITIAL_DECK_SETUP_STEP__"
@@ -230,7 +230,7 @@
           "aspirate_y_position": 0,
           "blowout_checkbox": false,
           "blowout_flowRate": 478,
-          "blowout_location": "b857dbdc-b5db-4c29-ac10-d13cc5aca69c:trashBin",
+          "blowout_location": "d5c2faa5-d6e1-4762-85e5-07b47dd6e96e:trashBin",
           "blowout_z_offset": 0,
           "changeTip": "always",
           "conditioning_checkbox": false,
@@ -270,7 +270,7 @@
           "dispense_y_position": 0,
           "disposalVolume_checkbox": true,
           "disposalVolume_volume": "100",
-          "dropTip_location": "b857dbdc-b5db-4c29-ac10-d13cc5aca69c:trashBin",
+          "dropTip_location": "d5c2faa5-d6e1-4762-85e5-07b47dd6e96e:trashBin",
           "liquidClassesSupported": false,
           "liquidClass": "none",
           "nozzles": null,
@@ -293,13 +293,13 @@
           "aspirate_flowRate": null,
           "blowout_checkbox": false,
           "blowout_flowRate": null,
-          "blowout_location": "b857dbdc-b5db-4c29-ac10-d13cc5aca69c:trashBin",
+          "blowout_location": "d5c2faa5-d6e1-4762-85e5-07b47dd6e96e:trashBin",
           "blowout_z_offset": 0,
           "changeTip": "always",
           "dispense_delay_checkbox": false,
           "dispense_delay_seconds": "1",
           "dispense_flowRate": null,
-          "dropTip_location": "b857dbdc-b5db-4c29-ac10-d13cc5aca69c:trashBin",
+          "dropTip_location": "d5c2faa5-d6e1-4762-85e5-07b47dd6e96e:trashBin",
           "labware": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
           "liquidClassesSupported": false,
           "liquidClass": "none",
@@ -491,7 +491,7 @@
           "aspirate_y_position": 0,
           "blowout_checkbox": false,
           "blowout_flowRate": 478,
-          "blowout_location": "b857dbdc-b5db-4c29-ac10-d13cc5aca69c:trashBin",
+          "blowout_location": "d5c2faa5-d6e1-4762-85e5-07b47dd6e96e:trashBin",
           "blowout_z_offset": 0,
           "changeTip": "once",
           "conditioning_checkbox": false,
@@ -531,7 +531,7 @@
           "dispense_y_position": 0,
           "disposalVolume_checkbox": true,
           "disposalVolume_volume": "100",
-          "dropTip_location": "b857dbdc-b5db-4c29-ac10-d13cc5aca69c:trashBin",
+          "dropTip_location": "d5c2faa5-d6e1-4762-85e5-07b47dd6e96e:trashBin",
           "liquidClassesSupported": false,
           "liquidClass": "none",
           "nozzles": null,
@@ -547,10 +547,25 @@
           "stepDetails": "",
           "id": "a47ddb5f-5469-461c-ad7f-6307c5fe0a69",
           "dispense_touchTip_mmfromTop": null
+        },
+        "eb7e45cb-aa84-4321-a7a5-799d9474ddda": {
+          "heaterShakerSetTimer": null,
+          "heaterShakerTimer": null,
+          "latchOpen": false,
+          "moduleId": "c19dffa3-cb34-4702-bcf6-dcea786257d1:heaterShakerModuleType",
+          "setHeaterShakerTemperature": true,
+          "setShake": null,
+          "targetHeaterShakerTemperature": "40",
+          "targetSpeed": null,
+          "id": "eb7e45cb-aa84-4321-a7a5-799d9474ddda",
+          "stepType": "heaterShaker",
+          "stepName": "heater-shaker",
+          "stepDetails": ""
         }
       },
       "orderedStepIds": [
         "d6db5e5d-98cf-4f19-abbb-2f1406a389c7",
+        "eb7e45cb-aa84-4321-a7a5-799d9474ddda",
         "8b105da1-63d9-49f1-b370-5c74e01aa188",
         "236ab92a-24e3-42d8-bad5-cd4cdae9a4c4",
         "2d5ee9a5-c405-4dbc-a57e-2603d709c03d",
@@ -590,7 +605,7 @@
       },
       "labware": {
         "d95bb3be-b453-457c-a947-bd03dc8e56b9:opentrons/opentrons_96_flat_bottom_adapter/1": {
-          "displayName": "Opentrons 96 Flat Bottom Heater-Shaker Adapter",
+          "displayName": "Opentrons 96 Flat Bottom Adapter",
           "labwareDefURI": "opentrons/opentrons_96_flat_bottom_adapter/1"
         },
         "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1": {
@@ -4075,7 +4090,7 @@
   "commandSchemaId": "opentronsCommandSchemaV10",
   "commands": [
     {
-      "key": "3cab9e7d-f34f-42c1-98c4-ac636fc71f6a",
+      "key": "6f95dddd-e02a-40dc-a239-e19fa19679ce",
       "commandType": "loadPipette",
       "params": {
         "pipetteName": "p1000_single_flex",
@@ -4084,7 +4099,7 @@
       }
     },
     {
-      "key": "bb4f5bca-f64b-47c6-aaa4-ca54765e71d9",
+      "key": "d83e1701-150a-4c77-b600-2f67ae336b71",
       "commandType": "loadPipette",
       "params": {
         "pipetteName": "p50_multi_flex",
@@ -4093,7 +4108,7 @@
       }
     },
     {
-      "key": "ce934dde-5980-4ef3-8dbf-69addcac74f0",
+      "key": "99e7711d-8702-4556-931c-bb1c6bc4ee7f",
       "commandType": "loadModule",
       "params": {
         "model": "magneticBlockV1",
@@ -4104,7 +4119,7 @@
       }
     },
     {
-      "key": "89473991-5ed6-4281-b847-b5e2f4929244",
+      "key": "02eb6dca-3abc-45fc-9476-6c4b2bd54f6e",
       "commandType": "loadModule",
       "params": {
         "model": "heaterShakerModuleV1",
@@ -4115,7 +4130,7 @@
       }
     },
     {
-      "key": "00bd144b-89fe-419a-b2b2-da443cbe6f50",
+      "key": "178833aa-33a6-436a-94eb-8997bf5b159b",
       "commandType": "loadModule",
       "params": {
         "model": "temperatureModuleV2",
@@ -4126,7 +4141,7 @@
       }
     },
     {
-      "key": "f56d3f7c-2bdd-421a-82c3-0dd0d7d78420",
+      "key": "aece3021-fc6e-4c6b-93e7-e2be58991813",
       "commandType": "loadModule",
       "params": {
         "model": "thermocyclerModuleV2",
@@ -4137,7 +4152,7 @@
       }
     },
     {
-      "key": "009708c2-ce5a-41f0-979c-20919c3c1957",
+      "key": "96eada57-c3c8-494c-b84c-3e7e5495357f",
       "commandType": "loadLabware",
       "params": {
         "displayName": "Opentrons 96 Flat Bottom Heater-Shaker Adapter",
@@ -4151,7 +4166,7 @@
       }
     },
     {
-      "key": "ea1d8694-17c4-4882-aabc-6e5fa30a0df0",
+      "key": "eb7d2db1-a8f7-4e7a-8fea-fef6fde0fc82",
       "commandType": "loadLabware",
       "params": {
         "displayName": "Opentrons Flex 96 Filter Tip Rack 50 µL",
@@ -4165,7 +4180,7 @@
       }
     },
     {
-      "key": "f97cd8a4-2545-4369-9c8a-d3e4f3c48265",
+      "key": "8adaf4eb-a42b-4b58-9e2e-05de7487fb94",
       "commandType": "loadLabware",
       "params": {
         "displayName": "NEST 96 Well Plate 100 µL PCR Full Skirt",
@@ -4179,7 +4194,7 @@
       }
     },
     {
-      "key": "81632163-16dd-40e5-842b-32b87b5d831a",
+      "key": "bee776c8-8954-426f-a7dc-760f1a373233",
       "commandType": "loadLabware",
       "params": {
         "displayName": "Opentrons 24 Well Aluminum Block with NEST 1.5 mL Snapcap",
@@ -4193,7 +4208,7 @@
       }
     },
     {
-      "key": "61ba13fc-a105-4148-8438-c1e291ee65a2",
+      "key": "b4b5845f-01bf-4db4-b368-fff5cc7e3fc1",
       "commandType": "loadLabware",
       "params": {
         "displayName": "NEST 96 Well Plate 200 µL Flat",
@@ -4208,7 +4223,7 @@
     },
     {
       "commandType": "loadLiquid",
-      "key": "2e975a73-9643-48ad-9c5f-c515ec7b16b7",
+      "key": "a82b0072-9424-40e7-b4ce-5c60aa66ba40",
       "params": {
         "liquidId": "1",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -4219,7 +4234,7 @@
     },
     {
       "commandType": "loadLiquid",
-      "key": "74466e45-0124-4d36-aad7-e9ac4a6188a4",
+      "key": "86c0bbaf-efb7-4099-b484-2e32e974ddd2",
       "params": {
         "liquidId": "0",
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
@@ -4237,15 +4252,30 @@
     },
     {
       "commandType": "temperatureModule/setTargetTemperature",
-      "key": "5de1e5ad-842c-4652-b4f2-4be0bb987766",
+      "key": "ee6c5810-f155-4e19-96a2-87822fc7b15d",
       "params": {
         "moduleId": "ef44ad7f-0fd9-46d6-8bc0-c70785644cc8:temperatureModuleType",
         "celsius": 4
       }
     },
     {
+      "commandType": "heaterShaker/closeLabwareLatch",
+      "key": "1e6f944f-c981-4594-b265-8b1b4013bf63",
+      "params": {
+        "moduleId": "c19dffa3-cb34-4702-bcf6-dcea786257d1:heaterShakerModuleType"
+      }
+    },
+    {
+      "commandType": "heaterShaker/setTargetTemperature",
+      "key": "74e773cc-c904-4434-bec9-3c792e2dead0",
+      "params": {
+        "moduleId": "c19dffa3-cb34-4702-bcf6-dcea786257d1:heaterShakerModuleType",
+        "celsius": 40
+      }
+    },
+    {
       "commandType": "heaterShaker/waitForTemperature",
-      "key": "e10aa7b5-7e50-4b62-b8fa-5c92518ebfb8",
+      "key": "d2346b8f-ef6f-41b5-9509-9786fb57c62d",
       "params": {
         "moduleId": "c19dffa3-cb34-4702-bcf6-dcea786257d1:heaterShakerModuleType",
         "celsius": 4
@@ -4253,14 +4283,14 @@
     },
     {
       "commandType": "thermocycler/closeLid",
-      "key": "49297934-b3ec-4288-aee3-a54cd394d94d",
+      "key": "79e0b06b-21e9-4643-b13d-315156e32466",
       "params": {
         "moduleId": "627b7a27-5bb7-46de-a530-67af45652e3b:thermocyclerModuleType"
       }
     },
     {
       "commandType": "thermocycler/setTargetLidTemperature",
-      "key": "cf93ad88-6ce6-48d8-a80e-8aad2c537e71",
+      "key": "e8b36d01-e3b2-4842-b1bb-a748d6f47cf4",
       "params": {
         "moduleId": "627b7a27-5bb7-46de-a530-67af45652e3b:thermocyclerModuleType",
         "celsius": 40
@@ -4268,7 +4298,7 @@
     },
     {
       "commandType": "thermocycler/runProfile",
-      "key": "7d195279-0e10-4f9e-a39e-200fb6b613b0",
+      "key": "8b7ce0e2-6351-44c7-833a-9da4ca69dd56",
       "params": {
         "moduleId": "627b7a27-5bb7-46de-a530-67af45652e3b:thermocyclerModuleType",
         "profile": [
@@ -4286,28 +4316,28 @@
     },
     {
       "commandType": "thermocycler/deactivateBlock",
-      "key": "9836e884-0835-456f-9f05-0cb0a3c08c9c",
+      "key": "fa5a7f99-7784-44ac-aa4c-d86607a5b999",
       "params": {
         "moduleId": "627b7a27-5bb7-46de-a530-67af45652e3b:thermocyclerModuleType"
       }
     },
     {
       "commandType": "thermocycler/deactivateLid",
-      "key": "a3917f8a-19f8-44eb-8b9b-93d070fc5699",
+      "key": "838a6543-fb9a-4c5c-ae02-bd0cf8d3cefc",
       "params": {
         "moduleId": "627b7a27-5bb7-46de-a530-67af45652e3b:thermocyclerModuleType"
       }
     },
     {
       "commandType": "thermocycler/openLid",
-      "key": "ef4fcb46-804d-4066-99f2-10c8f73bcede",
+      "key": "306e3c96-92ba-40a2-8e73-c8a413a6c031",
       "params": {
         "moduleId": "627b7a27-5bb7-46de-a530-67af45652e3b:thermocyclerModuleType"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "6c736c5e-65f3-4546-ac5d-d9f4799eddab",
+      "key": "87bf3156-ff32-4571-a4fa-3d385dc53671",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -4316,7 +4346,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "715b4918-8795-4279-8657-712b5bcad793",
+      "key": "ecdf1935-3294-47a3-bccd-dc9fdb117ac0",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -4333,14 +4363,14 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "fae83195-a843-4d58-a46d-a5a8088712da",
+      "key": "448ad92f-548f-40df-88f5-ab6227bd11e5",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "34a7932b-da7a-434b-afef-23274ecdedbb",
+      "key": "3877a76f-e2ed-4eb2-bcaf-515e4e75f2fc",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -4357,7 +4387,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "fee78a2a-55e5-4a4e-a5c4-ade648c54c0c",
+      "key": "a45826a5-586a-4a3e-80e7-bd4d54be999f",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -4375,7 +4405,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "5cf43a62-09a1-4952-9a26-77ebd2db7210",
+      "key": "26a608c5-7c76-40ef-9bb2-609d4fd6a34e",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4384,7 +4414,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "3f5c80de-5747-419e-a8ff-f82903ef61db",
+      "key": "87c43648-5340-4279-a071-abb02e951e0c",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -4402,7 +4432,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "78990721-6e0d-45a2-9c88-9bd96d69b336",
+      "key": "10485215-ee09-4305-ab06-827073349dec",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
@@ -4419,7 +4449,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "daa1ba50-8692-4647-b106-2b8d8c954753",
+      "key": "e715b84b-3628-4cdf-8e24-8fd2a977935e",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
@@ -4437,7 +4467,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "1be686d2-b82f-41f0-90c0-c44e7fe67a5f",
+      "key": "dc994cab-9b6b-4299-997f-c4ec260cfb78",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4447,7 +4477,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "75ffe60b-8194-4b6c-8ae5-197fb95924b6",
+      "key": "8e5bfa9f-09da-4670-9cb9-aa639f572341",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
@@ -4465,7 +4495,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "9ff1e5f6-25d4-4e2f-bb6a-b58f467a116e",
+      "key": "67b192b5-d56b-4214-b4a3-1aecdb8611b4",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "addressableAreaName": "movableTrashA3",
@@ -4479,14 +4509,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "4f10163f-0397-4705-9acb-e1eb1b48a9f6",
+      "key": "740a5d0a-ade6-42cf-8fb8-c44fd9a996d2",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "4b306390-f332-4974-b9e0-169cbe9bcbe0",
+      "key": "115d487f-6888-49ee-a5d5-4c9a51a980dc",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -4495,7 +4525,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "e0fad61b-2bce-49f7-8907-8173f1073990",
+      "key": "64991416-1a9d-4354-aff6-76327efa1d7e",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -4512,14 +4542,14 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "4611a93d-e1ae-4d0c-90da-d367c1e4095c",
+      "key": "202a6cdc-ce68-4a00-8781-bff02d9c2994",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "0e731a14-ee0e-442b-80dc-f30fdfd4c8fe",
+      "key": "839b612d-3217-411f-8d29-890c138d801e",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -4536,7 +4566,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "34b8db42-a9f7-493d-8d70-2f03cb9d1c3d",
+      "key": "b46b42b8-2983-47a2-8622-baa25f9ca3d5",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -4554,7 +4584,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "623da091-4c0f-4dcd-bdac-20a97d3f4371",
+      "key": "934e1d73-0b78-4113-940f-77742bb82871",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4563,7 +4593,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "c0a06b90-fa03-4e1b-a7cb-7a876d518a01",
+      "key": "ba762a2d-9775-4c29-8c0f-27a6959591e3",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -4581,7 +4611,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "f4caf8c7-f9ac-45d1-9cc0-89a7c0216e80",
+      "key": "93c55a0a-0a50-48df-8315-d9ce120d9aa4",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
@@ -4598,7 +4628,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "9bdf26de-2d9b-4560-83e1-2e509c4f6250",
+      "key": "c8431718-d8e8-47ab-bdfa-4d38bfb94b0f",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
@@ -4616,7 +4646,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "53e7fd1c-1070-4484-bd83-f7d8572e2117",
+      "key": "355d5f56-e70b-43ef-bd71-c00687dd66a0",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4626,7 +4656,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "16075577-3f50-401c-93fa-f1bbc8693a84",
+      "key": "ef761d78-f181-43af-9eba-6ef7ca712913",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
@@ -4644,7 +4674,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "64194490-3110-49eb-be27-a51b98380d62",
+      "key": "9cb61805-a9b6-495c-8c1e-2933e12c14ea",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "addressableAreaName": "movableTrashA3",
@@ -4658,14 +4688,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "123fc325-270e-4978-af4d-f224a95fd622",
+      "key": "15213b01-1d0b-4da1-a3b3-1be691046c29",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "fb56b24f-df52-4dda-bcee-ac49bdeb5aa3",
+      "key": "b5983b46-ac0e-4edb-bb5b-3d005af0579d",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -4674,7 +4704,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "97f7fc99-d6de-4dd1-947d-48e37e4bdfd2",
+      "key": "e1b16dc4-4027-4cde-902a-72306dae418c",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -4691,14 +4721,14 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "3f34a803-0f16-431f-afa8-d882ab1126c3",
+      "key": "65c6ecfa-04cb-40c7-a42e-6d380d315435",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "331c036f-13f6-4b32-86b9-0adab8ac44b8",
+      "key": "1cd48790-08e7-4c04-944d-96346c25f6b0",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -4715,7 +4745,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "7bcdc549-2027-4d7d-9a22-c9f3b183d705",
+      "key": "d1b47fe7-9ef6-4520-8dd8-1fc6cb43da7a",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -4733,7 +4763,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "64fd1380-e742-4ce8-b598-f0d23414e61b",
+      "key": "3d8095d4-4134-4ce7-90de-d37b33028e6a",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4742,7 +4772,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "50959d1e-21d1-49dc-89a1-77c7f7d6c13d",
+      "key": "6743eb69-750d-4928-851f-f0c5677110a1",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -4760,7 +4790,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "67876c42-cd80-4600-813f-9b820140ddca",
+      "key": "8be417db-a683-49c4-96f7-714ff9cd0cd1",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
@@ -4777,7 +4807,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "7fddcc91-9b8f-4e1e-ad41-6aafcf2fab53",
+      "key": "dd32bee0-e0c5-4de3-a63d-a14ec40b96f7",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
@@ -4795,7 +4825,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "b49be8d2-12e1-41c3-86f0-853fa30be3ed",
+      "key": "22b14d18-2852-48a6-9b50-3fa31169277b",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4805,7 +4835,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "7944dbb1-f281-43e6-866a-e72eb1a62670",
+      "key": "86c58648-9101-43d3-b8fa-7e1c3e2282be",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
@@ -4823,7 +4853,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "e6181c91-2921-4473-a74c-114863d3e371",
+      "key": "3910f4b5-95f2-47fd-a641-39bcbf6c0bb4",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "addressableAreaName": "movableTrashA3",
@@ -4837,14 +4867,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "2951c7f4-deec-41f3-a2b9-11f18e04552f",
+      "key": "6ddc34ee-0fa3-4101-ac9f-c53980401ada",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "622469dd-8a91-4d82-b7aa-08415fb1ce2e",
+      "key": "dd8ee3af-5796-4d9e-b473-28da64cbc2ab",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -4853,7 +4883,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "e95de40c-25ad-4feb-9b3e-3167e5ea9ded",
+      "key": "1856ec23-b077-4d24-b91b-dcbe36dcc5f5",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -4870,14 +4900,14 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "8c0e70b3-c50f-424e-8e02-f549feaaf80f",
+      "key": "9be5943a-9362-4e91-ac99-9ed9559216e2",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "f4c36f22-31dd-4173-8fbc-2337b6a939bd",
+      "key": "a50f258f-238b-4658-af8b-a0a02b5e1b37",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -4894,7 +4924,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "391b56b2-d571-4b19-bd77-a904be8f3663",
+      "key": "7ee205db-91d1-4c0a-b2d4-ba5c2107a305",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -4912,7 +4942,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "7b074f70-8665-435a-98ea-f4b85c2399ff",
+      "key": "328af692-49de-4361-ab7a-498718d37f27",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4921,7 +4951,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "4b17294b-8fcb-4ea8-9db4-cc06834ff8e2",
+      "key": "a98c83bc-a357-4b8d-b0f2-9614136295b2",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -4939,7 +4969,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "066c76e5-65c3-4e8c-9ab9-77264ab47c4d",
+      "key": "130987f4-a8b4-4c4e-9bed-1f7a7c833f21",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
@@ -4956,7 +4986,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "7d1f97fc-7610-4bc4-9d69-ed7da419245a",
+      "key": "384a9050-810a-4e83-8b5d-c091e0374d9d",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
@@ -4974,7 +5004,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "31f12e9a-fe22-4c87-ab63-29278ed80df2",
+      "key": "0e079fcb-a46d-46b3-961d-96e58ee8fd12",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4984,7 +5014,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "06a0825d-92b1-4ec3-bf04-56f2f36c52ed",
+      "key": "a09f644e-acf3-499d-9c63-64f5002359e3",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
@@ -5002,7 +5032,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "724bdad6-f47b-4fe0-b78f-8d5979bb7737",
+      "key": "04ec6147-4d16-4045-87b1-86114797e6a2",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "addressableAreaName": "movableTrashA3",
@@ -5016,14 +5046,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "c2edff19-aa23-451d-bc93-2dacfebb361e",
+      "key": "d4016a05-5dbd-4bfc-b740-e109fccf12ae",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "7b109ad4-0249-439a-a2ae-ae4390a724aa",
+      "key": "6f73b26e-d0de-4e1b-95c6-a8c19d8a06bc",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -5032,7 +5062,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "d447914b-49f0-4cfa-99ba-7dd95f277403",
+      "key": "363c1a01-4b91-44dd-8a72-c3ca7fd355dc",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -5049,14 +5079,14 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "a3ec580b-c526-4305-97f9-03c95bd1e503",
+      "key": "a7e2d11b-8fb2-4c72-828d-29b5e0b763db",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "9a0bdf02-1b1e-46ea-a57f-9906ba2cfc3d",
+      "key": "9eeb4631-c85c-40fa-9741-c423c1e41adc",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -5073,7 +5103,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "45c0c79c-1424-4cec-9641-b975d53928fe",
+      "key": "29b92d6b-6c80-447d-8c06-97b1228f63f5",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -5091,7 +5121,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "a3cc2b37-68ea-48c5-b3b8-9be996865d5d",
+      "key": "bb33e7d6-ec1f-4b4f-8d0a-7835f52db79a",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -5100,7 +5130,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "98f49aff-0041-42cb-aedd-acbda6da8bf7",
+      "key": "768cb79a-f8fd-47ca-a7a9-95a002ba7844",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -5118,7 +5148,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "09ddfdf2-1cfc-44eb-ae6a-d88d40330f69",
+      "key": "d16bc7b9-0285-46e8-a786-f6728ee3fcfa",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
@@ -5135,7 +5165,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "aa6b775d-b7c9-471f-b2e0-f586ab13859f",
+      "key": "d153813b-8ef7-4ab7-8a2f-b3a49034e55b",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
@@ -5153,7 +5183,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "b80b9357-ec42-4abf-9877-465569a00296",
+      "key": "a64ae630-e395-43e9-a49b-8e59651969f6",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -5163,7 +5193,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "b50c3227-b434-456e-980e-6df8560be051",
+      "key": "e60eb3ef-ec18-4a2f-ac31-d1bc796db670",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
@@ -5181,7 +5211,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "7f33b084-a538-4b64-904d-1e6a1c0d838d",
+      "key": "4584eea5-3cd1-4cbb-9635-ab7853e4d8a8",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "addressableAreaName": "movableTrashA3",
@@ -5195,14 +5225,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "af6a82bb-6870-45c5-8e81-6f398980ce4c",
+      "key": "e5ef1b39-c93d-479a-b1e6-ca19d11b794e",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "1958ddc2-3750-4777-bbc9-d0ce019f86e7",
+      "key": "a242da7a-0465-463a-8204-51f807afd621",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -5211,7 +5241,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "47fb7fc0-e370-4561-b2cb-13bbe744eff6",
+      "key": "429aa2ec-c1b4-4f02-a59e-6b065f4bdac8",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -5228,14 +5258,14 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "b77ca79f-4d4b-4f8d-ac2c-3fce1a07f439",
+      "key": "3acee11c-718f-44d6-b158-4469be91f5be",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "c007ddef-ae46-48f2-a421-8135ef6dc3fd",
+      "key": "b2ed85b1-916e-4c61-bb32-91f358398072",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -5252,7 +5282,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "c8e6b902-df3c-447a-86d7-93bd0a73e916",
+      "key": "8633eb1d-06a2-476a-ab6c-d1c65996aa02",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -5270,7 +5300,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "ee5ec142-0dfe-4453-af1c-a3cb49461f75",
+      "key": "c15837e2-3ea9-47c6-927e-845818f804b8",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -5279,7 +5309,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "9750529d-cb97-4f86-9a3a-e9ff611498bb",
+      "key": "5b509ccc-543c-44ea-b337-c43aa298ff21",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -5297,7 +5327,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "e8e4f607-bd64-439d-8403-3e8c689c6472",
+      "key": "b92a6ffc-7640-4090-b0ae-d4ceca50a1f2",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
@@ -5314,7 +5344,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "2fe818b5-5192-4128-9118-1b25345be401",
+      "key": "fc8dc563-6ebc-48bf-8e16-401b6aec57df",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
@@ -5332,7 +5362,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "9e4090e7-719c-4efb-8826-7084fd0e097d",
+      "key": "e3b16bcf-886b-449f-9a68-045288a33041",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -5342,7 +5372,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "0d3f9815-5597-4926-b354-4c9ce6ca63a4",
+      "key": "c9162660-b5ef-4564-acfc-c7e0aae83744",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
@@ -5360,7 +5390,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "d3ac2f35-d0f8-49b8-8899-966191f24ede",
+      "key": "e4c3fd86-693e-4783-935d-e5ca8a42b3c3",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "addressableAreaName": "movableTrashA3",
@@ -5374,14 +5404,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "9f7bce0e-95b2-4c96-b939-3a12ac35accc",
+      "key": "f07e8941-d99f-4890-917f-7afe266f18b5",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "db6f309e-545a-4b2d-9276-83d72751788b",
+      "key": "51bff949-6651-4623-a042-bb5cd6f6bc8e",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -5390,7 +5420,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "1ff4078c-b5e6-499d-bec9-b2b65d584545",
+      "key": "69c07bba-a5de-4673-b3be-a925d86dd88a",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -5407,14 +5437,14 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "725abb81-4a18-4639-a36e-c9b1bd556ce8",
+      "key": "7ff4a70b-b072-41f7-875b-6cbdb567cee1",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "ea0e300c-fdca-4c92-89ab-bff320593c89",
+      "key": "e911694d-0bde-48d6-82b5-916cc36348f4",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -5431,7 +5461,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "d2b5c3ad-2b48-4ebf-a7da-df63378070cb",
+      "key": "32ced883-b180-4068-a910-394e9158d089",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -5449,7 +5479,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "46eb88b4-cc96-4b0e-91bd-ba936cdd530d",
+      "key": "298428d4-8e53-4a7f-a612-a35c3c74be6c",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -5458,7 +5488,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "6308f835-237d-47d4-a79a-a2a60b348ece",
+      "key": "659f48a2-8e37-4d58-b1c2-c3a636f41b62",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -5476,7 +5506,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "a82762fa-0d2c-4065-93d8-752d41f2cc16",
+      "key": "e6ee6287-6c4a-46e7-92e1-bd5399beb68c",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
@@ -5493,7 +5523,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "f94298a9-f913-4098-8ca5-1d019757c396",
+      "key": "f1740e3d-bee5-49d4-82c9-c5888fc5bbd5",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
@@ -5511,7 +5541,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "cbc40b8e-e9c4-44fb-ac99-fdc013919bde",
+      "key": "6f7139a9-f4b3-42eb-b518-f12f98a207dc",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -5521,7 +5551,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "47879bfc-aaaf-436c-8c4f-77a254809122",
+      "key": "61fa65ea-63b2-4d22-8cb3-4584b9c4998d",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
@@ -5539,7 +5569,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "b3a95907-d6f1-4d5b-9482-060891acfe8b",
+      "key": "00de8fb6-2301-4965-ae96-ec3fbc79663e",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "addressableAreaName": "movableTrashA3",
@@ -5553,14 +5583,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "6fe079a3-1566-4d89-908a-b3df5d6c6580",
+      "key": "8f4d080a-f8ec-4ad9-9c54-1494041a3156",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "987986f3-d437-45dd-b23e-a6998aba2fab",
+      "key": "518fa4f3-1c85-4d83-990f-f15378631002",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -5569,7 +5599,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "58f6e3a9-126e-46f7-a756-ae56dfae8600",
+      "key": "f993f3e3-326c-4f02-acd6-c8a309db94cd",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -5586,14 +5616,14 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "c43d83ef-b5ca-417c-944f-2473f193164c",
+      "key": "bdb83500-0e1c-499f-b48e-8094533ed3bf",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "33b62077-0c40-4d15-99a4-b2ad375f514e",
+      "key": "951d784c-7989-4f46-99f5-8d693d58eb51",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -5610,7 +5640,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "182653e2-32ab-4c84-8b59-cc084d97e5e9",
+      "key": "c50fea15-4d16-4714-b945-175f47beb334",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -5628,7 +5658,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "80e27700-9fca-4853-9119-0aff7ef14f14",
+      "key": "c33f1480-136a-4dbd-9c0c-c06e26add4a7",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -5637,7 +5667,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "73cfddf9-41a9-44ab-a393-a2b76b7e7152",
+      "key": "fbc8385d-d7d7-4433-8417-1ae1c8b68ab1",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -5655,7 +5685,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "aff7fb47-701e-4217-b18e-de4a88c82087",
+      "key": "d41c6919-075d-4bc7-9e6a-7e977900f32e",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
@@ -5672,7 +5702,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "15f7ea1b-7bdd-43a5-8fb7-8b83f70887d9",
+      "key": "b15d9f07-d3bb-45b5-a537-c1adb33a3eb5",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
@@ -5690,7 +5720,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "2092e1eb-04b7-47d3-9fad-fdea5e9c26cb",
+      "key": "96219163-6e12-464c-9eec-cf4acf789b89",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -5700,7 +5730,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "6a0b66a1-cddf-4e9a-8e7b-fbc4b0dd622b",
+      "key": "db67ba9b-cf24-460c-92d2-ee605c69e268",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
@@ -5718,7 +5748,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "fe128af5-efbb-4ba7-8f95-6a5c85822ef1",
+      "key": "4e16ab6b-b5d3-42a5-b48a-fb8a1daf8165",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "addressableAreaName": "movableTrashA3",
@@ -5732,14 +5762,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "781c49d2-e705-46f7-9af0-1e02294bb37e",
+      "key": "80f206e5-88df-4ce5-b0e2-b490b6f392c8",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "4de91c10-4c21-49b2-b4ca-89c758d66603",
+      "key": "385d6280-7185-4eaa-9708-f847212563ef",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -5748,7 +5778,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "11972fd8-32bf-47c1-b8f9-36765bbb9795",
+      "key": "6e2f606b-1b13-45bc-a1c2-1edce1736281",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -5765,14 +5795,14 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "354023d6-2525-4e4d-8ba9-dbcd7eb1fcd0",
+      "key": "e8096fb0-73ac-4550-9c01-c84b2b56268b",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "05c76bf2-ad84-4052-84e1-48cc4e91e6f1",
+      "key": "d74c6012-f9d4-43ca-bd93-980d376815b0",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -5789,7 +5819,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "b027db83-cce5-4183-87c4-0f0a0e0d15b6",
+      "key": "01d4f760-3711-446c-ad65-1303c7041465",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -5807,7 +5837,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "03a3e538-4a97-4c94-a72d-ff7594fdcf4a",
+      "key": "42c06b5e-a5e4-4436-ab31-fa9875708a05",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -5816,7 +5846,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "ce551dc3-8fae-4ef8-92d9-a410883850e5",
+      "key": "14cf9176-8250-4b6c-8885-a290b2b781c8",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -5834,7 +5864,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "243c89ca-31b1-4cb0-bf60-f326cab1c7ca",
+      "key": "122070d3-04fc-4002-84ef-f198fc8cd152",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
@@ -5851,7 +5881,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "fb19c02c-e41b-4161-a9c9-5c75f66f192c",
+      "key": "c3a6a2bf-900d-457c-a9ab-a452c60b980f",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
@@ -5869,7 +5899,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "ef5b9e14-08cb-4ffb-af9e-43ef6866014b",
+      "key": "6de84d98-68e7-47d6-a56e-8a4716ba05f2",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -5879,7 +5909,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "886e3122-d5b5-4b94-bfa4-89b7bb617804",
+      "key": "8d38b963-48fd-49cb-9918-aa79a06c24b4",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
@@ -5897,7 +5927,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "4252068e-4b91-4840-b02b-348605c8035f",
+      "key": "9df04901-0de9-43ab-91a1-382fc4b66b75",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "addressableAreaName": "movableTrashA3",
@@ -5911,14 +5941,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "a45c64b7-c71c-4738-9ef1-f7ac71e75f7e",
+      "key": "30de7c72-58f0-4cde-8354-77d919b40f96",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "f765473b-b60a-45e1-bba8-1ae670945342",
+      "key": "a56e27c7-e087-43aa-9e31-52011b65c7c2",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -5927,7 +5957,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "9eb728c9-949b-4347-99f4-2993620163d3",
+      "key": "60e734cb-673d-4376-bbf2-31811570b684",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -5944,14 +5974,14 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "0230c6cd-88f3-4294-a7e0-db1a61c586d2",
+      "key": "e09a594e-8213-467e-b6a4-42d6b30cd239",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "1bd87acb-2e17-42b4-be0c-15d5661b516d",
+      "key": "1e3fff6f-55c2-45be-ada7-87b73be77623",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -5968,7 +5998,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "14ef2611-99e2-4fa8-bd82-36c2a26b43ec",
+      "key": "51af8ff1-1cf6-4f89-9149-41d7c4f09e7d",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -5986,7 +6016,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "e84dff00-2326-4550-ba17-05b7d17a1a79",
+      "key": "c2a7ba53-31fc-40b9-a6c5-5a3ab456b8ba",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -5995,7 +6025,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "82b8e417-7e3c-43a4-a71c-a5c6ef466c85",
+      "key": "eff2a528-619f-44dc-b0d2-e1ac92b8977a",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -6013,7 +6043,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "69c65ac0-79ad-42d7-a4dc-27994673521f",
+      "key": "206136c9-eb8f-4824-997b-e8ce67e0ff84",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
@@ -6030,7 +6060,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "ee33c796-1da8-4aca-9d2c-e7c797b2a151",
+      "key": "9afb615d-b1d1-4340-a755-39c33a93af91",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
@@ -6048,7 +6078,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "e1461961-e79f-47c3-be01-b8d2d5306d47",
+      "key": "1442e6e0-e290-475e-9f77-7319aef544ba",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -6058,7 +6088,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "585f5c62-9cf8-45a8-bbfd-f3693da1ba0b",
+      "key": "d8eb2d8c-5636-4599-9546-176b89930078",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
@@ -6076,7 +6106,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "14aeb458-4ac4-4494-a553-82fd2aae56ee",
+      "key": "d3f2d9a5-2b43-4de8-adff-35eaa3f3b166",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "addressableAreaName": "movableTrashA3",
@@ -6090,14 +6120,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "37f98e46-572a-4d6b-b57c-68a5da688f93",
+      "key": "49f5d507-eef3-4132-bdf3-e73ec33b5695",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "a20d93b4-f17f-4b70-b789-6ee9570d5e7f",
+      "key": "a21cbba7-5ab1-4df5-856b-6ec7281631ff",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -6106,7 +6136,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "2cf6efba-660e-4fdf-b710-27471457e3d5",
+      "key": "55880aaa-1414-4a89-92cf-7f5448abb2d5",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -6123,14 +6153,14 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "bb0117ad-37b2-4999-ad77-ed5bdd217c92",
+      "key": "ef78105c-7704-4569-be43-c2bfda1295e7",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "d16be8cf-666c-401f-98dd-e9b7bda37592",
+      "key": "9343bd6c-32e8-4ae9-bd51-5621ae219687",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -6147,7 +6177,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "13c3ed19-e6a0-4e48-9cf5-6817cee1f25d",
+      "key": "caa3056a-607d-4130-9d21-e743fa2b6d13",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -6165,7 +6195,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "7384fdb5-f3cf-4a1c-a5f5-134bcf9a445b",
+      "key": "3ba65b80-3161-47f6-a687-ca4e3c8a4fbb",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -6174,7 +6204,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "e86be59e-9a92-40cb-b94d-03a53ec3e8be",
+      "key": "ac1c8b55-6f41-4909-a1d9-44dd0e201313",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -6192,7 +6222,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "6f9dccd7-d323-4658-9d3c-9b5eaa7808f1",
+      "key": "0ed5d8a4-d5a2-4130-8637-a1a7598a4fc6",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
@@ -6209,7 +6239,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "333292ea-8f4e-4c09-abb9-6f0c89c9d52e",
+      "key": "3282e6f1-1306-4e4a-9201-5d58776f26bf",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
@@ -6227,7 +6257,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "b194c954-3704-4963-b2a2-58fe99018a52",
+      "key": "92dbf6cd-fe44-4456-913c-48c307898ead",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -6237,7 +6267,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "cae3b22a-6e68-4c13-9bac-bd6b54c6064b",
+      "key": "27912d99-709d-42c0-9e76-00370ac907c5",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
@@ -6255,7 +6285,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "68cfe93d-bb54-49e6-beff-fc5abf862394",
+      "key": "5426c177-bbf4-4ce3-9a0f-93d2283d7663",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "addressableAreaName": "movableTrashA3",
@@ -6269,14 +6299,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "9f73e02b-bfc2-429e-bc38-c8a90c12842e",
+      "key": "d75f7123-d4f9-46f1-a5f9-cc1fd88f8361",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "d43192c9-a3dc-4e46-a6c8-2073c405932e",
+      "key": "9d3920bc-491f-43dd-ba8d-cec8ec38ca91",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -6285,7 +6315,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "460ccdf9-726b-4dde-aeac-11840681fe2f",
+      "key": "bc002aa2-3f64-435c-aae2-a9683d868cb3",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -6302,14 +6332,14 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "cdc2083a-bb5a-4582-9fde-3c0818be4b91",
+      "key": "c051b071-01b7-4165-9e42-591a35db2eaa",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "fc9c0d1c-a899-4ecf-bebd-73a9521f02a4",
+      "key": "150c8b6d-a414-498c-b54b-395020317059",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -6326,7 +6356,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "0eea7b95-8a99-41a1-b643-d33a3675bcea",
+      "key": "35ddcb95-c6cd-4d38-bb46-d59eea33e1fd",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -6344,7 +6374,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "e66b6847-02ce-418d-8bbc-6d449065f703",
+      "key": "fa495bae-d787-4889-ac12-ce1ebe62a70d",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -6353,7 +6383,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "c55028c1-19c4-4606-87a4-c4fd12c077f0",
+      "key": "d5cddd37-c641-4b96-b100-80956be1540f",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -6371,7 +6401,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "3f3ab494-42bb-460d-be7b-7d7419d2d2c1",
+      "key": "6b91d1a2-b2b5-46f0-83f6-cd993fde735b",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
@@ -6388,7 +6418,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "9cb8ce97-9dff-4f58-a709-75db269eaaea",
+      "key": "637fd07b-e6c3-4cb2-a728-b201da33091c",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
@@ -6406,7 +6436,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "73182135-0d86-4708-997f-f0bfc7f3b3e7",
+      "key": "854ae467-1595-486e-aa8a-35f79393901b",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -6416,7 +6446,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "1a2ff879-e5c7-4c39-abb1-79644168849e",
+      "key": "71a35e6f-38ea-491c-b0e6-bdc7a00ea3c1",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
@@ -6434,7 +6464,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "2c86d77a-2f34-49a4-b5fb-5b7912bdd45e",
+      "key": "9f91e5e6-ee13-4dce-b339-97d1561cb46c",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "addressableAreaName": "movableTrashA3",
@@ -6448,14 +6478,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "fb31c697-7bea-4036-a4b2-81cb8837a75b",
+      "key": "520241a4-e550-4472-8175-f778e7a7f7a2",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "c75371bc-4066-4661-a16d-cf7486097845",
+      "key": "3d46a01b-0e6f-4015-bcec-3352b4f3b129",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -6464,7 +6494,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "4b660813-7377-484e-b1d7-5feb50652ee0",
+      "key": "768d8a67-0b58-4896-8f64-ed1336e673f9",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -6481,14 +6511,14 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "6258ed07-aa38-4d96-b11d-f79c75f332fe",
+      "key": "7891ac8c-5e4c-49b7-be9c-5492c1c0b030",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "5202b741-02ce-4592-8c72-ae1eabfbab97",
+      "key": "886b334c-d334-46dc-9d25-1fe888e6ce8f",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -6505,7 +6535,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "882868c3-16b7-4b81-b4ea-346e9b98f004",
+      "key": "eab3511c-68f3-47ac-baac-3c23e16702b7",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -6523,7 +6553,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "c5210d86-d42b-4918-94d1-4cca464100dc",
+      "key": "39efa3c8-86e4-442a-8acd-ef861cefdd55",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -6532,7 +6562,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "1df7602d-7209-4505-82ee-089932ea9518",
+      "key": "f59d7634-f867-4647-89a9-2b62639e18c7",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -6550,7 +6580,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "19e7142a-f32b-4c8f-bf62-a4029939a8f0",
+      "key": "399ec31d-405c-49b9-a383-899d342a2c72",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
@@ -6567,7 +6597,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "5bbd75b5-e82c-43da-bf39-e57ecce00e10",
+      "key": "ff5834dd-847b-4d4d-a06b-d8e07acba78f",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
@@ -6585,7 +6615,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "fdd0e96a-d6d7-476b-a6d8-01d144276d24",
+      "key": "4d49d7f9-8180-4855-8ae9-35196e1aa7ec",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -6595,7 +6625,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "5edcd733-199c-4bef-b8fb-4e3818b0e0f6",
+      "key": "55e2e711-2085-4827-ad87-f2e14645e7be",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
@@ -6613,7 +6643,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "696ee630-7509-4074-92f7-60a5b8970933",
+      "key": "eb05a0d0-8f40-4d5d-b431-f151e5ff8cdd",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "addressableAreaName": "movableTrashA3",
@@ -6627,14 +6657,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "3eb9ea88-f50f-4301-b1e0-cd0cba6378c4",
+      "key": "7c1da1b5-01fa-4002-bc52-9425cdeb3ae2",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "98cea73d-f695-4305-b685-969db952c27d",
+      "key": "3b600481-a3b0-437d-9e28-c093927c1bce",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -6643,7 +6673,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "4f2c1465-4421-4c53-9086-edee7d0886f6",
+      "key": "cfa8a390-61d1-4818-af18-93d0fef6601c",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -6660,14 +6690,14 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "cc7ba1ee-c2ce-4602-9036-b49a942e92b8",
+      "key": "7f04a360-ebda-405b-8039-b7811e9f5f45",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "f07208df-1d16-4b66-9cd9-452a14ca623e",
+      "key": "a50b21a4-713a-4630-9d20-ff93a8a6d21e",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -6684,7 +6714,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "9345178c-fabf-4446-bbef-17328661f5bd",
+      "key": "44953afb-8d3b-47d9-bbf6-b981f78a7a25",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -6702,7 +6732,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "164ccfb1-b966-48de-91a6-5b7db0822df9",
+      "key": "0436b39c-31c8-49b3-be0c-50e0051e746c",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -6711,7 +6741,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "36237809-cd13-433c-8af7-bbd4b3b0ead6",
+      "key": "9f595d51-6f73-4776-bc35-c58818b3b31a",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -6729,7 +6759,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "4455b180-956a-49cb-8965-e790ee081b14",
+      "key": "965440b7-06e7-4804-89aa-2aa62964f0d9",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
@@ -6746,7 +6776,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "39c85e95-3077-446f-a24e-74b8e89d5230",
+      "key": "43384fdc-c1c2-4063-952d-3de2e2384c5c",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
@@ -6764,7 +6794,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "253f52b0-1678-4ccc-a11c-0af608ccee7c",
+      "key": "091f57c9-c9d3-4bfc-9167-aa43ae573631",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -6774,7 +6804,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "c463cd7e-7be9-49df-a309-9a908dd5929d",
+      "key": "b9c7e83d-9da6-4904-9bd6-ac367e0c4ea1",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
@@ -6792,7 +6822,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "8a981e68-ccb3-4215-9f79-5e61425f63c6",
+      "key": "e6a5cf6c-6ff5-4da1-9ee2-3643f83b0c68",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "addressableAreaName": "movableTrashA3",
@@ -6806,14 +6836,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "92cb0b02-9dc8-469b-80a4-0b66fddf101f",
+      "key": "109cc56d-4b51-481d-ba47-cae27a452d57",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "1d1d82ef-37ba-4150-b0c5-be730ea43573",
+      "key": "9c3ff976-59c6-4549-a72b-2b982cdb65fa",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -6822,7 +6852,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "ace59562-3f0d-43d2-9f3d-3444569e1afa",
+      "key": "5936b0ca-2e84-4e67-86b6-7efd38b0a658",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -6839,14 +6869,14 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "e1e7eaa7-e85e-4eae-9151-151c0d8f110b",
+      "key": "f1de6dc3-55b2-4068-99dd-37ef5a0fd89b",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "55607804-5f9c-4117-b20d-ae7b471832f9",
+      "key": "fdcf1d07-699a-44d8-aee2-b23b62687ff5",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -6863,7 +6893,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "ef4bb30d-1126-459f-a4e7-08cb184bc34c",
+      "key": "7b68b9b9-ca9c-47fb-b12d-7234e902611d",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -6881,7 +6911,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "414e3ed1-70b4-485b-be01-00628e5e1872",
+      "key": "bd41a4c8-8a68-4e3f-b870-fcc374f9b02c",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -6890,7 +6920,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "9281e765-44d6-42d2-a3ec-d163782d3358",
+      "key": "32771c9b-4db8-41b1-aff1-1246ee9d16cc",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -6908,7 +6938,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "3b8a6115-3329-47d7-b0e1-f22a35ad40b1",
+      "key": "e59a133d-92fd-4367-9af7-7173d2cdeb71",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
@@ -6925,7 +6955,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "49759791-545b-4337-a980-4e29fb24fec9",
+      "key": "5770b5e8-efac-4d39-99a3-84580bb4ecc5",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
@@ -6943,7 +6973,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "db87e009-0b30-4242-b9b8-931ae9d8f44e",
+      "key": "213e128b-c735-4a84-a9d1-3b83fc877636",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -6953,7 +6983,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "82a6a6e3-cd8d-4b00-a183-1af43b2eada5",
+      "key": "d75e01f0-2c18-452a-b7fa-64c5b4a2f7a4",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
@@ -6971,7 +7001,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "3875e039-1047-4ad1-8c9d-e6b1112e6570",
+      "key": "3f7036cd-ff01-4e3e-b48f-0034a2b0f1a4",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "addressableAreaName": "movableTrashA3",
@@ -6985,14 +7015,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "6c34080b-cb67-4c89-8292-93eec497d931",
+      "key": "489bee8f-5f63-448b-8185-4faf71b4d188",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "1a9f8568-fcf7-45d4-a6a9-1ac4eed1e875",
+      "key": "994ed83b-b184-4852-8266-bd9c6ea5996f",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -7001,7 +7031,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "a95bf04d-82ae-4e6c-a14a-1673b8ce41d2",
+      "key": "21984efa-2478-4db6-a89f-d9f871ba177e",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -7018,14 +7048,14 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "1d96d8a1-0905-4863-ad4b-28e73e3bee34",
+      "key": "4bdeac74-3f22-4e06-90be-759b8b572523",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "4bac78ff-1aa0-4632-8966-91d92482167c",
+      "key": "a19fef6e-f4a6-4938-83c0-051bf305f70c",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -7042,7 +7072,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "acf1e939-3b29-4371-97d2-366c69595861",
+      "key": "2048f26b-8a00-481f-899f-04369f67bc49",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -7060,7 +7090,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "1510535a-13cc-4037-b302-867ebca6cdd5",
+      "key": "20ae277c-fa87-4c1c-a593-aba1ccf2c4bb",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -7069,7 +7099,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "d10b46c8-0663-4c9a-ab06-f6007500ede1",
+      "key": "0a3c4b71-4884-43ce-9fc2-57f5cc7024e5",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -7087,7 +7117,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "1f82cc45-94e2-427d-bca9-9ea65da41f63",
+      "key": "542dcbc5-3f39-4273-a8fa-630098945f74",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
@@ -7104,7 +7134,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "aaa6c0d5-ede6-4d62-a0fc-d3ac5f98cf49",
+      "key": "e6893af4-f6f7-4d5e-8eae-ef5ffe63c01f",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
@@ -7122,7 +7152,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "da8d15cf-15e7-42fc-ba5b-182b00035255",
+      "key": "f1e0432d-631f-493f-8188-d17d988e79b9",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -7132,7 +7162,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "c6a01de8-071a-4c40-b4ff-2dc8cfdf5980",
+      "key": "c39ec7f5-38a0-47bd-934a-4cd3977f4dad",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
@@ -7150,7 +7180,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "d1f849da-c379-452d-8f33-848f11676a23",
+      "key": "0a24129e-c07e-4344-be8e-4b0436b14ba0",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "addressableAreaName": "movableTrashA3",
@@ -7164,14 +7194,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "a2d47f73-815f-4fe7-86fd-91e83acb87c7",
+      "key": "3cbc4996-47f4-4d41-9c16-423ad8f220ca",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "5ee07049-d2ed-4fb6-ad23-9702dfa19423",
+      "key": "2cc272aa-a667-4841-b9b2-0ae5fb7324d1",
       "params": {
         "pipetteId": "6d1e53c3-2db3-451b-ad60-3fe13781a193",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -7180,7 +7210,7 @@
     },
     {
       "commandType": "configureForVolume",
-      "key": "2a92250a-3db5-4499-954c-1a68abff12bf",
+      "key": "a0f3dfca-3560-403e-9d7b-e7ac66621202",
       "params": {
         "pipetteId": "6d1e53c3-2db3-451b-ad60-3fe13781a193",
         "volume": 10
@@ -7188,14 +7218,14 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "2f1122b5-db81-4751-9855-f0b22373d09d",
+      "key": "180e0b26-7f68-4c0e-8c2e-2e823e848267",
       "params": {
         "pipetteId": "6d1e53c3-2db3-451b-ad60-3fe13781a193"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "f948ec0d-939d-4690-9785-e990428159ab",
+      "key": "64519449-2221-4869-b372-0dbc6522b17b",
       "params": {
         "pipetteId": "6d1e53c3-2db3-451b-ad60-3fe13781a193",
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
@@ -7212,7 +7242,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "5e503907-3a38-4ba3-86b1-ce3d3f760f7c",
+      "key": "9b8a32ca-4417-4230-8262-84f42ef7777c",
       "params": {
         "pipetteId": "6d1e53c3-2db3-451b-ad60-3fe13781a193",
         "volume": 10,
@@ -7221,7 +7251,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "4592e8bd-222e-4716-a23f-71030b6506cb",
+      "key": "8a73da6d-d951-494b-9078-b4f0a0cc210e",
       "params": {
         "pipetteId": "6d1e53c3-2db3-451b-ad60-3fe13781a193",
         "volume": 10,
@@ -7231,7 +7261,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "e2e00d18-f244-43b5-b619-5084de780473",
+      "key": "efd70662-8957-4e10-9cc6-f87a6bc1b8bd",
       "params": {
         "pipetteId": "6d1e53c3-2db3-451b-ad60-3fe13781a193",
         "volume": 10,
@@ -7240,7 +7270,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "584ff4f6-d949-4a4c-b5ba-e68b3b5be102",
+      "key": "7aff45e6-9cd2-450d-bf5e-8fe38eb65cff",
       "params": {
         "pipetteId": "6d1e53c3-2db3-451b-ad60-3fe13781a193",
         "volume": 10,
@@ -7250,7 +7280,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "fd3cc044-7040-4acd-96d7-d0e968a709d5",
+      "key": "c1471137-b304-4fe6-a72b-6dbb5065777c",
       "params": {
         "pipetteId": "6d1e53c3-2db3-451b-ad60-3fe13781a193",
         "addressableAreaName": "movableTrashA3",
@@ -7264,14 +7294,14 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "baf8c1d1-6004-43b1-8c0f-67f62e36ae09",
+      "key": "bfaac1c2-fa68-4537-a5e8-81f37c11e895",
       "params": {
         "pipetteId": "6d1e53c3-2db3-451b-ad60-3fe13781a193"
       }
     },
     {
       "commandType": "moveLabware",
-      "key": "5a870ee4-5037-47cd-b6d0-25dc91a74929",
+      "key": "1c38ae21-40cc-4d84-a4a4-df042a2850a2",
       "params": {
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
         "strategy": "usingGripper",
@@ -7282,7 +7312,7 @@
     },
     {
       "commandType": "waitForDuration",
-      "key": "b3ce7236-6190-4b61-9497-90272f86370f",
+      "key": "afea497a-63db-4da9-86f6-5ee8cc30d28b",
       "params": {
         "seconds": 60,
         "message": ""
@@ -7290,7 +7320,7 @@
     },
     {
       "commandType": "moveLabware",
-      "key": "157fc026-e756-4054-96cf-32f594dbd253",
+      "key": "291b7fad-0f3b-4c06-bc3e-5c80129ac9de",
       "params": {
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
         "strategy": "usingGripper",
@@ -7301,21 +7331,21 @@
     },
     {
       "commandType": "heaterShaker/closeLabwareLatch",
-      "key": "c2e9865d-d8bd-43f0-ab88-7c7dcc0f1f98",
+      "key": "ab37ff4c-2781-4d32-b3a5-6a5dea197f5d",
       "params": {
         "moduleId": "c19dffa3-cb34-4702-bcf6-dcea786257d1:heaterShakerModuleType"
       }
     },
     {
       "commandType": "heaterShaker/deactivateHeater",
-      "key": "2d963188-367e-4952-8e25-88ba7c7a6b2c",
+      "key": "c11b99a4-39b5-4a51-8917-a3fe40a62b95",
       "params": {
         "moduleId": "c19dffa3-cb34-4702-bcf6-dcea786257d1:heaterShakerModuleType"
       }
     },
     {
       "commandType": "heaterShaker/setAndWaitForShakeSpeed",
-      "key": "764cb301-96b4-4536-ae8a-ee10d5deadb5",
+      "key": "18c9a721-7077-4b74-99c5-44b496c202cc",
       "params": {
         "moduleId": "c19dffa3-cb34-4702-bcf6-dcea786257d1:heaterShakerModuleType",
         "rpm": 500
@@ -7323,28 +7353,28 @@
     },
     {
       "commandType": "heaterShaker/deactivateHeater",
-      "key": "dc6ecf05-304f-4f71-90e9-5c121f6f46aa",
+      "key": "dc1f6ff0-4754-4fe9-8bd3-0585e4cc3212",
       "params": {
         "moduleId": "c19dffa3-cb34-4702-bcf6-dcea786257d1:heaterShakerModuleType"
       }
     },
     {
       "commandType": "heaterShaker/deactivateShaker",
-      "key": "fe45609f-8b19-4d6d-abe8-6f2e96583462",
+      "key": "d98dc809-4115-4eb6-a42d-380af45cd17b",
       "params": {
         "moduleId": "c19dffa3-cb34-4702-bcf6-dcea786257d1:heaterShakerModuleType"
       }
     },
     {
       "commandType": "heaterShaker/openLabwareLatch",
-      "key": "f22a8d10-1605-43e5-a3a3-f77f2d1b69ab",
+      "key": "2da3f6d8-85f6-43eb-ab24-3b2a1c8a2855",
       "params": {
         "moduleId": "c19dffa3-cb34-4702-bcf6-dcea786257d1:heaterShakerModuleType"
       }
     },
     {
       "commandType": "moveLabware",
-      "key": "9e26c280-ff71-4d57-84e5-2850e035f449",
+      "key": "5c0e5809-0074-4dbc-bde1-4308d24dbc8b",
       "params": {
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
         "strategy": "manualMoveWithPause",
@@ -7353,14 +7383,14 @@
     },
     {
       "commandType": "temperatureModule/deactivate",
-      "key": "a7e58923-733d-4947-a602-dc9a2fba95f9",
+      "key": "e8fd2d42-ea8d-4790-9df8-da34415c6244",
       "params": {
         "moduleId": "ef44ad7f-0fd9-46d6-8bc0-c70785644cc8:temperatureModuleType"
       }
     },
     {
       "commandType": "moveLabware",
-      "key": "034dcb44-3e19-4f42-a363-3d0f0b965b05",
+      "key": "a5809c1f-c299-49d8-a4d1-80f97c102258",
       "params": {
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
         "strategy": "manualMoveWithPause",
@@ -7371,7 +7401,7 @@
     },
     {
       "commandType": "pickUpTip",
-      "key": "244174cf-035b-48c7-8041-3bf33594167a",
+      "key": "6cf9ae4c-756b-4e3a-88d8-d9f78275b25b",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -7380,7 +7410,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "4d624711-0d13-478d-87bd-d509c1cc2bfe",
+      "key": "59eb459f-ee29-445b-a028-f7e63abce8e0",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -7397,14 +7427,14 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "68fa6e6d-6ff6-47df-a714-8e5ec20aeaba",
+      "key": "d1d25991-ea7e-4419-b834-121d4266896e",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "8a0afc87-d7a0-46a5-9ecb-b9de022c7f9b",
+      "key": "73c7fb6c-ef4e-4311-b7a2-0bc14dfa5b53",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -7421,7 +7451,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "fd48b1a3-1481-4326-b8a5-0f47e94a516e",
+      "key": "fb094683-c23f-4bf9-86cd-3cd1fad1ca5a",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -7439,7 +7469,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "e90a44e4-9f29-4e95-b8ef-868a896d6f03",
+      "key": "607d60e7-4d5d-4de8-b43f-63a38c95f92e",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 5,
@@ -7449,7 +7479,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "6ae02ce6-d8dd-4bb1-9e7b-f31a35a7ce15",
+      "key": "25b2e7f8-1763-417f-a891-63acd73dc023",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -7467,7 +7497,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "e87f447c-2591-410a-b5f9-a7788983bd4f",
+      "key": "02f064af-6bf8-4e2b-896e-619ef14efaef",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -7484,7 +7514,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "79b1951c-d053-4ec4-bff2-73969ba9ac8a",
+      "key": "ebdade17-12fb-42a6-8026-ce85ccc8e9ce",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -7501,7 +7531,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "0b660094-93c7-426c-bc92-98689e5c23dd",
+      "key": "54593f3f-0f5d-4731-9d75-51a7ea131ebd",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -7519,7 +7549,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "3c0bd4d5-af4d-4422-878c-2ad622a54e25",
+      "key": "c40e03b8-ebfb-4eeb-aea6-5629dd4eb346",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 5,
@@ -7529,7 +7559,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "dfff3fbf-4c3b-4579-b6b7-5de9093ca226",
+      "key": "0e5f8974-f3da-45ad-bf33-8e41548592e8",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -7547,7 +7577,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "a41a2207-d33a-42f9-9afb-e12770fd5672",
+      "key": "5871479d-174f-43c2-b5c6-36438bc37d47",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -7564,7 +7594,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "caff4bda-8680-4f96-b0ce-cfc5d13553e9",
+      "key": "0fe1de43-8f07-46d2-bf94-3340437e710d",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -7581,7 +7611,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "f849ffa2-6a76-4526-a9d9-af1a0c74a265",
+      "key": "6d679731-07fe-4d06-bc1e-72278e275b74",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -7599,7 +7629,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "c29cbaa8-c03d-4e28-94bd-d9fc343eb50e",
+      "key": "d4216fb3-bbcc-428b-90b4-2125294266d1",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 5,
@@ -7609,7 +7639,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "4f03f4a3-429c-494f-ae56-392c60d78472",
+      "key": "e733cc4d-2620-4527-99df-54f42622049e",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -7627,7 +7657,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "d0e15c50-2ce8-409d-8619-ef59dfeb3ffc",
+      "key": "5c193130-33b9-48ff-a35e-1d50cb1a4c5b",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -7644,7 +7674,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "db2b0fd0-2f3b-4a18-9305-ebcadcb7cce1",
+      "key": "0ae5e061-c915-47d8-9d3a-02cebbeb97b6",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -7661,7 +7691,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "63a38167-b368-47ed-b358-1737e4ac9e26",
+      "key": "984ea3fc-a2ab-4414-a2d2-aab91464f2e7",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -7679,7 +7709,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "86830c97-0e81-4dac-84cd-9a5332e49b27",
+      "key": "720e8137-839c-4d1b-a69a-970c0fccaefd",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 5,
@@ -7689,7 +7719,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "7ee5e5c4-d9a5-45ab-9d31-2973ec1d32c8",
+      "key": "36c7c975-8b52-486c-8072-625127f4c521",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -7707,7 +7737,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "1f597a05-9d21-41cf-b5bb-1a0d053af1de",
+      "key": "9930d83d-eff7-4ca4-8928-28033d7a92eb",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -7724,7 +7754,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "0bdb23c8-f47e-4c9f-aff5-7e9401896846",
+      "key": "8efcd80b-f6b8-453b-a1e4-3889cedd367e",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -7741,7 +7771,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "9519e541-44f3-467b-ab86-dd0dd995d82f",
+      "key": "4e47daee-4773-41d1-99dd-7f0999b3c0ff",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -7759,7 +7789,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "1ee1baf4-7d00-4138-8650-896bfbb76e08",
+      "key": "7442318a-4925-4a2a-a3c2-c4d49584fd72",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 5,
@@ -7769,7 +7799,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "f208d865-5883-4c08-8f3c-94d5fc179ebf",
+      "key": "9fc7a8d2-367f-43dc-92d4-9024952c03f8",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -7787,7 +7817,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "76b8bad9-0a4f-4661-9416-8293c55f6eb9",
+      "key": "181f5b0c-eb00-4377-aa9c-40b6abc97b74",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -7804,7 +7834,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "2ef0b327-5e11-4a2a-82ff-f7a35827870b",
+      "key": "f3c09792-1da4-4be0-aea2-05f18dd3557d",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -7821,7 +7851,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "60dd02e6-8119-450c-9deb-7e912ffa2a6d",
+      "key": "7e278c67-bf6e-42e6-8e2c-c076df5c3f1a",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -7839,7 +7869,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "3872015c-387a-4c37-9b78-38730d90cf6a",
+      "key": "f29168ae-4663-4d8b-898a-ec2a1210036f",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 5,
@@ -7849,7 +7879,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "4e2e456f-70bf-491b-91e3-c97e4b8c1d82",
+      "key": "c27a3930-0609-4b75-b5ee-4abde177b2ca",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -7867,7 +7897,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "f769eda8-be01-4c9e-9cc6-d433c27a46df",
+      "key": "76ad0ec5-0f48-4764-811a-cd78c9628f78",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -7884,7 +7914,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "422f2fff-9bc7-484d-9509-1b172dfd616c",
+      "key": "6a735932-d495-49cc-98e3-2df62730ffd3",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -7901,7 +7931,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "f72d3737-14a2-4f53-99fc-3ed52ba787a2",
+      "key": "884da49f-8d9a-4ab1-85c7-4c2e729abfd5",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -7919,7 +7949,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "db633ef5-6ef6-4394-9621-3381fcbddee8",
+      "key": "3a1ed1fa-c941-44b9-8d3c-d3235674f859",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 5,
@@ -7929,7 +7959,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "f8a3af15-9dbc-4646-ba56-05c08205a63a",
+      "key": "fd538c94-77f4-48b0-864b-32c1cbbe0112",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -7947,7 +7977,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "1e5fa961-9207-48d1-ab9c-b87aa036aa5f",
+      "key": "eeb5c5a2-1bda-458a-89d5-951fb2361819",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -7964,7 +7994,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "1ae575e4-5eff-4c7d-a321-fd10562d956f",
+      "key": "a5cabd0c-ade2-4182-86c4-36acc7183651",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -7981,7 +8011,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "4c8d465f-419e-45c2-b4a0-0d082ad30a7d",
+      "key": "4b68739d-a7b8-4c01-86e7-d2a442de8b44",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -7999,7 +8029,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "e83c30e2-0fb8-4982-9bd2-5ec770ec3f73",
+      "key": "751fe534-9cef-42b9-8b2f-5bdd4a404ba6",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 5,
@@ -8009,7 +8039,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "45d597fe-efac-439e-9231-733a4083627e",
+      "key": "35c6c73e-f02b-475a-8e5c-63fbd340a661",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -8027,7 +8057,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "a829edca-f09d-4b54-a3d4-210e486726c4",
+      "key": "b3943871-fbb5-44cb-b621-9c7d5b3e26c8",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -8044,7 +8074,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "d05fd878-70ec-4fd3-9736-4ab25fd20f0e",
+      "key": "ce8beab3-c478-4450-bffd-1c5a057563b2",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -8061,7 +8091,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "950eae69-5400-4cf7-b1db-ad8057f6c9ee",
+      "key": "cc75e027-6c6f-4957-8b39-7072ed3be4c3",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -8079,7 +8109,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "24d7e5e5-8c6d-438d-882f-6e52301b96ef",
+      "key": "77da58e5-c598-419b-997e-4fef3782fd83",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 5,
@@ -8089,7 +8119,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "f6ae187b-4b10-44d5-b842-70772bfe80d1",
+      "key": "627bc50c-5644-40f0-8fab-a9ce46214d26",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -8107,7 +8137,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "ab05dd82-ab1f-468d-9194-0bd2caaeeb74",
+      "key": "9686dd76-5f32-4aa6-b0a7-79f6d486a092",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -8124,7 +8154,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "228f027a-9d84-4985-aa66-12195b0466aa",
+      "key": "4761e180-5d52-4573-aa26-c144fa8985d6",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -8141,7 +8171,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "fc3bbe4f-8ba6-4b9b-97e6-7877387b5f4e",
+      "key": "8b565301-b9e0-4ed4-9329-e2e672d30874",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -8159,7 +8189,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "15887b9a-02ff-4024-9438-b43c36b67509",
+      "key": "17cd34ec-53d9-4ce1-b499-f11316997e67",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 5,
@@ -8169,7 +8199,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "036be488-89d0-4d69-be2a-7456d13aaa18",
+      "key": "27674088-32bc-4636-bae3-338ef69e9b4f",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -8187,7 +8217,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "944797e9-29ff-4684-bf8a-62630671bf22",
+      "key": "e28a03aa-7dac-442b-8937-3f204e049e5f",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -8204,7 +8234,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "600454f5-542e-4c51-bf93-e65b173642d3",
+      "key": "eaa389af-684a-4aae-85ad-625d62d2782b",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -8222,7 +8252,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "f18c3006-e6c6-4a2c-840e-9bc84cd74ac3",
+      "key": "ddfdd8ec-dcef-433e-935b-8177b62eac92",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -8239,7 +8269,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "f89ee9ee-097a-4dad-84f8-ad10d8e20c2c",
+      "key": "62f02665-e454-473c-a45a-8f310839d9bb",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -8257,7 +8287,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "d2ae27ae-2179-4ffa-abcf-7641588334c1",
+      "key": "3007330a-2f21-48d8-b511-ff40e7b74f32",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -8268,7 +8298,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "c756487b-d16e-4208-b619-6489c386ede4",
+      "key": "b52ea102-56b4-4136-b042-636bd7b98872",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -8285,14 +8315,14 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "89fd44d6-f41f-4a00-b51c-8f79481cccc9",
+      "key": "a6b531f0-3664-4e1d-8e59-80c65f10bb40",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "a258e73b-af56-4381-ad3d-f70ec78969f4",
+      "key": "0264ea04-9571-45fc-be21-f2321189d390",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -8309,7 +8339,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "14d950bc-0f42-4d44-a1ac-98d0a61a36f9",
+      "key": "123db7cd-ad06-42fd-8842-80594acc4626",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -8327,7 +8357,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "3525fcf1-4dcf-4324-92a3-ffba7d870b9f",
+      "key": "3f96962e-b1c5-4604-8d34-5a43d23fd375",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 5,
@@ -8337,7 +8367,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "bbe9b798-f761-4c06-9a9a-6b0c3dc758dc",
+      "key": "2b231f9b-d197-444e-ba95-ead892be0dc5",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -8355,7 +8385,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "31759a53-a851-4cda-86bd-0001f21cc6a9",
+      "key": "5dc0c862-d6f8-466a-9d56-9e6c8ef842c3",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -8372,7 +8402,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "b9bd0596-e2bf-4a11-9e64-6346a72e1d11",
+      "key": "e18fccfa-4e6a-49b6-89c5-7417c3ed8f95",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -8389,7 +8419,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "3b41d36a-c722-4151-939e-c3572d0dbc4f",
+      "key": "caa26303-84ae-4bad-88ed-0a9fb3a088cc",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -8407,7 +8437,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "52eee631-3d9d-4cbd-a313-32a05469b604",
+      "key": "666f139e-4f66-432c-88fc-822ac3d9e880",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 5,
@@ -8417,7 +8447,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "ec51fa84-45b2-4dae-8346-d88fd819405f",
+      "key": "a651876a-2176-445b-9691-2f29acf87fc7",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -8435,7 +8465,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "8e5de349-6189-4bff-823c-f973e5a0502a",
+      "key": "154d1588-7390-440f-82a6-3b20791d2678",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -8452,7 +8482,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "7c7dc8f5-9d09-4337-97ef-01ad4d4fb684",
+      "key": "c933508f-3934-4d7c-9349-2c4721c38b45",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -8469,7 +8499,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "caf29d74-d5c7-4253-a98d-5abc6ca73ddb",
+      "key": "4b309485-7c2b-48ca-a113-fe63946f6ad8",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -8487,7 +8517,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "16c84b31-c1ab-4a3b-bb51-46b9b94daa8c",
+      "key": "14147aea-0464-4f99-8532-6d37b5d997de",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 5,
@@ -8497,7 +8527,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "29b36e8f-412d-434b-8334-4dd4ef471c54",
+      "key": "37662183-a8cb-498b-bc82-6dc32bc1abfb",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -8515,7 +8545,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "0c858792-9104-4466-81a1-74614034ece4",
+      "key": "cf2b0243-a605-4db9-aa5e-ea8386b2b73a",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -8532,7 +8562,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "36b4387c-c59e-4e78-b0fe-f6eab8dbde64",
+      "key": "3a43c5f5-3578-4ce0-9c2c-1f4d240070b2",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -8549,7 +8579,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "87c44134-650d-43a6-92cf-fc468abc0775",
+      "key": "63473359-3306-467f-b0d9-c32a18e813ab",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -8567,7 +8597,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "d9399b33-406c-4aa2-9faa-8bc6dfa0528e",
+      "key": "6c7f6ef3-ee3d-4c10-a4ca-acdd76dd8d53",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 5,
@@ -8577,7 +8607,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "d7bf311e-aa59-4c2a-9b58-a3c290e0f07a",
+      "key": "c6b76bd1-42a1-427b-8ce6-76bde56302fc",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -8595,7 +8625,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "1cd89de0-ad3e-4086-ac3d-66e3bc9e024f",
+      "key": "5cc7c206-975f-4a2a-b4b1-0ca54861a137",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -8612,7 +8642,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "110479e2-746a-4901-9c98-f1ffee4d4438",
+      "key": "f6c94d73-fb36-4ea0-b54b-10f922609dd8",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -8629,7 +8659,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "85abc8df-51b6-4bd2-82a2-b3be7505e709",
+      "key": "d137c1c0-262c-40a8-9c59-a2e5b8dafc06",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -8647,7 +8677,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "17ad3e81-2b88-4169-8654-8e0d5abb6779",
+      "key": "aa5a426c-391c-4477-9577-aefc03ea17f3",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 5,
@@ -8657,7 +8687,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "a61fbbbe-0481-4b54-8f35-63fd9b0b0a81",
+      "key": "ff3d15f9-cfb3-46a9-aa69-51a0392e34d4",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -8675,7 +8705,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "a6ca2a1f-22ea-4c2f-b42d-61a4dfe1f0c8",
+      "key": "d5b8e59a-fb7a-4808-bc43-38b2ac63ab55",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -8692,7 +8722,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "c04197d1-2c41-4481-93c6-7eb5e166a14f",
+      "key": "dbddb799-08e4-4544-9825-e4c7a5bc7b1e",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -8709,7 +8739,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "930a5e44-b89c-4d9e-9c4a-2883cf0a8414",
+      "key": "5557beae-6269-4a2a-a3c9-95d257c8006c",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -8727,7 +8757,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "0e6b5a6b-1b73-4ea8-9515-1abb20a14b7b",
+      "key": "d00a592d-8fa6-4fc2-a20c-bbf93c55f17a",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 5,
@@ -8737,7 +8767,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "9e67467d-71a7-44db-9c0e-81004f044edb",
+      "key": "55ae514a-158b-4ab1-8bb4-b631a361b522",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -8755,7 +8785,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "b5f679e3-c12b-4438-8156-42e135dfd936",
+      "key": "aa2ea157-e2c6-401f-8a31-6fa989e0bc03",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -8772,7 +8802,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "8c0cf61e-cbc8-4ace-ab8e-8b8d83d8735e",
+      "key": "0d4cd784-e951-49bf-931e-2836fe466254",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -8789,7 +8819,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "a88f3222-2aee-4f3d-842f-10e661af597e",
+      "key": "6dae4bfd-67b4-455b-af45-60e47d31cb27",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -8807,7 +8837,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "d719c4c9-5d72-480d-8a9f-b97c8c40aee7",
+      "key": "925d87da-6e35-4d78-97ae-826832ff51ad",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 5,
@@ -8817,7 +8847,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "0a8363b5-694c-4f40-a322-825004ee6b13",
+      "key": "bab54fc2-efd4-48d1-b8e5-bd35550ebd9f",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -8835,7 +8865,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "7bedf113-a22d-4ee9-8493-7b51692dfd90",
+      "key": "a10c94ae-9a99-4d13-a821-8e1bac805b79",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -8852,7 +8882,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "5eada93c-e07d-496d-af24-540d6c9ab27e",
+      "key": "427d5c6d-aae2-45e9-bd76-e317a9069c7e",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -8869,7 +8899,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "3e22ae68-d1c2-4e46-aaf0-c1a72fb66b08",
+      "key": "f9b469a7-08fe-49a0-9196-65b5caf0e9e8",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -8887,7 +8917,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "f7a59826-5d6c-48d3-9b66-bdd5048fdea4",
+      "key": "1d3c9578-19c4-491f-b154-e7c51d08e481",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 5,
@@ -8897,7 +8927,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "c29ccd68-71c8-4d1c-8f56-618066e9ecd8",
+      "key": "bd8ac9d5-4436-4719-afec-44c0463432d1",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -8915,7 +8945,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "f187d9dc-ecb7-49f7-9c94-ec7e17c5c805",
+      "key": "0f5ec80c-2e76-4a31-8840-99d88b444386",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -8932,7 +8962,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "5682f438-37e8-43bd-8f7f-5def13d735cd",
+      "key": "429dd0dc-bf56-43db-9b5b-99621b5999cc",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -8949,7 +8979,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "16aae2df-546d-4c73-8436-c9de10df902e",
+      "key": "77bc6e76-de35-4470-9be0-91383533e2ba",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -8967,7 +8997,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "6e491068-3ae6-4427-97de-f2d16dcedafe",
+      "key": "aa3a1127-137d-4eae-ae91-98e33e286027",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 5,
@@ -8977,7 +9007,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "4b387420-1a61-42a4-978e-e483d700677c",
+      "key": "7dfec5c3-1444-4e23-810e-6225e8b2fd82",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -8995,7 +9025,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "2129e0dc-8204-4e6f-9301-82437be3535b",
+      "key": "5e15a978-1985-46dc-820c-c09f284c0ddd",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -9012,7 +9042,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "54374172-5876-4729-b4b1-f9a5a208aa2b",
+      "key": "48e6a66f-d3bd-43cd-92c0-65fa214d0c93",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -9029,7 +9059,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "7602a8f2-b8c8-4c8b-b672-fa9a8a68f181",
+      "key": "7cbf50c6-973c-418a-85a2-f7af792e6c34",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -9047,7 +9077,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "ba0300d0-27c7-4c7d-b342-0cefbaef401a",
+      "key": "e9f04d4e-4510-436e-b8b2-9f1a2a139ab6",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 5,
@@ -9057,7 +9087,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "54c1ef0f-868e-471d-960c-e71c70d77ccb",
+      "key": "daf9c1d4-af69-4caf-a56d-799708d5fe68",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -9075,7 +9105,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "12ff65a8-d49c-466b-8b9d-dc975fa96468",
+      "key": "2f2bf323-d95b-42b1-8e11-9736e1172fc4",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -9092,7 +9122,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "899206ef-6d89-4005-91bf-5651c4d18b65",
+      "key": "1c3f360c-4d29-41f9-95ab-ef63f493ee65",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -9110,7 +9140,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "80cb387d-a40e-4d39-9731-af676432274f",
+      "key": "a92dcb36-b607-433f-9716-145e76a2516e",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -9127,7 +9157,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "a698e7fe-3602-4522-8c06-c36456552003",
+      "key": "06bd49b1-fe87-4567-ab0c-29982d06314a",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -9145,7 +9175,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "f621ac95-c559-4eaf-8f44-b808349de1ac",
+      "key": "f4616b95-18f5-4c1c-a7b3-815515f68f94",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -9156,7 +9186,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "7b9f200d-4e23-4c39-b31e-94b1a9b614eb",
+      "key": "512f4c8a-ee22-465d-8511-af9a751914db",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -9173,14 +9203,14 @@
     },
     {
       "commandType": "prepareToAspirate",
-      "key": "098809ad-034d-4a5f-b5bb-e86c3812f770",
+      "key": "91487dd7-c526-4eba-acab-f5f5f7a51dbd",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }
     },
     {
       "commandType": "moveToWell",
-      "key": "0d15e84c-d0d9-4d80-80dd-302429512e7a",
+      "key": "5a5311d5-bf01-4367-b00f-e3aac1d5932f",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -9197,7 +9227,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "851cbcfe-9dcb-409b-a401-495691811661",
+      "key": "9cbbf5f0-7bd7-462d-822b-41039dc4a9f5",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -9215,7 +9245,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "477b204a-bb91-4c5a-bd3e-97c8ebaf9263",
+      "key": "babfcd9c-4905-4ade-a2ba-154c53c00d00",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 5,
@@ -9225,7 +9255,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "505db950-ff84-4f13-aecc-540bf416d254",
+      "key": "7da2376b-b4f9-480e-9257-3d0f437907ec",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -9243,7 +9273,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "410bbbd3-fd19-4e74-b9c5-dbe76ea8c9f9",
+      "key": "940367e6-494d-4c7c-b26f-4bfa29d800d6",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -9260,7 +9290,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "a29e7d78-b6d7-45b9-bb02-fabb39ecab52",
+      "key": "f3a7b594-cf65-4e93-a4a8-049fbe595c06",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -9277,7 +9307,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "3a69638e-bb12-4f0a-a879-c06398fc3646",
+      "key": "170a89e4-95bf-42cf-b49a-e2361ff3dff9",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -9295,7 +9325,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "84e7680c-33d9-4eb0-9bfb-cde98b1a30db",
+      "key": "569696aa-2465-45d6-bfab-884099cb4bf1",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 5,
@@ -9305,7 +9335,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "893b0b0c-32b2-4b0a-81e4-2be33ee4c54e",
+      "key": "34fd9d1c-55e8-47ba-932d-e02bf99b5065",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -9323,7 +9353,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "335e959e-f732-410e-a845-521e43f377fa",
+      "key": "c615ce95-e3d3-4472-af89-ee0863c25907",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -9340,7 +9370,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "7cf60215-d267-4bb2-893a-4a932f03aa93",
+      "key": "f81214f4-247a-481b-a291-4221eab845d4",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -9357,7 +9387,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "51f14591-9adf-4f16-9250-f4e56460a5c5",
+      "key": "8b22bdf0-c4a5-4c9f-891d-775c63c251af",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -9375,7 +9405,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "88e78c1a-06bf-45f9-9728-9e316e175e79",
+      "key": "8a162d77-1a09-4dfc-88a8-9e03d3e714e0",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 5,
@@ -9385,7 +9415,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "9f25f710-3b6a-446e-956e-92c06fbe81a1",
+      "key": "a77eae75-528c-49f2-9009-e3cc77c63371",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -9403,7 +9433,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "3dd870e6-1121-49dc-baff-db26f61ae034",
+      "key": "5f4d2a82-c31d-45a5-8290-67c946c46202",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -9420,7 +9450,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "982811d7-3cf3-4247-aa84-01e80ebda1db",
+      "key": "3045f08b-fa2a-44a0-8b5f-0499ae1b6e85",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -9437,7 +9467,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "1cd6ad03-9169-45ab-821e-5efe1f95cacc",
+      "key": "007dc99d-1b37-49c6-915b-16d24f359068",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -9455,7 +9485,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "bebdde3b-6e68-4d83-a0fb-91a7b5ccdbf8",
+      "key": "aee7cb50-eb46-4c11-99ce-488de2b9f14c",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 5,
@@ -9465,7 +9495,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "60fefb0f-50f8-48b6-99f1-0a02b03ac26f",
+      "key": "5c9673ae-ea98-4645-88e4-839123af6472",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -9483,7 +9513,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "0b69b2a1-a83d-41b7-971e-4db1ca576f8b",
+      "key": "94e9cbbf-9a03-450f-84b7-9a1db51f1d88",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -9500,7 +9530,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "a6687bf8-9fab-436d-afd5-837870d1ea03",
+      "key": "102582d2-35fa-4255-932d-1e7075826540",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -9517,7 +9547,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "c69703d2-bc1a-4eba-9677-315878745040",
+      "key": "f52bbe9b-96a5-428b-a9e0-3a6804667101",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -9535,7 +9565,7 @@
     },
     {
       "commandType": "aspirateInPlace",
-      "key": "4facb045-3cc2-4a5b-886b-65606d358710",
+      "key": "cc507097-f57c-48db-8ec0-cda286e99343",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 5,
@@ -9545,7 +9575,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "351bf875-1119-4224-8cdf-6d58c2d9d1b1",
+      "key": "f8981d25-6d24-4c31-ad68-d67c116112eb",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -9563,7 +9593,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "a01c4e3a-93bf-41e7-a3bc-3cf9a40bc35b",
+      "key": "60a1b2ff-84d7-490a-9b7f-9fd98bb6e813",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -9580,7 +9610,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "5af9f326-496a-4f52-b0bc-066ac49cf97c",
+      "key": "187af8b0-7794-4dd4-b735-6043fbf9f72b",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -9598,7 +9628,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "ce20bcc1-33c9-4bb8-b0a0-d29e67e9be05",
+      "key": "606fe0c8-44ab-43e8-9609-57866b75bca6",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -9615,7 +9645,7 @@
     },
     {
       "commandType": "moveToWell",
-      "key": "9d7a5e33-e557-4101-bef0-ef1b747c0dc1",
+      "key": "aaa05f5f-c8d7-408b-889b-2407e020647f",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
@@ -9633,7 +9663,7 @@
     },
     {
       "commandType": "dispenseInPlace",
-      "key": "00df96f6-cc3b-457d-ad54-aeef846ea107",
+      "key": "45b76988-88f0-4e63-859c-b8d714d3f4a2",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 25,
@@ -9644,7 +9674,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "aeb4fc3f-9ac5-4a4f-9378-aea668a5c899",
+      "key": "e17704b5-d6d6-4241-a687-ab6a0710c3f6",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "addressableAreaName": "movableTrashA3",
@@ -9658,7 +9688,7 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "86ec89cb-015f-46f6-8d71-b7ffadf765d5",
+      "key": "859a02b2-d720-4674-9bc6-bc50ac2ef74c",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe"
       }

--- a/protocol-designer/src/components/organisms/StepSummary/index.tsx
+++ b/protocol-designer/src/components/organisms/StepSummary/index.tsx
@@ -41,7 +41,7 @@ interface StepSummaryProps {
 export function StepSummary(props: StepSummaryProps): JSX.Element | null {
   const { currentStep, stepDetails } = props
   const { t } = useTranslation(['protocol_steps', 'application'])
-  const unknownModule = t('unkonwn_module')
+  const unknownModule = t('unknown_module')
   const labwareNicknamesById = useSelector(getLabwareNicknamesById)
   const additionalEquipmentEntities = useSelector(
     getAdditionalEquipmentEntities

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/PauseTools/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/PauseTools/index.tsx
@@ -168,6 +168,7 @@ export function PauseTools(props: StepFormProps): JSX.Element {
                     <DropdownStepFormField
                       {...propsForFields.moduleId}
                       tooltipContent={null}
+                      padding="0"
                       title={i18n.format(
                         t(
                           'form:step_edit_form.field.moduleActionLabware.label'

--- a/step-generation/src/__tests__/waitForTemperature.test.ts
+++ b/step-generation/src/__tests__/waitForTemperature.test.ts
@@ -187,7 +187,7 @@ describe('waitForTemperature', () => {
           slot: 'A1',
           moduleState: {
             type: HEATERSHAKER_MODULE_TYPE,
-            targetTemp: null,
+            targetTemp: 40,
             latchOpen: false,
             targetSpeed: null,
           },

--- a/step-generation/src/commandCreators/atomic/waitForTemperature.ts
+++ b/step-generation/src/commandCreators/atomic/waitForTemperature.ts
@@ -58,7 +58,9 @@ export const waitForTemperature: CommandCreator<TemperatureParams> = (
 
   if (
     unreachableTemp ||
-    ('status' in moduleState && moduleState.status === TEMPERATURE_DEACTIVATED)
+    ('status' in moduleState &&
+      moduleState.status === TEMPERATURE_DEACTIVATED) ||
+    ('targetTemp' in moduleState && moduleState.targetTemp == null)
   ) {
     return {
       errors: [errorCreators.missingTemperatureStep()],


### PR DESCRIPTION
…r-shaker

closes RQA-4297

# Overview

Fix a bug where there was no timeline error showing up for the attached protocol which caused an analysis failure since the error was not caught.

## Test Plan and Hands on Testing

upload the protocol to PD and see that there is now a timeline error

[doItAllV7.json](https://github.com/user-attachments/files/20801137/doItAllV7.json)

## Changelog

- extend timeline error logic to account for an unset heater-shaker temperature status

## Risk assessment

low
