### PR TITLE
feat(opentrons-ai-client): remove footer

### DIFF
--- a/opentrons-ai-client/src/OpentronsAI.tsx
+++ b/opentrons-ai-client/src/OpentronsAI.tsx
@@ -100,7 +100,7 @@ export function OpentronsAI(): JSX.Element | null {
 
   return (
     <HashRouter>
-      <AppContent
+      <AppWrapper
         displayHeaderWithMeter={displayHeaderWithMeter}
         progress={progress}
       />
@@ -108,10 +108,29 @@ export function OpentronsAI(): JSX.Element | null {
   )
 }
 
+function AppWrapper({
+  displayHeaderWithMeter,
+  progress,
+}: {
+  displayHeaderWithMeter: boolean
+  progress: number
+}): JSX.Element {
+  const location = useLocation()
+  const isOnChatPage = location.pathname === '/chat'
+
+  return (
+    <AppContent
+      displayHeaderWithMeter={displayHeaderWithMeter}
+      progress={progress}
+      isOnChatPage={isOnChatPage}
+    />
+  )
+}
+
 interface AppContentProps {
   displayHeaderWithMeter: boolean
   progress: number
-  isOnChatPage?: boolean
+  isOnChatPage: boolean
 }
 
 function AppContent({
@@ -119,8 +138,6 @@ function AppContent({
   progress,
   isOnChatPage,
 }: AppContentProps): JSX.Element {
-  const location = useLocation()
-  const shouldHideFooter = isOnChatPage ?? location.pathname === '/chat'
   return (
     <Flex width="100%" height="100vh" flexDirection={DIRECTION_COLUMN}>
       <StickyHeader>
@@ -146,7 +163,7 @@ function AppContent({
           <ExitConfirmModal />
           <OpentronsAIRoutes />
         </Flex>
-        {!shouldHideFooter ? <Footer /> : null}
+        {!isOnChatPage ? <Footer /> : null}
       </Flex>
     </Flex>
   )

--- a/opentrons-ai-client/src/OpentronsAI.tsx
+++ b/opentrons-ai-client/src/OpentronsAI.tsx
@@ -143,7 +143,7 @@ function AppContent({
           <ExitConfirmModal />
           <OpentronsAIRoutes />
         </Flex>
-        {!isOnChatPage && <Footer />}
+        {!isOnChatPage ? <Footer /> : null}
       </Flex>
     </Flex>
   )

--- a/opentrons-ai-client/src/OpentronsAI.tsx
+++ b/opentrons-ai-client/src/OpentronsAI.tsx
@@ -108,16 +108,19 @@ export function OpentronsAI(): JSX.Element | null {
   )
 }
 
+interface AppContentProps {
+  displayHeaderWithMeter: boolean
+  progress: number
+  isOnChatPage?: boolean
+}
+
 function AppContent({
   displayHeaderWithMeter,
   progress,
-}: {
-  displayHeaderWithMeter: boolean
-  progress: number
-}): JSX.Element {
+  isOnChatPage,
+}: AppContentProps): JSX.Element {
   const location = useLocation()
-  const isOnChatPage = location.pathname === '/chat'
-
+  const shouldHideFooter = isOnChatPage ?? location.pathname === '/chat'
   return (
     <Flex width="100%" height="100vh" flexDirection={DIRECTION_COLUMN}>
       <StickyHeader>
@@ -143,7 +146,7 @@ function AppContent({
           <ExitConfirmModal />
           <OpentronsAIRoutes />
         </Flex>
-        {!isOnChatPage ? <Footer /> : null}
+        {!shouldHideFooter ? <Footer /> : null}
       </Flex>
     </Flex>
   )

--- a/opentrons-ai-client/src/OpentronsAI.tsx
+++ b/opentrons-ai-client/src/OpentronsAI.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react'
-import { HashRouter } from 'react-router-dom'
+import { HashRouter, useLocation } from 'react-router-dom'
 import { useAuth0 } from '@auth0/auth0-react'
 import { useAtom } from 'jotai'
 import styled from 'styled-components'
@@ -100,33 +100,52 @@ export function OpentronsAI(): JSX.Element | null {
 
   return (
     <HashRouter>
-      <Flex width="100%" height="100vh" flexDirection={DIRECTION_COLUMN}>
-        <StickyHeader>
-          {displayHeaderWithMeter ? (
-            <HeaderWithMeter progressPercentage={progress} />
-          ) : (
-            <Header />
-          )}
-        </StickyHeader>
-        <Flex
-          flex="1"
-          flexDirection={DIRECTION_COLUMN}
-          backgroundColor={COLORS.grey10}
-          overflow={OVERFLOW_AUTO}
-        >
-          <Flex
-            width="100%"
-            maxWidth={CLIENT_MAX_WIDTH}
-            alignSelf={ALIGN_CENTER}
-            flex="1"
-          >
-            <ExitConfirmModal />
-            <OpentronsAIRoutes />
-          </Flex>
-          <Footer />
-        </Flex>
-      </Flex>
+      <AppContent
+        displayHeaderWithMeter={displayHeaderWithMeter}
+        progress={progress}
+      />
     </HashRouter>
+  )
+}
+
+function AppContent({
+  displayHeaderWithMeter,
+  progress,
+}: {
+  displayHeaderWithMeter: boolean
+  progress: number
+}): JSX.Element {
+  const location = useLocation()
+  const isOnChatPage = location.pathname === '/chat'
+
+  return (
+    <Flex width="100%" height="100vh" flexDirection={DIRECTION_COLUMN}>
+      <StickyHeader>
+        {displayHeaderWithMeter ? (
+          <HeaderWithMeter progressPercentage={progress} />
+        ) : (
+          <Header />
+        )}
+      </StickyHeader>
+
+      <Flex
+        flex="1"
+        flexDirection={DIRECTION_COLUMN}
+        backgroundColor={COLORS.grey10}
+        overflow={OVERFLOW_AUTO}
+      >
+        <Flex
+          width="100%"
+          maxWidth={CLIENT_MAX_WIDTH}
+          alignSelf={ALIGN_CENTER}
+          flex="1"
+        >
+          <ExitConfirmModal />
+          <OpentronsAIRoutes />
+        </Flex>
+        {!isOnChatPage && <Footer />}
+      </Flex>
+    </Flex>
   )
 }
 

--- a/opentrons-ai-client/src/OpentronsAI.tsx
+++ b/opentrons-ai-client/src/OpentronsAI.tsx
@@ -31,12 +31,22 @@ import { useGetAccessToken } from './resources/hooks'
 import { useTrackEvent } from './resources/hooks/useTrackEvent'
 
 export function OpentronsAI(): JSX.Element | null {
+  return (
+    <HashRouter>
+      <OpentronsAIApp />
+    </HashRouter>
+  )
+}
+
+function OpentronsAIApp(): JSX.Element | null {
   const { isAuthenticated, isLoading, loginWithRedirect } = useAuth0()
   const [, setToken] = useAtom(tokenAtom)
   const [{ displayHeaderWithMeter, progress }] = useAtom(headerWithMeterAtom)
   const [mixpanelState, setMixpanelState] = useAtom(mixpanelAtom)
   const { getAccessToken } = useGetAccessToken()
   const [featureFlags, setFeatureFlags] = useAtom(featureFlagsAtom)
+  const location = useLocation()
+  const isOnChatPage = location.pathname === '/chat'
 
   const trackEvent = useTrackEvent()
 
@@ -97,26 +107,6 @@ export function OpentronsAI(): JSX.Element | null {
   global.enablePrereleaseMode = () => {
     setFeatureFlags({ enablePrereleaseMode: true })
   }
-
-  return (
-    <HashRouter>
-      <AppWrapper
-        displayHeaderWithMeter={displayHeaderWithMeter}
-        progress={progress}
-      />
-    </HashRouter>
-  )
-}
-
-function AppWrapper({
-  displayHeaderWithMeter,
-  progress,
-}: {
-  displayHeaderWithMeter: boolean
-  progress: number
-}): JSX.Element {
-  const location = useLocation()
-  const isOnChatPage = location.pathname === '/chat'
 
   return (
     <AppContent


### PR DESCRIPTION
# Overview

Closes AUTH-2019
[Figma](https://www.figma.com/design/viYBfEgz3TEnqHqfgH9B7S/Opentrons-AI?node-id=4734-12045&m=dev)

  - On the Chat page: Only shows the ChatFooter with the disclaimer "OpentronsAI can make
  mistakes. Review your protocol before running it on an Opentrons robot."
  - On other pages (like home): Shows the full Footer 

Old: 
<img width="897" height="167" alt="image" src="https://github.com/user-attachments/assets/7d44f4d6-88eb-4260-b2fb-cb1625a5125e" />


Changed:
<img width="921" height="159" alt="image" src="https://github.com/user-attachments/assets/7c55e88d-8211-4691-9bc5-fc346a835dd0" />




## Review requests

Open UI and confirm that the footer is gone

## Risk assessment

Low