### PR TITLE
fix(api): Ensure thermocycler dodge waypoints can account for fixtures

### DIFF
--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -1097,14 +1097,36 @@ class GeometryView:
             if self._modules.should_dodge_thermocycler(
                 from_slot=from_slot, to_slot=to_slot
             ):
-                middle_slot = DeckSlotName.SLOT_5.to_equivalent_for_robot_type(
-                    self._config.robot_type
-                )
-                middle_slot_center = (
-                    self._addressable_areas.get_addressable_area_center(
-                        addressable_area_name=middle_slot.id,
+
+                middle_slot_fixture = (
+                    self._addressable_areas.get_fixture_by_deck_slot_name(
+                        DeckSlotName.SLOT_C2
                     )
                 )
+                if middle_slot_fixture is None:
+                    middle_slot = DeckSlotName.SLOT_5.to_equivalent_for_robot_type(
+                        self._config.robot_type
+                    )
+                    middle_slot_center = (
+                        self._addressable_areas.get_addressable_area_center(
+                            addressable_area_name=middle_slot.id,
+                        )
+                    )
+                else:
+                    # todo(chb, 2025-07-30): For now we're defaulting to the first addressable area for these center slot fixtures, but
+                    # if we ever introduce a fixture in the center slot with many addressable areas that aren't "centered" over the deck
+                    # slot we will enter up generating a pretty whacky movement path (potentially dangerous).
+                    middle_slot_center = self._addressable_areas.get_addressable_area_center(
+                        addressable_area_name=middle_slot_fixture[
+                            "providesAddressableAreas"
+                        ][
+                            deck_configuration_provider.get_cutout_id_by_deck_slot_name(
+                                DeckSlotName.SLOT_C2
+                            )
+                        ][
+                            0
+                        ],
+                    )
                 return [(middle_slot_center.x, middle_slot_center.y)]
         return []
 


### PR DESCRIPTION
# Overview
Covers RESC-476

Originally we just hardcoded to Slot 5/C2 when planning waypoints to dodge the thermocycler. This PR adds in logic to find an appropriate fixtures and center over its first addressable area instead, which fixes out issue for magnetic blocks.

Of note, this potentially causes issues if we add new center slot fixtures that have a bunch of whacky addressable areas that are offset from the center of the cutout. Think about how the flex stacker's addressable areas skew way off the deck from their cutout origin, we could see similar behavior here in the future.

For now I think this is really fine given the reality of what fixtures we allow there, but I've left a todo explaining the issue and we may need to address it in the future if we want more foolproof solution. 

## Test Plan and Hands on Testing

- [x] Run the following protocol on Flex, ensure we don't raise the "Addressable area C2 not in deck config" error:
```
def run(protocol_context: ProtocolContext):
    trash = protocol_context.load_trash_bin("A3")
    thermo = protocol_context.load_module("thermocyclerModuleV2")
    mag_block = protocol_context.load_module('magneticBlockV1', location='C2')
    tiprack1 = protocol_context.load_labware(load_name="opentrons_flex_96_tiprack_200ul", location="B3", adapter="opentrons_flex_96_tiprack_adapter")
    plate = protocol_context.load_labware('nest_96_wellplate_200ul_flat', "C1")

    instrument = protocol_context.load_instrument('flex_96channel_1000', mount="right", tip_racks=[tiprack1])
    instrument.pick_up_tip()

    instrument.aspirate(200, plate.wells_by_name()["A1"])
    instrument.dispense(200, plate.wells_by_name()["A1"])

    instrument.drop_tip()
```

## Changelog
Modified geometry waypoint planning to dodge thermocycler using dynamic fixtures.

## Review requests

## Risk assessment
Low/Medium - this fixes the issue, but at what cost?!?!?! Not really any cost for now, but as mentioned above if we ever introduce a fixture in the center slot with whacky addressable areas it will mess up the waypoint planning again.