### PR TITLE
fix(protocol-designer): thermocycler caption and error copy

### DIFF
--- a/protocol-designer/src/assets/localization/en/protocol_steps.json
+++ b/protocol-designer/src/assets/localization/en/protocol_steps.json
@@ -15,8 +15,8 @@
   "blowout_location": "Blowout location",
   "blowout_position": "Blowout position from top",
   "captions_for_fields": {
-    "blockTargetTemp": "Must be between 4 and 99˚C",
-    "lidTargetTemp": "Must be between 37 and 110˚C",
+    "blockTargetTemp": "Valid range between 4 and 99˚C",
+    "lidTargetTemp": "Valid range between 37 and 110˚C",
     "targetSpeed": "Must be between 200 and 3000 rpm",
     "targetTemperature": "Must be between 4 and 95˚C",
     "targetHeaterShakerTemperature": "Must be between 37 and 95˚C",

--- a/protocol-designer/src/steplist/formLevel/errors.ts
+++ b/protocol-designer/src/steplist/formLevel/errors.ts
@@ -173,31 +173,31 @@ const PROFILE_VOLUME_REQUIRED: FormError = {
   page: 1,
 }
 const PROFILE_LID_TEMPERATURE_REQUIRED: FormError = {
-  title: 'Temperature required',
+  title: RANGE_TITLE,
   dependentFields: ['thermocyclerFormType', 'profileTargetLidTemp'],
   location: 'field',
   page: 1,
 }
 const LID_TEMPERATURE_REQUIRED: FormError = {
-  title: 'Temperature required',
+  title: RANGE_TITLE,
   dependentFields: ['lidIsActive', 'lidTargetTemp'],
   location: 'field',
   page: 1,
 }
 const BLOCK_TEMPERATURE_REQUIRED: FormError = {
-  title: 'Temperature required',
+  title: RANGE_TITLE,
   dependentFields: ['blockIsActive', 'blockTargetTemp'],
   location: 'field',
   page: 1,
 }
 const BLOCK_TEMPERATURE_HOLD_REQUIRED: FormError = {
-  title: 'Temperature required',
+  title: RANGE_TITLE,
   dependentFields: ['blockIsActiveHold', 'blockTargetTempHold'],
   location: 'field',
   page: 1,
 }
 const LID_TEMPERATURE_HOLD_REQUIRED: FormError = {
-  title: 'Temperature required',
+  title: RANGE_TITLE,
   dependentFields: ['lidIsActiveHold', 'lidTargetTempHold'],
   location: 'field',
   page: 1,


### PR DESCRIPTION
# Overview

This PR updates the lid and block temperature range captions to match designs. It also updates the error copy to display "Enter a value within the specified range" whether the relevant temperature field is empty, or it is entered but out of range.

Closes RQA-4195

<img width="257" height="287" alt="Screenshot 2025-07-16 at 11 09 09 AM" src="https://github.com/user-attachments/assets/b836742f-e715-4dbc-80d3-61826018c8b1" />
<img width="269" height="297" alt="Screenshot 2025-07-16 at 11 08 07 AM" src="https://github.com/user-attachments/assets/5a209cfb-79f0-42f6-af5d-20144007bfe3" />

## Test Plan and Hands on Testing

- create or open a thermocycler > state form
- check on block and lid temperature settings
- verify that caption reads "Valid range between [x] and [y]˚C"
- enter temperature out of range and verify that error message reads "Enter a value within the specified range"
- go back and change state to profile
- verify the same behavior under hold settings

## Changelog

- update caption copy and error copy for thermocycler lid and block temperature fields

## Review requests

see test plan

## Risk assessment

low