### PR TITLE
fix(app): Fix module positioning in certain deck maps

### DIFF
--- a/app/src/organisms/ErrorRecoveryFlows/shared/TwoColLwInfoAndDeck.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/TwoColLwInfoAndDeck.tsx
@@ -149,6 +149,8 @@ export function TwoColLwInfoAndDeck(
                     moduleDef,
                     nestedLabwareDef,
                     nestedLabwareId,
+                    targetDeckId,
+                    targetSlotId,
                   }) => (
                     <Module
                       key={moduleId}
@@ -156,6 +158,8 @@ export function TwoColLwInfoAndDeck(
                       x={x}
                       y={y}
                       orientation={inferModuleOrientationFromXCoordinate(x)}
+                      targetDeckId={targetDeckId}
+                      targetSlotId={targetSlotId}
                     >
                       {nestedLabwareDef != null &&
                       nestedLabwareId !== failedLwId ? (

--- a/app/src/organisms/InterventionModal/MoveLabwareInterventionContent.tsx
+++ b/app/src/organisms/InterventionModal/MoveLabwareInterventionContent.tsx
@@ -210,6 +210,8 @@ export function MoveLabwareInterventionContent({
                       moduleDef,
                       nestedLabwareDef,
                       nestedLabwareId,
+                      targetDeckId,
+                      targetSlotId,
                     }) => (
                       <Module
                         key={moduleId}
@@ -217,6 +219,8 @@ export function MoveLabwareInterventionContent({
                         x={x}
                         y={y}
                         orientation={inferModuleOrientationFromXCoordinate(x)}
+                        targetDeckId={targetDeckId}
+                        targetSlotId={targetSlotId}
                       >
                         {nestedLabwareDef != null &&
                         nestedLabwareId !== command.params.labwareId ? (

--- a/app/src/organisms/InterventionModal/__tests__/utils.test.ts
+++ b/app/src/organisms/InterventionModal/__tests__/utils.test.ts
@@ -200,7 +200,7 @@ describe('getRunLabwareRenderInfo', () => {
   })
 })
 
-describe('getCurrentRunModuleRenderInfo', () => {
+describe('getRunModuleRenderInfo', () => {
   it('returns an empty array if there is no loaded module for the run', () => {
     const res = getRunModuleRenderInfo({ modules: [] } as any, {} as any, {})
     expect(res).toBeInstanceOf(Array)
@@ -219,6 +219,8 @@ describe('getCurrentRunModuleRenderInfo', () => {
     expect(moduleInfo.y).toEqual(0)
     expect(moduleInfo.moduleDef.moduleType).toEqual('heaterShakerModuleType')
     expect(moduleInfo.moduleId).toEqual('mockModuleID')
+    expect(moduleInfo.targetDeckId).toEqual(ot2DeckDefV5.otId)
+    expect(moduleInfo.targetSlotId).toEqual('3') // taken from mockRunData
     expect(moduleInfo.nestedLabwareDef).not.toEqual(null)
     expect(moduleInfo.nestedLabwareId).toEqual('mockLabwareID')
   })

--- a/app/src/organisms/InterventionModal/utils/getRunModuleRenderInfo.ts
+++ b/app/src/organisms/InterventionModal/utils/getRunModuleRenderInfo.ts
@@ -4,7 +4,9 @@ import {
   SPAN7_8_10_11_SLOT,
 } from '@opentrons/shared-data'
 
+import type { ComponentProps } from 'react'
 import type { RunData } from '@opentrons/api-client'
+import type { Module } from '@opentrons/components'
 import type {
   DeckDefinition,
   LabwareDefinition,
@@ -19,6 +21,8 @@ export interface RunModuleInfo {
   moduleDef: ModuleDefinition
   nestedLabwareDef: LabwareDefinition | null
   nestedLabwareId: string | null
+  targetDeckId: ComponentProps<typeof Module>['targetDeckId']
+  targetSlotId: ComponentProps<typeof Module>['targetSlotId']
 }
 
 export function getRunModuleRenderInfo(
@@ -52,6 +56,8 @@ export function getRunModuleRenderInfo(
           moduleDef,
           nestedLabwareDef,
           nestedLabwareId: nestedLabware?.id ?? null,
+          targetDeckId: deckDef.otId,
+          targetSlotId: slotName,
         },
       ]
     }, [])


### PR DESCRIPTION
## Overview

Closes EXEC-1645.

## Details

The `<Module>` component knows how to offset itself so it's positioned correctly relative to the deck, but in order do that, we need to remember to pass it the `targetDeckId` and `targetSlotId` props, which are optional. A util feeding a couple of deck maps was forgetting to do that, so `<Module>` fell back using default, slot-nonspecific positioning. This was too subtle of an error to be noticeable for most modules, but it is noticeable for at least the Thermocycler.

## Test Plan and Hands on Testing

* [x] In the "Move labware" modal, the Thermocycler is now correctly positioned slightly to the left of the column of deck slots.

<img width="751" alt="Screenshot 2025-07-09 at 7 25 58 PM" src="https://github.com/user-attachments/assets/c5aad717-9dcb-425b-86d6-053c934f9d52" />


## Review requests

Anything else I should be looking at that's at risk of having the same mistake? I know there's `getStackedItemsOnStartingDeck()`, but I haven't broken into that yet.

[Edit: Same problem on the protocol setup page, I think.]

## Risk assessment

Low, easy enough to test.