### PR TITLE
fix(app,components): Fix unreliable `MoveLabwareOnDeck` animation

### DIFF
--- a/components/src/hardware-sim/Deck/MoveLabwareOnDeck.tsx
+++ b/components/src/hardware-sim/Deck/MoveLabwareOnDeck.tsx
@@ -116,25 +116,36 @@ export function MoveLabwareOnDeck(
     animationFinalCoordinates
   )
 
-  const springProps = useSpring({
-    reset: shouldReset,
-    config: { duration: 1000, easing: easings.easeInOutSine },
-    from: {
-      ...animationInitialCoordinates,
-      splashOpacity: 0,
-      deckOpacity: 0,
-    },
-    to: [
-      { deckOpacity: 1 },
-      { splashOpacity: 1 },
-      { splashOpacity: 0 },
-      { ...animationFinalCoordinates },
-      { splashOpacity: 1 },
-      { splashOpacity: 0 },
-      { deckOpacity: 0 },
-    ],
-    loop: true,
-  })
+  const [springProps] = useSpring(
+    () => ({
+      reset: shouldReset,
+      config: { duration: 1000, easing: easings.easeInOutSine },
+      from: {
+        ...animationInitialCoordinates,
+        splashOpacity: 0,
+        deckOpacity: 0,
+      },
+      to: [
+        { deckOpacity: 1 },
+        { splashOpacity: 1 },
+        { splashOpacity: 0 },
+        { ...animationFinalCoordinates },
+        { splashOpacity: 1 },
+        { splashOpacity: 0 },
+        { deckOpacity: 0 },
+      ],
+      loop: true,
+    }),
+    // Dependency array:
+    [
+      shouldReset,
+      // react-spring behaves weirdly if its props are updated too frequently.
+      // So make sure to filter out coordinate "updates" that are just object identity
+      // updates and not updates to the actual x/y/z components.
+      ...Object.values(animationInitialCoordinates),
+      ...Object.values(animationFinalCoordinates),
+    ]
+  )
 
   return (
     <BaseDeck

--- a/components/src/hardware-sim/Deck/MoveLabwareOnDeck.tsx
+++ b/components/src/hardware-sim/Deck/MoveLabwareOnDeck.tsx
@@ -111,6 +111,13 @@ export function MoveLabwareOnDeck(
       ? finalCoordinates
       : offDeckCoordinates
 
+  // The user can't see the splash animation if it happens off-deck.
+  // Skip it so there's no pause where it looks like nothing is happening.
+  const shouldAnimateSplashBeforeMove =
+    animationInitialCoordinates !== offDeckCoordinates
+  const shouldAnimateSplashAfterMove =
+    animationFinalCoordinates !== offDeckCoordinates
+
   const shouldReset = usePositionChangeReset(
     animationInitialCoordinates,
     animationFinalCoordinates
@@ -127,11 +134,13 @@ export function MoveLabwareOnDeck(
       },
       to: [
         { deckOpacity: 1 },
-        { splashOpacity: 1 },
-        { splashOpacity: 0 },
+        ...(shouldAnimateSplashBeforeMove
+          ? [{ splashOpacity: 1 }, { splashOpacity: 0 }]
+          : []),
         { ...animationFinalCoordinates },
-        { splashOpacity: 1 },
-        { splashOpacity: 0 },
+        ...(shouldAnimateSplashAfterMove
+          ? [{ splashOpacity: 1 }, { splashOpacity: 0 }]
+          : []),
         { deckOpacity: 0 },
       ],
       loop: true,
@@ -144,6 +153,8 @@ export function MoveLabwareOnDeck(
       // updates and not updates to the actual x/y/z components.
       ...Object.values(animationInitialCoordinates),
       ...Object.values(animationFinalCoordinates),
+      shouldAnimateSplashBeforeMove,
+      shouldAnimateSplashAfterMove,
     ]
   )
 


### PR DESCRIPTION
## Overview

Fixes EXEC-1642 / RQA-4511? Maybe?

## Test Plan and Hands on Testing

Manually play with the move-labware animations. One place where these animations happen is in manual move-labware commands, and the other place seems to be somewhere in error recovery—not sure exactly where.

Here's the protocol I used, though there's probably value in testing with more variety, if you have a different one handy.

```python
from opentrons import protocol_api

requirements = {
    "apiLevel": "2.23",
    "robotType": "Flex",
}

def run(protocol: protocol_api.ProtocolContext):
    slot = "C2"
    labware = protocol.load_labware("agilent_1_reservoir_290ml", slot)

    module = protocol.load_module("thermocyclerModuleV2")
    module.open_lid()

    protocol.move_labware(labware, module)
    protocol.move_labware(labware, protocol_api.OFF_DECK)
```

* [x] Animation loops properly
* [x] To/from locations are correct between the two instances of the animation; back-to-back animations from separate commands don't "bleed into" each other

https://github.com/user-attachments/assets/a8e76903-0ff9-4ce6-97c5-26cfdac1cba1

## Changelog

Instead of passing in a straight object to `useSpring()`, pass in a callback and a dependency array. The idea is that maybe we were spamming react-spring with too many prop changes.

And a completely unrelated thing. The animation has a few steps for animating the "splash" around the labware. For labware being moved to/from off-deck, this created a weird (in my opinion) pause where it looked like nothing was happening, because it was happening off-deck where you couldn't see it. So, now, conditionally skip those animation steps when we know they're not going to be visible.

I can delete the splash change if we don't think it's worth the complexity or if it looks weird.

## Review requests

react-spring's rerendering and prop-updating semantics seem completely undocumented, so this is all guesswork on my part. Should we have to do this? Is this the real problem? The answers are unknowable and the questions will lead me to madness. [I am at peace with these dreadful mysteries, and I hope that you feel the same way.](https://www.usenix.org/system/files/login-logout_1305_mickens.pdf)

## Risk assessment

🤷 
