### PR TITLE
fix(shared-data): NEST deep well plate units

### DIFF
--- a/protocol-designer/cypress/support/SetupSteps.ts
+++ b/protocol-designer/cypress/support/SetupSteps.ts
@@ -57,7 +57,7 @@ export enum SetupContent {
   SampleLiquidName = 'My liquid!',
   ProtocolSteps = 'Protocol steps',
   AddStep = 'Add Step',
-  NestDeepWell = 'NEST 96 Deep Well Plate 2mL',
+  NestDeepWell = 'NEST 96 Deep Well Plate 2 mL',
   Save = 'Save',
 }
 
@@ -603,7 +603,7 @@ export const SetupSteps = {
   }),
 
   /**
-   * Adds "NEST 96 Deep Well Plate 2mL".
+   * Adds "NEST 96 Deep Well Plate 2 mL".
    */
   AddNest96DeepWellPlate: (): StepThunk => ({
     call: () => {

--- a/shared-data/labware/definitions/2/nest_96_wellplate_2ml_deep/4.json
+++ b/shared-data/labware/definitions/2/nest_96_wellplate_2ml_deep/4.json
@@ -19,7 +19,7 @@
     "links": ["https://www.nest-biotech.com/deep-well-plates/59253726.html"]
   },
   "metadata": {
-    "displayName": "NEST 96 Deep Well Plate 2mL",
+    "displayName": "NEST 96 Deep Well Plate 2 mL",
     "displayCategory": "wellPlate",
     "displayVolumeUnits": "µL",
     "tags": []


### PR DESCRIPTION

# Overview

🧐 ok, so

SI and Opentrons house style is to put a space between the number and units. This labware definition is the only one in the entire library that didn't do that.

## Test Plan and Hands on Testing

- Built LL locally.
- Automated tests.

## Changelog

␣

## Review requests

- Does this have major knock-on effects outside LL? Not worth the trouble?
- Does this small change require a bump from 4.json to 5.json?

## Risk assessment

not sure, see above!