### PR TITLE
fix(shared-data): Add gripHeightFromLabwareBottom offset to appliedbiosystemsmicroamp_384_wellplate_40ul

### DIFF
--- a/shared-data/labware/definitions/2/appliedbiosystemsmicroamp_384_wellplate_40ul/3.json
+++ b/shared-data/labware/definitions/2/appliedbiosystemsmicroamp_384_wellplate_40ul/3.json
@@ -4696,6 +4696,7 @@
   "namespace": "opentrons",
   "version": 3,
   "schemaVersion": 2,
+  "gripHeightFromLabwareBottom": 6.2,
   "stackingOffsetWithLabware": {
     "appliedbiosystemsmicroamp_384_wellplate_40ul": {
       "x": 0,


### PR DESCRIPTION
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Adds gripHeightFromLabwareBottom offset to `appliedbiosystemsmicroamp_384_wellplate_40ul`

Closes: [RABR-814](https://opentrons.atlassian.net/browse/RABR-814)

## Test Plan and Hands on Testing

- Tested new offset on labware in robot and moved it x6 times between 2 deck slots. This resulted in no stalls.

## Changelog

- Added gripHeightFromLabwareBottom to definition. This distance puts the gripper pads above the labware skirt and below the top of the labware.

![IMG_3897](https://github.com/user-attachments/assets/23939f11-871a-48a4-acae-d567d167a45d)
![IMG_3898](https://github.com/user-attachments/assets/d8b68d57-82e4-413e-95f7-6cf605d35d0f)




[RABR-814]: https://opentrons.atlassian.net/browse/RABR-814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ