### PR TITLE
refactor(components): Add `childrenPositioningMode` prop to `<Module>` to prepare for backwards compatibility

### DIFF
--- a/app/src/organisms/ErrorRecoveryFlows/shared/TwoColLwInfoAndDeck.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/TwoColLwInfoAndDeck.tsx
@@ -162,6 +162,7 @@ export function TwoColLwInfoAndDeck(
                       orientation={inferModuleOrientationFromXCoordinate(x)}
                       targetDeckId={targetDeckId}
                       targetSlotId={targetSlotId}
+                      childrenPositioningMode="offsetToSlot"
                     >
                       {nestedLabwareDef != null &&
                       nestedLabwareId !== failedLwId ? (

--- a/app/src/organisms/InterventionModal/MoveLabwareInterventionContent.tsx
+++ b/app/src/organisms/InterventionModal/MoveLabwareInterventionContent.tsx
@@ -222,6 +222,7 @@ export function MoveLabwareInterventionContent({
                         orientation={inferModuleOrientationFromXCoordinate(x)}
                         targetDeckId={targetDeckId}
                         targetSlotId={targetSlotId}
+                        childrenPositioningMode="offsetToSlot"
                       >
                         {nestedLabwareDef != null &&
                         nestedLabwareId !== command.params.labwareId ? (

--- a/app/src/pages/Desktop/Protocols/ProtocolPreview/DeckViewDetails.tsx
+++ b/app/src/pages/Desktop/Protocols/ProtocolPreview/DeckViewDetails.tsx
@@ -209,6 +209,7 @@ export function DeckViewDetails(props: DeckViewDetailsProps): JSX.Element {
                 }
                 targetSlotId={slot}
                 targetDeckId={deckDef.otId}
+                childrenPositioningMode="offsetToSlot"
               >
                 {labwareLoadedOnModuleId != null ? (
                   <>

--- a/components/src/hardware-sim/BaseDeck/BaseDeck.tsx
+++ b/components/src/hardware-sim/BaseDeck/BaseDeck.tsx
@@ -311,6 +311,7 @@ export function BaseDeck(props: BaseDeckProps): JSX.Element {
                 innerProps={innerProps}
                 targetDeckId={deckDef.otId}
                 targetSlotId={moduleLocation.slotName}
+                childrenPositioningMode="offsetToSlot"
               >
                 {nestedLabwareDef != null ? (
                   <g cursor={onLabwareClick != null ? 'pointer' : ''}>
@@ -372,6 +373,7 @@ export function BaseDeck(props: BaseDeckProps): JSX.Element {
                   innerProps={innerProps}
                   targetDeckId={deckDef.otId}
                   targetSlotId={moduleLocation.slotName}
+                  childrenPositioningMode="offsetToSlot"
                 >
                   {nestedLabwareDef != null ? (
                     <g

--- a/components/src/hardware-sim/Module/Module.stories.tsx
+++ b/components/src/hardware-sim/Module/Module.stories.tsx
@@ -69,6 +69,7 @@ const Template: Story<{
         orientation={args.orientation}
         targetSlotId={null}
         targetDeckId={null}
+        childrenPositioningMode="offsetToSlot"
       >
         {args.hasLabware ? (
           <LabwareRender

--- a/components/src/hardware-sim/Module/index.tsx
+++ b/components/src/hardware-sim/Module/index.tsx
@@ -50,7 +50,23 @@ interface Props {
     | ComponentProps<typeof Temperature>
     | {}
   statusInfo?: ReactNode // contents of small status rectangle, not displayed if absent
-  children?: ReactNode // contents to be rendered on top of the labware mating surface of the module
+
+  children?: ReactNode
+
+  /**
+   * How child components should be positioned.
+   *
+   * "offsetToSlot" - The SVG origin of a child will be at the labware mating interface of the
+   *   module, which is the front-left (-x, -y) corner of the slot on top of the module.
+   *
+   * todo(mm, 2025-07-21):
+   * 1. Add a "passThrough" mode that disables the "offsetToSlot" behavior,
+   *    to allow child components to replace it with their own SVG transform,
+   *    to support labware schema 3.
+   * 2. Migrate all existing call sites to use "passThrough".
+   * 3. Remove "offsetToSlot".
+   */
+  childrenPositioningMode: 'offsetToSlot'
 
   /**
    * Used for applying slot-specific positioning adjustments.

--- a/protocol-designer/src/components/organisms/Ot2Modules/index.tsx
+++ b/protocol-designer/src/components/organisms/Ot2Modules/index.tsx
@@ -461,6 +461,7 @@ export function Ot2Modules(): JSX.Element {
                           }
                           targetSlotId={slotId}
                           targetDeckId={deckDef.otId}
+                          childrenPositioningMode="offsetToSlot"
                         />
                       </Fragment>
                     )

--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupDetails.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupDetails.tsx
@@ -275,6 +275,7 @@ export function DeckSetupDetails(props: DeckSetupDetailsProps): JSX.Element {
               innerProps={innerProps}
               targetSlotId={slotId}
               targetDeckId={deckDef.otId}
+              childrenPositioningMode="offsetToSlot"
             >
               {labwareOnModule != null &&
               !isLabwareOccludedByThermocyclerLid ? (

--- a/protocol-designer/src/pages/Designer/DeckSetup/FixtureRender.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/FixtureRender.tsx
@@ -99,6 +99,7 @@ export const FixtureRender = (props: FixtureRenderProps): JSX.Element => {
         def={getModuleDef(adjacentModule.model)}
         targetSlotId={adjacentModule.slot}
         targetDeckId={deckDef.otId}
+        childrenPositioningMode="offsetToSlot"
       />
     )
   }

--- a/protocol-designer/src/pages/Designer/DeckSetup/SelectedItems.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/SelectedItems.tsx
@@ -117,6 +117,7 @@ export const SelectedItems = (props: SelectedItemsProps): JSX.Element => {
             orientation={orientation}
             targetDeckId={null}
             targetSlotId={null}
+            childrenPositioningMode="offsetToSlot"
           >
             <>
               <SelectedModuleLabwareRender

--- a/protocol-designer/src/pages/ProtocolOverview/DeckThumbnailDetails.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/DeckThumbnailDetails.tsx
@@ -91,6 +91,7 @@ export const DeckThumbnailDetails = (
               }
               targetSlotId={slotId}
               targetDeckId={deckDef.otId}
+              childrenPositioningMode="offsetToSlot"
             >
               {labwareLoadedOnModuleId != null ? (
                 <>


### PR DESCRIPTION
## Overview

This is something to help make #18890 less risky in the context of our ongoing release (v8.6.0) and other PRs continually merging into `edge`.

## Changelog

I'm basically making a type-checking tweak that will turn certain merge mistakes into a hard error. See the new documentation comment for details.

Without this change, #18890 would need to do a hard cutover where it updates all uses of `<Module>` at once, which would be error-prone.

This change will be in the v8.6.0 branch. The changes in #18890 will not be.

## Test Plan and Hands on Testing

None needed.

<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests

None.

## Risk assessment

No risk, no behavioral changes.