### PR TITLE
fix(python): Do math on monotonic clocks only

### DIFF
--- a/abr-testing/abr_testing/tools/test_modules.py
+++ b/abr-testing/abr_testing/tools/test_modules.py
@@ -16,8 +16,8 @@ import traceback
 async def tc_test_1(module: str, path_to_file: str) -> None:
     """Thermocycler Test 1 Open and Close Lid."""
     duration = int(input("How long to run this test for? (in seconds): "))
-    start = time.time()
-    while time.time() - start < duration:
+    start = time.monotonic()
+    while time.monotonic() - start < duration:
         try:
             await (tc_open_lid(module, path_to_file))
         except asyncio.TimeoutError:
@@ -34,8 +34,8 @@ async def hs_test_1(module: str, path_to_file: str) -> None:
     """Heater Shaker Test 1. (Home and Shake)."""
     duration = int(input("How long to run this test for? (in seconds): "))
     rpm = input("Target RPM (200-3000): ")
-    start = time.time()
-    while time.time() - start < duration:
+    start = time.monotonic()
+    while time.monotonic() - start < duration:
         try:
             await (hs_test_home(module, path_to_file))
         except asyncio.TimeoutError:

--- a/analyses-snapshot-testing/citools/generate_analyses.py
+++ b/analyses-snapshot-testing/citools/generate_analyses.py
@@ -125,8 +125,8 @@ def start_containers(image_name: str, num_containers: int, timeout: int = 60) ->
         containers.append(container)
 
     # Wait for containers to be ready
-    start_time = time.time()
-    while time.time() - start_time < timeout:
+    start_time = time.monotonic()
+    while time.monotonic() - start_time < timeout:
         all_ready = True
         for container in containers:
             exit_code, _ = container.exec_run(f"ls -al {CONTAINER_LABWARE}")
@@ -172,7 +172,7 @@ def analyze(protocol: TargetProtocol, container: docker.models.containers.Contai
     # Build the command with all relevant file paths
     all_files = [str(protocol.container_protocol_file)] + [str(lw) for lw in labware_files]
     command = f"python -I -m opentrons.cli analyze --json-output {protocol.container_analysis_file} " + " ".join(all_files)
-    start_time = time.time()
+    start_time = time.monotonic()
     result = None
     exit_code = None
     console.print(f"Beginning analysis of {protocol.host_protocol_file.name}")
@@ -191,7 +191,7 @@ def analyze(protocol: TargetProtocol, container: docker.models.containers.Contai
         protocol.set_analysis()
         return False
     finally:
-        protocol.set_analysis_execution_time(time.time() - start_time)
+        protocol.set_analysis_execution_time(time.monotonic() - start_time)
         console.print(f"Analysis of {protocol.host_protocol_file.name} completed in {protocol.analysis_execution_time:.2f} seconds.")
 
 
@@ -238,7 +238,7 @@ def get_container_instances(protocol_len: int) -> int:
 
 def generate_analyses_from_test(tag: str, protocols: List[Protocol]) -> List[TargetProtocol]:
     """Generate analyses from the tests."""
-    start_time = time.time()
+    start_time = time.monotonic()
     protocols_to_process: List[TargetProtocol] = []
     for test_protocol in protocols:
         host_protocol_file = Path(test_protocol.file_path)
@@ -256,6 +256,6 @@ def generate_analyses_from_test(tag: str, protocols: List[Protocol]) -> List[Tar
         )
     instance_count = get_container_instances(len(protocols_to_process))
     analyze_against_image(tag, protocols_to_process, instance_count)
-    end_time = time.time()
+    end_time = time.monotonic()
     console.print(f"Clock time to generate analyses: {end_time - start_time:.2f} seconds.")
     return protocols_to_process

--- a/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -12,7 +12,7 @@ import asyncio
 import contextlib
 import logging
 from os import environ
-from time import time
+from time import monotonic
 from typing import Any, Dict, Optional, Union, List, Tuple, cast, AsyncIterator
 
 from math import isclose
@@ -1901,12 +1901,12 @@ class SmoothieDriver:
         # if loop:
         #    kwargs["loop"] = loop
         log.info(update_cmd)
-        before = time()
+        before = monotonic()
         proc = await asyncio.create_subprocess_shell(update_cmd, **kwargs)
-        created = time()
+        created = monotonic()
         log.info(f"created lpc21isp subproc in {created-before}")
         out_b, err_b = await proc.communicate()
-        done = time()
+        done = monotonic()
         log.info(f"ran lpc21isp subproc in {done-created}")
         if proc.returncode != 0:
             log.error(

--- a/g-code-testing/g_code_parsing/g_code_engine.py
+++ b/g-code-testing/g_code_parsing/g_code_engine.py
@@ -108,10 +108,10 @@ class GCodeEngine:
             feature_flags=HardwareFeatureFlags.build_from_ff(),
         )
         # Wait for modules to be present
-        wait_begins = time.time()
+        wait_begins = time.monotonic()
         while len(emulator.attached_modules) != len(modules):
             time.sleep(0.1)
-            if (time.time() - wait_begins) > 30:
+            if (time.monotonic() - wait_begins) > 30:
                 proc.kill()
                 proc.join()
                 raise RuntimeError(

--- a/hardware-testing/hardware_testing/drivers/mark10/mark10_fg.py
+++ b/hardware-testing/hardware_testing/drivers/mark10/mark10_fg.py
@@ -1,7 +1,7 @@
 """Mark10 Force Gauge Driver."""
 from serial import Serial  # type: ignore[import]
 from abc import ABC, abstractmethod
-from time import time
+from time import monotonic
 from typing import Tuple
 
 
@@ -96,8 +96,8 @@ class Mark10(Mark10Base):
     def read_force(self, timeout: float = 1.0) -> float:
         """Get Force in Newtons."""
         self._force_guage.write("?\r\n".encode("utf-8"))
-        start_time = time()
-        while time() < start_time + timeout:
+        start_time = monotonic()
+        while monotonic() < start_time + timeout:
             # return "12.3 N"
             line = self._force_guage.readline().decode("utf-8").strip()
             try:

--- a/hardware-testing/hardware_testing/drivers/mitutoyo_digimatic_indicator.py
+++ b/hardware-testing/hardware_testing/drivers/mitutoyo_digimatic_indicator.py
@@ -66,9 +66,9 @@ class Mitutoyo_Digimatic_Indicator:
 
     def read_stable(self, timeout: float = 5) -> float:
         """Reads dial indicator with stable reading."""
-        then = time.time()
+        then = time.monotonic()
         values = [self.read(), self.read(), self.read(), self.read(), self.read()]
-        while (time.time() - then) < timeout:
+        while (time.monotonic() - then) < timeout:
             if numpy.allclose(values, list(reversed(values))):
                 return values[-1]
             values = values[1:] + [self.read()]
@@ -79,8 +79,8 @@ if __name__ == "__main__":
     print("Mitutoyo ABSOLUTE Digimatic Indicator")
     gauge = Mitutoyo_Digimatic_Indicator(port="/dev/ttyUSB0")
     gauge.connect()
-    start_time = time.time()
+    start_time = time.monotonic()
     while True:
-        elapsed_time = round(time.time() - start_time, 3)
+        elapsed_time = round(time.monotonic() - start_time, 3)
         distance = gauge.read()
         print("Time: {} Distance: {}".format(elapsed_time, distance))

--- a/hardware-testing/hardware_testing/production_qc/ninety_six_assembly_qc_ot3/test_droplets.py
+++ b/hardware-testing/hardware_testing/production_qc/ninety_six_assembly_qc_ot3/test_droplets.py
@@ -1,6 +1,6 @@
 """Test Droplets."""
 from asyncio import sleep
-from time import time
+from time import monotonic
 from typing import List, Union, Tuple, Optional, Dict, Literal
 
 from opentrons.hardware_control.ot3api import OT3API
@@ -110,7 +110,7 @@ async def aspirate_and_wait(
     await api.aspirate(OT3Mount.LEFT, volume)
     await api.move_to(OT3Mount.LEFT, reservoir + Point(z=HOVER_HEIGHT_MM))
 
-    start_time = time()
+    start_time = monotonic()
     for i in range(seconds):
         print(f"waiting {i + 1}/{seconds}")
         if i == 0 or i == seconds - 1:
@@ -123,7 +123,7 @@ async def aspirate_and_wait(
         result = ui.get_user_answer("look good")
     else:
         result = True
-    duration_seconds = time() - start_time
+    duration_seconds = monotonic() - start_time
     print(f"waited for {duration_seconds} seconds")
 
     await api.move_to(

--- a/hardware-testing/hardware_testing/production_qc/robot_assembly_qc_ot3/test_peripherals.py
+++ b/hardware-testing/hardware_testing/production_qc/robot_assembly_qc_ot3/test_peripherals.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from subprocess import run as run_subprocess, Popen, CalledProcessError
 from typing import List, Union, Optional, Dict
 from urllib.request import urlopen
-from time import time
+from time import monotonic
 from typing import Tuple
 
 from opentrons_hardware.hardware_control.rear_panel_settings import set_ui_color
@@ -223,19 +223,19 @@ async def run(api: OT3API, report: CSVReport, section: str) -> None:
     ui.print_header("DOOR SWITCH")
     door_timeout_seconds = 10
     print("CLOSE the front door")
-    start_time_seconds = time()
+    start_time_seconds = monotonic()
     while not api.is_simulator and api.door_state != DoorState.CLOSED:
         await asyncio.sleep(0.1)
-        if time() - start_time_seconds > door_timeout_seconds:
+        if monotonic() - start_time_seconds > door_timeout_seconds:
             ui.print_error("timed out waiting for door to close")
             break
     print(api.door_state)
     is_closed = api.door_state == DoorState.CLOSED
     print("OPEN the front door")
-    start_time_seconds = time()
+    start_time_seconds = monotonic()
     while not api.is_simulator and api.door_state != DoorState.OPEN:
         await asyncio.sleep(0.1)
-        if time() - start_time_seconds > door_timeout_seconds:
+        if monotonic() - start_time_seconds > door_timeout_seconds:
             ui.print_error("timed out waiting for door to open")
             break
     print(api.door_state)

--- a/hardware-testing/hardware_testing/production_qc/stress_test_qc_ot3.py
+++ b/hardware-testing/hardware_testing/production_qc/stress_test_qc_ot3.py
@@ -131,7 +131,7 @@ def _create_csv_and_get_callbacks(sn: str) -> Tuple[CSVProperties, CSVCallbacks]
     file_name = data.create_file_name(test_name=test_name, run_id=run_id, tag=sn)
     csv_display_name = os.path.join(run_path, file_name)
     print(f"CSV: {csv_display_name}")
-    start_time = time.time()
+    start_time = time.monotonic()
 
     def _append_csv_data(
         data_list: List[Any],
@@ -142,7 +142,7 @@ def _create_csv_and_get_callbacks(sn: str) -> Tuple[CSVProperties, CSVCallbacks]
         # every line in the CSV file begins with the elapsed seconds
         if not first_row_value_included:
             if first_row_value is None:
-                first_row_value = str(round(time.time() - start_time, 2))
+                first_row_value = str(round(time.monotonic() - start_time, 2))
             data_list = [first_row_value] + data_list
         data_str = ",".join([str(d) for d in data_list])
         if line_number is None:

--- a/hardware-testing/hardware_testing/scripts/faster_plunger_lifetime_test.py
+++ b/hardware-testing/hardware_testing/scripts/faster_plunger_lifetime_test.py
@@ -101,7 +101,7 @@ async def main(args: argparse.Namespace, cfg: TestConfig) -> None:
         }
         writer = csv.DictWriter(csvfile, test_data)
         writer.writeheader()
-        start_time = time.time()
+        start_time = time.monotonic()
         try:
             currents = list(CURRENTS_SPEEDS.keys())
             for cycle in range(1, args.cycles + 1):
@@ -133,7 +133,7 @@ async def main(args: argparse.Namespace, cfg: TestConfig) -> None:
                             api, mount, bottom, speed=speed, motor_current=current
                         )
                         down_passed = await position_check()
-                        test_data["time_sec"] = time.time() - start_time
+                        test_data["time_sec"] = time.monotonic() - start_time
                         test_data["cycle"] = cycle
                         test_data["position"] = "bottom"
                         test_data["position_check"] = down_passed
@@ -191,7 +191,7 @@ async def main(args: argparse.Namespace, cfg: TestConfig) -> None:
                             api, mount, 0, speed=speed, motor_current=current
                         )
                         up_passed = await position_check()
-                        test_data["time_sec"] = time.time() - start_time
+                        test_data["time_sec"] = time.monotonic() - start_time
                         test_data["cycle"] = cycle
                         test_data["position"] = "top"
                         test_data["position_check"] = up_passed

--- a/hardware-testing/hardware_testing/scripts/gripper_and_zmount_move.py
+++ b/hardware-testing/hardware_testing/scripts/gripper_and_zmount_move.py
@@ -188,7 +188,7 @@ jira credentials to: {storage_directory}."
     )
     await asyncio.sleep(1)
     await hw_api.cache_instruments()
-    timeout_start = time.time()
+    timeout_start = time.monotonic()
     timeout = time_min * 60
     count = 0
     errored = False
@@ -198,14 +198,14 @@ jira credentials to: {storage_directory}."
         await hw_api.home()
         await asyncio.sleep(1)
         await hw_api.move_rel(mount, Point(0, 0, -1))
-        while time.time() < timeout_start + timeout:
+        while time.monotonic() < timeout_start + timeout:
             # while True:
             await hw_api.move_rel(mount, Point(0, 0, (-1 * int(travel))))
             await hw_api.move_rel(mount, Point(0, 0, int(travel)))
             # grab and print time and move count
             count += 1
             print(f"cycle: {count}")
-            runtime = time.time() - timeout_start
+            runtime = time.monotonic() - timeout_start
             print(f"time: {runtime}")
             # write count and runtime to csv sheet
             run_data = [

--- a/hardware-testing/hardware_testing/scripts/plunger_overshoot.py
+++ b/hardware-testing/hardware_testing/scripts/plunger_overshoot.py
@@ -67,15 +67,15 @@ def _dial_thread(simulate: bool, csv_file_name: str) -> None:
         dial = Mitutoyo_Digimatic_Indicator(list_ports_and_select("dial-indicator"))
         dial.connect()
     DIAL_THREAD_RUNNING.set()  # set the flag
-    start_timestamp = time.time()
+    start_timestamp = time.monotonic()
     read_timestamp = start_timestamp
     dial_zero = 0.0
     plunger_zero = 0.0
     data_buffer = []
     while DIAL_THREAD_RUNNING.is_set():  # continue until flag is cleared
         time.sleep(0.01)  # give time to main thread
-        if read_timestamp + DIAL_INDICATOR_READ_SECONDS < time.time():
-            read_timestamp = time.time()
+        if read_timestamp + DIAL_INDICATOR_READ_SECONDS < time.monotonic():
+            read_timestamp = time.monotonic()
             if simulate or not dial:
                 dial_pos = random()
             else:

--- a/hardware-testing/hardware_testing/scripts/stacker_hardware_acc_life_test.py
+++ b/hardware-testing/hardware_testing/scripts/stacker_hardware_acc_life_test.py
@@ -329,7 +329,7 @@ class Stacker_Axis_Acc_Lifetime_Test:
         await self.stacker_setup()
         await self.file_setup()
         print("\n-> Starting Stacker Test!\n")
-        self.start_time = time.time()
+        self.start_time = time.monotonic()
 
     async def stacker_setup(self) -> None:
         """Detect Stackers."""

--- a/hardware-testing/hardware_testing/scripts/stacker_tof_data_collection.py
+++ b/hardware-testing/hardware_testing/scripts/stacker_tof_data_collection.py
@@ -146,7 +146,7 @@ class Stacker_TOF_Data_Collection:
         await self.stacker_setup()
         self.file_setup()
         print("\n-> Starting Stacker TOF Validation Test!\n")
-        self.start_time = time.time()
+        self.start_time = time.monotonic()
 
     async def stacker_setup(self) -> None:
         """Find stacker symlinks from the file system."""
@@ -206,7 +206,7 @@ class Stacker_TOF_Data_Collection:
                     for k in range(self.samples):
                         sample = k + 1
                         print(f">>> Reading {axis} {pos} Sample = {sample}")
-                        elapsed_time = (time.time() - self.start_time) / 60
+                        elapsed_time = (time.monotonic() - self.start_time) / 60
                         if self.api is not None:
                             await self.api.attached_modules[i].home_axis(  # type: ignore
                                 StackerAxis.X, direction

--- a/hardware-testing/photometric-ot2/photometric_ot2/plate_prep_ot2.py
+++ b/hardware-testing/photometric-ot2/photometric_ot2/plate_prep_ot2.py
@@ -175,7 +175,7 @@ def run(protocol: protocol_api.ProtocolContext):
     assert CFG.volume > 0
     assert len(CFG.plate_rows) == len(CFG.trough_cols)
 
-    start_timestamp = time.time()
+    start_timestamp = time.monotonic()
     print(f'Time: {datetime.now().strftime("%m/%d/%Y, %H:%M:%S")}')
 
     items = load_labware_and_pipettes(
@@ -212,7 +212,7 @@ def run(protocol: protocol_api.ProtocolContext):
     fill_plate_with_baseline(
         protocol, items.multi, items.trough, items.plate)
     print(f'Time: {datetime.now().strftime("%m/%d/%Y, %H:%M:%S")}')
-    print(f'Duration: {round((time.time() - start_timestamp) / 60, 1)} minutes')
+    print(f'Duration: {round((time.monotonic() - start_timestamp) / 60, 1)} minutes')
     print('\ndone')
 
 

--- a/hardware/opentrons_hardware/hardware_control/move_group_runner.py
+++ b/hardware/opentrons_hardware/hardware_control/move_group_runner.py
@@ -678,7 +678,7 @@ class MoveScheduler:
 
         expected_time = max(3.0, self._durations[group_id - self._start_at_index] * 1.1)
         full_timeout = max(10.0, self._durations[group_id - self._start_at_index] * 2)
-        start_time = time.time()
+        start_time = time.monotonic()
 
         try:
             # The staged timeout handles some times when a move takes a liiiittle extra
@@ -686,7 +686,7 @@ class MoveScheduler:
                 self._event.wait(),
                 full_timeout,
             )
-            duration = time.time() - start_time
+            duration = time.monotonic() - start_time
             await self._send_stop_if_necessary(can_messenger, group_id)
 
             if duration >= expected_time:
@@ -707,7 +707,7 @@ class MoveScheduler:
                     "missing-nodes": missing_node_msg,
                     "full-timeout": str(full_timeout),
                     "expected-time": str(expected_time),
-                    "elapsed": str(time.time() - start_time),
+                    "elapsed": str(time.monotonic() - start_time),
                 },
             )
         except EnumeratedError:

--- a/hardware/opentrons_hardware/scripts/load.py
+++ b/hardware/opentrons_hardware/scripts/load.py
@@ -165,12 +165,12 @@ class BusLoader:
 
     async def _load_bus(self) -> None:
         warned = False
-        then = time.time()
+        then = time.monotonic()
         while True:
             for node in self._targets:
                 await self._messenger.send(node_id=node, message=DeviceInfoRequest())
                 self._stats.messages_sent[node] += 1
-            now = time.time()
+            now = time.monotonic()
             if now - then > self._period:
                 if not warned:
                     log.warning(

--- a/hardware/opentrons_hardware/scripts/network_test.py
+++ b/hardware/opentrons_hardware/scripts/network_test.py
@@ -170,14 +170,14 @@ async def run_test(
     task = asyncio.get_event_loop().create_task(
         _do_test(driver, load_percentage, bitrate, results_queue, mode)
     )
-    started = time.time()
+    started = time.monotonic()
     should_quit = False
     try:
         while not should_quit:
             results = await results_queue.get()
             sent_in = yield results
             should_quit = bool(sent_in)
-            if duration and (time.time() - started > duration):
+            if duration and (time.monotonic() - started > duration):
                 should_quit = True
     finally:
         task.cancel()
@@ -191,12 +191,12 @@ class WarningsWithCooldown:
 
     def __init__(self, cooldown_secs: float = 10) -> None:
         """Build the warner."""
-        self.last_warning = time.time()
+        self.last_warning = time.monotonic()
         self.cooldown_secs = cooldown_secs
 
     def warning(self, message: str) -> None:
         """Send a warning to logging.warning."""
-        now = time.time()
+        now = time.monotonic()
         if now > self.last_warning + self.cooldown_secs:
             log.warning(message)
             sys.stderr.write(message)
@@ -262,12 +262,12 @@ async def _do_test(
     transaction_size = message_size + response_size
 
     time_per_transaction = float(transaction_size) / (bitrate * load_percentage)
-    started = time.time()
+    started = time.monotonic()
 
     def listener(definition: MessageDefinition, arb_id: ArbitrationId) -> None:
         result_queue.put_nowait(
             StatisticElement(
-                sec_since_start=time.time() - started,
+                sec_since_start=time.monotonic() - started,
                 sending_node=arb_id.parts.originating_node,
                 bits=definition.payload.get_size(),
                 error=False,
@@ -277,7 +277,7 @@ async def _do_test(
     try:
         messenger.add_listener(listener)
         while True:
-            then = time.time()
+            then = time.monotonic()
             try:
                 await messenger.send(target, message(payload=EmptyPayload()))
                 error = False
@@ -288,13 +288,13 @@ async def _do_test(
                 bits = 0
             await result_queue.put(
                 StatisticElement(
-                    sec_since_start=(time.time() - started),
+                    sec_since_start=(time.monotonic() - started),
                     sending_node=NodeId.host,
                     bits=bits,
                     error=error,
                 )
             )
-            now = time.time()
+            now = time.monotonic()
             left = time_per_transaction - now - then
             if left > 0:
                 await asyncio.sleep(left)

--- a/opentrons-ai-server/tests/helpers/client.py
+++ b/opentrons-ai-server/tests/helpers/client.py
@@ -22,9 +22,9 @@ F = TypeVar("F", bound=Callable[..., Any])
 def timeit(func: F) -> F:
     @wraps(func)
     def wrapper(*args: Any, **kwargs: Any) -> Any:
-        start_time = time.time()
+        start_time = time.monotonic()
         result = func(*args, **kwargs)
-        end_time = time.time()
+        end_time = time.monotonic()
         elapsed_time = end_time - start_time
         console.print(f"[bold green]{func.__name__} completed in {elapsed_time:.4f} seconds[/bold green]")
         return result

--- a/usb-bridge/ot3usb/__main__.py
+++ b/usb-bridge/ot3usb/__main__.py
@@ -35,8 +35,8 @@ async def main() -> NoReturn:
         exit(-1)
 
     # Give the kernel a couple seconds to set up the handle
-    timeout = time.time() + 2.0
-    while time.time() < timeout and not config.handle_exists():
+    timeout = time.monotonic() + 2.0
+    while time.monotonic() < timeout and not config.handle_exists():
         time.sleep(0.1)
 
     if not config.handle_exists():


### PR DESCRIPTION
## Overview

A lot of Python code (in various projects) was doing stuff like:

```python
start = time.now()
do_stuff()
end = time.now()
duration = end - start
```

That's not quite right because `time.now()` can be affected by things like daylight savings time, leap seconds, and NTP adjustments. If we're doing math on timestamps, it needs to come from a monotonic clock. So this switches all (or at least most) of those places to use `time.monotonic()` instead.

## Test Plan and Hands on Testing

None.

## Changelog

Basically a global Ctrl+F for `time.time()`. I replaced it with `time.monotonic()` when it was obvious to me that it was only used in the local scope and that math was being done on it. So this excludes things like `time()` calls that were getting saved in CSV reports.

## Review requests

OK with all the hardware-testing changes, or do I need to run that by anybody?

## Risk assessment

Low. Changes are trivial.