### PR TITLE
feat(protocol-designer, step-generation): the journey of tip rack lids

### DIFF
--- a/protocol-designer/src/assets/localization/en/alert.json
+++ b/protocol-designer/src/assets/localization/en/alert.json
@@ -166,6 +166,10 @@
       "RETURN_TIP_UNAVAILABLE": {
         "title": "Return tip unavailable",
         "body": "Unable to find the most pipette's most recent pickup location for return tip."
+      },
+      "TIPRACK_LID_NOT_ALLOWED_ON_DECK": {
+        "title": "Invalid tip rack lid position",
+        "body": "The tip rack lid is not allowed directly on a deck slot"
       }
     },
     "warning": {

--- a/protocol-designer/src/components/organisms/EditInstrumentsModal/PipetteOverview.tsx
+++ b/protocol-designer/src/components/organisms/EditInstrumentsModal/PipetteOverview.tsx
@@ -123,6 +123,12 @@ export function PipetteOverview({
     lw => lw.def.parameters.loadName === TIPRACK_LID_LOADNAME
   )
 
+  const handleDeletingTipLids = (): void => {
+    allTiprackLidsOnDeck.forEach(lid =>
+      dispatch(deleteContainer({ labwareId: lid.id }))
+    )
+  }
+
   return (
     <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing24}>
       <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing8}>
@@ -176,7 +182,6 @@ export function PipetteOverview({
                 dispatch(deletePipettes([leftPipette.id as string]))
                 previousLeftPipetteTipracks.forEach(tip => {
                   const tipStack = tip.stack
-                  console.log('tipStack', tipStack)
                   //  to delete any tiprackAdapters + tipracks
                   tipStack.forEach(item => {
                     if (labware[item] != null) {
@@ -184,9 +189,7 @@ export function PipetteOverview({
                     }
                   })
                 })
-                allTiprackLidsOnDeck.forEach(lid =>
-                  dispatch(deleteContainer({ labwareId: lid.id }))
-                )
+                handleDeletingTipLids()
               }}
             />
           ) : null}
@@ -213,9 +216,7 @@ export function PipetteOverview({
                       dispatch(deleteContainer({ labwareId: item }))
                     }
                   })
-                  allTiprackLidsOnDeck.forEach(lid =>
-                    dispatch(deleteContainer({ labwareId: lid.id }))
-                  )
+                  handleDeletingTipLids()
                 })
               }}
             />

--- a/protocol-designer/src/components/organisms/EditInstrumentsModal/PipetteOverview.tsx
+++ b/protocol-designer/src/components/organisms/EditInstrumentsModal/PipetteOverview.tsx
@@ -23,6 +23,7 @@ import { FLEX_ROBOT_TYPE } from '@opentrons/shared-data'
 import { LINK_BUTTON_STYLE } from '/protocol-designer/components/atoms'
 import { INITIAL_DECK_SETUP_STEP_ID } from '/protocol-designer/constants'
 import { deleteContainer } from '/protocol-designer/labware-ingred/actions'
+import { TIPRACK_LID_LOADNAME } from '/protocol-designer/pages/Designer/utils'
 import { deletePipettes } from '/protocol-designer/step-forms/actions'
 import { toggleIsGripperRequired } from '/protocol-designer/step-forms/actions/additionalItems'
 import { getAdditionalEquipmentEntities } from '/protocol-designer/step-forms/selectors'
@@ -118,6 +119,9 @@ export function PipetteOverview({
     setMount(targetPipetteMount)
     setSaveAttemptFailed(false)
   }
+  const allTiprackLidsOnDeck = Object.values(labware).filter(
+    lw => lw.def.parameters.loadName === TIPRACK_LID_LOADNAME
+  )
 
   return (
     <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing24}>
@@ -170,8 +174,18 @@ export function PipetteOverview({
               }}
               cleanForm={() => {
                 dispatch(deletePipettes([leftPipette.id as string]))
-                previousLeftPipetteTipracks.forEach(tip =>
-                  dispatch(deleteContainer({ labwareId: tip.id }))
+                previousLeftPipetteTipracks.forEach(tip => {
+                  const tipStack = tip.stack
+                  console.log('tipStack', tipStack)
+                  //  to delete any tiprackAdapters + tipracks
+                  tipStack.forEach(item => {
+                    if (labware[item] != null) {
+                      dispatch(deleteContainer({ labwareId: item }))
+                    }
+                  })
+                })
+                allTiprackLidsOnDeck.forEach(lid =>
+                  dispatch(deleteContainer({ labwareId: lid.id }))
                 )
               }}
             />
@@ -191,9 +205,18 @@ export function PipetteOverview({
               }}
               cleanForm={() => {
                 dispatch(deletePipettes([rightPipette.id as string]))
-                previousRightPipetteTipracks.forEach(tip =>
-                  dispatch(deleteContainer({ labwareId: tip.id }))
-                )
+                previousRightPipetteTipracks.forEach(tip => {
+                  const tipStack = tip.stack
+                  //  to delete any tiprackAdapters + tipracks
+                  tipStack.forEach(item => {
+                    if (labware[item] != null) {
+                      dispatch(deleteContainer({ labwareId: item }))
+                    }
+                  })
+                  allTiprackLidsOnDeck.forEach(lid =>
+                    dispatch(deleteContainer({ labwareId: lid.id }))
+                  )
+                })
               }}
             />
           ) : null}

--- a/protocol-designer/src/components/organisms/EditInstrumentsModal/editPipettes.ts
+++ b/protocol-designer/src/components/organisms/EditInstrumentsModal/editPipettes.ts
@@ -4,10 +4,7 @@ import last from 'lodash/last'
 import mapValues from 'lodash/mapValues'
 
 import { INITIAL_DECK_SETUP_STEP_ID } from '/protocol-designer/constants'
-import {
-  createContainer,
-  deleteContainer,
-} from '/protocol-designer/labware-ingred/actions'
+import { createContainer } from '/protocol-designer/labware-ingred/actions'
 import { actions as stepFormActions } from '/protocol-designer/step-forms'
 import { actions as steplistActions } from '/protocol-designer/steplist'
 import { uuid } from '/protocol-designer/utils'
@@ -15,10 +12,7 @@ import { uuid } from '/protocol-designer/utils'
 import type { PipetteMount, PipetteName } from '@opentrons/shared-data'
 import type { NormalizedPipette } from '@opentrons/step-generation'
 import type { StepIdType } from '/protocol-designer/form-types'
-import type {
-  LabwareOnDeck,
-  PipetteOnDeck,
-} from '/protocol-designer/step-forms'
+import type { PipetteOnDeck } from '/protocol-designer/step-forms'
 import type { ThunkDispatch } from '/protocol-designer/types'
 
 const adapter96ChannelDefUri = 'opentrons/opentrons_flex_96_tiprack_adapter/1'
@@ -27,9 +21,7 @@ type PipetteFieldsData = Omit<
   PipetteOnDeck,
   'id' | 'spec' | 'tiprackLabwareDef' | 'pythonName'
 >
-
 export const editPipettes = (
-  labware: { [labwareId: string]: LabwareOnDeck },
   pipettes: { [pipetteId: string]: PipetteOnDeck },
   orderedStepIds: StepIdType[],
   dispatch: ThunkDispatch<any>,
@@ -88,38 +80,24 @@ export const editPipettes = (
   const newTiprackUris = new Set(
     newPipetteArray.flatMap(pipette => pipette.tiprackDefURI)
   )
-  const previousTiprackLabwares = Object.values(labware).filter(
-    lw => lw.def.parameters.isTiprack
-  )
-
-  const previousTiprackUris = new Set(
-    previousTiprackLabwares.map(labware => labware.labwareDefURI)
-  )
-
-  // Find tipracks to delete (old tipracks not in new pipettes)
-  previousTiprackLabwares
-    .filter(labware => !newTiprackUris.has(labware.labwareDefURI))
-    .forEach(labware => dispatch(deleteContainer({ labwareId: labware.id })))
 
   // Create new tipracks that are not in previous tiprackURIs
   newTiprackUris.forEach(tiprackDefUri => {
-    if (!previousTiprackUris.has(tiprackDefUri)) {
-      const adapterUnderLabwareDefURI = newPipetteArray.some(
-        pipette => pipette.name === 'p1000_96'
-      )
-        ? adapter96ChannelDefUri
-        : undefined
-      dispatch(
-        createContainer({
-          labwareDefURIStack: [
-            ...(adapterUnderLabwareDefURI != null
-              ? [adapterUnderLabwareDefURI]
-              : []),
-            tiprackDefUri,
-          ],
-        })
-      )
-    }
+    const adapterUnderLabwareDefURI = newPipetteArray.some(
+      pipette => pipette.name === 'p1000_96'
+    )
+      ? adapter96ChannelDefUri
+      : undefined
+    dispatch(
+      createContainer({
+        labwareDefURIStack: [
+          ...(adapterUnderLabwareDefURI != null
+            ? [adapterUnderLabwareDefURI]
+            : []),
+          tiprackDefUri,
+        ],
+      })
+    )
   })
   dispatch(
     stepFormActions.createPipettes(

--- a/protocol-designer/src/components/organisms/EditInstrumentsModal/editPipettes.ts
+++ b/protocol-designer/src/components/organisms/EditInstrumentsModal/editPipettes.ts
@@ -87,7 +87,7 @@ export const editPipettes = (
       pipette => pipette.name === 'p1000_96'
     )
       ? adapter96ChannelDefUri
-      : undefined
+      : null
     dispatch(
       createContainer({
         labwareDefURIStack: [

--- a/protocol-designer/src/components/organisms/EditInstrumentsModal/index.tsx
+++ b/protocol-designer/src/components/organisms/EditInstrumentsModal/index.tsx
@@ -90,7 +90,6 @@ export function EditInstrumentsModal(
     } else {
       setPage('overview')
       editPipettes(
-        labware,
         pipettes,
         orderedStepIds,
         dispatch,

--- a/protocol-designer/src/components/organisms/SelectLabwareModal/index.tsx
+++ b/protocol-designer/src/components/organisms/SelectLabwareModal/index.tsx
@@ -37,6 +37,8 @@ import {
   OT2_ROBOT_TYPE,
 } from '@opentrons/shared-data'
 
+import { TIPRACK_LID_LOADNAME } from '/protocol-designer/pages/Designer/utils'
+
 import { LINK_BUTTON_STYLE } from '../../../components/atoms'
 import { getEnableStacking } from '../../../feature-flags/selectors'
 import { getRobotType } from '../../../file-data/selectors'
@@ -203,7 +205,9 @@ export function SelectLabwareModal(
         (slot === 'offDeck' && isAdapter) ||
         (PLATE_READER_LOADNAME === parameters.loadName &&
           moduleType !== ABSORBANCE_READER_TYPE) ||
-        (!enableStacking && parameters.loadName === 'opentrons_flex_deck_riser')
+        (!enableStacking &&
+          parameters.loadName === 'opentrons_flex_deck_riser') ||
+        parameters.loadName === TIPRACK_LID_LOADNAME
       )
     },
     [filterRecommended, filterHeight, getIsLabwareCompatible, moduleType, slot]

--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupDetails.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupDetails.tsx
@@ -30,7 +30,7 @@ import {
   getTopmostLabwareOnModuleFromStack,
 } from '../../../utils'
 import { HighlightLabware } from '../HighlightLabware'
-import { getSlotInformation } from '../utils'
+import { getSlotInformation, TIPRACK_LID_LOADNAME } from '../utils'
 import { HighlightItems } from './HighlightItems'
 import { AdapterControls, LabwareControls, SlotControls } from './Overlays'
 import { ActiveLabwareControls } from './Overlays/ActiveLabwareControls'
@@ -429,7 +429,8 @@ export function DeckSetupDetails(props: DeckSetupDetailsProps): JSX.Element {
         if (
           getSlotInLocationStack(labware.stack) === 'offDeck' ||
           allModules.some(m => labware.stack.includes(m.id)) ||
-          labware.id === adjacentLabware?.id
+          labware.id === adjacentLabware?.id ||
+          labware.def.parameters.loadName === TIPRACK_LID_LOADNAME
         ) {
           return null
         }
@@ -507,7 +508,8 @@ export function DeckSetupDetails(props: DeckSetupDetailsProps): JSX.Element {
       {allLabware.map(labware => {
         if (
           allModules.some(m => labware.stack.includes(m.id)) ||
-          getSlotInLocationStack(labware.stack) === 'offDeck'
+          getSlotInLocationStack(labware.stack) === 'offDeck' ||
+          labware.def.parameters.loadName === TIPRACK_LID_LOADNAME
         )
           return null
         if (

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLabwareTools/LabwareLocationField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLabwareTools/LabwareLocationField.tsx
@@ -1,12 +1,24 @@
 import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 
+import {
+  FLEX_SINGLE_SLOT_ADDRESSABLE_AREAS,
+  FLEX_STAGING_AREA_SLOT_ADDRESSABLE_AREAS,
+  OT2_SINGLE_SLOT_ADDRESSABLE_AREAS,
+  WASTE_CHUTE_CUTOUT,
+} from '@opentrons/shared-data'
 import { getSlotInLocationStack } from '@opentrons/step-generation'
 
 import { DropdownStepFormField } from '/protocol-designer/components/molecules'
 import { getEnableStacking } from '/protocol-designer/feature-flags/selectors'
-import { getUnoccupiedStackOptions } from '/protocol-designer/pages/Designer/utils'
-import { getLabwareEntities } from '/protocol-designer/step-forms/selectors'
+import {
+  getUnoccupiedStackOptions,
+  TIPRACK_LID_LOADNAME,
+} from '/protocol-designer/pages/Designer/utils'
+import {
+  getAdditionalEquipmentEntities,
+  getLabwareEntities,
+} from '/protocol-designer/step-forms/selectors'
 import {
   getDeckSetupForActiveItem,
   getRobotStateAtActiveItem,
@@ -14,6 +26,7 @@ import {
 } from '/protocol-designer/top-selectors/labware-locations'
 import { hoverSelection } from '/protocol-designer/ui/steps/actions/actions'
 
+import type { AddressableAreaName } from '@opentrons/shared-data'
 import type { Option } from '/protocol-designer/top-selectors/labware-locations'
 import type { FieldProps } from '../../types'
 
@@ -31,6 +44,9 @@ export function LabwareLocationField(
   const { labware: deckSetupLabware } = useSelector(getDeckSetupForActiveItem)
   const dispatch = useDispatch()
   const labwareEntities = useSelector(getLabwareEntities)
+  const additionalEquipmentEntities = useSelector(
+    getAdditionalEquipmentEntities
+  )
   const robotState = useSelector(getRobotStateAtActiveItem)
   const unoccupiedLabwareStackOptions: Option[] =
     robotState && enableStacking
@@ -47,18 +63,51 @@ export function LabwareLocationField(
       ? getSlotInLocationStack(robotState?.labware[labware]?.stack ?? []) ===
         'offDeck'
       : false
-
+  const isLabwareALid =
+    deckSetupLabware[labware]?.def.allowedRoles?.includes('lid') ?? false
+  const isLabwareATiprackLid =
+    deckSetupLabware[labware]?.def.parameters.loadName === TIPRACK_LID_LOADNAME
   const unoccupiedLabwareLocationsOptionsSelector =
     useSelector(getUnoccupiedLabwareLocationOptions) ?? []
 
   // invalid offDeck move filter
-  const unoccupiedLabwareLocationsOptions = [
+  let unoccupiedLabwareLocationsOptions = [
     ...unoccupiedLabwareStackOptions,
     ...unoccupiedLabwareLocationsOptionsSelector,
-  ].filter(option => {
-    const canMoveOffDeck = !(useGripper || isLabwareOffDeck)
-    return option.value !== 'offDeck' || canMoveOffDeck
-  })
+  ]
+  if (useGripper || isLabwareOffDeck) {
+    unoccupiedLabwareLocationsOptions = unoccupiedLabwareLocationsOptions.filter(
+      option => option.value !== 'offDeck'
+    )
+  }
+
+  if (
+    !useGripper &&
+    Object.values(additionalEquipmentEntities).find(
+      ae => ae.name === 'wasteChute'
+    ) != null
+  ) {
+    unoccupiedLabwareLocationsOptions = unoccupiedLabwareLocationsOptions.filter(
+      option => option.value !== WASTE_CHUTE_CUTOUT
+    )
+  }
+
+  if (!isLabwareALid) {
+    unoccupiedLabwareLocationsOptions = unoccupiedLabwareLocationsOptions.filter(
+      option => option.name !== 'Trash bin'
+    )
+  }
+  const allSlotNames = [
+    ...FLEX_SINGLE_SLOT_ADDRESSABLE_AREAS,
+    ...FLEX_STAGING_AREA_SLOT_ADDRESSABLE_AREAS,
+    ...OT2_SINGLE_SLOT_ADDRESSABLE_AREAS,
+  ]
+
+  if (isLabwareATiprackLid) {
+    unoccupiedLabwareLocationsOptions = unoccupiedLabwareLocationsOptions.filter(
+      option => !allSlotNames.includes(option.value as AddressableAreaName)
+    )
+  }
 
   return (
     <DropdownStepFormField

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/AddStepButton.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/AddStepButton.tsx
@@ -27,6 +27,7 @@ import {
 } from '@opentrons/components'
 import {
   ABSORBANCE_READER_TYPE,
+  getIsLid,
   getIsTiprack,
   HEATERSHAKER_MODULE_TYPE,
   MAGNETIC_MODULE_TYPE,
@@ -118,7 +119,8 @@ export function AddStepButton({
       labwareDef != null &&
       getSlotInLocationStack(stack) !== OFFDECK &&
       !getIsTiprack(labwareDef) &&
-      !getIsAdapterFromDef(labwareDef)
+      !getIsAdapterFromDef(labwareDef) &&
+      !getIsLid(labwareDef)
     )
   })
   const getSupportedSteps = (): Array<

--- a/protocol-designer/src/pages/Designer/utils.ts
+++ b/protocol-designer/src/pages/Designer/utils.ts
@@ -5,6 +5,7 @@ import { reduce } from 'lodash'
 import {
   FLEX_ROBOT_TYPE,
   getAllLabwareDefs,
+  getIsLid,
   getIsPipettableLabware,
   getIsTiprack,
   getPositionFromSlotId,
@@ -326,6 +327,7 @@ export const useLabwareDropdownOptions = (
         t
       )
       const isTiprack = getIsTiprack(def)
+      const isLid = getIsLid(def)
       const isFilterOffDeck =
         deckSlot === 'offDeck' &&
         (type === 'labware' || (type === 'moveLabware' && useGripper))
@@ -342,7 +344,7 @@ export const useLabwareDropdownOptions = (
       const restOfOptions: DropdownOption[] =
         isAdapter ||
         isLabwareInWasteChute ||
-        (type === 'labware' && isTiprack) ||
+        (type === 'labware' && (isTiprack || isLid)) ||
         isFilterOffDeck ||
         !isTopOfStack
           ? acc

--- a/protocol-designer/src/pages/ProtocolOverview/DeckThumbnailDetails.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/DeckThumbnailDetails.tsx
@@ -21,6 +21,7 @@ import {
   getStagingAreaAddressableAreas,
   getTopmostLabwareOnModuleFromStack,
 } from '../../utils'
+import { TIPRACK_LID_LOADNAME } from '../Designer/utils'
 import { SlotHover } from './SlotHover'
 
 import type { Dispatch, SetStateAction } from 'react'
@@ -119,7 +120,8 @@ export const DeckThumbnailDetails = (
       {allLabware.map(labware => {
         if (
           getSlotInLocationStack(labware.stack) === 'offDeck' ||
-          allModules.some(m => labware.stack.includes(m.id))
+          allModules.some(m => labware.stack.includes(m.id)) ||
+          labware.def.parameters.loadName === TIPRACK_LID_LOADNAME
         ) {
           return null
         }

--- a/step-generation/src/__tests__/moveLabware.test.ts
+++ b/step-generation/src/__tests__/moveLabware.test.ts
@@ -8,6 +8,7 @@ import {
 } from '@opentrons/shared-data'
 
 import { moveLabware } from '../commandCreators/atomic'
+import { TIPRACK_LID_LOADNAME } from '../commandCreators/atomic/moveLabware'
 import {
   DEST_LABWARE,
   getErrorResult,
@@ -498,6 +499,7 @@ describe('moveLabware', () => {
   it('should return an error for trying to move an aluminum block with a gripper', () => {
     const aluminumBlockDef = ({
       metadata: { displayCategory: 'aluminumBlock' },
+      parameters: { loadName: 'mockAluminumBlockLoadName' },
     } as any) as LabwareDefinition2
 
     invariantContext = {
@@ -1070,6 +1072,62 @@ describe('moveLabware', () => {
     expect(errors).toHaveLength(1)
     expect(errors[0]).toMatchObject({
       type: 'LABWARE_ON_ANOTHER_ENTITY',
+    })
+  })
+  it('should return an error when trying to move a tiprack lid to a slot', () => {
+    invariantContext = {
+      ...invariantContext,
+      labwareEntities: {
+        ...invariantContext.labwareEntities,
+        [SOURCE_LABWARE]: {
+          ...invariantContext.labwareEntities[SOURCE_LABWARE],
+          def: {
+            ...invariantContext.labwareEntities[SOURCE_LABWARE].def,
+            parameters: { loadName: TIPRACK_LID_LOADNAME } as any,
+            allowedRoles: ['lid'],
+          } as LabwareDefinition2,
+        },
+      },
+    } as InvariantContext
+
+    const params = {
+      labwareId: SOURCE_LABWARE,
+      newLocation: { slotName: 'A1' },
+      strategy: 'manualMoveWithPause',
+    } as MoveLabwareParams
+    const result = moveLabware(params, invariantContext, robotState)
+    const { errors } = getErrorResult(result)
+    expect(errors).toHaveLength(1)
+    expect(errors[0]).toMatchObject({
+      type: 'TIPRACK_LID_NOT_ALLOWED_ON_DECK',
+    })
+  })
+  it('should return an error when trying to move a tiprack lid to a staging area', () => {
+    invariantContext = {
+      ...invariantContext,
+      labwareEntities: {
+        ...invariantContext.labwareEntities,
+        [SOURCE_LABWARE]: {
+          ...invariantContext.labwareEntities[SOURCE_LABWARE],
+          def: {
+            ...invariantContext.labwareEntities[SOURCE_LABWARE].def,
+            parameters: { loadName: TIPRACK_LID_LOADNAME } as any,
+            allowedRoles: ['lid'],
+          } as LabwareDefinition2,
+        },
+      },
+    } as InvariantContext
+
+    const params = {
+      labwareId: SOURCE_LABWARE,
+      newLocation: { addressableAreaName: 'A4' },
+      strategy: 'manualMoveWithPause',
+    } as MoveLabwareParams
+    const result = moveLabware(params, invariantContext, robotState)
+    const { errors } = getErrorResult(result)
+    expect(errors).toHaveLength(1)
+    expect(errors[0]).toMatchObject({
+      type: 'TIPRACK_LID_NOT_ALLOWED_ON_DECK',
     })
   })
 })

--- a/step-generation/src/commandCreators/atomic/moveLabware.ts
+++ b/step-generation/src/commandCreators/atomic/moveLabware.ts
@@ -1,6 +1,7 @@
 import {
   ABSORBANCE_READER_TYPE,
   FLEX_ROBOT_TYPE,
+  FLEX_STAGING_AREA_SLOT_ADDRESSABLE_AREAS,
   getIsLid,
   HEATERSHAKER_MODULE_TYPE,
   MOVABLE_TRASH_ADDRESSABLE_AREAS,
@@ -38,6 +39,8 @@ import type {
   CommandCreatorWarning,
   ModuleState,
 } from '../../types'
+
+export const TIPRACK_LID_LOADNAME = 'opentrons_flex_tiprack_lid'
 
 /** Move labware from one location to another, manually or via a gripper. */
 export const moveLabware: CommandCreator<MoveLabwareParams> = (
@@ -216,6 +219,21 @@ export const moveLabware: CommandCreator<MoveLabwareParams> = (
         errors.push(errorCreators.absorbanceReaderLidClosed())
       }
     }
+  }
+  const isLabwareIdATiprackLid =
+    labwareEntities[labwareId]?.def.parameters.loadName === TIPRACK_LID_LOADNAME
+  if (
+    isLabwareIdATiprackLid &&
+    newLocation != null &&
+    newLocation !== 'offDeck' &&
+    newLocation !== 'systemLocation' &&
+    ('slotName' in newLocation ||
+      ('addressableAreaName' in newLocation &&
+        FLEX_STAGING_AREA_SLOT_ADDRESSABLE_AREAS.includes(
+          newLocation.addressableAreaName as AddressableAreaName
+        )))
+  ) {
+    errors.push(errorCreators.tipRackLidNotAllowedOnDeck())
   }
 
   const params = {

--- a/step-generation/src/errorCreators.ts
+++ b/step-generation/src/errorCreators.ts
@@ -353,3 +353,10 @@ export const returnTipUnavailable = (): CommandCreatorError => {
     message: 'Current tip does not have a known location to return to',
   }
 }
+
+export const tipRackLidNotAllowedOnDeck = (): CommandCreatorError => {
+  return {
+    type: 'TIPRACK_LID_NOT_ALLOWED_ON_DECK',
+    message: 'The tip rack lid is not supported directly on the deck',
+  }
+}

--- a/step-generation/src/types.ts
+++ b/step-generation/src/types.ts
@@ -726,6 +726,7 @@ export type ErrorType =
   | 'TALL_LABWARE_EAST_WEST_OF_HEATER_SHAKER'
   | 'THERMOCYCLER_LID_CLOSED'
   | 'TIP_VOLUME_EXCEEDED'
+  | 'TIPRACK_LID_NOT_ALLOWED_ON_DECK'
 
 export interface CommandCreatorError {
   message: string


### PR DESCRIPTION
closes AUTH-2012

# Overview

This PR tells the journey of tip rack lids, the lids that are treated much differently than other lids:

1. they can not go on a slot
2. they can not be stacked
3. they can only be discarded (trash bin, waste chute, off-deck)
4. they don't even show up on the deck map

## Test Plan and Hands on Testing

- Create a Flex protocol with a tiprack
- go into deck map view and edit that tiprack and add a lid on top of the tiprack
- see that the tiprack lid does not show up on the deck
- confirm that you can't drag/drop that lid because it is not visible
- add a labware on the deck with no lid
- create a transfer step and see that the lid is not an option to transfer liquid in
- create a move labware step and see that if the tiprack lid is selected, you can't drop it into any location except for the off-deck or waste chute. (NOTE: the trash bin drop location is added in this PR: https://github.com/Opentrons/opentrons/pull/19204)

## Changelog

- create timeline error for moving a tiprack lid onto the deckmap (can't actually replicate this in practice so its a safe guard)
- delete lid when deleting the pipette assosciated tipracks
- filter out the slot names from movign the lid in the move labware dropdown menu
- filter out transferring/mixing in a lid

## Risk assessment

low
