### PR TITLE
chore(components,protocol-designer): Trigger Storybook builds on protocol-designer components changes

### DIFF
--- a/.github/workflows/components-test-build-deploy.yaml
+++ b/.github/workflows/components-test-build-deploy.yaml
@@ -5,21 +5,24 @@ name: 'Components test, build, and deploy'
 on:
   pull_request:
     paths:
-      - 'Makefile'
-      - 'components/**'
-      - 'app/**.stories.*'
-      - 'app/src/atoms/**'
-      - 'app/src/molecules/**'
+      - Makefile
       - 'package.json'
       - '.github/workflows/components-test-build-deploy.yaml'
+      - '**.stories.*'
+      - 'components/**'
+      - 'app/src/atoms/**'
+      - 'app/src/molecules/**'
+      - 'protocol-designer/src/components/**'
   push:
     paths:
-      - 'components/**'
-      - 'app/**.stories.*'
-      - 'app/src/atoms/**'
-      - 'app/src/molecules/**'
+      - Makefile
       - 'package.json'
       - '.github/workflows/components-test-build-deploy.yaml'
+      - '**.stories.*'
+      - 'components/**'
+      - 'app/src/atoms/**'
+      - 'app/src/molecules/**'
+      - 'protocol-designer/src/components/**'
     branches:
       - '**'
     tags:


### PR DESCRIPTION
## Overview

Files in `protocol-designer/` can contribute to Storybook, but they were not triggering Storybook builds. This fixes that.

## Test Plan and Hands on Testing

🤷 

## Changelog

* Add `'protocol-designer/src/components/**'`. We want to trigger a build if a CSF file changes *or* if the actual component changes.
* Replace `app/**.stories.*'` with `'**.stories.*'`, so we trigger builds if a CSF file changes anywhere in the repo. This is probably redundant with the above, but we were already doing it for `app/` so 🤷 might as well do it everywhere.
* Make sure the `push` and `pull_request` triggers match each other exactly.

## Review requests

Is `protocol-designer/src/components/` the right path? Any other paths we want to add?

## Risk assessment

Low, dev-only.
