### PR TITLE
feat(api): Add task state

### DIFF
--- a/api/src/opentrons/protocol_engine/errors/exceptions.py
+++ b/api/src/opentrons/protocol_engine/errors/exceptions.py
@@ -414,7 +414,11 @@ class WellDoesNotExistError(ProtocolEngineError):
 
 
 class NoTaskFoundError(ProtocolEngineError):
-    """Raised when referencing a task that does not exist."""
+    """Raised when referencing a task that does not exist.
+
+    This error could be raised if a protocol references a task before it
+    has been created.
+    """
 
     def __init__(
         self,

--- a/api/src/opentrons/protocol_engine/errors/exceptions.py
+++ b/api/src/opentrons/protocol_engine/errors/exceptions.py
@@ -413,6 +413,19 @@ class WellDoesNotExistError(ProtocolEngineError):
         super().__init__(ErrorCodes.GENERAL_ERROR, message, details, wrapping)
 
 
+class NoTaskFoundError(ProtocolEngineError):
+    """Raised when referencing a task that does not exist."""
+
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        details: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build a NoTaskFoundError."""
+        super().__init__(ErrorCodes.GENERAL_ERROR, message, details, wrapping)
+
+
 class PipetteNotLoadedError(ProtocolEngineError):
     """Raised when referencing a pipette that has not been loaded."""
 

--- a/api/src/opentrons/protocol_engine/state/state.py
+++ b/api/src/opentrons/protocol_engine/state/state.py
@@ -34,6 +34,7 @@ from .files import FileView, FileState, FileStore
 from .config import Config
 from .state_summary import StateSummary
 from ..types import DeckConfigurationType
+from .tasks import TaskState, TaskView, TaskStore
 
 
 _ParamsT = ParamSpec("_ParamsT")
@@ -54,6 +55,7 @@ class State:
     tips: TipState
     wells: WellState
     files: FileState
+    tasks: TaskState
 
 
 class StateView(HasState[State]):
@@ -73,6 +75,7 @@ class StateView(HasState[State]):
     _motion: MotionView
     _files: FileView
     _config: Config
+    _tasks: TaskView
 
     @property
     def commands(self) -> CommandView:
@@ -139,6 +142,11 @@ class StateView(HasState[State]):
         """Get ProtocolEngine configuration."""
         return self._config
 
+    @property
+    def tasks(self) -> TaskView:
+        """Get state view selectors for task state."""
+        return self._tasks
+
     def get_summary(self) -> StateSummary:
         """Get protocol run data."""
         error = self._commands.get_error()
@@ -162,6 +170,7 @@ class StateView(HasState[State]):
                 )
                 for liquid_class_id, liquid_class_record in self._liquid_classes.get_all().items()
             ],
+            tasks=self._tasks.get_summary(),
         )
 
 
@@ -231,6 +240,7 @@ class StateStore(StateView, ActionHandler):
         self._tip_store = TipStore()
         self._well_store = WellStore()
         self._file_store = FileStore()
+        self._task_store = TaskStore()
 
         self._substores: List[HandlesActions] = [
             self._command_store,
@@ -243,6 +253,7 @@ class StateStore(StateView, ActionHandler):
             self._tip_store,
             self._well_store,
             self._file_store,
+            self._task_store,
         ]
         self._config = config
         self._change_notifier = change_notifier or ChangeNotifier()
@@ -366,6 +377,7 @@ class StateStore(StateView, ActionHandler):
             tips=self._tip_store.state,
             wells=self._well_store.state,
             files=self._file_store.state,
+            tasks=self._task_store.state,
         )
 
     def _initialize_state(self) -> None:
@@ -384,6 +396,7 @@ class StateStore(StateView, ActionHandler):
         self._tips = TipView(state.tips)
         self._wells = WellView(state.wells)
         self._files = FileView(state.files)
+        self._tasks = TaskView(state.tasks)
 
         # Derived states
         self._geometry = GeometryView(
@@ -416,6 +429,7 @@ class StateStore(StateView, ActionHandler):
         self._liquid_classes._state = next_state.liquid_classes
         self._tips._state = next_state.tips
         self._wells._state = next_state.wells
+        self._tasks._state = next_state.tasks
         self._change_notifier.notify()
         if self._notify_robot_server is not None:
             self._notify_robot_server()

--- a/api/src/opentrons/protocol_engine/state/state_summary.py
+++ b/api/src/opentrons/protocol_engine/state/state_summary.py
@@ -1,6 +1,6 @@
 """Public protocol run data models."""
 from pydantic import BaseModel, Field
-from typing import List, Optional, Dict
+from typing import List, Optional
 from datetime import datetime
 
 from ..errors import ErrorOccurrence
@@ -35,4 +35,4 @@ class StateSummary(BaseModel):
     wells: List[WellInfoSummary] = Field(default_factory=list)
     files: List[str] = Field(default_factory=list)
     liquidClasses: List[LiquidClassRecordWithId] = Field(default_factory=list)
-    tasks: Dict[str, TaskSummary] = Field(default_factory=dict)
+    tasks: List[TaskSummary] = Field(default_factory=list)

--- a/api/src/opentrons/protocol_engine/state/state_summary.py
+++ b/api/src/opentrons/protocol_engine/state/state_summary.py
@@ -1,6 +1,6 @@
 """Public protocol run data models."""
 from pydantic import BaseModel, Field
-from typing import List, Optional
+from typing import List, Optional, Dict
 from datetime import datetime
 
 from ..errors import ErrorOccurrence
@@ -13,6 +13,7 @@ from ..types import (
     Liquid,
     LiquidClassRecordWithId,
     WellInfoSummary,
+    TaskSummary,
 )
 
 
@@ -34,3 +35,4 @@ class StateSummary(BaseModel):
     wells: List[WellInfoSummary] = Field(default_factory=list)
     files: List[str] = Field(default_factory=list)
     liquidClasses: List[LiquidClassRecordWithId] = Field(default_factory=list)
+    tasks: Dict[str, TaskSummary] = Field(default_factory=dict)

--- a/api/src/opentrons/protocol_engine/state/tasks.py
+++ b/api/src/opentrons/protocol_engine/state/tasks.py
@@ -1,0 +1,62 @@
+"""Task state tracking."""
+from dataclasses import dataclass
+from ..types import Task, TaskSummary
+from ._abstract_store import HasState, HandlesActions
+from ..actions import Action, get_state_updates
+from opentrons.protocol_engine.state import update_types
+from opentrons.protocol_engine.errors.exceptions import NoTaskFoundError
+
+
+@dataclass
+class TaskState:
+    """Task state tracking."""
+
+    tasks_by_id: dict[str, Task]
+
+
+class TaskStore(HasState[TaskState], HandlesActions):
+    """Stores tasks."""
+
+    _state: TaskState
+
+    def __init__(self) -> None:
+        """Initialize a TaskStore."""
+        self._state = TaskState(tasks_by_id={})
+
+    def handle_action(self, action: Action) -> None:
+        """Handle an action."""
+        for state_update in get_state_updates(action):
+            self._handle_state_update(state_update)
+
+    def _handle_state_update(self, state_update: update_types.StateUpdate) -> None:
+        """Handle a state update."""
+        return
+
+
+class TaskView:
+    """Read-only task state view."""
+
+    _state: TaskState
+
+    def __init__(self, state: TaskState) -> None:
+        """Initialize a TaskView."""
+        self._state = state
+
+    def get(self, id: str) -> Task:
+        """Get a task by ID."""
+        try:
+            return self._state.tasks_by_id[id]
+        except KeyError as e:
+            raise NoTaskFoundError(f"No task with ID {id}") from e
+
+    def get_summary(self) -> dict[str, TaskSummary]:
+        """Get a summary of all tasks."""
+        return {
+            id: TaskSummary(
+                id=id,
+                createdAt=task.createdAt,
+                finishedAt=task.finishedAt,
+                error=task.error,
+            )
+            for id, task in self._state.tasks_by_id.items()
+        }

--- a/api/src/opentrons/protocol_engine/state/tasks.py
+++ b/api/src/opentrons/protocol_engine/state/tasks.py
@@ -49,14 +49,14 @@ class TaskView:
         except KeyError as e:
             raise NoTaskFoundError(f"No task with ID {id}") from e
 
-    def get_summary(self) -> dict[str, TaskSummary]:
+    def get_summary(self) -> list[TaskSummary]:
         """Get a summary of all tasks."""
-        return {
-            id: TaskSummary(
+        return [
+            TaskSummary(
                 id=id,
                 createdAt=task.createdAt,
                 finishedAt=task.finishedAt,
                 error=task.error,
             )
             for id, task in self._state.tasks_by_id.items()
-        }
+        ]

--- a/api/src/opentrons/protocol_engine/types/__init__.py
+++ b/api/src/opentrons/protocol_engine/types/__init__.py
@@ -146,6 +146,7 @@ from .labware_movement import LabwareMovementStrategy, LabwareMovementOffsetData
 from .tip import TipGeometry
 from .hardware_passthrough import MovementAxis, MotorAxis
 from .util import Vec3f, Dimensions
+from .tasks import Task, TaskSummary
 
 __all__ = [
     # Runtime parameters
@@ -305,4 +306,7 @@ __all__ = [
     "Dimensions",
     # Convenience re-export
     "LabwareUri",
+    # Tasks
+    "Task",
+    "TaskSummary",
 ]

--- a/api/src/opentrons/protocol_engine/types/tasks.py
+++ b/api/src/opentrons/protocol_engine/types/tasks.py
@@ -18,7 +18,7 @@ class Task:
 
 @dataclass
 class TaskSummary:
-    """A summary of a task."""
+    """Task info for use in summary lists."""
 
     id: str
     createdAt: datetime

--- a/api/src/opentrons/protocol_engine/types/tasks.py
+++ b/api/src/opentrons/protocol_engine/types/tasks.py
@@ -1,0 +1,26 @@
+"""Types for Tasks."""
+from datetime import datetime
+from opentrons.protocol_engine.errors import ErrorOccurrence
+from dataclasses import dataclass
+import asyncio
+
+
+@dataclass
+class Task:
+    """A task representation."""
+
+    id: str
+    createdAt: datetime
+    asyncioTask: asyncio.Task[None]
+    finishedAt: datetime | None
+    error: ErrorOccurrence | None
+
+
+@dataclass
+class TaskSummary:
+    """A summary of a task."""
+
+    id: str
+    createdAt: datetime
+    finishedAt: datetime | None
+    error: ErrorOccurrence | None

--- a/api/tests/opentrons/protocol_engine/state/test_task_state.py
+++ b/api/tests/opentrons/protocol_engine/state/test_task_state.py
@@ -1,0 +1,75 @@
+"""Tests for TaskState+TaskStore+TaskView trifecta."""
+import pytest
+from opentrons.protocol_engine.state.tasks import TaskStore, TaskView
+from opentrons.protocol_engine.types import Task
+from datetime import datetime
+import asyncio
+
+
+@pytest.fixture
+def subject() -> TaskStore:
+    """Create a TaskStore fixture."""
+    return TaskStore()
+
+
+async def test_get(subject: TaskStore) -> None:
+    """It should get a task by ID."""
+    task_id = "task-123"
+    timestamp = datetime.now()
+    asyncio_task = asyncio.create_task(asyncio.sleep(0))
+    subject._state.tasks_by_id[task_id] = Task(
+        id=task_id,
+        createdAt=timestamp,
+        finishedAt=None,
+        asyncioTask=asyncio_task,
+        error=None,
+    )
+
+    view = TaskView(subject._state)
+    result = view.get(task_id)
+
+    assert result.id == task_id
+    assert result.createdAt == timestamp
+    assert result.asyncioTask is asyncio_task
+    assert result.finishedAt is None
+    assert result.error is None
+    await asyncio_task
+
+
+async def test_get_summary(subject: TaskStore) -> None:
+    """It should get a summary of all tasks."""
+    task_id_1 = "task-123"
+    task_id_2 = "task-456"
+    timestamp_1 = datetime.now()
+    timestamp_2 = datetime.now()
+    asyncio_task_1 = asyncio.create_task(asyncio.sleep(0))
+    asyncio_task_2 = asyncio.create_task(asyncio.sleep(0))
+    subject._state.tasks_by_id[task_id_1] = Task(
+        id=task_id_1,
+        createdAt=timestamp_1,
+        finishedAt=None,
+        asyncioTask=asyncio_task_1,
+        error=None,
+    )
+    subject._state.tasks_by_id[task_id_2] = Task(
+        id=task_id_2,
+        createdAt=timestamp_2,
+        finishedAt=None,
+        asyncioTask=asyncio_task_2,
+        error=None,
+    )
+
+    view = TaskView(subject._state)
+    summary = view.get_summary()
+
+    assert len(summary) == 2
+    assert summary[task_id_1].id == task_id_1
+    assert summary[task_id_1].createdAt == timestamp_1
+    assert summary[task_id_1].finishedAt is None
+    assert summary[task_id_1].error is None
+
+    assert summary[task_id_2].id == task_id_2
+    assert summary[task_id_2].createdAt == timestamp_2
+    assert summary[task_id_2].finishedAt is None
+    assert summary[task_id_2].error is None
+    await asyncio.gather(asyncio_task_1, asyncio_task_2)

--- a/api/tests/opentrons/protocol_engine/state/test_task_state.py
+++ b/api/tests/opentrons/protocol_engine/state/test_task_state.py
@@ -63,13 +63,13 @@ async def test_get_summary(subject: TaskStore) -> None:
     summary = view.get_summary()
 
     assert len(summary) == 2
-    assert summary[task_id_1].id == task_id_1
-    assert summary[task_id_1].createdAt == timestamp_1
-    assert summary[task_id_1].finishedAt is None
-    assert summary[task_id_1].error is None
+    assert summary[0].id == task_id_1
+    assert summary[0].createdAt == timestamp_1
+    assert summary[0].finishedAt is None
+    assert summary[0].error is None
 
-    assert summary[task_id_2].id == task_id_2
-    assert summary[task_id_2].createdAt == timestamp_2
-    assert summary[task_id_2].finishedAt is None
-    assert summary[task_id_2].error is None
+    assert summary[1].id == task_id_2
+    assert summary[1].createdAt == timestamp_2
+    assert summary[1].finishedAt is None
+    assert summary[1].error is None
     await asyncio.gather(asyncio_task_1, asyncio_task_2)


### PR DESCRIPTION
Create scaffolding for concurrent tasks in the engine state to enable module concurrent actions. No new actions are added but this creates a skeleton to allow for future implementation.

closes EXEC-1667

