### PR TITLE
fix(app): single slot conflict next to stacker not accounted for

### DIFF
--- a/app/src/organisms/LocationConflictModal/LocationConflictModal.tsx
+++ b/app/src/organisms/LocationConflictModal/LocationConflictModal.tsx
@@ -131,11 +131,11 @@ export const LocationConflictModal = (
     ) {
       return getFixtureDisplayName(t as TFunction, MAGNETIC_BLOCK_V1_FIXTURE)
     } else if (
-      (requiredFixtureId === SINGLE_RIGHT_SLOT_FIXTURE &&
+      requiredFixtureId === SINGLE_RIGHT_SLOT_FIXTURE &&
+      (deckConfigurationAtLocationFixtureId ===
+        FLEX_STACKER_WITH_WASTE_CHUTE_ADAPTER_COVERED_FIXTURE ||
         deckConfigurationAtLocationFixtureId ===
-          FLEX_STACKER_WITH_WASTE_CHUTE_ADAPTER_COVERED_FIXTURE) ||
-      deckConfigurationAtLocationFixtureId ===
-        FLEX_STACKER_WITH_WASTE_CHUTE_ADAPTER_NO_COVER_FIXTURE
+          FLEX_STACKER_WITH_WASTE_CHUTE_ADAPTER_NO_COVER_FIXTURE)
     ) {
       return getFixtureDisplayName(
         t as TFunction,

--- a/app/src/organisms/LocationConflictModal/LocationConflictModal.tsx
+++ b/app/src/organisms/LocationConflictModal/LocationConflictModal.tsx
@@ -33,6 +33,7 @@ import {
   getModuleDisplayName,
   MAGNETIC_BLOCK_V1_FIXTURE,
   SINGLE_LEFT_SLOT_FIXTURE,
+  SINGLE_RIGHT_SLOT_FIXTURE,
   THERMOCYCLER_MODULE_V1,
   THERMOCYCLER_MODULE_V2,
   THERMOCYCLER_V2_FRONT_FIXTURE,
@@ -40,6 +41,7 @@ import {
   WASTE_CHUTE_FLEX_STACKER_FIXTURES,
   WASTE_CHUTE_ONLY_FIXTURES,
   WASTE_CHUTE_RIGHT_ADAPTER_COVERED_FIXTURE,
+  WASTE_CHUTE_RIGHT_ADAPTER_NO_COVER_FIXTURE,
 } from '@opentrons/shared-data'
 
 import { getTopPortalEl } from '/app/App/portal'
@@ -121,13 +123,34 @@ export const LocationConflictModal = (
     deckConfigurationAtLocationFixtureId === THERMOCYCLER_V2_REAR_FIXTURE ||
     deckConfigurationAtLocationFixtureId === THERMOCYCLER_V2_FRONT_FIXTURE
 
-  const currentFixtureDisplayName =
-    deckConfigurationAtLocationFixtureId != null
-      ? getFixtureDisplayName(
-          t as TFunction,
-          deckConfigurationAtLocationFixtureId
-        )
-      : ''
+  const getCurrentFixtureDisplayName = (): string => {
+    if (
+      requiredFixtureId === SINGLE_RIGHT_SLOT_FIXTURE &&
+      deckConfigurationAtLocationFixtureId ===
+        FLEX_STACKER_WITH_MAG_BLOCK_FIXTURE
+    ) {
+      return getFixtureDisplayName(t as TFunction, MAGNETIC_BLOCK_V1_FIXTURE)
+    } else if (
+      (requiredFixtureId === SINGLE_RIGHT_SLOT_FIXTURE &&
+        deckConfigurationAtLocationFixtureId ===
+          FLEX_STACKER_WITH_WASTE_CHUTE_ADAPTER_COVERED_FIXTURE) ||
+      deckConfigurationAtLocationFixtureId ===
+        FLEX_STACKER_WITH_WASTE_CHUTE_ADAPTER_NO_COVER_FIXTURE
+    ) {
+      return getFixtureDisplayName(
+        t as TFunction,
+        WASTE_CHUTE_RIGHT_ADAPTER_NO_COVER_FIXTURE
+      )
+    } else {
+      return deckConfigurationAtLocationFixtureId != null
+        ? getFixtureDisplayName(
+            t as TFunction,
+            deckConfigurationAtLocationFixtureId
+          )
+        : ''
+    }
+  }
+  const currentFixtureDisplayName = getCurrentFixtureDisplayName()
 
   const handleConfigureModule = (moduleSerialNumber?: string): void => {
     if (requiredModule != null) {

--- a/app/src/resources/deck_configuration/utils.ts
+++ b/app/src/resources/deck_configuration/utils.ts
@@ -6,6 +6,7 @@ import {
   MAGNETIC_BLOCK_ADDRESSABLE_AREAS,
   MAGNETIC_BLOCK_FIXTURES,
   MAGNETIC_BLOCK_V1_FIXTURE,
+  SINGLE_RIGHT_SLOT_FIXTURE,
   SINGLE_SLOT_FIXTURES,
   STAGING_AREA_FIXTURES,
   STAGING_AREA_RIGHT_SLOT_FIXTURE,
@@ -110,6 +111,9 @@ export const getFilteredDeckConfigFixtureCompatibility = (
           ) &&
             !compatabilityItem.requiredAddressableAreas.some(raa =>
               MAGNETIC_BLOCK_ADDRESSABLE_AREAS.includes(raa)
+            ) &&
+            !compatabilityItem.requiredAddressableAreas.some(raa =>
+              FLEX_SINGLE_SLOT_ADDRESSABLE_AREAS.includes(raa)
             ))
         ) {
           return acc
@@ -137,6 +141,25 @@ export const getFilteredDeckConfigFixtureCompatibility = (
             }
             acc.push(stagingAreaRequirement)
           }
+          return acc
+        } else if (
+          compatabilityItem.requiredAddressableAreas.some(
+            raa =>
+              FLEX_STACKER_ADDRESSABLE_AREAS.includes(raa) &&
+              compatabilityItem.requiredAddressableAreas.some(raa =>
+                FLEX_SINGLE_SLOT_ADDRESSABLE_AREAS.includes(raa)
+              )
+          )
+        ) {
+          const rightSlotRequirement = {
+            ...compatabilityItem,
+            partialRequiredCutoutFixtureId: SINGLE_RIGHT_SLOT_FIXTURE,
+          }
+          if (
+            compatabilityItem.cutoutFixtureId !== FLEX_STACKER_V1_FIXTURE &&
+            compatabilityItem.cutoutFixtureId !== SINGLE_RIGHT_SLOT_FIXTURE
+          )
+            acc.push(rightSlotRequirement)
           return acc
         } else {
           acc.push(compatabilityItem)


### PR DESCRIPTION
fix RQA-4622
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This was a weird one. If you have a mag block or waste chute configured next to a stacker but the protocol requires the stacker-adjacent slot to be empty for labware moved into that location, we weren't surfacing a right slot conflict in deck hardware setup.
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing

https://github.com/user-attachments/assets/18e291b9-1087-4470-b813-92a3b475ee6b

For a protocol that requires stacker adjacent slots to be empty, load a mag block and waste chute in these slots. See that now, the right slot conflicts appear and the modal correctly tells you to remove the waste chute or mag block in favor of an empty slot.
If the stacker is configured before resolving this conflict, ensure that the stacker is not removed from the deck config upon resolution.

<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
1. Update the `getFilteredDeckConfigCompatibility` util to add a fixture conflict item for the single right slot in the case where both flex stacker and right slot addressable areas are required and a different item is loaded into that cutout
2. Update the location conflict modal so that it prompts the user to remove only the magblock or waste chute for this right slot conflict as opposed to "Flex stacker with mag block"

<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests
Check the logic here, it's a weird case but this fixes the bug Nus reported
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
Low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
