### PR TITLE
feat(protocol-designer): add logic for lid move compatibility

### DIFF
--- a/protocol-designer/src/file-data/selectors/commands.ts
+++ b/protocol-designer/src/file-data/selectors/commands.ts
@@ -83,9 +83,9 @@ export const getInitialRobotState: (
           )
         return {
           stack,
-          // set touchedPipettableLabware to TOUCHED_PIPETTABLE_LABWARE if the labware is a lid and the parent is pipettable labware
+          // set sterility to TOUCHED_PIPETTABLE_LABWARE if the labware is a lid and the parent is pipettable labware
           ...(isLid && isParentPipettableLabware
-            ? { touchedPipettableLabware: TOUCHED_PIPETTABLE_LABWARE }
+            ? { sterility: TOUCHED_PIPETTABLE_LABWARE }
             : {}),
         }
       }

--- a/protocol-designer/src/file-data/selectors/commands.ts
+++ b/protocol-designer/src/file-data/selectors/commands.ts
@@ -6,7 +6,10 @@ import { createSelector } from 'reselect'
 
 import { getIsLid, getIsPipettableLabware } from '@opentrons/shared-data'
 import * as StepGeneration from '@opentrons/step-generation'
-import { getNearestParentInStack } from '@opentrons/step-generation'
+import {
+  getNearestParentInStack,
+  TOUCHED_PIPETTABLE_LABWARE,
+} from '@opentrons/step-generation'
 
 import { selectors as labwareIngredSelectors } from '../../labware-ingred/selectors'
 import { selectors as stepFormSelectors } from '../../step-forms'
@@ -80,8 +83,10 @@ export const getInitialRobotState: (
           )
         return {
           stack,
-          // set isUsedLid to true if the labware is a lid and the parent is pipettable labware
-          ...(isLid && isParentPipettableLabware ? { isUsedLid: true } : {}),
+          // set touchedPipettableLabware to TOUCHED_PIPETTABLE_LABWARE if the labware is a lid and the parent is pipettable labware
+          ...(isLid && isParentPipettableLabware
+            ? { touchedPipettableLabware: TOUCHED_PIPETTABLE_LABWARE }
+            : {}),
         }
       }
     )

--- a/protocol-designer/src/file-data/selectors/commands.ts
+++ b/protocol-designer/src/file-data/selectors/commands.ts
@@ -70,7 +70,7 @@ export const getInitialRobotState: (
       initialDeckSetup.labware,
       ({ id, stack }): LabwareTemporalProperties => {
         const labwareEntity = invariantContext.labwareEntities[id]
-        const isLid = getIsLid(labwareEntity?.def)
+        const isLid = getIsLid(labwareEntity.def)
         const nearestParent = getNearestParentInStack(stack)
         const isParentPipettableLabware =
           nearestParent != null &&
@@ -80,7 +80,8 @@ export const getInitialRobotState: (
           )
         return {
           stack,
-          ...(isLid && isParentPipettableLabware ? { isUsed: true } : {}),
+          // set isUsedLid to true if the labware is a lid and the parent is pipettable labware
+          ...(isLid && isParentPipettableLabware ? { isUsedLid: true } : {}),
         }
       }
     )

--- a/protocol-designer/src/file-data/selectors/commands.ts
+++ b/protocol-designer/src/file-data/selectors/commands.ts
@@ -4,14 +4,15 @@ import omit from 'lodash/omit'
 import uniqBy from 'lodash/uniqBy'
 import { createSelector } from 'reselect'
 
+import { getIsLid, getIsPipettableLabware } from '@opentrons/shared-data'
 import * as StepGeneration from '@opentrons/step-generation'
+import { getNearestParentInStack } from '@opentrons/step-generation'
 
 import { selectors as labwareIngredSelectors } from '../../labware-ingred/selectors'
 import { selectors as stepFormSelectors } from '../../step-forms'
 
 import type { StepIdType } from '../../form-types'
 import type {
-  LabwareOnDeck,
   LabwareTemporalProperties,
   ModuleOnDeck,
   ModuleTemporalProperties,
@@ -67,9 +68,21 @@ export const getInitialRobotState: (
     )
     const labware: Record<string, LabwareTemporalProperties> = mapValues(
       initialDeckSetup.labware,
-      (l: LabwareOnDeck): LabwareTemporalProperties => ({
-        stack: l.stack,
-      })
+      ({ id, stack }): LabwareTemporalProperties => {
+        const labwareEntity = invariantContext.labwareEntities[id]
+        const isLid = getIsLid(labwareEntity?.def)
+        const nearestParent = getNearestParentInStack(stack)
+        const isParentPipettableLabware =
+          nearestParent != null &&
+          nearestParent in invariantContext.labwareEntities &&
+          getIsPipettableLabware(
+            invariantContext.labwareEntities[nearestParent].def
+          )
+        return {
+          stack,
+          ...(isLid && isParentPipettableLabware ? { isUsed: true } : {}),
+        }
+      }
     )
     const modules: Record<string, ModuleTemporalProperties> = mapValues(
       initialDeckSetup.modules,

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLabwareTools/LabwareLocationField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLabwareTools/LabwareLocationField.tsx
@@ -1,12 +1,11 @@
 import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 
-import { WASTE_CHUTE_CUTOUT } from '@opentrons/shared-data'
 import { getSlotInLocationStack } from '@opentrons/step-generation'
 
 import { DropdownStepFormField } from '../../../../../../components/molecules'
 import { getEnableStacking } from '../../../../../../feature-flags/selectors'
-import { getAdditionalEquipmentEntities } from '../../../../../../step-forms/selectors'
+import { getLabwareEntities } from '../../../../../../step-forms/selectors'
 import {
   getDeckSetupForActiveItem,
   getRobotStateAtActiveItem,
@@ -29,15 +28,19 @@ export function LabwareLocationField(
   const { t } = useTranslation(['form', 'protocol_steps'])
   const { labware, useGripper } = props
   const enableStacking = useSelector(getEnableStacking)
-  const additionalEquipmentEntities = useSelector(
-    getAdditionalEquipmentEntities
-  )
   const { labware: deckSetupLabware } = useSelector(getDeckSetupForActiveItem)
   const dispatch = useDispatch()
+  const labwareEntities = useSelector(getLabwareEntities)
   const robotState = useSelector(getRobotStateAtActiveItem)
   const unoccupiedLabwareStackOptions: Option[] =
     robotState && enableStacking
-      ? getUnoccupiedStackOptions(robotState, deckSetupLabware, labware, t)
+      ? getUnoccupiedStackOptions({
+          robotState,
+          deckSetupLabware,
+          labwareIdFromDropdown: labware,
+          labwareEntities,
+          t,
+        })
       : []
   const isLabwareOffDeck =
     labware != null
@@ -48,26 +51,13 @@ export function LabwareLocationField(
   const unoccupiedLabwareLocationsOptionsSelector =
     useSelector(getUnoccupiedLabwareLocationOptions) ?? []
 
-  let unoccupiedLabwareLocationsOptions = [
+  const unoccupiedLabwareLocationsOptions = [
     ...unoccupiedLabwareStackOptions,
     ...unoccupiedLabwareLocationsOptionsSelector,
-  ]
-  if (useGripper || isLabwareOffDeck) {
-    unoccupiedLabwareLocationsOptions = unoccupiedLabwareLocationsOptions.filter(
-      option => option.value !== 'offDeck'
-    )
-  }
-
-  if (
-    !useGripper &&
-    Object.values(additionalEquipmentEntities).find(
-      ae => ae.name === 'wasteChute'
-    ) != null
-  ) {
-    unoccupiedLabwareLocationsOptions = unoccupiedLabwareLocationsOptions.filter(
-      option => option.value !== WASTE_CHUTE_CUTOUT
-    )
-  }
+  ].filter(option => {
+    const canMoveOffDeck = !(useGripper || isLabwareOffDeck)
+    return option.value !== 'offDeck' || canMoveOffDeck
+  })
 
   return (
     <DropdownStepFormField

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLabwareTools/LabwareLocationField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLabwareTools/LabwareLocationField.tsx
@@ -51,6 +51,7 @@ export function LabwareLocationField(
   const unoccupiedLabwareLocationsOptionsSelector =
     useSelector(getUnoccupiedLabwareLocationOptions) ?? []
 
+  // invalid offDeck move filter
   const unoccupiedLabwareLocationsOptions = [
     ...unoccupiedLabwareStackOptions,
     ...unoccupiedLabwareLocationsOptionsSelector,

--- a/protocol-designer/src/pages/Designer/__tests__/utils.test.ts
+++ b/protocol-designer/src/pages/Designer/__tests__/utils.test.ts
@@ -290,7 +290,13 @@ describe('getUnoccupiedStackOptions', () => {
       labId3: mockLabOnStagingArea,
     }
     expect(
-      getUnoccupiedStackOptions(mockRobotState, mockLabware, 'labId2', mockT)
+      getUnoccupiedStackOptions({
+        robotState: mockRobotState,
+        deckSetupLabware: mockLabware,
+        labwareIdFromDropdown: 'labId2',
+        labwareEntities: mockLabware,
+        t: mockT,
+      })
     ).toEqual([
       {
         name: 'Fixture Flex 96 Tip Rack Adapter',
@@ -304,7 +310,32 @@ describe('getUnoccupiedStackOptions', () => {
       labId: mockLabOnDeck1Flex,
     }
     expect(
-      getUnoccupiedStackOptions(mockRobotState, mockLabware, 'labId', mockT)
+      getUnoccupiedStackOptions({
+        robotState: mockRobotState,
+        deckSetupLabware: mockLabware,
+        labwareIdFromDropdown: 'labId',
+        labwareEntities: mockLabware,
+        t: mockT,
+      })
+    ).toEqual([])
+  })
+
+  it('should filter out labware that was moved to a waste chute', () => {
+    const mockLabware: AllTemporalPropertiesForTimelineFrame['labware'] = {
+      labId: mockLabOnDeck1Flex,
+      labId2: {
+        ...mockLabOnDeck2Flex,
+        stack: ['labId2', 'gripperWasteChute'],
+      },
+    }
+    expect(
+      getUnoccupiedStackOptions({
+        robotState: mockRobotState,
+        deckSetupLabware: mockLabware,
+        labwareIdFromDropdown: 'labId',
+        labwareEntities: mockLabware,
+        t: mockT,
+      })
     ).toEqual([])
   })
 })

--- a/protocol-designer/src/pages/Designer/utils.ts
+++ b/protocol-designer/src/pages/Designer/utils.ts
@@ -5,6 +5,7 @@ import { reduce } from 'lodash'
 import {
   FLEX_ROBOT_TYPE,
   getAllLabwareDefs,
+  getIsPipettableLabware,
   getIsTiprack,
   getPositionFromSlotId,
   TC_MODULE_LOCATION_OT2,
@@ -36,6 +37,7 @@ import type {
 import type {
   AdditionalEquipmentName,
   DeckSlot,
+  LabwareEntities,
   LabwareEntity,
   RobotState,
 } from '@opentrons/step-generation'
@@ -365,12 +367,20 @@ export const useLabwareDropdownOptions = (
 }
 
 //  used for LabwareLocationField dropdown
-export const getUnoccupiedStackOptions = (
-  robotState: RobotState,
-  deckSetupLabware: AllTemporalPropertiesForTimelineFrame['labware'],
-  labwareIdFromDropdown: string,
+export const getUnoccupiedStackOptions = (args: {
+  robotState: RobotState
+  deckSetupLabware: AllTemporalPropertiesForTimelineFrame['labware']
+  labwareIdFromDropdown: string
+  labwareEntities: LabwareEntities
   t: any
-): Option[] => {
+}): Option[] => {
+  const {
+    robotState,
+    deckSetupLabware,
+    labwareIdFromDropdown,
+    labwareEntities,
+    t,
+  } = args
   if (deckSetupLabware[labwareIdFromDropdown] == null) {
     return []
   }
@@ -393,23 +403,41 @@ export const getUnoccupiedStackOptions = (
         labwareIdFromDropdown
       )
 
-      if (isTopOfStack && isCompatible && isNotCurrentLabwareStack) {
+      const isUsedLid =
+        robotState?.labware[labwareIdFromDropdown]?.isUsedLid === true
+      const newLabwareEntity = labwareEntities[labwareId]
+      const isNewLabwarePipettable =
+        newLabwareEntity?.def != null &&
+        getIsPipettableLabware(newLabwareEntity.def)
+      const isSafeLidMove = !(isUsedLid && isNewLabwarePipettable)
+
+      const isInWasteChute = slot === 'gripperWasteChute'
+
+      if (
+        isTopOfStack &&
+        isCompatible &&
+        isNotCurrentLabwareStack &&
+        isSafeLidMove &&
+        !isInWasteChute
+      ) {
         const similarLabwareStackIds = getAllLabwareIdsOfCertainURIOnStack(
           deckSetupLabware,
           labwareOnDeck
         )
-        acc.push({
-          name:
-            similarLabwareStackIds.length > 1
-              ? t('protocol_steps:unoccupied_stack', {
-                  name: displayName,
-                })
-              : displayName,
-          value: labwareId,
-          deckLabel: slot,
-        })
+        return [
+          ...acc,
+          {
+            name:
+              similarLabwareStackIds.length > 1
+                ? t('protocol_steps:unoccupied_stack', {
+                    name: displayName,
+                  })
+                : displayName,
+            value: labwareId,
+            deckLabel: slot,
+          },
+        ]
       }
-
       return acc
     },
     []

--- a/protocol-designer/src/pages/Designer/utils.ts
+++ b/protocol-designer/src/pages/Designer/utils.ts
@@ -403,8 +403,7 @@ export const getUnoccupiedStackOptions = (args: {
         labwareIdFromDropdown
       )
 
-      const isUsedLid =
-        robotState?.labware[labwareIdFromDropdown]?.isUsedLid === true
+      const isUsedLid = temporalLabwareOnDeck.isUsedLid === true
       const newLabwareEntity = labwareEntities[labwareId]
       const isNewLabwarePipettable =
         newLabwareEntity?.def != null &&
@@ -417,8 +416,8 @@ export const getUnoccupiedStackOptions = (args: {
         isTopOfStack &&
         isCompatible &&
         isNotCurrentLabwareStack &&
-        isSafeLidMove &&
-        !isInWasteChute
+        !isInWasteChute &&
+        isSafeLidMove
       ) {
         const similarLabwareStackIds = getAllLabwareIdsOfCertainURIOnStack(
           deckSetupLabware,

--- a/protocol-designer/src/pages/Designer/utils.ts
+++ b/protocol-designer/src/pages/Designer/utils.ts
@@ -393,7 +393,7 @@ export const getUnoccupiedStackOptions = (args: {
   const { labware: labwareState } = robotState
 
   const isLabwareToMoveUsedLid =
-    labwareState[labwareIdFromDropdown]?.touchedPipettableLabware ===
+    labwareState[labwareIdFromDropdown]?.sterility ===
     TOUCHED_PIPETTABLE_LABWARE
 
   return Object.entries(labwareState).reduce<Option[]>(

--- a/protocol-designer/src/pages/Designer/utils.ts
+++ b/protocol-designer/src/pages/Designer/utils.ts
@@ -16,6 +16,7 @@ import {
   getFullStackFromLabwares,
   getNearestParentInStack,
   getSlotInLocationStack,
+  TOUCHED_PIPETTABLE_LABWARE,
 } from '@opentrons/step-generation'
 
 import { getRobotType } from '../../file-data/selectors'
@@ -392,7 +393,8 @@ export const getUnoccupiedStackOptions = (args: {
   const { labware: labwareState } = robotState
 
   const isLabwareToMoveUsedLid =
-    labwareState[labwareIdFromDropdown]?.isUsedLid === true
+    labwareState[labwareIdFromDropdown]?.touchedPipettableLabware ===
+    TOUCHED_PIPETTABLE_LABWARE
 
   return Object.entries(labwareState).reduce<Option[]>(
     (acc, [labwareId, temporalLabwareOnDeck]) => {

--- a/protocol-designer/src/pages/Designer/utils.ts
+++ b/protocol-designer/src/pages/Designer/utils.ts
@@ -14,6 +14,7 @@ import {
 } from '@opentrons/shared-data'
 import {
   getFullStackFromLabwares,
+  getNearestParentInStack,
   getSlotInLocationStack,
 } from '@opentrons/step-generation'
 
@@ -388,10 +389,15 @@ export const getUnoccupiedStackOptions = (args: {
   const { def } = deckSetupLabware[labwareIdFromDropdown]
   const labwareCompatibleParentLabware = def.compatibleParentLabware
 
-  return Object.entries(robotState.labware).reduce<Option[]>(
+  const { labware: labwareState } = robotState
+
+  const isLabwareToMoveUsedLid =
+    labwareState[labwareIdFromDropdown]?.isUsedLid === true
+
+  return Object.entries(labwareState).reduce<Option[]>(
     (acc, [labwareId, temporalLabwareOnDeck]) => {
       const slot = getSlotInLocationStack(temporalLabwareOnDeck.stack)
-      const fullStack = getFullStackFromLabwares(robotState.labware, slot)
+      const fullStack = getFullStackFromLabwares(labwareState, slot)
       const labwareOnDeck = deckSetupLabware[labwareId]
       const isTopOfStack = fullStack[0] === labwareId
       const { def: labwareOnDeckDef } = labwareOnDeck
@@ -403,12 +409,17 @@ export const getUnoccupiedStackOptions = (args: {
         labwareIdFromDropdown
       )
 
-      const isUsedLid = temporalLabwareOnDeck.isUsedLid === true
-      const newLabwareEntity = labwareEntities[labwareId]
+      const nearestParentInStack = getNearestParentInStack(fullStack)
+      const isNearestParentPipettableLabware =
+        nearestParentInStack != null &&
+        labwareEntities[nearestParentInStack] != null &&
+        getIsPipettableLabware(labwareEntities[nearestParentInStack].def)
+
       const isNewLabwarePipettable =
-        newLabwareEntity?.def != null &&
-        getIsPipettableLabware(newLabwareEntity.def)
-      const isSafeLidMove = !(isUsedLid && isNewLabwarePipettable)
+        labwareOnDeckDef != null && getIsPipettableLabware(labwareOnDeckDef)
+      const isSafeLidMove =
+        !(isLabwareToMoveUsedLid && isNewLabwarePipettable) &&
+        !isNearestParentPipettableLabware
 
       const isInWasteChute = slot === 'gripperWasteChute'
 

--- a/protocol-designer/src/step-forms/types.ts
+++ b/protocol-designer/src/step-forms/types.ts
@@ -108,7 +108,7 @@ export type NormalizedLabware = NormalizedLabwareById[keyof NormalizedLabwareByI
 // Temporal properties (eg location) that are time-variant
 export interface LabwareTemporalProperties {
   stack: string[] // a stack of ids from top to bottom
-  touchedPipettableLabware?: typeof TOUCHED_PIPETTABLE_LABWARE
+  sterility?: typeof TOUCHED_PIPETTABLE_LABWARE
 }
 export interface PipetteTemporalProperties {
   mount: Mount

--- a/protocol-designer/src/step-forms/types.ts
+++ b/protocol-designer/src/step-forms/types.ts
@@ -18,6 +18,7 @@ import type {
   ModuleEntity,
   PipetteEntity,
   TemperatureStatus,
+  TOUCHED_PIPETTABLE_LABWARE,
 } from '@opentrons/step-generation'
 import type { DeckSlot } from '../types'
 
@@ -107,7 +108,7 @@ export type NormalizedLabware = NormalizedLabwareById[keyof NormalizedLabwareByI
 // Temporal properties (eg location) that are time-variant
 export interface LabwareTemporalProperties {
   stack: string[] // a stack of ids from top to bottom
-  isUsedLid?: boolean
+  touchedPipettableLabware?: typeof TOUCHED_PIPETTABLE_LABWARE
 }
 export interface PipetteTemporalProperties {
   mount: Mount

--- a/protocol-designer/src/step-forms/types.ts
+++ b/protocol-designer/src/step-forms/types.ts
@@ -107,6 +107,7 @@ export type NormalizedLabware = NormalizedLabwareById[keyof NormalizedLabwareByI
 // Temporal properties (eg location) that are time-variant
 export interface LabwareTemporalProperties {
   stack: string[] // a stack of ids from top to bottom
+  isUsedLid?: boolean
 }
 export interface PipetteTemporalProperties {
   mount: Mount

--- a/protocol-designer/src/step-forms/types.ts
+++ b/protocol-designer/src/step-forms/types.ts
@@ -108,6 +108,8 @@ export type NormalizedLabware = NormalizedLabwareById[keyof NormalizedLabwareByI
 // Temporal properties (eg location) that are time-variant
 export interface LabwareTemporalProperties {
   stack: string[] // a stack of ids from top to bottom
+  // we currently use this property only to track if a lid has been placed on a "pipettable" labware that could presumably contain liquid
+  // we can expand this type in the future to track other types of sterility for various labware types
   sterility?: typeof TOUCHED_PIPETTABLE_LABWARE
 }
 export interface PipetteTemporalProperties {

--- a/protocol-designer/src/top-selectors/labware-locations/index.ts
+++ b/protocol-designer/src/top-selectors/labware-locations/index.ts
@@ -269,24 +269,23 @@ export const getUnoccupiedLabwareLocationOptions: Selector<
       )
     )
 
-    const unoccupiedSlotOptions = allSlotIds
-      .filter(slotId => {
-        const isTrashSlot =
-          robotType === FLEX_ROBOT_TYPE
-            ? MOVABLE_TRASH_ADDRESSABLE_AREAS.includes(slotId)
-            : ['fixedTrash', '12'].includes(slotId)
-        return (
-          !slotIdsOccupiedByModules.includes(slotId) &&
-          !Object.values(labware).some(lw => lw.stack.includes(slotId)) &&
-          !isTrashSlot &&
-          !trashCutouts.some(cutout => cutout.includes(slotId)) &&
-          !WASTE_CHUTE_ADDRESSABLE_AREAS.includes(slotId) &&
-          !notSelectedStagingAreaAddressableAreas.includes(slotId) &&
-          !FLEX_MODULE_ADDRESSABLE_AREAS.includes(slotId) &&
-          !FLEX_STACKER_ADDRESSABLE_AREAS.includes(slotId)
-        )
-      })
-      .map(slotId => ({ name: slotId, value: slotId, deckLabel: slotId }))
+    const unoccupiedSlotOptions = allSlotIds.reduce<Option[]>((acc, slotId) => {
+      const isTrashSlot =
+        robotType === FLEX_ROBOT_TYPE
+          ? MOVABLE_TRASH_ADDRESSABLE_AREAS.includes(slotId)
+          : ['fixedTrash', '12'].includes(slotId)
+      return !slotIdsOccupiedByModules.includes(slotId) &&
+        !Object.values(labware).some(lw => lw.stack.includes(slotId)) &&
+        !isTrashSlot &&
+        !trashCutouts.some(cutout => cutout.includes(slotId)) &&
+        !WASTE_CHUTE_ADDRESSABLE_AREAS.includes(slotId) &&
+        !notSelectedStagingAreaAddressableAreas.includes(slotId) &&
+        !FLEX_MODULE_ADDRESSABLE_AREAS.includes(slotId) &&
+        !FLEX_STACKER_ADDRESSABLE_AREAS.includes(slotId)
+        ? [...acc, { name: slotId, value: slotId, deckLabel: slotId }]
+        : acc
+    }, [])
+
     const offDeck = {
       name: 'Off-deck',
       value: OFFDECK,
@@ -298,20 +297,13 @@ export const getUnoccupiedLabwareLocationOptions: Selector<
       deckLabel: 'D3',
     }
 
-    return hasWasteChute
-      ? [
-          wasteChuteSlot,
-          ...unoccupiedAdapterOptions,
-          ...unoccupiedModuleOptions,
-          ...unoccupiedSlotOptions,
-          offDeck,
-        ]
-      : [
-          ...unoccupiedAdapterOptions,
-          ...unoccupiedModuleOptions,
-          ...unoccupiedSlotOptions,
-          offDeck,
-        ]
+    return [
+      ...(hasWasteChute ? [wasteChuteSlot] : []),
+      ...unoccupiedAdapterOptions,
+      ...unoccupiedModuleOptions,
+      ...unoccupiedSlotOptions,
+      offDeck,
+    ]
   }
 )
 

--- a/shared-data/js/getLabware.ts
+++ b/shared-data/js/getLabware.ts
@@ -183,6 +183,8 @@ export const getIsPipettableLabware = (
   if (labwareDef.allowedRoles == null) {
     return true
   }
-  const allowedRolesSet = new Set(labwareDef.allowedRoles)
-  return allowedRolesSet.has('labware') && !allowedRolesSet.has('lid')
+  return (
+    labwareDef.allowedRoles.includes('labware') &&
+    !labwareDef.allowedRoles.includes('lid')
+  )
 }

--- a/shared-data/js/getLabware.ts
+++ b/shared-data/js/getLabware.ts
@@ -171,5 +171,18 @@ export function getWellPropsForSVGLabwareV1(
   }))
 }
 
+// determines if the labware is a lid
 export const getIsLid = (labwareDef: LabwareDefinition): boolean =>
   labwareDef.allowedRoles?.includes('lid') ?? false
+
+// determines if the labware can be a target for pipetting
+export const getIsPipettableLabware = (
+  labwareDef: LabwareDefinition
+): boolean => {
+  // assume the labware can be a pipetting target if labware definition's `allowedRoles` is undefined
+  if (labwareDef.allowedRoles == null) {
+    return true
+  }
+  const allowedRolesSet = new Set(labwareDef.allowedRoles)
+  return allowedRolesSet.has('labware') && !allowedRolesSet.has('lid')
+}

--- a/shared-data/js/helpers/__tests__/getIsLid.test.ts
+++ b/shared-data/js/helpers/__tests__/getIsLid.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+
+import { fixture_96_plate as _fixture96Plate } from '../../../labware/fixtures/2'
+import { getIsLid } from '../../getLabware'
+
+import type { LabwareDefinition } from '../../types'
+
+const fixture96Plate = _fixture96Plate as LabwareDefinition
+
+describe('getIsLid', () => {
+  let props: { labwareDef: LabwareDefinition }
+
+  it('should return false if the labware does not specify allowedRoles property', () => {
+    props = {
+      labwareDef: fixture96Plate,
+    }
+    const result = getIsLid(props.labwareDef)
+    expect(result).toBe(false)
+  })
+
+  it('should return true if the labware specifies allowedRoles property with "lid" role', () => {
+    props = {
+      labwareDef: { ...fixture96Plate, allowedRoles: ['lid'] },
+    }
+    const result = getIsLid(props.labwareDef)
+    expect(result).toBe(true)
+  })
+
+  it('should return false if the labware specifies allowedRoles property without "lid" role', () => {
+    props = {
+      labwareDef: { ...fixture96Plate, allowedRoles: ['labware'] },
+    }
+    const result = getIsLid(props.labwareDef)
+    expect(result).toBe(false)
+  })
+})

--- a/shared-data/js/helpers/__tests__/getIsPipettableLabware.test.ts
+++ b/shared-data/js/helpers/__tests__/getIsPipettableLabware.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+
+import { fixture_96_plate as _fixture96Plate } from '../../../labware/fixtures/2'
+import { getIsPipettableLabware } from '../../getLabware'
+
+import type { LabwareDefinition } from '../../types'
+
+const fixture96Plate = _fixture96Plate as LabwareDefinition
+
+describe('getIsPipettableLabware', () => {
+  let props: { labwareDef: LabwareDefinition }
+
+  it('should return true if the labware does not specify allowedRoles property', () => {
+    props = {
+      labwareDef: fixture96Plate,
+    }
+    const result = getIsPipettableLabware(props.labwareDef)
+    expect(result).toBe(true)
+  })
+
+  it('should return true if the labware specifies allowedRoles property with "labware" role only', () => {
+    props = {
+      labwareDef: { ...fixture96Plate, allowedRoles: ['labware'] },
+    }
+    const result = getIsPipettableLabware(props.labwareDef)
+    expect(result).toBe(true)
+  })
+
+  it('should return false if the labware specifies allowedRoles property without "labware" role', () => {
+    props = {
+      labwareDef: {
+        ...fixture96Plate,
+        allowedRoles: ['lid', 'adapter', 'fixture'],
+      },
+    }
+    const result = getIsPipettableLabware(props.labwareDef)
+    expect(result).toBe(false)
+  })
+
+  it('should return false if the labware specifies allowedRoles property with "labware" role and "lid" role', () => {
+    props = {
+      labwareDef: {
+        ...fixture96Plate,
+        allowedRoles: ['labware', 'lid'],
+      },
+    }
+    const result = getIsPipettableLabware(props.labwareDef)
+    expect(result).toBe(false)
+  })
+})

--- a/step-generation/src/getNextRobotStateAndWarnings/forMoveLabware.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/forMoveLabware.ts
@@ -64,7 +64,7 @@ export function forMoveLabware(
         ...robotState.labware[id],
         stack: [id, ...stackBelow, ...newLocationStack],
         ...(isLabwareToMoveLid && isParentPipettableLabware
-          ? { touchedPipettableLabware: TOUCHED_PIPETTABLE_LABWARE }
+          ? { sterility: TOUCHED_PIPETTABLE_LABWARE }
           : {}),
       }
     }

--- a/step-generation/src/getNextRobotStateAndWarnings/forMoveLabware.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/forMoveLabware.ts
@@ -1,3 +1,5 @@
+import { getIsLid, getIsPipettableLabware } from '@opentrons/shared-data'
+
 import { getFullStackFromLabwares, getSlotInLocationStack } from '../utils'
 
 import type { MoveLabwareParams } from '@opentrons/shared-data'
@@ -10,6 +12,7 @@ export function forMoveLabware(
 ): void {
   const { labwareId, newLocation } = params
   const { robotState } = robotStateAndWarnings
+  const { labwareEntities } = invariantContext
   const { modules, labware } = robotState
   const initialDeckSlot = getSlotInLocationStack(labware[labwareId].stack)
   const fullStackFromLabwares = getFullStackFromLabwares(
@@ -18,6 +21,9 @@ export function forMoveLabware(
   )
   const index = fullStackFromLabwares.indexOf(labwareId)
   const labwareToMove = fullStackFromLabwares.slice(0, index + 1) // includes labwareId you're moving
+
+  const isLabwareToMoveLid = getIsLid(labwareEntities[labwareId].def)
+  let isParentPipettableLabware: boolean = false
 
   const newLocationStack: string[] = []
   if (newLocation === 'offDeck' || newLocation === 'systemLocation') {
@@ -32,6 +38,9 @@ export function forMoveLabware(
     const { slotName } = newLocation
     // new location is a labware stack
     if (slotName in labware) {
+      isParentPipettableLabware = getIsPipettableLabware(
+        labwareEntities[slotName].def
+      )
       newLocationStack.push(...labware[slotName].stack)
     } else {
       // new location is a slot
@@ -39,6 +48,9 @@ export function forMoveLabware(
     }
   } else if ('labwareId' in newLocation) {
     const labwareId = newLocation.labwareId
+    isParentPipettableLabware = getIsPipettableLabware(
+      labwareEntities[labwareId].def
+    )
     const labwareIdStack = labware[labwareId].stack
     newLocationStack.push(...labwareIdStack)
   } else if ('addressableAreaName' in newLocation) {
@@ -47,7 +59,11 @@ export function forMoveLabware(
   labwareToMove.forEach((id, i) => {
     if (labware[id] != null) {
       const stackBelow = labwareToMove.slice(i + 1) // what's under labware you're moving
-      robotState.labware[id].stack = [id, ...stackBelow, ...newLocationStack]
+      robotState.labware[id] = {
+        ...robotState.labware[id],
+        stack: [id, ...stackBelow, ...newLocationStack],
+        isUsedLid: isLabwareToMoveLid && isParentPipettableLabware,
+      }
     }
   })
 }

--- a/step-generation/src/getNextRobotStateAndWarnings/forMoveLabware.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/forMoveLabware.ts
@@ -1,5 +1,6 @@
 import { getIsLid, getIsPipettableLabware } from '@opentrons/shared-data'
 
+import { TOUCHED_PIPETTABLE_LABWARE } from '../types'
 import { getFullStackFromLabwares, getSlotInLocationStack } from '../utils'
 
 import type { MoveLabwareParams } from '@opentrons/shared-data'
@@ -62,7 +63,9 @@ export function forMoveLabware(
       robotState.labware[id] = {
         ...robotState.labware[id],
         stack: [id, ...stackBelow, ...newLocationStack],
-        isUsedLid: isLabwareToMoveLid && isParentPipettableLabware,
+        ...(isLabwareToMoveLid && isParentPipettableLabware
+          ? { touchedPipettableLabware: TOUCHED_PIPETTABLE_LABWARE }
+          : {}),
       }
     }
   })

--- a/step-generation/src/types.ts
+++ b/step-generation/src/types.ts
@@ -35,7 +35,7 @@ export const TOUCHED_PIPETTABLE_LABWARE: 'TOUCHED_PIPETTABLE_LABWARE' =
 export interface LabwareTemporalProperties {
   // a stack of ids from top to bottom
   stack: string[]
-  touchedPipettableLabware?: typeof TOUCHED_PIPETTABLE_LABWARE
+  sterility?: typeof TOUCHED_PIPETTABLE_LABWARE
 }
 
 export interface PipetteTemporalProperties {

--- a/step-generation/src/types.ts
+++ b/step-generation/src/types.ts
@@ -30,7 +30,10 @@ export type DeckSlot = string
 type THERMOCYCLER_STATE = 'thermocyclerState'
 type THERMOCYCLER_PROFILE = 'thermocyclerProfile'
 export interface LabwareTemporalProperties {
-  stack: string[] // a stack of ids from top to bottom
+  // a stack of ids from top to bottom
+  stack: string[]
+  // isUsed is a boolean currently only used for lids that designates whether the lid was previously placed on a labware
+  isUsedLid?: boolean
 }
 
 export interface PipetteTemporalProperties {

--- a/step-generation/src/types.ts
+++ b/step-generation/src/types.ts
@@ -35,6 +35,8 @@ export const TOUCHED_PIPETTABLE_LABWARE: 'TOUCHED_PIPETTABLE_LABWARE' =
 export interface LabwareTemporalProperties {
   // a stack of ids from top to bottom
   stack: string[]
+  // we currently use this property only to track if a lid has been placed on a "pipettable" labware that could presumably contain liquid
+  // we can expand this type in the future to track other types of sterility for various labware types
   sterility?: typeof TOUCHED_PIPETTABLE_LABWARE
 }
 

--- a/step-generation/src/types.ts
+++ b/step-generation/src/types.ts
@@ -29,11 +29,13 @@ import type {
 export type DeckSlot = string
 type THERMOCYCLER_STATE = 'thermocyclerState'
 type THERMOCYCLER_PROFILE = 'thermocyclerProfile'
+
+export const TOUCHED_PIPETTABLE_LABWARE: 'TOUCHED_PIPETTABLE_LABWARE' =
+  'TOUCHED_PIPETTABLE_LABWARE'
 export interface LabwareTemporalProperties {
   // a stack of ids from top to bottom
   stack: string[]
-  // isUsed is a boolean currently only used for lids that designates whether the lid was previously placed on a labware
-  isUsedLid?: boolean
+  touchedPipettableLabware?: typeof TOUCHED_PIPETTABLE_LABWARE
 }
 
 export interface PipetteTemporalProperties {


### PR DESCRIPTION
# Overview

This PR extends functionality for moving lids around the deck according to product specs. As part of this work, I extend `LabwareTemporalProperties` in `step-generation` and `protocol-designer` to include a new optional property `sterility`. This property is updated if the lid is loaded on or moved to a "pipettable" labware, which could presumably contain liquid, at any point. We check this property's value when determining safe moves to labware stacks. If the lid has been used, we do not allow its further movement to a new pipettable labware for sterility concerns.

Closes AUTH-1071

## Test Plan and Hands on Testing

[test protocol ](https://github.com/user-attachments/files/21496323/lid_move_test.py.zip)
- create a protocol with a lid stack, a plate loaded with a lid, and 2 other plate loaded without a lid
- create a move labware step
- select the lid loaded on the plate as the labware
- open the new location dropdown and verify that the lid-less plates are _not_ options
- select the lid stack as the source labware
- open the new location dropdown and verify that the lid-less plates are options
- move select one of those plates and save
- create a new move labware step
- select the newly-moved lid on the plate as the source labware
- open the new location dropdown and verify that the remaining lid-less plate is _not_ an option

## Changelog

- extend `LabwareTemporalProperties` interfaces with new optional `sterility` property in PD/SG
- update `sterility` in `getInitialRobotState` for lids loaded on pipettable labware
- update `sterility` in `forMoveLabware` for lids moved to pipettable labware- update and refactor `LabwareLocationField` and `getUnoccupiedStackOptions` util for lid safety
- non-functional refactor in `protocol-designer/src/top-selectors/labware-locations/index.ts` 
- add new utilities for determining if a labware is a lid/if a labware is pipettable (and tests)

## Review requests

see test plan

## Risk assessment

pretty low. behind feature flag and should only add functionality/refine logic