### PR TITLE
fix(protocol-designer): remove version check from e2e migration test

### DIFF
--- a/protocol-designer/cypress/support/Import.ts
+++ b/protocol-designer/cypress/support/Import.ts
@@ -108,7 +108,6 @@ export const migrateAndMatchSnapshot = ({
         savedFile.designerApplication.version as string
       )
       assert(version !== null, 'PD version is not valid semver')
-      const isBelowVersion850 = semver.lte(version ?? '', '8.5.0')
 
       const files = [savedFile, expectedFile]
       files.forEach(f => {
@@ -122,10 +121,7 @@ export const migrateAndMatchSnapshot = ({
         //  a uuid is randomly generated each time you upload a protocol that is less than version 8_5_0
         //  which is the migration version that adds these keys. Due to this, we need to ignore
         //  the uuids
-        if (
-          Boolean(savedStepForms[initialDeckSetupStep]) &&
-          isBelowVersion850
-        ) {
+        if (Boolean(savedStepForms[initialDeckSetupStep])) {
           savedStepForms[initialDeckSetupStep].trashBinLocationUpdate = {
             trashBin: 'trashLocation',
           }

--- a/protocol-designer/cypress/support/Import.ts
+++ b/protocol-designer/cypress/support/Import.ts
@@ -108,7 +108,7 @@ export const migrateAndMatchSnapshot = ({
         savedFile.designerApplication.version as string
       )
       assert(version !== null, 'PD version is not valid semver')
-      const isBelowVersion850 = semver.lt(version ?? '', '8.5.0')
+      const isBelowVersion850 = semver.lte(version ?? '', '8.5.0')
 
       const files = [savedFile, expectedFile]
       files.forEach(f => {


### PR DESCRIPTION
# Overview

Okay so the uuid for the `-locationUpdate`s change with every export so this check we had before didn't make sense to preserve it for protocols that are version 8.5.0 or higher.

## Test Plan and Hands on Testing

ensure e2e migration test passes

## Changelog

fix boolean

## Risk assessment
low

