### PR TITLE
fix(opentons-ai-client): keep settings button in settings page

### DIFF
--- a/opentrons-ai-client/src/molecules/Header/index.tsx
+++ b/opentrons-ai-client/src/molecules/Header/index.tsx
@@ -99,7 +99,7 @@ export function Header({ isExitButton = false }: HeaderProps): JSX.Element {
           <LogoutOrExitButton onClick={handleLoginOrExitClick}>
             {isExitButton ? t('exit') : t('logout')}
           </LogoutOrExitButton>
-          {location.pathname === '/' && (
+          {(location.pathname === '/' || location.pathname === '/settings') && (
             <Box marginLeft={SPACING.spacing16}>
               <SettingsButton onClick={handleSettingsClick} />
             </Box>


### PR DESCRIPTION
# Overview

Closes 2055

Keep settings button in the settings page when we transition from the landing page.

**Before**
<img width="1448" alt="image" src="https://github.com/user-attachments/assets/396a7c83-26ba-48d3-9015-a5a38b39e225" />


**After**

<img width="1548" alt="image" src="https://github.com/user-attachments/assets/254f0b93-3bc1-4bb0-b6bf-152ec0daacf3" />


## Test Plan and Hands on Testing
CI

## Review requests
Confirm Settings icon is there at the settings page

## Risk assessment

Low