### PR TITLE
fix(app): generate robot state timeline in quick transfer

### DIFF
--- a/app/src/organisms/ODD/QuickTransferFlow/utils/createCommandCreatorFromStepArgs.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/utils/createCommandCreatorFromStepArgs.ts
@@ -1,0 +1,25 @@
+import * as StepGeneration from '@opentrons/step-generation'
+import type { MoveLiquidStepArgs } from './generateQuickTransferArgs'
+
+export const createCommandCreatorFromStepArgs = (
+  args: MoveLiquidStepArgs
+): StepGeneration.CurriedCommandCreator | null => {
+  if (args == null) {
+    return null
+  }
+
+  switch (args.commandCreatorFnName) {
+    case 'transfer': {
+      return StepGeneration.curryCommandCreator(StepGeneration.transfer, args)
+    }
+    case 'consolidate': {
+      return StepGeneration.curryCommandCreator(
+        StepGeneration.consolidate,
+        args
+      )
+    }
+    case 'distribute': {
+      return StepGeneration.curryCommandCreator(StepGeneration.distribute, args)
+    }
+  }
+}

--- a/app/src/organisms/ODD/QuickTransferFlow/utils/createQuickTransferFile.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/utils/createQuickTransferFile.ts
@@ -108,7 +108,7 @@ export function createQuickTransferFile(
     ...loadLabwareCommands,
     ...nonLoadCommands,
   ]
-  console.log('nonLoadCommands', nonLoadCommands)
+
   const sourceLabwareName = quickTransferState.source.metadata.displayName
   let destinationLabwareName = sourceLabwareName
   if (quickTransferState.destination !== 'source') {

--- a/app/src/organisms/ODD/QuickTransferFlow/utils/createQuickTransferFile.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/utils/createQuickTransferFile.ts
@@ -1,25 +1,14 @@
 import uuidv1 from 'uuid/v4'
-import {
-  consolidate,
-  transfer,
-  distribute,
-  getWasteChuteAddressableAreaNamePip,
-} from '@opentrons/step-generation'
-import { generateQuickTransferArgs } from './'
-import {
-  FLEX_ROBOT_TYPE,
-  FLEX_STANDARD_DECKID,
-  getDeckDefFromRobotType,
-  TRASH_BIN_ADAPTER_FIXTURE,
-  WASTE_CHUTE_FIXTURES,
-} from '@opentrons/shared-data'
+import flatMap from 'lodash/flatMap'
+import { FLEX_ROBOT_TYPE, FLEX_STANDARD_DECKID } from '@opentrons/shared-data'
+import { generateQuickTransferArgs } from './generateQuickTransferArgs'
+import { generateQuickTransferRobotStateTimeline } from './generateQuickTransferRobotStateTimeline'
+
 import type {
-  AddressableAreaName,
   DeckConfiguration,
   CommandAnnotationV1Mixin,
   CommandV8Mixin,
   CreateCommand,
-  CutoutId,
   LabwareV2Mixin,
   LiquidV1Mixin,
   LoadLabwareCreateCommand,
@@ -27,7 +16,6 @@ import type {
   OT3RobotMixin,
   LabwareDefinition2,
 } from '@opentrons/shared-data'
-import type { CommandCreatorResult } from '@opentrons/step-generation'
 import type { QuickTransferSummaryState } from '../types'
 
 const uuid: () => string = uuidv1
@@ -104,88 +92,23 @@ export function createQuickTransferFile(
     return acc
   }, [])
 
-  let nonLoadCommandCreator: CommandCreatorResult | null = null
-  if (stepArgs?.commandCreatorFnName === 'transfer') {
-    nonLoadCommandCreator = transfer(
-      stepArgs,
-      invariantContext,
-      initialRobotState
-    )
-  } else if (stepArgs?.commandCreatorFnName === 'consolidate') {
-    nonLoadCommandCreator = consolidate(
-      stepArgs,
-      invariantContext,
-      initialRobotState
-    )
-  } else if (stepArgs?.commandCreatorFnName === 'distribute') {
-    nonLoadCommandCreator = distribute(
-      stepArgs,
-      invariantContext,
-      initialRobotState
-    )
-  }
-
-  const nonLoadCommands =
-    nonLoadCommandCreator != null && 'commands' in nonLoadCommandCreator
-      ? nonLoadCommandCreator.commands
-      : []
-
-  let finalDropTipCommands: CreateCommand[] = []
-  let addressableAreaName: AddressableAreaName | null = null
-  if (
-    quickTransferState.dropTipLocation.cutoutFixtureId ===
-    TRASH_BIN_ADAPTER_FIXTURE
-  ) {
-    const trashLocation = quickTransferState.dropTipLocation.cutoutId
-    const deckDef = getDeckDefFromRobotType(FLEX_ROBOT_TYPE)
-    const cutouts: Record<CutoutId, AddressableAreaName[]> | null =
-      deckDef.cutoutFixtures.find(
-        cutoutFixture => cutoutFixture.id === 'trashBinAdapter'
-      )?.providesAddressableAreas ?? null
-    addressableAreaName =
-      trashLocation != null && cutouts != null
-        ? cutouts[trashLocation]?.[0] ?? null
-        : null
-  } else if (
-    WASTE_CHUTE_FIXTURES.includes(
-      quickTransferState.dropTipLocation.cutoutFixtureId
-    )
-  ) {
-    addressableAreaName = getWasteChuteAddressableAreaNamePip(
-      pipetteEntity.spec.channels
-    )
-  }
-  if (addressableAreaName == null) {
-    console.error(
-      `expected to find addressableAreaName with trashBin or wasteChute location but could not`
-    )
-  } else {
-    finalDropTipCommands = [
-      {
-        key: uuid(),
-        commandType: 'moveToAddressableAreaForDropTip',
-        params: {
-          pipetteId: pipetteEntity.id,
-          addressableAreaName,
-        },
-      },
-      {
-        key: uuid(),
-        commandType: 'dropTipInPlace',
-        params: {
-          pipetteId: pipetteEntity.id,
-        },
-      },
-    ]
-  }
+  const robotStateTimeline = generateQuickTransferRobotStateTimeline({
+    stepArgs,
+    initialRobotState,
+    invariantContext,
+  })
+  const nonLoadCommands: CreateCommand[] = flatMap(
+    robotStateTimeline.timeline,
+    timelineFrame => timelineFrame.commands
+  )
 
   const commands: CreateCommand[] = [
     loadPipetteCommand,
     ...loadAdapterCommands,
     ...loadLabwareCommands,
     ...nonLoadCommands,
-    ...finalDropTipCommands,
   ]
+  console.log('nonLoadCommands', nonLoadCommands)
   const sourceLabwareName = quickTransferState.source.metadata.displayName
   let destinationLabwareName = sourceLabwareName
   if (quickTransferState.destination !== 'source') {

--- a/app/src/organisms/ODD/QuickTransferFlow/utils/generateQuickTransferArgs.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/utils/generateQuickTransferArgs.ts
@@ -32,7 +32,11 @@ import {
 } from '../constants'
 import type { QuickTransferSummaryState } from '../types'
 
-type MoveLiquidStepArgs = ConsolidateArgs | DistributeArgs | TransferArgs | null
+export type MoveLiquidStepArgs =
+  | ConsolidateArgs
+  | DistributeArgs
+  | TransferArgs
+  | null
 
 const uuid: () => string = uuidv1
 const adapter96ChannelDefUri = 'opentrons/opentrons_flex_96_tiprack_adapter/1'

--- a/app/src/organisms/ODD/QuickTransferFlow/utils/generateQuickTransferRobotStateTimeline.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/utils/generateQuickTransferRobotStateTimeline.ts
@@ -1,0 +1,86 @@
+import {
+  dropTipInTrash,
+  dropTipInWasteChute,
+  curryCommandCreator,
+  dropTip,
+  reduceCommandCreators,
+  commandCreatorsTimeline,
+  getPipetteIdFromCCArgs,
+} from '@opentrons/step-generation'
+import { createCommandCreatorFromStepArgs } from './createCommandCreatorFromStepArgs'
+import type * as StepGeneration from '@opentrons/step-generation'
+import type { CutoutId } from '@opentrons/shared-data'
+import type { MoveLiquidStepArgs } from './generateQuickTransferArgs'
+
+export interface GenerateQuickTransferRobotStateTimelineArgs {
+  stepArgs: MoveLiquidStepArgs
+  initialRobotState: StepGeneration.RobotState
+  invariantContext: StepGeneration.InvariantContext
+}
+export const generateQuickTransferRobotStateTimeline = (
+  args: GenerateQuickTransferRobotStateTimelineArgs
+): StepGeneration.Timeline => {
+  const { stepArgs, initialRobotState, invariantContext } = args
+
+  if (stepArgs == null) {
+    return { timeline: [] }
+  }
+
+  const curriedCommandCreator = createCommandCreatorFromStepArgs(stepArgs)
+
+  if (curriedCommandCreator === null) {
+    return { timeline: [] }
+  }
+
+  const pipetteId = getPipetteIdFromCCArgs(stepArgs)
+  const dropTipLocation = stepArgs.dropTipLocation
+
+  const curriedCommandCreators: StepGeneration.CurriedCommandCreator[] = []
+
+  // Always add the transfer/consolidate/distribute commands first
+  curriedCommandCreators.push(curriedCommandCreator)
+
+  if (pipetteId != null) {
+    const dropTipEntity =
+      invariantContext.additionalEquipmentEntities[dropTipLocation]
+    const isWasteChute = dropTipEntity.name === 'wasteChute'
+    const isTrashBin = dropTipEntity.name === 'trashBin'
+
+    let dropTipCommand: StepGeneration.CurriedCommandCreator
+
+    if (isWasteChute) {
+      dropTipCommand = curryCommandCreator(dropTipInWasteChute, {
+        pipetteId,
+        wasteChuteId: dropTipEntity.id,
+      })
+    } else if (isTrashBin) {
+      dropTipCommand = curryCommandCreator(dropTipInTrash, {
+        pipetteId,
+        trashLocation: dropTipEntity.location as CutoutId,
+      })
+    } else {
+      dropTipCommand = curryCommandCreator(dropTip, {
+        pipette: pipetteId,
+        dropTipLocation,
+      })
+    }
+
+    // Wrap drop tip commands and rest of commands in a grouped reducer
+    curriedCommandCreators[curriedCommandCreators.length - 1] = (
+      _invariantContext,
+      _prevRobotState
+    ) =>
+      reduceCommandCreators(
+        [curriedCommandCreator, dropTipCommand],
+        _invariantContext,
+        _prevRobotState
+      )
+  }
+
+  const timeline = commandCreatorsTimeline(
+    curriedCommandCreators,
+    invariantContext,
+    initialRobotState
+  )
+  return timeline
+}


### PR DESCRIPTION
closes AUTH-1520

# Overview

Alex found a bug where there were 2 drop tip command sequences being emitted with a distribute. This is because of this legacy code in `distribute.ts`:

```
      // if using dispense > air gap, drop or change the tip at the end
      const dropTipAfterDispenseAirGap =
        airGapAfterDispenseCommands.length > 0 ? dropTipCommand : []
```

Upon investigating, the real issue is that we shouldn't be emitting the 2nd drop tip command sequence which is hard coded in the `createQuickTransferFile`.

To first fix this, i tried emitting the `createCommands` using `dropTipInWasteChute` and `dropTipInTrash` but that didn't work because I realized the robot state wasn't getting updated. 

Then, i realized, that in order for the logic to properly work and utilize the robot state, we needed to update the robot state after the previous transfer/consolidate/distribute step has been emitted. This lead me to do a slight refactor where I:

1. created QT's version of `createCommandCreatorFromStepArgs` to generate the curried commands of the transfer/consolidate/distribute
2. create a `generateQuickTransferRobotStateTimeline` to generate the timeline of commands + robot state for the consolidate/transfer/distribute + drop tip commands

This seemed to solve the issue! woohoo! its just a big amount of code change for a minor version release??? IDK, lmk if you have concerns about this going into 8.5.1 or if it should be fixed in 8.6.0

## Test Plan and Hands on Testing

Test Alex's case in the ticket and smoke test some other combos of transfer/consolidate and using trash bin and waste chute.

## Changelog

- create `createCommandCreatorFromStepArgs`
- create `generateQuickTransferRobotStateTimeline`
- refactor `createQuickTransferFile`

## Risk assessment

medium?