### PR TITLE
fix(protocol-designer): update drop tip location in saved step form r…

### DIFF
--- a/protocol-designer/src/step-forms/reducers/index.ts
+++ b/protocol-designer/src/step-forms/reducers/index.ts
@@ -387,7 +387,8 @@ export const savedStepForms = (
             },
           }
         } else if (
-          savedForm.dropTip_location == null &&
+          (locationUpdate[savedForm.dropTip_location] == null ||
+            savedForm.dropTip_location == null) &&
           (name === 'trashBin' || name === 'wasteChute')
         ) {
           return {


### PR DESCRIPTION
…educer

closes RQA-4318

# Overview

Some additional refinement to the `savedStepForm` reducer for when you add a deck fixture of a trash bin or waste chute so you don't have to manually update the trash bin/waste chute in the form drop down

## Test Plan and Hands on Testing

Upload the protocol attached to the ticket. then delete the waste chute and add a waste chute or trash bin and see that the error resolves

## Changelog

- check if the drop tip location exists in the `trashBinLocationUpdate` or `wasteChuteLocationUpdate`

## Risk assessment

low
