### PR TITLE
chore(hardware): print node name instead of number when listing usage data.

### DIFF
--- a/hardware/opentrons_hardware/hardware_control/network.py
+++ b/hardware/opentrons_hardware/hardware_control/network.py
@@ -512,8 +512,8 @@ def _parse_can_device_info_response(
 def _listener(message: MessageDefinition, arb_id: ArbitrationId) -> None:
     if isinstance(message, GetMotorUsageResponse):
         usage_elements = message.payload.usage_elements
-        node = arb_id.parts.originating_node_id
-        logline = f"Usage from {node}: "
+        node = NodeId(arb_id.parts.originating_node_id)
+        logline = f"Usage from {node.name}: "
         for m in usage_elements:
             data_name = MotorUsageValueType(m.key).name
             data_value = m.usage_value


### PR DESCRIPTION

# Overview
Usage data is currently kinda hard to read and this makes it readable.
