### PR TITLE
fix(protocol-designer): fix temperature module stepform copy

### DIFF
--- a/protocol-designer/cypress/support/ModuleSteps.ts
+++ b/protocol-designer/cypress/support/ModuleSteps.ts
@@ -19,7 +19,7 @@ export enum ModLocators {
 export enum ModContent {
   ModState = 'Heat or cool',
   DeactivateTempDeck = 'Off',
-  Temperature = 'Temperature module state',
+  Temperature = 'Temperature',
   Save = 'Save',
   Temp4CVerification = `Build a pause step to wait until Temperature Module GEN2 reaches 4°C`,
   PlateReader = 'Absorbance Plate Reader Module GEN1',

--- a/protocol-designer/src/assets/localization/en/form.json
+++ b/protocol-designer/src/assets/localization/en/form.json
@@ -407,6 +407,9 @@
       "sterility": "sterility",
       "sterility&motion": "sterility & motion"
     },
+    "temperature": {
+      "state": "Temperature Module state"
+    },
     "tipRack": "tip rack",
     "wellSelectionLabel": {
       "choose_wells": "Choose wells",

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/TemperatureTools/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/TemperatureTools/index.tsx
@@ -7,6 +7,7 @@ import {
   DIRECTION_COLUMN,
   Flex,
   SPACING,
+  StyledText,
 } from '@opentrons/components'
 
 import {
@@ -44,7 +45,14 @@ export function TemperatureTools(props: StepFormProps): JSX.Element {
         }}
       />
       <Box borderBottom={`1px solid ${COLORS.grey30}`} />
-      <Flex padding={`0 ${SPACING.spacing16}`}>
+      <Flex
+        flexDirection={DIRECTION_COLUMN}
+        gridGap={SPACING.spacing4}
+        padding={`0 ${SPACING.spacing16}`}
+      >
+        <StyledText desktopStyle="bodyDefaultSemiBold">
+          {t('form:step_edit_form.temperature.state')}
+        </StyledText>
         <ToggleExpandStepFormField
           {...propsForFields.targetTemperature}
           toggleValue={propsForFields.setTemperature.value}

--- a/protocol-designer/src/step-forms/test/createPresavedStepForm.test.ts
+++ b/protocol-designer/src/step-forms/test/createPresavedStepForm.test.ts
@@ -363,7 +363,7 @@ describe('createPresavedStepForm', () => {
       // Default fields
       setTemperature: null,
       targetTemperature: null,
-      stepName: 'temperature module state',
+      stepName: 'temperature',
       stepDetails: '',
       stepNumber: 0,
     })

--- a/protocol-designer/src/steplist/formLevel/createBlankForm.ts
+++ b/protocol-designer/src/steplist/formLevel/createBlankForm.ts
@@ -31,7 +31,7 @@ const getStepType = (stepType: StepType): string => {
       return 'magnetic module state'
     }
     case 'temperature': {
-      return 'temperature module state'
+      return 'temperature'
     }
     default: {
       return stepType


### PR DESCRIPTION
# Overview

This PR updates the default title for a new temperature module form from "temperature module state" to "temperature". It also adds the header for "temperature module state" above the heat/cool field

Closes RQA-4433

<img width="306" height="234" alt="Screenshot 2025-07-23 at 11 16 29 AM" src="https://github.com/user-attachments/assets/681baadb-7041-4f24-a2a2-c86245139234" />

## Test Plan and Hands on Testing

- create a new temperature step form
- verify that title of the step reads "Temperature"
- in the body of the form, verify that the header for the heat/cool field reads "Temperature Module state"

## Changelog

- revert step form name
- add translations
- add header in temperature tools

## Review requests

see test plan

## Risk assessment

low