### PR TITLE
fix(app): queue notification refetch if mqtt topic update occurs while refetching

### DIFF
--- a/app/src/resources/__tests__/useNotifyDataReady.test.ts
+++ b/app/src/resources/__tests__/useNotifyDataReady.test.ts
@@ -139,7 +139,6 @@ describe('useNotifyDataReady', () => {
     vi.mocked(appShellListener).mockImplementation(function ({
       callback,
     }): any {
-      // eslint-disable-next-line n/no-callback-literal
       callback({ refetch: true })
     })
     const { rerender, result } = renderHook(() =>
@@ -156,7 +155,6 @@ describe('useNotifyDataReady', () => {
     vi.mocked(appShellListener).mockImplementation(function ({
       callback,
     }): any {
-      // eslint-disable-next-line n/no-callback-literal
       callback({ unsubscribe: true })
     })
     const { rerender, result } = renderHook(() =>
@@ -167,6 +165,105 @@ describe('useNotifyDataReady', () => {
     )
     rerender()
     expect(result.current.shouldRefetch).toEqual(true)
+  })
+
+  it('should handle multiple refetch requests during an active refetch', () => {
+    let capturedCallback: any
+    vi.mocked(appShellListener).mockImplementation(function ({
+      callback,
+    }): any {
+      capturedCallback = callback
+    })
+
+    const mockOnSettled = vi.fn()
+    const { result, rerender } = renderHook(() =>
+      useNotifyDataReady({
+        topic: MOCK_TOPIC,
+        options: { ...MOCK_OPTIONS, onSettled: mockOnSettled },
+      } as any)
+    )
+
+    expect(result.current.shouldRefetch).toEqual(true)
+
+    capturedCallback({ refetch: true })
+    rerender()
+    expect(result.current.shouldRefetch).toEqual(true)
+
+    result.current.queryOptionsNotify.onSettled?.(undefined, null)
+    rerender()
+    expect(result.current.shouldRefetch).toEqual(true)
+
+    result.current.queryOptionsNotify.onSettled?.(undefined, null)
+    rerender()
+    expect(result.current.shouldRefetch).toEqual(false)
+
+    expect(mockOnSettled).toHaveBeenCalledTimes(2)
+  })
+
+  it('should not trigger additional refetch if notification arrives after refetch completes', () => {
+    let capturedCallback: any
+    vi.mocked(appShellListener).mockImplementation(function ({
+      callback,
+    }): any {
+      capturedCallback = callback
+    })
+
+    const mockOnSettled = vi.fn()
+    const { result, rerender } = renderHook(() =>
+      useNotifyDataReady({
+        topic: MOCK_TOPIC,
+        options: { ...MOCK_OPTIONS, onSettled: mockOnSettled },
+      } as any)
+    )
+
+    expect(result.current.shouldRefetch).toEqual(true)
+
+    result.current.queryOptionsNotify.onSettled?.(undefined, null)
+    rerender()
+    expect(result.current.shouldRefetch).toEqual(false)
+
+    capturedCallback({ refetch: true })
+    rerender()
+    expect(result.current.shouldRefetch).toEqual(true)
+
+    result.current.queryOptionsNotify.onSettled?.(undefined, null)
+    rerender()
+    expect(result.current.shouldRefetch).toEqual(false)
+  })
+
+  it('should only queue one additional refetch even with multiple notifications during active refetch', () => {
+    let capturedCallback: any
+    vi.mocked(appShellListener).mockImplementation(function ({
+      callback,
+    }): any {
+      capturedCallback = callback
+    })
+
+    const mockOnSettled = vi.fn()
+    const { result, rerender } = renderHook(() =>
+      useNotifyDataReady({
+        topic: MOCK_TOPIC,
+        options: { ...MOCK_OPTIONS, onSettled: mockOnSettled },
+      } as any)
+    )
+
+    expect(result.current.shouldRefetch).toEqual(true)
+
+    capturedCallback({ refetch: true })
+    capturedCallback({ refetch: true })
+    capturedCallback({ unsubscribe: true })
+    rerender()
+    expect(result.current.shouldRefetch).toEqual(true)
+
+    result.current.queryOptionsNotify.onSettled?.(undefined, null)
+    rerender()
+    expect(result.current.shouldRefetch).toEqual(true)
+
+    result.current.queryOptionsNotify.onSettled?.(undefined, null)
+    rerender()
+    expect(result.current.shouldRefetch).toEqual(false)
+
+    expect(mockOnSettled).toHaveBeenCalledTimes(2)
   })
 
   it('should clean up the listener on dismount', () => {

--- a/app/src/resources/useNotifyDataReady.ts
+++ b/app/src/resources/useNotifyDataReady.ts
@@ -58,6 +58,7 @@ export function useNotifyDataReady<TData, TError = Error>({
   const forcePollingFF = useFeatureFlag('forceHttpPolling')
   const seenHostname = useRef<string | null>(null)
   const [refetch, setRefetch] = useState<HTTPRefetchFrequency>(null)
+  const [pendingRefetch, setPendingRefetch] = useState(false)
   const [
     hasEncounteredNotificationsError,
     setHasEncounteredNotificationsError,
@@ -107,18 +108,32 @@ export function useNotifyDataReady<TData, TError = Error>({
         })
       }
     } else if ('refetch' in data || 'unsubscribe' in data) {
-      setRefetch('once')
+      setRefetch(currentRefetch => {
+        // A refetch is already in progress, mark that we need to do another
+        // one after the current refetch resolves.
+        if (currentRefetch === 'once') {
+          setPendingRefetch(true)
+          return currentRefetch
+        }
+        // No refetch is in progress, start one immediately.
+        else {
+          return 'once'
+        }
+      })
     }
   }, [])
 
   const notifyOnSettled = useCallback(
     (data: TData | undefined, error: TError | null) => {
       if (refetch === 'once') {
-        setRefetch(null)
+        setRefetch(pendingRefetch ? 'once' : null)
+        // We only ever need to queue up one additional refetch to get the latest
+        // data, so it's safe to the pending to false as soon as the refetch settles.
+        setPendingRefetch(false)
       }
       options.onSettled?.(data, error)
     },
-    [refetch, options.onSettled]
+    [refetch, pendingRefetch, options.onSettled]
   )
 
   const isNotifyEnabled =


### PR DESCRIPTION
Closes [RABR-781](https://opentrons.atlassian.net/browse/RABR-781)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

If MQTT informs the app that it should refetch a particular topic while the app is actively refetching that topic, the app doesn't perform an additional refetch after the first refetch completes. This creates a potential race condition.

To fix, the app always needs to refetch again if MQTT tells the app an update is available while the app is in the process of refetching.

This bug is most noticeable on the `robot-server/runs/commands_links` when the commands in question are extremely short lived commands such as `comment` commands. This protocol repros the issue rather readily:

```
from opentrons import protocol_api
# metadata
metadata = {
    'protocolName': "Let's Pause A Lot",
    'author': '',
    'description': '',
}
requirements = {
    "robotType": "Flex",
    "apiLevel": "2.22",
}
def run(protocol: protocol_api.ProtocolContext):
    tiprack1 = protocol.load_labware('opentrons_flex_96_tiprack_1000ul', 'C3')
    instrument = protocol.load_instrument('flex_1channel_1000', mount = 'left', tip_racks=[tiprack1])

    for i in range(1, 10):
        protocol.comment("                          ")
        protocol.comment("**************************")
        protocol.comment("         Incubation       ")
        protocol.comment("**************************")
        protocol.comment("                          ")

        protocol.pause(
            """Starting Detection incubation on Flex. Please add seal to plate.
            Heater-shaker incubation will begin afterwards."""
        )
        instrument.pick_up_tip(tiprack1["A1"])
        instrument.return_tip()
```

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
Reran the above protocol multiple times:
- On the network tab, when the race condition would have occurred, the app correctly performed an additional refetch and fetched the latest command. Ex, if the latest command returned from an app fetch was a "comment" command, a command that persists for only milliseconds, the app would immediately refetch and be returned a "pause" command.
- Previously, the bug would happen maybe 1/2 pause screens. With changes, the issue did not occur once after multiple protocol run-throughs.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed intervention modals on the desktop app/ODD not always appearing when the robot emits related commands.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests

- I'm targeting `edge` with these changes given the risk level, but let me know if we want them elsewhere. (After some convos, we are targeting 8.5 for this fix).

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low-med: This change is only additive. If anything in the app was dependent on stale data, this bug was still a race condition at the end of the day, and we would have visibly seen the unwanted behavior by now. It's still a networking change though, so there's inherent risk involved.
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RABR-781]: https://opentrons.atlassian.net/browse/RABR-781?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ