### PR TITLE
feat(step-generation): ensure retract position is safe for air gap

### DIFF
--- a/step-generation/src/commandCreators/compound/consolidate.ts
+++ b/step-generation/src/commandCreators/compound/consolidate.ts
@@ -23,6 +23,7 @@ import {
   curryWithoutPython,
   DEST_WELL_BLOWOUT_DESTINATION,
   formatPyStr,
+  getIsRetractSafeForAirGap,
   getIsSafePipetteMovement,
   getSlotInLocationStack,
   getTransferPlanAndReferenceVolumes,
@@ -489,6 +490,25 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
       defaultValue: null,
     }) ?? dispenseFlowRateUlSec
 
+  const isDispenseRetractSafeForAirGap = getIsRetractSafeForAirGap({
+    retractZOffset: dispenseRetractZOffset,
+    retractPositionReference: dispenseRetractPositionReference,
+    labwareId: destLabware,
+    labwareEntities,
+    well: destWell,
+  })
+  const preDispenseAirGapMoveToCommand =
+    !isDispenseRetractSafeForAirGap && destWell != null
+      ? [
+          curryWithoutPython(moveToWell, {
+            pipetteId: pipette,
+            labwareId: destLabware,
+            wellName: destWell,
+            wellLocation: SAFE_MOVE_TO_WELL_LOCATION,
+          }),
+        ]
+      : []
+
   const jsonCommandCreators = flatMap(
     sourceWellChunks,
     (
@@ -496,12 +516,14 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
       chunkIndex: number
     ): CurriedCommandCreator[] => {
       const getAirGapAfterDispenseCommands = (
-        considerUltimateSubtransfer: boolean
+        considerUltimateSubtransfer: boolean,
+        considerRetractSafety: boolean = true
       ): CurriedCommandCreator[] =>
         dispenseAirGapVolume > 0 &&
         // don't air gap if end of full transfer and not changing tip
         !(changeTip === 'never' && isLastChunk && considerUltimateSubtransfer)
           ? [
+              ...(considerRetractSafety ? preDispenseAirGapMoveToCommand : []),
               curryWithoutPython(prepareToAspirate, {
                 pipetteId: pipette,
               }),
@@ -536,8 +558,9 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
                   : {}),
               }),
               // move back to retract position after touch tip if air gap needed
+              // if retract isn't safe for air gap, air gap commands will include a move to well safe position
               ...(getAirGapAfterDispenseCommands(considerUltimateSubtransfer)
-                .length > 0
+                .length > 0 && isDispenseRetractSafeForAirGap
                 ? [
                     curryWithoutPython(moveToWell, {
                       pipetteId: pipette,
@@ -606,6 +629,24 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
               z: aspirateRetractZOffset,
             },
           }
+          const isAspirateRetractSafeForAirGap = getIsRetractSafeForAirGap({
+            retractZOffset: aspirateRetractZOffset,
+            retractPositionReference: aspirateRetractPositionReference,
+            labwareId: sourceLabware,
+            labwareEntities,
+            well: sourceWell,
+          })
+          const preAspirateAirGapMoveToCommand =
+            !isAspirateRetractSafeForAirGap && sourceWell != null
+              ? [
+                  curryWithoutPython(moveToWell, {
+                    pipetteId: pipette,
+                    labwareId: sourceLabware,
+                    wellName: sourceWell,
+                    wellLocation: SAFE_MOVE_TO_WELL_LOCATION,
+                  }),
+                ]
+              : []
           const dispenseCorrectionVolumeForDispenseAirGap =
             getByVolumeValue({
               liquidClass,
@@ -726,7 +767,8 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
                     : {}),
                 }),
                 // move back to retract position after touch tip if air gap needed
-                ...(aspirateAirGapVolume > 0
+                // if retract isn't safe for air gap, air gap commands will include a move to well safe position
+                ...(aspirateAirGapVolume > 0 && isAspirateRetractSafeForAirGap
                   ? [
                       curryWithoutPython(moveToWell, {
                         pipetteId: pipette,
@@ -751,6 +793,7 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
           const airGapAfterAspirateRetractCommands =
             aspirateAirGapVolume > 0
               ? [
+                  ...preAspirateAirGapMoveToCommand,
                   curryWithoutPython(airGapInPlace, {
                     pipetteId: pipette,
                     volume: aspirateAirGapVolume,
@@ -1014,7 +1057,7 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
             },
           }),
           ...blowOutInPlaceCommand,
-          ...getAirGapAfterDispenseCommands(true),
+          ...getAirGapAfterDispenseCommands(true, false),
         ]
       }
 

--- a/step-generation/src/commandCreators/compound/distribute.ts
+++ b/step-generation/src/commandCreators/compound/distribute.ts
@@ -24,6 +24,7 @@ import {
   curryWithoutPython,
   DEST_WELL_BLOWOUT_DESTINATION,
   formatPyStr,
+  getIsRetractSafeForAirGap,
   getIsSafePipetteMovement,
   getSlotInLocationStack,
   getTransferPlanAndReferenceVolumes,
@@ -507,6 +508,26 @@ export const distribute: CommandCreator<DistributeArgs> = (
     }) ?? dispenseFlowRateUlSec
 
   const destWellChunks = chunk(destWells, numWellsToFitInTip)
+
+  const isAspirateRetractSafeForAirGap = getIsRetractSafeForAirGap({
+    retractZOffset: aspirateRetractZOffset,
+    retractPositionReference: aspirateRetractPositionReference,
+    labwareId: sourceLabware,
+    labwareEntities,
+    well: sourceWell,
+  })
+  const preAspirateAirGapMoveToCommand =
+    !isAspirateRetractSafeForAirGap && sourceWell != null
+      ? [
+          curryWithoutPython(moveToWell, {
+            pipetteId: pipette,
+            labwareId: sourceLabware,
+            wellName: sourceWell,
+            wellLocation: SAFE_MOVE_TO_WELL_LOCATION,
+          }),
+        ]
+      : []
+
   const jsonCommandCreators = flatMap(
     destWellChunks,
     (destWellChunk: string[], chunkIndex: number): CurriedCommandCreator[] => {
@@ -696,7 +717,8 @@ export const distribute: CommandCreator<DistributeArgs> = (
                 : {}),
             }),
             // move back to retract position after touch tip if air gap needed
-            ...(aspirateAirGapVolume > 0
+            // if retract isn't safe for air gap, air gap commands will include a move to well safe position
+            ...(aspirateAirGapVolume > 0 && isAspirateRetractSafeForAirGap
               ? [
                   curryWithoutPython(moveToWell, {
                     pipetteId: pipette,
@@ -721,6 +743,7 @@ export const distribute: CommandCreator<DistributeArgs> = (
       const airGapAfterAspirateRetractCommands =
         aspirateAirGapVolume > 0
           ? [
+              ...preAspirateAirGapMoveToCommand,
               curryWithoutPython(airGapInPlace, {
                 pipetteId: pipette,
                 volume: aspirateAirGapVolume,
@@ -833,6 +856,25 @@ export const distribute: CommandCreator<DistributeArgs> = (
               byVolumeProperty: 'correctionByVolume',
               defaultValue: 0,
             }) ?? 0
+
+          const isDispenseRetractSafeForAirGap = getIsRetractSafeForAirGap({
+            retractZOffset: dispenseRetractZOffset,
+            retractPositionReference: dispensePositionReference,
+            labwareId: destLabware,
+            labwareEntities,
+            well: destinationWell,
+          })
+          const preDispenseAirGapMoveToCommand = !isDispenseRetractSafeForAirGap
+            ? [
+                curryWithoutPython(moveToWell, {
+                  pipetteId: pipette,
+                  labwareId: destLabware,
+                  wellName: destinationWell,
+                  wellLocation: SAFE_MOVE_TO_WELL_LOCATION,
+                }),
+              ]
+            : []
+
           const dispenseSubmergeCommands =
             destinationWell != null
               ? [
@@ -951,7 +993,8 @@ export const distribute: CommandCreator<DistributeArgs> = (
               defaultValue: 0,
             }) ?? 0
           const getAirGapAfterDispenseCommands = (
-            considerUltimateSubtransfer: boolean
+            considerUltimateSubtransfer: boolean,
+            considerRetractSafety: boolean = true
           ): CurriedCommandCreator[] =>
             dispenseAirGapVolume > 0 &&
             // don't air gap if not last well in chunk and conditioning volume is present
@@ -967,6 +1010,9 @@ export const distribute: CommandCreator<DistributeArgs> = (
               considerUltimateSubtransfer
             )
               ? [
+                  ...(considerRetractSafety
+                    ? preDispenseAirGapMoveToCommand
+                    : []),
                   curryWithoutPython(prepareToAspirate, {
                     pipetteId: pipette,
                   }),
@@ -1001,9 +1047,10 @@ export const distribute: CommandCreator<DistributeArgs> = (
                       : {}),
                   }),
                   // move back to retract position after touch tip if air gap needed
+                  // if retract isn't safe for air gap, air gap commands will include a move to well safe position
                   ...(getAirGapAfterDispenseCommands(
                     considerUltimateSubtransfer
-                  ).length > 0
+                  ).length > 0 && isDispenseRetractSafeForAirGap
                     ? [
                         curryWithoutPython(moveToWell, {
                           pipetteId: pipette,
@@ -1082,7 +1129,7 @@ export const distribute: CommandCreator<DistributeArgs> = (
                     }),
                   ]
                 : []),
-              ...finalAirGapAfterDispenseCommands,
+              ...getAirGapAfterDispenseCommands(true, false),
             ]
           } else {
             // trash or waste chute
@@ -1102,7 +1149,7 @@ export const distribute: CommandCreator<DistributeArgs> = (
                 },
               }),
               ...blowoutInPlaceCommand,
-              ...getAirGapAfterDispenseCommands(true),
+              ...getAirGapAfterDispenseCommands(true, false),
             ]
           }
 

--- a/step-generation/src/commandCreators/compound/transfer.ts
+++ b/step-generation/src/commandCreators/compound/transfer.ts
@@ -20,6 +20,7 @@ import {
   curryWithoutPython,
   DEST_WELL_BLOWOUT_DESTINATION,
   formatPyStr,
+  getIsRetractSafeForAirGap,
   getSlotInLocationStack,
   getTrashOrLabware,
   indentPyLines,
@@ -489,22 +490,22 @@ export const transfer: CommandCreator<TransferArgs> = (
               ]
             : []
 
-          const wellDepth =
+          const aspirateWellDepth =
             labwareEntities[sourceLabware]?.def.wells[sourceWell]?.depth ?? null
           const aspirateMmFromBottom = getMmFromBottom(
             aspirateZOffset,
             aspiratePositionReference,
-            wellDepth
+            aspirateWellDepth
           )
           const aspirateSubmergeMmFromBottom = getMmFromBottom(
             aspirateSubmergeZOffset,
             aspirateSubmergePositionReference,
-            wellDepth
+            aspirateWellDepth
           )
           const aspirateRetractMmFromBottom = getMmFromBottom(
             aspirateRetractZOffset,
             aspirateRetractPositionReference,
-            wellDepth
+            aspirateWellDepth
           )
           if (
             aspirateMmFromBottom != null &&
@@ -513,6 +514,44 @@ export const transfer: CommandCreator<TransferArgs> = (
           ) {
             errors.push(errorCreators.submergeBelowAspirate())
           }
+
+          const isAspirateRetractSafeForAirGap = getIsRetractSafeForAirGap({
+            retractZOffset: aspirateRetractZOffset,
+            retractPositionReference: aspirateRetractPositionReference,
+            labwareId: sourceLabware,
+            labwareEntities,
+            well: sourceWell,
+          })
+          const preAspirateAirGapMoveToCommand =
+            !isAspirateRetractSafeForAirGap && sourceWell != null
+              ? [
+                  curryWithoutPython(moveToWell, {
+                    pipetteId: pipette,
+                    labwareId: sourceLabware,
+                    wellName: sourceWell,
+                    wellLocation: SAFE_MOVE_TO_WELL_LOCATION,
+                  }),
+                ]
+              : []
+
+          const isDispenseRetractSafeForAirGap = getIsRetractSafeForAirGap({
+            retractZOffset: dispenseRetractZOffset,
+            retractPositionReference: dispensePositionReference,
+            labwareId: destLabware,
+            labwareEntities,
+            well: destinationWell,
+          })
+          const preDispenseAirGapMoveToCommand =
+            !isDispenseRetractSafeForAirGap && destinationWell != null
+              ? [
+                  curryWithoutPython(moveToWell, {
+                    pipetteId: pipette,
+                    labwareId: destLabware,
+                    wellName: destinationWell,
+                    wellLocation: SAFE_MOVE_TO_WELL_LOCATION,
+                  }),
+                ]
+              : []
           if (
             aspirateMmFromBottom != null &&
             aspirateRetractMmFromBottom != null &&
@@ -674,7 +713,8 @@ export const transfer: CommandCreator<TransferArgs> = (
                     : {}),
                 }),
                 // move back to retract position after touch tip if air gap needed
-                ...(aspirateAirGapVol > 0
+                // if retract isn't safe for air gap, air gap commands will include a move to well safe position
+                ...(aspirateAirGapVol > 0 && isAspirateRetractSafeForAirGap
                   ? [
                       curryWithoutPython(moveToWell, {
                         pipetteId: pipette,
@@ -699,6 +739,7 @@ export const transfer: CommandCreator<TransferArgs> = (
           const airGapAfterAspirateRetractCommands =
             aspirateAirGapVol > 0
               ? [
+                  ...preAspirateAirGapMoveToCommand,
                   curryWithoutPython(airGapInPlace, {
                     pipetteId: pipette,
                     volume: aspirateAirGapVol,
@@ -906,7 +947,8 @@ export const transfer: CommandCreator<TransferArgs> = (
             }) ?? 0
 
           const getAirGapAfterDispenseCommands = (
-            considerUltimateSubtransfer: boolean
+            considerUltimateSubtransfer: boolean,
+            considerRetractSafety: boolean = true
           ): CurriedCommandCreator[] =>
             dispenseAirGapVol > 0 &&
             !(
@@ -915,6 +957,9 @@ export const transfer: CommandCreator<TransferArgs> = (
               considerUltimateSubtransfer
             ) // don't air gap if end of full transfer and not changing tip
               ? [
+                  ...(considerRetractSafety
+                    ? preDispenseAirGapMoveToCommand
+                    : []),
                   curryWithoutPython(airGapInPlace, {
                     pipetteId: pipette,
                     volume: dispenseAirGapVol,
@@ -947,9 +992,10 @@ export const transfer: CommandCreator<TransferArgs> = (
                       : {}),
                   }),
                   // move back to retract position after touch tip if air gap needed
+                  // if retract isn't safe for air gap, air gap commands will include a move to well safe position
                   ...(getAirGapAfterDispenseCommands(
                     considerUltimateSubtransfer
-                  ).length > 0
+                  ).length > 0 && isDispenseRetractSafeForAirGap
                     ? [
                         curryWithoutPython(moveToWell, {
                           pipetteId: pipette,
@@ -1017,7 +1063,7 @@ export const transfer: CommandCreator<TransferArgs> = (
                       }),
                     ]
                   : []),
-                ...getAirGapAfterDispenseCommands(true),
+                ...getAirGapAfterDispenseCommands(true, false),
               ]
               break
             default:
@@ -1031,7 +1077,7 @@ export const transfer: CommandCreator<TransferArgs> = (
                     flowRate: blowoutFlowRateUlSec,
                     trashId: blowoutLocation,
                   }),
-                  ...getAirGapAfterDispenseCommands(true),
+                  ...getAirGapAfterDispenseCommands(true, false),
                 ]
               } else if (blowoutLocation in wasteChuteEntities) {
                 advancedDispenseArgsCommands = [
@@ -1040,7 +1086,7 @@ export const transfer: CommandCreator<TransferArgs> = (
                     flowRate: blowoutFlowRateUlSec,
                     wasteChuteId: blowoutLocation,
                   }),
-                  ...getAirGapAfterDispenseCommands(true),
+                  ...getAirGapAfterDispenseCommands(true, false),
                 ]
               }
               break

--- a/step-generation/src/fixtures/commandFixtures.ts
+++ b/step-generation/src/fixtures/commandFixtures.ts
@@ -236,6 +236,7 @@ export const aspirateHelperLiquidClass = (submergeParams: {
   touchTipMmFromTop?: number
   touchTipMmFromEdge?: number
   touchTipSpeed?: number
+  isRetractSafeForAirGap?: boolean
 }) => {
   const {
     volume,
@@ -263,6 +264,7 @@ export const aspirateHelperLiquidClass = (submergeParams: {
     touchTipMmFromTop,
     touchTipMmFromEdge,
     touchTipSpeed,
+    isRetractSafeForAirGap = false,
   } = submergeParams
   const mixCommands = []
   for (let i = 0; i < mixTimes; i++) {
@@ -492,24 +494,22 @@ export const aspirateHelperLiquidClass = (submergeParams: {
               speed: touchTipSpeed,
             },
           },
-          ...(aspirateAirGap > 0
-            ? [
-                {
-                  commandType: 'moveToWell',
-                  key: expect.any(String),
-                  params: {
-                    pipetteId: 'p300SingleId',
-                    labwareId: SOURCE_LABWARE,
-                    wellName,
-                    wellLocation: retractLocation,
-                  },
-                },
-              ]
-            : []),
         ]
       : []),
     ...(aspirateAirGap > 0
       ? [
+          {
+            commandType: 'moveToWell',
+            key: expect.any(String),
+            params: {
+              pipetteId: 'p300SingleId',
+              labwareId: SOURCE_LABWARE,
+              wellName,
+              wellLocation: isRetractSafeForAirGap
+                ? retractLocation
+                : SAFE_MOVE_TO_WELL_LOCATION,
+            },
+          },
           {
             commandType: 'airGapInPlace',
             key: expect.any(String),
@@ -625,6 +625,7 @@ export const dispenseHelperLiquidClass = (params: {
   pushOut?: number
   shouldBlowoutInDestination?: boolean
   blowoutFlowRate?: number
+  isRetractSafeForAirGap?: boolean
 }) => {
   const {
     volume,
@@ -653,6 +654,7 @@ export const dispenseHelperLiquidClass = (params: {
     pushOut,
     shouldBlowoutInDestination = false,
     blowoutFlowRate,
+    isRetractSafeForAirGap = false,
   } = params
   const mixCommands = []
   for (let i = 0; i < mixTimes; i++) {
@@ -824,24 +826,22 @@ export const dispenseHelperLiquidClass = (params: {
               speed: touchTipSpeed,
             },
           },
-          ...(dispenseAirGap > 0
-            ? [
-                {
-                  commandType: 'moveToWell',
-                  key: expect.any(String),
-                  params: {
-                    pipetteId: 'p300SingleId',
-                    labwareId,
-                    wellName,
-                    wellLocation: retractLocation,
-                  },
-                },
-              ]
-            : []),
         ]
       : []),
     ...(dispenseAirGap > 0
       ? [
+          {
+            commandType: 'moveToWell',
+            key: expect.any(String),
+            params: {
+              pipetteId: 'p300SingleId',
+              labwareId,
+              wellName,
+              wellLocation: isRetractSafeForAirGap
+                ? retractLocation
+                : SAFE_MOVE_TO_WELL_LOCATION,
+            },
+          },
           {
             commandType: 'airGapInPlace',
             key: expect.any(String),

--- a/step-generation/src/utils/__tests__/misc.test.ts
+++ b/step-generation/src/utils/__tests__/misc.test.ts
@@ -1,13 +1,26 @@
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   fixtureTiprack10ul as _fixtureTiprack10ul,
   fixtureTiprack300ul as _fixtureTiprack300ul,
+  getMmFromBottom,
+  POSITION_REFERENCE_TOP,
 } from '@opentrons/shared-data'
 
-import { getTransferPlanAndReferenceVolumes } from '../misc'
+import {
+  getIsRetractSafeForAirGap,
+  getTransferPlanAndReferenceVolumes,
+} from '../misc'
 
 import type { LabwareDefinition2, PipetteV2Specs } from '@opentrons/shared-data'
+
+vi.mock('@opentrons/shared-data', async () => {
+  const actual = await vi.importActual('@opentrons/shared-data')
+  return {
+    ...actual,
+    getMmFromBottom: vi.fn(),
+  }
+})
 
 const fixtureTiprack10ul = _fixtureTiprack10ul as LabwareDefinition2
 const fixtureTiprack300ul = _fixtureTiprack300ul as LabwareDefinition2
@@ -46,6 +59,19 @@ const MOCK_P300_SPECS: PipetteV2Specs = {
     },
   },
 } as any
+
+const MOCK_LABWARE_ID = 'mockLabwareId'
+const MOCK_LABWARE_ENTITIES = {
+  [MOCK_LABWARE_ID]: {
+    def: {
+      wells: {
+        A1: {
+          depth: 10,
+        },
+      },
+    },
+  },
+}
 
 describe('getTransferPlanAndReferenceVolumes', () => {
   it('should return correct values for single path', () => {
@@ -352,5 +378,49 @@ describe('getTransferPlanAndReferenceVolumes', () => {
       disposalByVolume: null,
     })
     expect(result.referenceVolumes.airGap.aspirate).toBe(0.8)
+  })
+})
+
+describe('getIsRetractSafeForAirGap', () => {
+  let args: any
+  beforeEach(() => {
+    args = {
+      retractZOffset: 0,
+      retractPositionReference: POSITION_REFERENCE_TOP,
+      labwareEntities: MOCK_LABWARE_ENTITIES,
+      labwareId: 'mockLabwareId',
+      well: 'A1',
+    }
+  })
+
+  it('should return false if well is null (trash entity)', () => {
+    const result = getIsRetractSafeForAirGap({ ...args, well: null })
+    expect(result).toBe(false)
+  })
+
+  it('should return false if well depth is null', () => {
+    const result = getIsRetractSafeForAirGap({
+      ...args,
+      well: 'B1',
+    })
+    expect(result).toBe(false)
+  })
+
+  it('should return true if retract mm from bottom === safe move to well offset from top', () => {
+    vi.mocked(getMmFromBottom).mockReturnValue(12)
+    const result = getIsRetractSafeForAirGap(args)
+    expect(result).toBe(true)
+  })
+
+  it('should return true if retract mm from bottom > safe move to well offset from top', () => {
+    vi.mocked(getMmFromBottom).mockReturnValue(13)
+    const result = getIsRetractSafeForAirGap(args)
+    expect(result).toBe(true)
+  })
+
+  it('should return false if retract mm from bottom < safe move to well offset from top', () => {
+    vi.mocked(getMmFromBottom).mockReturnValue(11)
+    const result = getIsRetractSafeForAirGap(args)
+    expect(result).toBe(false)
   })
 })

--- a/step-generation/src/utils/misc.ts
+++ b/step-generation/src/utils/misc.ts
@@ -9,11 +9,13 @@ import {
   getDeckDefFromRobotType,
   getIsTiprack,
   getLabwareDefURI,
+  getMmFromBottom,
   getWellNamePerMultiTip,
   linearInterpolate,
   NINETY_SIX_CHANNEL_WASTE_CHUTE_ADDRESSABLE_AREA,
   ONE_CHANNEL_WASTE_CHUTE_ADDRESSABLE_AREA,
   OT2_ROBOT_TYPE,
+  SAFE_MOVE_TO_WELL_OFFSET_FROM_TOP_MM,
 } from '@opentrons/shared-data'
 
 import {
@@ -44,6 +46,7 @@ import type {
   LabwareDefinition2,
   PipetteChannels,
   PipetteV2Specs,
+  PositionReference,
   RobotType,
 } from '@opentrons/shared-data'
 import type {
@@ -1150,4 +1153,37 @@ export const getTransferPlanAndReferenceVolumes = (args: {
       numWellsToFitInTip: maxSourcesPerAspiration,
     },
   }
+}
+
+export const getIsRetractSafeForAirGap = (args: {
+  retractZOffset: number
+  retractPositionReference: PositionReference
+  labwareEntities: LabwareEntities
+  labwareId: string
+  well: string | null
+}): boolean => {
+  const {
+    retractZOffset,
+    retractPositionReference,
+    labwareId,
+    labwareEntities,
+    well,
+  } = args
+  if (well == null) {
+    return false
+  }
+  const wellDepth = labwareEntities[labwareId]?.def.wells[well]?.depth
+  if (wellDepth == null) {
+    return false
+  }
+  const retractMmFromBottom = getMmFromBottom(
+    retractZOffset,
+    retractPositionReference,
+    wellDepth
+  )
+  if (retractMmFromBottom == null) {
+    return false
+  }
+  const retractZOffsetFromTop = retractMmFromBottom - wellDepth
+  return retractZOffsetFromTop >= SAFE_MOVE_TO_WELL_OFFSET_FROM_TOP_MM
 }


### PR DESCRIPTION
# Overview

This PR introduces logic to check whether or not the retract position is safe for post-aspirate or -dispense air gaps. If the retract position is 2mm or more above the top of the well (deemed to be a "safe" position for air gap), we can move to the retract position for air gap. Otherwise, we move to the safe position above the well, and air gap there.

## Test Plan and Hands on Testing

- Difficult to test in practice. I confirmed intended behavior in unit and integration migration tests

## Changelog

- create utility to determine if retract position is safe for air gap
- wire up this check in step generation move liquid command creators
- update and create unit tests

## Review requests

see description

## Risk assessment

lowish. no longer exporting JSON 