### PR TITLE
refactor(app): update LPC exit button copy on labware list view

### DIFF
--- a/app/src/assets/localization/en/labware_position_check.json
+++ b/app/src/assets/localization/en/labware_position_check.json
@@ -165,6 +165,7 @@
   "robot_in_motion": "Stand back, robot is in motion.",
   "run": "Run",
   "save": "Save",
+  "save_and_exit": "Save & exit",
   "secondary_pipette_tipracks_section": "Check tip racks with {{secondary_mount}} Pipette",
   "see_how_offsets_work": "See how labware offsets work",
   "select_labware_to_view_data": "Select a labware to view its stored offset data.",

--- a/app/src/molecules/WizardHeader/index.tsx
+++ b/app/src/molecules/WizardHeader/index.tsx
@@ -22,6 +22,8 @@ import { StepMeter } from '/app/atoms/StepMeter'
 interface WizardHeaderProps {
   title: string
   onExit?: (() => void) | null
+  /* Optional copy override for the exit button. */
+  exitButtonCopy?: string
   totalSteps?: number | null
   currentStep?: number | null
   exitDisabled?: boolean
@@ -81,6 +83,7 @@ export const WizardHeader = (props: WizardHeaderProps): JSX.Element => {
     title,
     onExit,
     exitDisabled,
+    exitButtonCopy,
   } = props
   const { t } = useTranslation('shared')
 
@@ -111,7 +114,7 @@ export const WizardHeader = (props: WizardHeaderProps): JSX.Element => {
         {onExit != null ? (
           <Btn onClick={onExit} aria-label="Exit" disabled={exitDisabled}>
             <LegacyStyledText css={EXIT_BUTTON_STYLE}>
-              {t('exit')}
+              {exitButtonCopy ?? t('exit')}
             </LegacyStyledText>
           </Btn>
         ) : null}

--- a/app/src/organisms/LabwarePositionCheck/LPCContentContainer.tsx
+++ b/app/src/organisms/LabwarePositionCheck/LPCContentContainer.tsx
@@ -49,10 +49,22 @@ interface LPCContentContainerTertiaryBtnProps {
 }
 
 export type LPCContentContainerProps = LPCWizardContentProps &
-  Partial<ChildNavigationProps> & {
+  Pick<
+    ChildNavigationProps,
+    | 'onClickButton'
+    | 'buttonIsDisabled'
+    | 'secondaryButtonProps'
+    | 'onClickBack'
+  > & {
     children: JSX.Element
     /* The ODD view header. The desktop header is hard-coded. */
     header: string
+    /* The copy for the desktop header button. */
+    oddHeaderBtnCopy: string
+    /* The copy for the desktop header button. */
+    desktopHeaderBtnCopy: string
+    /* The copy  for the desktop footer button. */
+    desktopFooterBtnCopy: string
     /* An optional style override for the content container. */
     contentStyle?: FlattenSimpleInterpolation
     /* An optional style override for the container. */
@@ -67,7 +79,16 @@ export function LPCContentContainer(
   props: LPCContentContainerProps
 ): JSX.Element {
   const { t } = useTranslation('labware_position_check')
-  const { runId, children, contentStyle, containerStyle, ...rest } = props
+  const {
+    runId,
+    children,
+    contentStyle,
+    containerStyle,
+    oddHeaderBtnCopy,
+    desktopHeaderBtnCopy,
+    desktopFooterBtnCopy,
+    ...rest
+  } = props
   const { commandUtils } = rest
   const { currentStepIndex, totalStepCount, currentSubstep } = useSelector(
     selectStepInfo(runId)
@@ -100,6 +121,7 @@ export function LPCContentContainer(
             />
             <ChildNavigation
               {...rest}
+              buttonText={oddHeaderBtnCopy}
               css={CHILD_NAV_STYLE}
               buttonIsDisabled={rest.buttonIsDisabled}
               header={truncateString(rest.header, 40)}
@@ -125,6 +147,7 @@ export function LPCContentContainer(
                 currentStep={currentStepIndex + 1}
                 totalSteps={totalStepCount}
                 hideStepText={true}
+                exitButtonCopy={desktopHeaderBtnCopy}
               />
             }
           >
@@ -142,13 +165,13 @@ export function LPCContentContainer(
 
 function DesktopFooterContent({
   runId,
-  buttonText,
   buttonIsDisabled,
   tertiaryBtnProps,
   onClickButton,
   primaryBtnAlert,
   commandUtils,
-}: Omit<LPCContentContainerProps, 'children'>): JSX.Element {
+  desktopFooterBtnCopy,
+}: Omit<LPCContentContainerProps, 'children' | 'buttonText'>): JSX.Element {
   const step = useSelector(selectCurrentStep(runId))
   const { currentSubstep } = useSelector(selectStepInfo(runId))
   const showHelpLink =
@@ -170,11 +193,11 @@ function DesktopFooterContent({
             disabled={buttonIsDisabled}
             onClick={onClickButton}
           >
-            {buttonText}
+            {desktopFooterBtnCopy}
           </AlertPrimaryButton>
         ) : (
           <PrimaryButton disabled={buttonIsDisabled} onClick={onClickButton}>
-            {buttonText}
+            {desktopFooterBtnCopy}
           </PrimaryButton>
         )}
       </Flex>

--- a/app/src/organisms/LabwarePositionCheck/LPCContentContainer.tsx
+++ b/app/src/organisms/LabwarePositionCheck/LPCContentContainer.tsx
@@ -59,11 +59,11 @@ export type LPCContentContainerProps = LPCWizardContentProps &
     children: JSX.Element
     /* The ODD view header. The desktop header is hard-coded. */
     header: string
-    /* The copy for the desktop header button. */
+    /* The copy for the ODD header button. */
     oddHeaderBtnCopy: string
     /* The copy for the desktop header button. */
     desktopHeaderBtnCopy: string
-    /* The copy  for the desktop footer button. */
+    /* The copy for the desktop footer button. */
     desktopFooterBtnCopy: string
     /* An optional style override for the content container. */
     contentStyle?: FlattenSimpleInterpolation

--- a/app/src/organisms/LabwarePositionCheck/LPCFatalError.tsx
+++ b/app/src/organisms/LabwarePositionCheck/LPCFatalError.tsx
@@ -31,7 +31,9 @@ export function LPCFatalError(props: LPCWizardContentProps): JSX.Element {
       header={t('labware_position_check_title')}
       onClickButton={headerCommands.handleCloseWithoutHome}
       contentStyle={isOnDevice ? CHILDREN_CONTAINER_STYLE : undefined}
-      buttonText={t('exit')}
+      oddHeaderBtnCopy={t('exit')}
+      desktopHeaderBtnCopy={t('exit')}
+      desktopFooterBtnCopy={t('exit')}
     >
       <Flex css={CONTAINER_STYLE}>
         <Icon name="alert-circle" css={ICON_STYLE} />

--- a/app/src/organisms/LabwarePositionCheck/LPCProbeNotAttached.tsx
+++ b/app/src/organisms/LabwarePositionCheck/LPCProbeNotAttached.tsx
@@ -29,7 +29,9 @@ export function LPCProbeNotAttached(props: LPCWizardContentProps): JSX.Element {
     <LPCContentContainer
       {...props}
       header={t('labware_position_check_title')}
-      buttonText={t('try_again')}
+      desktopFooterBtnCopy={t('try_again')}
+      desktopHeaderBtnCopy={t('exit')}
+      oddHeaderBtnCopy={t('try_again')}
       onClickButton={headerCommands.handleUnableToDetectProbe}
       secondaryButtonProps={{
         buttonText: t('exit'),

--- a/app/src/organisms/LabwarePositionCheck/LPCRobotInMotion.tsx
+++ b/app/src/organisms/LabwarePositionCheck/LPCRobotInMotion.tsx
@@ -35,6 +35,9 @@ export function LPCRobotInMotion(props: RobotMotionLoaderProps): JSX.Element {
       {...props}
       header={t('labware_position_check_title')}
       contentStyle={isOnDevice ? CHILDREN_CONTAINER_STYLE : undefined}
+      oddHeaderBtnCopy="NO_COPY"
+      desktopHeaderBtnCopy="NO_COPY"
+      desktopFooterBtnCopy="NO_COPY"
     >
       <Flex css={CONTAINER_STYLE}>
         <Icon name="ot-spinner" css={SPINNER_STYLE} spin />

--- a/app/src/organisms/LabwarePositionCheck/__fixtures__/MockLPCContentContainer.tsx
+++ b/app/src/organisms/LabwarePositionCheck/__fixtures__/MockLPCContentContainer.tsx
@@ -3,23 +3,35 @@ import React from 'react'
 import { vi } from 'vitest'
 
 export const MockLPCContentContainer = vi.fn(
-  ({ header, onClickButton, buttonText, secondaryButtonProps, children }) => (
-    <div data-testid="mock-container">
-      <div data-testid="header-prop">{header}</div>
-      <button
-        data-testid="primary-button"
-        data-click-handler={String(!!onClickButton)}
-        data-button-text={buttonText}
-        onClick={onClickButton}
-      />
-      <button
-        data-testid="secondary-button"
-        data-text={secondaryButtonProps?.buttonText}
-        data-category={secondaryButtonProps?.buttonCategory}
-        data-type={secondaryButtonProps?.buttonType}
-        data-has-click={String(!!secondaryButtonProps?.onClick)}
-      />
-      {children}
-    </div>
-  )
+  ({
+    header,
+    onClickButton,
+    oddHeaderBtnCopy,
+    desktopFooterBtnCopy,
+    secondaryButtonProps,
+    children,
+  }) => {
+    const buttonText =
+      oddHeaderBtnCopy !== '' ? oddHeaderBtnCopy : desktopFooterBtnCopy
+
+    return (
+      <div data-testid="mock-container">
+        <div data-testid="header-prop">{header}</div>
+        <button
+          data-testid="primary-button"
+          data-click-handler={String(!!onClickButton)}
+          data-button-text={buttonText}
+          onClick={onClickButton}
+        />
+        <button
+          data-testid="secondary-button"
+          data-text={secondaryButtonProps?.buttonText}
+          data-category={secondaryButtonProps?.buttonCategory}
+          data-type={secondaryButtonProps?.buttonType}
+          data-has-click={String(!!secondaryButtonProps?.onClick)}
+        />
+        {children}
+      </div>
+    )
+  }
 )

--- a/app/src/organisms/LabwarePositionCheck/__tests__/LPCContentContainer.test.tsx
+++ b/app/src/organisms/LabwarePositionCheck/__tests__/LPCContentContainer.test.tsx
@@ -36,6 +36,9 @@ describe('LPCContentContainer', () => {
       header: 'MOCK_HEADER',
       ...mockLPCContentProps,
       children: <div>MOCK_CHILDREN</div>,
+      desktopHeaderBtnCopy: '',
+      desktopFooterBtnCopy: '',
+      oddHeaderBtnCopy: '',
     }
 
     vi.mocked(ChildNavigation).mockReturnValue(<div>MOCK_CHILD_NAV</div>)

--- a/app/src/organisms/LabwarePositionCheck/steps/AttachProbe.tsx
+++ b/app/src/organisms/LabwarePositionCheck/steps/AttachProbe.tsx
@@ -56,7 +56,9 @@ export function AttachProbe(props: LPCWizardContentProps): JSX.Element {
       {...props}
       header={t('labware_position_check_title')}
       onClickButton={handleAttachProbeCheck}
-      buttonText={t('continue')}
+      oddHeaderBtnCopy={t('continue')}
+      desktopFooterBtnCopy={t('continue')}
+      desktopHeaderBtnCopy={t('exit')}
       secondaryButtonProps={{
         buttonText: t('exit'),
         buttonCategory: 'rounded',

--- a/app/src/organisms/LabwarePositionCheck/steps/BeforeBeginning.tsx
+++ b/app/src/organisms/LabwarePositionCheck/steps/BeforeBeginning.tsx
@@ -33,7 +33,9 @@ export function BeforeBeginning(props: LPCWizardContentProps): JSX.Element {
     <LPCContentContainer
       {...props}
       header={t('labware_position_check_title')}
-      buttonText={t('move_gantry_to_front')}
+      desktopHeaderBtnCopy={t('exit')}
+      desktopFooterBtnCopy={t('move_gantry_to_front')}
+      oddHeaderBtnCopy={t('move_gantry_to_front')}
       onClickButton={commandUtils.headerCommands.handleProceed}
       secondaryButtonProps={{
         buttonText: t('exit'),

--- a/app/src/organisms/LabwarePositionCheck/steps/DetachProbe.tsx
+++ b/app/src/organisms/LabwarePositionCheck/steps/DetachProbe.tsx
@@ -91,7 +91,9 @@ export function DetachProbe(props: LPCWizardContentProps): JSX.Element {
     <LPCContentContainer
       {...props}
       header={t('labware_position_check_title')}
-      buttonText={t('confirm_removal')}
+      desktopFooterBtnCopy={t('confirm_removal')}
+      desktopHeaderBtnCopy={t('exit')}
+      oddHeaderBtnCopy={t('confirm_removal')}
       onClickButton={() => {
         proceedStep()
       }}

--- a/app/src/organisms/LabwarePositionCheck/steps/HandleLabware/EditOffset/CheckLabware/index.tsx
+++ b/app/src/organisms/LabwarePositionCheck/steps/HandleLabware/EditOffset/CheckLabware/index.tsx
@@ -196,7 +196,9 @@ function CheckLabwareContentODD(props: CheckLabwareContentProps): JSX.Element {
       <LPCContentContainer
         {...props}
         header={contentHeader}
-        buttonText={t('confirm_placement')}
+        desktopHeaderBtnCopy={t('exit')}
+        desktopFooterBtnCopy={t('confirm_placement')}
+        oddHeaderBtnCopy={t('confirm_placement')}
         onClickButton={handleProceed}
         onClickBack={handleGoBack}
       >
@@ -283,7 +285,9 @@ function CheckLabwareContentDesktop(
     <LPCContentContainer
       {...props}
       header={contentHeader}
-      buttonText={t('confirm_placement')}
+      desktopHeaderBtnCopy={t('exit')}
+      desktopFooterBtnCopy={t('confirm_placement')}
+      oddHeaderBtnCopy={t('confirm_placement')}
       onClickButton={handleProceed}
       onClickBack={handleGoBack}
       containerStyle={DESKTOP_CONTAINER_STYLE}

--- a/app/src/organisms/LabwarePositionCheck/steps/HandleLabware/EditOffset/DesktopOffsetSuccess.tsx
+++ b/app/src/organisms/LabwarePositionCheck/steps/HandleLabware/EditOffset/DesktopOffsetSuccess.tsx
@@ -100,7 +100,9 @@ export function DesktopOffsetSuccess(
     <LPCContentContainer
       {...props}
       header={t('labware_position_check_title')}
-      buttonText={t('continue')}
+      oddHeaderBtnCopy={t('continue')}
+      desktopFooterBtnCopy={t('continue')}
+      desktopHeaderBtnCopy={t('exit')}
       onClickButton={props.handleAddConfirmedWorkingVector}
     >
       <Flex css={CONTENT_CONTAINER}>

--- a/app/src/organisms/LabwarePositionCheck/steps/HandleLabware/EditOffset/PrepareLabware/index.tsx
+++ b/app/src/organisms/LabwarePositionCheck/steps/HandleLabware/EditOffset/PrepareLabware/index.tsx
@@ -70,7 +70,9 @@ export function PrepareLabware(props: EditOffsetContentProps): JSX.Element {
     <LPCContentContainer
       {...props}
       header={contentHeader}
-      buttonText={t('confirm_placement')}
+      desktopHeaderBtnCopy={t('exit')}
+      desktopFooterBtnCopy={t('confirm_placement')}
+      oddHeaderBtnCopy={t('confirm_placement')}
       onClickButton={handleConfirmPlacement}
       onClickBack={goBackSubstep}
       tertiaryBtnProps={{ text: t('go_back'), onClick: goBackSubstep }}

--- a/app/src/organisms/LabwarePositionCheck/steps/HandleLabware/LPCLabwareDetails/index.tsx
+++ b/app/src/organisms/LabwarePositionCheck/steps/HandleLabware/LPCLabwareDetails/index.tsx
@@ -87,7 +87,9 @@ export function LPCLabwareDetails(props: LPCWizardContentProps): JSX.Element {
         <LPCContentContainer
           {...props}
           header={selectedLwName}
-          buttonText={t('save')}
+          oddHeaderBtnCopy={t('save')}
+          desktopFooterBtnCopy={t('save')}
+          desktopHeaderBtnCopy={t('exit')}
           onClickButton={onHeaderSave}
           onClickBack={onHeaderGoBack}
           buttonIsDisabled={!doWorkingOffsetsExist}

--- a/app/src/organisms/LabwarePositionCheck/steps/HandleLabware/LPCLabwareList.tsx
+++ b/app/src/organisms/LabwarePositionCheck/steps/HandleLabware/LPCLabwareList.tsx
@@ -50,19 +50,26 @@ export function LPCLabwareList(props: LPCWizardContentProps): JSX.Element {
 
   const primaryButtonProps = (): Pick<
     LPCContentContainerProps,
-    'onClickButton' | 'buttonText'
+    | 'onClickButton'
+    | 'desktopFooterBtnCopy'
+    | 'desktopHeaderBtnCopy'
+    | 'oddHeaderBtnCopy'
   > => {
     if (isOnDevice) {
       return {
-        buttonText: t('exit'),
+        oddHeaderBtnCopy: t('save_and_exit'),
         onClickButton: props.commandUtils.headerCommands.handleNavToDetachProbe,
+        desktopHeaderBtnCopy: '',
+        desktopFooterBtnCopy: '',
       }
     } else {
       return {
-        buttonText: t('continue'),
+        desktopHeaderBtnCopy: t('save_and_exit'),
+        desktopFooterBtnCopy: t('continue'),
         onClickButton: () => {
           handlePrimaryOnClick(selectedUri)
         },
+        oddHeaderBtnCopy: '',
       }
     }
   }
@@ -71,7 +78,6 @@ export function LPCLabwareList(props: LPCWizardContentProps): JSX.Element {
     <LPCContentContainer
       {...props}
       header={t('labware_position_check_title')}
-      buttonText={t('exit')}
       {...primaryButtonProps()}
       containerStyle={isOnDevice ? undefined : DESKTOP_CONTAINER_STYLE}
       contentStyle={isOnDevice ? undefined : DESKTOP_CONTENT_CONTAINER_STYLE}

--- a/app/src/organisms/LabwarePositionCheck/steps/HandleLabware/UnsavedOffsets/UnsavedOffsetsDesktop.tsx
+++ b/app/src/organisms/LabwarePositionCheck/steps/HandleLabware/UnsavedOffsets/UnsavedOffsetsDesktop.tsx
@@ -48,7 +48,9 @@ export function UnsavedOffsetsDesktop(
         text: t('cancel'),
         onClick: toggleShowUnsavedOffsetsDesktop,
       }}
-      buttonText={t('confirm')}
+      oddHeaderBtnCopy={t('confirm')}
+      desktopHeaderBtnCopy={t('exit')}
+      desktopFooterBtnCopy={t('confirm')}
       onClickButton={onGoBack}
     >
       <Flex css={CONTAINER_STYLE}>

--- a/app/src/organisms/LabwarePositionCheck/steps/HandleLabware/__tests__/LPCLabwareList.test.tsx
+++ b/app/src/organisms/LabwarePositionCheck/steps/HandleLabware/__tests__/LPCLabwareList.test.tsx
@@ -150,7 +150,7 @@ describe('LPCLabwareList', () => {
     expect(header).toHaveTextContent('Labware Position Check')
 
     const primaryButton = screen.getByTestId('primary-button')
-    expect(primaryButton).toHaveAttribute('data-button-text', 'Exit')
+    expect(primaryButton).toHaveAttribute('data-button-text', 'Save & exit')
     expect(primaryButton).toHaveAttribute('data-click-handler', 'true')
   })
 

--- a/app/src/organisms/LabwarePositionCheck/steps/LPCComplete.tsx
+++ b/app/src/organisms/LabwarePositionCheck/steps/LPCComplete.tsx
@@ -25,7 +25,9 @@ export function LPCComplete(props: LPCWizardContentProps): JSX.Element {
     <LPCContentContainer
       {...props}
       header={t('labware_position_check_title')}
-      buttonText={t('exit')}
+      oddHeaderBtnCopy={t('exit')}
+      desktopHeaderBtnCopy={t('exit')}
+      desktopFooterBtnCopy={t('exit')}
       onClickButton={props.commandUtils.headerCommands.handleCloseAndHome}
       contentStyle={isOnDevice ? CHILDREN_CONTAINER_STYLE : undefined}
     >


### PR DESCRIPTION
Closes [EXEC-1596](https://opentrons.atlassian.net/browse/EXEC-1596)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

See linked ticket for problem statement and proposed design changes. In terms of code changes, we no longer have button copy parity between the desktop and ODD, which means we need to specifically support which copy goes in which button on which app type (desktop/ODD) during LPC for each step. While this generates a bunch of noise and requires more granular props, the testing we have helps verify that we only update "exit" to "save & exit" in the places we care about (only the `LPCLabwareList` view). The required new props ensure that lint catches any potential views that might have gone overlooked. 

<img width="1019" alt="Screenshot 2025-07-08 at 1 16 54 PM" src="https://github.com/user-attachments/assets/69068c3e-2054-4903-9c05-419a9bf63bf6" />

<img width="1030" alt="Screenshot 2025-07-08 at 1 19 43 PM" src="https://github.com/user-attachments/assets/4943c2c9-3357-4c42-9de5-a885e90bc4c3" />

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- See images.
- Covered by existing testing on other views.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- The LPC labware list view exit button copy is now "save & exit".
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
none, just copy and test updates
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[EXEC-1596]: https://opentrons.atlassian.net/browse/EXEC-1596?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ