### PR TITLE
fix(api): Fix gripper move point calculation for modules

### DIFF
--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -380,15 +380,14 @@ class GeometryView:
 
         This includes module calibration but excludes the calibration of the given labware.
         """
-        labware_data = self._labware.get(labware_id)
+        location = self._labware.get(labware_id).location
+        definition = self._labware.get_definition(labware_id)
 
         slot_front_left = self._get_labware_ancestor_position(labware_id)
         stackup_origin_to_lw_origin = self._get_stackup_placement_origin_to_lw_origin(
-            labware_id, is_topmost_labware=True
+            location=location, definition=definition, is_topmost_labware=True
         )
-        module_cal_offset = self._get_calibrated_module_offset(
-            labware_data.location
-        ).to_point()
+        module_cal_offset = self._get_calibrated_module_offset(location).to_point()
 
         return slot_front_left + stackup_origin_to_lw_origin + module_cal_offset
 
@@ -402,12 +401,12 @@ class GeometryView:
         return parent_pos
 
     def _get_stackup_placement_origin_to_lw_origin(
-        self, labware_id: str, is_topmost_labware: bool
+        self,
+        location: LabwareLocation,
+        definition: LabwareDefinition,
+        is_topmost_labware: bool,
     ) -> Point:
         """Get the offset vector from the lowest entity in a stackup to the labware."""
-        location = self._labware.get(labware_id).location
-        definition = self._labware.get_definition(labware_id)
-
         if isinstance(
             location, (AddressableAreaLocation, DeckSlotLocation, ModuleLocation)
         ):
@@ -417,6 +416,10 @@ class GeometryView:
                 is_topmost_labware=is_topmost_labware,
             )
         elif isinstance(location, OnLabwareLocation):
+            parent_id = location.labwareId
+            parent_location = self._labware.get(parent_id).location
+            parent_definition = self._labware.get_definition(parent_id)
+
             parent_placement_origin_to_lw_origin = (
                 self._get_parent_placement_origin_to_lw_origin(
                     labware_location=location,
@@ -428,7 +431,8 @@ class GeometryView:
             return (
                 parent_placement_origin_to_lw_origin
                 + self._get_stackup_placement_origin_to_lw_origin(
-                    labware_id=location.labwareId,
+                    location=parent_location,
+                    definition=parent_definition,
                     is_topmost_labware=False,
                 )
             )
@@ -1040,9 +1044,9 @@ class GeometryView:
             self._labware.get_grip_height_from_labware_bottom(labware_definition)
         )
         location_name = self._get_underlying_addressable_area_name(location)
-        parent_to_lw_offset = self._get_parent_placement_origin_to_lw_origin(
-            labware_location=location,
-            labware_definition=labware_definition,
+        parent_to_lw_offset = self._get_stackup_placement_origin_to_lw_origin(
+            location=location,
+            definition=labware_definition,
             is_topmost_labware=True,  # We aren't concerned with entities above the gripped labware.
         )
         mod_cal_offset = self._get_calibrated_module_offset(location)

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -394,21 +394,12 @@ class GeometryView:
 
     def _get_labware_ancestor_position(self, labware_id: str) -> Point:
         """Get the position of the labware's underlying ancestor."""
-        slot_name = self._get_underlying_slot_name(labware_id)
+        slot_name = self._get_underlying_addressable_area_name(
+            self._labware.get(labware_id).location
+        )
         parent_pos = self._addressable_areas.get_addressable_area_position(slot_name)
 
         return parent_pos
-
-    def _get_underlying_slot_name(self, labware_id: str) -> str:
-        """Get the name of the labware's underlying slot."""
-        try:
-            slot_name = self.get_ancestor_slot_name(labware_id).id
-        except errors.LocationIsStagingSlotError:
-            slot_name = self._get_staging_slot_name(labware_id)
-        except errors.LocationIsLidDockSlotError:
-            slot_name = self._get_lid_dock_slot_name(labware_id)
-
-        return slot_name
 
     def _get_stackup_placement_origin_to_lw_origin(
         self, labware_id: str, is_topmost_labware: bool
@@ -456,9 +447,10 @@ class GeometryView:
         parent_entity = self._get_parent_definition(labware_location)
 
         if isinstance(labware_location, ModuleLocation):
-            module_parent_to_child_offset = self._modules.get_nominal_offset_to_child(
-                module_id=labware_location.moduleId,
-                addressable_areas=self._addressable_areas,
+            module_parent_to_child_offset = (
+                self._modules.get_nominal_offset_to_child_from_addressable_area(
+                    module_id=labware_location.moduleId,
+                )
             )
             return get_parent_placement_origin_to_lw_origin(
                 child_labware=labware_definition,
@@ -526,7 +518,6 @@ class GeometryView:
                 f"Cannot get ancestor from location {location}"
             )
 
-    # TODO(jh, 06-12-25): This is suspiciously similar to get_ancestor_addressable_area_name. Can we unify these two?
     def _get_underlying_addressable_area_name(self, location: LabwareLocation) -> str:
         if isinstance(location, DeckSlotLocation):
             return location.slotName.id
@@ -817,28 +808,6 @@ class GeometryView:
             origin=WellOrigin(well_location.origin.value), offset=well_location.offset
         )
 
-    # TODO(jbl 11-30-2023) fold this function into get_ancestor_slot_name see RSS-411
-    def _get_staging_slot_name(self, labware_id: str) -> str:
-        """Get the staging slot name that the labware is on."""
-        labware_location = self._labware.get(labware_id).location
-        if isinstance(labware_location, OnLabwareLocation):
-            below_labware_id = labware_location.labwareId
-            return self._get_staging_slot_name(below_labware_id)
-        elif isinstance(
-            labware_location, AddressableAreaLocation
-        ) and fixture_validation.is_staging_slot(labware_location.addressableAreaName):
-            return labware_location.addressableAreaName
-        else:
-            raise ValueError(
-                "Cannot get staging slot name for labware not on staging slot."
-            )
-
-    def _get_lid_dock_slot_name(self, labware_id: str) -> str:
-        """Get the staging slot name that the labware is on."""
-        labware_location = self._labware.get(labware_id).location
-        assert isinstance(labware_location, AddressableAreaLocation)
-        return labware_location.addressableAreaName
-
     def get_ancestor_slot_name(
         self, labware_id: str
     ) -> Union[DeckSlotName, StagingSlotName]:
@@ -1074,7 +1043,7 @@ class GeometryView:
         parent_to_lw_offset = self._get_parent_placement_origin_to_lw_origin(
             labware_location=location,
             labware_definition=labware_definition,
-            is_topmost_labware=True,  # We only ever get the grip point for the topmost labware in a stackup.
+            is_topmost_labware=True,  # We aren't concerned with entities above the gripped labware.
         )
         mod_cal_offset = self._get_calibrated_module_offset(location)
         location_center = self._addressable_areas.get_addressable_area_center(

--- a/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
@@ -702,7 +702,9 @@ def test_get_module_labware_highest_z(
         calibration_offset
     )
     decoy.when(
-        mock_addressable_area_view.get_addressable_area_position(DeckSlotName.SLOT_3.id)
+        mock_addressable_area_view.get_addressable_area_position(
+            "magneticModuleV2Slot3"
+        )
     ).then_return(slot_pos)
     decoy.when(mock_module_view.get_location("module-id")).then_return(
         DeckSlotLocation(slotName=DeckSlotName.SLOT_3)
@@ -721,8 +723,8 @@ def test_get_module_labware_highest_z(
         )
     )
     decoy.when(
-        mock_module_view.get_nominal_offset_to_child(
-            module_id="module-id", addressable_areas=mock_addressable_area_view
+        mock_module_view.get_nominal_offset_to_child_from_addressable_area(
+            module_id="module-id"
         )
     ).then_return(LabwareOffsetVector(x=0, y=0, z=0))
     decoy.when(mock_module_view.get_connected_model("module-id")).then_return(
@@ -830,12 +832,10 @@ def test_get_obstacle_highest_z_with_labware(
     shuttle_height = addressable_area_view.get_addressable_area_position(
         "flexStackerModuleV1D4"
     ).z
-    monkeypatch.setattr(
-        "opentrons.protocol_engine.state.geometry.get_parent_placement_origin_to_lw_origin",
-        lambda *args, **kwargs: Point(10, 20, shuttle_height),
-    )
 
-    assert subject.get_all_obstacle_highest_z() == 300 + shuttle_height
+    expected_height = 300 + shuttle_height + _PARENT_ORIGIN_TO_LABWARE_ORIGIN.z
+
+    assert subject.get_all_obstacle_highest_z() == expected_height
 
 
 @pytest.mark.parametrize("use_mocks", [False])
@@ -1200,13 +1200,21 @@ def test_get_highest_z_in_slot_with_labware_stack_on_module(
         errors.LabwareNotLoadedOnLabwareError("top labware")
     )
     decoy.when(
-        mock_module_view.get_nominal_offset_to_child(
-            module_id="module-id", addressable_areas=mock_addressable_area_view
+        mock_module_view.get_nominal_offset_to_child_from_addressable_area(
+            module_id="module-id"
         )
     ).then_return(LabwareOffsetVector(x=0, y=0, z=0))
-
+    decoy.when(mock_module_view.get_provided_addressable_area("module-id")).then_return(
+        "magneticModuleV2Slot3"
+    )
     decoy.when(mock_labware_view.get("adapter-id")).then_return(adapter)
     decoy.when(mock_labware_view.get("top-labware-id")).then_return(top_labware)
+    decoy.when(mock_labware_view.get_definition("top-labware-id")).then_return(
+        _MOCK_LABWARE_DEFINITION3
+    )
+    decoy.when(mock_labware_view.get_definition("adapter-id")).then_return(
+        _MOCK_LABWARE_DEFINITION3
+    )
     decoy.when(
         mock_labware_view.get_dimensions(labware_id="top-labware-id")
     ).then_return(Dimensions(x=0, y=0, z=1000))
@@ -1214,12 +1222,17 @@ def test_get_highest_z_in_slot_with_labware_stack_on_module(
         mock_labware_view.get_labware_offset_vector("top-labware-id")
     ).then_return(top_lw_lpc_offset)
     decoy.when(
-        mock_addressable_area_view.get_addressable_area_position(DeckSlotName.SLOT_3.id)
+        mock_addressable_area_view.get_addressable_area_position(
+            "magneticModuleV2Slot3"
+        )
     ).then_return(Point(11, 22, 33))
 
     expected_highest_z = (
-        33 + 1000 + 3 + _PARENT_ORIGIN_TO_LABWARE_ORIGIN.z * 2
-    )  # Both the adapter and top labware
+        33
+        + 1000
+        + 3
+        + _PARENT_ORIGIN_TO_LABWARE_ORIGIN.z * 2  # Both the adapter and top labware
+    )
 
     assert (
         subject.get_highest_z_in_slot(DeckSlotLocation(slotName=DeckSlotName.SLOT_3))
@@ -1466,18 +1479,23 @@ def test_get_module_labware_well_position(
     decoy.when(mock_labware_view.get_labware_offset_vector("labware-id")).then_return(
         calibration_offset
     )
+    decoy.when(mock_module_view.get_provided_addressable_area("module-id")).then_return(
+        "magneticModuleV2Slot3"
+    )
     decoy.when(
-        mock_addressable_area_view.get_addressable_area_position(DeckSlotName.SLOT_4.id)
+        mock_addressable_area_view.get_addressable_area_position(
+            "magneticModuleV2Slot3"
+        )
     ).then_return(slot_pos)
     decoy.when(mock_labware_view.get_well_definition("labware-id", "B2")).then_return(
         well_def
     )
     decoy.when(mock_module_view.get_location("module-id")).then_return(
-        DeckSlotLocation(slotName=DeckSlotName.SLOT_4)
+        DeckSlotLocation(slotName=DeckSlotName.SLOT_3)
     )
     decoy.when(
-        mock_module_view.get_nominal_offset_to_child(
-            module_id="module-id", addressable_areas=mock_addressable_area_view
+        mock_module_view.get_nominal_offset_to_child_from_addressable_area(
+            module_id="module-id"
         )
     ).then_return(LabwareOffsetVector(x=0, y=0, z=0))
     decoy.when(mock_module_view.get_module_calibration_offset("module-id")).then_return(
@@ -2726,9 +2744,9 @@ def test_get_labware_grip_point_on_labware(
     )
 
     assert grip_point == Point(
-        5.0 + _PARENT_ORIGIN_TO_LABWARE_ORIGIN.x,
-        9.0 + _PARENT_ORIGIN_TO_LABWARE_ORIGIN.y,
-        110.0 + _PARENT_ORIGIN_TO_LABWARE_ORIGIN.z,
+        5.0 + _PARENT_ORIGIN_TO_LABWARE_ORIGIN.x * 2,  # The labware and adapter
+        9.0 + _PARENT_ORIGIN_TO_LABWARE_ORIGIN.y * 2,
+        110.0 + _PARENT_ORIGIN_TO_LABWARE_ORIGIN.z * 2,
     )
 
 
@@ -2889,9 +2907,10 @@ def test_get_labware_grip_point_for_labware_stack_on_module(
     )
 
     assert result_grip_point == Point(
-        x=492.0 + _PARENT_ORIGIN_TO_LABWARE_ORIGIN.x,
-        y=350.0 + _PARENT_ORIGIN_TO_LABWARE_ORIGIN.y,
-        z=838.0 + _PARENT_ORIGIN_TO_LABWARE_ORIGIN.z,
+        x=492.0
+        + _PARENT_ORIGIN_TO_LABWARE_ORIGIN.x * 2,  # The labware and module beneath it.
+        y=350.0 + _PARENT_ORIGIN_TO_LABWARE_ORIGIN.y * 2,
+        z=838.0 + _PARENT_ORIGIN_TO_LABWARE_ORIGIN.z * 2,
     )
 
 


### PR DESCRIPTION
Closes [RQA-4295](https://opentrons.atlassian.net/browse/RQA-4295)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

When we `get_labware_origin_position`, we start by retrieving the deck coordinates for the _underlying_ addressable area, so for example, if the addressable area is `heaterShakerV1D1`, we get the coordinates for `D1`. Much later down stream, if there is a module involved in a stackup, we offset `D1` by the `heaterShakerV1D1` 's `offsetFromCutoutFixture`.

In https://github.com/Opentrons/opentrons/pull/18564, we refactored `get_labware_grip_point` to utilize more of the `get_labware_origin_position` logic (see that PR for more details), however, the grip point does exactly one thing different: we utilize the deck position for the actual addressable area we care about, ex, `heaterShakerV1D1`. This means that an extra `offsetFromCutoutFixture` is applied for grip moves.

To fix, we should refactor `get_labware_origin_position` to get the deck coordinates for the addressable area we actually care about and not do the `offsetFromCutoutFixture` adjustment much later down stream. Doing so unifies the gripper point and labware point calculation behavior almost entirely.

[a89db22](https://github.com/Opentrons/opentrons/pull/18691/commits/a89db22494b89e94f3b1193a98ad0581debd9362) fixes the second half of the issue, which is we weren't correctly applying _all_ stacking offsets in a stackup to the gripper moves. Now we are. 

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- Ran the stackup testing script to ensure that there isn't any regression in well positioning behavior.
- Ran a few simulations of protocols for gripper moves: the gripper point calculations now match the positioning that occurred before https://github.com/Opentrons/opentrons/pull/18564. 
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed the gripper moving to incorrect positions when interacting with labware on top of a module.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
lowish - the risk only comes from the `get_grip_point` changes, since we have regression testing for the labware origin changes. 
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-4295]: https://opentrons.atlassian.net/browse/RQA-4295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ