### PR TITLE
docs(api): fix runtime parameter type annotation

### DIFF
--- a/api/docs/v2/parameters/defining.rst
+++ b/api/docs/v2/parameters/defining.rst
@@ -62,7 +62,7 @@ The examples on this page assume the following definition, which uses the argume
 
 .. code-block::
 
-    def add_parameters(parameters: protocol_api.Parameters):
+    def add_parameters(parameters: protocol_api.ParameterContext):
 
 Within this function definition, call methods on ``parameters`` to define parameters. The next section demonstrates how each type of parameter has its own method.
 


### PR DESCRIPTION
# Overview

Addresses #18803 

> The documentation found [here](https://docs.opentrons.com/v2/parameters/defining.html?#the-add-parameters-function), i.e. the "The add_parameters() Function" section of the page on "Defining Parameters", has the wrong type annotation. It is documented as Parameters when it should be ParameterContext.

## Test Plan and Hands on Testing

[Sandbox](http://sandbox.docs.opentrons.com/docs-fix-rtp-annotation/v2/parameters/defining.html#the-add-parameters-function)

## Changelog

1-liner

## Review requests

nothing special.

## Risk assessment

nil