### PR TITLE
fix(protocol-designer): remove error track event for Mixpanel

### DIFF
--- a/protocol-designer/index.html
+++ b/protocol-designer/index.html
@@ -1,10 +1,13 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name='viewport' content='width=device-width,initial-scale=1'>
-
-    <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,400i,600,600i,700,700i" rel="stylesheet">
+    <link rel="icon" href="./src/assets/images/favicon.ico" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <link
+      href="https://fonts.googleapis.com/css?family=Open+Sans:400,400i,600,600i,700,700i"
+      rel="stylesheet"
+    />
 
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Opentrons Protocol Designer</title>

--- a/protocol-designer/src/resources/ProtocolDesignerAppFallback.tsx
+++ b/protocol-designer/src/resources/ProtocolDesignerAppFallback.tsx
@@ -15,11 +15,9 @@ import {
   StyledText,
 } from '@opentrons/components'
 
-import { analyticsEvent } from '../analytics/actions'
 import { actions } from '../load-file'
 
 import type { FallbackProps } from 'react-error-boundary'
-import type { AnalyticsEvent } from '../analytics/mixpanel'
 import type { ThunkDispatch } from '../types'
 
 const LOG_LEVEL = 'error'
@@ -30,21 +28,9 @@ export function ProtocolDesignerAppFallback({
 }: FallbackProps): JSX.Element {
   const { t } = useTranslation('shared')
   const dispatch: ThunkDispatch<any> = useDispatch()
-
-  // Note errorId will be used to track a specific user's error
-  // when the support team share the data(screenshot or errorId) with us
   const errorId = uuidv4()
-  const errorEvent: AnalyticsEvent = {
-    name: 'protocolDesignerAppError',
-    properties: {
-      errorId,
-      errorStack: error.stack,
-      errorMessage: error.message,
-    },
-  }
 
   const handleReloadClick = (): void => {
-    dispatch(analyticsEvent(errorEvent))
     resetErrorBoundary()
   }
   const handleDownloadProtocol = (): void => {
@@ -52,7 +38,7 @@ export function ProtocolDesignerAppFallback({
   }
 
   useEffect(() => {
-    if (error) {
+    if (error != null) {
       captureException(error, { extra: { errorId }, level: LOG_LEVEL })
     }
   }, [error, errorId])

--- a/protocol-designer/src/resources/__tests__/ProtocolDesignerAppFallback.test.tsx
+++ b/protocol-designer/src/resources/__tests__/ProtocolDesignerAppFallback.test.tsx
@@ -2,13 +2,10 @@ import { fireEvent, screen } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { renderWithProviders } from '../../__testing-utils__'
-import { analyticsEvent } from '../../analytics/actions'
 import { i18n } from '../../assets/localization'
 import { ProtocolDesignerAppFallback } from '../ProtocolDesignerAppFallback'
 
 import type { FallbackProps } from 'react-error-boundary'
-
-vi.mock('../../analytics/actions')
 
 const mockError = {
   message: 'mock error',
@@ -44,7 +41,6 @@ describe('ProtocolDesignerAppFallback', () => {
   it('should call mock function when clicking the button', () => {
     render(props)
     fireEvent.click(screen.getByText('Reload app'))
-    expect(vi.mocked(analyticsEvent)).toHaveBeenCalled()
     expect(mockFunc).toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
we started using Sentry so we don't need to send an error event to Mixpanel any more.
also thinking about using ErrorBoundary from `sentry/react` instead `react-error-boundary`. (still checking checking Sentry docs)

remove error track event for Mixpanel

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing

<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog

<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
