### PR TITLE
fix(app): hide module setup and firmware update banners while run is in progress

### DIFF
--- a/app/src/organisms/ModuleCard/__tests__/ModuleCard.test.tsx
+++ b/app/src/organisms/ModuleCard/__tests__/ModuleCard.test.tsx
@@ -2,11 +2,8 @@ import { fireEvent, screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { when } from 'vitest-when'
 
-import { RUN_STATUS_IDLE, RUN_STATUS_RUNNING } from '@opentrons/api-client'
-
 import { nestedTextMatcher, renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
-import { useCurrentRunStatus } from '/app/organisms/RunTimeControl'
 import { useToaster } from '/app/organisms/ToasterOven'
 import { useIsFlex } from '/app/redux-resources/robots'
 import { getIsHeaterShakerAttached } from '/app/redux/config'
@@ -22,6 +19,7 @@ import { FAILURE, getRequestById, PENDING, SUCCESS } from '/app/redux/robot-api'
 import { mockRobot } from '/app/redux/robot-api/__fixtures__'
 import { useNotifyDeckConfigurationQuery } from '/app/resources/deck_configuration'
 import { useIsEstopNotDisengaged } from '/app/resources/devices'
+import { useRunStatuses } from '/app/resources/runs'
 
 import { ModuleCard } from '..'
 import { useIsDoorOpen } from '../../DoorOpenControl/useIsDoorOpen'
@@ -55,7 +53,7 @@ vi.mock('../FlexStackerModuleData')
 vi.mock('/app/redux/config')
 vi.mock('../ModuleOverflowMenu')
 vi.mock('../../ModuleWizardFlows')
-vi.mock('/app/organisms/RunTimeControl')
+vi.mock('/app/resources/runs')
 vi.mock('../FirmwareUpdateFailedModal')
 vi.mock('/app/redux/robot-api')
 vi.mock('/app/redux-resources/robots')
@@ -261,7 +259,9 @@ describe('ModuleCard', () => {
       eatToast: mockEatToast,
     })
     vi.mocked(getRequestById).mockReturnValue(null)
-    when(useCurrentRunStatus).calledWith().thenReturn(RUN_STATUS_IDLE)
+    when(useRunStatuses)
+      .calledWith()
+      .thenReturn({ isRunRunning: false } as any)
     when(useIsFlex).calledWith(props.robotName).thenReturn(true)
     when(useIsEstopNotDisengaged).calledWith(props.robotName).thenReturn(false)
     vi.mocked(useNotifyDeckConfigurationQuery).mockReturnValue(({
@@ -357,7 +357,9 @@ describe('ModuleCard', () => {
   })
 
   it('renders kebab icon and it is disabled when run is in progress', () => {
-    when(useCurrentRunStatus).calledWith().thenReturn(RUN_STATUS_RUNNING)
+    when(useRunStatuses)
+      .calledWith()
+      .thenReturn({ isRunRunning: true } as any)
     render({
       ...props,
       module: mockMagneticModule,

--- a/app/src/organisms/ModuleCard/index.tsx
+++ b/app/src/organisms/ModuleCard/index.tsx
@@ -179,6 +179,10 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
   }
 
   const isPending = latestRequest?.status === PENDING
+  const runInProgress =
+    runStatus === RUN_STATUS_RUNNING || runStatus === RUN_STATUS_FINISHING
+
+  const hideBanners = isPending || runInProgress
   const hotToTouch: IconProps = { name: 'ot-hot-to-touch' }
   const isFlex = useIsFlex(robotName)
   const deckConfig = useNotifyDeckConfigurationQuery().data
@@ -206,9 +210,6 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
     }
   }
   const { requireModuleCalibration, requireModuleSetup } = getSetupWizardFlow()
-
-  const isOverflowBtnDisabled =
-    runStatus === RUN_STATUS_RUNNING || runStatus === RUN_STATUS_FINISHING
 
   const isTooHot = getModuleTooHot(module)
 
@@ -366,7 +367,8 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
                 errorMessage={getErrorResponseMessage(latestRequest.error)}
               />
             )}
-            {!isPending && (requireModuleCalibration || requireModuleSetup) ? (
+            {!hideBanners &&
+            (requireModuleCalibration || requireModuleSetup) ? (
               <UpdateBanner
                 robotName={robotName}
                 updateType={requireModuleCalibration ? 'calibration' : 'setup'}
@@ -377,7 +379,7 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
                 updatePipetteFWRequired={updatePipetteFWRequired}
                 isTooHot={isTooHot}
               />
-            ) : !isPending && module.hasAvailableUpdate && showFWBanner ? (
+            ) : !hideBanners && module.hasAvailableUpdate && showFWBanner ? (
               <UpdateBanner
                 robotName={robotName}
                 updateType="firmware"
@@ -472,11 +474,11 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
       >
         <OverflowBtn
           aria-label="overflow"
-          disabled={isOverflowBtnDisabled || isEstopNotDisengaged}
+          disabled={runInProgress || isEstopNotDisengaged}
           {...targetProps}
           onClick={handleOverflowClick}
         />
-        {isOverflowBtnDisabled && (
+        {runInProgress && (
           <Tooltip tooltipProps={tooltipProps}>
             {t('module_actions_unavailable')}
           </Tooltip>

--- a/app/src/organisms/ModuleCard/index.tsx
+++ b/app/src/organisms/ModuleCard/index.tsx
@@ -2,7 +2,11 @@ import { useState } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 
-import { RUN_STATUS_FINISHING, RUN_STATUS_RUNNING } from '@opentrons/api-client'
+import {
+  RUN_STATUS_FAILED,
+  RUN_STATUS_IDLE,
+  RUN_STATUS_SUCCEEDED,
+} from '@opentrons/api-client'
 import {
   ALIGN_START,
   Banner,
@@ -180,7 +184,10 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
 
   const isPending = latestRequest?.status === PENDING
   const runInProgress =
-    runStatus === RUN_STATUS_RUNNING || runStatus === RUN_STATUS_FINISHING
+    runStatus != null &&
+    runStatus !== RUN_STATUS_SUCCEEDED &&
+    runStatus !== RUN_STATUS_FAILED &&
+    runStatus !== RUN_STATUS_IDLE
 
   const hideBanners = isPending || runInProgress
   const hotToTouch: IconProps = { name: 'ot-hot-to-touch' }

--- a/app/src/organisms/ModuleCard/index.tsx
+++ b/app/src/organisms/ModuleCard/index.tsx
@@ -3,11 +3,6 @@ import { Trans, useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 
 import {
-  RUN_STATUS_FAILED,
-  RUN_STATUS_IDLE,
-  RUN_STATUS_SUCCEEDED,
-} from '@opentrons/api-client'
-import {
   ALIGN_START,
   Banner,
   BORDERS,
@@ -43,7 +38,6 @@ import {
 import { useModuleUSBPort } from '/app/local-resources/modules'
 import { UpdateBanner } from '/app/molecules/UpdateBanner'
 import { handleModuleWizardFlows } from '/app/organisms/ModuleWizardFlows'
-import { useCurrentRunStatus } from '/app/organisms/RunTimeControl'
 import { useToaster } from '/app/organisms/ToasterOven'
 import { useIsFlex } from '/app/redux-resources/robots'
 import {
@@ -56,6 +50,7 @@ import {
 } from '/app/redux/robot-api'
 import { useNotifyDeckConfigurationQuery } from '/app/resources/deck_configuration'
 import { useIsEstopNotDisengaged } from '/app/resources/devices'
+import { useRunStatuses } from '/app/resources/runs'
 import { getModuleTooHot } from '/app/transformations/modules'
 
 import { AboutModuleSlideout } from './AboutModuleSlideout'
@@ -149,7 +144,7 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
   const [showFWBanner, setShowFWBanner] = useState(true)
   const [targetProps, tooltipProps] = useHoverTooltip()
 
-  const runStatus = useCurrentRunStatus()
+  const { isRunRunning } = useRunStatuses()
   const { parseModuleUSBPort } = useModuleUSBPort()
 
   const isPipetteReady =
@@ -183,13 +178,8 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
   }
 
   const isPending = latestRequest?.status === PENDING
-  const runInProgress =
-    runStatus != null &&
-    runStatus !== RUN_STATUS_SUCCEEDED &&
-    runStatus !== RUN_STATUS_FAILED &&
-    runStatus !== RUN_STATUS_IDLE
 
-  const hideBanners = isPending || runInProgress
+  const hideBanners = isPending || isRunRunning
   const hotToTouch: IconProps = { name: 'ot-hot-to-touch' }
   const isFlex = useIsFlex(robotName)
   const deckConfig = useNotifyDeckConfigurationQuery().data
@@ -481,11 +471,11 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
       >
         <OverflowBtn
           aria-label="overflow"
-          disabled={runInProgress || isEstopNotDisengaged}
+          disabled={isRunRunning || isEstopNotDisengaged}
           {...targetProps}
           onClick={handleOverflowClick}
         />
-        {runInProgress && (
+        {isRunRunning && (
           <Tooltip tooltipProps={tooltipProps}>
             {t('module_actions_unavailable')}
           </Tooltip>


### PR DESCRIPTION
Fix RQA-4617
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
We should hide module banners for setup & firmware update if a run is in progress
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
With a run ongoing and a module that requires a firmware update or to be calibrated, look at the device details page and see that no banners are present on the module cards. When the run is over, the banners should return
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
Use the same logic we have for disabling module overflow menu during a run to hide the banners
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests
Are these the only run statuses that are relevant?
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
Low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
