### PR TITLE
refactor(step-generation): default robotState.pipette location to home

### DIFF
--- a/app/src/organisms/ODD/QuickTransferFlow/__tests__/utils/quickTransferStepCommands.test.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/__tests__/utils/quickTransferStepCommands.test.ts
@@ -68,6 +68,7 @@ const mockRobotState: TimelineFrame = {
   pipettes: {
     mockPipette: {
       mount: 'left',
+      location: 'home',
     },
   },
   labware: {

--- a/app/src/organisms/ODD/QuickTransferFlow/utils/generateQuickTransferArgs.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/utils/generateQuickTransferArgs.ts
@@ -89,6 +89,7 @@ function getInvariantContextAndRobotState(
   const pipetteLocations: RobotState['pipettes'] = {
     [pipetteId]: {
       mount: quickTransferState.mount,
+      location: 'home',
     },
   }
   const sourceLabwareURI = getLabwareDefURI(quickTransferState.source)

--- a/protocol-designer/src/components/organisms/EditInstrumentsModal/editPipettes.ts
+++ b/protocol-designer/src/components/organisms/EditInstrumentsModal/editPipettes.ts
@@ -43,12 +43,14 @@ export const editPipettes = (
           mount: oppositePipette.mount,
           name: oppositePipette.name,
           tiprackDefURI: oppositePipette.tiprackDefURI,
+          location: oppositePipette.location,
         }
       : null
   const newPip: PipetteFieldsData = {
     mount: mount,
     name: selectedPip,
     tiprackDefURI: selectedTips,
+    location: 'home',
   }
 
   const newPipetteArray: PipetteFieldsData[] =

--- a/protocol-designer/src/file-data/__fixtures__/createFile/engageMagnet.ts
+++ b/protocol-designer/src/file-data/__fixtures__/createFile/engageMagnet.ts
@@ -27,6 +27,7 @@ export const initialRobotState: RobotState = {
   pipettes: {
     pipetteId: {
       mount: 'left',
+      location: 'home',
     },
   },
   liquidState: {

--- a/protocol-designer/src/file-data/__fixtures__/createFile/noModules.ts
+++ b/protocol-designer/src/file-data/__fixtures__/createFile/noModules.ts
@@ -19,6 +19,7 @@ export const initialRobotState: RobotState = {
   pipettes: {
     pipetteId: {
       mount: 'left',
+      location: 'home',
     },
   },
   liquidState: {

--- a/protocol-designer/src/file-data/__fixtures__/createFile/v6Fixture.ts
+++ b/protocol-designer/src/file-data/__fixtures__/createFile/v6Fixture.ts
@@ -19,6 +19,7 @@ export const initialRobotState: RobotState = {
   pipettes: {
     pipetteId: {
       mount: 'left',
+      location: 'home',
     },
   },
   liquidState: {

--- a/protocol-designer/src/file-data/__fixtures__/createFile/v7Fixture.ts
+++ b/protocol-designer/src/file-data/__fixtures__/createFile/v7Fixture.ts
@@ -19,6 +19,7 @@ export const initialRobotState: RobotState = {
   pipettes: {
     pipetteId: {
       mount: 'left',
+      location: 'home',
     },
   },
   liquidState: {

--- a/protocol-designer/src/file-data/selectors/commands.ts
+++ b/protocol-designer/src/file-data/selectors/commands.ts
@@ -62,6 +62,7 @@ export const getInitialRobotState: (
       initialDeckSetup.pipettes,
       (p: PipetteOnDeck): PipetteTemporalProperties => ({
         mount: p.mount,
+        location: 'home',
       })
     )
     const labware: Record<string, LabwareTemporalProperties> = mapValues(

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/__tests__/AddStepButton.test.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/__tests__/AddStepButton.test.tsx
@@ -75,6 +75,7 @@ const MOCK_INITIAL_ROBOT_STATE = {
   pipettes: {
     'a212ebf2-bbd7-4946-a0e7-894a55e730ce': {
       mount: 'left',
+      location: 'home',
     },
   },
   liquidState: {

--- a/protocol-designer/src/pages/Onboarding/index.tsx
+++ b/protocol-designer/src/pages/Onboarding/index.tsx
@@ -156,6 +156,7 @@ export function Onboarding(): JSX.Element | null {
                 mount,
                 name: formPipette.pipetteName as PipetteName,
                 tiprackDefURI: formPipette.tiprackDefURI,
+                location: 'home',
               },
             ]
           : acc

--- a/protocol-designer/src/step-forms/selectors/index.ts
+++ b/protocol-designer/src/step-forms/selectors/index.ts
@@ -361,7 +361,7 @@ const _getInitialDeckSetup = (
     pipettes: mapValues<{}, PipetteOnDeck>(
       pipetteLocations as Record<Mount, string>,
       (mount: Mount, pipetteId: string): PipetteOnDeck => {
-        return { mount, ...pipetteEntities[pipetteId] }
+        return { mount, location: 'home', ...pipetteEntities[pipetteId] }
       }
     ),
     additionalEquipmentOnDeck: additionalEquipmentEntitiesOnDeck,

--- a/protocol-designer/src/step-forms/types.ts
+++ b/protocol-designer/src/step-forms/types.ts
@@ -110,6 +110,7 @@ export interface LabwareTemporalProperties {
 }
 export interface PipetteTemporalProperties {
   mount: Mount
+  location: 'home' | string
   nozzles?: NozzleConfigurationStyle
   prevNozzles?: NozzleConfigurationStyle
 }

--- a/protocol-designer/src/steplist/substepTimeline.ts
+++ b/protocol-designer/src/steplist/substepTimeline.ts
@@ -99,12 +99,12 @@ export const substepTimelineSingleChannel = (
           }
           const { volume, pipetteId } = command.params
           const pipetteEntity = pipettes[pipetteId]
-          const entityId = pipetteEntity.entityId ?? ''
+          const location = pipetteEntity.location ?? ''
           const wellName = pipetteEntity.wellName ?? ''
-          const isMoveToWell = labwareEntities[entityId] != null
+          const isMoveToWell = labwareEntities[location] != null
 
           if (isMoveToWell) {
-            const { id: labwareId } = invariantContext.labwareEntities[entityId]
+            const { id: labwareId } = invariantContext.labwareEntities[location]
 
             const wellInfo = {
               labwareId,
@@ -130,16 +130,16 @@ export const substepTimelineSingleChannel = (
               ],
             }
           } else {
-            const isWasteChute = wasteChuteEntities[entityId] != null
+            const isWasteChute = wasteChuteEntities[location] != null
             const wellInfo = {
-              additionalEquipmentId: entityId,
+              additionalEquipmentId: location,
               wells: [],
               preIngreds: isWasteChute
-                ? liquidState.wasteChute[entityId]
-                : liquidState.trashBins[entityId],
+                ? liquidState.wasteChute[location]
+                : liquidState.trashBins[location],
               postIngreds: isWasteChute
-                ? nextRobotState.liquidState.wasteChute[entityId]
-                : nextRobotState.liquidState.trashBins[entityId],
+                ? nextRobotState.liquidState.wasteChute[location]
+                : nextRobotState.liquidState.trashBins[location],
             }
 
             return {
@@ -218,9 +218,9 @@ export const substepTimelineMultiChannel = (
 
           const { volume, pipetteId } = command.params
           const pipetteEntity = pipettes[pipetteId]
-          const entityId = pipetteEntity.entityId ?? ''
+          const location = pipetteEntity.location ?? ''
           const wellName = pipetteEntity.wellName ?? ''
-          const isMoveToWell = labwareEntities[entityId] != null
+          const isMoveToWell = labwareEntities[location] != null
           const channels = pipetteEntities[pipetteId].spec.channels
           const nozzles = pipetteEntity.nozzles
 
@@ -236,7 +236,7 @@ export const substepTimelineMultiChannel = (
             const {
               def: labwareDef,
               id: labwareId,
-            } = invariantContext.labwareEntities[entityId]
+            } = invariantContext.labwareEntities[location]
             const wellsForTips =
               numChannels &&
               labwareDef &&
@@ -268,16 +268,16 @@ export const substepTimelineMultiChannel = (
               prevRobotState: nextRobotState,
             }
           } else {
-            const isWasteChute = wasteChuteEntities[entityId] != null
+            const isWasteChute = wasteChuteEntities[location] != null
             const wellInfo = {
-              additionalEquipmentId: entityId,
+              additionalEquipmentId: location,
               wells: [],
               preIngreds: isWasteChute
-                ? liquidState.wasteChute[entityId]
-                : liquidState.trashBins[entityId],
+                ? liquidState.wasteChute[location]
+                : liquidState.trashBins[location],
               postIngreds: isWasteChute
-                ? nextRobotState.liquidState.wasteChute[entityId]
-                : nextRobotState.liquidState.trashBins[entityId],
+                ? nextRobotState.liquidState.wasteChute[location]
+                : nextRobotState.liquidState.trashBins[location],
             }
 
             return {

--- a/protocol-designer/src/steplist/test/generateSubsteps.test.ts
+++ b/protocol-designer/src/steplist/test/generateSubsteps.test.ts
@@ -44,7 +44,7 @@ describe('generateSubstepItem', () => {
     }
     robotState = makeInitialRobotState({
       invariantContext,
-      pipetteLocations: { p300SingleId: { mount: 'left' } },
+      pipetteLocations: { p300SingleId: { mount: 'left', location: 'home' } },
       labwareLocations: {
         tiprack1Id: { stack: ['tiprack1Id', '2'] },
         sourcePlateId: { stack: ['sourcePlateId', '4'] },

--- a/protocol-designer/src/ui/steps/actions/__tests__/actions.test.ts
+++ b/protocol-designer/src/ui/steps/actions/__tests__/actions.test.ts
@@ -40,6 +40,7 @@ const initialRobotState: RobotState = {
   pipettes: {
     pipetteId: {
       mount: 'left',
+      location: 'home',
     },
   },
   liquidState: {
@@ -341,6 +342,7 @@ describe('steps actions', () => {
                     pipettes: {
                       pipetteId: {
                         mount: 'left',
+                        location: 'home',
                       },
                     },
                     tipState: {
@@ -489,6 +491,7 @@ describe('steps actions', () => {
                     pipettes: {
                       pipetteId: {
                         mount: 'left',
+                        location: 'home',
                       },
                     },
                     tipState: {

--- a/step-generation/src/__tests__/__snapshots__/fixtureGeneration.test.ts.snap
+++ b/step-generation/src/__tests__/__snapshots__/fixtureGeneration.test.ts.snap
@@ -19362,6 +19362,7 @@ exports[`snapshot tests > makeState 1`] = `
   "modules": {},
   "pipettes": {
     "p300SingleId": {
+      "location": "home",
       "mount": "left",
     },
   },

--- a/step-generation/src/__tests__/__snapshots__/utils.test.ts.snap
+++ b/step-generation/src/__tests__/__snapshots__/utils.test.ts.snap
@@ -358,9 +358,11 @@ exports[`makeInitialRobotState > matches snapshot 1`] = `
   },
   "pipettes": {
     "p10SingleId": {
+      "location": "home",
       "mount": "left",
     },
     "p300MultiId": {
+      "location": "home",
       "mount": "right",
     },
   },

--- a/step-generation/src/__tests__/fixtureGeneration.test.ts
+++ b/step-generation/src/__tests__/fixtureGeneration.test.ts
@@ -37,6 +37,7 @@ describe('snapshot tests', () => {
         pipetteLocations: {
           p300SingleId: {
             mount: 'left',
+            location: 'home',
           },
         },
         tiprackSetting: {

--- a/step-generation/src/__tests__/getIsSafePipetteMovement.test.ts
+++ b/step-generation/src/__tests__/getIsSafePipetteMovement.test.ts
@@ -76,7 +76,7 @@ describe('getIsSafePipetteMovement', () => {
       },
     }
     mockRobotState = {
-      pipettes: { pip: { mount: 'left' } },
+      pipettes: { pip: { mount: 'left', location: 'home' } },
       labware: {
         [mockLabwareId]: { stack: ['mockLabwareId', 'D2'] },
         [mockTiprackId]: { stack: ['mockTiprackId', 'A2'] },

--- a/step-generation/src/__tests__/pythonFileUtils.test.ts
+++ b/step-generation/src/__tests__/pythonFileUtils.test.ts
@@ -334,8 +334,8 @@ describe('getLoadPipettes', () => {
       },
     }
     const pipetteRobotState: TimelineFrame['pipettes'] = {
-      [pipette1]: { mount: 'left' },
-      [pipette2]: { mount: 'right' },
+      [pipette1]: { mount: 'left', location: 'home' },
+      [pipette2]: { mount: 'right', location: 'home' },
     }
     const labwareRobotState: TimelineFrame['labware'] = {
       [tiprack1]: { stack: [tiprack1, 'offDeck'] },
@@ -371,7 +371,7 @@ pipette_left = protocol.load_instrument("flex_1channel_1000", "right", tip_racks
     }
     const mockTiprackEntities: LabwareEntities = {}
     const pipetteRobotState: TimelineFrame['pipettes'] = {
-      [pipette1]: { mount: 'left' },
+      [pipette1]: { mount: 'left', location: 'home' },
     }
 
     expect(
@@ -403,7 +403,7 @@ pipette_left = protocol.load_instrument("p300_multi_gen2", "left")`.trimStart()
 
     const mockTiprackEntities: LabwareEntities = {}
     const pipetteRobotState: TimelineFrame['pipettes'] = {
-      [pipette1]: { mount: 'left' },
+      [pipette1]: { mount: 'left', location: 'home' },
     }
 
     expect(

--- a/step-generation/src/__tests__/replaceTip.test.ts
+++ b/step-generation/src/__tests__/replaceTip.test.ts
@@ -335,7 +335,12 @@ describe('replaceTip', () => {
       initialRobotState = {
         ...initialRobotState,
         pipettes: {
-          p100096Id: { mount: 'left', nozzles: COLUMN, tiprackId: tiprack5Id },
+          p100096Id: {
+            mount: 'left',
+            location: 'home',
+            nozzles: COLUMN,
+            tiprackId: tiprack5Id,
+          },
         },
         tipState: {
           tipracks: {

--- a/step-generation/src/__tests__/robotStateSelectors.test.ts
+++ b/step-generation/src/__tests__/robotStateSelectors.test.ts
@@ -82,8 +82,8 @@ describe('_getNextTip', () => {
       invariantContext: _invariantContext,
       labwareLocations: { [tiprackId]: { stack: [tiprackId, '8'] } },
       pipetteLocations: {
-        p300SingleId: { mount: 'left' },
-        p300MultiId: { mount: 'right' },
+        p300SingleId: { mount: 'left', location: 'home' },
+        p300MultiId: { mount: 'right', location: 'home' },
       },
       tiprackSetting: { [tiprackId]: true },
     })
@@ -152,7 +152,7 @@ describe('getNextTiprack - single-channel', () => {
         tiprack1Id: { stack: ['tiprack1Id', '1'] },
         sourcePlateId: { stack: ['sourcePlateId', '2'] },
       },
-      pipetteLocations: { p300SingleId: { mount: 'left' } },
+      pipetteLocations: { p300SingleId: { mount: 'left', location: 'home' } },
       tiprackSetting: { tiprack1Id: true },
     })
 
@@ -172,7 +172,7 @@ describe('getNextTiprack - single-channel', () => {
   it('single tiprack, empty, should return null', () => {
     const robotState = makeState({
       invariantContext,
-      pipetteLocations: { p300SingleId: { mount: 'left' } },
+      pipetteLocations: { p300SingleId: { mount: 'left', location: 'home' } },
       labwareLocations: { tiprack1Id: { stack: ['tiprack1Id', '1'] } },
       tiprackSetting: { tiprack1Id: false },
     })
@@ -189,7 +189,7 @@ describe('getNextTiprack - single-channel', () => {
   it('multiple tipracks, all full, should return the filled tiprack in the lowest slot', () => {
     const robotState = makeState({
       invariantContext,
-      pipetteLocations: { p300SingleId: { mount: 'left' } },
+      pipetteLocations: { p300SingleId: { mount: 'left', location: 'home' } },
       labwareLocations: {
         tiprack1Id: { stack: ['tiprack1Id', '1'] },
         tiprack2Id: { stack: ['tiprack2Id', '11'] },
@@ -210,7 +210,7 @@ describe('getNextTiprack - single-channel', () => {
   it('multiple tipracks, some partially full, should return the filled tiprack in the lowest slot', () => {
     const robotState = makeState({
       invariantContext,
-      pipetteLocations: { p300SingleId: { mount: 'left' } },
+      pipetteLocations: { p300SingleId: { mount: 'left', location: 'home' } },
       labwareLocations: {
         tiprack1Id: { stack: ['tiprack1Id', '2'] },
         tiprack2Id: { stack: ['tiprack2Id', '11'] },
@@ -234,7 +234,7 @@ describe('getNextTiprack - single-channel', () => {
   it('multiple tipracks, all empty, should return null', () => {
     const robotState = makeState({
       invariantContext,
-      pipetteLocations: { p300SingleId: { mount: 'left' } },
+      pipetteLocations: { p300SingleId: { mount: 'left', location: 'home' } },
       labwareLocations: {
         tiprack1Id: { stack: ['tiprack1Id', '2'] },
         tiprack2Id: { stack: ['tiprack2Id', '11'] },
@@ -256,7 +256,7 @@ describe('getNextTiprack - 8-channel', () => {
   it('single tiprack, totally full', () => {
     const robotState = makeState({
       invariantContext,
-      pipetteLocations: { p300SingleId: { mount: 'left' } },
+      pipetteLocations: { p300SingleId: { mount: 'left', location: 'home' } },
       labwareLocations: {
         tiprack1Id: { stack: ['tiprack1Id', '1'] },
       },
@@ -277,7 +277,7 @@ describe('getNextTiprack - 8-channel', () => {
   it('single tiprack, partially full', () => {
     const robotState = makeState({
       invariantContext,
-      pipetteLocations: { p300SingleId: { mount: 'left' } },
+      pipetteLocations: { p300SingleId: { mount: 'left', location: 'home' } },
       labwareLocations: {
         tiprack1Id: { stack: ['tiprack1Id', '2'] },
       },
@@ -303,7 +303,7 @@ describe('getNextTiprack - 8-channel', () => {
   it('single tiprack, empty, should return null', () => {
     const robotState = makeState({
       invariantContext,
-      pipetteLocations: { p300SingleId: { mount: 'left' } },
+      pipetteLocations: { p300SingleId: { mount: 'left', location: 'home' } },
       labwareLocations: {
         tiprack1Id: { stack: ['tiprack1Id', '2'] },
       },
@@ -322,7 +322,7 @@ describe('getNextTiprack - 8-channel', () => {
   it('single tiprack, a well missing from each column, should return null', () => {
     const robotState = makeState({
       invariantContext,
-      pipetteLocations: { p300SingleId: { mount: 'left' } },
+      pipetteLocations: { p300SingleId: { mount: 'left', location: 'home' } },
       labwareLocations: {
         tiprack1Id: { stack: ['tiprack1Id', '2'] },
       },
@@ -357,7 +357,7 @@ describe('getNextTiprack - 8-channel', () => {
   it('multiple tipracks, all full, should return the filled tiprack in the lowest slot', () => {
     const robotState = makeState({
       invariantContext,
-      pipetteLocations: { p300SingleId: { mount: 'left' } },
+      pipetteLocations: { p300SingleId: { mount: 'left', location: 'home' } },
       labwareLocations: {
         tiprack1Id: { stack: ['tiprack1Id', '2'] },
         tiprack2Id: { stack: ['tiprack2Id', '3'] },
@@ -379,7 +379,7 @@ describe('getNextTiprack - 8-channel', () => {
   it('multiple tipracks, some partially full, should return the filled tiprack in the lowest slot', () => {
     const robotState = makeState({
       invariantContext,
-      pipetteLocations: { p300SingleId: { mount: 'left' } },
+      pipetteLocations: { p300SingleId: { mount: 'left', location: 'home' } },
       labwareLocations: {
         tiprack1Id: { stack: ['tiprack1Id', '1'] },
         tiprack2Id: { stack: ['tiprack2Id', '2'] },
@@ -439,7 +439,7 @@ describe('getNextTiprack - 8-channel', () => {
   it('multiple tipracks, all empty, should return null', () => {
     const robotState = makeState({
       invariantContext,
-      pipetteLocations: { p300SingleId: { mount: 'left' } },
+      pipetteLocations: { p300SingleId: { mount: 'left', location: 'home' } },
       labwareLocations: {
         tiprack1Id: { stack: ['tiprack1Id', '1'] },
         tiprack2Id: { stack: ['tiprack2Id', '2'] },
@@ -470,7 +470,7 @@ describe('getModuleState', () => {
     }
     const robotState = makeState({
       invariantContext,
-      pipetteLocations: { p300SingleId: { mount: 'left' } },
+      pipetteLocations: { p300SingleId: { mount: 'left', location: 'home' } },
       labwareLocations: {
         tiprack1Id: { stack: ['tiprack1Id', '2'] },
       },

--- a/step-generation/src/__tests__/utils.test.ts
+++ b/step-generation/src/__tests__/utils.test.ts
@@ -349,8 +349,8 @@ describe('makeInitialRobotState', () => {
           },
         },
         pipetteLocations: {
-          p10SingleId: { mount: 'left' },
-          p300MultiId: { mount: 'right' },
+          p10SingleId: { mount: 'left', location: 'home' },
+          p300MultiId: { mount: 'right', location: 'home' },
         },
       })
     ).toMatchSnapshot()

--- a/step-generation/src/fixtures/robotStateFixtures.ts
+++ b/step-generation/src/fixtures/robotStateFixtures.ts
@@ -237,10 +237,12 @@ export const makeStateArgsStandard = (): StandardMakeStateArgs => ({
     [DEFAULT_PIPETTE]: {
       mount: 'left',
       tiprackId: 'tiprack1Id',
+      location: 'home',
     },
     [MULTI_PIPETTE]: {
       mount: 'right',
       tiprackId: 'tiprack1Id',
+      location: 'home',
     },
   },
   labwareLocations: {
@@ -275,9 +277,11 @@ export const makeStateArgsLabwareOffDeck = (): StandardMakeStateArgs => ({
   pipetteLocations: {
     [DEFAULT_PIPETTE]: {
       mount: 'left',
+      location: 'home',
     },
     [MULTI_PIPETTE]: {
       mount: 'right',
+      location: 'home',
     },
   },
   labwareLocations: {

--- a/step-generation/src/getNextRobotStateAndWarnings/forAspirate.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/forAspirate.ts
@@ -29,7 +29,7 @@ export function forAspirate(
   const labwareId =
     'labwareId' in params
       ? params.labwareId
-      : robotState.pipettes[pipetteId].entityId ?? ''
+      : robotState.pipettes[pipetteId].location ?? ''
   const wellName =
     'wellName' in params
       ? params.wellName

--- a/step-generation/src/getNextRobotStateAndWarnings/forDispense.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/forDispense.ts
@@ -16,7 +16,7 @@ export function forDispense(
   const entityId =
     'labwareId' in params
       ? params.labwareId
-      : robotState.pipettes[pipetteId].entityId ?? ''
+      : robotState.pipettes[pipetteId].location ?? ''
   const wellName =
     'wellName' in params
       ? params.wellName

--- a/step-generation/src/getNextRobotStateAndWarnings/forMoveToAddressableArea.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/forMoveToAddressableArea.ts
@@ -24,12 +24,12 @@ export function forMoveToAddressableArea(
       getTrashLocationFromAddressableAreaName(addressableAreaName)
   )?.id
 
-  const entityId = addressableAreaInWasteChute
+  const location = addressableAreaInWasteChute
     ? Object.values(wasteChuteEntities)[0].id
-    : trashBinId
+    : trashBinId ?? 'home'
   const { robotState } = robotStateAndWarnings
   robotState.pipettes[pipetteId] = {
     ...robotState.pipettes[pipetteId],
-    entityId,
+    location,
   }
 }

--- a/step-generation/src/getNextRobotStateAndWarnings/forMoveToWell.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/forMoveToWell.ts
@@ -10,7 +10,7 @@ export function forMoveToWell(
   const { robotState } = robotStateAndWarnings
   robotState.pipettes[pipetteId] = {
     ...robotState.pipettes[pipetteId],
-    entityId: labwareId,
+    location: labwareId,
     wellName: wellName,
   }
 }

--- a/step-generation/src/getNextRobotStateAndWarnings/inPlaceCommandUpdates.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/inPlaceCommandUpdates.ts
@@ -13,7 +13,7 @@ export const forBlowOutInPlace = (
 ): void => {
   const { pipetteId } = params
   const { robotState } = robotStateAndWarnings
-  const entityId = robotState.pipettes[pipetteId].entityId ?? ''
+  const entityId = robotState.pipettes[pipetteId].location ?? ''
 
   dispenseUpdateLiquidState({
     invariantContext,
@@ -32,7 +32,7 @@ export const forDropTipInPlace = (
 ): void => {
   const { pipetteId } = params
   const { robotState } = robotStateAndWarnings
-  const entityId = robotState.pipettes[pipetteId].entityId ?? ''
+  const entityId = robotState.pipettes[pipetteId].location ?? ''
   robotState.tipState.pipettes[pipetteId] = {
     hasTip: false,
     tiprackURI: null,

--- a/step-generation/src/types.ts
+++ b/step-generation/src/types.ts
@@ -35,8 +35,9 @@ export interface LabwareTemporalProperties {
 
 export interface PipetteTemporalProperties {
   mount: Mount
-  //  entityId is either a labwareId or a trashBin/wasteChute id
-  entityId?: string
+  //  location is either a labwareId a trashBin/wasteChute id, or home
+  //  home is used before the pipette has moved in the protocol
+  location: 'home' | string
   //  primary nozzle's wellName if over a labware
   wellName?: string
   //  pipette's nozzle configuration

--- a/step-generation/src/utils/createTimelineFromRunCommands.ts
+++ b/step-generation/src/utils/createTimelineFromRunCommands.ts
@@ -30,6 +30,7 @@ export function getResultingTimelineFrameFromRunCommands(
           ...acc,
           [command.result.pipetteId]: {
             mount: command.params.mount,
+            location: 'home',
           },
         }
       }


### PR DESCRIPTION
# Overview

This doesn't technically affect anything, it is just the _accurate_ thing to do since the pipette's location is never technically `undefined` and is always located either at the home, labware or trash location. This PR, instead of undefining the location will default the location to home until a pipette movement is added (like a `moveToWell` or `moveToAddressableArea`) 

Since this doesn't affect any functionality and PD 8.5 code freeze is already in the past, i opted to merge this into `edge` but lmk if you think it should be in the release branch.

## Test Plan and Hands on Testing

Just review the code. You can smoke test to, just see if the robot state seems to update and that things seem normal -> in particular, you can test that a transfer step's step details look correct.

## Changelog

- default the pipette location to `home` and plug in everywhere and fix tests

## Risk assessment

low