### PR TITLE
feat(docs): build all docs at once

### DIFF
--- a/.github/workflows/docs-build-deploy.yaml
+++ b/.github/workflows/docs-build-deploy.yaml
@@ -45,12 +45,12 @@ jobs:
       - name: Sync the project
         working-directory: ./docs
         run: make setup
-      - name: Build Flex Manual
+      - name: Build Docs Site
         working-directory: ./docs
-        run: make build-flex-manual
-      - name: Deploy Flex Manual to Sandbox
+        run: make build
+      - name: Deploy Docs Site to Sandbox
         working-directory: ./docs
-        run: make deploy-flex-manual BRANCH=${{ env.BRANCH }}
+        run: make deploy BRANCH=${{ env.BRANCH }}
       - name: Output URL to Summary
         run: |
           echo "## Flex Manual deployed to sandbox" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/docs-build-deploy.yaml
+++ b/.github/workflows/docs-build-deploy.yaml
@@ -20,7 +20,7 @@ defaults:
     shell: bash
 
 jobs:
-  sandbox-build-and-deploy-flex-manual:
+  sandbox-build-and-deploy-mkdocs-site:
     timeout-minutes: 5
     runs-on: 'ubuntu-24.04'
     permissions:
@@ -53,5 +53,5 @@ jobs:
         run: make deploy BRANCH=${{ env.BRANCH }}
       - name: Output URL to Summary
         run: |
-          echo "## Flex Manual deployed to sandbox" >> $GITHUB_STEP_SUMMARY
-          echo "<http://sandbox.docs.s3-website.us-east-2.amazonaws.com/${{ env.BRANCH }}/flex-manual/>" >> $GITHUB_STEP_SUMMARY
+          echo "## Docs site deployed to sandbox" >> $GITHUB_STEP_SUMMARY
+          echo "<http://sandbox.docs.s3-website.us-east-2.amazonaws.com/${{ env.BRANCH }}/>" >> $GITHUB_STEP_SUMMARY

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -7,6 +7,21 @@ SANDBOX_S3_BUCKET ?= sandbox.docs
 setup:
 	uv sync
 
+.PHONY: serve
+serve:
+	uv run mkdocs serve -f ./mkdocs.yml
+
+.PHONY: build
+build:
+	uv run mkdocs build -f ./mkdocs.yml
+
+.PHONY: deploy
+deploy:
+	@if [ -n "$$CI" ]; then \
+		echo "If you need to run this locally, set the variable AWS_PROFILE."; \
+	fi
+	aws s3 sync /site/ s3://$(SANDBOX_S3_BUCKET)/$(BRANCH)/ --acl public-read $(if $(AWS_PROFILE),--profile $(AWS_PROFILE))
+
 .PHONY: serve-flex-manual
 serve-flex-manual:
 	uv run mkdocs serve -f $(FLEX_MANUAL_PREFIX)/mkdocs.yml

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -20,7 +20,7 @@ deploy:
 	@if [ -n "$$CI" ]; then \
 		echo "If you need to run this locally, set the variable AWS_PROFILE."; \
 	fi
-	aws s3 sync /site/ s3://$(SANDBOX_S3_BUCKET)/$(BRANCH)/ --acl public-read $(if $(AWS_PROFILE),--profile $(AWS_PROFILE))
+	aws s3 sync ./site/ s3://$(SANDBOX_S3_BUCKET)/$(BRANCH)/ --acl public-read $(if $(AWS_PROFILE),--profile $(AWS_PROFILE))
 
 .PHONY: serve-flex-manual
 serve-flex-manual:

--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "mkdocs>=1.6.1",
     "mkdocs-autorefs>=1.4.2",
     "mkdocs-material>=9.6.14",
+    "mkdocs-monorepo-plugin>=1.1.2",
     "mkdocs-parent-css-plugin",
 ]
 

--- a/docs/uv.lock
+++ b/docs/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 
 [[package]]
@@ -123,6 +123,7 @@ dependencies = [
     { name = "mkdocs" },
     { name = "mkdocs-autorefs" },
     { name = "mkdocs-material" },
+    { name = "mkdocs-monorepo-plugin" },
     { name = "mkdocs-parent-css-plugin" },
 ]
 
@@ -131,6 +132,7 @@ requires-dist = [
     { name = "mkdocs", specifier = ">=1.6.1" },
     { name = "mkdocs-autorefs", specifier = ">=1.4.2" },
     { name = "mkdocs-material", specifier = ">=9.6.14" },
+    { name = "mkdocs-monorepo-plugin", specifier = ">=1.1.2" },
     { name = "mkdocs-parent-css-plugin", editable = "mkdocs-parent-css-plugin" },
 ]
 
@@ -327,6 +329,19 @@ wheels = [
 ]
 
 [[package]]
+name = "mkdocs-monorepo-plugin"
+version = "1.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mkdocs" },
+    { name = "python-slugify" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d4/6a/a75245020e44beb9d7c806158f8a2cda37597711409d40c5a37c70078a7e/mkdocs-monorepo-plugin-1.1.2.tar.gz", hash = "sha256:09200bcf837ad35070e6da973aa0cb682e69ed6e16f254a30584550c6d2d8ebb", size = 13723, upload-time = "2025-06-05T19:09:45.042Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/26/4f4c19457d1d4e6d571a3b092921b7a0ce9477d18d997755ac615d72b96b/mkdocs_monorepo_plugin-1.1.2-py3-none-any.whl", hash = "sha256:4b917bc224b89e34e1736bb31ad5ae9deb0a907da879e03bb9454b41fb8b1cac", size = 14539, upload-time = "2025-06-05T19:09:43.74Z" },
+]
+
+[[package]]
 name = "mkdocs-parent-css-plugin"
 version = "1.0.0"
 source = { editable = "mkdocs-parent-css-plugin" }
@@ -408,6 +423,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-slugify"
+version = "8.0.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "text-unidecode" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/c7/5e1547c44e31da50a460df93af11a535ace568ef89d7a811069ead340c4a/python-slugify-8.0.4.tar.gz", hash = "sha256:59202371d1d05b54a9e7720c5e038f928f45daaffe41dd10822f3907b937c856", size = 10921, upload-time = "2024-02-08T18:32:45.488Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/62/02da182e544a51a5c3ccf4b03ab79df279f9c60c5e82d5e8bec7ca26ac11/python_slugify-8.0.4-py2.py3-none-any.whl", hash = "sha256:276540b79961052b66b7d116620b36518847f52d5fd9e3a70164fc8c50faa6b8", size = 10051, upload-time = "2024-02-08T18:32:43.911Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -485,6 +512,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "text-unidecode"
+version = "1.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ab/e2/e9a00f0ccb71718418230718b3d900e71a5d16e701a3dae079a21e9cd8f8/text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93", size = 76885, upload-time = "2019-08-30T21:36:45.405Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/a5/c0b6468d3824fe3fde30dbb5e1f687b291608f9473681bbf7dabbf5a87d7/text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8", size = 78154, upload-time = "2019-08-30T21:37:03.543Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Overview

Add to `Makefile` and update `uv` config so you can build the omnibus docs site.

## Test Plan and Hands on Testing

Tested locally:
- `make -C docs build`
- `make -C docs serve`

Tested CI for this PR and it works.
<img width="2782" height="2002" alt="Screenshot 2025-08-04 at 4 45 04 PM" src="https://github.com/user-attachments/assets/eb7b06d7-975c-46fa-998c-0a977814a84e" />

## Changelog

- Three new `make` commands.
- Add `mkdocs-monorepo-plugin` to requirements.
- Have the CI workflow use the new commands.

## Review requests

Any bad patterns or things we should fix here?
How do we get this using the `sandbox.docs.opentrons.com` domain instead of a plain S3 URL?

## Risk assessment

low-med, messing with CI.