### PR TITLE
fix(protocol-designer): only show liquid class assignment if in source well

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/hooks.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/hooks.ts
@@ -63,7 +63,6 @@ export function useAssignLiquidClass(
       ? getAllWellsFromPrimaryWells(
           formData[wellsField] as string[],
           labwareEntities[formData[labwareField]]?.def,
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
           channels as 8 | 96
         )
       : (formData[wellsField] as string[])

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/hooks.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/hooks.ts
@@ -70,7 +70,7 @@ export function useAssignLiquidClass(
   const liquidClassesInSourceWellsSet = allWellsAdjustedForPipette.reduce<
     Set<string>
   >((acc, wellName) => {
-    const liquidGroupsInWell = liquidsInLabware[wellName] ?? {}
+    const liquidGroupsInWell = liquidsInLabware?.[wellName] ?? {}
     for (const liquidGroup of Object.keys(liquidGroupsInWell)) {
       const liquidClass = allIngredientGroupFields[liquidGroup]?.liquidClass
       if (liquidClass != null) {

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/hooks.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/hooks.ts
@@ -3,11 +3,14 @@ import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 
 import {
+  ALL,
+  COLUMN,
   getAllLiquidClassDefs,
   getFlexNameConversion,
 } from '@opentrons/shared-data'
 
 import { MINIMUM_LIQUID_CLASS_VOLUME } from '../../../../../../constants'
+import { selectors as labwareIngredSelectors } from '../../../../../../labware-ingred/selectors'
 import {
   getCurrentFormIsPresaved,
   getCurrentFormUnsavedChangedFields,
@@ -40,6 +43,43 @@ export function useAssignLiquidClass(
   const { t } = useTranslation('liquids')
   const liquids = useSelector(getLiquidEntities)
   const currentFormIsPresaved = useSelector(getCurrentFormIsPresaved)
+  const labwareEntities = useSelector(getLabwareEntities)
+  const liquidEntities = useSelector(getLiquidEntities)
+  const allIngredientGroupFields = useSelector(
+    labwareIngredSelectors.allIngredientGroupFields
+  )
+  const liquidsInLabware = useSelector(
+    labwareIngredSelectors.getLiquidsByLabwareId
+  )[formData[labwareField]]
+  const nozzlesConfigured = formData.nozzles
+  let channels = 1
+  if (nozzlesConfigured === COLUMN) {
+    channels = 8
+  } else if (nozzlesConfigured === ALL) {
+    channels = 96
+  }
+  const allWellsAdjustedForPipette =
+    channels !== 1
+      ? getAllWellsFromPrimaryWells(
+          formData[wellsField] as string[],
+          labwareEntities[formData[labwareField]]?.def,
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+          channels as 8 | 96
+        )
+      : (formData[wellsField] as string[])
+
+  const liquidClassesInSourceWellsSet = allWellsAdjustedForPipette.reduce<
+    Set<string>
+  >((acc, wellName) => {
+    const liquidGroupsInWell = liquidsInLabware[wellName] ?? {}
+    for (const liquidGroup of Object.keys(liquidGroupsInWell)) {
+      const liquidClass = allIngredientGroupFields[liquidGroup]?.liquidClass
+      if (liquidClass != null) {
+        acc.add(liquidClass)
+      }
+    }
+    return acc
+  }, new Set<string>())
   const liquidClasses = getAllLiquidClassDefs()
   const liquidClassToLiquidsMap: Record<string, string[]> = {}
   Object.values(liquids).forEach(({ displayName, liquidClass }) => {
@@ -59,7 +99,8 @@ export function useAssignLiquidClass(
     ...Object.entries(liquidClasses).map(([liquidClassName, def]) => ({
       name: def.displayName,
       value: liquidClassName,
-      subButtonLabel: (liquidClassToLiquidsMap[liquidClassName] != null
+      subButtonLabel: (liquidClassToLiquidsMap[liquidClassName] != null &&
+      liquidClassesInSourceWellsSet.has(liquidClassName)
         ? t('assigned_liquid', {
             liquidName: liquidClassToLiquidsMap[liquidClassName].join(', '),
           })
@@ -74,19 +115,6 @@ export function useAssignLiquidClass(
   )
   const aspirateLabwareLiquids =
     allWellContentsForActiveItem?.[formData[labwareField]]
-  const labwareEntities = useSelector(getLabwareEntities)
-  const pipetteEntities = useSelector(getPipetteEntities)
-  const liquidEntities = useSelector(getLiquidEntities)
-  const channels = pipetteEntities[formData.pipette]?.spec.channels ?? 1
-  const allWellsAdjustedForPipette =
-    channels !== 1
-      ? getAllWellsFromPrimaryWells(
-          formData[wellsField] as string[],
-          labwareEntities[formData[labwareField]]?.def,
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-          channels
-        )
-      : formData[wellsField]
 
   const [orderedLiquidClassOptions, setOrderedLiquidClassOptions] = useState<
     LiquidClassOption[]


### PR DESCRIPTION
# Overview

This PR fixes the subtext in the liquid class options in a transfer or mix form. We should only show "Assigned to [x,y,z wells]" subtext to a liquid class option if the liquid class is assigned to a liquid in at least one of the selected source/mix wells. If the liquid class is present in the source/mix labwrae, but not present in the selected source wells, we show the liquid class's generic description.

Closes RQA-4106

## Test Plan and Hands on Testing

- create or import a protocol with liquids with assigned liquid classes ([example](https://github.com/user-attachments/files/21000691/RQA4151.3.json))
- add the liquids to a labware on the deck
- create or edit a transfer form selecting the labware with liquid classes as the source labware
- select wells with only one liquid class among them (i.e., the source wells only contain liquid of class "viscous")
- continue to liquid class options page
- verify that subtext for the liquid class _included in the source wells_ is the "Assigned to [liquid name]" text
- verify that subtext for the liquid class _not included in the source wells_ is the liquid class's generic description
- repeat with mix form

## Changelog

- fix hook for liquid class options

## Review requests

see test plan

## Risk assessment

low