### PR TITLE
fix(app): more heater-shaker max limits stuff

### DIFF
--- a/api/src/opentrons/protocol_api/module_validation_and_errors.py
+++ b/api/src/opentrons/protocol_api/module_validation_and_errors.py
@@ -19,13 +19,13 @@ class InvalidTargetSpeedError(ValueError):
 
 
 def _validate_hs_temp_nomin(celsius: float) -> float:
-    if celsius <= HEATER_SHAKER_TEMPERATURE_MAX:
+    if 0 <= celsius <= HEATER_SHAKER_TEMPERATURE_MAX:
         return celsius
     else:
         raise InvalidTargetTemperatureError(
             f"Cannot set Heater-Shaker to {celsius} °C."
             f" The maximum temperature for the Heater-Shaker is"
-            f"{HEATER_SHAKER_TEMPERATURE_MAX} °C."
+            f"{HEATER_SHAKER_TEMPERATURE_MAX} °C, and the temperature must be positive."
         )
 
 

--- a/api/src/opentrons/protocol_engine/state/module_substates/heater_shaker_module_substate.py
+++ b/api/src/opentrons/protocol_engine/state/module_substates/heater_shaker_module_substate.py
@@ -19,7 +19,7 @@ from opentrons.protocol_engine.errors import (
 HeaterShakerModuleId = NewType("HeaterShakerModuleId", str)
 
 
-HEATER_SHAKER_MAX_TEMPERATURE_RANGE = TemperatureRange(min=0, max=95)
+HEATER_SHAKER_TEMPERATURE_RANGE = TemperatureRange(min=0, max=95)
 HEATER_SHAKER_SPEED_RANGE = SpeedRange(min=200, max=3000)
 
 

--- a/api/src/opentrons/protocol_engine/state/module_substates/heater_shaker_module_substate.py
+++ b/api/src/opentrons/protocol_engine/state/module_substates/heater_shaker_module_substate.py
@@ -1,4 +1,5 @@
 """Heater-Shaker Module sub-state."""
+
 from dataclasses import dataclass
 from typing import NewType, Optional
 
@@ -18,8 +19,7 @@ from opentrons.protocol_engine.errors import (
 HeaterShakerModuleId = NewType("HeaterShakerModuleId", str)
 
 
-# TODO (spp, 2022-03-22): Move these values to heater-shaker module definition.
-HEATER_SHAKER_TEMPERATURE_RANGE = TemperatureRange(min=37, max=95)
+HEATER_SHAKER_MAX_TEMPERATURE_RANGE = TemperatureRange(min=0, max=95)
 HEATER_SHAKER_SPEED_RANGE = SpeedRange(min=200, max=3000)
 
 
@@ -99,9 +99,11 @@ class HeaterShakerModuleSubState:
         if ModuleDataValidator.is_heater_shaker_data(data):
             return cls(
                 module_id=module_id,
-                labware_latch_status=HeaterShakerLatchStatus.CLOSED
-                if data["labwareLatchStatus"] == "idle_closed"
-                else HeaterShakerLatchStatus.OPEN,
+                labware_latch_status=(
+                    HeaterShakerLatchStatus.CLOSED
+                    if data["labwareLatchStatus"] == "idle_closed"
+                    else HeaterShakerLatchStatus.OPEN
+                ),
                 is_plate_shaking=data["targetSpeed"] is not None,
                 plate_target_temperature=data["targetTemp"],
             )

--- a/api/tests/opentrons/protocol_api_old/test_module_validation_and_errors.py
+++ b/api/tests/opentrons/protocol_api_old/test_module_validation_and_errors.py
@@ -29,7 +29,7 @@ def test_validate_heater_shaker_temperature_raises_under_api_225(
         )
 
 
-@pytest.mark.parametrize("invalid_celsius_value", [95.01])
+@pytest.mark.parametrize("invalid_celsius_value", [-1, 95.01])
 def test_validate_heater_shaker_temperature_raises_over_api_225(
     invalid_celsius_value: float,
 ) -> None:

--- a/api/tests/opentrons/protocol_engine/state/test_module_view_old.py
+++ b/api/tests/opentrons/protocol_engine/state/test_module_view_old.py
@@ -4,6 +4,7 @@ DEPRECATED: Testing ModuleView independently of ModuleView is no longer helpful.
 Try to add new tests to test_module_state.py, where they can be tested together,
 treating ModuleState as a private implementation detail.
 """
+
 import pytest
 from math import isclose
 from pytest_lazy_fixtures import lf as lazy_fixture
@@ -137,10 +138,10 @@ def make_module_view(
         for module_id in slot_by_module_id:
             deck_slot = slot_by_module_id[module_id]
             if deck_slot is not None:
-                load_location_by_module_id[
-                    module_id
-                ] = deck_configuration_provider.get_cutout_id_by_deck_slot_name(
-                    deck_slot
+                load_location_by_module_id[module_id] = (
+                    deck_configuration_provider.get_cutout_id_by_deck_slot_name(
+                        deck_slot
+                    )
                 )
             else:
                 load_location_by_module_id[module_id] = None
@@ -1159,7 +1160,7 @@ def test_magnetic_module_view_calculate_magnet_hardware_height(
         assert result == expected_result
 
 
-@pytest.mark.parametrize("target_temp", [36.8, 95.1])
+@pytest.mark.parametrize("target_temp", [-1, 95.1])
 def test_validate_heater_shaker_target_temperature_raises(
     heater_shaker_v1_def: ModuleDefinition,
     target_temp: float,

--- a/api/tests/opentrons/protocol_engine/state/test_module_view_old.py
+++ b/api/tests/opentrons/protocol_engine/state/test_module_view_old.py
@@ -138,10 +138,10 @@ def make_module_view(
         for module_id in slot_by_module_id:
             deck_slot = slot_by_module_id[module_id]
             if deck_slot is not None:
-                load_location_by_module_id[module_id] = (
-                    deck_configuration_provider.get_cutout_id_by_deck_slot_name(
-                        deck_slot
-                    )
+                load_location_by_module_id[
+                    module_id
+                ] = deck_configuration_provider.get_cutout_id_by_deck_slot_name(
+                    deck_slot
                 )
             else:
                 load_location_by_module_id[module_id] = None

--- a/app/src/organisms/ModuleCard/HeaterShakerSlideout.tsx
+++ b/app/src/organisms/ModuleCard/HeaterShakerSlideout.tsx
@@ -15,7 +15,6 @@ import {
   CELSIUS,
   getModuleDisplayName,
   HS_TEMP_MAX,
-  HS_TEMP_MIN,
 } from '@opentrons/shared-data'
 
 import { SubmitPrimaryButton } from '/app/atoms/buttons'
@@ -91,14 +90,14 @@ export const HeaterShakerSlideout = (
       onCloseClick()
     }
   }
-  const errorMessage =
-    hsValue != null && (hsValue < HS_TEMP_MIN || hsValue > HS_TEMP_MAX)
-      ? t('input_out_of_range')
-      : null
 
   const inputMax = HS_TEMP_MAX
-  const inputMin = HS_TEMP_MIN
+  const inputMin = 20
   const unit = CELSIUS
+  const errorMessage =
+    hsValue != null && (hsValue < inputMin || hsValue > HS_TEMP_MAX)
+      ? t('input_out_of_range')
+      : null
 
   const handleCloseSlideout = (): void => {
     setHsValue(null)


### PR DESCRIPTION
We need a couple more places:
- an engine max limit
- the app module card max limit

(oopsy didn't test the other one good)
## Actual device testing
- [x] control to 32C (well, "control") from the module card
- [x] do that in a protocol