### PR TITLE
feat(step-generation): wire up return tip in step generation

### DIFF
--- a/step-generation/src/__tests__/consolidate.test.ts
+++ b/step-generation/src/__tests__/consolidate.test.ts
@@ -3706,3 +3706,82 @@ describe.skip('consolidate multi-channel', () => {
 
   it.todo('multi-channel trough A1 A2 A3 A4 to 96-plate A12')
 })
+
+describe('consolidate: return tip', () => {
+  let allArgs: ConsolidateArgs
+  beforeEach(() => {
+    allArgs = {
+      ...mixinArgs,
+      volume: 60,
+      sourceWells: ['A1', 'A2', 'A3'],
+      destWellName: 'B1',
+      tipRack: getLabwareDefURI(fixtureTiprack300ul as LabwareDefinition2),
+      dropTipLocation: 'fixture/fixture_tiprack_300_ul/1',
+      changeTip: 'always',
+      stepNumber: 1,
+    } as ConsolidateArgs
+  })
+
+  it('emits python correctly for a simple 1 to 3, single channel distribute', () => {
+    const consolidateArgs = allArgs as ConsolidateArgs
+    const result = consolidate(
+      consolidateArgs,
+      invariantContext,
+      robotStatePickedUpOneTip
+    )
+    const res = getSuccessResult(result)
+    expect(res.python).toEqual(
+      `
+mock_pipette.consolidate_with_liquid_class(
+    volume=60,
+    source=[mock_source_plate["A1"], mock_source_plate["A2"], mock_source_plate["A3"]],
+    dest=[mock_dest_plate["B1"]],
+    new_tip="always",
+    return_tip=True,
+    tip_racks=[mock_tip_rack_1, mock_tip_rack_2],
+    liquid_class=protocol.define_liquid_class(
+        name="consolidate_step_1",
+        properties={"p300_single": {"fixture/fixture_tiprack_300_ul/1": {
+            "aspirate": {
+                "aspirate_position": {"offset": {"x": 0, "y": 0}},
+                "flow_rate_by_volume": [(0, 2.1)],
+                "pre_wet": False,
+                "correction_by_volume": [(0, 0)],
+                "delay": {"enabled": False},
+                "mix": {"enabled": False},
+                "submerge": {
+                    "delay": {"enabled": False},
+                    "start_position": {"offset": {}},
+                },
+                "retract": {
+                    "air_gap_by_volume": [(0, 0)],
+                    "delay": {"enabled": False},
+                    "end_position": {"offset": {}},
+                    "touch_tip": {"enabled": False},
+                },
+            },
+            "dispense": {
+                "dispense_position": {"offset": {"x": 0, "y": 0}},
+                "flow_rate_by_volume": [(0, 2.2)],
+                "delay": {"enabled": False},
+                "submerge": {
+                    "delay": {"enabled": False},
+                    "start_position": {"offset": {}},
+                },
+                "retract": {
+                    "air_gap_by_volume": [(0, 0)],
+                    "delay": {"enabled": False},
+                    "end_position": {"offset": {}},
+                    "touch_tip": {"enabled": False},
+                    "blowout": {"enabled": False},
+                },
+                "correction_by_volume": [(0, 0)],
+                "push_out_by_volume": [(0, 0)],
+                "mix": {"enabled": False},
+            },
+        }}},
+    ),
+)`.trimStart()
+    )
+  })
+})

--- a/step-generation/src/__tests__/distribute.test.ts
+++ b/step-generation/src/__tests__/distribute.test.ts
@@ -2248,3 +2248,100 @@ describe('distribute volume exceeds pipette max volume', () => {
     expect(res.errors[0].type).toEqual('PIPETTE_VOLUME_EXCEEDED')
   })
 })
+
+describe('distribute: return tip', () => {
+  let allArgs: DistributeArgs
+  beforeEach(() => {
+    allArgs = {
+      ...mixinArgs,
+      volume: 60,
+      sourceWell: 'A1',
+      destWells: ['A2', 'A3', 'A4'],
+      tipRack: getLabwareDefURI(fixtureTiprack300ul as LabwareDefinition2),
+      dropTipLocation: 'fixture/fixture_tiprack_300_ul/1',
+      changeTip: 'always',
+    } as DistributeArgs
+  })
+
+  it('emits python correctly for a simple 1 to 3, single channel distribute', () => {
+    const distributeArgs = allArgs as DistributeArgs
+    const result = distribute(
+      distributeArgs,
+      invariantContext,
+      robotStateWithTip
+    )
+    const res = getSuccessResult(result)
+    expect(res.python).toEqual(
+      `
+mock_pipette.distribute_with_liquid_class(
+    volume=60,
+    source=[mock_source_plate["A1"]],
+    dest=[mock_dest_plate["A2"], mock_dest_plate["A3"], mock_dest_plate["A4"]],
+    new_tip="always",
+    return_tip=True,
+    tip_racks=[mock_tip_rack_1, mock_tip_rack_2],
+    liquid_class=protocol.define_liquid_class(
+        name="distribute_step_1",
+        properties={"p300_single": {"fixture/fixture_tiprack_300_ul/1": {
+            "aspirate": {
+                "aspirate_position": {"offset": {"x": 0, "y": 0, "z": 0}},
+                "flow_rate_by_volume": [(0, 2.1)],
+                "pre_wet": False,
+                "correction_by_volume": [(0, 0)],
+                "delay": {"enabled": False},
+                "mix": {"enabled": False},
+                "submerge": {
+                    "delay": {"enabled": False},
+                    "start_position": {"offset": {}},
+                },
+                "retract": {
+                    "air_gap_by_volume": [(0, 0)],
+                    "delay": {"enabled": False},
+                    "end_position": {"offset": {}},
+                    "touch_tip": {"enabled": False},
+                },
+            },
+            "dispense": {
+                "dispense_position": {"offset": {"x": 0, "y": 0, "z": 0}},
+                "flow_rate_by_volume": [(0, 2.2)],
+                "delay": {"enabled": False},
+                "submerge": {
+                    "delay": {"enabled": False},
+                    "start_position": {"offset": {}},
+                },
+                "retract": {
+                    "air_gap_by_volume": [(0, 0)],
+                    "delay": {"enabled": False},
+                    "end_position": {"offset": {}},
+                    "touch_tip": {"enabled": False},
+                    "blowout": {"enabled": True, "location": "trash", "flow_rate": 2.3},
+                },
+                "correction_by_volume": [(0, 0)],
+                "push_out_by_volume": [(0, 0)],
+                "mix": {"enabled": False},
+            },
+            "multi_dispense": {
+                "dispense_position": {"offset": {"x": 0, "y": 0, "z": 0}},
+                "flow_rate_by_volume": [(0, 2.2)],
+                "delay": {"enabled": False},
+                "submerge": {
+                    "delay": {"enabled": False},
+                    "start_position": {"offset": {}},
+                },
+                "retract": {
+                    "air_gap_by_volume": [(0, 0)],
+                    "delay": {"enabled": False},
+                    "end_position": {"offset": {}},
+                    "touch_tip": {"enabled": False},
+                    "blowout": {"enabled": True, "location": "trash", "flow_rate": 2.3},
+                },
+                "correction_by_volume": [(0, 0)],
+                "conditioning_by_volume": [(0, 0)],
+                "disposal_by_volume": [(0, 60)],
+            },
+        }}},
+    ),
+)`.trimStart()
+    )
+  })
+})

--- a/step-generation/src/__tests__/mix.test.ts
+++ b/step-generation/src/__tests__/mix.test.ts
@@ -825,3 +825,85 @@ describe('mix: errors', () => {
   it.todo('"times" arg non-integer')
   it.todo('"times" arg negative')
 })
+
+describe('mix: return tip', () => {
+  let args: MixArgs
+  beforeEach(() => {
+    args = {
+      ...mixinArgs,
+      volume: 8,
+      times: 2,
+      dropTipLocation: 'fixture/fixture_tiprack_300_ul/1',
+      wells: ['A1', 'B1', 'C1'],
+      changeTip: 'always',
+    } as MixArgs
+  })
+  it('should return tip if changeTip is always', () => {
+    args.dropTipLocation = 'fixture/fixture_tiprack_300_ul/1'
+    args.wells = ['A1', 'B1', 'C1']
+    args.changeTip = 'always'
+    const result = mix(args, invariantContext, robotStateWithTip)
+    expect(getSuccessResult(result).python).toBe(
+      `mock_pipette.drop_tip()
+mock_pipette.pick_up_tip(location=mock_tip_rack_1)
+mock_pipette.mix(
+    repetitions=2,
+    volume=8,
+    location=mock_source_plate["A1"].bottom(z=3.2),
+    aspirate_flow_rate=2.1,
+    dispense_flow_rate=2.2,
+)
+mock_pipette.drop_tip(location=mock_tip_rack_1.wells_by_name()["A1"])
+mock_pipette.pick_up_tip(location=mock_tip_rack_1)
+mock_pipette.mix(
+    repetitions=2,
+    volume=8,
+    location=mock_source_plate["B1"].bottom(z=3.2),
+    aspirate_flow_rate=2.1,
+    dispense_flow_rate=2.2,
+)
+mock_pipette.drop_tip(location=mock_tip_rack_1.wells_by_name()["B1"])
+mock_pipette.pick_up_tip(location=mock_tip_rack_1)
+mock_pipette.mix(
+    repetitions=2,
+    volume=8,
+    location=mock_source_plate["C1"].bottom(z=3.2),
+    aspirate_flow_rate=2.1,
+    dispense_flow_rate=2.2,
+)
+mock_pipette.drop_tip(location=mock_tip_rack_1.wells_by_name()["C1"])`
+    )
+  })
+  it('should return tip if changeTip is once', () => {
+    args.dropTipLocation = 'fixture/fixture_tiprack_300_ul/1'
+    args.wells = ['A1', 'B1', 'C1']
+    args.changeTip = 'once'
+    const result = mix(args, invariantContext, robotStateWithTip)
+    expect(getSuccessResult(result).python).toBe(
+      `mock_pipette.drop_tip()
+mock_pipette.pick_up_tip(location=mock_tip_rack_1)
+mock_pipette.mix(
+    repetitions=2,
+    volume=8,
+    location=mock_source_plate["A1"].bottom(z=3.2),
+    aspirate_flow_rate=2.1,
+    dispense_flow_rate=2.2,
+)
+mock_pipette.mix(
+    repetitions=2,
+    volume=8,
+    location=mock_source_plate["B1"].bottom(z=3.2),
+    aspirate_flow_rate=2.1,
+    dispense_flow_rate=2.2,
+)
+mock_pipette.mix(
+    repetitions=2,
+    volume=8,
+    location=mock_source_plate["C1"].bottom(z=3.2),
+    aspirate_flow_rate=2.1,
+    dispense_flow_rate=2.2,
+)
+mock_pipette.drop_tip(location=mock_tip_rack_1.wells_by_name()["A1"])`
+    )
+  })
+})

--- a/step-generation/src/__tests__/transfer.test.ts
+++ b/step-generation/src/__tests__/transfer.test.ts
@@ -6544,3 +6544,103 @@ mock_pipette.transfer_with_liquid_class(
     })
   })
 })
+
+describe('transfer: return tip', () => {
+  let allArgs: TransferArgs
+  beforeEach(() => {
+    allArgs = {
+      ...mixinArgs,
+      volume: 175,
+      sourceWells: ['A1'],
+      destWells: ['B1'],
+      tipRack: getLabwareDefURI(fixtureTiprack300ul as LabwareDefinition2),
+      dropTipLocation: 'fixture/fixture_tiprack_300_ul/1',
+      changeTip: 'always',
+    } as TransferArgs
+  })
+
+  it('should return tip', () => {
+    const args = {
+      ...allArgs,
+      changeTip: 'always',
+    } as TransferArgs
+
+    const result = transfer(args, invariantContext, robotStateWithTip)
+    const res = getSuccessResult(result)
+    expect(res.python).toEqual(
+      `
+mock_pipette.transfer_with_liquid_class(
+    volume=175,
+    source=[mock_source_plate["A1"]],
+    dest=[mock_dest_plate["B1"]],
+    new_tip="always",
+    return_tip=True,
+    tip_racks=[mock_tip_rack_1, mock_tip_rack_2],
+    liquid_class=protocol.define_liquid_class(
+        name="transfer_step_1",
+        properties={"p300_single": {"fixture/fixture_tiprack_300_ul/1": {
+            "aspirate": {
+                "aspirate_position": {
+                    "offset": {"x": 0, "y": 0, "z": 2},
+                    "position_reference": "well-bottom",
+                },
+                "flow_rate_by_volume": [(0, 10)],
+                "pre_wet": False,
+                "correction_by_volume": [(0, 0)],
+                "delay": {"enabled": False},
+                "mix": {"enabled": False},
+                "submerge": {
+                    "delay": {"enabled": False},
+                    "speed": 50,
+                    "start_position": {
+                        "offset": {"x": 1, "y": 0, "z": 5},
+                        "position_reference": "well-bottom",
+                    },
+                },
+                "retract": {
+                    "air_gap_by_volume": [(0, 0)],
+                    "delay": {"enabled": False},
+                    "end_position": {
+                        "offset": {"x": 2, "y": -1, "z": -4},
+                        "position_reference": "well-top",
+                    },
+                    "speed": 51,
+                    "touch_tip": {"enabled": False},
+                },
+            },
+            "dispense": {
+                "dispense_position": {
+                    "offset": {"x": 0, "y": 0, "z": 3},
+                    "position_reference": "well-bottom",
+                },
+                "flow_rate_by_volume": [(0, 12)],
+                "delay": {"enabled": False},
+                "submerge": {
+                    "delay": {"enabled": False},
+                    "speed": 52,
+                    "start_position": {
+                        "offset": {"x": 2, "y": 1, "z": -2},
+                        "position_reference": "well-center",
+                    },
+                },
+                "retract": {
+                    "air_gap_by_volume": [(0, 0)],
+                    "delay": {"enabled": False},
+                    "end_position": {
+                        "offset": {"x": 3, "y": -2, "z": -5},
+                        "position_reference": "well-top",
+                    },
+                    "speed": 53,
+                    "touch_tip": {"enabled": False},
+                    "blowout": {"enabled": False},
+                },
+                "correction_by_volume": [(0, 0)],
+                "push_out_by_volume": [(0, 0)],
+                "mix": {"enabled": False},
+            },
+        }}},
+    ),
+)`.trimStart()
+    )
+  })
+})

--- a/step-generation/src/commandCreators/compound/consolidate.ts
+++ b/step-generation/src/commandCreators/compound/consolidate.ts
@@ -6,6 +6,7 @@ import {
   getAllLiquidClassDefs,
   getByVolumeValue,
   getFlexNameConversion,
+  getIsTiprack,
   getMmFromBottom,
   GRIPPER_WASTE_CHUTE_ADDRESSABLE_AREA,
   isFlexPipette,
@@ -46,6 +47,7 @@ import {
   configureForVolume,
   delay,
   dispenseInPlace,
+  dropTip,
   moveToAddressableArea,
   moveToWell,
   prepareToAspirate,
@@ -192,17 +194,32 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
   ) {
     errors.push(errorCreators.labwareDiscarded())
   }
+  const trashLikeIds = [
+    ...Object.keys(invariantContext.trashBinEntities),
+    ...Object.keys(invariantContext.wasteChuteEntities),
+  ]
 
-  const isWasteChuteDropTipLocation =
-    wasteChuteEntities[dropTipLocation] != null
-  const isTrashBinDropTipLocation = trashBinEntities[dropTipLocation] != null
+  const fallBackTrashLikeId = trashLikeIds.length > 0 ? trashLikeIds[0] : null
+
+  // tiprack for return tip
+  const dropTipLabware = Object.values(invariantContext.labwareEntities).find(
+    ({ labwareDefURI }) => labwareDefURI === dropTipLocation
+  )
+  const isReturnTip = dropTipLabware != null && getIsTiprack(dropTipLabware.def)
+
+  const isWasteChuteDropLocation =
+    invariantContext.wasteChuteEntities[dropTipLocation] != null
+  const isTrashBinDropLocation =
+    invariantContext.trashBinEntities[dropTipLocation] != null
 
   if (
-    !dropTipLocation ||
-    (!isWasteChuteDropTipLocation && !isTrashBinDropTipLocation)
+    dropTipLocation == null ||
+    (isReturnTip && fallBackTrashLikeId == null && changeTip !== 'never') ||
+    (!isReturnTip && !isWasteChuteDropLocation && !isTrashBinDropLocation)
   ) {
     errors.push(errorCreators.dropTipLocationDoesNotExist())
   }
+
   const tiprack = Object.values(labwareEntities).find(
     ({ labwareDefURI }) => labwareDefURI === tipRack
   )
@@ -377,9 +394,10 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
       pythonDestWells != null ? `[${pythonDestWells}]` : destTrashPipetteName
     }`,
     `new_tip=${formatPyStr(formatChangeTipArg(changeTip))}`,
-    `trash_location=${trashPipetteName}`,
+    ...(isReturnTip
+      ? [`return_tip=True`]
+      : [`trash_location=${trashPipetteName}`, `keep_last_tip=True`]),
     ...(pipetteSpecs.channels > 1 ? [`group_wells=False`] : []),
-    `keep_last_tip=True`,
     ...(tipracks.filteredSortedTiprackIds.length > 0
       ? [
           getPythonAssignTipRacksString({
@@ -595,7 +613,10 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
         ? [
             curryCommandCreator(replaceTip, {
               pipette,
-              dropTipLocation,
+              dropTipLocation:
+                isReturnTip && fallBackTrashLikeId != null
+                  ? fallBackTrashLikeId
+                  : dropTipLocation,
               tipRack,
               ...(nozzles != null ? { nozzles } : {}),
             }),
@@ -1070,6 +1091,17 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
           ...getAirGapAfterDispenseCommands(true, false),
         ]
       }
+      const returnTipCommands: CurriedCommandCreator[] =
+        isReturnTip &&
+        (chunkIndex === sourceWellChunks.length - 1 || changeTip === 'always')
+          ? [
+              curryWithoutPython(dropTip, {
+                pipette,
+                dropTipLocation: tipRack,
+                isReturnTip,
+              }),
+            ]
+          : []
 
       return [
         ...tipCommands,
@@ -1081,6 +1113,7 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
         ...dispenseCommands,
         ...mixInDestinationCommands,
         ...advancedDispenseArgsCommands,
+        ...returnTipCommands,
       ]
     }
   )

--- a/step-generation/src/commandCreators/compound/consolidate.ts
+++ b/step-generation/src/commandCreators/compound/consolidate.ts
@@ -212,9 +212,14 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
   const isTrashBinDropLocation =
     invariantContext.trashBinEntities[dropTipLocation] != null
 
+  const hasTip = prevRobotState.pipettes[pipette]?.tipWell != null
+
   if (
     dropTipLocation == null ||
-    (isReturnTip && fallBackTrashLikeId == null && changeTip !== 'never') ||
+    (isReturnTip &&
+      fallBackTrashLikeId == null &&
+      changeTip !== 'never' &&
+      hasTip) ||
     (!isReturnTip && !isWasteChuteDropLocation && !isTrashBinDropLocation)
   ) {
     errors.push(errorCreators.dropTipLocationDoesNotExist())

--- a/step-generation/src/commandCreators/compound/distribute.ts
+++ b/step-generation/src/commandCreators/compound/distribute.ts
@@ -6,6 +6,7 @@ import {
   getAllLiquidClassDefs,
   getByVolumeValue,
   getFlexNameConversion,
+  getIsTiprack,
   getMmFromBottom,
   GRIPPER_WASTE_CHUTE_ADDRESSABLE_AREA,
   isFlexPipette,
@@ -49,6 +50,7 @@ import {
   configureForVolume,
   delay,
   dispenseInPlace,
+  dropTip,
   moveToAddressableArea,
   moveToWell,
   prepareToAspirate,
@@ -204,10 +206,29 @@ export const distribute: CommandCreator<DistributeArgs> = (
     errors.push(errorCreators.labwareDiscarded())
   }
 
-  const isWasteChute = wasteChuteEntities[dropTipLocation] != null
-  const isTrashBin = trashBinEntities[dropTipLocation] != null
+  const trashLikeIds = [
+    ...Object.keys(invariantContext.trashBinEntities),
+    ...Object.keys(invariantContext.wasteChuteEntities),
+  ]
 
-  if (!dropTipLocation || (!isWasteChute && !isTrashBin)) {
+  const fallBackTrashLikeId = trashLikeIds.length > 0 ? trashLikeIds[0] : null
+
+  // tiprack for return tip
+  const dropTipLabware = Object.values(invariantContext.labwareEntities).find(
+    ({ labwareDefURI }) => labwareDefURI === dropTipLocation
+  )
+  const isReturnTip = dropTipLabware != null && getIsTiprack(dropTipLabware.def)
+
+  const isWasteChuteDropLocation =
+    invariantContext.wasteChuteEntities[dropTipLocation] != null
+  const isTrashBinDropLocation =
+    invariantContext.trashBinEntities[dropTipLocation] != null
+
+  if (
+    dropTipLocation == null ||
+    (isReturnTip && fallBackTrashLikeId == null && changeTip !== 'never') ||
+    (!isReturnTip && !isWasteChuteDropLocation && !isTrashBinDropLocation)
+  ) {
     errors.push(errorCreators.dropTipLocationDoesNotExist())
   }
 
@@ -410,9 +431,10 @@ export const distribute: CommandCreator<DistributeArgs> = (
     `source=[${pythonSourceWells}]`,
     `dest=[${pythonDestWells ?? destTrashPipetteName}]`,
     `new_tip=${formatPyStr(formatChangeTipArg(changeTip))}`,
-    `trash_location=${trashPipetteName}`,
+    ...(isReturnTip
+      ? [`return_tip=True`]
+      : [`trash_location=${trashPipetteName}`, `keep_last_tip=True`]),
     ...(pipetteSpecs.channels > 1 ? [`group_wells=False`] : []),
-    `keep_last_tip=True`,
     ...(tipracks.filteredSortedTiprackIds.length > 0
       ? [
           getPythonAssignTipRacksString({
@@ -564,7 +586,10 @@ export const distribute: CommandCreator<DistributeArgs> = (
         ? [
             curryCommandCreator(replaceTip, {
               pipette,
-              dropTipLocation,
+              dropTipLocation:
+                isReturnTip && fallBackTrashLikeId != null
+                  ? fallBackTrashLikeId
+                  : dropTipLocation,
               tipRack,
               ...(nozzles != null ? { nozzles } : {}),
             }),
@@ -1174,6 +1199,18 @@ export const distribute: CommandCreator<DistributeArgs> = (
         }
       )
 
+      const returnTipCommands: CurriedCommandCreator[] =
+        isReturnTip &&
+        (chunkIndex === destWellChunks.length - 1 || changeTip === 'always')
+          ? [
+              curryWithoutPython(dropTip, {
+                pipette,
+                dropTipLocation: tipRack,
+                isReturnTip,
+              }),
+            ]
+          : []
+
       return [
         ...tipCommands,
         ...preAspirateSubmergeCommands,
@@ -1185,6 +1222,7 @@ export const distribute: CommandCreator<DistributeArgs> = (
         ...touchTipAfterAspirateRetractCommands,
         ...airGapAfterAspirateRetractCommands,
         ...dispenseChunkCommands,
+        ...returnTipCommands,
       ]
     }
   )

--- a/step-generation/src/commandCreators/compound/distribute.ts
+++ b/step-generation/src/commandCreators/compound/distribute.ts
@@ -224,9 +224,14 @@ export const distribute: CommandCreator<DistributeArgs> = (
   const isTrashBinDropLocation =
     invariantContext.trashBinEntities[dropTipLocation] != null
 
+  const hasTip = prevRobotState.pipettes[pipette]?.tipWell != null
+
   if (
     dropTipLocation == null ||
-    (isReturnTip && fallBackTrashLikeId == null && changeTip !== 'never') ||
+    (isReturnTip &&
+      fallBackTrashLikeId == null &&
+      changeTip !== 'never' &&
+      hasTip) ||
     (!isReturnTip && !isWasteChuteDropLocation && !isTrashBinDropLocation)
   ) {
     errors.push(errorCreators.dropTipLocationDoesNotExist())

--- a/step-generation/src/commandCreators/compound/mix.ts
+++ b/step-generation/src/commandCreators/compound/mix.ts
@@ -339,9 +339,14 @@ export const mix: CommandCreator<MixArgs> = (
   const isTrashBinDropLocation =
     invariantContext.trashBinEntities[dropTipLocation] != null
 
+  const hasTip = prevRobotState.pipettes[pipette]?.tipWell != null
+
   if (
     dropTipLocation == null ||
-    (isReturnTip && fallBackTrashLikeId == null && changeTip !== 'never') ||
+    (isReturnTip &&
+      fallBackTrashLikeId == null &&
+      changeTip !== 'never' &&
+      hasTip) ||
     (!isReturnTip && !isWasteChuteDropLocation && !isTrashBinDropLocation)
   ) {
     return { errors: [errorCreators.dropTipLocationDoesNotExist()] }

--- a/step-generation/src/commandCreators/compound/mix.ts
+++ b/step-generation/src/commandCreators/compound/mix.ts
@@ -1,7 +1,8 @@
-import flatMap from 'lodash/flatMap'
+import { flatMap } from 'lodash'
 
 import {
   getByVolumeValue,
+  getIsTiprack,
   GRIPPER_WASTE_CHUTE_ADDRESSABLE_AREA,
   LOW_VOLUME_PIPETTES,
   WELL_ORIGIN_BOTTOM,
@@ -24,6 +25,7 @@ import {
   configureForVolume,
   delay,
   dispenseInPlace,
+  dropTip,
   moveToWell,
   prepareToAspirate,
   touchTip,
@@ -319,10 +321,28 @@ export const mix: CommandCreator<MixArgs> = (
     return { errors: [errorCreators.labwareDiscarded()] }
   }
 
+  const trashLikeIds = [
+    ...Object.keys(invariantContext.trashBinEntities),
+    ...Object.keys(invariantContext.wasteChuteEntities),
+  ]
+
+  const fallBackTrashLikeId = trashLikeIds.length > 0 ? trashLikeIds[0] : null
+
+  // tiprack for return tip
+  const dropTipLabware = Object.values(invariantContext.labwareEntities).find(
+    ({ labwareDefURI }) => labwareDefURI === dropTipLocation
+  )
+  const isReturnTip = dropTipLabware != null && getIsTiprack(dropTipLabware.def)
+
+  const isWasteChuteDropLocation =
+    invariantContext.wasteChuteEntities[dropTipLocation] != null
+  const isTrashBinDropLocation =
+    invariantContext.trashBinEntities[dropTipLocation] != null
+
   if (
-    !dropTipLocation ||
-    (invariantContext.wasteChuteEntities[dropTipLocation] == null &&
-      invariantContext.trashBinEntities[dropTipLocation] == null)
+    dropTipLocation == null ||
+    (isReturnTip && fallBackTrashLikeId == null && changeTip !== 'never') ||
+    (!isReturnTip && !isWasteChuteDropLocation && !isTrashBinDropLocation)
   ) {
     return { errors: [errorCreators.dropTipLocationDoesNotExist()] }
   }
@@ -362,6 +382,7 @@ export const mix: CommandCreator<MixArgs> = (
         }),
       ]
     : []
+
   // Command generation
   const commandCreators = flatMap(
     wells,
@@ -372,7 +393,11 @@ export const mix: CommandCreator<MixArgs> = (
         tipCommands = [
           curryCommandCreator(replaceTip, {
             pipette,
-            dropTipLocation,
+            // the tip will only be dropped on the first time through this loop if we are returning tip to tiprack
+            dropTipLocation:
+              isReturnTip && fallBackTrashLikeId != null
+                ? fallBackTrashLikeId
+                : dropTipLocation,
             tipRack,
             ...(nozzles != null ? { nozzles } : {}),
             isFromMixCommand: true,
@@ -423,6 +448,18 @@ export const mix: CommandCreator<MixArgs> = (
         ? [...touchTipCommands, ...blowoutCommand]
         : [...blowoutCommand, ...touchTipCommands]
 
+      const returnTipCommands: CurriedCommandCreator[] =
+        isReturnTip &&
+        (wellIndex === wells.length - 1 || changeTip === 'always')
+          ? [
+              curryCommandCreator(dropTip, {
+                pipette,
+                dropTipLocation: tipRack,
+                isReturnTip,
+              }),
+            ]
+          : []
+
       const mixCommands = mixInPlaceUtil({
         pipette,
         volume,
@@ -450,15 +487,18 @@ export const mix: CommandCreator<MixArgs> = (
         },
         generatePython: true,
       })
-      return [
+      const newCommands = [
         ...tipCommands,
         ...configureForVolumeCommand,
         ...prepareToAspirateCommand,
         ...mixCommands,
         ...advancedDispenseCommands,
+        ...returnTipCommands,
       ]
+      return newCommands
     }
   )
+
   return reduceCommandCreators(
     commandCreators,
     invariantContext,

--- a/step-generation/src/commandCreators/compound/mix.ts
+++ b/step-generation/src/commandCreators/compound/mix.ts
@@ -1,4 +1,4 @@
-import { flatMap } from 'lodash'
+import flatMap from 'lodash/flatMap'
 
 import {
   getByVolumeValue,
@@ -492,7 +492,7 @@ export const mix: CommandCreator<MixArgs> = (
         },
         generatePython: true,
       })
-      const newCommands = [
+      return [
         ...tipCommands,
         ...configureForVolumeCommand,
         ...prepareToAspirateCommand,
@@ -500,7 +500,6 @@ export const mix: CommandCreator<MixArgs> = (
         ...advancedDispenseCommands,
         ...returnTipCommands,
       ]
-      return newCommands
     }
   )
 

--- a/step-generation/src/commandCreators/compound/transfer.ts
+++ b/step-generation/src/commandCreators/compound/transfer.ts
@@ -249,9 +249,14 @@ export const transfer: CommandCreator<TransferArgs> = (
   )
   const isReturnTip = dropTipLabware != null && getIsTiprack(dropTipLabware.def)
 
+  const hasTip = prevRobotState.pipettes[pipette]?.tipWell != null
+
   if (
     dropTipLocation == null ||
-    (isReturnTip && fallBackTrashLikeId == null && changeTip !== 'never') ||
+    (isReturnTip &&
+      fallBackTrashLikeId == null &&
+      changeTip !== 'never' &&
+      hasTip) ||
     (!isReturnTip && !isWasteChuteDropLocation && !isTrashBinDropLocation)
   ) {
     return { errors: [errorCreators.dropTipLocationDoesNotExist()] }

--- a/step-generation/src/commandCreators/compound/transfer.ts
+++ b/step-generation/src/commandCreators/compound/transfer.ts
@@ -5,6 +5,7 @@ import {
   getAllLiquidClassDefs,
   getByVolumeValue,
   getFlexNameConversion,
+  getIsTiprack,
   getMmFromBottom,
   GRIPPER_WASTE_CHUTE_ADDRESSABLE_AREA,
   isFlexPipette,
@@ -47,6 +48,7 @@ import {
   configureForVolume,
   delay,
   dispenseInPlace,
+  dropTip,
   moveToAddressableArea,
   moveToWell,
   prepareToAspirate,
@@ -234,6 +236,27 @@ export const transfer: CommandCreator<TransferArgs> = (
     errors.push(errorCreators.labwareDiscarded())
   }
 
+  const trashLikeIds = [
+    ...Object.keys(invariantContext.trashBinEntities),
+    ...Object.keys(invariantContext.wasteChuteEntities),
+  ]
+
+  const fallBackTrashLikeId = trashLikeIds.length > 0 ? trashLikeIds[0] : null
+
+  // tiprack for return tip
+  const dropTipLabware = Object.values(invariantContext.labwareEntities).find(
+    ({ labwareDefURI }) => labwareDefURI === dropTipLocation
+  )
+  const isReturnTip = dropTipLabware != null && getIsTiprack(dropTipLabware.def)
+
+  if (
+    dropTipLocation == null ||
+    (isReturnTip && fallBackTrashLikeId == null && changeTip !== 'never') ||
+    (!isReturnTip && !isWasteChuteDropLocation && !isTrashBinDropLocation)
+  ) {
+    return { errors: [errorCreators.dropTipLocationDoesNotExist()] }
+  }
+
   if (
     !args.destLabware ||
     (!labwareEntities[destLabware] &&
@@ -241,13 +264,6 @@ export const transfer: CommandCreator<TransferArgs> = (
       !trashBinEntities[destLabware])
   ) {
     errors.push(errorCreators.equipmentDoesNotExist())
-  }
-
-  if (
-    !dropTipLocation ||
-    (!isWasteChuteDropLocation && !isTrashBinDropLocation)
-  ) {
-    errors.push(errorCreators.dropTipLocationDoesNotExist())
   }
 
   const tiprack = Object.values(labwareEntities).find(
@@ -417,9 +433,10 @@ export const transfer: CommandCreator<TransferArgs> = (
       pythonDestWells != null ? `[${pythonDestWells}]` : destTrashPipetteName
     }`,
     `new_tip=${formatPyStr(formatChangeTipArg(changeTip))}`,
-    `trash_location=${trashPipetteName}`,
+    ...(isReturnTip
+      ? [`return_tip=True`]
+      : [`trash_location=${trashPipetteName}`, `keep_last_tip=True`]),
     ...(pipetteSpecs.channels > 1 ? [`group_wells=False`] : []),
-    `keep_last_tip=True`,
     ...(tipracks.filteredSortedTiprackIds.length > 0
       ? [
           getPythonAssignTipRacksString({
@@ -531,7 +548,10 @@ export const transfer: CommandCreator<TransferArgs> = (
             ? [
                 curryCommandCreator(replaceTip, {
                   pipette,
-                  dropTipLocation,
+                  dropTipLocation:
+                    isReturnTip && fallBackTrashLikeId != null
+                      ? fallBackTrashLikeId
+                      : dropTipLocation,
                   tipRack,
                   ...(nozzles != null ? { nozzles } : {}),
                 }),
@@ -1142,6 +1162,17 @@ export const transfer: CommandCreator<TransferArgs> = (
               }
               break
           }
+          const returnTipCommands: CurriedCommandCreator[] =
+            isReturnTip &&
+            (pairIdx === sourceDestPairs.length - 1 || changeTip === 'always')
+              ? [
+                  curryWithoutPython(dropTip, {
+                    pipette,
+                    dropTipLocation: tipRack,
+                    isReturnTip,
+                  }),
+                ]
+              : []
 
           // if using dispense > air gap, drop or change the tip at the end
           const nextCommands = [
@@ -1159,6 +1190,7 @@ export const transfer: CommandCreator<TransferArgs> = (
             ...mixAfterDispenseCommands,
             ...postDispenseRetractCommands,
             ...advancedDispenseArgsCommands,
+            ...returnTipCommands,
           ]
           // NOTE: side-effecting
           prevSourceWell = sourceWell


### PR DESCRIPTION
# Overview

This PR wires up return tip logic in mix, transfer, consolidate, and distribute command creators.

TODO:
- [x] add tests for moveLiquid command creators
## Test Plan and Hands on Testing

- create a protocol with return tip in mix, transfer, consolidate, distribute ([example](https://github.com/user-attachments/files/21991783/return_tip_test_full.py.zip))
- verify the tiprack for the selected step correctly shows tips being picked up/returned
- verify that used (returned) tips are skipped for subsequent liquid handling steps
- export file and inspect that mix step specifies an explicit drop tip at pick up tip location
- inspect that transfer/consolidate/distribute steps specify correct Python args (undefined `keep_last_tip` defaulting to `False`, undefined `trash_location`, and `return_tip=True`

## Changelog

- wire up logic for return tip in all liquid handling command creators
- find fallback trash entity if return tip is selected and changeTip policy is not "never" and the pipette starts with a tip (tip needs to be dropped and replaced at beginning at command creator sequence)
- update python args: 1) if returning tip, set `return_tip=True`, 2) if not returning tip, set `trash_location` and `keep_last_tip=True`
- curry drop tip commands for return tip, _with Python_ for mix (need to drop explicitly at tip well), and _without_ Python for transfer/consolidate/distribute (return tip handled by API internals)

## Review requests

see test plan

## Risk assessment


