### PR TITLE
fix(app): Fix quantity field for fill stacker intervention screen

### DIFF
--- a/app/src/organisms/InterventionModal/StackerFillInterventionContent.tsx
+++ b/app/src/organisms/InterventionModal/StackerFillInterventionContent.tsx
@@ -45,31 +45,21 @@ export function StackerFillInterventionContent({
   const { data: runCurrentState } = useRunCurrentState(run.id)
   const flexStacker =
     runCurrentState?.data.flexStackerStates?.[command.params.moduleId] ?? null
+  const moduleLocation =
+    run?.modules.find(m => m.id === command.params.moduleId)?.location ?? null
+
+  if (moduleLocation?.slotName == null || flexStacker == null) return null
 
   const analysisCommands = analysis?.commands ?? []
   const labwareDefsByUri = getLoadedLabwareDefinitionsByUri(analysisCommands)
 
   // Get the name of the labware to be removed from the stacker
-  let labwareName: string | null = null
-  let quantity = command.params.count ?? null
-  if (flexStacker) {
-    const labwareDef = labwareDefsByUri?.[flexStacker.primaryLabwareURI] ?? null
-    labwareName = labwareDef?.metadata.displayName ?? null
-    if (quantity == null) {
-      quantity = flexStacker.maxCount
-    }
-  }
-
-  const moduleLocation =
-    run?.modules.find(m => m.id === command.params.moduleId)?.location ?? null
-
-  if (
-    moduleLocation?.slotName == null ||
-    labwareName == null ||
-    flexStacker == null ||
-    quantity == null
-  )
-    return null
+  const labwareDef = labwareDefsByUri?.[flexStacker.primaryLabwareURI] ?? null
+  const labwareName = labwareDef?.metadata.displayName ?? null
+  const quantity =
+    command.params.labwareToStore?.length ??
+    command.params.count ??
+    flexStacker.maxCount
 
   const infoProps: ComponentProps<typeof InterventionInfo> = {
     layout: 'stacked',


### PR DESCRIPTION
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
When a `stacker_fill_items` command is issued there is no quantity field in the params but there is a list of labware ids. In this case, we should grab the quantity field for the fill intervention screen from the length of this list.
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
Test fill stacker where no quantity is passed in but list of labware id's is passed in, see that the quantity equals the length of that list
<img width="794" height="458" alt="Screenshot 2025-08-28 at 1 56 00 PM" src="https://github.com/user-attachments/assets/5190a982-6a67-4c00-9005-af4f5b93a579" />
Test fill stacker where quantity is passed in, see that the quantity equals that number
<img width="777" height="444" alt="Screenshot 2025-08-28 at 1 57 32 PM" src="https://github.com/user-attachments/assets/7acb9b84-8c26-4c4c-a1e4-f03925371858" />

<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
Change quantity logic for fill screen to first check the list of id's in the params, then quantity field, then max count if both are empty
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests
Is this the correct logic ordering?
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
Low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
