### PR TITLE
refactor(api,hardware-testing): Make the ExecutionManager optional in the AbstractModule class to build stand-alone modules.

### DIFF
--- a/api/src/opentrons/hardware_control/modules/absorbance_reader.py
+++ b/api/src/opentrons/hardware_control/modules/absorbance_reader.py
@@ -103,8 +103,8 @@ class AbsorbanceReader(mod_abc.AbstractModule):
         cls,
         port: str,
         usb_port: USBPort,
-        execution_manager: ExecutionManager,
         hw_control_loop: asyncio.AbstractEventLoop,
+        execution_manager: Optional[ExecutionManager] = None,
         poll_interval_seconds: Optional[float] = None,
         simulating: bool = False,
         sim_model: Optional[str] = None,
@@ -117,8 +117,8 @@ class AbsorbanceReader(mod_abc.AbstractModule):
         Args:
             port: The port to connect to
             usb_port: USB Port
-            execution_manager: Execution manager.
             hw_control_loop: The event loop running in the hardware control thread.
+            execution_manager: Execution manager.
             poll_interval_seconds: Poll interval override.
             simulating: whether to build a simulating driver
             sim_model: The model name used by simulator
@@ -169,8 +169,8 @@ class AbsorbanceReader(mod_abc.AbstractModule):
         reader: AbsorbanceReaderReader,
         poller: Poller,
         device_info: Mapping[str, str],
-        execution_manager: ExecutionManager,
         hw_control_loop: asyncio.AbstractEventLoop,
+        execution_manager: Optional[ExecutionManager] = None,
         disconnected_callback: ModuleDisconnectedCallback = None,
     ) -> None:
         """
@@ -179,12 +179,12 @@ class AbsorbanceReader(mod_abc.AbstractModule):
         Args:
             port: The port the absorbance is connected to.
             usb_port: The USB port.
-            execution_manager: The hardware execution manager.
             driver: The Absorbance driver.
             reader: An interface to read data from the Absorbance Reader.
             poller: A poll controller for reads.
             device_info: The Absorbance device info.
             hw_control_loop: The event loop running in the hardware control thread.
+            execution_manager: The hardware execution manager.
         """
         self._driver = driver
         super().__init__(
@@ -276,10 +276,6 @@ class AbsorbanceReader(mod_abc.AbstractModule):
     async def deactivate(self, must_be_running: bool = True) -> None:
         """Deactivate the module."""
         pass
-
-    async def wait_for_is_running(self) -> None:
-        if not self.is_simulated:
-            await self._execution_manager.wait_for_is_running()
 
     async def prep_for_update(self) -> str:
         """Prepare for an update.

--- a/api/src/opentrons/hardware_control/modules/flex_stacker.py
+++ b/api/src/opentrons/hardware_control/modules/flex_stacker.py
@@ -88,69 +88,12 @@ class FlexStacker(mod_abc.AbstractModule):
     MODULE_TYPE = ModuleType.FLEX_STACKER
 
     @classmethod
-    async def build_standalone(
-        cls,
-        port: str,
-        hw_control_loop: asyncio.AbstractEventLoop,
-        simulating: bool = False,
-        sim_serial_number: Optional[str] = None,
-        poll_interval_seconds: Optional[float] = None,
-    ) -> "FlexStacker":
-        """
-        Build a FlexStacker in standalone mode, without an execution manager.
-        This is useful for testing or when the module is used outside a protocol.
-
-        Args:
-            port: The port to connect to
-            usb_port: USB Port
-            simulating: whether to build a simulating driver
-            sim_serial_number: Serial number for the simulated driver
-
-        Returns:
-            FlexStacker instance
-        """
-        driver: AbstractFlexStackerDriver
-        if not simulating:
-            driver = await FlexStackerDriver.create(port=port, loop=hw_control_loop)
-            poll_interval_seconds = poll_interval_seconds or POLL_PERIOD
-        else:
-            driver = SimulatingDriver(serial_number=sim_serial_number)
-            poll_interval_seconds = poll_interval_seconds or SIMULATING_POLL_PERIOD
-
-        reader = FlexStackerReader(driver=driver)
-        poller = Poller(reader=reader, interval=poll_interval_seconds)
-        module = cls(
-            port=port,
-            driver=driver,
-            reader=reader,
-            poller=poller,
-            device_info=(await driver.get_device_info()).to_dict(),
-            hw_control_loop=hw_control_loop,
-        )
-
-        # Set initialized callback
-        reader.set_initialized_callback(module._initialized_callback)
-
-        # Enable stallguard
-        for axis, config in STALLGUARD_CONFIG.items():
-            await driver.set_stallguard_threshold(
-                axis, config.enabled, config.threshold
-            )
-
-        try:
-            await poller.start()
-        except Exception:
-            log.exception(f"First read of Flex-Stacker on port {port} failed")
-
-        return module
-
-    @classmethod
     async def build(
         cls,
         port: str,
         usb_port: USBPort,
-        execution_manager: ExecutionManager,
         hw_control_loop: asyncio.AbstractEventLoop,
+        execution_manager: Optional[ExecutionManager] = None,
         poll_interval_seconds: Optional[float] = None,
         simulating: bool = False,
         sim_model: Optional[str] = None,
@@ -215,23 +158,22 @@ class FlexStacker(mod_abc.AbstractModule):
     def __init__(
         self,
         port: str,
+        usb_port: USBPort,
         driver: AbstractFlexStackerDriver,
         reader: FlexStackerReader,
         poller: Poller,
         device_info: Mapping[str, str],
         hw_control_loop: asyncio.AbstractEventLoop,
-        usb_port: Optional[USBPort] = None,
         execution_manager: Optional[ExecutionManager] = None,
         disconnected_callback: ModuleDisconnectedCallback = None,
     ):
-        if execution_manager is not None and usb_port is not None:
-            super().__init__(
-                port=port,
-                usb_port=usb_port,
-                hw_control_loop=hw_control_loop,
-                execution_manager=execution_manager,
-                disconnected_callback=disconnected_callback,
-            )
+        super().__init__(
+            port=port,
+            usb_port=usb_port,
+            hw_control_loop=hw_control_loop,
+            execution_manager=execution_manager,
+            disconnected_callback=disconnected_callback,
+        )
         self._device_info = device_info
         self._driver = driver
         self._reader = reader

--- a/api/src/opentrons/hardware_control/modules/heater_shaker.py
+++ b/api/src/opentrons/hardware_control/modules/heater_shaker.py
@@ -46,8 +46,8 @@ class HeaterShaker(mod_abc.AbstractModule):
         cls,
         port: str,
         usb_port: USBPort,
-        execution_manager: ExecutionManager,
         hw_control_loop: asyncio.AbstractEventLoop,
+        execution_manager: Optional[ExecutionManager] = None,
         poll_interval_seconds: Optional[float] = None,
         simulating: bool = False,
         sim_model: Optional[str] = None,
@@ -60,8 +60,8 @@ class HeaterShaker(mod_abc.AbstractModule):
         Args:
             port: The port to connect to
             usb_port: USB Port
-            execution_manager: Execution manager.
             hw_control_loop: The event loop running in the hardware control thread.
+            execution_manager: Execution manager.
             poll_interval_seconds: Poll interval override.
             simulating: whether to build a simulating driver
             loop: Loop
@@ -104,12 +104,12 @@ class HeaterShaker(mod_abc.AbstractModule):
         self,
         port: str,
         usb_port: USBPort,
-        execution_manager: ExecutionManager,
         driver: AbstractHeaterShakerDriver,
         reader: HeaterShakerReader,
         poller: Poller,
         device_info: Mapping[str, str],
         hw_control_loop: asyncio.AbstractEventLoop,
+        execution_manager: Optional[ExecutionManager] = None,
         disconnected_callback: ModuleDisconnectedCallback = None,
     ):
         super().__init__(

--- a/api/src/opentrons/hardware_control/modules/magdeck.py
+++ b/api/src/opentrons/hardware_control/modules/magdeck.py
@@ -48,8 +48,8 @@ class MagDeck(mod_abc.AbstractModule):
         cls,
         port: str,
         usb_port: USBPort,
-        execution_manager: ExecutionManager,
         hw_control_loop: asyncio.AbstractEventLoop,
+        execution_manager: Optional[ExecutionManager] = None,
         poll_interval_seconds: Optional[float] = None,
         simulating: bool = False,
         sim_model: Optional[str] = None,
@@ -80,10 +80,10 @@ class MagDeck(mod_abc.AbstractModule):
         self,
         port: str,
         usb_port: USBPort,
-        execution_manager: ExecutionManager,
         hw_control_loop: asyncio.AbstractEventLoop,
         driver: AbstractMagDeckDriver,
         device_info: Dict[str, str],
+        execution_manager: Optional[ExecutionManager] = None,
         disconnected_callback: types.ModuleDisconnectedCallback = None,
     ) -> None:
         """Constructor"""

--- a/api/src/opentrons/hardware_control/modules/mod_abc.py
+++ b/api/src/opentrons/hardware_control/modules/mod_abc.py
@@ -46,8 +46,8 @@ class AbstractModule(abc.ABC):
         cls,
         port: str,
         usb_port: USBPort,
-        execution_manager: ExecutionManager,
         hw_control_loop: asyncio.AbstractEventLoop,
+        execution_manager: Optional[ExecutionManager] = None,
         poll_interval_seconds: Optional[float] = None,
         simulating: bool = False,
         sim_model: Optional[str] = None,
@@ -64,8 +64,8 @@ class AbstractModule(abc.ABC):
         self,
         port: str,
         usb_port: USBPort,
-        execution_manager: ExecutionManager,
         hw_control_loop: asyncio.AbstractEventLoop,
+        execution_manager: Optional[ExecutionManager] = None,
         disconnected_callback: ModuleDisconnectedCallback = None,
     ) -> None:
         self._port = port
@@ -127,11 +127,12 @@ class AbstractModule(abc.ABC):
         return False
 
     async def wait_for_is_running(self) -> None:
-        if not self.is_simulated:
+        if not self.is_simulated and self._execution_manager is not None:
             await self._execution_manager.wait_for_is_running()
 
     def make_cancellable(self, task: "asyncio.Task[TaskPayload]") -> None:
-        self._execution_manager.register_cancellable_task(task)
+        if self._execution_manager is not None:
+            self._execution_manager.register_cancellable_task(task)
 
     @abc.abstractmethod
     async def deactivate(self, must_be_running: bool = True) -> None:

--- a/api/src/opentrons/hardware_control/modules/tempdeck.py
+++ b/api/src/opentrons/hardware_control/modules/tempdeck.py
@@ -37,8 +37,8 @@ class TempDeck(mod_abc.AbstractModule):
         cls,
         port: str,
         usb_port: USBPort,
-        execution_manager: ExecutionManager,
         hw_control_loop: asyncio.AbstractEventLoop,
+        execution_manager: Optional[ExecutionManager] = None,
         poll_interval_seconds: Optional[float] = None,
         simulating: bool = False,
         sim_model: Optional[str] = None,
@@ -51,8 +51,8 @@ class TempDeck(mod_abc.AbstractModule):
         Args:
             port: The port to connect to
             usb_port: USB Port
-            execution_manager: Execution manager.
             hw_control_loop: The event loop running in the hardware control thread.
+            execution_manager: Execution manager.
             poll_interval_seconds: Poll interval override.
             simulating: whether to build a simulating driver
             sim_model: The model name used by simulator
@@ -96,12 +96,12 @@ class TempDeck(mod_abc.AbstractModule):
         self,
         port: str,
         usb_port: USBPort,
-        execution_manager: ExecutionManager,
         driver: AbstractTempDeckDriver,
         reader: TempDeckReader,
         poller: Poller,
         device_info: Dict[str, str],
         hw_control_loop: asyncio.AbstractEventLoop,
+        execution_manager: Optional[ExecutionManager] = None,
         disconnected_callback: ModuleDisconnectedCallback = None,
     ) -> None:
         """Constructor"""

--- a/api/src/opentrons/hardware_control/modules/thermocycler.py
+++ b/api/src/opentrons/hardware_control/modules/thermocycler.py
@@ -61,8 +61,8 @@ class Thermocycler(mod_abc.AbstractModule):
         cls,
         port: str,
         usb_port: USBPort,
-        execution_manager: ExecutionManager,
         hw_control_loop: asyncio.AbstractEventLoop,
+        execution_manager: Optional[ExecutionManager] = None,
         poll_interval_seconds: Optional[float] = None,
         simulating: bool = False,
         sim_model: Optional[str] = None,
@@ -75,8 +75,8 @@ class Thermocycler(mod_abc.AbstractModule):
         Args:
             port: The port to connect to
             usb_port: USB Port
-            execution_manager: Execution manager.
             hw_control_loop: The event loop running in the hardware control thread.
+            execution_manager: Execution manager.
             poll_interval_seconds: Poll interval override.
             simulating: whether to build a simulating driver
             loop: Loop
@@ -121,12 +121,12 @@ class Thermocycler(mod_abc.AbstractModule):
         self,
         port: str,
         usb_port: USBPort,
-        execution_manager: ExecutionManager,
         driver: AbstractThermocyclerDriver,
         reader: ThermocyclerReader,
         poller: Poller,
         device_info: Dict[str, str],
         hw_control_loop: asyncio.AbstractEventLoop,
+        execution_manager: Optional[ExecutionManager] = None,
         disconnected_callback: ModuleDisconnectedCallback = None,
     ) -> None:
         """
@@ -135,12 +135,12 @@ class Thermocycler(mod_abc.AbstractModule):
         Args:
             port: The port the thermocycler is connected to.
             usb_port: The USB port.
-            execution_manager: The hardware execution manager.
             driver: The thermocycler driver.
             reader: An interface to read data from the Thermocycler.
             poller: A poll controller for reads.
             device_info: The thermocycler device info.
             hw_control_loop: The event loop running in the hardware control thread.
+            execution_manager: The hardware execution manager.
             disconnected_callback: Callback to inform the module controller that the device was disconnected
         """
         self._driver = driver

--- a/api/src/opentrons/hardware_control/modules/utils.py
+++ b/api/src/opentrons/hardware_control/modules/utils.py
@@ -46,7 +46,7 @@ async def build(
     simulating: bool,
     usb_port: USBPort,
     hw_control_loop: asyncio.AbstractEventLoop,
-    execution_manager: ExecutionManager,
+    execution_manager: Optional[ExecutionManager] = None,
     sim_model: Optional[str] = None,
     sim_serial_number: Optional[str] = None,
     disconnected_callback: ModuleDisconnectedCallback = None,

--- a/hardware-testing/hardware_testing/modules/flex_stacker_qc/__main__.py
+++ b/hardware-testing/hardware_testing/modules/flex_stacker_qc/__main__.py
@@ -16,6 +16,7 @@ from hardware_testing.data.csv_report import CSVReport
 
 from .config import TestSection, TestConfig, build_report, TESTS
 from .utils import find_stacker_port, get_estop
+from opentrons.drivers.rpi_drivers.types import USBPort
 from opentrons.hardware_control.modules.flex_stacker import FlexStacker
 from opentrons.hardware_control.modules.types import PlatformState
 
@@ -27,8 +28,10 @@ async def build_stacker_report(
     test_name = Path(__file__).parent.name.replace("_", "-")
     ui.print_title(test_name.upper())
 
-    stacker = await FlexStacker.build_standalone(
-        port="" if is_simulating else find_stacker_port(),
+    port = "" if is_simulating else find_stacker_port()
+    stacker = await FlexStacker.build(
+        port=port,
+        usb_port=USBPort(port, 0),
         hw_control_loop=asyncio.get_running_loop(),
         simulating=is_simulating,
         sim_serial_number="FLEX1234" if is_simulating else None,


### PR DESCRIPTION
# Overview

A few small changes to make building modules stand-alone (Outside of the OT3Controller) a bit easier for creating test scripts.

## Test Plan and Hands on Testing

## Changelog
- Make the `ExecutionManager` optional in the AbstractModule class to build stand-alone modules.
- Remove `build_standalone` and use `build` with optional `execution_manager` instead.
- Remove `wait_for_is_running` from the `AbsorbanceReader` module, since the base class already has this. 

## Review requests

## Risk assessment
Low, changes make hardware testing easier.
