### PR TITLE
test: Bump analyses-snapshot-test/execute-tests timeout

### DIFF
--- a/.github/workflows/analyses-snapshot-test.yaml
+++ b/.github/workflows/analyses-snapshot-test.yaml
@@ -124,7 +124,7 @@ jobs:
           if-no-files-found: error
 
   execute-tests:
-    timeout-minutes: 5
+    timeout-minutes: 15
     needs: process-chunk
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
## Overview

This part is timing out after 5 minutes (and, perplexingly, showing up as "canceled" instead of "failed"). Bump it to 15 to give us some headroom.

## Risk assessment

No risk.