### PR TITLE
fix(protocol-designer): fix max conditioning volume

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/SecondStepsMoveLiquidTools.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/SecondStepsMoveLiquidTools.tsx
@@ -405,6 +405,7 @@ export const SecondStepsMoveLiquidTools = ({
                 >
                   {formData.conditioning_checkbox === true ? (
                     <InputStepFormField
+                      {...propsForFields.conditioning_volume}
                       title={t(
                         'form:step_edit_form.field.conditioning.conditioning_volume.label'
                       )}
@@ -413,7 +414,6 @@ export const SecondStepsMoveLiquidTools = ({
                         { min: 0, max: maxConditioningVolume }
                       )}
                       padding="0"
-                      {...propsForFields.conditioning_volume}
                       showTooltip={false}
                     />
                   ) : null}

--- a/protocol-designer/src/utils/__tests__/utils.test.ts
+++ b/protocol-designer/src/utils/__tests__/utils.test.ts
@@ -149,46 +149,7 @@ describe('getMaxConditioningVolume', () => {
     } as any
 
     const result = getMaxConditioningVolume(args)
-    expect(result).toBe(200 - 5 - 10)
-  })
-
-  it('should calculate the max conditioning volume with low volume liquid specs and tiprack volume', () => {
-    const args = {
-      transferVolume: 4,
-      disposalVolume: 1,
-      tiprackDefUri: 'opentrons/opentrons_96_tiprack_10ul/1',
-      labwareEntities: {
-        tiprack: {
-          id: 'tiprack',
-          labwareDefURI: 'opentrons/opentrons_96_tiprack_10ul/1',
-          def: {
-            parameters: {
-              loadName: 'opentrons_96_tiprack_10ul',
-            },
-            wells: {
-              A1: {
-                totalLiquidVolume: 10,
-              },
-            },
-          },
-        },
-      },
-      pipetteSpecs: {
-        liquids: {
-          default: {
-            maxVolume: 10,
-            minVolume: 5,
-          },
-          lowVolumeDefault: {
-            maxVolume: 5,
-            minVolume: 0.1,
-          },
-        },
-      },
-    } as any
-
-    const result = getMaxConditioningVolume(args)
-    expect(result).toBe(5 - 4 - 1)
+    expect(result).toBe(200 - 5 - 10 * 2)
   })
 
   it('should calculate the max conditioning volume without tiprack volume', () => {
@@ -208,7 +169,7 @@ describe('getMaxConditioningVolume', () => {
     } as any
 
     const result = getMaxConditioningVolume(args)
-    expect(result).toBe(200 - 5 - 10)
+    expect(result).toBe(200 - 5 - 10 * 2)
   })
 
   it('should handle zero disposal volume', () => {
@@ -243,6 +204,6 @@ describe('getMaxConditioningVolume', () => {
     } as any
 
     const result = getMaxConditioningVolume(args)
-    expect(result).toBe(200 - 10)
+    expect(result).toBe(200 - 10 * 2)
   })
 })

--- a/protocol-designer/src/utils/index.ts
+++ b/protocol-designer/src/utils/index.ts
@@ -378,8 +378,10 @@ export const getMaxConditioningVolume = (args: {
     pipetteSpecs,
   } = args
   const { liquids } = pipetteSpecs
+  const minVolumeForMultiDispense = transferVolume * 2
   const isInLowVolumeMode =
-    transferVolume < liquids.default.minVolume && 'lowVolumeDefault' in liquids
+    minVolumeForMultiDispense < liquids.default.minVolume &&
+    'lowVolumeDefault' in liquids
   const tiprack = Object.values(labwareEntities).find(
     ({ labwareDefURI }) => labwareDefURI === tiprackDefUri
   )
@@ -391,7 +393,10 @@ export const getMaxConditioningVolume = (args: {
       : liquids.default.maxVolume,
     ...(tipMaxVolume != null ? [tipMaxVolume] : [])
   )
-  return maxWorkingVolume - disposalVolume - transferVolume
+  return Math.max(
+    0,
+    maxWorkingVolume - disposalVolume - minVolumeForMultiDispense
+  )
 }
 
 // for stacking


### PR DESCRIPTION
# Overview

This PR fixes the logic for determining the max conditioning volume allowed in a multiDispense transfer. We should always leave room enough in the tip to accommodate a minimum of 2 destinations-worth of volume.

## Test Plan and Hands on Testing

- create a multiDispense transfer and verify that conditioning volume range shows
- verify that conditioning volume maximum = (tip max volume) - (2x transfer volume) - (disposal volume)

## Changelog

- fix utility for max conditioning volume
- fix caption for conditioning volume range
- update unit tests

## Review requests

see test plan

## Risk assessment

low. fixes a UI-scoped bug