### PR TITLE
fix(protocol-designer): Fix misaligned "Edit labware" overlay in OffDeckDetails

### DIFF
--- a/protocol-designer/src/pages/Designer/OffDeck/OffDeckControls.tsx
+++ b/protocol-designer/src/pages/Designer/OffDeck/OffDeckControls.tsx
@@ -18,19 +18,15 @@ import * as wellContentsSelectors from '../../../top-selectors/well-contents'
 import { DECK_CONTROLS_STYLE } from '../DeckSetup/constants'
 
 import type { Dispatch, SetStateAction } from 'react'
-import type {
-  CoordinateTuple,
-  DeckSlotId,
-  Dimensions,
-} from '@opentrons/shared-data'
+import type { DeckSlotId, Vector2D } from '@opentrons/shared-data'
 import type { DeckSetupTerminalIdType } from '../types'
 
 interface OffDeckControlsProps extends DeckSetupTerminalIdType {
   hover: string | null
   setHover: Dispatch<SetStateAction<string | null>>
-  slotBoundingBox: Dimensions
+  slotBoundingBox: Vector2D
   labwareId: string
-  slotPosition: CoordinateTuple | null
+  slotPosition: Vector2D | null
   setShowMenuListForId: Dispatch<SetStateAction<string | null>>
   menuListId: DeckSlotId | null
   isSelected?: boolean
@@ -84,10 +80,10 @@ export function OffDeckControls(
         />
       ) : null}
       <RobotCoordsForeignDiv
-        x={slotPosition[0]}
-        y={slotPosition[1]}
-        width={slotBoundingBox.xDimension}
-        height={slotBoundingBox.yDimension}
+        x={slotPosition.x}
+        y={slotPosition.y}
+        width={slotBoundingBox.x}
+        height={slotBoundingBox.y}
         innerDivProps={{
           style: {
             opacity: hoverOpacity,

--- a/protocol-designer/src/pages/Designer/OffDeck/OffDeckDetails.tsx
+++ b/protocol-designer/src/pages/Designer/OffDeck/OffDeckDetails.tsx
@@ -20,6 +20,7 @@ import {
   SPACING,
   StyledText,
 } from '@opentrons/components'
+import { getLabwareViewBox } from '@opentrons/shared-data'
 import {
   getSlotInLocationStack,
   wellFillFromWellContents,
@@ -105,17 +106,13 @@ export function OffDeckDetails(props: OffDeckDetailsProps): JSX.Element {
                 ? allWellContentsForActiveItem[lw.id]
                 : null
               const definition = lw.def
-              const { dimensions } = definition
-              const xyzDimensions = {
-                xDimension: dimensions.xDimension ?? 0,
-                yDimension: dimensions.yDimension ?? 0,
-                zDimension: dimensions.zDimension ?? 0,
-              }
+              const viewBox = getLabwareViewBox(definition)
+
               return (
                 <Flex id={lw.id} flexDirection={DIRECTION_COLUMN} key={lw.id}>
                   <RobotWorkSpace
                     key={lw.id}
-                    viewBox={`${definition.cornerOffsetFromSlot.x} ${definition.cornerOffsetFromSlot.y} ${dimensions.xDimension} ${dimensions.yDimension}`}
+                    viewBox={`${viewBox.minX} ${viewBox.minY} ${viewBox.xDimension} ${viewBox.yDimension}`}
                     width="9.5625rem"
                     height="6.375rem"
                   >
@@ -123,7 +120,7 @@ export function OffDeckDetails(props: OffDeckDetailsProps): JSX.Element {
                       <>
                         <LabwareRender
                           definition={definition}
-                          positioningMode="offsetInSlot"
+                          positioningMode="passThrough"
                           wellFill={wellFillFromWellContents(
                             wellContents,
                             liquidDisplayColors
@@ -135,8 +132,11 @@ export function OffDeckDetails(props: OffDeckDetailsProps): JSX.Element {
                           setShowMenuListForId={setShowMenuListForId}
                           menuListId={menuListId}
                           setHover={setHoverSlot}
-                          slotBoundingBox={xyzDimensions}
-                          slotPosition={ZERO_SLOT_POSITION}
+                          slotBoundingBox={{
+                            x: viewBox.xDimension,
+                            y: viewBox.yDimension,
+                          }}
+                          slotPosition={{ x: viewBox.minX, y: viewBox.minY }}
                           labwareId={lw.id}
                           terminalItemId={terminalItemId}
                         />

--- a/shared-data/js/helpers/__tests__/labwareSchemaShims.test.ts
+++ b/shared-data/js/helpers/__tests__/labwareSchemaShims.test.ts
@@ -77,6 +77,8 @@ describe('getLabwareViewBox()', () => {
     const expectedResult: typeof result = {
       minX: 0,
       minY: 0,
+      maxX: 200,
+      maxY: 100,
       xDimension: 200,
       yDimension: 100,
     }
@@ -104,6 +106,8 @@ describe('getLabwareViewBox()', () => {
     const expectedResult: typeof result = {
       minX: -20,
       minY: -10,
+      maxX: 180,
+      maxY: 90,
       xDimension: 200,
       yDimension: 100,
     }

--- a/shared-data/js/helpers/positionMath.ts
+++ b/shared-data/js/helpers/positionMath.ts
@@ -50,15 +50,25 @@ export function getLabwareViewBox(
   minX: number
   /** The minimum y-coord, i.e. the front of the labware. */
   minY: number
+  /** The maximum x-coord, i.e. the right of the labware. */
+  maxX: number
+  /** The maximum y-coord, i.e. the back of the labware. */
+  maxY: number
+  /** The distance between left and right. */
   xDimension: number
+  /** The distance between front and back. */
   yDimension: number
 } {
   if (definition.schemaVersion === 2) {
     const { xDimension, yDimension } = definition.dimensions
+    // In labware schema 2, the front-left is always at (0, 0) by definition.
+    const minX = 0
+    const minY = 0
     return {
-      // In labware schema 2, the front-left is always at (0, 0) by definition.
-      minX: 0,
-      minY: 0,
+      minX,
+      minY,
+      maxX: minX + xDimension,
+      maxY: minY + yDimension,
       xDimension,
       yDimension,
     }
@@ -71,6 +81,8 @@ export function getLabwareViewBox(
     return {
       minX,
       minY,
+      maxX,
+      maxY,
       xDimension: maxX - minX,
       yDimension: maxY - minY,
     }


### PR DESCRIPTION
## Overview

1. Fix a bug where the "Edit labware" overlay would be misaligned if the labware had a nonzero `cornerOffsetFromSlot`.
2. Prepare this component for labware schema 3, which is a step towards EXEC-1551.

## Test Plan and Hands on Testing

### `cornerOffsetFromSlot` bug fix

Here is a custom labware definition (in schema 2) that intentionally overflows 10 mm beyonds the bounds of a deck slot. [chubby_well_plate.json.zip](https://github.com/user-attachments/files/21321782/chubby_well_plate.json.zip). The 96 wells are clustered in the front-left corner because I copy-pasted them and was too lazy to update their coordinates.



1. Go to "Starting deck" in the protocol timeline
3. Go to the "Off-deck" tab
4. Add a new labware
5. Import the custom labware above and select it
6. Ignore the broken labware render as soon as you do that, which is a different component and a different problem
7. View the "Off-deck" tab again, now with the newly-added labware

Before:

<img width="627" height="221" alt="Screenshot 2025-07-18 at 2 08 48 PM" src="https://github.com/user-attachments/assets/5bc484b3-caf1-4ed0-b05c-73b3acb26d53" />

After:

<img width="635" height="196" alt="Screenshot 2025-07-18 at 2 10 10 PM" src="https://github.com/user-attachments/assets/54ab428b-f35b-4f0f-9294-476aacdaec48" />

### Labware schema 3 support

Protocol Designer doesn't yet support labware schema 3 well enough in general for us to import a real schema-3 definition here and test it, unfortunately. But this is an easy change following a previously-established pattern, so I'm comfortable with it.

## Review requests

None in particular.

## Risk assessment

Low.
