### PR TITLE
feat(opentrons-ai-client): add 96ch low volume

### DIFF
--- a/opentrons-ai-client/src/assets/localization/en/create_protocol.json
+++ b/opentrons-ai-client/src/assets/localization/en/create_protocol.json
@@ -1,6 +1,7 @@
 {
-  "96_channel_1000ul_pipette_label": "96-Channel 1000uL pipette",
-  "96_channel_1000ul_pipette": "96-Channel 1000uL pipette",
+  "96_channel_pipette_label": "96-Channel pipette",
+  "96_channel_1000ul": "96-Channel 1000uL",
+  "96_channel_low_volume": "96-Channel Low Volume",
   "absorbance_plate_reader_module_v1": "Absorbance Plate Reader Module GEN1",
   "adapter": "Adapter",
   "add_individual_step": "Add individual steps",
@@ -73,7 +74,7 @@
   "pcr": "PCR",
   "pd_prompt_warning": "Not all prompts will be possible to output to Protocol Designer. If OpentronsAI produces errors, you can correct them in OpentronsAI chat.",
   "pd_protocol": "Protocol Designer protocol",
-  "pipette_mounts": "Pipette mount(s)",
+  "pipette_mounts": "Pipette",
   "protocol_format_title": "Protocol Format",
   "protocol_format": "What file format should OpentronsAI use to generate the protocol?",
   "python_protocol": "Python protocol",

--- a/opentrons-ai-client/src/assets/localization/en/create_protocol.json
+++ b/opentrons-ai-client/src/assets/localization/en/create_protocol.json
@@ -74,7 +74,7 @@
   "pcr": "PCR",
   "pd_prompt_warning": "Not all prompts will be possible to output to Protocol Designer. If OpentronsAI produces errors, you can correct them in OpentronsAI chat.",
   "pd_protocol": "Protocol Designer protocol",
-  "pipette_mounts": "Pipette",
+  "pipette": "Pipette",
   "protocol_format_title": "Protocol Format",
   "protocol_format": "What file format should OpentronsAI use to generate the protocol?",
   "python_protocol": "Python protocol",

--- a/opentrons-ai-client/src/assets/localization/en/create_protocol.json
+++ b/opentrons-ai-client/src/assets/localization/en/create_protocol.json
@@ -1,7 +1,7 @@
 {
-  "96_channel_pipette_label": "96-Channel pipette",
-  "96_channel_1000ul": "96-Channel 1000uL",
-  "96_channel_low_volume": "96-Channel Low Volume",
+  "96_channel_pipette_label": "96-Channel pipettes",
+  "96_channel_200ul": "96-Channel 200uL pipette",
+  "96_channel_1000ul": "96-Channel 1000uL pipette",
   "absorbance_plate_reader_module_v1": "Absorbance Plate Reader Module GEN1",
   "adapter": "Adapter",
   "add_individual_step": "Add individual steps",

--- a/opentrons-ai-client/src/components/organisms/InstrumentsSection/__tests__/InstrumentsSection.test.tsx
+++ b/opentrons-ai-client/src/components/organisms/InstrumentsSection/__tests__/InstrumentsSection.test.tsx
@@ -46,16 +46,34 @@ describe('ApplicationSection', () => {
     ).toBeInTheDocument()
   })
 
-  it('should not render left and right mount dropdowns if 96-Channel 1000µL pipette radio is selected', () => {
+  it('should render 96-channel pipette dropdown when 96-Channel pipette radio is selected', () => {
     render()
 
-    const pipettesRadioButton = screen.getByLabelText(
-      '96-Channel 1000uL pipette'
-    )
+    const pipettesRadioButton = screen.getByLabelText('96-Channel pipette')
     fireEvent.click(pipettesRadioButton)
 
     expect(screen.queryByText('Left mount')).not.toBeInTheDocument()
     expect(screen.queryByText('Right mount')).not.toBeInTheDocument()
+    expect(screen.getByText('Pipette')).toBeInTheDocument()
+  })
+
+  it('should be able to select 96-channel pipette options from dropdown', async () => {
+    render()
+
+    const pipettesRadioButton = screen.getByLabelText('96-Channel pipette')
+    fireEvent.click(pipettesRadioButton)
+
+    const dropdown = screen.getByText('Choose pipette')
+    fireEvent.click(dropdown)
+
+    expect(screen.getByText('96-Channel 1000uL')).toBeInTheDocument()
+    expect(screen.getByText('96-Channel Low Volume')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('96-Channel 1000uL'))
+
+    await waitFor(() => {
+      expect(screen.getByText('96-Channel 1000uL')).toBeInTheDocument()
+    })
   })
 
   it('should render only left and right mount dropdowns if Opentrons OT-2 is selected', () => {
@@ -71,9 +89,7 @@ describe('ApplicationSection', () => {
     expect(screen.getByText('Right mount')).toBeInTheDocument()
 
     expect(screen.queryByText('Two pipettes')).not.toBeInTheDocument()
-    expect(
-      screen.queryByText('96-Channel 1000µL pipette')
-    ).not.toBeInTheDocument()
+    expect(screen.queryByText('96-Channel pipette')).not.toBeInTheDocument()
     expect(
       screen.queryByText('Do you want to use the Flex Gripper')
     ).not.toBeInTheDocument()

--- a/opentrons-ai-client/src/components/organisms/InstrumentsSection/__tests__/InstrumentsSection.test.tsx
+++ b/opentrons-ai-client/src/components/organisms/InstrumentsSection/__tests__/InstrumentsSection.test.tsx
@@ -49,7 +49,7 @@ describe('ApplicationSection', () => {
   it('should render 96-channel pipette dropdown when 96-Channel pipette radio is selected', () => {
     render()
 
-    const pipettesRadioButton = screen.getByLabelText('96-Channel pipette')
+    const pipettesRadioButton = screen.getByLabelText('96-Channel pipettes')
     fireEvent.click(pipettesRadioButton)
 
     expect(screen.queryByText('Left mount')).not.toBeInTheDocument()
@@ -60,19 +60,19 @@ describe('ApplicationSection', () => {
   it('should be able to select 96-channel pipette options from dropdown', async () => {
     render()
 
-    const pipettesRadioButton = screen.getByLabelText('96-Channel pipette')
+    const pipettesRadioButton = screen.getByLabelText('96-Channel pipettes')
     fireEvent.click(pipettesRadioButton)
 
     const dropdown = screen.getByText('Choose pipette')
     fireEvent.click(dropdown)
 
-    expect(screen.getByText('96-Channel 1000uL')).toBeInTheDocument()
-    expect(screen.getByText('96-Channel Low Volume')).toBeInTheDocument()
+    expect(screen.getByText('96-Channel 1000uL pipette')).toBeInTheDocument()
+    expect(screen.getByText('96-Channel 200uL pipette')).toBeInTheDocument()
 
-    fireEvent.click(screen.getByText('96-Channel 1000uL'))
+    fireEvent.click(screen.getByText('96-Channel 1000uL pipette'))
 
     await waitFor(() => {
-      expect(screen.getByText('96-Channel 1000uL')).toBeInTheDocument()
+      expect(screen.getByText('96-Channel 1000uL pipette')).toBeInTheDocument()
     })
   })
 
@@ -89,7 +89,7 @@ describe('ApplicationSection', () => {
     expect(screen.getByText('Right mount')).toBeInTheDocument()
 
     expect(screen.queryByText('Two pipettes')).not.toBeInTheDocument()
-    expect(screen.queryByText('96-Channel pipette')).not.toBeInTheDocument()
+    expect(screen.queryByText('96-Channel pipettes')).not.toBeInTheDocument()
     expect(
       screen.queryByText('Do you want to use the Flex Gripper')
     ).not.toBeInTheDocument()

--- a/opentrons-ai-client/src/components/organisms/InstrumentsSection/index.tsx
+++ b/opentrons-ai-client/src/components/organisms/InstrumentsSection/index.tsx
@@ -96,8 +96,8 @@ export function InstrumentsSection(): JSX.Element | null {
   ]
 
   const ninetySixChannelOptions = [
-    { name: t('96_channel_1000ul'), value: 'flex_96channel_1000' },
-    { name: t('96_channel_low_volume'), value: 'flex_96channel_low_volume' },
+    { name: t('96_channel_200ul'), value: 'Flex 96-Channel 200uL pipette' },
+    { name: t('96_channel_1000ul'), value: 'Flex 96-Channel 1000uL pipette' },
   ]
 
   const pipetteOptions = useMemo(() => {

--- a/opentrons-ai-client/src/components/organisms/InstrumentsSection/index.tsx
+++ b/opentrons-ai-client/src/components/organisms/InstrumentsSection/index.tsx
@@ -31,7 +31,7 @@ export const FLEX_GRIPPER = 'flex_gripper'
 export const NO_FLEX_GRIPPER = 'no_flex_gripper'
 export const OPENTRONS_FLEX = 'opentrons_flex'
 export const OPENTRONS_OT2 = 'opentrons_ot2'
-export const _96_CHANNEL_PIPETTE = '96_channel_pipette'
+export const NINETY_SIX_CHANNEL_PIPETTE = '96_channel_pipette'
 export const TWO_PIPETTES = 'two_pipettes'
 export const NO_PIPETTES = 'none'
 
@@ -53,7 +53,8 @@ export function InstrumentsSection(): JSX.Element | null {
 
   const robotType = watch(ROBOT_FIELD_NAME)
   const isOtherPipettesSelected = watch(PIPETTES_FIELD_NAME) === TWO_PIPETTES
-  const is96ChannelSelected = watch(PIPETTES_FIELD_NAME) === _96_CHANNEL_PIPETTE
+  const is96ChannelSelected =
+    watch(PIPETTES_FIELD_NAME) === NINETY_SIX_CHANNEL_PIPETTE
   const isOpentronsOT2Selected = robotType === OPENTRONS_OT2
 
   const robotRadioButtons = [
@@ -76,9 +77,9 @@ export function InstrumentsSection(): JSX.Element | null {
       buttonValue: TWO_PIPETTES,
     },
     {
-      id: _96_CHANNEL_PIPETTE,
+      id: NINETY_SIX_CHANNEL_PIPETTE,
       buttonLabel: t('96_channel_pipette_label'),
-      buttonValue: _96_CHANNEL_PIPETTE,
+      buttonValue: NINETY_SIX_CHANNEL_PIPETTE,
     },
   ]
 

--- a/opentrons-ai-client/src/components/organisms/InstrumentsSection/index.tsx
+++ b/opentrons-ai-client/src/components/organisms/InstrumentsSection/index.tsx
@@ -193,7 +193,7 @@ export function InstrumentsSection(): JSX.Element | null {
             <ControlledDropdownMenu
               width="100%"
               dropdownType="neutral"
-              title={t('pipette_mounts')}
+              title={t('pipette')}
               name={NINETY_SIX_CHANNEL_PIPETTE_FIELD_NAME}
               options={ninetySixChannelOptions}
               placeholder={t('choose_pipette_placeholder')}

--- a/opentrons-ai-client/src/components/organisms/InstrumentsSection/index.tsx
+++ b/opentrons-ai-client/src/components/organisms/InstrumentsSection/index.tsx
@@ -25,11 +25,13 @@ export const PIPETTES_FIELD_NAME = 'instruments.pipettes'
 export const FLEX_GRIPPER_FIELD_NAME = 'instruments.flexGripper'
 export const LEFT_PIPETTE_FIELD_NAME = 'instruments.leftPipette'
 export const RIGHT_PIPETTE_FIELD_NAME = 'instruments.rightPipette'
+export const NINETY_SIX_CHANNEL_PIPETTE_FIELD_NAME =
+  'instruments.ninetySixChannelPipette'
 export const FLEX_GRIPPER = 'flex_gripper'
 export const NO_FLEX_GRIPPER = 'no_flex_gripper'
 export const OPENTRONS_FLEX = 'opentrons_flex'
 export const OPENTRONS_OT2 = 'opentrons_ot2'
-export const _96_CHANNEL_1000UL_PIPETTE = '96_channel_1000ul_pipette'
+export const _96_CHANNEL_PIPETTE = '96_channel_pipette'
 export const TWO_PIPETTES = 'two_pipettes'
 export const NO_PIPETTES = 'none'
 
@@ -45,11 +47,13 @@ export function InstrumentsSection(): JSX.Element | null {
       FLEX_GRIPPER_FIELD_NAME,
       LEFT_PIPETTE_FIELD_NAME,
       RIGHT_PIPETTE_FIELD_NAME,
+      NINETY_SIX_CHANNEL_PIPETTE_FIELD_NAME,
     ])
   })
 
   const robotType = watch(ROBOT_FIELD_NAME)
   const isOtherPipettesSelected = watch(PIPETTES_FIELD_NAME) === TWO_PIPETTES
+  const is96ChannelSelected = watch(PIPETTES_FIELD_NAME) === _96_CHANNEL_PIPETTE
   const isOpentronsOT2Selected = robotType === OPENTRONS_OT2
 
   const robotRadioButtons = [
@@ -72,9 +76,9 @@ export function InstrumentsSection(): JSX.Element | null {
       buttonValue: TWO_PIPETTES,
     },
     {
-      id: _96_CHANNEL_1000UL_PIPETTE,
-      buttonLabel: t('96_channel_1000ul_pipette_label'),
-      buttonValue: _96_CHANNEL_1000UL_PIPETTE,
+      id: _96_CHANNEL_PIPETTE,
+      buttonLabel: t('96_channel_pipette_label'),
+      buttonValue: _96_CHANNEL_PIPETTE,
     },
   ]
 
@@ -89,6 +93,11 @@ export function InstrumentsSection(): JSX.Element | null {
       buttonLabel: t('flex_gripper_no_label'),
       buttonValue: NO_FLEX_GRIPPER,
     },
+  ]
+
+  const ninetySixChannelOptions = [
+    { name: t('96_channel_1000ul'), value: 'flex_96channel_1000' },
+    { name: t('96_channel_low_volume'), value: 'flex_96channel_low_volume' },
   ]
 
   const pipetteOptions = useMemo(() => {
@@ -171,6 +180,22 @@ export function InstrumentsSection(): JSX.Element | null {
               title={t('right_pipette_label')}
               name={RIGHT_PIPETTE_FIELD_NAME}
               options={pipetteOptions}
+              placeholder={t('choose_pipette_placeholder')}
+              rules={{
+                required: true,
+              }}
+            />
+          </PipettesDropdown>
+        )}
+
+        {is96ChannelSelected && (
+          <PipettesDropdown>
+            <ControlledDropdownMenu
+              width="100%"
+              dropdownType="neutral"
+              title={t('pipette_mounts')}
+              name={NINETY_SIX_CHANNEL_PIPETTE_FIELD_NAME}
+              options={ninetySixChannelOptions}
               placeholder={t('choose_pipette_placeholder')}
               rules={{
                 required: true,

--- a/opentrons-ai-client/src/pages/CreateProtocol/index.tsx
+++ b/opentrons-ai-client/src/pages/CreateProtocol/index.tsx
@@ -51,6 +51,7 @@ export interface CreateProtocolFormData {
     pipettes: string
     leftPipette: string
     rightPipette: string
+    ninetySixChannelPipette: string
     flexGripper: string
   }
   modules: DisplayModule[]

--- a/opentrons-ai-client/src/resources/utils/createProtocolUtils.tsx
+++ b/opentrons-ai-client/src/resources/utils/createProtocolUtils.tsx
@@ -9,6 +9,7 @@ import {
 
 import { OTHER } from '/ai-client/components/organisms/ApplicationSection'
 import {
+  _96_CHANNEL_PIPETTE,
   FLEX_GRIPPER,
   NO_PIPETTES,
   OPENTRONS_FLEX,
@@ -60,7 +61,14 @@ export function generatePromptPreviewInstrumentItems(
   t: any
 ): string[] {
   const {
-    instruments: { robot, pipettes, leftPipette, rightPipette, flexGripper },
+    instruments: {
+      robot,
+      pipettes,
+      leftPipette,
+      rightPipette,
+      ninetySixChannelPipette,
+      flexGripper,
+    },
   } = watch()
 
   const items = []
@@ -75,6 +83,8 @@ export function generatePromptPreviewInstrumentItems(
     rightPipette !== '' &&
       rightPipette !== NO_PIPETTES &&
       items.push(getPipetteSpecsV2(rightPipette as PipetteName)?.displayName)
+  } else if (pipettes === _96_CHANNEL_PIPETTE) {
+    ninetySixChannelPipette !== '' && items.push(t(ninetySixChannelPipette))
   } else {
     items.push(pipettes !== '' && t(pipettes))
   }
@@ -359,6 +369,8 @@ export function generateChatPrompt(
             ? `right pipette ${rightPipettePromptName}`
             : '',
         ].filter(Boolean)
+      : values.instruments.pipettes === _96_CHANNEL_PIPETTE
+      ? [values.instruments.ninetySixChannelPipette]
       : [values.instruments.pipettes]
 
   const pipetteMounts =
@@ -371,6 +383,8 @@ export function generateChatPrompt(
         ]
           .filter(Boolean)
           .join('\n')
+      : values.instruments.pipettes === _96_CHANNEL_PIPETTE
+      ? `- ${t(values.instruments.ninetySixChannelPipette)}`
       : `- ${t(values.instruments.pipettes)}`
   const flexGripper =
     values.instruments.flexGripper === FLEX_GRIPPER &&

--- a/opentrons-ai-client/src/resources/utils/createProtocolUtils.tsx
+++ b/opentrons-ai-client/src/resources/utils/createProtocolUtils.tsx
@@ -450,7 +450,7 @@ ${t('application_title')}:\n${scientificApplication}
 ${t('description')}:\n${description}
 
 ${t(
-  'pipette_mounts'
+  'pipette'
 )}:\n\n${pipetteMounts}${flexGripper}${moduleSection}${fixtureSection}
 
 \n${t('labware_section_title')}:\n${labwares}

--- a/opentrons-ai-client/src/resources/utils/createProtocolUtils.tsx
+++ b/opentrons-ai-client/src/resources/utils/createProtocolUtils.tsx
@@ -9,8 +9,8 @@ import {
 
 import { OTHER } from '/ai-client/components/organisms/ApplicationSection'
 import {
-  _96_CHANNEL_PIPETTE,
   FLEX_GRIPPER,
+  NINETY_SIX_CHANNEL_PIPETTE,
   NO_PIPETTES,
   OPENTRONS_FLEX,
   OPENTRONS_OT2,
@@ -83,7 +83,7 @@ export function generatePromptPreviewInstrumentItems(
     rightPipette !== '' &&
       rightPipette !== NO_PIPETTES &&
       items.push(getPipetteSpecsV2(rightPipette as PipetteName)?.displayName)
-  } else if (pipettes === _96_CHANNEL_PIPETTE) {
+  } else if (pipettes === NINETY_SIX_CHANNEL_PIPETTE) {
     ninetySixChannelPipette !== '' && items.push(t(ninetySixChannelPipette))
   } else {
     items.push(pipettes !== '' && t(pipettes))
@@ -369,7 +369,7 @@ export function generateChatPrompt(
             ? `right pipette ${rightPipettePromptName}`
             : '',
         ].filter(Boolean)
-      : values.instruments.pipettes === _96_CHANNEL_PIPETTE
+      : values.instruments.pipettes === NINETY_SIX_CHANNEL_PIPETTE
       ? [values.instruments.ninetySixChannelPipette]
       : [values.instruments.pipettes]
 
@@ -383,7 +383,7 @@ export function generateChatPrompt(
         ]
           .filter(Boolean)
           .join('\n')
-      : values.instruments.pipettes === _96_CHANNEL_PIPETTE
+      : values.instruments.pipettes === NINETY_SIX_CHANNEL_PIPETTE
       ? `- ${t(values.instruments.ninetySixChannelPipette)}`
       : `- ${t(values.instruments.pipettes)}`
   const flexGripper =


### PR DESCRIPTION
# Overview

Close AUTH-1847
PR adds 96ch low volume (200uL) option

<img width="816" height="359" alt="image" src="https://github.com/user-attachments/assets/8be105f8-f0bb-424c-8e80-95336fb33aec" />


## Test Plan and Hands on Testing

CI


## Review requests

See UI and confirm 96 low channel exists

## Risk assessment

Low