### PR TITLE
Flex stacker pvt qc cycle test

### DIFF
--- a/hardware-testing/hardware_testing/modules/flex_stacker_cycle_qc/__init__.py
+++ b/hardware-testing/hardware_testing/modules/flex_stacker_cycle_qc/__init__.py
@@ -1,0 +1,1 @@
+"""FLEX Stacker Cycle QC Test."""

--- a/hardware-testing/hardware_testing/modules/flex_stacker_cycle_qc/__main__.py
+++ b/hardware-testing/hardware_testing/modules/flex_stacker_cycle_qc/__main__.py
@@ -1,0 +1,98 @@
+"""FLEX Stacker Cycle QC Test."""
+from os import environ
+from serial.tools.list_ports import comports  # type: ignore[import]
+STACKER_VID = 0x483
+STACKER_PID = 0xEF24
+
+# NOTE: this is required to get WIFI test to work
+if "OT_SYSTEM_VERSION" not in environ:
+    environ["OT_SYSTEM_VERSION"] = "0.0.0"
+
+import argparse
+import asyncio
+import subprocess
+from pathlib import Path
+from typing import Tuple
+
+from hardware_testing.data import ui
+from hardware_testing.data.csv_report import CSVReport
+
+from .config import TestSection, TestConfig, build_report, TESTS
+from opentrons.hardware_control.modules import FlexStacker
+
+async def build_stacker_report(
+    is_simulating: bool, port: str = ""
+) -> Tuple[CSVReport, FlexStacker]:
+    """Report setup for FLEX Stacker Cycle QC Test."""
+    test_name = Path(__file__).parent.name.replace("_", "-")
+    ui.print_title(test_name.upper())
+
+    stacker = await FlexStacker.build(port=port,
+                                usb_port=None,
+                                execution_manager=None,
+                                loop=asyncio.get_running_loop(),
+                                simulating=is_simulating)
+
+
+    report = build_report(test_name)
+    report.set_operator(
+        "simulating" if is_simulating else input("enter OPERATOR name: ")
+    )
+    return report, stacker
+
+
+async def _main(cfg: TestConfig) -> None:
+    # BUILD REPORT
+    port = []
+    for i in comports():
+        if i.vid == STACKER_VID and i.pid == STACKER_PID:
+            port.append(i.device)
+            break
+    assert port, "could not find connected FLEX Stacker"
+    report, stacker = await build_stacker_report(cfg.simulate, port=port[0])
+
+    if not cfg.simulate:
+        print("Stopping the robot server")
+        subprocess.run(["systemctl stop opentrons-robot-server"], shell=True)
+
+    device_info = await stacker._driver.get_device_info()
+    report.set_tag(device_info.sn if device_info.sn else "UNKNOWN")
+
+    # RUN TESTS
+    try:
+        for section, test_run in cfg.tests.items():
+            ui.print_title(section.value)
+            await test_run(stacker, report, section.value)
+    except Exception as e:
+        ui.print_error(f"An error occurred: {e}")
+
+    # SAVE REPORT
+    ui.print_title("DONE")
+    report.save_to_disk()
+    report.print_results()
+
+    # Restart the robot server
+    if not cfg.simulate:
+        print("Starting the robot server")
+        subprocess.run(["systemctl restart opentrons-robot-server &"], shell=True)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--simulate", action="store_true")
+    # add each test-section as a skippable argument (eg: --skip-connectivity)
+    for s in TestSection:
+        parser.add_argument(f"--skip-{s.value.lower()}", action="store_true")
+        parser.add_argument(f"--only-{s.value.lower()}", action="store_true")
+    args = parser.parse_args()
+    _t_sections = {s: f for s, f in TESTS if getattr(args, f"only_{s.value.lower()}")}
+    if _t_sections:
+        assert (
+            len(list(_t_sections.keys())) < 2
+        ), 'use "--only" for just one test, not multiple tests'
+    else:
+        _t_sections = {
+            s: f for s, f in TESTS if not getattr(args, f"skip_{s.value.lower()}")
+        }
+    _config = TestConfig(simulate=args.simulate, tests=_t_sections)
+    asyncio.run(_main(_config))

--- a/hardware-testing/hardware_testing/modules/flex_stacker_cycle_qc/__main__.py
+++ b/hardware-testing/hardware_testing/modules/flex_stacker_cycle_qc/__main__.py
@@ -1,12 +1,6 @@
 """FLEX Stacker Cycle QC Test."""
 from os import environ
 from serial.tools.list_ports import comports  # type: ignore[import]
-STACKER_VID = 0x483
-STACKER_PID = 0xEF24
-
-# NOTE: this is required to get WIFI test to work
-if "OT_SYSTEM_VERSION" not in environ:
-    environ["OT_SYSTEM_VERSION"] = "0.0.0"
 
 import argparse
 import asyncio
@@ -19,18 +13,29 @@ from hardware_testing.data.csv_report import CSVReport
 
 from .config import TestSection, TestConfig, build_report, TESTS
 from opentrons.hardware_control.modules import FlexStacker
+from opentrons.drivers.rpi_drivers.types import USBPort
+
+STACKER_VID = 0x483
+STACKER_PID = 0xEF24
+
+# NOTE: this is required to get WIFI test to work
+if "OT_SYSTEM_VERSION" not in environ:
+    environ["OT_SYSTEM_VERSION"] = "0.0.0"
+
 
 async def build_stacker_report(
-    is_simulating: bool, operator: str, port: str = "",
+    is_simulating: bool,
+    operator: str,
+    port: str = "",
 ) -> Tuple[CSVReport, FlexStacker]:
     """Report setup for FLEX Stacker Cycle QC Test."""
     test_name = Path(__file__).parent.name.replace("_", "-")
-    stacker = await FlexStacker.build(port=port,
-                                usb_port=None,
-                                execution_manager=None,
-                                hw_control_loop=asyncio.get_running_loop(),
-                                simulating=is_simulating)
-
+    stacker = await FlexStacker.build(
+        port=port,
+        usb_port=USBPort(port, 0),
+        hw_control_loop=asyncio.get_running_loop(),
+        simulating=is_simulating,
+    )
 
     report = build_report(test_name)
     report.set_operator("simulating" if is_simulating else operator)
@@ -57,8 +62,10 @@ async def _main(cfg: TestConfig) -> None:
 
     stackers = {}
     for p in ports:
-        report, stacker = await build_stacker_report(cfg.simulate, operator=operator, port=p)
-        device_sn = stacker.device_info['serial']
+        report, stacker = await build_stacker_report(
+            cfg.simulate, operator=operator, port=p
+        )
+        device_sn = stacker.device_info["serial"]
         report.set_tag(device_sn if device_sn else "UNKNOWN")
         stackers[device_sn] = (report, stacker)
 
@@ -79,10 +86,12 @@ async def _main(cfg: TestConfig) -> None:
         report.save_to_disk()
         report.print_results()
 
+    # TODO: Do we want to restart the server here?
+    # # It will just have to be disabled to rerun the script again?
     # Restart the robot server
-    if not cfg.simulate:
-        print("Starting the robot server")
-        subprocess.run(["systemctl restart opentrons-robot-server &"], shell=True)
+    # if not cfg.simulate:
+    #     print("Starting the robot server")
+    #     subprocess.run(["systemctl restart opentrons-robot-server &"], shell=True)
 
 
 if __name__ == "__main__":

--- a/hardware-testing/hardware_testing/modules/flex_stacker_cycle_qc/__main__.py
+++ b/hardware-testing/hardware_testing/modules/flex_stacker_cycle_qc/__main__.py
@@ -21,60 +21,76 @@ from .config import TestSection, TestConfig, build_report, TESTS
 from opentrons.hardware_control.modules import FlexStacker
 
 async def build_stacker_report(
-    is_simulating: bool, port: str = ""
+    is_simulating: bool, operator: str, port: str = "",
 ) -> Tuple[CSVReport, FlexStacker]:
     """Report setup for FLEX Stacker Cycle QC Test."""
     test_name = Path(__file__).parent.name.replace("_", "-")
-    ui.print_title(test_name.upper())
-
     stacker = await FlexStacker.build(port=port,
                                 usb_port=None,
                                 execution_manager=None,
-                                loop=asyncio.get_running_loop(),
+                                hw_control_loop=asyncio.get_running_loop(),
                                 simulating=is_simulating)
 
 
     report = build_report(test_name)
-    report.set_operator(
-        "simulating" if is_simulating else input("enter OPERATOR name: ")
-    )
+    report.set_operator("simulating" if is_simulating else operator)
     return report, stacker
 
 
 async def _main(cfg: TestConfig) -> None:
     # BUILD REPORT
-    port = []
+    ports = []
     for i in comports():
+        print(i)
         if i.vid == STACKER_VID and i.pid == STACKER_PID:
-            port.append(i.device)
-            break
-    assert port, "could not find connected FLEX Stacker"
-    report, stacker = await build_stacker_report(cfg.simulate, port=port[0])
+            ports.append(i.device)
+            print(f"Found FLEX Stacker on {i.device}")
+    assert ports, "could not find connected FLEX Stacker"
 
     if not cfg.simulate:
         print("Stopping the robot server")
         subprocess.run(["systemctl stop opentrons-robot-server"], shell=True)
 
-    device_info = await stacker._driver.get_device_info()
-    report.set_tag(device_info.sn if device_info.sn else "UNKNOWN")
+    test_name = Path(__file__).parent.name.replace("_", "-")
+    ui.print_title(test_name.upper())
+    operator = "simulating" if cfg.simulate else input("enter OPERATOR name: ")
 
-    # RUN TESTS
+    stackers = {}
+    for p in ports:
+        report, stacker = await build_stacker_report(cfg.simulate, operator=operator, port=p)
+        device_sn = stacker.device_info['serial']
+        report.set_tag(device_sn if device_sn else "UNKNOWN")
+        stackers[device_sn] = (report, stacker)
+
+    # # RUN TESTS
     try:
         for section, test_run in cfg.tests.items():
             ui.print_title(section.value)
-            await test_run(stacker, report, section.value)
+            tasks = []
+            for sn, (report, stacker) in stackers.items():
+                tasks.append(test_run(stacker, report, section.value))
+            await asyncio.gather(*tasks)  # Run all tasks concurrently
     except Exception as e:
         ui.print_error(f"An error occurred: {e}")
 
+    # try:
+    #     for section, test_run in cfg.tests.items():
+    #         ui.print_title(section.value)
+    #         await test_run(stacker, report, section.value)
+    # except Exception as e:
+    #     ui.print_error(f"An error occurred: {e}")
+
+
     # SAVE REPORT
     ui.print_title("DONE")
-    report.save_to_disk()
-    report.print_results()
+    for sn, (report, stacker) in stackers.items():
+        report.save_to_disk()
+        report.print_results()
 
     # Restart the robot server
-    if not cfg.simulate:
-        print("Starting the robot server")
-        subprocess.run(["systemctl restart opentrons-robot-server &"], shell=True)
+    # if not cfg.simulate:
+    #     print("Starting the robot server")
+    #     subprocess.run(["systemctl restart opentrons-robot-server &"], shell=True)
 
 
 if __name__ == "__main__":

--- a/hardware-testing/hardware_testing/modules/flex_stacker_cycle_qc/__main__.py
+++ b/hardware-testing/hardware_testing/modules/flex_stacker_cycle_qc/__main__.py
@@ -18,8 +18,8 @@ from opentrons.drivers.rpi_drivers.types import USBPort
 STACKER_VID = 0x483
 STACKER_PID = 0xEF24
 
-DEFAULT_NUM_CYCLES = 100
-DEFAULT_LABWARE_HEIGHT = 16  # mm
+DEFAULT_NUM_CYCLES = 500
+DEFAULT_LABWARE_HEIGHT = 102.0  # mm, tiprack
 
 # NOTE: this is required to get WIFI test to work
 if "OT_SYSTEM_VERSION" not in environ:
@@ -91,19 +91,22 @@ async def _main(cfg: TestConfig, cycles: int, labware_height: int) -> None:
         report.save_to_disk()
         report.print_results()
 
-    # TODO: Do we want to restart the server here?
-    # # It will just have to be disabled to rerun the script again?
-    # Restart the robot server
-    # if not cfg.simulate:
-    #     print("Starting the robot server")
-    #     subprocess.run(["systemctl restart opentrons-robot-server &"], shell=True)
-
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--simulate", action="store_true")
-    parser.add_argument("--cycles", type=int, default=DEFAULT_NUM_CYCLES)
-    parser.add_argument("--labware-height", type=int, default=DEFAULT_LABWARE_HEIGHT)
+    parser.add_argument(
+        "--cycles",
+        type=int,
+        default=DEFAULT_NUM_CYCLES,
+        help="number of load/store cycles to run",
+    )
+    parser.add_argument(
+        "--labware-height",
+        type=int,
+        default=DEFAULT_LABWARE_HEIGHT,
+        help="LabwareHeight - stackingOffsetWithLabware, in mm",
+    )
     # add each test-section as a skippable argument (eg: --skip-connectivity)
     for s in TestSection:
         parser.add_argument(f"--skip-{s.value.lower()}", action="store_true")

--- a/hardware-testing/hardware_testing/modules/flex_stacker_cycle_qc/__main__.py
+++ b/hardware-testing/hardware_testing/modules/flex_stacker_cycle_qc/__main__.py
@@ -62,7 +62,7 @@ async def _main(cfg: TestConfig) -> None:
         report.set_tag(device_sn if device_sn else "UNKNOWN")
         stackers[device_sn] = (report, stacker)
 
-    # # RUN TESTS
+    # RUN TESTS
     try:
         for section, test_run in cfg.tests.items():
             ui.print_title(section.value)
@@ -73,14 +73,6 @@ async def _main(cfg: TestConfig) -> None:
     except Exception as e:
         ui.print_error(f"An error occurred: {e}")
 
-    # try:
-    #     for section, test_run in cfg.tests.items():
-    #         ui.print_title(section.value)
-    #         await test_run(stacker, report, section.value)
-    # except Exception as e:
-    #     ui.print_error(f"An error occurred: {e}")
-
-
     # SAVE REPORT
     ui.print_title("DONE")
     for sn, (report, stacker) in stackers.items():
@@ -88,9 +80,9 @@ async def _main(cfg: TestConfig) -> None:
         report.print_results()
 
     # Restart the robot server
-    # if not cfg.simulate:
-    #     print("Starting the robot server")
-    #     subprocess.run(["systemctl restart opentrons-robot-server &"], shell=True)
+    if not cfg.simulate:
+        print("Starting the robot server")
+        subprocess.run(["systemctl restart opentrons-robot-server &"], shell=True)
 
 
 if __name__ == "__main__":

--- a/hardware-testing/hardware_testing/modules/flex_stacker_cycle_qc/__main__.py
+++ b/hardware-testing/hardware_testing/modules/flex_stacker_cycle_qc/__main__.py
@@ -18,6 +18,9 @@ from opentrons.drivers.rpi_drivers.types import USBPort
 STACKER_VID = 0x483
 STACKER_PID = 0xEF24
 
+DEFAULT_NUM_CYCLES = 100
+DEFAULT_LABWARE_HEIGHT = 16  # mm
+
 # NOTE: this is required to get WIFI test to work
 if "OT_SYSTEM_VERSION" not in environ:
     environ["OT_SYSTEM_VERSION"] = "0.0.0"
@@ -42,7 +45,7 @@ async def build_stacker_report(
     return report, stacker
 
 
-async def _main(cfg: TestConfig) -> None:
+async def _main(cfg: TestConfig, cycles: int, labware_height: int) -> None:
     # BUILD REPORT
     ports = []
     for i in comports():
@@ -75,7 +78,9 @@ async def _main(cfg: TestConfig) -> None:
             ui.print_title(section.value)
             tasks = []
             for sn, (report, stacker) in stackers.items():
-                tasks.append(test_run(stacker, report, section.value))
+                tasks.append(
+                    test_run(stacker, report, section.value, cycles, labware_height)
+                )
             await asyncio.gather(*tasks)  # Run all tasks concurrently
     except Exception as e:
         ui.print_error(f"An error occurred: {e}")
@@ -97,6 +102,8 @@ async def _main(cfg: TestConfig) -> None:
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--simulate", action="store_true")
+    parser.add_argument("--cycles", type=int, default=DEFAULT_NUM_CYCLES)
+    parser.add_argument("--labware-height", type=int, default=DEFAULT_LABWARE_HEIGHT)
     # add each test-section as a skippable argument (eg: --skip-connectivity)
     for s in TestSection:
         parser.add_argument(f"--skip-{s.value.lower()}", action="store_true")
@@ -112,4 +119,4 @@ if __name__ == "__main__":
             s: f for s, f in TESTS if not getattr(args, f"skip_{s.value.lower()}")
         }
     _config = TestConfig(simulate=args.simulate, tests=_t_sections)
-    asyncio.run(_main(_config))
+    asyncio.run(_main(_config, args.cycles, args.labware_height))

--- a/hardware-testing/hardware_testing/modules/flex_stacker_cycle_qc/config.py
+++ b/hardware-testing/hardware_testing/modules/flex_stacker_cycle_qc/config.py
@@ -1,0 +1,45 @@
+"""Config."""
+from dataclasses import dataclass
+import enum
+from typing import Dict, Callable
+
+from hardware_testing.data.csv_report import CSVReport, CSVSection
+
+from . import (
+    test_cycles,
+)
+
+
+class TestSection(enum.Enum):
+    """Test Section."""
+
+    CYCLES = "CYCLES"
+
+
+@dataclass
+class TestConfig:
+    """Test Config."""
+
+    simulate: bool
+    tests: Dict[TestSection, Callable]
+
+
+TESTS = [
+    (
+        TestSection.CYCLES,
+        test_cycles.run,
+    )
+]
+
+
+def build_report(test_name: str) -> CSVReport:
+    """Build report."""
+    return CSVReport(
+        test_name=test_name,
+        sections=[
+            CSVSection(
+                title=TestSection.CYCLES.value,
+                lines=test_cycles.build_csv_lines(),
+            ),
+        ],
+    )

--- a/hardware-testing/hardware_testing/modules/flex_stacker_cycle_qc/test_cycles.py
+++ b/hardware-testing/hardware_testing/modules/flex_stacker_cycle_qc/test_cycles.py
@@ -11,10 +11,6 @@ from hardware_testing.data.csv_report import (
 
 from opentrons.hardware_control.modules import FlexStacker
 
-# TODO Determine number of cycles we actually want to use
-NUM_CYCLES = 100
-LABWARE_HEIGHT = 16  # mm
-
 
 def build_csv_lines() -> List[Union[CSVLine, CSVLineRepeating]]:
     """Build CSV Lines."""
@@ -29,37 +25,45 @@ def print_cycle(stacker: FlexStacker, cycle: int, total_cycles: int) -> None:
     ui.print_info(out_str)
 
 
-async def test_cycles(stacker: FlexStacker) -> Tuple[bool, int]:
+async def test_cycles(
+    stacker: FlexStacker, cycles: int, labware_height: int
+) -> Tuple[bool, int]:
     """Test Cycling Labware on Stacker."""
     cycles_completed = 0
 
-    for cycle in range(NUM_CYCLES):
+    for cycle in range(cycles):
         try:
             await stacker.dispense_labware(
-                LABWARE_HEIGHT,
+                labware_height,
                 enforce_hopper_lw_sensing=False,
                 enforce_shuttle_lw_sensing=False,
             )
             await stacker.store_labware(
-                LABWARE_HEIGHT, enforce_shuttle_lw_sensing=False
+                labware_height, enforce_shuttle_lw_sensing=False
             )
         except Exception as e:
             ui.print_error(f"{stacker.device_info['serial']}: An error occurred: {e}")
             break
 
         cycles_completed += 1
-        if (cycles_completed % 5 == 0) and (not cycles_completed == NUM_CYCLES):
-            print_cycle(stacker, cycles_completed, NUM_CYCLES)
+        if (cycles_completed % 5 == 0) and (not cycles_completed == cycles):
+            print_cycle(stacker, cycles_completed, cycles)
 
-    print_cycle(stacker, NUM_CYCLES, NUM_CYCLES)
-    return (cycles_completed == NUM_CYCLES, cycles_completed)
+    print_cycle(stacker, cycles, cycles)
+    return (cycles_completed == cycles, cycles_completed)
 
 
-async def run(stacker: FlexStacker, report: CSVReport, section: str) -> None:
+async def run(
+    stacker: FlexStacker,
+    report: CSVReport,
+    section: str,
+    cycles: int,
+    labware_height: int,
+) -> None:
     """Run."""
     ui.print_header(f"Cycle Test - {stacker.device_info['serial']}")
 
     await stacker.home_all()
-    cycle_result, cycles_completed = await test_cycles(stacker)
+    cycle_result, cycles_completed = await test_cycles(stacker, cycles, labware_height)
 
     report(section, "cycle", [cycles_completed, CSVResult.from_bool(cycle_result)])

--- a/hardware-testing/hardware_testing/modules/flex_stacker_cycle_qc/test_cycles.py
+++ b/hardware-testing/hardware_testing/modules/flex_stacker_cycle_qc/test_cycles.py
@@ -1,5 +1,5 @@
 """Test Cycling."""
-from typing import List, Union
+from typing import List, Union, Tuple
 
 from hardware_testing.data import ui
 from hardware_testing.data.csv_report import (
@@ -9,34 +9,46 @@ from hardware_testing.data.csv_report import (
     CSVResult,
 )
 
-from opentrons.drivers.flex_stacker.types import HardwareRevision
 from opentrons.hardware_control.modules import FlexStacker
 
+NUM_CYCLES = 10
 
 def build_csv_lines() -> List[Union[CSVLine, CSVLineRepeating]]:
     """Build CSV Lines."""
     return [
-        CSVLine("cycle", [CSVResult]),
+        CSVLine("cycle", [int, CSVResult]),
     ]
 
+def print_cycle(stacker: FlexStacker, cycle: int, total_cycles: int) -> None:
+    """Print formater for cycle progress"""
+    out_str = f"{stacker.device_info['serial']}: Cycle {cycle}/{total_cycles} Completed"
+    ui.print_info(out_str)
 
-# async def test_gcode(stacker: FlexStacker, report: CSVReport) -> None:
-#     """Send and receive response for GCODE M115."""
-#     success = True
-#     info = await stacker._driver.get_device_info()
-#     # TODO: update this with PVT/MP revisions
-#     if info.hw != HardwareRevision.DVT:
-#         ui.print_warning(f"Hardware Revision is {info.hw}, expected DVT")
-#     report(
-#         "CONNECTIVITY",
-#         "usb-get-device-info",
-#         [info.fw, info.hw, info.sn, CSVResult.from_bool(success)],
-#     )
+async def test_cycles(stacker: FlexStacker) -> Tuple[bool, int]:
+    """Test Cycling Labware on Stacker"""
+    cycles_completed = 0
+
+    for cycle in range(NUM_CYCLES):
+        try:
+            await stacker.dispense_labware(15)
+            await stacker.store_labware(15)
+        except Exception as e:
+            ui.print_error(f"{stacker.device_info['serial']}: An error occurred: {e}")
+
+        cycles_completed += 1
+        if (cycles_completed % 5 == 0) and (not cycles_completed==NUM_CYCLES):
+            print_cycle(stacker, cycles_completed, NUM_CYCLES)
+    
+    print_cycle(stacker, NUM_CYCLES, NUM_CYCLES)   
+    return (cycles_completed==NUM_CYCLES, cycles_completed)
 
 
 
 async def run(stacker: FlexStacker, report: CSVReport, section: str) -> None:
     """Run."""
-    ui.print_header("Cycle Test")
-    model = await stacker.get_model()
-    ui.print_info(f"Model: {model}")
+    ui.print_header(f"Cycle Test - {stacker.device_info['serial']}")
+
+    await stacker.home_all()
+    cycle_result, cycles_completed = await test_cycles(stacker)     
+    
+    report(section, "cycle", [cycles_completed, CSVResult.from_bool(cycle_result)])

--- a/hardware-testing/hardware_testing/modules/flex_stacker_cycle_qc/test_cycles.py
+++ b/hardware-testing/hardware_testing/modules/flex_stacker_cycle_qc/test_cycles.py
@@ -13,7 +13,8 @@ from opentrons.hardware_control.modules import FlexStacker
 
 # TODO Determine number of cycles we actually want to use
 NUM_CYCLES = 100
-LABWARE_HEIGHT = 15  # mm
+LABWARE_HEIGHT = 16  # mm
+
 
 def build_csv_lines() -> List[Union[CSVLine, CSVLineRepeating]]:
     """Build CSV Lines."""
@@ -21,29 +22,37 @@ def build_csv_lines() -> List[Union[CSVLine, CSVLineRepeating]]:
         CSVLine("cycle", [int, CSVResult]),
     ]
 
+
 def print_cycle(stacker: FlexStacker, cycle: int, total_cycles: int) -> None:
-    """Print formater for cycle progress"""
+    """Print formater for cycle progress."""
     out_str = f"{stacker.device_info['serial']}: Cycle {cycle}/{total_cycles} Completed"
     ui.print_info(out_str)
 
+
 async def test_cycles(stacker: FlexStacker) -> Tuple[bool, int]:
-    """Test Cycling Labware on Stacker"""
+    """Test Cycling Labware on Stacker."""
     cycles_completed = 0
 
     for cycle in range(NUM_CYCLES):
         try:
-            await stacker.dispense_labware(LABWARE_HEIGHT)
-            await stacker.store_labware(LABWARE_HEIGHT)
+            await stacker.dispense_labware(
+                LABWARE_HEIGHT,
+                enforce_hopper_lw_sensing=False,
+                enforce_shuttle_lw_sensing=False,
+            )
+            await stacker.store_labware(
+                LABWARE_HEIGHT, enforce_shuttle_lw_sensing=False
+            )
         except Exception as e:
             ui.print_error(f"{stacker.device_info['serial']}: An error occurred: {e}")
+            break
 
         cycles_completed += 1
-        if (cycles_completed % 5 == 0) and (not cycles_completed==NUM_CYCLES):
+        if (cycles_completed % 5 == 0) and (not cycles_completed == NUM_CYCLES):
             print_cycle(stacker, cycles_completed, NUM_CYCLES)
-    
-    print_cycle(stacker, NUM_CYCLES, NUM_CYCLES)   
-    return (cycles_completed==NUM_CYCLES, cycles_completed)
 
+    print_cycle(stacker, NUM_CYCLES, NUM_CYCLES)
+    return (cycles_completed == NUM_CYCLES, cycles_completed)
 
 
 async def run(stacker: FlexStacker, report: CSVReport, section: str) -> None:
@@ -51,6 +60,6 @@ async def run(stacker: FlexStacker, report: CSVReport, section: str) -> None:
     ui.print_header(f"Cycle Test - {stacker.device_info['serial']}")
 
     await stacker.home_all()
-    cycle_result, cycles_completed = await test_cycles(stacker)     
-    
+    cycle_result, cycles_completed = await test_cycles(stacker)
+
     report(section, "cycle", [cycles_completed, CSVResult.from_bool(cycle_result)])

--- a/hardware-testing/hardware_testing/modules/flex_stacker_cycle_qc/test_cycles.py
+++ b/hardware-testing/hardware_testing/modules/flex_stacker_cycle_qc/test_cycles.py
@@ -12,7 +12,8 @@ from hardware_testing.data.csv_report import (
 from opentrons.hardware_control.modules import FlexStacker
 
 # TODO Determine number of cycles we actually want to use
-NUM_CYCLES = 10
+NUM_CYCLES = 100
+LABWARE_HEIGHT = 15  # mm
 
 def build_csv_lines() -> List[Union[CSVLine, CSVLineRepeating]]:
     """Build CSV Lines."""
@@ -31,8 +32,8 @@ async def test_cycles(stacker: FlexStacker) -> Tuple[bool, int]:
 
     for cycle in range(NUM_CYCLES):
         try:
-            await stacker.dispense_labware(15)
-            await stacker.store_labware(15)
+            await stacker.dispense_labware(LABWARE_HEIGHT)
+            await stacker.store_labware(LABWARE_HEIGHT)
         except Exception as e:
             ui.print_error(f"{stacker.device_info['serial']}: An error occurred: {e}")
 

--- a/hardware-testing/hardware_testing/modules/flex_stacker_cycle_qc/test_cycles.py
+++ b/hardware-testing/hardware_testing/modules/flex_stacker_cycle_qc/test_cycles.py
@@ -1,0 +1,42 @@
+"""Test Cycling."""
+from typing import List, Union
+
+from hardware_testing.data import ui
+from hardware_testing.data.csv_report import (
+    CSVReport,
+    CSVLine,
+    CSVLineRepeating,
+    CSVResult,
+)
+
+from opentrons.drivers.flex_stacker.types import HardwareRevision
+from opentrons.hardware_control.modules import FlexStacker
+
+
+def build_csv_lines() -> List[Union[CSVLine, CSVLineRepeating]]:
+    """Build CSV Lines."""
+    return [
+        CSVLine("cycle", [CSVResult]),
+    ]
+
+
+# async def test_gcode(stacker: FlexStacker, report: CSVReport) -> None:
+#     """Send and receive response for GCODE M115."""
+#     success = True
+#     info = await stacker._driver.get_device_info()
+#     # TODO: update this with PVT/MP revisions
+#     if info.hw != HardwareRevision.DVT:
+#         ui.print_warning(f"Hardware Revision is {info.hw}, expected DVT")
+#     report(
+#         "CONNECTIVITY",
+#         "usb-get-device-info",
+#         [info.fw, info.hw, info.sn, CSVResult.from_bool(success)],
+#     )
+
+
+
+async def run(stacker: FlexStacker, report: CSVReport, section: str) -> None:
+    """Run."""
+    ui.print_header("Cycle Test")
+    model = await stacker.get_model()
+    ui.print_info(f"Model: {model}")

--- a/hardware-testing/hardware_testing/modules/flex_stacker_cycle_qc/test_cycles.py
+++ b/hardware-testing/hardware_testing/modules/flex_stacker_cycle_qc/test_cycles.py
@@ -11,6 +11,7 @@ from hardware_testing.data.csv_report import (
 
 from opentrons.hardware_control.modules import FlexStacker
 
+# TODO Determine number of cycles we actually want to use
 NUM_CYCLES = 10
 
 def build_csv_lines() -> List[Union[CSVLine, CSVLineRepeating]]:


### PR DESCRIPTION
# Overview

Adds a cycling test to the Flex Stacker PVT test suite.
Uses the FlexStacker Module to run for stackers in parallel. Does a set number of load unload cycles and then generates a report for each stacker. 

Still TBD is the number of cycles we want to do.  

## Test Plan and Hands on Testing

Tested on a robot with 4 stackers.

## Changelog


## Review requests


## Risk assessment

