### PR TITLE
fix(protocol-designer): make volumeTooHigh() not crash when pipette is deleted

### DIFF
--- a/protocol-designer/src/form-types.ts
+++ b/protocol-designer/src/form-types.ts
@@ -373,7 +373,7 @@ export interface HydratedMixFormData extends AnnotationFields {
   mix_wellOrder_first: WellOrderOption
   mix_wellOrder_second: WellOrderOption
   nozzles: NozzleConfigurationStyle | null
-  pipette: PipetteEntity
+  pipette: PipetteEntity // can be null if user deletes pipette
   stepType: 'mix'
   tipRack: string
   volume: number

--- a/protocol-designer/src/steplist/formLevel/errors.ts
+++ b/protocol-designer/src/steplist/formLevel/errors.ts
@@ -762,12 +762,13 @@ export const volumeTooHigh = (
   fields: HydratedMixFormData
 ): FormError | null => {
   const { pipette, tipRack } = fields
+  if (!pipette) {
+    // pipette is null if user deletes pipette
+    return null
+  }
   const volume = Number(fields.volume)
 
-  const pipetteCapacity = getPipetteCapacity(
-    pipette as PipetteEntity,
-    tipRack as string
-  )
+  const pipetteCapacity = getPipetteCapacity(pipette, tipRack)
   if (
     !Number.isNaN(volume) &&
     !Number.isNaN(pipetteCapacity) &&


### PR DESCRIPTION
# Overview

In PD, if you have a Mix step, then delete/replace the pipette, you'll get a whitescreen crash with https://opentrons-76.sentry.io/issues/6805349834 RQA-4595.

The root cause is that when we try to regenerate the steps after the pipette is deleted, the Mix step has a null pipette, and it crashes when trying to call `volumeTooHigh()` to get the pipette capacity.

## Test Plan and Hands on Testing

Before this change, create a Mix step, then delete the pipette used for the Mix. PD will crash.

Observe that PD no longer crashes after this change.

## Risk assessment

Low. Straightforward bug fix.