### PR TITLE
refactor(api): simplify get next tip logic in protocol engine when using a nozzle map

### DIFF
--- a/api/src/opentrons/hardware_control/nozzle_manager.py
+++ b/api/src/opentrons/hardware_control/nozzle_manager.py
@@ -77,6 +77,8 @@ class NozzleMap:
     #: A map of all of the nozzles of an instrument
     full_instrument_rows: Dict[str, List[str]]
     #: A map of all the rows of an instrument
+    full_instrument_columns: Dict[str, List[str]]
+    #: A map of all the columns of an instrument
 
     @classmethod
     def determine_nozzle_configuration(
@@ -299,6 +301,7 @@ class NozzleMap:
             rows=rows,
             full_instrument_map_store=physical_nozzles,
             full_instrument_rows=physical_rows,
+            full_instrument_columns=physical_columns,
             columns=columns,
             configuration=cls.determine_nozzle_configuration(
                 physical_rows, rows, physical_columns, columns

--- a/api/src/opentrons/protocol_engine/state/_well_math.py
+++ b/api/src/opentrons/protocol_engine/state/_well_math.py
@@ -1,6 +1,6 @@
 """Utilities for doing coverage math on wells."""
 
-from typing import Iterator
+from typing import Iterator, Dict, List
 from opentrons_shared_data.errors.exceptions import (
     InvalidStoredData,
     InvalidProtocolData,
@@ -17,13 +17,47 @@ def wells_covered_by_pipette_configuration(
     """Compute the wells covered by a pipette nozzle configuration."""
     if len(labware_wells_by_column) >= 12 and len(labware_wells_by_column[0]) >= 8:
         yield from wells_covered_dense(
-            nozzle_map,
+            nozzle_map.columns,
+            nozzle_map.rows,
+            nozzle_map.starting_nozzle,
             target_well,
             labware_wells_by_column,
         )
     elif len(labware_wells_by_column) < 12 and len(labware_wells_by_column[0]) < 8:
         yield from wells_covered_sparse(
-            nozzle_map, target_well, labware_wells_by_column
+            nozzle_map.columns,
+            nozzle_map.rows,
+            nozzle_map.starting_nozzle,
+            target_well,
+            labware_wells_by_column,
+        )
+    else:
+        raise InvalidStoredData(
+            "Labware of non-SBS and non-reservoir format cannot be handled"
+        )
+
+
+def wells_covered_by_physical_pipette(
+    nozzle_map: NozzleMap,
+    target_well: str,
+    labware_wells_by_column: list[list[str]],
+) -> Iterator[str]:
+    """Compute the wells covered by a pipette nozzle configuration."""
+    if len(labware_wells_by_column) >= 12 and len(labware_wells_by_column[0]) >= 8:
+        yield from wells_covered_dense(
+            nozzle_map.full_instrument_columns,
+            nozzle_map.full_instrument_rows,
+            nozzle_map.starting_nozzle,
+            target_well,
+            labware_wells_by_column,
+        )
+    elif len(labware_wells_by_column) < 12 and len(labware_wells_by_column[0]) < 8:
+        yield from wells_covered_sparse(
+            nozzle_map.full_instrument_columns,
+            nozzle_map.full_instrument_rows,
+            nozzle_map.starting_nozzle,
+            target_well,
+            labware_wells_by_column,
         )
     else:
         raise InvalidStoredData(
@@ -42,7 +76,11 @@ def row_col_ordinals_from_column_major_map(
 
 
 def wells_covered_dense(  # noqa: C901
-    nozzle_map: NozzleMap, target_well: str, target_wells_by_column: list[list[str]]
+    columns: Dict[str, List[str]],
+    rows: Dict[str, List[str]],
+    starting_nozzle: str,
+    target_well: str,
+    target_wells_by_column: list[list[str]],
 ) -> Iterator[str]:
     """Get the list of wells covered by a nozzle map on an SBS format labware with a specified multiplier of 96 into the number of wells.
 
@@ -66,11 +104,11 @@ def wells_covered_dense(  # noqa: C901
             "This labware cannot be used with wells_covered_dense() because it is less dense than an SBS 96 standard"
         )
 
-    for nozzle_column in range(len(nozzle_map.columns)):
+    for nozzle_column in range(len(columns)):
         target_column_offset = nozzle_column * column_downsample
-        for nozzle_row in range(len(nozzle_map.rows)):
+        for nozzle_row in range(len(rows)):
             target_row_offset = nozzle_row * row_downsample
-            if nozzle_map.starting_nozzle == "A1":
+            if starting_nozzle == "A1":
                 if (
                     target_column_index + target_column_offset
                     < len(target_wells_by_column)
@@ -81,7 +119,7 @@ def wells_covered_dense(  # noqa: C901
                     yield target_wells_by_column[
                         target_column_index + target_column_offset
                     ][target_row_index + target_row_offset]
-            elif nozzle_map.starting_nozzle == "A12":
+            elif starting_nozzle == "A12":
                 if (target_column_index - target_column_offset >= 0) and (
                     target_row_index + target_row_offset
                     < len(target_wells_by_column[target_column_index])
@@ -89,7 +127,7 @@ def wells_covered_dense(  # noqa: C901
                     yield target_wells_by_column[
                         target_column_index - target_column_offset
                     ][target_row_index + target_row_offset]
-            elif nozzle_map.starting_nozzle == "H1":
+            elif starting_nozzle == "H1":
                 if (
                     target_column_index + target_column_offset
                     < len(target_wells_by_column)
@@ -97,7 +135,7 @@ def wells_covered_dense(  # noqa: C901
                     yield target_wells_by_column[
                         target_column_index + target_column_offset
                     ][target_row_index - target_row_offset]
-            elif nozzle_map.starting_nozzle == "H12":
+            elif starting_nozzle == "H12":
                 if (target_column_index - target_column_offset >= 0) and (
                     target_row_index - target_row_offset >= 0
                 ):
@@ -106,12 +144,16 @@ def wells_covered_dense(  # noqa: C901
                     ][target_row_index - target_row_offset]
             else:
                 raise InvalidProtocolData(
-                    f"A pipette nozzle configuration may not having a starting nozzle of {nozzle_map.starting_nozzle}"
+                    f"A pipette nozzle configuration may not having a starting nozzle of {starting_nozzle}"
                 )
 
 
 def wells_covered_sparse(  # noqa: C901
-    nozzle_map: NozzleMap, target_well: str, target_wells_by_column: list[list[str]]
+    columns: Dict[str, List[str]],
+    rows: Dict[str, List[str]],
+    starting_nozzle: str,
+    target_well: str,
+    target_wells_by_column: list[list[str]],
 ) -> Iterator[str]:
     """Get the list of wells covered by a nozzle map on a column-oriented reservoir.
 
@@ -128,9 +170,9 @@ def wells_covered_sparse(  # noqa: C901
         raise InvalidStoredData(
             "This labware cannot be used with wells_covered_sparse() because it is more dense than an SBS 96 standard."
         )
-    for nozzle_column in range(max(1, len(nozzle_map.columns) // column_upsample)):
-        for nozzle_row in range(max(1, len(nozzle_map.rows) // row_upsample)):
-            if nozzle_map.starting_nozzle == "A1":
+    for nozzle_column in range(max(1, len(columns) // column_upsample)):
+        for nozzle_row in range(max(1, len(rows) // row_upsample)):
+            if starting_nozzle == "A1":
                 if (
                     target_column_index + nozzle_column < len(target_wells_by_column)
                 ) and (
@@ -140,7 +182,7 @@ def wells_covered_sparse(  # noqa: C901
                     yield target_wells_by_column[target_column_index + nozzle_column][
                         target_row_index + nozzle_row
                     ]
-            elif nozzle_map.starting_nozzle == "A12":
+            elif starting_nozzle == "A12":
                 if (target_column_index - nozzle_column >= 0) and (
                     target_row_index + nozzle_row
                     < len(target_wells_by_column[target_column_index])
@@ -148,7 +190,7 @@ def wells_covered_sparse(  # noqa: C901
                     yield target_wells_by_column[target_column_index - nozzle_column][
                         target_row_index + nozzle_row
                     ]
-            elif nozzle_map.starting_nozzle == "H1":
+            elif starting_nozzle == "H1":
                 if (
                     target_column_index + nozzle_column
                     < len(target_wells_by_column[target_column_index])
@@ -156,7 +198,7 @@ def wells_covered_sparse(  # noqa: C901
                     yield target_wells_by_column[target_column_index + nozzle_column][
                         target_row_index - nozzle_row
                     ]
-            elif nozzle_map.starting_nozzle == "H12":
+            elif starting_nozzle == "H12":
                 if (target_column_index - nozzle_column >= 0) and (
                     target_row_index - nozzle_row >= 0
                 ):
@@ -165,7 +207,7 @@ def wells_covered_sparse(  # noqa: C901
                     ]
             else:
                 raise InvalidProtocolData(
-                    f"A pipette nozzle configuration may not having a starting nozzle of {nozzle_map.starting_nozzle}"
+                    f"A pipette nozzle configuration may not having a starting nozzle of {starting_nozzle}"
                 )
 
 

--- a/api/src/opentrons/protocol_engine/state/_well_math.py
+++ b/api/src/opentrons/protocol_engine/state/_well_math.py
@@ -1,6 +1,6 @@
 """Utilities for doing coverage math on wells."""
 
-from typing import Iterator, Dict, List
+from typing import Iterator
 from opentrons_shared_data.errors.exceptions import (
     InvalidStoredData,
     InvalidProtocolData,
@@ -76,8 +76,8 @@ def row_col_ordinals_from_column_major_map(
 
 
 def wells_covered_dense(  # noqa: C901
-    columns: Dict[str, List[str]],
-    rows: Dict[str, List[str]],
+    columns: dict[str, list[str]],
+    rows: dict[str, list[str]],
     starting_nozzle: str,
     target_well: str,
     target_wells_by_column: list[list[str]],
@@ -149,8 +149,8 @@ def wells_covered_dense(  # noqa: C901
 
 
 def wells_covered_sparse(  # noqa: C901
-    columns: Dict[str, List[str]],
-    rows: Dict[str, List[str]],
+    columns: dict[str, list[str]],
+    rows: dict[str, list[str]],
     starting_nozzle: str,
     target_well: str,
     target_wells_by_column: list[list[str]],

--- a/api/src/opentrons/protocol_engine/state/tips.py
+++ b/api/src/opentrons/protocol_engine/state/tips.py
@@ -2,13 +2,17 @@
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Dict, Iterable, Optional, List, Union
+from typing import Dict, Iterable, Optional, List, Set
 
-from opentrons.types import NozzleMapInterface
+from opentrons.types import NozzleMapInterface, NozzleConfigurationType
 from opentrons.protocol_engine.state import update_types
 
 from ._abstract_store import HasState, HandlesActions
-from ._well_math import wells_covered_dense
+from ._well_math import (
+    wells_covered_dense,
+    wells_covered_by_pipette_configuration,
+    wells_covered_by_physical_pipette,
+)
 from ..actions import Action, ResetTipsAction, get_state_updates
 
 from opentrons.hardware_control.nozzle_manager import NozzleMap
@@ -117,226 +121,15 @@ class TipView:
         starting_tip_name: Optional[str],
         nozzle_map: Optional[NozzleMapInterface],
     ) -> Optional[str]:
-        """Get the next available clean tip. Does not support use of a starting tip if the pipette used is in a partial configuration."""
-        wells = self._state.tips_by_labware_id.get(labware_id, {})
-        columns = self._state.columns_by_labware_id.get(labware_id, [])
+        """Gets the next available clean tip.
 
-        # TODO(sf): I'm pretty sure this can be replaced with wells_covered_96 but I'm not quite sure how
-        def _identify_tip_cluster(
-            active_columns: int,
-            active_rows: int,
-            critical_column: int,
-            critical_row: int,
-            entry_well: str,
-        ) -> Optional[List[str]]:
-            tip_cluster: list[str] = []
-            for i in range(active_columns):
-                if entry_well == "A1" or entry_well == "H1":
-                    if critical_column - i >= 0:
-                        column = columns[critical_column - i]
-                    else:
-                        return None
-                elif entry_well == "A12" or entry_well == "H12":
-                    if critical_column + i < len(columns):
-                        column = columns[critical_column + i]
-                    else:
-                        return None
-                else:
-                    raise ValueError(
-                        f"Invalid entry well {entry_well} for tip cluster identification."
-                    )
-                for j in range(active_rows):
-                    if entry_well == "A1" or entry_well == "A12":
-                        if critical_row - j >= 0:
-                            well = column[critical_row - j]
-                        else:
-                            return None
-                    elif entry_well == "H1" or entry_well == "H12":
-                        if critical_row + j < len(column):
-                            well = column[critical_row + j]
-                        else:
-                            return None
-                    tip_cluster.append(well)
-
-            if any(well not in [*wells] for well in tip_cluster):
-                return None
-
-            return tip_cluster
-
-        def _validate_tip_cluster(
-            active_columns: int, active_rows: int, tip_cluster: List[str]
-        ) -> Union[str, int, None]:
-            if not any(wells[well] == _TipRackWellState.USED for well in tip_cluster):
-                return tip_cluster[0]
-            elif all(wells[well] == _TipRackWellState.USED for well in tip_cluster):
-                return None
-            else:
-                # In the case of an 8ch pipette where a column has mixed state tips we may simply progress to the next column in our search
-                if nozzle_map is not None and nozzle_map.physical_nozzle_count == 8:
-                    return None
-
-                # In the case of a 96ch we can attempt to index in by singular rows and columns assuming that indexed direction is safe
-                # The tip cluster list is ordered: Each row from a column in order by columns
-                tip_cluster_final_column: list[str] = []
-                for i in range(active_rows):
-                    tip_cluster_final_column.append(
-                        tip_cluster[((active_columns * active_rows) - 1) - i]
-                    )
-                tip_cluster_final_row: list[str] = []
-                for i in range(active_columns):
-                    tip_cluster_final_row.append(
-                        tip_cluster[(active_rows - 1) + (i * active_rows)]
-                    )
-                if all(
-                    wells[well] == _TipRackWellState.USED
-                    for well in tip_cluster_final_column
-                ):
-                    return None
-                elif all(
-                    wells[well] == _TipRackWellState.USED
-                    for well in tip_cluster_final_row
-                ):
-                    return None
-                else:
-                    # Tiprack has no valid tip selection, cannot progress
-                    return -1
-
-        # Search through the tiprack beginning at A1
-        def _cluster_search_A1(active_columns: int, active_rows: int) -> Optional[str]:
-            critical_column = active_columns - 1
-            critical_row = active_rows - 1
-
-            while critical_column < len(columns):
-                tip_cluster = _identify_tip_cluster(
-                    active_columns, active_rows, critical_column, critical_row, "A1"
-                )
-                if tip_cluster is not None:
-                    result = _validate_tip_cluster(
-                        active_columns, active_rows, tip_cluster
-                    )
-                    if isinstance(result, str):
-                        return result
-                    elif isinstance(result, int) and result == -1:
-                        return None
-                if critical_row + 1 < len(columns[0]):
-                    critical_row = critical_row + 1
-                else:
-                    critical_column += 1
-                    critical_row = active_rows - 1
-            return None
-
-        # Search through the tiprack beginning at A12
-        def _cluster_search_A12(active_columns: int, active_rows: int) -> Optional[str]:
-            critical_column = len(columns) - active_columns
-            critical_row = active_rows - 1
-
-            while critical_column >= 0:
-                tip_cluster = _identify_tip_cluster(
-                    active_columns, active_rows, critical_column, critical_row, "A12"
-                )
-                if tip_cluster is not None:
-                    result = _validate_tip_cluster(
-                        active_columns, active_rows, tip_cluster
-                    )
-                    if isinstance(result, str):
-                        return result
-                    elif isinstance(result, int) and result == -1:
-                        return None
-                if critical_row + 1 < len(columns[0]):
-                    critical_row = critical_row + 1
-                else:
-                    critical_column -= 1
-                    critical_row = active_rows - 1
-            return None
-
-        # Search through the tiprack beginning at H1
-        def _cluster_search_H1(active_columns: int, active_rows: int) -> Optional[str]:
-            critical_column = active_columns - 1
-            critical_row = len(columns[critical_column]) - active_rows
-
-            while critical_column <= len(columns):  # change to max size of labware
-                tip_cluster = _identify_tip_cluster(
-                    active_columns, active_rows, critical_column, critical_row, "H1"
-                )
-                if tip_cluster is not None:
-                    result = _validate_tip_cluster(
-                        active_columns, active_rows, tip_cluster
-                    )
-                    if isinstance(result, str):
-                        return result
-                    elif isinstance(result, int) and result == -1:
-                        return None
-                if critical_row - 1 >= 0:
-                    critical_row = critical_row - 1
-                else:
-                    critical_column += 1
-                    if critical_column >= len(columns):
-                        return None
-                    critical_row = len(columns[critical_column]) - active_rows
-            return None
-
-        # Search through the tiprack beginning at H12
-        def _cluster_search_H12(active_columns: int, active_rows: int) -> Optional[str]:
-            critical_column = len(columns) - active_columns
-            critical_row = len(columns[critical_column]) - active_rows
-
-            while critical_column >= 0:
-                tip_cluster = _identify_tip_cluster(
-                    active_columns, active_rows, critical_column, critical_row, "H12"
-                )
-                if tip_cluster is not None:
-                    result = _validate_tip_cluster(
-                        active_columns, active_rows, tip_cluster
-                    )
-                    if isinstance(result, str):
-                        return result
-                    elif isinstance(result, int) and result == -1:
-                        return None
-                if critical_row - 1 >= 0:
-                    critical_row = critical_row - 1
-                else:
-                    critical_column -= 1
-                    if critical_column < 0:
-                        return None
-                    critical_row = len(columns[critical_column]) - active_rows
-            return None
-
-        if starting_tip_name is None and nozzle_map is not None and columns:
-            num_channels = nozzle_map.physical_nozzle_count
-            num_nozzle_cols = len(nozzle_map.columns)
-            num_nozzle_rows = len(nozzle_map.rows)
-            # Each pipette's cluster search is determined by the point of entry for a given pipette/configuration:
-            # - Single channel pipettes always search a tiprack top to bottom, left to right
-            # - Eight channel pipettes will begin at the top if the primary nozzle is H1 and at the bottom if
-            #   it is A1. The eight channel will always progress across the columns left to right.
-            # - 96 Channel pipettes will begin in the corner opposite their primary/starting nozzle (if starting nozzle = A1, enter tiprack at H12)
-            #   The 96 channel will then progress towards the opposite corner, either going up or down, left or right depending on configuration.
-
-            if num_channels == 1:
-                return _cluster_search_A1(num_nozzle_cols, num_nozzle_rows)
-            elif num_channels == 8:
-                if nozzle_map.starting_nozzle == "A1":
-                    return _cluster_search_H1(num_nozzle_cols, num_nozzle_rows)
-                elif nozzle_map.starting_nozzle == "H1":
-                    return _cluster_search_A1(num_nozzle_cols, num_nozzle_rows)
-            elif num_channels == 96:
-                if nozzle_map.starting_nozzle == "A1":
-                    return _cluster_search_H12(num_nozzle_cols, num_nozzle_rows)
-                elif nozzle_map.starting_nozzle == "A12":
-                    return _cluster_search_H1(num_nozzle_cols, num_nozzle_rows)
-                elif nozzle_map.starting_nozzle == "H1":
-                    return _cluster_search_A12(num_nozzle_cols, num_nozzle_rows)
-                elif nozzle_map.starting_nozzle == "H12":
-                    return _cluster_search_A1(num_nozzle_cols, num_nozzle_rows)
-                else:
-                    raise ValueError(
-                        f"Nozzle {nozzle_map.starting_nozzle} is an invalid starting tip for automatic tip pickup."
-                    )
-            else:
-                raise RuntimeError(
-                    "Invalid number of channels for automatic tip tracking."
-                )
+        Does not support use of a starting tip if the pipette used is in a partial configuration.
+        """
+        if starting_tip_name is None and nozzle_map is not None:
+            return self._get_next_tip_with_nozzle_map(labware_id, nozzle_map)
         else:
+            wells = self._state.tips_by_labware_id.get(labware_id, {})
+            columns = self._state.columns_by_labware_id.get(labware_id, [])
             if columns and num_tips == len(columns[0]):  # Get next tips for 8-channel
                 column_head = [column[0] for column in columns]
                 starting_column_index = 0
@@ -373,6 +166,74 @@ class TipView:
                         return well_name
         return None
 
+    def _get_next_tip_with_nozzle_map(
+        self,
+        labware_id: str,
+        nozzle_map: NozzleMapInterface,
+    ) -> Optional[str]:
+        """Get the next available clean tip for given nozzle configuration if one can be found."""
+        tip_well_states = self._state.tips_by_labware_id.get(labware_id, {})
+        wells_by_columns = self._state.columns_by_labware_id.get(labware_id, [])
+
+        def _validate_wells(well_list: Set[str], target_well: str) -> bool:
+            # If we are not picking up the correct number of tips it's not valid
+            if len(well_list) != nozzle_map.tip_count:
+                return False
+            # If not all the tips we'll be picking up are clean it's not valid
+            cluster_tip_well_states = [
+                tip_well_states[well_name] for well_name in well_list
+            ]
+            if not all(
+                well_state == _TipRackWellState.CLEAN
+                for well_state in cluster_tip_well_states
+            ):
+                return False
+            if nozzle_map.configuration != NozzleConfigurationType.FULL:
+                # If we have a partial configuration we need to ensure that any wells in the way are NOT present
+                wells_covered_physically = set(
+                    wells_covered_by_physical_pipette(
+                        nozzle_map=nozzle_map,  # type: ignore[arg-type]
+                        target_well=target_well,
+                        labware_wells_by_column=wells_by_columns,
+                    )
+                )
+                wells_in_way_well_state = [
+                    tip_well_states[well_name]
+                    for well_name in wells_covered_physically.difference(well_list)
+                ]
+                if not all(
+                    well_state == _TipRackWellState.USED
+                    for well_state in wells_in_way_well_state
+                ):
+                    return False
+
+            return True
+
+        # Get an ordered list of wells to most efficiently search, depending on pipette configuration
+        targeted_well_list = _resolve_well_order(
+            wells_by_columns,
+            nozzle_map.starting_nozzle,
+            nozzle_map.physical_nozzle_count,
+        )
+
+        for well in targeted_well_list:
+            # If the target well/tip isn't clean, skip to the next one
+            if tip_well_states[well] != _TipRackWellState.CLEAN:
+                continue
+            # Get list of all wells (i.e. tips) that would be covered by the active nozzles
+            targeted_wells = set(
+                wells_covered_by_pipette_configuration(
+                    nozzle_map=nozzle_map,  # type: ignore[arg-type]
+                    target_well=well,
+                    labware_wells_by_column=wells_by_columns,
+                )
+            )
+            # If we are picking up the correct number of tips, return that target well
+            if _validate_wells(targeted_wells, target_well=well):
+                return well
+
+        return None
+
     def has_clean_tip(self, labware_id: str, well_name: str) -> bool:
         """Get whether a well in a labware has a clean tip.
 
@@ -403,7 +264,15 @@ class TipView:
             The well names of all the tips that the operation will use.
         """
         columns = self._state.columns_by_labware_id.get(labware_id, [])
-        return list(wells_covered_dense(nozzle_map, well_name, columns))
+        return list(
+            wells_covered_dense(
+                nozzle_map.columns,
+                nozzle_map.rows,
+                nozzle_map.starting_nozzle,
+                well_name,
+                columns,
+            )
+        )
 
 
 def _drop_wells_before_starting_tip(
@@ -418,3 +287,69 @@ def _drop_wells_before_starting_tip(
         if seen_starting_well:
             remaining_wells[well_name] = tip_state
     return remaining_wells
+
+
+def _resolve_well_order(  # noqa: C901
+    well_list: List[List[str]], starting_nozzle: str, physical_nozzle_count: int
+) -> List[str]:
+    """Given a list of ordered columns and pipette information, returns a flat list of wells ordered for tip pick up.
+
+    The order depends on the physical nozzle count and starting nozzle of the pipette configuration
+    - A single channel pipette will search for tips top to bottom, left to right (A1, B1, ... A2, B2, .. G12, H12)
+    - An eight channel pipette will always search left to right, top to bottom if the starting nozzle is H1,
+        bottom to top (H1, G1, ... H2, G2, ... B12, A12) if the starting nozzle is A1
+    - A 96 channel pipette will begin in the opposite corner of it's primary nozzle
+        - Top to bottom, left to right for starting nozzle H12
+        - Bottom to top, left to right for starting nozzle A12
+        - Top to bottom, right to left (A12, B12, ... A11, B11, ... G1, H1) for starting nozzle H1
+        - Bottom to top, right to left (H12, G12, ... H11, G11, ... B1, A1) for starting nozzle A1
+    """
+    if physical_nozzle_count == 1:
+        return _get_top_to_bottom_left_to_right(well_list)
+    elif physical_nozzle_count == 8:
+        if starting_nozzle == "A1":
+            return _get_bottom_to_top_left_to_right(well_list)
+        elif starting_nozzle == "H1":
+            return _get_top_to_bottom_left_to_right(well_list)
+        else:
+            raise ValueError(
+                f"Nozzle {starting_nozzle} is an invalid starting tip for 8-channel pipette automatic tip pickup."
+            )
+    elif physical_nozzle_count == 96:
+        if starting_nozzle == "A1":
+            return _get_bottom_to_top_right_to_left(well_list)
+        elif starting_nozzle == "A12":
+            return _get_bottom_to_top_left_to_right(well_list)
+        elif starting_nozzle == "H1":
+            return _get_top_to_bottom_right_to_left(well_list)
+        elif starting_nozzle == "H12":
+            return _get_top_to_bottom_left_to_right(well_list)
+        else:
+            raise ValueError(
+                f"Nozzle {starting_nozzle} is an invalid starting tip for 96-channel automatic tip pickup."
+            )
+    else:
+        raise ValueError(
+            f"Automatic tip pickup does not support {physical_nozzle_count}-channel pipettes"
+        )
+
+
+def _get_top_to_bottom_left_to_right(well_list: List[List[str]]) -> List[str]:
+    return [well for column in well_list for well in column]
+
+
+def _get_bottom_to_top_left_to_right(well_list: List[List[str]]) -> List[str]:
+    reverse_column_ordering = [list(reversed(column)) for column in well_list]
+    return [well for column in reverse_column_ordering for well in column]
+
+
+def _get_top_to_bottom_right_to_left(well_list: List[List[str]]) -> List[str]:
+    reverse_row_ordering = list(reversed(well_list))
+    return [well for column in reverse_row_ordering for well in column]
+
+
+def _get_bottom_to_top_right_to_left(well_list: List[List[str]]) -> List[str]:
+    reverse_row_column_ordering = [
+        list(reversed(column)) for column in reversed(well_list)
+    ]
+    return [well for column in reverse_row_column_ordering for well in column]

--- a/api/src/opentrons/protocol_engine/state/tips.py
+++ b/api/src/opentrons/protocol_engine/state/tips.py
@@ -127,39 +127,43 @@ class TipView:
         """
         if starting_tip_name is None and nozzle_map is not None:
             return self._get_next_tip_with_nozzle_map(labware_id, nozzle_map)
+        else:
+            wells = self._state.tips_by_labware_id.get(labware_id, {})
+            columns = self._state.columns_by_labware_id.get(labware_id, [])
+            if columns and num_tips == len(columns[0]):  # Get next tips for 8-channel
+                column_head = [column[0] for column in columns]
+                starting_column_index = 0
 
-        wells = self._state.tips_by_labware_id.get(labware_id, {})
-        columns = self._state.columns_by_labware_id.get(labware_id, [])
-        if columns and num_tips == len(columns[0]):  # Get next tips for 8-channel
-            column_head = [column[0] for column in columns]
-            starting_column_index = 0
+                if starting_tip_name:
+                    for idx, column in enumerate(columns):
+                        if starting_tip_name in column:
+                            if starting_tip_name not in column_head:
+                                starting_column_index = idx + 1
+                            else:
+                                starting_column_index = idx
 
-            if starting_tip_name:
-                for idx, column in enumerate(columns):
-                    if starting_tip_name in column:
-                        if starting_tip_name not in column_head:
-                            starting_column_index = idx + 1
-                        else:
-                            starting_column_index = idx
+                for column in columns[starting_column_index:]:
+                    if not any(
+                        wells[well] == _TipRackWellState.USED for well in column
+                    ):
+                        return column[0]
 
-            for column in columns[starting_column_index:]:
-                if not any(wells[well] == _TipRackWellState.USED for well in column):
-                    return column[0]
-        elif num_tips == len(wells.keys()):  # Get next tips for 96 channel
-            if starting_tip_name and starting_tip_name != columns[0][0]:
-                return None
+            elif num_tips == len(wells.keys()):  # Get next tips for 96 channel
+                if starting_tip_name and starting_tip_name != columns[0][0]:
+                    return None
 
-            if not any(
-                tip_state == _TipRackWellState.USED for tip_state in wells.values()
-            ):
-                return next(iter(wells))
-        else:  # Get next tips for single channel
-            if starting_tip_name is not None:
-                wells = _drop_wells_before_starting_tip(wells, starting_tip_name)
+                if not any(
+                    tip_state == _TipRackWellState.USED for tip_state in wells.values()
+                ):
+                    return next(iter(wells))
 
-            for well_name, tip_state in wells.items():
-                if tip_state == _TipRackWellState.CLEAN:
-                    return well_name
+            else:  # Get next tips for single channel
+                if starting_tip_name is not None:
+                    wells = _drop_wells_before_starting_tip(wells, starting_tip_name)
+
+                for well_name, tip_state in wells.items():
+                    if tip_state == _TipRackWellState.CLEAN:
+                        return well_name
         return None
 
     def _get_next_tip_with_nozzle_map(

--- a/api/src/opentrons/protocol_engine/state/tips.py
+++ b/api/src/opentrons/protocol_engine/state/tips.py
@@ -288,14 +288,14 @@ def _resolve_well_order(  # noqa: C901
     """Given a list of ordered columns and pipette information, returns a flat list of wells ordered for tip pick up.
 
     Wells can be ordered in four different ways:
-        - Left to right, top to bottom (A1, B1, ... A2, B2, ... G12, H12)
-        - Left to right, bottom to top (H1, G1, ... H2, G2, ... B12, A12)
-        - Right to left, top to bottom (A12, B12, ... A11, B11, ... G1, H1)
-        - Right to left, bottom to top (A12, B12, ... A11, B11, ... G1, H1)
+        - Top to bottom, left to right (A1, B1, ... A2, B2, ... G12, H12)
+        - Top to bottom, right to left (A12, B12, ... A11, B11, ... G1, H1)
+        - Bottom to top, left to right, (H1, G1, ... H2, G2, ... B12, A12)
+        - Bottom to top, right to left (A12, B12, ... A11, B11, ... G1, H1)
 
-    - Full configurations (which will always cover a single channel) will always go left to right, top to bottom.
-    - A partial 8-channel pipette configuration will always search left to right, either top to bottom for starting
-        nozzle H1 or bottom to top for starting nozzle A1
+    - Full configurations (which will always cover a single channel) will go top to bottom, left to right.
+    - A partial 8-channel pipette configuration will always search left to right, starting at either top to bottom for
+        starting nozzle H1 or bottom to top for starting nozzle A1
     - A partial 96-channel pipette configuration will always begin in the opposite corner of the starting nozzle
     """
     if nozzle_map.configuration == NozzleConfigurationType.FULL:

--- a/api/src/opentrons/protocol_engine/state/tips.py
+++ b/api/src/opentrons/protocol_engine/state/tips.py
@@ -210,13 +210,9 @@ class TipView:
             return True
 
         # Get an ordered list of wells to most efficiently search, depending on pipette configuration
-        targeted_well_list = _resolve_well_order(
-            wells_by_columns,
-            nozzle_map.starting_nozzle,
-            nozzle_map.physical_nozzle_count,
-        )
+        well_list = _resolve_well_order(wells_by_columns, nozzle_map)
 
-        for well in targeted_well_list:
+        for well in well_list:
             # If the target well/tip isn't clean, skip to the next one
             if tip_well_states[well] != _TipRackWellState.CLEAN:
                 continue
@@ -290,47 +286,49 @@ def _drop_wells_before_starting_tip(
 
 
 def _resolve_well_order(  # noqa: C901
-    well_list: List[List[str]], starting_nozzle: str, physical_nozzle_count: int
+    well_list: List[List[str]], nozzle_map: NozzleMapInterface
 ) -> List[str]:
     """Given a list of ordered columns and pipette information, returns a flat list of wells ordered for tip pick up.
 
-    The order depends on the physical nozzle count and starting nozzle of the pipette configuration
-    - A single channel pipette will search for tips top to bottom, left to right (A1, B1, ... A2, B2, .. G12, H12)
-    - An eight channel pipette will always search left to right, top to bottom if the starting nozzle is H1,
-        bottom to top (H1, G1, ... H2, G2, ... B12, A12) if the starting nozzle is A1
-    - A 96 channel pipette will begin in the opposite corner of it's primary nozzle
-        - Top to bottom, left to right for starting nozzle H12
-        - Bottom to top, left to right for starting nozzle A12
-        - Top to bottom, right to left (A12, B12, ... A11, B11, ... G1, H1) for starting nozzle H1
-        - Bottom to top, right to left (H12, G12, ... H11, G11, ... B1, A1) for starting nozzle A1
+    Wells can be ordered in four different ways:
+        - Left to right, top to bottom (A1, B1, ... A2, B2, ... G12, H12)
+        - Left to right, bottom to top (H1, G1, ... H2, G2, ... B12, A12)
+        - Right to left, top to bottom (A12, B12, ... A11, B11, ... G1, H1)
+        - Right to left, bottom to top (A12, B12, ... A11, B11, ... G1, H1)
+
+    - Full configurations (which will always cover a single channel) will always go left to right, top to bottom.
+    - A partial 8-channel pipette configuration will always search left to right, either top to bottom for starting
+        nozzle H1 or bottom to top for starting nozzle A1
+    - A partial 96-channel pipette configuration will always begin in the opposite corner of the starting nozzle
     """
-    if physical_nozzle_count == 1:
+    if nozzle_map.configuration == NozzleConfigurationType.FULL:
         return _get_top_to_bottom_left_to_right(well_list)
-    elif physical_nozzle_count == 8:
-        if starting_nozzle == "A1":
+    elif nozzle_map.physical_nozzle_count == 8:
+        if nozzle_map.starting_nozzle == "A1":
             return _get_bottom_to_top_left_to_right(well_list)
-        elif starting_nozzle == "H1":
+        elif nozzle_map.starting_nozzle == "H1":
             return _get_top_to_bottom_left_to_right(well_list)
         else:
             raise ValueError(
-                f"Nozzle {starting_nozzle} is an invalid starting tip for 8-channel pipette automatic tip pickup."
+                f"Nozzle {nozzle_map.starting_nozzle} is an invalid starting tip for"
+                " 8-channel pipette automatic tip pickup."
             )
-    elif physical_nozzle_count == 96:
-        if starting_nozzle == "A1":
+    elif nozzle_map.physical_nozzle_count == 96:
+        if nozzle_map.starting_nozzle == "A1":
             return _get_bottom_to_top_right_to_left(well_list)
-        elif starting_nozzle == "A12":
+        elif nozzle_map.starting_nozzle == "A12":
             return _get_bottom_to_top_left_to_right(well_list)
-        elif starting_nozzle == "H1":
+        elif nozzle_map.starting_nozzle == "H1":
             return _get_top_to_bottom_right_to_left(well_list)
-        elif starting_nozzle == "H12":
+        elif nozzle_map.starting_nozzle == "H12":
             return _get_top_to_bottom_left_to_right(well_list)
         else:
             raise ValueError(
-                f"Nozzle {starting_nozzle} is an invalid starting tip for 96-channel automatic tip pickup."
+                f"Nozzle {nozzle_map.starting_nozzle} is an invalid starting tip for 96-channel automatic tip pickup."
             )
     else:
         raise ValueError(
-            f"Automatic tip pickup does not support {physical_nozzle_count}-channel pipettes"
+            f"Automatic tip pickup does not support {nozzle_map.physical_nozzle_count}-channel pipettes"
         )
 
 

--- a/api/src/opentrons/protocol_engine/state/tips.py
+++ b/api/src/opentrons/protocol_engine/state/tips.py
@@ -185,6 +185,8 @@ class TipView:
                 state == _TipRackWellState.CLEAN for state in target_well_states
             ):
                 return False
+            # Since we know a full configuration will always produce zero non-active overlapping wells
+            # we can skip the following checks if it is a full configuration.
             if nozzle_map.configuration != NozzleConfigurationType.FULL:
                 # If we have a partial configuration we need to ensure that any wells in the way are NOT present
                 wells_covered_physically = set(
@@ -210,7 +212,8 @@ class TipView:
         target_well_list = _resolve_well_order(wells_by_columns, nozzle_map)
 
         for well in target_well_list:
-            # If the target well/tip isn't clean, skip to the next one
+            # If the target well/tip isn't clean, skip to the next one. This will be checked
+            # again in _validate_wells, but we can short circuit the following checks if this is False
             if tip_well_states[well] != _TipRackWellState.CLEAN:
                 continue
             # Get list of all wells (i.e. tips) that would be covered by the active nozzles
@@ -290,7 +293,7 @@ def _resolve_well_order(  # noqa: C901
     Wells can be ordered in four different ways:
         - Top to bottom, left to right (A1, B1, ... A2, B2, ... G12, H12)
         - Top to bottom, right to left (A12, B12, ... A11, B11, ... G1, H1)
-        - Bottom to top, left to right, (H1, G1, ... H2, G2, ... B12, A12)
+        - Bottom to top, left to right (H1, G1, ... H2, G2, ... B12, A12)
         - Bottom to top, right to left (A12, B12, ... A11, B11, ... G1, H1)
 
     - Full configurations (which will always cover a single channel) will go top to bottom, left to right.

--- a/api/src/opentrons/protocol_engine/state/tips.py
+++ b/api/src/opentrons/protocol_engine/state/tips.py
@@ -127,43 +127,39 @@ class TipView:
         """
         if starting_tip_name is None and nozzle_map is not None:
             return self._get_next_tip_with_nozzle_map(labware_id, nozzle_map)
-        else:
-            wells = self._state.tips_by_labware_id.get(labware_id, {})
-            columns = self._state.columns_by_labware_id.get(labware_id, [])
-            if columns and num_tips == len(columns[0]):  # Get next tips for 8-channel
-                column_head = [column[0] for column in columns]
-                starting_column_index = 0
 
-                if starting_tip_name:
-                    for idx, column in enumerate(columns):
-                        if starting_tip_name in column:
-                            if starting_tip_name not in column_head:
-                                starting_column_index = idx + 1
-                            else:
-                                starting_column_index = idx
+        wells = self._state.tips_by_labware_id.get(labware_id, {})
+        columns = self._state.columns_by_labware_id.get(labware_id, [])
+        if columns and num_tips == len(columns[0]):  # Get next tips for 8-channel
+            column_head = [column[0] for column in columns]
+            starting_column_index = 0
 
-                for column in columns[starting_column_index:]:
-                    if not any(
-                        wells[well] == _TipRackWellState.USED for well in column
-                    ):
-                        return column[0]
+            if starting_tip_name:
+                for idx, column in enumerate(columns):
+                    if starting_tip_name in column:
+                        if starting_tip_name not in column_head:
+                            starting_column_index = idx + 1
+                        else:
+                            starting_column_index = idx
 
-            elif num_tips == len(wells.keys()):  # Get next tips for 96 channel
-                if starting_tip_name and starting_tip_name != columns[0][0]:
-                    return None
+            for column in columns[starting_column_index:]:
+                if not any(wells[well] == _TipRackWellState.USED for well in column):
+                    return column[0]
+        elif num_tips == len(wells.keys()):  # Get next tips for 96 channel
+            if starting_tip_name and starting_tip_name != columns[0][0]:
+                return None
 
-                if not any(
-                    tip_state == _TipRackWellState.USED for tip_state in wells.values()
-                ):
-                    return next(iter(wells))
+            if not any(
+                tip_state == _TipRackWellState.USED for tip_state in wells.values()
+            ):
+                return next(iter(wells))
+        else:  # Get next tips for single channel
+            if starting_tip_name is not None:
+                wells = _drop_wells_before_starting_tip(wells, starting_tip_name)
 
-            else:  # Get next tips for single channel
-                if starting_tip_name is not None:
-                    wells = _drop_wells_before_starting_tip(wells, starting_tip_name)
-
-                for well_name, tip_state in wells.items():
-                    if tip_state == _TipRackWellState.CLEAN:
-                        return well_name
+            for well_name, tip_state in wells.items():
+                if tip_state == _TipRackWellState.CLEAN:
+                    return well_name
         return None
 
     def _get_next_tip_with_nozzle_map(
@@ -180,12 +176,9 @@ class TipView:
             if len(well_list) != nozzle_map.tip_count:
                 return False
             # If not all the tips we'll be picking up are clean it's not valid
-            cluster_tip_well_states = [
-                tip_well_states[well_name] for well_name in well_list
-            ]
+            target_well_states = [tip_well_states[well_name] for well_name in well_list]
             if not all(
-                well_state == _TipRackWellState.CLEAN
-                for well_state in cluster_tip_well_states
+                state == _TipRackWellState.CLEAN for state in target_well_states
             ):
                 return False
             if nozzle_map.configuration != NozzleConfigurationType.FULL:
@@ -210,9 +203,9 @@ class TipView:
             return True
 
         # Get an ordered list of wells to most efficiently search, depending on pipette configuration
-        well_list = _resolve_well_order(wells_by_columns, nozzle_map)
+        target_well_list = _resolve_well_order(wells_by_columns, nozzle_map)
 
-        for well in well_list:
+        for well in target_well_list:
             # If the target well/tip isn't clean, skip to the next one
             if tip_well_states[well] != _TipRackWellState.CLEAN:
                 continue

--- a/api/tests/opentrons/protocol_engine/state/test_tip_state.py
+++ b/api/tests/opentrons/protocol_engine/state/test_tip_state.py
@@ -665,6 +665,64 @@ def test_next_tip_automatic_tip_tracking_tiprack_limits(
     assert _get_next_and_pickup(pipette_nozzle_map) is None
 
 
+def test_96_column_after_row_returns_none(
+    subject: TipStore,
+    load_labware_action: actions.SucceedCommandAction,
+) -> None:
+    """It should return None when there's no valid columns to pick up."""
+    subject.handle_action(load_labware_action)
+
+    def _get_next_and_pickup(nozzle_map: NozzleMap) -> str | None:
+        result = TipView(subject.state).get_next_tip(
+            labware_id="cool-labware",
+            num_tips=0,
+            starting_tip_name=None,
+            nozzle_map=nozzle_map,
+        )
+        if result is not None:
+            pick_up_tip_state_update = update_types.StateUpdate(
+                tips_used=update_types.TipsUsedUpdate(
+                    labware_id="cool-labware",
+                    well_names=TipView(subject.state).compute_tips_to_mark_as_used(
+                        labware_id="cool-labware",
+                        well_name=result,
+                        nozzle_map=nozzle_map,
+                    ),
+                )
+            )
+
+            subject.handle_action(
+                actions.SucceedCommandAction(
+                    command=_dummy_command(),
+                    state_update=pick_up_tip_state_update,
+                )
+            )
+
+        return result
+
+    row_nozzle_map = NozzleMap.build(
+        physical_nozzles=NINETY_SIX_MAP,
+        physical_rows=NINETY_SIX_ROWS,
+        physical_columns=NINETY_SIX_COLS,
+        starting_nozzle="A1",
+        back_left_nozzle="A1",
+        front_right_nozzle="A12",
+        valid_nozzle_maps=ValidNozzleMaps(maps={"RowA": NINETY_SIX_ROWS["A"]}),
+    )
+    assert _get_next_and_pickup(row_nozzle_map) is not None
+
+    col_nozzle_map = NozzleMap.build(
+        physical_nozzles=NINETY_SIX_MAP,
+        physical_rows=NINETY_SIX_ROWS,
+        physical_columns=NINETY_SIX_COLS,
+        starting_nozzle="A1",
+        back_left_nozzle="A1",
+        front_right_nozzle="H1",
+        valid_nozzle_maps=ValidNozzleMaps(maps={"Column1": NINETY_SIX_COLS["1"]}),
+    )
+    assert _get_next_and_pickup(col_nozzle_map) is None
+
+
 def test_handle_batch_labware_loaded_update(
     subject: TipStore, labware_definition: LabwareDefinition
 ) -> None:

--- a/api/tests/opentrons/protocol_engine/state/test_tip_state.py
+++ b/api/tests/opentrons/protocol_engine/state/test_tip_state.py
@@ -178,7 +178,6 @@ def test_get_next_tip_skips_picked_up_tip(
     subject.handle_action(load_labware_action)
 
     if input_starting_tip is not None:
-        pipette_name_type = PipetteNameType.P1000_96
         if input_tip_amount == 1:
             pipette_name_type = PipetteNameType.P300_SINGLE_GEN2
         elif input_tip_amount == 8:
@@ -186,7 +185,6 @@ def test_get_next_tip_skips_picked_up_tip(
         else:
             pipette_name_type = PipetteNameType.P1000_96
     else:
-        pipette_name_type = PipetteNameType.P1000_96
         if get_next_tip_tips == 1:
             pipette_name_type = PipetteNameType.P300_SINGLE_GEN2
         elif get_next_tip_tips == 8:
@@ -560,27 +558,27 @@ def test_next_tip_automatic_tip_tracking_with_partial_configurations(
             ),
         )
 
-    map = _build_nozzle_map("A1", "A1", "H3")
-    _assert_and_pickup("A10", map)
-    map = _build_nozzle_map("A1", "A1", "F2")
-    _assert_and_pickup("C8", map)
+    pipette_nozzle_map = _build_nozzle_map("A1", "A1", "H3")
+    _assert_and_pickup("A10", pipette_nozzle_map)
+    pipette_nozzle_map = _build_nozzle_map("A1", "A1", "F2")
+    _assert_and_pickup("C8", pipette_nozzle_map)
 
     # Configure to single tip pickups
-    map = _build_nozzle_map("H12", "H12", "H12")
-    _assert_and_pickup("A1", map)
-    map = _build_nozzle_map("H1", "H1", "H1")
-    _assert_and_pickup("A9", map)
-    map = _build_nozzle_map("A12", "A12", "A12")
-    _assert_and_pickup("H1", map)
-    map = _build_nozzle_map("A1", "A1", "A1")
-    _assert_and_pickup("B9", map)
+    pipette_nozzle_map = _build_nozzle_map("H12", "H12", "H12")
+    _assert_and_pickup("A1", pipette_nozzle_map)
+    pipette_nozzle_map = _build_nozzle_map("H1", "H1", "H1")
+    _assert_and_pickup("A9", pipette_nozzle_map)
+    pipette_nozzle_map = _build_nozzle_map("A12", "A12", "A12")
+    _assert_and_pickup("H1", pipette_nozzle_map)
+    pipette_nozzle_map = _build_nozzle_map("A1", "A1", "A1")
+    _assert_and_pickup("B9", pipette_nozzle_map)
 
 
 def test_next_tip_automatic_tip_tracking_tiprack_limits(
     subject: TipStore,
     load_labware_action: actions.SucceedCommandAction,
 ) -> None:
-    """Test tip tracking logic to ensure once a tiprack is consumed it returns None when consuming tips using multiple pipette configurations."""
+    """Ensure once a tip rack is consumed it returns None when consuming tips using multiple pipette configurations."""
     # Load labware
     subject.handle_action(load_labware_action)
 
@@ -643,28 +641,28 @@ def test_next_tip_automatic_tip_tracking_tiprack_limits(
             ),
         )
 
-    map = _build_nozzle_map("A1", "A1", "A1")
+    pipette_nozzle_map = _build_nozzle_map("A1", "A1", "A1")
     for _ in range(96):
-        assert _get_next_and_pickup(map) is not None
-    assert _get_next_and_pickup(map) is None
+        assert _get_next_and_pickup(pipette_nozzle_map) is not None
+    assert _get_next_and_pickup(pipette_nozzle_map) is None
 
     subject.handle_action(actions.ResetTipsAction(labware_id="cool-labware"))
-    map = _build_nozzle_map("A12", "A12", "A12")
+    pipette_nozzle_map = _build_nozzle_map("A12", "A12", "A12")
     for _ in range(96):
-        assert _get_next_and_pickup(map) is not None
-    assert _get_next_and_pickup(map) is None
+        assert _get_next_and_pickup(pipette_nozzle_map) is not None
+    assert _get_next_and_pickup(pipette_nozzle_map) is None
 
     subject.handle_action(actions.ResetTipsAction(labware_id="cool-labware"))
-    map = _build_nozzle_map("H1", "H1", "H1")
+    pipette_nozzle_map = _build_nozzle_map("H1", "H1", "H1")
     for _ in range(96):
-        assert _get_next_and_pickup(map) is not None
-    assert _get_next_and_pickup(map) is None
+        assert _get_next_and_pickup(pipette_nozzle_map) is not None
+    assert _get_next_and_pickup(pipette_nozzle_map) is None
 
     subject.handle_action(actions.ResetTipsAction(labware_id="cool-labware"))
-    map = _build_nozzle_map("H12", "H12", "H12")
+    pipette_nozzle_map = _build_nozzle_map("H12", "H12", "H12")
     for _ in range(96):
-        assert _get_next_and_pickup(map) is not None
-    assert _get_next_and_pickup(map) is None
+        assert _get_next_and_pickup(pipette_nozzle_map) is not None
+    assert _get_next_and_pickup(pipette_nozzle_map) is None
 
 
 def test_handle_batch_labware_loaded_update(

--- a/api/tests/opentrons/protocol_engine/state/test_well_math.py
+++ b/api/tests/opentrons/protocol_engine/state/test_well_math.py
@@ -18,7 +18,7 @@ from opentrons.protocol_engine.state._well_math import (
     nozzles_per_well,
 )
 
-from tests.opentrons.protocol_engine import pipette_fixtures
+from .. import pipette_fixtures
 
 _96_FULL_MAP = NozzleMap.build(
     physical_nozzles=pipette_fixtures.NINETY_SIX_MAP,

--- a/api/tests/opentrons/protocol_engine/state/test_well_math.py
+++ b/api/tests/opentrons/protocol_engine/state/test_well_math.py
@@ -18,7 +18,7 @@ from opentrons.protocol_engine.state._well_math import (
     nozzles_per_well,
 )
 
-from .. import pipette_fixtures
+from tests.opentrons.protocol_engine import pipette_fixtures
 
 _96_FULL_MAP = NozzleMap.build(
     physical_nozzles=pipette_fixtures.NINETY_SIX_MAP,
@@ -225,7 +225,18 @@ def test_wells_covered_dense_96(
     _96_wells: list[list[str]],
 ) -> None:
     """It should calculate well coverage for an SBS 96."""
-    assert list(wells_covered_dense(nozzle_map, target_well, _96_wells)) == result
+    assert (
+        list(
+            wells_covered_dense(
+                nozzle_map.columns,
+                nozzle_map.rows,
+                nozzle_map.starting_nozzle,
+                target_well,
+                _96_wells,
+            )
+        )
+        == result
+    )
 
 
 @pytest.mark.parametrize(
@@ -307,7 +318,18 @@ def test_wells_covered_dense_384(
     _384_wells: list[list[str]],
 ) -> None:
     """It should calculate well coverage for an SBS 384."""
-    assert list(wells_covered_dense(nozzle_map, target_well, _384_wells)) == result
+    assert (
+        list(
+            wells_covered_dense(
+                nozzle_map.columns,
+                nozzle_map.rows,
+                nozzle_map.starting_nozzle,
+                target_well,
+                _384_wells,
+            )
+        )
+        == result
+    )
 
 
 @pytest.mark.parametrize(
@@ -338,7 +360,18 @@ def test_wells_covered_sparse_12(
     _12_reservoir: list[list[str]],
 ) -> None:
     """It should calculate well coverage for a 12 column reservoir."""
-    assert list(wells_covered_sparse(nozzle_map, target_well, _12_reservoir)) == result
+    assert (
+        list(
+            wells_covered_sparse(
+                nozzle_map.columns,
+                nozzle_map.rows,
+                nozzle_map.starting_nozzle,
+                target_well,
+                _12_reservoir,
+            )
+        )
+        == result
+    )
 
 
 @pytest.mark.parametrize(
@@ -354,7 +387,15 @@ def test_wells_covered_sparse_1(
     nozzle_map: NozzleMap, _1_reservoir: list[list[str]]
 ) -> None:
     """It should calculate well coverage for a 1 column reservoir."""
-    assert list(wells_covered_sparse(nozzle_map, "A1", _1_reservoir)) == ["A1"]
+    assert list(
+        wells_covered_sparse(
+            nozzle_map.columns,
+            nozzle_map.rows,
+            nozzle_map.starting_nozzle,
+            "A1",
+            _1_reservoir,
+        )
+    ) == ["A1"]
 
 
 @pytest.mark.parametrize(

--- a/robot-server/tests/runs/router/test_base_router.py
+++ b/robot-server/tests/runs/router/test_base_router.py
@@ -858,6 +858,7 @@ async def test_get_current_state_success(
                 valid_map_key="mock-key",
                 full_instrument_map_store={},
                 full_instrument_rows={},
+                full_instrument_columns={},
             )
         }
     )


### PR DESCRIPTION
# Overview

This PR refactors Protocol Engine `TipView.get_next_tip` to simplify logic and reduce repeated code when provided a `NozzleMap` object, which allows partial tip pickup.

The outcome of this function is finding the next available (if any) tip for a tip rack, the result tip expressed in the form of a well name `str`, e.g. `"A1"` or `None` if no valid tip(s) could be found. It ensures that the correct number of fresh (`_TipRackWellState.CLEAN`) tips are picked up, without accidentally picking up any other tips for a partial tip configuration.

The previous implementation did this by first determining what order the tips should be searched through (which can be one of four combinations of left to right/right to left and top to bottom/bottom to top), and then calling one of four functions for that path. Each of these would iterate through the columns and rows, identify any potential "tip cluster". This would be checked by the internal `_validate_tip_cluster` to check if all the tips were clean, and then return either a well name `str`, `None` or an `int` `-1` to signal that a partial configuration could not be picked up from that tip rack.

The four tip cluster search methods were all very similar yet had enough differences in iterative logic that they were required to be separate. In addition, each had multiple `return` paths, `while` loops, and nested `for` loops that made reading and maintaining this code difficult.

The new logic works in a more straightforward way. First, after checking that a nozzle map exists and that there is no starting tip, we create a flat list of well name `str`s ordered in the same way the previous cluster searches would iterate through the wells (except for a `FULL` configuration, more on that on the paragraph describing differences).  We then iterate through that list, first checking that the target tip is clean, and then using `wells_covered_by_pipette_configuration` to get a set of wells that will be picked up when targeting that tip well. This is then verified to make sure the following things are true:
- The correct number of tips are being picked up
- All tips being picked up are `_TipRackWellState.CLEAN`
- If it is partial configuration, no other tips that would physically collide with any non-active nozzles that are present
If all the above are true, we return that tip well name, otherwise if we exhaust all the tip wells we return `None`

For checking the partial configuration case, a new method was added to `_well_math` called `wells_covered_by_physical_pipette`, which reuses the same logic as `wells_covered_by_pipette_configuration`, but refactored to allow repeated code (aided by having the `NozzleManager` now hold onto the full instrument columns). The difference in these two sets is taken, and all the extra wells are checked to assure they are `_TipRackWellState.USED`

There are two logical (but not functional) differences to this implementation. One is that for any `FULL` configuration we are defaulting to the standard well order of top to bottom, left to right (i.e. `A1, B1, ... A2, B2, ... G12, H12`). For a single channel pipette it would be that order anyway, for an eight channel pipette all tips will be picked up in the `A` row and this orders them to be evaluated sooner, and a 96 channel will only pick up from `A1` and this will be first in that list versus last, reducing a common worst-case scenario.

The other change is that the previous logic had a short circuit escape from searching if it determined there was a combination of unused tips that would prevent a particular partial configuration from being able to be picked up in that tip rack. This new version does not have such logic, though ultimately it will arrive at the same result of `None`.

## Test Plan and Hands on Testing

Unit tests and integration tests should cover a lot of the regression testing. The following protocols are used to test functionality on robot:

```python
from opentrons.protocol_api import PARTIAL_COLUMN, SINGLE

requirements = {
    "robotType": "Flex",
    "apiLevel": "2.25"
}


metadata = {
    "protocolName":'8-channel, partial column and single automatic tip tracking test',
    'author':'Jeremy'
}

def run(protocol_context):
    tiprack = protocol_context.load_labware("opentrons_flex_96_tiprack_50ul", "C2")
    trash = protocol_context.load_trash_bin('A3')
    single_pipette = protocol_context.load_instrument("flex_1channel_1000", "right", tip_racks=[tiprack])
    multi_channel_pipette = protocol_context.load_instrument("flex_8channel_50", "left", tip_racks=[tiprack])


    # Pick up the first 2 columns
    for _ in range(2):
        multi_channel_pipette.pick_up_tip()
        multi_channel_pipette.drop_tip()

    # Configure for 4 tip pick up
    multi_channel_pipette.configure_nozzle_layout(PARTIAL_COLUMN, start="H1", end="E1", tip_racks=[tiprack])

    # Pick up a column in two iterations
    for _ in range(2):
        multi_channel_pipette.pick_up_tip()
        multi_channel_pipette.drop_tip()

    # Configure single with H1
    multi_channel_pipette.configure_nozzle_layout(SINGLE, start="H1", tip_racks=[tiprack])

    # Pick up the first two tips in a column with 8-channel
    for _ in range(2):
        multi_channel_pipette.pick_up_tip()
        multi_channel_pipette.drop_tip()


    # Configure back to 4 tip pick up
    multi_channel_pipette.configure_nozzle_layout(PARTIAL_COLUMN, start="H1", end="E1", tip_racks=[tiprack])

    # Pick up middle of column
    multi_channel_pipette.pick_up_tip()
    multi_channel_pipette.drop_tip()


    # Configure single with A1
    multi_channel_pipette.configure_nozzle_layout(SINGLE, start="A1", tip_racks=[tiprack])

    # Pick up the last two tips in a column with 8-channel
    for _ in range(2):
        multi_channel_pipette.pick_up_tip()
        multi_channel_pipette.drop_tip()

    # Configure for 3 tips
    multi_channel_pipette.configure_nozzle_layout(PARTIAL_COLUMN, start="H1", end="F1", tip_racks=[tiprack])

    single_pipette.pick_up_tip()
    single_pipette.drop_tip()

    for _ in range(2):
        multi_channel_pipette.pick_up_tip()
        multi_channel_pipette.drop_tip()

    single_pipette.pick_up_tip()
    single_pipette.drop_tip()
```
```python
from opentrons.protocol_api import COLUMN, ROW, SINGLE, OFF_DECK

requirements = {
    "robotType": "Flex",
    "apiLevel": "2.25"
}


metadata = {
    "protocolName":'96 Channel Full, Column, Row and Single tip tracking test',
    'author':'Jeremy'
}

def run(protocol_context):
    tiprack_adapter = protocol_context.load_adapter("opentrons_flex_96_tiprack_adapter", "C2")
    tiprack_with_adapter = tiprack_adapter.load_labware("opentrons_flex_96_tiprack_50ul")
    tiprack = protocol_context.load_labware("opentrons_flex_96_tiprack_50ul", "D1")
    trash = protocol_context.load_trash_bin('A3')
    pipette = protocol_context.load_instrument("flex_96channel_1000", tip_racks=[tiprack_with_adapter])

    # Pick up 96 tips
    pipette.pick_up_tip()
    pipette.return_tip()

    # Move stuff around
    protocol_context.move_labware(tiprack_with_adapter, OFF_DECK)
    protocol_context.move_labware(tiprack_adapter, OFF_DECK)
    protocol_context.move_labware(tiprack, "C2")

    # Configure for column on the right side
    pipette.configure_nozzle_layout(COLUMN, start="A12", tip_racks=[tiprack])

    # Pick up the 2 leftmost columns
    for _ in range(2):
        pipette.pick_up_tip()
        pipette.drop_tip()

    # Configure for column on the left side
    pipette.configure_nozzle_layout(COLUMN, start="A1", tip_racks=[tiprack])

    # Pick up the 2 rightmost columns
    for _ in range(2):
        pipette.pick_up_tip()
        pipette.drop_tip()

    protocol_context.pause()
    tiprack.reset()

    # Configure for row on the back row
    pipette.configure_nozzle_layout(ROW, start="A1", tip_racks=[tiprack])

    # Pick up the 2 fowardmost rows
    for _ in range(2):
        pipette.pick_up_tip()
        pipette.drop_tip()

    # Configure for row on the front row
    pipette.configure_nozzle_layout(ROW, start="H1", tip_racks=[tiprack])

    # Pick up the 2 backmost rows
    for _ in range(2):
        pipette.pick_up_tip()
        pipette.drop_tip()

    protocol_context.pause()
    tiprack.reset()

    # Single tip on A1
    pipette.configure_nozzle_layout(SINGLE, start="A1", tip_racks=[tiprack])

    # Pick up the H12 - E12
    for _ in range(4):
        pipette.pick_up_tip()
        pipette.drop_tip()

    # Single tip on H1
    pipette.configure_nozzle_layout(SINGLE, start="H1", tip_racks=[tiprack])

    # Pick up the A12 - D12
    for _ in range(4):
        pipette.pick_up_tip()
        pipette.drop_tip()


    # Single tip on A12
    pipette.configure_nozzle_layout(SINGLE, start="A12", tip_racks=[tiprack])

    # Pick up the H1 - E1
    for _ in range(4):
        pipette.pick_up_tip()
        pipette.drop_tip()

    # Single tip on H12
    pipette.configure_nozzle_layout(SINGLE, start="H12", tip_racks=[tiprack])

    # Pick up the A1 - D1
    for _ in range(4):
        pipette.pick_up_tip()
        pipette.drop_tip()
```

## Changelog

- refactored `TipView.get_next_tip` logic when using a nozzle map
- added `full_instrument_columns` to `NozzleManager`
- slightly refactored `wells_covered_by_pipette_configuration` and added a `wells_covered_by_physical_pipette` method for determining wells covered by the physical nozzles, not just the active ones

## Review requests

Overall I believe this logic is about as efficient as the old logic, though the nested `for` loop logic has now been obfuscated away in `_well_math` and there's definitely some cases where we could be "smarter" (yet complicate) the logic to reduce the amount of calls to `wells_covered_by_pipette_configuration` when we know it won't produce a valid tip group. Are we happy with this logic as it's been rewritten?

## Risk assessment

Medium, this affects most modern tip pick ups but if anything the logic is now more easier to grasp from the code and simpler to debug.