### PR TITLE
fix(api): fix for backwards liquid probe when using aspirate_while_probing 

### DIFF
--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -2835,7 +2835,7 @@ class OT3API(
         if not probe_settings:
             probe_settings = deepcopy(self.config.liquid_sense)
 
-        # We need to significatly slow down the 96 channel liquid probe
+        # We need to significantly slow down the 96 channel liquid probe
         if self.gantry_load in [
             GantryLoad.HIGH_THROUGHPUT_1000,
             GantryLoad.HIGH_THROUGHPUT_200,

--- a/hardware/opentrons_hardware/hardware_control/tool_sensors.py
+++ b/hardware/opentrons_hardware/hardware_control/tool_sensors.py
@@ -300,7 +300,7 @@ async def liquid_probe(
     )
     p_prep_distance = float(plunger_impulse_time * plunger_speed)
     p_pass_distance = float(max_p_distance - p_prep_distance)
-    max_z_distance = (p_pass_distance / plunger_speed) * mount_speed
+    max_z_distance = (p_pass_distance / abs(plunger_speed)) * mount_speed
 
     lower_plunger = create_step(
         distance={tool: float64(p_prep_distance)},


### PR DESCRIPTION
## Overview
Since our refactor of `tool_sensors.py::liquid_probe`, we're using the plunger distance and speed to calculate the mount's distance and speed. The problem is, if you're telling the robot to aspirate, rather than dispense, while probing, that plunger speed is negative. This unfortunately causes the mount speed to also be negative, causing the mount to move up instead of down into the well. 

## Changelog
just use the absolute value of the plunger speed when calculating the mount speed