### PR TITLE
fix(app): Fix labware viewbox in experimental protocol preview

### DIFF
--- a/app/src/pages/Desktop/Protocols/ProtocolPreview/LabwareSlotDetails.tsx
+++ b/app/src/pages/Desktop/Protocols/ProtocolPreview/LabwareSlotDetails.tsx
@@ -7,6 +7,7 @@ import {
   StyledText,
   Tag,
 } from '@opentrons/components'
+import { getLabwareViewBox } from '@opentrons/shared-data'
 import { wellFillFromWellContents } from '@opentrons/step-generation'
 
 import { ActiveWellSlotDetails } from './ActiveWellSlotDetails'
@@ -115,6 +116,9 @@ export function LabwareSlotDetails(
           pipetteTemporalProperties[1].nozzles
         )
       : 1
+
+  const labwareViewBox = getLabwareViewBox(labwareDef)
+
   return (
     <>
       <div>
@@ -151,13 +155,13 @@ export function LabwareSlotDetails(
             <RobotWorkSpace
               key={topLabwareOnSlotId}
               width="14rem"
-              viewBox={`0 0 ${labwareDef.dimensions.xDimension} ${labwareDef.dimensions.yDimension}`}
+              viewBox={`${labwareViewBox.minX} ${labwareViewBox.minY} ${labwareViewBox.xDimension} ${labwareViewBox.yDimension}`}
             >
               {() => (
                 <g>
                   <LabwareRender
                     definition={labwareDef}
-                    positioningMode="offsetInSlot"
+                    positioningMode="passThrough"
                     wellFill={wellFill}
                     missingTips={missingTips}
                     highlightedWells={wellGroup}


### PR DESCRIPTION
## Overview

This component was showing the labware clipped off at the edge if the labware had a nonzero `cornerOffsetFromSlot`. This fixes that, and also prepares the component for labware schema 3.

Goes towards EXEC-1278.

## Test Plan and Hands on Testing

**Before:**

<img width="334" height="414" alt="Screenshot 2025-07-18 at 11 32 21 AM" src="https://github.com/user-attachments/assets/65a09d42-a1f6-4621-b34d-0b888dac3bef" />

**After:**

<img width="331" height="317" alt="Screenshot 2025-07-18 at 11 42 35 AM" src="https://github.com/user-attachments/assets/4eed8678-78df-4669-8c3c-66063a94b453" />


## Review requests

None in particular.

## Risk assessment

Low.
