### PR TITLE
feat(api): add keep_last_tip argument to liquid class transfer methods

### DIFF
--- a/api/src/opentrons/protocol_api/_transfer_liquid_validation.py
+++ b/api/src/opentrons/protocol_api/_transfer_liquid_validation.py
@@ -98,6 +98,11 @@ def verify_and_normalize_transfer_args(
 def resolve_keep_last_tip(
     keep_last_tip: Optional[bool], tip_strategy: TransferTipPolicyV2
 ) -> bool:
+    """Resolve the liquid class transfer argument `keep_last_tip`
+
+    If set to a boolean value, maintains that setting. Otherwise, default to
+    `True` if tip policy is `NEVER`, otherwise default to `False`
+    """
     if keep_last_tip is not None:
         return keep_last_tip
     return tip_strategy == TransferTipPolicyV2.NEVER

--- a/api/src/opentrons/protocol_api/_transfer_liquid_validation.py
+++ b/api/src/opentrons/protocol_api/_transfer_liquid_validation.py
@@ -93,3 +93,11 @@ def verify_and_normalize_transfer_args(
         tip_racks=valid_tip_racks,
         trash_location=valid_trash_location,
     )
+
+
+def resolve_keep_last_tip(
+    keep_last_tip: Optional[bool], tip_strategy: TransferTipPolicyV2
+) -> bool:
+    if keep_last_tip is not None:
+        return keep_last_tip
+    return tip_strategy == TransferTipPolicyV2.NEVER

--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -1405,16 +1405,14 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                     transfer_type=tx_comps_executor.TransferType.ONE_TO_ONE,
                     tip_contents=post_asp_tip_contents,
                     add_final_air_gap=(
-                        False
-                        if is_last_step
-                        and (keep_last_tip or new_tip == TransferTipPolicyV2.NEVER)
-                        else True
+                        False if is_last_step and keep_last_tip else True
                     ),
                     trash_location=trash_location,
                 )
             prev_src = step_source
             prev_dest = step_destination
-        if not keep_last_tip or new_tip != TransferTipPolicyV2.NEVER:
+
+        if not keep_last_tip:
             _drop_tip()
 
     # TODO(spp, 2025-02-25): wire up return tip
@@ -1697,10 +1695,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                         transfer_type=tx_comps_executor.TransferType.ONE_TO_MANY,
                         tip_contents=tip_contents,
                         add_final_air_gap=(
-                            False
-                            if is_last_step
-                            and (keep_last_tip or new_tip == TransferTipPolicyV2.NEVER)
-                            else True
+                            False if is_last_step and keep_last_tip else True
                         ),
                         trash_location=trash_location,
                     )
@@ -1713,10 +1708,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                         transfer_type=tx_comps_executor.TransferType.ONE_TO_MANY,
                         tip_contents=tip_contents,
                         add_final_air_gap=(
-                            False
-                            if is_last_step
-                            and (keep_last_tip or new_tip == TransferTipPolicyV2.NEVER)
-                            else True
+                            False if is_last_step and keep_last_tip else True
                         ),
                         trash_location=trash_location,
                         conditioning_volume=conditioning_vol,
@@ -1724,7 +1716,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                     )
                 is_first_step = False
 
-        if not keep_last_tip or new_tip != TransferTipPolicyV2.NEVER:
+        if not keep_last_tip:
             _drop_tip()
 
     def _tip_can_hold_volume_for_multi_dispensing(
@@ -1929,15 +1921,11 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                 transfer_properties=transfer_props,
                 transfer_type=tx_comps_executor.TransferType.MANY_TO_ONE,
                 tip_contents=tip_contents,
-                add_final_air_gap=(
-                    False
-                    if is_last_step
-                    and (keep_last_tip or new_tip == TransferTipPolicyV2.NEVER)
-                    else True
-                ),
+                add_final_air_gap=(False if is_last_step and keep_last_tip else True),
                 trash_location=trash_location,
             )
-        if not keep_last_tip or new_tip != TransferTipPolicyV2.NEVER:
+
+        if not keep_last_tip:
             _drop_tip()
 
     def _get_location_and_well_core_from_next_tip_info(

--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -1205,6 +1205,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         starting_tip: Optional[WellCore],
         trash_location: Union[Location, TrashBin, WasteChute],
         return_tip: bool,
+        keep_last_tip: bool,
     ) -> None:
         """Execute transfer using liquid class properties.
 
@@ -1405,14 +1406,15 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                     tip_contents=post_asp_tip_contents,
                     add_final_air_gap=(
                         False
-                        if is_last_step and new_tip == TransferTipPolicyV2.NEVER
+                        if is_last_step
+                        and (keep_last_tip or new_tip == TransferTipPolicyV2.NEVER)
                         else True
                     ),
                     trash_location=trash_location,
                 )
             prev_src = step_source
             prev_dest = step_destination
-        if new_tip != TransferTipPolicyV2.NEVER:
+        if not keep_last_tip or new_tip != TransferTipPolicyV2.NEVER:
             _drop_tip()
 
     # TODO(spp, 2025-02-25): wire up return tip
@@ -1427,6 +1429,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         starting_tip: Optional[WellCore],
         trash_location: Union[Location, TrashBin, WasteChute],
         return_tip: bool,
+        keep_last_tip: bool,
     ) -> None:
         """Execute a distribution using liquid class properties.
 
@@ -1510,6 +1513,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                 starting_tip=starting_tip,
                 trash_location=trash_location,
                 return_tip=return_tip,
+                keep_last_tip=keep_last_tip,
             )
             return
 
@@ -1694,7 +1698,8 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                         tip_contents=tip_contents,
                         add_final_air_gap=(
                             False
-                            if is_last_step and new_tip == TransferTipPolicyV2.NEVER
+                            if is_last_step
+                            and (keep_last_tip or new_tip == TransferTipPolicyV2.NEVER)
                             else True
                         ),
                         trash_location=trash_location,
@@ -1709,7 +1714,8 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                         tip_contents=tip_contents,
                         add_final_air_gap=(
                             False
-                            if is_last_step and new_tip == TransferTipPolicyV2.NEVER
+                            if is_last_step
+                            and (keep_last_tip or new_tip == TransferTipPolicyV2.NEVER)
                             else True
                         ),
                         trash_location=trash_location,
@@ -1718,7 +1724,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                     )
                 is_first_step = False
 
-        if new_tip != TransferTipPolicyV2.NEVER:
+        if not keep_last_tip or new_tip != TransferTipPolicyV2.NEVER:
             _drop_tip()
 
     def _tip_can_hold_volume_for_multi_dispensing(
@@ -1753,6 +1759,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         starting_tip: Optional[WellCore],
         trash_location: Union[Location, TrashBin, WasteChute],
         return_tip: bool,
+        keep_last_tip: bool,
     ) -> None:
         if not tip_racks:
             raise RuntimeError(
@@ -1924,12 +1931,13 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                 tip_contents=tip_contents,
                 add_final_air_gap=(
                     False
-                    if is_last_step and new_tip == TransferTipPolicyV2.NEVER
+                    if is_last_step
+                    and (keep_last_tip or new_tip == TransferTipPolicyV2.NEVER)
                     else True
                 ),
                 trash_location=trash_location,
             )
-        if new_tip != TransferTipPolicyV2.NEVER:
+        if not keep_last_tip or new_tip != TransferTipPolicyV2.NEVER:
             _drop_tip()
 
     def _get_location_and_well_core_from_next_tip_info(

--- a/api/src/opentrons/protocol_api/core/instrument.py
+++ b/api/src/opentrons/protocol_api/core/instrument.py
@@ -371,6 +371,7 @@ class AbstractInstrument(ABC, Generic[WellCoreType, LabwareCoreType]):
         starting_tip: Optional[WellCoreType],
         trash_location: Union[types.Location, TrashBin, WasteChute],
         return_tip: bool,
+        keep_last_tip: bool,
     ) -> None:
         """Transfer a liquid from source to dest according to liquid class properties."""
         ...
@@ -387,6 +388,7 @@ class AbstractInstrument(ABC, Generic[WellCoreType, LabwareCoreType]):
         starting_tip: Optional[WellCoreType],
         trash_location: Union[types.Location, TrashBin, WasteChute],
         return_tip: bool,
+        keep_last_tip: bool,
     ) -> None:
         """
         Distribute a liquid from single source to multiple destinations
@@ -406,6 +408,7 @@ class AbstractInstrument(ABC, Generic[WellCoreType, LabwareCoreType]):
         starting_tip: Optional[WellCoreType],
         trash_location: Union[types.Location, TrashBin, WasteChute],
         return_tip: bool,
+        keep_last_tip: bool,
     ) -> None:
         """
         Consolidate liquid from multiple sources to a single destination

--- a/api/src/opentrons/protocol_api/core/legacy/legacy_instrument_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy/legacy_instrument_core.py
@@ -611,6 +611,7 @@ class LegacyInstrumentCore(AbstractInstrument[LegacyWellCore, LegacyLabwareCore]
         starting_tip: Optional[LegacyWellCore],
         trash_location: Union[types.Location, TrashBin, WasteChute],
         return_tip: bool,
+        keep_last_tip: bool,
     ) -> None:
         """This will never be called because it was added in API 2.23"""
         assert False, "transfer_liquid is not supported in legacy context"
@@ -626,6 +627,7 @@ class LegacyInstrumentCore(AbstractInstrument[LegacyWellCore, LegacyLabwareCore]
         starting_tip: Optional[LegacyWellCore],
         trash_location: Union[types.Location, TrashBin, WasteChute],
         return_tip: bool,
+        keep_last_tip: bool,
     ) -> None:
         """This will never be called because it was added in API 2.23"""
         assert False, "distribute_liquid is not supported in legacy context"
@@ -641,6 +643,7 @@ class LegacyInstrumentCore(AbstractInstrument[LegacyWellCore, LegacyLabwareCore]
         starting_tip: Optional[LegacyWellCore],
         trash_location: Union[types.Location, TrashBin, WasteChute],
         return_tip: bool,
+        keep_last_tip: bool,
     ) -> None:
         """This will never be called because it was added in API 2.23."""
         assert False, "consolidate_liquid is not supported in legacy context"

--- a/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_instrument_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_instrument_core.py
@@ -525,6 +525,7 @@ class LegacyInstrumentCoreSimulator(
         starting_tip: Optional[LegacyWellCore],
         trash_location: Union[types.Location, TrashBin, WasteChute],
         return_tip: bool,
+        keep_last_tip: bool,
     ) -> None:
         """This will never be called because it was added in API 2.23."""
         assert False, "transfer_liquid is not supported in legacy context"
@@ -540,6 +541,7 @@ class LegacyInstrumentCoreSimulator(
         starting_tip: Optional[LegacyWellCore],
         trash_location: Union[types.Location, TrashBin, WasteChute],
         return_tip: bool,
+        keep_last_tip: bool,
     ) -> None:
         """This will never be called because it was added in API 2.23."""
         assert False, "distribute_liquid is not supported in legacy context"
@@ -555,6 +557,7 @@ class LegacyInstrumentCoreSimulator(
         starting_tip: Optional[LegacyWellCore],
         trash_location: Union[types.Location, TrashBin, WasteChute],
         return_tip: bool,
+        keep_last_tip: bool,
     ) -> None:
         """This will never be called because it was added in API 2.23."""
         assert False, "consolidate_liquid is not supported in legacy context"

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1834,9 +1834,9 @@ class InstrumentContext(publisher.CommandPublisher):
         :param group_wells: For multi-channel transfers only. If set to ``True``, group together contiguous wells
             given into a single transfer step, taking into account the tip configuration. If ``False``, target
             each well given with the primary nozzle. Defaults to ``True``.
-        :param keep_last_tip: If set to ``True``, do not drop or return the last tip used in the transfer. If set to
-            ``False``, the last tip will be dropped or returned. If not set, default depends on tip policy chosen. A
-            tip policy of ``"never"`` will default to ``True``, all other tip policies will default to ``False``.
+        :param keep_last_tip: When ``True``, the pipette keeps the last tip used in the transfer attached. When
+            ``False``, the last tip will be dropped or returned. If not set, behavior depends on the value of
+            ``new_tip``. ``new_tip="never"`` keeps the tip, and all other values of ``new_tip`` drop or return the tip.
 
         :meta private:
         """
@@ -1961,9 +1961,9 @@ class InstrumentContext(publisher.CommandPublisher):
         :param group_wells: For multi-channel transfers only. If set to ``True``, group together contiguous wells
             given into a single transfer step, taking into account the tip configuration. If ``False``, target
             each well given with the primary nozzle. Defaults to ``True``.
-        :param keep_last_tip: If set to ``True``, do not drop or return the last tip used in the distribute. If set to
-            ``False``, the last tip will be dropped or returned. If not set, default depends on tip policy chosen. A
-            tip policy of ``"never"`` will default to ``True``, all other tip policies will default to ``False``.
+        :param keep_last_tip: When ``True``, the pipette keeps the last tip used in the distribute attached. When
+            ``False``, the last tip will be dropped or returned. If not set, behavior depends on the value of
+            ``new_tip``. ``new_tip="never"`` keeps the tip, and all other values of ``new_tip`` drop or return the tip.
 
         :meta private:
         """
@@ -2096,9 +2096,9 @@ class InstrumentContext(publisher.CommandPublisher):
         :param group_wells: For multi-channel transfers only. If set to ``True``, group together contiguous wells
             given into a single transfer step, taking into account the tip configuration. If ``False``, target
             each well given with the primary nozzle. Defaults to ``True``.
-        :param keep_last_tip: If set to ``True``, do not drop or return the last tip used in the consolidate. If set to
-            ``False``, the last tip will be dropped or returned. If not set, default depends on tip policy chosen. A
-            tip policy of ``"never"`` will default to ``True``, all other tip policies will default to ``False``.
+        :param keep_last_tip: When ``True``, the pipette keeps the last tip used in the consolidate attached. When
+            ``False``, the last tip will be dropped or returned. If not set, behavior depends on the value of
+            ``new_tip``. ``new_tip="never"`` keeps the tip, and all other values of ``new_tip`` drop or return the tip.
 
         :meta private:
         """

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1834,7 +1834,7 @@ class InstrumentContext(publisher.CommandPublisher):
         :param group_wells: For multi-channel transfers only. If set to ``True``, group together contiguous wells
             given into a single transfer step, taking into account the tip configuration. If ``False``, target
             each well given with the primary nozzle. Defaults to ``True``.
-        :parm keep_last_tip: If set to ``True``, do not drop or return the last tip used in the transfer. If set to
+        :param keep_last_tip: If set to ``True``, do not drop or return the last tip used in the transfer. If set to
             ``False``, the last tip will be dropped or returned. If not set, default depends on tip policy chosen. A
             tip policy of ``"never"`` will default to ``True``, all other tip policies will default to ``False``.
 
@@ -1961,7 +1961,7 @@ class InstrumentContext(publisher.CommandPublisher):
         :param group_wells: For multi-channel transfers only. If set to ``True``, group together contiguous wells
             given into a single transfer step, taking into account the tip configuration. If ``False``, target
             each well given with the primary nozzle. Defaults to ``True``.
-        :parm keep_last_tip: If set to ``True``, do not drop or return the last tip used in the distribute. If set to
+        :param keep_last_tip: If set to ``True``, do not drop or return the last tip used in the distribute. If set to
             ``False``, the last tip will be dropped or returned. If not set, default depends on tip policy chosen. A
             tip policy of ``"never"`` will default to ``True``, all other tip policies will default to ``False``.
 
@@ -2096,7 +2096,7 @@ class InstrumentContext(publisher.CommandPublisher):
         :param group_wells: For multi-channel transfers only. If set to ``True``, group together contiguous wells
             given into a single transfer step, taking into account the tip configuration. If ``False``, target
             each well given with the primary nozzle. Defaults to ``True``.
-        :parm keep_last_tip: If set to ``True``, do not drop or return the last tip used in the consolidate. If set to
+        :param keep_last_tip: If set to ``True``, do not drop or return the last tip used in the consolidate. If set to
             ``False``, the last tip will be dropped or returned. If not set, default depends on tip policy chosen. A
             tip policy of ``"never"`` will default to ``True``, all other tip policies will default to ``False``.
 

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1834,6 +1834,9 @@ class InstrumentContext(publisher.CommandPublisher):
         :param group_wells: For multi-channel transfers only. If set to ``True``, group together contiguous wells
             given into a single transfer step, taking into account the tip configuration. If ``False``, target
             each well given with the primary nozzle. Defaults to ``True``.
+        :parm keep_last_tip: If set to ``True``, do not drop or return the last tip used in the transfer. If set to
+            ``False``, the last tip will be dropped or returned. If not set, default depends on tip policy chosen. A
+            tip policy of ``"never"`` will default to ``True``, all other tip policies will default to ``False``.
 
         :meta private:
         """
@@ -1958,6 +1961,9 @@ class InstrumentContext(publisher.CommandPublisher):
         :param group_wells: For multi-channel transfers only. If set to ``True``, group together contiguous wells
             given into a single transfer step, taking into account the tip configuration. If ``False``, target
             each well given with the primary nozzle. Defaults to ``True``.
+        :parm keep_last_tip: If set to ``True``, do not drop or return the last tip used in the distribute. If set to
+            ``False``, the last tip will be dropped or returned. If not set, default depends on tip policy chosen. A
+            tip policy of ``"never"`` will default to ``True``, all other tip policies will default to ``False``.
 
         :meta private:
         """
@@ -2090,6 +2096,9 @@ class InstrumentContext(publisher.CommandPublisher):
         :param group_wells: For multi-channel transfers only. If set to ``True``, group together contiguous wells
             given into a single transfer step, taking into account the tip configuration. If ``False``, target
             each well given with the primary nozzle. Defaults to ``True``.
+        :parm keep_last_tip: If set to ``True``, do not drop or return the last tip used in the consolidate. If set to
+            ``False``, the last tip will be dropped or returned. If not set, default depends on tip policy chosen. A
+            tip policy of ``"never"`` will default to ``True``, all other tip policies will default to ``False``.
 
         :meta private:
         """

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -39,7 +39,10 @@ from .config import Clearances
 from .disposal_locations import TrashBin, WasteChute
 from ._nozzle_layout import NozzleLayout
 from ._liquid import LiquidClass
-from ._transfer_liquid_validation import verify_and_normalize_transfer_args
+from ._transfer_liquid_validation import (
+    verify_and_normalize_transfer_args,
+    resolve_keep_last_tip,
+)
 from . import labware, validation
 from ..protocols.advanced_control.transfers.common import (
     TransferTipPolicyV2,
@@ -1795,6 +1798,7 @@ class InstrumentContext(publisher.CommandPublisher):
         ] = None,
         return_tip: bool = False,
         group_wells: bool = True,
+        keep_last_tip: Optional[bool] = None,
     ) -> InstrumentContext:
         """Move a particular type of liquid from one well or group of wells to another.
 
@@ -1853,6 +1857,9 @@ class InstrumentContext(publisher.CommandPublisher):
                 trash_location if trash_location is not None else self.trash_container
             ),
         )
+        verified_keep_last_tip = resolve_keep_last_tip(
+            keep_last_tip, transfer_args.tip_policy
+        )
 
         verified_dest: Union[
             List[Tuple[types.Location, WellCore]], TrashBin, WasteChute
@@ -1899,6 +1906,7 @@ class InstrumentContext(publisher.CommandPublisher):
                 ),
                 trash_location=transfer_args.trash_location,
                 return_tip=return_tip,
+                keep_last_tip=verified_keep_last_tip,
             )
         return self
 
@@ -1917,6 +1925,7 @@ class InstrumentContext(publisher.CommandPublisher):
         ] = None,
         return_tip: bool = False,
         group_wells: bool = True,
+        keep_last_tip: Optional[bool] = None,
     ) -> InstrumentContext:
         """
         Distribute a particular type of liquid from one well to a group of wells.
@@ -1972,6 +1981,10 @@ class InstrumentContext(publisher.CommandPublisher):
                 trash_location if trash_location is not None else self.trash_container
             ),
         )
+        verified_keep_last_tip = resolve_keep_last_tip(
+            keep_last_tip, transfer_args.tip_policy
+        )
+
         if isinstance(transfer_args.dest, (TrashBin, WasteChute)):
             raise ValueError(
                 "distribute_with_liquid_class() does not support trash bin or waste chute"
@@ -2024,6 +2037,7 @@ class InstrumentContext(publisher.CommandPublisher):
                 ),
                 trash_location=transfer_args.trash_location,
                 return_tip=return_tip,
+                keep_last_tip=verified_keep_last_tip,
             )
         return self
 
@@ -2042,6 +2056,7 @@ class InstrumentContext(publisher.CommandPublisher):
         ] = None,
         return_tip: bool = False,
         group_wells: bool = True,
+        keep_last_tip: Optional[bool] = None,
     ) -> InstrumentContext:
         """
         Consolidate a particular type of liquid from a group of wells to one well.
@@ -2098,6 +2113,10 @@ class InstrumentContext(publisher.CommandPublisher):
                 trash_location if trash_location is not None else self.trash_container
             ),
         )
+        verified_keep_last_tip = resolve_keep_last_tip(
+            keep_last_tip, transfer_args.tip_policy
+        )
+
         verified_dest: Union[Tuple[types.Location, WellCore], TrashBin, WasteChute]
         if isinstance(transfer_args.dest, (TrashBin, WasteChute)):
             verified_dest = transfer_args.dest
@@ -2149,6 +2168,7 @@ class InstrumentContext(publisher.CommandPublisher):
                 ),
                 trash_location=transfer_args.trash_location,
                 return_tip=return_tip,
+                keep_last_tip=verified_keep_last_tip,
             )
         return self
 

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -2494,6 +2494,7 @@ def test_transfer_liquid_delegates_to_engine_core(
             starting_tip=mock_starting_tip_well._core,
             trash_location=trash_location,
             return_tip=True,
+            keep_last_tip=False,
         )
     )
 
@@ -2551,6 +2552,7 @@ def test_transfer_liquid_multi_channel_delegates_to_engine_core(
             starting_tip=None,
             trash_location=trash_location,
             return_tip=True,
+            keep_last_tip=False,
         )
     )
 
@@ -2601,6 +2603,7 @@ def test_transfer_liquid_delegates_to_engine_core_with_trash_destination(
             starting_tip=mock_starting_tip_well._core,
             trash_location=trash_location,
             return_tip=True,
+            keep_last_tip=False,
         )
     )
 
@@ -2825,6 +2828,7 @@ def test_distribute_liquid_delegates_to_engine_core(
             starting_tip=mock_starting_tip_well._core,
             trash_location=trash_location,
             return_tip=True,
+            keep_last_tip=False,
         )
     )
 
@@ -2890,6 +2894,7 @@ def test_distribute_liquid_multi_channel_delegates_to_engine_core(
             starting_tip=None,
             trash_location=trash_location,
             return_tip=True,
+            keep_last_tip=False,
         )
     )
 
@@ -3108,6 +3113,7 @@ def test_consolidate_liquid_delegates_to_engine_core(
             starting_tip=mock_starting_tip_well._core,
             trash_location=trash_location,
             return_tip=True,
+            keep_last_tip=False,
         )
     )
 
@@ -3174,6 +3180,7 @@ def test_consolidate_liquid_multi_channel_delegates_to_engine_core(
             starting_tip=None,
             trash_location=trash_location,
             return_tip=True,
+            keep_last_tip=False,
         )
     )
 
@@ -3225,5 +3232,6 @@ def test_consolidate_liquid_delegates_to_engine_core_with_trash_destination(
             starting_tip=mock_starting_tip_well._core,
             trash_location=trash_location,
             return_tip=True,
+            keep_last_tip=False,
         )
     )


### PR DESCRIPTION
# Overview

Closes AUTH-1996.

This PR adds a new argument `keep_last_tip` to three liquid class transfer functions (`transfer_with_liquid_class`, `consolidate_with_liquid_class`, and `distribute_with_liquid_class`). If this is set to `True`, the last (or only tip for `never` and `once`) will not be dropped at the end of the high level transfer/consolidate/distribute.  Otherwise, the last tip will be dropped, even if the tip policy is `never`.

In order to maintain existing behavior, this new argument will actually default to `None` to represent it not being set. If the value is `None`, we will default to `keep_last_tip=False` for all tip policies EXCEPT `never`, which will default to `True`. This preserves existing behavior and ensures that if not set, it continues to work as expect and if set, works in a logical and orthogonal way.

## Test Plan and Hands on Testing

Unit tests and integration tests should cover for any regressions, and the following protocol should work as described in the comments

```
requirements = {
	"robotType": "Flex",
	"apiLevel": "2.24"
}

metadata = {
    "protocolName":'Liquid Class keep last tip',
    'author':'Jeremy'
}

def run(protocol_context):
	tiprack = protocol_context.load_labware("opentrons_flex_96_tiprack_1000ul", "C2")
	trash = protocol_context.load_trash_bin('A3')
	pipette_1k = protocol_context.load_instrument("flex_1channel_1000", "right", tip_racks=[tiprack])
	nest_plate = protocol_context.load_labware("nest_96_wellplate_2ml_deep", "D1")
	arma_plate = protocol_context.load_labware("armadillo_96_wellplate_200ul_pcr_full_skirt", "D3")

	water_class = protocol_context.get_liquid_class("water")

	pipette_1k.pick_up_tip()
	
	# Tip should stay on at the end, default behavior
	pipette_1k.transfer_with_liquid_class(
		liquid_class=water_class,
		volume=200,
		source=nest_plate['A1'],
		dest=arma_plate['A1'],
		new_tip="never",
		trash_location=trash,
	)
	# Tip should be dropped at the end
	pipette_1k.transfer_with_liquid_class(
		liquid_class=water_class,
		volume=200,
		source=nest_plate['A1'],
		dest=arma_plate['A1'],
		new_tip="never",
		trash_location=trash,
		keep_last_tip=False,
	)

	# Tip should be dropped at the end, default behavior
	pipette_1k.transfer_with_liquid_class(
		liquid_class=water_class,
		volume=200,
		source=nest_plate['A1'],
		dest=arma_plate['A1'],
		new_tip="once",
		trash_location=trash,
	)
	# Tip should be kept at the end
	pipette_1k.transfer_with_liquid_class(
		liquid_class=water_class,
		volume=200,
		source=nest_plate['A1'],
		dest=arma_plate['A1'],
		new_tip="once",
		trash_location=trash,
		keep_last_tip=True,
	)
	pipette_1k.drop_tip()
```

## Changelog

- add `keep_last_tip` to `transfer_with_liquid_class`, `consolidate_with_liquid_class`, and `distribute_with_liquid_class` to control whether the last (or only) tip used is dropped at the end

## Review requests

Mostly name and doc string related suggestions.

## Risk assessment

Low-medium, theres changes to all three liquid class functions but the scope is pretty small and the changes overall do not complicate the code.