### PR TITLE
fix(protocol-designer): properly reset labware stack when items change

### DIFF
--- a/protocol-designer/src/components/organisms/SelectLabwareModal/index.tsx
+++ b/protocol-designer/src/components/organisms/SelectLabwareModal/index.tsx
@@ -570,7 +570,17 @@ export function SelectLabwareModal(
                                                 : uri,
                                           })
                                         )
+                                        dispatch(
+                                          selectAdapter({
+                                            adapterDefURI: null,
+                                          })
+                                        )
                                       }
+                                      dispatch(
+                                        selectLid({
+                                          labwareDefURI: null,
+                                        })
+                                      )
                                     }}
                                     isSelected={
                                       (isAdapter &&


### PR DESCRIPTION
closes RQA-4317

# Overview

reset the topLabware and adapter and lid when other items in the stack change

## Test Plan and Hands on Testing

create a protocol and click to add an adapter to the deck but then click to add a well plate and see that the adapter selection resets to null.

## Changelog

- add a few dispatches to delete the adapter + lid selected

## Risk assessment

low