### PR TITLE
fix(hardware_testing): fix failing tests. 

### DIFF
--- a/hardware-testing/hardware_testing/protocols/universal_photometric.py
+++ b/hardware-testing/hardware_testing/protocols/universal_photometric.py
@@ -45,7 +45,7 @@ def add_parameters(parameters: protocol_api.ParameterContext) -> None:
     parameters.add_int(
         display_name="model type",
         variable_name="model_type",
-        default=200,
+        default=1000,
         choices=[
             {"display_name": "200", "value": 200},
             {"display_name": "1000", "value": 1000},


### PR DESCRIPTION

# Overview
default to the p1000_96 because the p200 doesn't have liquid class info on edge.