### PR TITLE
docs: update error recovery options table

### DIFF
--- a/docs/flex-manual/docs/software-operation.md
+++ b/docs/flex-manual/docs/software-operation.md
@@ -296,9 +296,9 @@ Flex provides a protocol recovery path for the following error conditions.
       <td>Occurs when a pipette encounters an empty well and expects a liquid to be present.</td>
       <td>
         <ul>
-          <li>Manually fill the empty well retry with the same tips.</li>
+          <li>Manually fill the empty well and retry with the same tips.</li>
           <li>Manually fill the empty well and retry with new tips.</li>
-          <li>Manually refill well and skip to the next step.</li>
+          <li>Manually fill the empty well and skip to the next step.</li>
           <li>Ignore the error and skip to the next step.</li>
           <li>Cancel protocol run.</li>
         </ul>

--- a/docs/flex-manual/docs/software-operation.md
+++ b/docs/flex-manual/docs/software-operation.md
@@ -243,13 +243,6 @@ move the pipette quickly, but beware of crashing the pipette into
 labware.</figcaption>
 </figure>
 
-<!-- commenting this, no image, TK placeholder text below
-<figure class="screenshot" markdown>
-TK image of 8.4 LPC
-<figcaption>Summary of new labware offsets ready to be applied to a protocol.</figcaption>
-</figure>
--->
-
 When you run Labware Position Check for the first time, the pipette will start at its default position for all labware (X 0.0 Y 0.0 Z 0.0). On subsequent runs, the pipette will start at the previously saved offset locations. This lets you quickly confirm offset data before every protocol run.
 
 !!! note

--- a/docs/flex-manual/docs/software-operation.md
+++ b/docs/flex-manual/docs/software-operation.md
@@ -282,11 +282,56 @@ Tap **Launch recovery mode** to see options for the particular type of error tha
 
 Flex provides a protocol recovery path for the following error conditions.
 
-| Error type | Description {style="width: 30%;"} | Recovery options |
-| :--------- | :---------- | :--------------- |
-| No liquid detected | Occurs when a pipette encounters an empty well and expects a liquid to be present. | <ul><li>Manually refill well and skip to the next step.</li><li>Ignore the error and skip to the next step.</li><li>Cancel protocol run.</li></ul> |
-| Pipette overpressure | Occurs when pressure inside the pipette exceeds the normal range while aspirating or dispensing liquid. Caused by clogged, bent, or sealed tips. | <ul><li>For aspiration:</li><ul><li>Retry with new tips.</li><li>Cancel protocol run.</li></ul><li>For dispense:</li><ul><li>Skip to the next step with the same tips.</li><li>Skip to the next step with new tips.</li><li>Cancel protocol run.</li></ul></ul> |
-| General errors | A catch-all category for other errors. | <ul><li>Retry step.</li><li>Skip to next step.</li><li>Cancel protocol run.</li></ul> |
+<table>
+  <thead>
+    <tr>
+      <th>Error type</th>
+      <th style="width: 30%;">Description</th>
+      <th>Recovery options</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>No liquid detected</td>
+      <td>Occurs when a pipette encounters an empty well and expects a liquid to be present.</td>
+      <td>
+        <ul>
+          <li>Manually fill the empty well retry with the same tips.</li>
+          <li>Manually fill the empty well and retry with new tips.</li>
+          <li>Manually refill well and skip to the next step.</li>
+          <li>Ignore the error and skip to the next step.</li>
+          <li>Cancel protocol run.</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <td>Pipette overpressure</td>
+      <td>Occurs when pressure inside the pipette exceeds the normal range while aspirating or dispensing liquid. Caused by clogged, bent, or sealed tips.</td>
+      <td>For aspiration:<br>
+        <ul>
+            <li>Retry with new tips.</li>
+            <li>Cancel protocol run.</li>
+        </ul>
+        For dispense:
+        <ul>
+            <li>Skip to the next step with the same tips.</li>
+            <li>Skip to the next step with new tips.</li>
+            <li>Cancel protocol run.</li>
+        </ul>
+      </td>
+    </tr>
+      <td>General errors</td>
+      <td>A catch-all category for other errors.</td>
+      <td>
+        <ul>
+          <li>Retry step.</li>
+          <li>Skip to next step.</li>
+          <li>Cancel protocol run.</li>
+        </ul>
+      </td>
+    </tr>
+  </tbody>
+</table>
 
 !!! note
     The tip presence sensor is disabled for [partial tip pickup](system-description.md#partial-tip-pickup) of 1, 2, or 3 tips. In these configurations, Flex cannot detect tip pickup errors and will not present error recovery options if the pipette fails to pick up the tips. The run will continue unless and until another error occurs.

--- a/docs/flex-manual/docs/software-operation.md
+++ b/docs/flex-manual/docs/software-operation.md
@@ -243,10 +243,12 @@ move the pipette quickly, but beware of crashing the pipette into
 labware.</figcaption>
 </figure>
 
+<!-- commenting this, no image, TK placeholder text below
 <figure class="screenshot" markdown>
 TK image of 8.4 LPC
 <figcaption>Summary of new labware offsets ready to be applied to a protocol.</figcaption>
 </figure>
+-->
 
 When you run Labware Position Check for the first time, the pipette will start at its default position for all labware (X 0.0 Y 0.0 Z 0.0). On subsequent runs, the pipette will start at the previously saved offset locations. This lets you quickly confirm offset data before every protocol run.
 
@@ -320,6 +322,7 @@ Flex provides a protocol recovery path for the following error conditions.
         </ul>
       </td>
     </tr>
+    <tr>
       <td>General errors</td>
       <td>A catch-all category for other errors.</td>
       <td>
@@ -329,8 +332,7 @@ Flex provides a protocol recovery path for the following error conditions.
           <li>Cancel protocol run.</li>
         </ul>
       </td>
-    </tr>
-  </tbody>
+    </tr> </tbody>
 </table>
 
 !!! note
@@ -749,7 +751,7 @@ Flex *will not* retain information about more than 20 runs on the robot. Proceed
 
 You can work with your Flex through a Secure Shell (SSH) terminal connection. Terminal access lets you [run protocols directly from the command line](https://docs.opentrons.com/v2/new_advanced_running.html#command-line) or perform advanced tasks, such as customizing the Python environment on the robot. Protocols that reference external files on disk (apart from custom labware definition files) must be run from the command line.
 
-!!!Note
+!!!note
     - SSH keys are required before you can connect to Flex and issue commands from a terminal.
     - If you're unable to use a Wi-Fi network for SSH, see [Hardwired SSH Connections][hardwired-ssh-connections] below.
 


### PR DESCRIPTION
# Overview

Chapter 7, Software and Operations. Updates the table that lists error recovery options.

- Changes markdown table to HTML.
- No liquid detected row: adds 2 new recovery options
- Pipette overpressure row: removes nested unordered lists, not needed.

## Test Plan and Hands on Testing

Check the revised code to make sure it displays info in a formatted table.

Sandbox URL: see the table in the [error recovery section](http://sandbox.docs.s3-website.us-east-2.amazonaws.com/error-recovery-flex-manual/flex-manual/software-operation/#error-recovery).

## Changelog

See summary above.

## Review requests

Nothing specific.

## Risk assessment

Low, docs only.
