### PR TITLE
fix(opentrons-ai-client): buttons are not stretched

### DIFF
--- a/opentrons-ai-client/src/organisms/LabwareLiquidsSection/index.tsx
+++ b/opentrons-ai-client/src/organisms/LabwareLiquidsSection/index.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useFormContext } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
+import styled from 'styled-components'
 
 import {
   COLORS,
@@ -50,14 +51,18 @@ export function LabwareLiquidsSection(): JSX.Element | null {
         {t('labware_section_textbody')}
       </StyledText>
 
-      <EmptySelectorButton
-        onClick={() => {
-          setDisplayLabwareModal(true)
-        }}
-        text={t('add_opentrons_labware')}
-        textAlignment="left"
-        iconName="plus"
-      />
+      <Flex justifyContent="flex-start">
+        <ButtonWrapper>
+          <EmptySelectorButton
+            onClick={() => {
+              setDisplayLabwareModal(true)
+            }}
+            text={t('add_opentrons_labware')}
+            textAlignment="left"
+            iconName="plus"
+          />
+        </ButtonWrapper>
+      </Flex>
 
       <LabwareModal
         displayLabwareModal={displayLabwareModal}
@@ -79,14 +84,18 @@ export function LabwareLiquidsSection(): JSX.Element | null {
         {t('liquid_section_textbody')}
       </StyledText>
 
-      <EmptySelectorButton
-        onClick={() => {
-          setValue(LIQUIDS_FIELD_NAME, [...liquids, ''])
-        }}
-        text={t('add_opentrons_liquid')}
-        textAlignment="left"
-        iconName="plus"
-      />
+      <Flex justifyContent="flex-start">
+        <ButtonWrapper>
+          <EmptySelectorButton
+            onClick={() => {
+              setValue(LIQUIDS_FIELD_NAME, [...liquids, ''])
+            }}
+            text={t('add_opentrons_liquid')}
+            textAlignment="left"
+            iconName="plus"
+          />
+        </ButtonWrapper>
+      </Flex>
 
       <ControlledAddTextAreaFields
         fieldName={LIQUIDS_FIELD_NAME}
@@ -96,3 +105,9 @@ export function LabwareLiquidsSection(): JSX.Element | null {
     </Flex>
   )
 }
+
+const ButtonWrapper = styled.div`
+  display: inline-block;
+  flex-grow: 0;
+  flex-shrink: 1;
+`

--- a/opentrons-ai-client/src/organisms/LabwareLiquidsSection/index.tsx
+++ b/opentrons-ai-client/src/organisms/LabwareLiquidsSection/index.tsx
@@ -9,6 +9,7 @@ import {
   EmptySelectorButton,
   Flex,
   InfoScreen,
+  JUSTIFY_FLEX_START,
   SPACING,
   StyledText,
 } from '@opentrons/components'
@@ -51,7 +52,7 @@ export function LabwareLiquidsSection(): JSX.Element | null {
         {t('labware_section_textbody')}
       </StyledText>
 
-      <Flex justifyContent="flex-start">
+      <Flex justifyContent={JUSTIFY_FLEX_START}>
         <ButtonWrapper>
           <EmptySelectorButton
             onClick={() => {
@@ -84,7 +85,7 @@ export function LabwareLiquidsSection(): JSX.Element | null {
         {t('liquid_section_textbody')}
       </StyledText>
 
-      <Flex justifyContent="flex-start">
+      <Flex justifyContent={JUSTIFY_FLEX_START}>
         <ButtonWrapper>
           <EmptySelectorButton
             onClick={() => {


### PR DESCRIPTION
# Overview

Close AUTH-1816
PR fixes `bug: add item tile is stretched to full width`.


Fixed version:
![image](https://github.com/user-attachments/assets/326c46ac-6f28-4145-ae86-b1ff3cf90c71)

## Test Plan and Hands on Testing
CI


## Review requests

See if the button is on not stretched to the full width

## Risk assessment

Low