### PR TITLE
fix(protocol-designer): fix advanced settings tooltips

### DIFF
--- a/protocol-designer/src/components/molecules/CheckboxExpandStepFormField/index.tsx
+++ b/protocol-designer/src/components/molecules/CheckboxExpandStepFormField/index.tsx
@@ -35,7 +35,9 @@ export function CheckboxExpandStepFormField(
     disabled = false,
   } = fieldProps
 
-  const [targetProps, tooltipProps] = useHoverTooltip()
+  const [targetProps, tooltipProps] = useHoverTooltip({
+    placement: 'top-start',
+  })
   return (
     <>
       <ListButton
@@ -53,15 +55,14 @@ export function CheckboxExpandStepFormField(
           width="100%"
           flexDirection={DIRECTION_COLUMN}
           gridGap={SPACING.spacing8}
+          {...targetProps}
         >
           <Flex
             justifyContent={JUSTIFY_SPACE_BETWEEN}
             alignItems={ALIGN_CENTER}
           >
             <>
-              <StyledText desktopStyle="bodyDefaultRegular" {...targetProps}>
-                {title}
-              </StyledText>
+              <StyledText desktopStyle="bodyDefaultRegular">{title}</StyledText>
               <Btn
                 data-testid={testId}
                 onClick={() => {

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepFormToolbox.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepFormToolbox.tsx
@@ -140,6 +140,7 @@ export function StepFormToolbox(props: StepFormToolboxProps): JSX.Element {
     'application',
     'shared',
     'protocol_steps',
+    'tooltip',
   ])
   const dispatch = useDispatch()
   const { makeSnackbar } = useKitchen()

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/utils.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/utils.ts
@@ -193,17 +193,17 @@ export const getVisibleProfileFormLevelErrors = (args: {
   })
 }
 export const getFieldDefaultTooltip = (name: string, t: any): string =>
-  name != null ? t(`step_fields.defaults.${name}`) : ''
+  name != null ? t(`tooltip:step_fields.defaults.${name}`) : ''
 export const getFieldIndeterminateTooltip = (name: string, t: any): string =>
-  name != null ? t(`step_fields.indeterminate.${name}`) : ''
+  name != null ? t(`tooltip:step_fields.indeterminate.${name}`) : ''
 export const getSingleSelectDisabledTooltip = (
   name: string,
   stepType: string,
   t: any
 ): string =>
   name != null
-    ? t(`step_fields.${stepType}.disabled.${name}`)
-    : t(`step_fields.${stepType}.disabled.$generic`)
+    ? t(`tooltip:step_fields.${stepType}.disabled.${name}`)
+    : t(`tooltip:step_fields.${stepType}.disabled.$generic`)
 
 export const getFieldCaptions = (
   name: string,


### PR DESCRIPTION
# Overview

This PR fixes a bug where tooltip.json was not retrieved in the StepFormToolbox translation, used to get tooltip content in `propsForFields`. It also grabs the translation from that tooltip file in `makeSingleEditFieldProps` tooltip utilities.

Closes RQA-4254

## Test Plan and Hands on Testing

- open a transfer form and hover advanced settings
- verify that tooltips translations render correctly

## Changelog

- get `tooltip` in `StepFormToolbox` translation
- access `tooltip` translation in `makeSingleEditFieldProps` tooltip utils
- fix tooltip hover behavior in `CheckboxExpandStepFormField`

## Review requests

see test plan

## Risk assessment

low
