### PR TITLE
feat(api): Ensure Labware Schema 2 and 3 cross-compatibility

### DIFF
--- a/api/integration_testing/labware_stackup/stackup_coordinates_snapshot.json
+++ b/api/integration_testing/labware_stackup/stackup_coordinates_snapshot.json
@@ -1556,6 +1556,25 @@
       "robot_type": "Flex"
     }
   },
+  "Flex,None,opentrons_96_pcr_adapter,schema3test_96_wellplate_200ul_pcr_full_skirt": {
+    "coordinates": [
+      342.38,
+      74.24,
+      18.9
+    ],
+    "spec": {
+      "adapter_load_info": [
+        "opentrons_96_pcr_adapter",
+        1
+      ],
+      "labware_load_info": [
+        "schema3test_96_wellplate_200ul_pcr_full_skirt",
+        999
+      ],
+      "module_load_name": null,
+      "robot_type": "Flex"
+    }
+  },
   "Flex,None,opentrons_96_well_aluminum_block,armadillo_96_wellplate_200ul_pcr_full_skirt": {
     "coordinates": [
       342.38,
@@ -1627,6 +1646,25 @@
       "labware_load_info": [
         "opentrons_96_wellplate_200ul_pcr_full_skirt",
         3
+      ],
+      "module_load_name": null,
+      "robot_type": "Flex"
+    }
+  },
+  "Flex,None,opentrons_96_well_aluminum_block,schema3test_96_wellplate_200ul_pcr_full_skirt": {
+    "coordinates": [
+      342.38,
+      74.24,
+      22.25
+    ],
+    "spec": {
+      "adapter_load_info": [
+        "opentrons_96_well_aluminum_block",
+        1
+      ],
+      "labware_load_info": [
+        "schema3test_96_wellplate_200ul_pcr_full_skirt",
+        999
       ],
       "module_load_name": null,
       "robot_type": "Flex"
@@ -3703,6 +3741,25 @@
       "robot_type": "Flex"
     }
   },
+  "Flex,flexStackerModuleV1,opentrons_96_pcr_adapter,schema3test_96_wellplate_200ul_pcr_full_skirt": {
+    "coordinates": [
+      503.38,
+      74.24,
+      49.9
+    ],
+    "spec": {
+      "adapter_load_info": [
+        "opentrons_96_pcr_adapter",
+        1
+      ],
+      "labware_load_info": [
+        "schema3test_96_wellplate_200ul_pcr_full_skirt",
+        999
+      ],
+      "module_load_name": "flexStackerModuleV1",
+      "robot_type": "Flex"
+    }
+  },
   "Flex,flexStackerModuleV1,opentrons_96_well_aluminum_block,armadillo_96_wellplate_200ul_pcr_full_skirt": {
     "coordinates": [
       503.38,
@@ -3774,6 +3831,25 @@
       "labware_load_info": [
         "opentrons_96_wellplate_200ul_pcr_full_skirt",
         3
+      ],
+      "module_load_name": "flexStackerModuleV1",
+      "robot_type": "Flex"
+    }
+  },
+  "Flex,flexStackerModuleV1,opentrons_96_well_aluminum_block,schema3test_96_wellplate_200ul_pcr_full_skirt": {
+    "coordinates": [
+      503.38,
+      74.24,
+      53.25
+    ],
+    "spec": {
+      "adapter_load_info": [
+        "opentrons_96_well_aluminum_block",
+        1
+      ],
+      "labware_load_info": [
+        "schema3test_96_wellplate_200ul_pcr_full_skirt",
+        999
       ],
       "module_load_name": "flexStackerModuleV1",
       "robot_type": "Flex"
@@ -5754,6 +5830,25 @@
       "robot_type": "Flex"
     }
   },
+  "Flex,heaterShakerModuleV1,opentrons_96_pcr_adapter,schema3test_96_wellplate_200ul_pcr_full_skirt": {
+    "coordinates": [
+      342.38,
+      74.24,
+      37.85
+    ],
+    "spec": {
+      "adapter_load_info": [
+        "opentrons_96_pcr_adapter",
+        1
+      ],
+      "labware_load_info": [
+        "schema3test_96_wellplate_200ul_pcr_full_skirt",
+        999
+      ],
+      "module_load_name": "heaterShakerModuleV1",
+      "robot_type": "Flex"
+    }
+  },
   "Flex,heaterShakerModuleV1,opentrons_96_well_aluminum_block,armadillo_96_wellplate_200ul_pcr_full_skirt": {
     "coordinates": [
       342.38,
@@ -5825,6 +5920,25 @@
       "labware_load_info": [
         "opentrons_96_wellplate_200ul_pcr_full_skirt",
         3
+      ],
+      "module_load_name": "heaterShakerModuleV1",
+      "robot_type": "Flex"
+    }
+  },
+  "Flex,heaterShakerModuleV1,opentrons_96_well_aluminum_block,schema3test_96_wellplate_200ul_pcr_full_skirt": {
+    "coordinates": [
+      342.38,
+      74.24,
+      41.2
+    ],
+    "spec": {
+      "adapter_load_info": [
+        "opentrons_96_well_aluminum_block",
+        1
+      ],
+      "labware_load_info": [
+        "schema3test_96_wellplate_200ul_pcr_full_skirt",
+        999
       ],
       "module_load_name": "heaterShakerModuleV1",
       "robot_type": "Flex"
@@ -7805,6 +7919,25 @@
       "robot_type": "Flex"
     }
   },
+  "Flex,magneticBlockV1,opentrons_96_pcr_adapter,schema3test_96_wellplate_200ul_pcr_full_skirt": {
+    "coordinates": [
+      342.38,
+      74.24,
+      56.9
+    ],
+    "spec": {
+      "adapter_load_info": [
+        "opentrons_96_pcr_adapter",
+        1
+      ],
+      "labware_load_info": [
+        "schema3test_96_wellplate_200ul_pcr_full_skirt",
+        999
+      ],
+      "module_load_name": "magneticBlockV1",
+      "robot_type": "Flex"
+    }
+  },
   "Flex,magneticBlockV1,opentrons_96_well_aluminum_block,armadillo_96_wellplate_200ul_pcr_full_skirt": {
     "coordinates": [
       342.38,
@@ -7876,6 +8009,25 @@
       "labware_load_info": [
         "opentrons_96_wellplate_200ul_pcr_full_skirt",
         3
+      ],
+      "module_load_name": "magneticBlockV1",
+      "robot_type": "Flex"
+    }
+  },
+  "Flex,magneticBlockV1,opentrons_96_well_aluminum_block,schema3test_96_wellplate_200ul_pcr_full_skirt": {
+    "coordinates": [
+      342.38,
+      74.24,
+      60.25
+    ],
+    "spec": {
+      "adapter_load_info": [
+        "opentrons_96_well_aluminum_block",
+        1
+      ],
+      "labware_load_info": [
+        "schema3test_96_wellplate_200ul_pcr_full_skirt",
+        999
       ],
       "module_load_name": "magneticBlockV1",
       "robot_type": "Flex"
@@ -9856,6 +10008,25 @@
       "robot_type": "Flex"
     }
   },
+  "Flex,temperatureModuleV2,opentrons_96_pcr_adapter,schema3test_96_wellplate_200ul_pcr_full_skirt": {
+    "coordinates": [
+      342.38,
+      74.24,
+      27.9
+    ],
+    "spec": {
+      "adapter_load_info": [
+        "opentrons_96_pcr_adapter",
+        1
+      ],
+      "labware_load_info": [
+        "schema3test_96_wellplate_200ul_pcr_full_skirt",
+        999
+      ],
+      "module_load_name": "temperatureModuleV2",
+      "robot_type": "Flex"
+    }
+  },
   "Flex,temperatureModuleV2,opentrons_96_well_aluminum_block,armadillo_96_wellplate_200ul_pcr_full_skirt": {
     "coordinates": [
       342.38,
@@ -9927,6 +10098,25 @@
       "labware_load_info": [
         "opentrons_96_wellplate_200ul_pcr_full_skirt",
         3
+      ],
+      "module_load_name": "temperatureModuleV2",
+      "robot_type": "Flex"
+    }
+  },
+  "Flex,temperatureModuleV2,opentrons_96_well_aluminum_block,schema3test_96_wellplate_200ul_pcr_full_skirt": {
+    "coordinates": [
+      342.38,
+      74.24,
+      31.25
+    ],
+    "spec": {
+      "adapter_load_info": [
+        "opentrons_96_well_aluminum_block",
+        1
+      ],
+      "labware_load_info": [
+        "schema3test_96_wellplate_200ul_pcr_full_skirt",
+        999
       ],
       "module_load_name": "temperatureModuleV2",
       "robot_type": "Flex"
@@ -11907,6 +12097,25 @@
       "robot_type": "Flex"
     }
   },
+  "Flex,thermocyclerModuleV2,opentrons_96_pcr_adapter,schema3test_96_wellplate_200ul_pcr_full_skirt": {
+    "coordinates": [
+      -5.625,
+      356.2,
+      29.86
+    ],
+    "spec": {
+      "adapter_load_info": [
+        "opentrons_96_pcr_adapter",
+        1
+      ],
+      "labware_load_info": [
+        "schema3test_96_wellplate_200ul_pcr_full_skirt",
+        999
+      ],
+      "module_load_name": "thermocyclerModuleV2",
+      "robot_type": "Flex"
+    }
+  },
   "Flex,thermocyclerModuleV2,opentrons_96_well_aluminum_block,armadillo_96_wellplate_200ul_pcr_full_skirt": {
     "coordinates": [
       -5.625,
@@ -11978,6 +12187,25 @@
       "labware_load_info": [
         "opentrons_96_wellplate_200ul_pcr_full_skirt",
         3
+      ],
+      "module_load_name": "thermocyclerModuleV2",
+      "robot_type": "Flex"
+    }
+  },
+  "Flex,thermocyclerModuleV2,opentrons_96_well_aluminum_block,schema3test_96_wellplate_200ul_pcr_full_skirt": {
+    "coordinates": [
+      -5.625,
+      356.2,
+      33.21
+    ],
+    "spec": {
+      "adapter_load_info": [
+        "opentrons_96_well_aluminum_block",
+        1
+      ],
+      "labware_load_info": [
+        "schema3test_96_wellplate_200ul_pcr_full_skirt",
+        999
       ],
       "module_load_name": "thermocyclerModuleV2",
       "robot_type": "Flex"
@@ -13901,6 +14129,25 @@
       "robot_type": "OT-2"
     }
   },
+  "OT-2,None,opentrons_96_well_aluminum_block,schema3test_96_wellplate_200ul_pcr_full_skirt": {
+    "coordinates": [
+      279.38,
+      74.24,
+      22.25
+    ],
+    "spec": {
+      "adapter_load_info": [
+        "opentrons_96_well_aluminum_block",
+        1
+      ],
+      "labware_load_info": [
+        "schema3test_96_wellplate_200ul_pcr_full_skirt",
+        999
+      ],
+      "module_load_name": null,
+      "robot_type": "OT-2"
+    }
+  },
   "OT-2,heaterShakerModuleV1,None,agilent_1_reservoir_290ml": {
     "coordinates": [
       329.005,
@@ -15396,6 +15643,25 @@
       "labware_load_info": [
         "opentrons_96_wellplate_200ul_pcr_full_skirt",
         3
+      ],
+      "module_load_name": "heaterShakerModuleV1",
+      "robot_type": "OT-2"
+    }
+  },
+  "OT-2,heaterShakerModuleV1,opentrons_96_well_aluminum_block,schema3test_96_wellplate_200ul_pcr_full_skirt": {
+    "coordinates": [
+      279.505,
+      73.115,
+      90.525
+    ],
+    "spec": {
+      "adapter_load_info": [
+        "opentrons_96_well_aluminum_block",
+        1
+      ],
+      "labware_load_info": [
+        "schema3test_96_wellplate_200ul_pcr_full_skirt",
+        999
       ],
       "module_load_name": "heaterShakerModuleV1",
       "robot_type": "OT-2"

--- a/api/integration_testing/labware_stackup/stackup_coordinates_snapshot.json
+++ b/api/integration_testing/labware_stackup/stackup_coordinates_snapshot.json
@@ -1556,25 +1556,6 @@
       "robot_type": "Flex"
     }
   },
-  "Flex,None,opentrons_96_pcr_adapter,schema3test_96_wellplate_200ul_pcr_full_skirt": {
-    "coordinates": [
-      342.38,
-      74.24,
-      18.9
-    ],
-    "spec": {
-      "adapter_load_info": [
-        "opentrons_96_pcr_adapter",
-        1
-      ],
-      "labware_load_info": [
-        "schema3test_96_wellplate_200ul_pcr_full_skirt",
-        999
-      ],
-      "module_load_name": null,
-      "robot_type": "Flex"
-    }
-  },
   "Flex,None,opentrons_96_well_aluminum_block,armadillo_96_wellplate_200ul_pcr_full_skirt": {
     "coordinates": [
       342.38,
@@ -1646,25 +1627,6 @@
       "labware_load_info": [
         "opentrons_96_wellplate_200ul_pcr_full_skirt",
         3
-      ],
-      "module_load_name": null,
-      "robot_type": "Flex"
-    }
-  },
-  "Flex,None,opentrons_96_well_aluminum_block,schema3test_96_wellplate_200ul_pcr_full_skirt": {
-    "coordinates": [
-      342.38,
-      74.24,
-      22.25
-    ],
-    "spec": {
-      "adapter_load_info": [
-        "opentrons_96_well_aluminum_block",
-        1
-      ],
-      "labware_load_info": [
-        "schema3test_96_wellplate_200ul_pcr_full_skirt",
-        999
       ],
       "module_load_name": null,
       "robot_type": "Flex"
@@ -1988,25 +1950,6 @@
       "labware_load_info": [
         "corning_96_wellplate_360ul_flat",
         3
-      ],
-      "module_load_name": null,
-      "robot_type": "Flex"
-    }
-  },
-  "Flex,None,schema3test_96_well_aluminum_block,schema3test_96_wellplate_200ul_pcr_full_skirt": {
-    "coordinates": [
-      342.38,
-      74.76,
-      22.25
-    ],
-    "spec": {
-      "adapter_load_info": [
-        "schema3test_96_well_aluminum_block",
-        999
-      ],
-      "labware_load_info": [
-        "schema3test_96_wellplate_200ul_pcr_full_skirt",
-        999
       ],
       "module_load_name": null,
       "robot_type": "Flex"
@@ -3741,25 +3684,6 @@
       "robot_type": "Flex"
     }
   },
-  "Flex,flexStackerModuleV1,opentrons_96_pcr_adapter,schema3test_96_wellplate_200ul_pcr_full_skirt": {
-    "coordinates": [
-      503.38,
-      74.24,
-      49.9
-    ],
-    "spec": {
-      "adapter_load_info": [
-        "opentrons_96_pcr_adapter",
-        1
-      ],
-      "labware_load_info": [
-        "schema3test_96_wellplate_200ul_pcr_full_skirt",
-        999
-      ],
-      "module_load_name": "flexStackerModuleV1",
-      "robot_type": "Flex"
-    }
-  },
   "Flex,flexStackerModuleV1,opentrons_96_well_aluminum_block,armadillo_96_wellplate_200ul_pcr_full_skirt": {
     "coordinates": [
       503.38,
@@ -3831,25 +3755,6 @@
       "labware_load_info": [
         "opentrons_96_wellplate_200ul_pcr_full_skirt",
         3
-      ],
-      "module_load_name": "flexStackerModuleV1",
-      "robot_type": "Flex"
-    }
-  },
-  "Flex,flexStackerModuleV1,opentrons_96_well_aluminum_block,schema3test_96_wellplate_200ul_pcr_full_skirt": {
-    "coordinates": [
-      503.38,
-      74.24,
-      53.25
-    ],
-    "spec": {
-      "adapter_load_info": [
-        "opentrons_96_well_aluminum_block",
-        1
-      ],
-      "labware_load_info": [
-        "schema3test_96_wellplate_200ul_pcr_full_skirt",
-        999
       ],
       "module_load_name": "flexStackerModuleV1",
       "robot_type": "Flex"
@@ -4173,25 +4078,6 @@
       "labware_load_info": [
         "corning_96_wellplate_360ul_flat",
         3
-      ],
-      "module_load_name": "flexStackerModuleV1",
-      "robot_type": "Flex"
-    }
-  },
-  "Flex,flexStackerModuleV1,schema3test_96_well_aluminum_block,schema3test_96_wellplate_200ul_pcr_full_skirt": {
-    "coordinates": [
-      503.5,
-      74.5,
-      53.25
-    ],
-    "spec": {
-      "adapter_load_info": [
-        "schema3test_96_well_aluminum_block",
-        999
-      ],
-      "labware_load_info": [
-        "schema3test_96_wellplate_200ul_pcr_full_skirt",
-        999
       ],
       "module_load_name": "flexStackerModuleV1",
       "robot_type": "Flex"
@@ -5830,25 +5716,6 @@
       "robot_type": "Flex"
     }
   },
-  "Flex,heaterShakerModuleV1,opentrons_96_pcr_adapter,schema3test_96_wellplate_200ul_pcr_full_skirt": {
-    "coordinates": [
-      342.38,
-      74.24,
-      37.85
-    ],
-    "spec": {
-      "adapter_load_info": [
-        "opentrons_96_pcr_adapter",
-        1
-      ],
-      "labware_load_info": [
-        "schema3test_96_wellplate_200ul_pcr_full_skirt",
-        999
-      ],
-      "module_load_name": "heaterShakerModuleV1",
-      "robot_type": "Flex"
-    }
-  },
   "Flex,heaterShakerModuleV1,opentrons_96_well_aluminum_block,armadillo_96_wellplate_200ul_pcr_full_skirt": {
     "coordinates": [
       342.38,
@@ -5920,25 +5787,6 @@
       "labware_load_info": [
         "opentrons_96_wellplate_200ul_pcr_full_skirt",
         3
-      ],
-      "module_load_name": "heaterShakerModuleV1",
-      "robot_type": "Flex"
-    }
-  },
-  "Flex,heaterShakerModuleV1,opentrons_96_well_aluminum_block,schema3test_96_wellplate_200ul_pcr_full_skirt": {
-    "coordinates": [
-      342.38,
-      74.24,
-      41.2
-    ],
-    "spec": {
-      "adapter_load_info": [
-        "opentrons_96_well_aluminum_block",
-        1
-      ],
-      "labware_load_info": [
-        "schema3test_96_wellplate_200ul_pcr_full_skirt",
-        999
       ],
       "module_load_name": "heaterShakerModuleV1",
       "robot_type": "Flex"
@@ -6262,25 +6110,6 @@
       "labware_load_info": [
         "corning_96_wellplate_360ul_flat",
         3
-      ],
-      "module_load_name": "heaterShakerModuleV1",
-      "robot_type": "Flex"
-    }
-  },
-  "Flex,heaterShakerModuleV1,schema3test_96_well_aluminum_block,schema3test_96_wellplate_200ul_pcr_full_skirt": {
-    "coordinates": [
-      342.5,
-      74.5,
-      41.2
-    ],
-    "spec": {
-      "adapter_load_info": [
-        "schema3test_96_well_aluminum_block",
-        999
-      ],
-      "labware_load_info": [
-        "schema3test_96_wellplate_200ul_pcr_full_skirt",
-        999
       ],
       "module_load_name": "heaterShakerModuleV1",
       "robot_type": "Flex"
@@ -7919,25 +7748,6 @@
       "robot_type": "Flex"
     }
   },
-  "Flex,magneticBlockV1,opentrons_96_pcr_adapter,schema3test_96_wellplate_200ul_pcr_full_skirt": {
-    "coordinates": [
-      342.38,
-      74.24,
-      56.9
-    ],
-    "spec": {
-      "adapter_load_info": [
-        "opentrons_96_pcr_adapter",
-        1
-      ],
-      "labware_load_info": [
-        "schema3test_96_wellplate_200ul_pcr_full_skirt",
-        999
-      ],
-      "module_load_name": "magneticBlockV1",
-      "robot_type": "Flex"
-    }
-  },
   "Flex,magneticBlockV1,opentrons_96_well_aluminum_block,armadillo_96_wellplate_200ul_pcr_full_skirt": {
     "coordinates": [
       342.38,
@@ -8009,25 +7819,6 @@
       "labware_load_info": [
         "opentrons_96_wellplate_200ul_pcr_full_skirt",
         3
-      ],
-      "module_load_name": "magneticBlockV1",
-      "robot_type": "Flex"
-    }
-  },
-  "Flex,magneticBlockV1,opentrons_96_well_aluminum_block,schema3test_96_wellplate_200ul_pcr_full_skirt": {
-    "coordinates": [
-      342.38,
-      74.24,
-      60.25
-    ],
-    "spec": {
-      "adapter_load_info": [
-        "opentrons_96_well_aluminum_block",
-        1
-      ],
-      "labware_load_info": [
-        "schema3test_96_wellplate_200ul_pcr_full_skirt",
-        999
       ],
       "module_load_name": "magneticBlockV1",
       "robot_type": "Flex"
@@ -8351,25 +8142,6 @@
       "labware_load_info": [
         "corning_96_wellplate_360ul_flat",
         3
-      ],
-      "module_load_name": "magneticBlockV1",
-      "robot_type": "Flex"
-    }
-  },
-  "Flex,magneticBlockV1,schema3test_96_well_aluminum_block,schema3test_96_wellplate_200ul_pcr_full_skirt": {
-    "coordinates": [
-      342.375,
-      74.375,
-      60.25
-    ],
-    "spec": {
-      "adapter_load_info": [
-        "schema3test_96_well_aluminum_block",
-        999
-      ],
-      "labware_load_info": [
-        "schema3test_96_wellplate_200ul_pcr_full_skirt",
-        999
       ],
       "module_load_name": "magneticBlockV1",
       "robot_type": "Flex"
@@ -10008,25 +9780,6 @@
       "robot_type": "Flex"
     }
   },
-  "Flex,temperatureModuleV2,opentrons_96_pcr_adapter,schema3test_96_wellplate_200ul_pcr_full_skirt": {
-    "coordinates": [
-      342.38,
-      74.24,
-      27.9
-    ],
-    "spec": {
-      "adapter_load_info": [
-        "opentrons_96_pcr_adapter",
-        1
-      ],
-      "labware_load_info": [
-        "schema3test_96_wellplate_200ul_pcr_full_skirt",
-        999
-      ],
-      "module_load_name": "temperatureModuleV2",
-      "robot_type": "Flex"
-    }
-  },
   "Flex,temperatureModuleV2,opentrons_96_well_aluminum_block,armadillo_96_wellplate_200ul_pcr_full_skirt": {
     "coordinates": [
       342.38,
@@ -10098,25 +9851,6 @@
       "labware_load_info": [
         "opentrons_96_wellplate_200ul_pcr_full_skirt",
         3
-      ],
-      "module_load_name": "temperatureModuleV2",
-      "robot_type": "Flex"
-    }
-  },
-  "Flex,temperatureModuleV2,opentrons_96_well_aluminum_block,schema3test_96_wellplate_200ul_pcr_full_skirt": {
-    "coordinates": [
-      342.38,
-      74.24,
-      31.25
-    ],
-    "spec": {
-      "adapter_load_info": [
-        "opentrons_96_well_aluminum_block",
-        1
-      ],
-      "labware_load_info": [
-        "schema3test_96_wellplate_200ul_pcr_full_skirt",
-        999
       ],
       "module_load_name": "temperatureModuleV2",
       "robot_type": "Flex"
@@ -10440,25 +10174,6 @@
       "labware_load_info": [
         "corning_96_wellplate_360ul_flat",
         3
-      ],
-      "module_load_name": "temperatureModuleV2",
-      "robot_type": "Flex"
-    }
-  },
-  "Flex,temperatureModuleV2,schema3test_96_well_aluminum_block,schema3test_96_wellplate_200ul_pcr_full_skirt": {
-    "coordinates": [
-      342.5,
-      74.5,
-      31.25
-    ],
-    "spec": {
-      "adapter_load_info": [
-        "schema3test_96_well_aluminum_block",
-        999
-      ],
-      "labware_load_info": [
-        "schema3test_96_wellplate_200ul_pcr_full_skirt",
-        999
       ],
       "module_load_name": "temperatureModuleV2",
       "robot_type": "Flex"
@@ -12097,25 +11812,6 @@
       "robot_type": "Flex"
     }
   },
-  "Flex,thermocyclerModuleV2,opentrons_96_pcr_adapter,schema3test_96_wellplate_200ul_pcr_full_skirt": {
-    "coordinates": [
-      -5.625,
-      356.2,
-      29.86
-    ],
-    "spec": {
-      "adapter_load_info": [
-        "opentrons_96_pcr_adapter",
-        1
-      ],
-      "labware_load_info": [
-        "schema3test_96_wellplate_200ul_pcr_full_skirt",
-        999
-      ],
-      "module_load_name": "thermocyclerModuleV2",
-      "robot_type": "Flex"
-    }
-  },
   "Flex,thermocyclerModuleV2,opentrons_96_well_aluminum_block,armadillo_96_wellplate_200ul_pcr_full_skirt": {
     "coordinates": [
       -5.625,
@@ -12187,25 +11883,6 @@
       "labware_load_info": [
         "opentrons_96_wellplate_200ul_pcr_full_skirt",
         3
-      ],
-      "module_load_name": "thermocyclerModuleV2",
-      "robot_type": "Flex"
-    }
-  },
-  "Flex,thermocyclerModuleV2,opentrons_96_well_aluminum_block,schema3test_96_wellplate_200ul_pcr_full_skirt": {
-    "coordinates": [
-      -5.625,
-      356.2,
-      33.21
-    ],
-    "spec": {
-      "adapter_load_info": [
-        "opentrons_96_well_aluminum_block",
-        1
-      ],
-      "labware_load_info": [
-        "schema3test_96_wellplate_200ul_pcr_full_skirt",
-        999
       ],
       "module_load_name": "thermocyclerModuleV2",
       "robot_type": "Flex"
@@ -12529,25 +12206,6 @@
       "labware_load_info": [
         "corning_96_wellplate_360ul_flat",
         3
-      ],
-      "module_load_name": "thermocyclerModuleV2",
-      "robot_type": "Flex"
-    }
-  },
-  "Flex,thermocyclerModuleV2,schema3test_96_well_aluminum_block,schema3test_96_wellplate_200ul_pcr_full_skirt": {
-    "coordinates": [
-      -5.625,
-      356.2,
-      33.21
-    ],
-    "spec": {
-      "adapter_load_info": [
-        "schema3test_96_well_aluminum_block",
-        999
-      ],
-      "labware_load_info": [
-        "schema3test_96_wellplate_200ul_pcr_full_skirt",
-        999
       ],
       "module_load_name": "thermocyclerModuleV2",
       "robot_type": "Flex"
@@ -14129,25 +13787,6 @@
       "robot_type": "OT-2"
     }
   },
-  "OT-2,None,opentrons_96_well_aluminum_block,schema3test_96_wellplate_200ul_pcr_full_skirt": {
-    "coordinates": [
-      279.38,
-      74.24,
-      22.25
-    ],
-    "spec": {
-      "adapter_load_info": [
-        "opentrons_96_well_aluminum_block",
-        1
-      ],
-      "labware_load_info": [
-        "schema3test_96_wellplate_200ul_pcr_full_skirt",
-        999
-      ],
-      "module_load_name": null,
-      "robot_type": "OT-2"
-    }
-  },
   "OT-2,heaterShakerModuleV1,None,agilent_1_reservoir_290ml": {
     "coordinates": [
       329.005,
@@ -15643,25 +15282,6 @@
       "labware_load_info": [
         "opentrons_96_wellplate_200ul_pcr_full_skirt",
         3
-      ],
-      "module_load_name": "heaterShakerModuleV1",
-      "robot_type": "OT-2"
-    }
-  },
-  "OT-2,heaterShakerModuleV1,opentrons_96_well_aluminum_block,schema3test_96_wellplate_200ul_pcr_full_skirt": {
-    "coordinates": [
-      279.505,
-      73.115,
-      90.525
-    ],
-    "spec": {
-      "adapter_load_info": [
-        "opentrons_96_well_aluminum_block",
-        1
-      ],
-      "labware_load_info": [
-        "schema3test_96_wellplate_200ul_pcr_full_skirt",
-        999
       ],
       "module_load_name": "heaterShakerModuleV1",
       "robot_type": "OT-2"

--- a/api/src/opentrons/protocol_engine/resources/labware_validation.py
+++ b/api/src/opentrons/protocol_engine/resources/labware_validation.py
@@ -2,6 +2,7 @@
 
 from opentrons_shared_data.labware.labware_definition import (
     LabwareDefinition,
+    LabwareDefinition2,
     LabwareRole,
 )
 
@@ -44,15 +45,18 @@ def validate_definition_is_system(definition: LabwareDefinition) -> bool:
     return LabwareRole.system in definition.allowedRoles
 
 
-def validate_labware_can_be_stacked(
-    top_labware_definition: LabwareDefinition, below_labware_load_name: str
+def validate_legacy_labware_can_be_stacked(
+    child_labware_definition: LabwareDefinition2, parent_labware_load_name: str
 ) -> bool:
-    """Validate that the labware being loaded onto is in the above labware's stackingOffsetWithLabware definition."""
+    """Validate that the parent labware is in the child labware's stackingOffsetWithLabware definition.
+
+    Schema 3 Labware stacking validation is handled in locating features.
+    """
     return (
-        below_labware_load_name in top_labware_definition.stackingOffsetWithLabware
+        parent_labware_load_name in child_labware_definition.stackingOffsetWithLabware
         or (
-            "default" in top_labware_definition.stackingOffsetWithLabware
-            and top_labware_definition.compatibleParentLabware is None
+            "default" in child_labware_definition.stackingOffsetWithLabware
+            and child_labware_definition.compatibleParentLabware is None
         )
     )
 

--- a/api/src/opentrons/protocol_engine/state/_labware_origin_math.py
+++ b/api/src/opentrons/protocol_engine/state/_labware_origin_math.py
@@ -398,9 +398,7 @@ def _get_parent_deck_item_origin_to_child_labware_placement_origin(
 
 
 def _get_corner_offset_from_extents(child_labware: LabwareDefinition3) -> Point:
-    """
-    Derive the corner offset from slot from a LabwareDefinition3's extents.
-    """
+    """Derive the corner offset from slot from a LabwareDefinition3's extents."""
     back_left_bottom = child_labware.extents.total.backLeftBottom
 
     x = back_left_bottom.x

--- a/api/src/opentrons/protocol_engine/state/_labware_origin_math.py
+++ b/api/src/opentrons/protocol_engine/state/_labware_origin_math.py
@@ -253,7 +253,9 @@ def _get_parent_placement_origin_to_lw_origin(
     Only parent-child specific offsets are calculated. Offsets that apply to a single entity
     (ex., module cal) or the entire stackup (ex., LPC) are handled elsewhere.
     """
-    if isinstance(child_labware, LabwareDefinition2):
+    if isinstance(child_labware, LabwareDefinition2) or isinstance(
+        parent_deck_item, LabwareDefinition2
+    ):
         parent_deck_item_origin_to_child_labware_placement_origin = (
             _get_parent_deck_item_origin_to_child_labware_placement_origin(
                 child_labware=child_labware,
@@ -267,22 +269,36 @@ def _get_parent_placement_origin_to_lw_origin(
         # For v2 definitions, cornerOffsetFromSlot is the parent entity placement origin to child labware origin offset.
         # For compatibility with historical (buggy?) behavior,
         # we only consider it when the child labware is the topmost labware in a stackup.
-        parent_deck_item_to_child_labware_offset = (
-            Point.from_xyz_attrs(child_labware.cornerOffsetFromSlot)
-            if is_topmost_labware
-            else Point(0, 0, 0)
-        )
+        if isinstance(child_labware, LabwareDefinition2):
+            parent_deck_item_to_child_labware_offset = (
+                Point.from_xyz_attrs(child_labware.cornerOffsetFromSlot)
+                if is_topmost_labware
+                else Point(0, 0, 0)
+            )
 
-        return (
-            parent_deck_item_origin_to_child_labware_placement_origin
-            + parent_deck_item_to_child_labware_offset
-        )
+            return (
+                parent_deck_item_origin_to_child_labware_placement_origin
+                + parent_deck_item_to_child_labware_offset
+            )
+        else:
+            assert isinstance(child_labware, LabwareDefinition3)
+            parent_deck_item_to_child_labware_back_left = Point(
+                x=0, y=child_labware.extents.total.frontRightTop.y * -1, z=0
+            )
+            child_labware_back_left_to_child_labware_origin = (
+                _get_corner_offset_from_extents(child_labware)
+                if is_topmost_labware
+                else Point(0, 0, 0)
+            )
+
+            return (
+                parent_deck_item_origin_to_child_labware_placement_origin  # Only the Z-offset in this case.
+                + parent_deck_item_to_child_labware_back_left
+                + child_labware_back_left_to_child_labware_origin
+            )
     else:
         # For v3 definitions, get the vector from the back left bottom to the front right bottom.
         assert_type(child_labware, LabwareDefinition3)
-
-        if isinstance(parent_deck_item, LabwareDefinition2):
-            raise NotImplementedError()
 
         # TODO(jh, 06-25-25): This code is entirely temporary and only exists for the purposes of more useful
         #  snapshot testing. This code should exist in NO capacity after features are implemented outside of the
@@ -379,6 +395,19 @@ def _get_parent_deck_item_origin_to_child_labware_placement_origin(
 
     else:
         raise TypeError(f"Unsupported labware location type: {labware_location}")
+
+
+def _get_corner_offset_from_extents(child_labware: LabwareDefinition3) -> Point:
+    """
+    Derive the corner offset from slot from a LabwareDefinition3's extents.
+    """
+    back_left_bottom = child_labware.extents.total.backLeftBottom
+
+    x = back_left_bottom.x
+    y = back_left_bottom.y * -1
+    z = back_left_bottom.z
+
+    return Point(x, y, z)
 
 
 def _module_parent_to_child_offset(
@@ -698,15 +727,38 @@ def _get_child_labware_overlap_with_parent_labware(
     child_labware: LabwareDefinition, parent_labware_name: str
 ) -> Point:
     """Get the child labware's overlap with the parent labware's load name."""
-    overlap = child_labware.stackingOffsetWithLabware.get(parent_labware_name)
-
-    if overlap is None:
-        overlap = child_labware.stackingOffsetWithLabware.get("default")
-
-    if overlap is None:
-        raise ValueError(
-            f"No default labware overlap specified for parent labware: {parent_labware_name}"
+    if isinstance(child_labware, LabwareDefinition3) and not hasattr(
+        child_labware, "legacyStackingOffsetWithLabware"
+    ):
+        raise NotImplementedError(
+            f"Labware {child_labware.metadata.displayName} contains no legacyStackingOffsetWithLabware. "
+            f"Either add this property explictly on the definition or update your protocol's API Level."
         )
+
+    overlap = (
+        child_labware.stackingOffsetWithLabware.get(parent_labware_name)
+        if isinstance(child_labware, LabwareDefinition2)
+        else child_labware.legacyStackingOffsetWithLabware.get(parent_labware_name)
+    )
+
+    if overlap is None:
+        overlap = (
+            child_labware.stackingOffsetWithLabware.get("default")
+            if isinstance(child_labware, LabwareDefinition2)
+            else child_labware.legacyStackingOffsetWithLabware.get("default")
+        )
+
+    if overlap is None:
+        if isinstance(child_labware, LabwareDefinition3):
+            raise ValueError(
+                f"No default labware overlap specified for parent labware: {parent_labware_name} "
+                f"in legacyStackingOffsetWithLabware."
+            )
+        else:
+            raise ValueError(
+                f"No default labware overlap specified for parent labware: {parent_labware_name} "
+                f"in stackingOffsetWithLabware."
+            )
     else:
         return Point.from_xyz_attrs(overlap)
 

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -1093,7 +1093,9 @@ class LabwareView:
                 raise errors.LabwareCannotBeStackedError(
                     f"Labware {lid_labware_definition.parameters.loadName} cannot be used as a lid in the Flex Stacker."
                 )
-            if not labware_validation.validate_labware_can_be_stacked(
+            if isinstance(
+                lid_labware_definition, LabwareDefinition2
+            ) and not labware_validation.validate_legacy_labware_can_be_stacked(
                 lid_labware_definition, primary_labware_definition.parameters.loadName
             ):
                 raise errors.LabwareCannotBeStackedError(
@@ -1106,7 +1108,9 @@ class LabwareView:
                 raise errors.LabwareCannotBeStackedError(
                     f"Labware {adapter_labware_definition.parameters.loadName} cannot be used as an adapter in the Flex Stacker."
                 )
-            if not labware_validation.validate_labware_can_be_stacked(
+            if isinstance(
+                primary_labware_definition, LabwareDefinition2
+            ) and not labware_validation.validate_legacy_labware_can_be_stacked(
                 primary_labware_definition,
                 adapter_labware_definition.parameters.loadName,
             ):
@@ -1160,9 +1164,9 @@ class LabwareView:
         below_labware = self.get(bottom_labware_id)
         if isinstance(
             top_labware_definition, LabwareDefinition2
-        ) and not labware_validation.validate_labware_can_be_stacked(
-            top_labware_definition=top_labware_definition,
-            below_labware_load_name=below_labware.loadName,
+        ) and not labware_validation.validate_legacy_labware_can_be_stacked(
+            child_labware_definition=top_labware_definition,
+            parent_labware_load_name=below_labware.loadName,
         ):
             raise errors.LabwareCannotBeStackedError(
                 f"Labware {top_labware_definition.parameters.loadName} cannot be loaded onto labware {below_labware.loadName}"

--- a/api/tests/opentrons/protocol_engine/resources/test_labware_validation.py
+++ b/api/tests/opentrons/protocol_engine/resources/test_labware_validation.py
@@ -82,7 +82,7 @@ def test_validate_definition_is_adapter(
     ],
 )
 def test_validate_labware_can_be_stacked(
-    definition: LabwareDefinition, expected_result: bool
+    definition: LabwareDefinition2, expected_result: bool
 ) -> None:
     """It should validate if definition allows it to stack on given labware."""
     assert (

--- a/api/tests/opentrons/protocol_engine/resources/test_labware_validation.py
+++ b/api/tests/opentrons/protocol_engine/resources/test_labware_validation.py
@@ -86,7 +86,7 @@ def test_validate_labware_can_be_stacked(
 ) -> None:
     """It should validate if definition allows it to stack on given labware."""
     assert (
-        subject.validate_labware_can_be_stacked(definition, "labware123")
+        subject.validate_legacy_labware_can_be_stacked(definition, "labware123")
         == expected_result
     )
 

--- a/api/tests/opentrons/protocol_engine/state/test_labware_origin_math.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_origin_math.py
@@ -517,6 +517,12 @@ LABWARE_OVERLAP_SPECS: List[LabwareOverlapSpec] = [
         labware_location=OnLabwareLocation(labwareId="parent-labware-2"),
         expected_total_offset=Point(x=450, y=650, z=950),
     ),
+    LabwareOverlapSpec(
+        child_definition=_LW_V2_WITH_LABWARE_STACKING,
+        parent_definition=_LW_V3_WITH_SLOT_AS_PARENT_CHILD_FEATURES,
+        labware_location=OnLabwareLocation(labwareId="parent-labware-3"),
+        expected_total_offset=Point(x=440, y=2135, z=742),
+    ),
 ]
 
 ADDRESSABLE_AREA_SPECS: List[AddressableAreaSpec] = [

--- a/api/tests/opentrons/protocol_engine/state/test_labware_origin_math.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_origin_math.py
@@ -474,8 +474,8 @@ class ModuleOverlapSpec(NamedTuple):
 class LabwareOverlapSpec(NamedTuple):
     """Spec data to test labware stacking behavior."""
 
-    child_definition: LabwareDefinition2
-    parent_definition: LabwareDefinition2
+    child_definition: LabwareDefinition
+    parent_definition: LabwareDefinition
     labware_location: OnLabwareLocation
     expected_total_offset: Point
 

--- a/api/tests/opentrons/protocol_engine/state/test_labware_origin_math.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_origin_math.py
@@ -229,7 +229,7 @@ _LW_V3_WITH_SLOT_FP_AS_CHILD_FEATURE = LabwareDefinition3.model_construct(  # ty
             backLeft=Vector2D(x=0, y=0), frontRight=Vector2D(x=80, y=60), z=5
         )
     ),
-    stackingOffsetWithLabware={
+    legacyStackingOffsetWithLabware={
         "default": Vector3D(x=0, y=0, z=0),
     },
     parameters=Parameters3.model_construct(loadName="labware-v3-child"),  # type: ignore[call-arg]
@@ -316,7 +316,56 @@ _LW_V3_WITH_FLEX_TIP_RACK_LID_AS_CHILD = LabwareDefinition3.model_construct(  # 
     gripperOffsets={},
 )
 
-# Module definitions
+_LW_V3_WITH_LEGACY_STACKING = LabwareDefinition3.model_construct(  # type: ignore[call-arg]
+    namespace="test",
+    version=1,
+    schemaVersion=3,
+    extents=Extents(
+        total=AxisAlignedBoundingBox3D(
+            backLeftBottom=Vector3D(x=75, y=125, z=175),
+            frontRightTop=Vector3D(x=875, y=-475, z=975),
+        ),
+    ),
+    features=LocatingFeatures(
+        slotFootprintAsChild=SlotFootprintAsChildFeature(
+            backLeft=Vector2D(x=5, y=10), frontRight=Vector2D(x=85, y=50), z=3
+        )
+    ),
+    legacyStackingOffsetWithLabware={
+        "labware-name": Vector3D(x=25, y=35, z=45),
+        "default": Vector3D(x=125, y=225, z=325),
+    },
+    parameters=Parameters3.model_construct(loadName="labware-v3-with-legacy-stacking"),  # type: ignore[call-arg]
+    gripperOffsets={},
+)
+
+_LW_V3_WITH_GRIPPER_OFFSETS = LabwareDefinition3.model_construct(  # type: ignore[call-arg]
+    namespace="test",
+    version=1,
+    schemaVersion=3,
+    extents=Extents(
+        total=AxisAlignedBoundingBox3D(
+            backLeftBottom=Vector3D(x=75, y=125, z=175),
+            frontRightTop=Vector3D(x=875, y=-475, z=975),
+        ),
+    ),
+    features=LocatingFeatures(
+        slotFootprintAsChild=SlotFootprintAsChildFeature(
+            backLeft=Vector2D(x=5, y=10), frontRight=Vector2D(x=85, y=50), z=3
+        )
+    ),
+    legacyStackingOffsetWithLabware={
+        "default": Vector3D(x=125, y=225, z=325),
+    },
+    gripperOffsets={
+        "default": GripperOffsets(
+            pickUpOffset=Vector3D(x=15, y=25, z=35),
+            dropOffset=Vector3D(x=45, y=55, z=65),
+        )
+    },
+    parameters=Parameters3.model_construct(loadName="labware-v3-with-gripper"),  # type: ignore[call-arg]
+)
+
 _MODULE_DEF_TEMP_V2 = ModuleDefinition.model_construct(  # type: ignore[call-arg]
     schemaVersion=2,
     model=ModuleModel.TEMPERATURE_MODULE_V2,
@@ -523,6 +572,12 @@ LABWARE_OVERLAP_SPECS: List[LabwareOverlapSpec] = [
         labware_location=OnLabwareLocation(labwareId="parent-labware-3"),
         expected_total_offset=Point(x=440, y=2135, z=742),
     ),
+    LabwareOverlapSpec(
+        child_definition=_LW_V3_WITH_LEGACY_STACKING,
+        parent_definition=_LW_V2_2,
+        labware_location=OnLabwareLocation(labwareId="parent-v2-labware"),
+        expected_total_offset=Point(x=100, y=385, z=880),
+    ),
 ]
 
 ADDRESSABLE_AREA_SPECS: List[AddressableAreaSpec] = [
@@ -656,6 +711,21 @@ GRIPPER_OFFSET_SPECS: List[GripperOffsetSpec] = [
         module_parent_to_child_offset=None,
         expected_pick_up_offset=Point(x=7, y=14, z=21),
         expected_drop_offset=Point(x=28, y=35, z=41.25),
+    ),
+    GripperOffsetSpec(
+        stackup_lw_info_top_to_bottom=[
+            (_LW_V3_WITH_GRIPPER_OFFSETS, OnLabwareLocation(labwareId="parent-id")),
+            (
+                _LW_V2_WITH_DEFAULT_GRIPPER_OFFSETS,
+                DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
+            ),
+        ],
+        underlying_ancestor_definition=_ADDRESSABLE_AREA,
+        slot_name=DeckSlotName.SLOT_1,
+        deck_definition=load_deck(STANDARD_OT3_DECK, 5),
+        module_parent_to_child_offset=None,
+        expected_pick_up_offset=Point(x=15.0, y=25.0, z=35.0),
+        expected_drop_offset=Point(x=45.0, y=55.0, z=64.25),
     ),
 ]
 
@@ -793,6 +863,44 @@ def test_get_parent_placement_origin_to_lw_origin_v3_definitions(
     )
 
     assert result == expected_total_offset
+
+
+def test_v3_child_on_v2_parent_labware() -> None:
+    """Test that v3 labware can stack on v2 labware correctly."""
+    deck_def = load_deck(STANDARD_OT3_DECK, 5)
+
+    # Top-most labware case
+    result = get_stackup_origin_to_labware_origin(
+        context=LabwareOriginContext.PIPETTING,
+        stackup_lw_info_top_to_bottom=[
+            (_LW_V3_WITH_LEGACY_STACKING, OnLabwareLocation(labwareId="parent-id")),
+            (_LW_V2_2, AddressableAreaLocation(addressableAreaName="test_area")),
+        ],
+        underlying_ancestor_definition=_ADDRESSABLE_AREA,
+        slot_name=DeckSlotName.SLOT_A1,
+        module_parent_to_child_offset=None,
+        deck_definition=deck_def,
+    )
+
+    assert result == Point(x=100, y=385, z=880)
+
+    # Non-topmost labware case
+    result_non_topmost = get_stackup_origin_to_labware_origin(
+        context=LabwareOriginContext.PIPETTING,
+        stackup_lw_info_top_to_bottom=[
+            (_LW_V2, OnLabwareLocation(labwareId="adapter-id")),
+            (_LW_V3_WITH_LEGACY_STACKING, OnLabwareLocation(labwareId="parent-id")),
+            (_LW_V2_2, AddressableAreaLocation(addressableAreaName="test_area")),
+        ],
+        underlying_ancestor_definition=_ADDRESSABLE_AREA,
+        slot_name=DeckSlotName.SLOT_A1,
+        module_parent_to_child_offset=None,
+        deck_definition=deck_def,
+    )
+
+    expected_total = Point(x=175, y=760, z=1855)
+
+    assert result_non_topmost == expected_total
 
 
 @pytest.mark.parametrize(

--- a/shared-data/js/__tests__/labwareDefSchemaV3.test.ts
+++ b/shared-data/js/__tests__/labwareDefSchemaV3.test.ts
@@ -146,5 +146,10 @@ describe(`test labware definitions with schema v3`, () => {
         expect(well.z).toBeGreaterThan(0)
       }
     })
+
+    // Consult documentation if it is unclear why this is the case.
+    test('should not contain the legacyStackingOffsetWithLabware property', () => {
+      expect(labwareDef.legacyStackingOffsetWithLabware).toBe(undefined)
+    })
   })
 })

--- a/shared-data/js/types.ts
+++ b/shared-data/js/types.ts
@@ -335,6 +335,7 @@ export interface LabwareDefinition3 {
   groups: LabwareWellGroup[]
   allowedRoles?: LabwareRoles[]
   stackingOffsetWithLabware?: Record<string, LabwareOffset>
+  legacyStackingOffsetWithLabware?: Record<string, LabwareOffset>
   stackingOffsetWithModule?: Record<string, LabwareOffset>
   stackLimit?: number
   compatibleParentLabware?: string[]

--- a/shared-data/labware/definitions/3/schema3test_96_wellplate_200ul_pcr_full_skirt/999.json
+++ b/shared-data/labware/definitions/3/schema3test_96_wellplate_200ul_pcr_full_skirt/999.json
@@ -50,33 +50,6 @@
   },
   "stackLimit": 4,
   "compatibleParentLabware": ["opentrons_96_wellplate_200ul_pcr_full_skirt"],
-  "stackingOffsetWithLabware": {
-    "opentrons_96_pcr_adapter": {
-      "x": 0,
-      "y": 0,
-      "z": 10.95
-    },
-    "opentrons_96_well_aluminum_block": {
-      "x": 0,
-      "y": 0,
-      "z": 11.91
-    },
-    "schema3test_96_well_aluminum_block": {
-      "x": 0,
-      "y": 0,
-      "z": 11.91
-    },
-    "opentrons_96_wellplate_200ul_pcr_full_skirt": {
-      "x": 0,
-      "y": 0,
-      "z": 3.0
-    },
-    "schema3test_96_wellplate_200ul_pcr_full_skirt": {
-      "x": 0,
-      "y": 0,
-      "z": 3.0
-    }
-  },
   "stackingOffsetWithModule": {
     "magneticBlockV1": {
       "x": 0,

--- a/shared-data/labware/definitions/3/schema3test_tough_pcr_auto_sealing_lid/999.json
+++ b/shared-data/labware/definitions/3/schema3test_tough_pcr_auto_sealing_lid/999.json
@@ -63,53 +63,6 @@
       "z": 0
     }
   },
-  "stackingOffsetWithLabware": {
-    "default": {
-      "x": 0,
-      "y": 0,
-      "z": 8.193
-    },
-    "opentrons_tough_pcr_auto_sealing_lid": {
-      "x": 0,
-      "y": 0,
-      "z": 6.492
-    },
-    "schema3test_tough_pcr_auto_sealing_lid": {
-      "x": 0,
-      "y": 0,
-      "z": 6.492
-    },
-    "armadillo_96_wellplate_200ul_pcr_full_skirt": {
-      "x": 0,
-      "y": 0,
-      "z": 8.193
-    },
-    "opentrons_96_wellplate_200ul_pcr_full_skirt": {
-      "x": 0,
-      "y": 0,
-      "z": 8.193
-    },
-    "schema3test_96_wellplate_200ul_pcr_full_skirt": {
-      "x": 0,
-      "y": 0,
-      "z": 8.193
-    },
-    "biorad_96_wellplate_200ul_pcr": {
-      "x": 0,
-      "y": 0,
-      "z": 8.08
-    },
-    "opentrons_flex_deck_riser": {
-      "x": 0,
-      "y": 0,
-      "z": 34
-    },
-    "protocol_engine_lid_stack_object": {
-      "x": 0,
-      "y": 0,
-      "z": 0
-    }
-  },
   "stackLimit": 5,
   "compatibleParentLabware": [
     "armadillo_96_wellplate_200ul_pcr_full_skirt",

--- a/shared-data/labware/schemas/3.json
+++ b/shared-data/labware/schemas/3.json
@@ -778,6 +778,13 @@
         "$ref": "#/definitions/vector3D"
       }
     },
+    "legacyStackingOffsetWithLabware": {
+      "type": "object",
+      "description": "Legacy labware stacking offsets for Labware Schema 2 compatibility. See Labware Schema 2 `stackingOffsetWithLabware` documentation.",
+      "additionalProperties": {
+        "$ref": "#/definitions/vector3D"
+      }
+    },
     "stackingOffsetWithModule": {
       "type": "object",
       "description": "Supported module that can be stacked upon, with overlap height between labware and module.",

--- a/shared-data/python/opentrons_shared_data/labware/labware_definition.py
+++ b/shared-data/python/opentrons_shared_data/labware/labware_definition.py
@@ -604,6 +604,7 @@ class LabwareDefinition3(BaseModel):
     wells: dict[str, WellDefinition3]
     groups: list[Group]
     stackingOffsetWithLabware: dict[str, Vector3D] = Field(default_factory=dict)
+    legacyStackingOffsetWithLabware: dict[str, Vector3D] = Field(default_factory=dict)
     stackingOffsetWithModule: dict[str, Vector3D] = Field(default_factory=dict)
     allowedRoles: list[LabwareRole] = Field(default_factory=list)
     gripperOffsets: dict[str, GripperOffsets] = Field(default_factory=dict)

--- a/shared-data/python/opentrons_shared_data/labware/types.py
+++ b/shared-data/python/opentrons_shared_data/labware/types.py
@@ -237,6 +237,7 @@ class LabwareDefinition3(_OTSharedSchemaMixin, TypedDict):
     wells: dict[str, WellDefinition3]
     groups: list[WellGroup]
     stackingOffsetWithLabware: NotRequired[dict[str, Vector3D]]
+    legacyStackingOffsetWithLabware: NotRequired[dict[str, Vector3D]]
     stackingOffsetWithModule: NotRequired[dict[str, Vector3D]]
     allowedRoles: NotRequired[list[LabwareRoles]]
     gripperOffsets: NotRequired[dict[str, GripperOffsets]]


### PR DESCRIPTION
Works towards [EXEC-77](https://opentrons.atlassian.net/browse/EXEC-77)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

We want to support labware stackups that comprise of both labware schema 2 definitions and schema 3 definitions as best as possible, and this PR fills in the cross-compatibility gaps when support does not exist. Each parent-child labware stackup case is elaborated upon below.

### Schema 3 Parent Definition, Schema 2 Child Definition

We are already fully covering this case. While the stackup integration snapshot testing covers testing for this currently, a650449057fe2df32faf1fd557bb402f3227c90b adds a unit test.

### Schema 2 Parent Defintion, Schema 3 Child Definition

Ok, this is the bigger issue, and the primary focus of this PR. When we place a schema 3 labware on top of a schema 2, we can't use locating features, so we have to fallback to the schema 2 way of doing things. That means we need to know the following:

- The `cornerOffsetFromSlot` in the child definition. This is easy and can be derived entirely from `extents`. Extents themselves are partially derived from `cornerOffsetFromSlot` as seen in the [schema 2 to 3 migration script](https://github.com/syntaxColoring/labware-scripts/blob/main/migrate_to_extents.py). 
- The `stackingOffsetWithLabware`. Unfortunately, this is _not_ easy... 

After discussion with @SyntaxColoring, our plan is to provide affordances for specifying these offsets via a `legacyStackingOffsetWithLabware` field, but not include these values in any of our official definitions. The reason for this being that we'd have to maintain these values for every officially supported definition in perpetuity and constantly add to them as new labware gets released. In practice, it seems like there are only a few select group of users who could encounter this issue:

- Users that use a lower API Level than the Schema 3 release and then use Labware Creator to create a schema 3 labware. We can update Labware Creator with some warnings to mitigate this issue. 
- Users that specify the `version` param when loading labware in protocols and mix schema 2 and 3 labware.
- Users that roll their own labware definitions (or with the help of Support).

So this seems like a case of choosing the better of two unideal scenarios.

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- Covered by the snapshot testing here. All the snapshot additions are quite identical when comparing to their schema 2 on schema 2 equivalents. NOTE: I hacked in some legacy offsets to generate the snapshot diffs and demonstrate that the offsets do work and are correct when supplied. Before merging in the PR, I will update the snapshot testing to the values that reflect the actual commited code (no legacy offsets).
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Adds support for stacking Labware Schema 3 labware on top of Labware Schema 2 labware.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests
- Are we ok with the tradeoff we're making when we drop stacking offsets from schema 3?
- Do the error messaging changes seem reasonable?
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low in the sense that this is gated and doesn't affect current behavior
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[EXEC-77]: https://opentrons.atlassian.net/browse/EXEC-77?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ