### PR TITLE
fix(hardware-testing): fix hanging gravi analysis

### DIFF
--- a/hardware-testing/.flake8
+++ b/hardware-testing/.flake8
@@ -1,16 +1,13 @@
 [flake8]
 
-# set line-length for future black support
-# https://github.com/psf/black/blob/master/docs/compatible_configs.md
-max-line-length = 100
-
 # max cyclomatic complexity
 # NOTE: (andy s) increasing this from 9 to 15 b/c test scripts often handle all logic in main
 max-complexity = 15
 
 extend-ignore =
-    # ignore E203 because black might reformat it
+    # black handles formatting
     E203,
+    E501,
     # do not require type annotations for self nor cls
     ANN101,
     ANN102

--- a/hardware-testing/hardware_testing/gravimetric/measurement/record.py
+++ b/hardware-testing/hardware_testing/gravimetric/measurement/record.py
@@ -1,4 +1,5 @@
 """Record weight measurements."""
+
 from contextlib import contextmanager
 from dataclasses import dataclass
 from statistics import stdev

--- a/hardware-testing/hardware_testing/gravimetric/protocol_replacement/96ch1000.csv
+++ b/hardware-testing/hardware_testing/gravimetric/protocol_replacement/96ch1000.csv
@@ -8,7 +8,7 @@ return_tip,TRUE,,,,,,,,
 touch_tip,FALSE,,,,,,,,
 liquid,water,Deionized water,#0000ff,100000,,,,,
 tipracks_20ul,,,,,,,,,
-tipracks_50ul,D2
+tipracks_50ul,D2,D3,C2,C3,B1,B2
 tipracks_200ul,,,,,,,,,
 tipracks_1000ul,,,,,,,,,
 labware_on_scale,nest_1_reservoir_195ml,A1,,,,,,,

--- a/hardware-testing/hardware_testing/gravimetric/protocol_replacement/gravimetric.py
+++ b/hardware-testing/hardware_testing/gravimetric/protocol_replacement/gravimetric.py
@@ -650,6 +650,14 @@ def run_one_test(
 def run(ctx: ProtocolContext) -> None:
     """Run."""
     fixture_settings = FixtureSettings.build(ctx)
+    try:
+        _do_run(ctx, fixture_settings)
+    finally:
+        if fixture_settings.recorder.is_recording:
+            fixture_settings.recorder.stop()
+
+
+def _do_run(ctx: ProtocolContext, fixture_settings: FixtureSettings) -> None:
     first_tip = fixture_settings.tips[list(fixture_settings.tips)[0]].pop(0)
     print_info("Picking up first tip.")
     pick_up_tip_for_channel(fixture_settings, first_tip, 1)

--- a/hardware-testing/tests/hardware_testing/gravimetric/test_gravimetric_protocol.py
+++ b/hardware-testing/tests/hardware_testing/gravimetric/test_gravimetric_protocol.py
@@ -103,7 +103,7 @@ def test_gravimetric_test_protocol_passes_analysis(pipette: str) -> None:
     print(result.stdout_stderr)
     assert result.exit_code == 0
     assert result.json_output
-    assert result.json_output.get("errors", None) is None, "Analysis failed: " + str(
+    assert result.json_output["errors"] == [], "Analysis failed: " + str(
         result.json_output
     )
     assert result.json_output["config"]["apiVersion"] == [

--- a/hardware-testing/tests/hardware_testing/gravimetric/test_gravimetric_protocol.py
+++ b/hardware-testing/tests/hardware_testing/gravimetric/test_gravimetric_protocol.py
@@ -3,12 +3,13 @@
 import json
 import tempfile
 
+import subprocess
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 from pathlib import Path
 
-from click.testing import CliRunner
-from opentrons.cli.analyze import analyze
+import pytest
+
 from opentrons.protocols.api_support.definitions import MAX_SUPPORTED_VERSION
 
 
@@ -45,8 +46,14 @@ def _get_analysis_result(
     """
     with tempfile.TemporaryDirectory() as temp_dir:
         analysis_output_file = Path(temp_dir) / "analysis_output.json"
-        runner = CliRunner()
-        args = [output_type, str(analysis_output_file)]
+        args = [
+            "python",
+            "-m",
+            "opentrons.cli",
+            "analyze",
+            output_type,
+            str(analysis_output_file),
+        ]
 
         if rtp_values is not None:
             args.extend(["--rtp-values", rtp_values])
@@ -59,32 +66,45 @@ def _get_analysis_result(
         if check:
             args.append("--check")
 
-        result = runner.invoke(analyze, args)
+        process = subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         if analysis_output_file.exists():
             json_output = json.loads(analysis_output_file.read_bytes())
         else:
             json_output = None
         return _AnalysisCLIResult(
-            exit_code=result.exit_code,
+            exit_code=process.returncode,
             json_output=json_output,
-            stdout_stderr=result.output,
+            stdout_stderr=process.stdout,
         )
 
 
-# TODO (spp, 2025-06-10): update this test to verify that the gravimetric protocol
-#   analyzes successfully once the protocol and CSV file values are corrected.
-#   It's better to write a *single* test that verifies all aspects of its analysis result
-#   than writing a different one for each aspect since the gravimetric test is complex
-#   and analyzing it takes a long time.
-def test_gravimetric_test_protocol_uses_latest_api_version() -> None:
+@pytest.mark.parametrize(
+    "pipette",
+    [
+        pytest.param(
+            "96ch200", marks=pytest.mark.xfail(reason="200ul has no liquid class")
+        ),
+        pytest.param("96ch1000"),
+    ],
+)
+def test_gravimetric_test_protocol_passes_analysis(pipette: str) -> None:
     """Should check that gravimetric test protocol uses the latest Python API version."""
     result = _get_analysis_result(
         [GRAVIMETRIC_PROTOCOL_FILEPATH],
         "--json-output",
-        rtp_files=json.dumps({"qc_test_profile": str(CSV_FILEPATH.resolve())}),
+        rtp_files=json.dumps(
+            {
+                "qc_test_profile": str(
+                    (GRAVIMETRIC_PROTOCOL_PARENT_FILEPATH / f"{pipette}.csv").resolve()
+                )
+            }
+        ),
     )
+    print(result.stdout_stderr)
     assert result.exit_code == 0
-    assert result.json_output is not None
+    assert result.json_output["errors"] is None, f"Analysis failed: " + str(
+        result.json_output
+    )
     assert result.json_output["config"]["apiVersion"] == [
         MAX_SUPPORTED_VERSION.major,
         MAX_SUPPORTED_VERSION.minor,

--- a/hardware-testing/tests/hardware_testing/gravimetric/test_gravimetric_protocol.py
+++ b/hardware-testing/tests/hardware_testing/gravimetric/test_gravimetric_protocol.py
@@ -84,11 +84,14 @@ def _get_analysis_result(
         pytest.param(
             "96ch200", marks=pytest.mark.xfail(reason="200ul has no liquid class")
         ),
-        pytest.param("96ch1000"),
+        pytest.param(
+            "96ch1000",
+            marks=pytest.mark.xfail(reason="the 1000ul test csv is incorrect"),
+        ),
     ],
 )
 def test_gravimetric_test_protocol_passes_analysis(pipette: str) -> None:
-    """Should check that gravimetric test protocol uses the latest Python API version."""
+    """Should check that gravimetric test protocol uses the latest Python API version and simulates properly."""
     result = _get_analysis_result(
         [GRAVIMETRIC_PROTOCOL_FILEPATH],
         "--json-output",

--- a/hardware-testing/tests/hardware_testing/gravimetric/test_gravimetric_protocol.py
+++ b/hardware-testing/tests/hardware_testing/gravimetric/test_gravimetric_protocol.py
@@ -24,7 +24,7 @@ CSV_FILEPATH = GRAVIMETRIC_PROTOCOL_PARENT_FILEPATH / "96ch200.csv"
 class _AnalysisCLIResult:
     exit_code: int
     json_output: Optional[Dict[str, Any]]
-    stdout_stderr: str
+    stdout_stderr: bytes
 
 
 # Function copied from api/tests/opentrons/cli/test_cli.py
@@ -91,7 +91,7 @@ def _get_analysis_result(
     ],
 )
 def test_gravimetric_test_protocol_passes_analysis(pipette: str) -> None:
-    """Should check that gravimetric test protocol uses the latest Python API version and simulates properly."""
+    """Check that gravimetric test protocol uses the latest Python API version and simulates."""
     result = _get_analysis_result(
         [GRAVIMETRIC_PROTOCOL_FILEPATH],
         "--json-output",
@@ -105,7 +105,8 @@ def test_gravimetric_test_protocol_passes_analysis(pipette: str) -> None:
     )
     print(result.stdout_stderr)
     assert result.exit_code == 0
-    assert result.json_output["errors"] is None, f"Analysis failed: " + str(
+    assert result.json_output
+    assert result.json_output.get("errors", None) is None, "Analysis failed: " + str(
         result.json_output
     )
     assert result.json_output["config"]["apiVersion"] == [

--- a/hardware-testing/tests/hardware_testing/gravimetric/test_gravimetric_protocol.py
+++ b/hardware-testing/tests/hardware_testing/gravimetric/test_gravimetric_protocol.py
@@ -84,10 +84,7 @@ def _get_analysis_result(
         pytest.param(
             "96ch200", marks=pytest.mark.xfail(reason="200ul has no liquid class")
         ),
-        pytest.param(
-            "96ch1000",
-            marks=pytest.mark.xfail(reason="the 1000ul test csv is incorrect"),
-        ),
+        pytest.param("96ch1000"),
     ],
 )
 def test_gravimetric_test_protocol_passes_analysis(pipette: str) -> None:


### PR DESCRIPTION
You can't really use click.test's isolated environments because it needs to be able to import hardware testing. It also needs to clean up its recording thread on failure in addition to on success, and finally doing these thigns reveals some failures we'll also have to fix.
