### PR TITLE
fix(ci): backup and reinstate to_upload_* folders

### DIFF
--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -397,16 +397,15 @@ jobs:
       - name: 'backup upload folders before checkout'
         run: |
           # Move upload folders to temp location to preserve them during checkout
-          sudo mkdir -p /tmp/upload_backup
-          sudo mv to_upload_* /tmp/upload_backup/ 2>/dev/null || true
+          mkdir -p ${{ runner.temp }}/upload_backup
+          mv to_upload_* ${{ runner.temp }}/upload_backup/ 2>/dev/null || true
       - name: 'pull repo for scripts'
         uses: 'actions/checkout@v4'
       - name: 'restore upload folders after checkout'
         run: |
           # Restore upload folders from temp location
-          sudo mv /tmp/upload_backup/to_upload_* ./ 2>/dev/null || true
+          mv ${{ runner.temp }}/upload_backup/to_upload_* ./ 2>/dev/null || true
       - uses: ./.github/actions/js/setup
-
       - name: 'print upload folders contents'
         run: |
           echo "Test Outputs"

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -409,6 +409,7 @@ jobs:
 
       - name: 'print upload folders contents'
         run: |
+          echo "Test Outputs"
           echo "Contents of to_upload_internal-release: $(ls -l ./to_upload_internal-release)"
           echo "Contents of to_upload_release: $(ls -l ./to_upload_release)"
       - name: 'update internal-releases releases.json'

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -394,21 +394,33 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.OT_APP_ROBOTSTACK_SLACK_NOTIFICATION_WEBHOOK_URL }}
           _ACCESS_URL: https://${{env._APP_DEPLOY_BUCKET_ROBOTSTACK}}/${{env._APP_DEPLOY_FOLDER_ROBOTSTACK}}
 
+      - name: 'backup upload folders before checkout'
+        run: |
+          # Move upload folders to temp location to preserve them during checkout
+          sudo mkdir -p /tmp/upload_backup
+          sudo mv to_upload_* /tmp/upload_backup/ 2>/dev/null || true
       - name: 'pull repo for scripts'
         uses: 'actions/checkout@v4'
-        with:
-          path: ./monorepo
-      - uses: ./monorepo/.github/actions/js/setup
+      - name: 'restore upload folders after checkout'
+        run: |
+          # Restore upload folders from temp location
+          sudo mv /tmp/upload_backup/to_upload_* ./ 2>/dev/null || true
+      - uses: ./.github/actions/js/setup
+
+      - name: 'print upload folders contents'
+        run: |
+          echo "Contents of to_upload_internal-release: $(ls -l ./to_upload_internal-release)"
+          echo "Contents of to_upload_release: $(ls -l ./to_upload_release)"
       - name: 'update internal-releases releases.json'
         if: needs.determine-build-type.outputs.type == 'release' && contains(fromJSON(needs.determine-build-type.outputs.variants), 'internal-release')
         run: |
           aws --profile=deploy s3 cp s3://${{ env._APP_DEPLOY_BUCKET_OT3 }}/${{ env._APP_DEPLOY_FOLDER_OT3 }}/releases.json ./to_upload_internal-release/releases.json
-          node ./monorepo/scripts/update-releases-json ./to_upload_internal-release/releases.json ot3 ./to_upload_internal-release https://ot3-development.builds.opentrons.com/app/
+          node ./scripts/update-releases-json ./to_upload_internal-release/releases.json ot3 ./to_upload_internal-release https://ot3-development.builds.opentrons.com/app/
           aws --profile=deploy s3 cp ./to_upload_internal-release/releases.json s3://${{ env._APP_DEPLOY_BUCKET_OT3 }}/${{ env._APP_DEPLOY_FOLDER_OT3 }}/releases.json
 
       - name: 'update release releases.json'
         if: needs.determine-build-type.outputs.type == 'release' && contains(fromJSON(needs.determine-build-type.outputs.variants), 'release')
         run: |
           aws --profile=deploy s3 cp s3://${{ env._APP_DEPLOY_BUCKET_ROBOTSTACK }}/${{ env._APP_DEPLOY_FOLDER_ROBOTSTACK }}/releases.json ./to_upload_release/releases.json
-          node ./monorepo/scripts/update-releases-json ./to_upload_release/releases.json robot-stack ./to_upload_release https://builds.opentrons.com/app/
+          node ./scripts/update-releases-json ./to_upload_release/releases.json robot-stack ./to_upload_release https://builds.opentrons.com/app/
           aws --profile=deploy s3 cp ./to_upload_release/releases.json s3://${{ env._APP_DEPLOY_BUCKET_ROBOTSTACK }}/${{ env._APP_DEPLOY_FOLDER_ROBOTSTACK }}/releases.json


### PR DESCRIPTION
We cannot use the ./monorepo folder as a checkout location because this messes up the relative pathing in the setup script. https://github.com/actions/runner/issues/1348

Instead, preserve the upload folders in temp and restore after checkout.

Proof the folder is retained in the job now post checkout
<img width="1257" height="1033" alt="image" src="https://github.com/user-attachments/assets/f6e6dce9-b218-4622-a6d0-3cc218205c67" />
