### PR TITLE
feat(opentrons-ai-client, opentrons-ai-server): content field 

### DIFF
--- a/opentrons-ai-client/src/analytics/constants.ts
+++ b/opentrons-ai-client/src/analytics/constants.ts
@@ -1,4 +1,4 @@
-export const TRACK_EVENTS = {
+export const ANALYTICS = {
   // App lifecycle
   APP_OPEN: 'appOpen',
 
@@ -25,4 +25,4 @@ export const TRACK_EVENTS = {
   FEEDBACK_SENT: 'feedback-sent',
 } as const
 
-export type AnalyticsTrackEvent = typeof TRACK_EVENTS[keyof typeof TRACK_EVENTS]
+export type AnalyticsTrackEvent = typeof ANALYTICS[keyof typeof ANALYTICS]

--- a/opentrons-ai-client/src/analytics/constants.ts
+++ b/opentrons-ai-client/src/analytics/constants.ts
@@ -1,0 +1,28 @@
+export const TRACK_EVENTS = {
+  // App lifecycle
+  APP_OPEN: 'appOpen',
+
+  // Authentication
+  USER_LOGIN: 'user-login',
+  USER_LOGOUT: 'user-logout',
+
+  // Chat interactions
+  CHAT_SUBMITTED: 'chat-submitted',
+  SUBMIT_PROMPT: 'submit-prompt',
+
+  // Protocol actions
+  GENERATED_PROTOCOL: 'generated-protocol',
+  REGENERATE_PROTOCOL: 'regenerate-protocol',
+  DOWNLOAD_PROTOCOL: 'download-protocol',
+  COPY_PROTOCOL: 'copy-protocol',
+
+  // Navigation
+  CREATE_NEW_PROTOCOL: 'create-new-protocol',
+  UPDATE_PROTOCOL: 'update-protocol',
+  GO_TO_CHAT: 'go-to-chat',
+
+  // Feedback
+  FEEDBACK_SENT: 'feedback-sent',
+} as const
+
+export type AnalyticsTrackEvent = typeof TRACK_EVENTS[keyof typeof TRACK_EVENTS]

--- a/opentrons-ai-client/src/molecules/FeedbackModal/__tests__/FeedbackModal.test.tsx
+++ b/opentrons-ai-client/src/molecules/FeedbackModal/__tests__/FeedbackModal.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { renderWithProviders } from '/ai-client/__testing-utils__'
-import { TRACK_EVENTS } from '/ai-client/analytics/constants'
+import { ANALYTICS } from '/ai-client/analytics/constants'
 import { feedbackModalAtom } from '/ai-client/resources/atoms'
 
 import { FeedbackModal } from '..'
@@ -81,7 +81,7 @@ describe('FeedbackModal', () => {
     // Then wait for the tracking event to be triggered
     await waitFor(() => {
       expect(mockUseTrackEvent).toHaveBeenCalledWith({
-        name: TRACK_EVENTS.FEEDBACK_SENT,
+        name: ANALYTICS.FEEDBACK_SENT,
         properties: {
           feedback: 'This is a test feedback',
         },

--- a/opentrons-ai-client/src/molecules/FeedbackModal/__tests__/FeedbackModal.test.tsx
+++ b/opentrons-ai-client/src/molecules/FeedbackModal/__tests__/FeedbackModal.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { renderWithProviders } from '/ai-client/__testing-utils__'
+import { TRACK_EVENTS } from '/ai-client/analytics/constants'
 import { feedbackModalAtom } from '/ai-client/resources/atoms'
 
 import { FeedbackModal } from '..'
@@ -21,6 +22,9 @@ vi.mock('/ai-client/hooks/useTrackEvent', () => ({
 vi.mock('/ai-client/resources/hooks', () => ({
   useApiCall: () => ({
     callApi: mockCallApi,
+    error: null,
+    isLoading: false,
+    data: { success: true },
   }),
 }))
 
@@ -77,7 +81,7 @@ describe('FeedbackModal', () => {
     // Then wait for the tracking event to be triggered
     await waitFor(() => {
       expect(mockUseTrackEvent).toHaveBeenCalledWith({
-        name: 'feedback-sent',
+        name: TRACK_EVENTS.FEEDBACK_SENT,
         properties: {
           feedback: 'This is a test feedback',
         },

--- a/opentrons-ai-client/src/molecules/FeedbackModal/index.tsx
+++ b/opentrons-ai-client/src/molecules/FeedbackModal/index.tsx
@@ -1,9 +1,11 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useAtom } from 'jotai'
 
 import {
   ALIGN_FLEX_END,
+  COLORS,
+  DIRECTION_COLUMN,
   Flex,
   InputField,
   Modal,
@@ -13,12 +15,12 @@ import {
   StyledText,
 } from '@opentrons/components'
 
+import { TRACK_EVENTS } from '/ai-client/analytics/constants'
 import { feedbackModalAtom, tokenAtom } from '/ai-client/resources/atoms'
 import {
   LOCAL_FEEDBACK_END_POINT,
   PROD_FEEDBACK_END_POINT,
   STAGING_FEEDBACK_END_POINT,
-  TRACK_EVENTS,
 } from '/ai-client/resources/constants'
 import { useApiCall } from '/ai-client/resources/hooks'
 import { useTrackEvent } from '/ai-client/resources/hooks/useTrackEvent'
@@ -32,7 +34,8 @@ export function FeedbackModal(): JSX.Element {
   const [feedbackValue, setFeedbackValue] = useState<string>('')
   const [, setShowFeedbackModal] = useAtom(feedbackModalAtom)
   const [token] = useAtom(tokenAtom)
-  const { callApi } = useApiCall()
+  const { callApi, error, isLoading, data } = useApiCall()
+  const [isSubmitting, setIsSubmitting] = useState<boolean>(false)
 
   const handleSendFeedback = async (): Promise<void> => {
     const headers = {
@@ -62,15 +65,25 @@ export function FeedbackModal(): JSX.Element {
         fake: false,
       },
     }
+    setIsSubmitting(true)
     await callApi(config as AxiosRequestConfig)
-    trackEvent({
-      name: TRACK_EVENTS.FEEDBACK_SENT,
-      properties: {
-        feedback: feedbackValue,
-      },
-    })
-    setShowFeedbackModal(false)
   }
+
+  useEffect(() => {
+    if (isSubmitting && !isLoading) {
+      if (!error && data) {
+        // Success - track event and close modal
+        trackEvent({
+          name: TRACK_EVENTS.FEEDBACK_SENT,
+          properties: {
+            feedback: feedbackValue,
+          },
+        })
+        setShowFeedbackModal(false)
+      }
+      setIsSubmitting(false)
+    }
+  }, [isSubmitting, isLoading, error, data, feedbackValue])
 
   return (
     <Modal
@@ -94,7 +107,7 @@ export function FeedbackModal(): JSX.Element {
             </StyledText>
           </SecondaryButton>
           <PrimaryButton
-            disabled={feedbackValue === ''}
+            disabled={feedbackValue === '' || isLoading}
             onClick={async () => {
               await handleSendFeedback()
             }}
@@ -106,14 +119,21 @@ export function FeedbackModal(): JSX.Element {
         </Flex>
       }
     >
-      <InputField
-        title={t(`send_feedback_input_title`)}
-        size="medium"
-        value={feedbackValue}
-        onChange={event => {
-          setFeedbackValue(event.target.value as string)
-        }}
-      ></InputField>
+      <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing16}>
+        {error && (
+          <StyledText desktopStyle="bodyDefaultRegular" color={COLORS.red50}>
+            {error}
+          </StyledText>
+        )}
+        <InputField
+          title={t(`send_feedback_input_title`)}
+          size="medium"
+          value={feedbackValue}
+          onChange={event => {
+            setFeedbackValue(event.target.value as string)
+          }}
+        />
+      </Flex>
     </Modal>
   )
 }

--- a/opentrons-ai-client/src/molecules/FeedbackModal/index.tsx
+++ b/opentrons-ai-client/src/molecules/FeedbackModal/index.tsx
@@ -15,7 +15,7 @@ import {
   StyledText,
 } from '@opentrons/components'
 
-import { TRACK_EVENTS } from '/ai-client/analytics/constants'
+import { ANALYTICS } from '/ai-client/analytics/constants'
 import { feedbackModalAtom, tokenAtom } from '/ai-client/resources/atoms'
 import {
   LOCAL_FEEDBACK_END_POINT,
@@ -74,7 +74,7 @@ export function FeedbackModal(): JSX.Element {
       if (!error && data) {
         // Success - track event and close modal
         trackEvent({
-          name: TRACK_EVENTS.FEEDBACK_SENT,
+          name: ANALYTICS.FEEDBACK_SENT,
           properties: {
             feedback: feedbackValue,
           },

--- a/opentrons-ai-client/src/molecules/FeedbackModal/index.tsx
+++ b/opentrons-ai-client/src/molecules/FeedbackModal/index.tsx
@@ -18,6 +18,7 @@ import {
   LOCAL_FEEDBACK_END_POINT,
   PROD_FEEDBACK_END_POINT,
   STAGING_FEEDBACK_END_POINT,
+  TRACK_EVENTS,
 } from '/ai-client/resources/constants'
 import { useApiCall } from '/ai-client/resources/hooks'
 import { useTrackEvent } from '/ai-client/resources/hooks/useTrackEvent'
@@ -34,46 +35,41 @@ export function FeedbackModal(): JSX.Element {
   const { callApi } = useApiCall()
 
   const handleSendFeedback = async (): Promise<void> => {
-    try {
-      const headers = {
-        Authorization: `Bearer ${token}`,
-        'Content-Type': 'application/json',
-      }
-
-      const getEndpoint = (): string => {
-        switch (process.env.NODE_ENV) {
-          case 'production':
-            return PROD_FEEDBACK_END_POINT
-          case 'development':
-            return LOCAL_FEEDBACK_END_POINT
-          default:
-            return STAGING_FEEDBACK_END_POINT
-        }
-      }
-
-      const url = getEndpoint()
-
-      const config = {
-        url,
-        method: 'POST',
-        headers,
-        data: {
-          feedbackText: feedbackValue,
-          fake: false,
-        },
-      }
-      await callApi(config as AxiosRequestConfig)
-      trackEvent({
-        name: 'feedback-sent',
-        properties: {
-          feedback: feedbackValue,
-        },
-      })
-      setShowFeedbackModal(false)
-    } catch (err: any) {
-      console.error(`error: ${err.message}`)
-      throw err
+    const headers = {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
     }
+
+    const getEndpoint = (): string => {
+      switch (process.env.NODE_ENV) {
+        case 'production':
+          return PROD_FEEDBACK_END_POINT
+        case 'development':
+          return LOCAL_FEEDBACK_END_POINT
+        default:
+          return STAGING_FEEDBACK_END_POINT
+      }
+    }
+
+    const url = getEndpoint()
+
+    const config = {
+      url,
+      method: 'POST',
+      headers,
+      data: {
+        feedbackText: feedbackValue,
+        fake: false,
+      },
+    }
+    await callApi(config as AxiosRequestConfig)
+    trackEvent({
+      name: TRACK_EVENTS.FEEDBACK_SENT,
+      properties: {
+        feedback: feedbackValue,
+      },
+    })
+    setShowFeedbackModal(false)
   }
 
   return (

--- a/opentrons-ai-client/src/molecules/InputPrompt/index.tsx
+++ b/opentrons-ai-client/src/molecules/InputPrompt/index.tsx
@@ -27,6 +27,7 @@ import {
   STAGING_CREATE_PROTOCOL_END_POINT,
   STAGING_END_POINT,
   STAGING_UPDATE_PROTOCOL_END_POINT,
+  TRACK_EVENTS,
 } from '/ai-client/resources/constants'
 import { useApiCall } from '/ai-client/resources/hooks'
 import { useAttachFiles } from '/ai-client/resources/hooks/useAttachFiles'
@@ -105,14 +106,14 @@ export function InputPrompt(): JSX.Element {
 
   useEffect(() => {
     if (sendAutoFilledPrompt) {
-      handleClick(true)
+      void handleClick(true)
       setSendAutoFilledPrompt(false)
     }
   }, [watchUserPrompt])
 
   useEffect(() => {
     if (regenerateProtocol.regenerate) {
-      handleClick(regenerateProtocol.isCreateOrUpdateProtocol, true)
+      void handleClick(regenerateProtocol.isCreateOrUpdateProtocol, true)
       setRegenerateProtocol({
         isCreateOrUpdateProtocol: false,
         regenerate: false,
@@ -219,7 +220,7 @@ export function InputPrompt(): JSX.Element {
           const originalMsg = chatHistory[messageIndex]
           if (originalMsg?.attachments) {
             const originalAtt = originalMsg.attachments.find(
-              a => a.name === att.name
+              attachment => attachment.name === att.name
             )
             if (originalAtt?.content) {
               // Use message index in filename for backend association
@@ -252,7 +253,7 @@ export function InputPrompt(): JSX.Element {
       'Content-Type': 'application/json',
     }
 
-    const url = isUpdateOrCreateRequest
+    const targetEndpoint = isUpdateOrCreateRequest
       ? getCreateOrUpdateEndpoint()
       : getChatEndpoint()
 
@@ -286,7 +287,7 @@ export function InputPrompt(): JSX.Element {
       )
 
       return {
-        url,
+        url: targetEndpoint,
         method: 'POST',
         headers,
         data: isUpdateOrCreateRequest
@@ -317,7 +318,7 @@ export function InputPrompt(): JSX.Element {
       },
     ])
     trackEvent({
-      name: 'chat-submitted',
+      name: TRACK_EVENTS.CHAT_SUBMITTED,
       properties: {
         chat: watchUserPrompt,
         protocol_format: protocolFormat,
@@ -385,13 +386,8 @@ export function InputPrompt(): JSX.Element {
       }
     }
 
-    try {
-      await callApi(config)
-      handleSuccessfulSubmission(userInput, currentProtocolFormat)
-    } catch (err: any) {
-      console.error(`error: ${err.message}`)
-      throw err
-    }
+    await callApi(config)
+    handleSuccessfulSubmission(userInput, currentProtocolFormat)
   }
 
   const getCreateOrUpdateEndpoint = (): string => {
@@ -419,7 +415,7 @@ export function InputPrompt(): JSX.Element {
       ])
       setChatData(chatData => [...chatData, assistantResponse])
       trackEvent({
-        name: 'generated-protocol',
+        name: TRACK_EVENTS.GENERATED_PROTOCOL,
         properties: {
           createOrUpdate: isNewProtocol ? 'create' : 'update',
           protocol: reply,

--- a/opentrons-ai-client/src/molecules/InputPrompt/index.tsx
+++ b/opentrons-ai-client/src/molecules/InputPrompt/index.tsx
@@ -48,7 +48,6 @@ import styles from './inputprompt.module.css'
 import type { AxiosRequestConfig } from 'axios'
 import type { ProtocolFile } from '@opentrons/shared-data'
 import type { ChatData } from '/ai-client/resources/types'
-import type { FileType } from '/ai-client/resources/utils/fileUtils'
 
 export function InputPrompt(): JSX.Element {
   const { t } = useTranslation('protocol_generator')
@@ -86,7 +85,6 @@ export function InputPrompt(): JSX.Element {
     handleFileSelect,
     handleRemoveFile,
     prepareFilesForUpload,
-    processFilesForHistory,
     clearFiles,
   } = useAttachFiles()
 
@@ -160,7 +158,7 @@ export function InputPrompt(): JSX.Element {
                 id: uuidv4(),
                 name: file.name,
                 type: fileType,
-                content: '', // Empty for multipart uploads, populated by backend
+                content: file, // Store the raw File object
               }
             })
           : undefined,
@@ -191,10 +189,19 @@ export function InputPrompt(): JSX.Element {
     // Build a complete history array that preserves file attachments in their original messages.
     // This allows the backend to construct proper conversation history with files in the right context.
     const completeHistory = chatHistory.map(msg => {
-      const baseMessage = {
+      const baseMessage: any = {
         role: msg.role,
         content: msg.content,
-        attachments: msg.attachments || [], // Keep attachments with their original messages
+      }
+
+      // Convert File objects to metadata for JSON serialization
+      if (msg.attachments && msg.attachments.length > 0) {
+        baseMessage.attachments = msg.attachments.map(att => ({
+          id: att.id,
+          name: att.name,
+          type: att.type,
+          // Don't include the File object as it can't be serialized
+        }))
       }
 
       // Handle Protocol Designer content if needed
@@ -220,9 +227,6 @@ export function InputPrompt(): JSX.Element {
     let config: AxiosRequestConfig
 
     if (validatedFiles.length > 0 && !isUpdateOrCreateRequest) {
-      // Process files locally for chat history storage
-      const fileAttachmentsWithContent = processFilesForHistory(validatedFiles)
-
       // Multipart upload for file attachments
       const formData = new FormData()
       formData.append('message', watchUserPrompt)
@@ -230,9 +234,31 @@ export function InputPrompt(): JSX.Element {
       formData.append('fake', 'false')
       formData.append('protocol_format', currentProtocolFormat)
 
-      // Add files to FormData
+      // Collect and add files from chat history with message index
+      completeHistory.forEach((msg, messageIndex) => {
+        if (msg.role === 'user' && msg.attachments) {
+          msg.attachments.forEach((att: any) => {
+            // Get the File object from the original chat history
+            const originalMsg = chatHistory[messageIndex]
+            if (originalMsg?.attachments) {
+              const originalAtt = originalMsg.attachments.find(
+                a => a.name === att.name
+              )
+              if (originalAtt?.content) {
+                // Use message index in filename for backend association
+                const fileKey = `msg${messageIndex}_${att.name}`
+                formData.append('files', originalAtt.content, fileKey)
+              }
+            }
+          })
+        }
+      })
+
+      // Add current message files (they belong to the next message index)
+      const currentMessageIndex = completeHistory.length
       validatedFiles.forEach(file => {
-        formData.append('files', file)
+        const fileKey = `msg${currentMessageIndex}_${file.name}`
+        formData.append('files', file, fileKey)
       })
 
       config = {
@@ -244,20 +270,6 @@ export function InputPrompt(): JSX.Element {
         },
         data: formData,
       }
-
-      // Ensure all files were processed successfully
-      if (fileAttachmentsWithContent.length !== validatedFiles.length) {
-        console.error('Failed to process some files for chat history')
-        return
-      }
-
-      // Store processed files for chat history
-      userInput.attachments = fileAttachmentsWithContent.map(file => ({
-        id: file.id,
-        name: file.filename,
-        type: file.file_type as FileType,
-        content: file.content, // Populated by backend processing
-      }))
     } else {
       // Traditional JSON request (no files or update/create requests)
       config = {

--- a/opentrons-ai-client/src/molecules/InputPrompt/index.tsx
+++ b/opentrons-ai-client/src/molecules/InputPrompt/index.tsx
@@ -47,7 +47,11 @@ import styles from './inputprompt.module.css'
 
 import type { AxiosRequestConfig } from 'axios'
 import type { ProtocolFile } from '@opentrons/shared-data'
-import type { ChatData, ChatMessage } from '/ai-client/resources/types'
+import type {
+  ChatData,
+  ChatMessage,
+  ProtocolFormat,
+} from '/ai-client/resources/types'
 
 export function InputPrompt(): JSX.Element {
   const { t } = useTranslation('protocol_generator')
@@ -116,35 +120,30 @@ export function InputPrompt(): JSX.Element {
     }
   }, [regenerateProtocol])
 
-  const handleClick = async (
-    isUpdateOrCreateRequest: boolean = false,
-    isRegenerateRequest: boolean = false
-  ): Promise<void> => {
-    const newRequestId = `${uuidv4()}${getPreFixText(
-      isUpdateOrCreateRequest,
-      isNewProtocol
-    )}`
-    setRequestId(newRequestId)
-    const currentProtocolFormat = detectProtocolFormat(
-      watchUserPrompt,
-      chatHistory
-    )
-
-    // Prepare files for upload - use multipart for efficiency
-    let validatedFiles: File[] = []
-    if (attachedFiles.length > 0 && !isUpdateOrCreateRequest) {
-      const files = prepareFilesForUpload()
-      if (files === null) {
-        return // Validation failed, error already shown to user
-      }
-      validatedFiles = files
+  const prepareValidatedFiles = (
+    isUpdateOrCreateRequest: boolean
+  ): File[] | null => {
+    if (attachedFiles.length === 0 || isUpdateOrCreateRequest) {
+      return []
     }
 
-    const userInput: ChatData = {
-      requestId: newRequestId,
+    const files = prepareFilesForUpload()
+    if (files === null) {
+      return null // Validation failed, error already shown to user
+    }
+    return files
+  }
+
+  const createUserInput = (
+    requestId: string,
+    protocolFormat: ProtocolFormat,
+    validatedFiles: File[]
+  ): ChatData => {
+    return {
+      requestId,
       role: 'user',
       reply: watchUserPrompt,
-      protocol_format: currentProtocolFormat,
+      protocol_format: protocolFormat,
       attachments:
         validatedFiles.length > 0
           ? validatedFiles.map(file => {
@@ -158,55 +157,32 @@ export function InputPrompt(): JSX.Element {
                 id: uuidv4(),
                 name: file.name,
                 type: fileType,
-                content: file, // Store the raw File object
+                content: file,
               }
             })
           : undefined,
     }
-    reset()
-    clearFiles() // Clear attached files and errors after sending
-    setChatData(chatData => [...chatData, userInput])
+  }
 
-    const headers = {
-      Authorization: `Bearer ${token}`,
-      'Content-Type': 'application/json',
-    }
-
-    const url = isUpdateOrCreateRequest
-      ? getCreateOrUpdateEndpoint()
-      : getChatEndpoint()
-
-    const promptData = getUpdateOrCreatePrompt(
-      isNewProtocol,
-      createProtocol,
-      updateProtocol,
-      isRegenerateRequest,
-      detectProtocolFormat(
-        isNewProtocol ? createProtocol.prompt : updateProtocol.prompt
-      )
-    )
-
-    // Build a complete history array that preserves file attachments in their original messages.
-    // This allows the backend to construct proper conversation history with files in the right context.
-    const completeHistory = chatHistory.map(msg => {
+  const buildChatHistory = (protocolFormat: ProtocolFormat): ChatMessage[] => {
+    return chatHistory.map(msg => {
       const baseMessage: ChatMessage = {
         role: msg.role,
         content: msg.content,
       }
 
-      // Convert File objects to metadata for JSON serialization
+      // Extract file metadata from attachments for JSON serialization
       if (msg.attachments && msg.attachments.length > 0) {
-        baseMessage.attachments = msg.attachments.map(att => ({
+        baseMessage.fileMetadata = msg.attachments.map(att => ({
           id: att.id,
           name: att.name,
           type: att.type,
-          // Don't include the File object as it can't be serialized
         }))
       }
 
       // Handle Protocol Designer content if needed
       if (
-        currentProtocolFormat === 'Protocol Designer' &&
+        protocolFormat === 'Protocol Designer' &&
         msg.protocol_content != null
       ) {
         // Use helper to parse the protocol content into a plain object
@@ -222,46 +198,73 @@ export function InputPrompt(): JSX.Element {
 
       return baseMessage
     })
+  }
 
-    // Use multipart upload when files are attached (much more efficient)
-    let config: AxiosRequestConfig
+  const buildMultipartFormData = (
+    completeHistory: ChatMessage[],
+    validatedFiles: File[],
+    protocolFormat: ProtocolFormat
+  ): FormData => {
+    const formData = new FormData()
+    formData.append('message', watchUserPrompt)
+    formData.append('history', JSON.stringify(completeHistory))
+    formData.append('fake', 'false')
+    formData.append('protocol_format', protocolFormat)
+
+    // Collect and add files from chat history with message index
+    completeHistory.forEach((msg, messageIndex) => {
+      if (msg.role === 'user' && msg.fileMetadata) {
+        msg.fileMetadata.forEach(att => {
+          // Get the File object from the original chat history
+          const originalMsg = chatHistory[messageIndex]
+          if (originalMsg?.attachments) {
+            const originalAtt = originalMsg.attachments.find(
+              a => a.name === att.name
+            )
+            if (originalAtt?.content) {
+              // Use message index in filename for backend association
+              const fileKey = `msg${messageIndex}_${att.name}`
+              formData.append('files', originalAtt.content, fileKey)
+            }
+          }
+        })
+      }
+    })
+
+    // Add current message files (they belong to the next message index)
+    const currentMessageIndex = completeHistory.length
+    validatedFiles.forEach(file => {
+      const fileKey = `msg${currentMessageIndex}_${file.name}`
+      formData.append('files', file, fileKey)
+    })
+
+    return formData
+  }
+
+  const buildRequestConfig = (
+    validatedFiles: File[],
+    isUpdateOrCreateRequest: boolean,
+    completeHistory: ChatMessage[],
+    protocolFormat: ProtocolFormat
+  ): AxiosRequestConfig => {
+    const headers = {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    }
+
+    const url = isUpdateOrCreateRequest
+      ? getCreateOrUpdateEndpoint()
+      : getChatEndpoint()
 
     if (validatedFiles.length > 0 && !isUpdateOrCreateRequest) {
       // Multipart upload for file attachments
-      const formData = new FormData()
-      formData.append('message', watchUserPrompt)
-      formData.append('history', JSON.stringify(completeHistory))
-      formData.append('fake', 'false')
-      formData.append('protocol_format', currentProtocolFormat)
+      const formData = buildMultipartFormData(
+        completeHistory,
+        validatedFiles,
+        protocolFormat
+      )
 
-      // Collect and add files from chat history with message index
-      completeHistory.forEach((msg, messageIndex) => {
-        if (msg.role === 'user' && msg.attachments) {
-          msg.attachments.forEach(att => {
-            // Get the File object from the original chat history
-            const originalMsg = chatHistory[messageIndex]
-            if (originalMsg?.attachments) {
-              const originalAtt = originalMsg.attachments.find(
-                a => a.name === att.name
-              )
-              if (originalAtt?.content) {
-                // Use message index in filename for backend association
-                const fileKey = `msg${messageIndex}_${att.name}`
-                formData.append('files', originalAtt.content, fileKey)
-              }
-            }
-          })
-        }
-      })
-
-      // Add current message files (they belong to the next message index)
-      const currentMessageIndex = completeHistory.length
-      validatedFiles.forEach(file => {
-        const fileKey = `msg${currentMessageIndex}_${file.name}`
-        formData.append('files', file, fileKey)
-      })
-
-      config = {
+      return {
         url: getChatEndpoint().replace('/completion', '/completion-multipart'),
         method: 'POST',
         headers: {
@@ -272,7 +275,17 @@ export function InputPrompt(): JSX.Element {
       }
     } else {
       // Traditional JSON request (no files or update/create requests)
-      config = {
+      const promptData = getUpdateOrCreatePrompt(
+        isNewProtocol,
+        createProtocol,
+        updateProtocol,
+        false, // isRegenerateRequest will be passed from handleClick
+        detectProtocolFormat(
+          isNewProtocol ? createProtocol.prompt : updateProtocol.prompt
+        )
+      )
+
+      return {
         url,
         method: 'POST',
         headers,
@@ -284,32 +297,97 @@ export function InputPrompt(): JSX.Element {
               fake: false,
               chat_options: isUpdateOrCreateRequest ? 'create' : 'update',
               pd_protocol_content: pdProtocolContent,
-              protocol_format: currentProtocolFormat,
+              protocol_format: protocolFormat,
               // No separate attachments parameter needed - they're in history now
             },
+      }
+    }
+  }
+
+  const handleSuccessfulSubmission = (
+    userInput: ChatData,
+    protocolFormat: ProtocolFormat
+  ): void => {
+    setChatHistory(chatHistory => [
+      ...chatHistory,
+      {
+        role: 'user',
+        content: watchUserPrompt,
+        attachments: userInput.attachments, // Use the processed attachments with content
+      },
+    ])
+    trackEvent({
+      name: 'chat-submitted',
+      properties: {
+        chat: watchUserPrompt,
+        protocol_format: protocolFormat,
+      },
+    })
+    setSubmitted(true)
+  }
+
+  const handleClick = async (
+    isUpdateOrCreateRequest: boolean = false,
+    isRegenerateRequest: boolean = false
+  ): Promise<void> => {
+    const newRequestId = `${uuidv4()}${getPreFixText(
+      isUpdateOrCreateRequest,
+      isNewProtocol
+    )}`
+    setRequestId(newRequestId)
+    const currentProtocolFormat = detectProtocolFormat(
+      watchUserPrompt,
+      chatHistory
+    )
+
+    // Prepare files for upload
+    const validatedFiles = prepareValidatedFiles(isUpdateOrCreateRequest)
+    if (validatedFiles === null) {
+      return // Validation failed, error already shown to user
+    }
+
+    // Create user input data
+    const userInput = createUserInput(
+      newRequestId,
+      currentProtocolFormat,
+      validatedFiles
+    )
+
+    // Clear form and update state
+    reset()
+    clearFiles()
+    setChatData(chatData => [...chatData, userInput])
+
+    // Build complete chat history for API
+    const completeHistory = buildChatHistory(currentProtocolFormat)
+
+    // Build request configuration
+    const config = buildRequestConfig(
+      validatedFiles,
+      isUpdateOrCreateRequest,
+      completeHistory,
+      currentProtocolFormat
+    )
+
+    // Handle regenerate request for traditional JSON requests
+    if (isRegenerateRequest && validatedFiles.length === 0) {
+      const promptData = getUpdateOrCreatePrompt(
+        isNewProtocol,
+        createProtocol,
+        updateProtocol,
+        isRegenerateRequest,
+        detectProtocolFormat(
+          isNewProtocol ? createProtocol.prompt : updateProtocol.prompt
+        )
+      )
+      if (isUpdateOrCreateRequest && config.data !== promptData) {
+        config.data = promptData
       }
     }
 
     try {
       await callApi(config)
-
-      // Update chat history AFTER successful API call
-      setChatHistory(chatHistory => [
-        ...chatHistory,
-        {
-          role: 'user',
-          content: watchUserPrompt,
-          attachments: userInput.attachments, // Use the processed attachments with content
-        },
-      ])
-      trackEvent({
-        name: 'chat-submitted',
-        properties: {
-          chat: watchUserPrompt,
-          protocol_format: currentProtocolFormat,
-        },
-      })
-      setSubmitted(true)
+      handleSuccessfulSubmission(userInput, currentProtocolFormat)
     } catch (err: any) {
       console.error(`error: ${err.message}`)
       throw err
@@ -409,7 +487,7 @@ export function InputPrompt(): JSX.Element {
             disabled={watchUserPrompt.length === 0}
             isLoading={isLoading}
             handleClick={() => {
-              handleClick()
+              void handleClick()
             }}
           />
         </div>

--- a/opentrons-ai-client/src/molecules/InputPrompt/index.tsx
+++ b/opentrons-ai-client/src/molecules/InputPrompt/index.tsx
@@ -230,14 +230,14 @@ export function InputPrompt(): JSX.Element {
       // Multipart upload for file attachments
       const formData = new FormData()
       formData.append('message', watchUserPrompt)
-      formData.append('history', JSON.stringify(completeHistory)) // Send complete history with attachments
+      formData.append('history', JSON.stringify(completeHistory))
       formData.append('fake', 'false')
       formData.append('protocol_format', currentProtocolFormat)
 
       // Collect and add files from chat history with message index
       completeHistory.forEach((msg, messageIndex) => {
         if (msg.role === 'user' && msg.attachments) {
-          msg.attachments.forEach((att: any) => {
+          msg.attachments.forEach(att => {
             // Get the File object from the original chat history
             const originalMsg = chatHistory[messageIndex]
             if (originalMsg?.attachments) {

--- a/opentrons-ai-client/src/molecules/InputPrompt/index.tsx
+++ b/opentrons-ai-client/src/molecules/InputPrompt/index.tsx
@@ -6,6 +6,7 @@ import { v4 as uuidv4 } from 'uuid'
 
 import { COLORS, StyledText, TYPOGRAPHY } from '@opentrons/components'
 
+import { TRACK_EVENTS } from '/ai-client/analytics/constants'
 import { AttachedFileItem } from '/ai-client/atoms/AttachedFileItem'
 import { AttachFileButton } from '/ai-client/atoms/AttachFileButton'
 import { SendButton } from '/ai-client/atoms/SendButton'
@@ -27,7 +28,6 @@ import {
   STAGING_CREATE_PROTOCOL_END_POINT,
   STAGING_END_POINT,
   STAGING_UPDATE_PROTOCOL_END_POINT,
-  TRACK_EVENTS,
 } from '/ai-client/resources/constants'
 import { useApiCall } from '/ai-client/resources/hooks'
 import { useAttachFiles } from '/ai-client/resources/hooks/useAttachFiles'
@@ -75,7 +75,7 @@ export function InputPrompt(): JSX.Element {
   const [submitted, setSubmitted] = useState<boolean>(false)
   const watchUserPrompt = (watch('userPrompt') ?? '') as string
 
-  const { data, isLoading, callApi } = useApiCall()
+  const { data, isLoading, callApi, error } = useApiCall()
 
   let pdProtocolContent: null | ProtocolFile = null
   if (data != null && typeof data === 'object' && 'protocol_content' in data) {
@@ -395,47 +395,53 @@ export function InputPrompt(): JSX.Element {
   }
 
   useEffect(() => {
-    if (submitted && data != null && !isLoading) {
-      const { role, reply, protocol_content } = data as ChatData
-      const assistantResponse: ChatData = {
-        requestId,
-        role,
-        reply,
-        protocol_content,
+    if (submitted && !isLoading) {
+      if (error) {
+        // Error occurred - reset submitted state to allow retry
+        setSubmitted(false)
+      } else if (data != null) {
+        // Success - process the response
+        const { role, reply, protocol_content } = data as ChatData
+        const assistantResponse: ChatData = {
+          requestId,
+          role,
+          reply,
+          protocol_content,
+        }
+        setChatHistory(chatHistory => [
+          ...chatHistory,
+          {
+            role: 'assistant',
+            content: reply,
+            protocol_content: (JSON.stringify(
+              protocol_content
+            ) as unknown) as string,
+          },
+        ])
+        setChatData(chatData => [...chatData, assistantResponse])
+        trackEvent({
+          name: TRACK_EVENTS.GENERATED_PROTOCOL,
+          properties: {
+            createOrUpdate: isNewProtocol ? 'create' : 'update',
+            protocol: reply,
+          },
+        })
+        setSubmitted(false)
       }
-      setChatHistory(chatHistory => [
-        ...chatHistory,
-        {
-          role: 'assistant',
-          content: reply,
-          protocol_content: (JSON.stringify(
-            protocol_content
-          ) as unknown) as string,
-        },
-      ])
-      setChatData(chatData => [...chatData, assistantResponse])
-      trackEvent({
-        name: TRACK_EVENTS.GENERATED_PROTOCOL,
-        properties: {
-          createOrUpdate: isNewProtocol ? 'create' : 'update',
-          protocol: reply,
-        },
-      })
-      setSubmitted(false)
     }
-  }, [data, isLoading, submitted])
+  }, [data, isLoading, submitted, error])
 
   return (
     <form id="User_Prompt" className={styles.form}>
       {/* Error message */}
-      {fileError && (
+      {(fileError || error) && (
         <div className={styles.error_container}>
           <StyledText
             color={COLORS.red50}
             fontSize={TYPOGRAPHY.fontSizeH3}
             lineHeight={TYPOGRAPHY.lineHeight20}
           >
-            {fileError}
+            {fileError || error}
           </StyledText>
         </div>
       )}

--- a/opentrons-ai-client/src/molecules/InputPrompt/index.tsx
+++ b/opentrons-ai-client/src/molecules/InputPrompt/index.tsx
@@ -6,7 +6,7 @@ import { v4 as uuidv4 } from 'uuid'
 
 import { COLORS, StyledText, TYPOGRAPHY } from '@opentrons/components'
 
-import { TRACK_EVENTS } from '/ai-client/analytics/constants'
+import { ANALYTICS } from '/ai-client/analytics/constants'
 import { AttachedFileItem } from '/ai-client/atoms/AttachedFileItem'
 import { AttachFileButton } from '/ai-client/atoms/AttachFileButton'
 import { SendButton } from '/ai-client/atoms/SendButton'
@@ -318,7 +318,7 @@ export function InputPrompt(): JSX.Element {
       },
     ])
     trackEvent({
-      name: TRACK_EVENTS.CHAT_SUBMITTED,
+      name: ANALYTICS.CHAT_SUBMITTED,
       properties: {
         chat: watchUserPrompt,
         protocol_format: protocolFormat,
@@ -420,7 +420,7 @@ export function InputPrompt(): JSX.Element {
         ])
         setChatData(chatData => [...chatData, assistantResponse])
         trackEvent({
-          name: TRACK_EVENTS.GENERATED_PROTOCOL,
+          name: ANALYTICS.GENERATED_PROTOCOL,
           properties: {
             createOrUpdate: isNewProtocol ? 'create' : 'update',
             protocol: reply,

--- a/opentrons-ai-client/src/molecules/InputPrompt/index.tsx
+++ b/opentrons-ai-client/src/molecules/InputPrompt/index.tsx
@@ -47,7 +47,7 @@ import styles from './inputprompt.module.css'
 
 import type { AxiosRequestConfig } from 'axios'
 import type { ProtocolFile } from '@opentrons/shared-data'
-import type { ChatData } from '/ai-client/resources/types'
+import type { ChatData, ChatMessage } from '/ai-client/resources/types'
 
 export function InputPrompt(): JSX.Element {
   const { t } = useTranslation('protocol_generator')
@@ -189,7 +189,7 @@ export function InputPrompt(): JSX.Element {
     // Build a complete history array that preserves file attachments in their original messages.
     // This allows the backend to construct proper conversation history with files in the right context.
     const completeHistory = chatHistory.map(msg => {
-      const baseMessage: any = {
+      const baseMessage: ChatMessage = {
         role: msg.role,
         content: msg.content,
       }

--- a/opentrons-ai-client/src/resources/constants.ts
+++ b/opentrons-ai-client/src/resources/constants.ts
@@ -44,30 +44,3 @@ export const CLIENT_MAX_WIDTH = '1440px'
 export const PD = 'Protocol Designer'
 export const PYTHON = 'Python'
 export const PROTOCOL_FORMAT = 'protocol_format'
-
-export const TRACK_EVENTS = {
-  // App lifecycle
-  APP_OPEN: 'appOpen',
-
-  // Authentication
-  USER_LOGIN: 'user-login',
-  USER_LOGOUT: 'user-logout',
-
-  // Chat interactions
-  CHAT_SUBMITTED: 'chat-submitted',
-  SUBMIT_PROMPT: 'submit-prompt',
-
-  // Protocol actions
-  GENERATED_PROTOCOL: 'generated-protocol',
-  REGENERATE_PROTOCOL: 'regenerate-protocol',
-  DOWNLOAD_PROTOCOL: 'download-protocol',
-  COPY_PROTOCOL: 'copy-protocol',
-
-  // Navigation
-  CREATE_NEW_PROTOCOL: 'create-new-protocol',
-  UPDATE_PROTOCOL: 'update-protocol',
-  GO_TO_CHAT: 'go-to-chat',
-
-  // Feedback
-  FEEDBACK_SENT: 'feedback-sent',
-} as const

--- a/opentrons-ai-client/src/resources/constants.ts
+++ b/opentrons-ai-client/src/resources/constants.ts
@@ -44,3 +44,30 @@ export const CLIENT_MAX_WIDTH = '1440px'
 export const PD = 'Protocol Designer'
 export const PYTHON = 'Python'
 export const PROTOCOL_FORMAT = 'protocol_format'
+
+export const TRACK_EVENTS = {
+  // App lifecycle
+  APP_OPEN: 'appOpen',
+
+  // Authentication
+  USER_LOGIN: 'user-login',
+  USER_LOGOUT: 'user-logout',
+
+  // Chat interactions
+  CHAT_SUBMITTED: 'chat-submitted',
+  SUBMIT_PROMPT: 'submit-prompt',
+
+  // Protocol actions
+  GENERATED_PROTOCOL: 'generated-protocol',
+  REGENERATE_PROTOCOL: 'regenerate-protocol',
+  DOWNLOAD_PROTOCOL: 'download-protocol',
+  COPY_PROTOCOL: 'copy-protocol',
+
+  // Navigation
+  CREATE_NEW_PROTOCOL: 'create-new-protocol',
+  UPDATE_PROTOCOL: 'update-protocol',
+  GO_TO_CHAT: 'go-to-chat',
+
+  // Feedback
+  FEEDBACK_SENT: 'feedback-sent',
+} as const

--- a/opentrons-ai-client/src/resources/hooks/useAttachFiles.ts
+++ b/opentrons-ai-client/src/resources/hooks/useAttachFiles.ts
@@ -1,20 +1,10 @@
 import { useState } from 'react'
-import { v4 as uuidv4 } from 'uuid'
 
 import {
-  getFileType,
   MAX_FILES_PER_MESSAGE,
   prepareFilesForMultipart,
   validateFile,
 } from '../utils/fileUtils'
-
-export interface FileAttachmentForBackend {
-  id: string
-  filename: string
-  file_type: string
-  content: string // Empty for multipart uploads, populated by backend
-  media_type: string
-}
 
 interface UseAttachFilesReturn {
   attachedFiles: File[]
@@ -22,7 +12,6 @@ interface UseAttachFilesReturn {
   handleFileSelect: (files: FileList) => void
   handleRemoveFile: (index: number) => void
   prepareFilesForUpload: () => File[] | null
-  processFilesForHistory: (validatedFiles: File[]) => FileAttachmentForBackend[]
   clearFiles: () => void
   clearError: () => void
 }
@@ -73,27 +62,6 @@ export function useAttachFiles(): UseAttachFilesReturn {
     return result
   }
 
-  const processFilesForHistory = (
-    validatedFiles: File[]
-  ): FileAttachmentForBackend[] => {
-    const fileAttachmentsWithContent: FileAttachmentForBackend[] = []
-
-    for (const file of validatedFiles) {
-      const fileType = getFileType(file)
-      if (fileType !== null) {
-        fileAttachmentsWithContent.push({
-          id: uuidv4(),
-          filename: file.name,
-          file_type: fileType,
-          content: '',
-          media_type: file.type || 'text/plain',
-        })
-      }
-    }
-
-    return fileAttachmentsWithContent
-  }
-
   const clearFiles = (): void => {
     setAttachedFiles([])
     setFileError(null)
@@ -109,7 +77,6 @@ export function useAttachFiles(): UseAttachFilesReturn {
     handleFileSelect,
     handleRemoveFile,
     prepareFilesForUpload,
-    processFilesForHistory,
     clearFiles,
     clearError,
   }

--- a/opentrons-ai-client/src/resources/types.ts
+++ b/opentrons-ai-client/src/resources/types.ts
@@ -12,7 +12,7 @@ export interface FileAttachment {
   id?: string // Optional because it's not present when initially selecting files
   name: string
   type: FileType
-  content: File // Raw File object
+  content: File
 }
 
 export interface ChatData {
@@ -91,7 +91,7 @@ export interface ChatMessage {
   content: string
   protocol_content?: string
   protocol_format?: ProtocolFormat
-  attachments?: Array<Omit<FileAttachment, 'content'>>
+  fileMetadata?: Array<Omit<FileAttachment, 'content'>>
 }
 
 export interface RouteProps {

--- a/opentrons-ai-client/src/resources/types.ts
+++ b/opentrons-ai-client/src/resources/types.ts
@@ -12,7 +12,7 @@ export interface FileAttachment {
   id?: string // Optional because it's not present when initially selecting files
   name: string
   type: FileType
-  content: string // Populated by backend after processing
+  content: File // Raw File object
 }
 
 export interface ChatData {

--- a/opentrons-ai-client/src/resources/types.ts
+++ b/opentrons-ai-client/src/resources/types.ts
@@ -85,6 +85,15 @@ export interface Chat {
   attachments?: FileAttachment[]
 }
 
+/** Chat message serialized for API requests (without File content) */
+export interface ChatMessage {
+  role: Role
+  content: string
+  protocol_content?: string
+  protocol_format?: ProtocolFormat
+  attachments?: Array<Omit<FileAttachment, 'content'>>
+}
+
 export interface RouteProps {
   /** the component rendered by a route match
    * drop developed components into slots held by placeholder div components

--- a/opentrons-ai-server/api/domain/anthropic_predict.py
+++ b/opentrons-ai-server/api/domain/anthropic_predict.py
@@ -400,7 +400,7 @@ class AnthropicPredict:
 
         return messages
 
-    def _create_current_user_message(self, prompt: str, new_file_references: Optional[List[Dict[str, str]]], user_id: str) -> MessageParam:
+    def _create_current_user_message(self, prompt: str, current_msg_files: Optional[List[Dict[str, str]]], user_id: str) -> MessageParam:
         """Create the current user message with file attachments."""
         relevant_api_docs = self.get_relevant_api_docs(prompt, user_id)
         prompt_with_docs = f"{prompt}\n\n{relevant_api_docs}"
@@ -409,18 +409,18 @@ class AnthropicPredict:
         current_user_content: List[ContentBlockParam] = [TextBlockParam(type="text", text=PROMPT.format(USER_PROMPT=prompt_with_docs))]
 
         # Add NEW file attachments to current message
-        if new_file_references:
-            file_refs_summary = [{k: v for k, v in ref.items() if k != "content"} for ref in new_file_references]
+        if current_msg_files:
+            file_refs_summary = [{k: v for k, v in ref.items() if k != "content"} for ref in current_msg_files]
             logger.info(f"Processing new file attachments: {file_refs_summary}")
 
-            new_file_blocks = self._create_file_attachment_blocks(new_file_references, user_id)
+            new_file_blocks = self._create_file_attachment_blocks(current_msg_files, user_id)
             current_user_content.extend(new_file_blocks)
             logger.info(
                 "Added new file attachments to current message",
                 extra={
                     "user_id": user_id,
-                    "num_new_files": len(new_file_references),
-                    "file_ids": [ref["id"] for ref in new_file_references],
+                    "num_new_files": len(current_msg_files),
+                    "file_ids": [ref["id"] for ref in current_msg_files],
                 },
             )
 
@@ -433,7 +433,7 @@ class AnthropicPredict:
         prompt: str,
         history_with_attachments: List[Dict[str, Any]] | None = None,
         message_type: MessageType = "create",
-        new_file_references: Optional[List[Dict[str, str]]] = None,
+        current_msg_files: Optional[List[Dict[str, str]]] = None,
     ) -> str | None:
         """Process chat message with file attachments in conversation history"""
         try:
@@ -445,7 +445,7 @@ class AnthropicPredict:
                 messages.extend(historical_messages)
 
             # Create and add current user message
-            current_user_message = self._create_current_user_message(prompt, new_file_references, user_id)
+            current_user_message = self._create_current_user_message(prompt, current_msg_files, user_id)
             messages.append(current_user_message)
 
             # Log the improved message structure

--- a/opentrons-ai-server/api/domain/anthropic_predict.py
+++ b/opentrons-ai-server/api/domain/anthropic_predict.py
@@ -370,10 +370,10 @@ class AnthropicPredict:
 
         return {
             "id": attachment.get("id", ""),
-            "filename": attachment.get("name", attachment.get("filename", "")),
-            "file_type": attachment.get("type", attachment.get("file_type", "")),
+            "filename": attachment.get("filename", ""),
+            "file_type": attachment.get("file_type", ""),
             "content": attachment.get("content", ""),
-            "media_type": self._determine_media_type(attachment.get("type", attachment.get("file_type", ""))),
+            "media_type": self._determine_media_type(attachment.get("file_type", "")),
         }
 
     def _build_conversation_history(self, history_with_attachments: List[Dict[str, Any]], user_id: str) -> List[MessageParam]:

--- a/opentrons-ai-server/api/domain/anthropic_predict.py
+++ b/opentrons-ai-server/api/domain/anthropic_predict.py
@@ -137,13 +137,13 @@ class AnthropicPredict:
     def get_docs(self) -> str:
         """
         Processes documents from a directory and returns their content wrapped in XML tags.
-        Each document is wrapped in <document> tags with metadata subtags.
+        Each document is wrapped in <system_doc> tags with metadata subtags.
 
         Returns:
-            str: XML-formatted string containing all documents and their metadata
+            str: XML-formatted string containing all system documentation
         """
         logger.info("Getting docs", extra={"path": str(self.path_docs)})
-        xml_output = ["<documents>"]
+        xml_output = ["<system_documentation>"]
         for file_path in self.path_docs.iterdir():
             try:
                 # Skip directories
@@ -152,12 +152,13 @@ class AnthropicPredict:
 
                 content = file_path.read_text(encoding="utf-8")
                 document_xml = [
-                    "<document>",
-                    f"  <source>{file_path.name}</source>",
-                    "   <document_content>",
+                    "<system_doc>",
+                    f"  <title>{file_path.name}</title>",
+                    "  <type>reference</type>",
+                    "   <content>",
                     f"    {content}",
-                    "   </document_content>",
-                    "</document>",
+                    "   </content>",
+                    "</system_doc>",
                 ]
                 xml_output.extend(document_xml)
 
@@ -165,7 +166,7 @@ class AnthropicPredict:
                 logger.error("Error processing file", extra={"file": file_path.name, "error": str(e)})
                 continue
 
-        xml_output.append("</documents>")
+        xml_output.append("</system_documentation>")
         return "\n".join(xml_output)
 
     @tracer.wrap()
@@ -295,6 +296,10 @@ class AnthropicPredict:
 
         content_blocks: List[ContentBlockParam] = []
 
+        # Add wrapper for user uploaded files
+        user_files_header = TextBlockParam(type="text", text="<user_uploaded_files>\n")
+        content_blocks.append(user_files_header)
+
         for file_ref in file_references:
             filename = file_ref.get("name", "Attached File")
             # file_type is the internal type ("pdf", "csv", "python"), not MIME type
@@ -305,9 +310,10 @@ class AnthropicPredict:
                 # Fallback if content is missing
                 text_block = TextBlockParam(
                     type="text",
-                    text=f"=== FILE: {filename} ({file_type.upper()}) ===\n\n"
-                    f"[File content is empty or missing]\n\n"
-                    f"=== END OF FILE: {filename} ===\n\n",
+                    text=f"<user_file name=\"{filename}\" type=\"{file_type}\" id=\"{file_ref.get('id', 'unknown')}\">\n"
+                    f"Filename: {filename}\n"
+                    f"[File content is empty or missing]\n"
+                    f"</user_file>\n\n",
                 )
                 content_blocks.append(text_block)
                 continue
@@ -317,11 +323,9 @@ class AnthropicPredict:
                 # Add explicit filename context that Claude cannot ignore
                 logger.info(f"Creating PDF document block with title: '{filename}'")
 
-                # Add a text block with explicit filename information before the PDF
-                pdf_intro_text = (
-                    f"=== UPLOADED PDF FILE: {filename} ===\n\n"
-                    f"The following document is the PDF file named '{filename}' that was uploaded:\n\n"
-                )
+                # Add a text block to start the user file wrapper with prominent filename
+                pdf_intro_text = f"<user_file name=\"{filename}\" type=\"{file_type}\" id=\"{file_ref.get('id', 'unknown')}\">\n"
+                pdf_intro_text += f"Filename: {filename}\n"
                 filename_text_block = TextBlockParam(type="text", text=pdf_intro_text)
                 content_blocks.append(filename_text_block)
 
@@ -332,32 +336,25 @@ class AnthropicPredict:
                     title=filename,
                 )
                 content_blocks.append(doc_block)
+
+                # Close the user file wrapper
+                pdf_close_text = "</user_file>\n\n"
+                filename_close_block = TextBlockParam(type="text", text=pdf_close_text)
+                content_blocks.append(filename_close_block)
             else:
                 # CSV and Python files are sent as text blocks
-                # Add explicit filename context for all text-based files (consistent with PDF approach)
-                if file_type.lower() == "python":
-                    # Add explicit filename introduction similar to PDF approach
-                    python_intro_text = (
-                        f"=== UPLOADED PYTHON FILE: {filename} ===\n\n"
-                        f"The following is the Python protocol file named '{filename}' that was uploaded:\n\n"
-                    )
-                    filename_intro_block = TextBlockParam(type="text", text=python_intro_text)
-                    content_blocks.append(filename_intro_block)
-                elif file_type.lower() == "csv":
-                    # Add explicit filename introduction for CSV files
-                    csv_intro_text = (
-                        f"=== UPLOADED CSV FILE: {filename} ===\n\n"
-                        f"The following is the CSV data file named '{filename}' that was uploaded:\n\n"
-                    )
-                    filename_intro_block = TextBlockParam(type="text", text=csv_intro_text)
-                    content_blocks.append(filename_intro_block)
-
-                # Add the file content
                 text_block = TextBlockParam(
                     type="text",
-                    text=f"=== FILE CONTENT ===\n\n{file_content}\n\n=== END OF FILE: {filename} ===\n\n",
+                    text=f"<user_file name=\"{filename}\" type=\"{file_type}\" id=\"{file_ref.get('id', 'unknown')}\">\n"
+                    f"Filename: {filename}\n"
+                    f"{file_content}\n"
+                    f"</user_file>\n\n",
                 )
                 content_blocks.append(text_block)
+
+        # Close wrapper for user uploaded files
+        user_files_footer = TextBlockParam(type="text", text="</user_uploaded_files>\n")
+        content_blocks.append(user_files_footer)
 
         return content_blocks
 

--- a/opentrons-ai-server/api/domain/anthropic_predict.py
+++ b/opentrons-ai-server/api/domain/anthropic_predict.py
@@ -296,9 +296,9 @@ class AnthropicPredict:
         content_blocks: List[ContentBlockParam] = []
 
         for file_ref in file_references:
-            filename = file_ref.get("filename", "Attached File")
+            filename = file_ref.get("name", "Attached File")
             # file_type is the internal type ("pdf", "csv", "python"), not MIME type
-            file_type = file_ref.get("file_type", "unknown").lower()
+            file_type = file_ref.get("type", "unknown").lower()
             file_content = file_ref.get("content", "")
 
             if not file_content:
@@ -370,10 +370,10 @@ class AnthropicPredict:
 
         return {
             "id": attachment.get("id", ""),
-            "filename": attachment.get("filename", ""),
-            "file_type": attachment.get("file_type", ""),
+            "name": attachment.get("name", ""),
+            "type": attachment.get("type", ""),
             "content": attachment.get("content", ""),
-            "media_type": self._determine_media_type(attachment.get("file_type", "")),
+            "media_type": self._determine_media_type(attachment.get("type", "")),
         }
 
     def _build_conversation_history(self, history_with_attachments: List[Dict[str, Any]], user_id: str) -> List[MessageParam]:

--- a/opentrons-ai-server/api/domain/config_anthropic.py
+++ b/opentrons-ai-server/api/domain/config_anthropic.py
@@ -2,7 +2,28 @@ SYSTEM_PROMPT = """
 You are an expert AI assistant specializing in Opentrons protocol development,
 combining deep knowledge of laboratory automation with practical programming expertise.
 Your mission is to help scientists automate their laboratory workflows efficiently and
-safely using the Opentrons Python API v2 and provided documents in <document>.
+safely using the Opentrons Python API v2.
+
+<Document Types>
+You have access to two types of documentation:
+- <system_documentation>: Official Opentrons API reference materials and documentation
+- <user_uploaded_files>: Files uploaded by the user (PDFs, CSVs, Python protocols)
+
+CRITICAL RULE: Never show or reference content from <system_documentation> unless the user EXPLICITLY asks
+for "API documentation", "API reference", "Opentrons API docs", or similar explicit requests for documentation.
+
+Default Behavior:
+- When users ask about "files", "protocols", "content", or use filenames, ALWAYS refer to <user_uploaded_files> ONLY
+- If files exist in <user_uploaded_files>, assume ALL file-related queries refer to those files
+- Do NOT mention or show system documentation unless explicitly requested
+- When no user files are uploaded, simply state "No files have been uploaded" rather than referring to system docs
+
+File Handling Guidelines:
+- Each user file is wrapped in <user_file> tags with name, type, and id attributes
+- The actual filename is prominently displayed as "Filename: [name]" at the start of each file
+- When listing files, always use the exact filename shown in the "Filename:" line
+- PDF files contain the filename info followed by the document content
+- Text files (CSV, Python) show the filename followed by the raw content
 
 <Technical Competencies>
 - Complete mastery of Opentrons Python API v2

--- a/opentrons-ai-server/api/handler/fast.py
+++ b/opentrons-ai-server/api/handler/fast.py
@@ -25,7 +25,12 @@ from api.domain.anthropic_predict import AnthropicPredict, get_tracing_context, 
 from api.domain.fake_responses import FakeResponse, get_fake_response
 from api.domain.openai_predict import OpenAIPredict
 from api.handler.custom_logging import setup_logging
-from api.handler.utils_fast import parse_tagged_content
+from api.handler.utils_fast import (
+    extract_message_index_from_filename,
+    parse_tagged_content,
+    process_single_multipart_file,
+    reconstruct_conversation_history,
+)
 from api.integration.auth import VerifyToken
 from api.integration.google_sheets import GoogleSheetsClient
 from api.models.chat_request import ChatRequest
@@ -478,7 +483,7 @@ async def create_chat_completion_multipart(
         files_by_message, token_warning = await _process_multipart_files_with_mapping(files)
 
         # Reconstruct conversation history with file content
-        enhanced_history = _reconstruct_conversation_history(parsed_history_with_attachments, files_by_message)
+        enhanced_history = reconstruct_conversation_history(parsed_history_with_attachments, files_by_message)
 
         # Get current message files (either at index -1 or at the end of history)
         current_message_index = len(enhanced_history)
@@ -522,7 +527,7 @@ async def _process_multipart_files_with_mapping(files: List[UploadFile]) -> tupl
         if not file.filename:
             continue
 
-        message_index, original_filename = _extract_message_index_from_filename(file.filename)
+        message_index, original_filename = extract_message_index_from_filename(file.filename)
 
         # Initialize message group if needed
         if message_index not in files_by_message:
@@ -530,7 +535,7 @@ async def _process_multipart_files_with_mapping(files: List[UploadFile]) -> tupl
 
         try:
             file_count = len(files_by_message[message_index])
-            file_ref = await _process_single_multipart_file(file, message_index, file_count)
+            file_ref = await process_single_multipart_file(file, message_index, file_count)
             file_ref["filename"] = original_filename  # Use extracted original filename
             files_by_message[message_index].append(file_ref)
         except ValueError as e:
@@ -543,104 +548,6 @@ async def _process_multipart_files_with_mapping(files: List[UploadFile]) -> tupl
         token_warning = FileProcessor.check_files_token_warning(all_files, claude.client, settings.anthropic_model_name)
 
     return files_by_message, token_warning
-
-
-def _enhance_message_with_file_content(msg: Dict[str, Any], message_files: List[Dict[str, str]]) -> Dict[str, Any]:
-    """Post-upload phase: Merges frontend attachment metadata with processed file content.
-
-    Bridges frontend JSON (metadata only) with backend processed files before AI model.
-    """
-    enhanced_msg = msg.copy()
-    file_content_map = {f["filename"]: f for f in message_files}
-
-    if enhanced_msg.get("attachments"):
-        # Message has attachment metadata - enhance with content
-        enhanced_attachments = []
-        for att in enhanced_msg["attachments"]:
-            filename = att.get("name", att.get("filename", ""))
-            if filename in file_content_map:
-                file_ref = file_content_map[filename]
-                enhanced_attachments.append(
-                    {
-                        "id": att.get("id", file_ref["id"]),
-                        "filename": filename,
-                        "file_type": file_ref["file_type"],
-                        "content": file_ref["content"],
-                        "media_type": file_ref["media_type"],
-                    }
-                )
-        enhanced_msg["attachments"] = enhanced_attachments
-    else:
-        # No metadata - use files directly
-        enhanced_msg["attachments"] = []
-        for file_ref in message_files:
-            enhanced_msg["attachments"].append(
-                {
-                    "id": file_ref["id"],
-                    "filename": file_ref["filename"],
-                    "file_type": file_ref["file_type"],
-                    "content": file_ref["content"],
-                    "media_type": file_ref["media_type"],
-                }
-            )
-
-    return enhanced_msg
-
-
-def _reconstruct_conversation_history(
-    parsed_history: List[Dict[str, Any]], files_by_message: Dict[int, List[Dict[str, str]]]
-) -> List[Dict[str, Any]]:
-    """Pre-AI phase: Final assembly of conversation history with files in correct message positions.
-
-    Ensures AI model sees files in their original conversational context.
-    """
-    enhanced_history = []
-
-    for i, msg in enumerate(parsed_history):
-        if i in files_by_message and files_by_message[i]:
-            enhanced_msg = _enhance_message_with_file_content(msg, files_by_message[i])
-        else:
-            enhanced_msg = msg.copy()
-        enhanced_history.append(enhanced_msg)
-
-    return enhanced_history
-
-
-def _extract_message_index_from_filename(filename: str) -> tuple[int, str]:
-    """Raw upload phase: Parses msgN_filename format to determine conversation placement.
-
-    Returns (message_index, original_filename) for proper file grouping.
-    """
-    if filename.startswith("msg") and "_" in filename:
-        parts = filename.split("_", 1)
-        if len(parts) == 2 and parts[0][3:].isdigit():
-            return int(parts[0][3:]), parts[1]
-
-    return -1, filename  # Default for current message
-
-
-async def _process_single_multipart_file(file: UploadFile, message_index: int, file_count: int) -> Dict[str, str]:
-    """Raw upload processing: Validates and processes single file for AI consumption.
-
-    Sits between HTTP multipart parsing and conversation reconstruction.
-    """
-    file_content = await file.read()
-
-    if not file.filename:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="File has no filename")
-
-    if not file.content_type:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"File {file.filename} has no content type")
-
-    processed = FileProcessor.process_multipart_file(file.filename, file.content_type, file_content)
-
-    return {
-        "id": f"upload_{message_index}_{file_count}",
-        "filename": file.filename,
-        "file_type": processed["file_type"],
-        "content": processed["content"],
-        "media_type": processed["media_type"],
-    }
 
 
 def _determine_protocol_action(body: ChatRequest) -> str:

--- a/opentrons-ai-server/api/handler/fast.py
+++ b/opentrons-ai-server/api/handler/fast.py
@@ -20,7 +20,6 @@ from pydantic import BaseModel, Field, conint
 from starlette.middleware.base import BaseHTTPMiddleware
 from uvicorn.protocols.utils import get_path_with_query_string
 
-from api.constants.file_constants import MEDIA_TYPE_MAPPING
 from api.domain.anthropic_predict import AnthropicPredict, get_tracing_context, setup_weave_analytics
 from api.domain.fake_responses import FakeResponse, get_fake_response
 from api.domain.openai_predict import OpenAIPredict
@@ -220,7 +219,7 @@ def _generate_llm_response_with_history(
     history_with_attachments: Optional[List[Dict[str, Any]]] = None,
     protocol_format: Optional[ProtocolFormat] = None,
     protocol_action: Optional[str] = None,
-    new_file_references: Optional[List[Dict[str, str]]] = None,
+    current_msg_files: Optional[List[Dict[str, str]]] = None,
 ) -> Optional[str]:
     """Generate a response from the appropriate LLM with proper history handling."""
     # Wrap all LLM calls with the appropriate tracing context
@@ -234,29 +233,9 @@ def _generate_llm_response_with_history(
 
         # Claude models - convert history to proper message format
         converted_history = []
-        all_file_references = []
-
         if history_with_attachments:
             for msg in history_with_attachments:
-                if msg["role"] == "user" and msg.get("attachments"):
-                    # Collect all file references from history
-                    for attachment in msg["attachments"]:
-                        all_file_references.append(
-                            {
-                                "id": attachment.get("id", ""),
-                                "name": attachment.get("name", ""),
-                                "type": attachment.get("type", ""),
-                                "content": attachment.get("content", ""),
-                                "media_type": MEDIA_TYPE_MAPPING.get(attachment.get("type", ""), "text/plain"),
-                            }
-                        )
-
-                # Convert to MessageParam format (role + content only)
                 converted_history.append({"role": msg["role"], "content": msg["content"]})
-
-        # Add new files to the collection
-        if new_file_references:
-            all_file_references.extend(new_file_references)
 
         # Use existing Claude logic with all files
         if protocol_format == ProtocolFormat.PROTOCOL_DESIGNER:
@@ -271,7 +250,7 @@ def _generate_llm_response_with_history(
                 prompt=prompt,
                 history_with_attachments=history_with_attachments,
                 message_type="update",
-                new_file_references=all_file_references,
+                current_msg_files=current_msg_files,
             )
 
 
@@ -421,8 +400,6 @@ async def create_chat_completion(
                     }
                     history_with_attachments.append(history_msg)
 
-        new_file_references: List[Dict[str, str]] = []
-
         # Use the new history-aware response generation
         response = _generate_llm_response_with_history(
             model_type=settings.model,
@@ -432,7 +409,7 @@ async def create_chat_completion(
             history_with_attachments=history_with_attachments,
             protocol_format=protocol_format,
             protocol_action=protocol_action,
-            new_file_references=new_file_references,
+            current_msg_files=[],
         )
         return _format_response(response, protocol_format, bool(body.fake))
 
@@ -467,13 +444,13 @@ async def create_chat_completion_multipart(
         "POST /api/chat/completion-multipart",
         extra={"message": message, "num_files": len(files), "file_names": [f.filename for f in files], "user": user},
     )
-
     try:
         # Setup Weave analytics based on frontend preference
         enable_analytics = _get_analytics_preference(request) if request else False
         setup_weave_analytics(enable_analytics)
 
         # Parse history from JSON string (now includes attachments in each message)
+
         try:
             parsed_history_with_attachments = json.loads(history) if history else []
         except json.JSONDecodeError:
@@ -483,29 +460,28 @@ async def create_chat_completion_multipart(
         files_by_message, token_warning = await _process_multipart_files_with_mapping(files)
 
         # Reconstruct conversation history with file content
-        enhanced_history = reconstruct_conversation_history(parsed_history_with_attachments, files_by_message)
+        history_with_attachments = reconstruct_conversation_history(parsed_history_with_attachments, files_by_message)
 
-        # Get current message files (either at index -1 or at the end of history)
-        current_message_index = len(enhanced_history)
-        current_files = files_by_message.get(current_message_index, [])
-        if not current_files and -1 in files_by_message:
-            current_files = files_by_message[-1]
+        # Get current message files. history_with_attachments contains messages without current message
+        # The files for current message are in files_by_message[N]. 0 to N-1 are the previous messages.
+        # N is the current message index.
+        # For example, when history_with_attachments=[], files_by_message={0: [file1, file2]}.
+        current_msg_idx = len(history_with_attachments)
+        current_msg_files = files_by_message.get(current_msg_idx, [])
 
-        # Determine protocol format
         protocol_format_enum = ProtocolFormat.PYTHON
         if protocol_format.lower() == "protocol_designer":
             protocol_format_enum = ProtocolFormat.PROTOCOL_DESIGNER
 
-        # Generate response using the enhanced history
         response = _generate_llm_response_with_history(
             model_type=settings.model,
             user_id=str(user.sub),
             prompt=message,
             enable_analytics=enable_analytics,
-            history_with_attachments=enhanced_history,
+            history_with_attachments=history_with_attachments,
             protocol_format=protocol_format_enum,
-            protocol_action="update",  # Default action
-            new_file_references=current_files,
+            protocol_action="update",
+            current_msg_files=current_msg_files,
         )
         return _format_response(response, protocol_format_enum, fake, token_warning)
 

--- a/opentrons-ai-server/api/handler/fast.py
+++ b/opentrons-ai-server/api/handler/fast.py
@@ -244,10 +244,10 @@ def _generate_llm_response_with_history(
                         all_file_references.append(
                             {
                                 "id": attachment.get("id", ""),
-                                "filename": attachment.get("name", attachment.get("filename", "")),
-                                "file_type": attachment.get("type", attachment.get("file_type", "")),
+                                "name": attachment.get("name", ""),
+                                "type": attachment.get("type", ""),
                                 "content": attachment.get("content", ""),
-                                "media_type": MEDIA_TYPE_MAPPING.get(attachment.get("type", attachment.get("file_type", "")), "text/plain"),
+                                "media_type": MEDIA_TYPE_MAPPING.get(attachment.get("type", ""), "text/plain"),
                             }
                         )
 
@@ -536,7 +536,7 @@ async def _process_multipart_files_with_mapping(files: List[UploadFile]) -> tupl
         try:
             file_count = len(files_by_message[message_index])
             file_ref = await process_single_multipart_file(file, message_index, file_count)
-            file_ref["filename"] = original_filename  # Use extracted original filename
+            file_ref["name"] = original_filename  # Use extracted original filename
             files_by_message[message_index].append(file_ref)
         except ValueError as e:
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e

--- a/opentrons-ai-server/api/handler/fast.py
+++ b/opentrons-ai-server/api/handler/fast.py
@@ -474,24 +474,33 @@ async def create_chat_completion_multipart(
         except json.JSONDecodeError:
             parsed_history_with_attachments = []
 
-        # Process NEW uploaded files for current message
-        new_file_references, token_warning = await _process_multipart_files(files)
+        # Process uploaded files with message mapping
+        files_by_message, token_warning = await _process_multipart_files_with_mapping(files)
+
+        # Reconstruct conversation history with file content
+        enhanced_history = _reconstruct_conversation_history(parsed_history_with_attachments, files_by_message)
+
+        # Get current message files (either at index -1 or at the end of history)
+        current_message_index = len(enhanced_history)
+        current_files = files_by_message.get(current_message_index, [])
+        if not current_files and -1 in files_by_message:
+            current_files = files_by_message[-1]
 
         # Determine protocol format
         protocol_format_enum = ProtocolFormat.PYTHON
         if protocol_format.lower() == "protocol_designer":
             protocol_format_enum = ProtocolFormat.PROTOCOL_DESIGNER
 
-        # Generate response using the new history-aware logic
+        # Generate response using the enhanced history
         response = _generate_llm_response_with_history(
             model_type=settings.model,
             user_id=str(user.sub),
             prompt=message,
             enable_analytics=enable_analytics,
-            history_with_attachments=parsed_history_with_attachments,
+            history_with_attachments=enhanced_history,
             protocol_format=protocol_format_enum,
             protocol_action="update",  # Default action
-            new_file_references=new_file_references,
+            new_file_references=current_files,
         )
         return _format_response(response, protocol_format_enum, fake, token_warning)
 
@@ -502,54 +511,136 @@ async def create_chat_completion_multipart(
         ) from e
 
 
-async def _process_multipart_files(files: List[UploadFile]) -> tuple[Optional[List[Dict[str, str]]], Optional[str]]:
-    """
-    Process uploaded files in the multipart completion handler.
-
-    This is called within the /api/chat/completion-multipart endpoint, AFTER FastAPI
-    has parsed the multipart form data but BEFORE sending files to the LLM. It handles
-    raw file bytes, processes them via FileProcessor, and validates token limits.
-
-    Pipeline position: HTTP Request → Multipart Parsing → File Processing → LLM Request
-    """
+async def _process_multipart_files_with_mapping(files: List[UploadFile]) -> tuple[Dict[int, List[Dict[str, str]]], Optional[str]]:
+    """Process uploaded files and group them by message index."""
     if not files or not any(f.filename for f in files):
-        return None, None
+        return {}, None
 
-    file_references: List[Dict[str, str]] = []
+    files_by_message: Dict[int, List[Dict[str, str]]] = {}
+
     for file in files:
-        if not file.filename:  # Skip empty file entries
+        if not file.filename:
             continue
 
-        # Read file content
-        file_content = await file.read()
+        message_index, original_filename = _extract_message_index_from_filename(file.filename)
 
-        # Validate content type before processing
-        if not file.content_type:
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"File {file.filename} has no content type")
+        # Initialize message group if needed
+        if message_index not in files_by_message:
+            files_by_message[message_index] = []
 
-        # Let FileProcessor handle all validation and processing
         try:
-            processed = FileProcessor.process_multipart_file(file.filename, file.content_type, file_content)
-
-            file_references.append(
-                {
-                    "id": f"upload_{len(file_references)}",
-                    "filename": file.filename,
-                    "file_type": processed["file_type"],
-                    "content": processed["content"],
-                    "media_type": processed["media_type"],
-                }
-            )
+            file_count = len(files_by_message[message_index])
+            file_ref = await _process_single_multipart_file(file, message_index, file_count)
+            file_ref["filename"] = original_filename  # Use extracted original filename
+            files_by_message[message_index].append(file_ref)
         except ValueError as e:
-            # Handle file processing errors (like PDF too large)
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
 
-    # Check total token count and generate warning if needed
-    token_warning = (
-        FileProcessor.check_files_token_warning(file_references, claude.client, settings.anthropic_model_name) if file_references else None
-    )
+    # Check token count for all files
+    all_files = [file for file_list in files_by_message.values() for file in file_list]
+    token_warning = None
+    if all_files:
+        token_warning = FileProcessor.check_files_token_warning(all_files, claude.client, settings.anthropic_model_name)
 
-    return file_references, token_warning
+    return files_by_message, token_warning
+
+
+def _enhance_message_with_file_content(msg: Dict[str, Any], message_files: List[Dict[str, str]]) -> Dict[str, Any]:
+    """Post-upload phase: Merges frontend attachment metadata with processed file content.
+
+    Bridges frontend JSON (metadata only) with backend processed files before AI model.
+    """
+    enhanced_msg = msg.copy()
+    file_content_map = {f["filename"]: f for f in message_files}
+
+    if enhanced_msg.get("attachments"):
+        # Message has attachment metadata - enhance with content
+        enhanced_attachments = []
+        for att in enhanced_msg["attachments"]:
+            filename = att.get("name", att.get("filename", ""))
+            if filename in file_content_map:
+                file_ref = file_content_map[filename]
+                enhanced_attachments.append(
+                    {
+                        "id": att.get("id", file_ref["id"]),
+                        "filename": filename,
+                        "file_type": file_ref["file_type"],
+                        "content": file_ref["content"],
+                        "media_type": file_ref["media_type"],
+                    }
+                )
+        enhanced_msg["attachments"] = enhanced_attachments
+    else:
+        # No metadata - use files directly
+        enhanced_msg["attachments"] = []
+        for file_ref in message_files:
+            enhanced_msg["attachments"].append(
+                {
+                    "id": file_ref["id"],
+                    "filename": file_ref["filename"],
+                    "file_type": file_ref["file_type"],
+                    "content": file_ref["content"],
+                    "media_type": file_ref["media_type"],
+                }
+            )
+
+    return enhanced_msg
+
+
+def _reconstruct_conversation_history(
+    parsed_history: List[Dict[str, Any]], files_by_message: Dict[int, List[Dict[str, str]]]
+) -> List[Dict[str, Any]]:
+    """Pre-AI phase: Final assembly of conversation history with files in correct message positions.
+
+    Ensures AI model sees files in their original conversational context.
+    """
+    enhanced_history = []
+
+    for i, msg in enumerate(parsed_history):
+        if i in files_by_message and files_by_message[i]:
+            enhanced_msg = _enhance_message_with_file_content(msg, files_by_message[i])
+        else:
+            enhanced_msg = msg.copy()
+        enhanced_history.append(enhanced_msg)
+
+    return enhanced_history
+
+
+def _extract_message_index_from_filename(filename: str) -> tuple[int, str]:
+    """Raw upload phase: Parses msgN_filename format to determine conversation placement.
+
+    Returns (message_index, original_filename) for proper file grouping.
+    """
+    if filename.startswith("msg") and "_" in filename:
+        parts = filename.split("_", 1)
+        if len(parts) == 2 and parts[0][3:].isdigit():
+            return int(parts[0][3:]), parts[1]
+
+    return -1, filename  # Default for current message
+
+
+async def _process_single_multipart_file(file: UploadFile, message_index: int, file_count: int) -> Dict[str, str]:
+    """Raw upload processing: Validates and processes single file for AI consumption.
+
+    Sits between HTTP multipart parsing and conversation reconstruction.
+    """
+    file_content = await file.read()
+
+    if not file.filename:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="File has no filename")
+
+    if not file.content_type:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"File {file.filename} has no content type")
+
+    processed = FileProcessor.process_multipart_file(file.filename, file.content_type, file_content)
+
+    return {
+        "id": f"upload_{message_index}_{file_count}",
+        "filename": file.filename,
+        "file_type": processed["file_type"],
+        "content": processed["content"],
+        "media_type": processed["media_type"],
+    }
 
 
 def _determine_protocol_action(body: ChatRequest) -> str:

--- a/opentrons-ai-server/api/handler/utils_fast.py
+++ b/opentrons-ai-server/api/handler/utils_fast.py
@@ -43,20 +43,20 @@ def enhance_message_with_file_content(msg: Dict[str, Any], message_files: List[D
     Bridges frontend JSON (metadata only) with backend processed files before AI model.
     """
     enhanced_msg = msg.copy()
-    file_content_map = {f["filename"]: f for f in message_files}
+    file_content_map = {f["name"]: f for f in message_files}
 
     if enhanced_msg.get("attachments"):
         # Message has attachment metadata - enhance with content
         enhanced_attachments = []
         for att in enhanced_msg["attachments"]:
-            filename = att.get("name", att.get("filename", ""))
+            filename = att.get("name", "")
             if filename in file_content_map:
                 file_ref = file_content_map[filename]
                 enhanced_attachments.append(
                     {
                         "id": att.get("id", file_ref["id"]),
-                        "filename": filename,
-                        "file_type": file_ref["file_type"],
+                        "name": filename,
+                        "type": file_ref["type"],
                         "content": file_ref["content"],
                         "media_type": file_ref["media_type"],
                     }
@@ -69,8 +69,8 @@ def enhance_message_with_file_content(msg: Dict[str, Any], message_files: List[D
             enhanced_msg["attachments"].append(
                 {
                     "id": file_ref["id"],
-                    "filename": file_ref["filename"],
-                    "file_type": file_ref["file_type"],
+                    "name": file_ref["name"],
+                    "type": file_ref["type"],
                     "content": file_ref["content"],
                     "media_type": file_ref["media_type"],
                 }
@@ -115,8 +115,8 @@ async def process_single_multipart_file(file: UploadFile, message_index: int, fi
 
     return {
         "id": f"upload_{message_index}_{file_count}",
-        "filename": file.filename,
-        "file_type": processed["file_type"],
+        "name": file.filename,
+        "type": processed["file_type"],
         "content": processed["content"],
         "media_type": processed["media_type"],
     }

--- a/opentrons-ai-server/api/handler/utils_fast.py
+++ b/opentrons-ai-server/api/handler/utils_fast.py
@@ -1,5 +1,9 @@
 import re
-from typing import Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
+
+from fastapi import HTTPException, UploadFile, status
+
+from api.services.file_processor import FileProcessor
 
 
 def parse_tagged_content(text: str) -> Tuple[Optional[str], Optional[str], Optional[str]]:
@@ -18,3 +22,101 @@ def parse_tagged_content(text: str) -> Tuple[Optional[str], Optional[str], Optio
     comments_content = extract_tag_content("COMMENTS", text)
 
     return thinking_content, pd_json_content, comments_content
+
+
+def extract_message_index_from_filename(filename: str) -> tuple[int, str]:
+    """
+    Raw upload phase: Parses msgN_filename format to determine conversation placement.
+    Returns (message_index, original_filename) for proper file grouping.
+    """
+    if filename.startswith("msg") and "_" in filename:
+        parts = filename.split("_", 1)
+        if len(parts) == 2 and parts[0][3:].isdigit():
+            return int(parts[0][3:]), parts[1]
+
+    return -1, filename  # Default for current message
+
+
+def enhance_message_with_file_content(msg: Dict[str, Any], message_files: List[Dict[str, str]]) -> Dict[str, Any]:
+    """
+    Post-upload phase: Merges frontend attachment metadata with processed file content.
+    Bridges frontend JSON (metadata only) with backend processed files before AI model.
+    """
+    enhanced_msg = msg.copy()
+    file_content_map = {f["filename"]: f for f in message_files}
+
+    if enhanced_msg.get("attachments"):
+        # Message has attachment metadata - enhance with content
+        enhanced_attachments = []
+        for att in enhanced_msg["attachments"]:
+            filename = att.get("name", att.get("filename", ""))
+            if filename in file_content_map:
+                file_ref = file_content_map[filename]
+                enhanced_attachments.append(
+                    {
+                        "id": att.get("id", file_ref["id"]),
+                        "filename": filename,
+                        "file_type": file_ref["file_type"],
+                        "content": file_ref["content"],
+                        "media_type": file_ref["media_type"],
+                    }
+                )
+        enhanced_msg["attachments"] = enhanced_attachments
+    else:
+        # No metadata - use files directly
+        enhanced_msg["attachments"] = []
+        for file_ref in message_files:
+            enhanced_msg["attachments"].append(
+                {
+                    "id": file_ref["id"],
+                    "filename": file_ref["filename"],
+                    "file_type": file_ref["file_type"],
+                    "content": file_ref["content"],
+                    "media_type": file_ref["media_type"],
+                }
+            )
+
+    return enhanced_msg
+
+
+def reconstruct_conversation_history(
+    parsed_history: List[Dict[str, Any]], files_by_message: Dict[int, List[Dict[str, str]]]
+) -> List[Dict[str, Any]]:
+    """
+    Pre-AI phase: Final assembly of conversation history with files in correct message positions.
+    Ensures AI model sees files in their original conversational context.
+    """
+    enhanced_history = []
+
+    for i, msg in enumerate(parsed_history):
+        if i in files_by_message and files_by_message[i]:
+            enhanced_msg = enhance_message_with_file_content(msg, files_by_message[i])
+        else:
+            enhanced_msg = msg.copy()
+        enhanced_history.append(enhanced_msg)
+
+    return enhanced_history
+
+
+async def process_single_multipart_file(file: UploadFile, message_index: int, file_count: int) -> Dict[str, str]:
+    """
+    Raw upload processing: Validates and processes single file for AI consumption.
+    Sits between HTTP multipart parsing and conversation reconstruction.
+    """
+    file_content = await file.read()
+
+    if not file.filename:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="File has no filename")
+
+    if not file.content_type:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"File {file.filename} has no content type")
+
+    processed = FileProcessor.process_multipart_file(file.filename, file.content_type, file_content)
+
+    return {
+        "id": f"upload_{message_index}_{file_count}",
+        "filename": file.filename,
+        "file_type": processed["file_type"],
+        "content": processed["content"],
+        "media_type": processed["media_type"],
+    }

--- a/opentrons-ai-server/api/handler/utils_fast.py
+++ b/opentrons-ai-server/api/handler/utils_fast.py
@@ -26,76 +26,94 @@ def parse_tagged_content(text: str) -> Tuple[Optional[str], Optional[str], Optio
 
 def extract_message_index_from_filename(filename: str) -> tuple[int, str]:
     """
-    Raw upload phase: Parses msgN_filename format to determine conversation placement.
-    Returns (message_index, original_filename) for proper file grouping.
+    Parses msgN_filename format to extract message index and original filename.
+    Example: "msg0_report.pdf" -> (0, "report.pdf")
     """
-    if filename.startswith("msg") and "_" in filename:
-        parts = filename.split("_", 1)
-        if len(parts) == 2 and parts[0][3:].isdigit():
-            return int(parts[0][3:]), parts[1]
-
-    return -1, filename  # Default for current message
+    parts = filename.split("_", 1)
+    message_index = int(parts[0][3:])
+    original_filename = parts[1]
+    return message_index, original_filename
 
 
-def enhance_message_with_file_content(msg: Dict[str, Any], message_files: List[Dict[str, str]]) -> Dict[str, Any]:
+def enhance_message_with_file_content(msg: Dict[str, Any], msg_files: List[Dict[str, str]]) -> Dict[str, Any]:
     """
-    Post-upload phase: Merges frontend attachment metadata with processed file content.
-    Bridges frontend JSON (metadata only) with backend processed files before AI model.
-    """
-    enhanced_msg = msg.copy()
-    file_content_map = {f["name"]: f for f in message_files}
+    Merges frontend attachment metadata with processed file content.
+    i.e., attachment = file metadata + file content
 
-    if enhanced_msg.get("attachments"):
-        # Message has attachment metadata - enhance with content
-        enhanced_attachments = []
-        for att in enhanced_msg["attachments"]:
-            filename = att.get("name", "")
-            if filename in file_content_map:
-                file_ref = file_content_map[filename]
-                enhanced_attachments.append(
-                    {
-                        "id": att.get("id", file_ref["id"]),
-                        "name": filename,
-                        "type": file_ref["type"],
-                        "content": file_ref["content"],
-                        "media_type": file_ref["media_type"],
-                    }
-                )
-        enhanced_msg["attachments"] = enhanced_attachments
-    else:
-        # No metadata - use files directly
-        enhanced_msg["attachments"] = []
-        for file_ref in message_files:
-            enhanced_msg["attachments"].append(
+    Input:
+    msg = {
+        'role': 'user',
+        'content': 'hi',
+        'fileMetadata': [{'id': ..., 'name': ..., 'type': ...}]
+    }
+
+    msg_files = [
+        {
+            'id': ...,
+            'name': ...,
+            'type': ...,
+            'content': ..., # note: this is the file content
+            'media_type': ...
+        }
+    ]
+
+    Return:
+    msg_with_files = {
+        'role': 'user',
+        'content': 'hi',
+        'fileMetadata': [{'id': ..., 'name': ..., 'type': ...}],
+        'attachments': [
+            {
+                'id': ...,
+                'name': ...,
+                'type': ...,
+                'content': ..., # note: this is the file content
+                'media_type': ...
+            }
+        ]
+    }
+
+    """
+
+    msg_with_files = msg.copy()
+    file_content_map = {f["name"]: f for f in msg_files}
+
+    attachments = []
+    for att in msg_with_files["fileMetadata"]:
+        filename = att.get("name", "")
+        if filename in file_content_map:
+            file_ref = file_content_map[filename]
+            attachments.append(
                 {
-                    "id": file_ref["id"],
-                    "name": file_ref["name"],
+                    "id": att.get("id", file_ref["id"]),
+                    "name": filename,
                     "type": file_ref["type"],
                     "content": file_ref["content"],
                     "media_type": file_ref["media_type"],
                 }
             )
+    msg_with_files["attachments"] = attachments
 
-    return enhanced_msg
+    return msg_with_files
 
 
 def reconstruct_conversation_history(
     parsed_history: List[Dict[str, Any]], files_by_message: Dict[int, List[Dict[str, str]]]
 ) -> List[Dict[str, Any]]:
     """
-    Pre-AI phase: Final assembly of conversation history with files in correct message positions.
+    Assembly of conversation history with files in correct message positions.
     Ensures AI model sees files in their original conversational context.
     """
-    enhanced_history = []
+    history_with_files = []
 
     for i, msg in enumerate(parsed_history):
         if i in files_by_message and files_by_message[i]:
-            enhanced_msg = enhance_message_with_file_content(msg, files_by_message[i])
+            msg_with_files = enhance_message_with_file_content(msg, files_by_message[i])
         else:
-            enhanced_msg = msg.copy()
-        enhanced_history.append(enhanced_msg)
+            msg_with_files = msg.copy()
+        history_with_files.append(msg_with_files)
 
-    return enhanced_history
+    return history_with_files
 
 
 async def process_single_multipart_file(file: UploadFile, message_index: int, file_count: int) -> Dict[str, str]:

--- a/opentrons-ai-server/api/services/file_processor.py
+++ b/opentrons-ai-server/api/services/file_processor.py
@@ -181,7 +181,7 @@ class FileProcessor:
                 logger.warning(f"Invalid file reference type: {type(file_ref)}")
                 continue
 
-            filename = file_ref.get("filename", "unknown")
+            filename = file_ref.get("name", "unknown")
             content = file_ref.get("content", "")
             media_type = file_ref.get("media_type", "text/plain")
 


### PR DESCRIPTION
# Overview
Closes AUTH-2159

This PR addresses the handling of file attachments in the multipart upload flow by restructuring how files are managed between the frontend and backend. The primary focus is fixing the `content` field for file attachments.

This field is essential for maintaining chat history, enabling users to reference files across multi-turn conversations. Currently, the chat system can only process files on a per-message basis. While users can attach a file and ask a question about it in a single message, the system loses context in subsequent turns. This happens because the frontend only sends files attached to the current message, rather than maintaining file references throughout the conversation history.

File attachments persist across the entire conversation, allowing for more natural multi-turn interactions with uploaded files.

## Test Plan and Hands on Testing

CI

## Review requests
Multi-turn conversations with files: Upload pdf, csv, or python then ask questions.

## Risk assessment

Mid