### PR TITLE
fix(protocol-designer): use tiprack displayname and not nickname in d…

### DIFF
--- a/protocol-designer/src/ui/labware/selectors.ts
+++ b/protocol-designer/src/ui/labware/selectors.ts
@@ -87,14 +87,12 @@ export const getDisposalOptions = createSelector(
 
 export const getTiprackOptions: Selector<DropdownOption[]> = createSelector(
   stepFormSelectors.getLabwareEntities,
-  getLabwareNicknamesById,
-  (labwareEntities, nicknamesById) => {
+  labwareEntities => {
     const options = reduce(
       labwareEntities,
       (
         acc: DropdownOption[],
-        labwareEntity: LabwareEntity,
-        labwareId: string
+        labwareEntity: LabwareEntity
       ): DropdownOption[] => {
         const labwareDefURI = labwareEntity.labwareDefURI
         const optionDefURI = acc.map(option => option.value)
@@ -108,7 +106,7 @@ export const getTiprackOptions: Selector<DropdownOption[]> = createSelector(
           return [
             ...acc,
             {
-              name: nicknamesById[labwareId],
+              name: labwareEntity.def.metadata.displayName,
               value: labwareDefURI,
             },
           ]


### PR DESCRIPTION
…ropdown

closes AUTH-2217

# Overview

The bug was we were displaying the nickname instead of the display name so sometimes, it incorrectly showed a number at the end of the display name.

before
<img width="375" height="408" alt="Screenshot 2025-09-02 at 10 21 02" src="https://github.com/user-attachments/assets/d6ee5a0c-25e7-4401-9da7-f8b19a4f58ad" />

after
<img width="374" height="403" alt="Screenshot 2025-09-02 at 10 20 51" src="https://github.com/user-attachments/assets/ff24e517-54a8-4265-8a68-92301839bbe9" />


## Test Plan and Hands on Testing

Import attached protocol to a build in edge and a build on this branch and look at the transfer step and see that the tiprack field shows the display name correctly 

[tiprack_field_bug.py.zip](https://github.com/user-attachments/files/22100506/tiprack_field_bug.py.zip)


## Changelog

show display name instead of nick name

## Risk assessment

low
