### PR TITLE
fix(step-generation): add delay after dispensing air gap

### DIFF
--- a/step-generation/src/commandCreators/compound/consolidate.ts
+++ b/step-generation/src/commandCreators/compound/consolidate.ts
@@ -688,6 +688,7 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
                       : {}),
                     pushOut: 0,
                   }),
+                  ...delayAfterDispenseCommands,
                 ]
               : []
           const moveToSourceWellTopCommand = [

--- a/step-generation/src/commandCreators/compound/distribute.ts
+++ b/step-generation/src/commandCreators/compound/distribute.ts
@@ -588,6 +588,14 @@ export const distribute: CommandCreator<DistributeArgs> = (
           byVolumeProperty: 'correctionByVolume',
           defaultValue: 0,
         }) ?? 0
+      const delayAfterDispenseCommands =
+        dispenseDelay != null
+          ? [
+              curryWithoutPython(delay, {
+                seconds: dispenseDelay.seconds,
+              }),
+            ]
+          : []
       const voidDispenseAirGapCommand =
         dispenseAirGapVolume > 0 &&
         !changeTipNow &&
@@ -607,6 +615,7 @@ export const distribute: CommandCreator<DistributeArgs> = (
                   : {}),
                 pushOut: 0,
               }),
+              ...delayAfterDispenseCommands,
             ]
           : []
 
@@ -690,14 +699,6 @@ export const distribute: CommandCreator<DistributeArgs> = (
           ? [
               curryWithoutPython(delay, {
                 seconds: aspirateDelay.seconds,
-              }),
-            ]
-          : []
-      const delayAfterDispenseCommands =
-        dispenseDelay != null
-          ? [
-              curryWithoutPython(delay, {
-                seconds: dispenseDelay.seconds,
               }),
             ]
           : []

--- a/step-generation/src/commandCreators/compound/transfer.ts
+++ b/step-generation/src/commandCreators/compound/transfer.ts
@@ -596,6 +596,15 @@ export const transfer: CommandCreator<TransferArgs> = (
               byVolumeProperty: 'correctionByVolume',
               defaultValue: 0,
             }) ?? 0
+          const delayAfterDispenseCommands =
+            dispenseDelay != null
+              ? [
+                  curryWithoutPython(delay, {
+                    seconds: dispenseDelay.seconds,
+                  }),
+                ]
+              : []
+
           const voidDispenseAirGapCommand =
             dispenseAirGapVol > 0 &&
             !changeTipNow &&
@@ -612,6 +621,7 @@ export const transfer: CommandCreator<TransferArgs> = (
                         }
                       : {}),
                   }),
+                  ...delayAfterDispenseCommands,
                 ]
               : []
           const preAspirateSubmergeCommands = [
@@ -785,14 +795,6 @@ export const transfer: CommandCreator<TransferArgs> = (
                 ]
               : []),
           ]
-          const delayAfterDispenseCommands =
-            dispenseDelay != null
-              ? [
-                  curryWithoutPython(delay, {
-                    seconds: dispenseDelay.seconds,
-                  }),
-                ]
-              : []
           const dispenseCorrectionVolumeForAspirateAirGap =
             getByVolumeValue({
               liquidClass,

--- a/step-generation/src/fixtures/commandFixtures.ts
+++ b/step-generation/src/fixtures/commandFixtures.ts
@@ -333,6 +333,15 @@ export const aspirateHelperLiquidClass = (submergeParams: {
             },
             meta: AIR_GAP_META,
           },
+          ...(dispenseDelay > 0
+            ? [
+                {
+                  commandType: 'waitForDuration',
+                  key: expect.any(String),
+                  params: { seconds: dispenseDelay },
+                },
+              ]
+            : []),
         ]
       : []),
     // ...(shouldProbe


### PR DESCRIPTION
# Overview

This PR ensures the specified dispense delay for a move liquid form is applied after dispensing air gap.

## Test Plan and Hands on Testing

Please review implementation of delay commands after voiding air gap. Not much to test practically other than creating a protocol with air gaps and dispense delays, and verify that a delay command is emitted after each air gap dispense in place command.

## Changelog

- add delay commands after dispensing air gap

## Review requests

see test plan

## Risk assessment

low