### PR TITLE
refactor(api): move last tip picked up tracking from context to engine

### DIFF
--- a/api/src/opentrons/protocol_api/_transfer_liquid_validation.py
+++ b/api/src/opentrons/protocol_api/_transfer_liquid_validation.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import List, Union, Sequence, Optional, Tuple
+from typing import List, Union, Sequence, Optional
 
 from opentrons.types import Location, NozzleMapInterface
 from opentrons.protocols.api_support import instrument
@@ -13,7 +13,6 @@ from opentrons.protocols.advanced_control.transfers.common import (
 
 from .disposal_locations import TrashBin, WasteChute
 from .labware import Labware, Well
-from .core.common import WellCore
 from . import validation
 
 
@@ -25,7 +24,6 @@ class TransferInfo:
     tip_policy: TransferTipPolicyV2
     tip_racks: List[Labware]
     trash_location: Union[Location, TrashBin, WasteChute]
-    last_tip_location: Optional[Tuple[Location, WellCore]]
 
 
 def verify_and_normalize_transfer_args(
@@ -88,22 +86,12 @@ def verify_and_normalize_transfer_args(
         trash_location=_trash_location
     )
 
-    if last_tip_well is not None:
-        parent_tip_rack = last_tip_well.parent
-        last_tip_location = (
-            Location(last_tip_well.top().point, parent_tip_rack),
-            last_tip_well._core,
-        )
-    else:
-        last_tip_location = None
-
     return TransferInfo(
         source=flat_sources_list,
         dest=flat_dests_list if not isinstance(dest, (TrashBin, WasteChute)) else dest,
         tip_policy=valid_new_tip,
         tip_racks=valid_tip_racks,
         trash_location=valid_trash_location,
-        last_tip_location=last_tip_location,
     )
 
 

--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -1049,6 +1049,22 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
     def get_liquid_presence_detection(self) -> bool:
         return self._liquid_presence_detection
 
+    def get_last_well_tip_picked_up_from(
+        self,
+    ) -> Optional[Tuple[LabwareCore, WellCore]]:
+        tiprack_ids = (
+            self._engine_client.state.pipettes.get_last_tiprack_well_picked_up_from(
+                self._pipette_id
+            )
+        )
+        if tiprack_ids is None:
+            return None
+        else:
+            labware_id, well_name = tiprack_ids
+            tiprack_labware_core = self._protocol_core._labware_cores_by_id[labware_id]
+            tip_well_core = tiprack_labware_core.get_well_core(well_name)
+            return tiprack_labware_core, tip_well_core
+
     def is_tip_tracking_available(self) -> bool:
         if self.get_nozzle_configuration() == NozzleConfigurationType.FULL:
             return True

--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -1052,18 +1052,18 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
     def get_last_well_tip_picked_up_from(
         self,
     ) -> Optional[Tuple[LabwareCore, WellCore]]:
-        tiprack_ids = (
-            self._engine_client.state.pipettes.get_last_tiprack_well_picked_up_from(
+        tip_rack_ids = (
+            self._engine_client.state.pipettes.get_tip_rack_well_picked_up_from(
                 self._pipette_id
             )
         )
-        if tiprack_ids is None:
+        if tip_rack_ids is None:
             return None
         else:
-            labware_id, well_name = tiprack_ids
-            tiprack_labware_core = self._protocol_core._labware_cores_by_id[labware_id]
-            tip_well_core = tiprack_labware_core.get_well_core(well_name)
-            return tiprack_labware_core, tip_well_core
+            labware_id, well_name = tip_rack_ids
+            tip_rack_labware_core = self._protocol_core._labware_cores_by_id[labware_id]
+            tip_well_core = tip_rack_labware_core.get_well_core(well_name)
+            return tip_rack_labware_core, tip_well_core
 
     def is_tip_tracking_available(self) -> bool:
         if self.get_nozzle_configuration() == NozzleConfigurationType.FULL:

--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -1052,17 +1052,18 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
     def get_last_well_tip_picked_up_from(
         self,
     ) -> Optional[Tuple[LabwareCore, WellCore]]:
-        tip_rack_ids = (
+        tip_rack_id = (
             self._engine_client.state.pipettes.get_tip_rack_well_picked_up_from(
                 self._pipette_id
             )
         )
-        if tip_rack_ids is None:
+        if tip_rack_id is None:
             return None
         else:
-            labware_id, well_name = tip_rack_ids
-            tip_rack_labware_core = self._protocol_core._labware_cores_by_id[labware_id]
-            tip_well_core = tip_rack_labware_core.get_well_core(well_name)
+            tip_rack_labware_core = self._protocol_core._labware_cores_by_id[
+                tip_rack_id.labware_id
+            ]
+            tip_well_core = tip_rack_labware_core.get_well_core(tip_rack_id.well_name)
             return tip_rack_labware_core, tip_well_core
 
     def is_tip_tracking_available(self) -> bool:

--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -1233,8 +1233,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         trash_location: Union[Location, TrashBin, WasteChute],
         return_tip: bool,
         keep_last_tip: bool,
-        last_tip_location: Optional[Tuple[Location, WellCore]],
-    ) -> Optional[Tuple[Location, WellCore]]:
+    ) -> None:
         """Execute transfer using liquid class properties.
 
         Args:
@@ -1256,10 +1255,6 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             return_tip: If `True`, return tips to the tip rack location they were picked up from,
                         otherwise drop in `trash_location`
             keep_last_tip: When set to `True`, do not drop the final tip used in the transfer.
-            last_tip_location: If a tip is already attached, this will be the tiprack and well it was
-                           picked up from, represented as a tuple of types.Location and WellCore.
-                           Used so a tip can be returned if it was picked up outside this function
-                           as could be the case for a new_tip of `never`.
         """
         if not tip_racks:
             raise RuntimeError(
@@ -1296,9 +1291,8 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             )
         )
 
-        last_tip = last_tip_location
         if new_tip == TransferTipPolicyV2.ONCE:
-            last_tip = self._pick_up_tip_for_liquid_class(
+            self._pick_up_tip_for_liquid_class(
                 tip_racks, starting_tip, tiprack_uri_for_transfer_props
             )
 
@@ -1337,10 +1331,8 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                 )
             ):
                 if prev_src is not None and prev_dest is not None:
-                    self._drop_tip_for_liquid_class(
-                        trash_location, last_tip, return_tip
-                    )
-                last_tip = self._pick_up_tip_for_liquid_class(
+                    self._drop_tip_for_liquid_class(trash_location, return_tip)
+                self._pick_up_tip_for_liquid_class(
                     tip_racks, starting_tip, tiprack_uri_for_transfer_props
                 )
                 post_disp_tip_contents = [
@@ -1372,10 +1364,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             prev_dest = step_destination
 
         if not keep_last_tip:
-            self._drop_tip_for_liquid_class(trash_location, last_tip, return_tip)
-            last_tip = None
-
-        return last_tip
+            self._drop_tip_for_liquid_class(trash_location, return_tip)
 
     def distribute_with_liquid_class(  # noqa: C901
         self,
@@ -1393,8 +1382,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         trash_location: Union[Location, TrashBin, WasteChute],
         return_tip: bool,
         keep_last_tip: bool,
-        last_tip_location: Optional[Tuple[Location, WellCore]],
-    ) -> Optional[Tuple[Location, WellCore]]:
+    ) -> None:
         """Execute a distribution using liquid class properties.
 
         Args:
@@ -1417,10 +1405,6 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             return_tip: If `True`, return tips to the tip rack location they were picked up from,
                         otherwise drop in `trash_location`
             keep_last_tip: When set to `True`, do not drop the final tip used in the distribute.
-            last_tip_location: If a tip is already attached, this will be the tiprack and well it was
-                           picked up from, represented as a tuple of types.Location and WellCore.
-                           Used so a tip can be returned if it was picked up outside this function
-                           as could be the case for a new_tip of `never`
 
         This method distributes the liquid in the source well into multiple destinations.
         It can accomplish this by either doing a multi-dispense (aspirate once and then
@@ -1480,7 +1464,6 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                 trash_location=trash_location,
                 return_tip=return_tip,
                 keep_last_tip=keep_last_tip,
-                last_tip_location=last_tip_location,
             )
 
         # TODO: use the ID returned by load_liquid_class in command annotations
@@ -1502,9 +1485,8 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             )
         )
 
-        last_tip = last_tip_location
         if new_tip != TransferTipPolicyV2.NEVER:
-            last_tip = self._pick_up_tip_for_liquid_class(
+            self._pick_up_tip_for_liquid_class(
                 tip_racks, starting_tip, tiprack_uri_for_transfer_props
             )
 
@@ -1571,8 +1553,8 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                 )
 
             if not is_first_step and new_tip == TransferTipPolicyV2.ALWAYS:
-                self._drop_tip_for_liquid_class(trash_location, last_tip, return_tip)
-                last_tip = self._pick_up_tip_for_liquid_class(
+                self._drop_tip_for_liquid_class(trash_location, return_tip)
+                self._pick_up_tip_for_liquid_class(
                     tip_racks, starting_tip, tiprack_uri_for_transfer_props
                 )
                 tip_contents = [
@@ -1631,10 +1613,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                 is_first_step = False
 
         if not keep_last_tip:
-            self._drop_tip_for_liquid_class(trash_location, last_tip, return_tip)
-            last_tip = None
-
-        return last_tip
+            self._drop_tip_for_liquid_class(trash_location, return_tip)
 
     def _tip_can_hold_volume_for_multi_dispensing(
         self,
@@ -1673,8 +1652,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         trash_location: Union[Location, TrashBin, WasteChute],
         return_tip: bool,
         keep_last_tip: bool,
-        last_tip_location: Optional[Tuple[Location, WellCore]],
-    ) -> Optional[Tuple[Location, WellCore]]:
+    ) -> None:
         """Execute consolidate using liquid class properties.
 
         Args:
@@ -1698,10 +1676,6 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             return_tip: If `True`, return tips to the tip rack location they were picked up from,
                         otherwise drop in `trash_location`
             keep_last_tip: When set to `True`, do not drop the final tip used in the consolidate.
-            last_tip_location: If a tip is already attached, this will be the tiprack and well it was
-                           picked up from, represented as a tuple of types.Location and WellCore.
-                           Used so a tip can be returned if it was picked up outside this function
-                           as could be the case for a new_tip of `never`.
         """
         if not tip_racks:
             raise RuntimeError(
@@ -1747,9 +1721,8 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             )
         )
 
-        last_tip = last_tip_location
         if new_tip in [TransferTipPolicyV2.ONCE, TransferTipPolicyV2.ALWAYS]:
-            last_tip = self._pick_up_tip_for_liquid_class(
+            self._pick_up_tip_for_liquid_class(
                 tip_racks, starting_tip, tiprack_uri_for_transfer_props
             )
 
@@ -1781,8 +1754,8 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                     break
 
             if not is_first_step and new_tip == TransferTipPolicyV2.ALWAYS:
-                self._drop_tip_for_liquid_class(trash_location, last_tip, return_tip)
-                last_tip = self._pick_up_tip_for_liquid_class(
+                self._drop_tip_for_liquid_class(trash_location, return_tip)
+                self._pick_up_tip_for_liquid_class(
                     tip_racks, starting_tip, tiprack_uri_for_transfer_props
                 )
                 tip_contents = [
@@ -1819,10 +1792,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             )
 
         if not keep_last_tip:
-            self._drop_tip_for_liquid_class(trash_location, last_tip, return_tip)
-            last_tip = None
-
-        return last_tip
+            self._drop_tip_for_liquid_class(trash_location, return_tip)
 
     def _get_location_and_well_core_from_next_tip_info(
         self,
@@ -1906,11 +1876,11 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
     def _drop_tip_for_liquid_class(
         self,
         trash_location: Union[Location, TrashBin, WasteChute],
-        last_tip: Optional[Tuple[Location, WellCore]],
         return_tip: bool,
     ) -> None:
         """Drop or return tip for usage in liquid class transfers."""
         if return_tip:
+            last_tip = self.get_last_well_tip_picked_up_from()
             assert last_tip is not None
             _, tip_well = last_tip
             self.drop_tip(

--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -1052,18 +1052,20 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
     def get_last_well_tip_picked_up_from(
         self,
     ) -> Optional[Tuple[LabwareCore, WellCore]]:
-        tip_rack_id = (
+        last_tip_pickup_info = (
             self._engine_client.state.pipettes.get_tip_rack_well_picked_up_from(
                 self._pipette_id
             )
         )
-        if tip_rack_id is None:
+        if last_tip_pickup_info is None:
             return None
         else:
             tip_rack_labware_core = self._protocol_core._labware_cores_by_id[
-                tip_rack_id.labware_id
+                last_tip_pickup_info.labware_id
             ]
-            tip_well_core = tip_rack_labware_core.get_well_core(tip_rack_id.well_name)
+            tip_well_core = tip_rack_labware_core.get_well_core(
+                last_tip_pickup_info.well_name
+            )
             return tip_rack_labware_core, tip_well_core
 
     def is_tip_tracking_available(self) -> bool:

--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -1845,7 +1845,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         tip_racks: List[Tuple[Location, LabwareCore]],
         starting_tip: Optional[WellCore],
         tiprack_uri_for_transfer_props: str,
-    ) -> Tuple[Location, WellCore]:
+    ) -> None:
         """Resolve next tip and pick it up, for use in liquid class transfer code."""
         next_tip = self.get_next_tip(
             tip_racks=[core for loc, core in tip_racks],
@@ -1872,7 +1872,6 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             presses=None,
             increment=None,
         )
-        return tiprack_loc, tip_well
 
     def _drop_tip_for_liquid_class(
         self,

--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -1049,7 +1049,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
     def get_liquid_presence_detection(self) -> bool:
         return self._liquid_presence_detection
 
-    def get_last_well_tip_picked_up_from(
+    def get_tip_origin(
         self,
     ) -> Optional[Tuple[LabwareCore, WellCore]]:
         last_tip_pickup_info = (
@@ -1882,7 +1882,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
     ) -> None:
         """Drop or return tip for usage in liquid class transfers."""
         if return_tip:
-            last_tip = self.get_last_well_tip_picked_up_from()
+            last_tip = self.get_tip_origin()
             assert last_tip is not None
             _, tip_well = last_tip
             self.drop_tip(

--- a/api/src/opentrons/protocol_api/core/instrument.py
+++ b/api/src/opentrons/protocol_api/core/instrument.py
@@ -311,6 +311,12 @@ class AbstractInstrument(ABC, Generic[WellCoreType, LabwareCoreType]):
         ...
 
     @abstractmethod
+    def get_last_well_tip_picked_up_from(
+        self,
+    ) -> Optional[Tuple[LabwareCoreType, WellCoreType]]:
+        ...
+
+    @abstractmethod
     def _pressure_supported_by_pipette(self) -> bool:
         ...
 

--- a/api/src/opentrons/protocol_api/core/instrument.py
+++ b/api/src/opentrons/protocol_api/core/instrument.py
@@ -378,8 +378,7 @@ class AbstractInstrument(ABC, Generic[WellCoreType, LabwareCoreType]):
         trash_location: Union[types.Location, TrashBin, WasteChute],
         return_tip: bool,
         keep_last_tip: bool,
-        last_tip_location: Optional[Tuple[types.Location, WellCoreType]],
-    ) -> Optional[Tuple[types.Location, WellCoreType]]:
+    ) -> None:
         """Transfer a liquid from source to dest according to liquid class properties."""
         ...
 
@@ -396,8 +395,7 @@ class AbstractInstrument(ABC, Generic[WellCoreType, LabwareCoreType]):
         trash_location: Union[types.Location, TrashBin, WasteChute],
         return_tip: bool,
         keep_last_tip: bool,
-        last_tip_location: Optional[Tuple[types.Location, WellCoreType]],
-    ) -> Optional[Tuple[types.Location, WellCoreType]]:
+    ) -> None:
         """
         Distribute a liquid from single source to multiple destinations
         according to liquid class properties.
@@ -417,8 +415,7 @@ class AbstractInstrument(ABC, Generic[WellCoreType, LabwareCoreType]):
         trash_location: Union[types.Location, TrashBin, WasteChute],
         return_tip: bool,
         keep_last_tip: bool,
-        last_tip_location: Optional[Tuple[types.Location, WellCoreType]],
-    ) -> Optional[Tuple[types.Location, WellCoreType]]:
+    ) -> None:
         """
         Consolidate liquid from multiple sources to a single destination
         using the specified liquid class properties.

--- a/api/src/opentrons/protocol_api/core/instrument.py
+++ b/api/src/opentrons/protocol_api/core/instrument.py
@@ -311,7 +311,7 @@ class AbstractInstrument(ABC, Generic[WellCoreType, LabwareCoreType]):
         ...
 
     @abstractmethod
-    def get_last_well_tip_picked_up_from(
+    def get_tip_origin(
         self,
     ) -> Optional[Tuple[LabwareCoreType, WellCoreType]]:
         ...

--- a/api/src/opentrons/protocol_api/core/legacy/legacy_instrument_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy/legacy_instrument_core.py
@@ -67,7 +67,7 @@ class LegacyInstrumentCore(AbstractInstrument[LegacyWellCore, LegacyLabwareCore]
             api_level=self._api_version,
         )
         self._liquid_presence_detection = False
-        self._last_tiprack_and_well: Optional[
+        self._last_tip_rack_and_well: Optional[
             Tuple[LegacyLabwareCore, LegacyWellCore]
         ] = None
 
@@ -259,7 +259,7 @@ class LegacyInstrumentCore(AbstractInstrument[LegacyWellCore, LegacyLabwareCore]
         # a well or labware
         parent_labware, _ = location.labware.get_parent_labware_and_well()
         if parent_labware is not None:
-            self._last_tiprack_and_well = parent_labware._core, well_core  # type: ignore[assignment]
+            self._last_tip_rack_and_well = parent_labware._core, well_core  # type: ignore[assignment]
 
     def drop_tip(
         self,
@@ -306,7 +306,7 @@ class LegacyInstrumentCore(AbstractInstrument[LegacyWellCore, LegacyLabwareCore]
         hw = self._protocol_interface.get_hardware()
         self.move_to(location=location)
         hw.drop_tip(self._mount, home_after=True if home_after is None else home_after)
-        self._last_tiprack_and_well = None
+        self._last_tip_rack_and_well = None
 
         if self._api_version < APIVersion(2, 2) and labware_core.is_tip_rack():
             # If this is a tiprack we can try and add the dirty tip back to the tracker
@@ -544,7 +544,7 @@ class LegacyInstrumentCore(AbstractInstrument[LegacyWellCore, LegacyLabwareCore]
     def get_last_well_tip_picked_up_from(
         self,
     ) -> Optional[Tuple[LegacyLabwareCore, LegacyWellCore]]:
-        return self._last_tiprack_and_well
+        return self._last_tip_rack_and_well
 
     def set_flow_rate(
         self,

--- a/api/src/opentrons/protocol_api/core/legacy/legacy_instrument_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy/legacy_instrument_core.py
@@ -626,8 +626,7 @@ class LegacyInstrumentCore(AbstractInstrument[LegacyWellCore, LegacyLabwareCore]
         trash_location: Union[types.Location, TrashBin, WasteChute],
         return_tip: bool,
         keep_last_tip: bool,
-        last_tip_location: Optional[Tuple[types.Location, LegacyWellCore]],
-    ) -> Optional[Tuple[types.Location, LegacyWellCore]]:
+    ) -> None:
         """This will never be called because it was added in API 2.23"""
         assert False, "transfer_liquid is not supported in legacy context"
 
@@ -643,8 +642,7 @@ class LegacyInstrumentCore(AbstractInstrument[LegacyWellCore, LegacyLabwareCore]
         trash_location: Union[types.Location, TrashBin, WasteChute],
         return_tip: bool,
         keep_last_tip: bool,
-        last_tip_location: Optional[Tuple[types.Location, LegacyWellCore]],
-    ) -> Optional[Tuple[types.Location, LegacyWellCore]]:
+    ) -> None:
         """This will never be called because it was added in API 2.23"""
         assert False, "distribute_liquid is not supported in legacy context"
 
@@ -660,8 +658,7 @@ class LegacyInstrumentCore(AbstractInstrument[LegacyWellCore, LegacyLabwareCore]
         trash_location: Union[types.Location, TrashBin, WasteChute],
         return_tip: bool,
         keep_last_tip: bool,
-        last_tip_location: Optional[Tuple[types.Location, LegacyWellCore]],
-    ) -> Optional[Tuple[types.Location, LegacyWellCore]]:
+    ) -> None:
         """This will never be called because it was added in API 2.23."""
         assert False, "consolidate_liquid is not supported in legacy context"
 

--- a/api/src/opentrons/protocol_api/core/legacy/legacy_instrument_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy/legacy_instrument_core.py
@@ -537,7 +537,7 @@ class LegacyInstrumentCore(AbstractInstrument[LegacyWellCore, LegacyLabwareCore]
     def get_speed(self) -> PlungerSpeeds:
         return self._speeds
 
-    def get_last_well_tip_picked_up_from(
+    def get_tip_origin(
         self,
     ) -> Optional[Tuple[LegacyLabwareCore, LegacyWellCore]]:
         return self._last_tip_rack_and_well

--- a/api/src/opentrons/protocol_api/core/legacy/legacy_instrument_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy/legacy_instrument_core.py
@@ -306,6 +306,7 @@ class LegacyInstrumentCore(AbstractInstrument[LegacyWellCore, LegacyLabwareCore]
         hw = self._protocol_interface.get_hardware()
         self.move_to(location=location)
         hw.drop_tip(self._mount, home_after=True if home_after is None else home_after)
+        self._last_tiprack_and_well = None
 
         if self._api_version < APIVersion(2, 2) and labware_core.is_tip_rack():
             # If this is a tiprack we can try and add the dirty tip back to the tracker

--- a/api/src/opentrons/protocol_api/core/legacy/legacy_instrument_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy/legacy_instrument_core.py
@@ -255,11 +255,7 @@ class LegacyInstrumentCore(AbstractInstrument[LegacyWellCore, LegacyLabwareCore]
             num_channels=self.get_channels(),
             fail_if_full=self._api_version < APIVersion(2, 2),
         )
-        # In practice this will always resolve to a labware, since location should be either
-        # a well or labware
-        parent_labware, _ = location.labware.get_parent_labware_and_well()
-        if parent_labware is not None:
-            self._last_tip_rack_and_well = parent_labware._core, well_core  # type: ignore[assignment]
+        self._last_tip_rack_and_well = tip_rack_core, well_core
 
     def drop_tip(
         self,

--- a/api/src/opentrons/protocol_api/core/legacy/legacy_instrument_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy/legacy_instrument_core.py
@@ -67,6 +67,9 @@ class LegacyInstrumentCore(AbstractInstrument[LegacyWellCore, LegacyLabwareCore]
             api_level=self._api_version,
         )
         self._liquid_presence_detection = False
+        self._last_tiprack_and_well: Optional[
+            Tuple[LegacyLabwareCore, LegacyWellCore]
+        ] = None
 
     def get_default_speed(self) -> float:
         """Gets the speed at which the robot's gantry moves."""
@@ -252,6 +255,11 @@ class LegacyInstrumentCore(AbstractInstrument[LegacyWellCore, LegacyLabwareCore]
             num_channels=self.get_channels(),
             fail_if_full=self._api_version < APIVersion(2, 2),
         )
+        # In practice this will always resolve to a labware, since location should be either
+        # a well or labware
+        parent_labware, _ = location.labware.get_parent_labware_and_well()
+        if parent_labware is not None:
+            self._last_tiprack_and_well = parent_labware._core, well_core  # type: ignore[assignment]
 
     def drop_tip(
         self,
@@ -531,6 +539,11 @@ class LegacyInstrumentCore(AbstractInstrument[LegacyWellCore, LegacyLabwareCore]
 
     def get_speed(self) -> PlungerSpeeds:
         return self._speeds
+
+    def get_last_well_tip_picked_up_from(
+        self,
+    ) -> Optional[Tuple[LegacyLabwareCore, LegacyWellCore]]:
+        return self._last_tiprack_and_well
 
     def set_flow_rate(
         self,

--- a/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_instrument_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_instrument_core.py
@@ -227,11 +227,7 @@ class LegacyInstrumentCoreSimulator(
             num_channels=self.get_channels(),
             fail_if_full=self._api_version < APIVersion(2, 2),
         )
-        # In practice this will always resolve to a labware, since location should be either
-        # a well or labware
-        parent_labware, _ = location.labware.get_parent_labware_and_well()
-        if parent_labware is not None:
-            self._last_tip_rack_and_well = parent_labware._core, well_core  # type: ignore[assignment]
+        self._last_tip_rack_and_well = tip_rack_core, well_core
 
     def drop_tip(
         self,

--- a/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_instrument_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_instrument_core.py
@@ -540,8 +540,7 @@ class LegacyInstrumentCoreSimulator(
         trash_location: Union[types.Location, TrashBin, WasteChute],
         return_tip: bool,
         keep_last_tip: bool,
-        last_tip_location: Optional[Tuple[types.Location, LegacyWellCore]],
-    ) -> Optional[Tuple[types.Location, LegacyWellCore]]:
+    ) -> None:
         """This will never be called because it was added in API 2.23."""
         assert False, "transfer_liquid is not supported in legacy context"
 
@@ -557,8 +556,7 @@ class LegacyInstrumentCoreSimulator(
         trash_location: Union[types.Location, TrashBin, WasteChute],
         return_tip: bool,
         keep_last_tip: bool,
-        last_tip_location: Optional[Tuple[types.Location, LegacyWellCore]],
-    ) -> Optional[Tuple[types.Location, LegacyWellCore]]:
+    ) -> None:
         """This will never be called because it was added in API 2.23."""
         assert False, "distribute_liquid is not supported in legacy context"
 
@@ -574,8 +572,7 @@ class LegacyInstrumentCoreSimulator(
         trash_location: Union[types.Location, TrashBin, WasteChute],
         return_tip: bool,
         keep_last_tip: bool,
-        last_tip_location: Optional[Tuple[types.Location, LegacyWellCore]],
-    ) -> Optional[Tuple[types.Location, LegacyWellCore]]:
+    ) -> None:
         """This will never be called because it was added in API 2.23."""
         assert False, "consolidate_liquid is not supported in legacy context"
 

--- a/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_instrument_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_instrument_core.py
@@ -82,6 +82,9 @@ class LegacyInstrumentCoreSimulator(
             protocol_interface.get_hardware().get_instrument_max_height(self._mount)
         )
         self._liquid_presence_detection = False
+        self._last_tiprack_and_well: Optional[
+            Tuple[LegacyLabwareCore, LegacyWellCore]
+        ] = None
 
     def get_default_speed(self) -> float:
         return self._default_speed
@@ -224,6 +227,11 @@ class LegacyInstrumentCoreSimulator(
             num_channels=self.get_channels(),
             fail_if_full=self._api_version < APIVersion(2, 2),
         )
+        # In practice this will always resolve to a labware, since location should be either
+        # a well or labware
+        parent_labware, _ = location.labware.get_parent_labware_and_well()
+        if parent_labware is not None:
+            self._last_tiprack_and_well = parent_labware._core, well_core  # type: ignore[assignment]
 
     def drop_tip(
         self,
@@ -422,6 +430,11 @@ class LegacyInstrumentCoreSimulator(
 
     def get_blow_out_flow_rate(self, rate: float = 1.0) -> float:
         return self._pipette_dict["blow_out_flow_rate"] * rate
+
+    def get_last_well_tip_picked_up_from(
+        self,
+    ) -> Optional[Tuple[LegacyLabwareCore, LegacyWellCore]]:
+        return self._last_tiprack_and_well
 
     def set_flow_rate(
         self,

--- a/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_instrument_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_instrument_core.py
@@ -82,7 +82,7 @@ class LegacyInstrumentCoreSimulator(
             protocol_interface.get_hardware().get_instrument_max_height(self._mount)
         )
         self._liquid_presence_detection = False
-        self._last_tiprack_and_well: Optional[
+        self._last_tip_rack_and_well: Optional[
             Tuple[LegacyLabwareCore, LegacyWellCore]
         ] = None
 
@@ -231,7 +231,7 @@ class LegacyInstrumentCoreSimulator(
         # a well or labware
         parent_labware, _ = location.labware.get_parent_labware_and_well()
         if parent_labware is not None:
-            self._last_tiprack_and_well = parent_labware._core, well_core  # type: ignore[assignment]
+            self._last_tip_rack_and_well = parent_labware._core, well_core  # type: ignore[assignment]
 
     def drop_tip(
         self,
@@ -272,7 +272,7 @@ class LegacyInstrumentCoreSimulator(
         self._pipette_dict["has_tip"] = False
         self._pipette_dict["tip_length"] = 0.0
         self._update_volume(0)
-        self._last_tiprack_and_well = None
+        self._last_tip_rack_and_well = None
 
         if self._api_version < APIVersion(2, 2) and labware_core.is_tip_rack():
             # If this is a tiprack we can try and add the dirty tip back to the tracker
@@ -435,7 +435,7 @@ class LegacyInstrumentCoreSimulator(
     def get_last_well_tip_picked_up_from(
         self,
     ) -> Optional[Tuple[LegacyLabwareCore, LegacyWellCore]]:
-        return self._last_tiprack_and_well
+        return self._last_tip_rack_and_well
 
     def set_flow_rate(
         self,

--- a/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_instrument_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_instrument_core.py
@@ -272,6 +272,7 @@ class LegacyInstrumentCoreSimulator(
         self._pipette_dict["has_tip"] = False
         self._pipette_dict["tip_length"] = 0.0
         self._update_volume(0)
+        self._last_tiprack_and_well = None
 
         if self._api_version < APIVersion(2, 2) and labware_core.is_tip_rack():
             # If this is a tiprack we can try and add the dirty tip back to the tracker

--- a/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_instrument_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_instrument_core.py
@@ -428,7 +428,7 @@ class LegacyInstrumentCoreSimulator(
     def get_blow_out_flow_rate(self, rate: float = 1.0) -> float:
         return self._pipette_dict["blow_out_flow_rate"] * rate
 
-    def get_last_well_tip_picked_up_from(
+    def get_tip_origin(
         self,
     ) -> Optional[Tuple[LegacyLabwareCore, LegacyWellCore]]:
         return self._last_tip_rack_and_well

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1072,7 +1072,7 @@ class InstrumentContext(publisher.CommandPublisher):
         if not self._core.has_tip():
             _log.warning("Pipette has no tip to return")
 
-        loc = self._get_last_tip_rack_well()
+        loc = self.get_last_tip_rack_well_used()
 
         # TODO rewrite this error message
         if not isinstance(loc, labware.Well):
@@ -1848,7 +1848,7 @@ class InstrumentContext(publisher.CommandPublisher):
             source=source,
             dest=dest,
             tip_policy=new_tip,
-            last_tip_well=self._get_last_tip_rack_well(),
+            last_tip_well=self.get_last_tip_rack_well_used(),
             tip_racks=self._tip_racks,
             nozzle_map=self._core.get_nozzle_map(),
             group_wells_for_multi_channel=group_wells,
@@ -1977,7 +1977,7 @@ class InstrumentContext(publisher.CommandPublisher):
             source=source,
             dest=dest,
             tip_policy=new_tip,
-            last_tip_well=self._get_last_tip_rack_well(),
+            last_tip_well=self.get_last_tip_rack_well_used(),
             tip_racks=self._tip_racks,
             nozzle_map=self._core.get_nozzle_map(),
             group_wells_for_multi_channel=group_wells,
@@ -2115,7 +2115,7 @@ class InstrumentContext(publisher.CommandPublisher):
             source=source,
             dest=dest,
             tip_policy=new_tip,
-            last_tip_well=self._get_last_tip_rack_well(),
+            last_tip_well=self.get_last_tip_rack_well_used(),
             tip_racks=self._tip_racks,
             nozzle_map=self._core.get_nozzle_map(),
             group_wells_for_multi_channel=group_wells,
@@ -3107,15 +3107,20 @@ class InstrumentContext(publisher.CommandPublisher):
 
     @property
     def _last_tip_picked_up_from(self) -> Optional[labware.Well]:
-        """This exists to prevent old protocols that relied on this old internal variable from failing.
-
-        Normally we would enforce not relying on underscore variables/methods, but given this
-        variable's age and the lack of other ways to get this data previously, we'll continue
-        to support this.
         """
-        return self._get_last_tip_rack_well()
+        .. deprecated:: 2.26
+           Use :py:obj:`ProtocolContext.get_last_tip_rack_well_used` instead.
 
-    def _get_last_tip_rack_well(self) -> Optional[labware.Well]:
+           If the pipette has a tip on it, returns the tip rack well it was picked up from.
+           Otherwise will return ``None``.
+        """
+        return self.get_last_tip_rack_well_used()
+
+    def get_last_tip_rack_well_used(self) -> Optional[labware.Well]:
+        """Returns the tip rack well the current tip has been picked up from.
+
+        If there is no tip currently on the pipette, this will return ``None``.
+        """
         tip_rack_cores = self._core.get_last_well_tip_picked_up_from()
         if tip_rack_cores is None:
             return None

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -33,6 +33,7 @@ from opentrons.protocols.api_support.util import (
 )
 
 from .core.common import InstrumentCore, ProtocolCore, WellCore
+from .core.core_map import LoadedCoreMap
 from .core.engine import ENGINE_CORE_API_VERSION
 from .core.legacy.legacy_instrument_core import LegacyInstrumentCore
 from .config import Clearances
@@ -117,13 +118,13 @@ class InstrumentContext(publisher.CommandPublisher):
         tip_racks: List[labware.Labware],
         trash: Optional[Union[labware.Labware, TrashBin, WasteChute]],
         requested_as: str,
+        core_map: LoadedCoreMap,
     ) -> None:
         super().__init__(broker)
         self._api_version = api_version
         self._core = core
         self._protocol_core = protocol_core
         self._tip_racks = tip_racks
-        self._last_tip_picked_up_from: Union[labware.Well, None] = None
         self._starting_tip: Union[labware.Well, None] = None
         self._well_bottom_clearances = Clearances(
             default_aspirate=_DEFAULT_ASPIRATE_CLEARANCE,
@@ -133,6 +134,7 @@ class InstrumentContext(publisher.CommandPublisher):
             labware.Labware, TrashBin, WasteChute, None
         ] = trash
         self.requested_as = requested_as
+        self._core_map = core_map
 
     @property
     @requires_version(2, 0)
@@ -1070,8 +1072,9 @@ class InstrumentContext(publisher.CommandPublisher):
         if not self._core.has_tip():
             _log.warning("Pipette has no tip to return")
 
-        loc = self._last_tip_picked_up_from
+        loc = self._get_last_tiprack_well()
 
+        # TODO rewrite this error message
         if not isinstance(loc, labware.Well):
             raise TypeError(f"Last tip location should be a Well but it is: {loc}")
 
@@ -1312,8 +1315,6 @@ class InstrumentContext(publisher.CommandPublisher):
                 prep_after=prep_after,
             )
 
-        self._last_tip_picked_up_from = well
-
         return self
 
     @requires_version(2, 0)
@@ -1401,7 +1402,6 @@ class InstrumentContext(publisher.CommandPublisher):
                         home_after=home_after,
                         alternate_tip_drop=True,
                     )
-                self._last_tip_picked_up_from = None
                 return self
 
         elif isinstance(location, labware.Well):
@@ -1440,7 +1440,6 @@ class InstrumentContext(publisher.CommandPublisher):
                     home_after=home_after,
                     alternate_tip_drop=alternate_drop_location,
                 )
-            self._last_tip_picked_up_from = None
             return self
 
         else:
@@ -1462,7 +1461,6 @@ class InstrumentContext(publisher.CommandPublisher):
                 alternate_drop_location=alternate_drop_location,
             )
 
-        self._last_tip_picked_up_from = None
         return self
 
     @requires_version(2, 0)
@@ -1850,7 +1848,7 @@ class InstrumentContext(publisher.CommandPublisher):
             source=source,
             dest=dest,
             tip_policy=new_tip,
-            last_tip_well=self._last_tip_picked_up_from,
+            last_tip_well=self._get_last_tiprack_well(),
             tip_racks=self._tip_racks,
             nozzle_map=self._core.get_nozzle_map(),
             group_wells_for_multi_channel=group_wells,
@@ -1890,7 +1888,7 @@ class InstrumentContext(publisher.CommandPublisher):
                 destination=dest,
             ),
         ):
-            last_tip_location = self._core.transfer_with_liquid_class(
+            self._core.transfer_with_liquid_class(
                 liquid_class=liquid_class,
                 volume=volume,
                 source=[
@@ -1911,16 +1909,6 @@ class InstrumentContext(publisher.CommandPublisher):
                 keep_last_tip=verified_keep_last_tip,
                 last_tip_location=transfer_args.last_tip_location,
             )
-
-        # TODO(jbl 2025-06-23) last_tip_picked_up_from should be removed from the public context and
-        #   moved to the engine core or engine as a simpler and more holistic solution
-        if last_tip_location is not None:
-            tip_rack_loc, tip_well_core = last_tip_location
-            self._last_tip_picked_up_from = tip_rack_loc.labware.as_labware()[
-                tip_well_core.get_name()
-            ]
-        else:
-            self._last_tip_picked_up_from = None
 
         return self
 
@@ -1990,7 +1978,7 @@ class InstrumentContext(publisher.CommandPublisher):
             source=source,
             dest=dest,
             tip_policy=new_tip,
-            last_tip_well=self._last_tip_picked_up_from,
+            last_tip_well=self._get_last_tiprack_well(),
             tip_racks=self._tip_racks,
             nozzle_map=self._core.get_nozzle_map(),
             group_wells_for_multi_channel=group_wells,
@@ -2035,7 +2023,7 @@ class InstrumentContext(publisher.CommandPublisher):
                 destination=dest,
             ),
         ):
-            last_tip_location = self._core.distribute_with_liquid_class(
+            self._core.distribute_with_liquid_class(
                 liquid_class=liquid_class,
                 volume=volume,
                 source=(
@@ -2059,16 +2047,6 @@ class InstrumentContext(publisher.CommandPublisher):
                 keep_last_tip=verified_keep_last_tip,
                 last_tip_location=transfer_args.last_tip_location,
             )
-
-        # TODO(jbl 2025-06-23) last_tip_picked_up_from should be removed from the public context and
-        #   moved to the engine core or engine as a simpler and more holistic solution
-        if last_tip_location is not None:
-            tip_rack_loc, tip_well_core = last_tip_location
-            self._last_tip_picked_up_from = tip_rack_loc.labware.as_labware()[
-                tip_well_core.get_name()
-            ]
-        else:
-            self._last_tip_picked_up_from = None
 
         return self
 
@@ -2139,7 +2117,7 @@ class InstrumentContext(publisher.CommandPublisher):
             source=source,
             dest=dest,
             tip_policy=new_tip,
-            last_tip_well=self._last_tip_picked_up_from,
+            last_tip_well=self._get_last_tiprack_well(),
             tip_racks=self._tip_racks,
             nozzle_map=self._core.get_nozzle_map(),
             group_wells_for_multi_channel=group_wells,
@@ -2186,7 +2164,7 @@ class InstrumentContext(publisher.CommandPublisher):
                 destination=dest,
             ),
         ):
-            last_tip_location = self._core.consolidate_with_liquid_class(
+            self._core.consolidate_with_liquid_class(
                 liquid_class=liquid_class,
                 volume=volume,
                 source=[
@@ -2207,16 +2185,6 @@ class InstrumentContext(publisher.CommandPublisher):
                 keep_last_tip=verified_keep_last_tip,
                 last_tip_location=transfer_args.last_tip_location,
             )
-
-        # TODO(jbl 2025-06-23) last_tip_picked_up_from should be removed from the public context and
-        #   moved to the engine core or engine as a simpler and more holistic solution
-        if last_tip_location is not None:
-            tip_rack_loc, tip_well_core = last_tip_location
-            self._last_tip_picked_up_from = tip_rack_loc.labware.as_labware()[
-                tip_well_core.get_name()
-            ]
-        else:
-            self._last_tip_picked_up_from = None
 
         return self
 
@@ -3139,6 +3107,16 @@ class InstrumentContext(publisher.CommandPublisher):
                 )
         if isinstance(target, validation.PointTarget):
             return target.location, None, None
+
+    def _get_last_tiprack_well(self) -> Optional[labware.Well]:
+        tiprack_cores = self._core.get_last_well_tip_picked_up_from()
+        if tiprack_cores is None:
+            return None
+        labware_core, well_core = tiprack_cores
+        tiprack_labware = self._core_map.get(labware_core)
+        return labware.Well(
+            parent=tiprack_labware, core=well_core, api_version=self._api_version
+        )
 
 
 class AutoProbeDisable:

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -3118,7 +3118,7 @@ class InstrumentContext(publisher.CommandPublisher):
     @property
     def _last_tip_picked_up_from(self) -> Optional[labware.Well]:
         """
-        .. deprecated:: 2.26
+        .. deprecated:: 2.25
            Use :py:obj:`ProtocolContext.last_tip_rack_well_used` instead.
 
            If the pipette has a tip on it, returns the tip rack well it was picked up from.

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -3105,6 +3105,16 @@ class InstrumentContext(publisher.CommandPublisher):
         if isinstance(target, validation.PointTarget):
             return target.location, None, None
 
+    @property
+    def _last_tip_picked_up_from(self) -> Optional[labware.Well]:
+        """This exists to prevent old protocols that relied on this old internal variable from failing.
+
+        Normally we would enforce not relying on underscore variables/methods, but given this
+        variable's age and the lack of other ways to get this data previously, we'll continue
+        to support this.
+        """
+        return self._get_last_tiprack_well()
+
     def _get_last_tiprack_well(self) -> Optional[labware.Well]:
         tiprack_cores = self._core.get_last_well_tip_picked_up_from()
         if tiprack_cores is None:

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1072,7 +1072,7 @@ class InstrumentContext(publisher.CommandPublisher):
         if not self._core.has_tip():
             _log.warning("Pipette has no tip to return")
 
-        loc = self.get_last_tip_rack_well_used()
+        loc = self._get_last_tip_rack_well_used()
 
         # TODO rewrite this error message
         if not isinstance(loc, labware.Well):
@@ -1848,7 +1848,7 @@ class InstrumentContext(publisher.CommandPublisher):
             source=source,
             dest=dest,
             tip_policy=new_tip,
-            last_tip_well=self.get_last_tip_rack_well_used(),
+            last_tip_well=self._get_last_tip_rack_well_used(),
             tip_racks=self._tip_racks,
             nozzle_map=self._core.get_nozzle_map(),
             group_wells_for_multi_channel=group_wells,
@@ -1977,7 +1977,7 @@ class InstrumentContext(publisher.CommandPublisher):
             source=source,
             dest=dest,
             tip_policy=new_tip,
-            last_tip_well=self.get_last_tip_rack_well_used(),
+            last_tip_well=self._get_last_tip_rack_well_used(),
             tip_racks=self._tip_racks,
             nozzle_map=self._core.get_nozzle_map(),
             group_wells_for_multi_channel=group_wells,
@@ -2115,7 +2115,7 @@ class InstrumentContext(publisher.CommandPublisher):
             source=source,
             dest=dest,
             tip_policy=new_tip,
-            last_tip_well=self.get_last_tip_rack_well_used(),
+            last_tip_well=self._get_last_tip_rack_well_used(),
             tip_racks=self._tip_racks,
             nozzle_map=self._core.get_nozzle_map(),
             group_wells_for_multi_channel=group_wells,
@@ -3105,22 +3105,7 @@ class InstrumentContext(publisher.CommandPublisher):
         if isinstance(target, validation.PointTarget):
             return target.location, None, None
 
-    @property
-    def _last_tip_picked_up_from(self) -> Optional[labware.Well]:
-        """
-        .. deprecated:: 2.26
-           Use :py:obj:`ProtocolContext.get_last_tip_rack_well_used` instead.
-
-           If the pipette has a tip on it, returns the tip rack well it was picked up from.
-           Otherwise will return ``None``.
-        """
-        return self.get_last_tip_rack_well_used()
-
-    def get_last_tip_rack_well_used(self) -> Optional[labware.Well]:
-        """Returns the tip rack well the current tip has been picked up from.
-
-        If there is no tip currently on the pipette, this will return ``None``.
-        """
+    def _get_last_tip_rack_well_used(self) -> Optional[labware.Well]:
         tip_rack_cores = self._core.get_tip_origin()
         if tip_rack_cores is None:
             return None
@@ -3129,6 +3114,25 @@ class InstrumentContext(publisher.CommandPublisher):
         return labware.Well(
             parent=tip_rack_labware, core=well_core, api_version=self._api_version
         )
+
+    @property
+    def _last_tip_picked_up_from(self) -> Optional[labware.Well]:
+        """
+        .. deprecated:: 2.26
+           Use :py:obj:`ProtocolContext.last_tip_rack_well_used` instead.
+
+           If the pipette has a tip on it, returns the tip rack well it was picked up from.
+           Otherwise will return ``None``.
+        """
+        return self._get_last_tip_rack_well_used()
+
+    @requires_version(2, 25)
+    def last_tip_rack_well_used(self) -> Optional[labware.Well]:
+        """Returns the tip rack well the current tip has been picked up from.
+
+        If there is no tip currently on the pipette, this will return ``None``.
+        """
+        return self._get_last_tip_rack_well_used()
 
 
 class AutoProbeDisable:

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1072,7 +1072,7 @@ class InstrumentContext(publisher.CommandPublisher):
         if not self._core.has_tip():
             _log.warning("Pipette has no tip to return")
 
-        loc = self._get_last_tiprack_well()
+        loc = self._get_last_tip_rack_well()
 
         # TODO rewrite this error message
         if not isinstance(loc, labware.Well):
@@ -1848,7 +1848,7 @@ class InstrumentContext(publisher.CommandPublisher):
             source=source,
             dest=dest,
             tip_policy=new_tip,
-            last_tip_well=self._get_last_tiprack_well(),
+            last_tip_well=self._get_last_tip_rack_well(),
             tip_racks=self._tip_racks,
             nozzle_map=self._core.get_nozzle_map(),
             group_wells_for_multi_channel=group_wells,
@@ -1977,7 +1977,7 @@ class InstrumentContext(publisher.CommandPublisher):
             source=source,
             dest=dest,
             tip_policy=new_tip,
-            last_tip_well=self._get_last_tiprack_well(),
+            last_tip_well=self._get_last_tip_rack_well(),
             tip_racks=self._tip_racks,
             nozzle_map=self._core.get_nozzle_map(),
             group_wells_for_multi_channel=group_wells,
@@ -2115,7 +2115,7 @@ class InstrumentContext(publisher.CommandPublisher):
             source=source,
             dest=dest,
             tip_policy=new_tip,
-            last_tip_well=self._get_last_tiprack_well(),
+            last_tip_well=self._get_last_tip_rack_well(),
             tip_racks=self._tip_racks,
             nozzle_map=self._core.get_nozzle_map(),
             group_wells_for_multi_channel=group_wells,
@@ -3113,16 +3113,16 @@ class InstrumentContext(publisher.CommandPublisher):
         variable's age and the lack of other ways to get this data previously, we'll continue
         to support this.
         """
-        return self._get_last_tiprack_well()
+        return self._get_last_tip_rack_well()
 
-    def _get_last_tiprack_well(self) -> Optional[labware.Well]:
-        tiprack_cores = self._core.get_last_well_tip_picked_up_from()
-        if tiprack_cores is None:
+    def _get_last_tip_rack_well(self) -> Optional[labware.Well]:
+        tip_rack_cores = self._core.get_last_well_tip_picked_up_from()
+        if tip_rack_cores is None:
             return None
-        labware_core, well_core = tiprack_cores
-        tiprack_labware = self._core_map.get(labware_core)
+        labware_core, well_core = tip_rack_cores
+        tip_rack_labware = self._core_map.get(labware_core)
         return labware.Well(
-            parent=tiprack_labware, core=well_core, api_version=self._api_version
+            parent=tip_rack_labware, core=well_core, api_version=self._api_version
         )
 
 

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -3121,7 +3121,7 @@ class InstrumentContext(publisher.CommandPublisher):
 
         If there is no tip currently on the pipette, this will return ``None``.
         """
-        tip_rack_cores = self._core.get_last_well_tip_picked_up_from()
+        tip_rack_cores = self._core.get_tip_origin()
         if tip_rack_cores is None:
             return None
         labware_core, well_core = tip_rack_cores

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1907,7 +1907,6 @@ class InstrumentContext(publisher.CommandPublisher):
                 trash_location=transfer_args.trash_location,
                 return_tip=return_tip,
                 keep_last_tip=verified_keep_last_tip,
-                last_tip_location=transfer_args.last_tip_location,
             )
 
         return self
@@ -2045,7 +2044,6 @@ class InstrumentContext(publisher.CommandPublisher):
                 trash_location=transfer_args.trash_location,
                 return_tip=return_tip,
                 keep_last_tip=verified_keep_last_tip,
-                last_tip_location=transfer_args.last_tip_location,
             )
 
         return self
@@ -2183,7 +2181,6 @@ class InstrumentContext(publisher.CommandPublisher):
                 trash_location=transfer_args.trash_location,
                 return_tip=return_tip,
                 keep_last_tip=verified_keep_last_tip,
-                last_tip_location=transfer_args.last_tip_location,
             )
 
         return self

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1072,7 +1072,7 @@ class InstrumentContext(publisher.CommandPublisher):
         if not self._core.has_tip():
             _log.warning("Pipette has no tip to return")
 
-        loc = self._get_last_tip_rack_well_used()
+        loc = self._get_current_tip_source_well()
 
         # TODO rewrite this error message
         if not isinstance(loc, labware.Well):
@@ -1848,7 +1848,7 @@ class InstrumentContext(publisher.CommandPublisher):
             source=source,
             dest=dest,
             tip_policy=new_tip,
-            last_tip_well=self._get_last_tip_rack_well_used(),
+            last_tip_well=self._get_current_tip_source_well(),
             tip_racks=self._tip_racks,
             nozzle_map=self._core.get_nozzle_map(),
             group_wells_for_multi_channel=group_wells,
@@ -1977,7 +1977,7 @@ class InstrumentContext(publisher.CommandPublisher):
             source=source,
             dest=dest,
             tip_policy=new_tip,
-            last_tip_well=self._get_last_tip_rack_well_used(),
+            last_tip_well=self._get_current_tip_source_well(),
             tip_racks=self._tip_racks,
             nozzle_map=self._core.get_nozzle_map(),
             group_wells_for_multi_channel=group_wells,
@@ -2115,7 +2115,7 @@ class InstrumentContext(publisher.CommandPublisher):
             source=source,
             dest=dest,
             tip_policy=new_tip,
-            last_tip_well=self._get_last_tip_rack_well_used(),
+            last_tip_well=self._get_current_tip_source_well(),
             tip_racks=self._tip_racks,
             nozzle_map=self._core.get_nozzle_map(),
             group_wells_for_multi_channel=group_wells,
@@ -3105,7 +3105,7 @@ class InstrumentContext(publisher.CommandPublisher):
         if isinstance(target, validation.PointTarget):
             return target.location, None, None
 
-    def _get_last_tip_rack_well_used(self) -> Optional[labware.Well]:
+    def _get_current_tip_source_well(self) -> Optional[labware.Well]:
         tip_rack_cores = self._core.get_tip_origin()
         if tip_rack_cores is None:
             return None
@@ -3119,20 +3119,20 @@ class InstrumentContext(publisher.CommandPublisher):
     def _last_tip_picked_up_from(self) -> Optional[labware.Well]:
         """
         .. deprecated:: 2.25
-           Use :py:obj:`ProtocolContext.last_tip_rack_well_used` instead.
+           Use :py:obj:`ProtocolContext.current_tip_source_well` instead.
 
            If the pipette has a tip on it, returns the tip rack well it was picked up from.
            Otherwise will return ``None``.
         """
-        return self._get_last_tip_rack_well_used()
+        return self._get_current_tip_source_well()
 
     @requires_version(2, 25)
-    def last_tip_rack_well_used(self) -> Optional[labware.Well]:
+    def current_tip_source_well(self) -> Optional[labware.Well]:
         """Returns the tip rack well the current tip has been picked up from.
 
         If there is no tip currently on the pipette, this will return ``None``.
         """
-        return self._get_last_tip_rack_well_used()
+        return self._get_current_tip_source_well()
 
 
 class AutoProbeDisable:

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -1091,6 +1091,7 @@ class ProtocolContext(CommandPublisher):
             tip_racks=tip_racks,
             trash=trash,
             requested_as=instrument_name,
+            core_map=self._core_map,
         )
 
         self._instruments[checked_mount] = instrument

--- a/api/src/opentrons/protocol_engine/commands/drop_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/drop_tip.py
@@ -191,7 +191,9 @@ class DropTipImplementation(AbstractCommandImpl[DropTipParams, _ExecuteReturn]):
                     StateUpdate(), move_result.state_update
                 ).set_fluid_unknown(pipette_id=pipette_id),
                 state_update_if_false_positive=move_result.state_update.update_pipette_tip_state(
-                    pipette_id=params.pipetteId, tip_geometry=None
+                    pipette_id=params.pipetteId,
+                    tip_geometry=None,
+                    well_picked_up_from=None,
                 ),
             )
         else:
@@ -200,7 +202,9 @@ class DropTipImplementation(AbstractCommandImpl[DropTipParams, _ExecuteReturn]):
                 state_update=move_result.state_update.set_fluid_unknown(
                     pipette_id=pipette_id
                 ).update_pipette_tip_state(
-                    pipette_id=params.pipetteId, tip_geometry=None
+                    pipette_id=params.pipetteId,
+                    tip_geometry=None,
+                    well_picked_up_from=None,
                 ),
             )
 

--- a/api/src/opentrons/protocol_engine/commands/drop_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/drop_tip.py
@@ -193,7 +193,7 @@ class DropTipImplementation(AbstractCommandImpl[DropTipParams, _ExecuteReturn]):
                 state_update_if_false_positive=move_result.state_update.update_pipette_tip_state(
                     pipette_id=params.pipetteId,
                     tip_geometry=None,
-                    well_picked_up_from=None,
+                    tip_source=None,
                 ),
             )
         else:
@@ -204,7 +204,7 @@ class DropTipImplementation(AbstractCommandImpl[DropTipParams, _ExecuteReturn]):
                 ).update_pipette_tip_state(
                     pipette_id=params.pipetteId,
                     tip_geometry=None,
-                    well_picked_up_from=None,
+                    tip_source=None,
                 ),
             )
 

--- a/api/src/opentrons/protocol_engine/commands/drop_tip_in_place.py
+++ b/api/src/opentrons/protocol_engine/commands/drop_tip_in_place.py
@@ -100,7 +100,7 @@ class DropTipInPlaceImplementation(
             state_update_if_false_positive.update_pipette_tip_state(
                 pipette_id=params.pipetteId,
                 tip_geometry=None,
-                well_picked_up_from=None,
+                tip_source=None,
             )
             state_update.set_fluid_unknown(pipette_id=params.pipetteId)
             error = TipPhysicallyAttachedError(
@@ -125,7 +125,7 @@ class DropTipInPlaceImplementation(
             state_update_if_false_positive.update_pipette_tip_state(
                 pipette_id=params.pipetteId,
                 tip_geometry=None,
-                well_picked_up_from=None,
+                tip_source=None,
             )
             state_update.set_fluid_unknown(pipette_id=params.pipetteId)
             return DefinedErrorData(
@@ -149,7 +149,7 @@ class DropTipInPlaceImplementation(
             state_update_if_false_positive.update_pipette_tip_state(
                 pipette_id=params.pipetteId,
                 tip_geometry=None,
-                well_picked_up_from=None,
+                tip_source=None,
             )
             state_update.set_fluid_unknown(pipette_id=params.pipetteId)
             return DefinedErrorData(
@@ -173,7 +173,7 @@ class DropTipInPlaceImplementation(
             state_update.update_pipette_tip_state(
                 pipette_id=params.pipetteId,
                 tip_geometry=None,
-                well_picked_up_from=None,
+                tip_source=None,
             )
             return SuccessData(public=DropTipInPlaceResult(), state_update=state_update)
 

--- a/api/src/opentrons/protocol_engine/commands/drop_tip_in_place.py
+++ b/api/src/opentrons/protocol_engine/commands/drop_tip_in_place.py
@@ -98,7 +98,9 @@ class DropTipInPlaceImplementation(
         except TipAttachedError as exception:
             state_update_if_false_positive = update_types.StateUpdate()
             state_update_if_false_positive.update_pipette_tip_state(
-                pipette_id=params.pipetteId, tip_geometry=None
+                pipette_id=params.pipetteId,
+                tip_geometry=None,
+                well_picked_up_from=None,
             )
             state_update.set_fluid_unknown(pipette_id=params.pipetteId)
             error = TipPhysicallyAttachedError(
@@ -121,7 +123,9 @@ class DropTipInPlaceImplementation(
         except PipetteOverpressureError as exception:
             state_update_if_false_positive = update_types.StateUpdate()
             state_update_if_false_positive.update_pipette_tip_state(
-                pipette_id=params.pipetteId, tip_geometry=None
+                pipette_id=params.pipetteId,
+                tip_geometry=None,
+                well_picked_up_from=None,
             )
             state_update.set_fluid_unknown(pipette_id=params.pipetteId)
             return DefinedErrorData(
@@ -143,7 +147,9 @@ class DropTipInPlaceImplementation(
         except StallOrCollisionDetectedError as exception:
             state_update_if_false_positive = update_types.StateUpdate()
             state_update_if_false_positive.update_pipette_tip_state(
-                pipette_id=params.pipetteId, tip_geometry=None
+                pipette_id=params.pipetteId,
+                tip_geometry=None,
+                well_picked_up_from=None,
             )
             state_update.set_fluid_unknown(pipette_id=params.pipetteId)
             return DefinedErrorData(
@@ -165,7 +171,9 @@ class DropTipInPlaceImplementation(
         else:
             state_update.set_fluid_unknown(pipette_id=params.pipetteId)
             state_update.update_pipette_tip_state(
-                pipette_id=params.pipetteId, tip_geometry=None
+                pipette_id=params.pipetteId,
+                tip_geometry=None,
+                well_picked_up_from=None,
             )
             return SuccessData(public=DropTipInPlaceResult(), state_update=state_update)
 

--- a/api/src/opentrons/protocol_engine/commands/pick_up_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/pick_up_tip.py
@@ -10,7 +10,7 @@ from typing_extensions import Literal
 from ..errors import ErrorOccurrence, PickUpTipTipNotAttachedError
 from ..resources import ModelUtils
 from ..state import update_types
-from ..types import PickUpTipWellLocation
+from ..types import PickUpTipWellLocation, LabwareWellId
 from .pipetting_common import (
     PipetteIdMixin,
 )
@@ -155,7 +155,7 @@ class PickUpTipImplementation(AbstractCommandImpl[PickUpTipParams, _ExecuteRetur
                 .update_pipette_tip_state(
                     pipette_id=pipette_id,
                     tip_geometry=e.tip_geometry,
-                    well_picked_up_from=update_types.Well(
+                    well_picked_up_from=LabwareWellId(
                         labware_id=labware_id, well_name=well_name
                     ),
                 )
@@ -193,7 +193,7 @@ class PickUpTipImplementation(AbstractCommandImpl[PickUpTipParams, _ExecuteRetur
                 move_result.state_update.update_pipette_tip_state(
                     pipette_id=pipette_id,
                     tip_geometry=tip_geometry,
-                    well_picked_up_from=update_types.Well(
+                    well_picked_up_from=LabwareWellId(
                         labware_id=labware_id, well_name=well_name
                     ),
                 )

--- a/api/src/opentrons/protocol_engine/commands/pick_up_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/pick_up_tip.py
@@ -155,7 +155,7 @@ class PickUpTipImplementation(AbstractCommandImpl[PickUpTipParams, _ExecuteRetur
                 .update_pipette_tip_state(
                     pipette_id=pipette_id,
                     tip_geometry=e.tip_geometry,
-                    well_picked_up_from=LabwareWellId(
+                    tip_source=LabwareWellId(
                         labware_id=labware_id, well_name=well_name
                     ),
                 )
@@ -193,7 +193,7 @@ class PickUpTipImplementation(AbstractCommandImpl[PickUpTipParams, _ExecuteRetur
                 move_result.state_update.update_pipette_tip_state(
                     pipette_id=pipette_id,
                     tip_geometry=tip_geometry,
-                    well_picked_up_from=LabwareWellId(
+                    tip_source=LabwareWellId(
                         labware_id=labware_id, well_name=well_name
                     ),
                 )

--- a/api/src/opentrons/protocol_engine/commands/pick_up_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/pick_up_tip.py
@@ -155,6 +155,9 @@ class PickUpTipImplementation(AbstractCommandImpl[PickUpTipParams, _ExecuteRetur
                 .update_pipette_tip_state(
                     pipette_id=pipette_id,
                     tip_geometry=e.tip_geometry,
+                    well_picked_up_from=update_types.Well(
+                        labware_id=labware_id, well_name=well_name
+                    ),
                 )
                 .set_fluid_empty(pipette_id=pipette_id, clean_tip=True)
                 .mark_tips_as_used(
@@ -190,6 +193,9 @@ class PickUpTipImplementation(AbstractCommandImpl[PickUpTipParams, _ExecuteRetur
                 move_result.state_update.update_pipette_tip_state(
                     pipette_id=pipette_id,
                     tip_geometry=tip_geometry,
+                    well_picked_up_from=update_types.Well(
+                        labware_id=labware_id, well_name=well_name
+                    ),
                 )
                 .mark_tips_as_used(
                     labware_id=labware_id, well_names=tips_to_mark_as_used

--- a/api/src/opentrons/protocol_engine/commands/seal_pipette_to_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/seal_pipette_to_tip.py
@@ -310,9 +310,7 @@ class SealPipetteToTipImplementation(
         state_update = move_result.state_update.update_pipette_tip_state(
             pipette_id=pipette_id,
             tip_geometry=tip_geometry,
-            well_picked_up_from=LabwareWellId(
-                labware_id=labware_id, well_name=well_name
-            ),
+            tip_source=LabwareWellId(labware_id=labware_id, well_name=well_name),
         ).set_fluid_aspirated(
             pipette_id=pipette_id,
             fluid=AspiratedFluid(kind=FluidKind.LIQUID, volume=_SAFE_TOP_VOLUME),

--- a/api/src/opentrons/protocol_engine/commands/seal_pipette_to_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/seal_pipette_to_tip.py
@@ -12,6 +12,7 @@ from opentrons.types import MountType
 from opentrons.protocol_engine.types import MotorAxis
 from ..resources import ModelUtils, ensure_ot3_hardware
 from ..types import PickUpTipWellLocation, FluidKind, AspiratedFluid
+from ..state.update_types import Well
 from .pipetting_common import (
     PipetteIdMixin,
 )
@@ -310,6 +311,7 @@ class SealPipetteToTipImplementation(
         state_update = move_result.state_update.update_pipette_tip_state(
             pipette_id=pipette_id,
             tip_geometry=tip_geometry,
+            well_picked_up_from=Well(labware_id=labware_id, well_name=well_name),
         ).set_fluid_aspirated(
             pipette_id=pipette_id,
             fluid=AspiratedFluid(kind=FluidKind.LIQUID, volume=_SAFE_TOP_VOLUME),

--- a/api/src/opentrons/protocol_engine/commands/seal_pipette_to_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/seal_pipette_to_tip.py
@@ -11,8 +11,7 @@ from opentrons_shared_data.errors.exceptions import PositionUnknownError
 from opentrons.types import MountType
 from opentrons.protocol_engine.types import MotorAxis
 from ..resources import ModelUtils, ensure_ot3_hardware
-from ..types import PickUpTipWellLocation, FluidKind, AspiratedFluid
-from ..state.update_types import Well
+from ..types import PickUpTipWellLocation, FluidKind, AspiratedFluid, LabwareWellId
 from .pipetting_common import (
     PipetteIdMixin,
 )
@@ -311,7 +310,9 @@ class SealPipetteToTipImplementation(
         state_update = move_result.state_update.update_pipette_tip_state(
             pipette_id=pipette_id,
             tip_geometry=tip_geometry,
-            well_picked_up_from=Well(labware_id=labware_id, well_name=well_name),
+            well_picked_up_from=LabwareWellId(
+                labware_id=labware_id, well_name=well_name
+            ),
         ).set_fluid_aspirated(
             pipette_id=pipette_id,
             fluid=AspiratedFluid(kind=FluidKind.LIQUID, volume=_SAFE_TOP_VOLUME),

--- a/api/src/opentrons/protocol_engine/commands/unsafe/unsafe_drop_tip_in_place.py
+++ b/api/src/opentrons/protocol_engine/commands/unsafe/unsafe_drop_tip_in_place.py
@@ -87,7 +87,9 @@ class UnsafeDropTipInPlaceImplementation(
 
         state_update = StateUpdate()
         state_update.update_pipette_tip_state(
-            pipette_id=params.pipetteId, tip_geometry=None
+            pipette_id=params.pipetteId,
+            tip_geometry=None,
+            well_picked_up_from=None,
         )
         state_update.set_fluid_unknown(pipette_id=params.pipetteId)
 

--- a/api/src/opentrons/protocol_engine/commands/unsafe/unsafe_drop_tip_in_place.py
+++ b/api/src/opentrons/protocol_engine/commands/unsafe/unsafe_drop_tip_in_place.py
@@ -89,7 +89,7 @@ class UnsafeDropTipInPlaceImplementation(
         state_update.update_pipette_tip_state(
             pipette_id=params.pipetteId,
             tip_geometry=None,
-            well_picked_up_from=None,
+            tip_source=None,
         )
         state_update.set_fluid_unknown(pipette_id=params.pipetteId)
 

--- a/api/src/opentrons/protocol_engine/commands/unseal_pipette_from_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/unseal_pipette_from_tip.py
@@ -122,7 +122,9 @@ class UnsealPipetteFromTipImplementation(
             public=UnsealPipetteFromTipResult(position=move_result.public.position),
             state_update=move_result.state_update.set_fluid_unknown(
                 pipette_id=pipette_id
-            ).update_pipette_tip_state(pipette_id=params.pipetteId, tip_geometry=None),
+            ).update_pipette_tip_state(
+                pipette_id=params.pipetteId, tip_geometry=None, well_picked_up_from=None
+            ),
         )
 
 

--- a/api/src/opentrons/protocol_engine/commands/unseal_pipette_from_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/unseal_pipette_from_tip.py
@@ -123,7 +123,7 @@ class UnsealPipetteFromTipImplementation(
             state_update=move_result.state_update.set_fluid_unknown(
                 pipette_id=pipette_id
             ).update_pipette_tip_state(
-                pipette_id=params.pipetteId, tip_geometry=None, well_picked_up_from=None
+                pipette_id=params.pipetteId, tip_geometry=None, tip_source=None
             ),
         )
 

--- a/api/src/opentrons/protocol_engine/state/pipettes.py
+++ b/api/src/opentrons/protocol_engine/state/pipettes.py
@@ -128,7 +128,7 @@ class PipetteState:
     liquid_presence_detection_by_id: Dict[str, bool]
     ready_to_aspirate_by_id: Dict[str, bool]
     has_clean_tips_by_id: Dict[str, bool]
-    last_tip_rack_well_by_id: Dict[str, Optional[LabwareWellId]]
+    tip_source_by_id: Dict[str, Optional[LabwareWellId]]
 
 
 class PipetteStore(HasState[PipetteState], HandlesActions):
@@ -151,7 +151,7 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
             liquid_presence_detection_by_id={},
             ready_to_aspirate_by_id={},
             has_clean_tips_by_id={},
-            last_tip_rack_well_by_id={},
+            tip_source_by_id={},
         )
 
     def handle_action(self, action: Action) -> None:
@@ -183,7 +183,7 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
             self._state.movement_speed_by_id[pipette_id] = None
             self._state.attached_tip_by_id[pipette_id] = None
             self._state.ready_to_aspirate_by_id[pipette_id] = False
-            self._state.last_tip_rack_well_by_id[pipette_id] = None
+            self._state.tip_source_by_id[pipette_id] = None
 
     def _update_tip_state(self, state_update: update_types.StateUpdate) -> None:
         if state_update.pipette_tip_state != update_types.NO_CHANGE:
@@ -192,9 +192,9 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
                 attached_tip = state_update.pipette_tip_state.tip_geometry
 
                 self._state.attached_tip_by_id[pipette_id] = attached_tip
-                self._state.last_tip_rack_well_by_id[
+                self._state.tip_source_by_id[
                     pipette_id
-                ] = state_update.pipette_tip_state.well_picked_up_from
+                ] = state_update.pipette_tip_state.tip_source
 
                 static_config = self._state.static_config_by_id.get(pipette_id)
                 if static_config:
@@ -223,7 +223,7 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
                 pipette_id = state_update.pipette_tip_state.pipette_id
                 self._state.attached_tip_by_id[pipette_id] = None
                 self._state.has_clean_tips_by_id[pipette_id] = False
-                self._state.last_tip_rack_well_by_id[pipette_id] = None
+                self._state.tip_source_by_id[pipette_id] = None
 
                 static_config = self._state.static_config_by_id.get(pipette_id)
                 if static_config:
@@ -489,7 +489,7 @@ class PipetteView:
     ) -> Optional[LabwareWellId]:
         """Get the tip rack well a tip has been has picked up from, if there currently is a tip attached."""
         try:
-            return self._state.last_tip_rack_well_by_id[pipette_id]
+            return self._state.tip_source_by_id[pipette_id]
         except KeyError as e:
             raise errors.PipetteNotLoadedError(
                 f"Pipette {pipette_id} no found; unable to get last tip rack well accessed."

--- a/api/src/opentrons/protocol_engine/state/pipettes.py
+++ b/api/src/opentrons/protocol_engine/state/pipettes.py
@@ -127,6 +127,9 @@ class PipetteState:
     liquid_presence_detection_by_id: Dict[str, bool]
     ready_to_aspirate_by_id: Dict[str, bool]
     has_clean_tips_by_id: Dict[str, bool]
+    last_tiprack_well_by_id: Dict[
+        str, Optional[Tuple[str, str]]
+    ]  # TODO make this another type?
 
 
 class PipetteStore(HasState[PipetteState], HandlesActions):
@@ -149,6 +152,7 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
             liquid_presence_detection_by_id={},
             ready_to_aspirate_by_id={},
             has_clean_tips_by_id={},
+            last_tiprack_well_by_id={},
         )
 
     def handle_action(self, action: Action) -> None:
@@ -186,8 +190,14 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
             pipette_id = state_update.pipette_tip_state.pipette_id
             if state_update.pipette_tip_state.tip_geometry:
                 attached_tip = state_update.pipette_tip_state.tip_geometry
+                last_well = state_update.pipette_tip_state.well_picked_up_from
+                assert last_well is not None
 
                 self._state.attached_tip_by_id[pipette_id] = attached_tip
+                self._state.last_tiprack_well_by_id[pipette_id] = (
+                    last_well.labware_id,
+                    last_well.well_name,
+                )
 
                 static_config = self._state.static_config_by_id.get(pipette_id)
                 if static_config:
@@ -216,6 +226,7 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
                 pipette_id = state_update.pipette_tip_state.pipette_id
                 self._state.attached_tip_by_id[pipette_id] = None
                 self._state.has_clean_tips_by_id[pipette_id] = False
+                self._state.last_tiprack_well_by_id[pipette_id] = None
 
                 static_config = self._state.static_config_by_id.get(pipette_id)
                 if static_config:
@@ -475,6 +486,17 @@ class PipetteView:
             for pipette_id, tip in self._state.attached_tip_by_id.items()
             if tip is not None
         ]
+
+    def get_last_tiprack_well_picked_up_from(
+        self, pipette_id: str
+    ) -> Optional[Tuple[str, str]]:
+        """Get the last tiprack well a tip has been has picked up from, if there currently is a tip attached."""
+        try:
+            return self._state.last_tiprack_well_by_id[pipette_id]
+        except KeyError as e:
+            raise errors.PipetteNotLoadedError(
+                f"Pipette {pipette_id} no found; unable to get last tiprack well."
+            ) from e
 
     def get_aspirated_volume(self, pipette_id: str) -> Optional[float]:
         """Get the currently aspirated volume of a pipette by ID.

--- a/api/src/opentrons/protocol_engine/state/pipettes.py
+++ b/api/src/opentrons/protocol_engine/state/pipettes.py
@@ -127,7 +127,7 @@ class PipetteState:
     liquid_presence_detection_by_id: Dict[str, bool]
     ready_to_aspirate_by_id: Dict[str, bool]
     has_clean_tips_by_id: Dict[str, bool]
-    last_tiprack_well_by_id: Dict[
+    last_tip_rack_well_by_id: Dict[
         str, Optional[Tuple[str, str]]
     ]  # TODO make this another type?
 
@@ -152,7 +152,7 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
             liquid_presence_detection_by_id={},
             ready_to_aspirate_by_id={},
             has_clean_tips_by_id={},
-            last_tiprack_well_by_id={},
+            last_tip_rack_well_by_id={},
         )
 
     def handle_action(self, action: Action) -> None:
@@ -184,7 +184,7 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
             self._state.movement_speed_by_id[pipette_id] = None
             self._state.attached_tip_by_id[pipette_id] = None
             self._state.ready_to_aspirate_by_id[pipette_id] = False
-            self._state.last_tiprack_well_by_id[pipette_id] = None
+            self._state.last_tip_rack_well_by_id[pipette_id] = None
 
     def _update_tip_state(self, state_update: update_types.StateUpdate) -> None:
         if state_update.pipette_tip_state != update_types.NO_CHANGE:
@@ -195,7 +195,7 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
                 assert last_well is not None
 
                 self._state.attached_tip_by_id[pipette_id] = attached_tip
-                self._state.last_tiprack_well_by_id[pipette_id] = (
+                self._state.last_tip_rack_well_by_id[pipette_id] = (
                     last_well.labware_id,
                     last_well.well_name,
                 )
@@ -227,7 +227,7 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
                 pipette_id = state_update.pipette_tip_state.pipette_id
                 self._state.attached_tip_by_id[pipette_id] = None
                 self._state.has_clean_tips_by_id[pipette_id] = False
-                self._state.last_tiprack_well_by_id[pipette_id] = None
+                self._state.last_tip_rack_well_by_id[pipette_id] = None
 
                 static_config = self._state.static_config_by_id.get(pipette_id)
                 if static_config:
@@ -488,15 +488,15 @@ class PipetteView:
             if tip is not None
         ]
 
-    def get_last_tiprack_well_picked_up_from(
+    def get_tip_rack_well_picked_up_from(
         self, pipette_id: str
     ) -> Optional[Tuple[str, str]]:
-        """Get the last tiprack well a tip has been has picked up from, if there currently is a tip attached."""
+        """Get the tip rack well a tip has been has picked up from, if there currently is a tip attached."""
         try:
-            return self._state.last_tiprack_well_by_id[pipette_id]
+            return self._state.last_tip_rack_well_by_id[pipette_id]
         except KeyError as e:
             raise errors.PipetteNotLoadedError(
-                f"Pipette {pipette_id} no found; unable to get last tiprack well."
+                f"Pipette {pipette_id} no found; unable to get last tip rack well accessed."
             ) from e
 
     def get_aspirated_volume(self, pipette_id: str) -> Optional[float]:

--- a/api/src/opentrons/protocol_engine/state/pipettes.py
+++ b/api/src/opentrons/protocol_engine/state/pipettes.py
@@ -128,9 +128,7 @@ class PipetteState:
     liquid_presence_detection_by_id: Dict[str, bool]
     ready_to_aspirate_by_id: Dict[str, bool]
     has_clean_tips_by_id: Dict[str, bool]
-    last_tip_rack_well_by_id: Dict[
-        str, Optional[Tuple[str, str]]
-    ]  # TODO make this another type?
+    last_tip_rack_well_by_id: Dict[str, Optional[LabwareWellId]]
 
 
 class PipetteStore(HasState[PipetteState], HandlesActions):
@@ -192,14 +190,11 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
             pipette_id = state_update.pipette_tip_state.pipette_id
             if state_update.pipette_tip_state.tip_geometry:
                 attached_tip = state_update.pipette_tip_state.tip_geometry
-                last_well = state_update.pipette_tip_state.well_picked_up_from
-                assert last_well is not None
 
                 self._state.attached_tip_by_id[pipette_id] = attached_tip
-                self._state.last_tip_rack_well_by_id[pipette_id] = (
-                    last_well.labware_id,
-                    last_well.well_name,
-                )
+                self._state.last_tip_rack_well_by_id[
+                    pipette_id
+                ] = state_update.pipette_tip_state.well_picked_up_from
 
                 static_config = self._state.static_config_by_id.get(pipette_id)
                 if static_config:
@@ -491,7 +486,7 @@ class PipetteView:
 
     def get_tip_rack_well_picked_up_from(
         self, pipette_id: str
-    ) -> Optional[Tuple[str, str]]:
+    ) -> Optional[LabwareWellId]:
         """Get the tip rack well a tip has been has picked up from, if there currently is a tip attached."""
         try:
             return self._state.last_tip_rack_well_by_id[pipette_id]

--- a/api/src/opentrons/protocol_engine/state/pipettes.py
+++ b/api/src/opentrons/protocol_engine/state/pipettes.py
@@ -184,6 +184,7 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
             self._state.movement_speed_by_id[pipette_id] = None
             self._state.attached_tip_by_id[pipette_id] = None
             self._state.ready_to_aspirate_by_id[pipette_id] = False
+            self._state.last_tiprack_well_by_id[pipette_id] = None
 
     def _update_tip_state(self, state_update: update_types.StateUpdate) -> None:
         if state_update.pipette_tip_state != update_types.NO_CHANGE:

--- a/api/src/opentrons/protocol_engine/state/pipettes.py
+++ b/api/src/opentrons/protocol_engine/state/pipettes.py
@@ -38,6 +38,7 @@ from ..types import (
     CurrentAddressableArea,
     CurrentPipetteLocation,
     TipGeometry,
+    LabwareWellId,
 )
 from ..actions import (
     Action,
@@ -255,7 +256,7 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
             new_logical_location = location_update.new_location
             new_deck_point = location_update.new_deck_point
             match new_logical_location:
-                case update_types.Well(labware_id=labware_id, well_name=well_name):
+                case LabwareWellId(labware_id=labware_id, well_name=well_name):
                     self._state.current_location = CurrentWell(
                         pipette_id=location_update.pipette_id,
                         labware_id=labware_id,

--- a/api/src/opentrons/protocol_engine/state/update_types.py
+++ b/api/src/opentrons/protocol_engine/state/update_types.py
@@ -230,6 +230,7 @@ class PipetteTipStateUpdate:
 
     pipette_id: str
     tip_geometry: TipGeometry | None
+    well_picked_up_from: Well | None
 
 
 @dataclasses.dataclass
@@ -720,11 +721,16 @@ class StateUpdate:
         return self
 
     def update_pipette_tip_state(
-        self: Self, pipette_id: str, tip_geometry: TipGeometry | None
+        self: Self,
+        pipette_id: str,
+        tip_geometry: TipGeometry | None,
+        well_picked_up_from: Well | None,
     ) -> Self:
         """Update a pipette's tip state. See `PipetteTipStateUpdate`."""
         self.pipette_tip_state = PipetteTipStateUpdate(
-            pipette_id=pipette_id, tip_geometry=tip_geometry
+            pipette_id=pipette_id,
+            tip_geometry=tip_geometry,
+            well_picked_up_from=well_picked_up_from,
         )
         return self
 

--- a/api/src/opentrons/protocol_engine/state/update_types.py
+++ b/api/src/opentrons/protocol_engine/state/update_types.py
@@ -223,7 +223,7 @@ class PipetteTipStateUpdate:
 
     pipette_id: str
     tip_geometry: TipGeometry | None
-    well_picked_up_from: LabwareWellId | None
+    tip_source: LabwareWellId | None
 
 
 @dataclasses.dataclass
@@ -719,13 +719,13 @@ class StateUpdate:
         self: Self,
         pipette_id: str,
         tip_geometry: TipGeometry | None,
-        well_picked_up_from: LabwareWellId | None,
+        tip_source: LabwareWellId | None,
     ) -> Self:
         """Update a pipette's tip state. See `PipetteTipStateUpdate`."""
         self.pipette_tip_state = PipetteTipStateUpdate(
             pipette_id=pipette_id,
             tip_geometry=tip_geometry,
-            well_picked_up_from=well_picked_up_from,
+            tip_source=tip_source,
         )
         return self
 

--- a/api/src/opentrons/protocol_engine/state/update_types.py
+++ b/api/src/opentrons/protocol_engine/state/update_types.py
@@ -22,6 +22,7 @@ from opentrons.protocol_engine.types import (
     StackerStoredLabwareGroup,
     ModuleModel,
     ModuleDefinition,
+    LabwareWellId,
 )
 from opentrons.types import MountType, DeckSlotName
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition
@@ -65,14 +66,6 @@ Unfortunately, mypy doesn't let us write `Literal[CLEAR]`. Use this instead.
 
 
 @dataclasses.dataclass(frozen=True)
-class Well:
-    """Designates a well in a labware."""
-
-    labware_id: str
-    well_name: str
-
-
-@dataclasses.dataclass(frozen=True)
 class AddressableArea:
     """Designates an addressable area."""
 
@@ -86,7 +79,7 @@ class PipetteLocationUpdate:
     pipette_id: str
     """The ID of the already-loaded pipette."""
 
-    new_location: Well | AddressableArea | None | NoChangeType
+    new_location: LabwareWellId | AddressableArea | None | NoChangeType
     """The pipette's new logical location.
 
     Note: `new_location=None` means "change the location to `None` (unknown)",
@@ -230,7 +223,7 @@ class PipetteTipStateUpdate:
 
     pipette_id: str
     tip_geometry: TipGeometry | None
-    well_picked_up_from: Well | None
+    well_picked_up_from: LabwareWellId | None
 
 
 @dataclasses.dataclass
@@ -563,7 +556,9 @@ class StateUpdate:
         else:
             self.pipette_location = PipetteLocationUpdate(
                 pipette_id=pipette_id,
-                new_location=Well(labware_id=new_labware_id, well_name=new_well_name),
+                new_location=LabwareWellId(
+                    labware_id=new_labware_id, well_name=new_well_name
+                ),
                 new_deck_point=new_deck_point,
             )
         return self
@@ -724,7 +719,7 @@ class StateUpdate:
         self: Self,
         pipette_id: str,
         tip_geometry: TipGeometry | None,
-        well_picked_up_from: Well | None,
+        well_picked_up_from: LabwareWellId | None,
     ) -> Self:
         """Update a pipette's tip state. See `PipetteTipStateUpdate`."""
         self.pipette_tip_state = PipetteTipStateUpdate(

--- a/api/src/opentrons/protocol_engine/types/__init__.py
+++ b/api/src/opentrons/protocol_engine/types/__init__.py
@@ -100,6 +100,7 @@ from .labware import (
     LabwareOffsetCreateInternal,
     LoadedLabware,
     LabwareParentDefinition,
+    LabwareWellId,
 )
 from .liquid import HexColor, EmptyLiquidId, LiquidId, Liquid, FluidKind, AspiratedFluid
 from .labware_offset_location import (
@@ -253,6 +254,7 @@ __all__ = [
     "LoadedLabware",
     "LabwareOffsetVector",
     "LabwareParentDefinition",
+    "LabwareWellId",
     # Liquids
     "HexColor",
     "EmptyLiquidId",

--- a/api/src/opentrons/protocol_engine/types/labware.py
+++ b/api/src/opentrons/protocol_engine/types/labware.py
@@ -121,3 +121,11 @@ LabwareParentDefinition = Union[
     DeckLocationDefinition, ModuleDefinition, LabwareDefinition
 ]
 """Information pertaining to a labware's parent (deck slot, module, or another labware) location."""
+
+
+@dataclass(frozen=True)
+class LabwareWellId:
+    """Designates a well in a labware."""
+
+    labware_id: str
+    well_name: str

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -2515,7 +2515,6 @@ def test_transfer_liquid_delegates_to_engine_core(
             trash_location=trash_location,
             return_tip=True,
             keep_last_tip=False,
-            last_tip_location=None,
         )
     )
 
@@ -2579,7 +2578,6 @@ def test_transfer_liquid_multi_channel_delegates_to_engine_core(
             trash_location=trash_location,
             return_tip=True,
             keep_last_tip=False,
-            last_tip_location=None,
         )
     )
 
@@ -2631,7 +2629,6 @@ def test_transfer_liquid_delegates_to_engine_core_with_trash_destination(
             trash_location=trash_location,
             return_tip=True,
             keep_last_tip=False,
-            last_tip_location=None,
         )
     )
 
@@ -2857,7 +2854,6 @@ def test_distribute_liquid_delegates_to_engine_core(
             trash_location=trash_location,
             return_tip=True,
             keep_last_tip=False,
-            last_tip_location=None,
         )
     )
 
@@ -2924,7 +2920,6 @@ def test_distribute_liquid_multi_channel_delegates_to_engine_core(
             trash_location=trash_location,
             return_tip=True,
             keep_last_tip=False,
-            last_tip_location=None,
         )
     )
 
@@ -3144,7 +3139,6 @@ def test_consolidate_liquid_delegates_to_engine_core(
             trash_location=trash_location,
             return_tip=True,
             keep_last_tip=False,
-            last_tip_location=None,
         )
     )
 
@@ -3212,7 +3206,6 @@ def test_consolidate_liquid_multi_channel_delegates_to_engine_core(
             trash_location=trash_location,
             return_tip=True,
             keep_last_tip=False,
-            last_tip_location=None,
         )
     )
 
@@ -3265,6 +3258,5 @@ def test_consolidate_liquid_delegates_to_engine_core_with_trash_destination(
             trash_location=trash_location,
             return_tip=True,
             keep_last_tip=False,
-            last_tip_location=None,
         )
     )

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -50,7 +50,13 @@ from opentrons.protocol_api import (
     labware,
     LiquidClass,
 )
-from opentrons.protocol_api.core.common import InstrumentCore, ProtocolCore
+from opentrons.protocol_api.core.common import (
+    InstrumentCore,
+    ProtocolCore,
+    WellCore,
+    LabwareCore,
+)
+from opentrons.protocol_api.core.core_map import LoadedCoreMap
 from opentrons.protocol_api.core.legacy.legacy_instrument_core import (
     LegacyInstrumentCore,
 )
@@ -133,6 +139,12 @@ def mock_protocol_core(decoy: Decoy) -> ProtocolCore:
 
 
 @pytest.fixture
+def mock_core_map(decoy: Decoy) -> LoadedCoreMap:
+    """Get a mock LoadedCoreMap."""
+    return decoy.mock(cls=LoadedCoreMap)
+
+
+@pytest.fixture
 def mock_broker(decoy: Decoy) -> LegacyBroker:
     """Get a mock command message broker."""
     return decoy.mock(cls=LegacyBroker)
@@ -154,6 +166,7 @@ def api_version() -> APIVersion:
 def subject(
     mock_instrument_core: InstrumentCore,
     mock_protocol_core: ProtocolCore,
+    mock_core_map: LoadedCoreMap,
     mock_broker: LegacyBroker,
     mock_trash: Labware,
     api_version: APIVersion,
@@ -167,6 +180,7 @@ def subject(
         tip_racks=[],
         trash=mock_trash,
         requested_as="requested-pipette-name",
+        core_map=mock_core_map,
     )
 
 
@@ -1002,27 +1016,33 @@ def test_return_tip(
     decoy: Decoy, mock_instrument_core: InstrumentCore, subject: InstrumentContext
 ) -> None:
     """It should pick up a tip and return it."""
+    mock_tiprack_core = decoy.mock(cls=LabwareCore)
+    mock_tiprack = decoy.mock(cls=Labware)
+    mock_well_core = decoy.mock(cls=WellCore)
+    subject._core_map = {mock_tiprack_core: mock_tiprack}  # type: ignore[assignment]
     mock_well = decoy.mock(cls=Well)
     top_location = Location(point=Point(1, 2, 3), labware=mock_well)
-    decoy.when(mock_well.top()).then_return(top_location)
 
-    subject.pick_up_tip(mock_well)
+    decoy.when(mock_well_core.get_display_name()).then_return("bar")
+    decoy.when(mock_well_core.get_name()).then_return("foo")
+    decoy.when(mock_well.top()).then_return(top_location)
+    decoy.when(mock_instrument_core.has_tip()).then_return(True)
+    decoy.when(mock_instrument_core.get_last_well_tip_picked_up_from()).then_return(
+        (mock_tiprack_core, mock_well_core)
+    )
+
     subject.return_tip()
 
     decoy.verify(
-        mock_instrument_core.pick_up_tip(
-            location=top_location,
-            well_core=mock_well._core,
-            presses=None,
-            increment=None,
-            prep_after=True,
-        ),
         mock_instrument_core.drop_tip(
             location=None,
-            well_core=mock_well._core,
+            well_core=mock_well_core,
             home_after=None,
             alternate_drop_location=False,
-        ),
+        )
+    )
+    decoy.when(mock_instrument_core.get_last_well_tip_picked_up_from()).then_return(
+        None
     )
 
     with pytest.raises(TypeError, match="Last tip location"):

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -1027,7 +1027,7 @@ def test_return_tip(
     decoy.when(mock_well_core.get_name()).then_return("foo")
     decoy.when(mock_well.top()).then_return(top_location)
     decoy.when(mock_instrument_core.has_tip()).then_return(True)
-    decoy.when(mock_instrument_core.get_last_well_tip_picked_up_from()).then_return(
+    decoy.when(mock_instrument_core.get_tip_origin()).then_return(
         (mock_tiprack_core, mock_well_core)
     )
 
@@ -1041,9 +1041,7 @@ def test_return_tip(
             alternate_drop_location=False,
         )
     )
-    decoy.when(mock_instrument_core.get_last_well_tip_picked_up_from()).then_return(
-        None
-    )
+    decoy.when(mock_instrument_core.get_tip_origin()).then_return(None)
 
     with pytest.raises(TypeError, match="Last tip location"):
         subject.return_tip()

--- a/api/tests/opentrons/protocol_api_integration/test_transfer_with_liquid_classes.py
+++ b/api/tests/opentrons/protocol_api_integration/test_transfer_with_liquid_classes.py
@@ -2303,7 +2303,6 @@ def test_transfer_with_keep_last_tip(
             ),
         ]
         assert pipette_1k.has_tip
-        assert pipette_1k._last_tip_picked_up_from is not None
         assert mock_manager.mock_calls == expected_calls
 
 
@@ -2366,7 +2365,6 @@ def test_transfer_with_keep_last_tip_false(
             )
         ]
         assert not pipette_1k.has_tip
-        assert pipette_1k._last_tip_picked_up_from is None
         assert mock_manager.mock_calls == expected_calls
 
 
@@ -2420,7 +2418,6 @@ def test_transfer_with_keep_last_tip_chained(
             keep_last_tip=True,
         )
         assert pipette_1k.has_tip
-        assert pipette_1k._last_tip_picked_up_from is not None
         pipette_1k.consolidate_with_liquid_class(
             liquid_class=water,
             volume=400,
@@ -2439,7 +2436,6 @@ def test_transfer_with_keep_last_tip_chained(
             )
         ]
         assert pipette_1k.has_tip
-        assert pipette_1k._last_tip_picked_up_from is not None
         assert mock_manager.mock_calls == expected_calls
 
 
@@ -2504,7 +2500,6 @@ def test_return_tip_after_transfer_with_never(
             ),
         ]
         assert not pipette_1k.has_tip
-        assert pipette_1k._last_tip_picked_up_from is None
         assert mock_manager.mock_calls == expected_calls
 
 
@@ -2558,7 +2553,6 @@ def test_return_tip_after_chained_transfers(
             keep_last_tip=True,
         )
         assert pipette_1k.has_tip
-        assert pipette_1k._last_tip_picked_up_from is not None
         pipette_1k.distribute_with_liquid_class(
             liquid_class=water,
             volume=400,
@@ -2586,7 +2580,6 @@ def test_return_tip_after_chained_transfers(
             ),
         ]
         assert not pipette_1k.has_tip
-        assert pipette_1k._last_tip_picked_up_from is None
         assert mock_manager.mock_calls == expected_calls
 
 

--- a/api/tests/opentrons/protocol_engine/commands/test_aspirate.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_aspirate.py
@@ -39,6 +39,7 @@ from opentrons.protocol_engine.types import (
     AspiratedFluid,
     FluidKind,
     WellLocation,
+    LabwareWellId,
 )
 from opentrons.hardware_control import HardwareControlAPI
 from opentrons.protocol_engine.notes import CommandNoteAdder
@@ -139,9 +140,7 @@ async def test_aspirate_implementation_no_prep(
         state_update=update_types.StateUpdate(
             pipette_location=update_types.PipetteLocationUpdate(
                 pipette_id=pipette_id,
-                new_location=update_types.Well(
-                    labware_id=labware_id, well_name=well_name
-                ),
+                new_location=LabwareWellId(labware_id=labware_id, well_name=well_name),
                 new_deck_point=DeckPoint(x=1, y=2, z=3),
             ),
             liquid_operated=update_types.LiquidOperatedUpdate(
@@ -251,9 +250,7 @@ async def test_aspirate_implementation_with_prep(
         state_update=update_types.StateUpdate(
             pipette_location=update_types.PipetteLocationUpdate(
                 pipette_id=pipette_id,
-                new_location=update_types.Well(
-                    labware_id=labware_id, well_name=well_name
-                ),
+                new_location=LabwareWellId(labware_id=labware_id, well_name=well_name),
                 new_deck_point=DeckPoint(x=1, y=2, z=3),
             ),
             liquid_operated=update_types.LiquidOperatedUpdate(
@@ -432,9 +429,7 @@ async def test_overpressure_error(
         state_update=update_types.StateUpdate(
             pipette_location=update_types.PipetteLocationUpdate(
                 pipette_id=pipette_id,
-                new_location=update_types.Well(
-                    labware_id=labware_id, well_name=well_name
-                ),
+                new_location=LabwareWellId(labware_id=labware_id, well_name=well_name),
                 new_deck_point=DeckPoint(x=position.x, y=position.y, z=position.z),
             ),
             liquid_operated=update_types.LiquidOperatedUpdate(
@@ -526,9 +521,7 @@ async def test_aspirate_implementation_meniscus(
         state_update=update_types.StateUpdate(
             pipette_location=update_types.PipetteLocationUpdate(
                 pipette_id=pipette_id,
-                new_location=update_types.Well(
-                    labware_id=labware_id, well_name=well_name
-                ),
+                new_location=LabwareWellId(labware_id=labware_id, well_name=well_name),
                 new_deck_point=DeckPoint(x=1, y=2, z=3),
             ),
             liquid_operated=update_types.LiquidOperatedUpdate(
@@ -744,9 +737,7 @@ async def test_overpressure_during_preparation(
         state_update=update_types.StateUpdate(
             pipette_location=update_types.PipetteLocationUpdate(
                 pipette_id=pipette_id,
-                new_location=update_types.Well(
-                    labware_id=labware_id, well_name=well_name
-                ),
+                new_location=LabwareWellId(labware_id=labware_id, well_name=well_name),
                 new_deck_point=DeckPoint(
                     x=prep_location.x, y=prep_location.y, z=prep_location.z
                 ),

--- a/api/tests/opentrons/protocol_engine/commands/test_blow_out.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_blow_out.py
@@ -17,6 +17,7 @@ from opentrons.protocol_engine import (
 )
 from opentrons.protocol_engine.state import update_types
 from opentrons.protocol_engine.state.state import StateView
+from opentrons.protocol_engine.types import LabwareWellId
 from opentrons.protocol_engine.commands import (
     BlowOutResult,
     BlowOutImplementation,
@@ -90,7 +91,7 @@ async def test_blow_out_implementation(
         state_update=update_types.StateUpdate(
             pipette_location=update_types.PipetteLocationUpdate(
                 pipette_id="pipette-id",
-                new_location=update_types.Well(
+                new_location=LabwareWellId(
                     labware_id="labware-id",
                     well_name="C6",
                 ),
@@ -170,7 +171,7 @@ async def test_overpressure_error(
         state_update=update_types.StateUpdate(
             pipette_location=update_types.PipetteLocationUpdate(
                 pipette_id="pipette-id",
-                new_location=update_types.Well(
+                new_location=LabwareWellId(
                     labware_id="labware-id",
                     well_name="C6",
                 ),
@@ -183,7 +184,7 @@ async def test_overpressure_error(
         state_update_if_false_positive=update_types.StateUpdate(
             pipette_location=update_types.PipetteLocationUpdate(
                 pipette_id="pipette-id",
-                new_location=update_types.Well(
+                new_location=LabwareWellId(
                     labware_id="labware-id",
                     well_name="C6",
                 ),

--- a/api/tests/opentrons/protocol_engine/commands/test_dispense.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_dispense.py
@@ -19,6 +19,7 @@ from opentrons.protocol_engine import (
 from opentrons.protocol_engine.execution import MovementHandler, PipettingHandler
 from opentrons.protocol_engine.state import update_types
 from opentrons.protocol_engine.state.state import StateView
+from opentrons.protocol_engine.types import LabwareWellId
 from opentrons.types import Point
 
 from opentrons.protocol_engine.commands.command import SuccessData, DefinedErrorData
@@ -126,7 +127,7 @@ async def test_dispense_implementation(
         state_update=update_types.StateUpdate(
             pipette_location=update_types.PipetteLocationUpdate(
                 pipette_id="pipette-id-abc123",
-                new_location=update_types.Well(
+                new_location=LabwareWellId(
                     labware_id="labware-id-abc123",
                     well_name="A3",
                 ),
@@ -233,7 +234,7 @@ async def test_overpressure_error(
         state_update=update_types.StateUpdate(
             pipette_location=update_types.PipetteLocationUpdate(
                 pipette_id="pipette-id",
-                new_location=update_types.Well(
+                new_location=LabwareWellId(
                     labware_id="labware-id",
                     well_name="well-name",
                 ),
@@ -254,7 +255,7 @@ async def test_overpressure_error(
         state_update_if_false_positive=update_types.StateUpdate(
             pipette_location=update_types.PipetteLocationUpdate(
                 pipette_id="pipette-id",
-                new_location=update_types.Well(
+                new_location=LabwareWellId(
                     labware_id="labware-id",
                     well_name="well-name",
                 ),

--- a/api/tests/opentrons/protocol_engine/commands/test_drop_tip.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_drop_tip.py
@@ -153,7 +153,7 @@ async def test_drop_tip_implementation(
             pipette_tip_state=update_types.PipetteTipStateUpdate(
                 pipette_id="abc",
                 tip_geometry=None,
-                well_picked_up_from=None,
+                tip_source=None,
             ),
             pipette_aspirated_fluid=update_types.PipetteUnknownFluidUpdate(
                 pipette_id="abc"
@@ -242,7 +242,7 @@ async def test_drop_tip_with_alternating_locations(
             pipette_tip_state=update_types.PipetteTipStateUpdate(
                 pipette_id="abc",
                 tip_geometry=None,
-                well_picked_up_from=None,
+                tip_source=None,
             ),
             pipette_aspirated_fluid=update_types.PipetteUnknownFluidUpdate(
                 pipette_id="abc"
@@ -337,7 +337,7 @@ async def test_tip_attached_error(
             pipette_tip_state=update_types.PipetteTipStateUpdate(
                 pipette_id="abc",
                 tip_geometry=None,
-                well_picked_up_from=None,
+                tip_source=None,
             ),
             pipette_location=update_types.PipetteLocationUpdate(
                 pipette_id="abc",

--- a/api/tests/opentrons/protocol_engine/commands/test_drop_tip.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_drop_tip.py
@@ -28,6 +28,7 @@ from opentrons.protocol_engine.errors.exceptions import TipAttachedError
 from opentrons.protocol_engine.resources.model_utils import ModelUtils
 from opentrons.protocol_engine.state import update_types
 from opentrons.protocol_engine.state.state import StateView
+from opentrons.protocol_engine.types import LabwareWellId
 from opentrons.protocol_engine.execution import MovementHandler, TipHandler
 
 
@@ -143,7 +144,7 @@ async def test_drop_tip_implementation(
         state_update=update_types.StateUpdate(
             pipette_location=update_types.PipetteLocationUpdate(
                 pipette_id="abc",
-                new_location=update_types.Well(
+                new_location=LabwareWellId(
                     labware_id="123",
                     well_name="A3",
                 ),
@@ -232,7 +233,7 @@ async def test_drop_tip_with_alternating_locations(
         state_update=update_types.StateUpdate(
             pipette_location=update_types.PipetteLocationUpdate(
                 pipette_id="abc",
-                new_location=update_types.Well(
+                new_location=LabwareWellId(
                     labware_id="123",
                     well_name="A3",
                 ),
@@ -322,7 +323,7 @@ async def test_tip_attached_error(
         state_update=update_types.StateUpdate(
             pipette_location=update_types.PipetteLocationUpdate(
                 pipette_id="abc",
-                new_location=update_types.Well(
+                new_location=LabwareWellId(
                     labware_id="123",
                     well_name="A3",
                 ),
@@ -340,7 +341,7 @@ async def test_tip_attached_error(
             ),
             pipette_location=update_types.PipetteLocationUpdate(
                 pipette_id="abc",
-                new_location=update_types.Well(
+                new_location=LabwareWellId(
                     labware_id="123",
                     well_name="A3",
                 ),

--- a/api/tests/opentrons/protocol_engine/commands/test_drop_tip.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_drop_tip.py
@@ -150,7 +150,9 @@ async def test_drop_tip_implementation(
                 new_deck_point=DeckPoint(x=111, y=222, z=333),
             ),
             pipette_tip_state=update_types.PipetteTipStateUpdate(
-                pipette_id="abc", tip_geometry=None
+                pipette_id="abc",
+                tip_geometry=None,
+                well_picked_up_from=None,
             ),
             pipette_aspirated_fluid=update_types.PipetteUnknownFluidUpdate(
                 pipette_id="abc"
@@ -237,7 +239,9 @@ async def test_drop_tip_with_alternating_locations(
                 new_deck_point=DeckPoint(x=111, y=222, z=333),
             ),
             pipette_tip_state=update_types.PipetteTipStateUpdate(
-                pipette_id="abc", tip_geometry=None
+                pipette_id="abc",
+                tip_geometry=None,
+                well_picked_up_from=None,
             ),
             pipette_aspirated_fluid=update_types.PipetteUnknownFluidUpdate(
                 pipette_id="abc"
@@ -332,6 +336,7 @@ async def test_tip_attached_error(
             pipette_tip_state=update_types.PipetteTipStateUpdate(
                 pipette_id="abc",
                 tip_geometry=None,
+                well_picked_up_from=None,
             ),
             pipette_location=update_types.PipetteLocationUpdate(
                 pipette_id="abc",

--- a/api/tests/opentrons/protocol_engine/commands/test_drop_tip_in_place.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_drop_tip_in_place.py
@@ -62,7 +62,7 @@ async def test_success(
         public=DropTipInPlaceResult(),
         state_update=StateUpdate(
             pipette_tip_state=PipetteTipStateUpdate(
-                pipette_id="abc", tip_geometry=None, well_picked_up_from=None
+                pipette_id="abc", tip_geometry=None, tip_source=None
             ),
             pipette_aspirated_fluid=PipetteUnknownFluidUpdate(pipette_id="abc"),
         ),
@@ -117,7 +117,7 @@ async def test_tip_attached_error(
             pipette_tip_state=PipetteTipStateUpdate(
                 pipette_id="abc",
                 tip_geometry=None,
-                well_picked_up_from=None,
+                tip_source=None,
             ),
         ),
     )

--- a/api/tests/opentrons/protocol_engine/commands/test_drop_tip_in_place.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_drop_tip_in_place.py
@@ -62,7 +62,7 @@ async def test_success(
         public=DropTipInPlaceResult(),
         state_update=StateUpdate(
             pipette_tip_state=PipetteTipStateUpdate(
-                pipette_id="abc", tip_geometry=None
+                pipette_id="abc", tip_geometry=None, well_picked_up_from=None
             ),
             pipette_aspirated_fluid=PipetteUnknownFluidUpdate(pipette_id="abc"),
         ),
@@ -115,7 +115,9 @@ async def test_tip_attached_error(
         ),
         state_update_if_false_positive=StateUpdate(
             pipette_tip_state=PipetteTipStateUpdate(
-                pipette_id="abc", tip_geometry=None
+                pipette_id="abc",
+                tip_geometry=None,
+                well_picked_up_from=None,
             ),
         ),
     )

--- a/api/tests/opentrons/protocol_engine/commands/test_liquid_probe.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_liquid_probe.py
@@ -33,6 +33,7 @@ from opentrons.protocol_engine.state.pipettes import (
 from opentrons.protocol_engine.state import update_types
 from opentrons.types import MountType, Point
 from opentrons.protocol_engine import WellLocation, WellOrigin, WellOffset, DeckPoint
+from opentrons.protocol_engine.types import LabwareWellId
 from opentrons.protocol_engine.types.liquid_level_detection import SimulatedProbeResult
 
 from opentrons.protocol_engine.commands.liquid_probe import (
@@ -247,7 +248,7 @@ async def test_liquid_probe_implementation(
         state_update=update_types.StateUpdate(
             pipette_location=update_types.PipetteLocationUpdate(
                 pipette_id="abc",
-                new_location=update_types.Well(labware_id="123", well_name="A3"),
+                new_location=LabwareWellId(labware_id="123", well_name="A3"),
                 new_deck_point=DeckPoint(x=1, y=2, z=3),
             ),
             liquid_probed=update_types.LiquidProbedUpdate(
@@ -362,7 +363,7 @@ async def test_liquid_not_found_error(
     expected_state_update = update_types.StateUpdate(
         pipette_location=update_types.PipetteLocationUpdate(
             pipette_id=pipette_id,
-            new_location=update_types.Well(labware_id=labware_id, well_name=well_name),
+            new_location=LabwareWellId(labware_id=labware_id, well_name=well_name),
             new_deck_point=DeckPoint(x=position.x, y=position.y, z=position.z),
         ),
         liquid_probed=update_types.LiquidProbedUpdate(

--- a/api/tests/opentrons/protocol_engine/commands/test_move_to_well.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_move_to_well.py
@@ -24,7 +24,7 @@ from opentrons.protocol_engine.commands.move_to_well import (
 from opentrons.protocol_engine.commands.movement_common import StallOrCollisionError
 from opentrons.protocol_engine.state.state import StateView
 from opentrons.protocol_engine.resources.model_utils import ModelUtils
-from opentrons.protocol_engine.types import LiquidHandlingWellLocation
+from opentrons.protocol_engine.types import LiquidHandlingWellLocation, LabwareWellId
 
 
 @pytest.fixture
@@ -81,7 +81,7 @@ async def test_move_to_well_implementation(
         state_update=update_types.StateUpdate(
             pipette_location=update_types.PipetteLocationUpdate(
                 pipette_id="abc",
-                new_location=update_types.Well(labware_id="123", well_name="A3"),
+                new_location=LabwareWellId(labware_id="123", well_name="A3"),
                 new_deck_point=DeckPoint(x=9, y=8, z=7),
             )
         ),

--- a/api/tests/opentrons/protocol_engine/commands/test_pick_up_tip.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_pick_up_tip.py
@@ -112,9 +112,7 @@ async def test_success(
             pipette_tip_state=update_types.PipetteTipStateUpdate(
                 pipette_id="pipette-id",
                 tip_geometry=TipGeometry(length=42, diameter=5, volume=300),
-                well_picked_up_from=LabwareWellId(
-                    labware_id="labware-id", well_name="A3"
-                ),
+                tip_source=LabwareWellId(labware_id="labware-id", well_name="A3"),
             ),
             tips_used=update_types.TipsUsedUpdate(
                 labware_id="labware-id", well_names=sentinel.tips_to_mark_as_used
@@ -213,7 +211,7 @@ async def test_tip_physically_missing_error(
             pipette_tip_state=update_types.PipetteTipStateUpdate(
                 pipette_id="pipette-id",
                 tip_geometry=sentinel.tip_geometry,
-                well_picked_up_from=LabwareWellId(
+                tip_source=LabwareWellId(
                     labware_id="labware-id", well_name="well-name"
                 ),
             ),

--- a/api/tests/opentrons/protocol_engine/commands/test_pick_up_tip.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_pick_up_tip.py
@@ -112,6 +112,9 @@ async def test_success(
             pipette_tip_state=update_types.PipetteTipStateUpdate(
                 pipette_id="pipette-id",
                 tip_geometry=TipGeometry(length=42, diameter=5, volume=300),
+                well_picked_up_from=update_types.Well(
+                    labware_id="labware-id", well_name="A3"
+                ),
             ),
             tips_used=update_types.TipsUsedUpdate(
                 labware_id="labware-id", well_names=sentinel.tips_to_mark_as_used
@@ -208,7 +211,11 @@ async def test_tip_physically_missing_error(
         ),
         state_update_if_false_positive=update_types.StateUpdate(
             pipette_tip_state=update_types.PipetteTipStateUpdate(
-                pipette_id="pipette-id", tip_geometry=sentinel.tip_geometry
+                pipette_id="pipette-id",
+                tip_geometry=sentinel.tip_geometry,
+                well_picked_up_from=update_types.Well(
+                    labware_id="labware-id", well_name="well-name"
+                ),
             ),
             pipette_aspirated_fluid=update_types.PipetteEmptyFluidUpdate(
                 pipette_id="pipette-id", clean_tip=True

--- a/api/tests/opentrons/protocol_engine/commands/test_pick_up_tip.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_pick_up_tip.py
@@ -21,7 +21,7 @@ from opentrons.protocol_engine.execution import MovementHandler, TipHandler
 from opentrons.protocol_engine.resources import ModelUtils
 from opentrons.protocol_engine.state import update_types
 from opentrons.protocol_engine.state.state import StateView
-from opentrons.protocol_engine.types import TipGeometry
+from opentrons.protocol_engine.types import TipGeometry, LabwareWellId
 
 from opentrons.protocol_engine.commands.movement_common import StallOrCollisionError
 from opentrons.protocol_engine.commands.command import DefinedErrorData, SuccessData
@@ -106,13 +106,13 @@ async def test_success(
         state_update=update_types.StateUpdate(
             pipette_location=update_types.PipetteLocationUpdate(
                 pipette_id="pipette-id",
-                new_location=update_types.Well(labware_id="labware-id", well_name="A3"),
+                new_location=LabwareWellId(labware_id="labware-id", well_name="A3"),
                 new_deck_point=DeckPoint(x=111, y=222, z=333),
             ),
             pipette_tip_state=update_types.PipetteTipStateUpdate(
                 pipette_id="pipette-id",
                 tip_geometry=TipGeometry(length=42, diameter=5, volume=300),
-                well_picked_up_from=update_types.Well(
+                well_picked_up_from=LabwareWellId(
                     labware_id="labware-id", well_name="A3"
                 ),
             ),
@@ -197,7 +197,7 @@ async def test_tip_physically_missing_error(
         state_update=update_types.StateUpdate(
             pipette_location=update_types.PipetteLocationUpdate(
                 pipette_id="pipette-id",
-                new_location=update_types.Well(
+                new_location=LabwareWellId(
                     labware_id="labware-id", well_name="well-name"
                 ),
                 new_deck_point=DeckPoint(x=111, y=222, z=333),
@@ -213,7 +213,7 @@ async def test_tip_physically_missing_error(
             pipette_tip_state=update_types.PipetteTipStateUpdate(
                 pipette_id="pipette-id",
                 tip_geometry=sentinel.tip_geometry,
-                well_picked_up_from=update_types.Well(
+                well_picked_up_from=LabwareWellId(
                     labware_id="labware-id", well_name="well-name"
                 ),
             ),
@@ -225,7 +225,7 @@ async def test_tip_physically_missing_error(
             ),
             pipette_location=update_types.PipetteLocationUpdate(
                 pipette_id="pipette-id",
-                new_location=update_types.Well(
+                new_location=LabwareWellId(
                     labware_id="labware-id", well_name="well-name"
                 ),
                 new_deck_point=DeckPoint(x=111, y=222, z=333),

--- a/api/tests/opentrons/protocol_engine/commands/test_pressure_dispense.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_pressure_dispense.py
@@ -29,6 +29,7 @@ from opentrons.protocol_engine.commands.pressure_dispense import (
 from opentrons.protocol_engine.resources import ModelUtils
 from opentrons.protocol_engine.state.state import StateView
 from opentrons.protocol_engine.state import update_types
+from opentrons.protocol_engine.types import LabwareWellId
 
 from opentrons_shared_data.labware import load_definition
 
@@ -128,7 +129,7 @@ async def test_pressure_dispense_implementation(
         state_update=update_types.StateUpdate(
             pipette_location=update_types.PipetteLocationUpdate(
                 pipette_id="pipette-id-abc123",
-                new_location=update_types.Well(
+                new_location=LabwareWellId(
                     labware_id="labware-id-abc123",
                     well_name="A3",
                 ),

--- a/api/tests/opentrons/protocol_engine/commands/test_seal_pipette_to_tip.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_seal_pipette_to_tip.py
@@ -26,7 +26,12 @@ from opentrons.protocol_engine.execution import MovementHandler, GantryMover, Ti
 from opentrons.protocol_engine.resources import ModelUtils
 from opentrons.protocol_engine.state import update_types
 from opentrons.protocol_engine.state.state import StateView
-from opentrons.protocol_engine.types import TipGeometry, FluidKind, AspiratedFluid
+from opentrons.protocol_engine.types import (
+    TipGeometry,
+    FluidKind,
+    AspiratedFluid,
+    LabwareWellId,
+)
 
 from opentrons.protocol_engine.commands.movement_common import StallOrCollisionError
 from opentrons.protocol_engine.commands.command import DefinedErrorData, SuccessData
@@ -130,7 +135,7 @@ async def test_success(
             pipette_tip_state=update_types.PipetteTipStateUpdate(
                 pipette_id="pipette-id",
                 tip_geometry=TipGeometry(length=42, diameter=5, volume=300),
-                well_picked_up_from=update_types.Well(
+                well_picked_up_from=LabwareWellId(
                     labware_id="labware-id", well_name="A3"
                 ),
             ),
@@ -140,7 +145,7 @@ async def test_success(
             ),
             pipette_location=update_types.PipetteLocationUpdate(
                 pipette_id="pipette-id",
-                new_location=update_types.Well(labware_id="labware-id", well_name="A3"),
+                new_location=LabwareWellId(labware_id="labware-id", well_name="A3"),
                 new_deck_point=DeckPoint(x=111, y=222, z=333),
             ),
         ),
@@ -226,7 +231,7 @@ async def test_no_tip_physically_missing_error(
             pipette_tip_state=update_types.PipetteTipStateUpdate(
                 pipette_id="pipette-id",
                 tip_geometry=TipGeometry(length=42, diameter=5, volume=300),
-                well_picked_up_from=update_types.Well(
+                well_picked_up_from=LabwareWellId(
                     labware_id="labware-id", well_name="well-name"
                 ),
             ),
@@ -236,7 +241,7 @@ async def test_no_tip_physically_missing_error(
             ),
             pipette_location=update_types.PipetteLocationUpdate(
                 pipette_id="pipette-id",
-                new_location=update_types.Well(
+                new_location=LabwareWellId(
                     labware_id="labware-id", well_name="well-name"
                 ),
                 new_deck_point=DeckPoint(x=111, y=222, z=333),

--- a/api/tests/opentrons/protocol_engine/commands/test_seal_pipette_to_tip.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_seal_pipette_to_tip.py
@@ -135,9 +135,7 @@ async def test_success(
             pipette_tip_state=update_types.PipetteTipStateUpdate(
                 pipette_id="pipette-id",
                 tip_geometry=TipGeometry(length=42, diameter=5, volume=300),
-                well_picked_up_from=LabwareWellId(
-                    labware_id="labware-id", well_name="A3"
-                ),
+                tip_source=LabwareWellId(labware_id="labware-id", well_name="A3"),
             ),
             pipette_aspirated_fluid=update_types.PipetteAspiratedFluidUpdate(
                 pipette_id="pipette-id",
@@ -231,7 +229,7 @@ async def test_no_tip_physically_missing_error(
             pipette_tip_state=update_types.PipetteTipStateUpdate(
                 pipette_id="pipette-id",
                 tip_geometry=TipGeometry(length=42, diameter=5, volume=300),
-                well_picked_up_from=LabwareWellId(
+                tip_source=LabwareWellId(
                     labware_id="labware-id", well_name="well-name"
                 ),
             ),

--- a/api/tests/opentrons/protocol_engine/commands/test_seal_pipette_to_tip.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_seal_pipette_to_tip.py
@@ -130,6 +130,9 @@ async def test_success(
             pipette_tip_state=update_types.PipetteTipStateUpdate(
                 pipette_id="pipette-id",
                 tip_geometry=TipGeometry(length=42, diameter=5, volume=300),
+                well_picked_up_from=update_types.Well(
+                    labware_id="labware-id", well_name="A3"
+                ),
             ),
             pipette_aspirated_fluid=update_types.PipetteAspiratedFluidUpdate(
                 pipette_id="pipette-id",
@@ -223,6 +226,9 @@ async def test_no_tip_physically_missing_error(
             pipette_tip_state=update_types.PipetteTipStateUpdate(
                 pipette_id="pipette-id",
                 tip_geometry=TipGeometry(length=42, diameter=5, volume=300),
+                well_picked_up_from=update_types.Well(
+                    labware_id="labware-id", well_name="well-name"
+                ),
             ),
             pipette_aspirated_fluid=update_types.PipetteAspiratedFluidUpdate(
                 pipette_id="pipette-id",

--- a/api/tests/opentrons/protocol_engine/commands/test_touch_tip.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_touch_tip.py
@@ -10,6 +10,7 @@ from opentrons.protocol_engine.resources import ModelUtils
 from opentrons.protocol_engine.execution import MovementHandler, GantryMover
 from opentrons.protocol_engine.state import update_types
 from opentrons.protocol_engine.state.state import StateView
+from opentrons.protocol_engine.types import LabwareWellId
 from opentrons.types import Point
 
 from opentrons.protocol_engine.commands.command import SuccessData
@@ -143,7 +144,7 @@ async def test_touch_tip_implementation(
         state_update=update_types.StateUpdate(
             pipette_location=update_types.PipetteLocationUpdate(
                 pipette_id="abc",
-                new_location=update_types.Well(labware_id="123", well_name="A3"),
+                new_location=LabwareWellId(labware_id="123", well_name="A3"),
                 new_deck_point=DeckPoint(x=4, y=5, z=6),
             )
         ),
@@ -233,7 +234,7 @@ async def test_touch_tip_implementation_with_mm_from_edge(
         state_update=update_types.StateUpdate(
             pipette_location=update_types.PipetteLocationUpdate(
                 pipette_id="abc",
-                new_location=update_types.Well(labware_id="123", well_name="A3"),
+                new_location=LabwareWellId(labware_id="123", well_name="A3"),
                 new_deck_point=DeckPoint(x=4, y=5, z=6),
             )
         ),

--- a/api/tests/opentrons/protocol_engine/commands/test_unseal_pipette_from_tip.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_unseal_pipette_from_tip.py
@@ -173,7 +173,7 @@ async def test_drop_tip_implementation(
             pipette_tip_state=update_types.PipetteTipStateUpdate(
                 pipette_id="abc",
                 tip_geometry=None,
-                well_picked_up_from=None,
+                tip_source=None,
             ),
             pipette_aspirated_fluid=update_types.PipetteUnknownFluidUpdate(
                 pipette_id="abc"

--- a/api/tests/opentrons/protocol_engine/commands/test_unseal_pipette_from_tip.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_unseal_pipette_from_tip.py
@@ -32,7 +32,7 @@ from opentrons.protocol_engine.resources.model_utils import ModelUtils
 from opentrons.protocol_engine.state import update_types
 from opentrons.protocol_engine.state.state import StateView
 from opentrons.protocol_engine.execution import MovementHandler, GantryMover, TipHandler
-from opentrons.protocol_engine.types import TipGeometry
+from opentrons.protocol_engine.types import TipGeometry, LabwareWellId
 
 from opentrons.types import Point
 
@@ -164,7 +164,7 @@ async def test_drop_tip_implementation(
         state_update=update_types.StateUpdate(
             pipette_location=update_types.PipetteLocationUpdate(
                 pipette_id="abc",
-                new_location=update_types.Well(
+                new_location=LabwareWellId(
                     labware_id="123",
                     well_name="A3",
                 ),

--- a/api/tests/opentrons/protocol_engine/commands/test_unseal_pipette_from_tip.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_unseal_pipette_from_tip.py
@@ -171,7 +171,9 @@ async def test_drop_tip_implementation(
                 new_deck_point=DeckPoint(x=111, y=222, z=333),
             ),
             pipette_tip_state=update_types.PipetteTipStateUpdate(
-                pipette_id="abc", tip_geometry=None
+                pipette_id="abc",
+                tip_geometry=None,
+                well_picked_up_from=None,
             ),
             pipette_aspirated_fluid=update_types.PipetteUnknownFluidUpdate(
                 pipette_id="abc"

--- a/api/tests/opentrons/protocol_engine/commands/unsafe/test_unsafe_drop_tip_in_place.py
+++ b/api/tests/opentrons/protocol_engine/commands/unsafe/test_unsafe_drop_tip_in_place.py
@@ -61,7 +61,7 @@ async def test_drop_tip_implementation(
             pipette_tip_state=PipetteTipStateUpdate(
                 pipette_id="abc",
                 tip_geometry=None,
-                well_picked_up_from=None,
+                tip_source=None,
             ),
             pipette_aspirated_fluid=PipetteUnknownFluidUpdate(pipette_id="abc"),
         ),

--- a/api/tests/opentrons/protocol_engine/commands/unsafe/test_unsafe_drop_tip_in_place.py
+++ b/api/tests/opentrons/protocol_engine/commands/unsafe/test_unsafe_drop_tip_in_place.py
@@ -59,7 +59,9 @@ async def test_drop_tip_implementation(
         public=UnsafeDropTipInPlaceResult(),
         state_update=StateUpdate(
             pipette_tip_state=PipetteTipStateUpdate(
-                pipette_id="abc", tip_geometry=None
+                pipette_id="abc",
+                tip_geometry=None,
+                well_picked_up_from=None,
             ),
             pipette_aspirated_fluid=PipetteUnknownFluidUpdate(pipette_id="abc"),
         ),

--- a/api/tests/opentrons/protocol_engine/state/test_pipette_state.py
+++ b/api/tests/opentrons/protocol_engine/state/test_pipette_state.py
@@ -9,6 +9,7 @@ from collections import OrderedDict
 import pytest
 
 from opentrons_shared_data.pipette import pipette_definition
+from opentrons_shared_data.pipette.types import PipetteNameType
 
 from opentrons.hardware_control.nozzle_manager import NozzleMap
 from opentrons.protocol_engine import actions, commands
@@ -17,8 +18,8 @@ from opentrons.protocol_engine.resources.pipette_data_provider import (
 )
 from opentrons.protocol_engine.state import update_types
 from opentrons.protocol_engine.state.pipettes import PipetteStore, PipetteView
-from opentrons.protocol_engine.types import FlowRates
-from opentrons.types import Point
+from opentrons.protocol_engine.types import FlowRates, TipGeometry, LabwareWellId
+from opentrons.types import Point, MountType
 
 from ..pipette_fixtures import (
     EIGHT_CHANNEL_COLS,
@@ -223,4 +224,65 @@ def test_active_channels(
     assert (
         PipetteView(subject.state).get_active_channels("pipette-id")
         == expected_channels
+    )
+
+
+def test_last_tip_rack_well() -> None:
+    """Should update last tip rack well after pipette load and tip state updates."""
+    subject = PipetteStore()
+
+    load_pipette_update = update_types.LoadPipetteUpdate(
+        pipette_id="pipette-id",
+        pipette_name=PipetteNameType.P50_SINGLE_FLEX,
+        mount=MountType.RIGHT,
+        liquid_presence_detection=None,
+    )
+
+    subject.handle_action(
+        actions.SucceedCommandAction(
+            state_update=update_types.StateUpdate(loaded_pipette=load_pipette_update),
+            command=_dummy_command(),
+        )
+    )
+
+    assert (
+        PipetteView(subject.state).get_tip_rack_well_picked_up_from("pipette-id")
+        is None
+    )
+
+    tip_picked_up_update = update_types.PipetteTipStateUpdate(
+        pipette_id="pipette-id",
+        tip_geometry=TipGeometry(length=1, diameter=2, volume=3),
+        well_picked_up_from=LabwareWellId(
+            labware_id="my-cool-labware", well_name="less-cool-well"
+        ),
+    )
+
+    subject.handle_action(
+        actions.SucceedCommandAction(
+            state_update=update_types.StateUpdate(
+                pipette_tip_state=tip_picked_up_update
+            ),
+            command=_dummy_command(),
+        )
+    )
+
+    assert PipetteView(subject.state).get_tip_rack_well_picked_up_from(
+        "pipette-id"
+    ) == LabwareWellId(labware_id="my-cool-labware", well_name="less-cool-well")
+
+    tip_dropped_update = update_types.PipetteTipStateUpdate(
+        pipette_id="pipette-id", tip_geometry=None, well_picked_up_from=None
+    )
+
+    subject.handle_action(
+        actions.SucceedCommandAction(
+            state_update=update_types.StateUpdate(pipette_tip_state=tip_dropped_update),
+            command=_dummy_command(),
+        )
+    )
+
+    assert (
+        PipetteView(subject.state).get_tip_rack_well_picked_up_from("pipette-id")
+        is None
     )

--- a/api/tests/opentrons/protocol_engine/state/test_pipette_state.py
+++ b/api/tests/opentrons/protocol_engine/state/test_pipette_state.py
@@ -253,7 +253,7 @@ def test_last_tip_rack_well() -> None:
     tip_picked_up_update = update_types.PipetteTipStateUpdate(
         pipette_id="pipette-id",
         tip_geometry=TipGeometry(length=1, diameter=2, volume=3),
-        well_picked_up_from=LabwareWellId(
+        tip_source=LabwareWellId(
             labware_id="my-cool-labware", well_name="less-cool-well"
         ),
     )
@@ -272,7 +272,7 @@ def test_last_tip_rack_well() -> None:
     ) == LabwareWellId(labware_id="my-cool-labware", well_name="less-cool-well")
 
     tip_dropped_update = update_types.PipetteTipStateUpdate(
-        pipette_id="pipette-id", tip_geometry=None, well_picked_up_from=None
+        pipette_id="pipette-id", tip_geometry=None, tip_source=None
     )
 
     subject.handle_action(

--- a/api/tests/opentrons/protocol_engine/state/test_pipette_store_old.py
+++ b/api/tests/opentrons/protocol_engine/state/test_pipette_store_old.py
@@ -280,6 +280,7 @@ def test_handles_pick_up_and_drop_tip(subject: PipetteStore) -> None:
                 pipette_tip_state=update_types.PipetteTipStateUpdate(
                     pipette_id="abc",
                     tip_geometry=TipGeometry(volume=42, length=101, diameter=8.0),
+                    well_picked_up_from=None,
                 ),
                 pipette_aspirated_fluid=update_types.PipetteEmptyFluidUpdate(
                     pipette_id="abc", clean_tip=True
@@ -297,7 +298,9 @@ def test_handles_pick_up_and_drop_tip(subject: PipetteStore) -> None:
             command=dummy_command,
             state_update=update_types.StateUpdate(
                 pipette_tip_state=update_types.PipetteTipStateUpdate(
-                    pipette_id="abc", tip_geometry=None
+                    pipette_id="abc",
+                    tip_geometry=None,
+                    well_picked_up_from=None,
                 ),
                 pipette_aspirated_fluid=update_types.PipetteUnknownFluidUpdate(
                     pipette_id="abc"
@@ -336,6 +339,7 @@ def test_handles_drop_tip_in_place(subject: PipetteStore) -> None:
                 pipette_tip_state=update_types.PipetteTipStateUpdate(
                     pipette_id="xyz",
                     tip_geometry=TipGeometry(volume=42, length=101, diameter=8.0),
+                    well_picked_up_from=None,
                 ),
                 pipette_aspirated_fluid=update_types.PipetteEmptyFluidUpdate(
                     pipette_id="xyz", clean_tip=False
@@ -353,7 +357,9 @@ def test_handles_drop_tip_in_place(subject: PipetteStore) -> None:
             command=dummy_command,
             state_update=update_types.StateUpdate(
                 pipette_tip_state=update_types.PipetteTipStateUpdate(
-                    pipette_id="xyz", tip_geometry=None
+                    pipette_id="xyz",
+                    tip_geometry=None,
+                    well_picked_up_from=None,
                 ),
                 pipette_aspirated_fluid=update_types.PipetteUnknownFluidUpdate(
                     pipette_id="xyz"
@@ -391,6 +397,7 @@ def test_handles_unsafe_drop_tip_in_place(subject: PipetteStore) -> None:
                 pipette_tip_state=update_types.PipetteTipStateUpdate(
                     pipette_id="xyz",
                     tip_geometry=TipGeometry(volume=42, length=101, diameter=8.0),
+                    well_picked_up_from=None,
                 ),
                 pipette_aspirated_fluid=update_types.PipetteEmptyFluidUpdate(
                     pipette_id="xyz", clean_tip=False
@@ -408,7 +415,9 @@ def test_handles_unsafe_drop_tip_in_place(subject: PipetteStore) -> None:
             command=dummy_command,
             state_update=update_types.StateUpdate(
                 pipette_tip_state=update_types.PipetteTipStateUpdate(
-                    pipette_id="xyz", tip_geometry=None
+                    pipette_id="xyz",
+                    tip_geometry=None,
+                    well_picked_up_from=None,
                 ),
                 pipette_aspirated_fluid=update_types.PipetteUnknownFluidUpdate(
                     pipette_id="xyz"
@@ -453,6 +462,7 @@ def test_aspirate_adds_volume(subject: PipetteStore) -> None:
                 pipette_tip_state=update_types.PipetteTipStateUpdate(
                     pipette_id="pipette-id",
                     tip_geometry=TipGeometry(volume=42, length=101, diameter=8.0),
+                    well_picked_up_from=None,
                 ),
                 pipette_aspirated_fluid=update_types.PipetteEmptyFluidUpdate(
                     pipette_id="pipette-id", clean_tip=True
@@ -510,6 +520,7 @@ def test_dispense_subtracts_volume(subject: PipetteStore) -> None:
                 pipette_tip_state=update_types.PipetteTipStateUpdate(
                     pipette_id="pipette-id",
                     tip_geometry=TipGeometry(volume=47, length=101, diameter=8.0),
+                    well_picked_up_from=None,
                 ),
                 pipette_aspirated_fluid=update_types.PipetteEmptyFluidUpdate(
                     pipette_id="pipette-id", clean_tip=True
@@ -567,6 +578,7 @@ def test_blow_out_clears_volume(subject: PipetteStore) -> None:
                 pipette_tip_state=update_types.PipetteTipStateUpdate(
                     pipette_id="pipette-id",
                     tip_geometry=TipGeometry(volume=47, length=101, diameter=8.0),
+                    well_picked_up_from=None,
                 ),
                 pipette_aspirated_fluid=update_types.PipetteEmptyFluidUpdate(
                     pipette_id="pipette-id", clean_tip=True
@@ -737,6 +749,7 @@ def test_prepare_to_aspirate_marks_pipette_ready(
                 pipette_tip_state=update_types.PipetteTipStateUpdate(
                     pipette_id="pipette-id",
                     tip_geometry=TipGeometry(volume=42, length=101, diameter=8.0),
+                    well_picked_up_from=None,
                 ),
                 pipette_aspirated_fluid=update_types.PipetteEmptyFluidUpdate(
                     pipette_id="xyz", clean_tip=True

--- a/api/tests/opentrons/protocol_engine/state/test_pipette_store_old.py
+++ b/api/tests/opentrons/protocol_engine/state/test_pipette_store_old.py
@@ -74,7 +74,7 @@ def test_sets_initial_state(subject: PipetteStore) -> None:
         liquid_presence_detection_by_id={},
         ready_to_aspirate_by_id={},
         has_clean_tips_by_id={},
-        last_tip_rack_well_by_id={},
+        tip_source_by_id={},
     )
 
 
@@ -282,9 +282,7 @@ def test_handles_pick_up_and_drop_tip(subject: PipetteStore) -> None:
                 pipette_tip_state=update_types.PipetteTipStateUpdate(
                     pipette_id="abc",
                     tip_geometry=TipGeometry(volume=42, length=101, diameter=8.0),
-                    well_picked_up_from=LabwareWellId(
-                        labware_id="xyz", well_name="123"
-                    ),
+                    tip_source=LabwareWellId(labware_id="xyz", well_name="123"),
                 ),
                 pipette_aspirated_fluid=update_types.PipetteEmptyFluidUpdate(
                     pipette_id="abc", clean_tip=True
@@ -296,7 +294,7 @@ def test_handles_pick_up_and_drop_tip(subject: PipetteStore) -> None:
         volume=42, length=101, diameter=8.0
     )
     assert subject.state.pipette_contents_by_id["abc"] == FluidStack()
-    assert subject.state.last_tip_rack_well_by_id["abc"] == LabwareWellId(
+    assert subject.state.tip_source_by_id["abc"] == LabwareWellId(
         labware_id="xyz", well_name="123"
     )
 
@@ -307,7 +305,7 @@ def test_handles_pick_up_and_drop_tip(subject: PipetteStore) -> None:
                 pipette_tip_state=update_types.PipetteTipStateUpdate(
                     pipette_id="abc",
                     tip_geometry=None,
-                    well_picked_up_from=None,
+                    tip_source=None,
                 ),
                 pipette_aspirated_fluid=update_types.PipetteUnknownFluidUpdate(
                     pipette_id="abc"
@@ -346,9 +344,7 @@ def test_handles_drop_tip_in_place(subject: PipetteStore) -> None:
                 pipette_tip_state=update_types.PipetteTipStateUpdate(
                     pipette_id="xyz",
                     tip_geometry=TipGeometry(volume=42, length=101, diameter=8.0),
-                    well_picked_up_from=LabwareWellId(
-                        labware_id="abc", well_name="123"
-                    ),
+                    tip_source=LabwareWellId(labware_id="abc", well_name="123"),
                 ),
                 pipette_aspirated_fluid=update_types.PipetteEmptyFluidUpdate(
                     pipette_id="xyz", clean_tip=False
@@ -360,7 +356,7 @@ def test_handles_drop_tip_in_place(subject: PipetteStore) -> None:
         volume=42, length=101, diameter=8.0
     )
     assert subject.state.pipette_contents_by_id["xyz"] == FluidStack()
-    assert subject.state.last_tip_rack_well_by_id["xyz"] == LabwareWellId(
+    assert subject.state.tip_source_by_id["xyz"] == LabwareWellId(
         labware_id="abc", well_name="123"
     )
 
@@ -371,7 +367,7 @@ def test_handles_drop_tip_in_place(subject: PipetteStore) -> None:
                 pipette_tip_state=update_types.PipetteTipStateUpdate(
                     pipette_id="xyz",
                     tip_geometry=None,
-                    well_picked_up_from=None,
+                    tip_source=None,
                 ),
                 pipette_aspirated_fluid=update_types.PipetteUnknownFluidUpdate(
                     pipette_id="xyz"
@@ -409,9 +405,7 @@ def test_handles_unsafe_drop_tip_in_place(subject: PipetteStore) -> None:
                 pipette_tip_state=update_types.PipetteTipStateUpdate(
                     pipette_id="xyz",
                     tip_geometry=TipGeometry(volume=42, length=101, diameter=8.0),
-                    well_picked_up_from=LabwareWellId(
-                        labware_id="abc", well_name="123"
-                    ),
+                    tip_source=LabwareWellId(labware_id="abc", well_name="123"),
                 ),
                 pipette_aspirated_fluid=update_types.PipetteEmptyFluidUpdate(
                     pipette_id="xyz", clean_tip=False
@@ -423,7 +417,7 @@ def test_handles_unsafe_drop_tip_in_place(subject: PipetteStore) -> None:
         volume=42, length=101, diameter=8.0
     )
     assert subject.state.pipette_contents_by_id["xyz"] == FluidStack()
-    assert subject.state.last_tip_rack_well_by_id["xyz"] == LabwareWellId(
+    assert subject.state.tip_source_by_id["xyz"] == LabwareWellId(
         labware_id="abc", well_name="123"
     )
 
@@ -434,7 +428,7 @@ def test_handles_unsafe_drop_tip_in_place(subject: PipetteStore) -> None:
                 pipette_tip_state=update_types.PipetteTipStateUpdate(
                     pipette_id="xyz",
                     tip_geometry=None,
-                    well_picked_up_from=None,
+                    tip_source=None,
                 ),
                 pipette_aspirated_fluid=update_types.PipetteUnknownFluidUpdate(
                     pipette_id="xyz"
@@ -479,9 +473,7 @@ def test_aspirate_adds_volume(subject: PipetteStore) -> None:
                 pipette_tip_state=update_types.PipetteTipStateUpdate(
                     pipette_id="pipette-id",
                     tip_geometry=TipGeometry(volume=42, length=101, diameter=8.0),
-                    well_picked_up_from=LabwareWellId(
-                        labware_id="abc", well_name="123"
-                    ),
+                    tip_source=LabwareWellId(labware_id="abc", well_name="123"),
                 ),
                 pipette_aspirated_fluid=update_types.PipetteEmptyFluidUpdate(
                     pipette_id="pipette-id", clean_tip=True
@@ -539,9 +531,7 @@ def test_dispense_subtracts_volume(subject: PipetteStore) -> None:
                 pipette_tip_state=update_types.PipetteTipStateUpdate(
                     pipette_id="pipette-id",
                     tip_geometry=TipGeometry(volume=47, length=101, diameter=8.0),
-                    well_picked_up_from=LabwareWellId(
-                        labware_id="abc", well_name="123"
-                    ),
+                    tip_source=LabwareWellId(labware_id="abc", well_name="123"),
                 ),
                 pipette_aspirated_fluid=update_types.PipetteEmptyFluidUpdate(
                     pipette_id="pipette-id", clean_tip=True
@@ -599,9 +589,7 @@ def test_blow_out_clears_volume(subject: PipetteStore) -> None:
                 pipette_tip_state=update_types.PipetteTipStateUpdate(
                     pipette_id="pipette-id",
                     tip_geometry=TipGeometry(volume=47, length=101, diameter=8.0),
-                    well_picked_up_from=LabwareWellId(
-                        labware_id="abc", well_name="123"
-                    ),
+                    tip_source=LabwareWellId(labware_id="abc", well_name="123"),
                 ),
                 pipette_aspirated_fluid=update_types.PipetteEmptyFluidUpdate(
                     pipette_id="pipette-id", clean_tip=True
@@ -772,9 +760,7 @@ def test_prepare_to_aspirate_marks_pipette_ready(
                 pipette_tip_state=update_types.PipetteTipStateUpdate(
                     pipette_id="pipette-id",
                     tip_geometry=TipGeometry(volume=42, length=101, diameter=8.0),
-                    well_picked_up_from=LabwareWellId(
-                        labware_id="abc", well_name="123"
-                    ),
+                    tip_source=LabwareWellId(labware_id="abc", well_name="123"),
                 ),
                 pipette_aspirated_fluid=update_types.PipetteEmptyFluidUpdate(
                     pipette_id="xyz", clean_tip=True

--- a/api/tests/opentrons/protocol_engine/state/test_pipette_store_old.py
+++ b/api/tests/opentrons/protocol_engine/state/test_pipette_store_old.py
@@ -20,6 +20,7 @@ from opentrons.protocol_engine.types import (
     TipGeometry,
     AspiratedFluid,
     FluidKind,
+    LabwareWellId,
 )
 from opentrons.protocol_engine.actions import (
     SetPipetteMovementSpeedAction,
@@ -87,7 +88,7 @@ def test_location_state_update(subject: PipetteStore) -> None:
             state_update=update_types.StateUpdate(
                 pipette_location=update_types.PipetteLocationUpdate(
                     pipette_id="pipette-id",
-                    new_location=update_types.Well(
+                    new_location=LabwareWellId(
                         labware_id="come on barbie",
                         well_name="let's go party",
                     ),
@@ -281,7 +282,7 @@ def test_handles_pick_up_and_drop_tip(subject: PipetteStore) -> None:
                 pipette_tip_state=update_types.PipetteTipStateUpdate(
                     pipette_id="abc",
                     tip_geometry=TipGeometry(volume=42, length=101, diameter=8.0),
-                    well_picked_up_from=update_types.Well(
+                    well_picked_up_from=LabwareWellId(
                         labware_id="xyz", well_name="123"
                     ),
                 ),
@@ -343,7 +344,7 @@ def test_handles_drop_tip_in_place(subject: PipetteStore) -> None:
                 pipette_tip_state=update_types.PipetteTipStateUpdate(
                     pipette_id="xyz",
                     tip_geometry=TipGeometry(volume=42, length=101, diameter=8.0),
-                    well_picked_up_from=update_types.Well(
+                    well_picked_up_from=LabwareWellId(
                         labware_id="abc", well_name="123"
                     ),
                 ),
@@ -404,7 +405,7 @@ def test_handles_unsafe_drop_tip_in_place(subject: PipetteStore) -> None:
                 pipette_tip_state=update_types.PipetteTipStateUpdate(
                     pipette_id="xyz",
                     tip_geometry=TipGeometry(volume=42, length=101, diameter=8.0),
-                    well_picked_up_from=update_types.Well(
+                    well_picked_up_from=LabwareWellId(
                         labware_id="abc", well_name="123"
                     ),
                 ),
@@ -472,7 +473,7 @@ def test_aspirate_adds_volume(subject: PipetteStore) -> None:
                 pipette_tip_state=update_types.PipetteTipStateUpdate(
                     pipette_id="pipette-id",
                     tip_geometry=TipGeometry(volume=42, length=101, diameter=8.0),
-                    well_picked_up_from=update_types.Well(
+                    well_picked_up_from=LabwareWellId(
                         labware_id="abc", well_name="123"
                     ),
                 ),
@@ -532,7 +533,7 @@ def test_dispense_subtracts_volume(subject: PipetteStore) -> None:
                 pipette_tip_state=update_types.PipetteTipStateUpdate(
                     pipette_id="pipette-id",
                     tip_geometry=TipGeometry(volume=47, length=101, diameter=8.0),
-                    well_picked_up_from=update_types.Well(
+                    well_picked_up_from=LabwareWellId(
                         labware_id="abc", well_name="123"
                     ),
                 ),
@@ -592,7 +593,7 @@ def test_blow_out_clears_volume(subject: PipetteStore) -> None:
                 pipette_tip_state=update_types.PipetteTipStateUpdate(
                     pipette_id="pipette-id",
                     tip_geometry=TipGeometry(volume=47, length=101, diameter=8.0),
-                    well_picked_up_from=update_types.Well(
+                    well_picked_up_from=LabwareWellId(
                         labware_id="abc", well_name="123"
                     ),
                 ),
@@ -765,7 +766,7 @@ def test_prepare_to_aspirate_marks_pipette_ready(
                 pipette_tip_state=update_types.PipetteTipStateUpdate(
                     pipette_id="pipette-id",
                     tip_geometry=TipGeometry(volume=42, length=101, diameter=8.0),
-                    well_picked_up_from=update_types.Well(
+                    well_picked_up_from=LabwareWellId(
                         labware_id="abc", well_name="123"
                     ),
                 ),

--- a/api/tests/opentrons/protocol_engine/state/test_pipette_store_old.py
+++ b/api/tests/opentrons/protocol_engine/state/test_pipette_store_old.py
@@ -73,7 +73,7 @@ def test_sets_initial_state(subject: PipetteStore) -> None:
         liquid_presence_detection_by_id={},
         ready_to_aspirate_by_id={},
         has_clean_tips_by_id={},
-        last_tiprack_well_by_id={},
+        last_tip_rack_well_by_id={},
     )
 
 
@@ -295,7 +295,7 @@ def test_handles_pick_up_and_drop_tip(subject: PipetteStore) -> None:
         volume=42, length=101, diameter=8.0
     )
     assert subject.state.pipette_contents_by_id["abc"] == FluidStack()
-    assert subject.state.last_tiprack_well_by_id["abc"] == ("xyz", "123")
+    assert subject.state.last_tip_rack_well_by_id["abc"] == ("xyz", "123")
 
     subject.handle_action(
         SucceedCommandAction(
@@ -357,7 +357,7 @@ def test_handles_drop_tip_in_place(subject: PipetteStore) -> None:
         volume=42, length=101, diameter=8.0
     )
     assert subject.state.pipette_contents_by_id["xyz"] == FluidStack()
-    assert subject.state.last_tiprack_well_by_id["xyz"] == ("abc", "123")
+    assert subject.state.last_tip_rack_well_by_id["xyz"] == ("abc", "123")
 
     subject.handle_action(
         SucceedCommandAction(
@@ -418,7 +418,7 @@ def test_handles_unsafe_drop_tip_in_place(subject: PipetteStore) -> None:
         volume=42, length=101, diameter=8.0
     )
     assert subject.state.pipette_contents_by_id["xyz"] == FluidStack()
-    assert subject.state.last_tiprack_well_by_id["xyz"] == ("abc", "123")
+    assert subject.state.last_tip_rack_well_by_id["xyz"] == ("abc", "123")
 
     subject.handle_action(
         SucceedCommandAction(

--- a/api/tests/opentrons/protocol_engine/state/test_pipette_store_old.py
+++ b/api/tests/opentrons/protocol_engine/state/test_pipette_store_old.py
@@ -73,6 +73,7 @@ def test_sets_initial_state(subject: PipetteStore) -> None:
         liquid_presence_detection_by_id={},
         ready_to_aspirate_by_id={},
         has_clean_tips_by_id={},
+        last_tiprack_well_by_id={},
     )
 
 
@@ -280,7 +281,9 @@ def test_handles_pick_up_and_drop_tip(subject: PipetteStore) -> None:
                 pipette_tip_state=update_types.PipetteTipStateUpdate(
                     pipette_id="abc",
                     tip_geometry=TipGeometry(volume=42, length=101, diameter=8.0),
-                    well_picked_up_from=None,
+                    well_picked_up_from=update_types.Well(
+                        labware_id="xyz", well_name="123"
+                    ),
                 ),
                 pipette_aspirated_fluid=update_types.PipetteEmptyFluidUpdate(
                     pipette_id="abc", clean_tip=True
@@ -292,6 +295,7 @@ def test_handles_pick_up_and_drop_tip(subject: PipetteStore) -> None:
         volume=42, length=101, diameter=8.0
     )
     assert subject.state.pipette_contents_by_id["abc"] == FluidStack()
+    assert subject.state.last_tiprack_well_by_id["abc"] == ("xyz", "123")
 
     subject.handle_action(
         SucceedCommandAction(
@@ -339,7 +343,9 @@ def test_handles_drop_tip_in_place(subject: PipetteStore) -> None:
                 pipette_tip_state=update_types.PipetteTipStateUpdate(
                     pipette_id="xyz",
                     tip_geometry=TipGeometry(volume=42, length=101, diameter=8.0),
-                    well_picked_up_from=None,
+                    well_picked_up_from=update_types.Well(
+                        labware_id="abc", well_name="123"
+                    ),
                 ),
                 pipette_aspirated_fluid=update_types.PipetteEmptyFluidUpdate(
                     pipette_id="xyz", clean_tip=False
@@ -351,6 +357,7 @@ def test_handles_drop_tip_in_place(subject: PipetteStore) -> None:
         volume=42, length=101, diameter=8.0
     )
     assert subject.state.pipette_contents_by_id["xyz"] == FluidStack()
+    assert subject.state.last_tiprack_well_by_id["xyz"] == ("abc", "123")
 
     subject.handle_action(
         SucceedCommandAction(
@@ -397,7 +404,9 @@ def test_handles_unsafe_drop_tip_in_place(subject: PipetteStore) -> None:
                 pipette_tip_state=update_types.PipetteTipStateUpdate(
                     pipette_id="xyz",
                     tip_geometry=TipGeometry(volume=42, length=101, diameter=8.0),
-                    well_picked_up_from=None,
+                    well_picked_up_from=update_types.Well(
+                        labware_id="abc", well_name="123"
+                    ),
                 ),
                 pipette_aspirated_fluid=update_types.PipetteEmptyFluidUpdate(
                     pipette_id="xyz", clean_tip=False
@@ -409,6 +418,7 @@ def test_handles_unsafe_drop_tip_in_place(subject: PipetteStore) -> None:
         volume=42, length=101, diameter=8.0
     )
     assert subject.state.pipette_contents_by_id["xyz"] == FluidStack()
+    assert subject.state.last_tiprack_well_by_id["xyz"] == ("abc", "123")
 
     subject.handle_action(
         SucceedCommandAction(
@@ -462,7 +472,9 @@ def test_aspirate_adds_volume(subject: PipetteStore) -> None:
                 pipette_tip_state=update_types.PipetteTipStateUpdate(
                     pipette_id="pipette-id",
                     tip_geometry=TipGeometry(volume=42, length=101, diameter=8.0),
-                    well_picked_up_from=None,
+                    well_picked_up_from=update_types.Well(
+                        labware_id="abc", well_name="123"
+                    ),
                 ),
                 pipette_aspirated_fluid=update_types.PipetteEmptyFluidUpdate(
                     pipette_id="pipette-id", clean_tip=True
@@ -520,7 +532,9 @@ def test_dispense_subtracts_volume(subject: PipetteStore) -> None:
                 pipette_tip_state=update_types.PipetteTipStateUpdate(
                     pipette_id="pipette-id",
                     tip_geometry=TipGeometry(volume=47, length=101, diameter=8.0),
-                    well_picked_up_from=None,
+                    well_picked_up_from=update_types.Well(
+                        labware_id="abc", well_name="123"
+                    ),
                 ),
                 pipette_aspirated_fluid=update_types.PipetteEmptyFluidUpdate(
                     pipette_id="pipette-id", clean_tip=True
@@ -578,7 +592,9 @@ def test_blow_out_clears_volume(subject: PipetteStore) -> None:
                 pipette_tip_state=update_types.PipetteTipStateUpdate(
                     pipette_id="pipette-id",
                     tip_geometry=TipGeometry(volume=47, length=101, diameter=8.0),
-                    well_picked_up_from=None,
+                    well_picked_up_from=update_types.Well(
+                        labware_id="abc", well_name="123"
+                    ),
                 ),
                 pipette_aspirated_fluid=update_types.PipetteEmptyFluidUpdate(
                     pipette_id="pipette-id", clean_tip=True
@@ -749,7 +765,9 @@ def test_prepare_to_aspirate_marks_pipette_ready(
                 pipette_tip_state=update_types.PipetteTipStateUpdate(
                     pipette_id="pipette-id",
                     tip_geometry=TipGeometry(volume=42, length=101, diameter=8.0),
-                    well_picked_up_from=None,
+                    well_picked_up_from=update_types.Well(
+                        labware_id="abc", well_name="123"
+                    ),
                 ),
                 pipette_aspirated_fluid=update_types.PipetteEmptyFluidUpdate(
                     pipette_id="xyz", clean_tip=True

--- a/api/tests/opentrons/protocol_engine/state/test_pipette_store_old.py
+++ b/api/tests/opentrons/protocol_engine/state/test_pipette_store_old.py
@@ -296,7 +296,9 @@ def test_handles_pick_up_and_drop_tip(subject: PipetteStore) -> None:
         volume=42, length=101, diameter=8.0
     )
     assert subject.state.pipette_contents_by_id["abc"] == FluidStack()
-    assert subject.state.last_tip_rack_well_by_id["abc"] == ("xyz", "123")
+    assert subject.state.last_tip_rack_well_by_id["abc"] == LabwareWellId(
+        labware_id="xyz", well_name="123"
+    )
 
     subject.handle_action(
         SucceedCommandAction(
@@ -358,7 +360,9 @@ def test_handles_drop_tip_in_place(subject: PipetteStore) -> None:
         volume=42, length=101, diameter=8.0
     )
     assert subject.state.pipette_contents_by_id["xyz"] == FluidStack()
-    assert subject.state.last_tip_rack_well_by_id["xyz"] == ("abc", "123")
+    assert subject.state.last_tip_rack_well_by_id["xyz"] == LabwareWellId(
+        labware_id="abc", well_name="123"
+    )
 
     subject.handle_action(
         SucceedCommandAction(
@@ -419,7 +423,9 @@ def test_handles_unsafe_drop_tip_in_place(subject: PipetteStore) -> None:
         volume=42, length=101, diameter=8.0
     )
     assert subject.state.pipette_contents_by_id["xyz"] == FluidStack()
-    assert subject.state.last_tip_rack_well_by_id["xyz"] == ("abc", "123")
+    assert subject.state.last_tip_rack_well_by_id["xyz"] == LabwareWellId(
+        labware_id="abc", well_name="123"
+    )
 
     subject.handle_action(
         SucceedCommandAction(

--- a/api/tests/opentrons/protocol_engine/state/test_pipette_view_old.py
+++ b/api/tests/opentrons/protocol_engine/state/test_pipette_view_old.py
@@ -31,6 +31,7 @@ from opentrons.protocol_engine.types import (
     DeckPoint,
     CurrentPipetteLocation,
     TipGeometry,
+    LabwareWellId,
 )
 from opentrons.protocol_engine.state.pipettes import (
     PipetteState,
@@ -89,7 +90,7 @@ def get_pipette_view(
         Dict[str, Optional[fluid_stack.FluidStack]]
     ] = None,
     has_clean_tips_by_id: Optional[Dict[str, bool]] = None,
-    last_tiprack_well_by_id: Optional[Dict[str, Optional[Tuple[str, str]]]] = None,
+    last_tip_rack_well_by_id: Optional[Dict[str, Optional[LabwareWellId]]] = None,
 ) -> PipetteView:
     """Get a pipette view test subject with the specified state."""
     state = PipetteState(
@@ -105,7 +106,7 @@ def get_pipette_view(
         liquid_presence_detection_by_id=liquid_presence_detection_by_id or {},
         ready_to_aspirate_by_id=ready_to_aspirate_by_id or {},
         has_clean_tips_by_id=has_clean_tips_by_id or {},
-        last_tip_rack_well_by_id=last_tiprack_well_by_id or {},
+        last_tip_rack_well_by_id=last_tip_rack_well_by_id or {},
     )
 
     return PipetteView(state=state)

--- a/api/tests/opentrons/protocol_engine/state/test_pipette_view_old.py
+++ b/api/tests/opentrons/protocol_engine/state/test_pipette_view_old.py
@@ -106,7 +106,7 @@ def get_pipette_view(
         liquid_presence_detection_by_id=liquid_presence_detection_by_id or {},
         ready_to_aspirate_by_id=ready_to_aspirate_by_id or {},
         has_clean_tips_by_id=has_clean_tips_by_id or {},
-        last_tip_rack_well_by_id=last_tip_rack_well_by_id or {},
+        tip_source_by_id=last_tip_rack_well_by_id or {},
     )
 
     return PipetteView(state=state)

--- a/api/tests/opentrons/protocol_engine/state/test_pipette_view_old.py
+++ b/api/tests/opentrons/protocol_engine/state/test_pipette_view_old.py
@@ -89,6 +89,7 @@ def get_pipette_view(
         Dict[str, Optional[fluid_stack.FluidStack]]
     ] = None,
     has_clean_tips_by_id: Optional[Dict[str, bool]] = None,
+    last_tiprack_well_by_id: Optional[Dict[str, Optional[Tuple[str, str]]]] = None,
 ) -> PipetteView:
     """Get a pipette view test subject with the specified state."""
     state = PipetteState(
@@ -104,6 +105,7 @@ def get_pipette_view(
         liquid_presence_detection_by_id=liquid_presence_detection_by_id or {},
         ready_to_aspirate_by_id=ready_to_aspirate_by_id or {},
         has_clean_tips_by_id=has_clean_tips_by_id or {},
+        last_tiprack_well_by_id=last_tiprack_well_by_id or {},
     )
 
     return PipetteView(state=state)

--- a/api/tests/opentrons/protocol_engine/state/test_pipette_view_old.py
+++ b/api/tests/opentrons/protocol_engine/state/test_pipette_view_old.py
@@ -105,7 +105,7 @@ def get_pipette_view(
         liquid_presence_detection_by_id=liquid_presence_detection_by_id or {},
         ready_to_aspirate_by_id=ready_to_aspirate_by_id or {},
         has_clean_tips_by_id=has_clean_tips_by_id or {},
-        last_tiprack_well_by_id=last_tiprack_well_by_id or {},
+        last_tip_rack_well_by_id=last_tiprack_well_by_id or {},
     )
 
     return PipetteView(state=state)


### PR DESCRIPTION
# Overview

This PR refactors the way the Python API tracks where a tip has been picked up from. Previously we were relying on the `InstrumentContext._last_tip_picked_up_from` to keep track of which tip rack well the current tip was picked up from, mostly for the purposes of storing it for `return_tip`. The issue with this approach is that anything that did not go through the top level instrument context, whether it is via the cores or directly in protocol engine, would lead to this not being updated and lead to either incorrect behavior for tip returns or an error.

This became more acute with the introduction of liquid classes and allowing them to return tips and keep them at the end, as this variable wasn't getting updated and we had to manually code around that.

Now the tracking of the last tip rack well has been moved entirely to the engine, where it will store it as a combination of `labware_id` and `well_name`. This is then reconstructed into a `LabwareCore` and `WellCore` by the `InstrumentCore`, which is further reconstructed into a `Well` object by the top level `InstrumentContext`. This allowed a lot of the liquid class scaffolding around this issue to be removed and those methods to be simplified.

This change also required adding this functionality to the legacy core. With no engine, in those older cores we are now simply storing the legacy labware and well cores when a pick up tip or drop tip is called, allowing this new method to work via both intefaces.

Because it was discovered a lot of older protocols rely on `_last_tip_picked_up_from`, a property of the same name was added that uses the new interface. In addition, a version gated `current_tip_source_well()` function was added to provide a version-protected method that should now be used instead.

## Test Plan and Hands on Testing

Snapshots and integration tests should cover a lot of the regression testing, but the following protocols will be tested:

```
requirements = {
	"robotType": "Flex",
	"apiLevel": "2.25"
}


metadata = {
    "protocolName":'Return tip new',
    'author':'Jeremy'
}

def run(protocol_context):
	tiprack = protocol_context.load_labware("opentrons_flex_96_tiprack_200ul", "C2")
	trash = protocol_context.load_trash_bin('A3')
	pipette_1k = protocol_context.load_instrument("flex_1channel_1000", "right", tip_racks=[tiprack])
	nest_plate = protocol_context.load_labware("nest_96_wellplate_2ml_deep", "D1")
	arma_plate = protocol_context.load_labware("armadillo_96_wellplate_200ul_pcr_full_skirt", "D3")

	pipette_1k.pick_up_tip()

	pipette_1k.return_tip()

	water_class = protocol_context.get_liquid_class("water")

	pipette_1k.transfer_with_liquid_class(
		liquid_class=water_class,
		volume=200,
		source=nest_plate.wells()[:4],
		dest=arma_plate.wells()[:4],
		new_tip="always",
		trash_location=trash,
		return_tip=True,
	)

	pipette_1k.transfer_with_liquid_class(
		liquid_class=water_class,
		volume=200,
		source=nest_plate.wells()[0],
		dest=arma_plate.wells()[0],
		new_tip="once",
		trash_location=trash,
		keep_last_tip=True
	)


	pipette_1k.return_tip()
```
```
requirements = {
    "robotType": "OT-2",
    "apiLevel": "2.13"
}

metadata = {
    "protocolName":'Return tip OT-2 2.13',
    'author':'Jeremy'
}

def run(protocol_context):
    p300rack = protocol_context.load_labware('opentrons_96_tiprack_300ul', 1)
    p300 = protocol_context.load_instrument('p300_single_gen2', 'left', tip_racks=[p300rack])

    p300.pick_up_tip()

    p300.return_tip()
```

## Changelog

- Refactored `_last_tip_picked_up_from` to use engine and cores to keep track of tip, not the instrument context

## Review requests

Does the way we reconstruct the `Well` object make sense?

## Risk assessment

Medium/high, this refactor touches a lot of long existing methods and is not gated by version. There's no new logic added but this affects not only Flex run code but OT-2 older API versions as well.