### PR TITLE
feat(api, app): add disable Flex Stacker labware detection as a feature flag 

### DIFF
--- a/api/src/opentrons/config/advanced_settings.py
+++ b/api/src/opentrons/config/advanced_settings.py
@@ -222,6 +222,14 @@ settings = [
         robot_type=[RobotTypeEnum.OT2, RobotTypeEnum.FLEX],
         internal_only=True,
     ),
+    SettingDefinition(
+        _id="disableFlexStackerLabwareDetection",
+        title="Disable Flex Stacker's labware detection features",
+        description=(
+            "Flex Stackers will ignore labware's presence in the hopper and on the shuttle. Protocol runs will no longer raise the following recoverable errors: Hopper Empty, Shuttle Empty and Shuttle Occupied."
+        ),
+        robot_type=[RobotTypeEnum.FLEX],
+    ),
 ]
 
 
@@ -733,6 +741,16 @@ def _migrate36to37(previous: SettingsMap) -> SettingsMap:
     return {k: v for k, v in previous.items() if "allowLiquidClasses" != k}
 
 
+def _migrate37to38(previous: SettingsMap) -> SettingsMap:
+    """Migrate to version 36 of the feature flags file.
+
+    -  Adds the disableFlexStackerLabwareDetection config element.
+    """
+    newmap = {k: v for k, v in previous.items()}
+    newmap["disableFlexStackerLabwareDetection"] = None
+    return newmap
+
+
 _MIGRATIONS = [
     _migrate0to1,
     _migrate1to2,
@@ -771,6 +789,7 @@ _MIGRATIONS = [
     _migrate34to35,
     _migrate35to36,
     _migrate36to37,
+    _migrate37to38,
 ]
 """
 List of all migrations to apply, indexed by (version - 1). See _migrate below

--- a/api/src/opentrons/config/feature_flags.py
+++ b/api/src/opentrons/config/feature_flags.py
@@ -78,3 +78,9 @@ def enable_performance_metrics(robot_type: RobotTypeEnum) -> bool:
 
 def oem_mode_enabled() -> bool:
     return advs.get_setting_with_env_overload("enableOEMMode", RobotTypeEnum.FLEX)
+
+
+def flex_stacker_tof_sensors_enabled() -> bool:
+    return not advs.get_setting_with_env_overload(
+        "disableFlexStackerLabwareDetection", RobotTypeEnum.FLEX
+    )

--- a/api/src/opentrons/config/feature_flags.py
+++ b/api/src/opentrons/config/feature_flags.py
@@ -80,7 +80,7 @@ def oem_mode_enabled() -> bool:
     return advs.get_setting_with_env_overload("enableOEMMode", RobotTypeEnum.FLEX)
 
 
-def flex_stacker_tof_sensors_enabled() -> bool:
-    return not advs.get_setting_with_env_overload(
+def flex_stacker_tof_sensors_disabled() -> bool:
+    return advs.get_setting_with_env_overload(
         "disableFlexStackerLabwareDetection", RobotTypeEnum.FLEX
     )

--- a/api/src/opentrons/hardware_control/modules/flex_stacker.py
+++ b/api/src/opentrons/hardware_control/modules/flex_stacker.py
@@ -53,6 +53,7 @@ from opentrons.hardware_control.modules.types import (
     FlexStackerData,
 )
 from opentrons.hardware_control.types import StatusBarState, StatusBarUpdateEvent
+from opentrons.config import feature_flags as ff
 
 from opentrons_shared_data.errors.exceptions import (
     FlexStackerStallError,
@@ -730,30 +731,32 @@ class FlexStacker(mod_abc.AbstractModule):
         self, direction: Direction, labware_expected: bool
     ) -> None:
         """Check whether or not a labware is detected on the shuttle."""
-        result = await self.labware_detected(StackerAxis.X, direction)
-        if labware_expected != result:
-            if labware_expected:
-                raise FlexStackerShuttleLabwareError(
+        if ff.flex_stacker_tof_sensors_enabled():
+            result = await self.labware_detected(StackerAxis.X, direction)
+            if labware_expected != result:
+                if labware_expected:
+                    raise FlexStackerShuttleLabwareError(
+                        self.device_info["serial"],
+                        shuttle_state=self.platform_state,
+                        labware_expected=labware_expected,
+                    )
+                raise FlexStackerShuttleNotEmptyError(
                     self.device_info["serial"],
                     shuttle_state=self.platform_state,
                     labware_expected=labware_expected,
                 )
-            raise FlexStackerShuttleNotEmptyError(
-                self.device_info["serial"],
-                shuttle_state=self.platform_state,
-                labware_expected=labware_expected,
-            )
 
     async def verify_hopper_labware_presence(
         self, direction: Direction, labware_expected: bool
     ) -> None:
         """Check whether or not a labware is detected inside the hopper."""
-        result = await self.labware_detected(StackerAxis.Z, direction)
-        if labware_expected != result:
-            raise FlexStackerHopperLabwareError(
-                self.device_info["serial"],
-                labware_expected=labware_expected,
-            )
+        if ff.flex_stacker_tof_sensors_enabled():
+            result = await self.labware_detected(StackerAxis.Z, direction)
+            if labware_expected != result:
+                raise FlexStackerHopperLabwareError(
+                    self.device_info["serial"],
+                    labware_expected=labware_expected,
+                )
 
     def verify_labware_height(self, labware_height: float) -> None:
         """Check that the labware height is within valid range."""

--- a/api/src/opentrons/hardware_control/modules/flex_stacker.py
+++ b/api/src/opentrons/hardware_control/modules/flex_stacker.py
@@ -731,32 +731,34 @@ class FlexStacker(mod_abc.AbstractModule):
         self, direction: Direction, labware_expected: bool
     ) -> None:
         """Check whether or not a labware is detected on the shuttle."""
-        if ff.flex_stacker_tof_sensors_enabled():
-            result = await self.labware_detected(StackerAxis.X, direction)
-            if labware_expected != result:
-                if labware_expected:
-                    raise FlexStackerShuttleLabwareError(
-                        self.device_info["serial"],
-                        shuttle_state=self.platform_state,
-                        labware_expected=labware_expected,
-                    )
-                raise FlexStackerShuttleNotEmptyError(
+        if ff.flex_stacker_tof_sensors_disabled():
+            return
+        result = await self.labware_detected(StackerAxis.X, direction)
+        if labware_expected != result:
+            if labware_expected:
+                raise FlexStackerShuttleLabwareError(
                     self.device_info["serial"],
                     shuttle_state=self.platform_state,
                     labware_expected=labware_expected,
                 )
+            raise FlexStackerShuttleNotEmptyError(
+                self.device_info["serial"],
+                shuttle_state=self.platform_state,
+                labware_expected=labware_expected,
+            )
 
     async def verify_hopper_labware_presence(
         self, direction: Direction, labware_expected: bool
     ) -> None:
         """Check whether or not a labware is detected inside the hopper."""
-        if ff.flex_stacker_tof_sensors_enabled():
-            result = await self.labware_detected(StackerAxis.Z, direction)
-            if labware_expected != result:
-                raise FlexStackerHopperLabwareError(
-                    self.device_info["serial"],
-                    labware_expected=labware_expected,
-                )
+        if ff.flex_stacker_tof_sensors_disabled():
+            return
+        result = await self.labware_detected(StackerAxis.Z, direction)
+        if labware_expected != result:
+            raise FlexStackerHopperLabwareError(
+                self.device_info["serial"],
+                labware_expected=labware_expected,
+            )
 
     def verify_labware_height(self, labware_height: float) -> None:
         """Check that the labware height is within valid range."""

--- a/api/tests/opentrons/config/test_advanced_settings_migration.py
+++ b/api/tests/opentrons/config/test_advanced_settings_migration.py
@@ -8,7 +8,7 @@ from opentrons.config.advanced_settings import _migrate, _ensure
 
 @pytest.fixture
 def migrated_file_version() -> int:
-    return 37
+    return 38
 
 
 # make sure to set a boolean value in default_file_settings only if
@@ -30,6 +30,7 @@ def default_file_settings() -> Dict[str, Any]:
         "enableErrorRecoveryExperiments": None,
         "enableOEMMode": None,
         "enablePerformanceMetrics": None,
+        "disableFlexStackerLabwareDetection": None,
     }
 
 
@@ -438,6 +439,18 @@ def v37_config(v36_config: Dict[str, Any]) -> Dict[str, Any]:
     return r
 
 
+@pytest.fixture
+def v38_config(v37_config: Dict[str, Any]) -> Dict[str, Any]:
+    r = v37_config.copy()
+    r.update(
+        {
+            "_version": 38,
+            "disableFlexStackerLabwareDetection": None,
+        }
+    )
+    return r
+
+
 @pytest.fixture(
     params=[
         lazy_fixture("empty_settings"),
@@ -479,6 +492,7 @@ def v37_config(v36_config: Dict[str, Any]) -> Dict[str, Any]:
         lazy_fixture("v35_config"),
         lazy_fixture("v36_config"),
         lazy_fixture("v37_config"),
+        lazy_fixture("v38_config"),
     ],
 )
 def old_settings(request: SubRequest) -> Dict[str, Any]:
@@ -569,4 +583,5 @@ def test_ensures_config() -> None:
         "enableErrorRecoveryExperiments": None,
         "enableOEMMode": None,
         "enablePerformanceMetrics": None,
+        "disableFlexStackerLabwareDetection": None,
     }

--- a/app/index.html
+++ b/app/index.html
@@ -1,10 +1,13 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name='viewport' content='width=device-width,initial-scale=1'>
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
 
-    <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,400i,600,600i,700,700i" rel="stylesheet">
+    <link
+      href="https://fonts.googleapis.com/css?family=Open+Sans:400,400i,600,600i,700,700i"
+      rel="stylesheet"
+    />
 
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Opentrons</title>

--- a/app/src/assets/localization/en/device_settings.json
+++ b/app/src/assets/localization/en/device_settings.json
@@ -91,6 +91,8 @@
   "device_reset_slideout_description": "Select individual settings to only clear specific data types.",
   "device_resets_cannot_be_undone": "Resets cannot be undone",
   "directly_connected_to_this_computer": "Directly connected to this computer.",
+  "disable_stacker_sensors": "Disable Stacker sensors for labware detection in z-axis and x-axis",
+  "disable_stacker_sensors_description": "Disable sensors for all stackers that are connected to the robot.",
   "disconnect": "Disconnect",
   "disconnect_from_ssid": "Disconnect from {{ssid}}",
   "disconnect_from_wifi": "Disconnect from Wi-Fi",

--- a/app/src/atoms/SoftwareKeyboard/index.css
+++ b/app/src/atoms/SoftwareKeyboard/index.css
@@ -7,14 +7,8 @@
   padding: 5px;
   border-radius: 5px;
   background-color: #ececec;
-  font-family:
-    HelveticaNeue-Light,
-    Helvetica Neue Light,
-    Helvetica Neue,
-    Helvetica,
-    Arial,
-    Lucida Grande,
-    sans-serif;
+  font-family: HelveticaNeue-Light, Helvetica Neue Light, Helvetica Neue,
+    Helvetica, Arial, Lucida Grande, sans-serif;
   touch-action: manipulation;
   -webkit-user-select: none;
   -moz-user-select: none;

--- a/app/src/organisms/Desktop/Devices/RobotSettings/AdvancedTab/DisableStackerSensors.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/AdvancedTab/DisableStackerSensors.tsx
@@ -1,0 +1,52 @@
+import { useTranslation } from 'react-i18next'
+import { useDispatch } from 'react-redux'
+
+import {
+  ALIGN_CENTER,
+  Box,
+  Flex,
+  JUSTIFY_SPACE_BETWEEN,
+  LegacyStyledText,
+  SPACING,
+  TYPOGRAPHY,
+} from '@opentrons/components'
+
+import { ToggleButton } from '/app/atoms/buttons'
+import { useDisableStackerSensors } from '/app/resources/robot-settings'
+
+interface DisableStackerSensorsProps {
+  robotName: string
+  isRobotBusy: boolean
+}
+
+export function DisableStackerSensors({
+  robotName,
+  isRobotBusy,
+}: DisableStackerSensorsProps): JSX.Element {
+  const { t } = useTranslation('device_settings')
+  const { sensorsDisabled, toggleSensors } = useDisableStackerSensors(robotName)
+
+  return (
+    <Flex alignItems={ALIGN_CENTER} justifyContent={JUSTIFY_SPACE_BETWEEN}>
+      <Box width="70%">
+        <LegacyStyledText
+          css={TYPOGRAPHY.pSemiBold}
+          paddingBottom={SPACING.spacing4}
+          id="AdvancedSettings_disableStackerSensors"
+        >
+          {t('disable_stacker_sensors')}
+        </LegacyStyledText>
+        <LegacyStyledText as="p">
+          {t('disable_stacker_sensors_description')}
+        </LegacyStyledText>
+      </Box>
+      <ToggleButton
+        label="disable_stacker_sensors"
+        toggledOn={sensorsDisabled}
+        onClick={toggleSensors}
+        id="RobotSettings_DisableStackerSensorsToggleButton"
+        disabled={isRobotBusy}
+      />
+    </Flex>
+  )
+}

--- a/app/src/organisms/Desktop/Devices/RobotSettings/AdvancedTab/DisableStackerSensors.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/AdvancedTab/DisableStackerSensors.tsx
@@ -1,5 +1,4 @@
 import { useTranslation } from 'react-i18next'
-import { useDispatch } from 'react-redux'
 
 import {
   ALIGN_CENTER,

--- a/app/src/organisms/Desktop/Devices/RobotSettings/AdvancedTab/__tests__/DisableStackerSensors.test.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/AdvancedTab/__tests__/DisableStackerSensors.test.tsx
@@ -1,0 +1,63 @@
+import { fireEvent, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import '@testing-library/jest-dom/vitest'
+
+import { renderWithProviders } from '/app/__testing-utils__'
+import { i18n } from '/app/i18n'
+import { useDisableStackerSensors } from '/app/resources/robot-settings'
+
+import { DisableStackerSensors } from '../DisableStackerSensors'
+
+import type { ComponentProps } from 'react'
+
+vi.mock('/app/resources/robot-settings')
+
+const ROBOT_NAME = 'otie'
+const mockToggleSensors = vi.fn()
+const render = (props: ComponentProps<typeof DisableStackerSensors>) => {
+  return renderWithProviders(<DisableStackerSensors {...props} />, {
+    i18nInstance: i18n,
+  })
+}
+
+describe('DisableStackerSensors', () => {
+  let props: ComponentProps<typeof DisableStackerSensors>
+
+  beforeEach(() => {
+    props = {
+      robotName: ROBOT_NAME,
+      isRobotBusy: false,
+    }
+    vi.mocked(useDisableStackerSensors).mockReturnValue({
+      sensorsDisabled: false,
+      toggleSensors: mockToggleSensors,
+    })
+  })
+
+  it('should render text and toggle button', () => {
+    render(props)
+    screen.getByText(
+      'Disable Stacker sensors for labware detection in z-axis and x-axis'
+    )
+    screen.getByText(
+      'Disable sensors for all stackers that are connected to the robot.'
+    )
+    expect(screen.getByLabelText('disable_stacker_sensors')).toBeInTheDocument()
+  })
+
+  it('should call a mock function when clicking toggle button', () => {
+    render(props)
+    fireEvent.click(screen.getByLabelText('disable_stacker_sensors'))
+    expect(mockToggleSensors).toHaveBeenCalled()
+  })
+
+  it('shoud make toggle button disabled when robot is busy', () => {
+    props = {
+      ...props,
+      isRobotBusy: true,
+    }
+    render(props)
+    expect(screen.getByLabelText('disable_stacker_sensors')).toBeDisabled()
+  })
+})

--- a/app/src/organisms/Desktop/Devices/RobotSettings/AdvancedTab/index.ts
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/AdvancedTab/index.ts
@@ -1,5 +1,6 @@
 export * from './DeviceReset'
 export * from './DisplayRobotName'
+export * from './DisableStackerSensors'
 export * from './EnableStatusLight'
 export * from './FactoryMode'
 export * from './GantryHoming'

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsAdvanced.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsAdvanced.tsx
@@ -30,6 +30,7 @@ import { useIsEstopNotDisengaged } from '/app/resources/devices/hooks/useIsEstop
 
 import {
   DeviceReset,
+  DisableStackerSensors,
   DisplayRobotName,
   EnableErrorRecoveryMode,
   EnableStatusLight,
@@ -219,6 +220,15 @@ export function RobotSettingsAdvanced({
           <>
             <Divider marginY={SPACING.spacing16} />
             <EnableErrorRecoveryMode isRobotBusy={isRobotBusy} />
+          </>
+        ) : null}
+        {isFlex ? (
+          <>
+            <Divider marginY={SPACING.spacing16} />
+            <DisableStackerSensors
+              robotName={robotName}
+              isRobotBusy={isRobotBusy || isEstopNotDisengaged}
+            />
           </>
         ) : null}
         <Divider marginY={SPACING.spacing16} />

--- a/app/src/organisms/Desktop/Devices/RobotSettings/__tests__/RobotSettingsAdvanced.test.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/__tests__/RobotSettingsAdvanced.test.tsx
@@ -12,6 +12,7 @@ import { getShellUpdateState } from '/app/redux/shell'
 
 import {
   DeviceReset,
+  DisableStackerSensors,
   DisplayRobotName,
   EnableStatusLight,
   GantryHoming,
@@ -53,6 +54,7 @@ vi.mock('../AdvancedTab/Troubleshooting')
 vi.mock('../AdvancedTab/UpdateRobotSoftware')
 vi.mock('../AdvancedTab/UsageSettings')
 vi.mock('../AdvancedTab/UseOlderAspirateBehavior')
+vi.mock('../AdvancedTab/DisableStackerSensors')
 
 const mockUpdateRobotStatus = vi.fn()
 
@@ -112,6 +114,12 @@ describe('RobotSettings Advanced tab', () => {
     when(useIsFlex).calledWith('otie').thenReturn(false)
     vi.mocked(EnableStatusLight).mockReturnValue(
       <div>mock EnableStatusLight</div>
+    )
+    vi.mocked(GantryHoming).mockReturnValue(
+      <div>Mock GantryHoming Section</div>
+    )
+    vi.mocked(DisableStackerSensors).mockReturnValue(
+      <div>Mock DisableStackerSensors Section</div>
     )
     vi.mocked(useIsRobotBusy).mockReturnValue(false)
   })
@@ -215,5 +223,18 @@ describe('RobotSettings Advanced tab', () => {
     when(useIsFlex).calledWith('otie').thenReturn(true)
     render()
     screen.getByText('mock EnableStatusLight')
+  })
+
+  it('should not render DisableStackerSensors section for OT-2', () => {
+    render()
+    expect(
+      screen.queryByText('Mock DisableStackerSensors')
+    ).not.toBeInTheDocument()
+  })
+
+  it('should render DisableStackerSensors section for Flex', () => {
+    when(useIsFlex).calledWith('otie').thenReturn(true)
+    render()
+    screen.getByText('Mock DisableStackerSensors Section')
   })
 })

--- a/app/src/pages/Desktop/Protocols/ProtocolPreview/preview.module.css
+++ b/app/src/pages/Desktop/Protocols/ProtocolPreview/preview.module.css
@@ -83,14 +83,13 @@
   position: relative;
   height: var(--spacing-4);
   border-radius: var(--border-radius-2);
-  background:
-    linear-gradient(
-      to right,
-      var(--blue-50) 0%,
-      var(--blue-50) var(--progress, 0%),
-      #ccc var(--progress, 0%),
-      #ccc 100%
-    );
+  background: linear-gradient(
+    to right,
+    var(--blue-50) 0%,
+    var(--blue-50) var(--progress, 0%),
+    #ccc var(--progress, 0%),
+    #ccc 100%
+  );
 }
 
 /* Hide thumb initially */
@@ -151,10 +150,9 @@
 }
 
 .command_step_groups {
-  height:
-    calc(
-      100vh - 248px
-    ); /* 248px is height of the controls container + timeline header */
+  height: calc(
+    100vh - 248px
+  ); /* 248px is height of the controls container + timeline header */
 
   overflow-y: scroll;
 }

--- a/app/src/pages/Desktop/Protocols/ProtocolPreview/preview.module.css
+++ b/app/src/pages/Desktop/Protocols/ProtocolPreview/preview.module.css
@@ -83,13 +83,14 @@
   position: relative;
   height: var(--spacing-4);
   border-radius: var(--border-radius-2);
-  background: linear-gradient(
-    to right,
-    var(--blue-50) 0%,
-    var(--blue-50) var(--progress, 0%),
-    #ccc var(--progress, 0%),
-    #ccc 100%
-  );
+  background:
+    linear-gradient(
+      to right,
+      var(--blue-50) 0%,
+      var(--blue-50) var(--progress, 0%),
+      #ccc var(--progress, 0%),
+      #ccc 100%
+    );
 }
 
 /* Hide thumb initially */
@@ -150,9 +151,10 @@
 }
 
 .command_step_groups {
-  height: calc(
-    100vh - 248px
-  ); /* 248px is height of the controls container + timeline header */
+  height:
+    calc(
+      100vh - 248px
+    ); /* 248px is height of the controls container + timeline header */
 
   overflow-y: scroll;
 }

--- a/app/src/pages/ODD/RobotSettingsDashboard/RobotSettingsList.tsx
+++ b/app/src/pages/ODD/RobotSettingsDashboard/RobotSettingsList.tsx
@@ -28,7 +28,10 @@ import { getRobotSettings, updateSetting } from '/app/redux/robot-settings'
 import { getRobotUpdateAvailable } from '/app/redux/robot-update'
 import { useErrorRecoverySettingsToggle } from '/app/resources/errorRecovery'
 import { useNetworkConnection } from '/app/resources/networking'
-import { useLEDLights } from '/app/resources/robot-settings'
+import {
+  useDisableStackerSensors,
+  useLEDLights,
+} from '/app/resources/robot-settings'
 
 import styles from './robotsettingslist.module.css'
 
@@ -71,6 +74,7 @@ export function RobotSettingsList(props: RobotSettingsListProps): JSX.Element {
   const isUpdateAvailable = robotUpdateType === 'upgrade'
   const devToolsOn = useSelector(getDevtoolsEnabled)
   const { lightsEnabled, toggleLights } = useLEDLights(robotName)
+  const { sensorsDisabled, toggleSensors } = useDisableStackerSensors(robotName)
   const { toggleERSettings, isEREnabled } = useErrorRecoverySettingsToggle()
 
   const appLanguage = useSelector(getAppLanguage)
@@ -199,6 +203,14 @@ export function RobotSettingsList(props: RobotSettingsListProps): JSX.Element {
               updateSetting(robotName, HOME_GANTRY_SETTING_ID, !isHomeGantryOn)
             )
           }
+        />
+        <RobotSettingButton
+          settingName={t('disable_stacker_sensors')}
+          dataTestId="RobotSettingButton_disable_stacker_sensors"
+          settingInfo={t('disable_stacker_sensors_description')}
+          iconName="stacker-sensors"
+          rightElement={<OnOffToggle isOn={sensorsDisabled} />}
+          onClick={toggleSensors}
         />
         <RobotSettingButton
           settingName={t('app_settings:update_channel')}

--- a/app/src/pages/ODD/RobotSettingsDashboard/__tests__/RobotSettingsDashboard.test.tsx
+++ b/app/src/pages/ODD/RobotSettingsDashboard/__tests__/RobotSettingsDashboard.test.tsx
@@ -22,7 +22,10 @@ import { getRobotSettings } from '/app/redux/robot-settings'
 import { getRobotUpdateAvailable } from '/app/redux/robot-update'
 import { useErrorRecoverySettingsToggle } from '/app/resources/errorRecovery'
 import { useNetworkConnection } from '/app/resources/networking'
-import { useLEDLights } from '/app/resources/robot-settings'
+import {
+  useDisableStackerSensors,
+  useLEDLights,
+} from '/app/resources/robot-settings'
 
 import { RobotSettingsDashboard } from '../'
 
@@ -48,6 +51,7 @@ vi.mock('/app/organisms/ODD/RobotSettingsDashboard/LanguageSetting')
 
 const mockToggleLights = vi.fn()
 const mockToggleER = vi.fn()
+const mockToggleStackerSensors = vi.fn()
 
 const render = () => {
   return renderWithProviders(
@@ -78,6 +82,10 @@ describe('RobotSettingsDashboard', () => {
     vi.mocked(useLEDLights).mockReturnValue({
       lightsEnabled: false,
       toggleLights: mockToggleLights,
+    })
+    vi.mocked(useDisableStackerSensors).mockReturnValue({
+      sensorsDisabled: false,
+      toggleSensors: mockToggleStackerSensors,
     })
     vi.mocked(useNetworkConnection).mockReturnValue({} as any)
     vi.mocked(useErrorRecoverySettingsToggle).mockReturnValue({
@@ -172,6 +180,32 @@ describe('RobotSettingsDashboard', () => {
     expect(
       screen.getByTestId('RobotSettingButton_error_recovery_mode')
     ).toHaveTextContent('Off')
+  })
+
+  it('should render disable stacker sensors copy, and calls toggleSensors', () => {
+    render()
+    screen.getByText(
+      'Disable Stacker sensors for labware detection in z-axis and x-axis'
+    )
+
+    const toggle = screen.getByTestId(
+      'RobotSettingButton_disable_stacker_sensors'
+    )
+    expect(toggle).toHaveTextContent('Off')
+
+    fireEvent.click(toggle)
+    expect(mockToggleStackerSensors).toHaveBeenCalled()
+  })
+
+  it('should render on toggle with stacker sensors disabled', () => {
+    vi.mocked(useDisableStackerSensors).mockReturnValue({
+      sensorsDisabled: true,
+      toggleSensors: mockToggleStackerSensors,
+    })
+    render()
+    expect(
+      screen.getByTestId('RobotSettingButton_disable_stacker_sensors')
+    ).toHaveTextContent('On')
   })
 
   it('should render component when tapping network settings', () => {

--- a/app/src/resources/robot-settings/index.ts
+++ b/app/src/resources/robot-settings/index.ts
@@ -1,2 +1,3 @@
 export * from './hooks'
 export * from './useLEDLights'
+export * from './useDisableStackerSensors'

--- a/app/src/resources/robot-settings/useDisableStackerSensors.ts
+++ b/app/src/resources/robot-settings/useDisableStackerSensors.ts
@@ -38,14 +38,14 @@ export function useDisableStackerSensors(
   }, [dispatch, robotName])
 
   const toggleSensors = (): void => {
+    setSensorsDisabledCache(!sensorDisabledCache)
     dispatch(
       updateSetting(
         robotName,
         'disableFlexStackerLabwareDetection',
-        sensorDisabledCache
+        !sensorDisabledCache
       )
     )
-    setSensorsDisabledCache(!sensorDisabledCache)
   }
 
   return { sensorsDisabled: sensorDisabledCache, toggleSensors }

--- a/app/src/resources/robot-settings/useDisableStackerSensors.ts
+++ b/app/src/resources/robot-settings/useDisableStackerSensors.ts
@@ -1,0 +1,52 @@
+import { useEffect, useState } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+
+import {
+  fetchSettings,
+  getRobotSettings,
+  updateSetting,
+} from '/app/redux/robot-settings'
+
+import type { RobotSettings } from '/app/redux/robot-settings/types'
+import type { Dispatch, State } from '/app/redux/types'
+
+// not releveant to the OT-2, this controls the front LED lights on the Flex
+export function useDisableStackerSensors(
+  robotName: string
+): {
+  sensorsDisabled: boolean
+  toggleSensors: () => void
+} {
+  const [sensorDisabledCache, setSensorsDisabledCache] = useState<boolean>(
+    false
+  )
+
+  const dispatch = useDispatch<Dispatch>()
+
+  const sensorsDisabledFromSettings =
+    useSelector<State, RobotSettings>((state: State) =>
+      getRobotSettings(state, robotName)
+    ).find(setting => setting.id === 'disableFlexStackerLabwareDetection')
+      ?.value === true
+
+  useEffect(() => {
+    setSensorsDisabledCache(sensorsDisabledFromSettings)
+  }, [sensorsDisabledFromSettings])
+
+  useEffect(() => {
+    dispatch(fetchSettings(robotName))
+  }, [dispatch, robotName])
+
+  const toggleSensors = (): void => {
+    dispatch(
+      updateSetting(
+        robotName,
+        'disableFlexStackerLabwareDetection',
+        sensorDisabledCache
+      )
+    )
+    setSensorsDisabledCache(!sensorDisabledCache)
+  }
+
+  return { sensorsDisabled: sensorDisabledCache, toggleSensors }
+}


### PR DESCRIPTION
# Overview
This PR adds the ability to disable labware detection on the stackers during a protocol run as a robot settings feature flag. This can be useful when working with labware whose reflectivity falls outside our validated range, or in cases where the sensors are malfunctioning. 