### PR TITLE
refactor(shared-data, protocol-designer, app):  Update `moveToWell` command copy

### DIFF
--- a/app/src/assets/localization/en/protocol_command_text.json
+++ b/app/src/assets/localization/en/protocol_command_text.json
@@ -60,7 +60,7 @@
   "move_to_addressable_area_drop_tip": "Moving to {{addressable_area}}",
   "move_to_coordinates": "Moving to (X: {{x}}, Y: {{y}}, Z: {{z}})",
   "move_to_slot": "Moving to Slot {{slot_name}}",
-  "move_to_well": "Moving to well {{well_name}} of {{labware}} in {{labware_location}}",
+  "move_to_well": "Moving to well {{wellName}} of {{labware}} with x,y,z offset {{xOffset}}, {{yOffset}}, {{zOffset}} relative to {{positionRelative}} in {{displayLocation}}",
   "multiple": "multiple",
   "notes": "notes",
   "off_deck": "off deck",

--- a/app/src/assets/localization/en/protocol_command_text.json
+++ b/app/src/assets/localization/en/protocol_command_text.json
@@ -60,7 +60,7 @@
   "move_to_addressable_area_drop_tip": "Moving to {{addressable_area}}",
   "move_to_coordinates": "Moving to (X: {{x}}, Y: {{y}}, Z: {{z}})",
   "move_to_slot": "Moving to Slot {{slot_name}}",
-  "move_to_well": "Moving to well {{wellName}} of {{labware}} with x,y,z offset {{xOffset}}, {{yOffset}}, {{zOffset}} relative to {{positionRelative}} in {{displayLocation}}",
+  "move_to_well": "Moving to X {{xOffset}} Y {{yOffset}} Z {{zOffset}} relative to {{positionRelative}} of well {{wellName}} of {{labware}} in {{displayLocation}}",
   "multiple": "multiple",
   "notes": "notes",
   "off_deck": "off deck",

--- a/components/src/assets/localization/en/protocol_command_text.json
+++ b/components/src/assets/localization/en/protocol_command_text.json
@@ -54,7 +54,7 @@
   "move_to_addressable_area_drop_tip": "Moving to {{addressable_area}}",
   "move_to_coordinates": "Moving to (X: {{x}}, Y: {{y}}, Z: {{z}})",
   "move_to_slot": "Moving to Slot {{slot_name}}",
-  "move_to_well": "Moving to well {{well_name}} of {{labware}} in {{labware_location}}",
+  "move_to_well": "Moving to well {{wellName}} of {{labware}} with x,y,z offset {{xOffset}}, {{yOffset}}, {{zOffset}} relative to {{positionRelative}} in {{displayLocation}}",
   "multiple": "multiple",
   "notes": "notes",
   "off_deck": "off deck",

--- a/components/src/assets/localization/en/protocol_command_text.json
+++ b/components/src/assets/localization/en/protocol_command_text.json
@@ -54,7 +54,7 @@
   "move_to_addressable_area_drop_tip": "Moving to {{addressable_area}}",
   "move_to_coordinates": "Moving to (X: {{x}}, Y: {{y}}, Z: {{z}})",
   "move_to_slot": "Moving to Slot {{slot_name}}",
-  "move_to_well": "Moving to well {{wellName}} of {{labware}} with x,y,z offset {{xOffset}}, {{yOffset}}, {{zOffset}} relative to {{positionRelative}} in {{displayLocation}}",
+  "move_to_well": "Moving to X {{xOffset}} Y {{yOffset}} Z {{zOffset}} relative to {{positionRelative}} of well {{wellName}} of {{labware}} in {{displayLocation}}",
   "multiple": "multiple",
   "notes": "notes",
   "off_deck": "off deck",

--- a/components/src/organisms/CommandText/__tests__/CommandText.test.tsx
+++ b/components/src/organisms/CommandText/__tests__/CommandText.test.tsx
@@ -1,15 +1,8 @@
-import { it, expect, describe } from 'vitest'
-import { screen } from '@testing-library/react'
-
 import {
   FLEX_ROBOT_TYPE,
-  OT2_ROBOT_TYPE,
   GRIPPER_WASTE_CHUTE_ADDRESSABLE_AREA,
+  OT2_ROBOT_TYPE,
 } from '@opentrons/shared-data'
-import { i18n } from '../../../i18n'
-import { renderWithProviders } from '../../../testing/utils'
-import { CommandText } from '../index'
-
 import type {
   AspirateInPlaceRunTimeCommand,
   BlowoutInPlaceRunTimeCommand,
@@ -22,17 +15,22 @@ import type {
   DropTipRunTimeCommand,
   LabwareDefinition2,
   LoadLabwareRunTimeCommand,
+  LoadLiquidClassRunTimeCommand,
   LoadLiquidRunTimeCommand,
+  MoveToAddressableAreaForDropTipRunTimeCommand,
   MoveToAddressableAreaRunTimeCommand,
   MoveToWellRunTimeCommand,
   PrepareToAspirateRunTimeCommand,
   RunTimeCommand,
-  MoveToAddressableAreaForDropTipRunTimeCommand,
-  LoadLiquidClassRunTimeCommand,
 } from '@opentrons/shared-data'
+import { screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { i18n } from '../../../i18n'
+import { renderWithProviders } from '../../../testing/utils'
 import type { CommandTextData } from '../../ProtocolTimelineScrubber'
 import { getCommandTextData } from '../../ProtocolTimelineScrubber/utils'
 import { mockRobotSideAnalysis } from '../fixtures'
+import { CommandText } from '../index'
 
 const mockCommandTextData: CommandTextData = {
   commands: mockRobotSideAnalysis.commands,
@@ -216,7 +214,7 @@ describe('CommandText', () => {
         { i18nInstance: i18n }
       )
       screen.getByText(
-        'Moving to well A1 of NEST 1 Well Reservoir 195 mL with x,y,z offset 0.00, 0.00, -24.00 relative to top in Slot 5'
+        'Moving to X 0.00 Y 0.00 Z -24.00 relative to top of well A1 of NEST 1 Well Reservoir 195 mL in Slot 5'
       )
     }
   })

--- a/components/src/organisms/CommandText/__tests__/CommandText.test.tsx
+++ b/components/src/organisms/CommandText/__tests__/CommandText.test.tsx
@@ -216,7 +216,7 @@ describe('CommandText', () => {
         { i18nInstance: i18n }
       )
       screen.getByText(
-        'Moving to well A1 of NEST 1 Well Reservoir 195 mL in Slot 5'
+        'Moving to well A1 of NEST 1 Well Reservoir 195 mL with x,y,z offset 0.00, 0.00, -24.00 relative to top in Slot 5'
       )
     }
   })

--- a/components/src/organisms/CommandText/useCommandTextString/utils/commandText/getMoveToWellCommandText.ts
+++ b/components/src/organisms/CommandText/useCommandTextString/utils/commandText/getMoveToWellCommandText.ts
@@ -17,7 +17,7 @@ export function getMoveToWellCommandText({
     x: xOffsetUnformatted,
     y: yOffsetUnformatted,
     z: zOffsetUnformatted,
-  } = wellLocation.offset
+  } = wellLocation?.offset ?? { x: '', y: '', z: '' }
   const allPreviousCommands = commandTextData?.commands.slice(
     0,
     commandTextData.commands.findIndex(c => c.id === command.id)
@@ -36,6 +36,13 @@ export function getMoveToWellCommandText({
     t,
   })
 
+  const xOffset =
+    typeof xOffsetUnformatted === 'number' ? xOffsetUnformatted?.toFixed(2) : ''
+  const yOffset =
+    typeof yOffsetUnformatted === 'number' ? yOffsetUnformatted?.toFixed(2) : ''
+  const zOffset =
+    typeof zOffsetUnformatted === 'number' ? zOffsetUnformatted?.toFixed(2) : ''
+
   return t('move_to_well', {
     wellName,
     labware:
@@ -46,10 +53,10 @@ export function getMoveToWellCommandText({
             allRunDefs,
           })
         : null,
-    xOffset: xOffsetUnformatted.toFixed(2),
-    yOffset: yOffsetUnformatted.toFixed(2),
-    zOffset: zOffsetUnformatted.toFixed(2),
-    positionRelative: wellLocation.origin,
+    xOffset,
+    yOffset,
+    zOffset,
+    positionRelative: wellLocation?.origin,
     displayLocation,
   })
 }

--- a/components/src/organisms/CommandText/useCommandTextString/utils/commandText/getMoveToWellCommandText.ts
+++ b/components/src/organisms/CommandText/useCommandTextString/utils/commandText/getMoveToWellCommandText.ts
@@ -12,7 +12,12 @@ export function getMoveToWellCommandText({
   commandTextData,
   robotType,
 }: HandlesCommands<MoveToWellRunTimeCommand>): string {
-  const { wellName, labwareId } = command.params
+  const { wellName, labwareId, wellLocation } = command.params
+  const {
+    x: xOffsetUnformatted,
+    y: yOffsetUnformatted,
+    z: zOffsetUnformatted,
+  } = wellLocation.offset
   const allPreviousCommands = commandTextData?.commands.slice(
     0,
     commandTextData.commands.findIndex(c => c.id === command.id)
@@ -32,7 +37,7 @@ export function getMoveToWellCommandText({
   })
 
   return t('move_to_well', {
-    well_name: wellName,
+    wellName,
     labware:
       commandTextData != null
         ? getLabwareName({
@@ -41,6 +46,10 @@ export function getMoveToWellCommandText({
             allRunDefs,
           })
         : null,
-    labware_location: displayLocation,
+    xOffset: xOffsetUnformatted.toFixed(2),
+    yOffset: yOffsetUnformatted.toFixed(2),
+    zOffset: zOffsetUnformatted.toFixed(2),
+    positionRelative: wellLocation.origin,
+    displayLocation,
   })
 }

--- a/protocol-designer/src/assets/localization/en/protocol_command_text.json
+++ b/protocol-designer/src/assets/localization/en/protocol_command_text.json
@@ -54,7 +54,7 @@
   "move_to_addressable_area_drop_tip": "Moving to {{addressable_area}}",
   "move_to_coordinates": "Moving to (X: {{x}}, Y: {{y}}, Z: {{z}})",
   "move_to_slot": "Moving to Slot {{slot_name}}",
-  "move_to_well": "Moving to well {{well_name}} of {{labware}} in {{labware_location}}",
+  "move_to_well": "Moving to well {{wellName}} of {{labware}} with x,y,z offset {{xOffset}}, {{yOffset}}, {{zOffset}} relative to {{positionRelative}} in {{displayLocation}}",
   "multiple": "multiple",
   "notes": "notes",
   "off_deck": "off deck",

--- a/protocol-designer/src/assets/localization/en/protocol_command_text.json
+++ b/protocol-designer/src/assets/localization/en/protocol_command_text.json
@@ -54,7 +54,7 @@
   "move_to_addressable_area_drop_tip": "Moving to {{addressable_area}}",
   "move_to_coordinates": "Moving to (X: {{x}}, Y: {{y}}, Z: {{z}})",
   "move_to_slot": "Moving to Slot {{slot_name}}",
-  "move_to_well": "Moving to well {{wellName}} of {{labware}} with x,y,z offset {{xOffset}}, {{yOffset}}, {{zOffset}} relative to {{positionRelative}} in {{displayLocation}}",
+  "move_to_well": "Moving to X {{xOffset}} Y {{yOffset}} Z {{zOffset}} relative to {{positionRelative}} of well {{wellName}} of {{labware}} in {{displayLocation}}",
   "multiple": "multiple",
   "notes": "notes",
   "off_deck": "off deck",

--- a/shared-data/command/types/gantry.ts
+++ b/shared-data/command/types/gantry.ts
@@ -1,12 +1,12 @@
-import type { CommonCommandCreateInfo, CommonCommandRunTimeInfo } from '.'
+import type { CommonCommandRunTimeInfo, CommonCommandCreateInfo } from '.'
 import type { AddressableAreaName } from '../../deck'
+import type { WellLocation } from './support'
 import type {
   Coordinates,
-  GantryMount,
   MotorAxes,
   MotorAxis,
+  GantryMount,
 } from '../../js/types'
-import type { WellLocation } from './support'
 
 export interface MoveToSlotCreateCommand extends CommonCommandCreateInfo {
   commandType: 'moveToSlot'
@@ -126,7 +126,7 @@ export interface MoveToWellParams {
   pipetteId: string
   labwareId: string
   wellName: string
-  wellLocation: WellLocation
+  wellLocation?: WellLocation
   minimumZHeight?: number
   forceDirect?: boolean
 }

--- a/shared-data/command/types/gantry.ts
+++ b/shared-data/command/types/gantry.ts
@@ -1,12 +1,12 @@
-import type { CommonCommandRunTimeInfo, CommonCommandCreateInfo } from '.'
+import type { CommonCommandCreateInfo, CommonCommandRunTimeInfo } from '.'
 import type { AddressableAreaName } from '../../deck'
-import type { WellLocation } from './support'
 import type {
   Coordinates,
+  GantryMount,
   MotorAxes,
   MotorAxis,
-  GantryMount,
 } from '../../js/types'
+import type { WellLocation } from './support'
 
 export interface MoveToSlotCreateCommand extends CommonCommandCreateInfo {
   commandType: 'moveToSlot'
@@ -126,7 +126,7 @@ export interface MoveToWellParams {
   pipetteId: string
   labwareId: string
   wellName: string
-  wellLocation?: WellLocation
+  wellLocation: WellLocation
   minimumZHeight?: number
   forceDirect?: boolean
 }

--- a/shared-data/command/types/support.ts
+++ b/shared-data/command/types/support.ts
@@ -1,13 +1,13 @@
 type BaseWellOrigin = 'top' | 'bottom' | 'center'
 export type WellOrigin = BaseWellOrigin | 'meniscus'
 export interface WellOffset {
-  x: number
-  y: number
-  z: number
+  x?: number
+  y?: number
+  z?: number
 }
 export interface WellLocation {
-  origin: WellOrigin
-  offset: WellOffset
+  origin?: WellOrigin
+  offset?: WellOffset
 }
 
 export type DropTipWellOrigin = BaseWellOrigin | 'default'

--- a/shared-data/command/types/support.ts
+++ b/shared-data/command/types/support.ts
@@ -1,13 +1,13 @@
 type BaseWellOrigin = 'top' | 'bottom' | 'center'
 export type WellOrigin = BaseWellOrigin | 'meniscus'
 export interface WellOffset {
-  x?: number
-  y?: number
-  z?: number
+  x: number
+  y: number
+  z: number
 }
 export interface WellLocation {
-  origin?: WellOrigin
-  offset?: WellOffset
+  origin: WellOrigin
+  offset: WellOffset
 }
 
 export type DropTipWellOrigin = BaseWellOrigin | 'default'

--- a/shared-data/command/types/support.ts
+++ b/shared-data/command/types/support.ts
@@ -5,6 +5,7 @@ export interface WellOffset {
   y?: number
   z?: number
 }
+// TODO(jh, 06-27-25): Origin and offset should be required. Mark them as so and fix all the type errors.
 export interface WellLocation {
   origin?: WellOrigin
   offset?: WellOffset


### PR DESCRIPTION
Closes [AUTH-1777](https://opentrons.atlassian.net/browse/AUTH-1777)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Updates the `moveToWell` command text so the run log is a bit less ambiguous about command output.

It appears that the `offset` and `origin` are always provided for this command, based on looking at a few files in the engine stemming from [here](https://github.com/Opentrons/opentrons/blob/5c731d4f6e4c6308fa0473f21dda204eef95bce8/api/src/opentrons/protocol_engine/types/well_position.py#L73-L81). 

NOTE: I had to revert [9e96e01](https://github.com/Opentrons/opentrons/pull/18776/commits/9e96e01a0e37b974ab2ab773dd528d6fe862c5ff)  given the extensive (74) type errors that would need fixing, and I don't have the time to address them right now. I'll leave a TODO and just default to any empty string for now. It should be sufficient if these values are always present and makes this change pretty much riskless, which seems nice given where we are in the QA process.

### Current Behavior

<img width="902" alt="Screenshot 2025-06-27 at 7 14 43 PM" src="https://github.com/user-attachments/assets/930a410d-aebe-4d73-8c3c-5d1533f5d129" />

### Fixed Behavior

<img width="808" alt="Screenshot 2025-06-27 at 7 13 11 PM" src="https://github.com/user-attachments/assets/49efac98-7184-480b-aa2e-bbdeff0594d2" />

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- See images. See ticket for protocol used to test.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Updated the run log command text for the `moveToWellCommand`.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low, just copy. Only risk comes from the assumption that we always have access to these params, but at worst we just show some undefined copy values.
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[AUTH-1777]: https://opentrons.atlassian.net/browse/AUTH-1777?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ