### PR TITLE
fix(shared-data): update `flexStackerModuleV1` labwareOffset value

### DIFF
--- a/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
@@ -965,7 +965,7 @@ def test_get_all_obstacle_highest_z_with_modules(
     # Note: since no labware are loaded on the modules, the thermocycler
     # lid is considered open, so the thermocycler lid height is not included
     # in the thermocycler height
-    assert isclose(subject.get_all_obstacle_highest_z(), 44.725)
+    assert isclose(subject.get_all_obstacle_highest_z(), 35.0)
 
 
 @pytest.mark.parametrize("use_mocks", [False])

--- a/shared-data/module/definitions/3/flexStackerModuleV1.json
+++ b/shared-data/module/definitions/3/flexStackerModuleV1.json
@@ -9,7 +9,7 @@
   },
   "features": {},
   "dimensions": {
-    "bareOverallHeight": 82,
+    "bareOverallHeight": 35,
     "overLabwareHeight": 0,
     "xDimension": 156.25,
     "yDimension": 91.75,

--- a/shared-data/module/definitions/3/flexStackerModuleV1.json
+++ b/shared-data/module/definitions/3/flexStackerModuleV1.json
@@ -3,9 +3,9 @@
   "moduleType": "flexStackerModuleType",
   "model": "flexStackerModuleV1",
   "labwareOffset": {
-    "x": -0.125,
-    "y": 1.125,
-    "z": 68.275
+    "x": 97,
+    "y": 0,
+    "z": 31
   },
   "features": {},
   "dimensions": {


### PR DESCRIPTION
Closes [EXEC-1648](https://opentrons.atlassian.net/browse/EXEC-1648)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Updates the `FlexStackerModuleV1` definition's `labwareOffset` value. Reach out to me if you'd like the hardware file. I'm deriving these values from the PVT tab. The Y value is not explicitly outlined, but it's possible to infer that it's 0 based on some of the drawn lines in the file and visually verifying it's flush with a standard deck slot.

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Updated the `labwareOffset` value for `flexStackerModuleV1`.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests
- Am I correct in thinking that we offset from standard slots and never extension slots? I'm assuming this is the case based on the way we utilize these values.
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[EXEC-1648]: https://opentrons.atlassian.net/browse/EXEC-1648?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ