### PR TITLE
Labware sense enable argument for cycling test

### DIFF
--- a/hardware-testing/hardware_testing/modules/flex_stacker_cycle_qc/__main__.py
+++ b/hardware-testing/hardware_testing/modules/flex_stacker_cycle_qc/__main__.py
@@ -45,7 +45,9 @@ async def build_stacker_report(
     return report, stacker
 
 
-async def _main(cfg: TestConfig, cycles: int, labware_height: int) -> None:
+async def _main(
+    cfg: TestConfig, cycles: int, labware_height: int, labware_sense: bool
+) -> None:
     # BUILD REPORT
     ports = []
     for i in comports():
@@ -79,7 +81,14 @@ async def _main(cfg: TestConfig, cycles: int, labware_height: int) -> None:
             tasks = []
             for sn, (report, stacker) in stackers.items():
                 tasks.append(
-                    test_run(stacker, report, section.value, cycles, labware_height)
+                    test_run(
+                        stacker,
+                        report,
+                        section.value,
+                        cycles,
+                        labware_height,
+                        labware_sense,
+                    )
                 )
             await asyncio.gather(*tasks)  # Run all tasks concurrently
     except Exception as e:
@@ -107,6 +116,11 @@ if __name__ == "__main__":
         default=DEFAULT_LABWARE_HEIGHT,
         help="LabwareHeight - stackingOffsetWithLabware, in mm",
     )
+    parser.add_argument(
+        "--labware-sense",
+        action="store_true",
+        help="Enable labware sensing",
+    )
     # add each test-section as a skippable argument (eg: --skip-connectivity)
     for s in TestSection:
         parser.add_argument(f"--skip-{s.value.lower()}", action="store_true")
@@ -122,4 +136,4 @@ if __name__ == "__main__":
             s: f for s, f in TESTS if not getattr(args, f"skip_{s.value.lower()}")
         }
     _config = TestConfig(simulate=args.simulate, tests=_t_sections)
-    asyncio.run(_main(_config, args.cycles, args.labware_height))
+    asyncio.run(_main(_config, args.cycles, args.labware_height, args.labware_sense))

--- a/hardware-testing/hardware_testing/modules/flex_stacker_cycle_qc/test_cycles.py
+++ b/hardware-testing/hardware_testing/modules/flex_stacker_cycle_qc/test_cycles.py
@@ -26,7 +26,7 @@ def print_cycle(stacker: FlexStacker, cycle: int, total_cycles: int) -> None:
 
 
 async def test_cycles(
-    stacker: FlexStacker, cycles: int, labware_height: int
+    stacker: FlexStacker, cycles: int, labware_height: int, labware_sense: bool
 ) -> Tuple[bool, int]:
     """Test Cycling Labware on Stacker."""
     cycles_completed = 0
@@ -35,11 +35,11 @@ async def test_cycles(
         try:
             await stacker.dispense_labware(
                 labware_height,
-                enforce_hopper_lw_sensing=False,
-                enforce_shuttle_lw_sensing=False,
+                enforce_hopper_lw_sensing=labware_sense,
+                enforce_shuttle_lw_sensing=labware_sense,
             )
             await stacker.store_labware(
-                labware_height, enforce_shuttle_lw_sensing=False
+                labware_height, enforce_shuttle_lw_sensing=labware_sense
             )
         except Exception as e:
             ui.print_error(f"{stacker.device_info['serial']}: An error occurred: {e}")
@@ -59,11 +59,14 @@ async def run(
     section: str,
     cycles: int,
     labware_height: int,
+    labware_sense: bool,
 ) -> None:
     """Run."""
     ui.print_header(f"Cycle Test - {stacker.device_info['serial']}")
 
     await stacker.home_all()
-    cycle_result, cycles_completed = await test_cycles(stacker, cycles, labware_height)
+    cycle_result, cycles_completed = await test_cycles(
+        stacker, cycles, labware_height, labware_sense
+    )
 
     report(section, "cycle", [cycles_completed, CSVResult.from_bool(cycle_result)])


### PR DESCRIPTION
# Overview

adds an argument to enable labware sensing in the cycling test. default is off, labware is not sensed so test can run faster

## Test Plan and Hands on Testing

tested on 4 stackers works

## Changelog



## Review requests



## Risk assessment


