### PR TITLE
fix(api): fix correction by volume calculations for liquid class transfers

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -2145,7 +2145,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             return
 
         correction_volume = dispense_props.correction_by_volume.get_for_volume(
-            last_air_gap
+            self.get_current_volume() - last_air_gap
         )
         # The minimum flow rate should be air_gap_volume per second
         flow_rate = max(

--- a/api/src/opentrons/protocol_api/core/engine/transfer_components_executor.py
+++ b/api/src/opentrons/protocol_api/core/engine/transfer_components_executor.py
@@ -229,7 +229,9 @@ class TransferComponentsExecutor:
             and self._target_well is not None
         )
         aspirate_props = self._transfer_properties.aspirate
-        correction_volume = aspirate_props.correction_by_volume.get_for_volume(volume)
+        correction_volume = aspirate_props.correction_by_volume.get_for_volume(
+            self._instrument.get_current_volume() + volume
+        )
         self._instrument.aspirate(
             location=self._target_location,
             well_core=None,
@@ -252,7 +254,7 @@ class TransferComponentsExecutor:
     ) -> None:
         """Dispense according to dispense properties and wait if enabled."""
         correction_volume = dispense_properties.correction_by_volume.get_for_volume(
-            volume
+            self._instrument.get_current_volume() - volume
         )
         self._instrument.dispense(
             location=self._target_location,
@@ -895,7 +897,7 @@ class TransferComponentsExecutor:
             return
         aspirate_props = self._transfer_properties.aspirate
         correction_volume = aspirate_props.correction_by_volume.get_for_volume(
-            air_gap_volume
+            self._instrument.get_current_volume() + air_gap_volume
         )
         # The minimum flow rate should be air_gap_volume per second
         flow_rate = max(

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -952,7 +952,11 @@ def maximal_liquid_class_def() -> LiquidClassSchemaV1:
                                 offset=Coordinate(x=10, y=20, z=30),
                             ),
                             flowRateByVolume=[(1.0, 35.0), (10.0, 24.0), (50.0, 35.0)],
-                            correctionByVolume=[(0.0, 0.0)],
+                            correctionByVolume=[
+                                (0.0, 0.0),
+                                (10.0, -1.0),
+                                (50.0, -10.0),
+                            ],
                             preWet=True,
                             mix=MixProperties(
                                 enable=True, params=MixParams(repetitions=1, volume=50)
@@ -1001,7 +1005,11 @@ def maximal_liquid_class_def() -> LiquidClassSchemaV1:
                                 offset=Coordinate(x=33, y=22, z=11),
                             ),
                             flowRateByVolume=[(1.0, 50.0)],
-                            correctionByVolume=[(0.0, 0.0)],
+                            correctionByVolume=[
+                                (0.0, 0.0),
+                                (10.0, -1.0),
+                                (50.0, -10.0),
+                            ],
                             mix=MixProperties(
                                 enable=True, params=MixParams(repetitions=1, volume=50)
                             ),
@@ -1056,7 +1064,11 @@ def maximal_liquid_class_def() -> LiquidClassSchemaV1:
                                 offset=Coordinate(x=1, y=3, z=2),
                             ),
                             flowRateByVolume=[(50.0, 50.0)],
-                            correctionByVolume=[(0.0, 0.0)],
+                            correctionByVolume=[
+                                (0.0, 0.0),
+                                (10.0, -1.0),
+                                (50.0, -10.0),
+                            ],
                             conditioningByVolume=[(1.0, 5.0), (45.0, 5.0), (50.0, 0.0)],
                             disposalByVolume=[(1.0, 5.0), (45.0, 5.0), (50.0, 0.0)],
                             delay=DelayProperties(

--- a/api/tests/opentrons/protocol_api/core/engine/test_instrument_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_instrument_core.py
@@ -2176,7 +2176,7 @@ def test_aspirate_liquid_class_for_transfer_without_volume_config(
     assert result == [LiquidAndAirGapPair(air_gap=222, liquid=111)]
 
 
-@pytest.mark.parametrize("version", versions_at_or_above(APIVersion(2, 23)))
+@pytest.mark.parametrize("version", versions_at_or_above(APIVersion(2, 24)))
 def test_aspirate_liquid_class_using_volume_config(
     decoy: Decoy,
     mock_engine_client: EngineClient,
@@ -2201,6 +2201,11 @@ def test_aspirate_liquid_class_using_volume_config(
     test_transfer_properties.dispense.delay.enabled = True
 
     last_liquid_and_airgap_in_tip = LiquidAndAirGapPair(liquid=0, air_gap=100)
+    decoy.when(
+        mock_engine_client.state.pipettes.get_aspirated_volume(
+            pipette_id=subject.pipette_id
+        )
+    ).then_return(200)
     decoy.when(mock_protocol_core.api_version).then_return(version)
     decoy.when(source_well.labware_id).then_return("source-labware-id")
     decoy.when(source_well.get_name()).then_return("source-well")
@@ -2420,16 +2425,24 @@ def test_remove_air_gap_during_transfer_with_liquid_class(
     """It should remove ait gap by calling dispense and delay with liquid class props."""
     test_transfer_props = decoy.mock(cls=TransferProperties)
     air_gap_correction_by_vol = 0.321
+    current_volume = 0.654
 
     test_transfer_props.dispense.delay.duration = 321
     test_transfer_props.dispense.delay.enabled = True
 
+    decoy.when(
+        mock_engine_client.state.pipettes.get_aspirated_volume(
+            pipette_id=subject.pipette_id
+        )
+    ).then_return(current_volume)
     decoy.when(mock_protocol_core.api_version).then_return(version)
     decoy.when(
         test_transfer_props.dispense.flow_rate_by_volume.get_for_volume(air_gap_volume)
     ).then_return(air_gap_flow_rate_by_vol)
     decoy.when(
-        test_transfer_props.dispense.correction_by_volume.get_for_volume(air_gap_volume)
+        test_transfer_props.dispense.correction_by_volume.get_for_volume(
+            current_volume - air_gap_volume
+        )
     ).then_return(air_gap_correction_by_vol)
     subject.remove_air_gap_during_transfer_with_liquid_class(
         last_air_gap=air_gap_volume,
@@ -2463,15 +2476,23 @@ def test_remove_air_gap_during_transfer_with_liquid_class_handles_delays(
     air_gap_volume = 0.123
     air_gap_flow_rate_by_vol = 123
     air_gap_correction_by_vol = 0.321
+    current_volume = 0.654
 
     test_transfer_props.dispense.delay.enabled = False
 
+    decoy.when(
+        mock_engine_client.state.pipettes.get_aspirated_volume(
+            pipette_id=subject.pipette_id
+        )
+    ).then_return(current_volume)
     decoy.when(mock_protocol_core.api_version).then_return(version)
     decoy.when(
         test_transfer_props.dispense.flow_rate_by_volume.get_for_volume(air_gap_volume)
     ).then_return(air_gap_flow_rate_by_vol)
     decoy.when(
-        test_transfer_props.dispense.correction_by_volume.get_for_volume(air_gap_volume)
+        test_transfer_props.dispense.correction_by_volume.get_for_volume(
+            current_volume - air_gap_volume
+        )
     ).then_return(air_gap_correction_by_vol)
 
     subject.remove_air_gap_during_transfer_with_liquid_class(

--- a/api/tests/opentrons/protocol_api/core/engine/test_instrument_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_instrument_core.py
@@ -2422,7 +2422,7 @@ def test_remove_air_gap_during_transfer_with_liquid_class(
     expected_air_gap_flow_rate: float,
     version: APIVersion,
 ) -> None:
-    """It should remove ait gap by calling dispense and delay with liquid class props."""
+    """It should remove air gap by calling dispense and delay with liquid class props."""
     test_transfer_props = decoy.mock(cls=TransferProperties)
     air_gap_correction_by_vol = 0.321
     current_volume = 0.654
@@ -2471,7 +2471,7 @@ def test_remove_air_gap_during_transfer_with_liquid_class_handles_delays(
     subject: InstrumentCore,
     version: APIVersion,
 ) -> None:
-    """It should remove ait gap by calling dispense and delay with liquid class props."""
+    """It should remove air gap by calling dispense and delay with liquid class props."""
     test_transfer_props = decoy.mock(cls=TransferProperties)
     air_gap_volume = 0.123
     air_gap_flow_rate_by_vol = 123

--- a/api/tests/opentrons/protocol_api/core/engine/test_transfer_components_executor.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_transfer_components_executor.py
@@ -342,8 +342,9 @@ def test_aspirate_and_wait(
     aspirate_flow_rate = (
         sample_transfer_props.aspirate.flow_rate_by_volume.get_for_volume(10)
     )
+    decoy.when(mock_instrument_core.get_current_volume()).then_return(5)
     correction_volume = (
-        sample_transfer_props.aspirate.correction_by_volume.get_for_volume(10)
+        sample_transfer_props.aspirate.correction_by_volume.get_for_volume(15)
     )
     subject = TransferComponentsExecutor(
         instrument_core=mock_instrument_core,
@@ -376,6 +377,7 @@ def test_aspirate_and_wait_skips_delay(
     """It should skip the wait after aspirate."""
     sample_transfer_props.aspirate.delay.enabled = False
     source_well = decoy.mock(cls=WellCore)
+    decoy.when(mock_instrument_core.get_current_volume()).then_return(5)
 
     subject = TransferComponentsExecutor(
         instrument_core=mock_instrument_core,
@@ -413,8 +415,9 @@ def test_dispense_and_wait(
     dispense_flow_rate = (
         sample_transfer_props.dispense.flow_rate_by_volume.get_for_volume(10)
     )
+    decoy.when(mock_instrument_core.get_current_volume()).then_return(50)
     correction_volume = (
-        sample_transfer_props.dispense.correction_by_volume.get_for_volume(50)
+        sample_transfer_props.dispense.correction_by_volume.get_for_volume(40)
     )
     subject = TransferComponentsExecutor(
         instrument_core=mock_instrument_core,
@@ -452,6 +455,7 @@ def test_dispense_and_wait_skips_delay(
     """It should skip the wait after dispense."""
     sample_transfer_props.dispense.delay.enabled = False
     source_well = decoy.mock(cls=WellCore)
+    decoy.when(mock_instrument_core.get_current_volume()).then_return(50)
 
     subject = TransferComponentsExecutor(
         instrument_core=mock_instrument_core,
@@ -482,8 +486,9 @@ def test_dispense_into_trash_and_wait(
     dispense_flow_rate = (
         sample_transfer_props.dispense.flow_rate_by_volume.get_for_volume(10)
     )
+    decoy.when(mock_instrument_core.get_current_volume()).then_return(50)
     correction_volume = (
-        sample_transfer_props.dispense.correction_by_volume.get_for_volume(50)
+        sample_transfer_props.dispense.correction_by_volume.get_for_volume(40)
     )
     subject = TransferComponentsExecutor(
         instrument_core=mock_instrument_core,
@@ -526,11 +531,12 @@ def test_mix(
     dispense_flow_rate = (
         sample_transfer_props.dispense.flow_rate_by_volume.get_for_volume(50)
     )
+    decoy.when(mock_instrument_core.get_current_volume()).then_return(0, 50)
     aspirate_correction_volume = (
         sample_transfer_props.aspirate.correction_by_volume.get_for_volume(50)
     )
     dispense_correction_volume = (
-        sample_transfer_props.dispense.correction_by_volume.get_for_volume(50)
+        sample_transfer_props.dispense.correction_by_volume.get_for_volume(0)
     )
     subject = TransferComponentsExecutor(
         instrument_core=mock_instrument_core,
@@ -623,11 +629,12 @@ def test_pre_wet(
     dispense_flow_rate = (
         sample_transfer_props.dispense.flow_rate_by_volume.get_for_volume(40)
     )
+    decoy.when(mock_instrument_core.get_current_volume()).then_return(0, 40)
     aspirate_correction_volume = (
-        sample_transfer_props.aspirate.correction_by_volume.get_for_volume(50)
+        sample_transfer_props.aspirate.correction_by_volume.get_for_volume(40)
     )
     dispense_correction_volume = (
-        sample_transfer_props.dispense.correction_by_volume.get_for_volume(50)
+        sample_transfer_props.dispense.correction_by_volume.get_for_volume(0)
     )
     subject = TransferComponentsExecutor(
         instrument_core=mock_instrument_core,
@@ -733,6 +740,7 @@ def test_retract_after_aspiration(
     sample_transfer_props.aspirate.correction_by_volume.set_for_volume(
         air_gap_volume, air_gap_correction_by_vol
     )
+    decoy.when(mock_instrument_core.get_current_volume()).then_return(0)
 
     subject = TransferComponentsExecutor(
         instrument_core=mock_instrument_core,
@@ -823,6 +831,7 @@ def test_retract_after_aspiration_when_retract_loc_below_safe_airgap_point(
         tip_state=TipState(),
         transfer_type=TransferType.ONE_TO_ONE,
     )
+    decoy.when(mock_instrument_core.get_current_volume()).then_return(0)
     decoy.when(source_well.get_bottom(0)).then_return(well_bottom_point)
     decoy.when(source_well.get_top(0)).then_return(well_top_point)
     decoy.when(source_well.get_top(AIR_GAP_LOC_Z_OFFSET_FROM_WELL_TOP)).then_return(
@@ -953,6 +962,7 @@ def test_retract_after_aspiration_without_touch_tip_and_delay(
         ),
         transfer_type=TransferType.ONE_TO_ONE,
     )
+    decoy.when(mock_instrument_core.get_current_volume()).then_return(0)
     decoy.when(source_well.get_bottom(0)).then_return(well_bottom_point)
     decoy.when(source_well.get_top(0)).then_return(well_top_point)
     # Assume air gap safe location is below retract location
@@ -999,7 +1009,7 @@ def test_retract_after_aspiration_for_consolidate(
         air_gap_volume, air_gap_flow_rate_by_vol
     )
     sample_transfer_props.aspirate.correction_by_volume.set_for_volume(
-        air_gap_volume, air_gap_correction_by_vol
+        12.3 + air_gap_volume, air_gap_correction_by_vol
     )
 
     subject = TransferComponentsExecutor(
@@ -1116,6 +1126,7 @@ def test_retract_after_dispense_with_blowout_in_source(
         tip_state=TipState(),
         transfer_type=TransferType.ONE_TO_ONE,
     )
+    decoy.when(mock_instrument_core.get_current_volume()).then_return(0)
     decoy.when(dest_well.get_bottom(0)).then_return(well_bottom_point)
     decoy.when(dest_well.get_top(0)).then_return(well_top_point)
     decoy.when(source_well.get_top(0)).then_return(Point(10, 20, 30))
@@ -1248,6 +1259,7 @@ def test_retract_after_dispense_with_blowout_in_destination(
         ),
         transfer_type=TransferType.ONE_TO_ONE,
     )
+    decoy.when(mock_instrument_core.get_current_volume()).then_return(0)
     decoy.when(dest_well.get_bottom(0)).then_return(well_bottom_point)
     decoy.when(dest_well.get_top(0)).then_return(well_top_point)
     # Assume air gap safe location is below retract location
@@ -1348,6 +1360,7 @@ def test_retract_after_dispense_with_blowout_in_trash_well(
         tip_state=TipState(),
         transfer_type=TransferType.ONE_TO_ONE,
     )
+    decoy.when(mock_instrument_core.get_current_volume()).then_return(0)
     decoy.when(dest_well.get_bottom(0)).then_return(well_bottom_point)
     decoy.when(dest_well.get_top(0)).then_return(well_top_point)
     decoy.when(trash_well._core).then_return(trash_well_core)
@@ -1474,6 +1487,7 @@ def test_retract_after_dispense_with_blowout_in_disposal_location(
         tip_state=TipState(),
         transfer_type=TransferType.ONE_TO_ONE,
     )
+    decoy.when(mock_instrument_core.get_current_volume()).then_return(0)
     decoy.when(dest_well.get_bottom(0)).then_return(well_bottom_point)
     decoy.when(dest_well.get_top(0)).then_return(well_top_point)
     # Assume air gap safe location is below retract location
@@ -1578,6 +1592,7 @@ def test_retract_after_dispense_in_trash_with_blowout_in_source(
         transfer_type=TransferType.ONE_TO_ONE,
     )
 
+    decoy.when(mock_instrument_core.get_current_volume()).then_return(0)
     decoy.when(source_well.get_top(0)).then_return(Point(10, 20, 30))
     # Assume air gap safe location for air-gapping at src is below touch-tip position,
     # where touch tip position is source well top
@@ -1684,6 +1699,7 @@ def test_retract_after_dispense_in_trash_with_blowout_in_destination(
         ),
         transfer_type=TransferType.ONE_TO_ONE,
     )
+    decoy.when(mock_instrument_core.get_current_volume()).then_return(0)
     decoy.when(target_trash.offset).then_return(DisposalOffset(x=4, y=5, z=6))
     decoy.when(target_trash.top(x=0, y=0, z=2)).then_return(trash_top)
     decoy.when(trash_top.offset).then_return(DisposalOffset(x=1, y=2, z=3))
@@ -1758,6 +1774,7 @@ def test_retract_after_dispense_in_trash_with_blowout_in_disposal_location(
         tip_state=TipState(),
         transfer_type=TransferType.ONE_TO_ONE,
     )
+    decoy.when(mock_instrument_core.get_current_volume()).then_return(0)
     decoy.when(target_trash.offset).then_return(DisposalOffset(x=4, y=5, z=6))
     decoy.when(target_trash.top(x=0, y=0, z=2)).then_return(target_trash_top)
     decoy.when(target_trash_top.offset).then_return(DisposalOffset(x=1, y=2, z=3))
@@ -1874,6 +1891,7 @@ def test_retract_after_dispense_with_blowout_in_src_moves_to_safe_loc_for_air_ga
         tip_state=TipState(),
         transfer_type=TransferType.ONE_TO_ONE,
     )
+    decoy.when(mock_instrument_core.get_current_volume()).then_return(0)
     decoy.when(dest_well.get_bottom(0)).then_return(well_bottom_point)
     decoy.when(dest_well.get_top(0)).then_return(well_top_point)
     decoy.when(source_well.get_top(0)).then_return(Point(10, 20, 30))
@@ -2017,6 +2035,7 @@ def test_multi_dispense_retract_after_dispense_without_conditioning_volume_or_bl
         tip_state=TipState(),
         transfer_type=TransferType.ONE_TO_MANY,
     )
+    decoy.when(mock_instrument_core.get_current_volume()).then_return(0)
     decoy.when(dest_well.get_top(0)).then_return(well_top_point)
     # Assume air gap safe location is below retract location
     decoy.when(dest_well.get_top(AIR_GAP_LOC_Z_OFFSET_FROM_WELL_TOP)).then_return(
@@ -2135,6 +2154,7 @@ def test_multi_dispense_retract_after_dispense_with_blowout_without_conditioning
         tip_state=TipState(),
         transfer_type=TransferType.ONE_TO_MANY,
     )
+    decoy.when(mock_instrument_core.get_current_volume()).then_return(0)
     decoy.when(dest_well.get_top(0)).then_return(well_top_point)
     # Assume air gap safe location is below retract location
     decoy.when(dest_well.get_top(AIR_GAP_LOC_Z_OFFSET_FROM_WELL_TOP)).then_return(


### PR DESCRIPTION
# Overview

This fix was prompted by RQA-4294, which showed an error happening related to an `airGapInPlace` being executed when the pipette was not ready to aspirate. After tracking down the source of this, it was determined that the correction volume being applied was causing the pipette's plunger position to go beyond the bottom, which caused it to be marked as not `ready_to_aspirate`. Because this was not being tracked anywhere else, we were both not reporting it in analysis as well as not preparing to aspirate before trying the air gap.

On further investigation, it was determined that correction volume was not being calculated properly. Correction volume is a `by_volume` property, meaning we find the appropriate value on the curve based on a volume. Previously we were using the volume being aspirated or dispensed as the point on the curve, but according to @andySigler it was supposed to be the volume in the tip **AFTER** the operation. Meaning `current volume + aspirated volume` for aspirate correction volume, and `current volume - dispense volume` for a dispense correction volume.

The above calculation is fixed by this PR, which allows the protocol that caused the bug to pass. What is not fixed is keeping track of this condition happening (which it should not with the defaults, but a user could change their values to have this happen), meaning we would not prepare to aspirate if the correction volume somehow still caused this. We also are still not keeping track of this in the simulated pipetting code, so this error would not be caught in analysis if it occurs.

## Test Plan and Hands on Testing

Updated a lot of unit tests that exercise this new logic, and this protocol that previously was failing is now passing:

```
from opentrons import protocol_api

requirements = {"robotType": "Flex", "apiLevel": "2.24"}

metadata = {
    "protocolName":'Liquid Class Ethanol Correction Volume Bug',
    'author':'Jeremy'
}

def run(protocol: protocol_api.ProtocolContext):
    partial_rack_1 = protocol.load_labware(
        load_name="opentrons_flex_96_filtertiprack_1000ul",
        location="B2")


    plate = protocol.load_labware(
        load_name = "opentrons_96_wellplate_200ul_pcr_full_skirt",
        location = "C3"
    )
    pipette = protocol.load_instrument(
        instrument_name="flex_8channel_1000", mount='left' , tip_racks= [partial_rack_1])

    trash = protocol.load_trash_bin("A3")
    ethanol = protocol.get_liquid_class('ethanol_80')

    pipette.distribute_with_liquid_class(
        liquid_class=ethanol,
        volume=200,
        source=plate['A1'],
        dest=[plate['A2'], plate['A3']],
        new_tip='always',
        group_wells=False
    )
```

## Changelog

- use volume of pipette after operation as the volume to calculate correction volume for

## Review requests

## Risk assessment

Medium-high. This will not affect the `water` liquid class since it did not have correction volumes, and the aspirate correction volumes for transfers were accidentally correct in the previous implementation, but this does change pipette behavior for all `glycerol` and `ethanol` liquid class transfers.