### PR TITLE
fix(app): align column numbers in deck config

### DIFF
--- a/components/src/hardware-sim/Deck/SlotLabels.tsx
+++ b/components/src/hardware-sim/Deck/SlotLabels.tsx
@@ -40,6 +40,9 @@ export const SlotLabels = ({
   const simpleItemWidthStyle: Record<string, string> = {
     '--dynamic-width': `${widthLargeRem}rem`,
   }
+  const smallItemWidthStyle: Record<string, string> = {
+    '--dynamic-width': `${widthSmallRem}rem`,
+  }
   const nextTo4thWidthStyle: Record<string, string> = {
     '--dynamic-width': itemDynamicWidth,
   }
@@ -88,7 +91,7 @@ export const SlotLabels = ({
           </div>
           <div
             className={styles.deck_label_row_container}
-            style={simpleItemWidthStyle}
+            style={smallItemWidthStyle}
           >
             <DeckInfoLabel deckLabel="2" height="100%" />
           </div>


### PR DESCRIPTION
# Overview

closes https://opentrons.atlassian.net/browse/RQA-4499.
aligne column numbers in deck config.

## Test Plan and Hands on Testing

make sure all views of deck config (OT-2 and FLEX) column numbers are aligned. 

<img width="778" height="477" alt="Screenshot 2025-08-08 at 4 28 32 PM" src="https://github.com/user-attachments/assets/25867bd3-8092-4120-88ed-9396a8b72f68" />

<img width="756" height="432" alt="Screenshot 2025-08-08 at 4 26 48 PM" src="https://github.com/user-attachments/assets/de7fac2f-5026-43c7-aba2-82833ea4ad92" />

## Risk assessment

low. 