### PR TITLE
fix(app): calculate the correct waste chute fixture when adding a combo fixture

### DIFF
--- a/shared-data/js/__tests__/fixtures.test.ts
+++ b/shared-data/js/__tests__/fixtures.test.ts
@@ -862,6 +862,29 @@ describe('getWasteChuteComboFixture', () => {
     })
   })
 
+  it('Should get a none covered waste chute', () => {
+    const result = getWasteChuteComboFixture(
+      {
+        addressableAreaId: 'flexStackerModuleV1D4',
+        cutoutFixtureId: FLEX_STACKER_V1_FIXTURE,
+        cutoutId: 'cutoutD3',
+        opentronsModuleSerialNumber: '123',
+      },
+      [
+        {
+          cutoutId: 'cutoutD3',
+          cutoutFixtureId: FAKE_WASTE_CHUTE_WITH_EMPTY_SLOT_FIXTURE,
+          addressableAreaId: '1ChannelWasteChute',
+        },
+      ]
+    )
+    expect(result).toEqual({
+      cutoutFixtureId: FLEX_STACKER_WTIH_WASTE_CHUTE_ADAPTER_NO_COVER_FIXTURE,
+      cutoutId: 'cutoutD3',
+      opentronsModuleSerialNumber: '123',
+    })
+  })
+
   it('Should get a none covered waste chute when stacker is on deck', () => {
     const result = getWasteChuteComboFixture(
       {

--- a/shared-data/js/fixtures.ts
+++ b/shared-data/js/fixtures.ts
@@ -1453,7 +1453,6 @@ export const replaceCutoutFixtureWithComboFixture = (
       aaCutoutItem,
       deckConfigWithAA
     )
-    console.log('wasteChuteCombo: ', wasteChuteCombo)
     if (wasteChuteCombo) {
       return wasteChuteCombo
     }

--- a/shared-data/js/fixtures.ts
+++ b/shared-data/js/fixtures.ts
@@ -1381,6 +1381,13 @@ export const getWasteChuteComboFixture = (
     {
       condition:
         cutoutFixtureId === FLEX_STACKER_MODULE_V1 &&
+        wasteChuteFixture === FAKE_WASTE_CHUTE_WITH_EMPTY_SLOT_FIXTURE,
+      comboFixtureId: FLEX_STACKER_WTIH_WASTE_CHUTE_ADAPTER_NO_COVER_FIXTURE,
+      comboOpentronsModuleSerialNumber: opentronsModuleSerialNumber,
+    },
+    {
+      condition:
+        cutoutFixtureId === FLEX_STACKER_MODULE_V1 &&
         wasteChuteFixture === WASTE_CHUTE_RIGHT_ADAPTER_COVERED_FIXTURE,
       comboFixtureId: FLEX_STACKER_WITH_WASTE_CHUTE_ADAPTER_COVERED_FIXTURE,
       comboOpentronsModuleSerialNumber: opentronsModuleSerialNumber,
@@ -1446,6 +1453,7 @@ export const replaceCutoutFixtureWithComboFixture = (
       aaCutoutItem,
       deckConfigWithAA
     )
+    console.log('wasteChuteCombo: ', wasteChuteCombo)
     if (wasteChuteCombo) {
       return wasteChuteCombo
     }


### PR DESCRIPTION
# Overview

closes https://opentrons.atlassian.net/browse/RQA-4518.
when adding a waste chute flex stacker combo look at the fake waste chute fixture as well.

## Test Plan and Hands on Testing

explained in the ticket

## Changelog

add a rule for a fake waste chute fixture

## Risk assessment

low. 
