### PR TITLE
fix(protocol-designer): don't use liquid displayColor to choose default selectedLiquidId

### DIFF
--- a/protocol-designer/src/components/organisms/SlotDetailModal/index.tsx
+++ b/protocol-designer/src/components/organisms/SlotDetailModal/index.tsx
@@ -78,14 +78,9 @@ export const SlotDetailModal = (
   const individualIds = getLiquidIdsOnLabware(wellContents)
 
   const volumesPerLiquid = getVolumesPerLiquid(wellContents, individualIds)
-  const ingedInputs = Object.values(allIngredientGroupFields)
-  const wellFill = Object.values(allWellFill)
 
   const [selectedLiquidId, setSelectedLiquidId] = useState<string | undefined>(
-    wellFill.length > 0
-      ? ingedInputs.find(ingred => wellFill.includes(ingred.displayColor))
-          ?.liquidGroupId ?? ingedInputs[0].liquidGroupId
-      : undefined
+    individualIds[0] // default to the first liquidId in this labware
   )
   const wellContentsWithLiquidId: WellGroup =
     wellContents != null && selectedLiquidId != null


### PR DESCRIPTION
# Overview

Part 3 of the fix for RQA-4612 / https://opentrons-76.sentry.io/issues/6804929039?project=4509363266387968

In `<SlotDetailModal>`, we were trying to pick a default value for `selectedLiquidId` like this: https://github.com/Opentrons/opentrons/blob/0658d18d98c317ec6f16c537c1faae9d16ae3a39/protocol-designer/src/components/organisms/SlotDetailModal/index.tsx#L84-L89
We were looping through all the `liquidId`s that are defined in the protocol, and picking the first `liquidId` whose `displayColor` is present in this labware.

But this is broken when there are multiple liquids with the same `displayColor`. In the test file attached to RQA-4612, the wellplate contains only `liquidId="1"` with the color `#aabbcc`, but the protocol happens to define another liquid `liquidId="0"` with the same color. In the code above, we would pick a `selectedLiquidId` of `liquidId="0"` because it comes first ... and then crash because the wellplate doesn't have `liquidId="0"` in it.

In this fix, we just pick a default `selectedLiquidId` of `individualIds[0]`, which is the first `liquidId` that is present on this labware.

## Test Plan and Hands on Testing

Load the protocol attached to the JIRA ticket into PD 8.5.2, and observe that it crashes when you click "View labware." Confirmed that it no longer crashes with this change.

## Risk assessment

Low. Fixes broken behavior, and simplifies the code.