### PR TITLE
docs(api): add Flex to `protocol_api` docstring

### DIFF
--- a/api/src/opentrons/protocol_api/__init__.py
+++ b/api/src/opentrons/protocol_api/__init__.py
@@ -1,9 +1,10 @@
-""" protocol_api: The user-facing API for OT2 protocols.
+"""protocol_api: The user-facing API for Opentrons OT-2 and Opentrons Flex protocols.
 
-This package defines classes and functions for access through a protocol to
-control the OT2.
+This package defines classes and functions for Python protocols to
+control an OT-2 or Flex robot.
 
 """
+
 from opentrons.protocols.api_support.definitions import (
     MAX_SUPPORTED_VERSION,
     MIN_SUPPORTED_VERSION,


### PR DESCRIPTION
# Overview

Adds the Flex to the docstring that describes the overall Python Protocol API. Also properly punctuates "OT-2".

## Test Plan and Hands on Testing

automated tests only

## Changelog

Just the one docstring + ran `black`.

## Review requests

I don't know if this is user-facing anywhere — I suspect not, since we hadn't spotted it until now — but it does make sense to keep this up to date, no?

## Risk assessment

v low