### PR TITLE
refactor(step-generation): load_liquid more eloquantly

### DIFF
--- a/step-generation/src/__tests__/pythonFileUtils.test.ts
+++ b/step-generation/src/__tests__/pythonFileUtils.test.ts
@@ -433,7 +433,7 @@ liquid_2 = protocol.define_liquid(
 })
 
 describe('getLoadLiquids', () => {
-  it('should generate 2 liquids in 2 labware in 4 wells', () => {
+  it('should generate 2 liquids in 2 labware in multiple wells', () => {
     const mockLiquidsBylabwareId: LabwareLiquidState = {
       [labwareId3]: {
         A1: { [liquid1]: { volume: 10 } },
@@ -442,6 +442,14 @@ describe('getLoadLiquids', () => {
       },
       [labwareId4]: {
         D1: { [liquid2]: { volume: 180 } },
+        D2: { [liquid2]: { volume: 180 } },
+        D3: { [liquid2]: { volume: 180 } },
+        D4: { [liquid2]: { volume: 180 } },
+        D5: { [liquid2]: { volume: 180 } },
+        D6: { [liquid2]: { volume: 180 } },
+        D7: { [liquid2]: { volume: 180 } },
+        D8: { [liquid2]: { volume: 180 } },
+        E3: { [liquid2]: { volume: 180 } },
       },
     }
     expect(
@@ -453,10 +461,24 @@ describe('getLoadLiquids', () => {
     ).toBe(
       `
 # Load Liquids:
-well_plate_1["A1"].load_liquid(liquid_1, 10)
-well_plate_1["A2"].load_liquid(liquid_1, 10)
-well_plate_1["A3"].load_liquid(liquid_2, 50)
-well_plate_2["D1"].load_liquid(liquid_2, 180)`.trimStart()
+well_plate_1.load_liquid(
+    wells=["A1", "A2"],
+    liquid=liquid_1,
+    volume=10,
+)
+well_plate_1.load_liquid(
+    wells=["A3"],
+    liquid=liquid_2,
+    volume=50,
+)
+well_plate_2.load_liquid(
+    wells=[
+        "D1", "D2", "D3", "D4", "D5", "D6", "D7", "D8",
+        "E3"
+        ],
+    liquid=liquid_2,
+    volume=180,
+)`.trimStart()
     )
   })
 })

--- a/step-generation/src/utils/pythonFileUtils.ts
+++ b/step-generation/src/utils/pythonFileUtils.ts
@@ -13,7 +13,10 @@ import { getPythonLiquidClassName } from './liquidClassUtils'
 import {
   CUSTOM_LABWARE_DICT_NAME,
   formatPyDict,
+  formatPyList,
   formatPyStr,
+  getChunkForIndentingLists,
+  INDENT,
   indentPyLines,
   OFF_DECK,
   PROTOCOL_CONTEXT_NAME,
@@ -293,19 +296,67 @@ export function getLoadLiquids(
   liquidEntities: LiquidEntities,
   labwareEntities: LabwareEntities
 ): string {
-  const pythonLoadLiquids = Object.entries(liquidsByLabwareId)
-    .flatMap(([labwareId, liquidState]) => {
+  const groupedLiquids = Object.entries(liquidsByLabwareId).reduce(
+    (
+      acc: Record<
+        string,
+        {
+          labwarePythonName: string
+          liquidPythonName: string
+          volume: number
+          wells: string[]
+        }
+      >,
+      [labwareId, liquidState]
+    ) => {
       const labwarePythonName = labwareEntities[labwareId].pythonName
 
-      return Object.entries(liquidState).flatMap(([well, locationState]) =>
-        Object.entries(locationState)
-          .map(([liquidGroupId, volume]) => {
-            const liquidPythonName = liquidEntities[liquidGroupId].pythonName
-            return `${labwarePythonName}[${formatPyStr(
-              well
-            )}].load_liquid(${liquidPythonName}, ${volume.volume})`
-          })
-          .join('\n')
+      Object.entries(liquidState).forEach(([well, locationState]) => {
+        Object.entries(locationState).forEach(([liquidGroupId, volumeInfo]) => {
+          const liquidPythonName = liquidEntities[liquidGroupId].pythonName
+
+          const key = `${labwarePythonName}__${liquidPythonName}__${volumeInfo.volume}`
+          if (!acc[key]) {
+            acc[key] = {
+              labwarePythonName,
+              liquidPythonName,
+              volume: volumeInfo.volume,
+              wells: [],
+            }
+          }
+          acc[key].wells.push(well)
+        })
+      })
+
+      return acc
+    },
+    {}
+  )
+
+  const pythonLoadLiquids = Object.values(groupedLiquids)
+    .map(({ labwarePythonName, liquidPythonName, volume, wells }) => {
+      const formattedWells = wells.map(w => formatPyStr(w))
+      const wellChunks = getChunkForIndentingLists(formattedWells, 8)
+
+      const indentedWells = wellChunks
+        .map(chunk => INDENT + chunk.join(', '))
+        .join(',\n')
+
+      const pythonWells =
+        formattedWells.length < 8
+          ? formattedWells.join(', ')
+          : `\n${indentedWells}\n${INDENT}`
+
+      const loadLiquidArgs = [
+        `wells=[${pythonWells}],\n` +
+          `liquid=${liquidPythonName},\n` +
+          `volume=${volume},\n`,
+      ].join()
+
+      return (
+        `${labwarePythonName}.load_liquid(\n` +
+        `${indentPyLines(loadLiquidArgs)}` +
+        `)`
       )
     })
     .join('\n')

--- a/step-generation/src/utils/pythonFileUtils.ts
+++ b/step-generation/src/utils/pythonFileUtils.ts
@@ -13,7 +13,6 @@ import { getPythonLiquidClassName } from './liquidClassUtils'
 import {
   CUSTOM_LABWARE_DICT_NAME,
   formatPyDict,
-  formatPyList,
   formatPyStr,
   getChunkForIndentingLists,
   INDENT,

--- a/step-generation/src/utils/pythonFormat.ts
+++ b/step-generation/src/utils/pythonFormat.ts
@@ -14,7 +14,7 @@ export const OFF_DECK = 'protocol_api.OFF_DECK'
 /** The variable name for the Python dict containing the custom labware defintions. */
 export const CUSTOM_LABWARE_DICT_NAME = 'CUSTOM_LABWARE'
 
-const INDENT = '    '
+export const INDENT = '    '
 
 /** Indent each of the lines in `text`. */
 export function indentPyLines(text: string): string {
@@ -150,4 +150,15 @@ export function formatPyWellLocation(wellLocation?: WellLocation): string {
     python += `.move(types.Point(${args.join(', ')}))`
   }
   return python
+}
+
+export function getChunkForIndentingLists(
+  lists: string[],
+  size: number
+): string[][] {
+  const chunks: string[][] = []
+  for (let index = 0; index < lists.length; index += size) {
+    chunks.push(lists.slice(index, index + size))
+  }
+  return chunks
 }


### PR DESCRIPTION
closes AUTH-1454

# Overview

Decided to address this given this slack thread: https://opentrons.slack.com/archives/C07E9T2NAQK/p1750788788180059

## Test Plan and Hands on Testing

Test exporting python with a bunch of liquids, the load_liquid commands should be grouped based on liquid group, labware, and volume.

I smoke tested and made sure it passes analysis but you can double check the syntax too 😄 

```
import json
from opentrons import protocol_api, types

metadata = {
    "created": "2025-06-25T14:17:31.888Z",
    "lastModified": "2025-06-25T14:41:13.989Z",
    "protocolDesigner": "8.5.0-alpha.0",
    "source": "Protocol Designer",
}

requirements = {"robotType": "Flex", "apiLevel": "2.24"}

def run(protocol: protocol_api.ProtocolContext) -> None:
    # Load Labware:
    tip_rack_1 = protocol.load_labware(
        "opentrons_flex_96_tiprack_50ul",
        location="C2",
        namespace="opentrons",
    )
    well_plate_1 = protocol.load_labware(
        "biorad_96_wellplate_200ul_pcr",
        location="D3",
        namespace="opentrons",
    )

    # Load Pipettes:
    pipette_left = protocol.load_instrument("flex_1channel_50", "left", tip_racks=[tip_rack_1])

    # Load Trash Bins:
    trash_bin_1 = protocol.load_trash_bin("A3")

    # Define Liquids:
    liquid_1 = protocol.define_liquid(
        "fdsaf",
        display_color="#b925ff",
    )

    # Load Liquids:
    well_plate_1.load_liquid(
        wells=[
            "A1", "B1", "C1", "D1", "E1", "F1", "G1", "H1",
            "A2", "B2", "C2", "D2", "E2", "F2", "G2", "H2",
            "A3", "B3", "C3", "D3", "E3", "F3", "G3", "H3",
            "A4", "B4", "C4", "D4", "E4", "F4", "G4", "H4",
            "A5", "B5", "C5", "D5", "E5", "F5", "G5", "H5",
            "A6", "B6", "C6", "D6", "E6", "F6", "G6", "H6",
            "A7", "B7", "C7", "D7", "E7", "F7", "G7", "H7"
            ],
        liquid=liquid_1,
        volume=30,
    )
    well_plate_1.load_liquid(
        wells=["D12", "C12"],
        liquid=liquid_1,
        volume=62,
    )

    # PROTOCOL STEPS



DESIGNER_APPLICATION = """{"robot":{"model":"OT-3 Standard"},"designerApplication":{"name":"opentrons/protocol-designer","version":"8.5.0","data":{"pipetteTiprackAssignments":{"59d98cd9-ddb0-4564-9124-b8be233846c0":["opentrons/opentrons_flex_96_tiprack_50ul/1"]},"dismissedWarnings":{"form":[],"timeline":[]},"ingredients":{"0":{"displayName":"fdsaf","displayColor":"#b925ff","description":null,"liquidGroupId":"0"}},"ingredLocations":{"56aab230-86e3-47f3-8a7e-19278bc57b85:opentrons/biorad_96_wellplate_200ul_pcr/3":{"A1":{"0":{"volume":30}},"B1":{"0":{"volume":30}},"C1":{"0":{"volume":30}},"D1":{"0":{"volume":30}},"E1":{"0":{"volume":30}},"F1":{"0":{"volume":30}},"G1":{"0":{"volume":30}},"H1":{"0":{"volume":30}},"A2":{"0":{"volume":30}},"B2":{"0":{"volume":30}},"C2":{"0":{"volume":30}},"D2":{"0":{"volume":30}},"E2":{"0":{"volume":30}},"F2":{"0":{"volume":30}},"G2":{"0":{"volume":30}},"H2":{"0":{"volume":30}},"A3":{"0":{"volume":30}},"B3":{"0":{"volume":30}},"C3":{"0":{"volume":30}},"D3":{"0":{"volume":30}},"E3":{"0":{"volume":30}},"F3":{"0":{"volume":30}},"G3":{"0":{"volume":30}},"H3":{"0":{"volume":30}},"A4":{"0":{"volume":30}},"B4":{"0":{"volume":30}},"C4":{"0":{"volume":30}},"D4":{"0":{"volume":30}},"E4":{"0":{"volume":30}},"F4":{"0":{"volume":30}},"G4":{"0":{"volume":30}},"H4":{"0":{"volume":30}},"A5":{"0":{"volume":30}},"B5":{"0":{"volume":30}},"C5":{"0":{"volume":30}},"D5":{"0":{"volume":30}},"E5":{"0":{"volume":30}},"F5":{"0":{"volume":30}},"G5":{"0":{"volume":30}},"H5":{"0":{"volume":30}},"A6":{"0":{"volume":30}},"B6":{"0":{"volume":30}},"C6":{"0":{"volume":30}},"D6":{"0":{"volume":30}},"E6":{"0":{"volume":30}},"F6":{"0":{"volume":30}},"G6":{"0":{"volume":30}},"H6":{"0":{"volume":30}},"A7":{"0":{"volume":30}},"B7":{"0":{"volume":30}},"C7":{"0":{"volume":30}},"D7":{"0":{"volume":30}},"E7":{"0":{"volume":30}},"F7":{"0":{"volume":30}},"G7":{"0":{"volume":30}},"H7":{"0":{"volume":30}},"D12":{"0":{"volume":62}},"C12":{"0":{"volume":62}}}},"savedStepForms":{"__INITIAL_DECK_SETUP_STEP__":{"labwareLocationUpdate":{"b33098e3-22d4-44fe-a9c8-c182db5f82b5:opentrons/opentrons_flex_96_tiprack_50ul/1":"C2","56aab230-86e3-47f3-8a7e-19278bc57b85:opentrons/biorad_96_wellplate_200ul_pcr/3":"D3"},"moduleLocationUpdate":{},"pipetteLocationUpdate":{"59d98cd9-ddb0-4564-9124-b8be233846c0":"left"},"trashBinLocationUpdate":{"b3d8e28c-05eb-4838-9439-641b2fd8f6fa:trashBin":"cutoutA3"},"wasteChuteLocationUpdate":{},"stagingAreaLocationUpdate":{},"gripperLocationUpdate":{},"stepType":"manualIntervention","id":"__INITIAL_DECK_SETUP_STEP__"}},"orderedStepIds":[],"pipettes":{"59d98cd9-ddb0-4564-9124-b8be233846c0":{"pipetteName":"p50_single_flex"}},"modules":{},"labware":{"b33098e3-22d4-44fe-a9c8-c182db5f82b5:opentrons/opentrons_flex_96_tiprack_50ul/1":{"displayName":"Opentrons Flex 96 Tip Rack 50 µL","labwareDefURI":"opentrons/opentrons_flex_96_tiprack_50ul/1"},"56aab230-86e3-47f3-8a7e-19278bc57b85:opentrons/biorad_96_wellplate_200ul_pcr/3":{"displayName":"Bio-Rad 96 Well Plate 200 µL PCR","labwareDefURI":"opentrons/biorad_96_wellplate_200ul_pcr/3"}}}},"metadata":{"protocolName":"","author":"","description":"","source":"Protocol Designer","created":1750861051888,"lastModified":1750862473989}}"""
```

## Changelog

- group the liquids based on liquidId, labwareId, and volume and then also group together the long list of wells
- add test coverage

## Risk assessment

low
