### PR TITLE
fix(protocol-designer): wire up disposal volume required error

### DIFF
--- a/protocol-designer/src/steplist/formLevel/errors.ts
+++ b/protocol-designer/src/steplist/formLevel/errors.ts
@@ -619,6 +619,14 @@ const DISPENSE_RETRACT_SPEED_REQUIRED: FormError = {
   showOnReopen: true,
   tab: 'dispense',
 }
+const DISPOSAL_VOLUME_REQUIRED: FormError = {
+  title: 'Disposal volume required',
+  dependentFields: ['disposalVolume_checkbox', 'disposalVolume_volume'],
+  location: 'field',
+  page: 2,
+  showOnReopen: true,
+  tab: 'dispense',
+}
 
 export type FormErrorChecker = (
   arg: HydratedFormData,
@@ -1575,7 +1583,14 @@ export const dispenseRetractSpeedRequired = (
     ? DISPENSE_RETRACT_SPEED_REQUIRED
     : null
 }
-
+export const disposalVolumeRequired = (
+  fields: HydratedMoveLiquidFormData
+): FormError | null => {
+  const { disposalVolume_checkbox, disposalVolume_volume } = fields
+  return disposalVolume_checkbox && !disposalVolume_volume
+    ? DISPOSAL_VOLUME_REQUIRED
+    : null
+}
 /*******************
  **     Helpers    **
  ********************/

--- a/protocol-designer/src/steplist/formLevel/index.ts
+++ b/protocol-designer/src/steplist/formLevel/index.ts
@@ -31,6 +31,7 @@ import {
   dispenseTouchTipMmFromEdgeRequired,
   dispenseTouchTipSpeedRequired,
   dispenseWellsRequired,
+  disposalVolumeRequired,
   engageHeightRangeExceeded,
   engageHeightRequired,
   fileNameRequired,
@@ -238,7 +239,8 @@ const stepFormHelperMap: {
       aspirateSubmergeSpeedRequired,
       aspirateRetractSpeedRequired,
       dispenseSubmergeSpeedRequired,
-      dispenseRetractSpeedRequired
+      dispenseRetractSpeedRequired,
+      disposalVolumeRequired
     ),
     getWarnings: composeWarnings(
       belowPipetteMinimumVolume,


### PR DESCRIPTION
# Overview

This PR enforces that a user enter a valid disposal volume in a transfer form with 1) "distribute" path, and 2) disposal volume checked.

Closes RQA-4355

## Test Plan and Hands on Testing

- create or open a transfer form
- select "distribute" path and navigate to dispense advanced settings
- ensure "disposal volume" checkbox is checked on, and leave disposal volume field empty
- try to save and verify that disposal volume required error shows
- without unchecking disposal field or entering a valid volume, go back and change path to "single"
- verify that the form can be saved

## Changelog

create and wire up disposal volume required form-level error

## Review requests

see test plan

## Risk assessment

low