### PR TITLE
fix(api): require LC transfers to use API v2.24

### DIFF
--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1777,7 +1777,7 @@ class InstrumentContext(publisher.CommandPublisher):
         for cmd in plan:
             getattr(self, cmd["method"])(*cmd["args"], **cmd["kwargs"])
 
-    @requires_version(2, 23)
+    @requires_version(2, 24)
     def transfer_with_liquid_class(
         self,
         liquid_class: LiquidClass,
@@ -1913,7 +1913,7 @@ class InstrumentContext(publisher.CommandPublisher):
             )
         return self
 
-    @requires_version(2, 23)
+    @requires_version(2, 24)
     def distribute_with_liquid_class(
         self,
         liquid_class: LiquidClass,
@@ -2049,7 +2049,7 @@ class InstrumentContext(publisher.CommandPublisher):
             )
         return self
 
-    @requires_version(2, 23)
+    @requires_version(2, 24)
     def consolidate_with_liquid_class(
         self,
         liquid_class: LiquidClass,


### PR DESCRIPTION
Closes AUTH-2004

# Overview

Updates the liquid classes based transfer, consolidate and distribute methods to require 2.24 instead of 2.23. Details in ticket above for why we need to do this.

## Review requests

Any side effects I might be missing?

## Risk assessment

Not really. We had previously indicated in api source code that liquid classes work is in-progress and subject to change. And these methods are not available in public docs until 8.5.0.
