### PR TITLE
fix(shared-data): Increased appliedbiosystemsmicroamp_384_wellplate_40ul grip height

### DIFF
--- a/shared-data/labware/definitions/2/appliedbiosystemsmicroamp_384_wellplate_40ul/3.json
+++ b/shared-data/labware/definitions/2/appliedbiosystemsmicroamp_384_wellplate_40ul/3.json
@@ -4696,7 +4696,7 @@
   "namespace": "opentrons",
   "version": 3,
   "schemaVersion": 2,
-  "gripHeightFromLabwareBottom": 6.2,
+  "gripHeightFromLabwareBottom": 7.45,
   "stackingOffsetWithLabware": {
     "appliedbiosystemsmicroamp_384_wellplate_40ul": {
       "x": 0,


### PR DESCRIPTION

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Increased appliedbiosystemsmicroamp_384_wellplate_40ul grip height for larger clearance btwn gripper and deck

## Test Plan and Hands on Testing

- small change for grip height, lower height has been tested without scraping the deck. this height just adds an extra safety net.

## Sources

Current height results in the gripper being 0.25 mm from the bottom of the deck  
<img width="720" height="572" alt="image" src="https://github.com/user-attachments/assets/302a94fc-b6dd-4be5-ad99-b5bcd197fdae" />
 New height gives 1.5 mm clearance

<img width="720" height="627" alt="image" src="https://github.com/user-attachments/assets/97f13780-80bb-42ad-a5f1-4011ca24bbc7" />

