### PR TITLE
feat(api): remove auto probing from LC based transfers

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -1384,43 +1384,25 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                         air_gap=0,
                     )
                 ]
-                # Enable LPD only if all of these apply:
-                # - LPD is globally enabled for this pipette
-                # - it is the first time visiting this well
-                # - pipette tip is unused
-                enable_lpd = (
-                    self.get_liquid_presence_detection() and step_source != prev_src
-                )
-            elif new_tip == TransferTipPolicyV2.ONCE:
-                # Enable LPD only if:
-                # - LPD is globally enabled for this pipette
-                # - this is the first source well of the entire transfer, which means
-                #   that the current tip is unused
-                enable_lpd = self.get_liquid_presence_detection() and prev_src is None
-            else:
-                enable_lpd = False
 
-            with self.lpd_for_transfer(enable_lpd):
-                post_asp_tip_contents = self.aspirate_liquid_class(
-                    volume=step_volume,
-                    source=step_source,
-                    transfer_properties=transfer_props,
-                    transfer_type=tx_comps_executor.TransferType.ONE_TO_ONE,
-                    tip_contents=post_disp_tip_contents,
-                    volume_for_pipette_mode_configuration=step_volume,
-                )
-                post_disp_tip_contents = self.dispense_liquid_class(
-                    volume=step_volume,
-                    dest=step_destination,
-                    source=step_source,
-                    transfer_properties=transfer_props,
-                    transfer_type=tx_comps_executor.TransferType.ONE_TO_ONE,
-                    tip_contents=post_asp_tip_contents,
-                    add_final_air_gap=(
-                        False if is_last_step and keep_last_tip else True
-                    ),
-                    trash_location=trash_location,
-                )
+            post_asp_tip_contents = self.aspirate_liquid_class(
+                volume=step_volume,
+                source=step_source,
+                transfer_properties=transfer_props,
+                transfer_type=tx_comps_executor.TransferType.ONE_TO_ONE,
+                tip_contents=post_disp_tip_contents,
+                volume_for_pipette_mode_configuration=step_volume,
+            )
+            post_disp_tip_contents = self.dispense_liquid_class(
+                volume=step_volume,
+                dest=step_destination,
+                source=step_source,
+                transfer_properties=transfer_props,
+                transfer_type=tx_comps_executor.TransferType.ONE_TO_ONE,
+                tip_contents=post_asp_tip_contents,
+                add_final_air_gap=(False if is_last_step and keep_last_tip else True),
+                trash_location=trash_location,
+            )
             prev_src = step_source
             prev_dest = step_destination
 
@@ -1695,17 +1677,6 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                     " Specify a blowout location and enable blowout when using a disposal volume."
                 )
 
-            if (
-                self.get_liquid_presence_detection()
-                and new_tip != TransferTipPolicyV2.NEVER
-                and is_first_step
-            ):
-                # Do probing only once, regardless of whether you are coming back to refill
-                # with a fresh tip since there's only one source well
-                enable_lpd = True
-            else:
-                enable_lpd = False
-
             if not is_first_step and new_tip == TransferTipPolicyV2.ALWAYS:
                 _drop_tip()
                 last_tip = _pick_up_tip()
@@ -1715,20 +1686,19 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                         air_gap=0,
                     )
                 ]
-            with self.lpd_for_transfer(enable=enable_lpd):
-                # Aspirate the total volume determined by the loop above
-                tip_contents = self.aspirate_liquid_class(
-                    volume=total_aspirate_volume + conditioning_vol + disposal_vol,
-                    source=source,
-                    transfer_properties=transfer_props,
-                    transfer_type=tx_comps_executor.TransferType.ONE_TO_MANY,
-                    tip_contents=tip_contents,
-                    # We configure the mode based on the last dispense volume and disposal volume
-                    # since the mode is only used to determine the dispense push out volume
-                    # and we can do a push out only at the last dispense, that too if there is no disposal volume.
-                    volume_for_pipette_mode_configuration=vol_dest_combo[-1][0],
-                    conditioning_volume=conditioning_vol,
-                )
+            # Aspirate the total volume determined by the loop above
+            tip_contents = self.aspirate_liquid_class(
+                volume=total_aspirate_volume + conditioning_vol + disposal_vol,
+                source=source,
+                transfer_properties=transfer_props,
+                transfer_type=tx_comps_executor.TransferType.ONE_TO_MANY,
+                tip_contents=tip_contents,
+                # We configure the mode based on the last dispense volume and disposal volume
+                # since the mode is only used to determine the dispense push out volume
+                # and we can do a push out only at the last dispense, that too if there is no disposal volume.
+                volume_for_pipette_mode_configuration=vol_dest_combo[-1][0],
+                conditioning_volume=conditioning_vol,
+            )
 
             # If the tip has volumes correspoinding to multiple destinations, then
             # multi-dispense in those destinations.
@@ -1981,13 +1951,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                     is_last_step = True
                     break
 
-            if (
-                self.get_liquid_presence_detection()
-                and new_tip != TransferTipPolicyV2.NEVER
-                and is_first_step
-            ):
-                enable_lpd = True
-            elif not is_first_step and new_tip == TransferTipPolicyV2.ALWAYS:
+            if not is_first_step and new_tip == TransferTipPolicyV2.ALWAYS:
                 _drop_tip()
                 last_tip = _pick_up_tip()
                 tip_contents = [
@@ -1996,33 +1960,23 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                         air_gap=0,
                     )
                 ]
-                # Enable LPD if it's globally enabled, as long as
-                # the next source is different from previous source
-                enable_lpd = (
-                    self.get_liquid_presence_detection()
-                    and prev_src != vol_aspirate_combo[0][1]
-                )
-            else:
-                enable_lpd = False
 
             total_aspirated_volume = 0.0
             for step_num, (step_volume, step_source) in enumerate(vol_aspirate_combo):
-                with self.lpd_for_transfer(enable=enable_lpd):
-                    tip_contents = self.aspirate_liquid_class(
-                        volume=step_volume,
-                        source=step_source,
-                        transfer_properties=transfer_props,
-                        transfer_type=tx_comps_executor.TransferType.MANY_TO_ONE,
-                        tip_contents=tip_contents,
-                        volume_for_pipette_mode_configuration=(
-                            total_dispense_volume if step_num == 0 else None
-                        ),
-                        current_volume=total_aspirated_volume,
-                    )
+                tip_contents = self.aspirate_liquid_class(
+                    volume=step_volume,
+                    source=step_source,
+                    transfer_properties=transfer_props,
+                    transfer_type=tx_comps_executor.TransferType.MANY_TO_ONE,
+                    tip_contents=tip_contents,
+                    volume_for_pipette_mode_configuration=(
+                        total_dispense_volume if step_num == 0 else None
+                    ),
+                    current_volume=total_aspirated_volume,
+                )
                 prev_src = step_source
                 total_aspirated_volume += step_volume
                 is_first_step = False
-                enable_lpd = False
             tip_contents = self.dispense_liquid_class(
                 volume=total_dispense_volume,
                 dest=dest,
@@ -2119,10 +2073,6 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                 location=prep_location,
             )
             last_liquid_and_airgap_in_tip.air_gap = 0
-            if self.get_liquid_presence_detection():
-                self.liquid_probe_with_recovery(
-                    well_core=source_well, loc=prep_location
-                )
             # TODO: do volume configuration + prepare for aspirate only if the mode needs to be changed
             self.configure_for_volume(volume_for_pipette_mode_configuration)
             self.prepare_to_aspirate()
@@ -2540,14 +2490,6 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
     def delay(self, seconds: float) -> None:
         """Call a protocol delay."""
         self._protocol_core.delay(seconds=seconds, msg=None)
-
-    @contextmanager
-    def lpd_for_transfer(self, enable: bool) -> Generator[None, None, None]:
-        """Context manager for the instrument's LPD state during a transfer."""
-        global_lpd_enabled = self.get_liquid_presence_detection()
-        self.set_liquid_presence_detection(enable=enable)
-        yield
-        self.set_liquid_presence_detection(enable=global_lpd_enabled)
 
 
 class _TipInfo(NamedTuple):

--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -1,7 +1,6 @@
 """ProtocolEngine-based InstrumentContext core implementation."""
 
 from __future__ import annotations
-from contextlib import contextmanager
 from itertools import dropwhile
 from copy import deepcopy
 from typing import (
@@ -13,7 +12,6 @@ from typing import (
     Sequence,
     Tuple,
     NamedTuple,
-    Generator,
     Literal,
 )
 from opentrons.types import (
@@ -1933,7 +1931,6 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         next_step_volume, next_source = next(source_per_volume_step)
         is_first_step = True
         is_last_step = False
-        prev_src: Optional[tuple[Location, WellCore]] = None
         while not is_last_step:
             total_dispense_volume = 0.0
             vol_aspirate_combo = []
@@ -1974,7 +1971,6 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                     ),
                     current_volume=total_aspirated_volume,
                 )
-                prev_src = step_source
                 total_aspirated_volume += step_volume
                 is_first_step = False
             tip_contents = self.dispense_liquid_class(

--- a/api/tests/opentrons/protocol_api/core/engine/test_instrument_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_instrument_core.py
@@ -2177,7 +2177,7 @@ def test_aspirate_liquid_class_for_transfer_without_volume_config(
 
 
 @pytest.mark.parametrize("version", versions_at_or_above(APIVersion(2, 23)))
-def test_aspirate_liquid_class_using_volume_config_without_lpd(
+def test_aspirate_liquid_class_using_volume_config(
     decoy: Decoy,
     mock_engine_client: EngineClient,
     subject: InstrumentCore,
@@ -2186,7 +2186,7 @@ def test_aspirate_liquid_class_using_volume_config_without_lpd(
     mock_protocol_core: ProtocolCore,
     version: APIVersion,
 ) -> None:
-    """It should execute steps required for volume config only, without LPD steps."""
+    """It should execute steps required for volume config."""
     source_well = decoy.mock(cls=WellCore)
     source_location = Location(Point(1, 2, 3), labware=None)
     liquid_probe_start_point = Point(3, 2, 1)
@@ -2292,185 +2292,6 @@ def test_aspirate_liquid_class_using_volume_config_without_lpd(
         ),
     )
     assert result == [LiquidAndAirGapPair(air_gap=222, liquid=111)]
-
-
-@pytest.mark.parametrize("version", versions_at_or_above(APIVersion(2, 23)))
-def test_aspirate_liquid_class_using_volume_config_and_lpd(
-    decoy: Decoy,
-    mock_engine_client: EngineClient,
-    instrument_core_with_lpd: InstrumentCore,
-    minimal_liquid_class_def2: LiquidClassSchemaV1,
-    mock_transfer_components_executor: TransferComponentsExecutor,
-    mock_protocol_core: ProtocolCore,
-    version: APIVersion,
-) -> None:
-    """It should execute steps required for volume config and LPD."""
-    source_well = decoy.mock(cls=WellCore)
-    source_location = Location(Point(1, 2, 3), labware=None)
-    liquid_probe_start_point = Point(3, 2, 1)
-
-    test_liquid_class = LiquidClass.create(minimal_liquid_class_def2)
-    test_transfer_properties = test_liquid_class.get_for(
-        "flex_1channel_50", "opentrons_flex_96_tiprack_50ul"
-    )
-    decoy.when(source_well.labware_id).then_return("source-labware-id")
-    decoy.when(source_well.get_name()).then_return("source-well")
-    decoy.when(source_well.get_top(2)).then_return(liquid_probe_start_point)
-    decoy.when(
-        mock_engine_client.state.geometry.get_relative_well_location(
-            labware_id="source-labware-id",
-            well_name="source-well",
-            absolute_point=liquid_probe_start_point,
-            location_type=WellLocationFunction.LIQUID_HANDLING,
-        )
-    ).then_return((LiquidHandlingWellLocation(origin=WellOrigin.BOTTOM), True))
-    decoy.when(
-        transfer_components_executor.absolute_point_from_position_reference_and_offset(
-            well=source_well,
-            well_volume_difference=-123,
-            position_reference=PositionReference.WELL_BOTTOM,
-            offset=Coordinate(x=0, y=0, z=-5),
-            mount=Mount.LEFT,
-        )
-    ).then_return(Point(1, 2, 3))
-    decoy.when(
-        transfer_components_executor.TransferComponentsExecutor(
-            instrument_core=instrument_core_with_lpd,
-            transfer_properties=test_transfer_properties,
-            target_location=Location(Point(1, 2, 3), labware=None),
-            target_well=source_well,
-            tip_state=TipState(),
-            transfer_type=TransferType.ONE_TO_ONE,
-        )
-    ).then_return(mock_transfer_components_executor)
-    decoy.when(
-        mock_transfer_components_executor.tip_state.last_liquid_and_air_gap_in_tip
-    ).then_return(LiquidAndAirGapPair(liquid=111, air_gap=222))
-    decoy.when(mock_protocol_core.api_version).then_return(version)
-    result = instrument_core_with_lpd.aspirate_liquid_class(
-        volume=123,
-        source=(source_location, source_well),
-        transfer_properties=test_transfer_properties,
-        transfer_type=TransferType.ONE_TO_ONE,
-        tip_contents=[],
-        volume_for_pipette_mode_configuration=123,
-    )
-    decoy.verify(
-        mock_engine_client.execute_command(
-            cmd.MoveToWellParams(
-                pipetteId="abc123",
-                labwareId="source-labware-id",
-                wellName="source-well",
-                wellLocation=LiquidHandlingWellLocation(origin=WellOrigin.BOTTOM),
-                minimumZHeight=None,
-                forceDirect=False,
-                speed=None,
-            )
-        ),
-        mock_engine_client.execute_command(
-            cmd.LiquidProbeParams(
-                pipetteId="abc123",
-                labwareId="source-labware-id",
-                wellName="source-well",
-                wellLocation=WellLocation(
-                    origin=WellOrigin.TOP, offset=WellOffset(x=0, y=0, z=2)
-                ),
-            )
-        ),
-        mock_engine_client.execute_command(
-            cmd.ConfigureForVolumeParams(
-                pipetteId="abc123",
-                volume=123,
-                tipOverlapNotAfterVersion="v3",
-            )
-        ),
-        mock_engine_client.execute_command(
-            cmd.PrepareToAspirateParams(
-                pipetteId="abc123",
-            )
-        ),
-        mock_transfer_components_executor.submerge(
-            submerge_properties=test_transfer_properties.aspirate.submerge,
-            post_submerge_action="aspirate",
-        ),
-        mock_transfer_components_executor.mix(
-            mix_properties=test_transfer_properties.aspirate.mix,
-            last_dispense_push_out=False,
-        ),
-        mock_transfer_components_executor.pre_wet(volume=123),
-        mock_transfer_components_executor.aspirate_and_wait(volume=123),
-        mock_transfer_components_executor.retract_after_aspiration(
-            volume=123, add_air_gap=True
-        ),
-    )
-    assert result == [LiquidAndAirGapPair(air_gap=222, liquid=111)]
-
-
-@pytest.mark.parametrize("version", versions_at_or_above(APIVersion(2, 23)))
-def test_aspirate_liquid_class_does_not_do_lpd_for_consolidate(
-    decoy: Decoy,
-    mock_engine_client: EngineClient,
-    subject: InstrumentCore,
-    minimal_liquid_class_def2: LiquidClassSchemaV1,
-    mock_transfer_components_executor: TransferComponentsExecutor,
-    mock_protocol_core: ProtocolCore,
-    version: APIVersion,
-) -> None:
-    """It should execute steps required for LPD."""
-    source_well = decoy.mock(cls=WellCore)
-    source_location = Location(Point(1, 2, 3), labware=None)
-    liquid_probe_start_point = Point(3, 2, 1)
-
-    test_liquid_class = LiquidClass.create(minimal_liquid_class_def2)
-    test_transfer_properties = test_liquid_class.get_for(
-        "flex_1channel_50", "opentrons_flex_96_tiprack_50ul"
-    )
-    decoy.when(source_well.labware_id).then_return("source-labware-id")
-    decoy.when(source_well.get_name()).then_return("source-well")
-    decoy.when(source_well.get_top(2)).then_return(liquid_probe_start_point)
-    decoy.when(
-        mock_engine_client.state.geometry.get_relative_well_location(
-            labware_id="source-labware-id",
-            well_name="source-well",
-            absolute_point=liquid_probe_start_point,
-            location_type=WellLocationFunction.LIQUID_HANDLING,
-        )
-    ).then_return((LiquidHandlingWellLocation(origin=WellOrigin.BOTTOM), True))
-    decoy.when(
-        transfer_components_executor.absolute_point_from_position_reference_and_offset(
-            well=source_well,
-            well_volume_difference=-123,
-            position_reference=PositionReference.WELL_BOTTOM,
-            offset=Coordinate(x=0, y=0, z=-5),
-            mount=Mount.LEFT,
-        )
-    ).then_return(Point(1, 2, 3))
-    decoy.when(
-        transfer_components_executor.TransferComponentsExecutor(
-            instrument_core=subject,
-            transfer_properties=test_transfer_properties,
-            target_location=Location(Point(1, 2, 3), labware=None),
-            target_well=source_well,
-            tip_state=TipState(),
-            transfer_type=TransferType.ONE_TO_ONE,
-        )
-    ).then_return(mock_transfer_components_executor)
-    decoy.when(
-        mock_transfer_components_executor.tip_state.last_liquid_and_air_gap_in_tip
-    ).then_return(LiquidAndAirGapPair(liquid=111, air_gap=222))
-    decoy.when(mock_protocol_core.api_version).then_return(version)
-    subject.aspirate_liquid_class(
-        volume=123,
-        source=(source_location, source_well),
-        transfer_properties=test_transfer_properties,
-        transfer_type=TransferType.ONE_TO_ONE,
-        tip_contents=[],
-        volume_for_pipette_mode_configuration=123,
-    )
-    decoy.verify(
-        mock_engine_client.execute_command(params=matchers.IsA(cmd.LiquidProbeParams)),
-        times=0,
-    )
 
 
 def test_aspirate_liquid_class_for_consolidate(
@@ -3034,13 +2855,3 @@ def test_get_next_tip_raises_for_starting_tip_with_partial_config(
             tip_racks=tip_racks,
             starting_well=mock_starting_well,
         )
-
-
-def test_lpd_for_transfer_context_manager(
-    subject: InstrumentCore,
-) -> None:
-    """It should update LPD state according to context."""
-    assert subject.get_liquid_presence_detection() is False
-    with subject.lpd_for_transfer(enable=True):
-        assert subject.get_liquid_presence_detection() is True
-    assert subject.get_liquid_presence_detection() is False

--- a/api/tests/opentrons/protocol_api_integration/test_transfer_with_liquid_classes.py
+++ b/api/tests/opentrons/protocol_api_integration/test_transfer_with_liquid_classes.py
@@ -913,7 +913,7 @@ def test_order_of_water_consolidate_steps_larger_volume_than_tip(
 @pytest.mark.parametrize(
     "simulated_protocol_context", [("2.24", "Flex")], indirect=True
 )
-def test_order_of_water_consolidate_steps_larger_volume_than_tip_with_lpd_and_new_tip_always(
+def test_order_of_water_consolidate_steps_larger_volume_than_tip_with_new_tip_always(
     simulated_protocol_context: ProtocolContext,
 ) -> None:
     """It should pick up new tips & probe liquid before every group of aspirates."""
@@ -966,11 +966,6 @@ def test_order_of_water_consolidate_steps_larger_volume_than_tip_with_lpd_and_ne
             side_effect=InstrumentCore.drop_tip_in_disposal_location,
             autospec=True,
         ) as patched_drop_tip,
-        mock.patch.object(
-            InstrumentCore,
-            "liquid_probe_with_recovery",
-            autospec=True,
-        ) as patched_liquid_probe,
     ):
         mock_manager = mock.Mock()
         mock_manager.attach_mock(patched_pick_up_tip, "pick_up_tip")
@@ -978,7 +973,6 @@ def test_order_of_water_consolidate_steps_larger_volume_than_tip_with_lpd_and_ne
         mock_manager.attach_mock(patched_aspirate, "aspirate_liquid_class")
         mock_manager.attach_mock(patched_dispense, "dispense_liquid_class")
         mock_manager.attach_mock(patched_drop_tip, "drop_tip_in_disposal_location")
-        mock_manager.attach_mock(patched_liquid_probe, "liquid_probe_with_recovery")
         pipette_50.consolidate_with_liquid_class(
             liquid_class=water,
             volume=30,
@@ -1010,11 +1004,6 @@ def test_order_of_water_consolidate_steps_larger_volume_than_tip_with_lpd_and_ne
                 tip_contents=[LiquidAndAirGapPair(liquid=0, air_gap=0)],
                 volume_for_pipette_mode_configuration=30.0,
                 current_volume=0.0,
-            ),
-            mock.call.liquid_probe_with_recovery(  # Called as part of aspirate_liquid_class
-                mock.ANY,
-                well_core=mock.ANY,
-                loc=mock.ANY,
             ),
             mock.call.dispense_liquid_class(
                 mock.ANY,
@@ -1049,11 +1038,6 @@ def test_order_of_water_consolidate_steps_larger_volume_than_tip_with_lpd_and_ne
                 tip_contents=[LiquidAndAirGapPair(liquid=0, air_gap=0)],
                 volume_for_pipette_mode_configuration=30.0,
                 current_volume=0.0,
-            ),
-            mock.call.liquid_probe_with_recovery(  # Called as part of aspirate_liquid_class
-                mock.ANY,
-                well_core=mock.ANY,
-                loc=mock.ANY,
             ),
             mock.call.dispense_liquid_class(
                 mock.ANY,
@@ -2032,16 +2016,10 @@ def test_water_distribution_raises_error_for_disposal_vol_without_blowout(
 @pytest.mark.parametrize(
     "simulated_protocol_context", [("2.24", "Flex")], indirect=True
 )
-@pytest.mark.parametrize(
-    ["new_tip", "expected_number_of_calls"],
-    [("once", 1), ("always", 12), ("per source", 12)],
-)
-def test_water_transfer_with_lpd(
+def test_transfers_do_not_perform_lpd(
     simulated_protocol_context: ProtocolContext,
-    new_tip: TransferTipPolicyV2Type,
-    expected_number_of_calls: int,
 ) -> None:
-    """It should send a single liquid probing command for each source well."""
+    """It should not do any liquid probing for LC-based transfer/ consolidate/ distribute."""
     trash = simulated_protocol_context.load_trash_bin("A3")
     tiprack = simulated_protocol_context.load_labware(
         "opentrons_flex_96_tiprack_1000ul", "D1"
@@ -2074,182 +2052,26 @@ def test_water_transfer_with_lpd(
             volume=1100,
             source=nest_plate.rows()[0],
             dest=arma_plate.rows()[0],
-            new_tip=new_tip,
-            trash_location=trash,
-        )
-        assert patched_liquid_probe.call_count == expected_number_of_calls
-
-
-@pytest.mark.ot3_only
-@pytest.mark.parametrize(
-    "simulated_protocol_context", [("2.24", "Flex")], indirect=True
-)
-@pytest.mark.parametrize(
-    "new_tip",
-    ["once", "always", "per source"],
-)
-def test_water_transfer_does_lpd_only_once_for_a_source_well(
-    simulated_protocol_context: ProtocolContext,
-    new_tip: TransferTipPolicyV2Type,
-) -> None:
-    """It should send a single liquid probing command for the source well."""
-    trash = simulated_protocol_context.load_trash_bin("A3")
-    tiprack = simulated_protocol_context.load_labware(
-        "opentrons_flex_96_tiprack_1000ul", "D1"
-    )
-    pipette_1k = simulated_protocol_context.load_instrument(
-        "flex_1channel_1000",
-        mount="left",
-        tip_racks=[tiprack],
-        liquid_presence_detection=True,
-    )
-    nest_plate = simulated_protocol_context.load_labware(
-        "nest_96_wellplate_200ul_flat", "C3"
-    )
-    arma_plate = simulated_protocol_context.load_labware(
-        "armadillo_96_wellplate_200ul_pcr_full_skirt", "C2"
-    )
-    water = simulated_protocol_context.get_liquid_class("water")
-
-    with (
-        mock.patch.object(
-            InstrumentCore,
-            "liquid_probe_with_recovery",
-            autospec=True,
-        ) as patched_liquid_probe
-    ):
-        mock_manager = mock.Mock()
-        mock_manager.attach_mock(patched_liquid_probe, "liquid_probe_with_recovery")
-        pipette_1k.transfer_with_liquid_class(
-            liquid_class=water,
-            volume=1100,
-            source=[nest_plate.wells_by_name()["A1"] for _ in range(3)],
-            dest=arma_plate.rows()[0][:3],
-            new_tip=new_tip,
-            trash_location=trash,
-        )
-        assert patched_liquid_probe.call_count == 1
-
-
-@pytest.mark.ot3_only
-@pytest.mark.parametrize(
-    "simulated_protocol_context", [("2.24", "Flex")], indirect=True
-)
-@pytest.mark.parametrize("new_tip", ["once", "always"])
-def test_water_distribution_with_lpd(
-    simulated_protocol_context: ProtocolContext,
-    new_tip: TransferTipPolicyV2Type,
-) -> None:
-    """It should send a single liquid probing command for the source well."""
-    trash = simulated_protocol_context.load_trash_bin("A3")
-    tiprack = simulated_protocol_context.load_labware(
-        "opentrons_flex_96_tiprack_1000ul", "D1"
-    )
-    pipette_1k = simulated_protocol_context.load_instrument(
-        "flex_1channel_1000",
-        mount="left",
-        tip_racks=[tiprack],
-        liquid_presence_detection=True,
-    )
-    nest_plate = simulated_protocol_context.load_labware(
-        "nest_96_wellplate_200ul_flat", "C3"
-    )
-    arma_plate = simulated_protocol_context.load_labware(
-        "armadillo_96_wellplate_200ul_pcr_full_skirt", "C2"
-    )
-
-    water = simulated_protocol_context.get_liquid_class("water")
-    water_props = water.get_for(pipette_1k, tiprack)
-    assert water_props.multi_dispense is not None
-    water_props.multi_dispense.retract.blowout.location = "destination"  # type: ignore[assignment]
-    water_props.multi_dispense.retract.blowout.flow_rate = pipette_1k.flow_rate.blow_out
-    water_props.multi_dispense.retract.blowout.enabled = True
-
-    with (
-        mock.patch.object(
-            InstrumentCore,
-            "liquid_probe_with_recovery",
-            autospec=True,
-        ) as patched_liquid_probe
-    ):
-        mock_manager = mock.Mock()
-        mock_manager.attach_mock(patched_liquid_probe, "liquid_probe_with_recovery")
-        pipette_1k.distribute_with_liquid_class(
-            liquid_class=water,
-            volume=40,
-            source=nest_plate.rows()[0][1],
-            dest=arma_plate.rows()[0],
-            new_tip=new_tip,
-            trash_location=trash,
-        )
-        patched_liquid_probe.assert_called_once()
-
-
-@pytest.mark.ot3_only
-@pytest.mark.parametrize(
-    "simulated_protocol_context", [("2.24", "Flex")], indirect=True
-)
-def test_incompatible_transfers_skip_probing_even_with_lpd_on(
-    simulated_protocol_context: ProtocolContext,
-) -> None:
-    """It should not send a liquid probing command."""
-    trash = simulated_protocol_context.load_trash_bin("A3")
-    tiprack = simulated_protocol_context.load_labware(
-        "opentrons_flex_96_tiprack_1000ul", "D1"
-    )
-    pipette_1k = simulated_protocol_context.load_instrument(
-        "flex_1channel_1000",
-        mount="left",
-        tip_racks=[tiprack],
-        liquid_presence_detection=True,
-    )
-    nest_plate = simulated_protocol_context.load_labware(
-        "nest_96_wellplate_200ul_flat", "C3"
-    )
-    arma_plate = simulated_protocol_context.load_labware(
-        "armadillo_96_wellplate_200ul_pcr_full_skirt", "C2"
-    )
-
-    water = simulated_protocol_context.get_liquid_class("water")
-    water_props = water.get_for(pipette_1k, tiprack)
-    assert water_props.multi_dispense is not None
-    water_props.multi_dispense.retract.blowout.location = "destination"  # type: ignore[assignment]
-    water_props.multi_dispense.retract.blowout.flow_rate = pipette_1k.flow_rate.blow_out
-    water_props.multi_dispense.retract.blowout.enabled = True
-    pipette_1k.pick_up_tip()
-    with (
-        mock.patch.object(
-            InstrumentCore,
-            "liquid_probe_with_recovery",
-            autospec=True,
-        ) as patched_liquid_probe,
-    ):
-        mock_manager = mock.Mock()
-        mock_manager.attach_mock(patched_liquid_probe, "liquid_probe_with_recovery")
-        pipette_1k.transfer_with_liquid_class(
-            liquid_class=water,
-            volume=40,
-            source=nest_plate.rows()[0],
-            dest=arma_plate.rows()[0],
-            new_tip="never",
-            trash_location=trash,
-        )
-        pipette_1k.distribute_with_liquid_class(
-            liquid_class=water,
-            volume=40,
-            source=nest_plate.rows()[0][1],
-            dest=arma_plate.rows()[0][:3],
-            new_tip="never",
+            new_tip="always",
             trash_location=trash,
         )
         pipette_1k.consolidate_with_liquid_class(
             liquid_class=water,
-            volume=40,
+            volume=100,
             source=nest_plate.rows()[0],
             dest=arma_plate.rows()[0][0],
-            new_tip="never",
+            new_tip="always",
             trash_location=trash,
         )
+        pipette_1k.distribute_with_liquid_class(
+            liquid_class=water,
+            volume=100,
+            source=nest_plate.rows()[0][0],
+            dest=arma_plate.rows()[0],
+            new_tip="always",
+            trash_location=trash,
+        )
+        assert patched_liquid_probe.call_count == 0
 
 
 @pytest.mark.ot3_only


### PR DESCRIPTION
Closes AUTH-2018

# Overview

Removes auto-probing during LC-based transfer, consolidate & distribute to avoid having this non-tested and not-fully-defined feature in the release.

## Test Plan and Hands on Testing

Integration test updates should suffice.

## Review requests

- Usual stuff

## Risk assessment

None. Removes a pretty isolated feature.
