### PR TITLE
fix(protocol-designer): align the overflow menus types the same over …

### DIFF
--- a/protocol-designer/src/components/organisms/LiquidsOverflowMenu/index.tsx
+++ b/protocol-designer/src/components/organisms/LiquidsOverflowMenu/index.tsx
@@ -60,7 +60,7 @@ export function LiquidsOverflowMenu({
     right = undefined
     left =
       targetWidth !== undefined
-        ? `${targetWidth - OVERFLOW_MENU_POSITION_ADJUSTMENT}px`
+        ? `${targetWidth + OVERFLOW_MENU_POSITION_ADJUSTMENT}px`
         : undefined
   }
 

--- a/protocol-designer/src/constants.ts
+++ b/protocol-designer/src/constants.ts
@@ -205,7 +205,7 @@ export const OFFDECK: 'offDeck' = 'offDeck'
 export const PROTOCOL_DESIGNER_SOURCE: 'Protocol Designer' = 'Protocol Designer' // protocolSource for tracking analytics in the app
 
 export const DECK_SETUP_TOOLS_WIDTH_REM = 21.875
-export const OVERFLOW_MENU_POSITION_ADJUSTMENT = 4
+export const OVERFLOW_MENU_POSITION_ADJUSTMENT = 8
 
 // Below values copied from opentrons/api/src/opentrons/config/defaults_ot[2/3].py
 export const FLEX_X_Y_MAX_SPEED = 300

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/AddStepButton.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/AddStepButton.tsx
@@ -200,15 +200,7 @@ export function AddStepButton({
 
       {showStepOverflowMenu ? (
         <Flex
-          position={POSITION_ABSOLUTE}
-          zIndex={5}
-          left={sidebarWidth - 4} // 4 is the position over the toolbox
-          whiteSpace={NO_WRAP}
-          bottom="1rem"
-          borderRadius={BORDERS.borderRadius8}
-          boxShadow="0px 1px 3px rgba(0, 0, 0, 0.2)"
-          backgroundColor={COLORS.white}
-          flexDirection={DIRECTION_COLUMN}
+          css={STEP_OVERFLOW_MENU_STYLE}
           ref={overflowWrapperRef}
           onClick={(e: MouseEvent) => {
             e.preventDefault()
@@ -241,3 +233,15 @@ export function AddStepButton({
     </>
   )
 }
+
+const STEP_OVERFLOW_MENU_STYLE = css`
+  position: ${POSITION_ABSOLUTE};
+  z-index: 5;
+  right: -8.05rem;
+  white-space: ${NO_WRAP};
+  bottom: 1rem;
+  border-radius: ${BORDERS.borderRadius8};
+  box-shadow: 0px 1px 3px rgba(0, 0, 0, 0.2);
+  background-color: ${COLORS.white};
+  flex-direction: ${DIRECTION_COLUMN};
+`

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/AddStepButton.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/AddStepButton.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 import last from 'lodash/last'
+import { css } from 'styled-components'
 
 import {
   ALIGN_CENTER,

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/AddStepButton.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/AddStepButton.tsx
@@ -2,8 +2,7 @@ import { useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
-import { last } from 'lodash'
-import { css } from 'styled-components'
+import last from 'lodash/last'
 
 import {
   ALIGN_CENTER,
@@ -66,9 +65,13 @@ import type { BaseState } from '../../../../types'
 
 interface AddStepButtonProps {
   hasText: boolean
+  sidebarWidth: number
 }
 
-export function AddStepButton({ hasText }: AddStepButtonProps): JSX.Element {
+export function AddStepButton({
+  hasText,
+  sidebarWidth,
+}: AddStepButtonProps): JSX.Element {
   const { t } = useTranslation(['tooltip', 'button', 'starting_deck_state'])
   const enableComment = useSelector(getEnableComment)
   const { makeSnackbar } = useKitchen()
@@ -197,7 +200,15 @@ export function AddStepButton({ hasText }: AddStepButtonProps): JSX.Element {
 
       {showStepOverflowMenu ? (
         <Flex
-          css={STEP_OVERFLOW_MENU_STYLE}
+          position={POSITION_ABSOLUTE}
+          zIndex={5}
+          left={sidebarWidth - 4} // 4 is the position over the toolbox
+          whiteSpace={NO_WRAP}
+          bottom="1rem"
+          borderRadius={BORDERS.borderRadius8}
+          boxShadow="0px 1px 3px rgba(0, 0, 0, 0.2)"
+          backgroundColor={COLORS.white}
+          flexDirection={DIRECTION_COLUMN}
           ref={overflowWrapperRef}
           onClick={(e: MouseEvent) => {
             e.preventDefault()
@@ -230,15 +241,3 @@ export function AddStepButton({ hasText }: AddStepButtonProps): JSX.Element {
     </>
   )
 }
-
-const STEP_OVERFLOW_MENU_STYLE = css`
-  position: ${POSITION_ABSOLUTE};
-  z-index: 5;
-  right: -6.5rem;
-  white-space: ${NO_WRAP};
-  bottom: 1rem;
-  border-radius: ${BORDERS.borderRadius8};
-  box-shadow: 0px 1px 3px rgba(0, 0, 0, 0.2);
-  background-color: ${COLORS.white};
-  flex-direction: ${DIRECTION_COLUMN};
-`

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/AddStepButton.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/AddStepButton.tsx
@@ -234,7 +234,7 @@ export function AddStepButton({ hasText }: AddStepButtonProps): JSX.Element {
 const STEP_OVERFLOW_MENU_STYLE = css`
   position: ${POSITION_ABSOLUTE};
   z-index: 5;
-  right: -8.05rem;
+  right: -6.5rem;
   white-space: ${NO_WRAP};
   bottom: 1rem;
   border-radius: ${BORDERS.borderRadius8};

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/AddStepOverflowButton.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/AddStepOverflowButton.tsx
@@ -25,11 +25,6 @@ export function AddStepOverflowButton(
 ): JSX.Element {
   const { onClick, stepType, isFirstStep = false, isLastStep = false } = props
   const { t, i18n } = useTranslation(['tooltip', 'application'])
-  //   TODO(ja): add or delete tooltips when designs are finalized
-  //   const [targetProps, tooltipProps] = useHoverTooltip({
-  //     placement: TOOLTIP_RIGHT,
-  //   })
-  //   const tooltipMessage = t(`step_description.${stepType}`)
 
   const selectHoverStyle = (): string => {
     if (isFirstStep) {
@@ -52,7 +47,6 @@ export function AddStepOverflowButton(
           )}
         </StyledText>
       </MenuButton>
-      {/* <Tooltip tooltipProps={tooltipProps}>{tooltipMessage}</Tooltip> */}
     </>
   )
 }

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/StepOverflowMenu.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/StepOverflowMenu.tsx
@@ -14,6 +14,7 @@ import {
 
 import { analyticsEvent } from '../../../../analytics/actions'
 import { OPEN_STEP_DETAILS_EVENT } from '../../../../analytics/constants'
+import { OVERFLOW_MENU_POSITION_ADJUSTMENT } from '../../../../constants'
 import {
   getBatchEditFormHasUnsavedChanges,
   getCurrentFormHasUnsavedChanges,
@@ -43,8 +44,6 @@ interface StepOverflowMenuProps {
   multiSelectItemIds: string[] | null
   sidebarWidth: number // adjust the position of the overflow menu
 }
-
-const POSITION_ADJUSTMENT = 4
 
 export function StepOverflowMenu(props: StepOverflowMenuProps): JSX.Element {
   const {
@@ -102,7 +101,7 @@ export function StepOverflowMenu(props: StepOverflowMenuProps): JSX.Element {
         ref={menuRootRef}
         zIndex={12}
         top={top}
-        left={sidebarWidth - POSITION_ADJUSTMENT} // the space between kebab menu button and overflow menu is 8px
+        left={sidebarWidth + OVERFLOW_MENU_POSITION_ADJUSTMENT} // the space between kebab menu button and overflow menu is 8px
         position={POSITION_ABSOLUTE}
         whiteSpace={NO_WRAP}
         borderRadius={BORDERS.borderRadius8}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/TimelineToolbox.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/TimelineToolbox.tsx
@@ -156,7 +156,10 @@ export function TimelineToolbox({
       childrenPadding="0px"
       confirmButton={
         formData != null ? undefined : (
-          <AddStepButton hasText={sidebarWidth > SIDEBAR_MIN_WIDTH_FOR_ICON} />
+          <AddStepButton
+            hasText={sidebarWidth > SIDEBAR_MIN_WIDTH_FOR_ICON}
+            sidebarWidth={sidebarWidth}
+          />
         )
       }
     >

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/__tests__/AddStepButton.test.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/__tests__/AddStepButton.test.tsx
@@ -106,6 +106,7 @@ describe('AddStepButton', () => {
   beforeEach(() => {
     props = {
       hasText: true,
+      sidebarWidth: 10,
     }
     vi.mocked(getEnableComment).mockReturnValue(true)
     vi.mocked(getCurrentFormIsPresaved).mockReturnValue(false)


### PR DESCRIPTION
…timeline

closes RQA-4339

# Overview

Check overflow menu alignment between the 3 overflow menu types - they should all be the same and match designs

<img width="351" alt="Screenshot 2025-07-08 at 12 01 23" src="https://github.com/user-attachments/assets/02a90555-1bf9-488d-895b-ccb49fe6d9f9" />

<img width="370" alt="Screenshot 2025-07-08 at 12 01 34" src="https://github.com/user-attachments/assets/c613ae9f-4a65-4f36-9bc1-c72a60714a9b" />

<img width="461" alt="Screenshot 2025-07-08 at 12 01 44" src="https://github.com/user-attachments/assets/ae92397f-0d92-4bd0-bea1-3b259153d224" />

## Test Plan and Hands on Testing

Review the screenshots and code and it should match designs

## Changelog

- adjust the overflow menu positioning

## Risk assessment

low