### PR TITLE
fix(components): font css props in LabwareWellLabels

### DIFF
--- a/components/src/hardware-sim/Labware/labwareInternals/LabwareWellLabels.tsx
+++ b/components/src/hardware-sim/Labware/labwareInternals/LabwareWellLabels.tsx
@@ -65,12 +65,10 @@ const Labels = (props: {
             key={wellName}
             x={isLetterColumn ? firstWellXPosition : well.x}
             y={isLetterColumn ? well.y : firstWellYPosition}
-            style={{
-              fontSize: '0.2rem', // LEGACY --fs-micro
-              fontWeight: TYPOGRAPHY.fontWeightSemiBold,
-              textAnchor: 'middle',
-              dominantBaseline: isLetterColumn ? 'middle' : 'auto',
-            }}
+            fontSize="0.2rem" // LEGACY --fs-micro
+            fontWeight={TYPOGRAPHY.fontWeightSemiBold}
+            textAnchor="middle"
+            dominantBaseline={isLetterColumn ? 'middle' : 'auto'}
             fill={
               highlightedWellLabels?.wells.includes(wellName) ?? false
                 ? highlightColor


### PR DESCRIPTION
# Overview

Fix font size of well labels in `LabwareWellLabels` component - this broke after the CSS migration for shared deck map components

<img width="678" height="565" alt="Screenshot 2025-07-23 at 10 15 24" src="https://github.com/user-attachments/assets/d44beb40-ecf2-42b2-9f32-3cf1700e2e43" />

## Test Plan and Hands on Testing

see screenshot and review code

## Changelog

- define font specs directly without using `style`

## Risk assessment

low
