### PR TITLE
fix(step-generation): blowout waste chute QT bug

### DIFF
--- a/step-generation/src/__tests__/blowoutUtil.test.ts
+++ b/step-generation/src/__tests__/blowoutUtil.test.ts
@@ -11,7 +11,6 @@ import {
   DEFAULT_PIPETTE,
   SOURCE_LABWARE,
   DEST_LABWARE,
-  TROUGH_LABWARE,
   BLOWOUT_FLOW_RATE,
   BLOWOUT_OFFSET_FROM_TOP_MM,
   makeContext,
@@ -118,11 +117,11 @@ describe('blowoutLocationHelper', () => {
   it('blowoutLocationHelper curries blowout with an arbitrary labware Id', () => {
     blowoutLocationHelper({
       ...blowoutArgs,
-      blowoutLocation: TROUGH_LABWARE,
+      blowoutLocation: 'source_well',
     })
     expect(curryCommandCreator).toHaveBeenCalledWith(blowOutInWell, {
       pipetteId: blowoutArgs.pipette,
-      labwareId: TROUGH_LABWARE,
+      labwareId: SOURCE_LABWARE,
       wellName: 'A1',
       flowRate: blowoutArgs.flowRate,
       wellLocation: {

--- a/step-generation/src/__tests__/distribute.test.ts
+++ b/step-generation/src/__tests__/distribute.test.ts
@@ -288,7 +288,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
       volume: 120,
       mixBeforeAspirate: { times: 2, volume: 50 },
       disposalVolume: 12,
-      blowoutLocation: SOURCE_LABWARE,
+      blowoutLocation: 'source_well',
     } as DistributeArgs
     const result = distribute(
       distributeArgs,
@@ -724,13 +724,53 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
       aspirateHelper('A1', aspirateVol),
       dispenseHelper('A2', volume),
       dispenseHelper('A3', volume),
-      blowoutSingleToSourceA1,
+      {
+        commandType: 'moveToAddressableArea',
+        key: expect.anything(),
+        params: {
+          addressableAreaName: 'movableTrashA3',
+          offset: {
+            x: 0,
+            y: 0,
+            z: 0,
+          },
+          pipetteId: 'p300SingleId',
+        },
+      },
+      {
+        commandType: 'blowOutInPlace',
+        key: expect.anything(),
+        params: {
+          flowRate: 2.3,
+          pipetteId: 'p300SingleId',
+        },
+      },
 
       ...mixCommands,
       aspirateHelper('A1', aspirateVol),
       dispenseHelper('A4', volume),
       dispenseHelper('A5', volume),
-      blowoutSingleToSourceA1,
+      {
+        commandType: 'moveToAddressableArea',
+        key: expect.anything(),
+        params: {
+          addressableAreaName: 'movableTrashA3',
+          offset: {
+            x: 0,
+            y: 0,
+            z: 0,
+          },
+          pipetteId: 'p300SingleId',
+        },
+      },
+      {
+        commandType: 'blowOutInPlace',
+        key: expect.anything(),
+        params: {
+          flowRate: 2.3,
+          pipetteId: 'p300SingleId',
+        },
+      },
     ])
   })
 

--- a/step-generation/src/__tests__/mix.test.ts
+++ b/step-generation/src/__tests__/mix.test.ts
@@ -221,7 +221,7 @@ describe('mix: advanced options', () => {
       volume,
       times,
       changeTip: 'always',
-      blowoutLocation: blowoutLabwareId,
+      blowoutLocation: 'source_well',
       wells: ['A1', 'B1', 'C1'],
     } as MixArgs
 
@@ -237,6 +237,8 @@ describe('mix: advanced options', () => {
         aspirateHelper(well, volume, mockWellLocation),
         dispenseHelper(well, volume, mockWellLocation),
         blowoutHelper(blowoutLabwareId, {
+          wellName: well,
+          labwareId: 'sourcePlateId',
           wellLocation: {
             origin: 'top',
             offset: {
@@ -254,7 +256,7 @@ describe('mix: advanced options', () => {
       volume,
       times,
       changeTip: 'always',
-      blowoutLocation: blowoutLabwareId,
+      blowoutLocation: 'source_well',
       touchTip: true,
       wells: ['A1', 'B1', 'C1'],
     } as MixArgs
@@ -271,6 +273,8 @@ describe('mix: advanced options', () => {
         aspirateHelper(well, volume, mockWellLocation),
         dispenseHelper(well, volume, mockWellLocation),
         blowoutHelper(blowoutLabwareId, {
+          wellName: well,
+          labwareId: 'sourcePlateId',
           wellLocation: {
             origin: 'top',
             offset: {
@@ -339,7 +343,7 @@ describe('mix: advanced options', () => {
         touchTip: true,
         aspirateDelaySeconds: 10,
         dispenseDelaySeconds: 12,
-        blowoutLocation: blowoutLabwareId,
+        blowoutLocation: 'source_well',
         volume,
         times,
         changeTip: 'always',
@@ -368,6 +372,8 @@ describe('mix: advanced options', () => {
           dispenseHelper(well, volume, mockWellLocationCustomXY),
           delayCommand(12),
           blowoutHelper(blowoutLabwareId, {
+            wellName: well,
+            labwareId: 'sourcePlateId',
             wellLocation: {
               origin: 'top',
               offset: {
@@ -436,7 +442,7 @@ mockPythonName.dispense(
 )
 protocol.delay(seconds=12)
 mockPythonName.flow_rate.blow_out = 2.3
-mockPythonName.blow_out(mockPythonName["A1"].top(z=3.3))
+mockPythonName.blow_out(mockPythonName["B1"].top(z=3.3))
 mockPythonName.touch_tip(mockPythonName["B1"], v_offset=-3.4)
 mockPythonName.drop_tip()
 mockPythonName.pick_up_tip(location=mockPythonName)
@@ -465,7 +471,7 @@ mockPythonName.dispense(
 )
 protocol.delay(seconds=12)
 mockPythonName.flow_rate.blow_out = 2.3
-mockPythonName.blow_out(mockPythonName["A1"].top(z=3.3))
+mockPythonName.blow_out(mockPythonName["C1"].top(z=3.3))
 mockPythonName.touch_tip(mockPythonName["C1"], v_offset=-3.4)`.trimStart()
       )
     })
@@ -474,7 +480,7 @@ mockPythonName.touch_tip(mockPythonName["C1"], v_offset=-3.4)`.trimStart()
     const args: MixArgs = {
       ...mixinArgs,
       touchTip: true,
-      blowoutLocation: blowoutLabwareId,
+      blowoutLocation: 'dest_well',
       volume,
       times,
       changeTip: 'always',
@@ -510,7 +516,7 @@ mockPythonName.mix(
     location=mockPythonName["B1"].bottom(z=3.2).move(types.Point(x=1, y=1)),
 )
 mockPythonName.flow_rate.blow_out = 2.3
-mockPythonName.blow_out(mockPythonName["A1"].top(z=3.3))
+mockPythonName.blow_out(mockPythonName["B1"].top(z=3.3))
 mockPythonName.touch_tip(mockPythonName["B1"], v_offset=-3.4)
 mockPythonName.drop_tip()
 mockPythonName.pick_up_tip(location=mockPythonName)
@@ -522,7 +528,7 @@ mockPythonName.mix(
     location=mockPythonName["C1"].bottom(z=3.2).move(types.Point(x=1, y=1)),
 )
 mockPythonName.flow_rate.blow_out = 2.3
-mockPythonName.blow_out(mockPythonName["A1"].top(z=3.3))
+mockPythonName.blow_out(mockPythonName["C1"].top(z=3.3))
 mockPythonName.touch_tip(mockPythonName["C1"], v_offset=-3.4)`.trimStart()
     )
   })

--- a/step-generation/src/utils/misc.ts
+++ b/step-generation/src/utils/misc.ts
@@ -340,7 +340,9 @@ export const blowoutLocationHelper = (args: {
     offsetFromTopMm,
     invariantContext,
   } = args
-  if (!blowoutLocation) return []
+  if (!blowoutLocation) {
+    return []
+  }
   const { labwareEntities, additionalEquipmentEntities } = invariantContext
   const trashOrLabware = getTrashOrLabware(
     labwareEntities,
@@ -363,7 +365,7 @@ export const blowoutLocationHelper = (args: {
     labware = invariantContext.labwareEntities?.[blowoutLocation]
     well = trashOrLabware === 'labware' ? 'A1' : null
   }
-
+  console.log(trashOrLabware, 'trashOrLabware')
   if (well != null && trashOrLabware === 'labware' && labware != null) {
     return [
       curryCommandCreator(blowOutInWell, {
@@ -379,7 +381,11 @@ export const blowoutLocationHelper = (args: {
         },
       }),
     ]
-  } else if (trashOrLabware === 'wasteChute') {
+  } else if (
+    trashOrLabware === 'wasteChute' ||
+    (additionalEquipmentEntities[blowoutLocation] != null &&
+      additionalEquipmentEntities[blowoutLocation].name === 'wasteChute')
+  ) {
     const wasteChute = Object.values(additionalEquipmentEntities).find(
       ae => ae.name === 'wasteChute'
     )

--- a/step-generation/src/utils/misc.ts
+++ b/step-generation/src/utils/misc.ts
@@ -365,7 +365,7 @@ export const blowoutLocationHelper = (args: {
     labware = invariantContext.labwareEntities?.[blowoutLocation]
     well = trashOrLabware === 'labware' ? 'A1' : null
   }
-  console.log(trashOrLabware, 'trashOrLabware')
+
   if (well != null && trashOrLabware === 'labware' && labware != null) {
     return [
       curryCommandCreator(blowOutInWell, {
@@ -382,9 +382,8 @@ export const blowoutLocationHelper = (args: {
       }),
     ]
   } else if (
-    trashOrLabware === 'wasteChute' ||
-    (additionalEquipmentEntities[blowoutLocation] != null &&
-      additionalEquipmentEntities[blowoutLocation].name === 'wasteChute')
+    additionalEquipmentEntities[blowoutLocation] != null &&
+    additionalEquipmentEntities[blowoutLocation].name === 'wasteChute'
   ) {
     const wasteChute = Object.values(additionalEquipmentEntities).find(
       ae => ae.name === 'wasteChute'

--- a/step-generation/src/utils/misc.ts
+++ b/step-generation/src/utils/misc.ts
@@ -343,30 +343,20 @@ export const blowoutLocationHelper = (args: {
   if (!blowoutLocation) {
     return []
   }
-  const { labwareEntities, additionalEquipmentEntities } = invariantContext
-  const trashOrLabware = getTrashOrLabware(
-    labwareEntities,
-    additionalEquipmentEntities,
-    destLabwareId
-  )
+  const { additionalEquipmentEntities } = invariantContext
+
   let labware: LabwareEntity | null = null
   let well: string | null = null
   if (blowoutLocation === SOURCE_WELL_BLOWOUT_DESTINATION) {
     labware = invariantContext.labwareEntities[sourceLabwareId]
     well = sourceWell
   } else if (blowoutLocation === DEST_WELL_BLOWOUT_DESTINATION) {
-    labware =
-      trashOrLabware === 'labware'
-        ? invariantContext.labwareEntities[destLabwareId]
-        : null
-    well = trashOrLabware === 'labware' ? destWell : null
-  } else {
-    // if it's not one of the magic strings, it's a labware or waste chute or trash bin id
-    labware = invariantContext.labwareEntities?.[blowoutLocation]
-    well = trashOrLabware === 'labware' ? 'A1' : null
+    labware = invariantContext.labwareEntities[destLabwareId]
+
+    well = destWell
   }
 
-  if (well != null && trashOrLabware === 'labware' && labware != null) {
+  if (well != null && labware != null) {
     return [
       curryCommandCreator(blowOutInWell, {
         pipetteId: pipette,


### PR DESCRIPTION
closes AUTH-2088

# Overview

Fixes the blowout waste chute QT bug outlined here: https://opentrons.slack.com/archives/C06M6R72UDS/p1752505971123429

okay so blow out is confusing because it can be these strings:
- `source_well`
- `dest_well`
- `labwareId`
- `wasteChuteId`
- `trashBinId`

The logic is broken for when blowout is happening in the waste chute because the logic `trashOrLabware` is only searching for the destination id. So if you are blowing out in the waste chute and your destination id is also the waste chute, then it works. Otherwise, the logic isn't smart enough and will default to blowing out in the trash bin.

## Test Plan and Hands on Testing

Smoke test that QT works with a quick transfer and distribute

## Changelog


## Risk assessment

low
