### PR TITLE
feat(step-generation): reassign tipracks before `_with_liquid_class` emission

### DIFF
--- a/step-generation/src/commandCreators/compound/consolidate.ts
+++ b/step-generation/src/commandCreators/compound/consolidate.ts
@@ -36,6 +36,7 @@ import {
 import {
   getCustomLiquidClassProperties,
   getLiquidClassName,
+  getPythonAssignTipRacksString,
 } from '../../utils/liquidClassUtils'
 import {
   airGapInPlace,
@@ -361,6 +362,12 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
     pythonLiquidClassArgs.join(',\n')
   )},\n)`
 
+  const pythonAssignTipracks = getPythonAssignTipRacksString({
+    pipetteEntity: pipetteEntities[pipette],
+    labwareEntities,
+    tiprackURI: tipRack,
+  })
+
   const pythonArgs = [
     `volume=${volume}`,
     `source=[${pythonSourceWells}]`,
@@ -375,7 +382,7 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
   ]
   const pythonCommandCreator: CurriedCommandCreator = () => ({
     commands: [],
-    python: `${pythonPipetteName}.consolidate_with_liquid_class(\n${indentPyLines(
+    python: `${pythonAssignTipracks}${pythonPipetteName}.consolidate_with_liquid_class(\n${indentPyLines(
       pythonArgs.join(',\n')
     )},\n)`,
   })

--- a/step-generation/src/commandCreators/compound/consolidate.ts
+++ b/step-generation/src/commandCreators/compound/consolidate.ts
@@ -365,6 +365,7 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
   const pythonAssignTipracks = getPythonAssignTipRacksString({
     pipetteEntity: pipetteEntities[pipette],
     labwareEntities,
+    labwareState: prevRobotState.labware,
     tiprackURI: tipRack,
   })
 

--- a/step-generation/src/commandCreators/compound/distribute.ts
+++ b/step-generation/src/commandCreators/compound/distribute.ts
@@ -37,6 +37,7 @@ import {
 import {
   getCustomLiquidClassProperties,
   getLiquidClassName,
+  getPythonAssignTipRacksString,
 } from '../../utils/liquidClassUtils'
 import {
   airGapInPlace,
@@ -394,6 +395,12 @@ export const distribute: CommandCreator<DistributeArgs> = (
     pythonLiquidClassArgs.join(',\n')
   )},\n)`
 
+  const pythonAssignTipracks = getPythonAssignTipRacksString({
+    pipetteEntity: pipetteEntities[pipette],
+    labwareEntities,
+    tiprackURI: tipRack,
+  })
+
   const pythonArgs = [
     `volume=${volume}`,
     `source=[${pythonSourceWells}]`,
@@ -406,7 +413,7 @@ export const distribute: CommandCreator<DistributeArgs> = (
   ]
   const pythonCommandCreator: CurriedCommandCreator = () => ({
     commands: [],
-    python: `${pythonPipetteName}.distribute_with_liquid_class(\n${indentPyLines(
+    python: `${pythonAssignTipracks}${pythonPipetteName}.distribute_with_liquid_class(\n${indentPyLines(
       pythonArgs.join(',\n')
     )},\n)`,
   })

--- a/step-generation/src/commandCreators/compound/distribute.ts
+++ b/step-generation/src/commandCreators/compound/distribute.ts
@@ -398,6 +398,7 @@ export const distribute: CommandCreator<DistributeArgs> = (
   const pythonAssignTipracks = getPythonAssignTipRacksString({
     pipetteEntity: pipetteEntities[pipette],
     labwareEntities,
+    labwareState: prevRobotState.labware,
     tiprackURI: tipRack,
   })
 

--- a/step-generation/src/commandCreators/compound/mix.ts
+++ b/step-generation/src/commandCreators/compound/mix.ts
@@ -14,7 +14,6 @@ import {
   formatPyStr,
   formatPyWellLocation,
   getIsSafePipetteMovement,
-  getPythonAssignTipRacksString,
   getSlotInLocationStack,
   indentPyLines,
   mixBlowoutLocationHelper,
@@ -65,7 +64,6 @@ const makePythonCommandCreator: (args: {
     yOffset: number
     offsetFromBottomMm: number
   }
-  tiprackURI: string
 }) => CurriedCommandCreator = args => () => {
   const {
     invariantContext,
@@ -78,7 +76,6 @@ const makePythonCommandCreator: (args: {
     aspirateFlowRateUlSec,
     dispenseFlowRateUlSec,
     positionArgs,
-    tiprackURI,
   } = args
 
   const { pipetteEntities, labwareEntities } = invariantContext
@@ -95,13 +92,6 @@ const makePythonCommandCreator: (args: {
       well
     )}]${formatPyWellLocation(pythonWellLocation)}`
   }
-
-  const pythonAssignTipracks = getPythonAssignTipRacksString({
-    pipetteEntity: pipetteEntities[pipette],
-    labwareEntities,
-    tiprackURI,
-  })
-
   const pythonArgs = [
     `repetitions=${times}`,
     `volume=${volume}`,
@@ -120,11 +110,12 @@ const makePythonCommandCreator: (args: {
     commands: [],
     //  Note: we do not support mix in trashBin or wasteChute so location
     //  will always be a well
-    python: `${pythonAssignTipracks}${pipettePythonName}.mix(\n${indentPyLines(
+    python: `${pipettePythonName}.mix(\n${indentPyLines(
       pythonArgs.join(',\n')
     )},\n)`,
   }
 }
+
 /** Helper fn to make mix command creators w/ minimal arguments */
 export const mixInPlaceUtil = (args: {
   pipette: string
@@ -177,7 +168,6 @@ export const mixInPlaceUtil = (args: {
             offsetFromBottomMm: moveToWellParams.wellLocation?.offset?.z ?? 0,
           }
         : undefined,
-    tiprackURI: tiprack,
   })
 
   const pipetteSpecs = invariantContext.pipetteEntities[pipette].spec

--- a/step-generation/src/commandCreators/compound/mix.ts
+++ b/step-generation/src/commandCreators/compound/mix.ts
@@ -14,6 +14,7 @@ import {
   formatPyStr,
   formatPyWellLocation,
   getIsSafePipetteMovement,
+  getPythonAssignTipRacksString,
   getSlotInLocationStack,
   indentPyLines,
   mixBlowoutLocationHelper,
@@ -64,6 +65,7 @@ const makePythonCommandCreator: (args: {
     yOffset: number
     offsetFromBottomMm: number
   }
+  tiprackURI: string
 }) => CurriedCommandCreator = args => () => {
   const {
     invariantContext,
@@ -76,6 +78,7 @@ const makePythonCommandCreator: (args: {
     aspirateFlowRateUlSec,
     dispenseFlowRateUlSec,
     positionArgs,
+    tiprackURI,
   } = args
 
   const { pipetteEntities, labwareEntities } = invariantContext
@@ -92,6 +95,13 @@ const makePythonCommandCreator: (args: {
       well
     )}]${formatPyWellLocation(pythonWellLocation)}`
   }
+
+  const pythonAssignTipracks = getPythonAssignTipRacksString({
+    pipetteEntity: pipetteEntities[pipette],
+    labwareEntities,
+    tiprackURI,
+  })
+
   const pythonArgs = [
     `repetitions=${times}`,
     `volume=${volume}`,
@@ -110,12 +120,11 @@ const makePythonCommandCreator: (args: {
     commands: [],
     //  Note: we do not support mix in trashBin or wasteChute so location
     //  will always be a well
-    python: `${pipettePythonName}.mix(\n${indentPyLines(
+    python: `${pythonAssignTipracks}${pipettePythonName}.mix(\n${indentPyLines(
       pythonArgs.join(',\n')
     )},\n)`,
   }
 }
-
 /** Helper fn to make mix command creators w/ minimal arguments */
 export const mixInPlaceUtil = (args: {
   pipette: string
@@ -168,6 +177,7 @@ export const mixInPlaceUtil = (args: {
             offsetFromBottomMm: moveToWellParams.wellLocation?.offset?.z ?? 0,
           }
         : undefined,
+    tiprackURI: tiprack,
   })
 
   const pipetteSpecs = invariantContext.pipetteEntities[pipette].spec

--- a/step-generation/src/commandCreators/compound/transfer.ts
+++ b/step-generation/src/commandCreators/compound/transfer.ts
@@ -35,6 +35,7 @@ import {
 import {
   getCustomLiquidClassProperties,
   getLiquidClassName,
+  getPythonAssignTipRacksString,
 } from '../../utils/liquidClassUtils'
 import {
   airGapInPlace,
@@ -381,6 +382,12 @@ export const transfer: CommandCreator<TransferArgs> = (
           .join(', ')
       : null
 
+  const pythonAssignTipracks = getPythonAssignTipRacksString({
+    pipetteEntity: pipetteEntities[pipette],
+    labwareEntities,
+    tiprackURI: tipRack,
+  })
+
   const pythonLiquidClassArgs = [
     `name=${formatPyStr(`${args.commandCreatorFnName}_step_${stepId}`)}`,
     ...(liquidClass != null
@@ -413,7 +420,7 @@ export const transfer: CommandCreator<TransferArgs> = (
   ]
   const pythonCommandCreator: CurriedCommandCreator = () => ({
     commands: [],
-    python: `${pythonPipetteName}.transfer_with_liquid_class(\n${indentPyLines(
+    python: `${pythonAssignTipracks}${pythonPipetteName}.transfer_with_liquid_class(\n${indentPyLines(
       pythonArgs.join(',\n')
     )},\n)`,
   })

--- a/step-generation/src/commandCreators/compound/transfer.ts
+++ b/step-generation/src/commandCreators/compound/transfer.ts
@@ -385,6 +385,7 @@ export const transfer: CommandCreator<TransferArgs> = (
   const pythonAssignTipracks = getPythonAssignTipRacksString({
     pipetteEntity: pipetteEntities[pipette],
     labwareEntities,
+    labwareState: prevRobotState.labware,
     tiprackURI: tipRack,
   })
 

--- a/step-generation/src/utils/liquidClassUtils.ts
+++ b/step-generation/src/utils/liquidClassUtils.ts
@@ -1,4 +1,4 @@
-import { last } from 'lodash'
+import last from 'lodash/last'
 
 import { getAllLiquidClassDefs } from '@opentrons/shared-data'
 
@@ -266,31 +266,16 @@ export const getPythonAssignTipRacksString = (args: {
   const { pythonName: pythonPipetteName } = pipetteEntity
   if (pipetteEntity.tiprackDefURI.length > 1) {
     const assignedTipRackPythonNames = Object.keys(labwareEntities).reduce<
-      Record<'onDeck' | 'offDeck', string[]>
-    >(
-      (acc, id) => {
-        const isOffDeck = last(labwareState[id].stack) === 'offDeck'
-        if (labwareEntities[id].labwareDefURI === tiprackURI) {
-          return isOffDeck
-            ? {
-                ...acc,
-                offDeck: [...acc.offDeck, labwareEntities[id].pythonName],
-              }
-            : {
-                ...acc,
-                onDeck: [...acc.onDeck, labwareEntities[id].pythonName],
-              }
-        }
-        return acc
-      },
-      { onDeck: [], offDeck: [] }
-    )
-    const orderedAssignedTipRackPythonNames = [
-      ...assignedTipRackPythonNames.onDeck,
-      ...assignedTipRackPythonNames.offDeck,
-    ]
+      string[]
+    >((acc, id) => {
+      const isOffDeck = last(labwareState[id].stack) === 'offDeck'
+      if (labwareEntities[id].labwareDefURI === tiprackURI && isOffDeck) {
+        return [...acc, labwareEntities[id].pythonName]
+      }
+      return acc
+    }, [])
 
-    return `${pythonPipetteName}.tip_racks = [${orderedAssignedTipRackPythonNames.join(
+    return `${pythonPipetteName}.tip_racks = [${assignedTipRackPythonNames.join(
       ', '
     )}]\n`
   }

--- a/step-generation/src/utils/liquidClassUtils.ts
+++ b/step-generation/src/utils/liquidClassUtils.ts
@@ -11,6 +11,8 @@ import type {
   ConsolidateArgs,
   DistributeArgs,
   InnerMixArgs,
+  LabwareEntities,
+  PipetteEntity,
   TransferArgs,
 } from '../types'
 
@@ -249,4 +251,28 @@ const getBlowoutPythonLocation = (
   } else {
     return 'trash'
   }
+}
+
+export const getPythonAssignTipRacksString = (args: {
+  pipetteEntity: PipetteEntity
+  labwareEntities: LabwareEntities
+  tiprackURI: string
+}): string => {
+  const { pipetteEntity, labwareEntities, tiprackURI } = args
+  const { pythonName: pythonPipetteName } = pipetteEntity
+  if (pipetteEntity.tiprackDefURI.length > 1) {
+    const assignedTipRackPythonNames = Object.keys(labwareEntities).reduce<
+      string[]
+    >((acc, id) => {
+      // return only tipracks matching the tiprack URI used in this step
+      if (labwareEntities[id].labwareDefURI === tiprackURI) {
+        return [...acc, labwareEntities[id].pythonName]
+      }
+      return acc
+    }, [])
+    return `${pythonPipetteName}.tip_racks = [${assignedTipRackPythonNames.join(
+      ', '
+    )}]\n`
+  }
+  return ''
 }

--- a/step-generation/src/utils/liquidClassUtils.ts
+++ b/step-generation/src/utils/liquidClassUtils.ts
@@ -1,3 +1,5 @@
+import { last } from 'lodash'
+
 import { getAllLiquidClassDefs } from '@opentrons/shared-data'
 
 import {
@@ -13,6 +15,7 @@ import type {
   InnerMixArgs,
   LabwareEntities,
   PipetteEntity,
+  RobotState,
   TransferArgs,
 } from '../types'
 
@@ -256,21 +259,38 @@ const getBlowoutPythonLocation = (
 export const getPythonAssignTipRacksString = (args: {
   pipetteEntity: PipetteEntity
   labwareEntities: LabwareEntities
+  labwareState: RobotState['labware']
   tiprackURI: string
 }): string => {
-  const { pipetteEntity, labwareEntities, tiprackURI } = args
+  const { pipetteEntity, labwareEntities, labwareState, tiprackURI } = args
   const { pythonName: pythonPipetteName } = pipetteEntity
   if (pipetteEntity.tiprackDefURI.length > 1) {
     const assignedTipRackPythonNames = Object.keys(labwareEntities).reduce<
-      string[]
-    >((acc, id) => {
-      // return only tipracks matching the tiprack URI used in this step
-      if (labwareEntities[id].labwareDefURI === tiprackURI) {
-        return [...acc, labwareEntities[id].pythonName]
-      }
-      return acc
-    }, [])
-    return `${pythonPipetteName}.tip_racks = [${assignedTipRackPythonNames.join(
+      Record<'onDeck' | 'offDeck', string[]>
+    >(
+      (acc, id) => {
+        const isOffDeck = last(labwareState[id].stack) === 'offDeck'
+        if (labwareEntities[id].labwareDefURI === tiprackURI) {
+          return isOffDeck
+            ? {
+                ...acc,
+                offDeck: [...acc.offDeck, labwareEntities[id].pythonName],
+              }
+            : {
+                ...acc,
+                onDeck: [...acc.onDeck, labwareEntities[id].pythonName],
+              }
+        }
+        return acc
+      },
+      { onDeck: [], offDeck: [] }
+    )
+    const orderedAssignedTipRackPythonNames = [
+      ...assignedTipRackPythonNames.onDeck,
+      ...assignedTipRackPythonNames.offDeck,
+    ]
+
+    return `${pythonPipetteName}.tip_racks = [${orderedAssignedTipRackPythonNames.join(
       ', '
     )}]\n`
   }

--- a/step-generation/src/utils/liquidClassUtils.ts
+++ b/step-generation/src/utils/liquidClassUtils.ts
@@ -269,7 +269,7 @@ export const getPythonAssignTipRacksString = (args: {
       string[]
     >((acc, id) => {
       const isOffDeck = last(labwareState[id].stack) === 'offDeck'
-      if (labwareEntities[id].labwareDefURI === tiprackURI && isOffDeck) {
+      if (labwareEntities[id].labwareDefURI === tiprackURI && !isOffDeck) {
         return [...acc, labwareEntities[id].pythonName]
       }
       return acc


### PR DESCRIPTION
# Overview

This PR ensures that tipracks are properly assigned to pipettes performing `_with_liquid_class` API methods. Previously, if a pipette was loaded with assignment of tipracks of varying types, the custom liquid class properties may contain the intended tiprack type for that transfer, but the API may attempt to perform the liquid handling with a tiprack of a different type not specified in the liquid class properties (priority order during tiprack assignment). This PR explicitly reassigns the tiprack array directly preceding these liquid handling methods in the event that a pipette has multiple tiprack types assigned.

## Test Plan and Hands on Testing

#### Multiple tiprack types assigned
- create a protocol with multiple tiprack types assigned to a pipette
- create transfer step for that pipette with path set to "single transfer" (n-to-n)
- export and verify that directly preceding the step is a Python tiprack assignment (`pipette.tip_racks=[selected_tiprack_type_python_name, ...]`
- repeat with distribute and consolidate paths

#### Single tiprack type assigned
- create a protocol with a single tiprack type assigned to a pipette
- create transfer step for that pipette with path set to "single transfer" (n-to-n)
- export and verify there _is no_ tiprack assignment command as specified above 
- repeat with distribute and consolidate paths

## Changelog

- create utility for getting tiprack assignment text dynamically
- wire up in `transfer`, `distribute`, and `consolidate` command creators

## Review requests

see tests plan

## Risk assessment

lowish