### PR TITLE
refactor(protocol-designer): make selectedLiquidId non-nullable in LiquidCardList/LiquidDetailCard

### DIFF
--- a/protocol-designer/src/components/organisms/SlotDetailModal/LiquidCardList.tsx
+++ b/protocol-designer/src/components/organisms/SlotDetailModal/LiquidCardList.tsx
@@ -12,7 +12,7 @@ import type { WellContentsByNumber } from './index'
 
 interface LiquidCardListProps {
   selectedLabware: LabwareOnDeck
-  selectedLiquidId: string | undefined
+  selectedLiquidId: string
   setSelectedLiquidId: Dispatch<SetStateAction<string | undefined>>
   allIngredGroupFields: AllIngredGroupFields
   individualIds: string[]

--- a/protocol-designer/src/components/organisms/SlotDetailModal/LiquidDetailCard.tsx
+++ b/protocol-designer/src/components/organisms/SlotDetailModal/LiquidDetailCard.tsx
@@ -32,7 +32,7 @@ interface LiquidDetailCardProps {
   labwareWellOrdering: string[][]
   volumesPerLiquid: Record<string, WellContentsByNumber>
   setSelectedValue: Dispatch<SetStateAction<string | undefined>>
-  selectedValue?: string
+  selectedValue: string
 }
 
 export function LiquidDetailCard(props: LiquidDetailCardProps): JSX.Element {

--- a/protocol-designer/src/components/organisms/SlotDetailModal/index.tsx
+++ b/protocol-designer/src/components/organisms/SlotDetailModal/index.tsx
@@ -171,7 +171,7 @@ export const SlotDetailModal = (
           {selectedLiquidId != null ? (
             <LiquidCardList
               selectedLabware={labwareOnDeck}
-              selectedLiquidId={selectedLiquidId ?? ''}
+              selectedLiquidId={selectedLiquidId}
               setSelectedLiquidId={setSelectedLiquidId}
               allIngredGroupFields={allIngredientGroupFields}
               individualIds={individualIds}


### PR DESCRIPTION
# Overview

Another change for RQA-4612:

In `<LiquidCardList>`, we declared the `selectedLiquidId` prop as optional, and in `<LiquidDetailCard>`, we declared the prop `selectedValue` as optional.

However, these components are only ever rendered when there **is** a selected value: https://github.com/Opentrons/opentrons/blob/37e527266d757b9d1111d907d1b60ed3ba049149/protocol-designer/src/components/organisms/SlotDetailModal/index.tsx#L171-L180

So we can get stronger type-checking in TypeScript by making `selectedLiquidId` required instead of optional.

## Test Plan and Hands on Testing

Will run CI tests.

## Risk assessment

Low. Just a type declaration change, has no effect on functionality.