### PR TITLE
feat(api): add EMPTY tip rack well state to protocol engine tip store

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/drop_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/drop_tip.py
@@ -12,7 +12,7 @@ from opentrons.protocol_engine.errors.exceptions import TipAttachedError
 from opentrons.protocol_engine.resources.model_utils import ModelUtils
 
 from ..state.update_types import StateUpdate
-from ..types import DropTipWellLocation
+from ..types import DropTipWellLocation, TipRackWellState
 from .pipetting_common import (
     PipetteIdMixin,
     TipPhysicallyAttachedError,
@@ -140,6 +140,25 @@ class DropTipImplementation(AbstractCommandImpl[DropTipParams, _ExecuteReturn]):
             partially_configured=is_partially_configured,
         )
 
+        is_tip_rack = self._state_view.labware.get_definition(
+            labware_id
+        ).parameters.isTiprack
+
+        # It's possible that we are dropping tips into a labware trash for pre API v2.14 OT-2 protocols
+        # (or something else unexpected), so if it is not a tip rack mark no wells as used
+        if is_tip_rack:
+            tips_to_mark_as_used = (
+                self._state_view.tips.compute_tips_to_mark_as_used_or_empty(
+                    labware_id=labware_id,
+                    well_name=well_name,
+                    nozzle_map=self._state_view.pipettes.get_nozzle_configuration(
+                        pipette_id
+                    ),
+                )
+            )
+        else:
+            tips_to_mark_as_used = []
+
         move_result = await move_to_well(
             movement=self._movement_handler,
             model_utils=self._model_utils,
@@ -152,12 +171,7 @@ class DropTipImplementation(AbstractCommandImpl[DropTipParams, _ExecuteReturn]):
             return move_result
 
         scrape_type = TipScrapeType.NONE
-        if (
-            params.scrape_tips
-            and self._state_view.geometry._labware.get_definition(
-                labware_id
-            ).parameters.isTiprack
-        ):
+        if params.scrape_tips and is_tip_rack:
             if int("".join(filter(str.isdigit, well_name))) <= 6:
                 scrape_type = TipScrapeType.RIGHT_ONE_COL
             else:
@@ -201,10 +215,16 @@ class DropTipImplementation(AbstractCommandImpl[DropTipParams, _ExecuteReturn]):
                 public=DropTipResult(position=move_result.public.position),
                 state_update=move_result.state_update.set_fluid_unknown(
                     pipette_id=pipette_id
-                ).update_pipette_tip_state(
+                )
+                .update_pipette_tip_state(
                     pipette_id=params.pipetteId,
                     tip_geometry=None,
                     tip_source=None,
+                )
+                .update_tip_rack_well_state(
+                    tip_state=TipRackWellState.USED,
+                    labware_id=labware_id,
+                    well_names=tips_to_mark_as_used,
                 ),
             )
 

--- a/api/src/opentrons/protocol_engine/commands/drop_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/drop_tip.py
@@ -208,6 +208,10 @@ class DropTipImplementation(AbstractCommandImpl[DropTipParams, _ExecuteReturn]):
                     pipette_id=params.pipetteId,
                     tip_geometry=None,
                     tip_source=None,
+                ).update_tip_rack_well_state(
+                    tip_state=TipRackWellState.USED,
+                    labware_id=labware_id,
+                    well_names=tips_to_mark_as_used,
                 ),
             )
         else:

--- a/api/src/opentrons/protocol_engine/commands/pick_up_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/pick_up_tip.py
@@ -10,7 +10,7 @@ from typing_extensions import Literal
 from ..errors import ErrorOccurrence, PickUpTipTipNotAttachedError
 from ..resources import ModelUtils
 from ..state import update_types
-from ..types import PickUpTipWellLocation, LabwareWellId
+from ..types import PickUpTipWellLocation, LabwareWellId, TipRackWellState
 from .pipetting_common import (
     PipetteIdMixin,
 )
@@ -160,16 +160,20 @@ class PickUpTipImplementation(AbstractCommandImpl[PickUpTipParams, _ExecuteRetur
                     ),
                 )
                 .set_fluid_empty(pipette_id=pipette_id, clean_tip=True)
-                .mark_tips_as_used(
-                    labware_id=labware_id, well_names=tips_to_mark_as_used
+                .update_tip_rack_well_state(
+                    tip_state=TipRackWellState.EMPTY,
+                    labware_id=labware_id,
+                    well_names=tips_to_mark_as_used,
                 )
             )
             state_update = (
                 update_types.StateUpdate.reduce(
                     update_types.StateUpdate(), move_result.state_update
                 )
-                .mark_tips_as_used(
-                    labware_id=labware_id, well_names=tips_to_mark_as_used
+                .update_tip_rack_well_state(
+                    tip_state=TipRackWellState.EMPTY,
+                    labware_id=labware_id,
+                    well_names=tips_to_mark_as_used,
                 )
                 .set_fluid_unknown(pipette_id=pipette_id)
             )
@@ -197,8 +201,10 @@ class PickUpTipImplementation(AbstractCommandImpl[PickUpTipParams, _ExecuteRetur
                         labware_id=labware_id, well_name=well_name
                     ),
                 )
-                .mark_tips_as_used(
-                    labware_id=labware_id, well_names=tips_to_mark_as_used
+                .update_tip_rack_well_state(
+                    tip_state=TipRackWellState.EMPTY,
+                    labware_id=labware_id,
+                    well_names=tips_to_mark_as_used,
                 )
                 .set_fluid_empty(pipette_id=pipette_id, clean_tip=True)
                 .set_pipette_ready_to_aspirate(

--- a/api/src/opentrons/protocol_engine/commands/pick_up_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/pick_up_tip.py
@@ -121,10 +121,14 @@ class PickUpTipImplementation(AbstractCommandImpl[PickUpTipParams, _ExecuteRetur
         labware_id = params.labwareId
         well_name = params.wellName
 
-        tips_to_mark_as_used = self._state_view.tips.compute_tips_to_mark_as_used(
-            labware_id=labware_id,
-            well_name=well_name,
-            nozzle_map=self._state_view.pipettes.get_nozzle_configuration(pipette_id),
+        tips_to_mark_as_empty = (
+            self._state_view.tips.compute_tips_to_mark_as_used_or_empty(
+                labware_id=labware_id,
+                well_name=well_name,
+                nozzle_map=self._state_view.pipettes.get_nozzle_configuration(
+                    pipette_id
+                ),
+            )
         )
 
         well_location = self._state_view.geometry.convert_pick_up_tip_well_location(
@@ -163,7 +167,7 @@ class PickUpTipImplementation(AbstractCommandImpl[PickUpTipParams, _ExecuteRetur
                 .update_tip_rack_well_state(
                     tip_state=TipRackWellState.EMPTY,
                     labware_id=labware_id,
-                    well_names=tips_to_mark_as_used,
+                    well_names=tips_to_mark_as_empty,
                 )
             )
             state_update = (
@@ -173,7 +177,7 @@ class PickUpTipImplementation(AbstractCommandImpl[PickUpTipParams, _ExecuteRetur
                 .update_tip_rack_well_state(
                     tip_state=TipRackWellState.EMPTY,
                     labware_id=labware_id,
-                    well_names=tips_to_mark_as_used,
+                    well_names=tips_to_mark_as_empty,
                 )
                 .set_fluid_unknown(pipette_id=pipette_id)
             )
@@ -204,7 +208,7 @@ class PickUpTipImplementation(AbstractCommandImpl[PickUpTipParams, _ExecuteRetur
                 .update_tip_rack_well_state(
                     tip_state=TipRackWellState.EMPTY,
                     labware_id=labware_id,
-                    well_names=tips_to_mark_as_used,
+                    well_names=tips_to_mark_as_empty,
                 )
                 .set_fluid_empty(pipette_id=pipette_id, clean_tip=True)
                 .set_pipette_ready_to_aspirate(

--- a/api/src/opentrons/protocol_engine/state/tips.py
+++ b/api/src/opentrons/protocol_engine/state/tips.py
@@ -55,10 +55,11 @@ class TipStore(HasState[TipState], HandlesActions):
                 ] = TipRackWellState.CLEAN
 
     def _handle_state_update(self, state_update: update_types.StateUpdate) -> None:
-        if state_update.tips_used != update_types.NO_CHANGE:
-            self._set_used_tips(
-                labware_id=state_update.tips_used.labware_id,
-                well_names=state_update.tips_used.well_names,
+        if state_update.tips_state != update_types.NO_CHANGE:
+            self._set_tip_state(
+                labware_id=state_update.tips_state.labware_id,
+                well_names=state_update.tips_state.well_names,
+                tip_state=state_update.tips_state.tip_state,
             )
 
         if state_update.loaded_labware != update_types.NO_CHANGE:
@@ -88,10 +89,12 @@ class TipStore(HasState[TipState], HandlesActions):
                         column for column in definition.ordering
                     ]
 
-    def _set_used_tips(self, labware_id: str, well_names: Iterable[str]) -> None:
+    def _set_tip_state(
+        self, labware_id: str, well_names: Iterable[str], tip_state: TipRackWellState
+    ) -> None:
         well_states = self._state.tips_by_labware_id.get(labware_id, {})
         for well_name in well_names:
-            well_states[well_name] = TipRackWellState.USED
+            well_states[well_name] = tip_state
 
 
 class TipView:

--- a/api/src/opentrons/protocol_engine/state/tips.py
+++ b/api/src/opentrons/protocol_engine/state/tips.py
@@ -1,11 +1,11 @@
 """Tip state tracking."""
 
 from dataclasses import dataclass
-from enum import Enum
 from typing import Dict, Iterable, Optional, List, Set
 
 from opentrons.types import NozzleMapInterface, NozzleConfigurationType
 from opentrons.protocol_engine.state import update_types
+from opentrons.protocol_engine.types import TipRackWellState
 
 from ._abstract_store import HasState, HandlesActions
 from ._well_math import (
@@ -18,14 +18,7 @@ from ..actions import Action, ResetTipsAction, get_state_updates
 from opentrons.hardware_control.nozzle_manager import NozzleMap
 
 
-class _TipRackWellState(Enum):
-    """The state of a single tip in a tip rack's well."""
-
-    CLEAN = "clean"
-    USED = "used"
-
-
-_TipRackStateByWellName = Dict[str, _TipRackWellState]
+_TipRackStateByWellName = Dict[str, TipRackWellState]
 
 
 @dataclass
@@ -59,7 +52,7 @@ class TipStore(HasState[TipState], HandlesActions):
             for well_name in self._state.tips_by_labware_id[labware_id].keys():
                 self._state.tips_by_labware_id[labware_id][
                     well_name
-                ] = _TipRackWellState.CLEAN
+                ] = TipRackWellState.CLEAN
 
     def _handle_state_update(self, state_update: update_types.StateUpdate) -> None:
         if state_update.tips_used != update_types.NO_CHANGE:
@@ -73,7 +66,7 @@ class TipStore(HasState[TipState], HandlesActions):
             definition = state_update.loaded_labware.definition
             if definition.parameters.isTiprack:
                 self._state.tips_by_labware_id[labware_id] = {
-                    well_name: _TipRackWellState.CLEAN
+                    well_name: TipRackWellState.CLEAN
                     for column in definition.ordering
                     for well_name in column
                 }
@@ -87,7 +80,7 @@ class TipStore(HasState[TipState], HandlesActions):
                 ]
                 if definition.parameters.isTiprack:
                     self._state.tips_by_labware_id[labware_id] = {
-                        well_name: _TipRackWellState.CLEAN
+                        well_name: TipRackWellState.CLEAN
                         for column in definition.ordering
                         for well_name in column
                     }
@@ -98,7 +91,12 @@ class TipStore(HasState[TipState], HandlesActions):
     def _set_used_tips(self, labware_id: str, well_names: Iterable[str]) -> None:
         well_states = self._state.tips_by_labware_id.get(labware_id, {})
         for well_name in well_names:
-            well_states[well_name] = _TipRackWellState.USED
+            well_states[well_name] = TipRackWellState.USED
+
+    def _set_empty_tips(self, labware_id: str, well_names: Iterable[str]) -> None:
+        well_states = self._state.tips_by_labware_id.get(labware_id, {})
+        for well_name in well_names:
+            well_states[well_name] = TipRackWellState.EMPTY
 
 
 class TipView:
@@ -143,9 +141,7 @@ class TipView:
                                 starting_column_index = idx
 
                 for column in columns[starting_column_index:]:
-                    if not any(
-                        wells[well] == _TipRackWellState.USED for well in column
-                    ):
+                    if not any(wells[well] == TipRackWellState.USED for well in column):
                         return column[0]
 
             elif num_tips == len(wells.keys()):  # Get next tips for 96 channel
@@ -153,7 +149,7 @@ class TipView:
                     return None
 
                 if not any(
-                    tip_state == _TipRackWellState.USED for tip_state in wells.values()
+                    tip_state == TipRackWellState.USED for tip_state in wells.values()
                 ):
                     return next(iter(wells))
 
@@ -162,7 +158,7 @@ class TipView:
                     wells = _drop_wells_before_starting_tip(wells, starting_tip_name)
 
                 for well_name, tip_state in wells.items():
-                    if tip_state == _TipRackWellState.CLEAN:
+                    if tip_state == TipRackWellState.CLEAN:
                         return well_name
         return None
 
@@ -181,9 +177,7 @@ class TipView:
                 return False
             # If not all the tips we'll be picking up are clean it's not valid
             target_well_states = [tip_well_states[well_name] for well_name in well_list]
-            if not all(
-                state == _TipRackWellState.CLEAN for state in target_well_states
-            ):
+            if not all(state == TipRackWellState.CLEAN for state in target_well_states):
                 return False
             # Since we know a full configuration will always produce zero non-active overlapping wells
             # we can skip the following checks if it is a full configuration.
@@ -201,7 +195,7 @@ class TipView:
                     for well_name in wells_covered_physically.difference(well_list)
                 ]
                 if not all(
-                    well_state == _TipRackWellState.USED
+                    well_state == TipRackWellState.USED
                     for well_state in wells_in_way_well_state
                 ):
                     return False
@@ -214,7 +208,7 @@ class TipView:
         for well in target_well_list:
             # If the target well/tip isn't clean, skip to the next one. This will be checked
             # again in _validate_wells, but we can short circuit the following checks if this is False
-            if tip_well_states[well] != _TipRackWellState.CLEAN:
+            if tip_well_states[well] != TipRackWellState.CLEAN:
                 continue
             # Get list of all wells (i.e. tips) that would be covered by the active nozzles
             targeted_wells = set(
@@ -244,7 +238,7 @@ class TipView:
         tip_rack = self._state.tips_by_labware_id.get(labware_id)
         well_state = tip_rack.get(well_name) if tip_rack else None
 
-        return well_state == _TipRackWellState.CLEAN
+        return well_state == TipRackWellState.CLEAN
 
     def compute_tips_to_mark_as_used(
         self, labware_id: str, well_name: str, nozzle_map: NozzleMap
@@ -276,7 +270,7 @@ def _drop_wells_before_starting_tip(
 ) -> _TipRackStateByWellName:
     """Drop any wells that come before the starting tip and return the remaining ones after."""
     seen_starting_well = False
-    remaining_wells: dict[str, _TipRackWellState] = {}
+    remaining_wells: dict[str, TipRackWellState] = {}
     for well_name, tip_state in wells.items():
         if well_name == starting_tip_name:
             seen_starting_well = True

--- a/api/src/opentrons/protocol_engine/state/tips.py
+++ b/api/src/opentrons/protocol_engine/state/tips.py
@@ -93,11 +93,6 @@ class TipStore(HasState[TipState], HandlesActions):
         for well_name in well_names:
             well_states[well_name] = TipRackWellState.USED
 
-    def _set_empty_tips(self, labware_id: str, well_names: Iterable[str]) -> None:
-        well_states = self._state.tips_by_labware_id.get(labware_id, {})
-        for well_name in well_names:
-            well_states[well_name] = TipRackWellState.EMPTY
-
 
 class TipView:
     """Read-only tip state view."""
@@ -141,15 +136,15 @@ class TipView:
                                 starting_column_index = idx
 
                 for column in columns[starting_column_index:]:
-                    if not any(wells[well] == TipRackWellState.USED for well in column):
+                    if all(wells[well] == TipRackWellState.CLEAN for well in column):
                         return column[0]
 
             elif num_tips == len(wells.keys()):  # Get next tips for 96 channel
                 if starting_tip_name and starting_tip_name != columns[0][0]:
                     return None
 
-                if not any(
-                    tip_state == TipRackWellState.USED for tip_state in wells.values()
+                if all(
+                    tip_state == TipRackWellState.CLEAN for tip_state in wells.values()
                 ):
                     return next(iter(wells))
 
@@ -194,8 +189,10 @@ class TipView:
                     tip_well_states[well_name]
                     for well_name in wells_covered_physically.difference(well_list)
                 ]
-                if not all(
-                    well_state == TipRackWellState.USED
+                # TODO(jbl 2025-08-25) this should be changed to ensure all these extra wells are EMPTY when further
+                #   tip return work occurs
+                if any(
+                    well_state == TipRackWellState.CLEAN
                     for well_state in wells_in_way_well_state
                 ):
                     return False

--- a/api/src/opentrons/protocol_engine/state/tips.py
+++ b/api/src/opentrons/protocol_engine/state/tips.py
@@ -240,10 +240,10 @@ class TipView:
 
         return well_state == TipRackWellState.CLEAN
 
-    def compute_tips_to_mark_as_used(
+    def compute_tips_to_mark_as_used_or_empty(
         self, labware_id: str, well_name: str, nozzle_map: NozzleMap
     ) -> list[str]:
-        """Compute which tips a hypothetical tip pickup should mark as "used".
+        """Compute which tips a hypothetical tip pickup/drop should mark as "used" or "empty".
 
         Params:
             labware_id: The labware ID of the tip rack.

--- a/api/src/opentrons/protocol_engine/state/update_types.py
+++ b/api/src/opentrons/protocol_engine/state/update_types.py
@@ -236,21 +236,6 @@ class PipetteAspirateReadyUpdate:
 
 
 @dataclasses.dataclass
-class TipsUsedUpdate:
-    """Represents an update that marks tips in a tip rack as used."""
-
-    labware_id: str
-    """The labware ID of the tip rack."""
-
-    well_names: list[str]
-    """The exact wells in the tip rack that should be marked as used.
-
-    This is the *full* list, which is probably more than what appeared in the pickUpTip
-    command's params, for multi-channel reasons.
-    """
-
-
-@dataclasses.dataclass
 class TipsStateUpdate:
     """Represents an update that marks tips in a tip rack as the requested state."""
 
@@ -469,8 +454,6 @@ class StateUpdate:
     loaded_lid_stack: LoadedLidStackUpdate | NoChangeType = NO_CHANGE
 
     labware_lid: LabwareLidUpdate | NoChangeType = NO_CHANGE
-
-    tips_used: TipsUsedUpdate | NoChangeType = NO_CHANGE
 
     tips_state: TipsStateUpdate | NoChangeType = NO_CHANGE
 
@@ -750,17 +733,12 @@ class StateUpdate:
         return self
 
     def update_tip_rack_well_state(
-        self: Self, tip_state: TipRackWellState, labware_id: str, well_name: list[str]
+        self: Self, tip_state: TipRackWellState, labware_id: str, well_names: list[str]
     ) -> Self:
         """Marks tips in a tip rack to provided tip state. See `TipsStateUpdate`."""
         self.tips_state = TipsStateUpdate(
-            tip_state=tip_state, labware_id=labware_id, well_names=well_name
+            tip_state=tip_state, labware_id=labware_id, well_names=well_names
         )
-        return self
-
-    def mark_tips_as_used(self: Self, labware_id: str, well_names: list[str]) -> Self:
-        """Mark tips in a tip rack as used. See `TipsUsedUpdate`."""
-        self.tips_used = TipsUsedUpdate(labware_id=labware_id, well_names=well_names)
         return self
 
     def set_liquid_loaded(

--- a/api/src/opentrons/protocol_engine/state/update_types.py
+++ b/api/src/opentrons/protocol_engine/state/update_types.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import dataclasses
 import enum
 import typing
-from typing_extensions import Self, Optional
+from typing_extensions import Self
 from datetime import datetime
 
 from opentrons.hardware_control.nozzle_manager import NozzleMap
@@ -15,6 +15,7 @@ from opentrons.protocol_engine.types import (
     LabwareLocation,
     OnLabwareLocation,
     TipGeometry,
+    TipRackWellState,
     AspiratedFluid,
     LiquidClassRecord,
     ABSMeasureMode,
@@ -250,6 +251,23 @@ class TipsUsedUpdate:
 
 
 @dataclasses.dataclass
+class TipsStateUpdate:
+    """Represents an update that marks tips in a tip rack as the requested state."""
+
+    tip_state: TipRackWellState
+
+    labware_id: str
+    """The labware ID of the tip rack."""
+
+    well_names: list[str]
+    """The exact wells in the tip rack that should be marked as used.
+
+    This is the *full* list, which is probably more than what appeared in the pickUpTip
+    command's params, for multi-channel reasons.
+    """
+
+
+@dataclasses.dataclass
 class LiquidLoadedUpdate:
     """An update from loading a liquid."""
 
@@ -413,7 +431,7 @@ class LoadModuleUpdate:
     definition: ModuleDefinition
     slot_name: DeckSlotName
     requested_model: ModuleModel
-    serial_number: Optional[str]
+    serial_number: typing.Optional[str]
 
 
 @dataclasses.dataclass
@@ -453,6 +471,8 @@ class StateUpdate:
     labware_lid: LabwareLidUpdate | NoChangeType = NO_CHANGE
 
     tips_used: TipsUsedUpdate | NoChangeType = NO_CHANGE
+
+    tips_state: TipsStateUpdate | NoChangeType = NO_CHANGE
 
     liquid_loaded: LiquidLoadedUpdate | NoChangeType = NO_CHANGE
 
@@ -682,7 +702,7 @@ class StateUpdate:
         definition: ModuleDefinition,
         slot_name: DeckSlotName,
         requested_model: ModuleModel,
-        serial_number: Optional[str],
+        serial_number: typing.Optional[str],
     ) -> Self:
         """Add a new module to state. See `LoadModuleUpdate`."""
         self.loaded_module = LoadModuleUpdate(
@@ -726,6 +746,15 @@ class StateUpdate:
             pipette_id=pipette_id,
             tip_geometry=tip_geometry,
             tip_source=tip_source,
+        )
+        return self
+
+    def update_tip_rack_well_state(
+        self: Self, tip_state: TipRackWellState, labware_id: str, well_name: list[str]
+    ) -> Self:
+        """Marks tips in a tip rack to provided tip state. See `TipsStateUpdate`."""
+        self.tips_state = TipsStateUpdate(
+            tip_state=tip_state, labware_id=labware_id, well_names=well_name
         )
         return self
 

--- a/api/src/opentrons/protocol_engine/types/__init__.py
+++ b/api/src/opentrons/protocol_engine/types/__init__.py
@@ -144,7 +144,7 @@ from .liquid_level_detection import (
 )
 from .liquid_handling import FlowRates
 from .labware_movement import LabwareMovementStrategy, LabwareMovementOffsetData
-from .tip import TipGeometry
+from .tip import TipGeometry, TipRackWellState
 from .hardware_passthrough import MovementAxis, MotorAxis
 from .util import Vec3f, Dimensions
 from .tasks import Task, TaskSummary
@@ -300,6 +300,7 @@ __all__ = [
     "LabwareMovementOffsetData",
     # Tips
     "TipGeometry",
+    "TipRackWellState",
     # Hardware passthrough
     "MovementAxis",
     "MotorAxis",

--- a/api/src/opentrons/protocol_engine/types/tip.py
+++ b/api/src/opentrons/protocol_engine/types/tip.py
@@ -1,6 +1,7 @@
 """Protocol Engine types to deal with tips."""
 
 from dataclasses import dataclass
+from enum import Enum
 
 
 @dataclass(frozen=True)
@@ -16,3 +17,11 @@ class TipGeometry:
     length: float
     diameter: float
     volume: float
+
+
+class TipRackWellState(Enum):
+    """The state of a single tip in a tip rack's well."""
+
+    CLEAN = "clean"
+    USED = "used"
+    EMPTY = "empty"

--- a/api/tests/opentrons/protocol_engine/commands/test_drop_tip.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_drop_tip.py
@@ -4,8 +4,13 @@ from datetime import datetime
 
 import pytest
 from decoy import Decoy, matchers
+from unittest.mock import sentinel
 
 from opentrons_shared_data.errors.exceptions import StallOrCollisionDetectedError
+from opentrons_shared_data.labware.labware_definition import (
+    LabwareDefinition2,
+    Parameters2,
+)
 
 from opentrons.protocol_engine import (
     DropTipWellLocation,
@@ -28,7 +33,7 @@ from opentrons.protocol_engine.errors.exceptions import TipAttachedError
 from opentrons.protocol_engine.resources.model_utils import ModelUtils
 from opentrons.protocol_engine.state import update_types
 from opentrons.protocol_engine.state.state import StateView
-from opentrons.protocol_engine.types import LabwareWellId
+from opentrons.protocol_engine.types import LabwareWellId, TipRackWellState
 from opentrons.protocol_engine.execution import MovementHandler, TipHandler
 
 
@@ -123,6 +128,20 @@ async def test_drop_tip_implementation(
         )
     ).then_return(WellLocation(offset=WellOffset(x=4, y=5, z=6)))
 
+    decoy.when(mock_state_view.labware.get_definition("123")).then_return(
+        LabwareDefinition2.model_construct(  # type: ignore[call-arg]
+            parameters=Parameters2.model_construct(isTiprack=True),  # type: ignore[call-arg]
+        )
+    )
+    decoy.when(mock_state_view.pipettes.get_nozzle_configuration("abc")).then_return(
+        sentinel.nozzle_configuration
+    )
+    decoy.when(
+        mock_state_view.tips.compute_tips_to_mark_as_used_or_empty(
+            "123", "A3", sentinel.nozzle_configuration
+        )
+    ).then_return(sentinel.tips_to_mark_as_used)
+
     decoy.when(
         await mock_movement_handler.move_to_well(
             pipette_id="abc",
@@ -157,6 +176,11 @@ async def test_drop_tip_implementation(
             ),
             pipette_aspirated_fluid=update_types.PipetteUnknownFluidUpdate(
                 pipette_id="abc"
+            ),
+            tips_state=update_types.TipsStateUpdate(
+                tip_state=TipRackWellState.USED,
+                labware_id="123",
+                well_names=sentinel.tips_to_mark_as_used,
             ),
         ),
     )
@@ -213,6 +237,12 @@ async def test_drop_tip_with_alternating_locations(
         )
     ).then_return(WellLocation(offset=WellOffset(x=4, y=5, z=6)))
 
+    decoy.when(mock_state_view.labware.get_definition("123")).then_return(
+        LabwareDefinition2.model_construct(  # type: ignore[call-arg]
+            parameters=Parameters2.model_construct(isTiprack=False),  # type: ignore[call-arg]
+        )
+    )
+
     decoy.when(
         await mock_movement_handler.move_to_well(
             pipette_id="abc",
@@ -246,6 +276,11 @@ async def test_drop_tip_with_alternating_locations(
             ),
             pipette_aspirated_fluid=update_types.PipetteUnknownFluidUpdate(
                 pipette_id="abc"
+            ),
+            tips_state=update_types.TipsStateUpdate(
+                tip_state=TipRackWellState.USED,
+                labware_id="123",
+                well_names=[],
             ),
         ),
     )
@@ -286,6 +321,20 @@ async def test_tip_attached_error(
             partially_configured=False,
         )
     ).then_return(WellLocation(offset=WellOffset(x=4, y=5, z=6)))
+
+    decoy.when(mock_state_view.labware.get_definition("123")).then_return(
+        LabwareDefinition2.model_construct(  # type: ignore[call-arg]
+            parameters=Parameters2.model_construct(isTiprack=True),  # type: ignore[call-arg]
+        )
+    )
+    decoy.when(mock_state_view.pipettes.get_nozzle_configuration("abc")).then_return(
+        sentinel.nozzle_configuration
+    )
+    decoy.when(
+        mock_state_view.tips.compute_tips_to_mark_as_used_or_empty(
+            "123", "A3", sentinel.nozzle_configuration
+        )
+    ).then_return(sentinel.tips_to_mark_as_used)
 
     decoy.when(
         await mock_movement_handler.move_to_well(
@@ -385,6 +434,12 @@ async def test_stall_error(
             partially_configured=False,
         )
     ).then_return(WellLocation(offset=WellOffset(x=4, y=5, z=6)))
+
+    decoy.when(mock_state_view.labware.get_definition("123")).then_return(
+        LabwareDefinition2.model_construct(  # type: ignore[call-arg]
+            parameters=Parameters2.model_construct(isTiprack=False),  # type: ignore[call-arg]
+        )
+    )
 
     decoy.when(
         await mock_movement_handler.move_to_well(

--- a/api/tests/opentrons/protocol_engine/commands/test_drop_tip.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_drop_tip.py
@@ -396,6 +396,11 @@ async def test_tip_attached_error(
                 ),
                 new_deck_point=DeckPoint(x=111, y=222, z=333),
             ),
+            tips_state=update_types.TipsStateUpdate(
+                tip_state=TipRackWellState.USED,
+                labware_id="123",
+                well_names=sentinel.tips_to_mark_as_used,
+            ),
         ),
     )
 

--- a/api/tests/opentrons/protocol_engine/commands/test_pick_up_tip.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_pick_up_tip.py
@@ -21,7 +21,7 @@ from opentrons.protocol_engine.execution import MovementHandler, TipHandler
 from opentrons.protocol_engine.resources import ModelUtils
 from opentrons.protocol_engine.state import update_types
 from opentrons.protocol_engine.state.state import StateView
-from opentrons.protocol_engine.types import TipGeometry, LabwareWellId
+from opentrons.protocol_engine.types import TipGeometry, LabwareWellId, TipRackWellState
 
 from opentrons.protocol_engine.commands.movement_common import StallOrCollisionError
 from opentrons.protocol_engine.commands.command import DefinedErrorData, SuccessData
@@ -114,8 +114,10 @@ async def test_success(
                 tip_geometry=TipGeometry(length=42, diameter=5, volume=300),
                 tip_source=LabwareWellId(labware_id="labware-id", well_name="A3"),
             ),
-            tips_used=update_types.TipsUsedUpdate(
-                labware_id="labware-id", well_names=sentinel.tips_to_mark_as_used
+            tips_state=update_types.TipsStateUpdate(
+                tip_state=TipRackWellState.EMPTY,
+                labware_id="labware-id",
+                well_names=sentinel.tips_to_mark_as_used,
             ),
             pipette_aspirated_fluid=update_types.PipetteEmptyFluidUpdate(
                 pipette_id="pipette-id", clean_tip=True
@@ -200,8 +202,10 @@ async def test_tip_physically_missing_error(
                 ),
                 new_deck_point=DeckPoint(x=111, y=222, z=333),
             ),
-            tips_used=update_types.TipsUsedUpdate(
-                labware_id="labware-id", well_names=sentinel.tips_to_mark_as_used
+            tips_state=update_types.TipsStateUpdate(
+                tip_state=TipRackWellState.EMPTY,
+                labware_id="labware-id",
+                well_names=sentinel.tips_to_mark_as_used,
             ),
             pipette_aspirated_fluid=update_types.PipetteUnknownFluidUpdate(
                 pipette_id="pipette-id"
@@ -218,8 +222,10 @@ async def test_tip_physically_missing_error(
             pipette_aspirated_fluid=update_types.PipetteEmptyFluidUpdate(
                 pipette_id="pipette-id", clean_tip=True
             ),
-            tips_used=update_types.TipsUsedUpdate(
-                labware_id="labware-id", well_names=sentinel.tips_to_mark_as_used
+            tips_state=update_types.TipsStateUpdate(
+                tip_state=TipRackWellState.EMPTY,
+                labware_id="labware-id",
+                well_names=sentinel.tips_to_mark_as_used,
             ),
             pipette_location=update_types.PipetteLocationUpdate(
                 pipette_id="pipette-id",

--- a/api/tests/opentrons/protocol_engine/commands/test_pick_up_tip.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_pick_up_tip.py
@@ -82,7 +82,7 @@ async def test_success(
         sentinel.nozzle_configuration
     )
     decoy.when(
-        state_view.tips.compute_tips_to_mark_as_used(
+        state_view.tips.compute_tips_to_mark_as_used_or_empty(
             "labware-id", "A3", sentinel.nozzle_configuration
         )
     ).then_return(sentinel.tips_to_mark_as_used)
@@ -181,7 +181,7 @@ async def test_tip_physically_missing_error(
         sentinel.nozzle_configuration
     )
     decoy.when(
-        state_view.tips.compute_tips_to_mark_as_used(
+        state_view.tips.compute_tips_to_mark_as_used_or_empty(
             labware_id, well_name, sentinel.nozzle_configuration
         )
     ).then_return(sentinel.tips_to_mark_as_used)

--- a/api/tests/opentrons/protocol_engine/state/test_tip_state.py
+++ b/api/tests/opentrons/protocol_engine/state/test_tip_state.py
@@ -18,6 +18,7 @@ from opentrons.protocol_engine.state.tips import TipStore, TipView
 from opentrons.protocol_engine.types import (
     DeckSlotLocation,
     OFF_DECK_LOCATION,
+    TipRackWellState,
 )
 from opentrons.types import DeckSlotName
 from opentrons_shared_data.pipette.types import PipetteNameType
@@ -195,7 +196,8 @@ def test_get_next_tip_skips_picked_up_tip(
     nozzle_map = get_default_nozzle_map(pipette_name_type)
 
     pick_up_tip_state_update = update_types.StateUpdate(
-        tips_used=update_types.TipsUsedUpdate(
+        tips_state=update_types.TipsStateUpdate(
+            tip_state=TipRackWellState.EMPTY,
             labware_id="cool-labware",
             well_names=TipView(subject.state).compute_tips_to_mark_as_used(
                 labware_id="cool-labware", well_name="A1", nozzle_map=nozzle_map
@@ -237,7 +239,8 @@ def test_get_next_tip_with_starting_tip(
     assert result == "B2"
 
     pick_up_tip_state_update = update_types.StateUpdate(
-        tips_used=update_types.TipsUsedUpdate(
+        tips_state=update_types.TipsStateUpdate(
+            tip_state=TipRackWellState.EMPTY,
             labware_id="cool-labware",
             well_names=TipView(subject.state).compute_tips_to_mark_as_used(
                 labware_id="cool-labware", well_name="B2", nozzle_map=nozzle_map
@@ -278,7 +281,8 @@ def test_get_next_tip_with_starting_tip_8_channel(
     assert result == "A2"
 
     pick_up_tip_state_update = update_types.StateUpdate(
-        tips_used=update_types.TipsUsedUpdate(
+        tips_state=update_types.TipsStateUpdate(
+            tip_state=TipRackWellState.EMPTY,
             labware_id="cool-labware",
             well_names=TipView(subject.state).compute_tips_to_mark_as_used(
                 labware_id="cool-labware", well_name="A2", nozzle_map=nozzle_map
@@ -321,7 +325,8 @@ def test_get_next_tip_with_1_channel_followed_by_8_channel(
     assert result == "A1"
 
     pick_up_tip_1_channel_state_update = update_types.StateUpdate(
-        tips_used=update_types.TipsUsedUpdate(
+        tips_state=update_types.TipsStateUpdate(
+            tip_state=TipRackWellState.EMPTY,
             labware_id="cool-labware",
             well_names=TipView(subject.state).compute_tips_to_mark_as_used(
                 labware_id="cool-labware",
@@ -362,7 +367,8 @@ def test_get_next_tip_with_starting_tip_out_of_tips(
     assert result == "H12"
 
     pick_up_tip_state_update = update_types.StateUpdate(
-        tips_used=update_types.TipsUsedUpdate(
+        tips_state=update_types.TipsStateUpdate(
+            tip_state=TipRackWellState.EMPTY,
             labware_id="cool-labware",
             well_names=TipView(subject.state).compute_tips_to_mark_as_used(
                 labware_id="cool-labware",
@@ -416,7 +422,8 @@ def test_reset_tips(
         actions.SucceedCommandAction(
             command=_dummy_command(),
             state_update=update_types.StateUpdate(
-                tips_used=update_types.TipsUsedUpdate(
+                tips_state=update_types.TipsStateUpdate(
+                    tip_state=TipRackWellState.EMPTY,
                     labware_id="cool-labware",
                     well_names=["A1", "A2", "A3"],
                 )
@@ -485,7 +492,8 @@ def test_next_tip_automatic_tip_tracking_with_partial_configurations(
         assert result is not None and result == expected_next_tip
 
         pick_up_tip_state_update = update_types.StateUpdate(
-            tips_used=update_types.TipsUsedUpdate(
+            tips_state=update_types.TipsStateUpdate(
+                tip_state=TipRackWellState.EMPTY,
                 labware_id="cool-labware",
                 well_names=TipView(subject.state).compute_tips_to_mark_as_used(
                     labware_id="cool-labware", well_name=result, nozzle_map=nozzle_map
@@ -591,7 +599,8 @@ def test_next_tip_automatic_tip_tracking_tiprack_limits(
         )
         if result is not None:
             pick_up_tip_state_update = update_types.StateUpdate(
-                tips_used=update_types.TipsUsedUpdate(
+                tips_state=update_types.TipsStateUpdate(
+                    tip_state=TipRackWellState.EMPTY,
                     labware_id="cool-labware",
                     well_names=TipView(subject.state).compute_tips_to_mark_as_used(
                         labware_id="cool-labware",
@@ -681,7 +690,8 @@ def test_96_column_after_row_returns_none(
         )
         if result is not None:
             pick_up_tip_state_update = update_types.StateUpdate(
-                tips_used=update_types.TipsUsedUpdate(
+                tips_state=update_types.TipsStateUpdate(
+                    tip_state=TipRackWellState.EMPTY,
                     labware_id="cool-labware",
                     well_names=TipView(subject.state).compute_tips_to_mark_as_used(
                         labware_id="cool-labware",

--- a/api/tests/opentrons/protocol_engine/state/test_tip_state.py
+++ b/api/tests/opentrons/protocol_engine/state/test_tip_state.py
@@ -199,7 +199,7 @@ def test_get_next_tip_skips_picked_up_tip(
         tips_state=update_types.TipsStateUpdate(
             tip_state=TipRackWellState.EMPTY,
             labware_id="cool-labware",
-            well_names=TipView(subject.state).compute_tips_to_mark_as_used(
+            well_names=TipView(subject.state).compute_tips_to_mark_as_used_or_empty(
                 labware_id="cool-labware", well_name="A1", nozzle_map=nozzle_map
             ),
         )
@@ -242,7 +242,7 @@ def test_get_next_tip_with_starting_tip(
         tips_state=update_types.TipsStateUpdate(
             tip_state=TipRackWellState.EMPTY,
             labware_id="cool-labware",
-            well_names=TipView(subject.state).compute_tips_to_mark_as_used(
+            well_names=TipView(subject.state).compute_tips_to_mark_as_used_or_empty(
                 labware_id="cool-labware", well_name="B2", nozzle_map=nozzle_map
             ),
         )
@@ -284,7 +284,7 @@ def test_get_next_tip_with_starting_tip_8_channel(
         tips_state=update_types.TipsStateUpdate(
             tip_state=TipRackWellState.EMPTY,
             labware_id="cool-labware",
-            well_names=TipView(subject.state).compute_tips_to_mark_as_used(
+            well_names=TipView(subject.state).compute_tips_to_mark_as_used_or_empty(
                 labware_id="cool-labware", well_name="A2", nozzle_map=nozzle_map
             ),
         )
@@ -328,7 +328,7 @@ def test_get_next_tip_with_1_channel_followed_by_8_channel(
         tips_state=update_types.TipsStateUpdate(
             tip_state=TipRackWellState.EMPTY,
             labware_id="cool-labware",
-            well_names=TipView(subject.state).compute_tips_to_mark_as_used(
+            well_names=TipView(subject.state).compute_tips_to_mark_as_used_or_empty(
                 labware_id="cool-labware",
                 well_name="A1",
                 nozzle_map=nozzle_map_1_channel,
@@ -370,7 +370,7 @@ def test_get_next_tip_with_starting_tip_out_of_tips(
         tips_state=update_types.TipsStateUpdate(
             tip_state=TipRackWellState.EMPTY,
             labware_id="cool-labware",
-            well_names=TipView(subject.state).compute_tips_to_mark_as_used(
+            well_names=TipView(subject.state).compute_tips_to_mark_as_used_or_empty(
                 labware_id="cool-labware",
                 well_name="H12",
                 nozzle_map=get_default_nozzle_map(PipetteNameType.P300_SINGLE_GEN2),
@@ -495,7 +495,7 @@ def test_next_tip_automatic_tip_tracking_with_partial_configurations(
             tips_state=update_types.TipsStateUpdate(
                 tip_state=TipRackWellState.EMPTY,
                 labware_id="cool-labware",
-                well_names=TipView(subject.state).compute_tips_to_mark_as_used(
+                well_names=TipView(subject.state).compute_tips_to_mark_as_used_or_empty(
                     labware_id="cool-labware", well_name=result, nozzle_map=nozzle_map
                 ),
             )
@@ -602,7 +602,9 @@ def test_next_tip_automatic_tip_tracking_tiprack_limits(
                 tips_state=update_types.TipsStateUpdate(
                     tip_state=TipRackWellState.EMPTY,
                     labware_id="cool-labware",
-                    well_names=TipView(subject.state).compute_tips_to_mark_as_used(
+                    well_names=TipView(
+                        subject.state
+                    ).compute_tips_to_mark_as_used_or_empty(
                         labware_id="cool-labware",
                         well_name=result,
                         nozzle_map=nozzle_map,
@@ -693,7 +695,9 @@ def test_96_column_after_row_returns_none(
                 tips_state=update_types.TipsStateUpdate(
                     tip_state=TipRackWellState.EMPTY,
                     labware_id="cool-labware",
-                    well_names=TipView(subject.state).compute_tips_to_mark_as_used(
+                    well_names=TipView(
+                        subject.state
+                    ).compute_tips_to_mark_as_used_or_empty(
                         labware_id="cool-labware",
                         well_name=result,
                         nozzle_map=nozzle_map,


### PR DESCRIPTION
# Overview

Closes AUTH-2160

This PR introduces a third tip rack well state, `EMPTY`, in addition to the existing ones of `CLEAN` and `USED` while not introducing any new behavior.

This idea behind this third state is to be able discern between a tip rack well that does not have any tip currently in it and a tip rack well that has a tip that's been returned after being used. We were previously using `USED` for both of these states, which was a blocker for implementing partial tip return.

In this PR there is no change in behavior for picking or dropping tips or determining whether a tip is clean or has been used, but we are now more accurately marking the tip wells as `EMPTY` after a `pickupTip` and `USED` after a `dropTip` into a tip rack.

This PR also refactors some of the state updates, changing `TipsUsedUpdate` into a more generic `TipsStateUpdate` that now also takes a `TipRackWellState` and sets all given wells in the tip rack to that state.

## Test Plan and Hands on Testing

Since there is no change in observable behavior unit tests and integration tests should cover any potential regressions.

## Changelog

- Add a `TipRackWellState.EMPTY` state for tip rack wells
- Set tip racks well to `EMPTY` after a `pickupTip` command
- Set tip rack wells to `USED` after a `dropTip` command
- Refactor `TipsUsedUpdate` to a `TipsStateUpdate`

## Review requests


## Risk assessment

Low-medium, tip pickup and drop are pretty core parts of any protocol, but the actual changes to logic are pretty straightforward to handle the new state, and there is no changes to tip pick up, tracking and dropping behaviors in the PR