### PR TITLE
fix(protocol-designer): restore tip position behavior on BatchEdit

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/PositionField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/PositionField.tsx
@@ -109,8 +109,8 @@ export function PositionField(props: PositionFieldProps): JSX.Element {
 
   const handleOpen = (has3Specs: boolean): void => {
     if (
-      wellDepthMm != null &&
-      (has3Specs ? wellXWidthMm != null && wellYWidthMm != null : true)
+      (has3Specs && wellDepthMm && wellXWidthMm && wellYWidthMm) ||
+      (!has3Specs && wellDepthMm)
     ) {
       setIsModalOpen(true)
     }


### PR DESCRIPTION
# Overview

This PR restores the disabling of the tip position in BatchEdit, since relative positions of wells with different depths are not configurable in a single modal.

Closes RQA-4487

## Test Plan and Hands on Testing

- create a protocol with two transfers (see ticket for template)
- open batch edit
- verify that tip position button does not open a modal, and a tooltip renders as before

## Changelog

- revert logic for opening modal in `PositionField`

## Review requests

see test plan