### PR TITLE
Chore: mergeback of Labware-library 3.4.0 release branch into edge

### DIFF
--- a/shared-data/labware/definitions/2/ev_resin_tips_flex_96_labware/1.json
+++ b/shared-data/labware/definitions/2/ev_resin_tips_flex_96_labware/1.json
@@ -14,7 +14,7 @@
     ["A12", "B12", "C12", "D12", "E12", "F12", "G12", "H12"]
   ],
   "brand": {
-    "brand": "opentrons",
+    "brand": "Opentrons",
     "brandId": ["999-00254"],
     "links": [
       "https://opentrons.com/products/opentrons-flex-adapter-set-for-3rd-party-evotips/"

--- a/shared-data/labware/definitions/2/ibidi_96_square_well_plate_300ul/1.json
+++ b/shared-data/labware/definitions/2/ibidi_96_square_well_plate_300ul/1.json
@@ -1,5 +1,5 @@
 {
-  "brand": { "brand": "ibidi ", "brandId": ["89626", "89621"] },
+  "brand": { "brand": "ibidi", "brandId": ["89626", "89621"] },
   "wells": {
     "A1": {
       "x": 14.38,


### PR DESCRIPTION
# Overview

LL 3.4.0 is now live, thanks to @skowalski08. Just doing the mergeback now so release tags are in `edge`