### PR TITLE
refactor(api): add labware origin calculation context

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/unsafe/unsafe_place_labware.py
+++ b/api/src/opentrons/protocol_engine/commands/unsafe/unsafe_place_labware.py
@@ -20,6 +20,7 @@ from ...types import (
     DeckSlotLocation,
     ModuleModel,
     OnDeckLabwareLocation,
+    GripperMoveType,
 )
 from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
 from ...errors.error_occurrence import ErrorOccurrence
@@ -156,7 +157,9 @@ class UnsafePlaceLabwareImplementation(
         )
 
         to_labware_center = self._state_view.geometry.get_labware_grip_point(
-            labware_definition=labware_definition, location=location
+            labware_definition=labware_definition,
+            location=location,
+            move_type=GripperMoveType.DROP_LABWARE,
         )
 
         movement_waypoints = get_gripper_labware_placement_waypoints(

--- a/api/src/opentrons/protocol_engine/execution/labware_movement.py
+++ b/api/src/opentrons/protocol_engine/execution/labware_movement.py
@@ -31,6 +31,7 @@ from ..types import (
     OnLabwareLocation,
     LabwareLocation,
     OnDeckLabwareLocation,
+    GripperMoveType,
 )
 
 if TYPE_CHECKING:
@@ -141,10 +142,14 @@ class LabwareMovementHandler:
             labware_definition = self._state_store.labware.get_definition(labware_id)
 
         from_labware_center = self._state_store.geometry.get_labware_grip_point(
-            labware_definition=labware_definition, location=current_location
+            labware_definition=labware_definition,
+            location=current_location,
+            move_type=GripperMoveType.PICK_UP_LABWARE,
         )
         to_labware_center = self._state_store.geometry.get_labware_grip_point(
-            labware_definition=labware_definition, location=new_location
+            labware_definition=labware_definition,
+            location=new_location,
+            move_type=GripperMoveType.DROP_LABWARE,
         )
 
         if use_virtual_gripper:

--- a/api/src/opentrons/protocol_engine/state/_labware_origin_math.py
+++ b/api/src/opentrons/protocol_engine/state/_labware_origin_math.py
@@ -1,5 +1,6 @@
 """Utilities for calculating the labware origin offset position."""
 import dataclasses
+import enum
 from typing import Union, overload
 
 from typing_extensions import assert_type
@@ -42,13 +43,60 @@ _LabwareStackupDefinition = Union[
 """Information pertaining to a deck item that is present in a labware stackup."""
 
 
+class LabwareOriginContext(enum.Enum):
+    """Context for labware origin calculations."""
+
+    PIPETTING = enum.auto()
+    GRIPPER_PICKING_UP = enum.auto()
+    GRIPPER_DROPPING = enum.auto()
+
+
 @dataclasses.dataclass
 class _Labware3SupportedParentDefinition:
     features: LocatingFeatures
     extents: Extents
 
 
-def get_stackup_placement_origin_to_lw_origin(
+def get_stackup_origin_to_labware_origin(
+    context: LabwareOriginContext,
+    stackup_lw_info_top_to_bottom: list[tuple[LabwareDefinition, LabwareLocation]],
+    underlying_ancestor_definition: LabwareStackupAncestorDefinition,
+    module_parent_to_child_offset: Union[Point, None],
+    deck_definition: DeckDefinitionV5,
+) -> Point:
+    """Returns the offset from the stackup placement origin to child labware origin.
+
+    Accounts for offset differences caused by consuming context.
+    """
+    if context == LabwareOriginContext.PIPETTING:
+        return _get_stackup_origin_to_lw_origin(
+            stackup_lw_info_top_to_bottom=stackup_lw_info_top_to_bottom,
+            underlying_ancestor_definition=underlying_ancestor_definition,
+            module_parent_to_child_offset=module_parent_to_child_offset,
+            deck_definition=deck_definition,
+        )
+    elif context == LabwareOriginContext.GRIPPER_PICKING_UP:
+        # TODO: Gripper specific offsets will go here.
+        return _get_stackup_origin_to_lw_origin(
+            stackup_lw_info_top_to_bottom=stackup_lw_info_top_to_bottom,
+            underlying_ancestor_definition=underlying_ancestor_definition,
+            module_parent_to_child_offset=module_parent_to_child_offset,
+            deck_definition=deck_definition,
+        )
+    elif context == LabwareOriginContext.GRIPPER_DROPPING:
+        # TODO: Gripper specific offsets will go here.
+        return _get_stackup_origin_to_lw_origin(
+            stackup_lw_info_top_to_bottom=stackup_lw_info_top_to_bottom,
+            underlying_ancestor_definition=underlying_ancestor_definition,
+            module_parent_to_child_offset=module_parent_to_child_offset,
+            deck_definition=deck_definition,
+        )
+
+    else:
+        raise ValueError(f"Unsupported context {context}")
+
+
+def _get_stackup_origin_to_lw_origin(
     stackup_lw_info_top_to_bottom: list[tuple[LabwareDefinition, LabwareLocation]],
     underlying_ancestor_definition: LabwareStackupAncestorDefinition,
     module_parent_to_child_offset: Union[Point, None],
@@ -84,15 +132,12 @@ def get_stackup_placement_origin_to_lw_origin(
         )
         remaining_lw_defs_locs_top_to_bottom = stackup_lw_info_top_to_bottom[1:]
 
-        return (
-            parent_placement_origin_to_lw_origin
-            + get_stackup_placement_origin_to_lw_origin(
-                stackup_lw_info_top_to_bottom=remaining_lw_defs_locs_top_to_bottom,
-                underlying_ancestor_definition=underlying_ancestor_definition,
-                module_parent_to_child_offset=module_parent_to_child_offset,
-                deck_definition=deck_definition,
-                is_topmost_labware=False,
-            )
+        return parent_placement_origin_to_lw_origin + _get_stackup_origin_to_lw_origin(
+            stackup_lw_info_top_to_bottom=remaining_lw_defs_locs_top_to_bottom,
+            underlying_ancestor_definition=underlying_ancestor_definition,
+            module_parent_to_child_offset=module_parent_to_child_offset,
+            deck_definition=deck_definition,
+            is_topmost_labware=False,
         )
     else:
         raise errors.LabwareNotOnDeckError(

--- a/api/src/opentrons/protocol_engine/state/_labware_origin_math.py
+++ b/api/src/opentrons/protocol_engine/state/_labware_origin_math.py
@@ -61,7 +61,7 @@ def get_stackup_origin_to_labware_origin(
     context: LabwareOriginContext,
     stackup_lw_info_top_to_bottom: list[tuple[LabwareDefinition, LabwareLocation]],
     underlying_ancestor_definition: LabwareStackupAncestorDefinition,
-    module_parent_to_child_offset: Union[Point, None],
+    module_parent_to_child_offset: Point | None,
     deck_definition: DeckDefinitionV5,
 ) -> Point:
     """Returns the offset from the stackup placement origin to child labware origin.
@@ -99,7 +99,7 @@ def get_stackup_origin_to_labware_origin(
 def _get_stackup_origin_to_lw_origin(
     stackup_lw_info_top_to_bottom: list[tuple[LabwareDefinition, LabwareLocation]],
     underlying_ancestor_definition: LabwareStackupAncestorDefinition,
-    module_parent_to_child_offset: Union[Point, None],
+    module_parent_to_child_offset: Point | None,
     deck_definition: DeckDefinitionV5,
     is_topmost_labware: bool = True,
 ) -> Point:
@@ -151,7 +151,7 @@ def _get_parent_placement_origin_to_lw_origin_by_location(
     labware_definition: LabwareDefinition,
     parent_definition: _LabwareStackupDefinition,
     deck_definition: DeckDefinitionV5,
-    module_parent_to_child_offset: Union[Point, None],
+    module_parent_to_child_offset: Point | None,
     is_topmost_labware: bool,
 ) -> Point:
     if isinstance(labware_location, ModuleLocation):
@@ -229,7 +229,7 @@ def _get_parent_placement_origin_to_lw_origin(
 def _get_parent_placement_origin_to_lw_origin(
     child_labware: LabwareDefinition,
     parent_deck_item: _LabwareStackupDefinition,
-    module_parent_to_child_offset: Union[Point, None],
+    module_parent_to_child_offset: Point | None,
     deck_definition: DeckDefinitionV5,
     is_topmost_labware: bool,
     labware_location: LabwareLocation,
@@ -314,7 +314,7 @@ def _get_parent_placement_origin_to_lw_origin(
 def _get_parent_deck_item_origin_to_child_labware_placement_origin(
     child_labware: LabwareDefinition,
     parent_deck_item: _LabwareStackupDefinition,
-    module_parent_to_child_offset: Union[Point, None],
+    module_parent_to_child_offset: Point | None,
     deck_definition: DeckDefinitionV5,
     labware_location: LabwareLocation,
 ) -> Point:
@@ -371,7 +371,7 @@ def _get_parent_deck_item_origin_to_child_labware_placement_origin(
 
 
 def _module_parent_to_child_offset(
-    module_parent_to_child_offset: Union[Point, None],
+    module_parent_to_child_offset: Point | None,
     labware_location: LabwareLocation,
 ) -> Point:
     """Returns the module offset if applicable."""

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -93,6 +93,7 @@ from ..types import (
     WellLocationFunction,
     LabwareStackupAncestorDefinition,
     AddressableArea,
+    GripperMoveType,
 )
 from ..types.liquid_level_detection import SimulatedProbeResult, LiquidTrackingType
 from .config import Config
@@ -108,7 +109,10 @@ from .inner_well_math_utils import (
     find_volume_user_defined_volumes,
 )
 from ._well_math import wells_covered_by_pipette_configuration, nozzles_per_well
-from ._labware_origin_math import get_stackup_placement_origin_to_lw_origin
+from ._labware_origin_math import (
+    get_stackup_origin_to_labware_origin,
+    LabwareOriginContext,
+)
 
 _LOG = getLogger(__name__)
 SLOT_WIDTH = 128
@@ -122,13 +126,6 @@ class _TipDropSection(enum.Enum):
 
     LEFT = "left"
     RIGHT = "right"
-
-
-class _GripperMoveType(enum.Enum):
-    """Types of gripper movement."""
-
-    PICK_UP_LABWARE = enum.auto()
-    DROP_LABWARE = enum.auto()
 
 
 @dataclass
@@ -393,7 +390,8 @@ class GeometryView:
             location
         )
 
-        stackup_origin_to_lw_origin = get_stackup_placement_origin_to_lw_origin(
+        stackup_origin_to_lw_origin = get_stackup_origin_to_labware_origin(
+            context=LabwareOriginContext.PIPETTING,
             stackup_lw_info_top_to_bottom=stackup_lw_defs_locs,
             underlying_ancestor_definition=underlying_ancestor_def,
             module_parent_to_child_offset=module_parent_to_child_offset,
@@ -999,6 +997,7 @@ class GeometryView:
         location: Union[
             DeckSlotLocation, ModuleLocation, OnLabwareLocation, AddressableAreaLocation
         ],
+        move_type: GripperMoveType,
     ) -> Point:
         """Get the grip point of the labware as placed on the given location.
 
@@ -1024,8 +1023,13 @@ class GeometryView:
         underlying_ancestor_def = self._get_stackup_underlying_ancestor_definition(
             location
         )
-
-        parent_to_lw_offset = get_stackup_placement_origin_to_lw_origin(
+        context_type = (
+            LabwareOriginContext.GRIPPER_PICKING_UP
+            if move_type == GripperMoveType.PICK_UP_LABWARE
+            else LabwareOriginContext.GRIPPER_DROPPING
+        )
+        parent_to_lw_offset = get_stackup_origin_to_labware_origin(
+            context=context_type,
             module_parent_to_child_offset=module_parent_to_child_offset,
             underlying_ancestor_definition=underlying_ancestor_def,
             stackup_lw_info_top_to_bottom=stackup_defs_locs,
@@ -1355,7 +1359,7 @@ class GeometryView:
         pick_up_offset = (
             self.get_total_nominal_gripper_offset_for_move_type(
                 location=from_location,
-                move_type=_GripperMoveType.PICK_UP_LABWARE,
+                move_type=GripperMoveType.PICK_UP_LABWARE,
                 current_labware=current_labware,
             )
             + additional_pick_up_offset
@@ -1363,7 +1367,7 @@ class GeometryView:
         drop_offset = (
             self.get_total_nominal_gripper_offset_for_move_type(
                 location=to_location,
-                move_type=_GripperMoveType.DROP_LABWARE,
+                move_type=GripperMoveType.DROP_LABWARE,
                 current_labware=current_labware,
             )
             + additional_drop_offset
@@ -1402,11 +1406,11 @@ class GeometryView:
     def get_total_nominal_gripper_offset_for_move_type(
         self,
         location: OnDeckLabwareLocation,
-        move_type: _GripperMoveType,
+        move_type: GripperMoveType,
         current_labware: LabwareDefinition,
     ) -> Point:
         """Get the total of the offsets to be used to pick up labware in its current location."""
-        if move_type == _GripperMoveType.PICK_UP_LABWARE:
+        if move_type == GripperMoveType.PICK_UP_LABWARE:
             if isinstance(
                 location, (ModuleLocation, DeckSlotLocation, AddressableAreaLocation)
             ):

--- a/api/src/opentrons/protocol_engine/types/__init__.py
+++ b/api/src/opentrons/protocol_engine/types/__init__.py
@@ -130,6 +130,7 @@ from .instrument import (
     CurrentWell,
     CurrentPipetteLocation,
     InstrumentOffsetVector,
+    GripperMoveType,
 )
 from .execution import EngineStatus, PostRunHardwareState
 from .liquid_level_detection import (
@@ -282,6 +283,7 @@ __all__ = [
     "CurrentWell",
     "CurrentPipetteLocation",
     "InstrumentOffsetVector",
+    "GripperMoveType",
     # Liquid level detection types
     "LoadedVolumeInfo",
     "ProbedHeightInfo",

--- a/api/src/opentrons/protocol_engine/types/instrument.py
+++ b/api/src/opentrons/protocol_engine/types/instrument.py
@@ -1,5 +1,5 @@
 """Protocol Engine types to do with instruments."""
-
+import enum
 from typing import Union
 
 from dataclasses import dataclass
@@ -45,3 +45,10 @@ class InstrumentOffsetVector(BaseModel):
     x: float
     y: float
     z: float
+
+
+class GripperMoveType(enum.Enum):
+    """Types of gripper movement."""
+
+    PICK_UP_LABWARE = enum.auto()
+    DROP_LABWARE = enum.auto()

--- a/api/tests/opentrons/protocol_engine/execution/test_labware_movement_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_labware_movement_handler.py
@@ -24,6 +24,7 @@ from opentrons.protocol_engine.types import (
     NonStackedLocation,
     LabwareMovementOffsetData,
     Dimensions,
+    GripperMoveType,
 )
 from opentrons.protocol_engine.execution.thermocycler_plate_lifter import (
     ThermocyclerPlateLifter,
@@ -202,12 +203,15 @@ async def test_raise_error_if_gripper_pickup_failed(
         state_store.geometry.get_labware_grip_point(
             labware_definition=sentinel.my_teleporting_labware_def,
             location=starting_location,
+            move_type=GripperMoveType.PICK_UP_LABWARE,
         )
     ).then_return(Point(101, 102, 119.5))
 
     decoy.when(
         state_store.geometry.get_labware_grip_point(
-            labware_definition=sentinel.my_teleporting_labware_def, location=to_location
+            labware_definition=sentinel.my_teleporting_labware_def,
+            location=to_location,
+            move_type=GripperMoveType.DROP_LABWARE,
         )
     ).then_return(Point(201, 202, 219.5))
 
@@ -348,11 +352,14 @@ async def test_move_labware_with_gripper(
         state_store.geometry.get_labware_grip_point(
             labware_definition=sentinel.my_teleporting_labware_def,
             location=from_location,
+            move_type=GripperMoveType.PICK_UP_LABWARE,
         )
     ).then_return(Point(101, 102, 119.5))
     decoy.when(
         state_store.geometry.get_labware_grip_point(
-            labware_definition=sentinel.my_teleporting_labware_def, location=to_location
+            labware_definition=sentinel.my_teleporting_labware_def,
+            location=to_location,
+            move_type=GripperMoveType.DROP_LABWARE,
         )
     ).then_return(Point(201, 202, 219.5))
     mock_tc_context_manager = decoy.mock(name="mock_tc_context_manager")

--- a/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
@@ -97,6 +97,7 @@ from opentrons.protocol_engine.types import (
     AreaType,
     AddressableOffsetVector,
     WellLocationFunction,
+    GripperMoveType,
 )
 from opentrons.protocol_engine.commands import Command
 from opentrons.protocol_engine.actions import (
@@ -125,7 +126,7 @@ from opentrons.protocol_engine.state._axis_aligned_bounding_box import (
     AxisAlignedBoundingBox3D as EngineAABB,
 )
 from opentrons.protocol_engine.state import geometry
-from opentrons.protocol_engine.state.geometry import GeometryView, _GripperMoveType
+from opentrons.protocol_engine.state.geometry import GeometryView
 from opentrons.protocol_engine.state.inner_well_math_utils import (
     _height_from_volume_circular,
     _height_from_volume_rectangular,
@@ -454,7 +455,7 @@ _PARENT_ORIGIN_TO_LABWARE_ORIGIN = Point(x=10, y=20, z=30)
 def mock_labware_origin_math(monkeypatch: pytest.MonkeyPatch) -> None:
     """Mock labware origin math's main export."""
     monkeypatch.setattr(
-        "opentrons.protocol_engine.state.geometry.get_stackup_placement_origin_to_lw_origin",
+        "opentrons.protocol_engine.state.geometry.get_stackup_origin_to_labware_origin",
         lambda *args, **kwargs: _PARENT_ORIGIN_TO_LABWARE_ORIGIN,
     )
 
@@ -959,7 +960,7 @@ def test_get_obstacle_highest_z_with_lid(
     # The labware's highest z is the z dimension of the lid + labware's height
     labware_height = labware_view.get_dimensions(labware_id="labware-id").z
     monkeypatch.setattr(
-        "opentrons.protocol_engine.state.geometry.get_stackup_placement_origin_to_lw_origin",
+        "opentrons.protocol_engine.state.geometry.get_stackup_origin_to_labware_origin",
         lambda *args, **kwargs: Point(10, 20, labware_height),
     )
 
@@ -1695,7 +1696,7 @@ def test_get_well_position_with_center_offset(
 ) -> None:
     """It should be able to get the position of a well center in a labware."""
     monkeypatch.setattr(
-        "opentrons.protocol_engine.state.geometry.get_stackup_placement_origin_to_lw_origin",
+        "opentrons.protocol_engine.state.geometry.get_stackup_origin_to_labware_origin",
         lambda *args, **kwargs: Point(0, 0, 0),
     )
     labware_data = LoadedLabware(
@@ -2279,7 +2280,7 @@ def test_get_relative_well_location(
 ) -> None:
     """It should get the relative location of a well given an absolute position."""
     monkeypatch.setattr(
-        "opentrons.protocol_engine.state.geometry.get_stackup_placement_origin_to_lw_origin",
+        "opentrons.protocol_engine.state.geometry.get_stackup_origin_to_labware_origin",
         lambda *args, **kwargs: Point(0, 0, 0),
     )
     labware_data = LoadedLabware(
@@ -2757,6 +2758,7 @@ def test_get_labware_grip_point_v2_definition(
     labware_center = subject.get_labware_grip_point(
         labware_definition=_MOCK_LABWARE_DEFINITION2,
         location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
+        move_type=GripperMoveType.PICK_UP_LABWARE,
     )
 
     assert labware_center == Point(
@@ -2795,6 +2797,7 @@ def test_get_labware_grip_point_v3_definition(
     labware_center = subject.get_labware_grip_point(
         labware_definition=_MOCK_LABWARE_DEFINITION3,
         location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
+        move_type=GripperMoveType.PICK_UP_LABWARE,
     )
 
     assert labware_center == Point(
@@ -2845,6 +2848,7 @@ def test_get_labware_grip_point_on_labware(
     grip_point = subject.get_labware_grip_point(
         labware_definition=sentinel.definition,
         location=OnLabwareLocation(labwareId="below-id"),
+        move_type=GripperMoveType.PICK_UP_LABWARE,
     )
 
     assert grip_point == Point(
@@ -2933,6 +2937,7 @@ def test_get_labware_grip_point_for_labware_on_module(
     result_grip_point = subject.get_labware_grip_point(
         labware_definition=sentinel.labware_definition,
         location=ModuleLocation(moduleId="module-id"),
+        move_type=GripperMoveType.PICK_UP_LABWARE,
     )
     assert result_grip_point == Point(
         x=492 + _PARENT_ORIGIN_TO_LABWARE_ORIGIN.x + expected_lw_origin_to_parent.x,
@@ -3025,6 +3030,7 @@ def test_get_labware_grip_point_for_labware_stack_on_module(
     result_grip_point = subject.get_labware_grip_point(
         labware_definition=sentinel.labware_definition,
         location=OnLabwareLocation(labwareId="below-id-9"),
+        move_type=GripperMoveType.PICK_UP_LABWARE,
     )
 
     assert result_grip_point == Point(
@@ -3450,7 +3456,7 @@ def test_get_total_nominal_gripper_offset(
     # Case 1: labware on deck
     result1 = subject.get_total_nominal_gripper_offset_for_move_type(
         location=DeckSlotLocation(slotName=DeckSlotName.SLOT_3),
-        move_type=_GripperMoveType.PICK_UP_LABWARE,
+        move_type=GripperMoveType.PICK_UP_LABWARE,
         current_labware=mock_labware_view.get_definition("labware-d"),
     )
     assert result1 == Point(x=1, y=2, z=3)
@@ -3458,7 +3464,7 @@ def test_get_total_nominal_gripper_offset(
     # Case 2: labware on module
     result2 = subject.get_total_nominal_gripper_offset_for_move_type(
         location=ModuleLocation(moduleId="module-id"),
-        move_type=_GripperMoveType.DROP_LABWARE,
+        move_type=GripperMoveType.DROP_LABWARE,
         current_labware=mock_labware_view.get_definition("labware-id"),
     )
     assert result2 == Point(x=33, y=22, z=11)
@@ -3503,14 +3509,14 @@ def test_get_stacked_labware_total_nominal_offset_slot_specific(
     )
     result1 = subject.get_total_nominal_gripper_offset_for_move_type(
         location=OnLabwareLocation(labwareId="adapter-id"),
-        move_type=_GripperMoveType.PICK_UP_LABWARE,
+        move_type=GripperMoveType.PICK_UP_LABWARE,
         current_labware=mock_labware_view.get_definition("labware-id"),
     )
     assert result1 == Point(x=111, y=222, z=333)
 
     result2 = subject.get_total_nominal_gripper_offset_for_move_type(
         location=OnLabwareLocation(labwareId="adapter-id"),
-        move_type=_GripperMoveType.DROP_LABWARE,
+        move_type=GripperMoveType.DROP_LABWARE,
         current_labware=mock_labware_view.get_definition("labware-id"),
     )
     assert result2 == Point(x=333, y=222, z=111)
@@ -3560,14 +3566,14 @@ def test_get_stacked_labware_total_nominal_offset_default(
     )
     result1 = subject.get_total_nominal_gripper_offset_for_move_type(
         location=OnLabwareLocation(labwareId="adapter-id"),
-        move_type=_GripperMoveType.PICK_UP_LABWARE,
+        move_type=GripperMoveType.PICK_UP_LABWARE,
         current_labware=mock_labware_view.get_definition("labware-id"),
     )
     assert result1 == Point(x=111, y=222, z=333)
 
     result2 = subject.get_total_nominal_gripper_offset_for_move_type(
         location=OnLabwareLocation(labwareId="adapter-id"),
-        move_type=_GripperMoveType.DROP_LABWARE,
+        move_type=GripperMoveType.DROP_LABWARE,
         current_labware=mock_labware_view.get_definition("labware-id"),
     )
     assert result2 == Point(x=333, y=222, z=111)

--- a/api/tests/opentrons/protocol_engine/state/test_labware_origin_math.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_origin_math.py
@@ -29,7 +29,8 @@ from opentrons_shared_data.labware.types import (
 
 from opentrons.types import Point
 from opentrons.protocol_engine.state._labware_origin_math import (
-    get_stackup_placement_origin_to_lw_origin,
+    get_stackup_origin_to_labware_origin,
+    LabwareOriginContext,
 )
 from opentrons.protocol_engine.types import (
     ModuleModel,
@@ -452,7 +453,8 @@ def test_get_parent_placement_origin_to_lw_origin_with_module(
     expected_total_offset: Point,
 ) -> None:
     """It should calculate the correct offset from module parent to labware origin."""
-    result = get_stackup_placement_origin_to_lw_origin(
+    result = get_stackup_origin_to_labware_origin(
+        context=LabwareOriginContext.PIPETTING,
         stackup_lw_info_top_to_bottom=[
             (child_definition, labware_location),
         ],
@@ -475,7 +477,8 @@ def test_get_parent_placement_origin_to_lw_origin_with_labware(
     expected_total_offset: Point,
 ) -> None:
     """It should calculate the correct offset from labware parent to labware origin for v2_schema_labware."""
-    result = get_stackup_placement_origin_to_lw_origin(
+    result = get_stackup_origin_to_labware_origin(
+        context=LabwareOriginContext.PIPETTING,
         stackup_lw_info_top_to_bottom=[
             (child_definition, labware_location),
             (
@@ -502,7 +505,8 @@ def test_get_parent_placement_origin_to_lw_origin_with_addressable_area(
     expected_total_offset: Point,
 ) -> None:
     """It should calculate the correct offset from addressable area to labware origin."""
-    result = get_stackup_placement_origin_to_lw_origin(
+    result = get_stackup_origin_to_labware_origin(
+        context=LabwareOriginContext.PIPETTING,
         stackup_lw_info_top_to_bottom=[
             (child_definition, labware_location),
         ],
@@ -525,7 +529,8 @@ def test_get_parent_placement_origin_to_lw_origin_v3_definitions_non_lw(
     expected_total_offset: Point,
 ) -> None:
     """It should handle LabwareDefinition3 correctly with various parent configurations (that are not labware)."""
-    result = get_stackup_placement_origin_to_lw_origin(
+    result = get_stackup_origin_to_labware_origin(
+        context=LabwareOriginContext.PIPETTING,
         stackup_lw_info_top_to_bottom=[
             (child_definition, labware_location),
         ],
@@ -548,7 +553,8 @@ def test_get_parent_placement_origin_to_lw_origin_v3_definitions(
     expected_total_offset: Point,
 ) -> None:
     """It should handle LabwareDefinition3 correctly with various labware configurations."""
-    result = get_stackup_placement_origin_to_lw_origin(
+    result = get_stackup_origin_to_labware_origin(
+        context=LabwareOriginContext.PIPETTING,
         stackup_lw_info_top_to_bottom=[
             (child_definition, labware_location),
             (


### PR DESCRIPTION
Works toward [EXEC-1690](https://opentrons.atlassian.net/browse/EXEC-1690)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

When calculating the stackup origin to the labware origin, the finalized labware origin is dependent on the context in which we utilize the labware origin. For example, when we drop labware in a slot, the labware origin offset is typically "lower" than the default offset, because we want to press the labware into the slot. We need to account for these differences, and we want to do so in our labware origin math API.

Currently, there are three identifiable contexts after auditing the code:

1. Pipetting context. The "default" context in the sense that there are no special offsets that require consideration. It's utilized typically when we move from the labware origin to a well for pipetting purposes.
2. Gripper pick up labware context. When we pick up labware, we apply special gripper pick up offsets.
3. Gripper drop labware context. When we drop labware, we apply special gripper drop offsets.

None of the nuances of those contexts are implemented in this PR. The goal of the PR is to provide the groundwork.

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- CI is sufficient, no functional changes.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests
- Note that the `UnsafePlaceLabware` command doesn't directly provide gripper offsets in the same manner as a typical `MoveLabware` command. I'm not entirely sure how to resolve that as of yet, but I wouldn't want to do so in this PR anyway.
- The goal is to keep `_labware_origin_math.py` only concerned with labware origin math. At this point, I'd expect our public interface to account for _all_ labware origin related calculations (sans the refactor required to move the gripper specific offsets into that interface) and nothing more. If anyone feels that we aren't achieving said goal, this is a good time to address that.
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
none - nothing makes use of those variables.
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[EXEC-1690]: https://opentrons.atlassian.net/browse/EXEC-1690?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ