### PR TITLE
refactor(protocol-designer): prevent glitching when selecting items i…

### DIFF
--- a/protocol-designer/src/components/molecules/LabwareButtonBasket/index.tsx
+++ b/protocol-designer/src/components/molecules/LabwareButtonBasket/index.tsx
@@ -5,13 +5,12 @@ import { StyledText } from '@opentrons/components'
 import { LabwareButton } from '../../atoms'
 import styles from './labwarebuttonbasket.module.css'
 
-import type { Dispatch, SetStateAction } from 'react'
 import type { AllTemporalPropertiesForTimelineFrame } from '/protocol-designer/step-forms'
 
 interface LabwareButtonBasketProps {
   stackOfLabware: string[]
   labware: AllTemporalPropertiesForTimelineFrame['labware']
-  setSelectedLabware: Dispatch<SetStateAction<string>>
+  setSelectedLabware: (selectedLabwareId: string) => void
   selectedLabware: string
 }
 export function LabwareButtonBasket(

--- a/protocol-designer/src/components/organisms/SlotDetailModal/index.tsx
+++ b/protocol-designer/src/components/organisms/SlotDetailModal/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
@@ -75,8 +75,6 @@ export const SlotDetailModal = (
     wellContents,
     liquidDisplayColors
   )
-  const ingedInputs = Object.values(allIngredientGroupFields)
-  const wellFill = Object.values(allWellFill)
   const individualIds = getLiquidIdsOnLabware(wellContents)
 
   const volumesPerLiquid = getVolumesPerLiquid(wellContents, individualIds)
@@ -84,23 +82,6 @@ export const SlotDetailModal = (
   const [selectedLiquidId, setSelectedLiquidId] = useState<string | undefined>(
     individualIds.length > 0 ? individualIds[0] : undefined
   )
-
-  //  NOTE: this is used for setting the selected liquid when selecting from
-  //  a lid to a labware with liquids in the stack.
-  useEffect(() => {
-    if (wellFill.length > 0) {
-      const match = ingedInputs.find(ingred =>
-        wellFill.includes(ingred.displayColor)
-      )
-      if (match) {
-        setSelectedLiquidId(match.liquidGroupId)
-      } else if (individualIds.length > 0) {
-        setSelectedLiquidId(individualIds[0])
-      }
-    } else {
-      setSelectedLiquidId(undefined)
-    }
-  }, [selectedLabware, wellFill, ingedInputs])
 
   const wellContentsWithLiquidId: WellGroup =
     wellContents != null && selectedLiquidId != null
@@ -153,7 +134,21 @@ export const SlotDetailModal = (
               stackOfLabware={stackOfLabware}
               selectedLabware={selectedLabware}
               labware={labware}
-              setSelectedLabware={setSelectedLabware}
+              setSelectedLabware={(selectedLabwareId: string) => {
+                const wellContentsForNewlySelected =
+                  allWellContentsForActiveItem != null
+                    ? allWellContentsForActiveItem[selectedLabwareId]
+                    : null
+
+                const individualIdsForNewlySelected = getLiquidIdsOnLabware(
+                  wellContentsForNewlySelected
+                )
+
+                setSelectedLabware(selectedLabwareId)
+                setSelectedLiquidId(
+                  individualIdsForNewlySelected[0] ?? undefined
+                )
+              }}
             />
           ) : null}
           <Flex


### PR DESCRIPTION
…n stack

closes AUTH-2252

# Overview

There was a glitching when rendering the liquid details when selecting a layer with no liquids to a layer with liquids (a lid to a labware) and this pr fixes that

## Test Plan and Hands on Testing

Upload attached protocol and go to the ending deck state in the timeline. click on the slot with just the labware and see that the liquid deetails render. click on the slot with the labware + lid and see that you can select the different layers without any glitching

[untitled (36).py.zip](https://github.com/user-attachments/files/22095827/untitled.36.py.zip)


https://github.com/user-attachments/assets/31485477-7b00-439d-b444-5f644b30761a



## Changelog

render the liquid id when selecting the different labware and remove the use state

## Risk assessment

low
