### PR TITLE
fix(app): defensive code around slot names

### DIFF
--- a/app/src/organisms/Desktop/CalibrateTipLength/index.tsx
+++ b/app/src/organisms/Desktop/CalibrateTipLength/index.tsx
@@ -190,9 +190,7 @@ export function CalibrateTipLength({
   )
 }
 
-const blockRemovalAssetBySlot: {
-  [slot in CalibrationLabware['slot']]: string
-} = {
+const blockRemovalAssetBySlot: Record<string, string> = {
   '1': slotOneRemoveBlockAsset,
   '3': slotThreeRemoveBlockAsset,
 }
@@ -206,13 +204,23 @@ function TipLengthCalibrationComplete(
   const visualAid =
     calBlock != null ? (
       <AnimationVideo
-        key={blockRemovalAssetBySlot[calBlock.slot]}
+        key={
+          blockRemovalAssetBySlot[
+            Sessions.slotNameFromCalibrationSlot(calBlock.slot)
+          ]
+        }
         css={css`
           max-width: 100%;
           max-height: 15rem;
         `}
       >
-        <source src={blockRemovalAssetBySlot[calBlock.slot]} />
+        <source
+          src={
+            blockRemovalAssetBySlot[
+              Sessions.slotNameFromCalibrationSlot(calBlock.slot)
+            ]
+          }
+        />
       </AnimationVideo>
     ) : null
 

--- a/app/src/organisms/Desktop/CalibrationPanels/DeckSetup.tsx
+++ b/app/src/organisms/Desktop/CalibrationPanels/DeckSetup.tsx
@@ -128,13 +128,13 @@ export function DeckSetup(props: CalibrationPanelProps): JSX.Element {
                     if (
                       tipRack?.slot != null &&
                       Sessions.slotNameFromCalibrationSlot(tipRack?.slot) ===
-                      addressableAreaName
+                        addressableAreaName
                     ) {
                       return tipRack.definition
                     } else if (
                       calBlock?.slot != null &&
                       Sessions.slotNameFromCalibrationSlot(calBlock?.slot) ===
-                      addressableAreaName
+                        addressableAreaName
                     ) {
                       return calBlock.definition
                     } else {

--- a/app/src/organisms/Desktop/CalibrationPanels/DeckSetup.tsx
+++ b/app/src/organisms/Desktop/CalibrationPanels/DeckSetup.tsx
@@ -125,15 +125,28 @@ export function DeckSetup(props: CalibrationPanelProps): JSX.Element {
                   }
 
                   const labwareDef = ((): LabwareDefinition | null => {
-                    if (tipRack?.slot === addressableAreaName) {
+                    if (
+                      tipRack?.slot != null &&
+                      Sessions.slotNameFromCalibrationSlot(tipRack?.slot) ===
+                      addressableAreaName
+                    ) {
                       return tipRack.definition
-                    } else if (calBlock?.slot === addressableAreaName) {
+                    } else if (
+                      calBlock?.slot != null &&
+                      Sessions.slotNameFromCalibrationSlot(calBlock?.slot) ===
+                      addressableAreaName
+                    ) {
                       return calBlock.definition
                     } else {
                       return null
                     }
                   })()
-
+                  console.log(
+                    `with aaname ${addressableAreaName} (${typeof addressableAreaName}) and tiprack slot ${
+                      tipRack?.slot
+                    } (${typeof tipRack?.slot}) labwaredef is null `,
+                    labwareDef == null
+                  )
                   if (labwareDef == null) {
                     return null
                   }
@@ -142,6 +155,7 @@ export function DeckSetup(props: CalibrationPanelProps): JSX.Element {
                     addressableArea.id,
                     deckDef
                   )
+                  console.log(`slotOrigin is null: `, slotOrigin == null)
                   if (slotOrigin == null) {
                     return null // Shouldn't happen.
                   }

--- a/app/src/organisms/Desktop/CalibrationPanels/DeckSetup.tsx
+++ b/app/src/organisms/Desktop/CalibrationPanels/DeckSetup.tsx
@@ -141,12 +141,6 @@ export function DeckSetup(props: CalibrationPanelProps): JSX.Element {
                       return null
                     }
                   })()
-                  console.log(
-                    `with aaname ${addressableAreaName} (${typeof addressableAreaName}) and tiprack slot ${
-                      tipRack?.slot
-                    } (${typeof tipRack?.slot}) labwaredef is null `,
-                    labwareDef == null
-                  )
                   if (labwareDef == null) {
                     return null
                   }
@@ -155,7 +149,6 @@ export function DeckSetup(props: CalibrationPanelProps): JSX.Element {
                     addressableArea.id,
                     deckDef
                   )
-                  console.log(`slotOrigin is null: `, slotOrigin == null)
                   if (slotOrigin == null) {
                     return null // Shouldn't happen.
                   }

--- a/app/src/organisms/Desktop/CalibrationPanels/SaveXYPoint.tsx
+++ b/app/src/organisms/Desktop/CalibrationPanels/SaveXYPoint.tsx
@@ -50,7 +50,7 @@ import type {
 import type { CalibrationPanelProps } from './types'
 
 const assetMap: Record<
-  CalibrationLabware['slot'],
+  string,
   Record<Mount, Record<'multi' | 'single', string>>
 > = {
   '1': {

--- a/app/src/organisms/Desktop/CalibrationPanels/SaveXYPoint.tsx
+++ b/app/src/organisms/Desktop/CalibrationPanels/SaveXYPoint.tsx
@@ -42,7 +42,6 @@ import { formatJogVector } from './utils'
 import type { Mount } from '@opentrons/components'
 import type { Axis, Sign, StepSize } from '/app/molecules/JogControls/types'
 import type {
-  CalibrationLabware,
   CalibrationSessionStep,
   SessionCommandString,
   SessionType,

--- a/app/src/redux/sessions/__fixtures__/calibration-check.ts
+++ b/app/src/redux/sessions/__fixtures__/calibration-check.ts
@@ -7,6 +7,7 @@ import {
   CHECK_STEP_COMPARING_POINT_TWO,
   CHECK_STEP_COMPARING_TIP,
 } from '../calibration-check/constants'
+import { calibrationSlotFromSlotName } from '../utils'
 
 import type {
   CalibrationCheckComparison,
@@ -18,7 +19,7 @@ import type {
 } from '../types'
 
 export const mockCalibrationCheckLabware: CalibrationLabware = {
-  slot: '8',
+  slot: calibrationSlotFromSlotName('8'),
   loadName: 'opentrons_96_tiprack_300ul',
   namespace: 'opentrons',
   version: 1,

--- a/app/src/redux/sessions/__fixtures__/deck-calibration.ts
+++ b/app/src/redux/sessions/__fixtures__/deck-calibration.ts
@@ -1,12 +1,14 @@
 import { fixtureTiprack300ul } from '@opentrons/shared-data'
 
+import { calibrationSlotFromSlotName } from '../utils'
+
 import type {
   CalibrationLabware,
   DeckCalibrationSessionDetails,
 } from '../types'
 
 export const mockDeckCalTipRack: CalibrationLabware = {
-  slot: '8',
+  slot: calibrationSlotFromSlotName('8'),
   loadName: 'opentrons_96_tiprack_300ul',
   namespace: 'opentrons',
   version: 1,

--- a/app/src/redux/sessions/__fixtures__/pipette-offset-calibration.ts
+++ b/app/src/redux/sessions/__fixtures__/pipette-offset-calibration.ts
@@ -1,5 +1,7 @@
 import { fixtureTiprack300ul } from '@opentrons/shared-data'
 
+import { calibrationSlotFromSlotName } from '../utils'
+
 import type { PipetteOffsetCalibrationSessionParams } from '../pipette-offset-calibration/types'
 import type {
   CalibrationLabware,
@@ -7,7 +9,7 @@ import type {
 } from '../types'
 
 export const mockPipetteOffsetTipRack: CalibrationLabware = {
-  slot: '8',
+  slot: calibrationSlotFromSlotName('8'),
   loadName: 'opentrons_96_tiprack_300ul',
   namespace: 'opentrons',
   version: 1,

--- a/app/src/redux/sessions/__fixtures__/tip-length-calibration.ts
+++ b/app/src/redux/sessions/__fixtures__/tip-length-calibration.ts
@@ -3,6 +3,8 @@ import {
   fixtureTiprack300ul,
 } from '@opentrons/shared-data'
 
+import { calibrationSlotFromSlotName } from '../utils'
+
 import type { TipLengthCalibrationSessionParams } from '../tip-length-calibration/types'
 import type {
   CalibrationLabware,
@@ -10,7 +12,7 @@ import type {
 } from '../types'
 
 export const mockTipLengthTipRack: CalibrationLabware = {
-  slot: '8',
+  slot: calibrationSlotFromSlotName('8'),
   loadName: 'opentrons_96_tiprack_300ul',
   namespace: 'opentrons',
   version: 1,
@@ -19,7 +21,7 @@ export const mockTipLengthTipRack: CalibrationLabware = {
 }
 
 export const mockTipLengthCalBlock: CalibrationLabware = {
-  slot: '1',
+  slot: calibrationSlotFromSlotName('1'),
   loadName: 'opentrons_calibrationblock_short_side_left',
   namespace: 'opentrons',
   version: 1,

--- a/app/src/redux/sessions/index.ts
+++ b/app/src/redux/sessions/index.ts
@@ -11,6 +11,7 @@ import type {
 export * from './actions'
 export * from './constants'
 export * from './selectors'
+export * from './utils'
 
 export type {
   Session,

--- a/app/src/redux/sessions/types.ts
+++ b/app/src/redux/sessions/types.ts
@@ -320,8 +320,16 @@ export type SessionState = Partial<{
   readonly [robotName: string]: undefined | PerRobotSessionState
 }>
 
+// Unfortunately, the server can sometimes give us numerical slots here, so let's make
+// this a unique and gross type so you can't accidentally check them against a string
+// without converting. Use utils.ts slotNameFromCalibrationSlot and calibrationSlotFromSlotName
+// to convert.
+export type CalibrationLabwareSlot = {
+  readonly __brand: 'UniqueType'
+}
+
 export interface CalibrationLabware {
-  slot: string
+  slot: CalibrationLabwareSlot
   loadName: string
   namespace: string
   version: number

--- a/app/src/redux/sessions/types.ts
+++ b/app/src/redux/sessions/types.ts
@@ -324,7 +324,7 @@ export type SessionState = Partial<{
 // this a unique and gross type so you can't accidentally check them against a string
 // without converting. Use utils.ts slotNameFromCalibrationSlot and calibrationSlotFromSlotName
 // to convert.
-export type CalibrationLabwareSlot = {
+export interface CalibrationLabwareSlot {
   readonly __brand: 'CalibrationLabwareSlot'
 }
 

--- a/app/src/redux/sessions/types.ts
+++ b/app/src/redux/sessions/types.ts
@@ -325,7 +325,7 @@ export type SessionState = Partial<{
 // without converting. Use utils.ts slotNameFromCalibrationSlot and calibrationSlotFromSlotName
 // to convert.
 export type CalibrationLabwareSlot = {
-  readonly __brand: 'UniqueType'
+  readonly __brand: 'CalibrationLabwareSlot'
 }
 
 export interface CalibrationLabware {

--- a/app/src/redux/sessions/utils.ts
+++ b/app/src/redux/sessions/utils.ts
@@ -1,0 +1,16 @@
+import type { CalibrationLabwareSlot } from './types'
+
+export function slotNameFromCalibrationSlot(
+  calibrationLabwareSlot: CalibrationLabwareSlot
+): string {
+  const calSlot = (calibrationLabwareSlot as any) as string | number
+  return typeof calSlot === 'string' ? calSlot : calSlot.toString()
+}
+
+export function calibrationSlotFromSlotName(
+  slotName: string | number
+): CalibrationLabwareSlot {
+  return ((typeof slotName === 'string'
+    ? slotName
+    : slotName.toString()) as any) as CalibrationLabwareSlot
+}


### PR DESCRIPTION
The slot names coming back from the OT-2 calibration interface can be numbers instead of strings. Maybe this is new, maybe this isn't, but it's always been a valid possibility, so defensively code around it in the app using an awful branded type and some nasty little utilities.

Closes RQA-4543

## testing
- [x] start a calibration session and see the labware
<img width="749" height="467" alt="Screenshot 2025-08-14 at 2 50 56 PM" src="https://github.com/user-attachments/assets/c624bae6-9991-4bb6-8b2d-0404ec5b7a6f" />
