### PR TITLE
fix(opentrons-ai-client): fix adapter dropdown

### DIFF
--- a/opentrons-ai-client/src/molecules/ModuleListItemGroup/__tests__/ModuleListItemGroup.test.tsx
+++ b/opentrons-ai-client/src/molecules/ModuleListItemGroup/__tests__/ModuleListItemGroup.test.tsx
@@ -92,7 +92,7 @@ describe('ModuleListItemGroup', () => {
     const listBox = await screen.findByRole('listbox')
 
     const adapterOptionButton = within(listBox).getByText(
-      'Opentrons 24 Well Aluminum Block with Generic 2 mL Screwcap'
+      'Opentrons 96 Deep Well Temperature Module Adapter'
     )
 
     fireEvent.click(adapterOptionButton)
@@ -110,7 +110,7 @@ describe('ModuleListItemGroup', () => {
 
     expect(
       within(secondModuleListItem).getByText(
-        'Opentrons 24 Well Aluminum Block with Generic 2 mL Screwcap'
+        'Opentrons 96 Deep Well Temperature Module Adapter'
       )
     ).toBeInTheDocument()
 

--- a/opentrons-ai-client/src/molecules/ModuleListItemGroup/index.tsx
+++ b/opentrons-ai-client/src/molecules/ModuleListItemGroup/index.tsx
@@ -21,13 +21,14 @@ import {
   THERMOCYCLER_MODULE_TYPE,
 } from '@opentrons/shared-data'
 
-import { MODULES_FIELD_NAME } from '../../organisms/ModulesAndFixturesSection'
-import { getOnlyLatestDefs } from '../../resources/utils'
+import { MODULES_FIELD_NAME } from "../../../../../../../../../ai-client/organisms/ModulesAndFixturesSection"
+import { getOnlyLatestDefs } from "../../../../../../../../../ai-client/resources/utils"
+
 import { ModuleDiagram } from '../ModelDiagram'
 
 import type { DropdownBorder } from '@opentrons/components'
 import type { ModuleType } from '@opentrons/shared-data'
-import type { DisplayModule } from '../../organisms/ModulesAndFixturesSection'
+import type { DisplayModule } from "../../../../../../../../../ai-client/organisms/ModulesAndFixturesSection"
 
 export const RECOMMENDED_LABWARE_BY_MODULE: { [K in ModuleType]: string[] } = {
   [TEMPERATURE_MODULE_TYPE]: [
@@ -71,7 +72,6 @@ export function ModuleListItemGroup(): JSX.Element | null {
   const modulesWatch: DisplayModule[] = watch(MODULES_FIELD_NAME) ?? []
 
   const allDefinitionsValues = useMemo(
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
     () => Object.values(getOnlyLatestDefs()),
     []
   )
@@ -101,13 +101,17 @@ export function ModuleListItemGroup(): JSX.Element | null {
                 <ListItem type="default" key={module.id}>
                   <ListItemCustomize
                     label={
-                      adapters != null && adapters.length > 0
+                      adapters != null &&
+                      adapters.length > 0 &&
+                      module.type !== THERMOCYCLER_MODULE_TYPE
                         ? t('modules_adapter_label')
                         : undefined
                     }
                     linkText={t('modules_remove_label')}
                     dropdown={
-                      adapters != null && adapters.length > 0
+                      adapters != null &&
+                      adapters.length > 0 &&
+                      module.type !== THERMOCYCLER_MODULE_TYPE
                         ? {
                             title: (null as unknown) as string,
                             width: '13rem',
@@ -134,17 +138,10 @@ export function ModuleListItemGroup(): JSX.Element | null {
                               )
                             },
                             dropdownType: 'neutral' as DropdownBorder,
-                            filterOptions: adapters
-                              ?.filter(adapter => {
-                                if (module.type === TEMPERATURE_MODULE_TYPE) {
-                                  return adapter.includes('adapter')
-                                }
-                                return true
-                              })
-                              ?.map(adapter => ({
-                                name: getDefDisplayName(adapter),
-                                value: adapter,
-                              })),
+                            filterOptions: adapters?.map(adapter => ({
+                              name: getDefDisplayName(adapter),
+                              value: adapter,
+                            })),
                           }
                         : undefined
                     }

--- a/opentrons-ai-client/src/molecules/ModuleListItemGroup/index.tsx
+++ b/opentrons-ai-client/src/molecules/ModuleListItemGroup/index.tsx
@@ -71,7 +71,6 @@ export function ModuleListItemGroup(): JSX.Element | null {
   const modulesWatch: DisplayModule[] = watch(MODULES_FIELD_NAME) ?? []
 
   const allDefinitionsValues = useMemo(
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
     () => Object.values(getOnlyLatestDefs()),
     []
   )

--- a/opentrons-ai-client/src/molecules/ModuleListItemGroup/index.tsx
+++ b/opentrons-ai-client/src/molecules/ModuleListItemGroup/index.tsx
@@ -71,6 +71,7 @@ export function ModuleListItemGroup(): JSX.Element | null {
   const modulesWatch: DisplayModule[] = watch(MODULES_FIELD_NAME) ?? []
 
   const allDefinitionsValues = useMemo(
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
     () => Object.values(getOnlyLatestDefs()),
     []
   )
@@ -133,10 +134,16 @@ export function ModuleListItemGroup(): JSX.Element | null {
                               )
                             },
                             dropdownType: 'neutral' as DropdownBorder,
-                            filterOptions: adapters?.map(adapter => ({
-                              name: getDefDisplayName(adapter),
-                              value: adapter,
-                            })),
+                            filterOptions: adapters
+                              ?.filter(adapter =>
+                                module.type === TEMPERATURE_MODULE_TYPE
+                                  ? adapter.includes('adapter')
+                                  : true
+                              )
+                              ?.map(adapter => ({
+                                name: getDefDisplayName(adapter),
+                                value: adapter,
+                              })),
                           }
                         : undefined
                     }

--- a/opentrons-ai-client/src/molecules/ModuleListItemGroup/index.tsx
+++ b/opentrons-ai-client/src/molecules/ModuleListItemGroup/index.tsx
@@ -21,14 +21,13 @@ import {
   THERMOCYCLER_MODULE_TYPE,
 } from '@opentrons/shared-data'
 
-import { MODULES_FIELD_NAME } from "../../../../../../../../../ai-client/organisms/ModulesAndFixturesSection"
-import { getOnlyLatestDefs } from "../../../../../../../../../ai-client/resources/utils"
-
+import { MODULES_FIELD_NAME } from '../../organisms/ModulesAndFixturesSection'
+import { getOnlyLatestDefs } from '../../resources/utils'
 import { ModuleDiagram } from '../ModelDiagram'
 
 import type { DropdownBorder } from '@opentrons/components'
 import type { ModuleType } from '@opentrons/shared-data'
-import type { DisplayModule } from "../../../../../../../../../ai-client/organisms/ModulesAndFixturesSection"
+import type { DisplayModule } from '../../organisms/ModulesAndFixturesSection'
 
 export const RECOMMENDED_LABWARE_BY_MODULE: { [K in ModuleType]: string[] } = {
   [TEMPERATURE_MODULE_TYPE]: [
@@ -72,6 +71,7 @@ export function ModuleListItemGroup(): JSX.Element | null {
   const modulesWatch: DisplayModule[] = watch(MODULES_FIELD_NAME) ?? []
 
   const allDefinitionsValues = useMemo(
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
     () => Object.values(getOnlyLatestDefs()),
     []
   )
@@ -101,17 +101,13 @@ export function ModuleListItemGroup(): JSX.Element | null {
                 <ListItem type="default" key={module.id}>
                   <ListItemCustomize
                     label={
-                      adapters != null &&
-                      adapters.length > 0 &&
-                      module.type !== THERMOCYCLER_MODULE_TYPE
+                      adapters != null && adapters.length > 0
                         ? t('modules_adapter_label')
                         : undefined
                     }
                     linkText={t('modules_remove_label')}
                     dropdown={
-                      adapters != null &&
-                      adapters.length > 0 &&
-                      module.type !== THERMOCYCLER_MODULE_TYPE
+                      adapters != null && adapters.length > 0
                         ? {
                             title: (null as unknown) as string,
                             width: '13rem',
@@ -138,10 +134,17 @@ export function ModuleListItemGroup(): JSX.Element | null {
                               )
                             },
                             dropdownType: 'neutral' as DropdownBorder,
-                            filterOptions: adapters?.map(adapter => ({
-                              name: getDefDisplayName(adapter),
-                              value: adapter,
-                            })),
+                            filterOptions: adapters
+                              ?.filter(adapter => {
+                                if (module.type === TEMPERATURE_MODULE_TYPE) {
+                                  return adapter.includes('adapter')
+                                }
+                                return true
+                              })
+                              ?.map(adapter => ({
+                                name: getDefDisplayName(adapter),
+                                value: adapter,
+                              })),
                           }
                         : undefined
                     }

--- a/opentrons-ai-client/src/molecules/ModuleListItemGroup/index.tsx
+++ b/opentrons-ai-client/src/molecules/ModuleListItemGroup/index.tsx
@@ -85,19 +85,20 @@ export function ModuleListItemGroup(): JSX.Element | null {
   return (
     <>
       {modulesWatch?.map(module => {
+        const moduleId = module.id
         const adapters = RECOMMENDED_LABWARE_BY_MODULE[module.type]
 
         return (
           <Controller
-            key={module.id}
+            key={moduleId}
             name={MODULES_FIELD_NAME}
             render={({ field }) => {
               const currentModule = field.value.find(
-                (m: DisplayModule) => m.id === module.id
+                (m: DisplayModule) => m.id === moduleId
               )
 
               return (
-                <ListItem type="default" key={module.id}>
+                <ListItem type="default" key={moduleId}>
                   <ListItemCustomize
                     label={
                       adapters != null && adapters.length > 0
@@ -120,7 +121,7 @@ export function ModuleListItemGroup(): JSX.Element | null {
                             onClick: (value: string) => {
                               field.onChange(
                                 field.value.map((m: DisplayModule) =>
-                                  m.id === module.id
+                                  m.id === moduleId
                                     ? {
                                         ...m,
                                         adapter: {
@@ -150,7 +151,7 @@ export function ModuleListItemGroup(): JSX.Element | null {
                     onClick={() => {
                       setValue(
                         MODULES_FIELD_NAME,
-                        modulesWatch.filter(m => m.id !== module.id),
+                        modulesWatch.filter(m => m.id !== moduleId),
                         { shouldValidate: true }
                       )
                     }}

--- a/opentrons-ai-client/src/molecules/ModuleListItemGroup/index.tsx
+++ b/opentrons-ai-client/src/molecules/ModuleListItemGroup/index.tsx
@@ -135,11 +135,12 @@ export function ModuleListItemGroup(): JSX.Element | null {
                             },
                             dropdownType: 'neutral' as DropdownBorder,
                             filterOptions: adapters
-                              ?.filter(adapter =>
-                                module.type === TEMPERATURE_MODULE_TYPE
-                                  ? adapter.includes('adapter')
-                                  : true
-                              )
+                              ?.filter(adapter => {
+                                if (module.type === TEMPERATURE_MODULE_TYPE) {
+                                  return adapter.includes('adapter')
+                                }
+                                return true
+                              })
                               ?.map(adapter => ({
                                 name: getDefDisplayName(adapter),
                                 value: adapter,


### PR DESCRIPTION
# Overview

Closes AUTH-1812

show only adapters for the Temperature Module, rather than showing all labware options including aluminum blocks

Keep only adapters
![image](https://github.com/user-attachments/assets/9d8a8dc9-00cc-4966-b298-60ac6e81ba4c)


## Test Plan and Hands on Testing

CI


## Review requests

- Got to create protocol workflow
- Choose temperature module and see the adapter dropdown shows only adapter

## Risk assessment

Low