### PR TITLE
fix(api): don't touch-tip on source well after blowout to source if it's untouchable

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/transfer_components_executor.py
+++ b/api/src/opentrons/protocol_api/core/engine/transfer_components_executor.py
@@ -5,7 +5,7 @@ import logging
 from copy import deepcopy
 from enum import Enum
 from typing import TYPE_CHECKING, Optional, Union, Literal
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 
 from opentrons_shared_data.liquid_classes.liquid_class_definition import (
     PositionReference,
@@ -21,7 +21,6 @@ from opentrons.protocol_api._liquid_properties import (
     MultiDispenseProperties,
     TouchTipProperties,
 )
-from opentrons.protocol_engine.errors import TouchTipDisabledError
 from opentrons.types import Location, Point, Mount
 from opentrons.protocols.advanced_control.transfers.transfer_liquid_utils import (
     LocationCheckDescriptors,
@@ -466,7 +465,7 @@ class TransferComponentsExecutor:
         2. If blowout is enabled and “destination”
             - Do blow-out (at the retract position)
             - Leave plunger down
-        3. Touch-tip
+        3. Touch-tip in the destination well.
         4. If not ready-to-aspirate
             - Prepare-to-aspirate (at the retract position)
         5. Air-gap (at the retract position)
@@ -479,7 +478,7 @@ class TransferComponentsExecutor:
         6. If blowout is “source” or “trash”
             - Move to location (top of Well)
             - Do blow-out (top of well)
-            - Do touch-tip (?????) (only if it’s in a non-trash location)
+            - Do touch-tip AGAIN at the source well (if blowout in a non-trash location)
             - Prepare-to-aspirate (top of well)
             - Do air-gap (top of well)
         7. If drop tip, move to drop tip location, drop tip
@@ -563,9 +562,9 @@ class TransferComponentsExecutor:
             blowout_props.enabled
             and blowout_props.location != BlowoutLocation.DESTINATION
         ):
-            # TODO: no-op touch tip if touch tip is enabled and blowout is in trash/ reservoir/ any labware with touch-tip disabled
             assert blowout_props.flow_rate is not None
             self._instrument.set_flow_rate(blow_out=blowout_props.flow_rate)
+            blowout_touch_tip_props = retract_props.touch_tip
             touch_tip_and_air_gap_location: Union[Location, TrashBin, WasteChute]
             if blowout_props.location == BlowoutLocation.SOURCE:
                 if source_location is None or source_well is None:
@@ -584,6 +583,13 @@ class TransferComponentsExecutor:
                     source_well.get_top(0), labware=source_location.labware
                 )
                 touch_tip_and_air_gap_well = source_well
+                # Skip touch tip if blowing out at the SOURCE and it's untouchable:
+                if (
+                    "touchTipDisabled"
+                    in source_location.labware.quirks_from_any_parent()
+                ):
+                    blowout_touch_tip_props = replace(blowout_touch_tip_props)
+                    blowout_touch_tip_props.enabled = False
             else:
                 self._instrument.blow_out(
                     location=trash_location,
@@ -612,7 +618,7 @@ class TransferComponentsExecutor:
             )
             # Do touch tip and air gap again after blowing out into source well or trash
             self._do_touch_tip_and_air_gap_after_dispense(
-                touch_tip_properties=retract_props.touch_tip,
+                touch_tip_properties=blowout_touch_tip_props,
                 location=touch_tip_and_air_gap_location,
                 well=touch_tip_and_air_gap_well,
                 air_gap_volume=air_gap_volume,
@@ -758,6 +764,7 @@ class TransferComponentsExecutor:
         ):
             assert blowout_props.flow_rate is not None
             self._instrument.set_flow_rate(blow_out=blowout_props.flow_rate)
+            blowout_touch_tip_props = retract_props.touch_tip
             touch_tip_and_air_gap_location: Union[Location, TrashBin, WasteChute]
             if blowout_props.location == BlowoutLocation.SOURCE:
                 if source_location is None or source_well is None:
@@ -776,6 +783,13 @@ class TransferComponentsExecutor:
                     source_well.get_top(0), labware=source_location.labware
                 )
                 touch_tip_and_air_gap_well = source_well
+                # Skip touch tip if blowing out at the SOURCE and it's untouchable:
+                if (
+                    "touchTipDisabled"
+                    in source_location.labware.quirks_from_any_parent()
+                ):
+                    blowout_touch_tip_props = replace(blowout_touch_tip_props)
+                    blowout_touch_tip_props.enabled = False
             else:
                 self._instrument.blow_out(
                     location=trash_location,
@@ -807,13 +821,13 @@ class TransferComponentsExecutor:
                 air_gap_volume = 0
             # Do touch tip and air gap again after blowing out into source well or trash
             self._do_touch_tip_and_air_gap_after_dispense(
-                touch_tip_properties=retract_props.touch_tip,
+                touch_tip_properties=blowout_touch_tip_props,
                 location=touch_tip_and_air_gap_location,
                 well=touch_tip_and_air_gap_well,
                 air_gap_volume=air_gap_volume,
             )
 
-    def _do_touch_tip_and_air_gap_after_dispense(  # noqa: C901
+    def _do_touch_tip_and_air_gap_after_dispense(
         self,
         touch_tip_properties: TouchTipProperties,
         location: Union[Location, TrashBin, WasteChute],
@@ -821,6 +835,12 @@ class TransferComponentsExecutor:
         air_gap_volume: float,
     ) -> None:
         """Perform touch tip and air gap as part of post-dispense retract.
+
+        This function can be invoked up to 2 times for each dispense:
+        1) Once for touching tip at the dispense location.
+        2) Then again in the blowout location if it is not the dispense location.
+        For case (2), the caller should disable touch-tip in touch_tip_properties
+        if the blowout location is not touchable (such as reservoirs).
 
         If the retract location is at or above the safe location of
         AIR_GAP_LOC_Z_OFFSET_FROM_WELL_TOP, then add the air gap at the retract location
@@ -842,18 +862,14 @@ class TransferComponentsExecutor:
             #  whether the touch tip params from transfer props should be used for
             #  both dest-well touch tip and non-dest-well touch tip.
             if isinstance(location, Location) and well is not None:
-                try:
-                    self._instrument.touch_tip(
-                        location=location,
-                        well_core=well,
-                        radius=1,
-                        z_offset=touch_tip_properties.z_offset,
-                        speed=touch_tip_properties.speed,
-                        mm_from_edge=touch_tip_properties.mm_from_edge,
-                    )
-                except TouchTipDisabledError:
-                    # TODO: log a warning
-                    pass
+                self._instrument.touch_tip(
+                    location=location,
+                    well_core=well,
+                    radius=1,
+                    z_offset=touch_tip_properties.z_offset,
+                    speed=touch_tip_properties.speed,
+                    mm_from_edge=touch_tip_properties.mm_from_edge,
+                )
 
                 # Move back to the 'retract' position
                 self._instrument.move_to(

--- a/api/tests/opentrons/protocol_api/core/engine/test_transfer_components_executor.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_transfer_components_executor.py
@@ -1,4 +1,6 @@
 """Tests for complex commands executor."""
+from typing import Literal, Union
+
 import pytest
 from decoy import Decoy, matchers
 from opentrons_shared_data.liquid_classes.liquid_class_definition import (
@@ -8,7 +10,7 @@ from opentrons_shared_data.liquid_classes.liquid_class_definition import (
     BlowoutLocation,
 )
 
-from opentrons.protocol_api import TrashBin, WasteChute
+from opentrons.protocol_api import TrashBin, WasteChute, Labware
 from opentrons.protocol_api._liquid import LiquidClass
 from opentrons.protocol_api._liquid_properties import TransferProperties
 from opentrons.protocol_api.core.engine.well import WellCore
@@ -1843,6 +1845,113 @@ def test_retract_after_dispense_in_trash_with_blowout_in_disposal_location(
             ]
             or []
         ),
+    )
+
+
+@pytest.mark.parametrize(
+    argnames=["dest_type", "blowout_location", "source_touchable"],
+    argvalues=[
+        # Try all combinations of destination type, blowout location, and touchability
+        ("well", BlowoutLocation.SOURCE, True),
+        ("well", BlowoutLocation.SOURCE, False),
+        ("well", BlowoutLocation.DESTINATION, True),
+        ("well", BlowoutLocation.DESTINATION, False),
+        ("well", BlowoutLocation.TRASH, True),
+        ("well", BlowoutLocation.TRASH, False),
+        ("trash", BlowoutLocation.SOURCE, True),
+        ("trash", BlowoutLocation.SOURCE, False),
+        ("trash", BlowoutLocation.DESTINATION, True),
+        ("trash", BlowoutLocation.DESTINATION, False),
+        ("trash", BlowoutLocation.TRASH, True),
+        ("trash", BlowoutLocation.TRASH, False),
+    ],
+)
+def test_retract_after_dispense_touch_tip(
+    decoy: Decoy,
+    mock_instrument_core: InstrumentCore,
+    sample_transfer_props: TransferProperties,
+    dest_type: Literal["well", "trash"],
+    blowout_location: BlowoutLocation,
+    source_touchable: bool,
+) -> None:
+    """Should not fail if touchTipDisabled at the blowout location if blowing out to SOURCE."""
+    source_location_labware = decoy.mock(cls=Labware)
+    source_location = Location(Point(1, 2, 3), labware=source_location_labware)
+    source_well = decoy.mock(cls=WellCore)
+    dest_well = decoy.mock(cls=WellCore)
+    well_top_point = Point(1, 2, 3)
+    trash_location = decoy.mock(cls=TrashBin)
+    trash_top = decoy.mock(cls=TrashBin)
+
+    target_location: Union[Location, TrashBin, WasteChute]
+    if dest_type == "trash":
+        target_location = trash_location
+        target_well = None
+    else:  # dest_type == "well"
+        target_location = Location(Point(1, 1, 1), labware=None)
+        target_well = dest_well
+
+    sample_transfer_props.dispense.retract.touch_tip.enabled = True
+    sample_transfer_props.dispense.retract.blowout.enabled = True
+    sample_transfer_props.dispense.retract.blowout.location = blowout_location
+
+    subject = TransferComponentsExecutor(
+        instrument_core=mock_instrument_core,
+        transfer_properties=sample_transfer_props,
+        target_location=target_location,
+        target_well=target_well,
+        tip_state=TipState(
+            ready_to_aspirate=True,
+            last_liquid_and_air_gap_in_tip=LiquidAndAirGapPair(liquid=0, air_gap=0),
+        ),
+        transfer_type=TransferType.ONE_TO_ONE,
+    )
+
+    decoy.when(mock_instrument_core.get_current_volume()).then_return(0)
+    decoy.when(source_location_labware.quirks).then_return(
+        [] if source_touchable else ["touchTipDisabled"]
+    )
+    decoy.when(source_well.get_top(0)).then_return(well_top_point)
+    decoy.when(source_well.get_top(AIR_GAP_LOC_Z_OFFSET_FROM_WELL_TOP)).then_return(
+        well_top_point + Point(0, 0, AIR_GAP_LOC_Z_OFFSET_FROM_WELL_TOP)
+    )
+    decoy.when(dest_well.get_top(0)).then_return(well_top_point)
+    decoy.when(dest_well.get_top(AIR_GAP_LOC_Z_OFFSET_FROM_WELL_TOP)).then_return(
+        well_top_point + Point(0, 0, AIR_GAP_LOC_Z_OFFSET_FROM_WELL_TOP)
+    )
+    decoy.when(trash_location.offset).then_return(DisposalOffset(x=0, y=0, z=0))
+    decoy.when(
+        trash_location.top(x=0, y=0, z=AIR_GAP_LOC_Z_OFFSET_FROM_WELL_TOP)
+    ).then_return(trash_top)
+    decoy.when(trash_top.offset).then_return(
+        DisposalOffset(x=0, y=0, z=AIR_GAP_LOC_Z_OFFSET_FROM_WELL_TOP)
+    )
+
+    subject.retract_after_dispensing(
+        trash_location=trash_location,
+        source_location=source_location,
+        source_well=source_well,
+        add_final_air_gap=False,
+    )
+
+    decoy.verify(
+        mock_instrument_core.touch_tip(),  # type: ignore[call-arg]
+        ignore_extra_args=True,
+        times={
+            # (destination type, blowout location, source is touchable):
+            ("well", BlowoutLocation.SOURCE, True): 2,  # touch dest, touch source
+            ("well", BlowoutLocation.SOURCE, False): 1,  # touch dest, no touch source
+            ("well", BlowoutLocation.DESTINATION, True): 1,  # touch dest
+            ("well", BlowoutLocation.DESTINATION, False): 1,  # touch dest
+            ("well", BlowoutLocation.TRASH, True): 1,  # touch dest
+            ("well", BlowoutLocation.TRASH, False): 1,  # touch dest
+            ("trash", BlowoutLocation.SOURCE, True): 1,  # touch source
+            ("trash", BlowoutLocation.SOURCE, False): 0,  # don't touch source
+            ("trash", BlowoutLocation.DESTINATION, True): 0,
+            ("trash", BlowoutLocation.DESTINATION, False): 0,
+            ("trash", BlowoutLocation.TRASH, True): 0,
+            ("trash", BlowoutLocation.TRASH, False): 0,
+        }[dest_type, blowout_location, source_touchable],
     )
 
 

--- a/api/tests/opentrons/protocol_api/core/engine/test_transfer_components_executor.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_transfer_components_executor.py
@@ -1848,24 +1848,10 @@ def test_retract_after_dispense_in_trash_with_blowout_in_disposal_location(
     )
 
 
-@pytest.mark.parametrize(
-    argnames=["dest_type", "blowout_location", "source_touchable"],
-    argvalues=[
-        # Try all combinations of destination type, blowout location, and touchability
-        ("well", BlowoutLocation.SOURCE, True),
-        ("well", BlowoutLocation.SOURCE, False),
-        ("well", BlowoutLocation.DESTINATION, True),
-        ("well", BlowoutLocation.DESTINATION, False),
-        ("well", BlowoutLocation.TRASH, True),
-        ("well", BlowoutLocation.TRASH, False),
-        ("trash", BlowoutLocation.SOURCE, True),
-        ("trash", BlowoutLocation.SOURCE, False),
-        ("trash", BlowoutLocation.DESTINATION, True),
-        ("trash", BlowoutLocation.DESTINATION, False),
-        ("trash", BlowoutLocation.TRASH, True),
-        ("trash", BlowoutLocation.TRASH, False),
-    ],
-)
+# Try all combinations of destination type, blowout location, and touchability
+@pytest.mark.parametrize("dest_type", ["well", "trash"])
+@pytest.mark.parametrize("blowout_location", [bl for bl in BlowoutLocation])
+@pytest.mark.parametrize("source_touchable", [True, False])
 def test_retract_after_dispense_touch_tip(
     decoy: Decoy,
     mock_instrument_core: InstrumentCore,
@@ -1938,7 +1924,7 @@ def test_retract_after_dispense_touch_tip(
         mock_instrument_core.touch_tip(),  # type: ignore[call-arg]
         ignore_extra_args=True,
         times={
-            # (destination type, blowout location, source is touchable):
+            # (destination type, blowout location, source touchable):
             ("well", BlowoutLocation.SOURCE, True): 2,  # touch dest, touch source
             ("well", BlowoutLocation.SOURCE, False): 1,  # touch dest, no touch source
             ("well", BlowoutLocation.DESTINATION, True): 1,  # touch dest


### PR DESCRIPTION
# Overview

This fixes AUTH-1871, where a customer was doing a liquid class transfer with:
- A source that's a reservoir with `touchTipDisabled`.
- A destination that's a normal well plate.
- Blowout enabled after dispense with a location of `SOURCE`.
- Touch-tip enabled after dispense.

The customer was getting a `TouchTipDisabledError` when our implementation tried to touch the reservoir.

In this fix, we disable the touch-tip after blowout when the blowout location is `SOURCE` and the source has `touchTipDisabled`.

To keep this fix minimal, this PR does not change any behavior if the blowout location is **not** `SOURCE`. For example, if a user is transfering to a destination reservoir, and has touch-tip after dispense enabled, we would continue to fail with `TouchTipDisabledError`. (In that case, the user can disable touch-tip after dispense to get a working transfer.) 

## Test Plan and Hands on Testing

I analyzed the customer's protocol before and after this change, and confirmed that we no longer fail with `TouchTipDisabledError` after this change.

I also added a unit test where we try every combination of:
- transfer source is touchable or not
- transfer destination is a normal well or a trash bin
- the blowout location is `SOURCE`, `DESTINATION`, or `TRASH`

## Review requests

Sanniti's intent in the original implementation is a bit unclear.

In the original implementation of `_do_touch_tip_and_air_gap_after_dispense()`, she had:
```
_do_touch_tip_and_air_gap_after_dispense():
    ...
    try:
        self._instrument.touch_tip(...)
    except TouchTipDisabledError:
        # TODO: log a warning
        pass
```
This implied that she intended to ignore any touch-tip failure after the blowout. However, this code didn't work, because the exception that is actually raised here is a `ProtocolCommandFailedError`.

There are other hints in the comments of the original implementation:

In `retract_after_dispensing()`, she wrote:
```
6. If blowout is “source” or “trash”
  - Move to location (top of Well)
  - Do blow-out (top of well)
  - Do touch-tip (?????) (only if it’s in a non-trash location)
```
so it looks like there was an open question of whether we wanted to do a touch-tip after blowing out at all.

She also left the comment in `retract_after_dispensing()`
```
# TODO: no-op touch tip if touch tip is enabled and blowout is in trash/ reservoir/ any labware with touch-tip disabled
```
which implied that we shouldn't attempt to touch-tip at all if the source is untouchable.


## Risk assessment

Low-ish.