### PR TITLE
fix(protocol-designer): fix liquid class display name in dropdown

### DIFF
--- a/protocol-designer/src/assets/localization/en/liquids.json
+++ b/protocol-designer/src/assets/localization/en/liquids.json
@@ -23,7 +23,6 @@
     "title": "Liquid class",
     "tooltip": "Applies predefined pipetting settings to transfer and mix steps using this liquid"
   },
-  "liquid_class_name": "{{displayName}}",
   "liquids_added": "Liquids added",
   "liquids": "Liquids",
   "microliters": "µL",

--- a/protocol-designer/src/assets/localization/en/liquids.json
+++ b/protocol-designer/src/assets/localization/en/liquids.json
@@ -23,7 +23,7 @@
     "title": "Liquid class",
     "tooltip": "Applies predefined pipetting settings to transfer and mix steps using this liquid"
   },
-  "liquid_class_name_description": "{{displayName}} ({{description}})",
+  "liquid_class_name": "{{displayName}}",
   "liquids_added": "Liquids added",
   "liquids": "Liquids",
   "microliters": "µL",

--- a/protocol-designer/src/components/organisms/DefineLiquidsModal/index.tsx
+++ b/protocol-designer/src/components/organisms/DefineLiquidsModal/index.tsx
@@ -143,9 +143,7 @@ export function DefineLiquidsModal(
       ([liquidClassDefName, { displayName }]) => {
         return {
           value: liquidClassDefName,
-          name: t('liquids:liquid_class_name', {
-            displayName,
-          }),
+          name: displayName,
         }
       }
     ),

--- a/protocol-designer/src/components/organisms/DefineLiquidsModal/index.tsx
+++ b/protocol-designer/src/components/organisms/DefineLiquidsModal/index.tsx
@@ -140,12 +140,11 @@ export function DefineLiquidsModal(
   const liquidClassOptions = [
     { name: t('liquids:dont_use_liquid_class'), value: '' },
     ...Object.entries(sortedLiquidClassDefs).map(
-      ([liquidClassDefName, { displayName, description }]) => {
+      ([liquidClassDefName, { displayName }]) => {
         return {
           value: liquidClassDefName,
-          name: t('liquids:liquid_class_name_description', {
+          name: t('liquids:liquid_class_name', {
             displayName,
-            description,
           }),
         }
       }


### PR DESCRIPTION
closes RQA-4338

# Overview

Fix the display name for the liquid classes

<img width="609" alt="Screenshot 2025-07-02 at 12 04 31" src="https://github.com/user-attachments/assets/dec838cc-8d7b-40d1-a86b-026e61964058" />

## Test Plan and Hands on Testing

Create a protocol and add a liquid class to a liquid and see the dropdown doesn't repeat the description.

## Changelog

- remove the description since its part of the display name now.

## Risk assessment

low
