### PR TITLE
chore(ci): include matrix.with-ot-hardware in test name to tell tests apart

### DIFF
--- a/.github/workflows/api-test-lint-deploy.yaml
+++ b/.github/workflows/api-test-lint-deploy.yaml
@@ -67,7 +67,7 @@ jobs:
       - name: Lint with opentrons_hardware
         run: make -C api lint
   test:
-    name: 'opentrons package tests on ${{ matrix.os }}, python ${{ matrix.python }}'
+    name: 'opentrons package tests on ${{ matrix.os }}, python ${{ matrix.python }}, ot-hardware ${{ matrix.with-ot-hardware }}'
     timeout-minutes: 30
     needs: [lint]
     strategy:


### PR DESCRIPTION
# Overview

Some time ago, we added `with-ot-hardware: ['true', 'false']` to the test matrix for the `opentrons package tests`, but we didn't update the test name with the new variable. This makes it look like the same test is running twice in CI, which is confusing:
<img width="447" src="https://github.com/user-attachments/assets/d4dc5d97-3950-416e-8e7f-fcfe0aadfb55" />

This change just adds the `with-ot-hardware` to the test name.

## Test Plan and Hands on Testing

Run the CI tests and see.

## Risk assessment

Low, cosmetic change for Github display.