### PR TITLE
refactor(step-generation): use correct liquid class name for loadLiqu…

### DIFF
--- a/protocol-designer/src/load-file/migration/utils/__tests__/getLoadLiquidClassCommands.test.ts
+++ b/protocol-designer/src/load-file/migration/utils/__tests__/getLoadLiquidClassCommands.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { getAllLiquidClassDefs } from '@opentrons/shared-data'
+import {
+  ETHANOL_LIQUID_CLASS_NAME,
+  getAllLiquidClassDefs,
+  GLYCEROL_LIQUID_CLASS_NAME,
+} from '@opentrons/shared-data'
 
 import { getLoadLiquidClassCommands } from '../getLoadLiquidClassCommands'
 
@@ -28,14 +32,14 @@ const MOCK_PIPETTE_ENTITIES = ({
 const MOCK_SAVED_STEP_FORMS = ({
   step0: {
     pipette: 'mockPipette1',
-    liquidClass: 'mockLiquidClass1',
+    liquidClass: ETHANOL_LIQUID_CLASS_NAME,
     tipRack: 'mockTipRack1',
     stepType: 'moveLiquid',
     id: 'step0',
   },
   step1: {
     pipette: 'mockPipette1',
-    liquidClass: 'mockLiquidClass2',
+    liquidClass: GLYCEROL_LIQUID_CLASS_NAME,
     tipRack: 'mockTipRack3',
     stepType: 'mix',
     id: 'step1',
@@ -43,7 +47,8 @@ const MOCK_SAVED_STEP_FORMS = ({
 } as unknown) as SavedStepFormState
 
 const mockLiquidClasses = {
-  mockLiquidClass1: {
+  [ETHANOL_LIQUID_CLASS_NAME]: {
+    liquidClassName: 'ethanol_80',
     byPipette: [
       {
         pipetteModel: 'flex_1channel_1000',
@@ -58,7 +63,8 @@ const mockLiquidClasses = {
       },
     ],
   },
-  mockLiquidClass2: {
+  [GLYCEROL_LIQUID_CLASS_NAME]: {
+    liquidClassName: 'glycerol_50',
     byPipette: [
       {
         pipetteModel: 'flex_1channel_1000',
@@ -94,7 +100,7 @@ describe('getLoadLiquidClassCommands', () => {
         params: {
           liquidClassRecord: {
             tiprack: 'mockTipRack1',
-            liquidClassName: 'mockLiquidClass1',
+            liquidClassName: 'ethanol_80',
             pipetteModel: 'flex_1channel_1000',
           },
         },
@@ -105,7 +111,7 @@ describe('getLoadLiquidClassCommands', () => {
         params: {
           liquidClassRecord: {
             tiprack: 'mockTipRack3',
-            liquidClassName: 'mockLiquidClass2',
+            liquidClassName: 'glycerol_50',
             pipetteModel: 'flex_1channel_1000',
           },
         },
@@ -120,7 +126,7 @@ describe('getLoadLiquidClassCommands', () => {
         stepType: 'moveLiquid',
         id: 'step2',
         pipette: 'mockPipette1',
-        liquidClass: 'mockLiquidClass2',
+        liquidClass: GLYCEROL_LIQUID_CLASS_NAME,
         tipRack: 'mockTipRack3',
       },
     })
@@ -131,7 +137,7 @@ describe('getLoadLiquidClassCommands', () => {
         params: {
           liquidClassRecord: {
             tiprack: 'mockTipRack1',
-            liquidClassName: 'mockLiquidClass1',
+            liquidClassName: 'ethanol_80',
             pipetteModel: 'flex_1channel_1000',
           },
         },
@@ -142,7 +148,7 @@ describe('getLoadLiquidClassCommands', () => {
         params: {
           liquidClassRecord: {
             tiprack: 'mockTipRack3',
-            liquidClassName: 'mockLiquidClass2',
+            liquidClassName: 'glycerol_50',
             pipetteModel: 'flex_1channel_1000',
           },
         },
@@ -165,7 +171,7 @@ describe('getLoadLiquidClassCommands', () => {
         params: {
           liquidClassRecord: {
             tiprack: 'mockTipRack1',
-            liquidClassName: 'mockLiquidClass1',
+            liquidClassName: 'ethanol_80',
             pipetteModel: 'flex_1channel_1000',
           },
         },
@@ -188,7 +194,7 @@ describe('getLoadLiquidClassCommands', () => {
         params: {
           liquidClassRecord: {
             tiprack: 'mockTipRack1',
-            liquidClassName: 'mockLiquidClass1',
+            liquidClassName: 'ethanol_80',
             pipetteModel: 'flex_1channel_1000',
           },
         },

--- a/protocol-designer/src/load-file/migration/utils/getLoadLiquidClassCommands.ts
+++ b/protocol-designer/src/load-file/migration/utils/getLoadLiquidClassCommands.ts
@@ -2,6 +2,7 @@ import {
   getAllLiquidClassDefs,
   getFlexNameConversion,
 } from '@opentrons/shared-data'
+import { getLiquidClassName } from '@opentrons/step-generation'
 
 import { uuid } from '../../../utils'
 
@@ -49,7 +50,7 @@ export const getLoadLiquidClassCommands = (
             params: {
               liquidClassRecord: {
                 ...byTipTypeSettings,
-                liquidClassName: liquidClass,
+                liquidClassName: getLiquidClassName(liquidClass),
                 pipetteModel,
               },
             },

--- a/protocol-designer/src/load-file/migration/utils/getLoadLiquidClassCommands.ts
+++ b/protocol-designer/src/load-file/migration/utils/getLoadLiquidClassCommands.ts
@@ -39,7 +39,6 @@ export const getLoadLiquidClassCommands = (
               )
               ?.byTipType.find(({ tiprack }) => tiprack === tipRack)
           : null
-
       if (byTipTypeSettings != null && !loadedLiquidClasses.has(uniqueString)) {
         loadedLiquidClasses.add(uniqueString)
         return [

--- a/step-generation/src/__tests__/pythonFileUtils.test.ts
+++ b/step-generation/src/__tests__/pythonFileUtils.test.ts
@@ -552,9 +552,9 @@ describe('getLoadLiquidClasses', () => {
     ).toBe(
       `
 # Load Liquid Classes:
-water_v1 = protocol.get_liquid_class("water")
-ethanol_80_v1 = protocol.get_liquid_class("ethanol_80")
-glycerol_50_v1 = protocol.get_liquid_class("glycerol_50")`.trimStart()
+water_base_class = protocol.get_liquid_class("water")
+ethanol_80_base_class = protocol.get_liquid_class("ethanol_80")
+glycerol_50_base_class = protocol.get_liquid_class("glycerol_50")`.trimStart()
     )
   })
 })

--- a/step-generation/src/commandCreators/compound/consolidate.ts
+++ b/step-generation/src/commandCreators/compound/consolidate.ts
@@ -34,7 +34,7 @@ import {
 } from '../../utils'
 import {
   getCustomLiquidClassProperties,
-  getPythonLiquidClassName,
+  getLiquidClassName,
 } from '../../utils/liquidClassUtils'
 import {
   airGapInPlace,
@@ -351,7 +351,7 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
   const pythonLiquidClassArgs = [
     `name=${formatPyStr(`${args.commandCreatorFnName}_step_${stepId}`)}`,
     ...(liquidClass != null
-      ? [`base_liquid_class=${getPythonLiquidClassName(liquidClass)}`]
+      ? [`base_liquid_class=${getLiquidClassName(liquidClass)}`]
       : []),
     `properties=${getCustomLiquidClassProperties({
       args,

--- a/step-generation/src/commandCreators/compound/consolidate.ts
+++ b/step-generation/src/commandCreators/compound/consolidate.ts
@@ -351,7 +351,7 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
   const pythonLiquidClassArgs = [
     `name=${formatPyStr(`${args.commandCreatorFnName}_step_${stepId}`)}`,
     ...(liquidClass != null
-      ? [`base_liquid_class=${getLiquidClassName(liquidClass)}`]
+      ? [`base_liquid_class=${getLiquidClassName(liquidClass, true)}`]
       : []),
     `properties=${getCustomLiquidClassProperties({
       args,

--- a/step-generation/src/commandCreators/compound/distribute.ts
+++ b/step-generation/src/commandCreators/compound/distribute.ts
@@ -385,7 +385,7 @@ export const distribute: CommandCreator<DistributeArgs> = (
   const pythonLiquidClassArgs = [
     `name=${formatPyStr(`${args.commandCreatorFnName}_step_${stepId}`)}`,
     ...(liquidClass != null
-      ? [`base_liquid_class=${getLiquidClassName(liquidClass)}`]
+      ? [`base_liquid_class=${getLiquidClassName(liquidClass, true)}`]
       : []),
     `properties=${getCustomLiquidClassProperties({
       args,

--- a/step-generation/src/commandCreators/compound/distribute.ts
+++ b/step-generation/src/commandCreators/compound/distribute.ts
@@ -35,7 +35,7 @@ import {
 } from '../../utils'
 import {
   getCustomLiquidClassProperties,
-  getPythonLiquidClassName,
+  getLiquidClassName,
 } from '../../utils/liquidClassUtils'
 import {
   airGapInPlace,
@@ -385,7 +385,7 @@ export const distribute: CommandCreator<DistributeArgs> = (
   const pythonLiquidClassArgs = [
     `name=${formatPyStr(`${args.commandCreatorFnName}_step_${stepId}`)}`,
     ...(liquidClass != null
-      ? [`base_liquid_class=${getPythonLiquidClassName(liquidClass)}`]
+      ? [`base_liquid_class=${getLiquidClassName(liquidClass)}`]
       : []),
     `properties=${getCustomLiquidClassProperties({
       args,

--- a/step-generation/src/commandCreators/compound/transfer.ts
+++ b/step-generation/src/commandCreators/compound/transfer.ts
@@ -30,7 +30,7 @@ import {
 } from '../../utils'
 import {
   getCustomLiquidClassProperties,
-  getPythonLiquidClassName,
+  getLiquidClassName,
 } from '../../utils/liquidClassUtils'
 import {
   airGapInPlace,
@@ -354,7 +354,7 @@ export const transfer: CommandCreator<TransferArgs> = (
   const pythonLiquidClassArgs = [
     `name=${formatPyStr(`${args.commandCreatorFnName}_step_${stepId}`)}`,
     ...(liquidClass != null
-      ? [`base_liquid_class=${getPythonLiquidClassName(liquidClass)}`]
+      ? [`base_liquid_class=${getLiquidClassName(liquidClass)}`]
       : []),
     `properties=${getCustomLiquidClassProperties({
       args,

--- a/step-generation/src/commandCreators/compound/transfer.ts
+++ b/step-generation/src/commandCreators/compound/transfer.ts
@@ -354,7 +354,7 @@ export const transfer: CommandCreator<TransferArgs> = (
   const pythonLiquidClassArgs = [
     `name=${formatPyStr(`${args.commandCreatorFnName}_step_${stepId}`)}`,
     ...(liquidClass != null
-      ? [`base_liquid_class=${getLiquidClassName(liquidClass)}`]
+      ? [`base_liquid_class=${getLiquidClassName(liquidClass, true)}`]
       : []),
     `properties=${getCustomLiquidClassProperties({
       args,

--- a/step-generation/src/utils/index.ts
+++ b/step-generation/src/utils/index.ts
@@ -21,12 +21,13 @@ export {
   findThermocyclerProfileRepetitions,
 }
 export * from './commandCreatorArgsGetters'
-export * from './heaterShakerCollision'
-export * from './createTimelineFromRunCommands'
-export * from './misc'
-export * from './safePipetteMovements'
-export * from './createTimelineFromRunCommands'
 export * from './constructInvariantContextFromRunCommands'
-export * from './pythonFormat'
+export * from './createTimelineFromRunCommands'
+export * from './createTimelineFromRunCommands'
+export * from './heaterShakerCollision'
+export * from './misc'
 export * from './pythonFileUtils'
+export * from './pythonFormat'
+export * from './safePipetteMovements'
+export * from './liquidClassUtils'
 export const uuid: () => string = uuidv4

--- a/step-generation/src/utils/liquidClassUtils.ts
+++ b/step-generation/src/utils/liquidClassUtils.ts
@@ -220,10 +220,15 @@ export const getCustomLiquidClassProperties = (
   return formatPyDict(stringifiedCustomLiquidClassProperties)
 }
 
-export const getLiquidClassName = (liquidClass: string): string => {
+export const getLiquidClassName = (
+  liquidClass: string,
+  showVersion?: boolean
+): string => {
   const allLiquidClassDefs = getAllLiquidClassDefs()
   const liquidClassDef = allLiquidClassDefs[liquidClass]
-  return `${liquidClassDef.liquidClassName}_v${liquidClassDef.schemaVersion}`
+  return `${liquidClassDef.liquidClassName}${
+    showVersion ? `_v${liquidClassDef.schemaVersion}` : ''
+  }`
 }
 
 const getBlowoutPythonLocation = (

--- a/step-generation/src/utils/liquidClassUtils.ts
+++ b/step-generation/src/utils/liquidClassUtils.ts
@@ -222,13 +222,11 @@ export const getCustomLiquidClassProperties = (
 
 export const getLiquidClassName = (
   liquidClass: string,
-  showVersion?: boolean
+  showBase?: boolean
 ): string => {
   const allLiquidClassDefs = getAllLiquidClassDefs()
   const liquidClassDef = allLiquidClassDefs[liquidClass]
-  return `${liquidClassDef.liquidClassName}${
-    showVersion ? `_v${liquidClassDef.schemaVersion}` : ''
-  }`
+  return `${liquidClassDef.liquidClassName}${showBase ? `_base_class` : ''}`
 }
 
 const getBlowoutPythonLocation = (

--- a/step-generation/src/utils/liquidClassUtils.ts
+++ b/step-generation/src/utils/liquidClassUtils.ts
@@ -220,7 +220,7 @@ export const getCustomLiquidClassProperties = (
   return formatPyDict(stringifiedCustomLiquidClassProperties)
 }
 
-export const getPythonLiquidClassName = (liquidClass: string): string => {
+export const getLiquidClassName = (liquidClass: string): string => {
   const allLiquidClassDefs = getAllLiquidClassDefs()
   const liquidClassDef = allLiquidClassDefs[liquidClass]
   return `${liquidClassDef.liquidClassName}_v${liquidClassDef.schemaVersion}`

--- a/step-generation/src/utils/pythonFileUtils.ts
+++ b/step-generation/src/utils/pythonFileUtils.ts
@@ -392,7 +392,8 @@ export function getLoadLiquidClasses(
         return ''
       }
       return `${getLiquidClassName(
-        liquidClass
+        liquidClass,
+        true
       )} = ${PROTOCOL_CONTEXT_NAME}.get_liquid_class(${formatPyStr(
         allLiquidClassDefs[liquidClass].liquidClassName
       )})`

--- a/step-generation/src/utils/pythonFileUtils.ts
+++ b/step-generation/src/utils/pythonFileUtils.ts
@@ -9,7 +9,7 @@ import {
   OT2_ROBOT_TYPE,
 } from '@opentrons/shared-data'
 
-import { getPythonLiquidClassName } from './liquidClassUtils'
+import { getLiquidClassName } from './liquidClassUtils'
 import { getSlotInLocationStack } from './misc'
 import {
   CUSTOM_LABWARE_DICT_NAME,
@@ -391,7 +391,7 @@ export function getLoadLiquidClasses(
       if (liquidClass == null) {
         return ''
       }
-      return `${getPythonLiquidClassName(
+      return `${getLiquidClassName(
         liquidClass
       )} = ${PROTOCOL_CONTEXT_NAME}.get_liquid_class(${formatPyStr(
         allLiquidClassDefs[liquidClass].liquidClassName


### PR DESCRIPTION
…idClass json and python command

# Overview

Noticed this bug in the run log not showing the liquid class name. Basically, for example, `ethanol80V1` should be `ethanol_80`

Additionally, i update the python liquid class name to include `_base_class` at the end instead of the version.

## Test Plan and Hands on Testing

Create a protocol that loads a liquid class
import into the app
the run log should show the liquid class name in the command text

## Changelog

- rename the util to now just be used for python but also for jSON. 
- the util should be used in the `loadLiquidClass` json command creation
- update the util to return `_base_class` for python liquid class name
- fix tests

## Risk assessment

low
