### PR TITLE
fix(protocol-designer): fix height and padding in ProtocolSteps

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/index.tsx
@@ -272,7 +272,7 @@ export function ProtocolSteps({
               <Flex
                 justifyContent={JUSTIFY_END}
                 position={POSITION_ABSOLUTE}
-                right="0"
+                right={SPACING.spacing24}
                 zIndex={1000}
               >
                 <ExportButton onClick={handleExporting} />

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/index.tsx
@@ -234,7 +234,6 @@ export function ProtocolSteps({
 
       <Flex
         backgroundColor={COLORS.grey10}
-        maxHeight={`calc(100vh - ${NAV_BAR_HEIGHT_REM}rem)`}
         width="100%"
         minHeight={FLEX_MAX_CONTENT}
       >

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/index.tsx
@@ -25,7 +25,6 @@ import {
   OT2_ROBOT_TYPE,
 } from '@opentrons/shared-data'
 
-import { NAV_BAR_HEIGHT_REM } from '../../../components/atoms'
 import { ExportButton, HotKeyDisplay } from '../../../components/molecules'
 import {
   SlotDetailsContainer,

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/index.tsx
@@ -291,7 +291,9 @@ export function ProtocolSteps({
                   : CONTENT_MAX_WIDTH
               }
               justifyContent={JUSTIFY_CENTER}
-              paddingTop={isZoomedIn ? '0' : SPACING.spacing60}
+              paddingTop={
+                isZoomedIn || showTimelineAlerts ? '0' : SPACING.spacing60
+              }
               marginX="auto"
             >
               {isZoomedIn || selectedTerminalItemId === HARDWARE_ID ? null : (

--- a/protocol-designer/src/pages/Designer/index.tsx
+++ b/protocol-designer/src/pages/Designer/index.tsx
@@ -10,6 +10,7 @@ import {
   useOnClickOutside,
 } from '@opentrons/components'
 
+import { NAV_BAR_HEIGHT_REM } from '../../components/atoms/constants'
 import { DefineLiquidsModal } from '../../components/organisms'
 import { useKitchen } from '../../components/organisms/Kitchen/hooks'
 import { LiquidsOverflowMenu } from '../../components/organisms/LiquidsOverflowMenu'
@@ -101,7 +102,12 @@ export function Designer(): JSX.Element {
           targetWidth={targetWidth}
         />
       ) : null}
-      <Flex height="100%" width="100%" overflowY={OVERFLOW_HIDDEN}>
+      <Flex
+        height="100%"
+        maxHeight={`calc(100vh - ${NAV_BAR_HEIGHT_REM}rem )`}
+        width="100%"
+        overflowY={OVERFLOW_HIDDEN}
+      >
         <ProtocolSteps
           zoomedInSlot={zoomIn.slot}
           showLiquidOverflowMenu={showLiquidOverflowMenu}


### PR DESCRIPTION
# Overview

This PR fixes the max height of `ProtocolSteps` container in the `Designer` component to account for the NavBar height and exclude excess scrollable white space at the bottom of the container. It also fixes the padding logic in `ProtocolSteps` to show '0' padding if there are timeline errors (since the Export button is no longer position ed relatively)

## Test Plan and Hands on Testing

- create or import a protocol and navigate to Edit Protocol
- scroll up and down and verify that there is no excess padding at the bottom of the container

#### Scrolled Down Before
<img width="1708" height="863" alt="Screenshot 2025-08-06 at 1 15 35 PM" src="https://github.com/user-attachments/assets/a4d8c25d-cb52-4089-ac57-9567cf61ad15" />

#### Scrolled Down After
<img width="1711" height="870" alt="Screenshot 2025-08-06 at 1 15 08 PM" src="https://github.com/user-attachments/assets/d54a054b-8e79-4b60-afb6-1de79528752b" />

#### After

## Changelog

- account for NavBar height in `ProtocolSteps` container max height
- add additional check to have 0 padding above ProtocolStep content if there are timeline errors (since export button is now positioned absolutely)
- move over Export button 2rem (per design recommendation)

## Review requests

see test plan

## Risk assessment

low