### PR TITLE
fix(protocol-designer): fix Ot2Modules style

### DIFF
--- a/protocol-designer/src/components/organisms/Ot2Modules/index.tsx
+++ b/protocol-designer/src/components/organisms/Ot2Modules/index.tsx
@@ -322,12 +322,7 @@ export function Ot2Modules(): JSX.Element {
       ) : null}
       {changeModuleWarning}
       <Flex flexWrap={WRAP} width="100%">
-        <Flex
-          flexDirection={DIRECTION_COLUMN}
-          flex="1.27"
-          minWidth="30.375rem"
-          paddingTop={SPACING.spacing120}
-        >
+        <Flex flexDirection={DIRECTION_COLUMN} flex="1.27" minWidth="30.375rem">
           {filteredSupportedModules.length > 0 ? (
             <StyledText
               desktopStyle="headingSmallBold"
@@ -416,12 +411,7 @@ export function Ot2Modules(): JSX.Element {
             </Flex>
           ) : null}
         </Flex>
-        <Flex
-          flex="1.27"
-          maxHeight="35rem"
-          minWidth="50%"
-          paddingTop={SPACING.spacing80}
-        >
+        <Flex flex="1.27" maxHeight="35rem" minWidth="50%">
           <RobotCoordinateSpaceWithRef
             height="100%"
             width="100%"


### PR DESCRIPTION
# Overview

Removes excess padding not specified in designs from OT2 modules

Closes RQA-4486

## Test Plan and Hands on Testing

- create or import an OT-2 protocol (see ticket)
- from Protocol Overview > Modules, click "edit"
- verify no excess padding

<img width="1711" height="864" alt="Screenshot 2025-08-06 at 10 24 23 AM" src="https://github.com/user-attachments/assets/55ded075-37d8-4de0-9e90-36650a60149f" />


- save and select Edit Protocol
- select Deck Hardware
- verify no excess padding

<img width="1718" height="818" alt="Screenshot 2025-08-06 at 10 24 35 AM" src="https://github.com/user-attachments/assets/3c3df5d4-03fd-497a-976d-a32994ba608e" />

## Changelog

- remove excess padding in `Ot2Modules` component

## Review requests

see test plan

## Risk assessment

low