### PR TITLE
fix(app): Fix ODD labware offsets label color during run setup

### DIFF
--- a/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/__tests__/useUpdateLabware.test.ts
+++ b/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/__tests__/useUpdateLabware.test.ts
@@ -131,40 +131,6 @@ describe('useUpdateLabware', () => {
     )
   })
 
-  it('should not re-dispatch when runId changes but other params remain the same', () => {
-    const { rerender } = renderHook(
-      props => {
-        useUpdateLabware(
-          props.isFlex,
-          props.runId,
-          props.maintenanceRunId,
-          props.labwareInfo
-        )
-      },
-      {
-        initialProps: {
-          isFlex: true,
-          runId: RUN_ID,
-          maintenanceRunId: null,
-          labwareInfo: MOCK_LABWARE_INFO,
-        },
-      }
-    )
-
-    expect(mockDispatch).toHaveBeenCalledTimes(1)
-    mockDispatch.mockClear()
-
-    const NEW_RUN_ID = 'run-456'
-    rerender({
-      isFlex: true,
-      runId: NEW_RUN_ID,
-      maintenanceRunId: null,
-      labwareInfo: MOCK_LABWARE_INFO,
-    })
-
-    expect(mockDispatch).not.toHaveBeenCalled()
-  })
-
   it('should not dispatch if the robot is not a flex', () => {
     renderHook(() =>
       useUpdateLabware(false, RUN_ID, MAINTENANCE_RUN_ID, MOCK_LABWARE_INFO)

--- a/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useUpdateLabware.ts
+++ b/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useUpdateLabware.ts
@@ -19,5 +19,5 @@ export function useUpdateLabware(
     if (runId != null && maintenanceRunId == null && isFlex) {
       dispatch(updateLPCLabware(runId, labwareInfo.labware))
     }
-  }, [labwareInfo, maintenanceRunId, isFlex])
+  }, [labwareInfo, maintenanceRunId, isFlex, runId])
 }

--- a/app/src/organisms/LabwarePositionCheck/LPCFlows/useLPCFlows.ts
+++ b/app/src/organisms/LabwarePositionCheck/LPCFlows/useLPCFlows.ts
@@ -32,6 +32,8 @@ import type {
   LPCFlowsProps,
 } from '/app/organisms/LabwarePositionCheck/LPCFlows/LPCFlows'
 
+const RUN_RECORD_INTERVAL_MS = 1000 * 5
+
 interface UseLPCFlowsBase {
   showLPC: boolean
   lpcProps: LPCFlowsProps | null
@@ -72,7 +74,9 @@ export function useLPCFlows({
 
   const isFlex = robotType === FLEX_ROBOT_TYPE
   const deckConfig = useNotifyDeckConfigurationQuery().data
-  const { data: runRecord } = useNotifyRunQuery(runId ?? null)
+  const { data: runRecord } = useNotifyRunQuery(runId ?? null, {
+    refetchInterval: RUN_RECORD_INTERVAL_MS,
+  })
   const mostRecentAnalysis = useMostRecentCompletedAnalysis(runId)
   const compatibleFlexAnalysis = useCompatibleAnalysis(
     runId,

--- a/app/src/pages/ODD/ProtocolSetup/index.tsx
+++ b/app/src/pages/ODD/ProtocolSetup/index.tsx
@@ -130,7 +130,7 @@ interface PrepareToRunProps {
   robotName: string
   runRecord: Run | null
   labwareConfirmed: boolean
-  isRequiredOffsetMissing: boolean
+  offsetsConfirmed: boolean
   isLPCInitializing: boolean
 }
 
@@ -143,9 +143,9 @@ function PrepareToRun({
   robotName,
   runRecord,
   labwareConfirmed,
-  isRequiredOffsetMissing,
   isLPCInitializing,
   confirmStepsComplete,
+  offsetsConfirmed,
 }: PrepareToRunProps): JSX.Element {
   const { t, i18n } = useTranslation(['protocol_setup', 'shared'])
   const navigate = useNavigate()
@@ -348,11 +348,15 @@ function PrepareToRun({
       ? 'ready'
       : 'not ready'
 
+  const isAnyNecessaryDefaultOffsetMissing = useSelector(
+    selectIsAnyNecessaryDefaultOffsetMissing(runId)
+  )
+
   const isReadyToRun =
     incompleteInstrumentCount === 0 &&
     areModulesReady &&
     areFixturesReady &&
-    !isRequiredOffsetMissing
+    !isAnyNecessaryDefaultOffsetMissing
   const onPlay = (): void => {
     if (doorStatus.isDoorOpen) {
       if (
@@ -506,9 +510,6 @@ function PrepareToRun({
   const numMissingLSOffsets = useSelector(
     selectCountMissingLSOffsetsWithoutDefault(runId)
   )
-  const isAnyNecessaryDefaultOffsetMissing = useSelector(
-    selectIsAnyNecessaryDefaultOffsetMissing(runId)
-  )
 
   const lpcSetupStepProps = (): Pick<
     ProtocolSetupStepProps,
@@ -520,7 +521,7 @@ function PrepareToRun({
         status: 'ready',
         interactionDisabled: true,
       }
-    } else if (isRequiredOffsetMissing) {
+    } else if (offsetsConfirmed) {
       return {
         detail: t('num_offsets_applied', { num: totalOffsets }),
         status: 'ready',
@@ -816,9 +817,6 @@ export function ProtocolSetup(): JSX.Element {
   )
   // TODO(jh 10-31-24): Refactor the below to utilize useMissingStepsModal.
   const [labwareConfirmed, setLabwareConfirmed] = useState<boolean>(false)
-  const isRequiredOffsetMissing = useSelector(
-    selectIsAnyNecessaryDefaultOffsetMissing(runId)
-  )
   const missingSteps = [
     !labwareConfirmed ? t('labware_placement') : null,
     !offsetsConfirmed ? t('applied_labware_offsets') : null,
@@ -850,8 +848,8 @@ export function ProtocolSetup(): JSX.Element {
         robotName={robotName}
         runRecord={runRecord ?? null}
         labwareConfirmed={labwareConfirmed}
-        isRequiredOffsetMissing={isRequiredOffsetMissing}
         isLPCInitializing={lpcLaunchProps.isFlexLPCInitializing}
+        offsetsConfirmed={offsetsConfirmed}
       />
     ),
     instruments: (


### PR DESCRIPTION
Closes [RABR-804](https://opentrons.atlassian.net/browse/RABR-804), [RQA-4438](https://opentrons.atlassian.net/browse/RQA-4438), and [RQA-4430](https://opentrons.atlassian.net/browse/RQA-4430)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Whoops,  in https://github.com/Opentrons/opentrons/pull/18867, we updated the way run setup offset application works, and for no real reason, we swapped the conditional logic for determining which offset copy/color to show on the LPC label on the ODD. To fix, we just revert this change. Doing so brings the logic in-line with the desktop logic.

Some cleanup in a `useEffect` and protocol setup is included (48fda694698da357b37028a2947964417ce46a2b and some of c995b84b66d0efaff987b67f7bb2c0f8c6824246), but the actual change is just L523 of `ProtocolSetup/index.tsx`.

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- Verified correct label colors/copy displays given various labware offset states.
- Verified the behavior introduced in https://github.com/Opentrons/opentrons/pull/18867 still works as expected.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
very low, just copy
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RABR-804]: https://opentrons.atlassian.net/browse/RABR-804?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RQA-4438]: https://opentrons.atlassian.net/browse/RQA-4438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RQA-4430]: https://opentrons.atlassian.net/browse/RQA-4430?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ