### PR TITLE
Updates to Stacker TOF data collection script

### DIFF
--- a/hardware-testing/hardware_testing/scripts/stacker_tof_data_collection.py
+++ b/hardware-testing/hardware_testing/scripts/stacker_tof_data_collection.py
@@ -40,12 +40,36 @@ def build_arg_parser() -> argparse.ArgumentParser:
         default=1,
     )
     arg_parser.add_argument(
-        "-n",
-        "--labware_amount",
+        "-x",
+        "--labware_amount_x",
         type=int,
         required=False,
-        help="Sets the labware amount",
+        help="Sets the labware amount for the X a-lxis",
         default=0,
+    )
+    arg_parser.add_argument(
+        "-z",
+        "--labware_amount_z",
+        type=int,
+        required=False,
+        help="Sets the labware amount for the Z axis",
+        default=0,
+    )
+    arg_parser.add_argument(
+        "-l",
+        "--labware_name",
+        type=str,
+        required=False,
+        help="Sets the name of labware",
+        default="baseline",
+    )
+    arg_parser.add_argument(
+        "-t",
+        "--test_name",
+        type=str,
+        required=False,
+        help="Sets the name of the test",
+        default="tof_data_collection",
     )
     arg_parser.add_argument(
         "-s",
@@ -61,13 +85,23 @@ class Stacker_TOF_Data_Collection:
     """Class to collect TOF Sensor data."""
 
     def __init__(
-        self, simulate: bool, samples: int, interval: int, labware_amount: int
+        self,
+        simulate: bool,
+        samples: int,
+        interval: int,
+        labware_amount_x: int,
+        labware_amount_z: int,
+        labware_name: str,
+        test_name: str,
     ) -> None:
         """Init."""
         self.simulate = simulate
         self.samples = samples
         self.interval = interval
-        self.labware_amount = labware_amount
+        self.labware_amount_x = labware_amount_x
+        self.labware_amount_z = labware_amount_z
+        self.labware_name = labware_name
+        self.test_name = test_name
         self.api: Optional[OT3API] = None
         self.mount: Optional[OT3Mount] = None
         self.home: Optional[Point] = None
@@ -134,25 +168,14 @@ class Stacker_TOF_Data_Collection:
 
     def file_setup(self) -> None:
         """Setup where the test output is stored."""
-        class_name = self.__class__.__name__
-        self.test_name = class_name.lower()
         self.test_header = self.dict_keys_to_line(self.test_data)
         self.test_id = data.create_run_id()
         self.test_date = "run-" + datetime.utcnow().strftime("%y-%m-%d")
-        self.test_path = data.create_folder_for_test_data(self.test_name)
-        if self.labware_amount == 0:
-            self.labware_name = "baseline"
-            self.labware_amount_z = self.labware_amount
-        elif self.labware_amount == 1:
-            self.labware_name = "nest-96-pcr"
-            self.labware_amount_z = self.labware_amount
-        elif self.labware_amount == 3:
-            self.labware_name = "tiprack"
-            self.labware_amount = 1
-            self.labware_amount_z = 3
+        class_name = self.__class__.__name__
+        self.test_path = data.create_folder_for_test_data(class_name.lower())
         for stacker in self.stackers:
             self.test_tag = (
-                f"labx{self.labware_amount}_labz{self.labware_amount_z}_{stacker}"
+                f"labx{self.labware_amount_x}_labz{self.labware_amount_z}_{stacker}"
             )
             test_file = data.create_file_name(
                 self.labware_name, self.test_id, self.test_tag
@@ -203,7 +226,7 @@ class Stacker_TOF_Data_Collection:
                                 test_data["Stacker_SN"] = self.stackers[i]
                                 test_data["Axis"] = str(axis.lower())
                                 test_data["Platform_Position"] = pos.lower()
-                                test_data["Labware_Num_X"] = str(self.labware_amount)
+                                test_data["Labware_Num_X"] = str(self.labware_amount_x)
                                 test_data["Labware_Num_Z"] = str(self.labware_amount_z)
                                 test_data["Sample"] = str(sample)
                                 test_data["Zone"] = str(zone)
@@ -214,12 +237,13 @@ class Stacker_TOF_Data_Collection:
                                 # Update the csv with new values
                                 test_data_str = self.dict_values_to_line(test_data)
                                 for test_file in self.test_files:
-                                    data.append_data_to_file(
-                                        test_name=self.test_name,
-                                        run_id=self.test_date,
-                                        file_name=test_file,
-                                        data=test_data_str,
-                                    )
+                                    if self.stackers[i] in test_file:
+                                        data.append_data_to_file(
+                                            test_name=self.test_name,
+                                            run_id=self.test_date,
+                                            file_name=test_file,
+                                            data=test_data_str,
+                                        )
                             time.sleep(self.interval)
                 print("")
 
@@ -255,6 +279,12 @@ if __name__ == "__main__":
     arg_parser = build_arg_parser()
     args = arg_parser.parse_args()
     test = Stacker_TOF_Data_Collection(
-        args.simulate, args.samples, args.interval, args.labware_amount
+        args.simulate,
+        args.samples,
+        args.interval,
+        args.labware_amount_x,
+        args.labware_amount_z,
+        args.labware_name,
+        args.test_name,
     )
     asyncio.run(test.run())


### PR DESCRIPTION
# Overview

made labware, test, and labware numbers arguments in the test to make collecting labware data easier.
Commands like:
`python3 -m hardware_testing.scripts.stacker_tof_data_collection -t PVT_STACKER -x 0 -z 1 -l armadillo-96-pcr
`
are now possible to directly set the test name, number of x and z labware and type of labware

## Test Plan and Hands on Testing

Tested and collected data on two stackers.

## Changelog

- fixed bug where 2 stackers connected would write their values in both csv output files

## Review requests


## Risk assessment

