### PR TITLE
fix(api,app): Block protocol start if the Flex Stacker is not homed or shuttle is missing + home stacker from Desktop app.

### DIFF
--- a/api/src/opentrons/hardware_control/modules/flex_stacker.py
+++ b/api/src/opentrons/hardware_control/modules/flex_stacker.py
@@ -253,21 +253,11 @@ class FlexStacker(mod_abc.AbstractModule):
     def is_simulated(self) -> bool:
         return isinstance(self._driver, SimulatingDriver)
 
-    def _get_platform_live_data(self) -> PlatformState:
-        """Get the platform state for live data."""
-        if self.initialized and self.platform_state == PlatformState.UNKNOWN:
-            # If the platform state is unknown, we need to poll it
-            if self.limit_switch_status[StackerAxis.X] != StackerAxisState.UNKNOWN:
-                # Set flag so the reader can poll the limit switch state
-                self._reader.set_refresh_state()
-                return PlatformState.MISSING
-        return self.platform_state
-
     @property
     def live_data(self) -> LiveData:
         data: FlexStackerData = {
             "latchState": self.latch_state.value,
-            "platformState": self._get_platform_live_data().value,
+            "platformState": self.platform_state.value,
             "hopperDoorState": self.hopper_door_state.value,
             "installDetected": self.install_detected,
             "errorDetails": self._reader.error,
@@ -751,7 +741,14 @@ class FlexStackerReader(Reader):
     async def get_platform_sensor_state(self) -> None:
         """Get the platform state."""
         status = await self._driver.get_platform_status()
-        self.platform_state = PlatformState.from_status(status)
+        platform_state = PlatformState.from_status(status)
+        if self.initialized and platform_state == PlatformState.UNKNOWN:
+            # If the platform state is unknown but the X axis is known,
+            # the platform is missing.
+            await self.get_limit_switch_status()
+            if self.limit_switch_status[StackerAxis.X] != StackerAxisState.UNKNOWN:
+                platform_state = PlatformState.MISSING
+        self.platform_state = platform_state
 
     async def get_door_closed(self) -> None:
         """Check if the hopper door is closed."""

--- a/api/src/opentrons/hardware_control/modules/flex_stacker.py
+++ b/api/src/opentrons/hardware_control/modules/flex_stacker.py
@@ -258,6 +258,8 @@ class FlexStacker(mod_abc.AbstractModule):
         if self.initialized and self.platform_state == PlatformState.UNKNOWN:
             # If the platform state is unknown, we need to poll it
             if self.limit_switch_status[StackerAxis.X] != StackerAxisState.UNKNOWN:
+                # Set flag so the reader can poll the limit switch state
+                self._reader.set_refresh_state()
                 return PlatformState.MISSING
         return self.platform_state
 
@@ -702,6 +704,7 @@ class FlexStackerReader(Reader):
         self.hopper_door_closed = False
         self.initialized = False
         self.installation_detected = False
+        self._refresh_state = False
         self._initialized_callback: Optional[Callable[[], Awaitable[None]]] = None
 
     def set_initialized_callback(self, callback: Callable[[], Awaitable[None]]) -> None:
@@ -711,7 +714,7 @@ class FlexStackerReader(Reader):
     async def read(self) -> None:
         await self.get_door_closed()
         await self.get_platform_sensor_state()
-        if not self.initialized:
+        if not self.initialized or self._refresh_state:
             initialized = True
             await self.get_installation_detected()
             await self.get_limit_switch_status()
@@ -722,8 +725,9 @@ class FlexStackerReader(Reader):
                     self.tof_sensor_status[sensor] = status
                     initialized &= status.ok
 
+            self._refresh_state = False
             # We are done initializing, sync the led state
-            if initialized:
+            if not self.initialized and initialized:
                 self.initialized = True
                 if self._initialized_callback:
                     await self._initialized_callback()
@@ -760,6 +764,10 @@ class FlexStackerReader(Reader):
         """Check if the stacker install detect is set."""
         detected = await self._driver.get_installation_detected()
         self.installation_detected = detected
+
+    def set_refresh_state(self) -> None:
+        """Tell the reader to refresh all states, even ones that arent polled."""
+        self._refresh_state = True
 
     def on_error(self, exception: Exception) -> None:
         self._driver.reset_serial_buffers()

--- a/api/tests/opentrons/hardware_control/modules/test_hc_flexstacker.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_flexstacker.py
@@ -182,7 +182,7 @@ async def test_platform_state(
     # update the cached value
     await subject._reader.get_limit_switch_status()
     await subject._reader.get_platform_sensor_state()
-    assert subject._get_platform_live_data() == expected
+    assert subject.platform_state == expected
 
 
 @pytest.mark.parametrize(
@@ -206,7 +206,7 @@ async def test_platform_state_unknown(
     # update the value
     await subject._reader.get_limit_switch_status()
     await subject._reader.get_platform_sensor_state()
-    assert subject._get_platform_live_data() == expected
+    assert subject.platform_state == expected
 
 
 @pytest.mark.parametrize(

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunSetup.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunSetup.tsx
@@ -277,8 +277,7 @@ export function ProtocolRunSetup({
         completeText: isFlex
           ? t('modules_and_fixtures_ready')
           : t('modules_ready'),
-        incompleteText:
-          isFlex && hasModules ? t('calibration_needed') : t('action_needed'),
+        incompleteText: t('action_needed'),
         missingHardware: isMissingModule || isFixtureMismatch,
         missingHardwareText: t('action_needed'),
         incompleteElement: null,

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/SetupModuleAndDeck/SetupModulesList.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/SetupModuleAndDeck/SetupModulesList.tsx
@@ -43,7 +43,6 @@ import { StatusLabel } from '/app/atoms/StatusLabel'
 import {
   getFlexStackerPrepCommands,
   getModuleImage,
-  ModulePrepCommandsType,
 } from '/app/local-resources/modules'
 import { LocationConflictModal } from '/app/organisms/LocationConflictModal'
 import { ModuleSetupModal } from '/app/organisms/ModuleCard/ModuleSetupModal'
@@ -65,6 +64,7 @@ import type {
   DeckDefinition,
   ModuleModel,
 } from '@opentrons/shared-data'
+import type { ModulePrepCommandsType } from '/app/local-resources/modules'
 import type { AttachedModule } from '/app/redux/modules/types'
 import type {
   ModuleRenderInfoForProtocol,
@@ -284,9 +284,7 @@ export function ModulesListItem({
     attachedModuleMatch.moduleType !== FLEX_STACKER_MODULE_TYPE &&
     attachedModuleMatch.moduleOffset?.last_modified == null
 
-  console.log(attachedModuleMatch?.data)
-  console.log(needsCalibration, stackerShuttleMissing, stackerNeedsHome)
-  if (needsCalibration || stackerShuttleMissing) {
+  if (needsCalibration) {
     renderModuleStatus = (
       <>
         <TertiaryButton
@@ -316,6 +314,15 @@ export function ModulesListItem({
           {t('home_stacker')}
         </TertiaryButton>
       </>
+    )
+  } else if (stackerShuttleMissing) {
+    renderModuleStatus = (
+      <StatusLabel
+        status={t('missing_shuttle')}
+        backgroundColor={COLORS.yellow30}
+        iconColor={COLORS.yellow60}
+        textColor={COLORS.yellow60}
+      />
     )
   } else if (attachedModuleMatch == null) {
     renderModuleStatus = (

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/SetupModuleAndDeck/SetupModulesList.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/SetupModuleAndDeck/SetupModulesList.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import map from 'lodash/map'
 import { css } from 'styled-components'
 
+import { CommandData } from '@opentrons/api-client'
 import {
   BORDERS,
   Box,
@@ -39,12 +40,17 @@ import {
 
 import { TertiaryButton } from '/app/atoms/buttons'
 import { StatusLabel } from '/app/atoms/StatusLabel'
-import { getModuleImage } from '/app/local-resources/modules'
+import {
+  getFlexStackerPrepCommands,
+  getModuleImage,
+  ModulePrepCommandsType,
+} from '/app/local-resources/modules'
 import { LocationConflictModal } from '/app/organisms/LocationConflictModal'
 import { ModuleSetupModal } from '/app/organisms/ModuleCard/ModuleSetupModal'
 import { ModuleWizardFlows } from '/app/organisms/ModuleWizardFlows'
 import { useIsFlex, useRobot } from '/app/redux-resources/robots'
 import {
+  useChainLiveCommands,
   useModuleRenderInfoForProtocolById,
   useRunCalibrationStatus,
   useUnmatchedModulesForProtocol,
@@ -85,6 +91,7 @@ export const SetupModulesList = (props: SetupModulesListProps): JSX.Element => {
   const deckDef = getDeckDefFromRobotType(robotModel ?? FLEX_ROBOT_TYPE)
 
   const calibrationStatus = useRunCalibrationStatus(robotName, runId)
+  const { chainLiveCommands } = useChainLiveCommands()
 
   const moduleModels = map(
     moduleRenderInfoForProtocolById,
@@ -129,6 +136,7 @@ export const SetupModulesList = (props: SetupModulesListProps): JSX.Element => {
               }
               isFlex={isFlex}
               calibrationStatus={calibrationStatus}
+              chainLiveCommands={chainLiveCommands}
               conflictedFixture={conflictedFixture}
               deckDef={deckDef}
               robotName={robotName}
@@ -148,6 +156,10 @@ interface ModulesListItemProps {
   heaterShakerModuleFromProtocol: ModuleRenderInfoForProtocol | null
   isFlex: boolean
   calibrationStatus: ProtocolCalibrationStatus
+  chainLiveCommands: (
+    commands: ModulePrepCommandsType[],
+    continuePastCommandFailure: boolean
+  ) => Promise<CommandData[]>
   deckDef: DeckDefinition
   conflictedFixture: CutoutConfig | null
   robotName: string
@@ -160,6 +172,7 @@ export function ModulesListItem({
   attachedModuleMatch,
   isFlex,
   calibrationStatus,
+  chainLiveCommands,
   conflictedFixture,
   deckDef,
   robotName,
@@ -179,8 +192,18 @@ export function ModulesListItem({
 
   const [showModuleWizard, setShowModuleWizard] = useState<boolean>(false)
 
-  const handleCalibrateClick = (): void => {
+  const handleSetupModuleClick = (): void => {
     setShowModuleWizard(true)
+  }
+
+  const handleHomeStackerClick = (): void => {
+    if (attachedModuleMatch?.moduleType === FLEX_STACKER_MODULE_TYPE) {
+      chainLiveCommands(
+        getFlexStackerPrepCommands(attachedModuleMatch),
+        // if the close latch command fails, we still want to home the shuttle
+        true
+      )
+    }
   }
 
   const [targetProps, tooltipProps] = useHoverTooltip({
@@ -244,6 +267,12 @@ export function ModulesListItem({
       textColor={COLORS.green60}
     />
   )
+  const stackerNeedsHome =
+    attachedModuleMatch?.moduleType === FLEX_STACKER_MODULE_TYPE
+      ? attachedModuleMatch?.data.platformState === 'unknown' ||
+        attachedModuleMatch?.data.platformState === 'retracted' ||
+        attachedModuleMatch?.data.latchState !== 'closed'
+      : false
   const stackerShuttleMissing =
     attachedModuleMatch?.moduleType === FLEX_STACKER_MODULE_TYPE
       ? attachedModuleMatch?.data.platformState === 'missing'
@@ -255,12 +284,31 @@ export function ModulesListItem({
     attachedModuleMatch.moduleType !== FLEX_STACKER_MODULE_TYPE &&
     attachedModuleMatch.moduleOffset?.last_modified == null
 
-  if (needsCalibration || stackerShuttleMissing) {
+  if (stackerNeedsHome) {
     renderModuleStatus = (
       <>
         <TertiaryButton
           {...targetProps}
-          onClick={handleCalibrateClick}
+          onClick={handleHomeStackerClick}
+          width="max-content"
+          disabled={!calibrationStatus?.complete || isModuleTooHot}
+        >
+          {t('home_stacker')}
+        </TertiaryButton>
+        {(!calibrationStatus?.complete && calibrationStatus?.reason != null) ||
+        isModuleTooHot ? (
+          <Tooltip tooltipProps={tooltipProps}>
+            {calibrateDisabledReason}
+          </Tooltip>
+        ) : null}
+      </>
+    )
+  } else if (needsCalibration || stackerShuttleMissing) {
+    renderModuleStatus = (
+      <>
+        <TertiaryButton
+          {...targetProps}
+          onClick={handleSetupModuleClick}
           width="max-content"
           disabled={!calibrationStatus?.complete || isModuleTooHot}
         >

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/SetupModuleAndDeck/SetupModulesList.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/SetupModuleAndDeck/SetupModulesList.tsx
@@ -3,7 +3,6 @@ import { useTranslation } from 'react-i18next'
 import map from 'lodash/map'
 import { css } from 'styled-components'
 
-import { CommandData } from '@opentrons/api-client'
 import {
   BORDERS,
   Box,
@@ -59,6 +58,7 @@ import { getModuleTooHot } from '/app/transformations/modules'
 import { OT2MultipleModulesHelp } from './OT2MultipleModulesHelp'
 import { UnMatchedModuleWarning } from './UnMatchedModuleWarning'
 
+import type { CommandData } from '@opentrons/api-client'
 import type {
   CutoutConfig,
   DeckDefinition,

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/SetupModuleAndDeck/SetupModulesList.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/SetupModuleAndDeck/SetupModulesList.tsx
@@ -284,26 +284,9 @@ export function ModulesListItem({
     attachedModuleMatch.moduleType !== FLEX_STACKER_MODULE_TYPE &&
     attachedModuleMatch.moduleOffset?.last_modified == null
 
-  if (stackerNeedsHome) {
-    renderModuleStatus = (
-      <>
-        <TertiaryButton
-          {...targetProps}
-          onClick={handleHomeStackerClick}
-          width="max-content"
-          disabled={!calibrationStatus?.complete || isModuleTooHot}
-        >
-          {t('home_stacker')}
-        </TertiaryButton>
-        {(!calibrationStatus?.complete && calibrationStatus?.reason != null) ||
-        isModuleTooHot ? (
-          <Tooltip tooltipProps={tooltipProps}>
-            {calibrateDisabledReason}
-          </Tooltip>
-        ) : null}
-      </>
-    )
-  } else if (needsCalibration || stackerShuttleMissing) {
+  console.log(attachedModuleMatch?.data)
+  console.log(needsCalibration, stackerShuttleMissing, stackerNeedsHome)
+  if (needsCalibration || stackerShuttleMissing) {
     renderModuleStatus = (
       <>
         <TertiaryButton
@@ -320,6 +303,18 @@ export function ModulesListItem({
             {calibrateDisabledReason}
           </Tooltip>
         ) : null}
+      </>
+    )
+  } else if (stackerNeedsHome) {
+    renderModuleStatus = (
+      <>
+        <TertiaryButton
+          {...targetProps}
+          onClick={handleHomeStackerClick}
+          width="max-content"
+        >
+          {t('home_stacker')}
+        </TertiaryButton>
       </>
     )
   } else if (attachedModuleMatch == null) {

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/SetupModuleAndDeck/__tests__/SetupModulesList.test.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/SetupModuleAndDeck/__tests__/SetupModulesList.test.tsx
@@ -19,6 +19,7 @@ import {
   mockMagneticModule as mockMagneticModuleFixture,
 } from '/app/redux/modules/__fixtures__/index'
 import {
+  useChainLiveCommands,
   useModuleRenderInfoForProtocolById,
   useRunCalibrationStatus,
   useUnmatchedModulesForProtocol,
@@ -86,12 +87,15 @@ const render = (props: ComponentProps<typeof SetupModulesList>) => {
 }
 
 describe('SetupModulesList', () => {
+  let mockChainLiveCommands = vi.fn()
   let props: ComponentProps<typeof SetupModulesList>
   beforeEach(() => {
     props = {
       robotName: ROBOT_NAME,
       runId: RUN_ID,
     }
+    mockChainLiveCommands = vi.fn()
+    mockChainLiveCommands.mockResolvedValue(null)
     when(vi.mocked(useRobot))
       .calledWith(ROBOT_NAME)
       .thenReturn({ robotModel: FLEX_ROBOT_TYPE } as DiscoveredRobot)
@@ -111,6 +115,9 @@ describe('SetupModulesList', () => {
     vi.mocked(ModuleWizardFlows).mockReturnValue(
       <div>mock ModuleWizardFlows</div>
     )
+    vi.mocked(useChainLiveCommands).mockReturnValue({
+      chainLiveCommands: mockChainLiveCommands,
+    } as any)
     vi.mocked(LocationConflictModal).mockReturnValue(
       <div>mock location conflict modal</div>
     )

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/__tests__/ProtocolRunSetup.test.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/__tests__/ProtocolRunSetup.test.tsx
@@ -332,7 +332,7 @@ describe('ProtocolRunSetup', () => {
       expect(screen.getAllByText('Instruments attached').length).toEqual(1)
     })
 
-    it('renders calibration needed if robot is Flex and modules are not calibrated', () => {
+    it('renders action needed if modules need to be calibrated, homed, etc.', () => {
       when(vi.mocked(useIsFlex)).calledWith(ROBOT_NAME).thenReturn(true)
       when(vi.mocked(useModuleCalibrationStatus))
         .calledWith(ROBOT_NAME, RUN_ID)
@@ -340,7 +340,7 @@ describe('ProtocolRunSetup', () => {
 
       render()
       screen.getByText('Deck Hardware')
-      screen.getByText('Calibration needed')
+      screen.getByText('Action needed')
     })
 
     it('does not render calibration element if robot is OT-2', () => {

--- a/app/src/resources/runs/useModuleCalibrationStatus.ts
+++ b/app/src/resources/runs/useModuleCalibrationStatus.ts
@@ -22,8 +22,7 @@ export function useModuleCalibrationStatus(
     useModuleRenderInfoForProtocolById(runId),
     moduleRenderInfo =>
       moduleRenderInfo.moduleDef.moduleType === MAGNETIC_BLOCK_TYPE ||
-      moduleRenderInfo.moduleDef.moduleType === ABSORBANCE_READER_TYPE ||
-      moduleRenderInfo.moduleDef.moduleType === FLEX_STACKER_MODULE_TYPE
+      moduleRenderInfo.moduleDef.moduleType === ABSORBANCE_READER_TYPE
   )
 
   // only check module calibration for Flex
@@ -39,9 +38,16 @@ export function useModuleCalibrationStatus(
     key => moduleRenderInfoForProtocolById[key]
   )
   if (
-    moduleData.some(
-      m => m.attachedModuleMatch?.moduleOffset?.last_modified == null
-    )
+    moduleData.some(m => {
+      if (m.attachedModuleMatch?.moduleType === FLEX_STACKER_MODULE_TYPE) {
+        return (
+          m.attachedModuleMatch?.data.platformState !== 'extended' ||
+          m.attachedModuleMatch?.data.latchState !== 'closed'
+        )
+      } else {
+        return m.attachedModuleMatch?.moduleOffset?.last_modified == null
+      }
+    })
   ) {
     return { complete: false, reason: 'calibrate_module_failure_reason' }
   } else {


### PR DESCRIPTION
# Overview

The Flex stacker Platform might not always be at the homed (gripper) position, which could cause a problem when loading labware on a stacker occupied column 4, since the labware would not be physically where we expected. So let's ensure we can't start the protocol if the relevant stackers are not homed or the shuttle is missing. The Platform missing status coming from the backend was also wrong, let's also fix that.

## Stacker needs home
<img width="929" alt="Screenshot 2025-06-24 at 11 18 35 AM" src="https://github.com/user-attachments/assets/5d276fc9-b364-4d99-b138-0cd36afd1387" />

## Stacker Missing shuttle

<img width="915" alt="Screenshot 2025-06-24 at 12 09 31 PM" src="https://github.com/user-attachments/assets/2fb9629e-ba16-469a-9170-c622c9b7ebdd" />

## Module needs setup

<img width="925" alt="Screenshot 2025-06-24 at 10 13 14 AM" src="https://github.com/user-attachments/assets/084c83f5-34ab-4fa2-af60-da2772eb2b34" />

## Modules and fixtures ready

<img width="920" alt="Screenshot 2025-06-24 at 12 09 57 PM" src="https://github.com/user-attachments/assets/0fa68c6b-ba7c-455e-90b8-156cae8ac986" />


Closes: [EXEC-1563](https://opentrons.atlassian.net/browse/EXEC-1563) [EXEC-1572](https://opentrons.atlassian.net/browse/EXEC-1572)

## Test Plan and Hands on Testing

- [x] Make sure the "Play" or "Start Protocol" button is disabled on the ODD and Desktop app if a stacker needs homing or the shuttle is missing.
- [x] Make sure that the "Home Stacker" button is shown in protocol setup for the Desktop App and ODD if the stacker needs to be homed.
- [x] Make sure the "Action needed" button is shown in protocol setup on the desktop app if the shuttle is missing
- [x] Make sure the "missing-shuttle" status is shown in protocol setup on the ODD if the shuttle is missing

## Changelog

- Move `PlatformState.MISSING` logic to the `get_platform_sensor_state` method of the FlexStacker Reader, since we need up-to-date limit switch status
- Added 'set_refresh_state' to the FlexStacker module in the API to tell the reader when to refetch states not polled, like limit switch status, TOF sensors, etc.
- Change "Calibration needed" copy in deck configuration to "Action needed" per design
- Added "Home Stacker" button to the protocol setup of the desktop app if the flex stacker needs to home.
- Block protocol start if the flex stacker is not homed or the platform is not extended

## Review requests

- Makes sense?

## Risk assessment

Low, unreleased.

[EXEC-1563]: https://opentrons.atlassian.net/browse/EXEC-1563?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EXEC-1572]: https://opentrons.atlassian.net/browse/EXEC-1572?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ