### PR TITLE
fix(app): fix unhandled `go back` during compound pipette wizard flow

### DIFF
--- a/app/src/organisms/PipetteWizardFlows/index.tsx
+++ b/app/src/organisms/PipetteWizardFlows/index.tsx
@@ -96,7 +96,6 @@ export const PipetteWizardFlows = (
   const totalStepCount =
     pipetteWizardSteps != null ? pipetteWizardSteps.length - 1 : 0
   const currentStep = pipetteWizardSteps?.[currentStepIndex] ?? null
-  console.log('=>(index.tsx:99) pipetteWizardSteps', pipetteWizardSteps)
   const [isFetchingPipettes, setIsFetchingPipettes] = useState<boolean>(false)
   const memoizedAttachedPipettes = useMemo(() => attachedPipettes, [])
   const hasCalData =

--- a/app/src/organisms/PipetteWizardFlows/index.tsx
+++ b/app/src/organisms/PipetteWizardFlows/index.tsx
@@ -96,6 +96,7 @@ export const PipetteWizardFlows = (
   const totalStepCount =
     pipetteWizardSteps != null ? pipetteWizardSteps.length - 1 : 0
   const currentStep = pipetteWizardSteps?.[currentStepIndex] ?? null
+  console.log('=>(index.tsx:99) pipetteWizardSteps', pipetteWizardSteps)
   const [isFetchingPipettes, setIsFetchingPipettes] = useState<boolean>(false)
   const memoizedAttachedPipettes = useMemo(() => attachedPipettes, [])
   const hasCalData =
@@ -121,12 +122,28 @@ export const PipetteWizardFlows = (
     monitorMaintenanceRunForDeletion,
     setMonitorMaintenanceRunForDeletion,
   ] = useState<boolean>(false)
+  const isDetachPipettesAndAttach96ChFlow =
+    flowType === FLOWS.ATTACH &&
+    !isGantryEmpty &&
+    selectedPipette === NINETY_SIX_CHANNEL
 
   const goBack = (): void => {
-    setCurrentStepIndex(
-      currentStepIndex !== totalStepCount ? 0 : currentStepIndex
-    )
+    if (currentStepIndex !== totalStepCount) {
+      // The detach pipettes + attach 96ch flow is a compound flow that effectively
+      // has two "checkpoints". As a user passes a checkpoint, pressing "go back"
+      // should return to the most recent checkpoint.
+      if (isDetachPipettesAndAttach96ChFlow) {
+        if (currentStepIndex <= 2) {
+          setCurrentStepIndex(0)
+        } else {
+          setCurrentStepIndex(3)
+        }
+      } else {
+        setCurrentStepIndex(0)
+      }
+    }
   }
+
   const { data: maintenanceRunData } = useNotifyCurrentMaintenanceRun({
     refetchInterval: RUN_REFETCH_INTERVAL,
     enabled: createdMaintenanceRunId != null,


### PR DESCRIPTION
Closes [RQA-4534](https://opentrons.atlassian.net/browse/RQA-4534)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

The "Detach pipettes and attach 96 channel" flow is a special pipette wizard flow, because it is effectively a "compound" flow. We combine the "detach pipettes" flow with an "attach pipettes" flow.

When we "go back" on any step in any pipette flow, we return to the first step (unless we're on the last step). Going back to step 1 doesn't work in this particular compound flow if we are at an "attach" step, because we return to the initial "detach" step. Because those pipettes are no longer attached, internal state gets confused and we show nothing.

To fix, we should institute go back "checkpoints". As a user passes a checkpoint, pressing "go back" should return to the most recent checkpoint. So if a user presses "go back" during the attach portion of the flow, go back to the first attach step.

### Current Behavior

https://github.com/user-attachments/assets/dce92e11-fe3e-46e2-9e24-b94409113034

### Fixed Behavior

https://github.com/user-attachments/assets/21c5b672-b27d-40af-9f44-87b102699ddd

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- See videos.
- Used this protocol. Start the run with any non-96ch pipette attached.

```
requirements = {"robotType": "Flex", "apiLevel": "2.25"}


def run(protocol):
    adapter1 = protocol.load_adapter("opentrons_flex_96_tiprack_adapter", "A2")
    lw = adapter1.load_labware("opentrons_flex_96_tiprack_50ul")
    pipette = protocol.load_instrument(
        "flex_96channel_1000", "left", tip_racks=[lw]
    )

    pipette.pick_up_tip()
    pipette.return_tip()
```

<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed a blank pipette wizard step when attaching a 96 channel pipette and clicking "go back".
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-4534]: https://opentrons.atlassian.net/browse/RQA-4534?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ