### PR TITLE
test(protocol-designer,app): delete screen.debug() to make tests less noisy

### DIFF
--- a/app/src/organisms/Desktop/Devices/__tests__/HistoricalProtocolRun.test.tsx
+++ b/app/src/organisms/Desktop/Devices/__tests__/HistoricalProtocolRun.test.tsx
@@ -60,7 +60,6 @@ describe('RecentProtocolRuns', () => {
 
   it('renders the correct information derived from run and protocol', () => {
     render(props)
-    screen.debug()
     screen.getByText('Completed')
     screen.getByText('mock HistoricalProtocolRunOverflowMenu')
   })

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupModulesAndDeck/__tests__/ProtocolSetupModulesAndDeck.test.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupModulesAndDeck/__tests__/ProtocolSetupModulesAndDeck.test.tsx
@@ -294,7 +294,6 @@ describe('ProtocolSetupModulesAndDeck', () => {
   it('should render ModulesAndDeckMapView when tapping map view button', () => {
     render()
     fireEvent.click(screen.getByText('Map View'))
-    screen.debug()
     expect(vi.mocked(ModulesAndDeckMapView)).toHaveBeenCalled()
   })
 })

--- a/protocol-designer/src/components/organisms/Settings/__tests__/AppInfo.test.tsx
+++ b/protocol-designer/src/components/organisms/Settings/__tests__/AppInfo.test.tsx
@@ -40,7 +40,6 @@ describe('AppInfo', () => {
     const windowOpenButton = screen.getByRole('button', {
       name: 'Software manual',
     })
-    screen.debug(windowOpenButton)
     fireEvent.click(windowOpenButton)
     expect(window.open).toHaveBeenCalledWith(DOC_URL, '_blank')
     screen.getByRole('button', { name: 'Release notes' })


### PR DESCRIPTION
# Overview

We have a couple of `screen.debug()` calls in our tests that print out the React DOM tree. They're kind of distracting when I'm reading the test logs.

## Test Plan and Hands on Testing

Run CI tests.

## Risk assessment

Low: this is a test-only debugging change.