### PR TITLE
refactor(api): calculate grip point from labware center position

### DIFF
--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -88,7 +88,6 @@ from ..types import (
     labware_location_is_system,
     WellLocationType,
     WellLocationFunction,
-    AddressableArea,
     GripperMoveType,
 )
 from ..types.liquid_level_detection import SimulatedProbeResult, LiquidTrackingType
@@ -1007,6 +1006,7 @@ class GeometryView:
         """
         aa_name = self._get_underlying_addressable_area_name(location)
         addressable_area = self._addressable_areas.get_addressable_area(aa_name)
+        slot_front_left = self._addressable_areas.get_addressable_area_position(aa_name)
 
         stackup_defs_locs = self._get_stackup_lw_info_top_to_bottom(
             labware_definition=labware_definition, location=location
@@ -1031,39 +1031,44 @@ class GeometryView:
             slot_name=addressable_area.base_slot,
             deck_definition=self._addressable_areas.deck_definition,
         )
-        lw_origin_to_stackup_placement_origin = self._get_lw_origin_to_parent(
-            labware_definition=labware_definition, addressable_area=addressable_area
-        )
         mod_cal_offset = self._get_calibrated_module_offset(location)
-        location_center = self._addressable_areas.get_addressable_area_center(aa_name)
+
+        lw_origin_to_lw_center = self._get_labware_center(labware_definition)
         grip_z_from_lw_origin = self._labware.get_grip_z(labware_definition)
+        lw_origin_to_lw_grip_center = Point(
+            x=lw_origin_to_lw_center.x,
+            y=lw_origin_to_lw_center.y,
+            z=grip_z_from_lw_origin,
+        )
+
         user_additional_offset = user_additional_offset or Point()
 
         return (
-            location_center
+            slot_front_left
             + stackup_placement_origin_to_lw_origin
-            + lw_origin_to_stackup_placement_origin
+            + lw_origin_to_lw_grip_center
             + mod_cal_offset
-            + Point(0, 0, grip_z_from_lw_origin)
             + user_additional_offset
         )
 
-    def _get_lw_origin_to_parent(
-        self, labware_definition: LabwareDefinition, addressable_area: AddressableArea
-    ) -> Point:
+    def _get_labware_center(self, labware_definition: LabwareDefinition) -> Point:
+        """Get the x,y,z center of the labware."""
         if isinstance(labware_definition, LabwareDefinition2):
-            return Point(0, 0, 0)
+            dimensions = labware_definition.dimensions
+            x = dimensions.xDimension / 2
+            y = dimensions.yDimension / 2
+            z = dimensions.zDimension / 2
+
+            return Point(x, y, z)
         else:
-            bb_y = addressable_area.bounding_box.y
-            bb_z = addressable_area.bounding_box.z
-            return (
-                Point(
-                    x=0,
-                    y=bb_y,
-                    z=bb_z,
-                )
-                * -1
-            )
+            front_right_top = labware_definition.extents.total.frontRightTop
+            back_left_bottom = labware_definition.extents.total.backLeftBottom
+
+            x = (front_right_top.x - back_left_bottom.x) / 2
+            y = (front_right_top.y - back_left_bottom.y) / 2
+            z = (front_right_top.z - back_left_bottom.z) / 2
+
+            return Point(x, y, z)
 
     def get_extra_waypoints(
         self,

--- a/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
@@ -2816,14 +2816,12 @@ def test_get_labware_grip_point_v2_definition(
     decoy.when(mock_labware_view.get_grip_z(_MOCK_LABWARE_DEFINITION2)).then_return(100)
 
     decoy.when(
-        mock_addressable_area_view.get_addressable_area_center(DeckSlotName.SLOT_1.id)
+        mock_addressable_area_view.get_addressable_area_position(DeckSlotName.SLOT_1.id)
     ).then_return(Point(x=101, y=102, z=103))
 
     decoy.when(
         mock_addressable_area_view.get_addressable_area(DeckSlotName.SLOT_1.id)
     ).then_return(MOCK_ADDRESSABLE_AREA)
-
-    expected_lw_origin_to_parent = Point(0, 0, 0)
 
     labware_center = subject.get_labware_grip_point(
         labware_definition=_MOCK_LABWARE_DEFINITION2,
@@ -2833,9 +2831,9 @@ def test_get_labware_grip_point_v2_definition(
     )
 
     assert labware_center == Point(
-        101.0 + _PARENT_ORIGIN_TO_LABWARE_ORIGIN.x + expected_lw_origin_to_parent.x,
-        102.0 + _PARENT_ORIGIN_TO_LABWARE_ORIGIN.y + expected_lw_origin_to_parent.y,
-        203 + _PARENT_ORIGIN_TO_LABWARE_ORIGIN.z + expected_lw_origin_to_parent.z,
+        101.0 + 500 + _PARENT_ORIGIN_TO_LABWARE_ORIGIN.x,
+        102.0 + 600 + _PARENT_ORIGIN_TO_LABWARE_ORIGIN.y,
+        103 + 100 + _PARENT_ORIGIN_TO_LABWARE_ORIGIN.z,
     )
 
 
@@ -2849,21 +2847,12 @@ def test_get_labware_grip_point_v3_definition(
     decoy.when(mock_labware_view.get_grip_z(_MOCK_LABWARE_DEFINITION3)).then_return(100)
 
     decoy.when(
-        mock_addressable_area_view.get_addressable_area_center(DeckSlotName.SLOT_1.id)
+        mock_addressable_area_view.get_addressable_area_position(DeckSlotName.SLOT_1.id)
     ).then_return(Point(x=101, y=102, z=103))
 
     decoy.when(
         mock_addressable_area_view.get_addressable_area(DeckSlotName.SLOT_1.id)
     ).then_return(MOCK_ADDRESSABLE_AREA)
-
-    expected_lw_origin_to_parent = (
-        Point(
-            0,
-            MOCK_ADDRESSABLE_AREA.bounding_box.y,
-            MOCK_ADDRESSABLE_AREA.bounding_box.z,
-        )
-        * -1
-    )
 
     labware_center = subject.get_labware_grip_point(
         labware_definition=_MOCK_LABWARE_DEFINITION3,
@@ -2873,9 +2862,9 @@ def test_get_labware_grip_point_v3_definition(
     )
 
     assert labware_center == Point(
-        101.0 + _PARENT_ORIGIN_TO_LABWARE_ORIGIN.x + expected_lw_origin_to_parent.x,
-        102.0 + _PARENT_ORIGIN_TO_LABWARE_ORIGIN.y + expected_lw_origin_to_parent.y,
-        203 + _PARENT_ORIGIN_TO_LABWARE_ORIGIN.z + expected_lw_origin_to_parent.z,
+        101.0 + 100 + _PARENT_ORIGIN_TO_LABWARE_ORIGIN.x,
+        102.0 - 25 + _PARENT_ORIGIN_TO_LABWARE_ORIGIN.y,
+        203 + _PARENT_ORIGIN_TO_LABWARE_ORIGIN.z,
     )
 
 
@@ -2897,40 +2886,29 @@ def test_get_labware_grip_point_on_labware(
     decoy.when(mock_labware_view.get_definition("below-id")).then_return(
         sentinel.below_definition
     )
+    test_definition = _MOCK_LABWARE_DEFINITION2
     decoy.when(
-        mock_labware_view.get_grip_z(labware_definition=sentinel.definition)
+        mock_labware_view.get_grip_z(labware_definition=test_definition)
     ).then_return(100)
     decoy.when(
-        mock_addressable_area_view.get_addressable_area_center(DeckSlotName.SLOT_4.id)
+        mock_addressable_area_view.get_addressable_area_position(DeckSlotName.SLOT_4.id)
     ).then_return(Point(x=5, y=9, z=10))
 
     decoy.when(
         mock_addressable_area_view.get_addressable_area(DeckSlotName.SLOT_4.id)
     ).then_return(MOCK_ADDRESSABLE_AREA)
 
-    expected_lw_origin_to_parent = (
-        Point(
-            0,
-            MOCK_ADDRESSABLE_AREA.bounding_box.y,
-            MOCK_ADDRESSABLE_AREA.bounding_box.z,
-        )
-        * -1
-    )
-
     grip_point = subject.get_labware_grip_point(
-        labware_definition=sentinel.definition,
+        labware_definition=test_definition,
         location=OnLabwareLocation(labwareId="below-id"),
         move_type=GripperMoveType.PICK_UP_LABWARE,
         user_additional_offset=None,
     )
 
     assert grip_point == Point(
-        5.0 + _PARENT_ORIGIN_TO_LABWARE_ORIGIN.x + expected_lw_origin_to_parent.x,
-        9.0 + _PARENT_ORIGIN_TO_LABWARE_ORIGIN.y + expected_lw_origin_to_parent.y,
-        10.0
-        + 100
-        + _PARENT_ORIGIN_TO_LABWARE_ORIGIN.z
-        + expected_lw_origin_to_parent.z,
+        5 + 500 + _PARENT_ORIGIN_TO_LABWARE_ORIGIN.x,
+        9 + 600 + _PARENT_ORIGIN_TO_LABWARE_ORIGIN.y,
+        10.0 + 100 + _PARENT_ORIGIN_TO_LABWARE_ORIGIN.z,
     )
 
 
@@ -2974,9 +2952,8 @@ def test_get_labware_grip_point_for_labware_on_module(
         pipette_view=subject._pipettes,
         addressable_area_view=addressable_area_view,
     )
-    decoy.when(mock_labware_view.get_grip_z(sentinel.labware_definition)).then_return(
-        500
-    )
+    test_definition = _MOCK_LABWARE_DEFINITION2
+    decoy.when(mock_labware_view.get_grip_z(test_definition)).then_return(500)
     decoy.when(mock_module_view.get_location("module-id")).then_return(
         DeckSlotLocation(slotName=DeckSlotName.SLOT_C3)
     )
@@ -2998,25 +2975,16 @@ def test_get_labware_grip_point_for_labware_on_module(
         )
     ).then_return(Point(x=0, y=0, z=0))
 
-    expected_lw_origin_to_parent = (
-        Point(
-            0,
-            MOCK_ADDRESSABLE_AREA.bounding_box.y,
-            MOCK_ADDRESSABLE_AREA.bounding_box.z,
-        )
-        * -1
-    )
-
     result_grip_point = subject.get_labware_grip_point(
-        labware_definition=sentinel.labware_definition,
+        labware_definition=test_definition,
         location=ModuleLocation(moduleId="module-id"),
         move_type=GripperMoveType.PICK_UP_LABWARE,
         user_additional_offset=Point(x=1, y=2, z=3),
     )
     assert result_grip_point == Point(
-        x=492 + _PARENT_ORIGIN_TO_LABWARE_ORIGIN.x + expected_lw_origin_to_parent.x + 1,
-        y=350 + _PARENT_ORIGIN_TO_LABWARE_ORIGIN.y + expected_lw_origin_to_parent.y + 2,
-        z=838 + _PARENT_ORIGIN_TO_LABWARE_ORIGIN.z + expected_lw_origin_to_parent.z + 3,
+        x=929 + _PARENT_ORIGIN_TO_LABWARE_ORIGIN.x,
+        y=909 + _PARENT_ORIGIN_TO_LABWARE_ORIGIN.y,
+        z=841 + _PARENT_ORIGIN_TO_LABWARE_ORIGIN.z,
     )
 
 
@@ -3061,9 +3029,8 @@ def test_get_labware_grip_point_for_labware_stack_on_module(
         pipette_view=subject._pipettes,
         addressable_area_view=addressable_area_view,
     )
-    decoy.when(mock_labware_view.get_grip_z(sentinel.labware_definition)).then_return(
-        500
-    )
+    test_definition = _MOCK_LABWARE_DEFINITION2
+    decoy.when(mock_labware_view.get_grip_z(test_definition)).then_return(500)
     decoy.when(mock_module_view.get_location("module-id")).then_return(
         DeckSlotLocation(slotName=DeckSlotName.SLOT_C3)
     )
@@ -3092,26 +3059,17 @@ def test_get_labware_grip_point_for_labware_stack_on_module(
         "magneticBlockV1C3"
     )
 
-    expected_lw_origin_to_parent = (
-        Point(
-            0,
-            MOCK_ADDRESSABLE_AREA.bounding_box.y,
-            MOCK_ADDRESSABLE_AREA.bounding_box.z,
-        )
-        * -1
-    )
-
     result_grip_point = subject.get_labware_grip_point(
-        labware_definition=sentinel.labware_definition,
+        labware_definition=test_definition,
         location=OnLabwareLocation(labwareId="below-id-9"),
         move_type=GripperMoveType.PICK_UP_LABWARE,
         user_additional_offset=None,
     )
 
     assert result_grip_point == Point(
-        x=492.0 + _PARENT_ORIGIN_TO_LABWARE_ORIGIN.x + expected_lw_origin_to_parent.x,
-        y=350.0 + _PARENT_ORIGIN_TO_LABWARE_ORIGIN.y + expected_lw_origin_to_parent.y,
-        z=838.0 + _PARENT_ORIGIN_TO_LABWARE_ORIGIN.z + expected_lw_origin_to_parent.z,
+        x=928.0 + _PARENT_ORIGIN_TO_LABWARE_ORIGIN.x,
+        y=907.0 + _PARENT_ORIGIN_TO_LABWARE_ORIGIN.y,
+        z=838.0 + _PARENT_ORIGIN_TO_LABWARE_ORIGIN.z,
     )
 
 


### PR DESCRIPTION
Closes [EXEC-1751](https://opentrons.atlassian.net/browse/EXEC-1751)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

When calculating the grip point, we currently use the center of the addressable area as our base position and adjust from there. This works currently, but it's more technically correct to grip from the expected labware bottom center position and apply offsets from that position. Doing so would in theory let us move labware that may not be in the center of an addressable area.
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- We're decently covered by CI already in terms of fundamentals (see risk assessment).
- I did simulate this protocol to do some regression testing via logging, confirming the grip point remained nearly identical (~0.1mm grip point difference):

```
from opentrons import protocol_api

# requirements
requirements = {"robotType": "Flex", "apiLevel": "2.25"}


# protocol run function
def run(protocol: protocol_api.ProtocolContext):
    tr1 = protocol.load_labware(
        load_name="opentrons_flex_96_tiprack_1000ul", location="C2"
    )

    protocol.move_labware(tr1, "C1", use_gripper=True)
```
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Grip point calculations are based off the expected bottom center labware position instead of the center of the addressable area.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
lowish-medium. If any labware definition gripper offsets were compensating hackily because we were using the center of the addressable area as the base position, they would be inaccurate now. That being said, it's easily to audit the existing definitions, and none appear to have been doing this from what I can tell.
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[EXEC-1751]: https://opentrons.atlassian.net/browse/EXEC-1751?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ