### PR TITLE
fix(api): cross-platform deck names

### DIFF
--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -1122,7 +1122,9 @@ class GeometryView:
                             "providesAddressableAreas"
                         ][
                             deck_configuration_provider.get_cutout_id_by_deck_slot_name(
-                                DeckSlotName.SLOT_C2
+                                DeckSlotName.SLOT_C2.to_equivalent_for_robot_type(
+                                    self._config.robot_type
+                                )
                             )
                         ][
                             0


### PR DESCRIPTION
Another thermocycler dodging slot problem

Closes RQA-4547

## testing
- [ ] run an ot-2 protocol with a thermocycler in it