### PR TITLE
fix(app): Temp fix for waste chute stacker combo conflict

### DIFF
--- a/app/src/organisms/Desktop/Devices/ProtocolRun/SetupModuleAndDeck/SetupFixtureList.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/SetupModuleAndDeck/SetupFixtureList.tsx
@@ -27,6 +27,7 @@ import {
   SINGLE_SLOT_FIXTURES,
   THERMOCYCLER_V2_FRONT_FIXTURE,
   THERMOCYCLER_V2_REAR_FIXTURE,
+  WASTE_CHUTE_ADDRESSABLE_AREAS,
 } from '@opentrons/shared-data'
 
 import { TertiaryButton } from '/app/atoms/buttons/TertiaryButton'
@@ -91,9 +92,12 @@ export const SetupFixtureList = (props: SetupFixtureListProps): JSX.Element => {
         return cutoutConfigAndCompatibility.requiredAddressableAreas.every(
           raa => FLEX_USB_MODULE_ADDRESSABLE_AREAS.includes(raa)
         ) ||
-          cutoutConfigAndCompatibility.requiredAddressableAreas.some(raa =>
+          (cutoutConfigAndCompatibility.requiredAddressableAreas.some(raa =>
             FLEX_STACKER_ADDRESSABLE_AREAS.includes(raa)
-          ) ? null : (
+          ) &&
+            !cutoutConfigAndCompatibility.requiredAddressableAreas.some(raa =>
+              WASTE_CHUTE_ADDRESSABLE_AREAS.includes(raa)
+            )) ? null : (
           <FixtureListItem
             key={cutoutConfigAndCompatibility.cutoutId}
             deckDef={deckDef}

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupModulesAndDeck/FixtureTable.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupModulesAndDeck/FixtureTable.tsx
@@ -26,6 +26,7 @@ import {
   TC_MODULE_LOCATION_OT3,
   THERMOCYCLER_V2_FRONT_FIXTURE,
   THERMOCYCLER_V2_REAR_FIXTURE,
+  WASTE_CHUTE_ADDRESSABLE_AREAS,
 } from '@opentrons/shared-data'
 
 import { SmallButton } from '/app/atoms/buttons'
@@ -119,9 +120,12 @@ export function FixtureTable({
         return fixtureCompatibility.requiredAddressableAreas.every(raa =>
           FLEX_USB_MODULE_ADDRESSABLE_AREAS.includes(raa)
         ) ||
-          fixtureCompatibility.requiredAddressableAreas.some(raa =>
+          (fixtureCompatibility.requiredAddressableAreas.some(raa =>
             FLEX_STACKER_ADDRESSABLE_AREAS.includes(raa)
-          ) ? null : (
+          ) &&
+            !fixtureCompatibility.requiredAddressableAreas.some(raa =>
+              WASTE_CHUTE_ADDRESSABLE_AREAS.includes(raa)
+            )) ? null : (
           <FixtureTableItem
             key={`FixtureTableItem_${index}`}
             {...fixtureCompatibility}


### PR DESCRIPTION

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
I am working on a robust change that adds waste chute + stacker combo fixture support to the modules table. In the interim to unblock QA, this re-adds the combo fixture under the fixtures list so the conflicts can be resolved. This means we will have duplicate entries for stackers in this scenario only, with both the Stacker line item showing up that has module controls, and the stacker + waste chute combo item that allows for conflict resolution.

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
Tested this with the PR linked in https://opentrons.atlassian.net/browse/RQA-4319 and conflicts are now able to be resolved
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
Re-add stacker line items to fixture table if they also provide a waste chute addressable area
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests
Does this make sense as an interim fix? My larger fix will be up within a few days.
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
Low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
