### PR TITLE
fix(protocol-designer): fix upside down labware on module copy render

### DIFF
--- a/app/src/pages/Desktop/Protocols/ProtocolPreview/DeckViewDetails.tsx
+++ b/app/src/pages/Desktop/Protocols/ProtocolPreview/DeckViewDetails.tsx
@@ -181,7 +181,6 @@ export function DeckViewDetails(props: DeckViewDetailsProps): JSX.Element {
                 >
                   <StyledText
                     desktopStyle="captionRegular"
-                    transform={`rotate(180deg) scaleX(-1)`}
                     color={COLORS.white}
                   >
                     {isActiveLayerVisible


### PR DESCRIPTION
# Overview

fix the upside down text of the styled text in the svg. this is for protocol viz 

Before
<img width="432" height="374" alt="Screenshot 2025-07-25 at 11 27 03" src="https://github.com/user-attachments/assets/e8118e5f-5f45-4311-a188-b6f46b719e1a" />

After
<img width="421" height="373" alt="Screenshot 2025-07-25 at 11 26 23" src="https://github.com/user-attachments/assets/82cf1302-011b-4bda-ab31-66197c011647" />

## Test Plan and Hands on Testing

see the screenshots

## Changelog

fix the upside down text

## Risk assessment

low