### PR TITLE
fix(app): fix recovery tip source location for aspirate/dispenseInPlace commands

### DIFF
--- a/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useFailedLabwareUtils.test.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useFailedLabwareUtils.test.tsx
@@ -342,6 +342,61 @@ describe('getFailedCmdRelevantLabware', () => {
   })
 })
 
+describe('getRelevantPickUpTipCommand', () => {
+  it('should return null when failedCommandByRunRecord does not have pipetteId in params', () => {
+    const failedCommand = {
+      commandType: 'dispenseInPlace',
+      params: {
+        wellName: 'A1',
+      },
+    } as any
+
+    const runCommands = {
+      data: [failedCommand],
+    } as any
+
+    const result = getRelevantFailedLabwareCmdFrom({
+      failedCommand: { byRunRecord: failedCommand } as any,
+      runCommands,
+    })
+
+    expect(result).toBeNull()
+  })
+
+  it('should return pickUpTip command when failedCommandByRunRecord has pipetteId', () => {
+    const pickUpTipCommand = {
+      key: 'pickUpTipKey',
+      commandType: 'pickUpTip',
+      params: {
+        pipetteId: 'pipetteId',
+        labwareId: 'labwareId',
+        wellName: 'A1',
+      },
+    } as any
+
+    const failedCommand = {
+      key: 'failedKey',
+      commandType: 'dispenseInPlace',
+      params: {
+        pipetteId: 'pipetteId',
+        labwareId: 'labwareId',
+      },
+      error: { isDefined: true, errorType: DEFINED_ERROR_TYPES.OVERPRESSURE },
+    } as any
+
+    const runCommands = {
+      data: [pickUpTipCommand, failedCommand],
+    } as any
+
+    const result = getRelevantFailedLabwareCmdFrom({
+      failedCommand: { byRunRecord: failedCommand } as any,
+      runCommands,
+    })
+
+    expect(result).toBe(pickUpTipCommand)
+  })
+})
+
 describe('useFailedLabwareUtils', () => {
   const mockPickUpTipCommand = {
     key: 'pickUpTipKey',

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useFailedLabwareUtils.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useFailedLabwareUtils.ts
@@ -214,7 +214,6 @@ function getRelevantPickUpTipCommand(
   if (
     failedCommandByRunRecord == null ||
     runCommands == null ||
-    !('wellName' in failedCommandByRunRecord.params) ||
     !('pipetteId' in failedCommandByRunRecord.params)
   ) {
     return null


### PR DESCRIPTION
Closes [RABR-791](https://opentrons.atlassian.net/browse/RABR-791)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

In https://github.com/Opentrons/opentrons/pull/16674, we better separated the logic for getting the failed command's related `pickUpTip` command from the failed command itself. One accidental holdover still exists though: currently, if the failed command itself doesn't contain a `wellName`, we assume there's no related `pickUpTipCommand`. This isn't true of `aspirate/DispenseInPlace` commands. We don't actually care if the failed command itself has a `wellName`.

### Current Behavior

https://github.com/user-attachments/assets/4bab0c63-c1bc-4f04-9e1e-0b7837c0625e

### Fixed Behavior

https://github.com/user-attachments/assets/a879bed2-dd41-4997-8b1d-8f5989936a57

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- See videos
- I've audited all the code in error recovery that depends on `wellName` or any of the variables derived from `wellName`, and it seems that any time we care about `wellName`, it's directly related to the pick up tip location. 
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed error recovery failing to pick up a tip after a failed `aspirateInPlace` or `dispenseInPlace` command.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low-ish. the change only reduces the amount of gating we do around finding related labware, and we don't do any conditional recovery options that would depend on related labware. 
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RABR-791]: https://opentrons.atlassian.net/browse/RABR-791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ