### PR TITLE
fix(protocol-designer): Fix comma splice

### DIFF
--- a/protocol-designer/src/assets/localization/en/shared.json
+++ b/protocol-designer/src/assets/localization/en/shared.json
@@ -12,7 +12,7 @@
   "change_robot_movement": "Change how the robot moves from well to well.",
   "close": "Close",
   "confirm_import": "Are you sure you want to upload this protocol?",
-  "confirm_reorder": "Are you sure you want to reorder these steps, it may cause errors?",
+  "confirm_reorder": "Are you sure you want to reorder these steps? It may cause errors.",
   "confirm": "Confirm",
   "consent_to_eula": "By using Protocol Designer, you consent to the Opentrons <link1>EULA</link1>.",
   "continue_with_export": "Continue with export",


### PR DESCRIPTION
## Overview

This fixes a [very old](https://github.com/Opentrons/opentrons/pull/2714) comma splice in the confirmation modal when you reorder steps in the timeline.

This modal doesn't appear anywhere in the designs, as far as I can tell, so I think we're good to just fix it here.

## Test Plan and Hands on Testing

None needed.

## Review requests

None.

## Risk assessment

Very low.
