### PR TITLE
fix(protocol-designer): null protection when opening a step after a t…

### DIFF
--- a/protocol-designer/src/pages/Designer/utils.ts
+++ b/protocol-designer/src/pages/Designer/utils.ts
@@ -246,8 +246,11 @@ const getNickname = (
   t: any
 ): string => {
   const { modules } = activeDeckSetup
-  const stack = activeDeckSetup.labware[labwareId].stack
-  const latestSlot = resolveSlotLocation(modules, stack, robotType)
+  const stack = activeDeckSetup.labware[labwareId]?.stack
+  const latestSlot =
+    stack != null
+      ? resolveSlotLocation(modules, stack, robotType)
+      : 'unknown slot'
   const name = nicknamesById[labwareId]
   let nickName: string = name
   if (latestSlot != null && latestSlot !== 'offDeck') {
@@ -275,7 +278,7 @@ export const useLabwareDropdownOptions = (
       labwareId: string
     ): DropdownOption[] => {
       const deckSlot = getSlotInLocationStack(
-        activeDeckSetup.labware[labwareId].stack
+        activeDeckSetup.labware[labwareId]?.stack
       )
       const isLabwareInWasteChute = deckSlot === 'gripperWasteChute'
 


### PR DESCRIPTION
…imeline error

closes AUTH-2149

# Overview

null protection to prevent a whitescreen - see ticket for more details

## Test Plan and Hands on Testing

Upload attached protocol. open a move step that occurs after the step that has the timeline error. see that there is no whitescreen.

[extraction adn.json](https://github.com/user-attachments/files/21418199/extraction.adn.json)

## Changelog

add null protection

## Risk assessment

low
