### PR TITLE
chore(app): display waste chute and fixture options together

### DIFF
--- a/app/src/organisms/DeviceDetailsDeckConfiguration/AddFixtureModal.tsx
+++ b/app/src/organisms/DeviceDetailsDeckConfiguration/AddFixtureModal.tsx
@@ -24,7 +24,6 @@ import {
   replaceCutoutFixtureWithComboFixture,
   replaceFixtureToFakeFixtureAndTransformCutoutFixturesToAA,
   SINGLE_CENTER_CUTOUTS,
-  WASTE_CHUTE_CUTOUT,
 } from '@opentrons/shared-data'
 
 import { OddModal } from '/app/molecules/OddModal'

--- a/app/src/organisms/DeviceDetailsDeckConfiguration/AddFixtureModal.tsx
+++ b/app/src/organisms/DeviceDetailsDeckConfiguration/AddFixtureModal.tsx
@@ -150,24 +150,6 @@ export function AddFixtureModal({
         />
       </>
     )
-  } else if (
-    optionStage === 'fixtureOptions' &&
-    cutoutId === WASTE_CHUTE_CUTOUT &&
-    addressableAreaId === 'D3'
-  ) {
-    nextStageOptions = (
-      <>
-        <FixtureOption
-          key="wasteChuteStageOption"
-          optionName="Waste chute"
-          buttonText={t('select_options')}
-          onClickHandler={() => {
-            setOptionStage('wasteChuteOptions')
-          }}
-          isOnDevice={isOnDevice}
-        />
-      </>
-    )
   }
 
   const sendIdentifyStacker = useSendIdentifyStacker()

--- a/app/src/organisms/DeviceDetailsDeckConfiguration/__tests__/AddFixtureModal.test.tsx
+++ b/app/src/organisms/DeviceDetailsDeckConfiguration/__tests__/AddFixtureModal.test.tsx
@@ -133,10 +133,7 @@ describe('Desktop AddFixtureModal', () => {
     fireEvent.click(screen.getAllByText('Add')[0])
     screen.getByText('Trash bin')
     screen.getByText('Waste chute')
-    expect(screen.getAllByRole('button', { name: 'Add' }).length).toBe(1)
-    expect(
-      screen.getAllByRole('button', { name: 'Select options' }).length
-    ).toBe(1)
+    expect(screen.getAllByRole('button', { name: 'Add' }).length).toBe(2)
   })
 
   it('should render text and buttons slot A1', () => {
@@ -190,8 +187,7 @@ describe('Desktop AddFixtureModal', () => {
   it('should display appropriate Waste Chute options when the generic Waste Chute button is clicked', () => {
     render(props)
     fireEvent.click(screen.getAllByRole('button', { name: 'Add' })[0]) // click fixtures
-    fireEvent.click(screen.getByRole('button', { name: 'Select options' })) // click waste chute options
-    expect(screen.getAllByRole('button', { name: 'Add' }).length).toBe(1)
+    expect(screen.getAllByRole('button', { name: 'Add' }).length).toBe(2)
 
     const displayText = getFixtureDisplayName(
       WASTE_CHUTE_RIGHT_ADAPTER_NO_COVER_FIXTURE
@@ -203,9 +199,6 @@ describe('Desktop AddFixtureModal', () => {
     render(props)
     expect(screen.getAllByRole('button', { name: 'Add' }).length).toBe(2)
     fireEvent.click(screen.getAllByRole('button', { name: 'Add' })[0]) // click fixtures
-    fireEvent.click(screen.getByRole('button', { name: 'Select options' }))
-
-    fireEvent.click(screen.getByText('Go back'))
     screen.getByText('Waste chute')
   })
 })

--- a/app/src/organisms/DeviceDetailsDeckConfiguration/__tests__/utils.test.tsx
+++ b/app/src/organisms/DeviceDetailsDeckConfiguration/__tests__/utils.test.tsx
@@ -208,6 +208,13 @@ describe('getFixtureOptions', () => {
           addressableAreaId: 'movableTrashD3',
         },
       ],
+      [
+        {
+          cutoutId: 'cutoutD3',
+          cutoutFixtureId: 'wasteChuteRightAdapterNoCover',
+          addressableAreaId: '96ChannelWasteChute',
+        },
+      ],
     ])
   })
   it('Should get staging area for cutoutD3 and aa fakeD4', () => {

--- a/app/src/organisms/DeviceDetailsDeckConfiguration/utils.ts
+++ b/app/src/organisms/DeviceDetailsDeckConfiguration/utils.ts
@@ -220,7 +220,6 @@ export const getFixtureOptions = (
     TRASH_BIN_ADAPTER_FIXTURE,
     addressableAreaId
   )
-  console.log('TrashBinAA: ', TrashBinAA)
   if (TrashBinAA != null) {
     availableOptions = [
       ...availableOptions,
@@ -251,6 +250,11 @@ export const getFixtureOptions = (
         },
       ],
     ]
+  }
+
+  if (cutoutId == 'cutoutD3') {
+    const wasteChuteOptions = getWasteChuteOptions(cutoutId)
+    availableOptions = [...availableOptions, ...wasteChuteOptions]
   }
   return availableOptions
 }

--- a/app/src/organisms/DeviceDetailsDeckConfiguration/utils.ts
+++ b/app/src/organisms/DeviceDetailsDeckConfiguration/utils.ts
@@ -252,7 +252,7 @@ export const getFixtureOptions = (
     ]
   }
 
-  if (cutoutId === 'cutoutD3') {
+  if (cutoutId === 'cutoutD3' && addressableAreaId === 'D3') {
     const wasteChuteOptions = getWasteChuteOptions(cutoutId)
     availableOptions = [...availableOptions, ...wasteChuteOptions]
   }

--- a/app/src/organisms/DeviceDetailsDeckConfiguration/utils.ts
+++ b/app/src/organisms/DeviceDetailsDeckConfiguration/utils.ts
@@ -252,7 +252,7 @@ export const getFixtureOptions = (
     ]
   }
 
-  if (cutoutId == 'cutoutD3') {
+  if (cutoutId === 'cutoutD3') {
     const wasteChuteOptions = getWasteChuteOptions(cutoutId)
     availableOptions = [...availableOptions, ...wasteChuteOptions]
   }


### PR DESCRIPTION
# Overview

combine waste chute options with fixture options now that we are only showing the fixture type and there are less options.
before this change:
<img width="433" alt="Screenshot 2025-07-03 at 1 55 52 PM" src="https://github.com/user-attachments/assets/38bf20c1-be8c-44cf-b04b-d08a761f0840" />

<img width="433" alt="Screenshot 2025-07-03 at 1 56 01 PM" src="https://github.com/user-attachments/assets/4c8f4ef3-03da-4b05-9db0-94793ee5cc5c" />

after change:

<img width="438" alt="Screenshot 2025-07-03 at 1 55 34 PM" src="https://github.com/user-attachments/assets/d9f97d48-47e6-4cb5-9ae0-dcfc2027e183" />


## Risk assessment

low.
