### PR TITLE
fix(app): support "go back" on detaching multiple pipettes, attaching 96ch

### DIFF
--- a/app/src/organisms/PipetteWizardFlows/index.tsx
+++ b/app/src/organisms/PipetteWizardFlows/index.tsx
@@ -135,7 +135,12 @@ export const PipetteWizardFlows = (
         if (currentStepIndex <= 2) {
           setCurrentStepIndex(0)
         } else {
-          setCurrentStepIndex(3)
+          const stepIdx =
+            pipetteWizardSteps?.findIndex(
+              step => step.section === SECTIONS.CARRIAGE
+            ) ?? 3 // Safe fallback that at least allows users to proceed.
+
+          setCurrentStepIndex(stepIdx)
         }
       } else {
         setCurrentStepIndex(0)


### PR DESCRIPTION
Closes [RQA-4598](https://opentrons.atlassian.net/browse/RQA-4598)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Whoops, https://github.com/Opentrons/opentrons/pull/19281 had the right idea, but we have a _separate_ set of steps when we are detaching _multiple_ pipettes before attaching the 96ch, which means we can't hardcode the `stepIndex`. Instead, we can do the right thing and find the step we care about and navigate to that one - that will work for both detaching a single or multiple pipettes before attaching the 96ch.

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- Tested both the single attachment and multi-attachment cases, ensuring "go back" works as expected.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed pressing "go back" on the multi-detach pipette + attach 96ch flow going back too far.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-4598]: https://opentrons.atlassian.net/browse/RQA-4598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ