### PR TITLE
refactor(api): handle labware gripper offsets in labware origin math

### DIFF
--- a/api/src/opentrons/motion_planning/waypoints.py
+++ b/api/src/opentrons/motion_planning/waypoints.py
@@ -7,7 +7,6 @@ from opentrons.hardware_control.types import CriticalPoint
 
 from .types import Waypoint, MoveType, GripperMovementWaypointsWithJawStatus
 from .errors import DestinationOutOfBoundsError, ArcOutOfBoundsError
-from ..protocol_engine.types import LabwareMovementOffsetData
 
 DEFAULT_GENERAL_ARC_Z_MARGIN: Final[float] = 10.0
 DEFAULT_IN_LABWARE_ARC_Z_MARGIN: Final[float] = 5.0
@@ -125,47 +124,41 @@ def get_gripper_labware_movement_waypoints(
     from_labware_center: Point,
     to_labware_center: Point,
     gripper_home_z: float,
-    offset_data: LabwareMovementOffsetData,
     post_drop_slide_offset: Optional[Point],
     gripper_home_z_offset: Optional[float] = None,
 ) -> List[GripperMovementWaypointsWithJawStatus]:
     """Get waypoints for moving labware using a gripper."""
-    pick_up_offset = offset_data.pickUpOffset
-    drop_offset = offset_data.dropOffset
-
-    pick_up_location = from_labware_center + Point(
-        pick_up_offset.x, pick_up_offset.y, pick_up_offset.z
-    )
-    drop_location = to_labware_center + Point(
-        drop_offset.x, drop_offset.y, drop_offset.z
-    )
-
     gripper_max_z_home = gripper_home_z - (gripper_home_z_offset or 0)
-
-    post_drop_home_pos = Point(drop_location.x, drop_location.y, gripper_home_z)
+    post_drop_home_pos = Point(to_labware_center.x, to_labware_center.y, gripper_home_z)
 
     waypoints_with_jaw_status = [
         GripperMovementWaypointsWithJawStatus(
-            position=Point(pick_up_location.x, pick_up_location.y, gripper_home_z),
+            position=Point(
+                from_labware_center.x, from_labware_center.y, gripper_home_z
+            ),
             jaw_open=False,
             dropping=False,
         ),
         GripperMovementWaypointsWithJawStatus(
-            position=pick_up_location, jaw_open=True, dropping=False
+            position=from_labware_center, jaw_open=True, dropping=False
         ),
         # Gripper grips the labware here
         GripperMovementWaypointsWithJawStatus(
-            position=Point(pick_up_location.x, pick_up_location.y, gripper_max_z_home),
+            position=Point(
+                from_labware_center.x, from_labware_center.y, gripper_max_z_home
+            ),
             jaw_open=False,
             dropping=False,
         ),
         GripperMovementWaypointsWithJawStatus(
-            position=Point(drop_location.x, drop_location.y, gripper_max_z_home),
+            position=Point(
+                to_labware_center.x, to_labware_center.y, gripper_max_z_home
+            ),
             jaw_open=False,
             dropping=False,
         ),
         GripperMovementWaypointsWithJawStatus(
-            position=drop_location, jaw_open=False, dropping=False
+            position=to_labware_center, jaw_open=False, dropping=False
         ),
         # Gripper ungrips here
         GripperMovementWaypointsWithJawStatus(
@@ -189,25 +182,18 @@ def get_gripper_labware_movement_waypoints(
 def get_gripper_labware_placement_waypoints(
     to_labware_center: Point,
     gripper_home_z: float,
-    drop_offset: Optional[Point],
 ) -> List[GripperMovementWaypointsWithJawStatus]:
     """Get waypoints for placing labware using a gripper."""
-    drop_offset = drop_offset or Point()
-
-    drop_location = to_labware_center + Point(
-        drop_offset.x, drop_offset.y, drop_offset.z
-    )
-
-    post_drop_home_pos = Point(drop_location.x, drop_location.y, gripper_home_z)
+    post_drop_home_pos = Point(to_labware_center.x, to_labware_center.y, gripper_home_z)
 
     return [
         GripperMovementWaypointsWithJawStatus(
-            position=Point(drop_location.x, drop_location.y, gripper_home_z),
+            position=Point(to_labware_center.x, to_labware_center.y, gripper_home_z),
             jaw_open=False,
             dropping=False,
         ),
         GripperMovementWaypointsWithJawStatus(
-            position=drop_location, jaw_open=False, dropping=False
+            position=to_labware_center, jaw_open=False, dropping=False
         ),
         # Gripper ungrips here
         GripperMovementWaypointsWithJawStatus(

--- a/api/src/opentrons/protocol_engine/commands/absorbance_reader/close_lid.py
+++ b/api/src/opentrons/protocol_engine/commands/absorbance_reader/close_lid.py
@@ -102,25 +102,12 @@ class CloseLidImpl(AbstractCommandImpl[CloseLidParams, SuccessData[CloseLidResul
                 )
             )
 
-            # The lid's labware definition stores gripper offsets for itself in the
-            # space normally meant for offsets for labware stacked atop it.
-            lid_gripper_offsets = self._state_view.labware.get_child_gripper_offsets(
-                labware_definition=lid_definition,
-                slot_name=None,
-            )
-            if lid_gripper_offsets is None:
-                raise ValueError(
-                    "Gripper Offset values for Absorbance Reader Lid labware must not be None."
-                )
-
             await self._labware_movement.move_labware_with_gripper(
                 labware_definition=lid_definition,
                 current_location=current_location,
                 new_location=new_location,
-                user_pick_up_offset=Point.from_xyz_attrs(
-                    lid_gripper_offsets.pickUpOffset
-                ),
-                user_drop_offset=Point.from_xyz_attrs(lid_gripper_offsets.dropOffset),
+                user_pick_up_offset=Point(),
+                user_drop_offset=Point(),
                 post_drop_slide_offset=None,
                 gripper_z_offset=LID_Z_CLEARANCE,
             )

--- a/api/src/opentrons/protocol_engine/commands/absorbance_reader/open_lid.py
+++ b/api/src/opentrons/protocol_engine/commands/absorbance_reader/open_lid.py
@@ -103,25 +103,12 @@ class OpenLidImpl(AbstractCommandImpl[OpenLidParams, SuccessData[OpenLidResult]]
                 mod_substate.module_id
             )
 
-            # The lid's labware definition stores gripper offsets for itself in the
-            # space normally meant for offsets for labware stacked atop it.
-            lid_gripper_offsets = self._state_view.labware.get_child_gripper_offsets(
-                labware_definition=lid_definition,
-                slot_name=None,
-            )
-            if lid_gripper_offsets is None:
-                raise ValueError(
-                    "Gripper Offset values for Absorbance Reader Lid labware must not be None."
-                )
-
             await self._labware_movement.move_labware_with_gripper(
                 labware_definition=lid_definition,
                 current_location=current_location,
                 new_location=new_location,
-                user_pick_up_offset=Point.from_xyz_attrs(
-                    lid_gripper_offsets.pickUpOffset
-                ),
-                user_drop_offset=Point.from_xyz_attrs(lid_gripper_offsets.dropOffset),
+                user_pick_up_offset=Point(),
+                user_drop_offset=Point(),
                 post_drop_slide_offset=None,
                 gripper_z_offset=LID_Z_CLEARANCE,
             )

--- a/api/src/opentrons/protocol_engine/commands/unsafe/unsafe_place_labware.py
+++ b/api/src/opentrons/protocol_engine/commands/unsafe/unsafe_place_labware.py
@@ -14,8 +14,6 @@ from opentrons.protocol_engine.errors.exceptions import (
     CannotPerformGripperAction,
     GripperNotAttachedError,
 )
-from opentrons.types import Point
-
 from ...types import (
     DeckSlotLocation,
     ModuleModel,
@@ -101,22 +99,6 @@ class UnsafePlaceLabwareImplementation(
             LabwareUri(params.labwareURI)
         )
 
-        # todo(mm, 2024-11-06): This is only correct in the special case of an
-        # absorbance reader lid. Its definition currently puts the offsets for *itself*
-        # in the property that's normally meant for offsets for its *children.*
-        final_offsets = self._state_view.labware.get_child_gripper_offsets(
-            labware_definition=definition, slot_name=None
-        )
-        drop_offset = (
-            Point(
-                final_offsets.dropOffset.x,
-                final_offsets.dropOffset.y,
-                final_offsets.dropOffset.z,
-            )
-            if final_offsets
-            else None
-        )
-
         if isinstance(params.location, DeckSlotLocation):
             self._state_view.addressable_areas.raise_if_area_not_in_deck_configuration(
                 params.location.slotName.id
@@ -140,7 +122,7 @@ class UnsafePlaceLabwareImplementation(
         await ot3api.update_axis_position_estimations([Axis.X, Axis.Y])
 
         # Place the labware down
-        await self._start_movement(ot3api, definition, location, drop_offset)
+        await self._start_movement(ot3api, definition, location)
 
         return SuccessData(public=UnsafePlaceLabwareResult())
 
@@ -149,7 +131,6 @@ class UnsafePlaceLabwareImplementation(
         ot3api: OT3HardwareControlAPI,
         labware_definition: LabwareDefinition,
         location: OnDeckLabwareLocation,
-        drop_offset: Optional[Point],
     ) -> None:
         gripper_homed_position = await ot3api.gantry_position(
             mount=OT3Mount.GRIPPER,
@@ -160,12 +141,12 @@ class UnsafePlaceLabwareImplementation(
             labware_definition=labware_definition,
             location=location,
             move_type=GripperMoveType.DROP_LABWARE,
+            user_additional_offset=None,
         )
 
         movement_waypoints = get_gripper_labware_placement_waypoints(
             to_labware_center=to_labware_center,
             gripper_home_z=gripper_homed_position.z,
-            drop_offset=drop_offset,
         )
 
         # start movement

--- a/api/src/opentrons/protocol_engine/execution/labware_movement.py
+++ b/api/src/opentrons/protocol_engine/execution/labware_movement.py
@@ -145,11 +145,13 @@ class LabwareMovementHandler:
             labware_definition=labware_definition,
             location=current_location,
             move_type=GripperMoveType.PICK_UP_LABWARE,
+            user_additional_offset=user_pick_up_offset,
         )
         to_labware_center = self._state_store.geometry.get_labware_grip_point(
             labware_definition=labware_definition,
             location=new_location,
             move_type=GripperMoveType.DROP_LABWARE,
+            user_additional_offset=user_drop_offset,
         )
 
         if use_virtual_gripper:
@@ -198,20 +200,10 @@ class LabwareMovementHandler:
         async with self._thermocycler_plate_lifter.lift_plate_for_labware_movement(
             labware_location=current_location
         ):
-            final_offsets = (
-                self._state_store.geometry.get_final_labware_movement_offset_vectors(
-                    from_location=current_location,
-                    to_location=new_location,
-                    additional_pick_up_offset=user_pick_up_offset,
-                    additional_drop_offset=user_drop_offset,
-                    current_labware=labware_definition,
-                )
-            )
             movement_waypoints = get_gripper_labware_movement_waypoints(
                 from_labware_center=from_labware_center,
                 to_labware_center=to_labware_center,
                 gripper_home_z=gripper_homed_position.z,
-                offset_data=final_offsets,
                 post_drop_slide_offset=post_drop_slide_offset,
                 gripper_home_z_offset=gripper_z_offset,
             )

--- a/api/src/opentrons/protocol_engine/state/_labware_origin_math.py
+++ b/api/src/opentrons/protocol_engine/state/_labware_origin_math.py
@@ -1,18 +1,15 @@
 """Utilities for calculating the labware origin offset position."""
 import dataclasses
 import enum
-from typing import Union, overload
+from typing import Union, overload, Optional
 
 from typing_extensions import assert_type
 
-from opentrons.types import Point
+from opentrons.types import Point, DeckSlotName
 from opentrons_shared_data.labware.labware_definition import (
     LabwareDefinition,
     LabwareDefinition2,
     LabwareDefinition3,
-    Extents,
-    AxisAlignedBoundingBox3D,
-    Vector3D,
 )
 from opentrons_shared_data.labware.types import (
     SlotFootprintAsChildFeature,
@@ -20,11 +17,14 @@ from opentrons_shared_data.labware.types import (
     SpringDirectionalForce,
     SlotFootprintAsParentFeature,
 )
+from opentrons.protocol_engine.resources.labware_validation import (
+    validate_definition_is_lid,
+    is_absorbance_reader_lid,
+)
 from opentrons.protocol_engine.types import AddressableArea
 from opentrons_shared_data.deck.types import DeckDefinitionV5, SlotDefV3
 from .. import errors
 from ..types import (
-    LabwareStackupAncestorDefinition,
     ModuleDefinition,
     ModuleModel,
     DeckLocationDefinition,
@@ -33,14 +33,19 @@ from ..types import (
     DeckSlotLocation,
     AddressableAreaLocation,
     OnLabwareLocation,
+    LabwareMovementOffsetData,
+    LabwareOffsetVector,
 )
 
 _OFFSET_ON_TC_OT2 = Point(x=0, y=0, z=10.7)
 
+LabwareStackupAncestorDefinition = Union[
+    DeckLocationDefinition,
+    ModuleDefinition,
+]
 _LabwareStackupDefinition = Union[
     DeckLocationDefinition, ModuleDefinition, LabwareDefinition
 ]
-"""Information pertaining to a deck item that is present in a labware stackup."""
 
 
 class LabwareOriginContext(enum.Enum):
@@ -54,19 +59,25 @@ class LabwareOriginContext(enum.Enum):
 @dataclasses.dataclass
 class _Labware3SupportedParentDefinition:
     features: LocatingFeatures
-    extents: Extents
+
+
+@dataclasses.dataclass
+class _GripperOffsets:
+    pick_up_offset: Point
+    drop_offset: Point
 
 
 def get_stackup_origin_to_labware_origin(
     context: LabwareOriginContext,
     stackup_lw_info_top_to_bottom: list[tuple[LabwareDefinition, LabwareLocation]],
     underlying_ancestor_definition: LabwareStackupAncestorDefinition,
+    slot_name: DeckSlotName,
     module_parent_to_child_offset: Point | None,
     deck_definition: DeckDefinitionV5,
 ) -> Point:
     """Returns the offset from the stackup placement origin to child labware origin.
 
-    Accounts for offset differences caused by consuming context.
+    Accounts for offset differences caused by context.
     """
     if context == LabwareOriginContext.PIPETTING:
         return _get_stackup_origin_to_lw_origin(
@@ -75,25 +86,25 @@ def get_stackup_origin_to_labware_origin(
             module_parent_to_child_offset=module_parent_to_child_offset,
             deck_definition=deck_definition,
         )
-    elif context == LabwareOriginContext.GRIPPER_PICKING_UP:
-        # TODO: Gripper specific offsets will go here.
-        return _get_stackup_origin_to_lw_origin(
+    else:
+        gripper_offsets = _total_nominal_gripper_offsets(
             stackup_lw_info_top_to_bottom=stackup_lw_info_top_to_bottom,
             underlying_ancestor_definition=underlying_ancestor_definition,
-            module_parent_to_child_offset=module_parent_to_child_offset,
+            slot_name=slot_name,
             deck_definition=deck_definition,
         )
-    elif context == LabwareOriginContext.GRIPPER_DROPPING:
-        # TODO: Gripper specific offsets will go here.
-        return _get_stackup_origin_to_lw_origin(
-            stackup_lw_info_top_to_bottom=stackup_lw_info_top_to_bottom,
-            underlying_ancestor_definition=underlying_ancestor_definition,
-            module_parent_to_child_offset=module_parent_to_child_offset,
-            deck_definition=deck_definition,
+        gripper_offset = (
+            gripper_offsets.pick_up_offset
+            if context == LabwareOriginContext.GRIPPER_PICKING_UP
+            else gripper_offsets.drop_offset
         )
 
-    else:
-        raise ValueError(f"Unsupported context {context}")
+        return gripper_offset + _get_stackup_origin_to_lw_origin(
+            stackup_lw_info_top_to_bottom=stackup_lw_info_top_to_bottom,
+            underlying_ancestor_definition=underlying_ancestor_definition,
+            module_parent_to_child_offset=module_parent_to_child_offset,
+            deck_definition=deck_definition,
+        )
 
 
 def _get_stackup_origin_to_lw_origin(
@@ -415,24 +426,12 @@ def _get_standardized_parent_deck_item(
                     **parent_deck_item.features,
                     "slotFootprintAsParent": slot_footprint_as_parent,
                 },
-                extents=parent_deck_item.extents,
             )
         else:
             return _Labware3SupportedParentDefinition(
-                features=parent_deck_item.features, extents=parent_deck_item.extents
+                features=parent_deck_item.features,
             )
     elif isinstance(parent_deck_item, AddressableArea):
-        extents = Extents(
-            total=AxisAlignedBoundingBox3D(
-                backLeftBottom=Vector3D(x=0, y=0, z=0),
-                frontRightTop=Vector3D(
-                    x=parent_deck_item.bounding_box.x,
-                    y=parent_deck_item.bounding_box.y * 1,
-                    z=parent_deck_item.bounding_box.z,
-                ),
-            )
-        )
-
         slot_footprint_as_parent = _aa_slot_footprint_as_parent(parent_deck_item)
         if slot_footprint_as_parent is not None:
             return _Labware3SupportedParentDefinition(
@@ -440,35 +439,23 @@ def _get_standardized_parent_deck_item(
                     **parent_deck_item.features,
                     "slotFootprintAsParent": slot_footprint_as_parent,
                 },
-                extents=extents,
             )
         else:
             return _Labware3SupportedParentDefinition(
-                parent_deck_item.features, extents=extents
+                parent_deck_item.features,
             )
     elif isinstance(parent_deck_item, LabwareDefinition3):
         return _Labware3SupportedParentDefinition(
-            features=parent_deck_item.features, extents=parent_deck_item.extents
+            features=parent_deck_item.features,
         )
     # The slotDefV3 case.
     else:
-        extents = Extents(
-            total=AxisAlignedBoundingBox3D(
-                backLeftBottom=Vector3D(x=0, y=0, z=0),
-                frontRightTop=Vector3D(
-                    x=parent_deck_item["boundingBox"]["xDimension"],
-                    y=parent_deck_item["boundingBox"]["yDimension"] * 1,
-                    z=parent_deck_item["boundingBox"]["zDimension"],
-                ),
-            )
-        )
         slot_footprint_as_parent = _slot_def_slot_footprint_as_parent(parent_deck_item)
         return _Labware3SupportedParentDefinition(
             features={
                 **parent_deck_item["features"],
                 "slotFootprintAsParent": slot_footprint_as_parent,
             },
-            extents=extents,
         )
 
 
@@ -782,3 +769,254 @@ def _get_labware_footprint_as_child(
         )
     else:
         return footprint_as_child
+
+
+def _total_nominal_gripper_offsets(
+    stackup_lw_info_top_to_bottom: list[tuple[LabwareDefinition, LabwareLocation]],
+    slot_name: DeckSlotName,
+    deck_definition: DeckDefinitionV5,
+    underlying_ancestor_definition: LabwareStackupAncestorDefinition,
+) -> _GripperOffsets:
+    """Get the total of the offsets to be used to pick up and drop labware."""
+    top_most_lw_definition, top_most_lw_location = stackup_lw_info_top_to_bottom[0]
+    special_offsets = _get_special_gripper_offsets(
+        stackup_lw_info_top_to_bottom, underlying_ancestor_definition
+    )
+
+    if isinstance(
+        top_most_lw_location,
+        (ModuleLocation, DeckSlotLocation, AddressableAreaLocation),
+    ):
+        offsets = _nominal_gripper_offsets_for_location(
+            labware_location=top_most_lw_location,
+            labware_definition=top_most_lw_definition,
+            slot_name=slot_name,
+            deck_definition=deck_definition,
+            underlying_ancestor_definition=underlying_ancestor_definition,
+        )
+
+        pick_up_offset = Point.from_xyz_attrs(offsets.pickUpOffset)
+        drop_offset = Point.from_xyz_attrs(offsets.dropOffset)
+
+        return _GripperOffsets(
+            pick_up_offset=pick_up_offset + special_offsets.pick_up_offset,
+            drop_offset=drop_offset + special_offsets.drop_offset,
+        )
+    else:
+        # If it's a labware on a labware (most likely an adapter),
+        # we calculate the offset as sum of offsets for the direct parent labware
+        # and the underlying non-labware parent location.
+        direct_parent_def, direct_parent_loc = stackup_lw_info_top_to_bottom[1]
+        direct_parent_offsets = _nominal_gripper_offsets_for_location(
+            labware_location=direct_parent_loc,
+            labware_definition=direct_parent_def,
+            slot_name=slot_name,
+            deck_definition=deck_definition,
+            underlying_ancestor_definition=underlying_ancestor_definition,
+        )
+
+        top_most_offsets = _nominal_gripper_offsets_for_location(
+            labware_location=top_most_lw_location,
+            labware_definition=top_most_lw_definition,
+            slot_name=slot_name,
+            deck_definition=deck_definition,
+            underlying_ancestor_definition=underlying_ancestor_definition,
+        )
+
+        pick_up_offset = Point.from_xyz_attrs(
+            direct_parent_offsets.pickUpOffset
+        ) + Point.from_xyz_attrs(top_most_offsets.pickUpOffset)
+        drop_offset = Point.from_xyz_attrs(
+            direct_parent_offsets.dropOffset
+        ) + Point.from_xyz_attrs(top_most_offsets.dropOffset)
+
+        return _GripperOffsets(
+            pick_up_offset=pick_up_offset + special_offsets.pick_up_offset,
+            drop_offset=drop_offset + special_offsets.drop_offset,
+        )
+
+
+# TODO(jh, 08-15-25): Return _GripperOffsets instead of LabwareMovementOffsetData.
+def _nominal_gripper_offsets_for_location(
+    labware_location: LabwareLocation,
+    labware_definition: LabwareDefinition,
+    slot_name: DeckSlotName,
+    deck_definition: DeckDefinitionV5,
+    underlying_ancestor_definition: LabwareStackupAncestorDefinition,
+) -> LabwareMovementOffsetData:
+    """Provide the default gripper offset data for the given location type."""
+    if isinstance(labware_location, (DeckSlotLocation, AddressableAreaLocation)):
+        offsets = _get_deck_default_gripper_offsets(deck_definition)
+    elif isinstance(labware_location, ModuleLocation):
+        offsets = _get_module_default_gripper_offsets(underlying_ancestor_definition)  # type: ignore[arg-type]
+    else:
+        offsets = _labware_gripper_offsets(
+            top_most_lw_definition=labware_definition, slot_name=slot_name
+        )
+    return offsets or LabwareMovementOffsetData(
+        pickUpOffset=LabwareOffsetVector(x=0, y=0, z=0),
+        dropOffset=LabwareOffsetVector(x=0, y=0, z=0),
+    )
+
+
+def _get_deck_default_gripper_offsets(
+    deck_definition: DeckDefinitionV5,
+) -> Optional[LabwareMovementOffsetData]:
+    """Get the deck's default gripper offsets."""
+    parsed_offsets = deck_definition.get("gripperOffsets", {}).get("default")
+    return (
+        LabwareMovementOffsetData(
+            pickUpOffset=LabwareOffsetVector(
+                x=parsed_offsets["pickUpOffset"]["x"],
+                y=parsed_offsets["pickUpOffset"]["y"],
+                z=parsed_offsets["pickUpOffset"]["z"],
+            ),
+            dropOffset=LabwareOffsetVector(
+                x=parsed_offsets["dropOffset"]["x"],
+                y=parsed_offsets["dropOffset"]["y"],
+                z=parsed_offsets["dropOffset"]["z"],
+            ),
+        )
+        if parsed_offsets
+        else None
+    )
+
+
+def _get_module_default_gripper_offsets(
+    module_definition: ModuleDefinition,
+) -> Optional[LabwareMovementOffsetData]:
+    """Get the deck's default gripper offsets."""
+    offsets = module_definition.gripperOffsets
+    return offsets.get("default") if offsets else None
+
+
+def _labware_gripper_offsets(
+    top_most_lw_definition: LabwareDefinition, slot_name: DeckSlotName
+) -> Optional[LabwareMovementOffsetData]:
+    """Provide the most appropriate gripper offset data for the specified labware.
+
+    We check the types of gripper offsets available for the labware ("default" or slot-based)
+    and return the most appropriate one for the overall location of the labware.
+    Currently, only module adapters (specifically, the H/S universal flat adapter)
+    have non-default offsets that are specific to location of the module on deck,
+    so, this code only checks for the presence of those known offsets.
+    """
+    slot_based_offset = _get_child_gripper_offsets(
+        top_most_lw_definition=top_most_lw_definition, slot_name=slot_name
+    )
+    return slot_based_offset or _get_child_gripper_offsets(
+        top_most_lw_definition=top_most_lw_definition, slot_name=None
+    )
+
+
+def _get_child_gripper_offsets(
+    top_most_lw_definition: LabwareDefinition,
+    slot_name: DeckSlotName | None,
+) -> Optional[LabwareMovementOffsetData]:
+    """Get the grip offsets that a labware says should be applied to children stacked atop it.
+
+    If `slot_name` is provided, returns the gripper offsets that the parent labware definition
+    specifies just for that slot, or `None` if the labware definition doesn't have an
+    exact match.
+
+    If `slot_name` is `None`, returns the gripper offsets that the parent labware
+    definition designates as "default," or `None` if it doesn't designate any as such.
+    """
+    parsed_offsets = top_most_lw_definition.gripperOffsets
+    offset_key = slot_name.id if slot_name else "default"
+
+    if parsed_offsets is None or offset_key not in parsed_offsets:
+        return None
+    else:
+        return LabwareMovementOffsetData(
+            pickUpOffset=LabwareOffsetVector.model_construct(
+                x=parsed_offsets[offset_key].pickUpOffset.x,
+                y=parsed_offsets[offset_key].pickUpOffset.y,
+                z=parsed_offsets[offset_key].pickUpOffset.z,
+            ),
+            dropOffset=LabwareOffsetVector.model_construct(
+                x=parsed_offsets[offset_key].dropOffset.x,
+                y=parsed_offsets[offset_key].dropOffset.y,
+                z=parsed_offsets[offset_key].dropOffset.z,
+            ),
+        )
+
+
+def _get_special_gripper_offsets(
+    stackup_lw_info_top_to_bottom: list[tuple[LabwareDefinition, LabwareLocation]],
+    underlying_ancestor_definition: LabwareStackupAncestorDefinition,
+) -> _GripperOffsets:
+    """Handles all special-cased gripper offsets."""
+    tc_lid_offsets = (
+        _get_tc_lid_gripper_offsets(
+            stackup_lw_info_top_to_bottom, underlying_ancestor_definition
+        )
+    ) or _GripperOffsets(drop_offset=Point(), pick_up_offset=Point())
+
+    ar_lid_offsets = (
+        _get_absorbance_reader_lid_gripper_offsets(stackup_lw_info_top_to_bottom)
+    ) or _GripperOffsets(drop_offset=Point(), pick_up_offset=Point())
+
+    return _GripperOffsets(
+        pick_up_offset=tc_lid_offsets.pick_up_offset + ar_lid_offsets.pick_up_offset,
+        drop_offset=tc_lid_offsets.pick_up_offset + ar_lid_offsets.drop_offset,
+    )
+
+
+def _get_tc_lid_gripper_offsets(
+    stackup_lw_info_top_to_bottom: list[tuple[LabwareDefinition, LabwareLocation]],
+    underlying_ancestor_definition: LabwareStackupAncestorDefinition,
+) -> _GripperOffsets | None:
+    top_most_lw_def, top_most_lw_loc = stackup_lw_info_top_to_bottom[0]
+
+    if isinstance(top_most_lw_loc, OnLabwareLocation):
+        bottom_most_lw_location = stackup_lw_info_top_to_bottom[-1][1]
+
+        # This is done as a workaround for some TC geometry inaccuracies.
+        # See PLAT-579 for context.
+        if (
+            isinstance(bottom_most_lw_location, ModuleLocation)
+            and getattr(underlying_ancestor_definition, "model", None)
+            == ModuleModel.THERMOCYCLER_MODULE_V2
+            and validate_definition_is_lid(top_most_lw_def)
+        ):
+            # It is intentional to use the `pickUpOffset` in both the gripper pick up and drop cases.
+            if "lidOffsets" in top_most_lw_def.gripperOffsets.keys():
+                offset = Point(
+                    x=top_most_lw_def.gripperOffsets["lidOffsets"].pickUpOffset.x,
+                    y=top_most_lw_def.gripperOffsets["lidOffsets"].pickUpOffset.y,
+                    z=top_most_lw_def.gripperOffsets["lidOffsets"].pickUpOffset.z,
+                )
+                return _GripperOffsets(pick_up_offset=offset, drop_offset=offset)
+            else:
+                raise errors.LabwareOffsetDoesNotExistError(
+                    f"Labware Definition {top_most_lw_def.parameters.loadName} does not contain required field 'lidOffsets' of 'gripperOffsets'."
+                )
+
+    return None
+
+
+def _get_absorbance_reader_lid_gripper_offsets(
+    stackup_lw_info_top_to_bottom: list[tuple[LabwareDefinition, LabwareLocation]],
+) -> _GripperOffsets | None:
+    top_most_lw_definition = stackup_lw_info_top_to_bottom[0][0]
+    load_name = top_most_lw_definition.parameters.loadName
+
+    if is_absorbance_reader_lid(load_name):
+        # todo(mm, 2024-11-06): This is only correct in the special case of an
+        # absorbance reader lid. Its definition currently puts the offsets for *itself*
+        # in the property that's normally meant for offsets for its *children.*
+        offsets = _get_child_gripper_offsets(top_most_lw_definition, slot_name=None)
+
+        if offsets is None:
+            raise ValueError(
+                "Expected gripper offsets for absorbance reader lid to be defined."
+            )
+        else:
+            return _GripperOffsets(
+                pick_up_offset=Point.from_xyz_attrs(offsets.pickUpOffset),
+                drop_offset=Point.from_xyz_attrs(offsets.dropOffset),
+            )
+
+    else:
+        return None

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -375,7 +375,12 @@ class GeometryView:
         location = self._labware.get(labware_id).location
         definition = self._labware.get_definition(labware_id)
         aa_name = self._get_underlying_addressable_area_name(location)
-        addressable_area = self._addressable_areas.get_addressable_area(aa_name)
+        # TODO(jh, 08-18-25): Labware locations return the underlying slot as the "on location" for the fixed trash,
+        #  but the underlying slot's name does not exist in addressable area state. Getting the addressable area from data is
+        #  a workaround. Investigate further.
+        addressable_area = self._addressable_areas._get_addressable_area_from_deck_data(
+            aa_name, do_compatibility_check=False
+        )
         stackup_lw_defs_locs = self._get_stackup_lw_info_top_to_bottom(
             labware_definition=definition, location=location
         )

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -44,7 +44,6 @@ from ..errors.exceptions import (
 )
 from ..resources import (
     fixture_validation,
-    labware_validation,
     deck_configuration_provider,
 )
 from ..types import (
@@ -63,12 +62,10 @@ from ..types import (
     ModuleLocation,
     OnLabwareLocation,
     LabwareLocation,
-    LabwareOffsetVector,
     ModuleOffsetData,
     CurrentWell,
     CurrentPipetteLocation,
     TipGeometry,
-    LabwareMovementOffsetData,
     InStackerHopperLocation,
     OnDeckLabwareLocation,
     AddressableAreaLocation,
@@ -79,7 +76,6 @@ from ..types import (
     OnAddressableAreaOffsetLocationSequenceComponent,
     OnLabwareOffsetLocationSequenceComponent,
     OnLabwareLocationSequenceComponent,
-    ModuleModel,
     PotentialCutoutFixture,
     LabwareLocationSequence,
     OnModuleLocationSequenceComponent,
@@ -91,7 +87,6 @@ from ..types import (
     labware_location_is_system,
     WellLocationType,
     WellLocationFunction,
-    LabwareStackupAncestorDefinition,
     AddressableArea,
     GripperMoveType,
 )
@@ -112,6 +107,7 @@ from ._well_math import wells_covered_by_pipette_configuration, nozzles_per_well
 from ._labware_origin_math import (
     get_stackup_origin_to_labware_origin,
     LabwareOriginContext,
+    LabwareStackupAncestorDefinition,
 )
 
 _LOG = getLogger(__name__)
@@ -378,8 +374,8 @@ class GeometryView:
         """
         location = self._labware.get(labware_id).location
         definition = self._labware.get_definition(labware_id)
-
-        ancestor_pos = self._get_labware_ancestor_position(labware_id)
+        aa_name = self._get_underlying_addressable_area_name(location)
+        addressable_area = self._addressable_areas.get_addressable_area(aa_name)
         stackup_lw_defs_locs = self._get_stackup_lw_info_top_to_bottom(
             labware_definition=definition, location=location
         )
@@ -390,25 +386,18 @@ class GeometryView:
             location
         )
 
+        slot_front_left = self._addressable_areas.get_addressable_area_position(aa_name)
         stackup_origin_to_lw_origin = get_stackup_origin_to_labware_origin(
             context=LabwareOriginContext.PIPETTING,
             stackup_lw_info_top_to_bottom=stackup_lw_defs_locs,
             underlying_ancestor_definition=underlying_ancestor_def,
             module_parent_to_child_offset=module_parent_to_child_offset,
             deck_definition=self._addressable_areas.deck_definition,
+            slot_name=addressable_area.base_slot,
         )
         module_cal_offset = self._get_calibrated_module_offset(location)
 
-        return ancestor_pos + stackup_origin_to_lw_origin + module_cal_offset
-
-    def _get_labware_ancestor_position(self, labware_id: str) -> Point:
-        """Get the position of the labware's underlying ancestor."""
-        slot_name = self._get_underlying_addressable_area_name(
-            self._labware.get(labware_id).location
-        )
-        parent_pos = self._addressable_areas.get_addressable_area_position(slot_name)
-
-        return parent_pos
+        return slot_front_left + stackup_origin_to_lw_origin + module_cal_offset
 
     def _get_stackup_lw_info_top_to_bottom(
         self, labware_definition: LabwareDefinition, location: LabwareLocation
@@ -998,6 +987,7 @@ class GeometryView:
             DeckSlotLocation, ModuleLocation, OnLabwareLocation, AddressableAreaLocation
         ],
         move_type: GripperMoveType,
+        user_additional_offset: Point | None,
     ) -> Point:
         """Get the grip point of the labware as placed on the given location.
 
@@ -1009,10 +999,8 @@ class GeometryView:
         It is calculated as the xy center of the slot with z as the point indicated by
         z-position of labware bottom + grip height from labware bottom.
         """
-        grip_z_from_lw_origin = self._labware.get_grip_z(
-            labware_definition
-        )  # Moved into the labware origin for gripper context
         aa_name = self._get_underlying_addressable_area_name(location)
+        addressable_area = self._addressable_areas.get_addressable_area(aa_name)
 
         stackup_defs_locs = self._get_stackup_lw_info_top_to_bottom(
             labware_definition=labware_definition, location=location
@@ -1028,26 +1016,30 @@ class GeometryView:
             if move_type == GripperMoveType.PICK_UP_LABWARE
             else LabwareOriginContext.GRIPPER_DROPPING
         )
-        parent_to_lw_offset = get_stackup_origin_to_labware_origin(
+
+        stackup_placement_origin_to_lw_origin = get_stackup_origin_to_labware_origin(
             context=context_type,
             module_parent_to_child_offset=module_parent_to_child_offset,
             underlying_ancestor_definition=underlying_ancestor_def,
             stackup_lw_info_top_to_bottom=stackup_defs_locs,
+            slot_name=addressable_area.base_slot,
             deck_definition=self._addressable_areas.deck_definition,
         )
-        addressable_area = self._addressable_areas.get_addressable_area(aa_name)
-        lw_origin_to_parent = self._get_lw_origin_to_parent(
+        lw_origin_to_stackup_placement_origin = self._get_lw_origin_to_parent(
             labware_definition=labware_definition, addressable_area=addressable_area
         )
         mod_cal_offset = self._get_calibrated_module_offset(location)
         location_center = self._addressable_areas.get_addressable_area_center(aa_name)
+        grip_z_from_lw_origin = self._labware.get_grip_z(labware_definition)
+        user_additional_offset = user_additional_offset or Point()
 
         return (
             location_center
-            + parent_to_lw_offset
-            + lw_origin_to_parent
+            + stackup_placement_origin_to_lw_origin
+            + lw_origin_to_stackup_placement_origin
             + mod_cal_offset
             + Point(0, 0, grip_z_from_lw_origin)
+            + user_additional_offset
         )
 
     def _get_lw_origin_to_parent(
@@ -1347,41 +1339,6 @@ class GeometryView:
                     x_well_offset = 0
         return x_well_offset
 
-    def get_final_labware_movement_offset_vectors(
-        self,
-        from_location: OnDeckLabwareLocation,
-        to_location: OnDeckLabwareLocation,
-        additional_pick_up_offset: Point,
-        additional_drop_offset: Point,
-        current_labware: LabwareDefinition,
-    ) -> LabwareMovementOffsetData:
-        """Calculate the final labware offset vector to use in labware movement."""
-        pick_up_offset = (
-            self.get_total_nominal_gripper_offset_for_move_type(
-                location=from_location,
-                move_type=GripperMoveType.PICK_UP_LABWARE,
-                current_labware=current_labware,
-            )
-            + additional_pick_up_offset
-        )
-        drop_offset = (
-            self.get_total_nominal_gripper_offset_for_move_type(
-                location=to_location,
-                move_type=GripperMoveType.DROP_LABWARE,
-                current_labware=current_labware,
-            )
-            + additional_drop_offset
-        )
-
-        return LabwareMovementOffsetData(
-            pickUpOffset=LabwareOffsetVector(
-                x=pick_up_offset.x, y=pick_up_offset.y, z=pick_up_offset.z
-            ),
-            dropOffset=LabwareOffsetVector(
-                x=drop_offset.x, y=drop_offset.y, z=drop_offset.z
-            ),
-        )
-
     @staticmethod
     def ensure_valid_gripper_location(
         location: LabwareLocation,
@@ -1402,130 +1359,6 @@ class GeometryView:
                 "Off-deck labware movements are not supported using the gripper."
             )
         return location
-
-    def get_total_nominal_gripper_offset_for_move_type(
-        self,
-        location: OnDeckLabwareLocation,
-        move_type: GripperMoveType,
-        current_labware: LabwareDefinition,
-    ) -> Point:
-        """Get the total of the offsets to be used to pick up labware in its current location."""
-        if move_type == GripperMoveType.PICK_UP_LABWARE:
-            if isinstance(
-                location, (ModuleLocation, DeckSlotLocation, AddressableAreaLocation)
-            ):
-                return Point.from_xyz_attrs(
-                    self._nominal_gripper_offsets_for_location(location).pickUpOffset
-                )
-            else:
-                # If it's a labware on a labware (most likely an adapter),
-                # we calculate the offset as sum of offsets for the direct parent labware
-                # and the underlying non-labware parent location.
-                direct_parent_offset = self._nominal_gripper_offsets_for_location(
-                    location
-                )
-                ancestor = self._labware.get_parent_location(location.labwareId)
-                extra_offset = Point(x=0, y=0, z=0)
-                if (
-                    isinstance(ancestor, ModuleLocation)
-                    # todo(mm, 2025-06-20): Avoid this private attribute access.
-                    and self._modules._state.requested_model_by_id[ancestor.moduleId]
-                    == ModuleModel.THERMOCYCLER_MODULE_V2
-                    and labware_validation.validate_definition_is_lid(current_labware)
-                ):
-                    if "lidOffsets" in current_labware.gripperOffsets.keys():
-                        extra_offset = Point(
-                            x=current_labware.gripperOffsets[
-                                "lidOffsets"
-                            ].pickUpOffset.x,
-                            y=current_labware.gripperOffsets[
-                                "lidOffsets"
-                            ].pickUpOffset.y,
-                            z=current_labware.gripperOffsets[
-                                "lidOffsets"
-                            ].pickUpOffset.z,
-                        )
-                    else:
-                        raise errors.LabwareOffsetDoesNotExistError(
-                            f"Labware Definition {current_labware.parameters.loadName} does not contain required field 'lidOffsets' of 'gripperOffsets'."
-                        )
-
-                assert isinstance(
-                    ancestor,
-                    (
-                        DeckSlotLocation,
-                        ModuleLocation,
-                        OnLabwareLocation,
-                        AddressableAreaLocation,
-                    ),
-                ), "No gripper offsets for off-deck labware"
-                return (
-                    Point.from_xyz_attrs(direct_parent_offset.pickUpOffset)
-                    + Point.from_xyz_attrs(
-                        self._nominal_gripper_offsets_for_location(
-                            location=ancestor
-                        ).pickUpOffset
-                    )
-                    + extra_offset
-                )
-        else:
-            if isinstance(
-                location, (ModuleLocation, DeckSlotLocation, AddressableAreaLocation)
-            ):
-                return Point.from_xyz_attrs(
-                    self._nominal_gripper_offsets_for_location(location).dropOffset
-                )
-            else:
-                # If it's a labware on a labware (most likely an adapter),
-                # we calculate the offset as sum of offsets for the direct parent labware
-                # and the underlying non-labware parent location.
-                direct_parent_offset = self._nominal_gripper_offsets_for_location(
-                    location
-                )
-                ancestor = self._labware.get_parent_location(location.labwareId)
-                extra_offset = Point(x=0, y=0, z=0)
-                if (
-                    isinstance(ancestor, ModuleLocation)
-                    # todo(mm, 2024-11-06): Do not access private module state; only use public ModuleView methods.
-                    and self._modules._state.requested_model_by_id[ancestor.moduleId]
-                    == ModuleModel.THERMOCYCLER_MODULE_V2
-                    and labware_validation.validate_definition_is_lid(current_labware)
-                ):
-                    if "lidOffsets" in current_labware.gripperOffsets.keys():
-                        extra_offset = Point(
-                            x=current_labware.gripperOffsets[
-                                "lidOffsets"
-                            ].pickUpOffset.x,
-                            y=current_labware.gripperOffsets[
-                                "lidOffsets"
-                            ].pickUpOffset.y,
-                            z=current_labware.gripperOffsets[
-                                "lidOffsets"
-                            ].pickUpOffset.z,
-                        )
-                    else:
-                        raise errors.LabwareOffsetDoesNotExistError(
-                            f"Labware Definition {current_labware.parameters.loadName} does not contain required field 'lidOffsets' of 'gripperOffsets'."
-                        )
-
-                assert isinstance(
-                    ancestor,
-                    (
-                        DeckSlotLocation,
-                        ModuleLocation,
-                        OnLabwareLocation,
-                        AddressableAreaLocation,
-                    ),
-                ), "No gripper offsets for off-deck labware"
-                return (
-                    Point.from_xyz_attrs(direct_parent_offset.dropOffset)
-                    + Point.from_xyz_attrs(
-                        self._nominal_gripper_offsets_for_location(
-                            location=ancestor
-                        ).dropOffset
-                    )
-                    + extra_offset
-                )
 
     # todo(mm, 2024-11-05): This may be incorrect because it does not take the following
     # offsets into account, which *are* taken into account for the actual gripper movement:
@@ -1577,64 +1410,6 @@ class GeometryView:
                 raise LabwareMovementNotAllowedError(
                     f"Cannot move labware '{labware_definition.parameters.loadName}' when {int(tip.volume)} µL tips are attached."
                 )
-
-    def _nominal_gripper_offsets_for_location(
-        self, location: OnDeckLabwareLocation
-    ) -> LabwareMovementOffsetData:
-        """Provide the default gripper offset data for the given location type."""
-        if isinstance(location, (DeckSlotLocation, AddressableAreaLocation)):
-            # TODO we might need a separate type of gripper offset for addressable areas but that also might just
-            #   be covered by the drop labware offset/location
-            offsets = self._labware.get_deck_default_gripper_offsets()
-        elif isinstance(location, ModuleLocation):
-            offsets = self._modules.get_default_gripper_offsets(location.moduleId)
-        else:
-            # Labware is on a labware/adapter
-            offsets = self._labware_gripper_offsets(location.labwareId)
-        return offsets or LabwareMovementOffsetData(
-            pickUpOffset=LabwareOffsetVector(x=0, y=0, z=0),
-            dropOffset=LabwareOffsetVector(x=0, y=0, z=0),
-        )
-
-    def _labware_gripper_offsets(
-        self, labware_id: str
-    ) -> Optional[LabwareMovementOffsetData]:
-        """Provide the most appropriate gripper offset data for the specified labware.
-
-        We check the types of gripper offsets available for the labware ("default" or slot-based)
-        and return the most appropriate one for the overall location of the labware.
-        Currently, only module adapters (specifically, the H/S universal flat adapter)
-        have non-default offsets that are specific to location of the module on deck,
-        so, this code only checks for the presence of those known offsets.
-        """
-        parent_location = self._labware.get_parent_location(labware_id)
-        assert isinstance(
-            parent_location,
-            (
-                DeckSlotLocation,
-                ModuleLocation,
-                AddressableAreaLocation,
-                OnLabwareLocation,
-            ),
-        ), "No gripper offsets for off-deck labware"
-
-        if isinstance(parent_location, DeckSlotLocation):
-            slot_name = parent_location.slotName
-        elif isinstance(parent_location, AddressableAreaLocation):
-            slot_name = self._addressable_areas.get_addressable_area_base_slot(
-                parent_location.addressableAreaName
-            )
-        else:
-            module_loc = self._modules.get_location(parent_location.moduleId)
-            slot_name = module_loc.slotName
-
-        slot_based_offset = self._labware.get_child_gripper_offsets(
-            labware_id=labware_id, slot_name=slot_name.to_ot3_equivalent()
-        )
-
-        return slot_based_offset or self._labware.get_child_gripper_offsets(
-            labware_id=labware_id, slot_name=None
-        )
 
     def get_location_sequence(self, labware_id: str) -> LabwareLocationSequence:
         """Provide the LocationSequence specifying the current position of the labware.

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -55,7 +55,6 @@ from ..types import (
     LoadedLabware,
     ModuleLocation,
     OverlapOffset,
-    LabwareMovementOffsetData,
     OnDeckLabwareLocation,
     OFF_DECK_LOCATION,
     SYSTEM_LOCATION,
@@ -1251,28 +1250,6 @@ class LabwareView:
         uri = self.get_uri_from_definition(self.get_definition(labware_id))
         return uri in _MAGDECK_HALF_MM_LABWARE
 
-    def get_deck_default_gripper_offsets(self) -> Optional[LabwareMovementOffsetData]:
-        """Get the deck's default gripper offsets."""
-        parsed_offsets = (
-            self.get_deck_definition().get("gripperOffsets", {}).get("default")
-        )
-        return (
-            LabwareMovementOffsetData(
-                pickUpOffset=LabwareOffsetVector(
-                    x=parsed_offsets["pickUpOffset"]["x"],
-                    y=parsed_offsets["pickUpOffset"]["y"],
-                    z=parsed_offsets["pickUpOffset"]["z"],
-                ),
-                dropOffset=LabwareOffsetVector(
-                    x=parsed_offsets["dropOffset"]["x"],
-                    y=parsed_offsets["dropOffset"]["y"],
-                    z=parsed_offsets["dropOffset"]["z"],
-                ),
-            )
-            if parsed_offsets
-            else None
-        )
-
     def get_absorbance_reader_lid_definition(self) -> LabwareDefinition:
         """Return the special labware definition for the plate reader lid.
 
@@ -1282,68 +1259,6 @@ class LabwareView:
         return self._state.definitions_by_uri[
             "opentrons/opentrons_flex_lid_absorbance_plate_reader_module/1"
         ]
-
-    @overload
-    def get_child_gripper_offsets(
-        self,
-        *,
-        labware_definition: LabwareDefinition,
-        slot_name: Optional[DeckSlotName],
-    ) -> Optional[LabwareMovementOffsetData]:
-        pass
-
-    @overload
-    def get_child_gripper_offsets(
-        self, *, labware_id: str, slot_name: Optional[DeckSlotName]
-    ) -> Optional[LabwareMovementOffsetData]:
-        pass
-
-    def get_child_gripper_offsets(
-        self,
-        *,
-        labware_definition: Optional[LabwareDefinition] = None,
-        labware_id: Optional[str] = None,
-        slot_name: Optional[DeckSlotName],
-    ) -> Optional[LabwareMovementOffsetData]:
-        """Get the grip offsets that a labware says should be applied to children stacked atop it.
-
-        Params:
-            labware_id: The ID of a parent labware (atop which another labware, the child, will be stacked).
-            slot_name: The ancestor slot that the parent labware is ultimately loaded into,
-                       perhaps after going through a module in the middle.
-
-        Returns:
-            If `slot_name` is provided, returns the gripper offsets that the parent labware definition
-            specifies just for that slot, or `None` if the labware definition doesn't have an
-            exact match.
-
-            If `slot_name` is `None`, returns the gripper offsets that the parent labware
-            definition designates as "default," or `None` if it doesn't designate any as such.
-        """
-        if labware_id is not None:
-            labware_definition = self.get_definition(labware_id)
-        else:
-            # Should be ensured by our @overloads.
-            assert labware_definition is not None
-
-        parsed_offsets = labware_definition.gripperOffsets
-        offset_key = slot_name.id if slot_name else "default"
-
-        if parsed_offsets is None or offset_key not in parsed_offsets:
-            return None
-        else:
-            return LabwareMovementOffsetData(
-                pickUpOffset=LabwareOffsetVector.model_construct(
-                    x=parsed_offsets[offset_key].pickUpOffset.x,
-                    y=parsed_offsets[offset_key].pickUpOffset.y,
-                    z=parsed_offsets[offset_key].pickUpOffset.z,
-                ),
-                dropOffset=LabwareOffsetVector.model_construct(
-                    x=parsed_offsets[offset_key].dropOffset.x,
-                    y=parsed_offsets[offset_key].dropOffset.y,
-                    z=parsed_offsets[offset_key].dropOffset.z,
-                ),
-            )
 
     def get_grip_force(self, labware_definition: LabwareDefinition) -> float:
         """Get the recommended grip force for gripping labware using gripper."""

--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -56,7 +56,6 @@ from ..types import (
     HeaterShakerLatchStatus,
     HeaterShakerMovementRestrictors,
     DeckType,
-    LabwareMovementOffsetData,
     AddressableAreaLocation,
     StackerStoredLabwareGroup,
 )
@@ -1314,13 +1313,6 @@ class ModuleView:
                 raise errors.LocationIsOccupiedError(
                     f"Module {module.model} is already present at {location}."
                 )
-
-    def get_default_gripper_offsets(
-        self, module_id: str
-    ) -> Optional[LabwareMovementOffsetData]:
-        """Get the deck's default gripper offsets."""
-        offsets = self.get_definition(module_id).gripperOffsets
-        return offsets.get("default") if offsets else None
 
     def get_overflowed_module_in_slot(
         self, slot_name: DeckSlotName

--- a/api/src/opentrons/protocol_engine/types/__init__.py
+++ b/api/src/opentrons/protocol_engine/types/__init__.py
@@ -99,7 +99,6 @@ from .labware import (
     LegacyLabwareOffsetCreate,
     LabwareOffsetCreateInternal,
     LoadedLabware,
-    LabwareStackupAncestorDefinition,
     LabwareWellId,
 )
 from .liquid import HexColor, EmptyLiquidId, LiquidId, Liquid, FluidKind, AspiratedFluid
@@ -255,7 +254,6 @@ __all__ = [
     "LabwareOffsetCreateInternal",
     "LoadedLabware",
     "LabwareOffsetVector",
-    "LabwareStackupAncestorDefinition",
     "LabwareWellId",
     # Liquids
     "HexColor",

--- a/api/src/opentrons/protocol_engine/types/labware.py
+++ b/api/src/opentrons/protocol_engine/types/labware.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Optional, Union
+from typing import Optional
 from dataclasses import dataclass
 from datetime import datetime
 
@@ -15,8 +15,6 @@ from .labware_offset_location import (
 )
 from .labware_offset_vector import LabwareOffsetVector
 from .util import Vec3f
-from .module import ModuleDefinition
-from .deck_configuration import DeckLocationDefinition
 
 
 class OverlapOffset(Vec3f):
@@ -111,13 +109,6 @@ class LoadedLabware(BaseModel):
         None,
         description="A user-specified display name for this labware, if provided.",
     )
-
-
-LabwareStackupAncestorDefinition = Union[
-    DeckLocationDefinition,
-    ModuleDefinition,
-]
-"""Information pertaining to the lowest deck item in a labware stackup."""
 
 
 @dataclass(frozen=True)

--- a/api/tests/opentrons/motion_planning/test_waypoints.py
+++ b/api/tests/opentrons/motion_planning/test_waypoints.py
@@ -2,10 +2,6 @@
 import pytest
 
 from opentrons.motion_planning.types import GripperMovementWaypointsWithJawStatus
-from opentrons.protocol_engine.types import (
-    LabwareMovementOffsetData,
-    LabwareOffsetVector,
-)
 from opentrons.types import Point
 from opentrons.hardware_control.types import CriticalPoint as CP
 
@@ -271,25 +267,21 @@ def test_get_gripper_labware_movement_waypoints() -> None:
         from_labware_center=Point(101, 102, 119.5),
         to_labware_center=Point(201, 202, 219.5),
         gripper_home_z=999,
-        offset_data=LabwareMovementOffsetData(
-            pickUpOffset=LabwareOffsetVector(x=-1, y=-2, z=-3),
-            dropOffset=LabwareOffsetVector(x=1, y=2, z=3),
-        ),
         post_drop_slide_offset=None,
     )
     assert result == [
         # move to above "from" slot
-        GripperMovementWaypointsWithJawStatus(Point(100, 100, 999), False, False),
+        GripperMovementWaypointsWithJawStatus(Point(101, 102, 999), False, False),
         # with jaw open, move to labware on "from" slot
-        GripperMovementWaypointsWithJawStatus(Point(100, 100, 116.5), True, False),
+        GripperMovementWaypointsWithJawStatus(Point(101, 102, 119.5), True, False),
         # grip labware and retract in place
-        GripperMovementWaypointsWithJawStatus(Point(100, 100, 999), False, False),
+        GripperMovementWaypointsWithJawStatus(Point(101, 102, 999), False, False),
         # with labware gripped, move to above "to" slot
-        GripperMovementWaypointsWithJawStatus(Point(202.0, 204.0, 999), False, False),
+        GripperMovementWaypointsWithJawStatus(Point(201, 202, 999), False, False),
         # with labware gripped, move down to labware drop height on "to" slot
-        GripperMovementWaypointsWithJawStatus(Point(202.0, 204.0, 222.5), False, False),
+        GripperMovementWaypointsWithJawStatus(Point(201, 202, 219.5), False, False),
         # ungrip labware and retract in place
-        GripperMovementWaypointsWithJawStatus(Point(202.0, 204.0, 999), True, True),
+        GripperMovementWaypointsWithJawStatus(Point(201, 202, 999), True, True),
     ]
 
 
@@ -299,25 +291,21 @@ def test_get_gripper_labware_movement_waypoint_with_slide() -> None:
         from_labware_center=Point(101, 102, 119.5),
         to_labware_center=Point(201, 202, 219.5),
         gripper_home_z=999,
-        offset_data=LabwareMovementOffsetData(
-            pickUpOffset=LabwareOffsetVector(x=-1, y=-2, z=-3),
-            dropOffset=LabwareOffsetVector(x=1, y=2, z=3),
-        ),
         post_drop_slide_offset=Point(x=10, y=10, z=1),
     )
     assert result == [
         # move to above "from" slot
-        GripperMovementWaypointsWithJawStatus(Point(100, 100, 999), False, False),
+        GripperMovementWaypointsWithJawStatus(Point(101, 102, 999), False, False),
         # with jaw open, move to labware on "from" slot
-        GripperMovementWaypointsWithJawStatus(Point(100, 100, 116.5), True, False),
+        GripperMovementWaypointsWithJawStatus(Point(101, 102, 119.5), True, False),
         # grip labware and retract in place
-        GripperMovementWaypointsWithJawStatus(Point(100, 100, 999), False, False),
+        GripperMovementWaypointsWithJawStatus(Point(101, 102, 999), False, False),
         # with labware gripped, move to above "to" slot
-        GripperMovementWaypointsWithJawStatus(Point(202.0, 204.0, 999), False, False),
+        GripperMovementWaypointsWithJawStatus(Point(201, 202, 999), False, False),
         # with labware gripped, move down to labware drop height on "to" slot
-        GripperMovementWaypointsWithJawStatus(Point(202.0, 204.0, 222.5), False, False),
+        GripperMovementWaypointsWithJawStatus(Point(201, 202, 219.5), False, False),
         # ungrip labware and retract in place
-        GripperMovementWaypointsWithJawStatus(Point(202.0, 204.0, 999), True, True),
+        GripperMovementWaypointsWithJawStatus(Point(201, 202, 999), True, True),
         # slide after ungripping
-        GripperMovementWaypointsWithJawStatus(Point(212.0, 214.0, 1000), True, False),
+        GripperMovementWaypointsWithJawStatus(Point(211, 212, 1000), True, False),
     ]

--- a/api/tests/opentrons/protocol_engine/commands/absorbance_reader/test_close_lid.py
+++ b/api/tests/opentrons/protocol_engine/commands/absorbance_reader/test_close_lid.py
@@ -24,10 +24,6 @@ from opentrons.protocol_engine.commands.absorbance_reader import (
 from opentrons.protocol_engine.commands.absorbance_reader.close_lid import (
     CloseLidImpl,
 )
-from opentrons.protocol_engine.types import (
-    LabwareMovementOffsetData,
-    LabwareOffsetVector,
-)
 from opentrons.types import DeckSlotName
 from opentrons_shared_data.labware.labware_definition import (
     LabwareDefinition2,
@@ -112,17 +108,6 @@ async def test_absorbance_reader_close_lid_implementation(
     decoy.when(state_view.labware.get_absorbance_reader_lid_definition()).then_return(
         absorbance_def
     )
-    decoy.when(
-        state_view.labware.get_child_gripper_offsets(
-            labware_definition=absorbance_def,
-            slot_name=None,
-        )
-    ).then_return(
-        LabwareMovementOffsetData(
-            pickUpOffset=LabwareOffsetVector(x=0, y=0, z=0),
-            dropOffset=LabwareOffsetVector(x=0, y=0, z=0),
-        )
-    )
 
     result = await subject.execute(params=params)
 
@@ -161,61 +146,4 @@ async def test_close_lid_raises_no_module(
     decoy.when(state_view.config.use_virtual_modules).then_return(False)
     decoy.when(equipment.get_module_hardware_api(verified_module_id)).then_return(None)
     with pytest.raises(CannotPerformModuleAction):
-        await subject.execute(params=params)
-
-
-async def test_close_lid_raises_no_gripper_offset(
-    decoy: Decoy,
-    state_view: StateView,
-    equipment: EquipmentHandler,
-    subject: CloseLidImpl,
-    absorbance_def: LabwareDefinition2,
-) -> None:
-    """Should raise an error that gripper offset not found."""
-    params = CloseLidParams(
-        moduleId="unverified-module-id",
-    )
-
-    mabsorbance_module_substate = decoy.mock(cls=AbsorbanceReaderSubState)
-    absorbance_module_hw = decoy.mock(cls=AbsorbanceReader)
-    verified_module_id = AbsorbanceReaderId("module-id")
-
-    decoy.when(
-        state_view.modules.get_absorbance_reader_substate("unverified-module-id")
-    ).then_return(mabsorbance_module_substate)
-
-    decoy.when(mabsorbance_module_substate.module_id).then_return(verified_module_id)
-
-    decoy.when(equipment.get_module_hardware_api(verified_module_id)).then_return(
-        absorbance_module_hw
-    )
-
-    decoy.when(await absorbance_module_hw.get_current_lid_status()).then_return(
-        AbsorbanceReaderLidStatus.OFF
-    )
-    decoy.when(state_view.modules.get_requested_model(params.moduleId)).then_return(
-        ModuleModel.ABSORBANCE_READER_V1
-    )
-
-    decoy.when(state_view.labware.get_absorbance_reader_lid_definition()).then_return()
-
-    decoy.when(state_view.modules.get_location(params.moduleId)).then_return(
-        DeckSlotLocation(slotName=DeckSlotName.SLOT_D3)
-    )
-    decoy.when(
-        state_view.modules.ensure_and_convert_module_fixture_location(
-            DeckSlotName.SLOT_D3, ModuleModel.ABSORBANCE_READER_V1
-        )
-    ).then_return("absorbanceReaderV1D3")
-
-    decoy.when(state_view.labware.get_absorbance_reader_lid_definition()).then_return(
-        absorbance_def
-    )
-    decoy.when(
-        state_view.labware.get_child_gripper_offsets(
-            labware_definition=absorbance_def,
-            slot_name=None,
-        )
-    ).then_return(None)
-    with pytest.raises(ValueError):
         await subject.execute(params=params)

--- a/api/tests/opentrons/protocol_engine/commands/absorbance_reader/test_open_lid.py
+++ b/api/tests/opentrons/protocol_engine/commands/absorbance_reader/test_open_lid.py
@@ -24,10 +24,6 @@ from opentrons.protocol_engine.commands.absorbance_reader import (
 from opentrons.protocol_engine.commands.absorbance_reader.open_lid import (
     OpenLidImpl,
 )
-from opentrons.protocol_engine.types import (
-    LabwareMovementOffsetData,
-    LabwareOffsetVector,
-)
 from opentrons.types import DeckSlotName
 from opentrons_shared_data.labware.labware_definition import (
     LabwareDefinition2,
@@ -113,17 +109,6 @@ async def test_absorbance_reader_implementation(
     decoy.when(state_view.labware.get_absorbance_reader_lid_definition()).then_return(
         absorbance_def
     )
-    decoy.when(
-        state_view.labware.get_child_gripper_offsets(
-            labware_definition=absorbance_def,
-            slot_name=None,
-        )
-    ).then_return(
-        LabwareMovementOffsetData(
-            pickUpOffset=LabwareOffsetVector(x=0, y=0, z=0),
-            dropOffset=LabwareOffsetVector(x=0, y=0, z=0),
-        )
-    )
 
     result = await subject.execute(params=params)
 
@@ -162,61 +147,4 @@ async def test_open_lid_raises_no_module(
     decoy.when(state_view.config.use_virtual_modules).then_return(False)
     decoy.when(equipment.get_module_hardware_api(verified_module_id)).then_return(None)
     with pytest.raises(CannotPerformModuleAction):
-        await subject.execute(params=params)
-
-
-async def test_open_lid_raises_no_gripper_offset(
-    decoy: Decoy,
-    state_view: StateView,
-    equipment: EquipmentHandler,
-    subject: OpenLidImpl,
-    absorbance_def: LabwareDefinition2,
-) -> None:
-    """Should raise an error that gripper offset not found."""
-    params = OpenLidParams(
-        moduleId="unverified-module-id",
-    )
-
-    mabsorbance_module_substate = decoy.mock(cls=AbsorbanceReaderSubState)
-    absorbance_module_hw = decoy.mock(cls=AbsorbanceReader)
-    verified_module_id = AbsorbanceReaderId("module-id")
-
-    decoy.when(
-        state_view.modules.get_absorbance_reader_substate("unverified-module-id")
-    ).then_return(mabsorbance_module_substate)
-
-    decoy.when(mabsorbance_module_substate.module_id).then_return(verified_module_id)
-
-    decoy.when(equipment.get_module_hardware_api(verified_module_id)).then_return(
-        absorbance_module_hw
-    )
-
-    decoy.when(await absorbance_module_hw.get_current_lid_status()).then_return(
-        AbsorbanceReaderLidStatus.OFF
-    )
-    decoy.when(state_view.modules.get_requested_model(params.moduleId)).then_return(
-        ModuleModel.ABSORBANCE_READER_V1
-    )
-
-    decoy.when(state_view.labware.get_absorbance_reader_lid_definition()).then_return()
-
-    decoy.when(state_view.modules.get_location(params.moduleId)).then_return(
-        DeckSlotLocation(slotName=DeckSlotName.SLOT_D3)
-    )
-    decoy.when(
-        state_view.modules.ensure_and_convert_module_fixture_location(
-            DeckSlotName.SLOT_D3, ModuleModel.ABSORBANCE_READER_V1
-        )
-    ).then_return("absorbanceReaderV1D3")
-
-    decoy.when(state_view.labware.get_absorbance_reader_lid_definition()).then_return(
-        absorbance_def
-    )
-    decoy.when(
-        state_view.labware.get_child_gripper_offsets(
-            labware_definition=absorbance_def,
-            slot_name=None,
-        )
-    ).then_return(None)
-    with pytest.raises(ValueError):
         await subject.execute(params=params)

--- a/api/tests/opentrons/protocol_engine/execution/test_labware_movement_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_labware_movement_handler.py
@@ -22,7 +22,6 @@ from opentrons.protocol_engine.types import (
     LabwareOffsetVector,
     LabwareLocation,
     NonStackedLocation,
-    LabwareMovementOffsetData,
     Dimensions,
     GripperMoveType,
 )
@@ -166,10 +165,6 @@ async def test_raise_error_if_gripper_pickup_failed(
 
     user_pick_up_offset = Point(x=123, y=234, z=345)
     user_drop_offset = Point(x=111, y=222, z=333)
-    final_offset_data = LabwareMovementOffsetData(
-        pickUpOffset=LabwareOffsetVector(x=-1, y=-2, z=-3),
-        dropOffset=LabwareOffsetVector(x=1, y=2, z=3),
-    )
 
     starting_location = DeckSlotLocation(slotName=DeckSlotName.SLOT_1)
     to_location = DeckSlotLocation(slotName=DeckSlotName.SLOT_2)
@@ -185,25 +180,12 @@ async def test_raise_error_if_gripper_pickup_failed(
         )
     ).then_return(mock_tc_context_manager)
 
-    current_labware = state_store.labware.get_definition(
-        labware_id="my-teleporting-labware"
-    )
-
-    decoy.when(
-        state_store.geometry.get_final_labware_movement_offset_vectors(
-            from_location=starting_location,
-            to_location=to_location,
-            additional_pick_up_offset=user_pick_up_offset,
-            additional_drop_offset=user_drop_offset,
-            current_labware=current_labware,
-        )
-    ).then_return(final_offset_data)
-
     decoy.when(
         state_store.geometry.get_labware_grip_point(
             labware_definition=sentinel.my_teleporting_labware_def,
             location=starting_location,
             move_type=GripperMoveType.PICK_UP_LABWARE,
+            user_additional_offset=user_pick_up_offset,
         )
     ).then_return(Point(101, 102, 119.5))
 
@@ -212,6 +194,7 @@ async def test_raise_error_if_gripper_pickup_failed(
             labware_definition=sentinel.my_teleporting_labware_def,
             location=to_location,
             move_type=GripperMoveType.DROP_LABWARE,
+            user_additional_offset=user_drop_offset,
         )
     ).then_return(Point(201, 202, 219.5))
 
@@ -316,25 +299,6 @@ async def test_move_labware_with_gripper(
 
     user_pick_up_offset = Point(x=123, y=234, z=345)
     user_drop_offset = Point(x=111, y=222, z=333)
-    final_offset_data = LabwareMovementOffsetData(
-        pickUpOffset=LabwareOffsetVector(x=-1, y=-2, z=-3),
-        dropOffset=LabwareOffsetVector(x=1, y=2, z=3),
-    )
-
-    current_labware = state_store.labware.get_definition(
-        labware_id="my-teleporting-labware"
-    )
-    decoy.when(
-        state_store.geometry.get_final_labware_movement_offset_vectors(
-            from_location=from_location,
-            to_location=to_location,
-            additional_pick_up_offset=user_pick_up_offset,
-            additional_drop_offset=user_drop_offset,
-            current_labware=current_labware,
-        )
-    ).then_return(
-        final_offset_data
-    )  # TODO: Is this used for anything? Could this have been a sentinel? Are sentinels appropriate here?
 
     decoy.when(
         state_store.labware.get_dimensions(
@@ -348,20 +312,27 @@ async def test_move_labware_with_gripper(
         )
     ).then_return(Dimensions(x=99, y=80, z=1))
 
+    pickup_grip_point = Point(101, 102, 119.5)
+    drop_grip_point = Point(201, 202, 219.5)
+
     decoy.when(
         state_store.geometry.get_labware_grip_point(
             labware_definition=sentinel.my_teleporting_labware_def,
             location=from_location,
             move_type=GripperMoveType.PICK_UP_LABWARE,
+            user_additional_offset=user_pick_up_offset,
         )
-    ).then_return(Point(101, 102, 119.5))
+    ).then_return(pickup_grip_point)
+
     decoy.when(
         state_store.geometry.get_labware_grip_point(
             labware_definition=sentinel.my_teleporting_labware_def,
             location=to_location,
             move_type=GripperMoveType.DROP_LABWARE,
+            user_additional_offset=user_drop_offset,
         )
-    ).then_return(Point(201, 202, 219.5))
+    ).then_return(drop_grip_point)
+
     mock_tc_context_manager = decoy.mock(name="mock_tc_context_manager")
     decoy.when(
         thermocycler_plate_lifter.lift_plate_for_labware_movement(
@@ -370,12 +341,16 @@ async def test_move_labware_with_gripper(
     ).then_return(mock_tc_context_manager)
 
     expected_waypoints = [
-        Point(100, 100, 999),  # move to above slot 1
-        Point(100, 100, 116.5),  # move to labware on slot 1
-        Point(100, 100, 999),  # gripper retract at current location
-        Point(202.0, 204.0, 999),  # move to above slot 3
-        Point(202.0, 204.0, 222.5),  # move down to labware drop height on slot 3
-        Point(202.0, 204.0, 999),  # retract in place
+        Point(
+            pickup_grip_point.x, pickup_grip_point.y, 999
+        ),  # move to above pickup location
+        pickup_grip_point,  # move to pickup location
+        Point(
+            pickup_grip_point.x, pickup_grip_point.y, 999
+        ),  # gripper retract at pickup location
+        Point(drop_grip_point.x, drop_grip_point.y, 999),  # move to above drop location
+        drop_grip_point,  # move down to drop location
+        Point(drop_grip_point.x, drop_grip_point.y, 999),  # retract at drop location
     ]
 
     await subject.move_labware_with_gripper(

--- a/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
@@ -280,6 +280,11 @@ def auto_setup_addressable_area_mocks(
             mock_addressable_area_view.get_addressable_area(slot_id)
         ).then_return(mock_area)
         decoy.when(
+            mock_addressable_area_view._get_addressable_area_from_deck_data(
+                slot_id, False
+            )
+        ).then_return(mock_area)
+        decoy.when(
             mock_addressable_area_view.get_addressable_area_position(slot_id)
         ).then_return(Point(1, 2, 3))
 
@@ -306,6 +311,11 @@ def auto_setup_addressable_area_mocks(
 
         decoy.when(
             mock_addressable_area_view.get_addressable_area(area_name)
+        ).then_return(mock_module_area)
+        decoy.when(
+            mock_addressable_area_view._get_addressable_area_from_deck_data(
+                area_name, False
+            )
         ).then_return(mock_module_area)
         decoy.when(
             mock_addressable_area_view.get_addressable_area_position(area_name)

--- a/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
@@ -74,7 +74,6 @@ from opentrons.protocol_engine.types import (
     CurrentWell,
     CurrentAddressableArea,
     CurrentPipetteLocation,
-    LabwareMovementOffsetData,
     LoadedPipette,
     TipGeometry,
     ModuleDefinition,
@@ -254,6 +253,67 @@ def mock_pipette_view(decoy: Decoy) -> PipetteView:
 def mock_addressable_area_view(decoy: Decoy) -> AddressableAreaView:
     """Get a mock in the shape of a AddressableAreaView."""
     return decoy.mock(cls=AddressableAreaView)
+
+
+@pytest.fixture(autouse=True)
+def auto_setup_addressable_area_mocks(
+    decoy: Decoy, mock_addressable_area_view: AddressableAreaView, use_mocks: bool
+) -> None:
+    """Addressable area mocks for all tests."""
+    if not use_mocks:
+        return
+
+    for slot_id in ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12"]:
+        mock_area = AddressableArea(
+            area_name=slot_id,
+            area_type=AreaType.SLOT,
+            base_slot=DeckSlotName(slot_id),
+            display_name=f"Slot {slot_id}",
+            bounding_box=Dimensions(x=128, y=86, z=0),
+            position=AddressableOffsetVector(x=0, y=0, z=0),
+            compatible_module_types=[],
+            features=LocatingFeatures(),
+            mating_surface_unit_vector=[-1, 1, -1],
+        )
+
+        decoy.when(
+            mock_addressable_area_view.get_addressable_area(slot_id)
+        ).then_return(mock_area)
+        decoy.when(
+            mock_addressable_area_view.get_addressable_area_position(slot_id)
+        ).then_return(Point(1, 2, 3))
+
+    module_areas = [
+        "magneticModuleV2Slot3",
+        "temperatureModuleV2A3",
+        "thermocyclerModuleV2",
+        "flexStackerModuleV1A4",
+        "flexStackerModuleV1D4",
+    ]
+
+    for area_name in module_areas:
+        mock_module_area = AddressableArea(
+            area_name=area_name,
+            area_type=AreaType.SLOT,
+            base_slot=DeckSlotName.SLOT_3,
+            display_name=f"Module Area {area_name}",
+            bounding_box=Dimensions(x=128, y=86, z=0),
+            position=AddressableOffsetVector(x=0, y=0, z=0),
+            compatible_module_types=[],
+            features=LocatingFeatures(),
+            mating_surface_unit_vector=[-1, 1, -1],
+        )
+
+        decoy.when(
+            mock_addressable_area_view.get_addressable_area(area_name)
+        ).then_return(mock_module_area)
+        decoy.when(
+            mock_addressable_area_view.get_addressable_area_position(area_name)
+        ).then_return(Point(1, 2, 3))
+
+    decoy.when(mock_addressable_area_view.deck_definition).then_return(
+        sentinel.deck_definition
+    )
 
 
 @pytest.fixture(autouse=True)
@@ -798,9 +858,6 @@ def test_get_module_labware_highest_z(
     decoy.when(mock_module_view.get_provided_addressable_area("module-id")).then_return(
         "magneticModuleV2Slot3"
     )
-    decoy.when(
-        mock_addressable_area_view.get_addressable_area("magneticModuleV2Slot3")
-    ).then_return(sentinel.module_addressable_area)
 
     highest_z = subject.get_labware_highest_z("labware-id")
 
@@ -2759,6 +2816,7 @@ def test_get_labware_grip_point_v2_definition(
         labware_definition=_MOCK_LABWARE_DEFINITION2,
         location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
         move_type=GripperMoveType.PICK_UP_LABWARE,
+        user_additional_offset=None,
     )
 
     assert labware_center == Point(
@@ -2798,6 +2856,7 @@ def test_get_labware_grip_point_v3_definition(
         labware_definition=_MOCK_LABWARE_DEFINITION3,
         location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
         move_type=GripperMoveType.PICK_UP_LABWARE,
+        user_additional_offset=None,
     )
 
     assert labware_center == Point(
@@ -2849,6 +2908,7 @@ def test_get_labware_grip_point_on_labware(
         labware_definition=sentinel.definition,
         location=OnLabwareLocation(labwareId="below-id"),
         move_type=GripperMoveType.PICK_UP_LABWARE,
+        user_additional_offset=None,
     )
 
     assert grip_point == Point(
@@ -2938,11 +2998,12 @@ def test_get_labware_grip_point_for_labware_on_module(
         labware_definition=sentinel.labware_definition,
         location=ModuleLocation(moduleId="module-id"),
         move_type=GripperMoveType.PICK_UP_LABWARE,
+        user_additional_offset=Point(x=1, y=2, z=3),
     )
     assert result_grip_point == Point(
-        x=492 + _PARENT_ORIGIN_TO_LABWARE_ORIGIN.x + expected_lw_origin_to_parent.x,
-        y=350 + _PARENT_ORIGIN_TO_LABWARE_ORIGIN.y + expected_lw_origin_to_parent.y,
-        z=838 + _PARENT_ORIGIN_TO_LABWARE_ORIGIN.z + expected_lw_origin_to_parent.z,
+        x=492 + _PARENT_ORIGIN_TO_LABWARE_ORIGIN.x + expected_lw_origin_to_parent.x + 1,
+        y=350 + _PARENT_ORIGIN_TO_LABWARE_ORIGIN.y + expected_lw_origin_to_parent.y + 2,
+        z=838 + _PARENT_ORIGIN_TO_LABWARE_ORIGIN.z + expected_lw_origin_to_parent.z + 3,
     )
 
 
@@ -3031,6 +3092,7 @@ def test_get_labware_grip_point_for_labware_stack_on_module(
         labware_definition=sentinel.labware_definition,
         location=OnLabwareLocation(labwareId="below-id-9"),
         move_type=GripperMoveType.PICK_UP_LABWARE,
+        user_additional_offset=None,
     )
 
     assert result_grip_point == Point(
@@ -3371,44 +3433,6 @@ def test_get_next_drop_tip_location_in_non_trash_labware(
     )
 
 
-def test_get_final_labware_movement_offset_vectors(
-    decoy: Decoy,
-    mock_module_view: ModuleView,
-    mock_labware_view: LabwareView,
-    subject: GeometryView,
-    well_plate_def: LabwareDefinition,
-) -> None:
-    """It should provide the final labware movement offset data based on locations."""
-    decoy.when(mock_labware_view.get_deck_default_gripper_offsets()).then_return(
-        LabwareMovementOffsetData(
-            pickUpOffset=LabwareOffsetVector(x=1, y=2, z=3),
-            dropOffset=LabwareOffsetVector(x=3, y=2, z=1),
-        )
-    )
-    decoy.when(mock_module_view.get_default_gripper_offsets("module-id")).then_return(
-        LabwareMovementOffsetData(
-            pickUpOffset=LabwareOffsetVector(x=11, y=22, z=33),
-            dropOffset=LabwareOffsetVector(x=33, y=22, z=11),
-        )
-    )
-
-    decoy.when(mock_labware_view.get_definition("labware-id")).then_return(
-        well_plate_def
-    )
-
-    final_offsets = subject.get_final_labware_movement_offset_vectors(
-        from_location=DeckSlotLocation(slotName=DeckSlotName("D2")),
-        to_location=ModuleLocation(moduleId="module-id"),
-        additional_pick_up_offset=Point(x=100, y=200, z=300),
-        additional_drop_offset=Point(x=400, y=500, z=600),
-        current_labware=mock_labware_view.get_definition("labware-id"),
-    )
-    assert final_offsets == LabwareMovementOffsetData(
-        pickUpOffset=LabwareOffsetVector(x=101, y=202, z=303),
-        dropOffset=LabwareOffsetVector(x=433, y=522, z=611),
-    )
-
-
 def test_ensure_valid_gripper_location(subject: GeometryView) -> None:
     """It should raise error if it's not a valid labware movement location for gripper."""
     slot_location = DeckSlotLocation(slotName=DeckSlotName.SLOT_3)
@@ -3425,158 +3449,6 @@ def test_ensure_valid_gripper_location(subject: GeometryView) -> None:
 
     with pytest.raises(errors.LabwareMovementNotAllowedError):
         subject.ensure_valid_gripper_location(off_deck_location)
-
-
-def test_get_total_nominal_gripper_offset(
-    decoy: Decoy,
-    mock_labware_view: LabwareView,
-    mock_module_view: ModuleView,
-    subject: GeometryView,
-    well_plate_def: LabwareDefinition,
-) -> None:
-    """It should calculate the correct gripper offsets given the location and move type.."""
-    decoy.when(mock_labware_view.get_deck_default_gripper_offsets()).then_return(
-        LabwareMovementOffsetData(
-            pickUpOffset=LabwareOffsetVector(x=1, y=2, z=3),
-            dropOffset=LabwareOffsetVector(x=3, y=2, z=1),
-        )
-    )
-
-    decoy.when(mock_module_view.get_default_gripper_offsets("module-id")).then_return(
-        LabwareMovementOffsetData(
-            pickUpOffset=LabwareOffsetVector(x=11, y=22, z=33),
-            dropOffset=LabwareOffsetVector(x=33, y=22, z=11),
-        )
-    )
-
-    decoy.when(mock_labware_view.get_definition("labware-id")).then_return(
-        well_plate_def
-    )
-
-    # Case 1: labware on deck
-    result1 = subject.get_total_nominal_gripper_offset_for_move_type(
-        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_3),
-        move_type=GripperMoveType.PICK_UP_LABWARE,
-        current_labware=mock_labware_view.get_definition("labware-d"),
-    )
-    assert result1 == Point(x=1, y=2, z=3)
-
-    # Case 2: labware on module
-    result2 = subject.get_total_nominal_gripper_offset_for_move_type(
-        location=ModuleLocation(moduleId="module-id"),
-        move_type=GripperMoveType.DROP_LABWARE,
-        current_labware=mock_labware_view.get_definition("labware-id"),
-    )
-    assert result2 == Point(x=33, y=22, z=11)
-
-
-def test_get_stacked_labware_total_nominal_offset_slot_specific(
-    decoy: Decoy,
-    mock_labware_view: LabwareView,
-    mock_module_view: ModuleView,
-    subject: GeometryView,
-    well_plate_def: LabwareDefinition,
-) -> None:
-    """Get nominal offset for stacked labware."""
-    # Case: labware on adapter on module, adapter has slot-specific offsets
-    decoy.when(mock_module_view.get_default_gripper_offsets("module-id")).then_return(
-        LabwareMovementOffsetData(
-            pickUpOffset=LabwareOffsetVector(x=11, y=22, z=33),
-            dropOffset=LabwareOffsetVector(x=33, y=22, z=11),
-        )
-    )
-    decoy.when(mock_module_view.get_location("module-id")).then_return(
-        DeckSlotLocation(slotName=DeckSlotName.SLOT_C1)
-    )
-    decoy.when(
-        mock_labware_view.get_child_gripper_offsets(
-            labware_id="adapter-id", slot_name=DeckSlotName.SLOT_C1
-        )
-    ).then_return(
-        LabwareMovementOffsetData(
-            pickUpOffset=LabwareOffsetVector(x=100, y=200, z=300),
-            dropOffset=LabwareOffsetVector(x=300, y=200, z=100),
-        )
-    )
-    decoy.when(mock_labware_view.get_parent_location("adapter-id")).then_return(
-        ModuleLocation(moduleId="module-id")
-    )
-    decoy.when(mock_labware_view.get_definition("labware-id")).then_return(
-        well_plate_def
-    )
-    decoy.when(mock_module_view._state.requested_model_by_id).then_return(
-        {"module-id": ModuleModel.HEATER_SHAKER_MODULE_V1}
-    )
-    result1 = subject.get_total_nominal_gripper_offset_for_move_type(
-        location=OnLabwareLocation(labwareId="adapter-id"),
-        move_type=GripperMoveType.PICK_UP_LABWARE,
-        current_labware=mock_labware_view.get_definition("labware-id"),
-    )
-    assert result1 == Point(x=111, y=222, z=333)
-
-    result2 = subject.get_total_nominal_gripper_offset_for_move_type(
-        location=OnLabwareLocation(labwareId="adapter-id"),
-        move_type=GripperMoveType.DROP_LABWARE,
-        current_labware=mock_labware_view.get_definition("labware-id"),
-    )
-    assert result2 == Point(x=333, y=222, z=111)
-
-
-def test_get_stacked_labware_total_nominal_offset_default(
-    decoy: Decoy,
-    mock_labware_view: LabwareView,
-    mock_module_view: ModuleView,
-    subject: GeometryView,
-    well_plate_def: LabwareDefinition,
-) -> None:
-    """Get nominal offset for stacked labware."""
-    # Case: labware on adapter on module, adapter has only default offsets
-    decoy.when(mock_module_view.get_default_gripper_offsets("module-id")).then_return(
-        LabwareMovementOffsetData(
-            pickUpOffset=LabwareOffsetVector(x=11, y=22, z=33),
-            dropOffset=LabwareOffsetVector(x=33, y=22, z=11),
-        )
-    )
-    decoy.when(mock_module_view.get_location("module-id")).then_return(
-        DeckSlotLocation(slotName=DeckSlotName.SLOT_4)
-    )
-    decoy.when(
-        mock_labware_view.get_child_gripper_offsets(
-            labware_id="adapter-id", slot_name=DeckSlotName.SLOT_C1
-        )
-    ).then_return(None)
-    decoy.when(
-        mock_labware_view.get_child_gripper_offsets(
-            labware_id="adapter-id", slot_name=None
-        )
-    ).then_return(
-        LabwareMovementOffsetData(
-            pickUpOffset=LabwareOffsetVector(x=100, y=200, z=300),
-            dropOffset=LabwareOffsetVector(x=300, y=200, z=100),
-        )
-    )
-    decoy.when(mock_labware_view.get_parent_location("adapter-id")).then_return(
-        ModuleLocation(moduleId="module-id")
-    )
-    decoy.when(mock_labware_view.get_definition("labware-id")).then_return(
-        well_plate_def
-    )
-    decoy.when(mock_module_view._state.requested_model_by_id).then_return(
-        {"module-id": ModuleModel.HEATER_SHAKER_MODULE_V1}
-    )
-    result1 = subject.get_total_nominal_gripper_offset_for_move_type(
-        location=OnLabwareLocation(labwareId="adapter-id"),
-        move_type=GripperMoveType.PICK_UP_LABWARE,
-        current_labware=mock_labware_view.get_definition("labware-id"),
-    )
-    assert result1 == Point(x=111, y=222, z=333)
-
-    result2 = subject.get_total_nominal_gripper_offset_for_move_type(
-        location=OnLabwareLocation(labwareId="adapter-id"),
-        move_type=GripperMoveType.DROP_LABWARE,
-        current_labware=mock_labware_view.get_definition("labware-id"),
-    )
-    assert result2 == Point(x=333, y=222, z=111)
 
 
 def test_check_gripper_labware_tip_collision(

--- a/api/tests/opentrons/protocol_engine/state/test_labware_origin_math.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_origin_math.py
@@ -1,5 +1,5 @@
 """Test suite for _labware_origin_math.py module."""
-from typing import NamedTuple, List
+from typing import NamedTuple, List, Optional
 import pytest
 
 from opentrons.protocols.api_support.deck_type import (
@@ -8,6 +8,7 @@ from opentrons.protocols.api_support.deck_type import (
 )
 from opentrons_shared_data.deck import load as load_deck
 from opentrons_shared_data.labware.labware_definition import (
+    LabwareDefinition,
     LabwareDefinition2,
     LabwareDefinition3,
     Vector3D,
@@ -16,6 +17,8 @@ from opentrons_shared_data.labware.labware_definition import (
     Dimensions,
     Parameters2,
     Parameters3,
+    GripperOffsets,
+    LabwareRole,
 )
 from opentrons_shared_data.deck.types import DeckDefinitionV5
 from opentrons_shared_data.labware.types import (
@@ -27,10 +30,11 @@ from opentrons_shared_data.labware.types import (
     OpentronsFlexTipRackLidAsParentFeature,
 )
 
-from opentrons.types import Point
+from opentrons.types import Point, DeckSlotName
 from opentrons.protocol_engine.state._labware_origin_math import (
     get_stackup_origin_to_labware_origin,
     LabwareOriginContext,
+    LabwareStackupAncestorDefinition,
 )
 from opentrons.protocol_engine.types import (
     ModuleModel,
@@ -43,16 +47,33 @@ from opentrons.protocol_engine.types import (
     ModuleLocation,
     AddressableAreaLocation,
     OnLabwareLocation,
+    DeckSlotLocation,
+    LabwareMovementOffsetData,
+    LabwareOffsetVector,
+    LabwareLocation,
 )
-from opentrons.types import DeckSlotName
 
 
+# Test fixtures for labware definitions
 _LW_V2 = LabwareDefinition2.model_construct(  # type: ignore[call-arg]
     namespace="test",
     version=1,
     schemaVersion=2,
     cornerOffsetFromSlot=Vector3D(x=150, y=250, z=350),
     stackingOffsetWithModule={},
+    gripperOffsets={
+        "default": GripperOffsets(
+            pickUpOffset=Vector3D(x=100, y=200, z=300),
+            dropOffset=Vector3D(x=300, y=200, z=100),
+        ),
+    },
+    stackingOffsetWithLabware={
+        "labware-name": Vector3D(x=0, y=0, z=0),
+        "default": Vector3D(x=0, y=0, z=0),
+        "adapter-labware": Vector3D(x=0, y=0, z=0),
+    },
+    dimensions=Dimensions(xDimension=1000, yDimension=1200, zDimension=750),
+    parameters=Parameters2.model_construct(loadName="labware-name"),  # type: ignore[call-arg]
 )
 
 _LW_V2_WITH_MODULE_STACKING = LabwareDefinition2.model_construct(  # type: ignore[call-arg]
@@ -65,6 +86,7 @@ _LW_V2_WITH_MODULE_STACKING = LabwareDefinition2.model_construct(  # type: ignor
         str(ModuleModel.THERMOCYCLER_MODULE_V1.value): Vector3D(x=200, y=300, z=400),
         str(ModuleModel.THERMOCYCLER_MODULE_V2.value): Vector3D(x=500, y=600, z=700),
     },
+    gripperOffsets={},
 )
 
 _LW_V2_WITH_LABWARE_STACKING = LabwareDefinition2.model_construct(  # type: ignore[call-arg]
@@ -76,6 +98,44 @@ _LW_V2_WITH_LABWARE_STACKING = LabwareDefinition2.model_construct(  # type: igno
         "labware-name": Vector3D(x=50, y=100, z=150),
         "default": Vector3D(x=250, y=350, z=450),
     },
+    gripperOffsets={},
+)
+
+_LW_V2_WITH_DEFAULT_GRIPPER_OFFSETS = LabwareDefinition2.model_construct(  # type: ignore[call-arg]
+    namespace="test",
+    version=1,
+    schemaVersion=2,
+    cornerOffsetFromSlot=Vector3D(x=0, y=0, z=0),
+    stackingOffsetWithModule={},
+    dimensions=Dimensions(xDimension=1000, yDimension=1200, zDimension=750),
+    gripperOffsets={
+        "default": GripperOffsets(
+            pickUpOffset=Vector3D(x=10, y=20, z=30),
+            dropOffset=Vector3D(x=40, y=50, z=60),
+        )
+    },
+    stackingOffsetWithLabware={
+        "labware-name": Vector3D(x=50, y=100, z=150),
+        "default": Vector3D(x=250, y=350, z=450),
+    },
+    parameters=Parameters2.model_construct(loadName="labware-name"),  # type: ignore[call-arg]
+)
+
+_LW_V2_WITH_SLOT_SPECIFIC_GRIPPER_OFFSETS = LabwareDefinition2.model_construct(  # type: ignore[call-arg]
+    namespace="test",
+    version=1,
+    schemaVersion=2,
+    cornerOffsetFromSlot=Vector3D(x=0, y=0, z=0),
+    stackingOffsetWithLabware={"default": Vector3D(x=0, y=0, z=0)},
+    stackingOffsetWithModule={},
+    dimensions=Dimensions(xDimension=1000, yDimension=1200, zDimension=750),
+    gripperOffsets={
+        "A1": GripperOffsets(
+            pickUpOffset=Vector3D(x=111, y=222, z=333),
+            dropOffset=Vector3D(x=333, y=222, z=111),
+        ),
+    },
+    parameters=Parameters2.model_construct(loadName="adapter-labware"),  # type: ignore[call-arg]
 )
 
 _LW_V2_2 = LabwareDefinition2.model_construct(  # type: ignore[call-arg]
@@ -84,6 +144,7 @@ _LW_V2_2 = LabwareDefinition2.model_construct(  # type: ignore[call-arg]
     schemaVersion=2,
     dimensions=Dimensions(xDimension=1000, yDimension=1200, zDimension=750),
     parameters=Parameters2.model_construct(loadName="labware-name"),  # type: ignore[call-arg]
+    gripperOffsets={},
 )
 
 _LW_V2_3 = LabwareDefinition2.model_construct(  # type: ignore[call-arg]
@@ -96,8 +157,43 @@ _LW_V2_3 = LabwareDefinition2.model_construct(  # type: ignore[call-arg]
         zDimension=1000,
     ),
     parameters=Parameters3.model_construct(loadName="unknown-labware-name"),  # type: ignore[call-arg]
+    gripperOffsets={},
 )
 
+_TC_LID_V2 = LabwareDefinition2.model_construct(  # type: ignore[call-arg]
+    namespace="test",
+    version=1,
+    schemaVersion=2,
+    cornerOffsetFromSlot=Vector3D(x=0, y=0, z=0),
+    stackingOffsetWithLabware={"default": Vector3D(x=0, y=0, z=0)},
+    dimensions=Dimensions(xDimension=1000, yDimension=1200, zDimension=750),
+    stackingOffsetWithModule={},
+    parameters=Parameters2.model_construct(loadName="tc_lid"),  # type: ignore[call-arg]
+    allowedRoles=[LabwareRole.lid],
+    gripperOffsets={
+        "lidOffsets": GripperOffsets(
+            pickUpOffset=Vector3D(x=5, y=10, z=15),
+            dropOffset=Vector3D(x=5, y=10, z=15),  # Intentionally same as pickup
+        )
+    },
+)
+
+_AR_LID_V2 = LabwareDefinition2.model_construct(  # type: ignore[call-arg]
+    namespace="test",
+    version=1,
+    schemaVersion=2,
+    cornerOffsetFromSlot=Vector3D(x=0, y=0, z=0),
+    stackingOffsetWithLabware={"default": Vector3D(x=0, y=0, z=0)},
+    dimensions=Dimensions(xDimension=1000, yDimension=1200, zDimension=750),
+    stackingOffsetWithModule={},
+    parameters=Parameters2.model_construct(loadName="opentrons_flex_lid_absorbance_plate_reader_module"),  # type: ignore[call-arg]
+    gripperOffsets={
+        "default": GripperOffsets(
+            pickUpOffset=Vector3D(x=7, y=14, z=21),
+            dropOffset=Vector3D(x=28, y=35, z=42),
+        )
+    },
+)
 
 _LW_V3 = LabwareDefinition3.model_construct(  # type: ignore[call-arg]
     namespace="test",
@@ -115,6 +211,7 @@ _LW_V3 = LabwareDefinition3.model_construct(  # type: ignore[call-arg]
         )
     ),
     parameters=Parameters3.model_construct(loadName="labware-v3-basic"),  # type: ignore[call-arg]
+    gripperOffsets={},
 )
 
 _LW_V3_WITH_SLOT_FP_AS_CHILD_FEATURE = LabwareDefinition3.model_construct(  # type: ignore[call-arg]
@@ -136,6 +233,7 @@ _LW_V3_WITH_SLOT_FP_AS_CHILD_FEATURE = LabwareDefinition3.model_construct(  # ty
         "default": Vector3D(x=0, y=0, z=0),
     },
     parameters=Parameters3.model_construct(loadName="labware-v3-child"),  # type: ignore[call-arg]
+    gripperOffsets={},
 )
 
 _LW_V3_WITH_SLOT_FP_AS_PARENT_FEATURE = LabwareDefinition3.model_construct(  # type: ignore[call-arg]
@@ -154,6 +252,7 @@ _LW_V3_WITH_SLOT_FP_AS_PARENT_FEATURE = LabwareDefinition3.model_construct(  # t
         )
     ),
     parameters=Parameters3.model_construct(loadName="parent-labware-v3"),  # type: ignore[call-arg]
+    gripperOffsets={},
 )
 
 _LW_V3_WITH_SLOT_AS_PARENT_CHILD_FEATURES = LabwareDefinition3.model_construct(  # type: ignore[call-arg]
@@ -175,6 +274,7 @@ _LW_V3_WITH_SLOT_AS_PARENT_CHILD_FEATURES = LabwareDefinition3.model_construct( 
         ),
     ),
     parameters=Parameters3.model_construct(loadName="dual-feature-labware"),  # type: ignore[call-arg]
+    gripperOffsets={},
 )
 
 _LW_V3_WITH_FLEX_TIP_RACK_LID_AS_PARENT = LabwareDefinition3.model_construct(  # type: ignore[call-arg]
@@ -193,6 +293,7 @@ _LW_V3_WITH_FLEX_TIP_RACK_LID_AS_PARENT = LabwareDefinition3.model_construct(  #
         )
     ),
     parameters=Parameters3.model_construct(loadName="flex-tip-rack-lid-parent"),  # type: ignore[call-arg]
+    gripperOffsets={},
 )
 
 _LW_V3_WITH_FLEX_TIP_RACK_LID_AS_CHILD = LabwareDefinition3.model_construct(  # type: ignore[call-arg]
@@ -212,8 +313,10 @@ _LW_V3_WITH_FLEX_TIP_RACK_LID_AS_CHILD = LabwareDefinition3.model_construct(  # 
         "default": Vector3D(x=0, y=0, z=0),
     },
     parameters=Parameters3.model_construct(loadName="flex-tip-rack-lid-child"),  # type: ignore[call-arg]
+    gripperOffsets={},
 )
 
+# Module definitions
 _MODULE_DEF_TEMP_V2 = ModuleDefinition.model_construct(  # type: ignore[call-arg]
     schemaVersion=2,
     model=ModuleModel.TEMPERATURE_MODULE_V2,
@@ -223,6 +326,24 @@ _MODULE_DEF_TEMP_V2 = ModuleDefinition.model_construct(  # type: ignore[call-arg
         labwareInterfaceXDimension=1000,
         labwareInterfaceYDimension=700,
     ),
+    gripperOffsets={},
+)
+
+_MODULE_DEF_WITH_GRIPPER_OFFSETS = ModuleDefinition.model_construct(  # type: ignore[call-arg]
+    schemaVersion=2,
+    model=ModuleModel.HEATER_SHAKER_MODULE_V1,
+    dimensions=ModuleDimensions(
+        bareOverallHeight=500,
+        overLabwareHeight=600,
+        labwareInterfaceXDimension=1000,
+        labwareInterfaceYDimension=700,
+    ),
+    gripperOffsets={
+        "default": LabwareMovementOffsetData(
+            pickUpOffset=LabwareOffsetVector(x=11, y=22, z=33),
+            dropOffset=LabwareOffsetVector(x=33, y=22, z=11),
+        )
+    },
 )
 
 _MODULE_DEF_TC_V1 = ModuleDefinition.model_construct(  # type: ignore[call-arg]
@@ -232,6 +353,7 @@ _MODULE_DEF_TC_V1 = ModuleDefinition.model_construct(  # type: ignore[call-arg]
         bareOverallHeight=800,
         overLabwareHeight=900,
     ),
+    gripperOffsets={},
 )
 
 _MODULE_DEF_TC_V2 = ModuleDefinition.model_construct(  # type: ignore[call-arg]
@@ -241,6 +363,7 @@ _MODULE_DEF_TC_V2 = ModuleDefinition.model_construct(  # type: ignore[call-arg]
         bareOverallHeight=1000,
         overLabwareHeight=1100,
     ),
+    gripperOffsets={},
 )
 
 _ADDRESSABLE_AREA = AddressableArea(
@@ -324,6 +447,18 @@ class LabwareV3Spec(NamedTuple):
     parent_definition: object
     labware_location: object
     expected_total_offset: Point
+
+
+class GripperOffsetSpec(NamedTuple):
+    """Spec data to test gripper offset behavior."""
+
+    stackup_lw_info_top_to_bottom: List[tuple[LabwareDefinition, object]]
+    underlying_ancestor_definition: object
+    slot_name: DeckSlotName
+    deck_definition: DeckDefinitionV5
+    module_parent_to_child_offset: Optional[Point]
+    expected_pick_up_offset: Point
+    expected_drop_offset: Point
 
 
 MODULE_OVERLAP_SPECS: List[ModuleOverlapSpec] = [
@@ -440,6 +575,85 @@ LW_V3_SPECS_ON_LW: List[LabwareV3Spec] = [
 ]
 
 
+GRIPPER_OFFSET_SPECS: List[GripperOffsetSpec] = [
+    GripperOffsetSpec(
+        stackup_lw_info_top_to_bottom=[
+            (_LW_V2, DeckSlotLocation(slotName=DeckSlotName.SLOT_3)),
+        ],
+        underlying_ancestor_definition=_ADDRESSABLE_AREA,
+        slot_name=DeckSlotName.SLOT_3,
+        deck_definition=load_deck(STANDARD_OT3_DECK, 5),
+        module_parent_to_child_offset=None,
+        expected_pick_up_offset=Point(x=0, y=0, z=0),
+        expected_drop_offset=Point(x=0, y=0, z=-0.75),
+    ),
+    GripperOffsetSpec(
+        stackup_lw_info_top_to_bottom=[
+            (_LW_V2, ModuleLocation(moduleId="module-id")),
+        ],
+        underlying_ancestor_definition=_MODULE_DEF_WITH_GRIPPER_OFFSETS,
+        slot_name=DeckSlotName.SLOT_1,
+        deck_definition=load_deck(STANDARD_OT3_DECK, 5),
+        module_parent_to_child_offset=Point(x=0, y=0, z=0),
+        expected_pick_up_offset=Point(x=11, y=22, z=33),
+        expected_drop_offset=Point(x=33, y=22, z=11),
+    ),
+    GripperOffsetSpec(
+        stackup_lw_info_top_to_bottom=[
+            (
+                _LW_V2_WITH_DEFAULT_GRIPPER_OFFSETS,
+                OnLabwareLocation(labwareId="parent-id"),
+            ),
+            (_LW_V2, DeckSlotLocation(slotName=DeckSlotName.SLOT_1)),
+        ],
+        underlying_ancestor_definition=_ADDRESSABLE_AREA,
+        slot_name=DeckSlotName.SLOT_1,
+        deck_definition=load_deck(STANDARD_OT3_DECK, 5),
+        module_parent_to_child_offset=None,
+        expected_pick_up_offset=Point(x=10, y=20, z=30),
+        expected_drop_offset=Point(x=40, y=50, z=59.25),
+    ),
+    GripperOffsetSpec(
+        stackup_lw_info_top_to_bottom=[
+            (_LW_V2, OnLabwareLocation(labwareId="adapter-id")),
+            (
+                _LW_V2_WITH_SLOT_SPECIFIC_GRIPPER_OFFSETS,
+                ModuleLocation(moduleId="module-id"),
+            ),
+        ],
+        underlying_ancestor_definition=_MODULE_DEF_WITH_GRIPPER_OFFSETS,
+        slot_name=DeckSlotName.SLOT_C1,
+        deck_definition=load_deck(STANDARD_OT3_DECK, 5),
+        module_parent_to_child_offset=Point(x=0, y=0, z=0),
+        expected_pick_up_offset=Point(x=111, y=222, z=333),
+        expected_drop_offset=Point(x=333, y=222, z=111),
+    ),
+    GripperOffsetSpec(
+        stackup_lw_info_top_to_bottom=[
+            (_TC_LID_V2, OnLabwareLocation(labwareId="adapter-id")),
+            (_LW_V2, ModuleLocation(moduleId="module-id")),
+        ],
+        underlying_ancestor_definition=_MODULE_DEF_TC_V2,
+        slot_name=DeckSlotName.SLOT_B1,
+        deck_definition=load_deck(STANDARD_OT3_DECK, 5),
+        module_parent_to_child_offset=Point(x=0, y=0, z=0),
+        expected_pick_up_offset=Point(x=5, y=10, z=15),
+        expected_drop_offset=Point(x=5, y=10, z=15),
+    ),
+    GripperOffsetSpec(
+        stackup_lw_info_top_to_bottom=[
+            (_AR_LID_V2, DeckSlotLocation(slotName=DeckSlotName.SLOT_3)),
+        ],
+        underlying_ancestor_definition=_ADDRESSABLE_AREA,
+        slot_name=DeckSlotName.SLOT_3,
+        deck_definition=load_deck(STANDARD_OT3_DECK, 5),
+        module_parent_to_child_offset=None,
+        expected_pick_up_offset=Point(x=7, y=14, z=21),
+        expected_drop_offset=Point(x=28, y=35, z=41.25),
+    ),
+]
+
+
 @pytest.mark.parametrize(
     argnames=ModuleOverlapSpec._fields,
     argvalues=MODULE_OVERLAP_SPECS,
@@ -459,6 +673,7 @@ def test_get_parent_placement_origin_to_lw_origin_with_module(
             (child_definition, labware_location),
         ],
         underlying_ancestor_definition=module_definition,
+        slot_name=DeckSlotName.SLOT_1,
         module_parent_to_child_offset=module_parent_to_child_offset,
         deck_definition=spec_deck_definition,
     )
@@ -487,6 +702,7 @@ def test_get_parent_placement_origin_to_lw_origin_with_labware(
             ),
         ],
         underlying_ancestor_definition=_ADDRESSABLE_AREA,
+        slot_name=DeckSlotName.SLOT_A1,
         module_parent_to_child_offset=None,
         deck_definition=load_deck(STANDARD_OT3_DECK, 5),
     )
@@ -511,6 +727,7 @@ def test_get_parent_placement_origin_to_lw_origin_with_addressable_area(
             (child_definition, labware_location),
         ],
         underlying_ancestor_definition=addressable_area,
+        slot_name=DeckSlotName.SLOT_A1,
         module_parent_to_child_offset=None,
         deck_definition=load_deck(STANDARD_OT3_DECK, 5),
     )
@@ -535,6 +752,7 @@ def test_get_parent_placement_origin_to_lw_origin_v3_definitions_non_lw(
             (child_definition, labware_location),
         ],
         underlying_ancestor_definition=parent_definition,
+        slot_name=DeckSlotName.SLOT_A1,
         module_parent_to_child_offset=None,
         deck_definition=load_deck(STANDARD_OT3_DECK, 5),
     )
@@ -563,8 +781,172 @@ def test_get_parent_placement_origin_to_lw_origin_v3_definitions(
             ),
         ],
         underlying_ancestor_definition=_ADDRESSABLE_AREA,
+        slot_name=DeckSlotName.SLOT_A1,
         module_parent_to_child_offset=None,
         deck_definition=load_deck(STANDARD_OT3_DECK, 5),
     )
 
     assert result == expected_total_offset
+
+
+@pytest.mark.parametrize(
+    argnames=GripperOffsetSpec._fields,
+    argvalues=GRIPPER_OFFSET_SPECS,
+)
+def test_gripper_offsets_for_pickup(
+    stackup_lw_info_top_to_bottom: List[tuple[LabwareDefinition, LabwareLocation]],
+    underlying_ancestor_definition: LabwareStackupAncestorDefinition,
+    slot_name: DeckSlotName,
+    deck_definition: DeckDefinitionV5,
+    module_parent_to_child_offset: Optional[Point],
+    expected_pick_up_offset: Point,
+    expected_drop_offset: Point,
+) -> None:
+    """It should calculate the correct gripper offsets for pick up context."""
+    pick_up_result = get_stackup_origin_to_labware_origin(
+        context=LabwareOriginContext.GRIPPER_PICKING_UP,
+        stackup_lw_info_top_to_bottom=stackup_lw_info_top_to_bottom,
+        underlying_ancestor_definition=underlying_ancestor_definition,
+        slot_name=slot_name,
+        module_parent_to_child_offset=module_parent_to_child_offset,
+        deck_definition=deck_definition,
+    )
+
+    # Baseline without gripper offsets
+    pipetting_result = get_stackup_origin_to_labware_origin(
+        context=LabwareOriginContext.PIPETTING,
+        stackup_lw_info_top_to_bottom=stackup_lw_info_top_to_bottom,
+        underlying_ancestor_definition=underlying_ancestor_definition,
+        slot_name=slot_name,
+        module_parent_to_child_offset=module_parent_to_child_offset,
+        deck_definition=deck_definition,
+    )
+
+    actual_pick_up_offset = pick_up_result - pipetting_result
+
+    assert actual_pick_up_offset == expected_pick_up_offset
+
+
+@pytest.mark.parametrize(
+    argnames=GripperOffsetSpec._fields,
+    argvalues=GRIPPER_OFFSET_SPECS,
+)
+def test_gripper_offsets_for_drop(
+    stackup_lw_info_top_to_bottom: List[tuple[LabwareDefinition, LabwareLocation]],
+    underlying_ancestor_definition: LabwareStackupAncestorDefinition,
+    slot_name: DeckSlotName,
+    deck_definition: DeckDefinitionV5,
+    module_parent_to_child_offset: Optional[Point],
+    expected_drop_offset: Point,
+    expected_pick_up_offset: Point,
+) -> None:
+    """It should calculate the correct gripper offsets for drop context."""
+    drop_result = get_stackup_origin_to_labware_origin(
+        context=LabwareOriginContext.GRIPPER_DROPPING,
+        stackup_lw_info_top_to_bottom=stackup_lw_info_top_to_bottom,
+        underlying_ancestor_definition=underlying_ancestor_definition,
+        slot_name=slot_name,
+        module_parent_to_child_offset=module_parent_to_child_offset,
+        deck_definition=deck_definition,
+    )
+
+    # Baseline without gripper offsets
+    pipetting_result = get_stackup_origin_to_labware_origin(
+        context=LabwareOriginContext.PIPETTING,
+        stackup_lw_info_top_to_bottom=stackup_lw_info_top_to_bottom,
+        underlying_ancestor_definition=underlying_ancestor_definition,
+        slot_name=slot_name,
+        module_parent_to_child_offset=module_parent_to_child_offset,
+        deck_definition=deck_definition,
+    )
+
+    actual_drop_offset = drop_result - pipetting_result
+
+    assert actual_drop_offset == expected_drop_offset
+
+
+def test_gripper_offsets_stacked_labware_with_module() -> None:
+    """Test labware on adapter on module with slot-specific offsets."""
+    deck_def = load_deck(STANDARD_OT3_DECK, 5)
+
+    stackup_lw_info: list[tuple[LabwareDefinition, LabwareLocation]] = [
+        (_LW_V2, OnLabwareLocation(labwareId="adapter-id")),
+        (
+            _LW_V2_WITH_SLOT_SPECIFIC_GRIPPER_OFFSETS,
+            ModuleLocation(moduleId="module-id"),
+        ),
+    ]
+
+    pick_up_result = get_stackup_origin_to_labware_origin(
+        context=LabwareOriginContext.GRIPPER_PICKING_UP,
+        stackup_lw_info_top_to_bottom=stackup_lw_info,
+        underlying_ancestor_definition=_MODULE_DEF_WITH_GRIPPER_OFFSETS,
+        slot_name=DeckSlotName.SLOT_C1,
+        module_parent_to_child_offset=Point(x=0, y=0, z=0),
+        deck_definition=deck_def,
+    )
+
+    pipetting_result = get_stackup_origin_to_labware_origin(
+        context=LabwareOriginContext.PIPETTING,
+        stackup_lw_info_top_to_bottom=stackup_lw_info,
+        underlying_ancestor_definition=_MODULE_DEF_WITH_GRIPPER_OFFSETS,
+        slot_name=DeckSlotName.SLOT_C1,
+        module_parent_to_child_offset=Point(x=0, y=0, z=0),
+        deck_definition=deck_def,
+    )
+
+    expected_pick_up_offset = Point(x=111, y=222, z=333)
+    actual_pick_up_offset = pick_up_result - pipetting_result
+
+    assert actual_pick_up_offset == expected_pick_up_offset
+
+    drop_result = get_stackup_origin_to_labware_origin(
+        context=LabwareOriginContext.GRIPPER_DROPPING,
+        stackup_lw_info_top_to_bottom=stackup_lw_info,
+        underlying_ancestor_definition=_MODULE_DEF_WITH_GRIPPER_OFFSETS,
+        slot_name=DeckSlotName.SLOT_C1,
+        module_parent_to_child_offset=Point(x=0, y=0, z=0),
+        deck_definition=deck_def,
+    )
+
+    expected_drop_offset = Point(x=333, y=222, z=111)
+    actual_drop_offset = drop_result - pipetting_result
+
+    assert actual_drop_offset == expected_drop_offset
+
+
+def test_gripper_offsets_fallback_to_default() -> None:
+    """Test that gripper offsets fall back to default when slot-specific not available."""
+    deck_def = load_deck(STANDARD_OT3_DECK, 5)
+
+    stackup_lw_info: list[tuple[LabwareDefinition, LabwareLocation]] = [
+        (_LW_V2, OnLabwareLocation(labwareId="adapter-id")),
+        (
+            _LW_V2_WITH_DEFAULT_GRIPPER_OFFSETS,
+            ModuleLocation(moduleId="module-id"),
+        ),
+    ]
+
+    pick_up_result = get_stackup_origin_to_labware_origin(
+        context=LabwareOriginContext.GRIPPER_PICKING_UP,
+        stackup_lw_info_top_to_bottom=stackup_lw_info,
+        underlying_ancestor_definition=_MODULE_DEF_WITH_GRIPPER_OFFSETS,
+        slot_name=DeckSlotName.SLOT_D2,
+        module_parent_to_child_offset=Point(x=0, y=0, z=0),
+        deck_definition=deck_def,
+    )
+
+    # Baseline without gripper offsets
+    pipetting_result = get_stackup_origin_to_labware_origin(
+        context=LabwareOriginContext.PIPETTING,
+        stackup_lw_info_top_to_bottom=stackup_lw_info,
+        underlying_ancestor_definition=_MODULE_DEF_WITH_GRIPPER_OFFSETS,
+        slot_name=DeckSlotName.SLOT_D2,
+        module_parent_to_child_offset=Point(x=0, y=0, z=0),
+        deck_definition=deck_def,
+    )
+
+    expected_pick_up_offset = Point(x=111, y=222, z=333)
+    actual_pick_up_offset = pick_up_result - pipetting_result
+
+    assert actual_pick_up_offset == expected_pick_up_offset

--- a/api/tests/opentrons/protocol_engine/state/test_labware_view_old.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_view_old.py
@@ -17,7 +17,6 @@ from opentrons_shared_data.labware.labware_definition import (
     AxisAlignedBoundingBox3D,
     Dimensions as LabwareDimensions,
     Extents,
-    GripperOffsets,
     labware_definition_type_adapter,
     LabwareDefinition,
     LabwareDefinition2,
@@ -43,7 +42,6 @@ from opentrons.protocol_engine.types import (
     LabwareLocation,
     AddressableAreaLocation,
     OFF_DECK_LOCATION,
-    LabwareMovementOffsetData,
     OnAddressableAreaOffsetLocationSequenceComponent,
     OnModuleOffsetLocationSequenceComponent,
 )
@@ -1775,83 +1773,6 @@ def test_labware_stacking_height_passes_or_raises(
             ),
             bottom_labware_id="labware-id4",
         )
-
-
-def test_get_deck_gripper_offsets(ot3_standard_deck_def: DeckDefinitionV5) -> None:
-    """It should get the deck's gripper offsets."""
-    subject = get_labware_view(deck_definition=ot3_standard_deck_def)
-
-    assert subject.get_deck_default_gripper_offsets() == LabwareMovementOffsetData(
-        pickUpOffset=LabwareOffsetVector(x=0, y=0, z=0),
-        dropOffset=LabwareOffsetVector(x=0, y=0, z=-0.75),
-    )
-
-
-def test_get_labware_gripper_offsets(
-    well_plate_def: LabwareDefinition,
-    adapter_plate_def: LabwareDefinition,
-) -> None:
-    """It should get the labware's gripper offsets."""
-    subject = get_labware_view(
-        labware_by_id={"plate-id": plate, "adapter-plate-id": adapter_plate},
-        definitions_by_uri={
-            "some-plate-uri": well_plate_def,
-            "some-adapter-uri": adapter_plate_def,
-        },
-    )
-
-    assert (
-        subject.get_child_gripper_offsets(labware_id="plate-id", slot_name=None) is None
-    )
-    assert subject.get_child_gripper_offsets(
-        labware_id="adapter-plate-id", slot_name=DeckSlotName.SLOT_D1
-    ) == LabwareMovementOffsetData(
-        pickUpOffset=LabwareOffsetVector(x=0, y=0, z=0),
-        dropOffset=LabwareOffsetVector(x=2, y=0, z=0),
-    )
-
-
-def test_get_labware_gripper_offsets_default_no_slots(
-    well_plate_def: LabwareDefinition,
-    adapter_plate_def: LabwareDefinition,
-) -> None:
-    """It should get the labware's gripper offsets with only a default gripper offset entry."""
-    subject = get_labware_view(
-        labware_by_id={
-            "labware-id": LoadedLabware(
-                id="labware-id",
-                loadName="labware-load-name",
-                location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
-                definitionUri="some-labware-uri",
-                offsetId=None,
-                displayName="Fancy Labware Name",
-            )
-        },
-        definitions_by_uri={
-            "some-labware-uri": LabwareDefinition2.model_construct(  # type: ignore[call-arg]
-                gripperOffsets={
-                    "default": GripperOffsets(
-                        pickUpOffset=Vector3D(x=1, y=2, z=3),
-                        dropOffset=Vector3D(x=4, y=5, z=6),
-                    )
-                }
-            ),
-        },
-    )
-
-    assert (
-        subject.get_child_gripper_offsets(
-            labware_id="labware-id", slot_name=DeckSlotName.SLOT_D1
-        )
-        is None
-    )
-
-    assert subject.get_child_gripper_offsets(
-        labware_id="labware-id", slot_name=None
-    ) == LabwareMovementOffsetData(
-        pickUpOffset=LabwareOffsetVector(x=1, y=2, z=3),
-        dropOffset=LabwareOffsetVector(x=4, y=5, z=6),
-    )
 
 
 def test_get_grip_force(

--- a/api/tests/opentrons/protocol_engine/state/test_module_view_old.py
+++ b/api/tests/opentrons/protocol_engine/state/test_module_view_old.py
@@ -38,7 +38,6 @@ from opentrons.protocol_engine.types import (
     DeckType,
     ModuleOffsetData,
     HeaterShakerLatchStatus,
-    LabwareMovementOffsetData,
     AddressableArea,
     DeckConfigurationType,
     PotentialCutoutFixture,
@@ -1878,51 +1877,6 @@ def test_is_edge_move_unsafe(
     result = subject.is_edge_move_unsafe(mount=mount, target_slot=target_slot)
 
     assert result is expected_result
-
-
-@pytest.mark.parametrize(
-    argnames=["module_def", "expected_offset_data"],
-    argvalues=[
-        (
-            lazy_fixture("thermocycler_v2_def"),
-            LabwareMovementOffsetData(
-                pickUpOffset=LabwareOffsetVector(x=0, y=0, z=4.6),
-                dropOffset=LabwareOffsetVector(x=0, y=0, z=5.6),
-            ),
-        ),
-        (
-            lazy_fixture("heater_shaker_v1_def"),
-            LabwareMovementOffsetData(
-                pickUpOffset=LabwareOffsetVector(x=0, y=0, z=0),
-                dropOffset=LabwareOffsetVector(x=0, y=0, z=1.0),
-            ),
-        ),
-        (
-            lazy_fixture("tempdeck_v1_def"),
-            None,
-        ),
-    ],
-)
-def test_get_default_gripper_offsets(
-    module_def: ModuleDefinition,
-    expected_offset_data: Optional[LabwareMovementOffsetData],
-) -> None:
-    """It should return the correct gripper offsets, if present."""
-    subject = make_module_view(
-        slot_by_module_id={
-            "module-1": DeckSlotName.SLOT_1,
-        },
-        requested_model_by_module_id={
-            "module-1": ModuleModel.TEMPERATURE_MODULE_V1,  # Does not matter
-        },
-        hardware_by_module_id={
-            "module-1": HardwareModule(
-                serial_number="serial-1",
-                definition=module_def,
-            ),
-        },
-    )
-    assert subject.get_default_gripper_offsets("module-1") == expected_offset_data
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes [EXEC-1690](https://opentrons.atlassian.net/browse/EXEC-1690)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Colocates all the gripper offset calculations relating to the labware being gripped into labware origin math. These values were sprawled across a few files, but as a general entry point, look at the diff for `labware_movement` and see where the internals of the finalized gripper offsets are utilized. 

In addition to the standard "move labware with gripper" case, there is the "move absorbance plate reader lid" case, which is special-cased given how gripper offsets are typically defined and utilized. Some of the complexity of those helpers is reduced, and all of that code is also encapsulated in labware origin math.
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- In theory, we should be covered by CI. Most of the testing that already existed elsewhere is simply redefined in labware origin math.
- Simulated standard gripper movement protocols between edge and this branch, ensuring the final gripper movement coordinates were identical.
- Ran some open/close lid and e-stop cases for the absorbance reader lid, verifying the gripper moves the lid correctly.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests
none in particular
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
should be low. this does shuffle around a lot of code, though
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[EXEC-1690]: https://opentrons.atlassian.net/browse/EXEC-1690?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ