### PR TITLE
fix(protocol-designer): fix import modal close behavior

### DIFF
--- a/protocol-designer/src/components/organisms/FileUploadMessagesModal/index.tsx
+++ b/protocol-designer/src/components/organisms/FileUploadMessagesModal/index.tsx
@@ -37,6 +37,11 @@ export function FileUploadMessagesModal(): JSX.Element | null {
 
   const isMigration = title === t('migration_header')
 
+  const showButtons =
+    title !== t('invalid_json_file') &&
+    title !== t('incorrect_file_header') &&
+    title !== t('incorrect_python_file_header')
+
   const handleClose = (): void => {
     if (isMigration) {
       dispatch(undoLoadFile())
@@ -44,11 +49,6 @@ export function FileUploadMessagesModal(): JSX.Element | null {
       dismissModal()
     }
   }
-
-  const showButtons =
-    title !== t('invalid_json_file') &&
-    title !== t('incorrect_file_header') &&
-    title !== t('incorrect_python_file_header')
 
   return (
     <Modal

--- a/protocol-designer/src/components/organisms/FileUploadMessagesModal/index.tsx
+++ b/protocol-designer/src/components/organisms/FileUploadMessagesModal/index.tsx
@@ -42,21 +42,11 @@ export function FileUploadMessagesModal(): JSX.Element | null {
     title !== t('incorrect_file_header') &&
     title !== t('incorrect_python_file_header')
 
-  const handleClose = (): void => {
-    if (isMigration) {
-      dispatch(undoLoadFile())
-    } else {
-      dismissModal()
-    }
-  }
-
   return (
     <Modal
       marginLeft="0"
       type={message?.isError ? 'error' : 'info'}
       title={title}
-      closeOnOutsideClick
-      onClose={handleClose}
       footer={
         showButtons && (
           <Flex

--- a/protocol-designer/src/components/organisms/FileUploadMessagesModal/index.tsx
+++ b/protocol-designer/src/components/organisms/FileUploadMessagesModal/index.tsx
@@ -37,6 +37,14 @@ export function FileUploadMessagesModal(): JSX.Element | null {
 
   const isMigration = title === t('migration_header')
 
+  const handleClose = (): void => {
+    if (isMigration) {
+      dispatch(undoLoadFile())
+    } else {
+      dismissModal()
+    }
+  }
+
   const showButtons =
     title !== t('invalid_json_file') &&
     title !== t('incorrect_file_header') &&
@@ -47,6 +55,9 @@ export function FileUploadMessagesModal(): JSX.Element | null {
       marginLeft="0"
       type={message?.isError ? 'error' : 'info'}
       title={title}
+      {...(!isMigration
+        ? { onClose: handleClose, closeOnOutsideClick: true }
+        : {})}
       footer={
         showButtons && (
           <Flex


### PR DESCRIPTION
# Overview

`FileUploadMessagesModal` should force user action to acknowledge the migration modal when importing an older protocol. This PR removes the close button and close on click outside behavior

Closes AUTH-2234

## Test Plan and Hands on Testing

- import an older PD protocol
- verify that the migration modal must be confirmed or canceled

## Changelog

- force action when a migration modal is prompted

## Review requests

see test plan

## Risk assessment

low