### PR TITLE
test(api): speed up the slowest unit tests to decrease unit test execution time

### DIFF
--- a/api/src/opentrons/hardware_control/backends/subsystem_manager.py
+++ b/api/src/opentrons/hardware_control/backends/subsystem_manager.py
@@ -91,6 +91,7 @@ class SubsystemManager:
         self._present_tools = tools.types.ToolSummary(
             left=None, right=None, gripper=None
         )
+        self._check_device_update_timeout = 10.0
 
     @property
     def ok(self) -> bool:
@@ -183,11 +184,12 @@ class SubsystemManager:
             return self._tool_task_state is True
 
     async def _check_devices_after_update(
-        self, devices: Set[SubSystem], timeout_sec: float = 10.0
+        self, devices: Set[SubSystem], timeout_sec: Optional[float] = None
     ) -> None:
         try:
             await asyncio.wait_for(
-                self._do_check_devices_after_update(devices), timeout=timeout_sec
+                self._do_check_devices_after_update(devices),
+                timeout=timeout_sec or self._check_device_update_timeout,
             )
         except asyncio.TimeoutError:
             raise RuntimeError("Device failed to come back after firmware update")

--- a/api/src/opentrons/hardware_control/backends/subsystem_manager.py
+++ b/api/src/opentrons/hardware_control/backends/subsystem_manager.py
@@ -91,6 +91,7 @@ class SubsystemManager:
         self._present_tools = tools.types.ToolSummary(
             left=None, right=None, gripper=None
         )
+        # This is intended to be an internal variable but is modified in unit tests to avoid long timeouts
         self._check_device_update_timeout = 10.0
 
     @property

--- a/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
@@ -741,6 +741,7 @@ async def test_liquid_probe(
     fake_liquid_settings: LiquidProbeSettings,
     mock_move_group_run: mock.AsyncMock,
     mock_send_stop_threshold: mock.AsyncMock,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     fake_max_p_dist = 70
     head_node = axis_to_node(Axis.by_mount(mount))
@@ -750,6 +751,10 @@ async def test_liquid_probe(
     )
     controller._pipettes_to_monitor_pressure = mock.MagicMock(  # type: ignore[method-assign]
         return_value=[sensor_node_for_mount(mount)]
+    )
+    monkeypatch.setattr(
+        "opentrons_hardware.hardware_control.tool_sensors.finalize_logs",
+        mock.AsyncMock(),
     )
     try:
         await controller.liquid_probe(

--- a/api/tests/opentrons/hardware_control/backends/test_ot3_subsystem_manager.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_subsystem_manager.py
@@ -984,8 +984,9 @@ async def test_update_process_fails_if_subsytem_does_not_appear_afterward(
     await tool_detection_controller.add_resolution(tool_struct, network_info_value)
 
     await subject.start()
+    subject._check_device_update_timeout = 0.5
     iteration = 0
-    with pytest.raises(RuntimeError):
+    with pytest.raises(RuntimeError, match="Device failed"):
         async for status in subject.update_firmware({SubSystem.gantry_x}):
             iteration += 1
             if iteration == 3:
@@ -1032,8 +1033,9 @@ async def test_update_process_fails_if_subsytem_is_not_ok_afterward(
     await tool_detection_controller.add_resolution(tool_struct, network_info_value)
 
     await subject.start()
+    subject._check_device_update_timeout = 0.5
     iteration = 0
-    with pytest.raises(RuntimeError):
+    with pytest.raises(RuntimeError, match="Device failed"):
         async for status in subject.update_firmware({SubSystem.gantry_x}):
             iteration += 1
             if iteration == 3:

--- a/api/tests/opentrons/hardware_control/integration/conftest.py
+++ b/api/tests/opentrons/hardware_control/integration/conftest.py
@@ -86,4 +86,4 @@ def poll_interval_seconds() -> float:
     If too fast, tests may fail due to stale data in the serial buffers.
     If too slow, tests will take too long and may time out.
     """
-    return 0.1
+    return 0.01

--- a/api/tests/opentrons/hardware_control/test_modules.py
+++ b/api/tests/opentrons/hardware_control/test_modules.py
@@ -398,7 +398,10 @@ async def test_module_update_integration(  # noqa: C901
     mod_absorbancereader._driver.update_firmware = byonoy_update_firmware_mock  # type: ignore
 
     assert not mod_absorbancereader.updating
-    await modules.update_firmware(mod_absorbancereader, "fake_fw_file_path")
+    with mock.patch(
+        "opentrons.hardware_control.modules.absorbance_reader.asyncio", mock.AsyncMock()
+    ):
+        await modules.update_firmware(mod_absorbancereader, "fake_fw_file_path")
     byonoy_update_firmware_mock.assert_called_once_with("fake_fw_file_path")
     assert not mod_absorbancereader.updating
 

--- a/api/tests/opentrons/hardware_control/test_modules.py
+++ b/api/tests/opentrons/hardware_control/test_modules.py
@@ -399,7 +399,7 @@ async def test_module_update_integration(  # noqa: C901
 
     assert not mod_absorbancereader.updating
     with mock.patch(
-        "opentrons.hardware_control.modules.absorbance_reader.asyncio", mock.AsyncMock()
+        "opentrons.hardware_control.modules.absorbance_reader.asyncio", autospec=True
     ):
         await modules.update_firmware(mod_absorbancereader, "fake_fw_file_path")
     byonoy_update_firmware_mock.assert_called_once_with("fake_fw_file_path")


### PR DESCRIPTION
# Overview

The api unit test suite is currently taking approximately 3 minutes and 18 seconds. While not an extremely long time, anybody who watched the stdout of the pytest suite running has noticed that there are a few tests where the suite hangs before continuing. Using the `--durations=N` argument, one can see the execution time of the top N unit tests. The top 10 slowest unit tests before this PR were:
```
25.00s call     tests/opentrons/hardware_control/integration/test_thermocycler.py::test_cycle_temperatures
14.01s call     tests/opentrons/hardware_control/backends/test_ot3_controller.py::test_liquid_probe[OT3Mount.RIGHT]
14.01s call     tests/opentrons/hardware_control/backends/test_ot3_controller.py::test_liquid_probe[OT3Mount.LEFT]
10.01s call     tests/opentrons/hardware_control/backends/test_ot3_subsystem_manager.py::test_update_process_fails_if_subsytem_is_not_ok_afterward
10.00s call     tests/opentrons/hardware_control/test_modules.py::test_module_update_integration
10.00s call     tests/opentrons/hardware_control/backends/test_ot3_subsystem_manager.py::test_update_process_fails_if_subsytem_does_not_appear_afterward
7.00s call     tests/opentrons/hardware_control/integration/test_thermocycler.py::test_cycle_cannot_be_interrupted_by_pause
6.14s call     tests/opentrons/hardware_control/integration/test_thermocycler.py::test_plate_temperature
3.62s call     tests/opentrons/hardware_control/integration/test_thermocycler.py::test_cycle_can_be_blocked_by_preexisting_pause
3.24s call     tests/opentrons/hardware_control/modules/test_hc_thermocycler.py::test_execute_profile
```

With over 6000 tests currently being run, this meant that the top 6 tests, or 0.1% of the entire suite, were taking approximately a third of the time. In the name of targeting the lowest hanging fruit, those top six were targeted for speed ups. The following changes were made to speed up these tests:

- For `test_thermocycler.py::test_cycle_temperatures` the `poll_interval_seconds` fixture in the conftest was decreased by a factor of 10, from `0.1` seconds to `0.01` seconds. There was a warning that if this was set to be "too fast" it would lead to tests failing but I have not seen this myself. This single change alone saved over 40 seconds of time.
- For `test_ot3_controller.py::test_liquid_probe` it was discovered that the hardware control `tool_sensors.finalize_logs` function was timing out after 10 seconds waiting for sensor data. Because this is a unit test and therefore has no sensor and was not adding anything to the test, this was monkeypatched out. This took these two tests from 28 seconds to 1 second.
- For `test_modules.py::test_module_update_integration`, it was the absorbance reader tests that was adding 10 seconds of execution time, this time from an `asyncio.sleep(10)` in the `update_device` method. This was patched out without affecting test efficacy, which removed 10 seconds from this test.
- For `test_ot3_subsystem_manager.py`, the two tests that were failing were also hitting a 10 second timeout. Mocking or patching this out proved more difficult, because `asyncio.wait_for` could not be mocked without either removing what was being tested or reimplementing part of the logic under test in the unit test itself. Instead, a small refactor was undertaken to make the timeout part of the class, therefore allowing it be easily changed within the test, This reduced these two tests from 20 seconds to a little over a second.

Overall, these four changes saves us over 90 seconds of unit test execution time, or around a total of 1 minutes and 40 seconds (all of this was calculated on my laptop so results may slightly differ). This should also translate to CI as well so you should hopefully see your green checkmark (or red X) appear slightly quicker now!

Now the top 10 slowest unit tests are:
```
3.61s call     tests/opentrons/hardware_control/integration/test_thermocycler.py::test_cycle_temperatures
3.25s call     tests/opentrons/hardware_control/modules/test_hc_thermocycler.py::test_execute_profile
2.03s call     tests/opentrons/hardware_control/modules/test_hc_thermocycler.py::test_cycle_temperature
1.74s call     tests/opentrons/protocol_api_integration/test_transfer_with_liquid_classes.py::test_raises_no_tips_available_error[simulated_protocol_context0]
1.69s call     tests/opentrons/protocols/geometry/test_inner_well_math_utils.py::test_volume_and_height_circular[well2]
1.28s setup    tests/opentrons/hardware_control/integration/test_controller.py::test_get_fw_version
1.18s setup    tests/opentrons/hardware_control/integration/test_controller.py::test_get_attached_instruments
1.18s setup    tests/opentrons/hardware_control/integration/test_controller.py::test_move
1.17s setup    tests/opentrons/hardware_control/integration/test_smoothie.py::test_read_and_write_pipettes
1.17s setup    tests/opentrons/hardware_control/integration/test_smoothie.py::test_disable_motor
```

Speeding these up is left as an exercise for the reader.

## Test Plan and Hands on Testing

Test only change (plus a small refactor), so if the tests are passing in CI and other people's laptops, all is good.

## Changelog

- small refactor to `subsystem_manager.py`
- various unit test changes described above to speed up tests

## Review requests

Please test running the api unit tests on your laptop to make sure it doesn't only work on mine. Also, some of the async mocks might be slightly off or can be improved, so please recommend another method if I used a more clunky or out of date method.

## Risk assessment

Low, the only production code change was a very small refactor and otherwise all other changes are test only.