### PR TITLE
fix(abr-testing): can't set pipette._last_tip_picked_up_from anymore

### DIFF
--- a/abr-testing/abr_testing/protocols/test_protocols/trash_bin_tip_removal.py
+++ b/abr-testing/abr_testing/protocols/test_protocols/trash_bin_tip_removal.py
@@ -109,7 +109,6 @@ def run(protocol: ProtocolContext) -> None:
         """Drop tip with pipette ejector extended."""
         move_pipette_plunger(api, mount, drop_tip_pos)
         api.remove_tip(mount)
-        pipette._last_tip_picked_up_from = None
 
     def clip_trash_edge() -> None:
         """Knock tips off with trash bin edge."""

--- a/abr-testing/abr_testing/protocols/test_protocols/waste_chute_tip_removal.py
+++ b/abr-testing/abr_testing/protocols/test_protocols/waste_chute_tip_removal.py
@@ -87,7 +87,6 @@ def run(protocol: ProtocolContext) -> None:
         """Drop tip with pipette ejector extended."""
         move_pipette_plunger(api, mount, drop_tip_pos)
         api.remove_tip(mount)
-        pipette._last_tip_picked_up_from = None
 
     def clip_waste_chute_edge() -> None:
         """Knock tips off with waste chute edge."""


### PR DESCRIPTION
# Overview

Since PR #19061, `InstrumentContext._last_tip_picked_up_from` is no longer a property in the class, and can no longer be set.

This change was causing the ABR tests `trash_bin_tip_removal.py` / `waste_chute_tip_removal.py` to fail, because they were trying to set `_last_tip_picked_up_from` to `None` after manually ejecting the tip via the hardware API.

This fix just deletes the line
```
pipette._last_tip_picked_up_from = None
```
The API will think that the pipette's tip came from wherever it came from, but since that info is only used for tip-return, and the test is not using tip-return, this is harmless.

## Test Plan and Hands on Testing

See if CI builds successfully now.

## Risk assessment

Low, should have no effect on the test's behavior.