### PR TITLE
refactor(hardware, shared-data, api): add bounds to unbounded lru caches

### DIFF
--- a/api/src/opentrons/legacy_commands/publisher.py
+++ b/api/src/opentrons/legacy_commands/publisher.py
@@ -124,7 +124,7 @@ def publish_context(broker: LegacyBroker, command: CommandPayload) -> Iterator[N
         _do_publish(broker=broker, message_id=message_id, command=command, when="after")
 
 
-@functools.lru_cache(maxsize=None)
+@functools.lru_cache(maxsize=100)
 def _inspect_signature(func: Callable[..., Any]) -> inspect.Signature:
     """Inspect function signatures, memoized because it is called very often."""
     return inspect.signature(func)

--- a/hardware/opentrons_hardware/firmware_bindings/messages/binary_message_definitions.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/binary_message_definitions.py
@@ -449,7 +449,7 @@ BinaryMessageDefinition = Union[
 ]
 
 
-@lru_cache(maxsize=None)
+@lru_cache(maxsize=100)
 def get_binary_definition(
     message_id: BinaryMessageId,
 ) -> Optional[Type[BinaryMessageDefinition]]:

--- a/hardware/opentrons_hardware/firmware_bindings/messages/messages.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/messages.py
@@ -118,7 +118,7 @@ MessageDefinition = Union[
 ]
 
 
-@lru_cache(maxsize=None)
+@lru_cache(maxsize=100)
 def get_definition(message_id: MessageId) -> Optional[Type[MessageDefinition]]:
     """Get the message type for a message id.
 

--- a/shared-data/python/opentrons_shared_data/pipette/__init__.py
+++ b/shared-data/python/opentrons_shared_data/pipette/__init__.py
@@ -38,7 +38,7 @@ def model_config() -> PipetteModelSpecs:
     return copy.deepcopy(_model_config())
 
 
-@lru_cache(maxsize=None)
+@lru_cache(maxsize=1)
 def _model_config() -> PipetteModelSpecs:
     return json.loads(
         load_shared_data("pipette/definitions/1/pipetteModelSpecs.json") or "{}"
@@ -50,7 +50,7 @@ def name_config() -> PipetteNameSpecs:
     return _name_config()
 
 
-@lru_cache(maxsize=None)
+@lru_cache(maxsize=1)
 def _name_config() -> PipetteNameSpecs:
     return json.loads(
         load_shared_data("pipette/definitions/1/pipetteNameSpecs.json") or "{}"
@@ -73,7 +73,7 @@ def fuse_specs(
     return copy.deepcopy(_fuse_specs_cached(pipette_model, pipette_name))
 
 
-@lru_cache(maxsize=None)
+@lru_cache(maxsize=10)
 def _fuse_specs_cached(
     pipette_model: PipetteModel, pipette_name: Optional[PipetteName] = None
 ) -> PipetteFusedSpec:

--- a/shared-data/python/opentrons_shared_data/pipette/load_data.py
+++ b/shared-data/python/opentrons_shared_data/pipette/load_data.py
@@ -66,7 +66,7 @@ def _get_configuration_dictionary(
     return json.loads(load_shared_data(config_path))
 
 
-@lru_cache(maxsize=None)
+@lru_cache(maxsize=10)
 def _geometry(
     channels: PipetteChannelType,
     model: PipetteModelType,
@@ -76,7 +76,7 @@ def _geometry(
     return _get_configuration_dictionary("geometry", channels, model, version, oem)
 
 
-@lru_cache(maxsize=None)
+@lru_cache(maxsize=10)
 def _liquid(
     channels: PipetteChannelType,
     model: PipetteModelType,
@@ -95,7 +95,7 @@ def _liquid(
     return liquid_dict
 
 
-@lru_cache(maxsize=None)
+@lru_cache(maxsize=10)
 def _physical(
     channels: PipetteChannelType,
     model: PipetteModelType,
@@ -111,7 +111,7 @@ def _dirs_in(path: Path) -> Iterator[Path]:
             yield child
 
 
-@lru_cache(maxsize=None)
+@lru_cache(maxsize=1)
 def load_serial_lookup_table() -> Dict[str, str]:
     """Load a serial abbreviation lookup table mapped to model name."""
     config_path = get_shared_data_root() / "pipette" / "definitions" / "2" / "general"


### PR DESCRIPTION
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Unbounded caches have the potential for causing memory leaks. From a code audit standpoint, it is difficult to verify whether or not a particular cache is responsible for a leak without fulling understanding how the caching API interacts with its callees and the parameters passed to the API. 

Yes, this is entirely a paranoia PR, but it seems like a reasonable ask to bound caches so that:

- Any upstream changes to a cached API don't cause memory issues. Bounding caches eliminates a bug vector.
- Auditing LRU caches in the future is a bit easier.
- Future API authors, when adding a cache to a function, see that the rest of our codebase always defines a cache size and therefore do so themselves (or that is hopefully more likely, at least).

What do we think?

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Defined `maxsize` for all unbounded LRU caches.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests
- Does this seem like a good idea?
- I'm taking stabs in the dark on what constitutes a reasonable cache size for many of these functions, so that's why I have nominated you all to help! Push changes and merge as you will - I'm out next week.
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
- theoretically low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
