### PR TITLE
fix(protocol-designer): get submerge/retract defaults for OT-2

### DIFF
--- a/protocol-designer/src/steplist/formLevel/handleFormChange/utils.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/utils.ts
@@ -513,9 +513,13 @@ const getNoLiquidClassValuesMoveLiquid = (
         : {}
     return {
       aspirate_submerge_speed: zSpeedOT2,
+      aspirate_submerge_mmFromBottom: SAFE_MOVE_TO_WELL_OFFSET_FROM_TOP_MM,
       aspirate_retract_speed: zSpeedOT2,
+      aspirate_retract_mmFromBottom: SAFE_MOVE_TO_WELL_OFFSET_FROM_TOP_MM,
       dispense_submerge_speed: zSpeedOT2,
+      dispense_submerge_mmFromBottom: SAFE_MOVE_TO_WELL_OFFSET_FROM_TOP_MM,
       dispense_retract_speed: zSpeedOT2,
+      dispense_retract_mmFromBottom: SAFE_MOVE_TO_WELL_OFFSET_FROM_TOP_MM,
       ...dipsosalFields,
     }
   }


### PR DESCRIPTION
# Overview

Ensures OT-2 liquid class default values for aspirate/dispense submerge/retract z height are populated.

Closes RQA-4345

## Test Plan and Hands on Testing

- create or import an OT-2 protocol
- create a new transfer step
- open aspirate or dispense settings > submerge or retract position
- verify that the default position is set to 2mm above the top of the well ("safe" point)

## Changelog

update `getNoLiquidClassValuesMoveLiquid` to fill OT-2 submerge/retract z values

## Review requests

see test plan