### PR TITLE
Merge back 'chore_release-8.6.0' into 'edge'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,7 @@ deploy-py: export pypi_username = $(pypi_username)
 deploy-py: export pypi_password = $(pypi_password)
 deploy-py:
 	$(MAKE) -C $(API_DIR) deploy
-	$(MAKE) -C $(SHARED_DATA_DIR) deploy-py
+	$(MAKE) -C $(SHARED_DATA_DIR) deploy
 
 .PHONY: push-api
 push-api: export host = $(usb_host)

--- a/abr-testing/abr_testing/protocols/test_protocols/trash_bin_tip_removal.py
+++ b/abr-testing/abr_testing/protocols/test_protocols/trash_bin_tip_removal.py
@@ -109,7 +109,6 @@ def run(protocol: ProtocolContext) -> None:
         """Drop tip with pipette ejector extended."""
         move_pipette_plunger(api, mount, drop_tip_pos)
         api.remove_tip(mount)
-        pipette._last_tip_picked_up_from = None
 
     def clip_trash_edge() -> None:
         """Knock tips off with trash bin edge."""

--- a/abr-testing/abr_testing/protocols/test_protocols/waste_chute_tip_removal.py
+++ b/abr-testing/abr_testing/protocols/test_protocols/waste_chute_tip_removal.py
@@ -87,7 +87,6 @@ def run(protocol: ProtocolContext) -> None:
         """Drop tip with pipette ejector extended."""
         move_pipette_plunger(api, mount, drop_tip_pos)
         api.remove_tip(mount)
-        pipette._last_tip_picked_up_from = None
 
     def clip_waste_chute_edge() -> None:
         """Knock tips off with waste chute edge."""

--- a/app/src/pages/ODD/ProtocolSetup/__tests__/ProtocolSetup.test.tsx
+++ b/app/src/pages/ODD/ProtocolSetup/__tests__/ProtocolSetup.test.tsx
@@ -574,4 +574,10 @@ describe('ProtocolSetup', () => {
     render(`/runs/${RUN_ID}/setup/`)
     expect(mockNavigate).toHaveBeenCalledWith('/protocols')
   })
+
+  it('should show action needed when modules are not calibrated', () => {
+    vi.mocked(useModuleCalibrationStatus).mockReturnValue({ complete: false })
+    render(`/runs/${RUN_ID}/setup/`)
+    expect(screen.getByText('Action needed')).toBeInTheDocument()
+  })
 })

--- a/app/src/pages/ODD/ProtocolSetup/index.tsx
+++ b/app/src/pages/ODD/ProtocolSetup/index.tsx
@@ -483,7 +483,7 @@ function PrepareToRun({
   } else if (isMissingModules) {
     modulesDetail = missingModulesText
   } else if (!moduleCalibrationStatus.complete) {
-    modulesDetail = t('calibration_required')
+    modulesDetail = t('action_needed')
   } else {
     // modules and deck are ready
     const hardwareDetail = getConnectedHardwareText(

--- a/shared-data/Makefile
+++ b/shared-data/Makefile
@@ -103,8 +103,13 @@ push-no-restart-ot3:
 push-ot3:
 	$(MAKE) -f Makefile-python.mk push-ot3
 
-.PHONY: deploy-py
-deploy-py:
+# NOTE: This Python-only recipe is intentionally generically named "deploy" as opposed
+# to something like "deploy-py". Our GitHub Actions workflows for Python projects
+# currently hard-code "deploy". If we add a JS deploy recipe to this Makefile, we
+# should probably rename this to "deploy-py" to avoid confusion, and reconsider the way
+# the GitHub Actions stuff works.
+.PHONY: deploy
+deploy:
 	$(MAKE) -f Makefile-python.mk deploy
 
 .PHONY: test-py


### PR DESCRIPTION
This picks up the `pipette._last_tip_picked_up_from = None` fix.