### PR TITLE
feat(protocol-designer): report console.assert() failures to Sentry

### DIFF
--- a/protocol-designer/src/resources/sentry.ts
+++ b/protocol-designer/src/resources/sentry.ts
@@ -1,5 +1,6 @@
 import {
   browserTracingIntegration,
+  captureConsoleIntegration,
   init,
   replayIntegration,
 } from '@sentry/react'
@@ -33,7 +34,11 @@ export const initializeSentry = (state: BaseState): void => {
     try {
       init({
         dsn: sentryDsn,
-        integrations: [replayIntegration(), browserTracingIntegration()],
+        integrations: [
+          captureConsoleIntegration({ levels: ['assert'] }),
+          replayIntegration(),
+          browserTracingIntegration(),
+        ],
         tracesSampleRate: 1.0,
         tracePropagationTargets: [
           'localhost',


### PR DESCRIPTION
# Overview

In JavaScript, `console.assert()` logs an error to the console if the assertion is violated, but it doesn't raise an exception (like assertions in other programming languages do).

This change will send any `assert()` failures to Sentry as well.

I'm hoping that this will help us diagnose some tricky bugs where we can't figure out what's going on.

## Test Plan and Hands on Testing

I smoke-tested with running PD locally after this change. Will also run the CI tests.

Note that it's hard to see the effects of a Sentry config change until we deploy it though.

## Risk assessment

Low. Would not affect PD functionality. But this might make our Sentry dashboard very noisy if there are a lot of `assert()` failures (which we wouldn't have known about before).