### PR TITLE
fix(opentrons-ai-client): removed tabs to simplify and fix whitescreen

### DIFF
--- a/opentrons-ai-client/src/organisms/StepsSection/__tests__/StepsSection.test.tsx
+++ b/opentrons-ai-client/src/organisms/StepsSection/__tests__/StepsSection.test.tsx
@@ -9,7 +9,7 @@ import { StepsSection } from '../../StepsSection'
 const TestFormProviderComponent = () => {
   const methods = useForm({
     defaultValues: {
-      steps: [''],
+      steps: '',
     },
   })
 
@@ -19,11 +19,7 @@ const TestFormProviderComponent = () => {
     <FormProvider {...methods}>
       <StepsSection />
 
-      {Array.isArray(steps) ? (
-        steps.map((step, index) => <p key={index}>{step}</p>)
-      ) : (
-        <p>{steps}</p>
-      )}
+      <p>{steps}</p>
 
       <p>{`form is ${methods.formState.isValid ? 'valid' : 'invalid'}`}</p>
     </FormProvider>
@@ -45,75 +41,36 @@ describe('StepsSection', () => {
         'Give step-by-step instructions on how to handle liquids, with quantities in microliters (uL) and exact source and destination locations within labware. Always err on the side of providing extra information!'
       )
     ).toBeInTheDocument()
-    expect(screen.getByText('Add individual steps')).toBeInTheDocument()
-    expect(screen.getByText('Paste from document')).toBeInTheDocument()
-  })
-
-  it('should render the Add individual steps part', () => {
-    render()
-
-    expect(screen.getByText('Add individual steps')).toBeInTheDocument()
-    expect(screen.getByText('Add step')).toBeInTheDocument()
-    expect(screen.getByText('Step 1')).toBeInTheDocument()
     expect(screen.getByRole('textbox')).toBeInTheDocument()
+    expect(screen.getByText('Example:')).toBeInTheDocument()
   })
 
-  it('should render the Paste from document part', () => {
+  it('should render example text', () => {
     render()
 
-    fireEvent.click(screen.getByText('Paste from document'))
-
+    expect(screen.getByText('Example:')).toBeInTheDocument()
     expect(
       screen.getByText(
-        'Paste the steps from your document. Make sure your steps are clearly numbered.'
+        'Use right pipette to transfer 15 uL of mastermix from source well to destination well. Use the same pipette tip for all transfers.'
       )
     ).toBeInTheDocument()
-    expect(screen.getByRole('textbox')).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        'Use left pipette to transfer 10 ul of sample from the source to destination well. Mix the sample and mastermix of 25 ul total volume 9 times. Blow out to `destination well`. Use a new tip for each transfer.'
+      )
+    ).toBeInTheDocument()
   })
 
-  it('should add a step when the Add step button is clicked', () => {
+  it('should add step description when the text area is filled', () => {
     render()
 
-    fireEvent.click(screen.getByText('Add step'))
+    const textbox = screen.getByRole('textbox')
 
-    expect(screen.getByText('Step 2')).toBeInTheDocument()
-  })
-
-  it('should add step descriptions when the text area is filled', () => {
-    render()
-
-    fireEvent.change(screen.getByRole('textbox'), {
+    fireEvent.change(textbox, {
       target: { value: 'description test' },
     })
 
-    expect(screen.getByText('Step 1: description test')).toBeInTheDocument()
-  })
-
-  it('should add multiple step descriptions when the text area is filled multiple times', () => {
-    render()
-
-    fireEvent.change(screen.getByRole('textbox'), {
-      target: { value: 'description test' },
-    })
-    fireEvent.click(screen.getByText('Add step'))
-    fireEvent.change(screen.getAllByRole('textbox')[1], {
-      target: { value: 'description test 2' },
-    })
-
-    expect(screen.getByText('Step 1: description test')).toBeInTheDocument()
-    expect(screen.getByText('Step 2: description test 2')).toBeInTheDocument()
-  })
-
-  it('should add a step description when pasting from a document', () => {
-    render()
-
-    fireEvent.click(screen.getByText('Paste from document'))
-
-    fireEvent.change(screen.getByRole('textbox'), {
-      target: { value: 'description test' },
-    })
-
-    expect(screen.getAllByText('description test')[1]).toBeInTheDocument()
+    expect(textbox).toHaveValue('description test')
   })
 
   it('should update form state to valid when steps have been added', async () => {

--- a/opentrons-ai-client/src/organisms/StepsSection/index.tsx
+++ b/opentrons-ai-client/src/organisms/StepsSection/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect } from 'react'
 import { useFormContext } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
@@ -6,25 +6,18 @@ import styled from 'styled-components'
 import {
   COLORS,
   DIRECTION_COLUMN,
-  EmptySelectorButton,
   Flex,
   SPACING,
   StyledText,
-  Tabs,
 } from '@opentrons/components'
-import { COLUMN } from '@opentrons/shared-data'
 
 import { ControlledTextAreaField } from '../../atoms/ControlledTextAreaField'
-import { ControlledAddTextAreaFields } from '../../molecules/ControlledAddTextAreaFields'
 
 export const STEPS_FIELD_NAME = 'steps'
 
 export function StepsSection(): JSX.Element | null {
   const { t } = useTranslation('create_protocol')
-  const { setValue, watch, trigger } = useFormContext()
-  const [isIndividualStep, setIsIndividualStep] = useState(true)
-
-  const steps = watch(STEPS_FIELD_NAME) ?? []
+  const { trigger } = useFormContext()
 
   // trigger form validation on mount for when users come back to this section after moving on
   useEffect(() => {
@@ -41,91 +34,33 @@ export function StepsSection(): JSX.Element | null {
         {t('steps_section_textbody')}
       </StyledText>
 
-      <Tabs
-        tabs={[
-          {
-            text: t('add_individual_step'),
-            onClick: () => {
-              setIsIndividualStep(true)
-              setValue(STEPS_FIELD_NAME, [''], { shouldValidate: true })
-            },
-            isActive: isIndividualStep,
-            disabled: false,
-          },
-          {
-            text: t('paste_from_document'),
-            onClick: () => {
-              setIsIndividualStep(false)
-              setValue(STEPS_FIELD_NAME, [], { shouldValidate: true })
-            },
-            isActive: !isIndividualStep,
-            disabled: false,
-          },
-        ]}
-      ></Tabs>
-
       <Flex
         flexDirection={DIRECTION_COLUMN}
-        gap={SPACING.spacing10}
-        padding={SPACING.spacing16}
-        backgroundColor={COLORS.grey20}
+        gap={SPACING.spacing4}
+        color={COLORS.grey60}
       >
-        {isIndividualStep ? (
-          <>
-            <EmptySelectorButton
-              onClick={() => {
-                setValue(STEPS_FIELD_NAME, [...steps, ''])
-              }}
-              text={t('add_step')}
-              textAlignment="left"
-              iconName="plus"
-            />
-
-            <ControlledAddTextAreaFields
-              fieldName={STEPS_FIELD_NAME}
-              name={t('step').toLowerCase()}
-              textAreaHeight="163px"
-            />
-          </>
-        ) : (
-          <>
-            <StyledText
-              color={COLORS.grey60}
-              desktopStyle="headingSmallRegular"
-            >
-              {t('paste_from_document_title')}
+        <ControlledTextAreaField
+          name={STEPS_FIELD_NAME}
+          height="180px"
+          rules={{
+            required: true,
+          }}
+        />
+        <StyledText desktopStyle="bodyDefaultRegular">
+          {t('paste_from_document_input_caption_1')}
+        </StyledText>
+        <ExampleOrderedList>
+          <li>
+            <StyledText desktopStyle="bodyDefaultRegular">
+              {t('paste_from_document_input_caption_2')}
             </StyledText>
-
-            <Flex
-              flexDirection={COLUMN}
-              gap={SPACING.spacing4}
-              color={COLORS.grey60}
-            >
-              <ControlledTextAreaField
-                name={STEPS_FIELD_NAME}
-                height="180px"
-                rules={{
-                  required: true,
-                }}
-              />
-              <StyledText desktopStyle="bodyDefaultRegular">
-                {t('paste_from_document_input_caption_1')}
-              </StyledText>
-              <ExampleOrderedList>
-                <li>
-                  <StyledText desktopStyle="bodyDefaultRegular">
-                    {t('paste_from_document_input_caption_2')}
-                  </StyledText>
-                </li>
-                <li>
-                  <StyledText desktopStyle="bodyDefaultRegular">
-                    {t('paste_from_document_input_caption_3')}
-                  </StyledText>
-                </li>
-              </ExampleOrderedList>
-            </Flex>
-          </>
-        )}
+          </li>
+          <li>
+            <StyledText desktopStyle="bodyDefaultRegular">
+              {t('paste_from_document_input_caption_3')}
+            </StyledText>
+          </li>
+        </ExampleOrderedList>
       </Flex>
     </Flex>
   )

--- a/opentrons-ai-client/src/organisms/StepsSection/index.tsx
+++ b/opentrons-ai-client/src/organisms/StepsSection/index.tsx
@@ -41,7 +41,7 @@ export function StepsSection(): JSX.Element | null {
       >
         <ControlledTextAreaField
           name={STEPS_FIELD_NAME}
-          height="180px"
+          height="12.25rem"
           rules={{
             required: true,
           }}


### PR DESCRIPTION
# Overview
Closes AUTH-1973

This PR removes tab to simplify and fix whitescreen issue.

![image](https://github.com/user-attachments/assets/9e489f3d-c5cd-43e0-9981-a2975b134f98)


## Test Plan and Hands on Testing

CI handles them


## Review requests
Follow below: 

1. Fill out the UI wizard but don’t hit confirm on the “Steps” step
2. Go back to an earlier step to make a change
3. Continue forward and hit confirm. The whitescreen should NOT appear


## Risk assessment

Low
