### PR TITLE
chore: release note for floating point distribute bug fix

### DIFF
--- a/api/release-notes.md
+++ b/api/release-notes.md
@@ -15,7 +15,7 @@ The 8.5.1 hotfix release fixes these bugs:
 - Corrected behavior when performing multi-dispense actions using a custom or modified liquid class.
 - Fixed a problem where certain quick transfers (specifically ones that attempt to blow out over the waste chute) could not be run.
 - Air-gapping after a dispense when using a liquid class now uses the correct volume.
-- Fixed a problem where distributing with a liquid class would fail to blow out for certain volumes.
+- Fixed a problem where distributing with a liquid class would sometimes fail to blow out the disposal volume.
 
 ---
 

--- a/api/release-notes.md
+++ b/api/release-notes.md
@@ -14,7 +14,8 @@ The 8.5.1 hotfix release fixes these bugs:
 
 - Corrected behavior when performing multi-dispense actions using a custom or modified liquid class.
 - Fixed a problem where certain quick transfers (specifically ones that attempt to blow out over the waste chute) could not be run.
-- Air-gapping after a dispense when using a liquid class now uses the correct volume. It previously used the same volume as when air-gapping after an aspirate.
+- Air-gapping after a dispense when using a liquid class now uses the correct volume.
+- Fixed a problem where distributing with a liquid class would fail to blow out for certain volumes.
 
 ---
 


### PR DESCRIPTION

# Overview

Add a line for [AUTH-2151](https://opentrons.atlassian.net/browse/AUTH-2151) in the 8.5.1 release notes.

## Test Plan and Hands on Testing

n/a

## Changelog

- 1 new bullet
- Simplified note for air gap bug per [post-merge discussion on #19017](https://github.com/Opentrons/opentrons/pull/19017#discussion_r2228692853) 

## Review requests

good words?

## Risk assessment

none

[AUTH-2151]: https://opentrons.atlassian.net/browse/AUTH-2151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ