### PR TITLE
feat(api): Bump Flex Stacker PAPI to 2.25 and update the stacker protocols to match.

### DIFF
--- a/abr-testing/abr_testing/protocols/test_protocols/IDT xGen 96ch.py
+++ b/abr-testing/abr_testing/protocols/test_protocols/IDT xGen 96ch.py
@@ -18,7 +18,7 @@ metadata = {
 }
 requirements = {
     "robotType": "Flex",
-    "apiLevel": "2.23",
+    "apiLevel": "2.25",
 }
 
 

--- a/abr-testing/abr_testing/protocols/test_protocols/Illumina RNA all parts.py
+++ b/abr-testing/abr_testing/protocols/test_protocols/Illumina RNA all parts.py
@@ -21,7 +21,7 @@ metadata = {
 }
 requirements = {
     "robotType": "Flex",
-    "apiLevel": "2.23",
+    "apiLevel": "2.25",
 }
 
 

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -1118,18 +1118,18 @@ class FlexStackerContext(ModuleContext):
     It should not be instantiated directly; instead, it should be
     created through :py:meth:`.ProtocolContext.load_module`.
 
-    .. versionadded:: 2.23
+    .. versionadded:: 2.25
     """
 
     _core: FlexStackerCore
 
     @property
-    @requires_version(2, 23)
+    @requires_version(2, 25)
     def serial_number(self) -> str:
         """Get the module's unique hardware serial number."""
         return self._core.get_serial_number()
 
-    @requires_version(2, 23)
+    @requires_version(2, 25)
     def retrieve(self) -> Labware:
         """Retrieve a labware from the Flex Stacker and place it on the shuttle.
 
@@ -1147,7 +1147,7 @@ class FlexStackerContext(ModuleContext):
             ),
         )
 
-    @requires_version(2, 23)
+    @requires_version(2, 25)
     def store(self) -> None:
         """Move the labware currently on the Flex Stacker shuttle into the Flex Stacker."""
         self._core.store()
@@ -1167,7 +1167,7 @@ class FlexStackerContext(ModuleContext):
 
         return list(_convert())
 
-    @requires_version(2, 24)
+    @requires_version(2, 25)
     def get_max_storable_labware_from_list(
         self,
         labware: list[Labware],
@@ -1203,7 +1203,7 @@ class FlexStackerContext(ModuleContext):
             ),
         )
 
-    @requires_version(2, 24)
+    @requires_version(2, 25)
     def get_current_storable_labware_from_list(
         self, labware: list[Labware]
     ) -> list[Labware]:
@@ -1224,7 +1224,7 @@ class FlexStackerContext(ModuleContext):
             )
         )
 
-    @requires_version(2, 24)
+    @requires_version(2, 25)
     def get_max_storable_labware(self) -> int:
         """Get the number of labware that the Flex Stacker can store with its current stored labware configuration.
 
@@ -1234,7 +1234,7 @@ class FlexStackerContext(ModuleContext):
         """
         return self._core.get_max_storable_labware()
 
-    @requires_version(2, 24)
+    @requires_version(2, 25)
     def get_current_storable_labware(self) -> int:
         """Get the number of labware that the Flex Stacker currently has space for.
 
@@ -1243,7 +1243,7 @@ class FlexStackerContext(ModuleContext):
         """
         return self._core.get_current_storable_labware()
 
-    @requires_version(2, 24)
+    @requires_version(2, 25)
     def set_stored_labware_items(
         self,
         labware: list[Labware],
@@ -1293,7 +1293,7 @@ class FlexStackerContext(ModuleContext):
             stacking_offset_z=stacking_offset_z,
         )
 
-    @requires_version(2, 23)
+    @requires_version(2, 25)
     def set_stored_labware(
         self,
         load_name: str,
@@ -1369,7 +1369,7 @@ class FlexStackerContext(ModuleContext):
             stacking_offset_z=stacking_offset_z,
         )
 
-    @requires_version(2, 23)
+    @requires_version(2, 25)
     def fill(self, count: int | None = None, message: str | None = None) -> None:
         """Pause the protocol to add more labware to the Flex Stacker.
 
@@ -1377,25 +1377,9 @@ class FlexStackerContext(ModuleContext):
         :param count: The amount of labware the Flex Stacker should hold after this command is executed.
                       If not specified, the Flex Stacker should be full after this command is executed.
         """
-        if self.api_version < APIVersion(2, 24):
-            # politeness: the order of the arguments changed in api 2.24. This wasn't released so it isn't
-            # a problem, but anybody using this probably would not like their protocols suddenly breaking
-            if isinstance(count, str):
-                checked_message = count
-                checked_count = message
-            elif (not isinstance(message, str)) and message is not None:
-                checked_count = message
-                checked_message = count
-            else:
-                checked_count = count
-                checked_message = message
-        else:
-            checked_count = count
-            checked_message = message
+        self._core.fill(count, message)
 
-        self._core.fill(checked_count, checked_message)
-
-    @requires_version(2, 24)
+    @requires_version(2, 25)
     def fill_items(self, labware: list[Labware], message: str | None = None) -> None:
         """Pause the protocol to add a specific list of labware to the Flex Stacker.
 
@@ -1410,7 +1394,7 @@ class FlexStackerContext(ModuleContext):
         """
         self._core.fill_items(self._labware_to_cores(labware), message)
 
-    @requires_version(2, 23)
+    @requires_version(2, 25)
     def empty(self, message: str | None = None) -> None:
         """Pause the protocol to remove labware from the Flex Stacker.
 
@@ -1421,7 +1405,7 @@ class FlexStackerContext(ModuleContext):
             message,
         )
 
-    @requires_version(2, 24)
+    @requires_version(2, 25)
     def get_stored_labware(self) -> list[Labware]:
         """Get the list of labware currently stored inside the stacker.
 

--- a/api/tests/opentrons/protocol_api/test_flex_stacker_context.py
+++ b/api/tests/opentrons/protocol_api/test_flex_stacker_context.py
@@ -71,7 +71,7 @@ def subject(
 
 
 @pytest.mark.parametrize(
-    "api_version", versions_at_or_above(from_version=APIVersion(2, 23))
+    "api_version", versions_at_or_above(from_version=APIVersion(2, 25))
 )
 def test_get_serial_number(
     decoy: Decoy, mock_core: FlexStackerCore, subject: FlexStackerContext
@@ -82,24 +82,8 @@ def test_get_serial_number(
     assert result == "12345"
 
 
-@pytest.mark.parametrize("api_version", [APIVersion(2, 23)])
 @pytest.mark.parametrize(
-    "message,count", [("hello", 2), ("hello", None), (None, 2), (None, None)]
-)
-def test_fill_old_args(
-    decoy: Decoy,
-    mock_core: FlexStackerCore,
-    subject: FlexStackerContext,
-    message: str | None,
-    count: int | None,
-) -> None:
-    """It should pass args to the core."""
-    subject.fill(message, count)  # type: ignore[arg-type]
-    decoy.verify(mock_core.fill(count, message))
-
-
-@pytest.mark.parametrize(
-    "api_version", versions_at_or_above(from_version=APIVersion(2, 23))
+    "api_version", versions_at_or_above(from_version=APIVersion(2, 25))
 )
 def test_fill(
     decoy: Decoy, mock_core: FlexStackerCore, subject: FlexStackerContext
@@ -110,7 +94,7 @@ def test_fill(
 
 
 @pytest.mark.parametrize(
-    "api_version", versions_at_or_above(from_version=APIVersion(2, 23))
+    "api_version", versions_at_or_above(from_version=APIVersion(2, 25))
 )
 def test_empty(
     decoy: Decoy, mock_core: FlexStackerCore, subject: FlexStackerContext
@@ -121,7 +105,7 @@ def test_empty(
 
 
 @pytest.mark.parametrize(
-    "api_version", versions_at_or_above(from_version=APIVersion(2, 23))
+    "api_version", versions_at_or_above(from_version=APIVersion(2, 25))
 )
 def test_set_stored_labware(
     decoy: Decoy, mock_core: FlexStackerCore, subject: FlexStackerContext
@@ -148,7 +132,7 @@ def test_set_stored_labware(
 
 
 @pytest.mark.parametrize(
-    "api_version", versions_at_or_above(from_version=APIVersion(2, 24))
+    "api_version", versions_at_or_above(from_version=APIVersion(2, 25))
 )
 def test_get_max_storable_labware_from_list(
     decoy: Decoy,
@@ -168,7 +152,7 @@ def test_get_max_storable_labware_from_list(
     base_lw = [
         Labware(
             core=core,
-            api_version=APIVersion(2, 24),
+            api_version=APIVersion(2, 25),
             protocol_core=mock_protocol_core,
             core_map=subject._core_map,
         )
@@ -181,7 +165,7 @@ def test_get_max_storable_labware_from_list(
 
 
 @pytest.mark.parametrize(
-    "api_version", versions_at_or_above(from_version=APIVersion(2, 24))
+    "api_version", versions_at_or_above(from_version=APIVersion(2, 25))
 )
 def test_get_current_storable_labware_from_list(
     decoy: Decoy,
@@ -201,7 +185,7 @@ def test_get_current_storable_labware_from_list(
     base_lw = [
         Labware(
             core=core,
-            api_version=APIVersion(2, 24),
+            api_version=APIVersion(2, 25),
             protocol_core=mock_protocol_core,
             core_map=subject._core_map,
         )
@@ -214,7 +198,7 @@ def test_get_current_storable_labware_from_list(
 
 
 @pytest.mark.parametrize(
-    "api_version", versions_at_or_above(from_version=APIVersion(2, 24))
+    "api_version", versions_at_or_above(from_version=APIVersion(2, 25))
 )
 def test_get_max_storable_labware(
     decoy: Decoy,
@@ -227,7 +211,7 @@ def test_get_max_storable_labware(
 
 
 @pytest.mark.parametrize(
-    "api_version", versions_at_or_above(from_version=APIVersion(2, 24))
+    "api_version", versions_at_or_above(from_version=APIVersion(2, 25))
 )
 def test_get_current_storable_labware(
     decoy: Decoy,
@@ -240,7 +224,7 @@ def test_get_current_storable_labware(
 
 
 @pytest.mark.parametrize(
-    "api_version", versions_at_or_above(from_version=APIVersion(2, 24))
+    "api_version", versions_at_or_above(from_version=APIVersion(2, 25))
 )
 def test_get_stored_labware(
     decoy: Decoy,
@@ -260,7 +244,7 @@ def test_get_stored_labware(
     base_lw = [
         Labware(
             core=core,
-            api_version=APIVersion(2, 24),
+            api_version=APIVersion(2, 25),
             protocol_core=mock_protocol_core,
             core_map=subject._core_map,
         )
@@ -271,7 +255,7 @@ def test_get_stored_labware(
 
 
 @pytest.mark.parametrize(
-    "api_version", versions_at_or_above(from_version=APIVersion(2, 24))
+    "api_version", versions_at_or_above(from_version=APIVersion(2, 25))
 )
 @pytest.mark.parametrize("message", ["hello", None])
 def test_fill_items(
@@ -291,7 +275,7 @@ def test_fill_items(
     base_lw = [
         Labware(
             core=core,
-            api_version=APIVersion(2, 24),
+            api_version=APIVersion(2, 25),
             protocol_core=mock_protocol_core,
             core_map=subject._core_map,
         )
@@ -302,7 +286,7 @@ def test_fill_items(
 
 
 @pytest.mark.parametrize(
-    "api_version", versions_at_or_above(from_version=APIVersion(2, 24))
+    "api_version", versions_at_or_above(from_version=APIVersion(2, 25))
 )
 def test_set_stored_labware_items(
     decoy: Decoy,
@@ -320,7 +304,7 @@ def test_set_stored_labware_items(
     base_lw = [
         Labware(
             core=core,
-            api_version=APIVersion(2, 24),
+            api_version=APIVersion(2, 25),
             protocol_core=mock_protocol_core,
             core_map=subject._core_map,
         )

--- a/hardware-testing/hardware_testing/modules/stacker_qc_protocol.py
+++ b/hardware-testing/hardware_testing/modules/stacker_qc_protocol.py
@@ -10,7 +10,7 @@ metadata = {
 }
 requirements = {
     "robotType": "Flex",
-    "apiLevel": "2.23",
+    "apiLevel": "2.25",
 }
 
 

--- a/hardware-testing/hardware_testing/protocols/labware_stack_offset_test.py
+++ b/hardware-testing/hardware_testing/protocols/labware_stack_offset_test.py
@@ -11,7 +11,7 @@ metadata = {
 
 requirements = {
     "robotType": "Flex",
-    "apiLevel": "2.23",
+    "apiLevel": "2.25",
 }
 
 


### PR DESCRIPTION
# Overview

We bumped `MAX_SUPPORTED_VERSION` PAPI from `2.4` to `2.25` in the [Opentrons/opentrons#18725](https://github.com/Opentrons/opentrons/pull/18725) pull request. This follow-up pr updates the Flex Stacker PAPI commands to the new 2.25 version so they are in sync with the next release.

## Test Plan and Hands on Testing

- [x] Run the following protocol successfully

```python
"""PVT Flex Stacker QC."""
from opentrons.protocol_api import ProtocolContext, ParameterContext
from opentrons.protocol_api.module_contexts import (
    FlexStackerContext,
)

metadata = {
    "protocolName": "Flex Stacker PVT QC",
    "author": "Opentrons <protocols@opentrons.com>",
}
requirements = {
    "robotType": "Flex",
    "apiLevel": "2.25",
}


def add_parameters(parameters: ParameterContext) -> None:
    """Add parameters to the protocol."""
    parameters.add_str(
        variable_name="stacker_slot",
        display_name="Flex Stacker Slot",
        description="The slot where the Flex Stacker is loaded.",
        default="D4",
        choices=[
            {"display_name": "A4", "value": "A4"},
            {"display_name": "B4", "value": "B4"},
            {"display_name": "C4", "value": "C4"},
            {"display_name": "D4", "value": "D4"},
        ],
    )


def run(protocol: ProtocolContext) -> None:
    """Protocol."""
    # ======================= SIMPLE SETUP ARRANGEMENT ======================
    # STACKERS
    stacker: FlexStackerContext = protocol.load_module(
        "flexStackerModuleV1",
        protocol.params.stacker_slot,  # type: ignore[attr-defined]
    )  # type: ignore[assignment]
    stacker.set_stored_labware(
        load_name="opentrons_flex_96_tiprack_200ul",
        count=6,
        lid="opentrons_flex_tiprack_lid",
    )

    SLOTS = ["C1", "C2", "C3", "D1", "D2", "D3"]

    # ======================= RETRIEVE/STORE TIPRACKS ======================
    tipracks = []
    for slot in SLOTS:
        tiprack = stacker.retrieve()
        protocol.move_labware(tiprack, slot, use_gripper=True)
        tipracks.append(tiprack)

    for tiprack in tipracks:
        protocol.move_labware(tiprack, stacker, use_gripper=True)
        stacker.store()

    # =================== FILL TIPRACKS WITH PCR PLATES ======================

    stacker.empty("Empty all tipracks from the hopper and load in 6 PCR plates.")
    stacker.set_stored_labware(
        load_name="opentrons_96_wellplate_200ul_pcr_full_skirt",
        count=6,
    )

    # ======================= RETRIEVE/STORE PCR PLATES ======================
    plates = []
    for slot in SLOTS:
        plate = stacker.retrieve()
        protocol.move_labware(plate, slot, use_gripper=True)
        plates.append(plate)

    for plate in plates:
        protocol.move_labware(plate, stacker, use_gripper=True)
        stacker.store()

```

## Changelog

- Update Flex Stacker PAPI required version to 2.25
-  Update existing protocols to use the new PAPI 2.25 version.

## Review requests
## Risk assessment

low, unreleased