### PR TITLE
fix(shared-data): correct multi dispense alias

### DIFF
--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -1230,3 +1230,107 @@ def custom_pip_n_tip_transfer_properties_dict() -> Dict[
             )
         }
     }
+
+
+@pytest.fixture
+def custom_pip_n_tip_transfer_properties_dict_v2() -> Dict[str, Dict[str, Any]]:
+    """A minimal dictionary representation of transfer properties for a custom pipette and tiprack."""
+    return {
+        "a_custom_pipette_type": {
+            "a_custom_tiprack_uri": {
+                "aspirate": {
+                    "aspirate_position": {
+                        "offset": {"x": 1, "y": 2, "z": 3},
+                        "position_reference": "well-bottom",
+                    },
+                    "correction_by_volume": [(0.0, 0.0)],
+                    "delay": {"enable": False},
+                    "flow_rate_by_volume": [(10.0, 40.0), (20.0, 30.0)],
+                    "mix": {"enable": False},
+                    "pre_wet": True,
+                    "retract": {
+                        "air_gap_by_volume": [(5.0, 3.0), (10.0, 4.0)],
+                        "delay": {"enable": False},
+                        "end_position": {
+                            "offset": {"x": 1, "y": 2, "z": 3},
+                            "position_reference": "well-bottom",
+                        },
+                        "speed": 40,
+                        "touch_tip": {"enable": False},
+                    },
+                    "submerge": {
+                        "delay": {"enable": False},
+                        "speed": 100,
+                        "start_position": {
+                            "offset": {"x": 1, "y": 2, "z": 3},
+                            "position_reference": "well-bottom",
+                        },
+                    },
+                },
+                "dispense": {
+                    "dispense_position": {
+                        "offset": {"x": 1, "y": 2, "z": 3},
+                        "position_reference": "well-bottom",
+                    },
+                    "correction_by_volume": [(0.0, 0.0)],
+                    "delay": {"enable": False},
+                    "flow_rate_by_volume": [(10.0, 40.0), (20.0, 30.0)],
+                    "mix": {"enable": False},
+                    "push_out_by_volume": [(10.0, 7.0), (20.0, 10.0)],
+                    "retract": {
+                        "air_gap_by_volume": [(5.0, 3.0), (10.0, 4.0)],
+                        "blowout": {"enable": False},
+                        "delay": {"enable": False},
+                        "end_position": {
+                            "offset": {"x": 1, "y": 2, "z": 3},
+                            "position_reference": "well-bottom",
+                        },
+                        "speed": 40,
+                        "touch_tip": {"enable": False},
+                    },
+                    "submerge": {
+                        "delay": {"enable": False},
+                        "speed": 100,
+                        "start_position": {
+                            "offset": {"x": 1, "y": 2, "z": 3},
+                            "position_reference": "well-bottom",
+                        },
+                    },
+                },
+                "multi_dispense": {
+                    "dispense_position": {
+                        "offset": {"x": 0, "y": 0, "z": 1},
+                        "position_reference": "well-bottom",
+                    },
+                    "flow_rate_by_volume": [(0, 318)],
+                    "correction_by_volume": [(0, 0)],
+                    "delay": {"enabled": False},
+                    "submerge": {
+                        "delay": {"enabled": False},
+                        "speed": 100,
+                        "start_position": {
+                            "offset": {"x": 0, "y": 0, "z": 2},
+                            "position_reference": "well-top",
+                        },
+                    },
+                    "retract": {
+                        "air_gap_by_volume": [(0, 0)],
+                        "delay": {"enabled": False},
+                        "end_position": {
+                            "offset": {"x": 0, "y": 0, "z": 2},
+                            "position_reference": "well-top",
+                        },
+                        "speed": 50,
+                        "touch_tip": {"enabled": False},
+                        "blowout": {
+                            "enabled": True,
+                            "location": "trash",
+                            "flow_rate": 478,
+                        },
+                    },
+                    "conditioning_by_volume": [(0, 0)],
+                    "disposal_by_volume": [(0, 5)],
+                },
+            }
+        }
+    }

--- a/api/tests/opentrons/protocol_api_integration/test_liquid_classes.py
+++ b/api/tests/opentrons/protocol_api_integration/test_liquid_classes.py
@@ -1,5 +1,5 @@
 """Tests for the APIs around liquid classes."""
-from typing import Dict
+from typing import Dict, Any
 
 import pytest
 
@@ -69,6 +69,39 @@ def test_custom_liquid_class_creation_and_property_fetching(
     custom_water_props = custom_water.get_for(p50, tiprack)
     assert custom_water_props.aspirate.submerge.speed == 100
     assert custom_water_props.dispense.flow_rate_by_volume.get_for_volume(20) == 30
+
+    with pytest.raises(
+        ValueError,
+        match="No properties found for flex_8channel_50 in water_50 liquid class",
+    ):
+        custom_water.get_for(
+            "flex_8channel_50", "opentrons/opentrons_flex_96_tiprack_50ul/1"
+        )
+
+
+@pytest.mark.ot3_only
+@pytest.mark.parametrize(
+    "simulated_protocol_context", [("2.24", "Flex")], indirect=True
+)
+def test_custom_liquid_class_w_multi_dispense_creation_and_property_fetching(
+    simulated_protocol_context: ProtocolContext,
+    custom_pip_n_tip_transfer_properties_dict_v2: Dict[str, Dict[str, Any]],
+) -> None:
+    """It should create the liquid class with specified properties and provide access to its properties."""
+    p50 = "a_custom_pipette_type"
+    tiprack = "a_custom_tiprack_uri"
+    custom_water = simulated_protocol_context.define_liquid_class(
+        name="water_50",
+        properties=custom_pip_n_tip_transfer_properties_dict_v2,
+        display_name="Custom Aqueous",
+    )
+
+    assert custom_water.name == "water_50"
+    assert custom_water.display_name == "Custom Aqueous"
+    custom_water_props = custom_water.get_for(p50, tiprack)
+    assert custom_water_props.aspirate.retract.speed == 40
+    assert custom_water_props.dispense.submerge.speed == 100
+    assert custom_water_props.multi_dispense.retract.blowout.location.value == "trash"  # type: ignore[union-attr]
 
     with pytest.raises(
         ValueError,

--- a/shared-data/python/opentrons_shared_data/liquid_classes/liquid_class_definition.py
+++ b/shared-data/python/opentrons_shared_data/liquid_classes/liquid_class_definition.py
@@ -508,7 +508,7 @@ class TransferProperties(BaseLiquidClassModel):
     )
     multiDispense: MultiDispenseProperties | SkipJsonSchema[None] = Field(
         None,
-        alias="multi-dispense",
+        alias="multi_dispense",
         description="Optional multi-dispense parameters for this tip type.",
         json_schema_extra=_remove_default,
     )

--- a/shared-data/python/opentrons_shared_data/liquid_classes/types.py
+++ b/shared-data/python/opentrons_shared_data/liquid_classes/types.py
@@ -119,6 +119,7 @@ class MultiDispensePropertiesDict(TypedDict):
     dispense_position: TipPositionDict
     retract: RetractDispenseDict
     conditioning_by_volume: Sequence[Tuple[float, float]]
+    disposal_by_volume: Sequence[Tuple[float, float]]
 
 
 class TransferPropertiesDict(TypedDict):

--- a/shared-data/python_tests/conftest.py
+++ b/shared-data/python_tests/conftest.py
@@ -1,0 +1,108 @@
+"""Fixtures and helpers for python tests."""
+
+import pytest
+from typing import Any, Dict
+
+
+@pytest.fixture
+def sample_transfer_properties_dict() -> Dict[str, Dict[str, Any]]:
+    """A dictionary representation of transfer properties of a liquid class."""
+    return {
+        "flex_1channel_50": {
+            "opentrons/opentrons_flex_96_tiprack_50ul/1": {
+                "aspirate": {
+                    "aspirate_position": {
+                        "offset": {"x": 1, "y": 2, "z": 3},
+                        "position_reference": "well-bottom",
+                    },
+                    "correction_by_volume": [(0.0, 0.0)],
+                    "delay": {"enable": False},
+                    "flow_rate_by_volume": [(10.0, 40.0), (20.0, 30.0)],
+                    "mix": {"enable": False},
+                    "pre_wet": True,
+                    "retract": {
+                        "air_gap_by_volume": [(5.0, 3.0), (10.0, 4.0)],
+                        "delay": {"enable": False},
+                        "end_position": {
+                            "offset": {"x": 1, "y": 2, "z": 3},
+                            "position_reference": "well-bottom",
+                        },
+                        "speed": 40,
+                        "touch_tip": {"enable": False},
+                    },
+                    "submerge": {
+                        "delay": {"enable": False},
+                        "speed": 100,
+                        "start_position": {
+                            "offset": {"x": 1, "y": 2, "z": 3},
+                            "position_reference": "well-bottom",
+                        },
+                    },
+                },
+                "dispense": {
+                    "dispense_position": {
+                        "offset": {"x": 1, "y": 2, "z": 3},
+                        "position_reference": "well-bottom",
+                    },
+                    "correction_by_volume": [(0.0, 0.0)],
+                    "delay": {"enable": False},
+                    "flow_rate_by_volume": [(10.0, 40.0), (20.0, 30.0)],
+                    "mix": {"enable": False},
+                    "push_out_by_volume": [(10.0, 7.0), (20.0, 10.0)],
+                    "retract": {
+                        "air_gap_by_volume": [(5.0, 3.0), (10.0, 4.0)],
+                        "blowout": {"enable": False},
+                        "delay": {"enable": False},
+                        "end_position": {
+                            "offset": {"x": 1, "y": 2, "z": 3},
+                            "position_reference": "well-bottom",
+                        },
+                        "speed": 40,
+                        "touch_tip": {"enable": False},
+                    },
+                    "submerge": {
+                        "delay": {"enable": False},
+                        "speed": 100,
+                        "start_position": {
+                            "offset": {"x": 1, "y": 2, "z": 3},
+                            "position_reference": "well-bottom",
+                        },
+                    },
+                },
+                "multi_dispense": {
+                    "dispense_position": {
+                        "offset": {"x": 0, "y": 0, "z": 1},
+                        "position_reference": "well-bottom",
+                    },
+                    "flow_rate_by_volume": [(0, 318)],
+                    "correction_by_volume": [(0, 0)],
+                    "delay": {"enabled": False},
+                    "submerge": {
+                        "delay": {"enabled": False},
+                        "speed": 100,
+                        "start_position": {
+                            "offset": {"x": 0, "y": 0, "z": 2},
+                            "position_reference": "well-top",
+                        },
+                    },
+                    "retract": {
+                        "air_gap_by_volume": [(0, 0)],
+                        "delay": {"enabled": False},
+                        "end_position": {
+                            "offset": {"x": 0, "y": 0, "z": 2},
+                            "position_reference": "well-top",
+                        },
+                        "speed": 50,
+                        "touch_tip": {"enabled": False},
+                        "blowout": {
+                            "enabled": True,
+                            "location": "trash",
+                            "flow_rate": 478,
+                        },
+                    },
+                    "conditioning_by_volume": [(0, 0)],
+                    "disposal_by_volume": [(0, 5)],
+                },
+            }
+        }
+    }

--- a/shared-data/python_tests/liquid_classes/test_validations.py
+++ b/shared-data/python_tests/liquid_classes/test_validations.py
@@ -18,110 +18,6 @@ from opentrons_shared_data.liquid_classes.liquid_class_definition import (
 )
 
 
-@pytest.fixture
-def sample_transfer_properties_dict() -> Dict[str, Dict[str, Any]]:
-    """A dictionary representation of transfer properties of a liquid class."""
-    return {
-        "flex_1channel_50": {
-            "opentrons/opentrons_flex_96_tiprack_50ul/1": {
-                "aspirate": {
-                    "aspirate_position": {
-                        "offset": {"x": 1, "y": 2, "z": 3},
-                        "position_reference": "well-bottom",
-                    },
-                    "correction_by_volume": [(0.0, 0.0)],
-                    "delay": {"enable": False},
-                    "flow_rate_by_volume": [(10.0, 40.0), (20.0, 30.0)],
-                    "mix": {"enable": False},
-                    "pre_wet": True,
-                    "retract": {
-                        "air_gap_by_volume": [(5.0, 3.0), (10.0, 4.0)],
-                        "delay": {"enable": False},
-                        "end_position": {
-                            "offset": {"x": 1, "y": 2, "z": 3},
-                            "position_reference": "well-bottom",
-                        },
-                        "speed": 40,
-                        "touch_tip": {"enable": False},
-                    },
-                    "submerge": {
-                        "delay": {"enable": False},
-                        "speed": 100,
-                        "start_position": {
-                            "offset": {"x": 1, "y": 2, "z": 3},
-                            "position_reference": "well-bottom",
-                        },
-                    },
-                },
-                "dispense": {
-                    "dispense_position": {
-                        "offset": {"x": 1, "y": 2, "z": 3},
-                        "position_reference": "well-bottom",
-                    },
-                    "correction_by_volume": [(0.0, 0.0)],
-                    "delay": {"enable": False},
-                    "flow_rate_by_volume": [(10.0, 40.0), (20.0, 30.0)],
-                    "mix": {"enable": False},
-                    "push_out_by_volume": [(10.0, 7.0), (20.0, 10.0)],
-                    "retract": {
-                        "air_gap_by_volume": [(5.0, 3.0), (10.0, 4.0)],
-                        "blowout": {"enable": False},
-                        "delay": {"enable": False},
-                        "end_position": {
-                            "offset": {"x": 1, "y": 2, "z": 3},
-                            "position_reference": "well-bottom",
-                        },
-                        "speed": 40,
-                        "touch_tip": {"enable": False},
-                    },
-                    "submerge": {
-                        "delay": {"enable": False},
-                        "speed": 100,
-                        "start_position": {
-                            "offset": {"x": 1, "y": 2, "z": 3},
-                            "position_reference": "well-bottom",
-                        },
-                    },
-                },
-                "multi_dispense": {
-                    "dispense_position": {
-                        "offset": {"x": 0, "y": 0, "z": 1},
-                        "position_reference": "well-bottom",
-                    },
-                    "flow_rate_by_volume": [(0, 318)],
-                    "correction_by_volume": [(0, 0)],
-                    "delay": {"enabled": False},
-                    "submerge": {
-                        "delay": {"enabled": False},
-                        "speed": 100,
-                        "start_position": {
-                            "offset": {"x": 0, "y": 0, "z": 2},
-                            "position_reference": "well-top",
-                        },
-                    },
-                    "retract": {
-                        "air_gap_by_volume": [(0, 0)],
-                        "delay": {"enabled": False},
-                        "end_position": {
-                            "offset": {"x": 0, "y": 0, "z": 2},
-                            "position_reference": "well-top",
-                        },
-                        "speed": 50,
-                        "touch_tip": {"enabled": False},
-                        "blowout": {
-                            "enabled": True,
-                            "location": "trash",
-                            "flow_rate": 478,
-                        },
-                    },
-                    "conditioning_by_volume": [(0, 0)],
-                    "disposal_by_volume": [(0, 5)],
-                },
-            }
-        }
-    }
-
-
 def _get_all_liquid_classes() -> List[str]:
     return [
         deffile.stem
@@ -246,7 +142,7 @@ def test_validate_aspirate_properties_dict(
     )
     assert isinstance(obj, AspirateProperties)
     assert obj.aspiratePosition.positionReference == PositionReference.WELL_BOTTOM
-    assert obj.mix.enable == False
+    assert obj.mix.enable is False
 
 
 def test_validate_single_dispense_properties_dict(
@@ -260,7 +156,7 @@ def test_validate_single_dispense_properties_dict(
     )
     assert isinstance(obj, SingleDispenseProperties)
     assert obj.dispensePosition.positionReference == PositionReference.WELL_BOTTOM
-    assert obj.mix.enable == False
+    assert obj.mix.enable is False
 
 
 def test_validate_multi_dispense_properties_dict(
@@ -292,5 +188,5 @@ def test_validate_transfer_properties_dict(
         obj.aspirate.aspiratePosition.positionReference == PositionReference.WELL_BOTTOM
     )
     assert obj.singleDispense.pushOutByVolume == [(10.0, 7.0), (20.0, 10.0)]
-    assert obj.multiDispense.conditioningByVolume == [(0, 0)]
-    assert obj.multiDispense.disposalByVolume == [(0, 5)]
+    assert obj.multiDispense.conditioningByVolume == [(0, 0)]  # type: ignore[union-attr]
+    assert obj.multiDispense.disposalByVolume == [(0, 5)]  # type: ignore[union-attr]

--- a/shared-data/python_tests/liquid_classes/test_validations.py
+++ b/shared-data/python_tests/liquid_classes/test_validations.py
@@ -1,6 +1,6 @@
 """Tests that validate the built-in liquid class definitions."""
 import pytest
-from typing import List
+from typing import List, Dict, Any
 
 from opentrons_shared_data import get_shared_data_root
 from opentrons_shared_data.liquid_classes import load_definition
@@ -10,7 +10,116 @@ from opentrons_shared_data.liquid_classes.liquid_class_definition import (
     TouchTipProperties,
     BlowoutProperties,
     BlowoutLocation,
+    AspirateProperties,
+    PositionReference,
+    SingleDispenseProperties,
+    MultiDispenseProperties,
+    TransferProperties,
 )
+
+
+@pytest.fixture
+def sample_transfer_properties_dict() -> Dict[str, Dict[str, Any]]:
+    """A dictionary representation of transfer properties of a liquid class."""
+    return {
+        "flex_1channel_50": {
+            "opentrons/opentrons_flex_96_tiprack_50ul/1": {
+                "aspirate": {
+                    "aspirate_position": {
+                        "offset": {"x": 1, "y": 2, "z": 3},
+                        "position_reference": "well-bottom",
+                    },
+                    "correction_by_volume": [(0.0, 0.0)],
+                    "delay": {"enable": False},
+                    "flow_rate_by_volume": [(10.0, 40.0), (20.0, 30.0)],
+                    "mix": {"enable": False},
+                    "pre_wet": True,
+                    "retract": {
+                        "air_gap_by_volume": [(5.0, 3.0), (10.0, 4.0)],
+                        "delay": {"enable": False},
+                        "end_position": {
+                            "offset": {"x": 1, "y": 2, "z": 3},
+                            "position_reference": "well-bottom",
+                        },
+                        "speed": 40,
+                        "touch_tip": {"enable": False},
+                    },
+                    "submerge": {
+                        "delay": {"enable": False},
+                        "speed": 100,
+                        "start_position": {
+                            "offset": {"x": 1, "y": 2, "z": 3},
+                            "position_reference": "well-bottom",
+                        },
+                    },
+                },
+                "dispense": {
+                    "dispense_position": {
+                        "offset": {"x": 1, "y": 2, "z": 3},
+                        "position_reference": "well-bottom",
+                    },
+                    "correction_by_volume": [(0.0, 0.0)],
+                    "delay": {"enable": False},
+                    "flow_rate_by_volume": [(10.0, 40.0), (20.0, 30.0)],
+                    "mix": {"enable": False},
+                    "push_out_by_volume": [(10.0, 7.0), (20.0, 10.0)],
+                    "retract": {
+                        "air_gap_by_volume": [(5.0, 3.0), (10.0, 4.0)],
+                        "blowout": {"enable": False},
+                        "delay": {"enable": False},
+                        "end_position": {
+                            "offset": {"x": 1, "y": 2, "z": 3},
+                            "position_reference": "well-bottom",
+                        },
+                        "speed": 40,
+                        "touch_tip": {"enable": False},
+                    },
+                    "submerge": {
+                        "delay": {"enable": False},
+                        "speed": 100,
+                        "start_position": {
+                            "offset": {"x": 1, "y": 2, "z": 3},
+                            "position_reference": "well-bottom",
+                        },
+                    },
+                },
+                "multi_dispense": {
+                    "dispense_position": {
+                        "offset": {"x": 0, "y": 0, "z": 1},
+                        "position_reference": "well-bottom",
+                    },
+                    "flow_rate_by_volume": [(0, 318)],
+                    "correction_by_volume": [(0, 0)],
+                    "delay": {"enabled": False},
+                    "submerge": {
+                        "delay": {"enabled": False},
+                        "speed": 100,
+                        "start_position": {
+                            "offset": {"x": 0, "y": 0, "z": 2},
+                            "position_reference": "well-top",
+                        },
+                    },
+                    "retract": {
+                        "air_gap_by_volume": [(0, 0)],
+                        "delay": {"enabled": False},
+                        "end_position": {
+                            "offset": {"x": 0, "y": 0, "z": 2},
+                            "position_reference": "well-top",
+                        },
+                        "speed": 50,
+                        "touch_tip": {"enabled": False},
+                        "blowout": {
+                            "enabled": True,
+                            "location": "trash",
+                            "flow_rate": 478,
+                        },
+                    },
+                    "conditioning_by_volume": [(0, 0)],
+                    "disposal_by_volume": [(0, 5)],
+                },
+            }
+        }
+    }
 
 
 def _get_all_liquid_classes() -> List[str]:
@@ -124,3 +233,64 @@ def test_validate_blowout_properties_dict() -> None:
                 "params": {"foo": "bar"},
             }
         )
+
+
+def test_validate_aspirate_properties_dict(
+    sample_transfer_properties_dict: Dict[str, Dict[str, Any]],
+) -> None:
+    """Aspirate properties model validator should convert valid dict to AspirateProperties."""
+    obj = AspirateProperties.model_validate(
+        sample_transfer_properties_dict["flex_1channel_50"][
+            "opentrons/opentrons_flex_96_tiprack_50ul/1"
+        ]["aspirate"]
+    )
+    assert isinstance(obj, AspirateProperties)
+    assert obj.aspiratePosition.positionReference == PositionReference.WELL_BOTTOM
+    assert obj.mix.enable == False
+
+
+def test_validate_single_dispense_properties_dict(
+    sample_transfer_properties_dict: Dict[str, Dict[str, Any]],
+) -> None:
+    """Single dispense properties model validator should convert valid dict to SingleDispenseProperties."""
+    obj = SingleDispenseProperties.model_validate(
+        sample_transfer_properties_dict["flex_1channel_50"][
+            "opentrons/opentrons_flex_96_tiprack_50ul/1"
+        ]["dispense"]
+    )
+    assert isinstance(obj, SingleDispenseProperties)
+    assert obj.dispensePosition.positionReference == PositionReference.WELL_BOTTOM
+    assert obj.mix.enable == False
+
+
+def test_validate_multi_dispense_properties_dict(
+    sample_transfer_properties_dict: Dict[str, Dict[str, Any]],
+) -> None:
+    """Multi dispense properties model validator should convert valid dict to MultiDispenseProperties."""
+    obj = MultiDispenseProperties.model_validate(
+        sample_transfer_properties_dict["flex_1channel_50"][
+            "opentrons/opentrons_flex_96_tiprack_50ul/1"
+        ]["multi_dispense"]
+    )
+    assert isinstance(obj, MultiDispenseProperties)
+    assert obj.dispensePosition.positionReference == PositionReference.WELL_BOTTOM
+    assert obj.conditioningByVolume == [(0, 0)]
+    assert obj.disposalByVolume == [(0, 5)]
+
+
+def test_validate_transfer_properties_dict(
+    sample_transfer_properties_dict: Dict[str, Dict[str, Any]],
+) -> None:
+    """Transfer properties model validator should convert valid dict to TransferProperties."""
+    obj = TransferProperties.model_validate(
+        sample_transfer_properties_dict["flex_1channel_50"][
+            "opentrons/opentrons_flex_96_tiprack_50ul/1"
+        ]
+    )
+    assert isinstance(obj, TransferProperties)
+    assert (
+        obj.aspirate.aspiratePosition.positionReference == PositionReference.WELL_BOTTOM
+    )
+    assert obj.singleDispense.pushOutByVolume == [(10.0, 7.0), (20.0, 10.0)]
+    assert obj.multiDispense.conditioningByVolume == [(0, 0)]
+    assert obj.multiDispense.disposalByVolume == [(0, 5)]


### PR DESCRIPTION
Fixes AUTH-2105

# Overview

Fixes a typo where alias for `multiDispense` was using a hyphen instead of underscore (`multi_dispense`).
Adds tests to make sure a correct liquid class dictionary creates correct custom liquid class object.

This should now fix the linked issue where `distribute_with_liquid_class()` was doing only 1:1 transfers instead of doing multi-dispenses when used with a custom liquid class.

## Test Plan and Hands on Testing

- Added integration and unit tests
- Tested with PD protocol for distribute

## Review requests

- Usual stuff

## Risk assessment

None. Bug fix only.