### PR TITLE
refactor(api): do stackup to labware origin calculations in labware origin math

### DIFF
--- a/api/src/opentrons/protocol_engine/state/_labware_origin_math.py
+++ b/api/src/opentrons/protocol_engine/state/_labware_origin_math.py
@@ -24,6 +24,7 @@ from opentrons_shared_data.deck.types import DeckDefinitionV5, SlotDefV3
 from .. import errors
 from ..types import (
     LabwareStackupDefinition,
+    LabwareStackupAncestorDefinition,
     ModuleDefinition,
     ModuleModel,
     DeckLocationDefinition,
@@ -44,43 +45,46 @@ class _Labware3SupportedParentDefinition:
 
 
 def get_stackup_placement_origin_to_lw_origin(
-    stackup_info_top_to_bottom: list[tuple[LabwareStackupDefinition, LabwareLocation]],
+    stackup_lw_info_top_to_bottom: list[tuple[LabwareDefinition, LabwareLocation]],
+    underlying_ancestor_definition: LabwareStackupAncestorDefinition,
     module_parent_to_child_offset: Union[Point, None],
     deck_definition: DeckDefinitionV5,
     is_topmost_labware: bool = True,
 ) -> Point:
     """Returns the offset from the stackup placement origin to child labware origin."""
-    definition, location = stackup_info_top_to_bottom[0]
-    parent_definition, parent_location = stackup_info_top_to_bottom[1]
+    definition, location = stackup_lw_info_top_to_bottom[0]
 
     if isinstance(
-        parent_location, (AddressableAreaLocation, DeckSlotLocation, ModuleLocation)
+        location, (AddressableAreaLocation, DeckSlotLocation, ModuleLocation)
     ):
         return _get_parent_placement_origin_to_lw_origin_by_location(
             labware_location=location,
-            labware_definition=definition,  # type: ignore[arg-type]
-            parent_definition=parent_definition,
+            labware_definition=definition,
+            parent_definition=underlying_ancestor_definition,
             deck_definition=deck_definition,
             module_parent_to_child_offset=module_parent_to_child_offset,
             is_topmost_labware=is_topmost_labware,
         )
-    elif isinstance(parent_location, OnLabwareLocation):
+    elif isinstance(location, OnLabwareLocation):
+        parent_definition = stackup_lw_info_top_to_bottom[1][0]
+
         parent_placement_origin_to_lw_origin = (
             _get_parent_placement_origin_to_lw_origin_by_location(
                 labware_location=location,
-                labware_definition=definition,  # type: ignore[arg-type]
+                labware_definition=definition,
                 parent_definition=parent_definition,
                 deck_definition=deck_definition,
                 module_parent_to_child_offset=module_parent_to_child_offset,
                 is_topmost_labware=is_topmost_labware,
             )
         )
-        remaining_definitions_locations_top_to_bottom = stackup_info_top_to_bottom[1:]
+        remaining_lw_defs_locs_top_to_bottom = stackup_lw_info_top_to_bottom[1:]
 
         return (
             parent_placement_origin_to_lw_origin
             + get_stackup_placement_origin_to_lw_origin(
-                stackup_info_top_to_bottom=remaining_definitions_locations_top_to_bottom,
+                stackup_lw_info_top_to_bottom=remaining_lw_defs_locs_top_to_bottom,
+                underlying_ancestor_definition=underlying_ancestor_definition,
                 module_parent_to_child_offset=module_parent_to_child_offset,
                 deck_definition=deck_definition,
                 is_topmost_labware=False,

--- a/api/src/opentrons/protocol_engine/state/_labware_origin_math.py
+++ b/api/src/opentrons/protocol_engine/state/_labware_origin_math.py
@@ -23,7 +23,6 @@ from opentrons.protocol_engine.types import AddressableArea
 from opentrons_shared_data.deck.types import DeckDefinitionV5, SlotDefV3
 from .. import errors
 from ..types import (
-    LabwareStackupDefinition,
     LabwareStackupAncestorDefinition,
     ModuleDefinition,
     ModuleModel,
@@ -36,6 +35,11 @@ from ..types import (
 )
 
 _OFFSET_ON_TC_OT2 = Point(x=0, y=0, z=10.7)
+
+_LabwareStackupDefinition = Union[
+    DeckLocationDefinition, ModuleDefinition, LabwareDefinition
+]
+"""Information pertaining to a deck item that is present in a labware stackup."""
 
 
 @dataclasses.dataclass
@@ -100,7 +104,7 @@ def get_stackup_placement_origin_to_lw_origin(
 def _get_parent_placement_origin_to_lw_origin_by_location(
     labware_location: LabwareLocation,
     labware_definition: LabwareDefinition,
-    parent_definition: LabwareStackupDefinition,
+    parent_definition: _LabwareStackupDefinition,
     deck_definition: DeckDefinitionV5,
     module_parent_to_child_offset: Union[Point, None],
     is_topmost_labware: bool,
@@ -179,7 +183,7 @@ def _get_parent_placement_origin_to_lw_origin(
 
 def _get_parent_placement_origin_to_lw_origin(
     child_labware: LabwareDefinition,
-    parent_deck_item: LabwareStackupDefinition,
+    parent_deck_item: _LabwareStackupDefinition,
     module_parent_to_child_offset: Union[Point, None],
     deck_definition: DeckDefinitionV5,
     is_topmost_labware: bool,
@@ -264,7 +268,7 @@ def _get_parent_placement_origin_to_lw_origin(
 
 def _get_parent_deck_item_origin_to_child_labware_placement_origin(
     child_labware: LabwareDefinition,
-    parent_deck_item: LabwareStackupDefinition,
+    parent_deck_item: _LabwareStackupDefinition,
     module_parent_to_child_offset: Union[Point, None],
     deck_definition: DeckDefinitionV5,
     labware_location: LabwareLocation,
@@ -694,7 +698,7 @@ def _get_child_labware_overlap_with_parent_module(
 
 
 def _feature_exception_offsets(
-    parent_deck_item: LabwareStackupDefinition,
+    parent_deck_item: _LabwareStackupDefinition,
     deck_definition: DeckDefinitionV5,
 ) -> Point:
     """These offsets are intended for legacy reasons only and should generally be avoided post labware schema 2.

--- a/api/src/opentrons/protocol_engine/state/_labware_origin_math.py
+++ b/api/src/opentrons/protocol_engine/state/_labware_origin_math.py
@@ -1,6 +1,5 @@
 """Utilities for calculating the labware origin offset position."""
 import dataclasses
-import enum
 from typing import Union, overload
 
 from typing_extensions import assert_type
@@ -54,7 +53,6 @@ def get_stackup_placement_origin_to_lw_origin(
     definition, location = stackup_info_top_to_bottom[0]
     parent_definition, parent_location = stackup_info_top_to_bottom[1]
 
-    """Get the offset vector from the lowest entity in a stackup to the labware."""
     if isinstance(
         parent_location, (AddressableAreaLocation, DeckSlotLocation, ModuleLocation)
     ):

--- a/api/src/opentrons/protocol_engine/state/_labware_origin_math.py
+++ b/api/src/opentrons/protocol_engine/state/_labware_origin_math.py
@@ -1,5 +1,6 @@
 """Utilities for calculating the labware origin offset position."""
 import dataclasses
+import enum
 from typing import Union, overload
 
 from typing_extensions import assert_type
@@ -21,6 +22,7 @@ from opentrons_shared_data.labware.types import (
 )
 from opentrons.protocol_engine.types import AddressableArea
 from opentrons_shared_data.deck.types import DeckDefinitionV5, SlotDefV3
+from .. import errors
 from ..types import (
     LabwareParentDefinition,
     ModuleDefinition,
@@ -42,8 +44,103 @@ class _Labware3SupportedParentDefinition:
     extents: Extents
 
 
+def get_stackup_placement_origin_to_lw_origin(
+    stackup_info_top_to_bottom: list[tuple[LabwareParentDefinition, LabwareLocation]],
+    module_parent_to_child_offset: Union[Point, None],
+    deck_definition: DeckDefinitionV5,
+    is_topmost_labware: bool = True,
+) -> Point:
+    """Returns the offset from the stackup placement origin to child labware origin."""
+    definition, location = stackup_info_top_to_bottom[0]
+    parent_definition, parent_location = stackup_info_top_to_bottom[1]
+
+    """Get the offset vector from the lowest entity in a stackup to the labware."""
+    if isinstance(
+        parent_location, (AddressableAreaLocation, DeckSlotLocation, ModuleLocation)
+    ):
+        return _get_parent_placement_origin_to_lw_origin_by_location(
+            labware_location=location,
+            labware_definition=definition,  # type: ignore[arg-type]
+            parent_definition=parent_definition,
+            deck_definition=deck_definition,
+            module_parent_to_child_offset=module_parent_to_child_offset,
+            is_topmost_labware=is_topmost_labware,
+        )
+    elif isinstance(parent_location, OnLabwareLocation):
+        parent_placement_origin_to_lw_origin = (
+            _get_parent_placement_origin_to_lw_origin_by_location(
+                labware_location=location,
+                labware_definition=definition,  # type: ignore[arg-type]
+                parent_definition=parent_definition,
+                deck_definition=deck_definition,
+                module_parent_to_child_offset=module_parent_to_child_offset,
+                is_topmost_labware=is_topmost_labware,
+            )
+        )
+        remaining_definitions_locations_top_to_bottom = stackup_info_top_to_bottom[1:]
+
+        return (
+            parent_placement_origin_to_lw_origin
+            + get_stackup_placement_origin_to_lw_origin(
+                stackup_info_top_to_bottom=remaining_definitions_locations_top_to_bottom,
+                module_parent_to_child_offset=module_parent_to_child_offset,
+                deck_definition=deck_definition,
+                is_topmost_labware=False,
+            )
+        )
+    else:
+        raise errors.LabwareNotOnDeckError(
+            "Cannot access labware since it is not on the deck. "
+            "Either it has been loaded off-deck or its been moved off-deck."
+        )
+
+
+def _get_parent_placement_origin_to_lw_origin_by_location(
+    labware_location: LabwareLocation,
+    labware_definition: LabwareDefinition,
+    parent_definition: LabwareParentDefinition,
+    deck_definition: DeckDefinitionV5,
+    module_parent_to_child_offset: Union[Point, None],
+    is_topmost_labware: bool,
+) -> Point:
+    if isinstance(labware_location, ModuleLocation):
+        if module_parent_to_child_offset is None:
+            raise ValueError(
+                "Expected value for module_parent_to_child_offset, received None."
+            )
+        else:
+            return _get_parent_placement_origin_to_lw_origin(
+                child_labware=labware_definition,
+                parent_deck_item=parent_definition,  # type: ignore[arg-type]
+                module_parent_to_child_offset=module_parent_to_child_offset,
+                deck_definition=deck_definition,
+                is_topmost_labware=is_topmost_labware,
+                labware_location=labware_location,
+            )
+    elif isinstance(labware_location, OnLabwareLocation):
+        return _get_parent_placement_origin_to_lw_origin(
+            child_labware=labware_definition,
+            parent_deck_item=parent_definition,  # type: ignore[arg-type]
+            module_parent_to_child_offset=None,
+            deck_definition=deck_definition,
+            is_topmost_labware=is_topmost_labware,
+            labware_location=labware_location,
+        )
+    elif isinstance(labware_location, (DeckSlotLocation, AddressableAreaLocation)):
+        return _get_parent_placement_origin_to_lw_origin(
+            child_labware=labware_definition,
+            parent_deck_item=parent_definition,  # type: ignore[arg-type]
+            module_parent_to_child_offset=None,
+            deck_definition=deck_definition,
+            is_topmost_labware=is_topmost_labware,
+            labware_location=labware_location,
+        )
+    else:
+        raise ValueError(f"Invalid labware location: {labware_location}")
+
+
 @overload
-def get_parent_placement_origin_to_lw_origin(
+def _get_parent_placement_origin_to_lw_origin(
     child_labware: LabwareDefinition,
     parent_deck_item: ModuleDefinition,
     module_parent_to_child_offset: Point,
@@ -55,7 +152,7 @@ def get_parent_placement_origin_to_lw_origin(
 
 
 @overload
-def get_parent_placement_origin_to_lw_origin(
+def _get_parent_placement_origin_to_lw_origin(
     child_labware: LabwareDefinition,
     parent_deck_item: DeckLocationDefinition,
     module_parent_to_child_offset: None,
@@ -67,7 +164,7 @@ def get_parent_placement_origin_to_lw_origin(
 
 
 @overload
-def get_parent_placement_origin_to_lw_origin(
+def _get_parent_placement_origin_to_lw_origin(
     child_labware: LabwareDefinition,
     parent_deck_item: LabwareDefinition,
     module_parent_to_child_offset: None,
@@ -78,7 +175,7 @@ def get_parent_placement_origin_to_lw_origin(
     ...
 
 
-def get_parent_placement_origin_to_lw_origin(
+def _get_parent_placement_origin_to_lw_origin(
     child_labware: LabwareDefinition,
     parent_deck_item: LabwareParentDefinition,
     module_parent_to_child_offset: Union[Point, None],

--- a/api/src/opentrons/protocol_engine/state/_labware_origin_math.py
+++ b/api/src/opentrons/protocol_engine/state/_labware_origin_math.py
@@ -23,7 +23,7 @@ from opentrons.protocol_engine.types import AddressableArea
 from opentrons_shared_data.deck.types import DeckDefinitionV5, SlotDefV3
 from .. import errors
 from ..types import (
-    LabwareParentDefinition,
+    LabwareStackupDefinition,
     ModuleDefinition,
     ModuleModel,
     DeckLocationDefinition,
@@ -44,7 +44,7 @@ class _Labware3SupportedParentDefinition:
 
 
 def get_stackup_placement_origin_to_lw_origin(
-    stackup_info_top_to_bottom: list[tuple[LabwareParentDefinition, LabwareLocation]],
+    stackup_info_top_to_bottom: list[tuple[LabwareStackupDefinition, LabwareLocation]],
     module_parent_to_child_offset: Union[Point, None],
     deck_definition: DeckDefinitionV5,
     is_topmost_labware: bool = True,
@@ -96,7 +96,7 @@ def get_stackup_placement_origin_to_lw_origin(
 def _get_parent_placement_origin_to_lw_origin_by_location(
     labware_location: LabwareLocation,
     labware_definition: LabwareDefinition,
-    parent_definition: LabwareParentDefinition,
+    parent_definition: LabwareStackupDefinition,
     deck_definition: DeckDefinitionV5,
     module_parent_to_child_offset: Union[Point, None],
     is_topmost_labware: bool,
@@ -175,7 +175,7 @@ def _get_parent_placement_origin_to_lw_origin(
 
 def _get_parent_placement_origin_to_lw_origin(
     child_labware: LabwareDefinition,
-    parent_deck_item: LabwareParentDefinition,
+    parent_deck_item: LabwareStackupDefinition,
     module_parent_to_child_offset: Union[Point, None],
     deck_definition: DeckDefinitionV5,
     is_topmost_labware: bool,
@@ -260,7 +260,7 @@ def _get_parent_placement_origin_to_lw_origin(
 
 def _get_parent_deck_item_origin_to_child_labware_placement_origin(
     child_labware: LabwareDefinition,
-    parent_deck_item: LabwareParentDefinition,
+    parent_deck_item: LabwareStackupDefinition,
     module_parent_to_child_offset: Union[Point, None],
     deck_definition: DeckDefinitionV5,
     labware_location: LabwareLocation,
@@ -690,7 +690,7 @@ def _get_child_labware_overlap_with_parent_module(
 
 
 def _feature_exception_offsets(
-    parent_deck_item: LabwareParentDefinition,
+    parent_deck_item: LabwareStackupDefinition,
     deck_definition: DeckDefinitionV5,
 ) -> Point:
     """These offsets are intended for legacy reasons only and should generally be avoided post labware schema 2.

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -91,7 +91,6 @@ from ..types import (
     labware_location_is_system,
     WellLocationType,
     WellLocationFunction,
-    LabwareStackupDefinition,
     LabwareStackupAncestorDefinition,
     AddressableArea,
 )

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -108,8 +108,7 @@ from .inner_well_math_utils import (
     find_volume_user_defined_volumes,
 )
 from ._well_math import wells_covered_by_pipette_configuration, nozzles_per_well
-from ._labware_origin_math import get_parent_placement_origin_to_lw_origin
-
+from ._labware_origin_math import get_stackup_placement_origin_to_lw_origin
 
 _LOG = getLogger(__name__)
 SLOT_WIDTH = 128
@@ -383,13 +382,22 @@ class GeometryView:
         location = self._labware.get(labware_id).location
         definition = self._labware.get_definition(labware_id)
 
-        slot_front_left = self._get_labware_ancestor_position(labware_id)
-        stackup_origin_to_lw_origin = self._get_stackup_placement_origin_to_lw_origin(
-            location=location, definition=definition, is_topmost_labware=True
+        ancestor_pos = self._get_labware_ancestor_position(labware_id)
+        stackup_defs_locs = self._get_stackup_info_top_to_bottom(
+            labware_definition=definition, location=location
+        )
+        module_parent_to_child_offset = self._get_stackup_module_parent_to_child_offset(
+            location
+        )
+
+        stackup_origin_to_lw_origin = get_stackup_placement_origin_to_lw_origin(
+            module_parent_to_child_offset=module_parent_to_child_offset,
+            stackup_info_top_to_bottom=stackup_defs_locs,
+            deck_definition=self._addressable_areas.deck_definition,
         )
         module_cal_offset = self._get_calibrated_module_offset(location)
 
-        return slot_front_left + stackup_origin_to_lw_origin + module_cal_offset
+        return ancestor_pos + stackup_origin_to_lw_origin + module_cal_offset
 
     def _get_labware_ancestor_position(self, labware_id: str) -> Point:
         """Get the position of the labware's underlying ancestor."""
@@ -400,90 +408,63 @@ class GeometryView:
 
         return parent_pos
 
-    def _get_stackup_placement_origin_to_lw_origin(
-        self,
-        location: LabwareLocation,
-        definition: LabwareDefinition,
-        is_topmost_labware: bool,
-    ) -> Point:
-        """Get the offset vector from the lowest entity in a stackup to the labware."""
-        if isinstance(
-            location, (AddressableAreaLocation, DeckSlotLocation, ModuleLocation)
-        ):
-            return self._get_parent_placement_origin_to_lw_origin(
-                labware_location=location,
-                labware_definition=definition,
-                is_topmost_labware=is_topmost_labware,
-            )
-        elif isinstance(location, OnLabwareLocation):
-            parent_id = location.labwareId
-            parent_location = self._labware.get(parent_id).location
-            parent_definition = self._labware.get_definition(parent_id)
+    def _get_stackup_info_top_to_bottom(
+        self, labware_definition: LabwareDefinition, location: LabwareLocation
+    ) -> list[tuple[LabwareParentDefinition, LabwareLocation]]:
+        """Returns info about each deck item in the stackup.
 
-            parent_placement_origin_to_lw_origin = (
-                self._get_parent_placement_origin_to_lw_origin(
-                    labware_location=location,
-                    labware_definition=definition,
-                    is_topmost_labware=is_topmost_labware,
+        Traverse the stackup, collecting relevant data for each level.
+        The list is ordered from the top deck item to the bottom-most deck item.
+
+        The first entry will always be the definition and location of the given labware itself.
+        """
+        definitions_locations_top_to_bottom: list[
+            tuple[LabwareParentDefinition, LabwareLocation]
+        ] = []
+        current_location = location
+
+        definitions_locations_top_to_bottom.append(
+            (labware_definition, current_location)
+        )
+
+        while True:
+            if isinstance(current_location, OnLabwareLocation):
+                current_labware_id = current_location.labwareId
+                current_labware = self._labware.get(current_labware_id)
+                current_location = current_labware.location
+
+                parent_definition = self._get_parent_definition(current_location)
+                definitions_locations_top_to_bottom.append(
+                    (parent_definition, current_location)
                 )
-            )
+            else:
+                break
 
-            return (
-                parent_placement_origin_to_lw_origin
-                + self._get_stackup_placement_origin_to_lw_origin(
-                    location=parent_location,
-                    definition=parent_definition,
-                    is_topmost_labware=False,
+        return definitions_locations_top_to_bottom
+
+    def _get_stackup_module_parent_to_child_offset(
+        self, location: LabwareLocation
+    ) -> Union[Point, None]:
+        """Traverse the stackup to find the first parent-to-child module offset, if any."""
+        current_location = location
+
+        while True:
+            if isinstance(current_location, ModuleLocation):
+                module_parent_to_child_offset = (
+                    self._modules.get_nominal_offset_to_child_from_addressable_area(
+                        module_id=current_location.moduleId,
+                    )
                 )
-            )
-        else:
-            raise errors.LabwareNotOnDeckError(
-                "Cannot access labware since it is not on the deck. "
-                "Either it has been loaded off-deck or its been moved off-deck."
-            )
+                return module_parent_to_child_offset
 
-    def _get_parent_placement_origin_to_lw_origin(
-        self,
-        labware_location: LabwareLocation,
-        labware_definition: LabwareDefinition,
-        is_topmost_labware: bool,
-    ) -> Point:
-        parent_deck_item = self._get_parent_definition(labware_location)
+            if isinstance(current_location, OnLabwareLocation):
+                current_labware_id = current_location.labwareId
+                current_labware = self._labware.get(current_labware_id)
+                current_location = current_labware.location
+            else:
+                break
 
-        if isinstance(labware_location, ModuleLocation):
-            module_parent_to_child_offset = (
-                self._modules.get_nominal_offset_to_child_from_addressable_area(
-                    module_id=labware_location.moduleId,
-                )
-            )
-            return get_parent_placement_origin_to_lw_origin(
-                child_labware=labware_definition,
-                parent_deck_item=parent_deck_item,  # type: ignore[arg-type]
-                module_parent_to_child_offset=module_parent_to_child_offset,
-                deck_definition=self._addressable_areas.deck_definition,
-                is_topmost_labware=is_topmost_labware,
-                labware_location=labware_location,
-            )
-        elif isinstance(labware_location, OnLabwareLocation):
-            return get_parent_placement_origin_to_lw_origin(
-                child_labware=labware_definition,
-                parent_deck_item=parent_deck_item,  # type: ignore[arg-type]
-                module_parent_to_child_offset=None,
-                deck_definition=self._addressable_areas.deck_definition,
-                is_topmost_labware=is_topmost_labware,
-                labware_location=labware_location,
-            )
-        elif isinstance(labware_location, (DeckSlotLocation, AddressableAreaLocation)):
-            return get_parent_placement_origin_to_lw_origin(
-                child_labware=labware_definition,
-                parent_deck_item=parent_deck_item,  # type: ignore[arg-type]
-                module_parent_to_child_offset=None,
-                deck_definition=self._addressable_areas.deck_definition,
-                is_topmost_labware=is_topmost_labware,
-                labware_location=labware_location,
-            )
-        else:
-            raise ValueError(f"Invalid labware location: {labware_location}")
+        return None
 
     def _get_parent_definition(
         self, location: LabwareLocation
@@ -1041,12 +1022,22 @@ class GeometryView:
         It is calculated as the xy center of the slot with z as the point indicated by
         z-position of labware bottom + grip height from labware bottom.
         """
-        grip_z_from_lw_origin = self._labware.get_grip_z(labware_definition)
+        grip_z_from_lw_origin = self._labware.get_grip_z(
+            labware_definition
+        )  # Moved into the labware origin for gripper context
         aa_name = self._get_underlying_addressable_area_name(location)
-        parent_to_lw_offset = self._get_stackup_placement_origin_to_lw_origin(
-            location=location,
-            definition=labware_definition,
-            is_topmost_labware=True,  # We aren't concerned with entities above the gripped labware.
+
+        stackup_defs_locs = self._get_stackup_info_top_to_bottom(
+            labware_definition=labware_definition, location=location
+        )
+        module_parent_to_child_offset = self._get_stackup_module_parent_to_child_offset(
+            location
+        )
+
+        parent_to_lw_offset = get_stackup_placement_origin_to_lw_origin(
+            module_parent_to_child_offset=module_parent_to_child_offset,
+            stackup_info_top_to_bottom=stackup_defs_locs,
+            deck_definition=self._addressable_areas.deck_definition,
         )
         addressable_area = self._addressable_areas.get_addressable_area(aa_name)
         lw_origin_to_parent = self._get_lw_origin_to_parent(
@@ -1096,7 +1087,6 @@ class GeometryView:
             if self._modules.should_dodge_thermocycler(
                 from_slot=from_slot, to_slot=to_slot
             ):
-
                 middle_slot_fixture = (
                     self._addressable_areas.get_fixture_by_deck_slot_name(
                         DeckSlotName.SLOT_C2

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -92,6 +92,7 @@ from ..types import (
     WellLocationType,
     WellLocationFunction,
     LabwareStackupDefinition,
+    LabwareStackupAncestorDefinition,
     AddressableArea,
 )
 from ..types.liquid_level_detection import SimulatedProbeResult, LiquidTrackingType
@@ -383,16 +384,20 @@ class GeometryView:
         definition = self._labware.get_definition(labware_id)
 
         ancestor_pos = self._get_labware_ancestor_position(labware_id)
-        stackup_defs_locs = self._get_stackup_info_top_to_bottom(
+        stackup_lw_defs_locs = self._get_stackup_lw_info_top_to_bottom(
             labware_definition=definition, location=location
+        )
+        underlying_ancestor_def = self._get_stackup_underlying_ancestor_definition(
+            location
         )
         module_parent_to_child_offset = self._get_stackup_module_parent_to_child_offset(
             location
         )
 
         stackup_origin_to_lw_origin = get_stackup_placement_origin_to_lw_origin(
+            stackup_lw_info_top_to_bottom=stackup_lw_defs_locs,
+            underlying_ancestor_definition=underlying_ancestor_def,
             module_parent_to_child_offset=module_parent_to_child_offset,
-            stackup_info_top_to_bottom=stackup_defs_locs,
             deck_definition=self._addressable_areas.deck_definition,
         )
         module_cal_offset = self._get_calibrated_module_offset(location)
@@ -408,45 +413,39 @@ class GeometryView:
 
         return parent_pos
 
-    def _get_stackup_info_top_to_bottom(
+    def _get_stackup_lw_info_top_to_bottom(
         self, labware_definition: LabwareDefinition, location: LabwareLocation
-    ) -> list[tuple[LabwareStackupDefinition, LabwareLocation]]:
-        """Returns info about each deck item in the stackup.
+    ) -> list[tuple[LabwareDefinition, LabwareLocation]]:
+        """Returns info about each labware in the stackup.
 
-        Traverse the stackup, collecting relevant data for each level.
-        The list is ordered from the top deck item to the bottom-most deck item.
-
+        The list is ordered from the top labware to the bottom-most labware.
         The first entry will always be the definition and location of the given labware itself.
         """
         definitions_locations_top_to_bottom: list[
-            tuple[LabwareStackupDefinition, LabwareLocation]
+            tuple[LabwareDefinition, LabwareLocation]
         ] = []
         current_location = location
-
-        definitions_locations_top_to_bottom.append(
-            (labware_definition, current_location)
-        )
+        current_definition = labware_definition
 
         while True:
-            parent_definition = self._get_parent_definition(current_location)
             definitions_locations_top_to_bottom.append(
-                (parent_definition, current_location)
+                (current_definition, current_location)
             )
 
             if isinstance(current_location, OnLabwareLocation):
                 current_labware_id = current_location.labwareId
-                current_labware = self._labware.get(current_labware_id)
-                current_location = current_labware.location
+                current_location = self._labware.get(current_labware_id).location
+                current_definition = self._labware.get_definition(current_labware_id)
             else:
                 break
 
         return definitions_locations_top_to_bottom
 
     def _get_stackup_module_parent_to_child_offset(
-        self, location: LabwareLocation
+        self, top_most_lw_location: LabwareLocation
     ) -> Union[Point, None]:
         """Traverse the stackup to find the first parent-to-child module offset, if any."""
-        current_location = location
+        current_location = top_most_lw_location
 
         while True:
             if isinstance(current_location, ModuleLocation):
@@ -466,42 +465,32 @@ class GeometryView:
 
         return None
 
-    def _get_parent_definition(
-        self, location: LabwareLocation
-    ) -> LabwareStackupDefinition:
-        """Get the parent's definition given the labware's location."""
-        if isinstance(location, DeckSlotLocation):
-            addressable_area_name = location.slotName.id
-            return self._addressable_areas.get_slot_definition(addressable_area_name)
+    def _get_stackup_underlying_ancestor_definition(
+        self, top_most_lw_location: LabwareLocation
+    ) -> LabwareStackupAncestorDefinition:
+        """Traverse the stackup to find the first non-labware definition."""
+        current_location = top_most_lw_location
 
-        elif isinstance(location, AddressableAreaLocation):
-            addressable_area_name = location.addressableAreaName
-            return self._addressable_areas.get_addressable_area(addressable_area_name)
-
-        elif isinstance(location, ModuleLocation):
-            module_id = location.moduleId
-            return self._modules.get_definition(module_id)
-
-        elif isinstance(location, OnLabwareLocation):
-            below_labware_id = location.labwareId
-            return self._labware.get_definition(below_labware_id)
-
-        elif location == OFF_DECK_LOCATION or location == SYSTEM_LOCATION:
-            raise errors.LabwareNotOnDeckError(
-                f"Labware location {location} does not have a slot associated with it"
-                f" since it is no longer on the deck."
-            )
-
-        elif isinstance(location, InStackerHopperLocation):
-            raise errors.LabwareNotOnDeckError(
-                "Labware does not have a slot or module associated with it"
-                " since it is no longer on the deck."
-            )
-
-        else:
-            raise errors.InvalidLabwarePositionError(
-                f"Cannot get ancestor from location {location}"
-            )
+        while True:
+            if isinstance(current_location, OnLabwareLocation):
+                current_labware_id = current_location.labwareId
+                current_labware = self._labware.get(current_labware_id)
+                current_location = current_labware.location
+            else:
+                if isinstance(current_location, ModuleLocation):
+                    return self._modules.get_definition(current_location.moduleId)
+                elif isinstance(current_location, AddressableAreaLocation):
+                    return self._addressable_areas.get_addressable_area(
+                        current_location.addressableAreaName
+                    )
+                elif isinstance(current_location, DeckSlotLocation):
+                    return self._addressable_areas.get_slot_definition(
+                        current_location.slotName.id
+                    )
+                else:
+                    raise errors.InvalidLabwarePositionError(
+                        f"Cannot get ancestor slot of location {current_location}"
+                    )
 
     def _get_underlying_addressable_area_name(self, location: LabwareLocation) -> str:
         if isinstance(location, DeckSlotLocation):
@@ -1027,16 +1016,20 @@ class GeometryView:
         )  # Moved into the labware origin for gripper context
         aa_name = self._get_underlying_addressable_area_name(location)
 
-        stackup_defs_locs = self._get_stackup_info_top_to_bottom(
+        stackup_defs_locs = self._get_stackup_lw_info_top_to_bottom(
             labware_definition=labware_definition, location=location
         )
         module_parent_to_child_offset = self._get_stackup_module_parent_to_child_offset(
             location
         )
+        underlying_ancestor_def = self._get_stackup_underlying_ancestor_definition(
+            location
+        )
 
         parent_to_lw_offset = get_stackup_placement_origin_to_lw_origin(
             module_parent_to_child_offset=module_parent_to_child_offset,
-            stackup_info_top_to_bottom=stackup_defs_locs,
+            underlying_ancestor_definition=underlying_ancestor_def,
+            stackup_lw_info_top_to_bottom=stackup_defs_locs,
             deck_definition=self._addressable_areas.deck_definition,
         )
         addressable_area = self._addressable_areas.get_addressable_area(aa_name)

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -91,7 +91,7 @@ from ..types import (
     labware_location_is_system,
     WellLocationType,
     WellLocationFunction,
-    LabwareParentDefinition,
+    LabwareStackupDefinition,
     AddressableArea,
 )
 from ..types.liquid_level_detection import SimulatedProbeResult, LiquidTrackingType
@@ -410,7 +410,7 @@ class GeometryView:
 
     def _get_stackup_info_top_to_bottom(
         self, labware_definition: LabwareDefinition, location: LabwareLocation
-    ) -> list[tuple[LabwareParentDefinition, LabwareLocation]]:
+    ) -> list[tuple[LabwareStackupDefinition, LabwareLocation]]:
         """Returns info about each deck item in the stackup.
 
         Traverse the stackup, collecting relevant data for each level.
@@ -419,7 +419,7 @@ class GeometryView:
         The first entry will always be the definition and location of the given labware itself.
         """
         definitions_locations_top_to_bottom: list[
-            tuple[LabwareParentDefinition, LabwareLocation]
+            tuple[LabwareStackupDefinition, LabwareLocation]
         ] = []
         current_location = location
 
@@ -468,7 +468,7 @@ class GeometryView:
 
     def _get_parent_definition(
         self, location: LabwareLocation
-    ) -> LabwareParentDefinition:
+    ) -> LabwareStackupDefinition:
         """Get the parent's definition given the labware's location."""
         if isinstance(location, DeckSlotLocation):
             addressable_area_name = location.slotName.id

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -428,15 +428,15 @@ class GeometryView:
         )
 
         while True:
+            parent_definition = self._get_parent_definition(current_location)
+            definitions_locations_top_to_bottom.append(
+                (parent_definition, current_location)
+            )
+
             if isinstance(current_location, OnLabwareLocation):
                 current_labware_id = current_location.labwareId
                 current_labware = self._labware.get(current_labware_id)
                 current_location = current_labware.location
-
-                parent_definition = self._get_parent_definition(current_location)
-                definitions_locations_top_to_bottom.append(
-                    (parent_definition, current_location)
-                )
             else:
                 break
 

--- a/api/src/opentrons/protocol_engine/types/__init__.py
+++ b/api/src/opentrons/protocol_engine/types/__init__.py
@@ -99,7 +99,6 @@ from .labware import (
     LegacyLabwareOffsetCreate,
     LabwareOffsetCreateInternal,
     LoadedLabware,
-    LabwareStackupDefinition,
     LabwareStackupAncestorDefinition,
     LabwareWellId,
 )
@@ -254,7 +253,6 @@ __all__ = [
     "LabwareOffsetCreateInternal",
     "LoadedLabware",
     "LabwareOffsetVector",
-    "LabwareStackupDefinition",
     "LabwareStackupAncestorDefinition",
     "LabwareWellId",
     # Liquids

--- a/api/src/opentrons/protocol_engine/types/__init__.py
+++ b/api/src/opentrons/protocol_engine/types/__init__.py
@@ -100,6 +100,7 @@ from .labware import (
     LabwareOffsetCreateInternal,
     LoadedLabware,
     LabwareStackupDefinition,
+    LabwareStackupAncestorDefinition,
     LabwareWellId,
 )
 from .liquid import HexColor, EmptyLiquidId, LiquidId, Liquid, FluidKind, AspiratedFluid
@@ -254,6 +255,7 @@ __all__ = [
     "LoadedLabware",
     "LabwareOffsetVector",
     "LabwareStackupDefinition",
+    "LabwareStackupAncestorDefinition",
     "LabwareWellId",
     # Liquids
     "HexColor",

--- a/api/src/opentrons/protocol_engine/types/__init__.py
+++ b/api/src/opentrons/protocol_engine/types/__init__.py
@@ -99,7 +99,7 @@ from .labware import (
     LegacyLabwareOffsetCreate,
     LabwareOffsetCreateInternal,
     LoadedLabware,
-    LabwareParentDefinition,
+    LabwareStackupDefinition,
     LabwareWellId,
 )
 from .liquid import HexColor, EmptyLiquidId, LiquidId, Liquid, FluidKind, AspiratedFluid
@@ -253,7 +253,7 @@ __all__ = [
     "LabwareOffsetCreateInternal",
     "LoadedLabware",
     "LabwareOffsetVector",
-    "LabwareParentDefinition",
+    "LabwareStackupDefinition",
     "LabwareWellId",
     # Liquids
     "HexColor",

--- a/api/src/opentrons/protocol_engine/types/labware.py
+++ b/api/src/opentrons/protocol_engine/types/labware.py
@@ -121,6 +121,11 @@ LabwareStackupDefinition = Union[
     DeckLocationDefinition, ModuleDefinition, LabwareDefinition
 ]
 """Information pertaining to a deck item that is present in a labware stackup."""
+LabwareStackupAncestorDefinition = Union[
+    DeckLocationDefinition,
+    ModuleDefinition,
+]
+"""Information pertaining to the lowest deck item in a labware stackup."""
 
 
 @dataclass(frozen=True)

--- a/api/src/opentrons/protocol_engine/types/labware.py
+++ b/api/src/opentrons/protocol_engine/types/labware.py
@@ -117,10 +117,10 @@ class LoadedLabware(BaseModel):
     )
 
 
-LabwareParentDefinition = Union[
+LabwareStackupDefinition = Union[
     DeckLocationDefinition, ModuleDefinition, LabwareDefinition
 ]
-"""Information pertaining to a labware's parent (deck slot, module, or another labware) location."""
+"""Information pertaining to a deck item that is present in a labware stackup."""
 
 
 @dataclass(frozen=True)

--- a/api/src/opentrons/protocol_engine/types/labware.py
+++ b/api/src/opentrons/protocol_engine/types/labware.py
@@ -8,10 +8,6 @@ from datetime import datetime
 
 from pydantic import BaseModel, Field
 
-from opentrons_shared_data.labware.labware_definition import (
-    LabwareDefinition,
-)
-
 from .location import LabwareLocation
 from .labware_offset_location import (
     LegacyLabwareOffsetLocation,
@@ -117,10 +113,6 @@ class LoadedLabware(BaseModel):
     )
 
 
-LabwareStackupDefinition = Union[
-    DeckLocationDefinition, ModuleDefinition, LabwareDefinition
-]
-"""Information pertaining to a deck item that is present in a labware stackup."""
 LabwareStackupAncestorDefinition = Union[
     DeckLocationDefinition,
     ModuleDefinition,

--- a/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
@@ -454,7 +454,7 @@ _PARENT_ORIGIN_TO_LABWARE_ORIGIN = Point(x=10, y=20, z=30)
 def mock_labware_origin_math(monkeypatch: pytest.MonkeyPatch) -> None:
     """Mock labware origin math's main export."""
     monkeypatch.setattr(
-        "opentrons.protocol_engine.state.geometry.get_parent_placement_origin_to_lw_origin",
+        "opentrons.protocol_engine.state.geometry.get_stackup_placement_origin_to_lw_origin",
         lambda *args, **kwargs: _PARENT_ORIGIN_TO_LABWARE_ORIGIN,
     )
 
@@ -959,13 +959,11 @@ def test_get_obstacle_highest_z_with_lid(
     # The labware's highest z is the z dimension of the lid + labware's height
     labware_height = labware_view.get_dimensions(labware_id="labware-id").z
     monkeypatch.setattr(
-        "opentrons.protocol_engine.state.geometry.get_parent_placement_origin_to_lw_origin",
+        "opentrons.protocol_engine.state.geometry.get_stackup_placement_origin_to_lw_origin",
         lambda *args, **kwargs: Point(10, 20, labware_height),
     )
 
-    assert (
-        subject.get_all_obstacle_highest_z() == 100 + labware_height * 2
-    )  # The adapter + the labware are both labware_height
+    assert subject.get_all_obstacle_highest_z() == 100 + labware_height
 
 
 @pytest.mark.parametrize("use_mocks", [False])
@@ -1198,12 +1196,7 @@ def test_get_highest_z_in_slot_with_stacked_labware_on_slot(
         mock_addressable_area_view.get_addressable_area_position(DeckSlotName.SLOT_3.id)
     ).then_return(Point(11, 22, 33))
 
-    expected_highest_z = (
-        33
-        + 1000
-        + 3
-        + _PARENT_ORIGIN_TO_LABWARE_ORIGIN.z * 3  # The entire labware stackup.
-    )
+    expected_highest_z = 33 + 1000 + 3 + _PARENT_ORIGIN_TO_LABWARE_ORIGIN.z
 
     assert (
         subject.get_highest_z_in_slot(DeckSlotLocation(slotName=DeckSlotName.SLOT_3))
@@ -1291,12 +1284,7 @@ def test_get_highest_z_in_slot_with_labware_stack_on_module(
         )
     ).then_return(Point(11, 22, 33))
 
-    expected_highest_z = (
-        33
-        + 1000
-        + 3
-        + _PARENT_ORIGIN_TO_LABWARE_ORIGIN.z * 2  # Both the adapter and top labware
-    )
+    expected_highest_z = 33 + 1000 + 3 + _PARENT_ORIGIN_TO_LABWARE_ORIGIN.z
 
     assert (
         subject.get_highest_z_in_slot(DeckSlotLocation(slotName=DeckSlotName.SLOT_3))
@@ -1707,7 +1695,7 @@ def test_get_well_position_with_center_offset(
 ) -> None:
     """It should be able to get the position of a well center in a labware."""
     monkeypatch.setattr(
-        "opentrons.protocol_engine.state.geometry.get_parent_placement_origin_to_lw_origin",
+        "opentrons.protocol_engine.state.geometry.get_stackup_placement_origin_to_lw_origin",
         lambda *args, **kwargs: Point(0, 0, 0),
     )
     labware_data = LoadedLabware(
@@ -2291,7 +2279,7 @@ def test_get_relative_well_location(
 ) -> None:
     """It should get the relative location of a well given an absolute position."""
     monkeypatch.setattr(
-        "opentrons.protocol_engine.state.geometry.get_parent_placement_origin_to_lw_origin",
+        "opentrons.protocol_engine.state.geometry.get_stackup_placement_origin_to_lw_origin",
         lambda *args, **kwargs: Point(0, 0, 0),
     )
     labware_data = LoadedLabware(
@@ -2860,11 +2848,11 @@ def test_get_labware_grip_point_on_labware(
     )
 
     assert grip_point == Point(
-        5.0 + _PARENT_ORIGIN_TO_LABWARE_ORIGIN.x * 2 + expected_lw_origin_to_parent.x,
-        9.0 + _PARENT_ORIGIN_TO_LABWARE_ORIGIN.y * 2 + expected_lw_origin_to_parent.y,
+        5.0 + _PARENT_ORIGIN_TO_LABWARE_ORIGIN.x + expected_lw_origin_to_parent.x,
+        9.0 + _PARENT_ORIGIN_TO_LABWARE_ORIGIN.y + expected_lw_origin_to_parent.y,
         10.0
         + 100
-        + _PARENT_ORIGIN_TO_LABWARE_ORIGIN.z * 2
+        + _PARENT_ORIGIN_TO_LABWARE_ORIGIN.z
         + expected_lw_origin_to_parent.z,
     )
 
@@ -3040,15 +3028,9 @@ def test_get_labware_grip_point_for_labware_stack_on_module(
     )
 
     assert result_grip_point == Point(
-        x=492.0
-        + _PARENT_ORIGIN_TO_LABWARE_ORIGIN.x * 2  # The labware and module beneath it.
-        + expected_lw_origin_to_parent.x,
-        y=350.0
-        + _PARENT_ORIGIN_TO_LABWARE_ORIGIN.y * 2
-        + expected_lw_origin_to_parent.y,
-        z=838.0
-        + _PARENT_ORIGIN_TO_LABWARE_ORIGIN.z * 2
-        + expected_lw_origin_to_parent.z,
+        x=492.0 + _PARENT_ORIGIN_TO_LABWARE_ORIGIN.x + expected_lw_origin_to_parent.x,
+        y=350.0 + _PARENT_ORIGIN_TO_LABWARE_ORIGIN.y + expected_lw_origin_to_parent.y,
+        z=838.0 + _PARENT_ORIGIN_TO_LABWARE_ORIGIN.z + expected_lw_origin_to_parent.z,
     )
 
 

--- a/api/tests/opentrons/protocol_engine/state/test_labware_origin_math.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_origin_math.py
@@ -295,7 +295,6 @@ class ModuleOverlapSpec(NamedTuple):
     child_definition: LabwareDefinition2
     module_parent_to_child_offset: Point
     labware_location: ModuleLocation
-    parent_location: AddressableAreaLocation
     expected_total_offset: Point
 
 
@@ -305,7 +304,6 @@ class LabwareOverlapSpec(NamedTuple):
     child_definition: LabwareDefinition2
     parent_definition: LabwareDefinition2
     labware_location: OnLabwareLocation
-    parent_location: AddressableAreaLocation
     expected_total_offset: Point
 
 
@@ -315,7 +313,6 @@ class AddressableAreaSpec(NamedTuple):
     child_definition: LabwareDefinition2
     addressable_area: AddressableArea
     labware_location: AddressableAreaLocation
-    parent_location: AddressableAreaLocation
     expected_total_offset: Point
 
 
@@ -325,7 +322,6 @@ class LabwareV3Spec(NamedTuple):
     child_definition: LabwareDefinition3
     parent_definition: object
     labware_location: object
-    parent_location: AddressableAreaLocation
     expected_total_offset: Point
 
 
@@ -336,7 +332,6 @@ MODULE_OVERLAP_SPECS: List[ModuleOverlapSpec] = [
         child_definition=_LW_V2_WITH_MODULE_STACKING,
         module_parent_to_child_offset=Point(x=450, y=550, z=650),
         labware_location=ModuleLocation(moduleId="module-1"),
-        parent_location=AddressableAreaLocation(addressableAreaName="test_area"),
         expected_total_offset=Point(x=550, y=700, z=850),
     ),
     ModuleOverlapSpec(
@@ -345,7 +340,6 @@ MODULE_OVERLAP_SPECS: List[ModuleOverlapSpec] = [
         child_definition=_LW_V2_WITH_MODULE_STACKING,
         module_parent_to_child_offset=Point(x=450, y=550, z=650),
         labware_location=ModuleLocation(moduleId="module-1"),
-        parent_location=AddressableAreaLocation(addressableAreaName="test_area"),
         expected_total_offset=Point(x=400, y=500, z=600),
     ),
     ModuleOverlapSpec(
@@ -354,7 +348,6 @@ MODULE_OVERLAP_SPECS: List[ModuleOverlapSpec] = [
         child_definition=_LW_V2,
         module_parent_to_child_offset=Point(x=450, y=550, z=650),
         labware_location=ModuleLocation(moduleId="module-1"),
-        parent_location=AddressableAreaLocation(addressableAreaName="test_area"),
         expected_total_offset=Point(x=600, y=800, z=989.3),
     ),
     ModuleOverlapSpec(
@@ -363,7 +356,6 @@ MODULE_OVERLAP_SPECS: List[ModuleOverlapSpec] = [
         child_definition=_LW_V2,
         module_parent_to_child_offset=Point(x=450, y=550, z=650),
         labware_location=ModuleLocation(moduleId="module-1"),
-        parent_location=AddressableAreaLocation(addressableAreaName="test_area"),
         expected_total_offset=Point(x=600, y=800, z=1000),
     ),
     ModuleOverlapSpec(
@@ -372,7 +364,6 @@ MODULE_OVERLAP_SPECS: List[ModuleOverlapSpec] = [
         child_definition=_LW_V2_WITH_MODULE_STACKING,
         module_parent_to_child_offset=Point(x=450, y=550, z=650),
         labware_location=ModuleLocation(moduleId="module-1"),
-        parent_location=AddressableAreaLocation(addressableAreaName="test_area"),
         expected_total_offset=Point(x=100, y=200, z=300),
     ),
 ]
@@ -382,14 +373,12 @@ LABWARE_OVERLAP_SPECS: List[LabwareOverlapSpec] = [
         child_definition=_LW_V2_WITH_LABWARE_STACKING,
         parent_definition=_LW_V2_2,
         labware_location=OnLabwareLocation(labwareId="parent-labware-1"),
-        parent_location=AddressableAreaLocation(addressableAreaName="test_area"),
         expected_total_offset=Point(x=250, y=400, z=1000),
     ),
     LabwareOverlapSpec(
         child_definition=_LW_V2_WITH_LABWARE_STACKING,
         parent_definition=_LW_V2_3,
         labware_location=OnLabwareLocation(labwareId="parent-labware-2"),
-        parent_location=AddressableAreaLocation(addressableAreaName="test_area"),
         expected_total_offset=Point(x=450, y=650, z=950),
     ),
 ]
@@ -399,17 +388,15 @@ ADDRESSABLE_AREA_SPECS: List[AddressableAreaSpec] = [
         child_definition=_LW_V2,
         addressable_area=_ADDRESSABLE_AREA,
         labware_location=AddressableAreaLocation(addressableAreaName="test_area"),
-        parent_location=AddressableAreaLocation(addressableAreaName="test_area"),
         expected_total_offset=Point(x=150, y=250, z=350),
     ),
 ]
 
-LW_V3_SPECS: List[LabwareV3Spec] = [
+LW_V3_SPECS_ON_NON_LW: List[LabwareV3Spec] = [
     LabwareV3Spec(
         child_definition=_LW_V3,
         parent_definition=_ADDRESSABLE_AREA,
         labware_location=AddressableAreaLocation(addressableAreaName="test_area"),
-        parent_location=AddressableAreaLocation(addressableAreaName="test_area"),
         expected_total_offset=Point(x=10, y=1495, z=0),
     ),
     LabwareV3Spec(
@@ -418,29 +405,7 @@ LW_V3_SPECS: List[LabwareV3Spec] = [
         labware_location=AddressableAreaLocation(
             addressableAreaName="test_area_with_parent"
         ),
-        parent_location=AddressableAreaLocation(addressableAreaName="test_area"),
         expected_total_offset=Point(x=0, y=1600, z=-5),
-    ),
-    LabwareV3Spec(
-        child_definition=_LW_V3_WITH_SLOT_FP_AS_CHILD_FEATURE,
-        parent_definition=_LW_V3_WITH_SLOT_FP_AS_PARENT_FEATURE,
-        labware_location=OnLabwareLocation(labwareId="parent-labware-v3"),
-        parent_location=AddressableAreaLocation(addressableAreaName="test_area"),
-        expected_total_offset=Point(x=20.0, y=15, z=5),
-    ),
-    LabwareV3Spec(
-        child_definition=_LW_V3_WITH_SLOT_FP_AS_CHILD_FEATURE,
-        parent_definition=_LW_V3,
-        labware_location=OnLabwareLocation(labwareId="labware-v3-basic"),
-        parent_location=AddressableAreaLocation(addressableAreaName="test_area"),
-        expected_total_offset=Point(x=0, y=0, z=1000),
-    ),
-    LabwareV3Spec(
-        child_definition=_LW_V3_WITH_FLEX_TIP_RACK_LID_AS_CHILD,
-        parent_definition=_LW_V3_WITH_FLEX_TIP_RACK_LID_AS_PARENT,
-        labware_location=OnLabwareLocation(labwareId="flex-tip-rack-lid-parent"),
-        parent_location=AddressableAreaLocation(addressableAreaName="test_area"),
-        expected_total_offset=Point(x=0, y=0, z=40),
     ),
     LabwareV3Spec(
         child_definition=_LW_V3_WITH_FLEX_TIP_RACK_LID_AS_CHILD,
@@ -448,8 +413,28 @@ LW_V3_SPECS: List[LabwareV3Spec] = [
         labware_location=AddressableAreaLocation(
             addressableAreaName="test_area_with_flex_lid"
         ),
-        parent_location=AddressableAreaLocation(addressableAreaName="test_area"),
         expected_total_offset=Point(x=0, y=0, z=45),
+    ),
+]
+
+LW_V3_SPECS_ON_LW: List[LabwareV3Spec] = [
+    LabwareV3Spec(
+        child_definition=_LW_V3_WITH_SLOT_FP_AS_CHILD_FEATURE,
+        parent_definition=_LW_V3_WITH_SLOT_FP_AS_PARENT_FEATURE,
+        labware_location=OnLabwareLocation(labwareId="parent-labware-v3"),
+        expected_total_offset=Point(x=20.0, y=15, z=5),
+    ),
+    LabwareV3Spec(
+        child_definition=_LW_V3_WITH_SLOT_FP_AS_CHILD_FEATURE,
+        parent_definition=_LW_V3,
+        labware_location=OnLabwareLocation(labwareId="labware-v3-basic"),
+        expected_total_offset=Point(x=10, y=1495, z=1000),
+    ),
+    LabwareV3Spec(
+        child_definition=_LW_V3_WITH_FLEX_TIP_RACK_LID_AS_CHILD,
+        parent_definition=_LW_V3_WITH_FLEX_TIP_RACK_LID_AS_PARENT,
+        labware_location=OnLabwareLocation(labwareId="flex-tip-rack-lid-parent"),
+        expected_total_offset=Point(x=0, y=0, z=40),
     ),
 ]
 
@@ -464,15 +449,14 @@ def test_get_parent_placement_origin_to_lw_origin_with_module(
     child_definition: LabwareDefinition2,
     module_parent_to_child_offset: Point,
     labware_location: ModuleLocation,
-    parent_location: AddressableAreaLocation,
     expected_total_offset: Point,
 ) -> None:
     """It should calculate the correct offset from module parent to labware origin."""
     result = get_stackup_placement_origin_to_lw_origin(
-        stackup_info_top_to_bottom=[
+        stackup_lw_info_top_to_bottom=[
             (child_definition, labware_location),
-            (module_definition, parent_location),
         ],
+        underlying_ancestor_definition=module_definition,
         module_parent_to_child_offset=module_parent_to_child_offset,
         deck_definition=spec_deck_definition,
     )
@@ -488,15 +472,18 @@ def test_get_parent_placement_origin_to_lw_origin_with_labware(
     child_definition: LabwareDefinition2,
     parent_definition: LabwareDefinition2,
     labware_location: OnLabwareLocation,
-    parent_location: AddressableAreaLocation,
     expected_total_offset: Point,
 ) -> None:
-    """It should calculate the correct offset from labware parent to labware origin."""
+    """It should calculate the correct offset from labware parent to labware origin for v2_schema_labware."""
     result = get_stackup_placement_origin_to_lw_origin(
-        stackup_info_top_to_bottom=[
+        stackup_lw_info_top_to_bottom=[
             (child_definition, labware_location),
-            (parent_definition, parent_location),
+            (
+                parent_definition,
+                AddressableAreaLocation(addressableAreaName="test_area"),
+            ),
         ],
+        underlying_ancestor_definition=_ADDRESSABLE_AREA,
         module_parent_to_child_offset=None,
         deck_definition=load_deck(STANDARD_OT3_DECK, 5),
     )
@@ -512,15 +499,14 @@ def test_get_parent_placement_origin_to_lw_origin_with_addressable_area(
     child_definition: LabwareDefinition2,
     addressable_area: AddressableArea,
     labware_location: AddressableAreaLocation,
-    parent_location: AddressableAreaLocation,
     expected_total_offset: Point,
 ) -> None:
     """It should calculate the correct offset from addressable area to labware origin."""
     result = get_stackup_placement_origin_to_lw_origin(
-        stackup_info_top_to_bottom=[
+        stackup_lw_info_top_to_bottom=[
             (child_definition, labware_location),
-            (addressable_area, parent_location),
         ],
+        underlying_ancestor_definition=addressable_area,
         module_parent_to_child_offset=None,
         deck_definition=load_deck(STANDARD_OT3_DECK, 5),
     )
@@ -530,21 +516,47 @@ def test_get_parent_placement_origin_to_lw_origin_with_addressable_area(
 
 @pytest.mark.parametrize(
     argnames=LabwareV3Spec._fields,
-    argvalues=LW_V3_SPECS,
+    argvalues=LW_V3_SPECS_ON_NON_LW,
 )
-def test_get_parent_placement_origin_to_lw_origin_v3_definitions(
+def test_get_parent_placement_origin_to_lw_origin_v3_definitions_non_lw(
     child_definition: LabwareDefinition3,
     parent_definition: AddressableArea,
     labware_location: AddressableAreaLocation,
-    parent_location: AddressableAreaLocation,
     expected_total_offset: Point,
 ) -> None:
-    """It should handle LabwareDefinition3 correctly with various parent configurations."""
+    """It should handle LabwareDefinition3 correctly with various parent configurations (that are not labware)."""
     result = get_stackup_placement_origin_to_lw_origin(
-        stackup_info_top_to_bottom=[
+        stackup_lw_info_top_to_bottom=[
             (child_definition, labware_location),
-            (parent_definition, parent_location),
         ],
+        underlying_ancestor_definition=parent_definition,
+        module_parent_to_child_offset=None,
+        deck_definition=load_deck(STANDARD_OT3_DECK, 5),
+    )
+
+    assert result == expected_total_offset
+
+
+@pytest.mark.parametrize(
+    argnames=LabwareV3Spec._fields,
+    argvalues=LW_V3_SPECS_ON_LW,
+)
+def test_get_parent_placement_origin_to_lw_origin_v3_definitions(
+    child_definition: LabwareDefinition3,
+    parent_definition: LabwareDefinition3,
+    labware_location: OnLabwareLocation,
+    expected_total_offset: Point,
+) -> None:
+    """It should handle LabwareDefinition3 correctly with various labware configurations."""
+    result = get_stackup_placement_origin_to_lw_origin(
+        stackup_lw_info_top_to_bottom=[
+            (child_definition, labware_location),
+            (
+                parent_definition,
+                AddressableAreaLocation(addressableAreaName="test_area"),
+            ),
+        ],
+        underlying_ancestor_definition=_ADDRESSABLE_AREA,
         module_parent_to_child_offset=None,
         deck_definition=load_deck(STANDARD_OT3_DECK, 5),
     )

--- a/api/tests/opentrons/protocol_engine/state/test_labware_origin_math.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_origin_math.py
@@ -29,7 +29,7 @@ from opentrons_shared_data.labware.types import (
 
 from opentrons.types import Point
 from opentrons.protocol_engine.state._labware_origin_math import (
-    get_parent_placement_origin_to_lw_origin,
+    get_stackup_placement_origin_to_lw_origin,
 )
 from opentrons.protocol_engine.types import (
     ModuleModel,
@@ -294,8 +294,8 @@ class ModuleOverlapSpec(NamedTuple):
     module_definition: ModuleDefinition
     child_definition: LabwareDefinition2
     module_parent_to_child_offset: Point
-    is_topmost_labware: bool
     labware_location: ModuleLocation
+    parent_location: AddressableAreaLocation
     expected_total_offset: Point
 
 
@@ -304,8 +304,8 @@ class LabwareOverlapSpec(NamedTuple):
 
     child_definition: LabwareDefinition2
     parent_definition: LabwareDefinition2
-    is_topmost_labware: bool
     labware_location: OnLabwareLocation
+    parent_location: AddressableAreaLocation
     expected_total_offset: Point
 
 
@@ -314,8 +314,8 @@ class AddressableAreaSpec(NamedTuple):
 
     child_definition: LabwareDefinition2
     addressable_area: AddressableArea
-    is_topmost_labware: bool
     labware_location: AddressableAreaLocation
+    parent_location: AddressableAreaLocation
     expected_total_offset: Point
 
 
@@ -324,8 +324,8 @@ class LabwareV3Spec(NamedTuple):
 
     child_definition: LabwareDefinition3
     parent_definition: object
-    is_topmost_labware: bool
     labware_location: object
+    parent_location: AddressableAreaLocation
     expected_total_offset: Point
 
 
@@ -335,90 +335,45 @@ MODULE_OVERLAP_SPECS: List[ModuleOverlapSpec] = [
         module_definition=_MODULE_DEF_TEMP_V2,
         child_definition=_LW_V2_WITH_MODULE_STACKING,
         module_parent_to_child_offset=Point(x=450, y=550, z=650),
-        is_topmost_labware=True,
         labware_location=ModuleLocation(moduleId="module-1"),
+        parent_location=AddressableAreaLocation(addressableAreaName="test_area"),
         expected_total_offset=Point(x=550, y=700, z=850),
     ),
     ModuleOverlapSpec(
         spec_deck_definition=load_deck(STANDARD_OT2_DECK, 5),
-        module_definition=_MODULE_DEF_TEMP_V2,
-        child_definition=_LW_V2_WITH_MODULE_STACKING,
-        module_parent_to_child_offset=Point(x=450, y=550, z=650),
-        is_topmost_labware=False,
-        labware_location=ModuleLocation(moduleId="module-1"),
-        expected_total_offset=Point(x=400, y=450, z=500),
-    ),
-    ModuleOverlapSpec(
-        spec_deck_definition=load_deck(STANDARD_OT2_DECK, 5),
         module_definition=_MODULE_DEF_TC_V1,
         child_definition=_LW_V2_WITH_MODULE_STACKING,
         module_parent_to_child_offset=Point(x=450, y=550, z=650),
-        is_topmost_labware=True,
         labware_location=ModuleLocation(moduleId="module-1"),
+        parent_location=AddressableAreaLocation(addressableAreaName="test_area"),
         expected_total_offset=Point(x=400, y=500, z=600),
     ),
     ModuleOverlapSpec(
         spec_deck_definition=load_deck(STANDARD_OT2_DECK, 5),
-        module_definition=_MODULE_DEF_TC_V1,
-        child_definition=_LW_V2_WITH_MODULE_STACKING,
-        module_parent_to_child_offset=Point(x=450, y=550, z=650),
-        is_topmost_labware=False,
-        labware_location=ModuleLocation(moduleId="module-1"),
-        expected_total_offset=Point(x=250, y=250, z=250),
-    ),
-    ModuleOverlapSpec(
-        spec_deck_definition=load_deck(STANDARD_OT2_DECK, 5),
         module_definition=_MODULE_DEF_TC_V2,
         child_definition=_LW_V2,
         module_parent_to_child_offset=Point(x=450, y=550, z=650),
-        is_topmost_labware=True,
         labware_location=ModuleLocation(moduleId="module-1"),
+        parent_location=AddressableAreaLocation(addressableAreaName="test_area"),
         expected_total_offset=Point(x=600, y=800, z=989.3),
-    ),
-    ModuleOverlapSpec(
-        spec_deck_definition=load_deck(STANDARD_OT2_DECK, 5),
-        module_definition=_MODULE_DEF_TC_V2,
-        child_definition=_LW_V2,
-        module_parent_to_child_offset=Point(x=450, y=550, z=650),
-        is_topmost_labware=False,
-        labware_location=ModuleLocation(moduleId="module-1"),
-        expected_total_offset=Point(x=450, y=550, z=639.3),
     ),
     ModuleOverlapSpec(
         spec_deck_definition=load_deck(STANDARD_OT3_DECK, 5),
         module_definition=_MODULE_DEF_TC_V2,
         child_definition=_LW_V2,
         module_parent_to_child_offset=Point(x=450, y=550, z=650),
-        is_topmost_labware=True,
         labware_location=ModuleLocation(moduleId="module-1"),
+        parent_location=AddressableAreaLocation(addressableAreaName="test_area"),
         expected_total_offset=Point(x=600, y=800, z=1000),
     ),
     ModuleOverlapSpec(
         spec_deck_definition=load_deck(STANDARD_OT3_DECK, 5),
         module_definition=_MODULE_DEF_TC_V2,
-        child_definition=_LW_V2,
-        module_parent_to_child_offset=Point(x=450, y=550, z=650),
-        is_topmost_labware=False,
-        labware_location=ModuleLocation(moduleId="module-1"),
-        expected_total_offset=Point(x=450, y=550, z=650),
-    ),
-    ModuleOverlapSpec(
-        spec_deck_definition=load_deck(STANDARD_OT3_DECK, 5),
-        module_definition=_MODULE_DEF_TC_V2,
         child_definition=_LW_V2_WITH_MODULE_STACKING,
         module_parent_to_child_offset=Point(x=450, y=550, z=650),
-        is_topmost_labware=True,
         labware_location=ModuleLocation(moduleId="module-1"),
+        parent_location=AddressableAreaLocation(addressableAreaName="test_area"),
         expected_total_offset=Point(x=100, y=200, z=300),
-    ),
-    ModuleOverlapSpec(
-        spec_deck_definition=load_deck(STANDARD_OT3_DECK, 5),
-        module_definition=_MODULE_DEF_TC_V2,
-        child_definition=_LW_V2_WITH_MODULE_STACKING,
-        module_parent_to_child_offset=Point(x=450, y=550, z=650),
-        is_topmost_labware=False,
-        labware_location=ModuleLocation(moduleId="module-1"),
-        expected_total_offset=Point(x=-50, y=-50, z=-50),
     ),
 ]
 
@@ -426,30 +381,16 @@ LABWARE_OVERLAP_SPECS: List[LabwareOverlapSpec] = [
     LabwareOverlapSpec(
         child_definition=_LW_V2_WITH_LABWARE_STACKING,
         parent_definition=_LW_V2_2,
-        is_topmost_labware=True,
         labware_location=OnLabwareLocation(labwareId="parent-labware-1"),
+        parent_location=AddressableAreaLocation(addressableAreaName="test_area"),
         expected_total_offset=Point(x=250, y=400, z=1000),
     ),
     LabwareOverlapSpec(
         child_definition=_LW_V2_WITH_LABWARE_STACKING,
-        parent_definition=_LW_V2_2,
-        is_topmost_labware=False,
-        labware_location=OnLabwareLocation(labwareId="parent-labware-1"),
-        expected_total_offset=Point(x=50, y=100, z=600),
-    ),
-    LabwareOverlapSpec(
-        child_definition=_LW_V2_WITH_LABWARE_STACKING,
         parent_definition=_LW_V2_3,
-        is_topmost_labware=True,
         labware_location=OnLabwareLocation(labwareId="parent-labware-2"),
+        parent_location=AddressableAreaLocation(addressableAreaName="test_area"),
         expected_total_offset=Point(x=450, y=650, z=950),
-    ),
-    LabwareOverlapSpec(
-        child_definition=_LW_V2_WITH_LABWARE_STACKING,
-        parent_definition=_LW_V2_3,
-        is_topmost_labware=False,
-        labware_location=OnLabwareLocation(labwareId="parent-labware-2"),
-        expected_total_offset=Point(x=250, y=350, z=550),
     ),
 ]
 
@@ -457,16 +398,9 @@ ADDRESSABLE_AREA_SPECS: List[AddressableAreaSpec] = [
     AddressableAreaSpec(
         child_definition=_LW_V2,
         addressable_area=_ADDRESSABLE_AREA,
-        is_topmost_labware=True,
         labware_location=AddressableAreaLocation(addressableAreaName="test_area"),
+        parent_location=AddressableAreaLocation(addressableAreaName="test_area"),
         expected_total_offset=Point(x=150, y=250, z=350),
-    ),
-    AddressableAreaSpec(
-        child_definition=_LW_V2,
-        addressable_area=_ADDRESSABLE_AREA,
-        is_topmost_labware=False,
-        labware_location=AddressableAreaLocation(addressableAreaName="test_area"),
-        expected_total_offset=Point(x=0, y=0, z=0),
     ),
 ]
 
@@ -474,47 +408,47 @@ LW_V3_SPECS: List[LabwareV3Spec] = [
     LabwareV3Spec(
         child_definition=_LW_V3,
         parent_definition=_ADDRESSABLE_AREA,
-        is_topmost_labware=True,
         labware_location=AddressableAreaLocation(addressableAreaName="test_area"),
+        parent_location=AddressableAreaLocation(addressableAreaName="test_area"),
         expected_total_offset=Point(x=10, y=1495, z=0),
     ),
     LabwareV3Spec(
         child_definition=_LW_V3_WITH_SLOT_FP_AS_CHILD_FEATURE,
         parent_definition=_ADDRESSABLE_AREA_WITH_PARENT_FEATURES,
-        is_topmost_labware=True,
         labware_location=AddressableAreaLocation(
             addressableAreaName="test_area_with_parent"
         ),
+        parent_location=AddressableAreaLocation(addressableAreaName="test_area"),
         expected_total_offset=Point(x=0, y=1600, z=-5),
     ),
     LabwareV3Spec(
         child_definition=_LW_V3_WITH_SLOT_FP_AS_CHILD_FEATURE,
         parent_definition=_LW_V3_WITH_SLOT_FP_AS_PARENT_FEATURE,
-        is_topmost_labware=True,
         labware_location=OnLabwareLocation(labwareId="parent-labware-v3"),
+        parent_location=AddressableAreaLocation(addressableAreaName="test_area"),
         expected_total_offset=Point(x=20.0, y=15, z=5),
     ),
     LabwareV3Spec(
         child_definition=_LW_V3_WITH_SLOT_FP_AS_CHILD_FEATURE,
         parent_definition=_LW_V3,
-        is_topmost_labware=True,
         labware_location=OnLabwareLocation(labwareId="labware-v3-basic"),
+        parent_location=AddressableAreaLocation(addressableAreaName="test_area"),
         expected_total_offset=Point(x=0, y=0, z=1000),
     ),
     LabwareV3Spec(
         child_definition=_LW_V3_WITH_FLEX_TIP_RACK_LID_AS_CHILD,
         parent_definition=_LW_V3_WITH_FLEX_TIP_RACK_LID_AS_PARENT,
-        is_topmost_labware=True,
         labware_location=OnLabwareLocation(labwareId="flex-tip-rack-lid-parent"),
+        parent_location=AddressableAreaLocation(addressableAreaName="test_area"),
         expected_total_offset=Point(x=0, y=0, z=40),
     ),
     LabwareV3Spec(
         child_definition=_LW_V3_WITH_FLEX_TIP_RACK_LID_AS_CHILD,
         parent_definition=_ADDRESSABLE_AREA_WITH_FLEX_TIP_RACK_LID,
-        is_topmost_labware=True,
         labware_location=AddressableAreaLocation(
             addressableAreaName="test_area_with_flex_lid"
         ),
+        parent_location=AddressableAreaLocation(addressableAreaName="test_area"),
         expected_total_offset=Point(x=0, y=0, z=45),
     ),
 ]
@@ -529,18 +463,18 @@ def test_get_parent_placement_origin_to_lw_origin_with_module(
     module_definition: ModuleDefinition,
     child_definition: LabwareDefinition2,
     module_parent_to_child_offset: Point,
-    is_topmost_labware: bool,
     labware_location: ModuleLocation,
+    parent_location: AddressableAreaLocation,
     expected_total_offset: Point,
 ) -> None:
     """It should calculate the correct offset from module parent to labware origin."""
-    result = get_parent_placement_origin_to_lw_origin(
-        child_labware=child_definition,
-        parent_deck_item=module_definition,
+    result = get_stackup_placement_origin_to_lw_origin(
+        stackup_info_top_to_bottom=[
+            (child_definition, labware_location),
+            (module_definition, parent_location),
+        ],
         module_parent_to_child_offset=module_parent_to_child_offset,
         deck_definition=spec_deck_definition,
-        is_topmost_labware=is_topmost_labware,
-        labware_location=labware_location,
     )
 
     assert result == expected_total_offset
@@ -553,18 +487,18 @@ def test_get_parent_placement_origin_to_lw_origin_with_module(
 def test_get_parent_placement_origin_to_lw_origin_with_labware(
     child_definition: LabwareDefinition2,
     parent_definition: LabwareDefinition2,
-    is_topmost_labware: bool,
     labware_location: OnLabwareLocation,
+    parent_location: AddressableAreaLocation,
     expected_total_offset: Point,
 ) -> None:
     """It should calculate the correct offset from labware parent to labware origin."""
-    result = get_parent_placement_origin_to_lw_origin(
-        child_labware=child_definition,
-        parent_deck_item=parent_definition,
+    result = get_stackup_placement_origin_to_lw_origin(
+        stackup_info_top_to_bottom=[
+            (child_definition, labware_location),
+            (parent_definition, parent_location),
+        ],
         module_parent_to_child_offset=None,
         deck_definition=load_deck(STANDARD_OT3_DECK, 5),
-        is_topmost_labware=is_topmost_labware,
-        labware_location=labware_location,
     )
 
     assert result == expected_total_offset
@@ -577,18 +511,18 @@ def test_get_parent_placement_origin_to_lw_origin_with_labware(
 def test_get_parent_placement_origin_to_lw_origin_with_addressable_area(
     child_definition: LabwareDefinition2,
     addressable_area: AddressableArea,
-    is_topmost_labware: bool,
     labware_location: AddressableAreaLocation,
+    parent_location: AddressableAreaLocation,
     expected_total_offset: Point,
 ) -> None:
     """It should calculate the correct offset from addressable area to labware origin."""
-    result = get_parent_placement_origin_to_lw_origin(
-        child_labware=child_definition,
-        parent_deck_item=addressable_area,
+    result = get_stackup_placement_origin_to_lw_origin(
+        stackup_info_top_to_bottom=[
+            (child_definition, labware_location),
+            (addressable_area, parent_location),
+        ],
         module_parent_to_child_offset=None,
         deck_definition=load_deck(STANDARD_OT3_DECK, 5),
-        is_topmost_labware=is_topmost_labware,
-        labware_location=labware_location,
     )
 
     assert result == expected_total_offset
@@ -600,34 +534,19 @@ def test_get_parent_placement_origin_to_lw_origin_with_addressable_area(
 )
 def test_get_parent_placement_origin_to_lw_origin_v3_definitions(
     child_definition: LabwareDefinition3,
-    parent_definition: object,
-    is_topmost_labware: bool,
-    labware_location: object,
+    parent_definition: AddressableArea,
+    labware_location: AddressableAreaLocation,
+    parent_location: AddressableAreaLocation,
     expected_total_offset: Point,
 ) -> None:
     """It should handle LabwareDefinition3 correctly with various parent configurations."""
-    result = get_parent_placement_origin_to_lw_origin(  # type: ignore[call-overload]
-        child_labware=child_definition,
-        parent_deck_item=parent_definition,
+    result = get_stackup_placement_origin_to_lw_origin(
+        stackup_info_top_to_bottom=[
+            (child_definition, labware_location),
+            (parent_definition, parent_location),
+        ],
         module_parent_to_child_offset=None,
         deck_definition=load_deck(STANDARD_OT3_DECK, 5),
-        is_topmost_labware=is_topmost_labware,
-        labware_location=labware_location,
     )
 
     assert result == expected_total_offset
-
-
-def test_get_parent_placement_origin_to_lw_origin_v3_with_v2_parent_raises_error() -> (
-    None
-):
-    """It should raise NotImplementedError when v3 labware is placed on v2 parent."""
-    with pytest.raises(NotImplementedError):
-        get_parent_placement_origin_to_lw_origin(
-            child_labware=_LW_V3,
-            parent_deck_item=_LW_V2_2,
-            module_parent_to_child_offset=None,
-            deck_definition=load_deck(STANDARD_OT3_DECK, 5),
-            is_topmost_labware=True,
-            labware_location=OnLabwareLocation(labwareId="v2-parent"),
-        )


### PR DESCRIPTION
Works toward [EXEC-1690](https://opentrons.atlassian.net/browse/EXEC-1690)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Whenever we calculate labware origin, what we really care about is the "origin from the lowest deck item to the labware origin". This calculation typically involves offset calculations over multiple deck items and is not sufficiently captured in the notion of "the direct parent of the labware to the labware itself".

All this to say, we can and should encapsulate these notions within labware origin math instead of leaking them elsewhere.

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- No functional changes, sufficiently covered by testing.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests
Nothing in super particular. The only "new" functionality to support the refactor is `_get_stackup_info_top_to_bottom` and `_get_stackup_module_parent_to_child_offset`.
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
very low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[EXEC-1690]: https://opentrons.atlassian.net/browse/EXEC-1690?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ