### PR TITLE
refactor(protocol-designer): assert when pipette.tiprackDefURI has no def

### DIFF
--- a/protocol-designer/src/step-forms/utils/index.ts
+++ b/protocol-designer/src/step-forms/utils/index.ts
@@ -140,7 +140,12 @@ export function denormalizePipetteEntities(
       const pipetteEntity: PipetteEntity = {
         ...pipette,
         spec,
-        tiprackLabwareDef: pipette.tiprackDefURI.map(def => labwareDefs[def]),
+        tiprackLabwareDef: pipette.tiprackDefURI.map(def => {
+          if (!labwareDefs[def]) {
+            throw new Error(`pipette.tiprackDefURI "${def}" not in labwareDefs`)
+          }
+          return labwareDefs[def]
+        }),
         pythonName: is96Channel
           ? 'pipette'
           : `pipette_${pipetteLocationUpdate[pipetteId]}`,


### PR DESCRIPTION
# Overview

There are several Sentry bugs that are caused by an undefined entry in the `PipetteEntity.tiprackLabwareDef[]` array, e.g.:
- https://opentrons-76.sentry.io/issues/6805346647
- https://opentrons-76.sentry.io/issues/6810229655

I'm not sure how `undefined` is getting added as an entry to the array, but we can try to catch it when it happens, in `denormalizePipetteEntities()`.

This PR makes `denormalizePipetteEntities()` raise an exception when it cannot populate `PipetteEntity.tiprackLabwareDef[]`, rather than waiting for PD to fail later when we don't have any information about which tiprack caused us to create an `undefined` entry.

## Test Plan and Hands on Testing

I smoked-tested this by running PD on a few protocols after this change, and didn't encounter any new crashes. Will run CI tests.

## Risk assessment

Low, just adding an assertion for a precondition that should be true anyway.