### PR TITLE
fix(docs): de-duplicate header in Heater-Shaker docs

### DIFF
--- a/docs/heater-shaker/docs/adapters.md
+++ b/docs/heater-shaker/docs/adapters.md
@@ -2,8 +2,6 @@
 title: "Heater-Shaker Module: Thermal Adapters"
 ---
 
-# Thermal Adapters
-
 Aluminum thermal adapters help transfer heat from the Heater-Shaker to attached labware. The module comes with your choice of a universal flat adapter, a PCR well plate adapter, a 96-well flat bottom adapter, or a deep well adapter. You can also purchase additional adapters directly from the [modules section](https://opentrons.com/products/categories/modules) of the Opentrons website.
 
 ![Universal adapter, PCR adapter, flat bottom adapater, deep well adapter images](images/thermal-adapters.png)

--- a/docs/heater-shaker/docs/compliance.md
+++ b/docs/heater-shaker/docs/compliance.md
@@ -2,8 +2,6 @@
 title: "Heater-Shaker Module: Safety Information and Regulatory Compliance"
 ---
 
-# Safety Information and Regulatory Compliance
-
 Opentrons recommends that you follow the safe use specifications listed in this section and throughout this manual.
 
 ## Environmental Conditions

--- a/docs/heater-shaker/docs/flex-installation.md
+++ b/docs/heater-shaker/docs/flex-installation.md
@@ -2,8 +2,6 @@
 title: "Heater-Shaker Module: Flex Installation Instructions"
 ---
 
-# Flex Attachment Instructions
-
 Installing the Heater-Shaker on your robot includes attaching it to the deck and calibrating it for the first time. The instructions here and on the touchscreen will help you get started. The tools you need are included with the module or in the User Kit that came with your Flex.
 
 ## Attaching the Heater-Shaker

--- a/docs/heater-shaker/docs/maintenance.md
+++ b/docs/heater-shaker/docs/maintenance.md
@@ -2,8 +2,6 @@
 title: "Heater-Shaker Module: Maintenance and Cleaning"
 ---
 
-# Maintenance and Cleaning
-
 ## Maintenance
 
 Users should not attempt to service or repair the Heater-Shaker themselves. If you have concerns about the module’s performance or require maintenance, please contact Opentrons Support.

--- a/docs/heater-shaker/docs/ot2-installation.md
+++ b/docs/heater-shaker/docs/ot2-installation.md
@@ -2,8 +2,6 @@
 title: "Heater-Shaker Module: OT-2 Installation Instructions"
 ---
 
-# OT-2 Installation Instructions
-
 To install the Heater-Shaker on your OT-2:
 
 <div class="instruction-list" markdown>

--- a/docs/heater-shaker/docs/preinstall.md
+++ b/docs/heater-shaker/docs/preinstall.md
@@ -2,8 +2,6 @@
 title: "Heater-Shaker Module: Before You Begin"
 ---
 
-# Before You Begin
-
 Review this section for important information about deck placement, alignment, and anchor adjustments for the Heater-Shaker.
 
 ## Flex Caddies

--- a/docs/heater-shaker/docs/software-control.md
+++ b/docs/heater-shaker/docs/software-control.md
@@ -2,8 +2,6 @@
 title: "Heater-Shaker Module: Software Control"
 ---
 
-# Software Control
-
 You control the Heater-Shaker through protocols you create in [Opentrons Protocol Designer](https://designer.opentrons.com/) or the [Python API](https://docs.opentrons.com/v2/modules/heater_shaker.html#heater-shaker-module). Running these protocols requires version 6.1.0 or newer of the [Opentrons App](https://opentrons.com/ot-app) and robot server.
 
 The Opentrons App displays the current status of the Heater-Shaker and can also control the module outside of protocols. To control a Heater-Shaker, go to the **Devices** tab and select a robot that has a Heater-Shaker connected to it. Robots with a connected and powered on Heater-Shaker will display a thermometer icon <img src="../images/module-icon-dark.svg" style="width: 1.25em; height: auto; vertical-align: middle;" alt="thermometer icon"> under the modules section of the device card.

--- a/docs/heater-shaker/docs/specifications.md
+++ b/docs/heater-shaker/docs/specifications.md
@@ -2,8 +2,6 @@
 title: "Heater-Shaker Module: Product Specifications"
 ---
 
-# Product Specifications
-
 ![Heater-Shaker with external features labeled](images/hs-with-labels.svg)
 
 ## Model Number

--- a/docs/heater-shaker/docs/warranty.md
+++ b/docs/heater-shaker/docs/warranty.md
@@ -2,8 +2,6 @@
 title: "Heater-Shaker Module: Additional Product Information"
 ---
 
-# Additional Product Information
-
 ## Warranty
 
 All hardware purchased from Opentrons is covered under a 1-year standard warranty. Opentrons warrants to the end-user of the products that they will be free of manufacturing defects due to part quality issues or poor workmanship and also warrants that the products will materially conform to Opentrons’ published specifications.


### PR DESCRIPTION


# Overview

#19213 added stronger checks for mkdocs builds. And I included updates for those checks to pass…and then forgot to rebase before merging. This cleans up one warning that was introduced into `edge` in the interim.

## Test Plan and Hands on Testing

Docs build passing.

## Changelog

Removed all H1s from Heater-Shaker manual. The duplicated header matched one of these (`# Thermal Adapters`), and we have independent reasons to [remove H1s for search improvements](https://opentrons.atlassian.net/browse/RTC-817). Didn't go beyond the H-S manual in the interest of time.

## Review requests

Let's get this in

## Risk assessment

v low