### PR TITLE
fix(app): allow stacker setup with no pipette

### DIFF
--- a/app/src/App/hooks.ts
+++ b/app/src/App/hooks.ts
@@ -142,7 +142,7 @@ const MODULES_NOT_REQUIRING_PIPETTE_FOR_SETUP: ModuleType[] = [
 
 const MODULES_NOT_REQUIRING_CALIBRATION = MODULES_NOT_REQUIRING_PIPETTE_FOR_SETUP
 
-export function useGetUnlocatedModules(): AttachedModule[] {
+export function useGetModulesNeedingSetup(): AttachedModule[] {
   const attachedModules =
     useAttachedModules({
       refetchInterval: ATTACHED_MODULE_POLL_MS,
@@ -156,26 +156,18 @@ export function useGetUnlocatedModules(): AttachedModule[] {
       ?.filter(c => c.opentronsModuleSerialNumber)
       .map(m => m.opentronsModuleSerialNumber)
     return attachedModules.filter(
-      m => !modulesInDeckConfig.includes(m.serialNumber)
+      m =>
+        !modulesInDeckConfig.includes(m.serialNumber) ||
+        (!MODULES_NOT_REQUIRING_CALIBRATION.includes(m.moduleType) &&
+          m.moduleOffset === undefined)
     )
   }
   return []
 }
 
-export function useGetModulesNeedingSetup(): AttachedModule[] {
-  const allNewModules = useGetUnlocatedModules()
-  console.log(`ugmns: ${allNewModules}`)
-  return allNewModules.filter(
-    m =>
-      MODULES_NOT_REQUIRING_CALIBRATION.includes(m.moduleType) ||
-      m.moduleOffset === undefined
-  )
-}
-
 export function useGetModulesNeedingSetupThatCanCurrentlyBeSetUp(): AttachedModule[] {
   const modulesRequiringSetup = useGetModulesNeedingSetup()
   const attachedPipettes = useAttachedPipettes(modulesRequiringSetup.length > 0)
-  console.log(`ugmnstccbs: ${modulesRequiringSetup}`)
   return modulesRequiringSetup.filter(
     m =>
       MODULES_NOT_REQUIRING_PIPETTE_FOR_SETUP.includes(m.moduleType) ||
@@ -188,7 +180,6 @@ export function useModuleAttachedToast(
   launchModuleSetupCallback: () => void
 ): void {
   const currentlySetuppableModules = useGetModulesNeedingSetupThatCanCurrentlyBeSetUp()
-  console.log(`umat: ${currentlySetuppableModules}`)
 
   const currentRunId = useCurrentRunId({ refetchInterval: CURRENT_RUN_POLL })
   const { t, i18n } = useTranslation(['module_wizard_flows', 'shared'])
@@ -201,7 +192,6 @@ export function useModuleAttachedToast(
 
   useEffect(() => {
     const newModuleSerials = difference(moduleSerials, moduleSerialsRef.current)
-    console.log(`umat effect: ${newModuleSerials}`)
     if (!runInProgress && newModuleSerials.length > 0) {
       makeToast(t('module_added') as string, 'info', {
         buttonText: i18n.format(t('shared:close'), 'capitalize'),

--- a/app/src/App/hooks.ts
+++ b/app/src/App/hooks.ts
@@ -15,6 +15,10 @@ import {
   useCreateLiveCommandMutation,
   useHost,
 } from '@opentrons/react-api-client'
+import {
+  ABSORBANCE_READER_TYPE,
+  FLEX_STACKER_MODULE_TYPE,
+} from '@opentrons/shared-data'
 
 import { useToaster } from '/app/organisms/ToasterOven'
 import { checkShellUpdate } from '/app/redux/shell'
@@ -26,7 +30,10 @@ import { useCurrentRunId } from '../resources/runs'
 import { SharedScrollRefContext } from './ODDProviders/ScrollRefProvider'
 
 import type { AttachedModule } from '@opentrons/api-client'
-import type { SetStatusBarCreateCommand } from '@opentrons/shared-data'
+import type {
+  ModuleType,
+  SetStatusBarCreateCommand,
+} from '@opentrons/shared-data'
 import type { Dispatch } from '/app/redux/types'
 
 const UPDATE_RECHECK_INTERVAL_MS = 60000
@@ -151,12 +158,28 @@ export function useGetNewModules(): AttachedModule[] {
   return []
 }
 
+const MODULES_NOT_REQUIRING_PIPETTE_FOR_SETUP: ModuleType[] = [
+  ABSORBANCE_READER_TYPE,
+  FLEX_STACKER_MODULE_TYPE,
+]
+
 export function useModuleAttachedToast(
   launchModuleSetupCallback: () => void
 ): void {
   const newModules = useGetNewModules()
   const currentRunId = useCurrentRunId({ refetchInterval: CURRENT_RUN_POLL })
-  const attachedPipettes = useAttachedPipettes(newModules.length > 0)
+  const modulesNotRequiringPipette = newModules
+    .filter(thisModule =>
+      MODULES_NOT_REQUIRING_PIPETTE_FOR_SETUP.includes(thisModule.moduleType)
+    )
+    .map(thisModule => thisModule.serialNumber)
+  const moduleSerialsRequiringPipette = newModules
+    .map(thisModule => thisModule.serialNumber)
+    .filter(thisSerial => !modulesNotRequiringPipette.includes(thisSerial))
+
+  const attachedPipettes = useAttachedPipettes(
+    moduleSerialsRequiringPipette.length > 0
+  )
   const { t, i18n } = useTranslation(['module_wizard_flows', 'shared'])
   const { makeToast } = useToaster()
   const moduleSerials = newModules.map(m => m.serialNumber)
@@ -165,9 +188,19 @@ export function useModuleAttachedToast(
 
   useEffect(() => {
     const newModuleSerials = difference(moduleSerials, moduleSerialsRef.current)
+    const newModulesRequiringPipette = newModuleSerials.filter(serial =>
+      moduleSerialsRequiringPipette.includes(serial)
+    )
+    const newModulesNotRequiringPipette = newModuleSerials.filter(
+      serial => !moduleSerialsRequiringPipette.includes(serial)
+    )
     const hasPipette =
       attachedPipettes.left != null || attachedPipettes.right != null
-    if (!runInProgress && hasPipette && newModuleSerials.length > 0) {
+    if (
+      !runInProgress &&
+      ((hasPipette && newModulesRequiringPipette.length > 0) ||
+        newModulesNotRequiringPipette.length > 0)
+    ) {
       makeToast(t('module_added') as string, 'info', {
         buttonText: i18n.format(t('shared:close'), 'capitalize'),
         linkText: t('module_added_link'),
@@ -179,7 +212,7 @@ export function useModuleAttachedToast(
     moduleSerialsRef.current = moduleSerials
     // dont want this hook to rerun when other deps change
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [moduleSerials, runInProgress])
+  }, [moduleSerials, runInProgress, moduleSerialsRequiringPipette])
 }
 
 export function useScrollRef(): {

--- a/app/src/App/hooks.ts
+++ b/app/src/App/hooks.ts
@@ -1,4 +1,4 @@
-import { useCallback, useContext, useEffect, useRef } from 'react'
+import { useCallback, useContext, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useQueryClient } from 'react-query'
 import { useDispatch } from 'react-redux'
@@ -135,7 +135,14 @@ export function useProtocolReceiptToast(): void {
   }, [protocolIds])
 }
 
-export function useGetNewModules(): AttachedModule[] {
+const MODULES_NOT_REQUIRING_PIPETTE_FOR_SETUP: ModuleType[] = [
+  ABSORBANCE_READER_TYPE,
+  FLEX_STACKER_MODULE_TYPE,
+]
+
+const MODULES_NOT_REQUIRING_CALIBRATION = MODULES_NOT_REQUIRING_PIPETTE_FOR_SETUP
+
+export function useGetUnlocatedModules(): AttachedModule[] {
   const attachedModules =
     useAttachedModules({
       refetchInterval: ATTACHED_MODULE_POLL_MS,
@@ -148,59 +155,54 @@ export function useGetNewModules(): AttachedModule[] {
     const modulesInDeckConfig = deckConfig
       ?.filter(c => c.opentronsModuleSerialNumber)
       .map(m => m.opentronsModuleSerialNumber)
-    const newModules = attachedModules.filter(
-      m =>
-        m.moduleOffset === undefined &&
-        !modulesInDeckConfig.includes(m.serialNumber)
+    return attachedModules.filter(
+      m => !modulesInDeckConfig.includes(m.serialNumber)
     )
-    return newModules
   }
   return []
 }
 
-const MODULES_NOT_REQUIRING_PIPETTE_FOR_SETUP: ModuleType[] = [
-  ABSORBANCE_READER_TYPE,
-  FLEX_STACKER_MODULE_TYPE,
-]
+export function useGetModulesNeedingSetup(): AttachedModule[] {
+  const allNewModules = useGetUnlocatedModules()
+  console.log(`ugmns: ${allNewModules}`)
+  return allNewModules.filter(
+    m =>
+      MODULES_NOT_REQUIRING_CALIBRATION.includes(m.moduleType) ||
+      m.moduleOffset === undefined
+  )
+}
+
+export function useGetModulesNeedingSetupThatCanCurrentlyBeSetUp(): AttachedModule[] {
+  const modulesRequiringSetup = useGetModulesNeedingSetup()
+  const attachedPipettes = useAttachedPipettes(modulesRequiringSetup.length > 0)
+  console.log(`ugmnstccbs: ${modulesRequiringSetup}`)
+  return modulesRequiringSetup.filter(
+    m =>
+      MODULES_NOT_REQUIRING_PIPETTE_FOR_SETUP.includes(m.moduleType) ||
+      attachedPipettes.left != null ||
+      attachedPipettes.right != null
+  )
+}
 
 export function useModuleAttachedToast(
   launchModuleSetupCallback: () => void
 ): void {
-  const newModules = useGetNewModules()
-  const currentRunId = useCurrentRunId({ refetchInterval: CURRENT_RUN_POLL })
-  const modulesNotRequiringPipette = newModules
-    .filter(thisModule =>
-      MODULES_NOT_REQUIRING_PIPETTE_FOR_SETUP.includes(thisModule.moduleType)
-    )
-    .map(thisModule => thisModule.serialNumber)
-  const moduleSerialsRequiringPipette = newModules
-    .map(thisModule => thisModule.serialNumber)
-    .filter(thisSerial => !modulesNotRequiringPipette.includes(thisSerial))
+  const currentlySetuppableModules = useGetModulesNeedingSetupThatCanCurrentlyBeSetUp()
+  console.log(`umat: ${currentlySetuppableModules}`)
 
-  const attachedPipettes = useAttachedPipettes(
-    moduleSerialsRequiringPipette.length > 0
-  )
+  const currentRunId = useCurrentRunId({ refetchInterval: CURRENT_RUN_POLL })
   const { t, i18n } = useTranslation(['module_wizard_flows', 'shared'])
   const { makeToast } = useToaster()
-  const moduleSerials = newModules.map(m => m.serialNumber)
+  const moduleSerials = currentlySetuppableModules.map(m => m.serialNumber)
   const moduleSerialsRef = useRef(moduleSerials)
   const runInProgress = currentRunId != null
 
+  const [firstRun, setFirstRun] = useState<boolean>(true)
+
   useEffect(() => {
     const newModuleSerials = difference(moduleSerials, moduleSerialsRef.current)
-    const newModulesRequiringPipette = newModuleSerials.filter(serial =>
-      moduleSerialsRequiringPipette.includes(serial)
-    )
-    const newModulesNotRequiringPipette = newModuleSerials.filter(
-      serial => !moduleSerialsRequiringPipette.includes(serial)
-    )
-    const hasPipette =
-      attachedPipettes.left != null || attachedPipettes.right != null
-    if (
-      !runInProgress &&
-      ((hasPipette && newModulesRequiringPipette.length > 0) ||
-        newModulesNotRequiringPipette.length > 0)
-    ) {
+    console.log(`umat effect: ${newModuleSerials}`)
+    if (!runInProgress && newModuleSerials.length > 0) {
       makeToast(t('module_added') as string, 'info', {
         buttonText: i18n.format(t('shared:close'), 'capitalize'),
         linkText: t('module_added_link'),
@@ -210,9 +212,10 @@ export function useModuleAttachedToast(
       })
     }
     moduleSerialsRef.current = moduleSerials
+    setFirstRun(false)
     // dont want this hook to rerun when other deps change
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [moduleSerials, runInProgress, moduleSerialsRequiringPipette])
+  }, [moduleSerials, runInProgress, firstRun])
 }
 
 export function useScrollRef(): {

--- a/app/src/assets/localization/en/module_wizard_flows.json
+++ b/app/src/assets/localization/en/module_wizard_flows.json
@@ -15,6 +15,7 @@
   "close_doors_description": "The robot needs to safely move to its home location before you can set the labware shuttle onto the track.",
   "close_stacker_doors": "Close robot door and all stacker doors",
   "complete_calibration": "Complete calibration",
+  "connect_a_pipette_to_set_up_more_modules": "Connect a pipette to set up more modules.",
   "confirm_location": "Confirm location",
   "confirm_placement": "Confirm placement",
   "door_circuit_error": "Robot is open",

--- a/app/src/molecules/InterventionModal/ModalContentOneColSimpleButtons.tsx
+++ b/app/src/molecules/InterventionModal/ModalContentOneColSimpleButtons.tsx
@@ -4,6 +4,7 @@ import {
   DIRECTION_COLUMN,
   Flex,
   LegacyStyledText,
+  OVERFLOW_SCROLL,
   RadioButton,
   SPACING,
   TYPOGRAPHY,
@@ -25,6 +26,7 @@ export interface ModalContentOneColSimpleButtonsProps {
   onSelect?: ChangeEventHandler<HTMLInputElement>
   initialSelected?: string
   subText?: string
+  scroll?: boolean
 }
 
 export function ModalContentOneColSimpleButtons(
@@ -34,16 +36,26 @@ export function ModalContentOneColSimpleButtons(
     props.initialSelected ?? null
   )
   return (
-    <OneColumn>
-      <Flex flexDirection={DIRECTION_COLUMN} gap={SPACING.spacing16}>
-        <LegacyStyledText
-          fontSize={TYPOGRAPHY.fontSize28}
-          fontWeight={TYPOGRAPHY.fontWeightSemiBold}
-          lineHeight={TYPOGRAPHY.lineHeight36}
+    <OneColumn height="100%">
+      <Flex
+        flexDirection={DIRECTION_COLUMN}
+        gap={SPACING.spacing16}
+        height="100%"
+      >
+        <Flex>
+          <LegacyStyledText
+            fontSize={TYPOGRAPHY.fontSize28}
+            fontWeight={TYPOGRAPHY.fontWeightSemiBold}
+            lineHeight={TYPOGRAPHY.lineHeight36}
+          >
+            {props.headline}
+          </LegacyStyledText>
+        </Flex>
+        <Flex
+          flexDirection={DIRECTION_COLUMN}
+          gap={SPACING.spacing4}
+          overflowY={props.scroll === true ? 'auto' : null}
         >
-          {props.headline}
-        </LegacyStyledText>
-        <Flex flexDirection={DIRECTION_COLUMN} gap={SPACING.spacing4}>
           {props.buttons.map((buttonProps, idx) => (
             <RadioButton
               key={`button${idx}-${buttonProps.value}`}

--- a/app/src/molecules/InterventionModal/ModalContentOneColSimpleButtons.tsx
+++ b/app/src/molecules/InterventionModal/ModalContentOneColSimpleButtons.tsx
@@ -4,7 +4,6 @@ import {
   DIRECTION_COLUMN,
   Flex,
   LegacyStyledText,
-  OVERFLOW_SCROLL,
   RadioButton,
   SPACING,
   TYPOGRAPHY,

--- a/app/src/molecules/InterventionModal/ModalContentOneColSimpleButtons.tsx
+++ b/app/src/molecules/InterventionModal/ModalContentOneColSimpleButtons.tsx
@@ -24,6 +24,7 @@ export interface ModalContentOneColSimpleButtonsProps {
   buttons: ButtonProps[]
   onSelect?: ChangeEventHandler<HTMLInputElement>
   initialSelected?: string
+  subText?: string
 }
 
 export function ModalContentOneColSimpleButtons(
@@ -56,6 +57,15 @@ export function ModalContentOneColSimpleButtons(
               }}
             />
           ))}
+          {props.subText != null ? (
+            <LegacyStyledText
+              fontSize={TYPOGRAPHY.fontSize22}
+              fontWeight={TYPOGRAPHY.fontWeightRegular}
+              lineHeight={TYPOGRAPHY.lineHeight28}
+            >
+              {props.subText}
+            </LegacyStyledText>
+          ) : null}
         </Flex>
       </Flex>
     </OneColumn>

--- a/app/src/molecules/UpdateBanner/__tests__/UpdateBanner.test.tsx
+++ b/app/src/molecules/UpdateBanner/__tests__/UpdateBanner.test.tsx
@@ -123,7 +123,7 @@ describe('Module Update Banner', () => {
     expect(screen.queryByText('Setup module')).not.toBeInTheDocument()
   })
 
-  it('should not render module setup banner if pipette calibration is required', () => {
+  it('should render module setup banner even if pipette calibration is required', () => {
     props = {
       ...props,
       updateType: 'setup',
@@ -135,7 +135,7 @@ describe('Module Update Banner', () => {
         'ModuleCard_calibration_update_banner_test_number'
       )
     ).not.toBeInTheDocument()
-    expect(screen.queryByText('Setup module')).not.toBeInTheDocument()
+    screen.getByText('Setup module')
   })
 
   it('should not render a module setup link if pipette firmware update is required', () => {

--- a/app/src/molecules/UpdateBanner/index.tsx
+++ b/app/src/molecules/UpdateBanner/index.tsx
@@ -51,14 +51,17 @@ export const UpdateBanner = ({
     return t('module_calibration_required')
   }
 
-  const canProceed =
-    updateType === 'firmware'
-      ? true
-      : !isEstopNotDisengaged &&
-        !isTooHot &&
-        !attachPipetteRequired &&
-        !calibratePipetteRequired &&
-        !updatePipetteFWRequired
+  const proceedChecks = {
+    firmware: () => true,
+    calibration: () =>
+      !isEstopNotDisengaged &&
+      !isTooHot &&
+      !attachPipetteRequired &&
+      !calibratePipetteRequired &&
+      !updatePipetteFWRequired,
+    setup: () => true,
+  }
+  const canProceed = proceedChecks[updateType]()
 
   const getMessage = (): string => {
     switch (updateType) {

--- a/app/src/organisms/ModuleWizardFlows/AttachProbe.tsx
+++ b/app/src/organisms/ModuleWizardFlows/AttachProbe.tsx
@@ -21,9 +21,9 @@ import { SimpleWizardInProgressBody } from '/app/molecules/SimpleWizardBody'
 import { getFixtureIdByCutoutId } from './getFixtureIdByCutoutId'
 
 import type { CreateCommand, DeckConfiguration } from '@opentrons/shared-data'
-import type { ModuleSetupWizardStepProps } from './types'
+import type { ModuleSetupWizardRequiresPipetteStepProps } from './types'
 
-interface AttachProbeProps extends ModuleSetupWizardStepProps {
+interface AttachProbeProps extends ModuleSetupWizardRequiresPipetteStepProps {
   adapterId: string | null
   deckConfig: DeckConfiguration
 }

--- a/app/src/organisms/ModuleWizardFlows/BeforeBeginning.tsx
+++ b/app/src/organisms/ModuleWizardFlows/BeforeBeginning.tsx
@@ -12,7 +12,7 @@ import { GenericWizardTile } from '/app/molecules/GenericWizardTile'
 import { WizardRequiredEquipmentList } from '/app/molecules/WizardRequiredEquipmentList'
 
 import type { AttachedModule } from '@opentrons/api-client'
-import type { ModuleSetupWizardStepProps } from './types'
+import type { ModuleSetupWizardMaybePipetteStepProps } from './types'
 
 interface EqipmentItem {
   loadName: string
@@ -20,7 +20,7 @@ interface EqipmentItem {
   subtitle?: string
 }
 
-interface BeforeBeginningProps extends ModuleSetupWizardStepProps {}
+interface BeforeBeginningProps extends ModuleSetupWizardMaybePipetteStepProps {}
 
 export function BeforeBeginning(props: BeforeBeginningProps): JSX.Element {
   const { proceed, attachedModule, setErrorMessage } = props

--- a/app/src/organisms/ModuleWizardFlows/CheckStackerInstall.tsx
+++ b/app/src/organisms/ModuleWizardFlows/CheckStackerInstall.tsx
@@ -11,9 +11,10 @@ import { useSendIdentifyStacker } from './hooks'
 
 import type { AttachedModule } from '@opentrons/api-client'
 import type { DeckConfiguration } from '@opentrons/shared-data'
-import type { ModuleSetupWizardStepProps } from './types'
+import type { ModuleSetupWizardMaybePipetteStepProps } from './types'
 
-interface CheckStackerInstallProps extends ModuleSetupWizardStepProps {
+interface CheckStackerInstallProps
+  extends ModuleSetupWizardMaybePipetteStepProps {
   deckConfig: DeckConfiguration
   attachedModules: AttachedModule[]
   doorOpenStatus: boolean

--- a/app/src/organisms/ModuleWizardFlows/CloseStackerDoor.tsx
+++ b/app/src/organisms/ModuleWizardFlows/CloseStackerDoor.tsx
@@ -13,9 +13,9 @@ import {
 } from '/app/molecules/SimpleWizardBody'
 
 import type { CreateCommand, DeckConfiguration } from '@opentrons/shared-data'
-import type { ModuleSetupWizardStepProps } from './types'
+import type { ModuleSetupWizardMaybePipetteStepProps } from './types'
 
-interface CloseDoorProps extends ModuleSetupWizardStepProps {
+interface CloseDoorProps extends ModuleSetupWizardMaybePipetteStepProps {
   deckConfig: DeckConfiguration
 }
 

--- a/app/src/organisms/ModuleWizardFlows/DetachProbe.tsx
+++ b/app/src/organisms/ModuleWizardFlows/DetachProbe.tsx
@@ -15,7 +15,7 @@ import detachProbe8 from '/app/assets/videos/pipette-wizard-flows/Pipette_Detach
 import detachProbe96 from '/app/assets/videos/pipette-wizard-flows/Pipette_Detach_Probe_96.webm'
 import { GenericWizardTile } from '/app/molecules/GenericWizardTile'
 
-import type { ModuleSetupWizardStepProps } from './types'
+import type { ModuleSetupWizardRequiresPipetteStepProps } from './types'
 
 const BODY_STYLE = css`
   ${TYPOGRAPHY.pRegular};
@@ -26,7 +26,9 @@ const BODY_STYLE = css`
   }
 `
 
-export function DetachProbe(props: ModuleSetupWizardStepProps): JSX.Element {
+export function DetachProbe(
+  props: ModuleSetupWizardRequiresPipetteStepProps
+): JSX.Element {
   const { attachedPipette, proceed, goBack } = props
   const { t, i18n } = useTranslation('module_wizard_flows')
 

--- a/app/src/organisms/ModuleWizardFlows/InstallShuttle.tsx
+++ b/app/src/organisms/ModuleWizardFlows/InstallShuttle.tsx
@@ -22,9 +22,9 @@ import { SimpleWizardBody } from '/app/molecules/SimpleWizardBody'
 
 import type { AttachedModule } from '@opentrons/api-client'
 import type { DeckConfiguration } from '@opentrons/shared-data'
-import type { ModuleSetupWizardStepProps } from './types'
+import type { ModuleSetupWizardMaybePipetteStepProps } from './types'
 
-interface InstallShuttleProps extends ModuleSetupWizardStepProps {
+interface InstallShuttleProps extends ModuleSetupWizardMaybePipetteStepProps {
   deckConfig: DeckConfiguration
   attachedModules: AttachedModule[]
 }

--- a/app/src/organisms/ModuleWizardFlows/PlaceAdapter.tsx
+++ b/app/src/organisms/ModuleWizardFlows/PlaceAdapter.tsx
@@ -33,9 +33,9 @@ import { SimpleWizardInProgressBody } from '/app/molecules/SimpleWizardBody'
 import { LEFT_SLOTS } from './constants'
 
 import type { CreateCommand, DeckConfiguration } from '@opentrons/shared-data'
-import type { ModuleSetupWizardStepProps } from './types'
+import type { ModuleSetupWizardRequiresPipetteStepProps } from './types'
 
-interface PlaceAdapterProps extends ModuleSetupWizardStepProps {
+interface PlaceAdapterProps extends ModuleSetupWizardRequiresPipetteStepProps {
   deckConfig: DeckConfiguration
   setCreatedAdapterId: (adapterId: string) => void
 }

--- a/app/src/organisms/ModuleWizardFlows/SelectLocation.tsx
+++ b/app/src/organisms/ModuleWizardFlows/SelectLocation.tsx
@@ -42,7 +42,7 @@ import type {
   CutoutId,
   DeckConfiguration,
 } from '@opentrons/shared-data'
-import type { ModuleSetupWizardStepProps } from './types'
+import type { ModuleSetupWizardMaybePipetteStepProps } from './types'
 
 export const BODY_STYLE = css`
   ${TYPOGRAPHY.pRegular};
@@ -52,7 +52,8 @@ export const BODY_STYLE = css`
     line-height: 1.75rem;
   }
 `
-export interface SelectLocationProps extends ModuleSetupWizardStepProps {
+export interface SelectLocationProps
+  extends ModuleSetupWizardMaybePipetteStepProps {
   deckConfig: DeckConfiguration
   createMaintenanceRun: CreateMaintenanceRunType
   isLoadedInRun: boolean

--- a/app/src/organisms/ModuleWizardFlows/SelectModule.tsx
+++ b/app/src/organisms/ModuleWizardFlows/SelectModule.tsx
@@ -8,6 +8,7 @@ import {
   Flex,
   JUSTIFY_FLEX_END,
   JUSTIFY_SPACE_BETWEEN,
+  OVERFLOW_AUTO,
   PrimaryButton,
   RESPONSIVENESS,
   SPACING,
@@ -162,6 +163,7 @@ export function SelectModule(props: SelectModuleProps): JSX.Element | null {
           margin={SPACING.spacing32}
           flexDirection={DIRECTION_COLUMN}
           height="100%"
+          overflowY={OVERFLOW_AUTO}
           justifyContent={JUSTIFY_SPACE_BETWEEN}
         >
           <ModalContentOneColSimpleButtons
@@ -175,6 +177,7 @@ export function SelectModule(props: SelectModuleProps): JSX.Element | null {
                 ? t('connect_a_pipette_to_set_up_more_modules')
                 : null
             }
+            scroll={true}
           />
         </Flex>
         <Flex css={BUTTON_STYLE}>

--- a/app/src/organisms/ModuleWizardFlows/SelectModule.tsx
+++ b/app/src/organisms/ModuleWizardFlows/SelectModule.tsx
@@ -58,13 +58,22 @@ export function SelectModule(props: SelectModuleProps): JSX.Element | null {
   const { t } = useTranslation('module_wizard_flows')
 
   const { parseModuleUSBPort } = useModuleUSBPort()
+  // Every module that needs setup (isn't calibrated, isn't in deck config) that also
+  // CAN be set up with the current robot configuration (pipettes or not pipettes)
   const allSetupable = useGetModulesNeedingSetupThatCanCurrentlyBeSetUp()
+  // Every module that needs setup, but not all are guaranteed to be able to be set up
+  // right now (e.g. because they need calibration but we don't have a pipette)
   const allNeedingSetup = useGetModulesNeedingSetup()
   const newModules =
     attachedModuleOnLaunch == null ? allSetupable : [attachedModuleOnLaunch]
-  // allNeedingSetup is a superset of allSetupable
+  // if there are more modules that need setup than modules that can be set up, then
+  // it follows that some modules need setup but cannot be set up. in that case we want
+  // a warning
   const hasUnsetupabbleModules = allNeedingSetup.length > allSetupable.length
+  // And our special short-circuit flows where we never show a menu if there's only one
+  // entry should be avoided if we have that warning
   const isSingleModule = newModules.length === 1 && !hasUnsetupabbleModules
+  // Unless, of course, we're being invoked by a caller giving us a specific module
   const shortCircuitFlow = attachedModuleOnLaunch != null || isSingleModule
   const sendIdentifyStacker = useSendIdentifyStacker()
 

--- a/app/src/organisms/ModuleWizardFlows/SelectModule.tsx
+++ b/app/src/organisms/ModuleWizardFlows/SelectModule.tsx
@@ -12,7 +12,11 @@ import {
   RESPONSIVENESS,
   SPACING,
 } from '@opentrons/components'
-import { getModuleDisplayName } from '@opentrons/shared-data'
+import {
+  ABSORBANCE_READER_TYPE,
+  FLEX_STACKER_MODULE_TYPE,
+  getModuleDisplayName,
+} from '@opentrons/shared-data'
 
 import { useGetNewModules } from '/app/App/hooks'
 import { SmallButton } from '/app/atoms/buttons'
@@ -27,6 +31,8 @@ import {
 import { useSendIdentifyStacker } from './hooks'
 
 import type { AttachedModule } from '@opentrons/api-client'
+import type { ModuleType } from '@opentrons/shared-data'
+import type { PipetteInformation } from '/app/redux/pipettes'
 
 interface SelectModuleProps {
   buildFlowForSelectedModule: (module: AttachedModule) => void
@@ -35,6 +41,7 @@ interface SelectModuleProps {
   setSelectedModule: (module: AttachedModule | null) => void
   setShowLaunchSetup: (show: boolean) => void
   attachedModuleOnLaunch?: AttachedModule | null
+  attachedPipette?: PipetteInformation | null
 }
 
 interface ModuleNameAndPort {
@@ -42,7 +49,7 @@ interface ModuleNameAndPort {
   port: string
 }
 
-export function SelectModule(props: SelectModuleProps): JSX.Element {
+export function SelectModule(props: SelectModuleProps): JSX.Element | null {
   const {
     buildFlowForSelectedModule,
     isOnDevice,
@@ -50,15 +57,25 @@ export function SelectModule(props: SelectModuleProps): JSX.Element {
     setSelectedModule,
     setShowLaunchSetup,
     attachedModuleOnLaunch = null,
+    attachedPipette,
   } = props
   const { t } = useTranslation('module_wizard_flows')
 
   const { parseModuleUSBPort } = useModuleUSBPort()
   const availableModules = useGetNewModules()
-  const newModules =
+  const allNewModules =
     attachedModuleOnLaunch !== null
       ? [attachedModuleOnLaunch]
       : availableModules
+
+  const modulesNotRequiringPipette = allNewModules.filter(thisModule =>
+    ([
+      ABSORBANCE_READER_TYPE,
+      FLEX_STACKER_MODULE_TYPE,
+    ] as ModuleType[]).includes(thisModule.moduleType)
+  )
+  const newModules =
+    attachedPipette == null ? modulesNotRequiringPipette : allNewModules
 
   const isSingleModule = newModules.length === 1
   const sendIdentifyStacker = useSendIdentifyStacker()
@@ -114,8 +131,9 @@ export function SelectModule(props: SelectModuleProps): JSX.Element {
       padding-left: ${SPACING.spacing32};
     }
   `
-
-  if (isSingleModule && selectedModule != null) {
+  if (newModules.length === 0) {
+    return null
+  } else if (isSingleModule && selectedModule != null) {
     const m = getModuleNameAndPort(selectedModule)
     return (
       <SimpleWizardBody

--- a/app/src/organisms/ModuleWizardFlows/SelectModule.tsx
+++ b/app/src/organisms/ModuleWizardFlows/SelectModule.tsx
@@ -18,7 +18,7 @@ import {
   getModuleDisplayName,
 } from '@opentrons/shared-data'
 
-import { useGetNewModules } from '/app/App/hooks'
+import { useGetModulesNeedingSetupThatCanCurrentlyBeSetUp } from '/app/App/hooks'
 import { SmallButton } from '/app/atoms/buttons'
 import { i18n } from '/app/i18n'
 import { useModuleUSBPort } from '/app/local-resources/modules'
@@ -62,13 +62,13 @@ export function SelectModule(props: SelectModuleProps): JSX.Element | null {
   const { t } = useTranslation('module_wizard_flows')
 
   const { parseModuleUSBPort } = useModuleUSBPort()
-  const availableModules = useGetNewModules()
+  const availableModules = useGetModulesNeedingSetupThatCanCurrentlyBeSetUp()
+  const allSettupable = useGetModulesNeedingSetup()
   const allNewModules =
     attachedModuleOnLaunch !== null
       ? [attachedModuleOnLaunch]
       : availableModules
-
-  const modulesNotRequiringPipette = allNewModules.filter(thisModule =>
+  const modulesNotRequiringPipette = availableModules.filter(thisModule =>
     ([
       ABSORBANCE_READER_TYPE,
       FLEX_STACKER_MODULE_TYPE,

--- a/app/src/organisms/ModuleWizardFlows/SelectModule.tsx
+++ b/app/src/organisms/ModuleWizardFlows/SelectModule.tsx
@@ -12,13 +12,12 @@ import {
   RESPONSIVENESS,
   SPACING,
 } from '@opentrons/components'
-import {
-  ABSORBANCE_READER_TYPE,
-  FLEX_STACKER_MODULE_TYPE,
-  getModuleDisplayName,
-} from '@opentrons/shared-data'
+import { getModuleDisplayName } from '@opentrons/shared-data'
 
-import { useGetModulesNeedingSetupThatCanCurrentlyBeSetUp } from '/app/App/hooks'
+import {
+  useGetModulesNeedingSetup,
+  useGetModulesNeedingSetupThatCanCurrentlyBeSetUp,
+} from '/app/App/hooks'
 import { SmallButton } from '/app/atoms/buttons'
 import { i18n } from '/app/i18n'
 import { useModuleUSBPort } from '/app/local-resources/modules'
@@ -31,8 +30,6 @@ import {
 import { useSendIdentifyStacker } from './hooks'
 
 import type { AttachedModule } from '@opentrons/api-client'
-import type { ModuleType } from '@opentrons/shared-data'
-import type { PipetteInformation } from '/app/redux/pipettes'
 
 interface SelectModuleProps {
   buildFlowForSelectedModule: (module: AttachedModule) => void
@@ -41,7 +38,6 @@ interface SelectModuleProps {
   setSelectedModule: (module: AttachedModule | null) => void
   setShowLaunchSetup: (show: boolean) => void
   attachedModuleOnLaunch?: AttachedModule | null
-  attachedPipette?: PipetteInformation | null
 }
 
 interface ModuleNameAndPort {
@@ -57,27 +53,18 @@ export function SelectModule(props: SelectModuleProps): JSX.Element | null {
     setSelectedModule,
     setShowLaunchSetup,
     attachedModuleOnLaunch = null,
-    attachedPipette,
   } = props
   const { t } = useTranslation('module_wizard_flows')
 
   const { parseModuleUSBPort } = useModuleUSBPort()
-  const availableModules = useGetModulesNeedingSetupThatCanCurrentlyBeSetUp()
-  const allSettupable = useGetModulesNeedingSetup()
-  const allNewModules =
-    attachedModuleOnLaunch !== null
-      ? [attachedModuleOnLaunch]
-      : availableModules
-  const modulesNotRequiringPipette = availableModules.filter(thisModule =>
-    ([
-      ABSORBANCE_READER_TYPE,
-      FLEX_STACKER_MODULE_TYPE,
-    ] as ModuleType[]).includes(thisModule.moduleType)
-  )
+  const allSetupable = useGetModulesNeedingSetupThatCanCurrentlyBeSetUp()
+  const allNeedingSetup = useGetModulesNeedingSetup()
   const newModules =
-    attachedPipette == null ? modulesNotRequiringPipette : allNewModules
-
-  const isSingleModule = newModules.length === 1
+    attachedModuleOnLaunch == null ? allSetupable : [attachedModuleOnLaunch]
+  // allNeedingSetup is a superset of allSetupable
+  const hasUnsetupabbleModules = allNeedingSetup.length > allSetupable.length
+  const isSingleModule = newModules.length === 1 && !hasUnsetupabbleModules
+  const shortCircuitFlow = attachedModuleOnLaunch != null || isSingleModule
   const sendIdentifyStacker = useSendIdentifyStacker()
 
   const getModuleNameAndPort = (module: AttachedModule): ModuleNameAndPort => {
@@ -88,11 +75,11 @@ export function SelectModule(props: SelectModuleProps): JSX.Element | null {
 
   // Handler for when there is one module
   useEffect(() => {
-    if (isSingleModule) {
+    if (shortCircuitFlow) {
       setSelectedModule(newModules[0])
       sendIdentifyStacker(newModules[0], true)
     }
-  }, [isSingleModule])
+  }, [shortCircuitFlow])
 
   // Handler for when there are multiple modules.
   const handleModuleSelected = (serialNumber: string): void => {
@@ -133,7 +120,7 @@ export function SelectModule(props: SelectModuleProps): JSX.Element | null {
   `
   if (newModules.length === 0) {
     return null
-  } else if (isSingleModule && selectedModule != null) {
+  } else if (shortCircuitFlow && selectedModule != null) {
     const m = getModuleNameAndPort(selectedModule)
     return (
       <SimpleWizardBody
@@ -183,6 +170,11 @@ export function SelectModule(props: SelectModuleProps): JSX.Element | null {
             onSelect={event => {
               handleModuleSelected(event.target.value)
             }}
+            subText={
+              hasUnsetupabbleModules
+                ? t('connect_a_pipette_to_set_up_more_modules')
+                : null
+            }
           />
         </Flex>
         <Flex css={BUTTON_STYLE}>

--- a/app/src/organisms/ModuleWizardFlows/Success.tsx
+++ b/app/src/organisms/ModuleWizardFlows/Success.tsx
@@ -14,7 +14,7 @@ import {
 } from '@opentrons/components'
 import { getModuleDisplayName } from '@opentrons/shared-data'
 
-import { useGetNewModules } from '/app/App/hooks'
+import { useGetModulesNeedingSetupThatCanCurrentlyBeSetUp } from '/app/App/hooks'
 import { SmallButton } from '/app/atoms/buttons'
 import { SimpleWizardBody } from '/app/molecules/SimpleWizardBody'
 
@@ -50,7 +50,7 @@ export function Success(props: SuccessProps): JSX.Element {
   const { t } = useTranslation('module_wizard_flows')
   const sendIdentifyStacker = useSendIdentifyStacker()
   const moduleDisplayName = getModuleDisplayName(attachedModule.moduleModel)
-  const newModules = useGetNewModules()
+  const newModules = useGetModulesNeedingSetupThatCanCurrentlyBeSetUp()
 
   const handleOnClick = (restart: boolean): void => {
     if (restart) {

--- a/app/src/organisms/ModuleWizardFlows/Success.tsx
+++ b/app/src/organisms/ModuleWizardFlows/Success.tsx
@@ -21,7 +21,7 @@ import { SimpleWizardBody } from '/app/molecules/SimpleWizardBody'
 import { useSendIdentifyStacker } from './hooks'
 
 import type { AttachedModule } from '@opentrons/api-client'
-import type { ModuleSetupWizardStepProps } from './types'
+import type { ModuleSetupWizardMaybePipetteStepProps } from './types'
 
 export const BODY_STYLE = css`
   ${TYPOGRAPHY.pRegular};
@@ -32,7 +32,7 @@ export const BODY_STYLE = css`
   }
 `
 
-interface SuccessProps extends ModuleSetupWizardStepProps {
+interface SuccessProps extends ModuleSetupWizardMaybePipetteStepProps {
   setSelectedModule: (module: AttachedModule | null) => void
   attachedModuleOnLaunch?: AttachedModule | null
 }

--- a/app/src/organisms/ModuleWizardFlows/UpdateFirmware.tsx
+++ b/app/src/organisms/ModuleWizardFlows/UpdateFirmware.tsx
@@ -24,12 +24,12 @@ import { useSendIdentifyStacker } from './hooks'
 
 import type { AttachedModule } from '@opentrons/api-client'
 import type { Dispatch, State } from '/app/redux/types'
-import type { ModuleSetupWizardStepProps } from './types'
+import type { ModuleSetupWizardMaybePipetteStepProps } from './types'
 
 const EQUIPMENT_POLL_MS = 3000
 const MODULE_TIMEOUT_MS = 60000
 const NO_UPDATE_FOUND_TIMEOUT_MS = 2000
-interface UpdateFirmwareProps extends ModuleSetupWizardStepProps {
+interface UpdateFirmwareProps extends ModuleSetupWizardMaybePipetteStepProps {
   robotName: string
   patchModuleAfterUpdate: (module: AttachedModule) => void
 }

--- a/app/src/organisms/ModuleWizardFlows/index.tsx
+++ b/app/src/organisms/ModuleWizardFlows/index.tsx
@@ -111,7 +111,6 @@ export function ModuleWizardFlows(
           setSelectedModule={setSelectedModule}
           setShowLaunchSetup={setShowLaunchSetup}
           attachedModuleOnLaunch={attachedModuleOnLaunch}
-          attachedPipette={wizardFlowBaseProps.attachedPipette}
         />
       </ModuleWizardScreen>
     )

--- a/app/src/organisms/ModuleWizardFlows/index.tsx
+++ b/app/src/organisms/ModuleWizardFlows/index.tsx
@@ -63,7 +63,6 @@ export function ModuleWizardFlows(
     buildFlowForSelectedModule,
     patchModuleAfterUpdate,
     deckConfig,
-    requirePipette,
   } = useModuleSetupWizard({ closeFlow, attachedModuleOnLaunch, onComplete })
 
   // build out flow if there is a module passed in at launch
@@ -90,7 +89,6 @@ export function ModuleWizardFlows(
 
   const doorStatus = useIsDoorOpen(robotName).isDoorOpen
 
-  if (wizardFlowBaseProps.attachedPipette == null && requirePipette) return null
   if (showLaunchSetup || wizardFlowBaseProps.attachedModule == null) {
     return (
       <ModuleWizardScreen

--- a/app/src/organisms/ModuleWizardFlows/index.tsx
+++ b/app/src/organisms/ModuleWizardFlows/index.tsx
@@ -63,6 +63,7 @@ export function ModuleWizardFlows(
     buildFlowForSelectedModule,
     patchModuleAfterUpdate,
     deckConfig,
+    requirePipette,
   } = useModuleSetupWizard({ closeFlow, attachedModuleOnLaunch, onComplete })
 
   // build out flow if there is a module passed in at launch
@@ -89,7 +90,7 @@ export function ModuleWizardFlows(
 
   const doorStatus = useIsDoorOpen(robotName).isDoorOpen
 
-  if (wizardFlowBaseProps.attachedPipette == null) return null
+  if (wizardFlowBaseProps.attachedPipette == null && requirePipette) return null
   if (showLaunchSetup || wizardFlowBaseProps.attachedModule == null) {
     return (
       <ModuleWizardScreen
@@ -112,6 +113,7 @@ export function ModuleWizardFlows(
           setSelectedModule={setSelectedModule}
           setShowLaunchSetup={setShowLaunchSetup}
           attachedModuleOnLaunch={attachedModuleOnLaunch}
+          attachedPipette={wizardFlowBaseProps.attachedPipette}
         />
       </ModuleWizardScreen>
     )
@@ -217,7 +219,7 @@ export function ModuleWizardFlows(
         </ModuleWizardScreen>
       )
     case SECTIONS.PLACE_ADAPTER:
-      return (
+      return wizardFlowBaseProps.attachedPipette == null ? null : (
         <ModuleWizardScreen
           isRobotMoving={wizardFlowBaseProps.isRobotMoving}
           isModuleUpdating={wizardFlowBaseProps.isModuleUpdating}
@@ -236,7 +238,7 @@ export function ModuleWizardFlows(
         </ModuleWizardScreen>
       )
     case SECTIONS.ATTACH_PROBE:
-      return (
+      return wizardFlowBaseProps.attachedPipette == null ? null : (
         <ModuleWizardScreen
           isRobotMoving={wizardFlowBaseProps.isRobotMoving}
           isModuleUpdating={wizardFlowBaseProps.isModuleUpdating}
@@ -255,7 +257,7 @@ export function ModuleWizardFlows(
         </ModuleWizardScreen>
       )
     case SECTIONS.DETACH_PROBE:
-      return (
+      return wizardFlowBaseProps.attachedPipette == null ? null : (
         <ModuleWizardScreen
           isRobotMoving={wizardFlowBaseProps.isRobotMoving}
           isModuleUpdating={wizardFlowBaseProps.isModuleUpdating}

--- a/app/src/organisms/ModuleWizardFlows/types.ts
+++ b/app/src/organisms/ModuleWizardFlows/types.ts
@@ -47,7 +47,7 @@ interface ModuleWizardPatchModuleAction {
   type: typeof ACTIONS.PATCH_MODULE
   attachedModule: AttachedModule
 }
-export interface ModuleSetupWizardStepProps {
+export interface ModuleSetupWizardBaseStepProps {
   proceed: () => void
   goBack: () => void
   restartSetup: () => void
@@ -60,11 +60,24 @@ export interface ModuleSetupWizardStepProps {
   setIsModuleUpdating: (updating: boolean) => void
   maintenanceRunId: string | null
   attachedModule: AttachedModule
-  attachedPipette: PipetteInformation
   errorMessage: string | null
   setErrorMessage: (message: string | null) => void
   isOnDevice: boolean
 }
+
+export interface ModuleSetupWizardRequiresPipetteStepProps
+  extends ModuleSetupWizardBaseStepProps {
+  attachedPipette: PipetteInformation
+}
+
+export interface ModuleSetupWizardMaybePipetteStepProps
+  extends ModuleSetupWizardBaseStepProps {
+  attachedPipette: PipetteInformation | null
+}
+
+export type ModuleSetupWizardStepProps =
+  | ModuleSetupWizardMaybePipetteStepProps
+  | ModuleSetupWizardRequiresPipetteStepProps
 
 export type ModuleWizardFlow = typeof FLOWS.SETUP
 

--- a/app/src/organisms/ModuleWizardFlows/useModuleSetupWizard.ts
+++ b/app/src/organisms/ModuleWizardFlows/useModuleSetupWizard.ts
@@ -2,6 +2,7 @@ import { useEffect, useReducer, useState } from 'react'
 import { useSelector } from 'react-redux'
 
 import { useDeleteMaintenanceRunMutation } from '@opentrons/react-api-client'
+import { FLEX_STACKER_MODULE_TYPE } from '@opentrons/shared-data'
 
 import { getModulePrepCommands } from '/app/local-resources/modules'
 import { getIsOnDevice } from '/app/redux/config'
@@ -58,6 +59,7 @@ export interface UseModuleSetupWizardResult {
   buildFlowForSelectedModule: (module: AttachedModule) => void
   patchModuleAfterUpdate: (module: AttachedModule) => void
   deckConfig: DeckConfiguration
+  requirePipette: boolean
 }
 
 export interface UseModuleSetupWizardParams {
@@ -262,6 +264,8 @@ export function useModuleSetupWizard(
     deckConfig,
     buildFlowForSelectedModule,
     patchModuleAfterUpdate,
+    requirePipette:
+      attachedModuleOnLaunch?.moduleType === FLEX_STACKER_MODULE_TYPE,
   }
 }
 

--- a/app/src/organisms/ModuleWizardFlows/useModuleSetupWizard.ts
+++ b/app/src/organisms/ModuleWizardFlows/useModuleSetupWizard.ts
@@ -59,7 +59,6 @@ export interface UseModuleSetupWizardResult {
   buildFlowForSelectedModule: (module: AttachedModule) => void
   patchModuleAfterUpdate: (module: AttachedModule) => void
   deckConfig: DeckConfiguration
-  requirePipette: boolean
 }
 
 export interface UseModuleSetupWizardParams {
@@ -264,8 +263,6 @@ export function useModuleSetupWizard(
     deckConfig,
     buildFlowForSelectedModule,
     patchModuleAfterUpdate,
-    requirePipette:
-      attachedModuleOnLaunch?.moduleType === FLEX_STACKER_MODULE_TYPE,
   }
 }
 

--- a/app/src/organisms/ModuleWizardFlows/useModuleSetupWizard.ts
+++ b/app/src/organisms/ModuleWizardFlows/useModuleSetupWizard.ts
@@ -2,7 +2,6 @@ import { useEffect, useReducer, useState } from 'react'
 import { useSelector } from 'react-redux'
 
 import { useDeleteMaintenanceRunMutation } from '@opentrons/react-api-client'
-import { FLEX_STACKER_MODULE_TYPE } from '@opentrons/shared-data'
 
 import { getModulePrepCommands } from '/app/local-resources/modules'
 import { getIsOnDevice } from '/app/redux/config'


### PR DESCRIPTION
We want to allow module setup flows when there aren't pipettes attached, if the module can be setup without pipettes. Which is some of them, some of the time, from 3 different places.

Closes RQA-4481

The new behavior applies to stackers and to absorbance readers, since neither requires a pipette for setup.

The new behavior should be:
- On the desktop app, stacker/reader modules that are not currently in the deck config should get the setup banner even if no pipette is attached
- On the desktop app, clicking a stacker's setup banner should launch you into setup module, which should be completeable all the way through, even if no pipette is attached
- On the ODD, if either (a) at the time the system boots a stacker/reader is present and not in the deck config or (b) a stacker/reader is newly plugged in after boot and not in the deck config (removing a stacker from the deck config will not trigger this) you should get the blue new-module-connected banner, even if there's no pipette
- On the ODD, the module setup wizard should prompt only modules that both need to be can currently be set up - so, even if there is a heater/shaker that needs calibration, if you don't have a pipette it shouldn't appear in the menu, but stackers and readers should always appear
- When you run out of modules that can currently be calibrated, the flow should be the same as if you set up all the modules