### PR TITLE
refactor(app): round pipetting command params to 2 sig figs

### DIFF
--- a/components/src/organisms/CommandText/__tests__/CommandText.test.tsx
+++ b/components/src/organisms/CommandText/__tests__/CommandText.test.tsx
@@ -59,7 +59,7 @@ describe('CommandText', () => {
         { i18nInstance: i18n }
       )
       screen.getByText(
-        'Aspirating 100 µL from well A1 of NEST 1 Well Reservoir 195 mL in Slot 5 at 150 µL/sec'
+        'Aspirating 100.00 µL from well A1 of NEST 1 Well Reservoir 195 mL in Slot 5 at 150.00 µL/sec'
       )
     }
   })
@@ -79,7 +79,7 @@ describe('CommandText', () => {
         { i18nInstance: i18n }
       )
       screen.getByText(
-        'Dispensing 100 µL into well A1 of NEST 96 Well Plate 100 µL PCR Full Skirt (1) in Magnetic Module GEN2 in Slot 1 at 300 µL/sec'
+        'Dispensing 100.00 µL into well A1 of NEST 96 Well Plate 100 µL PCR Full Skirt (1) in Magnetic Module GEN2 in Slot 1 at 300.00 µL/sec'
       )
     }
   })
@@ -106,7 +106,7 @@ describe('CommandText', () => {
         { i18nInstance: i18n }
       )
       screen.getByText(
-        'Dispensing 100 µL into well A1 of NEST 96 Well Plate 100 µL PCR Full Skirt (1) in Magnetic Module GEN2 in Slot 1 at 300 µL/sec and pushing out 10 µL'
+        'Dispensing 100.00 µL into well A1 of NEST 96 Well Plate 100 µL PCR Full Skirt (1) in Magnetic Module GEN2 in Slot 1 at 300.00 µL/sec and pushing out 10.00 µL'
       )
     }
   })
@@ -129,7 +129,7 @@ describe('CommandText', () => {
       />,
       { i18nInstance: i18n }
     )
-    screen.getByText('Dispensing 50 µL in place at 300 µL/sec')
+    screen.getByText('Dispensing 50.00 µL in place at 300.00 µL/sec')
   })
   it('renders correct text for blowout', () => {
     const dispenseCommand = mockCommandTextData.commands.find(
@@ -151,7 +151,7 @@ describe('CommandText', () => {
         { i18nInstance: i18n }
       )
       screen.getByText(
-        'Blowing out at well A1 of NEST 96 Well Plate 100 µL PCR Full Skirt (1) in Magnetic Module GEN2 in Slot 1 at 300 µL/sec'
+        'Blowing out at well A1 of NEST 96 Well Plate 100 µL PCR Full Skirt (1) in Magnetic Module GEN2 in Slot 1 at 300.00 µL/sec'
       )
     }
   })
@@ -173,7 +173,7 @@ describe('CommandText', () => {
       />,
       { i18nInstance: i18n }
     )
-    screen.getByText('Blowing out in place at 300 µL/sec')
+    screen.getByText('Blowing out in place at 300.00 µL/sec')
   })
   it('renders correct text for aspirateInPlace', () => {
     renderWithProviders(
@@ -186,15 +186,15 @@ describe('CommandText', () => {
             commandType: 'aspirateInPlace',
             params: {
               pipetteId: 'f6d1c83c-9d1b-4d0d-9de3-e6d649739cfb',
-              flowRate: 300,
-              volume: 10,
+              flowRate: 300.7653423,
+              volume: 10.12526,
             },
           } as AspirateInPlaceRunTimeCommand
         }
       />,
       { i18nInstance: i18n }
     )
-    screen.getByText('Aspirating 10 µL in place at 300 µL/sec')
+    screen.getByText('Aspirating 10.13 µL in place at 300.77 µL/sec')
   })
   it('renders correct text for moveToWell', () => {
     const dispenseCommand = mockCommandTextData.commands.find(

--- a/components/src/organisms/CommandText/useCommandTextString/utils/commandText/__tests__/getPipettingCommandText.test.tsx
+++ b/components/src/organisms/CommandText/useCommandTextString/utils/commandText/__tests__/getPipettingCommandText.test.tsx
@@ -91,7 +91,7 @@ describe('getPipettingCommandText', () => {
 
     render(command)
     screen.getByText(
-      /Aspirating 100 µL from well A1 of Test Labware in Slot 1 at 150 µL\/sec/
+      /Aspirating 100.00 µL from well A1 of Test Labware in Slot 1 at 150.00 µL\/sec/
     )
   })
 
@@ -109,7 +109,7 @@ describe('getPipettingCommandText', () => {
 
     render(command)
     screen.getByText(
-      /Dispensing 100 µL into well A1 of Test Labware in Slot 1 at 150 µL\/sec/
+      /Dispensing 100.00 µL into well A1 of Test Labware in Slot 1 at 150.00 µL\/sec/
     )
   })
 
@@ -128,7 +128,7 @@ describe('getPipettingCommandText', () => {
 
     render(command)
     screen.getByText(
-      /Dispensing 100 µL into well A1 of Test Labware in Slot 1 at 150 µL\/sec and pushing out 10 µL/
+      /Dispensing 100.00 µL into well A1 of Test Labware in Slot 1 at 150.00 µL\/sec and pushing out 10.00 µL/
     )
   })
 

--- a/components/src/organisms/CommandText/useCommandTextString/utils/commandText/getPipettingCommandText.ts
+++ b/components/src/organisms/CommandText/useCommandTextString/utils/commandText/getPipettingCommandText.ts
@@ -195,12 +195,11 @@ export const getPipettingCommandText = ({
 const formatCmdParamDecimal = (
   command: RunTimeCommand | null | undefined,
   paramName: string
-): string | null => {
-  return command?.params &&
-    paramName in command.params &&
-    command.params[paramName as keyof typeof command.params] != null
+): string | null =>
+  command?.params &&
+  paramName in command.params &&
+  command.params[paramName as keyof typeof command.params] != null
     ? Number(command.params[paramName as keyof typeof command.params]).toFixed(
         2
       )
     : null
-}

--- a/components/src/organisms/CommandText/useCommandTextString/utils/commandText/getPipettingCommandText.ts
+++ b/components/src/organisms/CommandText/useCommandTextString/utils/commandText/getPipettingCommandText.ts
@@ -57,9 +57,12 @@ export const getPipettingCommandText = ({
         })
       : null
 
+  const volume = formatCmdParamDecimal(command, 'volume')
+  const flowRate = formatCmdParamDecimal(command, 'flowRate')
+  const pushOutVolume = formatCmdParamDecimal(command, 'pushOut')
+
   switch (command?.commandType) {
     case 'aspirate': {
-      const { volume, flowRate } = command.params
       return t('aspirate', {
         well_name: wellName,
         labware: labwareName,
@@ -69,15 +72,14 @@ export const getPipettingCommandText = ({
       })
     }
     case 'dispense': {
-      const { volume, flowRate, pushOut } = command.params
-      return pushOut != null
+      return pushOutVolume != null
         ? t('dispense_push_out', {
             well_name: wellName,
             labware: labwareName,
             labware_location: displayLocation,
             volume,
             flow_rate: flowRate,
-            push_out_volume: pushOut,
+            push_out_volume: pushOutVolume,
           })
         : t('dispense', {
             well_name: wellName,
@@ -88,7 +90,6 @@ export const getPipettingCommandText = ({
           })
     }
     case 'blowout': {
-      const { flowRate } = command.params
       return t('blowout', {
         well_name: wellName,
         labware: labwareName,
@@ -154,19 +155,15 @@ export const getPipettingCommandText = ({
       }
     }
     case 'dispenseInPlace': {
-      const { volume, flowRate } = command.params
       return t('dispense_in_place', { volume, flow_rate: flowRate })
     }
     case 'blowOutInPlace': {
-      const { flowRate } = command.params
       return t('blowout_in_place', { flow_rate: flowRate })
     }
     case 'aspirateInPlace': {
-      const { flowRate, volume } = command.params
       return t('aspirate_in_place', { volume, flow_rate: flowRate })
     }
     case 'airGapInPlace': {
-      const { volume } = command.params
       return t('air_gap_in_place', { volume })
     }
     case 'sealPipetteToTip': {
@@ -182,7 +179,6 @@ export const getPipettingCommandText = ({
       })
     }
     case 'pressureDispense': {
-      const { flowRate, volume } = command.params
       return t('pressurizing_to_dispense', { volume, flow_rate: flowRate })
     }
     default: {
@@ -193,4 +189,18 @@ export const getPipettingCommandText = ({
       return ''
     }
   }
+}
+
+// Format the given command param to two decimals if it exists and can be cast as a number.
+const formatCmdParamDecimal = (
+  command: RunTimeCommand | null | undefined,
+  paramName: string
+): string | null => {
+  return command?.params &&
+    paramName in command.params &&
+    command.params[paramName as keyof typeof command.params] != null
+    ? Number(command.params[paramName as keyof typeof command.params]).toFixed(
+        2
+      )
+    : null
 }


### PR DESCRIPTION
Closes [RQA-3937](https://opentrons.atlassian.net/browse/RQA-3937)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Rounds all pipetting command params to two significant figures. This does mean that pipetting commands that are integers also now have decimal points.

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- See screenshot.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed the run log displaying a floating number of decimal points for pipetting command params.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests
- Are we ok with all pipetting command parameters displaying 2 decimal points in the run log?
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
none, just copy
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-3937]: https://opentrons.atlassian.net/browse/RQA-3937?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ