### PR TITLE
Merge (fast-forward) 'chore_release-8.6.0' into 'chore_release-ll-3.5.0'

### DIFF
--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1856,7 +1856,7 @@ class InstrumentContext(publisher.CommandPublisher):
         ):
             raise APIVersionError(
                 api_element="tip_racks",
-                until_version="2.25",
+                until_version=f"{_LIQUID_CLASS_TRANSFER_TIP_RACKS_ARG_ADDED_IN}",
                 current_version=f"{self.api_version}",
             )
 
@@ -2001,7 +2001,7 @@ class InstrumentContext(publisher.CommandPublisher):
         ):
             raise APIVersionError(
                 api_element="tip_racks",
-                until_version="2.25",
+                until_version=f"{_LIQUID_CLASS_TRANSFER_TIP_RACKS_ARG_ADDED_IN}",
                 current_version=f"{self.api_version}",
             )
 
@@ -2155,7 +2155,7 @@ class InstrumentContext(publisher.CommandPublisher):
         ):
             raise APIVersionError(
                 api_element="tip_racks",
-                until_version="2.25",
+                until_version=f"{_LIQUID_CLASS_TRANSFER_TIP_RACKS_ARG_ADDED_IN}",
                 current_version=f"{self.api_version}",
             )
 
@@ -2999,10 +2999,8 @@ class InstrumentContext(publisher.CommandPublisher):
         ) and (style not in original_enabled_layouts):
             raise APIVersionError(
                 api_element=f"Nozzle layout configuration of style {style.value}",
-                until_version=str(
-                    _PARTIAL_NOZZLE_CONFIGURATION_SINGLE_ROW_PARTIAL_COLUMN_ADDED_IN
-                ),
-                current_version=str(self._api_version),
+                until_version=f"{_PARTIAL_NOZZLE_CONFIGURATION_SINGLE_ROW_PARTIAL_COLUMN_ADDED_IN}",
+                current_version=f"{self._api_version}",
             )
 
         front_right_resolved = front_right

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -509,7 +509,7 @@ class ProtocolContext(CommandPublisher):
             if self._api_version < validation.LID_STACK_VERSION_GATE:
                 raise APIVersionError(
                     api_element="Loading a Lid on a Labware",
-                    until_version="2.23",
+                    until_version=f"{validation.LID_STACK_VERSION_GATE}",
                     current_version=f"{self._api_version}",
                 )
             self._core.load_lid(
@@ -918,7 +918,7 @@ class ProtocolContext(CommandPublisher):
         ):
             raise APIVersionError(
                 api_element=f"Module of type {module_name}",
-                until_version=str(validation.FLEX_STACKER_VERSION_GATE),
+                until_version=f"{validation.FLEX_STACKER_VERSION_GATE}",
                 current_version=f"{self._api_version}",
             )
 
@@ -1350,8 +1350,8 @@ class ProtocolContext(CommandPublisher):
             if self._api_version < desc_and_display_color_omittable_since:
                 raise APIVersionError(
                     api_element="Calling `define_liquid()` without a `description`",
-                    current_version=str(self._api_version),
-                    until_version=str(desc_and_display_color_omittable_since),
+                    until_version=f"{desc_and_display_color_omittable_since}",
+                    current_version=f"{self._api_version}",
                     extra_message="Use a newer API version or explicitly supply `description=None`.",
                 )
             else:
@@ -1360,8 +1360,8 @@ class ProtocolContext(CommandPublisher):
             if self._api_version < desc_and_display_color_omittable_since:
                 raise APIVersionError(
                     api_element="Calling `define_liquid()` without a `display_color`",
-                    current_version=str(self._api_version),
-                    until_version=str(desc_and_display_color_omittable_since),
+                    until_version=f"{desc_and_display_color_omittable_since}",
+                    current_version=f"{self._api_version}",
                     extra_message="Use a newer API version or explicitly supply `display_color=None`.",
                 )
             else:
@@ -1498,7 +1498,7 @@ class ProtocolContext(CommandPublisher):
         if self._api_version < validation.LID_STACK_VERSION_GATE:
             raise APIVersionError(
                 api_element="Loading a Lid Stack",
-                until_version="2.23",
+                until_version=f"{validation.LID_STACK_VERSION_GATE}",
                 current_version=f"{self._api_version}",
             )
 

--- a/labware-library/index.html
+++ b/labware-library/index.html
@@ -1,10 +1,14 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name='viewport' content='width=device-width,initial-scale=1'>
+    <link rel="icon" href="./src/images/favicon.ico" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
 
-    <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,400i,600,600i,700,700i" rel="stylesheet">
+    <link
+      href="https://fonts.googleapis.com/css?family=Open+Sans:400,400i,600,600i,700,700i"
+      rel="stylesheet"
+    />
 
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Labware Library</title>


### PR DESCRIPTION
We want the favicon fix in LL 3.5.0.