### PR TITLE
refactor(protocol-designer): add warning when deleting a liquid

### DIFF
--- a/protocol-designer/src/assets/localization/en/liquids.json
+++ b/protocol-designer/src/assets/localization/en/liquids.json
@@ -14,6 +14,7 @@
   "description": "Description",
   "display_color": "Color",
   "dont_use_liquid_class": "Don't use a liquid class",
+  "liquid_in_use": "Liquid in use. Deletion might cause errors",
   "liquid_required": "Liquid required",
   "liquid_volume_nonzero": "Liquid volume must be larger than zero",
   "liquid_volume_required": "Liquid volume required",

--- a/protocol-designer/src/components/organisms/DefineLiquidsModal/index.tsx
+++ b/protocol-designer/src/components/organisms/DefineLiquidsModal/index.tsx
@@ -10,7 +10,6 @@ import {
   COLORS,
   DIRECTION_COLUMN,
   Flex,
-  FLEX_MAX_CONTENT,
   InlineNotification,
   InputField,
   JUSTIFY_END,
@@ -293,16 +292,15 @@ export function DefineLiquidsModal(
                 gridGap={SPACING.spacing8}
               >
                 {selectedIngredFields != null ? (
-                  <Flex gap={SPACING.spacing4}>
+                  <Flex>
                     <Btn
                       css={LINK_BUTTON_STYLE}
+                      padding={SPACING.spacing4}
                       onClick={deleteLiquidGroup}
+                      width="7.1875rem"
                       textDecoration={TYPOGRAPHY.textDecorationUnderline}
                     >
-                      <StyledText
-                        desktopStyle="bodyDefaultRegular"
-                        width={FLEX_MAX_CONTENT}
-                      >
+                      <StyledText desktopStyle="bodyDefaultRegular">
                         {t('delete_liquid')}
                       </StyledText>
                     </Btn>

--- a/protocol-designer/src/components/organisms/DefineLiquidsModal/index.tsx
+++ b/protocol-designer/src/components/organisms/DefineLiquidsModal/index.tsx
@@ -10,6 +10,8 @@ import {
   COLORS,
   DIRECTION_COLUMN,
   Flex,
+  FLEX_MAX_CONTENT,
+  InlineNotification,
   InputField,
   JUSTIFY_END,
   JUSTIFY_SPACE_BETWEEN,
@@ -31,6 +33,7 @@ import { swatchColors } from '@opentrons/step-generation'
 import {
   HandleEnter,
   LINE_CLAMP_TEXT_STYLE,
+  LINK_BUTTON_STYLE,
 } from '/protocol-designer/components/atoms'
 import { TextAreaField } from '/protocol-designer/components/molecules'
 import { getRobotType } from '/protocol-designer/file-data/selectors'
@@ -63,6 +66,9 @@ export function DefineLiquidsModal(
   const selectedLiquid = useSelector(
     labwareIngredSelectors.getSelectedLiquidGroupState
   )
+  const allLabwareWellContents = useSelector(
+    labwareIngredSelectors.getLiquidsByLabwareId
+  )
   const nextGroupId = useSelector(labwareIngredSelectors.getNextLiquidGroupId)
   const selectedLiquidGroupState = useSelector(
     labwareIngredSelectors.getSelectedLiquidGroupState
@@ -80,6 +86,15 @@ export function DefineLiquidsModal(
   const sortedLiquidClassDefs = getSortedLiquidClassDefs()
 
   const liquidGroupId = selectedLiquidGroupState.liquidGroupId
+  const volumePerWell = Object.values(
+    allLabwareWellContents
+  ).flatMap(labwareWithIngred =>
+    Object.values(labwareWithIngred).map(ingred =>
+      liquidGroupId != null ? ingred[liquidGroupId]?.volume : 0
+    )
+  )
+  const liquidHasAssignedWell = volumePerWell.some(volume => volume > 0)
+
   const deleteLiquidGroup = (): void => {
     if (liquidGroupId != null) {
       dispatch(labwareIngredActions.deleteLiquidGroup(liquidGroupId))
@@ -278,14 +293,26 @@ export function DefineLiquidsModal(
                 gridGap={SPACING.spacing8}
               >
                 {selectedIngredFields != null ? (
-                  <Btn
-                    onClick={deleteLiquidGroup}
-                    textDecoration={TYPOGRAPHY.textDecorationUnderline}
-                  >
-                    <StyledText desktopStyle="bodyDefaultRegular">
-                      {t('delete_liquid')}
-                    </StyledText>
-                  </Btn>
+                  <Flex gap={SPACING.spacing4}>
+                    <Btn
+                      css={LINK_BUTTON_STYLE}
+                      onClick={deleteLiquidGroup}
+                      textDecoration={TYPOGRAPHY.textDecorationUnderline}
+                    >
+                      <StyledText
+                        desktopStyle="bodyDefaultRegular"
+                        width={FLEX_MAX_CONTENT}
+                      >
+                        {t('delete_liquid')}
+                      </StyledText>
+                    </Btn>
+                    {liquidHasAssignedWell ? (
+                      <InlineNotification
+                        type="alert"
+                        message={t('liquid_in_use')}
+                      />
+                    ) : null}
+                  </Flex>
                 ) : (
                   <SecondaryButton onClick={cancelForm}>
                     {t('shared:close')}


### PR DESCRIPTION
closes AUTH-2214

# Overview
<img width="610" height="518" alt="Screenshot 2025-09-02 at 10 02 33" src="https://github.com/user-attachments/assets/d53e2c8a-3fc0-4702-9aed-d58d452eedab" />

Adds a warning in the modal to create and delete a liquid. it shows up when the liquid is added to a well.

## Test Plan and Hands on Testing

you can use a fixture, like `doItAllV8.json` but create a protocol and assign a liquid to a well and create another liquid that is not assigned to a well. when you try to delete the liquids, see that the warning notification only pops up when the liquid is assigned to a well.

## Changelog

add inline notification warning when liquid is assigned to a well.

## Risk assessment

low
