### PR TITLE
feat(step-generation): add lid arg to load_labware()

### DIFF
--- a/step-generation/src/__tests__/pythonFileUtils.test.ts
+++ b/step-generation/src/__tests__/pythonFileUtils.test.ts
@@ -127,6 +127,7 @@ const labwareId2 = 'labwareId2'
 const labwareId3 = 'labwareId3'
 const labwareId4 = 'labwareId4'
 const labwareId5 = 'labwareId5'
+const labwareId6 = 'labwareId6'
 
 const mockLabwareEntities: LabwareEntities = {
   [labwareId1]: {
@@ -159,6 +160,16 @@ const mockLabwareEntities: LabwareEntities = {
     def: fixture96Plate as LabwareDefinition2,
     pythonName: 'well_plate_3',
   },
+  [labwareId6]: {
+    id: labwareId6,
+    labwareDefURI: 'opentrons/mock_lid/1',
+    def: {
+      ...opentrons96Plate,
+      allowedRoles: ['lid'],
+      parameters: { loadName: 'mock_lid' } as any,
+    },
+    pythonName: 'lid_1',
+  },
 }
 
 const labwareRobotState: TimelineFrame['labware'] = {
@@ -172,6 +183,8 @@ const labwareRobotState: TimelineFrame['labware'] = {
   [labwareId4]: { stack: [labwareId4, moduleId3, 'A2'] },
   //  labware on a slot
   [labwareId5]: { stack: [labwareId5, 'C2'] },
+  // lid on labware
+  [labwareId6]: { stack: [labwareId6, labwareId3, labwareId2, 'B2'] },
 }
 
 const mockLabwareNicknames: Record<string, string> = {
@@ -223,7 +236,7 @@ adapter_2 = protocol.load_adapter_from_definition(
 })
 
 describe('getLoadLabware', () => {
-  it('should generate loadLabware for 3 labware', () => {
+  it('should generate loadLabware for 3 labware with a lid on the first one', () => {
     expect(
       getLoadLabware(
         mockModuleEntities,
@@ -238,6 +251,7 @@ well_plate_1 = adapter_2.load_labware(
     "fixture_96_plate",
     label="reagent plate",
     namespace="opentrons",
+    lid="mock_lid",
 )
 well_plate_2 = magnetic_block_2.load_labware(
     "fixture_96_plate",

--- a/step-generation/src/utils/pythonFileUtils.ts
+++ b/step-generation/src/utils/pythonFileUtils.ts
@@ -167,12 +167,20 @@ export function getLoadLabware(
   labwareNicknamesById: Record<string, string>
 ): string {
   const labwareEntities = Object.values(allLabwareEntities).filter(
-    lw => !lw.def.allowedRoles?.includes('adapter')
+    lw =>
+      !lw.def.allowedRoles?.includes('adapter') &&
+      !lw.def.allowedRoles?.includes('lid')
+  )
+  const lidEntities = Object.values(allLabwareEntities).filter(lw =>
+    lw.def.allowedRoles?.includes('lid')
   )
   const pythonLabware = Object.values(labwareEntities)
     .map(labware => {
       const { id, def, pythonName } = labware
       const { metadata, parameters, namespace } = def
+      const lidEntity = Object.values(lidEntities).find(
+        lid => labwareRobotState[lid.id].stack[1] === id
+      )
       const hasNickname =
         labwareNicknamesById[id] != null &&
         labwareNicknamesById[id] !== metadata.displayName
@@ -204,6 +212,9 @@ export function getLoadLabware(
           ...(locationArg ? [locationArg] : []),
           ...(labelArg ? [labelArg] : []),
           `namespace=${formatPyStr(namespace)}`,
+          ...(lidEntity != null
+            ? [`lid=${formatPyStr(lidEntity.def.parameters.loadName)}`]
+            : []),
           //  NOTE: temporarily removing version number
           //  until PD migrated labware defs to the latest version
           //  upon re-import


### PR DESCRIPTION
closes AUTH-2007

# Overview

This allows you to load a lid on a labware properly in the python generated code -> this is merging into `edge` since lids are not supported in PD 8.5

QUESTION: PD will no longer support exporting JSON starting at PD 8.5, so it is ok that I didn't add loading a lid to the JSON? 🤔  Quick transfer won't be loading lids, i don't think. So we don't need to worry about adding it to the JSON there.

## Test Plan and Hands on Testing

make sure attached protocol passes protocol analysis. there is a tiprack lid on the 2nd tip rack

```
import json
from opentrons import protocol_api, types

metadata = {
    "created": "2025-06-25T13:01:20.364Z",
    "lastModified": "2025-06-25T13:01:32.823Z",
    "protocolDesigner": "8.5.0-alpha.0",
    "source": "Protocol Designer",
}

requirements = {"robotType": "Flex", "apiLevel": "2.24"}

def run(protocol: protocol_api.ProtocolContext) -> None:
    # Load Labware:
    tip_rack_1 = protocol.load_labware(
        "opentrons_flex_96_tiprack_50ul",
        location="C2",
        namespace="opentrons",
    )
    tip_rack_2 = protocol.load_labware(
        "opentrons_flex_96_tiprack_50ul",
        location="D3",
        label="Opentrons Flex 96 Tip Rack 50 µL (1)",
        namespace="opentrons",
        lid="opentrons_flex_tiprack_lid",
    )

    # Load Pipettes:
    pipette_left = protocol.load_instrument("flex_1channel_50", "left", tip_racks=[tip_rack_1, tip_rack_2])

    # Load Trash Bins:
    trash_bin_1 = protocol.load_trash_bin("A3")

    # PROTOCOL STEPS



DESIGNER_APPLICATION = """{"robot":{"model":"OT-3 Standard"},"designerApplication":{"name":"opentrons/protocol-designer","version":"8.5.0","data":{"pipetteTiprackAssignments":{"e46199a9-cfce-4d7d-9ab9-6fc3c7f9d009":["opentrons/opentrons_flex_96_tiprack_50ul/2"]},"dismissedWarnings":{"form":[],"timeline":[]},"ingredients":{},"ingredLocations":{},"savedStepForms":{"__INITIAL_DECK_SETUP_STEP__":{"stepType":"manualIntervention","id":"__INITIAL_DECK_SETUP_STEP__","labwareLocationUpdate":{"565b2b42-3de2-4554-9254-e3fa684ef122:opentrons/opentrons_flex_96_tiprack_50ul/2":"C2","5d63d121-58e0-4dad-bf0e-e908cbcb2442:opentrons/opentrons_flex_96_tiprack_50ul/2":"D3","9b9d961f-eee2-4361-b6bb-1444418df391:opentrons/opentrons_flex_tiprack_lid/2":"5d63d121-58e0-4dad-bf0e-e908cbcb2442:opentrons/opentrons_flex_96_tiprack_50ul/2"},"pipetteLocationUpdate":{"e46199a9-cfce-4d7d-9ab9-6fc3c7f9d009":"left"},"moduleLocationUpdate":{},"trashBinLocationUpdate":{"de8a1280-cb0d-467f-a82f-506280550a15:trashBin":"cutoutA3"},"wasteChuteLocationUpdate":{},"stagingAreaLocationUpdate":{},"gripperLocationUpdate":{}}},"orderedStepIds":[],"pipettes":{"e46199a9-cfce-4d7d-9ab9-6fc3c7f9d009":{"pipetteName":"p50_single_flex"}},"modules":{},"labware":{"565b2b42-3de2-4554-9254-e3fa684ef122:opentrons/opentrons_flex_96_tiprack_50ul/2":{"displayName":"Opentrons Flex 96 Tip Rack 50 µL","labwareDefURI":"opentrons/opentrons_flex_96_tiprack_50ul/2"},"5d63d121-58e0-4dad-bf0e-e908cbcb2442:opentrons/opentrons_flex_96_tiprack_50ul/2":{"displayName":"Opentrons Flex 96 Tip Rack 50 µL (1)","labwareDefURI":"opentrons/opentrons_flex_96_tiprack_50ul/2"},"9b9d961f-eee2-4361-b6bb-1444418df391:opentrons/opentrons_flex_tiprack_lid/2":{"displayName":"Opentrons Flex Tip Rack Lid","labwareDefURI":"opentrons/opentrons_flex_tiprack_lid/2"}}}},"metadata":{"protocolName":"","author":"","description":"","source":"Protocol Designer","created":1750856480364,"lastModified":1750856492823}}"""
```

## Changelog

- add logic for loading the lid on top of a labware in `loadLabware`
- add test case

## Risk assessment

low
