### PR TITLE
fix(app): refactor logic for getSimplestDeckConfigForProtocol to be able to use combo fixtures

### DIFF
--- a/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabware/SetupLabwareMap.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabware/SetupLabwareMap.tsx
@@ -52,7 +52,7 @@ export function SetupLabwareMap({
   const [hoverLabwareId, setHoverLabwareId] = useState<string | null>(null)
 
   const deckConfig = useMemo(() => {
-      getSimplestDeckConfigForProtocol(protocolAnalysis)
+    return getSimplestDeckConfigForProtocol(protocolAnalysis)
   }, [protocolAnalysis])
 
   const startingDeck = useMemo(

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabware/SetupLabwareMap.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabware/SetupLabwareMap.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 
 import {
   BaseDeck,
@@ -50,6 +50,18 @@ export function SetupLabwareMap({
     stack: StackItem[]
   } | null>(null)
   const [hoverLabwareId, setHoverLabwareId] = useState<string | null>(null)
+  const [deckConfig, setDeckConfig] = useState(() =>
+    protocolAnalysis != null
+      ? getSimplestDeckConfigForProtocol(protocolAnalysis)
+      : []
+  )
+
+  useEffect(() => {
+    if (protocolAnalysis != null) {
+      setDeckConfig(getSimplestDeckConfigForProtocol(protocolAnalysis))
+    }
+  }, [protocolAnalysis])
+
   const startingDeck = useMemo(
     () =>
       getStackedItemsOnStartingDeck(
@@ -147,9 +159,6 @@ export function SetupLabwareMap({
       }
     }
   )
-
-  const deckConfig = getSimplestDeckConfigForProtocol(protocolAnalysis)
-
   const labwareOnDeck: Array<LabwareOnDeck | null> = Object.entries(
     getLabwareOnDeck(startingDeck)
   ).map(([slotName, stackedItems]) => {

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabware/SetupLabwareMap.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabware/SetupLabwareMap.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useMemo, useState } from 'react'
 
 import {
   BaseDeck,
@@ -50,15 +50,10 @@ export function SetupLabwareMap({
     stack: StackItem[]
   } | null>(null)
   const [hoverLabwareId, setHoverLabwareId] = useState<string | null>(null)
-  const [deckConfig, setDeckConfig] = useState(() =>
-    protocolAnalysis != null
-      ? getSimplestDeckConfigForProtocol(protocolAnalysis)
-      : []
-  )
 
-  useEffect(() => {
+  const deckConfig = useMemo(() => {
     if (protocolAnalysis != null) {
-      setDeckConfig(getSimplestDeckConfigForProtocol(protocolAnalysis))
+      getSimplestDeckConfigForProtocol(protocolAnalysis)
     }
   }, [protocolAnalysis])
 

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabware/SetupLabwareMap.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabware/SetupLabwareMap.tsx
@@ -52,9 +52,7 @@ export function SetupLabwareMap({
   const [hoverLabwareId, setHoverLabwareId] = useState<string | null>(null)
 
   const deckConfig = useMemo(() => {
-    if (protocolAnalysis != null) {
       getSimplestDeckConfigForProtocol(protocolAnalysis)
-    }
   }, [protocolAnalysis])
 
   const startingDeck = useMemo(

--- a/shared-data/js/fixtures.ts
+++ b/shared-data/js/fixtures.ts
@@ -1165,6 +1165,36 @@ export const getMainUsbModuleFixtureIdForComboFixture = (
   )
 }
 
+export const getMainFixtureIdForAA = (
+  compatibleCutoutFixtureIds: CutoutFixtureId[],
+  addressableAreaIds: AddressableAreaName[],
+  cutoutId: CutoutId
+): CutoutFixtureId | null => {
+  if (addressableAreaIds.length === 1) {
+    return getMainNonComboFixtureId(
+      compatibleCutoutFixtureIds,
+      addressableAreaIds,
+      cutoutId
+    )
+  }
+
+  const deckDef = getDeckDefFromRobotType('OT-3 Standard')
+  const cutoutFixtures = deckDef.cutoutFixtures.filter(cf =>
+    compatibleCutoutFixtureIds.includes(cf.id)
+  )
+  console.log('cutoutFixtures', cutoutFixtures)
+  const cutoutFixturesWithAddressableAreas = cutoutFixtures.find(cf =>
+    Object.values(cf.providesAddressableAreas).some(providedAAs =>
+      addressableAreaIds.every(aa => providedAAs.includes(aa))
+    )
+  )
+  console.log(
+    'cutoutFixturesWithAddressableAreas',
+    cutoutFixturesWithAddressableAreas
+  )
+  return cutoutFixturesWithAddressableAreas?.id ?? null
+}
+
 export const getMainNonComboFixtureId = (
   compatibleCutoutFixtureIds: CutoutFixtureId[],
   addressableAreaIds: AddressableAreaName[],

--- a/shared-data/js/fixtures.ts
+++ b/shared-data/js/fixtures.ts
@@ -1182,15 +1182,10 @@ export const getMainFixtureIdForAA = (
   const cutoutFixtures = deckDef.cutoutFixtures.filter(cf =>
     compatibleCutoutFixtureIds.includes(cf.id)
   )
-  console.log('cutoutFixtures', cutoutFixtures)
   const cutoutFixturesWithAddressableAreas = cutoutFixtures.find(cf =>
     Object.values(cf.providesAddressableAreas).some(providedAAs =>
       addressableAreaIds.every(aa => providedAAs.includes(aa))
     )
-  )
-  console.log(
-    'cutoutFixturesWithAddressableAreas',
-    cutoutFixturesWithAddressableAreas
   )
   return cutoutFixturesWithAddressableAreas?.id ?? null
 }

--- a/shared-data/js/helpers/getSimplestFlexDeckConfig.ts
+++ b/shared-data/js/helpers/getSimplestFlexDeckConfig.ts
@@ -84,7 +84,7 @@ export function getSimplestDeckConfigForProtocol(
       // finds what index in our acc that the `existingCutoutConfig` is at so that
       // we know which item to swap out with a new CutoutConfig that provides the previously
       // and newly found addressable areas
-      
+
       // so that we can see if we've already added a fixture for a different
       // addressable area located at the same cutout. this would mean we need to change it
       // to be a combination fixture

--- a/shared-data/js/helpers/getSimplestFlexDeckConfig.ts
+++ b/shared-data/js/helpers/getSimplestFlexDeckConfig.ts
@@ -81,7 +81,10 @@ export function getSimplestDeckConfigForProtocol(
       cutoutFixturesForCutoutId != null &&
       cutoutIdForAddressableArea != null
     ) {
-      // finds what index in out accumulated deck config object that cutout is at
+      // finds what index in our acc that the `existingCutoutConfig` is at so that
+      // we know which item to swap out with a new CutoutConfig that provides the previously
+      // and newly found addressable areas
+      
       // so that we can see if we've already added a fixture for a different
       // addressable area located at the same cutout. this would mean we need to change it
       // to be a combination fixture

--- a/shared-data/js/helpers/getSimplestFlexDeckConfig.ts
+++ b/shared-data/js/helpers/getSimplestFlexDeckConfig.ts
@@ -70,7 +70,8 @@ export function getSimplestDeckConfigForProtocol(
             deckDef.cutoutFixtures
           )
         : null
-    // finds what is currently in that specific cutout
+    // this grabs the previously found CutoutConfig if we've already added one to our acc
+    // for a different addressable area required by the same CutoutId
     const existingCutoutConfig = acc.find(
       cutoutConfig => cutoutConfig.cutoutId === cutoutIdForAddressableArea
     )

--- a/shared-data/js/helpers/getSimplestFlexDeckConfig.ts
+++ b/shared-data/js/helpers/getSimplestFlexDeckConfig.ts
@@ -2,7 +2,7 @@ import { getAddressableAreasInProtocol, getDeckDefFromRobotType } from '.'
 import { FLEX_ROBOT_TYPE } from '../constants'
 import {
   getAddressableAreaFromSlotId,
-  getMainNonComboFixtureId,
+  getMainFixtureIdForAA,
 } from '../fixtures'
 
 import type { AddressableAreaName, CutoutFixtureId, CutoutId } from '../../deck'
@@ -198,7 +198,7 @@ export function getSimplestFixtureForAddressableAreas(
     cutoutFixturesForCutoutId
   )
   if (nextCompatibleCutoutFixtures.length > 1) {
-    const mainFixture = getMainNonComboFixtureId(
+    const mainFixture = getMainFixtureIdForAA(
       nextCompatibleCutoutFixtures.map(cf => cf.id),
       requiredAddressableAreas,
       cutoutId

--- a/shared-data/js/helpers/getSimplestFlexDeckConfig.ts
+++ b/shared-data/js/helpers/getSimplestFlexDeckConfig.ts
@@ -84,10 +84,6 @@ export function getSimplestDeckConfigForProtocol(
       // finds what index in our acc that the `existingCutoutConfig` is at so that
       // we know which item to swap out with a new CutoutConfig that provides the previously
       // and newly found addressable areas
-
-      // so that we can see if we've already added a fixture for a different
-      // addressable area located at the same cutout. this would mean we need to change it
-      // to be a combination fixture
       const accIndex = acc.findIndex(
         ({ cutoutId }) => cutoutId === cutoutIdForAddressableArea
       )

--- a/shared-data/js/helpers/getSimplestFlexDeckConfig.ts
+++ b/shared-data/js/helpers/getSimplestFlexDeckConfig.ts
@@ -44,22 +44,25 @@ export function getSimplestDeckConfigForProtocol(
 ): CutoutConfigProtocolSpec[] {
   // TODO(BC, 2023-11-06): abstract out the robot type
   const deckDef = getDeckDefFromRobotType(FLEX_ROBOT_TYPE)
-
   const addressableAreas =
     protocolAnalysis != null
       ? getAddressableAreasInProtocol(protocolAnalysis, deckDef)
       : []
+  // iterates through the list of required addressable areas for the protocol
   const simplestDeckConfig = addressableAreas.reduce<
     CutoutConfigProtocolSpec[]
   >((acc, addressableArea) => {
+    // finds all cutout fixtures that provide this addressable area
     const cutoutFixturesForAddressableArea = getCutoutFixturesForAddressableAreas(
       [addressableArea],
       deckDef.cutoutFixtures
     )
+    // grabs the cutout id for the addressable area
     const cutoutIdForAddressableArea = getCutoutIdForAddressableArea(
       addressableArea,
       cutoutFixturesForAddressableArea
     )
+    // grabs all possible cutout fixtures for that cutout id
     const cutoutFixturesForCutoutId =
       cutoutIdForAddressableArea != null
         ? getCutoutFixturesForCutoutId(
@@ -67,6 +70,7 @@ export function getSimplestDeckConfigForProtocol(
             deckDef.cutoutFixtures
           )
         : null
+    // finds what is currently in that specific cutout
     const existingCutoutConfig = acc.find(
       cutoutConfig => cutoutConfig.cutoutId === cutoutIdForAddressableArea
     )
@@ -76,32 +80,30 @@ export function getSimplestDeckConfigForProtocol(
       cutoutFixturesForCutoutId != null &&
       cutoutIdForAddressableArea != null
     ) {
-      const indexOfExistingFixture = cutoutFixturesForCutoutId.findIndex(
-        ({ id }) => id === existingCutoutConfig.cutoutFixtureId
-      )
+      // finds what index in out accumulated deck config object that cutout is at
+      // so that we can see if we've already added a fixture for a different
+      // addressable area located at the same cutout. this would mean we need to change it
+      // to be a combination fixture
       const accIndex = acc.findIndex(
         ({ cutoutId }) => cutoutId === cutoutIdForAddressableArea
       )
+      // what addressable areas we've already looped through and added to this cutout
       const previousRequiredAAs = acc[accIndex]?.requiredAddressableAreas
       const allNextRequiredAddressableAreas =
         previousRequiredAAs != null &&
         previousRequiredAAs.includes(addressableArea)
           ? previousRequiredAAs
           : [...previousRequiredAAs, addressableArea]
-
+      // check for the next compatible fixture for the new, longer list of addressable areas
       const nextCompatibleCutoutFixture = getSimplestFixtureForAddressableAreas(
         cutoutIdForAddressableArea,
         allNextRequiredAddressableAreas,
         cutoutFixturesForCutoutId
       )
-      const indexOfCurrentFixture = cutoutFixturesForCutoutId.findIndex(
-        ({ id }) => id === nextCompatibleCutoutFixture?.id
-      )
 
-      if (
-        nextCompatibleCutoutFixture != null &&
-        indexOfCurrentFixture > indexOfExistingFixture
-      ) {
+      // this logic swaps out the newly found cutoutfixture id with the existing one
+      // that was added for the last addressable area we referenced
+      if (nextCompatibleCutoutFixture != null) {
         return [
           ...acc.slice(0, accIndex),
           {


### PR DESCRIPTION
# Overview

closes https://opentrons.atlassian.net/browse/RQA-4499.
show waste chute when using a waste chute combo fixture in the protocol

## Test Plan and Hands on Testing

upload protocol on flex:

```
from opentrons import protocol_api, types
from opentrons.protocol_api import Labware
from opentrons.protocol_api.module_contexts import (FlexStackerContext)


metadata = {
    "protocolName": "Stacker Waste chute combo",
}

requirements = {
    "robotType": "Flex",
    "apiLevel": "2.25",
}


HEATER_SHAKER_ADAPTER_NAME = "opentrons_96_pcr_adapter"
HEATER_SHAKER_NAME = "heaterShakerModuleV1"
MAGNETIC_BLOCK_NAME = "magneticBlockV1"
TEMPERATURE_MODULE_ADAPTER_NAME = "opentrons_96_well_aluminum_block"
TEMPERATURE_MODULE_NAME = "temperature module gen2"
THERMOCYCLER_NAME = "thermocycler module gen2"
DECK_RISER_NAME = "opentrons_flex_deck_riser"
TC_LID = "opentrons_tough_pcr_auto_sealing_lid"
LID_COUNT = 5
TIPRACK_96_ADAPTER_NAME = "opentrons_flex_96_tiprack_adapter"
TIPRACK_96_NAME = "opentrons_flex_96_tiprack_1000ul"
PIPETTE_96_CHANNEL_NAME = "flex_96channel_1000"
WELL_PLATE_STARTING_POSITION = "C2"
RESERVOIR_STARTING_POSITION = "D2"
FLEX_STACKER = "flexStackerModuleV1"


def run(ctx: protocol_api.ProtocolContext) -> None:

    ################
    ### FIXTURES ###
    ################

    waste_chute = ctx.load_waste_chute()

    ###############
    ### MODULES ###
    ###############

    stacker_200_A4 = ctx.load_module(FLEX_STACKER, "A4")
    stacker_200_A4.set_stored_labware("opentrons_flex_96_tiprack_200ul", count=6)
    # tiprack_200_2 = stacker_200_A4.load_labware('opentrons_flex_96_tiprack_200ul')

    stacker_200_B4 = ctx.load_module(FLEX_STACKER, "B4")
    stacker_200_B4.set_stored_labware("opentrons_flex_96_tiprack_200ul", count=1, lid="opentrons_flex_tiprack_lid")

    stacker_50_C4 = ctx.load_module(FLEX_STACKER, "C4")
    stacker_50_C4.set_stored_labware("opentrons_flex_96_tiprack_50ul", count=6, lid="opentrons_flex_tiprack_lid")

    stacker_50_D4 = ctx.load_module(FLEX_STACKER, "D4")
    stacker_50_D4.set_stored_labware("nest_96_wellplate_2ml_deep", count=8

    tip_rack_4 = stacker_50_C4.retrieve()
    ctx.move_labware(tip_rack_4, waste_chute)

```

- make sure the labware tab is showing waste chute + stacker
- make sure the hardware tab is showing waste chute + stacker (list and map)
- make sure the image of the protocol is showing a waste chute and a stacker.
- run the same test without the waste chute! 

<img width="890" height="141" alt="Screenshot 2025-08-11 at 10 37 39 AM" src="https://github.com/user-attachments/assets/c10a5fff-4b3c-479e-b443-8ab083b4f78c" />
<img width="887" height="671" alt="Screenshot 2025-08-11 at 10 39 06 AM" src="https://github.com/user-attachments/assets/1c6c84f3-9d9a-425c-a9a4-51f492e478f5" />
<img width="871" height="577" alt="Screenshot 2025-08-11 at 10 39 14 AM" src="https://github.com/user-attachments/assets/a667b6ba-2574-413e-8bb1-2074d76333b7" />
<img width="886" height="623" alt="Screenshot 2025-08-11 at 10 39 19 AM" src="https://github.com/user-attachments/assets/6b1b3e2f-9f14-47e2-bb49-2299edb67ada" />

## Changelog

- calculate the main fixture base on the protocol analysis
- update if we found a match not based on the index.

## Review requests

changes make sense? 

## Risk assessment

Medium. bug fix related to protocol preview. need to smoke test and make sure nothing was affected 
