### PR TITLE
Merge back 'chore_release-8.5.0' into 'chore_release-pd-8.5.0'

### DIFF
--- a/api/src/opentrons/protocol_api/_transfer_liquid_validation.py
+++ b/api/src/opentrons/protocol_api/_transfer_liquid_validation.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import List, Union, Sequence, Optional
+from typing import List, Union, Sequence, Optional, Tuple
 
 from opentrons.types import Location, NozzleMapInterface
 from opentrons.protocols.api_support import instrument
@@ -13,6 +13,7 @@ from opentrons.protocols.advanced_control.transfers.common import (
 
 from .disposal_locations import TrashBin, WasteChute
 from .labware import Labware, Well
+from .core.common import WellCore
 from . import validation
 
 
@@ -24,13 +25,14 @@ class TransferInfo:
     tip_policy: TransferTipPolicyV2
     tip_racks: List[Labware]
     trash_location: Union[Location, TrashBin, WasteChute]
+    last_tip_location: Optional[Tuple[Location, WellCore]]
 
 
 def verify_and_normalize_transfer_args(
     source: Union[Well, Sequence[Well], Sequence[Sequence[Well]]],
     dest: Union[Well, Sequence[Well], Sequence[Sequence[Well]], TrashBin, WasteChute],
     tip_policy: TransferTipPolicyV2Type,
-    last_tip_picked_up_from: Optional[Well],
+    last_tip_well: Optional[Well],
     tip_racks: List[Labware],
     nozzle_map: NozzleMapInterface,
     group_wells_for_multi_channel: bool,
@@ -59,14 +61,14 @@ def verify_and_normalize_transfer_args(
 
     valid_new_tip = validation.ensure_new_tip_policy(tip_policy)
     if valid_new_tip == TransferTipPolicyV2.NEVER:
-        if last_tip_picked_up_from is None:
+        if last_tip_well is None:
             raise RuntimeError(
                 "Pipette has no tip attached to perform transfer."
                 " Either do a pick_up_tip beforehand or specify a new_tip parameter"
                 " of 'once' or 'always'."
             )
         else:
-            valid_tip_racks = [last_tip_picked_up_from.parent]
+            valid_tip_racks = [last_tip_well.parent]
     else:
         valid_tip_racks = tip_racks
     if current_volume != 0:
@@ -86,12 +88,22 @@ def verify_and_normalize_transfer_args(
         trash_location=_trash_location
     )
 
+    if last_tip_well is not None:
+        parent_tip_rack = last_tip_well.parent
+        last_tip_location = (
+            Location(last_tip_well.top().point, parent_tip_rack),
+            last_tip_well._core,
+        )
+    else:
+        last_tip_location = None
+
     return TransferInfo(
         source=flat_sources_list,
         dest=flat_dests_list if not isinstance(dest, (TrashBin, WasteChute)) else dest,
         tip_policy=valid_new_tip,
         tip_racks=valid_tip_racks,
         trash_location=valid_trash_location,
+        last_tip_location=last_tip_location,
     )
 
 

--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -1206,7 +1206,8 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         trash_location: Union[Location, TrashBin, WasteChute],
         return_tip: bool,
         keep_last_tip: bool,
-    ) -> None:
+        last_tip_location: Optional[Tuple[Location, WellCore]],
+    ) -> Optional[Tuple[Location, WellCore]]:
         """Execute transfer using liquid class properties.
 
         Args:
@@ -1220,8 +1221,18 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                     types.Location is only necessary for saving the last accessed location.
             new_tip: Whether the transfer should use a new tip 'once', 'never', 'always',
                      or 'per source'.
-            tiprack_uri: The URI of the tiprack that the transfer settings are for.
-            tip_drop_location: Location where the tip will be dropped (if appropriate).
+            tip_racks: List of tipracks that the transfer will pick up tips from, represented
+                       as tuples of types.Location and WellCore.
+            starting_tip: The user-chosen starting tip to use when deciding what tip to pick
+                          up, if the user has set it.
+            trash_location: The chosen trash container to drop tips in and dispose liquid in.
+            return_tip: If `True`, return tips to the tip rack location they were picked up from,
+                        otherwise drop in `trash_location`
+            keep_last_tip: When set to `True`, do not drop the final tip used in the transfer.
+            last_tip_location: If a tip is already attached, this will be the tiprack and well it was
+                           picked up from, represented as a tuple of types.Location and WellCore.
+                           Used so a tip can be returned if it was picked up outside this function
+                           as could be the case for a new_tip of `never`.
         """
         if not tip_racks:
             raise RuntimeError(
@@ -1273,14 +1284,15 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             )
         )
 
-        last_tip_picked_up_from: Optional[WellCore] = None
+        last_tip = last_tip_location
 
         def _drop_tip() -> None:
             if return_tip:
-                assert last_tip_picked_up_from is not None
+                assert last_tip is not None
+                _, tip_well = last_tip
                 self.drop_tip(
                     location=None,
-                    well_core=last_tip_picked_up_from,
+                    well_core=tip_well,
                     home_after=False,
                     alternate_drop_location=False,
                 )
@@ -1298,7 +1310,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                     alternate_drop_location=True,
                 )
 
-        def _pick_up_tip() -> WellCore:
+        def _pick_up_tip() -> Tuple[Location, WellCore]:
             next_tip = self.get_next_tip(
                 tip_racks=[core for loc, core in tip_racks],
                 starting_well=starting_tip,
@@ -1324,10 +1336,10 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                 presses=None,
                 increment=None,
             )
-            return tip_well
+            return tiprack_loc, tip_well
 
         if new_tip == TransferTipPolicyV2.ONCE:
-            last_tip_picked_up_from = _pick_up_tip()
+            last_tip = _pick_up_tip()
 
         prev_src: Optional[Tuple[Location, WellCore]] = None
         prev_dest: Optional[
@@ -1365,7 +1377,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             ):
                 if prev_src is not None and prev_dest is not None:
                     _drop_tip()
-                last_tip_picked_up_from = _pick_up_tip()
+                last_tip = _pick_up_tip()
                 post_disp_tip_contents = [
                     tx_comps_executor.LiquidAndAirGapPair(
                         liquid=0,
@@ -1414,8 +1426,10 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
 
         if not keep_last_tip:
             _drop_tip()
+            last_tip = None
 
-    # TODO(spp, 2025-02-25): wire up return tip
+        return last_tip
+
     def distribute_with_liquid_class(  # noqa: C901
         self,
         liquid_class: LiquidClass,
@@ -1432,7 +1446,8 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         trash_location: Union[Location, TrashBin, WasteChute],
         return_tip: bool,
         keep_last_tip: bool,
-    ) -> None:
+        last_tip_location: Optional[Tuple[Location, WellCore]],
+    ) -> Optional[Tuple[Location, WellCore]]:
         """Execute a distribution using liquid class properties.
 
         Args:
@@ -1447,8 +1462,18 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                      'never': the transfer will never pick up a new tip
                      'once': the transfer will pick up a new tip once at the start of transfer
                      'always': the transfer will pick up a new tip before every aspirate
-            tiprack_uri: The URI of the tiprack that the transfer settings are for.
-            tip_drop_location: Location where the tip will be dropped (if appropriate).
+            tip_racks: List of tipracks that the transfer will pick up tips from, represented
+                       as tuples of types.Location and WellCore.
+            starting_tip: The user-chosen starting tip to use when deciding what tip to pick
+                          up, if the user has set it.
+            trash_location: The chosen trash container to drop tips in and dispose liquid in.
+            return_tip: If `True`, return tips to the tip rack location they were picked up from,
+                        otherwise drop in `trash_location`
+            keep_last_tip: When set to `True`, do not drop the final tip used in the distribute.
+            last_tip_location: If a tip is already attached, this will be the tiprack and well it was
+                           picked up from, represented as a tuple of types.Location and WellCore.
+                           Used so a tip can be returned if it was picked up outside this function
+                           as could be the case for a new_tip of `never`
 
         This method distributes the liquid in the source well into multiple destinations.
         It can accomplish this by either doing a multi-dispense (aspirate once and then
@@ -1456,7 +1481,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         (going back to aspirate after each dispense). Whether it does a multi-dispense or
         multiple single dispenses is determined by whether multi-dispense properties
         are available in the liquid class and whether the tip in use can hold multiple
-        volumes to be dispensed whithout having to refill.
+        volumes to be dispensed without having to refill.
         """
         if not tip_racks:
             raise RuntimeError(
@@ -1512,7 +1537,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                 tip_working_volume=working_volume,
             )
         ):
-            self.transfer_with_liquid_class(
+            return self.transfer_with_liquid_class(
                 liquid_class=liquid_class,
                 volume=volume,
                 source=[source for _ in range(len(dest))],
@@ -1523,8 +1548,8 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                 trash_location=trash_location,
                 return_tip=return_tip,
                 keep_last_tip=keep_last_tip,
+                last_tip_location=last_tip_location,
             )
-            return
 
         # TODO: use the ID returned by load_liquid_class in command annotations
         self.load_liquid_class(
@@ -1551,14 +1576,15 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             )
         )
 
-        last_tip_picked_up_from: Optional[WellCore] = None
+        last_tip = last_tip_location
 
         def _drop_tip() -> None:
             if return_tip:
-                assert last_tip_picked_up_from is not None
+                assert last_tip is not None
+                _, tip_well = last_tip
                 self.drop_tip(
                     location=None,
-                    well_core=last_tip_picked_up_from,
+                    well_core=tip_well,
                     home_after=False,
                     alternate_drop_location=False,
                 )
@@ -1576,7 +1602,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                     alternate_drop_location=True,
                 )
 
-        def _pick_up_tip() -> WellCore:
+        def _pick_up_tip() -> Tuple[Location, WellCore]:
             next_tip = self.get_next_tip(
                 tip_racks=[core for loc, core in tip_racks],
                 starting_well=starting_tip,
@@ -1602,10 +1628,10 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                 presses=None,
                 increment=None,
             )
-            return tip_well
+            return tiprack_loc, tip_well
 
         if new_tip != TransferTipPolicyV2.NEVER:
-            last_tip_picked_up_from = _pick_up_tip()
+            last_tip = _pick_up_tip()
 
         tip_contents = [
             tx_comps_executor.LiquidAndAirGapPair(
@@ -1682,7 +1708,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
 
             if not is_first_step and new_tip == TransferTipPolicyV2.ALWAYS:
                 _drop_tip()
-                last_tip_picked_up_from = _pick_up_tip()
+                last_tip = _pick_up_tip()
                 tip_contents = [
                     tx_comps_executor.LiquidAndAirGapPair(
                         liquid=0,
@@ -1741,6 +1767,9 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
 
         if not keep_last_tip:
             _drop_tip()
+            last_tip = None
+
+        return last_tip
 
     def _tip_can_hold_volume_for_multi_dispensing(
         self,
@@ -1779,7 +1808,36 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         trash_location: Union[Location, TrashBin, WasteChute],
         return_tip: bool,
         keep_last_tip: bool,
-    ) -> None:
+        last_tip_location: Optional[Tuple[Location, WellCore]],
+    ) -> Optional[Tuple[Location, WellCore]]:
+        """Execute consolidate using liquid class properties.
+
+        Args:
+            liquid_class: The liquid class to use for transfer properties.
+            volume: Volume to transfer per well.
+            source: List of source wells, with each well represented as a tuple of
+                    types.Location and WellCore.
+                    types.Location is only necessary for saving the last accessed location.
+            dest: List of destination wells, with each well represented as a tuple of
+                    types.Location and WellCore.
+                    types.Location is only necessary for saving the last accessed location.
+            new_tip: Whether the transfer should use a new tip 'once', 'always' or 'never'.
+                     'never': the transfer will never pick up a new tip
+                     'once': the transfer will pick up a new tip once at the start of transfer
+                     'always': the transfer will pick up a new tip after every dispense
+            tip_racks: List of tipracks that the transfer will pick up tips from, represented
+                       as tuples of types.Location and WellCore.
+            starting_tip: The user-chosen starting tip to use when deciding what tip to pick
+                          up, if the user has set it.
+            trash_location: The chosen trash container to drop tips in and dispose liquid in.
+            return_tip: If `True`, return tips to the tip rack location they were picked up from,
+                        otherwise drop in `trash_location`
+            keep_last_tip: When set to `True`, do not drop the final tip used in the consolidate.
+            last_tip_location: If a tip is already attached, this will be the tiprack and well it was
+                           picked up from, represented as a tuple of types.Location and WellCore.
+                           Used so a tip can be returned if it was picked up outside this function
+                           as could be the case for a new_tip of `never`.
+        """
         if not tip_racks:
             raise RuntimeError(
                 "No tipracks found for pipette in order to perform transfer"
@@ -1839,14 +1897,15 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             )
         )
 
-        last_tip_picked_up_from: Optional[WellCore] = None
+        last_tip = last_tip_location
 
         def _drop_tip() -> None:
             if return_tip:
-                assert last_tip_picked_up_from is not None
+                assert last_tip is not None
+                _, tip_well = last_tip
                 self.drop_tip(
                     location=None,
-                    well_core=last_tip_picked_up_from,
+                    well_core=tip_well,
                     home_after=False,
                     alternate_drop_location=False,
                 )
@@ -1864,7 +1923,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                     alternate_drop_location=True,
                 )
 
-        def _pick_up_tip() -> WellCore:
+        def _pick_up_tip() -> Tuple[Location, WellCore]:
             next_tip = self.get_next_tip(
                 tip_racks=[core for loc, core in tip_racks],
                 starting_well=starting_tip,
@@ -1890,10 +1949,10 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                 presses=None,
                 increment=None,
             )
-            return tip_well
+            return tiprack_loc, tip_well
 
         if new_tip in [TransferTipPolicyV2.ONCE, TransferTipPolicyV2.ALWAYS]:
-            last_tip_picked_up_from = _pick_up_tip()
+            last_tip = _pick_up_tip()
 
         tip_contents = [
             tx_comps_executor.LiquidAndAirGapPair(
@@ -1930,7 +1989,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                 enable_lpd = True
             elif not is_first_step and new_tip == TransferTipPolicyV2.ALWAYS:
                 _drop_tip()
-                last_tip_picked_up_from = _pick_up_tip()
+                last_tip = _pick_up_tip()
                 tip_contents = [
                     tx_comps_executor.LiquidAndAirGapPair(
                         liquid=0,
@@ -1977,6 +2036,9 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
 
         if not keep_last_tip:
             _drop_tip()
+            last_tip = None
+
+        return last_tip
 
     def _get_location_and_well_core_from_next_tip_info(
         self,

--- a/api/src/opentrons/protocol_api/core/engine/transfer_components_executor.py
+++ b/api/src/opentrons/protocol_api/core/engine/transfer_components_executor.py
@@ -191,7 +191,6 @@ class TransferComponentsExecutor:
             )
             tx_utils.raise_if_location_inside_liquid(
                 location=submerge_start_location,
-                well_location=self._target_location,
                 well_core=self._target_well,
                 location_check_descriptors=LocationCheckDescriptors(
                     location_type="submerge start",
@@ -372,7 +371,6 @@ class TransferComponentsExecutor:
         )
         tx_utils.raise_if_location_inside_liquid(
             location=retract_location,
-            well_location=self._target_location,
             well_core=self._target_well,
             location_check_descriptors=LocationCheckDescriptors(
                 location_type="retract end",
@@ -499,7 +497,6 @@ class TransferComponentsExecutor:
             )
             tx_utils.raise_if_location_inside_liquid(
                 location=retract_location,
-                well_location=self._target_location,
                 well_core=self._target_well,
                 location_check_descriptors=LocationCheckDescriptors(
                     location_type="retract end",
@@ -647,7 +644,6 @@ class TransferComponentsExecutor:
         )
         tx_utils.raise_if_location_inside_liquid(
             location=retract_location,
-            well_location=self._target_location,
             well_core=self._target_well,
             location_check_descriptors=LocationCheckDescriptors(
                 location_type="retract end",

--- a/api/src/opentrons/protocol_api/core/instrument.py
+++ b/api/src/opentrons/protocol_api/core/instrument.py
@@ -372,7 +372,8 @@ class AbstractInstrument(ABC, Generic[WellCoreType, LabwareCoreType]):
         trash_location: Union[types.Location, TrashBin, WasteChute],
         return_tip: bool,
         keep_last_tip: bool,
-    ) -> None:
+        last_tip_location: Optional[Tuple[types.Location, WellCoreType]],
+    ) -> Optional[Tuple[types.Location, WellCoreType]]:
         """Transfer a liquid from source to dest according to liquid class properties."""
         ...
 
@@ -389,7 +390,8 @@ class AbstractInstrument(ABC, Generic[WellCoreType, LabwareCoreType]):
         trash_location: Union[types.Location, TrashBin, WasteChute],
         return_tip: bool,
         keep_last_tip: bool,
-    ) -> None:
+        last_tip_location: Optional[Tuple[types.Location, WellCoreType]],
+    ) -> Optional[Tuple[types.Location, WellCoreType]]:
         """
         Distribute a liquid from single source to multiple destinations
         according to liquid class properties.
@@ -409,7 +411,8 @@ class AbstractInstrument(ABC, Generic[WellCoreType, LabwareCoreType]):
         trash_location: Union[types.Location, TrashBin, WasteChute],
         return_tip: bool,
         keep_last_tip: bool,
-    ) -> None:
+        last_tip_location: Optional[Tuple[types.Location, WellCoreType]],
+    ) -> Optional[Tuple[types.Location, WellCoreType]]:
         """
         Consolidate liquid from multiple sources to a single destination
         using the specified liquid class properties.

--- a/api/src/opentrons/protocol_api/core/legacy/legacy_instrument_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy/legacy_instrument_core.py
@@ -612,7 +612,8 @@ class LegacyInstrumentCore(AbstractInstrument[LegacyWellCore, LegacyLabwareCore]
         trash_location: Union[types.Location, TrashBin, WasteChute],
         return_tip: bool,
         keep_last_tip: bool,
-    ) -> None:
+        last_tip_location: Optional[Tuple[types.Location, LegacyWellCore]],
+    ) -> Optional[Tuple[types.Location, LegacyWellCore]]:
         """This will never be called because it was added in API 2.23"""
         assert False, "transfer_liquid is not supported in legacy context"
 
@@ -628,7 +629,8 @@ class LegacyInstrumentCore(AbstractInstrument[LegacyWellCore, LegacyLabwareCore]
         trash_location: Union[types.Location, TrashBin, WasteChute],
         return_tip: bool,
         keep_last_tip: bool,
-    ) -> None:
+        last_tip_location: Optional[Tuple[types.Location, LegacyWellCore]],
+    ) -> Optional[Tuple[types.Location, LegacyWellCore]]:
         """This will never be called because it was added in API 2.23"""
         assert False, "distribute_liquid is not supported in legacy context"
 
@@ -644,7 +646,8 @@ class LegacyInstrumentCore(AbstractInstrument[LegacyWellCore, LegacyLabwareCore]
         trash_location: Union[types.Location, TrashBin, WasteChute],
         return_tip: bool,
         keep_last_tip: bool,
-    ) -> None:
+        last_tip_location: Optional[Tuple[types.Location, LegacyWellCore]],
+    ) -> Optional[Tuple[types.Location, LegacyWellCore]]:
         """This will never be called because it was added in API 2.23."""
         assert False, "consolidate_liquid is not supported in legacy context"
 

--- a/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_instrument_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_instrument_core.py
@@ -526,7 +526,8 @@ class LegacyInstrumentCoreSimulator(
         trash_location: Union[types.Location, TrashBin, WasteChute],
         return_tip: bool,
         keep_last_tip: bool,
-    ) -> None:
+        last_tip_location: Optional[Tuple[types.Location, LegacyWellCore]],
+    ) -> Optional[Tuple[types.Location, LegacyWellCore]]:
         """This will never be called because it was added in API 2.23."""
         assert False, "transfer_liquid is not supported in legacy context"
 
@@ -542,7 +543,8 @@ class LegacyInstrumentCoreSimulator(
         trash_location: Union[types.Location, TrashBin, WasteChute],
         return_tip: bool,
         keep_last_tip: bool,
-    ) -> None:
+        last_tip_location: Optional[Tuple[types.Location, LegacyWellCore]],
+    ) -> Optional[Tuple[types.Location, LegacyWellCore]]:
         """This will never be called because it was added in API 2.23."""
         assert False, "distribute_liquid is not supported in legacy context"
 
@@ -558,7 +560,8 @@ class LegacyInstrumentCoreSimulator(
         trash_location: Union[types.Location, TrashBin, WasteChute],
         return_tip: bool,
         keep_last_tip: bool,
-    ) -> None:
+        last_tip_location: Optional[Tuple[types.Location, LegacyWellCore]],
+    ) -> Optional[Tuple[types.Location, LegacyWellCore]]:
         """This will never be called because it was added in API 2.23."""
         assert False, "consolidate_liquid is not supported in legacy context"
 

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1851,7 +1851,7 @@ class InstrumentContext(publisher.CommandPublisher):
             source=source,
             dest=dest,
             tip_policy=new_tip,
-            last_tip_picked_up_from=self._last_tip_picked_up_from,
+            last_tip_well=self._last_tip_picked_up_from,
             tip_racks=self._tip_racks,
             nozzle_map=self._core.get_nozzle_map(),
             group_wells_for_multi_channel=group_wells,
@@ -1891,7 +1891,7 @@ class InstrumentContext(publisher.CommandPublisher):
                 destination=dest,
             ),
         ):
-            self._core.transfer_with_liquid_class(
+            last_tip_location = self._core.transfer_with_liquid_class(
                 liquid_class=liquid_class,
                 volume=volume,
                 source=[
@@ -1910,7 +1910,19 @@ class InstrumentContext(publisher.CommandPublisher):
                 trash_location=transfer_args.trash_location,
                 return_tip=return_tip,
                 keep_last_tip=verified_keep_last_tip,
+                last_tip_location=transfer_args.last_tip_location,
             )
+
+        # TODO(jbl 2025-06-23) last_tip_picked_up_from should be removed from the public context and
+        #   moved to the engine core or engine as a simpler and more holistic solution
+        if last_tip_location is not None:
+            tip_rack_loc, tip_well_core = last_tip_location
+            self._last_tip_picked_up_from = tip_rack_loc.labware.as_labware()[
+                tip_well_core.get_name()
+            ]
+        else:
+            self._last_tip_picked_up_from = None
+
         return self
 
     @requires_version(2, 24)
@@ -1979,7 +1991,7 @@ class InstrumentContext(publisher.CommandPublisher):
             source=source,
             dest=dest,
             tip_policy=new_tip,
-            last_tip_picked_up_from=self._last_tip_picked_up_from,
+            last_tip_well=self._last_tip_picked_up_from,
             tip_racks=self._tip_racks,
             nozzle_map=self._core.get_nozzle_map(),
             group_wells_for_multi_channel=group_wells,
@@ -2024,7 +2036,7 @@ class InstrumentContext(publisher.CommandPublisher):
                 destination=dest,
             ),
         ):
-            self._core.distribute_with_liquid_class(
+            last_tip_location = self._core.distribute_with_liquid_class(
                 liquid_class=liquid_class,
                 volume=volume,
                 source=(
@@ -2046,7 +2058,19 @@ class InstrumentContext(publisher.CommandPublisher):
                 trash_location=transfer_args.trash_location,
                 return_tip=return_tip,
                 keep_last_tip=verified_keep_last_tip,
+                last_tip_location=transfer_args.last_tip_location,
             )
+
+        # TODO(jbl 2025-06-23) last_tip_picked_up_from should be removed from the public context and
+        #   moved to the engine core or engine as a simpler and more holistic solution
+        if last_tip_location is not None:
+            tip_rack_loc, tip_well_core = last_tip_location
+            self._last_tip_picked_up_from = tip_rack_loc.labware.as_labware()[
+                tip_well_core.get_name()
+            ]
+        else:
+            self._last_tip_picked_up_from = None
+
         return self
 
     @requires_version(2, 24)
@@ -2116,7 +2140,7 @@ class InstrumentContext(publisher.CommandPublisher):
             source=source,
             dest=dest,
             tip_policy=new_tip,
-            last_tip_picked_up_from=self._last_tip_picked_up_from,
+            last_tip_well=self._last_tip_picked_up_from,
             tip_racks=self._tip_racks,
             nozzle_map=self._core.get_nozzle_map(),
             group_wells_for_multi_channel=group_wells,
@@ -2163,7 +2187,7 @@ class InstrumentContext(publisher.CommandPublisher):
                 destination=dest,
             ),
         ):
-            self._core.consolidate_with_liquid_class(
+            last_tip_location = self._core.consolidate_with_liquid_class(
                 liquid_class=liquid_class,
                 volume=volume,
                 source=[
@@ -2182,7 +2206,19 @@ class InstrumentContext(publisher.CommandPublisher):
                 trash_location=transfer_args.trash_location,
                 return_tip=return_tip,
                 keep_last_tip=verified_keep_last_tip,
+                last_tip_location=transfer_args.last_tip_location,
             )
+
+        # TODO(jbl 2025-06-23) last_tip_picked_up_from should be removed from the public context and
+        #   moved to the engine core or engine as a simpler and more holistic solution
+        if last_tip_location is not None:
+            tip_rack_loc, tip_well_core = last_tip_location
+            self._last_tip_picked_up_from = tip_rack_loc.labware.as_labware()[
+                tip_well_core.get_name()
+            ]
+        else:
+            self._last_tip_picked_up_from = None
+
         return self
 
     @requires_version(2, 0)

--- a/api/src/opentrons/protocols/advanced_control/transfers/transfer_liquid_utils.py
+++ b/api/src/opentrons/protocols/advanced_control/transfers/transfer_liquid_utils.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 from typing import Literal, Sequence, List, Optional, TYPE_CHECKING
 from dataclasses import dataclass
 
-from opentrons.protocol_engine.errors import LiquidHeightUnknownError
+from opentrons.protocol_engine.errors import (
+    LiquidHeightUnknownError,
+    IncompleteLabwareDefinitionError,
+)
 from opentrons.protocol_engine.state._well_math import (
     wells_covered_by_pipette_configuration,
 )
@@ -25,7 +28,6 @@ class LocationCheckDescriptors:
 
 def raise_if_location_inside_liquid(
     location: Location,
-    well_location: Location,
     well_core: WellCore,
     location_check_descriptors: LocationCheckDescriptors,
     logger: Logger,
@@ -39,7 +41,11 @@ def raise_if_location_inside_liquid(
     """
     try:
         liquid_height_from_bottom = well_core.current_liquid_height()
-    except LiquidHeightUnknownError:
+    except (IncompleteLabwareDefinitionError, LiquidHeightUnknownError):
+        # IncompleteLabwareDefinitionError is raised when there's no inner geometry
+        # defined for the well. So, we can't find the liquid height even if liquid volume is known.
+        # LiquidHeightUnknownError is raised when we don't have liquid volume info
+        # and no probing has been done either.
         liquid_height_from_bottom = None
     if isinstance(liquid_height_from_bottom, (int, float)):
         if liquid_height_from_bottom + well_core.get_bottom(0).z > location.point.z:
@@ -55,8 +61,9 @@ def raise_if_location_inside_liquid(
         # so we will not raise but just log the details.
         logger.info(
             f"Could not verify height of liquid in well {well_core.get_display_name()}, either"
-            f" because the liquid in this well has not been probed or because"
-            f" liquid was not loaded in this well using `load_liquid`."
+            f" because the liquid in this well has not been probed or"
+            f" liquid was not loaded in this well using `load_liquid` or"
+            f" inner geometry is not available for the target well."
             f" Proceeding without verifying if {location_check_descriptors.location_type}"
             f" location is outside the liquid."
         )

--- a/api/tests/opentrons/protocol_api/core/engine/test_transfer_components_executor.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_transfer_components_executor.py
@@ -126,7 +126,6 @@ def test_submerge(
     decoy.verify(
         tx_utils.raise_if_location_inside_liquid(
             location=Location(Point(x=2, y=4, z=7), labware=None),
-            well_location=Location(Point(x=1, y=2, z=3), labware=None),
             well_core=source_well,
             location_check_descriptors=LocationCheckDescriptors(
                 location_type="submerge start",
@@ -197,7 +196,6 @@ def test_submerge_without_starting_air_gap(
     decoy.verify(
         tx_utils.raise_if_location_inside_liquid(
             location=Location(Point(x=2, y=4, z=7), labware=None),
-            well_location=Location(Point(x=1, y=2, z=3), labware=None),
             well_core=source_well,
             location_check_descriptors=LocationCheckDescriptors(
                 location_type="submerge start",
@@ -308,7 +306,6 @@ def test_submerge_raises_when_submerge_point_is_invalid(
     decoy.when(
         tx_utils.raise_if_location_inside_liquid(
             location=Location(Point(x=2, y=4, z=7), labware=None),
-            well_location=Location(Point(x=1, y=2, z=3), labware=None),
             well_core=source_well,
             location_check_descriptors=LocationCheckDescriptors(
                 location_type="submerge start",
@@ -755,7 +752,6 @@ def test_retract_after_aspiration(
     decoy.verify(
         tx_utils.raise_if_location_inside_liquid(
             location=Location(Point(x=4, y=4, z=4), labware=None),
-            well_location=Location(Point(x=1, y=1, z=1), labware=None),
             well_core=source_well,
             location_check_descriptors=LocationCheckDescriptors(
                 location_type="retract end",
@@ -837,7 +833,6 @@ def test_retract_after_aspiration_when_retract_loc_below_safe_airgap_point(
     decoy.verify(
         tx_utils.raise_if_location_inside_liquid(
             location=Location(Point(x=4, y=4, z=4), labware=None),
-            well_location=Location(Point(x=1, y=1, z=1), labware=None),
             well_core=source_well,
             location_check_descriptors=LocationCheckDescriptors(
                 location_type="retract end",
@@ -906,7 +901,6 @@ def test_post_aspirate_retract_raises_when_retract_point_is_invalid(
     decoy.when(
         tx_utils.raise_if_location_inside_liquid(
             location=Location(Point(x=4, y=4, z=4), labware=None),
-            well_location=Location(Point(x=1, y=1, z=1), labware=None),
             well_core=source_well,
             location_check_descriptors=LocationCheckDescriptors(
                 location_type="retract end",
@@ -1830,7 +1824,6 @@ def test_retract_after_dispense_raises_for_invalid_retract_point(
     decoy.when(
         tx_utils.raise_if_location_inside_liquid(
             location=Location(Point(12, 24, 36), labware=None),
-            well_location=Location(Point(1, 1, 1), labware=None),
             well_core=dest_well,
             location_check_descriptors=LocationCheckDescriptors(
                 location_type="retract end",
@@ -2040,7 +2033,6 @@ def test_multi_dispense_retract_after_dispense_without_conditioning_volume_or_bl
     decoy.verify(
         tx_utils.raise_if_location_inside_liquid(
             location=Location(Point(3, 5, 4), labware=None),
-            well_location=Location(Point(1, 1, 1), labware=None),
             well_core=dest_well,
             location_check_descriptors=LocationCheckDescriptors(
                 location_type="retract end",
@@ -2159,7 +2151,6 @@ def test_multi_dispense_retract_after_dispense_with_blowout_without_conditioning
     decoy.verify(
         tx_utils.raise_if_location_inside_liquid(
             location=Location(Point(3, 5, 4), labware=None),
-            well_location=Location(Point(1, 1, 1), labware=None),
             well_core=dest_well,
             location_check_descriptors=LocationCheckDescriptors(
                 location_type="retract end",
@@ -2248,7 +2239,6 @@ def test_multi_dispense_retract_raises_for_invalid_retract_point(
     decoy.when(
         tx_utils.raise_if_location_inside_liquid(
             location=Location(Point(3, 5, 4), labware=None),
-            well_location=Location(Point(1, 1, 1), labware=None),
             well_core=dest_well,
             location_check_descriptors=LocationCheckDescriptors(
                 location_type="retract end",

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -2495,6 +2495,7 @@ def test_transfer_liquid_delegates_to_engine_core(
             trash_location=trash_location,
             return_tip=True,
             keep_last_tip=False,
+            last_tip_location=None,
         )
     )
 
@@ -2553,6 +2554,7 @@ def test_transfer_liquid_multi_channel_delegates_to_engine_core(
             trash_location=trash_location,
             return_tip=True,
             keep_last_tip=False,
+            last_tip_location=None,
         )
     )
 
@@ -2604,6 +2606,7 @@ def test_transfer_liquid_delegates_to_engine_core_with_trash_destination(
             trash_location=trash_location,
             return_tip=True,
             keep_last_tip=False,
+            last_tip_location=None,
         )
     )
 
@@ -2829,6 +2832,7 @@ def test_distribute_liquid_delegates_to_engine_core(
             trash_location=trash_location,
             return_tip=True,
             keep_last_tip=False,
+            last_tip_location=None,
         )
     )
 
@@ -2895,6 +2899,7 @@ def test_distribute_liquid_multi_channel_delegates_to_engine_core(
             trash_location=trash_location,
             return_tip=True,
             keep_last_tip=False,
+            last_tip_location=None,
         )
     )
 
@@ -3114,6 +3119,7 @@ def test_consolidate_liquid_delegates_to_engine_core(
             trash_location=trash_location,
             return_tip=True,
             keep_last_tip=False,
+            last_tip_location=None,
         )
     )
 
@@ -3181,6 +3187,7 @@ def test_consolidate_liquid_multi_channel_delegates_to_engine_core(
             trash_location=trash_location,
             return_tip=True,
             keep_last_tip=False,
+            last_tip_location=None,
         )
     )
 
@@ -3233,5 +3240,6 @@ def test_consolidate_liquid_delegates_to_engine_core_with_trash_destination(
             trash_location=trash_location,
             return_tip=True,
             keep_last_tip=False,
+            last_tip_location=None,
         )
     )

--- a/api/tests/opentrons/protocol_api_integration/test_liquid_classes.py
+++ b/api/tests/opentrons/protocol_api_integration/test_liquid_classes.py
@@ -23,7 +23,7 @@ def test_liquid_class_creation_and_property_fetching(
     water = simulated_protocol_context.get_liquid_class("water")
 
     assert water.name == "water"
-    assert water.display_name == "Aqueous"
+    assert water.display_name == "Aqueous (Deionized water)"
 
     # TODO (spp, 2024-10-17): update this to fetch pipette load name from instrument context
     assert (

--- a/api/tests/opentrons/protocol_api_integration/test_transfer_with_liquid_classes.py
+++ b/api/tests/opentrons/protocol_api_integration/test_transfer_with_liquid_classes.py
@@ -2365,3 +2365,400 @@ def test_raises_no_tips_available_error(
             new_tip="once",
             trash_location=trash,
         )
+
+
+@pytest.mark.ot3_only
+@pytest.mark.parametrize(
+    "simulated_protocol_context", [("2.24", "Flex")], indirect=True
+)
+def test_transfer_with_keep_last_tip(
+    simulated_protocol_context: ProtocolContext,
+) -> None:
+    """It should keep the last tip instead of dropping the last one."""
+    trash = simulated_protocol_context.load_trash_bin("A3")
+    tiprack = simulated_protocol_context.load_labware(
+        "opentrons_flex_96_tiprack_1000ul", "D1"
+    )
+    pipette_1k = simulated_protocol_context.load_instrument(
+        "flex_1channel_1000", mount="left", tip_racks=[tiprack]
+    )
+    nest_plate = simulated_protocol_context.load_labware(
+        "nest_96_wellplate_200ul_flat", "C3"
+    )
+    arma_plate = simulated_protocol_context.load_labware(
+        "armadillo_96_wellplate_200ul_pcr_full_skirt", "C2"
+    )
+    water = simulated_protocol_context.get_liquid_class("water")
+
+    with (
+        mock.patch.object(
+            InstrumentCore,
+            "pick_up_tip",
+            side_effect=InstrumentCore.pick_up_tip,
+            autospec=True,
+        ) as patched_pick_up_tip,
+        mock.patch.object(
+            InstrumentCore,
+            "drop_tip_in_disposal_location",
+            side_effect=InstrumentCore.drop_tip_in_disposal_location,
+            autospec=True,
+        ) as patched_drop_tip,
+    ):
+        mock_manager = mock.Mock()
+        mock_manager.attach_mock(patched_pick_up_tip, "pick_up_tip")
+        mock_manager.attach_mock(patched_drop_tip, "drop_tip_in_disposal_location")
+        pipette_1k.transfer_with_liquid_class(
+            liquid_class=water,
+            volume=400,
+            source=nest_plate.wells()[:2],
+            dest=arma_plate.wells()[:2],
+            new_tip="always",
+            trash_location=trash,
+            keep_last_tip=True,
+        )
+        expected_calls = [
+            mock.call.pick_up_tip(
+                mock.ANY,
+                location=mock.ANY,
+                well_core=mock.ANY,
+                presses=mock.ANY,
+                increment=mock.ANY,
+            ),
+            mock.call.drop_tip_in_disposal_location(
+                mock.ANY,
+                disposal_location=trash,
+                home_after=False,
+                alternate_tip_drop=True,
+            ),
+            mock.call.pick_up_tip(
+                mock.ANY,
+                location=mock.ANY,
+                well_core=mock.ANY,
+                presses=mock.ANY,
+                increment=mock.ANY,
+            ),
+        ]
+        assert pipette_1k.has_tip
+        assert pipette_1k._last_tip_picked_up_from is not None
+        assert mock_manager.mock_calls == expected_calls
+
+
+@pytest.mark.ot3_only
+@pytest.mark.parametrize(
+    "simulated_protocol_context", [("2.24", "Flex")], indirect=True
+)
+def test_transfer_with_keep_last_tip_false(
+    simulated_protocol_context: ProtocolContext,
+) -> None:
+    """It should not keep the last tip for a tip policy of never."""
+    trash = simulated_protocol_context.load_trash_bin("A3")
+    tiprack = simulated_protocol_context.load_labware(
+        "opentrons_flex_96_tiprack_1000ul", "D1"
+    )
+    pipette_1k = simulated_protocol_context.load_instrument(
+        "flex_1channel_1000", mount="left", tip_racks=[tiprack]
+    )
+    nest_plate = simulated_protocol_context.load_labware(
+        "nest_96_wellplate_200ul_flat", "C3"
+    )
+    arma_plate = simulated_protocol_context.load_labware(
+        "armadillo_96_wellplate_200ul_pcr_full_skirt", "C2"
+    )
+    water = simulated_protocol_context.get_liquid_class("water")
+
+    with (
+        mock.patch.object(
+            InstrumentCore,
+            "pick_up_tip",
+            side_effect=InstrumentCore.pick_up_tip,
+            autospec=True,
+        ) as patched_pick_up_tip,
+        mock.patch.object(
+            InstrumentCore,
+            "drop_tip_in_disposal_location",
+            side_effect=InstrumentCore.drop_tip_in_disposal_location,
+            autospec=True,
+        ) as patched_drop_tip,
+    ):
+        pipette_1k.pick_up_tip()
+        mock_manager = mock.Mock()
+        mock_manager.attach_mock(patched_pick_up_tip, "pick_up_tip")
+        mock_manager.attach_mock(patched_drop_tip, "drop_tip_in_disposal_location")
+        pipette_1k.transfer_with_liquid_class(
+            liquid_class=water,
+            volume=400,
+            source=nest_plate.wells()[:2],
+            dest=arma_plate.wells()[:2],
+            new_tip="never",
+            trash_location=trash,
+            keep_last_tip=False,
+        )
+        expected_calls = [
+            mock.call.drop_tip_in_disposal_location(
+                mock.ANY,
+                disposal_location=trash,
+                home_after=False,
+                alternate_tip_drop=True,
+            )
+        ]
+        assert not pipette_1k.has_tip
+        assert pipette_1k._last_tip_picked_up_from is None
+        assert mock_manager.mock_calls == expected_calls
+
+
+@pytest.mark.ot3_only
+@pytest.mark.parametrize(
+    "simulated_protocol_context", [("2.24", "Flex")], indirect=True
+)
+def test_transfer_with_keep_last_tip_chained(
+    simulated_protocol_context: ProtocolContext,
+) -> None:
+    """It should be able to use the last kept tip when calling with never after another transfer."""
+    trash = simulated_protocol_context.load_trash_bin("A3")
+    tiprack = simulated_protocol_context.load_labware(
+        "opentrons_flex_96_tiprack_1000ul", "D1"
+    )
+    pipette_1k = simulated_protocol_context.load_instrument(
+        "flex_1channel_1000", mount="left", tip_racks=[tiprack]
+    )
+    nest_plate = simulated_protocol_context.load_labware(
+        "nest_96_wellplate_200ul_flat", "C3"
+    )
+    arma_plate = simulated_protocol_context.load_labware(
+        "armadillo_96_wellplate_200ul_pcr_full_skirt", "C2"
+    )
+    water = simulated_protocol_context.get_liquid_class("water")
+
+    with (
+        mock.patch.object(
+            InstrumentCore,
+            "pick_up_tip",
+            side_effect=InstrumentCore.pick_up_tip,
+            autospec=True,
+        ) as patched_pick_up_tip,
+        mock.patch.object(
+            InstrumentCore,
+            "drop_tip_in_disposal_location",
+            side_effect=InstrumentCore.drop_tip_in_disposal_location,
+            autospec=True,
+        ) as patched_drop_tip,
+    ):
+        mock_manager = mock.Mock()
+        mock_manager.attach_mock(patched_pick_up_tip, "pick_up_tip")
+        mock_manager.attach_mock(patched_drop_tip, "drop_tip_in_disposal_location")
+        pipette_1k.distribute_with_liquid_class(
+            liquid_class=water,
+            volume=400,
+            source=nest_plate.wells()[0],
+            dest=arma_plate.wells()[:2],
+            new_tip="always",
+            trash_location=trash,
+            keep_last_tip=True,
+        )
+        assert pipette_1k.has_tip
+        assert pipette_1k._last_tip_picked_up_from is not None
+        pipette_1k.consolidate_with_liquid_class(
+            liquid_class=water,
+            volume=400,
+            source=nest_plate.wells()[:2],
+            dest=arma_plate.wells()[0],
+            new_tip="never",
+            trash_location=trash,
+        )
+        expected_calls = [
+            mock.call.pick_up_tip(
+                mock.ANY,
+                location=mock.ANY,
+                well_core=mock.ANY,
+                presses=mock.ANY,
+                increment=mock.ANY,
+            )
+        ]
+        assert pipette_1k.has_tip
+        assert pipette_1k._last_tip_picked_up_from is not None
+        assert mock_manager.mock_calls == expected_calls
+
+
+@pytest.mark.ot3_only
+@pytest.mark.parametrize(
+    "simulated_protocol_context", [("2.24", "Flex")], indirect=True
+)
+def test_return_tip_after_transfer_with_never(
+    simulated_protocol_context: ProtocolContext,
+) -> None:
+    """It should be able to return the current tip when calling a transfer with return tip."""
+    trash = simulated_protocol_context.load_trash_bin("A3")
+    tiprack = simulated_protocol_context.load_labware(
+        "opentrons_flex_96_tiprack_1000ul", "D1"
+    )
+    pipette_1k = simulated_protocol_context.load_instrument(
+        "flex_1channel_1000", mount="left", tip_racks=[tiprack]
+    )
+    nest_plate = simulated_protocol_context.load_labware(
+        "nest_96_wellplate_200ul_flat", "C3"
+    )
+    arma_plate = simulated_protocol_context.load_labware(
+        "armadillo_96_wellplate_200ul_pcr_full_skirt", "C2"
+    )
+    water = simulated_protocol_context.get_liquid_class("water")
+
+    with (
+        mock.patch.object(
+            InstrumentCore,
+            "pick_up_tip",
+            side_effect=InstrumentCore.pick_up_tip,
+            autospec=True,
+        ) as patched_pick_up_tip,
+        mock.patch.object(
+            InstrumentCore,
+            "drop_tip",
+            side_effect=InstrumentCore.drop_tip,
+            autospec=True,
+        ) as patched_drop_tip,
+    ):
+        pipette_1k.pick_up_tip()
+        mock_manager = mock.Mock()
+        mock_manager.attach_mock(patched_pick_up_tip, "pick_up_tip")
+        mock_manager.attach_mock(patched_drop_tip, "drop_tip")
+        pipette_1k.transfer_with_liquid_class(
+            liquid_class=water,
+            volume=400,
+            source=nest_plate.wells()[:2],
+            dest=arma_plate.wells()[:2],
+            new_tip="never",
+            trash_location=trash,
+            keep_last_tip=False,
+            return_tip=True,
+        )
+        expected_calls = [
+            mock.call.drop_tip(
+                mock.ANY,
+                location=None,
+                well_core=mock.ANY,
+                home_after=False,
+                alternate_drop_location=False,
+            ),
+        ]
+        assert not pipette_1k.has_tip
+        assert pipette_1k._last_tip_picked_up_from is None
+        assert mock_manager.mock_calls == expected_calls
+
+
+@pytest.mark.ot3_only
+@pytest.mark.parametrize(
+    "simulated_protocol_context", [("2.24", "Flex")], indirect=True
+)
+def test_return_tip_after_chained_transfers(
+    simulated_protocol_context: ProtocolContext,
+) -> None:
+    """It should be able to return the current tip when calling a transfer with return tip."""
+    trash = simulated_protocol_context.load_trash_bin("A3")
+    tiprack = simulated_protocol_context.load_labware(
+        "opentrons_flex_96_tiprack_1000ul", "D1"
+    )
+    pipette_1k = simulated_protocol_context.load_instrument(
+        "flex_1channel_1000", mount="left", tip_racks=[tiprack]
+    )
+    nest_plate = simulated_protocol_context.load_labware(
+        "nest_96_wellplate_200ul_flat", "C3"
+    )
+    arma_plate = simulated_protocol_context.load_labware(
+        "armadillo_96_wellplate_200ul_pcr_full_skirt", "C2"
+    )
+    water = simulated_protocol_context.get_liquid_class("water")
+
+    with (
+        mock.patch.object(
+            InstrumentCore,
+            "pick_up_tip",
+            side_effect=InstrumentCore.pick_up_tip,
+            autospec=True,
+        ) as patched_pick_up_tip,
+        mock.patch.object(
+            InstrumentCore,
+            "drop_tip",
+            side_effect=InstrumentCore.drop_tip,
+            autospec=True,
+        ) as patched_drop_tip,
+    ):
+        mock_manager = mock.Mock()
+        mock_manager.attach_mock(patched_pick_up_tip, "pick_up_tip")
+        mock_manager.attach_mock(patched_drop_tip, "drop_tip")
+        pipette_1k.transfer_with_liquid_class(
+            liquid_class=water,
+            volume=400,
+            source=nest_plate.wells()[:2],
+            dest=arma_plate.wells()[:2],
+            new_tip="once",
+            trash_location=trash,
+            keep_last_tip=True,
+        )
+        assert pipette_1k.has_tip
+        assert pipette_1k._last_tip_picked_up_from is not None
+        pipette_1k.distribute_with_liquid_class(
+            liquid_class=water,
+            volume=400,
+            source=nest_plate.wells()[0],
+            dest=arma_plate.wells()[:2],
+            new_tip="never",
+            trash_location=trash,
+            keep_last_tip=False,
+            return_tip=True,
+        )
+        expected_calls = [
+            mock.call.pick_up_tip(
+                mock.ANY,
+                location=mock.ANY,
+                well_core=mock.ANY,
+                presses=mock.ANY,
+                increment=mock.ANY,
+            ),
+            mock.call.drop_tip(
+                mock.ANY,
+                location=None,
+                well_core=mock.ANY,
+                home_after=False,
+                alternate_drop_location=False,
+            ),
+        ]
+        assert not pipette_1k.has_tip
+        assert pipette_1k._last_tip_picked_up_from is None
+        assert mock_manager.mock_calls == expected_calls
+
+
+@pytest.mark.ot3_only
+@pytest.mark.parametrize(
+    "simulated_protocol_context", [("2.24", "Flex")], indirect=True
+)
+def test_return_tip_fails_after_new_tip_never_keep_last_tip_false(
+    simulated_protocol_context: ProtocolContext,
+) -> None:
+    """It should fail in returning a tip with new tip of never and keep last tip False."""
+    trash = simulated_protocol_context.load_trash_bin("A3")
+    tiprack = simulated_protocol_context.load_labware(
+        "opentrons_flex_96_tiprack_1000ul", "D1"
+    )
+    pipette_1k = simulated_protocol_context.load_instrument(
+        "flex_1channel_1000", mount="left", tip_racks=[tiprack]
+    )
+    nest_plate = simulated_protocol_context.load_labware(
+        "nest_96_wellplate_200ul_flat", "C3"
+    )
+    arma_plate = simulated_protocol_context.load_labware(
+        "armadillo_96_wellplate_200ul_pcr_full_skirt", "C2"
+    )
+    water = simulated_protocol_context.get_liquid_class("water")
+
+    pipette_1k.pick_up_tip()
+    pipette_1k.transfer_with_liquid_class(
+        liquid_class=water,
+        volume=400,
+        source=nest_plate.wells()[0],
+        dest=arma_plate.wells()[0],
+        new_tip="never",
+        trash_location=trash,
+        keep_last_tip=False,
+    )
+
+    with pytest.raises(TypeError, match="Last tip location"):
+        pipette_1k.return_tip()

--- a/api/tests/opentrons/protocols/advanced_control/transfers/test_transfer_liquid_utils.py
+++ b/api/tests/opentrons/protocols/advanced_control/transfers/test_transfer_liquid_utils.py
@@ -7,10 +7,14 @@ from contextlib import nullcontext as does_not_raise
 
 
 from opentrons.hardware_control.nozzle_manager import NozzleMap
+from opentrons.protocol_engine import ProtocolEngineError
 from opentrons.protocol_engine.types.liquid_level_detection import (
     LiquidTrackingType,
 )
-from opentrons.protocol_engine.errors import LiquidHeightUnknownError
+from opentrons.protocol_engine.errors import (
+    LiquidHeightUnknownError,
+    IncompleteLabwareDefinitionError,
+)
 from opentrons.types import Location, Point
 from opentrons.protocol_api.core.engine import WellCore
 from opentrons.protocol_api.labware import Well, Labware
@@ -190,7 +194,6 @@ def test_raise_only_if_pip_location_inside_liquid(
     expected_raise: ContextManager[Any],
 ) -> None:
     """It should raise an error if we have access to liquid height and pipette is in liquid."""
-    well_location = Location(point=Point(1, 1, 1), labware=None)
     well_core = decoy.mock(cls=WellCore)
     location_descriptors = LocationCheckDescriptors(
         location_type="retract end",
@@ -204,19 +207,21 @@ def test_raise_only_if_pip_location_inside_liquid(
     with expected_raise:
         raise_if_location_inside_liquid(
             location=pip_location,
-            well_location=well_location,
             well_core=well_core,
             location_check_descriptors=location_descriptors,
             logger=logger,
         )
 
 
+@pytest.mark.parametrize(
+    "error_raised", [LiquidHeightUnknownError(), IncompleteLabwareDefinitionError()]
+)
 def test_log_warning_if_pip_location_cannot_be_validated(
     decoy: Decoy,
+    error_raised: ProtocolEngineError,
 ) -> None:
     """It should log a warning if we don't have access to liquid height."""
     pip_location = Location(point=Point(1, 2, 3), labware=None)
-    well_location = Location(point=Point(1, 1, 1), labware=None)
     well_core = decoy.mock(cls=WellCore)
     location_descriptors = LocationCheckDescriptors(
         location_type="retract end",
@@ -224,12 +229,11 @@ def test_log_warning_if_pip_location_cannot_be_validated(
     )
     logger = decoy.mock(cls=Logger)
 
-    decoy.when(well_core.current_liquid_height()).then_raise(LiquidHeightUnknownError())
+    decoy.when(well_core.current_liquid_height()).then_raise(error_raised)
     decoy.when(well_core.get_bottom(0)).then_return(Point(0, 0, 0))
     decoy.when(well_core.get_display_name()).then_return("Well A1 of test_labware")
     raise_if_location_inside_liquid(
         location=pip_location,
-        well_location=well_location,
         well_core=well_core,
         location_check_descriptors=location_descriptors,
         logger=logger,
@@ -237,8 +241,9 @@ def test_log_warning_if_pip_location_cannot_be_validated(
     decoy.verify(
         logger.info(
             "Could not verify height of liquid in well Well A1 of test_labware, either"
-            " because the liquid in this well has not been probed or because"
-            " liquid was not loaded in this well using `load_liquid`."
+            " because the liquid in this well has not been probed or"
+            " liquid was not loaded in this well using `load_liquid` or"
+            " inner geometry is not available for the target well."
             " Proceeding without verifying if retract end location is outside the liquid."
         )
     )

--- a/components/src/organisms/CommandText/__tests__/CommandText.test.tsx
+++ b/components/src/organisms/CommandText/__tests__/CommandText.test.tsx
@@ -708,7 +708,7 @@ describe('CommandText', () => {
       />,
       { i18nInstance: i18n }
     )
-    screen.getByText('Loading Volatile Liquid Class')
+    screen.getByText('Loading Volatile (80% ethanol) Liquid Class')
   })
   it('renders correct text for temperatureModule/setTargetTemperature', () => {
     const mockTemp = 20

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/__tests__/LiquidClassesStepTools.test.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/__tests__/LiquidClassesStepTools.test.tsx
@@ -1,10 +1,9 @@
-import { describe, it, vi, beforeEach, expect } from 'vitest'
 import { fireEvent, screen } from '@testing-library/react'
-import { i18n } from '../../../../../../../assets/localization'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { renderWithProviders } from '../../../../../../../__testing-utils__'
+import { i18n } from '../../../../../../../assets/localization'
 import { getLiquidEntities } from '../../../../../../../step-forms/selectors'
 import { LiquidClassesStepTools } from '../LiquidClassesStepTools'
-
 import type { ComponentProps } from 'react'
 
 vi.mock('../../../../../../../step-forms/selectors')
@@ -39,15 +38,17 @@ describe('LiquidClassesStepMoveLiquidTools', () => {
     render(props)
     screen.getByText('Apply liquid class settings for this transfer')
     screen.getByText("Don't use a liquid class")
-    screen.getByText('Aqueous')
+    screen.getByText('Aqueous (Deionized water)')
     screen.getByText('Deionized water')
-    screen.getByText('Viscous')
+    screen.getByText('Viscous (50% glycerol)')
     screen.getByText('50% glycerol')
-    screen.getByText('Volatile')
+    screen.getByText('Volatile (80% ethanol)')
     screen.getByText('80% ethanol')
 
     fireEvent.click(
-      screen.getByRole('label', { name: 'Aqueous Deionized water' })
+      screen.getByRole('label', {
+        name: 'Aqueous (Deionized water) Deionized water',
+      })
     )
     expect(props.propsForFields.liquidClass.updateValue).toHaveBeenCalled()
   })

--- a/shared-data/liquid-class/definitions/1/ethanol_80/1.json
+++ b/shared-data/liquid-class/definitions/1/ethanol_80/1.json
@@ -1,6 +1,6 @@
 {
   "liquidClassName": "ethanol_80",
-  "displayName": "Volatile",
+  "displayName": "Volatile (80% ethanol)",
   "description": "80% ethanol",
   "schemaVersion": 1,
   "version": 1,

--- a/shared-data/liquid-class/definitions/1/glycerol_50/1.json
+++ b/shared-data/liquid-class/definitions/1/glycerol_50/1.json
@@ -1,6 +1,6 @@
 {
   "liquidClassName": "glycerol_50",
-  "displayName": "Viscous",
+  "displayName": "Viscous (50% glycerol)",
   "description": "50% glycerol",
   "schemaVersion": 1,
   "version": 1,

--- a/shared-data/liquid-class/definitions/1/water/1.json
+++ b/shared-data/liquid-class/definitions/1/water/1.json
@@ -1,6 +1,6 @@
 {
   "liquidClassName": "water",
-  "displayName": "Aqueous",
+  "displayName": "Aqueous (Deionized water)",
   "description": "Deionized water",
   "schemaVersion": 1,
   "version": 1,


### PR DESCRIPTION
I have to do this merge manually because of a conflict in `protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/__tests__/LiquidClassesStepTools.test.tsx`.