### PR TITLE
fix(api): error raising when there's no innergeometry for a well

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/transfer_components_executor.py
+++ b/api/src/opentrons/protocol_api/core/engine/transfer_components_executor.py
@@ -191,7 +191,6 @@ class TransferComponentsExecutor:
             )
             tx_utils.raise_if_location_inside_liquid(
                 location=submerge_start_location,
-                well_location=self._target_location,
                 well_core=self._target_well,
                 location_check_descriptors=LocationCheckDescriptors(
                     location_type="submerge start",
@@ -372,7 +371,6 @@ class TransferComponentsExecutor:
         )
         tx_utils.raise_if_location_inside_liquid(
             location=retract_location,
-            well_location=self._target_location,
             well_core=self._target_well,
             location_check_descriptors=LocationCheckDescriptors(
                 location_type="retract end",
@@ -499,7 +497,6 @@ class TransferComponentsExecutor:
             )
             tx_utils.raise_if_location_inside_liquid(
                 location=retract_location,
-                well_location=self._target_location,
                 well_core=self._target_well,
                 location_check_descriptors=LocationCheckDescriptors(
                     location_type="retract end",
@@ -647,7 +644,6 @@ class TransferComponentsExecutor:
         )
         tx_utils.raise_if_location_inside_liquid(
             location=retract_location,
-            well_location=self._target_location,
             well_core=self._target_well,
             location_check_descriptors=LocationCheckDescriptors(
                 location_type="retract end",

--- a/api/src/opentrons/protocols/advanced_control/transfers/transfer_liquid_utils.py
+++ b/api/src/opentrons/protocols/advanced_control/transfers/transfer_liquid_utils.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 from typing import Literal, Sequence, List, Optional, TYPE_CHECKING
 from dataclasses import dataclass
 
-from opentrons.protocol_engine.errors import LiquidHeightUnknownError
+from opentrons.protocol_engine.errors import (
+    LiquidHeightUnknownError,
+    IncompleteLabwareDefinitionError,
+)
 from opentrons.protocol_engine.state._well_math import (
     wells_covered_by_pipette_configuration,
 )
@@ -25,7 +28,6 @@ class LocationCheckDescriptors:
 
 def raise_if_location_inside_liquid(
     location: Location,
-    well_location: Location,
     well_core: WellCore,
     location_check_descriptors: LocationCheckDescriptors,
     logger: Logger,
@@ -39,7 +41,11 @@ def raise_if_location_inside_liquid(
     """
     try:
         liquid_height_from_bottom = well_core.current_liquid_height()
-    except LiquidHeightUnknownError:
+    except (IncompleteLabwareDefinitionError, LiquidHeightUnknownError):
+        # IncompleteLabwareDefinitionError is raised when there's no inner geometry
+        # defined for the well. So, we can't find the liquid height even if liquid volume is known.
+        # LiquidHeightUnknownError is raised when we don't have liquid volume info
+        # and no probing has been done either.
         liquid_height_from_bottom = None
     if isinstance(liquid_height_from_bottom, (int, float)):
         if liquid_height_from_bottom + well_core.get_bottom(0).z > location.point.z:

--- a/api/src/opentrons/protocols/advanced_control/transfers/transfer_liquid_utils.py
+++ b/api/src/opentrons/protocols/advanced_control/transfers/transfer_liquid_utils.py
@@ -61,8 +61,9 @@ def raise_if_location_inside_liquid(
         # so we will not raise but just log the details.
         logger.info(
             f"Could not verify height of liquid in well {well_core.get_display_name()}, either"
-            f" because the liquid in this well has not been probed or because"
-            f" liquid was not loaded in this well using `load_liquid`."
+            f" because the liquid in this well has not been probed or"
+            f" liquid was not loaded in this well using `load_liquid` or"
+            f" inner geometry is not available for the target well."
             f" Proceeding without verifying if {location_check_descriptors.location_type}"
             f" location is outside the liquid."
         )

--- a/api/tests/opentrons/protocol_api/core/engine/test_transfer_components_executor.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_transfer_components_executor.py
@@ -126,7 +126,6 @@ def test_submerge(
     decoy.verify(
         tx_utils.raise_if_location_inside_liquid(
             location=Location(Point(x=2, y=4, z=7), labware=None),
-            well_location=Location(Point(x=1, y=2, z=3), labware=None),
             well_core=source_well,
             location_check_descriptors=LocationCheckDescriptors(
                 location_type="submerge start",
@@ -197,7 +196,6 @@ def test_submerge_without_starting_air_gap(
     decoy.verify(
         tx_utils.raise_if_location_inside_liquid(
             location=Location(Point(x=2, y=4, z=7), labware=None),
-            well_location=Location(Point(x=1, y=2, z=3), labware=None),
             well_core=source_well,
             location_check_descriptors=LocationCheckDescriptors(
                 location_type="submerge start",
@@ -308,7 +306,6 @@ def test_submerge_raises_when_submerge_point_is_invalid(
     decoy.when(
         tx_utils.raise_if_location_inside_liquid(
             location=Location(Point(x=2, y=4, z=7), labware=None),
-            well_location=Location(Point(x=1, y=2, z=3), labware=None),
             well_core=source_well,
             location_check_descriptors=LocationCheckDescriptors(
                 location_type="submerge start",
@@ -755,7 +752,6 @@ def test_retract_after_aspiration(
     decoy.verify(
         tx_utils.raise_if_location_inside_liquid(
             location=Location(Point(x=4, y=4, z=4), labware=None),
-            well_location=Location(Point(x=1, y=1, z=1), labware=None),
             well_core=source_well,
             location_check_descriptors=LocationCheckDescriptors(
                 location_type="retract end",
@@ -837,7 +833,6 @@ def test_retract_after_aspiration_when_retract_loc_below_safe_airgap_point(
     decoy.verify(
         tx_utils.raise_if_location_inside_liquid(
             location=Location(Point(x=4, y=4, z=4), labware=None),
-            well_location=Location(Point(x=1, y=1, z=1), labware=None),
             well_core=source_well,
             location_check_descriptors=LocationCheckDescriptors(
                 location_type="retract end",
@@ -906,7 +901,6 @@ def test_post_aspirate_retract_raises_when_retract_point_is_invalid(
     decoy.when(
         tx_utils.raise_if_location_inside_liquid(
             location=Location(Point(x=4, y=4, z=4), labware=None),
-            well_location=Location(Point(x=1, y=1, z=1), labware=None),
             well_core=source_well,
             location_check_descriptors=LocationCheckDescriptors(
                 location_type="retract end",
@@ -1830,7 +1824,6 @@ def test_retract_after_dispense_raises_for_invalid_retract_point(
     decoy.when(
         tx_utils.raise_if_location_inside_liquid(
             location=Location(Point(12, 24, 36), labware=None),
-            well_location=Location(Point(1, 1, 1), labware=None),
             well_core=dest_well,
             location_check_descriptors=LocationCheckDescriptors(
                 location_type="retract end",
@@ -2040,7 +2033,6 @@ def test_multi_dispense_retract_after_dispense_without_conditioning_volume_or_bl
     decoy.verify(
         tx_utils.raise_if_location_inside_liquid(
             location=Location(Point(3, 5, 4), labware=None),
-            well_location=Location(Point(1, 1, 1), labware=None),
             well_core=dest_well,
             location_check_descriptors=LocationCheckDescriptors(
                 location_type="retract end",
@@ -2159,7 +2151,6 @@ def test_multi_dispense_retract_after_dispense_with_blowout_without_conditioning
     decoy.verify(
         tx_utils.raise_if_location_inside_liquid(
             location=Location(Point(3, 5, 4), labware=None),
-            well_location=Location(Point(1, 1, 1), labware=None),
             well_core=dest_well,
             location_check_descriptors=LocationCheckDescriptors(
                 location_type="retract end",
@@ -2248,7 +2239,6 @@ def test_multi_dispense_retract_raises_for_invalid_retract_point(
     decoy.when(
         tx_utils.raise_if_location_inside_liquid(
             location=Location(Point(3, 5, 4), labware=None),
-            well_location=Location(Point(1, 1, 1), labware=None),
             well_core=dest_well,
             location_check_descriptors=LocationCheckDescriptors(
                 location_type="retract end",

--- a/api/tests/opentrons/protocols/advanced_control/transfers/test_transfer_liquid_utils.py
+++ b/api/tests/opentrons/protocols/advanced_control/transfers/test_transfer_liquid_utils.py
@@ -241,8 +241,9 @@ def test_log_warning_if_pip_location_cannot_be_validated(
     decoy.verify(
         logger.info(
             "Could not verify height of liquid in well Well A1 of test_labware, either"
-            " because the liquid in this well has not been probed or because"
-            " liquid was not loaded in this well using `load_liquid`."
+            " because the liquid in this well has not been probed or"
+            " liquid was not loaded in this well using `load_liquid` or"
+            " inner geometry is not available for the target well."
             " Proceeding without verifying if retract end location is outside the liquid."
         )
     )

--- a/api/tests/opentrons/protocols/advanced_control/transfers/test_transfer_liquid_utils.py
+++ b/api/tests/opentrons/protocols/advanced_control/transfers/test_transfer_liquid_utils.py
@@ -7,10 +7,14 @@ from contextlib import nullcontext as does_not_raise
 
 
 from opentrons.hardware_control.nozzle_manager import NozzleMap
+from opentrons.protocol_engine import ProtocolEngineError
 from opentrons.protocol_engine.types.liquid_level_detection import (
     LiquidTrackingType,
 )
-from opentrons.protocol_engine.errors import LiquidHeightUnknownError
+from opentrons.protocol_engine.errors import (
+    LiquidHeightUnknownError,
+    IncompleteLabwareDefinitionError,
+)
 from opentrons.types import Location, Point
 from opentrons.protocol_api.core.engine import WellCore
 from opentrons.protocol_api.labware import Well, Labware
@@ -204,15 +208,18 @@ def test_raise_only_if_pip_location_inside_liquid(
     with expected_raise:
         raise_if_location_inside_liquid(
             location=pip_location,
-            well_location=well_location,
             well_core=well_core,
             location_check_descriptors=location_descriptors,
             logger=logger,
         )
 
 
+@pytest.mark.parametrize(
+    "error_raised", [LiquidHeightUnknownError(), IncompleteLabwareDefinitionError()]
+)
 def test_log_warning_if_pip_location_cannot_be_validated(
     decoy: Decoy,
+    error_raised: ProtocolEngineError,
 ) -> None:
     """It should log a warning if we don't have access to liquid height."""
     pip_location = Location(point=Point(1, 2, 3), labware=None)
@@ -224,12 +231,11 @@ def test_log_warning_if_pip_location_cannot_be_validated(
     )
     logger = decoy.mock(cls=Logger)
 
-    decoy.when(well_core.current_liquid_height()).then_raise(LiquidHeightUnknownError())
+    decoy.when(well_core.current_liquid_height()).then_raise(error_raised)
     decoy.when(well_core.get_bottom(0)).then_return(Point(0, 0, 0))
     decoy.when(well_core.get_display_name()).then_return("Well A1 of test_labware")
     raise_if_location_inside_liquid(
         location=pip_location,
-        well_location=well_location,
         well_core=well_core,
         location_check_descriptors=location_descriptors,
         logger=logger,

--- a/api/tests/opentrons/protocols/advanced_control/transfers/test_transfer_liquid_utils.py
+++ b/api/tests/opentrons/protocols/advanced_control/transfers/test_transfer_liquid_utils.py
@@ -194,7 +194,6 @@ def test_raise_only_if_pip_location_inside_liquid(
     expected_raise: ContextManager[Any],
 ) -> None:
     """It should raise an error if we have access to liquid height and pipette is in liquid."""
-    well_location = Location(point=Point(1, 1, 1), labware=None)
     well_core = decoy.mock(cls=WellCore)
     location_descriptors = LocationCheckDescriptors(
         location_type="retract end",
@@ -223,7 +222,6 @@ def test_log_warning_if_pip_location_cannot_be_validated(
 ) -> None:
     """It should log a warning if we don't have access to liquid height."""
     pip_location = Location(point=Point(1, 2, 3), labware=None)
-    well_location = Location(point=Point(1, 1, 1), labware=None)
     well_core = decoy.mock(cls=WellCore)
     location_descriptors = LocationCheckDescriptors(
         location_type="retract end",


### PR DESCRIPTION
Closes RQA-4304

# Overview

The check that verifies that a submerge start location or retract end location is not inside the liquid in well relies on knowing the height of the liquid- either by calculating it based on liquid volume and well inner geometry or by probing into the well.
We already skip the check if we don't know the liquid volume or haven't probed the well yet, opting to simply log the decision instead. We should also skip the check if a well's innergeometry isn't present either otherwise the check will raise errors for any labware that doesn't have inner geometry defined, like the `smc_384_read_plate`, or if it's a custom labware.

So this PR makes it so that the check excepts on `IncompleteLabwareDefinitionError` as well.

## Test Plan and Hands on Testing

The protocol in the ticket above should now analyze succesfully.

## Review requests

- As far as I know, `IncompleteLabwareDefinitionError` is only raised while trying to find the liquid height based on liquid volume and well geometry, after the engine checks for a probed height. So this error won't be raised if there's a probed height, even if the well actually doesn't have an inner geometry; and that's what we would expect.
Let me know if I'm not right about this.

## Risk assessment

Low. Only skips a check that would have errored without being useful.
