### PR TITLE
fix(api): check shuttle presence before checking hopper

### DIFF
--- a/api/src/opentrons/hardware_control/modules/flex_stacker.py
+++ b/api/src/opentrons/hardware_control/modules/flex_stacker.py
@@ -418,10 +418,9 @@ class FlexStacker(mod_abc.AbstractModule):
     ) -> None:
         """Dispenses the next labware in the stacker."""
         self.verify_labware_height(labware_height)
+        await self._prepare_for_action()
         if enforce_hopper_lw_sensing:
             await self.verify_hopper_labware_presence(True)
-
-        await self._prepare_for_action()
 
         # Move platform along the X then Z axis
         await self._move_and_home_axis(StackerAxis.X, Direction.RETRACT, HOME_OFFSET_MD)


### PR DESCRIPTION
# Overview
We should check the shuttle location before checking the hopper, so we're not confusing the user by showing an empty hopper error when the shuttle is obviously missing. 
Fixes RQA-4291