### PR TITLE
fix(app): Clean up slot capitalization and usage in invervention and error modals

### DIFF
--- a/app/src/assets/localization/en/shared.json
+++ b/app/src/assets/localization/en/shared.json
@@ -71,6 +71,7 @@
   "robot_is_reachable_but_not_responding": "This robot's API server is not responding correctly to requests at IP address {{hostname}}",
   "robot_was_seen_but_is_unreachable": "This robot has been seen recently, but is currently not reachable at IP address {{hostname}}",
   "save": "save",
+  "slot": "Slot {{slot}}",
   "something_went_wrong": "something went wrong",
   "sort_by": "Sort by",
   "stand_back_robot_is_in_motion": "Stand back, robot is in motion",

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useFailedLabwareUtils.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useFailedLabwareUtils.ts
@@ -536,6 +536,7 @@ export function useRelevantFailedLwLocations({
                 (m: LoadedModule) =>
                   m.id === failedCommandByRunRecord?.params.moduleId
               )?.location ?? 'offDeck',
+            includeSlotText: false,
           }),
           newLoc: {
             moduleId: failedCommandByRunRecord?.params.moduleId,

--- a/app/src/organisms/ErrorRecoveryFlows/shared/LeftColumnLabwareInfo.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/LeftColumnLabwareInfo.tsx
@@ -42,12 +42,14 @@ export function LeftColumnLabwareInfo({
     STACKER_HOPPER_EMPTY_SKIP,
     STACKER_SHUTTLE_EMPTY_SKIP,
   } = RECOVERY_MAP
-  const { t } = useTranslation(['error_recovery', 'shared'])
+  const { t, i18n } = useTranslation(['error_recovery', 'shared'])
 
   const buildNewLocation = (): ComponentProps<
     typeof InterventionContent
   >['infoProps']['newLocationProps'] =>
-    displayNameNewLoc != null ? { deckLabel: displayNameNewLoc } : undefined
+    displayNameNewLoc != null
+      ? { deckLabel: displayNameNewLoc.toUpperCase() }
+      : undefined
 
   const buildInfoNames = (): {
     labwareName: string
@@ -89,9 +91,12 @@ export function LeftColumnLabwareInfo({
             labwareName: failedLabwareNames.name ?? '',
             labwareNickname: failedLabwareNames.nickName,
             currentLocationProps: {
-              deckLabel: t('shared:slot', {
-                slot: `${(displayNameNewLoc ?? '').slice(0, -1)}4`,
-              }),
+              deckLabel: i18n.format(
+                t('shared:slot', {
+                  slot: `${(displayNameNewLoc ?? '').slice(0, -1)}4`,
+                }),
+                'upperCase'
+              ),
             },
           }
         default:
@@ -99,7 +104,7 @@ export function LeftColumnLabwareInfo({
             labwareName: failedLabwareNames.name ?? '',
             labwareNickname: failedLabwareNames.nickName,
             currentLocationProps: {
-              deckLabel: failedLabwareLocations.displayNameCurrentLoc,
+              deckLabel: failedLabwareLocations.displayNameCurrentLoc.toUpperCase(),
             },
           }
       }

--- a/app/src/organisms/ErrorRecoveryFlows/shared/LeftColumnLabwareInfo.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/LeftColumnLabwareInfo.tsx
@@ -42,14 +42,12 @@ export function LeftColumnLabwareInfo({
     STACKER_HOPPER_EMPTY_SKIP,
     STACKER_SHUTTLE_EMPTY_SKIP,
   } = RECOVERY_MAP
-  const { t } = useTranslation('error_recovery')
+  const { t } = useTranslation(['error_recovery', 'shared'])
 
   const buildNewLocation = (): ComponentProps<
     typeof InterventionContent
   >['infoProps']['newLocationProps'] =>
-    displayNameNewLoc != null
-      ? { deckLabel: displayNameNewLoc.toUpperCase() }
-      : undefined
+    displayNameNewLoc != null ? { deckLabel: displayNameNewLoc } : undefined
 
   const buildInfoNames = (): {
     labwareName: string
@@ -91,9 +89,9 @@ export function LeftColumnLabwareInfo({
             labwareName: failedLabwareNames.name ?? '',
             labwareNickname: failedLabwareNames.nickName,
             currentLocationProps: {
-              deckLabel: `${(displayNameNewLoc?.toUpperCase() ?? '').charAt(
-                0
-              )}4`,
+              deckLabel: t('shared:slot', {
+                slot: `${(displayNameNewLoc ?? '').slice(0, -1)}4`,
+              }),
             },
           }
         default:
@@ -101,7 +99,7 @@ export function LeftColumnLabwareInfo({
             labwareName: failedLabwareNames.name ?? '',
             labwareNickname: failedLabwareNames.nickName,
             currentLocationProps: {
-              deckLabel: failedLabwareLocations.displayNameCurrentLoc.toUpperCase(),
+              deckLabel: failedLabwareLocations.displayNameCurrentLoc,
             },
           }
       }

--- a/app/src/organisms/InterventionModal/MoveLabwareInterventionContent.tsx
+++ b/app/src/organisms/InterventionModal/MoveLabwareInterventionContent.tsx
@@ -47,7 +47,7 @@ export function MoveLabwareInterventionContent({
   robotType,
   isOnDevice,
 }: MoveLabwareInterventionProps): JSX.Element | null {
-  const { t, i18n } = useTranslation('protocol_command_text')
+  const { t } = useTranslation('protocol_command_text')
 
   const analysisCommands = analysis?.commands ?? []
   const labwareDefsByUri = getLoadedLabwareDefinitionsByUri(analysisCommands)
@@ -126,10 +126,10 @@ export function MoveLabwareInterventionContent({
             type="location-arrow-location"
             labwareName={labwareName}
             currentLocationProps={{
-              deckLabel: i18n.format(oldDisplayLabwareLocation, 'upperCase'),
+              deckLabel: oldDisplayLabwareLocation,
             }}
             newLocationProps={{
-              deckLabel: i18n.format(newDisplayLabwareLocation, 'upperCase'),
+              deckLabel: newDisplayLabwareLocation,
             }}
           />
         </Flex>

--- a/app/src/organisms/InterventionModal/MoveLabwareInterventionContent.tsx
+++ b/app/src/organisms/InterventionModal/MoveLabwareInterventionContent.tsx
@@ -47,7 +47,7 @@ export function MoveLabwareInterventionContent({
   robotType,
   isOnDevice,
 }: MoveLabwareInterventionProps): JSX.Element | null {
-  const { t } = useTranslation('protocol_command_text')
+  const { t, i18n } = useTranslation('protocol_command_text')
 
   const analysisCommands = analysis?.commands ?? []
   const labwareDefsByUri = getLoadedLabwareDefinitionsByUri(analysisCommands)
@@ -126,10 +126,10 @@ export function MoveLabwareInterventionContent({
             type="location-arrow-location"
             labwareName={labwareName}
             currentLocationProps={{
-              deckLabel: oldDisplayLabwareLocation,
+              deckLabel: i18n.format(oldDisplayLabwareLocation, 'upperCase'),
             }}
             newLocationProps={{
-              deckLabel: newDisplayLabwareLocation,
+              deckLabel: i18n.format(newDisplayLabwareLocation, 'upperCase'),
             }}
           />
         </Flex>


### PR DESCRIPTION
fix RQA-4615
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
There was a lot of confusion between dev and design on whether we wanted "Slot" to appear in the deck info labels on manual intervention error recovery and pause screens. This fixes the locations for stacker that got wonky when we added "Slot" back in
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
Test manual move labware, manual fill and empty stacker, move labware error recover, stacker error recovery screens
<img width="814" height="472" alt="Screenshot 2025-08-28 at 1 28 15 PM" src="https://github.com/user-attachments/assets/57b63d1c-8513-4a1b-b0c8-acc5924ae951" />
<img width="787" height="464" alt="Screenshot 2025-08-28 at 1 28 09 PM" src="https://github.com/user-attachments/assets/6127aa1a-912b-431b-898d-1481ba606e42" />
<img width="788" height="470" alt="Screenshot 2025-08-28 at 1 27 33 PM" src="https://github.com/user-attachments/assets/607132da-6a40-47ba-aa21-f7ad2fff6203" />
<img width="794" height="467" alt="Screenshot 2025-08-28 at 1 27 24 PM" src="https://github.com/user-attachments/assets/4cfe189b-010d-4069-bd4b-73c0039f4070" />
<img width="796" height="404" alt="Screenshot 2025-08-28 at 1 27 15 PM" src="https://github.com/user-attachments/assets/cd61eac2-4bdb-4a38-ae68-60fbf8636ed5" />

<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
Remove uppercase text formatting
For stacker error recovery screens, don't add the slot text to the display name up front to make it easier to grab the column. Then re-add it where needed
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests
Quick check
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
Low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
