### PR TITLE
fix(app): deck resolution showing waste chute with stacker when mag block is attached

### DIFF
--- a/shared-data/js/fixtures.ts
+++ b/shared-data/js/fixtures.ts
@@ -1586,15 +1586,23 @@ export const getFlexStackerD3Compatibility = (
   const deckConfigCompatabilityD3 = deckConfigCompatibility?.find(
     configItem => configItem.cutoutId === 'cutoutD3'
   )
-
+  const matchWithAA = getMainFixtureIdForAA(deckConfigCompatabilityD3?.compatibleCutoutFixtureIds ?? [], deckConfigCompatabilityD3?.requiredAddressableAreas ?? [], 'cutoutD3')
+  console.log("matchWithAA: ", matchWithAA)
+  const matchWithFixture = matchWithAA ?? deckConfigCompatabilityD3?.compatibleCutoutFixtureIds[0]
   if (
     deckConfigCompatabilityD3 != null &&
-    (WASTE_CHUTE_FLEX_STACKER_FIXTURES.includes(
-      deckConfigCompatabilityD3?.compatibleCutoutFixtureIds[0]
-    ) ||
+    (
+      matchWithFixture !== undefined &&
       WASTE_CHUTE_FLEX_STACKER_FIXTURES.includes(
-        deckConfigCompatabilityD3?.cutoutFixtureId
-      ))
+        matchWithFixture as CutoutFixtureIdsWithFakes
+      )
+    ) ||
+    (
+      deckConfigCompatabilityD3?.cutoutFixtureId !== undefined &&
+      WASTE_CHUTE_FLEX_STACKER_FIXTURES.includes(
+        deckConfigCompatabilityD3.cutoutFixtureId as CutoutFixtureIdsWithFakes
+      )
+    )
   ) {
     // Convert CutoutFixtureIdsWithFakes to CutoutFixtureId by filtering out fake fixtures
     const comboFixtureId = deckConfigCompatabilityD3?.compatibleCutoutFixtureIds.find(

--- a/shared-data/js/fixtures.ts
+++ b/shared-data/js/fixtures.ts
@@ -1586,23 +1586,24 @@ export const getFlexStackerD3Compatibility = (
   const deckConfigCompatabilityD3 = deckConfigCompatibility?.find(
     configItem => configItem.cutoutId === 'cutoutD3'
   )
-  const matchWithAA = getMainFixtureIdForAA(deckConfigCompatabilityD3?.compatibleCutoutFixtureIds ?? [], deckConfigCompatabilityD3?.requiredAddressableAreas ?? [], 'cutoutD3')
-  console.log("matchWithAA: ", matchWithAA)
-  const matchWithFixture = matchWithAA ?? deckConfigCompatabilityD3?.compatibleCutoutFixtureIds[0]
+  const matchWithAA = getMainFixtureIdForAA(
+    deckConfigCompatabilityD3?.compatibleCutoutFixtureIds ?? [],
+    deckConfigCompatabilityD3?.requiredAddressableAreas ?? [],
+    'cutoutD3'
+  )
+  console.log('matchWithAA: ', matchWithAA)
+  const matchWithFixture =
+    matchWithAA ?? deckConfigCompatabilityD3?.compatibleCutoutFixtureIds[0]
   if (
-    deckConfigCompatabilityD3 != null &&
-    (
+    (deckConfigCompatabilityD3 != null &&
       matchWithFixture !== undefined &&
       WASTE_CHUTE_FLEX_STACKER_FIXTURES.includes(
         matchWithFixture as CutoutFixtureIdsWithFakes
-      )
-    ) ||
-    (
-      deckConfigCompatabilityD3?.cutoutFixtureId !== undefined &&
+      )) ||
+    (deckConfigCompatabilityD3?.cutoutFixtureId !== undefined &&
       WASTE_CHUTE_FLEX_STACKER_FIXTURES.includes(
         deckConfigCompatabilityD3.cutoutFixtureId as CutoutFixtureIdsWithFakes
-      )
-    )
+      ))
   ) {
     // Convert CutoutFixtureIdsWithFakes to CutoutFixtureId by filtering out fake fixtures
     const comboFixtureId = deckConfigCompatabilityD3?.compatibleCutoutFixtureIds.find(


### PR DESCRIPTION
# Overview

small fix for when there is a mag block on deck and flex stacker in the protocol conflicting was showing the waste chute combo

## Changelog

find best match for AA

## Risk assessment

low.
