### PR TITLE
fix(api,shared-data): Load new versions of Millipore labware in apiLevel 2.25

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/load_labware_params.py
+++ b/api/src/opentrons/protocol_api/core/engine/load_labware_params.py
@@ -89,6 +89,7 @@ _APILEVEL_2_25_OT_DEFAULT_VERSIONS: dict[str, int] = deepcopy(
 _APILEVEL_2_25_OT_DEFAULT_VERSIONS.update(
     {
         "appliedbiosystemsmicroamp_384_wellplate_40ul": 3,
+        "axygen_96_wellplate_500ul": 2,
         "biorad_384_wellplate_50ul": 4,
         "biorad_96_wellplate_200ul_pcr": 4,
         "corning_12_wellplate_6.9ml_flat": 4,
@@ -96,10 +97,12 @@ _APILEVEL_2_25_OT_DEFAULT_VERSIONS.update(
         "corning_48_wellplate_1.6ml_flat": 5,
         "corning_6_wellplate_16.8ml_flat": 4,
         "corning_96_wellplate_360ul_flat": 4,
+        "ibidi_96_square_well_plate_300ul": 2,
         "nest_96_wellplate_100ul_pcr_full_skirt": 4,
         "nest_96_wellplate_200ul_flat": 4,
         "nest_96_wellplate_2ml_deep": 4,
         "opentrons_96_wellplate_200ul_pcr_full_skirt": 4,
+        "smc_384_read_plate": 2,
         "thermoscientificnunc_96_wellplate_1300ul": 3,
         "thermoscientificnunc_96_wellplate_2000ul": 3,
         "usascientific_96_wellplate_2.4ml_deep": 3,


### PR DESCRIPTION
## Overview

PR #18807 added new versions of:

* `axygen_96_wellplate_500ul`
* `ibidi_96_square_well_plate_300ul`
* `smc_384_read_plate`

But unfortunately that's not enough for the Python Protocol API to actually load them. We need to add them to `load_labware_params.py`, too. (This is definitely not the first time we've forgotten to do this; it's a real unfortunate gotcha in our labware process. PR #19146 tries to help, and is in fact what caught this for me.)

## Test Plan and Hands on Testing

None—these new definitions were already validated in #18807.

## Review requests

We are ready to release these new labware versions in v8.6.0, right?

## Risk assessment

Low, as long as these definitions were already validated in #18807, which they were.
