### PR TITLE
fix(api): Catch and ignore flush exceptions after entering dfu mode when module is updating + show update success screen.

### DIFF
--- a/api/src/opentrons/drivers/asyncio/communication/async_serial.py
+++ b/api/src/opentrons/drivers/asyncio/communication/async_serial.py
@@ -120,8 +120,12 @@ class AsyncSerial:
         """
         if self._reset_buffer_before_write:
             self._serial.reset_input_buffer()
-        self._serial.write(data=data)
-        self._serial.flush()
+        self._serial.write(data)
+        # flush can fail after entering dfu mode, ignore any exceptions.
+        try:
+            self._serial.flush()
+        except Exception:
+            pass
 
     async def open(self) -> None:
         """

--- a/api/tests/opentrons/drivers/asyncio/communication/test_async_serial.py
+++ b/api/tests/opentrons/drivers/asyncio/communication/test_async_serial.py
@@ -136,3 +136,32 @@ def test_reset_input_buffer(mock_serial: MagicMock, subject: AsyncSerial) -> Non
     """It should call the underlying serial port's Reset function"""
     subject.reset_input_buffer()
     mock_serial.reset_input_buffer.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "flush_side_effect",
+    [
+        None,  # case 1: flush works normally
+        OSError("device disconnected!"),  # case 2: flush raises
+    ],
+)
+async def test_no_exception_on_flush(
+    mock_serial: MagicMock, subject: AsyncSerial, flush_side_effect: Optional[Exception]
+) -> None:
+    """It should ignore exceptions from flush.
+
+    This can happen after a device has been issued a `dfu` command
+    and disconnects before the flush command executes.
+    """
+    # Add side effect to simulate an exception happening when flush is called
+    mock_serial.flush.side_effect = flush_side_effect
+
+    # flush should not raise any exceptions in both cases, otherwise test fails.
+    try:
+        await subject.write("dfu".encode())
+    except Exception as e:
+        pytest.fail(f"_sync_write leaked an exception: {e!r}")
+
+    # Verify flush was called once
+    mock_serial.flush.assert_called_once()
+    mock_serial.reset_mock()

--- a/api/tests/opentrons/drivers/asyncio/communication/test_async_serial.py
+++ b/api/tests/opentrons/drivers/asyncio/communication/test_async_serial.py
@@ -141,8 +141,8 @@ def test_reset_input_buffer(mock_serial: MagicMock, subject: AsyncSerial) -> Non
 @pytest.mark.parametrize(
     "flush_side_effect",
     [
-        None,  # case 1: flush works normally
-        OSError("device disconnected!"),  # case 2: flush raises
+        None,
+        OSError("device disconnected!"),
     ],
 )
 async def test_no_exception_on_flush(
@@ -153,15 +153,12 @@ async def test_no_exception_on_flush(
     This can happen after a device has been issued a `dfu` command
     and disconnects before the flush command executes.
     """
-    # Add side effect to simulate an exception happening when flush is called
     mock_serial.flush.side_effect = flush_side_effect
 
-    # flush should not raise any exceptions in both cases, otherwise test fails.
     try:
         await subject.write("dfu".encode())
     except Exception as e:
         pytest.fail(f"_sync_write leaked an exception: {e!r}")
 
-    # Verify flush was called once
     mock_serial.flush.assert_called_once()
     mock_serial.reset_mock()

--- a/app/src/organisms/ModuleWizardFlows/UpdateFirmware.tsx
+++ b/app/src/organisms/ModuleWizardFlows/UpdateFirmware.tsx
@@ -92,6 +92,7 @@ export function UpdateFirmware(props: UpdateFirmwareProps): JSX.Element {
       // Update passed
       setShouldProceed(true)
       setIsModuleUpdating(false)
+      setInProgress(false)
       sendIdentifyStacker(matchingModule, true, 'blue')
       patchModuleAfterUpdate(matchingModule)
       setTimeout(() => {


### PR DESCRIPTION
# Overview

The Module failed to update because of an exception caused by calling `Serial.flush()` after issuing a `dfu` command, which puts the module in bootloader mode and disconnects it from USB. So let's catch and ignore any exceptions when `flush` is called after writing a command to a module, which will catch any exceptions. Also fixed an issue found while testing this: the success update screen was not showing after an update was installed successfully; the flow would go to the "deck config" screen instead.

Closes: [RQA-4565](https://opentrons.atlassian.net/browse/RQA-4565)

## Test Plan and Hands on Testing

- [x] Make sure you can still update modules
- [x] Make sure the Installed Successfully screen is shown after a successful update.

## Changelog

- Catch potential exceptions when calling `flush` after issuing a `dfu` command to enter bootloader mode
- Set the `setInProgress` flag to false after successfully installing an update so the "Update Successful" screen is shown.

## Review requests
## Risk assessment
Low

[RQA-4565]: https://opentrons.atlassian.net/browse/RQA-4565?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ