### PR TITLE
refactor(api): improve error messages for group_well argument in liquid class transfers

### DIFF
--- a/api/src/opentrons/protocol_api/_transfer_liquid_validation.py
+++ b/api/src/opentrons/protocol_api/_transfer_liquid_validation.py
@@ -47,10 +47,10 @@ def verify_and_normalize_transfer_args(
         flat_dests_list = []
     if group_wells_for_multi_channel and nozzle_map.tip_count > 1:
         flat_sources_list = tx_liquid_utils.group_wells_for_multi_channel_transfer(
-            flat_sources_list, nozzle_map
+            flat_sources_list, nozzle_map, "source"
         )
         flat_dests_list = tx_liquid_utils.group_wells_for_multi_channel_transfer(
-            flat_dests_list, nozzle_map
+            flat_dests_list, nozzle_map, "destination"
         )
     for well in flat_sources_list + flat_dests_list:
         instrument.validate_takes_liquid(

--- a/api/src/opentrons/protocols/advanced_control/transfers/transfer_liquid_utils.py
+++ b/api/src/opentrons/protocols/advanced_control/transfers/transfer_liquid_utils.py
@@ -72,6 +72,7 @@ def raise_if_location_inside_liquid(
 def group_wells_for_multi_channel_transfer(
     targets: Sequence[Well],
     nozzle_map: NozzleMapInterface,
+    target_name: Literal["source", "destination"],
 ) -> List[Well]:
     """Takes a list of wells and a nozzle map and returns a list of target wells to address every well given
 
@@ -94,7 +95,9 @@ def group_wells_for_multi_channel_transfer(
         or (configuration == NozzleConfigurationType.ROW and active_nozzles == 12)
         or active_nozzles == 96
     ):
-        return _group_wells_for_nozzle_configuration(list(targets), nozzle_map)
+        return _group_wells_for_nozzle_configuration(
+            list(targets), nozzle_map, target_name
+        )
     else:
         raise ValueError(
             "Unsupported nozzle configuration for well grouping. Set group_wells to False"
@@ -103,7 +106,9 @@ def group_wells_for_multi_channel_transfer(
 
 
 def _group_wells_for_nozzle_configuration(  # noqa: C901
-    targets: List[Well], nozzle_map: NozzleMapInterface
+    targets: List[Well],
+    nozzle_map: NozzleMapInterface,
+    target_name: Literal["source", "destination"],
 ) -> List[Well]:
     """Groups wells together for a column, row, or full 96 configuration and returns a reduced list of target wells."""
     grouped_wells = []
@@ -135,9 +140,9 @@ def _group_wells_for_nozzle_configuration(  # noqa: C901
         if active_wells_covered:
             if well.parent != active_labware:
                 raise ValueError(
-                    "Could not group wells to match pipette's nozzle configuration. Ensure that the wells are ordered"
-                    " correctly (e.g. rows() for a row layout or columns() for a column layout), or set group_wells to"
-                    " False to only target wells with the primary nozzle."
+                    f"Could not group wells for {target_name} to match pipette's nozzle configuration. Ensure that the"
+                    " wells are ordered correctly (e.g. rows() for a row layout or columns() for a column layout), or"
+                    " set group_wells to False to only target wells with the primary nozzle."
                 )
 
             if well.well_name in active_wells_covered:
@@ -169,9 +174,9 @@ def _group_wells_for_nozzle_configuration(  # noqa: C901
                 alternate_384_well_coverage_count += 1
             else:
                 raise ValueError(
-                    "Could not group wells to match pipette's nozzle configuration. Ensure that the wells are ordered"
-                    " correctly (e.g. rows() for a row layout or columns() for a column layout), or set group_wells to"
-                    " False to only target wells with the primary nozzle."
+                    f"Could not group wells for {target_name} to match pipette's nozzle configuration. Ensure that the"
+                    " wells are ordered correctly (e.g. rows() for a row layout or columns() for a column layout), or"
+                    " set group_wells to False to only target wells with the primary nozzle."
                 )
         # If we have no active wells covered to account for, add a new target well and list of covered wells to check
         else:
@@ -198,8 +203,8 @@ def _group_wells_for_nozzle_configuration(  # noqa: C901
 
     if active_wells_covered:
         raise ValueError(
-            "Pipette will access wells not provided in the liquid handling command. Set group_wells to False or include"
-            f" these wells: {active_wells_covered}"
+            f"Pipette will access wells for {target_name} not provided in the liquid handling command."
+            f" Set group_wells to False or include these wells: {active_wells_covered}"
         )
 
     # If we reversed the lookup of wells, reverse the grouped wells we will return

--- a/api/src/opentrons/protocols/advanced_control/transfers/transfer_liquid_utils.py
+++ b/api/src/opentrons/protocols/advanced_control/transfers/transfer_liquid_utils.py
@@ -96,7 +96,10 @@ def group_wells_for_multi_channel_transfer(
     ):
         return _group_wells_for_nozzle_configuration(list(targets), nozzle_map)
     else:
-        raise ValueError("Unsupported tip configuration for well grouping")
+        raise ValueError(
+            "Unsupported nozzle configuration for well grouping. Set group_wells to False"
+            " to only target wells with the primary nozzle for this configuration."
+        )
 
 
 def _group_wells_for_nozzle_configuration(  # noqa: C901
@@ -132,8 +135,9 @@ def _group_wells_for_nozzle_configuration(  # noqa: C901
         if active_wells_covered:
             if well.parent != active_labware:
                 raise ValueError(
-                    "Could not resolve wells provided to pipette's nozzle configuration. "
-                    "Please ensure wells are ordered to match pipette's nozzle layout."
+                    "Could not group wells to match pipette's nozzle configuration. Ensure that the wells are ordered"
+                    " correctly (e.g. rows() for a row layout or columns() for a column layout), or set group_wells to"
+                    " False to only target wells with the primary nozzle."
                 )
 
             if well.well_name in active_wells_covered:
@@ -165,8 +169,9 @@ def _group_wells_for_nozzle_configuration(  # noqa: C901
                 alternate_384_well_coverage_count += 1
             else:
                 raise ValueError(
-                    "Could not resolve wells provided to pipette's nozzle configuration. "
-                    "Please ensure wells are ordered to match pipette's nozzle layout."
+                    "Could not group wells to match pipette's nozzle configuration. Ensure that the wells are ordered"
+                    " correctly (e.g. rows() for a row layout or columns() for a column layout), or set group_wells to"
+                    " False to only target wells with the primary nozzle."
                 )
         # If we have no active wells covered to account for, add a new target well and list of covered wells to check
         else:
@@ -193,8 +198,8 @@ def _group_wells_for_nozzle_configuration(  # noqa: C901
 
     if active_wells_covered:
         raise ValueError(
-            "Could not target all wells provided without aspirating or dispensing from other wells. "
-            f"Other wells that would be targeted: {active_wells_covered}"
+            "Pipette will access wells not provided in the liquid handling command. Set group_wells to False or include"
+            f" these wells: {active_wells_covered}"
         )
 
     # If we reversed the lookup of wells, reverse the grouped wells we will return

--- a/api/src/opentrons/protocols/advanced_control/transfers/transfer_liquid_utils.py
+++ b/api/src/opentrons/protocols/advanced_control/transfers/transfer_liquid_utils.py
@@ -140,7 +140,7 @@ def _group_wells_for_nozzle_configuration(  # noqa: C901
         if active_wells_covered:
             if well.parent != active_labware:
                 raise ValueError(
-                    f"Could not group wells for {target_name} to match pipette's nozzle configuration. Ensure that the"
+                    f"Could not group {target_name} wells to match pipette's nozzle configuration. Ensure that the"
                     " wells are ordered correctly (e.g. rows() for a row layout or columns() for a column layout), or"
                     " set group_wells to False to only target wells with the primary nozzle."
                 )
@@ -174,7 +174,7 @@ def _group_wells_for_nozzle_configuration(  # noqa: C901
                 alternate_384_well_coverage_count += 1
             else:
                 raise ValueError(
-                    f"Could not group wells for {target_name} to match pipette's nozzle configuration. Ensure that the"
+                    f"Could not group {target_name} wells to match pipette's nozzle configuration. Ensure that the"
                     " wells are ordered correctly (e.g. rows() for a row layout or columns() for a column layout), or"
                     " set group_wells to False to only target wells with the primary nozzle."
                 )
@@ -203,7 +203,7 @@ def _group_wells_for_nozzle_configuration(  # noqa: C901
 
     if active_wells_covered:
         raise ValueError(
-            f"Pipette will access wells for {target_name} not provided in the liquid handling command."
+            f"Pipette will access {target_name} wells not provided in the liquid handling command."
             f" Set group_wells to False or include these wells: {active_wells_covered}"
         )
 

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -2525,7 +2525,12 @@ def test_transfer_liquid_multi_channel_delegates_to_engine_core(
     decoy.when(mock_instrument_core.get_nozzle_map()).then_return(mock_nozzle_map)
     decoy.when(
         mock_tx_liquid_utils.group_wells_for_multi_channel_transfer(
-            [mock_well, mock_well], mock_nozzle_map
+            [mock_well, mock_well], mock_nozzle_map, "source"
+        )
+    ).then_return([mock_well])
+    decoy.when(
+        mock_tx_liquid_utils.group_wells_for_multi_channel_transfer(
+            [mock_well, mock_well], mock_nozzle_map, "destination"
         )
     ).then_return([mock_well])
 
@@ -2862,12 +2867,12 @@ def test_distribute_liquid_multi_channel_delegates_to_engine_core(
     decoy.when(mock_instrument_core.get_nozzle_map()).then_return(mock_nozzle_map)
     decoy.when(
         mock_tx_liquid_utils.group_wells_for_multi_channel_transfer(
-            [mock_well, mock_well, mock_well], mock_nozzle_map
+            [mock_well, mock_well, mock_well], mock_nozzle_map, "source"
         )
     ).then_return([mock_well])
     decoy.when(
         mock_tx_liquid_utils.group_wells_for_multi_channel_transfer(
-            [mock_well, mock_well], mock_nozzle_map
+            [mock_well, mock_well], mock_nozzle_map, "destination"
         )
     ).then_return([mock_well, mock_well])
 
@@ -3149,14 +3154,14 @@ def test_consolidate_liquid_multi_channel_delegates_to_engine_core(
     decoy.when(mock_instrument_core.get_nozzle_map()).then_return(mock_nozzle_map)
     decoy.when(
         mock_tx_liquid_utils.group_wells_for_multi_channel_transfer(
-            [mock_well, mock_well, mock_well], mock_nozzle_map
-        )
-    ).then_return([mock_well])
-    decoy.when(
-        mock_tx_liquid_utils.group_wells_for_multi_channel_transfer(
-            [mock_well, mock_well], mock_nozzle_map
+            [mock_well, mock_well], mock_nozzle_map, "source"
         )
     ).then_return([mock_well, mock_well])
+    decoy.when(
+        mock_tx_liquid_utils.group_wells_for_multi_channel_transfer(
+            [mock_well, mock_well, mock_well], mock_nozzle_map, "destination"
+        )
+    ).then_return([mock_well])
 
     decoy.when(mock_instrument_core.get_active_channels()).then_return(2)
     decoy.when(mock_instrument_core.get_current_volume()).then_return(0)

--- a/api/tests/opentrons/protocols/advanced_control/transfers/test_transfer_liquid_utils.py
+++ b/api/tests/opentrons/protocols/advanced_control/transfers/test_transfer_liquid_utils.py
@@ -306,11 +306,11 @@ def test_grouping_wells_for_column_96_plate_raises(
         decoy.when(mock_well.parent).then_return(mock_96_well_labware)
 
     # leftover wells
-    with pytest.raises(ValueError, match="Pipette will access wells for source"):
+    with pytest.raises(ValueError, match="Pipette will access source wells"):
         group_wells_for_multi_channel_transfer(mock_wells, nozzle_map, "source")
 
     # non-contiguous wells from the same labware
-    with pytest.raises(ValueError, match="Could not group wells"):
+    with pytest.raises(ValueError, match="Could not group source wells"):
         group_wells_for_multi_channel_transfer(
             mock_wells[:7] + [mock_wells[-1], mock_wells[7]], nozzle_map, "source"
         )
@@ -322,7 +322,7 @@ def test_grouping_wells_for_column_96_plate_raises(
     decoy.when(other_well.parent).then_return(other_labware)
 
     # non-contiguous wells from different labware, well name is correct though
-    with pytest.raises(ValueError, match="Could not group wells"):
+    with pytest.raises(ValueError, match="Could not group source wells"):
         group_wells_for_multi_channel_transfer(
             mock_wells[:7] + [other_well], nozzle_map, "source"
         )
@@ -343,13 +343,13 @@ def test_grouping_wells_for_column_384_plate_raises(
         decoy.when(mock_well.parent).then_return(mock_384_well_labware)
 
     # leftover wells
-    with pytest.raises(ValueError, match="Pipette will access wells for destination"):
+    with pytest.raises(ValueError, match="Pipette will access destination wells"):
         group_wells_for_multi_channel_transfer(
             mock_wells[:-1], nozzle_map, "destination"
         )
 
     # non-contiguous or every other wells from the same labware
-    with pytest.raises(ValueError, match="Could not group wells"):
+    with pytest.raises(ValueError, match="Could not group"):
         group_wells_for_multi_channel_transfer(
             mock_wells[:2] + [mock_wells[-1]], nozzle_map, "source"
         )
@@ -364,7 +364,7 @@ def test_grouping_wells_for_column_384_plate_raises(
     decoy.when(other_well.parent).then_return(other_labware)
 
     # non-contiguous wells from different labware, well name is correct though
-    with pytest.raises(ValueError, match="Could not group wells"):
+    with pytest.raises(ValueError, match="Could not group source wells"):
         group_wells_for_multi_channel_transfer(
             mock_wells[:15] + [other_well], nozzle_map, "source"
         )
@@ -432,11 +432,11 @@ def test_grouping_wells_for_row_96_plate_raises(
         decoy.when(mock_well.parent).then_return(mock_96_well_labware)
 
     # leftover wells
-    with pytest.raises(ValueError, match="Pipette will access wells for source"):
+    with pytest.raises(ValueError, match="Pipette will access source wells"):
         group_wells_for_multi_channel_transfer(mock_wells[:-1], nozzle_map, "source")
 
     # non-contiguous wells from the same labware
-    with pytest.raises(ValueError, match="Could not group wells"):
+    with pytest.raises(ValueError, match="Could not group source wells"):
         group_wells_for_multi_channel_transfer(
             mock_wells[:11] + [mock_wells[-1], mock_wells[11]], nozzle_map, "source"
         )
@@ -448,7 +448,7 @@ def test_grouping_wells_for_row_96_plate_raises(
     decoy.when(other_well.parent).then_return(other_labware)
 
     # non-contiguous wells from different labware, well name is correct though
-    with pytest.raises(ValueError, match="Could not group wells"):
+    with pytest.raises(ValueError, match="Could not group destination wells"):
         group_wells_for_multi_channel_transfer(
             mock_wells[:11] + [other_well], nozzle_map, "destination"
         )
@@ -470,13 +470,13 @@ def test_grouping_wells_for_row_384_plate_raises(
         decoy.when(mock_well.parent).then_return(mock_384_well_labware)
 
     # leftover wells
-    with pytest.raises(ValueError, match="Pipette will access wells for destination"):
+    with pytest.raises(ValueError, match="Pipette will access destination wells"):
         group_wells_for_multi_channel_transfer(
             mock_wells[:-1], nozzle_map, "destination"
         )
 
     # non-contiguous or every other wells from the same labware
-    with pytest.raises(ValueError, match="Could not group wells"):
+    with pytest.raises(ValueError, match="Could not group"):
         group_wells_for_multi_channel_transfer(
             mock_wells[:2] + [mock_wells[-1]], nozzle_map, "destination"
         )
@@ -491,7 +491,7 @@ def test_grouping_wells_for_row_384_plate_raises(
     decoy.when(other_well.parent).then_return(other_labware)
 
     # non-contiguous wells from different labware, well name is correct though
-    with pytest.raises(ValueError, match="Could not group wells"):
+    with pytest.raises(ValueError, match="Could not group destination wells"):
         group_wells_for_multi_channel_transfer(
             mock_wells[:23] + [other_well], nozzle_map, "destination"
         )

--- a/api/tests/opentrons/protocols/advanced_control/transfers/test_transfer_liquid_utils.py
+++ b/api/tests/opentrons/protocols/advanced_control/transfers/test_transfer_liquid_utils.py
@@ -263,7 +263,7 @@ def test_grouping_wells_for_column_96_plate(
         decoy.when(mock_well.well_name).then_return(well_name)
         decoy.when(mock_well.parent).then_return(mock_96_well_labware)
 
-    wells = group_wells_for_multi_channel_transfer(mock_wells, nozzle_map)
+    wells = group_wells_for_multi_channel_transfer(mock_wells, nozzle_map, "source")
     assert len(wells) == 2
     assert wells[0].well_name == "A1"
     assert wells[1].well_name == "A2"
@@ -283,7 +283,7 @@ def test_grouping_wells_for_column_384_plate(
         decoy.when(mock_well.well_name).then_return(well_name)
         decoy.when(mock_well.parent).then_return(mock_384_well_labware)
 
-    wells = group_wells_for_multi_channel_transfer(mock_wells, nozzle_map)
+    wells = group_wells_for_multi_channel_transfer(mock_wells, nozzle_map, "source")
     assert len(wells) == 4
     assert wells[0].well_name == "A1"
     assert wells[1].well_name == "B1"
@@ -306,13 +306,13 @@ def test_grouping_wells_for_column_96_plate_raises(
         decoy.when(mock_well.parent).then_return(mock_96_well_labware)
 
     # leftover wells
-    with pytest.raises(ValueError, match="Could not target all wells"):
-        group_wells_for_multi_channel_transfer(mock_wells, nozzle_map)
+    with pytest.raises(ValueError, match="Pipette will access wells for source"):
+        group_wells_for_multi_channel_transfer(mock_wells, nozzle_map, "source")
 
     # non-contiguous wells from the same labware
-    with pytest.raises(ValueError, match="Could not resolve wells"):
+    with pytest.raises(ValueError, match="Could not group wells"):
         group_wells_for_multi_channel_transfer(
-            mock_wells[:7] + [mock_wells[-1], mock_wells[7]], nozzle_map
+            mock_wells[:7] + [mock_wells[-1], mock_wells[7]], nozzle_map, "source"
         )
 
     other_labware = decoy.mock(cls=Labware)
@@ -322,9 +322,9 @@ def test_grouping_wells_for_column_96_plate_raises(
     decoy.when(other_well.parent).then_return(other_labware)
 
     # non-contiguous wells from different labware, well name is correct though
-    with pytest.raises(ValueError, match="Could not resolve wells"):
+    with pytest.raises(ValueError, match="Could not group wells"):
         group_wells_for_multi_channel_transfer(
-            mock_wells[:7] + [other_well], nozzle_map
+            mock_wells[:7] + [other_well], nozzle_map, "source"
         )
 
 
@@ -343,16 +343,18 @@ def test_grouping_wells_for_column_384_plate_raises(
         decoy.when(mock_well.parent).then_return(mock_384_well_labware)
 
     # leftover wells
-    with pytest.raises(ValueError, match="Could not target all wells"):
-        group_wells_for_multi_channel_transfer(mock_wells[:-1], nozzle_map)
+    with pytest.raises(ValueError, match="Pipette will access wells for destination"):
+        group_wells_for_multi_channel_transfer(
+            mock_wells[:-1], nozzle_map, "destination"
+        )
 
     # non-contiguous or every other wells from the same labware
-    with pytest.raises(ValueError, match="Could not resolve wells"):
+    with pytest.raises(ValueError, match="Could not group wells"):
         group_wells_for_multi_channel_transfer(
-            mock_wells[:2] + [mock_wells[-1]], nozzle_map
+            mock_wells[:2] + [mock_wells[-1]], nozzle_map, "source"
         )
         group_wells_for_multi_channel_transfer(
-            mock_wells[:-1] + [mock_wells[0]], nozzle_map
+            mock_wells[:-1] + [mock_wells[0]], nozzle_map, "destination"
         )
 
     other_labware = decoy.mock(cls=Labware)
@@ -362,9 +364,9 @@ def test_grouping_wells_for_column_384_plate_raises(
     decoy.when(other_well.parent).then_return(other_labware)
 
     # non-contiguous wells from different labware, well name is correct though
-    with pytest.raises(ValueError, match="Could not resolve wells"):
+    with pytest.raises(ValueError, match="Could not group wells"):
         group_wells_for_multi_channel_transfer(
-            mock_wells[:15] + [other_well], nozzle_map
+            mock_wells[:15] + [other_well], nozzle_map, "source"
         )
 
 
@@ -383,7 +385,9 @@ def test_grouping_wells_for_row_96_plate(
         decoy.when(mock_well.well_name).then_return(well_name)
         decoy.when(mock_well.parent).then_return(mock_96_well_labware)
 
-    wells = group_wells_for_multi_channel_transfer(mock_wells, nozzle_map)
+    wells = group_wells_for_multi_channel_transfer(
+        mock_wells, nozzle_map, "destination"
+    )
     assert len(wells) == 2
     assert wells[0].well_name == "A1"
     assert wells[1].well_name == "B1"
@@ -404,7 +408,7 @@ def test_grouping_wells_for_row_384_plate(
         decoy.when(mock_well.well_name).then_return(well_name)
         decoy.when(mock_well.parent).then_return(mock_384_well_labware)
 
-    wells = group_wells_for_multi_channel_transfer(mock_wells, nozzle_map)
+    wells = group_wells_for_multi_channel_transfer(mock_wells, nozzle_map, "source")
     assert len(wells) == 4
     assert wells[0].well_name == "A1"
     assert wells[1].well_name == "A2"
@@ -428,13 +432,13 @@ def test_grouping_wells_for_row_96_plate_raises(
         decoy.when(mock_well.parent).then_return(mock_96_well_labware)
 
     # leftover wells
-    with pytest.raises(ValueError, match="Could not target all wells"):
-        group_wells_for_multi_channel_transfer(mock_wells[:-1], nozzle_map)
+    with pytest.raises(ValueError, match="Pipette will access wells for source"):
+        group_wells_for_multi_channel_transfer(mock_wells[:-1], nozzle_map, "source")
 
     # non-contiguous wells from the same labware
-    with pytest.raises(ValueError, match="Could not resolve wells"):
+    with pytest.raises(ValueError, match="Could not group wells"):
         group_wells_for_multi_channel_transfer(
-            mock_wells[:11] + [mock_wells[-1], mock_wells[11]], nozzle_map
+            mock_wells[:11] + [mock_wells[-1], mock_wells[11]], nozzle_map, "source"
         )
 
     other_labware = decoy.mock(cls=Labware)
@@ -444,9 +448,9 @@ def test_grouping_wells_for_row_96_plate_raises(
     decoy.when(other_well.parent).then_return(other_labware)
 
     # non-contiguous wells from different labware, well name is correct though
-    with pytest.raises(ValueError, match="Could not resolve wells"):
+    with pytest.raises(ValueError, match="Could not group wells"):
         group_wells_for_multi_channel_transfer(
-            mock_wells[:11] + [other_well], nozzle_map
+            mock_wells[:11] + [other_well], nozzle_map, "destination"
         )
 
 
@@ -466,16 +470,18 @@ def test_grouping_wells_for_row_384_plate_raises(
         decoy.when(mock_well.parent).then_return(mock_384_well_labware)
 
     # leftover wells
-    with pytest.raises(ValueError, match="Could not target all wells"):
-        group_wells_for_multi_channel_transfer(mock_wells[:-1], nozzle_map)
+    with pytest.raises(ValueError, match="Pipette will access wells for destination"):
+        group_wells_for_multi_channel_transfer(
+            mock_wells[:-1], nozzle_map, "destination"
+        )
 
     # non-contiguous or every other wells from the same labware
-    with pytest.raises(ValueError, match="Could not resolve wells"):
+    with pytest.raises(ValueError, match="Could not group wells"):
         group_wells_for_multi_channel_transfer(
-            mock_wells[:2] + [mock_wells[-1]], nozzle_map
+            mock_wells[:2] + [mock_wells[-1]], nozzle_map, "destination"
         )
         group_wells_for_multi_channel_transfer(
-            mock_wells[:-1] + [mock_wells[0]], nozzle_map
+            mock_wells[:-1] + [mock_wells[0]], nozzle_map, "source"
         )
 
     other_labware = decoy.mock(cls=Labware)
@@ -485,9 +491,9 @@ def test_grouping_wells_for_row_384_plate_raises(
     decoy.when(other_well.parent).then_return(other_labware)
 
     # non-contiguous wells from different labware, well name is correct though
-    with pytest.raises(ValueError, match="Could not resolve wells"):
+    with pytest.raises(ValueError, match="Could not group wells"):
         group_wells_for_multi_channel_transfer(
-            mock_wells[:23] + [other_well], nozzle_map
+            mock_wells[:23] + [other_well], nozzle_map, "destination"
         )
 
 
@@ -500,7 +506,9 @@ def test_grouping_wells_for_full_96_plate(
         decoy.when(mock_well.well_name).then_return(well_name)
         decoy.when(mock_well.parent).then_return(mock_96_well_labware)
 
-    wells = group_wells_for_multi_channel_transfer(mock_wells, _96_FULL_MAP)
+    wells = group_wells_for_multi_channel_transfer(
+        mock_wells, _96_FULL_MAP, "destination"
+    )
     assert len(wells) == 1
     assert wells[0].well_name == "A1"
 
@@ -515,7 +523,7 @@ def test_grouping_wells_for_full_384_plate(
         decoy.when(mock_well.well_name).then_return(well_name)
         decoy.when(mock_well.parent).then_return(mock_384_well_labware)
 
-    wells = group_wells_for_multi_channel_transfer(mock_wells, _96_FULL_MAP)
+    wells = group_wells_for_multi_channel_transfer(mock_wells, _96_FULL_MAP, "source")
     assert len(wells) == 4
     assert wells[0].well_name == "A1"
     assert wells[1].well_name == "B1"
@@ -534,8 +542,8 @@ def test_grouping_wells_raises_for_unsupported_configuration() -> None:
         front_right_nozzle="D1",
         valid_nozzle_maps=ValidNozzleMaps(maps={"Half": ["A1", "B1", "C1", "D1"]}),
     )
-    with pytest.raises(ValueError, match="Unsupported tip configuration"):
-        group_wells_for_multi_channel_transfer([], nozzle_map)
+    with pytest.raises(ValueError, match="Unsupported nozzle configuration"):
+        group_wells_for_multi_channel_transfer([], nozzle_map, "source")
 
 
 @pytest.mark.parametrize(
@@ -561,5 +569,5 @@ def test_grouping_well_returns_all_wells_for_non_96_or_384_plate(
         decoy.when(mock_well.well_name).then_return(well_name)
         decoy.when(mock_well.parent).then_return(mock_reservoir)
 
-    result = group_wells_for_multi_channel_transfer(mock_wells, nozzle_map)
+    result = group_wells_for_multi_channel_transfer(mock_wells, nozzle_map, "source")
     assert result == mock_wells


### PR DESCRIPTION
# Overview

In PR #17900 we introduced a new methodology of grouping wells together for multi-channel pipettes/configurations (see that PR for more details). Because this method is stricter than the old and less smart way of grouping wells there are a few errors that can appear if you provide wells out of order, or if you do not provide enough wells or too many.

Some of these error messages were unclear as to what the issue was and how to address it. This PR seeks to fix that by providing more context on what the error is and solutions to address it, while not overloading the user with information. In addition, we now include text so that it is clear whether it is the source wells or destination wells that are causing the error.

Screenshots of the improved error messages for not including all targeted wells or out of order wells:
<img width="488" alt="Screen Shot 2025-06-26 at 3 57 52 PM" src="https://github.com/user-attachments/assets/8fea57d5-8a7a-42af-b707-cf5e7a9e44b4" />
<img width="491" alt="Screen Shot 2025-06-26 at 3 59 32 PM" src="https://github.com/user-attachments/assets/9326936d-2fd7-495a-9cc2-46aa2cad37af" />


## Test Plan and Hands on Testing

The only changes this PR introduces is different error text and a new argument that is only passed to the error text, no logic changes. Tests had to be updated to include this new argument and match the changed text, but any larger issue would be caught by existing unit and integration tests.

## Changelog

- Updated error messages to make them more clear
- Added additional argument to pass to error messages to print if it is the source or destination wells

## Risk assessment

Low, error text changes only and additional argument does not change any logic.