### PR TITLE
test(components): fix CommandText.test.tsx after we changed liquid class displayNames

### DIFF
--- a/components/src/organisms/CommandText/__tests__/CommandText.test.tsx
+++ b/components/src/organisms/CommandText/__tests__/CommandText.test.tsx
@@ -708,7 +708,7 @@ describe('CommandText', () => {
       />,
       { i18nInstance: i18n }
     )
-    screen.getByText('Loading Volatile Liquid Class')
+    screen.getByText('Loading Volatile (80% ethanol) Liquid Class')
   })
   it('renders correct text for temperatureModule/setTargetTemperature', () => {
     const mockTemp = 20


### PR DESCRIPTION
# Overview

This fixes a broken test after PR #18711, which changed the names of our liquid classes (AUTH-2003).

Specifically, we renamed `Volatile` to `Volatile (80% ethanol)`.

## Test Plan and Hands on Testing

Ran test locally. Will also see if CI tests pass.

## Risk assessment
Low, test only.