### PR TITLE
feat(api): add x,y WellOffset for wells with an even number of subsections

### DIFF
--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -588,6 +588,40 @@ class GeometryView:
                 f"Liquid Height of {probed_height} mm is greater than maximum well height {well_depth} mm."
             )
 
+    def get_xy_offset_if_needed(self, labware_id: str, well_name: str) -> WellOffset:
+        """Add an x,y offset to position the tip into the center of the well if needed."""
+        well_def = self._labware.get_well_definition(labware_id, well_name)
+        well_geometry = self._labware.get_well_geometry(
+            labware_id=labware_id, well_name=well_name
+        )
+        x_offset = 0.0
+        y_offset = 0.0
+        if isinstance(well_geometry, InnerWellGeometry):
+            sorted_well = sorted(
+                well_geometry.sections, key=lambda section: section.topHeight
+            )
+            bottom_xcount = sorted_well[0].xCount
+            bottom_ycount = sorted_well[0].yCount
+
+            if well_def.shape == "circular":
+                well_x_dimension = well_y_dimension = well_def.diameter
+            else:
+                assert well_def.shape == "rectangular", "invalid well shape"
+                well_x_dimension = well_def.xDimension
+                well_y_dimension = well_def.yDimension
+
+            # if there are an even number of subsections, we'll need to reposition into
+            # the middle of one of the subsections, rather than the middle of the whole well.
+            if bottom_xcount % 2 == 0:
+                subsection_x_dimension = well_x_dimension / bottom_xcount
+                # move over into the middle of the nearest subsection
+                x_offset = subsection_x_dimension / 2
+            if bottom_ycount % 2 == 0:
+                subsection_y_dimension = well_y_dimension / bottom_ycount
+                # move over into the middle of the nearest subection
+                y_offset = subsection_y_dimension / 2
+        return WellOffset(x=x_offset, y=y_offset, z=0)
+
     def get_well_position(
         self,
         labware_id: str,
@@ -600,8 +634,10 @@ class GeometryView:
         labware_pos = self.get_labware_position(labware_id)
         well_def = self._labware.get_well_definition(labware_id, well_name)
         well_depth = well_def.depth
-
-        offset = WellOffset(x=0, y=0, z=well_depth)
+        xy_offset = self.get_xy_offset_if_needed(
+            labware_id=labware_id, well_name=well_name
+        )
+        offset = WellOffset(x=xy_offset.x, y=xy_offset.y, z=well_depth)
         if well_location is not None:
             offset = well_location.offset  # location of the bottom of the well
             offset_adjustment = self.get_well_offset_adjustment(

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -590,6 +590,9 @@ class GeometryView:
 
     def get_xy_offset_if_needed(self, labware_id: str, well_name: str) -> WellOffset:
         """Add an x,y offset to position the tip into the center of a sub-well if needed."""
+        labware_definition = self._labware.get_definition(labware_id)
+        if labware_definition.innerLabwareGeometry is None:
+            return WellOffset(x=0, y=0, z=0)
         well_def = self._labware.get_well_definition(labware_id, well_name)
         well_geometry = self._labware.get_well_geometry(
             labware_id=labware_id, well_name=well_name

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -588,11 +588,11 @@ class GeometryView:
                 f"Liquid Height of {probed_height} mm is greater than maximum well height {well_depth} mm."
             )
 
-    def get_xy_offset_if_needed(self, labware_id: str, well_name: str) -> WellOffset:
+    def _get_xy_offset_if_needed(self, labware_id: str, well_name: str) -> Point:
         """Add an x,y offset to position the tip into the center of a sub-well if needed."""
         labware_definition = self._labware.get_definition(labware_id)
         if labware_definition.innerLabwareGeometry is None:
-            return WellOffset(x=0, y=0, z=0)
+            return Point(x=0, y=0, z=0)
         well_def = self._labware.get_well_definition(labware_id, well_name)
         well_geometry = self._labware.get_well_geometry(
             labware_id=labware_id, well_name=well_name
@@ -609,7 +609,6 @@ class GeometryView:
             if well_def.shape == "circular":
                 well_x_dimension = well_y_dimension = well_def.diameter
             else:
-                assert well_def.shape == "rectangular", "invalid well shape"
                 well_x_dimension = well_def.xDimension
                 well_y_dimension = well_def.yDimension
 
@@ -623,7 +622,7 @@ class GeometryView:
                 subsection_y_dimension = well_y_dimension / bottom_ycount
                 # move over into the middle of the nearest subection
                 y_offset = subsection_y_dimension / 2
-        return WellOffset(x=x_offset, y=y_offset, z=0)
+        return Point(x=x_offset, y=y_offset, z=0)
 
     def get_well_position(
         self,
@@ -637,7 +636,7 @@ class GeometryView:
         labware_pos = self.get_labware_position(labware_id)
         well_def = self._labware.get_well_definition(labware_id, well_name)
         well_depth = well_def.depth
-        xy_offset = self.get_xy_offset_if_needed(
+        xy_offset = self._get_xy_offset_if_needed(
             labware_id=labware_id, well_name=well_name
         )
         offset = WellOffset(x=xy_offset.x, y=xy_offset.y, z=well_depth)

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -589,7 +589,7 @@ class GeometryView:
             )
 
     def get_xy_offset_if_needed(self, labware_id: str, well_name: str) -> WellOffset:
-        """Add an x,y offset to position the tip into the center of the well if needed."""
+        """Add an x,y offset to position the tip into the center of a sub-well if needed."""
         well_def = self._labware.get_well_definition(labware_id, well_name)
         well_geometry = self._labware.get_well_geometry(
             labware_id=labware_id, well_name=well_name


### PR DESCRIPTION
## Overview
Fixes [this issue in ABR](https://opentrons.atlassian.net/browse/RABR-801) where during meniscus-relative pipetting, a tip will hit the top of a reservoir's sub-wells at the bottom and cause an `OverPressure` error. 

When resolving the geometric position of a well, we can check if the well's bottom has an even number of rows or columns of sub-wells. If it does, add an offset to move into the middle of the nearest sub-well to allow the tip to go down into the bottom. 

Enabling pipetting like this into the bottom of reservoirs might result in running out of liquid in some sub-wells and not the whole reservoir, but I think that's fine.

## Changelog

- add a function to `geometry.py` to check if there are an even number of subwells, and return an offset into the middle of the nearest subwell if so
- add this offset to the well position returned by `get_well_position`

## TODO

- [ ] test on bot
- [ ] software test