### PR TITLE
feat(protocol-designer): optimize lid support in select labware modal

### DIFF
--- a/components/src/molecules/CustomizeExpandButton/__tests__/CustomizeExpandButton.test.tsx
+++ b/components/src/molecules/CustomizeExpandButton/__tests__/CustomizeExpandButton.test.tsx
@@ -31,7 +31,7 @@ describe('CustomizeExpandButton', () => {
       buttonValue: 'mockValue',
       onChange: vi.fn(),
       allowInputField: false,
-      loadName: 'mockLoadName',
+      isNestedDefALid: false,
     }
   })
 

--- a/components/src/molecules/CustomizeExpandButton/index.tsx
+++ b/components/src/molecules/CustomizeExpandButton/index.tsx
@@ -33,7 +33,7 @@ export interface StackingProps {
 interface CustomizeExpandButtonProps extends StyleProps {
   enableStackingFF: boolean
   allowInputField: boolean
-  loadName: string
+  isNestedDefALid: boolean
   buttonText: string
   buttonValue: string | number
   onChange: ChangeEventHandler<HTMLInputElement>
@@ -56,13 +56,12 @@ export function CustomizeExpandButtonComponent(
     id = buttonText,
     stackingProps,
     allowInputField,
-    loadName,
+    isNestedDefALid,
     enableStackingFF,
   } = props
   const isLid =
     stackingProps != null &&
     stackingProps.definition.allowedRoles?.includes('lid')
-  const tcLidDef = loadName === 'opentrons_tough_pcr_auto_sealing_lid'
 
   return (
     <Flex
@@ -100,7 +99,7 @@ export function CustomizeExpandButtonComponent(
               padding={`${SPACING.spacing16} ${SPACING.spacing20}`}
               borderRadius={BORDERS.borderRadius4}
             >
-              {isLid && !tcLidDef ? (
+              {isLid && !isNestedDefALid ? (
                 <CheckboxField
                   onChange={e => {
                     e.stopPropagation()

--- a/protocol-designer/src/components/organisms/SelectLabwareModal/SelectCustomLabware.tsx
+++ b/protocol-designer/src/components/organisms/SelectLabwareModal/SelectCustomLabware.tsx
@@ -99,7 +99,9 @@ export function SelectCustomLabware(
             return (
               <CustomizeExpandButton
                 enableStackingFF={enableStacking}
-                loadName={customLabwareDefs[uri].parameters.loadName}
+                isNestedDefALid={
+                  customLabwareDefs[uri].allowedRoles?.includes('lid') ?? false
+                }
                 allowInputField={onFlexStacker}
                 key={`${index}_${uri}`}
                 id={`${index}_${uri}`}

--- a/protocol-designer/src/components/organisms/SelectLabwareModal/SelectCustomLabware.tsx
+++ b/protocol-designer/src/components/organisms/SelectLabwareModal/SelectCustomLabware.tsx
@@ -13,6 +13,7 @@ import { getCustomLabwareDefsByURI } from '../../../labware-defs/selectors'
 import { selectLid, selectTopLabware } from '../../../labware-ingred/actions'
 import { selectors } from '../../../labware-ingred/selectors'
 import { CUSTOM_CATEGORY } from '../../../pages/Designer/DeckSetup/constants'
+import { getIsNestedDefinitionALid } from './utils'
 
 import type { ChangeEvent } from 'react'
 import type { StackingProps } from '@opentrons/components'
@@ -99,9 +100,9 @@ export function SelectCustomLabware(
             return (
               <CustomizeExpandButton
                 enableStackingFF={enableStacking}
-                isNestedDefALid={
-                  customLabwareDefs[uri].allowedRoles?.includes('lid') ?? false
-                }
+                isNestedDefALid={getIsNestedDefinitionALid(
+                  customLabwareDefs[uri]
+                )}
                 allowInputField={onFlexStacker}
                 key={`${index}_${uri}`}
                 id={`${index}_${uri}`}

--- a/protocol-designer/src/components/organisms/SelectLabwareModal/SelectLabware.tsx
+++ b/protocol-designer/src/components/organisms/SelectLabwareModal/SelectLabware.tsx
@@ -181,7 +181,9 @@ export function SelectLabware(props: SelectLabwareProps): JSX.Element | null {
                       <Fragment key={`${category}_${loadName}`}>
                         <CustomizeExpandButton
                           enableStackingFF={enableStacking}
-                          loadName={loadName}
+                          isNestedDefALid={
+                            def.allowedRoles?.includes('lid') ?? false
+                          }
                           allowInputField={
                             onFlexStacker || lidLoadNames.includes(loadName)
                           }

--- a/protocol-designer/src/components/organisms/SelectLabwareModal/SelectLabware.tsx
+++ b/protocol-designer/src/components/organisms/SelectLabwareModal/SelectLabware.tsx
@@ -24,6 +24,7 @@ import { getStackerDefinitions } from '../../../pages/Designer/DeckSetup/utils'
 import { TIPRACK_LID_LOADNAME } from '../../../pages/Designer/utils'
 import { SelectLabwareOnAdapter } from './SelectLabwareOnAdapter'
 import { SelectLidOnLabware } from './SelectLidOnLabware'
+import { getIsNestedDefinitionALid } from './utils'
 
 import type { ChangeEvent } from 'react'
 import type { StackingProps } from '@opentrons/components'
@@ -181,9 +182,7 @@ export function SelectLabware(props: SelectLabwareProps): JSX.Element | null {
                       <Fragment key={`${category}_${loadName}`}>
                         <CustomizeExpandButton
                           enableStackingFF={enableStacking}
-                          isNestedDefALid={
-                            def.allowedRoles?.includes('lid') ?? false
-                          }
+                          isNestedDefALid={getIsNestedDefinitionALid(def)}
                           allowInputField={
                             onFlexStacker || lidLoadNames.includes(loadName)
                           }

--- a/protocol-designer/src/components/organisms/SelectLabwareModal/SelectLabwareOnAdapter.tsx
+++ b/protocol-designer/src/components/organisms/SelectLabwareModal/SelectLabwareOnAdapter.tsx
@@ -107,7 +107,7 @@ export function SelectLabwareOnAdapter(
               return (
                 <CustomizeExpandButton
                   enableStackingFF={enableStacking}
-                  loadName={loadName}
+                  isNestedDefALid={false}
                   allowInputField={false}
                   key={`${index}_${category}_${loadName}_${tiprackDefUri}`}
                   id={`${index}_${category}_${loadName}_${tiprackDefUri}`}
@@ -186,7 +186,9 @@ export function SelectLabwareOnAdapter(
                 <Fragment key={`${loadName}_${category}`}>
                   <CustomizeExpandButton
                     enableStackingFF={enableStacking}
-                    loadName={nestedDef.parameters.loadName}
+                    isNestedDefALid={
+                      nestedDef.allowedRoles?.includes('lid') ?? false
+                    }
                     allowInputField={lidLoadNames.includes(
                       nestedDef.parameters.loadName
                     )}

--- a/protocol-designer/src/components/organisms/SelectLabwareModal/SelectLabwareOnAdapter.tsx
+++ b/protocol-designer/src/components/organisms/SelectLabwareModal/SelectLabwareOnAdapter.tsx
@@ -26,6 +26,7 @@ import { getPipetteEntities } from '../../../step-forms/selectors'
 import { getHas96Channel } from '../../../utils'
 import { ADAPTER_96_CHANNEL } from '../../../utils/labwareModuleCompatibility'
 import { SelectLidOnLabware } from './SelectLidOnLabware'
+import { getIsNestedDefinitionALid } from './utils'
 
 import type { ChangeEvent } from 'react'
 import type { StackingProps } from '@opentrons/components'
@@ -186,9 +187,7 @@ export function SelectLabwareOnAdapter(
                 <Fragment key={`${loadName}_${category}`}>
                   <CustomizeExpandButton
                     enableStackingFF={enableStacking}
-                    isNestedDefALid={
-                      nestedDef.allowedRoles?.includes('lid') ?? false
-                    }
+                    isNestedDefALid={getIsNestedDefinitionALid(nestedDef)}
                     allowInputField={lidLoadNames.includes(
                       nestedDef.parameters.loadName
                     )}

--- a/protocol-designer/src/components/organisms/SelectLabwareModal/SelectLidOnLabware.tsx
+++ b/protocol-designer/src/components/organisms/SelectLabwareModal/SelectLidOnLabware.tsx
@@ -70,7 +70,7 @@ export function SelectLidOnLabware(
           return (
             <CustomizeExpandButton
               enableStackingFF={enableStacking}
-              loadName={def.parameters.loadName}
+              isNestedDefALid={def.allowedRoles?.includes('lid') ?? false}
               allowInputField={lidLoadNames.includes(def.parameters.loadName)}
               key={`${category}_${loadName}_${defUri}`}
               id={`${category}_${loadName}_${defUri}`}

--- a/protocol-designer/src/components/organisms/SelectLabwareModal/SelectLidOnLabware.tsx
+++ b/protocol-designer/src/components/organisms/SelectLabwareModal/SelectLidOnLabware.tsx
@@ -12,6 +12,7 @@ import { getOnlyLatestDefs } from '../../../labware-defs'
 import { getCustomLabwareDefsByURI } from '../../../labware-defs/selectors'
 import { selectLid } from '../../../labware-ingred/actions'
 import { selectors } from '../../../labware-ingred/selectors'
+import { getIsNestedDefinitionALid } from './utils'
 
 import type { ChangeEvent } from 'react'
 import type { ThunkDispatch } from '../../../types'
@@ -70,7 +71,7 @@ export function SelectLidOnLabware(
           return (
             <CustomizeExpandButton
               enableStackingFF={enableStacking}
-              isNestedDefALid={def.allowedRoles?.includes('lid') ?? false}
+              isNestedDefALid={getIsNestedDefinitionALid(def)}
               allowInputField={lidLoadNames.includes(def.parameters.loadName)}
               key={`${category}_${loadName}_${defUri}`}
               id={`${category}_${loadName}_${defUri}`}

--- a/protocol-designer/src/components/organisms/SelectLabwareModal/utils.ts
+++ b/protocol-designer/src/components/organisms/SelectLabwareModal/utils.ts
@@ -1,0 +1,7 @@
+import type { LabwareDefinition2 } from '@opentrons/shared-data'
+
+export const getIsNestedDefinitionALid = (
+  def?: LabwareDefinition2
+): boolean => {
+  return def?.allowedRoles?.includes('lid') ?? false
+}

--- a/protocol-designer/src/pages/Designer/DeckSetup/utils.ts
+++ b/protocol-designer/src/pages/Designer/DeckSetup/utils.ts
@@ -189,14 +189,31 @@ const getStackerDefinitionsFromLoadName = (
   defs: LabwareDefByDefURI,
   loadName: string
 ): string[] | null => {
-  const labwareDefURI = Object.entries(defs)
+  const matchingLabwares: Array<{
+    labwareDefUri: string
+    loadName: string
+  }> = Object.entries(defs)
     .filter(([, { compatibleParentLabware }]) =>
       compatibleParentLabware?.includes(loadName)
     )
     .reverse()
-    .map(([labwareDefUri]) => labwareDefUri)
+    .map(([labwareDefUri, def]) => ({
+      labwareDefUri,
+      loadName: def.parameters.loadName,
+    }))
 
-  return labwareDefURI
+  //  TODO: remove this when we allow stacking of all labware on itself
+  //  in PD
+  if (
+    loadName === 'opentrons_96_wellplate_200ul_pcr_full_skirt' &&
+    matchingLabwares.some(labware => labware.loadName === loadName)
+  ) {
+    return matchingLabwares
+      .filter(labware => labware.loadName !== loadName)
+      .map(labware => labware.labwareDefUri)
+  }
+
+  return matchingLabwares.map(labware => labware.labwareDefUri)
 }
 
 const CATEGORIES_WITH_NO_LID = [
@@ -219,9 +236,9 @@ export const getStackerDefinitions = (
     category != null && !CATEGORIES_WITH_NO_LID.includes(category)
       ? universalLidURI
       : null
-  const supportedDef = getStackerDefinitionsFromLoadName(defs, loadName)
+  const supportedDefs = getStackerDefinitionsFromLoadName(defs, loadName)
   return [
-    ...(supportedDef != null ? supportedDef : []),
+    ...(supportedDefs != null ? supportedDefs : []),
     ...(universalLid != null ? [universalLid] : []),
   ]
 }

--- a/protocol-designer/src/pages/Designer/DeckSetup/utils.ts
+++ b/protocol-designer/src/pages/Designer/DeckSetup/utils.ts
@@ -204,13 +204,13 @@ const getStackerDefinitionsFromLoadName = (
 
   //  TODO: remove this when we allow stacking of all labware on itself
   //  in PD
-  if (
-    loadName === 'opentrons_96_wellplate_200ul_pcr_full_skirt' &&
-    matchingLabwares.some(labware => labware.loadName === loadName)
-  ) {
-    return matchingLabwares
-      .filter(labware => labware.loadName !== loadName)
-      .map(labware => labware.labwareDefUri)
+  if (matchingLabwares.some(labware => labware.loadName === loadName)) {
+    return matchingLabwares.reduce((acc: string[], labware) => {
+      if (labware.loadName !== loadName) {
+        acc.push(labware.labwareDefUri)
+      }
+      return acc
+    }, [])
   }
 
   return matchingLabwares.map(labware => labware.labwareDefUri)

--- a/shared-data/js/getLabware.ts
+++ b/shared-data/js/getLabware.ts
@@ -72,8 +72,6 @@ export const PD_DO_NOT_LIST = [
   // temporarily blocking 20 uL Flex tip racks until they launch
   'opentrons_flex_96_tiprack_20ul',
   'opentrons_flex_96_filtertiprack_20ul',
-  // temporarily blocking tough lids until geometry and collateral is finalized
-  'opentrons_tough_universal_lid',
 ]
 
 export function getIsLabwareV1Tiprack(def: LabwareDefinition1): boolean {


### PR DESCRIPTION
closes AUTH-2033 AUTH-2192

# Overview

This PR fixes a few issues with selecting lids on the deck. Also re-adds universal lid support (i think it was accidentally added back to the PD_DO_NOT_LIST during a mergeback)

## Test Plan and Hands on Testing

Make sure your labware stacking FF is turned on

Create a protocol in flex or ot-2. Add a tough 96 well plate and see that you can't stack it on itself. Then click on the lid category and select a lid, see that you don't see a checkbox + a quantity input field at the same time.

## Changelog

- Fix bug where the tough plate was showing up the ability to stack on itself
- fix bug where you saw a checkbox + quantity input field at the same time
- allow universal lid selection again

## Risk assessment

low