### PR TITLE
refactor(api): Defer new labware versions from apiLevel 2.26 to 2.27

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/_default_labware_versions.py
+++ b/api/src/opentrons/protocol_api/core/engine/_default_labware_versions.py
@@ -112,7 +112,7 @@ DEFAULT_LABWARE_VERSIONS: DefaultLabwareVersions = {
         "thermoscientificnunc_96_wellplate_2000ul": 3,
         "usascientific_96_wellplate_2.4ml_deep": 3,
     },
-    APIVersion(2, 26): {
+    APIVersion(2, 27): {
         "agilent_1_reservoir_290ml": 4,
         "axygen_1_reservoir_90ml": 3,
         "biorad_96_wellplate_200ul_pcr": 5,


### PR DESCRIPTION
## Overview

We've got this situation where Python Protocol API v2.26 is being introduced concurrently in `edge` (#19127) *and* in the robot software v8.6.1 release branch (#19348).

```mermaid
---
config:
  gitGraph:
    mainBranchName: edge
---

gitGraph

commit id: "base"

branch 8.6.1
commit id: "introduce apiLevel 2.26 and add new params"

checkout edge
commit id: "introduce apiLevel 2.26 and add new labware versions"
```

This updates the changes in `edge` to apply to PAPIv2.27 instead of PAPIv2.26. This avoids a future problem after the eventual robot software v8.6.1 mergeback, where PAPIv2.26 would behave differently between `edge` and our released software.

## Test Plan and Hands on Testing

None.

## Review requests

Makes sense?

## Risk assessment

Low.
