### PR TITLE
fix(protocol-designer): remove command references from 8_5_0 migration

### DIFF
--- a/protocol-designer/src/load-file/migration/8_5_0.ts
+++ b/protocol-designer/src/load-file/migration/8_5_0.ts
@@ -4,6 +4,7 @@ import min from 'lodash/min'
 
 import {
   FLEX_ROBOT_TYPE,
+  getAllLabwareDefs,
   getPipetteSpecsV2,
   POSITION_REFERENCE_BOTTOM,
   POSITION_REFERENCE_TOP,
@@ -15,6 +16,7 @@ import {
   DEFAULT_MM_TOUCH_TIP_OFFSET_FROM_EDGE,
   PROTOCOL_DESIGNER_SOURCE,
 } from '../../constants'
+import { getLabwareDefsByURI } from '../../labware-defs/selectors'
 import { getDefaultBlowoutFlowRate, getDefaultPushOutVolume } from '../../utils'
 import { getMigratedPositionFromTop } from './utils/getMigrationPositionFromTop'
 
@@ -54,7 +56,7 @@ const getMigratedBlowoutLocation = (
 export const migrateFile = (
   appData: ProtocolFile<PDMetadata>
 ): ProtocolFile<PDMetadata> => {
-  const { designerApplication, labwareDefinitions, robot } = appData
+  const { designerApplication, robot } = appData
   if (designerApplication == null || designerApplication?.data == null) {
     throw Error('The designerApplication key in your file is corrupt.')
   }
@@ -66,6 +68,7 @@ export const migrateFile = (
   } = designerApplication.data
   const { model: robotType } = robot
 
+  const allLabwareDefsByURI = getAllLabwareDefs()
   const migratedIngredients: Ingredients = Object.entries(
     ingredients
   ).reduce<Ingredients>((acc, [id, ingredient]) => {
@@ -123,16 +126,16 @@ export const migrateFile = (
         ...rest
       } = form
       const aspirateLabwareUri = labware[aspirate_labware].labwareDefURI
-      const isAspirateLabwareTouchtipDisabled = labwareDefinitions[
+      const isAspirateLabwareTouchtipDisabled = allLabwareDefsByURI[
         aspirateLabwareUri
       ].parameters.quirks?.includes('touchTipDisabled')
       const dispenseLabwareUri = labware[dispense_labware]?.labwareDefURI
 
       const isDispenseLabwareTouchtipDisabled =
         //  dispense is in a waste chute/trash bin
-        labwareDefinitions[dispenseLabwareUri] == null
+        allLabwareDefsByURI[dispenseLabwareUri] == null
           ? true
-          : labwareDefinitions[dispenseLabwareUri].parameters.quirks?.includes(
+          : allLabwareDefsByURI[dispenseLabwareUri].parameters.quirks?.includes(
               'touchTipDisabled'
             )
 
@@ -141,18 +144,18 @@ export const migrateFile = (
         firstTrashBinOrWasteChuteId
       )
       const matchingAspirateLabwareWellDepth = getMigratedPositionFromTop(
-        labwareDefinitions,
+        allLabwareDefsByURI,
         aspirate_labware as string,
         labware,
         'aspirate'
       )
       const matchingDispenseLabwareWellDepth = getMigratedPositionFromTop(
-        labwareDefinitions,
+        allLabwareDefsByURI,
         dispense_labware as string,
         labware,
         'dispense'
       )
-      const tipRackDef = labwareDefinitions[form.tipRack]
+      const tipRackDef = allLabwareDefsByURI[form.tipRack]
       const pipetteName = pipettes?.[form.pipette]?.pipetteName ?? null
       const pipetteSpecs =
         pipetteName != null ? getPipetteSpecsV2(pipetteName) : null
@@ -268,9 +271,9 @@ export const migrateFile = (
           mix_touchTip_checkbox,
           ...rest
         } = form
-        const tipRackDef = labwareDefinitions[form.tipRack]
+        const tipRackDef = allLabwareDefsByURI[form.tipRack]
         const mixLabwareUri = labware[formLabware].labwareDefURI
-        const isLabwareTouchtipDisabled = labwareDefinitions[
+        const isLabwareTouchtipDisabled = allLabwareDefsByURI[
           mixLabwareUri
         ].parameters.quirks?.includes('touchTipDisabled')
         const pipetteName = pipettes?.[form.pipette]?.pipetteName ?? null
@@ -286,7 +289,7 @@ export const migrateFile = (
               )
 
         const matchingLabwareWellDepth = getMigratedPositionFromTop(
-          labwareDefinitions,
+          allLabwareDefsByURI,
           formLabware as string,
           labware,
           'mix'

--- a/protocol-designer/src/load-file/migration/8_5_0.ts
+++ b/protocol-designer/src/load-file/migration/8_5_0.ts
@@ -16,12 +16,10 @@ import {
   PROTOCOL_DESIGNER_SOURCE,
 } from '../../constants'
 import { getDefaultBlowoutFlowRate, getDefaultPushOutVolume } from '../../utils'
-import { getEquipmentLoadInfoFromCommands } from './utils/getEquipmentLoadInfoFromCommands'
 import { getMigratedPositionFromTop } from './utils/getMigrationPositionFromTop'
 
 import type {
   LabwareDefinition2,
-  LoadLabwareCreateCommand,
   PipetteV2Specs,
   ProtocolFile,
 } from '@opentrons/shared-data'
@@ -56,20 +54,17 @@ const getMigratedBlowoutLocation = (
 export const migrateFile = (
   appData: ProtocolFile<PDMetadata>
 ): ProtocolFile<PDMetadata> => {
-  const { designerApplication, commands, labwareDefinitions, robot } = appData
+  const { designerApplication, labwareDefinitions, robot } = appData
   if (designerApplication == null || designerApplication?.data == null) {
     throw Error('The designerApplication key in your file is corrupt.')
   }
-  const { savedStepForms, ingredients } = designerApplication.data
+  const {
+    savedStepForms,
+    ingredients,
+    labware,
+    pipettes,
+  } = designerApplication.data
   const { model: robotType } = robot
-  const loadLabwareCommands = commands.filter(
-    (command): command is LoadLabwareCreateCommand =>
-      command.commandType === 'loadLabware'
-  )
-  const equipmentLoadInfoFromCommands = getEquipmentLoadInfoFromCommands(
-    commands,
-    labwareDefinitions
-  )
 
   const migratedIngredients: Ingredients = Object.entries(
     ingredients
@@ -127,13 +122,11 @@ export const migrateFile = (
         blowout_z_offset,
         ...rest
       } = form
-      const aspirateLabwareUri =
-        equipmentLoadInfoFromCommands.labware[aspirate_labware].labwareDefURI
+      const aspirateLabwareUri = labware[aspirate_labware].labwareDefURI
       const isAspirateLabwareTouchtipDisabled = labwareDefinitions[
         aspirateLabwareUri
       ].parameters.quirks?.includes('touchTipDisabled')
-      const dispenseLabwareUri =
-        equipmentLoadInfoFromCommands.labware[dispense_labware]?.labwareDefURI
+      const dispenseLabwareUri = labware[dispense_labware]?.labwareDefURI
 
       const isDispenseLabwareTouchtipDisabled =
         //  dispense is in a waste chute/trash bin
@@ -149,20 +142,18 @@ export const migrateFile = (
       )
       const matchingAspirateLabwareWellDepth = getMigratedPositionFromTop(
         labwareDefinitions,
-        loadLabwareCommands,
         aspirate_labware as string,
+        labware,
         'aspirate'
       )
       const matchingDispenseLabwareWellDepth = getMigratedPositionFromTop(
         labwareDefinitions,
-        loadLabwareCommands,
         dispense_labware as string,
+        labware,
         'dispense'
       )
       const tipRackDef = labwareDefinitions[form.tipRack]
-      const pipetteName =
-        equipmentLoadInfoFromCommands.pipettes?.[form.pipette]?.pipetteName ??
-        null
+      const pipetteName = pipettes?.[form.pipette]?.pipetteName ?? null
       const pipetteSpecs =
         pipetteName != null ? getPipetteSpecsV2(pipetteName) : null
       const defaultPushOutVolume =
@@ -272,20 +263,17 @@ export const migrateFile = (
         const {
           id,
           mix_touchTip_mmFromBottom,
-          labware,
+          labware: formLabware,
           liquidClassesSupported,
           mix_touchTip_checkbox,
           ...rest
         } = form
         const tipRackDef = labwareDefinitions[form.tipRack]
-        const mixLabwareUri =
-          equipmentLoadInfoFromCommands.labware[labware].labwareDefURI
+        const mixLabwareUri = labware[formLabware].labwareDefURI
         const isLabwareTouchtipDisabled = labwareDefinitions[
           mixLabwareUri
         ].parameters.quirks?.includes('touchTipDisabled')
-        const pipetteName =
-          equipmentLoadInfoFromCommands.pipettes?.[form.pipette]?.pipetteName ??
-          null
+        const pipetteName = pipettes?.[form.pipette]?.pipetteName ?? null
         const pipetteSpecs =
           pipetteName != null ? getPipetteSpecsV2(pipetteName) : null
         const defaultPushOutVolume =
@@ -299,8 +287,8 @@ export const migrateFile = (
 
         const matchingLabwareWellDepth = getMigratedPositionFromTop(
           labwareDefinitions,
-          loadLabwareCommands,
-          labware as string,
+          formLabware as string,
+          labware,
           'mix'
         )
 

--- a/protocol-designer/src/load-file/migration/8_5_0.ts
+++ b/protocol-designer/src/load-file/migration/8_5_0.ts
@@ -16,7 +16,6 @@ import {
   DEFAULT_MM_TOUCH_TIP_OFFSET_FROM_EDGE,
   PROTOCOL_DESIGNER_SOURCE,
 } from '../../constants'
-import { getLabwareDefsByURI } from '../../labware-defs/selectors'
 import { getDefaultBlowoutFlowRate, getDefaultPushOutVolume } from '../../utils'
 import { getMigratedPositionFromTop } from './utils/getMigrationPositionFromTop'
 

--- a/protocol-designer/src/load-file/migration/8_5_0.ts
+++ b/protocol-designer/src/load-file/migration/8_5_0.ts
@@ -55,7 +55,7 @@ const getMigratedBlowoutLocation = (
 export const migrateFile = (
   appData: ProtocolFile<PDMetadata>
 ): ProtocolFile<PDMetadata> => {
-  const { designerApplication, robot } = appData
+  const { designerApplication, robot, labwareDefinitions } = appData
   if (designerApplication == null || designerApplication?.data == null) {
     throw Error('The designerApplication key in your file is corrupt.')
   }
@@ -67,7 +67,13 @@ export const migrateFile = (
   } = designerApplication.data
   const { model: robotType } = robot
 
-  const allLabwareDefsByURI = getAllLabwareDefs()
+  const allLabwareDefsByURI =
+    //  read the labware definitions key first
+    //  otherwise map to all labware defs as a fallback
+    //  for OpentronsAI
+    Object.values(labwareDefinitions).length > 0
+      ? labwareDefinitions
+      : getAllLabwareDefs()
   const migratedIngredients: Ingredients = Object.entries(
     ingredients
   ).reduce<Ingredients>((acc, [id, ingredient]) => {

--- a/protocol-designer/src/load-file/migration/8_5_0.ts
+++ b/protocol-designer/src/load-file/migration/8_5_0.ts
@@ -317,7 +317,7 @@ export const migrateFile = (
           [id]: {
             ...rest,
             id,
-            labware,
+            labware: formLabware,
             mix_touchTip_checkbox: isLabwareTouchtipDisabled
               ? false
               : mix_touchTip_checkbox,

--- a/protocol-designer/src/load-file/migration/utils/getMigrationPositionFromTop.ts
+++ b/protocol-designer/src/load-file/migration/utils/getMigrationPositionFromTop.ts
@@ -1,12 +1,9 @@
-import { Labware } from '../../../file-types'
-
 import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { Labware } from '../../../file-types'
 import type { MoveLiquidPrefixType } from '../../../resources/types'
 
 export const getMigratedPositionFromTop = (
-  labwareDefinitions: {
-    [definitionId: string]: LabwareDefinition2
-  },
+  labwareDefsByURI: Record<string, LabwareDefinition2>,
   formLabwareId: string,
   labware: Labware,
   type: MoveLiquidPrefixType
@@ -20,12 +17,12 @@ export const getMigratedPositionFromTop = (
   }
 
   //    early exit for dispense_labware equaling trashBin or wasteChute
-  if (labwareDefinitions[labwareDefUri] == null) {
+  if (labwareDefsByURI[labwareDefUri] == null) {
     return 0
   }
 
   const matchingLabwareWellDepth = labwareDefUri
-    ? labwareDefinitions[labwareDefUri].wells.A1.depth
+    ? labwareDefsByURI[labwareDefUri].wells.A1.depth
     : 0
 
   if (matchingLabwareWellDepth === 0) {

--- a/protocol-designer/src/load-file/migration/utils/getMigrationPositionFromTop.ts
+++ b/protocol-designer/src/load-file/migration/utils/getMigrationPositionFromTop.ts
@@ -1,44 +1,36 @@
-import type {
-  LabwareDefinition2,
-  LoadLabwareCreateCommand,
-} from '@opentrons/shared-data'
+import { Labware } from '../../../file-types'
+
+import type { LabwareDefinition2 } from '@opentrons/shared-data'
 import type { MoveLiquidPrefixType } from '../../../resources/types'
 
 export const getMigratedPositionFromTop = (
   labwareDefinitions: {
     [definitionId: string]: LabwareDefinition2
   },
-  loadLabwareCommands: LoadLabwareCreateCommand[],
-  labware: string,
+  formLabwareId: string,
+  labware: Labware,
   type: MoveLiquidPrefixType
 ): number => {
-  const matchingLoadLabware = loadLabwareCommands.find(
-    command =>
-      command.commandType === 'loadLabware' &&
-      command.params.labwareId === labware
-  )
-  if (matchingLoadLabware == null) {
+  const labwareDefUri = labware[formLabwareId].labwareDefURI
+
+  if (labwareDefUri == null) {
     console.error(
-      `expected to find matching ${type} labware load command but could not with ${type}_labware from form data as ${labware}`
+      `unable to find matching labware def uri from form labware id ${formLabwareId}`
     )
   }
-  const labwareUri =
-    matchingLoadLabware != null
-      ? `${matchingLoadLabware.params.namespace}/${matchingLoadLabware.params.loadName}/${matchingLoadLabware.params.version}`
-      : ''
 
   //    early exit for dispense_labware equaling trashBin or wasteChute
-  if (labwareDefinitions[labwareUri] == null) {
+  if (labwareDefinitions[labwareDefUri] == null) {
     return 0
   }
 
-  const matchingLabwareWellDepth = labwareUri
-    ? labwareDefinitions[labwareUri].wells.A1.depth
+  const matchingLabwareWellDepth = labwareDefUri
+    ? labwareDefinitions[labwareDefUri].wells.A1.depth
     : 0
 
   if (matchingLabwareWellDepth === 0) {
     console.error(
-      `error in finding the ${type} labware well depth with labware uri ${labwareUri}`
+      `error in finding the ${type} labware well depth with labware uri ${labwareDefUri}`
     )
   }
   return matchingLabwareWellDepth


### PR DESCRIPTION
# Overview

Remove any reference of `commands` and branching logic for `labwareDefinitions` in the `8_5_0` migration since opentrons AI protocols won't have commands or labware defs.

We needed to keep reading `labwareDefinitions` if its populated so custom labware will still work.

## Test Plan and Hands on Testing

review the code and import attached protocol. should import correctly

[reallycool.json](https://github.com/user-attachments/files/21146747/reallycool.json)


## Changelog

remove any references of needing commands and instead import the top level `labware` and `pipettes` keys
branching logic for labware definitions by uri

## Risk assessment

low
