### PR TITLE
fix(robot-server): bound `out` broker message queue

### DIFF
--- a/robot-server/robot_server/service/notifications/notification_client.py
+++ b/robot-server/robot_server/service/notifications/notification_client.py
@@ -67,6 +67,8 @@ class NotificationClient:
         self._client.on_connect = self._on_connect
         self._client.on_disconnect = self._on_disconnect
 
+        self._client.max_queued_messages_set(100)
+
     def connect(self) -> None:
         """Connect the client to the MQTT broker."""
         self._client.on_connect = self._on_connect

--- a/robot-server/robot_server/service/notifications/publishers/runs_publisher.py
+++ b/robot-server/robot_server/service/notifications/publishers/runs_publisher.py
@@ -43,6 +43,7 @@ class RunsPublisher:
         """Returns a configured Runs Publisher."""
         self._client = client
         #  Variables and callbacks related to PE state changes.
+
         self._run_hooks: Optional[_RunHooks] = None
         self._engine_state_slice: Optional[_EngineStateSlice] = None
 
@@ -54,6 +55,7 @@ class RunsPublisher:
             ]
         )
 
+    # TODO(jh, 08-01-25): Free run_hooks and engine_state_slice during run cleanup for more predictable protocol engine GC.
     def start_publishing_for_run(
         self,
         run_id: str,


### PR DESCRIPTION
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

The Paho MQTT implementation by default poses no upper bound on the message queue for messages directed to the broker when the QoS is 1 or 2. If the broker were to be offline (typical of a testing environment or if a user explictly stops the mosquitto process), these messages would build indefinitely.

Given the frequency at which we send messages, especially during protocols, these do add up. Let's add a reasonable upper boundary. Note that these messages are all refetch requests.

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- Validated as a part of https://github.com/Opentrons/opentrons/pull/19108
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests
- I've decided to add a TODO to refactor the lifecycle on the PE handles, since this would be a higher risk change that isn't functionally necessary and adds more risk right before the 8.6.0 cut. However, if people feel otherwise, we could add that change to this PR as well.  
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
effectively none
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
