### PR TITLE
fix(app): Work around incomplete paints after a setup step has expanded

### DIFF
--- a/app/src/organisms/Desktop/Devices/ProtocolRun/SetupStep.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/SetupStep.tsx
@@ -90,9 +90,7 @@ export function SetupStep({
           </Flex>
         </Flex>
       </Btn>
-      <Box css={expanded ? EXPANDED_STYLE : COLLAPSED_STYLE}>
-        <Box overflow={OVERFLOW_HIDDEN}>{children}</Box>
-      </Box>
+      <Box css={expanded ? EXPANDED_STYLE : COLLAPSED_STYLE}>{children}</Box>
     </Flex>
   )
 }

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/SetupStep.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/SetupStep.tsx
@@ -90,7 +90,21 @@ export function SetupStep({
           </Flex>
         </Flex>
       </Btn>
-      <Box css={expanded ? EXPANDED_STYLE : COLLAPSED_STYLE}>{children}</Box>
+      <div
+        css={expanded ? EXPANDED_STYLE : COLLAPSED_STYLE}
+        onTransitionEnd={e => {
+          // HACK:
+          // There's some kind of Chromium bug where, when the section expands,
+          // the contents will sometimes be left only partially painted, i.e. partially
+          // missing. They'll remain that way until something like a screen resize
+          // happens to force a repaint. It seems to happen more when there are
+          // performance problems (dropped frames and partially-presented frames) and
+          // when the section contents land partially below the fold.
+          forceRepaint(e.currentTarget)
+        }}
+      >
+        {children}
+      </div>
     </Flex>
   )
 }
@@ -98,17 +112,6 @@ export function SetupStep({
 const EXPANDED_STYLE = css`
   interpolate-size: allow-keywords;
   overflow: hidden;
-  /*
-  "will-change: transform" is an attempt to work around an apparent Chrome bug. Rarely,
-  when the section expands, the contents will be left only partially painted, i.e.
-  partially missing. They'll remain that way until something like a screen resize
-  happens to force a repaint. It seems to happen more when there are performance
-  problems (dropped frames and partially-presented frames) and when the section
-  contents land partially below the fold.
-
-  "will-change: transform" forces a new compositor layer, which seems to help.
-  */
-  will-change: transform;
 
   visibility: visible;
   height: auto;
@@ -117,7 +120,6 @@ const EXPANDED_STYLE = css`
 const COLLAPSED_STYLE = css`
   interpolate-size: allow-keywords;
   overflow: hidden;
-  will-change: transform;
 
   visibility: hidden;
   height: 0;
@@ -137,3 +139,11 @@ const RIGHT_CONTENT_CONTAINER_STYLE = css`
   align-items: ${ALIGN_CENTER};
   text-wrap: ${NO_WRAP};
 `
+
+// https://stackoverflow.com/questions/3485365
+function forceRepaint(element: HTMLElement): void {
+  element.style.display = 'none'
+  // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+  element.offsetHeight // no need to store this anywhere, the reference is enough
+  element.style.display = ''
+}

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/SetupStep.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/SetupStep.tsx
@@ -2,17 +2,14 @@ import { css } from 'styled-components'
 
 import {
   ALIGN_CENTER,
-  Box,
   Btn,
   COLORS,
   DIRECTION_COLUMN,
   DIRECTION_ROW,
-  DISPLAY_GRID,
   Flex,
   Icon,
   JUSTIFY_SPACE_BETWEEN,
   NO_WRAP,
-  OVERFLOW_HIDDEN,
   SPACING,
   StyledText,
   TYPOGRAPHY,

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/SetupStep.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/SetupStep.tsx
@@ -90,10 +90,7 @@ export function SetupStep({
           </Flex>
         </Flex>
       </Btn>
-      <Box
-        display={DISPLAY_GRID}
-        css={expanded ? EXPANDED_STYLE : COLLAPSED_STYLE}
-      >
+      <Box css={expanded ? EXPANDED_STYLE : COLLAPSED_STYLE}>
         <Box overflow={OVERFLOW_HIDDEN}>{children}</Box>
       </Box>
     </Flex>
@@ -101,14 +98,32 @@ export function SetupStep({
 }
 
 const EXPANDED_STYLE = css`
-  transition: grid-template-rows 300ms ease-in, visibility 400ms ease;
-  grid-template-rows: 1fr;
+  interpolate-size: allow-keywords;
+  overflow: hidden;
+  /*
+  "will-change: transform" is an attempt to work around an apparent Chrome bug. Rarely,
+  when the section expands, the contents will be left only partially painted, i.e.
+  partially missing. They'll remain that way until something like a screen resize
+  happens to force a repaint. It seems to happen more when there are performance
+  problems (dropped frames and partially-presented frames) and when the section
+  contents land partially below the fold.
+
+  "will-change: transform" forces a new compositor layer, which seems to help.
+  */
+  will-change: transform;
+
   visibility: visible;
+  height: auto;
+  transition: height 300ms ease-in, visibility 300ms step-start;
 `
 const COLLAPSED_STYLE = css`
-  transition: grid-template-rows 500ms ease-out, visibility 600ms ease;
-  grid-template-rows: 0fr;
+  interpolate-size: allow-keywords;
+  overflow: hidden;
+  will-change: transform;
+
   visibility: hidden;
+  height: 0;
+  transition: height 500ms ease-out, visibility 500ms step-end;
 `
 const ACCORDION_STYLE = css`
   border-radius: 50%;


### PR DESCRIPTION
## Overview

Closes RQA-4532. See that ticket for background.

## Changelog

* ~~Slap `will-change: transform` on the contents of each accordion section. Chrome treats this as a hint to establish a separate compositor layer. I'm throwing spaghetti at the wall, but this seems to help with RQA-4532.~~ Never mind, after further testing, this doesn't quite solve it.

* Whenever an expand/collapse animation completes, do some hacky shit to trick the browser into repainting the screen. This seems to fix RQA-4532. 🤷 

* Change how the expand/collapse transition is computed.

  Formerly, each section was a grid containing a single row, and we transitioned that row's height between `0fr` and `1fr`. This is a known trick for, effectively, transitioning between `height: 0` and `height: auto`. But this did weird things at the intermediate stages of the animation—there was empty space below the contents, like the contents and container were growing/shrinking at different rates. The problem is easier to see if you increase the transition time from 300 ms to like 3000 ms.

  These days, we can just transition from `height: 0` to `height: auto` directly, without grid tricks. So this PR does that to fix the empty space problem.

* Refactor the way the `visibility` transition is specified. This is just code cleanup, no user-visible effect.

  `visibility` is all-or-nothing—it doesn't interpolate—so it was a little misleading to use `ease` as the transition function. And I don't think the duration of this transition needed to be different from the duration of the height transition.

## Test Plan and Hands on Testing

* [x] Try the reproduction steps in RQA-4532 and make sure the problem doesn't happen anymore.
* [x] Make sure I haven't broken basic operation of the setup step accordion.

## Review requests

* Any better ideas?
* It sounds like [height animations like this tend to have performance problems](https://web.dev/articles/stick-to-compositor-only-properties-and-manage-layer-count), because every frame needs to recalculate the page's layout and repaint it. I suspect performance problems are contributing to this bug. I looked around and couldn't find a real solution to this, other than fundamentally changing the animation so it doesn't have to re-layout every frame.

## Risk assessment

Low.
