### PR TITLE
feat(api): add version argument to protocol context get_liquid_class

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/_default_liquid_class_versions.py
+++ b/api/src/opentrons/protocol_api/core/engine/_default_liquid_class_versions.py
@@ -39,22 +39,18 @@ def get_liquid_class_version(
     api_version: APIVersion,
     liquid_class_name: str,
 ) -> int:
-    """Return what version of a standard labware the Protocol API should load by default.
-
-    The `default_labware_versions` param is exposed for testability and should be left
-    unspecified.
-    """
-    default_labware_versions_newest_to_oldest = sorted(
+    """Return what version of a liquid class the Protocol API should load by default."""
+    default_lc_versions_newest_to_oldest = sorted(
         DEFAULT_LIQUID_CLASS_VERSIONS.items(), key=lambda kv: kv[0], reverse=True
     )
     for (
         breakpoint_api_version,
-        breakpoint_labware_versions,
-    ) in default_labware_versions_newest_to_oldest:
+        breakpoint_liquid_class_versions,
+    ) in default_lc_versions_newest_to_oldest:
         if (
             api_version >= breakpoint_api_version
-            and liquid_class_name in breakpoint_labware_versions
+            and liquid_class_name in breakpoint_liquid_class_versions
         ):
-            return breakpoint_labware_versions[liquid_class_name]
+            return breakpoint_liquid_class_versions[liquid_class_name]
 
     return 1

--- a/api/src/opentrons/protocol_api/core/engine/_default_liquid_class_versions.py
+++ b/api/src/opentrons/protocol_api/core/engine/_default_liquid_class_versions.py
@@ -1,0 +1,60 @@
+"""The versions of standard liquid classes that the Protocol API should load by default."""
+
+from typing import TypeAlias
+from opentrons.protocols.api_support.types import APIVersion
+
+
+DefaultLiquidClassVersions: TypeAlias = dict[APIVersion, dict[str, int]]
+
+
+# This:
+#
+# {
+#     APIVersion(2, 100): {
+#         "foo_liquid": 3,
+#     },
+#     APIVersion(2, 105): {
+#         "foo_liquid": 7
+#     }
+# }
+#
+# Means this:
+#
+# apiLevels        name              Default liquid class version
+# ---------------------------------------------------------------
+# <2.100           foo_liquid        1
+# >=2.100,<2.105   foo_liquid        3
+# >=2.105          foo_liquid        7
+# [any]            [anything else]   1
+DEFAULT_LIQUID_CLASS_VERSIONS: DefaultLiquidClassVersions = {
+    APIVersion(2, 26): {
+        "ethanol_80": 2,
+        "glycerol_50": 2,
+        "water": 2,
+    },
+}
+
+
+def get_liquid_class_version(
+    api_version: APIVersion,
+    liquid_class_name: str,
+) -> int:
+    """Return what version of a standard labware the Protocol API should load by default.
+
+    The `default_labware_versions` param is exposed for testability and should be left
+    unspecified.
+    """
+    default_labware_versions_newest_to_oldest = sorted(
+        DEFAULT_LIQUID_CLASS_VERSIONS.items(), key=lambda kv: kv[0], reverse=True
+    )
+    for (
+        breakpoint_api_version,
+        breakpoint_labware_versions,
+    ) in default_labware_versions_newest_to_oldest:
+        if (
+            api_version >= breakpoint_api_version
+            and liquid_class_name in breakpoint_labware_versions
+        ):
+            return breakpoint_labware_versions[liquid_class_name]
+
+    return 1

--- a/api/src/opentrons/protocol_api/core/engine/protocol.py
+++ b/api/src/opentrons/protocol_api/core/engine/protocol.py
@@ -78,7 +78,12 @@ from .module_core import (
     FlexStackerCore,
 )
 from .exceptions import InvalidModuleLocationError
-from . import load_labware_params, deck_conflict, overlap_versions
+from . import (
+    load_labware_params,
+    deck_conflict,
+    overlap_versions,
+    _default_liquid_class_versions,
+)
 from opentrons.protocol_engine.resources import labware_validation
 
 if TYPE_CHECKING:
@@ -1068,8 +1073,12 @@ class ProtocolCore(
             display_color=(liquid.displayColor.root if liquid.displayColor else None),
         )
 
-    def get_liquid_class(self, name: str, version: int) -> LiquidClass:
+    def get_liquid_class(self, name: str, version: Optional[int]) -> LiquidClass:
         """Get an instance of a built-in liquid class."""
+        if version is None:
+            version = _default_liquid_class_versions.get_liquid_class_version(
+                self._api_version, name
+            )
         try:
             # Check if we have already loaded this liquid class' definition
             liquid_class_def = self._liquid_class_def_cache[(name, version)]

--- a/api/src/opentrons/protocol_api/core/legacy/legacy_protocol_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy/legacy_protocol_core.py
@@ -599,7 +599,7 @@ class LegacyProtocolCore(
         """Define a liquid to load into a well."""
         assert False, "define_liquid only supported on engine core"
 
-    def get_liquid_class(self, name: str, version: int) -> LiquidClass:
+    def get_liquid_class(self, name: str, version: Optional[int]) -> LiquidClass:
         """Get an instance of a built-in liquid class."""
         assert False, "define_liquid_class is only supported on engine core"
 

--- a/api/src/opentrons/protocol_api/core/protocol.py
+++ b/api/src/opentrons/protocol_api/core/protocol.py
@@ -297,7 +297,7 @@ class AbstractProtocol(
         """Define a liquid to load into a well."""
 
     @abstractmethod
-    def get_liquid_class(self, name: str, version: int) -> LiquidClass:
+    def get_liquid_class(self, name: str, version: Optional[int]) -> LiquidClass:
         """Get an instance of a built-in liquid class."""
 
     @abstractmethod

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -1377,6 +1377,7 @@ class ProtocolContext(CommandPublisher):
     def get_liquid_class(
         self,
         name: str,
+        version: Optional[int] = None,
     ) -> LiquidClass:
         """
         Get an instance of an Opentrons-verified liquid class for use in a Flex protocol.
@@ -1386,12 +1387,14 @@ class ProtocolContext(CommandPublisher):
             - ``"water"``: an Opentrons-verified liquid class based on deionized water.
             - ``"glycerol_50"``: an Opentrons-verified liquid class for viscous liquid. Based on 50% glycerol.
             - ``"ethanol_80"``: an Opentrons-verified liquid class for volatile liquid. Based on 80% ethanol.
+        :param version: The version of the liquid class to retrieve. If left unspecified, the latest definition for the
+            protocol's API version will be loaded.
 
         :raises: ``LiquidClassDefinitionDoesNotExist``: if the specified liquid class does not exist.
 
         :returns: A new LiquidClass object.
         """
-        return self._core.get_liquid_class(name=name, version=DEFAULT_LC_VERSION)
+        return self._core.get_liquid_class(name=name, version=version)
 
     @requires_version(2, 24)
     def define_liquid_class(

--- a/api/tests/opentrons/protocol_api/core/engine/test_protocol_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_protocol_core.py
@@ -124,7 +124,9 @@ def patch_default_liquid_class_versions(
     decoy: Decoy, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Mock out _default_liquid_class_versions.py functions."""
-    for name, func in inspect.getmembers(_default_liquid_class_versions, inspect.isfunction):
+    for name, func in inspect.getmembers(
+        _default_liquid_class_versions, inspect.isfunction
+    ):
         monkeypatch.setattr(_default_liquid_class_versions, name, decoy.mock(func=func))
 
 
@@ -1906,7 +1908,11 @@ def test_define_liquid_class_without_version_provided(
     expected_liquid_class = LiquidClass(
         _name="water1", _display_name="water 1", _by_pipette_setting={}
     )
-    decoy.when(_default_liquid_class_versions.get_liquid_class_version(subject.api_version, "water")).then_return(987)
+    decoy.when(
+        _default_liquid_class_versions.get_liquid_class_version(
+            subject.api_version, "water"
+        )
+    ).then_return(987)
     decoy.when(liquid_classes.load_definition("water", version=987)).then_return(
         minimal_liquid_class_def1
     )

--- a/api/tests/opentrons/protocol_api/core/engine/test_protocol_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_protocol_core.py
@@ -75,6 +75,7 @@ from opentrons.protocol_api.core.engine import (
     LabwareCore,
     ModuleCore,
     load_labware_params,
+    _default_liquid_class_versions,
 )
 from opentrons.protocol_api._liquid import Liquid, LiquidClass
 from opentrons.protocol_api.disposal_locations import TrashBin, WasteChute
@@ -116,6 +117,15 @@ def patch_mock_load_labware_params(
     """Mock out load_labware_params.py functions."""
     for name, func in inspect.getmembers(load_labware_params, inspect.isfunction):
         monkeypatch.setattr(load_labware_params, name, decoy.mock(func=func))
+
+
+@pytest.fixture(autouse=True)
+def patch_default_liquid_class_versions(
+    decoy: Decoy, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Mock out _default_liquid_class_versions.py functions."""
+    for name, func in inspect.getmembers(_default_liquid_class_versions, inspect.isfunction):
+        monkeypatch.setattr(_default_liquid_class_versions, name, decoy.mock(func=func))
 
 
 @pytest.fixture(autouse=True)
@@ -1884,6 +1894,38 @@ def test_define_liquid_class(
         minimal_liquid_class_def2
     )
     assert subject.get_liquid_class("water", 123) == expected_liquid_class
+
+
+def test_define_liquid_class_without_version_provided(
+    decoy: Decoy,
+    subject: ProtocolCore,
+    minimal_liquid_class_def1: LiquidClassSchemaV1,
+    minimal_liquid_class_def2: LiquidClassSchemaV1,
+) -> None:
+    """It should create a LiquidClass with the most recent version and cache the definition."""
+    expected_liquid_class = LiquidClass(
+        _name="water1", _display_name="water 1", _by_pipette_setting={}
+    )
+    decoy.when(_default_liquid_class_versions.get_liquid_class_version(subject.api_version, "water")).then_return(987)
+    decoy.when(liquid_classes.load_definition("water", version=987)).then_return(
+        minimal_liquid_class_def1
+    )
+
+    assert subject.get_liquid_class("water", version=None) == expected_liquid_class
+
+    # Test that specified version number works too
+    decoy.when(liquid_classes.load_definition("water", version=654)).then_return(
+        minimal_liquid_class_def2
+    )
+    different_liquid_class = subject.get_liquid_class("water", 654)
+    assert different_liquid_class.name == "water2"
+    assert different_liquid_class.display_name == "water 2"
+
+    # Test that definition caching works
+    decoy.when(liquid_classes.load_definition("water", version=987)).then_return(
+        minimal_liquid_class_def2
+    )
+    assert subject.get_liquid_class("water", version=None) == expected_liquid_class
 
 
 def test_get_labware_location_deck_slot(

--- a/api/tests/opentrons/protocol_api/test_protocol_context.py
+++ b/api/tests/opentrons/protocol_api/test_protocol_context.py
@@ -1849,11 +1849,11 @@ def test_define_liquid_class(
     expected_liquid_class = LiquidClass(
         _name="volatile_100", _display_name="volatile 100%", _by_pipette_setting={}
     )
-    decoy.when(mock_core.get_liquid_class("volatile_90", 1)).then_return(
+    decoy.when(mock_core.get_liquid_class("volatile_90", 123)).then_return(
         expected_liquid_class
     )
     decoy.when(mock_core.robot_type).then_return(robot_type)
-    assert subject.get_liquid_class("volatile_90") == expected_liquid_class
+    assert subject.get_liquid_class("volatile_90", 123) == expected_liquid_class
 
 
 @pytest.mark.parametrize("robot_type", ["OT-2 Standard", "OT-3 Standard"])


### PR DESCRIPTION
# Overview

Addresses part of AUTH-2246

This PR adds a `version` argument to the public `ProtocolContext.get_liquid_class` method. It is an optional argument that defaults to `None`. If the version argument is included, we will attempt to load that version of the liquid class, failing if that version does not exist. If the version argument is not filled, we will automatically try and load the latest version for the protocol's API level.

This PR adds loading version 2 of `water`, `ethanol_80` and `glycerol_50` for API version 2.26. This PR does not add those liquid class definitions nor does it bump up the API level. Those two tasks will be covered in future PRs.

## Test Plan and Hands on Testing

This protocol analyzes properly, and covers both explicitly calling with and without a version. Changing the version to a non-existent one causes an error appear.

```python
requirements = {
    "robotType": "Flex",
    "apiLevel": "2.25"
}

metadata = {
    "protocolName":'Liquid Class Loading Regression Test',
}

def run(protocol_context):
    tiprack = protocol_context.load_labware("opentrons_flex_96_tiprack_50ul", "C2")
    trash = protocol_context.load_trash_bin('A3')
    pipette = protocol_context.load_instrument("flex_1channel_50", "left")
    nest_plate = protocol_context.load_labware("nest_96_wellplate_2ml_deep", "D1")
    arma_plate = protocol_context.load_labware("armadillo_96_wellplate_200ul_pcr_full_skirt", "D3")

    water_class = protocol_context.get_liquid_class("water")

    ethanol_class = protocol_context.get_liquid_class("ethanol_80", version=1)

    another_ethanol_class = protocol_context.get_liquid_class("ethanol_80")


    pipette.transfer_with_liquid_class(
        liquid_class=water_class,
        volume=50,
        source=arma_plate.columns()[0][:2],
        dest=nest_plate.columns()[0][:2],
        new_tip="always",
        trash_location=trash,
        tip_racks=[tiprack],
    )

```

## Changelog

- add optional `version` argument to `get_liquid_class`
- add a `get_liquid_class_version` function to determine which liquid class definition version to load when a version is not provided

## Review requests


## Risk assessment

Low, this PR does not introduce the new liquid class versions and does not change the behavior of existing protocols.