### PR TITLE
refactor(app): Prepare getRunLabwareRenderInfo() for labware schema 3

### DIFF
--- a/app/src/organisms/ErrorRecoveryFlows/shared/TwoColLwInfoAndDeck.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/TwoColLwInfoAndDeck.tsx
@@ -243,10 +243,16 @@ export function TwoColLwInfoAndDeck(
                 )}
                 {labwareRenderInfo
                   .filter(l => l.labwareId !== failedLwId)
-                  .map(({ x, y, labwareDef, labwareId }) => (
-                    <g key={labwareId} transform={`translate(${x},${y})`}>
+                  .map(({ labwareOrigin, labwareDef, labwareId }) => (
+                    <g
+                      key={labwareId}
+                      transform={`translate(${labwareOrigin.x},${labwareOrigin.y})`}
+                    >
                       {labwareDef != null && labwareId !== failedLwId ? (
-                        <LabwareRender definition={labwareDef} />
+                        <LabwareRender
+                          definition={labwareDef}
+                          positioningMode="passThrough"
+                        />
                       ) : null}
                     </g>
                   ))}

--- a/app/src/organisms/ErrorRecoveryFlows/shared/TwoColLwInfoAndDeck.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/TwoColLwInfoAndDeck.tsx
@@ -248,12 +248,10 @@ export function TwoColLwInfoAndDeck(
                       key={labwareId}
                       transform={`translate(${labwareOrigin.x},${labwareOrigin.y})`}
                     >
-                      {labwareDef != null && labwareId !== failedLwId ? (
-                        <LabwareRender
-                          definition={labwareDef}
-                          positioningMode="passThrough"
-                        />
-                      ) : null}
+                      <LabwareRender
+                        definition={labwareDef}
+                        positioningMode="passThrough"
+                      />
                     </g>
                   ))}
               </>

--- a/app/src/organisms/InterventionModal/MoveLabwareInterventionContent.tsx
+++ b/app/src/organisms/InterventionModal/MoveLabwareInterventionContent.tsx
@@ -227,11 +227,17 @@ export function MoveLabwareInterventionContent({
                   )}
                   {labwareRenderInfo
                     .filter(l => l.labwareId !== command.params.labwareId)
-                    .map(({ x, y, labwareDef, labwareId }) => (
-                      <g key={labwareId} transform={`translate(${x},${y})`}>
+                    .map(({ labwareOrigin, labwareDef, labwareId }) => (
+                      <g
+                        key={labwareId}
+                        transform={`translate(${labwareOrigin.x},${labwareOrigin.y})`}
+                      >
                         {labwareDef != null &&
                         labwareId !== command.params.labwareId ? (
-                          <LabwareRender definition={labwareDef} />
+                          <LabwareRender
+                            definition={labwareDef}
+                            positioningMode="passThrough"
+                          />
                         ) : null}
                       </g>
                     ))}

--- a/app/src/organisms/InterventionModal/MoveLabwareInterventionContent.tsx
+++ b/app/src/organisms/InterventionModal/MoveLabwareInterventionContent.tsx
@@ -232,13 +232,10 @@ export function MoveLabwareInterventionContent({
                         key={labwareId}
                         transform={`translate(${labwareOrigin.x},${labwareOrigin.y})`}
                       >
-                        {labwareDef != null &&
-                        labwareId !== command.params.labwareId ? (
-                          <LabwareRender
-                            definition={labwareDef}
-                            positioningMode="passThrough"
-                          />
-                        ) : null}
+                        <LabwareRender
+                          definition={labwareDef}
+                          positioningMode="passThrough"
+                        />
                       </g>
                     ))}
                 </>

--- a/app/src/organisms/InterventionModal/__tests__/utils.test.ts
+++ b/app/src/organisms/InterventionModal/__tests__/utils.test.ts
@@ -144,8 +144,7 @@ describe('getRunLabwareRenderInfo', () => {
     )
     const labwareInfo = res[0]
     expect(labwareInfo).toBeTruthy()
-    expect(labwareInfo.x).toEqual(0) // taken from deckDef fixture
-    expect(labwareInfo.y).toEqual(0)
+    expect(labwareInfo.labwareOrigin).toStrictEqual({ x: 0, y: 0, z: 0 }) // taken from deckDef fixture
     expect(labwareInfo.labwareDef.metadata.displayName).toEqual(
       'NEST 96 Well Plate 100 µL PCR Full Skirt'
     )
@@ -173,14 +172,16 @@ describe('getRunLabwareRenderInfo', () => {
       labware => labware.labwareId === 'mockLabwareID3'
     )
     expect(labwareInfo).toBeTruthy()
-    expect(labwareInfo?.x).toEqual(0)
-    expect(labwareInfo?.y).toEqual(
-      ot2DeckDefV5.cornerOffsetFromOrigin[1] -
-        getSchema2Dimensions(mockLabwareDefinition).yDimension
-    )
+    expect(labwareInfo?.labwareOrigin).toStrictEqual({
+      x: 0,
+      y:
+        ot2DeckDefV5.cornerOffsetFromOrigin[1] -
+        getSchema2Dimensions(mockLabwareDefinition).yDimension,
+      z: 0,
+    })
   })
 
-  it('defaults labware x, y coordinates to 0,0 if slot position not found in deck definition', () => {
+  it('omits labware if slot position not found in deck definition', () => {
     const mockBadSlotLabware = {
       id: 'mockBadLabwareID',
       loadName: 'nest_96_wellplate_100ul_pcr_full_skirt',
@@ -195,8 +196,7 @@ describe('getRunLabwareRenderInfo', () => {
       ot2DeckDefV5 as any
     )
 
-    expect(res[0].x).toEqual(0)
-    expect(res[0].y).toEqual(0)
+    expect(res).toHaveLength(0)
   })
 })
 

--- a/app/src/organisms/InterventionModal/utils/getRunLabwareRenderInfo.ts
+++ b/app/src/organisms/InterventionModal/utils/getRunLabwareRenderInfo.ts
@@ -1,7 +1,11 @@
 import {
+  coordinateTupleToVector3D,
+  getAddressableAreaFromSlotId,
+  getDeckSlotOriginToLabwareOrigin,
+  getLabwareBackLeftBottomToOrigin,
   getPositionFromSlotId,
-  getSchema2Dimensions,
   getSlotHasMatingSurfaceUnitVector,
+  getVectorSum,
 } from '@opentrons/shared-data'
 
 import type { RunData } from '@opentrons/api-client'
@@ -9,11 +13,16 @@ import type {
   DeckDefinition,
   LabwareDefinition,
   LabwareDefinitionsByUri,
+  Vector3D,
 } from '@opentrons/shared-data'
 
 export interface RunLabwareInfo {
-  x: number
-  y: number
+  /**
+   * The labware origin, in deck coordinates.
+   * Use this with `<LabwareRender positioningMode="passThrough">`.
+   */
+  labwareOrigin: Vector3D
+
   labwareDef: LabwareDefinition
   labwareId: string
 }
@@ -44,30 +53,72 @@ export function getRunLabwareRenderInfo(
           'addressableAreaName' in location
             ? location.addressableAreaName
             : location.slotName
-        const slotPosition = getPositionFromSlotId(slotName, deckDef)
+
+        const slotAddressableArea = getAddressableAreaFromSlotId(
+          slotName,
+          deckDef
+        )
+        if (slotAddressableArea == null) {
+          return acc
+        }
+
         const slotHasMatingSurfaceVector = getSlotHasMatingSurfaceUnitVector(
           deckDef,
           slotName
         )
+        if (!slotHasMatingSurfaceVector) {
+          // todo(mm, 2025-06-25): Are we using slotHasMatingSurfaceVector as an
+          // approximation for "is a deck slot"? Should we use
+          // `slotAddressableArea.areaType === "slot"`` instead?
+          return acc
+        }
 
-        return slotHasMatingSurfaceVector
-          ? [
-              ...acc,
-              {
-                x: slotPosition?.[0] ?? 0,
-                y: slotPosition?.[1] ?? 0,
-                labwareId: labware.id,
-                labwareDef,
-              },
-            ]
-          : acc
-      } else {
-        const { yDimension } = getSchema2Dimensions(labwareDef)
+        // 0,0,0 default inherited from prior code. I don't think we ever reach it in
+        // practice, just keeping it to be safe.
+        const slotOriginTuple = getPositionFromSlotId(slotName, deckDef) ?? [
+          0,
+          0,
+          0,
+        ]
+        const slotOrigin = coordinateTupleToVector3D(slotOriginTuple)
+
+        const slotOriginToLabwareOrigin = getDeckSlotOriginToLabwareOrigin(
+          slotAddressableArea,
+          labwareDef
+        )
+        const labwareOrigin = getVectorSum(
+          slotOrigin,
+          slotOriginToLabwareOrigin
+        )
+
         return [
           ...acc,
           {
-            x: 0,
-            y: deckDef.cornerOffsetFromOrigin[1] - yDimension,
+            labwareOrigin,
+            labwareId: labware.id,
+            labwareDef,
+          },
+        ]
+      } else {
+        // Place off-deck labware literally beyond the bounds of the deck.
+        // Calling code can change the position for animated fly-ins/fly-outs.
+        // It's unclear to me whether it matters exactly what position we choose here;
+        // this roughly maintains prior behavior.
+        const whereToPutLabwareBackLeftBottom: Vector3D = {
+          x: 0,
+          y: deckDef.cornerOffsetFromOrigin[1],
+          z: 0,
+        }
+
+        const labwareOrigin = getVectorSum(
+          whereToPutLabwareBackLeftBottom,
+          getLabwareBackLeftBottomToOrigin(labwareDef)
+        )
+
+        return [
+          ...acc,
+          {
+            labwareOrigin,
             labwareId: labware.id,
             labwareDef,
           },

--- a/shared-data/js/helpers/__tests__/labwareSchemaShims.test.ts
+++ b/shared-data/js/helpers/__tests__/labwareSchemaShims.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import {
   getDeckSlotOriginToLabwareOrigin,
+  getLabwareBackLeftBottomToOrigin,
   getLabwareViewBox,
   getSchema2Dimensions,
 } from '../..'
@@ -167,6 +168,50 @@ describe('getDeckSlotOriginToLabwareOrigin()', () => {
       x: 0,
       y: 100,
       z: 0,
+    }
+    expect(result).toStrictEqual(expectedResult)
+  })
+})
+
+describe('getLabwareBackLeftBottomToOrigin()', () => {
+  it('should handle schema 2 labware definitions', () => {
+    const labwareDef: Partial<LabwareDefinition2> = {
+      schemaVersion: 2,
+      cornerOffsetFromSlot: {
+        // Should not affect result.
+        x: 10,
+        y: 20,
+        z: 30,
+      },
+      dimensions: {
+        xDimension: 100,
+        yDimension: 200,
+        zDimension: 300,
+      },
+    }
+    const result = getLabwareBackLeftBottomToOrigin(
+      labwareDef as LabwareDefinition2
+    )
+    const expectedResult: typeof result = { x: 0, y: -200, z: 0 }
+    expect(result).toStrictEqual(expectedResult)
+  })
+  it('should handle schema 3 labware definitions', () => {
+    const labwareDef: Partial<LabwareDefinition3> = {
+      schemaVersion: 3,
+      extents: {
+        total: {
+          backLeftBottom: { x: -10, y: 10, z: 0 },
+          frontRightTop: { x: 210, y: -110, z: 1000 },
+        },
+      },
+    }
+    const result = getLabwareBackLeftBottomToOrigin(
+      labwareDef as LabwareDefinition3
+    )
+    const expectedResult: typeof result = {
+      x: 10,
+      y: -10,
+      z: -0,
     }
     expect(result).toStrictEqual(expectedResult)
   })

--- a/shared-data/js/helpers/labwareSchemaShims.ts
+++ b/shared-data/js/helpers/labwareSchemaShims.ts
@@ -113,6 +113,29 @@ export function getDeckSlotOriginToLabwareOrigin(
 }
 
 /**
+ * Return the offset from a labware's back-left-bottom (-x, +y, -z) corner to its origin.
+ *
+ * This is a lower-level helper for the rare cases where we want to position a labware
+ * specifically by its back-left corner. Typically, you'll want something higher-level,
+ * like `getLabwareViewBox()` or `getDeckSlotOriginToLabwareOrigin()`, instead.
+ */
+export function getLabwareBackLeftBottomToOrigin(
+  definition: LabwareDefinition
+): Vector3D {
+  if (definition.schemaVersion === 2) {
+    return {
+      x: 0,
+      y: -definition.dimensions.yDimension,
+      z: 0,
+    }
+  } else {
+    const originToBackLeftBottom = definition.extents.total.backLeftBottom
+    const backLeftBottomToOrigin = getVectorInverse(originToBackLeftBottom)
+    return backLeftBottomToOrigin
+  }
+}
+
+/**
  * Return a definition's cornerOffsetFromSlot in the style of labware schema 2.
  *
  * @deprecated This is probably an inherently wrong interface to attempt, for a couple


### PR DESCRIPTION
## Overview

Another small chunk towards EXEC-1278.

`getRunLabwareRenderInfo()` is a helper used by a couple of organisms in `app/`. Given some run data, it returns a structure of all labware that can be shown on a deck map, and the coordinates where those labware should be shown. This adjusts the coordinate math so it does the right thing when given a labware definition in schema 3.

See also #18735, which deletes an unused function that's largely duplicated with this one.

## Test Plan and Hands on Testing

* [x] Manually test in-context in the app. I *think* the easiest way to get there is just to run a protocol with a `moveLabware` command to get to the intervention modal. 
    * [x] Schema 2 labware should still work, unchanged.
    * [ ] Schema 3 labware should now be aligned to deck slots correctly. Schema 3 labware in modules will still be incorrect, though.
      * Turns out they're still incorrect because I haven't updated `MoveLabwareOnDeck` yet. That'll happen in a separate PR.

## Review requests

None in particular.

## Risk assessment

Low. The blast radius is pretty small here.