### PR TITLE
feat(api): tip positioning for reservoir bottoms for schema 2

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/aspirate.py
+++ b/api/src/opentrons/protocol_engine/commands/aspirate.py
@@ -161,6 +161,7 @@ class AspirateImplementation(AbstractCommandImpl[AspirateParams, _ExecuteReturn]
             well_location=well_location,
             current_well=current_well,
             operation_volume=-params.volume,
+            offset_pipette_for_reservoir_subwells=False,
         )
         state_update.append(move_result.state_update)
         if isinstance(move_result, DefinedErrorData):

--- a/api/src/opentrons/protocol_engine/commands/dispense.py
+++ b/api/src/opentrons/protocol_engine/commands/dispense.py
@@ -101,6 +101,7 @@ class DispenseImplementation(AbstractCommandImpl[DispenseParams, _ExecuteReturn]
             well_name=well_name,
             well_location=well_location,
             operation_volume=volume,
+            offset_pipette_for_reservoir_subwells=False,
         )
         if isinstance(move_result, DefinedErrorData):
             return move_result

--- a/api/src/opentrons/protocol_engine/commands/movement_common.py
+++ b/api/src/opentrons/protocol_engine/commands/movement_common.py
@@ -152,6 +152,7 @@ async def move_to_well(
     minimum_z_height: Optional[float] = None,
     speed: Optional[float] = None,
     operation_volume: Optional[float] = None,
+    offset_pipette_for_reservoir_subwells: bool = False,
 ) -> MoveToWellOperationReturn:
     """Execute a move to well microoperation."""
     try:
@@ -165,6 +166,7 @@ async def move_to_well(
             minimum_z_height=minimum_z_height,
             speed=speed,
             operation_volume=operation_volume,
+            offset_pipette_for_reservoir_subwells=offset_pipette_for_reservoir_subwells,
         )
     except StallOrCollisionDetectedError as e:
         return DefinedErrorData(

--- a/api/src/opentrons/protocol_engine/execution/movement.py
+++ b/api/src/opentrons/protocol_engine/execution/movement.py
@@ -83,6 +83,7 @@ class MovementHandler:
         minimum_z_height: Optional[float] = None,
         speed: Optional[float] = None,
         operation_volume: Optional[float] = None,
+        offset_pipette_for_reservoir_subwells: bool = False,
     ) -> Point:
         """Move to a specific well."""
         self._state_store.geometry.raise_if_labware_inaccessible_by_pipette(
@@ -143,6 +144,7 @@ class MovementHandler:
             force_direct=force_direct,
             minimum_z_height=minimum_z_height,
             operation_volume=operation_volume,
+            offset_pipette_for_reservoir_subwells=offset_pipette_for_reservoir_subwells,
         )
 
         speed = self._state_store.pipettes.get_movement_speed(

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -662,10 +662,12 @@ class LabwareView:
         )
 
     def get_has_96_subwells(self, labware_id: str) -> bool:
-        return self.get_has_quirk(labware_id, "has96SubWells")
+        """True if a labware is a reservoir with a 96-grid of sub-wells."""
+        return self.get_has_quirk(labware_id, "offsetPipetteFor96GridSubwells")
 
     def get_has_12_subwells(self, labware_id: str) -> bool:
-        return self.get_has_quirk(labware_id, "has12ubWells")
+        """True if a labware is a reservoir with a 12-grid of sub-wells."""
+        return self.get_has_quirk(labware_id, "offsetPipetteFor12GridSubwells")
 
     def get_well_definition(
         self,

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -661,6 +661,12 @@ class LabwareView:
             or len(self.get_definition(labware_id).wells) >= 96
         )
 
+    def get_has_96_subwells(self, labware_id: str) -> bool:
+        return self.get_has_quirk(labware_id, "has96SubWells")
+
+    def get_has_12_subwells(self, labware_id: str) -> bool:
+        return self.get_has_quirk(labware_id, "has12ubWells")
+
     def get_well_definition(
         self,
         labware_id: str,

--- a/api/src/opentrons/protocol_engine/state/motion.py
+++ b/api/src/opentrons/protocol_engine/state/motion.py
@@ -136,6 +136,7 @@ class MotionView:
         force_direct: bool = False,
         minimum_z_height: Optional[float] = None,
         operation_volume: Optional[float] = None,
+        offset_pipette_for_reservoir_subwells: bool = False,
     ) -> List[motion_planning.Waypoint]:
         """Calculate waypoints to a destination that's specified as a well."""
         location = current_well or self._pipettes.get_current_location()
@@ -153,9 +154,10 @@ class MotionView:
             operation_volume=operation_volume,
             pipette_id=pipette_id,
         )
-        destination += self._get_pipette_offset_for_reservoirs(
-            labware_id=labware_id, well_name=well_name, pipette_id=pipette_id
-        )
+        if offset_pipette_for_reservoir_subwells:
+            destination += self._get_pipette_offset_for_reservoirs(
+                labware_id=labware_id, well_name=well_name, pipette_id=pipette_id
+            )
 
         move_type = _move_types.get_move_type_to_well(
             pipette_id, labware_id, well_name, location, force_direct

--- a/api/src/opentrons/protocol_engine/state/motion.py
+++ b/api/src/opentrons/protocol_engine/state/motion.py
@@ -90,8 +90,18 @@ class MotionView:
         return PipetteLocationData(mount=mount, critical_point=critical_point)
 
     def _get_pipette_offset_for_reservoirs(
-        self, labware_id: str, well_name: str
+        self, labware_id: str, well_name: str, pipette_id: str
     ) -> Point:
+        # - 96 channel pipettes need no adjustments, since they have an even number
+        #   of both rows and columns
+        # - 8 channel pipettes might need an adjustment in only the x direction,
+        #   since they have an odd number of columns
+        # - 1 channel pipettes might need an adjustment in x and y directions,
+        #   since they have an odd number of both rows and columns
+        pipette_channels = self._pipettes.get_config(pipette_id).channels
+        if pipette_channels == 96:
+            return Point()
+
         subwells_96 = self._labware.get_has_96_subwells(labware_id)
         subwells_12 = self._labware.get_has_12_subwells(labware_id)
         if not subwells_12 and not subwells_96:
@@ -115,8 +125,9 @@ class MotionView:
             # move half a subwell to the left + half a subwell up
             # half of a subwell width would be 1/12 * well_x_dim / 2
             x_offset = -1 * well_x_dim / 24
-            # half of a subwell length would be 1/8 * well_y_dim / 2
-            y_offset = well_y_dim / 16
+            if pipette_channels == 1:
+                # half of a subwell length would be 1/8 * well_y_dim / 2
+                y_offset = well_y_dim / 16
         return Point(x=x_offset, y=y_offset)
 
     def get_movement_waypoints_to_well(
@@ -150,7 +161,7 @@ class MotionView:
             pipette_id=pipette_id,
         )
         destination += self._get_pipette_offset_for_reservoirs(
-            labware_id=labware_id, well_name=well_name
+            labware_id=labware_id, well_name=well_name, pipette_id=pipette_id
         )
 
         move_type = _move_types.get_move_type_to_well(

--- a/api/src/opentrons/protocol_engine/state/motion.py
+++ b/api/src/opentrons/protocol_engine/state/motion.py
@@ -1,5 +1,4 @@
 """Motion state store and getters."""
-
 from dataclasses import dataclass
 from typing import List, Optional, Union
 import logging

--- a/api/src/opentrons/protocol_engine/state/motion.py
+++ b/api/src/opentrons/protocol_engine/state/motion.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass
 from typing import List, Optional, Union
+import logging
 
 from opentrons.types import MountType, Point, StagingSlotName
 from opentrons.hardware_control.types import CriticalPoint
@@ -28,6 +29,8 @@ from .addressable_areas import AddressableAreaView
 from .geometry import GeometryView
 from .modules import ModuleView
 from .module_substates import HeaterShakerModuleId
+
+log = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -86,7 +89,9 @@ class MotionView:
                 critical_point = CriticalPoint.XY_CENTER
         return PipetteLocationData(mount=mount, critical_point=critical_point)
 
-    def _get_pipette_offset_for_reservoirs(self, labware_id: str, well_name: str) -> Point:
+    def _get_pipette_offset_for_reservoirs(
+        self, labware_id: str, well_name: str
+    ) -> Point:
         subwells_96 = self._labware.get_has_96_subwells(labware_id)
         subwells_12 = self._labware.get_has_12_subwells(labware_id)
         if not subwells_12 and not subwells_96:
@@ -98,16 +103,20 @@ class MotionView:
 
         x_offset = 0.0
         y_offset = 0.0
-        if subwells_96:
+        if subwells_12 and subwells_96:
+            log.warning(
+                f"{labware_id} has both offsetPipetteFor96GridSubwells and offsetPipetteFor12GridSubwells quirks."
+            )
+        if subwells_12:
+            # move half a subwell to the left
+            # half of a subwell width would be 1/12 * well_x_dim / 2
+            x_offset = -1 * well_x_dim / 24
+        elif subwells_96:
             # move half a subwell to the left + half a subwell up
             # half of a subwell width would be 1/12 * well_x_dim / 2
             x_offset = -1 * well_x_dim / 24
             # half of a subwell length would be 1/8 * well_y_dim / 2
             y_offset = well_y_dim / 16
-        if subwells_12:
-            # move half a subwell to the left
-            # half of a subwell width would be 1/12 * well_x_dim / 2
-            x_offset = -1 * well_x_dim / 24
         return Point(x=x_offset, y=y_offset)
 
     def get_movement_waypoints_to_well(
@@ -141,8 +150,7 @@ class MotionView:
             pipette_id=pipette_id,
         )
         destination += self._get_pipette_offset_for_reservoirs(
-            labware_id=labware_id,
-            well_name=well_name
+            labware_id=labware_id, well_name=well_name
         )
 
         move_type = _move_types.get_move_type_to_well(

--- a/api/src/opentrons/protocol_engine/state/motion.py
+++ b/api/src/opentrons/protocol_engine/state/motion.py
@@ -91,42 +91,36 @@ class MotionView:
     def _get_pipette_offset_for_reservoirs(
         self, labware_id: str, well_name: str, pipette_id: str
     ) -> Point:
-        # - 96 channel pipettes need no adjustments, since they have an even number
-        #   of both rows and columns
-        # - 8 channel pipettes might need an adjustment in only the x direction,
-        #   since they have an odd number of columns
-        # - 1 channel pipettes might need an adjustment in x and y directions,
-        #   since they have an odd number of both rows and columns
-        pipette_channels = self._pipettes.get_config(pipette_id).channels
-        if pipette_channels == 96:
-            return Point()
-
+        #   8 rows, 12 columns
         subwells_96 = self._labware.get_has_96_subwells(labware_id)
+        #   1 row, 12 columns
         subwells_12 = self._labware.get_has_12_subwells(labware_id)
-        if not subwells_12 and not subwells_96:
-            return Point()
-
-        well_x_dim, well_y_dim, well_z_dim = self._labware.get_well_size(
-            labware_id=labware_id, well_name=well_name
-        )
-
-        x_offset = 0.0
-        y_offset = 0.0
         if subwells_12 and subwells_96:
             log.warning(
                 f"{labware_id} has both offsetPipetteFor96GridSubwells and offsetPipetteFor12GridSubwells quirks."
             )
-        if subwells_12:
-            # move half a subwell to the left
-            # half of a subwell width would be 1/12 * well_x_dim / 2
+
+        pipette_rows = self._pipettes.get_config(pipette_id).default_nozzle_map.rows
+        pipette_cols = self._pipettes.get_config(pipette_id).default_nozzle_map.columns
+
+        even_labware_rows = subwells_96
+        even_labware_columns = subwells_96 or subwells_12
+        odd_pipette_rows = len(pipette_rows) % 2 == 1
+        odd_pipette_cols = len(pipette_cols) % 2 == 1
+
+        well_x_dim, well_y_dim, well_z_dim = self._labware.get_well_size(
+            labware_id=labware_id, well_name=well_name
+        )
+        x_offset = 0.0
+        y_offset = 0.0
+        if even_labware_rows and odd_pipette_rows:
+            # need to move up half a row
+            # there's 8 rows, so move 1/16 of reservoir length
+            y_offset = well_y_dim / 16
+        if even_labware_columns and odd_pipette_cols:
+            # need to move left half a column
+            # there's 12 columns, so move 1/24 of reservoir width
             x_offset = -1 * well_x_dim / 24
-        elif subwells_96:
-            # move half a subwell to the left + half a subwell up
-            # half of a subwell width would be 1/12 * well_x_dim / 2
-            x_offset = -1 * well_x_dim / 24
-            if pipette_channels == 1:
-                # half of a subwell length would be 1/8 * well_y_dim / 2
-                y_offset = well_y_dim / 16
         return Point(x=x_offset, y=y_offset)
 
     def get_movement_waypoints_to_well(

--- a/api/src/opentrons/protocol_engine/state/motion.py
+++ b/api/src/opentrons/protocol_engine/state/motion.py
@@ -100,8 +100,8 @@ class MotionView:
                 f"{labware_id} has both offsetPipetteFor96GridSubwells and offsetPipetteFor12GridSubwells quirks."
             )
 
-        pipette_rows = self._pipettes.get_config(pipette_id).default_nozzle_map.rows
-        pipette_cols = self._pipettes.get_config(pipette_id).default_nozzle_map.columns
+        pipette_rows = self._pipettes.get_nozzle_configuration(pipette_id).rows
+        pipette_cols = self._pipettes.get_nozzle_configuration(pipette_id).columns
 
         even_labware_rows = subwells_96
         even_labware_columns = subwells_96 or subwells_12

--- a/api/src/opentrons/protocol_engine/state/motion.py
+++ b/api/src/opentrons/protocol_engine/state/motion.py
@@ -1,4 +1,5 @@
 """Motion state store and getters."""
+
 from dataclasses import dataclass
 from typing import List, Optional, Union
 
@@ -85,6 +86,30 @@ class MotionView:
                 critical_point = CriticalPoint.XY_CENTER
         return PipetteLocationData(mount=mount, critical_point=critical_point)
 
+    def _get_pipette_offset_for_reservoirs(self, labware_id: str, well_name: str) -> Point:
+        subwells_96 = self._labware.get_has_96_subwells(labware_id)
+        subwells_12 = self._labware.get_has_12_subwells(labware_id)
+        if not subwells_12 and not subwells_96:
+            return Point()
+
+        well_x_dim, well_y_dim, well_z_dim = self._labware.get_well_size(
+            labware_id=labware_id, well_name=well_name
+        )
+
+        x_offset = 0.0
+        y_offset = 0.0
+        if subwells_96:
+            # move half a subwell to the left + half a subwell up
+            # half of a subwell width would be 1/12 * well_x_dim / 2
+            x_offset = -1 * well_x_dim / 24
+            # half of a subwell length would be 1/8 * well_y_dim / 2
+            y_offset = well_y_dim / 16
+        if subwells_12:
+            # move half a subwell to the left
+            # half of a subwell width would be 1/12 * well_x_dim / 2
+            x_offset = -1 * well_x_dim / 24
+        return Point(x=x_offset, y=y_offset)
+
     def get_movement_waypoints_to_well(
         self,
         pipette_id: str,
@@ -114,6 +139,10 @@ class MotionView:
             well_location=well_location,
             operation_volume=operation_volume,
             pipette_id=pipette_id,
+        )
+        destination += self._get_pipette_offset_for_reservoirs(
+            labware_id=labware_id,
+            well_name=well_name
         )
 
         move_type = _move_types.get_move_type_to_well(

--- a/api/tests/opentrons/protocol_engine/commands/test_aspirate.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_aspirate.py
@@ -120,6 +120,7 @@ async def test_aspirate_implementation_no_prep(
             minimum_z_height=None,
             speed=None,
             operation_volume=-50,
+            offset_pipette_for_reservoir_subwells=False,
         ),
     ).then_return(Point(x=1, y=2, z=3))
 
@@ -212,6 +213,7 @@ async def test_aspirate_implementation_with_prep(
             minimum_z_height=None,
             speed=None,
             operation_volume=None,
+            offset_pipette_for_reservoir_subwells=False,
         ),
     ).then_return(Point())
 
@@ -230,6 +232,7 @@ async def test_aspirate_implementation_with_prep(
             minimum_z_height=None,
             speed=None,
             operation_volume=-volume,
+            offset_pipette_for_reservoir_subwells=False,
         ),
     ).then_return(Point(x=1, y=2, z=3))
 
@@ -323,6 +326,7 @@ async def test_aspirate_raises_volume_error(
             minimum_z_height=None,
             speed=None,
             operation_volume=-50,
+            offset_pipette_for_reservoir_subwells=False,
         ),
     ).then_return(Point(1, 2, 3))
 
@@ -401,6 +405,7 @@ async def test_overpressure_error(
             minimum_z_height=None,
             speed=None,
             operation_volume=-50,
+            offset_pipette_for_reservoir_subwells=False,
         ),
     ).then_return(position)
 
@@ -501,6 +506,7 @@ async def test_aspirate_implementation_meniscus(
             minimum_z_height=None,
             speed=None,
             operation_volume=-50,
+            offset_pipette_for_reservoir_subwells=False,
         ),
     ).then_return(Point(x=1, y=2, z=3))
 
@@ -580,6 +586,7 @@ async def test_stall_during_final_movement(
             minimum_z_height=None,
             speed=None,
             operation_volume=-50,
+            offset_pipette_for_reservoir_subwells=False,
         ),
     ).then_raise(StallOrCollisionDetectedError())
 
@@ -642,6 +649,7 @@ async def test_stall_during_preparation(
             minimum_z_height=None,
             speed=None,
             operation_volume=None,
+            offset_pipette_for_reservoir_subwells=False,
         ),
     ).then_raise(StallOrCollisionDetectedError())
     decoy.when(model_utils.generate_id()).then_return(error_id)
@@ -715,6 +723,7 @@ async def test_overpressure_during_preparation(
             minimum_z_height=None,
             speed=None,
             operation_volume=None,
+            offset_pipette_for_reservoir_subwells=False,
         ),
     ).then_return(prep_location)
 

--- a/api/tests/opentrons/protocol_engine/commands/test_aspirate_while_tracking.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_aspirate_while_tracking.py
@@ -161,6 +161,7 @@ async def test_aspirate_while_tracking_implementation(
             minimum_z_height=None,
             speed=None,
             operation_volume=-123,
+            offset_pipette_for_reservoir_subwells=False,
         ),
     ).then_return(Point(x=4, y=5, z=6))
 
@@ -299,6 +300,7 @@ async def test_aspirate_raises_volume_error(
             minimum_z_height=None,
             speed=None,
             operation_volume=-50,
+            offset_pipette_for_reservoir_subwells=False,
         ),
     ).then_return(Point(x=4, y=5, z=6))
 
@@ -403,6 +405,7 @@ async def test_overpressure_error(
             minimum_z_height=None,
             speed=None,
             operation_volume=-50,
+            offset_pipette_for_reservoir_subwells=False,
         ),
     ).then_return(Point(x=4, y=5, z=6))
 

--- a/api/tests/opentrons/protocol_engine/commands/test_blow_out.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_blow_out.py
@@ -81,6 +81,7 @@ async def test_blow_out_implementation(
             minimum_z_height=None,
             speed=None,
             operation_volume=None,
+            offset_pipette_for_reservoir_subwells=False,
         )
     ).then_return(Point(x=1, y=2, z=3))
 
@@ -156,6 +157,7 @@ async def test_overpressure_error(
             minimum_z_height=None,
             speed=None,
             operation_volume=None,
+            offset_pipette_for_reservoir_subwells=False,
         )
     ).then_return(Point(x=1, y=2, z=3))
 
@@ -231,6 +233,7 @@ async def test_stall_error(
             minimum_z_height=None,
             speed=None,
             operation_volume=None,
+            offset_pipette_for_reservoir_subwells=False,
         )
     ).then_raise(StallOrCollisionDetectedError())
 

--- a/api/tests/opentrons/protocol_engine/commands/test_dispense.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_dispense.py
@@ -81,6 +81,7 @@ async def test_dispense_implementation(
             minimum_z_height=None,
             speed=None,
             operation_volume=50.0,
+            offset_pipette_for_reservoir_subwells=False,
         )
     ).then_return(Point(x=1, y=2, z=3))
 
@@ -203,6 +204,7 @@ async def test_overpressure_error(
             minimum_z_height=None,
             speed=None,
             operation_volume=50.0,
+            offset_pipette_for_reservoir_subwells=False,
         ),
     ).then_return(position)
 
@@ -304,6 +306,7 @@ async def test_stall_error(
             minimum_z_height=None,
             speed=None,
             operation_volume=50.0,
+            offset_pipette_for_reservoir_subwells=False,
         ),
     ).then_raise(StallOrCollisionDetectedError())
 

--- a/api/tests/opentrons/protocol_engine/commands/test_dispense_while_tracking.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_dispense_while_tracking.py
@@ -151,6 +151,7 @@ async def test_dispense_while_tracking_implementation(
             minimum_z_height=None,
             speed=None,
             operation_volume=None,
+            offset_pipette_for_reservoir_subwells=False,
         ),
     ).then_return(Point(x=4, y=5, z=6))
 
@@ -296,6 +297,7 @@ async def test_overpressure_error(
             minimum_z_height=None,
             speed=None,
             operation_volume=None,
+            offset_pipette_for_reservoir_subwells=False,
         ),
     ).then_return(Point(x=4, y=5, z=6))
 

--- a/api/tests/opentrons/protocol_engine/commands/test_drop_tip.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_drop_tip.py
@@ -153,6 +153,7 @@ async def test_drop_tip_implementation(
             minimum_z_height=None,
             speed=None,
             operation_volume=None,
+            offset_pipette_for_reservoir_subwells=False,
         )
     ).then_return(Point(x=111, y=222, z=333))
 
@@ -254,6 +255,7 @@ async def test_drop_tip_with_alternating_locations(
             minimum_z_height=None,
             speed=None,
             operation_volume=None,
+            offset_pipette_for_reservoir_subwells=False,
         )
     ).then_return(Point(x=111, y=222, z=333))
 
@@ -347,6 +349,7 @@ async def test_tip_attached_error(
             minimum_z_height=None,
             speed=None,
             operation_volume=None,
+            offset_pipette_for_reservoir_subwells=False,
         )
     ).then_return(Point(x=111, y=222, z=333))
     decoy.when(
@@ -457,6 +460,7 @@ async def test_stall_error(
             minimum_z_height=None,
             speed=None,
             operation_volume=None,
+            offset_pipette_for_reservoir_subwells=False,
         )
     ).then_raise(StallOrCollisionDetectedError())
 

--- a/api/tests/opentrons/protocol_engine/commands/test_liquid_probe.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_liquid_probe.py
@@ -179,6 +179,7 @@ async def test_liquid_probe_implementation(
             minimum_z_height=None,
             speed=None,
             operation_volume=None,
+            offset_pipette_for_reservoir_subwells=False,
         ),
     ).then_return(Point(x=1, y=2, z=3))
 
@@ -342,6 +343,7 @@ async def test_liquid_not_found_error(
             minimum_z_height=None,
             speed=None,
             operation_volume=None,
+            offset_pipette_for_reservoir_subwells=False,
         ),
     ).then_return(position)
     decoy.when(
@@ -744,6 +746,7 @@ async def test_liquid_probe_stall(
             minimum_z_height=None,
             speed=None,
             operation_volume=None,
+            offset_pipette_for_reservoir_subwells=False,
         ),
     ).then_raise(StallOrCollisionDetectedError())
 

--- a/api/tests/opentrons/protocol_engine/commands/test_move_to_well.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_move_to_well.py
@@ -71,6 +71,7 @@ async def test_move_to_well_implementation(
             speed=7.89,
             current_well=None,
             operation_volume=None,
+            offset_pipette_for_reservoir_subwells=False,
         )
     ).then_return(Point(x=9, y=8, z=7))
 
@@ -137,6 +138,7 @@ async def test_move_to_well_stall_defined_error(
             speed=7.89,
             current_well=None,
             operation_volume=None,
+            offset_pipette_for_reservoir_subwells=False,
         )
     ).then_raise(StallOrCollisionDetectedError())
     decoy.when(mock_model_utils.generate_id()).then_return(error_id)

--- a/api/tests/opentrons/protocol_engine/commands/test_pick_up_tip.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_pick_up_tip.py
@@ -67,6 +67,7 @@ async def test_success(
             minimum_z_height=None,
             speed=None,
             operation_volume=None,
+            offset_pipette_for_reservoir_subwells=False,
         )
     ).then_return(Point(x=111, y=222, z=333))
 
@@ -167,6 +168,7 @@ async def test_tip_physically_missing_error(
             minimum_z_height=None,
             speed=None,
             operation_volume=None,
+            offset_pipette_for_reservoir_subwells=False,
         )
     ).then_return(Point(x=111, y=222, z=333))
     decoy.when(
@@ -276,6 +278,7 @@ async def test_stall_error(
             minimum_z_height=None,
             speed=None,
             operation_volume=None,
+            offset_pipette_for_reservoir_subwells=False,
         )
     ).then_raise(StallOrCollisionDetectedError())
 

--- a/api/tests/opentrons/protocol_engine/commands/test_pressure_dispense.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_pressure_dispense.py
@@ -95,6 +95,7 @@ async def test_pressure_dispense_implementation(
             minimum_z_height=None,
             speed=None,
             operation_volume=None,
+            offset_pipette_for_reservoir_subwells=False,
         )
     ).then_return(Point(x=1, y=2, z=3))
 

--- a/api/tests/opentrons/protocol_engine/commands/test_seal_pipette_to_tip.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_seal_pipette_to_tip.py
@@ -101,6 +101,7 @@ async def test_success(
             minimum_z_height=None,
             speed=None,
             operation_volume=None,
+            offset_pipette_for_reservoir_subwells=False,
         )
     ).then_return(Point(x=111, y=222, z=333))
     decoy.when(
@@ -195,6 +196,7 @@ async def test_no_tip_physically_missing_error(
             minimum_z_height=None,
             speed=None,
             operation_volume=None,
+            offset_pipette_for_reservoir_subwells=False,
         )
     ).then_return(Point(x=111, y=222, z=333))
     decoy.when(
@@ -293,6 +295,7 @@ async def test_stall_error(
             minimum_z_height=None,
             speed=None,
             operation_volume=None,
+            offset_pipette_for_reservoir_subwells=False,
         )
     ).then_raise(StallOrCollisionDetectedError())
 

--- a/api/tests/opentrons/protocol_engine/commands/test_touch_tip.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_touch_tip.py
@@ -89,6 +89,7 @@ async def test_touch_tip_implementation(
             minimum_z_height=None,
             speed=None,
             operation_volume=None,
+            offset_pipette_for_reservoir_subwells=False,
         )
     ).then_return(Point(x=1, y=2, z=3))
 
@@ -179,6 +180,7 @@ async def test_touch_tip_implementation_with_mm_from_edge(
             minimum_z_height=None,
             speed=None,
             operation_volume=None,
+            offset_pipette_for_reservoir_subwells=False,
         )
     ).then_return(Point(x=1, y=2, z=3))
 

--- a/api/tests/opentrons/protocol_engine/commands/test_unseal_pipette_from_tip.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_unseal_pipette_from_tip.py
@@ -154,6 +154,7 @@ async def test_drop_tip_implementation(
             minimum_z_height=None,
             speed=None,
             operation_volume=None,
+            offset_pipette_for_reservoir_subwells=False,
         )
     ).then_return(Point(x=111, y=222, z=333))
 
@@ -247,6 +248,7 @@ async def test_tip_attached_error(
             minimum_z_height=None,
             speed=None,
             operation_volume=None,
+            offset_pipette_for_reservoir_subwells=False,
         )
     ).then_return(Point(x=111, y=222, z=333))
     decoy.when(
@@ -323,6 +325,7 @@ async def test_stall_error(
             minimum_z_height=None,
             speed=None,
             operation_volume=None,
+            offset_pipette_for_reservoir_subwells=False,
         )
     ).then_raise(StallOrCollisionDetectedError())
 

--- a/api/tests/opentrons/protocol_engine/execution/test_movement_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_movement_handler.py
@@ -159,6 +159,7 @@ async def test_move_to_well(
             force_direct=True,
             minimum_z_height=12.3,
             operation_volume=None,
+            offset_pipette_for_reservoir_subwells=False,
         )
     ).then_return(
         [Waypoint(Point(1, 2, 3), CriticalPoint.XY_CENTER), Waypoint(Point(4, 5, 6))]
@@ -268,6 +269,7 @@ async def test_move_to_well_from_starting_location(
             force_direct=False,
             minimum_z_height=None,
             operation_volume=None,
+            offset_pipette_for_reservoir_subwells=False,
         )
     ).then_return([Waypoint(Point(1, 2, 3), CriticalPoint.XY_CENTER)])
 

--- a/api/tests/opentrons/protocol_engine/state/test_motion_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_motion_view.py
@@ -63,6 +63,12 @@ def patch_mock__move_types(decoy: Decoy, monkeypatch: pytest.MonkeyPatch) -> Non
 
 
 def _fake_static_pipette_config(channels: int) -> StaticPipetteConfig:
+    names_from_channels = {
+        1: PipetteNameType.P1000_SINGLE_FLEX,
+        8: PipetteNameType.P1000_MULTI_FLEX,
+        96: PipetteNameType.P1000_96,
+    }
+
     return StaticPipetteConfig(
         min_volume=1,
         max_volume=9001,
@@ -78,7 +84,7 @@ def _fake_static_pipette_config(channels: int) -> StaticPipetteConfig:
             back_left_offset=Point(x=10, y=20, z=30),
             front_right_offset=Point(x=40, y=50, z=60),
         ),
-        default_nozzle_map=get_default_nozzle_map(PipetteNameType.P1000_96),
+        default_nozzle_map=get_default_nozzle_map(names_from_channels[channels]),
         pipette_bounding_box_offsets=PipetteBoundingBoxOffsets(
             back_left_corner=Point(x=10, y=20, z=30),
             front_right_corner=Point(x=40, y=50, z=60),
@@ -393,14 +399,18 @@ def test_get_pipette_offset_for_reservoirs(
         geometry_view.get_extra_waypoints(location, DeckSlotName.SLOT_2)
     ).then_return([(456, 789)])
 
-    x_offset = 0.0
-    y_offset = 0.0
-    if has_12_grid and channels != 96:
-        x_offset = -1 * fake_x_dim / 24
-    elif has_96_grid and channels != 96:
-        x_offset = -1 * fake_x_dim / 24
+    has_x_offset = has_y_offset = False
+    if has_12_grid:
+        if channels == 1 or channels == 8:
+            has_x_offset = True
+    if has_96_grid:
         if channels == 1:
-            y_offset = fake_y_dim / 16
+            has_x_offset = has_y_offset = True
+        if channels == 8:
+            has_x_offset = True
+
+    x_offset = -1 * fake_x_dim / 24 if has_x_offset else 0.0
+    y_offset = fake_y_dim / 16 if has_y_offset else 0.0
     reservoir_offset = Point(x=x_offset, y=y_offset)
     expected_destination = fake_well_position + reservoir_offset
 

--- a/api/tests/opentrons/protocol_engine/state/test_motion_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_motion_view.py
@@ -351,10 +351,19 @@ def test_get_pipette_offset_for_reservoirs(
 ) -> None:
     """It should call get_waypoints() with the correct offset given the well's dimensions."""
     location = CurrentWell(pipette_id="123", labware_id="456", well_name="abc")
+    decoy.when(
+        geometry_view.get_min_travel_z("pipette-id", "labware-id", location, 123)
+    ).then_return(42.0)
 
     decoy.when(pipette_view.get_current_location()).then_return(location)
-    decoy.when(pipette_view.get_config("pipette-id")).then_return(
-        _fake_static_pipette_config(channels)
+
+    names_from_channels = {
+        1: PipetteNameType.P1000_SINGLE_FLEX,
+        8: PipetteNameType.P1000_MULTI_FLEX,
+        96: PipetteNameType.P1000_96,
+    }
+    decoy.when(pipette_view.get_nozzle_configuration("pipette-id")).then_return(
+        get_default_nozzle_map(names_from_channels[channels])
     )
 
     fake_x_dim, fake_y_dim, fake_z_dim = 7.0, 8.0, 9.0
@@ -569,9 +578,6 @@ def test_get_movement_waypoints_to_well_for_xy_center(
     decoy.when(
         geometry_view.get_min_travel_z("pipette-id", "labware-id", location, 123)
     ).then_return(42.0)
-    decoy.when(pipette_view.get_config("pipette-id")).then_return(
-        _fake_static_pipette_config(1)
-    )
 
     decoy.when(geometry_view.get_ancestor_slot_name("labware-id")).then_return(
         DeckSlotName.SLOT_2

--- a/api/tests/opentrons/protocol_engine/state/test_motion_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_motion_view.py
@@ -7,6 +7,9 @@ from decoy import Decoy
 from unittest.mock import sentinel
 
 from opentrons_shared_data.pipette.types import PipetteNameType
+from opentrons_shared_data.pipette.pipette_definition import (
+    AvailableSensorDefinition,
+)
 from opentrons.types import Point, MountType, DeckSlotName
 from opentrons.hardware_control.types import CriticalPoint
 from opentrons import motion_planning
@@ -24,13 +27,19 @@ from opentrons.protocol_engine.types import (
 from opentrons.protocol_engine.state import _move_types
 from opentrons.protocol_engine.state.config import Config
 from opentrons.protocol_engine.state.labware import LabwareView
-from opentrons.protocol_engine.state.pipettes import PipetteView
+from opentrons.protocol_engine.state.pipettes import (
+    PipetteView,
+    StaticPipetteConfig,
+    BoundingNozzlesOffsets,
+    PipetteBoundingBoxOffsets,
+)
 from opentrons.protocol_engine.state.addressable_areas import AddressableAreaView
 from opentrons.protocol_engine.state.geometry import GeometryView
 from opentrons.protocol_engine.state.motion import MotionView, PipetteLocationData
 from opentrons.protocol_engine.state.modules import ModuleView
 from opentrons.protocol_engine.state.module_substates import HeaterShakerModuleId
 from opentrons_shared_data.robot.types import RobotType
+from ..pipette_fixtures import get_default_nozzle_map
 
 
 @pytest.fixture
@@ -51,6 +60,41 @@ def patch_mock__move_types(decoy: Decoy, monkeypatch: pytest.MonkeyPatch) -> Non
     """Mock out _move_types.py functions."""
     for name, func in inspect.getmembers(_move_types, inspect.isfunction):
         monkeypatch.setattr(_move_types, name, decoy.mock(func=func))
+
+
+def _fake_static_pipette_config(channels: int) -> StaticPipetteConfig:
+    return StaticPipetteConfig(
+        min_volume=1,
+        max_volume=9001,
+        channels=channels,
+        model="blah",
+        display_name="bleh",
+        serial_number="",
+        tip_configuration_lookup_table={},
+        nominal_tip_overlap={},
+        home_position=0,
+        nozzle_offset_z=0,
+        bounding_nozzle_offsets=BoundingNozzlesOffsets(
+            back_left_offset=Point(x=10, y=20, z=30),
+            front_right_offset=Point(x=40, y=50, z=60),
+        ),
+        default_nozzle_map=get_default_nozzle_map(PipetteNameType.P1000_96),
+        pipette_bounding_box_offsets=PipetteBoundingBoxOffsets(
+            back_left_corner=Point(x=10, y=20, z=30),
+            front_right_corner=Point(x=40, y=50, z=60),
+            front_left_corner=Point(x=10, y=50, z=60),
+            back_right_corner=Point(x=40, y=20, z=60),
+        ),
+        lld_settings={},
+        plunger_positions={
+            "top": 0.0,
+            "bottom": 5.0,
+            "blow_out": 19.0,
+            "drop_tip": 20.0,
+        },
+        shaft_ul_per_mm=5.0,
+        available_sensors=AvailableSensorDefinition(sensors=[]),
+    )
 
 
 @pytest.fixture
@@ -287,6 +331,7 @@ def test_get_pipette_location_override_current_location_y_center(
 
 @pytest.mark.parametrize("has_96_grid", [True, False])
 @pytest.mark.parametrize("has_12_grid", [True, False])
+@pytest.mark.parametrize("channels", [1, 8, 96])
 def test_get_pipette_offset_for_reservoirs(
     decoy: Decoy,
     labware_view: LabwareView,
@@ -296,11 +341,15 @@ def test_get_pipette_offset_for_reservoirs(
     subject: MotionView,
     has_96_grid: bool,
     has_12_grid: bool,
+    channels: int,
 ) -> None:
     """It should call get_waypoints() with the correct offset given the well's dimensions."""
     location = CurrentWell(pipette_id="123", labware_id="456", well_name="abc")
 
     decoy.when(pipette_view.get_current_location()).then_return(location)
+    decoy.when(pipette_view.get_config("pipette-id")).then_return(
+        _fake_static_pipette_config(channels)
+    )
 
     fake_x_dim, fake_y_dim, fake_z_dim = 7.0, 8.0, 9.0
     decoy.when(labware_view.get_well_size("labware-id", "well-name")).then_return(
@@ -346,11 +395,12 @@ def test_get_pipette_offset_for_reservoirs(
 
     x_offset = 0.0
     y_offset = 0.0
-    if has_12_grid:
+    if has_12_grid and channels != 96:
         x_offset = -1 * fake_x_dim / 24
-    elif has_96_grid:
+    elif has_96_grid and channels != 96:
         x_offset = -1 * fake_x_dim / 24
-        y_offset = fake_y_dim / 16
+        if channels == 1:
+            y_offset = fake_y_dim / 16
     reservoir_offset = Point(x=x_offset, y=y_offset)
     expected_destination = fake_well_position + reservoir_offset
 
@@ -424,6 +474,9 @@ def test_get_movement_waypoints_to_well_for_y_center(
 
     decoy.when(geometry_view.get_ancestor_slot_name("labware-id")).then_return(
         DeckSlotName.SLOT_2
+    )
+    decoy.when(pipette_view.get_config("pipette-id")).then_return(
+        _fake_static_pipette_config(1)
     )
 
     decoy.when(
@@ -505,6 +558,9 @@ def test_get_movement_waypoints_to_well_for_xy_center(
     decoy.when(
         geometry_view.get_min_travel_z("pipette-id", "labware-id", location, 123)
     ).then_return(42.0)
+    decoy.when(pipette_view.get_config("pipette-id")).then_return(
+        _fake_static_pipette_config(1)
+    )
 
     decoy.when(geometry_view.get_ancestor_slot_name("labware-id")).then_return(
         DeckSlotName.SLOT_2
@@ -571,6 +627,9 @@ def test_get_movement_waypoints_to_well_raises(
     decoy.when(
         geometry_view.get_min_travel_z("pipette-id", "labware-id", None, None)
     ).then_return(456)
+    decoy.when(pipette_view.get_config("pipette-id")).then_return(
+        _fake_static_pipette_config(1)
+    )
     decoy.when(
         # TODO(mm, 2022-06-22): We should use decoy.matchers.Anything() for all
         # arguments. For some reason, Decoy does not match the call unless we

--- a/api/tests/opentrons/protocol_engine/state/test_motion_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_motion_view.py
@@ -4,6 +4,7 @@ from typing import List
 
 import pytest
 from decoy import Decoy
+from unittest.mock import sentinel
 
 from opentrons_shared_data.pipette.types import PipetteNameType
 from opentrons.types import Point, MountType, DeckSlotName
@@ -282,6 +283,104 @@ def test_get_pipette_location_override_current_location_y_center(
         mount=MountType.RIGHT,
         critical_point=CriticalPoint.Y_CENTER,
     )
+
+
+@pytest.mark.parametrize("has_96_grid", [True, False])
+@pytest.mark.parametrize("has_12_grid", [True, False])
+def test_get_pipette_offset_for_reservoirs(
+    decoy: Decoy,
+    labware_view: LabwareView,
+    pipette_view: PipetteView,
+    geometry_view: GeometryView,
+    mock_module_view: ModuleView,
+    subject: MotionView,
+    has_96_grid: bool,
+    has_12_grid: bool,
+) -> None:
+    """It should call get_waypoints() with the correct offset given the well's dimensions."""
+    location = CurrentWell(pipette_id="123", labware_id="456", well_name="abc")
+
+    decoy.when(pipette_view.get_current_location()).then_return(location)
+
+    fake_x_dim, fake_y_dim, fake_z_dim = 7.0, 8.0, 9.0
+    decoy.when(labware_view.get_well_size("labware-id", "well-name")).then_return(
+        (fake_x_dim, fake_y_dim, fake_z_dim)
+    )
+    decoy.when(labware_view.get_has_96_subwells("labware-id")).then_return(has_96_grid)
+    decoy.when(labware_view.get_has_12_subwells("labware-id")).then_return(has_12_grid)
+
+    decoy.when(
+        labware_view.get_should_center_column_on_target_well(
+            "labware-id",
+        )
+    ).then_return(True)
+    decoy.when(
+        labware_view.get_should_center_pipette_on_target_well(
+            "labware-id",
+        )
+    ).then_return(False)
+
+    fake_well_position = Point(x=4, y=5, z=6)
+    decoy.when(
+        geometry_view.get_well_position(
+            "labware-id", "well-name", WellLocation(), None, "pipette-id"
+        )
+    ).then_return(fake_well_position)
+
+    decoy.when(
+        _move_types.get_move_type_to_well(
+            "pipette-id", "labware-id", "well-name", location, True
+        )
+    ).then_return(motion_planning.MoveType.GENERAL_ARC)
+    decoy.when(
+        geometry_view.get_min_travel_z("pipette-id", "labware-id", location, 123)
+    ).then_return(42.0)
+
+    decoy.when(geometry_view.get_ancestor_slot_name("labware-id")).then_return(
+        DeckSlotName.SLOT_2
+    )
+
+    decoy.when(
+        geometry_view.get_extra_waypoints(location, DeckSlotName.SLOT_2)
+    ).then_return([(456, 789)])
+
+    x_offset = 0.0
+    y_offset = 0.0
+    if has_12_grid:
+        x_offset = -1 * fake_x_dim / 24
+    elif has_96_grid:
+        x_offset = -1 * fake_x_dim / 24
+        y_offset = fake_y_dim / 16
+    reservoir_offset = Point(x=x_offset, y=y_offset)
+    expected_destination = fake_well_position + reservoir_offset
+
+    # make sure get_waypoints is called with expected_destination
+    decoy.when(
+        motion_planning.get_waypoints(
+            move_type=motion_planning.MoveType.GENERAL_ARC,
+            origin=Point(x=1, y=2, z=3),
+            origin_cp=CriticalPoint.MOUNT,
+            max_travel_z=1337,
+            min_travel_z=42,
+            dest=expected_destination,
+            dest_cp=CriticalPoint.Y_CENTER,
+            xy_waypoints=[(456, 789)],
+        )
+    ).then_return(sentinel.waypoints)
+
+    result = subject.get_movement_waypoints_to_well(
+        pipette_id="pipette-id",
+        labware_id="labware-id",
+        well_name="well-name",
+        well_location=WellLocation(),
+        origin=Point(x=1, y=2, z=3),
+        origin_cp=CriticalPoint.MOUNT,
+        max_travel_z=1337,
+        force_direct=True,
+        minimum_z_height=123,
+    )
+
+    assert result is sentinel.waypoints
 
 
 def test_get_movement_waypoints_to_well_for_y_center(

--- a/api/tests/opentrons/protocol_engine/state/test_motion_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_motion_view.py
@@ -438,6 +438,7 @@ def test_get_pipette_offset_for_reservoirs(
         max_travel_z=1337,
         force_direct=True,
         minimum_z_height=123,
+        offset_pipette_for_reservoir_subwells=True,
     )
 
     assert result is sentinel.waypoints

--- a/shared-data/js/__tests__/labwareDefSchemaV2.test.ts
+++ b/shared-data/js/__tests__/labwareDefSchemaV2.test.ts
@@ -209,13 +209,23 @@ const expectGroupsFollowConvention = (
 }
 
 const checkQuirkRequirements = (labwareDef: LabwareDefinition2): void => {
-  test("definitions cannot have both offsetPipetteFor96GridSubwells and offsetPipetteFor12GridSubwells", () => {
-    if (labwareDef.parameters.quirks === undefined) {return}
-    if (labwareDef.parameters.quirks.includes("offsetPipetteFor96GridSubwells")) {
-      expect(labwareDef.parameters.quirks.includes("offsetPipetteFor12GridSubwells")).toBe(false)
+  test('definitions cannot have both offsetPipetteFor96GridSubwells and offsetPipetteFor12GridSubwells', () => {
+    if (labwareDef.parameters.quirks === undefined) {
+      return
     }
-    if (labwareDef.parameters.quirks.includes("offsetPipetteFor12GridSubwells")) {
-      expect(labwareDef.parameters.quirks.includes("offsetPipetteFor96GridSubwells")).toBe(false)
+    if (
+      labwareDef.parameters.quirks.includes('offsetPipetteFor96GridSubwells')
+    ) {
+      expect(
+        labwareDef.parameters.quirks.includes('offsetPipetteFor12GridSubwells')
+      ).toBe(false)
+    }
+    if (
+      labwareDef.parameters.quirks.includes('offsetPipetteFor12GridSubwells')
+    ) {
+      expect(
+        labwareDef.parameters.quirks.includes('offsetPipetteFor96GridSubwells')
+      ).toBe(false)
     }
   })
 }

--- a/shared-data/js/__tests__/labwareDefSchemaV2.test.ts
+++ b/shared-data/js/__tests__/labwareDefSchemaV2.test.ts
@@ -208,6 +208,18 @@ const expectGroupsFollowConvention = (
   })
 }
 
+const checkQuirkRequirements = (labwareDef: LabwareDefinition2): void => {
+  test("definitions cannot have both offsetPipetteFor96GridSubwells and offsetPipetteFor12GridSubwells", () => {
+    if (labwareDef.parameters.quirks === undefined) {return}
+    if (labwareDef.parameters.quirks.includes("offsetPipetteFor96GridSubwells")) {
+      expect(labwareDef.parameters.quirks.includes("offsetPipetteFor12GridSubwells")).toBe(false)
+    }
+    if (labwareDef.parameters.quirks.includes("offsetPipetteFor12GridSubwells")) {
+      expect(labwareDef.parameters.quirks.includes("offsetPipetteFor96GridSubwells")).toBe(false)
+    }
+  })
+}
+
 const checkGeometryDefinitions = (labwareDef: LabwareDefinition2): void => {
   test('geometries referenced by wells must actually exist', () => {
     for (const geometryId of Object.values(labwareDef.wells).map(
@@ -438,6 +450,7 @@ describe('test schemas of all opentrons definitions', () => {
     })
 
     expectGroupsFollowConvention(labwareDef, labwarePath)
+    checkQuirkRequirements(labwareDef)
   })
 })
 
@@ -509,6 +522,7 @@ describe('test schemas of all v2 labware fixtures', () => {
 
     expectGroupsFollowConvention(labwareDef, filename)
     checkGeometryDefinitions(labwareDef)
+    checkQuirkRequirements(labwareDef)
   })
 })
 


### PR DESCRIPTION
## Overview
This is a follow-up to [this defunct pr](https://github.com/Opentrons/opentrons/pull/19155). This code seeks to solve the issue of `OverPressure` errors that happen at the bottom of reservoirs by repositioning the pipette tip, if necessary, into a reservoir's sub-wells. Except this time, we're doing that not by using the well's inner geometry, but rather by adding and handling a quirk specifying that it has either 96 sub-wells, or 12 sub-wells. Additionally, the handling for this is going to go in the `MoveToWell` logic, in `motion.py`

## Changelog

- add `offsetPipetteFor96GridSubwells`, `offsetPipetteFor12GridSubwells` quirks
- add logic in `motion.py` to find the proper destination offset

# Review Requests
Check on my pipette channel number logic please

# TODO

- Update the appropriate schema 2 labware definitions with the new quirk
- enable this at the user-level