### PR TITLE
feat(docs): enforce that mkdocs build without warnings

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -13,7 +13,11 @@ serve:
 
 .PHONY: build
 build:
-	uv run mkdocs build -f ./mkdocs.yml
+	@if [ -n "$$CI" ]; then \
+		uv run mkdocs build -f ./mkdocs.yml --strict; \
+	else \
+		uv run mkdocs build -f ./mkdocs.yml; \
+	fi
 
 .PHONY: deploy
 deploy:

--- a/docs/flex/docs/installation/requirements.md
+++ b/docs/flex/docs/installation/requirements.md
@@ -29,7 +29,7 @@ Space is a valuable commodity in almost every lab. Your Flex is going to need so
 <figcaption>Top view of Opentrons Flex, showing minimum side and back clearance.</figcaption>
 </figure>
 
-## Power consumption
+## Power consumption { #power-consumption-flex }
 
 Opentrons Flex should be connected to a wall outlet at or near the bench location where you install it. Only connect Flex to circuits that can accommodate its peak power draw:
 
@@ -60,7 +60,7 @@ Along with the conditions described above, total power consumption also depends 
 !!! note 
     Always account for other electronics that consume power on the same circuit, including Flex modules with their own power supplies. For example, the Thermocycler Module has a peak power consumption (630 W) that is much greater than the Flex robot itself. If necessary, consult the manager of your facility to make sure it meets your equipment's peak power requirements.
 
-## Environmental conditions
+## Environmental conditions { #environmental-conditions-flex }
 
 Environmental conditions for recommended use, acceptable use, and storage vary:
 

--- a/docs/flex/docs/labware/index.md
+++ b/docs/flex/docs/labware/index.md
@@ -9,6 +9,6 @@ This chapter covers how Opentrons Flex works with labware, both in software and 
 - [Labware concepts](./concepts.md) describes how Opentrons software encodes and uses information about physical labware items in your lab.
 - [Labware types](./types.md) gives examples of the categories of labware that you'll find in the Opentrons Labware Library. 
 - Certain types of labware are [compatible with the Opentrons Flex Gripper](./gripper.md) for automated movement around the deck. (All labware can be moved manually.) 
-- [Labware definitions](./definitions) are the files Flex uses to understand the dimensions and characteristics of labware. This section describes all the features available for Opentrons-verified and custom labware defined by our JSON labware schema.
+	- [Labware definitions](./definitions.md) are the files Flex uses to understand the dimensions and characteristics of labware. This section describes all the features available for Opentrons-verified and custom labware defined by our JSON labware schema.
 
 You can purchase labware from the [Opentrons shop](https://opentrons.com/products/categories/tips-&-labware) or the original equipment manufacturers. And, Opentrons is always working to verify new labware definitions. See the [Labware Library](https://labware.opentrons.com/) for the latest listings. 

--- a/docs/flex/docs/labware/index.md
+++ b/docs/flex/docs/labware/index.md
@@ -9,6 +9,6 @@ This chapter covers how Opentrons Flex works with labware, both in software and 
 - [Labware concepts](./concepts.md) describes how Opentrons software encodes and uses information about physical labware items in your lab.
 - [Labware types](./types.md) gives examples of the categories of labware that you'll find in the Opentrons Labware Library. 
 - Certain types of labware are [compatible with the Opentrons Flex Gripper](./gripper.md) for automated movement around the deck. (All labware can be moved manually.) 
-	- [Labware definitions](./definitions.md) are the files Flex uses to understand the dimensions and characteristics of labware. This section describes all the features available for Opentrons-verified and custom labware defined by our JSON labware schema.
+- [Labware definitions](./definitions.md) are the files Flex uses to understand the dimensions and characteristics of labware. This section describes all the features available for Opentrons-verified and custom labware defined by our JSON labware schema.
 
 You can purchase labware from the [Opentrons shop](https://opentrons.com/products/categories/tips-&-labware) or the original equipment manufacturers. And, Opentrons is always working to verify new labware definitions. See the [Labware Library](https://labware.opentrons.com/) for the latest listings. 

--- a/docs/flex/docs/modules/absorbance-plate-reader.md
+++ b/docs/flex/docs/modules/absorbance-plate-reader.md
@@ -4,7 +4,7 @@ title: "Opentrons Flex: Absorbance Plate Reader"
 
 # Absorbance Plate Reader Module
 
-![plate reader hero](../../images/plate-reader-hero-lid-off.png)
+![plate reader hero](../images/plate-reader-hero-lid-off.png)
 
 !!! info "Additional Documentation"
     For complete instructions on module installation and use, see the Absorbance Plate Reader Instruction Manual.

--- a/docs/flex/docs/modules/heater-shaker.md
+++ b/docs/flex/docs/modules/heater-shaker.md
@@ -4,7 +4,7 @@ title: "Opentrons Flex: Heater-Shaker Module"
 
 # Heater-Shaker Module GEN1
 
-![The Heater-Shaker module as seen from the front left. The top of the module has the heating and shaking platform and labware latch. The left side of the module has the power button, USB port, and power port.](../../images/heater-shaker-module.png "Heater-Shaker Module")
+![The Heater-Shaker module as seen from the front left. The top of the module has the heating and shaking platform and labware latch. The left side of the module has the power button, USB port, and power port.](../images/heater-shaker-module.png "Heater-Shaker Module")
 
 !!! info "Additional Documentation"
     For complete instructions on module installation and use, see the Heater-Shaker Module Instruction Manual.
@@ -44,22 +44,22 @@ A compatible thermal adapter is required for adding labware to the Heater-Shaker
 
 <div class="parts-list" markdown>
 <figure markdown>
-![Adapter with flat plate and prongs on one side to press against the labware latch.](../../images/heater-shaker-adapter-universal.png "Heater-Shaker Universal Flat Adapter")
+![Adapter with flat plate and prongs on one side to press against the labware latch.](../images/heater-shaker-adapter-universal.png "Heater-Shaker Universal Flat Adapter")
 <figcaption>Universal Flat Adapter </figcaption>
 </figure>
 
 <figure markdown>
-![Adapter with indentations to hold 96-well PCR plates.](../../images/heater-shaker-adapter-pcr.png "Heater-Shaker PCR Adapter")
+![Adapter with indentations to hold 96-well PCR plates.](../images/heater-shaker-adapter-pcr.png "Heater-Shaker PCR Adapter")
 <figcaption>PCR Adapter</figcaption>
 </figure>
 
 <figure markdown>
-![Adapter with raised sides for deep well plates.](../../images/heater-shaker-adapter-deep-well.png "Heater-Shaker Deep Well Adapter")
+![Adapter with raised sides for deep well plates.](../images/heater-shaker-adapter-deep-well.png "Heater-Shaker Deep Well Adapter")
 <figcaption>Deep Well Adapter</figcaption>
 </figure>
 
 <figure markdown>
-![Adapter with flat bottom and sides to fit 96-well plates with circular wells.](../../images/heater-shaker-adapter-flat-bottom.png "Heater-Shaker 96 Flat Bottom Adapter")
+![Adapter with flat bottom and sides to fit 96-well plates with circular wells.](../images/heater-shaker-adapter-flat-bottom.png "Heater-Shaker 96 Flat Bottom Adapter")
 <figcaption>96 Flat Bottom Adapter</figcaption>
 </figure>
 </div>

--- a/docs/flex/docs/modules/hepa-uv.md
+++ b/docs/flex/docs/modules/hepa-uv.md
@@ -4,10 +4,10 @@ title: "Opentrons Flex: HEPA/UV Module"
 
 # HEPA/UV Module
 
-![hepa-uv hero](../../images/hepa-uv-hero.png)
+![hepa-uv hero](../images/hepa-uv-hero.png)
 
 !!! info "Additional Documentation"
-    For complete instructions on module installation and use, see the [HEPA/UV Module Instruction Manual](../../../hepa-uv/).
+    For complete instructions on module installation and use, see the [HEPA/UV Module Instruction Manual](../../hepa-uv/index.md).
 
 The top-mounted Opentrons Flex HEPA/UV Module is a clean air and ultraviolet (UV-C) disinfectant accessory for the Flex liquid handling robot. It contains a mesh pre-filter, a HEPA filter, and two UV lights. During operation, the HEPA system creates a positive pressure environment inside the Flex enclosure, which helps protect samples from contamination. When running the UV lights and air filtration for a full, 15-minute cycle, the HEPA/UV module can achieve ISO-5 clean bench standards within the Flex enclosure.
 

--- a/docs/flex/docs/modules/index.md
+++ b/docs/flex/docs/modules/index.md
@@ -9,7 +9,7 @@ Opentrons Flex integrates with several Opentrons hardware modules that add featu
 This chapter summarizes the functions and physical specifications of modules that are compatible with Opentrons Flex. It also covers the caddy attachment system and module calibration.
 
 !!! tip
-    - For complete instructions on module installation and use, refer to the quickstart guide that shipped with your unit or find its manual in the [Modules category](/modules/) of the Opentrons Documentation website.
+    - For complete instructions on module installation and use, refer to the quickstart guide that shipped with your unit or find its manual in the [Modules category](../../modules/index.md) of the Opentrons Documentation website.
 
     - For details on integrating modules into your protocols, see the [Protocol Designer section](../protocols/designer.md) of the Protocol Development chapter or the [Hardware Modules section](https://docs.opentrons.com/v2/new_modules.html) of our Python API documentation.
 

--- a/docs/flex/docs/modules/magnetic-block.md
+++ b/docs/flex/docs/modules/magnetic-block.md
@@ -4,7 +4,7 @@ title: "Opentrons Flex: Magnetic Block"
 
 # Magnetic Block GEN1
 
-![The Magnetic Block has an array of 96 high-strength magnets.](../../images/magnetic-block.png "Magnetic Block")
+![The Magnetic Block has an array of 96 high-strength magnets.](../images/magnetic-block.png "Magnetic Block")
 
 ## Magnetic Block features
 

--- a/docs/flex/docs/modules/temperature.md
+++ b/docs/flex/docs/modules/temperature.md
@@ -4,7 +4,7 @@ title: "Opentrons Flex: Temperature Module"
 
 # Temperature Module GEN2
 
-![The Temperature Module as seen from the top left. The top of the module has the heating and cooling surface and temperature display. The side has the power button, USB port, and power port.](../../images/temperature-module.png "Temperature Module")
+![The Temperature Module as seen from the top left. The top of the module has the heating and cooling surface and temperature display. The side has the power button, USB port, and power port.](../images/temperature-module.png "Temperature Module")
 
 !!! info "Additional Documentation"
     For complete instructions on module installation and use, see the Temperature Module Instruction Manual.
@@ -26,22 +26,22 @@ To hold labware at temperature, the module uses aluminum thermal blocks. The mod
 <div class="parts-list" markdown>
 
 <figure markdown>
-![24-well aluminum thermal block for Temperature Module](../../images/temperature-module-block-24-well.png "24-well thermal block")
+![24-well aluminum thermal block for Temperature Module](../images/temperature-module-block-24-well.png "24-well thermal block")
 <figcaption>24-well thermal block </figcaption>
 </figure>
 
 <figure markdown>
-![96-well aluminum thermal block for Temperature Module](../../images/temperature-module-block-96-well.png "96-well thermal block")
+![96-well aluminum thermal block for Temperature Module](../images/temperature-module-block-96-well.png "96-well thermal block")
 <figcaption>96-well thermal block</figcaption>
 </figure>
 
 <figure markdown>
-![Deep well aluminum thermal block for Temperature Module](../../images/temperature-module-block-deep-well.png "Deep well thermal block")
+![Deep well aluminum thermal block for Temperature Module](../images/temperature-module-block-deep-well.png "Deep well thermal block")
 <figcaption>Deep well thermal block</figcaption>
 </figure>
 
 <figure markdown>
-![Flat bottom aluminum thermal block for Temperature Module](../../images/temperature-module-block-flat.png "Flat bottom thermal block")
+![Flat bottom aluminum thermal block for Temperature Module](../images/temperature-module-block-flat.png "Flat bottom thermal block")
 <figcaption>Flat bottom thermal block for Flex</figcaption>
 </figure>
 

--- a/docs/flex/docs/opentrons-app.md
+++ b/docs/flex/docs/opentrons-app.md
@@ -4,7 +4,7 @@ title: "Opentrons Flex: App"
 
 # Opentrons App
 
-You can perform most functions of Flex either from the [touchscreen](../touchscreen/) or from a computer running the Opentrons App. This section covers using the app for features that are not available on the touchscreen.
+You can perform most functions of Flex either from the [touchscreen](touchscreen/index.md) or from a computer running the Opentrons App. This section covers using the app for features that are not available on the touchscreen.
 
 ## App installation
 
@@ -51,7 +51,7 @@ The Ubuntu version of the Opentrons App is packaged as an AppImage. To use it:
 
 ## Transferring protocols to Flex
 
-Every protocol will begin as a file on your computer, regardless of what method of [protocol development](../protocols/) you use. You need to import the protocol into the Opentrons App and then transfer it to your Flex. When transferring a protocol, you can choose to begin run setup immediately or later.
+Every protocol will begin as a file on your computer, regardless of what method of [protocol development](protocols/index.md) you use. You need to import the protocol into the Opentrons App and then transfer it to your Flex. When transferring a protocol, you can choose to begin run setup immediately or later.
 
 ### Import a protocol
 

--- a/docs/flex/docs/protocols/designer.md
+++ b/docs/flex/docs/protocols/designer.md
@@ -15,7 +15,7 @@ Protocol Designer is a web-based, no-code tool for developing protocols that run
 - Pause to let you verify progress or access samples.
 
 !!! info "Additional Documentation"
-    This section covers using Protocol Designer to create and edit a Flex protocol. For more details, see our [Protocol Designer Instruction Manual](../../../protocol-designer/).
+    This section covers using Protocol Designer to create and edit a Flex protocol. For more details, see our [Protocol Designer Instruction Manual](../../protocol-designer/index.md).
 
 All work in Protocol Designer takes place within your web browser. When
 you're done creating or editing your protocol, you'll need to export it to

--- a/docs/flex/docs/protocols/index.md
+++ b/docs/flex/docs/protocols/index.md
@@ -8,9 +8,9 @@ The Opentrons Flex system can run a wide variety of automated protocols, for tas
 
 
 - [Protocol Library](./library.md) provides fully built and verified protocols, as well as community-submitted protocols.
-- Our [Custom Protocol Development Service](./development-service) will work with you to build a protocol that suits your needs.
-- [Protocol Designer](./designer) lets you build protocols in your web browser without writing any code.
+- Our [Custom Protocol Development Service](./development-service.md) will work with you to build a protocol that suits your needs.
+- [Protocol Designer](./designer.md) lets you build protocols in your web browser without writing any code.
 - OpentronsAI will get you started with a Python protocol that you can run as-is or modify to suit your needs.
-- The [Python Protocol API](./python-api) offers a complete set of commands for controlling Flex, and can integrate with other Python tools. 
+- The [Python Protocol API](./python-api.md) offers a complete set of commands for controlling Flex, and can integrate with other Python tools. 
 
-This chapter provides an overview of each of these protocol development methods, as well as giving guidance on how to [adapt protocols written for the Opentrons OT-2](./ot-2) to run on Opentrons Flex.
+This chapter provides an overview of each of these protocol development methods, as well as giving guidance on how to [adapt protocols written for the Opentrons OT-2](./ot-2.md) to run on Opentrons Flex.

--- a/docs/flex/docs/safety-regulatory.md
+++ b/docs/flex/docs/safety-regulatory.md
@@ -49,7 +49,7 @@ Always observe the following electrical safety warnings:
 | ![Symbol for electrical shock](images/regulatory-marks/warning-label-electrical-shock.svg "Electrical shock") | Do not connect (plug in), disconnect (unplug), or use AC power cables if: <ul><li>The cable is frayed or damaged.</li><li>Other attached cables, cords, or receptacles are frayed or damaged.</li></ul> Using damaged power cords can cause an electric shock hazard resulting in serious injury or damage to the robot.                                                           |
 | ![Symbol for warning](images/regulatory-marks/warning-label-caution.svg "Warning") | Do not replace the AC power cable unless at the direction of Opentrons Support.                                                                                            |
 
-For more information on electrical requirements, see the [Power Consumption section][power-consumption] of the Installation and Relocation chapter.
+For more information on electrical requirements, see the [Power Consumption section][power-consumption-flex] of the Installation and Relocation chapter.
 
 ### Additional safety warnings
 

--- a/docs/flex/docs/system-description/specs.md
+++ b/docs/flex/docs/system-description/specs.md
@@ -35,7 +35,7 @@ title: "Opentrons Flex: System Specifications"
 | **Relative humidity**     | 40–60%, non-condensing (recommended) |
 | **Pollution degree**      | 2 (non-conductive pollution only) |
 
-For additional information on acceptable environmental conditions for use and transport, see the [Environmental Conditions section][environmental-conditions] of the Installation and Relocation chapter.
+For additional information on acceptable environmental conditions for use and transport, see the [Environmental Conditions section][environmental-conditions-flex] of the Installation and Relocation chapter.
 
 ## Certifications
 

--- a/docs/flex/docs/touchscreen/index.md
+++ b/docs/flex/docs/touchscreen/index.md
@@ -6,6 +6,6 @@ title: "Opentrons Flex: Touchscreen"
 
 This chapter focuses on operating Flex from its on-device touchscreen. You can use the touchscreen to control Flex whenever the robot is on. If your robot is on and the touchscreen is off, tap it once to wake the screen.
 
-You can perform most functions either from the touchscreen or from a computer running the [Opentrons App](../opentrons-app/). You can choose how to control Opentrons Flex, depending on the needs of your lab.  
+You can perform most functions either from the touchscreen or from a computer running the [Opentrons App](../opentrons-app.md). You can choose how to control Opentrons Flex, depending on the needs of your lab.  
 
 One major difference between touchscreen and app operation is the software's relationship to the robot. The touchscreen is integrated, and therefore only controls the Flex robot that it's physically a part of. In contrast, the Opentrons App can control any number of Opentrons robots connected to the computer that's running the app. Using both pieces of software is required to set up Flex and run your first protocol, but it's up to you to decide the balance of how you will control Flex in your daily workflow.

--- a/docs/hepa-uv/docs/product-specifications.md
+++ b/docs/hepa-uv/docs/product-specifications.md
@@ -79,7 +79,7 @@ The HEPA/UV Module has the following power input requirements, which are met by 
 | Mains supply voltage fluctuation | 100–240 VAC ±10% |
 | Fuse type | T3.15 A, 250 V, 5×20 mm |
 
-### Power consumption
+### Power consumption { #power-consumption-hepa-uv }
 
 The power consumption specifications are measured with the UV lights and fan on.
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,7 +1,6 @@
 site_name: Opentrons Documentation
 
 docs_dir: ./shared
-custom_dir: ./shared
 
 nav:
   - Opentrons Flex: '!include flex/mkdocs.yml'
@@ -31,6 +30,7 @@ theme:
   icon:
     admonition:
       tip: material/lightbulb-on-outline
+  custom_dir: ./shared
 
 markdown_extensions:
   - admonition

--- a/docs/thermocycler-manual/docs/compliance.md
+++ b/docs/thermocycler-manual/docs/compliance.md
@@ -22,7 +22,7 @@ The Thermocycler requires the following power input, met by the included power s
 - **Current**: 8.5–5 A
 - **Overvoltage**: Category II
 
-### Environmental Conditions { #thermocycler-environmental-conditions }
+### Environmental Conditions { #environmental-conditions-thermocycler }
 
 The Thermocycler should only be used indoors on a sturdy, dry, flat horizontal surface. Install this module in a low-vibration environment with stable ambient conditions. Keep it away from direct sunlight or HVAC systems that may cause significant temperature or humidity changes.
 

--- a/docs/thermocycler-manual/docs/preinstall.md
+++ b/docs/thermocycler-manual/docs/preinstall.md
@@ -8,7 +8,7 @@ Review this section for important information about the Thermocycler's deck plac
 
 ## Flex Caddies
 
-When used with a Flex robot, the Thermocycler fits into a caddy that occupies space below the deck. The caddy places your labware closer to the deck surface and allows for below-deck cable routing. See the [Modules chapter](../flex/modules.md) in the Flex Instruction Manual for more information.
+When used with a Flex robot, the Thermocycler fits into a caddy that occupies space below the deck. The caddy places your labware closer to the deck surface and allows for below-deck cable routing. See the [Modules chapter](../flex/modules/index.md) in the Flex Instruction Manual for more information.
 
 ![Flex caddy with labels](images/flex-caddy.png)
 

--- a/docs/thermocycler-manual/docs/preinstall.md
+++ b/docs/thermocycler-manual/docs/preinstall.md
@@ -8,7 +8,7 @@ Review this section for important information about the Thermocycler's deck plac
 
 ## Flex Caddies
 
-When used with a Flex robot, the Thermocycler fits into a caddy that occupies space below the deck. The caddy places your labware closer to the deck surface and allows for below-deck cable routing. See the [Modules chapter](../flex-manual/modules.md) in the Flex Instruction Manual for more information.
+When used with a Flex robot, the Thermocycler fits into a caddy that occupies space below the deck. The caddy places your labware closer to the deck surface and allows for below-deck cable routing. See the [Modules chapter](../flex/modules.md) in the Flex Instruction Manual for more information.
 
 ![Flex caddy with labels](images/flex-caddy.png)
 
@@ -45,8 +45,8 @@ To properly align the module relative to the robot, make sure its exhaust port f
 
 The Flex and OT-2 need at least 20 cm (8") of side and back clearance. This space helps dissipate exhaust from the Thermocycler.
 
-![Diagram showing recommended clearance around robot](../images/robot-clearance.png)
+![Diagram showing recommended clearance around robot](images/robot-clearance.png)
 
 For OT-2 ventilation, Opentrons recommends using the side and rear window panels shown below. These panels are included with newer OT-2 models. If you have an older OT-2 and need these panels, contact us at <support@opentrons.com>.
 
-![OT-2 replacement window panels](../images/ot2-panels.png)
+![OT-2 replacement window panels](images/ot2-panels.png)


### PR DESCRIPTION

# Overview

Cleaning up our mkdocs warnings. And having the docs build fail in CI if there are warnings in the future.

## Test Plan and Hands on Testing

- [x] Pushed with one warning deliberately left.
- [x] Pushed with all warnings fixed.

## Changelog

Mostly link paths and making disambiguating identical headers with `id`s.

## Review requests

Cool to enforce this in CI now?

## Risk assessment

low