### PR TITLE
refactor(app, components): Do not require applying offsets behavior starting a run

### DIFF
--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderContent/ActionButton/index.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderContent/ActionButton/index.tsx
@@ -16,7 +16,7 @@ import {
 
 import { useRobotAnalyticsData } from '/app/redux-resources/analytics'
 import { useIsFlex, useRobot } from '/app/redux-resources/robots'
-import { selectAreOffsetsApplied } from '/app/redux/protocol-runs'
+import { selectIsAnyNecessaryDefaultOffsetMissing } from '/app/redux/protocol-runs'
 import { useIsRobotOnWrongVersionOfSoftware } from '/app/redux/robot-update'
 import {
   useCurrentRunId,
@@ -72,14 +72,16 @@ export function ActionButton(props: ActionButtonProps): JSX.Element {
     robotName
   )
   const currentRunId = useCurrentRunId()
-  const areOffsetsApplied = useSelector(selectAreOffsetsApplied(runId))
+  const isRequiredOffsetMissing = useSelector(
+    selectIsAnyNecessaryDefaultOffsetMissing(runId)
+  )
 
   const isSetupComplete =
     isCalibrationComplete &&
     isModuleCalibrationComplete &&
     missingModuleIds.length === 0
   const isRobotTypeSetupComplete = isFlex
-    ? isSetupComplete && areOffsetsApplied
+    ? isSetupComplete && !isRequiredOffsetMissing
     : isSetupComplete
 
   const isCurrentRun = currentRunId === runId

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderModalContainer/hooks/useHeaterShakerConfirmationModal.ts
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderModalContainer/hooks/useHeaterShakerConfirmationModal.ts
@@ -20,7 +20,7 @@ export type UseHeaterShakerConfirmationModalResult =
     }
 
 export function useHeaterShakerConfirmationModal(
-  handleProceedToRunClick: () => void
+  handleProceedToRunClick: () => Promise<void>
 ): UseHeaterShakerConfirmationModalResult {
   const configBypassHeaterShakerAttachmentConfirmation = useSelector(
     getIsHeaterShakerAttached

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderModalContainer/hooks/useMissingStepsModal.ts
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderModalContainer/hooks/useMissingStepsModal.ts
@@ -27,7 +27,8 @@ interface UseMissingStepsModalProps {
   runStatus: RunStatus | null
   attachedModules: AttachedModule[]
   runId: string
-  handleProceedToRunClick: () => void
+  handleProceedToRunClick: () => Promise<void>
+  isRunStarting: boolean
 }
 
 export type UseMissingStepsModalResult =
@@ -47,6 +48,7 @@ export function useMissingStepsModal({
   runStatus,
   runId,
   handleProceedToRunClick,
+  isRunStarting,
 }: UseMissingStepsModalProps): UseMissingStepsModalResult {
   const isHeaterShakerInProtocol = useIsHeaterShakerInProtocol()
   const isHeaterShakerShaking = isAnyHeaterShakerShaking(attachedModules)
@@ -76,6 +78,7 @@ export function useMissingStepsModal({
         : handleProceedToRunClick()
     },
     missingSteps: reportableMissingSetupSteps,
+    isRunStarting,
   }
 
   return conditionalConfirmUtils.showConfirmation

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderModalContainer/modals/ConfirmMissingStepsModal.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderModalContainer/modals/ConfirmMissingStepsModal.tsx
@@ -1,15 +1,20 @@
 import { useTranslation } from 'react-i18next'
+import { css } from 'styled-components'
 
 import {
   ALIGN_CENTER,
+  COLORS,
   DIRECTION_COLUMN,
   DIRECTION_ROW,
+  DISPLAY_FLEX,
   Flex,
+  Icon,
   JUSTIFY_FLEX_END,
   LegacyStyledText,
   Modal,
   PrimaryButton,
   SecondaryButton,
+  SIZE_1,
   SPACING,
   TYPOGRAPHY,
 } from '@opentrons/components'
@@ -34,11 +39,12 @@ export interface ConfirmMissingStepsModalProps {
   onCloseClick: () => void
   onConfirmClick: () => void
   missingSteps: StepKey[]
+  isRunStarting: boolean
 }
 export const ConfirmMissingStepsModal = (
   props: ConfirmMissingStepsModalProps
 ): JSX.Element | null => {
-  const { missingSteps, onCloseClick, onConfirmClick } = props
+  const { missingSteps, onCloseClick, onConfirmClick, isRunStarting } = props
   const { t, i18n } = useTranslation(['protocol_setup', 'shared'])
 
   const confirmAttached = (): void => {
@@ -72,10 +78,19 @@ export const ConfirmMissingStepsModal = (
         <SecondaryButton onClick={onCloseClick}>
           {i18n.format(t('shared:go_back'), 'capitalize')}
         </SecondaryButton>
-        <PrimaryButton onClick={confirmAttached}>
+        <PrimaryButton onClick={confirmAttached} css={PRIMARY_BUTTON_STYLE}>
+          {isRunStarting && (
+            <Icon name="ot-spinner" spin size={SIZE_1} color={COLORS.white} />
+          )}
           {t('start_run')}
         </PrimaryButton>
       </Flex>
     </Modal>
   )
 }
+
+const PRIMARY_BUTTON_STYLE = css`
+  display: ${DISPLAY_FLEX};
+  gap: ${SPACING.spacing4};
+  align-items: ${ALIGN_CENTER};
+`

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderModalContainer/useRunHeaderModalContainer.ts
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderModalContainer/useRunHeaderModalContainer.ts
@@ -1,7 +1,10 @@
 import { useSelector } from 'react-redux'
 import { useNavigate } from 'react-router-dom'
 
+import { FLEX_ROBOT_TYPE } from '@opentrons/shared-data'
+
 import { useErrorRecoveryFlows } from '/app/organisms/ErrorRecoveryFlows'
+import { useApplyOffsets } from '/app/organisms/LabwarePositionCheck'
 import {
   useRobotAnalyticsData,
   useTrackProtocolRunEvent,
@@ -12,7 +15,11 @@ import {
   ANALYTICS_PROTOCOL_RUN_ACTION,
   useTrackEvent,
 } from '/app/redux/analytics'
-import { OFFSETS_CONFLICT, selectOffsetSource } from '/app/redux/protocol-runs'
+import {
+  OFFSETS_CONFLICT,
+  selectAreOffsetsApplied,
+  selectOffsetSource,
+} from '/app/redux/protocol-runs'
 import { useCurrentRunId, useProtocolDetailsForRun } from '/app/resources/runs'
 
 import { getFallbackRobotSerialNumber } from '../utils'
@@ -93,8 +100,10 @@ export function useRunHeaderModalContainer({
   const isLabwareOffsetConflict =
     useSelector(selectOffsetSource(runId)) === OFFSETS_CONFLICT
   const isThisRunCurrent = runId === useCurrentRunId()
+  const flexOffsetsApplied = useSelector(selectAreOffsetsApplied(runId))
+  const { applyOffsets, isApplyingOffsets } = useApplyOffsets(runId)
 
-  function handleProceedToRunClick(): void {
+  function proceedToRun(): void {
     navigate(`/devices/${robotName}/protocol-runs/${runId}/run-preview`)
     trackEvent({
       name: ANALYTICS_PROTOCOL_PROCEED_TO_RUN,
@@ -105,6 +114,15 @@ export function useRunHeaderModalContainer({
       properties: robotAnalyticsData ?? {},
     })
     protocolRunControls.play()
+  }
+
+  function handleProceedToRunClick(): Promise<void> {
+    if (robotType === FLEX_ROBOT_TYPE && !flexOffsetsApplied) {
+      return applyOffsets().then(proceedToRun)
+    } else {
+      proceedToRun()
+      return Promise.resolve()
+    }
   }
 
   const confirmCancelModalUtils = useConfirmCancelModal()
@@ -128,6 +146,7 @@ export function useRunHeaderModalContainer({
     runStatus,
     runId,
     handleProceedToRunClick,
+    isRunStarting: isApplyingOffsets,
   })
 
   const dropTipUtils = useRunHeaderDropTip({

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunSetup.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunSetup.tsx
@@ -145,7 +145,7 @@ export function ProtocolRunSetup({
     if (flexOffsetsApplied) {
       dispatch(updateRunSetupStepsComplete(runId, { [LPC_STEP_KEY]: true }))
     }
-  }, [flexOffsetsApplied])
+  }, [dispatch, flexOffsetsApplied, runId])
 
   const offsetsConfirmed = isFlex
     ? runHasStarted ||
@@ -290,6 +290,11 @@ export function ProtocolRunSetup({
           setOffsetsConfirmed={confirmed => {
             if (confirmed) {
               dispatch(appliedOffsetsToRun(runId))
+              dispatch(
+                updateRunSetupStepsComplete(runId, {
+                  [LPC_STEP_KEY]: confirmed,
+                })
+              )
               updateLPCStatusWithRunId(runId)
 
               setExpandedStepKey(LABWARE_SETUP_STEP_KEY)

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabwarePositionCheck/FlexSetupLPC/LPCSetupFlexBtns.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabwarePositionCheck/FlexSetupLPC/LPCSetupFlexBtns.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 
@@ -12,14 +11,14 @@ import {
   TOOLTIP_BOTTOM,
   useHoverTooltip,
 } from '@opentrons/components'
-import { useAddLabwareOffsetToRunMutation } from '@opentrons/react-api-client'
 import { FLEX_ROBOT_TYPE } from '@opentrons/shared-data'
 
-import { useLPCAnalytics } from '/app/organisms/LabwarePositionCheck/LPCFlows'
-import { useToaster } from '/app/organisms/ToasterOven'
+import {
+  useApplyOffsets,
+  useLPCAnalytics,
+} from '/app/organisms/LabwarePositionCheck/LPCFlows'
 import {
   selectIsAnyNecessaryDefaultOffsetMissing,
-  selectLabwareOffsetsToAddToRun,
   selectTotalCountNonHardCodedLSOffsets,
 } from '/app/redux/protocol-runs'
 import { useLPCDisabledReason } from '/app/resources/runs'
@@ -40,7 +39,6 @@ export function LPCSetupFlexBtns({
   hasMissingCalForFlex,
 }: LPCSetupFlexBtnsProps): JSX.Element {
   const { t } = useTranslation('protocol_setup')
-  const { makeSnackbar } = useToaster()
   const { reportApplyOffsets } = useLPCAnalytics({
     runId,
     robotType: FLEX_ROBOT_TYPE,
@@ -66,10 +64,6 @@ export function LPCSetupFlexBtns({
 
   const anyOffsetsToLpc =
     useSelector(selectTotalCountNonHardCodedLSOffsets(runId)) === 0
-  const lwOffsetsForRun = useSelector(selectLabwareOffsetsToAddToRun(runId))
-  const { createLabwareOffset } = useAddLabwareOffsetToRunMutation()
-
-  const [isApplyOffsets, setIsApplyingOffsets] = useState(false)
 
   const isApplyOffsetsBtnDisabled =
     offsetsConfirmed ||
@@ -101,23 +95,12 @@ export function LPCSetupFlexBtns({
     }
   }
 
+  const { applyOffsets } = useApplyOffsets(runId)
   const onApplyOffsets = (): void => {
-    if (!isApplyOffsets && lwOffsetsForRun != null) {
-      setIsApplyingOffsets(true)
-      Promise.all(
-        lwOffsetsForRun.map(data => createLabwareOffset({ runId, data }))
-      )
-        .then(() => {
-          setOffsetsConfirmed(true)
-          reportApplyOffsets()
-        })
-        .catch(() => {
-          makeSnackbar(t('failed_to_apply_offsets') as string)
-        })
-        .finally(() => {
-          setIsApplyingOffsets(false)
-        })
-    }
+    void applyOffsets().then(() => {
+      setOffsetsConfirmed(true)
+      reportApplyOffsets()
+    })
   }
 
   return (
@@ -140,7 +123,6 @@ export function LPCSetupFlexBtns({
         id="LPC_setOffsetsConfirmed"
         padding={`${SPACING.spacing8} ${SPACING.spacing16}`}
         {...confirmOffsetsTargetProps}
-        disabled={isApplyOffsetsBtnDisabled}
       >
         {t('apply_offsets')}
       </PrimaryButton>

--- a/app/src/organisms/LabwarePositionCheck/LPCFlows/index.ts
+++ b/app/src/organisms/LabwarePositionCheck/LPCFlows/index.ts
@@ -1,5 +1,6 @@
 export { useLPCFlows } from './useLPCFlows'
 export { useLPCAnalytics } from './useLPCAnalytics'
+export { useApplyOffsets } from './useApplyOffsets'
 export * from './LPCFlows'
 
 export type { UseLPCFlowsProps, UseLPCFlowsResult } from './useLPCFlows'

--- a/app/src/organisms/LabwarePositionCheck/LPCFlows/useApplyOffsets.ts
+++ b/app/src/organisms/LabwarePositionCheck/LPCFlows/useApplyOffsets.ts
@@ -1,0 +1,54 @@
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useSelector } from 'react-redux'
+
+import { useAddLabwareOffsetToRunMutation } from '@opentrons/react-api-client'
+
+import { useToaster } from '/app/organisms/ToasterOven'
+import {
+  selectIsAnyNecessaryDefaultOffsetMissing,
+  selectLabwareOffsetsToAddToRun,
+} from '/app/redux/protocol-runs'
+
+interface ApplyOffsetsResult {
+  applyOffsets: () => Promise<void>
+  isApplyingOffsets: boolean
+}
+
+export function useApplyOffsets(runId: string): ApplyOffsetsResult {
+  const { t } = useTranslation('protocol_setup')
+  const lwOffsetsForRun = useSelector(selectLabwareOffsetsToAddToRun(runId))
+  const isNecessaryDefaultOffsetMissing = useSelector(
+    selectIsAnyNecessaryDefaultOffsetMissing(runId)
+  )
+  const { makeSnackbar } = useToaster()
+  const { createLabwareOffset } = useAddLabwareOffsetToRunMutation()
+  const [isApplyingOffsets, setIsApplyingOffsets] = useState(false)
+
+  const applyOffsets = (): Promise<void> => {
+    if (isApplyingOffsets) {
+      return Promise.resolve()
+    } else if (isNecessaryDefaultOffsetMissing) {
+      makeSnackbar(t('add_missing_labware_offsets') as string)
+      return Promise.reject(new Error('Missing necessary default offsets'))
+    } else if (lwOffsetsForRun == null) {
+      makeSnackbar(t('no_offsets_found') as string)
+      return Promise.reject(new Error('No offsets found'))
+    } else {
+      setIsApplyingOffsets(true)
+      return Promise.all(
+        lwOffsetsForRun.map(data => createLabwareOffset({ runId, data }))
+      )
+        .catch(error => {
+          makeSnackbar(t('failed_to_apply_offsets') as string)
+          throw error // Re-throw to allow chaining
+        })
+        .finally(() => {
+          setIsApplyingOffsets(false)
+        })
+        .then(() => {})
+    }
+  }
+
+  return { applyOffsets, isApplyingOffsets }
+}

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupOffsets/SetupOffsetsHeader.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupOffsets/SetupOffsetsHeader.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 import { css } from 'styled-components'
@@ -9,17 +8,17 @@ import {
   JUSTIFY_SPACE_BETWEEN,
   SPACING,
 } from '@opentrons/components'
-import { useAddLabwareOffsetToRunMutation } from '@opentrons/react-api-client'
 import { FLEX_ROBOT_TYPE } from '@opentrons/shared-data'
 
 import { SmallButton } from '/app/atoms/buttons'
 import { ODDBackButton } from '/app/molecules/ODDBackButton'
-import { useLPCAnalytics } from '/app/organisms/LabwarePositionCheck'
-import { useToaster } from '/app/organisms/ToasterOven'
+import {
+  useApplyOffsets,
+  useLPCAnalytics,
+} from '/app/organisms/LabwarePositionCheck'
 import {
   appliedOffsetsToRun,
   selectIsAnyNecessaryDefaultOffsetMissing,
-  selectLabwareOffsetsToAddToRun,
 } from '/app/redux/protocol-runs'
 import { useUpdateClientLPC } from '/app/resources/client_data'
 
@@ -32,45 +31,23 @@ export function SetupOffsetsHeader({
 }: ProtocolSetupOffsetsProps): JSX.Element {
   const { t } = useTranslation('protocol_setup')
   const dispatch = useDispatch()
-  const { makeSnackbar } = useToaster()
   const { reportApplyOffsets } = useLPCAnalytics({
     runId,
     robotType: FLEX_ROBOT_TYPE,
   })
-  const { createLabwareOffset } = useAddLabwareOffsetToRunMutation()
   const isNecessaryDefaultOffsetMissing = useSelector(
     selectIsAnyNecessaryDefaultOffsetMissing(runId)
   )
-  const lwOffsetsForRun = useSelector(selectLabwareOffsetsToAddToRun(runId))
   const { updateWithRunId } = useUpdateClientLPC()
 
-  const [isApplyOffsets, setIsApplyingOffsets] = useState(false)
-
+  const { applyOffsets, isApplyingOffsets } = useApplyOffsets(runId)
   const onApplyOffsets = (): void => {
-    if (!isApplyOffsets) {
-      if (isNecessaryDefaultOffsetMissing) {
-        makeSnackbar(t('add_missing_labware_offsets') as string)
-      } else if (lwOffsetsForRun == null) {
-        makeSnackbar(t('no_offsets_found') as string)
-      } else {
-        setIsApplyingOffsets(true)
-        Promise.all(
-          lwOffsetsForRun.map(data => createLabwareOffset({ runId, data }))
-        )
-          .then(() => {
-            dispatch(appliedOffsetsToRun(runId))
-            reportApplyOffsets()
-            updateWithRunId(runId)
-            setSetupScreen('prepare to run')
-          })
-          .catch(() => {
-            makeSnackbar(t('failed_to_apply_offsets') as string)
-          })
-          .finally(() => {
-            setIsApplyingOffsets(false)
-          })
-      }
-    }
+    void applyOffsets().then(() => {
+      dispatch(appliedOffsetsToRun(runId))
+      reportApplyOffsets()
+      updateWithRunId(runId)
+      setSetupScreen('prepare to run')
+    })
   }
 
   return (
@@ -95,7 +72,7 @@ export function SetupOffsetsHeader({
           onClick={onApplyOffsets}
           buttonCategory="rounded"
           iconPlacement="startIcon"
-          iconName={isApplyOffsets ? 'ot-spinner' : null}
+          iconName={isApplyingOffsets ? 'ot-spinner' : null}
           padding={`${SPACING.spacing16} ${SPACING.spacing24}`}
         />
       )}

--- a/app/src/pages/ODD/ProtocolSetup/ConfirmSetupStepsCompleteModal.tsx
+++ b/app/src/pages/ODD/ProtocolSetup/ConfirmSetupStepsCompleteModal.tsx
@@ -16,12 +16,14 @@ interface ConfirmSetupStepsCompleteModalProps {
   onCloseClick: () => void
   onConfirmClick: () => void
   missingSteps: string[]
+  isRunStarting: boolean
 }
 
 export function ConfirmSetupStepsCompleteModal({
   onCloseClick,
   missingSteps,
   onConfirmClick,
+  isRunStarting,
 }: ConfirmSetupStepsCompleteModalProps): JSX.Element {
   const { i18n, t } = useTranslation(['protocol_setup', 'shared'])
   const modalHeader: OddModalHeaderBaseProps = {
@@ -63,6 +65,8 @@ export function ConfirmSetupStepsCompleteModal({
             buttonType="primary"
             buttonText={t('start_run')}
             onClick={handleStartRun}
+            iconName={isRunStarting ? 'ot-spinner' : undefined}
+            iconPlacement={isRunStarting ? 'startIcon' : undefined}
           />
         </Flex>
       </Flex>

--- a/app/src/pages/ODD/ProtocolSetup/__tests__/ProtocolSetup.test.tsx
+++ b/app/src/pages/ODD/ProtocolSetup/__tests__/ProtocolSetup.test.tsx
@@ -27,7 +27,10 @@ import {
   NOT_CONFIGURED,
   useIsDoorOpen,
 } from '/app/organisms/DoorOpenControl/useIsDoorOpen'
-import { useLPCFlows } from '/app/organisms/LabwarePositionCheck'
+import {
+  useApplyOffsets,
+  useLPCFlows,
+} from '/app/organisms/LabwarePositionCheck'
 import { useIsHeaterShakerInProtocol } from '/app/organisms/ModuleCard/hooks'
 import {
   getUnmatchedModulesForProtocol,
@@ -133,6 +136,7 @@ vi.mock('/app/redux/protocol-runs')
 vi.mock('/app/resources/maintenance_runs')
 vi.mock('/app/local-resources/instruments')
 vi.mock('/app/organisms/DoorOpenControl/useIsDoorOpen')
+vi.mock('/app/organisms/LabwarePositionCheck')
 
 const render = (path = '/') => {
   return renderWithProviders(
@@ -343,6 +347,10 @@ describe('ProtocolSetup', () => {
       selectIsAnyNecessaryDefaultOffsetMissing
     ).mockImplementation(() => () => false)
     vi.mocked(selectOffsetSource).mockImplementation(() => () => 'fromDatabase')
+    vi.mocked(useApplyOffsets).mockReturnValue({
+      isApplyingOffsets: false,
+      applyOffsets: vi.fn(),
+    })
   })
 
   it('should render text, image, and buttons', () => {

--- a/app/src/pages/ODD/ProtocolSetup/index.tsx
+++ b/app/src/pages/ODD/ProtocolSetup/index.tsx
@@ -40,7 +40,10 @@ import {
   useIsDoorOpen,
 } from '/app/organisms/DoorOpenControl/useIsDoorOpen'
 import { LabwareOffsetsConflictModal } from '/app/organisms/LabwareOffsetsConflictModal'
-import { useLPCFlows } from '/app/organisms/LabwarePositionCheck'
+import {
+  useApplyOffsets,
+  useLPCFlows,
+} from '/app/organisms/LabwarePositionCheck'
 import { useIsHeaterShakerInProtocol } from '/app/organisms/ModuleCard/hooks'
 import {
   AnalysisFailedModal,
@@ -133,7 +136,7 @@ interface PrepareToRunProps {
   robotName: string
   runRecord: Run | null
   labwareConfirmed: boolean
-  offsetsConfirmed: boolean
+  isRequiredOffsetMissing: boolean
   isLPCInitializing: boolean
 }
 
@@ -146,7 +149,7 @@ function PrepareToRun({
   robotName,
   runRecord,
   labwareConfirmed,
-  offsetsConfirmed,
+  isRequiredOffsetMissing,
   isLPCInitializing,
   confirmStepsComplete,
 }: PrepareToRunProps): JSX.Element {
@@ -355,7 +358,7 @@ function PrepareToRun({
     incompleteInstrumentCount === 0 &&
     areModulesReady &&
     areFixturesReady &&
-    offsetsConfirmed
+    !isRequiredOffsetMissing
   const onPlay = (): void => {
     if (doorStatus.isDoorOpen) {
       if (
@@ -523,7 +526,7 @@ function PrepareToRun({
         status: 'ready',
         interactionDisabled: true,
       }
-    } else if (offsetsConfirmed) {
+    } else if (isRequiredOffsetMissing) {
       return {
         detail: t('num_offsets_applied', { num: totalOffsets }),
         status: 'ready',
@@ -783,7 +786,9 @@ export function ProtocolSetup(): JSX.Element {
   const { trackProtocolRunEvent } = useTrackProtocolRunEvent(runId, robotName)
   const robotAnalyticsData = useRobotAnalyticsData(robotName)
 
-  const handleProceedToRunClick = (): void => {
+  const offsetsConfirmed = useSelector(selectAreOffsetsApplied(runId))
+  const { applyOffsets, isApplyingOffsets } = useApplyOffsets(runId)
+  const proceedToRun = (): void => {
     trackEvent({
       name: ANALYTICS_PROTOCOL_PROCEED_TO_RUN,
       properties: { robotSerialNumber },
@@ -794,6 +799,16 @@ export function ProtocolSetup(): JSX.Element {
     })
     play()
   }
+
+  const handleProceedToRunClick = (): Promise<void> => {
+    if (!offsetsConfirmed) {
+      return applyOffsets().then(proceedToRun)
+    } else {
+      proceedToRun()
+      return Promise.resolve()
+    }
+  }
+
   const configBypassHeaterShakerAttachmentConfirmation = useSelector(
     getIsHeaterShakerAttached
   )
@@ -815,9 +830,12 @@ export function ProtocolSetup(): JSX.Element {
   >([])
   // TODO(jh 10-31-24): Refactor the below to utilize useMissingStepsModal.
   const [labwareConfirmed, setLabwareConfirmed] = useState<boolean>(false)
-  const offsetsConfirmed = useSelector(selectAreOffsetsApplied(runId))
+  const isRequiredOffsetMissing = useSelector(
+    selectIsAnyNecessaryDefaultOffsetMissing(runId)
+  )
   const missingSteps = [
     !labwareConfirmed ? t('labware_placement') : null,
+    !offsetsConfirmed ? t('applied_labware_offsets') : null,
   ].filter(s => s != null)
   const {
     confirm: confirmMissingSteps,
@@ -846,7 +864,7 @@ export function ProtocolSetup(): JSX.Element {
         robotName={robotName}
         runRecord={runRecord ?? null}
         labwareConfirmed={labwareConfirmed}
-        offsetsConfirmed={offsetsConfirmed}
+        isRequiredOffsetMissing={isRequiredOffsetMissing}
         isLPCInitializing={lpcLaunchProps.isFlexLPCInitializing}
       />
     ),
@@ -914,6 +932,7 @@ export function ProtocolSetup(): JSX.Element {
               ? confirmAttachment()
               : handleProceedToRunClick()
           }}
+          isRunStarting={isApplyingOffsets}
         />
       ) : null}
       {showHSConfirmationModal ? (

--- a/app/src/redux-resources/runs/hooks/useRequiredSetupStepsInOrder.ts
+++ b/app/src/redux-resources/runs/hooks/useRequiredSetupStepsInOrder.ts
@@ -101,7 +101,7 @@ export function useRequiredSetupStepsInOrder({
         ),
       })
     )
-  }, [runId, keyFor(protocolAnalysis), dispatch])
+  }, [runId, dispatch, keyFor(protocolAnalysis), noLwOffsetsInRun])
   return protocolAnalysis == null
     ? {
         orderedSteps: NO_ANALYSIS_STEPS_IN_ORDER,

--- a/components/src/hooks/useConditionalConfirm.ts
+++ b/components/src/hooks/useConditionalConfirm.ts
@@ -42,6 +42,10 @@ export interface UseConditionalConfirmResult<T extends any[]> {
   cancel: () => unknown
 }
 
+/**
+ * Provides conditional confirmation logic, allowing certain actions to be blocked
+ * until explicitly confirmed.
+ */
 export const useConditionalConfirm = <T extends any[]>(
   handleContinue: (...args: T) => any,
   shouldBlock: boolean
@@ -52,11 +56,17 @@ export const useConditionalConfirm = <T extends any[]>(
     if (shouldBlock && !pendingConfirm) {
       setPendingArgs(confirmArgs)
     } else {
-      // call handleContinue with pending args if we have them
-      const handleContinueArgs =
-        pendingArgs !== null ? pendingArgs : confirmArgs
-      handleContinue(...handleContinueArgs)
-      setPendingArgs(null)
+      const handleContinueArgs = pendingArgs ?? confirmArgs
+      const result = handleContinue(...handleContinueArgs)
+
+      // Check if result is a promise
+      if (result != null && typeof result.then === 'function') {
+        result.finally(() => {
+          setPendingArgs(null)
+        })
+      } else {
+        setPendingArgs(null)
+      }
     }
   }
 


### PR DESCRIPTION
Closes [EXEC-1611](https://opentrons.atlassian.net/browse/EXEC-1611)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Per product, users are experiencing friction when attempting to start a run due to the requirement that offsets must be formally confirmed by opening LPC and clicking "apply offsets." The solution is to bring LPC more in-line with other setup flows: if offsets haven't been formally applied as they were required in 8.4, we show the "you haven't confirmed XYZ modal", which now includes an entry for applying labware offsets. If the user clicks "confirm", we apply the offsets to the run before proceeding to the run.

Note that the "start run" buttons are still disabled if required default offsets are missing.

d4684e6273dbfa2a0e2cbe95c991f8114238af65 - Since we now have several touchpoints for applying offsets to the run, and because design has asked we enforce identical messaging/behavior on the desktop/ODD, let's move the apply offsets logic into its own hook. Note that the desktop "apply offsets" button is never disabled now, and that's an intentional request by design.

530e571e99057e7c4c8d574c78d04b9d317507a8 - Our conditional confirmation utility supports any type of return, which is great, but if the return type is a promise, we shouldn't mark the condition as resolved until the promise resolves.

0e7d6f0fe95864c010504e9b3327d3650fb23484 - The desktop implementation.

50f1cc8482eb3950e1fb0c56fd40a05031bc1d8e - The ODD implementation

<img width="1014" alt="Screenshot 2025-07-09 at 2 27 41 PM" src="https://github.com/user-attachments/assets/ca4e067c-e12e-480a-8ed6-2158b1442b58" />

![Screenshot 2025-07-09 at 2 28 04 PM](https://github.com/user-attachments/assets/b917161b-6a32-4c18-a273-d2e573d870b9)
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- Ran LPC through several entry points, verifying network logs to ensure that offsets are applied before starting the run.
- Ensured the "you haven't confirmed" copy is correct and reasonable when applying offsets.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Users no longer have to click into LPC to apply offsets before starting a run.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
mediumish - this touches protocol setup code, which historically has proven to lead to interesting interactions.
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[EXEC-1611]: https://opentrons.atlassian.net/browse/EXEC-1611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ