### PR TITLE
docs(shared-data): Document the `labwareOffset` property in module definitions

### DIFF
--- a/shared-data/module/schemas/3.json
+++ b/shared-data/module/schemas/3.json
@@ -137,7 +137,10 @@
       "type": "string",
       "pattern": "^(temperatureModule|magneticModule|thermocyclerModule|heaterShakerModule|magneticBlock|absorbanceReader|flexStackerModule)V[0-9]+$"
     },
-    "labwareOffset": { "$ref": "#/definitions/coordinates" },
+    "labwareOffset": {
+      "$ref": "#/definitions/coordinates",
+      "description": "The offset from the left-front-bottom corner of the slot holding this module, to the left-front-bottom corner of the labware interface atop this module."
+    },
     "extents": {
       "description": "The outer dimensions of the addressable area. Includes offsets from `cornerOffsetFromSlot`.",
       "type": "object",


### PR DESCRIPTION
## Overview

This clarifies a field in module definitions.

Surprisingly to me, `labwareOffset` is not an offset from the module's front-left-bottom corner (specified by `cornerOffsetFromSlot`). It's an offset from the _parent slot's_ front-left-bottom corner.

To deduce that this is true, look at `shared-data/module/definitions/3/temperatureModuleV2.json`. Physically, the module body juts out far beyond the bounds of the slot, but the module's top slot is basically aligned with the underlying deck slot. In the definition, this is represented by a big `cornerOffsetFromSlot` x/y and a small `labwareOffset` x/y.

## Test Plan and Hands on Testing

None needed.

## Review requests

* Seems right?
* Meaning is clear?

## Risk assessment

No risk.
