### PR TITLE
fix(docs): exclude NEST 12-well from autoclave-safe labware

### DIFF
--- a/docs/flex/docs/maintenance/cleaning.md
+++ b/docs/flex/docs/maintenance/cleaning.md
@@ -198,7 +198,7 @@ The following table lists labware sold by Opentrons that we have verified as aut
   <tbody>
     <tr>
       <td><strong>Reservoirs</strong></td>
-      <td>All NEST reservoirs</td>
+      <td>NEST 1-well reservoirs</td>
     </tr>
     <tr>
       <td><strong>Sample vials</strong></td>


### PR DESCRIPTION
# Overview

> The NEST 12-well reservoir is not autoclavable. The column dividers become deformed and can cause problems for automation.

## Test Plan and Hands on Testing

[Sandbox](https://sandbox.docs.opentrons.com/docs-nest-autoclavable/flex/maintenance/cleaning/#autoclave-safe-labware) build

## Changelog

1-liner

## Review requests

:shipit: ❓ 

## Risk assessment

none