### PR TITLE
fix(app): change stacker shuttle not empty copy to full.

### DIFF
--- a/app/src/assets/localization/en/error_recovery.json
+++ b/app/src/assets/localization/en/error_recovery.json
@@ -143,7 +143,7 @@
   "stacker_latch_jammed_errors_occur_when": "Stacker latch jammed errors occur when labware gets stuck in between the stacker latch. This is usually caused by improperly placed labware or inaccurate labware definitions",
   "stacker_latch_will_reengage": "The stacker latch will re-engage so that you can reload the stacker. Make sure that any obstructions have been cleared.",
   "stacker_shuttle_missing_error_occurs_when": "Stacker shuttle missing errors occur when the shuttle is not placed correctly on the track. Load the stacker shuttle onto the track to proceed.",
-  "stacker_shuttle_not_empty": "Stacker Shuttle Not Empty",
+  "stacker_shuttle_full": "Stacker shuttle full",
   "stacker_stall_or_collision_error": "Stacker stalled",
   "stall_or_collision_detected_when": "A stall or collision is detected when the robot's motors are blocked",
   "stall_or_collision_error": "Stall or collision",

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useErrorName.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useErrorName.ts
@@ -34,7 +34,7 @@ export function useErrorName(errorKind: ErrorKind): string {
     case ERROR_KINDS.STACKER_SHUTTLE_EMPTY:
       return t('labware_not_retrieved')
     case ERROR_KINDS.STACKER_SHUTTLE_OCCUPIED:
-      return t('stacker_shuttle_not_empty')
+      return t('stacker_shuttle_full')
     case ERROR_KINDS.STACKER_HOPPER_OR_SHUTTLE_EMPTY:
       return t('stacker_error')
     default:


### PR DESCRIPTION
# Overview

Copy change for shuttle not empty error to "Stacker shuttle full"

Closes: [RQA-4528](https://opentrons.atlassian.net/browse/RQA-4528)

## Test Plan and Hands on Testing
## Changelog
## Review requests
## Risk assessment

[RQA-4528]: https://opentrons.atlassian.net/browse/RQA-4528?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ