### PR TITLE
fix(protocol-designer,shared-data): remove blowout placeholder

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/FlowRateField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/FlowRateField.tsx
@@ -171,17 +171,18 @@ export function FlowRateField(props: FlowRateFieldProps): JSX.Element {
   const isFlowRateOutOfBounds =
     (maxFlowRate != null && flowRateNum > maxFlowRate) || flowRateNum < 0
 
-  let errorMessage: string | null = null
-  if (
-    (!isPristine && passThruProps.value !== undefined && flowRateNum === 0) ||
+  const errorMessage =
+    (passThruProps.value &&
+      !isPristine &&
+      passThruProps.value !== undefined &&
+      flowRateNum === 0) ||
     isFlowRateOutOfBounds ||
     (isPristine && flowRateNum === 0)
-  ) {
-    errorMessage = i18n.format(
-      t('step_edit_form.field.flow_rate.error_out_of_bounds'),
-      'capitalize'
-    )
-  }
+      ? i18n.format(
+          t('step_edit_form.field.flow_rate.error_out_of_bounds'),
+          'capitalize'
+        )
+      : passThruProps.errorToShow ?? null
 
   useEffect(() => {
     if (isPristine && passThruProps.value == null) {
@@ -195,7 +196,7 @@ export function FlowRateField(props: FlowRateFieldProps): JSX.Element {
       padding={padding}
       type="number"
       setIsPristine={setIsPristine}
-      errorToShow={maxFlowRate != null ? errorMessage : null}
+      errorToShow={errorMessage}
       key={`${flowRateType}_FlowRateInput`}
       title={title}
       showTooltip={false}
@@ -209,7 +210,6 @@ export function FlowRateField(props: FlowRateFieldProps): JSX.Element {
             })
           : null
       }
-      placeholder={String(defaultFlowRate)}
     />
   )
 }

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/utils.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/utils.ts
@@ -13,6 +13,7 @@ import {
   WATER_LIQUID_CLASS_NAME,
 } from '@opentrons/shared-data'
 import {
+  DEST_WELL_BLOWOUT_DESTINATION,
   getTransferPlanAndReferenceVolumes,
   SOURCE_WELL_BLOWOUT_DESTINATION,
 } from '@opentrons/step-generation'
@@ -382,13 +383,20 @@ const getBlowoutFields = (args: {
     hardwareMaximumFlowRate = null,
   } = args
   const { enable, params } = blowout
-  // transform location to additional equipment entity ID
-  const transformedLocation =
-    (params?.location === 'trash'
-      ? Object.values(additionalEquipmentEntities).find(
-          ({ name }) => name === 'trashBin' || name === 'wasteChute'
-        )?.id
-      : params?.location) ?? null
+
+  // transform location
+  let transformedLocation: string | null = null
+  if (params?.location === 'trash') {
+    transformedLocation =
+      Object.values(additionalEquipmentEntities).find(
+        ({ name }) => name === 'trashBin' || name === 'wasteChute'
+      )?.id ?? null
+  } else if (params?.location === 'source') {
+    transformedLocation = SOURCE_WELL_BLOWOUT_DESTINATION
+  } else if (params?.location === 'destination') {
+    transformedLocation = DEST_WELL_BLOWOUT_DESTINATION
+  }
+
   const checkedFlowRate =
     params != null
       ? min([

--- a/shared-data/js/helpers/linearInterpolate.ts
+++ b/shared-data/js/helpers/linearInterpolate.ts
@@ -17,11 +17,8 @@ export const linearInterpolate = (
   left: number | null = null,
   right: number | null = null
 ): number | null => {
-  console.assert(
-    interpolationPoints.length > 0,
-    'At least one point required for interpolation'
-  )
   if (interpolationPoints.length === 0) {
+    console.warn('At least one point required for interpolation')
     return null
   }
   const sortedInterpolationPoints = interpolationPoints.sort((a, b) => {


### PR DESCRIPTION
# Overview

This PR fixes blowout flow rate behavior to not show an inaccurate placeholder value when the field is empty. It also correctly transforms the liquid class's retract blowout location value to its corresponding value in the PD UI blowout location dropdown (`'source'` -> `'source_well'`, `'destination'` -> `'dest_well'`)

Closes RQA-4372

## Test Plan and Hands on Testing

### Blowout flowrate required
- create or open a transfer step
- navigate to advanced dispense settings and check on blowout or disposal field
- delete blowout flowrate and verify that saving is blocked by an error specifying that flow rate is required

### Liquid class blowout location
- create or open a transfer step and select a liquid class (aqueous, viscous, volatile)
- navigate to advanced dispense settings and check on blowout
- verify that location is correctly selected to source, destination, or trash (dependent on liquid class)

## Changelog

- fix logic for `FlowRateField` error
- fix transformation for blowout location in form update handler util
- remove assertion in linear interpolate (often receives empty array)

## Review requests

see test plan

## Risk assessment

low