### PR TITLE
fix(app): Fix selectability on select module screen in setup wizard

### DIFF
--- a/app/src/organisms/ModuleWizardFlows/SelectLocation.tsx
+++ b/app/src/organisms/ModuleWizardFlows/SelectLocation.tsx
@@ -15,7 +15,6 @@ import {
   FAKE_FIXTURE_IDS,
   FLEX_MODULE_AA_TYPE_BY_MODEL,
   FLEX_ROBOT_TYPE,
-  FLEX_STACKER_FIXTURES,
   FLEX_STACKER_MODULE_TYPE,
   getAAByAAId,
   getAAForModuleFixture,
@@ -123,13 +122,12 @@ export function SelectLocation(props: SelectLocationProps): JSX.Element {
         ) && attachedModule.serialNumber === opentronsModuleSerialNumber
       if (
         // in run setup, module calibration only available when module location is already correctly configured
-        (!isLoadedInRun &&
-          mayMountToCutoutIds.includes(cutoutId) &&
-          (isCurrentConfiguration ||
-            SINGLE_SLOT_FIXTURES.includes(cutoutFixtureId) ||
-            // fake fixtures include mag block next to an empty staging slot and a waste chute next to an empty staging slot
-            FAKE_FIXTURE_IDS.includes(cutoutFixtureId))) ||
-        FLEX_STACKER_FIXTURES.includes(cutoutFixtureId as CutoutFixtureId)
+        !isLoadedInRun &&
+        mayMountToCutoutIds.includes(cutoutId) &&
+        (isCurrentConfiguration ||
+          SINGLE_SLOT_FIXTURES.includes(cutoutFixtureId) ||
+          // fake fixtures include mag block next to an empty staging slot and a waste chute next to an empty staging slot
+          FAKE_FIXTURE_IDS.includes(cutoutFixtureId))
       ) {
         return [...acc, cutoutId]
       }

--- a/components/src/hardware-sim/DeckConfigurator/index.tsx
+++ b/components/src/hardware-sim/DeckConfigurator/index.tsx
@@ -4,6 +4,7 @@ import {
   filterAAByAreaType,
   FLEX_ROBOT_TYPE,
   getDeckDefFromRobotType,
+  isModuleAllowedOnAA,
   replaceFixtureToFakeFixtureAndTransformCutoutFixturesToAA,
   STAGING_AREA_SLOT_WITH_MAGNETIC_BLOCK_V1_FIXTURE,
   THERMOCYCLER_MODULE_CUTOUTS,
@@ -144,22 +145,26 @@ export function DeckConfigurator(props: DeckConfiguratorProps): JSX.Element {
       viewBox={`${deckDef.cornerOffsetFromOrigin[0]} ${deckDef.cornerOffsetFromOrigin[1]} ${deckDef.dimensions[0]} ${deckDef.dimensions[1]}`}
     >
       {stagingAreaItems.map(
-        ({ cutoutId, cutoutFixtureId, addressableAreaId }) => (
-          <StagingAreaConfigItem
-            data-testid={cutoutId}
-            key={addressableAreaId}
-            deckDefinition={deckDef}
-            handleClickRemove={
-              editableCutoutIds.includes(cutoutId)
-                ? handleClickRemove
-                : undefined
-            }
-            fixtureLocation={cutoutId}
-            cutoutFixtureId={cutoutFixtureId}
-            addressableAreaId={addressableAreaId}
-            selected={cutoutId === selectedCutoutId}
-          />
-        )
+        ({ cutoutId, cutoutFixtureId, addressableAreaId }) => {
+          const shouldAllowRemove =
+            moduleModel != null
+              ? isModuleAllowedOnAA(cutoutId, addressableAreaId, moduleModel)
+              : editableCutoutIds.includes(cutoutId)
+          return (
+            <StagingAreaConfigItem
+              data-testid={cutoutId}
+              key={addressableAreaId}
+              deckDefinition={deckDef}
+              handleClickRemove={
+                shouldAllowRemove ? handleClickRemove : undefined
+              }
+              fixtureLocation={cutoutId}
+              cutoutFixtureId={cutoutFixtureId}
+              addressableAreaId={addressableAreaId}
+              selected={cutoutId === selectedCutoutId}
+            />
+          )
+        }
       )}
       {emptySlotLikeItems.map(({ cutoutId, addressableAreaId }) => (
         <EmptyConfigItem
@@ -174,21 +179,25 @@ export function DeckConfigurator(props: DeckConfiguratorProps): JSX.Element {
         />
       ))}
       {wasteChuteItems.map(
-        ({ cutoutId, cutoutFixtureId, addressableAreaId }) => (
-          <WasteChuteConfigFixture
-            data-testid={cutoutId}
-            key={addressableAreaId}
-            deckDefinition={deckDef}
-            handleClickRemove={
-              editableCutoutIds.includes(cutoutId)
-                ? handleClickRemove
-                : undefined
-            }
-            fixtureLocation={cutoutId}
-            cutoutFixtureId={cutoutFixtureId}
-            selected={cutoutId === selectedCutoutId}
-          />
-        )
+        ({ cutoutId, cutoutFixtureId, addressableAreaId }) => {
+          const shouldAllowRemove =
+            moduleModel != null
+              ? isModuleAllowedOnAA(cutoutId, addressableAreaId, moduleModel)
+              : editableCutoutIds.includes(cutoutId)
+          return (
+            <WasteChuteConfigFixture
+              data-testid={cutoutId}
+              key={addressableAreaId}
+              deckDefinition={deckDef}
+              handleClickRemove={
+                shouldAllowRemove ? handleClickRemove : undefined
+              }
+              fixtureLocation={cutoutId}
+              cutoutFixtureId={cutoutFixtureId}
+              selected={cutoutId === selectedCutoutId}
+            />
+          )
+        }
       )}
       {trashBinItems.map(({ cutoutId, cutoutFixtureId, addressableAreaId }) => (
         <TrashBinConfigItem
@@ -241,26 +250,30 @@ export function DeckConfigurator(props: DeckConfiguratorProps): JSX.Element {
         )
       )}
       {magneticBlockItems.map(
-        ({ cutoutId, cutoutFixtureId, addressableAreaId }) => (
-          <MagneticBlockItem
-            data-testid={cutoutId}
-            key={addressableAreaId}
-            deckDefinition={deckDef}
-            handleClickRemove={
-              editableCutoutIds.includes(cutoutId)
-                ? handleClickRemove
-                : undefined
-            }
-            fixtureLocation={cutoutId}
-            cutoutFixtureId={cutoutFixtureId}
-            addressableAreaId={addressableAreaId}
-            selected={cutoutId === selectedCutoutId}
-            hasStagingArea={
-              cutoutFixtureId ===
-              STAGING_AREA_SLOT_WITH_MAGNETIC_BLOCK_V1_FIXTURE
-            }
-          />
-        )
+        ({ cutoutId, cutoutFixtureId, addressableAreaId }) => {
+          const shouldAllowRemove =
+            moduleModel != null
+              ? isModuleAllowedOnAA(cutoutId, addressableAreaId, moduleModel)
+              : editableCutoutIds.includes(cutoutId)
+          return (
+            <MagneticBlockItem
+              data-testid={cutoutId}
+              key={addressableAreaId}
+              deckDefinition={deckDef}
+              handleClickRemove={
+                shouldAllowRemove ? handleClickRemove : undefined
+              }
+              fixtureLocation={cutoutId}
+              cutoutFixtureId={cutoutFixtureId}
+              addressableAreaId={addressableAreaId}
+              selected={cutoutId === selectedCutoutId}
+              hasStagingArea={
+                cutoutFixtureId ===
+                STAGING_AREA_SLOT_WITH_MAGNETIC_BLOCK_V1_FIXTURE
+              }
+            />
+          )
+        }
       )}
       {thermocyclerItems.map(
         ({ cutoutId, cutoutFixtureId, addressableAreaId }) => {


### PR DESCRIPTION
Fix RQA-4610
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
In the `SelectLocation` screen of the module wizard flow, there was some wonky behavior for the stacker being next to items in 3/4 where there can be multiple selected modules or fixtures per cutoutId. 

When adding a stacker all items in 3/4 were shown with an "x" and when you selected a location for the stacker, if there was a mag block or waste chute right next to it, that item would also get the blue highlight. Pressing the "x" on this item would remove the stacker. Pressing the "x" on this item when there was no stacker next to it would do nothing.

This PR fixes those bugs! Now, the stacker being edited is the only thing that will get the blue highlight behavior and the only thing that will have an "x" which matches behavior for other modules and previous releases.
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
1. With a mag block and waste chute attached, go through the setup flow for a flex stacker and see that none of the other items in columns 3/4 have the "x", and that nothing next to the stacker is highlighted blue
2. Smoke test this flow for other modules
<img width="813" height="517" alt="Screenshot 2025-08-27 at 4 47 55 PM" src="https://github.com/user-attachments/assets/7786a8ad-c223-419e-a42b-75b423e45641" />
<img width="831" height="505" alt="Screenshot 2025-08-27 at 4 47 51 PM" src="https://github.com/user-attachments/assets/d05aa5d1-c2c6-409d-b422-c2dbbe901cc4" />

<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
1. Remove check that was adding all flex stacker fixtures to the `editableCutoutIds` list
2. Utilize `isModuleAllowedOnAA` function to secondarily check whether we should allow mag blocks and waste chutes to be editable

<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests
Check my logic, I think it all makes sense
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
Low, I tested pretty thoroughly so feel confident about this fix. 
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
