### PR TITLE
fix(app): Update stacker error recovery flow to remove redundant incorrect labware count

### DIFF
--- a/app/src/assets/localization/en/error_recovery.json
+++ b/app/src/assets/localization/en/error_recovery.json
@@ -67,7 +67,6 @@
   "latch_will_release_in_s": "Latch will release labware in {{seconds}} seconds",
   "launch_recovery_mode": "Launch recovery mode",
   "load_labware_into_labware_shuttle": "Load labware onto labware shuttle",
-  "load_labware_into_stacker": "Load {{quantity}} labware into stacker",
   "load_labware_into_stacker_and_retry_step": "Load labware into stacker and retry step",
   "load_labware_shuttle_and_retry_step": "Load labware shuttle and retry step",
   "load_labware_shuttle_onto_track": "Load labware shuttle onto track",

--- a/app/src/organisms/ErrorRecoveryFlows/shared/StackerHopperLwInfo.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/StackerHopperLwInfo.tsx
@@ -3,7 +3,6 @@ import { useTranslation } from 'react-i18next'
 import FillHopper from '/app/assets/videos/error-recovery/FlexStacker_FillHopper.webm'
 import { TwoColumn } from '/app/molecules/InterventionModal'
 
-import { ERROR_KINDS } from '../constants'
 import { LeftColumnLabwareInfo } from './LeftColumnLabwareInfo'
 import { RecoverySingleColumnContentWrapper } from './RecoveryContentWrapper'
 import { RecoveryFooterButtons } from './RecoveryFooterButtons'
@@ -14,21 +13,15 @@ import type { RecoveryContentProps } from '../types'
 export function StackerHopperLwInfo(props: RecoveryContentProps): JSX.Element {
   const { t } = useTranslation('error_recovery')
 
-  const { routeUpdateActions, failedLabwareUtils, errorKind } = props
-  const { labwareQuantity } = failedLabwareUtils
+  const { routeUpdateActions } = props
   const { proceedNextStep, goBackPrevStep } = routeUpdateActions
-
-  const title =
-    errorKind === ERROR_KINDS.STACKER_HOPPER_EMPTY
-      ? t('load_labware_into_stacker', { quantity: labwareQuantity })
-      : t('ensure_stacker_has_labware')
 
   return (
     <RecoverySingleColumnContentWrapper>
       <TwoColumn>
         <LeftColumnLabwareInfo
           {...props}
-          title={title}
+          title={t('ensure_stacker_has_labware')}
           type={'location'}
           layout={'stacked'}
           bannerText={t('make_sure_loaded_correct_number_of_labware_stacker')}

--- a/app/src/organisms/ErrorRecoveryFlows/shared/__tests__/StackerHopperLwInfo.test.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/__tests__/StackerHopperLwInfo.test.tsx
@@ -82,19 +82,6 @@ describe('Render StackerHopperLwInfo', () => {
 
     expect(LeftColumnLabwareInfo).toHaveBeenCalledWith(
       expect.objectContaining({
-        title: 'Load 2 labware into stacker',
-      }),
-      expect.anything()
-    )
-    screen.getByText('MOCK_LEFT_COLUMN_LABWARE_INFO')
-  })
-
-  it(`renders correct title for other error kinds`, () => {
-    props.errorKind = ERROR_KINDS.STACKER_SHUTTLE_EMPTY
-    render(props)
-
-    expect(LeftColumnLabwareInfo).toHaveBeenCalledWith(
-      expect.objectContaining({
         title: 'Ensure stacker has labware',
       }),
       expect.anything()


### PR DESCRIPTION
# Overview
Covers RQA-4480

Originally we had a title in our flow that stated "Load X labware into Stacker". The count on X was wrong for a reason traced back to when and how it's sampling the current run state. However, looking at the rest of our flows we actually use "Ensure Stacker has Labware" everywhere else. After speaking with design and QA about this, we have decided to simply consolidate the titles used on these flows to be the same in order to limit confusion.

## Test Plan and Hands on Testing

- [x] Test on robot with ER protocol for store and retrieve flows
- [x] Update unit test coverage

## Changelog


## Review requests


## Risk assessment
Low