### PR TITLE
fix(step-generation): blowout waste chute bug

### DIFF
--- a/step-generation/src/__tests__/blowoutUtil.test.ts
+++ b/step-generation/src/__tests__/blowoutUtil.test.ts
@@ -10,7 +10,6 @@ import {
   getInitialRobotStateStandard,
   makeContext,
   SOURCE_LABWARE,
-  TROUGH_LABWARE,
 } from '../fixtures'
 import {
   DEST_WELL_BLOWOUT_DESTINATION,

--- a/step-generation/src/__tests__/blowoutUtil.test.ts
+++ b/step-generation/src/__tests__/blowoutUtil.test.ts
@@ -13,8 +13,8 @@ import {
   TROUGH_LABWARE,
 } from '../fixtures'
 import {
-  blowoutLocationHelper,
   DEST_WELL_BLOWOUT_DESTINATION,
+  mixBlowoutLocationHelper,
   SOURCE_WELL_BLOWOUT_DESTINATION,
 } from '../utils'
 import { curryCommandCreator } from '../utils/curryCommandCreator'
@@ -56,8 +56,8 @@ describe('blowoutLocationHelper', () => {
     }
     vi.mocked(curryCommandCreator).mockClear()
   })
-  it('blowoutLocationHelper curries blowout with source well params', () => {
-    blowoutLocationHelper({
+  it('mixBlowoutLocationHelper curries blowout with source well params', () => {
+    mixBlowoutLocationHelper({
       ...blowoutArgs,
       blowoutLocation: SOURCE_WELL_BLOWOUT_DESTINATION,
     })
@@ -74,7 +74,7 @@ describe('blowoutLocationHelper', () => {
       },
     })
   })
-  it('blowoutLocationHelper curries waste chute commands when there is no well', () => {
+  it('mixBlowoutLocationHelper curries waste chute commands when there is no well', () => {
     const wasteChuteId = 'wasteChuteId'
     invariantContext = {
       ...invariantContext,
@@ -86,7 +86,7 @@ describe('blowoutLocationHelper', () => {
         },
       },
     }
-    blowoutLocationHelper({
+    mixBlowoutLocationHelper({
       ...blowoutArgs,
       destLabwareId: wasteChuteId,
       invariantContext: invariantContext,
@@ -99,8 +99,8 @@ describe('blowoutLocationHelper', () => {
       wasteChuteId,
     })
   })
-  it('blowoutLocationHelper curries blowout with dest plate params', () => {
-    blowoutLocationHelper({
+  it('mixBlowoutLocationHelper curries blowout with dest plate params', () => {
+    mixBlowoutLocationHelper({
       ...blowoutArgs,
       blowoutLocation: DEST_WELL_BLOWOUT_DESTINATION,
     })
@@ -117,8 +117,8 @@ describe('blowoutLocationHelper', () => {
       },
     })
   })
-  it('blowoutLocationHelper curries blowout with an arbitrary labware Id', () => {
-    blowoutLocationHelper({
+  it('mixBlowoutLocationHelper curries blowout with an arbitrary labware Id', () => {
+    mixBlowoutLocationHelper({
       ...blowoutArgs,
       blowoutLocation: TROUGH_LABWARE,
     })
@@ -135,8 +135,8 @@ describe('blowoutLocationHelper', () => {
       },
     })
   })
-  it('blowoutLocationHelper returns an empty array if not given a blowoutLocation', () => {
-    const result = blowoutLocationHelper({
+  it('mixBlowoutLocationHelper returns an empty array if not given a blowoutLocation', () => {
+    const result = mixBlowoutLocationHelper({
       ...blowoutArgs,
       blowoutLocation: null,
     })

--- a/step-generation/src/__tests__/blowoutUtil.test.ts
+++ b/step-generation/src/__tests__/blowoutUtil.test.ts
@@ -120,12 +120,12 @@ describe('blowoutLocationHelper', () => {
   it('mixBlowoutLocationHelper curries blowout with an arbitrary labware Id', () => {
     mixBlowoutLocationHelper({
       ...blowoutArgs,
-      blowoutLocation: TROUGH_LABWARE,
+      blowoutLocation: 'dest_well',
     })
     expect(curryCommandCreator).toHaveBeenCalledWith(blowOutInWell, {
       pipetteId: blowoutArgs.pipette,
-      labwareId: TROUGH_LABWARE,
-      wellName: 'A1',
+      labwareId: 'destPlateId',
+      wellName: 'A2',
       flowRate: blowoutArgs.flowRate,
       wellLocation: {
         origin: 'top',

--- a/step-generation/src/__tests__/mix.test.ts
+++ b/step-generation/src/__tests__/mix.test.ts
@@ -364,7 +364,7 @@ describe('mix: advanced options', () => {
       volume,
       times,
       changeTip: 'always',
-      blowoutLocation: blowoutLabwareId,
+      blowoutLocation: 'source_well',
       wells: ['A1', 'B1', 'C1'],
     } as MixArgs
 
@@ -408,6 +408,8 @@ describe('mix: advanced options', () => {
           flowRate: 2.2,
         }),
         blowoutHelper(blowoutLabwareId, {
+          labwareId: 'sourcePlateId',
+          wellName: well,
           wellLocation: {
             origin: 'top',
             offset: {
@@ -425,9 +427,9 @@ describe('mix: advanced options', () => {
       volume,
       times,
       changeTip: 'always',
-      blowoutLocation: blowoutLabwareId,
+      blowoutLocation: 'dest_well',
       touchTip: true,
-      wells: ['A1', 'B1', 'C1'],
+      wells: ['A1'],
     } as MixArgs
 
     const result = mix(args, invariantContext, robotStateWithTip)
@@ -470,6 +472,8 @@ describe('mix: advanced options', () => {
           flowRate: 2.2,
         }),
         blowoutHelper(blowoutLabwareId, {
+          labwareId: 'sourcePlateId',
+          wellName: 'A1',
           wellLocation: {
             origin: 'top',
             offset: {
@@ -594,7 +598,7 @@ describe('mix: advanced options', () => {
         touchTip: true,
         aspirateDelaySeconds: 10,
         dispenseDelaySeconds: 12,
-        blowoutLocation: blowoutLabwareId,
+        blowoutLocation: 'source_well',
         volume,
         times,
         changeTip: 'always',
@@ -654,6 +658,8 @@ describe('mix: advanced options', () => {
           }),
           delayCommand(12),
           blowoutHelper(blowoutLabwareId, {
+            labwareId: 'sourcePlateId',
+            wellName: well,
             wellLocation: {
               origin: 'top',
               offset: {
@@ -679,7 +685,7 @@ mock_pipette.mix(
     final_push_out=2,
 )
 mock_pipette.flow_rate.blow_out = 2.3
-mock_pipette.blow_out(mock_dest_plate["A1"].top(z=3.3))
+mock_pipette.blow_out(mock_source_plate["A1"].top(z=3.3))
 mock_pipette.touch_tip(mock_source_plate["A1"], v_offset=-3.4)
 mock_pipette.drop_tip()
 mock_pipette.pick_up_tip(location=mock_tip_rack_1)
@@ -695,7 +701,7 @@ mock_pipette.mix(
     final_push_out=2,
 )
 mock_pipette.flow_rate.blow_out = 2.3
-mock_pipette.blow_out(mock_dest_plate["A1"].top(z=3.3))
+mock_pipette.blow_out(mock_source_plate["B1"].top(z=3.3))
 mock_pipette.touch_tip(mock_source_plate["B1"], v_offset=-3.4)
 mock_pipette.drop_tip()
 mock_pipette.pick_up_tip(location=mock_tip_rack_1)
@@ -711,7 +717,7 @@ mock_pipette.mix(
     final_push_out=2,
 )
 mock_pipette.flow_rate.blow_out = 2.3
-mock_pipette.blow_out(mock_dest_plate["A1"].top(z=3.3))
+mock_pipette.blow_out(mock_source_plate["C1"].top(z=3.3))
 mock_pipette.touch_tip(mock_source_plate["C1"], v_offset=-3.4)
 `.trim()
       )
@@ -721,7 +727,7 @@ mock_pipette.touch_tip(mock_source_plate["C1"], v_offset=-3.4)
     const args: MixArgs = {
       ...mixinArgs,
       touchTip: true,
-      blowoutLocation: blowoutLabwareId,
+      blowoutLocation: 'dest_well',
       volume,
       times,
       changeTip: 'always',
@@ -745,7 +751,7 @@ mock_pipette.mix(
     dispense_flow_rate=2.2,
 )
 mock_pipette.flow_rate.blow_out = 2.3
-mock_pipette.blow_out(mock_dest_plate["A1"].top(z=3.3))
+mock_pipette.blow_out(mock_source_plate["A1"].top(z=3.3))
 mock_pipette.touch_tip(mock_source_plate["A1"], v_offset=-3.4)
 mock_pipette.drop_tip()
 mock_pipette.pick_up_tip(location=mock_tip_rack_1)
@@ -758,7 +764,7 @@ mock_pipette.mix(
     dispense_flow_rate=2.2,
 )
 mock_pipette.flow_rate.blow_out = 2.3
-mock_pipette.blow_out(mock_dest_plate["A1"].top(z=3.3))
+mock_pipette.blow_out(mock_source_plate["B1"].top(z=3.3))
 mock_pipette.touch_tip(mock_source_plate["B1"], v_offset=-3.4)
 mock_pipette.drop_tip()
 mock_pipette.pick_up_tip(location=mock_tip_rack_1)
@@ -771,7 +777,7 @@ mock_pipette.mix(
     dispense_flow_rate=2.2,
 )
 mock_pipette.flow_rate.blow_out = 2.3
-mock_pipette.blow_out(mock_dest_plate["A1"].top(z=3.3))
+mock_pipette.blow_out(mock_source_plate["C1"].top(z=3.3))
 mock_pipette.touch_tip(mock_source_plate["C1"], v_offset=-3.4)
 `.trim()
     )

--- a/step-generation/src/commandCreators/compound/mix.ts
+++ b/step-generation/src/commandCreators/compound/mix.ts
@@ -9,7 +9,6 @@ import {
 
 import * as errorCreators from '../../errorCreators'
 import {
-  blowoutLocationHelper,
   curryCommandCreator,
   curryWithoutPython,
   formatPyStr,
@@ -17,6 +16,7 @@ import {
   getIsSafePipetteMovement,
   getSlotInLocationStack,
   indentPyLines,
+  mixBlowoutLocationHelper,
   reduceCommandCreators,
 } from '../../utils'
 import {
@@ -401,7 +401,7 @@ export const mix: CommandCreator<MixArgs> = (
             }),
           ]
         : []
-      const blowoutCommand = blowoutLocationHelper({
+      const blowoutCommand = mixBlowoutLocationHelper({
         pipette: data.pipette,
         sourceLabwareId: data.labware,
         sourceWell: well,

--- a/step-generation/src/utils/misc.ts
+++ b/step-generation/src/utils/misc.ts
@@ -382,17 +382,7 @@ export const blowoutLocationHelper = (args: {
     invariantContext,
   } = args
   if (!blowoutLocation) return []
-  const {
-    labwareEntities,
-    trashBinEntities,
-    wasteChuteEntities,
-  } = invariantContext
-  const trashOrLabware = getTrashOrLabware(
-    labwareEntities,
-    wasteChuteEntities,
-    trashBinEntities,
-    destLabwareId
-  )
+  const { trashBinEntities, wasteChuteEntities } = invariantContext
 
   let labware: LabwareEntity | null = null
   let well: string | null = null
@@ -400,18 +390,11 @@ export const blowoutLocationHelper = (args: {
     labware = invariantContext.labwareEntities[sourceLabwareId]
     well = sourceWell
   } else if (blowoutLocation === DEST_WELL_BLOWOUT_DESTINATION) {
-    labware =
-      trashOrLabware === 'labware'
-        ? invariantContext.labwareEntities[destLabwareId]
-        : null
-    well = trashOrLabware === 'labware' ? destWell : null
-  } else {
-    // if it's not one of the magic strings, it's a labware or waste chute or trash bin id
-    labware = invariantContext.labwareEntities?.[blowoutLocation]
-    well = trashOrLabware === 'labware' ? 'A1' : null
+    labware = invariantContext.labwareEntities[destLabwareId]
+    well = destWell
   }
 
-  if (well != null && trashOrLabware === 'labware' && labware != null) {
+  if (well != null && labware != null) {
     return [
       curryCommandCreator(blowOutInWell, {
         pipetteId: pipette,
@@ -426,7 +409,7 @@ export const blowoutLocationHelper = (args: {
         },
       }),
     ]
-  } else if (trashOrLabware === 'wasteChute') {
+  } else if (wasteChuteEntities[blowoutLocation] != null) {
     return [
       curryCommandCreator(blowOutInWasteChute, {
         pipetteId: pipette,

--- a/step-generation/src/utils/misc.ts
+++ b/step-generation/src/utils/misc.ts
@@ -359,7 +359,7 @@ export function getWellsForTips(
 // Set blowout location depending on the 'blowoutLocation' arg: set it to
 // the SOURCE_WELL_BLOWOUT_DESTINATION / DEST_WELL_BLOWOUT_DESTINATION
 // special strings, or to a labware ID.
-export const blowoutLocationHelper = (args: {
+export const mixBlowoutLocationHelper = (args: {
   pipette: BlowoutParams['pipetteId']
   sourceLabwareId: string
   sourceWell: BlowoutParams['wellName']
@@ -381,24 +381,25 @@ export const blowoutLocationHelper = (args: {
     offsetFromTopMm,
     invariantContext,
   } = args
-  if (!blowoutLocation) return []
+  if (!blowoutLocation) {
+    return []
+  }
   const { trashBinEntities, wasteChuteEntities } = invariantContext
 
-  let labware: LabwareEntity | null = null
+  let labwareId: string | null = null
   let well: string | null = null
   if (blowoutLocation === SOURCE_WELL_BLOWOUT_DESTINATION) {
-    labware = invariantContext.labwareEntities[sourceLabwareId]
+    labwareId = sourceLabwareId
     well = sourceWell
   } else if (blowoutLocation === DEST_WELL_BLOWOUT_DESTINATION) {
-    labware = invariantContext.labwareEntities[destLabwareId]
+    labwareId = destLabwareId
     well = destWell
   }
-
-  if (well != null && labware != null) {
+  if (well != null && labwareId != null) {
     return [
       curryCommandCreator(blowOutInWell, {
         pipetteId: pipette,
-        labwareId: labware.id,
+        labwareId: labwareId,
         wellName: well,
         flowRate,
         wellLocation: {


### PR DESCRIPTION
closes AUTH-2088

# Overview

Fixes the blowout waste chute QT bug outlined here: https://opentrons.slack.com/archives/C06M6R72UDS/p1752505971123429
(AUTH-2088)

okay so blow out is confusing because it can be these strings:
- `source_well`
- `dest_well`
- `labwareId`
- `wasteChuteId`
- `trashBinId`

The logic is broken for when blowout is happening in the waste chute because the logic `trashOrLabware` is only searching for the destination id. So if you are blowing out in the waste chute and your destination id is also the waste chute, then it works. Otherwise, the logic isn't smart enough and will default to blowing out in the trash bin.

## Test Plan and Hands on Testing

smoke test a distribute with blowout in waste chute for QT and PD 

## Changelog


## Risk assessment

low
