### PR TITLE
feat(protocol-designer): remove Lids from being behind ff

### DIFF
--- a/components/src/molecules/CustomizeExpandButton/__tests__/CustomizeExpandButton.test.tsx
+++ b/components/src/molecules/CustomizeExpandButton/__tests__/CustomizeExpandButton.test.tsx
@@ -26,7 +26,6 @@ describe('CustomizeExpandButton', () => {
 
   beforeEach(() => {
     props = {
-      enableStackingFF: true,
       buttonText: 'mock text',
       buttonValue: 'mockValue',
       onChange: vi.fn(),

--- a/components/src/molecules/CustomizeExpandButton/index.tsx
+++ b/components/src/molecules/CustomizeExpandButton/index.tsx
@@ -31,7 +31,6 @@ export interface StackingProps {
 }
 
 interface CustomizeExpandButtonProps extends StyleProps {
-  enableStackingFF: boolean
   allowInputField: boolean
   isNestedDefALid: boolean
   buttonText: string
@@ -57,7 +56,6 @@ export function CustomizeExpandButtonComponent(
     stackingProps,
     allowInputField,
     isNestedDefALid,
-    enableStackingFF,
   } = props
   const isLid =
     stackingProps != null &&
@@ -92,7 +90,7 @@ export function CustomizeExpandButtonComponent(
           <StyledText desktopStyle="bodyDefaultRegular">
             {buttonText}
           </StyledText>
-          {stackingProps != null && enableStackingFF && isSelected ? (
+          {stackingProps != null && isSelected ? (
             <Flex
               flexDirection={DIRECTION_COLUMN}
               backgroundColor={COLORS.blue10}

--- a/protocol-designer/src/assets/localization/en/feature_flags.json
+++ b/protocol-designer/src/assets/localization/en/feature_flags.json
@@ -45,7 +45,7 @@
   },
   "OT_PD_ENABLE_STACKING": {
     "title": "Enable more labware capabilities",
-    "description": "Ability to stack labware, add lids, etc"
+    "description": "Ability to stack labwares and add the Flex Stacker"
   },
   "OT_PD_ENABLE_CONCURRENT_MODULE_ACTIONS": {
     "title": "Enable concurrent module actions",

--- a/protocol-designer/src/components/organisms/SelectLabwareModal/SelectCustomLabware.tsx
+++ b/protocol-designer/src/components/organisms/SelectLabwareModal/SelectCustomLabware.tsx
@@ -8,7 +8,6 @@ import {
   ListButtonAccordionContainer,
 } from '@opentrons/components'
 
-import { getEnableStacking } from '../../../feature-flags/selectors'
 import { getCustomLabwareDefsByURI } from '../../../labware-defs/selectors'
 import { selectLid, selectTopLabware } from '../../../labware-ingred/actions'
 import { selectors } from '../../../labware-ingred/selectors'
@@ -41,7 +40,6 @@ export function SelectCustomLabware(
     filteredLabwareByCategory,
     universalLid,
   } = props
-  const enableStacking = useSelector(getEnableStacking)
   const { t } = useTranslation(['starting_deck_state', 'shared'])
   const customLabwareDefs = useSelector(getCustomLabwareDefsByURI)
   const dispatch = useDispatch<ThunkDispatch<any>>()
@@ -72,7 +70,6 @@ export function SelectCustomLabware(
           {filteredLabwareByCategory[CUSTOM_CATEGORY].map(({ uri }, index) => {
             const lidProps: StackingProps | null =
               slot !== 'offDeck' &&
-              enableStacking &&
               universalLid != null &&
               customLabwareDefs[uri].metadata.displayCategory !== 'tubeRack'
                 ? {
@@ -99,7 +96,6 @@ export function SelectCustomLabware(
 
             return (
               <CustomizeExpandButton
-                enableStackingFF={enableStacking}
                 isNestedDefALid={getIsNestedDefinitionALid(
                   customLabwareDefs[uri]
                 )}

--- a/protocol-designer/src/components/organisms/SelectLabwareModal/SelectLabware.tsx
+++ b/protocol-designer/src/components/organisms/SelectLabwareModal/SelectLabware.tsx
@@ -9,7 +9,6 @@ import {
   ListButtonAccordionContainer,
 } from '@opentrons/components'
 
-import { getEnableStacking } from '../../../feature-flags/selectors'
 import { getOnlyLatestDefs } from '../../../labware-defs'
 import { getCustomLabwareDefsByURI } from '../../../labware-defs/selectors'
 import {
@@ -56,7 +55,6 @@ export function SelectLabware(props: SelectLabwareProps): JSX.Element | null {
   } = props
   const dispatch = useDispatch<ThunkDispatch<any>>()
   const { t } = useTranslation(['starting_deck_state', 'shared'])
-  const enableStacking = useSelector(getEnableStacking)
   const customLabwareDefs = useSelector(getCustomLabwareDefsByURI)
   const defs = getOnlyLatestDefs()
   const zoomedInSlotInfo = useSelector(selectors.getZoomedInSlotInfo)
@@ -139,9 +137,7 @@ export function SelectLabware(props: SelectLabwareProps): JSX.Element | null {
                       category
                     )
                     const stackingProps: StackingProps | null =
-                      stackingLabwareDefUris.length === 1 &&
-                      slot !== 'offDeck' &&
-                      enableStacking
+                      stackingLabwareDefUris.length === 1 && slot !== 'offDeck'
                         ? {
                             inputTitle: t('labware_quantity'),
                             errorMessage: t('unsupported_range'),
@@ -181,7 +177,6 @@ export function SelectLabware(props: SelectLabwareProps): JSX.Element | null {
                       !getIsLabwareFiltered(def) ? (
                       <Fragment key={`${category}_${loadName}`}>
                         <CustomizeExpandButton
-                          enableStackingFF={enableStacking}
                           isNestedDefALid={getIsNestedDefinitionALid(def)}
                           allowInputField={
                             onFlexStacker || lidLoadNames.includes(loadName)

--- a/protocol-designer/src/components/organisms/SelectLabwareModal/SelectLabwareOnAdapter.tsx
+++ b/protocol-designer/src/components/organisms/SelectLabwareModal/SelectLabwareOnAdapter.tsx
@@ -8,7 +8,6 @@ import {
   ListButtonAccordionContainer,
 } from '@opentrons/components'
 
-import { getEnableStacking } from '../../../feature-flags/selectors'
 import { getOnlyLatestDefs } from '../../../labware-defs'
 import { getCustomLabwareDefsByURI } from '../../../labware-defs/selectors'
 import {
@@ -55,7 +54,6 @@ export function SelectLabwareOnAdapter(
     universalLid,
   } = props
   const { t } = useTranslation(['starting_deck_state', 'shared'])
-  const enableStacking = useSelector(getEnableStacking)
   const customLabwareDefs = useSelector(getCustomLabwareDefsByURI)
   const pipetteEntities = useSelector(getPipetteEntities)
   const has96Channel = getHas96Channel(pipetteEntities)
@@ -93,8 +91,7 @@ export function SelectLabwareOnAdapter(
 
   return isAdapter &&
     parentLabwareURI === selectedAdapterDefURI &&
-    getLabwareCompatibleWithAdapter(defs, enableStacking, loadName)?.length >
-      0 ? (
+    getLabwareCompatibleWithAdapter(defs, loadName)?.length > 0 ? (
     <ListButtonAccordionContainer id={`nestedAccordionContainer_${loadName}`}>
       <ListButtonAccordion
         key={`${category}_${loadName}_accordion`}
@@ -107,7 +104,6 @@ export function SelectLabwareOnAdapter(
               const nestedDef = defs[tiprackDefUri]
               return (
                 <CustomizeExpandButton
-                  enableStackingFF={enableStacking}
                   isNestedDefALid={false}
                   allowInputField={false}
                   key={`${index}_${category}_${loadName}_${tiprackDefUri}`}
@@ -133,7 +129,7 @@ export function SelectLabwareOnAdapter(
                 ...defs,
                 ...customLabwareDefs,
               },
-              enableStacking,
+
               loadName
             ).map(nestedDefUri => {
               const nestedDef =
@@ -186,7 +182,6 @@ export function SelectLabwareOnAdapter(
               return (
                 <Fragment key={`${loadName}_${category}`}>
                   <CustomizeExpandButton
-                    enableStackingFF={enableStacking}
                     isNestedDefALid={getIsNestedDefinitionALid(nestedDef)}
                     allowInputField={lidLoadNames.includes(
                       nestedDef.parameters.loadName

--- a/protocol-designer/src/components/organisms/SelectLabwareModal/SelectLidOnLabware.tsx
+++ b/protocol-designer/src/components/organisms/SelectLabwareModal/SelectLidOnLabware.tsx
@@ -7,7 +7,6 @@ import {
   ListButtonAccordionContainer,
 } from '@opentrons/components'
 
-import { getEnableStacking } from '../../../feature-flags/selectors'
 import { getOnlyLatestDefs } from '../../../labware-defs'
 import { getCustomLabwareDefsByURI } from '../../../labware-defs/selectors'
 import { selectLid } from '../../../labware-ingred/actions'
@@ -37,7 +36,6 @@ export function SelectLidOnLabware(
     lidURIs,
   } = props
   const { t } = useTranslation('starting_deck_state')
-  const enableStacking = useSelector(getEnableStacking)
   const customLabwareDefs = useSelector(getCustomLabwareDefsByURI)
   const dispatch = useDispatch<ThunkDispatch<any>>()
   const defs = getOnlyLatestDefs()
@@ -70,7 +68,6 @@ export function SelectLidOnLabware(
 
           return (
             <CustomizeExpandButton
-              enableStackingFF={enableStacking}
               isNestedDefALid={getIsNestedDefinitionALid(def)}
               allowInputField={lidLoadNames.includes(def.parameters.loadName)}
               key={`${category}_${loadName}_${defUri}`}

--- a/protocol-designer/src/components/organisms/SelectLabwareModal/__tests__/SelectLabwareModal.test.tsx
+++ b/protocol-designer/src/components/organisms/SelectLabwareModal/__tests__/SelectLabwareModal.test.tsx
@@ -13,7 +13,6 @@ import {
 
 import { renderWithProviders } from '/protocol-designer/__testing-utils__'
 import { i18n } from '/protocol-designer/assets/localization'
-import { getEnableStacking } from '/protocol-designer/feature-flags/selectors'
 import { getRobotType } from '/protocol-designer/file-data/selectors'
 import { createCustomLabwareDef } from '/protocol-designer/labware-defs/actions'
 import { getCustomLabwareDefsByURI } from '/protocol-designer/labware-defs/selectors'
@@ -39,7 +38,6 @@ vi.mock('/protocol-designer/labware-defs/selectors')
 vi.mock('/protocol-designer/labware-defs/actions')
 vi.mock('/protocol-designer/file-data/selectors')
 vi.mock('/protocol-designer/labware-ingred/actions')
-vi.mock('/protocol-designer/feature-flags/selectors')
 vi.mock('@opentrons/components', async importOriginal => {
   const actual = await importOriginal<typeof InfoScreen>()
   return {
@@ -64,7 +62,6 @@ describe('SelectLabwareModal', () => {
       onConfirm: vi.fn(),
       slotFull: false,
     }
-    vi.mocked(getEnableStacking).mockReturnValue(true)
     vi.mocked(getCustomLabwareDefsByURI).mockReturnValue({})
     vi.mocked(getRobotType).mockReturnValue(FLEX_ROBOT_TYPE)
     vi.mocked(getPermittedTipracks).mockReturnValue([])

--- a/protocol-designer/src/components/organisms/SelectLabwareModal/index.tsx
+++ b/protocol-designer/src/components/organisms/SelectLabwareModal/index.tsx
@@ -40,7 +40,6 @@ import {
 import { TIPRACK_LID_LOADNAME } from '/protocol-designer/pages/Designer/utils'
 
 import { LINK_BUTTON_STYLE } from '../../../components/atoms'
-import { getEnableStacking } from '../../../feature-flags/selectors'
 import { getRobotType } from '../../../file-data/selectors'
 import { getOnlyLatestDefs } from '../../../labware-defs'
 import { createCustomLabwareDef } from '../../../labware-defs/actions'
@@ -96,7 +95,6 @@ export function SelectLabwareModal(
   const [error, setError] = useState<string | null>(null)
 
   const dispatch = useDispatch<ThunkDispatch<any>>()
-  const enableStacking = useSelector(getEnableStacking)
   const permittedTipracks = useSelector(stepFormSelectors.getPermittedTipracks)
   const pipetteEntities = useSelector(getPipetteEntities)
   const customLabwareDefs = useSelector(getCustomLabwareDefsByURI)
@@ -205,8 +203,6 @@ export function SelectLabwareModal(
         (slot === 'offDeck' && isAdapter) ||
         (PLATE_READER_LOADNAME === parameters.loadName &&
           moduleType !== ABSORBANCE_READER_TYPE) ||
-        (!enableStacking &&
-          parameters.loadName === 'opentrons_flex_deck_riser') ||
         parameters.loadName === TIPRACK_LID_LOADNAME
       )
     },
@@ -223,9 +219,8 @@ export function SelectLabwareModal(
         const category: string = def.metadata.displayCategory
         //  filter out non-permitted tipracks
         if (
-          (category === 'tipRack' &&
-            !permittedTipracks.includes(getLabwareDefURI(def))) ||
-          (category === 'lid' && !enableStacking)
+          category === 'tipRack' &&
+          !permittedTipracks.includes(getLabwareDefURI(def))
         ) {
           return acc
         }

--- a/protocol-designer/src/pages/Designer/DeckSetup/utils.ts
+++ b/protocol-designer/src/pages/Designer/DeckSetup/utils.ts
@@ -160,29 +160,18 @@ export const getLabwareIsRecommended = (
 //  purely for labware<>adapter combos
 export const getLabwareCompatibleWithAdapter = (
   defs: LabwareDefByDefURI,
-  enableStackingFF: boolean,
   adapterLoadName?: string
 ): string[] => {
   if (adapterLoadName == null) {
     return []
   }
 
-  if (enableStackingFF) {
-    return Object.entries(defs)
-      .filter(
-        ([, { stackingOffsetWithLabware }]) =>
-          stackingOffsetWithLabware?.[adapterLoadName] != null
-      )
-      .map(([labwareDefUri]) => labwareDefUri)
-  } else {
-    return Object.entries(defs)
-      .filter(
-        ([, { stackingOffsetWithLabware, compatibleParentLabware }]) =>
-          stackingOffsetWithLabware?.[adapterLoadName] != null &&
-          !compatibleParentLabware?.includes(adapterLoadName)
-      )
-      .map(([labwareDefUri]) => labwareDefUri)
-  }
+  return Object.entries(defs)
+    .filter(
+      ([, { stackingOffsetWithLabware }]) =>
+        stackingOffsetWithLabware?.[adapterLoadName] != null
+    )
+    .map(([labwareDefUri]) => labwareDefUri)
 }
 
 const getStackerDefinitionsFromLoadName = (

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLabwareTools/LabwareLocationField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLabwareTools/LabwareLocationField.tsx
@@ -10,7 +10,6 @@ import {
 import { getSlotInLocationStack } from '@opentrons/step-generation'
 
 import { DropdownStepFormField } from '/protocol-designer/components/molecules'
-import { getEnableStacking } from '/protocol-designer/feature-flags/selectors'
 import {
   getUnoccupiedStackOptions,
   TIPRACK_LID_LOADNAME,
@@ -40,7 +39,6 @@ export function LabwareLocationField(
 ): JSX.Element {
   const { t } = useTranslation(['form', 'protocol_steps'])
   const { labware, useGripper } = props
-  const enableStacking = useSelector(getEnableStacking)
   const { labware: deckSetupLabware } = useSelector(getDeckSetupForActiveItem)
   const dispatch = useDispatch()
   const labwareEntities = useSelector(getLabwareEntities)
@@ -48,16 +46,15 @@ export function LabwareLocationField(
     getAdditionalEquipmentEntities
   )
   const robotState = useSelector(getRobotStateAtActiveItem)
-  const unoccupiedLabwareStackOptions: Option[] =
-    robotState && enableStacking
-      ? getUnoccupiedStackOptions({
-          robotState,
-          deckSetupLabware,
-          labwareIdFromDropdown: labware,
-          labwareEntities,
-          t,
-        })
-      : []
+  const unoccupiedLabwareStackOptions: Option[] = robotState
+    ? getUnoccupiedStackOptions({
+        robotState,
+        deckSetupLabware,
+        labwareIdFromDropdown: labware,
+        labwareEntities,
+        t,
+      })
+    : []
   const isLabwareOffDeck =
     labware != null
       ? getSlotInLocationStack(robotState?.labware[labware]?.stack ?? []) ===


### PR DESCRIPTION
closes AUTH-2247

# Overview

removed lids from being behind the stacking ff and repurpose that ff for stacker support + stacking labware

## Test Plan and Hands on Testing

Test that you can select lids in the deck setup and that you can place a lid onto a lid stack in move labware

## Changelog

- remove usage of the ff and fix the tests

## Risk assessment

low