### PR TITLE
fix(shared-data): revert changes to LC displayNames

### DIFF
--- a/api/tests/opentrons/protocol_api_integration/test_liquid_classes.py
+++ b/api/tests/opentrons/protocol_api_integration/test_liquid_classes.py
@@ -23,7 +23,7 @@ def test_liquid_class_creation_and_property_fetching(
     water = simulated_protocol_context.get_liquid_class("water")
 
     assert water.name == "water"
-    assert water.display_name == "Aqueous (Deionized water)"
+    assert water.display_name == "Aqueous"
 
     # TODO (spp, 2024-10-17): update this to fetch pipette load name from instrument context
     assert (

--- a/components/src/organisms/CommandText/__tests__/CommandText.test.tsx
+++ b/components/src/organisms/CommandText/__tests__/CommandText.test.tsx
@@ -708,7 +708,7 @@ describe('CommandText', () => {
       />,
       { i18nInstance: i18n }
     )
-    screen.getByText('Loading Volatile (80% ethanol) Liquid Class')
+    screen.getByText('Loading Volatile Liquid Class')
   })
   it('renders correct text for temperatureModule/setTargetTemperature', () => {
     const mockTemp = 20

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/__tests__/LiquidClassesStepTools.test.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/__tests__/LiquidClassesStepTools.test.tsx
@@ -1,9 +1,10 @@
+import { describe, it, vi, beforeEach, expect } from 'vitest'
 import { fireEvent, screen } from '@testing-library/react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { renderWithProviders } from '../../../../../../../__testing-utils__'
 import { i18n } from '../../../../../../../assets/localization'
+import { renderWithProviders } from '../../../../../../../__testing-utils__'
 import { getLiquidEntities } from '../../../../../../../step-forms/selectors'
 import { LiquidClassesStepTools } from '../LiquidClassesStepTools'
+
 import type { ComponentProps } from 'react'
 
 vi.mock('../../../../../../../step-forms/selectors')
@@ -38,17 +39,15 @@ describe('LiquidClassesStepMoveLiquidTools', () => {
     render(props)
     screen.getByText('Apply liquid class settings for this transfer')
     screen.getByText("Don't use a liquid class")
-    screen.getByText('Aqueous (Deionized water)')
+    screen.getByText('Aqueous')
     screen.getByText('Deionized water')
-    screen.getByText('Viscous (50% glycerol)')
+    screen.getByText('Viscous')
     screen.getByText('50% glycerol')
-    screen.getByText('Volatile (80% ethanol)')
+    screen.getByText('Volatile')
     screen.getByText('80% ethanol')
 
     fireEvent.click(
-      screen.getByRole('label', {
-        name: 'Aqueous (Deionized water) Deionized water',
-      })
+      screen.getByRole('label', { name: 'Aqueous Deionized water' })
     )
     expect(props.propsForFields.liquidClass.updateValue).toHaveBeenCalled()
   })

--- a/shared-data/liquid-class/definitions/1/ethanol_80/1.json
+++ b/shared-data/liquid-class/definitions/1/ethanol_80/1.json
@@ -1,6 +1,6 @@
 {
   "liquidClassName": "ethanol_80",
-  "displayName": "Volatile (80% ethanol)",
+  "displayName": "Volatile",
   "description": "80% ethanol",
   "schemaVersion": 1,
   "version": 1,

--- a/shared-data/liquid-class/definitions/1/glycerol_50/1.json
+++ b/shared-data/liquid-class/definitions/1/glycerol_50/1.json
@@ -1,6 +1,6 @@
 {
   "liquidClassName": "glycerol_50",
-  "displayName": "Viscous (50% glycerol)",
+  "displayName": "Viscous",
   "description": "50% glycerol",
   "schemaVersion": 1,
   "version": 1,

--- a/shared-data/liquid-class/definitions/1/water/1.json
+++ b/shared-data/liquid-class/definitions/1/water/1.json
@@ -1,6 +1,6 @@
 {
   "liquidClassName": "water",
-  "displayName": "Aqueous (Deionized water)",
+  "displayName": "Aqueous",
   "description": "Deionized water",
   "schemaVersion": 1,
   "version": 1,


### PR DESCRIPTION
# Overview

In PR #18711 (AUTH-2003), we changed the liquid class display names to:
`Aqueous (Deionized water)` / `Volatile (80% ethanol)` / `Viscous (50% glycerol)`

But we've decided we want to change the display names back. So:
- displayName: `Aqueous`, description `Deionized water`, loadname: `water`
- displayName: `Volatile`, description `80% ethanol`, loadname: `ethanol_80`
- displayName: `Viscous`, description `50% glycerol`, loadname: `glycerol_50`

https://opentrons.slack.com/archives/C07JJA1AJFQ/p1751036532344239?thread_ts=1750692306.637929&cid=C07JJA1AJFQ

This PR reverts #18711 and #18738, and was generated by `git revert` with no manual changes:
```
git revert ec54caf 968ddc8
```

## Test Plan and Hands on Testing

Running CI tests.

## Review requests

This is what we want now, right?

## Risk assessment

Low, but we're cutting it close.