### PR TITLE
fix(protocol-designer): submerge mmFromBottom fields to position from…

### DIFF
--- a/protocol-designer/src/components/organisms/TipPositionModal/utils.tsx
+++ b/protocol-designer/src/components/organisms/TipPositionModal/utils.tsx
@@ -16,11 +16,8 @@ import { DECIMALS_ALLOWED, TOO_MANY_DECIMALS } from './constants'
 import type { PositionReference } from '@opentrons/shared-data'
 import type { StepFieldName } from '../../../form-types'
 
-export function getDefaultMmFromEdge(args: {
-  name: StepFieldName
-  wellDepth?: number
-}): number {
-  const { name, wellDepth = 0 } = args
+export function getDefaultMmFromEdge(args: { name: StepFieldName }): number {
+  const { name } = args
 
   switch (name) {
     case 'mix_mmFromBottom':
@@ -30,10 +27,9 @@ export function getDefaultMmFromEdge(args: {
     case 'aspirate_mmFromBottom':
     case 'aspirate_retract_mmFromBottom':
     case 'dispense_retract_mmFromBottom':
-      return DEFAULT_MM_OFFSET_FROM_BOTTOM
     case 'aspirate_submerge_mmFromBottom':
     case 'dispense_submerge_mmFromBottom':
-      return round(wellDepth + DEFAULT_MM_TOUCH_TIP_OFFSET_FROM_TOP, 1)
+      return DEFAULT_MM_OFFSET_FROM_BOTTOM
     default:
       // touch tip fields
       console.assert(

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/PositionField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/PositionField.tsx
@@ -124,9 +124,7 @@ export function PositionField(props: PositionFieldProps): JSX.Element {
   const mmFromBottom = typeof rawZValue === 'number' ? rawZValue : null
   if (wellDepthMm !== null) {
     // show default value for field in parens if no mmFromBottom value is selected
-    zValue =
-      mmFromBottom ??
-      getDefaultMmFromEdge({ name: zName, wellDepth: wellDepthMm })
+    zValue = mmFromBottom ?? getDefaultMmFromEdge({ name: zName })
   }
 
   let modal = (

--- a/protocol-designer/src/steplist/fieldLevel/index.ts
+++ b/protocol-designer/src/steplist/fieldLevel/index.ts
@@ -397,6 +397,18 @@ const stepFieldHelperMap: Record<StepFieldName, StepFieldHelpers> = {
     maskValue: composeMaskers(maskToFloat, onlyPositiveNumbers),
     castValue: numberOrNull,
   },
+  aspirate_submerge_mmFromBottom: {
+    castValue: Number,
+  },
+  dispense_submerge_mmFromBottom: {
+    castValue: Number,
+  },
+  aspirate_retract_mmFromBottom: {
+    castValue: Number,
+  },
+  dispense_retract_mmFromBottom: {
+    castValue: Number,
+  },
 }
 export const castField = (name: StepFieldName, value: unknown): unknown => {
   const fieldCaster =


### PR DESCRIPTION
… bottom

closes RQA-4346

# Overview

Fix bug where the default `submerge_mmFromBottom` fields for aspirate and dispense were not in range, causing a bug with the positioning in the generated protocol

## Test Plan and Hands on Testing

Upload the attached protocol in the ticket. Open the first transfer step and go through so the fields update appropriately to their fixed defaults. Then when you export the protocol, see that the `aspirate_submerge_mmFromBottom` is not `null` and instead should be `1`

## Changelog

- submerge mm from bottom fields to return the default of -1 from the top since interpolation will convert from mm from top, mm from bottom and mm from center
- cast the mm from bottom fields to type number so they don't populate as `null` to step-generation

## Risk assessment

low
