### PR TITLE
fix(app): RQA-4559 Show topmost labware in stack on error recovery deck map

### DIFF
--- a/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useDeckMapUtils.test.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useDeckMapUtils.test.ts
@@ -5,6 +5,7 @@ import {
   fixture96Plate,
   getLoadedLabwareDefinitionsByUri,
   getModuleDef,
+  getModuleType,
   getPositionFromSlotId,
   TEMPERATURE_MODULE_V2,
 } from '@opentrons/shared-data'
@@ -22,7 +23,7 @@ import {
   updateLabwareInModules,
 } from '../useDeckMapUtils'
 
-import type { LabwareDefinition } from '@opentrons/shared-data'
+import type { LabwareDefinition, ModuleModel } from '@opentrons/shared-data'
 
 vi.mock('@opentrons/shared-data', async importOriginal => {
   const actual = await importOriginal<typeof getLoadedLabwareDefinitionsByUri>()
@@ -31,6 +32,7 @@ vi.mock('@opentrons/shared-data', async importOriginal => {
     getLoadedLabwareDefinitionsByUri: vi.fn(),
     getPositionFromSlotId: vi.fn(),
     getModuleDef: vi.fn(),
+    getModuleType: vi.fn(),
   }
 })
 vi.mock('@opentrons/components')
@@ -275,6 +277,7 @@ describe('getRunCurrentModulesInfo', () => {
     } as any)
     vi.mocked(getPositionFromSlotId).mockReturnValue('position' as any)
     vi.mocked(getModuleDef).mockReturnValue('MOCK_MODULE_DEF' as any)
+    vi.mocked(getModuleType).mockReturnValue('MOCK_MODULE_TYPE' as any)
   })
 
   it('should return an empty array if runRecord is null', () => {
@@ -391,6 +394,7 @@ describe('getRunCurrentLabwareInfo', () => {
       {
         labwareDef: mockLabwareDef,
         slotName: 'A1',
+        labwareId: 'MOCK_PickUpTipLabware_ID',
         labwareLocation: { slotName: 'A1' },
       },
     ])
@@ -408,7 +412,11 @@ describe('getSlotNameAndLwLocFrom', () => {
     expect(result).toEqual([null, null])
   })
 
-  it('should return [null, null] if location has a moduleId and excludeModules is true', () => {
+  it('should return [null, null] if location has a moduleId and moduleModel and excludeModules is true', () => {
+    vi.mocked(getLabwareLocation).mockReturnValue({
+      slotName: 'A1',
+      moduleModel: 'MOCK_MODULE_MODEL' as ModuleModel,
+    })
     const result = getSlotNameAndLwLocFrom(
       { moduleId: 'MOCK_MODULE_ID' },
       {} as any,

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useDeckMapUtils.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useDeckMapUtils.ts
@@ -285,8 +285,8 @@ export const getRunCurrentModulesInfo = ({
         const moduleType = getModuleType(moduleDef.model)
 
         // for stacker, we only want to consider labware in the hopper as "nested"
-        const nestedLabware = runRecord.data.labware.find(lw => {
-          return (
+        const nestedLabware = runRecord.data.labware.find(
+          lw =>
             typeof lw.location === 'object' &&
             'moduleId' in lw.location &&
             lw.location.moduleId === module.id &&
@@ -294,8 +294,7 @@ export const getRunCurrentModulesInfo = ({
               (FLEX_STACKER_MODULE_TYPE === moduleType &&
                 'kind' in lw.location &&
                 lw.location.kind === 'inStackerHopper'))
-          )
-        })
+        )
 
         const nestedLabwareDef =
           nestedLabware != null

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useDeckMapUtils.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useDeckMapUtils.ts
@@ -282,14 +282,20 @@ export const getRunCurrentModulesInfo = ({
     return runRecord.data.modules.reduce<RunCurrentModuleInfo[]>(
       (acc, module) => {
         const moduleDef = getModuleDef(module.model)
+        const moduleType = getModuleType(moduleDef.model)
 
-        // Get the labware that is placed on top of the module.
-        const nestedLabware = runRecord.data.labware.find(
-          lw =>
+        // for stacker, we only want to consider labware in the hopper as "nested"
+        const nestedLabware = runRecord.data.labware.find(lw => {
+          return (
             typeof lw.location === 'object' &&
             'moduleId' in lw.location &&
-            lw.location.moduleId === module.id
-        )
+            lw.location.moduleId === module.id &&
+            (!(FLEX_STACKER_MODULE_TYPE === moduleType) ||
+              (FLEX_STACKER_MODULE_TYPE === moduleType &&
+                'kind' in lw.location &&
+                lw.location.kind === 'inStackerHopper'))
+          )
+        })
 
         const nestedLabwareDef =
           nestedLabware != null
@@ -332,6 +338,7 @@ interface RunCurrentLabwareInfo {
   labwareDef: LabwareDefinition
   labwareLocation: LabwareLocation
   slotName: string
+  labwareId?: string
 }
 
 // Derive the labware info necessary to render labware on the deck.
@@ -364,6 +371,7 @@ export function getRunCurrentLabwareInfo({
               labwareDef,
               slotName,
               labwareLocation: labwareLocation,
+              labwareId: lw.id,
             },
           ]
         }
@@ -384,18 +392,23 @@ export function getRunCurrentLabwareInfo({
     }, {})
 
     // For each slot, return either:
-    // 1. The first labware with 'labwareId' in its location if it exists
-    // 2. The first labware in the slot if no labware has 'labwareId'
+    // 1. The first labware where no other labware has its 'labwareId' as a location
+    // 2. The first labware in the slot if no labware matches criteria 1
     return Object.values(labwareBySlot).map(slotLabware => {
-      const labwareWithId = slotLabware.find(
-        lw =>
-          typeof lw.labwareLocation !== 'string' &&
-          'labwareId' in lw.labwareLocation
-      )
-      return labwareWithId != null
+      const topMostLabware = slotLabware.find(lw => {
+        const labwareOnCurrentLabware = slotLabware.find(
+          otherLw =>
+            typeof otherLw.labwareLocation !== 'string' &&
+            'labwareId' in otherLw.labwareLocation &&
+            otherLw.labwareLocation.labwareId === lw.labwareId
+        )
+        return labwareOnCurrentLabware == null
+      })
+
+      return topMostLabware != null
         ? {
-            ...labwareWithId,
-            labwareLocation: { slotName: labwareWithId.slotName },
+            ...topMostLabware,
+            labwareLocation: { slotName: topMostLabware.slotName },
           }
         : slotLabware[0]
     })
@@ -419,15 +432,22 @@ export function getSlotNameAndLwLocFrom(
   runRecord: UseDeckMapUtilsProps['runRecord'],
   excludeModules: boolean
 ): [string | null, LabwareLocation | null] {
-  const baseSlot =
-    getLabwareLocation({
-      location,
-      detailLevel: 'slot-only',
-      loadedLabwares: runRecord?.data?.labware ?? [],
-      loadedModules: runRecord?.data?.modules ?? [],
-      robotType: FLEX_ROBOT_TYPE,
-    })?.slotName ?? null
+  const labwareLocationObject = getLabwareLocation({
+    location,
+    detailLevel: 'slot-only',
+    loadedLabwares: runRecord?.data?.labware ?? [],
+    loadedModules: runRecord?.data?.modules ?? [],
+    robotType: FLEX_ROBOT_TYPE,
+  })
+  const onModuleModel = labwareLocationObject?.moduleModel ?? null
 
+  // change base slot to just be the column for hopper labware, leave shuttle
+  // labware in the fourth row since we consolidate by slot name later
+  const baseSlot =
+    onModuleModel != null &&
+    getModuleType(onModuleModel) === FLEX_STACKER_MODULE_TYPE
+      ? labwareLocationObject?.slotName.charAt(0) ?? null
+      : labwareLocationObject?.slotName ?? null
   if (
     location == null ||
     location === 'offDeck' ||
@@ -435,7 +455,7 @@ export function getSlotNameAndLwLocFrom(
   ) {
     return [null, null]
   } else if ('moduleId' in location) {
-    if (excludeModules) {
+    if (excludeModules && onModuleModel != null) {
       return [null, null]
     } else {
       const moduleId = location.moduleId

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useDeckMapUtils.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useDeckMapUtils.ts
@@ -284,6 +284,7 @@ export const getRunCurrentModulesInfo = ({
         const moduleDef = getModuleDef(module.model)
         const moduleType = getModuleType(moduleDef.model)
 
+        // Get the labware that is placed on/in the module.
         // for stacker, we only want to consider labware in the hopper as "nested"
         const nestedLabware = runRecord.data.labware.find(
           lw =>
@@ -393,6 +394,7 @@ export function getRunCurrentLabwareInfo({
     // For each slot, return either:
     // 1. The first labware where no other labware has its 'labwareId' as a location
     // 2. The first labware in the slot if no labware matches criteria 1
+    // TODO: (sarah, 8-22-25) revisit this logic and reduce complexity when we have location sequences
     return Object.values(labwareBySlot).map(slotLabware => {
       const topMostLabware = slotLabware.find(lw => {
         const labwareOnCurrentLabware = slotLabware.find(

--- a/components/src/organisms/CommandText/useCommandTextString/utils/getLabwareLocation.tsx
+++ b/components/src/organisms/CommandText/useCommandTextString/utils/getLabwareLocation.tsx
@@ -210,7 +210,8 @@ export function getLabwareLocation(
     return {
       slotName,
       moduleModel:
-        getModuleType(moduleModel) === FLEX_STACKER_MODULE_TYPE
+        getModuleType(moduleModel) === FLEX_STACKER_MODULE_TYPE &&
+        !('kind' in location && location.kind === 'inStackerHopper')
           ? undefined
           : moduleModel,
     }


### PR DESCRIPTION
fix RQA-4559
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This PR fixes some logic in the labware rendering for the error recovery deck maps. Previously, the second stacked labware would be shown, which for lid stacks is the "lid stack object" which can't be rendered. Additionally, labware on the stacker wasn't being properly split between the stacker and the hopper. 

This fixes the open bug tickets but doesn't fix another issue I noticed where we seem to be rendering the first labware on a module instead of the top most labware. I'm going to look into this issue once I get a few higher priority tasks done as it hasn't ever been ticketed and for stacker hopper labware, all labware is the same so it doesn't really matter which we render.

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
Trigger error recovery for a protocol that has a lid stack on a deck riser and labware both in the stacker hopper and shuttle. It doesn't matter if it is any of these labware that are causing the error. Verify that the lid stack is now visible and the shuttle and hopper labware are properly separated:
<img width="814" height="462" alt="Screenshot 2025-08-21 at 8 35 31 PM" src="https://github.com/user-attachments/assets/8562c2b4-f6ab-4f04-8ac3-f536d4f00867" />


<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
All stacker labware, both in the hopper and on the shuttle has the stackers `moduleId` in it's location. This meant that for most of this logic, stacker and hopper labware were getting lumped together. I updated this to mirror what we do for protocol setup deck maps which is:
1. Consider `inHopperLocation` labware to be nested within the stacker module
2. Consider labware loaded onto the shuttle to be in slot `x4`

Change the logic for grabbing the labware to render from looking for any labware stacked on a labware, to looking for any labware that has nothing stacked on top of it

<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests
Review the logic, does it seem sound to you? 
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
Low-Med, these maps were wrong before so this is definitely an improvement
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
