### PR TITLE
feat(app): add labware nickname to labware for protocol viz

### DIFF
--- a/app/src/pages/Desktop/Protocols/ProtocolPreview/DeckViewDetails.tsx
+++ b/app/src/pages/Desktop/Protocols/ProtocolPreview/DeckViewDetails.tsx
@@ -183,8 +183,8 @@ export function DeckViewDetails(props: DeckViewDetailsProps): JSX.Element {
                   >
                     {isActiveLayerVisible
                       ? copy
-                      : labwareEntities[labwareLoadedOnModuleId].def.metadata
-                          .displayName}
+                      : labwareEntities[labwareLoadedOnModuleId]
+                          .labwareNickName}
                   </StyledText>
                 </div>
               </RobotCoordsForeignDiv>
@@ -429,7 +429,7 @@ export function DeckViewDetails(props: DeckViewDetailsProps): JSX.Element {
                     desktopStyle="captionRegular"
                     color={COLORS.white}
                   >
-                    {labwareEntities[id].def.metadata.displayName}
+                    {labwareEntities[id].labwareNickName}
                   </StyledText>
                 )}
               </div>
@@ -548,7 +548,7 @@ export function DeckViewDetails(props: DeckViewDetailsProps): JSX.Element {
                     desktopStyle="captionRegular"
                     color={COLORS.white}
                   >
-                    {labwareEntities[id].def.metadata.displayName}
+                    {labwareEntities[id].labwareNickName}
                   </StyledText>
                 )}
               </div>

--- a/app/src/pages/Desktop/Protocols/ProtocolPreview/preview.module.css
+++ b/app/src/pages/Desktop/Protocols/ProtocolPreview/preview.module.css
@@ -306,6 +306,9 @@
   height: 85.48px; /* STANDARD_Y_HEIGHT */
   padding: var(--spacing-8);
   background-color: transparent;
+  align-items: center;
+  display: flex;
+  justify-content: center;
 }
 
 .dont_show_render_slot_box {

--- a/step-generation/src/types.ts
+++ b/step-generation/src/types.ts
@@ -106,6 +106,7 @@ export interface LabwareEntity {
   labwareDefURI: string
   def: LabwareDefinition2
   pythonName: string
+  labwareNickName?: string
 }
 export interface LabwareEntities {
   [labwareId: string]: LabwareEntity

--- a/step-generation/src/types.ts
+++ b/step-generation/src/types.ts
@@ -106,6 +106,7 @@ export interface LabwareEntity {
   labwareDefURI: string
   def: LabwareDefinition2
   pythonName: string
+  //  used specifically for protocol viz at the moment
   labwareNickName?: string
 }
 export interface LabwareEntities {

--- a/step-generation/src/utils/constructInvariantContextFromRunCommands.ts
+++ b/step-generation/src/utils/constructInvariantContextFromRunCommands.ts
@@ -38,6 +38,9 @@ export function constructInvariantContextFromRunCommands(
               def: result.definition,
               //  ProtocolTimelineScrubber won't need access to pythonNames
               pythonName: 'n/a',
+              labwareNickName:
+                command.params.displayName ??
+                result.definition.metadata.displayName,
             },
           }
           return {
@@ -92,7 +95,9 @@ export function constructInvariantContextFromRunCommands(
         let tiprackLabwareDef = matchingCommand?.result?.definition ?? null
         // We're not prepared to handle labware schema 3 yet. See the todo comment
         // in the loadLabware handling, above.
-        if (tiprackLabwareDef?.schemaVersion === 3) tiprackLabwareDef = null
+        if (tiprackLabwareDef?.schemaVersion === 3) {
+          tiprackLabwareDef = null
+        }
 
         const specs: any = getPipetteSpecsV2(command.params.pipetteName)
 


### PR DESCRIPTION
# Overview

Add labware nickname to labware entity and display on deck map for protocol viz -> Mel wanted me to add this in quickly for user testing

## Test Plan and Hands on Testing

upload atached protocol, should have labware nicknames over the labware in protocol viz

[ProtocolVizPrototypeAnalysisPass (1).json](https://github.com/user-attachments/files/21262485/ProtocolVizPrototypeAnalysisPass.1.json)

## Changelog

- add optional labware nickname key to labware entity that is used for protocol viz

## Risk assessment

low