### PR TITLE
fix(protocol-designer): turn well max form error into a form warning

### DIFF
--- a/protocol-designer/src/assets/localization/en/protocol_steps.json
+++ b/protocol-designer/src/assets/localization/en/protocol_steps.json
@@ -22,7 +22,7 @@
     "targetHeaterShakerTemperature": "Must be between 37 and 95˚C",
     "blockTargetTempHold": "Must be between 4 and 99˚C",
     "lidTargetTempHold": "Must be between 37 and 110˚C",
-    "volume": "Must be between 0.1 and {{max}}"
+    "volume": "Recommended between 0.1 and {{max}}"
   },
   "change_tips": "Change tips",
   "column": "Column",

--- a/protocol-designer/src/steplist/formLevel/errors.ts
+++ b/protocol-designer/src/steplist/formLevel/errors.ts
@@ -497,13 +497,6 @@ const CONDITIONING_VOLUME_OUT_OF_RANGE: FormError = {
   page: 2,
   tab: 'aspirate',
 }
-const VOLUME_OUT_OF_RANGE: FormError = {
-  title: RANGE_TITLE,
-  dependentFields: ['volume'],
-  location: 'field',
-  page: 0,
-  showOnReopen: true,
-}
 const VOLUME_UNDER_MINIMUM: FormError = {
   title: RANGE_TITLE,
   dependentFields: ['volume'],
@@ -1452,38 +1445,6 @@ export const getIsOutOfRange = (
 ): boolean => {
   const castValue = Number(value)
   return castValue < min || castValue > max
-}
-
-export const transferVolumeMax = (
-  fields: HydratedMoveLiquidFormData | HydratedMixFormData
-): FormError | null => {
-  let labware
-  if (
-    'dispense_labware' in fields &&
-    fields.dispense_labware != null &&
-    fields.stepType === 'moveLiquid'
-  ) {
-    labware = fields.dispense_labware
-  } else if (
-    'labware' in fields &&
-    fields.labware != null &&
-    fields.stepType === 'mix'
-  ) {
-    labware = fields.labware
-  }
-
-  if (labware == null) {
-    return null
-  }
-
-  const dispenseLabwareMaxVolume =
-    'def' in labware ? labware.def?.wells.A1.totalLiquidVolume : null
-
-  return dispenseLabwareMaxVolume != null &&
-    typeof fields.volume === 'string' &&
-    parseInt(fields.volume) > dispenseLabwareMaxVolume
-    ? VOLUME_OUT_OF_RANGE
-    : null
 }
 
 export const transferVolumeMin = (

--- a/protocol-designer/src/steplist/formLevel/index.ts
+++ b/protocol-designer/src/steplist/formLevel/index.ts
@@ -71,7 +71,6 @@ import {
   targetTemperatureRequired,
   temperatureRequired,
   timesRequired,
-  transferVolumeMax,
   transferVolumeMin,
   volumeRequired,
   volumeTooHigh,
@@ -86,6 +85,7 @@ import {
   maxDispenseWellVolume,
   mixTipPositionInTube,
   tipPositionInTube,
+  wellVolumeMax,
 } from './warnings'
 
 import type {
@@ -180,14 +180,14 @@ const stepFormHelperMap: {
       pushOutVolumeOutOfRange,
       pushOutVolumeRequired,
       blowoutFlowRateRequired,
-      transferVolumeMax,
       transferVolumeMin,
       pipetteRequired
     ),
     getWarnings: composeWarnings(
       belowPipetteMinimumVolume,
       mixTipPositionInTube,
-      incompatibleLiquidClass
+      incompatibleLiquidClass,
+      wellVolumeMax
     ),
   },
   pause: {
@@ -232,7 +232,6 @@ const stepFormHelperMap: {
       conditioningVolumeRequired,
       conditioningVolumeOutOfRange,
       blowoutFlowRateRequired,
-      transferVolumeMax,
       transferVolumeMin,
       pipetteRequired,
       aspirateSubmergeSpeedRequired,
@@ -245,7 +244,8 @@ const stepFormHelperMap: {
       belowPipetteMinimumVolume,
       maxDispenseWellVolume,
       tipPositionInTube,
-      incompatibleLiquidClass
+      incompatibleLiquidClass,
+      wellVolumeMax
     ),
   },
   magnet: {

--- a/protocol-designer/src/steplist/formLevel/warnings.tsx
+++ b/protocol-designer/src/steplist/formLevel/warnings.tsx
@@ -31,6 +31,7 @@ export type FormWarningType =
   | 'MIX_TIP_POSITIONED_LOW_IN_TUBE'
   | 'OVER_MAX_WELL_VOLUME'
   | 'TIP_POSITIONED_LOW_IN_TUBE'
+  | 'VOLUME_OUT_OF_RANGE'
 export type FormWarning = FormError & {
   type: FormWarningType
 }
@@ -64,6 +65,13 @@ const mixTipPositionedLowInTube = (): FormWarning => ({
   title:
     'The default mix height is 1mm from the bottom of the well, which could cause liquid overflow or pipette damage. Edit tip position in advanced settings.',
   dependentFields: ['labware'],
+  location: 'form',
+})
+
+const volumeTooHighInWell = (): FormWarning => ({
+  type: 'VOLUME_OUT_OF_RANGE',
+  title: 'Well volume is out of range',
+  dependentFields: ['volume'],
   location: 'form',
 })
 
@@ -149,6 +157,38 @@ export const maxDispenseWellVolume = (
     return maximum && effectiveVolume > maximum
   })
   return hasExceeded ? overMaxWellVolumeWarning() : null
+}
+
+export const wellVolumeMax = (
+  fields: HydratedMoveLiquidFormData | HydratedMixFormData
+): FormWarning | null => {
+  let labware
+  if (
+    'dispense_labware' in fields &&
+    fields.dispense_labware != null &&
+    fields.stepType === 'moveLiquid'
+  ) {
+    labware = fields.dispense_labware
+  } else if (
+    'labware' in fields &&
+    fields.labware != null &&
+    fields.stepType === 'mix'
+  ) {
+    labware = fields.labware
+  }
+
+  if (labware == null) {
+    return null
+  }
+
+  const dispenseLabwareMaxVolume =
+    'def' in labware ? labware.def?.wells.A1.totalLiquidVolume : null
+
+  return dispenseLabwareMaxVolume != null &&
+    typeof fields.volume === 'string' &&
+    parseInt(fields.volume) > dispenseLabwareMaxVolume
+    ? volumeTooHighInWell()
+    : null
 }
 
 export const _lowVolumeTransferWarning = (): FormWarning => ({

--- a/protocol-designer/src/steplist/formLevel/warnings.tsx
+++ b/protocol-designer/src/steplist/formLevel/warnings.tsx
@@ -186,7 +186,7 @@ export const wellVolumeMax = (
 
   return dispenseLabwareMaxVolume != null &&
     typeof fields.volume === 'string' &&
-    parseInt(fields.volume) > dispenseLabwareMaxVolume
+    parseFloat(fields.volume) > dispenseLabwareMaxVolume
     ? volumeTooHighInWell()
     : null
 }


### PR DESCRIPTION
closes RQA-4573

# Overview

Turn the "volume too high in well" form error into a from warning so it still generates the step properly.

<img width="369" height="812" alt="Screenshot 2025-08-19 at 08 51 17" src="https://github.com/user-attachments/assets/2c2e8ec9-8d2f-46d8-8756-148a6bb2662a" />

## Test Plan and Hands on Testing

Upload attached protocol. See that the 1st transfer step has 2 form warnings 

[Bad Transfer Step messes up move to (1).json](https://github.com/user-attachments/files/21859329/Bad.Transfer.Step.messes.up.move.to.1.json)

## Changelog

- move form error into a form warning
- update copy

## Risk assessment

low
