### PR TITLE
refactor(protocol-designer): change manual link from PDF to mkdocs site

### DIFF
--- a/protocol-designer/src/components/organisms/KnowledgeLink.tsx
+++ b/protocol-designer/src/components/organisms/KnowledgeLink.tsx
@@ -12,7 +12,7 @@ export const RELEASE_NOTES_URL =
   'https://github.com/Opentrons/opentrons/blob/edge/protocol-designer/release-notes.md'
 
 export const DOC_URL =
-  'https://insights.opentrons.com/hubfs/Protocol%20Designer%20Instruction%20Manual.pdf'
+  'https://docs.opentrons.com/protocol-designer/'
 
 export function KnowledgeLink(props: KnowledgeLinkProps): JSX.Element {
   const { children } = props

--- a/protocol-designer/src/components/organisms/KnowledgeLink.tsx
+++ b/protocol-designer/src/components/organisms/KnowledgeLink.tsx
@@ -11,8 +11,7 @@ interface KnowledgeLinkProps {
 export const RELEASE_NOTES_URL =
   'https://github.com/Opentrons/opentrons/blob/edge/protocol-designer/release-notes.md'
 
-export const DOC_URL =
-  'https://docs.opentrons.com/protocol-designer/'
+export const DOC_URL = 'https://docs.opentrons.com/protocol-designer/'
 
 export function KnowledgeLink(props: KnowledgeLinkProps): JSX.Element {
   const { children } = props


### PR DESCRIPTION
Prep for launching the new docs site.

# Overview

Changes the Protocol Designer Instruction Manual link from the PDF on Hubspot to our (still future) mkdocs site on `docs.opentrons.com`.

## Test Plan and Hands on Testing

Just CI for now.

## Changelog

1-liner

## Review requests

TK

## Risk assessment

just don't break the link.
