### PR TITLE
fix(api): Implement Flex Stacker deck conflict checking

### DIFF
--- a/api/src/opentrons/motion_planning/deck_conflict.py
+++ b/api/src/opentrons/motion_planning/deck_conflict.py
@@ -1,4 +1,5 @@
 """Check a deck layout for conflicts."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -97,7 +98,12 @@ class ThermocyclerModule(_Module):
 
 @dataclass
 class OtherModule(_Module):
-    """A module that's not a Heater-Shaker or Thermocycler."""
+    """A module that's not a Heater-Shaker or Thermocycler or stacker."""
+
+
+@dataclass
+class FlexStackerModule(_Module):
+    """A stacker."""
 
 
 DeckItem = Union[
@@ -107,6 +113,7 @@ DeckItem = Union[
     ThermocyclerModule,
     OtherModule,
     TrashBin,
+    FlexStackerModule,
 ]
 
 
@@ -118,6 +125,19 @@ class _NothingAllowed(NamedTuple):
     source_location: Union[DeckSlotName, StagingSlotName]
 
     def is_allowed(self, item: DeckItem) -> bool:
+        return False
+
+
+class _NothingButStackerAllowed(NamedTuple):
+    """Nothing (in the Odyssean sense) is allowed in this slot."""
+
+    location: Union[DeckSlotName, StagingSlotName]
+    source_item: DeckItem
+    source_location: Union[DeckSlotName, StagingSlotName]
+
+    def is_allowed(self, item: DeckItem) -> bool:
+        if isinstance(item, FlexStackerModule):
+            return True
         return False
 
 
@@ -169,6 +189,7 @@ _DeckRestriction = Union[
     _MaxHeight,
     _NoModule,
     _NoHeaterShakerModule,
+    _NothingButStackerAllowed,
 ]
 """A restriction on what is allowed in a given slot."""
 
@@ -296,13 +317,7 @@ def _create_ot2_restrictions(  # noqa: C901
 def _create_flex_restrictions(
     item: DeckItem, location: Union[DeckSlotName, StagingSlotName]
 ) -> List[_DeckRestriction]:
-    restrictions: List[_DeckRestriction] = [
-        _NothingAllowed(
-            location=location,
-            source_item=item,
-            source_location=location,
-        )
-    ]
+    restrictions: List[_DeckRestriction] = []
 
     if isinstance(item, (HeaterShakerModule, OtherModule)):
         if isinstance(location, StagingSlotName):
@@ -321,7 +336,32 @@ def _create_flex_restrictions(
                     source_location=location,
                 )
             )
-
+        restrictions.append(
+            _NothingAllowed(
+                location=location,
+                source_item=item,
+                source_location=location,
+            )
+        )
+    elif isinstance(item, FlexStackerModule):
+        if location not in _flex_slots_allowing_stacker():
+            raise DeckConflictError("Cannot place a Flex Stacker outside of column 3.")
+        # this is a typing assertion; the check above guarantees this is true
+        assert isinstance(location, DeckSlotName)
+        adjacent_staging_slot = get_adjacent_staging_slot(location)
+        # this is a typing assertion; the check above guarantees this isn't none
+        assert adjacent_staging_slot is not None
+        # nothing goes in the staging slot in the row the stacker is in, because the stacker is in the
+        # way (different from blocking you because of the design of the caddy).
+        restrictions.append(
+            _NothingAllowed(
+                location=adjacent_staging_slot,
+                source_item=item,
+                source_location=location,
+            )
+        )
+        # note that the stacker does NOT block use of the "slot" that it is "loaded in" because
+        # it is actually loaded in that cutout, and you can put a deck slot on top just fine
     elif isinstance(item, ThermocyclerModule):
         for covered_location in _flex_slots_covered_by_thermocycler():
             restrictions.append(
@@ -331,6 +371,27 @@ def _create_flex_restrictions(
                     source_location=location,
                 )
             )
+        restrictions.append(
+            _NothingAllowed(
+                location=location,
+                source_item=item,
+                source_location=location,
+            )
+        )
+    elif location in _flex_slots_allowing_stacker():
+        restrictions.append(
+            _NothingButStackerAllowed(
+                location=location,
+                source_item=item,
+                source_location=location,
+            )
+        )
+    else:
+        restrictions.append(
+            _NothingAllowed(
+                location=location, source_item=item, source_location=location
+            )
+        )
 
     return restrictions
 
@@ -388,6 +449,15 @@ def _ot2_slots_covered_by_thermocycler(
 
 def _flex_slots_covered_by_thermocycler() -> Set[DeckSlotName]:
     return {DeckSlotName.SLOT_B1, DeckSlotName.SLOT_A1}
+
+
+def _flex_slots_allowing_stacker() -> Set[DeckSlotName]:
+    return {
+        DeckSlotName.SLOT_A3,
+        DeckSlotName.SLOT_B3,
+        DeckSlotName.SLOT_C3,
+        DeckSlotName.SLOT_D3,
+    }
 
 
 def _is_ot2_fixed_trash(item: DeckItem) -> bool:

--- a/api/src/opentrons/motion_planning/deck_conflict.py
+++ b/api/src/opentrons/motion_planning/deck_conflict.py
@@ -103,7 +103,14 @@ class OtherModule(_Module):
 
 @dataclass
 class FlexStackerModule(_Module):
-    """A stacker."""
+    """A stacker where nothing else is known to be in the "location" in column 3 that it lives."""
+
+
+@dataclass
+class FlexStackerModuleKindaButSomethingElseReally(_Module):
+    """A stacker where something else is also in the "location" in column 3 that it lives."""
+
+    original_item: "DeckItem"
 
 
 DeckItem = Union[
@@ -114,6 +121,7 @@ DeckItem = Union[
     OtherModule,
     TrashBin,
     FlexStackerModule,
+    FlexStackerModuleKindaButSomethingElseReally,
 ]
 
 
@@ -314,7 +322,7 @@ def _create_ot2_restrictions(  # noqa: C901
     return restrictions
 
 
-def _create_flex_restrictions(
+def _create_flex_restrictions(  # noqa: C901
     item: DeckItem, location: Union[DeckSlotName, StagingSlotName]
 ) -> List[_DeckRestriction]:
     restrictions: List[_DeckRestriction] = []
@@ -362,6 +370,33 @@ def _create_flex_restrictions(
         )
         # note that the stacker does NOT block use of the "slot" that it is "loaded in" because
         # it is actually loaded in that cutout, and you can put a deck slot on top just fine
+    elif isinstance(item, FlexStackerModuleKindaButSomethingElseReally):
+        if location not in _flex_slots_allowing_stacker():
+            raise DeckConflictError("Cannot place a Flex Stacker outside of column 3.")
+        # this is a typing assertion; the check above guarantees this is true
+        assert isinstance(location, DeckSlotName)
+        adjacent_staging_slot = get_adjacent_staging_slot(location)
+        assert adjacent_staging_slot is not None
+        # nothing goes in the staging slot in the row the stacker is in, because the stacker is in the
+        # way (different from blocking you because of the design of the caddy).
+        restrictions.append(
+            _NothingAllowed(
+                location=adjacent_staging_slot,
+                source_item=item,
+                source_location=location,
+            )
+        )
+        # while the stacker on its own doesn't block use of the "slot" that it is "loaded in",
+        # the kind of "flex stacker" that actually means "you loaded a labware in column 3 where a
+        # stacker is sort of also "loaded" in column 3" does
+        restrictions.append(
+            _NothingAllowed(
+                location=location,
+                source_item=item.original_item,
+                source_location=location,
+            )
+        )
+
     elif isinstance(item, ThermocyclerModule):
         for covered_location in _flex_slots_covered_by_thermocycler():
             restrictions.append(

--- a/api/src/opentrons/protocol_api/core/engine/deck_conflict.py
+++ b/api/src/opentrons/protocol_api/core/engine/deck_conflict.py
@@ -306,7 +306,7 @@ def _map_module(
     elif module_type == ModuleType.FLEX_STACKER:
         return (
             mapped_location,
-            wrapped_deck_conflict.OtherModule(
+            wrapped_deck_conflict.FlexStackerModule(
                 name_for_errors=name_for_errors,
                 highest_z_including_labware=highest_z_including_labware,
             ),

--- a/api/src/opentrons/protocol_api/core/engine/deck_conflict.py
+++ b/api/src/opentrons/protocol_api/core/engine/deck_conflict.py
@@ -304,8 +304,13 @@ def _map_module(
             ),
         )
     elif module_type == ModuleType.FLEX_STACKER:
-        # TODO: This is a placeholder. We need to implement this.
-        return None
+        return (
+            mapped_location,
+            wrapped_deck_conflict.OtherModule(
+                name_for_errors=name_for_errors,
+                highest_z_including_labware=highest_z_including_labware,
+            ),
+        )
     else:
         return (
             mapped_location,

--- a/api/src/opentrons/protocol_api/core/engine/deck_conflict.py
+++ b/api/src/opentrons/protocol_api/core/engine/deck_conflict.py
@@ -176,14 +176,61 @@ def check(
     for existing_location, existing_item in itertools.chain(
         mapped_existing_labware, mapped_existing_modules, mapped_disposal_locations
     ):
-        assert existing_location not in existing_items
-        existing_items[existing_location] = existing_item
+        if existing_location not in existing_items:
+            existing_items[existing_location] = existing_item
+        else:
+            existing_items[existing_location] = _check_pair_compatibility(
+                existing_items[existing_location], existing_item, existing_location
+            )
 
     wrapped_deck_conflict.check(
         existing_items=existing_items,
         new_item=new_item,
         new_location=new_location,
         robot_type=engine_state.config.robot_type,
+    )
+
+
+def _check_pair_compatibility(
+    item1: wrapped_deck_conflict.DeckItem,
+    item2: wrapped_deck_conflict.DeckItem,
+    location: Union[DeckSlotName, StagingSlotName],
+) -> wrapped_deck_conflict.DeckItem:
+    # if this is a stacker and something that can also "go" where a stacker "goes" (like a labware or magblock)
+    # then we build a combo; otherwise, we raise an error. this error in theory should never happen because to
+    # have the configuration that causes the error, it has to have passed the wrapped deck conflict checking,
+    # so there would be a bug in there, which is of course impossible.
+
+    def _check_pair_compat_once(
+        item1: wrapped_deck_conflict.DeckItem, item2: wrapped_deck_conflict.DeckItem
+    ) -> bool:
+        if isinstance(item1, wrapped_deck_conflict.FlexStackerModule) and isinstance(
+            item2,
+            (wrapped_deck_conflict.MagneticBlockModule, wrapped_deck_conflict.Labware),
+        ):
+            return True
+        return False
+
+    if _check_pair_compat_once(item1, item2) or _check_pair_compat_once(item2, item1):
+        not_stacker = (
+            item1
+            if not isinstance(item1, wrapped_deck_conflict.FlexStackerModule)
+            else item2
+        )
+        # type-only assertion: trash bins are not alowed in _check_pair_compat_once and
+        # so we would never get here
+        assert not isinstance(not_stacker, wrapped_deck_conflict.TrashBin)
+        return wrapped_deck_conflict.FlexStackerModuleKindaButSomethingElseReally(
+            name_for_errors=not_stacker.name_for_errors,
+            highest_z_including_labware=(
+                not_stacker.highest_z
+                if isinstance(not_stacker, wrapped_deck_conflict.Labware)
+                else not_stacker.highest_z_including_labware
+            ),
+            original_item=not_stacker,
+        )
+    raise wrapped_deck_conflict.DeckConflictError(
+        f"{item1.name_for_errors} and {item2.name_for_errors} cannot both be loaded in {location}"
     )
 
 

--- a/api/tests/opentrons/motion_planning/test_deck_conflict.py
+++ b/api/tests/opentrons/motion_planning/test_deck_conflict.py
@@ -1,4 +1,5 @@
 """Tests for opentrons.protocols.geometry.deck_conflict."""
+
 from typing import ContextManager
 from contextlib import nullcontext
 
@@ -641,6 +642,43 @@ def test_no_staging_slot_adjacent_to_module(
     deck_conflict.check(
         existing_items={adjacent_staging_slot: staging_slot_labware},
         new_item=magnetic_block,
+        new_location=deck_slot_name,
+        robot_type="OT-3 Standard",
+    )
+
+
+@pytest.mark.parametrize(
+    ("deck_slot_name",),
+    [
+        (DeckSlotName.SLOT_A3,),
+        (DeckSlotName.SLOT_B3,),
+        (DeckSlotName.SLOT_C3,),
+        (DeckSlotName.SLOT_D3,),
+    ],
+)
+def test_allow_labware_in_stacker_quote_slot_unquote(
+    deck_slot_name: DeckSlotName,
+) -> None:
+    """You should be able to load labware "in" "the same" "slot" as a stacker."""
+    labware = deck_conflict.Labware(
+        uri=LabwareUri("some_labware_uri"),
+        highest_z=123,
+        is_fixed_trash=False,
+        name_for_errors="some_labware",
+    )
+    stacker = deck_conflict.FlexStackerModule(
+        name_for_errors="some_stacker",
+        highest_z_including_labware=123,
+    )
+    deck_conflict.check(
+        existing_items={deck_slot_name: stacker},
+        new_item=labware,
+        new_location=deck_slot_name,
+        robot_type="OT-3 Standard",
+    )
+    deck_conflict.check(
+        existing_items={deck_slot_name: labware},
+        new_item=stacker,
         new_location=deck_slot_name,
         robot_type="OT-3 Standard",
     )

--- a/api/tests/opentrons/protocol_api/core/engine/test_deck_conflict.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_deck_conflict.py
@@ -280,9 +280,6 @@ def test_maps_different_module_models(
     decoy: Decoy, mock_state_view: StateView, module_model: ModuleModel
 ) -> None:
     """It should correctly map all possible kinds of hardware module."""
-    # TODO: skipping flex stacker check for now to enable evt
-    if module_model is ModuleModel.FLEX_STACKER_MODULE_V1:
-        pytest.skip("Flex stacker check not implemented yet")
 
     def get_expected_mapping_result() -> wrapped_deck_conflict.DeckItem:
         expected_name_for_errors = module_model.value
@@ -304,6 +301,11 @@ def test_maps_different_module_models(
                 name_for_errors=expected_name_for_errors,
                 highest_z_including_labware=3.14159,
                 is_semi_configuration=False,
+            )
+        elif module_model is ModuleModel.FLEX_STACKER_MODULE_V1:
+            return wrapped_deck_conflict.OtherModule(
+                name_for_errors=expected_name_for_errors,
+                highest_z_including_labware=3.14159,
             )
         else:
             return wrapped_deck_conflict.OtherModule(

--- a/api/tests/opentrons/protocol_api/core/engine/test_deck_conflict.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_deck_conflict.py
@@ -1,8 +1,9 @@
 """Unit tests for the deck_conflict module."""
 
 import pytest
-from typing import ContextManager, Any, NamedTuple, List, Tuple
-from decoy import Decoy
+import random
+from typing import ContextManager, Any, NamedTuple, List, Tuple, Literal, cast
+from decoy import Decoy, matchers
 from contextlib import nullcontext as does_not_raise
 from opentrons_shared_data.labware.types import LabwareUri
 from opentrons_shared_data.robot.types import RobotType
@@ -407,6 +408,265 @@ def test_maps_trash_bins(
             robot_type=mock_state_view.config.robot_type,
         )
     )
+
+
+def _modules_non_stacker() -> list[ModuleModel]:
+    return [m for m in ModuleModel if not ModuleModel.is_flex_stacker(m)]
+
+
+def _provide_item_in_state(
+    decoy: Decoy,
+    mock_state_view: StateView,
+    mock_sync_client: SyncClient,
+    item_type: Literal["labware", "trash-bin"] | ModuleModel,
+) -> tuple[str | None, str | None, TrashBin | None]:
+    if item_type == "labware":
+        labware_id = f"labware-id-{random.randint(0,10)}"
+        decoy.when(
+            mock_state_view.labware.get_location(labware_id=labware_id)
+        ).then_return(DeckSlotLocation(slotName=DeckSlotName.SLOT_5))
+        decoy.when(
+            mock_state_view.labware.get_load_name(labware_id=labware_id)
+        ).then_return("labware_load_name")
+        decoy.when(
+            mock_state_view.geometry.get_labware_highest_z(labware_id=labware_id)
+        ).then_return(3.14159)
+        decoy.when(
+            mock_state_view.labware.get_definition_uri(labware_id=labware_id)
+        ).then_return(LabwareUri("test/labware_load_name/123"))
+        decoy.when(
+            mock_state_view.labware.is_fixed_trash(labware_id=labware_id)
+        ).then_return(False)
+        return (labware_id, None, None)
+    elif item_type == "trash-bin":
+        decoy.when(
+            mock_sync_client.state.addressable_areas.get_fixture_height(
+                _TRASH_BIN_CUTOUT_FIXTURE
+            )
+        ).then_return(1.23)
+        return (
+            None,
+            None,
+            TrashBin(
+                location=DeckSlotName.SLOT_5,
+                addressable_area_name="blah",
+                engine_client=mock_sync_client,
+                api_version=APIVersion(2, 23),
+            ),
+        )
+    else:
+        module_id = f"module-id-{random.randint(0,10)}"
+        decoy.when(mock_state_view.modules.get_connected_model(module_id)).then_return(
+            item_type
+        )
+        decoy.when(mock_state_view.modules.get_location(module_id)).then_return(
+            DeckSlotLocation(slotName=DeckSlotName.SLOT_5)
+        )
+        return (None, module_id, None)
+
+
+def occupancy_check_state_setup(
+    decoy: Decoy,
+    mock_state_view: StateView,
+    request: pytest.FixtureRequest,
+    mock_sync_client: SyncClient,
+) -> dict[str, Any]:
+    """Set up the current state in the engine occupancy check."""
+    kind = cast(Literal["labware", "trash-bin"] | ModuleModel, request.param)
+    labware_id, module_id, trash_bin = _provide_item_in_state(
+        decoy, mock_state_view, mock_sync_client, kind
+    )
+
+    return {
+        "existing_labware_ids": [labware_id] if labware_id is not None else [],
+        "existing_module_ids": [module_id] if module_id is not None else [],
+        "existing_disposal_locations": [trash_bin] if trash_bin is not None else [],
+    }
+
+
+@pytest.fixture
+def occupancy_check_state_setup1(
+    decoy: Decoy,
+    mock_state_view: StateView,
+    request: pytest.FixtureRequest,
+    mock_sync_client: SyncClient,
+) -> dict[str, Any]:
+    """First preconfigured item in the occupancy check."""
+    return occupancy_check_state_setup(
+        decoy, mock_state_view, request, mock_sync_client
+    )
+
+
+@pytest.fixture
+def occupancy_check_state_setup2(
+    decoy: Decoy,
+    mock_state_view: StateView,
+    request: pytest.FixtureRequest,
+    mock_sync_client: SyncClient,
+) -> dict[str, Any]:
+    """Second preconfigured item in the occupancy check."""
+    return occupancy_check_state_setup(
+        decoy, mock_state_view, request, mock_sync_client
+    )
+
+
+@pytest.fixture
+def occupancy_check_new_item(
+    decoy: Decoy,
+    mock_state_view: StateView,
+    request: pytest.FixtureRequest,
+    mock_sync_client: SyncClient,
+) -> dict[str, Any]:
+    """Set up the engine for the new-item side for the occupancy check."""
+    kind = cast(Literal["labware", "trash-bin"] | ModuleModel, request.param)
+    labware_id, module_id, trash_bin = _provide_item_in_state(
+        decoy, mock_state_view, mock_sync_client, kind
+    )
+    return {
+        "new_labware_id": labware_id,
+        "new_module_id": module_id,
+        "new_trash_bin": trash_bin,
+    }
+
+
+@pytest.mark.parametrize(
+    "occupancy_check_state_setup1",
+    ["labware", "trash-bin"] + _modules_non_stacker(),  # type: ignore[operator]
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "occupancy_check_state_setup2",
+    ["labware", "trash-bin"] + _modules_non_stacker(),  # type: ignore[operator]
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "occupancy_check_new_item",
+    ["labware"],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    ("robot_type", "deck_type"),
+    [
+        ("OT-2 Standard", DeckType.OT2_STANDARD),
+        ("OT-3 Standard", DeckType.OT3_STANDARD),
+    ],
+)
+def test_maps_default_single_occupancy(
+    decoy: Decoy,
+    mock_state_view: StateView,
+    occupancy_check_state_setup1: dict[str, Any],
+    occupancy_check_state_setup2: dict[str, Any],
+    occupancy_check_new_item: dict[str, Any],
+) -> None:
+    """It should correctly prevent double occupancy when a stacker is not involved."""
+    setup = {**occupancy_check_state_setup1}
+    for k, v in occupancy_check_state_setup2.items():
+        setup[k].extend(v)
+    with pytest.raises(
+        wrapped_deck_conflict.DeckConflictError, match="cannot both be loaded in"
+    ):
+        deck_conflict.check(
+            engine_state=mock_state_view,
+            **setup,
+            **occupancy_check_new_item,
+        )
+
+
+@pytest.mark.parametrize(
+    "occupancy_check_state_setup1",
+    [m for m in ModuleModel if ModuleModel.is_flex_stacker(m)],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "occupancy_check_state_setup2",
+    ["labware"] + [m for m in ModuleModel if ModuleModel.is_magnetic_block(m)],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "occupancy_check_new_item",
+    ["labware"],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    ("robot_type", "deck_type"),
+    [
+        ("OT-3 Standard", DeckType.OT3_STANDARD),
+    ],
+)
+def test_maps_allows_stacker_labware_double_occupancy(
+    decoy: Decoy,
+    mock_state_view: StateView,
+    occupancy_check_state_setup1: dict[str, Any],
+    occupancy_check_state_setup2: dict[str, Any],
+    occupancy_check_new_item: dict[str, Any],
+) -> None:
+    """It should correctly allow double occupancy for a stacker and labware or mag block."""
+    decoy.when(
+        wrapped_deck_conflict.check(
+            existing_items=matchers.Anything(),
+            new_item=matchers.Anything(),
+            new_location=matchers.Anything(),
+            robot_type=matchers.Anything(),
+        )
+    ).then_return(None)
+    setup_a = {k: [i for i in v] for k, v in occupancy_check_state_setup1.items()}
+    for k, v in occupancy_check_state_setup2.items():
+        setup_a[k].extend(v)
+    deck_conflict.check(  # type: ignore[call-overload]
+        engine_state=mock_state_view,
+        **setup_a,
+        **occupancy_check_new_item,
+    )
+    setup_b = {k: [i for i in v] for k, v in occupancy_check_state_setup2.items()}
+    for k, v in occupancy_check_state_setup1.items():
+        setup_b[k].extend(v)
+    deck_conflict.check(  # type: ignore[call-overload]
+        engine_state=mock_state_view,
+        **setup_b,
+        **occupancy_check_new_item,
+    )
+
+
+@pytest.mark.parametrize(
+    "occupancy_check_state_setup1",
+    [m for m in ModuleModel if ModuleModel.is_flex_stacker(m)],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "occupancy_check_state_setup2",
+    ["trash-bin"] + [m for m in ModuleModel if not ModuleModel.is_magnetic_block(m)],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "occupancy_check_new_item",
+    ["labware"],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    ("robot_type", "deck_type"),
+    [
+        ("OT-3 Standard", DeckType.OT3_STANDARD),
+    ],
+)
+def test_maps_prevents_stacker_non_labware_double_occupancy(
+    decoy: Decoy,
+    mock_state_view: StateView,
+    occupancy_check_state_setup1: dict[str, Any],
+    occupancy_check_state_setup2: dict[str, Any],
+    occupancy_check_new_item: dict[str, Any],
+) -> None:
+    """It should correctly allow double occupancy for a stacker and labware or mag block."""
+    setup = {**occupancy_check_state_setup1}
+    for k, v in occupancy_check_state_setup2.items():
+        setup[k].extend(v)
+    with pytest.raises(
+        wrapped_deck_conflict.DeckConflictError, match="cannot both be loaded in"
+    ):
+        deck_conflict.check(
+            engine_state=mock_state_view,
+            **setup,
+            **occupancy_check_new_item,
+        )
 
 
 plate = LoadedLabware(

--- a/api/tests/opentrons/protocol_api/core/engine/test_deck_conflict.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_deck_conflict.py
@@ -1,4 +1,5 @@
 """Unit tests for the deck_conflict module."""
+
 import pytest
 from typing import ContextManager, Any, NamedTuple, List, Tuple
 from decoy import Decoy
@@ -303,7 +304,7 @@ def test_maps_different_module_models(
                 is_semi_configuration=False,
             )
         elif module_model is ModuleModel.FLEX_STACKER_MODULE_V1:
-            return wrapped_deck_conflict.OtherModule(
+            return wrapped_deck_conflict.FlexStackerModule(
                 name_for_errors=expected_name_for_errors,
                 highest_z_including_labware=3.14159,
             )

--- a/api/tests/opentrons/protocol_api/core/engine/test_deck_conflict.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_deck_conflict.py
@@ -1,7 +1,6 @@
 """Unit tests for the deck_conflict module."""
 
 import pytest
-import random
 from typing import ContextManager, Any, NamedTuple, List, Tuple, Literal, cast
 from decoy import Decoy, matchers
 from contextlib import nullcontext as does_not_raise
@@ -414,14 +413,20 @@ def _modules_non_stacker() -> list[ModuleModel]:
     return [m for m in ModuleModel if not ModuleModel.is_flex_stacker(m)]
 
 
+_lw_index = 0
+_mod_index = 0
+
+
 def _provide_item_in_state(
     decoy: Decoy,
     mock_state_view: StateView,
     mock_sync_client: SyncClient,
     item_type: Literal["labware", "trash-bin"] | ModuleModel,
 ) -> tuple[str | None, str | None, TrashBin | None]:
+    global _lw_index, _mod_index
     if item_type == "labware":
-        labware_id = f"labware-id-{random.randint(0,10)}"
+        labware_id = f"labware-id-{_lw_index}"
+        _lw_index += 1
         decoy.when(
             mock_state_view.labware.get_location(labware_id=labware_id)
         ).then_return(DeckSlotLocation(slotName=DeckSlotName.SLOT_5))
@@ -455,7 +460,8 @@ def _provide_item_in_state(
             ),
         )
     else:
-        module_id = f"module-id-{random.randint(0,10)}"
+        module_id = f"module-id-{_mod_index}"
+        _mod_index += 1
         decoy.when(mock_state_view.modules.get_connected_model(module_id)).then_return(
             item_type
         )


### PR DESCRIPTION
# Overview
Covers RQA-4539

The deck conflict checker is a circus and we play the role of it's clowns.

We missed implementing the deck conflict checker for the Flex Stacker module, which previously just returned None which proceeded to boot it out of further deck conflict checking. This lead to issues like trash bins being loadable into A3 when a stacker is in A4.

## Test Plan and Hands on Testing
- [x] Implement Unit Test to enforce stacker deck conflict check

- [x] The following protocol should fail analysis with this error: "DeckConflictError [line 20]: flexStackerModuleV1 in slot B3 prevents trash bin from using slot B3."
```
from opentrons.protocol_api import ProtocolContext

metadata = {
    "protocolName": "Flex Stacker Trashbin Error Protocol",
    "author": "Opentrons <protocols@opentrons.com>",
}
requirements = {
    "robotType": "Flex",
    "apiLevel": "2.25",
}
def run(protocol: ProtocolContext) -> None:
    """Protocol."""
    stacker_B = protocol.load_module( "flexStackerModuleV1", "B4")
    stacker_B.set_stored_labware(
        load_name="opentrons_flex_96_tiprack_200ul",
        count=1,
        lid="opentrons_flex_tiprack_lid",
    )

    trash = protocol.load_trash_bin("B3")

    tiprack = stacker_B.retrieve()
    protocol.move_lid(tiprack, trash, use_gripper=True)
```

## Changelog


## Review requests
So we wrap the Flex Stacker conflict errors in the "other module" class, which is correct for now and kind of makes checking for it at all as opposed to just returning under the "else" conditional redundant. Do we want to leave it that way incase in the future we want a more fleshed out stacker conflict error? Or should we just excise it entirely?

## Risk assessment
Low - fixes existing behavior
