### PR TITLE
fix(app): Ensure Identify button for modules covers deck hardware in Protocol Run Setup

### DIFF
--- a/app/src/assets/localization/en/shared.json
+++ b/app/src/assets/localization/en/shared.json
@@ -40,6 +40,7 @@
   "get_started": "Get started",
   "github": "GitHub",
   "go_back": "Go back",
+  "identify": "Identify",
   "instruments": "instruments",
   "loading": "Loading...",
   "next": "Next",

--- a/app/src/organisms/LocationConflictModal/ChooseModuleToConfigureModal.tsx
+++ b/app/src/organisms/LocationConflictModal/ChooseModuleToConfigureModal.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
@@ -32,10 +33,14 @@ import { OddModal } from '/app/molecules/OddModal'
 import { useNotifyDeckConfigurationQuery } from '/app/resources/deck_configuration'
 import { useCloseCurrentRun } from '/app/resources/runs'
 
+import { useSendIdentifyStacker } from '../ModuleWizardFlows/hooks'
+
 import type { AttachedModule } from '@opentrons/api-client'
 import type { DeckDefinition, ModuleModel } from '@opentrons/shared-data'
 
 const EQUIPMENT_POLL_MS = 5000
+const MODULE_IDENTIFY_TIME_MS = 10000
+
 interface ModuleFixtureOption {
   moduleModel: ModuleModel
   usbPort?: number | string
@@ -83,6 +88,20 @@ export const ChooseModuleToConfigureModal = (
       [[], []]
     ) ?? []
 
+  const sendIdentifyStacker = useSendIdentifyStacker()
+  const [identifyInUse, setIdentifyInUse] = useState<string | null>(null)
+  const [identifyTimeout, setTimeoutID] = useState<NodeJS.Timeout | null>(null)
+
+  const stackerIdentifyHandler = (module: AttachedModule): void => {
+    sendIdentifyStacker(module, true, 'blue')
+    setIdentifyInUse(module.serialNumber)
+    const timeoutID = setTimeout(() => {
+      sendIdentifyStacker(module, false)
+      setIdentifyInUse(null)
+    }, MODULE_IDENTIFY_TIME_MS)
+    setTimeoutID(timeoutID)
+  }
+
   const connectedOptions: ModuleFixtureOption[] = unconfiguredModuleMatches.map(
     attachedMod => {
       const portDisplay =
@@ -96,6 +115,31 @@ export const ChooseModuleToConfigureModal = (
       }
     }
   )
+  const handleIdentifyFixture = (module: AttachedModule): void => {
+    if (identifyInUse === null) {
+      stackerIdentifyHandler(module)
+    } else if (identifyInUse !== null) {
+      const previousModule =
+        unconfiguredModuleMatches.find(m => m.serialNumber === identifyInUse) ??
+        null
+      if (previousModule !== null && module !== null) {
+        sendIdentifyStacker(previousModule, false)
+        if (identifyTimeout !== null) {
+          clearTimeout(identifyTimeout)
+        }
+        stackerIdentifyHandler(module)
+      }
+    }
+  }
+  const handleStackerClearAndConfigureModule = (
+    module: AttachedModule
+  ): void => {
+    sendIdentifyStacker(module, false)
+    if (identifyTimeout !== null) {
+      clearTimeout(identifyTimeout)
+    }
+    handleConfigureModule(module.serialNumber)
+  }
   const passiveOptions: ModuleFixtureOption[] =
     requiredModuleModel === MAGNETIC_BLOCK_V1
       ? [{ moduleModel: MAGNETIC_BLOCK_V1 }]
@@ -106,17 +150,41 @@ export const ChooseModuleToConfigureModal = (
         moduleModel,
         deckDef
       )
-      return (
-        <FixtureOption
-          key={serialNumber}
-          onClickHandler={() => {
-            handleConfigureModule(serialNumber)
-          }}
-          optionName={getFixtureDisplayName(moduleFixtures[0].id, usbPort)}
-          buttonText={i18n.format(t('shared:add'), 'capitalize')}
-          isOnDevice={isOnDevice}
-        />
-      )
+      const selectedModule =
+        unconfiguredModuleMatches.find(m => m.serialNumber === serialNumber) ??
+        null
+      if (moduleModel === 'flexStackerModuleV1' && selectedModule !== null) {
+        return (
+          <FixtureOption
+            key={serialNumber}
+            onClickHandler={() => {
+              handleStackerClearAndConfigureModule(selectedModule)
+            }}
+            optionName={getFixtureDisplayName(moduleFixtures[0].id, usbPort)}
+            buttonText={i18n.format(t('shared:add'), 'capitalize')}
+            secondaryButtonText={i18n.format(
+              t('shared:identify'),
+              'capitalize'
+            )}
+            secondaryOnClickHandler={() => {
+              handleIdentifyFixture(selectedModule)
+            }}
+            isOnDevice={isOnDevice}
+          />
+        )
+      } else {
+        return (
+          <FixtureOption
+            key={serialNumber}
+            onClickHandler={() => {
+              handleConfigureModule(serialNumber)
+            }}
+            optionName={getFixtureDisplayName(moduleFixtures[0].id, usbPort)}
+            buttonText={i18n.format(t('shared:add'), 'capitalize')}
+            isOnDevice={isOnDevice}
+          />
+        )
+      }
     }
   )
 

--- a/app/src/organisms/LocationConflictModal/__tests__/LocationConflictModal.test.tsx
+++ b/app/src/organisms/LocationConflictModal/__tests__/LocationConflictModal.test.tsx
@@ -18,7 +18,7 @@ import {
 
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
-import { mockHeaterShaker } from '/app/redux/modules/__fixtures__'
+import { mockFlexStacker, mockHeaterShaker } from '/app/redux/modules/__fixtures__'
 import { useNotifyDeckConfigurationQuery } from '/app/resources/deck_configuration'
 import { useCloseCurrentRun } from '/app/resources/runs'
 
@@ -26,11 +26,15 @@ import { LocationConflictModal } from '../LocationConflictModal'
 
 import type { ComponentProps } from 'react'
 import type { UseQueryResult } from 'react-query'
-import type { DeckConfiguration } from '@opentrons/shared-data'
+import type { DeckConfiguration, IdentifyColor } from '@opentrons/shared-data'
+import { AttachedModule } from '@opentrons/api-client'
+import { useSendIdentifyStacker } from '../../ModuleWizardFlows/hooks'
 
 vi.mock('@opentrons/react-api-client')
 vi.mock('/app/resources/deck_configuration')
 vi.mock('/app/resources/runs')
+vi.mock('/app/organisms/ModuleCard/utils')
+vi.mock('/app/organisms/ModuleWizardFlows/hooks.tsx')
 
 const mockFixture = {
   cutoutId: 'cutoutB3',
@@ -50,6 +54,11 @@ const render = (props: ComponentProps<typeof LocationConflictModal>) => {
 
 describe('LocationConflictModal', () => {
   let props: ComponentProps<typeof LocationConflictModal>
+  let sendIdentifyStacker: (
+      module: AttachedModule,
+      start: boolean,
+      color?: IdentifyColor
+    ) => void
   const mockUpdate = vi.fn()
   beforeEach(() => {
     props = {
@@ -59,6 +68,7 @@ describe('LocationConflictModal', () => {
       deckDef: ot3StandardDeckV5 as any,
       robotName: 'otie',
     }
+    sendIdentifyStacker = vi.fn()
     vi.mocked(useCloseCurrentRun).mockReturnValue({
       closeCurrentRun: vi.fn(),
     } as any)
@@ -69,6 +79,7 @@ describe('LocationConflictModal', () => {
     vi.mocked(useUpdateDeckConfigurationMutation).mockReturnValue({
       updateDeckConfiguration: mockUpdate,
     } as any)
+    vi.mocked(useSendIdentifyStacker).mockReturnValue(sendIdentifyStacker)
   })
   afterEach(() => {
     vi.resetAllMocks()
@@ -104,6 +115,28 @@ describe('LocationConflictModal', () => {
     expect(props.onCloseClick).toHaveBeenCalled()
     fireEvent.click(screen.getByRole('button', { name: 'Update deck' }))
     screen.getByText('Heater-Shaker Module GEN1 in USB-1')
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }))
+    expect(mockUpdate).toHaveBeenCalled()
+  })
+  it('should render the modal information for a stacker module fixture and include the identify button', () => {
+    vi.mocked(useModulesQuery).mockReturnValue({
+      data: { data: [mockFlexStacker] },
+    } as any)
+    props = {
+      onCloseClick: vi.fn(),
+      cutoutId: 'cutoutB3',
+      requiredModule: 'flexStackerModuleV1',
+      deckDef: ot3StandardDeckV5 as any,
+      robotName: 'otie',
+    }
+    render(props)
+    screen.getByText('Protocol specifies')
+    screen.getByText('Currently configured')
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(props.onCloseClick).toHaveBeenCalled()
+    fireEvent.click(screen.getByRole('button', { name: 'Update deck' }))
+    screen.getByText('Flex Stacker Module GEN1 in USB-1')
+    screen.getByText('Identify')
     fireEvent.click(screen.getByRole('button', { name: 'Add' }))
     expect(mockUpdate).toHaveBeenCalled()
   })

--- a/app/src/organisms/LocationConflictModal/__tests__/LocationConflictModal.test.tsx
+++ b/app/src/organisms/LocationConflictModal/__tests__/LocationConflictModal.test.tsx
@@ -18,17 +18,20 @@ import {
 
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
-import { mockFlexStacker, mockHeaterShaker } from '/app/redux/modules/__fixtures__'
+import {
+  mockFlexStacker,
+  mockHeaterShaker,
+} from '/app/redux/modules/__fixtures__'
 import { useNotifyDeckConfigurationQuery } from '/app/resources/deck_configuration'
 import { useCloseCurrentRun } from '/app/resources/runs'
 
+import { useSendIdentifyStacker } from '../../ModuleWizardFlows/hooks'
 import { LocationConflictModal } from '../LocationConflictModal'
 
 import type { ComponentProps } from 'react'
 import type { UseQueryResult } from 'react-query'
+import type { AttachedModule } from '@opentrons/api-client'
 import type { DeckConfiguration, IdentifyColor } from '@opentrons/shared-data'
-import { AttachedModule } from '@opentrons/api-client'
-import { useSendIdentifyStacker } from '../../ModuleWizardFlows/hooks'
 
 vi.mock('@opentrons/react-api-client')
 vi.mock('/app/resources/deck_configuration')
@@ -55,10 +58,10 @@ const render = (props: ComponentProps<typeof LocationConflictModal>) => {
 describe('LocationConflictModal', () => {
   let props: ComponentProps<typeof LocationConflictModal>
   let sendIdentifyStacker: (
-      module: AttachedModule,
-      start: boolean,
-      color?: IdentifyColor
-    ) => void
+    module: AttachedModule,
+    start: boolean,
+    color?: IdentifyColor
+  ) => void
   const mockUpdate = vi.fn()
   beforeEach(() => {
     props = {


### PR DESCRIPTION
# Overview
Covers RQA-4207

We added an identify button for module addition to the deck configuration for the stackers, but didn't cover the deck hardware flow on the Protocol Run Setup (it is a different modal entirely). This extends the coverage to here, and adds a test case to verify for stackers.

## Test Plan and Hands on Testing
- [x] Test on simulated Flex during run setup, ensure modal appears
- [x] Unit test coverage
- [x] Test on Live Flex by uploading a protocol that uses stackers to an unconfigured Flex. Should see the identify button on Protocol Setup add fixture view.

## Changelog
Extended the behavior of the `ChooseModuleToConfigureModal` to render an identify button when appropriate.

## Review requests
There is another "Add fixture" type of modal called `NotConfiguredModal`. I could extend coverage to that modal in this PR as well fairly easily through the same methodology used in the deck hardware view modal, however I could not confirm when this modal actually renders. Is it still in use widely? Should it be replaced by the `AddFixtureModal` or the `ChooseModuleToConfigureModal`?

## Risk assessment
Low - expands functionality coverage for desired stacker behavior.
