### PR TITLE
chore: 8.5.1 alpha release notes

### DIFF
--- a/api/release-notes.md
+++ b/api/release-notes.md
@@ -8,6 +8,15 @@ By installing and using Opentrons software, you agree to the Opentrons End-User 
 
 ---
 
+## Opentrons Robot Software Changes in 8.5.1
+
+The 8.5.1 hotfix release fixes two bugs:
+
+- Corrected behavior when performing multi-dispense actions using a custom or modified liquid class.
+- Fixed a problem where certain quick transfers (specifically ones that attempt to blow out over the waste chute) could not be run.
+
+---
+
 ## Opentrons Robot Software Changes in 8.5.0
 
 Welcome to the v8.5.0 release of the Opentrons robot software! This release features the ability to pipette more accurately by using liquid classes in your protocols.

--- a/app-shell/build/release-notes.md
+++ b/app-shell/build/release-notes.md
@@ -8,6 +8,14 @@ By installing and using Opentrons software, you agree to the Opentrons End-User 
 
 ---
 
+## Opentrons App Changes in 8.5.1
+
+Welcome to the v8.5.1 release of the Opentrons App!
+
+There are no changes to the Opentrons App in v8.5.1, but it is required for updating the robot software to improve some features.
+
+---
+
 ## Opentrons App Changes in 8.5.0
 
 Welcome to the v8.5.0 release of the Opentrons App! This release features the ability to run protocols that use liquid classes to improve pipetting accuracy.


### PR DESCRIPTION

# Overview

Alpha release notes for 8.5.1. These may become the stable release notes if no further changes are needed.

## Test Plan and Hands on Testing

Test in-app when we cut alpha 0.

## Changelog

- List 2 bug fixes in API notes.
- Note version bump only in app notes.

## Review requests

gtg?

## Risk assessment

v low