### PR TITLE
feat(api, shared-data): Support flex tip rack lid feature

### DIFF
--- a/api/src/opentrons/protocol_engine/state/_labware_origin_math.py
+++ b/api/src/opentrons/protocol_engine/state/_labware_origin_math.py
@@ -237,10 +237,16 @@ def _shim_does_locating_feature_pair_exist(
     parent_deck_item: _Labware3SupportedParentDefinition,
 ) -> bool:
     """Temporary util."""
-    return (
+    slot_footprint_exists = (
         parent_deck_item.features.get("slotFootprintAsParent") is not None
         and child_labware.features.get("slotFootprintAsChild") is not None
     )
+    flex_tiprack_lid_exists = (
+        parent_deck_item.features.get("opentronsFlexTipRackLidAsParent") is not None
+        and child_labware.features.get("opentronsFlexTipRackLidAsChild") is not None
+    )
+
+    return slot_footprint_exists or flex_tiprack_lid_exists
 
 
 def _parent_deck_item_with_features(
@@ -360,6 +366,13 @@ def _parent_deck_item_to_child_labware_feature_offset(
 ) -> Point:
     """Get the offset vector from the parent entity origin to the child labware origin."""
     if (
+        parent_deck_item.features.get("opentronsFlexTipRackLidAsParent") is not None
+        and child_labware.features.get("opentronsFlexTipRackLidAsChild") is not None
+    ):
+        return _parent_origin_flex_tip_rack_lid_feature(
+            parent_deck_item
+        ) + _flex_tip_rack_lid_feature_to_child_origin(child_labware)
+    elif (
         parent_deck_item.features.get("slotFootprintAsParent") is not None
         and child_labware.features.get("slotFootprintAsChild") is not None
     ):
@@ -407,10 +420,22 @@ def _get_spring_force(
     return parent_spring_force or child_spring_force
 
 
+def _parent_origin_flex_tip_rack_lid_feature(
+    parent_deck_item: _Labware3SupportedParentDefinition,
+) -> Point:
+    """Returns the offset from a deck item's origin to the Flex tip rack lid locating feature."""
+    flex_tip_rack_lid_as_parent = parent_deck_item.features.get(
+        "opentronsFlexTipRackLidAsParent"
+    )
+    assert flex_tip_rack_lid_as_parent is not None
+
+    return Point(x=0, y=0, z=flex_tip_rack_lid_as_parent["matingZ"])
+
+
 def _parent_origin_to_slot_bottom_center(
     parent_deck_item: _Labware3SupportedParentDefinition,
 ) -> Point:
-    """Returns the offset from something's origin to the bottom center of the slot that it provides."""
+    """Returns the offset from a deck item's origin to the bottom center of the slot that it provides."""
     slot_footprint_as_parent = parent_deck_item.features.get("slotFootprintAsParent")
     assert slot_footprint_as_parent is not None
 
@@ -430,7 +455,7 @@ def _parent_origin_to_slot_bottom_center(
 def _parent_origin_to_slot_back_left_bottom(
     parent_deck_item: _Labware3SupportedParentDefinition,
 ) -> Point:
-    """Returns the offset from something's origin to the back left bottom of the slot that it provides."""
+    """Returns the offset from a deck item's origin to the back left bottom of the slot that it provides."""
     slot_footprint_as_parent = parent_deck_item.features.get("slotFootprintAsParent")
     assert slot_footprint_as_parent is not None
 
@@ -439,6 +464,18 @@ def _parent_origin_to_slot_back_left_bottom(
     z = slot_footprint_as_parent["z"]
 
     return Point(x, y, z)
+
+
+def _flex_tip_rack_lid_feature_to_child_origin(
+    child_labware: LabwareDefinition3,
+) -> Point:
+    """Returns the offset from a parent lid's Flex tip rack lid locating feature to the child origin."""
+    flex_tip_rack_lid_as_child = child_labware.features.get(
+        "opentronsFlexTipRackLidAsChild"
+    )
+    assert flex_tip_rack_lid_as_child is not None
+
+    return Point(x=0, y=0, z=flex_tip_rack_lid_as_child["matingZ"])
 
 
 def slot_bottom_center_to_child_origin(

--- a/api/src/opentrons/protocol_engine/state/_labware_origin_math.py
+++ b/api/src/opentrons/protocol_engine/state/_labware_origin_math.py
@@ -463,10 +463,7 @@ def _parent_origin_to_flex_tip_rack_lid_feature(
     )
     assert flex_tip_rack_lid_as_parent is not None
 
-    x_mid = parent_deck_item.extents.total.frontRightTop.x / 2
-    y_mid = parent_deck_item.extents.total.frontRightTop.y / 2
-
-    return Point(x=x_mid, y=y_mid, z=flex_tip_rack_lid_as_parent["matingZ"])
+    return Point(x=0, y=0, z=flex_tip_rack_lid_as_parent["matingZ"])
 
 
 def _parent_origin_to_slot_bottom_center(
@@ -512,10 +509,7 @@ def _flex_tip_rack_lid_feature_to_child_origin(
     )
     assert flex_tip_rack_lid_as_child is not None
 
-    x_mid = child_labware.extents.total.frontRightTop.x / 2
-    y_mid = child_labware.extents.total.frontRightTop.y / 2
-
-    return Point(x=x_mid, y=y_mid, z=flex_tip_rack_lid_as_child["matingZ"]) * -1
+    return Point(x=0, y=0, z=flex_tip_rack_lid_as_child["matingZ"])
 
 
 def slot_bottom_center_to_child_origin(

--- a/api/src/opentrons/protocol_engine/state/_labware_origin_math.py
+++ b/api/src/opentrons/protocol_engine/state/_labware_origin_math.py
@@ -403,6 +403,8 @@ def _parent_deck_item_to_child_labware_feature_offset(
         parent_deck_item.features.get("opentronsFlexTipRackLidAsParent") is not None
         and child_labware.features.get("opentronsFlexTipRackLidAsChild") is not None
     ):
+        # TODO(jh, 07-29-25): Support center X/Y calculation after addressing grip point
+        # calculations. See #18929 discussion.
         return _parent_origin_to_flex_tip_rack_lid_feature(
             parent_deck_item
         ) + _flex_tip_rack_lid_feature_to_child_origin(child_labware)

--- a/api/src/opentrons/protocol_engine/state/_labware_origin_math.py
+++ b/api/src/opentrons/protocol_engine/state/_labware_origin_math.py
@@ -9,6 +9,9 @@ from opentrons_shared_data.labware.labware_definition import (
     LabwareDefinition,
     LabwareDefinition2,
     LabwareDefinition3,
+    Extents,
+    AxisAlignedBoundingBox3D,
+    Vector3D,
 )
 from opentrons_shared_data.labware.types import (
     SlotFootprintAsChildFeature,
@@ -36,6 +39,7 @@ _OFFSET_ON_TC_OT2 = Point(x=0, y=0, z=10.7)
 @dataclasses.dataclass
 class _Labware3SupportedParentDefinition:
     features: LocatingFeatures
+    extents: Extents
 
 
 @overload
@@ -126,7 +130,7 @@ def get_parent_placement_origin_to_lw_origin(
         #  module_parent_to_child_offset.
         if _shim_does_locating_feature_pair_exist(
             child_labware=child_labware,
-            parent_deck_item=_parent_deck_item_with_features(parent_deck_item),
+            parent_deck_item=_get_standardized_parent_deck_item(parent_deck_item),
         ):
             parent_deck_item_origin_to_child_labware_placement_origin = (
                 _module_parent_to_child_offset(
@@ -147,7 +151,7 @@ def get_parent_placement_origin_to_lw_origin(
         parent_deck_item_to_child_labware_feature_offset = (
             _parent_deck_item_to_child_labware_feature_offset(
                 child_labware=child_labware,
-                parent_deck_item=_parent_deck_item_with_features(parent_deck_item),
+                parent_deck_item=_get_standardized_parent_deck_item(parent_deck_item),
             )
         ) + _feature_exception_offsets(
             deck_definition=deck_definition, parent_deck_item=parent_deck_item
@@ -249,7 +253,7 @@ def _shim_does_locating_feature_pair_exist(
     return slot_footprint_exists or flex_tiprack_lid_exists
 
 
-def _parent_deck_item_with_features(
+def _get_standardized_parent_deck_item(
     parent_deck_item: Union[
         LabwareDefinition3, DeckLocationDefinition, ModuleDefinition
     ],
@@ -259,34 +263,64 @@ def _parent_deck_item_with_features(
         slot_footprint_as_parent = _module_slot_footprint_as_parent(parent_deck_item)
         if slot_footprint_as_parent is not None:
             return _Labware3SupportedParentDefinition(
-                {
+                features={
                     **parent_deck_item.features,
                     "slotFootprintAsParent": slot_footprint_as_parent,
-                }
+                },
+                extents=parent_deck_item.extents,
             )
         else:
-            return _Labware3SupportedParentDefinition(parent_deck_item.features)
+            return _Labware3SupportedParentDefinition(
+                features=parent_deck_item.features, extents=parent_deck_item.extents
+            )
     elif isinstance(parent_deck_item, AddressableArea):
+        extents = Extents(
+            total=AxisAlignedBoundingBox3D(
+                backLeftBottom=Vector3D(x=0, y=0, z=0),
+                frontRightTop=Vector3D(
+                    x=parent_deck_item.bounding_box.x,
+                    y=parent_deck_item.bounding_box.y * 1,
+                    z=parent_deck_item.bounding_box.z,
+                ),
+            )
+        )
+
         slot_footprint_as_parent = _aa_slot_footprint_as_parent(parent_deck_item)
         if slot_footprint_as_parent is not None:
             return _Labware3SupportedParentDefinition(
-                {
+                features={
                     **parent_deck_item.features,
                     "slotFootprintAsParent": slot_footprint_as_parent,
-                }
+                },
+                extents=extents,
             )
         else:
-            return _Labware3SupportedParentDefinition(parent_deck_item.features)
+            return _Labware3SupportedParentDefinition(
+                parent_deck_item.features, extents=extents
+            )
     elif isinstance(parent_deck_item, LabwareDefinition3):
-        return _Labware3SupportedParentDefinition(parent_deck_item.features)
+        return _Labware3SupportedParentDefinition(
+            features=parent_deck_item.features, extents=parent_deck_item.extents
+        )
     # The slotDefV3 case.
     else:
+        extents = Extents(
+            total=AxisAlignedBoundingBox3D(
+                backLeftBottom=Vector3D(x=0, y=0, z=0),
+                frontRightTop=Vector3D(
+                    x=parent_deck_item["boundingBox"]["xDimension"],
+                    y=parent_deck_item["boundingBox"]["yDimension"] * 1,
+                    z=parent_deck_item["boundingBox"]["zDimension"],
+                ),
+            )
+        )
         slot_footprint_as_parent = _slot_def_slot_footprint_as_parent(parent_deck_item)
         return _Labware3SupportedParentDefinition(
-            {
+            features={
                 **parent_deck_item["features"],
                 "slotFootprintAsParent": slot_footprint_as_parent,
-            }
+            },
+            extents=extents,
         )
 
 

--- a/api/src/opentrons/protocol_engine/state/_labware_origin_math.py
+++ b/api/src/opentrons/protocol_engine/state/_labware_origin_math.py
@@ -463,7 +463,10 @@ def _parent_origin_to_flex_tip_rack_lid_feature(
     )
     assert flex_tip_rack_lid_as_parent is not None
 
-    return Point(x=0, y=0, z=flex_tip_rack_lid_as_parent["matingZ"])
+    x_mid = parent_deck_item.extents.total.frontRightTop.x / 2
+    y_mid = parent_deck_item.extents.total.frontRightTop.y / 2
+
+    return Point(x=x_mid, y=y_mid, z=flex_tip_rack_lid_as_parent["matingZ"])
 
 
 def _parent_origin_to_slot_bottom_center(
@@ -509,7 +512,10 @@ def _flex_tip_rack_lid_feature_to_child_origin(
     )
     assert flex_tip_rack_lid_as_child is not None
 
-    return Point(x=0, y=0, z=flex_tip_rack_lid_as_child["matingZ"])
+    x_mid = child_labware.extents.total.frontRightTop.x / 2
+    y_mid = child_labware.extents.total.frontRightTop.y / 2
+
+    return Point(x=x_mid, y=y_mid, z=flex_tip_rack_lid_as_child["matingZ"]) * -1
 
 
 def slot_bottom_center_to_child_origin(

--- a/api/src/opentrons/protocol_engine/state/_labware_origin_math.py
+++ b/api/src/opentrons/protocol_engine/state/_labware_origin_math.py
@@ -369,7 +369,7 @@ def _parent_deck_item_to_child_labware_feature_offset(
         parent_deck_item.features.get("opentronsFlexTipRackLidAsParent") is not None
         and child_labware.features.get("opentronsFlexTipRackLidAsChild") is not None
     ):
-        return _parent_origin_flex_tip_rack_lid_feature(
+        return _parent_origin_to_flex_tip_rack_lid_feature(
             parent_deck_item
         ) + _flex_tip_rack_lid_feature_to_child_origin(child_labware)
     elif (
@@ -420,7 +420,7 @@ def _get_spring_force(
     return parent_spring_force or child_spring_force
 
 
-def _parent_origin_flex_tip_rack_lid_feature(
+def _parent_origin_to_flex_tip_rack_lid_feature(
     parent_deck_item: _Labware3SupportedParentDefinition,
 ) -> Point:
     """Returns the offset from a deck item's origin to the Flex tip rack lid locating feature."""
@@ -469,7 +469,7 @@ def _parent_origin_to_slot_back_left_bottom(
 def _flex_tip_rack_lid_feature_to_child_origin(
     child_labware: LabwareDefinition3,
 ) -> Point:
-    """Returns the offset from a parent lid's Flex tip rack lid locating feature to the child origin."""
+    """Returns the offset from a Flex tip rack lid locating feature to the child origin."""
     flex_tip_rack_lid_as_child = child_labware.features.get(
         "opentronsFlexTipRackLidAsChild"
     )

--- a/api/tests/opentrons/protocol_engine/state/test_labware_origin_math.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_origin_math.py
@@ -23,6 +23,8 @@ from opentrons_shared_data.labware.types import (
     SlotFootprintAsChildFeature,
     SlotFootprintAsParentFeature,
     Vector2D,
+    OpentronsFlexTipRackLidAsChildFeature,
+    OpentronsFlexTipRackLidAsParentFeature,
 )
 
 from opentrons.types import Point
@@ -174,6 +176,43 @@ _LW_V3_WITH_SLOT_AS_PARENT_CHILD_FEATURES = LabwareDefinition3.model_construct( 
     parameters=Parameters3.model_construct(loadName="dual-feature-labware"),  # type: ignore[call-arg]
 )
 
+_LW_V3_WITH_FLEX_TIP_RACK_LID_AS_PARENT = LabwareDefinition3.model_construct(  # type: ignore[call-arg]
+    namespace="test",
+    version=1,
+    schemaVersion=3,
+    extents=Extents(
+        total=AxisAlignedBoundingBox3D(
+            backLeftBottom=Vector3D(x=0, y=0, z=0),
+            frontRightTop=Vector3D(x=1000, y=800, z=50),
+        ),
+    ),
+    features=LocatingFeatures(
+        opentronsFlexTipRackLidAsParent=OpentronsFlexTipRackLidAsParentFeature(
+            matingZ=25
+        )
+    ),
+    parameters=Parameters3.model_construct(loadName="flex-tip-rack-lid-parent"),  # type: ignore[call-arg]
+)
+
+_LW_V3_WITH_FLEX_TIP_RACK_LID_AS_CHILD = LabwareDefinition3.model_construct(  # type: ignore[call-arg]
+    namespace="test",
+    version=1,
+    schemaVersion=3,
+    extents=Extents(
+        total=AxisAlignedBoundingBox3D(
+            backLeftBottom=Vector3D(x=10, y=20, z=30),
+            frontRightTop=Vector3D(x=810, y=-580, z=830),
+        ),
+    ),
+    features=LocatingFeatures(
+        opentronsFlexTipRackLidAsChild=OpentronsFlexTipRackLidAsChildFeature(matingZ=15)
+    ),
+    stackingOffsetWithLabware={
+        "default": Vector3D(x=0, y=0, z=0),
+    },
+    parameters=Parameters3.model_construct(loadName="flex-tip-rack-lid-child"),  # type: ignore[call-arg]
+)
+
 _MODULE_DEF_TEMP_V2 = ModuleDefinition.model_construct(  # type: ignore[call-arg]
     schemaVersion=2,
     model=ModuleModel.TEMPERATURE_MODULE_V2,
@@ -226,6 +265,22 @@ _ADDRESSABLE_AREA_WITH_PARENT_FEATURES = AddressableArea(
     features=LocatingFeatures(
         slotFootprintAsParent=SlotFootprintAsParentFeature(
             backLeft=Vector2D(x=0, y=0), frontRight=Vector2D(x=150, y=120), z=15
+        )
+    ),
+    mating_surface_unit_vector=[-1, 1, -1],
+)
+
+_ADDRESSABLE_AREA_WITH_FLEX_TIP_RACK_LID = AddressableArea(
+    area_name="test_area_with_flex_lid",
+    area_type=AreaType.SLOT,
+    base_slot=DeckSlotName.SLOT_A3,
+    display_name="Test Area with Flex Tip Rack Lid",
+    bounding_box=AddressableAreaDimensions(x=1100, y=1400, z=2100),
+    position=AddressableOffsetVector(x=50, y=100, z=150),
+    compatible_module_types=[],
+    features=LocatingFeatures(
+        opentronsFlexTipRackLidAsParent=OpentronsFlexTipRackLidAsParentFeature(
+            matingZ=30
         )
     ),
     mating_surface_unit_vector=[-1, 1, -1],
@@ -445,6 +500,22 @@ LW_V3_SPECS: List[LabwareV3Spec] = [
         is_topmost_labware=True,
         labware_location=OnLabwareLocation(labwareId="labware-v3-basic"),
         expected_total_offset=Point(x=0, y=0, z=1000),
+    ),
+    LabwareV3Spec(
+        child_definition=_LW_V3_WITH_FLEX_TIP_RACK_LID_AS_CHILD,
+        parent_definition=_LW_V3_WITH_FLEX_TIP_RACK_LID_AS_PARENT,
+        is_topmost_labware=True,
+        labware_location=OnLabwareLocation(labwareId="flex-tip-rack-lid-parent"),
+        expected_total_offset=Point(x=0, y=0, z=40),
+    ),
+    LabwareV3Spec(
+        child_definition=_LW_V3_WITH_FLEX_TIP_RACK_LID_AS_CHILD,
+        parent_definition=_ADDRESSABLE_AREA_WITH_FLEX_TIP_RACK_LID,
+        is_topmost_labware=True,
+        labware_location=AddressableAreaLocation(
+            addressableAreaName="test_area_with_flex_lid"
+        ),
+        expected_total_offset=Point(x=0, y=0, z=45),
     ),
 ]
 

--- a/api/tests/opentrons/protocol_engine/state/test_labware_origin_math.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_origin_math.py
@@ -506,7 +506,7 @@ LW_V3_SPECS: List[LabwareV3Spec] = [
         parent_definition=_LW_V3_WITH_FLEX_TIP_RACK_LID_AS_PARENT,
         is_topmost_labware=True,
         labware_location=OnLabwareLocation(labwareId="flex-tip-rack-lid-parent"),
-        expected_total_offset=Point(x=95, y=690, z=10),
+        expected_total_offset=Point(x=0, y=0, z=40),
     ),
     LabwareV3Spec(
         child_definition=_LW_V3_WITH_FLEX_TIP_RACK_LID_AS_CHILD,
@@ -515,7 +515,7 @@ LW_V3_SPECS: List[LabwareV3Spec] = [
         labware_location=AddressableAreaLocation(
             addressableAreaName="test_area_with_flex_lid"
         ),
-        expected_total_offset=Point(x=145, y=990, z=15),
+        expected_total_offset=Point(x=0, y=0, z=45),
     ),
 ]
 

--- a/api/tests/opentrons/protocol_engine/state/test_labware_origin_math.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_origin_math.py
@@ -506,7 +506,7 @@ LW_V3_SPECS: List[LabwareV3Spec] = [
         parent_definition=_LW_V3_WITH_FLEX_TIP_RACK_LID_AS_PARENT,
         is_topmost_labware=True,
         labware_location=OnLabwareLocation(labwareId="flex-tip-rack-lid-parent"),
-        expected_total_offset=Point(x=0, y=0, z=40),
+        expected_total_offset=Point(x=95, y=690, z=10),
     ),
     LabwareV3Spec(
         child_definition=_LW_V3_WITH_FLEX_TIP_RACK_LID_AS_CHILD,
@@ -515,7 +515,7 @@ LW_V3_SPECS: List[LabwareV3Spec] = [
         labware_location=AddressableAreaLocation(
             addressableAreaName="test_area_with_flex_lid"
         ),
-        expected_total_offset=Point(x=0, y=0, z=45),
+        expected_total_offset=Point(x=145, y=990, z=15),
     ),
 ]
 

--- a/shared-data/labware/definitions/3/schema3test_flex_96_tiprack_200ul/999.json
+++ b/shared-data/labware/definitions/3/schema3test_flex_96_tiprack_200ul/999.json
@@ -48,6 +48,9 @@
         "x": 127.75,
         "y": -85.75
       }
+    },
+    "opentronsFlexTipRackLidAsParent": {
+      "matingZ": 84.75
     }
   },
   "gripForce": 16,

--- a/shared-data/labware/definitions/3/schema3test_flex_tiprack_lid/999.json
+++ b/shared-data/labware/definitions/3/schema3test_flex_tiprack_lid/999.json
@@ -27,17 +27,6 @@
     }
   },
   "features": {
-    "slotFootprintAsChild": {
-      "z": 0,
-      "backLeft": {
-        "x": 0,
-        "y": 0
-      },
-      "frontRight": {
-        "x": 127.7,
-        "y": -78.75
-      }
-    },
     "opentronsFlexTipRackLidAsChild": {
       "matingZ": 0
     }

--- a/shared-data/labware/definitions/3/schema3test_flex_tiprack_lid/999.json
+++ b/shared-data/labware/definitions/3/schema3test_flex_tiprack_lid/999.json
@@ -37,6 +37,9 @@
         "x": 127.7,
         "y": -78.75
       }
+    },
+    "opentronsFlexTipRackLidAsChild": {
+      "matingZ": 0
     }
   },
   "wells": {},
@@ -57,64 +60,7 @@
   "namespace": "opentrons",
   "version": 999,
   "schemaVersion": 3,
-  "stackingOffsetWithLabware": {
-    "default": {
-      "x": 0,
-      "y": 0,
-      "z": 14.25
-    },
-    "opentrons_flex_96_filtertiprack_50ul": {
-      "x": 0,
-      "y": 0,
-      "z": 14.25
-    },
-    "opentrons_flex_96_filtertiprack_200ul": {
-      "x": 0,
-      "y": 0,
-      "z": 14.25
-    },
-    "schema3test_flex_96_tiprack_200ul": {
-      "x": 0,
-      "y": 0,
-      "z": 14.25
-    },
-    "opentrons_flex_96_filtertiprack_1000ul": {
-      "x": 0,
-      "y": 0,
-      "z": 14.25
-    },
-    "opentrons_flex_96_tiprack_20ul": {
-      "x": 0,
-      "y": 0,
-      "z": 14.25
-    },
-    "opentrons_flex_96_tiprack_50ul": {
-      "x": 0,
-      "y": 0,
-      "z": 14.25
-    },
-    "opentrons_flex_96_tiprack_200ul": {
-      "x": 0,
-      "y": 0,
-      "z": 14.25
-    },
-    "opentrons_flex_96_tiprack_1000ul": {
-      "x": 0,
-      "y": 0,
-      "z": 14.25
-    }
-  },
   "stackLimit": 1,
-  "compatibleParentLabware": [
-    "opentrons_flex_96_tiprack_20ul",
-    "opentrons_flex_96_tiprack_50ul",
-    "opentrons_flex_96_tiprack_200ul",
-    "opentrons_flex_96_tiprack_1000ul",
-    "opentrons_flex_96_filtertiprack_50ul",
-    "opentrons_flex_96_filtertiprack_200ul",
-    "opentrons_flex_96_filtertiprack_1000ul",
-    "schema3test_flex_96_tiprack_200ul"
-  ],
   "gripForce": 10,
   "gripHeightFromLabwareBottom": 10,
   "gripperOffsets": {

--- a/shared-data/labware/schemas/3.json
+++ b/shared-data/labware/schemas/3.json
@@ -685,7 +685,8 @@
           "required": ["matingZ"],
           "properties": {
             "matingZ": {
-              "description": "Z-coordinate in the parent where the child makes contact. By convention, measured from the bottom of the labware."
+              "description": "Z-coordinate in the parent where the child makes contact. By convention, measured from the bottom of the labware.",
+              "type": "number"
             }
           }
         },
@@ -695,7 +696,8 @@
           "required": ["matingZ"],
           "properties": {
             "matingZ": {
-              "description": "Z-coordinate in the child where it makes contact with the parent. By convention, measured from the bottom of the lid."
+              "description": "Z-coordinate in the child where it makes contact with the parent. By convention, measured from the bottom of the lid.",
+              "type": "number"
             }
           }
         }

--- a/shared-data/labware/schemas/3.json
+++ b/shared-data/labware/schemas/3.json
@@ -678,6 +678,26 @@
               "enum": ["backLeftBottom"]
             }
           }
+        },
+        "opentronsFlexTipRackLidAsParent": {
+          "description": "Allows placement of Flex tip rack lids on this labware.",
+          "type": "object",
+          "required": ["matingZ"],
+          "properties": {
+            "matingZ": {
+              "description": "Z-coordinate in the parent where the child makes contact. By convention, measured from the bottom of the labware."
+            }
+          }
+        },
+        "opentronsFlexTipRackLidAsChild": {
+          "description": "Designates this labware as a flex tip rack lid.",
+          "type": "object",
+          "required": ["matingZ"],
+          "properties": {
+            "matingZ": {
+              "description": "Z-coordinate in the child where it makes contact with the parent. By convention, measured from the bottom of the lid."
+            }
+          }
         }
       }
     },

--- a/shared-data/python/opentrons_shared_data/labware/types.py
+++ b/shared-data/python/opentrons_shared_data/labware/types.py
@@ -172,12 +172,22 @@ class SlotFootprintAsParentFeature(TypedDict):
     springDirectionalForce: NotRequired[SpringDirectionalForce]
 
 
+class OpentronsFlexTipRackLidAsParentFeature(TypedDict):
+    matingZ: float
+
+
+class OpentronsFlexTipRackLidAsChildFeature(TypedDict):
+    matingZ: float
+
+
 class LocatingFeatures(TypedDict):
     """A dictionary of locating features."""
 
     slotFootprintAsChild: NotRequired[SlotFootprintAsChildFeature]
     slotFootprintAsParent: NotRequired[SlotFootprintAsParentFeature]
     springDirectionalForceAsParent: NotRequired[SpringDirectionalForce]
+    opentronsFlexTipRackLidAsParent: NotRequired[OpentronsFlexTipRackLidAsParentFeature]
+    opentronsFlexTipRackLidAsChild: NotRequired[OpentronsFlexTipRackLidAsChildFeature]
 
 
 class LabwareDefinition2(TypedDict):


### PR DESCRIPTION
Works toward [EXEC-77](https://opentrons.atlassian.net/browse/EXEC-77)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Adds the `opentronsFlexTipRackLidAsChild` and `opentronsFlexTipRackLidAsParent` features, which support Flex tip rack lids specifically. See the[ locating features proposal doc](https://opentrons.atlassian.net/wiki/spaces/PER/pages/5062557756/Locating+features+proposal+2#Flex-tip-rack-lids) for more info.

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing

If testing, note that the gripper movement is currently buggy and will be fixed in https://github.com/Opentrons/opentrons/pull/18920. Cherry-pick that commit to this branch if testing.

- Tested some gripper movements using various permutations of the following on a real robot:

```
requirements = {"robotType": "Flex", "apiLevel": "2.23"}

def run(protocol):
    tip_rack = protocol.load_labware("schema3test_flex_96_tiprack_200ul", "D2", version=999, lid="schema3test_flex_tiprack_lid")
    tip_rack_2 = protocol.load_labware("schema3test_flex_96_tiprack_200ul", "C2", version=999)
    labware = protocol.load_labware("schema3test_96_wellplate_200ul_pcr_full_skirt", "D1", version=999)
    chute = protocol.load_waste_chute()


    pipette = protocol.load_instrument(
        "flex_1channel_1000", "left", tip_racks=[tip_rack]
    )

    protocol.move_lid(source_location=tip_rack, new_location=chute, use_gripper=True)
```

- Ensured that moving lids into waste chutes and to/from locations involving adapters works as well.
- Placing and/or moving tip rack lids onto labware where they shouldn't be placed still fails.

<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Added schema 3 support for the flex tiprack lid locating feature.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
Still none, gated behind schema 3 definitions.
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[EXEC-77]: https://opentrons.atlassian.net/browse/EXEC-77?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ