### PR TITLE
fix(api): post-dispense air gaps in LC based transfers

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/transfer_components_executor.py
+++ b/api/src/opentrons/protocol_api/core/engine/transfer_components_executor.py
@@ -604,13 +604,18 @@ class TransferComponentsExecutor:
             last_air_gap = self._tip_state.last_liquid_and_air_gap_in_tip.air_gap
             self._tip_state.delete_air_gap(last_air_gap)
             self._tip_state.ready_to_aspirate = False
+
+            air_gap_volume = (
+                retract_props.air_gap_by_volume.get_for_volume(0)
+                if add_final_air_gap
+                else 0.0
+            )
             # Do touch tip and air gap again after blowing out into source well or trash
             self._do_touch_tip_and_air_gap_after_dispense(
                 touch_tip_properties=retract_props.touch_tip,
                 location=touch_tip_and_air_gap_location,
                 well=touch_tip_and_air_gap_well,
-                air_gap_volume=add_final_air_gap
-                and retract_props.air_gap_by_volume.get_for_volume(0),
+                air_gap_volume=air_gap_volume,
             )
 
     def retract_during_multi_dispensing(  # noqa: C901
@@ -726,6 +731,14 @@ class TransferComponentsExecutor:
             else:
                 add_air_gap = True
 
+        air_gap_volume = (
+            retract_props.air_gap_by_volume.get_for_volume(
+                self.tip_state.last_liquid_and_air_gap_in_tip.liquid
+            )
+            if add_air_gap
+            else 0.0
+        )
+
         # Regardless of the blowout location, do touch tip
         # when leaving the dispense well.
         # Add an air gap depending on conditioning volume + whether this is
@@ -735,10 +748,7 @@ class TransferComponentsExecutor:
             touch_tip_properties=retract_props.touch_tip,
             location=retract_location,
             well=self._target_well,
-            air_gap_volume=add_air_gap
-            and retract_props.air_gap_by_volume.get_for_volume(
-                self.tip_state.last_liquid_and_air_gap_in_tip.liquid
-            ),
+            air_gap_volume=air_gap_volume,
         )
 
         if (

--- a/api/src/opentrons/protocol_api/core/engine/transfer_components_executor.py
+++ b/api/src/opentrons/protocol_api/core/engine/transfer_components_executor.py
@@ -543,6 +543,11 @@ class TransferComponentsExecutor:
             blowout_props.enabled
             and blowout_props.location == BlowoutLocation.DESTINATION
         ) or not blowout_props.enabled
+
+        if is_final_air_gap and not add_final_air_gap:
+            air_gap_volume = 0.0
+        else:
+            air_gap_volume = retract_props.air_gap_by_volume.get_for_volume(0)
         # Regardless of the blowout location, do touch tip and air gap
         # when leaving the dispense well. If this will be the final air gap, i.e,
         # we won't be moving to a Trash or a Source for Blowout after this air gap,
@@ -551,7 +556,7 @@ class TransferComponentsExecutor:
             touch_tip_properties=retract_props.touch_tip,
             location=retract_location,
             well=self._target_well,
-            add_air_gap=False if is_final_air_gap and not add_final_air_gap else True,
+            air_gap_volume=air_gap_volume,
         )
 
         if (
@@ -604,10 +609,11 @@ class TransferComponentsExecutor:
                 touch_tip_properties=retract_props.touch_tip,
                 location=touch_tip_and_air_gap_location,
                 well=touch_tip_and_air_gap_well,
-                add_air_gap=add_final_air_gap,
+                air_gap_volume=add_final_air_gap
+                and retract_props.air_gap_by_volume.get_for_volume(0),
             )
 
-    def retract_during_multi_dispensing(
+    def retract_during_multi_dispensing(  # noqa: C901
         self,
         trash_location: Union[Location, TrashBin, WasteChute],
         source_location: Optional[Location],
@@ -729,7 +735,10 @@ class TransferComponentsExecutor:
             touch_tip_properties=retract_props.touch_tip,
             location=retract_location,
             well=self._target_well,
-            add_air_gap=add_air_gap,
+            air_gap_volume=add_air_gap
+            and retract_props.air_gap_by_volume.get_for_volume(
+                self.tip_state.last_liquid_and_air_gap_in_tip.liquid
+            ),
         )
 
         if (
@@ -776,17 +785,22 @@ class TransferComponentsExecutor:
             self._tip_state.delete_last_air_gap_and_liquid()
             self._tip_state.ready_to_aspirate = False
 
+            if (
+                # Same check as before for when it's the final air gap of current retract
+                conditioning_volume > 0
+                and is_last_retract
+                and add_final_air_gap
+            ):
+                # The volume in tip at this point should be 0uL
+                air_gap_volume = retract_props.air_gap_by_volume.get_for_volume(0)
+            else:
+                air_gap_volume = 0
             # Do touch tip and air gap again after blowing out into source well or trash
             self._do_touch_tip_and_air_gap_after_dispense(
                 touch_tip_properties=retract_props.touch_tip,
                 location=touch_tip_and_air_gap_location,
                 well=touch_tip_and_air_gap_well,
-                add_air_gap=(
-                    # Same check as before for when it's the final air gap of current retract
-                    conditioning_volume > 0
-                    and is_last_retract
-                    and add_final_air_gap
-                ),
+                air_gap_volume=air_gap_volume,
             )
 
     def _do_touch_tip_and_air_gap_after_dispense(  # noqa: C901
@@ -794,7 +808,7 @@ class TransferComponentsExecutor:
         touch_tip_properties: TouchTipProperties,
         location: Union[Location, TrashBin, WasteChute],
         well: Optional[WellCore],
-        add_air_gap: bool,
+        air_gap_volume: float,
     ) -> None:
         """Perform touch tip and air gap as part of post-dispense retract.
 
@@ -840,7 +854,7 @@ class TransferComponentsExecutor:
                     # Full speed because the tip will already be out of the liquid
                     speed=None,
                 )
-        if add_air_gap or not self._tip_state.ready_to_aspirate:
+        if air_gap_volume > 0 or not self._tip_state.ready_to_aspirate:
             # If we need to move the plunger up either to prepare for aspirate or to add air gap,
             # move to a safe location above the well if the retract location is not already
             # at or above this safe location
@@ -886,12 +900,8 @@ class TransferComponentsExecutor:
             if not self._tip_state.ready_to_aspirate:
                 self._instrument.prepare_to_aspirate()
                 self._tip_state.ready_to_aspirate = True
-            if add_air_gap:
-                self._add_air_gap(
-                    air_gap_volume=self._transfer_properties.aspirate.retract.air_gap_by_volume.get_for_volume(
-                        0
-                    )
-                )
+            if air_gap_volume > 0:
+                self._add_air_gap(air_gap_volume=air_gap_volume)
 
     def _add_air_gap(
         self,

--- a/api/tests/opentrons/protocol_api/core/engine/test_transfer_components_executor.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_transfer_components_executor.py
@@ -1257,6 +1257,10 @@ def test_retract_after_dispense_with_blowout_in_destination(
     air_gap_flow_rate_by_vol = 123
     air_gap_correction_by_vol = 0.321
 
+    sample_transfer_props.aspirate.retract.air_gap_by_volume.set_for_volume(
+        0,
+        1234,  # Explicitly check that this value is not used during post-dispense air gap
+    )
     sample_transfer_props.dispense.retract.air_gap_by_volume.set_for_volume(
         0, air_gap_volume
     )

--- a/api/tests/opentrons/protocol_api/core/engine/test_transfer_components_executor.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_transfer_components_executor.py
@@ -1134,7 +1134,7 @@ def test_retract_after_dispense_with_blowout_in_source(
     air_gap_flow_rate_by_vol = 123
     air_gap_correction_by_vol = 0.321
 
-    sample_transfer_props.aspirate.retract.air_gap_by_volume.set_for_volume(
+    sample_transfer_props.dispense.retract.air_gap_by_volume.set_for_volume(
         0, air_gap_volume
     )
     sample_transfer_props.aspirate.flow_rate_by_volume.set_for_volume(
@@ -1257,7 +1257,7 @@ def test_retract_after_dispense_with_blowout_in_destination(
     air_gap_flow_rate_by_vol = 123
     air_gap_correction_by_vol = 0.321
 
-    sample_transfer_props.aspirate.retract.air_gap_by_volume.set_for_volume(
+    sample_transfer_props.dispense.retract.air_gap_by_volume.set_for_volume(
         0, air_gap_volume
     )
     sample_transfer_props.aspirate.flow_rate_by_volume.set_for_volume(
@@ -1366,7 +1366,7 @@ def test_retract_after_dispense_with_blowout_in_trash_well(
     air_gap_flow_rate_by_vol = 123
     air_gap_correction_by_vol = 0.321
 
-    sample_transfer_props.aspirate.retract.air_gap_by_volume.set_for_volume(
+    sample_transfer_props.dispense.retract.air_gap_by_volume.set_for_volume(
         0, air_gap_volume
     )
     sample_transfer_props.aspirate.flow_rate_by_volume.set_for_volume(
@@ -1493,7 +1493,7 @@ def test_retract_after_dispense_with_blowout_in_disposal_location(
     air_gap_flow_rate_by_vol = 123
     air_gap_correction_by_vol = 0.321
 
-    sample_transfer_props.aspirate.retract.air_gap_by_volume.set_for_volume(
+    sample_transfer_props.dispense.retract.air_gap_by_volume.set_for_volume(
         0, air_gap_volume
     )
     sample_transfer_props.aspirate.flow_rate_by_volume.set_for_volume(
@@ -1599,7 +1599,7 @@ def test_retract_after_dispense_in_trash_with_blowout_in_source(
     air_gap_flow_rate_by_vol = 123
     air_gap_correction_by_vol = 0.321
 
-    sample_transfer_props.aspirate.retract.air_gap_by_volume.set_for_volume(
+    sample_transfer_props.dispense.retract.air_gap_by_volume.set_for_volume(
         0, air_gap_volume
     )
     sample_transfer_props.aspirate.flow_rate_by_volume.set_for_volume(
@@ -1697,7 +1697,7 @@ def test_retract_after_dispense_in_trash_with_blowout_in_destination(
     air_gap_flow_rate_by_vol = 123
     air_gap_correction_by_vol = 0.321
 
-    sample_transfer_props.aspirate.retract.air_gap_by_volume.set_for_volume(
+    sample_transfer_props.dispense.retract.air_gap_by_volume.set_for_volume(
         0, air_gap_volume
     )
     sample_transfer_props.aspirate.flow_rate_by_volume.set_for_volume(
@@ -1780,7 +1780,7 @@ def test_retract_after_dispense_in_trash_with_blowout_in_disposal_location(
     air_gap_flow_rate_by_vol = 123
     air_gap_correction_by_vol = 0.321
 
-    sample_transfer_props.aspirate.retract.air_gap_by_volume.set_for_volume(
+    sample_transfer_props.dispense.retract.air_gap_by_volume.set_for_volume(
         0, air_gap_volume
     )
     sample_transfer_props.aspirate.flow_rate_by_volume.set_for_volume(
@@ -1899,7 +1899,7 @@ def test_retract_after_dispense_with_blowout_in_src_moves_to_safe_loc_for_air_ga
     air_gap_flow_rate_by_vol = 123
     air_gap_correction_by_vol = 0.321
 
-    sample_transfer_props.aspirate.retract.air_gap_by_volume.set_for_volume(
+    sample_transfer_props.dispense.retract.air_gap_by_volume.set_for_volume(
         0, air_gap_volume
     )
     sample_transfer_props.aspirate.flow_rate_by_volume.set_for_volume(
@@ -2039,26 +2039,33 @@ def test_multi_dispense_retract_after_dispense_without_conditioning_volume_or_bl
     dest_well = decoy.mock(cls=WellCore)
     well_top_point = Point(1, 2, 3)
     sample_transfer_props.multi_dispense.retract.touch_tip.enabled = True  # type: ignore[union-attr]
-    air_gap_volume = 0.123
     air_gap_flow_rate_by_vol = 123
     air_gap_correction_by_vol = 0.321
 
-    sample_transfer_props.aspirate.retract.air_gap_by_volume.set_for_volume(
-        0, air_gap_volume
+    sample_transfer_props.multi_dispense.retract.air_gap_by_volume.set_for_volume(  # type: ignore[union-attr]
+        100, 51
     )
     sample_transfer_props.aspirate.flow_rate_by_volume.set_for_volume(
-        air_gap_volume, air_gap_flow_rate_by_vol
+        51, air_gap_flow_rate_by_vol
     )
     sample_transfer_props.aspirate.correction_by_volume.set_for_volume(
-        air_gap_volume, air_gap_correction_by_vol
+        51, air_gap_correction_by_vol
     )
-
     subject = TransferComponentsExecutor(
         instrument_core=mock_instrument_core,
         transfer_properties=sample_transfer_props,
         target_location=Location(Point(1, 1, 1), labware=None),
         target_well=dest_well,
-        tip_state=TipState(),
+        tip_state=TipState(
+            ready_to_aspirate=True,
+            last_liquid_and_air_gap_in_tip=LiquidAndAirGapPair(
+                # Since we'll be testing retract_during_multi_dispensing right after
+                # initializing the executor, this is the tip state that retract_during_multi_dispensing
+                # will start with.
+                liquid=100,
+                air_gap=0,
+            ),
+        ),
         transfer_type=TransferType.ONE_TO_MANY,
     )
     decoy.when(mock_instrument_core.get_current_volume()).then_return(0)
@@ -2112,7 +2119,7 @@ def test_multi_dispense_retract_after_dispense_without_conditioning_volume_or_bl
             and [
                 mock_instrument_core.air_gap_in_place(
                     # type: ignore[func-returns-value]
-                    volume=air_gap_volume,
+                    volume=51,
                     flow_rate=air_gap_flow_rate_by_vol,
                     correction_volume=air_gap_correction_by_vol,
                 ),
@@ -2159,8 +2166,8 @@ def test_multi_dispense_retract_after_dispense_with_blowout_without_conditioning
     air_gap_flow_rate_by_vol = 123
     air_gap_correction_by_vol = 0.321
 
-    sample_transfer_props.aspirate.retract.air_gap_by_volume.set_for_volume(
-        0, air_gap_volume
+    sample_transfer_props.multi_dispense.retract.air_gap_by_volume.set_for_all_volumes(  # type: ignore[union-attr]
+        air_gap_volume
     )
     sample_transfer_props.aspirate.flow_rate_by_volume.set_for_volume(
         air_gap_volume, air_gap_flow_rate_by_vol

--- a/api/tests/opentrons/protocol_api_integration/test_transfer_with_liquid_classes.py
+++ b/api/tests/opentrons/protocol_api_integration/test_transfer_with_liquid_classes.py
@@ -1406,12 +1406,20 @@ def test_order_of_water_distribution_steps_using_multi_dispense(
 
     water = simulated_protocol_context.get_liquid_class("water")
     water_props = water.get_for(pipette_1k, tiprack)
-    water_props.multi_dispense.retract.blowout.location = "destination"  # type: ignore[union-attr]
-    water_props.multi_dispense.retract.blowout.flow_rate = pipette_1k.flow_rate.blow_out  # type: ignore[union-attr]
-    water_props.multi_dispense.retract.blowout.enabled = True  # type: ignore[union-attr]
 
-    expected_conditioning_volume = water_props.multi_dispense.conditioning_by_volume.get_for_volume(120)  # type: ignore[union-attr]
-    expected_disposal_volume = water_props.multi_dispense.disposal_by_volume.get_for_volume(120)  # type: ignore[union-attr]
+    assert water_props.multi_dispense is not None
+    water_props.multi_dispense.retract.blowout.location = "destination"  # type: ignore[assignment]
+    water_props.multi_dispense.retract.blowout.flow_rate = pipette_1k.flow_rate.blow_out
+    water_props.multi_dispense.retract.blowout.enabled = True
+
+    expected_conditioning_volume = 4.5
+    expected_disposal_volume = 5.5
+    water_props.multi_dispense.conditioning_by_volume.set_for_all_volumes(
+        expected_conditioning_volume
+    )
+    water_props.multi_dispense.disposal_by_volume.set_for_all_volumes(
+        expected_disposal_volume
+    )
 
     with (
         mock.patch.object(
@@ -1574,6 +1582,224 @@ def test_order_of_water_distribution_steps_using_multi_dispense(
                 trash_location=mock.ANY,
                 conditioning_volume=expected_conditioning_volume,
                 disposal_volume=expected_disposal_volume,
+            ),
+            mock.call.drop_tip_in_disposal_location(
+                mock.ANY,
+                disposal_location=trash,
+                home_after=False,
+                alternate_tip_drop=True,
+            ),
+        ]
+        assert mock_manager.mock_calls == expected_calls
+
+
+@pytest.mark.ot3_only
+@pytest.mark.parametrize(
+    "simulated_protocol_context", [("2.24", "Flex")], indirect=True
+)
+def test_order_of_water_distribution_steps_using_multi_dispense_without_conditioning_volume(
+    simulated_protocol_context: ProtocolContext,
+) -> None:
+    """It should distribute the liquid using multi-dispense steps in the expected order.
+
+    It should add air gaps between dispenses due to no conditioning volume..
+    """
+    trash = simulated_protocol_context.load_trash_bin("A3")
+    tiprack = simulated_protocol_context.load_labware(
+        "opentrons_flex_96_tiprack_1000ul", "D1"
+    )
+    pipette_1k = simulated_protocol_context.load_instrument(
+        "flex_1channel_1000", mount="left", tip_racks=[tiprack]
+    )
+    nest_plate = simulated_protocol_context.load_labware(
+        "nest_96_wellplate_200ul_flat", "C3"
+    )
+    arma_plate = simulated_protocol_context.load_labware(
+        "armadillo_96_wellplate_200ul_pcr_full_skirt", "C2"
+    )
+
+    water = simulated_protocol_context.get_liquid_class("water")
+    water_props = water.get_for(pipette_1k, tiprack)
+
+    assert water_props.multi_dispense is not None
+    water_props.multi_dispense.retract.blowout.location = "destination"  # type: ignore[assignment]
+    water_props.multi_dispense.retract.blowout.flow_rate = pipette_1k.flow_rate.blow_out
+    water_props.multi_dispense.retract.blowout.enabled = True
+    disposal_volume = 5.5
+    water_props.multi_dispense.conditioning_by_volume.set_for_all_volumes(0)
+    water_props.multi_dispense.disposal_by_volume.set_for_all_volumes(disposal_volume)
+
+    # Set distinct air gaps for different post-dispense volumes so that
+    # we can verify that air gap volumes are calculated using the current tip volume
+    post_aspirate_air_gap_vol = 1.5
+    water_props.aspirate.retract.air_gap_by_volume.set_for_all_volumes(
+        post_aspirate_air_gap_vol
+    )
+    water_props.multi_dispense.retract.air_gap_by_volume.set_for_volume(
+        400 + disposal_volume, 2.5
+    )
+    water_props.multi_dispense.retract.air_gap_by_volume.set_for_volume(
+        disposal_volume, 3.5
+    )
+    water_props.multi_dispense.retract.air_gap_by_volume.set_for_volume(0, 4.5)
+
+    with (
+        mock.patch.object(
+            InstrumentCore,
+            "load_liquid_class",
+            side_effect=InstrumentCore.load_liquid_class,
+            autospec=True,
+        ) as patched_load_liquid_class,
+        mock.patch.object(
+            InstrumentCore,
+            "pick_up_tip",
+            side_effect=InstrumentCore.pick_up_tip,
+            autospec=True,
+        ) as patched_pick_up_tip,
+        mock.patch.object(
+            InstrumentCore,
+            "aspirate_liquid_class",
+            side_effect=InstrumentCore.aspirate_liquid_class,
+            autospec=True,
+        ) as patched_aspirate,
+        mock.patch.object(
+            InstrumentCore,
+            "dispense_liquid_class_during_multi_dispense",
+            side_effect=InstrumentCore.dispense_liquid_class_during_multi_dispense,
+            autospec=True,
+        ) as patched_dispense,
+        mock.patch.object(
+            InstrumentCore,
+            "drop_tip_in_disposal_location",
+            side_effect=InstrumentCore.drop_tip_in_disposal_location,
+            autospec=True,
+        ) as patched_drop_tip,
+    ):
+        mock_manager = mock.Mock()
+        mock_manager.attach_mock(patched_pick_up_tip, "pick_up_tip")
+        mock_manager.attach_mock(patched_load_liquid_class, "load_liquid_class")
+        mock_manager.attach_mock(patched_aspirate, "aspirate_liquid_class")
+        mock_manager.attach_mock(
+            patched_dispense, "dispense_liquid_class_during_multi_dispense"
+        )
+        mock_manager.attach_mock(patched_drop_tip, "drop_tip_in_disposal_location")
+        pipette_1k.distribute_with_liquid_class(
+            liquid_class=water,
+            volume=400,
+            source=nest_plate.rows()[0][1],
+            dest=arma_plate.rows()[0][:4],
+            new_tip="once",
+            trash_location=trash,
+        )
+        expected_calls = [
+            mock.call.load_liquid_class(
+                mock.ANY,
+                name="water",
+                transfer_properties=mock.ANY,
+                tiprack_uri="opentrons/opentrons_flex_96_tiprack_1000ul/1",
+            ),
+            mock.call.pick_up_tip(
+                mock.ANY,
+                location=mock.ANY,
+                well_core=mock.ANY,
+                presses=mock.ANY,
+                increment=mock.ANY,
+            ),
+            mock.call.aspirate_liquid_class(
+                mock.ANY,
+                volume=800 + disposal_volume,
+                source=mock.ANY,
+                transfer_properties=mock.ANY,
+                transfer_type=TransferType.ONE_TO_MANY,
+                tip_contents=[LiquidAndAirGapPair(liquid=0, air_gap=0)],
+                conditioning_volume=0,
+                volume_for_pipette_mode_configuration=400,
+            ),
+            mock.call.dispense_liquid_class_during_multi_dispense(
+                mock.ANY,
+                volume=400,
+                dest=(
+                    Location(Point(), arma_plate.rows()[0][0]),
+                    arma_plate.rows()[0][0]._core,
+                ),
+                source=mock.ANY,
+                transfer_properties=mock.ANY,
+                transfer_type=TransferType.ONE_TO_MANY,
+                tip_contents=[
+                    LiquidAndAirGapPair(
+                        liquid=800 + disposal_volume, air_gap=post_aspirate_air_gap_vol
+                    )
+                ],
+                add_final_air_gap=True,
+                trash_location=mock.ANY,
+                conditioning_volume=0,
+                disposal_volume=disposal_volume,
+            ),
+            mock.call.dispense_liquid_class_during_multi_dispense(
+                mock.ANY,
+                volume=400,
+                dest=(
+                    Location(Point(), arma_plate.rows()[0][1]),
+                    arma_plate.rows()[0][1]._core,
+                ),
+                source=mock.ANY,
+                transfer_properties=mock.ANY,
+                transfer_type=TransferType.ONE_TO_MANY,
+                tip_contents=[
+                    LiquidAndAirGapPair(liquid=400 + disposal_volume, air_gap=2.5)
+                ],
+                add_final_air_gap=True,
+                trash_location=mock.ANY,
+                conditioning_volume=0,
+                disposal_volume=disposal_volume,
+            ),
+            mock.call.aspirate_liquid_class(
+                mock.ANY,
+                volume=800 + disposal_volume,
+                source=mock.ANY,
+                transfer_properties=mock.ANY,
+                transfer_type=TransferType.ONE_TO_MANY,
+                tip_contents=[LiquidAndAirGapPair(liquid=0, air_gap=4.5)],
+                conditioning_volume=0,
+                volume_for_pipette_mode_configuration=400,
+            ),
+            mock.call.dispense_liquid_class_during_multi_dispense(
+                mock.ANY,
+                volume=400,
+                dest=(
+                    Location(Point(), arma_plate.rows()[0][2]),
+                    arma_plate.rows()[0][2]._core,
+                ),
+                source=mock.ANY,
+                transfer_properties=mock.ANY,
+                transfer_type=TransferType.ONE_TO_MANY,
+                tip_contents=[
+                    LiquidAndAirGapPair(
+                        liquid=800 + disposal_volume, air_gap=post_aspirate_air_gap_vol
+                    )
+                ],
+                add_final_air_gap=True,
+                trash_location=mock.ANY,
+                conditioning_volume=0,
+                disposal_volume=disposal_volume,
+            ),
+            mock.call.dispense_liquid_class_during_multi_dispense(
+                mock.ANY,
+                volume=400,
+                dest=(
+                    Location(Point(), arma_plate.rows()[0][3]),
+                    arma_plate.rows()[0][3]._core,
+                ),
+                source=mock.ANY,
+                transfer_properties=mock.ANY,
+                transfer_type=TransferType.ONE_TO_MANY,
+                tip_contents=[
+                    LiquidAndAirGapPair(liquid=400 + disposal_volume, air_gap=2.5)
+                ],
+                add_final_air_gap=True,
+                trash_location=mock.ANY,
+                conditioning_volume=0,
+                disposal_volume=disposal_volume,
             ),
             mock.call.drop_tip_in_disposal_location(
                 mock.ANY,

--- a/api/tests/opentrons/protocol_api_integration/test_transfer_with_liquid_classes.py
+++ b/api/tests/opentrons/protocol_api_integration/test_transfer_with_liquid_classes.py
@@ -1602,7 +1602,7 @@ def test_order_of_water_distribution_steps_using_multi_dispense_without_conditio
 ) -> None:
     """It should distribute the liquid using multi-dispense steps in the expected order.
 
-    It should add air gaps between dispenses due to no conditioning volume..
+    It should add air gaps between dispenses due to no conditioning volume.
     """
     trash = simulated_protocol_context.load_trash_bin("A3")
     tiprack = simulated_protocol_context.load_labware(


### PR DESCRIPTION
Closes AUTH-2138

# Overview

We were previously using `airGapByVolume` of post-aspirate retract property for finding air gaps to use during post-dispense retracts. This PR fixes that so we use the `airGapByVolume` property of a post-single-dispense or a post-multi-dispense in such cases.

Additionally, when adding air gaps in-between multi-dispenses (when conditioning volume is zero), we should be using the total tip volume as the lookup volume for `airGapByVolume` but we were just using `0`uL. 

## Test Plan and Hands on Testing

- updated & added unit & integration tests
- there are several cases we should test for to make sure that:
  - the correct `airGapByVolume` properties are used
  - the correct tip volume is used for looking up the air gap
 These require a lot of different test protocols so I'm adding them in the bug ticket instead.

## Review requests

- Check for code sanity. The changes make yet another function "too complex" according to flake8
- Any cases I'm missing?

## Risk assessment

Medium. This fixes the air gaps in a lot of cases, but the impact of this change is not too high practically speaking.
