### PR TITLE
fix(app): ensure disabled touch tip value is null

### DIFF
--- a/app/src/organisms/ODD/QuickTransferFlow/Aspirate/hooks/useAspirateSettingsConfig.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/Aspirate/hooks/useAspirateSettingsConfig.ts
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { useToaster } from '/app/organisms/ToasterOven'
 
 import { ASPIRATE_SETTING_OPTIONS as SETTING_OPTIONS } from '../../constants'
+import { getIsTouchTipEnabled } from '../../utils/getIsTouchTipEnabled'
 
 import type { Dispatch } from 'react'
 import type {
@@ -28,8 +29,7 @@ export function useAspirateSettingsConfig({
   const { t } = useTranslation(['quick_transfer', 'shared'])
   const { makeSnackbar } = useToaster()
 
-  const sourceIsReservoir =
-    state.source.metadata.displayCategory === 'reservoir'
+  const touchTipEnabled = getIsTouchTipEnabled(state.source)
 
   const aspirateSettingsItems: SettingItem[] = [
     {
@@ -148,15 +148,15 @@ export function useAspirateSettingsConfig({
       option: SETTING_OPTIONS.ASPIRATE_TOUCH_TIP,
       copy: t('touch_tip'),
       value:
-        state.touchTipAspirate !== undefined
+        state.touchTipAspirate !== undefined && touchTipEnabled
           ? t('touch_tip_value', {
               speed: state.touchTipAspirateSpeed,
               position: state.touchTipAspirate,
             })
           : t('option_disabled'),
-      enabled: !sourceIsReservoir,
+      enabled: touchTipEnabled,
       onClick: () => {
-        if (!sourceIsReservoir) {
+        if (touchTipEnabled) {
           setSelectedSetting(SETTING_OPTIONS.ASPIRATE_TOUCH_TIP)
         } else {
           makeSnackbar(t('aspirate_setting_disabled') as string)

--- a/app/src/organisms/ODD/QuickTransferFlow/Dispense/hooks/useDispenseSettingsConfig.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/Dispense/hooks/useDispenseSettingsConfig.ts
@@ -9,6 +9,7 @@ import { SOURCE_WELL_BLOWOUT_DESTINATION } from '@opentrons/step-generation'
 import { useToaster } from '/app/organisms/ToasterOven'
 
 import { DISPENSE_SETTING_OPTIONS as SETTING_OPTIONS } from '../../constants'
+import { getIsTouchTipEnabled } from '../../utils/getIsTouchTipEnabled'
 
 import type {
   DispenseSettingOption,
@@ -53,6 +54,8 @@ export function useDispenseSettingsConfig({
       return t('blow_out_into_waste_chute')
     }
   }
+
+  const touchTipEnabled = getIsTouchTipEnabled(state.destination)
 
   const dispenseSettingsItems = [
     {
@@ -202,15 +205,19 @@ export function useDispenseSettingsConfig({
       option: 'dispense_touch_tip',
       copy: t('touch_tip'),
       value:
-        state.touchTipDispense !== undefined
+        state.touchTipDispense !== undefined && touchTipEnabled
           ? t('touch_tip_value', {
               speed: state.touchTipDispenseSpeed,
               position: state.touchTipDispense,
             })
           : t('option_disabled'),
-      enabled: true,
+      enabled: touchTipEnabled,
       onClick: () => {
-        setSelectedSetting('dispense_touch_tip')
+        if (touchTipEnabled) {
+          setSelectedSetting('dispense_touch_tip')
+        } else {
+          makeSnackbar(t('dispense_setting_disabled') as string)
+        }
       },
     },
     {

--- a/app/src/organisms/ODD/QuickTransferFlow/__tests__/Dispense/Dispense.test.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/__tests__/Dispense/Dispense.test.tsx
@@ -8,6 +8,7 @@ import { Dispense } from '../../Dispense'
 import { DispenseSettingDetail } from '../../Dispense/DispenseSettingDetail'
 import { DispenseSettingItem } from '../../Dispense/DispenseSettingItem'
 import { ResetAdvancedSettingsModal } from '../../QuickTransferAdvancedSettings/ResetAdvancedSettingsModal'
+import { getIsTouchTipEnabled } from '../../utils/getIsTouchTipEnabled'
 
 import type { ComponentProps } from 'react'
 
@@ -15,6 +16,7 @@ vi.mock('../../Dispense/DispenseSettingItem')
 vi.mock('../../Dispense/DispenseSettingDetail')
 vi.mock('../../Dispense/hooks/useAspirateSettingsConfig')
 vi.mock('../../QuickTransferAdvancedSettings/ResetAdvancedSettingsModal')
+vi.mock('../../utils/getIsTouchTipEnabled')
 
 const render = (props: ComponentProps<typeof Dispense>) => {
   return renderWithProviders(<Dispense {...props} />, {
@@ -95,6 +97,7 @@ describe('Dispense', () => {
     vi.mocked(ResetAdvancedSettingsModal).mockReturnValue(
       <div>mock ResetAdvancedSettingsModal</div>
     )
+    vi.mocked(getIsTouchTipEnabled).mockReturnValue(true)
   })
 
   it('renders mock components and reset button', () => {

--- a/app/src/organisms/ODD/QuickTransferFlow/__tests__/utils/getIsTouchTipEnabled.test.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/__tests__/utils/getIsTouchTipEnabled.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+
+import { getIsTouchTipEnabled } from '../../utils/getIsTouchTipEnabled'
+
+import type { LabwareDefinition2 } from '@opentrons/shared-data'
+
+describe('getIsTouchTipEnabled', () => {
+  it('should return true if the source or destination does not have quirks', () => {
+    const sourceOrDestination = {
+      parameters: {},
+    } as LabwareDefinition2
+    expect(getIsTouchTipEnabled(sourceOrDestination)).toBe(true)
+  })
+  it('should return true if the source or destination does not have touchTipDisabled quirk', () => {
+    const sourceOrDestination = {
+      parameters: { quirks: ['someQuirk'] },
+    } as LabwareDefinition2
+    expect(getIsTouchTipEnabled(sourceOrDestination)).toBe(true)
+  })
+  it('should return false if the source or destination has touchTipDisabled quirk', () => {
+    const sourceOrDestination = {
+      parameters: { quirks: ['touchTipDisabled'] },
+    } as LabwareDefinition2
+    expect(getIsTouchTipEnabled(sourceOrDestination)).toBe(false)
+  })
+  it('should return true if the source or destination is "source"', () => {
+    const sourceOrDestination = 'source'
+    expect(getIsTouchTipEnabled(sourceOrDestination)).toBe(true)
+  })
+})

--- a/app/src/organisms/ODD/QuickTransferFlow/types.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/types.ts
@@ -83,7 +83,7 @@ export interface QuickTransferSummaryState {
   delayAspirate?: {
     delayDuration: number
   }
-  touchTipAspirate?: number
+  touchTipAspirate?: number // specifies the tip position from the top of the well
   touchTipAspirateSpeed?: number
   airGapAspirate?: number
   tipPositionDispense: number
@@ -104,7 +104,7 @@ export interface QuickTransferSummaryState {
   delayDispense?: {
     delayDuration: number
   }
-  touchTipDispense?: number
+  touchTipDispense?: number // specifies the tip position from the top of the well
   touchTipDispenseSpeed?: number
   disposalVolume?: number
   blowOutDispense?: {

--- a/app/src/organisms/ODD/QuickTransferFlow/utils/getIsTouchTipEnabled.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/utils/getIsTouchTipEnabled.ts
@@ -6,4 +6,4 @@ export const getIsTouchTipEnabled = (
     | QuickTransferSummaryState['destination']
 ): boolean =>
   sourceOrDestination === 'source' ||
-  sourceOrDestination.metadata.displayCategory !== 'reservoir'
+  (sourceOrDestination.parameters.quirks?.includes('reservoir') ?? true)

--- a/app/src/organisms/ODD/QuickTransferFlow/utils/getIsTouchTipEnabled.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/utils/getIsTouchTipEnabled.ts
@@ -6,4 +6,4 @@ export const getIsTouchTipEnabled = (
     | QuickTransferSummaryState['destination']
 ): boolean =>
   sourceOrDestination === 'source' ||
-  (sourceOrDestination.parameters.quirks?.includes('reservoir') ?? true)
+  (sourceOrDestination.parameters.quirks?.includes('touchTipDisabled') ?? true)

--- a/app/src/organisms/ODD/QuickTransferFlow/utils/getIsTouchTipEnabled.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/utils/getIsTouchTipEnabled.ts
@@ -6,4 +6,6 @@ export const getIsTouchTipEnabled = (
     | QuickTransferSummaryState['destination']
 ): boolean =>
   sourceOrDestination === 'source' ||
-  (sourceOrDestination.parameters.quirks?.includes('touchTipDisabled') ?? true)
+  !(
+    sourceOrDestination.parameters.quirks?.includes('touchTipDisabled') ?? false
+  )

--- a/app/src/organisms/ODD/QuickTransferFlow/utils/getIsTouchTipEnabled.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/utils/getIsTouchTipEnabled.ts
@@ -5,5 +5,5 @@ export const getIsTouchTipEnabled = (
     | QuickTransferSummaryState['source']
     | QuickTransferSummaryState['destination']
 ): boolean =>
-  typeof sourceOrDestination === 'object' &&
-  sourceOrDestination.metadata?.displayCategory !== 'reservoir'
+  sourceOrDestination === 'source' ||
+  sourceOrDestination.metadata.displayCategory !== 'reservoir'

--- a/app/src/organisms/ODD/QuickTransferFlow/utils/getIsTouchTipEnabled.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/utils/getIsTouchTipEnabled.ts
@@ -1,4 +1,4 @@
-import { QuickTransferSummaryState } from '../types'
+import type { QuickTransferSummaryState } from '../types'
 
 export const getIsTouchTipEnabled = (
   sourceOrDestination:

--- a/app/src/organisms/ODD/QuickTransferFlow/utils/getIsTouchTipEnabled.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/utils/getIsTouchTipEnabled.ts
@@ -1,0 +1,9 @@
+import { QuickTransferSummaryState } from '../types'
+
+export const getIsTouchTipEnabled = (
+  sourceOrDestination:
+    | QuickTransferSummaryState['source']
+    | QuickTransferSummaryState['destination']
+): boolean =>
+  typeof sourceOrDestination === 'object' &&
+  sourceOrDestination.metadata?.displayCategory !== 'reservoir'


### PR DESCRIPTION
# Overview

Add logic to `useAspirateSettingsConfig` and `useDispenseSettingsConfig` hooks to appropriately check if source/destination is compatible with touch tip. Refactors this check to a util.

## Test Plan and Hands on Testing

- create a quick transfer protocol with the source labware set to a reservoir
- continue to advanced aspirate settings, and verify that aspirate touchtip setting is disabled and does not specify any values
- repeat with destination labware as a reservoir
- continue to advanced dispense settings, and verify that dispense touchtip setting is disabled and does not specify any values

## Changelog

- create utility for determining touch tip safety
- wire up in `use[Aspirate/Dispense]SettingsConfig` touchtip settings

## Review requests

- see test plan

## Risk assessment

lowish