### PR TITLE
feat(app): generate loadLiquidClass in JSON commands for QT

### DIFF
--- a/app/src/organisms/ODD/QuickTransferFlow/Overview.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/Overview.tsx
@@ -14,6 +14,7 @@ import {
 } from '@opentrons/components'
 import {
   FLEX_SINGLE_SLOT_BY_CUTOUT_ID,
+  getAllLiquidClassDefs,
   TRASH_BIN_ADAPTER_FIXTURE,
 } from '@opentrons/shared-data'
 
@@ -31,7 +32,7 @@ export function Overview(props: OverviewProps): JSX.Element | null {
   const { state } = props
   const { t } = useTranslation(['quick_transfer', 'shared'])
   const { makeSnackbar } = useToaster()
-
+  const allLiquidClasses = getAllLiquidClassDefs()
   let transferCopy = t('volume_per_well')
   if (state.transferType === CONSOLIDATE) {
     transferCopy = t('aspirate_volume')
@@ -90,7 +91,7 @@ export function Overview(props: OverviewProps): JSX.Element | null {
     },
     {
       option: t('liquid_class'),
-      value: state?.liquidClass?.displayName,
+      value: allLiquidClasses[state?.liquidClassName]?.displayName,
     },
   ]
 

--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/BlowOut.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/BlowOut.tsx
@@ -15,18 +15,15 @@ import {
   StyledText,
 } from '@opentrons/components'
 import {
-  ETHANOL_LIQUID_CLASS_NAME,
   FLEX_SINGLE_SLOT_BY_CUTOUT_ID,
   getAllLiquidClassDefs,
   getFlexNameConversion,
   getTipTypeFromTipRackDefinition,
-  GLYCEROL_LIQUID_CLASS_NAME,
   linearInterpolate,
   LOW_VOLUME_PIPETTES,
   NONE_LIQUID_CLASS_NAME,
   TRASH_BIN_ADAPTER_FIXTURE,
   WASTE_CHUTE_FIXTURES,
-  WATER_LIQUID_CLASS_NAME,
 } from '@opentrons/shared-data'
 import { getTransferPlanAndReferenceVolumes } from '@opentrons/step-generation'
 
@@ -217,16 +214,8 @@ export function BlowOut(props: BlowOutProps): JSX.Element {
       : liquidSpecs.default.supportedTips[tipType]
 
   const allLiquidClassDefs = getAllLiquidClassDefs()
-  const liquidClassMap = new Map<string, string>([
-    ['none', NONE_LIQUID_CLASS_NAME],
-    ['water', WATER_LIQUID_CLASS_NAME],
-    ['glycerol_50', GLYCEROL_LIQUID_CLASS_NAME],
-    ['ethanol_80', ETHANOL_LIQUID_CLASS_NAME],
-  ])
 
-  const selectedLiquidClass = liquidClassMap.get(
-    state.liquidClass?.liquidClassName ?? 'none'
-  )
+  const selectedLiquidClass = state.liquidClassName
   const liquidClassDef =
     allLiquidClassDefs[selectedLiquidClass ?? NONE_LIQUID_CLASS_NAME]
   const convertedPipetteName =

--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/ResetAdvancedSettingsModal.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/ResetAdvancedSettingsModal.tsx
@@ -8,6 +8,7 @@ import {
   SPACING,
   StyledText,
 } from '@opentrons/components'
+import { getAllLiquidClassDefs } from '@opentrons/shared-data'
 
 import { getTopPortalEl } from '/app/App/portal'
 import { SmallButton } from '/app/atoms/buttons'
@@ -36,7 +37,11 @@ export function ResetAdvancedSettingsModal({
   onClose,
 }: ResetAdvancedSettingsModalProps): JSX.Element {
   const { i18n, t } = useTranslation(['quick_transfer', 'shared'])
-  const { liquidClass } = state
+  const { liquidClassName: stateLiquidClassName } = state
+  const liquidClass =
+    stateLiquidClassName != null && stateLiquidClassName !== 'none'
+      ? getAllLiquidClassDefs()[stateLiquidClassName]
+      : { displayName: 'none', liquidClassName: 'none' }
   const { displayName, liquidClassName } = liquidClass
   const modalHeader = {
     title: t('reset_kind_settings', { transferName: kind }),
@@ -61,7 +66,7 @@ export function ResetAdvancedSettingsModal({
     })
     onClose()
   }
-
+  console.log(liquidClassName)
   return createPortal(
     <OddModal {...modalProps}>
       <Flex flexDirection={DIRECTION_COLUMN} gap={SPACING.spacing32}>

--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/ResetAdvancedSettingsModal.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/ResetAdvancedSettingsModal.tsx
@@ -66,7 +66,7 @@ export function ResetAdvancedSettingsModal({
     })
     onClose()
   }
-  console.log(liquidClassName)
+
   return createPortal(
     <OddModal {...modalProps}>
       <Flex flexDirection={DIRECTION_COLUMN} gap={SPACING.spacing32}>

--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/__tests__/ResetAdvancedSettingsModal.test.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/__tests__/ResetAdvancedSettingsModal.test.tsx
@@ -1,6 +1,8 @@
 import { fireEvent, screen } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { WATER_LIQUID_CLASS_NAME } from '@opentrons/shared-data'
+
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
 
@@ -8,7 +10,6 @@ import QuickTransferState from '../__fixtures__/QuickTransferState.json'
 import { ResetAdvancedSettingsModal } from '../ResetAdvancedSettingsModal'
 
 import type { ComponentProps } from 'react'
-import type { LiquidClass } from '@opentrons/shared-data'
 
 vi.mock('../../utils/retrieveLiquidClassValues')
 
@@ -26,10 +27,7 @@ describe('ResetAdvancedSettingsModal', () => {
       kind: 'aspirate',
       state: {
         ...QuickTransferState,
-        liquidClass: {
-          displayName: 'Water',
-          liquidClassName: 'water',
-        } as LiquidClass,
+        liquidClassName: WATER_LIQUID_CLASS_NAME,
       } as any,
       dispatch: vi.fn(),
       onClose: vi.fn(),
@@ -40,17 +38,14 @@ describe('ResetAdvancedSettingsModal', () => {
     render(props)
     screen.getByText('Reset aspirate settings?')
     screen.getByText(
-      'Continuing will undo any changes and restore the aspirate settings to the values associated with the Water liquid class.'
+      'Continuing will undo any changes and restore the aspirate settings to the values associated with the Aqueous liquid class.'
     )
     screen.getByText('Cancel')
     screen.getByText('Continue')
   })
 
   it('renders the modal with correct title and description - aspirate', () => {
-    props.state.liquidClass = {
-      displayName: '',
-      liquidClassName: 'none',
-    } as LiquidClass
+    props.state.liquidClassName = 'none'
     render(props)
     screen.getByText('Reset aspirate settings?')
     screen.getByText(
@@ -65,7 +60,7 @@ describe('ResetAdvancedSettingsModal', () => {
     render(props)
     screen.getByText('Reset dispense settings?')
     screen.getByText(
-      'Continuing will undo any changes and restore the dispense settings to the values associated with the Water liquid class.'
+      'Continuing will undo any changes and restore the dispense settings to the values associated with the Aqueous liquid class.'
     )
     screen.getByText('Cancel')
     screen.getByText('Continue')
@@ -73,10 +68,7 @@ describe('ResetAdvancedSettingsModal', () => {
 
   it('renders the modal with correct title and description - dispense', () => {
     props.kind = 'dispense'
-    props.state.liquidClass = {
-      displayName: '',
-      liquidClassName: 'none',
-    } as LiquidClass
+    props.state.liquidClassName = 'none'
     render(props)
     screen.getByText('Reset dispense settings?')
     screen.getByText(

--- a/app/src/organisms/ODD/QuickTransferFlow/README.md
+++ b/app/src/organisms/ODD/QuickTransferFlow/README.md
@@ -76,7 +76,7 @@ export interface QuickTransferWizardState {
   path?: PathOption // this has been added
   changeTip?: ChangeTipOptions // this has been added
   dropTipLocation?: CutoutConfig // this has been added
-  liquidClass?: LiquidClass // this has been added
+  liquidClassName?: string // this has been added
 }
 ```
 
@@ -155,7 +155,7 @@ export interface QuickTransferSummaryState {
   airGapDispense?: number
   changeTip: ChangeTipOptions
   dropTipLocation: CutoutConfig
-  liquidClass: LiquidClass // this has been added
+  liquidClassName: string // this has been added
   conditionAspirate?: number // this has been added
   disposalVolumeDispenseSettings?: {
     volume: number

--- a/app/src/organisms/ODD/QuickTransferFlow/SelectLiquidClass.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/SelectLiquidClass.tsx
@@ -8,7 +8,13 @@ import {
   SPACING,
   StyledText,
 } from '@opentrons/components'
-import { getAllLiquidClassDefs } from '@opentrons/shared-data'
+import {
+  ETHANOL_LIQUID_CLASS_NAME,
+  getAllLiquidClassDefs,
+  GLYCEROL_LIQUID_CLASS_NAME,
+  NONE_LIQUID_CLASS_NAME,
+  WATER_LIQUID_CLASS_NAME,
+} from '@opentrons/shared-data'
 
 import { ChildNavigation } from '/app/organisms/ODD/ChildNavigation'
 import { useToaster } from '/app/organisms/ToasterOven'
@@ -52,13 +58,25 @@ export function SelectLiquidClass({
     schemaVersion: 1,
   }
 
+  const mapLiquidClassToInternalName: Record<
+    LiquidClass['liquidClassName'],
+    string
+  > = {
+    ethanol_80: ETHANOL_LIQUID_CLASS_NAME,
+    glycerol_50: GLYCEROL_LIQUID_CLASS_NAME,
+    water: WATER_LIQUID_CLASS_NAME,
+    none: NONE_LIQUID_CLASS_NAME,
+  }
+
   const liquidClassOptions = [noLiquidClass, ...Object.values(liquidClasses)]
   const handleClickNext = (): void => {
-    dispatch({
-      type: 'SET_LIQUID_CLASS',
-      liquidClass: selectedLiquidClass ?? noLiquidClass,
-    })
-
+    if (selectedLiquidClass != null) {
+      dispatch({
+        type: 'SET_LIQUID_CLASS',
+        liquidClassName:
+          mapLiquidClassToInternalName[selectedLiquidClass.liquidClassName],
+      })
+    }
     onNext()
   }
 

--- a/app/src/organisms/ODD/QuickTransferFlow/__tests__/Overview.test.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/__tests__/Overview.test.tsx
@@ -1,6 +1,8 @@
 import { screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, it, vi } from 'vitest'
 
+import { WATER_LIQUID_CLASS_NAME } from '@opentrons/shared-data'
+
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
 
@@ -42,14 +44,7 @@ describe('Overview', () => {
         } as any,
         transferType: 'transfer',
         volume: 25,
-        liquidClass: {
-          liquidClassName: 'dummyLiquidClass',
-          displayName: 'Dummy liquid class',
-          description: 'Dummy liquid class description',
-          schemaVersion: 0,
-          namespace: '',
-          byPipette: [],
-        },
+        liquidClassName: WATER_LIQUID_CLASS_NAME,
       } as any,
     }
   })
@@ -141,6 +136,6 @@ describe('Overview', () => {
     screen.getByText('Tip change frequency')
     screen.getByText('Tip drop location')
     screen.getByText('Liquid class')
-    screen.getByText('Dummy liquid class')
+    screen.getByText('Aqueous')
   })
 })

--- a/app/src/organisms/ODD/QuickTransferFlow/__tests__/SelectLiquidClass.test.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/__tests__/SelectLiquidClass.test.tsx
@@ -1,7 +1,13 @@
 import { fireEvent, screen } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { getAllLiquidClassDefs } from '@opentrons/shared-data'
+import {
+  ETHANOL_LIQUID_CLASS_NAME,
+  getAllLiquidClassDefs,
+  GLYCEROL_LIQUID_CLASS_NAME,
+  NONE_LIQUID_CLASS_NAME,
+  WATER_LIQUID_CLASS_NAME,
+} from '@opentrons/shared-data'
 
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
@@ -22,15 +28,6 @@ vi.mock('@opentrons/shared-data', async importOriginal => {
   }
 })
 const mockMakeSnackbar = vi.fn()
-
-const mockNoLiquidClass = {
-  byPipette: [],
-  description: 'Default',
-  displayName: "Don't use liquid class settings",
-  liquidClassName: 'none',
-  namespace: 'opentrons',
-  schemaVersion: 1,
-}
 
 const mockByPipette = [
   {
@@ -58,25 +55,25 @@ const mockByPipette = [
 ]
 
 const mockLiquidClasses = {
-  ethanol: {
-    liquidClassName: 'mock ethanol',
+  [ETHANOL_LIQUID_CLASS_NAME]: {
+    liquidClassName: 'ethanol_80',
     displayName: 'Volatile',
     description: '80% ethanol',
     schemaVersion: 0,
     namespace: '',
     byPipette: mockByPipette,
   },
-  glyeral: {
-    liquidClassName: 'mock glyeral',
+  [GLYCEROL_LIQUID_CLASS_NAME]: {
+    liquidClassName: 'glycerol_50',
     displayName: 'Viscous',
     description: '50% glycerol',
     schemaVersion: 0,
     namespace: '',
     byPipette: mockByPipette,
   },
-  water: {
+  [WATER_LIQUID_CLASS_NAME]: {
     displayName: 'Aqueous',
-    liquidClassName: 'mock water',
+    liquidClassName: 'water',
     description: 'Deionized water',
     schemaVersion: 0,
     namespace: '',
@@ -211,7 +208,7 @@ describe('SelectLiquidClass', () => {
     expect(props.onNext).toHaveBeenCalled()
     expect(props.dispatch).toHaveBeenCalledWith({
       type: 'SET_LIQUID_CLASS',
-      liquidClass: mockNoLiquidClass,
+      liquidClassName: NONE_LIQUID_CLASS_NAME,
     })
   })
 
@@ -223,7 +220,7 @@ describe('SelectLiquidClass', () => {
     expect(props.onNext).toHaveBeenCalled()
     expect(props.dispatch).toHaveBeenCalledWith({
       type: 'SET_LIQUID_CLASS',
-      liquidClass: mockLiquidClasses.water,
+      liquidClassName: WATER_LIQUID_CLASS_NAME,
     })
   })
 

--- a/app/src/organisms/ODD/QuickTransferFlow/reducers.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/reducers.ts
@@ -111,7 +111,7 @@ export function quickTransferWizardReducer(
     case 'SET_LIQUID_CLASS': {
       return {
         ...state,
-        liquidClass: action.liquidClass,
+        liquidClassName: action.liquidClassName,
       }
     }
   }

--- a/app/src/organisms/ODD/QuickTransferFlow/types.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/types.ts
@@ -2,7 +2,6 @@ import type { Mount } from '@opentrons/api-client'
 import type {
   CutoutConfig,
   LabwareDefinition2,
-  LiquidClass,
   PipetteV2Specs,
 } from '@opentrons/shared-data'
 import type {
@@ -28,7 +27,7 @@ export interface QuickTransferWizardState {
   path?: PathOption
   changeTip?: ChangeTipOptions
   dropTipLocation?: CutoutConfig
-  liquidClass?: LiquidClass
+  liquidClassName?: string
 }
 export type PathOption = 'single' | 'multiAspirate' | 'multiDispense'
 export type ChangeTipOptions =
@@ -115,7 +114,7 @@ export interface QuickTransferSummaryState {
   airGapDispense?: number
   changeTip: ChangeTipOptions
   dropTipLocation: CutoutConfig
-  liquidClass: LiquidClass
+  liquidClassName: string
   conditionAspirate?: number
   disposalVolumeDispenseSettings?: {
     volume: number
@@ -285,7 +284,7 @@ interface SetDropTipLocation {
 
 interface SetLiquidClassAction {
   type: typeof ACTIONS.SET_LIQUID_CLASS
-  liquidClass: LiquidClass
+  liquidClassName: string
 }
 
 interface SelectPipetteAction {

--- a/app/src/organisms/ODD/QuickTransferFlow/utils/createQuickTransferFile.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/utils/createQuickTransferFile.ts
@@ -3,13 +3,16 @@ import uuidv1 from 'uuid/v4'
 import {
   FLEX_ROBOT_TYPE,
   FLEX_STANDARD_DECKID,
+  getAllLiquidClassDefs,
   getDeckDefFromRobotType,
+  getFlexNameConversion,
   TRASH_BIN_ADAPTER_FIXTURE,
   WASTE_CHUTE_FIXTURES,
 } from '@opentrons/shared-data'
 import {
   consolidate,
   distribute,
+  getLiquidClassName,
   getSlotInLocationStack,
   getWasteChuteAddressableAreaNamePip,
   pythonImports,
@@ -32,6 +35,7 @@ import type {
   LabwareV2Mixin,
   LiquidV1Mixin,
   LoadLabwareCreateCommand,
+  LoadLiquidClassCreateCommand,
   LoadPipetteCreateCommand,
   OT3RobotMixin,
 } from '@opentrons/shared-data'
@@ -51,14 +55,15 @@ export function createQuickTransferFile(
     initialRobotState,
   } = generateQuickTransferArgs(quickTransferState, deckConfig)
   const pipetteEntity = Object.values(invariantContext.pipetteEntities)[0]
+  const { name, id, spec } = pipetteEntity
 
   const loadPipetteCommand: LoadPipetteCreateCommand = {
     key: uuid(),
     commandType: 'loadPipette' as const,
     params: {
-      pipetteName: pipetteEntity.name,
+      pipetteName: name,
       mount: quickTransferState.mount,
-      pipetteId: pipetteEntity.id,
+      pipetteId: id,
     },
   }
   const labwareEntities = Object.values(invariantContext.labwareEntities)
@@ -113,6 +118,38 @@ export function createQuickTransferFile(
     })
     return acc
   }, [])
+  const {
+    loadName: currentTiprackLoadName,
+  } = quickTransferState.tipRack.parameters
+
+  const liquidClass =
+    stepArgs?.liquidClass != null ? stepArgs.liquidClass : null
+  const byTipTypeSettings =
+    liquidClass != null
+      ? getAllLiquidClassDefs()
+          [liquidClass]?.byPipette.find(
+            pipetteObject =>
+              pipetteObject.pipetteModel === getFlexNameConversion(spec)
+          )
+          ?.byTipType.find(tipObject => {
+            const tiprackLoadName = tipObject.tiprack.split('/')[1]
+            return tiprackLoadName === currentTiprackLoadName
+          })
+      : null
+  const loadLiquidCommand: LoadLiquidClassCreateCommand | null =
+    liquidClass != null && byTipTypeSettings != null
+      ? {
+          key: uuid(),
+          commandType: 'loadLiquidClass' as const,
+          params: {
+            liquidClassRecord: {
+              ...byTipTypeSettings,
+              liquidClassName: getLiquidClassName(liquidClass),
+              pipetteModel: spec.model,
+            },
+          },
+        }
+      : null
 
   let nonLoadCommandCreator: CommandCreatorResult | null = null
   if (stepArgs?.commandCreatorFnName === 'transfer') {
@@ -188,11 +225,11 @@ export function createQuickTransferFile(
       },
     ]
   }
-
   const commands: CreateCommand[] = [
     loadPipetteCommand,
     ...loadAdapterCommands,
     ...loadLabwareCommands,
+    ...(loadLiquidCommand != null ? [loadLiquidCommand] : []),
     ...nonLoadCommands,
     ...finalDropTipCommands,
   ]

--- a/app/src/organisms/ODD/QuickTransferFlow/utils/generateQuickTransferArgs.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/utils/generateQuickTransferArgs.ts
@@ -435,8 +435,7 @@ export function generateQuickTransferArgs(
     description: null,
     nozzles,
     pushOut: null,
-    /** TODO: update all values below once quick transfer state is updated */
-    liquidClass: null,
+    liquidClass: quickTransferState.liquidClassName,
     aspiratePositionReference: POSITION_REFERENCE_BOTTOM,
     aspirateZOffset: 0,
     aspirateSubmergeSpeed: null,

--- a/app/src/organisms/ODD/QuickTransferFlow/utils/getInitialSummaryState.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/utils/getInitialSummaryState.ts
@@ -8,7 +8,6 @@ import type { Mount } from '@opentrons/api-client'
 import type {
   DeckConfiguration,
   LabwareDefinition2,
-  LiquidClass,
   PipetteV2Specs,
 } from '@opentrons/shared-data'
 import type {
@@ -30,7 +29,7 @@ interface InitialSummaryStateProps {
     transferType: TransferType
     volume: number
     path: PathOption
-    liquidClass: LiquidClass
+    liquidClassName: string
     pushOutDispense?: {
       volume: number
     }
@@ -111,7 +110,7 @@ export function getInitialSummaryState(
     tipPositionDispense: 1,
     changeTip,
     dropTipLocation: trashConfigCutout,
-    liquidClass: state.liquidClass,
+    liquidClassName: state.liquidClassName,
     liquidClassValuesInitialized: false,
     pushOutDispense: state.pushOutDispense,
   }

--- a/app/src/organisms/ODD/QuickTransferFlow/utils/retrieveLiquidClassValues.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/utils/retrieveLiquidClassValues.ts
@@ -11,6 +11,7 @@ import {
 } from '@opentrons/shared-data'
 import {
   DEST_WELL_BLOWOUT_DESTINATION,
+  getLiquidClassName,
   SOURCE_WELL_BLOWOUT_DESTINATION,
 } from '@opentrons/step-generation'
 
@@ -26,7 +27,7 @@ export const retrieveLiquidClassValues = (
   const { pipette } = state
   const convertedPipetteName = getFlexNameConversion(pipette)
 
-  if (state.liquidClass.liquidClassName === NONE_LIQUID_CLASS_NAME) {
+  if (state.liquidClassName === NONE_LIQUID_CLASS_NAME) {
     return getNoLiquidClassValues(
       state,
       convertedPipetteName,
@@ -257,7 +258,7 @@ const getLiquidClassValues = (
     ['ethanol_80', ETHANOL_LIQUID_CLASS_NAME],
   ])
   const selectedLiquidClass = liquidClassMap.get(
-    state.liquidClass?.liquidClassName ?? 'none'
+    getLiquidClassName(state.liquidClassName) ?? 'none'
   )
   const liquidClassDef =
     allLiquidClassDefs[selectedLiquidClass ?? NONE_LIQUID_CLASS_NAME]


### PR DESCRIPTION
closes AUTH-1988

# Overview

generate `loadLiquidClass` command in JSON for generating a QT protocol - one of the last items needed for QT liquid classes support

## Test Plan and Hands on Testing

Sorta hard to test without looking at the JSON protocol generated so i advise to log the commands in `CreateQuickTransferFile` then smoke test in a dev env to make sure the load liquid class is properly generated

Smoke test liquid classes in general because i had to refactor some things

## Changelog

- change the QT state liquid class to `liquidClassName` and make it be a string instead of the liquid class def
- wire up generating the liquid class command
- fix all affected components and tests

## Review requests

had an unfortunate realization that `liquidClass` in the form to args for step-generation needed a liquid class name string but the quick transfer state was populating the whole liquid class definition so i had to refactor some things quickly - lmk what you think @koji @ncdiehl 

## Risk assessment

medium