### PR TITLE
fix(step-generation): fix params for `getIsRetractSafeForAirGap`

### DIFF
--- a/step-generation/src/commandCreators/compound/distribute.ts
+++ b/step-generation/src/commandCreators/compound/distribute.ts
@@ -859,7 +859,7 @@ export const distribute: CommandCreator<DistributeArgs> = (
 
           const isDispenseRetractSafeForAirGap = getIsRetractSafeForAirGap({
             retractZOffset: dispenseRetractZOffset,
-            retractPositionReference: dispensePositionReference,
+            retractPositionReference: dispenseRetractPositionReference,
             labwareId: destLabware,
             labwareEntities,
             well: destinationWell,

--- a/step-generation/src/commandCreators/compound/transfer.ts
+++ b/step-generation/src/commandCreators/compound/transfer.ts
@@ -541,7 +541,6 @@ export const transfer: CommandCreator<TransferArgs> = (
             labwareEntities,
             well: destinationWell,
           })
-          console.log({ isDispenseRetractSafeForAirGap })
           const preDispenseAirGapMoveToCommand =
             !isDispenseRetractSafeForAirGap && destinationWell != null
               ? [

--- a/step-generation/src/commandCreators/compound/transfer.ts
+++ b/step-generation/src/commandCreators/compound/transfer.ts
@@ -536,11 +536,12 @@ export const transfer: CommandCreator<TransferArgs> = (
 
           const isDispenseRetractSafeForAirGap = getIsRetractSafeForAirGap({
             retractZOffset: dispenseRetractZOffset,
-            retractPositionReference: dispensePositionReference,
+            retractPositionReference: dispenseRetractPositionReference,
             labwareId: destLabware,
             labwareEntities,
             well: destinationWell,
           })
+          console.log({ isDispenseRetractSafeForAirGap })
           const preDispenseAirGapMoveToCommand =
             !isDispenseRetractSafeForAirGap && destinationWell != null
               ? [


### PR DESCRIPTION
# Overview

Correctly pass `dispenseRetractPositionReference` rather than `dispensePositionReference` to `getIsRetractSafeForAirGap` in `distribute` and `transfer` compound command creators.

[thread for context](https://opentrons.slack.com/archives/C07JJA1AJFQ/p1751305420186259)

## Test Plan and Hands on Testing

- import [this protocol](https://github.com/user-attachments/files/20986070/hypothetical_lc_transfer.json) which specifies a dispense retract position that is safe for air gap (>= 2mm above the top of the well)
- verify that no superfluous `moveToWell` command to 2mm above the top of the well is emitted (the movement to the retract position is safe as is)

## Changelog

- fix params for position reference passed to `getIsRetractSafeForAirGap` util

## Review requests

see test plan

## Risk assessment

low