### PR TITLE
fix(step-generation): fix correction volume curve passing

### DIFF
--- a/app/src/organisms/ODD/QuickTransferFlow/__tests__/utils/quickTransferStepCommands.test.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/__tests__/utils/quickTransferStepCommands.test.ts
@@ -243,7 +243,6 @@ pipette.transfer_with_liquid_class(
                     "position_reference": "well-bottom",
                 },
                 "flow_rate_by_volume": [(0, 80)],
-                "correction_by_volume": [(0, 0)],
                 "delay": {"enabled": False},
                 "submerge": {
                     "delay": {"enabled": False},
@@ -262,6 +261,7 @@ pipette.transfer_with_liquid_class(
                     "touch_tip": {"enabled": False},
                     "blowout": {"enabled": True, "location": "source", "flow_rate": 50},
                 },
+                "correction_by_volume": [(0, 0)],
                 "push_out_by_volume": [(0, 0)],
                 "mix": {"enabled": False},
             },
@@ -396,7 +396,6 @@ pipette.consolidate_with_liquid_class(
                     "position_reference": "well-bottom",
                 },
                 "flow_rate_by_volume": [(0, 80)],
-                "correction_by_volume": [(0, 0)],
                 "delay": {"enabled": False},
                 "submerge": {
                     "delay": {"enabled": False},
@@ -415,6 +414,7 @@ pipette.consolidate_with_liquid_class(
                     "touch_tip": {"enabled": False},
                     "blowout": {"enabled": True, "location": "trash", "flow_rate": 50},
                 },
+                "correction_by_volume": [(0, 0)],
                 "push_out_by_volume": [(0, 0)],
                 "mix": {"enabled": False},
             },
@@ -550,7 +550,6 @@ pipette.distribute_with_liquid_class(
                     "position_reference": "well-bottom",
                 },
                 "flow_rate_by_volume": [(0, 80)],
-                "correction_by_volume": [(0, 0)],
                 "delay": {"enabled": False},
                 "submerge": {
                     "delay": {"enabled": False},
@@ -569,6 +568,7 @@ pipette.distribute_with_liquid_class(
                     "touch_tip": {"enabled": False},
                     "blowout": {"enabled": True, "location": "source", "flow_rate": 50},
                 },
+                "correction_by_volume": [(0, 0)],
                 "push_out_by_volume": [(0, 0)],
                 "mix": {"enabled": False},
             },
@@ -578,7 +578,6 @@ pipette.distribute_with_liquid_class(
                     "position_reference": "well-bottom",
                 },
                 "flow_rate_by_volume": [(0, 80)],
-                "correction_by_volume": [(0, 0)],
                 "delay": {"enabled": False},
                 "submerge": {
                     "delay": {"enabled": False},
@@ -597,6 +596,7 @@ pipette.distribute_with_liquid_class(
                     "touch_tip": {"enabled": False},
                     "blowout": {"enabled": True, "location": "source", "flow_rate": 50},
                 },
+                "correction_by_volume": [(0, 0)],
                 "conditioning_by_volume": [(0, 0)],
                 "disposal_by_volume": [(0, 0)],
             },

--- a/step-generation/src/__tests__/consolidate.test.ts
+++ b/step-generation/src/__tests__/consolidate.test.ts
@@ -153,7 +153,6 @@ mock_pipette.consolidate_with_liquid_class(
             "dispense": {
                 "dispense_position": {"offset": {"x": 0, "y": 0}},
                 "flow_rate_by_volume": [(0, 2.2)],
-                "correction_by_volume": [(0, 0)],
                 "delay": {"enabled": False},
                 "submerge": {
                     "delay": {"enabled": False},
@@ -166,6 +165,7 @@ mock_pipette.consolidate_with_liquid_class(
                     "touch_tip": {"enabled": False},
                     "blowout": {"enabled": False},
                 },
+                "correction_by_volume": [(0, 0)],
                 "push_out_by_volume": [(0, 0)],
                 "mix": {"enabled": False},
             },
@@ -246,7 +246,6 @@ mock_pipette.consolidate_with_liquid_class(
             "dispense": {
                 "dispense_position": {"offset": {"x": 0, "y": 0}},
                 "flow_rate_by_volume": [(0, 2.2)],
-                "correction_by_volume": [(0, 0)],
                 "delay": {"enabled": True, "duration": 12},
                 "submerge": {
                     "delay": {"enabled": False},
@@ -259,6 +258,7 @@ mock_pipette.consolidate_with_liquid_class(
                     "touch_tip": {"enabled": True, "z_offset": -3.4},
                     "blowout": {"enabled": True, "location": "destination", "flow_rate": 2.3},
                 },
+                "correction_by_volume": [(0, 0)],
                 "push_out_by_volume": [(0, 0)],
                 "mix": {"enabled": True, "repetitions": 1, "volume": 36},
             },
@@ -313,7 +313,6 @@ mock_pipette.consolidate_with_liquid_class(
             "dispense": {
                 "dispense_position": {"offset": {"x": 0, "y": 0}},
                 "flow_rate_by_volume": [(0, 2.2)],
-                "correction_by_volume": [(0, 0)],
                 "delay": {"enabled": False},
                 "submerge": {
                     "delay": {"enabled": False},
@@ -326,6 +325,7 @@ mock_pipette.consolidate_with_liquid_class(
                     "touch_tip": {"enabled": False},
                     "blowout": {"enabled": False},
                 },
+                "correction_by_volume": [(0, 0)],
                 "push_out_by_volume": [(0, 0)],
                 "mix": {"enabled": False},
             },

--- a/step-generation/src/__tests__/distribute.test.ts
+++ b/step-generation/src/__tests__/distribute.test.ts
@@ -189,7 +189,6 @@ mock_pipette.distribute_with_liquid_class(
             "dispense": {
                 "dispense_position": {"offset": {"x": 0, "y": 0, "z": 0}},
                 "flow_rate_by_volume": [(0, 2.2)],
-                "correction_by_volume": [(0, 0)],
                 "delay": {"enabled": False},
                 "submerge": {
                     "delay": {"enabled": False},
@@ -202,13 +201,13 @@ mock_pipette.distribute_with_liquid_class(
                     "touch_tip": {"enabled": False},
                     "blowout": {"enabled": True, "location": "trash", "flow_rate": 2.3},
                 },
+                "correction_by_volume": [(0, 0)],
                 "push_out_by_volume": [(0, 0)],
                 "mix": {"enabled": False},
             },
             "multi_dispense": {
                 "dispense_position": {"offset": {"x": 0, "y": 0, "z": 0}},
                 "flow_rate_by_volume": [(0, 2.2)],
-                "correction_by_volume": [(0, 0)],
                 "delay": {"enabled": False},
                 "submerge": {
                     "delay": {"enabled": False},
@@ -221,6 +220,7 @@ mock_pipette.distribute_with_liquid_class(
                     "touch_tip": {"enabled": False},
                     "blowout": {"enabled": True, "location": "trash", "flow_rate": 2.3},
                 },
+                "correction_by_volume": [(0, 0)],
                 "conditioning_by_volume": [(0, 0)],
                 "disposal_by_volume": [(0, 60)],
             },
@@ -1058,7 +1058,6 @@ mock_pipette.distribute_with_liquid_class(
             "dispense": {
                 "dispense_position": {"offset": {"x": 0, "y": 0, "z": 0}},
                 "flow_rate_by_volume": [(0, 2.2)],
-                "correction_by_volume": [(0, 0)],
                 "delay": {"enabled": True, "duration": 12},
                 "submerge": {
                     "delay": {"enabled": False},
@@ -1071,13 +1070,13 @@ mock_pipette.distribute_with_liquid_class(
                     "touch_tip": {"enabled": True, "z_offset": -3.4},
                     "blowout": {"enabled": True, "location": "trash", "flow_rate": 2.3},
                 },
+                "correction_by_volume": [(0, 0)],
                 "push_out_by_volume": [(0, 0)],
                 "mix": {"enabled": False},
             },
             "multi_dispense": {
                 "dispense_position": {"offset": {"x": 0, "y": 0, "z": 0}},
                 "flow_rate_by_volume": [(0, 2.2)],
-                "correction_by_volume": [(0, 0)],
                 "delay": {"enabled": True, "duration": 12},
                 "submerge": {
                     "delay": {"enabled": False},
@@ -1090,6 +1089,7 @@ mock_pipette.distribute_with_liquid_class(
                     "touch_tip": {"enabled": True, "z_offset": -3.4},
                     "blowout": {"enabled": True, "location": "trash", "flow_rate": 2.3},
                 },
+                "correction_by_volume": [(0, 0)],
                 "conditioning_by_volume": [(0, 10)],
                 "disposal_by_volume": [(0, 60)],
             },

--- a/step-generation/src/__tests__/liquidClassUtils.test.tsx
+++ b/step-generation/src/__tests__/liquidClassUtils.test.tsx
@@ -18,7 +18,10 @@ import {
 import { SOURCE_WELL_BLOWOUT_DESTINATION } from '../utils'
 import { getCustomLiquidClassProperties } from '../utils/liquidClassUtils'
 
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type {
+  ByTipTypeSetting,
+  LabwareDefinition2,
+} from '@opentrons/shared-data'
 
 describe('getCustomLiquidClassProperties', () => {
   it('returns all args populated for transfer', () => {
@@ -91,8 +94,18 @@ describe('getCustomLiquidClassProperties', () => {
         },
         pipetteName: 'p20_single_gen2',
         tiprackUri: 'opentrons/opentrons_96_tiprack_20ul/1',
-        aspirateCorrectionVolume: 5,
-        dispenseCorrectionVolume: 5,
+        liquidClassValuesForTip: {
+          aspirate: {
+            correctionByVolume: [[0, 5]],
+          },
+          singleDispense: {
+            correctionByVolume: [
+              [0, 5],
+              [100, 10],
+            ],
+          },
+          tiprack: 'opentrons/opentrons_96_tiprack_20ul/1',
+        } as ByTipTypeSetting,
       })
     ).toEqual(
       `
@@ -137,7 +150,6 @@ describe('getCustomLiquidClassProperties', () => {
             "position_reference": "well-bottom",
         },
         "flow_rate_by_volume": [(0, 2.2)],
-        "correction_by_volume": [(0, 5)],
         "delay": {"enabled": True, "duration": 20},
         "submerge": {
             "delay": {"enabled": True, "duration": 50},
@@ -163,6 +175,7 @@ describe('getCustomLiquidClassProperties', () => {
             },
             "blowout": {"enabled": True, "location": "source", "flow_rate": 2.3},
         },
+        "correction_by_volume": [(0, 5), (100, 10)],
         "push_out_by_volume": [(0, 0)],
         "mix": {"enabled": True, "repetitions": 3, "volume": 10},
     },
@@ -241,8 +254,23 @@ describe('getCustomLiquidClassProperties', () => {
         },
         pipetteName: 'p20_single_gen2',
         tiprackUri: 'opentrons/opentrons_96_tiprack_20ul/1',
-        aspirateCorrectionVolume: 5,
-        dispenseCorrectionVolume: 5,
+        liquidClassValuesForTip: {
+          aspirate: {
+            correctionByVolume: [[0, 5]],
+          },
+          singleDispense: {
+            correctionByVolume: [
+              [0, 5],
+              [100, 10],
+            ],
+          },
+          multiDispense: {
+            correctionByVolume: [
+              [0, 5],
+              [200, 20],
+            ],
+          },
+        } as ByTipTypeSetting,
       })
     ).toEqual(
       `
@@ -287,7 +315,6 @@ describe('getCustomLiquidClassProperties', () => {
             "position_reference": "well-bottom",
         },
         "flow_rate_by_volume": [(0, 2.2)],
-        "correction_by_volume": [(0, 5)],
         "delay": {"enabled": True, "duration": 20},
         "submerge": {
             "delay": {"enabled": True, "duration": 50},
@@ -313,6 +340,7 @@ describe('getCustomLiquidClassProperties', () => {
             },
             "blowout": {"enabled": True, "location": "source", "flow_rate": 2.3},
         },
+        "correction_by_volume": [(0, 5), (100, 10)],
         "push_out_by_volume": [(0, 0)],
         "mix": {"enabled": False},
     },
@@ -322,7 +350,6 @@ describe('getCustomLiquidClassProperties', () => {
             "position_reference": "well-bottom",
         },
         "flow_rate_by_volume": [(0, 2.2)],
-        "correction_by_volume": [(0, 5)],
         "delay": {"enabled": True, "duration": 20},
         "submerge": {
             "delay": {"enabled": True, "duration": 50},
@@ -348,6 +375,7 @@ describe('getCustomLiquidClassProperties', () => {
             },
             "blowout": {"enabled": True, "location": "source", "flow_rate": 2.3},
         },
+        "correction_by_volume": [(0, 5), (200, 20)],
         "conditioning_by_volume": [(0, 5)],
         "disposal_by_volume": [(0, 5)],
     },

--- a/step-generation/src/__tests__/transfer.test.ts
+++ b/step-generation/src/__tests__/transfer.test.ts
@@ -207,7 +207,6 @@ mock_pipette.transfer_with_liquid_class(
                     "position_reference": "well-bottom",
                 },
                 "flow_rate_by_volume": [(0, 12)],
-                "correction_by_volume": [(0, 0)],
                 "delay": {"enabled": False},
                 "submerge": {
                     "delay": {"enabled": False},
@@ -228,6 +227,7 @@ mock_pipette.transfer_with_liquid_class(
                     "touch_tip": {"enabled": False},
                     "blowout": {"enabled": False},
                 },
+                "correction_by_volume": [(0, 0)],
                 "push_out_by_volume": [(0, 0)],
                 "mix": {"enabled": False},
             },
@@ -398,7 +398,6 @@ mock_pipette.transfer_with_liquid_class(
                     "position_reference": "well-bottom",
                 },
                 "flow_rate_by_volume": [(0, 12)],
-                "correction_by_volume": [(0, 0)],
                 "delay": {"enabled": False},
                 "submerge": {
                     "delay": {"enabled": False},
@@ -419,6 +418,7 @@ mock_pipette.transfer_with_liquid_class(
                     "touch_tip": {"enabled": False},
                     "blowout": {"enabled": False},
                 },
+                "correction_by_volume": [(0, 0)],
                 "push_out_by_volume": [(0, 0)],
                 "mix": {"enabled": False},
             },
@@ -651,7 +651,6 @@ mock_pipette.transfer_with_liquid_class(
                     "position_reference": "well-bottom",
                 },
                 "flow_rate_by_volume": [(0, 12)],
-                "correction_by_volume": [(0, 0)],
                 "delay": {"enabled": False},
                 "submerge": {
                     "delay": {"enabled": False},
@@ -672,6 +671,7 @@ mock_pipette.transfer_with_liquid_class(
                     "touch_tip": {"enabled": False},
                     "blowout": {"enabled": False},
                 },
+                "correction_by_volume": [(0, 0)],
                 "push_out_by_volume": [(0, 0)],
                 "mix": {"enabled": False},
             },
@@ -5552,7 +5552,6 @@ mock_pipette.transfer_with_liquid_class(
                     "position_reference": "well-bottom",
                 },
                 "flow_rate_by_volume": [(0, 12)],
-                "correction_by_volume": [(0, 0)],
                 "delay": {"enabled": True, "duration": 12},
                 "submerge": {
                     "delay": {"enabled": False},
@@ -5573,6 +5572,7 @@ mock_pipette.transfer_with_liquid_class(
                     "touch_tip": {"enabled": True, "z_offset": -3.4},
                     "blowout": {"enabled": True, "location": "trash", "flow_rate": 2.3},
                 },
+                "correction_by_volume": [(0, 0)],
                 "push_out_by_volume": [(0, 0)],
                 "mix": {"enabled": True, "repetitions": 1, "volume": 36},
             },

--- a/step-generation/src/commandCreators/compound/consolidate.ts
+++ b/step-generation/src/commandCreators/compound/consolidate.ts
@@ -219,15 +219,17 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
     name: pipetteName,
     pythonName: pythonPipetteName,
   } = pipetteEntities[pipette]
-  const liquidClassValuesForTip = getAllLiquidClassDefs()
-    [
-      liquidClass === NONE_LIQUID_CLASS_NAME || liquidClass == null
-        ? WATER_LIQUID_CLASS_NAME
-        : liquidClass
-    ].byPipette?.find(
-      ({ pipetteModel }) => (pipetteModel = getFlexNameConversion(pipetteSpecs))
-    )
-    ?.byTipType.find(({ tiprack }) => tiprack === tiprackDefUri)
+  const liquidClassValuesForTip =
+    getAllLiquidClassDefs()
+      [
+        liquidClass === NONE_LIQUID_CLASS_NAME || liquidClass == null
+          ? WATER_LIQUID_CLASS_NAME
+          : liquidClass
+      ].byPipette?.find(
+        ({ pipetteModel }) =>
+          pipetteModel === getFlexNameConversion(pipetteSpecs)
+      )
+      ?.byTipType.find(({ tiprack }) => tiprack === tiprackDefUri) ?? null
   const { aspirate } = liquidClassValuesForTip ?? {}
   const { multiWellHandling } = getTransferPlanAndReferenceVolumes({
     pipetteSpecs,
@@ -323,16 +325,7 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
       byVolumeProperty: 'correctionByVolume',
       defaultValue: 0,
     }) ?? 0
-  const dispenseCorrectionForTotalDispense =
-    getByVolumeValue({
-      liquidClass,
-      pipetteSpecs,
-      tiprackDefUri: tipRack,
-      targetVolume: volume,
-      liquidHandlingAction: 'singleDispense',
-      byVolumeProperty: 'correctionByVolume',
-      defaultValue: 0,
-    }) ?? 0
+
   /** needed for python generation! > */
   const destTrashPipetteName =
     trashBinEntities[destLabware]?.pythonName ??
@@ -361,8 +354,7 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
         ? getFlexNameConversion(pipetteSpecs)
         : pipetteName,
       tiprackUri: tipRack,
-      aspirateCorrectionVolume: aspirateCorrectionVolumeForSampleAspiration,
-      dispenseCorrectionVolume: dispenseCorrectionForTotalDispense,
+      liquidClassValuesForTip,
     })}`,
   ]
   const customLiquidClass = `${PROTOCOL_CONTEXT_NAME}.define_liquid_class(\n${indentPyLines(

--- a/step-generation/src/commandCreators/compound/distribute.ts
+++ b/step-generation/src/commandCreators/compound/distribute.ts
@@ -226,15 +226,17 @@ export const distribute: CommandCreator<DistributeArgs> = (
     pythonName: pythonPipetteName,
   } = pipetteEntities[pipette]
 
-  const liquidClassValuesForTip = getAllLiquidClassDefs()
-    [
-      liquidClass === NONE_LIQUID_CLASS_NAME || liquidClass == null
-        ? WATER_LIQUID_CLASS_NAME
-        : liquidClass
-    ].byPipette?.find(
-      ({ pipetteModel }) => (pipetteModel = getFlexNameConversion(pipetteSpecs))
-    )
-    ?.byTipType.find(({ tiprack }) => tiprack === tiprackDefUri)
+  const liquidClassValuesForTip =
+    getAllLiquidClassDefs()
+      [
+        liquidClass === NONE_LIQUID_CLASS_NAME || liquidClass == null
+          ? WATER_LIQUID_CLASS_NAME
+          : liquidClass
+      ].byPipette?.find(
+        ({ pipetteModel }) =>
+          pipetteModel === getFlexNameConversion(pipetteSpecs)
+      )
+      ?.byTipType.find(({ tiprack }) => tiprack === tiprackDefUri) ?? null
   const { aspirate, multiDispense } = liquidClassValuesForTip ?? {}
   const { multiWellHandling } = getTransferPlanAndReferenceVolumes({
     pipetteSpecs,
@@ -347,16 +349,6 @@ export const distribute: CommandCreator<DistributeArgs> = (
       errors,
     }
 
-  const aspirateCorrectionVolume =
-    getByVolumeValue({
-      liquidClass,
-      pipetteSpecs,
-      tiprackDefUri: tipRack,
-      targetVolume: volume,
-      liquidHandlingAction: 'aspirate',
-      byVolumeProperty: 'correctionByVolume',
-      defaultValue: 0,
-    }) ?? 0
   const dispenseCorrectionVolumeForDestination =
     getByVolumeValue({
       liquidClass,
@@ -395,8 +387,7 @@ export const distribute: CommandCreator<DistributeArgs> = (
         ? getFlexNameConversion(pipetteSpecs)
         : pipetteName,
       tiprackUri: tipRack,
-      aspirateCorrectionVolume: aspirateCorrectionVolume,
-      dispenseCorrectionVolume: dispenseCorrectionVolumeForDestination,
+      liquidClassValuesForTip,
     })}`,
   ]
   const customLiquidClass = `${PROTOCOL_CONTEXT_NAME}.define_liquid_class(\n${indentPyLines(

--- a/step-generation/src/commandCreators/compound/transfer.ts
+++ b/step-generation/src/commandCreators/compound/transfer.ts
@@ -2,14 +2,17 @@ import assert from 'assert'
 import zip from 'lodash/zip'
 
 import {
+  getAllLiquidClassDefs,
   getByVolumeValue,
   getFlexNameConversion,
   getMmFromBottom,
   GRIPPER_WASTE_CHUTE_ADDRESSABLE_AREA,
   isFlexPipette,
   LOW_VOLUME_PIPETTES,
+  NONE_LIQUID_CLASS_NAME,
   POSITION_REFERENCE_MAPPED_TO_WELL_ORIGIN,
   SAFE_MOVE_TO_WELL_LOCATION,
+  WATER_LIQUID_CLASS_NAME,
   WELL_ORIGIN_TOP,
 } from '@opentrons/shared-data'
 
@@ -311,6 +314,32 @@ export const transfer: CommandCreator<TransferArgs> = (
     pythonName: pythonPipetteName,
   } = pipetteEntities[args.pipette]
 
+  const tiprack = Object.values(labwareEntities).find(
+    ({ labwareDefURI }) => labwareDefURI === tipRack
+  )
+  if (tiprack == null) {
+    errors.push(
+      errorCreators.labwareDoesNotExist({
+        actionName,
+        labware: tipRack,
+      })
+    )
+  }
+
+  const { labwareDefURI: tiprackDefUri } = tiprack ?? {}
+
+  const liquidClassValuesForTip =
+    getAllLiquidClassDefs()
+      [
+        liquidClass === NONE_LIQUID_CLASS_NAME || liquidClass == null
+          ? WATER_LIQUID_CLASS_NAME
+          : liquidClass
+      ].byPipette?.find(
+        ({ pipetteModel }) =>
+          pipetteModel === getFlexNameConversion(pipetteSpecs)
+      )
+      ?.byTipType.find(({ tiprack }) => tiprack === tiprackDefUri) ?? null
+
   const dispenseCorrectionVolumeForSubtransferTarget =
     getByVolumeValue({
       liquidClass: args.liquidClass,
@@ -363,8 +392,7 @@ export const transfer: CommandCreator<TransferArgs> = (
         ? getFlexNameConversion(pipetteSpecs)
         : pipetteName,
       tiprackUri: tipRack,
-      aspirateCorrectionVolume: dispenseCorrectionVolumeForSubtransferTarget,
-      dispenseCorrectionVolume: aspirateCorrectionVolumeForSubtransferTarget,
+      liquidClassValuesForTip,
     })}`,
   ]
   const customLiquidClass = `${PROTOCOL_CONTEXT_NAME}.define_liquid_class(\n${indentPyLines(

--- a/step-generation/src/utils/liquidClassUtils.ts
+++ b/step-generation/src/utils/liquidClassUtils.ts
@@ -6,6 +6,7 @@ import {
 } from './misc'
 import { formatPyDict } from './pythonFormat'
 
+import type { ByTipTypeSetting } from '@opentrons/shared-data'
 import type {
   ConsolidateArgs,
   DistributeArgs,
@@ -19,20 +20,13 @@ interface CustomLiquidClassPropertiesProps {
   args: TransferArgs | ConsolidateArgs | DistributeArgs
   pipetteName: string
   tiprackUri: string
-  aspirateCorrectionVolume: number
-  dispenseCorrectionVolume: number
+  liquidClassValuesForTip: ByTipTypeSetting | null
 }
 
 export const getCustomLiquidClassProperties = (
   props: CustomLiquidClassPropertiesProps
 ): string => {
-  const {
-    args,
-    pipetteName,
-    tiprackUri,
-    aspirateCorrectionVolume,
-    dispenseCorrectionVolume,
-  } = props
+  const { args, pipetteName, tiprackUri, liquidClassValuesForTip } = props
   let aspirateMixArgs: InnerMixArgs | null = null
   if ('mixBeforeAspirate' in args) {
     aspirateMixArgs = args.mixBeforeAspirate as InnerMixArgs | null
@@ -50,7 +44,6 @@ export const getCustomLiquidClassProperties = (
       position_reference: args.dispensePositionReference,
     },
     flow_rate_by_volume: [[0, args.dispenseFlowRateUlSec ?? 0]],
-    correction_by_volume: [[0, dispenseCorrectionVolume ?? 0]],
     delay: {
       enabled: args.dispenseDelay != null,
       duration: args.dispenseDelay?.seconds ?? undefined,
@@ -125,7 +118,8 @@ export const getCustomLiquidClassProperties = (
           flow_rate_by_volume: [[0, args.aspirateFlowRateUlSec]],
 
           pre_wet: args.preWetTip,
-          correction_by_volume: [[0, aspirateCorrectionVolume ?? 0]],
+          correction_by_volume: liquidClassValuesForTip?.aspirate
+            .correctionByVolume ?? [[0, 0]], // nullish coalescing for type checks. Should never hit
           delay: {
             enabled: args.aspirateDelay != null,
             duration: args.aspirateDelay?.seconds ?? undefined,
@@ -183,6 +177,8 @@ export const getCustomLiquidClassProperties = (
         },
         dispense: {
           ...sharedDispenseArgs,
+          correction_by_volume: liquidClassValuesForTip?.singleDispense
+            .correctionByVolume ?? [[0, 0]], // nullish coalescing for type checks. Should never hit
           push_out_by_volume: [[0, args.pushOut ?? 0]],
           mix: {
             enabled:
@@ -204,6 +200,8 @@ export const getCustomLiquidClassProperties = (
               multi_dispense: {
                 ...sharedDispenseArgs,
                 //  distribute specific args
+                correction_by_volume: liquidClassValuesForTip?.multiDispense
+                  ?.correctionByVolume ?? [[0, 0]], // nullish coalescing for type checks. Should never hit
                 ...('conditioningVolume' in args
                   ? {
                       conditioning_by_volume: [


### PR DESCRIPTION
# Overview

Rather than interpolating a single point and passing that as a custom liquid class property, we should pass the entire correctionByVolume array from the liquid class's definition (for aspirate, singleDispense, and multiDispense)

## Test Plan and Hands on Testing

- create a transfer form with a liquid class selected
- export Python and verify that full `correction_by_volume` properties are present (directly matching that in liquid class)
- repeat with distribute and consolidate

## Changelog

- update logic for getting correctionByVolume property for custom liquid class
- fix unit tests

## Review requests

- see test paln

## Risk assessment

lowish