### PR TITLE
fix(app): hopper-empty ER should home

### DIFF
--- a/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/StackerSelectErrorFlow.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/StackerSelectErrorFlow.tsx
@@ -57,9 +57,11 @@ export function StackerHopperOrShuttleEmptyOptions(
     getRecoveryOptionCopy,
     isOnDevice,
     currentRecoveryOptionUtils,
+    recoveryCommands,
   } = props
-  const { proceedToRouteAndStep } = routeUpdateActions
+  const { proceedToRouteAndStep, handleMotionRouting } = routeUpdateActions
   const { setSelectedRecoveryOption } = currentRecoveryOptionUtils
+  const { homeShuttle } = recoveryCommands
   const { t } = useTranslation('error_recovery')
 
   const [showErrorOptions, setShowErrorOptions] = useState<boolean>(true)
@@ -70,14 +72,23 @@ export function StackerHopperOrShuttleEmptyOptions(
     undefined
   )
 
-  const handlePrimaryClick = (): void => {
+  const handlePrimaryClick = (): Promise<void> => {
     if (showErrorOptions) {
       const options = getRecoveryOptions(selectedError)
       setSelectedRoute(options[0])
       setShowErrorOptions(false)
+      return Promise.resolve()
     } else if (selectedRoute != null) {
       setSelectedRecoveryOption(selectedRoute)
-      void proceedToRouteAndStep(selectedRoute)
+      return handleMotionRouting(true).then(() => {
+        void homeShuttle().finally(() => {
+          void handleMotionRouting(false).then(() => {
+            void proceedToRouteAndStep(selectedRoute)
+          })
+        })
+      })
+    } else {
+      return Promise.resolve()
     }
   }
 


### PR DESCRIPTION
Looks like we forgot to link in the stacker shuttle homing that was in the designs for stacker hopper empty, whoops.

Closes RQA-4616

## testing
- [x] cause a stacker-empty error
- [x] in both the skip and retry cases, the shuttle should home after you select retry or skip and continue to the flow-specific screens