### PR TITLE
fix(app): fix default touchTip values when no liquid class is selecte…

### DIFF
--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/TouchTip.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/TouchTip.tsx
@@ -49,7 +49,9 @@ export function TouchTip(props: TouchTipProps): JSX.Element {
       : state.touchTipDispense != null
   )
   const initialSpeed =
-    kind === 'aspirate' ? state.touchTipAspirate : state.touchTipDispense
+    kind === 'aspirate'
+      ? state.touchTipAspirateSpeed
+      : state.touchTipDispenseSpeed
   const [speed, setSpeed] = useState<number | null>(initialSpeed ?? null)
   const [currentStep, setCurrentStep] = useState<number>(1)
   const touchTipAspirate =

--- a/app/src/organisms/ODD/QuickTransferFlow/utils/createQuickTransferFile.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/utils/createQuickTransferFile.ts
@@ -48,7 +48,7 @@ export function createQuickTransferFile(
   } = generateQuickTransferArgs(quickTransferState, deckConfig)
   const pipetteEntity = Object.values(invariantContext.pipetteEntities)[0]
   const { name, id, spec } = pipetteEntity
-
+  console.log('stepArgs', stepArgs)
   const loadPipetteCommand: LoadPipetteCreateCommand = {
     key: uuid(),
     commandType: 'loadPipette' as const,

--- a/app/src/organisms/ODD/QuickTransferFlow/utils/createQuickTransferFile.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/utils/createQuickTransferFile.ts
@@ -48,7 +48,7 @@ export function createQuickTransferFile(
   } = generateQuickTransferArgs(quickTransferState, deckConfig)
   const pipetteEntity = Object.values(invariantContext.pipetteEntities)[0]
   const { name, id, spec } = pipetteEntity
-  console.log('stepArgs', stepArgs)
+
   const loadPipetteCommand: LoadPipetteCreateCommand = {
     key: uuid(),
     commandType: 'loadPipette' as const,

--- a/app/src/organisms/ODD/QuickTransferFlow/utils/retrieveLiquidClassValues.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/utils/retrieveLiquidClassValues.ts
@@ -151,7 +151,9 @@ const getNoLiquidClassValues = (
       positionFromBottom: aspirate.retract.endPosition.offset.z ?? 0,
       delayDuration: aspirate.retract.delay.params?.duration ?? 0,
     },
-    touchTipAspirate: aspirate.retract.touchTip.params?.zOffset,
+    touchTipAspirate: !aspirate.retract.touchTip.enable
+      ? undefined
+      : aspirate.retract.touchTip.params?.zOffset,
     touchTipAspirateSpeed: aspirate.retract.touchTip.params?.speed,
     airGapAspirate: airGap.aspirate,
     conditionAspirate: conditioning ?? 0,
@@ -185,7 +187,9 @@ const getNoLiquidClassValues = (
       ),
       flowRate: dispense.retract.blowout?.params?.flowRate ?? 0,
     },
-    touchTipDispense: dispense.retract.touchTip.params?.zOffset,
+    touchTipDispense: !dispense.retract.touchTip.enable
+      ? undefined
+      : dispense.retract.touchTip.params?.zOffset,
     touchTipDispenseSpeed: dispense.retract.touchTip.params?.speed,
     airGapDispense: airGap.dispense,
     disposalVolumeDispenseSettings: {


### PR DESCRIPTION
…d in QT

closes RQA-4576

# Overview

Fixes a bug where we were defaulting the touch tip value for all labware to -1 when no liquid class was selected.

Also i noticed that we were setting the default value for touch tip aspirate/dispense speed to the zIndex instead of the default speed.

## Test Plan and Hands on Testing

Follow the steps in the ticket. See that if you select the dispense labware as a reseroivr that the protocol passes analysis.

## Changelog

- fix the default speed
- fix the default touch tip for aspirate and dispense when no liquid class is selected

## Risk assessment

low