### PR TITLE
fix(api): Ensure the engine recovery state is properly handling door status

### DIFF
--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -374,7 +374,10 @@ class CommandStore(HasState[CommandState], HandlesActions):
             prev_entry.command.intent in (CommandIntent.PROTOCOL, None)
             and action.type == ErrorRecoveryType.WAIT_FOR_RECOVERY
         ):
-            self._state.queue_status = QueueStatus.AWAITING_RECOVERY
+            if self._state.is_door_blocking:
+                self._state.queue_status = QueueStatus.AWAITING_RECOVERY_PAUSED
+            else:
+                self._state.queue_status = QueueStatus.AWAITING_RECOVERY
             self._state.recovery_target = _RecoveryTargetInfo(
                 command_id=action.command_id,
                 state_update_if_false_positive=state_update_if_false_positive,

--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -374,7 +374,7 @@ class CommandStore(HasState[CommandState], HandlesActions):
             prev_entry.command.intent in (CommandIntent.PROTOCOL, None)
             and action.type == ErrorRecoveryType.WAIT_FOR_RECOVERY
         ):
-            if self._state.is_door_blocking:
+            if self._state.queue_status == QueueStatus.PAUSED or self._state.is_door_blocking:
                 self._state.queue_status = QueueStatus.AWAITING_RECOVERY_PAUSED
             else:
                 self._state.queue_status = QueueStatus.AWAITING_RECOVERY

--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -374,7 +374,10 @@ class CommandStore(HasState[CommandState], HandlesActions):
             prev_entry.command.intent in (CommandIntent.PROTOCOL, None)
             and action.type == ErrorRecoveryType.WAIT_FOR_RECOVERY
         ):
-            if self._state.queue_status == QueueStatus.PAUSED or self._state.is_door_blocking:
+            if (
+                self._state.queue_status == QueueStatus.PAUSED
+                or self._state.is_door_blocking
+            ):
                 self._state.queue_status = QueueStatus.AWAITING_RECOVERY_PAUSED
             else:
                 self._state.queue_status = QueueStatus.AWAITING_RECOVERY

--- a/api/tests/opentrons/protocol_engine/state/test_command_state.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_state.py
@@ -389,6 +389,78 @@ def test_nonfatal_command_failure() -> None:
     assert subject_view.get_running_command_id() is None
 
 
+def test_nonfatal_command_failure_with_door_open() -> None:
+    """Test the command queue if a command fails recoverably but the door is open.
+
+    Commands that were after the failed command in the queue should be left in
+    the queue.
+
+    The queue status should be "awaiting-recovery-paused."
+    """
+    subject = CommandStore(
+        is_door_open=False,
+        config=Config(
+            block_on_door_open=True,
+            # Choice of robot and deck type are arbitrary.
+            robot_type="OT-3 Standard",
+            deck_type=DeckType.OT3_STANDARD,
+        ),
+        error_recovery_policy=_placeholder_error_recovery_policy,
+    )
+    subject_view = CommandView(subject.state)
+
+    queue_1 = actions.QueueCommandAction(
+        request=commands.WaitForResumeCreate(
+            params=commands.WaitForResumeParams(), key="command-key-1"
+        ),
+        request_hash=None,
+        created_at=datetime(year=2021, month=1, day=1),
+        command_id="command-id-1",
+    )
+    subject.handle_action(queue_1)
+    queue_2 = actions.QueueCommandAction(
+        request=commands.WaitForResumeCreate(
+            params=commands.WaitForResumeParams(), key="command-key-2"
+        ),
+        request_hash=None,
+        created_at=datetime(year=2021, month=1, day=1),
+        command_id="command-id-2",
+    )
+    subject.handle_action(queue_2)
+
+    run_1 = actions.RunCommandAction(
+        command_id="command-id-1",
+        started_at=datetime(year=2022, month=2, day=2),
+    )
+    subject.handle_action(run_1)
+    door_open = actions.DoorChangeAction(
+        door_state=DoorState.OPEN,
+        module_serial=None,
+    )
+    subject.handle_action(door_open)
+    assert subject_view.get_is_door_blocking() == True
+
+    fail_1 = actions.FailCommandAction(
+        command_id="command-id-1",
+        running_command=subject_view.get("command-id-1"),
+        error_id="error-id",
+        failed_at=datetime(year=2023, month=3, day=3),
+        error=errors.ProtocolEngineError(message="oh no"),
+        notes=[],
+        type=ErrorRecoveryType.WAIT_FOR_RECOVERY,
+    )
+    subject.handle_action(fail_1)
+
+    assert (
+        subject_view.get_status() == EngineStatus.AWAITING_RECOVERY_BLOCKED_BY_OPEN_DOOR
+    )
+    assert [(c.id, c.status) for c in subject_view.get_all()] == [
+        ("command-id-1", commands.CommandStatus.FAILED),
+        ("command-id-2", commands.CommandStatus.QUEUED),
+    ]
+    assert subject_view.get_running_command_id() is None
+
+
 def test_fixit_command_failure_handling_by_recovery_type() -> None:
     """Test that fixit command failures are handled differently based on error recovery type.
 

--- a/api/tests/opentrons/protocol_engine/state/test_command_state.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_state.py
@@ -438,7 +438,7 @@ def test_nonfatal_command_failure_with_door_open() -> None:
         module_serial=None,
     )
     subject.handle_action(door_open)
-    assert subject_view.get_is_door_blocking() == True
+    assert subject_view.get_is_door_blocking() is True
 
     fail_1 = actions.FailCommandAction(
         command_id="command-id-1",


### PR DESCRIPTION
# Overview
Covers RQA-4446

First and foremost I am truly peeved it took me so long to trace this issue, shame upon my entire family. Other than that, the core of this issue stems from how we were transitioning into the AWAITING_RECOVERY state for our queue status. Typically AWAITING_RECOVERY was directly transitioned into when an error occurred by the failed command action handler. AWAITING_RECOVERY_PAUSED would then be transitioned into when the door opens, under a separate door event action handler. AWAITING_RECOVERY_BLOCKED_BY_OPEN_DOOR (the engine status, not the queue status) would *then* be returned to the client assuming a door was the cause of the pause and was "allowed" to interrupt us at this point. 

The thing thats missing from all of that though, is that what happens when the door is already open before a failed command has been handled? Well we'll transition to PAUSED, and then transition straight to AWAITING_RECOVERY. The two handlers contradict each other, so here we are. Simple fix here is to check the door state again for AWAITING_RECOVERY when we catch a failure, and then transition straight to AWAITING_RECOVERY_PAUSED instead. 

## Test Plan and Hands on Testing
- [x] Execute a protocol on Flex and trigger an error recovery. Open the door before error recovery begins and ensure we are blocked from launching ER. When door is closed, ensure ER proceeds (and pipette homes) as expected.

## Changelog
Included a state transition check in our failed command action handler

## Review requests
Any complex ER situations we think this change will have weird knock on effects with? Since this happens at the "front" of an error recovery event (where the error is first handled) it shouldn't be a problem?
Here's a weird case to think about:
If we are in error recovery, and the user attempts to retry a command, and that command fails AND the user reopens the door during failure, we will go back into an AWAITING_RECOVERY_BLOCKED_BY_OPEN_DOOR state. I think that's actually correct, but might make things "weird". Thoughts? (Maybe the answer is "Don't do that! Bad!").

## Risk assessment
Low - fixes a bug thats been around since ER was added