### PR TITLE
docs: thermocycler-remove-h1-titles

### DIFF
--- a/docs/thermocycler-manual/docs/compliance.md
+++ b/docs/thermocycler-manual/docs/compliance.md
@@ -2,8 +2,6 @@
 title: "Thermocycler Module: Safety and Compliance"
 ---
 
-# Safety Information and Regulatory Compliance
-
 Opentrons recommends that you follow the safe use specifications in this section and throughout this manual.
 
 ## Safe Use Specifications

--- a/docs/thermocycler-manual/docs/flex-installation.md
+++ b/docs/thermocycler-manual/docs/flex-installation.md
@@ -2,8 +2,6 @@
 title: "Thermocycler Module: Flex Attachment Steps"
 ---
 
-# Flex Attachment Steps
-
 Setting up the Thermocycler on your robot includes attaching it to the deck and running a first-time calibration process. The instructions here and on the touchscreen will help you get started. The tools you need are included in the User Kit that came with your Flex.
 
 ## Attaching the Thermocycler

--- a/docs/thermocycler-manual/docs/index.md
+++ b/docs/thermocycler-manual/docs/index.md
@@ -5,10 +5,6 @@ hide: toc
 
 <div style="text-align: center;" markdown>
 
-![Opentrons Flex®](../images/opentrons-flex-logo.svg "opentrons-flex-logo.svg"){style="width: 60%"}
-
-# Thermocycler GEN2 Instruction Manual
-
 ![Thermocycler hero cover image](images/thermocycler-hero-cover.png){style="width: 60%"}
 
 **Opentrons Labworks Inc.**<br>

--- a/docs/thermocycler-manual/docs/lid-seals.md
+++ b/docs/thermocycler-manual/docs/lid-seals.md
@@ -2,8 +2,6 @@
 title: "Thermocycler Module: Thermocycler Lid Seals"
 ---
 
-# Thermocycler Lid Seals
-
 The Thermocycler GEN2 accepts two different plate seals to help protect PCR samples: the disposable [Opentrons Tough PCR Auto-sealing Lid](https://opentrons.com/products/opentrons-flex-tough-auto-sealing-lids-20-count) and the reusable [GEN2 automation seals](https://opentrons.com/products/gen2-thermocycler-seals).
 
 ## Disposable PCR Lids

--- a/docs/thermocycler-manual/docs/maintenance.md
+++ b/docs/thermocycler-manual/docs/maintenance.md
@@ -2,8 +2,6 @@
 title: "Thermocycler Module: Maintenance and Cleaning"
 ---
 
-# Maintenance and Cleaning
-
 ## Maintenance
 
 Users should not attempt to service or repair the Thermocycler themselves. If you have concerns about the module's performance or require maintenance, please contact Opentrons Support.

--- a/docs/thermocycler-manual/docs/ot2-installation.md
+++ b/docs/thermocycler-manual/docs/ot2-installation.md
@@ -2,8 +2,6 @@
 title: "Thermocycler Module: OT-2 Attachment Steps"
 ---
 
-# OT-2 Attachment Steps
-
 To attach the Thermocycler to your OT-2:
 
 <div class="instruction-list" markdown>

--- a/docs/thermocycler-manual/docs/preinstall.md
+++ b/docs/thermocycler-manual/docs/preinstall.md
@@ -2,8 +2,6 @@
 title: "Thermocycler Module: Before You Begin"
 ---
 
-# Before You Begin
-
 Review this section for important information about the Thermocycler's deck placement, alignment, and anchor adjustments.
 
 ## Flex Caddies

--- a/docs/thermocycler-manual/docs/specifications.md
+++ b/docs/thermocycler-manual/docs/specifications.md
@@ -2,8 +2,6 @@
 title: "Thermocycler Module: Product Specifications"
 ---
 
-# Product Specifications
-
 ![Thermocycler with labeled main features](images/specifications.png)
 
 ## Model Number

--- a/docs/thermocycler-manual/mkdocs.yml
+++ b/docs/thermocycler-manual/mkdocs.yml
@@ -14,8 +14,8 @@ theme:
       tip: material/lightbulb-on-outline
 
 nav:
-  - Product Description: index.md
-  - Safety and Compliance: compliance.md
+  - Thermocycler GEN2 Instruction Manual: index.md
+  - Safety and Regulatory Compliance: compliance.md
   - Product Specifications: specifications.md
   - Installing the Thermocycler:
       - Before You Begin: preinstall.md


### PR DESCRIPTION
# Overview

This PR removes the H1 title headers from each page. Instead of using those, the `nav` section of the `mkdocs.yml` file will control the page titles. This helps clean up search clutter and makes search more efficient.

## Test Plan and Hands on Testing

Test to make sure I didn't forget to remove an H1 and that the `nav` key-value has a title.

## Changelog

- H1s removed from all thermocycler markdown pages.
- Update YAML file and make sure it contains the page titles
- Removed logo header from `index.md`.

## Review requests

Check it out.

## Risk assessment

Low.
