### PR TITLE
fix(step-generation): transform changeTip arg to correct python string

### DIFF
--- a/step-generation/src/__tests__/pythonFileUtils.test.ts
+++ b/step-generation/src/__tests__/pythonFileUtils.test.ts
@@ -19,6 +19,7 @@ import {
 } from '@opentrons/shared-data'
 
 import {
+  formatChangeTipArg,
   getDefineLiquids,
   getLoadAdapters,
   getLoadLabware,
@@ -568,5 +569,17 @@ water_base_class = protocol.get_liquid_class("water")
 ethanol_80_base_class = protocol.get_liquid_class("ethanol_80")
 glycerol_50_base_class = protocol.get_liquid_class("glycerol_50")`.trimStart()
     )
+  })
+})
+
+describe('formatChangeTipArg', () => {
+  it('should transform perSource into per source', () => {
+    expect(formatChangeTipArg('perSource')).toBe('per source')
+  })
+  it('should transform perDest into per destination', () => {
+    expect(formatChangeTipArg('perDest')).toBe('per destination')
+  })
+  it('should not alter never', () => {
+    expect(formatChangeTipArg('never')).toBe('never')
   })
 })

--- a/step-generation/src/commandCreators/compound/consolidate.ts
+++ b/step-generation/src/commandCreators/compound/consolidate.ts
@@ -22,6 +22,7 @@ import {
   curryCommandCreator,
   curryWithoutPython,
   DEST_WELL_BLOWOUT_DESTINATION,
+  formatChangeTipArg,
   formatPyStr,
   getIsRetractSafeForAirGap,
   getIsSafePipetteMovement,
@@ -373,9 +374,7 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
     `dest=${
       pythonDestWells != null ? `[${pythonDestWells}]` : destTrashPipetteName
     }`,
-    //  TODO: fix bug where new_tip api arg does not allow
-    //  changeTip: always but PD does
-    `new_tip=${formatPyStr(changeTip)}`,
+    `new_tip=${formatPyStr(formatChangeTipArg(changeTip))}`,
     `trash_location=${trashPipetteName}`,
     ...(pipetteSpecs.channels > 1 ? [`group_wells=False`] : []),
     `keep_last_tip=True`,

--- a/step-generation/src/commandCreators/compound/distribute.ts
+++ b/step-generation/src/commandCreators/compound/distribute.ts
@@ -23,6 +23,7 @@ import {
   curryCommandCreator,
   curryWithoutPython,
   DEST_WELL_BLOWOUT_DESTINATION,
+  formatChangeTipArg,
   formatPyStr,
   getIsRetractSafeForAirGap,
   getIsSafePipetteMovement,
@@ -405,9 +406,7 @@ export const distribute: CommandCreator<DistributeArgs> = (
     `volume=${volume}`,
     `source=[${pythonSourceWells}]`,
     `dest=[${pythonDestWells ?? destTrashPipetteName}]`,
-    //  TODO: fix bug where new_tip api arg does not allow
-    //  changeTip: always but PD does
-    `new_tip=${formatPyStr(changeTip)}`,
+    `new_tip=${formatPyStr(formatChangeTipArg(changeTip))}`,
     `trash_location=${trashPipetteName}`,
     ...(pipetteSpecs.channels > 1 ? [`group_wells=False`] : []),
     `keep_last_tip=True`,

--- a/step-generation/src/commandCreators/compound/transfer.ts
+++ b/step-generation/src/commandCreators/compound/transfer.ts
@@ -19,6 +19,7 @@ import {
   curryCommandCreator,
   curryWithoutPython,
   DEST_WELL_BLOWOUT_DESTINATION,
+  formatChangeTipArg,
   formatPyStr,
   getIsRetractSafeForAirGap,
   getSlotInLocationStack,
@@ -376,7 +377,7 @@ export const transfer: CommandCreator<TransferArgs> = (
     `dest=${
       pythonDestWells != null ? `[${pythonDestWells}]` : destTrashPipetteName
     }`,
-    `new_tip=${formatPyStr(changeTip)}`,
+    `new_tip=${formatPyStr(formatChangeTipArg(changeTip))}`,
     `trash_location=${trashPipetteName}`,
     ...(pipetteSpecs.channels > 1 ? [`group_wells=False`] : []),
     `keep_last_tip=True`,

--- a/step-generation/src/utils/pythonFileUtils.ts
+++ b/step-generation/src/utils/pythonFileUtils.ts
@@ -24,6 +24,7 @@ import {
 
 import type { CutoutId, ProtocolFile, RobotType } from '@opentrons/shared-data'
 import type {
+  ChangeTipOptions,
   InvariantContext,
   LabwareEntities,
   LabwareEntity,
@@ -509,5 +510,19 @@ export function pythonCustomLabwareDict(
     )}""")`
   } else {
     return ''
+  }
+}
+
+export const formatChangeTipArg = (changeTip: ChangeTipOptions): string => {
+  switch (changeTip) {
+    case 'perDest': {
+      return 'per destination'
+    }
+    case 'perSource': {
+      return 'per source'
+    }
+    default: {
+      return changeTip
+    }
   }
 }


### PR DESCRIPTION
closes RQA-4445

# Overview

create util to transform the `changeTip` arg from the form value into the correct string that protocol engine accepts

## Test Plan and Hands on Testing

Upload attached json protocol from ticket and export to python. import to the app and it should pass analysis (I tested this already btw)

## Changelog

- create util and wire up in transfer, consolidate, and distribute
- add unit test cases

## Risk assessment

low