### PR TITLE
feat(api): Add and implement task control actions

### DIFF
--- a/api/src/opentrons/protocol_engine/actions/__init__.py
+++ b/api/src/opentrons/protocol_engine/actions/__init__.py
@@ -28,6 +28,10 @@ from .actions import (
     DoorChangeAction,
     ResetTipsAction,
     SetPipetteMovementSpeedAction,
+    StartTaskAction,
+    CancelAllTasksAction,
+    CancelTaskAction,
+    FinishTaskAction,
 )
 from .get_state_update import get_state_updates
 
@@ -57,6 +61,10 @@ __all__ = [
     "DoorChangeAction",
     "ResetTipsAction",
     "SetPipetteMovementSpeedAction",
+    "StartTaskAction",
+    "CancelAllTasksAction",
+    "CancelTaskAction",
+    "FinishTaskAction",
     # action payload values
     "PauseSource",
     "FinishErrorDetails",

--- a/api/src/opentrons/protocol_engine/actions/__init__.py
+++ b/api/src/opentrons/protocol_engine/actions/__init__.py
@@ -29,8 +29,6 @@ from .actions import (
     ResetTipsAction,
     SetPipetteMovementSpeedAction,
     StartTaskAction,
-    CancelAllTasksAction,
-    CancelTaskAction,
     FinishTaskAction,
 )
 from .get_state_update import get_state_updates
@@ -62,8 +60,6 @@ __all__ = [
     "ResetTipsAction",
     "SetPipetteMovementSpeedAction",
     "StartTaskAction",
-    "CancelAllTasksAction",
-    "CancelTaskAction",
     "FinishTaskAction",
     # action payload values
     "PauseSource",

--- a/api/src/opentrons/protocol_engine/actions/actions.py
+++ b/api/src/opentrons/protocol_engine/actions/actions.py
@@ -220,21 +220,6 @@ class FinishTaskAction:
 
 
 @dataclasses.dataclass(frozen=True)
-class CancelTaskAction:
-    """Cancel task in state."""
-
-    task_id: str
-    message: str | None
-
-
-@dataclasses.dataclass(frozen=True)
-class CancelAllTasksAction:
-    """Cancel all the tasks in state."""
-
-    message: str | None
-
-
-@dataclasses.dataclass(frozen=True)
 class AddLabwareOffsetAction:
     """Add a labware offset, to apply to subsequent `LoadLabwareCommand`s."""
 
@@ -333,7 +318,5 @@ Action = Union[
     SetPipetteMovementSpeedAction,
     SetErrorRecoveryPolicyAction,
     StartTaskAction,
-    CancelAllTasksAction,
-    CancelTaskAction,
     FinishTaskAction,
 ]

--- a/api/src/opentrons/protocol_engine/actions/actions.py
+++ b/api/src/opentrons/protocol_engine/actions/actions.py
@@ -20,6 +20,7 @@ from ..commands import (
     CommandDefinedErrorData,
 )
 from ..error_recovery_policy import ErrorRecoveryPolicy, ErrorRecoveryType
+from ..errors import ErrorOccurrence
 from ..notes.notes import CommandNote
 from ..state.update_types import StateUpdate
 from ..types import (
@@ -27,6 +28,7 @@ from ..types import (
     ModuleDefinition,
     Liquid,
     DeckConfigurationType,
+    Task,
 )
 
 
@@ -202,6 +204,37 @@ class FailCommandAction:
 
 
 @dataclasses.dataclass(frozen=True)
+class StartTaskAction:
+    """Store new task in state."""
+
+    task: Task
+
+
+@dataclasses.dataclass(frozen=True)
+class FinishTaskAction:
+    """Mark task as finished in state."""
+
+    task_id: str
+    finished_at: datetime
+    error: ErrorOccurrence | None
+
+
+@dataclasses.dataclass(frozen=True)
+class CancelTaskAction:
+    """Cancel task in state."""
+
+    task_id: str
+    message: str | None
+
+
+@dataclasses.dataclass(frozen=True)
+class CancelAllTasksAction:
+    """Cancel all the tasks in state."""
+
+    message: str | None
+
+
+@dataclasses.dataclass(frozen=True)
 class AddLabwareOffsetAction:
     """Add a labware offset, to apply to subsequent `LoadLabwareCommand`s."""
 
@@ -299,4 +332,8 @@ Action = Union[
     ResetTipsAction,
     SetPipetteMovementSpeedAction,
     SetErrorRecoveryPolicyAction,
+    StartTaskAction,
+    CancelAllTasksAction,
+    CancelTaskAction,
+    FinishTaskAction,
 ]

--- a/api/src/opentrons/protocol_engine/execution/command_executor.py
+++ b/api/src/opentrons/protocol_engine/execution/command_executor.py
@@ -218,3 +218,7 @@ class CommandExecutor:
                         type=error_recovery_type,
                     )
                 )
+
+    def cancel_tasks(self, message: str | None = None) -> None:
+        """Cancel all concurrent tasks."""
+        self._task_handler.cancel_all(message=message)

--- a/api/src/opentrons/protocol_engine/execution/create_queue_worker.py
+++ b/api/src/opentrons/protocol_engine/execution/create_queue_worker.py
@@ -78,7 +78,7 @@ def create_queue_worker(
         hardware_api=hardware_api,
     )
     task_handler = TaskHandler(
-        state_store=state_store,
+        state_store=state_store, action_dispatcher=action_dispatcher
     )
     status_bar_handler = StatusBarHandler(hardware_api=hardware_api)
 

--- a/api/src/opentrons/protocol_engine/execution/queue_worker.py
+++ b/api/src/opentrons/protocol_engine/execution/queue_worker.py
@@ -51,6 +51,7 @@ class QueueWorker:
         """
         if self._worker_task:
             self._worker_task.cancel()
+            self._command_executor.cancel_tasks("Engine cancelled")
 
     async def join(self) -> None:
         """Wait for the worker to finish, propagating any errors."""
@@ -65,7 +66,10 @@ class QueueWorker:
                 pass
             except Exception as e:
                 log.error("Unhandled exception in QueueWorker job", exc_info=e)
+                self._command_executor.cancel_tasks("Engine failed")
                 raise e
+            else:
+                self._command_executor.cancel_tasks("Engine commands complete")
 
     async def _run_commands(self) -> None:
         async for command_id in self._command_generator():

--- a/api/src/opentrons/protocol_engine/execution/task_handler.py
+++ b/api/src/opentrons/protocol_engine/execution/task_handler.py
@@ -142,3 +142,14 @@ class TaskHandler:
     async def synchronize_concurrent(self, group_id: str) -> AsyncIterator[None]:
         """Run a list of tasks at the same time."""
         yield
+
+    def cancel_all(self, message: str | None = None) -> None:
+        """Cancel all asyncio tasks immediately.
+
+        Do not call this more than once synchronously because
+        that could lead to tasks cancelling more than once.
+        It can be called if there are no current tasks. In that case
+        nothing will happen.
+        """
+        for task in self._state_store.tasks.get_all_current():
+            task.asyncioTask.cancel(msg=message)

--- a/api/src/opentrons/protocol_engine/execution/task_handler.py
+++ b/api/src/opentrons/protocol_engine/execution/task_handler.py
@@ -51,8 +51,6 @@ class TaskHandler:
             id=task_id,
             createdAt=self._model_utils.get_timestamp(),
             asyncioTask=asyncio_task,
-            finishedAt=None,
-            error=None,
         )
 
     @staticmethod

--- a/api/src/opentrons/protocol_engine/execution/task_handler.py
+++ b/api/src/opentrons/protocol_engine/execution/task_handler.py
@@ -8,7 +8,9 @@ from ..resources import ModelUtils, ConcurrencyProvider
 from ..types import Task
 import asyncio
 import contextlib
-
+from ..actions import ActionDispatcher, FinishTaskAction
+from ..errors import ErrorOccurrence
+from opentrons_shared_data.errors.exceptions import EnumeratedError, PythonException
 
 log = logging.getLogger(__name__)
 
@@ -31,6 +33,7 @@ class TaskHandler:
     def __init__(
         self,
         state_store: StateStore,
+        action_dispatcher: ActionDispatcher,
         model_utils: ModelUtils | None = None,
         concurrency_provider: ConcurrencyProvider | None = None,
     ) -> None:
@@ -38,6 +41,7 @@ class TaskHandler:
         self._state_store = state_store
         self._model_utils = model_utils or ModelUtils()
         self._concurrency_provider = concurrency_provider or ConcurrencyProvider()
+        self._action_dispatcher = action_dispatcher
 
     async def create_task(
         self, task_function: TaskFunction, id: str | None = None
@@ -47,6 +51,38 @@ class TaskHandler:
         asyncio_task = asyncio.create_task(
             task_function(task_handler=self), name=f"engine-task-{task_id}"
         )
+
+        def _done_callback(task: asyncio.Task[None]) -> None:
+            try:
+                maybe_exception = task.exception()
+            except asyncio.CancelledError as e:
+                maybe_exception = e
+            if isinstance(maybe_exception, EnumeratedError):
+                occurence: ErrorOccurrence | None = ErrorOccurrence.from_failed(
+                    id=self._model_utils.generate_id(),
+                    createdAt=self._model_utils.get_timestamp(),
+                    error=maybe_exception,
+                )
+            elif isinstance(maybe_exception, BaseException):
+                occurence = ErrorOccurrence.from_failed(
+                    id=self._model_utils.generate_id(),
+                    createdAt=self._model_utils.get_timestamp(),
+                    error=PythonException(maybe_exception),
+                )
+            else:
+                occurence = None
+            try:
+                self._action_dispatcher.dispatch(
+                    FinishTaskAction(
+                        task_id=task_id,
+                        finished_at=self._model_utils.get_timestamp(),
+                        error=occurence,
+                    ),
+                )
+            except BaseException:
+                log.exception("Exception in task finish dispatch.")
+
+        asyncio_task.add_done_callback(_done_callback)
         return Task(
             id=task_id,
             createdAt=self._model_utils.get_timestamp(),

--- a/api/src/opentrons/protocol_engine/state/tasks.py
+++ b/api/src/opentrons/protocol_engine/state/tasks.py
@@ -76,6 +76,10 @@ class TaskView:
         except KeyError as e:
             raise NoTaskFoundError(f"No current task with ID {id}") from e
 
+    def get_all_current(self) -> list[Task]:
+        """Get all currently running tasks."""
+        return [task for task in self._state.current_tasks_by_id.values()]
+
     def get_finished(self, id: str) -> FinishedTask:
         """Get a finished task by ID."""
         try:

--- a/api/src/opentrons/protocol_engine/state/tasks.py
+++ b/api/src/opentrons/protocol_engine/state/tasks.py
@@ -1,19 +1,14 @@
 """Task state tracking."""
 from dataclasses import dataclass
 from itertools import chain
-from datetime import datetime
-from ..errors.exceptions import ProtocolEngineError
 from ..types import Task, TaskSummary, FinishedTask
 from ._abstract_store import HasState, HandlesActions
 from opentrons.protocol_engine.state import update_types
-from opentrons.protocol_engine.errors import ErrorOccurrence
 from opentrons.protocol_engine.errors.exceptions import NoTaskFoundError
 from ..actions import (
     get_state_updates,
     Action,
     StartTaskAction,
-    CancelAllTasksAction,
-    CancelTaskAction,
     FinishTaskAction,
 )
 
@@ -52,40 +47,6 @@ class TaskStore(HasState[TaskState], HandlesActions):
         )
         del self._state.current_tasks_by_id[action.task_id]
 
-    def _handle_cancel_task_action(self, action: CancelTaskAction) -> None:
-        task = self._state.current_tasks_by_id[action.task_id]
-        task.asyncioTask.cancel()
-        del self._state.current_tasks_by_id[action.task_id]
-        self._state.finished_tasks_by_id[action.task_id] = FinishedTask(
-            id=task.id,
-            createdAt=task.createdAt,
-            finishedAt=datetime.now(),
-            error=ErrorOccurrence.from_failed(
-                createdAt=task.createdAt,
-                id=action.task_id,
-                error=ProtocolEngineError(message=action.message),
-            ),
-        )
-
-    def _handle_cancel_all_tasks_action(self, action: CancelAllTasksAction) -> None:
-        all_tasks = list(self._state.current_tasks_by_id.values())
-        for task in all_tasks:
-            task.asyncioTask.cancel()
-
-        self._state.current_tasks_by_id.clear()
-
-        for task in all_tasks:
-            self._state.finished_tasks_by_id[task.id] = FinishedTask(
-                id=task.id,
-                createdAt=task.createdAt,
-                finishedAt=datetime.now(),
-                error=ErrorOccurrence.from_failed(
-                    createdAt=task.createdAt,
-                    id=task.id,
-                    error=ProtocolEngineError(message=action.message),
-                ),
-            )
-
     def handle_action(self, action: Action) -> None:
         """Modify the state in reaction to an action."""
         for state_update in get_state_updates(action):
@@ -95,10 +56,6 @@ class TaskStore(HasState[TaskState], HandlesActions):
                 self._handle_start_task_action(action)
             case FinishTaskAction():
                 self._handle_finish_task_action(action)
-            case CancelTaskAction():
-                self._handle_cancel_task_action(action)
-            case CancelAllTasksAction():
-                self._handle_cancel_all_tasks_action(action)
             case _:
                 pass
 

--- a/api/src/opentrons/protocol_engine/state/tasks.py
+++ b/api/src/opentrons/protocol_engine/state/tasks.py
@@ -1,17 +1,29 @@
 """Task state tracking."""
 from dataclasses import dataclass
-from ..types import Task, TaskSummary
+from itertools import chain
+from datetime import datetime
+from ..errors.exceptions import ProtocolEngineError
+from ..types import Task, TaskSummary, FinishedTask
 from ._abstract_store import HasState, HandlesActions
-from ..actions import Action, get_state_updates
 from opentrons.protocol_engine.state import update_types
+from opentrons.protocol_engine.errors import ErrorOccurrence
 from opentrons.protocol_engine.errors.exceptions import NoTaskFoundError
+from ..actions import (
+    get_state_updates,
+    Action,
+    StartTaskAction,
+    CancelAllTasksAction,
+    CancelTaskAction,
+    FinishTaskAction,
+)
 
 
 @dataclass
 class TaskState:
     """Task state tracking."""
 
-    tasks_by_id: dict[str, Task]
+    current_tasks_by_id: dict[str, Task]
+    finished_tasks_by_id: dict[str, FinishedTask]
 
 
 class TaskStore(HasState[TaskState], HandlesActions):
@@ -21,16 +33,74 @@ class TaskStore(HasState[TaskState], HandlesActions):
 
     def __init__(self) -> None:
         """Initialize a TaskStore."""
-        self._state = TaskState(tasks_by_id={})
-
-    def handle_action(self, action: Action) -> None:
-        """Handle an action."""
-        for state_update in get_state_updates(action):
-            self._handle_state_update(state_update)
+        self._state = TaskState(current_tasks_by_id={}, finished_tasks_by_id={})
 
     def _handle_state_update(self, state_update: update_types.StateUpdate) -> None:
         """Handle a state update."""
         return
+
+    def _handle_start_task_action(self, action: StartTaskAction) -> None:
+        self._state.current_tasks_by_id[action.task.id] = action.task
+
+    def _handle_finish_task_action(self, action: FinishTaskAction) -> None:
+        task = self._state.current_tasks_by_id[action.task_id]
+        self._state.finished_tasks_by_id[action.task_id] = FinishedTask(
+            id=task.id,
+            createdAt=task.createdAt,
+            finishedAt=action.finished_at,
+            error=action.error,
+        )
+        del self._state.current_tasks_by_id[action.task_id]
+
+    def _handle_cancel_task_action(self, action: CancelTaskAction) -> None:
+        task = self._state.current_tasks_by_id[action.task_id]
+        task.asyncioTask.cancel()
+        del self._state.current_tasks_by_id[action.task_id]
+        self._state.finished_tasks_by_id[action.task_id] = FinishedTask(
+            id=task.id,
+            createdAt=task.createdAt,
+            finishedAt=datetime.now(),
+            error=ErrorOccurrence.from_failed(
+                createdAt=task.createdAt,
+                id=action.task_id,
+                error=ProtocolEngineError(message=action.message),
+            ),
+        )
+
+    def _handle_cancel_all_tasks_action(self, action: CancelAllTasksAction) -> None:
+        all_tasks = list(self._state.current_tasks_by_id.values())
+        for task in all_tasks:
+            task.asyncioTask.cancel()
+
+        self._state.current_tasks_by_id.clear()
+
+        for task in all_tasks:
+            self._state.finished_tasks_by_id[task.id] = FinishedTask(
+                id=task.id,
+                createdAt=task.createdAt,
+                finishedAt=datetime.now(),
+                error=ErrorOccurrence.from_failed(
+                    createdAt=task.createdAt,
+                    id=task.id,
+                    error=ProtocolEngineError(message=action.message),
+                ),
+            )
+
+    def handle_action(self, action: Action) -> None:
+        """Modify the state in reaction to an action."""
+        for state_update in get_state_updates(action):
+            self._handle_state_update(state_update)
+        match action:
+            case StartTaskAction():
+                self._handle_start_task_action(action)
+            case FinishTaskAction():
+                self._handle_finish_task_action(action)
+            case CancelTaskAction():
+                self._handle_cancel_task_action(action)
+            case CancelAllTasksAction():
+                self._handle_cancel_all_tasks_action(action)
+            case _:
+                pass
 
 
 class TaskView:
@@ -42,21 +112,31 @@ class TaskView:
         """Initialize a TaskView."""
         self._state = state
 
-    def get(self, id: str) -> Task:
+    def get_current(self, id: str) -> Task:
         """Get a task by ID."""
         try:
-            return self._state.tasks_by_id[id]
+            return self._state.current_tasks_by_id[id]
         except KeyError as e:
-            raise NoTaskFoundError(f"No task with ID {id}") from e
+            raise NoTaskFoundError(f"No current task with ID {id}") from e
+
+    def get_finished(self, id: str) -> FinishedTask:
+        """Get a finished task by ID."""
+        try:
+            return self._state.finished_tasks_by_id[id]
+        except KeyError as e:
+            raise NoTaskFoundError(f"No finished task with ID {id}") from e
 
     def get_summary(self) -> list[TaskSummary]:
         """Get a summary of all tasks."""
         return [
             TaskSummary(
-                id=id,
+                id=task_id,
                 createdAt=task.createdAt,
-                finishedAt=task.finishedAt,
-                error=task.error,
+                finishedAt=getattr(task, "finishedAt", None),
+                error=getattr(task, "error", None),
             )
-            for id, task in self._state.tasks_by_id.items()
+            for task_id, task in chain(
+                self._state.current_tasks_by_id.items(),
+                self._state.finished_tasks_by_id.items(),
+            )
         ]

--- a/api/src/opentrons/protocol_engine/types/__init__.py
+++ b/api/src/opentrons/protocol_engine/types/__init__.py
@@ -147,7 +147,7 @@ from .labware_movement import LabwareMovementStrategy, LabwareMovementOffsetData
 from .tip import TipGeometry
 from .hardware_passthrough import MovementAxis, MotorAxis
 from .util import Vec3f, Dimensions
-from .tasks import Task, TaskSummary
+from .tasks import Task, TaskSummary, FinishedTask
 
 __all__ = [
     # Runtime parameters
@@ -311,4 +311,5 @@ __all__ = [
     # Tasks
     "Task",
     "TaskSummary",
+    "FinishedTask",
 ]

--- a/api/src/opentrons/protocol_engine/types/tasks.py
+++ b/api/src/opentrons/protocol_engine/types/tasks.py
@@ -6,13 +6,25 @@ import asyncio
 
 
 @dataclass
-class Task:
-    """A task representation."""
+class _BaseTask:
+    """A base task representation."""
 
     id: str
     createdAt: datetime
+
+
+@dataclass
+class Task(_BaseTask):
+    """A task representation."""
+
     asyncioTask: asyncio.Task[None]
-    finishedAt: datetime | None
+
+
+@dataclass
+class FinishedTask(_BaseTask):
+    """A finished task representation."""
+
+    finishedAt: datetime
     error: ErrorOccurrence | None
 
 

--- a/api/tests/opentrons/protocol_engine/execution/test_queue_worker.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_queue_worker.py
@@ -102,13 +102,13 @@ async def test_cancel(
     """It should stop pulling jobs if it is cancelled."""
     subject.start()
     subject.cancel()
-
     await subject.join()
 
     decoy.verify(
         await command_executor.execute(command_id=matchers.Anything()),
         times=0,
     )
+    decoy.verify(command_executor.cancel_tasks("Engine cancelled"), times=1)
 
 
 async def test_cancel_noops_if_joined(
@@ -121,6 +121,7 @@ async def test_cancel_noops_if_joined(
     subject.start()
     await subject.join()
     subject.cancel()
+    decoy.verify(command_executor.cancel_tasks("Engine commands complete"), times=1)
 
 
 async def test_unhandled_exception_breaks_loop(
@@ -138,6 +139,7 @@ async def test_unhandled_exception_breaks_loop(
 
     with pytest.raises(RuntimeError, match="oh no"):
         await subject.join()
+    decoy.verify(command_executor.cancel_tasks("Engine failed"), times=1)
 
 
 async def test_engine_stopped_exception_breaks_loop_gracefully(
@@ -153,3 +155,4 @@ async def test_engine_stopped_exception_breaks_loop_gracefully(
 
     subject.start()
     await subject.join()
+    decoy.verify(command_executor.cancel_tasks("Engine commands complete"), times=1)

--- a/api/tests/opentrons/protocol_engine/execution/test_task_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_task_handler.py
@@ -3,20 +3,33 @@
 import pytest
 import asyncio
 from datetime import datetime
-from decoy import Decoy
+from decoy import Decoy, matchers
 from opentrons.protocol_engine.execution.task_handler import TaskHandler
 from opentrons.protocol_engine.state.state import (
     StateStore,
 )
+from opentrons.protocol_engine.errors import ErrorOccurrence
+from opentrons_shared_data.errors.codes import ErrorCodes
+from opentrons_shared_data.errors.exceptions import RoboticsInteractionError
+
 from opentrons.protocol_engine.resources import (
     ModelUtils,
 )
+from opentrons.protocol_engine.actions import ActionDispatcher, FinishTaskAction
 
 
 @pytest.fixture
-def subject(state_store: StateStore, model_utils: ModelUtils) -> TaskHandler:
+def subject(
+    state_store: StateStore,
+    model_utils: ModelUtils,
+    action_dispatcher: ActionDispatcher,
+) -> TaskHandler:
     """Get a task handler to test."""
-    return TaskHandler(state_store=state_store, model_utils=model_utils)
+    return TaskHandler(
+        state_store=state_store,
+        model_utils=model_utils,
+        action_dispatcher=action_dispatcher,
+    )
 
 
 @pytest.fixture
@@ -31,8 +44,17 @@ def model_utils(decoy: Decoy) -> ModelUtils:
     return decoy.mock(cls=ModelUtils)
 
 
+@pytest.fixture
+def action_dispatcher(decoy: Decoy) -> ActionDispatcher:
+    """Get a mock action dispatcher."""
+    return decoy.mock(cls=ActionDispatcher)
+
+
 async def test_create_task(
-    subject: TaskHandler, decoy: Decoy, model_utils: ModelUtils
+    subject: TaskHandler,
+    decoy: Decoy,
+    model_utils: ModelUtils,
+    action_dispatcher: ActionDispatcher,
 ) -> None:
     """Create a task and run it."""
     task_ran = asyncio.Event()
@@ -42,36 +64,155 @@ async def test_create_task(
 
     created_timestamp = datetime.now()
     decoy.when(model_utils.get_timestamp()).then_return(created_timestamp)
+    decoy.when(model_utils.ensure_id(None)).then_return("create_timestamp")
+
     task = await subject.create_task(_task)
     await asyncio.wait_for(task_ran.wait(), timeout=0.25)
     await task.asyncioTask
     assert task.createdAt == created_timestamp
+    decoy.verify(
+        action_dispatcher.dispatch(
+            FinishTaskAction(
+                task_id=matchers.Anything(), finished_at=matchers.Anything(), error=None
+            )
+        ),
+        times=1,
+    )
 
 
 async def test_uses_passed_id(
-    subject: TaskHandler, decoy: Decoy, model_utils: ModelUtils
+    subject: TaskHandler,
+    decoy: Decoy,
+    model_utils: ModelUtils,
+    action_dispatcher: ActionDispatcher,
 ) -> None:
     """Should use provided id."""
 
     async def _task(task_handler: TaskHandler) -> None:
         await asyncio.sleep(0)
 
+    finished_at = datetime.now()
+    decoy.when(model_utils.get_timestamp()).then_return(finished_at)
     decoy.when(model_utils.ensure_id("testid1")).then_return("checked testid1")
     task = await subject.create_task(_task, id="testid1")
     assert task.id == "checked testid1"
+    await task.asyncioTask
+    decoy.verify(
+        action_dispatcher.dispatch(
+            FinishTaskAction(
+                task_id="checked testid1", finished_at=finished_at, error=None
+            )
+        ),
+        times=1,
+    )
 
 
 async def test_generates_id(
-    subject: TaskHandler, decoy: Decoy, model_utils: ModelUtils
+    subject: TaskHandler,
+    decoy: Decoy,
+    model_utils: ModelUtils,
+    action_dispatcher: ActionDispatcher,
 ) -> None:
     """It should generate an id if no id is provided."""
 
     async def _task(task_handler: TaskHandler) -> None:
         await asyncio.sleep(0)
 
+    finished_at = datetime.now()
+    decoy.when(model_utils.get_timestamp()).then_return(finished_at)
     decoy.when(model_utils.ensure_id(None)).then_return("testid2")
     task = await subject.create_task(_task)
     assert task.id == "testid2"
+    await task.asyncioTask
+    decoy.verify(
+        action_dispatcher.dispatch(
+            FinishTaskAction(task_id="testid2", finished_at=finished_at, error=None)
+        ),
+        times=1,
+    )
+
+
+async def test_generates_error(
+    subject: TaskHandler,
+    decoy: Decoy,
+    model_utils: ModelUtils,
+    action_dispatcher: ActionDispatcher,
+) -> None:
+    """It should generate an error."""
+
+    async def _task(task_handler: TaskHandler) -> None:
+        await asyncio.Event().wait()
+
+    finished_at = datetime.now()
+    decoy.when(model_utils.get_timestamp()).then_return(finished_at)
+    decoy.when(model_utils.generate_id()).then_return("errorid")
+    decoy.when(model_utils.ensure_id(None)).then_return("testid2")
+    task = await subject.create_task(_task)
+    task.asyncioTask.cancel(msg="hello")
+    try:
+        await asyncio.wait_for(task.asyncioTask, timeout=0.25)
+    except asyncio.CancelledError:
+        pass
+    decoy.verify(
+        action_dispatcher.dispatch(
+            FinishTaskAction(
+                task_id="testid2",
+                finished_at=finished_at,
+                error=ErrorOccurrence.model_construct(
+                    id="errorid",
+                    createdAt=finished_at,
+                    isDefined=False,
+                    errorType=matchers.Anything(),
+                    errorCode=ErrorCodes.GENERAL_ERROR.value.code,
+                    detail=matchers.Anything(),
+                    errorInfo=matchers.Anything(),
+                    wrappedErrors=matchers.Anything(),
+                ),
+            )
+        ),
+        times=1,
+    )
+
+
+async def test_generates_enumerated_error(
+    subject: TaskHandler,
+    decoy: Decoy,
+    model_utils: ModelUtils,
+    action_dispatcher: ActionDispatcher,
+) -> None:
+    """It should generate an enumerated error."""
+
+    async def _task(task_handler: TaskHandler) -> None:
+        raise RoboticsInteractionError()
+
+    finished_at = datetime.now()
+    decoy.when(model_utils.get_timestamp()).then_return(finished_at)
+    decoy.when(model_utils.generate_id()).then_return("errorid")
+    decoy.when(model_utils.ensure_id(None)).then_return("testid2")
+    task = await subject.create_task(_task)
+    try:
+        await asyncio.wait_for(task.asyncioTask, timeout=0.25)
+    except (asyncio.CancelledError, RoboticsInteractionError):
+        pass
+    decoy.verify(
+        action_dispatcher.dispatch(
+            FinishTaskAction(
+                task_id="testid2",
+                finished_at=finished_at,
+                error=ErrorOccurrence.model_construct(
+                    id="errorid",
+                    createdAt=finished_at,
+                    isDefined=False,
+                    errorType=matchers.Anything(),
+                    errorCode=ErrorCodes.ROBOTICS_INTERACTION_ERROR.value.code,
+                    detail=matchers.Anything(),
+                    errorInfo=matchers.Anything(),
+                    wrappedErrors=matchers.Anything(),
+                ),
+            )
+        ),
+        times=1,
+    )
 
 
 async def test_synchronization_cancel_latest(subject: TaskHandler) -> None:

--- a/api/tests/opentrons/protocol_engine/execution/test_task_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_task_handler.py
@@ -16,6 +16,7 @@ from opentrons.protocol_engine.resources import (
     ModelUtils,
 )
 from opentrons.protocol_engine.actions import ActionDispatcher, FinishTaskAction
+from opentrons.protocol_engine.types import Task
 
 
 @pytest.fixture
@@ -450,3 +451,14 @@ async def test_synchronize_concurrent(subject: TaskHandler) -> None:
     assert max(events.index("task1started"), events.index("task2started")) < min(
         events.index("task1finished"), events.index("task2finished")
     )
+
+
+async def test_cancel_all(
+    subject: TaskHandler, decoy: Decoy, state_store: StateStore
+) -> None:
+    """Test cancel all."""
+    mock_tasks = [decoy.mock(cls=Task) for i in range(3)]
+    decoy.when(state_store.tasks.get_all_current()).then_return(mock_tasks)
+    subject.cancel_all("cancel all")
+    for task in mock_tasks:
+        decoy.verify(task.asyncioTask.cancel(msg="cancel all"))

--- a/api/tests/opentrons/protocol_engine/execution/test_task_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_task_handler.py
@@ -216,6 +216,48 @@ async def test_generates_enumerated_error(
     )
 
 
+async def test_generates_cancelled_error(
+    subject: TaskHandler,
+    decoy: Decoy,
+    model_utils: ModelUtils,
+    action_dispatcher: ActionDispatcher,
+) -> None:
+    """It should generate an cancelled error."""
+
+    async def _task(task_handler: TaskHandler) -> None:
+        await asyncio.Event().wait()
+
+    finished_at = datetime.now()
+    decoy.when(model_utils.get_timestamp()).then_return(finished_at)
+    decoy.when(model_utils.generate_id()).then_return("errorid")
+    decoy.when(model_utils.ensure_id(None)).then_return("testid2")
+    task = await subject.create_task(_task)
+    task.asyncioTask.cancel(msg="Cancel task")
+    try:
+        await asyncio.wait_for(task.asyncioTask, timeout=0.25)
+    except (asyncio.CancelledError):
+        pass
+    decoy.verify(
+        action_dispatcher.dispatch(
+            FinishTaskAction(
+                task_id="testid2",
+                finished_at=finished_at,
+                error=ErrorOccurrence.model_construct(
+                    id="errorid",
+                    createdAt=finished_at,
+                    isDefined=False,
+                    errorType=matchers.Anything(),
+                    errorCode=ErrorCodes.GENERAL_ERROR.value.code,
+                    detail=matchers.StringMatching(r"(CancelledError)|(Cancel Task)"),
+                    errorInfo=matchers.Anything(),
+                    wrappedErrors=matchers.Anything(),
+                ),
+            )
+        ),
+        times=1,
+    )
+
+
 async def test_synchronization_cancel_latest(subject: TaskHandler) -> None:
     """Test cancel_lastest synchronization."""
     task1_started = asyncio.Event()

--- a/api/tests/opentrons/protocol_engine/state/test_task_state.py
+++ b/api/tests/opentrons/protocol_engine/state/test_task_state.py
@@ -1,9 +1,17 @@
 """Tests for TaskState+TaskStore+TaskView trifecta."""
 import pytest
 from opentrons.protocol_engine.state.tasks import TaskStore, TaskView
-from opentrons.protocol_engine.types import Task
+from opentrons.protocol_engine.types import Task, FinishedTask
+from opentrons.protocol_engine.errors import ErrorOccurrence
+from opentrons.protocol_engine.errors.exceptions import ProtocolEngineError
 from datetime import datetime
 import asyncio
+from opentrons.protocol_engine.actions.actions import (
+    StartTaskAction,
+    FinishTaskAction,
+    CancelTaskAction,
+    CancelAllTasksAction,
+)
 
 
 @pytest.fixture
@@ -12,27 +20,50 @@ def subject() -> TaskStore:
     return TaskStore()
 
 
-async def test_get(subject: TaskStore) -> None:
-    """It should get a task by ID."""
+async def test_get_current(subject: TaskStore) -> None:
+    """It should get a current task by ID."""
     task_id = "task-123"
     timestamp = datetime.now()
     asyncio_task = asyncio.create_task(asyncio.sleep(0))
-    subject._state.tasks_by_id[task_id] = Task(
+    subject._state.current_tasks_by_id[task_id] = Task(
         id=task_id,
         createdAt=timestamp,
-        finishedAt=None,
         asyncioTask=asyncio_task,
-        error=None,
     )
 
     view = TaskView(subject._state)
-    result = view.get(task_id)
+    result = view.get_current(task_id)
 
+    assert isinstance(result, Task)
     assert result.id == task_id
     assert result.createdAt == timestamp
     assert result.asyncioTask is asyncio_task
-    assert result.finishedAt is None
-    assert result.error is None
+    assert not hasattr(result, "finishedAt")
+    assert not hasattr(result, "error")
+    await asyncio_task
+
+
+async def test_get_finished(subject: TaskStore) -> None:
+    """It should get a finished task by ID."""
+    task_id = "task-123"
+    timestamp = datetime.now()
+    timestamp2 = datetime.now()
+    error = None
+    asyncio_task = asyncio.create_task(asyncio.sleep(0))
+
+    subject._state.finished_tasks_by_id[task_id] = FinishedTask(
+        id=task_id, createdAt=timestamp, finishedAt=timestamp2, error=error
+    )
+
+    view = TaskView(subject._state)
+    result = view.get_finished(task_id)
+
+    assert isinstance(result, FinishedTask)
+    assert result.id == task_id
+    assert result.createdAt == timestamp
+    assert not hasattr(result, "asyncioTask")
+    assert result.finishedAt == timestamp2
+    assert result.error == error
     await asyncio_task
 
 
@@ -40,29 +71,35 @@ async def test_get_summary(subject: TaskStore) -> None:
     """It should get a summary of all tasks."""
     task_id_1 = "task-123"
     task_id_2 = "task-456"
+    task_id_3 = "task-789"
     timestamp_1 = datetime.now()
     timestamp_2 = datetime.now()
+    timestamp_3 = datetime.now()
+    timestamp_4 = datetime.now()
     asyncio_task_1 = asyncio.create_task(asyncio.sleep(0))
     asyncio_task_2 = asyncio.create_task(asyncio.sleep(0))
-    subject._state.tasks_by_id[task_id_1] = Task(
+
+    subject._state.current_tasks_by_id[task_id_1] = Task(
         id=task_id_1,
         createdAt=timestamp_1,
-        finishedAt=None,
         asyncioTask=asyncio_task_1,
-        error=None,
     )
-    subject._state.tasks_by_id[task_id_2] = Task(
+    subject._state.current_tasks_by_id[task_id_2] = Task(
         id=task_id_2,
         createdAt=timestamp_2,
-        finishedAt=None,
         asyncioTask=asyncio_task_2,
+    )
+    subject._state.finished_tasks_by_id[task_id_3] = FinishedTask(
+        id=task_id_1,
+        createdAt=timestamp_3,
+        finishedAt=timestamp_4,
         error=None,
     )
 
     view = TaskView(subject._state)
     summary = view.get_summary()
 
-    assert len(summary) == 2
+    assert len(summary) == 3
     assert summary[0].id == task_id_1
     assert summary[0].createdAt == timestamp_1
     assert summary[0].finishedAt is None
@@ -72,4 +109,140 @@ async def test_get_summary(subject: TaskStore) -> None:
     assert summary[1].createdAt == timestamp_2
     assert summary[1].finishedAt is None
     assert summary[1].error is None
+
+    assert summary[2].id == task_id_3
+    assert summary[2].createdAt == timestamp_3
+    assert summary[2].finishedAt is timestamp_4
+    assert summary[2].error is None
+
     await asyncio.gather(asyncio_task_1, asyncio_task_2)
+
+
+async def test_handle_start_task_action(subject: TaskStore) -> None:
+    """It should store data about a start task action."""
+    timestamp_1 = datetime.now()
+    task_id_1 = "task123"
+    asyncio_task_1 = asyncio.create_task(asyncio.sleep(0))
+    await asyncio.gather(asyncio_task_1)
+
+    action_started = StartTaskAction(
+        task=Task(
+            id=task_id_1,
+            createdAt=timestamp_1,
+            asyncioTask=asyncio_task_1,
+        )
+    )
+    subject.handle_action(action_started)
+    task = subject._state.current_tasks_by_id[task_id_1]
+    assert task.id == task_id_1
+    assert task.createdAt == timestamp_1
+    assert task.asyncioTask == asyncio_task_1
+
+
+async def test_handle_finish_task_action(subject: TaskStore) -> None:
+    """It should store data about a finish task action."""
+    timestamp_1 = datetime.now()
+    timestamp_2 = datetime.now()
+    task_id_1 = "task123"
+    asyncio_task_1 = asyncio.create_task(asyncio.sleep(0))
+    await asyncio.gather(asyncio_task_1)
+
+    action_started = StartTaskAction(
+        task=Task(
+            id=task_id_1,
+            createdAt=timestamp_1,
+            asyncioTask=asyncio_task_1,
+        )
+    )
+    subject.handle_action(action_started)
+    assert task_id_1 in subject._state.current_tasks_by_id
+    action_finished = FinishTaskAction(
+        task_id=task_id_1, finished_at=timestamp_2, error=None
+    )
+    subject.handle_action(action_finished)
+    task_finished = subject._state.finished_tasks_by_id[task_id_1]
+    assert task_finished.id == task_id_1
+    assert task_finished.createdAt == timestamp_1
+    assert task_finished.finishedAt == timestamp_2
+    assert task_finished.error is None
+    assert not hasattr(task_finished, "asyncioTask")
+    assert task_id_1 not in subject._state.current_tasks_by_id
+
+
+async def test_handle_cancel_task_action(subject: TaskStore) -> None:
+    """It should store data about a cancelled task action."""
+    timestamp_1 = datetime.now()
+    task_id_1 = "task123"
+    message = "task canceled"
+    asyncio_task_1 = asyncio.create_task(asyncio.sleep(0))
+    await asyncio.gather(asyncio_task_1)
+    action_started = StartTaskAction(
+        task=Task(
+            id=task_id_1,
+            createdAt=timestamp_1,
+            asyncioTask=asyncio_task_1,
+        )
+    )
+    subject.handle_action(action_started)
+    assert task_id_1 in subject._state.current_tasks_by_id
+    action_cancelled = CancelTaskAction(task_id=task_id_1, message=message)
+    subject.handle_action(action_cancelled)
+    assert task_id_1 not in subject._state.current_tasks_by_id
+    task_finished = subject._state.finished_tasks_by_id[task_id_1]
+    assert task_finished.id == task_id_1
+    assert task_finished.error == ErrorOccurrence.from_failed(
+        createdAt=timestamp_1,
+        id=task_id_1,
+        error=ProtocolEngineError(message=message),
+    )
+    assert task_finished.createdAt == timestamp_1
+    assert not hasattr(task_finished, "asyncioTask")
+
+
+async def test_handle_cancel_all_tasks_action(subject: TaskStore) -> None:
+    """It should store data about all cancelled task actions."""
+    timestamp_1 = datetime.now()
+    timestamp_2 = datetime.now()
+    task_id_1 = "task123"
+    task_id_2 = "task345"
+    message = "task cancelled"
+    asyncio_task_1 = asyncio.create_task(asyncio.sleep(0))
+    asyncio_task_2 = asyncio.create_task(asyncio.sleep(0))
+    await asyncio.gather(asyncio_task_1, asyncio_task_2)
+    action_started_1 = StartTaskAction(
+        task=Task(
+            id=task_id_1,
+            createdAt=timestamp_1,
+            asyncioTask=asyncio_task_1,
+        )
+    )
+    action_started_2 = StartTaskAction(
+        task=Task(
+            id=task_id_2,
+            createdAt=timestamp_2,
+            asyncioTask=asyncio_task_2,
+        )
+    )
+    subject.handle_action(action_started_1)
+    subject.handle_action(action_started_2)
+    assert task_id_1, task_id_2 in subject._state.current_tasks_by_id
+    action_cancelled = CancelAllTasksAction(message=message)
+    subject.handle_action(action_cancelled)
+    assert task_id_1, task_id_2 not in subject._state.current_tasks_by_id
+    view = TaskView(subject._state)
+    summary = view.get_summary()
+    assert len(summary) == 2
+    assert summary[0].id == task_id_1
+    assert summary[0].createdAt == timestamp_1
+    assert summary[0].error == ErrorOccurrence.from_failed(
+        createdAt=timestamp_1,
+        id=task_id_1,
+        error=ProtocolEngineError(message=message),
+    )
+    assert summary[1].id == task_id_2
+    assert summary[1].createdAt == timestamp_2
+    assert summary[1].error == ErrorOccurrence.from_failed(
+        createdAt=timestamp_2,
+        id=task_id_2,
+        error=ProtocolEngineError(message=message),
+    )

--- a/api/tests/opentrons/protocol_engine/state/test_task_state.py
+++ b/api/tests/opentrons/protocol_engine/state/test_task_state.py
@@ -2,15 +2,11 @@
 import pytest
 from opentrons.protocol_engine.state.tasks import TaskStore, TaskView
 from opentrons.protocol_engine.types import Task, FinishedTask
-from opentrons.protocol_engine.errors import ErrorOccurrence
-from opentrons.protocol_engine.errors.exceptions import ProtocolEngineError
 from datetime import datetime
 import asyncio
 from opentrons.protocol_engine.actions.actions import (
     StartTaskAction,
     FinishTaskAction,
-    CancelTaskAction,
-    CancelAllTasksAction,
 )
 
 
@@ -167,82 +163,3 @@ async def test_handle_finish_task_action(subject: TaskStore) -> None:
     assert task_finished.error is None
     assert not hasattr(task_finished, "asyncioTask")
     assert task_id_1 not in subject._state.current_tasks_by_id
-
-
-async def test_handle_cancel_task_action(subject: TaskStore) -> None:
-    """It should store data about a cancelled task action."""
-    timestamp_1 = datetime.now()
-    task_id_1 = "task123"
-    message = "task canceled"
-    asyncio_task_1 = asyncio.create_task(asyncio.sleep(0))
-    await asyncio.gather(asyncio_task_1)
-    action_started = StartTaskAction(
-        task=Task(
-            id=task_id_1,
-            createdAt=timestamp_1,
-            asyncioTask=asyncio_task_1,
-        )
-    )
-    subject.handle_action(action_started)
-    assert task_id_1 in subject._state.current_tasks_by_id
-    action_cancelled = CancelTaskAction(task_id=task_id_1, message=message)
-    subject.handle_action(action_cancelled)
-    assert task_id_1 not in subject._state.current_tasks_by_id
-    task_finished = subject._state.finished_tasks_by_id[task_id_1]
-    assert task_finished.id == task_id_1
-    assert task_finished.error == ErrorOccurrence.from_failed(
-        createdAt=timestamp_1,
-        id=task_id_1,
-        error=ProtocolEngineError(message=message),
-    )
-    assert task_finished.createdAt == timestamp_1
-    assert not hasattr(task_finished, "asyncioTask")
-
-
-async def test_handle_cancel_all_tasks_action(subject: TaskStore) -> None:
-    """It should store data about all cancelled task actions."""
-    timestamp_1 = datetime.now()
-    timestamp_2 = datetime.now()
-    task_id_1 = "task123"
-    task_id_2 = "task345"
-    message = "task cancelled"
-    asyncio_task_1 = asyncio.create_task(asyncio.sleep(0))
-    asyncio_task_2 = asyncio.create_task(asyncio.sleep(0))
-    await asyncio.gather(asyncio_task_1, asyncio_task_2)
-    action_started_1 = StartTaskAction(
-        task=Task(
-            id=task_id_1,
-            createdAt=timestamp_1,
-            asyncioTask=asyncio_task_1,
-        )
-    )
-    action_started_2 = StartTaskAction(
-        task=Task(
-            id=task_id_2,
-            createdAt=timestamp_2,
-            asyncioTask=asyncio_task_2,
-        )
-    )
-    subject.handle_action(action_started_1)
-    subject.handle_action(action_started_2)
-    assert task_id_1, task_id_2 in subject._state.current_tasks_by_id
-    action_cancelled = CancelAllTasksAction(message=message)
-    subject.handle_action(action_cancelled)
-    assert task_id_1, task_id_2 not in subject._state.current_tasks_by_id
-    view = TaskView(subject._state)
-    summary = view.get_summary()
-    assert len(summary) == 2
-    assert summary[0].id == task_id_1
-    assert summary[0].createdAt == timestamp_1
-    assert summary[0].error == ErrorOccurrence.from_failed(
-        createdAt=timestamp_1,
-        id=task_id_1,
-        error=ProtocolEngineError(message=message),
-    )
-    assert summary[1].id == task_id_2
-    assert summary[1].createdAt == timestamp_2
-    assert summary[1].error == ErrorOccurrence.from_failed(
-        createdAt=timestamp_2,
-        id=task_id_2,
-        error=ProtocolEngineError(message=message),
-    )


### PR DESCRIPTION
# Overview

Add and implement task control actions to track tasks starting and finishing.
This also makes sure that tasks are completed when the engine finishes, making the lifespan of tasks and engine equal to each other.  
Tasks are categorized as current or finished to reduce number of optional arguments.


Closes  EXEC-1698