### PR TITLE
fix(protocol-designer): style fixes for tip management in PD

### DIFF
--- a/protocol-designer/src/assets/localization/en/protocol_steps.json
+++ b/protocol-designer/src/assets/localization/en/protocol_steps.json
@@ -186,7 +186,7 @@
   "time_in": "{{times}} times in",
   "timeline": "Timeline",
   "tip_handling": {
-    "title": "Tip pickup behavior",
+    "title": "Tip usage",
     "tooltip": "Choose tip pickup frequency for aspirations"
   },
   "tip_management": "Tip management",

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/ChangeTipField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/ChangeTipField.tsx
@@ -49,7 +49,6 @@ export function ChangeTipField(
       value={value}
       title={t('tip_handling.title')}
       width="100%"
-      tooltipContent={t('tip_handling.tooltip')}
     />
   )
 }

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MixTools/FirstStepMixTools.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MixTools/FirstStepMixTools.tsx
@@ -104,23 +104,25 @@ export function FirstStepMixTools({
         <StyledText desktopStyle="bodyDefaultSemiBold">
           {t('protocol_steps:tip_management')}
         </StyledText>
-        <ChangeTipField
-          {...propsForFields.changeTip}
-          aspirateWells={formData.aspirate_wells}
-          dispenseWells={formData.dispense_wells}
-          path={formData.path}
-          stepType={formData.stepType}
-          isDisposalLocation={false}
-          tooltipContent={null}
-          padding="0"
-        />
-        <DropTipField
-          {...propsForFields.dropTip_location}
-          nozzles={formData.nozzles}
-          tooltipContent={null}
-          padding="0"
-          tiprackDefUri={formData.tipRack}
-        />
+        <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing12}>
+          <ChangeTipField
+            {...propsForFields.changeTip}
+            aspirateWells={formData.aspirate_wells}
+            dispenseWells={formData.dispense_wells}
+            path={formData.path}
+            stepType={formData.stepType}
+            isDisposalLocation={false}
+            tooltipContent={null}
+            padding="0"
+          />
+          <DropTipField
+            {...propsForFields.dropTip_location}
+            nozzles={formData.nozzles}
+            tooltipContent={null}
+            padding="0"
+            tiprackDefUri={formData.tipRack}
+          />
+        </Flex>
       </Flex>
       {enableTipPickupLocation ? (
         <>

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/FirstStepMoveLiquidTools.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/FirstStepMoveLiquidTools.tsx
@@ -154,23 +154,25 @@ export function FirstStepMoveLiquidTools({
         <StyledText desktopStyle="bodyDefaultSemiBold">
           {t('tip_management')}
         </StyledText>
-        <ChangeTipField
-          {...propsForFields.changeTip}
-          aspirateWells={formData.aspirate_wells}
-          dispenseWells={formData.dispense_wells}
-          path={formData.path}
-          stepType={formData.stepType}
-          isDisposalLocation={isDisposalLocation}
-          tooltipContent={null}
-          padding="0"
-        />
-        <DropTipField
-          {...propsForFields.dropTip_location}
-          nozzles={formData.nozzles}
-          tiprackDefUri={formData.tipRack}
-          tooltipContent={null}
-          padding="0"
-        />
+        <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing12}>
+          <ChangeTipField
+            {...propsForFields.changeTip}
+            aspirateWells={formData.aspirate_wells}
+            dispenseWells={formData.dispense_wells}
+            path={formData.path}
+            stepType={formData.stepType}
+            isDisposalLocation={isDisposalLocation}
+            tooltipContent={null}
+            padding="0"
+          />
+          <DropTipField
+            {...propsForFields.dropTip_location}
+            nozzles={formData.nozzles}
+            tiprackDefUri={formData.tipRack}
+            tooltipContent={null}
+            padding="0"
+          />
+        </Flex>
       </Flex>
       {enableTipPickupLocation ? (
         <>


### PR DESCRIPTION
# Overview

Provide minor style fixes for PD tip management section in mix and transfer step forms.

[Designs](https://www.figma.com/design/VBs9eWmCwtzlF1qas5lUG4/Feature--Partial-tip-pickup?node-id=1034-38718&p=f&t=2M1PXYrqLmG0SaMY-0)

## Test Plan and Hands on Testing

- create or open mix form
- scroll to tip management section
- verify that padding matches designs
- verify that tip usage dropdown has no tooltip
- repeat with moveLiquid form

## Changelog

- fix padding
- remove tooltip
- rename tip usage dropdown title

## Review requests

see test plan

## Risk assessment

low