### PR TITLE
fix(step-generation): remove indent from load liquid array

### DIFF
--- a/step-generation/src/__tests__/pythonFileUtils.test.ts
+++ b/step-generation/src/__tests__/pythonFileUtils.test.ts
@@ -489,7 +489,7 @@ well_plate_2.load_liquid(
     wells=[
         "D1", "D2", "D3", "D4", "D5", "D6", "D7", "D8",
         "E3"
-        ],
+    ],
     liquid=liquid_2,
     volume=180,
 )`.trimStart()

--- a/step-generation/src/utils/pythonFileUtils.ts
+++ b/step-generation/src/utils/pythonFileUtils.ts
@@ -364,7 +364,7 @@ export function getLoadLiquids(
       const pythonWells =
         formattedWells.length < 8
           ? formattedWells.join(', ')
-          : `\n${indentedWells}\n${INDENT}`
+          : `\n${indentedWells}\n`
 
       const loadLiquidArgs = [
         `wells=[${pythonWells}],\n` +


### PR DESCRIPTION
# Overview

remove indent from wells array in load liquid command

## Test Plan and Hands on Testing

Review code and smoke test but the indent after the closing wells array bracket should no longer be there

## Changelog

remove indent

## Risk assessment

low