### PR TITLE
refactor(api): clean up liquid class transfer code

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -1266,81 +1266,22 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         else:
             target_destinations = dest
 
-        max_volume = min(
-            self.get_max_volume(),
-            self._engine_client.state.geometry.get_nominal_tip_geometry(
-                pipette_id=self.pipette_id,
-                labware_id=tip_racks[0][1].labware_id,
-                well_name=None,
-            ).volume,
-        )
+        working_volume = self.get_working_volume_for_tip_rack(tip_racks[0][1])
 
-        aspirate_air_gap_by_volume = transfer_props.aspirate.retract.air_gap_by_volume
         source_dest_per_volume_step = (
-            tx_commons.expand_for_volume_constraints_for_liquid_classes(
+            tx_commons.get_sources_and_destinations_for_liquid_classes(
                 volumes=[volume for _ in range(len(source))],
+                max_volume=working_volume,
                 targets=zip(source, target_destinations),
-                max_volume=max_volume,
-                air_gap=aspirate_air_gap_by_volume,
+                transfer_properties=transfer_props,
             )
         )
 
         last_tip = last_tip_location
-
-        def _drop_tip() -> None:
-            if return_tip:
-                assert last_tip is not None
-                _, tip_well = last_tip
-                self.drop_tip(
-                    location=None,
-                    well_core=tip_well,
-                    home_after=False,
-                    alternate_drop_location=False,
-                )
-            elif isinstance(trash_location, (TrashBin, WasteChute)):
-                self.drop_tip_in_disposal_location(
-                    disposal_location=trash_location,
-                    home_after=False,
-                    alternate_tip_drop=True,
-                )
-            elif isinstance(trash_location, Location):
-                self.drop_tip(
-                    location=trash_location,
-                    well_core=trash_location.labware.as_well()._core,  # type: ignore[arg-type]
-                    home_after=False,
-                    alternate_drop_location=True,
-                )
-
-        def _pick_up_tip() -> Tuple[Location, WellCore]:
-            next_tip = self.get_next_tip(
-                tip_racks=[core for loc, core in tip_racks],
-                starting_well=starting_tip,
-            )
-            if next_tip is None:
-                raise RuntimeError(
-                    f"No tip available among the tipracks assigned for {self.get_pipette_name()}:"
-                    f" {[f'{tip_rack[1].get_display_name()} in {tip_rack[1].get_deck_slot()}' for tip_rack in tip_racks]}"
-                )
-            (
-                tiprack_loc,
-                tiprack_uri,
-                tip_well,
-            ) = self._get_location_and_well_core_from_next_tip_info(next_tip, tip_racks)
-            if tiprack_uri != tiprack_uri_for_transfer_props:
-                raise RuntimeError(
-                    f"Tiprack {tiprack_uri} does not match the tiprack designated "
-                    f"for this transfer- {tiprack_uri_for_transfer_props}."
-                )
-            self.pick_up_tip(
-                location=tiprack_loc,
-                well_core=tip_well,
-                presses=None,
-                increment=None,
-            )
-            return tiprack_loc, tip_well
-
         if new_tip == TransferTipPolicyV2.ONCE:
-            last_tip = _pick_up_tip()
+            last_tip = self._pick_up_tip_for_liquid_class(
+                tip_racks, starting_tip, tiprack_uri_for_transfer_props
+            )
 
         prev_src: Optional[Tuple[Location, WellCore]] = None
         prev_dest: Optional[
@@ -1377,8 +1318,12 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                 )
             ):
                 if prev_src is not None and prev_dest is not None:
-                    _drop_tip()
-                last_tip = _pick_up_tip()
+                    self._drop_tip_for_liquid_class(
+                        trash_location, last_tip, return_tip
+                    )
+                last_tip = self._pick_up_tip_for_liquid_class(
+                    tip_racks, starting_tip, tiprack_uri_for_transfer_props
+                )
                 post_disp_tip_contents = [
                     tx_comps_executor.LiquidAndAirGapPair(
                         liquid=0,
@@ -1408,7 +1353,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             prev_dest = step_destination
 
         if not keep_last_tip:
-            _drop_tip()
+            self._drop_tip_for_liquid_class(trash_location, last_tip, return_tip)
             last_tip = None
 
         return last_tip
@@ -1477,14 +1422,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         ]
 
         tiprack_uri_for_transfer_props = tip_racks[0][1].get_uri()
-        working_volume = min(
-            self.get_max_volume(),
-            self._engine_client.state.geometry.get_nominal_tip_geometry(
-                pipette_id=self.pipette_id,
-                labware_id=tip_racks[0][1].labware_id,
-                well_name=None,
-            ).volume,
-        )
+        working_volume = self.get_working_volume_for_tip_rack(tip_racks[0][1])
 
         try:
             transfer_props = liquid_class.get_for(
@@ -1541,80 +1479,23 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             tiprack_uri=tiprack_uri_for_transfer_props,
         )
 
-        aspirate_air_gap_by_volume = transfer_props.aspirate.retract.air_gap_by_volume
-        disposal_vol_by_volume = transfer_props.multi_dispense.disposal_by_volume
-        conditioning_vol_by_volume = (
-            transfer_props.multi_dispense.conditioning_by_volume
-        )
         # This will return a generator that provides pairs of destination well and
         # the volume to dispense into it
         dest_per_volume_step = (
-            tx_commons.expand_for_volume_constraints_for_liquid_classes(
+            tx_commons.get_sources_and_destinations_for_liquid_classes(
                 volumes=[volume for _ in range(len(dest))],
-                targets=dest,
                 max_volume=working_volume,
-                air_gap=aspirate_air_gap_by_volume,
-                disposal_vol=disposal_vol_by_volume,
-                conditioning_vol=conditioning_vol_by_volume,
+                targets=dest,
+                transfer_properties=transfer_props,
+                is_multi_dispense=True,
             )
         )
 
         last_tip = last_tip_location
-
-        def _drop_tip() -> None:
-            if return_tip:
-                assert last_tip is not None
-                _, tip_well = last_tip
-                self.drop_tip(
-                    location=None,
-                    well_core=tip_well,
-                    home_after=False,
-                    alternate_drop_location=False,
-                )
-            elif isinstance(trash_location, (TrashBin, WasteChute)):
-                self.drop_tip_in_disposal_location(
-                    disposal_location=trash_location,
-                    home_after=False,
-                    alternate_tip_drop=True,
-                )
-            elif isinstance(trash_location, Location):
-                self.drop_tip(
-                    location=trash_location,
-                    well_core=trash_location.labware.as_well()._core,  # type: ignore[arg-type]
-                    home_after=False,
-                    alternate_drop_location=True,
-                )
-
-        def _pick_up_tip() -> Tuple[Location, WellCore]:
-            next_tip = self.get_next_tip(
-                tip_racks=[core for loc, core in tip_racks],
-                starting_well=starting_tip,
-            )
-            if next_tip is None:
-                raise RuntimeError(
-                    f"No tip available among the tipracks assigned for {self.get_pipette_name()}:"
-                    f" {[f'{tip_rack[1].get_display_name()} in {tip_rack[1].get_deck_slot()}' for tip_rack in tip_racks]}"
-                )
-            (
-                tiprack_loc,
-                tiprack_uri,
-                tip_well,
-            ) = self._get_location_and_well_core_from_next_tip_info(next_tip, tip_racks)
-            if tiprack_uri != tiprack_uri_for_transfer_props:
-                raise RuntimeError(
-                    f"Tiprack {tiprack_uri} does not match the tiprack designated "
-                    f"for this transfer- {tiprack_uri_for_transfer_props}."
-                )
-            self.pick_up_tip(
-                location=tiprack_loc,
-                well_core=tip_well,
-                presses=None,
-                increment=None,
-            )
-            return tiprack_loc, tip_well
-
         if new_tip != TransferTipPolicyV2.NEVER:
-            last_tip = _pick_up_tip()
+            last_tip = self._pick_up_tip_for_liquid_class(
+                tip_racks, starting_tip, tiprack_uri_for_transfer_props
+            )
 
         tip_contents = [
             tx_comps_executor.LiquidAndAirGapPair(
@@ -1679,8 +1560,10 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                 )
 
             if not is_first_step and new_tip == TransferTipPolicyV2.ALWAYS:
-                _drop_tip()
-                last_tip = _pick_up_tip()
+                self._drop_tip_for_liquid_class(trash_location, last_tip, return_tip)
+                last_tip = self._pick_up_tip_for_liquid_class(
+                    tip_racks, starting_tip, tiprack_uri_for_transfer_props
+                )
                 tip_contents = [
                     tx_comps_executor.LiquidAndAirGapPair(
                         liquid=0,
@@ -1737,7 +1620,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                 is_first_step = False
 
         if not keep_last_tip:
-            _drop_tip()
+            self._drop_tip_for_liquid_class(trash_location, last_tip, return_tip)
             last_tip = None
 
         return last_tip
@@ -1849,82 +1732,24 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             tiprack_uri=tiprack_uri_for_transfer_props,
         )
 
-        max_volume = min(
-            self.get_max_volume(),
-            self._engine_client.state.geometry.get_nominal_tip_geometry(
-                pipette_id=self.pipette_id,
-                labware_id=tip_racks[0][1].labware_id,
-                well_name=None,
-            ).volume,
-        )
+        working_volume = self.get_working_volume_for_tip_rack(tip_racks[0][1])
 
-        aspirate_air_gap_by_volume = transfer_props.aspirate.retract.air_gap_by_volume
         source_per_volume_step = (
-            tx_commons.expand_for_volume_constraints_for_liquid_classes(
+            tx_commons.get_sources_and_destinations_for_liquid_classes(
                 volumes=[volume for _ in range(len(source))],
+                max_volume=working_volume,
                 targets=source,
-                max_volume=max_volume,
-                air_gap=aspirate_air_gap_by_volume,
+                transfer_properties=transfer_props,
             )
         )
 
         last_tip = last_tip_location
-
-        def _drop_tip() -> None:
-            if return_tip:
-                assert last_tip is not None
-                _, tip_well = last_tip
-                self.drop_tip(
-                    location=None,
-                    well_core=tip_well,
-                    home_after=False,
-                    alternate_drop_location=False,
-                )
-            elif isinstance(trash_location, (TrashBin, WasteChute)):
-                self.drop_tip_in_disposal_location(
-                    disposal_location=trash_location,
-                    home_after=False,
-                    alternate_tip_drop=True,
-                )
-            elif isinstance(trash_location, Location):
-                self.drop_tip(
-                    location=trash_location,
-                    well_core=trash_location.labware.as_well()._core,  # type: ignore[arg-type]
-                    home_after=False,
-                    alternate_drop_location=True,
-                )
-
-        def _pick_up_tip() -> Tuple[Location, WellCore]:
-            next_tip = self.get_next_tip(
-                tip_racks=[core for loc, core in tip_racks],
-                starting_well=starting_tip,
-            )
-            if next_tip is None:
-                raise RuntimeError(
-                    f"No tip available among the tipracks assigned for {self.get_pipette_name()}:"
-                    f" {[ f'{tip_rack[1].get_display_name()} in {tip_rack[1].get_deck_slot()}' for tip_rack in tip_racks]}"
-                )
-            (
-                tiprack_loc,
-                tiprack_uri,
-                tip_well,
-            ) = self._get_location_and_well_core_from_next_tip_info(next_tip, tip_racks)
-            if tiprack_uri != tiprack_uri_for_transfer_props:
-                raise RuntimeError(
-                    f"Tiprack {tiprack_uri} does not match the tiprack designated "
-                    f"for this transfer- {tiprack_uri_for_transfer_props}."
-                )
-            self.pick_up_tip(
-                location=tiprack_loc,
-                well_core=tip_well,
-                presses=None,
-                increment=None,
-            )
-            return tiprack_loc, tip_well
-
         if new_tip in [TransferTipPolicyV2.ONCE, TransferTipPolicyV2.ALWAYS]:
-            last_tip = _pick_up_tip()
+            last_tip = self._pick_up_tip_for_liquid_class(
+                tip_racks, starting_tip, tiprack_uri_for_transfer_props
+            )
 
+        aspirate_air_gap_by_volume = transfer_props.aspirate.retract.air_gap_by_volume
         tip_contents = [
             tx_comps_executor.LiquidAndAirGapPair(
                 liquid=0,
@@ -1939,7 +1764,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             vol_aspirate_combo = []
             air_gap = aspirate_air_gap_by_volume.get_for_volume(next_step_volume)
             # Take air gap into account because there will be a final air gap before the dispense
-            while total_dispense_volume + next_step_volume <= max_volume - air_gap:
+            while total_dispense_volume + next_step_volume <= working_volume - air_gap:
                 total_dispense_volume += next_step_volume
                 vol_aspirate_combo.append((next_step_volume, next_source))
                 try:
@@ -1952,8 +1777,10 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                     break
 
             if not is_first_step and new_tip == TransferTipPolicyV2.ALWAYS:
-                _drop_tip()
-                last_tip = _pick_up_tip()
+                self._drop_tip_for_liquid_class(trash_location, last_tip, return_tip)
+                last_tip = self._pick_up_tip_for_liquid_class(
+                    tip_racks, starting_tip, tiprack_uri_for_transfer_props
+                )
                 tip_contents = [
                     tx_comps_executor.LiquidAndAirGapPair(
                         liquid=0,
@@ -1988,7 +1815,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             )
 
         if not keep_last_tip:
-            _drop_tip()
+            self._drop_tip_for_liquid_class(trash_location, last_tip, return_tip)
             last_tip = None
 
         return last_tip
@@ -2012,6 +1839,81 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             tiprack_labware_core.get_uri(),
             tip_well,
         )
+
+    def get_working_volume_for_tip_rack(self, tip_rack: LabwareCore) -> float:
+        """Given a tip rack, return the maximum allowed volume for the pipette."""
+        return min(
+            self.get_max_volume(),
+            self._engine_client.state.geometry.get_nominal_tip_geometry(
+                pipette_id=self.pipette_id,
+                labware_id=tip_rack.labware_id,
+                well_name=None,
+            ).volume,
+        )
+
+    def _pick_up_tip_for_liquid_class(
+        self,
+        tip_racks: List[Tuple[Location, LabwareCore]],
+        starting_tip: Optional[WellCore],
+        tiprack_uri_for_transfer_props: str,
+    ) -> Tuple[Location, WellCore]:
+        """Resolve next tip and pick it up, for use in liquid class transfer code."""
+        next_tip = self.get_next_tip(
+            tip_racks=[core for loc, core in tip_racks],
+            starting_well=starting_tip,
+        )
+        if next_tip is None:
+            raise RuntimeError(
+                f"No tip available among the tipracks assigned for {self.get_pipette_name()}:"
+                f" {[f'{tip_rack[1].get_display_name()} in {tip_rack[1].get_deck_slot()}' for tip_rack in tip_racks]}"
+            )
+        (
+            tiprack_loc,
+            tiprack_uri,
+            tip_well,
+        ) = self._get_location_and_well_core_from_next_tip_info(next_tip, tip_racks)
+        if tiprack_uri != tiprack_uri_for_transfer_props:
+            raise RuntimeError(
+                f"Tiprack {tiprack_uri} does not match the tiprack designated "
+                f"for this transfer- {tiprack_uri_for_transfer_props}."
+            )
+        self.pick_up_tip(
+            location=tiprack_loc,
+            well_core=tip_well,
+            presses=None,
+            increment=None,
+        )
+        return tiprack_loc, tip_well
+
+    def _drop_tip_for_liquid_class(
+        self,
+        trash_location: Union[Location, TrashBin, WasteChute],
+        last_tip: Optional[Tuple[Location, WellCore]],
+        return_tip: bool,
+    ) -> None:
+        """Drop or return tip for usage in liquid class transfers."""
+        if return_tip:
+            assert last_tip is not None
+            _, tip_well = last_tip
+            self.drop_tip(
+                location=None,
+                well_core=tip_well,
+                home_after=False,
+                alternate_drop_location=False,
+            )
+        elif isinstance(trash_location, (TrashBin, WasteChute)):
+            self.drop_tip_in_disposal_location(
+                disposal_location=trash_location,
+                home_after=False,
+                alternate_tip_drop=True,
+            )
+        elif isinstance(trash_location, Location):
+            self.drop_tip(
+                location=trash_location,
+                well_core=trash_location.labware.as_well()._core,  # type: ignore[arg-type]
+                home_after=False,
+                alternate_drop_location=True,
+            )
 
     def aspirate_liquid_class(
         self,

--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -1435,7 +1435,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                 ) from None
             raise
 
-        # If the volume to dispense into a well is less than threashold for low volume mode,
+        # If the volume to dispense into a well is less than threshold for low volume mode,
         # then set the max working volume to the max volume of low volume mode.
         # NOTE: this logic will need to be updated once we support list of volumes
         # TODO (spp): refactor this to use the volume thresholds from shared data
@@ -1450,9 +1450,9 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         # to consecutively distribute to at least two wells, then we resort to using
         # a regular, one-to-one transfer to carry out the distribution.
         min_asp_vol_for_multi_dispense = 2 * volume
-        if transfer_props.multi_dispense is None or (
-            transfer_props.multi_dispense is not None
-            and not self._tip_can_hold_volume_for_multi_dispensing(
+        if (
+            transfer_props.multi_dispense is None
+            or not self._tip_can_hold_volume_for_multi_dispensing(
                 transfer_volume=min_asp_vol_for_multi_dispense,
                 multi_dispense_properties=transfer_props.multi_dispense,
                 tip_working_volume=working_volume,

--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -1240,16 +1240,9 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                 "No tipracks found for pipette in order to perform transfer"
             )
         tiprack_uri_for_transfer_props = tip_racks[0][1].get_uri()
-        try:
-            transfer_props = liquid_class.get_for(
-                pipette=self.get_pipette_name(), tip_rack=tiprack_uri_for_transfer_props
-            )
-        except NoLiquidClassPropertyError:
-            if self._protocol_core.robot_type == "OT-2 Standard":
-                raise NoLiquidClassPropertyError(
-                    "Default liquid classes are not supported with OT-2 pipettes and tip racks."
-                ) from None
-            raise
+        transfer_props = self._get_transfer_properties_for_tip_rack(
+            liquid_class, tiprack_uri_for_transfer_props
+        )
 
         # TODO: use the ID returned by load_liquid_class in command annotations
         self.load_liquid_class(
@@ -1422,18 +1415,9 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         ]
 
         tiprack_uri_for_transfer_props = tip_racks[0][1].get_uri()
-        working_volume = self.get_working_volume_for_tip_rack(tip_racks[0][1])
-
-        try:
-            transfer_props = liquid_class.get_for(
-                pipette=self.get_pipette_name(), tip_rack=tiprack_uri_for_transfer_props
-            )
-        except NoLiquidClassPropertyError:
-            if self._protocol_core.robot_type == "OT-2 Standard":
-                raise NoLiquidClassPropertyError(
-                    "Default liquid classes are not supported with OT-2 pipettes and tip racks."
-                ) from None
-            raise
+        transfer_props = self._get_transfer_properties_for_tip_rack(
+            liquid_class, tiprack_uri_for_transfer_props
+        )
 
         # If the volume to dispense into a well is less than threshold for low volume mode,
         # then set the max working volume to the max volume of low volume mode.
@@ -1443,6 +1427,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             "flex_1channel_50",
             "flex_8channel_50",
         ]
+        working_volume = self.get_working_volume_for_tip_rack(tip_racks[0][1])
         if has_low_volume_mode and volume < 5:
             working_volume = 30
         # If there are no multi-dispense properties or if the volume to distribute
@@ -1704,16 +1689,9 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             TransferTipPolicyV2.ALWAYS,
         ]
         tiprack_uri_for_transfer_props = tip_racks[0][1].get_uri()
-        try:
-            transfer_props = liquid_class.get_for(
-                pipette=self.get_pipette_name(), tip_rack=tiprack_uri_for_transfer_props
-            )
-        except NoLiquidClassPropertyError:
-            if self._protocol_core.robot_type == "OT-2 Standard":
-                raise NoLiquidClassPropertyError(
-                    "Default liquid classes are not supported with OT-2 pipettes and tip racks."
-                ) from None
-            raise
+        transfer_props = self._get_transfer_properties_for_tip_rack(
+            liquid_class, tiprack_uri_for_transfer_props
+        )
 
         blow_out_properties = transfer_props.dispense.retract.blowout
         if (
@@ -1839,6 +1817,20 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             tiprack_labware_core.get_uri(),
             tip_well,
         )
+
+    def _get_transfer_properties_for_tip_rack(
+        self, liquid_class: LiquidClass, tip_rack_uri: str
+    ) -> TransferProperties:
+        try:
+            return liquid_class.get_for(
+                pipette=self.get_pipette_name(), tip_rack=tip_rack_uri
+            )
+        except NoLiquidClassPropertyError:
+            if self._protocol_core.robot_type == "OT-2 Standard":
+                raise NoLiquidClassPropertyError(
+                    "Default liquid classes are not supported with OT-2 pipettes and tip racks."
+                ) from None
+            raise
 
     def get_working_volume_for_tip_rack(self, tip_rack: LabwareCore) -> float:
         """Given a tip rack, return the maximum allowed volume for the pipette."""

--- a/api/src/opentrons/protocols/advanced_control/transfers/common.py
+++ b/api/src/opentrons/protocols/advanced_control/transfers/common.py
@@ -3,7 +3,10 @@ import enum
 import math
 from typing import Iterable, Generator, Tuple, TypeVar, Literal, List, Union
 
-from opentrons.protocol_api._liquid_properties import LiquidHandlingPropertyByVolume
+from opentrons.protocol_api._liquid_properties import (
+    LiquidHandlingPropertyByVolume,
+    TransferProperties,
+)
 
 
 class NoLiquidClassPropertyError(ValueError):
@@ -100,6 +103,37 @@ def _split_volume_equally(volume: float, max_volume: float) -> List[float]:
     else:
         iterations = math.ceil(volume / max_volume)
         return [volume / iterations for _ in range(iterations)]
+
+
+def get_sources_and_destinations_for_liquid_classes(
+    volumes: List[float],
+    max_volume: float,
+    targets: Iterable[Target],
+    transfer_properties: TransferProperties,
+    is_multi_dispense: bool = False,
+) -> Generator[Tuple[float, "Target"], None, None]:
+    """Return a list of targets (wells or tuples of wells) and volumes for a liquid class transfer."""
+    aspirate_air_gap_by_volume = transfer_properties.aspirate.retract.air_gap_by_volume
+    if is_multi_dispense:
+        assert transfer_properties.multi_dispense is not None
+        disposal_vol_by_volume = transfer_properties.multi_dispense.disposal_by_volume
+        conditioning_vol_by_volume = (
+            transfer_properties.multi_dispense.conditioning_by_volume
+        )
+        return expand_for_volume_constraints_for_liquid_classes(
+            volumes=volumes,
+            targets=targets,
+            max_volume=max_volume,
+            air_gap=aspirate_air_gap_by_volume,
+            disposal_vol=disposal_vol_by_volume,
+            conditioning_vol=conditioning_vol_by_volume,
+        )
+    return expand_for_volume_constraints_for_liquid_classes(
+        volumes=volumes,
+        targets=targets,
+        max_volume=max_volume,
+        air_gap=aspirate_air_gap_by_volume,
+    )
 
 
 def expand_for_volume_constraints_for_liquid_classes(


### PR DESCRIPTION
# Overview

This PR has minor refactor work for the instrument core implementation of liquid class transfers (those being transfer, distribute and consolidate), mostly to reduce the amount of repeated code between the three functions. The areas refactored are:

- Drop tip and pick up tip logic for liquid classes, which was the largest chunk of repeated code between the three and now exists within its own private function
- Getting the transfer properties and resulting error handling, now in a private function
- Getting the working volume given a tip rack labware core, this is not private though it has not been added to the instrument core interface
- Getting the sources and/or destinations and volume splitting has been put behind another function that encapsulates the getting of properties and handling the difference between multi dispense and regular dispense


## Test Plan and Hands on Testing

Pure refacotr only, so existing unit tests, integration tests and snapshot tests should cover any regression.

## Changelog

- Refactored instrument core liquid class transfer code to remove repeated code and encapsulate more elsewhere

## Review requests

Do we agree with these refactors, in that they make the code easier to follow? Is there any other area we'd like to see refactored?

## Risk assessment

Low, these changes are pretty straightforward and a diff checker was used to ensure that all code refactored was in fact the same.