### PR TITLE
fix(api): Always close the latch in `home_all` method of FlexStacker module.

### DIFF
--- a/api/src/opentrons/hardware_control/modules/flex_stacker.py
+++ b/api/src/opentrons/hardware_control/modules/flex_stacker.py
@@ -521,7 +521,7 @@ class FlexStacker(mod_abc.AbstractModule):
                 if self.latch_state == LatchState.OPENED:
                     # self.latch_state is OPENED, so we need to home Z in the EXTEND direction
                     await self.home_axis(StackerAxis.Z, Direction.EXTEND)
-                    await self.close_latch()
+            await self.close_latch()
 
         if (
             # if the platform is on the z or if x has not been homed


### PR DESCRIPTION
# Overview

Sometimes we would not close the latch, even though error recovery would send the request because of internal states of the FlexStacker module. So we should always make sure we move the z axis if needed to make sure we close the latch if the `ignore_latch` is false.

## Test Plan and Hands on Testing

- [x] Make sure the latch is closed when `ignore_latch` is false

## Changelog

- Always close the latch if the `ignore_latch` is false

## Review requests
## Risk assessment
