### PR TITLE
docs: Remove link to custom labware form

### DIFF
--- a/docs/flex-manual/docs/labware.md
+++ b/docs/flex-manual/docs/labware.md
@@ -396,7 +396,7 @@ Here are some diagrams that help you visualize the examples described above.
 | ![Labware with 3 square wells and 9 circular wells.](images/labware-layout-irregular-wells-not-identical.svg "Regular labware layout") | :octicons-x-12:{ .grey } **Irregular** <br />Columns/rows are evenly spaced but **wells are not identical.** |
 | ![Labware with a 4-by-5 grid of wells and another 2-by-3 grid of wells.](images/labware-layout-irregular-multiple-grids.svg "Regular labware layout") | :octicons-x-12:{ .grey } **Irregular** <br />There is **more than one grid.** |
 
-If you need help creating a custom labware definition, contact our support team by email (<support@opentrons.com>). They will work to design custom labware definitions based on your requirements. This is a fee-based service
+If you need help creating custom labware definitions, contact our support team by email (<support@opentrons.com>). They will work to design custom labware definitions based on your requirements. This is a fee-based service
 
 #### Python API 
 

--- a/docs/flex-manual/docs/labware.md
+++ b/docs/flex-manual/docs/labware.md
@@ -396,7 +396,7 @@ Here are some diagrams that help you visualize the examples described above.
 | ![Labware with 3 square wells and 9 circular wells.](images/labware-layout-irregular-wells-not-identical.svg "Regular labware layout") | :octicons-x-12:{ .grey } **Irregular** <br />Columns/rows are evenly spaced but **wells are not identical.** |
 | ![Labware with a 4-by-5 grid of wells and another 2-by-3 grid of wells.](images/labware-layout-irregular-multiple-grids.svg "Regular labware layout") | :octicons-x-12:{ .grey } **Irregular** <br />There is **more than one grid.** |
 
-Our labware team will work to understand your needs and design custom labware definitions for you. Contact Opentrons Support for more information. This is a fee-based service. 
+If you need help creating a custom labware definition, contact our support team by email (<support@opentrons.com>). They will work to design custom labware definitions based on your requirements. This is a fee-based service
 
 #### Python API 
 

--- a/docs/flex-manual/docs/labware.md
+++ b/docs/flex-manual/docs/labware.md
@@ -396,7 +396,7 @@ Here are some diagrams that help you visualize the examples described above.
 | ![Labware with 3 square wells and 9 circular wells.](images/labware-layout-irregular-wells-not-identical.svg "Regular labware layout") | :octicons-x-12:{ .grey } **Irregular** <br />Columns/rows are evenly spaced but **wells are not identical.** |
 | ![Labware with a 4-by-5 grid of wells and another 2-by-3 grid of wells.](images/labware-layout-irregular-multiple-grids.svg "Regular labware layout") | :octicons-x-12:{ .grey } **Irregular** <br />There is **more than one grid.** |
 
-If you need help creating custom labware definitions, contact our support team by email (<support@opentrons.com>). They will work to design custom labware definitions based on your requirements. This is a fee-based service
+If you need help creating custom labware definitions, contact Opentrons Support (<support@opentrons.com>). They will work to design custom labware definitions based on your requirements. This is a fee-based service.
 
 #### Python API 
 


### PR DESCRIPTION
# Overview

The custom labware form is no longer used but still included in the manual. Linked text to this form is in Chapter 5, Labware, p. 100.

Instead of this form, the right way to request the fee-based service is to contact support. Updating text to reflect this new process.

RTC-722

## Test Plan and Hands on Testing

Review for clarity and grammar.

## Changelog

Changes text and removes a link to an older form that's no longer used/needed.


## Review requests

n/a

## Risk assessment

Low. Small text and link changes.
