### PR TITLE
fix(app): A few error recovery deck map rendering fixes

### DIFF
--- a/app/src/molecules/InterventionModal/DeckMapContent.tsx
+++ b/app/src/molecules/InterventionModal/DeckMapContent.tsx
@@ -12,6 +12,8 @@ import {
   useDeckLocationSelect,
 } from '@opentrons/components'
 import {
+  FLEX_STACKER_MODULE_TYPE,
+  getModuleType,
   getSchema2CornerOffsetFromSlot,
   getSchema2Dimensions,
 } from '@opentrons/shared-data'
@@ -76,13 +78,17 @@ function InterventionStyleDeckMapContent(
           }
         : labwareOnDeck
     ) ?? []
+  // we should not highlight labware that matches the flex stacker slot location
   const modulesWithHighlights =
     props.modulesOnDeck?.map(module =>
-      props.highlightLabwareEventuallyIn.reduce(
-        (found, locationToMatch) =>
-          found || getIsLabwareMatch(module.moduleLocation, locationToMatch),
-        false
-      )
+      props.highlightLabwareEventuallyIn.reduce((found, locationToMatch) => {
+        const moduleType = getModuleType(module.moduleModel)
+        return (
+          found ||
+          (moduleType !== FLEX_STACKER_MODULE_TYPE &&
+            getIsLabwareMatch(module.moduleLocation, locationToMatch))
+        )
+      }, false)
         ? {
             ...module,
             moduleChildren:

--- a/app/src/organisms/ErrorRecoveryFlows/shared/TwoColLwInfoAndDeck.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/TwoColLwInfoAndDeck.tsx
@@ -39,10 +39,7 @@ export function TwoColLwInfoAndDeck(
     MANUAL_FILL_AND_RETRY_NEW_TIPS,
   } = RECOVERY_MAP
   const { selectedRecoveryOption } = currentRecoveryOptionUtils
-  const {
-    relevantPickUpTipWellName,
-    relevantPickUpTipLabware,
-  } = failedLabwareUtils
+  const { relevantPickUpTipWellName } = failedLabwareUtils
   const { proceedNextStep, goBackPrevStep } = routeUpdateActions
   const { failedPipetteInfo, isPartialTipConfigValid } = failedPipetteUtils
   const { t } = useTranslation('error_recovery')
@@ -126,7 +123,7 @@ export function TwoColLwInfoAndDeck(
           ...restUtils
         } = deckMapUtils
 
-        const failedLwId = relevantPickUpTipLabware?.id ?? ''
+        const failedLwId = failedLabwareUtils.failedLabware?.id ?? ''
 
         const isValidDeck =
           currentLoc != null && newLoc != null && movedLabwareDef != null


### PR DESCRIPTION
Fix RQA-4575, RQA-4582
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This fixes an issue where a labware in the third column was causing a highlight of the stacker labware and one where the move labware animation appeared over another image of the labware
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
Tested this out! Both manual move and manual replace and retry are now working as expected
<img width="823" height="486" alt="Screenshot 2025-08-21 at 3 58 43 PM" src="https://github.com/user-attachments/assets/5c850130-f2c1-483b-af66-605e11ead4bb" />
https://github.com/user-attachments/assets/82a64e40-04c7-48d0-bef2-2b6998d6e970


<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
1. Exclude stacker modules from highlight matching where a `highlightLabwareEventuallyIn` location matches the stacker's module location
2. Change the filter to remove the failed labware from the animation deck map instead of the most recent tiprack used

<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests
Quick check
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
Low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
