### PR TITLE
fix(app): reset RTP capture if analysis changes

### DIFF
--- a/app/src/organisms/Desktop/ChooseRobotToRunProtocolSlideout/index.tsx
+++ b/app/src/organisms/Desktop/ChooseRobotToRunProtocolSlideout/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
 import first from 'lodash/first'
@@ -94,6 +94,9 @@ export function ChooseRobotToRunProtocolSlideoutComponent(
   const [hasMissingFileParam, setHasMissingFileParam] = useState<boolean>(
     runTimeParameters?.some(parameter => parameter.type === 'csv_file') ?? false
   )
+  useEffect(() => setRunTimeParametersOverrides(runTimeParameters), [
+    storedProtocolData,
+  ])
 
   const [targetProps, tooltipProps] = useHoverTooltip()
 

--- a/app/src/organisms/Desktop/ChooseRobotToRunProtocolSlideout/index.tsx
+++ b/app/src/organisms/Desktop/ChooseRobotToRunProtocolSlideout/index.tsx
@@ -94,9 +94,9 @@ export function ChooseRobotToRunProtocolSlideoutComponent(
   const [hasMissingFileParam, setHasMissingFileParam] = useState<boolean>(
     runTimeParameters?.some(parameter => parameter.type === 'csv_file') ?? false
   )
-  useEffect(() => setRunTimeParametersOverrides(runTimeParameters), [
-    storedProtocolData,
-  ])
+  useEffect(() => {
+    setRunTimeParametersOverrides(runTimeParameters)
+  }, [storedProtocolData])
 
   const [targetProps, tooltipProps] = useHoverTooltip()
 


### PR DESCRIPTION
The ChooseRobotToRunProtocolSlideout needed to reset its react state that captures the RTP value overrides, since it doesn't get unmounted if you alter the protocol and reanalyze it. Sad.

Closes RQA-4496
