### PR TITLE
feat(api): format the last entry of UserDefinedVolumes dictionaries

### DIFF
--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -2078,13 +2078,19 @@ class GeometryView:
         well_geometry = self._labware.get_well_geometry(
             labware_id=labware_id, well_name=well_name
         )
+        well_def = self._labware.get_well_definition(labware_id, well_name)
+        well_volumetric_capacity = float(well_def.totalLiquidVolume)
         if isinstance(well_geometry, InnerWellGeometry):
             return find_volume_inner_well_geometry(
-                target_height=target_height, well_geometry=well_geometry
+                target_height=target_height,
+                well_geometry=well_geometry,
             )
         else:
             return find_volume_user_defined_volumes(
-                target_height=target_height, well_geometry=well_geometry
+                target_height=target_height,
+                well_geometry=well_geometry,
+                total_well_height=well_def.depth,
+                total_well_volume=well_volumetric_capacity,
             )
 
     def find_height_at_well_volume(
@@ -2097,13 +2103,19 @@ class GeometryView:
         well_geometry = self._labware.get_well_geometry(
             labware_id=labware_id, well_name=well_name
         )
+        well_def = self._labware.get_well_definition(labware_id, well_name)
+        well_volumetric_capacity = float(well_def.totalLiquidVolume)
         if isinstance(well_geometry, InnerWellGeometry):
             return find_height_inner_well_geometry(
-                target_volume=target_volume, well_geometry=well_geometry
+                target_volume=target_volume,
+                well_geometry=well_geometry,
             )
         else:
             return find_height_user_defined_volumes(
-                target_volume=target_volume, well_geometry=well_geometry
+                target_volume=target_volume,
+                well_geometry=well_geometry,
+                total_well_volume=well_volumetric_capacity,
+                total_well_height=well_def.depth,
             )
 
     def get_well_height_after_liquid_handling(

--- a/api/src/opentrons/protocol_engine/state/inner_well_math_utils.py
+++ b/api/src/opentrons/protocol_engine/state/inner_well_math_utils.py
@@ -383,26 +383,44 @@ def _linear_interpolation(
     raise ValueError("linear interpolation failed")
 
 
-def find_volume_user_defined_volumes(
-    target_height: LiquidTrackingType, well_geometry: UserDefinedVolumes
-) -> LiquidTrackingType:
-    """Return a linear interpolation of volume based on target height."""
-    if isinstance(target_height, SimulatedProbeResult):
-        return target_height
+def _format_user_defined_volumes_height_volume(
+    total_well_height: float,
+    total_well_volume: float,
+    well_geometry: UserDefinedVolumes,
+) -> Tuple[List[float], List[float]]:
     sorted_volume_map = sorted(
         well_geometry.heightToVolumeMap, key=lambda section: section.height
     )
-    max_height = sorted_volume_map[-1].height
-    if target_height < 0 or target_height > max_height:
-        raise InvalidLiquidHeightFound(
-            f"Invalid target height {target_height} mm; max well height is {max_height} mm."
-        )
+
     volumes = [0.0]
     heights = [0.0]
     for pair in sorted_volume_map:
         volumes.append(pair.volume)
         heights.append(pair.height)
+    if total_well_height not in heights or total_well_volume not in volumes:
+        heights.append(total_well_height)
+        volumes.append(total_well_volume)
+    return heights, volumes
 
+
+def find_volume_user_defined_volumes(
+    target_height: LiquidTrackingType,
+    total_well_height: float,
+    total_well_volume: float,
+    well_geometry: UserDefinedVolumes,
+) -> LiquidTrackingType:
+    """Return a linear interpolation of volume based on target height."""
+    if isinstance(target_height, SimulatedProbeResult):
+        return target_height
+    if target_height < 0 or target_height > total_well_height:
+        raise InvalidLiquidHeightFound(
+            f"Invalid target height {target_height} mm; max well height is {total_well_height} mm."
+        )
+    heights, volumes = _format_user_defined_volumes_height_volume(
+        total_well_height=total_well_height,
+        total_well_volume=total_well_volume,
+        well_geometry=well_geometry,
+    )
     try:
         return _linear_interpolation(
             interpolating_from=heights, to_interpolate=volumes, target_val=target_height
@@ -415,26 +433,22 @@ def find_volume_user_defined_volumes(
 
 def find_height_user_defined_volumes(
     target_volume: LiquidTrackingType,
+    total_well_volume: float,
+    total_well_height: float,
     well_geometry: UserDefinedVolumes,
 ) -> LiquidTrackingType:
     """Return a linear interpolation of height based on target volume."""
     if isinstance(target_volume, SimulatedProbeResult):
         return target_volume
-    sorted_volume_map = sorted(
-        well_geometry.heightToVolumeMap, key=lambda section: section.height
-    )
-    max_volume = sorted_volume_map[-1].volume
-    if target_volume < 0 or target_volume > max_volume:
+    if target_volume < 0 or target_volume > total_well_volume:
         raise InvalidLiquidHeightFound(
-            f"Invalid target volume {target_volume} mm; max well volume is {max_volume} uL."
+            f"Invalid target volume {target_volume} uL; max well volume is {total_well_volume} uL."
         )
-
-    volumes = [0.0]
-    heights = [0.0]
-    for pair in sorted_volume_map:
-        volumes.append(pair.volume)
-        heights.append(pair.height)
-
+    heights, volumes = _format_user_defined_volumes_height_volume(
+        total_well_height=total_well_height,
+        total_well_volume=total_well_volume,
+        well_geometry=well_geometry,
+    )
     try:
         return _linear_interpolation(
             interpolating_from=volumes, to_interpolate=heights, target_val=target_volume

--- a/api/tests/opentrons/protocols/geometry/test_inner_well_math_utils.py
+++ b/api/tests/opentrons/protocols/geometry/test_inner_well_math_utils.py
@@ -10,7 +10,10 @@ from opentrons_shared_data.labware.labware_definition import (
     InnerWellGeometry,
     UserDefinedVolumes,
     HeightVolumePair,
+    LabwareDefinition,
+    labware_definition_type_adapter,
 )
+from opentrons_shared_data import load_shared_data, get_shared_data_root
 from opentrons.protocol_engine.state.inner_well_math_utils import (
     _cross_section_area_rectangular,
     _cross_section_area_circular,
@@ -407,12 +410,17 @@ def test_volume_at_section_boundary_heights(well: List[Any]) -> None:
 def test_get_user_volumes(user_defined_volumes_params: Dict[str, Any]) -> None:
     """Test linear interpolation math for user-defined volumes."""
     user_defined_volumes_obj = user_defined_volumes_params["obj"]
+    max_height = user_defined_volumes_obj.heightToVolumeMap[-1].height
+    max_volume = user_defined_volumes_obj.heightToVolumeMap[-1].volume
     inputs_expected_outputs = user_defined_volumes_params[
         "volume_inputs_expected_outputs"
     ]
     for height, expected_vol in inputs_expected_outputs:
         volume_estimate = find_volume_user_defined_volumes(
-            target_height=height, well_geometry=user_defined_volumes_obj
+            target_height=height,
+            well_geometry=user_defined_volumes_obj,
+            total_well_height=max_height,
+            total_well_volume=max_volume,
         )
         assert isinstance(volume_estimate, float)
         assert isclose(volume_estimate, expected_vol, abs_tol=0.001)
@@ -426,10 +434,15 @@ def test_get_user_heights(
     inputs_expected_outputs = user_defined_volumes_params[
         "height_inputs_expected_outputs"
     ]
+    max_height = user_defined_volumes_obj.heightToVolumeMap[-1].height
+    max_volume = user_defined_volumes_obj.heightToVolumeMap[-1].volume
 
     for vol, expected_height in inputs_expected_outputs:
         height_estimate = find_height_user_defined_volumes(
-            target_volume=vol, well_geometry=user_defined_volumes_obj
+            target_volume=vol,
+            well_geometry=user_defined_volumes_obj,
+            total_well_height=max_height,
+            total_well_volume=max_volume,
         )
         assert isinstance(height_estimate, float)
         assert isclose(height_estimate, expected_height, abs_tol=0.001)


### PR DESCRIPTION
## Overview
This is kind of a fix for the `UserDefinedVolumes` fetaure. Earlier, the last entry was required to equal the well's volumetric capacity and well depth. However, since even custom labware are required to list out their wells' full depth and total liquid volume in the shared data file outside the `innerLabwareGeometry`, I think we might as well just use that.

## TODO
Before I merge this I actually have to remove the js test that requires the last entry to equal the well's `depth` and `totalLiquidVolume`