### PR TITLE
refactor(app): Make `getStacksOnModules()` more type-safe

### DIFF
--- a/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabware/SetupLabwareMap.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabware/SetupLabwareMap.tsx
@@ -23,7 +23,6 @@ import {
   getLabwareDefinitionsByURIForProtocol,
   getLabwareInfoByLiquidId,
   getLabwareOnDeck,
-  getModuleFromStack,
   getStackedItemsOnStartingDeck,
   getStacksOnModules,
   getTopLabwareFromStack,
@@ -36,7 +35,6 @@ import { SlotDetailModal } from './SlotDetailModal'
 import type { LabwareOnDeck } from '@opentrons/components'
 import type {
   CompletedProtocolAnalysis,
-  ModuleModel,
   ProtocolAnalysisOutput,
 } from '@opentrons/shared-data'
 import type { StackItem } from '/app/transformations/commands'
@@ -80,8 +78,7 @@ export function SetupLabwareMap({
   const labwareByLiquidId = getLabwareInfoByLiquidId(protocolAnalysis.commands)
 
   const modulesOnDeck = Object.entries(getStacksOnModules(startingDeck)).map(
-    ([slotName, stackedItems]) => {
-      const module = getModuleFromStack(stackedItems)
+    ([slotName, { allItemsInStack: stackedItems, moduleInStack: module }]) => {
       const topLabwareInfo = getTopLabwareFromStack(stackedItems)
       const topLabwareDefinition =
         topLabwareInfo != null
@@ -97,14 +94,13 @@ export function SetupLabwareMap({
               labwareByLiquidId
             )
           : undefined
-      const moduleType =
-        module?.moduleModel == null ? null : getModuleType(module.moduleModel)
+      const moduleType = getModuleType(module.moduleModel)
 
       return {
-        moduleModel: module?.moduleModel ?? ('' as ModuleModel),
-        moduleLocation: { slotName: module?.moduleSlotName ?? slotName },
+        moduleModel: module.moduleModel,
+        moduleLocation: { slotName: module.moduleSlotName },
         innerProps:
-          module?.moduleModel === THERMOCYCLER_MODULE_V1
+          module.moduleModel === THERMOCYCLER_MODULE_V1
             ? { lidMotorState: 'open' }
             : {},
 
@@ -118,7 +114,7 @@ export function SetupLabwareMap({
             onClick={() => {
               if (topLabwareInfo != null) {
                 setSelectedStack({
-                  slotName: slotName,
+                  slotName,
                   stack: stackedItems,
                 })
               }
@@ -131,7 +127,7 @@ export function SetupLabwareMap({
             onMouseLeave={() => {
               setHoverLabwareId(null)
             }}
-            cursor={'pointer'}
+            cursor="pointer"
           >
             {topLabwareDefinition != null && topLabwareInfo != null ? (
               <LabwareInfoOverlay
@@ -183,12 +179,12 @@ export function SetupLabwareMap({
       definition: topLabwareDefinition,
       highlight: hoverLabwareId === topLabwareInfo.labwareId,
       stacked: isLabwareInStack,
-      wellFill: wellFill,
+      wellFill,
       labwareChildren: (
         <g
-          cursor={'pointer'}
+          cursor="pointer"
           onClick={() => {
-            setSelectedStack({ slotName: slotName, stack: stackedItems })
+            setSelectedStack({ slotName, stack: stackedItems })
           }}
           onMouseEnter={() => {
             setHoverLabwareId(() => topLabwareInfo.labwareId)

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupLabware/LabwareMapView.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupLabware/LabwareMapView.tsx
@@ -12,17 +12,13 @@ import { getWellFillFromLabwareId } from '/app/organisms/ProtocolDeck'
 import {
   getLabwareDefinitionsByURIForProtocol,
   getLabwareOnDeck,
-  getModuleFromStack,
   getStacksOnModules,
   getTopLabwareFromStack,
 } from '/app/transformations/commands'
 
 import type { Dispatch, SetStateAction } from 'react'
 import type { LabwareOnDeck } from '@opentrons/components'
-import type {
-  CompletedProtocolAnalysis,
-  ModuleModel,
-} from '@opentrons/shared-data'
+import type { CompletedProtocolAnalysis } from '@opentrons/shared-data'
 import type {
   LabwareByLiquidId,
   StackedItemsOnDeck,

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupLabware/LabwareMapView.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupLabware/LabwareMapView.tsx
@@ -50,8 +50,7 @@ export function LabwareMapView(props: LabwareMapViewProps): JSX.Element {
     [mostRecentAnalysis]
   )
   const modulesOnDeck = Object.entries(getStacksOnModules(startingDeck)).map(
-    ([slotName, stackedItems]) => {
-      const module = getModuleFromStack(stackedItems)
+    ([slotName, { allItemsInStack: stackedItems, moduleInStack: module }]) => {
       const topLabwareInfo = getTopLabwareFromStack(stackedItems)
       const topLabwareDefinition =
         topLabwareInfo != null
@@ -67,10 +66,10 @@ export function LabwareMapView(props: LabwareMapViewProps): JSX.Element {
             )
           : undefined
       return {
-        moduleModel: module?.moduleModel ?? ('' as ModuleModel),
-        moduleLocation: { slotName: module?.moduleSlotName ?? slotName },
+        moduleModel: module.moduleModel,
+        moduleLocation: { slotName: module.moduleSlotName },
         innerProps:
-          module?.moduleModel === THERMOCYCLER_MODULE_V1
+          module.moduleModel === THERMOCYCLER_MODULE_V1
             ? { lidMotorState: 'open' }
             : {},
         nestedLabwareDef: topLabwareDefinition,

--- a/app/src/organisms/ProtocolDeck/index.tsx
+++ b/app/src/organisms/ProtocolDeck/index.tsx
@@ -10,7 +10,6 @@ import {
   getLabwareDefinitionsByURIForProtocol,
   getLabwareInfoByLiquidId,
   getLabwareOnDeck,
-  getModuleFromStack,
   getStackedItemsOnStartingDeck,
   getStacksOnModules,
   getTopLabwareFromStack,

--- a/app/src/organisms/ProtocolDeck/index.tsx
+++ b/app/src/organisms/ProtocolDeck/index.tsx
@@ -25,7 +25,6 @@ import type { ComponentProps } from 'react'
 import type { LabwareOnDeck } from '@opentrons/components'
 import type {
   CompletedProtocolAnalysis,
-  ModuleModel,
   ProtocolAnalysisOutput,
 } from '@opentrons/shared-data'
 
@@ -60,8 +59,7 @@ export function ProtocolDeck(props: ProtocolDeckProps): JSX.Element | null {
   const labwareByLiquidId = getLabwareInfoByLiquidId(protocolAnalysis.commands)
 
   const modulesOnDeck = Object.entries(getStacksOnModules(startingDeck)).map(
-    ([slotName, stackedItems]) => {
-      const module = getModuleFromStack(stackedItems)
+    ([slotName, { allItemsInStack: stackedItems, moduleInStack: module }]) => {
       const topLabwareInfo = getTopLabwareFromStack(stackedItems)
       const topLabwareDefinition =
         topLabwareInfo != null
@@ -69,8 +67,8 @@ export function ProtocolDeck(props: ProtocolDeckProps): JSX.Element | null {
           : null
 
       return {
-        moduleModel: module?.moduleModel ?? ('' as ModuleModel),
-        moduleLocation: { slotName: module?.moduleSlotName ?? slotName },
+        moduleModel: module.moduleModel,
+        moduleLocation: { slotName: module.moduleSlotName },
         nestedLabwareDef: topLabwareDefinition,
         nestedLabwareWellFill:
           topLabwareInfo != null

--- a/app/src/transformations/commands/transformations/getStackedItemsOnStartingDeck.ts
+++ b/app/src/transformations/commands/transformations/getStackedItemsOnStartingDeck.ts
@@ -474,7 +474,7 @@ export function getLabwareOnDeck(
   return Object.fromEntries(labwareOnDeckEntries)
 }
 
-// filter function to get stacks that include modules
+// filter function to get stacks that include labware
 export function getStacksWithLabware(
   itemsOnDeck: StackedItemsOnDeck
 ): { [slotName: string]: StackItem[] } {
@@ -491,15 +491,31 @@ export function getStacksWithLabware(
 // filter function to get stacks that include modules
 export function getStacksOnModules(
   itemsOnDeck: StackedItemsOnDeck
-): { [slotName: string]: StackItem[] } {
-  const stacksOnModuleEntries = Object.entries(
-    itemsOnDeck
-  ).filter(([key, value]) =>
-    value.some(
+): {
+  [slotName: string]: {
+    // This could be typed more cleverly as:
+    // [ModuleInStack, ...StackItem[]]
+    // if we're sure that the module is always the first element in the array,
+    // but I'm not sure if that's actually the case.
+    allItemsInStack: StackItem[]
+    moduleInStack: ModuleInStack
+  }
+} {
+  return Object.entries(itemsOnDeck).reduce((acc, entry) => {
+    const [slotName, stack] = entry
+    const moduleInStack = stack.find(
       (stackItem): stackItem is ModuleInStack => 'moduleId' in stackItem
     )
-  )
-  return Object.fromEntries(stacksOnModuleEntries)
+    return moduleInStack != null
+      ? {
+          ...acc,
+          [slotName]: {
+            allItemsInStack: stack,
+            moduleInStack,
+          },
+        }
+      : acc
+  }, {})
 }
 
 export function getTopLabwareFromStack(


### PR DESCRIPTION
## Overview

Some of our code was having to contend with module data being nullable in theory but not in practice, doing things like `module?.moduleModel ?? ('' as ModuleModel)`. (If it were ever actually null in practice and we passed `''`, [it would have thrown an error](https://github.com/Opentrons/opentrons/blob/62317d9efd20645ab6469e0e69f92f0e5de6fff8/shared-data/js/modules.ts#L69).) 

This refactors it so TypeScript can tell it's actually never nullable.

Helps with #18890.

## Test Plan and Hands on Testing

None, I think code review is sufficient here.

## Review requests

Nothing in particular, just general naming and TypeScript idiomaticness.

## Risk assessment

Low.
