### PR TITLE
fix(step-generation): add back version for load_labware and load_adapter

### DIFF
--- a/protocol-designer/src/file-data/__tests__/createFile.test.ts
+++ b/protocol-designer/src/file-data/__tests__/createFile.test.ts
@@ -166,12 +166,14 @@ def run(protocol: protocol_api.ProtocolContext) -> None:
         location="1",
         label="Opentrons 96 Tip Rack 10 µL",
         namespace="opentrons",
+        version=1,
     )
     mock_python_name_3 = protocol.load_labware(
         "fixture_96_plate",
         location="7",
         label="NEST 96 Well Plate 100 µL PCR Full Skirt",
         namespace="opentrons",
+        version=1,
     )
 
     # Load Pipettes:

--- a/step-generation/src/__tests__/pythonFileUtils.test.ts
+++ b/step-generation/src/__tests__/pythonFileUtils.test.ts
@@ -213,6 +213,7 @@ describe('getLoadAdapters', () => {
 adapter_1 = magnetic_block_1.load_adapter(
     "fixture_flex_96_tiprack_adapter",
     namespace="opentrons",
+    version=1,
 )
 adapter_2 = protocol.load_adapter_from_definition(
     CUSTOM_LABWARE["fixture/fixture_flex_96_tiprack_adapter/1"],
@@ -238,10 +239,12 @@ well_plate_1 = adapter_2.load_labware(
     "fixture_96_plate",
     label="reagent plate",
     namespace="opentrons",
+    version=1,
 )
 well_plate_2 = magnetic_block_2.load_labware(
     "fixture_96_plate",
     namespace="opentrons",
+    version=1,
 )
 well_plate_3 = protocol.load_labware_from_definition(
     CUSTOM_LABWARE["fixture/fixture_96_plate/1"],
@@ -274,6 +277,7 @@ well_plate_5 = protocol.load_labware(
     "fixture_96_plate",
     location=protocol_api.OFF_DECK,
     namespace="opentrons",
+    version=1,
 )`.trimStart()
       )
     })

--- a/step-generation/src/utils/pythonFileUtils.ts
+++ b/step-generation/src/utils/pythonFileUtils.ts
@@ -114,7 +114,7 @@ export function getLoadAdapters(
   const pythonAdapters = Object.values(adapterEntities)
     .map(adapter => {
       const { id, def, pythonName } = adapter
-      const { parameters, namespace } = def
+      const { parameters, namespace, version } = def
       // 2nd item in stack is the slot the adapter is on
       const adapterSlot = labwareRobotState[id].stack[1]
       const onModule = moduleEntities[adapterSlot] != null
@@ -136,10 +136,7 @@ export function getLoadAdapters(
           `${formatPyStr(parameters.loadName)}`,
           ...(locationArg ? [locationArg] : []),
           `namespace=${formatPyStr(namespace)}`,
-          //  NOTE: temporarily removing version number
-          //  until PD migrated labware defs to the latest version
-          //  upon re-import
-          // `version=${version}`,
+          `version=${version}`,
         ].join(',\n')
         return (
           `${pythonName} = ${parentName}.load_adapter(\n` +
@@ -176,7 +173,7 @@ export function getLoadLabware(
   const pythonLabware = Object.values(labwareEntities)
     .map(labware => {
       const { id, def, pythonName } = labware
-      const { metadata, parameters, namespace } = def
+      const { metadata, parameters, namespace, version } = def
       const hasNickname =
         labwareNicknamesById[id] != null &&
         labwareNicknamesById[id] !== metadata.displayName
@@ -208,10 +205,7 @@ export function getLoadLabware(
           ...(locationArg ? [locationArg] : []),
           ...(labelArg ? [labelArg] : []),
           `namespace=${formatPyStr(namespace)}`,
-          //  NOTE: temporarily removing version number
-          //  until PD migrated labware defs to the latest version
-          //  upon re-import
-          // `version=${version}`,
+          `version=${version}`,
         ].join(',\n')
         return (
           `${pythonName} = ${parentName}.load_labware(\n` +


### PR DESCRIPTION
# Overview

We should have the version number for the `load_adapter` and `load_labware` commands so its more accurate to what the uses adds in PD. The previous bug that errored requirement inner well geometries for API 2.24 was fixed by Sanniti. See thread [here](https://opentrons.slack.com/archives/C07E9T2NAQK/p1753291952375789)

## Test Plan and Hands on Testing

Review code

## Changelog

- emit version number for more accuracy

## Risk assessment

low