### PR TITLE
refactor(api): Remove unused version gate for tip scrapes

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -100,8 +100,6 @@ _RESIN_TIP_DEFAULT_FLOW_RATE = 10.0
 
 _FLEX_PIPETTE_NAMES_FIXED_IN = APIVersion(2, 23)
 """The version after which InstrumentContext.name returns the correct API-specific names of Flex pipettes."""
-_RETURN_TIP_SCRAPE_ADDED_IN = APIVersion(2, 23)
-"""The version after which return-tip for 1/8 channels will scrape off."""
 
 
 class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):


### PR DESCRIPTION
## Overview

PR #17526 added "scraping" to improve the reliability of tip returns. After ejecting tips, the pipette moves to the side to knock off any tips that are still clinging on.

It looks like the intent was for scraping to only be done on new Python Protocol API versions. However, the actual implementation has always scraped regardless of version. There's a constant, `_RETURN_TIP_SCRAPE_ADDED_IN = APIVersion(2, 23)`, that is just unused.

This PR just deletes the unused constant. I figure that we should just let the versioning mishap go at this point, since we don't have reason to believe that the behavior change has been harmful in practice.

## Test Plan and Hands on Testing

None needed.

## Review requests

Do we agree that we should just let this go at this point? Or should we change the implementation to actually disable tip scraping on old PAPI versions?

## Risk assessment

No risk of affecting robot behavior any more than it's already been affected.