### PR TITLE
fix(step-generation): drop_tip(tip_rack["A1"]) instead of wells_by_name()["A1"]

### DIFF
--- a/step-generation/src/__tests__/dropTip.test.ts
+++ b/step-generation/src/__tests__/dropTip.test.ts
@@ -197,7 +197,7 @@ describe('dropTip', () => {
       )
       const res = getSuccessResult(result)
       expect(res.python).toEqual(
-        'mock_pipette.drop_tip(location=mock_tip_rack_1.wells_by_name()["A1"])'
+        'mock_pipette.drop_tip(location=mock_tip_rack_1["A1"])'
       )
     })
 

--- a/step-generation/src/__tests__/mix.test.ts
+++ b/step-generation/src/__tests__/mix.test.ts
@@ -853,7 +853,7 @@ mock_pipette.mix(
     aspirate_flow_rate=2.1,
     dispense_flow_rate=2.2,
 )
-mock_pipette.drop_tip(location=mock_tip_rack_1.wells_by_name()["A1"])
+mock_pipette.drop_tip(location=mock_tip_rack_1["A1"])
 mock_pipette.pick_up_tip(location=mock_tip_rack_1)
 mock_pipette.mix(
     repetitions=2,
@@ -862,7 +862,7 @@ mock_pipette.mix(
     aspirate_flow_rate=2.1,
     dispense_flow_rate=2.2,
 )
-mock_pipette.drop_tip(location=mock_tip_rack_1.wells_by_name()["B1"])
+mock_pipette.drop_tip(location=mock_tip_rack_1["B1"])
 mock_pipette.pick_up_tip(location=mock_tip_rack_1)
 mock_pipette.mix(
     repetitions=2,
@@ -871,7 +871,7 @@ mock_pipette.mix(
     aspirate_flow_rate=2.1,
     dispense_flow_rate=2.2,
 )
-mock_pipette.drop_tip(location=mock_tip_rack_1.wells_by_name()["C1"])`
+mock_pipette.drop_tip(location=mock_tip_rack_1["C1"])`
     )
   })
   it('should return tip if changeTip is once', () => {
@@ -903,7 +903,7 @@ mock_pipette.mix(
     aspirate_flow_rate=2.1,
     dispense_flow_rate=2.2,
 )
-mock_pipette.drop_tip(location=mock_tip_rack_1.wells_by_name()["A1"])`
+mock_pipette.drop_tip(location=mock_tip_rack_1["A1"])`
     )
   })
 })

--- a/step-generation/src/commandCreators/atomic/dropTip.ts
+++ b/step-generation/src/commandCreators/atomic/dropTip.ts
@@ -46,7 +46,7 @@ export const dropTip: CommandCreator<DropTipArgs> = (
   if (isReturnTip && isReturnLocationKnown) {
     const pythonPipette = invariantContext.pipetteEntities[pipette].pythonName
     const pythonLabware = mostRecentlyAccessedTiprackLabware.pythonName
-    const pythonLocation = `${pythonLabware}.wells_by_name()["${mostRecentlyAccessedTipWell}"]`
+    const pythonLocation = `${pythonLabware}["${mostRecentlyAccessedTipWell}"]`
     python = `${pythonPipette}.drop_tip(location=${pythonLocation})`
   }
 


### PR DESCRIPTION
# Overview

I just saw that @ncdiehl's `dropTip` implementation refers to the tiprack well as:
```
pipette.drop_tip(location=tip_rack.wells_by_name()["A1"])
```

This PR changes it to the more idiomatic
```
pipette.drop_tip(location=tip_rack["A1"])
```
which is how it's shown in the API docs: https://docs.opentrons.com/v2/new_protocol_api.html#opentrons.protocol_api.InstrumentContext.drop_tip

## Test Plan and Hands on Testing

Updated unit tests.

## Risk assessment

Low. Small change to generated Python, feature not in use yet.