### PR TITLE
fix(shared-data): Fix sign-flip error in frontend calculations of labware-on-labware offsets

### DIFF
--- a/shared-data/js/helpers/positionMath.ts
+++ b/shared-data/js/helpers/positionMath.ts
@@ -398,8 +398,11 @@ export function getLabwareOriginToLabwareOrigin(
     childDefinition.stackingOffsetWithLabware?.[
       parentDefinition.parameters.loadName
     ] ?? IDENTITY_VECTOR
-  const total = getVectorDifference(base, adjustment)
-  return total
+  return getVectorSum(base, {
+    x: adjustment.x,
+    y: adjustment.y,
+    z: -adjustment.z,
+  })
 }
 
 /**

--- a/shared-data/js/helpers/positionMath.ts
+++ b/shared-data/js/helpers/positionMath.ts
@@ -8,7 +8,6 @@ import { IDENTITY_AFFINE_TRANSFORM, multiplyMatrices } from './matrixMath'
 import { pairsFromArray } from './pairsFromArray'
 import {
   coordinateTupleToVector3D,
-  getVectorDifference,
   getVectorInverse,
   getVectorSum,
   IDENTITY_VECTOR,


### PR DESCRIPTION
## Overview

This function is responsible for calculating the offset of one labware atop another. I made a mistake where I misinterpreted the way the labware definition's `stackingOffsetWithLabware` worked. I thought it was subtracted, but in fact only `z` is subtracted, while `x` and `y` are added (🤷). This new interpretation was documented in the JSON schema in #19411:

https://github.com/Opentrons/opentrons/blob/8cbdc6f19e339250d3b4ef1e2d801197216f420b/shared-data/labware/schemas/2.json#L685-L691

## Changelog

Fix the sign-flip error.

## Test Plan and Hands on Testing

None. I think code review is sufficient. If we wanted to be really sure, we could contrive some test definitions and test the "move labware" animation, which I think is the one place that uses this so far.

## Review requests

None.

## Risk assessment

Low. This function is part of a broader centralization effort, but not a whole lot uses it yet.