### PR TITLE
fix(protocol-designer): update logic for blowout UI max flow rate

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/FlowRateField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/FlowRateField.tsx
@@ -164,6 +164,7 @@ export function FlowRateField(props: FlowRateFieldProps): JSX.Element {
           tipLiquidSpecs: matchingTipLiquidSpecs,
           flowRateType,
           correctionVolume: correctionVolume ?? 0,
+          shaftULperMM: pipette.spec.shaftULperMM,
         })
       : null
 

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/utils.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/utils.ts
@@ -190,20 +190,9 @@ export function getDisabledPathMap(
 const _getPipetteAccuracyUlPerMm = (args: {
   targetVolume: number
   tipLiquidSpecs: SupportedTip
-  flowRateType: FlowRateType
-  shaftULperMM: number
-  maxPlungerSpeed: number
+  flowRateType: Exclude<FlowRateType, 'blowout'>
 }): number => {
-  const {
-    targetVolume,
-    tipLiquidSpecs,
-    flowRateType,
-    shaftULperMM,
-    maxPlungerSpeed,
-  } = args
-  if (flowRateType === 'blowout') {
-    return shaftULperMM * maxPlungerSpeed
-  }
+  const { targetVolume, tipLiquidSpecs, flowRateType } = args
 
   const flowRateFunction = tipLiquidSpecs[flowRateType].default['1']
   let pipetteAccuracyUlPerMm = null
@@ -236,14 +225,16 @@ export const getMaxUiFlowRate = (args: {
     correctionVolume,
     shaftULperMM,
   } = args
+
   const maxPlungerSpeed =
     CHANNELS_MAPPED_TO_MAX_SPEED[robotType][channels].plunger
+  if (flowRateType === 'blowout') {
+    return round(shaftULperMM * maxPlungerSpeed)
+  }
   const pipetteAccuracyUlPerMm = _getPipetteAccuracyUlPerMm({
     targetVolume,
     tipLiquidSpecs,
     flowRateType,
-    shaftULperMM,
-    maxPlungerSpeed,
   })
   const correctionMultiplier = 1.0 + correctionVolume / targetVolume
   const travelMm = targetVolume / pipetteAccuracyUlPerMm

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/utils.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/utils.ts
@@ -187,14 +187,25 @@ export function getDisabledPathMap(
   return disabledPathMap
 }
 
-const _getPipetteAccuracyUlPerMm = (
-  targetVolume: number,
-  tipLiquidSpecs: SupportedTip,
+const _getPipetteAccuracyUlPerMm = (args: {
+  targetVolume: number
+  tipLiquidSpecs: SupportedTip
   flowRateType: FlowRateType
-): number => {
-  const transformedFlowRateType =
-    flowRateType === 'blowout' ? 'dispense' : flowRateType
-  const flowRateFunction = tipLiquidSpecs[transformedFlowRateType].default['1']
+  shaftULperMM: number
+  maxPlungerSpeed: number
+}): number => {
+  const {
+    targetVolume,
+    tipLiquidSpecs,
+    flowRateType,
+    shaftULperMM,
+    maxPlungerSpeed,
+  } = args
+  if (flowRateType === 'blowout') {
+    return shaftULperMM * maxPlungerSpeed
+  }
+
+  const flowRateFunction = tipLiquidSpecs[flowRateType].default['1']
   let pipetteAccuracyUlPerMm = null
   for (let i = 0; i < flowRateFunction.length; i++) {
     const [x, y, z] = flowRateFunction[i]
@@ -214,6 +225,7 @@ export const getMaxUiFlowRate = (args: {
   tipLiquidSpecs: SupportedTip
   flowRateType: FlowRateType
   correctionVolume: number
+  shaftULperMM: number
 }): number => {
   const {
     targetVolume,
@@ -222,14 +234,17 @@ export const getMaxUiFlowRate = (args: {
     tipLiquidSpecs,
     flowRateType,
     correctionVolume,
+    shaftULperMM,
   } = args
-  const pipetteAccuracyUlPerMm = _getPipetteAccuracyUlPerMm(
-    targetVolume,
-    tipLiquidSpecs,
-    flowRateType
-  )
   const maxPlungerSpeed =
     CHANNELS_MAPPED_TO_MAX_SPEED[robotType][channels].plunger
+  const pipetteAccuracyUlPerMm = _getPipetteAccuracyUlPerMm({
+    targetVolume,
+    tipLiquidSpecs,
+    flowRateType,
+    shaftULperMM,
+    maxPlungerSpeed,
+  })
   const correctionMultiplier = 1.0 + correctionVolume / targetVolume
   const travelMm = targetVolume / pipetteAccuracyUlPerMm
   const travelMmCorrected = travelMm * correctionMultiplier

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/__tests__/utils.test.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/__tests__/utils.test.ts
@@ -149,6 +149,7 @@ describe('getMaxUiFlowRate', () => {
       tipLiquidSpecs: mockTipLiquidSpecs,
       flowRateType: 'aspirate',
       correctionVolume: 0,
+      shaftULperMM: 0.785,
     } as any
     const expectedAccuracy = 0.05 * 50 + 1
     const expectedTravelMm = 50 / expectedAccuracy
@@ -183,8 +184,9 @@ describe('getMaxUiFlowRate', () => {
       tipLiquidSpecs: mockTipLiquidSpecs,
       flowRateType: 'blowout',
       correctionVolume: 0,
+      shaftULperMM: 0.785,
     } as any
-    const expectedAccuracy = 0.06 * 80 + 1.2
+    const expectedAccuracy = 0.785 * FLEX_LOW_THROUGHPUT_PLUNGER_MAX_SPEED
     const expectedTravelMm = 80 / expectedAccuracy
     const expectedMaxFlowRate = round(
       80 / (expectedTravelMm / FLEX_LOW_THROUGHPUT_PLUNGER_MAX_SPEED)
@@ -200,6 +202,7 @@ describe('getMaxUiFlowRate', () => {
       tipLiquidSpecs: mockTipLiquidSpecs,
       flowRateType: 'aspirate',
       correctionVolume: 0,
+      shaftULperMM: 0.785,
     } as any
     const expectedAccuracy = 0.1 * 5 + 0.5
     const expectedTravelMm = 5 / expectedAccuracy
@@ -217,6 +220,7 @@ describe('getMaxUiFlowRate', () => {
       tipLiquidSpecs: mockTipLiquidSpecs,
       flowRateType: 'dispense',
       correctionVolume: 10,
+      shaftULperMM: 0.785,
     } as any
     const expectedAccuracy = 0.06 * 50 + 1.2
     const expectedTravelMm = 50 / expectedAccuracy
@@ -236,6 +240,7 @@ describe('getMaxUiFlowRate', () => {
       tipLiquidSpecs: mockTipLiquidSpecs,
       flowRateType: 'aspirate',
       correctionVolume: 0,
+      shaftULperMM: 0.785,
     } as any
     const expectedAccuracy = 0.05 * 150 + 1 // Using the last entry [100, 0.05, 1]
     const expectedTravelMm = 150 / expectedAccuracy

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/__tests__/utils.test.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/__tests__/utils.test.ts
@@ -186,10 +186,8 @@ describe('getMaxUiFlowRate', () => {
       correctionVolume: 0,
       shaftULperMM: 0.785,
     } as any
-    const expectedAccuracy = 0.785 * FLEX_LOW_THROUGHPUT_PLUNGER_MAX_SPEED
-    const expectedTravelMm = 80 / expectedAccuracy
     const expectedMaxFlowRate = round(
-      80 / (expectedTravelMm / FLEX_LOW_THROUGHPUT_PLUNGER_MAX_SPEED)
+      0.785 * FLEX_LOW_THROUGHPUT_PLUNGER_MAX_SPEED
     )
     expect(getMaxUiFlowRate(args)).toEqual(expectedMaxFlowRate)
   })


### PR DESCRIPTION
# Overview

For calculating blowout pipette max flow rate (µl/s), the hardware controller specifies the following rather than using the pipette definition's dispense curve:
```
maxFlowRate = shaftULperMM * maxPlungerSpeed
```

## Test Plan and Hands on Testing

not much to test. I confirmed the correct behavior with Andy and smoke tested a few easy cases

## Changelog

<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment

low. affects only UI recommended flow rate