### PR TITLE
docs(api): external CSS fix

### DIFF
--- a/api/docs/templates/v2/remote-nav.html
+++ b/api/docs/templates/v2/remote-nav.html
@@ -67,9 +67,10 @@ body{--wp--preset--color--black: #000000;--wp--preset--color--cyan-bluish-gray: 
 .wp-block-pullquote{font-size: 1.5em;line-height: 1.6;}
 </style>
 <link rel='stylesheet' id='auth0-widget-css' href='https://opentrons.com/wp-content/plugins/auth0/assets/css/main.css?ver=4.6.2' type='text/css' media='all' />
-<link rel='stylesheet' id='bigcommerce-styles-css' href='https://opentrons.com/wp-content/plugins/bigcommerce/assets/css/master.min.css?ver=5.0.8-11.48.12.14.2023' type='text/css' media='all' />
-<link rel='stylesheet' id='style-css' href='https://opentrons.com/wp-content/themes/timberland/theme/assets/build/app.css?id=06ae55a365bd3e1b84ee097bbfe9cb49&#038;ver=6.5.5' type='text/css' media='all' />
-<link rel='stylesheet' id='algolia-autocomplete-css' href='https://opentrons.com/wp-content/plugins/wp-search-with-algolia/css/algolia-autocomplete.css?ver=2.8.1' type='text/css' media='all' />
+<link rel='stylesheet' id='bigcommerce-styles-css' href='https://opentrons.com/wp-content/plugins/bigcommerce/assets/css/master.min.css?ver=5.1.2-4.39.09.12.2024' type='text/css' media='all' />
+<link rel='stylesheet' id='timberland-app-css' href='https://opentrons.com/wp-content/themes/timberland/theme/assets/build/css/app.css?id=e3cd5368a82afb21e5316b601787a0e5' type='text/css' media='all' />
+<link rel='stylesheet' id='youtube-popup-style-css' href='https://opentrons.com/wp-content/themes/timberland/theme/assets/styles/YouTubePopUp.css?ver=6.7.1' type='text/css' media='all' />
+<link rel='stylesheet' id='algolia-autocomplete-css' href='https://opentrons.com/wp-content/plugins/wp-search-with-algolia/css/algolia-autocomplete.css?ver=2.8.2' type='text/css' media='all' />
 <script type="text/javascript" src="https://opentrons.com/wp-includes/js/jquery/jquery.min.js?ver=3.7.1" id="jquery-core-js"></script>
 <script type="text/javascript" src="https://opentrons.com/wp-includes/js/jquery/jquery-migrate.min.js?ver=3.4.1" id="jquery-migrate-js"></script>
 <link rel="https://api.w.org/" href="https://opentrons.com/wp-json/" /><link rel="alternate" type="application/json" href="https://opentrons.com/wp-json/wp/v2/pages/1927" /><link rel="EditURI" type="application/rsd+xml" title="RSD" href="https://opentrons.com/xmlrpc.php?rsd" />


### PR DESCRIPTION
We linked to some external CSS from the marketing site in the docs site code. This was a bad idea and the offending parties have been sacked.

# Overview

This just does the bad thing anew! It is a temporary fix! If it holds for a couple months maybe this will all be replaced.

## Test Plan and Hands on Testing

It builds locally and looks right. [Sandbox](http://sandbox.docs.opentrons.com/docs-css-hotfix/v2/) too.

## Changelog

Copypasta from `https://opentrons.com/remote-nav`

## Review requests

We gotta do this fast, so are we OK with the band-aid? 🩹 

## Risk assessment

more than we thought! but we need this hotfix _now_