### PR TITLE
fix(api): allow stacker and magblock to coexist

### DIFF
--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -1261,7 +1261,22 @@ class ModuleView:
             if existing_def.model == model or model in existing_def.compatibleWith:
                 return existing_mod_in_slot
 
-            else:
+            # FIXME(sfoster): This is a bad hack. This code should check that these can coexist
+            # through some data-driven means. Or this code should, in fact, not exist at all,
+            # since it's probably for setup commands that we don't use anymore, and doesn't
+            # check serial numbers and therefore would fail if there was mroe than one of
+            # a given module loaded across the deck and the one in this location was not the
+            # one that was being requested.
+            elif not (
+                (
+                    ModuleModel.is_flex_stacker(existing_def.model)
+                    and ModuleModel.is_magnetic_block(model)
+                )
+                or (
+                    ModuleModel.is_magnetic_block(existing_def.model)
+                    and ModuleModel.is_flex_stacker(model)
+                )
+            ):
                 _err = f" present in {location}"
                 raise errors.ModuleAlreadyPresentError(
                     f"A {existing_def.model.value} is already" + _err

--- a/api/tests/opentrons/protocol_engine/state/test_module_view_old.py
+++ b/api/tests/opentrons/protocol_engine/state/test_module_view_old.py
@@ -1043,6 +1043,31 @@ def test_select_hardware_module_to_load_rejects_location_reassignment(
         )
 
 
+def test_select_hardware_module_to_load_allows_stacker_magblock_coexistence(
+    flex_stacker_v1_def: ModuleDefinition,
+    mag_block_v1_def: ModuleDefinition,
+) -> None:
+    """It should allow a stacker to be loaded where a magblock is."""
+    subject = make_module_view(
+        slot_by_module_id={"module-1": DeckSlotName.SLOT_C3},
+        hardware_by_module_id={
+            "module-1": HardwareModule(definition=mag_block_v1_def, serial_number=None)
+        },
+    )
+    attached_modules = [
+        HardwareModule(serial_number="serial-1", definition=flex_stacker_v1_def),
+        HardwareModule(serial_number="serial-2", definition=flex_stacker_v1_def),
+    ]
+    assert subject.select_hardware_module_to_load(
+        model=ModuleModel.FLEX_STACKER_MODULE_V1,
+        location=deck_configuration_provider.get_cutout_id_by_deck_slot_name(
+            DeckSlotName.SLOT_C3
+        ),
+        attached_modules=attached_modules,
+        expected_serial_number="serial-2",
+    ) == HardwareModule(serial_number="serial-2", definition=flex_stacker_v1_def)
+
+
 class _CalculateMagnetHardwareHeightTestParams(NamedTuple):
     definition: ModuleDefinition
     mm_from_base: float


### PR DESCRIPTION
We fixed all the deck configuration stuff (probably) but it turns out that in the engine, when you load a module, some ancient code intended to allow setup commands to set engine state that protocol commands would later reuse was refusing to load a stacker when a magblock was already configured in that cutout (the reverse would not be true because the method that happens to do this isn't run for magblocks).

There are some good ways to fix this! I didn't do any of them. Instead I check for the exact pair, because release bugfix. We should fix this.

Closes RQA-4588

## testing
- [x] Run the protocol (have to run, won't happen in simulate)

```
from opentrons import protocol_api, types
from opentrons.protocol_api import Labware
from opentrons.protocol_api.module_contexts import (FlexStackerContext)


metadata = {
    "protocolName": "D4/C4 Units - Stacker Error Recovery",
    "author": "Sara Kowalski",
}

requirements = {
    "robotType": "Flex",
    "apiLevel": "2.25",
}
MAGNETIC_BLOCK_NAME = "magneticBlockV1"
FLEX_STACKER = "flexStackerModuleV1"


def run(ctx: protocol_api.ProtocolContext) -> None:
    waste_chute = ctx.load_waste_chute()

    magnetic_block = ctx.load_module(MAGNETIC_BLOCK_NAME, "C3") 

    stacker_50_C4 = ctx.load_module(FLEX_STACKER, "C4")
    stacker_50_C4.set_stored_labware("opentrons_flex_96_tiprack_1000ul", count=5, lid="opentrons_flex_tiprack_lid")

    stacker_50_D4 = ctx.load_module(FLEX_STACKER, "D4")
    stacker_50_D4.set_stored_labware("opentrons_flex_96_tiprack_1000ul", count=5, lid="opentrons_flex_tiprack_lid")
    tiprack_50_store = stacker_50_D4.load_labware('opentrons_flex_96_tiprack_1000ul', lid="opentrons_flex_tiprack_lid")

    tip_racks = []

    stacker_50_D4.store()
    stacker_50_D4.empty('empty stacker')
    stacker_50_D4.fill(5, 'add more tipracks')

    ctx.pause('Empty stacker D4, for empty stacker error')
    tip_rack_2 = stacker_50_D4.retrieve()
    ctx.move_labware(tip_rack_2, "A2", use_gripper=True)
    tip_racks.append(tip_rack_2)

    ctx.pause('Stacker latch jammed C4, place tape over the TOF sensor and make sure stacker is empty')
    tip_rack_3 = stacker_50_C4.retrieve()

    ctx.pause('stacker stall C4, fill the stacker with tipracks make sure tiprack is on the shuttle')
    tip_rack_4 = stacker_50_C4.store()

    stacker_50_D4.fill(1, 'add more tipracks')
    ctx.pause('Stacker shuttle missing D4, remove shuttle')
    tip_rack_5 = stacker_50_D4.retrieve()
    ctx.move_labware(tip_rack_5, protocol_api.OFF_DECK)
```