### PR TITLE
fix max disposal volume logic

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/DisposalField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/DisposalField.tsx
@@ -9,7 +9,7 @@ import {
   InputStepFormField,
 } from '../../../../../components/molecules'
 import { selectors as stepFormSelectors } from '../../../../../step-forms'
-import { getMaxDisposalVolumeForMultidispense } from '../../../../../steplist/formLevel/handleFormChange/utils'
+import { getMaxDisposalVolumeForMultiDispense } from '../../../../../steplist/formLevel/handleFormChange/utils'
 import { selectors as uiLabwareSelectors } from '../../../../../ui/labware'
 import { getBlowoutLocationOptionsForForm } from '../utils'
 import { FlowRateField } from './FlowRateField'
@@ -26,7 +26,6 @@ interface DisposalFieldProps {
   volume: string | null
   aspirate_airGap_checkbox?: boolean | null
   aspirate_airGap_volume?: string | null
-  tipRack?: string | null
 }
 
 export function DisposalField(props: DisposalFieldProps): JSX.Element {
@@ -38,7 +37,6 @@ export function DisposalField(props: DisposalFieldProps): JSX.Element {
     propsForFields,
     aspirate_airGap_checkbox,
     aspirate_airGap_volume,
-    tipRack,
     formData,
   } = props
   const { t } = useTranslation(['application', 'form'])
@@ -49,7 +47,8 @@ export function DisposalField(props: DisposalFieldProps): JSX.Element {
     path,
     stepType,
   })
-  const maxDisposalVolume = getMaxDisposalVolumeForMultidispense(
+  const tipRack = formData.tipRack
+  const maxDisposalVolume = getMaxDisposalVolumeForMultiDispense(
     {
       aspirate_airGap_checkbox,
       aspirate_airGap_volume,

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.ts
@@ -22,7 +22,7 @@ import {
   getAllWellsFromPrimaryWells,
   getChannels,
   getDefaultWells,
-  getMaxDisposalVolumeForMultidispense,
+  getMaxDisposalVolumeForMultiDispense,
 } from './utils'
 
 import type { NozzleConfigurationStyle } from '@opentrons/shared-data'
@@ -416,7 +416,7 @@ const clampDisposalVolume = (
   const isDecimalString = appliedPatch.disposalVolume_volume === '.'
   // @ts-expect-error(sa, 2021-6-14): appliedPatch isn't well-typed, address in #3161
   if (appliedPatch.path !== 'multiDispense' || isDecimalString) return patch
-  const maxDisposalVolume = getMaxDisposalVolumeForMultidispense(
+  const maxDisposalVolume = getMaxDisposalVolumeForMultiDispense(
     // @ts-expect-error(sa, 2021-6-14): appliedPatch isn't well-typed, address in #3161
     appliedPatch,
     pipetteEntities

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/utils.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/utils.ts
@@ -148,7 +148,7 @@ export function getChannels(
   return pipette.spec.channels
 }
 export const DISPOSAL_VOL_DIGITS = 1
-export function getMaxDisposalVolumeForMultidispense(
+export function getMaxDisposalVolumeForMultiDispense(
   values: {
     aspirate_airGap_checkbox?: boolean | null
     aspirate_airGap_volume?: string | null

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/utils.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/utils.ts
@@ -1,3 +1,4 @@
+import max from 'lodash/max'
 import min from 'lodash/min'
 import round from 'lodash/round'
 import uniq from 'lodash/uniq'
@@ -172,7 +173,10 @@ export function getMaxDisposalVolumeForMultiDispense(
   const airGapChecked = values.aspirate_airGap_checkbox
   let airGapVolume = airGapChecked ? Number(values.aspirate_airGap_volume) : 0
   airGapVolume = Number.isFinite(airGapVolume) ? airGapVolume : 0
-  return round(pipetteCapacity - volume * 2 - airGapVolume, DISPOSAL_VOL_DIGITS)
+  return max([
+    round(pipetteCapacity - volume * 2 - airGapVolume, DISPOSAL_VOL_DIGITS),
+    0,
+  ])
 }
 // Ensures that 2x volume can fit in pipette
 // NOTE: ensuring that disposalVolume_volume will not exceed pipette capacity


### PR DESCRIPTION
# Overview

Correctly get tiprack def URI passed to `getMaxDisposalVolumeForMultiDispense` in `DisposalField`

Closes [RQA-4442](https://opentrons.atlassian.net/browse/RQA-4442)

## Test Plan and Hands on Testing

- create a transfer plan as specified in the ticket
- verify that disposal volume is never negative

## Changelog

- fix retrieval of tipRack def URI
- limit minimum disposal volume to 0µl

## Review requests

- see test plan

## Risk assessment

lowish

[RQA-4442]: https://opentrons.atlassian.net/browse/RQA-4442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ