### PR TITLE
feat(protocol-designer): Limit import file types to .py and .json.

### DIFF
--- a/protocol-designer/src/components/organisms/Navigation/index.tsx
+++ b/protocol-designer/src/components/organisms/Navigation/index.tsx
@@ -15,6 +15,7 @@ import {
   StyledText,
 } from '@opentrons/components'
 
+import { ACCEPTED_FILE_TYPES } from '/protocol-designer/constants'
 import { actions as loadFileActions } from '/protocol-designer/load-file'
 import { getHasUnsavedChanges } from '/protocol-designer/load-file/selectors'
 import { toggleNewProtocolModal } from '/protocol-designer/navigation/actions'
@@ -74,6 +75,7 @@ export function Navigation(): JSX.Element | null {
             onChange={loadFile}
             aria-label={t('import')}
             ref={fileInputRef}
+            accept={ACCEPTED_FILE_TYPES}
           />
         </StyledLabel>
         {location.pathname === '/createNew' ? null : <SettingsIcon />}

--- a/protocol-designer/src/components/organisms/Navigation/index.tsx
+++ b/protocol-designer/src/components/organisms/Navigation/index.tsx
@@ -15,7 +15,7 @@ import {
   StyledText,
 } from '@opentrons/components'
 
-import { ACCEPTED_FILE_TYPES } from '/protocol-designer/constants'
+import { ACCEPTED_PROTOCOL_FILE_TYPES } from '/protocol-designer/constants'
 import { actions as loadFileActions } from '/protocol-designer/load-file'
 import { getHasUnsavedChanges } from '/protocol-designer/load-file/selectors'
 import { toggleNewProtocolModal } from '/protocol-designer/navigation/actions'
@@ -75,7 +75,7 @@ export function Navigation(): JSX.Element | null {
             onChange={loadFile}
             aria-label={t('import')}
             ref={fileInputRef}
-            accept={ACCEPTED_FILE_TYPES}
+            accept={ACCEPTED_PROTOCOL_FILE_TYPES}
           />
         </StyledLabel>
         {location.pathname === '/createNew' ? null : <SettingsIcon />}

--- a/protocol-designer/src/constants.ts
+++ b/protocol-designer/src/constants.ts
@@ -153,4 +153,4 @@ export const CHANNELS_MAPPED_TO_MAX_SPEED: Record<
 
 export const MINIMUM_LIQUID_CLASS_VOLUME = 1
 
-export const ACCEPTED_FILE_TYPES = '.json,.py'
+export const ACCEPTED_PROTOCOL_FILE_TYPES = '.json,.py'

--- a/protocol-designer/src/constants.ts
+++ b/protocol-designer/src/constants.ts
@@ -152,3 +152,5 @@ export const CHANNELS_MAPPED_TO_MAX_SPEED: Record<
 }
 
 export const MINIMUM_LIQUID_CLASS_VOLUME = 1
+
+export const ACCEPTED_FILE_TYPES = '.json,.py'

--- a/protocol-designer/src/pages/Landing/index.tsx
+++ b/protocol-designer/src/pages/Landing/index.tsx
@@ -17,6 +17,7 @@ import { EndUserAgreementFooter } from '../../components/molecules'
 import { AnnouncementModal } from '../../components/organisms'
 import { useAnnouncements } from '../../components/organisms/AnnouncementModal/announcements'
 import { useKitchen } from '../../components/organisms/Kitchen/useKitchen'
+import { ACCEPTED_FILE_TYPES } from '../../constants'
 import { getFileMetadata } from '../../file-data/selectors'
 import { actions as loadFileActions } from '../../load-file'
 import { toggleNewProtocolModal } from '../../navigation/actions'
@@ -31,8 +32,6 @@ import type { ChangeEvent } from 'react'
 import type { ThunkDispatch } from '../../types'
 
 import welcomeImage from '../../assets/images/welcome_page.png'
-
-const ACCEPTED_FILE_TYPES = '.py,.json'
 
 export function Landing(): JSX.Element {
   const { t } = useTranslation('shared')

--- a/protocol-designer/src/pages/Landing/index.tsx
+++ b/protocol-designer/src/pages/Landing/index.tsx
@@ -32,6 +32,8 @@ import type { ThunkDispatch } from '../../types'
 
 import welcomeImage from '../../assets/images/welcome_page.png'
 
+const ACCEPTED_FILE_TYPES = '.py,.json'
+
 export function Landing(): JSX.Element {
   const { t } = useTranslation('shared')
   const dispatch: ThunkDispatch<any> = useDispatch()
@@ -151,6 +153,7 @@ export function Landing(): JSX.Element {
             ref={fileInputRef}
             aria-label={t('import')}
             className={styles.hiddenInput}
+            accept={ACCEPTED_FILE_TYPES}
           />
         </label>
       </div>

--- a/protocol-designer/src/pages/Landing/index.tsx
+++ b/protocol-designer/src/pages/Landing/index.tsx
@@ -17,7 +17,7 @@ import { EndUserAgreementFooter } from '../../components/molecules'
 import { AnnouncementModal } from '../../components/organisms'
 import { useAnnouncements } from '../../components/organisms/AnnouncementModal/announcements'
 import { useKitchen } from '../../components/organisms/Kitchen/useKitchen'
-import { ACCEPTED_FILE_TYPES } from '../../constants'
+import { ACCEPTED_PROTOCOL_FILE_TYPES } from '../../constants'
 import { getFileMetadata } from '../../file-data/selectors'
 import { actions as loadFileActions } from '../../load-file'
 import { toggleNewProtocolModal } from '../../navigation/actions'
@@ -152,7 +152,7 @@ export function Landing(): JSX.Element {
             ref={fileInputRef}
             aria-label={t('import')}
             className={styles.hiddenInput}
-            accept={ACCEPTED_FILE_TYPES}
+            accept={ACCEPTED_PROTOCOL_FILE_TYPES}
           />
         </label>
       </div>


### PR DESCRIPTION
## Overview

A minor quality of life thing. When you click an Import button in Protocol Designer and it opens a file selector, this makes it gray out files that definitely aren't valid imports, like .png, .txt, etc.

My downloads folder has a million entries and this narrows it down significantly. :^)

## Test Plan and Hands on Testing

* [x] .py protocols are not grayed out
* [x] .json files are not grayed out
* [x] everything else is grayed out

## Review requests

Protocol Designer has never exported a file extension other than .py or .json, has it?

## Risk assessment

Low a long as this is the complete list of file extensions.