### PR TITLE
fix(docs): proper alignment of search results on Flex manual homepage

### DIFF
--- a/docs/flex-manual/docs/index.md
+++ b/docs/flex-manual/docs/index.md
@@ -1,5 +1,5 @@
 <style>
-article {
+article.md-content__inner {
   text-align: center;
 }
 </style>

--- a/docs/flex-manual/docs/index.md
+++ b/docs/flex-manual/docs/index.md
@@ -1,5 +1,5 @@
 <style>
-article.md-content__inner {
+.md-content__inner {
   text-align: center;
 }
 </style>


### PR DESCRIPTION

# Overview

I had used an `article` CSS selector to center elements on the Flex manual homepage, thinking that was only the main page content. Turns out Material for mkdocs uses `<article>` tags in search results too.

## Test Plan and Hands on Testing

Before
![Screenshot 2025-06-19 at 11 58 20 AM](https://github.com/user-attachments/assets/07d2e2a1-41ae-4dda-9598-cdf0efc97f27)

After
![Screenshot 2025-06-19 at 11 58 39 AM](https://github.com/user-attachments/assets/e43ee2c6-2302-4e40-ac4e-90c81f3471ee)


## Changelog

CSS one-liner

## Review requests

is this the best selector? is something else more foolproof?

## Risk assessment

lowest