### PR TITLE
fix(protocol-designer): use liquid class defaults when resetting tip position

### DIFF
--- a/protocol-designer/cypress/support/MixSteps.ts
+++ b/protocol-designer/cypress/support/MixSteps.ts
@@ -341,7 +341,7 @@ export const MixSteps = {
         .should('exist')
         .should('be.visible')
         .should('have.prop', 'value')
-      cy.get(MixLocators.BlowoutPos).click()
+      cy.get(MixLocators.BlowoutPos).click({ force: true })
       cy.get(MixLocators.BlowoutZPosition).type('{selectAll}{backspace}4')
       cy.get(MixLocators.ResetToDefault).click()
       cy.get(MixLocators.BlowoutZPosition).type('{selectAll}{backspace}-3')

--- a/protocol-designer/src/components/organisms/TipPositionModal/__tests__/TipPositionModal.test.tsx
+++ b/protocol-designer/src/components/organisms/TipPositionModal/__tests__/TipPositionModal.test.tsx
@@ -1,14 +1,24 @@
 import { fireEvent, screen } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { FLEX_ROBOT_TYPE } from '@opentrons/shared-data'
+
 import { TipPositionModal } from '..'
 import { renderWithProviders } from '../../../../__testing-utils__'
 import { i18n } from '../../../../assets/localization'
+import { getRobotType } from '../../../../file-data/selectors'
+import {
+  getAdditionalEquipmentEntities,
+  getLabwareEntities,
+  getPipetteEntities,
+} from '../../../../step-forms/selectors'
 import { TipPositionSideView } from '../TipPositionSideView'
 
 import type { ComponentProps } from 'react'
 
 vi.mock('../TipPositionSideView')
+vi.mock('../../../../file-data/selectors')
+vi.mock('../../../../step-forms/selectors')
 const render = (props: ComponentProps<typeof TipPositionModal>) => {
   return renderWithProviders(<TipPositionModal {...props} />, {
     i18nInstance: i18n,
@@ -23,7 +33,15 @@ describe('TipPositionModal', () => {
   let props: ComponentProps<typeof TipPositionModal>
 
   beforeEach(() => {
+    vi.mocked(getPipetteEntities).mockReturnValue({})
+    vi.mocked(getLabwareEntities).mockReturnValue({})
+    vi.mocked(getAdditionalEquipmentEntities).mockReturnValue({})
+    vi.mocked(getRobotType).mockReturnValue(FLEX_ROBOT_TYPE)
     props = {
+      formData: {
+        stepType: 'moveLiquid',
+        id: 'mockFormId',
+      },
       prefix: 'aspirate',
       closeModal: vi.fn(),
       wellDepthMm: 50,
@@ -84,7 +102,7 @@ describe('TipPositionModal', () => {
     screen.getByText('Y position')
     screen.getByText('Must be between -5.2 and 5.2')
     screen.getByText('Z position')
-    screen.getByText('Must be between 0 and 50')
+    screen.getByText('Must be between 0 and 52')
     screen.getByText('mock TipPositionSideView')
   })
   it('renders a custom input field and clicks on it, calling the mock updates', () => {

--- a/protocol-designer/src/components/organisms/TipPositionModal/hooks.tsx
+++ b/protocol-designer/src/components/organisms/TipPositionModal/hooks.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useSelector } from 'react-redux'
 import { round } from 'lodash'
 
 import { DropdownMenu } from '@opentrons/components'
@@ -9,9 +10,19 @@ import {
   POSITION_REFERENCE_TOP,
 } from '@opentrons/shared-data'
 
+import { getRobotType } from '../../../file-data/selectors'
+import {
+  getAdditionalEquipmentEntities,
+  getLabwareEntities,
+  getPipetteEntities,
+} from '../../../step-forms/selectors'
+import { getLiquidClassesValues } from '../../../steplist/formLevel/handleFormChange/utils'
+
 import type { Dispatch, SetStateAction } from 'react'
 import type { DropdownOption } from '@opentrons/components'
-import type { PositionReference } from '@opentrons/shared-data'
+import type { PositionReference, WellLocation } from '@opentrons/shared-data'
+import type { FormData } from '../../../form-types'
+import type { MoveLiquidPrefixType } from '../../../resources/types'
 
 interface UsePositionReferenceResult {
   positionReferenceDropdown: JSX.Element
@@ -110,5 +121,35 @@ export function usePositionReference(args: {
     ),
     reference,
     setReference,
+  }
+}
+
+export function useDefaultPosition(
+  formData: FormData | null,
+  prefix: MoveLiquidPrefixType
+): WellLocation {
+  const pipetteEntities = useSelector(getPipetteEntities)
+  const labwareEntities = useSelector(getLabwareEntities)
+  const additionalEquipmentEntities = useSelector(
+    getAdditionalEquipmentEntities
+  )
+  const robotType = useSelector(getRobotType)
+  if (formData == null) {
+    return {}
+  }
+  const liquidClassDefaultValues = getLiquidClassesValues({
+    rawForm: formData,
+    pipetteEntities,
+    labwareEntities,
+    additionalEquipmentEntities,
+    robotType,
+  })
+  return {
+    origin: liquidClassDefaultValues[`${prefix}_position_reference`],
+    offset: {
+      x: liquidClassDefaultValues[`${prefix}_x_position`],
+      y: liquidClassDefaultValues[`${prefix}_y_position`],
+      z: liquidClassDefaultValues[`${prefix}_mmFromBottom`],
+    },
   }
 }

--- a/protocol-designer/src/components/organisms/TipPositionModal/hooks/index.ts
+++ b/protocol-designer/src/components/organisms/TipPositionModal/hooks/index.ts
@@ -1,0 +1,2 @@
+export * from './useDefaultPosition'
+export * from './usePositionReference'

--- a/protocol-designer/src/components/organisms/TipPositionModal/hooks/useDefaultPosition.tsx
+++ b/protocol-designer/src/components/organisms/TipPositionModal/hooks/useDefaultPosition.tsx
@@ -1,0 +1,43 @@
+import { useSelector } from 'react-redux'
+
+import { getRobotType } from '../../../../file-data/selectors'
+import {
+  getAdditionalEquipmentEntities,
+  getLabwareEntities,
+  getPipetteEntities,
+} from '../../../../step-forms/selectors'
+import { getLiquidClassesValues } from '../../../../steplist/formLevel/handleFormChange/utils'
+
+import type { WellLocation } from '@opentrons/shared-data'
+import type { FormData } from '../../../../form-types'
+import type { MoveLiquidPrefixType } from '../../../../resources/types'
+
+export function useDefaultPosition(
+  formData: FormData | null,
+  prefix: MoveLiquidPrefixType
+): WellLocation {
+  const pipetteEntities = useSelector(getPipetteEntities)
+  const labwareEntities = useSelector(getLabwareEntities)
+  const additionalEquipmentEntities = useSelector(
+    getAdditionalEquipmentEntities
+  )
+  const robotType = useSelector(getRobotType)
+  if (formData == null) {
+    return {}
+  }
+  const liquidClassDefaultValues = getLiquidClassesValues({
+    rawForm: formData,
+    pipetteEntities,
+    labwareEntities,
+    additionalEquipmentEntities,
+    robotType,
+  })
+  return {
+    origin: liquidClassDefaultValues[`${prefix}_position_reference`],
+    offset: {
+      x: liquidClassDefaultValues[`${prefix}_x_position`],
+      y: liquidClassDefaultValues[`${prefix}_y_position`],
+      z: liquidClassDefaultValues[`${prefix}_mmFromBottom`],
+    },
+  }
+}

--- a/protocol-designer/src/components/organisms/TipPositionModal/hooks/usePositionReference.tsx
+++ b/protocol-designer/src/components/organisms/TipPositionModal/hooks/usePositionReference.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useSelector } from 'react-redux'
 import { round } from 'lodash'
 
 import { DropdownMenu } from '@opentrons/components'
@@ -10,19 +9,9 @@ import {
   POSITION_REFERENCE_TOP,
 } from '@opentrons/shared-data'
 
-import { getRobotType } from '../../../file-data/selectors'
-import {
-  getAdditionalEquipmentEntities,
-  getLabwareEntities,
-  getPipetteEntities,
-} from '../../../step-forms/selectors'
-import { getLiquidClassesValues } from '../../../steplist/formLevel/handleFormChange/utils'
-
 import type { Dispatch, SetStateAction } from 'react'
 import type { DropdownOption } from '@opentrons/components'
-import type { PositionReference, WellLocation } from '@opentrons/shared-data'
-import type { FormData } from '../../../form-types'
-import type { MoveLiquidPrefixType } from '../../../resources/types'
+import type { PositionReference } from '@opentrons/shared-data'
 
 interface UsePositionReferenceResult {
   positionReferenceDropdown: JSX.Element
@@ -121,35 +110,5 @@ export function usePositionReference(args: {
     ),
     reference,
     setReference,
-  }
-}
-
-export function useDefaultPosition(
-  formData: FormData | null,
-  prefix: MoveLiquidPrefixType
-): WellLocation {
-  const pipetteEntities = useSelector(getPipetteEntities)
-  const labwareEntities = useSelector(getLabwareEntities)
-  const additionalEquipmentEntities = useSelector(
-    getAdditionalEquipmentEntities
-  )
-  const robotType = useSelector(getRobotType)
-  if (formData == null) {
-    return {}
-  }
-  const liquidClassDefaultValues = getLiquidClassesValues({
-    rawForm: formData,
-    pipetteEntities,
-    labwareEntities,
-    additionalEquipmentEntities,
-    robotType,
-  })
-  return {
-    origin: liquidClassDefaultValues[`${prefix}_position_reference`],
-    offset: {
-      x: liquidClassDefaultValues[`${prefix}_x_position`],
-      y: liquidClassDefaultValues[`${prefix}_y_position`],
-      z: liquidClassDefaultValues[`${prefix}_mmFromBottom`],
-    },
   }
 }

--- a/protocol-designer/src/components/organisms/TipPositionModal/index.tsx
+++ b/protocol-designer/src/components/organisms/TipPositionModal/index.tsx
@@ -23,6 +23,7 @@ import {
   POSITION_REFERENCE_BOTTOM,
   POSITION_REFERENCE_CENTER,
   POSITION_REFERENCE_TOP,
+  SAFE_MOVE_TO_WELL_OFFSET_FROM_TOP_MM,
 } from '@opentrons/shared-data'
 
 import { getIsTouchTipField } from '../../../form-types'
@@ -30,14 +31,14 @@ import { prefixMap } from '../../../resources/utils'
 import { LINK_BUTTON_STYLE } from '../../atoms'
 import { getMainPagePortalEl } from '../Portal'
 import { PERCENT_RANGE_TO_SHOW_WARNING, TOO_MANY_DECIMALS } from './constants'
-import { usePositionReference } from './hooks'
+import { useDefaultPosition, usePositionReference } from './hooks'
 import { TipPositionSideView } from './TipPositionSideView'
 import { TipPositionTopView } from './TipPositionTopView'
 import * as utils from './utils'
 
 import type { ChangeEvent, Dispatch, SetStateAction } from 'react'
 import type { PositionReference } from '@opentrons/shared-data'
-import type { StepFieldName } from '../../../form-types'
+import type { FormData, StepFieldName } from '../../../form-types'
 import type { FieldProps } from '../../../pages/Designer/ProtocolSteps/types'
 import type { MoveLiquidPrefixType } from '../../../resources/types'
 
@@ -58,12 +59,16 @@ interface TipPositionModalProps {
   prefix: MoveLiquidPrefixType
   isIndeterminate?: boolean
   reference?: FieldProps | null
+  liquidClass?: string | null
+  // optional to support batch edit
+  formData?: FormData | null
 }
 
 export function TipPositionModal(
   props: TipPositionModalProps
 ): JSX.Element | null {
   const {
+    formData = null,
     isIndeterminate,
     specs,
     wellDepthMm,
@@ -92,6 +97,7 @@ export function TipPositionModal(
   const defaultMmFromBottom = utils.getDefaultMmFromEdge({
     name: zSpec.name,
   })
+  const defaultPosition = useDefaultPosition(formData, prefix)
 
   const [zValue, setZValue] = useState<string | null>(
     zSpec?.value == null
@@ -134,13 +140,19 @@ export function TipPositionModal(
         minMmFromBottom: utils.roundValue(wellDepthMm / 2, 'up'),
       }
     }
-    let [min, max]: [number, number] = [0, wellDepthMm]
+    let [min, max]: [number, number] = [
+      0,
+      wellDepthMm + SAFE_MOVE_TO_WELL_OFFSET_FROM_TOP_MM,
+    ]
     switch (reference) {
       case POSITION_REFERENCE_CENTER:
-        ;[min, max] = [-wellDepth / 2, wellDepth / 2]
+        ;[min, max] = [
+          -wellDepth / 2,
+          wellDepth / 2 + SAFE_MOVE_TO_WELL_OFFSET_FROM_TOP_MM,
+        ]
         break
       case POSITION_REFERENCE_TOP:
-        ;[min, max] = [-wellDepth, 0]
+        ;[min, max] = [-wellDepth, 0 + SAFE_MOVE_TO_WELL_OFFSET_FROM_TOP_MM]
         break
       default:
         break
@@ -230,6 +242,14 @@ export function TipPositionModal(
     setPristine(false)
   }
 
+  const handleResetToDefault = (): void => {
+    setXValue(String(defaultPosition?.offset?.x ?? 0))
+    setYValue(String(defaultPosition?.offset?.y ?? 0))
+    setZValue(String(defaultPosition?.offset?.z ?? 0))
+    const reference = defaultPosition.origin
+    setReference(reference as PositionReference)
+  }
+
   const isXValueNearEdge =
     xValue != null &&
     (parseInt(xValue) > PERCENT_RANGE_TO_SHOW_WARNING * xMaxWidth ||
@@ -259,15 +279,7 @@ export function TipPositionModal(
           padding={SPACING.spacing24}
           alignItems={ALIGN_CENTER}
         >
-          <Btn
-            onClick={() => {
-              setXValue('0')
-              setYValue('0')
-              setZValue('1')
-              setReference(POSITION_REFERENCE_BOTTOM)
-            }}
-            css={LINK_BUTTON_STYLE}
-          >
+          <Btn onClick={handleResetToDefault} css={LINK_BUTTON_STYLE}>
             {t('shared:reset_to_default')}
           </Btn>
           <Flex gridGap={SPACING.spacing8} justifyContent={JUSTIFY_END}>

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/PositionField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/PositionField.tsx
@@ -28,6 +28,7 @@ import { selectors as stepFormSelectors } from '../../../../../step-forms'
 
 import type { PositionSpecs } from '../../../../../components/organisms'
 import type {
+  FormData,
   ReferenceFields,
   TipXOffsetFields,
   TipYOffsetFields,
@@ -47,10 +48,12 @@ interface PositionFieldProps {
   showButton?: boolean
   isNested?: boolean
   referenceField?: ReferenceFields
+  formData?: FormData
 }
 
 export function PositionField(props: PositionFieldProps): JSX.Element {
   const {
+    formData,
     labwareId,
     propsForFields,
     zField,
@@ -168,6 +171,7 @@ export function PositionField(props: PositionFieldProps): JSX.Element {
 
     modal = (
       <TipPositionModal
+        formData={formData}
         closeModal={handleClose}
         wellDepthMm={wellDepthMm}
         wellXWidthMm={wellXWidthMm}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MixTools/SecondStepMixTools.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MixTools/SecondStepMixTools.tsx
@@ -158,6 +158,7 @@ export function SecondStepMixTools({
             />
             <Divider marginY="0" />
             <PositionField
+              formData={formData}
               prefix="mix"
               propsForFields={propsForFields}
               zField="mix_mmFromBottom"
@@ -270,6 +271,7 @@ export function SecondStepMixTools({
               >
                 {formData.mix_touchTip_checkbox === true ? (
                   <PositionField
+                    formData={formData}
                     prefix={tab}
                     propsForFields={propsForFields}
                     zField="mix_touchTip_mmFromTop"

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/MultiInputField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/MultiInputField.tsx
@@ -16,7 +16,7 @@ import {
 import { InputStepFormField } from '../../../../../../components/molecules'
 import { PositionField } from '../../PipetteFields'
 
-import type { ReferenceFields } from '../../../../../../form-types'
+import type { FormData, ReferenceFields } from '../../../../../../form-types'
 import type { MoveLiquidPrefixType } from '../../../../../../resources/types'
 import type { FieldPropsByName } from '../../types'
 
@@ -26,6 +26,7 @@ export interface StepInputFieldProps {
   units: string
 }
 interface MultiInputFieldProps {
+  formData: FormData
   name: string
   tooltipContent: string
   propsForFields: FieldPropsByName
@@ -38,6 +39,7 @@ interface MultiInputFieldProps {
 
 export function MultiInputField(props: MultiInputFieldProps): JSX.Element {
   const {
+    formData,
     name,
     tooltipContent,
     isWellPosition,
@@ -88,6 +90,7 @@ export function MultiInputField(props: MultiInputFieldProps): JSX.Element {
           ))}
           {(isWellPosition ?? false) && (
             <PositionField
+              formData={formData}
               padding="0"
               prefix={prefix}
               propsForFields={propsForFields}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/SecondStepsMoveLiquidTools.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/SecondStepsMoveLiquidTools.tsx
@@ -318,6 +318,7 @@ export const SecondStepsMoveLiquidTools = ({
           <>
             <Divider marginY="0" />
             <PositionField
+              formData={formData}
               prefix={tab}
               propsForFields={propsForFields}
               zField={`${tab}_mmFromBottom`}
@@ -338,6 +339,7 @@ export const SecondStepsMoveLiquidTools = ({
           <>
             <Divider marginY="0" />
             <MultiInputField
+              formData={formData}
               name={t('submerge')}
               prefix={`${tab}_submerge`}
               tooltipContent={t(`tooltip:step_fields.defaults.${tab}_submerge`)}
@@ -355,6 +357,7 @@ export const SecondStepsMoveLiquidTools = ({
             />
             <Divider marginY="0" />
             <MultiInputField
+              formData={formData}
               name={t('retract')}
               prefix={`${tab}_retract`}
               tooltipContent={t(`tooltip:step_fields.defaults.${tab}_retract`)}
@@ -532,6 +535,7 @@ export const SecondStepsMoveLiquidTools = ({
                   units={t('application:units.millimeter')}
                 />
                 <PositionField
+                  formData={formData}
                   prefix={tab}
                   propsForFields={propsForFields}
                   zField={`${tab}_touchTip_mmFromTop`}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/__tests__/MultiInputField.test.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/__tests__/MultiInputField.test.tsx
@@ -25,6 +25,10 @@ describe('MultiInputField', () => {
 
   beforeEach(() => {
     props = {
+      formData: {
+        stepType: 'moveLiquid',
+        id: 'mockFormId',
+      },
       name: 'Retract',
       tooltipContent: 'some tooltip content',
       prefix: 'aspirate_retract',


### PR DESCRIPTION
# Overview

This PR adds logic to pull the correct default tip position given the tip position type (aspirate, dispense, aspirate_retract, aspirate_submerge, dispense_retract, dispense_submerge). Previously, the reset behavior was hard coded to set the tip 1mm from bottom of the well. This is accurate for aspirate and dispense, but not for retract and submerge.

Closes RQA-4256

## Test Plan and Hands on Testing

- create or open a move liquid form
- click the aspirate tip position button to open the tip position modal
- change some values and click "reset to default". Observe that the default values are correct for that liquid class (likely 2mm above bottom)
- save and open the aspirate submerge position
- change some values and click "reset to default". Observe that the default values are correct for that liquid class (likely 2mm above top)
- repeat above with aspirate retract, dispense, dispense submerge, and dispense retract
- repeat with mix form tip position

## Changelog

- add hook to get the form's liquid class default aspirate/dispense position and submerge/retract position
- wire up in step form tool components
- update tests

## Review requests

see test plan

## Risk assessment

lowish