### PR TITLE
fix(protocol-designer): timeline configurations padding adjustment

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/Configurations.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/Configurations.tsx
@@ -28,8 +28,7 @@ export function Configurations({
     <>
       <Flex
         gridGap={SPACING.spacing8}
-        paddingX={SPACING.spacing12}
-        paddingTop={SPACING.spacing12}
+        padding={SPACING.spacing12}
         flexDirection={DIRECTION_COLUMN}
       >
         <StyledText


### PR DESCRIPTION
closes RQA-4288

# Overview

`Configuration` section should have 12px padding on all sides

<img width="250" alt="Screenshot 2025-06-23 at 10 43 23" src="https://github.com/user-attachments/assets/1abbbc66-3f68-4fca-844f-43bf0bce1b38" />

## Test Plan and Hands on Testing

check that it matches designs from the ticket.

## Changelog

- fix padding

## Risk assessment

low