### PR TITLE
fix(opentrons-ai-client): remove adapters dropdown from thermocycler, magnetic, plate reader

### DIFF
--- a/opentrons-ai-client/src/molecules/ModuleListItemGroup/__tests__/ModuleListItemGroup.test.tsx
+++ b/opentrons-ai-client/src/molecules/ModuleListItemGroup/__tests__/ModuleListItemGroup.test.tsx
@@ -50,7 +50,7 @@ const modulesMock: TestDisplayModule[] = [
     id: 'module-6',
     type: 'absorbanceReaderType',
     model: 'absorbanceReaderV1',
-    name: 'Absorbance Plate Reader Module',
+    name: 'Absorbance Plate Reader Module GEN1',
   },
 ]
 
@@ -97,7 +97,7 @@ describe('ModuleListItemGroup', () => {
     screen.getByText('Magnetic Block GEN1')
 
     screen.getByAltText('absorbanceReaderType')
-    screen.getByText('Absorbance Plate Reader Module')
+    screen.getByText('Absorbance Plate Reader Module GEN1')
   })
 
   it('should remove the list item if remove is clicked', async () => {
@@ -217,7 +217,7 @@ describe('ModuleListItemGroup', () => {
 
     // Test Absorbance Reader
     const absorbanceReaderListItem = listItems.find(item =>
-      within(item).queryByText('Absorbance Plate Reader Module')
+      within(item).queryByText('Absorbance Plate Reader Module GEN1')
     )
     if (absorbanceReaderListItem == null) {
       throw new Error(

--- a/opentrons-ai-client/src/molecules/ModuleListItemGroup/__tests__/ModuleListItemGroup.test.tsx
+++ b/opentrons-ai-client/src/molecules/ModuleListItemGroup/__tests__/ModuleListItemGroup.test.tsx
@@ -34,6 +34,24 @@ const modulesMock: TestDisplayModule[] = [
     model: 'thermocyclerModuleV2',
     name: 'Thermocycler Module GEN2',
   },
+  {
+    id: 'module-4',
+    type: 'magneticModuleType',
+    model: 'magneticModuleV2',
+    name: 'Magnetic Module GEN2',
+  },
+  {
+    id: 'module-5',
+    type: 'magneticBlockType',
+    model: 'magneticBlockV1',
+    name: 'Magnetic Block GEN1',
+  },
+  {
+    id: 'module-6',
+    type: 'absorbanceReaderType',
+    model: 'absorbanceReaderV1',
+    name: 'Absorbance Plate Reader Module',
+  },
 ]
 
 const TestFormProviderComponent = () => {
@@ -61,7 +79,7 @@ describe('ModuleListItemGroup', () => {
     render()
 
     expect(screen.getAllByText('Adapter').length).toBe(2)
-    expect(screen.getAllByText('remove').length).toBe(3)
+    expect(screen.getAllByText('remove').length).toBe(6)
 
     screen.getByAltText('heaterShakerModuleType')
     screen.getByText('Heater-Shaker Module GEN1')
@@ -71,6 +89,15 @@ describe('ModuleListItemGroup', () => {
 
     screen.getByAltText('thermocyclerModuleType')
     screen.getByText('Thermocycler Module GEN2')
+
+    screen.getByAltText('magneticModuleType')
+    screen.getByText('Magnetic Module GEN2')
+
+    screen.getByAltText('magneticBlockType')
+    screen.getByText('Magnetic Block GEN1')
+
+    screen.getByAltText('absorbanceReaderType')
+    screen.getByText('Absorbance Plate Reader Module')
   })
 
   it('should remove the list item if remove is clicked', async () => {
@@ -85,9 +112,10 @@ describe('ModuleListItemGroup', () => {
     ).not.toBeInTheDocument()
   })
 
-  it('should render the dropdown if adapters are available', () => {
+  it('should render the dropdown only for modules with adapters enabled', () => {
     render()
 
+    // Only Temperature Module and Heater-Shaker Module should have dropdowns
     expect(screen.getAllByText('Choose an adapter').length).toBe(2)
   })
 
@@ -129,31 +157,81 @@ describe('ModuleListItemGroup', () => {
     ).not.toBeInTheDocument()
   })
 
-  it('should not render dropdown for thermocycler module', () => {
+  it('should not render dropdown for thermocycler, magnetic module, magnetic block, and absorbance reader', () => {
     render()
 
     const listItems = screen.getAllByTestId('ListItem_default')
+
+    // Test Thermocycler Module
     const thermocyclerListItem = listItems.find(item =>
       within(item).queryByText('Thermocycler Module GEN2')
     )
-
     if (thermocyclerListItem == null) {
       throw new Error(
         'Test failed: Could not find the thermocycler module list item.'
       )
     }
-
-    // Thermocycler should not have "Adapter" label
     expect(
       within(thermocyclerListItem).queryByText('Adapter')
     ).not.toBeInTheDocument()
-
-    // Thermocycler should not have dropdown with "Choose an adapter"
     expect(
       within(thermocyclerListItem).queryByText('Choose an adapter')
     ).not.toBeInTheDocument()
-
-    // But it should still have the remove button
     expect(within(thermocyclerListItem).getByText('remove')).toBeInTheDocument()
+
+    // Test Magnetic Module
+    const magneticListItem = listItems.find(item =>
+      within(item).queryByText('Magnetic Module GEN2')
+    )
+    if (magneticListItem == null) {
+      throw new Error(
+        'Test failed: Could not find the magnetic module list item.'
+      )
+    }
+    expect(
+      within(magneticListItem).queryByText('Adapter')
+    ).not.toBeInTheDocument()
+    expect(
+      within(magneticListItem).queryByText('Choose an adapter')
+    ).not.toBeInTheDocument()
+    expect(within(magneticListItem).getByText('remove')).toBeInTheDocument()
+
+    // Test Magnetic Block
+    const magneticBlockListItem = listItems.find(item =>
+      within(item).queryByText('Magnetic Block GEN1')
+    )
+    if (magneticBlockListItem == null) {
+      throw new Error(
+        'Test failed: Could not find the magnetic block list item.'
+      )
+    }
+    expect(
+      within(magneticBlockListItem).queryByText('Adapter')
+    ).not.toBeInTheDocument()
+    expect(
+      within(magneticBlockListItem).queryByText('Choose an adapter')
+    ).not.toBeInTheDocument()
+    expect(
+      within(magneticBlockListItem).getByText('remove')
+    ).toBeInTheDocument()
+
+    // Test Absorbance Reader
+    const absorbanceReaderListItem = listItems.find(item =>
+      within(item).queryByText('Absorbance Plate Reader Module')
+    )
+    if (absorbanceReaderListItem == null) {
+      throw new Error(
+        'Test failed: Could not find the absorbance reader list item.'
+      )
+    }
+    expect(
+      within(absorbanceReaderListItem).queryByText('Adapter')
+    ).not.toBeInTheDocument()
+    expect(
+      within(absorbanceReaderListItem).queryByText('Choose an adapter')
+    ).not.toBeInTheDocument()
+    expect(
+      within(absorbanceReaderListItem).getByText('remove')
+    ).toBeInTheDocument()
   })
 })

--- a/opentrons-ai-client/src/molecules/ModuleListItemGroup/__tests__/ModuleListItemGroup.test.tsx
+++ b/opentrons-ai-client/src/molecules/ModuleListItemGroup/__tests__/ModuleListItemGroup.test.tsx
@@ -28,6 +28,12 @@ const modulesMock: TestDisplayModule[] = [
     model: 'temperatureModuleV2',
     name: 'Temperature Module GEN2',
   },
+  {
+    id: 'module-3',
+    type: 'thermocyclerModuleType',
+    model: 'thermocyclerModuleV2',
+    name: 'Thermocycler Module GEN2',
+  },
 ]
 
 const TestFormProviderComponent = () => {
@@ -55,13 +61,16 @@ describe('ModuleListItemGroup', () => {
     render()
 
     expect(screen.getAllByText('Adapter').length).toBe(2)
-    expect(screen.getAllByText('remove').length).toBe(2)
+    expect(screen.getAllByText('remove').length).toBe(3)
 
     screen.getByAltText('heaterShakerModuleType')
     screen.getByText('Heater-Shaker Module GEN1')
 
     screen.getByAltText('temperatureModuleType')
     screen.getByText('Temperature Module GEN2')
+
+    screen.getByAltText('thermocyclerModuleType')
+    screen.getByText('Thermocycler Module GEN2')
   })
 
   it('should remove the list item if remove is clicked', async () => {
@@ -118,5 +127,33 @@ describe('ModuleListItemGroup', () => {
     expect(
       within(secondModuleListItem).queryByText('Choose an adapter')
     ).not.toBeInTheDocument()
+  })
+
+  it('should not render dropdown for thermocycler module', () => {
+    render()
+
+    const listItems = screen.getAllByTestId('ListItem_default')
+    const thermocyclerListItem = listItems.find(item =>
+      within(item).queryByText('Thermocycler Module GEN2')
+    )
+
+    if (thermocyclerListItem == null) {
+      throw new Error(
+        'Test failed: Could not find the thermocycler module list item.'
+      )
+    }
+
+    // Thermocycler should not have "Adapter" label
+    expect(
+      within(thermocyclerListItem).queryByText('Adapter')
+    ).not.toBeInTheDocument()
+
+    // Thermocycler should not have dropdown with "Choose an adapter"
+    expect(
+      within(thermocyclerListItem).queryByText('Choose an adapter')
+    ).not.toBeInTheDocument()
+
+    // But it should still have the remove button
+    expect(within(thermocyclerListItem).getByText('remove')).toBeInTheDocument()
   })
 })

--- a/opentrons-ai-client/src/molecules/ModuleListItemGroup/index.tsx
+++ b/opentrons-ai-client/src/molecules/ModuleListItemGroup/index.tsx
@@ -101,13 +101,13 @@ export function ModuleListItemGroup(): JSX.Element | null {
                 <ListItem type="default" key={module.id}>
                   <ListItemCustomize
                     label={
-                      adapters != null && adapters.length > 0
+                      adapters != null && adapters.length > 0 && module.type !== THERMOCYCLER_MODULE_TYPE
                         ? t('modules_adapter_label')
                         : undefined
                     }
                     linkText={t('modules_remove_label')}
                     dropdown={
-                      adapters != null && adapters.length > 0
+                      adapters != null && adapters.length > 0 && module.type !== THERMOCYCLER_MODULE_TYPE
                         ? {
                             title: (null as unknown) as string,
                             width: '13rem',

--- a/opentrons-ai-client/src/molecules/ModuleListItemGroup/index.tsx
+++ b/opentrons-ai-client/src/molecules/ModuleListItemGroup/index.tsx
@@ -19,7 +19,6 @@ import {
   MAGNETIC_MODULE_TYPE,
   TEMPERATURE_MODULE_TYPE,
   THERMOCYCLER_MODULE_TYPE,
-  type ModuleType,
 } from '@opentrons/shared-data'
 
 import { MODULES_FIELD_NAME } from '/ai-client/organisms/ModulesAndFixturesSection'
@@ -28,6 +27,7 @@ import { getOnlyLatestDefs } from '/ai-client/resources/utils'
 import { ModuleDiagram } from '../ModelDiagram'
 
 import type { DropdownBorder } from '@opentrons/components'
+import type { ModuleType } from '@opentrons/shared-data'
 import type { DisplayModule } from '/ai-client/organisms/ModulesAndFixturesSection'
 
 export const RECOMMENDED_LABWARE_BY_MODULE: { [K in ModuleType]: string[] } = {
@@ -72,7 +72,6 @@ export function ModuleListItemGroup(): JSX.Element | null {
   const modulesWatch: DisplayModule[] = watch(MODULES_FIELD_NAME) ?? []
 
   const allDefinitionsValues = useMemo(
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
     () => Object.values(getOnlyLatestDefs()),
     []
   )

--- a/opentrons-ai-client/src/molecules/ModuleListItemGroup/index.tsx
+++ b/opentrons-ai-client/src/molecules/ModuleListItemGroup/index.tsx
@@ -87,6 +87,15 @@ export function ModuleListItemGroup(): JSX.Element | null {
     <>
       {modulesWatch?.map(module => {
         const adapters = RECOMMENDED_LABWARE_BY_MODULE[module.type]
+        const shouldShowAdapterOptions =
+          adapters != null &&
+          adapters.length > 0 &&
+          ![
+            THERMOCYCLER_MODULE_TYPE,
+            MAGNETIC_MODULE_TYPE,
+            MAGNETIC_BLOCK_TYPE,
+            ABSORBANCE_READER_TYPE,
+          ].includes(module.type)
 
         return (
           <Controller
@@ -101,23 +110,13 @@ export function ModuleListItemGroup(): JSX.Element | null {
                 <ListItem type="default" key={module.id}>
                   <ListItemCustomize
                     label={
-                      adapters != null &&
-                      adapters.length > 0 &&
-                      module.type !== THERMOCYCLER_MODULE_TYPE &&
-                      module.type !== MAGNETIC_MODULE_TYPE &&
-                      module.type !== MAGNETIC_BLOCK_TYPE &&
-                      module.type !== ABSORBANCE_READER_TYPE
+                      shouldShowAdapterOptions
                         ? t('modules_adapter_label')
                         : undefined
                     }
                     linkText={t('modules_remove_label')}
                     dropdown={
-                      adapters != null &&
-                      adapters.length > 0 &&
-                      module.type !== THERMOCYCLER_MODULE_TYPE &&
-                      module.type !== MAGNETIC_MODULE_TYPE &&
-                      module.type !== MAGNETIC_BLOCK_TYPE &&
-                      module.type !== ABSORBANCE_READER_TYPE
+                      shouldShowAdapterOptions
                         ? {
                             title: (null as unknown) as string,
                             width: '13rem',

--- a/opentrons-ai-client/src/molecules/ModuleListItemGroup/index.tsx
+++ b/opentrons-ai-client/src/molecules/ModuleListItemGroup/index.tsx
@@ -19,6 +19,7 @@ import {
   MAGNETIC_MODULE_TYPE,
   TEMPERATURE_MODULE_TYPE,
   THERMOCYCLER_MODULE_TYPE,
+  type ModuleType,
 } from '@opentrons/shared-data'
 
 import { MODULES_FIELD_NAME } from '/ai-client/organisms/ModulesAndFixturesSection'
@@ -27,7 +28,6 @@ import { getOnlyLatestDefs } from '/ai-client/resources/utils'
 import { ModuleDiagram } from '../ModelDiagram'
 
 import type { DropdownBorder } from '@opentrons/components'
-import type { ModuleType } from '@opentrons/shared-data'
 import type { DisplayModule } from '/ai-client/organisms/ModulesAndFixturesSection'
 
 export const RECOMMENDED_LABWARE_BY_MODULE: { [K in ModuleType]: string[] } = {
@@ -72,6 +72,7 @@ export function ModuleListItemGroup(): JSX.Element | null {
   const modulesWatch: DisplayModule[] = watch(MODULES_FIELD_NAME) ?? []
 
   const allDefinitionsValues = useMemo(
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
     () => Object.values(getOnlyLatestDefs()),
     []
   )
@@ -101,13 +102,17 @@ export function ModuleListItemGroup(): JSX.Element | null {
                 <ListItem type="default" key={module.id}>
                   <ListItemCustomize
                     label={
-                      adapters != null && adapters.length > 0 && module.type !== THERMOCYCLER_MODULE_TYPE
+                      adapters != null &&
+                      adapters.length > 0 &&
+                      module.type !== THERMOCYCLER_MODULE_TYPE
                         ? t('modules_adapter_label')
                         : undefined
                     }
                     linkText={t('modules_remove_label')}
                     dropdown={
-                      adapters != null && adapters.length > 0 && module.type !== THERMOCYCLER_MODULE_TYPE
+                      adapters != null &&
+                      adapters.length > 0 &&
+                      module.type !== THERMOCYCLER_MODULE_TYPE
                         ? {
                             title: (null as unknown) as string,
                             width: '13rem',

--- a/opentrons-ai-client/src/molecules/ModuleListItemGroup/index.tsx
+++ b/opentrons-ai-client/src/molecules/ModuleListItemGroup/index.tsx
@@ -103,7 +103,10 @@ export function ModuleListItemGroup(): JSX.Element | null {
                     label={
                       adapters != null &&
                       adapters.length > 0 &&
-                      module.type !== THERMOCYCLER_MODULE_TYPE
+                      module.type !== THERMOCYCLER_MODULE_TYPE &&
+                      module.type !== MAGNETIC_MODULE_TYPE &&
+                      module.type !== MAGNETIC_BLOCK_TYPE &&
+                      module.type !== ABSORBANCE_READER_TYPE
                         ? t('modules_adapter_label')
                         : undefined
                     }
@@ -111,7 +114,10 @@ export function ModuleListItemGroup(): JSX.Element | null {
                     dropdown={
                       adapters != null &&
                       adapters.length > 0 &&
-                      module.type !== THERMOCYCLER_MODULE_TYPE
+                      module.type !== THERMOCYCLER_MODULE_TYPE &&
+                      module.type !== MAGNETIC_MODULE_TYPE &&
+                      module.type !== MAGNETIC_BLOCK_TYPE &&
+                      module.type !== ABSORBANCE_READER_TYPE
                         ? {
                             title: (null as unknown) as string,
                             width: '13rem',


### PR DESCRIPTION
# Overview

Closes AUTH-1811

Remove adapters dropdown from Thermocycler module, magnetic module, magnetic block and the plate reader 

Example:
![image](https://github.com/user-attachments/assets/a13856e4-6c77-4429-afa9-12ad6aa5e141)



## Test Plan and Hands on Testing
CI

## Review requests
- Confirm the dropdown is not there

## Risk assessment

Low