### PR TITLE
refactor(shared-data): Rename `getModuleDef2()` -> `getModuleDef()`

### DIFF
--- a/app/src/molecules/ModuleInfo/ModuleInfo.tsx
+++ b/app/src/molecules/ModuleInfo/ModuleInfo.tsx
@@ -17,7 +17,7 @@ import {
 } from '@opentrons/components'
 import {
   FLEX_STACKER_MODULE_TYPE,
-  getModuleDef2,
+  getModuleDef,
   getModuleDisplayName,
   MAGNETIC_BLOCK_V1,
 } from '@opentrons/shared-data'
@@ -36,7 +36,7 @@ export interface ModuleInfoProps {
 
 export const ModuleInfo = (props: ModuleInfoProps): JSX.Element => {
   const { moduleModel, physicalPort, isAttached, runId = null } = props
-  const moduleDef = getModuleDef2(moduleModel)
+  const moduleDef = getModuleDef(moduleModel)
   const {
     xDimension,
     yDimension,

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabware/__tests__/SetupLabwareMap.test.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabware/__tests__/SetupLabwareMap.test.tsx
@@ -6,7 +6,7 @@ import { when } from 'vitest-when'
 import { BaseDeck } from '@opentrons/components'
 import {
   fixtureTiprack300ul,
-  getModuleDef2,
+  getModuleDef,
   OT2_ROBOT_TYPE,
 } from '@opentrons/shared-data'
 
@@ -36,10 +36,10 @@ vi.mock('@opentrons/components', async importOriginal => {
   }
 })
 vi.mock('@opentrons/shared-data', async importOriginal => {
-  const actualSharedData = await importOriginal<typeof getModuleDef2>()
+  const actualSharedData = await importOriginal<typeof getModuleDef>()
   return {
     ...actualSharedData,
-    getModuleDef2: vi.fn(),
+    getModuleDef: vi.fn(),
   }
 })
 
@@ -210,10 +210,10 @@ describe('SetupLabwareMap', () => {
       },
     ])
 
-    when(vi.mocked(getModuleDef2))
+    when(vi.mocked(getModuleDef))
       .calledWith(mockMagneticModule.model)
       .thenReturn(mockMagneticModule as any)
-    when(vi.mocked(getModuleDef2))
+    when(vi.mocked(getModuleDef))
       .calledWith(mockTCModule.model)
       .thenReturn(mockTCModule as any)
 

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useDeckMapUtils.test.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useDeckMapUtils.test.ts
@@ -4,7 +4,7 @@ import { getLabwareLocation } from '@opentrons/components'
 import {
   fixture96Plate,
   getLoadedLabwareDefinitionsByUri,
-  getModuleDef2,
+  getModuleDef,
   getPositionFromSlotId,
   TEMPERATURE_MODULE_V2,
 } from '@opentrons/shared-data'
@@ -30,7 +30,7 @@ vi.mock('@opentrons/shared-data', async importOriginal => {
     ...actual,
     getLoadedLabwareDefinitionsByUri: vi.fn(),
     getPositionFromSlotId: vi.fn(),
-    getModuleDef2: vi.fn(),
+    getModuleDef: vi.fn(),
   }
 })
 vi.mock('@opentrons/components')
@@ -59,7 +59,7 @@ describe('getRunCurrentModulesOnDeck', () => {
   ]
 
   beforeEach(() => {
-    vi.mocked(getModuleDef2).mockReturnValue({ model: 'MOCK_MODEL' } as any)
+    vi.mocked(getModuleDef).mockReturnValue({ model: 'MOCK_MODEL' } as any)
     vi.mocked(getLabwareLocation).mockReturnValue({ slotName: 'A1' })
   })
 
@@ -274,7 +274,7 @@ describe('getRunCurrentModulesInfo', () => {
       'opentrons/opentrons_96_pcr_adapter/1': 'MOCK_LW_DEF',
     } as any)
     vi.mocked(getPositionFromSlotId).mockReturnValue('position' as any)
-    vi.mocked(getModuleDef2).mockReturnValue('MOCK_MODULE_DEF' as any)
+    vi.mocked(getModuleDef).mockReturnValue('MOCK_MODULE_DEF' as any)
   })
 
   it('should return an empty array if runRecord is null', () => {

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useDeckMapUtils.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useDeckMapUtils.ts
@@ -5,7 +5,7 @@ import {
   FLEX_ROBOT_TYPE,
   getDeckDefFromRobotType,
   getFixedTrashLabwareDefinition,
-  getModuleDef2,
+  getModuleDef,
   getPositionFromSlotId,
   getSimplestDeckConfigForProtocol,
   OT2_ROBOT_TYPE,
@@ -279,7 +279,7 @@ export const getRunCurrentModulesInfo = ({
   } else {
     return runRecord.data.modules.reduce<RunCurrentModuleInfo[]>(
       (acc, module) => {
-        const moduleDef = getModuleDef2(module.model)
+        const moduleDef = getModuleDef(module.model)
 
         // Get the labware that is placed on top of the module.
         const nestedLabware = runRecord.data.labware.find(

--- a/app/src/organisms/InterventionModal/__fixtures__/index.ts
+++ b/app/src/organisms/InterventionModal/__fixtures__/index.ts
@@ -1,5 +1,5 @@
 import {
-  getModuleDef2,
+  getModuleDef,
   SPAN7_8_10_11_SLOT,
   THERMOCYCLER_MODULE_V1,
 } from '@opentrons/shared-data'
@@ -228,7 +228,7 @@ export const mockModuleRenderInfoWithLabware = [
     moduleId: 'mockTCModuleID',
     x: 100,
     y: 100,
-    moduleDef: getModuleDef2(THERMOCYCLER_MODULE_V1),
+    moduleDef: getModuleDef(THERMOCYCLER_MODULE_V1),
     nestedLabwareDef: mockLabwareDefinition,
     nestedLabwareId: 'mockLabwareID',
   },
@@ -239,7 +239,7 @@ export const mockModuleRenderInfoWithoutLabware = [
     moduleId: 'mockTCModuleID',
     x: 100,
     y: 100,
-    moduleDef: getModuleDef2(THERMOCYCLER_MODULE_V1),
+    moduleDef: getModuleDef(THERMOCYCLER_MODULE_V1),
     nestedLabwareDef: null,
     nestedLabwareId: null,
   },

--- a/app/src/organisms/InterventionModal/utils/getRunModuleRenderInfo.ts
+++ b/app/src/organisms/InterventionModal/utils/getRunModuleRenderInfo.ts
@@ -1,5 +1,5 @@
 import {
-  getModuleDef2,
+  getModuleDef,
   getPositionFromSlotId,
   SPAN7_8_10_11_SLOT,
 } from '@opentrons/shared-data'
@@ -28,7 +28,7 @@ export function getRunModuleRenderInfo(
 ): RunModuleInfo[] {
   if (runData.modules.length > 0) {
     return runData.modules.reduce<RunModuleInfo[]>((acc, module) => {
-      const moduleDef = getModuleDef2(module.model)
+      const moduleDef = getModuleDef(module.model)
       const nestedLabware = runData.labware.find(
         labware =>
           typeof labware.location === 'object' &&

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupModulesAndDeck/__tests__/utils.test.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupModulesAndDeck/__tests__/utils.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { getModuleDef2 } from '@opentrons/shared-data'
+import { getModuleDef } from '@opentrons/shared-data'
 
 import { mockTemperatureModuleGen2 } from '/app/redux/modules/__fixtures__'
 
@@ -11,7 +11,7 @@ const temperatureProtocolModule = {
   x: 0,
   y: 0,
   z: 0,
-  moduleDef: getModuleDef2('temperatureModuleV2'),
+  moduleDef: getModuleDef('temperatureModuleV2'),
   nestedLabwareDef: null,
   nestedLabwareId: null,
   nestedLabwareDisplayName: null,
@@ -24,7 +24,7 @@ const magneticProtocolModule = {
   x: 0,
   y: 0,
   z: 0,
-  moduleDef: getModuleDef2('magneticModuleV2'),
+  moduleDef: getModuleDef('magneticModuleV2'),
   nestedLabwareDef: null,
   nestedLabwareId: null,
   nestedLabwareDisplayName: null,

--- a/app/src/transformations/analysis/__tests__/getAttachedProtocolModuleMatches.test.ts
+++ b/app/src/transformations/analysis/__tests__/getAttachedProtocolModuleMatches.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import {
-  getModuleDef2,
+  getModuleDef,
   TEMPERATURE_MODULE_V2_FIXTURE,
 } from '@opentrons/shared-data'
 
@@ -14,7 +14,7 @@ const temperatureProtocolModule = {
   x: 0,
   y: 0,
   z: 0,
-  moduleDef: getModuleDef2('temperatureModuleV2'),
+  moduleDef: getModuleDef('temperatureModuleV2'),
   nestedLabwareDef: null,
   nestedLabwareId: null,
   nestedLabwareDisplayName: null,
@@ -27,7 +27,7 @@ const magneticProtocolModule = {
   x: 0,
   y: 0,
   z: 0,
-  moduleDef: getModuleDef2('magneticModuleV2'),
+  moduleDef: getModuleDef('magneticModuleV2'),
   nestedLabwareDef: null,
   nestedLabwareId: null,
   nestedLabwareDisplayName: null,

--- a/app/src/transformations/analysis/__tests__/getProtocolModulesInfo.test.ts
+++ b/app/src/transformations/analysis/__tests__/getProtocolModulesInfo.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import {
-  getModuleDef2,
+  getModuleDef,
   multiple_temp_modules,
   ot2DeckDefV5,
   transfer_settings,
@@ -210,7 +210,7 @@ describe('getProtocolModulesInfo', () => {
         x: SLOT_1_COORDS[0],
         y: SLOT_1_COORDS[1],
         z: SLOT_1_COORDS[2],
-        moduleDef: getModuleDef2('magneticModuleV2'),
+        moduleDef: getModuleDef('magneticModuleV2'),
         nestedLabwareDef:
           transfer_settings.labwareDefinitions[
             'opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1'
@@ -225,7 +225,7 @@ describe('getProtocolModulesInfo', () => {
         x: SLOT_3_COORDS[0],
         y: SLOT_3_COORDS[1],
         z: SLOT_3_COORDS[2],
-        moduleDef: getModuleDef2('temperatureModuleV2'),
+        moduleDef: getModuleDef('temperatureModuleV2'),
         nestedLabwareDef:
           transfer_settings.labwareDefinitions[
             'opentrons/opentrons_96_aluminumblock_generic_pcr_strip_200ul/1'
@@ -241,7 +241,7 @@ describe('getProtocolModulesInfo', () => {
         x: SLOT_7_COORDS[0],
         y: SLOT_7_COORDS[1],
         z: SLOT_7_COORDS[2],
-        moduleDef: getModuleDef2('thermocyclerModuleV1'),
+        moduleDef: getModuleDef('thermocyclerModuleV1'),
         nestedLabwareDef:
           transfer_settings.labwareDefinitions[
             'opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1'
@@ -286,7 +286,7 @@ describe('getProtocolModulesInfo', () => {
         x: SLOT_1_COORDS[0],
         y: SLOT_1_COORDS[1],
         z: SLOT_1_COORDS[2],
-        moduleDef: getModuleDef2('magneticModuleV2'),
+        moduleDef: getModuleDef('magneticModuleV2'),
         nestedLabwareDef:
           multiple_temp_modules.labwareDefinitions[
             'opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1'
@@ -301,7 +301,7 @@ describe('getProtocolModulesInfo', () => {
         x: SLOT_3_COORDS[0],
         y: SLOT_3_COORDS[1],
         z: SLOT_3_COORDS[2],
-        moduleDef: getModuleDef2('temperatureModuleV2'),
+        moduleDef: getModuleDef('temperatureModuleV2'),
         nestedLabwareDef:
           multiple_temp_modules.labwareDefinitions[
             'opentrons/opentrons_96_aluminumblock_generic_pcr_strip_200ul/1'
@@ -317,7 +317,7 @@ describe('getProtocolModulesInfo', () => {
         x: SLOT_7_COORDS[0],
         y: SLOT_7_COORDS[1],
         z: SLOT_7_COORDS[2],
-        moduleDef: getModuleDef2('temperatureModuleV2'),
+        moduleDef: getModuleDef('temperatureModuleV2'),
         nestedLabwareDef:
           multiple_temp_modules.labwareDefinitions[
             'opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1'
@@ -350,7 +350,7 @@ describe('getProtocolModulesInfo', () => {
         x: SLOT_1_COORDS[0],
         y: SLOT_1_COORDS[1],
         z: SLOT_1_COORDS[2],
-        moduleDef: getModuleDef2('magneticModuleV2'),
+        moduleDef: getModuleDef('magneticModuleV2'),
         nestedLabwareDef:
           transfer_settings.labwareDefinitions[
             'opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1'

--- a/app/src/transformations/analysis/getProtocolModulesInfo.ts
+++ b/app/src/transformations/analysis/getProtocolModulesInfo.ts
@@ -1,6 +1,6 @@
 import {
   getLoadedLabwareDefinitionsByUri,
-  getModuleDef2,
+  getModuleDef,
   getPositionFromSlotId,
   SPAN7_8_10_11_SLOT,
 } from '@opentrons/shared-data'
@@ -35,7 +35,7 @@ export const getProtocolModulesInfo = (
 ): ProtocolModuleInfo[] => {
   if (protocolData != null && 'modules' in protocolData) {
     return protocolData.modules.reduce<ProtocolModuleInfo[]>((acc, module) => {
-      const moduleDef = getModuleDef2(module.model)
+      const moduleDef = getModuleDef(module.model)
       const nestedLabwareId =
         protocolData.commands
           .filter(

--- a/components/src/hardware-sim/BaseDeck/BaseDeck.tsx
+++ b/components/src/hardware-sim/BaseDeck/BaseDeck.tsx
@@ -4,7 +4,7 @@ import partition from 'lodash/partition'
 import {
   FLEX_STACKER_MODULE_TYPE,
   getDeckDefFromRobotType,
-  getModuleDef2,
+  getModuleDef,
   getModuleType,
   getPositionFromSlotId,
   HEATERSHAKER_MODULE_V1,
@@ -292,7 +292,7 @@ export function BaseDeck(props: BaseDeckProps): JSX.Element {
               moduleLocation.slotName,
               deckDef
             )
-            const moduleDef = getModuleDef2(moduleModel)
+            const moduleDef = getModuleDef(moduleModel)
             return slotPosition != null ? (
               <Module
                 key={`${moduleModel} ${moduleLocation.slotName}`}
@@ -341,7 +341,7 @@ export function BaseDeck(props: BaseDeckProps): JSX.Element {
               moduleLocation.slotName
             )
             const slotPosition = getPositionFromSlotId(stackerSlotName, deckDef)
-            const moduleDef = getModuleDef2(moduleModel)
+            const moduleDef = getModuleDef(moduleModel)
             return slotPosition != null ? (
               <>
                 <StagingAreaFixture
@@ -437,7 +437,7 @@ export function BaseDeck(props: BaseDeckProps): JSX.Element {
         {/* render stacked badge on module labware */}
         {modulesOnDeck.map(
           ({ moduleModel, moduleLocation, stacked = false }) => {
-            const moduleDef = getModuleDef2(moduleModel)
+            const moduleDef = getModuleDef(moduleModel)
             const slotPosition = getPositionFromSlotId(
               moduleDef.moduleType === FLEX_STACKER_MODULE_TYPE
                 ? getStackerLocationFromSlot(moduleLocation.slotName)

--- a/components/src/hardware-sim/Deck/MoveLabwareOnDeck.tsx
+++ b/components/src/hardware-sim/Deck/MoveLabwareOnDeck.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components'
 
 import {
   getDeckDefFromRobotType,
-  getModuleDef2,
+  getModuleDef,
   getPositionFromSlotId,
   getSchema2CornerOffsetFromSlot,
   getSchema2Dimensions,
@@ -45,7 +45,7 @@ const getModulePosition = (
   const [modX, modY] = modPosition
 
   const deckSpecificAffineTransform =
-    getModuleDef2(loadedModule.model).slotTransforms?.[deckDef.otId]?.[
+    getModuleDef(loadedModule.model).slotTransforms?.[deckDef.otId]?.[
       modSlot.id
     ]?.labwareOffset ?? IDENTITY_AFFINE_TRANSFORM
   const [[labwareX], [labwareY], [labwareZ]] = multiplyMatrices(

--- a/components/src/hardware-sim/Module/Module.stories.tsx
+++ b/components/src/hardware-sim/Module/Module.stories.tsx
@@ -1,6 +1,6 @@
 import {
   fixture96Plate,
-  getModuleDef2,
+  getModuleDef,
   HEATERSHAKER_MODULE_V1,
   MAGNETIC_BLOCK_V1,
   MAGNETIC_MODULE_V1,
@@ -42,7 +42,7 @@ const Template: Story<{
   return (
     <RobotCoordinateSpace height="100vh" width="100vw" viewBox="0 -50 200 320">
       <ModuleComponent
-        def={getModuleDef2(args.model)}
+        def={getModuleDef(args.model)}
         x={0}
         y={0}
         innerProps={args.innerProps}

--- a/components/src/hardware-sim/Module/Thermocycler/index.tsx
+++ b/components/src/hardware-sim/Module/Thermocycler/index.tsx
@@ -1,4 +1,4 @@
-import { getModuleDef2, THERMOCYCLER_MODULE_V1 } from '@opentrons/shared-data'
+import { getModuleDef, THERMOCYCLER_MODULE_V1 } from '@opentrons/shared-data'
 
 import { BORDERS, COLORS } from '../../../helix-design-system'
 import { C_MED_LIGHT_GRAY } from '../../../styles'
@@ -17,7 +17,7 @@ export interface ThermocyclerVizProps {
 
 export function Thermocycler(props: ThermocyclerVizProps): JSX.Element {
   const { lidMotorState, blockTargetTemp, model } = props
-  const def = getModuleDef2(model)
+  const def = getModuleDef(model)
   if (lidMotorState === 'unknown') {
     // just a rectangle if we don't know the state of the lid
     return (

--- a/labware-library/src/labware-creator/fieldsToLabware.ts
+++ b/labware-library/src/labware-creator/fieldsToLabware.ts
@@ -1,4 +1,4 @@
-import { createRegularLabware, getModuleDef2 } from '@opentrons/shared-data'
+import { createRegularLabware, getModuleDef } from '@opentrons/shared-data'
 
 import { DISPLAY_VOLUME_UNITS } from './fields'
 import { getIsCustomTubeRack } from './utils'
@@ -122,7 +122,7 @@ export function fieldsToLabware(
     })
     const stackingOffsetWithModule: Record<string, LabwareOffset> = {}
     Object.entries(compatibleModules).forEach(([moduleModel, z]) => {
-      const moduleDefinition = getModuleDef2(moduleModel as ModuleModel)
+      const moduleDefinition = getModuleDef(moduleModel as ModuleModel)
       return (stackingOffsetWithModule[moduleModel] = {
         x: 0,
         y: 0,

--- a/protocol-designer/src/components/organisms/Ot2Modules/index.tsx
+++ b/protocol-designer/src/components/organisms/Ot2Modules/index.tsx
@@ -20,7 +20,7 @@ import {
 import {
   getAddressableAreaFromSlotId,
   getDeckDefFromRobotType,
-  getModuleDef2,
+  getModuleDef,
   getModuleDisplayName,
   getModuleType,
   getPositionFromSlotId,
@@ -443,7 +443,7 @@ export function Ot2Modules(): JSX.Element {
                       console.warn(`no slot ${slotId} for module ${id}`)
                       return null
                     }
-                    const moduleDef = getModuleDef2(model)
+                    const moduleDef = getModuleDef(model)
                     return (
                       <Fragment key={id}>
                         <Module

--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupDetails.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupDetails.tsx
@@ -5,7 +5,7 @@ import values from 'lodash/values'
 import { Module } from '@opentrons/components'
 import {
   getAddressableAreaFromSlotId,
-  getModuleDef2,
+  getModuleDef,
   getPositionFromSlotId,
   inferModuleOrientationFromSlot,
   inferModuleOrientationFromXCoordinate,
@@ -199,7 +199,7 @@ export function DeckSetupDetails(props: DeckSetupDetailsProps): JSX.Element {
           console.warn(`no slot ${slotId} for module ${moduleOnDeck.id}`)
           return null
         }
-        const moduleDef = getModuleDef2(moduleOnDeck.model)
+        const moduleDef = getModuleDef(moduleOnDeck.model)
 
         const getModuleInnerProps = (
           moduleState: ModuleTemporalProperties['moduleState']

--- a/protocol-designer/src/pages/Designer/DeckSetup/FixtureRender.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/FixtureRender.tsx
@@ -12,7 +12,7 @@ import {
   WasteChuteStagingAreaFixture,
 } from '@opentrons/components'
 import {
-  getModuleDef2,
+  getModuleDef,
   getPositionFromSlotId,
   OT2_ROBOT_TYPE,
 } from '@opentrons/shared-data'
@@ -96,7 +96,7 @@ export const FixtureRender = (props: FixtureRenderProps): JSX.Element => {
         key={adjacentModule.id}
         x={slotPosition != null ? slotPosition[0] : 0}
         y={slotPosition != null ? slotPosition[1] : 0}
-        def={getModuleDef2(adjacentModule.model)}
+        def={getModuleDef(adjacentModule.model)}
         targetSlotId={adjacentModule.slot}
         targetDeckId={deckDef.otId}
       />

--- a/protocol-designer/src/pages/Designer/DeckSetup/ModuleLabel.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/ModuleLabel.tsx
@@ -5,7 +5,7 @@ import { DeckLabelSet } from '@opentrons/components'
 import {
   FLEX_ROBOT_TYPE,
   FLEX_STANDARD_DECKID,
-  getModuleDef2,
+  getModuleDef,
   HEATERSHAKER_MODULE_TYPE,
   OT2_STANDARD_DECKID,
   TEMPERATURE_MODULE_TYPE,
@@ -53,7 +53,7 @@ export const ModuleLabel = (props: ModuleLabelProps): JSX.Element => {
     }
   }, [labwareInfos])
 
-  const def = getModuleDef2(moduleModel)
+  const def = getModuleDef(moduleModel)
   const slotTransformKey =
     robotType === FLEX_ROBOT_TYPE ? FLEX_STANDARD_DECKID : OT2_STANDARD_DECKID
   const cornerOffsetsFromSlotFromTransform =

--- a/protocol-designer/src/pages/Designer/DeckSetup/SelectedItems.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/SelectedItems.tsx
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux'
 import { Module } from '@opentrons/components'
 import {
   getAllLabwareDefs,
-  getModuleDef2,
+  getModuleDef,
   inferModuleOrientationFromXCoordinate,
 } from '@opentrons/shared-data'
 import { getSlotInLocationStack } from '@opentrons/step-generation'
@@ -107,7 +107,7 @@ export const SelectedItems = (props: SelectedItemsProps): JSX.Element => {
             key={`${selectedModuleModel}_${selectedSlot.slot}_selected`}
             x={slotPosition[0]}
             y={slotPosition[1]}
-            def={getModuleDef2(selectedModuleModel)}
+            def={getModuleDef(selectedModuleModel)}
             orientation={orientation}
           >
             <>

--- a/protocol-designer/src/pages/ProtocolOverview/DeckThumbnailDetails.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/DeckThumbnailDetails.tsx
@@ -4,7 +4,7 @@ import values from 'lodash/values'
 import { Module } from '@opentrons/components'
 import {
   getAddressableAreaFromSlotId,
-  getModuleDef2,
+  getModuleDef,
   getPositionFromSlotId,
   inferModuleOrientationFromXCoordinate,
   isAddressableAreaStandardSlot,
@@ -69,7 +69,7 @@ export const DeckThumbnailDetails = (
           console.warn(`no slot ${slotId} for module ${id}`)
           return null
         }
-        const moduleDef = getModuleDef2(model)
+        const moduleDef = getModuleDef(model)
         const labwareLoadedOnModuleId = getTopmostLabwareOnModuleFromStack(
           id,
           allLabware

--- a/shared-data/js/__tests__/moduleAccessors.test.ts
+++ b/shared-data/js/__tests__/moduleAccessors.test.ts
@@ -11,7 +11,7 @@ import {
   THERMOCYCLER_MODULE_V1,
 } from '../constants'
 import {
-  getModuleDef2,
+  getModuleDef,
   getModuleDisplayName,
   getModuleType,
   normalizeModuleModel,
@@ -19,7 +19,7 @@ import {
 
 describe('all valid models work', () => {
   MODULE_MODELS.forEach(model => {
-    const loadedDef = getModuleDef2(model)
+    const loadedDef = getModuleDef(model)
 
     it('ensure valid models load', () => {
       expect(loadedDef).not.toBeNull()

--- a/shared-data/js/modules.ts
+++ b/shared-data/js/modules.ts
@@ -33,7 +33,7 @@ import type {
 
 // TODO(bc, 2021-09-18): generate typescript types directly from JSON schema
 // having to maintain TS types side by side with the schema is a liability
-export const getModuleDef2 = (moduleModel: ModuleModel): ModuleDefinition => {
+export const getModuleDef = (moduleModel: ModuleModel): ModuleDefinition => {
   switch (moduleModel) {
     case MAGNETIC_MODULE_V1:
       return magneticModuleV1 as ModuleDefinition
@@ -89,18 +89,18 @@ export function normalizeModuleModel(
 }
 
 export function getModuleType(moduleModel: ModuleModel): ModuleType {
-  return getModuleDef2(moduleModel).moduleType
+  return getModuleDef(moduleModel).moduleType
 }
 
 // use module model (not type!) to get model-specific displayName for UI
 export function getModuleDisplayName(moduleModel: ModuleModel): string {
-  return getModuleDef2(moduleModel).displayName
+  return getModuleDef(moduleModel).displayName
 }
 
 export function checkModuleCompatibility(
   modelA: ModuleModel,
   modelB: ModuleModel
 ): boolean {
-  const bDef = getModuleDef2(modelB)
+  const bDef = getModuleDef(modelB)
   return modelA === modelB || bDef.compatibleWith.includes(modelA)
 }

--- a/step-generation/src/utils/createTimelineFromRunCommands.ts
+++ b/step-generation/src/utils/createTimelineFromRunCommands.ts
@@ -1,4 +1,4 @@
-import { getModuleDef2 } from '@opentrons/shared-data'
+import { getModuleDef } from '@opentrons/shared-data'
 
 import { MODULE_INITIAL_STATE_BY_TYPE } from '../constants'
 import { getNextRobotStateAndWarnings } from '../getNextRobotStateAndWarnings'
@@ -40,7 +40,7 @@ export function getResultingTimelineFrameFromRunCommands(
   const moduleLocations = commands.reduce<RobotState['modules']>(
     (acc, command) => {
       if (command.commandType === 'loadModule' && command.result != null) {
-        const moduleType = getModuleDef2(command.params.model).moduleType
+        const moduleType = getModuleDef(command.params.model).moduleType
         return {
           ...acc,
           [command.result.moduleId]: {


### PR DESCRIPTION
## Overview

This function is called `getModuleDef2()` because it used to return `ModuleDefinition2` (module definition schema 2). It's actually returned schema 3 for a while, but its name never got updated.

## Test Plan and Hands on Testing

Just existing automated tests.

## Changelog

Rename `getModuleDef2()` -> `getModuleDef()`.

## Review requests

None.

## Risk assessment

Very low.