### PR TITLE
fix(step-generation): list off-deck labware last in tip_racks arg

### DIFF
--- a/app/src/organisms/ODD/QuickTransferFlow/utils/pythonDef.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/utils/pythonDef.ts
@@ -104,7 +104,7 @@ export function pythonDef(
   const sections: string[] = [
     getLoadAdapters(moduleEntities, labwareEntities, labware),
     getLoadLabware(moduleEntities, labwareEntities, labware, {}),
-    getLoadPipettes(pipetteEntities, labwareEntities, pipettes),
+    getLoadPipettes(pipetteEntities, labwareEntities, labware, pipettes),
     ...[
       getLoadTrashBins(trashBinEntities),
       getLoadWasteChute(wasteChuteEntities),

--- a/step-generation/src/__tests__/pythonFileUtils.test.ts
+++ b/step-generation/src/__tests__/pythonFileUtils.test.ts
@@ -281,9 +281,10 @@ well_plate_5 = protocol.load_labware(
 })
 
 describe('getLoadPipettes', () => {
-  it('should generate loadPipette for 2 pipettes using the same tiprack', () => {
+  it('should generate loadPipette for 2 pipettes using the same tipracks and off-deck labware last', () => {
     const mockTiprackDefURI = 'fixture/fixture_flex_96_tiprack_1000ul/1'
     const tiprack1 = 'tiprack1'
+    const tiprack2 = 'tiprack2'
     const pipette1 = 'pipette1'
     const pipette2 = 'pipette2'
     const mockPipetteEntities: PipetteEntities = {
@@ -311,23 +312,34 @@ describe('getLoadPipettes', () => {
         labwareDefURI: mockTiprackDefURI,
         pythonName: 'tip_rack_1',
       },
+      [tiprack2]: {
+        id: tiprack2,
+        def: fixtureTiprack1000ul as LabwareDefinition2,
+        labwareDefURI: mockTiprackDefURI,
+        pythonName: 'tip_rack_2',
+      },
     }
     const pipetteRobotState: TimelineFrame['pipettes'] = {
       [pipette1]: { mount: 'left' },
       [pipette2]: { mount: 'right' },
+    }
+    const labwareRobotState: TimelineFrame['labware'] = {
+      [tiprack1]: { stack: [tiprack1, 'offDeck'] },
+      [tiprack2]: { stack: [tiprack2, 'A1'] },
     }
 
     expect(
       getLoadPipettes(
         mockPipetteEntities,
         mockTiprackEntities,
+        labwareRobotState,
         pipetteRobotState
       )
     ).toBe(
       `
 # Load Pipettes:
-pipette_left = protocol.load_instrument("p300_multi_gen2", "left", tip_racks=[tip_rack_1])
-pipette_left = protocol.load_instrument("flex_1channel_1000", "right", tip_racks=[tip_rack_1])`.trimStart()
+pipette_left = protocol.load_instrument("p300_multi_gen2", "left", tip_racks=[tip_rack_2, tip_rack_1])
+pipette_left = protocol.load_instrument("flex_1channel_1000", "right", tip_racks=[tip_rack_2, tip_rack_1])`.trimStart()
     )
   })
 
@@ -352,6 +364,7 @@ pipette_left = protocol.load_instrument("flex_1channel_1000", "right", tip_racks
       getLoadPipettes(
         mockPipetteEntities,
         mockTiprackEntities,
+        labwareRobotState,
         pipetteRobotState
       )
     ).toBe(
@@ -383,6 +396,7 @@ pipette_left = protocol.load_instrument("p300_multi_gen2", "left")`.trimStart()
       getLoadPipettes(
         mockPipetteEntities,
         mockTiprackEntities,
+        labwareRobotState,
         pipetteRobotState
       )
     ).toBe(

--- a/step-generation/src/utils/pythonFileUtils.ts
+++ b/step-generation/src/utils/pythonFileUtils.ts
@@ -10,6 +10,7 @@ import {
 } from '@opentrons/shared-data'
 
 import { getPythonLiquidClassName } from './liquidClassUtils'
+import { getSlotInLocationStack } from './misc'
 import {
   CUSTOM_LABWARE_DICT_NAME,
   formatPyDict,
@@ -25,6 +26,7 @@ import type { CutoutId, ProtocolFile, RobotType } from '@opentrons/shared-data'
 import type {
   InvariantContext,
   LabwareEntities,
+  LabwareEntity,
   LabwareLiquidState,
   LiquidEntities,
   ModuleEntities,
@@ -238,6 +240,7 @@ export function getLoadLabware(
 export function getLoadPipettes(
   pipetteEntities: PipetteEntities,
   labwareEntities: LabwareEntities,
+  labwareRobotState: TimelineFrame['labware'],
   pipetteRobotState: TimelineFrame['pipettes']
 ): string {
   const pythonPipette = Object.values(pipetteEntities)
@@ -250,14 +253,29 @@ export function getLoadPipettes(
       const pipetteName = isFlexPipette(name)
         ? getFlexNameConversion(spec)
         : name
-      const tiprackPythonNames = tiprackDefURI
-        .flatMap(defURI =>
-          Object.values(labwareEntities).filter(
-            lw => lw.labwareDefURI === defURI
-          )
-        )
+      const allTipracks = tiprackDefURI.reduce(
+        (acc: LabwareEntity[], defURI) => {
+          for (const lw of Object.values(labwareEntities)) {
+            if (lw.labwareDefURI === defURI) {
+              acc.push(lw)
+            }
+          }
+          return acc
+        },
+        []
+      )
+      //  list off-deck labware last to match getNextTip logic
+      const tiprackPythonNames = allTipracks
+        .sort((a, b) => {
+          const aOffDeck =
+            getSlotInLocationStack(labwareRobotState[a.id].stack) === 'offDeck'
+          const bOffDeck =
+            getSlotInLocationStack(labwareRobotState[b.id].stack) === 'offDeck'
+          return Number(aOffDeck) - Number(bOffDeck)
+        })
         .map(tiprack => tiprack.pythonName)
         .join(', ')
+
       const pythonTipRacks =
         tiprackDefURI.length === 0 ? '' : `, tip_racks=[${tiprackPythonNames}]`
 
@@ -449,7 +467,7 @@ export function pythonDefRun(
       labware,
       labwareNicknamesById
     ),
-    getLoadPipettes(pipetteEntities, labwareEntities, pipettes),
+    getLoadPipettes(pipetteEntities, labwareEntities, labware, pipettes),
     ...(robotType === FLEX_ROBOT_TYPE
       ? [
           getLoadTrashBins(trashBinEntities),

--- a/step-generation/src/utils/pythonFileUtils.ts
+++ b/step-generation/src/utils/pythonFileUtils.ts
@@ -264,15 +264,17 @@ export function getLoadPipettes(
         },
         []
       )
-      //  list off-deck labware last to match getNextTip logic
-      const tiprackPythonNames = allTipracks
-        .sort((a, b) => {
-          const aOffDeck =
-            getSlotInLocationStack(labwareRobotState[a.id].stack) === 'offDeck'
-          const bOffDeck =
-            getSlotInLocationStack(labwareRobotState[b.id].stack) === 'offDeck'
-          return Number(aOffDeck) - Number(bOffDeck)
-        })
+      const onDeckTipracks = allTipracks.filter(
+        tiprack =>
+          getSlotInLocationStack(labwareRobotState[tiprack.id].stack) !==
+          'offDeck'
+      )
+      const offDeckTipracks = allTipracks.filter(
+        tiprack =>
+          getSlotInLocationStack(labwareRobotState[tiprack.id].stack) ===
+          'offDeck'
+      )
+      const tiprackPythonNames = [...onDeckTipracks, ...offDeckTipracks]
         .map(tiprack => tiprack.pythonName)
         .join(', ')
 


### PR DESCRIPTION
closes RQA-4309

# Overview

Alex ran into a bug where the `tip_racks` arg in `load_instrument` for loading a pipette listed off-deck labware too soon, so analysis would fail thinking the tiprack to use was off-deck.

This analysis error wasn't caught in PD because PD's `getNextTip` logic lists off-deck tipracks last. So you will use all your tips on deck first before running into the "tip is off deck" error. We needed the python to match this by also listing off-deck labware last.

## Test Plan and Hands on Testing

You can smoke test but also i added test coverage to test this. so just review the code!

## Changelog

- list off-deck labware last
- add test overage

## Risk assessment

low