### PR TITLE
fix(docs): disambiguate thermal blocks headers

### DIFF
--- a/docs/flex/docs/glossary.md
+++ b/docs/flex/docs/glossary.md
@@ -282,7 +282,7 @@ Aluminum blocks that attach to the Heater-Shaker and hold labware. See the [Ther
 
 ##### Thermal block
 
-Aluminum blocks that attach to the Temperature Module and hold labware to facilitate heating, cooling, and maintaining temperature. See the [Thermal blocks section][thermal-blocks] in the Modules chapter.
+Aluminum blocks that attach to the Temperature Module and hold labware to facilitate heating, cooling, and maintaining temperature. See the [Thermal blocks section][thermal-blocks-flex] in the Modules chapter.
 
 ##### Thermocycler profile
 

--- a/docs/flex/docs/modules/temperature.md
+++ b/docs/flex/docs/modules/temperature.md
@@ -15,7 +15,7 @@ title: "Opentrons Flex: Temperature Module"
 
 The Opentrons Temperature Module GEN2 is a hot and cold plate module. It is often used in protocols that require heating, cooling, or temperature changes. The module can reach and maintain temperatures ranging from 4 °C to 95 °C within minutes, depending on the module's configuration and contents.
 
-### Thermal blocks
+### Thermal blocks { #thermal-blocks-flex }
 
 To hold labware at temperature, the module uses aluminum thermal blocks. The module comes with 24- well and 96-well thermal blocks. The Temperature Module caddy comes with a deep well block and a flat bottom block designed for use with the Flex Gripper. The blocks hold 1.5 mL and 2.0 mL tubes, 96-well PCR plates, PCR strips, deep well plates, and flat bottom plates.
 

--- a/docs/temperature-module/docs/specifications.md
+++ b/docs/temperature-module/docs/specifications.md
@@ -56,7 +56,7 @@ The Temperature Module is designed to achieve and maintain a target temperature 
 
 Additionally, Opentrons has tested the Temperature Module’s temperature profile with both the 24-well and 96-well thermal blocks. The module can generally reach its minimum temperature in 12 to 18 minutes, depending on the block and contents. The module can reach a hot temperature (65 °C) in six minutes. For more details, see the [Temperature Module White Paper](https://insights.opentrons.com/hubfs/Products/Modules/Temperature%20Module%20White%20Paper.pdf).
 
-## Thermal Blocks
+## Thermal Blocks { #thermal-blocks-temperature }
 
 The Temperature Module uses aluminum thermal blocks to hold labware at temperature. The module comes with a 24-well block, a 96-well PCR block, and a flat bottom block. The blocks hold 1.5 mL and 2.0 mL tubes, 96-well PCR plates, PCR strips, deep well plates, and flat bottom plates. You can also buy these aluminum blocks from the Opentrons shop.
 


### PR DESCRIPTION
# Overview

Disambiguate "Thermal Blocks" headers across Flex and Temperature Module manuals. Resolves a warning so docs can build again.

## Test Plan and Hands on Testing

Sandbox action completing

## Changelog

- Added header IDs
- Updated link target in Flex glossary

## Review requests

Nothing beyond CI

## Risk assessment

nil