### PR TITLE
fix(api, app): add moveStrategy as a store command param so we can recover from a stacker error  

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/module_core.py
+++ b/api/src/opentrons/protocol_api/core/engine/module_core.py
@@ -24,6 +24,7 @@ from opentrons.protocol_engine.types import (
     ABSMeasureMode,
     StackerFillEmptyStrategy,
     StackerStoredLabwareGroup,
+    StackerLabwareMovementStrategy,
 )
 from opentrons.types import DeckSlotName
 from opentrons.protocol_engine.clients import SyncClient as ProtocolEngineClient
@@ -747,6 +748,7 @@ class FlexStackerCore(ModuleCore, AbstractFlexStackerCore[LabwareCore]):
         self._engine_client.execute_command(
             cmd.flex_stacker.StoreParams(
                 moduleId=self.module_id,
+                strategy=StackerLabwareMovementStrategy.AUTOMATIC,
             )
         )
 

--- a/api/src/opentrons/protocol_engine/commands/flex_stacker/store.py
+++ b/api/src/opentrons/protocol_engine/commands/flex_stacker/store.py
@@ -59,6 +59,13 @@ class StoreParams(BaseModel):
         ...,
         description="Unique ID of the flex stacker.",
     )
+    manualMove: bool | SkipJsonSchema[None] = Field(
+        None,
+        description=(
+            "If true, indicates that the store action is being performed manually, "
+            "as done in error recovery, without moving the stacker hardware."
+        ),
+    )
 
 
 class StoreResult(BaseModel):
@@ -201,42 +208,44 @@ class StoreImpl(AbstractCommandImpl[StoreParams, _ExecuteReturn]):
         stacker_hw = self._equipment.get_module_hardware_api(stacker_state.module_id)
 
         state_update = update_types.StateUpdate()
-        try:
-            if stacker_hw is not None:
-                stacker_hw.set_stacker_identify(True)
-                await stacker_hw.store_labware(
-                    labware_height=stacker_state.get_pool_height_minus_overlap()
+
+        if stacker_hw is None and not params.manualMove:
+            try:
+                if stacker_hw is not None:
+                    stacker_hw.set_stacker_identify(True)
+                    await stacker_hw.store_labware(
+                        labware_height=stacker_state.get_pool_height_minus_overlap()
+                    )
+            except FlexStackerStallError as e:
+                return DefinedErrorData(
+                    public=FlexStackerStallOrCollisionError(
+                        id=self._model_utils.generate_id(),
+                        createdAt=self._model_utils.get_timestamp(),
+                        wrappedErrors=[
+                            ErrorOccurrence.from_failed(
+                                id=self._model_utils.generate_id(),
+                                createdAt=self._model_utils.get_timestamp(),
+                                error=e,
+                            )
+                        ],
+                        errorInfo={"labwareId": primary_id},
+                    ),
                 )
-        except FlexStackerStallError as e:
-            return DefinedErrorData(
-                public=FlexStackerStallOrCollisionError(
-                    id=self._model_utils.generate_id(),
-                    createdAt=self._model_utils.get_timestamp(),
-                    wrappedErrors=[
-                        ErrorOccurrence.from_failed(
-                            id=self._model_utils.generate_id(),
-                            createdAt=self._model_utils.get_timestamp(),
-                            error=e,
-                        )
-                    ],
-                    errorInfo={"labwareId": primary_id},
-                ),
-            )
-        except FlexStackerShuttleMissingError as e:
-            return DefinedErrorData(
-                public=FlexStackerShuttleError(
-                    id=self._model_utils.generate_id(),
-                    createdAt=self._model_utils.get_timestamp(),
-                    wrappedErrors=[
-                        ErrorOccurrence.from_failed(
-                            id=self._model_utils.generate_id(),
-                            createdAt=self._model_utils.get_timestamp(),
-                            error=e,
-                        )
-                    ],
-                    errorInfo={"labwareId": primary_id},
-                ),
-            )
+            except FlexStackerShuttleMissingError as e:
+                return DefinedErrorData(
+                    public=FlexStackerShuttleError(
+                        id=self._model_utils.generate_id(),
+                        createdAt=self._model_utils.get_timestamp(),
+                        wrappedErrors=[
+                            ErrorOccurrence.from_failed(
+                                id=self._model_utils.generate_id(),
+                                createdAt=self._model_utils.get_timestamp(),
+                                error=e,
+                            )
+                        ],
+                        errorInfo={"labwareId": primary_id},
+                    ),
+                )
 
         id_list = [
             id for id in (primary_id, maybe_adapter_id, maybe_lid_id) if id is not None
@@ -273,7 +282,7 @@ class StoreImpl(AbstractCommandImpl[StoreParams, _ExecuteReturn]):
             ),
         )
 
-        if stacker_hw is not None:
+        if stacker_hw is not None and not params.manualMove:
             stacker_hw.set_stacker_identify(False)
 
         return SuccessData(

--- a/api/src/opentrons/protocol_engine/commands/flex_stacker/store.py
+++ b/api/src/opentrons/protocol_engine/commands/flex_stacker/store.py
@@ -60,8 +60,8 @@ class StoreParams(BaseModel):
         ...,
         description="Unique ID of the flex stacker.",
     )
-    moveStrategy: StackerLabwareMovementStrategy | SkipJsonSchema[None] = Field(
-        StackerLabwareMovementStrategy.AUTOMATIC,
+    strategy: StackerLabwareMovementStrategy = Field(
+        ...,
         description=(
             "If manual, indicates that labware has been moved to the hopper "
             "manually by the user, as required in error recovery."
@@ -213,7 +213,7 @@ class StoreImpl(AbstractCommandImpl[StoreParams, _ExecuteReturn]):
             stacker_hw.set_stacker_identify(True)
 
         if (
-            params.moveStrategy is StackerLabwareMovementStrategy.AUTOMATIC
+            params.strategy is StackerLabwareMovementStrategy.AUTOMATIC
             and stacker_hw is not None
         ):
             try:

--- a/api/src/opentrons/protocol_engine/commands/flex_stacker/store.py
+++ b/api/src/opentrons/protocol_engine/commands/flex_stacker/store.py
@@ -208,14 +208,14 @@ class StoreImpl(AbstractCommandImpl[StoreParams, _ExecuteReturn]):
         stacker_hw = self._equipment.get_module_hardware_api(stacker_state.module_id)
 
         state_update = update_types.StateUpdate()
+        if stacker_hw is not None:
+            stacker_hw.set_stacker_identify(True)
 
-        if stacker_hw is None and not params.manualMove:
+        if not params.manualMove and stacker_hw is not None:
             try:
-                if stacker_hw is not None:
-                    stacker_hw.set_stacker_identify(True)
-                    await stacker_hw.store_labware(
-                        labware_height=stacker_state.get_pool_height_minus_overlap()
-                    )
+                await stacker_hw.store_labware(
+                    labware_height=stacker_state.get_pool_height_minus_overlap()
+                )
             except FlexStackerStallError as e:
                 return DefinedErrorData(
                     public=FlexStackerStallOrCollisionError(
@@ -282,7 +282,7 @@ class StoreImpl(AbstractCommandImpl[StoreParams, _ExecuteReturn]):
             ),
         )
 
-        if stacker_hw is not None and not params.manualMove:
+        if stacker_hw is not None:
             stacker_hw.set_stacker_identify(False)
 
         return SuccessData(

--- a/api/src/opentrons/protocol_engine/commands/flex_stacker/store.py
+++ b/api/src/opentrons/protocol_engine/commands/flex_stacker/store.py
@@ -41,6 +41,7 @@ from ...types import (
     InStackerHopperLocation,
     StackerStoredLabwareGroup,
     ModuleLocation,
+    StackerLabwareMovementStrategy,
 )
 
 if TYPE_CHECKING:
@@ -59,11 +60,11 @@ class StoreParams(BaseModel):
         ...,
         description="Unique ID of the flex stacker.",
     )
-    manualMove: bool | SkipJsonSchema[None] = Field(
-        None,
+    moveStrategy: StackerLabwareMovementStrategy | SkipJsonSchema[None] = Field(
+        StackerLabwareMovementStrategy.AUTOMATIC,
         description=(
-            "If true, indicates that the store action is being performed manually, "
-            "as done in error recovery, without moving the stacker hardware."
+            "If manual, indicates that labware has been moved to the hopper "
+            "manually by the user, as required in error recovery."
         ),
     )
 
@@ -211,7 +212,10 @@ class StoreImpl(AbstractCommandImpl[StoreParams, _ExecuteReturn]):
         if stacker_hw is not None:
             stacker_hw.set_stacker_identify(True)
 
-        if not params.manualMove and stacker_hw is not None:
+        if (
+            params.moveStrategy is StackerLabwareMovementStrategy.AUTOMATIC
+            and stacker_hw is not None
+        ):
             try:
                 await stacker_hw.store_labware(
                     labware_height=stacker_state.get_pool_height_minus_overlap()

--- a/api/src/opentrons/protocol_engine/types/__init__.py
+++ b/api/src/opentrons/protocol_engine/types/__init__.py
@@ -68,6 +68,7 @@ from .module import (
     ModuleOffsetData,
     StackerFillEmptyStrategy,
     StackerStoredLabwareGroup,
+    StackerLabwareMovementStrategy,
 )
 from .location import (
     DeckSlotLocation,
@@ -212,6 +213,7 @@ __all__ = [
     "ModuleOffsetData",
     "StackerFillEmptyStrategy",
     "StackerStoredLabwareGroup",
+    "StackerLabwareMovementStrategy",
     # Locations of things on deck
     "DeckSlotLocation",
     "StagingSlotLocation",

--- a/api/src/opentrons/protocol_engine/types/module.py
+++ b/api/src/opentrons/protocol_engine/types/module.py
@@ -276,6 +276,13 @@ class StackerFillEmptyStrategy(str, Enum):
     LOGICAL = "logical"
 
 
+class StackerLabwareMovementStrategy(str, Enum):
+    """Strategy to retrieve or store labware."""
+
+    AUTOMATIC = "automatic"
+    MANUAL = "manual"
+
+
 class StackerStoredLabwareGroup(BaseModel):
     """Represents one group of labware stored in a stacker hopper."""
 

--- a/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_store.py
+++ b/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_store.py
@@ -444,6 +444,7 @@ async def test_store_raises_if_labware_does_not_match(
         await subject.execute(data)
 
 
+@pytest.mark.parametrize("manual_move", [False, True])
 async def test_store(
     decoy: Decoy,
     state_view: StateView,
@@ -452,9 +453,10 @@ async def test_store(
     subject: StoreImpl,
     stacker_hardware: FlexStacker,
     flex_50uL_tiprack: LabwareDefinition,
+    manual_move: bool,
 ) -> None:
     """It should store the labware on the stack."""
-    data = flex_stacker.StoreParams(moduleId=stacker_id)
+    data = flex_stacker.StoreParams(moduleId=stacker_id, manualMove=manual_move)
 
     fs_module_substate = FlexStackerSubState(
         module_id=stacker_id,
@@ -513,7 +515,11 @@ async def test_store(
 
     result = await subject.execute(data)
 
-    decoy.verify(await stacker_hardware.store_labware(labware_height=4), times=1)
+    decoy.verify(
+        await stacker_hardware.store_labware(labware_height=4),
+        times=1 if not manual_move else 0,
+    )
+
     assert result == SuccessData(
         public=flex_stacker.StoreResult(
             primaryOriginLocationSequence=[

--- a/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_store.py
+++ b/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_store.py
@@ -84,7 +84,9 @@ async def test_store_raises_if_full(
     flex_50uL_tiprack: LabwareDefinition,
 ) -> None:
     """It should raise if called when the stacker is full."""
-    data = flex_stacker.StoreParams(moduleId=stacker_id)
+    data = flex_stacker.StoreParams(
+        moduleId=stacker_id, strategy=StackerLabwareMovementStrategy.AUTOMATIC
+    )
 
     fs_module_substate = FlexStackerSubState(
         module_id=stacker_id,
@@ -115,7 +117,9 @@ async def test_store_raises_if_carriage_logically_empty(
     flex_50uL_tiprack: LabwareDefinition,
 ) -> None:
     """It should raise if called with a known-empty carriage."""
-    data = flex_stacker.StoreParams(moduleId=stacker_id)
+    data = flex_stacker.StoreParams(
+        moduleId=stacker_id, strategy=StackerLabwareMovementStrategy.AUTOMATIC
+    )
 
     fs_module_substate = FlexStackerSubState(
         module_id=stacker_id,
@@ -158,7 +162,9 @@ async def test_store_raises_if_not_configured(
     stacker_id: FlexStackerId,
 ) -> None:
     """It should raise if called before the stacker is configured."""
-    data = flex_stacker.StoreParams(moduleId=stacker_id)
+    data = flex_stacker.StoreParams(
+        moduleId=stacker_id, strategy=StackerLabwareMovementStrategy.AUTOMATIC
+    )
     fs_module_substate = FlexStackerSubState(
         module_id=stacker_id,
         pool_primary_definition=None,
@@ -211,7 +217,9 @@ async def test_store_raises_if_stall(
     ],
 ) -> None:
     """It should raise a stall error."""
-    data = flex_stacker.StoreParams(moduleId=stacker_id)
+    data = flex_stacker.StoreParams(
+        moduleId=stacker_id, strategy=StackerLabwareMovementStrategy.AUTOMATIC
+    )
     error_id = "error-id"
     error_timestamp = datetime(year=2020, month=1, day=2)
 
@@ -386,7 +394,9 @@ async def test_store_raises_if_labware_does_not_match(
     param_lid: LabwareDefinition | None,
 ) -> None:
     """It should raise if the labware to be stored does not match the labware pool parameters."""
-    data = flex_stacker.StoreParams(moduleId=stacker_id)
+    data = flex_stacker.StoreParams(
+        moduleId=stacker_id, strategy=StackerLabwareMovementStrategy.AUTOMATIC
+    )
 
     fs_module_substate = FlexStackerSubState(
         module_id=stacker_id,
@@ -460,7 +470,7 @@ async def test_store(
     move_strategy: StackerLabwareMovementStrategy,
 ) -> None:
     """It should store the labware on the stack."""
-    data = flex_stacker.StoreParams(moduleId=stacker_id, moveStrategy=move_strategy)
+    data = flex_stacker.StoreParams(moduleId=stacker_id, strategy=move_strategy)
 
     fs_module_substate = FlexStackerSubState(
         module_id=stacker_id,

--- a/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_store.py
+++ b/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_store.py
@@ -37,6 +37,7 @@ from opentrons.protocol_engine.types import (
     InStackerHopperLocation,
     OnCutoutFixtureLocationSequenceComponent,
     StackerStoredLabwareGroup,
+    StackerLabwareMovementStrategy,
 )
 from opentrons.protocol_engine.errors import (
     CannotPerformModuleAction,
@@ -444,7 +445,10 @@ async def test_store_raises_if_labware_does_not_match(
         await subject.execute(data)
 
 
-@pytest.mark.parametrize("manual_move", [False, True])
+@pytest.mark.parametrize(
+    "move_strategy",
+    [StackerLabwareMovementStrategy.AUTOMATIC, StackerLabwareMovementStrategy.MANUAL],
+)
 async def test_store(
     decoy: Decoy,
     state_view: StateView,
@@ -453,10 +457,10 @@ async def test_store(
     subject: StoreImpl,
     stacker_hardware: FlexStacker,
     flex_50uL_tiprack: LabwareDefinition,
-    manual_move: bool,
+    move_strategy: StackerLabwareMovementStrategy,
 ) -> None:
     """It should store the labware on the stack."""
-    data = flex_stacker.StoreParams(moduleId=stacker_id, manualMove=manual_move)
+    data = flex_stacker.StoreParams(moduleId=stacker_id, moveStrategy=move_strategy)
 
     fs_module_substate = FlexStackerSubState(
         module_id=stacker_id,
@@ -517,7 +521,7 @@ async def test_store(
 
     decoy.verify(
         await stacker_hardware.store_labware(labware_height=4),
-        times=1 if not manual_move else 0,
+        times=1 if move_strategy == StackerLabwareMovementStrategy.AUTOMATIC else 0,
     )
 
     assert result == SuccessData(

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useRecoveryCommands.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useRecoveryCommands.ts
@@ -558,7 +558,7 @@ const buildManualStore = (
     commandType: 'flexStacker/store',
     params: {
       moduleId: storeCommand.params.moduleId,
-      manualMove: true,
+      strategy: 'manual',
     },
     intent: 'fixit',
   }

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useRecoveryCommands.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useRecoveryCommands.ts
@@ -24,6 +24,8 @@ import type {
   CreateCommand,
   DispenseInPlaceRunTimeCommand,
   DropTipInPlaceRunTimeCommand,
+  FlexStackerRetrieveRunTimeCommand,
+  FlexStackerStoreRunTimeCommand,
   LoadedLabware,
   MoveLabwareParams,
   MoveToCoordinatesCreateCommand,
@@ -85,6 +87,8 @@ export interface UseRecoveryCommandsResult {
   homeShuttle: () => Promise<CommandData[]>
   /* A non-terminal recovery-command */
   manualRetrieve: () => Promise<CommandData[]>
+  /* A non-terminal recovery-command */
+  manualStore: () => Promise<CommandData[]>
 }
 
 // TODO(jh, 07-24-24): Create tighter abstractions for terminal vs. non-terminal commands.
@@ -416,6 +420,17 @@ export function useRecoveryCommands({
     }
   }, [chainRunRecoveryCommands, unvalidatedFailedCommand])
 
+  const manualStore = useCallback((): Promise<CommandData[]> => {
+    const manualStoreCommand = buildManualStore(unvalidatedFailedCommand)
+    if (manualStoreCommand == null) {
+      return reportAndRouteFailedCmd(
+        new Error('Invalid use of manual store command')
+      )
+    } else {
+      return chainRunRecoveryCommands([manualStoreCommand])
+    }
+  }, [chainRunRecoveryCommands, unvalidatedFailedCommand])
+
   const moveLabwareWithoutPause = useCallback((): Promise<CommandData[]> => {
     const moveLabwareCmd = buildMoveLabwareWithoutPause(
       unvalidatedFailedCommand
@@ -443,6 +458,7 @@ export function useRecoveryCommands({
     homeAll,
     homeShuttle,
     manualRetrieve,
+    manualStore,
     closeLabwareLatch,
     releaseLabwareLatch,
   }
@@ -521,15 +537,28 @@ const buildManualRetrieve = (
   if (failedCommand == null) {
     return null
   }
-  const storeOrRetriveFailedCommandParams = failedCommand.params
-  const moduleId =
-    'moduleId' in storeOrRetriveFailedCommandParams
-      ? storeOrRetriveFailedCommandParams.moduleId
-      : ''
+  const retrieveCommand = failedCommand as FlexStackerRetrieveRunTimeCommand
   return {
     commandType: 'unsafe/flexStacker/manualRetrieve',
     params: {
-      moduleId: moduleId,
+      moduleId: retrieveCommand.params.moduleId,
+    },
+    intent: 'fixit',
+  }
+}
+
+const buildManualStore = (
+  failedCommand: FailedCommand | null
+): CreateCommand | null => {
+  if (failedCommand == null) {
+    return null
+  }
+  const storeCommand = failedCommand as FlexStackerStoreRunTimeCommand
+  return {
+    commandType: 'flexStacker/store',
+    params: {
+      moduleId: storeCommand.params.moduleId,
+      manualMove: true,
     },
     intent: 'fixit',
   }

--- a/app/src/organisms/ErrorRecoveryFlows/shared/SkipStepInfo.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/SkipStepInfo.tsx
@@ -9,6 +9,7 @@ import type { RecoveryContentProps } from '../types'
 
 export function SkipStepInfo(props: RecoveryContentProps): JSX.Element {
   const {
+    failedCommand,
     recoveryCommands,
     routeUpdateActions,
     currentRecoveryOptionUtils,
@@ -24,7 +25,11 @@ export function SkipStepInfo(props: RecoveryContentProps): JSX.Element {
   } = RECOVERY_MAP
   const { selectedRecoveryOption } = currentRecoveryOptionUtils
   const { skipFailedCommand } = recoveryCommands
-  const { moveLabwareWithoutPause, manualRetrieve } = recoveryCommands
+  const {
+    moveLabwareWithoutPause,
+    manualRetrieve,
+    manualStore,
+  } = recoveryCommands
   const { handleMotionRouting } = routeUpdateActions
   const { ROBOT_SKIPPING_STEP } = RECOVERY_MAP
   const { t } = useTranslation('error_recovery')
@@ -40,9 +45,19 @@ export function SkipStepInfo(props: RecoveryContentProps): JSX.Element {
         case STACKER_HOPPER_EMPTY_SKIP.ROUTE:
         case STACKER_SHUTTLE_EMPTY_SKIP.ROUTE:
         case STACKER_STALLED_SKIP.ROUTE:
-          void manualRetrieve().then(() => {
-            skipFailedCommand()
-          })
+          if (
+            failedCommand?.byRunRecord.commandType === 'flexStacker/retrieve'
+          ) {
+            void manualRetrieve().then(() => {
+              skipFailedCommand()
+            })
+          } else if (
+            failedCommand?.byRunRecord.commandType === 'flexStacker/store'
+          ) {
+            void manualStore().then(() => {
+              skipFailedCommand()
+            })
+          }
           break
         default:
           skipFailedCommand()

--- a/app/src/organisms/ErrorRecoveryFlows/shared/__tests__/SkipStepInfo.test.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/__tests__/SkipStepInfo.test.tsx
@@ -16,11 +16,13 @@ describe('SkipStepInfo', () => {
   let mockHandleMotionRouting: Mock
   let mockSkipFailedCommand: Mock
   let mockManualRetrieve: Mock
+  let mockManualStore: Mock
 
   beforeEach(() => {
     mockHandleMotionRouting = vi.fn(() => Promise.resolve())
     mockSkipFailedCommand = vi.fn(() => Promise.resolve())
     mockManualRetrieve = vi.fn(() => Promise.resolve())
+    mockManualStore = vi.fn(() => Promise.resolve())
 
     props = {
       routeUpdateActions: {
@@ -29,6 +31,7 @@ describe('SkipStepInfo', () => {
       recoveryCommands: {
         skipFailedCommand: mockSkipFailedCommand,
         manualRetrieve: mockManualRetrieve,
+        manualStore: mockManualStore,
       } as any,
       currentRecoveryOptionUtils: {
         selectedRecoveryOption: RECOVERY_MAP.SKIP_STEP_WITH_SAME_TIPS.ROUTE,
@@ -125,6 +128,9 @@ describe('SkipStepInfo', () => {
     RECOVERY_MAP.STACKER_STALLED_SKIP.ROUTE,
   ])('calls manualRetreive when the route is %s', async route => {
     props.currentRecoveryOptionUtils.selectedRecoveryOption = route
+    props.failedCommand = {
+      byRunRecord: { commandType: 'flexStacker/retrieve' as any },
+    } as any
     render(props)
 
     clickButtonLabeled('Continue run now')
@@ -141,6 +147,35 @@ describe('SkipStepInfo', () => {
     await waitFor(() => {
       expect(mockHandleMotionRouting.mock.invocationCallOrder[0]).toBeLessThan(
         mockManualRetrieve.mock.invocationCallOrder[0]
+      )
+    })
+  })
+
+  it.each([
+    RECOVERY_MAP.STACKER_HOPPER_EMPTY_SKIP.ROUTE,
+    RECOVERY_MAP.STACKER_SHUTTLE_EMPTY_SKIP.ROUTE,
+    RECOVERY_MAP.STACKER_STALLED_SKIP.ROUTE,
+  ])('calls manualStore when the route is %s', async route => {
+    props.currentRecoveryOptionUtils.selectedRecoveryOption = route
+    props.failedCommand = {
+      byRunRecord: { commandType: 'flexStacker/store' as any },
+    } as any
+    render(props)
+
+    clickButtonLabeled('Continue run now')
+
+    await waitFor(() => {
+      expect(mockHandleMotionRouting).toHaveBeenCalledWith(
+        true,
+        RECOVERY_MAP.ROBOT_SKIPPING_STEP.ROUTE
+      )
+    })
+    await waitFor(() => {
+      expect(mockManualStore).toHaveBeenCalled()
+    })
+    await waitFor(() => {
+      expect(mockHandleMotionRouting.mock.invocationCallOrder[0]).toBeLessThan(
+        mockManualStore.mock.invocationCallOrder[0]
       )
     })
   })

--- a/shared-data/command/schemas/14.json
+++ b/shared-data/command/schemas/14.json
@@ -39,6 +39,7 @@
         "commandType": {
           "const": "airGapInPlace",
           "default": "airGapInPlace",
+          "enum": ["airGapInPlace"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -104,6 +105,7 @@
         "style": {
           "const": "ALL",
           "default": "ALL",
+          "enum": ["ALL"],
           "title": "Style",
           "type": "string"
         }
@@ -117,6 +119,7 @@
         "commandType": {
           "const": "aspirate",
           "default": "aspirate",
+          "enum": ["aspirate"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -144,6 +147,7 @@
         "commandType": {
           "const": "aspirateInPlace",
           "default": "aspirateInPlace",
+          "enum": ["aspirateInPlace"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -374,6 +378,7 @@
         "commandType": {
           "const": "aspirateWhileTracking",
           "default": "aspirateWhileTracking",
+          "enum": ["aspirateWhileTracking"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -453,6 +458,7 @@
         "commandType": {
           "const": "blowout",
           "default": "blowout",
+          "enum": ["blowout"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -480,6 +486,7 @@
         "commandType": {
           "const": "blowOutInPlace",
           "default": "blowOutInPlace",
+          "enum": ["blowOutInPlace"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -611,6 +618,7 @@
         "commandType": {
           "const": "calibration/calibrateGripper",
           "default": "calibration/calibrateGripper",
+          "enum": ["calibration/calibrateGripper"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -660,6 +668,7 @@
         "commandType": {
           "const": "calibration/calibrateModule",
           "default": "calibration/calibrateModule",
+          "enum": ["calibration/calibrateModule"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -709,6 +718,7 @@
         "commandType": {
           "const": "calibration/calibratePipette",
           "default": "calibration/calibratePipette",
+          "enum": ["calibration/calibratePipette"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -748,6 +758,7 @@
         "commandType": {
           "const": "robot/closeGripperJaw",
           "default": "robot/closeGripperJaw",
+          "enum": ["robot/closeGripperJaw"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -787,6 +798,7 @@
         "commandType": {
           "const": "heaterShaker/closeLabwareLatch",
           "default": "heaterShaker/closeLabwareLatch",
+          "enum": ["heaterShaker/closeLabwareLatch"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -833,6 +845,7 @@
         "style": {
           "const": "COLUMN",
           "default": "COLUMN",
+          "enum": ["COLUMN"],
           "title": "Style",
           "type": "string"
         }
@@ -853,6 +866,7 @@
         "commandType": {
           "const": "comment",
           "default": "comment",
+          "enum": ["comment"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -893,6 +907,7 @@
         "commandType": {
           "const": "configureForVolume",
           "default": "configureForVolume",
+          "enum": ["configureForVolume"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -944,6 +959,7 @@
         "commandType": {
           "const": "configureNozzleLayout",
           "default": "configureNozzleLayout",
+          "enum": ["configureNozzleLayout"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -1045,6 +1061,7 @@
         "commandType": {
           "const": "custom",
           "default": "custom",
+          "enum": ["custom"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -1079,6 +1096,7 @@
         "commandType": {
           "const": "thermocycler/deactivateBlock",
           "default": "thermocycler/deactivateBlock",
+          "enum": ["thermocycler/deactivateBlock"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -1119,6 +1137,7 @@
         "commandType": {
           "const": "heaterShaker/deactivateHeater",
           "default": "heaterShaker/deactivateHeater",
+          "enum": ["heaterShaker/deactivateHeater"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -1159,6 +1178,7 @@
         "commandType": {
           "const": "thermocycler/deactivateLid",
           "default": "thermocycler/deactivateLid",
+          "enum": ["thermocycler/deactivateLid"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -1199,6 +1219,7 @@
         "commandType": {
           "const": "heaterShaker/deactivateShaker",
           "default": "heaterShaker/deactivateShaker",
+          "enum": ["heaterShaker/deactivateShaker"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -1239,6 +1260,7 @@
         "commandType": {
           "const": "temperatureModule/deactivate",
           "default": "temperatureModule/deactivate",
+          "enum": ["temperatureModule/deactivate"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -1384,6 +1406,7 @@
         "commandType": {
           "const": "magneticModule/disengage",
           "default": "magneticModule/disengage",
+          "enum": ["magneticModule/disengage"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -1424,6 +1447,7 @@
         "commandType": {
           "const": "dispense",
           "default": "dispense",
+          "enum": ["dispense"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -1451,6 +1475,7 @@
         "commandType": {
           "const": "dispenseInPlace",
           "default": "dispenseInPlace",
+          "enum": ["dispenseInPlace"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -1578,6 +1603,7 @@
         "commandType": {
           "const": "dispenseWhileTracking",
           "default": "dispenseWhileTracking",
+          "enum": ["dispenseWhileTracking"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -1662,6 +1688,7 @@
         "commandType": {
           "const": "dropTip",
           "default": "dropTip",
+          "enum": ["dropTip"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -1689,6 +1716,7 @@
         "commandType": {
           "const": "dropTipInPlace",
           "default": "dropTipInPlace",
+          "enum": ["dropTipInPlace"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -1796,6 +1824,7 @@
         "commandType": {
           "const": "flexStacker/empty",
           "default": "flexStacker/empty",
+          "enum": ["flexStacker/empty"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -1860,6 +1889,7 @@
         "commandType": {
           "const": "magneticModule/engage",
           "default": "magneticModule/engage",
+          "enum": ["magneticModule/engage"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -1905,6 +1935,7 @@
         "commandType": {
           "const": "flexStacker/fill",
           "default": "flexStacker/fill",
+          "enum": ["flexStacker/fill"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -1985,6 +2016,7 @@
         "commandType": {
           "const": "getNextTip",
           "default": "getNextTip",
+          "enum": ["getNextTip"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -2038,6 +2070,7 @@
         "commandType": {
           "const": "getTipPresence",
           "default": "getTipPresence",
+          "enum": ["getTipPresence"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -2078,6 +2111,7 @@
         "commandType": {
           "const": "home",
           "default": "home",
+          "enum": ["home"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -2125,6 +2159,7 @@
         "commandType": {
           "const": "identifyModule",
           "default": "identifyModule",
+          "enum": ["identifyModule"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -2187,6 +2222,7 @@
         "commandType": {
           "const": "absorbanceReader/initialize",
           "default": "absorbanceReader/initialize",
+          "enum": ["absorbanceReader/initialize"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -2379,6 +2415,7 @@
             },
             {
               "const": "operationVolume",
+              "enum": ["operationVolume"],
               "type": "string"
             }
           ],
@@ -2396,6 +2433,7 @@
         "commandType": {
           "const": "liquidProbe",
           "default": "liquidProbe",
+          "enum": ["liquidProbe"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -2450,6 +2488,7 @@
         "commandType": {
           "const": "loadLabware",
           "default": "loadLabware",
+          "enum": ["loadLabware"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -2502,10 +2541,12 @@
             },
             {
               "const": "offDeck",
+              "enum": ["offDeck"],
               "type": "string"
             },
             {
               "const": "systemLocation",
+              "enum": ["systemLocation"],
               "type": "string"
             },
             {
@@ -2536,6 +2577,7 @@
         "commandType": {
           "const": "loadLid",
           "default": "loadLid",
+          "enum": ["loadLid"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -2578,10 +2620,12 @@
             },
             {
               "const": "offDeck",
+              "enum": ["offDeck"],
               "type": "string"
             },
             {
               "const": "systemLocation",
+              "enum": ["systemLocation"],
               "type": "string"
             },
             {
@@ -2612,6 +2656,7 @@
         "commandType": {
           "const": "loadLidStack",
           "default": "loadLidStack",
+          "enum": ["loadLidStack"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -2662,10 +2707,12 @@
             },
             {
               "const": "offDeck",
+              "enum": ["offDeck"],
               "type": "string"
             },
             {
               "const": "systemLocation",
+              "enum": ["systemLocation"],
               "type": "string"
             },
             {
@@ -2706,6 +2753,7 @@
         "commandType": {
           "const": "loadLiquidClass",
           "default": "loadLiquidClass",
+          "enum": ["loadLiquidClass"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -2750,6 +2798,7 @@
         "commandType": {
           "const": "loadLiquid",
           "default": "loadLiquid",
+          "enum": ["loadLiquid"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -2786,6 +2835,7 @@
             },
             {
               "const": "EMPTY",
+              "enum": ["EMPTY"],
               "type": "string"
             }
           ],
@@ -2811,6 +2861,7 @@
         "commandType": {
           "const": "loadModule",
           "default": "loadModule",
+          "enum": ["loadModule"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -2859,6 +2910,7 @@
         "commandType": {
           "const": "loadPipette",
           "default": "loadPipette",
+          "enum": ["loadPipette"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -3022,6 +3074,7 @@
         "commandType": {
           "const": "robot/moveAxesRelative",
           "default": "robot/moveAxesRelative",
+          "enum": ["robot/moveAxesRelative"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -3051,9 +3104,6 @@
             "type": "number"
           },
           "description": "A dictionary mapping axes to relative movements in mm.",
-          "propertyNames": {
-            "$ref": "#/$defs/MotorAxis"
-          },
           "title": "Axis Map",
           "type": "object"
         },
@@ -3073,6 +3123,7 @@
         "commandType": {
           "const": "robot/moveAxesTo",
           "default": "robot/moveAxesTo",
+          "enum": ["robot/moveAxesTo"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -3102,9 +3153,6 @@
             "type": "number"
           },
           "description": "The specified axes to move to an absolute deck position with.",
-          "propertyNames": {
-            "$ref": "#/$defs/MotorAxis"
-          },
           "title": "Axis Map",
           "type": "object"
         },
@@ -3113,9 +3161,6 @@
             "type": "number"
           },
           "description": "The critical point to move the mount with.",
-          "propertyNames": {
-            "$ref": "#/$defs/MotorAxis"
-          },
           "title": "Critical Point",
           "type": "object"
         },
@@ -3135,6 +3180,7 @@
         "commandType": {
           "const": "moveLabware",
           "default": "moveLabware",
+          "enum": ["moveLabware"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -3182,10 +3228,12 @@
             },
             {
               "const": "offDeck",
+              "enum": ["offDeck"],
               "type": "string"
             },
             {
               "const": "systemLocation",
+              "enum": ["systemLocation"],
               "type": "string"
             },
             {
@@ -3215,6 +3263,7 @@
         "commandType": {
           "const": "moveRelative",
           "default": "moveRelative",
+          "enum": ["moveRelative"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -3264,6 +3313,7 @@
         "commandType": {
           "const": "moveToAddressableArea",
           "default": "moveToAddressableArea",
+          "enum": ["moveToAddressableArea"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -3291,6 +3341,7 @@
         "commandType": {
           "const": "moveToAddressableAreaForDropTip",
           "default": "moveToAddressableAreaForDropTip",
+          "enum": ["moveToAddressableAreaForDropTip"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -3420,6 +3471,7 @@
         "commandType": {
           "const": "moveToCoordinates",
           "default": "moveToCoordinates",
+          "enum": ["moveToCoordinates"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -3480,6 +3532,7 @@
         "commandType": {
           "const": "robot/moveTo",
           "default": "robot/moveTo",
+          "enum": ["robot/moveTo"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -3507,6 +3560,7 @@
         "commandType": {
           "const": "calibration/moveToMaintenancePosition",
           "default": "calibration/moveToMaintenancePosition",
+          "enum": ["calibration/moveToMaintenancePosition"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -3572,6 +3626,7 @@
         "commandType": {
           "const": "moveToWell",
           "default": "moveToWell",
+          "enum": ["moveToWell"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -3837,6 +3892,7 @@
         "commandType": {
           "const": "robot/openGripperJaw",
           "default": "robot/openGripperJaw",
+          "enum": ["robot/openGripperJaw"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -3870,6 +3926,7 @@
         "commandType": {
           "const": "heaterShaker/openLabwareLatch",
           "default": "heaterShaker/openLabwareLatch",
+          "enum": ["heaterShaker/openLabwareLatch"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -3910,6 +3967,7 @@
         "commandType": {
           "const": "pickUpTip",
           "default": "pickUpTip",
+          "enum": ["pickUpTip"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -4016,6 +4074,7 @@
         "commandType": {
           "const": "prepareToAspirate",
           "default": "prepareToAspirate",
+          "enum": ["prepareToAspirate"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -4056,6 +4115,7 @@
         "commandType": {
           "const": "pressureDispense",
           "default": "pressureDispense",
+          "enum": ["pressureDispense"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -4192,6 +4252,7 @@
         "style": {
           "const": "QUADRANT",
           "default": "QUADRANT",
+          "enum": ["QUADRANT"],
           "title": "Style",
           "type": "string"
         }
@@ -4206,6 +4267,7 @@
         "commandType": {
           "const": "absorbanceReader/read",
           "default": "absorbanceReader/read",
+          "enum": ["absorbanceReader/read"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -4251,6 +4313,7 @@
         "commandType": {
           "const": "reloadLabware",
           "default": "reloadLabware",
+          "enum": ["reloadLabware"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -4368,6 +4431,7 @@
         "commandType": {
           "const": "retractAxis",
           "default": "retractAxis",
+          "enum": ["retractAxis"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -4489,6 +4553,7 @@
         "commandType": {
           "const": "flexStacker/retrieve",
           "default": "flexStacker/retrieve",
+          "enum": ["flexStacker/retrieve"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -4555,6 +4620,7 @@
         "style": {
           "const": "ROW",
           "default": "ROW",
+          "enum": ["ROW"],
           "title": "Style",
           "type": "string"
         }
@@ -4569,6 +4635,7 @@
         "commandType": {
           "const": "thermocycler/runExtendedProfile",
           "default": "thermocycler/runExtendedProfile",
+          "enum": ["thermocycler/runExtendedProfile"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -4629,6 +4696,7 @@
         "commandType": {
           "const": "thermocycler/runProfile",
           "default": "thermocycler/runProfile",
+          "enum": ["thermocycler/runProfile"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -4700,6 +4768,7 @@
         "commandType": {
           "const": "savePosition",
           "default": "savePosition",
+          "enum": ["savePosition"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -4750,6 +4819,7 @@
         "commandType": {
           "const": "sealPipetteToTip",
           "default": "sealPipetteToTip",
+          "enum": ["sealPipetteToTip"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -4816,6 +4886,7 @@
         "commandType": {
           "const": "heaterShaker/setAndWaitForShakeSpeed",
           "default": "heaterShaker/setAndWaitForShakeSpeed",
+          "enum": ["heaterShaker/setAndWaitForShakeSpeed"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -4861,6 +4932,7 @@
         "commandType": {
           "const": "setRailLights",
           "default": "setRailLights",
+          "enum": ["setRailLights"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -4901,6 +4973,7 @@
         "commandType": {
           "const": "setStatusBar",
           "default": "setStatusBar",
+          "enum": ["setStatusBar"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -4940,6 +5013,7 @@
         "commandType": {
           "const": "flexStacker/setStoredLabware",
           "default": "flexStacker/setStoredLabware",
+          "enum": ["flexStacker/setStoredLabware"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -5039,6 +5113,7 @@
         "commandType": {
           "const": "thermocycler/setTargetBlockTemperature",
           "default": "thermocycler/setTargetBlockTemperature",
+          "enum": ["thermocycler/setTargetBlockTemperature"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -5094,6 +5169,7 @@
         "commandType": {
           "const": "thermocycler/setTargetLidTemperature",
           "default": "thermocycler/setTargetLidTemperature",
+          "enum": ["thermocycler/setTargetLidTemperature"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -5289,6 +5365,7 @@
         "style": {
           "const": "SINGLE",
           "default": "SINGLE",
+          "enum": ["SINGLE"],
           "title": "Style",
           "type": "string"
         }
@@ -5360,6 +5437,7 @@
         "commandType": {
           "const": "flexStacker/store",
           "default": "flexStacker/store",
+          "enum": ["flexStacker/store"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -5384,6 +5462,12 @@
     "StoreParams": {
       "description": "Input parameters for a labware storage command.",
       "properties": {
+        "manualMove": {
+          "default": null,
+          "description": "If true, indicates that the store action is being performed manually, as done in error recovery, without moving the stacker hardware.",
+          "title": "Manualmove",
+          "type": "boolean"
+        },
         "moduleId": {
           "description": "Unique ID of the flex stacker.",
           "title": "Moduleid",
@@ -5479,6 +5563,7 @@
         "commandType": {
           "const": "touchTip",
           "default": "touchTip",
+          "enum": ["touchTip"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -5568,6 +5653,7 @@
         "commandType": {
           "const": "tryLiquidProbe",
           "default": "tryLiquidProbe",
+          "enum": ["tryLiquidProbe"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -5622,6 +5708,7 @@
         "commandType": {
           "const": "unsafe/blowOutInPlace",
           "default": "unsafe/blowOutInPlace",
+          "enum": ["unsafe/blowOutInPlace"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -5668,6 +5755,7 @@
         "commandType": {
           "const": "unsafe/dropTipInPlace",
           "default": "unsafe/dropTipInPlace",
+          "enum": ["unsafe/dropTipInPlace"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -5713,6 +5801,7 @@
         "commandType": {
           "const": "unsafe/engageAxes",
           "default": "unsafe/engageAxes",
+          "enum": ["unsafe/engageAxes"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -5756,6 +5845,7 @@
         "commandType": {
           "const": "unsafe/flexStacker/closeLatch",
           "default": "unsafe/flexStacker/closeLatch",
+          "enum": ["unsafe/flexStacker/closeLatch"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -5796,6 +5886,7 @@
         "commandType": {
           "const": "unsafe/flexStacker/manualRetrieve",
           "default": "unsafe/flexStacker/manualRetrieve",
+          "enum": ["unsafe/flexStacker/manualRetrieve"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -5856,6 +5947,7 @@
         "commandType": {
           "const": "unsafe/flexStacker/openLatch",
           "default": "unsafe/flexStacker/openLatch",
+          "enum": ["unsafe/flexStacker/openLatch"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -5896,6 +5988,7 @@
         "commandType": {
           "const": "unsafe/flexStacker/prepareShuttle",
           "default": "unsafe/flexStacker/prepareShuttle",
+          "enum": ["unsafe/flexStacker/prepareShuttle"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -5942,6 +6035,7 @@
         "commandType": {
           "const": "unsafe/placeLabware",
           "default": "unsafe/placeLabware",
+          "enum": ["unsafe/placeLabware"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -6000,6 +6094,7 @@
         "commandType": {
           "const": "unsafe/ungripLabware",
           "default": "unsafe/ungripLabware",
+          "enum": ["unsafe/ungripLabware"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -6033,6 +6128,7 @@
         "commandType": {
           "const": "unsealPipetteFromTip",
           "default": "unsealPipetteFromTip",
+          "enum": ["unsealPipetteFromTip"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -6087,6 +6183,7 @@
         "commandType": {
           "const": "unsafe/updatePositionEstimators",
           "default": "unsafe/updatePositionEstimators",
+          "enum": ["unsafe/updatePositionEstimators"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -6150,6 +6247,7 @@
         "commandType": {
           "const": "verifyTipPresence",
           "default": "verifyTipPresence",
+          "enum": ["verifyTipPresence"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -6199,6 +6297,7 @@
         "commandType": {
           "const": "thermocycler/waitForBlockTemperature",
           "default": "thermocycler/waitForBlockTemperature",
+          "enum": ["thermocycler/waitForBlockTemperature"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -6239,6 +6338,7 @@
         "commandType": {
           "const": "waitForDuration",
           "default": "waitForDuration",
+          "enum": ["waitForDuration"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -6284,6 +6384,7 @@
         "commandType": {
           "const": "thermocycler/waitForLidTemperature",
           "default": "thermocycler/waitForLidTemperature",
+          "enum": ["thermocycler/waitForLidTemperature"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -6411,6 +6512,7 @@
         "commandType": {
           "const": "absorbanceReader/closeLid",
           "default": "absorbanceReader/closeLid",
+          "enum": ["absorbanceReader/closeLid"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -6451,6 +6553,7 @@
         "commandType": {
           "const": "absorbanceReader/openLid",
           "default": "absorbanceReader/openLid",
+          "enum": ["absorbanceReader/openLid"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -6491,6 +6594,7 @@
         "commandType": {
           "const": "heaterShaker/setTargetTemperature",
           "default": "heaterShaker/setTargetTemperature",
+          "enum": ["heaterShaker/setTargetTemperature"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -6536,6 +6640,7 @@
         "commandType": {
           "const": "heaterShaker/waitForTemperature",
           "default": "heaterShaker/waitForTemperature",
+          "enum": ["heaterShaker/waitForTemperature"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -6581,6 +6686,7 @@
         "commandType": {
           "const": "temperatureModule/setTargetTemperature",
           "default": "temperatureModule/setTargetTemperature",
+          "enum": ["temperatureModule/setTargetTemperature"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -6626,6 +6732,7 @@
         "commandType": {
           "const": "temperatureModule/waitForTemperature",
           "default": "temperatureModule/waitForTemperature",
+          "enum": ["temperatureModule/waitForTemperature"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -6671,6 +6778,7 @@
         "commandType": {
           "const": "thermocycler/closeLid",
           "default": "thermocycler/closeLid",
+          "enum": ["thermocycler/closeLid"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -6711,6 +6819,7 @@
         "commandType": {
           "const": "thermocycler/openLid",
           "default": "thermocycler/openLid",
+          "enum": ["thermocycler/openLid"],
           "title": "Commandtype",
           "type": "string"
         },

--- a/shared-data/command/schemas/14.json
+++ b/shared-data/command/schemas/14.json
@@ -39,7 +39,6 @@
         "commandType": {
           "const": "airGapInPlace",
           "default": "airGapInPlace",
-          "enum": ["airGapInPlace"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -105,7 +104,6 @@
         "style": {
           "const": "ALL",
           "default": "ALL",
-          "enum": ["ALL"],
           "title": "Style",
           "type": "string"
         }
@@ -119,7 +117,6 @@
         "commandType": {
           "const": "aspirate",
           "default": "aspirate",
-          "enum": ["aspirate"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -147,7 +144,6 @@
         "commandType": {
           "const": "aspirateInPlace",
           "default": "aspirateInPlace",
-          "enum": ["aspirateInPlace"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -378,7 +374,6 @@
         "commandType": {
           "const": "aspirateWhileTracking",
           "default": "aspirateWhileTracking",
-          "enum": ["aspirateWhileTracking"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -458,7 +453,6 @@
         "commandType": {
           "const": "blowout",
           "default": "blowout",
-          "enum": ["blowout"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -486,7 +480,6 @@
         "commandType": {
           "const": "blowOutInPlace",
           "default": "blowOutInPlace",
-          "enum": ["blowOutInPlace"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -618,7 +611,6 @@
         "commandType": {
           "const": "calibration/calibrateGripper",
           "default": "calibration/calibrateGripper",
-          "enum": ["calibration/calibrateGripper"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -668,7 +660,6 @@
         "commandType": {
           "const": "calibration/calibrateModule",
           "default": "calibration/calibrateModule",
-          "enum": ["calibration/calibrateModule"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -718,7 +709,6 @@
         "commandType": {
           "const": "calibration/calibratePipette",
           "default": "calibration/calibratePipette",
-          "enum": ["calibration/calibratePipette"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -758,7 +748,6 @@
         "commandType": {
           "const": "robot/closeGripperJaw",
           "default": "robot/closeGripperJaw",
-          "enum": ["robot/closeGripperJaw"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -798,7 +787,6 @@
         "commandType": {
           "const": "heaterShaker/closeLabwareLatch",
           "default": "heaterShaker/closeLabwareLatch",
-          "enum": ["heaterShaker/closeLabwareLatch"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -845,7 +833,6 @@
         "style": {
           "const": "COLUMN",
           "default": "COLUMN",
-          "enum": ["COLUMN"],
           "title": "Style",
           "type": "string"
         }
@@ -866,7 +853,6 @@
         "commandType": {
           "const": "comment",
           "default": "comment",
-          "enum": ["comment"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -907,7 +893,6 @@
         "commandType": {
           "const": "configureForVolume",
           "default": "configureForVolume",
-          "enum": ["configureForVolume"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -959,7 +944,6 @@
         "commandType": {
           "const": "configureNozzleLayout",
           "default": "configureNozzleLayout",
-          "enum": ["configureNozzleLayout"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -1061,7 +1045,6 @@
         "commandType": {
           "const": "custom",
           "default": "custom",
-          "enum": ["custom"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -1096,7 +1079,6 @@
         "commandType": {
           "const": "thermocycler/deactivateBlock",
           "default": "thermocycler/deactivateBlock",
-          "enum": ["thermocycler/deactivateBlock"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -1137,7 +1119,6 @@
         "commandType": {
           "const": "heaterShaker/deactivateHeater",
           "default": "heaterShaker/deactivateHeater",
-          "enum": ["heaterShaker/deactivateHeater"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -1178,7 +1159,6 @@
         "commandType": {
           "const": "thermocycler/deactivateLid",
           "default": "thermocycler/deactivateLid",
-          "enum": ["thermocycler/deactivateLid"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -1219,7 +1199,6 @@
         "commandType": {
           "const": "heaterShaker/deactivateShaker",
           "default": "heaterShaker/deactivateShaker",
-          "enum": ["heaterShaker/deactivateShaker"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -1260,7 +1239,6 @@
         "commandType": {
           "const": "temperatureModule/deactivate",
           "default": "temperatureModule/deactivate",
-          "enum": ["temperatureModule/deactivate"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -1406,7 +1384,6 @@
         "commandType": {
           "const": "magneticModule/disengage",
           "default": "magneticModule/disengage",
-          "enum": ["magneticModule/disengage"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -1447,7 +1424,6 @@
         "commandType": {
           "const": "dispense",
           "default": "dispense",
-          "enum": ["dispense"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -1475,7 +1451,6 @@
         "commandType": {
           "const": "dispenseInPlace",
           "default": "dispenseInPlace",
-          "enum": ["dispenseInPlace"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -1603,7 +1578,6 @@
         "commandType": {
           "const": "dispenseWhileTracking",
           "default": "dispenseWhileTracking",
-          "enum": ["dispenseWhileTracking"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -1688,7 +1662,6 @@
         "commandType": {
           "const": "dropTip",
           "default": "dropTip",
-          "enum": ["dropTip"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -1716,7 +1689,6 @@
         "commandType": {
           "const": "dropTipInPlace",
           "default": "dropTipInPlace",
-          "enum": ["dropTipInPlace"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -1824,7 +1796,6 @@
         "commandType": {
           "const": "flexStacker/empty",
           "default": "flexStacker/empty",
-          "enum": ["flexStacker/empty"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -1889,7 +1860,6 @@
         "commandType": {
           "const": "magneticModule/engage",
           "default": "magneticModule/engage",
-          "enum": ["magneticModule/engage"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -1935,7 +1905,6 @@
         "commandType": {
           "const": "flexStacker/fill",
           "default": "flexStacker/fill",
-          "enum": ["flexStacker/fill"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -2016,7 +1985,6 @@
         "commandType": {
           "const": "getNextTip",
           "default": "getNextTip",
-          "enum": ["getNextTip"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -2070,7 +2038,6 @@
         "commandType": {
           "const": "getTipPresence",
           "default": "getTipPresence",
-          "enum": ["getTipPresence"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -2111,7 +2078,6 @@
         "commandType": {
           "const": "home",
           "default": "home",
-          "enum": ["home"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -2159,7 +2125,6 @@
         "commandType": {
           "const": "identifyModule",
           "default": "identifyModule",
-          "enum": ["identifyModule"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -2222,7 +2187,6 @@
         "commandType": {
           "const": "absorbanceReader/initialize",
           "default": "absorbanceReader/initialize",
-          "enum": ["absorbanceReader/initialize"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -2415,7 +2379,6 @@
             },
             {
               "const": "operationVolume",
-              "enum": ["operationVolume"],
               "type": "string"
             }
           ],
@@ -2433,7 +2396,6 @@
         "commandType": {
           "const": "liquidProbe",
           "default": "liquidProbe",
-          "enum": ["liquidProbe"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -2488,7 +2450,6 @@
         "commandType": {
           "const": "loadLabware",
           "default": "loadLabware",
-          "enum": ["loadLabware"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -2541,12 +2502,10 @@
             },
             {
               "const": "offDeck",
-              "enum": ["offDeck"],
               "type": "string"
             },
             {
               "const": "systemLocation",
-              "enum": ["systemLocation"],
               "type": "string"
             },
             {
@@ -2577,7 +2536,6 @@
         "commandType": {
           "const": "loadLid",
           "default": "loadLid",
-          "enum": ["loadLid"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -2620,12 +2578,10 @@
             },
             {
               "const": "offDeck",
-              "enum": ["offDeck"],
               "type": "string"
             },
             {
               "const": "systemLocation",
-              "enum": ["systemLocation"],
               "type": "string"
             },
             {
@@ -2656,7 +2612,6 @@
         "commandType": {
           "const": "loadLidStack",
           "default": "loadLidStack",
-          "enum": ["loadLidStack"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -2707,12 +2662,10 @@
             },
             {
               "const": "offDeck",
-              "enum": ["offDeck"],
               "type": "string"
             },
             {
               "const": "systemLocation",
-              "enum": ["systemLocation"],
               "type": "string"
             },
             {
@@ -2753,7 +2706,6 @@
         "commandType": {
           "const": "loadLiquidClass",
           "default": "loadLiquidClass",
-          "enum": ["loadLiquidClass"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -2798,7 +2750,6 @@
         "commandType": {
           "const": "loadLiquid",
           "default": "loadLiquid",
-          "enum": ["loadLiquid"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -2835,7 +2786,6 @@
             },
             {
               "const": "EMPTY",
-              "enum": ["EMPTY"],
               "type": "string"
             }
           ],
@@ -2861,7 +2811,6 @@
         "commandType": {
           "const": "loadModule",
           "default": "loadModule",
-          "enum": ["loadModule"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -2910,7 +2859,6 @@
         "commandType": {
           "const": "loadPipette",
           "default": "loadPipette",
-          "enum": ["loadPipette"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -3074,7 +3022,6 @@
         "commandType": {
           "const": "robot/moveAxesRelative",
           "default": "robot/moveAxesRelative",
-          "enum": ["robot/moveAxesRelative"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -3104,6 +3051,9 @@
             "type": "number"
           },
           "description": "A dictionary mapping axes to relative movements in mm.",
+          "propertyNames": {
+            "$ref": "#/$defs/MotorAxis"
+          },
           "title": "Axis Map",
           "type": "object"
         },
@@ -3123,7 +3073,6 @@
         "commandType": {
           "const": "robot/moveAxesTo",
           "default": "robot/moveAxesTo",
-          "enum": ["robot/moveAxesTo"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -3153,6 +3102,9 @@
             "type": "number"
           },
           "description": "The specified axes to move to an absolute deck position with.",
+          "propertyNames": {
+            "$ref": "#/$defs/MotorAxis"
+          },
           "title": "Axis Map",
           "type": "object"
         },
@@ -3161,6 +3113,9 @@
             "type": "number"
           },
           "description": "The critical point to move the mount with.",
+          "propertyNames": {
+            "$ref": "#/$defs/MotorAxis"
+          },
           "title": "Critical Point",
           "type": "object"
         },
@@ -3180,7 +3135,6 @@
         "commandType": {
           "const": "moveLabware",
           "default": "moveLabware",
-          "enum": ["moveLabware"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -3228,12 +3182,10 @@
             },
             {
               "const": "offDeck",
-              "enum": ["offDeck"],
               "type": "string"
             },
             {
               "const": "systemLocation",
-              "enum": ["systemLocation"],
               "type": "string"
             },
             {
@@ -3263,7 +3215,6 @@
         "commandType": {
           "const": "moveRelative",
           "default": "moveRelative",
-          "enum": ["moveRelative"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -3313,7 +3264,6 @@
         "commandType": {
           "const": "moveToAddressableArea",
           "default": "moveToAddressableArea",
-          "enum": ["moveToAddressableArea"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -3341,7 +3291,6 @@
         "commandType": {
           "const": "moveToAddressableAreaForDropTip",
           "default": "moveToAddressableAreaForDropTip",
-          "enum": ["moveToAddressableAreaForDropTip"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -3471,7 +3420,6 @@
         "commandType": {
           "const": "moveToCoordinates",
           "default": "moveToCoordinates",
-          "enum": ["moveToCoordinates"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -3532,7 +3480,6 @@
         "commandType": {
           "const": "robot/moveTo",
           "default": "robot/moveTo",
-          "enum": ["robot/moveTo"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -3560,7 +3507,6 @@
         "commandType": {
           "const": "calibration/moveToMaintenancePosition",
           "default": "calibration/moveToMaintenancePosition",
-          "enum": ["calibration/moveToMaintenancePosition"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -3626,7 +3572,6 @@
         "commandType": {
           "const": "moveToWell",
           "default": "moveToWell",
-          "enum": ["moveToWell"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -3892,7 +3837,6 @@
         "commandType": {
           "const": "robot/openGripperJaw",
           "default": "robot/openGripperJaw",
-          "enum": ["robot/openGripperJaw"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -3926,7 +3870,6 @@
         "commandType": {
           "const": "heaterShaker/openLabwareLatch",
           "default": "heaterShaker/openLabwareLatch",
-          "enum": ["heaterShaker/openLabwareLatch"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -3967,7 +3910,6 @@
         "commandType": {
           "const": "pickUpTip",
           "default": "pickUpTip",
-          "enum": ["pickUpTip"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -4074,7 +4016,6 @@
         "commandType": {
           "const": "prepareToAspirate",
           "default": "prepareToAspirate",
-          "enum": ["prepareToAspirate"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -4115,7 +4056,6 @@
         "commandType": {
           "const": "pressureDispense",
           "default": "pressureDispense",
-          "enum": ["pressureDispense"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -4252,7 +4192,6 @@
         "style": {
           "const": "QUADRANT",
           "default": "QUADRANT",
-          "enum": ["QUADRANT"],
           "title": "Style",
           "type": "string"
         }
@@ -4267,7 +4206,6 @@
         "commandType": {
           "const": "absorbanceReader/read",
           "default": "absorbanceReader/read",
-          "enum": ["absorbanceReader/read"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -4313,7 +4251,6 @@
         "commandType": {
           "const": "reloadLabware",
           "default": "reloadLabware",
-          "enum": ["reloadLabware"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -4431,7 +4368,6 @@
         "commandType": {
           "const": "retractAxis",
           "default": "retractAxis",
-          "enum": ["retractAxis"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -4553,7 +4489,6 @@
         "commandType": {
           "const": "flexStacker/retrieve",
           "default": "flexStacker/retrieve",
-          "enum": ["flexStacker/retrieve"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -4620,7 +4555,6 @@
         "style": {
           "const": "ROW",
           "default": "ROW",
-          "enum": ["ROW"],
           "title": "Style",
           "type": "string"
         }
@@ -4635,7 +4569,6 @@
         "commandType": {
           "const": "thermocycler/runExtendedProfile",
           "default": "thermocycler/runExtendedProfile",
-          "enum": ["thermocycler/runExtendedProfile"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -4696,7 +4629,6 @@
         "commandType": {
           "const": "thermocycler/runProfile",
           "default": "thermocycler/runProfile",
-          "enum": ["thermocycler/runProfile"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -4768,7 +4700,6 @@
         "commandType": {
           "const": "savePosition",
           "default": "savePosition",
-          "enum": ["savePosition"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -4819,7 +4750,6 @@
         "commandType": {
           "const": "sealPipetteToTip",
           "default": "sealPipetteToTip",
-          "enum": ["sealPipetteToTip"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -4886,7 +4816,6 @@
         "commandType": {
           "const": "heaterShaker/setAndWaitForShakeSpeed",
           "default": "heaterShaker/setAndWaitForShakeSpeed",
-          "enum": ["heaterShaker/setAndWaitForShakeSpeed"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -4932,7 +4861,6 @@
         "commandType": {
           "const": "setRailLights",
           "default": "setRailLights",
-          "enum": ["setRailLights"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -4973,7 +4901,6 @@
         "commandType": {
           "const": "setStatusBar",
           "default": "setStatusBar",
-          "enum": ["setStatusBar"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -5013,7 +4940,6 @@
         "commandType": {
           "const": "flexStacker/setStoredLabware",
           "default": "flexStacker/setStoredLabware",
-          "enum": ["flexStacker/setStoredLabware"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -5113,7 +5039,6 @@
         "commandType": {
           "const": "thermocycler/setTargetBlockTemperature",
           "default": "thermocycler/setTargetBlockTemperature",
-          "enum": ["thermocycler/setTargetBlockTemperature"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -5169,7 +5094,6 @@
         "commandType": {
           "const": "thermocycler/setTargetLidTemperature",
           "default": "thermocycler/setTargetLidTemperature",
-          "enum": ["thermocycler/setTargetLidTemperature"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -5365,7 +5289,6 @@
         "style": {
           "const": "SINGLE",
           "default": "SINGLE",
-          "enum": ["SINGLE"],
           "title": "Style",
           "type": "string"
         }
@@ -5378,6 +5301,12 @@
       "description": "Strategy to use for filling or emptying a stacker.",
       "enum": ["manualWithPause", "logical"],
       "title": "StackerFillEmptyStrategy",
+      "type": "string"
+    },
+    "StackerLabwareMovementStrategy": {
+      "description": "Strategy to retrieve or store labware.",
+      "enum": ["automatic", "manual"],
+      "title": "StackerLabwareMovementStrategy",
       "type": "string"
     },
     "StackerStoredLabwareDetails": {
@@ -5437,7 +5366,6 @@
         "commandType": {
           "const": "flexStacker/store",
           "default": "flexStacker/store",
-          "enum": ["flexStacker/store"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -5462,16 +5390,16 @@
     "StoreParams": {
       "description": "Input parameters for a labware storage command.",
       "properties": {
-        "manualMove": {
-          "default": null,
-          "description": "If true, indicates that the store action is being performed manually, as done in error recovery, without moving the stacker hardware.",
-          "title": "Manualmove",
-          "type": "boolean"
-        },
         "moduleId": {
           "description": "Unique ID of the flex stacker.",
           "title": "Moduleid",
           "type": "string"
+        },
+        "moveStrategy": {
+          "$ref": "#/$defs/StackerLabwareMovementStrategy",
+          "default": "automatic",
+          "description": "If manual, indicates that labware has been moved to the hopper manually by the user, as required in error recovery.",
+          "title": "Movestrategy"
         }
       },
       "required": ["moduleId"],
@@ -5563,7 +5491,6 @@
         "commandType": {
           "const": "touchTip",
           "default": "touchTip",
-          "enum": ["touchTip"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -5653,7 +5580,6 @@
         "commandType": {
           "const": "tryLiquidProbe",
           "default": "tryLiquidProbe",
-          "enum": ["tryLiquidProbe"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -5708,7 +5634,6 @@
         "commandType": {
           "const": "unsafe/blowOutInPlace",
           "default": "unsafe/blowOutInPlace",
-          "enum": ["unsafe/blowOutInPlace"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -5755,7 +5680,6 @@
         "commandType": {
           "const": "unsafe/dropTipInPlace",
           "default": "unsafe/dropTipInPlace",
-          "enum": ["unsafe/dropTipInPlace"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -5801,7 +5725,6 @@
         "commandType": {
           "const": "unsafe/engageAxes",
           "default": "unsafe/engageAxes",
-          "enum": ["unsafe/engageAxes"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -5845,7 +5768,6 @@
         "commandType": {
           "const": "unsafe/flexStacker/closeLatch",
           "default": "unsafe/flexStacker/closeLatch",
-          "enum": ["unsafe/flexStacker/closeLatch"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -5886,7 +5808,6 @@
         "commandType": {
           "const": "unsafe/flexStacker/manualRetrieve",
           "default": "unsafe/flexStacker/manualRetrieve",
-          "enum": ["unsafe/flexStacker/manualRetrieve"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -5947,7 +5868,6 @@
         "commandType": {
           "const": "unsafe/flexStacker/openLatch",
           "default": "unsafe/flexStacker/openLatch",
-          "enum": ["unsafe/flexStacker/openLatch"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -5988,7 +5908,6 @@
         "commandType": {
           "const": "unsafe/flexStacker/prepareShuttle",
           "default": "unsafe/flexStacker/prepareShuttle",
-          "enum": ["unsafe/flexStacker/prepareShuttle"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -6035,7 +5954,6 @@
         "commandType": {
           "const": "unsafe/placeLabware",
           "default": "unsafe/placeLabware",
-          "enum": ["unsafe/placeLabware"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -6094,7 +6012,6 @@
         "commandType": {
           "const": "unsafe/ungripLabware",
           "default": "unsafe/ungripLabware",
-          "enum": ["unsafe/ungripLabware"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -6128,7 +6045,6 @@
         "commandType": {
           "const": "unsealPipetteFromTip",
           "default": "unsealPipetteFromTip",
-          "enum": ["unsealPipetteFromTip"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -6183,7 +6099,6 @@
         "commandType": {
           "const": "unsafe/updatePositionEstimators",
           "default": "unsafe/updatePositionEstimators",
-          "enum": ["unsafe/updatePositionEstimators"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -6247,7 +6162,6 @@
         "commandType": {
           "const": "verifyTipPresence",
           "default": "verifyTipPresence",
-          "enum": ["verifyTipPresence"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -6297,7 +6211,6 @@
         "commandType": {
           "const": "thermocycler/waitForBlockTemperature",
           "default": "thermocycler/waitForBlockTemperature",
-          "enum": ["thermocycler/waitForBlockTemperature"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -6338,7 +6251,6 @@
         "commandType": {
           "const": "waitForDuration",
           "default": "waitForDuration",
-          "enum": ["waitForDuration"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -6384,7 +6296,6 @@
         "commandType": {
           "const": "thermocycler/waitForLidTemperature",
           "default": "thermocycler/waitForLidTemperature",
-          "enum": ["thermocycler/waitForLidTemperature"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -6512,7 +6423,6 @@
         "commandType": {
           "const": "absorbanceReader/closeLid",
           "default": "absorbanceReader/closeLid",
-          "enum": ["absorbanceReader/closeLid"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -6553,7 +6463,6 @@
         "commandType": {
           "const": "absorbanceReader/openLid",
           "default": "absorbanceReader/openLid",
-          "enum": ["absorbanceReader/openLid"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -6594,7 +6503,6 @@
         "commandType": {
           "const": "heaterShaker/setTargetTemperature",
           "default": "heaterShaker/setTargetTemperature",
-          "enum": ["heaterShaker/setTargetTemperature"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -6640,7 +6548,6 @@
         "commandType": {
           "const": "heaterShaker/waitForTemperature",
           "default": "heaterShaker/waitForTemperature",
-          "enum": ["heaterShaker/waitForTemperature"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -6686,7 +6593,6 @@
         "commandType": {
           "const": "temperatureModule/setTargetTemperature",
           "default": "temperatureModule/setTargetTemperature",
-          "enum": ["temperatureModule/setTargetTemperature"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -6732,7 +6638,6 @@
         "commandType": {
           "const": "temperatureModule/waitForTemperature",
           "default": "temperatureModule/waitForTemperature",
-          "enum": ["temperatureModule/waitForTemperature"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -6778,7 +6683,6 @@
         "commandType": {
           "const": "thermocycler/closeLid",
           "default": "thermocycler/closeLid",
-          "enum": ["thermocycler/closeLid"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -6819,7 +6723,6 @@
         "commandType": {
           "const": "thermocycler/openLid",
           "default": "thermocycler/openLid",
-          "enum": ["thermocycler/openLid"],
           "title": "Commandtype",
           "type": "string"
         },

--- a/shared-data/command/schemas/14.json
+++ b/shared-data/command/schemas/14.json
@@ -5395,14 +5395,12 @@
           "title": "Moduleid",
           "type": "string"
         },
-        "moveStrategy": {
+        "strategy": {
           "$ref": "#/$defs/StackerLabwareMovementStrategy",
-          "default": "automatic",
-          "description": "If manual, indicates that labware has been moved to the hopper manually by the user, as required in error recovery.",
-          "title": "Movestrategy"
+          "description": "If manual, indicates that labware has been moved to the hopper manually by the user, as required in error recovery."
         }
       },
-      "required": ["moduleId"],
+      "required": ["moduleId", "strategy"],
       "title": "StoreParams",
       "type": "object"
     },

--- a/shared-data/command/types/module.ts
+++ b/shared-data/command/types/module.ts
@@ -464,7 +464,10 @@ export interface FlexStackerRetrieveCreateCommand
 
 export interface FlexStackerStoreCreateCommand extends CommonCommandCreateInfo {
   commandType: 'flexStacker/store'
-  params: { moduleId: string }
+  params: {
+    moduleId: string,
+    manualMove?: boolean
+  }
 }
 
 export interface FlexStackerFillCreateCommand extends CommonCommandCreateInfo {

--- a/shared-data/command/types/module.ts
+++ b/shared-data/command/types/module.ts
@@ -466,7 +466,7 @@ export interface FlexStackerStoreCreateCommand extends CommonCommandCreateInfo {
   commandType: 'flexStacker/store'
   params: {
     moduleId: string
-    manualMove?: boolean
+    strategy: 'automatic' | 'manual'
   }
 }
 

--- a/shared-data/command/types/module.ts
+++ b/shared-data/command/types/module.ts
@@ -465,7 +465,7 @@ export interface FlexStackerRetrieveCreateCommand
 export interface FlexStackerStoreCreateCommand extends CommonCommandCreateInfo {
   commandType: 'flexStacker/store'
   params: {
-    moduleId: string,
+    moduleId: string
     manualMove?: boolean
   }
 }


### PR DESCRIPTION
# Overview
We currently call `manualRetrieve` when skipping a stacker store labware step when recovering from an error. This is wrong and would cause the ER to be stuck in a loop forever.

This PR adds the `moveStrategy` param to our store command so we get the stacker state update without moving the hardware through the use of `MANUAL`. This will allow us to properly "skip" the store step in error recovery.  

Fixes [RQA-4514](https://opentrons.atlassian.net/browse/RQA-4514)


[RQA-4514]: https://opentrons.atlassian.net/browse/RQA-4514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ