### PR TITLE
fix(analyses battery): PR generation bugs

### DIFF
--- a/.github/workflows/analyses-snapshot-test.yaml
+++ b/.github/workflows/analyses-snapshot-test.yaml
@@ -190,7 +190,7 @@ jobs:
           title: 'fix(analyses-snapshot-testing): heal ${{ github.event.pull_request.head.ref }} snapshots'
           body: 'This PR was requested on the PR https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           branch: 'analyses-snapshot-testing/heal-${{ github.event.pull_request.head.ref }}'
-          base: ${{ github.event.pull_request.base.ref }}
+          base: ${{ github.event.pull_request.head.ref }}
 
       - name: Comment on feature PR
         if: always() && steps.create_pull_request.outcome == 'success' && github.event_name == 'pull_request'

--- a/.gitignore
+++ b/.gitignore
@@ -154,3 +154,4 @@ api/docs/dist/hardware/
 api/docs/dist/v2/
 
 package-testing/results
+all_analysis_results/

--- a/analyses-snapshot-testing/files/protocols/Flex_S_v2_25_P200_stacker_2.py
+++ b/analyses-snapshot-testing/files/protocols/Flex_S_v2_25_P200_stacker_2.py
@@ -3,6 +3,8 @@ from opentrons import types
 from opentrons.protocol_api import COLUMN, ROW, ALL
 import math
 
+from opentrons.protocol_api.core.engine import protocol
+
 metadata = {'protocolName': 'Illumina RNA Prep 96x Dev v1.1-5/2/2025','author': 'Opentrons <protocols@opentrons.com>','source': 'Protocol Library',}
 requirements = {"robotType": "Flex","apiLevel": "2.25",}
 
@@ -2287,3 +2289,4 @@ def run(protocol: protocol_api.ProtocolContext):
     # =================================================================================================
     # ========================================== PROTOCOL END =========================================
     # =================================================================================================
+    protocol.comment("Done!!!")

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c3b37eae0f][Flex_S_v2_25_P200_stacker_2].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c3b37eae0f][Flex_S_v2_25_P200_stacker_2].json
@@ -57470,6 +57470,20 @@
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"
+    },
+    {
+      "commandType": "comment",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "0067a8a21005e68bd26126d29bb4732c",
+      "notes": [],
+      "params": {
+        "message": "Done!!!"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
     }
   ],
   "config": {


### PR DESCRIPTION
PRs are not generating correctly to heal the snapshots.  Figuring out why.

- [x] excluded analyses aggregation folder
- [x] target the right branch when a healing PR is created
- [x] change a protocol so healing PRs are generated on this PR and prove the fix