### PR TITLE
fix(components, app, opentrons-ai-client): fix global.css import issue

### DIFF
--- a/app/src/index.tsx
+++ b/app/src/index.tsx
@@ -15,7 +15,7 @@ import '../src/atoms/SoftwareKeyboard/AlphanumericKeyboard'
 import '../src/atoms/SoftwareKeyboard/FullKeyboard/index.css'
 import '../src/atoms/SoftwareKeyboard/IndividualKey/index.css'
 import '../src/atoms/SoftwareKeyboard/NumericalKeyboard/index.css'
-import '@opentrons/components/styles'
+import '@opentrons/components/styles/global'
 
 // export public types so they can be accessed by external deps
 export * from './redux/types'

--- a/app/vite.config.mts
+++ b/app/vite.config.mts
@@ -62,6 +62,9 @@ export default defineConfig(
       },
       resolve: {
         alias: {
+          '@opentrons/components/styles/global': path.resolve(
+            '../components/src/styles/global.css'
+          ),
           '@opentrons/components/styles': path.resolve(
             '../components/src/index.module.css'
           ),

--- a/components/package.json
+++ b/components/package.json
@@ -8,7 +8,8 @@
   "main": "src/index.ts",
   "module": "src/index.ts",
   "exports": {
-    "./styles": "./src/styles/global.css"
+    "./styles": "./src/index.module.css",
+    "./styles/global": "./src/styles/global.css"
   },
   "repository": {
     "type": "git",

--- a/components/src/forms/SelectField.module.css
+++ b/components/src/forms/SelectField.module.css
@@ -1,4 +1,4 @@
-@import '@opentrons/components/styles';
+@import '../index.module.css';
 
 .select_field.error {
   & :global(.ot_select__control) {

--- a/components/src/index.module.css
+++ b/components/src/index.module.css
@@ -3,7 +3,6 @@
 @import './styles/colors.module.css';
 @import './styles/typography.module.css';
 @import './styles/borders.module.css';
-@import './styles/global.css';
 
 :global(*) {
   box-sizing: border-box;

--- a/components/src/legacy-hardware-sim/ModuleItem.module.css
+++ b/components/src/legacy-hardware-sim/ModuleItem.module.css
@@ -1,4 +1,4 @@
-@import '@opentrons/components/styles';
+@import '../index.module.css';
 
 .module {
   display: flex;

--- a/components/src/structure/Splash.module.css
+++ b/components/src/structure/Splash.module.css
@@ -1,4 +1,4 @@
-@import '@opentrons/components/styles';
+@import '../index.module.css';
 
 .splash {
   position: relative;

--- a/components/vite.config.mts
+++ b/components/vite.config.mts
@@ -61,6 +61,9 @@ export default defineConfig({
       '@opentrons/components/styles': path.resolve(
         '../components/src/index.module.css'
       ),
+      '@opentrons/components/styles/global': path.resolve(
+        '../components/src/styles/global.css'
+      ),
       '@opentrons/step-generation': path.resolve(
         '../step-generation/src/index.ts'
       ),

--- a/opentrons-ai-client/src/main.tsx
+++ b/opentrons-ai-client/src/main.tsx
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom/client'
 import { I18nextProvider } from 'react-i18next'
 import { Auth0Provider } from '@auth0/auth0-react'
 
-import '@opentrons/components/styles'
+import '@opentrons/components/styles/global'
 
 import { App } from './App'
 import { i18n } from './i18n'

--- a/opentrons-ai-client/vite.config.mts
+++ b/opentrons-ai-client/vite.config.mts
@@ -48,8 +48,8 @@ export default defineConfig({
   },
   resolve: {
     alias: {
-      '@opentrons/components/styles': path.resolve(
-        '../components/src/index.module.css'
+      '@opentrons/components/styles/global': path.resolve(
+        '../components/src/styles/global.css'
       ),
       '@opentrons/components': path.resolve('../components/src/index.ts'),
       '/ai-client/': path.resolve('./src/') + '/',

--- a/protocol-designer/src/index.tsx
+++ b/protocol-designer/src/index.tsx
@@ -10,7 +10,7 @@ import { configureStore } from './configureStore'
 import { initialize } from './initialize'
 import { initializeSentry } from './resources/sentry'
 
-import '@opentrons/components/styles'
+import '@opentrons/components/styles/global'
 
 // initialize Redux
 const store = configureStore()

--- a/protocol-designer/vite.config.mts
+++ b/protocol-designer/vite.config.mts
@@ -80,8 +80,8 @@ export default defineConfig(
       },
       resolve: {
         alias: {
-          '@opentrons/components/styles': path.resolve(
-            '../components/src/index.module.css'
+          '@opentrons/components/styles/global': path.resolve(
+            '../components/src/styles/global.css'
           ),
           '@opentrons/components': path.resolve('../components/src/index.ts'),
           '@opentrons/shared-data': path.resolve('../shared-data/js/index.ts'),


### PR DESCRIPTION


<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
fix global.css import issue

the issue was that i exported styles as one file but labware-library uses css variables from components. (technically we use the specific order for importing global -> local but actually the issue is happening to labware-library)

i ended up exporting two css files one is index.module.css for old styles (labwre-library and app's old components) and the other is global.css for CSS Modules migration.

close AUTH-2147


<img width="1447" height="870" alt="Screenshot 2025-07-23 at 7 18 14 PM" src="https://github.com/user-attachments/assets/ef35cc39-db16-4f2e-a381-312de7dc171d" />

<img width="1443" height="869" alt="Screenshot 2025-07-23 at 7 18 04 PM" src="https://github.com/user-attachments/assets/0fd97f6b-dadc-447f-bcb6-420da8b9f711" />

<img width="1441" height="866" alt="Screenshot 2025-07-23 at 7 17 55 PM" src="https://github.com/user-attachments/assets/e39d1583-6d33-46b8-8448-351b1c83a874" />


<img width="1021" height="767" alt="Screenshot 2025-07-23 at 8 05 05 PM" src="https://github.com/user-attachments/assets/44e7c911-7da8-4cbf-8ab0-c129f8799185" />


<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- [ ] pd
`make -C protocol-designer dev` the landing page is the same as [the sandbox ](https://sandbox.designer.opentrons.com/chore_release-pd-8.5.0/)

- [ ] opentrons-ai-client
`make -C opentrons-ai-client dev` the landing page is the same as opentrons.ai (need to login)

- [ ] labweare-library
`make -C labware-library dev` the landing page is the same as [the prod](https://labware.opentrons.com/)

- [ ] app
`make -C app dev` the sidebar is the same as the prod and when turning of timeline ff, the previewe page is displayed with the styleds

<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog

<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
mid
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
