### PR TITLE
fix(api): failure to create a module instance should be logged and not interrupt hardware controller process

### DIFF
--- a/api/src/opentrons/hardware_control/module_control.py
+++ b/api/src/opentrons/hardware_control/module_control.py
@@ -183,24 +183,29 @@ class AttachedModulesControl:
 
         # build new mods
         for mod in unsorted_mods_at_port:
-            new_instance = await self.build_module(
-                port=mod.port,
-                usb_port=mod.usb_port,
-                type=modules.MODULE_TYPE_BY_NAME[mod.name],
-                sim_serial_number=(
-                    mod.serial_number
-                    if isinstance(mod, SimulatingModuleAtPort)
-                    else None
-                ),
-                sim_model=(
-                    mod.model if isinstance(mod, SimulatingModuleAtPort) else None
-                ),
-            )
-            self._available_modules.append(new_instance)
-            log.info(
-                f"Module {mod.name} discovered and attached"
-                f" at port {mod.port}, new_instance: {new_instance}"
-            )
+            try:
+                new_instance = await self.build_module(
+                    port=mod.port,
+                    usb_port=mod.usb_port,
+                    type=modules.MODULE_TYPE_BY_NAME[mod.name],
+                    sim_serial_number=(
+                        mod.serial_number
+                        if isinstance(mod, SimulatingModuleAtPort)
+                        else None
+                    ),
+                    sim_model=(
+                        mod.model if isinstance(mod, SimulatingModuleAtPort) else None
+                    ),
+                )
+                self._available_modules.append(new_instance)
+                log.info(
+                    f"Module {mod.name} discovered and attached"
+                    f" at port {mod.port}, new_instance: {new_instance}"
+                )
+            except Exception as e:
+                log.exception(
+                    f"Failed to build module {mod.name} at port {mod.port}: {e}"
+                )
         self._available_modules = sorted(
             self._available_modules, key=modules.AbstractModule.sort_key
         )


### PR DESCRIPTION
# Overview
This pull request improves error handling in `AttachedModulesControl.register_modules()` by adding a `try-except` block to ensure that failures during module creation are logged without interrupting the rest of the process.

This fixes an issue saw in ABR where connecting a module with a new hardware revision to a robot on an older software, the robot server would hang.