### PR TITLE
test(shared-data): check that standard liquid class correction volumes are non-negative

### DIFF
--- a/shared-data/python_tests/liquid_classes/test_liquid_class_values.py
+++ b/shared-data/python_tests/liquid_classes/test_liquid_class_values.py
@@ -18,7 +18,7 @@ def _get_all_liquid_classes() -> List[str]:
 @pytest.mark.parametrize("liquid_class_name", list(_get_all_liquid_classes()))
 def test_correction_values_equal_each_other(liquid_class_name: str) -> None:
     """The correction volume values for each pipette/tiprack combo should all be equal to one another."""
-    liquid_class_def = load_definition(liquid_class_name, version=1, schema_version=1)
+    liquid_class_def = load_definition(liquid_class_name)
     incorrect_combos = []
     for by_pipette in liquid_class_def.byPipette:
         for liquid_class_props in by_pipette.byTipType:
@@ -40,9 +40,35 @@ def test_correction_values_equal_each_other(liquid_class_name: str) -> None:
 
 
 @pytest.mark.parametrize("liquid_class_name", list(_get_all_liquid_classes()))
+def test_correction_volume_not_negative(liquid_class_name: str) -> None:
+    """Correction volumes must not push the plunger below zero position or else PipetteNotReadyToAspirateError."""
+    liquid_class_def = load_definition(liquid_class_name)
+    for by_pipette in liquid_class_def.byPipette:
+        for by_tip_type in by_pipette.byTipType:
+            for action_name, correction_by_volume in [
+                ("aspirate", by_tip_type.aspirate.correctionByVolume),
+                ("singleDispense", by_tip_type.singleDispense.correctionByVolume),
+                ("multiDispense", by_tip_type.multiDispense.correctionByVolume),
+            ]:
+                # The correction volume at 0 must be 0:
+                assert (
+                    0.0,
+                    0.0,
+                ) in correction_by_volume, f"Correction volume not 0 at 0 in {by_pipette.pipetteModel} {by_tip_type.tiprack} {action_name}"
+                # The nominal volume + correction volume must never be below 0.
+                # (Seth thinks this check is sufficient for ensuring that the plunger
+                # won't go below the zero position, whereas David thinks we need a
+                # stronger check that takes into account ul_per_mm(). But it's a start.)
+                for nominal_volume, correction_volume in correction_by_volume:
+                    assert (
+                        nominal_volume + correction_volume >= 0
+                    ), f"Volume + correction volume is negative in {by_pipette.pipetteModel} {by_tip_type.tiprack} {action_name}"
+
+
+@pytest.mark.parametrize("liquid_class_name", list(_get_all_liquid_classes()))
 def test_flow_rates_equal_each_other(liquid_class_name: str) -> None:
     """The dispense flow rate values for each pipette/tiprack combo should all be equal to one another."""
-    liquid_class_def = load_definition(liquid_class_name, version=1, schema_version=1)
+    liquid_class_def = load_definition(liquid_class_name)
     incorrect_combos = []
     for by_pipette in liquid_class_def.byPipette:
         for liquid_class_props in by_pipette.byTipType:

--- a/shared-data/python_tests/liquid_classes/test_liquid_class_values.py
+++ b/shared-data/python_tests/liquid_classes/test_liquid_class_values.py
@@ -45,24 +45,22 @@ def test_correction_volume_not_negative(liquid_class_name: str) -> None:
     liquid_class_def = load_definition(liquid_class_name)
     for by_pipette in liquid_class_def.byPipette:
         for by_tip_type in by_pipette.byTipType:
-            for action_name, correction_by_volume in [
-                ("aspirate", by_tip_type.aspirate.correctionByVolume),
-                ("singleDispense", by_tip_type.singleDispense.correctionByVolume),
-                ("multiDispense", by_tip_type.multiDispense.correctionByVolume),
-            ]:
-                # The correction volume at 0 must be 0:
+            # We just need to check one of aspirate/singleDispense/multiDispense, because
+            # the test above ensures that all 3 are the same.
+            correction_by_volume = by_tip_type.aspirate.correctionByVolume
+            # The correction volume at 0 must be 0:
+            assert (
+                0.0,
+                0.0,
+            ) in correction_by_volume, f"Correction volume not 0 at 0 in {by_pipette.pipetteModel} {by_tip_type.tiprack}"
+            # The nominal volume + correction volume must never be below 0.
+            # (Seth thinks this check is sufficient to ensure that the plunger won't
+            # go below the zero position, whereas David thinks we need a stronger
+            # check that takes into account ul_per_mm(). But this is a start.)
+            for nominal_volume, correction_volume in correction_by_volume:
                 assert (
-                    0.0,
-                    0.0,
-                ) in correction_by_volume, f"Correction volume not 0 at 0 in {by_pipette.pipetteModel} {by_tip_type.tiprack} {action_name}"
-                # The nominal volume + correction volume must never be below 0.
-                # (Seth thinks this check is sufficient for ensuring that the plunger
-                # won't go below the zero position, whereas David thinks we need a
-                # stronger check that takes into account ul_per_mm(). But it's a start.)
-                for nominal_volume, correction_volume in correction_by_volume:
-                    assert (
-                        nominal_volume + correction_volume >= 0
-                    ), f"Volume + correction volume is negative in {by_pipette.pipetteModel} {by_tip_type.tiprack} {action_name}"
+                    nominal_volume + correction_volume >= 0
+                ), f"Volume + correction volume is negative in {by_pipette.pipetteModel} {by_tip_type.tiprack}"
 
 
 @pytest.mark.parametrize("liquid_class_name", list(_get_all_liquid_classes()))


### PR DESCRIPTION
# Overview

This adds a check to the validation tests for our standard liquid classes to make sure we don't have any values that would push the plunger below the zero position, which would cause a `PipetteNotReadyToAspirateError`.

Note that this does not address the problem with user-defined liquid classes. This just helps me be more confident that our standard liquid classes aren't broken out-of-the-box. AUTH-2154

## Test Plan and Hands on Testing

All of our default liquid classes currently pass.

## Risk assessment

Low, test-only change.