### PR TITLE
fix(api): set the opentrons tipracks default version to 2.

### DIFF
--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[13cc2361a9][Flex_S_v2_25_P50_P200_stacker_all_parts].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[13cc2361a9][Flex_S_v2_25_P50_P200_stacker_all_parts].json
@@ -3819,7 +3819,7 @@
         "primaryLabware": {
           "loadName": "opentrons_flex_96_tiprack_200ul",
           "namespace": "opentrons",
-          "version": 1
+          "version": 2
         }
       },
       "result": {
@@ -4428,10 +4428,15 @@
               "x": 0,
               "y": 0,
               "z": 121
+            },
+            "opentrons_flex_tiprack_lid": {
+              "x": 0,
+              "y": 0,
+              "z": 0.25
             }
           },
           "stackingOffsetWithModule": {},
-          "version": 1,
+          "version": 2,
           "wells": {
             "A1": {
               "depth": 97.5,
@@ -5426,7 +5431,7 @@
           "labwareId": "UUID"
         },
         "namespace": "opentrons",
-        "version": 1
+        "version": 2
       },
       "result": {
         "definition": {
@@ -5695,10 +5700,15 @@
               "x": 0,
               "y": 0,
               "z": 121
+            },
+            "opentrons_flex_tiprack_lid": {
+              "x": 0,
+              "y": 0,
+              "z": 0.25
             }
           },
           "stackingOffsetWithModule": {},
-          "version": 1,
+          "version": 2,
           "wells": {
             "A1": {
               "depth": 97.5,
@@ -11421,7 +11431,7 @@
         "primaryLabware": {
           "loadName": "opentrons_flex_96_tiprack_200ul",
           "namespace": "opentrons",
-          "version": 1
+          "version": 2
         }
       },
       "result": {
@@ -12030,10 +12040,15 @@
               "x": 0,
               "y": 0,
               "z": 121
+            },
+            "opentrons_flex_tiprack_lid": {
+              "x": 0,
+              "y": 0,
+              "z": 0.25
             }
           },
           "stackingOffsetWithModule": {},
-          "version": 1,
+          "version": 2,
           "wells": {
             "A1": {
               "depth": 97.5,
@@ -13355,7 +13370,7 @@
         "primaryLabware": {
           "loadName": "opentrons_flex_96_tiprack_50ul",
           "namespace": "opentrons",
-          "version": 1
+          "version": 2
         }
       },
       "result": {
@@ -13964,10 +13979,15 @@
               "x": 0,
               "y": 0,
               "z": 121
+            },
+            "opentrons_flex_tiprack_lid": {
+              "x": 0,
+              "y": 0,
+              "z": 0.25
             }
           },
           "stackingOffsetWithModule": {},
-          "version": 1,
+          "version": 2,
           "wells": {
             "A1": {
               "depth": 97.5,
@@ -19695,7 +19715,7 @@
           "slotName": "C2"
         },
         "namespace": "opentrons",
-        "version": 1
+        "version": 2
       },
       "result": {
         "definition": {
@@ -19964,10 +19984,15 @@
               "x": 0,
               "y": 0,
               "z": 121
+            },
+            "opentrons_flex_tiprack_lid": {
+              "x": 0,
+              "y": 0,
+              "z": 0.25
             }
           },
           "stackingOffsetWithModule": {},
-          "version": 1,
+          "version": 2,
           "wells": {
             "A1": {
               "depth": 97.5,
@@ -22309,7 +22334,7 @@
         "primaryLabware": {
           "loadName": "opentrons_flex_96_tiprack_50ul",
           "namespace": "opentrons",
-          "version": 1
+          "version": 2
         }
       },
       "result": {
@@ -22918,10 +22943,15 @@
               "x": 0,
               "y": 0,
               "z": 121
+            },
+            "opentrons_flex_tiprack_lid": {
+              "x": 0,
+              "y": 0,
+              "z": 0.25
             }
           },
           "stackingOffsetWithModule": {},
-          "version": 1,
+          "version": 2,
           "wells": {
             "A1": {
               "depth": 97.5,
@@ -32026,7 +32056,7 @@
             "moduleId": "UUID"
           }
         ],
-        "primaryLabwareURI": "opentrons/opentrons_flex_96_tiprack_50ul/1",
+        "primaryLabwareURI": "opentrons/opentrons_flex_96_tiprack_50ul/2",
         "primaryLocationSequence": [
           {
             "addressableAreaName": "flexStackerModuleV1D4",
@@ -35954,7 +35984,7 @@
             "moduleId": "UUID"
           }
         ],
-        "primaryLabwareURI": "opentrons/opentrons_flex_96_tiprack_50ul/1",
+        "primaryLabwareURI": "opentrons/opentrons_flex_96_tiprack_50ul/2",
         "primaryLocationSequence": [
           {
             "addressableAreaName": "flexStackerModuleV1D4",
@@ -41350,7 +41380,7 @@
             "moduleId": "UUID"
           }
         ],
-        "primaryLabwareURI": "opentrons/opentrons_flex_96_tiprack_200ul/1",
+        "primaryLabwareURI": "opentrons/opentrons_flex_96_tiprack_200ul/2",
         "primaryLocationSequence": [
           {
             "addressableAreaName": "flexStackerModuleV1A4",
@@ -42079,7 +42109,7 @@
             "moduleId": "UUID"
           }
         ],
-        "primaryLabwareURI": "opentrons/opentrons_flex_96_tiprack_200ul/1",
+        "primaryLabwareURI": "opentrons/opentrons_flex_96_tiprack_200ul/2",
         "primaryLocationSequence": [
           {
             "addressableAreaName": "flexStackerModuleV1B4",
@@ -46552,7 +46582,7 @@
             "moduleId": "UUID"
           }
         ],
-        "primaryLabwareURI": "opentrons/opentrons_flex_96_tiprack_200ul/1",
+        "primaryLabwareURI": "opentrons/opentrons_flex_96_tiprack_200ul/2",
         "primaryLocationSequence": [
           {
             "addressableAreaName": "flexStackerModuleV1A4",
@@ -51372,7 +51402,7 @@
             "moduleId": "UUID"
           }
         ],
-        "primaryLabwareURI": "opentrons/opentrons_flex_96_tiprack_200ul/1",
+        "primaryLabwareURI": "opentrons/opentrons_flex_96_tiprack_200ul/2",
         "primaryLocationSequence": [
           {
             "addressableAreaName": "flexStackerModuleV1A4",
@@ -52192,7 +52222,7 @@
             "moduleId": "UUID"
           }
         ],
-        "primaryLabwareURI": "opentrons/opentrons_flex_96_tiprack_50ul/1",
+        "primaryLabwareURI": "opentrons/opentrons_flex_96_tiprack_50ul/2",
         "primaryLocationSequence": [
           {
             "addressableAreaName": "flexStackerModuleV1D4",
@@ -62973,7 +63003,7 @@
             "moduleId": "UUID"
           }
         ],
-        "primaryLabwareURI": "opentrons/opentrons_flex_96_tiprack_50ul/1",
+        "primaryLabwareURI": "opentrons/opentrons_flex_96_tiprack_50ul/2",
         "primaryLocationSequence": [
           {
             "addressableAreaName": "flexStackerModuleV1D4",
@@ -64051,7 +64081,7 @@
             "moduleId": "UUID"
           }
         ],
-        "primaryLabwareURI": "opentrons/opentrons_flex_96_tiprack_50ul/1",
+        "primaryLabwareURI": "opentrons/opentrons_flex_96_tiprack_50ul/2",
         "primaryLocationSequence": [
           {
             "addressableAreaName": "flexStackerModuleV1D4",
@@ -66727,7 +66757,7 @@
             "moduleId": "UUID"
           }
         ],
-        "primaryLabwareURI": "opentrons/opentrons_flex_96_tiprack_200ul/1",
+        "primaryLabwareURI": "opentrons/opentrons_flex_96_tiprack_200ul/2",
         "primaryLocationSequence": [
           {
             "addressableAreaName": "flexStackerModuleV1B4",
@@ -68192,7 +68222,7 @@
             "moduleId": "UUID"
           }
         ],
-        "primaryLabwareURI": "opentrons/opentrons_flex_96_tiprack_200ul/1",
+        "primaryLabwareURI": "opentrons/opentrons_flex_96_tiprack_200ul/2",
         "primaryLocationSequence": [
           {
             "addressableAreaName": "flexStackerModuleV1A4",
@@ -69582,7 +69612,7 @@
             "moduleId": "UUID"
           }
         ],
-        "primaryLabwareURI": "opentrons/opentrons_flex_96_tiprack_200ul/1",
+        "primaryLabwareURI": "opentrons/opentrons_flex_96_tiprack_200ul/2",
         "primaryLocationSequence": [
           {
             "addressableAreaName": "flexStackerModuleV1A4",
@@ -70962,7 +70992,7 @@
             "moduleId": "UUID"
           }
         ],
-        "primaryLabwareURI": "opentrons/opentrons_flex_96_tiprack_200ul/1",
+        "primaryLabwareURI": "opentrons/opentrons_flex_96_tiprack_200ul/2",
         "primaryLocationSequence": [
           {
             "addressableAreaName": "flexStackerModuleV1A4",
@@ -71537,7 +71567,7 @@
             "moduleId": "UUID"
           }
         ],
-        "primaryLabwareURI": "opentrons/opentrons_flex_96_tiprack_50ul/1",
+        "primaryLabwareURI": "opentrons/opentrons_flex_96_tiprack_50ul/2",
         "primaryLocationSequence": [
           {
             "addressableAreaName": "flexStackerModuleV1D4",
@@ -72862,7 +72892,7 @@
             "moduleId": "UUID"
           }
         ],
-        "primaryLabwareURI": "opentrons/opentrons_flex_96_tiprack_200ul/1",
+        "primaryLabwareURI": "opentrons/opentrons_flex_96_tiprack_200ul/2",
         "primaryLocationSequence": [
           {
             "addressableAreaName": "flexStackerModuleV1B4",
@@ -74260,7 +74290,7 @@
             "moduleId": "UUID"
           }
         ],
-        "primaryLabwareURI": "opentrons/opentrons_flex_96_tiprack_200ul/1",
+        "primaryLabwareURI": "opentrons/opentrons_flex_96_tiprack_200ul/2",
         "primaryLocationSequence": [
           {
             "addressableAreaName": "flexStackerModuleV1B4",
@@ -75658,7 +75688,7 @@
             "moduleId": "UUID"
           }
         ],
-        "primaryLabwareURI": "opentrons/opentrons_flex_96_tiprack_200ul/1",
+        "primaryLabwareURI": "opentrons/opentrons_flex_96_tiprack_200ul/2",
         "primaryLocationSequence": [
           {
             "addressableAreaName": "flexStackerModuleV1B4",
@@ -76318,7 +76348,7 @@
             "moduleId": "UUID"
           }
         ],
-        "primaryLabwareURI": "opentrons/opentrons_flex_96_tiprack_50ul/1",
+        "primaryLabwareURI": "opentrons/opentrons_flex_96_tiprack_50ul/2",
         "primaryLocationSequence": [
           {
             "addressableAreaName": "flexStackerModuleV1C4",
@@ -78431,7 +78461,7 @@
             "moduleId": "UUID"
           }
         ],
-        "primaryLabwareURI": "opentrons/opentrons_flex_96_tiprack_50ul/1",
+        "primaryLabwareURI": "opentrons/opentrons_flex_96_tiprack_50ul/2",
         "primaryLocationSequence": [
           {
             "addressableAreaName": "flexStackerModuleV1C4",
@@ -78908,7 +78938,7 @@
             "moduleId": "UUID"
           }
         ],
-        "primaryLabwareURI": "opentrons/opentrons_flex_96_tiprack_50ul/1",
+        "primaryLabwareURI": "opentrons/opentrons_flex_96_tiprack_50ul/2",
         "primaryLocationSequence": [
           {
             "addressableAreaName": "flexStackerModuleV1C4",
@@ -83337,7 +83367,7 @@
             "moduleId": "UUID"
           }
         ],
-        "primaryLabwareURI": "opentrons/opentrons_flex_96_tiprack_200ul/1",
+        "primaryLabwareURI": "opentrons/opentrons_flex_96_tiprack_200ul/2",
         "primaryLocationSequence": [
           {
             "addressableAreaName": "flexStackerModuleV1B4",
@@ -91338,7 +91368,7 @@
       "location": "offDeck"
     },
     {
-      "definitionUri": "opentrons/opentrons_flex_96_tiprack_200ul/1",
+      "definitionUri": "opentrons/opentrons_flex_96_tiprack_200ul/2",
       "id": "UUID",
       "loadName": "opentrons_flex_96_tiprack_200ul",
       "location": "offDeck"
@@ -91350,7 +91380,7 @@
       "location": "offDeck"
     },
     {
-      "definitionUri": "opentrons/opentrons_flex_96_tiprack_200ul/1",
+      "definitionUri": "opentrons/opentrons_flex_96_tiprack_200ul/2",
       "id": "UUID",
       "loadName": "opentrons_flex_96_tiprack_200ul",
       "location": "offDeck"
@@ -91362,7 +91392,7 @@
       "location": "offDeck"
     },
     {
-      "definitionUri": "opentrons/opentrons_flex_96_tiprack_200ul/1",
+      "definitionUri": "opentrons/opentrons_flex_96_tiprack_200ul/2",
       "id": "UUID",
       "loadName": "opentrons_flex_96_tiprack_200ul",
       "location": "offDeck"
@@ -91374,7 +91404,7 @@
       "location": "offDeck"
     },
     {
-      "definitionUri": "opentrons/opentrons_flex_96_tiprack_200ul/1",
+      "definitionUri": "opentrons/opentrons_flex_96_tiprack_200ul/2",
       "id": "UUID",
       "loadName": "opentrons_flex_96_tiprack_200ul",
       "location": "offDeck"
@@ -91386,7 +91416,7 @@
       "location": "offDeck"
     },
     {
-      "definitionUri": "opentrons/opentrons_flex_96_tiprack_200ul/1",
+      "definitionUri": "opentrons/opentrons_flex_96_tiprack_200ul/2",
       "id": "UUID",
       "loadName": "opentrons_flex_96_tiprack_200ul",
       "location": "offDeck"
@@ -91398,7 +91428,7 @@
       "location": "offDeck"
     },
     {
-      "definitionUri": "opentrons/opentrons_flex_96_tiprack_200ul/1",
+      "definitionUri": "opentrons/opentrons_flex_96_tiprack_200ul/2",
       "id": "UUID",
       "loadName": "opentrons_flex_96_tiprack_200ul",
       "location": "offDeck"
@@ -91412,7 +91442,7 @@
       }
     },
     {
-      "definitionUri": "opentrons/opentrons_flex_96_tiprack_200ul/1",
+      "definitionUri": "opentrons/opentrons_flex_96_tiprack_200ul/2",
       "id": "UUID",
       "loadName": "opentrons_flex_96_tiprack_200ul",
       "location": "offDeck"
@@ -91433,7 +91463,7 @@
       "location": "offDeck"
     },
     {
-      "definitionUri": "opentrons/opentrons_flex_96_tiprack_200ul/1",
+      "definitionUri": "opentrons/opentrons_flex_96_tiprack_200ul/2",
       "id": "UUID",
       "loadName": "opentrons_flex_96_tiprack_200ul",
       "location": "offDeck"
@@ -91445,7 +91475,7 @@
       "location": "offDeck"
     },
     {
-      "definitionUri": "opentrons/opentrons_flex_96_tiprack_200ul/1",
+      "definitionUri": "opentrons/opentrons_flex_96_tiprack_200ul/2",
       "id": "UUID",
       "loadName": "opentrons_flex_96_tiprack_200ul",
       "location": "offDeck"
@@ -91457,7 +91487,7 @@
       "location": "offDeck"
     },
     {
-      "definitionUri": "opentrons/opentrons_flex_96_tiprack_200ul/1",
+      "definitionUri": "opentrons/opentrons_flex_96_tiprack_200ul/2",
       "id": "UUID",
       "loadName": "opentrons_flex_96_tiprack_200ul",
       "location": "offDeck"
@@ -91469,7 +91499,7 @@
       "location": "offDeck"
     },
     {
-      "definitionUri": "opentrons/opentrons_flex_96_tiprack_200ul/1",
+      "definitionUri": "opentrons/opentrons_flex_96_tiprack_200ul/2",
       "id": "UUID",
       "loadName": "opentrons_flex_96_tiprack_200ul",
       "location": "offDeck"
@@ -91481,7 +91511,7 @@
       "location": "offDeck"
     },
     {
-      "definitionUri": "opentrons/opentrons_flex_96_tiprack_200ul/1",
+      "definitionUri": "opentrons/opentrons_flex_96_tiprack_200ul/2",
       "id": "UUID",
       "loadName": "opentrons_flex_96_tiprack_200ul",
       "location": "offDeck"
@@ -91493,7 +91523,7 @@
       "location": "offDeck"
     },
     {
-      "definitionUri": "opentrons/opentrons_flex_96_tiprack_200ul/1",
+      "definitionUri": "opentrons/opentrons_flex_96_tiprack_200ul/2",
       "id": "UUID",
       "loadName": "opentrons_flex_96_tiprack_200ul",
       "location": {
@@ -91551,7 +91581,7 @@
       "location": "offDeck"
     },
     {
-      "definitionUri": "opentrons/opentrons_flex_96_tiprack_50ul/1",
+      "definitionUri": "opentrons/opentrons_flex_96_tiprack_50ul/2",
       "id": "UUID",
       "loadName": "opentrons_flex_96_tiprack_50ul",
       "location": "offDeck"
@@ -91563,7 +91593,7 @@
       "location": "offDeck"
     },
     {
-      "definitionUri": "opentrons/opentrons_flex_96_tiprack_50ul/1",
+      "definitionUri": "opentrons/opentrons_flex_96_tiprack_50ul/2",
       "id": "UUID",
       "loadName": "opentrons_flex_96_tiprack_50ul",
       "location": "offDeck"
@@ -91575,7 +91605,7 @@
       "location": "offDeck"
     },
     {
-      "definitionUri": "opentrons/opentrons_flex_96_tiprack_50ul/1",
+      "definitionUri": "opentrons/opentrons_flex_96_tiprack_50ul/2",
       "id": "UUID",
       "loadName": "opentrons_flex_96_tiprack_50ul",
       "location": {
@@ -91591,7 +91621,7 @@
       }
     },
     {
-      "definitionUri": "opentrons/opentrons_flex_96_tiprack_50ul/1",
+      "definitionUri": "opentrons/opentrons_flex_96_tiprack_50ul/2",
       "id": "UUID",
       "lid_id": "UUID",
       "loadName": "opentrons_flex_96_tiprack_50ul",
@@ -91609,7 +91639,7 @@
       }
     },
     {
-      "definitionUri": "opentrons/opentrons_flex_96_tiprack_50ul/1",
+      "definitionUri": "opentrons/opentrons_flex_96_tiprack_50ul/2",
       "id": "UUID",
       "lid_id": "UUID",
       "loadName": "opentrons_flex_96_tiprack_50ul",
@@ -91627,7 +91657,7 @@
       }
     },
     {
-      "definitionUri": "opentrons/opentrons_flex_96_tiprack_50ul/1",
+      "definitionUri": "opentrons/opentrons_flex_96_tiprack_50ul/2",
       "id": "UUID",
       "lid_id": "UUID",
       "loadName": "opentrons_flex_96_tiprack_50ul",
@@ -91646,7 +91676,7 @@
       }
     },
     {
-      "definitionUri": "opentrons/opentrons_flex_96_tiprack_50ul/1",
+      "definitionUri": "opentrons/opentrons_flex_96_tiprack_50ul/2",
       "id": "UUID",
       "loadName": "opentrons_flex_96_tiprack_50ul",
       "location": "offDeck"
@@ -91667,7 +91697,7 @@
       "location": "offDeck"
     },
     {
-      "definitionUri": "opentrons/opentrons_flex_96_tiprack_50ul/1",
+      "definitionUri": "opentrons/opentrons_flex_96_tiprack_50ul/2",
       "id": "UUID",
       "loadName": "opentrons_flex_96_tiprack_50ul",
       "location": "offDeck"
@@ -91679,7 +91709,7 @@
       "location": "offDeck"
     },
     {
-      "definitionUri": "opentrons/opentrons_flex_96_tiprack_50ul/1",
+      "definitionUri": "opentrons/opentrons_flex_96_tiprack_50ul/2",
       "id": "UUID",
       "loadName": "opentrons_flex_96_tiprack_50ul",
       "location": "offDeck"
@@ -91691,7 +91721,7 @@
       "location": "offDeck"
     },
     {
-      "definitionUri": "opentrons/opentrons_flex_96_tiprack_50ul/1",
+      "definitionUri": "opentrons/opentrons_flex_96_tiprack_50ul/2",
       "id": "UUID",
       "loadName": "opentrons_flex_96_tiprack_50ul",
       "location": "offDeck"
@@ -91703,7 +91733,7 @@
       "location": "offDeck"
     },
     {
-      "definitionUri": "opentrons/opentrons_flex_96_tiprack_50ul/1",
+      "definitionUri": "opentrons/opentrons_flex_96_tiprack_50ul/2",
       "id": "UUID",
       "loadName": "opentrons_flex_96_tiprack_50ul",
       "location": "offDeck"
@@ -91715,7 +91745,7 @@
       "location": "offDeck"
     },
     {
-      "definitionUri": "opentrons/opentrons_flex_96_tiprack_50ul/1",
+      "definitionUri": "opentrons/opentrons_flex_96_tiprack_50ul/2",
       "id": "UUID",
       "loadName": "opentrons_flex_96_tiprack_50ul",
       "location": "offDeck"
@@ -91727,7 +91757,7 @@
       "location": "offDeck"
     },
     {
-      "definitionUri": "opentrons/opentrons_flex_96_tiprack_50ul/1",
+      "definitionUri": "opentrons/opentrons_flex_96_tiprack_50ul/2",
       "id": "UUID",
       "loadName": "opentrons_flex_96_tiprack_50ul",
       "location": "offDeck"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c3b37eae0f][Flex_S_v2_25_P200_stacker_2].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c3b37eae0f][Flex_S_v2_25_P200_stacker_2].json
@@ -66,7 +66,7 @@
         "primaryLabware": {
           "loadName": "opentrons_flex_96_tiprack_200ul",
           "namespace": "opentrons",
-          "version": 1
+          "version": 2
         }
       },
       "result": {
@@ -413,10 +413,15 @@
               "x": 0,
               "y": 0,
               "z": 121
+            },
+            "opentrons_flex_tiprack_lid": {
+              "x": 0,
+              "y": 0,
+              "z": 0.25
             }
           },
           "stackingOffsetWithModule": {},
-          "version": 1,
+          "version": 2,
           "wells": {
             "A1": {
               "depth": 97.5,
@@ -1321,7 +1326,7 @@
           "moduleId": "UUID"
         },
         "namespace": "opentrons",
-        "version": 1
+        "version": 2
       },
       "result": {
         "definition": {
@@ -1590,10 +1595,15 @@
               "x": 0,
               "y": 0,
               "z": 121
+            },
+            "opentrons_flex_tiprack_lid": {
+              "x": 0,
+              "y": 0,
+              "z": 0.25
             }
           },
           "stackingOffsetWithModule": {},
-          "version": 1,
+          "version": 2,
           "wells": {
             "A1": {
               "depth": 97.5,
@@ -2523,7 +2533,7 @@
         "primaryLabware": {
           "loadName": "opentrons_flex_96_tiprack_200ul",
           "namespace": "opentrons",
-          "version": 1
+          "version": 2
         }
       },
       "result": {
@@ -3132,10 +3142,15 @@
               "x": 0,
               "y": 0,
               "z": 121
+            },
+            "opentrons_flex_tiprack_lid": {
+              "x": 0,
+              "y": 0,
+              "z": 0.25
             }
           },
           "stackingOffsetWithModule": {},
-          "version": 1,
+          "version": 2,
           "wells": {
             "A1": {
               "depth": 97.5,
@@ -4072,7 +4087,7 @@
         "primaryLabware": {
           "loadName": "opentrons_flex_96_tiprack_50ul",
           "namespace": "opentrons",
-          "version": 1
+          "version": 2
         }
       },
       "result": {
@@ -4681,10 +4696,15 @@
               "x": 0,
               "y": 0,
               "z": 121
+            },
+            "opentrons_flex_tiprack_lid": {
+              "x": 0,
+              "y": 0,
+              "z": 0.25
             }
           },
           "stackingOffsetWithModule": {},
-          "version": 1,
+          "version": 2,
           "wells": {
             "A1": {
               "depth": 97.5,
@@ -5595,7 +5615,7 @@
           "moduleId": "UUID"
         },
         "namespace": "opentrons",
-        "version": 1
+        "version": 2
       },
       "result": {
         "definition": {
@@ -5864,10 +5884,15 @@
               "x": 0,
               "y": 0,
               "z": 121
+            },
+            "opentrons_flex_tiprack_lid": {
+              "x": 0,
+              "y": 0,
+              "z": 0.25
             }
           },
           "stackingOffsetWithModule": {},
-          "version": 1,
+          "version": 2,
           "wells": {
             "A1": {
               "depth": 97.5,
@@ -10185,7 +10210,7 @@
           "labwareId": "UUID"
         },
         "namespace": "opentrons",
-        "version": 1
+        "version": 2
       },
       "result": {
         "definition": {
@@ -10454,10 +10479,15 @@
               "x": 0,
               "y": 0,
               "z": 121
+            },
+            "opentrons_flex_tiprack_lid": {
+              "x": 0,
+              "y": 0,
+              "z": 0.25
             }
           },
           "stackingOffsetWithModule": {},
-          "version": 1,
+          "version": 2,
           "wells": {
             "A1": {
               "depth": 97.5,
@@ -11362,7 +11392,7 @@
           "slotName": "B2"
         },
         "namespace": "opentrons",
-        "version": 1
+        "version": 2
       },
       "result": {
         "definition": {
@@ -11631,10 +11661,15 @@
               "x": 0,
               "y": 0,
               "z": 121
+            },
+            "opentrons_flex_tiprack_lid": {
+              "x": 0,
+              "y": 0,
+              "z": 0.25
             }
           },
           "stackingOffsetWithModule": {},
-          "version": 1,
+          "version": 2,
           "wells": {
             "A1": {
               "depth": 97.5,
@@ -23373,7 +23408,7 @@
           "slotName": "C3"
         },
         "namespace": "opentrons",
-        "version": 1
+        "version": 2
       },
       "result": {
         "definition": {
@@ -23642,10 +23677,15 @@
               "x": 0,
               "y": 0,
               "z": 121
+            },
+            "opentrons_flex_tiprack_lid": {
+              "x": 0,
+              "y": 0,
+              "z": 0.25
             }
           },
           "stackingOffsetWithModule": {},
-          "version": 1,
+          "version": 2,
           "wells": {
             "A1": {
               "depth": 97.5,
@@ -31582,7 +31622,7 @@
             "moduleId": "UUID"
           }
         ],
-        "primaryLabwareURI": "opentrons/opentrons_flex_96_tiprack_50ul/1",
+        "primaryLabwareURI": "opentrons/opentrons_flex_96_tiprack_50ul/2",
         "primaryLocationSequence": [
           {
             "addressableAreaName": "flexStackerModuleV1C4",
@@ -32578,7 +32618,7 @@
             "moduleId": "UUID"
           }
         ],
-        "primaryLabwareURI": "opentrons/opentrons_flex_96_tiprack_50ul/1",
+        "primaryLabwareURI": "opentrons/opentrons_flex_96_tiprack_50ul/2",
         "primaryLocationSequence": [
           {
             "addressableAreaName": "flexStackerModuleV1C4",
@@ -34528,7 +34568,7 @@
             "moduleId": "UUID"
           }
         ],
-        "primaryLabwareURI": "opentrons/opentrons_flex_96_tiprack_50ul/1",
+        "primaryLabwareURI": "opentrons/opentrons_flex_96_tiprack_50ul/2",
         "primaryLocationSequence": [
           {
             "addressableAreaName": "flexStackerModuleV1C4",
@@ -35681,7 +35721,7 @@
             "moduleId": "UUID"
           }
         ],
-        "primaryLabwareURI": "opentrons/opentrons_flex_96_tiprack_200ul/1",
+        "primaryLabwareURI": "opentrons/opentrons_flex_96_tiprack_200ul/2",
         "primaryLocationSequence": [
           {
             "addressableAreaName": "flexStackerModuleV1A4",
@@ -35805,7 +35845,7 @@
             "moduleId": "UUID"
           }
         ],
-        "primaryLabwareURI": "opentrons/opentrons_flex_96_tiprack_200ul/1",
+        "primaryLabwareURI": "opentrons/opentrons_flex_96_tiprack_200ul/2",
         "primaryLocationSequence": [
           {
             "addressableAreaName": "flexStackerModuleV1A4",
@@ -41437,7 +41477,7 @@
             "moduleId": "UUID"
           }
         ],
-        "primaryLabwareURI": "opentrons/opentrons_flex_96_tiprack_50ul/1",
+        "primaryLabwareURI": "opentrons/opentrons_flex_96_tiprack_50ul/2",
         "primaryLocationSequence": [
           {
             "addressableAreaName": "flexStackerModuleV1C4",
@@ -45809,7 +45849,7 @@
             "moduleId": "UUID"
           }
         ],
-        "primaryLabwareURI": "opentrons/opentrons_flex_96_tiprack_50ul/1",
+        "primaryLabwareURI": "opentrons/opentrons_flex_96_tiprack_50ul/2",
         "primaryLocationSequence": [
           {
             "addressableAreaName": "flexStackerModuleV1C4",
@@ -48409,7 +48449,7 @@
             "moduleId": "UUID"
           }
         ],
-        "primaryLabwareURI": "opentrons/opentrons_flex_96_tiprack_200ul/1",
+        "primaryLabwareURI": "opentrons/opentrons_flex_96_tiprack_200ul/2",
         "primaryLocationSequence": [
           {
             "addressableAreaName": "flexStackerModuleV1A4",
@@ -51563,7 +51603,7 @@
             "moduleId": "UUID"
           }
         ],
-        "primaryLabwareURI": "opentrons/opentrons_flex_96_tiprack_200ul/1",
+        "primaryLabwareURI": "opentrons/opentrons_flex_96_tiprack_200ul/2",
         "primaryLocationSequence": [
           {
             "addressableAreaName": "flexStackerModuleV1A4",
@@ -52233,7 +52273,7 @@
             "moduleId": "UUID"
           }
         ],
-        "primaryLabwareURI": "opentrons/opentrons_flex_96_tiprack_50ul/1",
+        "primaryLabwareURI": "opentrons/opentrons_flex_96_tiprack_50ul/2",
         "primaryLocationSequence": [
           {
             "addressableAreaName": "flexStackerModuleV1C4",
@@ -52904,7 +52944,7 @@
             "moduleId": "UUID"
           }
         ],
-        "primaryLabwareURI": "opentrons/opentrons_flex_96_tiprack_200ul/1",
+        "primaryLabwareURI": "opentrons/opentrons_flex_96_tiprack_200ul/2",
         "primaryLocationSequence": [
           {
             "addressableAreaName": "flexStackerModuleV1A4",
@@ -54472,7 +54512,7 @@
             "moduleId": "UUID"
           }
         ],
-        "primaryLabwareURI": "opentrons/opentrons_flex_96_tiprack_200ul/1",
+        "primaryLabwareURI": "opentrons/opentrons_flex_96_tiprack_200ul/2",
         "primaryLocationSequence": [
           {
             "addressableAreaName": "flexStackerModuleV1A4",
@@ -57484,37 +57524,37 @@
   "files": [],
   "labware": [
     {
-      "definitionUri": "opentrons/opentrons_flex_96_tiprack_200ul/1",
+      "definitionUri": "opentrons/opentrons_flex_96_tiprack_200ul/2",
       "id": "UUID",
       "loadName": "opentrons_flex_96_tiprack_200ul",
       "location": "offDeck"
     },
     {
-      "definitionUri": "opentrons/opentrons_flex_96_tiprack_200ul/1",
+      "definitionUri": "opentrons/opentrons_flex_96_tiprack_200ul/2",
       "id": "UUID",
       "loadName": "opentrons_flex_96_tiprack_200ul",
       "location": "offDeck"
     },
     {
-      "definitionUri": "opentrons/opentrons_flex_96_tiprack_200ul/1",
+      "definitionUri": "opentrons/opentrons_flex_96_tiprack_200ul/2",
       "id": "UUID",
       "loadName": "opentrons_flex_96_tiprack_200ul",
       "location": "offDeck"
     },
     {
-      "definitionUri": "opentrons/opentrons_flex_96_tiprack_200ul/1",
+      "definitionUri": "opentrons/opentrons_flex_96_tiprack_200ul/2",
       "id": "UUID",
       "loadName": "opentrons_flex_96_tiprack_200ul",
       "location": "offDeck"
     },
     {
-      "definitionUri": "opentrons/opentrons_flex_96_tiprack_200ul/1",
+      "definitionUri": "opentrons/opentrons_flex_96_tiprack_200ul/2",
       "id": "UUID",
       "loadName": "opentrons_flex_96_tiprack_200ul",
       "location": "offDeck"
     },
     {
-      "definitionUri": "opentrons/opentrons_flex_96_tiprack_200ul/1",
+      "definitionUri": "opentrons/opentrons_flex_96_tiprack_200ul/2",
       "id": "UUID",
       "loadName": "opentrons_flex_96_tiprack_200ul",
       "location": {
@@ -57522,7 +57562,7 @@
       }
     },
     {
-      "definitionUri": "opentrons/opentrons_flex_96_tiprack_200ul/1",
+      "definitionUri": "opentrons/opentrons_flex_96_tiprack_200ul/2",
       "id": "UUID",
       "loadName": "opentrons_flex_96_tiprack_200ul",
       "location": "offDeck"
@@ -57536,7 +57576,7 @@
       }
     },
     {
-      "definitionUri": "opentrons/opentrons_flex_96_tiprack_200ul/1",
+      "definitionUri": "opentrons/opentrons_flex_96_tiprack_200ul/2",
       "id": "UUID",
       "lid_id": "UUID",
       "loadName": "opentrons_flex_96_tiprack_200ul",
@@ -57554,7 +57594,7 @@
       }
     },
     {
-      "definitionUri": "opentrons/opentrons_flex_96_tiprack_200ul/1",
+      "definitionUri": "opentrons/opentrons_flex_96_tiprack_200ul/2",
       "id": "UUID",
       "lid_id": "UUID",
       "loadName": "opentrons_flex_96_tiprack_200ul",
@@ -57572,7 +57612,7 @@
       }
     },
     {
-      "definitionUri": "opentrons/opentrons_flex_96_tiprack_200ul/1",
+      "definitionUri": "opentrons/opentrons_flex_96_tiprack_200ul/2",
       "id": "UUID",
       "lid_id": "UUID",
       "loadName": "opentrons_flex_96_tiprack_200ul",
@@ -57590,7 +57630,7 @@
       }
     },
     {
-      "definitionUri": "opentrons/opentrons_flex_96_tiprack_200ul/1",
+      "definitionUri": "opentrons/opentrons_flex_96_tiprack_200ul/2",
       "id": "UUID",
       "lid_id": "UUID",
       "loadName": "opentrons_flex_96_tiprack_200ul",
@@ -57608,7 +57648,7 @@
       }
     },
     {
-      "definitionUri": "opentrons/opentrons_flex_96_tiprack_200ul/1",
+      "definitionUri": "opentrons/opentrons_flex_96_tiprack_200ul/2",
       "id": "UUID",
       "lid_id": "UUID",
       "loadName": "opentrons_flex_96_tiprack_200ul",
@@ -57626,7 +57666,7 @@
       }
     },
     {
-      "definitionUri": "opentrons/opentrons_flex_96_tiprack_200ul/1",
+      "definitionUri": "opentrons/opentrons_flex_96_tiprack_200ul/2",
       "id": "UUID",
       "lid_id": "UUID",
       "loadName": "opentrons_flex_96_tiprack_200ul",
@@ -57642,7 +57682,7 @@
       "location": "offDeck"
     },
     {
-      "definitionUri": "opentrons/opentrons_flex_96_tiprack_50ul/1",
+      "definitionUri": "opentrons/opentrons_flex_96_tiprack_50ul/2",
       "id": "UUID",
       "loadName": "opentrons_flex_96_tiprack_50ul",
       "location": "offDeck"
@@ -57654,7 +57694,7 @@
       "location": "offDeck"
     },
     {
-      "definitionUri": "opentrons/opentrons_flex_96_tiprack_50ul/1",
+      "definitionUri": "opentrons/opentrons_flex_96_tiprack_50ul/2",
       "id": "UUID",
       "loadName": "opentrons_flex_96_tiprack_50ul",
       "location": "offDeck"
@@ -57666,7 +57706,7 @@
       "location": "offDeck"
     },
     {
-      "definitionUri": "opentrons/opentrons_flex_96_tiprack_50ul/1",
+      "definitionUri": "opentrons/opentrons_flex_96_tiprack_50ul/2",
       "id": "UUID",
       "loadName": "opentrons_flex_96_tiprack_50ul",
       "location": "offDeck"
@@ -57678,7 +57718,7 @@
       "location": "offDeck"
     },
     {
-      "definitionUri": "opentrons/opentrons_flex_96_tiprack_50ul/1",
+      "definitionUri": "opentrons/opentrons_flex_96_tiprack_50ul/2",
       "id": "UUID",
       "loadName": "opentrons_flex_96_tiprack_50ul",
       "location": "offDeck"
@@ -57690,7 +57730,7 @@
       "location": "offDeck"
     },
     {
-      "definitionUri": "opentrons/opentrons_flex_96_tiprack_50ul/1",
+      "definitionUri": "opentrons/opentrons_flex_96_tiprack_50ul/2",
       "id": "UUID",
       "loadName": "opentrons_flex_96_tiprack_50ul",
       "location": "offDeck"
@@ -57702,13 +57742,13 @@
       "location": "offDeck"
     },
     {
-      "definitionUri": "opentrons/opentrons_flex_96_tiprack_50ul/1",
+      "definitionUri": "opentrons/opentrons_flex_96_tiprack_50ul/2",
       "id": "UUID",
       "loadName": "opentrons_flex_96_tiprack_50ul",
       "location": "offDeck"
     },
     {
-      "definitionUri": "opentrons/opentrons_flex_96_tiprack_50ul/1",
+      "definitionUri": "opentrons/opentrons_flex_96_tiprack_50ul/2",
       "id": "UUID",
       "loadName": "opentrons_flex_96_tiprack_50ul",
       "location": "offDeck"
@@ -57821,13 +57861,13 @@
       }
     },
     {
-      "definitionUri": "opentrons/opentrons_flex_96_tiprack_200ul/1",
+      "definitionUri": "opentrons/opentrons_flex_96_tiprack_200ul/2",
       "id": "UUID",
       "loadName": "opentrons_flex_96_tiprack_200ul",
       "location": "offDeck"
     },
     {
-      "definitionUri": "opentrons/opentrons_flex_96_tiprack_50ul/1",
+      "definitionUri": "opentrons/opentrons_flex_96_tiprack_50ul/2",
       "id": "UUID",
       "loadName": "opentrons_flex_96_tiprack_50ul",
       "location": "offDeck"
@@ -57858,7 +57898,7 @@
       }
     },
     {
-      "definitionUri": "opentrons/opentrons_flex_96_tiprack_200ul/1",
+      "definitionUri": "opentrons/opentrons_flex_96_tiprack_200ul/2",
       "id": "UUID",
       "loadName": "opentrons_flex_96_tiprack_200ul",
       "location": "offDeck"

--- a/api/src/opentrons/protocol_api/core/engine/load_labware_params.py
+++ b/api/src/opentrons/protocol_api/core/engine/load_labware_params.py
@@ -88,6 +88,14 @@ _APILEVEL_2_25_OT_DEFAULT_VERSIONS: dict[str, int] = deepcopy(
 )
 _APILEVEL_2_25_OT_DEFAULT_VERSIONS.update(
     {
+        "opentrons_flex_96_filtertiprack_1000ul": 2,
+        "opentrons_flex_96_filtertiprack_200ul": 2,
+        "opentrons_flex_96_filtertiprack_20ul": 2,
+        "opentrons_flex_96_filtertiprack_50ul": 2,
+        "opentrons_flex_96_tiprack_1000ul": 2,
+        "opentrons_flex_96_tiprack_200ul": 2,
+        "opentrons_flex_96_tiprack_20ul": 2,
+        "opentrons_flex_96_tiprack_50ul": 2,
         "appliedbiosystemsmicroamp_384_wellplate_40ul": 3,
         "biorad_384_wellplate_50ul": 4,
         "biorad_96_wellplate_200ul_pcr": 4,


### PR DESCRIPTION
# Overview

The opentrons tiprack versions were updated to 2, but forgot to set the default version in the `_APILEVEL_2_25_OT_DEFAULT_VERSIONS` dict. This pull request fixes that.

## Test Plan and Hands on Testing

- [x] Make sure we can load Opentrons tipracks properly
- [x] Make sure the flex stacker can dispense/store tipracks

## Changelog

- Bump the default load version of the Opentrons tipracks from 1 -> 2

## Review requests

What are the implications for the Protocol Designer release, let's discuss @ddcc4 

## Risk assessment
