### PR TITLE
fix(step-generation): emit configureNozzleLayout when tiprack changes

### DIFF
--- a/step-generation/src/__tests__/replaceTip.test.ts
+++ b/step-generation/src/__tests__/replaceTip.test.ts
@@ -334,7 +334,9 @@ describe('replaceTip', () => {
       }
       initialRobotState = {
         ...initialRobotState,
-        pipettes: { p100096Id: { mount: 'left', nozzles: COLUMN } },
+        pipettes: {
+          p100096Id: { mount: 'left', nozzles: COLUMN, tiprackId: tiprack5Id },
+        },
         tipState: {
           tipracks: {
             [tiprack4Id]: getTiprackTipstate(false),

--- a/step-generation/src/commandCreators/compound/replaceTip.ts
+++ b/step-generation/src/commandCreators/compound/replaceTip.ts
@@ -56,6 +56,7 @@ export const replaceTip: CommandCreator<ReplaceTipArgs> = (
     isFromMixCommand = false,
   } = args
   const stateNozzles = prevRobotState.pipettes[pipette].nozzles
+  const stateTiprack = prevRobotState.pipettes[pipette].tiprackId
   if (tipRack == null) {
     return {
       errors: [errorCreators.noTipSelected()],
@@ -189,7 +190,7 @@ export const replaceTip: CommandCreator<ReplaceTipArgs> = (
     //  only emit the command if previous nozzle state is different
     (channels === 96 || channels === 8) &&
     args.nozzles != null &&
-    args.nozzles !== stateNozzles
+    (args.nozzles !== stateNozzles || nextTiprack.tiprackId !== stateTiprack)
       ? [
           curryCommandCreator(configureNozzleLayout, {
             configurationParams: {

--- a/step-generation/src/fixtures/robotStateFixtures.ts
+++ b/step-generation/src/fixtures/robotStateFixtures.ts
@@ -236,9 +236,11 @@ export const makeStateArgsStandard = (): StandardMakeStateArgs => ({
   pipetteLocations: {
     [DEFAULT_PIPETTE]: {
       mount: 'left',
+      tiprackId: 'tiprack1Id',
     },
     [MULTI_PIPETTE]: {
       mount: 'right',
+      tiprackId: 'tiprack1Id',
     },
   },
   labwareLocations: {

--- a/step-generation/src/getNextRobotStateAndWarnings/forPickUpTip.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/forPickUpTip.ts
@@ -45,4 +45,6 @@ export function forPickUpTip(
       tipState.tipracks[labwareId][wellName] = false
     })
   }
+  // update tiprackID assosciated with pipette for configureNozzleLayout
+  robotStateAndWarnings.robotState.pipettes[pipetteId].tiprackId = labwareId
 }

--- a/step-generation/src/types.ts
+++ b/step-generation/src/types.ts
@@ -39,7 +39,10 @@ export interface PipetteTemporalProperties {
   entityId?: string
   //  primary nozzle's wellName if over a labware
   wellName?: string
+  //  pipette's nozzle configuration
   nozzles?: NozzleConfigurationStyle
+  //  current tiprack assosciated with pipette
+  tiprackId?: string
 }
 
 export interface MagneticModuleState {


### PR DESCRIPTION
closes RQA-4307

# Overview

the `configure_nozzle_layout()` command was previously only emitted when the nozzle configuration changes but Alex found a bug where since it lists the tiprack for the api command, we need to emit it when the tiprack also changes. So i extended robot state to include the `tiprackId` when you pick up tip and that way, we emit `configure_nozzle_layout` based on both the previous nozzle configuration and the previous tiprack id.

## Test Plan and Hands on Testing

Upload protocol attached in the ticket to PD and export.see that there are now 3 configure nozzle layout commands emitted for every time you change the tiprack. it should pass analysis in the app

## Changelog

- add `tiprackId` to robot state
- wire in tiprack id as a dependency for when configure nozzle layout is emitted

## Risk assessment

low
