### PR TITLE
feat(step-generation): wrap the load_instrument() line because it's getting too long 

### DIFF
--- a/protocol-designer/src/file-data/__tests__/createFile.test.ts
+++ b/protocol-designer/src/file-data/__tests__/createFile.test.ts
@@ -175,7 +175,9 @@ def run(protocol: protocol_api.ProtocolContext) -> None:
     )
 
     # Load Pipettes:
-    mock_python_name_1 = protocol.load_instrument("p10_single", "left", tip_racks=[mock_python_name_2])
+    mock_python_name_1 = protocol.load_instrument(
+        "p10_single", "left", tip_racks=[mock_python_name_2],
+    )
 
     # PROTOCOL STEPS
 

--- a/step-generation/src/__tests__/pythonFileUtils.test.ts
+++ b/step-generation/src/__tests__/pythonFileUtils.test.ts
@@ -338,8 +338,12 @@ describe('getLoadPipettes', () => {
     ).toBe(
       `
 # Load Pipettes:
-pipette_left = protocol.load_instrument("p300_multi_gen2", "left", tip_racks=[tip_rack_2, tip_rack_1])
-pipette_left = protocol.load_instrument("flex_1channel_1000", "right", tip_racks=[tip_rack_2, tip_rack_1])`.trimStart()
+pipette_left = protocol.load_instrument(
+    "p300_multi_gen2", "left", tip_racks=[tip_rack_2, tip_rack_1],
+)
+pipette_left = protocol.load_instrument(
+    "flex_1channel_1000", "right", tip_racks=[tip_rack_2, tip_rack_1],
+)`.trimStart()
     )
   })
 
@@ -370,7 +374,9 @@ pipette_left = protocol.load_instrument("flex_1channel_1000", "right", tip_racks
     ).toBe(
       `
 # Load Pipettes:
-pipette_left = protocol.load_instrument("p300_multi_gen2", "left")`.trimStart()
+pipette_left = protocol.load_instrument(
+    "p300_multi_gen2", "left",
+)`.trimStart()
     )
   })
 
@@ -402,7 +408,9 @@ pipette_left = protocol.load_instrument("p300_multi_gen2", "left")`.trimStart()
     ).toBe(
       `
 # Load Pipettes:
-pipette = protocol.load_instrument("flex_96channel_1000")`.trimStart()
+pipette = protocol.load_instrument(
+    "flex_96channel_1000",
+)`.trimStart()
     )
   })
 })

--- a/step-generation/src/utils/pythonFileUtils.ts
+++ b/step-generation/src/utils/pythonFileUtils.ts
@@ -247,9 +247,7 @@ export function getLoadPipettes(
     .map(pipette => {
       const { name, id, spec, pythonName, tiprackDefURI } = pipette
       const mount =
-        spec.channels === 96
-          ? ''
-          : `, ${formatPyStr(pipetteRobotState[id].mount)}`
+        spec.channels === 96 ? '' : formatPyStr(pipetteRobotState[id].mount)
       const pipetteName = isFlexPipette(name)
         ? getFlexNameConversion(spec)
         : name
@@ -277,13 +275,20 @@ export function getLoadPipettes(
       const tiprackPythonNames = [...onDeckTipracks, ...offDeckTipracks]
         .map(tiprack => tiprack.pythonName)
         .join(', ')
-
       const pythonTipRacks =
-        tiprackDefURI.length === 0 ? '' : `, tip_racks=[${tiprackPythonNames}]`
+        tiprackDefURI.length === 0 ? '' : `tip_racks=[${tiprackPythonNames}]`
 
-      return `${pythonName} = ${PROTOCOL_CONTEXT_NAME}.load_instrument(${formatPyStr(
-        pipetteName
-      )}${mount}${pythonTipRacks})`
+      return (
+        `${pythonName} = ${PROTOCOL_CONTEXT_NAME}.load_instrument(\n` +
+        `${indentPyLines(
+          [
+            formatPyStr(pipetteName),
+            ...(mount ? [mount] : []),
+            ...(pythonTipRacks ? [pythonTipRacks] : []),
+          ].join(', ')
+        )},\n` +
+        ')'
+      )
     })
     .join('\n')
 


### PR DESCRIPTION
# Overview

The `load_instrument()` command we're generating doesn't fit on a line, especially when there are several tipracks, so wrap it.

Before:
```
pipette_right = protocol.load_instrument("flex_1channel_1000", "right", tip_racks=[tip_rack_2, tip_rack_1])
```
After:
```
pipette_right = protocol.load_instrument(
    "flex_1channel_1000", "right", tip_racks=[tip_rack_2, tip_rack_1],
)
```

## Test Plan and Hands on Testing

Updated unit tests. Ran `yarn vitest --silent=false step-generation protocol-designer app`. 

## Risk assessment

Low, cosmetic change.