### PR TITLE
feat(step-generation): update emitted python files to use api 2.25

### DIFF
--- a/protocol-designer/src/file-data/__tests__/createFile.test.ts
+++ b/protocol-designer/src/file-data/__tests__/createFile.test.ts
@@ -152,7 +152,7 @@ metadata = {
     "source": "Protocol Designer",
 }
 
-requirements = {"robotType": "OT-2", "apiLevel": "2.24"}
+requirements = {"robotType": "OT-2", "apiLevel": "2.25"}
 
 def run(protocol: protocol_api.ProtocolContext) -> None:
     # Load Labware:
@@ -285,7 +285,7 @@ CUSTOM_LABWARE = json.loads("""{"fixture/fixture_trash/1":{"ordering":[["A1"]],"
             },
           },
         },
-        version: '8.5.0',
+        version: '8.6.0',
         name: 'opentrons/protocol-designer',
       },
       robot: { model: OT2_ROBOT_TYPE },

--- a/step-generation/src/__tests__/pythonFileUtils.test.ts
+++ b/step-generation/src/__tests__/pythonFileUtils.test.ts
@@ -93,11 +93,11 @@ metadata = {
 describe('pythonRequirements', () => {
   it('should generate requirements section', () => {
     expect(pythonRequirements(OT2_ROBOT_TYPE)).toBe(
-      `requirements = {"robotType": "OT-2", "apiLevel": "2.24"}`
+      `requirements = {"robotType": "OT-2", "apiLevel": "2.25"}`
     )
 
     expect(pythonRequirements(FLEX_ROBOT_TYPE)).toBe(
-      `requirements = {"robotType": "Flex", "apiLevel": "2.24"}`
+      `requirements = {"robotType": "Flex", "apiLevel": "2.25"}`
     )
   })
 })

--- a/step-generation/src/utils/pythonFileUtils.ts
+++ b/step-generation/src/utils/pythonFileUtils.ts
@@ -41,8 +41,8 @@ import type {
   WasteChuteEntities,
 } from '../types'
 
-const PAPI_VERSION = '2.24' // latest version from api/src/opentrons/protocols/api_support/definitions.py
-export const PD_APPLICATION_VERSION = '8.5.0' // latest PD version to insert into DESIGNER_APPLICATION blob
+const PAPI_VERSION = '2.25' // latest version from api/src/opentrons/protocols/api_support/definitions.py
+export const PD_APPLICATION_VERSION = '8.6.0' // latest PD version to insert into DESIGNER_APPLICATION blob
 
 export function pythonImports(): string {
   return ['import json', 'from opentrons import protocol_api, types'].join('\n')


### PR DESCRIPTION
closes AUTH-2218

# Overview

introducing api level 2.25 for python generated PD protocols 😎 

this is needed to use the new `tip_rack` arg for the liquid class commands

<img width="509" height="224" alt="Screenshot 2025-08-21 at 10 44 16" src="https://github.com/user-attachments/assets/fbb35110-c977-43d8-b08f-8dca36ea4d55" />

## Test Plan and Hands on Testing

review code

## Changelog

update api level

## Risk assessment

low
