### PR TITLE
fix(hardware-testing): use both baseline and runtime to pass a TOF sensor

### DIFF
--- a/hardware-testing/hardware_testing/modules/flex_stacker/flex_stacker_qc/test_tof_functional.py
+++ b/hardware-testing/hardware_testing/modules/flex_stacker/flex_stacker_qc/test_tof_functional.py
@@ -136,7 +136,7 @@ async def test_tof_sensors_labware_detection(
         [
             baseline_result,
             "HISTOGRAM",
-            CSVResult.from_bool(runtime_result),
+            CSVResult.from_bool(baseline_result and runtime_result),
             histogram_string,
         ],
     )
@@ -154,11 +154,13 @@ async def run(stacker: FlexStacker, report: CSVReport, section: str) -> None:
         "Make sure there is NO labware in the stacker tower or gripper position"
     )
     print("Getting runtime baseline.")
-    runtime_baseline_x = await create_runtime_baseline(stacker, TOFSensor.X)
+    await stacker.home_axis(StackerAxis.X, Direction.EXTEND)
     runtime_baseline_z = await create_runtime_baseline(stacker, TOFSensor.Z)
 
-    print("Test that we have no labware on the X")
     await stacker.home_axis(StackerAxis.X, Direction.RETRACT)
+    runtime_baseline_x = await create_runtime_baseline(stacker, TOFSensor.X)
+
+    print("Test that we have no labware on the X")
     await test_tof_sensors_labware_detection(
         stacker,
         report,


### PR DESCRIPTION
# Overview

We want to reject sensors outside of the baseline measurements, so let's ensure the sensors pass both the baseline check and the runtime baseline check for the TOF functional test. Also, fixed a bug with the runtime baseline failing on the X because the platform was in the wrong position when the sample data was collected.

## Test Plan and Hands on Testing

- [x] Make sure the TOF functional test fails if the labware detection fails with the baseline or runtime.

## Changelog

- Check both baseline and runtime in the TOF functional test

## Review requests
## Risk assessment