### PR TITLE
fix(protocol-designer): populate blowout flow rate, remove disposal volume warning

### DIFF
--- a/protocol-designer/src/steplist/formLevel/handleFormChange/utils.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/utils.ts
@@ -631,6 +631,8 @@ const getNoLiquidClassValuesMoveLiquid = (args: {
       dispense_retract_delay_seconds:
         allOT2Defaults.dispense_retract_delay_seconds,
       ...dipsosalFields,
+      blowout_flowRate:
+        matchingTipLiquidSpecs?.defaultBlowOutFlowRate.default ?? null,
     }
     return {
       ...(liquidHandlingAction === 'all' || liquidHandlingAction === 'aspirate'
@@ -732,6 +734,11 @@ const getNoLiquidClassValuesMoveLiquid = (args: {
     'dispense',
     dispenseMaxUiFlowRate
   )
+
+  const blowoutFlowRateFields = {
+    blowout_flowRate: dispense.retract.blowout.params?.flowRate ?? null,
+  }
+
   const pushOutVolume =
     linearInterpolate(
       volume,
@@ -780,6 +787,7 @@ const getNoLiquidClassValuesMoveLiquid = (args: {
     ...dispenseFlowRateFields,
     ...dispenseOffsetFields,
     ...dispensePositionReferenceFields,
+    ...blowoutFlowRateFields,
     dispense_mmFromBottom: DEFAULT_MM_OFFSET_FROM_BOTTOM,
     dispense_submerge_mmFromBottom: SAFE_MOVE_TO_WELL_OFFSET_FROM_TOP_MM,
     dispense_submerge_position_reference: POSITION_REFERENCE_TOP,

--- a/protocol-designer/src/steplist/formLevel/index.ts
+++ b/protocol-designer/src/steplist/formLevel/index.ts
@@ -84,7 +84,6 @@ import {
   composeWarnings,
   incompatibleLiquidClass,
   maxDispenseWellVolume,
-  minDisposalVolume,
   mixTipPositionInTube,
   tipPositionInTube,
 } from './warnings'
@@ -245,7 +244,6 @@ const stepFormHelperMap: {
     getWarnings: composeWarnings(
       belowPipetteMinimumVolume,
       maxDispenseWellVolume,
-      minDisposalVolume,
       tipPositionInTube,
       incompatibleLiquidClass
     ),

--- a/protocol-designer/src/steplist/formLevel/test/warnings.test.ts
+++ b/protocol-designer/src/steplist/formLevel/test/warnings.test.ts
@@ -10,7 +10,6 @@ import {
   belowPipetteMinimumVolume,
   incompatibleLiquidClass,
   maxDispenseWellVolume,
-  minDisposalVolume,
   mixTipPositionInTube,
   tipPositionInTube,
 } from '../warnings'
@@ -66,90 +65,6 @@ describe('Below pipette minimum volume', () => {
     expect(belowPipetteMinimumVolume(fields).type).toBe(
       'BELOW_PIPETTE_MINIMUM_VOLUME'
     )
-  })
-})
-describe('Below min disposal volume', () => {
-  let fieldsWithPipette: {
-    pipette: { spec: { liquids: { default: { minVolume: number } } } }
-    disposalVolume_checkbox: boolean
-    disposalVolume_volume: number
-    path: string
-  }
-  beforeEach(() => {
-    fieldsWithPipette = {
-      pipette: {
-        spec: {
-          liquids: {
-            default: {
-              minVolume: 100,
-            },
-          },
-        },
-      },
-      disposalVolume_checkbox: true,
-      disposalVolume_volume: 100,
-      path: 'multiDispense',
-    }
-  })
-  it('should NOT return a warning when there is no pipette', () => {
-    const fields = {
-      ...fieldsWithPipette,
-      pipette: undefined,
-    } as any
-    expect(minDisposalVolume(fields)).toBe(null)
-  })
-  it('should NOT return a warning when there is no pipette spec', () => {
-    const fields = {
-      ...fieldsWithPipette,
-      pipette: { spec: undefined },
-    } as any
-    expect(minDisposalVolume(fields)).toBe(null)
-  })
-  it('should NOT return a warning when the path is NOT multi dispense', () => {
-    const fields = {
-      ...fieldsWithPipette,
-      path: 'another_path',
-    } as any
-    expect(minDisposalVolume(fields)).toBe(null)
-  })
-  it('should NOT return a warning when the volume is equal to the min pipette volume', () => {
-    const fields = {
-      ...fieldsWithPipette,
-      disposalVolume_volume: 100,
-    } as any
-    expect(minDisposalVolume(fields)).toBe(null)
-  })
-  it('should NOT return a warning when the volume is greater than the min pipette volume', () => {
-    const fields = {
-      ...fieldsWithPipette,
-      disposalVolume_volume: 100,
-    } as any
-    expect(minDisposalVolume(fields)).toBe(null)
-  })
-
-  it('should return a warning when the volume is less than the min pipette volume', () => {
-    const fields = {
-      ...fieldsWithPipette,
-      disposalVolume_volume: 99,
-    }
-    // @ts-expect-error(sa, 2021-6-15): minDisposalVolume might return null, need to null check before property access
-    expect(minDisposalVolume(fields).type).toBe('BELOW_MIN_DISPOSAL_VOLUME')
-  })
-  it('should return a warning when the path is multi dispense and the checkbox is unchecked', () => {
-    const fields = {
-      ...fieldsWithPipette,
-      disposalVolume_checkbox: false,
-    }
-    // @ts-expect-error(sa, 2021-6-15): minDisposalVolume might return null, need to null check before property access
-    expect(minDisposalVolume(fields).type).toBe('BELOW_MIN_DISPOSAL_VOLUME')
-  })
-  it('should return a warning when the path is multi dispense and there is no disposal volume', () => {
-    const fields = {
-      ...fieldsWithPipette,
-      disposalVolume_volume: undefined,
-    }
-    // @ts-expect-error(sa, 2021-6-15): minDisposalVolume might return null, need to null check before property access
-    expect(minDisposalVolume(fields).type).toBe('BELOW_MIN_DISPOSAL_VOLUME')
   })
 })
 describe('Max dispense well volume', () => {

--- a/protocol-designer/src/steplist/formLevel/warnings.tsx
+++ b/protocol-designer/src/steplist/formLevel/warnings.tsx
@@ -21,7 +21,6 @@ import type { FormError } from './errors'
  ********************/
 
 export type FormWarningType =
-  | 'BELOW_MIN_DISPOSAL_VOLUME'
   | 'BELOW_PIPETTE_MINIMUM_VOLUME'
   | 'INCOMPATIBLE_ALL_PIPETTE'
   | 'INCOMPATIBLE_PIPETTE_PATH'
@@ -49,15 +48,6 @@ const overMaxWellVolumeWarning = (): FormWarning => ({
   type: 'OVER_MAX_WELL_VOLUME',
   title: 'Dispense volume will overflow a destination well',
   dependentFields: ['dispense_labware', 'dispense_wells', 'volume'],
-  location: 'form',
-})
-
-const belowMinDisposalVolumeWarning = (min: number): FormWarning => ({
-  type: 'BELOW_MIN_DISPOSAL_VOLUME',
-  title: `Disposal volume is below recommended minimum (${min} uL)`,
-  body:
-    'For accuracy in multi-dispense Transfers we recommend you use a disposal volume of at least the pipette`s minimum.',
-  dependentFields: ['disposalVolume_volume', 'pipette'],
   location: 'form',
 })
 
@@ -159,29 +149,6 @@ export const maxDispenseWellVolume = (
     return maximum && effectiveVolume > maximum
   })
   return hasExceeded ? overMaxWellVolumeWarning() : null
-}
-
-export const minDisposalVolume = (
-  fields: HydratedMoveLiquidFormData
-): FormWarning | null => {
-  const {
-    disposalVolume_checkbox,
-    disposalVolume_volume,
-    pipette,
-    path,
-  } = fields
-  if (!(pipette && pipette.spec) || path !== 'multiDispense') return null
-  const isUnselected = !disposalVolume_checkbox || !disposalVolume_volume
-  const liquidSpecs = pipette.spec.liquids
-  const minVolume =
-    'lowVolumeDefault' in liquidSpecs
-      ? liquidSpecs.lowVolumeDefault.minVolume
-      : liquidSpecs.default.minVolume
-  if (isUnselected) {
-    return belowMinDisposalVolumeWarning(minVolume as number)
-  }
-  const isBelowMin = disposalVolume_volume < minVolume
-  return isBelowMin ? belowMinDisposalVolumeWarning(minVolume as number) : null
 }
 
 export const _lowVolumeTransferWarning = (): FormWarning => ({


### PR DESCRIPTION
# Overview

cherry-picked commits accidentally targeted edge in #19044

This PR ensures blowout flow rate is populated for "don't use a liquid class" transfers. It also removes a legacy warning for disposal volume below recommended value (liquid classes specify values below the 5ul minimum frequently).

Closes RQA-4425

## Test Plan and Hands on Testing

- create a new transfer form with "don't use a liquid class" selected
- open blowout field in dispense advanced settings
- verify that flow rate populates
- set a disposal volume below 5µl
- verify that no warning shows

## Changelog

- populate blowout flowrate fields for no liquid class transfers
- remove disposal volume below minimum warning

## Review requests

see test plan

## Risk assessment

low