### PR TITLE
fix(protocol-designer): use pre-LC default tip position for non-LC transfers

### DIFF
--- a/protocol-designer/src/steplist/formLevel/handleFormChange/utils.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/utils.ts
@@ -16,7 +16,10 @@ import {
   SOURCE_WELL_BLOWOUT_DESTINATION,
 } from '@opentrons/step-generation'
 
-import { CHANNELS_MAPPED_TO_MAX_SPEED } from '../../../constants'
+import {
+  CHANNELS_MAPPED_TO_MAX_SPEED,
+  DEFAULT_MM_OFFSET_FROM_BOTTOM,
+} from '../../../constants'
 import { getPipetteCapacity } from '../../../pipettes/pipetteData'
 import {
   canPipetteUseLabware,
@@ -651,6 +654,7 @@ const getNoLiquidClassValuesMoveLiquid = (
     ...aspirateFlowRateFields,
     ...aspirateOffsetFields,
     ...aspiratePositionReferenceFields,
+    aspirate_mmFromBottom: DEFAULT_MM_OFFSET_FROM_BOTTOM,
     aspirate_submerge_mmFromBottom: SAFE_MOVE_TO_WELL_OFFSET_FROM_TOP_MM,
     aspirate_submerge_position_reference: POSITION_REFERENCE_TOP,
     aspirate_submerge_x_position: 0,
@@ -669,6 +673,7 @@ const getNoLiquidClassValuesMoveLiquid = (
     ...dispenseFlowRateFields,
     ...dispenseOffsetFields,
     ...dispensePositionReferenceFields,
+    dispense_mmFromBottom: DEFAULT_MM_OFFSET_FROM_BOTTOM,
     dispense_submerge_mmFromBottom: SAFE_MOVE_TO_WELL_OFFSET_FROM_TOP_MM,
     dispense_submerge_position_reference: POSITION_REFERENCE_TOP,
     dispense_submerge_x_position: 0,


### PR DESCRIPTION
# Overview

This PR uses the old default tip offset from bottom (1mm) rather than the water liquid class values for aspirate/dispense tip positioning in non-liquid class transfers.

Closes RQA-4150

## Test Plan and Hands on Testing

- create or upload a protocol to PD
- create a new transfer step with "Don't use a liquid class" selected
- verify that aspirate and dispense tip positions are 1mm above bottom rather than 2mm above bottom

## Changelog

- override aspirate/dispense tip position for non-liquid class transfers to pre-LC default (1mm) 

## Review requests

see test plan

## Risk assessment

low