### PR TITLE
fix(protocol-designer): migrate null blowout location

### DIFF
--- a/protocol-designer/release-notes.md
+++ b/protocol-designer/release-notes.md
@@ -33,7 +33,7 @@ Use Opentrons-verified liquid classes to automatically define transfer settings 
 - During a mix, push out is set to 0 by default for all mixes except for the last, to avoid multiple push out actions. You can choose your own push out volume in a mix step menu.
 - Choose a new tip drop location from the dropdown menu when an uploaded protocol is missing a tip drop location.
 - Protocol Designer correctly updates adapter and labware combination definitions when you upload a protocol designed in Protocol Designer v7.0.0 or earlier.
-- When adding a disposal volume, a blowout location is now required.
+- When adding a disposal volume, a blowout location is now required. Older protocols that specified a blowout with no location selected will be updated to blowout in a loaded trash bin or waste chute.
 - No longer allow touch tip with incompatible labware. This changes the behavior of imported protocols that had touch tip on incompatible labware.
 - If multiple labware end up in the same slot at the same time due to deleting/rearranging steps, an error appears on the protocol timeline.
 - If a Heater-Shaker step is created with a a heater set and a timer, the protocol will now wait until the temperature is reached before counting down the timer.

--- a/protocol-designer/src/load-file/migration/8_5_0.ts
+++ b/protocol-designer/src/load-file/migration/8_5_0.ts
@@ -1,3 +1,4 @@
+import first from 'lodash/first'
 import floor from 'lodash/floor'
 import min from 'lodash/min'
 
@@ -40,6 +41,18 @@ const getMigratedBlowoutFlowRate = (
     ? getDefaultBlowoutFlowRate(Number(form.volume), pipetteSpecs, tipRackDef)
     : null
 
+const getMigratedBlowoutLocation = (
+  form: FormData,
+  firstTrashBinOrWasteChuteId: string | null
+): string | null => {
+  const { blowout_checkbox, blowout_location, disposalVolume_checkbox } = form
+  const doesBlowoutNeedMigration =
+    (blowout_checkbox === true || disposalVolume_checkbox === true) &&
+    blowout_location == null
+  return doesBlowoutNeedMigration && firstTrashBinOrWasteChuteId != null
+    ? firstTrashBinOrWasteChuteId
+    : blowout_location
+}
 export const migrateFile = (
   appData: ProtocolFile<PDMetadata>
 ): ProtocolFile<PDMetadata> => {
@@ -68,6 +81,25 @@ export const migrateFile = (
     return acc
   }, {})
 
+  const initialDeckSetupStep = Object.values(savedStepForms).find(
+    form => form.id === '__INITIAL_DECK_SETUP_STEP__'
+  )
+  const firstTrashBinOrWasteChuteId =
+    first([
+      ...Object.keys(
+        (initialDeckSetupStep?.trashBinLocationUpdate as Record<
+          string,
+          string
+        >) ?? {}
+      ),
+      ...Object.keys(
+        (initialDeckSetupStep?.wasteChuteLocationUpdate as Record<
+          string,
+          string
+        >) ?? {}
+      ),
+    ]) ?? null
+
   const savedStepsWithUpdatedMoveLiquidFields = Object.values(
     savedStepForms
   ).reduce((acc, form) => {
@@ -82,6 +114,7 @@ export const migrateFile = (
         liquidClass,
         aspirate_touchTip_checkbox,
         dispense_touchTip_checkbox,
+        blowout_location,
         // intentionally destructure but do not pass these deprecated fields
         aspirate_delay_mmFromBottom,
         dispense_delay_mmFromBottom,
@@ -104,6 +137,10 @@ export const migrateFile = (
               'touchTipDisabled'
             )
 
+      const migratedBlowoutLocation = getMigratedBlowoutLocation(
+        form,
+        firstTrashBinOrWasteChuteId
+      )
       const matchingAspirateLabwareWellDepth = getMigratedPositionFromTop(
         labwareDefinitions,
         loadLabwareCommands,
@@ -216,6 +253,7 @@ export const migrateFile = (
           ...(migratedBlowoutFlowRate != null
             ? { blowout_flowRate: migratedBlowoutFlowRate }
             : {}),
+          blowout_location: migratedBlowoutLocation,
         },
       }
     }
@@ -266,6 +304,12 @@ export const migrateFile = (
           pipetteSpecs,
           tipRackDef
         )
+
+        const migratedBlowoutLocation = getMigratedBlowoutLocation(
+          form,
+          firstTrashBinOrWasteChuteId
+        )
+
         return {
           ...acc,
           [id]: {
@@ -291,6 +335,7 @@ export const migrateFile = (
             ...(migratedBlowoutFlowRate != null
               ? { blowout_flowRate: migratedBlowoutFlowRate }
               : {}),
+            blowout_location: migratedBlowoutLocation,
           },
         }
       }

--- a/protocol-designer/src/load-file/migration/8_5_0.ts
+++ b/protocol-designer/src/load-file/migration/8_5_0.ts
@@ -100,6 +100,12 @@ export const migrateFile = (
       ),
     ]) ?? null
 
+  if (firstTrashBinOrWasteChuteId == null) {
+    console.error(
+      'No trash bin or waste chute found in the initial deck setup step. Protocol file may have been corrupted.'
+    )
+  }
+
   const savedStepsWithUpdatedMoveLiquidFields = Object.values(
     savedStepForms
   ).reduce((acc, form) => {


### PR DESCRIPTION
# Overview

Previously, we erroniously allowed a user to save a form with disposal or blowout checkbox on, but no blowout location selected from the dropdown. For the 8.5.0 release, we enforce a stepform error if the blowout location is left unselected. In order to prevent this error popping up for users who migrate older protocols in which the blowout location was unselected, we migrate the blowout location to the first available trash or waste chute ID.

Closes RQA-4311

## Test Plan and Hands on Testing

- upload protocol attached to this ticket
- open the transfer form > advanced dispense settings, and verify that the disposal blowout location is set to the trash bin, and the form has no errors

## Changelog

- add migration to fill a blowout field if it was previously saved while null

## Review requests

see test plan

## Risk assessment

low