### PR TITLE
fix(protocol-designer): getLiquidDisplayColors() must support non-contiguous liquidGroupIds

### DIFF
--- a/protocol-designer/src/components/organisms/Labware/WellTooltip.tsx
+++ b/protocol-designer/src/components/organisms/Labware/WellTooltip.tsx
@@ -151,7 +151,7 @@ export const WellTooltip = ({
                           <td>
                             <ColorCircle
                               color={
-                                liquidDisplayColors[Number(groupId)] ??
+                                liquidDisplayColors[groupId] ??
                                 swatchColors(groupId)
                               }
                             />

--- a/protocol-designer/src/components/organisms/LabwareOnDeck/utils.ts
+++ b/protocol-designer/src/components/organisms/LabwareOnDeck/utils.ts
@@ -15,15 +15,14 @@ import type {
 
 const ingredIdsToColor = (
   groupIds: string[],
-  displayColors: string[]
+  displayColors: Record<string, string> // liquidGroupId -> color
 ): string | null | undefined => {
   const filteredIngredIds = groupIds.filter(id => id !== AIR)
   if (filteredIngredIds.length === 0) return null
 
   if (filteredIngredIds.length === 1) {
     return (
-      displayColors[Number(filteredIngredIds[0])] ??
-      swatchColors(filteredIngredIds[0])
+      displayColors[filteredIngredIds[0]] ?? swatchColors(filteredIngredIds[0])
     )
   }
 
@@ -32,7 +31,7 @@ const ingredIdsToColor = (
 
 export const wellFillFromWellContents = (
   wellContents: ContentsByWell,
-  displayColors: string[]
+  displayColors: Record<string, string> // liquidGroupId -> color
 ): WellFill =>
   reduce(
     wellContents,

--- a/protocol-designer/src/components/organisms/SelectWellsModal/__tests__/SelectWellsModal.test.tsx
+++ b/protocol-designer/src/components/organisms/SelectWellsModal/__tests__/SelectWellsModal.test.tsx
@@ -49,7 +49,7 @@ describe('SelectWellsModal', () => {
     vi.mocked(SelectableLabware).mockReturnValue(
       <div>mock SelectableLabware</div>
     )
-    vi.mocked(selectors.getLiquidDisplayColors).mockReturnValue([])
+    vi.mocked(selectors.getLiquidDisplayColors).mockReturnValue({})
     vi.mocked(getAllWellContentsForActiveItem).mockReturnValue({})
     vi.mocked(selectors.getLiquidNamesById).mockReturnValue({})
     vi.mocked(getLabwareEntities).mockReturnValue({

--- a/protocol-designer/src/labware-ingred/selectors.ts
+++ b/protocol-designer/src/labware-ingred/selectors.ts
@@ -137,13 +137,19 @@ const getDeckHasLiquid: Selector<RootSlice, boolean> = createSelector(
   getLiquidGroupsOnDeck,
   liquidGroups => liquidGroups.length > 0
 )
-const getLiquidDisplayColors: Selector<RootSlice, string[]> = createSelector(
+const getLiquidDisplayColors: Selector<
+  RootSlice,
+  Record<string, string>
+> = createSelector(
   getLiquidGroupsById,
+  // returns liquidGroupId -> color
   liquids =>
-    Object.values(liquids).reduce<string[]>((acc, curr) => {
-      acc.push(curr.displayColor)
-      return acc
-    }, [])
+    Object.fromEntries(
+      Object.values(liquids).map(liquid => [
+        liquid.liquidGroupId,
+        liquid.displayColor,
+      ])
+    )
 )
 
 const getZoomedInSlotInfo: Selector<

--- a/protocol-designer/src/pages/Designer/OffDeck/__tests__/OffDeckDetails.test.tsx
+++ b/protocol-designer/src/pages/Designer/OffDeck/__tests__/OffDeckDetails.test.tsx
@@ -67,7 +67,7 @@ describe('OffDeckDetails', () => {
         },
       },
     })
-    vi.mocked(selectors.getLiquidDisplayColors).mockReturnValue([])
+    vi.mocked(selectors.getLiquidDisplayColors).mockReturnValue({})
     vi.mocked(getAllWellContentsForActiveItem).mockReturnValue({})
     vi.mocked(HighlightOffdeckSlot).mockReturnValue(
       <div>Highlight Offdeck Slot</div>

--- a/protocol-designer/src/pages/ProtocolOverview/__tests__/OffdeckThumbnail.test.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/__tests__/OffdeckThumbnail.test.tsx
@@ -59,7 +59,7 @@ describe('OffDeckThumbnail', () => {
         },
       },
     })
-    vi.mocked(selectors.getLiquidDisplayColors).mockReturnValue([])
+    vi.mocked(selectors.getLiquidDisplayColors).mockReturnValue({})
     vi.mocked(getAllWellContentsForActiveItem).mockReturnValue({})
   })
 


### PR DESCRIPTION
# Overview

Fixes AUTH-2195, where PD crashes when you click "View labware" in a protocol that has a deleted liquid. Also fixes the less-noticed issue where we would display the wrong liquid color after deleting a liquid.

The root cause is that the selector `getLiquidDisplayColors()` returned an **array** of liquid `displayColor`s, where the 0th entry is supposed to be the color of `liquidGroupId` `"0"`, the 1st entry is supposed to be the color of `liquidGroupId` `"1"`, etc.

But this implementation breaks once you start deleting liquids, because you might end up with:
```
{ "liquidGroupId": "4", "displayColor": "#444444" },
{ "liquidGroupId": "5", "displayColor": "#555555" },
{ "liquidGroupId": "6", "displayColor": "#666666" },
```
In this case, `getLiquidDisplayColors()` would still return an array of 3 values:
```
["#444444", "#555555", "#666666"]
```
But now trying to get array subscript `6` to look up the color for `liquidGroupId` `"6"` would fail terribly.

This PR changes `getLiquidDisplayColors()` to return a dictionary instead of an array so that it works even if the `liquidGroupId`s are not contiguous.

## Test Plan and Hands on Testing

Updated the unit tests that used `getLiquidDisplayColors()` directly.

My primary test case is the protocol file in https://opentrons.slack.com/archives/C07E9T2NAQK/p1755031718496719. Before this PR, it would crash when you click "View labware", and it no longer crashes after.

Here's why it was crashing before: It was crashing in: https://github.com/Opentrons/opentrons/blob/74217eb68533e79e605e69f578337bab5d8e29c7/shared-data/js/helpers/getWellRangeForLiquidLabwarePair.ts#L12 because `volumeByWell` is undefined.

`volumeByWell` was coming from here: https://github.com/Opentrons/opentrons/blob/74217eb68533e79e605e69f578337bab5d8e29c7/protocol-designer/src/components/organisms/SlotDetailModal/LiquidDetailCard.tsx#L53-L57 where we were trying to look up `volumesPerLiquid[selectedValue="2"]` in the case of the protocol above.

`volumesPerLiquid` in turn came from: https://github.com/Opentrons/opentrons/blob/74217eb68533e79e605e69f578337bab5d8e29c7/protocol-designer/src/components/organisms/SlotDetailModal/index.tsx#L80 where we were calling it with `individualIds=['1']` because `liquidGroupId="1"` is the only liquid on the labware. So we get back a `volumesPerLiquid` that only has an entry for `liquidGroupId="1"`.

That's all correct so far. So how did we ended up calling `LiquidDetailCard.tsx` with `selectedValue="2"` when `liquidGroupId="2"` is not on the labware?

The protocol has 2 liquids:
```
{ "liquidGroupId": "1", "displayColor": "#ffd600"},
{ "liquidGroupId": "2", "displayColor": "#9dffd8"},
```
with `liquidGroupId="0"` having been deleted.

The `selectedValue` came from: https://github.com/Opentrons/opentrons/blob/74217eb68533e79e605e69f578337bab5d8e29c7/protocol-designer/src/components/organisms/SlotDetailModal/index.tsx#L84-L89 Here, we're trying to find the first liquid that's present in the labware, by matching against the available `displayColor`s.

Those `displayColor`s in `wellFill` came from: https://github.com/Opentrons/opentrons/blob/74217eb68533e79e605e69f578337bab5d8e29c7/protocol-designer/src/components/organisms/SlotDetailModal/index.tsx#L74-L77 https://github.com/Opentrons/opentrons/blob/74217eb68533e79e605e69f578337bab5d8e29c7/protocol-designer/src/components/organisms/SlotDetailModal/index.tsx#L59
This is where the bug is. In the old code, `getLiquidDisplayColors()` returned an array:
```
["#ffd600" (liquidGroupId="1"), "#9dffd8" (liquidGroupId="2")]
```
In the labware, `"#ffd600"` (`liquidGroupId="1"`) is the only liquid present. We meant for `allWellFill` to contain `"#ffd600"`. But `allWellFill` actually only contains `"#9dffd8"` (for `liquidGroupId="2"`) because https://github.com/Opentrons/opentrons/blob/74217eb68533e79e605e69f578337bab5d8e29c7/protocol-designer/src/components/organisms/LabwareOnDeck/utils.ts#L33-L40 and `ingredIdsToColor()` is picking `displayColors["1"]` because we want `liquidGroupId="1"` -- but `displayColors["1"]` is the color for `liquidGroupId="2"`!

## Risk assessment

Low-medium. Small but subtle logic change.