### PR TITLE
fix(api): don't overwrite `next_dest`, fix distribute double-dispense

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -1698,15 +1698,15 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                 conditioning_volume=conditioning_vol,
             )
 
-            # If the tip has volumes correspoinding to multiple destinations, then
+            # If the tip has volumes corresponding to multiple destinations, then
             # multi-dispense in those destinations.
             # If the tip has a volume corresponding to a single destination, then
             # do a single-dispense into that destination.
-            for next_vol, next_dest in vol_dest_combo:
+            for dispense_vol, dispense_dest in vol_dest_combo:
                 if use_single_dispense:
                     tip_contents = self.dispense_liquid_class(
-                        volume=next_vol,
-                        dest=next_dest,
+                        volume=dispense_vol,
+                        dest=dispense_dest,
                         source=source,
                         transfer_properties=transfer_props,
                         transfer_type=tx_comps_executor.TransferType.ONE_TO_MANY,
@@ -1718,8 +1718,8 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                     )
                 else:
                     tip_contents = self.dispense_liquid_class_during_multi_dispense(
-                        volume=next_vol,
-                        dest=next_dest,
+                        volume=dispense_vol,
+                        dest=dispense_dest,
                         source=source,
                         transfer_properties=transfer_props,
                         transfer_type=tx_comps_executor.TransferType.ONE_TO_MANY,

--- a/api/tests/opentrons/protocol_api_integration/test_transfer_with_liquid_classes.py
+++ b/api/tests/opentrons/protocol_api_integration/test_transfer_with_liquid_classes.py
@@ -11,6 +11,7 @@ from opentrons.protocol_api.core.engine.transfer_components_executor import (
 from opentrons.protocols.advanced_control.transfers.common import (
     TransferTipPolicyV2Type,
 )
+from opentrons.types import Location, Point
 
 
 @pytest.mark.ot3_only
@@ -1454,9 +1455,9 @@ def test_order_of_water_distribution_steps_using_multi_dispense(
         mock_manager.attach_mock(patched_drop_tip, "drop_tip_in_disposal_location")
         pipette_1k.distribute_with_liquid_class(
             liquid_class=water,
-            volume=40,
+            volume=400,
             source=nest_plate.rows()[0][1],
-            dest=arma_plate.rows()[0][:3],
+            dest=arma_plate.rows()[0][:4],
             new_tip="once",
             trash_location=trash,
         )
@@ -1476,24 +1477,24 @@ def test_order_of_water_distribution_steps_using_multi_dispense(
             ),
             mock.call.aspirate_liquid_class(
                 mock.ANY,
-                volume=120 + expected_conditioning_volume + expected_disposal_volume,
+                volume=800 + expected_conditioning_volume + expected_disposal_volume,
                 source=mock.ANY,
                 transfer_properties=mock.ANY,
                 transfer_type=TransferType.ONE_TO_MANY,
                 tip_contents=[LiquidAndAirGapPair(liquid=0, air_gap=0)],
                 conditioning_volume=expected_conditioning_volume,
-                volume_for_pipette_mode_configuration=40,
+                volume_for_pipette_mode_configuration=400,
             ),
             mock.call.dispense_liquid_class_during_multi_dispense(
                 mock.ANY,
-                volume=40,
-                dest=mock.ANY,
+                volume=400,
+                dest=(Location(Point(), arma_plate.rows()[0][0]), arma_plate.rows()[0][0]._core),
                 source=mock.ANY,
                 transfer_properties=mock.ANY,
                 transfer_type=TransferType.ONE_TO_MANY,
                 tip_contents=[
                     LiquidAndAirGapPair(
-                        liquid=120 + expected_disposal_volume, air_gap=0
+                        liquid=800 + expected_disposal_volume, air_gap=0
                     )
                 ],
                 add_final_air_gap=True,
@@ -1503,13 +1504,40 @@ def test_order_of_water_distribution_steps_using_multi_dispense(
             ),
             mock.call.dispense_liquid_class_during_multi_dispense(
                 mock.ANY,
-                volume=40,
-                dest=mock.ANY,
+                volume=400,
+                dest=(Location(Point(), arma_plate.rows()[0][1]), arma_plate.rows()[0][1]._core),
                 source=mock.ANY,
                 transfer_properties=mock.ANY,
                 transfer_type=TransferType.ONE_TO_MANY,
                 tip_contents=[
-                    LiquidAndAirGapPair(liquid=80 + expected_disposal_volume, air_gap=0)
+                    LiquidAndAirGapPair(
+                        liquid=400 + expected_disposal_volume, air_gap=0
+                    )
+                ],
+                add_final_air_gap=True,
+                trash_location=mock.ANY,
+                conditioning_volume=expected_conditioning_volume,
+                disposal_volume=expected_disposal_volume,
+            ),
+            mock.call.aspirate_liquid_class(
+                mock.ANY,
+                volume=800 + expected_conditioning_volume + expected_disposal_volume,
+                source=mock.ANY,
+                transfer_properties=mock.ANY,
+                transfer_type=TransferType.ONE_TO_MANY,
+                tip_contents=[LiquidAndAirGapPair(liquid=0, air_gap=10)],
+                conditioning_volume=expected_conditioning_volume,
+                volume_for_pipette_mode_configuration=400,
+            ),
+            mock.call.dispense_liquid_class_during_multi_dispense(
+                mock.ANY,
+                volume=400,
+                dest=(Location(Point(), arma_plate.rows()[0][2]), arma_plate.rows()[0][2]._core),
+                source=mock.ANY,
+                transfer_properties=mock.ANY,
+                transfer_type=TransferType.ONE_TO_MANY,
+                tip_contents=[
+                    LiquidAndAirGapPair(liquid=800 + expected_disposal_volume, air_gap=0)
                 ],
                 add_final_air_gap=True,
                 trash_location=mock.ANY,
@@ -1518,13 +1546,13 @@ def test_order_of_water_distribution_steps_using_multi_dispense(
             ),
             mock.call.dispense_liquid_class_during_multi_dispense(
                 mock.ANY,
-                volume=40,
-                dest=mock.ANY,
+                volume=400,
+                dest=(Location(Point(), arma_plate.rows()[0][3]), arma_plate.rows()[0][3]._core),
                 source=mock.ANY,
                 transfer_properties=mock.ANY,
                 transfer_type=TransferType.ONE_TO_MANY,
                 tip_contents=[
-                    LiquidAndAirGapPair(liquid=40 + expected_disposal_volume, air_gap=0)
+                    LiquidAndAirGapPair(liquid=400 + expected_disposal_volume, air_gap=0)
                 ],
                 add_final_air_gap=True,
                 trash_location=mock.ANY,

--- a/api/tests/opentrons/protocol_api_integration/test_transfer_with_liquid_classes.py
+++ b/api/tests/opentrons/protocol_api_integration/test_transfer_with_liquid_classes.py
@@ -1488,7 +1488,10 @@ def test_order_of_water_distribution_steps_using_multi_dispense(
             mock.call.dispense_liquid_class_during_multi_dispense(
                 mock.ANY,
                 volume=400,
-                dest=(Location(Point(), arma_plate.rows()[0][0]), arma_plate.rows()[0][0]._core),
+                dest=(
+                    Location(Point(), arma_plate.rows()[0][0]),
+                    arma_plate.rows()[0][0]._core,
+                ),
                 source=mock.ANY,
                 transfer_properties=mock.ANY,
                 transfer_type=TransferType.ONE_TO_MANY,
@@ -1505,7 +1508,10 @@ def test_order_of_water_distribution_steps_using_multi_dispense(
             mock.call.dispense_liquid_class_during_multi_dispense(
                 mock.ANY,
                 volume=400,
-                dest=(Location(Point(), arma_plate.rows()[0][1]), arma_plate.rows()[0][1]._core),
+                dest=(
+                    Location(Point(), arma_plate.rows()[0][1]),
+                    arma_plate.rows()[0][1]._core,
+                ),
                 source=mock.ANY,
                 transfer_properties=mock.ANY,
                 transfer_type=TransferType.ONE_TO_MANY,
@@ -1532,12 +1538,17 @@ def test_order_of_water_distribution_steps_using_multi_dispense(
             mock.call.dispense_liquid_class_during_multi_dispense(
                 mock.ANY,
                 volume=400,
-                dest=(Location(Point(), arma_plate.rows()[0][2]), arma_plate.rows()[0][2]._core),
+                dest=(
+                    Location(Point(), arma_plate.rows()[0][2]),
+                    arma_plate.rows()[0][2]._core,
+                ),
                 source=mock.ANY,
                 transfer_properties=mock.ANY,
                 transfer_type=TransferType.ONE_TO_MANY,
                 tip_contents=[
-                    LiquidAndAirGapPair(liquid=800 + expected_disposal_volume, air_gap=0)
+                    LiquidAndAirGapPair(
+                        liquid=800 + expected_disposal_volume, air_gap=0
+                    )
                 ],
                 add_final_air_gap=True,
                 trash_location=mock.ANY,
@@ -1547,12 +1558,17 @@ def test_order_of_water_distribution_steps_using_multi_dispense(
             mock.call.dispense_liquid_class_during_multi_dispense(
                 mock.ANY,
                 volume=400,
-                dest=(Location(Point(), arma_plate.rows()[0][3]), arma_plate.rows()[0][3]._core),
+                dest=(
+                    Location(Point(), arma_plate.rows()[0][3]),
+                    arma_plate.rows()[0][3]._core,
+                ),
                 source=mock.ANY,
                 transfer_properties=mock.ANY,
                 transfer_type=TransferType.ONE_TO_MANY,
                 tip_contents=[
-                    LiquidAndAirGapPair(liquid=400 + expected_disposal_volume, air_gap=0)
+                    LiquidAndAirGapPair(
+                        liquid=400 + expected_disposal_volume, air_gap=0
+                    )
                 ],
                 add_final_air_gap=True,
                 trash_location=mock.ANY,


### PR DESCRIPTION
# Overview

In `distribute_with_liquid_class()`, we were dispensing into the same destination well twice when the distribute consists of multiple tip-fills.

The bug was caused by the reuse of the variable `next_dest` in `distribute_with_liquid_class()`. `next_dest` in the outer loop is supposed to contain the next well that we have not dispensed to yet. However, we accidently overwrote the variable because we also use it as a loop variable for an unrelated inner loop:
```
for next_vol, next_dest in vol_dest_combo:
```

## Test Plan and Hands on Testing

Using `analyze`, I confirmed that the double-dispense happened with Andy's example before this change, and that it was fixed after this change.

I also updated `test_order_of_water_distribution_steps_using_multi_dispense()` to perform a distribute that requires multiple tip-fills, and changed the test to check that we're dispensing into specific wells instead of `dest=mock.ANY`. I confirmed that the bug happened before this change, and it was fixed after this change.

## Risk assessment

Medium: this is change deep inside our implementation. But it's necessary to fix the bug.