### PR TITLE
fix(api): remove invalid errors for lc positioning check

### DIFF
--- a/api/src/opentrons/protocols/advanced_control/transfers/transfer_liquid_utils.py
+++ b/api/src/opentrons/protocols/advanced_control/transfers/transfer_liquid_utils.py
@@ -32,18 +32,11 @@ def raise_if_location_inside_liquid(
 ) -> None:
     """Raise an error if the location in question would be inside the liquid.
 
-    This checker will raise an error if:
-    - the location in question is below the target well location during aspirate/dispense or,
-    - if we can find the liquid height AND the location in question is below this height.
-      If we can't find the liquid height, then we simply log a warning and no error is raised.
+    This checker will raise an error if we can find the liquid height
+    AND the location in question is below this height.
+
+    If we can't find the liquid height, then we simply log the details and no error is raised.
     """
-    if location.point.z < well_location.point.z:
-        raise RuntimeError(
-            f"Received {location_check_descriptors.location_type} location of {location}"
-            f" and {location_check_descriptors.pipetting_action} location of {well_location}."
-            f" {location_check_descriptors.location_type.capitalize()} location z should not be lower"
-            f" than the {location_check_descriptors.pipetting_action} location z."
-        )
     try:
         liquid_height_from_bottom = well_core.current_liquid_height()
     except LiquidHeightUnknownError:
@@ -59,8 +52,8 @@ def raise_if_location_inside_liquid(
         # We could raise an error here but that would restrict the use of
         # liquid classes-based transfer to only when LPD is enabled or when liquids are
         # loaded in protocols using `load_liquid`. This can be quite restrictive
-        # so we will not raise but just log a warning.
-        logger.warning(
+        # so we will not raise but just log the details.
+        logger.info(
             f"Could not verify height of liquid in well {well_core.get_display_name()}, either"
             f" because the liquid in this well has not been probed or because"
             f" liquid was not loaded in this well using `load_liquid`."

--- a/api/tests/opentrons/protocols/advanced_control/transfers/test_transfer_liquid_utils.py
+++ b/api/tests/opentrons/protocols/advanced_control/transfers/test_transfer_liquid_utils.py
@@ -144,75 +144,6 @@ def mock_384_well_labware(decoy: Decoy) -> Labware:
 
 
 @pytest.mark.parametrize(
-    argnames=[
-        "pip_location",
-        "well_location",
-        "location_descriptors",
-        "expected_raise",
-    ],
-    argvalues=[
-        (
-            Location(point=Point(4, 5, 6), labware=None),
-            Location(point=Point(1, 1, 1), labware=None),
-            LocationCheckDescriptors(
-                location_type="submerge start",
-                pipetting_action="aspirate",
-            ),
-            does_not_raise(),
-        ),
-        (
-            Location(point=Point(4, 5, 6), labware=None),
-            Location(point=Point(5, 6, 7), labware=None),
-            LocationCheckDescriptors(
-                location_type="submerge start",
-                pipetting_action="aspirate",
-            ),
-            pytest.raises(
-                RuntimeError,
-                match="Received submerge start location of Location\\(point=Point\\(x=4, y=5, z=6\\), labware=, meniscus_tracking=None\\)"
-                " and aspirate location of Location\\(point=Point\\(x=5, y=6, z=7\\), labware=, meniscus_tracking=None\\)."
-                " Submerge start location z should not be lower than the aspirate location z.",
-            ),
-        ),
-        (
-            Location(point=Point(4, 5, 6), labware=None),
-            Location(point=Point(5, 6, 7), labware=None),
-            LocationCheckDescriptors(
-                location_type="retract end",
-                pipetting_action="dispense",
-            ),
-            pytest.raises(
-                RuntimeError,
-                match="Received retract end location of Location\\(point=Point\\(x=4, y=5, z=6\\), labware=, meniscus_tracking=None\\)"
-                " and dispense location of Location\\(point=Point\\(x=5, y=6, z=7\\), labware=, meniscus_tracking=None\\)."
-                " Retract end location z should not be lower than the dispense location z.",
-            ),
-        ),
-    ],
-)
-def test_raise_only_if_pip_location_below_target(
-    decoy: Decoy,
-    pip_location: Location,
-    well_location: Location,
-    location_descriptors: LocationCheckDescriptors,
-    expected_raise: ContextManager[Any],
-) -> None:
-    """It should raise appropriately based on heights of given location and target location."""
-    well_core = decoy.mock(cls=WellCore)
-    logger = decoy.mock(cls=Logger)
-    decoy.when(well_core.current_liquid_height()).then_return(0)
-    decoy.when(well_core.get_bottom(0)).then_return(Point(0, 0, 0))
-    with expected_raise:
-        raise_if_location_inside_liquid(
-            location=pip_location,
-            well_location=well_location,
-            well_core=well_core,
-            location_check_descriptors=location_descriptors,
-            logger=logger,
-        )
-
-
-@pytest.mark.parametrize(
     argnames=["liquid_height", "pip_location", "well_bottom", "expected_raise"],
     argvalues=[
         (
@@ -304,7 +235,7 @@ def test_log_warning_if_pip_location_cannot_be_validated(
         logger=logger,
     )
     decoy.verify(
-        logger.warning(
+        logger.info(
             "Could not verify height of liquid in well Well A1 of test_labware, either"
             " because the liquid in this well has not been probed or because"
             " liquid was not loaded in this well using `load_liquid`."


### PR DESCRIPTION
Replaces #18585

# Overview

**About the error removal**

Until now we have assumed, and pushed for the assumption, that a submerge start point and retract end point should be above the aspirate & dispense locations of the transfer properties specified in a liquid class. This requirement was mainly added to avoid getting into situations where the submerge start location or retract end location could end up being inside the liquid, especially when we have no idea of the liquid's height inside well. 

The above situation was a concern because it could mean aspirating liquid by mistake when trying to aspirate air gaps or move the plunger to prepare for aspiration at either the submerge start point or retract end point. But over the course, we have changed this behavior so that `prepareForAspirate` and `addAirGap` both happen above the well, always (#18653, #17800). So we no longer truly need to enforce the positioning requirement of submerge start & retract end.

Additionally, consider this example-
An LC-based transfer that wants to set its dispense location as 5mm below the liquid meniscus. Note that this is 5mm below where the meniscus would be at the **end** of the dispense. Let's assume this location is `Point(10, 10, 10)`.
Assuming the destination well is empty in the beginning, one could set their submerge location to be `Point(10, 10, 8)` and that would be totally fine since this location would actually not be inside liquid. The tip should be allowed to start at `(10, 10, 8)` and then move up to `(10, 10, 10)` to dispense. But the current check didn't allow that. 
There's a couple of more examples like this where a submerge/ retract point might lie below the aspirate/dispense points without causing any real issues but our code won't allow it.

Because of these reasons we want to remove this check that looks for order of these positions.
We will still be raising errors for when submerge start or retract end positions lie inside the liquid.

**About log level change**

Internal users complained that the warning is too verbose and happens way too often and it shows up in the default simulation output. So I'm changing this to an `INFO` level so that it won't show up in the output but will still be available in the logs as useful info.

## Test Plan and Hands on Testing

- Updated tests. On-robot testing not required

## Review requests

Do you agree with the two decisions above?

## Risk assessment

None
