### PR TITLE
feat(protocol-designer): wire up deck_configuration i18n file

### DIFF
--- a/protocol-designer/src/assets/localization/en/index.ts
+++ b/protocol-designer/src/assets/localization/en/index.ts
@@ -3,6 +3,7 @@ import application from './application.json'
 import button from './button.json'
 import card from './card.json'
 import context_menu from './context_menu.json'
+import deck_configuration from './deck_configuration.json'
 import deck from './deck.json'
 import feature_flags from './feature_flags.json'
 import form from './form.json'
@@ -25,6 +26,7 @@ export const en = {
   card,
   context_menu,
   deck,
+  deck_configuration,
   feature_flags,
   form,
   liquids,


### PR DESCRIPTION
# Overview

Wire up the `deck_configuration` i18n strings to work for deck configurator in PD.

## Test Plan and Hands on Testing

Go through deck setup and see that the fixtures to add to the deck map have correct copy.

## Changelog

- export deck config i18n file

## Risk assessment

low