### PR TITLE
feat(step-generation): emit load_lid_stack() on an adapter

### DIFF
--- a/step-generation/src/__tests__/pythonFileUtils.test.ts
+++ b/step-generation/src/__tests__/pythonFileUtils.test.ts
@@ -132,7 +132,8 @@ const labwareId4 = 'labwareId4'
 const labwareId5 = 'labwareId5'
 const labwareId6 = 'labwareId6'
 const labwareId7 = 'labwareId7'
-
+const labwareId8 = 'labwareId8'
+const deckRiserId = 'deckRiserId'
 const mockLabwareEntities: LabwareEntities = {
   [labwareId1]: {
     id: labwareId1,
@@ -260,9 +261,32 @@ describe('getLoadLidStacks', () => {
         parameters: { loadName: 'mock_lid' } as any,
       },
     } as LabwareEntity,
+    [labwareId8]: {
+      id: labwareId8,
+      labwareDefURI: 'opentrons/mock_lid/1',
+      def: {
+        ...opentrons96Plate,
+        allowedRoles: ['lid'],
+        parameters: { loadName: 'mock_lid' } as any,
+      },
+    } as LabwareEntity,
+    [deckRiserId]: {
+      id: deckRiserId,
+      labwareDefURI: 'opentrons/opentrons_flex_deck_riser/1',
+      def: {
+        ...opentrons96Plate,
+        allowedRoles: ['adapter'],
+        parameters: { loadName: 'opentrons_flex_deck_riser' } as any,
+      },
+      pythonName: 'mock_adapter_1',
+    } as LabwareEntity,
   }
   const labwareRobotStateWithLids = {
     ...labwareRobotState,
+    [deckRiserId]: {
+      ...labwareRobotState[labwareId6],
+      stack: [deckRiserId, 'B2'],
+    },
     [labwareId6]: {
       ...labwareRobotState[labwareId6],
       stack: [labwareId6, 'D1'],
@@ -271,9 +295,13 @@ describe('getLoadLidStacks', () => {
       ...labwareRobotState[labwareId7],
       stack: [labwareId7, labwareId6, 'D1'],
     },
+    [labwareId8]: {
+      ...labwareRobotState[labwareId8],
+      stack: [labwareId8, deckRiserId, 'B2'],
+    },
   }
 
-  it('should generate load_lid_stack for 2 lids in a stack', () => {
+  it('should generate load_lid_stack for 2 lids in a stack on the deck and 1 lid for a stack on an adapter', () => {
     expect(
       getLoadLidStacks(labwareEntitiesWithLid, labwareRobotStateWithLids)
     ).toBe(
@@ -281,6 +309,11 @@ describe('getLoadLidStacks', () => {
 lid_stack_D1 = protocol.load_lid_stack(
     load_name="mock_lid",
     location="D1",
+    quantity=2,
+)
+lid_stack_mock_adapter_1 = protocol.load_lid_stack(
+    load_name="mock_lid",
+    location=mock_adapter_1,
     quantity=2,
 )`
     )

--- a/step-generation/src/__tests__/pythonFileUtils.test.ts
+++ b/step-generation/src/__tests__/pythonFileUtils.test.ts
@@ -314,7 +314,7 @@ lid_stack_D1 = protocol.load_lid_stack(
 lid_stack_mock_adapter_1 = protocol.load_lid_stack(
     load_name="mock_lid",
     location=mock_adapter_1,
-    quantity=2,
+    quantity=1,
 )`
     )
   })

--- a/step-generation/src/utils/pythonFileUtils.ts
+++ b/step-generation/src/utils/pythonFileUtils.ts
@@ -174,15 +174,25 @@ const _getLidStacks = (
       const { stack } = labwareState[id]
       const nonSlotStackLength = stack.length - 1
       const parentLabware = stack.slice(1, nonSlotStackLength) // excluding stack
-      const isLidStack = parentLabware.every(
+      const deckRiserParentLabware = parentLabware.find(
         parentLabwareId =>
-          allLabwareEntities[parentLabwareId].labwareDefURI === labwareDefURI
+          allLabwareEntities[parentLabwareId].def.parameters.loadName ===
+          'opentrons_flex_deck_riser'
       )
+      const isLidStack =
+        parentLabware.every(
+          parentLabwareId =>
+            allLabwareEntities[parentLabwareId].labwareDefURI === labwareDefURI
+        ) || deckRiserParentLabware != null
+
       const loadName = def.parameters.loadName
       if (!isLidStack) {
         return acc
       }
-      const lidSlot = getSlotInLocationStack(stack)
+      const lidSlot =
+        deckRiserParentLabware != null
+          ? allLabwareEntities[deckRiserParentLabware].pythonName
+          : getSlotInLocationStack(stack)
       if (!(lidSlot in acc)) {
         return {
           ...acc,
@@ -213,8 +223,13 @@ export const getLoadLidStacks = (
 
   const pythonLidStacks = Object.entries(lidStacks)
     .map<string>(([slot, { loadName, quantity }]) => {
+      const isLidSlotOnAdapter = Object.values(allLabwareEntities).some(
+        entity => entity.pythonName === slot
+      )
       const loadNameArg = `load_name=${formatPyStr(loadName)}`
-      const locationArg = `location=${formatPyStr(slot)}`
+      const locationArg = `location=${
+        isLidSlotOnAdapter ? slot : formatPyStr(slot)
+      }`
       const quantityArg = `quantity=${quantity}`
       const allArgs = [loadNameArg, locationArg, quantityArg].join(',\n')
       const allArgsIndented = indentPyLines(allArgs)

--- a/step-generation/src/utils/pythonFileUtils.ts
+++ b/step-generation/src/utils/pythonFileUtils.ts
@@ -176,13 +176,13 @@ const _getLidStacks = (
       const parentLabware = stack.slice(1, nonSlotStackLength) // excluding stack
       const deckRiserParentLabware = parentLabware.find(
         parentLabwareId =>
-          allLabwareEntities[parentLabwareId].def.parameters.loadName ===
+          allLabwareEntities[parentLabwareId]?.def.parameters.loadName ===
           'opentrons_flex_deck_riser'
       )
       const isLidStack =
         parentLabware.every(
           parentLabwareId =>
-            allLabwareEntities[parentLabwareId].labwareDefURI === labwareDefURI
+            allLabwareEntities[parentLabwareId]?.labwareDefURI === labwareDefURI
         ) || deckRiserParentLabware != null
 
       const loadName = def.parameters.loadName
@@ -191,16 +191,19 @@ const _getLidStacks = (
       }
       const lidSlot =
         deckRiserParentLabware != null
-          ? allLabwareEntities[deckRiserParentLabware].pythonName
+          ? allLabwareEntities[deckRiserParentLabware]?.pythonName
           : getSlotInLocationStack(stack)
+      const nonSlotAndAdapterLength =
+        stack.length - (deckRiserParentLabware != null ? 2 : 1)
+
       if (!(lidSlot in acc)) {
         return {
           ...acc,
-          [lidSlot]: { loadName, quantity: nonSlotStackLength },
+          [lidSlot]: { loadName, quantity: nonSlotAndAdapterLength },
         }
       }
       const { quantity } = acc[lidSlot]
-      const newQuantity = max([quantity, nonSlotStackLength]) ?? quantity
+      const newQuantity = max([quantity, nonSlotAndAdapterLength]) ?? quantity
       return { ...acc, [lidSlot]: { loadName, quantity: newQuantity } }
     },
     {}
@@ -222,19 +225,19 @@ export const getLoadLidStacks = (
   )
 
   const pythonLidStacks = Object.entries(lidStacks)
-    .map<string>(([slot, { loadName, quantity }]) => {
+    .map<string>(([location, { loadName, quantity }]) => {
       const isLidSlotOnAdapter = Object.values(allLabwareEntities).some(
-        entity => entity.pythonName === slot
+        ({ pythonName }) => pythonName === location
       )
       const loadNameArg = `load_name=${formatPyStr(loadName)}`
       const locationArg = `location=${
-        isLidSlotOnAdapter ? slot : formatPyStr(slot)
+        isLidSlotOnAdapter ? location : formatPyStr(location)
       }`
       const quantityArg = `quantity=${quantity}`
       const allArgs = [loadNameArg, locationArg, quantityArg].join(',\n')
       const allArgsIndented = indentPyLines(allArgs)
       return (
-        `lid_stack_${slot} = ${PROTOCOL_CONTEXT_NAME}.load_lid_stack(\n` +
+        `lid_stack_${location} = ${PROTOCOL_CONTEXT_NAME}.load_lid_stack(\n` +
         `${allArgsIndented},\n` +
         `)`
       )


### PR DESCRIPTION
closes AUTH-2240

# Overview

Before, we weren't emitting a `load_lid_stack()` at all when loading any lid on the deck riser. This PR fixes that

## Test Plan and Hands on Testing

Create a protocol with a deck riser and add a lid to the top of it. export and review the python, should say there is a load lid stack command where the location is the adapter python name

## Changelog

- emit load lid stack when loading any sort of lid on the deck riser, this is the only adapter that accepts lids

## Risk assessment

low