### PR TITLE
refactor(protocol-designer): add i18n to unoccupied_stack string

### DIFF
--- a/protocol-designer/src/pages/Designer/utils.ts
+++ b/protocol-designer/src/pages/Designer/utils.ts
@@ -273,7 +273,7 @@ export const useLabwareDropdownOptions = (
   type: 'moveLabware' | 'labware',
   useGripper: boolean
 ): DropdownOption[] => {
-  const { t } = useTranslation('shared')
+  const { t } = useTranslation(['shared', 'protocol_steps'])
   const labwareEntities = useSelector(getLabwareEntities)
   const activeDeckSetup = useSelector(getDeckSetupForActiveItem)
   const { labware: deckSetupLabware } = activeDeckSetup
@@ -330,7 +330,7 @@ export const useLabwareDropdownOptions = (
       const bottomOfStackOption: DropdownOption | null =
         showStackOption && bottomOfStack != null
           ? {
-              name: t('unoccupied_stack', { name: nickName }),
+              name: t('protocol_steps:unoccupied_stack', { name: nickName }),
               value: bottomOfStack,
               deckLabel: latestSlot,
             }


### PR DESCRIPTION
closes AUTH-1910

# Overview

Fixed slight bug where we forgot to pass the i18n string correctly so the dropdown was showing `unoccupied_stack` instead of the actual string.

## Test Plan and Hands on Testing

upload attached protocol and try to move the stack of lids on top of the deck riser to another slot. see that you have the option of moving just the top lid or the whole stack - this also helps fully address a ticket in the lid epic

[untitled (43).py.zip](https://github.com/user-attachments/files/21715432/untitled.43.py.zip)

## Changelog

fix i18n string

## Risk assessment

low
