### PR TITLE
feat(robot-server): Support labware offset notifications

### DIFF
--- a/robot-server/robot_server/service/notifications/publishers/runs_publisher.py
+++ b/robot-server/robot_server/service/notifications/publishers/runs_publisher.py
@@ -31,6 +31,7 @@ class _EngineStateSlice:
     current_command: Optional[CommandPointer] = None
     recovery_target_command: Optional[CommandPointer] = None
     state_summary_status: Optional[EngineStatus] = None
+    state_summary_labware_offset_count: Optional[int] = None
 
 
 class RunsPublisher:
@@ -152,13 +153,23 @@ class RunsPublisher:
                 self._run_hooks.run_id
             )
 
-            if (
-                new_state_summary is not None
-                and self._engine_state_slice.state_summary_status
-                != new_state_summary.status
-            ):
-                self.publish_runs_advise_refetch(run_id=self._run_hooks.run_id)
-                self._engine_state_slice.state_summary_status = new_state_summary.status
+            if new_state_summary is not None:
+                if (
+                    self._engine_state_slice.state_summary_status
+                    != new_state_summary.status
+                ):
+                    self.publish_runs_advise_refetch(run_id=self._run_hooks.run_id)
+                    self._engine_state_slice.state_summary_status = (
+                        new_state_summary.status
+                    )
+
+                elif self._engine_state_slice.state_summary_labware_offset_count != len(
+                    new_state_summary.labwareOffsets
+                ):
+                    self.publish_runs_advise_refetch(run_id=self._run_hooks.run_id)
+                    self._engine_state_slice.state_summary_labware_offset_count = len(
+                        new_state_summary.labwareOffsets
+                    )
 
 
 _runs_publisher_accessor: AppStateAccessor[RunsPublisher] = AppStateAccessor[

--- a/robot-server/robot_server/service/notifications/publishers/runs_publisher.py
+++ b/robot-server/robot_server/service/notifications/publishers/runs_publisher.py
@@ -50,7 +50,7 @@ class RunsPublisher:
             [
                 self._handle_current_command_change,
                 self._handle_recovery_target_command_change,
-                self._handle_engine_status_change,
+                self._handle_relevant_engine_change,
             ]
         )
 
@@ -146,8 +146,8 @@ class RunsPublisher:
                     new_recovery_target_command
                 )
 
-    async def _handle_engine_status_change(self) -> None:
-        """Publish a refetch flag if the engine status has changed."""
+    async def _handle_relevant_engine_change(self) -> None:
+        """Publish a refetch flag if relevant engine changes occur."""
         if self._run_hooks is not None and self._engine_state_slice is not None:
             new_state_summary = self._run_hooks.get_state_summary(
                 self._run_hooks.run_id

--- a/robot-server/tests/service/notifications/publishers/test_runs_publisher.py
+++ b/robot-server/tests/service/notifications/publishers/test_runs_publisher.py
@@ -172,10 +172,10 @@ async def test_handle_recovery_target_command_change(
     )
 
 
-async def test_handle_engine_status_change(
+async def test_handle_relevant_engine_change(
     runs_publisher: RunsPublisher, notification_client: Mock
 ) -> None:
-    """It should handle engine status changes appropriately."""
+    """It should handle relevant engine changes appropriately."""
     runs_publisher.start_publishing_for_run(
         run_id="1234",
         get_current_command=lambda _: make_command_pointer("command1"),
@@ -195,7 +195,7 @@ async def test_handle_engine_status_change(
     runs_publisher._engine_state_slice.state_summary_status = EngineStatus.IDLE
     runs_publisher._engine_state_slice.state_summary_labware_offset_count = 0
 
-    await runs_publisher._handle_engine_status_change()
+    await runs_publisher._handle_relevant_engine_change()
 
     assert notification_client.publish_advise_refetch.call_count == 2
 
@@ -203,7 +203,7 @@ async def test_handle_engine_status_change(
         status=EngineStatus.RUNNING, labwareOffsets=[]
     )
 
-    await runs_publisher._handle_engine_status_change()
+    await runs_publisher._handle_relevant_engine_change()
 
     notification_client.publish_advise_refetch.assert_any_call(topic=topics.RUNS)
     notification_client.publish_advise_refetch.assert_any_call(
@@ -235,7 +235,7 @@ async def test_handle_labware_offset_count_change(
     runs_publisher._engine_state_slice.state_summary_status = EngineStatus.IDLE
     runs_publisher._engine_state_slice.state_summary_labware_offset_count = 2
 
-    await runs_publisher._handle_engine_status_change()
+    await runs_publisher._handle_relevant_engine_change()
     assert notification_client.publish_advise_refetch.call_count == 2
 
     new_offsets = ["offset1", "offset2", "offset3"]
@@ -243,7 +243,7 @@ async def test_handle_labware_offset_count_change(
         status=EngineStatus.IDLE, labwareOffsets=new_offsets
     )
 
-    await runs_publisher._handle_engine_status_change()
+    await runs_publisher._handle_relevant_engine_change()
 
     notification_client.publish_advise_refetch.assert_any_call(topic=topics.RUNS)
     notification_client.publish_advise_refetch.assert_any_call(

--- a/robot-server/tests/service/notifications/publishers/test_runs_publisher.py
+++ b/robot-server/tests/service/notifications/publishers/test_runs_publisher.py
@@ -69,6 +69,7 @@ async def test_initialize(
     assert runs_publisher._engine_state_slice.current_command is None
     assert runs_publisher._engine_state_slice.recovery_target_command is None
     assert runs_publisher._engine_state_slice.state_summary_status is None
+    assert runs_publisher._engine_state_slice.state_summary_labware_offset_count is None
 
     notification_client.publish_advise_refetch.assert_any_call(topic=topics.RUNS)
     notification_client.publish_advise_refetch.assert_any_call(
@@ -189,16 +190,17 @@ async def test_handle_engine_status_change(
 
     runs_publisher._run_hooks.run_id = "1234"
     runs_publisher._run_hooks.get_state_summary = MagicMock(
-        return_value=MagicMock(status=EngineStatus.IDLE)
+        return_value=MagicMock(status=EngineStatus.IDLE, labwareOffsets=[])
     )
     runs_publisher._engine_state_slice.state_summary_status = EngineStatus.IDLE
+    runs_publisher._engine_state_slice.state_summary_labware_offset_count = 0
 
     await runs_publisher._handle_engine_status_change()
 
     assert notification_client.publish_advise_refetch.call_count == 2
 
     runs_publisher._run_hooks.get_state_summary.return_value = MagicMock(
-        status=EngineStatus.RUNNING
+        status=EngineStatus.RUNNING, labwareOffsets=[]
     )
 
     await runs_publisher._handle_engine_status_change()
@@ -207,6 +209,47 @@ async def test_handle_engine_status_change(
     notification_client.publish_advise_refetch.assert_any_call(
         topic=f"{topics.RUNS}/1234"
     )
+
+
+async def test_handle_labware_offset_count_change(
+    runs_publisher: RunsPublisher, notification_client: Mock
+) -> None:
+    """It should handle labware offset count changes appropriately."""
+    runs_publisher.start_publishing_for_run(
+        run_id="1234",
+        get_current_command=lambda _: make_command_pointer("command1"),
+        get_recovery_target_command=AsyncMock(),
+        get_state_summary=AsyncMock(),
+    )
+
+    # todo(mm, 2024-05-21): We should test through the public interface of the subject,
+    # not through its private attributes.
+    assert runs_publisher._run_hooks
+    assert runs_publisher._engine_state_slice
+
+    initial_offsets = ["offset1", "offset2"]
+    runs_publisher._run_hooks.run_id = "1234"
+    runs_publisher._run_hooks.get_state_summary = MagicMock(
+        return_value=MagicMock(status=EngineStatus.IDLE, labwareOffsets=initial_offsets)
+    )
+    runs_publisher._engine_state_slice.state_summary_status = EngineStatus.IDLE
+    runs_publisher._engine_state_slice.state_summary_labware_offset_count = 2
+
+    await runs_publisher._handle_engine_status_change()
+    assert notification_client.publish_advise_refetch.call_count == 2
+
+    new_offsets = ["offset1", "offset2", "offset3"]
+    runs_publisher._run_hooks.get_state_summary.return_value = MagicMock(
+        status=EngineStatus.IDLE, labwareOffsets=new_offsets
+    )
+
+    await runs_publisher._handle_engine_status_change()
+
+    notification_client.publish_advise_refetch.assert_any_call(topic=topics.RUNS)
+    notification_client.publish_advise_refetch.assert_any_call(
+        topic=f"{topics.RUNS}/1234"
+    )
+    assert runs_publisher._engine_state_slice.state_summary_labware_offset_count == 3
 
 
 async def test_publish_pre_serialized_commannds_notif(


### PR DESCRIPTION
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

The notify callbacks we pass to protocol engine are intentionally very slim for performance reasons. Currently, we support notifications whenever the status of the run changes, but if offsets change (when a user applies offsets, which grows the labware offset count), we don't publish a notification. Let's add support for that behavior.
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- Verified via Postman that publish events now occur whenever offsets are applied to a run.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
