### PR TITLE
fix(components): fix title prop null check in DropdownMenu

### DIFF
--- a/components/src/molecules/DropdownMenu/index.tsx
+++ b/components/src/molecules/DropdownMenu/index.tsx
@@ -260,7 +260,7 @@ export function DropdownMenu(props: DropdownMenuProps): JSX.Element {
       gridGap={SPACING.spacing8}
       width={width}
     >
-      {title !== null ? (
+      {title != null ? (
         <Flex gridGap={SPACING.spacing8} alignItems={ALIGN_CENTER}>
           <StyledText
             desktopStyle="bodyDefaultRegular"


### PR DESCRIPTION
# Overview

This PR fixes the logic for nullish `title` prop in `DropdownMenu`, changing the check from `title !== null` to `title != null`, such that an undefined title results in this condition evaluating to `false`. The result is that when `title` is undefined, there will be no 8px spacing above the clickable dropdown box.

Closes RQA-4497

## Test Plan and Hands on Testing

- inspect a `DropdownMenu` instance without a title
- verify that there is no 8px spacing above the dropdown menu

#### Before 
<img width="554" height="89" alt="Screenshot 2025-08-06 at 12 25 04 PM" src="https://github.com/user-attachments/assets/0910bd34-ad3f-416a-a555-b6b82d2ea372" />


#### After
<img width="567" height="95" alt="Screenshot 2025-08-06 at 12 24 36 PM" src="https://github.com/user-attachments/assets/2560b0f6-cfe6-4776-9546-f959b5c46a5b" />


## Changelog

- change title check to loose inequality (nullish)

## Review requests

see test plan

## Risk assessment

low