### PR TITLE
fix(shared-data): capitalize brand Opentrons in labware def

### DIFF
--- a/shared-data/labware/definitions/2/ev_resin_tips_flex_96_labware/1.json
+++ b/shared-data/labware/definitions/2/ev_resin_tips_flex_96_labware/1.json
@@ -14,7 +14,7 @@
     ["A12", "B12", "C12", "D12", "E12", "F12", "G12", "H12"]
   ],
   "brand": {
-    "brand": "opentrons",
+    "brand": "Opentrons",
     "brandId": ["999-00254"],
     "links": [
       "https://opentrons.com/products/opentrons-flex-adapter-set-for-3rd-party-evotips/"


### PR DESCRIPTION
# Overview

Welp, this is the only opentrons def in our labware definitions that lowercases opentrons so i'm assuming this is not intentional. 

This fixes the bug Ed was seeing where `opentrons` and `Opentrons` were both listed as manufacturers in labware-library

## Changelog

- capitalize `Opentrons`

## Risk assessment

low
