### PR TITLE
fix(app): Fix labware misaligned with stacker hopper

### DIFF
--- a/components/src/hardware-sim/BaseDeck/BaseDeck.tsx
+++ b/components/src/hardware-sim/BaseDeck/BaseDeck.tsx
@@ -89,9 +89,15 @@ export interface HopperLabwareProps {
 // these ugly consts are unfortunately necessary as the hopper location exists
 // outside of our deck definition so the render doesn't follow our normal conventions
 export const STACKER_MODULE_Y_OFFSET = -6
-export const STACKER_HOPPER_LABWARE_X_OFFSET = 178.5
-export const STACKER_HOPPER_LABWARE_Y_OFFSET = 7
+// todo(mm, 2025-07-16): 17.5 mm is a by-eye adjustment that takes us from a little bit
+// left of the hopper to inside the hopper. The fact that we were 17.5 mm left in the
+// first place is weird, and suggests we're doing wrong math somewhere. A more normal
+// thing to expect here would be starting at the extended shuttle position and needing
+// an offset of hundreds of mm to go from there to inside the hopper.
+export const STACKER_HOPPER_LABWARE_X_OFFSET = 17.5
+export const STACKER_HOPPER_LABWARE_Y_OFFSET = 6
 export const STACKER_DECK_VIEW_BOX_EXPANSION = 220
+
 interface BaseDeckProps {
   deckConfig: DeckConfiguration
   robotType: RobotType


### PR DESCRIPTION
## Overview

Fixes visual misalignment of labware in a stacker hopper.

The full story is a mess, but the short story is: we have some hard-coded, by-eye adjustments that apply on top of the `labwareOffset` in the module definition; the `labwareOffset` got updated in #18889 and #18921; so these hard-coded numbers need to get updated too.

## Test Plan and Hands on Testing

* [x] Checked the map view in labware setup.

Before:
<img width="877" height="645" alt="Screenshot 2025-07-16 at 3 30 00 PM" src="https://github.com/user-attachments/assets/c59ae3ab-2f2a-4add-b6bc-4960cfc6cb9f" />

After:
<img width="861" height="644" alt="Screenshot 2025-07-16 at 5 06 13 PM" src="https://github.com/user-attachments/assets/c85cba35-5972-4126-80fc-e4fb6dd83b2d" />


## Review requests

See below.

## Risk assessment

Lowish? 