### PR TITLE
refactor(protocol-designer): allow stacking lids again

### DIFF
--- a/protocol-designer/src/pages/Designer/DeckSetup/utils.ts
+++ b/protocol-designer/src/pages/Designer/DeckSetup/utils.ts
@@ -204,10 +204,7 @@ const getStackerDefinitionsFromLoadName = (
 
   //  TODO: remove this when we allow stacking of the Opentrons Tough plate on itself
   //  in PD
-  if (
-    loadName === 'opentrons_96_wellplate_200ul_pcr_full_skirt' &&
-    matchingLabwares.some(labware => labware.loadName === loadName)
-  ) {
+  if (loadName === 'opentrons_96_wellplate_200ul_pcr_full_skirt') {
     return matchingLabwares.reduce((acc: string[], labware) => {
       if (labware.loadName !== loadName) {
         acc.push(labware.labwareDefUri)

--- a/protocol-designer/src/pages/Designer/DeckSetup/utils.ts
+++ b/protocol-designer/src/pages/Designer/DeckSetup/utils.ts
@@ -202,9 +202,12 @@ const getStackerDefinitionsFromLoadName = (
       loadName: def.parameters.loadName,
     }))
 
-  //  TODO: remove this when we allow stacking of all labware on itself
+  //  TODO: remove this when we allow stacking of the Opentrons Tough plate on itself
   //  in PD
-  if (matchingLabwares.some(labware => labware.loadName === loadName)) {
+  if (
+    loadName === 'opentrons_96_wellplate_200ul_pcr_full_skirt' &&
+    matchingLabwares.some(labware => labware.loadName === loadName)
+  ) {
     return matchingLabwares.reduce((acc: string[], labware) => {
       if (labware.loadName !== loadName) {
         acc.push(labware.labwareDefUri)


### PR DESCRIPTION
# Overview

Merged in a previous PR that changed this logic and it affected the ability to stack a quantity of lids. The fix is special-casing removing the ability to stack the Opentrons tough plate on itself because its labware def has that information for some reason, even though we haven't officially supported stacking plates on themselves directly on the deck map.

## Test Plan and Hands on Testing

make sure with the labware stacking ff turne on, you can stack lids on itself 

## Changelog

- make logic more specific

## Risk assessment

low
