### PR TITLE
fix(package-testing) path to protocol changed

### DIFF
--- a/.github/workflows/api-test-lint-deploy.yaml
+++ b/.github/workflows/api-test-lint-deploy.yaml
@@ -17,6 +17,7 @@ on:
       - '.github/workflows/api-test-lint-deploy.yaml'
       - '.github/actions/python/**'
       - '.github/workflows/utils.js'
+      - 'package-testing/**''
   push:
     paths:
       - 'api/**'

--- a/.github/workflows/api-test-lint-deploy.yaml
+++ b/.github/workflows/api-test-lint-deploy.yaml
@@ -17,7 +17,7 @@ on:
       - '.github/workflows/api-test-lint-deploy.yaml'
       - '.github/actions/python/**'
       - '.github/workflows/utils.js'
-      - 'package-testing/**''
+      - 'package-testing/**'
   push:
     paths:
       - 'api/**'

--- a/package-testing/run_tests.py
+++ b/package-testing/run_tests.py
@@ -50,7 +50,7 @@ tests: List[Union[TestHelp, TestSimulate]] = [
     TestSimulate(
         test_key="OT2_v6PD_expect_error",
         test_helper="simulate",
-        protocol_path="../analyses-snapshot-testing/files/protocols/OT2_X_v6_P300M_P20S_HS_MM_TM_TC_AllMods.json",
+        protocol_path="../analyses-snapshot-testing/files/protocols/protocol_designer/OT2_X_v6_P300M_P20S_HS_MM_TM_TC_AllMods.json",
         expected_return_code="1",
     ),
 ]


### PR DESCRIPTION
## Overview

I forgot that the package-testing relies on the protocols in `analyses-snapshot-testing/files/protocols/*` and did not update this path when I reorganized protocol files.