### PR TITLE
refactor(api): use named constants for APIVersionError(until_version=...)

### DIFF
--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1856,7 +1856,7 @@ class InstrumentContext(publisher.CommandPublisher):
         ):
             raise APIVersionError(
                 api_element="tip_racks",
-                until_version="2.25",
+                until_version=f"{_LIQUID_CLASS_TRANSFER_TIP_RACKS_ARG_ADDED_IN}",
                 current_version=f"{self.api_version}",
             )
 
@@ -2001,7 +2001,7 @@ class InstrumentContext(publisher.CommandPublisher):
         ):
             raise APIVersionError(
                 api_element="tip_racks",
-                until_version="2.25",
+                until_version=f"{_LIQUID_CLASS_TRANSFER_TIP_RACKS_ARG_ADDED_IN}",
                 current_version=f"{self.api_version}",
             )
 
@@ -2155,7 +2155,7 @@ class InstrumentContext(publisher.CommandPublisher):
         ):
             raise APIVersionError(
                 api_element="tip_racks",
-                until_version="2.25",
+                until_version=f"{_LIQUID_CLASS_TRANSFER_TIP_RACKS_ARG_ADDED_IN}",
                 current_version=f"{self.api_version}",
             )
 
@@ -2999,10 +2999,8 @@ class InstrumentContext(publisher.CommandPublisher):
         ) and (style not in original_enabled_layouts):
             raise APIVersionError(
                 api_element=f"Nozzle layout configuration of style {style.value}",
-                until_version=str(
-                    _PARTIAL_NOZZLE_CONFIGURATION_SINGLE_ROW_PARTIAL_COLUMN_ADDED_IN
-                ),
-                current_version=str(self._api_version),
+                until_version=f"{_PARTIAL_NOZZLE_CONFIGURATION_SINGLE_ROW_PARTIAL_COLUMN_ADDED_IN}",
+                current_version=f"{self._api_version}",
             )
 
         front_right_resolved = front_right

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -509,7 +509,7 @@ class ProtocolContext(CommandPublisher):
             if self._api_version < validation.LID_STACK_VERSION_GATE:
                 raise APIVersionError(
                     api_element="Loading a Lid on a Labware",
-                    until_version="2.23",
+                    until_version=f"{validation.LID_STACK_VERSION_GATE}",
                     current_version=f"{self._api_version}",
                 )
             self._core.load_lid(
@@ -918,7 +918,7 @@ class ProtocolContext(CommandPublisher):
         ):
             raise APIVersionError(
                 api_element=f"Module of type {module_name}",
-                until_version=str(validation.FLEX_STACKER_VERSION_GATE),
+                until_version=f"{validation.FLEX_STACKER_VERSION_GATE}",
                 current_version=f"{self._api_version}",
             )
 
@@ -1350,8 +1350,8 @@ class ProtocolContext(CommandPublisher):
             if self._api_version < desc_and_display_color_omittable_since:
                 raise APIVersionError(
                     api_element="Calling `define_liquid()` without a `description`",
-                    current_version=str(self._api_version),
-                    until_version=str(desc_and_display_color_omittable_since),
+                    until_version=f"{desc_and_display_color_omittable_since}",
+                    current_version=f"{self._api_version}",
                     extra_message="Use a newer API version or explicitly supply `description=None`.",
                 )
             else:
@@ -1360,8 +1360,8 @@ class ProtocolContext(CommandPublisher):
             if self._api_version < desc_and_display_color_omittable_since:
                 raise APIVersionError(
                     api_element="Calling `define_liquid()` without a `display_color`",
-                    current_version=str(self._api_version),
-                    until_version=str(desc_and_display_color_omittable_since),
+                    until_version=f"{desc_and_display_color_omittable_since}",
+                    current_version=f"{self._api_version}",
                     extra_message="Use a newer API version or explicitly supply `display_color=None`.",
                 )
             else:
@@ -1498,7 +1498,7 @@ class ProtocolContext(CommandPublisher):
         if self._api_version < validation.LID_STACK_VERSION_GATE:
             raise APIVersionError(
                 api_element="Loading a Lid Stack",
-                until_version="2.23",
+                until_version=f"{validation.LID_STACK_VERSION_GATE}",
                 current_version=f"{self._api_version}",
             )
 


### PR DESCRIPTION
# Overview

I noticed that we defined a constant for `_LIQUID_CLASS_TRANSFER_TIP_RACKS_ARG_ADDED_IN = APIVersion(2, 25)`, but then in the code, we write the version number as a literal:
```
raise APIVersionError(
    api_element="tip_racks",
    until_version="2.25",
)
```

In this PR, if there is a named constant for the `until_version`, I changed the code to use that instead of a literal string.

We were also inconsistent in how we were stringifying the `APIVersion` constant. Most places used `f"{VERSION_CONSTANT}"`, but some places used `str(VERSION_CONSTANT)`. I changed them all to be consistent.

I also swapped the order of the `until_version` and `current_version` args in a few places to be consistent.

## Test Plan and Hands on Testing

Run CI tests.

## Risk assessment

Low. Pure code cleanup with no behavioral change.