### PR TITLE
fix(app): module setup flow allow TC add/remove

### DIFF
--- a/shared-data/js/__tests__/fixtures.test.ts
+++ b/shared-data/js/__tests__/fixtures.test.ts
@@ -19,6 +19,7 @@ import {
   STAGING_AREA_SLOT_WITH_WASTE_CHUTE_RIGHT_ADAPTER_COVERED_FIXTURE,
   STAGING_AREA_SLOT_WITH_WASTE_CHUTE_RIGHT_ADAPTER_NO_COVER_FIXTURE,
   TEMPERATURE_MODULE_V2_FIXTURE,
+  THERMOCYCLER_MODULE_V2,
   WASTE_CHUTE_RIGHT_ADAPTER_COVERED_FIXTURE,
   WASTE_CHUTE_RIGHT_ADAPTER_NO_COVER_FIXTURE,
 } from '..'
@@ -589,6 +590,21 @@ describe('isModuleAllowedOnAA', () => {
   it('should return true for tempModule on D3', () => {
     const vs = isModuleAllowedOnAA('cutoutD3', 'D3', 'temperatureModuleV2')
     expect(vs).toEqual(true)
+  })
+
+  it('should return true for thermocycler on A1', () => {
+    const vs = isModuleAllowedOnAA('cutoutA1', 'A1', THERMOCYCLER_MODULE_V2)
+    expect(vs).toEqual(true)
+  })
+
+  it('should return true for thermocycler on B1', () => {
+    const vs = isModuleAllowedOnAA('cutoutB1', 'B1', THERMOCYCLER_MODULE_V2)
+    expect(vs).toEqual(true)
+  })
+
+  it('should return false for thermocycler on A3', () => {
+    const vs = isModuleAllowedOnAA('cutoutA3', 'A3', THERMOCYCLER_MODULE_V2)
+    expect(vs).toEqual(false)
   })
 })
 

--- a/shared-data/js/fixtures.ts
+++ b/shared-data/js/fixtures.ts
@@ -1184,7 +1184,7 @@ export const isModuleAllowedOnAA = (
   moduleModel: ModuleModel
 ): boolean => {
   if (moduleModel === THERMOCYCLER_MODULE_V2) {
-    return THERMOCYCLER_MODULE_CUTOUTS.includes(cutoutId) ? true : false
+    return THERMOCYCLER_MODULE_CUTOUTS.includes(cutoutId)
   }
   const fixtureId = getCutoutFixtureIdsForModuleModel(moduleModel)
   const aaForFixture = getAAWithFakesFromCutoutFixtureId(

--- a/shared-data/js/fixtures.ts
+++ b/shared-data/js/fixtures.ts
@@ -1257,6 +1257,14 @@ export const replaceCutoutFixtureWithComboFixture = (
   return addedCutoutConfigs.map(aaCutoutItem => {
     console.log('Processing cutout item:', aaCutoutItem)
 
+    if (
+      THERMOCYCLER_MODULE_CUTOUTS.includes(cutoutId) &&
+      MODULE_FIXTURES_BY_MODEL.thermocyclerModuleV2?.includes(
+        aaCutoutItem.cutoutFixtureId as CutoutFixtureId
+      )
+    ) {
+      return { ...aaCutoutItem }
+    }
     // Filter potential combo fixture options
     const comboFixturesOptions = Object.entries(
       addressableAreasById
@@ -1385,6 +1393,7 @@ export const getCutoutConfigReplacmentForModule = (
     deckConfigWithAA,
     cutoutId
   )
+  console.log('replacmentFixture:', replacmentFixture)
 
   return getReplacementFixtureForFakeFixture(
     replacmentFixture[0].cutoutFixtureId

--- a/shared-data/js/fixtures.ts
+++ b/shared-data/js/fixtures.ts
@@ -1393,7 +1393,6 @@ export const getCutoutConfigReplacmentForModule = (
     deckConfigWithAA,
     cutoutId
   )
-  console.log('replacmentFixture:', replacmentFixture)
 
   return getReplacementFixtureForFakeFixture(
     replacmentFixture[0].cutoutFixtureId

--- a/shared-data/js/fixtures.ts
+++ b/shared-data/js/fixtures.ts
@@ -11,6 +11,7 @@ import {
   FLEX_STACKER_FIXTURES,
   FLEX_STAGING_ADDRESSABLE_AREAS_WITH_FAKES,
   FLEX_USB_MODULE_FIXTURES,
+  THERMOCYCLER_MODULE_CUTOUTS,
   WASTE_CHUTE_FIXTURES,
   WASTE_CHUTE_WITH_FAKE_FIXTURES,
 } from '.'
@@ -1182,6 +1183,9 @@ export const isModuleAllowedOnAA = (
   aa: AddressableAreaNamesWithFakes,
   moduleModel: ModuleModel
 ): boolean => {
+  if (moduleModel === THERMOCYCLER_MODULE_V2) {
+    return THERMOCYCLER_MODULE_CUTOUTS.includes(cutoutId) ? true : false
+  }
   const fixtureId = getCutoutFixtureIdsForModuleModel(moduleModel)
   const aaForFixture = getAAWithFakesFromCutoutFixtureId(
     cutoutId,


### PR DESCRIPTION
# Overview

closes https://opentrons.atlassian.net/browse/RQA-4050.
allow adding and removing TC from module setup deck config. 

## Test Plan and Hands on Testing

1. recalibrate TC
2. add/remove TC
3. close and make sure change is reflected in the app

## Changelog

`isModuleAllowedOnAA` special case for TC

## Risk assessment

bug fix
