### PR TITLE
fix(robot-server): handle deck cal inputs better

### DIFF
--- a/robot-server/robot_server/service/session/models/session.py
+++ b/robot-server/robot_server/service/session/models/session.py
@@ -43,26 +43,14 @@ SessionCreateParamType = typing.Union[
 ]
 
 
-class SessionCreateAttributes(BaseModel):
-    """Attributes required for creating a session"""
-
-    sessionType: SessionType = Field(..., description="The type of the session")
-
-
-class SessionCreateAttributesNoParams(SessionCreateAttributes):
-    """The base model of request that has no createParams."""
-
-    createParams: typing.Optional[BaseModel] = None
-
-
-class CalibrationCheckCreateAttributes(SessionCreateAttributesNoParams):
+class CalibrationCheckCreateAttributes(BaseModel):
     """The calibration check create request."""
 
     sessionType: Literal[SessionType.calibration_check] = SessionType.calibration_check
     createParams: CalCheckCreateParams
 
 
-class TipLengthCalibrationCreateAttributes(SessionCreateAttributes):
+class TipLengthCalibrationCreateAttributes(BaseModel):
     """The tip length calibration create request."""
 
     sessionType: Literal[
@@ -71,13 +59,18 @@ class TipLengthCalibrationCreateAttributes(SessionCreateAttributes):
     createParams: SessionCreateParams
 
 
-class DeckCalibrationCreateAttributes(SessionCreateAttributesNoParams):
+class _NoParams(BaseModel):
+    ...
+
+
+class DeckCalibrationCreateAttributes(BaseModel):
     """The deck calibration create request."""
 
     sessionType: Literal[SessionType.deck_calibration] = SessionType.deck_calibration
+    createParams: None | _NoParams = None
 
 
-class PipetteOffsetCalibrationCreateAttributes(SessionCreateAttributes):
+class PipetteOffsetCalibrationCreateAttributes(BaseModel):
     """Pipette offset calibration create request."""
 
     sessionType: Literal[

--- a/robot-server/robot_server/service/session/models/session.py
+++ b/robot-server/robot_server/service/session/models/session.py
@@ -85,7 +85,6 @@ class SessionResponseAttributes(DeprecatedResponseDataModel):
     createdAt: datetime = Field(
         ..., description="Date and time that this session was created"
     )
-    details: BaseModel = Field(..., description="Detailed session specific status")
 
 
 class CalibrationCheckResponseAttributes(

--- a/robot-server/robot_server/service/session/session_types/deck_calibration_session.py
+++ b/robot-server/robot_server/service/session/session_types/deck_calibration_session.py
@@ -85,7 +85,7 @@ class DeckCalibrationSession(BaseSession):
     def get_response_model(self) -> DeckCalibrationResponseAttributes:
         return DeckCalibrationResponseAttributes(
             id=self.meta.identifier,
-            createParams=self.meta.create_params,
+            createParams=None,
             details=self._get_response_details(),
             createdAt=self.meta.created_at,
         )

--- a/robot-server/tests/integration/sessions/test_deck_calibration.tavern.yaml
+++ b/robot-server/tests/integration/sessions/test_deck_calibration.tavern.yaml
@@ -13,6 +13,7 @@ stages:
       json:
         data:
           sessionType: deckCalibration
+          createParams: {}
     response:
       status_code: 201
       save:


### PR DESCRIPTION
We had a pretty convoluted way of specifying to fastapi that deck calibration sessions don't have input parameters. The intent was definitely that clients would have to omit the createParams key, but even previously to the change that broke things fastapi was accepting createParams: {} just fine. But when we upgraded pydantic to 2.11.7, this stopped being fine: when you sent createParams: {} this would create an instance of BaseModel, for some abstruse reason relating to our inheritance hierarchy, which was never something you ought to create on its own. In 2.11.7, this now eventually causes an error.

The fix is to make sure that the empty-dict input case is explicitly allowed and tavern-tested - since that's what the app has always done - and tell fastapi that the createParams argument can be either none or the instance of an empty subclass of BaseModel, which is fine to instantiate.

Closes RQA-4519

## testing
- [x] on an ot2, run deck calibration without errors