### PR TITLE
fix(api): add stacker to pipette accessibility

### DIFF
--- a/api/src/opentrons/protocol_engine/execution/movement.py
+++ b/api/src/opentrons/protocol_engine/execution/movement.py
@@ -1,4 +1,5 @@
 """Movement command handling."""
+
 from __future__ import annotations
 
 import logging
@@ -84,7 +85,7 @@ class MovementHandler:
         operation_volume: Optional[float] = None,
     ) -> Point:
         """Move to a specific well."""
-        self._state_store.labware.raise_if_labware_inaccessible_by_pipette(
+        self._state_store.geometry.raise_if_labware_inaccessible_by_pipette(
             labware_id=labware_id
         )
 

--- a/api/src/opentrons/protocol_engine/resources/fixture_validation.py
+++ b/api/src/opentrons/protocol_engine/resources/fixture_validation.py
@@ -56,3 +56,13 @@ def is_deck_slot(addressable_area_name: str) -> bool:
 def is_abs_reader(addressable_area_name: str) -> bool:
     """Check if an addressable area is an absorbance plate reader area."""
     return "absorbanceReaderV1" in addressable_area_name
+
+
+def is_stacker_shuttle(addressable_area_name: str) -> bool:
+    """Check if an addressable area is a flex stacker shuttle area."""
+    return addressable_area_name in [
+        "flexStackerModuleV1A4",
+        "flexStackerModuleV1B4",
+        "flexStackerModuleV1C4",
+        "flexStackerModuleV1D4",
+    ]

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -2361,3 +2361,48 @@ class GeometryView:
                 return pending_labware[labware_id]
             except KeyError as ke:
                 raise lnle from ke
+
+    def raise_if_labware_inaccessible_by_pipette(  # noqa: C901
+        self, labware_id: str
+    ) -> None:
+        """Raise an error if the specified location cannot be reached via a pipette."""
+        labware = self._labware.get(labware_id)
+        labware_location = labware.location
+        if isinstance(labware_location, OnLabwareLocation):
+            return self.raise_if_labware_inaccessible_by_pipette(
+                labware_location.labwareId
+            )
+        elif labware.lid_id is not None:
+            raise errors.LocationNotAccessibleByPipetteError(
+                f"Cannot move pipette to {labware.loadName} "
+                "because labware is currently covered by a lid."
+            )
+        elif isinstance(labware_location, AddressableAreaLocation):
+            if fixture_validation.is_staging_slot(labware_location.addressableAreaName):
+                raise errors.LocationNotAccessibleByPipetteError(
+                    f"Cannot move pipette to {labware.loadName},"
+                    f" labware is on staging slot {labware_location.addressableAreaName}"
+                )
+            elif fixture_validation.is_stacker_shuttle(
+                labware_location.addressableAreaName
+            ):
+                raise errors.LocationNotAccessibleByPipetteError(
+                    f"Cannot move pipette to {labware.loadName} because it is on a stacker shuttle"
+                )
+        elif (
+            labware_location == OFF_DECK_LOCATION or labware_location == SYSTEM_LOCATION
+        ):
+            raise errors.LocationNotAccessibleByPipetteError(
+                f"Cannot move pipette to {labware.loadName}, labware is off-deck."
+            )
+        elif isinstance(labware_location, ModuleLocation):
+            module = self._modules.get(labware_location.moduleId)
+            if ModuleModel.is_flex_stacker(module.model):
+                raise errors.LocationNotAccessibleByPipetteError(
+                    f"Cannot move pipette to {labware.loadName}, labware is on a stacker shuttle"
+                )
+
+        elif isinstance(labware_location, InStackerHopperLocation):
+            raise errors.LocationNotAccessibleByPipetteError(
+                f"Cannot move pipette to {labware.loadName}, labware is in a stacker hopper"
+            )

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -58,7 +58,6 @@ from ..types import (
     LabwareMovementOffsetData,
     OnDeckLabwareLocation,
     OFF_DECK_LOCATION,
-    SYSTEM_LOCATION,
 )
 from ..actions import (
     Action,
@@ -1035,32 +1034,6 @@ class LabwareView:
     def is_lid(self, labware_id: str) -> bool:
         """Check if labware is a lid."""
         return LabwareRole.lid in self.get_definition(labware_id).allowedRoles
-
-    def raise_if_labware_inaccessible_by_pipette(self, labware_id: str) -> None:
-        """Raise an error if the specified location cannot be reached via a pipette."""
-        labware = self.get(labware_id)
-        labware_location = labware.location
-        if isinstance(labware_location, OnLabwareLocation):
-            return self.raise_if_labware_inaccessible_by_pipette(
-                labware_location.labwareId
-            )
-        elif labware.lid_id is not None:
-            raise errors.LocationNotAccessibleByPipetteError(
-                f"Cannot move pipette to {labware.loadName} "
-                "because labware is currently covered by a lid."
-            )
-        elif isinstance(labware_location, AddressableAreaLocation):
-            if fixture_validation.is_staging_slot(labware_location.addressableAreaName):
-                raise errors.LocationNotAccessibleByPipetteError(
-                    f"Cannot move pipette to {labware.loadName},"
-                    f" labware is on staging slot {labware_location.addressableAreaName}"
-                )
-        elif (
-            labware_location == OFF_DECK_LOCATION or labware_location == SYSTEM_LOCATION
-        ):
-            raise errors.LocationNotAccessibleByPipetteError(
-                f"Cannot move pipette to {labware.loadName}, labware is off-deck."
-            )
 
     def raise_if_labware_in_location(
         self,

--- a/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
@@ -105,7 +105,10 @@ from opentrons.protocol_engine.actions import (
 )
 from opentrons.protocol_engine.state import _move_types
 from opentrons.protocol_engine.state.config import Config
-from opentrons.protocol_engine.state.labware import LabwareView, LabwareStore
+from opentrons.protocol_engine.state.labware import (
+    LabwareView,
+    LabwareStore,
+)
 from opentrons.protocol_engine.state.wells import WellView, WellStore
 from opentrons.protocol_engine.state.modules import ModuleView, ModuleStore
 from opentrons.protocol_engine.state.pipettes import (
@@ -4683,3 +4686,142 @@ def test_get_liquid_handling_z_change(
         operation_volume=operation_volume,
     )
     assert isclose(change, expected_change, abs_tol=0.0001)
+
+
+def test_raise_if_labware_inaccessible_by_pipette_staging_area(
+    subject: GeometryView, mock_labware_view: LabwareView, decoy: Decoy
+) -> None:
+    """It should raise if the labware is on a staging slot."""
+    decoy.when(mock_labware_view.get("labware-id")).then_return(
+        LoadedLabware(
+            id="labware-id",
+            loadName="test",
+            definitionUri="def-uri",
+            location=AddressableAreaLocation(addressableAreaName="B4"),
+        )
+    )
+
+    with pytest.raises(
+        errors.LocationNotAccessibleByPipetteError, match="on staging slot"
+    ):
+        subject.raise_if_labware_inaccessible_by_pipette("labware-id")
+
+
+def test_raise_if_labware_inaccessible_by_pipette_off_deck(
+    subject: GeometryView, mock_labware_view: LabwareView, decoy: Decoy
+) -> None:
+    """It should raise if the labware is off-deck."""
+    decoy.when(mock_labware_view.get("labware-id")).then_return(
+        LoadedLabware(
+            id="labware-id",
+            loadName="test",
+            definitionUri="def-uri",
+            location=OFF_DECK_LOCATION,
+        )
+    )
+
+    with pytest.raises(errors.LocationNotAccessibleByPipetteError, match="off-deck"):
+        subject.raise_if_labware_inaccessible_by_pipette("labware-id")
+
+
+def test_raise_if_labware_inaccessible_by_pipette_stacked_labware_on_staging_area(
+    subject: GeometryView, mock_labware_view: LabwareView, decoy: Decoy
+) -> None:
+    """It should raise if the labware is stacked on a staging slot."""
+    decoy.when(mock_labware_view.get("labware-id")).then_return(
+        LoadedLabware(
+            id="labware-id",
+            loadName="test",
+            definitionUri="def-uri",
+            location=OnLabwareLocation(labwareId="lower-labware-id"),
+        )
+    )
+    decoy.when(mock_labware_view.get("lower-labware-id")).then_return(
+        LoadedLabware(
+            id="lower-labware-id",
+            loadName="test",
+            definitionUri="def-uri",
+            location=AddressableAreaLocation(addressableAreaName="B4"),
+        )
+    )
+
+    with pytest.raises(
+        errors.LocationNotAccessibleByPipetteError, match="on staging slot"
+    ):
+        subject.raise_if_labware_inaccessible_by_pipette("labware-id")
+
+
+@pytest.mark.parametrize(
+    "addressable_area",
+    [
+        "flexStackerModuleV1A4",
+        "flexStackerModuleV1B4",
+        "flexStackerModuleV1C4",
+        "flexStackerModuleV1D4",
+    ],
+)
+def test_raise_if_labware_on_stacker_aa(
+    subject: GeometryView,
+    mock_labware_view: LabwareView,
+    decoy: Decoy,
+    addressable_area: str,
+) -> None:
+    """It should raise if the labware is on a stacker shuttle aa."""
+    decoy.when(mock_labware_view.get("labware-id")).then_return(
+        LoadedLabware(
+            id="labware-id",
+            loadName="test",
+            definitionUri="def-uri",
+            location=AddressableAreaLocation(addressableAreaName=addressable_area),
+        )
+    )
+    with pytest.raises(
+        errors.LocationNotAccessibleByPipetteError, match="on a stacker shuttle"
+    ):
+        subject.raise_if_labware_inaccessible_by_pipette("labware-id")
+
+
+@pytest.mark.parametrize(
+    "model", [m for m in ModuleModel if ModuleModel.is_flex_stacker(m)]
+)
+def test_raise_if_labware_on_stacker_module(
+    subject: GeometryView,
+    mock_labware_view: LabwareView,
+    mock_module_view: ModuleView,
+    decoy: Decoy,
+    model: ModuleModel,
+) -> None:
+    """It should raise if the labware is on a stacker module."""
+    decoy.when(mock_labware_view.get("labware-id")).then_return(
+        LoadedLabware(
+            id="labware-id",
+            loadName="test",
+            definitionUri="def-uri",
+            location=ModuleLocation(moduleId="module-id"),
+        )
+    )
+    decoy.when(mock_module_view.get("module-id")).then_return(
+        LoadedModule(id="module-id", model=model, location=None, serialNumber=None)
+    )
+    with pytest.raises(
+        errors.LocationNotAccessibleByPipetteError, match="on a stacker shuttle"
+    ):
+        subject.raise_if_labware_inaccessible_by_pipette("labware-id")
+
+
+def test_raise_if_labware_in_stacker_hopper(
+    subject: GeometryView, mock_labware_view: LabwareView, decoy: Decoy
+) -> None:
+    """It should raise if the labware is in a stacker hopper."""
+    decoy.when(mock_labware_view.get("labware-id")).then_return(
+        LoadedLabware(
+            id="labware-id",
+            loadName="test",
+            definitionUri="def-uri",
+            location=InStackerHopperLocation(moduleId="module-id"),
+        )
+    )
+    with pytest.raises(
+        errors.LocationNotAccessibleByPipetteError, match="in a stacker hopper"
+    ):
+        subject.raise_if_labware_inaccessible_by_pipette("labware-id")

--- a/api/tests/opentrons/protocol_engine/state/test_labware_view_old.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_view_old.py
@@ -41,7 +41,6 @@ from opentrons.protocol_engine.types import (
     ModuleLocation,
     OnLabwareLocation,
     LabwareLocation,
-    AddressableAreaLocation,
     OFF_DECK_LOCATION,
     LabwareMovementOffsetData,
     OnAddressableAreaOffsetLocationSequenceComponent,
@@ -1317,69 +1316,6 @@ def test_get_all_labware_definition_empty() -> None:
     result = subject.get_loaded_labware_definitions()
 
     assert result == []
-
-
-def test_raise_if_labware_inaccessible_by_pipette_staging_area() -> None:
-    """It should raise if the labware is on a staging slot."""
-    subject = get_labware_view(
-        labware_by_id={
-            "labware-id": LoadedLabware(
-                id="labware-id",
-                loadName="test",
-                definitionUri="def-uri",
-                location=AddressableAreaLocation(addressableAreaName="B4"),
-            )
-        },
-    )
-
-    with pytest.raises(
-        errors.LocationNotAccessibleByPipetteError, match="on staging slot"
-    ):
-        subject.raise_if_labware_inaccessible_by_pipette("labware-id")
-
-
-def test_raise_if_labware_inaccessible_by_pipette_off_deck() -> None:
-    """It should raise if the labware is off-deck."""
-    subject = get_labware_view(
-        labware_by_id={
-            "labware-id": LoadedLabware(
-                id="labware-id",
-                loadName="test",
-                definitionUri="def-uri",
-                location=OFF_DECK_LOCATION,
-            )
-        },
-    )
-
-    with pytest.raises(errors.LocationNotAccessibleByPipetteError, match="off-deck"):
-        subject.raise_if_labware_inaccessible_by_pipette("labware-id")
-
-
-def test_raise_if_labware_inaccessible_by_pipette_stacked_labware_on_staging_area() -> (
-    None
-):
-    """It should raise if the labware is stacked on a staging slot."""
-    subject = get_labware_view(
-        labware_by_id={
-            "labware-id": LoadedLabware(
-                id="labware-id",
-                loadName="test",
-                definitionUri="def-uri",
-                location=OnLabwareLocation(labwareId="lower-labware-id"),
-            ),
-            "lower-labware-id": LoadedLabware(
-                id="lower-labware-id",
-                loadName="test",
-                definitionUri="def-uri",
-                location=AddressableAreaLocation(addressableAreaName="B4"),
-            ),
-        },
-    )
-
-    with pytest.raises(
-        errors.LocationNotAccessibleByPipetteError, match="on staging slot"
-    ):
-        subject.raise_if_labware_inaccessible_by_pipette("labware-id")
 
 
 def test_raise_if_labware_cannot_be_stacked_is_adapter() -> None:


### PR DESCRIPTION
This means it needs to move to geometry because now we care about modules. THis is cool. I'm happy.

Closes RQA-4577

## testing
- [x] analyze a protocol like below and see that it fails:
```
from opentrons import protocol_api

# metadata
metadata = {
    'protocolName': '2.25 Error Recovery Testing Protocol (4 stackers loaded)',
    'author': 'ot',
    'description': 'Simple Protocol',
}

requirements = {
    "robotType": "Flex",
    "apiLevel": "2.25",
}

DRYRUN = 'NO'
USE_GRIPPER = True

def run(protocol: protocol_api.ProtocolContext):

    # modules/fixtures
    trashbin = protocol.load_trash_bin(location = "A1")

    #labware
    tiprack1 = protocol.load_labware('opentrons_flex_96_tiprack_1000ul', 'A2')  
    tiprack2 = protocol.load_labware('opentrons_flex_96_tiprack_50ul', 'B2')
    sample_plate = protocol.load_labware('armadillo_96_wellplate_200ul_pcr_full_skirt','C3')
    reservoir = protocol.load_labware('nest_1_reservoir_290ml', 'D3')
    wet_sample = protocol.load_labware('nest_12_reservoir_15ml', 'B3')

    #liquids
    water = protocol.define_liquid(
        name="Water",
        description="water for ER testing",
        display_color="#90e0ef",
    )
    waterButMoreBlue = protocol.define_liquid(
        name="Water but more blue",
        description="Water for ER testing",
        display_color="#0077b6",
    )

    wet_sample["A1"].load_liquid(liquid=water, volume=8000)
    wet_sample["A2"].load_liquid(liquid=waterButMoreBlue, volume=8000)

    stacker_50_A4 = protocol.load_module("flexStackerModuleV1", "A4")
    stacker_50_A4.set_stored_labware("opentrons_flex_96_tiprack_1000ul", count=5, lid="opentrons_flex_tiprack_lid")

    stacker_50_B4 = protocol.load_module("flexStackerModuleV1", "B4")
    stacker_50_B4.set_stored_labware("opentrons_flex_96_tiprack_1000ul", count=5, lid="opentrons_flex_tiprack_lid")

    stacker_50_C4 = protocol.load_module("flexStackerModuleV1", "C4")
    stacker_50_C4.set_stored_labware("opentrons_flex_96_tiprack_1000ul", count=5, lid="opentrons_flex_tiprack_lid")

    stacker_50_D4 = protocol.load_module("flexStackerModuleV1", "D4")
    stacker_50_D4.set_stored_labware("opentrons_flex_96_tiprack_1000ul", count=5, lid="opentrons_flex_tiprack_lid")

    #instruments
    p1000 = protocol.load_instrument('flex_8channel_1000', mount = 'left', tip_racks=[tiprack1]) ## will need a modified pipette that doesn't have the ejector(?)
    p50 = protocol.load_instrument('flex_1channel_50', mount = 'right', tip_racks=[tiprack2]) ## will need a modified pipette that doesn't have the ejector(?)

    pipette_list = [p1000, p50]
    volume = 300


    ##############################  
    #######Gripper Failure########
    ##############################

    protocol.pause("This tests Gripper Move Failures")
    protocol.pause('no labware in slot')
    protocol.move_labware(labware=sample_plate, new_location= "D2", use_gripper=True)

    protocol.pause('labware stuck on deck - tape it down')
    protocol.move_labware(labware=reservoir, new_location= "D1", use_gripper=True)        

    protocol.pause('gripper collision - stack some labware in the way')
    protocol.move_labware(labware=tiprack1, new_location= stacker_50_D4, use_gripper=True)

    for pipette in pipette_list:
        if pipette == p50:
            volume = 50


        #############################  
        ####Tip Pick Up Failure######
        #############################

        protocol.pause("This tests Tip Pick Up Failure")
        protocol.pause("Please remove tip rack from deck. When you're testing recovery, add tiprack back as necessary.")
        pipette.pick_up_tip()


        #########################################  
        ####Overpressure - While Aspirating######
        #########################################

        protocol.pause("Overpressure - While Aspirating")
        pipette.home()
        protocol.pause("Use p50UL tips - Swap with tip(s) that are hot glued shut (you will need to swap the tips for retry recovery options)")
        
        for i in range(10):
            pipette.aspirate(volume, reservoir['A1'].top())
            pipette.dispense(volume, reservoir['A1'].top())

        
        ###################################    
        ####Liquid Presence Detection######
        ###################################
        protocol.pause("This tests Liquid Presence Detection - PLEASE MAKE SURE YOU'RE USING 1000UL TIPS OR YOU WILL BREAK THE PIPETTE")
        protocol.pause("Make sure reservoir is empty, and have full reservoir on standby to switch out with for recovery")

        pipette.require_liquid_presence(wet_sample['A1'])
        protocol.pause(f"liquid height = {wet_sample['A1'].current_liquid_height()}, volume = {wet_sample['A1'].current_liquid_volume()}")

        pipette.aspirate(volume, wet_sample['A1'].meniscus(z=-1, target='end'))
        protocol.pause(f"liquid height = {wet_sample['A1'].current_liquid_height()}")

        protocol.pause(f"liquid height = {wet_sample['A1'].current_liquid_height()}, volume = {wet_sample['A1'].current_liquid_volume()}")
        pipette.dispense(volume, wet_sample['A1'].meniscus(z=-1, target='start'))
        pipette.home()

        ####################################################
        ####Overpressure - While Dispensing######
        ####################################################

        protocol.pause("Overpressure - While Dispensing")

        pipette.aspirate(volume, reservoir['A1'].top(20))
        protocol.pause("Swap with tip(s) that are hot glued shut (you will need to cut the tips for retry recovery options)")
        pipette.dispense(volume, reservoir['A1'].top(20))

        #############################  
        ####Drop Pick Up Failure#####
        #############################
        
        pipette.move_to(trashbin)
        protocol.pause("This test Drop Tip Failure")
        protocol.pause("You will have to manually remove tips if you're using a modified pipette")
        pipette.drop_tip(trashbin)
        
```