### PR TITLE
fix(api): increase the PLATFORM_OFFSET in the FlexStacker to 4mm to handle wide labware.

### DIFF
--- a/api/src/opentrons/hardware_control/modules/flex_stacker.py
+++ b/api/src/opentrons/hardware_control/modules/flex_stacker.py
@@ -79,7 +79,7 @@ HOME_OFFSET_MD = 10.0
 
 # The labware platform will contact the labware this mm before the platform
 # touches the +Z endstop.
-PLATFORM_OFFSET = 2.5
+PLATFORM_OFFSET = 4
 
 
 class FlexStacker(mod_abc.AbstractModule):
@@ -430,7 +430,7 @@ class FlexStacker(mod_abc.AbstractModule):
         # Transfer
         await self.open_latch()
         # NOTE: When moving from the +Z limit switch down, the PLATFORM_OFFSET makes
-        # sure the bottom of the next labware is sitting 2.5mm above the latch.
+        # sure the bottom of the next labware is sitting N mm above the latch.
         # So when moving the labware_height we dont need to add an additional
         # offset to make sure we arent cutting it too close since the labware
         # will always be above the latch.


### PR DESCRIPTION
# Overview

When storing labware, wide labware like `usascientific_96_wellplate_2.4ml_deep` would hit the bottom of the latch since we were moving the bottom labware ~1-2mm above the latch to prevent the top labware from dropping. Unfortunately, this does not work with wide labware, so you have to move the bottom labware to right below the bottom of the latch, then open the latch, letting the labware drop ~1-1.5mm. We do this by increasing the PLATFORM_OFFSET to 4mm.

## Test Plan and Hands on Testing

- [x] Make sure you can dispense and store the following labware
```
opentrons_flex_96_tiprack_50ul
opentrons_flex_96_tiprack_200ul
opentrons_flex_96_tiprack_1000ul
armadillo_96_wellplate_200ul_pcr_full_skirt
nest_96_wellplate_2ml_deep
nest_12_reservoir_15ml
nest_96_wellplate_200ul_flat
biorad_96_wellplate_200ul_pcr
biorad_384_wellplate_50ul
opentrons_96_wellplate_200ul_pcr_full_skirt
nest_96_wellplate_100ul_pcr_full_skirt
corning_12_wellplate_6.9ml_flat
corning_24_wellplate_3.4ml_flat
corning_384_wellplate_112ul_flat
corning_48_wellplate_1.6ml_flat
corning_6_wellplate_16.8ml_flat
corning_96_wellplate_360ul_flat
appliedbiosystemsmicroamp_384_wellplate_40ul
thermoscientificnunc_96_wellplate_1300ul
thermoscientificnunc_96_wellplate_2000ul
usascientific_96_wellplate_2.4ml_deep
```


## Changelog

- Increasing the PLATFORM_OFFSET to 4mm to deal with wide labware

## Review requests
## Risk assessment