### PR TITLE
fix(step-generation): sort tip rack assigned array

### DIFF
--- a/protocol-designer/release-notes.md
+++ b/protocol-designer/release-notes.md
@@ -21,6 +21,7 @@ This hotfix release addresses several bugs.
 - Exported Python protocols include numbered commands, making it easier to identify errors.
 - Setting well volume over the limit results in a warning rather than a protocol error.
 - Crashes and protocol loss no longer occur when viewing liquids added to labware.
+- Additional refinement with assigning the correct tip rack to some liquid transfers.
 
 ## Opentrons Protocol Designer Changes in 8.5.1
 

--- a/step-generation/src/__tests__/pythonFileUtils.test.ts
+++ b/step-generation/src/__tests__/pythonFileUtils.test.ts
@@ -290,6 +290,7 @@ describe('getLoadPipettes', () => {
     const mockTiprackDefURI = 'fixture/fixture_flex_96_tiprack_1000ul/1'
     const tiprack1 = 'tiprack1'
     const tiprack2 = 'tiprack2'
+    const tiprack3 = 'tiprack3'
     const pipette1 = 'pipette1'
     const pipette2 = 'pipette2'
     const mockPipetteEntities: PipetteEntities = {
@@ -323,6 +324,12 @@ describe('getLoadPipettes', () => {
         labwareDefURI: mockTiprackDefURI,
         pythonName: 'tip_rack_2',
       },
+      [tiprack3]: {
+        id: tiprack3,
+        def: fixtureTiprack1000ul as LabwareDefinition2,
+        labwareDefURI: mockTiprackDefURI,
+        pythonName: 'tip_rack_3',
+      },
     }
     const pipetteRobotState: TimelineFrame['pipettes'] = {
       [pipette1]: { mount: 'left' },
@@ -330,7 +337,8 @@ describe('getLoadPipettes', () => {
     }
     const labwareRobotState: TimelineFrame['labware'] = {
       [tiprack1]: { stack: [tiprack1, 'offDeck'] },
-      [tiprack2]: { stack: [tiprack2, 'A1'] },
+      [tiprack2]: { stack: [tiprack2, '3'] },
+      [tiprack3]: { stack: [tiprack3, '1'] },
     }
 
     expect(
@@ -344,10 +352,10 @@ describe('getLoadPipettes', () => {
       `
 # Load Pipettes:
 pipette_left = protocol.load_instrument(
-    "p300_multi_gen2", "left", tip_racks=[tip_rack_2, tip_rack_1],
+    "p300_multi_gen2", "left", tip_racks=[tip_rack_3, tip_rack_2, tip_rack_1],
 )
 pipette_left = protocol.load_instrument(
-    "flex_1channel_1000", "right", tip_racks=[tip_rack_2, tip_rack_1],
+    "flex_1channel_1000", "right", tip_racks=[tip_rack_3, tip_rack_2, tip_rack_1],
 )`.trimStart()
     )
   })

--- a/step-generation/src/utils/liquidClassUtils.ts
+++ b/step-generation/src/utils/liquidClassUtils.ts
@@ -2,6 +2,7 @@ import last from 'lodash/last'
 
 import { getAllLiquidClassDefs } from '@opentrons/shared-data'
 
+import { sortLabwareBySlot } from '../robotStateSelectors'
 import {
   DEST_WELL_BLOWOUT_DESTINATION,
   SOURCE_WELL_BLOWOUT_DESTINATION,
@@ -265,15 +266,21 @@ export const getPythonAssignTipRacksString = (args: {
   const { pipetteEntity, labwareEntities, labwareState, tiprackURI } = args
   const { pythonName: pythonPipetteName } = pipetteEntity
   if (pipetteEntity.tiprackDefURI.length > 1) {
-    const assignedTipRackPythonNames = Object.keys(labwareEntities).reduce<
-      string[]
-    >((acc, id) => {
-      const isOffDeck = last(labwareState[id].stack) === 'offDeck'
-      if (labwareEntities[id].labwareDefURI === tiprackURI && !isOffDeck) {
-        return [...acc, labwareEntities[id].pythonName]
-      }
-      return acc
-    }, [])
+    const assignedTipRackPythonNames = sortLabwareBySlot(labwareState).reduce(
+      (acc: string[], labwareId) => {
+        const labwareEntity = labwareEntities[labwareId]
+        if (labwareEntity == null) {
+          return acc
+        }
+
+        const isOffDeck = last(labwareState[labwareId].stack) === 'offDeck'
+        if (labwareEntity.labwareDefURI === tiprackURI && !isOffDeck) {
+          acc.push(labwareEntity.pythonName)
+        }
+        return acc
+      },
+      []
+    )
 
     return `${pythonPipetteName}.tip_racks = [${assignedTipRackPythonNames.join(
       ', '

--- a/step-generation/src/utils/pythonFileUtils.ts
+++ b/step-generation/src/utils/pythonFileUtils.ts
@@ -246,18 +246,10 @@ export function getLoadPipettes(
       const pipetteName = isFlexPipette(name)
         ? getFlexNameConversion(spec)
         : name
-      const allTipracks = tiprackDefURI.flatMap(defURI => {
-        const matchingLabwareIds = Object.values(labwareEntities)
-          .filter(labware => labware.labwareDefURI === defURI)
-          .map(labware => labware.id)
-
-        // sort them by slot, matching getNextTiprack() logic
-        const sortedIds = sortLabwareBySlot(
-          labwareRobotState
-        ).filter(labwareId => matchingLabwareIds.includes(labwareId))
-
-        return sortedIds.map(labwareId => labwareEntities[labwareId])
-      })
+      const sortedLabwareIds = sortLabwareBySlot(labwareRobotState)
+      const allTipracks = sortedLabwareIds
+        .map(id => labwareEntities[id])
+        .filter(lw => lw && tiprackDefURI.includes(lw.labwareDefURI))
 
       const onDeckTipracks = allTipracks.filter(
         tiprack =>

--- a/step-generation/src/utils/pythonFileUtils.ts
+++ b/step-generation/src/utils/pythonFileUtils.ts
@@ -247,11 +247,9 @@ export function getLoadPipettes(
         ? getFlexNameConversion(spec)
         : name
       const sortedLabwareIds = sortLabwareBySlot(labwareRobotState)
-      const allTipracks = sortedLabwareIds.filter(
-        id =>
-          labwareEntities[id] &&
-          tiprackDefURI.includes(labwareEntities[id].labwareDefURI)
-      )
+      const allTipracks = sortedLabwareIds
+        .map(id => labwareEntities[id])
+        .filter(lw => lw && tiprackDefURI.includes(lw.labwareDefURI))
       const onDeckTipracks = allTipracks.filter(
         tiprack =>
           getSlotInLocationStack(labwareRobotState[tiprack.id].stack) !==

--- a/step-generation/src/utils/pythonFileUtils.ts
+++ b/step-generation/src/utils/pythonFileUtils.ts
@@ -9,6 +9,7 @@ import {
   OT2_ROBOT_TYPE,
 } from '@opentrons/shared-data'
 
+import { sortLabwareBySlot } from '../robotStateSelectors'
 import { getLiquidClassName } from './liquidClassUtils'
 import { getSlotInLocationStack } from './misc'
 import {
@@ -27,7 +28,6 @@ import type {
   ChangeTipOptions,
   InvariantContext,
   LabwareEntities,
-  LabwareEntity,
   LabwareLiquidState,
   LiquidEntities,
   ModuleEntities,
@@ -246,17 +246,19 @@ export function getLoadPipettes(
       const pipetteName = isFlexPipette(name)
         ? getFlexNameConversion(spec)
         : name
-      const allTipracks = tiprackDefURI.reduce(
-        (acc: LabwareEntity[], defURI) => {
-          for (const lw of Object.values(labwareEntities)) {
-            if (lw.labwareDefURI === defURI) {
-              acc.push(lw)
-            }
-          }
-          return acc
-        },
-        []
-      )
+      const allTipracks = tiprackDefURI.flatMap(defURI => {
+        const matchingLabwareIds = Object.values(labwareEntities)
+          .filter(labware => labware.labwareDefURI === defURI)
+          .map(labware => labware.id)
+
+        // sort them by slot, matching getNextTiprack() logic
+        const sortedIds = sortLabwareBySlot(
+          labwareRobotState
+        ).filter(labwareId => matchingLabwareIds.includes(labwareId))
+
+        return sortedIds.map(labwareId => labwareEntities[labwareId])
+      })
+      console.log('allTipracks', allTipracks)
       const onDeckTipracks = allTipracks.filter(
         tiprack =>
           getSlotInLocationStack(labwareRobotState[tiprack.id].stack) !==

--- a/step-generation/src/utils/pythonFileUtils.ts
+++ b/step-generation/src/utils/pythonFileUtils.ts
@@ -247,10 +247,11 @@ export function getLoadPipettes(
         ? getFlexNameConversion(spec)
         : name
       const sortedLabwareIds = sortLabwareBySlot(labwareRobotState)
-      const allTipracks = sortedLabwareIds
-        .map(id => labwareEntities[id])
-        .filter(lw => lw && tiprackDefURI.includes(lw.labwareDefURI))
-
+      const allTipracks = sortedLabwareIds.filter(
+        id =>
+          labwareEntities[id] &&
+          tiprackDefURI.includes(labwareEntities[id].labwareDefURI)
+      )
       const onDeckTipracks = allTipracks.filter(
         tiprack =>
           getSlotInLocationStack(labwareRobotState[tiprack.id].stack) !==

--- a/step-generation/src/utils/pythonFileUtils.ts
+++ b/step-generation/src/utils/pythonFileUtils.ts
@@ -258,7 +258,7 @@ export function getLoadPipettes(
 
         return sortedIds.map(labwareId => labwareEntities[labwareId])
       })
-      console.log('allTipracks', allTipracks)
+
       const onDeckTipracks = allTipracks.filter(
         tiprack =>
           getSlotInLocationStack(labwareRobotState[tiprack.id].stack) !==


### PR DESCRIPTION
closes RESC-492

# Overview

Sort the assigned tiprack arrays in generated python based off of the tiprack's slot. Do the same for assigning the tipracks before each `transfer`/`consolidate`/`distribute`

## Test Plan and Hands on Testing

Import protocol attached to the ticket and export. See that the `tiprack` array with the first pipette starts with `tip_rack_4`

## Changelog

- take `sortLabwareBySlot` into account when listing the assigned tiprack array, to match step-generation's `getNextTiprack` logic.

## Risk assessment

low
