### PR TITLE
fix(ci): Update "deploy" Makefile target name to fix deployments of shared-data Python

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,7 @@ deploy-py: export pypi_username = $(pypi_username)
 deploy-py: export pypi_password = $(pypi_password)
 deploy-py:
 	$(MAKE) -C $(API_DIR) deploy
-	$(MAKE) -C $(SHARED_DATA_DIR) deploy-py
+	$(MAKE) -C $(SHARED_DATA_DIR) deploy
 
 .PHONY: push-api
 push-api: export host = $(usb_host)

--- a/shared-data/Makefile
+++ b/shared-data/Makefile
@@ -103,8 +103,13 @@ push-no-restart-ot3:
 push-ot3:
 	$(MAKE) -f Makefile-python.mk push-ot3
 
-.PHONY: deploy-py
-deploy-py:
+# NOTE: This Python-only recipe is intentionally generically named "deploy" as opposed
+# to something like "deploy-py". Our GitHub Actions workflows for Python projects
+# currently hard-code "deploy". If we add a JS deploy recipe to this Makefile, we
+# should probably rename this to "deploy-py" to avoid confusion, and reconsider the way
+# the GitHub Actions stuff works.
+.PHONY: deploy
+deploy:
 	$(MAKE) -f Makefile-python.mk deploy
 
 .PHONY: test-py


### PR DESCRIPTION
## Overview

We used to have `make -C shared-data/python deploy`. In #18538, the correct command line changed to `make -C shared-data deploy-py`, but the actual command line run by CI changed to `make -C shared-data deploy`.

https://github.com/Opentrons/opentrons/blob/914690614e9900def9df23679e45d971504c64b7/.github/workflows/shared-data-test-lint-deploy.yaml#L192-L198

https://github.com/Opentrons/opentrons/blob/914690614e9900def9df23679e45d971504c64b7/.github/actions/python/pypi-deploy/action.yaml#L31

So we're getting failures like:

```
Run ./.github/actions/python/pypi-deploy
...
make: *** No rule to make target 'deploy'.  Stop.
make: Leaving directory '/home/runner/work/opentrons/opentrons/shared-data'
Error: Process completed with exit code 2.
```

## Changelog

After talking about this with @ddcc4, the solution we're going with for now is to just rename shared-data's `deploy-py` target to `deploy`, so the GitHub Action can continue to hard-code `make -C {project-name} deploy`.

This creates an ambiguity if shared-data ever has a JS deploy target in addition to its Python deploy target, but that doesn't seem to be the case today.

## Test Plan and Hands on Testing

Unfortunately, I think we can only test this by merging it? But I will click around in the GitHub UI and see if there's a better way.

## Review requests

Please double-check with me that:

* Nothing else is doing `make -C shared-data deploy-py` that now needs to be updated to `make -C shared-data deploy`. Makefiles sometimes hide stuff like this through concatenation.
* This doesn't create a dangerous ambiguity between Python and JS. e.g. it would be bad if we have a generic JS action somewhere that's *also* hard-coding the target name `deploy` the same way that the Python action is. If that's the case, we should probably step back and change the way that both the Python and JS actions work.
* This should merge into `chore_release-8.6.0`.

## Risk assessment

Medium.