### PR TITLE
fix(protocol-designer): scroll to bottom of SelectBasics in onboarding

### DIFF
--- a/protocol-designer/src/pages/Onboarding/SelectBasics.tsx
+++ b/protocol-designer/src/pages/Onboarding/SelectBasics.tsx
@@ -107,7 +107,13 @@ export function SelectBasics(props: WizardTileProps): JSX.Element {
 
   useEffect(() => {
     handleScrollToBottom()
-  }, [hasGripper, hasThermocycer, hasWasteChute, selectedPipetteName])
+  }, [
+    hasGripper,
+    hasThermocycer,
+    hasWasteChute,
+    selectedPipetteName,
+    robotType,
+  ])
 
   const handleSwapMounts = (): void => {
     const leftPipetteName = pipettesByMount.left.pipetteName
@@ -393,11 +399,7 @@ export function SelectBasics(props: WizardTileProps): JSX.Element {
             </>
           ) : null}
           {robotType === FLEX_ROBOT_TYPE && !noPipette && (
-            <Flex
-              flexDirection={DIRECTION_COLUMN}
-              gridGap={SPACING.spacing60}
-              ref={ref}
-            >
+            <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing60}>
               <BasicsButtons
                 type="gripper"
                 subHeader={t('some_modules_require_gripper')}
@@ -434,6 +436,8 @@ export function SelectBasics(props: WizardTileProps): JSX.Element {
               ) : null}
             </Flex>
           )}
+          {/* empty div for scrolling to bottom on form changes */}
+          <div ref={ref} />
         </WizardBody>
       </HandleEnter>
     </>


### PR DESCRIPTION
# Overview

Ensure scroll to bottom of scrollable basics selection container on any form change (useful for small or highly zoomed in screens)

Accidentally targeted `edge` in #19165 

Closes RQA-4507

https://github.com/user-attachments/assets/bb2b9acb-f0ab-4f01-9936-2f1ca61b13f2


## Test Plan and Hands on Testing

- start PD onboarding and land on Step 1: Basics
- shrink your window and/or zoom in such that the wizard body is scrollable
- begin selecting your robot type and other fields
- verify that with each form change, you are auto-scrolled to the bottom of the wizard body, to ensure the next selection is visible

## Changelog

- add empty `div` to bottom of container for scrolling
- add `robotType` to `useEffect` dependency array

## Review requests

see test plan

## Risk assessment

low