### PR TITLE
docs(api): resolve TODO for 2.23 changes to InstrumentContext.name

### DIFF
--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -2607,10 +2607,9 @@ class InstrumentContext(publisher.CommandPublisher):
         From API version 2.15 to 2.22, this property returned an internal name for Flex
         pipettes. (e.g., ``"p1000_single_flex"``).
 
-        .. TODO uncomment when 2.23 is ready
-          In API version 2.23 and later, this property returns the Python Protocol API
-          :ref:`load name <new-pipette-models>` of Flex pipettes (e.g.,
-          ``"flex_1channel_1000"``).
+        In API version 2.23 and later, this property returns the Python Protocol API
+        :ref:`load name <new-pipette-models>` of Flex pipettes (e.g.,
+        ``"flex_1channel_1000"``).
         """
         return self._core.get_pipette_name()
 


### PR DESCRIPTION
# Overview

See here's the thing about TODOs: you actually have _to do_ them.

thx @ddcc4 

## Test Plan and Hands on Testing

there's [a sandbox](http://sandbox.docs.opentrons.com/pipette-name-todo-finally/v2/new_protocol_api.html#opentrons.protocol_api.InstrumentContext.name)

## Changelog

uncommented the thing we were supposed to a while ago!

## Risk assessment

negative