### PR TITLE
fix(docs): broken internal links in Protocol Designer manual

### DIFF
--- a/docs/protocol-designer/docs/steps/mix.md
+++ b/docs/protocol-designer/docs/steps/mix.md
@@ -13,4 +13,4 @@ You can customize settings for your mix step in a two-part form. Just like in a 
   <figcaption>Select wells, volume, repetitions, and tip management settings in the first mix step form.</figcaption>
 </figure>
 
-In the aspirate and dispense tabs, you can adjust the flow rate, well order, and tip position within the well. Available advanced settings in a mix step include a delay after aspirating or dispensing, and blowout and touch tip after dispensing. See the advanced settings table in [Transfer steps](transfer-steps.md) for descriptions of each.
+In the aspirate and dispense tabs, you can adjust the flow rate, well order, and tip position within the well. Available advanced settings in a mix step include a delay after aspirating or dispensing, and blowout and touch tip after dispensing. See the advanced settings table in [Transfer steps](transfer.md) for descriptions of each.

--- a/docs/protocol-designer/docs/steps/module.md
+++ b/docs/protocol-designer/docs/steps/module.md
@@ -72,7 +72,7 @@ Adding a Heater-Shaker Module step to your protocol displays any labware and ada
   <figcaption>Add a temperature, shake speed, and timer for a Heater-Shaker step.</figcaption>
 </figure>
 
-In this example, a Corning 96-well flat plate is placed on top of an Opentrons universal flat Heater-Shaker adapter. Both are on the Heater-Shaker in deck slot D1. Before moving labware to or from the Heater-Shaker, make sure that the labware latch is open. Add a Heater-Shaker step that opens the labware latch before any step that moves labware to the Heater-Shaker. Without this step, a [timeline error](warnings-errors.md#errors) could occur. 
+In this example, a Corning 96-well flat plate is placed on top of an Opentrons universal flat Heater-Shaker adapter. Both are on the Heater-Shaker in deck slot D1. Before moving labware to or from the Heater-Shaker, make sure that the labware latch is open. Add a Heater-Shaker step that opens the labware latch before any step that moves labware to the Heater-Shaker. Without this step, a [timeline error](../warnings-errors.md#errors) could occur. 
 
 In the Heater-Shaker step form, set the temperature or shake functions to **Active** and enter a custom value for temperature or shake speed. The Heater-Shaker module can heat samples between 37 and 95° C, and shake samples between 200 and 3000 rpm. 
 


### PR DESCRIPTION
# Overview

Oops, a couple links got broken when combining all the step pages into a directory.

## Test Plan and Hands on Testing

[Sandbox](http://sandbox.docs.s3-website.us-east-2.amazonaws.com/fix-docs-pd-links/protocol-designer/)

## Changelog

Just the link targets.

## Review requests

Click the links plz.

## Risk assessment

nil