### PR TITLE
fix(app, protocol-designer, opentrons-ai-client, components): fix build issue with css module files

### DIFF
--- a/app/cssModuleSideEffect.ts
+++ b/app/cssModuleSideEffect.ts
@@ -1,0 +1,22 @@
+import type { Plugin } from 'vite'
+
+/**
+ * Plugin to make sure CSS modules do not get tree shaked out of the dist.
+ * see https://github.com/vitejs/vite/pull/16051
+ *
+ * @returns {Plugin} The Vite plugin object.
+ */
+
+export const cssModuleSideEffect = (): Plugin => {
+  return {
+    name: 'css-module-side-effectful',
+    enforce: 'post',
+    transform(_: string, id: string) {
+      if (id.includes('.module.')) {
+        return {
+          moduleSideEffects: 'no-treeshake', // or true, which also works with slightly better treeshake
+        }
+      }
+    },
+  }
+}

--- a/app/vite.config.mts
+++ b/app/vite.config.mts
@@ -1,12 +1,15 @@
 import path from 'path'
-import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
-import postCssImport from 'postcss-import'
+import lostCss from 'lost'
 import postCssApply from 'postcss-apply'
 import postColorModFunction from 'postcss-color-mod-function'
+import postCssImport from 'postcss-import'
 import postCssPresetEnv from 'postcss-preset-env'
-import lostCss from 'lost'
+import { defineConfig } from 'vite'
+
 import { versionForProject } from '../scripts/git-version.mjs'
+import { cssModuleSideEffect } from './cssModuleSideEffect'
+
 import type { UserConfig } from 'vite'
 
 export default defineConfig(
@@ -19,7 +22,7 @@ export default defineConfig(
       build: {
         // Relative to the root
         outDir: 'dist',
-        sourcemap: true
+        sourcemap: true,
       },
       plugins: [
         react({
@@ -29,6 +32,7 @@ export default defineConfig(
             configFile: true,
           },
         }),
+        cssModuleSideEffect(),
       ],
       optimizeDeps: {
         esbuildOptions: {

--- a/components/cssModuleSideEffect.ts
+++ b/components/cssModuleSideEffect.ts
@@ -1,0 +1,22 @@
+import type { Plugin } from 'vite'
+
+/**
+ * Plugin to make sure CSS modules do not get tree shaked out of the dist.
+ * see https://github.com/vitejs/vite/pull/16051
+ *
+ * @returns {Plugin} The Vite plugin object.
+ */
+
+export const cssModuleSideEffect = (): Plugin => {
+  return {
+    name: 'css-module-side-effectful',
+    enforce: 'post',
+    transform(_: string, id: string) {
+      if (id.includes('.module.')) {
+        return {
+          moduleSideEffects: 'no-treeshake', // or true, which also works with slightly better treeshake
+        }
+      }
+    },
+  }
+}

--- a/components/vite.config.mts
+++ b/components/vite.config.mts
@@ -1,11 +1,13 @@
 import path from 'path'
-import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
-import postCssImport from 'postcss-import'
+import lostCss from 'lost'
 import postCssApply from 'postcss-apply'
 import postColorModFunction from 'postcss-color-mod-function'
+import postCssImport from 'postcss-import'
 import postCssPresetEnv from 'postcss-preset-env'
-import lostCss from 'lost'
+import { defineConfig } from 'vite'
+
+import { cssModuleSideEffect } from './cssModuleSideEffect'
 
 export default defineConfig({
   build: {
@@ -31,6 +33,7 @@ export default defineConfig({
         configFile: true,
       },
     }),
+    cssModuleSideEffect(),
   ],
   optimizeDeps: {
     esbuildOptions: {

--- a/opentrons-ai-client/cssModuleSideEffect.ts
+++ b/opentrons-ai-client/cssModuleSideEffect.ts
@@ -1,0 +1,22 @@
+import type { Plugin } from 'vite'
+
+/**
+ * Plugin to make sure CSS modules do not get tree shaked out of the dist.
+ * see https://github.com/vitejs/vite/pull/16051
+ *
+ * @returns {Plugin} The Vite plugin object.
+ */
+
+export const cssModuleSideEffect = (): Plugin => {
+  return {
+    name: 'css-module-side-effectful',
+    enforce: 'post',
+    transform(_: string, id: string) {
+      if (id.includes('.module.')) {
+        return {
+          moduleSideEffects: 'no-treeshake', // or true, which also works with slightly better treeshake
+        }
+      }
+    },
+  }
+}

--- a/opentrons-ai-client/vite.config.mts
+++ b/opentrons-ai-client/vite.config.mts
@@ -7,6 +7,8 @@ import postCssImport from 'postcss-import'
 import postCssPresetEnv from 'postcss-preset-env'
 import { defineConfig } from 'vite'
 
+import { cssModuleSideEffect } from './cssModuleSideEffect'
+
 export default defineConfig({
   // this makes imports relative rather than absolute
   base: '',
@@ -22,6 +24,7 @@ export default defineConfig({
         configFile: true,
       },
     }),
+    cssModuleSideEffect(),
   ],
   optimizeDeps: {
     esbuildOptions: {

--- a/protocol-designer/cssModuleSideEffect.ts
+++ b/protocol-designer/cssModuleSideEffect.ts
@@ -1,0 +1,22 @@
+import type { Plugin } from 'vite'
+
+/**
+ * Plugin to make sure CSS modules do not get tree shaked out of the dist.
+ * see https://github.com/vitejs/vite/pull/16051
+ *
+ * @returns {Plugin} The Vite plugin object.
+ */
+
+export const cssModuleSideEffect = (): Plugin => {
+  return {
+    name: 'css-module-side-effectful',
+    enforce: 'post',
+    transform(_: string, id: string) {
+      if (id.includes('.module.')) {
+        return {
+          moduleSideEffects: 'no-treeshake', // or true, which also works with slightly better treeshake
+        }
+      }
+    },
+  }
+}

--- a/protocol-designer/vite.config.mts
+++ b/protocol-designer/vite.config.mts
@@ -9,6 +9,7 @@ import postCssPresetEnv from 'postcss-preset-env'
 import { defineConfig } from 'vite'
 
 import { versionForProject } from '../scripts/git-version.mjs'
+import { cssModuleSideEffect } from './cssModuleSideEffect'
 
 import type { UserConfig } from 'vite'
 
@@ -35,6 +36,7 @@ export default defineConfig(
             configFile: true,
           },
         }),
+        cssModuleSideEffect(),
         {
           name: 'markdown-loader',
           transform(code, id) {


### PR DESCRIPTION
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
fix build issue with css module files

this issue happens because of vite's tree-shaking function that happened to labware-library before.

close AUTH-2108

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing

<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog

<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
