### PR TITLE
refactor(protocol-designer): refine ui for multi-channel substeps

### DIFF
--- a/components/src/atoms/StyledText/PlaceholderStyledText.tsx
+++ b/components/src/atoms/StyledText/PlaceholderStyledText.tsx
@@ -37,7 +37,6 @@ export const PlaceholderStyledText = (
     desktopStyle != null ? styleMap[desktopStyle as StyleKey] : null,
     oddStyle != null ? styleMap[oddStyle as StyleKey] : null
   )
-
   return (
     <text className={combinedClassName} style={{ color: color ?? '' }}>
       {children}

--- a/components/src/atoms/StyledText/placeholderstyledtext.module.css
+++ b/components/src/atoms/StyledText/placeholderstyledtext.module.css
@@ -1,23 +1,24 @@
-.heading_small_bold {
-  @media not (height: 600px) and (width: 1024px) {
-    font: var(--font-weight-bold) 1.125rem/var(--line-height-24);
+@media not all and (width: 1024px) and (height: 600px) {
+  .heading_small_bold {
+    font-size: 1.125rem;
+    font-weight: var(--font-weight-bold);
+    line-height: var(--line-height-24);
+  }
+
+  .caption_bold {
+    font-size: 0.75rem;
+    font-weight: var(--font-weight-bold);
+  }
+
+  .body_default_semi_bold {
+    font-size: var(--font-size-h3);
+    font-weight: var(--font-weight-semi-bold);
+    line-height: var(--line-height-20);
   }
 }
 
-.caption_bold {
-  @media not (height: 600px) and (width: 1024px) {
-    font: var(--font-weight-bold) var(--font-size-h4)/var(--line-height-16);
-  }
-}
-
-.body_default_semi_bold {
-  @media not (height: 600px) and (width: 1024px) {
-    font: var(--font-weight-semi-bold) var(--font-size-h3)/var(--line-height-20);
-  }
-}
-
-.small_body_text_bold {
-  @media (height: 600px) and (width: 1024px) {
+@media (width: 1024px) and (height: 600px) {
+  .small_body_text_bold {
     font-size: var(--font-size-20);
     font-weight: var(--font-weight-bold);
     line-height: var(--font-height-24);

--- a/protocol-designer/src/assets/localization/en/protocol_steps.json
+++ b/protocol-designer/src/assets/localization/en/protocol_steps.json
@@ -82,6 +82,7 @@
   "heater_shaker_state": "Heater-Shaker state",
   "in": "in",
   "into": "into",
+  "individual_wells": "Individual wells",
   "labware_in": "Labware in",
   "labware_to": "{{labware}} to",
   "liquids": "{{num}} liquids",

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/MultichannelSubstep.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/MultichannelSubstep.tsx
@@ -88,14 +88,19 @@ export function MultichannelSubstep(
         <Flex
           flexDirection={DIRECTION_COLUMN}
           gridGap={SPACING.spacing4}
-          padding="12px"
+          padding={SPACING.spacing12}
           width="100%"
+          height={collapsed ? '3rem' : 'auto'}
         >
           <Flex
             justifyContent={JUSTIFY_SPACE_BETWEEN}
             alignItems={ALIGN_CENTER}
           >
-            <Flex gridGap={SPACING.spacing4}>
+            <Flex
+              gridGap={SPACING.spacing4}
+              paddingRight={SPACING.spacing12}
+              alignItems={ALIGN_CENTER}
+            >
               <StyledText desktopStyle="bodyDefaultRegular">
                 {titleCopy}
               </StyledText>
@@ -133,7 +138,11 @@ export function MultichannelSubstep(
                 >
                   {t('protocol_steps:individual_wells')}
                 </StyledText>
-                <Flex flexDirection="column" gridGap={SPACING.spacing4}>
+                <Flex
+                  flexDirection={DIRECTION_COLUMN}
+                  gridGap={SPACING.spacing4}
+                  alignItems={ALIGN_CENTER}
+                >
                   {rowGroup.map((row, rowKey) => {
                     return (
                       <Substep

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/MultichannelSubstep.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/MultichannelSubstep.tsx
@@ -3,11 +3,14 @@ import { useTranslation } from 'react-i18next'
 
 import {
   ALIGN_CENTER,
+  Btn,
+  COLORS,
   DeckInfoLabel,
   DIRECTION_COLUMN,
   Flex,
+  Icon,
   JUSTIFY_SPACE_BETWEEN,
-  ListButton,
+  ListItem,
   SPACING,
   StyledText,
   Tag,
@@ -81,55 +84,77 @@ export function MultichannelSubstep(
         selectSubstep(null)
       }}
     >
-      <ListButton type="noActive" onClick={handleToggleCollapsed}>
+      <ListItem type="default">
         <Flex
           flexDirection={DIRECTION_COLUMN}
           gridGap={SPACING.spacing4}
+          padding="12px"
           width="100%"
         >
           <Flex
-            padding={SPACING.spacing12}
             justifyContent={JUSTIFY_SPACE_BETWEEN}
-            width="100%"
-            gridGap={SPACING.spacing8}
             alignItems={ALIGN_CENTER}
           >
-            <StyledText desktopStyle="bodyDefaultRegular">
-              {titleCopy}
-            </StyledText>
-            <Tag
-              text={`${formatVolume(rowGroup[0].volume)} ${t(
-                'units.microliter'
-              )}`}
-              type="default"
-              shrinkToContent
-            />
-            <StyledText desktopStyle="bodyDefaultRegular">
-              {firstChannelSource != null && firstChannelDest == null
-                ? t('protocol_steps:from')
-                : t('protocol_steps:into')}
-            </StyledText>
-            {deckLabel}
+            <Flex gridGap={SPACING.spacing4}>
+              <StyledText desktopStyle="bodyDefaultRegular">
+                {titleCopy}
+              </StyledText>
+              <Tag
+                text={`${formatVolume(rowGroup[0].volume)} ${t(
+                  'units.microliter'
+                )}`}
+                type="default"
+                shrinkToContent
+              />
+              <StyledText desktopStyle="bodyDefaultRegular">
+                {firstChannelSource != null && firstChannelDest == null
+                  ? t('protocol_steps:from')
+                  : t('protocol_steps:into')}
+              </StyledText>
+              {deckLabel}
+            </Flex>
+            <Btn onClick={handleToggleCollapsed}>
+              <Icon
+                name={collapsed ? 'chevron-down' : 'chevron-up'}
+                size="1.5rem"
+              />
+            </Btn>
           </Flex>
           <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing4}>
-            {!collapsed &&
-              rowGroup.map((row, rowKey) => {
-                return (
-                  <Substep
-                    trashName={trashName}
-                    key={rowKey}
-                    volume={row.volume}
-                    source={row.source}
-                    dest={row.dest}
-                    stepId={stepId}
-                    substepIndex={substepIndex}
-                    isSameLabware={isSameLabware}
-                  />
-                )
-              })}
+            {!collapsed ? (
+              <Flex
+                flexDirection={DIRECTION_COLUMN}
+                paddingTop={SPACING.spacing8}
+                gridGap={SPACING.spacing8}
+              >
+                <StyledText
+                  color={COLORS.grey60}
+                  desktopStyle="bodyDefaultRegular"
+                >
+                  {t('protocol_steps:individual_wells')}
+                </StyledText>
+                <Flex flexDirection="column" gridGap={SPACING.spacing4}>
+                  {rowGroup.map((row, rowKey) => {
+                    return (
+                      <Substep
+                        isNested
+                        trashName={trashName}
+                        key={rowKey}
+                        volume={row.volume}
+                        source={row.source}
+                        dest={row.dest}
+                        stepId={stepId}
+                        substepIndex={substepIndex}
+                        isSameLabware={isSameLabware}
+                      />
+                    )
+                  })}
+                </Flex>
+              </Flex>
+            ) : null}
           </Flex>
         </Flex>
-      </ListButton>
+      </ListItem>
     </Flex>
   )
 }

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/PipettingSubsteps.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/PipettingSubsteps.tsx
@@ -54,6 +54,7 @@ export function PipettingSubsteps(props: PipettingSubstepsProps): JSX.Element {
       })
     : substeps.rows.map((row, substepIndex) => (
         <Substep
+          isNested={false}
           trashName={trashName}
           key={substepIndex}
           selectSubstep={selectSubstep}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/SubStepsToolbox.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/SubStepsToolbox.tsx
@@ -4,7 +4,6 @@ import { useDispatch, useSelector } from 'react-redux'
 import {
   COLORS,
   Flex,
-  FLEX_MAX_CONTENT,
   Icon,
   PrimaryButton,
   StyledText,
@@ -65,7 +64,7 @@ export function SubStepsToolbox(
     <Toolbox
       maxHeight={`calc(100vh - ${NAV_BAR_HEIGHT_REM}rem - 1.5rem)`}
       height="100%"
-      width={FLEX_MAX_CONTENT}
+      width="20.5625rem"
       closeButton={<Icon size="2rem" name="close" />}
       onCloseClick={handleClose}
       confirmButton={

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/Substep.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/Substep.tsx
@@ -23,6 +23,7 @@ interface SubstepProps {
   trashName: AdditionalEquipmentName | null
   stepId: string
   substepIndex: number
+  isNested: boolean
   volume?: number | string | null
   source?: SubstepWellData
   dest?: SubstepWellData
@@ -44,6 +45,7 @@ function SubstepComponent(props: SubstepProps): JSX.Element {
     isSameLabware,
     aspirateVolume,
     dispenseVolume,
+    isNested,
   } = props
   const { i18n, t } = useTranslation([
     'application',
@@ -90,7 +92,7 @@ function SubstepComponent(props: SubstepProps): JSX.Element {
       gridGap={SPACING.spacing4}
     >
       {isMix ? (
-        <ListItem type="default">
+        <ListItem type={isNested ? 'defaultOnColor' : 'default'}>
           <Flex
             gridGap={SPACING.spacing4}
             padding={SPACING.spacing12}
@@ -120,7 +122,7 @@ function SubstepComponent(props: SubstepProps): JSX.Element {
       ) : (
         <>
           {source != null ? (
-            <ListItem type="default">
+            <ListItem type={isNested ? 'defaultOnColor' : 'default'}>
               <Flex
                 gridGap={SPACING.spacing4}
                 padding={SPACING.spacing12}
@@ -149,7 +151,7 @@ function SubstepComponent(props: SubstepProps): JSX.Element {
             </ListItem>
           ) : null}
           {dest != null ? (
-            <ListItem type="default">
+            <ListItem type={isNested ? 'defaultOnColor' : 'default'}>
               <Flex
                 gridGap={SPACING.spacing4}
                 padding={SPACING.spacing12}


### PR DESCRIPTION
closes AUTH-1998

# Overview

The UI for multi-channel substeps should look like this:

<img width="359" height="898" alt="Screenshot 2025-07-24 at 13 45 14" src="https://github.com/user-attachments/assets/21b85257-db7b-404d-9c58-5c03ea7efda0" />

## Test Plan and Hands on Testing

import the attached protocol and look at the transfer step's details. Should see a toolbox with the ui matching designs for the substeps

[untitled - 2025-07-24T134530.725.json](https://github.com/user-attachments/files/21416304/untitled.-.2025-07-24T134530.725.json)

## Changelog

- refine ui of the substeps

## Risk assessment

low