### PR TITLE
refactor(protocol-designer): fix deck riser highlight coordinates

### DIFF
--- a/protocol-designer/src/pages/Designer/LabwareLabel.tsx
+++ b/protocol-designer/src/pages/Designer/LabwareLabel.tsx
@@ -13,6 +13,14 @@ import type {
   LabwareDefinition2,
 } from '@opentrons/shared-data'
 
+//  NOTE: the deck riser needs special values because the
+//  manually created SVG for it is slightly bigger than relying on the
+//  cornerOffsetFromSlot and zDimension values. When adjusting them in the definition
+//  it looks too small on the deck map, so i think the values in the def
+//  are correct? But i'm treating this like a module with adjusted values
+const DECK_RISER_ADJUSTED_X = 12
+const DECK_RISER_ADJUSTED_Z_DIMENSION = 2
+
 interface LabwareLabelProps {
   position: CoordinateTuple
   labwareDef: LabwareDefinition2
@@ -56,14 +64,25 @@ export const LabwareLabel = (props: LabwareLabelProps): JSX.Element => {
     }
   }, [nestedLabwareInfo])
 
+  const showDeckRiserAdjustments =
+    labwareDef.parameters.loadName === 'opentrons_flex_deck_riser' &&
+    nestedLabwareInfo.length === 0
+
   return (
     <DeckLabelSet
       ref={labelContainerRef}
       deckLabels={deckLabels}
-      x={position[0] - labwareDef.cornerOffsetFromSlot.x}
+      x={
+        position[0] -
+        labwareDef.cornerOffsetFromSlot.x -
+        (showDeckRiserAdjustments ? DECK_RISER_ADJUSTED_X : 0)
+      }
       y={position[1] + labwareDef.cornerOffsetFromSlot.y - labelContainerHeight}
       width={labwareDef.dimensions.xDimension}
-      height={labwareDef.dimensions.yDimension}
+      height={
+        labwareDef.dimensions.yDimension -
+        (showDeckRiserAdjustments ? DECK_RISER_ADJUSTED_Z_DIMENSION : 0)
+      }
       showModuleIcon={showModuleIcon}
     />
   )


### PR DESCRIPTION
closes AUTH-1918

# Overview

Fix deck riser highlight location

<img width="344" height="357" alt="Screenshot 2025-08-14 at 10 40 50" src="https://github.com/user-attachments/assets/8eee384f-2687-4726-9c36-244eb34e7837" />

## Test Plan and Hands on Testing

Review the screenshot :) 

## Changelog

fix deck riser highlight location

## Risk assessment

low