### PR TITLE
Merge back 'chore_release-8.5.0' into 'chore_release-pd-8.5.0'

### DIFF
--- a/.github/workflows/api-test-lint-deploy.yaml
+++ b/.github/workflows/api-test-lint-deploy.yaml
@@ -67,7 +67,7 @@ jobs:
       - name: Lint with opentrons_hardware
         run: make -C api lint
   test:
-    name: 'opentrons package tests on ${{ matrix.os }}, python ${{ matrix.python }}'
+    name: 'opentrons package tests on ${{ matrix.os }}, python ${{ matrix.python }}, ot-hardware ${{ matrix.with-ot-hardware }}'
     timeout-minutes: 30
     needs: [lint]
     strategy:

--- a/api/release-notes.md
+++ b/api/release-notes.md
@@ -10,7 +10,20 @@ By installing and using Opentrons software, you agree to the Opentrons End-User 
 
 ## Opentrons Robot Software Changes in 8.5.0
 
-### TODO
+Welcome to the v8.5.0 release of the Opentrons robot software! This release features the ability to pipette more accurately by using liquid classes in your protocols.
+
+### New Features
+
+- Use Opentrons-verified liquid classes (aqueous, viscous, and volatile) in the Python Protocol API to automatically adjust submerge speed, flow rate, touch tip, air gap, and more.
+- Customize and create your own liquid classes for even more control.
+
+### Improvements
+
+- Several Python API methods have new parameters that add capabilities available in Protocol Designer.
+
+### Bug Fixes
+
+- The Absorbance Plate Reader no longer reports measurements below 0.
 
 ---
 
@@ -50,13 +63,12 @@ The 8.3.2 hotfix release fixes a bug where protocol commands could time out, esp
 
 The 8.3.1 hotfix release contains two bug fixes:
 
-- Exported data from the Absorbance Plate Reader no longer contains invalid values. 
-- A small fix allows all robots to properly reboot after an upgrade to v8.3.0. 
+- Exported data from the Absorbance Plate Reader no longer contains invalid values.
+- A small fix allows all robots to properly reboot after an upgrade to v8.3.0.
 
 ## Opentrons Robot Software Changes in 8.3.0
 
-Welcome to the v8.3.0 release of the Opentrons robot software! This release includes improvements to error recovery on the Flex, as well as beta features for our commercial partners. 
-
+Welcome to the v8.3.0 release of the Opentrons robot software! This release includes improvements to error recovery on the Flex, as well as beta features for our commercial partners.
 
 ### Improved Features
 
@@ -171,7 +183,7 @@ Welcome to the v7.3.0 release of the Opentrons robot software!
 ### Bug Fixes
 
 - Fixed an edge case where capitalizing part of a labware load name could cause unexpected behavior or collisions.
-- Fixed Python packages installed  on the OT-2 with `pip` not being found by `import` statements.
+- Fixed Python packages installed on the OT-2 with `pip` not being found by `import` statements.
 
 ---
 
@@ -207,7 +219,7 @@ Welcome to the v7.2.1 release of the Opentrons robot software!
 
 Welcome to the v7.2.0 release of the Opentrons robot software!
 
-This update may take longer than usual if your robot has a lot of long protocols and runs stored on it. Allow *approximately 20 minutes* for your robot to restart. This delay will only happen once.
+This update may take longer than usual if your robot has a lot of long protocols and runs stored on it. Allow _approximately 20 minutes_ for your robot to restart. This delay will only happen once.
 
 If you don't care about preserving your labware offsets and run history, you can avoid the delay by clearing your runs and protocols before starting this update. Go to **Robot Settings** > **Device Reset** and select **Clear protocol run history**.
 
@@ -342,12 +354,12 @@ Some protocols can't be simulated with the `opentrons_simulate` command-line too
 Welcome to the v6.3.1 release of the OT-2 software! This hotfix release addresses a few problems.
 
 ### Improved Features
+
 - Changed the Thermocycler GEN2 plate ejection behavior to prevent plates from getting stuck after PCR cycles or being ejected too forcefully.
 
 ### Bug Fixes
 
-- Specifying Python API version 2.14 no longer prevents ``set_block_temperature`` from executing a hold time.
-
+- Specifying Python API version 2.14 no longer prevents `set_block_temperature` from executing a hold time.
 
 ---
 
@@ -373,6 +385,7 @@ Some protocols can't be simulated with the `opentrons_simulate` command-line too
 - Python protocols specifying an `apiLevel` of 2.14
 
 ---
+
 ## OT-2 Software Changes in 6.2.1
 
 Welcome to the v6.2.1 release of the OT-2 software! This hotfix release addresses a few problems.

--- a/api/src/opentrons/protocol_api/_transfer_liquid_validation.py
+++ b/api/src/opentrons/protocol_api/_transfer_liquid_validation.py
@@ -47,10 +47,10 @@ def verify_and_normalize_transfer_args(
         flat_dests_list = []
     if group_wells_for_multi_channel and nozzle_map.tip_count > 1:
         flat_sources_list = tx_liquid_utils.group_wells_for_multi_channel_transfer(
-            flat_sources_list, nozzle_map
+            flat_sources_list, nozzle_map, "source"
         )
         flat_dests_list = tx_liquid_utils.group_wells_for_multi_channel_transfer(
-            flat_dests_list, nozzle_map
+            flat_dests_list, nozzle_map, "destination"
         )
     for well in flat_sources_list + flat_dests_list:
         instrument.validate_takes_liquid(

--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -1,7 +1,6 @@
 """ProtocolEngine-based InstrumentContext core implementation."""
 
 from __future__ import annotations
-from contextlib import contextmanager
 from itertools import dropwhile
 from copy import deepcopy
 from typing import (
@@ -13,7 +12,6 @@ from typing import (
     Sequence,
     Tuple,
     NamedTuple,
-    Generator,
     Literal,
 )
 from opentrons.types import (
@@ -1384,43 +1382,25 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                         air_gap=0,
                     )
                 ]
-                # Enable LPD only if all of these apply:
-                # - LPD is globally enabled for this pipette
-                # - it is the first time visiting this well
-                # - pipette tip is unused
-                enable_lpd = (
-                    self.get_liquid_presence_detection() and step_source != prev_src
-                )
-            elif new_tip == TransferTipPolicyV2.ONCE:
-                # Enable LPD only if:
-                # - LPD is globally enabled for this pipette
-                # - this is the first source well of the entire transfer, which means
-                #   that the current tip is unused
-                enable_lpd = self.get_liquid_presence_detection() and prev_src is None
-            else:
-                enable_lpd = False
 
-            with self.lpd_for_transfer(enable_lpd):
-                post_asp_tip_contents = self.aspirate_liquid_class(
-                    volume=step_volume,
-                    source=step_source,
-                    transfer_properties=transfer_props,
-                    transfer_type=tx_comps_executor.TransferType.ONE_TO_ONE,
-                    tip_contents=post_disp_tip_contents,
-                    volume_for_pipette_mode_configuration=step_volume,
-                )
-                post_disp_tip_contents = self.dispense_liquid_class(
-                    volume=step_volume,
-                    dest=step_destination,
-                    source=step_source,
-                    transfer_properties=transfer_props,
-                    transfer_type=tx_comps_executor.TransferType.ONE_TO_ONE,
-                    tip_contents=post_asp_tip_contents,
-                    add_final_air_gap=(
-                        False if is_last_step and keep_last_tip else True
-                    ),
-                    trash_location=trash_location,
-                )
+            post_asp_tip_contents = self.aspirate_liquid_class(
+                volume=step_volume,
+                source=step_source,
+                transfer_properties=transfer_props,
+                transfer_type=tx_comps_executor.TransferType.ONE_TO_ONE,
+                tip_contents=post_disp_tip_contents,
+                volume_for_pipette_mode_configuration=step_volume,
+            )
+            post_disp_tip_contents = self.dispense_liquid_class(
+                volume=step_volume,
+                dest=step_destination,
+                source=step_source,
+                transfer_properties=transfer_props,
+                transfer_type=tx_comps_executor.TransferType.ONE_TO_ONE,
+                tip_contents=post_asp_tip_contents,
+                add_final_air_gap=(False if is_last_step and keep_last_tip else True),
+                trash_location=trash_location,
+            )
             prev_src = step_source
             prev_dest = step_destination
 
@@ -1695,17 +1675,6 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                     " Specify a blowout location and enable blowout when using a disposal volume."
                 )
 
-            if (
-                self.get_liquid_presence_detection()
-                and new_tip != TransferTipPolicyV2.NEVER
-                and is_first_step
-            ):
-                # Do probing only once, regardless of whether you are coming back to refill
-                # with a fresh tip since there's only one source well
-                enable_lpd = True
-            else:
-                enable_lpd = False
-
             if not is_first_step and new_tip == TransferTipPolicyV2.ALWAYS:
                 _drop_tip()
                 last_tip = _pick_up_tip()
@@ -1715,20 +1684,19 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                         air_gap=0,
                     )
                 ]
-            with self.lpd_for_transfer(enable=enable_lpd):
-                # Aspirate the total volume determined by the loop above
-                tip_contents = self.aspirate_liquid_class(
-                    volume=total_aspirate_volume + conditioning_vol + disposal_vol,
-                    source=source,
-                    transfer_properties=transfer_props,
-                    transfer_type=tx_comps_executor.TransferType.ONE_TO_MANY,
-                    tip_contents=tip_contents,
-                    # We configure the mode based on the last dispense volume and disposal volume
-                    # since the mode is only used to determine the dispense push out volume
-                    # and we can do a push out only at the last dispense, that too if there is no disposal volume.
-                    volume_for_pipette_mode_configuration=vol_dest_combo[-1][0],
-                    conditioning_volume=conditioning_vol,
-                )
+            # Aspirate the total volume determined by the loop above
+            tip_contents = self.aspirate_liquid_class(
+                volume=total_aspirate_volume + conditioning_vol + disposal_vol,
+                source=source,
+                transfer_properties=transfer_props,
+                transfer_type=tx_comps_executor.TransferType.ONE_TO_MANY,
+                tip_contents=tip_contents,
+                # We configure the mode based on the last dispense volume and disposal volume
+                # since the mode is only used to determine the dispense push out volume
+                # and we can do a push out only at the last dispense, that too if there is no disposal volume.
+                volume_for_pipette_mode_configuration=vol_dest_combo[-1][0],
+                conditioning_volume=conditioning_vol,
+            )
 
             # If the tip has volumes correspoinding to multiple destinations, then
             # multi-dispense in those destinations.
@@ -1963,7 +1931,6 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         next_step_volume, next_source = next(source_per_volume_step)
         is_first_step = True
         is_last_step = False
-        prev_src: Optional[tuple[Location, WellCore]] = None
         while not is_last_step:
             total_dispense_volume = 0.0
             vol_aspirate_combo = []
@@ -1981,13 +1948,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                     is_last_step = True
                     break
 
-            if (
-                self.get_liquid_presence_detection()
-                and new_tip != TransferTipPolicyV2.NEVER
-                and is_first_step
-            ):
-                enable_lpd = True
-            elif not is_first_step and new_tip == TransferTipPolicyV2.ALWAYS:
+            if not is_first_step and new_tip == TransferTipPolicyV2.ALWAYS:
                 _drop_tip()
                 last_tip = _pick_up_tip()
                 tip_contents = [
@@ -1996,33 +1957,22 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                         air_gap=0,
                     )
                 ]
-                # Enable LPD if it's globally enabled, as long as
-                # the next source is different from previous source
-                enable_lpd = (
-                    self.get_liquid_presence_detection()
-                    and prev_src != vol_aspirate_combo[0][1]
-                )
-            else:
-                enable_lpd = False
 
             total_aspirated_volume = 0.0
             for step_num, (step_volume, step_source) in enumerate(vol_aspirate_combo):
-                with self.lpd_for_transfer(enable=enable_lpd):
-                    tip_contents = self.aspirate_liquid_class(
-                        volume=step_volume,
-                        source=step_source,
-                        transfer_properties=transfer_props,
-                        transfer_type=tx_comps_executor.TransferType.MANY_TO_ONE,
-                        tip_contents=tip_contents,
-                        volume_for_pipette_mode_configuration=(
-                            total_dispense_volume if step_num == 0 else None
-                        ),
-                        current_volume=total_aspirated_volume,
-                    )
-                prev_src = step_source
+                tip_contents = self.aspirate_liquid_class(
+                    volume=step_volume,
+                    source=step_source,
+                    transfer_properties=transfer_props,
+                    transfer_type=tx_comps_executor.TransferType.MANY_TO_ONE,
+                    tip_contents=tip_contents,
+                    volume_for_pipette_mode_configuration=(
+                        total_dispense_volume if step_num == 0 else None
+                    ),
+                    current_volume=total_aspirated_volume,
+                )
                 total_aspirated_volume += step_volume
                 is_first_step = False
-                enable_lpd = False
             tip_contents = self.dispense_liquid_class(
                 volume=total_dispense_volume,
                 dest=dest,
@@ -2119,10 +2069,6 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                 location=prep_location,
             )
             last_liquid_and_airgap_in_tip.air_gap = 0
-            if self.get_liquid_presence_detection():
-                self.liquid_probe_with_recovery(
-                    well_core=source_well, loc=prep_location
-                )
             # TODO: do volume configuration + prepare for aspirate only if the mode needs to be changed
             self.configure_for_volume(volume_for_pipette_mode_configuration)
             self.prepare_to_aspirate()
@@ -2540,14 +2486,6 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
     def delay(self, seconds: float) -> None:
         """Call a protocol delay."""
         self._protocol_core.delay(seconds=seconds, msg=None)
-
-    @contextmanager
-    def lpd_for_transfer(self, enable: bool) -> Generator[None, None, None]:
-        """Context manager for the instrument's LPD state during a transfer."""
-        global_lpd_enabled = self.get_liquid_presence_detection()
-        self.set_liquid_presence_detection(enable=enable)
-        yield
-        self.set_liquid_presence_detection(enable=global_lpd_enabled)
 
 
 class _TipInfo(NamedTuple):

--- a/api/src/opentrons/protocols/advanced_control/transfers/transfer_liquid_utils.py
+++ b/api/src/opentrons/protocols/advanced_control/transfers/transfer_liquid_utils.py
@@ -72,6 +72,7 @@ def raise_if_location_inside_liquid(
 def group_wells_for_multi_channel_transfer(
     targets: Sequence[Well],
     nozzle_map: NozzleMapInterface,
+    target_name: Literal["source", "destination"],
 ) -> List[Well]:
     """Takes a list of wells and a nozzle map and returns a list of target wells to address every well given
 
@@ -94,13 +95,20 @@ def group_wells_for_multi_channel_transfer(
         or (configuration == NozzleConfigurationType.ROW and active_nozzles == 12)
         or active_nozzles == 96
     ):
-        return _group_wells_for_nozzle_configuration(list(targets), nozzle_map)
+        return _group_wells_for_nozzle_configuration(
+            list(targets), nozzle_map, target_name
+        )
     else:
-        raise ValueError("Unsupported tip configuration for well grouping")
+        raise ValueError(
+            "Unsupported nozzle configuration for well grouping. Set group_wells to False"
+            " to only target wells with the primary nozzle for this configuration."
+        )
 
 
 def _group_wells_for_nozzle_configuration(  # noqa: C901
-    targets: List[Well], nozzle_map: NozzleMapInterface
+    targets: List[Well],
+    nozzle_map: NozzleMapInterface,
+    target_name: Literal["source", "destination"],
 ) -> List[Well]:
     """Groups wells together for a column, row, or full 96 configuration and returns a reduced list of target wells."""
     grouped_wells = []
@@ -132,8 +140,9 @@ def _group_wells_for_nozzle_configuration(  # noqa: C901
         if active_wells_covered:
             if well.parent != active_labware:
                 raise ValueError(
-                    "Could not resolve wells provided to pipette's nozzle configuration. "
-                    "Please ensure wells are ordered to match pipette's nozzle layout."
+                    f"Could not group {target_name} wells to match pipette's nozzle configuration. Ensure that the"
+                    " wells are ordered correctly (e.g. rows() for a row layout or columns() for a column layout), or"
+                    " set group_wells to False to only target wells with the primary nozzle."
                 )
 
             if well.well_name in active_wells_covered:
@@ -165,8 +174,9 @@ def _group_wells_for_nozzle_configuration(  # noqa: C901
                 alternate_384_well_coverage_count += 1
             else:
                 raise ValueError(
-                    "Could not resolve wells provided to pipette's nozzle configuration. "
-                    "Please ensure wells are ordered to match pipette's nozzle layout."
+                    f"Could not group {target_name} wells to match pipette's nozzle configuration. Ensure that the"
+                    " wells are ordered correctly (e.g. rows() for a row layout or columns() for a column layout), or"
+                    " set group_wells to False to only target wells with the primary nozzle."
                 )
         # If we have no active wells covered to account for, add a new target well and list of covered wells to check
         else:
@@ -193,8 +203,8 @@ def _group_wells_for_nozzle_configuration(  # noqa: C901
 
     if active_wells_covered:
         raise ValueError(
-            "Could not target all wells provided without aspirating or dispensing from other wells. "
-            f"Other wells that would be targeted: {active_wells_covered}"
+            f"Pipette will access {target_name} wells not provided in the liquid handling command."
+            f" Set group_wells to False or include these wells: {active_wells_covered}"
         )
 
     # If we reversed the lookup of wells, reverse the grouped wells we will return

--- a/api/tests/opentrons/protocol_api/core/engine/test_instrument_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_instrument_core.py
@@ -2177,7 +2177,7 @@ def test_aspirate_liquid_class_for_transfer_without_volume_config(
 
 
 @pytest.mark.parametrize("version", versions_at_or_above(APIVersion(2, 23)))
-def test_aspirate_liquid_class_using_volume_config_without_lpd(
+def test_aspirate_liquid_class_using_volume_config(
     decoy: Decoy,
     mock_engine_client: EngineClient,
     subject: InstrumentCore,
@@ -2186,7 +2186,7 @@ def test_aspirate_liquid_class_using_volume_config_without_lpd(
     mock_protocol_core: ProtocolCore,
     version: APIVersion,
 ) -> None:
-    """It should execute steps required for volume config only, without LPD steps."""
+    """It should execute steps required for volume config."""
     source_well = decoy.mock(cls=WellCore)
     source_location = Location(Point(1, 2, 3), labware=None)
     liquid_probe_start_point = Point(3, 2, 1)
@@ -2292,185 +2292,6 @@ def test_aspirate_liquid_class_using_volume_config_without_lpd(
         ),
     )
     assert result == [LiquidAndAirGapPair(air_gap=222, liquid=111)]
-
-
-@pytest.mark.parametrize("version", versions_at_or_above(APIVersion(2, 23)))
-def test_aspirate_liquid_class_using_volume_config_and_lpd(
-    decoy: Decoy,
-    mock_engine_client: EngineClient,
-    instrument_core_with_lpd: InstrumentCore,
-    minimal_liquid_class_def2: LiquidClassSchemaV1,
-    mock_transfer_components_executor: TransferComponentsExecutor,
-    mock_protocol_core: ProtocolCore,
-    version: APIVersion,
-) -> None:
-    """It should execute steps required for volume config and LPD."""
-    source_well = decoy.mock(cls=WellCore)
-    source_location = Location(Point(1, 2, 3), labware=None)
-    liquid_probe_start_point = Point(3, 2, 1)
-
-    test_liquid_class = LiquidClass.create(minimal_liquid_class_def2)
-    test_transfer_properties = test_liquid_class.get_for(
-        "flex_1channel_50", "opentrons_flex_96_tiprack_50ul"
-    )
-    decoy.when(source_well.labware_id).then_return("source-labware-id")
-    decoy.when(source_well.get_name()).then_return("source-well")
-    decoy.when(source_well.get_top(2)).then_return(liquid_probe_start_point)
-    decoy.when(
-        mock_engine_client.state.geometry.get_relative_well_location(
-            labware_id="source-labware-id",
-            well_name="source-well",
-            absolute_point=liquid_probe_start_point,
-            location_type=WellLocationFunction.LIQUID_HANDLING,
-        )
-    ).then_return((LiquidHandlingWellLocation(origin=WellOrigin.BOTTOM), True))
-    decoy.when(
-        transfer_components_executor.absolute_point_from_position_reference_and_offset(
-            well=source_well,
-            well_volume_difference=-123,
-            position_reference=PositionReference.WELL_BOTTOM,
-            offset=Coordinate(x=0, y=0, z=-5),
-            mount=Mount.LEFT,
-        )
-    ).then_return(Point(1, 2, 3))
-    decoy.when(
-        transfer_components_executor.TransferComponentsExecutor(
-            instrument_core=instrument_core_with_lpd,
-            transfer_properties=test_transfer_properties,
-            target_location=Location(Point(1, 2, 3), labware=None),
-            target_well=source_well,
-            tip_state=TipState(),
-            transfer_type=TransferType.ONE_TO_ONE,
-        )
-    ).then_return(mock_transfer_components_executor)
-    decoy.when(
-        mock_transfer_components_executor.tip_state.last_liquid_and_air_gap_in_tip
-    ).then_return(LiquidAndAirGapPair(liquid=111, air_gap=222))
-    decoy.when(mock_protocol_core.api_version).then_return(version)
-    result = instrument_core_with_lpd.aspirate_liquid_class(
-        volume=123,
-        source=(source_location, source_well),
-        transfer_properties=test_transfer_properties,
-        transfer_type=TransferType.ONE_TO_ONE,
-        tip_contents=[],
-        volume_for_pipette_mode_configuration=123,
-    )
-    decoy.verify(
-        mock_engine_client.execute_command(
-            cmd.MoveToWellParams(
-                pipetteId="abc123",
-                labwareId="source-labware-id",
-                wellName="source-well",
-                wellLocation=LiquidHandlingWellLocation(origin=WellOrigin.BOTTOM),
-                minimumZHeight=None,
-                forceDirect=False,
-                speed=None,
-            )
-        ),
-        mock_engine_client.execute_command(
-            cmd.LiquidProbeParams(
-                pipetteId="abc123",
-                labwareId="source-labware-id",
-                wellName="source-well",
-                wellLocation=WellLocation(
-                    origin=WellOrigin.TOP, offset=WellOffset(x=0, y=0, z=2)
-                ),
-            )
-        ),
-        mock_engine_client.execute_command(
-            cmd.ConfigureForVolumeParams(
-                pipetteId="abc123",
-                volume=123,
-                tipOverlapNotAfterVersion="v3",
-            )
-        ),
-        mock_engine_client.execute_command(
-            cmd.PrepareToAspirateParams(
-                pipetteId="abc123",
-            )
-        ),
-        mock_transfer_components_executor.submerge(
-            submerge_properties=test_transfer_properties.aspirate.submerge,
-            post_submerge_action="aspirate",
-        ),
-        mock_transfer_components_executor.mix(
-            mix_properties=test_transfer_properties.aspirate.mix,
-            last_dispense_push_out=False,
-        ),
-        mock_transfer_components_executor.pre_wet(volume=123),
-        mock_transfer_components_executor.aspirate_and_wait(volume=123),
-        mock_transfer_components_executor.retract_after_aspiration(
-            volume=123, add_air_gap=True
-        ),
-    )
-    assert result == [LiquidAndAirGapPair(air_gap=222, liquid=111)]
-
-
-@pytest.mark.parametrize("version", versions_at_or_above(APIVersion(2, 23)))
-def test_aspirate_liquid_class_does_not_do_lpd_for_consolidate(
-    decoy: Decoy,
-    mock_engine_client: EngineClient,
-    subject: InstrumentCore,
-    minimal_liquid_class_def2: LiquidClassSchemaV1,
-    mock_transfer_components_executor: TransferComponentsExecutor,
-    mock_protocol_core: ProtocolCore,
-    version: APIVersion,
-) -> None:
-    """It should execute steps required for LPD."""
-    source_well = decoy.mock(cls=WellCore)
-    source_location = Location(Point(1, 2, 3), labware=None)
-    liquid_probe_start_point = Point(3, 2, 1)
-
-    test_liquid_class = LiquidClass.create(minimal_liquid_class_def2)
-    test_transfer_properties = test_liquid_class.get_for(
-        "flex_1channel_50", "opentrons_flex_96_tiprack_50ul"
-    )
-    decoy.when(source_well.labware_id).then_return("source-labware-id")
-    decoy.when(source_well.get_name()).then_return("source-well")
-    decoy.when(source_well.get_top(2)).then_return(liquid_probe_start_point)
-    decoy.when(
-        mock_engine_client.state.geometry.get_relative_well_location(
-            labware_id="source-labware-id",
-            well_name="source-well",
-            absolute_point=liquid_probe_start_point,
-            location_type=WellLocationFunction.LIQUID_HANDLING,
-        )
-    ).then_return((LiquidHandlingWellLocation(origin=WellOrigin.BOTTOM), True))
-    decoy.when(
-        transfer_components_executor.absolute_point_from_position_reference_and_offset(
-            well=source_well,
-            well_volume_difference=-123,
-            position_reference=PositionReference.WELL_BOTTOM,
-            offset=Coordinate(x=0, y=0, z=-5),
-            mount=Mount.LEFT,
-        )
-    ).then_return(Point(1, 2, 3))
-    decoy.when(
-        transfer_components_executor.TransferComponentsExecutor(
-            instrument_core=subject,
-            transfer_properties=test_transfer_properties,
-            target_location=Location(Point(1, 2, 3), labware=None),
-            target_well=source_well,
-            tip_state=TipState(),
-            transfer_type=TransferType.ONE_TO_ONE,
-        )
-    ).then_return(mock_transfer_components_executor)
-    decoy.when(
-        mock_transfer_components_executor.tip_state.last_liquid_and_air_gap_in_tip
-    ).then_return(LiquidAndAirGapPair(liquid=111, air_gap=222))
-    decoy.when(mock_protocol_core.api_version).then_return(version)
-    subject.aspirate_liquid_class(
-        volume=123,
-        source=(source_location, source_well),
-        transfer_properties=test_transfer_properties,
-        transfer_type=TransferType.ONE_TO_ONE,
-        tip_contents=[],
-        volume_for_pipette_mode_configuration=123,
-    )
-    decoy.verify(
-        mock_engine_client.execute_command(params=matchers.IsA(cmd.LiquidProbeParams)),
-        times=0,
-    )
 
 
 def test_aspirate_liquid_class_for_consolidate(
@@ -3034,13 +2855,3 @@ def test_get_next_tip_raises_for_starting_tip_with_partial_config(
             tip_racks=tip_racks,
             starting_well=mock_starting_well,
         )
-
-
-def test_lpd_for_transfer_context_manager(
-    subject: InstrumentCore,
-) -> None:
-    """It should update LPD state according to context."""
-    assert subject.get_liquid_presence_detection() is False
-    with subject.lpd_for_transfer(enable=True):
-        assert subject.get_liquid_presence_detection() is True
-    assert subject.get_liquid_presence_detection() is False

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -2525,7 +2525,12 @@ def test_transfer_liquid_multi_channel_delegates_to_engine_core(
     decoy.when(mock_instrument_core.get_nozzle_map()).then_return(mock_nozzle_map)
     decoy.when(
         mock_tx_liquid_utils.group_wells_for_multi_channel_transfer(
-            [mock_well, mock_well], mock_nozzle_map
+            [mock_well, mock_well], mock_nozzle_map, "source"
+        )
+    ).then_return([mock_well])
+    decoy.when(
+        mock_tx_liquid_utils.group_wells_for_multi_channel_transfer(
+            [mock_well, mock_well], mock_nozzle_map, "destination"
         )
     ).then_return([mock_well])
 
@@ -2862,12 +2867,12 @@ def test_distribute_liquid_multi_channel_delegates_to_engine_core(
     decoy.when(mock_instrument_core.get_nozzle_map()).then_return(mock_nozzle_map)
     decoy.when(
         mock_tx_liquid_utils.group_wells_for_multi_channel_transfer(
-            [mock_well, mock_well, mock_well], mock_nozzle_map
+            [mock_well, mock_well, mock_well], mock_nozzle_map, "source"
         )
     ).then_return([mock_well])
     decoy.when(
         mock_tx_liquid_utils.group_wells_for_multi_channel_transfer(
-            [mock_well, mock_well], mock_nozzle_map
+            [mock_well, mock_well], mock_nozzle_map, "destination"
         )
     ).then_return([mock_well, mock_well])
 
@@ -3149,14 +3154,14 @@ def test_consolidate_liquid_multi_channel_delegates_to_engine_core(
     decoy.when(mock_instrument_core.get_nozzle_map()).then_return(mock_nozzle_map)
     decoy.when(
         mock_tx_liquid_utils.group_wells_for_multi_channel_transfer(
-            [mock_well, mock_well, mock_well], mock_nozzle_map
-        )
-    ).then_return([mock_well])
-    decoy.when(
-        mock_tx_liquid_utils.group_wells_for_multi_channel_transfer(
-            [mock_well, mock_well], mock_nozzle_map
+            [mock_well, mock_well], mock_nozzle_map, "source"
         )
     ).then_return([mock_well, mock_well])
+    decoy.when(
+        mock_tx_liquid_utils.group_wells_for_multi_channel_transfer(
+            [mock_well, mock_well, mock_well], mock_nozzle_map, "destination"
+        )
+    ).then_return([mock_well])
 
     decoy.when(mock_instrument_core.get_active_channels()).then_return(2)
     decoy.when(mock_instrument_core.get_current_volume()).then_return(0)

--- a/api/tests/opentrons/protocol_api_integration/test_transfer_with_liquid_classes.py
+++ b/api/tests/opentrons/protocol_api_integration/test_transfer_with_liquid_classes.py
@@ -913,7 +913,7 @@ def test_order_of_water_consolidate_steps_larger_volume_than_tip(
 @pytest.mark.parametrize(
     "simulated_protocol_context", [("2.24", "Flex")], indirect=True
 )
-def test_order_of_water_consolidate_steps_larger_volume_than_tip_with_lpd_and_new_tip_always(
+def test_order_of_water_consolidate_steps_larger_volume_than_tip_with_new_tip_always(
     simulated_protocol_context: ProtocolContext,
 ) -> None:
     """It should pick up new tips & probe liquid before every group of aspirates."""
@@ -966,11 +966,6 @@ def test_order_of_water_consolidate_steps_larger_volume_than_tip_with_lpd_and_ne
             side_effect=InstrumentCore.drop_tip_in_disposal_location,
             autospec=True,
         ) as patched_drop_tip,
-        mock.patch.object(
-            InstrumentCore,
-            "liquid_probe_with_recovery",
-            autospec=True,
-        ) as patched_liquid_probe,
     ):
         mock_manager = mock.Mock()
         mock_manager.attach_mock(patched_pick_up_tip, "pick_up_tip")
@@ -978,7 +973,6 @@ def test_order_of_water_consolidate_steps_larger_volume_than_tip_with_lpd_and_ne
         mock_manager.attach_mock(patched_aspirate, "aspirate_liquid_class")
         mock_manager.attach_mock(patched_dispense, "dispense_liquid_class")
         mock_manager.attach_mock(patched_drop_tip, "drop_tip_in_disposal_location")
-        mock_manager.attach_mock(patched_liquid_probe, "liquid_probe_with_recovery")
         pipette_50.consolidate_with_liquid_class(
             liquid_class=water,
             volume=30,
@@ -1010,11 +1004,6 @@ def test_order_of_water_consolidate_steps_larger_volume_than_tip_with_lpd_and_ne
                 tip_contents=[LiquidAndAirGapPair(liquid=0, air_gap=0)],
                 volume_for_pipette_mode_configuration=30.0,
                 current_volume=0.0,
-            ),
-            mock.call.liquid_probe_with_recovery(  # Called as part of aspirate_liquid_class
-                mock.ANY,
-                well_core=mock.ANY,
-                loc=mock.ANY,
             ),
             mock.call.dispense_liquid_class(
                 mock.ANY,
@@ -1049,11 +1038,6 @@ def test_order_of_water_consolidate_steps_larger_volume_than_tip_with_lpd_and_ne
                 tip_contents=[LiquidAndAirGapPair(liquid=0, air_gap=0)],
                 volume_for_pipette_mode_configuration=30.0,
                 current_volume=0.0,
-            ),
-            mock.call.liquid_probe_with_recovery(  # Called as part of aspirate_liquid_class
-                mock.ANY,
-                well_core=mock.ANY,
-                loc=mock.ANY,
             ),
             mock.call.dispense_liquid_class(
                 mock.ANY,
@@ -2032,16 +2016,10 @@ def test_water_distribution_raises_error_for_disposal_vol_without_blowout(
 @pytest.mark.parametrize(
     "simulated_protocol_context", [("2.24", "Flex")], indirect=True
 )
-@pytest.mark.parametrize(
-    ["new_tip", "expected_number_of_calls"],
-    [("once", 1), ("always", 12), ("per source", 12)],
-)
-def test_water_transfer_with_lpd(
+def test_transfers_do_not_perform_lpd(
     simulated_protocol_context: ProtocolContext,
-    new_tip: TransferTipPolicyV2Type,
-    expected_number_of_calls: int,
 ) -> None:
-    """It should send a single liquid probing command for each source well."""
+    """It should not do any liquid probing for LC-based transfer/ consolidate/ distribute."""
     trash = simulated_protocol_context.load_trash_bin("A3")
     tiprack = simulated_protocol_context.load_labware(
         "opentrons_flex_96_tiprack_1000ul", "D1"
@@ -2074,182 +2052,26 @@ def test_water_transfer_with_lpd(
             volume=1100,
             source=nest_plate.rows()[0],
             dest=arma_plate.rows()[0],
-            new_tip=new_tip,
-            trash_location=trash,
-        )
-        assert patched_liquid_probe.call_count == expected_number_of_calls
-
-
-@pytest.mark.ot3_only
-@pytest.mark.parametrize(
-    "simulated_protocol_context", [("2.24", "Flex")], indirect=True
-)
-@pytest.mark.parametrize(
-    "new_tip",
-    ["once", "always", "per source"],
-)
-def test_water_transfer_does_lpd_only_once_for_a_source_well(
-    simulated_protocol_context: ProtocolContext,
-    new_tip: TransferTipPolicyV2Type,
-) -> None:
-    """It should send a single liquid probing command for the source well."""
-    trash = simulated_protocol_context.load_trash_bin("A3")
-    tiprack = simulated_protocol_context.load_labware(
-        "opentrons_flex_96_tiprack_1000ul", "D1"
-    )
-    pipette_1k = simulated_protocol_context.load_instrument(
-        "flex_1channel_1000",
-        mount="left",
-        tip_racks=[tiprack],
-        liquid_presence_detection=True,
-    )
-    nest_plate = simulated_protocol_context.load_labware(
-        "nest_96_wellplate_200ul_flat", "C3"
-    )
-    arma_plate = simulated_protocol_context.load_labware(
-        "armadillo_96_wellplate_200ul_pcr_full_skirt", "C2"
-    )
-    water = simulated_protocol_context.get_liquid_class("water")
-
-    with (
-        mock.patch.object(
-            InstrumentCore,
-            "liquid_probe_with_recovery",
-            autospec=True,
-        ) as patched_liquid_probe
-    ):
-        mock_manager = mock.Mock()
-        mock_manager.attach_mock(patched_liquid_probe, "liquid_probe_with_recovery")
-        pipette_1k.transfer_with_liquid_class(
-            liquid_class=water,
-            volume=1100,
-            source=[nest_plate.wells_by_name()["A1"] for _ in range(3)],
-            dest=arma_plate.rows()[0][:3],
-            new_tip=new_tip,
-            trash_location=trash,
-        )
-        assert patched_liquid_probe.call_count == 1
-
-
-@pytest.mark.ot3_only
-@pytest.mark.parametrize(
-    "simulated_protocol_context", [("2.24", "Flex")], indirect=True
-)
-@pytest.mark.parametrize("new_tip", ["once", "always"])
-def test_water_distribution_with_lpd(
-    simulated_protocol_context: ProtocolContext,
-    new_tip: TransferTipPolicyV2Type,
-) -> None:
-    """It should send a single liquid probing command for the source well."""
-    trash = simulated_protocol_context.load_trash_bin("A3")
-    tiprack = simulated_protocol_context.load_labware(
-        "opentrons_flex_96_tiprack_1000ul", "D1"
-    )
-    pipette_1k = simulated_protocol_context.load_instrument(
-        "flex_1channel_1000",
-        mount="left",
-        tip_racks=[tiprack],
-        liquid_presence_detection=True,
-    )
-    nest_plate = simulated_protocol_context.load_labware(
-        "nest_96_wellplate_200ul_flat", "C3"
-    )
-    arma_plate = simulated_protocol_context.load_labware(
-        "armadillo_96_wellplate_200ul_pcr_full_skirt", "C2"
-    )
-
-    water = simulated_protocol_context.get_liquid_class("water")
-    water_props = water.get_for(pipette_1k, tiprack)
-    assert water_props.multi_dispense is not None
-    water_props.multi_dispense.retract.blowout.location = "destination"  # type: ignore[assignment]
-    water_props.multi_dispense.retract.blowout.flow_rate = pipette_1k.flow_rate.blow_out
-    water_props.multi_dispense.retract.blowout.enabled = True
-
-    with (
-        mock.patch.object(
-            InstrumentCore,
-            "liquid_probe_with_recovery",
-            autospec=True,
-        ) as patched_liquid_probe
-    ):
-        mock_manager = mock.Mock()
-        mock_manager.attach_mock(patched_liquid_probe, "liquid_probe_with_recovery")
-        pipette_1k.distribute_with_liquid_class(
-            liquid_class=water,
-            volume=40,
-            source=nest_plate.rows()[0][1],
-            dest=arma_plate.rows()[0],
-            new_tip=new_tip,
-            trash_location=trash,
-        )
-        patched_liquid_probe.assert_called_once()
-
-
-@pytest.mark.ot3_only
-@pytest.mark.parametrize(
-    "simulated_protocol_context", [("2.24", "Flex")], indirect=True
-)
-def test_incompatible_transfers_skip_probing_even_with_lpd_on(
-    simulated_protocol_context: ProtocolContext,
-) -> None:
-    """It should not send a liquid probing command."""
-    trash = simulated_protocol_context.load_trash_bin("A3")
-    tiprack = simulated_protocol_context.load_labware(
-        "opentrons_flex_96_tiprack_1000ul", "D1"
-    )
-    pipette_1k = simulated_protocol_context.load_instrument(
-        "flex_1channel_1000",
-        mount="left",
-        tip_racks=[tiprack],
-        liquid_presence_detection=True,
-    )
-    nest_plate = simulated_protocol_context.load_labware(
-        "nest_96_wellplate_200ul_flat", "C3"
-    )
-    arma_plate = simulated_protocol_context.load_labware(
-        "armadillo_96_wellplate_200ul_pcr_full_skirt", "C2"
-    )
-
-    water = simulated_protocol_context.get_liquid_class("water")
-    water_props = water.get_for(pipette_1k, tiprack)
-    assert water_props.multi_dispense is not None
-    water_props.multi_dispense.retract.blowout.location = "destination"  # type: ignore[assignment]
-    water_props.multi_dispense.retract.blowout.flow_rate = pipette_1k.flow_rate.blow_out
-    water_props.multi_dispense.retract.blowout.enabled = True
-    pipette_1k.pick_up_tip()
-    with (
-        mock.patch.object(
-            InstrumentCore,
-            "liquid_probe_with_recovery",
-            autospec=True,
-        ) as patched_liquid_probe,
-    ):
-        mock_manager = mock.Mock()
-        mock_manager.attach_mock(patched_liquid_probe, "liquid_probe_with_recovery")
-        pipette_1k.transfer_with_liquid_class(
-            liquid_class=water,
-            volume=40,
-            source=nest_plate.rows()[0],
-            dest=arma_plate.rows()[0],
-            new_tip="never",
-            trash_location=trash,
-        )
-        pipette_1k.distribute_with_liquid_class(
-            liquid_class=water,
-            volume=40,
-            source=nest_plate.rows()[0][1],
-            dest=arma_plate.rows()[0][:3],
-            new_tip="never",
+            new_tip="always",
             trash_location=trash,
         )
         pipette_1k.consolidate_with_liquid_class(
             liquid_class=water,
-            volume=40,
+            volume=100,
             source=nest_plate.rows()[0],
             dest=arma_plate.rows()[0][0],
-            new_tip="never",
+            new_tip="always",
             trash_location=trash,
         )
+        pipette_1k.distribute_with_liquid_class(
+            liquid_class=water,
+            volume=100,
+            source=nest_plate.rows()[0][0],
+            dest=arma_plate.rows()[0],
+            new_tip="always",
+            trash_location=trash,
+        )
+        assert patched_liquid_probe.call_count == 0
 
 
 @pytest.mark.ot3_only

--- a/api/tests/opentrons/protocols/advanced_control/transfers/test_transfer_liquid_utils.py
+++ b/api/tests/opentrons/protocols/advanced_control/transfers/test_transfer_liquid_utils.py
@@ -263,7 +263,7 @@ def test_grouping_wells_for_column_96_plate(
         decoy.when(mock_well.well_name).then_return(well_name)
         decoy.when(mock_well.parent).then_return(mock_96_well_labware)
 
-    wells = group_wells_for_multi_channel_transfer(mock_wells, nozzle_map)
+    wells = group_wells_for_multi_channel_transfer(mock_wells, nozzle_map, "source")
     assert len(wells) == 2
     assert wells[0].well_name == "A1"
     assert wells[1].well_name == "A2"
@@ -283,7 +283,7 @@ def test_grouping_wells_for_column_384_plate(
         decoy.when(mock_well.well_name).then_return(well_name)
         decoy.when(mock_well.parent).then_return(mock_384_well_labware)
 
-    wells = group_wells_for_multi_channel_transfer(mock_wells, nozzle_map)
+    wells = group_wells_for_multi_channel_transfer(mock_wells, nozzle_map, "source")
     assert len(wells) == 4
     assert wells[0].well_name == "A1"
     assert wells[1].well_name == "B1"
@@ -306,13 +306,13 @@ def test_grouping_wells_for_column_96_plate_raises(
         decoy.when(mock_well.parent).then_return(mock_96_well_labware)
 
     # leftover wells
-    with pytest.raises(ValueError, match="Could not target all wells"):
-        group_wells_for_multi_channel_transfer(mock_wells, nozzle_map)
+    with pytest.raises(ValueError, match="Pipette will access source wells"):
+        group_wells_for_multi_channel_transfer(mock_wells, nozzle_map, "source")
 
     # non-contiguous wells from the same labware
-    with pytest.raises(ValueError, match="Could not resolve wells"):
+    with pytest.raises(ValueError, match="Could not group source wells"):
         group_wells_for_multi_channel_transfer(
-            mock_wells[:7] + [mock_wells[-1], mock_wells[7]], nozzle_map
+            mock_wells[:7] + [mock_wells[-1], mock_wells[7]], nozzle_map, "source"
         )
 
     other_labware = decoy.mock(cls=Labware)
@@ -322,9 +322,9 @@ def test_grouping_wells_for_column_96_plate_raises(
     decoy.when(other_well.parent).then_return(other_labware)
 
     # non-contiguous wells from different labware, well name is correct though
-    with pytest.raises(ValueError, match="Could not resolve wells"):
+    with pytest.raises(ValueError, match="Could not group source wells"):
         group_wells_for_multi_channel_transfer(
-            mock_wells[:7] + [other_well], nozzle_map
+            mock_wells[:7] + [other_well], nozzle_map, "source"
         )
 
 
@@ -343,16 +343,18 @@ def test_grouping_wells_for_column_384_plate_raises(
         decoy.when(mock_well.parent).then_return(mock_384_well_labware)
 
     # leftover wells
-    with pytest.raises(ValueError, match="Could not target all wells"):
-        group_wells_for_multi_channel_transfer(mock_wells[:-1], nozzle_map)
+    with pytest.raises(ValueError, match="Pipette will access destination wells"):
+        group_wells_for_multi_channel_transfer(
+            mock_wells[:-1], nozzle_map, "destination"
+        )
 
     # non-contiguous or every other wells from the same labware
-    with pytest.raises(ValueError, match="Could not resolve wells"):
+    with pytest.raises(ValueError, match="Could not group"):
         group_wells_for_multi_channel_transfer(
-            mock_wells[:2] + [mock_wells[-1]], nozzle_map
+            mock_wells[:2] + [mock_wells[-1]], nozzle_map, "source"
         )
         group_wells_for_multi_channel_transfer(
-            mock_wells[:-1] + [mock_wells[0]], nozzle_map
+            mock_wells[:-1] + [mock_wells[0]], nozzle_map, "destination"
         )
 
     other_labware = decoy.mock(cls=Labware)
@@ -362,9 +364,9 @@ def test_grouping_wells_for_column_384_plate_raises(
     decoy.when(other_well.parent).then_return(other_labware)
 
     # non-contiguous wells from different labware, well name is correct though
-    with pytest.raises(ValueError, match="Could not resolve wells"):
+    with pytest.raises(ValueError, match="Could not group source wells"):
         group_wells_for_multi_channel_transfer(
-            mock_wells[:15] + [other_well], nozzle_map
+            mock_wells[:15] + [other_well], nozzle_map, "source"
         )
 
 
@@ -383,7 +385,9 @@ def test_grouping_wells_for_row_96_plate(
         decoy.when(mock_well.well_name).then_return(well_name)
         decoy.when(mock_well.parent).then_return(mock_96_well_labware)
 
-    wells = group_wells_for_multi_channel_transfer(mock_wells, nozzle_map)
+    wells = group_wells_for_multi_channel_transfer(
+        mock_wells, nozzle_map, "destination"
+    )
     assert len(wells) == 2
     assert wells[0].well_name == "A1"
     assert wells[1].well_name == "B1"
@@ -404,7 +408,7 @@ def test_grouping_wells_for_row_384_plate(
         decoy.when(mock_well.well_name).then_return(well_name)
         decoy.when(mock_well.parent).then_return(mock_384_well_labware)
 
-    wells = group_wells_for_multi_channel_transfer(mock_wells, nozzle_map)
+    wells = group_wells_for_multi_channel_transfer(mock_wells, nozzle_map, "source")
     assert len(wells) == 4
     assert wells[0].well_name == "A1"
     assert wells[1].well_name == "A2"
@@ -428,13 +432,13 @@ def test_grouping_wells_for_row_96_plate_raises(
         decoy.when(mock_well.parent).then_return(mock_96_well_labware)
 
     # leftover wells
-    with pytest.raises(ValueError, match="Could not target all wells"):
-        group_wells_for_multi_channel_transfer(mock_wells[:-1], nozzle_map)
+    with pytest.raises(ValueError, match="Pipette will access source wells"):
+        group_wells_for_multi_channel_transfer(mock_wells[:-1], nozzle_map, "source")
 
     # non-contiguous wells from the same labware
-    with pytest.raises(ValueError, match="Could not resolve wells"):
+    with pytest.raises(ValueError, match="Could not group source wells"):
         group_wells_for_multi_channel_transfer(
-            mock_wells[:11] + [mock_wells[-1], mock_wells[11]], nozzle_map
+            mock_wells[:11] + [mock_wells[-1], mock_wells[11]], nozzle_map, "source"
         )
 
     other_labware = decoy.mock(cls=Labware)
@@ -444,9 +448,9 @@ def test_grouping_wells_for_row_96_plate_raises(
     decoy.when(other_well.parent).then_return(other_labware)
 
     # non-contiguous wells from different labware, well name is correct though
-    with pytest.raises(ValueError, match="Could not resolve wells"):
+    with pytest.raises(ValueError, match="Could not group destination wells"):
         group_wells_for_multi_channel_transfer(
-            mock_wells[:11] + [other_well], nozzle_map
+            mock_wells[:11] + [other_well], nozzle_map, "destination"
         )
 
 
@@ -466,16 +470,18 @@ def test_grouping_wells_for_row_384_plate_raises(
         decoy.when(mock_well.parent).then_return(mock_384_well_labware)
 
     # leftover wells
-    with pytest.raises(ValueError, match="Could not target all wells"):
-        group_wells_for_multi_channel_transfer(mock_wells[:-1], nozzle_map)
+    with pytest.raises(ValueError, match="Pipette will access destination wells"):
+        group_wells_for_multi_channel_transfer(
+            mock_wells[:-1], nozzle_map, "destination"
+        )
 
     # non-contiguous or every other wells from the same labware
-    with pytest.raises(ValueError, match="Could not resolve wells"):
+    with pytest.raises(ValueError, match="Could not group"):
         group_wells_for_multi_channel_transfer(
-            mock_wells[:2] + [mock_wells[-1]], nozzle_map
+            mock_wells[:2] + [mock_wells[-1]], nozzle_map, "destination"
         )
         group_wells_for_multi_channel_transfer(
-            mock_wells[:-1] + [mock_wells[0]], nozzle_map
+            mock_wells[:-1] + [mock_wells[0]], nozzle_map, "source"
         )
 
     other_labware = decoy.mock(cls=Labware)
@@ -485,9 +491,9 @@ def test_grouping_wells_for_row_384_plate_raises(
     decoy.when(other_well.parent).then_return(other_labware)
 
     # non-contiguous wells from different labware, well name is correct though
-    with pytest.raises(ValueError, match="Could not resolve wells"):
+    with pytest.raises(ValueError, match="Could not group destination wells"):
         group_wells_for_multi_channel_transfer(
-            mock_wells[:23] + [other_well], nozzle_map
+            mock_wells[:23] + [other_well], nozzle_map, "destination"
         )
 
 
@@ -500,7 +506,9 @@ def test_grouping_wells_for_full_96_plate(
         decoy.when(mock_well.well_name).then_return(well_name)
         decoy.when(mock_well.parent).then_return(mock_96_well_labware)
 
-    wells = group_wells_for_multi_channel_transfer(mock_wells, _96_FULL_MAP)
+    wells = group_wells_for_multi_channel_transfer(
+        mock_wells, _96_FULL_MAP, "destination"
+    )
     assert len(wells) == 1
     assert wells[0].well_name == "A1"
 
@@ -515,7 +523,7 @@ def test_grouping_wells_for_full_384_plate(
         decoy.when(mock_well.well_name).then_return(well_name)
         decoy.when(mock_well.parent).then_return(mock_384_well_labware)
 
-    wells = group_wells_for_multi_channel_transfer(mock_wells, _96_FULL_MAP)
+    wells = group_wells_for_multi_channel_transfer(mock_wells, _96_FULL_MAP, "source")
     assert len(wells) == 4
     assert wells[0].well_name == "A1"
     assert wells[1].well_name == "B1"
@@ -534,8 +542,8 @@ def test_grouping_wells_raises_for_unsupported_configuration() -> None:
         front_right_nozzle="D1",
         valid_nozzle_maps=ValidNozzleMaps(maps={"Half": ["A1", "B1", "C1", "D1"]}),
     )
-    with pytest.raises(ValueError, match="Unsupported tip configuration"):
-        group_wells_for_multi_channel_transfer([], nozzle_map)
+    with pytest.raises(ValueError, match="Unsupported nozzle configuration"):
+        group_wells_for_multi_channel_transfer([], nozzle_map, "source")
 
 
 @pytest.mark.parametrize(
@@ -561,5 +569,5 @@ def test_grouping_well_returns_all_wells_for_non_96_or_384_plate(
         decoy.when(mock_well.well_name).then_return(well_name)
         decoy.when(mock_well.parent).then_return(mock_reservoir)
 
-    result = group_wells_for_multi_channel_transfer(mock_wells, nozzle_map)
+    result = group_wells_for_multi_channel_transfer(mock_wells, nozzle_map, "source")
     assert result == mock_wells

--- a/app-shell/build/release-notes.md
+++ b/app-shell/build/release-notes.md
@@ -10,7 +10,16 @@ By installing and using Opentrons software, you agree to the Opentrons End-User 
 
 ## Opentrons App Changes in 8.5.0
 
-### TODO
+Welcome to the v8.5.0 release of the Opentrons App! This release features the ability to run protocols that use liquid classes to improve pipetting accuracy.
+
+### New Features
+
+- The app now supports running protocols that use liquid class features in the Python API, including Opentrons-verified and custom liquid class definitions.
+
+### Bug Fixes
+
+- Fixes errors (code 422) when performing Labware Position Check on an OT-2.
+- Error recovery now provides the correct options when a blowout causes an overpressure error.
 
 ---
 

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useFailedLabwareUtils.test.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useFailedLabwareUtils.test.tsx
@@ -342,6 +342,61 @@ describe('getFailedCmdRelevantLabware', () => {
   })
 })
 
+describe('getRelevantPickUpTipCommand', () => {
+  it('should return null when failedCommandByRunRecord does not have pipetteId in params', () => {
+    const failedCommand = {
+      commandType: 'dispenseInPlace',
+      params: {
+        wellName: 'A1',
+      },
+    } as any
+
+    const runCommands = {
+      data: [failedCommand],
+    } as any
+
+    const result = getRelevantFailedLabwareCmdFrom({
+      failedCommand: { byRunRecord: failedCommand } as any,
+      runCommands,
+    })
+
+    expect(result).toBeNull()
+  })
+
+  it('should return pickUpTip command when failedCommandByRunRecord has pipetteId', () => {
+    const pickUpTipCommand = {
+      key: 'pickUpTipKey',
+      commandType: 'pickUpTip',
+      params: {
+        pipetteId: 'pipetteId',
+        labwareId: 'labwareId',
+        wellName: 'A1',
+      },
+    } as any
+
+    const failedCommand = {
+      key: 'failedKey',
+      commandType: 'dispenseInPlace',
+      params: {
+        pipetteId: 'pipetteId',
+        labwareId: 'labwareId',
+      },
+      error: { isDefined: true, errorType: DEFINED_ERROR_TYPES.OVERPRESSURE },
+    } as any
+
+    const runCommands = {
+      data: [pickUpTipCommand, failedCommand],
+    } as any
+
+    const result = getRelevantFailedLabwareCmdFrom({
+      failedCommand: { byRunRecord: failedCommand } as any,
+      runCommands,
+    })
+
+    expect(result).toBe(pickUpTipCommand)
+  })
+})
+
 describe('useFailedLabwareUtils', () => {
   const mockPickUpTipCommand = {
     key: 'pickUpTipKey',

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useFailedLabwareUtils.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useFailedLabwareUtils.ts
@@ -214,7 +214,6 @@ function getRelevantPickUpTipCommand(
   if (
     failedCommandByRunRecord == null ||
     runCommands == null ||
-    !('wellName' in failedCommandByRunRecord.params) ||
     !('pipetteId' in failedCommandByRunRecord.params)
   ) {
     return null

--- a/shared-data/labware/definitions/2/ev_resin_tips_flex_96_labware/1.json
+++ b/shared-data/labware/definitions/2/ev_resin_tips_flex_96_labware/1.json
@@ -14,7 +14,7 @@
     ["A12", "B12", "C12", "D12", "E12", "F12", "G12", "H12"]
   ],
   "brand": {
-    "brand": "opentrons",
+    "brand": "Opentrons",
     "brandId": ["999-00254"],
     "links": [
       "https://opentrons.com/products/opentrons-flex-adapter-set-for-3rd-party-evotips/"

--- a/shared-data/labware/definitions/2/ibidi_96_square_well_plate_300ul/1.json
+++ b/shared-data/labware/definitions/2/ibidi_96_square_well_plate_300ul/1.json
@@ -1,5 +1,5 @@
 {
-  "brand": { "brand": "ibidi ", "brandId": ["89626", "89621"] },
+  "brand": { "brand": "ibidi", "brandId": ["89626", "89621"] },
   "wells": {
     "A1": {
       "x": 14.38,

--- a/shared-data/liquid-class/definitions/1/ethanol_80/1.json
+++ b/shared-data/liquid-class/definitions/1/ethanol_80/1.json
@@ -130,7 +130,7 @@
                 "enable": false,
                 "params": {
                   "location": "destination",
-                  "flowRate": 125.0
+                  "flowRate": 7.0
                 }
               },
               "touchTip": {
@@ -174,7 +174,7 @@
             "delay": {
               "enable": true,
               "params": {
-                "duration": 2.0
+                "duration": 0.2
               }
             }
           },
@@ -215,7 +215,7 @@
                 "enable": true,
                 "params": {
                   "location": "trash",
-                  "flowRate": 125.0
+                  "flowRate": 7.0
                 }
               },
               "touchTip": {
@@ -241,7 +241,7 @@
                 "z": 2
               }
             },
-            "flowRateByVolume": [[0.0, 30.0]],
+            "flowRateByVolume": [[0.0, 7.0]],
             "correctionByVolume": [
               [0.0, 0.0],
               [1.0, -1.6],
@@ -263,7 +263,7 @@
             "delay": {
               "enable": true,
               "params": {
-                "duration": 2.0
+                "duration": 0.2
               }
             }
           }
@@ -389,7 +389,7 @@
                 "enable": false,
                 "params": {
                   "location": "destination",
-                  "flowRate": 125.0
+                  "flowRate": 7.0
                 }
               },
               "touchTip": {
@@ -433,7 +433,7 @@
             "delay": {
               "enable": true,
               "params": {
-                "duration": 2.0
+                "duration": 0.2
               }
             }
           },
@@ -474,7 +474,7 @@
                 "enable": true,
                 "params": {
                   "location": "trash",
-                  "flowRate": 125.0
+                  "flowRate": 7.0
                 }
               },
               "touchTip": {
@@ -500,7 +500,7 @@
                 "z": 2
               }
             },
-            "flowRateByVolume": [[0.0, 30.0]],
+            "flowRateByVolume": [[0.0, 7.0]],
             "correctionByVolume": [
               [0.0, 0.0],
               [1.0, -1.6],
@@ -522,7 +522,7 @@
             "delay": {
               "enable": true,
               "params": {
-                "duration": 2.0
+                "duration": 0.2
               }
             }
           }
@@ -653,7 +653,7 @@
                 "enable": false,
                 "params": {
                   "location": "destination",
-                  "flowRate": 125.0
+                  "flowRate": 35.0
                 }
               },
               "touchTip": {
@@ -679,7 +679,7 @@
                 "z": 2
               }
             },
-            "flowRateByVolume": [[0.0, 7.0]],
+            "flowRateByVolume": [[0.0, 35.0]],
             "correctionByVolume": [
               [0.0, 0.0],
               [1.0, -0.5],
@@ -697,7 +697,7 @@
             "delay": {
               "enable": true,
               "params": {
-                "duration": 2.0
+                "duration": 0.2
               }
             }
           },
@@ -738,7 +738,7 @@
                 "enable": true,
                 "params": {
                   "location": "trash",
-                  "flowRate": 125.0
+                  "flowRate": 35.0
                 }
               },
               "touchTip": {
@@ -764,7 +764,7 @@
                 "z": 2
               }
             },
-            "flowRateByVolume": [[0.0, 30.0]],
+            "flowRateByVolume": [[0.0, 35.0]],
             "correctionByVolume": [
               [0.0, 0.0],
               [1.0, -1.6],
@@ -786,7 +786,7 @@
             "delay": {
               "enable": true,
               "params": {
-                "duration": 2.0
+                "duration": 0.2
               }
             }
           }
@@ -912,7 +912,7 @@
                 "enable": false,
                 "params": {
                   "location": "destination",
-                  "flowRate": 125.0
+                  "flowRate": 35.0
                 }
               },
               "touchTip": {
@@ -938,7 +938,7 @@
                 "z": 2
               }
             },
-            "flowRateByVolume": [[0.0, 7.0]],
+            "flowRateByVolume": [[0.0, 35.0]],
             "correctionByVolume": [
               [0.0, 0.0],
               [1.0, -0.5],
@@ -956,7 +956,7 @@
             "delay": {
               "enable": true,
               "params": {
-                "duration": 2.0
+                "duration": 0.2
               }
             }
           },
@@ -997,7 +997,7 @@
                 "enable": true,
                 "params": {
                   "location": "trash",
-                  "flowRate": 125.0
+                  "flowRate": 35.0
                 }
               },
               "touchTip": {
@@ -1023,7 +1023,7 @@
                 "z": 2
               }
             },
-            "flowRateByVolume": [[0.0, 30.0]],
+            "flowRateByVolume": [[0.0, 35.0]],
             "correctionByVolume": [
               [0.0, 0.0],
               [1.0, -1.6],
@@ -1045,7 +1045,7 @@
             "delay": {
               "enable": true,
               "params": {
-                "duration": 2.0
+                "duration": 0.2
               }
             }
           }
@@ -1176,7 +1176,7 @@
                 "enable": false,
                 "params": {
                   "location": "destination",
-                  "flowRate": 125.0
+                  "flowRate": 100.0
                 }
               },
               "touchTip": {
@@ -1202,7 +1202,7 @@
                 "z": 2
               }
             },
-            "flowRateByVolume": [[0.0, 40.0]],
+            "flowRateByVolume": [[0.0, 100.0]],
             "correctionByVolume": [
               [0.0, 0.0],
               [5.0, -0.75],
@@ -1266,7 +1266,7 @@
                 "enable": true,
                 "params": {
                   "location": "trash",
-                  "flowRate": 125.0
+                  "flowRate": 100.0
                 }
               },
               "touchTip": {
@@ -1292,7 +1292,7 @@
                 "z": 2
               }
             },
-            "flowRateByVolume": [[0.0, 125.0]],
+            "flowRateByVolume": [[0.0, 100.0]],
             "correctionByVolume": [
               [0.0, 0.0],
               [5.0, -2.1],
@@ -1440,7 +1440,7 @@
                 "enable": false,
                 "params": {
                   "location": "destination",
-                  "flowRate": 125.0
+                  "flowRate": 100.0
                 }
               },
               "touchTip": {
@@ -1466,7 +1466,7 @@
                 "z": 2
               }
             },
-            "flowRateByVolume": [[0.0, 40.0]],
+            "flowRateByVolume": [[0.0, 100.0]],
             "correctionByVolume": [
               [0.0, 0.0],
               [5.0, -0.75],
@@ -1530,7 +1530,7 @@
                 "enable": true,
                 "params": {
                   "location": "trash",
-                  "flowRate": 125.0
+                  "flowRate": 100.0
                 }
               },
               "touchTip": {
@@ -1556,7 +1556,7 @@
                 "z": 2
               }
             },
-            "flowRateByVolume": [[0.0, 125.0]],
+            "flowRateByVolume": [[0.0, 100.0]],
             "correctionByVolume": [
               [0.0, 0.0],
               [5.0, -2.1],
@@ -1704,7 +1704,7 @@
                 "enable": false,
                 "params": {
                   "location": "destination",
-                  "flowRate": 125.0
+                  "flowRate": 100.0
                 }
               },
               "touchTip": {
@@ -1730,7 +1730,7 @@
                 "z": 2
               }
             },
-            "flowRateByVolume": [[0.0, 40.0]],
+            "flowRateByVolume": [[0.0, 100.0]],
             "correctionByVolume": [
               [0.0, 0.0],
               [5.0, -0.5],
@@ -1752,7 +1752,7 @@
             "delay": {
               "enable": true,
               "params": {
-                "duration": 2.0
+                "duration": 1.0
               }
             }
           },
@@ -1793,7 +1793,7 @@
                 "enable": true,
                 "params": {
                   "location": "trash",
-                  "flowRate": 125.0
+                  "flowRate": 100.0
                 }
               },
               "touchTip": {
@@ -1819,7 +1819,7 @@
                 "z": 2
               }
             },
-            "flowRateByVolume": [[0.0, 125.0]],
+            "flowRateByVolume": [[0.0, 100.0]],
             "correctionByVolume": [
               [0.0, 0.0],
               [5.0, -1.5],
@@ -1841,7 +1841,7 @@
             "delay": {
               "enable": true,
               "params": {
-                "duration": 2.0
+                "duration": 1.0
               }
             }
           }
@@ -1967,7 +1967,7 @@
                 "enable": false,
                 "params": {
                   "location": "destination",
-                  "flowRate": 125.0
+                  "flowRate": 100.0
                 }
               },
               "touchTip": {
@@ -1993,7 +1993,7 @@
                 "z": 2
               }
             },
-            "flowRateByVolume": [[0.0, 40.0]],
+            "flowRateByVolume": [[0.0, 100.0]],
             "correctionByVolume": [
               [0.0, 0.0],
               [5.0, -0.5],
@@ -2015,7 +2015,7 @@
             "delay": {
               "enable": true,
               "params": {
-                "duration": 2.0
+                "duration": 1.0
               }
             }
           },
@@ -2056,7 +2056,7 @@
                 "enable": true,
                 "params": {
                   "location": "trash",
-                  "flowRate": 125.0
+                  "flowRate": 100.0
                 }
               },
               "touchTip": {
@@ -2082,7 +2082,7 @@
                 "z": 2
               }
             },
-            "flowRateByVolume": [[0.0, 125.0]],
+            "flowRateByVolume": [[0.0, 100.0]],
             "correctionByVolume": [
               [0.0, 0.0],
               [5.0, -1.5],
@@ -2104,7 +2104,7 @@
             "delay": {
               "enable": true,
               "params": {
-                "duration": 2.0
+                "duration": 1.0
               }
             }
           }
@@ -2230,7 +2230,7 @@
                 "enable": false,
                 "params": {
                   "location": "destination",
-                  "flowRate": 125.0
+                  "flowRate": 300.0
                 }
               },
               "touchTip": {
@@ -2256,7 +2256,7 @@
                 "z": 2
               }
             },
-            "flowRateByVolume": [[0.0, 40.0]],
+            "flowRateByVolume": [[0.0, 300.0]],
             "correctionByVolume": [
               [0.0, 0.0],
               [10.0, -0.9],
@@ -2278,7 +2278,7 @@
             "delay": {
               "enable": true,
               "params": {
-                "duration": 2.0
+                "duration": 1.0
               }
             }
           },
@@ -2319,7 +2319,7 @@
                 "enable": true,
                 "params": {
                   "location": "trash",
-                  "flowRate": 125.0
+                  "flowRate": 300.0
                 }
               },
               "touchTip": {
@@ -2345,7 +2345,7 @@
                 "z": 2
               }
             },
-            "flowRateByVolume": [[0.0, 250.0]],
+            "flowRateByVolume": [[0.0, 300.0]],
             "correctionByVolume": [
               [0.0, 0.0],
               [10.0, -1.9],
@@ -2367,7 +2367,7 @@
             "delay": {
               "enable": true,
               "params": {
-                "duration": 2.0
+                "duration": 1.0
               }
             }
           }
@@ -2493,7 +2493,7 @@
                 "enable": false,
                 "params": {
                   "location": "destination",
-                  "flowRate": 125.0
+                  "flowRate": 300.0
                 }
               },
               "touchTip": {
@@ -2519,7 +2519,7 @@
                 "z": 2
               }
             },
-            "flowRateByVolume": [[0.0, 40.0]],
+            "flowRateByVolume": [[0.0, 300.0]],
             "correctionByVolume": [
               [0.0, 0.0],
               [10.0, -0.9],
@@ -2541,7 +2541,7 @@
             "delay": {
               "enable": true,
               "params": {
-                "duration": 2.0
+                "duration": 1.0
               }
             }
           },
@@ -2582,7 +2582,7 @@
                 "enable": true,
                 "params": {
                   "location": "trash",
-                  "flowRate": 125.0
+                  "flowRate": 300.0
                 }
               },
               "touchTip": {
@@ -2608,7 +2608,7 @@
                 "z": 2
               }
             },
-            "flowRateByVolume": [[0.0, 250.0]],
+            "flowRateByVolume": [[0.0, 300.0]],
             "correctionByVolume": [
               [0.0, 0.0],
               [10.0, -1.9],
@@ -2630,7 +2630,7 @@
             "delay": {
               "enable": true,
               "params": {
-                "duration": 2.0
+                "duration": 1.0
               }
             }
           }
@@ -2761,7 +2761,7 @@
                 "enable": false,
                 "params": {
                   "location": "destination",
-                  "flowRate": 125.0
+                  "flowRate": 100.0
                 }
               },
               "touchTip": {
@@ -2787,7 +2787,7 @@
                 "z": 2
               }
             },
-            "flowRateByVolume": [[0.0, 40.0]],
+            "flowRateByVolume": [[0.0, 100.0]],
             "correctionByVolume": [
               [0.0, 0.0],
               [5.0, -0.75],
@@ -2851,7 +2851,7 @@
                 "enable": true,
                 "params": {
                   "location": "trash",
-                  "flowRate": 125.0
+                  "flowRate": 100.0
                 }
               },
               "touchTip": {
@@ -2877,7 +2877,7 @@
                 "z": 2
               }
             },
-            "flowRateByVolume": [[0.0, 125.0]],
+            "flowRateByVolume": [[0.0, 100.0]],
             "correctionByVolume": [
               [0.0, 0.0],
               [5.0, -2.1],
@@ -3025,7 +3025,7 @@
                 "enable": false,
                 "params": {
                   "location": "destination",
-                  "flowRate": 125.0
+                  "flowRate": 100.0
                 }
               },
               "touchTip": {
@@ -3051,7 +3051,7 @@
                 "z": 2
               }
             },
-            "flowRateByVolume": [[0.0, 40.0]],
+            "flowRateByVolume": [[0.0, 100.0]],
             "correctionByVolume": [
               [0.0, 0.0],
               [5.0, -0.75],
@@ -3115,7 +3115,7 @@
                 "enable": true,
                 "params": {
                   "location": "trash",
-                  "flowRate": 125.0
+                  "flowRate": 100.0
                 }
               },
               "touchTip": {
@@ -3141,7 +3141,7 @@
                 "z": 2
               }
             },
-            "flowRateByVolume": [[0.0, 125.0]],
+            "flowRateByVolume": [[0.0, 100.0]],
             "correctionByVolume": [
               [0.0, 0.0],
               [5.0, -2.1],
@@ -3289,7 +3289,7 @@
                 "enable": false,
                 "params": {
                   "location": "destination",
-                  "flowRate": 125.0
+                  "flowRate": 100.0
                 }
               },
               "touchTip": {
@@ -3315,7 +3315,7 @@
                 "z": 2
               }
             },
-            "flowRateByVolume": [[0.0, 40.0]],
+            "flowRateByVolume": [[0.0, 100.0]],
             "correctionByVolume": [
               [0.0, 0.0],
               [5.0, -0.5],
@@ -3337,7 +3337,7 @@
             "delay": {
               "enable": true,
               "params": {
-                "duration": 2.0
+                "duration": 1.0
               }
             }
           },
@@ -3378,7 +3378,7 @@
                 "enable": true,
                 "params": {
                   "location": "trash",
-                  "flowRate": 125.0
+                  "flowRate": 100.0
                 }
               },
               "touchTip": {
@@ -3404,7 +3404,7 @@
                 "z": 2
               }
             },
-            "flowRateByVolume": [[0.0, 125.0]],
+            "flowRateByVolume": [[0.0, 100.0]],
             "correctionByVolume": [
               [0.0, 0.0],
               [5.0, -1.5],
@@ -3426,7 +3426,7 @@
             "delay": {
               "enable": true,
               "params": {
-                "duration": 2.0
+                "duration": 1.0
               }
             }
           }
@@ -3552,7 +3552,7 @@
                 "enable": false,
                 "params": {
                   "location": "destination",
-                  "flowRate": 125.0
+                  "flowRate": 100.0
                 }
               },
               "touchTip": {
@@ -3578,7 +3578,7 @@
                 "z": 2
               }
             },
-            "flowRateByVolume": [[0.0, 40.0]],
+            "flowRateByVolume": [[0.0, 100.0]],
             "correctionByVolume": [
               [0.0, 0.0],
               [5.0, -0.5],
@@ -3600,7 +3600,7 @@
             "delay": {
               "enable": true,
               "params": {
-                "duration": 2.0
+                "duration": 1.0
               }
             }
           },
@@ -3641,7 +3641,7 @@
                 "enable": true,
                 "params": {
                   "location": "trash",
-                  "flowRate": 125.0
+                  "flowRate": 100.0
                 }
               },
               "touchTip": {
@@ -3667,7 +3667,7 @@
                 "z": 2
               }
             },
-            "flowRateByVolume": [[0.0, 125.0]],
+            "flowRateByVolume": [[0.0, 100.0]],
             "correctionByVolume": [
               [0.0, 0.0],
               [5.0, -1.5],
@@ -3689,7 +3689,7 @@
             "delay": {
               "enable": true,
               "params": {
-                "duration": 2.0
+                "duration": 1.0
               }
             }
           }
@@ -3815,7 +3815,7 @@
                 "enable": false,
                 "params": {
                   "location": "destination",
-                  "flowRate": 125.0
+                  "flowRate": 300.0
                 }
               },
               "touchTip": {
@@ -3841,7 +3841,7 @@
                 "z": 2
               }
             },
-            "flowRateByVolume": [[0.0, 40.0]],
+            "flowRateByVolume": [[0.0, 300.0]],
             "correctionByVolume": [
               [0.0, 0.0],
               [10.0, -0.9],
@@ -3863,7 +3863,7 @@
             "delay": {
               "enable": true,
               "params": {
-                "duration": 2.0
+                "duration": 1.0
               }
             }
           },
@@ -3904,7 +3904,7 @@
                 "enable": true,
                 "params": {
                   "location": "trash",
-                  "flowRate": 125.0
+                  "flowRate": 300.0
                 }
               },
               "touchTip": {
@@ -3930,7 +3930,7 @@
                 "z": 2
               }
             },
-            "flowRateByVolume": [[0.0, 250.0]],
+            "flowRateByVolume": [[0.0, 300.0]],
             "correctionByVolume": [
               [0.0, 0.0],
               [10.0, -1.9],
@@ -3952,7 +3952,7 @@
             "delay": {
               "enable": true,
               "params": {
-                "duration": 2.0
+                "duration": 1.0
               }
             }
           }
@@ -4078,7 +4078,7 @@
                 "enable": false,
                 "params": {
                   "location": "destination",
-                  "flowRate": 125.0
+                  "flowRate": 300.0
                 }
               },
               "touchTip": {
@@ -4104,7 +4104,7 @@
                 "z": 2
               }
             },
-            "flowRateByVolume": [[0.0, 40.0]],
+            "flowRateByVolume": [[0.0, 300.0]],
             "correctionByVolume": [
               [0.0, 0.0],
               [10.0, -0.9],
@@ -4126,7 +4126,7 @@
             "delay": {
               "enable": true,
               "params": {
-                "duration": 2.0
+                "duration": 1.0
               }
             }
           },
@@ -4167,7 +4167,7 @@
                 "enable": true,
                 "params": {
                   "location": "trash",
-                  "flowRate": 125.0
+                  "flowRate": 300.0
                 }
               },
               "touchTip": {
@@ -4193,7 +4193,7 @@
                 "z": 2
               }
             },
-            "flowRateByVolume": [[0.0, 250.0]],
+            "flowRateByVolume": [[0.0, 300.0]],
             "correctionByVolume": [
               [0.0, 0.0],
               [10.0, -1.9],
@@ -4215,7 +4215,7 @@
             "delay": {
               "enable": true,
               "params": {
-                "duration": 2.0
+                "duration": 1.0
               }
             }
           }
@@ -4346,7 +4346,7 @@
                 "enable": false,
                 "params": {
                   "location": "destination",
-                  "flowRate": 125.0
+                  "flowRate": 100.0
                 }
               },
               "touchTip": {
@@ -4372,7 +4372,7 @@
                 "z": 2
               }
             },
-            "flowRateByVolume": [[0.0, 40.0]],
+            "flowRateByVolume": [[0.0, 100.0]],
             "correctionByVolume": [
               [0.0, 0.0],
               [5.0, -0.35],
@@ -4436,7 +4436,7 @@
                 "enable": true,
                 "params": {
                   "location": "trash",
-                  "flowRate": 125.0
+                  "flowRate": 100.0
                 }
               },
               "touchTip": {
@@ -4462,7 +4462,7 @@
                 "z": 2
               }
             },
-            "flowRateByVolume": [[0.0, 125.0]],
+            "flowRateByVolume": [[0.0, 100.0]],
             "correctionByVolume": [
               [0.0, 0.0],
               [5.0, -2.1],
@@ -4610,7 +4610,7 @@
                 "enable": false,
                 "params": {
                   "location": "destination",
-                  "flowRate": 125.0
+                  "flowRate": 100.0
                 }
               },
               "touchTip": {
@@ -4636,7 +4636,7 @@
                 "z": 2
               }
             },
-            "flowRateByVolume": [[0.0, 40.0]],
+            "flowRateByVolume": [[0.0, 100.0]],
             "correctionByVolume": [
               [0.0, 0.0],
               [5.0, -0.35],
@@ -4700,7 +4700,7 @@
                 "enable": true,
                 "params": {
                   "location": "trash",
-                  "flowRate": 125.0
+                  "flowRate": 100.0
                 }
               },
               "touchTip": {
@@ -4726,7 +4726,7 @@
                 "z": 2
               }
             },
-            "flowRateByVolume": [[0.0, 125.0]],
+            "flowRateByVolume": [[0.0, 100.0]],
             "correctionByVolume": [
               [0.0, 0.0],
               [5.0, -2.1],
@@ -4874,7 +4874,7 @@
                 "enable": false,
                 "params": {
                   "location": "destination",
-                  "flowRate": 125.0
+                  "flowRate": 100.0
                 }
               },
               "touchTip": {
@@ -4900,7 +4900,7 @@
                 "z": 2
               }
             },
-            "flowRateByVolume": [[0.0, 40.0]],
+            "flowRateByVolume": [[0.0, 100.0]],
             "correctionByVolume": [
               [0.0, 0.0],
               [5.0, -0.25],
@@ -4922,7 +4922,7 @@
             "delay": {
               "enable": true,
               "params": {
-                "duration": 2.0
+                "duration": 1.0
               }
             }
           },
@@ -4963,7 +4963,7 @@
                 "enable": true,
                 "params": {
                   "location": "trash",
-                  "flowRate": 125.0
+                  "flowRate": 100.0
                 }
               },
               "touchTip": {
@@ -4989,7 +4989,7 @@
                 "z": 2
               }
             },
-            "flowRateByVolume": [[0.0, 125.0]],
+            "flowRateByVolume": [[0.0, 100.0]],
             "correctionByVolume": [
               [0.0, 0.0],
               [5.0, -1.5],
@@ -5011,7 +5011,7 @@
             "delay": {
               "enable": true,
               "params": {
-                "duration": 2.0
+                "duration": 1.0
               }
             }
           }
@@ -5137,7 +5137,7 @@
                 "enable": false,
                 "params": {
                   "location": "destination",
-                  "flowRate": 125.0
+                  "flowRate": 100.0
                 }
               },
               "touchTip": {
@@ -5163,7 +5163,7 @@
                 "z": 2
               }
             },
-            "flowRateByVolume": [[0.0, 40.0]],
+            "flowRateByVolume": [[0.0, 100.0]],
             "correctionByVolume": [
               [0.0, 0.0],
               [5.0, -0.25],
@@ -5185,7 +5185,7 @@
             "delay": {
               "enable": true,
               "params": {
-                "duration": 2.0
+                "duration": 1.0
               }
             }
           },
@@ -5226,7 +5226,7 @@
                 "enable": true,
                 "params": {
                   "location": "trash",
-                  "flowRate": 125.0
+                  "flowRate": 100.0
                 }
               },
               "touchTip": {
@@ -5252,7 +5252,7 @@
                 "z": 2
               }
             },
-            "flowRateByVolume": [[0.0, 125.0]],
+            "flowRateByVolume": [[0.0, 100.0]],
             "correctionByVolume": [
               [0.0, 0.0],
               [5.0, -1.5],
@@ -5274,7 +5274,7 @@
             "delay": {
               "enable": true,
               "params": {
-                "duration": 2.0
+                "duration": 1.0
               }
             }
           }
@@ -5400,7 +5400,7 @@
                 "enable": false,
                 "params": {
                   "location": "destination",
-                  "flowRate": 125.0
+                  "flowRate": 200.0
                 }
               },
               "touchTip": {
@@ -5426,7 +5426,7 @@
                 "z": 2
               }
             },
-            "flowRateByVolume": [[0.0, 40.0]],
+            "flowRateByVolume": [[0.0, 200.0]],
             "correctionByVolume": [
               [0.0, 0.0],
               [10.0, -0.4],
@@ -5448,7 +5448,7 @@
             "delay": {
               "enable": true,
               "params": {
-                "duration": 2.0
+                "duration": 1.0
               }
             }
           },
@@ -5489,7 +5489,7 @@
                 "enable": true,
                 "params": {
                   "location": "trash",
-                  "flowRate": 125.0
+                  "flowRate": 200.0
                 }
               },
               "touchTip": {
@@ -5537,7 +5537,7 @@
             "delay": {
               "enable": true,
               "params": {
-                "duration": 2.0
+                "duration": 1.0
               }
             }
           }
@@ -5663,7 +5663,7 @@
                 "enable": false,
                 "params": {
                   "location": "destination",
-                  "flowRate": 125.0
+                  "flowRate": 200.0
                 }
               },
               "touchTip": {
@@ -5689,7 +5689,7 @@
                 "z": 2
               }
             },
-            "flowRateByVolume": [[0.0, 40.0]],
+            "flowRateByVolume": [[0.0, 200.0]],
             "correctionByVolume": [
               [0.0, 0.0],
               [10.0, -0.4],
@@ -5711,7 +5711,7 @@
             "delay": {
               "enable": true,
               "params": {
-                "duration": 2.0
+                "duration": 1.0
               }
             }
           },
@@ -5752,7 +5752,7 @@
                 "enable": true,
                 "params": {
                   "location": "trash",
-                  "flowRate": 125.0
+                  "flowRate": 200.0
                 }
               },
               "touchTip": {
@@ -5800,7 +5800,7 @@
             "delay": {
               "enable": true,
               "params": {
-                "duration": 2.0
+                "duration": 1.0
               }
             }
           }

--- a/shared-data/liquid-class/definitions/1/glycerol_50/1.json
+++ b/shared-data/liquid-class/definitions/1/glycerol_50/1.json
@@ -5224,7 +5224,7 @@
                 "enable": true,
                 "params": {
                   "location": "trash",
-                  "flowRate": 200.0
+                  "flowRate": 250.0
                 }
               },
               "touchTip": {
@@ -5250,7 +5250,7 @@
                 "z": 2
               }
             },
-            "flowRateByVolume": [[0.0, 200.0]],
+            "flowRateByVolume": [[0.0, 250.0]],
             "correctionByVolume": [
               [0.0, 0.0],
               [10.0, -0.2],
@@ -5472,7 +5472,7 @@
                 "enable": true,
                 "params": {
                   "location": "trash",
-                  "flowRate": 200.0
+                  "flowRate": 250.0
                 }
               },
               "touchTip": {
@@ -5498,7 +5498,7 @@
                 "z": 2
               }
             },
-            "flowRateByVolume": [[0.0, 200.0]],
+            "flowRateByVolume": [[0.0, 250.0]],
             "correctionByVolume": [
               [0.0, 0.0],
               [10.0, -0.2],


### PR DESCRIPTION
This picks up the `chore_release-8.5.0` from yesterday.

Resolved conflicts in `api/tests/opentrons/protocol_api_integration/test_transfer_with_liquid_classes.py`.