### PR TITLE
refactor(protocol-designer): Add a feature flag for concurrent module actions

### DIFF
--- a/protocol-designer/src/assets/localization/en/feature_flags.json
+++ b/protocol-designer/src/assets/localization/en/feature_flags.json
@@ -47,6 +47,10 @@
     "title": "Enable more labware capabilities",
     "description": "Ability to stack labware, add lids, etc"
   },
+  "OT_PD_ENABLE_CONCURRENT_MODULE_ACTIONS": {
+    "title": "Enable concurrent module actions",
+    "description": "Features and design changes for running steps while waiting for modules to do stuff."
+  },
   "OT_PD_ENABLE_JSON_EXPORT": {
     "title": "Enable exporting JSON",
     "description": "Enables the ability to export JSON for internal usages only"

--- a/protocol-designer/src/feature-flags/reducers.ts
+++ b/protocol-designer/src/feature-flags/reducers.ts
@@ -40,6 +40,8 @@ const initialFlags: Flags = {
   OT_PD_ENABLE_PARTIAL_TIP_SUPPORT:
     process.env.OT_PD_ENABLE_PARTIAL_TIP_SUPPORT === '1' || false,
   OT_PD_ENABLE_STACKING: process.env.OT_PD_ENABLE_STACKING === '1' || false,
+  OT_PD_ENABLE_CONCURRENT_MODULE_ACTIONS:
+    process.env.OT_PD_ENABLE_CONCURRENT_MODULE_ACTIONS === '1' || false,
   OT_PD_ENABLE_JSON_EXPORT:
     process.env.OT_PD_ENABLE_JSON_EXPORT === '1' || false,
 }

--- a/protocol-designer/src/feature-flags/selectors.ts
+++ b/protocol-designer/src/feature-flags/selectors.ts
@@ -63,6 +63,10 @@ export const getEnableStacking: Selector<boolean> = createSelector(
   getFeatureFlagData,
   flags => flags.OT_PD_ENABLE_STACKING ?? false
 )
+export const getEnableConcurrentModuleActions: Selector<boolean> = createSelector(
+  getFeatureFlagData,
+  flags => flags.OT_PD_ENABLE_CONCURRENT_MODULE_ACTIONS ?? false
+)
 export const getEnableJsonExport: Selector<boolean> = createSelector(
   getFeatureFlagData,
   flags => flags.OT_PD_ENABLE_JSON_EXPORT ?? false

--- a/protocol-designer/src/feature-flags/types.ts
+++ b/protocol-designer/src/feature-flags/types.ts
@@ -43,6 +43,7 @@ export type FlagTypes =
   | 'OT_PD_ENABLE_TIMELINE_SCRUBBER'
   | 'OT_PD_ENABLE_PARTIAL_TIP_SUPPORT'
   | 'OT_PD_ENABLE_STACKING'
+  | 'OT_PD_ENABLE_CONCURRENT_MODULE_ACTIONS'
   //  this feature is for internal purposes, users should never export JSON
   | 'OT_PD_ENABLE_JSON_EXPORT'
 // flags that are not in this list only show in prerelease mode
@@ -62,6 +63,7 @@ export const allFlags: FlagTypes[] = [
   'OT_PD_ENABLE_TIMELINE_SCRUBBER',
   'OT_PD_ENABLE_PARTIAL_TIP_SUPPORT',
   'OT_PD_ENABLE_STACKING',
+  'OT_PD_ENABLE_CONCURRENT_MODULE_ACTIONS',
   'OT_PD_ENABLE_JSON_EXPORT',
 ]
 export type Flags = Partial<Record<FlagTypes, boolean | null | undefined>>


### PR DESCRIPTION
## Overview

Adds a Protocol Designer feature flag that will be used to hide in-development work for concurrent module actions. Not wired up to anything yet.

Closes EXEC-1689.

## Test Plan and Hands on Testing

* [x] The new feature flag appears on the settings page when `OT_PD_PRERELEASE_MODE=1`, and otherwise does not.

## Review requests

I'm just copying the patterns from #17828, so let me know if I missed anything.

## Risk assessment

Low.