### PR TITLE
fix(app): Intervention modal map rendering stacker and labware incorrectly

### DIFF
--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useDeckMapUtils.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useDeckMapUtils.ts
@@ -3,9 +3,11 @@ import { useMemo } from 'react'
 import { getLabwareLocation } from '@opentrons/components'
 import {
   FLEX_ROBOT_TYPE,
+  FLEX_STACKER_MODULE_TYPE,
   getDeckDefFromRobotType,
   getFixedTrashLabwareDefinition,
   getModuleDef,
+  getModuleType,
   getPositionFromSlotId,
   getSimplestDeckConfigForProtocol,
   OT2_ROBOT_TYPE,
@@ -495,9 +497,13 @@ export function updateLabwareInModules({
 } {
   const usedSlots = new Set<string>()
 
+  // a flex stackers module location will be in slot 3, but labware in that slot
+  // is not nested on the stacker so we shouldn't match those up
   const updatedModules = runCurrentModules.map(moduleInfo => {
     const labwareInSameLoc = currentLabwareInfo.find(
-      lw => moduleInfo.moduleLocation.slotName === lw.slotName
+      lw =>
+        moduleInfo.moduleLocation.slotName === lw.slotName &&
+        getModuleType(moduleInfo.moduleModel) !== FLEX_STACKER_MODULE_TYPE
     )
 
     if (labwareInSameLoc != null) {

--- a/app/src/organisms/ErrorRecoveryFlows/shared/TwoColLwInfoAndDeck.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/TwoColLwInfoAndDeck.tsx
@@ -4,10 +4,8 @@ import {
   COLORS,
   Flex,
   LabwareRender,
-  Module,
   MoveLabwareOnDeck,
 } from '@opentrons/components'
-import { inferModuleOrientationFromXCoordinate } from '@opentrons/shared-data'
 
 import { DeckMapContent, TwoColumn } from '/app/molecules/InterventionModal'
 
@@ -133,6 +131,18 @@ export function TwoColLwInfoAndDeck(
         const isValidDeck =
           currentLoc != null && newLoc != null && movedLabwareDef != null
 
+        const modulesOnDeck = moduleRenderInfo
+          ?.filter(module => module.targetSlotId != null)
+          .map(module => {
+            return {
+              moduleModel: module.moduleDef.model,
+              moduleLocation: { slotName: module.targetSlotId ?? '' },
+              nestedLabwareDef:
+                module.nestedLabwareId !== failedLwId
+                  ? module.nestedLabwareDef
+                  : null,
+            }
+          })
         return isValidDeck ? (
           <MoveLabwareOnDeck
             deckFill={isOnDevice ? COLORS.grey35 : '#e6e6e6'}
@@ -141,39 +151,9 @@ export function TwoColLwInfoAndDeck(
             movedLabwareDef={movedLabwareDef}
             labwareDefinitions={allRunDefs}
             {...restUtils}
+            modulesOnDeck={modulesOnDeck}
             backgroundItems={
               <>
-                {moduleRenderInfo.map(
-                  ({
-                    x,
-                    y,
-                    moduleId,
-                    moduleDef,
-                    nestedLabwareDef,
-                    nestedLabwareId,
-                    targetDeckId,
-                    targetSlotId,
-                  }) => (
-                    <Module
-                      key={moduleId}
-                      def={moduleDef}
-                      x={x}
-                      y={y}
-                      orientation={inferModuleOrientationFromXCoordinate(x)}
-                      targetDeckId={targetDeckId}
-                      targetSlotId={targetSlotId}
-                      childrenPositioningMode="offsetToSlot"
-                    >
-                      {nestedLabwareDef != null &&
-                      nestedLabwareId !== failedLwId ? (
-                        <LabwareRender
-                          definition={nestedLabwareDef}
-                          positioningMode="offsetInSlot"
-                        />
-                      ) : null}
-                    </Module>
-                  )
-                )}
                 {labwareRenderInfo
                   .filter(l => l.labwareId !== failedLwId)
                   .map(({ labwareOrigin, labwareDef, labwareId }) => (

--- a/app/src/organisms/ErrorRecoveryFlows/shared/__tests__/TwoColLwInfoAndDeck.test.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/__tests__/TwoColLwInfoAndDeck.test.tsx
@@ -202,8 +202,8 @@ describe('TwoColLwInfoAndDeck', () => {
     props.currentRecoveryOptionUtils.selectedRecoveryOption =
       RECOVERY_MAP.MANUAL_MOVE_AND_SKIP.ROUTE
     props.deckMapUtils = {
-      movedLabwareDef: null,
-      moduleRenderInfo: null,
+      currentLoc: null,
+      newLoc: null,
       labwareRenderInfo: null,
     } as any
 

--- a/app/src/organisms/InterventionModal/MoveLabwareInterventionContent.tsx
+++ b/app/src/organisms/InterventionModal/MoveLabwareInterventionContent.tsx
@@ -15,7 +15,6 @@ import {
   Icon,
   LabwareRender,
   LegacyStyledText,
-  Module,
   MoveLabwareOnDeck,
   RESPONSIVENESS,
   SPACING,
@@ -27,7 +26,6 @@ import {
   getLoadedLabwareDefinitionsByUri,
   getModuleType,
   GRIPPER_WASTE_CHUTE_ADDRESSABLE_AREA,
-  inferModuleOrientationFromXCoordinate,
   OT2_ROBOT_TYPE,
   TC_MODULE_LOCATION_OT2,
   TC_MODULE_LOCATION_OT3,
@@ -124,16 +122,29 @@ export function MoveLabwareInterventionContent({
   const deckDef = getDeckDefFromRobotType(robotType)
   const deckConfig = useNotifyDeckConfigurationQuery().data ?? []
 
-  const moduleRenderInfo = getRunModuleRenderInfo(
-    run,
-    deckDef,
-    labwareDefsByUri
-  )
   const labwareRenderInfo = getRunLabwareRenderInfo(
     run,
     labwareDefsByUri,
     deckDef
   )
+  const moduleRenderInfo = getRunModuleRenderInfo(
+    run,
+    deckDef,
+    labwareDefsByUri
+  )
+  const modulesOnDeck = moduleRenderInfo
+    ?.filter(module => module.targetSlotId != null)
+    .map(module => {
+      return {
+        moduleModel: module.moduleDef.model,
+        moduleLocation: { slotName: module.targetSlotId ?? '' },
+        nestedLabwareDef:
+          module.nestedLabwareId !== command.params.labwareId
+            ? module.nestedLabwareDef
+            : null,
+      }
+    })
+
   const oldLabwareLocation =
     getLoadedLabware(run.labware, command.params.labwareId)?.location ?? null
 
@@ -202,39 +213,9 @@ export function MoveLabwareInterventionContent({
               loadedModules={run.modules}
               loadedLabware={run.labware}
               deckConfig={deckConfig}
+              modulesOnDeck={modulesOnDeck}
               backgroundItems={
                 <>
-                  {moduleRenderInfo.map(
-                    ({
-                      x,
-                      y,
-                      moduleId,
-                      moduleDef,
-                      nestedLabwareDef,
-                      nestedLabwareId,
-                      targetDeckId,
-                      targetSlotId,
-                    }) => (
-                      <Module
-                        key={moduleId}
-                        def={moduleDef}
-                        x={x}
-                        y={y}
-                        orientation={inferModuleOrientationFromXCoordinate(x)}
-                        targetDeckId={targetDeckId}
-                        targetSlotId={targetSlotId}
-                        childrenPositioningMode="offsetToSlot"
-                      >
-                        {nestedLabwareDef != null &&
-                        nestedLabwareId !== command.params.labwareId ? (
-                          <LabwareRender
-                            definition={nestedLabwareDef}
-                            positioningMode="offsetInSlot"
-                          />
-                        ) : null}
-                      </Module>
-                    )
-                  )}
                   {labwareRenderInfo
                     .filter(l => l.labwareId !== command.params.labwareId)
                     .map(({ labwareOrigin, labwareDef, labwareId }) => (

--- a/components/src/hardware-sim/Deck/MoveLabwareOnDeck.tsx
+++ b/components/src/hardware-sim/Deck/MoveLabwareOnDeck.tsx
@@ -24,6 +24,7 @@ import type {
   RobotType,
   Vector3D,
 } from '@opentrons/shared-data'
+import type { ModuleOnDeck } from '../../hardware-sim/BaseDeck'
 import type { StyleProps } from '../../primitives'
 
 const SPLASH_Y_BUFFER_MM = 10
@@ -35,6 +36,7 @@ interface MoveLabwareOnDeckProps extends StyleProps {
   finalLabwareLocation: LabwareLocation
   loadedModules: LoadedModule[]
   loadedLabware: LoadedLabware[]
+  modulesOnDeck?: ModuleOnDeck[]
   labwareDefinitions: LabwareDefinition[]
   deckConfig: DeckConfiguration
   backgroundItems?: ReactNode
@@ -47,6 +49,7 @@ export function MoveLabwareOnDeck(
     robotType,
     movedLabwareDef,
     loadedLabware,
+    modulesOnDeck,
     labwareDefinitions,
     initialLabwareLocation,
     finalLabwareLocation,
@@ -137,6 +140,7 @@ export function MoveLabwareOnDeck(
     <BaseDeck
       deckConfig={deckConfig}
       robotType={robotType}
+      modulesOnDeck={modulesOnDeck}
       svgProps={{
         style: { opacity: springProps.deckOpacity },
         ...styleProps,


### PR DESCRIPTION
fix RQA-4427, RABR-815
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
`BaseDeck` has special casing for stackers to position them in the 4th column instead of the 3rd. A few of the intervention modal deck maps were bypassing this by passing in modules independently, so I changed that logic.
Additionally, there is some special cased logic in the position labware error recovery deck map to render labware that is in the same "slot" as a module on top of that module. For stackers, their "slot" is in column 3 but labware on column 3 is not on the stacker so we have to except stackers from this logic.
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
Run through some error recovery flows that are unrelated to stacker errors but where there are stackers in the deck map. Ensure the stackers are rendered in the proper location and column 3 labware is situated in column 3.
I've confirmed this works for the move labware case!
<img width="791" height="402" alt="Screenshot 2025-08-08 at 10 32 32 AM" src="https://github.com/user-attachments/assets/a0bebae6-02fc-40dd-88f7-3d72fe9c2b01" />


<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
1. Pass modules into the move labware deck map via `modulesOnDeck` instead of the `backgroundItems` prop
2. Don't add labware in third column to `nestedLabwareDef` field for stackers in the same column

<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests
Test it out if you can!
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
Low --> this may not fix all of the issues with these deck maps but is an improvement and fixes the issues listed above!
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
