### PR TITLE
fix(protocol-designer): LiquidDetailCard should show volume of its liquidId, not selectedValue

### DIFF
--- a/protocol-designer/src/components/organisms/SlotDetailModal/LiquidDetailCard.tsx
+++ b/protocol-designer/src/components/organisms/SlotDetailModal/LiquidDetailCard.tsx
@@ -50,7 +50,7 @@ export function LiquidDetailCard(props: LiquidDetailCardProps): JSX.Element {
     border: 1px solid ${COLORS.blue50};
     border-radius: ${BORDERS.borderRadius8};
   `
-  const volumeByWell = volumesPerLiquid[parseInt(selectedValue ?? '0')]
+  const volumeByWell = volumesPerLiquid[liquidId]
   const volumePerWellRange = getWellRangeForLiquidLabwarePair(
     volumeByWell,
     labwareWellOrdering
@@ -60,7 +60,7 @@ export function LiquidDetailCard(props: LiquidDetailCardProps): JSX.Element {
     setSelectedValue(liquidId)
   }
 
-  const totalVolume = sum(Object.values(volumesPerLiquid[parseInt(liquidId)]))
+  const totalVolume = sum(Object.values(volumesPerLiquid[liquidId]))
 
   return (
     <Box


### PR DESCRIPTION
# Overview

This is one of several fixes related to RQA-4612 and https://opentrons-76.sentry.io/issues/6804929039?project=4509363266387968.

In `<LiquidDetailCard>`, we were getting the volume with:
```
const volumeByWell = volumesPerLiquid[parseInt(selectedValue ?? '0')]
```

This is wrong because there's one `<LiquidDetailCard>` for each `liquidId`, so each `<LiquidDetailCard>` should be getting the volumes for its own `liquidId`, and not the `selectedValue`.

## Test Plan and Hands on Testing

Smoke tested on PD running locally. Will run CI tests.

Note that this bug is not easily user-visible, because we only show the volumes when this card is the selected one. So for the non-selected cards, we're just getting the wrong volumes, though we're not showing them.

## Risk assessment

Lowish.