### PR TITLE
refactor(protocol-designer): disallow lids in PD 8.5.0

### DIFF
--- a/protocol-designer/src/components/organisms/SelectLabwareModal/index.tsx
+++ b/protocol-designer/src/components/organisms/SelectLabwareModal/index.tsx
@@ -84,11 +84,6 @@ import type { ThunkDispatch } from '../../../types'
 
 const STANDARD_X_DIMENSION = 127.75
 const STANDARD_Y_DIMENSION = 85.48
-const STACKING_LOADNAMES = [
-  'opentrons_flex_deck_riser',
-  'opentrons_flex_tiprack_lid',
-  'opentrons_tough_pcr_auto_sealing_lid',
-]
 const PLATE_READER_LOADNAME =
   'opentrons_flex_lid_absorbance_plate_reader_module'
 interface SelectLabwareModalProps {
@@ -219,7 +214,7 @@ export function SelectLabwareModal(
         (slot === 'offDeck' && isAdapter) ||
         (PLATE_READER_LOADNAME === parameters.loadName &&
           moduleType !== ABSORBANCE_READER_TYPE) ||
-        (!enableStacking && STACKING_LOADNAMES.includes(parameters.loadName))
+        (!enableStacking && parameters.loadName === 'opentrons_flex_deck_riser')
       )
     },
     [filterRecommended, filterHeight, getIsLabwareCompatible, moduleType, slot]
@@ -235,8 +230,9 @@ export function SelectLabwareModal(
         const category: string = def.metadata.displayCategory
         //  filter out non-permitted tipracks
         if (
-          category === 'tipRack' &&
-          !permittedTipracks.includes(getLabwareDefURI(def))
+          (category === 'tipRack' &&
+            !permittedTipracks.includes(getLabwareDefURI(def))) ||
+          (category === 'lid' && !enableStacking)
         ) {
           return acc
         }


### PR DESCRIPTION
closes RQA-4302

# Overview

Whoops, we added 2 new lids recently so i generalized the blocking lid logic when the stacking ff is turned off because lids won't be introduced to the public until PD 8.6.0

## Test Plan and Hands on Testing

With the stacking FF turned off, see that there is no lid category and no deck riser in the adapter category.

With the stacking FF turned on, see that there is a lid category and the deck riser is listed in the adapter category

## Changelog

- properly filter out the lids and deck riser

## Risk assessment

lpw
