### PR TITLE
feat(api): add optional tip_racks argument to liquid class transfers

### DIFF
--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1833,6 +1833,7 @@ class InstrumentContext(publisher.CommandPublisher):
         :param keep_last_tip: When ``True``, the pipette keeps the last tip used in the transfer attached. When
             ``False``, the last tip will be dropped or returned. If not set, behavior depends on the value of
             ``new_tip``. ``new_tip="never"`` keeps the tip, and all other values of ``new_tip`` drop or return the tip.
+        :param tip_racks: If provided, use the tip racks given instead of the pipette's assigned tip racks.
 
         """
         if volume == 0.0:
@@ -1959,6 +1960,7 @@ class InstrumentContext(publisher.CommandPublisher):
         :param keep_last_tip: When ``True``, the pipette keeps the last tip used in the distribute attached. When
             ``False``, the last tip will be dropped or returned. If not set, behavior depends on the value of
             ``new_tip``. ``new_tip="never"`` keeps the tip, and all other values of ``new_tip`` drop or return the tip.
+        :param tip_racks: If provided, use the tip racks given instead of the pipette's assigned tip racks.
 
         """
         if volume == 0.0:
@@ -2094,6 +2096,7 @@ class InstrumentContext(publisher.CommandPublisher):
         :param keep_last_tip: When ``True``, the pipette keeps the last tip used in the consolidate attached. When
             ``False``, the last tip will be dropped or returned. If not set, behavior depends on the value of
             ``new_tip``. ``new_tip="never"`` keeps the tip, and all other values of ``new_tip`` drop or return the tip.
+        :param tip_racks: If provided, use the tip racks given instead of the pipette's assigned tip racks.
 
         """
         if volume == 0.0:

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1836,6 +1836,7 @@ class InstrumentContext(publisher.CommandPublisher):
             ``False``, the last tip will be dropped or returned. If not set, behavior depends on the value of
             ``new_tip``. ``new_tip="never"`` keeps the tip, and all other values of ``new_tip`` drop or return the tip.
         :param tip_racks: If provided, use the tip racks given instead of the pipette's assigned tip racks.
+            .. versionadded:: 2.25
 
         """
         if volume == 0.0:
@@ -1976,6 +1977,7 @@ class InstrumentContext(publisher.CommandPublisher):
             ``False``, the last tip will be dropped or returned. If not set, behavior depends on the value of
             ``new_tip``. ``new_tip="never"`` keeps the tip, and all other values of ``new_tip`` drop or return the tip.
         :param tip_racks: If provided, use the tip racks given instead of the pipette's assigned tip racks.
+            .. versionadded:: 2.25
 
         """
         if volume == 0.0:
@@ -2125,6 +2127,7 @@ class InstrumentContext(publisher.CommandPublisher):
             ``False``, the last tip will be dropped or returned. If not set, behavior depends on the value of
             ``new_tip``. ``new_tip="never"`` keeps the tip, and all other values of ``new_tip`` drop or return the tip.
         :param tip_racks: If provided, use the tip racks given instead of the pipette's assigned tip racks.
+            .. versionadded:: 2.25
 
         """
         if volume == 0.0:

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1835,8 +1835,12 @@ class InstrumentContext(publisher.CommandPublisher):
         :param keep_last_tip: When ``True``, the pipette keeps the last tip used in the transfer attached. When
             ``False``, the last tip will be dropped or returned. If not set, behavior depends on the value of
             ``new_tip``. ``new_tip="never"`` keeps the tip, and all other values of ``new_tip`` drop or return the tip.
-        :param tip_racks: If provided, use the tip racks given instead of the pipette's assigned tip racks.
-            .. versionadded:: 2.25
+        :param tip_racks: A list of tip racks to pick up from for this command. If not provided, the pipette will pick
+            up from its associated :py:obj:`.InstrumentContext.tip_racks`. Providing this argument does not change the
+            value of ``InstrumentContext.tip_racks``.
+
+            .. versionchanged:: 2.25
+                Added the ``tip_racks`` parameter.
 
         """
         if volume == 0.0:
@@ -1976,8 +1980,12 @@ class InstrumentContext(publisher.CommandPublisher):
         :param keep_last_tip: When ``True``, the pipette keeps the last tip used in the distribute attached. When
             ``False``, the last tip will be dropped or returned. If not set, behavior depends on the value of
             ``new_tip``. ``new_tip="never"`` keeps the tip, and all other values of ``new_tip`` drop or return the tip.
-        :param tip_racks: If provided, use the tip racks given instead of the pipette's assigned tip racks.
-            .. versionadded:: 2.25
+        :param tip_racks: A list of tip racks to pick up from for this command. If not provided, the pipette will pick
+            up from its associated :py:obj:`.InstrumentContext.tip_racks`. Providing this argument does not change the
+            value of ``InstrumentContext.tip_racks``.
+
+            .. versionchanged:: 2.25
+                Added the ``tip_racks`` parameter.
 
         """
         if volume == 0.0:
@@ -2126,8 +2134,12 @@ class InstrumentContext(publisher.CommandPublisher):
         :param keep_last_tip: When ``True``, the pipette keeps the last tip used in the consolidate attached. When
             ``False``, the last tip will be dropped or returned. If not set, behavior depends on the value of
             ``new_tip``. ``new_tip="never"`` keeps the tip, and all other values of ``new_tip`` drop or return the tip.
-        :param tip_racks: If provided, use the tip racks given instead of the pipette's assigned tip racks.
-            .. versionadded:: 2.25
+        :param tip_racks: A list of tip racks to pick up from for this command. If not provided, the pipette will pick
+            up from its associated :py:obj:`.InstrumentContext.tip_racks`. Providing this argument does not change the
+            value of ``InstrumentContext.tip_racks``.
+
+            .. versionchanged:: 2.25
+                Added the ``tip_racks`` parameter.
 
         """
         if volume == 0.0:

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -72,6 +72,8 @@ _PARTIAL_NOZZLE_CONFIGURATION_SINGLE_ROW_PARTIAL_COLUMN_ADDED_IN = APIVersion(2,
 """The version after which partial nozzle configurations of single, row, and partial column layouts became available."""
 _AIR_GAP_TRACKING_ADDED_IN = APIVersion(2, 22)
 """The version after which air gaps should be implemented with a separate call instead of an aspirate for better liquid volume tracking."""
+_LIQUID_CLASS_TRANSFER_TIP_RACKS_ARG_ADDED_IN = APIVersion(2, 25)
+"""The version after which the user can supply liquid class transfers with non-assigned tip racks."""
 
 
 AdvancedLiquidHandling = v1_transfer.AdvancedLiquidHandling
@@ -1843,6 +1845,16 @@ class InstrumentContext(publisher.CommandPublisher):
             )
             return self
 
+        if (
+            tip_racks is not None
+            and self.api_version < _LIQUID_CLASS_TRANSFER_TIP_RACKS_ARG_ADDED_IN
+        ):
+            raise APIVersionError(
+                api_element="tip_racks",
+                until_version="2.25",
+                current_version=f"{self.api_version}",
+            )
+
         transfer_args = verify_and_normalize_transfer_args(
             source=source,
             dest=dest,
@@ -1972,6 +1984,16 @@ class InstrumentContext(publisher.CommandPublisher):
                 f" Skipping."
             )
             return self
+
+        if (
+            tip_racks is not None
+            and self.api_version < _LIQUID_CLASS_TRANSFER_TIP_RACKS_ARG_ADDED_IN
+        ):
+            raise APIVersionError(
+                api_element="tip_racks",
+                until_version="2.25",
+                current_version=f"{self.api_version}",
+            )
 
         transfer_args = verify_and_normalize_transfer_args(
             source=source,
@@ -2111,6 +2133,16 @@ class InstrumentContext(publisher.CommandPublisher):
                 f" Skipping."
             )
             return self
+
+        if (
+            tip_racks is not None
+            and self.api_version < _LIQUID_CLASS_TRANSFER_TIP_RACKS_ARG_ADDED_IN
+        ):
+            raise APIVersionError(
+                api_element="tip_racks",
+                until_version="2.25",
+                current_version=f"{self.api_version}",
+            )
 
         transfer_args = verify_and_normalize_transfer_args(
             source=source,

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1877,6 +1877,9 @@ class InstrumentContext(publisher.CommandPublisher):
                 for well in transfer_args.dest
             ]
 
+        for tip_rack in transfer_args.tip_racks:
+            instrument.validate_tiprack(self.name, tip_rack, _log)
+
         with publisher.publish_context(
             broker=self.broker,
             command=cmds.transfer_with_liquid_class(
@@ -2007,6 +2010,9 @@ class InstrumentContext(publisher.CommandPublisher):
                 f" `distribute_with_liquid_class()` only supports `new_tip` values of"
                 f" 'once', 'never' and 'always'."
             )
+
+        for tip_rack in transfer_args.tip_racks:
+            instrument.validate_tiprack(self.name, tip_rack, _log)
 
         verified_source = transfer_args.source[0]
         with publisher.publish_context(
@@ -2146,6 +2152,9 @@ class InstrumentContext(publisher.CommandPublisher):
                 f" `consolidate_with_liquid_class()` only supports `new_tip` values of"
                 f" 'once', 'never' and 'always'."
             )
+
+        for tip_rack in transfer_args.tip_racks:
+            instrument.validate_tiprack(self.name, tip_rack, _log)
 
         with publisher.publish_context(
             broker=self.broker,

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1796,6 +1796,7 @@ class InstrumentContext(publisher.CommandPublisher):
         return_tip: bool = False,
         group_wells: bool = True,
         keep_last_tip: Optional[bool] = None,
+        tip_racks: Optional[List[labware.Labware]] = None,
     ) -> InstrumentContext:
         """Move a particular type of liquid from one well or group of wells to another.
 
@@ -1846,7 +1847,7 @@ class InstrumentContext(publisher.CommandPublisher):
             dest=dest,
             tip_policy=new_tip,
             last_tip_well=self._get_current_tip_source_well(),
-            tip_racks=self._tip_racks,
+            tip_racks=tip_racks or self._tip_racks,
             nozzle_map=self._core.get_nozzle_map(),
             group_wells_for_multi_channel=group_wells,
             current_volume=self.current_volume,
@@ -1924,6 +1925,7 @@ class InstrumentContext(publisher.CommandPublisher):
         return_tip: bool = False,
         group_wells: bool = True,
         keep_last_tip: Optional[bool] = None,
+        tip_racks: Optional[List[labware.Labware]] = None,
     ) -> InstrumentContext:
         """
         Distribute a particular type of liquid from one well to a group of wells.
@@ -1971,7 +1973,7 @@ class InstrumentContext(publisher.CommandPublisher):
             dest=dest,
             tip_policy=new_tip,
             last_tip_well=self._get_current_tip_source_well(),
-            tip_racks=self._tip_racks,
+            tip_racks=tip_racks or self._tip_racks,
             nozzle_map=self._core.get_nozzle_map(),
             group_wells_for_multi_channel=group_wells,
             current_volume=self.current_volume,
@@ -2057,6 +2059,7 @@ class InstrumentContext(publisher.CommandPublisher):
         return_tip: bool = False,
         group_wells: bool = True,
         keep_last_tip: Optional[bool] = None,
+        tip_racks: Optional[List[labware.Labware]] = None,
     ) -> InstrumentContext:
         """
         Consolidate a particular type of liquid from a group of wells to one well.
@@ -2105,7 +2108,7 @@ class InstrumentContext(publisher.CommandPublisher):
             dest=dest,
             tip_policy=new_tip,
             last_tip_well=self._get_current_tip_source_well(),
-            tip_racks=self._tip_racks,
+            tip_racks=tip_racks or self._tip_racks,
             nozzle_map=self._core.get_nozzle_map(),
             group_wells_for_multi_channel=group_wells,
             current_volume=self.current_volume,

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -2482,7 +2482,6 @@ def test_transfer_liquid_delegates_to_engine_core(
     mock_starting_tip_well = decoy.mock(cls=Well)
     tip_racks = [decoy.mock(cls=Labware)]
     trash_location = Location(point=Point(1, 2, 3), labware=mock_well)
-    next_tiprack = decoy.mock(cls=Labware)
     subject.starting_tip = mock_starting_tip_well
     subject._tip_racks = tip_racks
 
@@ -2490,7 +2489,6 @@ def test_transfer_liquid_delegates_to_engine_core(
     decoy.when(mock_instrument_core.get_nozzle_map()).then_return(MOCK_MAP)
     decoy.when(mock_instrument_core.get_active_channels()).then_return(2)
     decoy.when(mock_instrument_core.get_current_volume()).then_return(0)
-    decoy.when(next_tiprack.uri).then_return("tiprack-uri")
     decoy.when(mock_instrument_core.get_pipette_name()).then_return("pipette-name")
     subject.transfer_with_liquid_class(
         liquid_class=test_liq_class,
@@ -2532,7 +2530,6 @@ def test_transfer_liquid_multi_channel_delegates_to_engine_core(
     decoy.when(mock_well.well_name).then_return("mock well")
     tip_racks = [decoy.mock(cls=Labware)]
     trash_location = Location(point=Point(1, 2, 3), labware=mock_well)
-    next_tiprack = decoy.mock(cls=Labware)
     subject.starting_tip = None
     subject._tip_racks = tip_racks
 
@@ -2553,7 +2550,6 @@ def test_transfer_liquid_multi_channel_delegates_to_engine_core(
 
     decoy.when(mock_instrument_core.get_active_channels()).then_return(2)
     decoy.when(mock_instrument_core.get_current_volume()).then_return(0)
-    decoy.when(next_tiprack.uri).then_return("tiprack-uri")
     decoy.when(mock_instrument_core.get_pipette_name()).then_return("pipette-name")
     subject.transfer_with_liquid_class(
         liquid_class=test_liq_class,
@@ -2596,7 +2592,6 @@ def test_transfer_liquid_delegates_to_engine_core_with_trash_destination(
     mock_trash = decoy.mock(cls=TrashBin)
     tip_racks = [decoy.mock(cls=Labware)]
     trash_location = Location(point=Point(1, 2, 3), labware=mock_well)
-    next_tiprack = decoy.mock(cls=Labware)
     subject.starting_tip = mock_starting_tip_well
     subject._tip_racks = tip_racks
 
@@ -2604,7 +2599,6 @@ def test_transfer_liquid_delegates_to_engine_core_with_trash_destination(
     decoy.when(mock_instrument_core.get_nozzle_map()).then_return(MOCK_MAP)
     decoy.when(mock_instrument_core.get_active_channels()).then_return(2)
     decoy.when(mock_instrument_core.get_current_volume()).then_return(0)
-    decoy.when(next_tiprack.uri).then_return("tiprack-uri")
     decoy.when(mock_instrument_core.get_pipette_name()).then_return("pipette-name")
     subject.transfer_with_liquid_class(
         liquid_class=test_liq_class,
@@ -2873,7 +2867,6 @@ def test_distribute_liquid_delegates_to_engine_core(
     mock_starting_tip_well = decoy.mock(cls=Well)
     tip_racks = [decoy.mock(cls=Labware)]
     trash_location = Location(point=Point(1, 2, 3), labware=mock_well)
-    next_tiprack = decoy.mock(cls=Labware)
     subject.starting_tip = mock_starting_tip_well
     subject._tip_racks = tip_racks
 
@@ -2881,7 +2874,6 @@ def test_distribute_liquid_delegates_to_engine_core(
     decoy.when(mock_instrument_core.get_nozzle_map()).then_return(MOCK_MAP)
     decoy.when(mock_instrument_core.get_active_channels()).then_return(2)
     decoy.when(mock_instrument_core.get_current_volume()).then_return(0)
-    decoy.when(next_tiprack.uri).then_return("tiprack-uri")
     decoy.when(mock_instrument_core.get_pipette_name()).then_return("pipette-name")
     subject.distribute_with_liquid_class(
         liquid_class=test_liq_class,
@@ -2923,7 +2915,6 @@ def test_distribute_liquid_multi_channel_delegates_to_engine_core(
     decoy.when(mock_well.well_name).then_return("mock well")
     tip_racks = [decoy.mock(cls=Labware)]
     trash_location = Location(point=Point(1, 2, 3), labware=mock_well)
-    next_tiprack = decoy.mock(cls=Labware)
     subject.starting_tip = None
     subject._tip_racks = tip_racks
 
@@ -2944,7 +2935,6 @@ def test_distribute_liquid_multi_channel_delegates_to_engine_core(
 
     decoy.when(mock_instrument_core.get_active_channels()).then_return(2)
     decoy.when(mock_instrument_core.get_current_volume()).then_return(0)
-    decoy.when(next_tiprack.uri).then_return("tiprack-uri")
     decoy.when(mock_instrument_core.get_pipette_name()).then_return("pipette-name")
     subject.distribute_with_liquid_class(
         liquid_class=test_liq_class,
@@ -3225,7 +3215,6 @@ def test_consolidate_liquid_delegates_to_engine_core(
     mock_starting_tip_well = decoy.mock(cls=Well)
     tip_racks = [decoy.mock(cls=Labware)]
     trash_location = Location(point=Point(1, 2, 3), labware=mock_well)
-    next_tiprack = decoy.mock(cls=Labware)
     subject.starting_tip = mock_starting_tip_well
     subject._tip_racks = tip_racks
 
@@ -3233,7 +3222,6 @@ def test_consolidate_liquid_delegates_to_engine_core(
     decoy.when(mock_instrument_core.get_nozzle_map()).then_return(MOCK_MAP)
     decoy.when(mock_instrument_core.get_active_channels()).then_return(2)
     decoy.when(mock_instrument_core.get_current_volume()).then_return(0)
-    decoy.when(next_tiprack.uri).then_return("tiprack-uri")
     decoy.when(mock_instrument_core.get_pipette_name()).then_return("pipette-name")
 
     subject.consolidate_with_liquid_class(
@@ -3276,7 +3264,6 @@ def test_consolidate_liquid_multi_channel_delegates_to_engine_core(
     decoy.when(mock_well.well_name).then_return("mock well")
     tip_racks = [decoy.mock(cls=Labware)]
     trash_location = Location(point=Point(1, 2, 3), labware=mock_well)
-    next_tiprack = decoy.mock(cls=Labware)
     subject.starting_tip = None
     subject._tip_racks = tip_racks
 
@@ -3297,7 +3284,6 @@ def test_consolidate_liquid_multi_channel_delegates_to_engine_core(
 
     decoy.when(mock_instrument_core.get_active_channels()).then_return(2)
     decoy.when(mock_instrument_core.get_current_volume()).then_return(0)
-    decoy.when(next_tiprack.uri).then_return("tiprack-uri")
     decoy.when(mock_instrument_core.get_pipette_name()).then_return("pipette-name")
 
     subject.consolidate_with_liquid_class(
@@ -3344,7 +3330,6 @@ def test_consolidate_liquid_delegates_to_engine_core_with_trash_destination(
     mock_waste_chute = decoy.mock(cls=WasteChute)
     tip_racks = [decoy.mock(cls=Labware)]
     trash_location = Location(point=Point(1, 2, 3), labware=mock_well)
-    next_tiprack = decoy.mock(cls=Labware)
     subject.starting_tip = mock_starting_tip_well
     subject._tip_racks = tip_racks
 
@@ -3352,7 +3337,6 @@ def test_consolidate_liquid_delegates_to_engine_core_with_trash_destination(
     decoy.when(mock_instrument_core.get_nozzle_map()).then_return(MOCK_MAP)
     decoy.when(mock_instrument_core.get_active_channels()).then_return(2)
     decoy.when(mock_instrument_core.get_current_volume()).then_return(0)
-    decoy.when(next_tiprack.uri).then_return("tiprack-uri")
     decoy.when(mock_instrument_core.get_pipette_name()).then_return("pipette-name")
 
     subject.consolidate_with_liquid_class(

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -2632,6 +2632,58 @@ def test_transfer_liquid_delegates_to_engine_core_with_trash_destination(
 
 
 @pytest.mark.parametrize("robot_type", ["OT-2 Standard", "OT-3 Standard"])
+def test_transfer_liquid_uses_provided_tip_racks(
+    decoy: Decoy,
+    mock_protocol_core: ProtocolCore,
+    mock_instrument_core: InstrumentCore,
+    subject: InstrumentContext,
+    robot_type: RobotType,
+    minimal_liquid_class_def2: LiquidClassSchemaV1,
+) -> None:
+    """It should use the provided tip racks instead of the assigned ones."""
+    test_liq_class = LiquidClass.create(minimal_liquid_class_def2)
+    mock_well = decoy.mock(cls=Well)
+    mock_starting_tip_well = decoy.mock(cls=Well)
+    tip_racks = [decoy.mock(cls=Labware)]
+    trash_location = Location(point=Point(1, 2, 3), labware=mock_well)
+    assigned_tip_rack = decoy.mock(cls=Labware)
+    subject.starting_tip = mock_starting_tip_well
+    subject._tip_racks = tip_racks
+
+    decoy.when(mock_protocol_core.robot_type).then_return(robot_type)
+    decoy.when(mock_instrument_core.get_nozzle_map()).then_return(MOCK_MAP)
+    decoy.when(mock_instrument_core.get_active_channels()).then_return(2)
+    decoy.when(mock_instrument_core.get_current_volume()).then_return(0)
+    decoy.when(mock_instrument_core.get_pipette_name()).then_return("pipette-name")
+    subject.transfer_with_liquid_class(
+        liquid_class=test_liq_class,
+        volume=10,
+        source=[mock_well],
+        dest=[mock_well],
+        new_tip="once",
+        trash_location=trash_location,
+        return_tip=True,
+        tip_racks=[assigned_tip_rack],
+    )
+    decoy.verify(
+        mock_instrument_core.transfer_with_liquid_class(
+            liquid_class=test_liq_class,
+            volume=10,
+            source=[(Location(Point(), labware=mock_well), mock_well._core)],
+            dest=[(Location(Point(), labware=mock_well), mock_well._core)],
+            new_tip=TransferTipPolicyV2.ONCE,
+            tip_racks=[
+                (Location(Point(), labware=assigned_tip_rack), assigned_tip_rack._core)
+            ],
+            starting_tip=mock_starting_tip_well._core,
+            trash_location=trash_location,
+            return_tip=True,
+            keep_last_tip=False,
+        )
+    )
+
+
+@pytest.mark.parametrize("robot_type", ["OT-2 Standard", "OT-3 Standard"])
 def test_distribute_liquid_raises_if_more_than_one_source(
     decoy: Decoy,
     mock_protocol_core: ProtocolCore,
@@ -2914,6 +2966,74 @@ def test_distribute_liquid_multi_channel_delegates_to_engine_core(
             ],
             new_tip=TransferTipPolicyV2.ONCE,
             tip_racks=[(Location(Point(), labware=tip_racks[0]), tip_racks[0]._core)],
+            starting_tip=None,
+            trash_location=trash_location,
+            return_tip=True,
+            keep_last_tip=False,
+        )
+    )
+
+
+@pytest.mark.parametrize("robot_type", ["OT-2 Standard", "OT-3 Standard"])
+def test_distribute_liquid_uses_provided_tip_racks(
+    decoy: Decoy,
+    mock_protocol_core: ProtocolCore,
+    mock_instrument_core: InstrumentCore,
+    subject: InstrumentContext,
+    robot_type: RobotType,
+    minimal_liquid_class_def2: LiquidClassSchemaV1,
+) -> None:
+    """It should use the provided tip racks instead of the assigned ones."""
+    test_liq_class = LiquidClass.create(minimal_liquid_class_def2)
+    mock_well = decoy.mock(cls=Well)
+    decoy.when(mock_well.well_name).then_return("mock well")
+    tip_racks = [decoy.mock(cls=Labware)]
+    trash_location = Location(point=Point(1, 2, 3), labware=mock_well)
+    assigned_tip_rack = decoy.mock(cls=Labware)
+    subject.starting_tip = None
+    subject._tip_racks = tip_racks
+
+    decoy.when(mock_protocol_core.robot_type).then_return(robot_type)
+    mock_nozzle_map = decoy.mock(cls=NozzleMapInterface)
+    decoy.when(mock_nozzle_map.tip_count).then_return(2)
+    decoy.when(mock_instrument_core.get_nozzle_map()).then_return(mock_nozzle_map)
+    decoy.when(
+        mock_tx_liquid_utils.group_wells_for_multi_channel_transfer(
+            [mock_well, mock_well, mock_well], mock_nozzle_map, "source"
+        )
+    ).then_return([mock_well])
+    decoy.when(
+        mock_tx_liquid_utils.group_wells_for_multi_channel_transfer(
+            [mock_well, mock_well], mock_nozzle_map, "destination"
+        )
+    ).then_return([mock_well, mock_well])
+
+    decoy.when(mock_instrument_core.get_active_channels()).then_return(2)
+    decoy.when(mock_instrument_core.get_current_volume()).then_return(0)
+    decoy.when(mock_instrument_core.get_pipette_name()).then_return("pipette-name")
+    subject.distribute_with_liquid_class(
+        liquid_class=test_liq_class,
+        volume=10,
+        source=[mock_well, mock_well, mock_well],
+        dest=[[mock_well, mock_well]],
+        new_tip="once",
+        trash_location=trash_location,
+        return_tip=True,
+        tip_racks=[assigned_tip_rack],
+    )
+    decoy.verify(
+        mock_instrument_core.distribute_with_liquid_class(
+            liquid_class=test_liq_class,
+            volume=10,
+            source=(Location(Point(), labware=mock_well), mock_well._core),
+            dest=[
+                (Location(Point(), labware=mock_well), mock_well._core),
+                (Location(Point(), labware=mock_well), mock_well._core),
+            ],
+            new_tip=TransferTipPolicyV2.ONCE,
+            tip_racks=[
+                (Location(Point(), labware=assigned_tip_rack), assigned_tip_rack._core)
+            ],
             starting_tip=None,
             trash_location=trash_location,
             return_tip=True,
@@ -3252,6 +3372,59 @@ def test_consolidate_liquid_delegates_to_engine_core_with_trash_destination(
             dest=mock_waste_chute,
             new_tip=TransferTipPolicyV2.ONCE,
             tip_racks=[(Location(Point(), labware=tip_racks[0]), tip_racks[0]._core)],
+            starting_tip=mock_starting_tip_well._core,
+            trash_location=trash_location,
+            return_tip=True,
+            keep_last_tip=False,
+        )
+    )
+
+
+@pytest.mark.parametrize("robot_type", ["OT-2 Standard", "OT-3 Standard"])
+def test_consolidate_liquid_uses_provided_tip_racks(
+    decoy: Decoy,
+    mock_protocol_core: ProtocolCore,
+    mock_instrument_core: InstrumentCore,
+    subject: InstrumentContext,
+    robot_type: RobotType,
+    minimal_liquid_class_def2: LiquidClassSchemaV1,
+) -> None:
+    """It should use the provided tip racks instead of the assigned ones."""
+    test_liq_class = LiquidClass.create(minimal_liquid_class_def2)
+    mock_well = decoy.mock(cls=Well)
+    mock_starting_tip_well = decoy.mock(cls=Well)
+    tip_racks = [decoy.mock(cls=Labware)]
+    trash_location = Location(point=Point(1, 2, 3), labware=mock_well)
+    assigned_tip_rack = decoy.mock(cls=Labware)
+    subject.starting_tip = mock_starting_tip_well
+    subject._tip_racks = tip_racks
+
+    decoy.when(mock_protocol_core.robot_type).then_return(robot_type)
+    decoy.when(mock_instrument_core.get_nozzle_map()).then_return(MOCK_MAP)
+    decoy.when(mock_instrument_core.get_active_channels()).then_return(2)
+    decoy.when(mock_instrument_core.get_current_volume()).then_return(0)
+    decoy.when(mock_instrument_core.get_pipette_name()).then_return("pipette-name")
+
+    subject.consolidate_with_liquid_class(
+        liquid_class=test_liq_class,
+        volume=10,
+        source=[mock_well],
+        dest=mock_well,
+        new_tip="once",
+        trash_location=trash_location,
+        return_tip=True,
+        tip_racks=[assigned_tip_rack],
+    )
+    decoy.verify(
+        mock_instrument_core.consolidate_with_liquid_class(
+            liquid_class=test_liq_class,
+            volume=10,
+            source=[(Location(Point(), labware=mock_well), mock_well._core)],
+            dest=(Location(Point(), labware=mock_well), mock_well._core),
+            new_tip=TransferTipPolicyV2.ONCE,
+            tip_racks=[
+                (Location(Point(), labware=assigned_tip_rack), assigned_tip_rack._core)
+            ],
             starting_tip=mock_starting_tip_well._core,
             trash_location=trash_location,
             return_tip=True,


### PR DESCRIPTION
# Overview

Addresses AUTH-2190

This PR adds a new `tip_racks` argument, allowing the user to use tip racks that are not assigned to the instrument that is calling one of the liquid class transfer methods. This is useful for both bespoke transfers as well as PD-generated python where the user is using multiple tip rack types for different transfers.

Additionally, this PR adds some additional validation to make sure the tip racks that are being used are in fact tip racks. This does add a check for default assigned tip racks as well as ones provided by this new arguments. While default tip racks are validated when assigned in a `load_instrument` call, tip racks assigned via `pipette.tip_racks =` are not validated. However if non-tipracks were being used in previous calls to liquid class transfers they would have failed later on when we attempted to pick up a tip, so this change puts in no functional difference.

## Test Plan and Hands on Testing

Unit tests, integration tests, and this test protocol:

```python
requirements = {
    "robotType": "Flex",
    "apiLevel": "2.25"
}

metadata = {
    "protocolName":'Liquid Class Transfer with Tip Rack arguments',
}

def run(protocol_context):
    tiprack = protocol_context.load_labware("opentrons_flex_96_tiprack_50ul", "C2")
    trash = protocol_context.load_trash_bin('A3')
    pipette = protocol_context.load_instrument("flex_1channel_50", "left")
    nest_plate = protocol_context.load_labware("nest_96_wellplate_2ml_deep", "D1")
    arma_plate = protocol_context.load_labware("armadillo_96_wellplate_200ul_pcr_full_skirt", "D3")

    water_class = protocol_context.get_liquid_class("water")

    transfer_props = water_class.get_for(pipette, tiprack)

    pipette.transfer_with_liquid_class(
        liquid_class=water_class,
        volume=50,
        source=arma_plate.columns()[0][:2],
        dest=nest_plate.columns()[0][:2],
        new_tip="always",
        trash_location=trash,
        tip_racks=[tiprack],
    )

    pipette.distribute_with_liquid_class(
        liquid_class=water_class,
        volume=24,
        source=arma_plate['A1'],
        dest=nest_plate.columns()[0][:2],
        new_tip="once",
        trash_location=trash,
        tip_racks=[tiprack],
    )

    pipette.consolidate_with_liquid_class(
        liquid_class=water_class,
        volume=100,
        source=arma_plate.columns()[0][:2],
        dest=nest_plate['A1'],
        new_tip="once",
        trash_location=trash,
        tip_racks=[tiprack],
    )
```

## Changelog

- add `tip_racks` argument to `transfer_with_liquid_class`, `distribute_with_liquid_class` and `consolidate_with_liquid_class`
- add validation for tip racks before starting execution of liquid class transfers

## Review requests


## Risk assessment

Low, pretty simple argument addition, no changes on existing protocols or changes in behavior.