### PR TITLE
fix(components): Fix module positioning in more deck maps

### DIFF
--- a/components/src/hardware-sim/BaseDeck/BaseDeck.tsx
+++ b/components/src/hardware-sim/BaseDeck/BaseDeck.tsx
@@ -303,6 +303,8 @@ export function BaseDeck(props: BaseDeckProps): JSX.Element {
                   slotPosition[0]
                 )}
                 innerProps={innerProps}
+                targetDeckId={deckDef.otId}
+                targetSlotId={moduleLocation.slotName}
               >
                 {nestedLabwareDef != null ? (
                   <g cursor={onLabwareClick != null ? 'pointer' : ''}>
@@ -361,6 +363,8 @@ export function BaseDeck(props: BaseDeckProps): JSX.Element {
                     slotPosition[0]
                   )}
                   innerProps={innerProps}
+                  targetDeckId={deckDef.otId}
+                  targetSlotId={moduleLocation.slotName}
                 >
                   {nestedLabwareDef != null ? (
                     <g

--- a/components/src/hardware-sim/Module/index.tsx
+++ b/components/src/hardware-sim/Module/index.tsx
@@ -52,7 +52,16 @@ interface Props {
     | {}
   statusInfo?: ReactNode // contents of small status rectangle, not displayed if absent
   children?: ReactNode // contents to be rendered on top of the labware mating surface of the module
+
+  /**
+   * Used for applying slot-specific positioning adjustments.
+   * Supply this if you're rendering the module on a deck for correct positioning.
+   */
   targetSlotId?: string
+  /**
+   * Used for applying slot-specific positioning adjustments.
+   * Supply this if you're rendering the module on a deck for correct positioning.
+   */
   targetDeckId?: string
 }
 

--- a/components/src/hardware-sim/Module/index.tsx
+++ b/components/src/hardware-sim/Module/index.tsx
@@ -5,7 +5,6 @@ import {
   HEATERSHAKER_MODULE_TYPE,
   MAGNETIC_BLOCK_TYPE,
   MAGNETIC_MODULE_TYPE,
-  OT2_STANDARD_DECKID,
   TEMPERATURE_MODULE_TYPE,
   THERMOCYCLER_MODULE_TYPE,
 } from '@opentrons/shared-data'
@@ -55,14 +54,14 @@ interface Props {
 
   /**
    * Used for applying slot-specific positioning adjustments.
-   * Supply this if you're rendering the module on a deck for correct positioning.
+   * If you're rendering the module on a deck, supply this for correct positioning.
    */
-  targetSlotId?: string
+  targetSlotId: string | null
   /**
    * Used for applying slot-specific positioning adjustments.
-   * Supply this if you're rendering the module on a deck for correct positioning.
+   * If you're rendering the module on a deck, supply this for correct positioning.
    */
-  targetDeckId?: string
+  targetDeckId: string | null
 }
 
 const statusInfoWrapperProps = {
@@ -89,8 +88,9 @@ export const Module = (props: Props): JSX.Element => {
     statusInfo,
     children,
     targetSlotId,
-    targetDeckId = OT2_STANDARD_DECKID,
+    targetDeckId,
   } = props
+
   const moduleType = getModuleType(def.model)
 
   const { x: labwareOffsetX, y: labwareOffsetY } = def.labwareOffset
@@ -119,19 +119,16 @@ export const Module = (props: Props): JSX.Element => {
   let nestedLabwareOffsetY = labwareOffsetY
 
   // additional transforms to apply to vectors in certain deck/slot combinations
-  const transformsForDeckBySlot = def?.slotTransforms?.[targetDeckId]
+  const transformsForDeckBySlot =
+    (targetDeckId != null ? def?.slotTransforms?.[targetDeckId] : null) ?? {}
   const slotTransformsForDeckSlot =
-    targetSlotId != null &&
-    transformsForDeckBySlot != null &&
-    targetSlotId in transformsForDeckBySlot
-      ? transformsForDeckBySlot[targetSlotId]
-      : null
-  const deckSpecificTransforms = slotTransformsForDeckSlot ?? {}
-  if (deckSpecificTransforms?.cornerOffsetFromSlot != null) {
+    (targetSlotId != null ? transformsForDeckBySlot[targetSlotId] : null) ?? {}
+
+  if (slotTransformsForDeckSlot.cornerOffsetFromSlot != null) {
     const [
       [slotTranslateX],
       [slotTranslateY],
-    ] = multiplyMatrices(deckSpecificTransforms.cornerOffsetFromSlot, [
+    ] = multiplyMatrices(slotTransformsForDeckSlot.cornerOffsetFromSlot, [
       [translateX],
       [translateY],
       [translateZ],
@@ -139,11 +136,11 @@ export const Module = (props: Props): JSX.Element => {
     ])
     offsetTransform = `translate(${slotTranslateX}, ${slotTranslateY})`
   }
-  if (deckSpecificTransforms?.labwareOffset != null) {
+  if (slotTransformsForDeckSlot.labwareOffset != null) {
     const [
       [slotLabwareOffsetX],
       [slotLabwareOffsetY],
-    ] = multiplyMatrices(deckSpecificTransforms.labwareOffset, [
+    ] = multiplyMatrices(slotTransformsForDeckSlot.labwareOffset, [
       [labwareOffsetX],
       [labwareOffsetY],
       [1],

--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupDetails.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupDetails.tsx
@@ -591,9 +591,6 @@ export function DeckSetupDetails(props: DeckSetupDetailsProps): JSX.Element {
         deckDef={deckDef}
         robotType={robotType}
         slotPosition={slotPosition}
-        // todo(mm, 2025-07-10): In practice, can selectedZoomInSlot actually be nullish
-        // if we've reached this point? If so, what should we do about that?
-        slotId={selectedZoomInSlot ?? ''}
       />
 
       {/* slot overflow menu */}

--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupDetails.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupDetails.tsx
@@ -591,6 +591,9 @@ export function DeckSetupDetails(props: DeckSetupDetailsProps): JSX.Element {
         deckDef={deckDef}
         robotType={robotType}
         slotPosition={slotPosition}
+        // todo(mm, 2025-07-10): In practice, can selectedZoomInSlot actually be nullish
+        // if we've reached this point? If so, what should we do about that?
+        slotId={selectedZoomInSlot ?? ''}
       />
 
       {/* slot overflow menu */}

--- a/protocol-designer/src/pages/Designer/DeckSetup/SelectedItems.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/SelectedItems.tsx
@@ -103,6 +103,12 @@ export const SelectedItems = (props: SelectedItemsProps): JSX.Element => {
       slotPosition != null &&
       orientation != null ? (
         <>
+          {/*
+          todo(mm, 2025-07-10): This <Module> and <ModuleLabel> positioning is not
+          quite right, most obviously for the Thermocycler on a Flex. We aren't
+          passing a targetSlotId and targetDeckId down to <Module>, which means
+          it isn't applying slot-specific adjustments.
+          */}
           <Module
             key={`${selectedModuleModel}_${selectedSlot.slot}_selected`}
             x={slotPosition[0]}

--- a/protocol-designer/src/pages/Designer/DeckSetup/SelectedItems.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/SelectedItems.tsx
@@ -115,6 +115,8 @@ export const SelectedItems = (props: SelectedItemsProps): JSX.Element => {
             y={slotPosition[1]}
             def={getModuleDef(selectedModuleModel)}
             orientation={orientation}
+            targetDeckId={null}
+            targetSlotId={null}
           >
             <>
               <SelectedModuleLabwareRender

--- a/protocol-designer/src/pages/Designer/DeckSetup/SelectedItems.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/SelectedItems.tsx
@@ -20,18 +20,16 @@ import type { DeckLabelProps } from '@opentrons/components'
 import type {
   CoordinateTuple,
   DeckDefinition,
-  DeckSlotId,
   RobotType,
 } from '@opentrons/shared-data'
 
 interface SelectedItemsProps {
   deckDef: DeckDefinition
   robotType: RobotType
-  slotId: DeckSlotId
   slotPosition: CoordinateTuple | null
 }
 export const SelectedItems = (props: SelectedItemsProps): JSX.Element => {
-  const { deckDef, robotType, slotId, slotPosition } = props
+  const { deckDef, robotType, slotPosition } = props
   const selectedSlotInfo = useSelector(selectors.getZoomedInSlotInfo)
   const {
     selectedSlot,
@@ -111,8 +109,6 @@ export const SelectedItems = (props: SelectedItemsProps): JSX.Element => {
             y={slotPosition[1]}
             def={getModuleDef(selectedModuleModel)}
             orientation={orientation}
-            targetSlotId={slotId}
-            targetDeckId={deckDef.otId}
           >
             <>
               <SelectedModuleLabwareRender

--- a/protocol-designer/src/pages/Designer/DeckSetup/SelectedItems.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/SelectedItems.tsx
@@ -20,16 +20,18 @@ import type { DeckLabelProps } from '@opentrons/components'
 import type {
   CoordinateTuple,
   DeckDefinition,
+  DeckSlotId,
   RobotType,
 } from '@opentrons/shared-data'
 
 interface SelectedItemsProps {
   deckDef: DeckDefinition
   robotType: RobotType
+  slotId: DeckSlotId
   slotPosition: CoordinateTuple | null
 }
 export const SelectedItems = (props: SelectedItemsProps): JSX.Element => {
-  const { deckDef, robotType, slotPosition } = props
+  const { deckDef, robotType, slotId, slotPosition } = props
   const selectedSlotInfo = useSelector(selectors.getZoomedInSlotInfo)
   const {
     selectedSlot,
@@ -109,6 +111,8 @@ export const SelectedItems = (props: SelectedItemsProps): JSX.Element => {
             y={slotPosition[1]}
             def={getModuleDef(selectedModuleModel)}
             orientation={orientation}
+            targetSlotId={slotId}
+            targetDeckId={deckDef.otId}
           >
             <>
               <SelectedModuleLabwareRender

--- a/shared-data/js/types.ts
+++ b/shared-data/js/types.ts
@@ -577,11 +577,15 @@ export interface ModuleDefinition {
 export type AffineTransformMatrix = number[][]
 
 export interface SlotTransforms {
-  [deckOtId: string]: {
-    [slotId: string]: {
-      [transformKey in keyof ModuleDefinition]?: AffineTransformMatrix
-    }
-  }
+  [deckOtId: string]:
+    | undefined
+    | {
+        [slotId: string]:
+          | undefined
+          | {
+              [transformKey in keyof ModuleDefinition]?: AffineTransformMatrix
+            }
+      }
 }
 
 export type ModuleOrientation = 'left' | 'right'


### PR DESCRIPTION
## Overview

Exactly the same thing as #18871 / EXEC-1645, just in different places.

## Test Plan and Hands on Testing

* [x] Checked the protocol details page to make sure its deck map has the Thermocycler positioned correctly now.
  
  <img width="1024" height="796" alt="Screenshot 2025-07-10 at 10 56 20 AM" src="https://github.com/user-attachments/assets/606bda77-ac7b-46f6-aee6-24ee23c8e9fe" />

* [x] Audited all uses of `<Module>` to see if there are any other places I missed. Found one in protocol-designer, see comments.

## Review requests

See comments.

## Risk assessment

Medium. Fixing the positioning of `<Module>` means it's possible that things that were previously aligned to the incorrect positioning of `<Module>` will now be misaligned and look wrong.
