### PR TITLE
refactor(shared-data): Refactor bottom-to-top labware list to top-to-bottom

### DIFF
--- a/components/src/hardware-sim/Deck/__tests__/resolveLabwareLocation.test.ts
+++ b/components/src/hardware-sim/Deck/__tests__/resolveLabwareLocation.test.ts
@@ -66,10 +66,10 @@ it('should resolve a labware location', () => {
     deckDefinition,
     slotId,
     moduleDefinition,
-    labwareDefinitionsBottomToTop: [
-      labwareCDefinition,
-      labwareBDefinition,
+    labwareDefinitionsTopToBottom: [
       labwareADefinition,
+      labwareBDefinition,
+      labwareCDefinition,
     ],
   }
 

--- a/components/src/hardware-sim/Deck/resolveLabwareLocation.ts
+++ b/components/src/hardware-sim/Deck/resolveLabwareLocation.ts
@@ -42,14 +42,12 @@ export function resolveLabwareLocation({
     otherLoadedLabware,
     otherLabwareDefinitions,
   })
-  const labwareBottomToTop =
-    labwareTopToBottom !== 'error' ? labwareTopToBottom.toReversed() : 'error'
 
-  if (labwareBottomToTop === 'error' || labwareBottomToTop.length < 1) {
+  if (labwareTopToBottom === 'error' || labwareTopToBottom.length < 1) {
     return 'error'
   }
-
-  const bottomLabwareLocation = labwareBottomToTop[0].location
+  const bottomLabwareLocation =
+    labwareTopToBottom[labwareTopToBottom.length - 1].location
 
   if (
     bottomLabwareLocation === 'offDeck' ||
@@ -96,7 +94,7 @@ export function resolveLabwareLocation({
     deckDefinition: deckDef,
     slotId: bottom.slotId,
     moduleDefinition: bottom.moduleDefinition,
-    labwareDefinitionsBottomToTop: labwareBottomToTop.map(l => l.definition),
+    labwareDefinitionsTopToBottom: labwareTopToBottom.map(l => l.definition),
   }
 }
 

--- a/shared-data/js/helpers/positionMath.ts
+++ b/shared-data/js/helpers/positionMath.ts
@@ -162,7 +162,7 @@ function getLabwareStackAsArray(
     parentLabwareDefinition,
   ] of pairsFromArray(labwareDefinitionsTopToBottom)) {
     result.push({
-      debugMetadata: {
+      debugInfo: {
         type: 'labwareToLabware',
         parentLabwareDefinition,
         childLabwareDefinition,
@@ -186,7 +186,7 @@ function getLabwareStackAsArray(
     }
     const slotPosition = coordinateTupleToVector3D(slotPositionTuple)
     result.push({
-      debugMetadata: {
+      debugInfo: {
         type: 'deckSlotToLabware',
         parentSlotId: slotId,
         childLabwareDefinition: bottomLabware,
@@ -197,7 +197,7 @@ function getLabwareStackAsArray(
       ),
     })
     result.push({
-      debugMetadata: {
+      debugInfo: {
         type: 'rootDeckSlot',
         slotId,
       },
@@ -211,7 +211,7 @@ function getLabwareStackAsArray(
     }
     const slotPosition = coordinateTupleToVector3D(slotPositionTuple)
     result.push({
-      debugMetadata: {
+      debugInfo: {
         type: 'moduleToLabware',
         parentModuleDefinition: moduleDefinition,
         childLabwareDefinition: bottomLabware,
@@ -224,7 +224,7 @@ function getLabwareStackAsArray(
       ),
     })
     result.push({
-      debugMetadata: {
+      debugInfo: {
         type: 'rootModule',
         parentSlotId: slotId,
         moduleDefinition,
@@ -246,7 +246,7 @@ interface LabwareStackElement {
    * Human-readable metadata for the benefit of throwing in a console.log() or whatever.
    * Code should not consume this.
    */
-  debugMetadata:
+  debugInfo:
     | {
         type: 'rootDeckSlot'
         slotId: string

--- a/shared-data/js/helpers/positionMath.ts
+++ b/shared-data/js/helpers/positionMath.ts
@@ -91,14 +91,8 @@ export function getLabwareViewBox(
 
 /** Logically specifies where a labware is located. */
 export interface ComputeLabwareOriginInput {
-  /** The underlying deck. */
-  deckDefinition: DeckDefinition
-
-  /**
-   * The underlying slot. If this is a Flex and the labware is on a module, this should
-   * be the slot that the module replaces.
-   */
-  slotId: string
+  /** The labware and all the labware underneath it. */
+  labwareDefinitionsTopToBottom: LabwareDefinition[]
 
   /**
    * The definition of the module underneath the labware, if there is one.
@@ -107,8 +101,14 @@ export interface ComputeLabwareOriginInput {
    */
   moduleDefinition: ModuleDefinition | null
 
-  /** The labware and all the labware underneath it. */
-  labwareDefinitionsTopToBottom: LabwareDefinition[]
+  /**
+   * The underlying slot. If this is a Flex and the labware is on a module, this should
+   * be the slot that the module replaces.
+   */
+  slotId: string
+
+  /** The underlying deck. */
+  deckDefinition: DeckDefinition
 }
 
 /**

--- a/shared-data/js/helpers/positionMath.ts
+++ b/shared-data/js/helpers/positionMath.ts
@@ -108,7 +108,7 @@ export interface ComputeLabwareOriginInput {
   moduleDefinition: ModuleDefinition | null
 
   /** The labware and all the labware underneath it. */
-  labwareDefinitionsBottomToTop: LabwareDefinition[]
+  labwareDefinitionsTopToBottom: LabwareDefinition[]
 }
 
 /**
@@ -146,14 +146,33 @@ function getLabwareStackAsArray(
     deckDefinition,
     slotId,
     moduleDefinition,
-    labwareDefinitionsBottomToTop,
+    labwareDefinitionsTopToBottom,
   } = input
 
-  if (labwareDefinitionsBottomToTop.length === 0) {
+  if (labwareDefinitionsTopToBottom.length === 0) {
     return []
   }
+  const bottomLabware =
+    labwareDefinitionsTopToBottom[labwareDefinitionsTopToBottom.length - 1]
 
   const result: LabwareStackElement[] = []
+
+  for (const [
+    childLabwareDefinition,
+    parentLabwareDefinition,
+  ] of pairsFromArray(labwareDefinitionsTopToBottom)) {
+    result.push({
+      debugMetadata: {
+        type: 'labwareToLabware',
+        parentLabwareDefinition,
+        childLabwareDefinition,
+      },
+      offset: getLabwareOriginToLabwareOrigin(
+        parentLabwareDefinition,
+        childLabwareDefinition
+      ),
+    })
+  }
 
   if (moduleDefinition == null) {
     // The bottom of the stack is a labware in a deck slot.
@@ -168,21 +187,21 @@ function getLabwareStackAsArray(
     const slotPosition = coordinateTupleToVector3D(slotPositionTuple)
     result.push({
       debugMetadata: {
+        type: 'deckSlotToLabware',
+        parentSlotId: slotId,
+        childLabwareDefinition: bottomLabware,
+      },
+      offset: getDeckSlotOriginToLabwareOrigin(
+        slotAddressableArea,
+        bottomLabware
+      ),
+    })
+    result.push({
+      debugMetadata: {
         type: 'rootDeckSlot',
         slotId,
       },
       offset: slotPosition,
-    })
-    result.push({
-      debugMetadata: {
-        type: 'deckSlotToLabware',
-        parentSlotId: slotId,
-        childLabwareDefinition: labwareDefinitionsBottomToTop[0],
-      },
-      offset: getDeckSlotOriginToLabwareOrigin(
-        slotAddressableArea,
-        labwareDefinitionsBottomToTop[0]
-      ),
     })
   } else {
     // The bottom of the stack is a labware in a module in a deck slot.
@@ -193,6 +212,19 @@ function getLabwareStackAsArray(
     const slotPosition = coordinateTupleToVector3D(slotPositionTuple)
     result.push({
       debugMetadata: {
+        type: 'moduleToLabware',
+        parentModuleDefinition: moduleDefinition,
+        childLabwareDefinition: bottomLabware,
+      },
+      offset: getModuleParentOriginToLabwareOrigin(
+        deckDefinition.otId,
+        slotId,
+        moduleDefinition,
+        bottomLabware
+      ),
+    })
+    result.push({
+      debugMetadata: {
         type: 'rootModule',
         parentSlotId: slotId,
         moduleDefinition,
@@ -200,36 +232,6 @@ function getLabwareStackAsArray(
       // Modules don't really have an origin of their own that's separate from the
       // origin of their parent deck slot.
       offset: slotPosition,
-    })
-    result.push({
-      debugMetadata: {
-        type: 'moduleToLabware',
-        parentModuleDefinition: moduleDefinition,
-        childLabwareDefinition: labwareDefinitionsBottomToTop[0],
-      },
-      offset: getModuleParentOriginToLabwareOrigin(
-        deckDefinition.otId,
-        slotId,
-        moduleDefinition,
-        labwareDefinitionsBottomToTop[0]
-      ),
-    })
-  }
-
-  for (const [
-    parentLabwareDefinition,
-    childLabwareDefinition,
-  ] of pairsFromArray(labwareDefinitionsBottomToTop)) {
-    result.push({
-      debugMetadata: {
-        type: 'labwareToLabware',
-        parentLabwareDefinition,
-        childLabwareDefinition,
-      },
-      offset: getLabwareOriginToLabwareOrigin(
-        parentLabwareDefinition,
-        childLabwareDefinition
-      ),
     })
   }
 

--- a/shared-data/js/helpers/positionMath.ts
+++ b/shared-data/js/helpers/positionMath.ts
@@ -163,7 +163,7 @@ function getLabwareStackAsArray(
   ] of pairsFromArray(labwareDefinitionsTopToBottom)) {
     result.push({
       debugInfo: {
-        type: 'labwareToLabware',
+        type: 'labwareOnLabware',
         parentLabwareDefinition,
         childLabwareDefinition,
       },
@@ -187,7 +187,7 @@ function getLabwareStackAsArray(
     const slotPosition = coordinateTupleToVector3D(slotPositionTuple)
     result.push({
       debugInfo: {
-        type: 'deckSlotToLabware',
+        type: 'labwareOnDeckSlot',
         parentSlotId: slotId,
         childLabwareDefinition: bottomLabware,
       },
@@ -212,7 +212,7 @@ function getLabwareStackAsArray(
     const slotPosition = coordinateTupleToVector3D(slotPositionTuple)
     result.push({
       debugInfo: {
-        type: 'moduleToLabware',
+        type: 'labwareOnModule',
         parentModuleDefinition: moduleDefinition,
         childLabwareDefinition: bottomLabware,
       },
@@ -257,17 +257,17 @@ interface LabwareStackElement {
         moduleDefinition: ModuleDefinition
       }
     | {
-        type: 'deckSlotToLabware'
+        type: 'labwareOnDeckSlot'
         parentSlotId: string
         childLabwareDefinition: LabwareDefinition
       }
     | {
-        type: 'moduleToLabware'
+        type: 'labwareOnModule'
         parentModuleDefinition: ModuleDefinition
         childLabwareDefinition: LabwareDefinition
       }
     | {
-        type: 'labwareToLabware'
+        type: 'labwareOnLabware'
         parentLabwareDefinition: LabwareDefinition
         childLabwareDefinition: LabwareDefinition
       }


### PR DESCRIPTION
## Overview

Following up on a Slack discussion, when we have a stack of labware in a list, we want to standardize on the list being in top-to-bottom order. This does that for the recently-added labware positioning math function.

## Test Plan and Hands on Testing

I think existing tests and code review are sufficient here.

## Review requests

None.

## Risk assessment

Low. Changes are easy.