### PR TITLE
docs(api): Versioning page for API level 2.24

### DIFF
--- a/api/docs/v2/conf.py
+++ b/api/docs/v2/conf.py
@@ -99,7 +99,7 @@ extensions += ['sphinx-prompt', 'sphinx_substitution_extensions']
 # use rst_prolog to hold the subsitution
 # update the apiLevel value whenever a new minor version is released
 rst_prolog = f"""
-.. |apiLevel| replace:: 2.23
+.. |apiLevel| replace:: 2.24
 .. |release| replace:: {release}
 """
 

--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -68,7 +68,7 @@ The maximum supported API version for your robot is listed in the Opentrons App 
 
 If you upload a protocol that specifies a higher API level than the maximum supported, your robot won't be able to analyze or run your protocol. You can increase the maximum supported version by updating your robot software and Opentrons App. 
 
-Opentrons robots running the latest software (8.4.0) support the following version ranges: 
+Opentrons robots running the latest software (8.5.0) support the following version ranges: 
 
     * **Flex:** version 2.15–|apiLevel|.
     * **OT-2:** versions 2.0–|apiLevel|.
@@ -84,6 +84,8 @@ This table lists the correspondence between Protocol API versions and robot soft
 +-------------+------------------------------+
 | API Version | Introduced in Robot Software |
 +=============+==============================+
+|     2.24    |          8.5.0               |
++-------------+------------------------------+
 |     2.23    |          8.4.0               |
 +-------------+------------------------------+
 |     2.22    |          8.3.0               |
@@ -139,6 +141,15 @@ This table lists the correspondence between Protocol API versions and robot soft
 
 Changes in API Versions
 =======================
+
+Version 2.24
+-------------
+- Adds the ability to perform liquid handling actions using :ref:`liquid classes <liquid-classes>`.
+
+  - :py:meth:`.ProtocolContext.get_liquid_class` accesses :ref:`Opentrons-verified liquid class definitions <liquid-class-definitions>` for aqueous, volatile, and viscous liquids.
+  - :py:meth:`.ProtocolContext.define_liquid_class` lets you create your own liquid classes from verified classes or from scratch.
+  - New :py:class:`.InstrumentContext` methods — :py:meth:`.transfer_with_liquid_class`, :py:meth:`.distribute_with_liquid_class`, and :py:meth:`.consolidate_with_liquid_class` — move liquids according to their properties.
+- :py:meth:`.air_gap`, :py:meth:`.blow_out`, :py:meth:`.dispense`, :py:meth:`.mix`, and :py:meth:`.touch_tip` have new parameters for advanced settings that are also available in Protocol Designer.
 
 Version 2.23
 -------------


### PR DESCRIPTION
# Overview

Versioning page updates for Python API 2.24.

~~Draft while waiting for #18619 to merge (based on that branch, targeted on edge)~~

## Test Plan and Hands on Testing

[Sandbox](http://sandbox.docs.opentrons.com/docs-versioning-2.24/v2/versioning.html)

## Changelog

- Bullets for liquid classes and PD/PAPI interop features.
- Bump `|apiLevel|` substitution to 2.24

## Review requests

Anything else to add? Important bug fixes?

## Risk assessment

none, docs