### PR TITLE
feat(protocol-designer, step-generation): allow no trash or waste chute in PD

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/AddStepButton.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/AddStepButton.tsx
@@ -41,7 +41,6 @@ import {
   ConfirmDeleteModal,
   getMainPagePortalEl,
 } from '/protocol-designer/components/organisms'
-import { useKitchen } from '/protocol-designer/components/organisms/Kitchen/useKitchen'
 import { OFFDECK } from '/protocol-designer/constants'
 import { getEnableComment } from '/protocol-designer/feature-flags/selectors'
 import {
@@ -57,7 +56,7 @@ import {
   getIsMultiSelectMode,
   actions as stepsActions,
 } from '/protocol-designer/ui/steps'
-import { getHasTrash, getIsAdapterFromDef } from '/protocol-designer/utils'
+import { getIsAdapterFromDef } from '/protocol-designer/utils'
 
 import { AddStepOverflowButton } from './AddStepOverflowButton'
 
@@ -75,9 +74,8 @@ export function AddStepButton({
   hasText,
   sidebarWidth,
 }: AddStepButtonProps): JSX.Element {
-  const { t } = useTranslation(['tooltip', 'button', 'starting_deck_state'])
+  const { t } = useTranslation(['tooltip', 'button'])
   const enableComment = useSelector(getEnableComment)
-  const { makeSnackbar } = useKitchen()
   const dispatch = useDispatch<ThunkDispatch<BaseState, any, any>>()
   const [targetProps, tooltipProps] = useHoverTooltip({
     placement: TOOLTIP_TOP,
@@ -90,10 +88,7 @@ export function AddStepButton({
     stepFormSelectors.getCurrentFormHasUnsavedChanges
   )
   const isStepCreationDisabled = useSelector(getIsMultiSelectMode)
-  const { modules, additionalEquipmentOnDeck } = useSelector(
-    stepFormSelectors.getInitialDeckSetup
-  )
-  const hasTrash = getHasTrash(additionalEquipmentOnDeck)
+  const { modules } = useSelector(stepFormSelectors.getInitialDeckSetup)
   const [showStepOverflowMenu, setShowStepOverflowMenu] = useState<boolean>(
     false
   )
@@ -176,11 +171,7 @@ export function AddStepButton({
     ))
 
   const handleAddClick = (): void => {
-    if (hasTrash) {
-      setShowStepOverflowMenu(true)
-    } else {
-      makeSnackbar(t('starting_deck_state:trash_required') as string)
-    }
+    setShowStepOverflowMenu(true)
   }
 
   return (

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/StepContainer.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/StepContainer.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
-import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 
 import {
@@ -22,15 +21,12 @@ import {
   DELETE_STEP_FORM,
   getMainPagePortalEl,
 } from '/protocol-designer/components/organisms'
-import { useKitchen } from '/protocol-designer/components/organisms/Kitchen/useKitchen'
 import { actions as steplistActions } from '/protocol-designer/steplist'
-import { getDeckSetupForActiveItem } from '/protocol-designer/top-selectors/labware-locations'
 import {
   deselectAllSteps,
   populateForm,
 } from '/protocol-designer/ui/steps/actions/actions'
 import { getMultiSelectItemIds } from '/protocol-designer/ui/steps/selectors'
-import { getHasTrash } from '/protocol-designer/utils'
 
 import { StepOverflowMenu } from './StepOverflowMenu'
 import { capitalizeFirstLetterAfterNumber } from './utils'
@@ -88,16 +84,12 @@ export function ConnectedStepContainer(
     openedOverflowMenuId,
     sidebarWidth,
   } = props
-  const { t } = useTranslation('starting_deck_state')
-  const { makeSnackbar } = useKitchen()
   const [top, setTop] = useState<number>(0)
   const menuRootRef = useRef<HTMLDivElement | null>(null)
   const isStartingOrEndingState =
     title === STARTING_DECK_STATE || title === FINAL_DECK_STATE
   const dispatch = useDispatch<ThunkDispatch<BaseState, any, any>>()
   const multiSelectItemIds = useSelector(getMultiSelectItemIds)
-  const { additionalEquipmentOnDeck } = useSelector(getDeckSetupForActiveItem)
-  const hasTrash = getHasTrash(additionalEquipmentOnDeck)
 
   const hasText = sidebarWidth > PX_SIDEBAR_MIN_WIDTH_FOR_ICON
 
@@ -177,10 +169,6 @@ export function ConnectedStepContainer(
   } = useConditionalConfirm(handleDelete, true)
 
   const handleOpenForm = (clickNum: number, e: ReactMouseEvent): void => {
-    if (!hasTrash) {
-      makeSnackbar(t('trash_required') as string)
-    }
-
     if (clickNum === 0) {
       onClick?.(e)
     } else {

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/index.tsx
@@ -31,7 +31,6 @@ import {
   StepSummary,
   TimelineAlerts,
 } from '../../../components/organisms'
-import { useKitchen } from '../../../components/organisms/Kitchen/useKitchen'
 import { DECK_SETUP_TOOLS_WIDTH_REM } from '../../../constants'
 import { getEnableHotKeysDisplay } from '../../../feature-flags/selectors'
 import {
@@ -55,7 +54,6 @@ import {
   getSelectedSubstep,
   getSelectedTerminalItemId,
 } from '../../../ui/steps/selectors'
-import { getHasTrash } from '../../../utils'
 import { DeckSetupContainer } from '../DeckSetup'
 import { zoomInOnCoordinate } from '../DeckSetup/utils'
 import { OffDeck } from '../OffDeck'
@@ -87,7 +85,6 @@ export function ProtocolSteps({
 }: ProtocolStepsProps): JSX.Element {
   const { i18n, t } = useTranslation('starting_deck_state')
   const formData = useSelector(getUnsavedForm)
-  const { makeSnackbar } = useKitchen()
   const dispatch = useDispatch<ThunkDispatch<any>>()
   const selectedTerminalItemId = useSelector(getSelectedTerminalItemId)
   const hoveredTerminalItem = useSelector(getHoveredTerminalItemId)
@@ -102,7 +99,6 @@ export function ProtocolSteps({
   const [hoverSlot, setHoverSlot] = useState<DeckSlot | null>(null)
   const savedStepForms = useSelector(getSavedStepForms)
   const deckDef = useMemo(() => getDeckDefFromRobotType(robotType), [robotType])
-  const hasTrash = getHasTrash(additionalEquipmentOnDeck)
   const viewBoxX = deckDef.cornerOffsetFromOrigin[0]
   const windowInnerWidthRem = window.innerWidth / 16
   const deckMapRatio = round(
@@ -143,14 +139,6 @@ export function ProtocolSteps({
       dispatch(saveProtocolFile())
     },
   })
-
-  const handleExporting = (): void => {
-    if (hasTrash) {
-      handleExportClick()
-    } else {
-      makeSnackbar(t('trash_required') as string)
-    }
-  }
 
   let currentStep
   if (hoveredTerminalItem === HARDWARE_ID && selectedStepId != null) {
@@ -273,7 +261,7 @@ export function ProtocolSteps({
                 right={SPACING.spacing24}
                 zIndex={1000}
               >
-                <ExportButton onClick={handleExporting} />
+                <ExportButton onClick={handleExportClick} />
               </Flex>
             )}
             <Flex

--- a/protocol-designer/src/pages/Onboarding/SelectFlexHardware.tsx
+++ b/protocol-designer/src/pages/Onboarding/SelectFlexHardware.tsx
@@ -4,28 +4,19 @@ import { FLEX_ROBOT_TYPE } from '@opentrons/shared-data'
 
 import { HandleEnter } from '../../components/atoms'
 import { HardwareConfigurator } from '../../components/organisms/HardwareConfigurator'
-import { useKitchen } from '../../components/organisms/Kitchen/useKitchen'
 import { WizardBody } from './WizardBody'
 
 import type { WizardTileProps } from './types'
 
 export function SelectHardware(props: WizardTileProps): JSX.Element | null {
   const { goBack, proceed, watch, setValue } = props
-  const { makeSnackbar } = useKitchen()
   const fixtures = watch('fixtures')
   const modules = watch('modules')
   const hasGripper = watch('hasGripper')
   const { t } = useTranslation(['onboarding', 'shared'])
-  const hasTrash = Object.values(fixtures).some(
-    fixture => fixture.name === 'trashBin' || fixture.name === 'wasteChute'
-  )
 
   const handleProceed = (): void => {
-    if (!hasTrash) {
-      makeSnackbar(t('trash_required') as string)
-    } else {
-      proceed(1)
-    }
+    proceed(1)
   }
 
   return (

--- a/step-generation/src/__tests__/replaceTip.test.ts
+++ b/step-generation/src/__tests__/replaceTip.test.ts
@@ -292,6 +292,58 @@ describe('replaceTip', () => {
         pickUpTipHelper('B1'),
       ])
     })
+    it('Single-channel: no error if pipette does not have tip, and no waste chute or trash bin is found', () => {
+      invariantContext = {
+        ...invariantContext,
+        wasteChuteEntities: {},
+        trashBinEntities: {},
+      }
+      const result = replaceTip(
+        {
+          pipette: p300SingleId,
+          dropTipLocation: FIXED_TRASH_ID,
+          tipRack: tiprackURI1,
+        },
+        invariantContext,
+        {
+          ...initialRobotState,
+          tipState: {
+            ...initialRobotState.tipState,
+            pipettes: {
+              p300SingleId: { hasTip: false, tiprackURI: tiprackURI1 },
+            },
+          },
+        }
+      )
+      expect(getSuccessResult(result))
+    })
+    it('Single-channel: error if pipette does have tip, and no waste chute or trash bin is found', () => {
+      invariantContext = {
+        ...invariantContext,
+        wasteChuteEntities: {},
+        trashBinEntities: {},
+      }
+      const result = replaceTip(
+        {
+          pipette: p300SingleId,
+          dropTipLocation: FIXED_TRASH_ID,
+          tipRack: tiprackURI1,
+        },
+        invariantContext,
+        {
+          ...initialRobotState,
+          tipState: {
+            ...initialRobotState.tipState,
+            pipettes: {
+              p300SingleId: { hasTip: true, tiprackURI: tiprackURI1 },
+            },
+          },
+        }
+      )
+      expect(getErrorResult(result).errors[0]).toMatchObject({
+        type: 'DROP_TIP_LOCATION_DOES_NOT_EXIST',
+      })
+    })
   })
   describe('replaceTip: multi-channel', () => {
     it('multi-channel, all tipracks have tips', () => {

--- a/step-generation/src/commandCreators/compound/consolidate.ts
+++ b/step-generation/src/commandCreators/compound/consolidate.ts
@@ -212,7 +212,7 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
   const isTrashBinDropLocation =
     invariantContext.trashBinEntities[dropTipLocation] != null
 
-  const hasTip = prevRobotState.pipettes[pipette]?.tipWell != null
+  const hasTip = prevRobotState.tipState.pipettes[pipette]?.hasTip
 
   if (
     dropTipLocation == null ||

--- a/step-generation/src/commandCreators/compound/distribute.ts
+++ b/step-generation/src/commandCreators/compound/distribute.ts
@@ -224,7 +224,7 @@ export const distribute: CommandCreator<DistributeArgs> = (
   const isTrashBinDropLocation =
     invariantContext.trashBinEntities[dropTipLocation] != null
 
-  const hasTip = prevRobotState.pipettes[pipette]?.tipWell != null
+  const hasTip = prevRobotState.tipState.pipettes[pipette]?.hasTip
 
   if (
     dropTipLocation == null ||

--- a/step-generation/src/commandCreators/compound/replaceTip.ts
+++ b/step-generation/src/commandCreators/compound/replaceTip.ts
@@ -130,7 +130,10 @@ export const replaceTip: CommandCreator<ReplaceTipArgs> = (
       ],
     }
   }
-  if (!args.dropTipLocation || (!isWasteChute && !isTrashBin)) {
+
+  const hasTip = prevRobotState.tipState.pipettes[pipette]?.hasTip
+
+  if (!args.dropTipLocation || (!isWasteChute && !isTrashBin && hasTip)) {
     return { errors: [errorCreators.dropTipLocationDoesNotExist()] }
   }
 

--- a/step-generation/src/commandCreators/compound/transfer.ts
+++ b/step-generation/src/commandCreators/compound/transfer.ts
@@ -249,7 +249,7 @@ export const transfer: CommandCreator<TransferArgs> = (
   )
   const isReturnTip = dropTipLabware != null && getIsTiprack(dropTipLabware.def)
 
-  const hasTip = prevRobotState.pipettes[pipette]?.tipWell != null
+  const hasTip = prevRobotState.tipState.pipettes[pipette]?.hasTip
 
   if (
     dropTipLocation == null ||


### PR DESCRIPTION
# Overview

With the addition of return tip capabilities in PD, we want to remove the requirement to have added a trash bin or waste chute. Any error handling for command creators that require the presence of a trash bin or waste chute entity will live inside the command creators themselves.

Closes AUTH-587
Closes AUTH-589

## Test Plan and Hands on Testing

### Onboarding
- create a new Flex protocol
- in deck configuration, verify that you are not blocked from continuing if you choose not to add a trash bin or waste chute

### Timeline Editor
- after creating the above protocol without trash/waste chute, navigate to protocol editor
- verify that clicking "Add Step" or a timeline step item does not result in a "trash required" toast

## Changelog

- remove trash requirements from onboarding flow and timeline editor

## Review requests

see test plan

## Risk assessment
low