### PR TITLE
chore: additional release note for air gap volume bug fix

### DIFF
--- a/api/release-notes.md
+++ b/api/release-notes.md
@@ -14,6 +14,7 @@ The 8.5.1 hotfix release fixes two bugs:
 
 - Corrected behavior when performing multi-dispense actions using a custom or modified liquid class.
 - Fixed a problem where certain quick transfers (specifically ones that attempt to blow out over the waste chute) could not be run.
+- Air-gapping after a dispense when using a liquid class now uses the correct volume. It previously used the same volume as when air-gapping after an aspirate.
 
 ---
 

--- a/api/release-notes.md
+++ b/api/release-notes.md
@@ -10,7 +10,7 @@ By installing and using Opentrons software, you agree to the Opentrons End-User 
 
 ## Opentrons Robot Software Changes in 8.5.1
 
-The 8.5.1 hotfix release fixes two bugs:
+The 8.5.1 hotfix release fixes these bugs:
 
 - Corrected behavior when performing multi-dispense actions using a custom or modified liquid class.
 - Fixed a problem where certain quick transfers (specifically ones that attempt to blow out over the waste chute) could not be run.


### PR DESCRIPTION
# Overview

Adding a release note entry for the fix to [AUTH-2138](https://opentrons.atlassian.net/browse/AUTH-2138).

## Test Plan and Hands on Testing

See it in the next alpha.

## Changelog

+1

## Review requests

Good, accurate description of the fix?

## Risk assessment

nil

[AUTH-2138]: https://opentrons.atlassian.net/browse/AUTH-2138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ