### PR TITLE
fix(app): fix inverted drop tip wizard `selected` text

### DIFF
--- a/components/src/hooks/useSelectDeckLocation/index.tsx
+++ b/components/src/hooks/useSelectDeckLocation/index.tsx
@@ -332,4 +332,5 @@ const INNER_DIV_PROPS = {
   justifyContent: JUSTIFY_CENTER,
   height: '100%',
   gridGap: SPACING.spacing4,
+  transform: 'scaleY(-1)',
 }


### PR DESCRIPTION
Closes [RABR-824](https://opentrons.atlassian.net/browse/RABR-824)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Fixes inverted text in the drop tip wizard specific deck map. 

It would be worth investigating the root cause of this regression at some point when we're less pressed for time. It seemed like it may have been related to the CSS module migration, but the old code in `RobotCoordinateSpace` was doing exactly the same thing pre-migration. 

### Before

<img width="754" height="430" alt="Screenshot 2025-08-28 at 9 55 21 AM" src="https://github.com/user-attachments/assets/6f767bd2-cce1-4ba4-970a-016dea9b61d1" />

### After

<img width="1017" height="771" alt="Screenshot 2025-08-28 at 9 25 23 AM" src="https://github.com/user-attachments/assets/23a1bd18-5131-471a-bbc5-7b91b38f56ab" />

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- See images
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed inverted "selected" text in drop tip wizard when clicking a slot on the deck map.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
very low - only drop tip wizard uses this component, so the change is quite isolated.
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RABR-824]: https://opentrons.atlassian.net/browse/RABR-824?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ