### PR TITLE
fix(step-generation): only emit configure_nozzle_layout for 96-channel

### DIFF
--- a/step-generation/src/commandCreators/compound/replaceTip.ts
+++ b/step-generation/src/commandCreators/compound/replaceTip.ts
@@ -188,7 +188,8 @@ export const replaceTip: CommandCreator<ReplaceTipArgs> = (
     : curryWithoutPython
   const configureNozzleLayoutCommand: CurriedCommandCreator[] =
     //  only emit the command if previous nozzle state and tiprack state are different
-    (channels === 96 || channels === 8) &&
+    //  only check for the 96-channel since we do not support 8-channel partial tip yet
+    channels === 96 &&
     args.nozzles != null &&
     (args.nozzles !== stateNozzles || nextTiprack.tiprackId !== stateTiprack)
       ? [


### PR DESCRIPTION
closes RQA-4307

# Overview

The bug was that the `configure_nozzle_layout` command was incorrectly being emitted for 8-channel all tip pick up. since we don't support 8-channel partial tip yet, i just removed the 8-channel check.

## Test Plan and Hands on Testing

Upload protocol in the ticket to PD and add a tiprack to resolve the timeline error. then export and upload to the app and it should pass analysis

## Changelog

remove 8-channel check

## Risk assessment

low
