### PR TITLE
fix(shared-data): change z dimension to match inner well geometry

### DIFF
--- a/shared-data/labware/definitions/2/opentrons_tough_1_reservoir_300ml/1.json
+++ b/shared-data/labware/definitions/2/opentrons_tough_1_reservoir_300ml/1.json
@@ -16,7 +16,7 @@
   "dimensions": {
     "xDimension": 127.76,
     "yDimension": 85.48,
-    "zDimension": 45.3
+    "zDimension": 42.3
   },
   "wells": {
     "A1": {


### PR DESCRIPTION
## Overview
The z dimension for the opentrons tough reservoir is 3 mm larger than the largest `topHeight` value in the `innerLabwareGeometry`. This could be causing crashes seen in abr.