### PR TITLE
fix(app): Ensure pipette detach flow does not raise stall error

### DIFF
--- a/app/src/organisms/PipetteWizardFlows/DetachPipette.tsx
+++ b/app/src/organisms/PipetteWizardFlows/DetachPipette.tsx
@@ -115,7 +115,7 @@ export const DetachPipette = (props: DetachPipetteProps): JSX.Element => {
         {
           commandType: 'unsafe/updatePositionEstimators' as const,
           params: {
-            axes: ['x', 'y'],
+            axes: ['x', 'y', 'rightZ'],
           },
         },
         {

--- a/app/src/organisms/PipetteWizardFlows/DetachPipette.tsx
+++ b/app/src/organisms/PipetteWizardFlows/DetachPipette.tsx
@@ -115,7 +115,7 @@ export const DetachPipette = (props: DetachPipetteProps): JSX.Element => {
         {
           commandType: 'unsafe/updatePositionEstimators' as const,
           params: {
-            axes: ['x', 'y', 'rightZ'],
+            axes: ['x', 'y', 'rightZ', 'leftZ'],
           },
         },
         {


### PR DESCRIPTION
# Overview
Covers RQA-4599

In a previous PR [here](https://github.com/Opentrons/opentrons/pull/18114) an unsafe position estimation update was added for the X and Y to fix a similar issue from RQA-4020. Adding in the rightZ axis to this solves the problem of the Stall error raising during the pipette detach flow.

## Test Plan and Hands on Testing
- [x] Attach and detach a 96ch pipette, ensure the error does not raise

## Changelog


## Review requests
Is there a reason why this was not in the original implementation? I still have not found what has changed elsewhere to cause the rightZ stage to lose tracking.

## Risk assessment
