### PR TITLE
chore(protocol-designer): redo the chore_release-pd-8.5.1 branch

### DIFF
--- a/protocol-designer/cypress/support/Import.ts
+++ b/protocol-designer/cypress/support/Import.ts
@@ -108,7 +108,6 @@ export const migrateAndMatchSnapshot = ({
         savedFile.designerApplication.version as string
       )
       assert(version !== null, 'PD version is not valid semver')
-      const isBelowVersion850 = semver.lt(version ?? '', '8.5.0')
 
       const files = [savedFile, expectedFile]
       files.forEach(f => {
@@ -122,10 +121,7 @@ export const migrateAndMatchSnapshot = ({
         //  a uuid is randomly generated each time you upload a protocol that is less than version 8_5_0
         //  which is the migration version that adds these keys. Due to this, we need to ignore
         //  the uuids
-        if (
-          Boolean(savedStepForms[initialDeckSetupStep]) &&
-          isBelowVersion850
-        ) {
+        if (Boolean(savedStepForms[initialDeckSetupStep])) {
           savedStepForms[initialDeckSetupStep].trashBinLocationUpdate = {
             trashBin: 'trashLocation',
           }

--- a/protocol-designer/release-notes.md
+++ b/protocol-designer/release-notes.md
@@ -8,6 +8,12 @@ By using Opentrons Protocol Designer, you agree to the Opentrons End-User Licens
 
 ---
 
+## Opentrons Protocol Designer Changes in 8.5.1
+
+**Welcome to Protocol Designer 8.5.1!**
+
+This hotfix release addresses a bug that caused the incorrect tip rack to be assigned to some liquid transfers.
+
 ## Opentrons Protocol Designer Changes in 8.5.0
 
 **Welcome to Protocol Designer v8.5.0!**

--- a/step-generation/src/commandCreators/compound/consolidate.ts
+++ b/step-generation/src/commandCreators/compound/consolidate.ts
@@ -36,6 +36,7 @@ import {
 import {
   getCustomLiquidClassProperties,
   getLiquidClassName,
+  getPythonAssignTipRacksString,
 } from '../../utils/liquidClassUtils'
 import {
   airGapInPlace,
@@ -361,6 +362,13 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
     pythonLiquidClassArgs.join(',\n')
   )},\n)`
 
+  const pythonAssignTipracks = getPythonAssignTipRacksString({
+    pipetteEntity: pipetteEntities[pipette],
+    labwareEntities,
+    labwareState: prevRobotState.labware,
+    tiprackURI: tipRack,
+  })
+
   const pythonArgs = [
     `volume=${volume}`,
     `source=[${pythonSourceWells}]`,
@@ -375,7 +383,7 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
   ]
   const pythonCommandCreator: CurriedCommandCreator = () => ({
     commands: [],
-    python: `${pythonPipetteName}.consolidate_with_liquid_class(\n${indentPyLines(
+    python: `${pythonAssignTipracks}${pythonPipetteName}.consolidate_with_liquid_class(\n${indentPyLines(
       pythonArgs.join(',\n')
     )},\n)`,
   })

--- a/step-generation/src/commandCreators/compound/distribute.ts
+++ b/step-generation/src/commandCreators/compound/distribute.ts
@@ -37,6 +37,7 @@ import {
 import {
   getCustomLiquidClassProperties,
   getLiquidClassName,
+  getPythonAssignTipRacksString,
 } from '../../utils/liquidClassUtils'
 import {
   airGapInPlace,
@@ -394,6 +395,13 @@ export const distribute: CommandCreator<DistributeArgs> = (
     pythonLiquidClassArgs.join(',\n')
   )},\n)`
 
+  const pythonAssignTipracks = getPythonAssignTipRacksString({
+    pipetteEntity: pipetteEntities[pipette],
+    labwareEntities,
+    labwareState: prevRobotState.labware,
+    tiprackURI: tipRack,
+  })
+
   const pythonArgs = [
     `volume=${volume}`,
     `source=[${pythonSourceWells}]`,
@@ -406,7 +414,7 @@ export const distribute: CommandCreator<DistributeArgs> = (
   ]
   const pythonCommandCreator: CurriedCommandCreator = () => ({
     commands: [],
-    python: `${pythonPipetteName}.distribute_with_liquid_class(\n${indentPyLines(
+    python: `${pythonAssignTipracks}${pythonPipetteName}.distribute_with_liquid_class(\n${indentPyLines(
       pythonArgs.join(',\n')
     )},\n)`,
   })

--- a/step-generation/src/commandCreators/compound/transfer.ts
+++ b/step-generation/src/commandCreators/compound/transfer.ts
@@ -35,6 +35,7 @@ import {
 import {
   getCustomLiquidClassProperties,
   getLiquidClassName,
+  getPythonAssignTipRacksString,
 } from '../../utils/liquidClassUtils'
 import {
   airGapInPlace,
@@ -381,6 +382,13 @@ export const transfer: CommandCreator<TransferArgs> = (
           .join(', ')
       : null
 
+  const pythonAssignTipracks = getPythonAssignTipRacksString({
+    pipetteEntity: pipetteEntities[pipette],
+    labwareEntities,
+    labwareState: prevRobotState.labware,
+    tiprackURI: tipRack,
+  })
+
   const pythonLiquidClassArgs = [
     `name=${formatPyStr(`${args.commandCreatorFnName}_step_${stepId}`)}`,
     ...(liquidClass != null
@@ -413,7 +421,7 @@ export const transfer: CommandCreator<TransferArgs> = (
   ]
   const pythonCommandCreator: CurriedCommandCreator = () => ({
     commands: [],
-    python: `${pythonPipetteName}.transfer_with_liquid_class(\n${indentPyLines(
+    python: `${pythonAssignTipracks}${pythonPipetteName}.transfer_with_liquid_class(\n${indentPyLines(
       pythonArgs.join(',\n')
     )},\n)`,
   })

--- a/step-generation/src/utils/liquidClassUtils.ts
+++ b/step-generation/src/utils/liquidClassUtils.ts
@@ -1,3 +1,5 @@
+import last from 'lodash/last'
+
 import { getAllLiquidClassDefs } from '@opentrons/shared-data'
 
 import {
@@ -11,6 +13,9 @@ import type {
   ConsolidateArgs,
   DistributeArgs,
   InnerMixArgs,
+  LabwareEntities,
+  PipetteEntity,
+  RobotState,
   TransferArgs,
 } from '../types'
 
@@ -249,4 +254,30 @@ const getBlowoutPythonLocation = (
   } else {
     return 'trash'
   }
+}
+
+export const getPythonAssignTipRacksString = (args: {
+  pipetteEntity: PipetteEntity
+  labwareEntities: LabwareEntities
+  labwareState: RobotState['labware']
+  tiprackURI: string
+}): string => {
+  const { pipetteEntity, labwareEntities, labwareState, tiprackURI } = args
+  const { pythonName: pythonPipetteName } = pipetteEntity
+  if (pipetteEntity.tiprackDefURI.length > 1) {
+    const assignedTipRackPythonNames = Object.keys(labwareEntities).reduce<
+      string[]
+    >((acc, id) => {
+      const isOffDeck = last(labwareState[id].stack) === 'offDeck'
+      if (labwareEntities[id].labwareDefURI === tiprackURI && !isOffDeck) {
+        return [...acc, labwareEntities[id].pythonName]
+      }
+      return acc
+    }, [])
+
+    return `${pythonPipetteName}.tip_racks = [${assignedTipRackPythonNames.join(
+      ', '
+    )}]\n`
+  }
+  return ''
 }


### PR DESCRIPTION
# Overview

We accidentally created `chore_release-pd-8.5.1` from the wrong commit.

This PR attempts to replace the `chore_release-pd-8.5.1` branch entirely with the sequence of commits that we want.

## Test Plan and Hands on Testing

Run CI tests.

## Risk assessment

Low to users, moderate to our sanity.