### PR TITLE
docs(api): fix typo in load_labware lid parameter

### DIFF
--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -463,7 +463,7 @@ class ProtocolContext(CommandPublisher):
         :param lid: A lid to load on the top of the main labware. Accepts the same
             values as the ``load_name`` parameter of :py:meth:`.load_lid_stack`. The
             lid will use the same namespace as the labware, and the API will
-            choose the adapter's version automatically.
+            choose the lid's version automatically.
 
                         .. versionadded:: 2.23
         """


### PR DESCRIPTION
# Overview

Fix a copy/paste typo in the `load_labware(...lid)` docstring.

## Test Plan and Hands on Testing

Built locally. (Sandbox is AWOL)

## Changelog

-1 +1

## Review requests

`:squirrel:`

## Risk assessment

none
