### PR TITLE
feat(api): add b2 (PVT) rev to HardwareRevision of FlexStacker

### DIFF
--- a/api/src/opentrons/drivers/flex_stacker/types.py
+++ b/api/src/opentrons/drivers/flex_stacker/types.py
@@ -53,6 +53,7 @@ class HardwareRevision(Enum):
     NFF = "nff"
     EVT = "a1"
     DVT = "b1"
+    PVT = "b2"
 
 
 @dataclass

--- a/hardware-testing/hardware_testing/modules/flex_stacker_qc/test_connectivity.py
+++ b/hardware-testing/hardware_testing/modules/flex_stacker_qc/test_connectivity.py
@@ -26,9 +26,8 @@ async def test_gcode(stacker: FlexStacker, report: CSVReport) -> None:
     """Send and receive response for GCODE M115."""
     success = True
     info = await stacker._driver.get_device_info()
-    # TODO: update this with PVT/MP revisions
-    if info.hw != HardwareRevision.DVT:
-        ui.print_warning(f"Hardware Revision is {info.hw}, expected DVT")
+    if info.hw != HardwareRevision.PVT:
+        ui.print_warning(f"Hardware Revision is {info.hw}, expected PVT")
     report(
         "CONNECTIVITY",
         "usb-get-device-info",


### PR DESCRIPTION
# Overview

Sync the HardwareRevision enum with the latest B2 revision of the Flex Stacker introduced in this [Opentrons/opentrons-modules#529](https://github.com/Opentrons/opentrons-modules/pull/529) pr.

## Test Plan and Hands on Testing

## Changelog

- add PVT (rev b2) to HardwareRevision enum of Flex Stacker module.

## Review requests
## Risk assessment