### PR TITLE
fix(protocol-designer): account for dispensing in trash for migratedP…

### DIFF
--- a/protocol-designer/src/load-file/migration/utils/getMigrationPositionFromTop.ts
+++ b/protocol-designer/src/load-file/migration/utils/getMigrationPositionFromTop.ts
@@ -8,13 +8,7 @@ export const getMigratedPositionFromTop = (
   labware: Labware,
   type: MoveLiquidPrefixType
 ): number => {
-  const labwareDefUri = labware[formLabwareId].labwareDefURI
-
-  if (labwareDefUri == null) {
-    console.error(
-      `unable to find matching labware def uri from form labware id ${formLabwareId}`
-    )
-  }
+  const labwareDefUri = labware[formLabwareId]?.labwareDefURI
 
   //    early exit for dispense_labware equaling trashBin or wasteChute
   if (labwareDefsByURI[labwareDefUri] == null) {


### PR DESCRIPTION
…ositionFromTop

closes RQA-4449

# Overview

Account for migrating the touch tip position when dispensing into a trash bin or waste chute

## Test Plan and Hands on Testing

Import attached protocol in the ticket and see that it successfully imports

## Changelog

null protection check to finding the labwareDefURI

## Risk assessment

low
