### PR TITLE
feat(protocol-designer): restrict stack of 3 for TC lid on deck

### DIFF
--- a/components/src/atoms/ListButton/ListButton.stories.tsx
+++ b/components/src/atoms/ListButton/ListButton.stories.tsx
@@ -58,6 +58,7 @@ const Template = (args: ListButtonComponentProps): JSX.Element => {
         <ListButtonAccordionContainer id="mainAccordionContainer">
           <>
             <CustomizeExpandButton
+              isDirectlyOnDeck={false}
               enableStackingFF={false}
               key="buttonNested"
               allowInputField={false}
@@ -81,6 +82,7 @@ const Template = (args: ListButtonComponentProps): JSX.Element => {
                 >
                   <>
                     <CustomizeExpandButton
+                      isDirectlyOnDeck={false}
                       enableStackingFF={false}
                       allowInputField={false}
                       loadName="mockloadname1"
@@ -98,6 +100,7 @@ const Template = (args: ListButtonComponentProps): JSX.Element => {
                     ) : null}
                   </>
                   <CustomizeExpandButton
+                    isDirectlyOnDeck={false}
                     enableStackingFF={false}
                     allowInputField={false}
                     loadName="mockloadname2"
@@ -109,6 +112,7 @@ const Template = (args: ListButtonComponentProps): JSX.Element => {
                     }}
                   />
                   <CustomizeExpandButton
+                    isDirectlyOnDeck={false}
                     enableStackingFF={false}
                     allowInputField={false}
                     loadName="mockloadname3"
@@ -125,6 +129,7 @@ const Template = (args: ListButtonComponentProps): JSX.Element => {
           </>
           <>
             <CustomizeExpandButton
+              isDirectlyOnDeck={false}
               enableStackingFF={false}
               key="buttonNonNested"
               allowInputField={false}

--- a/components/src/molecules/CustomizeExpandButton/__tests__/CustomizeExpandButton.test.tsx
+++ b/components/src/molecules/CustomizeExpandButton/__tests__/CustomizeExpandButton.test.tsx
@@ -26,6 +26,7 @@ describe('CustomizeExpandButton', () => {
 
   beforeEach(() => {
     props = {
+      isDirectlyOnDeck: false,
       enableStackingFF: true,
       buttonText: 'mock text',
       buttonValue: 'mockValue',

--- a/components/src/molecules/CustomizeExpandButton/index.tsx
+++ b/components/src/molecules/CustomizeExpandButton/index.tsx
@@ -25,6 +25,7 @@ export interface StackingProps {
 }
 
 interface CustomizeExpandButtonProps extends StyleProps {
+  isDirectlyOnDeck: boolean
   enableStackingFF: boolean
   allowInputField: boolean
   loadName: string
@@ -36,6 +37,8 @@ interface CustomizeExpandButtonProps extends StyleProps {
   isSelected?: boolean
   id?: string
 }
+
+const TC_LID_DECK_MAX = 3
 
 //  used for helix and as a child button to ListButtonAccordion
 export function CustomizeExpandButton(
@@ -52,11 +55,16 @@ export function CustomizeExpandButton(
     allowInputField,
     loadName,
     enableStackingFF,
+    isDirectlyOnDeck,
   } = props
   const isLid =
     stackingProps != null &&
     stackingProps.definition.allowedRoles?.includes('lid')
   const tcLidDef = loadName === 'opentrons_tough_pcr_auto_sealing_lid'
+  const stackLimit =
+    tcLidDef && isDirectlyOnDeck
+      ? TC_LID_DECK_MAX
+      : stackingProps?.definition.stackLimit ?? 1
 
   return (
     <Flex
@@ -105,9 +113,7 @@ export function CustomizeExpandButton(
                   label={stackingProps.checkboxCaption}
                 />
               ) : null}
-              {stackingProps.definition.stackLimit != null &&
-              stackingProps.definition.stackLimit > 1 &&
-              allowInputField ? (
+              {stackLimit > 1 && allowInputField ? (
                 <InputField
                   id="CustomizeExpandButton_inputField"
                   title={stackingProps.inputTitle}
@@ -118,8 +124,7 @@ export function CustomizeExpandButton(
                   type="number"
                   error={
                     !stackingProps.inputFieldValue ||
-                    stackingProps.inputFieldValue >
-                      stackingProps.definition.stackLimit
+                    stackingProps.inputFieldValue > stackLimit
                       ? stackingProps.errorMessage
                       : null
                   }

--- a/protocol-designer/src/components/organisms/EditLabwareQuantityModal/__tests__/EditLabwareQuantityModal.test.tsx
+++ b/protocol-designer/src/components/organisms/EditLabwareQuantityModal/__tests__/EditLabwareQuantityModal.test.tsx
@@ -29,6 +29,7 @@ describe('EditLabwareQuantityModal', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     props = {
+      isDirectlyOnDeck: false,
       onClose: vi.fn(),
       labwareId: 'mockId',
       allLabwareIdsOnStack: ['mockId'],

--- a/protocol-designer/src/components/organisms/EditLabwareQuantityModal/index.tsx
+++ b/protocol-designer/src/components/organisms/EditLabwareQuantityModal/index.tsx
@@ -24,8 +24,8 @@ import { TC_LID_LOADNAME } from '../../../pages/Designer/utils'
 import { getLabwareEntities } from '../../../step-forms/selectors'
 import { maskToPositiveInteger } from '../../../steplist/fieldLevel/processing'
 import { HandleEnter } from '../../atoms'
-import { TC_LID_DECK_MAX } from '../SelectLabwareModal'
 import { getMainPagePortalEl } from '../Portal'
+import { TC_LID_DECK_MAX } from '../SelectLabwareModal'
 
 import type { ThunkDispatch } from '../../../types'
 
@@ -38,14 +38,15 @@ interface EditLabwareQuantityModalProps {
 export function EditLabwareQuantityModal(
   props: EditLabwareQuantityModalProps
 ): JSX.Element {
-  const { onClose, allLabwareIdsOnStack, labwareId , isDirectlyOnDeck} = props
+  const { onClose, allLabwareIdsOnStack, labwareId, isDirectlyOnDeck } = props
   const { t } = useTranslation(['starting_deck_state', 'shared'])
   const dispatch = useDispatch<ThunkDispatch<any>>()
   const labwareEntities = useSelector(getLabwareEntities)
   const { labwareDefURI, def } = labwareEntities[labwareId]
-  const {loadName} = def.parameters
+  const { loadName } = def.parameters
   const isTcLid = loadName === TC_LID_LOADNAME
-  const stackingLimit = isTcLid && isDirectlyOnDeck ? TC_LID_DECK_MAX : def.stackLimit ?? 0
+  const stackingLimit =
+    isTcLid && isDirectlyOnDeck ? TC_LID_DECK_MAX : def.stackLimit ?? 0
   const initialQuantity = allLabwareIdsOnStack.length
   const [quantity, setQuantity] = useState<string>(initialQuantity.toString())
   const [showError, setError] = useState<boolean>(false)

--- a/protocol-designer/src/components/organisms/EditLabwareQuantityModal/index.tsx
+++ b/protocol-designer/src/components/organisms/EditLabwareQuantityModal/index.tsx
@@ -20,14 +20,17 @@ import {
   createContainer,
   deleteContainer,
 } from '../../../labware-ingred/actions'
+import { TC_LID_LOADNAME } from '../../../pages/Designer/utils'
 import { getLabwareEntities } from '../../../step-forms/selectors'
 import { maskToPositiveInteger } from '../../../steplist/fieldLevel/processing'
 import { HandleEnter } from '../../atoms'
+import { TC_LID_DECK_MAX } from '../SelectLabwareModal'
 import { getMainPagePortalEl } from '../Portal'
 
 import type { ThunkDispatch } from '../../../types'
 
 interface EditLabwareQuantityModalProps {
+  isDirectlyOnDeck: boolean
   allLabwareIdsOnStack: string[]
   labwareId: string
   onClose: () => void
@@ -35,12 +38,14 @@ interface EditLabwareQuantityModalProps {
 export function EditLabwareQuantityModal(
   props: EditLabwareQuantityModalProps
 ): JSX.Element {
-  const { onClose, allLabwareIdsOnStack, labwareId } = props
+  const { onClose, allLabwareIdsOnStack, labwareId , isDirectlyOnDeck} = props
   const { t } = useTranslation(['starting_deck_state', 'shared'])
   const dispatch = useDispatch<ThunkDispatch<any>>()
   const labwareEntities = useSelector(getLabwareEntities)
   const { labwareDefURI, def } = labwareEntities[labwareId]
-  const stackingLimit = def.stackLimit ?? 0
+  const {loadName} = def.parameters
+  const isTcLid = loadName === TC_LID_LOADNAME
+  const stackingLimit = isTcLid && isDirectlyOnDeck ? TC_LID_DECK_MAX : def.stackLimit ?? 0
   const initialQuantity = allLabwareIdsOnStack.length
   const [quantity, setQuantity] = useState<string>(initialQuantity.toString())
   const [showError, setError] = useState<boolean>(false)

--- a/protocol-designer/src/components/organisms/LabwareCard/LabwareCard.stories.tsx
+++ b/protocol-designer/src/components/organisms/LabwareCard/LabwareCard.stories.tsx
@@ -43,6 +43,7 @@ export const LabwareCardField: Story = (
 }
 
 LabwareCardField.args = {
+  isDirectlyOnDeck: false,
   labware: {
     id: 'mockId',
     labwareDefURI: `${fixture96Plate.namespace}/${fixture96Plate.parameters.loadName}/${fixture96Plate.version}`,

--- a/protocol-designer/src/components/organisms/LabwareCard/__tests__/LabwareCard.test.tsx
+++ b/protocol-designer/src/components/organisms/LabwareCard/__tests__/LabwareCard.test.tsx
@@ -48,6 +48,7 @@ describe('LabwareCard', () => {
 
   beforeEach(() => {
     props = {
+      isDirectlyOnDeck: false,
       labware: {
         id: 'labwareId',
         pythonName: 'mockPythonName',

--- a/protocol-designer/src/components/organisms/LabwareCard/index.tsx
+++ b/protocol-designer/src/components/organisms/LabwareCard/index.tsx
@@ -36,13 +36,14 @@ import type { LabwareOnDeck } from '../../../step-forms'
 import type { ThunkDispatch } from '../../../types'
 
 interface LabwareCardProps {
+  isDirectlyOnDeck: boolean
   labware: LabwareOnDeck
   quantity: number
   lidDisplayName?: string
 }
 
 export function LabwareCard(props: LabwareCardProps): JSX.Element {
-  const { labware, lidDisplayName, quantity } = props
+  const { labware, lidDisplayName, quantity, isDirectlyOnDeck} = props
   const navigate = useNavigate()
   const dispatch = useDispatch<ThunkDispatch<any>>()
   const { t } = useTranslation('starting_deck_state')
@@ -99,6 +100,7 @@ export function LabwareCard(props: LabwareCardProps): JSX.Element {
           }}
           labwareId={labware.id}
           allLabwareIdsOnStack={allLabwareIdsOnStack}
+          isDirectlyOnDeck={isDirectlyOnDeck}
         />
       ) : null}
       <Box position={POSITION_RELATIVE}>

--- a/protocol-designer/src/components/organisms/LabwareCard/index.tsx
+++ b/protocol-designer/src/components/organisms/LabwareCard/index.tsx
@@ -43,7 +43,7 @@ interface LabwareCardProps {
 }
 
 export function LabwareCard(props: LabwareCardProps): JSX.Element {
-  const { labware, lidDisplayName, quantity, isDirectlyOnDeck} = props
+  const { labware, lidDisplayName, quantity, isDirectlyOnDeck } = props
   const navigate = useNavigate()
   const dispatch = useDispatch<ThunkDispatch<any>>()
   const { t } = useTranslation('starting_deck_state')

--- a/protocol-designer/src/components/organisms/SelectLabwareModal/index.tsx
+++ b/protocol-designer/src/components/organisms/SelectLabwareModal/index.tsx
@@ -64,7 +64,10 @@ import {
   getLabwareIsRecommended,
   getStackerDefinition,
 } from '../../../pages/Designer/DeckSetup/utils'
-import { TIPRACK_LID_LOADNAME } from '../../../pages/Designer/utils'
+import {
+  TC_LID_LOADNAME,
+  TIPRACK_LID_LOADNAME,
+} from '../../../pages/Designer/utils'
 import { selectors as stepFormSelectors } from '../../../step-forms'
 import { getPipetteEntities } from '../../../step-forms/selectors'
 import { getHas96Channel } from '../../../utils'
@@ -82,6 +85,7 @@ import type { CategoryExpand } from '../../../pages/Designer/DeckSetup/DeckSetup
 import type { ModuleOnDeck } from '../../../step-forms'
 import type { ThunkDispatch } from '../../../types'
 
+export const TC_LID_DECK_MAX = 3
 const STANDARD_X_DIMENSION = 127.75
 const STANDARD_Y_DIMENSION = 85.48
 const STACKING_LOADNAMES = [
@@ -440,6 +444,7 @@ export function SelectLabwareModal(
                   {filteredLabwareByCategory[CUSTOM_CATEGORY].map(
                     ({ uri }, index) => (
                       <CustomizeExpandButton
+                        isDirectlyOnDeck={selectedModuleModel == null}
                         enableStackingFF={enableStacking}
                         loadName={customLabwareDefs[uri].parameters.loadName}
                         allowInputField={onFlexStacker}
@@ -494,6 +499,9 @@ export function SelectLabwareModal(
                                 },
                                 loadName
                               )
+                              const isTCLid = loadName === TC_LID_LOADNAME
+                              const isDirectlyOnDeck =
+                                selectedModuleModel == null
 
                               const stackingProps: StackingProps | null =
                                 stackingLabwareDefUri != null &&
@@ -503,8 +511,10 @@ export function SelectLabwareModal(
                                       ...stackingPropsShared,
                                       inputCaption: t('valid_range', {
                                         max:
-                                          defs[stackingLabwareDefUri]
-                                            .stackLimit,
+                                          isTCLid && isDirectlyOnDeck
+                                            ? TC_LID_DECK_MAX
+                                            : defs[stackingLabwareDefUri]
+                                                .stackLimit,
                                       }),
                                       definition: defs[stackingLabwareDefUri],
                                       inputFieldValue:
@@ -546,6 +556,7 @@ export function SelectLabwareModal(
                                   key={`${index}_${category}_${loadName}`}
                                 >
                                   <CustomizeExpandButton
+                                    isDirectlyOnDeck={isDirectlyOnDeck}
                                     enableStackingFF={enableStacking}
                                     loadName={loadName}
                                     allowInputField={
@@ -621,6 +632,7 @@ export function SelectLabwareModal(
                                                     defs[tiprackDefUri]
                                                   return (
                                                     <CustomizeExpandButton
+                                                      isDirectlyOnDeck={false}
                                                       enableStackingFF={
                                                         enableStacking
                                                       }
@@ -737,6 +749,7 @@ export function SelectLabwareModal(
 
                                                 return (
                                                   <CustomizeExpandButton
+                                                    isDirectlyOnDeck={false}
                                                     enableStackingFF={
                                                       enableStacking
                                                     }

--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupToolbox.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupToolbox.tsx
@@ -310,6 +310,10 @@ export function DeckSetupToolbox(
                       createdStackForSlot[createdStackForSlot.length - 1]
                     ]
                   }
+                  isDirectlyOnDeck={
+                    createdAdapterForSlot == null &&
+                    createdModuleForSlot == null
+                  }
                   lidDisplayName={
                     createdLidForSlot != null &&
                     createdStackForSlot.includes(createdLidForSlot?.id)
@@ -320,7 +324,11 @@ export function DeckSetupToolbox(
                 />
               ) : null}
               {createdAdapterForSlot != null ? (
-                <LabwareCard labware={createdAdapterForSlot} quantity={1} />
+                <LabwareCard
+                  labware={createdAdapterForSlot}
+                  quantity={1}
+                  isDirectlyOnDeck={false}
+                />
               ) : null}
               {slotFull ? (
                 <StyledText


### PR DESCRIPTION
closes AUTH-1068

# Overview

Restrict stack of 3 TC lids when they're directly on the deck but allow for stack of 5 when on a deck riser.

## Test Plan and Hands on Testing

upload attached protocol and click on the TC lid on the deck and the deck riser. when you go to edit quantity, see that the limits are 3 for deck and 5 for on deck riser

## Changelog

- add logic for directly on deck for customizeExpandButton, the modal, and labware card
- fix tests

## Risk assessment

low