### PR TITLE
chore(ci): Try to fix Sentry uploads

### DIFF
--- a/.github/workflows/pd-test-build-deploy.yaml
+++ b/.github/workflows/pd-test-build-deploy.yaml
@@ -79,7 +79,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # Required for getsentry/action-release.
+          fetch-depth: 0 # Unlimited fetch depth. Required for getsentry/action-release.
       - uses: ./.github/actions/js/setup
       - name: 'build PD'
         env:
@@ -124,7 +124,7 @@ jobs:
       - name: 'Checkout Repository'
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # Required for getsentry/action-release.
+          fetch-depth: 0 # Unlimited fetch depth. Required for getsentry/action-release.
 
       - uses: ./.github/actions/git/resolve-tag
 

--- a/.github/workflows/pd-test-build-deploy.yaml
+++ b/.github/workflows/pd-test-build-deploy.yaml
@@ -79,7 +79,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 0 # Required for getsentry/action-release.
       - uses: ./.github/actions/js/setup
       - name: 'build PD'
         env:
@@ -123,6 +123,8 @@ jobs:
           aws-region: us-east-2
       - name: 'Checkout Repository'
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Required for getsentry/action-release.
 
       - uses: ./.github/actions/git/resolve-tag
 


### PR DESCRIPTION
## Overview

This tries to fix this recurring error in CI (e.g. [here](https://github.com/Opentrons/opentrons/actions/runs/16323485600/job/46108539378?pr=18923)):

> error: Could not find the SHA of the previous release in the git history. If you limit the clone depth, try to increase it. Otherwise, it means that the commit we are looking for was amended or squashed and cannot be retrieved. Use --ignore-missing flag to skip it and create a new release with the default commits count.

## Test Plan and Hands on Testing

Well, if it fails on this PR, we know it didn't work. :P

## Changelog

https://github.com/getsentry/action-release says we need to pass `fetch-depth: 0` to `@actions/checkout`, which, unintuitively, means "fetch everything," as opposed to the default `fetch-depth: 1`, which is shallow. This does that.

## Review requests

There are other questionable-looking things in this workflow file that I haven't touched:

* We are doing `environment: production` even when this runs on PRs.
* We are passing `version: ${{ steps.resolve-tag.outputs.tag }}`. As far as I can tell, that output...has never actually existed?
  * The raw logs show `INPUT_VERSION` and `INPUT_RELEASE` blank.

Any thoughts on those?

## Risk assessment

Low.