### PR TITLE
fix(protocol-designer): require app version 8.5.1 to run

### DIFF
--- a/protocol-designer/release-notes.md
+++ b/protocol-designer/release-notes.md
@@ -41,7 +41,7 @@ Use Opentrons-verified liquid classes to automatically define transfer settings 
 - Successfully delete a defined liquid that has not been assigned to any location.
 - Display correct substep details for all transfer paths and pipettes.
 
-Running a protocol created in Protocol Designer now requires Opentrons App version 8.5.0 or newer.
+Running a protocol created in Protocol Designer now requires Opentrons App version 8.5.1 or newer.
 
 ## Opentrons Protocol Designer Changes in 8.4.4
 

--- a/protocol-designer/src/assets/localization/en/modal.json
+++ b/protocol-designer/src/assets/localization/en/modal.json
@@ -63,7 +63,7 @@
       "body12": "If the timer of a Heater-Shaker step is toggled on and off, the timer input field no longer errors.",
       "body13": "Successfully delete a defined liquid that has not been assigned to any location.",
       "body14": "Display correct substep details for all transfer paths and pipettes.",
-      "body15": "All protocols now require Opentrons App version 8.5.0+ to run.",
+      "body15": "All protocols now require Opentrons App version 8.5.1+ to run.",
       "body16": "For more information, see the <link1>Protocol Designer Instruction Manual</link1>.",
       "body2": "We're excited to introduce support for liquid classes and exporting Python!",
       "body3": "Additionally, improvements for the following:",

--- a/protocol-designer/src/pages/ProtocolOverview/ProtocolMetadata.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/ProtocolMetadata.tsx
@@ -19,7 +19,7 @@ import {
   LINK_BUTTON_STYLE,
 } from '../../components/atoms'
 
-const REQUIRED_APP_VERSION = '8.5.0'
+const REQUIRED_APP_VERSION = '8.5.1'
 
 type MetadataInfo = Array<{
   author?: string

--- a/protocol-designer/src/pages/ProtocolOverview/__tests__/ProtocolMetadata.test.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/__tests__/ProtocolMetadata.test.tsx
@@ -45,7 +45,7 @@ describe('ProtocolMetadata', () => {
     screen.getByText('Protocol Metadata')
     screen.getByText('Edit')
     screen.getByText('Required app version')
-    screen.getByText('8.5.0 or higher')
+    screen.getByText('8.5.1 or higher')
   })
 
   it('should render protocol metadata', () => {


### PR DESCRIPTION
closes RQA-4461

# Overview

Require app version 8.5.1 to run PD 8.5.0 to account for the RS hot fix coming out

## Test Plan and Hands on Testing

Review the 3 areas:

1. protocol overview
2. announcement modal
3. release notes

## Changelog

update required app veresion to 8.5.1 everywhere

## Risk assessment

low
