### PR TITLE
fix(api): Re-enable the TOF sensor on the Z for the Flex Stacker module.

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/flex_stacker/retrieve.py
+++ b/api/src/opentrons/protocol_engine/commands/flex_stacker/retrieve.py
@@ -275,11 +275,7 @@ class RetrieveImpl(AbstractCommandImpl[RetrieveParams, _ExecuteReturn]):
             try:
                 stacker_hw.set_stacker_identify(True)
                 await stacker_hw.dispense_labware(
-                    labware_height=stacker_state.get_pool_height_minus_overlap(),
-                    # TODO (ba, 2025-07-18): This disables Labware sensing on the
-                    # stacker tower due to inconsistensies with data seen
-                    # in PVT stacker, review this once we have more data.
-                    enforce_hopper_lw_sensing=False,
+                    labware_height=stacker_state.get_pool_height_minus_overlap()
                 )
             except (
                 FlexStackerStallError,

--- a/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_retrieve.py
+++ b/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_retrieve.py
@@ -206,9 +206,7 @@ async def test_retrieve_primary_only(
     result = await subject.execute(data)
 
     decoy.verify(
-        await stacker_hardware.dispense_labware(
-            labware_height=4, enforce_hopper_lw_sensing=False
-        ),
+        await stacker_hardware.dispense_labware(labware_height=4),
         times=1,
     )
 
@@ -308,9 +306,7 @@ async def test_retrieve_primary_and_lid(
     result = await subject.execute(data)
 
     decoy.verify(
-        await stacker_hardware.dispense_labware(
-            labware_height=8, enforce_hopper_lw_sensing=False
-        ),
+        await stacker_hardware.dispense_labware(labware_height=8),
         times=1,
     )
 
@@ -432,9 +428,7 @@ async def test_retrieve_primary_and_adapter(
     result = await subject.execute(data)
 
     decoy.verify(
-        await stacker_hardware.dispense_labware(
-            labware_height=12, enforce_hopper_lw_sensing=False
-        ),
+        await stacker_hardware.dispense_labware(labware_height=12),
         times=1,
     )
 
@@ -583,7 +577,7 @@ async def test_retrieve_primary_adapter_and_lid(
 
     decoy.verify(
         await stacker_hardware.dispense_labware(
-            labware_height=16, enforce_hopper_lw_sensing=False
+            labware_height=16,
         ),
         times=1,
     )
@@ -742,7 +736,7 @@ async def test_retrieve_raises_recoverable_error(
 
     decoy.when(
         await stacker_hardware.dispense_labware(
-            labware_height=16, enforce_hopper_lw_sensing=False
+            labware_height=16,
         )
     ).then_raise(shared_data_error)
 


### PR DESCRIPTION
# Overview

We disabled the TOF sensor module preemptively to prevent potential issues between DVT and PVT stackers. Right now, there are no issues with the current batch of stackers, so we should be good to re-enable the Z TOF sensor so QA can test the error recovery flows.

## Test Plan and Hands on Testing

- [ ] Make sure the stacker can sense labware on the Z when dispensing

## Changelog

- set enforce_hopper_lw_sensing to True by default to enable tof sensor on the Z

## Review requests
## Risk assessment
