### PR TITLE
fix(api): fix some ot-2 cancel bugs

### DIFF
--- a/api/src/opentrons/drivers/asyncio/communication/serial_connection.py
+++ b/api/src/opentrons/drivers/asyncio/communication/serial_connection.py
@@ -263,8 +263,13 @@ class SerialConnection:
             return
 
         lower = response.lower()
-        res_gcode = response.split()[0]
-        req_gcode = request.split()[0]
+        try:
+            res_gcode = response.split()[0]
+            req_gcode = request.split()[0]
+        except IndexError:
+            # this means the response is an empty string or something, which is weird
+            # but not a canonical error
+            return
 
         # Make sure this is not just a normal response that happens to contain the
         # `err` or `alarm` keyword in the message body by checking the gcode values

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -1099,7 +1099,9 @@ class GeometryView:
 
                 middle_slot_fixture = (
                     self._addressable_areas.get_fixture_by_deck_slot_name(
-                        DeckSlotName.SLOT_C2
+                        DeckSlotName.SLOT_C2.to_equivalent_for_robot_type(
+                            self._config.robot_type
+                        )
                     )
                 )
                 if middle_slot_fixture is None:


### PR DESCRIPTION
Here are some bugfixes for ot-2 cancelling. See the commits for more details:

- https://github.com/Opentrons/opentrons/commit/f7ed5aab51333117fda3fefaf1d880421f28258b : smoothie responds with only whitespace sometimes, so don't assume we can split() (this caused cancels to fail)
- https://github.com/Opentrons/opentrons/commit/7cc3b6ceb285bb9ce486db26a28542ceb998bce4 : the engine needs to always use machine-agnostic names and can't assume c2 (this caused the protocols to get cancelled)

Closes RQA-4547
Closes RQA-4545

## Testing
- [x] start and cancel a protocol on and ot-2 without getting errors