### PR TITLE
feat(api): allow lids on h/s to be moved when h/s is latched

### DIFF
--- a/api/src/opentrons/protocol_engine/execution/labware_movement.py
+++ b/api/src/opentrons/protocol_engine/execution/labware_movement.py
@@ -277,9 +277,12 @@ class LabwareMovementHandler:
                 await self._tc_movement_flagger.ensure_labware_in_open_thermocycler(
                     labware_parent=parent
                 )
-                await self._hs_movement_flagger.raise_if_labware_latched_on_heater_shaker(
-                    labware_parent=parent
-                )
+                if not self._state_store.labware.is_lid(labware_id):
+                    # Lid placement is actually improved by holding the labware latched on the H/S
+                    # So, we skip this check for lids.
+                    await self._hs_movement_flagger.raise_if_labware_latched_on_heater_shaker(
+                        labware_parent=parent
+                    )
             except ThermocyclerNotOpenError:
                 raise LabwareMovementNotAllowedError(
                     "Cannot move labware to or from a Thermocycler with its lid closed."

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -1029,6 +1029,10 @@ class LabwareView:
             self.get(labware_id).loadName
         )
 
+    def is_lid(self, labware_id: str) -> bool:
+        """Check if labware is a lid."""
+        return LabwareRole.lid in self.get_definition(labware_id).allowedRoles
+
     def raise_if_labware_inaccessible_by_pipette(self, labware_id: str) -> None:
         """Raise an error if the specified location cannot be reached via a pipette."""
         labware = self.get(labware_id)

--- a/api/tests/opentrons/protocol_engine/execution/test_labware_movement_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_labware_movement_handler.py
@@ -557,7 +557,7 @@ async def test_ensure_movement_obstructed_by_thermocycler_raises(
             labware_parent=ModuleLocation(moduleId="a-thermocycler-id")
         )
     ).then_raise(ThermocyclerNotOpenError("Thou shall not pass!"))
-
+    decoy.when(state_store.labware.is_lid(labware_id="labware-id")).then_return(False)
     with pytest.raises(LabwareMovementNotAllowedError):
         await subject.ensure_movement_not_obstructed_by_module(
             labware_id="labware-id", new_location=to_loc
@@ -573,6 +573,7 @@ async def test_ensure_movement_not_obstructed_by_modules(
     decoy.when(
         state_store.labware.get_parent_location(labware_id="labware-id")
     ).then_return(ModuleLocation(moduleId="a-rando-module-id"))
+    decoy.when(state_store.labware.is_lid(labware_id="labware-id")).then_return(False)
     await subject.ensure_movement_not_obstructed_by_module(
         labware_id="labware-id",
         new_location=DeckSlotLocation(slotName=DeckSlotName.SLOT_3),
@@ -604,6 +605,7 @@ async def test_ensure_movement_obstructed_by_heater_shaker_raises(
     decoy.when(
         state_store.labware.get_parent_location(labware_id="labware-id")
     ).then_return(from_loc)
+    decoy.when(state_store.labware.is_lid(labware_id="labware-id")).then_return(False)
     decoy.when(
         await heater_shaker_movement_flagger.raise_if_labware_latched_on_heater_shaker(
             labware_parent=ModuleLocation(moduleId="a-heater-shaker-id")
@@ -628,4 +630,40 @@ async def test_ensure_movement_not_obstructed_does_not_raise_for_slot_locations(
     await subject.ensure_movement_not_obstructed_by_module(
         labware_id="labware-id",
         new_location=DeckSlotLocation(slotName=DeckSlotName.SLOT_3),
+    )
+
+
+@pytest.mark.parametrize(
+    argnames=["from_loc", "to_loc"],
+    argvalues=[
+        (
+            ModuleLocation(moduleId="a-heater-shaker-id"),
+            DeckSlotLocation(slotName=DeckSlotName.SLOT_3),
+        ),
+        (
+            DeckSlotLocation(slotName=DeckSlotName.SLOT_3),
+            ModuleLocation(moduleId="a-heater-shaker-id"),
+        ),
+    ],
+)
+async def test_ensure_movement_not_obstructed_does_not_raise_for_lids_on_hs(
+    decoy: Decoy,
+    subject: LabwareMovementHandler,
+    heater_shaker_movement_flagger: HeaterShakerMovementFlagger,
+    state_store: StateStore,
+    from_loc: NonStackedLocation,
+    to_loc: LabwareLocation,
+) -> None:
+    """It should not raise any errors when moving lid from a latched H/S."""
+    decoy.when(
+        state_store.labware.get_parent_location(labware_id="labware-id")
+    ).then_return(from_loc)
+    decoy.when(state_store.labware.is_lid(labware_id="labware-id")).then_return(True)
+    decoy.when(
+        await heater_shaker_movement_flagger.raise_if_labware_latched_on_heater_shaker(
+            labware_parent=ModuleLocation(moduleId="a-heater-shaker-id")
+        )
+    ).then_raise(HeaterShakerLabwareLatchNotOpenError("Thou shall not take!"))
+    await subject.ensure_movement_not_obstructed_by_module(
+        labware_id="labware-id", new_location=to_loc
     )

--- a/api/tests/opentrons/protocol_engine/state/test_labware_view_old.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_view_old.py
@@ -108,6 +108,14 @@ adapter_plate = LoadedLabware(
     offsetId=None,
 )
 
+tiprack_lid = LoadedLabware(
+    id="tiprack-lid-id",
+    loadName="tiprack-lid-load-name",
+    location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
+    definitionUri="some-tiprack-lid-uri",
+    offsetId=None,
+)
+
 
 def get_labware_view(
     labware_by_id: Optional[Dict[str, LoadedLabware]] = None,
@@ -720,6 +728,24 @@ def test_is_tiprack(
 
     assert subject.is_tiprack(labware_id="tip-rack-id") is True
     assert subject.is_tiprack(labware_id="reservoir-id") is False
+
+
+def test_is_lid(
+    reservoir_def: LabwareDefinition, tiprack_lid_def: LabwareDefinition
+) -> None:
+    """It should return True if labware is a lid."""
+    subject = get_labware_view(
+        labware_by_id={
+            "reservoir-id": reservoir,
+            "tiprack-lid-id": tiprack_lid,
+        },
+        definitions_by_uri={
+            "some-reservoir-uri": reservoir_def,
+            "some-tiprack-lid-uri": tiprack_lid_def,
+        },
+    )
+    assert subject.is_lid(labware_id="reservoir-id") is False
+    assert subject.is_lid(labware_id="tiprack-lid-id") is True
 
 
 def test_get_load_name(reservoir_def: LabwareDefinition) -> None:


### PR DESCRIPTION
Helps with EXEC-1647

# Overview

It's been observed that moving lids with a gripper (specifically the Greiner labware lids) to labware on H/S is more reliable when the labware itself is latched and doesn't have any room to wiggle on the H/S- specifically when placed on a universal adapter. So we should allow lids to be placed on H/S labware with the labware latched.

## Test Plan and Hands on Testing

Will be tested by @rclarke0 after merging. Added unit tests for code sanity check.

## Changelog

- In labware movement executor, skip checking if H/S labware latch is closed before moving a lid to a H/S parent location.

## Review requests

- This allows moving of all lids placed/ to be place on H/S- either directly on the H/S *or* on an adapter *or* on a labware on an adapter on H/S, etc. Are we ok with this? Or should we allow this only for:
  - specific labware + lid combo
  - a lid only on a labware on an adapter on the H/S
  - a specifc labware + lib combo on an adapter on the H/S
?

The presence of an adapter might be required here because that's what makes sure that the labware latch is at such a position on the labware that it doesn't get in the way of lid placement. But also, is it necessary to be that specific? What if there's some other labware that's tall enough that its lid placement is not affected by the latch, even without the adapter?

Also, do we check somewhere else whether a lid fits a labware or do we allow placing any lids on any labware?

## Risk assessment

Low- medium. This change will allow any labware categorized as a lid to be placed on H/S (either directly or on a stack of adpater/labware(s)) without doing a labware latch check. This puts the onus on the user to make sure to leave the latch closed for the lids. Which is not too much of a responsibility and has no dire consequences in reality even if the latch stays open.
We also plan on testing whether we need to add any other restrictions to improve the user experience.