### PR TITLE
fix(api): fix chained transfers with keep_last_tip set to True and return_tip

### DIFF
--- a/api/src/opentrons/protocol_api/_transfer_liquid_validation.py
+++ b/api/src/opentrons/protocol_api/_transfer_liquid_validation.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import List, Union, Sequence, Optional
+from typing import List, Union, Sequence, Optional, Tuple
 
 from opentrons.types import Location, NozzleMapInterface
 from opentrons.protocols.api_support import instrument
@@ -13,6 +13,7 @@ from opentrons.protocols.advanced_control.transfers.common import (
 
 from .disposal_locations import TrashBin, WasteChute
 from .labware import Labware, Well
+from .core.common import WellCore
 from . import validation
 
 
@@ -24,6 +25,7 @@ class TransferInfo:
     tip_policy: TransferTipPolicyV2
     tip_racks: List[Labware]
     trash_location: Union[Location, TrashBin, WasteChute]
+    last_tip_used: Optional[Tuple[Location, WellCore]]
 
 
 def verify_and_normalize_transfer_args(
@@ -86,12 +88,22 @@ def verify_and_normalize_transfer_args(
         trash_location=_trash_location
     )
 
+    if last_tip_picked_up_from is not None:
+        parent_tip_rack = last_tip_picked_up_from.parent
+        last_tip_used = (
+            Location(last_tip_picked_up_from.top().point, parent_tip_rack),
+            last_tip_picked_up_from._core,
+        )
+    else:
+        last_tip_used = None
+
     return TransferInfo(
         source=flat_sources_list,
         dest=flat_dests_list if not isinstance(dest, (TrashBin, WasteChute)) else dest,
         tip_policy=valid_new_tip,
         tip_racks=valid_tip_racks,
         trash_location=valid_trash_location,
+        last_tip_used=last_tip_used,
     )
 
 

--- a/api/src/opentrons/protocol_api/_transfer_liquid_validation.py
+++ b/api/src/opentrons/protocol_api/_transfer_liquid_validation.py
@@ -25,14 +25,14 @@ class TransferInfo:
     tip_policy: TransferTipPolicyV2
     tip_racks: List[Labware]
     trash_location: Union[Location, TrashBin, WasteChute]
-    last_tip_used: Optional[Tuple[Location, WellCore]]
+    last_tip_location: Optional[Tuple[Location, WellCore]]
 
 
 def verify_and_normalize_transfer_args(
     source: Union[Well, Sequence[Well], Sequence[Sequence[Well]]],
     dest: Union[Well, Sequence[Well], Sequence[Sequence[Well]], TrashBin, WasteChute],
     tip_policy: TransferTipPolicyV2Type,
-    last_tip_picked_up_from: Optional[Well],
+    last_tip_well: Optional[Well],
     tip_racks: List[Labware],
     nozzle_map: NozzleMapInterface,
     group_wells_for_multi_channel: bool,
@@ -61,14 +61,14 @@ def verify_and_normalize_transfer_args(
 
     valid_new_tip = validation.ensure_new_tip_policy(tip_policy)
     if valid_new_tip == TransferTipPolicyV2.NEVER:
-        if last_tip_picked_up_from is None:
+        if last_tip_well is None:
             raise RuntimeError(
                 "Pipette has no tip attached to perform transfer."
                 " Either do a pick_up_tip beforehand or specify a new_tip parameter"
                 " of 'once' or 'always'."
             )
         else:
-            valid_tip_racks = [last_tip_picked_up_from.parent]
+            valid_tip_racks = [last_tip_well.parent]
     else:
         valid_tip_racks = tip_racks
     if current_volume != 0:
@@ -88,14 +88,14 @@ def verify_and_normalize_transfer_args(
         trash_location=_trash_location
     )
 
-    if last_tip_picked_up_from is not None:
-        parent_tip_rack = last_tip_picked_up_from.parent
-        last_tip_used = (
-            Location(last_tip_picked_up_from.top().point, parent_tip_rack),
-            last_tip_picked_up_from._core,
+    if last_tip_well is not None:
+        parent_tip_rack = last_tip_well.parent
+        last_tip_location = (
+            Location(last_tip_well.top().point, parent_tip_rack),
+            last_tip_well._core,
         )
     else:
-        last_tip_used = None
+        last_tip_location = None
 
     return TransferInfo(
         source=flat_sources_list,
@@ -103,7 +103,7 @@ def verify_and_normalize_transfer_args(
         tip_policy=valid_new_tip,
         tip_racks=valid_tip_racks,
         trash_location=valid_trash_location,
-        last_tip_used=last_tip_used,
+        last_tip_location=last_tip_location,
     )
 
 

--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -1206,6 +1206,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         trash_location: Union[Location, TrashBin, WasteChute],
         return_tip: bool,
         keep_last_tip: bool,
+        last_tip_used: Optional[Tuple[Location, WellCore]],
     ) -> Optional[Tuple[Location, WellCore]]:
         """Execute transfer using liquid class properties.
 
@@ -1273,7 +1274,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             )
         )
 
-        last_tip: Optional[Tuple[Location, WellCore]] = None
+        last_tip = last_tip_used
 
         def _drop_tip() -> None:
             if return_tip:
@@ -1435,6 +1436,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         trash_location: Union[Location, TrashBin, WasteChute],
         return_tip: bool,
         keep_last_tip: bool,
+        last_tip_used: Optional[Tuple[Location, WellCore]],
     ) -> Optional[Tuple[Location, WellCore]]:
         """Execute a distribution using liquid class properties.
 
@@ -1526,6 +1528,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                 trash_location=trash_location,
                 return_tip=return_tip,
                 keep_last_tip=keep_last_tip,
+                last_tip_used=last_tip_used,
             )
 
         # TODO: use the ID returned by load_liquid_class in command annotations
@@ -1553,7 +1556,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             )
         )
 
-        last_tip: Optional[Tuple[Location, WellCore]] = None
+        last_tip = last_tip_used
 
         def _drop_tip() -> None:
             if return_tip:
@@ -1784,6 +1787,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         trash_location: Union[Location, TrashBin, WasteChute],
         return_tip: bool,
         keep_last_tip: bool,
+        last_tip_used: Optional[Tuple[Location, WellCore]],
     ) -> Optional[Tuple[Location, WellCore]]:
         if not tip_racks:
             raise RuntimeError(
@@ -1844,7 +1848,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             )
         )
 
-        last_tip: Optional[Tuple[Location, WellCore]] = None
+        last_tip = last_tip_used
 
         def _drop_tip() -> None:
             if return_tip:

--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -1206,7 +1206,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         trash_location: Union[Location, TrashBin, WasteChute],
         return_tip: bool,
         keep_last_tip: bool,
-        last_tip_used: Optional[Tuple[Location, WellCore]],
+        last_tip_location: Optional[Tuple[Location, WellCore]],
     ) -> Optional[Tuple[Location, WellCore]]:
         """Execute transfer using liquid class properties.
 
@@ -1229,7 +1229,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             return_tip: If `True`, return tips to the tip rack location they were picked up from,
                         otherwise drop in `trash_location`
             keep_last_tip: When set to `True`, do not drop the final tip used in the transfer.
-            last_tip_used: If a tip is already attached, this will be the tiprack and well it was
+            last_tip_location: If a tip is already attached, this will be the tiprack and well it was
                            picked up from, represented as a tuple of types.Location and WellCore.
                            Used so a tip can be returned if it was picked up outside this function
                            as could be the case for a new_tip of `never`.
@@ -1284,7 +1284,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             )
         )
 
-        last_tip = last_tip_used
+        last_tip = last_tip_location
 
         def _drop_tip() -> None:
             if return_tip:
@@ -1446,7 +1446,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         trash_location: Union[Location, TrashBin, WasteChute],
         return_tip: bool,
         keep_last_tip: bool,
-        last_tip_used: Optional[Tuple[Location, WellCore]],
+        last_tip_location: Optional[Tuple[Location, WellCore]],
     ) -> Optional[Tuple[Location, WellCore]]:
         """Execute a distribution using liquid class properties.
 
@@ -1470,7 +1470,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             return_tip: If `True`, return tips to the tip rack location they were picked up from,
                         otherwise drop in `trash_location`
             keep_last_tip: When set to `True`, do not drop the final tip used in the distribute.
-            last_tip_used: If a tip is already attached, this will be the tiprack and well it was
+            last_tip_location: If a tip is already attached, this will be the tiprack and well it was
                            picked up from, represented as a tuple of types.Location and WellCore.
                            Used so a tip can be returned if it was picked up outside this function
                            as could be the case for a new_tip of `never`
@@ -1548,7 +1548,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                 trash_location=trash_location,
                 return_tip=return_tip,
                 keep_last_tip=keep_last_tip,
-                last_tip_used=last_tip_used,
+                last_tip_location=last_tip_location,
             )
 
         # TODO: use the ID returned by load_liquid_class in command annotations
@@ -1576,7 +1576,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             )
         )
 
-        last_tip = last_tip_used
+        last_tip = last_tip_location
 
         def _drop_tip() -> None:
             if return_tip:
@@ -1808,7 +1808,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         trash_location: Union[Location, TrashBin, WasteChute],
         return_tip: bool,
         keep_last_tip: bool,
-        last_tip_used: Optional[Tuple[Location, WellCore]],
+        last_tip_location: Optional[Tuple[Location, WellCore]],
     ) -> Optional[Tuple[Location, WellCore]]:
         """Execute consolidate using liquid class properties.
 
@@ -1833,7 +1833,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             return_tip: If `True`, return tips to the tip rack location they were picked up from,
                         otherwise drop in `trash_location`
             keep_last_tip: When set to `True`, do not drop the final tip used in the consolidate.
-            last_tip_used: If a tip is already attached, this will be the tiprack and well it was
+            last_tip_location: If a tip is already attached, this will be the tiprack and well it was
                            picked up from, represented as a tuple of types.Location and WellCore.
                            Used so a tip can be returned if it was picked up outside this function
                            as could be the case for a new_tip of `never`.
@@ -1897,7 +1897,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             )
         )
 
-        last_tip = last_tip_used
+        last_tip = last_tip_location
 
         def _drop_tip() -> None:
             if return_tip:

--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -1426,6 +1426,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
 
         if not keep_last_tip:
             _drop_tip()
+            last_tip = None
 
         return last_tip
 
@@ -1766,6 +1767,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
 
         if not keep_last_tip:
             _drop_tip()
+            last_tip = None
 
         return last_tip
 
@@ -2034,6 +2036,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
 
         if not keep_last_tip:
             _drop_tip()
+            last_tip = None
 
         return last_tip
 

--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -1221,8 +1221,18 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                     types.Location is only necessary for saving the last accessed location.
             new_tip: Whether the transfer should use a new tip 'once', 'never', 'always',
                      or 'per source'.
-            tiprack_uri: The URI of the tiprack that the transfer settings are for.
-            tip_drop_location: Location where the tip will be dropped (if appropriate).
+            tip_racks: List of tipracks that the transfer will pick up tips from, represented
+                       as tuples of types.Location and WellCore.
+            starting_tip: The user-chosen starting tip to use when deciding what tip to pick
+                          up, if the user has set it.
+            trash_location: The chosen trash container to drop tips in and dispose liquid in.
+            return_tip: If `True`, return tips to the tip rack location they were picked up from,
+                        otherwise drop in `trash_location`
+            keep_last_tip: When set to `True`, do not drop the final tip used in the transfer.
+            last_tip_used: If a tip is already attached, this will be the tiprack and well it was
+                           picked up from, represented as a tuple of types.Location and WellCore.
+                           Used so a tip can be returned if it was picked up outside this function
+                           as could be the case for a new_tip of `never`.
         """
         if not tip_racks:
             raise RuntimeError(
@@ -1419,7 +1429,6 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
 
         return last_tip
 
-    # TODO(spp, 2025-02-25): wire up return tip
     def distribute_with_liquid_class(  # noqa: C901
         self,
         liquid_class: LiquidClass,
@@ -1452,8 +1461,18 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                      'never': the transfer will never pick up a new tip
                      'once': the transfer will pick up a new tip once at the start of transfer
                      'always': the transfer will pick up a new tip before every aspirate
-            tiprack_uri: The URI of the tiprack that the transfer settings are for.
-            tip_drop_location: Location where the tip will be dropped (if appropriate).
+            tip_racks: List of tipracks that the transfer will pick up tips from, represented
+                       as tuples of types.Location and WellCore.
+            starting_tip: The user-chosen starting tip to use when deciding what tip to pick
+                          up, if the user has set it.
+            trash_location: The chosen trash container to drop tips in and dispose liquid in.
+            return_tip: If `True`, return tips to the tip rack location they were picked up from,
+                        otherwise drop in `trash_location`
+            keep_last_tip: When set to `True`, do not drop the final tip used in the distribute.
+            last_tip_used: If a tip is already attached, this will be the tiprack and well it was
+                           picked up from, represented as a tuple of types.Location and WellCore.
+                           Used so a tip can be returned if it was picked up outside this function
+                           as could be the case for a new_tip of `never`
 
         This method distributes the liquid in the source well into multiple destinations.
         It can accomplish this by either doing a multi-dispense (aspirate once and then
@@ -1461,7 +1480,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         (going back to aspirate after each dispense). Whether it does a multi-dispense or
         multiple single dispenses is determined by whether multi-dispense properties
         are available in the liquid class and whether the tip in use can hold multiple
-        volumes to be dispensed whithout having to refill.
+        volumes to be dispensed without having to refill.
         """
         if not tip_racks:
             raise RuntimeError(
@@ -1789,6 +1808,34 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         keep_last_tip: bool,
         last_tip_used: Optional[Tuple[Location, WellCore]],
     ) -> Optional[Tuple[Location, WellCore]]:
+        """Execute consolidate using liquid class properties.
+
+        Args:
+            liquid_class: The liquid class to use for transfer properties.
+            volume: Volume to transfer per well.
+            source: List of source wells, with each well represented as a tuple of
+                    types.Location and WellCore.
+                    types.Location is only necessary for saving the last accessed location.
+            dest: List of destination wells, with each well represented as a tuple of
+                    types.Location and WellCore.
+                    types.Location is only necessary for saving the last accessed location.
+            new_tip: Whether the transfer should use a new tip 'once', 'always' or 'never'.
+                     'never': the transfer will never pick up a new tip
+                     'once': the transfer will pick up a new tip once at the start of transfer
+                     'always': the transfer will pick up a new tip after every dispense
+            tip_racks: List of tipracks that the transfer will pick up tips from, represented
+                       as tuples of types.Location and WellCore.
+            starting_tip: The user-chosen starting tip to use when deciding what tip to pick
+                          up, if the user has set it.
+            trash_location: The chosen trash container to drop tips in and dispose liquid in.
+            return_tip: If `True`, return tips to the tip rack location they were picked up from,
+                        otherwise drop in `trash_location`
+            keep_last_tip: When set to `True`, do not drop the final tip used in the consolidate.
+            last_tip_used: If a tip is already attached, this will be the tiprack and well it was
+                           picked up from, represented as a tuple of types.Location and WellCore.
+                           Used so a tip can be returned if it was picked up outside this function
+                           as could be the case for a new_tip of `never`.
+        """
         if not tip_racks:
             raise RuntimeError(
                 "No tipracks found for pipette in order to perform transfer"

--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -1206,7 +1206,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         trash_location: Union[Location, TrashBin, WasteChute],
         return_tip: bool,
         keep_last_tip: bool,
-    ) -> None:
+    ) -> Optional[Tuple[Location, WellCore]]:
         """Execute transfer using liquid class properties.
 
         Args:
@@ -1273,14 +1273,15 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             )
         )
 
-        last_tip_picked_up_from: Optional[WellCore] = None
+        last_tip: Optional[Tuple[Location, WellCore]] = None
 
         def _drop_tip() -> None:
             if return_tip:
-                assert last_tip_picked_up_from is not None
+                assert last_tip is not None
+                _, tip_well = last_tip
                 self.drop_tip(
                     location=None,
-                    well_core=last_tip_picked_up_from,
+                    well_core=tip_well,
                     home_after=False,
                     alternate_drop_location=False,
                 )
@@ -1298,7 +1299,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                     alternate_drop_location=True,
                 )
 
-        def _pick_up_tip() -> WellCore:
+        def _pick_up_tip() -> Tuple[Location, WellCore]:
             next_tip = self.get_next_tip(
                 tip_racks=[core for loc, core in tip_racks],
                 starting_well=starting_tip,
@@ -1324,10 +1325,10 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                 presses=None,
                 increment=None,
             )
-            return tip_well
+            return tiprack_loc, tip_well
 
         if new_tip == TransferTipPolicyV2.ONCE:
-            last_tip_picked_up_from = _pick_up_tip()
+            last_tip = _pick_up_tip()
 
         prev_src: Optional[Tuple[Location, WellCore]] = None
         prev_dest: Optional[
@@ -1365,7 +1366,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             ):
                 if prev_src is not None and prev_dest is not None:
                     _drop_tip()
-                last_tip_picked_up_from = _pick_up_tip()
+                last_tip = _pick_up_tip()
                 post_disp_tip_contents = [
                     tx_comps_executor.LiquidAndAirGapPair(
                         liquid=0,
@@ -1415,6 +1416,8 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         if not keep_last_tip:
             _drop_tip()
 
+        return last_tip
+
     # TODO(spp, 2025-02-25): wire up return tip
     def distribute_with_liquid_class(  # noqa: C901
         self,
@@ -1432,7 +1435,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         trash_location: Union[Location, TrashBin, WasteChute],
         return_tip: bool,
         keep_last_tip: bool,
-    ) -> None:
+    ) -> Optional[Tuple[Location, WellCore]]:
         """Execute a distribution using liquid class properties.
 
         Args:
@@ -1512,7 +1515,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                 tip_working_volume=working_volume,
             )
         ):
-            self.transfer_with_liquid_class(
+            return self.transfer_with_liquid_class(
                 liquid_class=liquid_class,
                 volume=volume,
                 source=[source for _ in range(len(dest))],
@@ -1524,7 +1527,6 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                 return_tip=return_tip,
                 keep_last_tip=keep_last_tip,
             )
-            return
 
         # TODO: use the ID returned by load_liquid_class in command annotations
         self.load_liquid_class(
@@ -1551,14 +1553,15 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             )
         )
 
-        last_tip_picked_up_from: Optional[WellCore] = None
+        last_tip: Optional[Tuple[Location, WellCore]] = None
 
         def _drop_tip() -> None:
             if return_tip:
-                assert last_tip_picked_up_from is not None
+                assert last_tip is not None
+                _, tip_well = last_tip
                 self.drop_tip(
                     location=None,
-                    well_core=last_tip_picked_up_from,
+                    well_core=tip_well,
                     home_after=False,
                     alternate_drop_location=False,
                 )
@@ -1576,7 +1579,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                     alternate_drop_location=True,
                 )
 
-        def _pick_up_tip() -> WellCore:
+        def _pick_up_tip() -> Tuple[Location, WellCore]:
             next_tip = self.get_next_tip(
                 tip_racks=[core for loc, core in tip_racks],
                 starting_well=starting_tip,
@@ -1602,10 +1605,10 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                 presses=None,
                 increment=None,
             )
-            return tip_well
+            return tiprack_loc, tip_well
 
         if new_tip != TransferTipPolicyV2.NEVER:
-            last_tip_picked_up_from = _pick_up_tip()
+            last_tip = _pick_up_tip()
 
         tip_contents = [
             tx_comps_executor.LiquidAndAirGapPair(
@@ -1682,7 +1685,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
 
             if not is_first_step and new_tip == TransferTipPolicyV2.ALWAYS:
                 _drop_tip()
-                last_tip_picked_up_from = _pick_up_tip()
+                last_tip = _pick_up_tip()
                 tip_contents = [
                     tx_comps_executor.LiquidAndAirGapPair(
                         liquid=0,
@@ -1742,6 +1745,8 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         if not keep_last_tip:
             _drop_tip()
 
+        return last_tip
+
     def _tip_can_hold_volume_for_multi_dispensing(
         self,
         transfer_volume: float,
@@ -1779,7 +1784,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         trash_location: Union[Location, TrashBin, WasteChute],
         return_tip: bool,
         keep_last_tip: bool,
-    ) -> None:
+    ) -> Optional[Tuple[Location, WellCore]]:
         if not tip_racks:
             raise RuntimeError(
                 "No tipracks found for pipette in order to perform transfer"
@@ -1839,14 +1844,15 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             )
         )
 
-        last_tip_picked_up_from: Optional[WellCore] = None
+        last_tip: Optional[Tuple[Location, WellCore]] = None
 
         def _drop_tip() -> None:
             if return_tip:
-                assert last_tip_picked_up_from is not None
+                assert last_tip is not None
+                _, tip_well = last_tip
                 self.drop_tip(
                     location=None,
-                    well_core=last_tip_picked_up_from,
+                    well_core=tip_well,
                     home_after=False,
                     alternate_drop_location=False,
                 )
@@ -1864,7 +1870,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                     alternate_drop_location=True,
                 )
 
-        def _pick_up_tip() -> WellCore:
+        def _pick_up_tip() -> Tuple[Location, WellCore]:
             next_tip = self.get_next_tip(
                 tip_racks=[core for loc, core in tip_racks],
                 starting_well=starting_tip,
@@ -1890,10 +1896,10 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                 presses=None,
                 increment=None,
             )
-            return tip_well
+            return tiprack_loc, tip_well
 
         if new_tip in [TransferTipPolicyV2.ONCE, TransferTipPolicyV2.ALWAYS]:
-            last_tip_picked_up_from = _pick_up_tip()
+            last_tip = _pick_up_tip()
 
         tip_contents = [
             tx_comps_executor.LiquidAndAirGapPair(
@@ -1930,7 +1936,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                 enable_lpd = True
             elif not is_first_step and new_tip == TransferTipPolicyV2.ALWAYS:
                 _drop_tip()
-                last_tip_picked_up_from = _pick_up_tip()
+                last_tip = _pick_up_tip()
                 tip_contents = [
                     tx_comps_executor.LiquidAndAirGapPair(
                         liquid=0,
@@ -1977,6 +1983,8 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
 
         if not keep_last_tip:
             _drop_tip()
+
+        return last_tip
 
     def _get_location_and_well_core_from_next_tip_info(
         self,

--- a/api/src/opentrons/protocol_api/core/instrument.py
+++ b/api/src/opentrons/protocol_api/core/instrument.py
@@ -372,7 +372,7 @@ class AbstractInstrument(ABC, Generic[WellCoreType, LabwareCoreType]):
         trash_location: Union[types.Location, TrashBin, WasteChute],
         return_tip: bool,
         keep_last_tip: bool,
-    ) -> None:
+    ) -> Optional[Tuple[types.Location, WellCoreType]]:
         """Transfer a liquid from source to dest according to liquid class properties."""
         ...
 
@@ -389,7 +389,7 @@ class AbstractInstrument(ABC, Generic[WellCoreType, LabwareCoreType]):
         trash_location: Union[types.Location, TrashBin, WasteChute],
         return_tip: bool,
         keep_last_tip: bool,
-    ) -> None:
+    ) -> Optional[Tuple[types.Location, WellCoreType]]:
         """
         Distribute a liquid from single source to multiple destinations
         according to liquid class properties.
@@ -409,7 +409,7 @@ class AbstractInstrument(ABC, Generic[WellCoreType, LabwareCoreType]):
         trash_location: Union[types.Location, TrashBin, WasteChute],
         return_tip: bool,
         keep_last_tip: bool,
-    ) -> None:
+    ) -> Optional[Tuple[types.Location, WellCoreType]]:
         """
         Consolidate liquid from multiple sources to a single destination
         using the specified liquid class properties.

--- a/api/src/opentrons/protocol_api/core/instrument.py
+++ b/api/src/opentrons/protocol_api/core/instrument.py
@@ -372,6 +372,7 @@ class AbstractInstrument(ABC, Generic[WellCoreType, LabwareCoreType]):
         trash_location: Union[types.Location, TrashBin, WasteChute],
         return_tip: bool,
         keep_last_tip: bool,
+        last_tip_used: Optional[Tuple[types.Location, WellCoreType]],
     ) -> Optional[Tuple[types.Location, WellCoreType]]:
         """Transfer a liquid from source to dest according to liquid class properties."""
         ...
@@ -389,6 +390,7 @@ class AbstractInstrument(ABC, Generic[WellCoreType, LabwareCoreType]):
         trash_location: Union[types.Location, TrashBin, WasteChute],
         return_tip: bool,
         keep_last_tip: bool,
+        last_tip_used: Optional[Tuple[types.Location, WellCoreType]],
     ) -> Optional[Tuple[types.Location, WellCoreType]]:
         """
         Distribute a liquid from single source to multiple destinations
@@ -409,6 +411,7 @@ class AbstractInstrument(ABC, Generic[WellCoreType, LabwareCoreType]):
         trash_location: Union[types.Location, TrashBin, WasteChute],
         return_tip: bool,
         keep_last_tip: bool,
+        last_tip_used: Optional[Tuple[types.Location, WellCoreType]],
     ) -> Optional[Tuple[types.Location, WellCoreType]]:
         """
         Consolidate liquid from multiple sources to a single destination

--- a/api/src/opentrons/protocol_api/core/instrument.py
+++ b/api/src/opentrons/protocol_api/core/instrument.py
@@ -372,7 +372,7 @@ class AbstractInstrument(ABC, Generic[WellCoreType, LabwareCoreType]):
         trash_location: Union[types.Location, TrashBin, WasteChute],
         return_tip: bool,
         keep_last_tip: bool,
-        last_tip_used: Optional[Tuple[types.Location, WellCoreType]],
+        last_tip_location: Optional[Tuple[types.Location, WellCoreType]],
     ) -> Optional[Tuple[types.Location, WellCoreType]]:
         """Transfer a liquid from source to dest according to liquid class properties."""
         ...
@@ -390,7 +390,7 @@ class AbstractInstrument(ABC, Generic[WellCoreType, LabwareCoreType]):
         trash_location: Union[types.Location, TrashBin, WasteChute],
         return_tip: bool,
         keep_last_tip: bool,
-        last_tip_used: Optional[Tuple[types.Location, WellCoreType]],
+        last_tip_location: Optional[Tuple[types.Location, WellCoreType]],
     ) -> Optional[Tuple[types.Location, WellCoreType]]:
         """
         Distribute a liquid from single source to multiple destinations
@@ -411,7 +411,7 @@ class AbstractInstrument(ABC, Generic[WellCoreType, LabwareCoreType]):
         trash_location: Union[types.Location, TrashBin, WasteChute],
         return_tip: bool,
         keep_last_tip: bool,
-        last_tip_used: Optional[Tuple[types.Location, WellCoreType]],
+        last_tip_location: Optional[Tuple[types.Location, WellCoreType]],
     ) -> Optional[Tuple[types.Location, WellCoreType]]:
         """
         Consolidate liquid from multiple sources to a single destination

--- a/api/src/opentrons/protocol_api/core/legacy/legacy_instrument_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy/legacy_instrument_core.py
@@ -612,7 +612,7 @@ class LegacyInstrumentCore(AbstractInstrument[LegacyWellCore, LegacyLabwareCore]
         trash_location: Union[types.Location, TrashBin, WasteChute],
         return_tip: bool,
         keep_last_tip: bool,
-    ) -> None:
+    ) -> Optional[Tuple[types.Location, LegacyWellCore]]:
         """This will never be called because it was added in API 2.23"""
         assert False, "transfer_liquid is not supported in legacy context"
 
@@ -628,7 +628,7 @@ class LegacyInstrumentCore(AbstractInstrument[LegacyWellCore, LegacyLabwareCore]
         trash_location: Union[types.Location, TrashBin, WasteChute],
         return_tip: bool,
         keep_last_tip: bool,
-    ) -> None:
+    ) -> Optional[Tuple[types.Location, LegacyWellCore]]:
         """This will never be called because it was added in API 2.23"""
         assert False, "distribute_liquid is not supported in legacy context"
 
@@ -644,7 +644,7 @@ class LegacyInstrumentCore(AbstractInstrument[LegacyWellCore, LegacyLabwareCore]
         trash_location: Union[types.Location, TrashBin, WasteChute],
         return_tip: bool,
         keep_last_tip: bool,
-    ) -> None:
+    ) -> Optional[Tuple[types.Location, LegacyWellCore]]:
         """This will never be called because it was added in API 2.23."""
         assert False, "consolidate_liquid is not supported in legacy context"
 

--- a/api/src/opentrons/protocol_api/core/legacy/legacy_instrument_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy/legacy_instrument_core.py
@@ -612,6 +612,7 @@ class LegacyInstrumentCore(AbstractInstrument[LegacyWellCore, LegacyLabwareCore]
         trash_location: Union[types.Location, TrashBin, WasteChute],
         return_tip: bool,
         keep_last_tip: bool,
+        last_tip_used: Optional[Tuple[types.Location, LegacyWellCore]],
     ) -> Optional[Tuple[types.Location, LegacyWellCore]]:
         """This will never be called because it was added in API 2.23"""
         assert False, "transfer_liquid is not supported in legacy context"
@@ -628,6 +629,7 @@ class LegacyInstrumentCore(AbstractInstrument[LegacyWellCore, LegacyLabwareCore]
         trash_location: Union[types.Location, TrashBin, WasteChute],
         return_tip: bool,
         keep_last_tip: bool,
+        last_tip_used: Optional[Tuple[types.Location, LegacyWellCore]],
     ) -> Optional[Tuple[types.Location, LegacyWellCore]]:
         """This will never be called because it was added in API 2.23"""
         assert False, "distribute_liquid is not supported in legacy context"
@@ -644,6 +646,7 @@ class LegacyInstrumentCore(AbstractInstrument[LegacyWellCore, LegacyLabwareCore]
         trash_location: Union[types.Location, TrashBin, WasteChute],
         return_tip: bool,
         keep_last_tip: bool,
+        last_tip_used: Optional[Tuple[types.Location, LegacyWellCore]],
     ) -> Optional[Tuple[types.Location, LegacyWellCore]]:
         """This will never be called because it was added in API 2.23."""
         assert False, "consolidate_liquid is not supported in legacy context"

--- a/api/src/opentrons/protocol_api/core/legacy/legacy_instrument_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy/legacy_instrument_core.py
@@ -612,7 +612,7 @@ class LegacyInstrumentCore(AbstractInstrument[LegacyWellCore, LegacyLabwareCore]
         trash_location: Union[types.Location, TrashBin, WasteChute],
         return_tip: bool,
         keep_last_tip: bool,
-        last_tip_used: Optional[Tuple[types.Location, LegacyWellCore]],
+        last_tip_location: Optional[Tuple[types.Location, LegacyWellCore]],
     ) -> Optional[Tuple[types.Location, LegacyWellCore]]:
         """This will never be called because it was added in API 2.23"""
         assert False, "transfer_liquid is not supported in legacy context"
@@ -629,7 +629,7 @@ class LegacyInstrumentCore(AbstractInstrument[LegacyWellCore, LegacyLabwareCore]
         trash_location: Union[types.Location, TrashBin, WasteChute],
         return_tip: bool,
         keep_last_tip: bool,
-        last_tip_used: Optional[Tuple[types.Location, LegacyWellCore]],
+        last_tip_location: Optional[Tuple[types.Location, LegacyWellCore]],
     ) -> Optional[Tuple[types.Location, LegacyWellCore]]:
         """This will never be called because it was added in API 2.23"""
         assert False, "distribute_liquid is not supported in legacy context"
@@ -646,7 +646,7 @@ class LegacyInstrumentCore(AbstractInstrument[LegacyWellCore, LegacyLabwareCore]
         trash_location: Union[types.Location, TrashBin, WasteChute],
         return_tip: bool,
         keep_last_tip: bool,
-        last_tip_used: Optional[Tuple[types.Location, LegacyWellCore]],
+        last_tip_location: Optional[Tuple[types.Location, LegacyWellCore]],
     ) -> Optional[Tuple[types.Location, LegacyWellCore]]:
         """This will never be called because it was added in API 2.23."""
         assert False, "consolidate_liquid is not supported in legacy context"

--- a/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_instrument_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_instrument_core.py
@@ -526,6 +526,7 @@ class LegacyInstrumentCoreSimulator(
         trash_location: Union[types.Location, TrashBin, WasteChute],
         return_tip: bool,
         keep_last_tip: bool,
+        last_tip_used: Optional[Tuple[types.Location, LegacyWellCore]],
     ) -> Optional[Tuple[types.Location, LegacyWellCore]]:
         """This will never be called because it was added in API 2.23."""
         assert False, "transfer_liquid is not supported in legacy context"
@@ -542,6 +543,7 @@ class LegacyInstrumentCoreSimulator(
         trash_location: Union[types.Location, TrashBin, WasteChute],
         return_tip: bool,
         keep_last_tip: bool,
+        last_tip_used: Optional[Tuple[types.Location, LegacyWellCore]],
     ) -> Optional[Tuple[types.Location, LegacyWellCore]]:
         """This will never be called because it was added in API 2.23."""
         assert False, "distribute_liquid is not supported in legacy context"
@@ -558,6 +560,7 @@ class LegacyInstrumentCoreSimulator(
         trash_location: Union[types.Location, TrashBin, WasteChute],
         return_tip: bool,
         keep_last_tip: bool,
+        last_tip_used: Optional[Tuple[types.Location, LegacyWellCore]],
     ) -> Optional[Tuple[types.Location, LegacyWellCore]]:
         """This will never be called because it was added in API 2.23."""
         assert False, "consolidate_liquid is not supported in legacy context"

--- a/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_instrument_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_instrument_core.py
@@ -526,7 +526,7 @@ class LegacyInstrumentCoreSimulator(
         trash_location: Union[types.Location, TrashBin, WasteChute],
         return_tip: bool,
         keep_last_tip: bool,
-        last_tip_used: Optional[Tuple[types.Location, LegacyWellCore]],
+        last_tip_location: Optional[Tuple[types.Location, LegacyWellCore]],
     ) -> Optional[Tuple[types.Location, LegacyWellCore]]:
         """This will never be called because it was added in API 2.23."""
         assert False, "transfer_liquid is not supported in legacy context"
@@ -543,7 +543,7 @@ class LegacyInstrumentCoreSimulator(
         trash_location: Union[types.Location, TrashBin, WasteChute],
         return_tip: bool,
         keep_last_tip: bool,
-        last_tip_used: Optional[Tuple[types.Location, LegacyWellCore]],
+        last_tip_location: Optional[Tuple[types.Location, LegacyWellCore]],
     ) -> Optional[Tuple[types.Location, LegacyWellCore]]:
         """This will never be called because it was added in API 2.23."""
         assert False, "distribute_liquid is not supported in legacy context"
@@ -560,7 +560,7 @@ class LegacyInstrumentCoreSimulator(
         trash_location: Union[types.Location, TrashBin, WasteChute],
         return_tip: bool,
         keep_last_tip: bool,
-        last_tip_used: Optional[Tuple[types.Location, LegacyWellCore]],
+        last_tip_location: Optional[Tuple[types.Location, LegacyWellCore]],
     ) -> Optional[Tuple[types.Location, LegacyWellCore]]:
         """This will never be called because it was added in API 2.23."""
         assert False, "consolidate_liquid is not supported in legacy context"

--- a/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_instrument_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_instrument_core.py
@@ -526,7 +526,7 @@ class LegacyInstrumentCoreSimulator(
         trash_location: Union[types.Location, TrashBin, WasteChute],
         return_tip: bool,
         keep_last_tip: bool,
-    ) -> None:
+    ) -> Optional[Tuple[types.Location, LegacyWellCore]]:
         """This will never be called because it was added in API 2.23."""
         assert False, "transfer_liquid is not supported in legacy context"
 
@@ -542,7 +542,7 @@ class LegacyInstrumentCoreSimulator(
         trash_location: Union[types.Location, TrashBin, WasteChute],
         return_tip: bool,
         keep_last_tip: bool,
-    ) -> None:
+    ) -> Optional[Tuple[types.Location, LegacyWellCore]]:
         """This will never be called because it was added in API 2.23."""
         assert False, "distribute_liquid is not supported in legacy context"
 
@@ -558,7 +558,7 @@ class LegacyInstrumentCoreSimulator(
         trash_location: Union[types.Location, TrashBin, WasteChute],
         return_tip: bool,
         keep_last_tip: bool,
-    ) -> None:
+    ) -> Optional[Tuple[types.Location, LegacyWellCore]]:
         """This will never be called because it was added in API 2.23."""
         assert False, "consolidate_liquid is not supported in legacy context"
 

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1910,6 +1910,7 @@ class InstrumentContext(publisher.CommandPublisher):
                 trash_location=transfer_args.trash_location,
                 return_tip=return_tip,
                 keep_last_tip=verified_keep_last_tip,
+                last_tip_used=transfer_args.last_tip_used,
             )
 
         # TODO(jbl 2025-06-23) last_tip_picked_up_from should be removed from the public context and
@@ -2055,6 +2056,7 @@ class InstrumentContext(publisher.CommandPublisher):
                 trash_location=transfer_args.trash_location,
                 return_tip=return_tip,
                 keep_last_tip=verified_keep_last_tip,
+                last_tip_used=transfer_args.last_tip_used,
             )
 
         # TODO(jbl 2025-06-23) last_tip_picked_up_from should be removed from the public context and
@@ -2200,6 +2202,7 @@ class InstrumentContext(publisher.CommandPublisher):
                 trash_location=transfer_args.trash_location,
                 return_tip=return_tip,
                 keep_last_tip=verified_keep_last_tip,
+                last_tip_used=transfer_args.last_tip_used,
             )
 
         # TODO(jbl 2025-06-23) last_tip_picked_up_from should be removed from the public context and

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1851,7 +1851,7 @@ class InstrumentContext(publisher.CommandPublisher):
             source=source,
             dest=dest,
             tip_policy=new_tip,
-            last_tip_picked_up_from=self._last_tip_picked_up_from,
+            last_tip_well=self._last_tip_picked_up_from,
             tip_racks=self._tip_racks,
             nozzle_map=self._core.get_nozzle_map(),
             group_wells_for_multi_channel=group_wells,
@@ -1910,7 +1910,7 @@ class InstrumentContext(publisher.CommandPublisher):
                 trash_location=transfer_args.trash_location,
                 return_tip=return_tip,
                 keep_last_tip=verified_keep_last_tip,
-                last_tip_used=transfer_args.last_tip_used,
+                last_tip_location=transfer_args.last_tip_location,
             )
 
         # TODO(jbl 2025-06-23) last_tip_picked_up_from should be removed from the public context and
@@ -1991,7 +1991,7 @@ class InstrumentContext(publisher.CommandPublisher):
             source=source,
             dest=dest,
             tip_policy=new_tip,
-            last_tip_picked_up_from=self._last_tip_picked_up_from,
+            last_tip_well=self._last_tip_picked_up_from,
             tip_racks=self._tip_racks,
             nozzle_map=self._core.get_nozzle_map(),
             group_wells_for_multi_channel=group_wells,
@@ -2058,7 +2058,7 @@ class InstrumentContext(publisher.CommandPublisher):
                 trash_location=transfer_args.trash_location,
                 return_tip=return_tip,
                 keep_last_tip=verified_keep_last_tip,
-                last_tip_used=transfer_args.last_tip_used,
+                last_tip_location=transfer_args.last_tip_location,
             )
 
         # TODO(jbl 2025-06-23) last_tip_picked_up_from should be removed from the public context and
@@ -2140,7 +2140,7 @@ class InstrumentContext(publisher.CommandPublisher):
             source=source,
             dest=dest,
             tip_policy=new_tip,
-            last_tip_picked_up_from=self._last_tip_picked_up_from,
+            last_tip_well=self._last_tip_picked_up_from,
             tip_racks=self._tip_racks,
             nozzle_map=self._core.get_nozzle_map(),
             group_wells_for_multi_channel=group_wells,
@@ -2206,7 +2206,7 @@ class InstrumentContext(publisher.CommandPublisher):
                 trash_location=transfer_args.trash_location,
                 return_tip=return_tip,
                 keep_last_tip=verified_keep_last_tip,
-                last_tip_used=transfer_args.last_tip_used,
+                last_tip_location=transfer_args.last_tip_location,
             )
 
         # TODO(jbl 2025-06-23) last_tip_picked_up_from should be removed from the public context and

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1920,6 +1920,8 @@ class InstrumentContext(publisher.CommandPublisher):
             self._last_tip_picked_up_from = tip_rack_loc.labware.as_labware()[
                 tip_well_core.get_name()
             ]
+        else:
+            self._last_tip_picked_up_from = None
 
         return self
 
@@ -2066,6 +2068,8 @@ class InstrumentContext(publisher.CommandPublisher):
             self._last_tip_picked_up_from = tip_rack_loc.labware.as_labware()[
                 tip_well_core.get_name()
             ]
+        else:
+            self._last_tip_picked_up_from = None
 
         return self
 
@@ -2212,6 +2216,8 @@ class InstrumentContext(publisher.CommandPublisher):
             self._last_tip_picked_up_from = tip_rack_loc.labware.as_labware()[
                 tip_well_core.get_name()
             ]
+        else:
+            self._last_tip_picked_up_from = None
 
         return self
 

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1891,7 +1891,7 @@ class InstrumentContext(publisher.CommandPublisher):
                 destination=dest,
             ),
         ):
-            self._core.transfer_with_liquid_class(
+            last_tip_location = self._core.transfer_with_liquid_class(
                 liquid_class=liquid_class,
                 volume=volume,
                 source=[
@@ -1911,6 +1911,15 @@ class InstrumentContext(publisher.CommandPublisher):
                 return_tip=return_tip,
                 keep_last_tip=verified_keep_last_tip,
             )
+
+        # TODO(jbl 2025-06-23) last_tip_picked_up_from should be removed from the public context and
+        #   moved to the engine core or engine as a simpler and more holistic solution
+        if last_tip_location is not None:
+            tip_rack_loc, tip_well_core = last_tip_location
+            self._last_tip_picked_up_from = tip_rack_loc.labware.as_labware()[
+                tip_well_core.get_name()
+            ]
+
         return self
 
     @requires_version(2, 23)
@@ -2024,7 +2033,7 @@ class InstrumentContext(publisher.CommandPublisher):
                 destination=dest,
             ),
         ):
-            self._core.distribute_with_liquid_class(
+            last_tip_location = self._core.distribute_with_liquid_class(
                 liquid_class=liquid_class,
                 volume=volume,
                 source=(
@@ -2047,6 +2056,15 @@ class InstrumentContext(publisher.CommandPublisher):
                 return_tip=return_tip,
                 keep_last_tip=verified_keep_last_tip,
             )
+
+        # TODO(jbl 2025-06-23) last_tip_picked_up_from should be removed from the public context and
+        #   moved to the engine core or engine as a simpler and more holistic solution
+        if last_tip_location is not None:
+            tip_rack_loc, tip_well_core = last_tip_location
+            self._last_tip_picked_up_from = tip_rack_loc.labware.as_labware()[
+                tip_well_core.get_name()
+            ]
+
         return self
 
     @requires_version(2, 23)
@@ -2163,7 +2181,7 @@ class InstrumentContext(publisher.CommandPublisher):
                 destination=dest,
             ),
         ):
-            self._core.consolidate_with_liquid_class(
+            last_tip_location = self._core.consolidate_with_liquid_class(
                 liquid_class=liquid_class,
                 volume=volume,
                 source=[
@@ -2183,6 +2201,15 @@ class InstrumentContext(publisher.CommandPublisher):
                 return_tip=return_tip,
                 keep_last_tip=verified_keep_last_tip,
             )
+
+        # TODO(jbl 2025-06-23) last_tip_picked_up_from should be removed from the public context and
+        #   moved to the engine core or engine as a simpler and more holistic solution
+        if last_tip_location is not None:
+            tip_rack_loc, tip_well_core = last_tip_location
+            self._last_tip_picked_up_from = tip_rack_loc.labware.as_labware()[
+                tip_well_core.get_name()
+            ]
+
         return self
 
     @requires_version(2, 0)

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -2495,6 +2495,7 @@ def test_transfer_liquid_delegates_to_engine_core(
             trash_location=trash_location,
             return_tip=True,
             keep_last_tip=False,
+            last_tip_used=None,
         )
     )
 
@@ -2553,6 +2554,7 @@ def test_transfer_liquid_multi_channel_delegates_to_engine_core(
             trash_location=trash_location,
             return_tip=True,
             keep_last_tip=False,
+            last_tip_used=None,
         )
     )
 
@@ -2604,6 +2606,7 @@ def test_transfer_liquid_delegates_to_engine_core_with_trash_destination(
             trash_location=trash_location,
             return_tip=True,
             keep_last_tip=False,
+            last_tip_used=None,
         )
     )
 
@@ -2829,6 +2832,7 @@ def test_distribute_liquid_delegates_to_engine_core(
             trash_location=trash_location,
             return_tip=True,
             keep_last_tip=False,
+            last_tip_used=None,
         )
     )
 
@@ -2895,6 +2899,7 @@ def test_distribute_liquid_multi_channel_delegates_to_engine_core(
             trash_location=trash_location,
             return_tip=True,
             keep_last_tip=False,
+            last_tip_used=None,
         )
     )
 
@@ -3114,6 +3119,7 @@ def test_consolidate_liquid_delegates_to_engine_core(
             trash_location=trash_location,
             return_tip=True,
             keep_last_tip=False,
+            last_tip_used=None,
         )
     )
 
@@ -3181,6 +3187,7 @@ def test_consolidate_liquid_multi_channel_delegates_to_engine_core(
             trash_location=trash_location,
             return_tip=True,
             keep_last_tip=False,
+            last_tip_used=None,
         )
     )
 
@@ -3233,5 +3240,6 @@ def test_consolidate_liquid_delegates_to_engine_core_with_trash_destination(
             trash_location=trash_location,
             return_tip=True,
             keep_last_tip=False,
+            last_tip_used=None,
         )
     )

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -2495,7 +2495,7 @@ def test_transfer_liquid_delegates_to_engine_core(
             trash_location=trash_location,
             return_tip=True,
             keep_last_tip=False,
-            last_tip_used=None,
+            last_tip_location=None,
         )
     )
 
@@ -2554,7 +2554,7 @@ def test_transfer_liquid_multi_channel_delegates_to_engine_core(
             trash_location=trash_location,
             return_tip=True,
             keep_last_tip=False,
-            last_tip_used=None,
+            last_tip_location=None,
         )
     )
 
@@ -2606,7 +2606,7 @@ def test_transfer_liquid_delegates_to_engine_core_with_trash_destination(
             trash_location=trash_location,
             return_tip=True,
             keep_last_tip=False,
-            last_tip_used=None,
+            last_tip_location=None,
         )
     )
 
@@ -2832,7 +2832,7 @@ def test_distribute_liquid_delegates_to_engine_core(
             trash_location=trash_location,
             return_tip=True,
             keep_last_tip=False,
-            last_tip_used=None,
+            last_tip_location=None,
         )
     )
 
@@ -2899,7 +2899,7 @@ def test_distribute_liquid_multi_channel_delegates_to_engine_core(
             trash_location=trash_location,
             return_tip=True,
             keep_last_tip=False,
-            last_tip_used=None,
+            last_tip_location=None,
         )
     )
 
@@ -3119,7 +3119,7 @@ def test_consolidate_liquid_delegates_to_engine_core(
             trash_location=trash_location,
             return_tip=True,
             keep_last_tip=False,
-            last_tip_used=None,
+            last_tip_location=None,
         )
     )
 
@@ -3187,7 +3187,7 @@ def test_consolidate_liquid_multi_channel_delegates_to_engine_core(
             trash_location=trash_location,
             return_tip=True,
             keep_last_tip=False,
-            last_tip_used=None,
+            last_tip_location=None,
         )
     )
 
@@ -3240,6 +3240,6 @@ def test_consolidate_liquid_delegates_to_engine_core_with_trash_destination(
             trash_location=trash_location,
             return_tip=True,
             keep_last_tip=False,
-            last_tip_used=None,
+            last_tip_location=None,
         )
     )

--- a/api/tests/opentrons/protocol_api_integration/test_transfer_with_liquid_classes.py
+++ b/api/tests/opentrons/protocol_api_integration/test_transfer_with_liquid_classes.py
@@ -2365,3 +2365,199 @@ def test_raises_no_tips_available_error(
             new_tip="once",
             trash_location=trash,
         )
+
+
+@pytest.mark.ot3_only
+@pytest.mark.parametrize(
+    "simulated_protocol_context", [("2.24", "Flex")], indirect=True
+)
+def test_transfer_with_keep_last_tip(
+    simulated_protocol_context: ProtocolContext,
+) -> None:
+    """It should keep the last tip instead of dropping the last one."""
+    trash = simulated_protocol_context.load_trash_bin("A3")
+    tiprack = simulated_protocol_context.load_labware(
+        "opentrons_flex_96_tiprack_1000ul", "D1"
+    )
+    pipette_1k = simulated_protocol_context.load_instrument(
+        "flex_1channel_1000", mount="left", tip_racks=[tiprack]
+    )
+    nest_plate = simulated_protocol_context.load_labware(
+        "nest_96_wellplate_200ul_flat", "C3"
+    )
+    arma_plate = simulated_protocol_context.load_labware(
+        "armadillo_96_wellplate_200ul_pcr_full_skirt", "C2"
+    )
+    water = simulated_protocol_context.get_liquid_class("water")
+
+    with (
+        mock.patch.object(
+            InstrumentCore,
+            "pick_up_tip",
+            side_effect=InstrumentCore.pick_up_tip,
+            autospec=True,
+        ) as patched_pick_up_tip,
+        mock.patch.object(
+            InstrumentCore,
+            "drop_tip_in_disposal_location",
+            side_effect=InstrumentCore.drop_tip_in_disposal_location,
+            autospec=True,
+        ) as patched_drop_tip,
+    ):
+        mock_manager = mock.Mock()
+        mock_manager.attach_mock(patched_pick_up_tip, "pick_up_tip")
+        mock_manager.attach_mock(patched_drop_tip, "drop_tip_in_disposal_location")
+        pipette_1k.transfer_with_liquid_class(
+            liquid_class=water,
+            volume=400,
+            source=nest_plate.wells()[:2],
+            dest=arma_plate.wells()[:2],
+            new_tip="always",
+            trash_location=trash,
+            keep_last_tip=True,
+        )
+        expected_calls = [
+            mock.call.pick_up_tip(
+                mock.ANY,
+                location=mock.ANY,
+                well_core=mock.ANY,
+                presses=mock.ANY,
+                increment=mock.ANY,
+            ),
+            mock.call.drop_tip_in_disposal_location(
+                mock.ANY,
+                disposal_location=trash,
+                home_after=False,
+                alternate_tip_drop=True,
+            ),
+            mock.call.pick_up_tip(
+                mock.ANY,
+                location=mock.ANY,
+                well_core=mock.ANY,
+                presses=mock.ANY,
+                increment=mock.ANY,
+            ),
+        ]
+        assert mock_manager.mock_calls == expected_calls
+
+
+@pytest.mark.ot3_only
+@pytest.mark.parametrize(
+    "simulated_protocol_context", [("2.24", "Flex")], indirect=True
+)
+def test_transfer_with_keep_last_tip_false(
+    simulated_protocol_context: ProtocolContext,
+) -> None:
+    """It should not keep the last tip for a tip policy of never."""
+    trash = simulated_protocol_context.load_trash_bin("A3")
+    tiprack = simulated_protocol_context.load_labware(
+        "opentrons_flex_96_tiprack_1000ul", "D1"
+    )
+    pipette_1k = simulated_protocol_context.load_instrument(
+        "flex_1channel_1000", mount="left", tip_racks=[tiprack]
+    )
+    nest_plate = simulated_protocol_context.load_labware(
+        "nest_96_wellplate_200ul_flat", "C3"
+    )
+    arma_plate = simulated_protocol_context.load_labware(
+        "armadillo_96_wellplate_200ul_pcr_full_skirt", "C2"
+    )
+    water = simulated_protocol_context.get_liquid_class("water")
+
+    with (
+        mock.patch.object(
+            InstrumentCore,
+            "pick_up_tip",
+            side_effect=InstrumentCore.pick_up_tip,
+            autospec=True,
+        ) as patched_pick_up_tip,
+        mock.patch.object(
+            InstrumentCore,
+            "drop_tip_in_disposal_location",
+            side_effect=InstrumentCore.drop_tip_in_disposal_location,
+            autospec=True,
+        ) as patched_drop_tip,
+    ):
+        pipette_1k.pick_up_tip()
+        mock_manager = mock.Mock()
+        mock_manager.attach_mock(patched_pick_up_tip, "pick_up_tip")
+        mock_manager.attach_mock(patched_drop_tip, "drop_tip_in_disposal_location")
+        pipette_1k.transfer_with_liquid_class(
+            liquid_class=water,
+            volume=400,
+            source=nest_plate.wells()[:2],
+            dest=arma_plate.wells()[:2],
+            new_tip="never",
+            trash_location=trash,
+            keep_last_tip=True,
+        )
+        assert mock_manager.mock_calls == []
+
+
+@pytest.mark.ot3_only
+@pytest.mark.parametrize(
+    "simulated_protocol_context", [("2.24", "Flex")], indirect=True
+)
+def test_transfer_with_keep_last_tip_chained(
+    simulated_protocol_context: ProtocolContext,
+) -> None:
+    """It should be able to use the last kept tip when calling with never after another transfer."""
+    trash = simulated_protocol_context.load_trash_bin("A3")
+    tiprack = simulated_protocol_context.load_labware(
+        "opentrons_flex_96_tiprack_1000ul", "D1"
+    )
+    pipette_1k = simulated_protocol_context.load_instrument(
+        "flex_1channel_1000", mount="left", tip_racks=[tiprack]
+    )
+    nest_plate = simulated_protocol_context.load_labware(
+        "nest_96_wellplate_200ul_flat", "C3"
+    )
+    arma_plate = simulated_protocol_context.load_labware(
+        "armadillo_96_wellplate_200ul_pcr_full_skirt", "C2"
+    )
+    water = simulated_protocol_context.get_liquid_class("water")
+
+    with (
+        mock.patch.object(
+            InstrumentCore,
+            "pick_up_tip",
+            side_effect=InstrumentCore.pick_up_tip,
+            autospec=True,
+        ) as patched_pick_up_tip,
+        mock.patch.object(
+            InstrumentCore,
+            "drop_tip_in_disposal_location",
+            side_effect=InstrumentCore.drop_tip_in_disposal_location,
+            autospec=True,
+        ) as patched_drop_tip,
+    ):
+        mock_manager = mock.Mock()
+        mock_manager.attach_mock(patched_pick_up_tip, "pick_up_tip")
+        mock_manager.attach_mock(patched_drop_tip, "drop_tip_in_disposal_location")
+        pipette_1k.distribute_with_liquid_class(
+            liquid_class=water,
+            volume=400,
+            source=nest_plate.wells()[0],
+            dest=arma_plate.wells()[:2],
+            new_tip="always",
+            trash_location=trash,
+            keep_last_tip=True,
+        )
+        pipette_1k.consolidate_with_liquid_class(
+            liquid_class=water,
+            volume=400,
+            source=nest_plate.wells()[:2],
+            dest=arma_plate.wells()[0],
+            new_tip="never",
+            trash_location=trash,
+        )
+        expected_calls = [
+            mock.call.pick_up_tip(
+                mock.ANY,
+                location=mock.ANY,
+                well_core=mock.ANY,
+                presses=mock.ANY,
+                increment=mock.ANY,
+            )
+        ]
+        assert mock_manager.mock_calls == expected_calls

--- a/api/tests/opentrons/protocol_api_integration/test_transfer_with_liquid_classes.py
+++ b/api/tests/opentrons/protocol_api_integration/test_transfer_with_liquid_classes.py
@@ -2439,6 +2439,7 @@ def test_transfer_with_keep_last_tip(
             ),
         ]
         assert pipette_1k.has_tip
+        assert pipette_1k._last_tip_picked_up_from is not None
         assert mock_manager.mock_calls == expected_calls
 
 
@@ -2501,6 +2502,7 @@ def test_transfer_with_keep_last_tip_false(
             )
         ]
         assert not pipette_1k.has_tip
+        assert pipette_1k._last_tip_picked_up_from is None
         assert mock_manager.mock_calls == expected_calls
 
 
@@ -2554,6 +2556,7 @@ def test_transfer_with_keep_last_tip_chained(
             keep_last_tip=True,
         )
         assert pipette_1k.has_tip
+        assert pipette_1k._last_tip_picked_up_from is not None
         pipette_1k.consolidate_with_liquid_class(
             liquid_class=water,
             volume=400,
@@ -2572,6 +2575,7 @@ def test_transfer_with_keep_last_tip_chained(
             )
         ]
         assert pipette_1k.has_tip
+        assert pipette_1k._last_tip_picked_up_from is not None
         assert mock_manager.mock_calls == expected_calls
 
 
@@ -2636,6 +2640,7 @@ def test_return_tip_after_transfer_with_never(
             ),
         ]
         assert not pipette_1k.has_tip
+        assert pipette_1k._last_tip_picked_up_from is None
         assert mock_manager.mock_calls == expected_calls
 
 
@@ -2689,6 +2694,7 @@ def test_return_tip_after_chained_transfers(
             keep_last_tip=True,
         )
         assert pipette_1k.has_tip
+        assert pipette_1k._last_tip_picked_up_from is not None
         pipette_1k.distribute_with_liquid_class(
             liquid_class=water,
             volume=400,
@@ -2716,6 +2722,7 @@ def test_return_tip_after_chained_transfers(
             ),
         ]
         assert not pipette_1k.has_tip
+        assert pipette_1k._last_tip_picked_up_from is None
         assert mock_manager.mock_calls == expected_calls
 
 

--- a/api/tests/opentrons/protocol_api_integration/test_transfer_with_liquid_classes.py
+++ b/api/tests/opentrons/protocol_api_integration/test_transfer_with_liquid_classes.py
@@ -2561,3 +2561,144 @@ def test_transfer_with_keep_last_tip_chained(
             )
         ]
         assert mock_manager.mock_calls == expected_calls
+
+
+@pytest.mark.ot3_only
+@pytest.mark.parametrize(
+    "simulated_protocol_context", [("2.24", "Flex")], indirect=True
+)
+def test_return_tip_after_transfer_with_never(
+    simulated_protocol_context: ProtocolContext,
+) -> None:
+    """It should be able to return the current tip when calling a transfer with return tip."""
+    trash = simulated_protocol_context.load_trash_bin("A3")
+    tiprack = simulated_protocol_context.load_labware(
+        "opentrons_flex_96_tiprack_1000ul", "D1"
+    )
+    pipette_1k = simulated_protocol_context.load_instrument(
+        "flex_1channel_1000", mount="left", tip_racks=[tiprack]
+    )
+    nest_plate = simulated_protocol_context.load_labware(
+        "nest_96_wellplate_200ul_flat", "C3"
+    )
+    arma_plate = simulated_protocol_context.load_labware(
+        "armadillo_96_wellplate_200ul_pcr_full_skirt", "C2"
+    )
+    water = simulated_protocol_context.get_liquid_class("water")
+
+    with (
+        mock.patch.object(
+            InstrumentCore,
+            "pick_up_tip",
+            side_effect=InstrumentCore.pick_up_tip,
+            autospec=True,
+        ) as patched_pick_up_tip,
+        mock.patch.object(
+            InstrumentCore,
+            "drop_tip",
+            side_effect=InstrumentCore.drop_tip,
+            autospec=True,
+        ) as patched_drop_tip,
+    ):
+        pipette_1k.pick_up_tip()
+        mock_manager = mock.Mock()
+        mock_manager.attach_mock(patched_pick_up_tip, "pick_up_tip")
+        mock_manager.attach_mock(patched_drop_tip, "drop_tip")
+        pipette_1k.transfer_with_liquid_class(
+            liquid_class=water,
+            volume=400,
+            source=nest_plate.wells()[:2],
+            dest=arma_plate.wells()[:2],
+            new_tip="never",
+            trash_location=trash,
+            keep_last_tip=False,
+            return_tip=True,
+        )
+        expected_calls = [
+            mock.call.drop_tip(
+                mock.ANY,
+                location=None,
+                well_core=mock.ANY,
+                home_after=False,
+                alternate_drop_location=False,
+            ),
+        ]
+        assert mock_manager.mock_calls == expected_calls
+
+
+@pytest.mark.ot3_only
+@pytest.mark.parametrize(
+    "simulated_protocol_context", [("2.24", "Flex")], indirect=True
+)
+def test_return_tip_after_chained_transfers(
+    simulated_protocol_context: ProtocolContext,
+) -> None:
+    """It should be able to return the current tip when calling a transfer with return tip."""
+    trash = simulated_protocol_context.load_trash_bin("A3")
+    tiprack = simulated_protocol_context.load_labware(
+        "opentrons_flex_96_tiprack_1000ul", "D1"
+    )
+    pipette_1k = simulated_protocol_context.load_instrument(
+        "flex_1channel_1000", mount="left", tip_racks=[tiprack]
+    )
+    nest_plate = simulated_protocol_context.load_labware(
+        "nest_96_wellplate_200ul_flat", "C3"
+    )
+    arma_plate = simulated_protocol_context.load_labware(
+        "armadillo_96_wellplate_200ul_pcr_full_skirt", "C2"
+    )
+    water = simulated_protocol_context.get_liquid_class("water")
+
+    with (
+        mock.patch.object(
+            InstrumentCore,
+            "pick_up_tip",
+            side_effect=InstrumentCore.pick_up_tip,
+            autospec=True,
+        ) as patched_pick_up_tip,
+        mock.patch.object(
+            InstrumentCore,
+            "drop_tip",
+            side_effect=InstrumentCore.drop_tip,
+            autospec=True,
+        ) as patched_drop_tip,
+    ):
+        mock_manager = mock.Mock()
+        mock_manager.attach_mock(patched_pick_up_tip, "pick_up_tip")
+        mock_manager.attach_mock(patched_drop_tip, "drop_tip")
+        pipette_1k.transfer_with_liquid_class(
+            liquid_class=water,
+            volume=400,
+            source=nest_plate.wells()[:2],
+            dest=arma_plate.wells()[:2],
+            new_tip="once",
+            trash_location=trash,
+            keep_last_tip=True,
+        )
+        pipette_1k.distribute_with_liquid_class(
+            liquid_class=water,
+            volume=400,
+            source=nest_plate.wells()[0],
+            dest=arma_plate.wells()[:2],
+            new_tip="never",
+            trash_location=trash,
+            keep_last_tip=False,
+            return_tip=True,
+        )
+        expected_calls = [
+            mock.call.pick_up_tip(
+                mock.ANY,
+                location=mock.ANY,
+                well_core=mock.ANY,
+                presses=mock.ANY,
+                increment=mock.ANY,
+            ),
+            mock.call.drop_tip(
+                mock.ANY,
+                location=None,
+                well_core=mock.ANY,
+                home_after=False,
+                alternate_drop_location=False,
+            ),
+        ]
+        assert mock_manager.mock_calls == expected_calls

--- a/api/tests/opentrons/protocol_api_integration/test_transfer_with_liquid_classes.py
+++ b/api/tests/opentrons/protocol_api_integration/test_transfer_with_liquid_classes.py
@@ -2438,6 +2438,7 @@ def test_transfer_with_keep_last_tip(
                 increment=mock.ANY,
             ),
         ]
+        assert pipette_1k.has_tip
         assert mock_manager.mock_calls == expected_calls
 
 
@@ -2489,9 +2490,18 @@ def test_transfer_with_keep_last_tip_false(
             dest=arma_plate.wells()[:2],
             new_tip="never",
             trash_location=trash,
-            keep_last_tip=True,
+            keep_last_tip=False,
         )
-        assert mock_manager.mock_calls == []
+        expected_calls = [
+            mock.call.drop_tip_in_disposal_location(
+                mock.ANY,
+                disposal_location=trash,
+                home_after=False,
+                alternate_tip_drop=True,
+            )
+        ]
+        assert not pipette_1k.has_tip
+        assert mock_manager.mock_calls == expected_calls
 
 
 @pytest.mark.ot3_only
@@ -2543,6 +2553,7 @@ def test_transfer_with_keep_last_tip_chained(
             trash_location=trash,
             keep_last_tip=True,
         )
+        assert pipette_1k.has_tip
         pipette_1k.consolidate_with_liquid_class(
             liquid_class=water,
             volume=400,
@@ -2560,6 +2571,7 @@ def test_transfer_with_keep_last_tip_chained(
                 increment=mock.ANY,
             )
         ]
+        assert pipette_1k.has_tip
         assert mock_manager.mock_calls == expected_calls
 
 
@@ -2623,6 +2635,7 @@ def test_return_tip_after_transfer_with_never(
                 alternate_drop_location=False,
             ),
         ]
+        assert not pipette_1k.has_tip
         assert mock_manager.mock_calls == expected_calls
 
 
@@ -2675,6 +2688,7 @@ def test_return_tip_after_chained_transfers(
             trash_location=trash,
             keep_last_tip=True,
         )
+        assert pipette_1k.has_tip
         pipette_1k.distribute_with_liquid_class(
             liquid_class=water,
             volume=400,
@@ -2701,4 +2715,43 @@ def test_return_tip_after_chained_transfers(
                 alternate_drop_location=False,
             ),
         ]
+        assert not pipette_1k.has_tip
         assert mock_manager.mock_calls == expected_calls
+
+
+@pytest.mark.ot3_only
+@pytest.mark.parametrize(
+    "simulated_protocol_context", [("2.24", "Flex")], indirect=True
+)
+def test_return_tip_fails_after_new_tip_never_keep_last_tip_false(
+    simulated_protocol_context: ProtocolContext,
+) -> None:
+    """It should fail in returning a tip with new tip of never and keep last tip False."""
+    trash = simulated_protocol_context.load_trash_bin("A3")
+    tiprack = simulated_protocol_context.load_labware(
+        "opentrons_flex_96_tiprack_1000ul", "D1"
+    )
+    pipette_1k = simulated_protocol_context.load_instrument(
+        "flex_1channel_1000", mount="left", tip_racks=[tiprack]
+    )
+    nest_plate = simulated_protocol_context.load_labware(
+        "nest_96_wellplate_200ul_flat", "C3"
+    )
+    arma_plate = simulated_protocol_context.load_labware(
+        "armadillo_96_wellplate_200ul_pcr_full_skirt", "C2"
+    )
+    water = simulated_protocol_context.get_liquid_class("water")
+
+    pipette_1k.pick_up_tip()
+    pipette_1k.transfer_with_liquid_class(
+        liquid_class=water,
+        volume=400,
+        source=nest_plate.wells()[0],
+        dest=arma_plate.wells()[0],
+        new_tip="never",
+        trash_location=trash,
+        keep_last_tip=False,
+    )
+
+    with pytest.raises(TypeError, match="Last tip location"):
+        pipette_1k.return_tip()


### PR DESCRIPTION
# Overview

This fixes known bugs from #18693

With the introduction of `keep_last_tip` argument, a couple bugs related to our use of the public context internal variable `InstrumentContext._last_tip_picked_up_from` manifested. This variable is used to keep track of what tiprack "well" the current tip on a pipette was picked up from, which is used by both `return_tip` and by the liquid class transfers to check for presence of the tip.

Since tips could now persist outside of transfers, this was causing two issues:
- Chaining a transfer with a `new_tip="never"` after a non `"never"` transfer with `keep_last_tip=True` would cause the second transfer to fail since `_last_tip_picked_up_from` would be `None`, having not been set within the internal core methods
- `return_tip` logic would fail in a couple different scenarios. Calling `return_tip=True` in a transfer or calling `InstrumentContext.return_tip()` after a `keep_last_tip=True` in a transfer would fail, again due to `_last_tip_picked_up_from` not being updated and the engine core transfer implementations not taking that information.

Two different ways of solving this were brought up. One would be a more holistic solution of getting rid of `_last_tip_picked_up_from` and moving that information to the cores and/or engine. This would involve updating `pick_up_tip`, `drop_tip`, `return_tip` as well as the engine core, legacy core and potentially Protocol Engine. Because of the scope of this change, this approach was not taken here, though this PR can and should be refactored once these changes are made.

The way this PR solves this issue is by returning the necessary and available information about the last tip used from the core transfer implementations, as well as allowing passing that information to the implementations so that the informations stays in sync. This approach was chosen because it limits the scope to just the transfer methods.

## Test Plan and Hands on Testing

Integration tests have been added covering a few different cases, some inspired by the failing protocol that identified this bug.

## Changelog

- return the last tip information used by the engine core liquid class transfer so that `_last_tip_picked_up_from` stays in sync
- allow the last tip information to be passed to the liquid class transfer implementations so that the `return_tip` argument can be used even if the tip was picked up outside of the transfer.

## Review requests

Are we okay with this approach for now, and are there any cases I'm missing?

## Risk assessment

Low-medium, touches the three liquid class transfer methods but only them and related code and does so in a limited way.