### PR TITLE
chore(ci): have prettier ignore mkdocs .yml files

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -46,3 +46,5 @@ opentrons-ai-server/api/storage/
 # Leave Markdown formatting alone because some of it is load-bearing for MkDocs.
 # Note that this is a Prettier thing, not an ESLint thing. Prettier shares this config file.
 /docs/**/*.md
+# And ignore non-semantic formatting issues in mkdocs YAML configuration files.
+/docs/**/*.yml


### PR DESCRIPTION

# Overview

Add a rule to our `.eslintignore` file so `prettier` doesn't complain about unimportant formatting quirks in mkdocs YAML configuration files.

Unlike the rule to ignore .md files, which is _required_ for proper mkdocs output, this is for convenience. But, the fact that a missing or stray newline here or there in fully functioning docs configuration files can cause the "JS checks" for our entire software stack to fail is not representative. It puts a lot on the documentation authors to make sure they don't mess things up for the whole software team when working in what should be a completely siloed environment.

## Test Plan and Hands on Testing

In local environment, removed an EOF newline (the sheer audacity!) in `docs/flex-manual/mkdocs.yml` and ran `make lint-js`.

## Changelog

Just the one ignore rule.

## Review requests

Any real reason not to do this?

## Risk assessment

v low.