### PR TITLE
fix(protocol-designer): ensure module does not disappear when clearing labware

### DIFF
--- a/protocol-designer/src/components/organisms/LabwareCardOverflowMenu/index.tsx
+++ b/protocol-designer/src/components/organisms/LabwareCardOverflowMenu/index.tsx
@@ -103,21 +103,15 @@ export function LabwareCardOverflowMenu(
     labwareIds.forEach(labwareId => {
       dispatch(deleteContainer({ labwareId }))
     })
-    if (isAdapter) {
-      dispatch(
-        editSlotInfo({
-          adapterDefURI: null,
-        })
-      )
-    } else {
-      dispatch(
-        editSlotInfo({
-          labwareDefURI: null,
-          lidDefURI: null,
-          amount: 1,
-        })
-      )
+    const module = moduleId != null ? deckSetupModules[moduleId] : null
+    const moduleModel = module?.model ?? null
+    const newSlotInfo = {
+      ...(moduleModel != null ? { moduleModel } : {}),
+      ...(isAdapter === true
+        ? { adapterDefURI: null }
+        : { labwareDefURI: null, lidDefURI: null, amount: 1 }),
     }
+    dispatch(editSlotInfo(newSlotInfo))
   }
   const handleConfirmDeleteEntityInUseModal = (): void => {
     labwareIds.forEach(labwareId => {


### PR DESCRIPTION
# Overview

This PR fixes the logic in clearing a zoomed in slot when adding and clearing labware such that the module does not disappear.

Closes AUTH-2171

## Test Plan and Hands on Testing

- create a protocol and add a module to the deck
- navigate to starting deck and select the module's to add labware
- add a labware
- click the new labware card's overflow menu, and select delete labware
- verify that labware is deleted, but module is still visible

## Changelog

- fix logic for clearing labware in `LabwareCardOverflowMenu`

## Review requests

see test plan

## Risk assessment

low