### PR TITLE
fix(app): slow response in deck config when adding/removing fixtures

### DIFF
--- a/app/src/organisms/DeviceDetailsDeckConfiguration/AddFixtureModal.tsx
+++ b/app/src/organisms/DeviceDetailsDeckConfiguration/AddFixtureModal.tsx
@@ -163,7 +163,7 @@ export function AddFixtureModal({
           <ODDFixtureOption
             key="fixturesOption"
             optionName="Fixtures"
-            buttonText={t('add')}
+            buttonText={t('select_options')}
             onClickHandler={() => {
               setOptionStage('fixtureOptions')
             }}
@@ -172,7 +172,7 @@ export function AddFixtureModal({
         <ODDFixtureOption
           key="modulesOption"
           optionName="Modules"
-          buttonText={t('add')}
+          buttonText={t('select_options')}
           onClickHandler={() => {
             setOptionStage('moduleOptions')
           }}

--- a/app/src/organisms/DeviceDetailsDeckConfiguration/index.tsx
+++ b/app/src/organisms/DeviceDetailsDeckConfiguration/index.tsx
@@ -74,10 +74,8 @@ export function DeviceDetailsDeckConfiguration({
       refetchInterval: DECK_CONFIG_REFETCH_INTERVAL,
     }).data ?? []
 
-  const deckConfigWithAA = useMemo(() =>
-    replaceFixtureToFakeFixtureAndTransformCutoutFixturesToAA(
-      deckConfig
-    ),
+  const deckConfigWithAA = useMemo(
+    () => replaceFixtureToFakeFixtureAndTransformCutoutFixturesToAA(deckConfig),
     [deckConfig]
   )
   const deckDef = getDeckDefFromRobotType(FLEX_ROBOT_TYPE)

--- a/app/src/organisms/DeviceDetailsDeckConfiguration/index.tsx
+++ b/app/src/organisms/DeviceDetailsDeckConfiguration/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { css } from 'styled-components'
 
@@ -74,8 +74,11 @@ export function DeviceDetailsDeckConfiguration({
       refetchInterval: DECK_CONFIG_REFETCH_INTERVAL,
     }).data ?? []
 
-  const deckConfigWithAA = replaceFixtureToFakeFixtureAndTransformCutoutFixturesToAA(
-    deckConfig
+  const deckConfigWithAA = useMemo(() =>
+    replaceFixtureToFakeFixtureAndTransformCutoutFixturesToAA(
+      deckConfig
+    ),
+    [deckConfig]
   )
   const deckDef = getDeckDefFromRobotType(FLEX_ROBOT_TYPE)
   const { isRunRunning } = useRunStatuses()

--- a/components/src/hardware-sim/DeckConfigurator/index.tsx
+++ b/components/src/hardware-sim/DeckConfigurator/index.tsx
@@ -22,7 +22,7 @@ import { ThermocyclerItem } from './ThermocyclerItem'
 import { TrashBinConfigItem } from './TrashBinConfigItem'
 import { WasteChuteConfigFixture } from './WasteChuteConfigItem'
 
-import type { ReactNode } from 'react'
+import { useMemo, type ReactNode } from 'react'
 import type {
   AddressableAreaNamesWithFakes,
   CutoutFixtureIdsWithFakes,
@@ -69,10 +69,13 @@ export function DeckConfigurator(props: DeckConfiguratorProps): JSX.Element {
     moduleModel,
   } = props
 
+  
   const deckDef = getDeckDefFromRobotType(FLEX_ROBOT_TYPE)
 
-  const deckConfigWithAA = replaceFixtureToFakeFixtureAndTransformCutoutFixturesToAA(
-    deckConfig
+  const deckConfigWithAA = useMemo(() =>
+    replaceFixtureToFakeFixtureAndTransformCutoutFixturesToAA(
+      deckConfig),
+    [deckConfig]
   )
 
   const stagingAreaItems = filterAAByAreaType(

--- a/components/src/hardware-sim/DeckConfigurator/index.tsx
+++ b/components/src/hardware-sim/DeckConfigurator/index.tsx
@@ -1,3 +1,5 @@
+import { useMemo } from 'react'
+
 import {
   filterAAByAreaType,
   FLEX_ROBOT_TYPE,
@@ -22,7 +24,7 @@ import { ThermocyclerItem } from './ThermocyclerItem'
 import { TrashBinConfigItem } from './TrashBinConfigItem'
 import { WasteChuteConfigFixture } from './WasteChuteConfigItem'
 
-import { useMemo, type ReactNode } from 'react'
+import type { ReactNode } from 'react'
 import type {
   AddressableAreaNamesWithFakes,
   CutoutFixtureIdsWithFakes,
@@ -69,12 +71,10 @@ export function DeckConfigurator(props: DeckConfiguratorProps): JSX.Element {
     moduleModel,
   } = props
 
-  
   const deckDef = getDeckDefFromRobotType(FLEX_ROBOT_TYPE)
 
-  const deckConfigWithAA = useMemo(() =>
-    replaceFixtureToFakeFixtureAndTransformCutoutFixturesToAA(
-      deckConfig),
+  const deckConfigWithAA = useMemo(
+    () => replaceFixtureToFakeFixtureAndTransformCutoutFixturesToAA(deckConfig),
     [deckConfig]
   )
 


### PR DESCRIPTION
# Overview

closes https://opentrons.atlassian.net/browse/RQA-4563, https://opentrons.atlassian.net/browse/RQA-4377
memo deckConfigWithAA and change CTA to match designs 

<img width="430" height="301" alt="Screenshot 2025-08-22 at 12 07 49 PM" src="https://github.com/user-attachments/assets/6d040edd-58e8-4dff-ba32-154659b5cfea" />
<img width="739" height="406" alt="Screenshot 2025-08-22 at 12 20 26 PM" src="https://github.com/user-attachments/assets/c236082b-1180-4f1a-9fbe-944a68fbd78c" />
<img width="733" height="317" alt="Screenshot 2025-08-22 at 12 20 34 PM" src="https://github.com/user-attachments/assets/b54b8bcd-93c7-4b37-a231-cb8fc202926f" />
<img width="728" height="586" alt="Screenshot 2025-08-22 at 12 20 43 PM" src="https://github.com/user-attachments/assets/8dd80e59-c001-45a9-95a5-0eaa27f48f06" />


## Test Plan and Hands on Testing

in tickets 

## Changelog

- memo deckConfigWithAA calculations. 
- fix CTA to select options

## Risk assessment

low.
