### PR TITLE
feat(api): remove the heater shaker low temp limit

### DIFF
--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -912,11 +912,17 @@ class HeaterShakerContext(ModuleContext):
         Use :py:meth:`~.HeaterShakerContext.wait_for_temperature` to delay
         protocol execution.
 
-        :param celsius: A value between 27 and 95, representing the target temperature in °C.
+        .. versionchanged:: 2.25
+            Removed the minimum temperature limit of 37 °C. Note that temperatures under ambient are
+            not achievable.
+
+        :param celsius: A value under 95, representing the target temperature in °C.
                         Values are automatically truncated to two decimal places,
                         and the Heater-Shaker module has a temperature accuracy of ±0.5 °C.
         """
-        validated_temp = validate_heater_shaker_temperature(celsius=celsius)
+        validated_temp = validate_heater_shaker_temperature(
+            celsius=celsius, api_version=self.api_version
+        )
         self._core.set_target_temperature(celsius=validated_temp)
 
     @requires_version(2, 13)

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -894,7 +894,11 @@ class HeaterShakerContext(ModuleContext):
 
         No other protocol commands will execute while waiting for the temperature.
 
-        :param celsius: A value between 27 and 95, representing the target temperature in °C.
+        .. versionchanged:: 2.25
+            Removed the minimum temperature limit of 37 °C. Note that temperatures under ambient are
+            not achievable.
+
+        :param celsius: A value under 95, representing the target temperature in °C.
                         Values are automatically truncated to two decimal places,
                         and the Heater-Shaker module has a temperature accuracy of ±0.5 °C.
         """

--- a/api/src/opentrons/protocol_api/module_validation_and_errors.py
+++ b/api/src/opentrons/protocol_api/module_validation_and_errors.py
@@ -1,10 +1,13 @@
 """Contains module command validation functions and module errors for heater-shaker."""
 
+from opentrons.protocols.api_support.types import APIVersion
+
 # TODO (spp, 2022-03-22): Move these values to heater-shaker module definition.
 HEATER_SHAKER_TEMPERATURE_MIN = 37
 HEATER_SHAKER_TEMPERATURE_MAX = 95
 HEATER_SHAKER_SPEED_MIN = 200
 HEATER_SHAKER_SPEED_MAX = 3000
+HEATER_SHAKER_TEMPERATURE_MIN_REMOVED_IN = APIVersion(2, 25)
 
 
 class InvalidTargetTemperatureError(ValueError):
@@ -15,8 +18,18 @@ class InvalidTargetSpeedError(ValueError):
     """An error raised when attempting to set an invalid target speed."""
 
 
-def validate_heater_shaker_temperature(celsius: float) -> float:
-    """Verify that the target temperature being set is valid for heater-shaker."""
+def _validate_hs_temp_nomin(celsius: float) -> float:
+    if celsius <= HEATER_SHAKER_TEMPERATURE_MAX:
+        return celsius
+    else:
+        raise InvalidTargetTemperatureError(
+            f"Cannot set Heater-Shaker to {celsius} °C."
+            f" The maximum temperature for the Heater-Shaker is"
+            f"{HEATER_SHAKER_TEMPERATURE_MAX} °C."
+        )
+
+
+def _validate_hs_temp_min(celsius: float) -> float:
     if HEATER_SHAKER_TEMPERATURE_MIN <= celsius <= HEATER_SHAKER_TEMPERATURE_MAX:
         return celsius
     else:
@@ -25,6 +38,16 @@ def validate_heater_shaker_temperature(celsius: float) -> float:
             f" Valid range is {HEATER_SHAKER_TEMPERATURE_MIN}-"
             f"{HEATER_SHAKER_TEMPERATURE_MAX} °C."
         )
+
+
+def validate_heater_shaker_temperature(
+    celsius: float, api_version: APIVersion
+) -> float:
+    """Verify that the target temperature being set is valid for heater-shaker."""
+    if api_version < HEATER_SHAKER_TEMPERATURE_MIN_REMOVED_IN:
+        return _validate_hs_temp_min(celsius)
+    else:
+        return _validate_hs_temp_nomin(celsius)
 
 
 def validate_heater_shaker_speed(rpm: int) -> int:

--- a/api/tests/opentrons/protocol_api_old/test_module_validation_and_errors.py
+++ b/api/tests/opentrons/protocol_api_old/test_module_validation_and_errors.py
@@ -1,5 +1,6 @@
 import pytest
 
+from opentrons.protocols.api_support.types import APIVersion
 from opentrons.protocol_api.module_validation_and_errors import (
     validate_heater_shaker_temperature,
     validate_heater_shaker_speed,
@@ -11,17 +12,37 @@ from opentrons.protocol_api.module_validation_and_errors import (
 @pytest.mark.parametrize("valid_celsius_value", [37.0, 37.1, 50, 94.99, 95])
 def test_validate_heater_shaker_temperature(valid_celsius_value: float) -> None:
     """It should return the validated temperature value."""
-    validated = validate_heater_shaker_temperature(celsius=valid_celsius_value)
+    validated = validate_heater_shaker_temperature(
+        celsius=valid_celsius_value, api_version=APIVersion(2, 25)
+    )
     assert validated == valid_celsius_value
 
 
 @pytest.mark.parametrize("invalid_celsius_value", [-1, 0, 36.99, 95.01])
-def test_validate_heater_shaker_temperature_raises(
+def test_validate_heater_shaker_temperature_raises_under_api_225(
     invalid_celsius_value: float,
 ) -> None:
     """It should raise an error for invalid temperature values."""
     with pytest.raises(InvalidTargetTemperatureError):
-        validate_heater_shaker_temperature(celsius=invalid_celsius_value)
+        validate_heater_shaker_temperature(
+            celsius=invalid_celsius_value, api_version=APIVersion(2, 24)
+        )
+
+
+@pytest.mark.parametrize("invalid_celsius_value", [95.01])
+def test_validate_heater_shaker_temperature_raises_over_api_225(
+    invalid_celsius_value: float,
+) -> None:
+    """It should raise an error for invalid temperature values."""
+    with pytest.raises(InvalidTargetTemperatureError):
+        validate_heater_shaker_temperature(
+            celsius=invalid_celsius_value, api_version=APIVersion(2, 25)
+        )
+
+
+def test_validate_heater_shaker_temperature_passes_low_temp_over_api_225() -> None:
+    """It should not raise an error for values under 37."""
+    assert validate_heater_shaker_temperature(celsius=22, api_version=APIVersion(2, 25))
 
 
 @pytest.mark.parametrize("valid_rpm_value", [200, 201, 1000, 2999, 3000])


### PR DESCRIPTION
This is a helpful limit to prevent people from commanding an unachievable temperature; but sometimes people have nice ACs in their labs. Remove the limit.

Closes EXEC-1654

## testing
- on api 2.25 you should be able to command 30C