### PR TITLE
fix(protocol-designer): fix whitescreen when deleting a used pipette

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TiprackField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TiprackField.tsx
@@ -39,7 +39,10 @@ export function TiprackField(props: TiprackFieldProps): JSX.Element {
   useEffect(() => {
     //  if default value is not included in the pipette's tiprack uris then
     //  change it so it is
-    if (!defaultTiprackUris.includes(value as string)) {
+    if (
+      !defaultTiprackUris.includes(value as string) &&
+      defaultTiprackUris.length > 0
+    ) {
       updateValue(defaultTiprackUris[0])
     }
   }, [defaultTiprackUris, value, updateValue])

--- a/protocol-designer/src/step-forms/reducers/index.ts
+++ b/protocol-designer/src/step-forms/reducers/index.ts
@@ -735,6 +735,7 @@ export const savedStepForms = (
               ...handleFormChange(
                 {
                   pipette: null,
+                  tipRack: null,
                 },
                 form,
                 _getPipetteEntitiesRootState(rootState),

--- a/protocol-designer/src/steplist/formLevel/test/warnings.test.ts
+++ b/protocol-designer/src/steplist/formLevel/test/warnings.test.ts
@@ -306,7 +306,7 @@ const MOCK_WATER = {
     },
   ],
 } as LiquidClass
-describe('class compatibility', () => {
+describe('liquid class compatibility', () => {
   let fields: any
   beforeEach(() => {
     fields = {
@@ -322,7 +322,13 @@ describe('class compatibility', () => {
       water: MOCK_WATER,
     })
   })
-
+  it('should return null if the pipette is null', () => {
+    fields = {
+      ...fields,
+      pipette: null,
+    }
+    expect(incompatibleLiquidClass(fields)).toBe(null)
+  })
   it('should return null if the liquid class is compatible with the pipette, tips, volume, and path', () => {
     expect(incompatibleLiquidClass(fields)).toBe(null)
   })

--- a/protocol-designer/src/steplist/formLevel/test/warnings.test.ts
+++ b/protocol-designer/src/steplist/formLevel/test/warnings.test.ts
@@ -329,6 +329,13 @@ describe('liquid class compatibility', () => {
     }
     expect(incompatibleLiquidClass(fields)).toBe(null)
   })
+  it('should return null if the tiprack is null', () => {
+    fields = {
+      ...fields,
+      tipRack: null,
+    }
+    expect(incompatibleLiquidClass(fields)).toBe(null)
+  })
   it('should return null if the liquid class is compatible with the pipette, tips, volume, and path', () => {
     expect(incompatibleLiquidClass(fields)).toBe(null)
   })

--- a/protocol-designer/src/steplist/formLevel/warnings.tsx
+++ b/protocol-designer/src/steplist/formLevel/warnings.tsx
@@ -257,7 +257,7 @@ export const incompatibleLiquidClass: (
   fields: HydratedMoveLiquidFormData | HydratedMixFormData
 ) => FormWarning | null = formData => {
   const { pipette, tipRack, volume: rawVolume } = formData
-  if (pipette == null) {
+  if (pipette == null || tipRack == null) {
     return null
   }
   // don't show warnings for OT-2

--- a/protocol-designer/src/steplist/formLevel/warnings.tsx
+++ b/protocol-designer/src/steplist/formLevel/warnings.tsx
@@ -257,6 +257,9 @@ export const incompatibleLiquidClass: (
   fields: HydratedMoveLiquidFormData | HydratedMixFormData
 ) => FormWarning | null = formData => {
   const { pipette, tipRack, volume: rawVolume } = formData
+  if (pipette == null) {
+    return null
+  }
   // don't show warnings for OT-2
   const isOT2 = Object.values(OT2_PIPETTES).includes(pipette.name)
   if (isOT2) {


### PR DESCRIPTION
# Overview

This PR fixes a whitescreen that occurs after deleting a pipette that is used in a moveLiquid or mix step form. There are actually 2 places that need to be addressed: 

#### 1) `incompatibleLiquidClass` warning

#### 2) `TiprackField` component

## Test Plan and Hands on Testing

- create or import a protocol that uses a pipette in a transfer or mix form
- delete the pipette from the Protocol Overview page
- navigate back to Protocol Timeline, open the step, and verify that no whitescreen occurs

## Changelog

- null check pipette in `incompatibleLiquidClass` warning
- check that length of `defaultTiprackURI`s > 0 in `TiprackField` `useEffect`
- update `DELETE_PIPETTES` action to null tipRack in addition to pipette

## Review requests

see test plan

## Risk assessment

lowish