### PR TITLE
doc(step-generation): liquidClass="none" is allowed in FormData but not in StepArgs

### DIFF
--- a/protocol-designer/src/form-types.ts
+++ b/protocol-designer/src/form-types.ts
@@ -343,7 +343,7 @@ export interface HydratedMoveLiquidFormData extends AnnotationFields {
   pickUpTip_location?: string | null
   pickUpTip_wellNames?: string[] | null
   preWetTip?: boolean | null
-  liquidClass?: string | null
+  liquidClass?: string | null // a liquid class name like "water" or "none" or null
 }
 
 export interface HydratedMoveLabwareFormData extends AnnotationFields {

--- a/step-generation/src/types.ts
+++ b/step-generation/src/types.ts
@@ -309,7 +309,7 @@ export type SharedTransferLikeArgs = CommonArgs & {
   blowoutFlowRateUlSec: number
 
   // ===== SETTINGS INTRODUCED WITH LIQUID CLASSES =====
-  liquidClass: string | null
+  liquidClass: string | null // a liquid class name like "water" or null; "none" is not allowed
   aspiratePositionReference: PositionReference
   aspirateZOffset: number
   aspirateSubmergeSpeed: number | null

--- a/step-generation/src/utils/liquidClassUtils.ts
+++ b/step-generation/src/utils/liquidClassUtils.ts
@@ -229,7 +229,7 @@ export const getCustomLiquidClassProperties = (
 }
 
 export const getLiquidClassName = (
-  liquidClass: string,
+  liquidClass: string, // a liquid class name like "water", "none" is not allowed
   showBase?: boolean
 ): string => {
   const allLiquidClassDefs = getAllLiquidClassDefs()


### PR DESCRIPTION
# Overview

We're running into bugs because there's confusion about when `liquidClass == "none"` is expected (e.g., RQA-4490).

After tracing through the code, I think the policy is:

- In the **form data** (`HydratedMoveLiquidFormData`), `null` means the user has not selected anything, and `"none"` (aka `NONE_LIQUID_CLASS_NAME`) means the user clicked "Don't use a liquid class," and otherwise the name of a liquid class (e.g., `"water"`) is expected.
- In the **step args** (`TransferArgs`, `ConsolidateArgs`, `DistributeArgs`, `SharedTransferLikeArgs`), the value `"none"` is not allowed. The `liquidClass` must be the name of a liquid class like `"water"`, or `null`.

Anyone who's converting from the FormData to StepArgs (PD and QT) is responsible for implementing this rule.

In PD, `moveLiquidFormToArgs.ts` is responsible for translating `"none"` to `null` when creating the StepArgs (https://github.com/Opentrons/opentrons/blob/chore_release-pd-8.5.0/protocol-designer/src/steplist/formLevel/stepFormToArgs/moveLiquidFormToArgs.ts#L392).

QT doesn't do that translation yet, and that's why it's crashing.

## Review requests

I'm not saying this rule is a good idea, but it's the only way to make the existing code work. Our functions that take StepArgs (like the `transfer.ts` CommandCreator) will crash if you pass them `"none"`.

## Risk assessment

Low. Comment-only change.