### PR TITLE
chore(release): add 8.6.0 release notes placeholder

### DIFF
--- a/api/release-notes-internal.md
+++ b/api/release-notes-internal.md
@@ -2,7 +2,7 @@ For more details about this release, please see the full [technical change log][
 
 [technical change log]: https://github.com/Opentrons/opentrons/releases
 
-## Internal Release 2.6.0-alpha.0
+## Internal Release 2.6.0-alpha.*
 
 This internal release, pulled from the `edge` branch, contains features being developed for 8.6.0. It's for internal testing only.
 

--- a/api/release-notes.md
+++ b/api/release-notes.md
@@ -8,6 +8,12 @@ By installing and using Opentrons software, you agree to the Opentrons End-User 
 
 ---
 
+## Opentrons Robot Software Changes in 8.6.0
+
+### TODO
+
+---
+
 ## Opentrons Robot Software Changes in 8.5.1
 
 The 8.5.1 hotfix release fixes these bugs:

--- a/app-shell/build/release-notes-internal.md
+++ b/app-shell/build/release-notes-internal.md
@@ -1,7 +1,7 @@
 For more details about this release, please see the full [technical changelog][].
 [technical change log]: https://github.com/Opentrons/opentrons/releases
 
-## Internal Release 2.6.0-alpha.0
+## Internal Release 2.6.0-alpha.*
 
 This internal release, pulled from the `edge` branch, contains features being developed for 8.6.0. It's for internal testing only.
 

--- a/app-shell/build/release-notes.md
+++ b/app-shell/build/release-notes.md
@@ -8,6 +8,12 @@ By installing and using Opentrons software, you agree to the Opentrons End-User 
 
 ---
 
+## Opentrons App Changes in 8.6.0
+
+### TODO
+
+---
+
 ## Opentrons App Changes in 8.5.1
 
 Welcome to the v8.5.1 release of the Opentrons App!


### PR DESCRIPTION
## Overview

Release notes placeholder for 8.6.0 and update to internal release notes to more accurately represent all the alphas we did.