### PR TITLE
feat(api,shared-data): Define labware schema 3 grip height relative to labware origin

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/pipette_movement_conflict.py
+++ b/api/src/opentrons/protocol_api/core/engine/pipette_movement_conflict.py
@@ -283,6 +283,10 @@ def check_safe_for_tip_pickup_and_return(
         adapter_height = engine_state.labware.get_dimensions(
             labware_id=tiprack_parent.labwareId
         ).z
+        # todo(mm, 2025-07-31): This looks like it needs to be something like
+        # `tiprack_top_plane < adapter_top_plane` instead of `tiprack_height < adapter_height`.
+        # In other words, take into account the stacking offset between the tip rack
+        # and its adapter.
         if is_partial_config and tiprack_height < adapter_height:
             raise PartialTipMovementNotAllowedError(
                 f"{tiprack_name} cannot be on an adapter taller than the tip rack"

--- a/api/src/opentrons/protocol_engine/state/_axis_aligned_bounding_box.py
+++ b/api/src/opentrons/protocol_engine/state/_axis_aligned_bounding_box.py
@@ -34,15 +34,6 @@ class AxisAlignedBoundingBox3D:
             max_z=max(corner_a.z, corner_b.z),
         )
 
-    def __post_init__(self) -> None:
-        """Validate that the input coordinates make sense."""
-        if not (
-            self.min_x <= self.max_x
-            and self.min_y <= self.max_y
-            and self.min_z <= self.max_z
-        ):
-            raise ValueError("Invalid coordinates.", self)
-
     @property
     def x_dimension(self) -> float:
         """Return the dimension along the x-axis."""

--- a/api/src/opentrons/protocol_engine/state/_axis_aligned_bounding_box.py
+++ b/api/src/opentrons/protocol_engine/state/_axis_aligned_bounding_box.py
@@ -1,0 +1,59 @@
+import dataclasses
+
+from typing_extensions import Self
+
+from opentrons.types import Point
+
+
+@dataclasses.dataclass(kw_only=True)
+class AxisAlignedBoundingBox3D:
+    """An axis-aligned bounding box (in other words, a cuboid in 3D space)."""
+
+    min_x: float
+    max_x: float
+
+    min_y: float
+    max_y: float
+
+    min_z: float
+    max_z: float
+
+    @classmethod
+    def from_corners(cls, corner_a: Point, corner_b: Point) -> Self:
+        """Construct from two diagonally opposite corners.
+
+        It doesn't matter which two corners, as long as they're diagonally opposite.
+        It also doesn't matter what order.
+        """
+        return cls(
+            min_x=min(corner_a.x, corner_b.x),
+            max_x=max(corner_a.x, corner_b.x),
+            min_y=min(corner_a.y, corner_b.y),
+            max_y=max(corner_a.y, corner_b.y),
+            min_z=min(corner_a.z, corner_b.z),
+            max_z=max(corner_a.z, corner_b.z),
+        )
+
+    def __post_init__(self) -> None:
+        """Validate that the input coordinates make sense."""
+        if not (
+            self.min_x <= self.max_x
+            and self.min_y <= self.max_y
+            and self.min_z <= self.max_z
+        ):
+            raise ValueError("Invalid coordinates.", self)
+
+    @property
+    def x_dimension(self) -> float:
+        """Return the dimension along the x-axis."""
+        return self.max_x - self.min_x
+
+    @property
+    def y_dimension(self) -> float:
+        """Return the dimension along the y-axis."""
+        return self.max_y - self.min_y
+
+    @property
+    def z_dimension(self) -> float:
+        """Return the dimension along the z-axis."""
+        return self.max_z - self.min_z

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -702,6 +702,8 @@ class GeometryView:
             # should be updated.
             module_id = lw_data.location.moduleId
             height_over_labware = self._modules.get_height_over_labware(module_id)
+        # todo(mm, 2025-07-31): This math needs updating for schema 2:
+        # labware_pos.z is not necessarily the bottom of the labware.
         return labware_pos.z + z_dim + height_over_labware
 
     def get_nominal_effective_tip_length(

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -1550,16 +1550,18 @@ class GeometryView:
             tip = self._pipettes.get_attached_tip(pipette.id)
             if not tip:
                 continue
+
             labware_top_z_when_gripped = gripper_homed_position_z + (
                 self._labware.get_dimensions(labware_definition=labware_definition).z
                 - self._labware.get_grip_height_from_labware_origin(labware_definition)
             )
-            # TODO(cb, 2024-01-18): Utilizing the nozzle map and labware X coordinates verify if collisions will occur on the X axis (analysis will use hard coded data to measure from the gripper critical point to the pipette mount)
+            # TODO(cb, 2024-01-18): Utilizing the nozzle map and labware X coordinates,
+            # verify if collisions will occur on the X axis (analysis will use hard coded data
+            # to measure from the gripper critical point to the pipette mount)
             if (_PIPETTE_HOMED_POSITION_Z - tip.length) < labware_top_z_when_gripped:
                 raise LabwareMovementNotAllowedError(
                     f"Cannot move labware '{labware_definition.parameters.loadName}' when {int(tip.volume)} µL tips are attached."
                 )
-        return
 
     def _nominal_gripper_offsets_for_location(
         self, location: OnDeckLabwareLocation

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -678,7 +678,6 @@ class GeometryView:
                     delta=delta,
                     meniscus_tracking=meniscus_tracking,
                 )
-        return NotImplemented
 
     def get_well_height(
         self,

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -1041,7 +1041,7 @@ class GeometryView:
         z-position of labware bottom + grip height from labware bottom.
         """
         grip_height_from_labware_bottom = (
-            self._labware.get_grip_height_from_labware_bottom(labware_definition)
+            self._labware.get_grip_height_from_labware_origin(labware_definition)
         )
         aa_name = self._get_underlying_addressable_area_name(location)
         parent_to_lw_offset = self._get_stackup_placement_origin_to_lw_origin(
@@ -1552,7 +1552,7 @@ class GeometryView:
                 continue
             labware_top_z_when_gripped = gripper_homed_position_z + (
                 self._labware.get_dimensions(labware_definition=labware_definition).z
-                - self._labware.get_grip_height_from_labware_bottom(labware_definition)
+                - self._labware.get_grip_height_from_labware_origin(labware_definition)
             )
             # TODO(cb, 2024-01-18): Utilizing the nozzle map and labware X coordinates verify if collisions will occur on the X axis (analysis will use hard coded data to measure from the gripper critical point to the pipette mount)
             if (_PIPETTE_HOMED_POSITION_Z - tip.length) < labware_top_z_when_gripped:

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -1041,9 +1041,7 @@ class GeometryView:
         It is calculated as the xy center of the slot with z as the point indicated by
         z-position of labware bottom + grip height from labware bottom.
         """
-        grip_height_from_labware_bottom = (
-            self._labware.get_grip_height_from_labware_origin(labware_definition)
-        )
+        grip_z_from_lw_origin = self._labware.get_grip_z(labware_definition)
         aa_name = self._get_underlying_addressable_area_name(location)
         parent_to_lw_offset = self._get_stackup_placement_origin_to_lw_origin(
             location=location,
@@ -1062,7 +1060,7 @@ class GeometryView:
             + parent_to_lw_offset
             + lw_origin_to_parent
             + mod_cal_offset
-            + Point(0, 0, grip_height_from_labware_bottom)
+            + Point(0, 0, grip_z_from_lw_origin)
         )
 
     def _get_lw_origin_to_parent(
@@ -1554,7 +1552,7 @@ class GeometryView:
 
             labware_top_z_when_gripped = gripper_homed_position_z + (
                 self._labware.get_dimensions(labware_definition=labware_definition).z
-                - self._labware.get_grip_height_from_labware_origin(labware_definition)
+                - self._labware.get_grip_z(labware_definition)
             )
             # TODO(cb, 2024-01-18): Utilizing the nozzle map and labware X coordinates,
             # verify if collisions will occur on the X axis (analysis will use hard coded data

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -1536,6 +1536,7 @@ class GeometryView:
         self,
         gripper_homed_position_z: float,
         labware_id: str,
+        # todo(mm, 2025-07-31): arg unused, investigate or remove.
         current_location: OnDeckLabwareLocation,
     ) -> None:
         """Check for potential collision of tips against labware to be lifted."""
@@ -1550,10 +1551,17 @@ class GeometryView:
             if not tip:
                 continue
 
-            labware_top_z_when_gripped = gripper_homed_position_z + (
-                self._labware.get_dimensions(labware_definition=labware_definition).z
-                - self._labware.get_grip_z(labware_definition)
+            labware_origin_to_grip_point = self._labware.get_grip_z(labware_definition)
+            grip_point_to_labware_origin = -labware_origin_to_grip_point
+            height_above_labware_origin = self._labware.get_extents_around_lw_origin(
+                labware_definition
+            ).max_z
+            labware_top_z_when_gripped = (
+                gripper_homed_position_z
+                + grip_point_to_labware_origin
+                + height_above_labware_origin
             )
+
             # TODO(cb, 2024-01-18): Utilizing the nozzle map and labware X coordinates,
             # verify if collisions will occur on the X axis (analysis will use hard coded data
             # to measure from the gripper critical point to the pipette mount)

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -32,7 +32,10 @@ from opentrons_shared_data.labware.labware_definition import (
 )
 from opentrons_shared_data.pipette.types import LabwareUri
 
-from opentrons.types import DeckSlotName, StagingSlotName, MountType
+from opentrons.protocol_engine.state._axis_aligned_bounding_box import (
+    AxisAlignedBoundingBox3D,
+)
+from opentrons.types import DeckSlotName, StagingSlotName, MountType, Point
 from opentrons.protocols.api_support.constants import OPENTRONS_NAMESPACE
 from opentrons.calibration_storage.helpers import uri_from_details
 
@@ -864,30 +867,30 @@ class LabwareView:
             assert labware_id is not None  # From our @overloads.
             labware_definition = self.get_definition(labware_id)
 
-        if isinstance(labware_definition, LabwareDefinition2):
-            return Dimensions(
-                x=labware_definition.dimensions.xDimension,
-                y=labware_definition.dimensions.yDimension,
-                z=labware_definition.dimensions.zDimension,
+        extents = self.get_extents_around_lw_origin(labware_definition)
+        return Dimensions(
+            x=extents.x_dimension, y=extents.y_dimension, z=extents.z_dimension
+        )
+
+    def get_extents_around_lw_origin(
+        self,
+        labware_definition: LabwareDefinition,
+    ) -> AxisAlignedBoundingBox3D:
+        """Return a bounding box around all the space the labware occupies, all-encompassing.
+
+        Returned coordinates are relative to the labware's local origin.
+        """
+        if labware_definition.schemaVersion == 2:
+            x_dimension = labware_definition.dimensions.xDimension
+            y_dimension = labware_definition.dimensions.yDimension
+            z_dimension = labware_definition.dimensions.zDimension
+            return AxisAlignedBoundingBox3D.from_corners(
+                Point(0, 0, 0), Point(x_dimension, y_dimension, z_dimension)
             )
         else:
-            assert_type(labware_definition, LabwareDefinition3)
-            back_left_bottom = labware_definition.extents.total.backLeftBottom
-            front_right_top = labware_definition.extents.total.frontRightTop
-            right, front, top = (
-                front_right_top.x,
-                front_right_top.y,
-                front_right_top.z,
-            )
-            left, back, bottom = (
-                back_left_bottom.x,
-                back_left_bottom.y,
-                back_left_bottom.z,
-            )
-            return Dimensions(
-                x=right - left,
-                y=back - front,
-                z=top - bottom,
+            return AxisAlignedBoundingBox3D.from_corners(
+                Point.from_xyz_attrs(labware_definition.extents.total.backLeftBottom),
+                Point.from_xyz_attrs(labware_definition.extents.total.frontRightTop),
             )
 
     def get_labware_overlap_offsets(
@@ -1360,12 +1363,8 @@ class LabwareView:
 
         def get_origin_to_mid_z(labware_definition: LabwareDefinition) -> float:
             """Return the z-coordinate of the middle of the labware, relative to the labware's origin."""
-            if labware_definition.schemaVersion == 2:
-                return labware_definition.dimensions.zDimension / 2
-            else:
-                bottom_z = labware_definition.extents.total.backLeftBottom.z
-                top_z = labware_definition.extents.total.frontRightTop.z
-                return (bottom_z + top_z) / 2
+            extents = self.get_extents_around_lw_origin(labware_definition)
+            return (extents.max_x - extents.min_z) / 2
 
         if labware_definition.schemaVersion == 2:
             # In schema 2, the bottom of the labware is at the z-origin by definition.

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -15,7 +15,7 @@ from typing import (
     Union,
     overload,
 )
-from typing_extensions import assert_never, assert_type
+from typing_extensions import assert_never
 
 from opentrons.protocol_engine.state import update_types
 from opentrons_shared_data.deck.types import DeckDefinitionV5
@@ -24,7 +24,6 @@ from opentrons_shared_data.labware.labware_definition import (
     InnerWellGeometry,
     LabwareDefinition,
     LabwareDefinition2,
-    LabwareDefinition3,
     LabwareRole,
     WellDefinition2,
     WellDefinition3,

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -1350,15 +1350,33 @@ class LabwareView:
             recommended_force if recommended_force is not None else LABWARE_GRIP_FORCE
         )
 
-    def get_grip_height_from_labware_bottom(
+    def get_grip_height_from_labware_origin(
         self, labware_definition: LabwareDefinition
     ) -> float:
-        """Get the recommended grip height from labware bottom, if present."""
-        recommended_height = labware_definition.gripHeightFromLabwareBottom
+        """Get the place on the labware where the gripper should contact.
+
+        The returned value is a z-offset relative to the labware origin.
+        """
+
+        def get_origin_to_mid_z(labware_definition: LabwareDefinition) -> float:
+            """Return the z-coordinate of the middle of the labware, relative to the labware's origin."""
+            if labware_definition.schemaVersion == 2:
+                return labware_definition.dimensions.zDimension / 2
+            else:
+                bottom_z = labware_definition.extents.total.backLeftBottom.z
+                top_z = labware_definition.extents.total.frontRightTop.z
+                return (bottom_z + top_z) / 2
+
+        if labware_definition.schemaVersion == 2:
+            # In schema 2, the bottom of the labware is at the z-origin by definition.
+            defined_height_from_origin = labware_definition.gripHeightFromLabwareBottom
+        else:
+            defined_height_from_origin = labware_definition.gripHeightFromLabwareOrigin
+
         return (
-            recommended_height
-            if recommended_height is not None
-            else self.get_dimensions(labware_definition=labware_definition).z / 2
+            defined_height_from_origin
+            if defined_height_from_origin is not None
+            else get_origin_to_mid_z(labware_definition)
         )
 
     @staticmethod

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -1361,7 +1361,7 @@ class LabwareView:
         def get_origin_to_mid_z(labware_definition: LabwareDefinition) -> float:
             """Return the z-coordinate of the middle of the labware, relative to the labware's origin."""
             extents = self.get_extents_around_lw_origin(labware_definition)
-            return (extents.max_x - extents.min_z) / 2
+            return (extents.max_z + extents.min_z) / 2
 
         if labware_definition.schemaVersion == 2:
             # In schema 2, the bottom of the labware is at the z-origin by definition.

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -1353,9 +1353,7 @@ class LabwareView:
             recommended_force if recommended_force is not None else LABWARE_GRIP_FORCE
         )
 
-    def get_grip_height_from_labware_origin(
-        self, labware_definition: LabwareDefinition
-    ) -> float:
+    def get_grip_z(self, labware_definition: LabwareDefinition) -> float:
         """Get the place on the labware where the gripper should contact.
 
         The returned value is a z-offset relative to the labware origin.

--- a/api/tests/opentrons/protocol_engine/state/test_axis_aligned_bounding_box.py
+++ b/api/tests/opentrons/protocol_engine/state/test_axis_aligned_bounding_box.py
@@ -1,0 +1,45 @@
+import pytest
+
+from opentrons.protocol_engine.state._axis_aligned_bounding_box import (
+    AxisAlignedBoundingBox3D,
+)
+from opentrons.types import Point
+
+
+def test_from_corners() -> None:
+    """Test the `from_corners()` constructor."""
+    result = AxisAlignedBoundingBox3D.from_corners(Point(1, -2, 3), Point(4, -5, 6))
+    assert result.min_x == 1
+    assert result.max_x == 4
+    assert result.min_y == -5
+    assert result.max_y == -2
+    assert result.min_z == 3
+    assert result.max_z == 6
+
+
+def test_dimensions() -> None:
+    """Test the dimension properties."""
+    result = AxisAlignedBoundingBox3D.from_corners(Point(1, -2, 3), Point(9, -8, 7))
+    assert result.x_dimension == 8
+    assert result.y_dimension == 6
+    assert result.z_dimension == 4
+
+
+def test_invalid_input() -> None:
+    """It should raise if any axis's coordinates are backwards."""
+    with pytest.raises(ValueError):
+        AxisAlignedBoundingBox3D(min_x=1, max_x=-1, min_y=0, max_y=0, min_z=0, max_z=0)
+
+    with pytest.raises(ValueError):
+        AxisAlignedBoundingBox3D(min_x=0, max_x=0, min_y=1, max_y=-1, min_z=0, max_z=0)
+
+    with pytest.raises(ValueError):
+        AxisAlignedBoundingBox3D(min_x=0, max_x=0, min_y=0, max_y=0, min_z=1, max_z=-1)
+
+
+def test_zero_input() -> None:
+    """It should allow a zero-sized bounding box."""
+    # Should not raise.
+    AxisAlignedBoundingBox3D(min_x=0, max_x=0, min_y=0, max_y=0, min_z=0, max_z=0)
+    # Should not raise.
+    AxisAlignedBoundingBox3D.from_corners(Point(), Point())

--- a/api/tests/opentrons/protocol_engine/state/test_axis_aligned_bounding_box.py
+++ b/api/tests/opentrons/protocol_engine/state/test_axis_aligned_bounding_box.py
@@ -1,5 +1,3 @@
-import pytest
-
 from opentrons.protocol_engine.state._axis_aligned_bounding_box import (
     AxisAlignedBoundingBox3D,
 )
@@ -23,23 +21,3 @@ def test_dimensions() -> None:
     assert result.x_dimension == 8
     assert result.y_dimension == 6
     assert result.z_dimension == 4
-
-
-def test_invalid_input() -> None:
-    """It should raise if any axis's coordinates are backwards."""
-    with pytest.raises(ValueError):
-        AxisAlignedBoundingBox3D(min_x=1, max_x=-1, min_y=0, max_y=0, min_z=0, max_z=0)
-
-    with pytest.raises(ValueError):
-        AxisAlignedBoundingBox3D(min_x=0, max_x=0, min_y=1, max_y=-1, min_z=0, max_z=0)
-
-    with pytest.raises(ValueError):
-        AxisAlignedBoundingBox3D(min_x=0, max_x=0, min_y=0, max_y=0, min_z=1, max_z=-1)
-
-
-def test_zero_input() -> None:
-    """It should allow a zero-sized bounding box."""
-    # Should not raise.
-    AxisAlignedBoundingBox3D(min_x=0, max_x=0, min_y=0, max_y=0, min_z=0, max_z=0)
-    # Should not raise.
-    AxisAlignedBoundingBox3D.from_corners(Point(), Point())

--- a/api/tests/opentrons/protocol_engine/state/test_axis_aligned_bounding_box.py
+++ b/api/tests/opentrons/protocol_engine/state/test_axis_aligned_bounding_box.py
@@ -1,3 +1,5 @@
+# noqa: D100
+
 from opentrons.protocol_engine.state._axis_aligned_bounding_box import (
     AxisAlignedBoundingBox3D,
 )

--- a/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
@@ -121,6 +121,9 @@ from opentrons.protocol_engine.state.addressable_areas import (
     AddressableAreaState,
 )
 
+from opentrons.protocol_engine.state._axis_aligned_bounding_box import (
+    AxisAlignedBoundingBox3D as EngineAABB,
+)
 from opentrons.protocol_engine.state import geometry
 from opentrons.protocol_engine.state.geometry import GeometryView, _GripperMoveType
 from opentrons.protocol_engine.state.inner_well_math_utils import (
@@ -3653,17 +3656,10 @@ def test_check_gripper_labware_tip_collision(
         Point(1, 2, 3)
     )
     decoy.when(mock_labware_view.get_definition("labware-id")).then_return(definition)
-    decoy.when(mock_labware_view.get_dimensions(labware_id="labware-id")).then_return(
-        Dimensions(
-            x=definition.dimensions.xDimension,
-            y=definition.dimensions.yDimension,
-            z=definition.dimensions.zDimension,
-        )
-    )
 
-    decoy.when(
-        mock_labware_view.get_dimensions(labware_definition=definition)
-    ).then_return(Dimensions(x=1, y=2, z=67))
+    decoy.when(mock_labware_view.get_extents_around_lw_origin(definition)).then_return(
+        EngineAABB(min_x=0, max_x=0, min_y=0, max_y=0, min_z=100, max_z=167)
+    )
     decoy.when(mock_labware_view.get_grip_z(definition)).then_return(1.0)
 
     with pytest.raises(errors.LabwareMovementNotAllowedError):

--- a/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
@@ -2752,7 +2752,7 @@ def test_get_labware_grip_point_v2_definition(
 ) -> None:
     """It should get the grip point of a LabwareDefinition2 labware at the specified location."""
     decoy.when(
-        mock_labware_view.get_grip_height_from_labware_bottom(_MOCK_LABWARE_DEFINITION2)
+        mock_labware_view.get_grip_height_from_labware_origin(_MOCK_LABWARE_DEFINITION2)
     ).then_return(100)
 
     decoy.when(
@@ -2785,7 +2785,7 @@ def test_get_labware_grip_point_v3_definition(
 ) -> None:
     """It should get the grip point of a LabwareDefinition3 labware at the specified location."""
     decoy.when(
-        mock_labware_view.get_grip_height_from_labware_bottom(_MOCK_LABWARE_DEFINITION3)
+        mock_labware_view.get_grip_height_from_labware_origin(_MOCK_LABWARE_DEFINITION3)
     ).then_return(100)
 
     decoy.when(
@@ -2836,7 +2836,7 @@ def test_get_labware_grip_point_on_labware(
         sentinel.below_definition
     )
     decoy.when(
-        mock_labware_view.get_grip_height_from_labware_bottom(
+        mock_labware_view.get_grip_height_from_labware_origin(
             labware_definition=sentinel.definition
         )
     ).then_return(100)
@@ -2913,7 +2913,7 @@ def test_get_labware_grip_point_for_labware_on_module(
         addressable_area_view=addressable_area_view,
     )
     decoy.when(
-        mock_labware_view.get_grip_height_from_labware_bottom(
+        mock_labware_view.get_grip_height_from_labware_origin(
             sentinel.labware_definition
         )
     ).then_return(500)
@@ -3000,7 +3000,7 @@ def test_get_labware_grip_point_for_labware_stack_on_module(
         addressable_area_view=addressable_area_view,
     )
     decoy.when(
-        mock_labware_view.get_grip_height_from_labware_bottom(
+        mock_labware_view.get_grip_height_from_labware_origin(
             sentinel.labware_definition
         )
     ).then_return(500)
@@ -3675,7 +3675,7 @@ def test_check_gripper_labware_tip_collision(
         mock_labware_view.get_dimensions(labware_definition=definition)
     ).then_return(Dimensions(x=1, y=2, z=67))
     decoy.when(
-        mock_labware_view.get_grip_height_from_labware_bottom(definition)
+        mock_labware_view.get_grip_height_from_labware_origin(definition)
     ).then_return(1.0)
 
     with pytest.raises(errors.LabwareMovementNotAllowedError):

--- a/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
@@ -2751,9 +2751,7 @@ def test_get_labware_grip_point_v2_definition(
     subject: GeometryView,
 ) -> None:
     """It should get the grip point of a LabwareDefinition2 labware at the specified location."""
-    decoy.when(
-        mock_labware_view.get_grip_height_from_labware_origin(_MOCK_LABWARE_DEFINITION2)
-    ).then_return(100)
+    decoy.when(mock_labware_view.get_grip_z(_MOCK_LABWARE_DEFINITION2)).then_return(100)
 
     decoy.when(
         mock_addressable_area_view.get_addressable_area_center(DeckSlotName.SLOT_1.id)
@@ -2784,9 +2782,7 @@ def test_get_labware_grip_point_v3_definition(
     subject: GeometryView,
 ) -> None:
     """It should get the grip point of a LabwareDefinition3 labware at the specified location."""
-    decoy.when(
-        mock_labware_view.get_grip_height_from_labware_origin(_MOCK_LABWARE_DEFINITION3)
-    ).then_return(100)
+    decoy.when(mock_labware_view.get_grip_z(_MOCK_LABWARE_DEFINITION3)).then_return(100)
 
     decoy.when(
         mock_addressable_area_view.get_addressable_area_center(DeckSlotName.SLOT_1.id)
@@ -2836,9 +2832,7 @@ def test_get_labware_grip_point_on_labware(
         sentinel.below_definition
     )
     decoy.when(
-        mock_labware_view.get_grip_height_from_labware_origin(
-            labware_definition=sentinel.definition
-        )
+        mock_labware_view.get_grip_z(labware_definition=sentinel.definition)
     ).then_return(100)
     decoy.when(
         mock_addressable_area_view.get_addressable_area_center(DeckSlotName.SLOT_4.id)
@@ -2912,11 +2906,9 @@ def test_get_labware_grip_point_for_labware_on_module(
         pipette_view=subject._pipettes,
         addressable_area_view=addressable_area_view,
     )
-    decoy.when(
-        mock_labware_view.get_grip_height_from_labware_origin(
-            sentinel.labware_definition
-        )
-    ).then_return(500)
+    decoy.when(mock_labware_view.get_grip_z(sentinel.labware_definition)).then_return(
+        500
+    )
     decoy.when(mock_module_view.get_location("module-id")).then_return(
         DeckSlotLocation(slotName=DeckSlotName.SLOT_C3)
     )
@@ -2999,11 +2991,9 @@ def test_get_labware_grip_point_for_labware_stack_on_module(
         pipette_view=subject._pipettes,
         addressable_area_view=addressable_area_view,
     )
-    decoy.when(
-        mock_labware_view.get_grip_height_from_labware_origin(
-            sentinel.labware_definition
-        )
-    ).then_return(500)
+    decoy.when(mock_labware_view.get_grip_z(sentinel.labware_definition)).then_return(
+        500
+    )
     decoy.when(mock_module_view.get_location("module-id")).then_return(
         DeckSlotLocation(slotName=DeckSlotName.SLOT_C3)
     )
@@ -3674,9 +3664,7 @@ def test_check_gripper_labware_tip_collision(
     decoy.when(
         mock_labware_view.get_dimensions(labware_definition=definition)
     ).then_return(Dimensions(x=1, y=2, z=67))
-    decoy.when(
-        mock_labware_view.get_grip_height_from_labware_origin(definition)
-    ).then_return(1.0)
+    decoy.when(mock_labware_view.get_grip_z(definition)).then_return(1.0)
 
     with pytest.raises(errors.LabwareMovementNotAllowedError):
         subject.check_gripper_labware_tip_collision(

--- a/api/tests/opentrons/protocol_engine/state/test_labware_view_old.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_view_old.py
@@ -1814,16 +1814,16 @@ def test_get_grip_force(
     assert subject.get_grip_force(reservoir_def) == 15  # default
 
 
-def test_get_grip_height_from_labware_bottom(
+def test_get_grip_height_from_labware_origin(
     well_plate_def: LabwareDefinition,
     reservoir_def: LabwareDefinition,
 ) -> None:
     """It should get the grip height, if present, from labware definition or return default."""
     subject = get_labware_view()
     assert (
-        subject.get_grip_height_from_labware_bottom(well_plate_def) == 12.2
+        subject.get_grip_height_from_labware_origin(well_plate_def) == 12.2
     )  # from definition
-    assert subject.get_grip_height_from_labware_bottom(reservoir_def) == 15.7  # default
+    assert subject.get_grip_height_from_labware_origin(reservoir_def) == 15.7  # default
 
 
 @pytest.mark.parametrize(

--- a/api/tests/opentrons/protocol_engine/state/test_labware_view_old.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_view_old.py
@@ -1849,8 +1849,8 @@ def test_get_grip_height_from_labware_origin() -> None:
         schemaVersion=3,
         extents=Extents(
             total=AxisAlignedBoundingBox3D(
-                backLeftBottom={"x": 0, "y": 0, "z": 500},
-                frontRightTop={"x": 0, "y": 0, "z": 1000},
+                backLeftBottom=Vector3D(x=0, y=0, z=500),
+                frontRightTop=Vector3D(x=0, y=0, z=1000),
             )
         ),
     )

--- a/api/tests/opentrons/protocol_engine/state/test_labware_view_old.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_view_old.py
@@ -27,7 +27,7 @@ from opentrons_shared_data.labware.labware_definition import (
     Vector3D,
 )
 
-from opentrons.types import DeckSlotName, MountType
+from opentrons.types import DeckSlotName, MountType, Point
 
 from opentrons.protocol_engine import errors
 from opentrons.protocol_engine.types import (
@@ -53,6 +53,10 @@ from opentrons.protocol_engine.state.labware import (
     LabwareView,
     LabwareLoadParams,
 )
+from opentrons.protocol_engine.state._axis_aligned_bounding_box import (
+    AxisAlignedBoundingBox3D as EngineAABB,
+)
+
 
 plate = LoadedLabware(
     id="plate-id",
@@ -764,21 +768,64 @@ def test_get_load_name(reservoir_def: LabwareDefinition) -> None:
     assert result == reservoir_def.parameters.loadName
 
 
-def test_get_dimensions(well_plate_def: LabwareDefinition) -> None:
+def test_get_dimensions() -> None:
     """It should compute the dimensions of a labware."""
-    subject = get_labware_view(
-        labware_by_id={"plate-id": plate},
-        definitions_by_uri={"some-plate-uri": well_plate_def},
-    )
+    subject = get_labware_view()
 
-    result = subject.get_dimensions(labware_id="plate-id")
+    # Schema 2 case:
+    assert subject.get_dimensions(
+        labware_definition=LabwareDefinition2.model_construct(  # type: ignore[call-arg]
+            schemaVersion=2,
+            cornerOffsetFromSlot=Vector3D(
+                x=1, y=2, z=3
+            ),  # Should not affect dimensions.
+            dimensions=LabwareDimensions(
+                xDimension=100, yDimension=200, zDimension=300
+            ),
+        )
+    ) == Dimensions(100, 200, 300)
 
-    assert well_plate_def.schemaVersion == 2  # For the presence of `dimensions`.
-    assert result == Dimensions(
-        x=well_plate_def.dimensions.xDimension,
-        y=well_plate_def.dimensions.yDimension,
-        z=well_plate_def.dimensions.zDimension,
-    )
+    # Schema 3 case:
+    assert subject.get_dimensions(
+        labware_definition=LabwareDefinition3.model_construct(  # type: ignore[call-arg]
+            schemaVersion=3,
+            extents=Extents(
+                total=AxisAlignedBoundingBox3D(
+                    backLeftBottom=Vector3D(x=1, y=2, z=3),
+                    frontRightTop=Vector3D(x=101, y=-198, z=303),
+                )
+            ),
+        )
+    ) == Dimensions(100, 200, 300)
+
+
+def test_get_extents_around_lw_origin() -> None:
+    """It should compute the extents of the labware, relative to the labware's origin."""
+    subject = get_labware_view()
+
+    # Schema 2 case:
+    assert subject.get_extents_around_lw_origin(
+        LabwareDefinition2.model_construct(  # type: ignore[call-arg]
+            schemaVersion=2,
+            cornerOffsetFromSlot=Vector3D(x=1, y=2, z=3),  # Should not affect extents.
+            dimensions=LabwareDimensions(
+                xDimension=100, yDimension=200, zDimension=300
+            ),
+        )
+    ) == EngineAABB.from_corners(Point(0, 0, 0), Point(100, 200, 300))
+
+    # Schema 3 case:
+    assert subject.get_extents_around_lw_origin(
+        LabwareDefinition3.model_construct(  # type: ignore[call-arg]
+            schemaVersion=3,
+            extents=Extents(
+                total=AxisAlignedBoundingBox3D(
+                    backLeftBottom=Vector3D(x=100, y=200, z=300),
+                    frontRightTop=Vector3D(x=50, y=250, z=350),
+                )
+            ),
+        )
+    ) == EngineAABB.from_corners(Point(100, 200, 300), Point(50, 250, 350))
 
 
 def test_get_default_magnet_height(

--- a/api/tests/opentrons/protocol_engine/state/test_labware_view_old.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_view_old.py
@@ -14,13 +14,17 @@ from opentrons_shared_data.deck.types import DeckDefinitionV5
 from opentrons_shared_data.pipette.types import LabwareUri
 from opentrons_shared_data.labware import load_definition
 from opentrons_shared_data.labware.labware_definition import (
-    Parameters2,
+    AxisAlignedBoundingBox3D,
+    Dimensions as LabwareDimensions,
+    Extents,
+    GripperOffsets,
+    labware_definition_type_adapter,
     LabwareDefinition,
     LabwareDefinition2,
+    LabwareDefinition3,
     LabwareRole,
-    GripperOffsets,
+    Parameters2,
     Vector3D,
-    labware_definition_type_adapter,
 )
 
 from opentrons.types import DeckSlotName, MountType
@@ -1814,16 +1818,46 @@ def test_get_grip_force(
     assert subject.get_grip_force(reservoir_def) == 15  # default
 
 
-def test_get_grip_height_from_labware_origin(
-    well_plate_def: LabwareDefinition,
-    reservoir_def: LabwareDefinition,
-) -> None:
+def test_get_grip_height_from_labware_origin() -> None:
     """It should get the grip height, if present, from labware definition or return default."""
     subject = get_labware_view()
+
+    schema_2_with_defined_height = LabwareDefinition2.model_construct(  # type: ignore[call-arg]
+        schemaVersion=2, gripHeightFromLabwareBottom=123
+    )
     assert (
-        subject.get_grip_height_from_labware_origin(well_plate_def) == 12.2
-    )  # from definition
-    assert subject.get_grip_height_from_labware_origin(reservoir_def) == 15.7  # default
+        subject.get_grip_height_from_labware_origin(schema_2_with_defined_height) == 123
+    )
+
+    schema_3_with_defined_height = LabwareDefinition3.model_construct(  # type: ignore[call-arg]
+        schemaVersion=3, gripHeightFromLabwareOrigin=123
+    )
+    assert (
+        subject.get_grip_height_from_labware_origin(schema_3_with_defined_height) == 123
+    )
+
+    schema_2_without_defined_height = LabwareDefinition2.model_construct(  # type: ignore[call-arg]
+        schemaVersion=2,
+        dimensions=LabwareDimensions(xDimension=0, yDimension=0, zDimension=500),
+    )
+    assert (
+        subject.get_grip_height_from_labware_origin(schema_2_without_defined_height)
+        == 250
+    )
+
+    schema_3_without_defined_height = LabwareDefinition3.model_construct(  # type: ignore[call-arg]
+        schemaVersion=3,
+        extents=Extents(
+            total=AxisAlignedBoundingBox3D(
+                backLeftBottom={"x": 0, "y": 0, "z": 500},
+                frontRightTop={"x": 0, "y": 0, "z": 1000},
+            )
+        ),
+    )
+    assert (
+        subject.get_grip_height_from_labware_origin(schema_3_without_defined_height)
+        == 750
+    )
 
 
 @pytest.mark.parametrize(

--- a/api/tests/opentrons/protocol_engine/state/test_labware_view_old.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_view_old.py
@@ -1865,32 +1865,25 @@ def test_get_grip_force(
     assert subject.get_grip_force(reservoir_def) == 15  # default
 
 
-def test_get_grip_height_from_labware_origin() -> None:
+def test_get_grip_z() -> None:
     """It should get the grip height, if present, from labware definition or return default."""
     subject = get_labware_view()
 
     schema_2_with_defined_height = LabwareDefinition2.model_construct(  # type: ignore[call-arg]
         schemaVersion=2, gripHeightFromLabwareBottom=123
     )
-    assert (
-        subject.get_grip_height_from_labware_origin(schema_2_with_defined_height) == 123
-    )
+    assert subject.get_grip_z(schema_2_with_defined_height) == 123
 
     schema_3_with_defined_height = LabwareDefinition3.model_construct(  # type: ignore[call-arg]
         schemaVersion=3, gripHeightFromLabwareOrigin=123
     )
-    assert (
-        subject.get_grip_height_from_labware_origin(schema_3_with_defined_height) == 123
-    )
+    assert subject.get_grip_z(schema_3_with_defined_height) == 123
 
     schema_2_without_defined_height = LabwareDefinition2.model_construct(  # type: ignore[call-arg]
         schemaVersion=2,
         dimensions=LabwareDimensions(xDimension=0, yDimension=0, zDimension=500),
     )
-    assert (
-        subject.get_grip_height_from_labware_origin(schema_2_without_defined_height)
-        == 250
-    )
+    assert subject.get_grip_z(schema_2_without_defined_height) == 250
 
     schema_3_without_defined_height = LabwareDefinition3.model_construct(  # type: ignore[call-arg]
         schemaVersion=3,
@@ -1901,10 +1894,7 @@ def test_get_grip_height_from_labware_origin() -> None:
             )
         ),
     )
-    assert (
-        subject.get_grip_height_from_labware_origin(schema_3_without_defined_height)
-        == 750
-    )
+    assert subject.get_grip_z(schema_3_without_defined_height) == 750
 
 
 @pytest.mark.parametrize(

--- a/shared-data/labware/definitions/3/schema3test_96_wellplate_200ul_pcr_full_skirt/999.json
+++ b/shared-data/labware/definitions/3/schema3test_96_wellplate_200ul_pcr_full_skirt/999.json
@@ -90,7 +90,7 @@
     }
   },
   "gripForce": 15,
-  "gripHeightFromLabwareBottom": 10,
+  "gripHeightFromLabwareOrigin": 10,
   "ordering": [
     ["A1", "B1", "C1", "D1", "E1", "F1", "G1", "H1"],
     ["A2", "B2", "C2", "D2", "E2", "F2", "G2", "H2"],

--- a/shared-data/labware/definitions/3/schema3test_flex_96_tiprack_200ul/999.json
+++ b/shared-data/labware/definitions/3/schema3test_flex_96_tiprack_200ul/999.json
@@ -51,7 +51,7 @@
     }
   },
   "gripForce": 16,
-  "gripHeightFromLabwareBottom": 23.9,
+  "gripHeightFromLabwareOrigin": 23.9,
   "wells": {
     "A1": {
       "depth": 97.5,

--- a/shared-data/labware/definitions/3/schema3test_flex_tiprack_lid/999.json
+++ b/shared-data/labware/definitions/3/schema3test_flex_tiprack_lid/999.json
@@ -116,7 +116,7 @@
     "schema3test_flex_96_tiprack_200ul"
   ],
   "gripForce": 10,
-  "gripHeightFromLabwareBottom": 10,
+  "gripHeightFromLabwareOrigin": 10,
   "gripperOffsets": {
     "default": {
       "pickUpOffset": {

--- a/shared-data/labware/definitions/3/schema3test_tough_pcr_auto_sealing_lid/999.json
+++ b/shared-data/labware/definitions/3/schema3test_tough_pcr_auto_sealing_lid/999.json
@@ -120,7 +120,7 @@
     "protocol_engine_lid_stack_object"
   ],
   "gripForce": 15,
-  "gripHeightFromLabwareBottom": 7.91,
+  "gripHeightFromLabwareOrigin": 7.91,
   "gripperOffsets": {
     "default": {
       "pickUpOffset": {

--- a/shared-data/labware/schemas/3.json
+++ b/shared-data/labware/schemas/3.json
@@ -765,7 +765,7 @@
     },
     "gripperOffsets": {
       "type": "object",
-      "description": "Offsets to add when picking up or dropping another labware stacked atop this one. Do not use this to adjust the position of the gripper paddles relative to this labware or the child labware; use `gripHeightFromLabwareBottom` on this definition or the child's definition for that.",
+      "description": "Offsets to add when picking up or dropping another labware stacked atop this one. Do not use this to adjust the position of the gripper paddles relative to this labware or the child labware; use `gripHeightFromLabwareOrigin` on this definition or the child's definition for that.",
       "additionalProperties": {
         "$ref": "#/definitions/pickUpAndDropOffsets",
         "description": "Properties here are named for, and matched based on, the deck slot that this labware is atop--or, if this labware is atop a module, the deck slot that that module is atop."
@@ -789,9 +789,9 @@
       "type": "number",
       "description": "Force, in Newtons, with which the gripper should grip the labware."
     },
-    "gripHeightFromLabwareBottom": {
+    "gripHeightFromLabwareOrigin": {
       "type": "number",
-      "description": "Recommended Z-height, from labware bottom to the center of gripper pads, when gripping the labware."
+      "description": "Recommended Z-height, from labware origin to the center of gripper pads, when gripping the labware."
     },
     "stackLimit": {
       "type": "number",

--- a/shared-data/python/opentrons_shared_data/labware/labware_definition.py
+++ b/shared-data/python/opentrons_shared_data/labware/labware_definition.py
@@ -608,7 +608,7 @@ class LabwareDefinition3(BaseModel):
     allowedRoles: list[LabwareRole] = Field(default_factory=list)
     gripperOffsets: dict[str, GripperOffsets] = Field(default_factory=dict)
     gripForce: float | None = None
-    gripHeightFromLabwareBottom: float | None = None
+    gripHeightFromLabwareOrigin: float | None = None
     stackLimit: int | None = None
     compatibleParentLabware: list[str] | None = None
     innerLabwareGeometry: dict[str, InnerWellGeometry] | None = None

--- a/shared-data/python/opentrons_shared_data/labware/types.py
+++ b/shared-data/python/opentrons_shared_data/labware/types.py
@@ -231,7 +231,7 @@ class LabwareDefinition3(_OTSharedSchemaMixin, TypedDict):
     allowedRoles: NotRequired[list[LabwareRoles]]
     gripperOffsets: NotRequired[dict[str, GripperOffsets]]
     gripForce: NotRequired[float]
-    gripHeightFromLabwareBottom: NotRequired[float]
+    gripHeightFromLabwareOrigin: NotRequired[float]
     stackLimit: NotRequired[int]
     compatibleParentLabware: NotRequired[list[str]]
     # The innerLabwareGeometry dict values are not currently modeled in these


### PR DESCRIPTION
## Overview


Goes towards EXEC-77.

Currently, labware schema 3 has a `gripHeightFromLabwareBottom` property, inherited from labware schema 2 unchanged.

That property makes sense in schema 2 because _everything_ there is relative to the labware bottom. However, in schema 3, we instead want everything to be relative to the labware origin. The labware origin in schema 3 is *usually* the bottom, but theoretically it can be any arbitrary point, chosen by the labware author.

## Changelog

* In labware schema 3, rename `gripHeightFromLabwareBottom` to `gripHeightFromLabwareOrigin`.
* Update the Python bindings for labware schema 3. Nothing in TypeScript has ever cared about this field, so there are no TypeScript bindings to update.
* Update some gripper math in `opentrons.protocol_engine` to correctly account for the possibility that a schema 3 labware's origin is not at the bottom.
* To help with the math, add a new helper class, `AxisAlignedBoundingBox3D`.
* Add `# todo` comments for a few other questionable things I noticed.

## Test Plan and Hands on Testing

Just unit tests, which I've updated.

## Review requests

None in particular.

## Risk assessment

Low.
