### PR TITLE
fix(opentrons-ai-client): update copy for info banner

### DIFF
--- a/opentrons-ai-client/src/assets/localization/en/create_protocol.json
+++ b/opentrons-ai-client/src/assets/localization/en/create_protocol.json
@@ -71,7 +71,7 @@
   "paste_from_document_title": "Paste the steps from your document. Make sure your steps are clearly numbered.",
   "paste_from_document": "Paste from document",
   "pcr": "PCR",
-  "pd_prompt_warning": "Not all prompts will be possible to output to Protocol Designer.",
+  "pd_prompt_warning": "Not all prompts will be possible to output to Protocol Designer. If OpentronsAI produces errors, you can correct them in OpentronsAI chat.",
   "pd_protocol": "Protocol Designer protocol",
   "pipette_mounts": "Pipette mount(s)",
   "protocol_format_title": "Protocol Format",


### PR DESCRIPTION
# Overview

Closes AUTH-1815

Update copy for info banner when choosing a PD protocol

Old
![image](https://github.com/user-attachments/assets/e0156f81-52ab-4ce5-8c16-2777d8c02bc9)

Updated
![image](https://github.com/user-attachments/assets/04dad1e8-64d6-43e0-8b34-a51036146fea)


## Test Plan and Hands on Testing

CI

## Review requests

Make sure it is like so
![image](https://github.com/user-attachments/assets/04dad1e8-64d6-43e0-8b34-a51036146fea)


## Risk assessment

Low
