### PR TITLE
fix(protocol-designer): do not close edit metadata modal on outside c…

### DIFF
--- a/protocol-designer/src/components/organisms/EditProtocolMetadataModal/index.tsx
+++ b/protocol-designer/src/components/organisms/EditProtocolMetadataModal/index.tsx
@@ -54,7 +54,6 @@ export function EditProtocolMetadataModal(
       marginLeft="0"
       title={t('shared:edit_protocol_metadata')}
       type="info"
-      closeOnOutsideClick
       onClose={onClose}
       childrenPadding={SPACING.spacing24}
       footer={


### PR DESCRIPTION
…lick

closes RQA-4253

# Overview

This bug is actually expected behavior but addressing it since i feel like users are likely to run into it.

## Test Plan and Hands on Testing

upload attached protocol. go to edit the protocol name and highlight over the input for the protocol name, make sure your mouse goes ouside of the modal. 

see that the modal does not close.

[RQA4255.json](https://github.com/user-attachments/files/20867221/RQA4255.json)

## Changelog

- remove the ability to close modal by clicking outside.

## Risk assessment

low
