### PR TITLE
refactor(app): Update `applyOffsets` analytic

### DIFF
--- a/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabwarePositionCheck/FlexSetupLPC/LPCSetupFlexBtns.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabwarePositionCheck/FlexSetupLPC/LPCSetupFlexBtns.tsx
@@ -39,10 +39,6 @@ export function LPCSetupFlexBtns({
   hasMissingCalForFlex,
 }: LPCSetupFlexBtnsProps): JSX.Element {
   const { t } = useTranslation('protocol_setup')
-  const { reportApplyOffsets } = useLPCAnalytics({
-    runId,
-    robotType: FLEX_ROBOT_TYPE,
-  })
   const lpcDisabledReason = useLPCDisabledReason({
     robotName,
     runId,
@@ -99,7 +95,6 @@ export function LPCSetupFlexBtns({
   const onApplyOffsets = (): void => {
     void applyOffsets().then(() => {
       setOffsetsConfirmed(true)
-      reportApplyOffsets()
     })
   }
 

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabwarePositionCheck/FlexSetupLPC/LPCSetupFlexBtns.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabwarePositionCheck/FlexSetupLPC/LPCSetupFlexBtns.tsx
@@ -11,12 +11,8 @@ import {
   TOOLTIP_BOTTOM,
   useHoverTooltip,
 } from '@opentrons/components'
-import { FLEX_ROBOT_TYPE } from '@opentrons/shared-data'
 
-import {
-  useApplyOffsets,
-  useLPCAnalytics,
-} from '/app/organisms/LabwarePositionCheck/LPCFlows'
+import { useApplyOffsets } from '/app/organisms/LabwarePositionCheck/LPCFlows'
 import {
   selectIsAnyNecessaryDefaultOffsetMissing,
   selectTotalCountNonHardCodedLSOffsets,

--- a/app/src/organisms/LabwarePositionCheck/LPCFlows/useApplyOffsets.ts
+++ b/app/src/organisms/LabwarePositionCheck/LPCFlows/useApplyOffsets.ts
@@ -46,7 +46,7 @@ export function useApplyOffsets(runId: string): ApplyOffsetsResult {
         lwOffsetsForRun.map(data => createLabwareOffset({ runId, data }))
       )
         .then(() => {
-          reportApplyOffsets()
+          reportApplyOffsets(lwOffsetsForRun)
         })
         .catch(error => {
           makeSnackbar(t('failed_to_apply_offsets') as string)

--- a/app/src/organisms/LabwarePositionCheck/LPCFlows/useApplyOffsets.ts
+++ b/app/src/organisms/LabwarePositionCheck/LPCFlows/useApplyOffsets.ts
@@ -3,7 +3,9 @@ import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 
 import { useAddLabwareOffsetToRunMutation } from '@opentrons/react-api-client'
+import { FLEX_ROBOT_TYPE } from '@opentrons/shared-data'
 
+import { useLPCAnalytics } from '/app/organisms/LabwarePositionCheck'
 import { useToaster } from '/app/organisms/ToasterOven'
 import {
   selectIsAnyNecessaryDefaultOffsetMissing,
@@ -23,6 +25,10 @@ export function useApplyOffsets(runId: string): ApplyOffsetsResult {
   )
   const { makeSnackbar } = useToaster()
   const { createLabwareOffset } = useAddLabwareOffsetToRunMutation()
+  const { reportApplyOffsets } = useLPCAnalytics({
+    runId,
+    robotType: FLEX_ROBOT_TYPE,
+  })
   const [isApplyingOffsets, setIsApplyingOffsets] = useState(false)
 
   const applyOffsets = (): Promise<void> => {
@@ -39,6 +45,9 @@ export function useApplyOffsets(runId: string): ApplyOffsetsResult {
       return Promise.all(
         lwOffsetsForRun.map(data => createLabwareOffset({ runId, data }))
       )
+        .then(() => {
+          reportApplyOffsets()
+        })
         .catch(error => {
           makeSnackbar(t('failed_to_apply_offsets') as string)
           throw error // Re-throw to allow chaining

--- a/app/src/organisms/LabwarePositionCheck/LPCFlows/useLPCAnalytics.ts
+++ b/app/src/organisms/LabwarePositionCheck/LPCFlows/useLPCAnalytics.ts
@@ -13,9 +13,11 @@ import {
 } from '/app/redux/analytics'
 
 import type {
+  LabwareOffsetCreateData,
   LegacyLabwareOffsetLocation,
   StoredLabwareOffset,
 } from '@opentrons/api-client'
+import type { LabwareOffsetLocationSequenceComponent } from '@opentrons/api-client/lib'
 import type {
   AddressableAreaName,
   LocationSequenceComponent,
@@ -48,7 +50,7 @@ export interface UseLPCAnalyticsResult {
   /* Report when a user launches LPC, generating a wizard session id. */
   reportLaunchLpcWizard: () => void
   /* Report when a user clicks the 'apply offsets' button. Effectively a Flex only event. */
-  reportApplyOffsets: () => void
+  reportApplyOffsets: (data: LabwareOffsetCreateData[]) => void
   /* Report all the modified offsets when a user saves to the database. Flex only. */
   reportSaveOffset: (
     params: [StoredLabwareOffset[], StoredLabwareOffset[]]
@@ -85,16 +87,21 @@ export function useLPCAnalytics({
   }
 
   // Offsets are applied outside the LPC wizard and therefore not tied to a wizard session.
-  const reportApplyOffsets = (): void => {
+  const reportApplyOffsets = (data: LabwareOffsetCreateData[]): void => {
     if (robotType === OT2_ROBOT_TYPE) {
       console.error('OT2 robot type should not report apply offsets.')
     } else {
-      doTrackEvent({
-        name: ANALYTICS_LPC_APPLY_OFFSETS,
-        properties: {
-          robotType,
-          runSession: runId,
-        },
+      data.forEach(offset => {
+        doTrackEvent({
+          name: ANALYTICS_LPC_APPLY_OFFSETS,
+          properties: {
+            robotType,
+            runSession: runId,
+            offsetKind: getOffsetKindFrom(offset.locationSequence),
+            slot: getSlotNameFrom(offset.locationSequence),
+            uri: offset.definitionUri,
+          },
+        })
       })
     }
   }
@@ -108,26 +115,6 @@ export function useLPCAnalytics({
       )
     } else {
       const sendSaveOffsetEvent = (offset: StoredLabwareOffset): void => {
-        const offsetKind =
-          offset.locationSequence === ANY_LOCATION
-            ? 'default'
-            : 'appliedLocation'
-
-        const slot = offset.locationSequence[offset.locationSequence.length - 1]
-
-        const slotName = ((): string | null => {
-          if (typeof slot === 'string') {
-            return null
-          } else if (slot.kind === 'onAddressableArea') {
-            return slot.addressableAreaName
-          }
-          // The last location sequence component in a LabwareOffsetLocationSequence is
-          // always the addressable area, but we handle unexpected input to be safe.
-          else {
-            return null
-          }
-        })()
-
         // Transform the locationSequence into a data structure digestible by Mixpanel.
         const locationDetails = ((): LPCLocationSequenceAnalytic | null => {
           if (offset.locationSequence === 'anyLocation') {
@@ -169,9 +156,9 @@ export function useLPCAnalytics({
             wizardSession: lpcWizardSessionId,
             uri: offset.definitionUri,
             locationDetails,
-            slot: slotName,
+            slot: getSlotNameFrom(offset.locationSequence),
             vector: offset.vector,
-            offsetKind,
+            offsetKind: getOffsetKindFrom(offset.locationSequence),
           },
         })
       }
@@ -227,4 +214,31 @@ export function useLPCAnalytics({
     reportSaveOffsetToRunRecord,
     reportOffsetSourceResolution,
   }
+}
+
+function getSlotNameFrom(
+  locationSequence:
+    | LabwareOffsetLocationSequenceComponent[]
+    | typeof ANY_LOCATION
+): string | null {
+  const slot = locationSequence[locationSequence.length - 1]
+
+  if (typeof slot === 'string') {
+    return null
+  } else if (slot.kind === 'onAddressableArea') {
+    return slot.addressableAreaName
+  }
+  // The last location sequence component in a LabwareOffsetLocationSequence is
+  // always the addressable area, but we handle unexpected input to be safe.
+  else {
+    return null
+  }
+}
+
+function getOffsetKindFrom(
+  locationSequence:
+    | LabwareOffsetLocationSequenceComponent[]
+    | typeof ANY_LOCATION
+): 'default' | 'appliedLocation' {
+  return locationSequence === ANY_LOCATION ? 'default' : 'appliedLocation'
 }

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupOffsets/SetupOffsetsHeader.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupOffsets/SetupOffsetsHeader.tsx
@@ -8,14 +8,10 @@ import {
   JUSTIFY_SPACE_BETWEEN,
   SPACING,
 } from '@opentrons/components'
-import { FLEX_ROBOT_TYPE } from '@opentrons/shared-data'
 
 import { SmallButton } from '/app/atoms/buttons'
 import { ODDBackButton } from '/app/molecules/ODDBackButton'
-import {
-  useApplyOffsets,
-  useLPCAnalytics,
-} from '/app/organisms/LabwarePositionCheck'
+import { useApplyOffsets } from '/app/organisms/LabwarePositionCheck'
 import {
   appliedOffsetsToRun,
   selectIsAnyNecessaryDefaultOffsetMissing,
@@ -31,10 +27,6 @@ export function SetupOffsetsHeader({
 }: ProtocolSetupOffsetsProps): JSX.Element {
   const { t } = useTranslation('protocol_setup')
   const dispatch = useDispatch()
-  const { reportApplyOffsets } = useLPCAnalytics({
-    runId,
-    robotType: FLEX_ROBOT_TYPE,
-  })
   const isNecessaryDefaultOffsetMissing = useSelector(
     selectIsAnyNecessaryDefaultOffsetMissing(runId)
   )
@@ -44,7 +36,6 @@ export function SetupOffsetsHeader({
   const onApplyOffsets = (): void => {
     void applyOffsets().then(() => {
       dispatch(appliedOffsetsToRun(runId))
-      reportApplyOffsets()
       updateWithRunId(runId)
       setSetupScreen('prepare to run')
     })


### PR DESCRIPTION
Closes [EXEC-1646](https://opentrons.atlassian.net/browse/EXEC-1646)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

For 8.6, product would like to be able to see frequency of default offset use vs. applied location offsets when a user applies offsets. We update the `applyOffsets` to enable this behavior. Note that this will send a separate event for every labware involved a run, but Product has noted that is ok (and preferred).

7ef144baf86f0ac55fb1f55d05de7636cb3bb02c - Add the `applyOffsets` analytic event directly to the new `useApplyOffsets` hook to keep things DRY. This also enables sending this event when people do not directly interact with the "apply offsets" button, which will be possible in 8.6.

c4951f88522685cf3dc75ba05a0c735470f986e5 - Do the event. Created a few utilities in the process since some of the data transformations are shared between events.

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- Ran LPC on a robot and confirmed the event is firing.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
effectively none, just moving around analytics
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[EXEC-1646]: https://opentrons.atlassian.net/browse/EXEC-1646?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ