### PR TITLE
feat(protocol-designer): populate `singleDispense` values when appropriate

### DIFF
--- a/protocol-designer/src/steplist/formLevel/handleFormChange/utils.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/utils.ts
@@ -523,8 +523,27 @@ const getNoLiquidClassValuesMoveLiquid = (
     return {}
   }
   const { aspirate, singleDispense, multiDispense } = liquidClassValuesForTip
+  const { multiWellHandling } = getTransferPlanAndReferenceVolumes({
+    pipetteSpecs,
+    tiprackDefinition: null,
+    conditioningByVolume: (multiDispense?.conditioningByVolume ?? []) as Array<
+      [number, number]
+    >,
+    disposalByVolume: (multiDispense?.disposalByVolume ?? []) as Array<
+      [number, number]
+    >,
+    volume,
+    path: rawForm.path as PathOption,
+    numDispenseWells: rawForm.dispense_wells.length,
+    aspirateAirGapByVolume: aspirate.retract.airGapByVolume as Array<
+      [number, number]
+    >,
+  })
+  const { isSupported: isMultiDispenseSupported } = multiWellHandling
   const dispense =
-    multiDispense != null && path === 'multiDispense'
+    multiDispense != null &&
+    path === 'multiDispense' &&
+    isMultiDispenseSupported
       ? multiDispense
       : singleDispense
   const aspirateFlowRateFields = getFlowRateFields(
@@ -753,7 +772,10 @@ const getLiquidClassValuesMoveLiquid = (args: {
     Object.values(labwareEntities).find(
       ({ labwareDefURI }) => labwareDefURI === tipRack
     )?.def ?? null
-  const byVolumeLookup = getTransferPlanAndReferenceVolumes({
+  const {
+    referenceVolumes: byVolumeLookup,
+    multiWellHandling,
+  } = getTransferPlanAndReferenceVolumes({
     pipetteSpecs,
     tiprackDefinition,
     conditioningByVolume,
@@ -764,7 +786,8 @@ const getLiquidClassValuesMoveLiquid = (args: {
     aspirateAirGapByVolume: aspirate.retract.airGapByVolume as Array<
       [number, number]
     >,
-  }).referenceVolumes
+  })
+  const { isSupported: isMultiDispenseSupported } = multiWellHandling
   // top-level aspirate fields
   const aspiratePositionReferenceFields = getPositionReferenceFields(
     aspiratePositionReference,
@@ -833,7 +856,9 @@ const getLiquidClassValuesMoveLiquid = (args: {
   })
   const dispenseSubmergeFields = getSubmergeRetractFields({
     submergeRetractLookup:
-      path === 'multiDispense' && multiDispense != null
+      path === 'multiDispense' &&
+      multiDispense != null &&
+      isMultiDispenseSupported
         ? multiDispense.submerge
         : singleDispense.submerge,
     volumes: byVolumeLookup,
@@ -851,7 +876,9 @@ const getLiquidClassValuesMoveLiquid = (args: {
   })
   const dispenseRetractFields = getSubmergeRetractFields({
     submergeRetractLookup:
-      path === 'multiDispense' && multiDispense != null
+      path === 'multiDispense' &&
+      multiDispense != null &&
+      isMultiDispenseSupported
         ? multiDispense.retract
         : singleDispense.retract,
     volumes: byVolumeLookup,


### PR DESCRIPTION
# Overview

This PR checks that with the preliminary settings defined for a multiDispense transfer in form step 1 cannot accommodate multiDispense behavior, we pre-populate the liquid class advanced settings with those from the class's `singleDispense` object rather than `multiDispense`.

[thread for context](https://opentrons.slack.com/archives/C06M6R72UDS/p1750797928452349)

## Test Plan and Hands on Testing

Difficult to manually test. One example is creating a form with path set to `Distribute`, with a transfer volume that cannot accommodate a multiDispense path (i.e., a 50µl tip with a 40µl transfer volume to 2 destinations, with `Distribute` path selected).

The selected liquid class's `singleDispense` settings should populate the advanced settings.

## Changelog

- check if multiDispense can be accommodated when populating liquid class values for move liquid form

## Review requests

see test plan

## Risk assessment

lowish