### PR TITLE
feat(shared-data): restore liquid class `water` v2 definitions

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/_default_liquid_class_versions.py
+++ b/api/src/opentrons/protocol_api/core/engine/_default_liquid_class_versions.py
@@ -28,8 +28,6 @@ DefaultLiquidClassVersions: TypeAlias = dict[APIVersion, dict[str, int]]
 # [any]            [anything else]   1
 DEFAULT_LIQUID_CLASS_VERSIONS: DefaultLiquidClassVersions = {
     APIVersion(2, 26): {
-        "ethanol_80": 2,
-        "glycerol_50": 2,
         "water": 2,
     },
 }

--- a/hardware-testing/hardware_testing/gravimetric/protocol_replacement/gravimetric.py
+++ b/hardware-testing/hardware_testing/gravimetric/protocol_replacement/gravimetric.py
@@ -36,7 +36,7 @@ from opentrons.protocol_api._nozzle_layout import NozzleLayout
 from opentrons.protocols.advanced_control.transfers import common as tx_ctl_lib
 
 metadata = {"protocolName": "Gravimetric QC"}
-requirements = {"robotType": "Flex", "apiLevel": "2.25"}
+requirements = {"robotType": "Flex", "apiLevel": "2.26"}
 
 SCALE_SECONDS_TO_TRUE_STABILIZE = 60 * 3
 

--- a/hardware-testing/hardware_testing/protocols/universal_photometric.py
+++ b/hardware-testing/hardware_testing/protocols/universal_photometric.py
@@ -402,7 +402,7 @@ def run(ctx: protocol_api.ProtocolContext) -> None:
     target_volume = ctx.params.target_volume  # type: ignore [attr-defined]
 
     def _get_transfer_settings(tiprack: Labware, first_trial: bool) -> LiquidClass:
-        liquid_class = ctx.get_liquid_class("water")
+        liquid_class = ctx.get_liquid_class("water", version=2)
         transfer_properties = liquid_class.get_for(pip, tiprack)
 
         asp_offset = Coordinate(x=0, y=0, z=-1 * ctx.params.asp_sub_depth)  # type: ignore [attr-defined]

--- a/hardware-testing/hardware_testing/protocols/universal_photometric.py
+++ b/hardware-testing/hardware_testing/protocols/universal_photometric.py
@@ -20,7 +20,7 @@ from opentrons.protocol_api.core.engine import (
 
 
 metadata = {"protocolName": "96ch Universal Photometric Protocol"}
-requirements = {"robotType": "Flex", "apiLevel": "2.24"}
+requirements = {"robotType": "Flex", "apiLevel": "2.26"}
 
 DYE_RESERVOIR_DEAD_VOLUME = 20000  # 20k uL
 

--- a/shared-data/liquid-class/definitions/1/water/2.json
+++ b/shared-data/liquid-class/definitions/1/water/2.json
@@ -1,0 +1,6316 @@
+{
+  "liquidClassName": "water",
+  "displayName": "Aqueous",
+  "description": "Deionized water",
+  "schemaVersion": 1,
+  "version": 1,
+  "namespace": "opentrons",
+  "byPipette": [
+    {
+      "pipetteModel": "flex_1channel_50",
+      "byTipType": [
+        {
+          "tiprack": "opentrons/opentrons_flex_96_tiprack_50ul/1",
+          "aspirate": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 100,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 50,
+              "airGapByVolume": [
+                [1.0, 0.1],
+                [49.9, 0.1],
+                [50.0, 0.0]
+              ],
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "aspiratePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [
+              [1.0, 35.0],
+              [10.0, 24.0],
+              [50.0, 35.0]
+            ],
+            "correctionByVolume": [[0.0, 0.0]],
+            "preWet": false,
+            "mix": {
+              "enable": false,
+              "params": {
+                "repetitions": 1,
+                "volume": 50
+              }
+            },
+            "delay": {
+              "enable": true,
+              "params": {
+                "duration": 0.2
+              }
+            }
+          },
+          "singleDispense": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 100,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 50,
+              "airGapByVolume": [
+                [1.0, 0.1],
+                [49.9, 0.1],
+                [50.0, 0.0]
+              ],
+              "blowout": {
+                "enable": true,
+                "params": {
+                  "location": "destination",
+                  "flowRate": 50.0
+                }
+              },
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "dispensePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[1.0, 50.0]],
+            "correctionByVolume": [[0.0, 0.0]],
+            "mix": {
+              "enable": false,
+              "params": {
+                "repetitions": 1,
+                "volume": 50
+              }
+            },
+            "pushOutByVolume": [
+              [1.0, 7.0],
+              [4.999, 7.0],
+              [5.0, 2.0],
+              [10.0, 2.0],
+              [50.0, 2.0]
+            ],
+            "delay": {
+              "enable": true,
+              "params": {
+                "duration": 0.2
+              }
+            }
+          },
+          "multiDispense": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 100,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 50,
+              "airGapByVolume": [
+                [1.0, 0.1],
+                [49.9, 0.1],
+                [50.0, 0.0]
+              ],
+              "blowout": {
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 50.0
+                }
+              },
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "dispensePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[1.0, 50.0]],
+            "correctionByVolume": [[0.0, 0.0]],
+            "conditioningByVolume": [
+              [1.0, 5.0],
+              [45.0, 5.0],
+              [50.0, 0.0]
+            ],
+            "disposalByVolume": [
+              [1.0, 5.0],
+              [45.0, 5.0],
+              [50.0, 0.0]
+            ],
+            "delay": {
+              "enable": true,
+              "params": {
+                "duration": 0.2
+              }
+            }
+          }
+        },
+        {
+          "tiprack": "opentrons/opentrons_flex_96_filtertiprack_50ul/1",
+          "aspirate": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 100,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 50,
+              "airGapByVolume": [
+                [1.0, 0.1],
+                [49.9, 0.1],
+                [50.0, 0.0]
+              ],
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "aspiratePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [
+              [1.0, 35.0],
+              [10.0, 24.0],
+              [50.0, 35.0]
+            ],
+            "correctionByVolume": [[0.0, 0.0]],
+            "preWet": false,
+            "mix": {
+              "enable": false,
+              "params": {
+                "repetitions": 1,
+                "volume": 50
+              }
+            },
+            "delay": {
+              "enable": true,
+              "params": {
+                "duration": 0.2
+              }
+            }
+          },
+          "singleDispense": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 100,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 50,
+              "airGapByVolume": [
+                [1.0, 0.1],
+                [49.9, 0.1],
+                [50.0, 0.0]
+              ],
+              "blowout": {
+                "enable": false,
+                "params": {
+                  "location": "destination",
+                  "flowRate": 50.0
+                }
+              },
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "dispensePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[1.0, 50.0]],
+            "correctionByVolume": [[0.0, 0.0]],
+            "mix": {
+              "enable": false,
+              "params": {
+                "repetitions": 1,
+                "volume": 50
+              }
+            },
+            "pushOutByVolume": [
+              [1.0, 7.0],
+              [4.999, 7.0],
+              [5.0, 2.0],
+              [10.0, 2.0],
+              [50.0, 2.0]
+            ],
+            "delay": {
+              "enable": true,
+              "params": {
+                "duration": 0.2
+              }
+            }
+          },
+          "multiDispense": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 100,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 50,
+              "airGapByVolume": [
+                [1.0, 0.1],
+                [49.9, 0.1],
+                [50.0, 0.0]
+              ],
+              "blowout": {
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 50.0
+                }
+              },
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "dispensePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[1.0, 50.0]],
+            "correctionByVolume": [[0.0, 0.0]],
+            "conditioningByVolume": [
+              [1.0, 5.0],
+              [45.0, 5.0],
+              [50.0, 0.0]
+            ],
+            "disposalByVolume": [
+              [1.0, 5.0],
+              [45.0, 5.0],
+              [50.0, 0.0]
+            ],
+            "delay": {
+              "enable": true,
+              "params": {
+                "duration": 0.2
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "pipetteModel": "flex_8channel_50",
+      "byTipType": [
+        {
+          "tiprack": "opentrons/opentrons_flex_96_tiprack_50ul/1",
+          "aspirate": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 100,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 50,
+              "airGapByVolume": [
+                [1.0, 0.1],
+                [49.9, 0.1],
+                [50.0, 0.0]
+              ],
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "aspiratePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [
+              [1.0, 35.0],
+              [10.0, 24.0],
+              [50.0, 35.0]
+            ],
+            "correctionByVolume": [[0.0, 0.0]],
+            "preWet": false,
+            "mix": {
+              "enable": false,
+              "params": {
+                "repetitions": 1,
+                "volume": 50
+              }
+            },
+            "delay": {
+              "enable": true,
+              "params": {
+                "duration": 0.2
+              }
+            }
+          },
+          "singleDispense": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 100,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 50,
+              "airGapByVolume": [
+                [1.0, 0.1],
+                [49.9, 0.1],
+                [50.0, 0.0]
+              ],
+              "blowout": {
+                "enable": false,
+                "params": {
+                  "location": "destination",
+                  "flowRate": 50.0
+                }
+              },
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "dispensePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[1.0, 50.0]],
+            "correctionByVolume": [[0.0, 0.0]],
+            "mix": {
+              "enable": false,
+              "params": {
+                "repetitions": 1,
+                "volume": 50
+              }
+            },
+            "pushOutByVolume": [
+              [1.0, 7.0],
+              [4.999, 7.0],
+              [5.0, 2.0],
+              [10.0, 2.0],
+              [50.0, 2.0]
+            ],
+            "delay": {
+              "enable": true,
+              "params": {
+                "duration": 0.2
+              }
+            }
+          },
+          "multiDispense": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 100,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 50,
+              "airGapByVolume": [
+                [1.0, 0.1],
+                [49.9, 0.1],
+                [50.0, 0.0]
+              ],
+              "blowout": {
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 50.0
+                }
+              },
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "dispensePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[1.0, 50.0]],
+            "correctionByVolume": [[0.0, 0.0]],
+            "conditioningByVolume": [
+              [1.0, 5.0],
+              [45.0, 5.0],
+              [50.0, 0.0]
+            ],
+            "disposalByVolume": [
+              [1.0, 5.0],
+              [45.0, 5.0],
+              [50.0, 0.0]
+            ],
+            "delay": {
+              "enable": true,
+              "params": {
+                "duration": 0.2
+              }
+            }
+          }
+        },
+        {
+          "tiprack": "opentrons/opentrons_flex_96_filtertiprack_50ul/1",
+          "aspirate": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 100,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 50,
+              "airGapByVolume": [
+                [1.0, 0.1],
+                [49.9, 0.1],
+                [50.0, 0.0]
+              ],
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "aspiratePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [
+              [1.0, 35.0],
+              [10.0, 24.0],
+              [50.0, 35.0]
+            ],
+            "correctionByVolume": [[0.0, 0.0]],
+            "preWet": false,
+            "mix": {
+              "enable": false,
+              "params": {
+                "repetitions": 1,
+                "volume": 50
+              }
+            },
+            "delay": {
+              "enable": true,
+              "params": {
+                "duration": 0.2
+              }
+            }
+          },
+          "singleDispense": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 100,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 50,
+              "airGapByVolume": [
+                [1.0, 0.1],
+                [49.9, 0.1],
+                [50.0, 0.0]
+              ],
+              "blowout": {
+                "enable": false,
+                "params": {
+                  "location": "destination",
+                  "flowRate": 50.0
+                }
+              },
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "dispensePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[1.0, 50.0]],
+            "correctionByVolume": [[0.0, 0.0]],
+            "mix": {
+              "enable": false,
+              "params": {
+                "repetitions": 1,
+                "volume": 50
+              }
+            },
+            "pushOutByVolume": [
+              [1.0, 7.0],
+              [4.999, 7.0],
+              [5.0, 2.0],
+              [10.0, 2.0],
+              [50.0, 2.0]
+            ],
+            "delay": {
+              "enable": true,
+              "params": {
+                "duration": 0.2
+              }
+            }
+          },
+          "multiDispense": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 100,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 50,
+              "airGapByVolume": [
+                [1.0, 0.1],
+                [49.9, 0.1],
+                [50.0, 0.0]
+              ],
+              "blowout": {
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 50.0
+                }
+              },
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "dispensePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[1.0, 50.0]],
+            "correctionByVolume": [[0.0, 0.0]],
+            "conditioningByVolume": [
+              [1.0, 5.0],
+              [45.0, 5.0],
+              [50.0, 0.0]
+            ],
+            "disposalByVolume": [
+              [1.0, 5.0],
+              [45.0, 5.0],
+              [50.0, 0.0]
+            ],
+            "delay": {
+              "enable": true,
+              "params": {
+                "duration": 0.2
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "pipetteModel": "flex_1channel_1000",
+      "byTipType": [
+        {
+          "tiprack": "opentrons/opentrons_flex_96_tiprack_50ul/1",
+          "aspirate": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 50,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 50,
+              "airGapByVolume": [
+                [1.0, 0.1],
+                [49.0, 0.1],
+                [50.0, 0.0]
+              ],
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "aspiratePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [
+              [5.0, 318.0],
+              [10.0, 478.0],
+              [50.0, 478.0]
+            ],
+            "correctionByVolume": [[0.0, 0.0]],
+            "preWet": false,
+            "mix": {
+              "enable": false,
+              "params": {
+                "repetitions": 1,
+                "volume": 50
+              }
+            },
+            "delay": {
+              "enable": true,
+              "params": {
+                "duration": 1.0
+              }
+            }
+          },
+          "singleDispense": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 50,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 50,
+              "airGapByVolume": [
+                [1.0, 0.1],
+                [49.0, 0.1],
+                [50.0, 0.0]
+              ],
+              "blowout": {
+                "enable": true,
+                "params": {
+                  "location": "destination",
+                  "flowRate": 318.0
+                }
+              },
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "dispensePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [
+              [5.0, 318.0],
+              [10.0, 478.0],
+              [50.0, 478.0]
+            ],
+            "correctionByVolume": [[0.0, 0.0]],
+            "mix": {
+              "enable": false,
+              "params": {
+                "repetitions": 1,
+                "volume": 50
+              }
+            },
+            "pushOutByVolume": [[1.0, 5.0]],
+            "delay": {
+              "enable": false,
+              "params": {
+                "duration": 0.5
+              }
+            }
+          },
+          "multiDispense": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 100,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 50,
+              "airGapByVolume": [
+                [1.0, 1.0],
+                [49.0, 1.0],
+                [50.0, 0.0]
+              ],
+              "blowout": {
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 478.0
+                }
+              },
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "dispensePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [
+              [5.0, 318.0],
+              [10.0, 478.0],
+              [50.0, 478.0]
+            ],
+            "correctionByVolume": [[0.0, 0.0]],
+            "conditioningByVolume": [
+              [1.0, 5.0],
+              [45.0, 5.0],
+              [50.0, 0.0]
+            ],
+            "disposalByVolume": [
+              [1.0, 5.0],
+              [45.0, 5.0],
+              [50.0, 0.0]
+            ],
+            "delay": {
+              "enable": false,
+              "params": {
+                "duration": 0.0
+              }
+            }
+          }
+        },
+        {
+          "tiprack": "opentrons/opentrons_flex_96_filtertiprack_50ul/1",
+          "aspirate": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 100,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 50,
+              "airGapByVolume": [
+                [1.0, 0.1],
+                [49.0, 0.1],
+                [50.0, 0.0]
+              ],
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "aspiratePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [
+              [5.0, 318.0],
+              [10.0, 478.0],
+              [50.0, 478.0]
+            ],
+            "correctionByVolume": [[0.0, 0.0]],
+            "preWet": false,
+            "mix": {
+              "enable": false,
+              "params": {
+                "repetitions": 1,
+                "volume": 50
+              }
+            },
+            "delay": {
+              "enable": true,
+              "params": {
+                "duration": 0.5
+              }
+            }
+          },
+          "singleDispense": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 100,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 50,
+              "airGapByVolume": [
+                [1.0, 0.1],
+                [49.0, 0.1],
+                [50.0, 0.0]
+              ],
+              "blowout": {
+                "enable": true,
+                "params": {
+                  "location": "destination",
+                  "flowRate": 478.0
+                }
+              },
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "dispensePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [
+              [5.0, 318.0],
+              [10.0, 478.0],
+              [50.0, 478.0]
+            ],
+            "correctionByVolume": [[0.0, 0.0]],
+            "mix": {
+              "enable": false,
+              "params": {
+                "repetitions": 1,
+                "volume": 50
+              }
+            },
+            "pushOutByVolume": [[1.0, 5.0]],
+            "delay": {
+              "enable": false,
+              "params": {
+                "duration": 0.0
+              }
+            }
+          },
+          "multiDispense": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 100,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 50,
+              "airGapByVolume": [
+                [1.0, 1.0],
+                [49.0, 1.0],
+                [50.0, 0.0]
+              ],
+              "blowout": {
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 478.0
+                }
+              },
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "dispensePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [
+              [5.0, 318.0],
+              [10.0, 478.0],
+              [50.0, 478.0]
+            ],
+            "correctionByVolume": [[0.0, 0.0]],
+            "conditioningByVolume": [
+              [1.0, 5.0],
+              [45.0, 5.0],
+              [50.0, 0.0]
+            ],
+            "disposalByVolume": [
+              [1.0, 5.0],
+              [45.0, 5.0],
+              [50.0, 0.0]
+            ],
+            "delay": {
+              "enable": false,
+              "params": {
+                "duration": 0.0
+              }
+            }
+          }
+        },
+        {
+          "tiprack": "opentrons/opentrons_flex_96_tiprack_200ul/1",
+          "aspirate": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 100,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 50,
+              "airGapByVolume": [
+                [1.0, 5.0],
+                [195.0, 5.0],
+                [200.0, 0.0]
+              ],
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "aspiratePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[1.0, 716.0]],
+            "correctionByVolume": [[0.0, 0.0]],
+            "preWet": false,
+            "mix": {
+              "enable": false,
+              "params": {
+                "repetitions": 1,
+                "volume": 50
+              }
+            },
+            "delay": {
+              "enable": true,
+              "params": {
+                "duration": 0.75
+              }
+            }
+          },
+          "singleDispense": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 100,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 50,
+              "airGapByVolume": [
+                [1.0, 5.0],
+                [195.0, 5.0],
+                [200.0, 0.0]
+              ],
+              "blowout": {
+                "enable": false,
+                "params": {
+                  "location": "destination",
+                  "flowRate": 716.0
+                }
+              },
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "dispensePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[1.0, 716.0]],
+            "correctionByVolume": [[0.0, 0.0]],
+            "mix": {
+              "enable": false,
+              "params": {
+                "repetitions": 1,
+                "volume": 50
+              }
+            },
+            "pushOutByVolume": [[1.0, 15.0]],
+            "delay": {
+              "enable": false,
+              "params": {
+                "duration": 0.0
+              }
+            }
+          },
+          "multiDispense": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 100,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 50,
+              "airGapByVolume": [
+                [1.0, 5.0],
+                [195.0, 5.0],
+                [200.0, 0.0]
+              ],
+              "blowout": {
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 716.0
+                }
+              },
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "dispensePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[1.0, 716.0]],
+            "correctionByVolume": [[0.0, 0.0]],
+            "conditioningByVolume": [
+              [1.0, 5.0],
+              [195.0, 5.0],
+              [200.0, 0.0]
+            ],
+            "disposalByVolume": [
+              [1.0, 5.0],
+              [195.0, 5.0],
+              [200.0, 0.0]
+            ],
+            "delay": {
+              "enable": false,
+              "params": {
+                "duration": 0.0
+              }
+            }
+          }
+        },
+        {
+          "tiprack": "opentrons/opentrons_flex_96_filtertiprack_200ul/1",
+          "aspirate": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 100,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 50,
+              "airGapByVolume": [
+                [1.0, 5.0],
+                [195.0, 5.0],
+                [200.0, 0.0]
+              ],
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "aspiratePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[1.0, 716.0]],
+            "correctionByVolume": [[0.0, 0.0]],
+            "preWet": false,
+            "mix": {
+              "enable": false,
+              "params": {
+                "repetitions": 1,
+                "volume": 50
+              }
+            },
+            "delay": {
+              "enable": true,
+              "params": {
+                "duration": 0.75
+              }
+            }
+          },
+          "singleDispense": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 100,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 50,
+              "airGapByVolume": [
+                [1.0, 5.0],
+                [195.0, 5.0],
+                [200.0, 0.0]
+              ],
+              "blowout": {
+                "enable": false,
+                "params": {
+                  "location": "destination",
+                  "flowRate": 716.0
+                }
+              },
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "dispensePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[1.0, 716.0]],
+            "correctionByVolume": [[0.0, 0.0]],
+            "mix": {
+              "enable": false,
+              "params": {
+                "repetitions": 1,
+                "volume": 50
+              }
+            },
+            "pushOutByVolume": [[1.0, 15.0]],
+            "delay": {
+              "enable": false,
+              "params": {
+                "duration": 0.0
+              }
+            }
+          },
+          "multiDispense": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 100,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 50,
+              "airGapByVolume": [
+                [1.0, 5.0],
+                [195.0, 5.0],
+                [200.0, 0.0]
+              ],
+              "blowout": {
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 716.0
+                }
+              },
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "dispensePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[1.0, 716.0]],
+            "correctionByVolume": [[0.0, 0.0]],
+            "conditioningByVolume": [
+              [1.0, 5.0],
+              [195.0, 5.0],
+              [200.0, 0.0]
+            ],
+            "disposalByVolume": [
+              [1.0, 5.0],
+              [195.0, 5.0],
+              [200.0, 0.0]
+            ],
+            "delay": {
+              "enable": false,
+              "params": {
+                "duration": 0.0
+              }
+            }
+          }
+        },
+        {
+          "tiprack": "opentrons/opentrons_flex_96_tiprack_1000ul/1",
+          "aspirate": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 100,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 50,
+              "airGapByVolume": [
+                [10.0, 10.0],
+                [990.0, 10.0],
+                [1000.0, 0.0]
+              ],
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "aspiratePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[1.0, 716.0]],
+            "correctionByVolume": [[0.0, 0.0]],
+            "preWet": false,
+            "mix": {
+              "enable": false,
+              "params": {
+                "repetitions": 1,
+                "volume": 50
+              }
+            },
+            "delay": {
+              "enable": true,
+              "params": {
+                "duration": 0.5
+              }
+            }
+          },
+          "singleDispense": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 100,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 50,
+              "airGapByVolume": [
+                [10.0, 10.0],
+                [990.0, 10.0],
+                [1000.0, 0.0]
+              ],
+              "blowout": {
+                "enable": false,
+                "params": {
+                  "location": "destination",
+                  "flowRate": 716.0
+                }
+              },
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "dispensePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[1.0, 716.0]],
+            "correctionByVolume": [[0.0, 0.0]],
+            "mix": {
+              "enable": false,
+              "params": {
+                "repetitions": 1,
+                "volume": 50
+              }
+            },
+            "pushOutByVolume": [[1.0, 20.0]],
+            "delay": {
+              "enable": false,
+              "params": {
+                "duration": 0.0
+              }
+            }
+          },
+          "multiDispense": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 100,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 50,
+              "airGapByVolume": [
+                [10.0, 10.0],
+                [990.0, 10.0],
+                [1000.0, 0.0]
+              ],
+              "blowout": {
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 716.0
+                }
+              },
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "dispensePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[1.0, 716.0]],
+            "correctionByVolume": [[0.0, 0.0]],
+            "conditioningByVolume": [
+              [1.0, 5.0],
+              [995.0, 5.0],
+              [1000.0, 0.0]
+            ],
+            "disposalByVolume": [
+              [1.0, 5.0],
+              [995.0, 5.0],
+              [1000.0, 0.0]
+            ],
+            "delay": {
+              "enable": false,
+              "params": {
+                "duration": 0.0
+              }
+            }
+          }
+        },
+        {
+          "tiprack": "opentrons/opentrons_flex_96_filtertiprack_1000ul/1",
+          "aspirate": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 100,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 50,
+              "airGapByVolume": [
+                [10.0, 10.0],
+                [990.0, 10.0],
+                [1000.0, 0.0]
+              ],
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "aspiratePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[1.0, 716.0]],
+            "correctionByVolume": [[0.0, 0.0]],
+            "preWet": false,
+            "mix": {
+              "enable": false,
+              "params": {
+                "repetitions": 1,
+                "volume": 50
+              }
+            },
+            "delay": {
+              "enable": true,
+              "params": {
+                "duration": 0.5
+              }
+            }
+          },
+          "singleDispense": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 100,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 50,
+              "airGapByVolume": [
+                [10.0, 10.0],
+                [990.0, 10.0],
+                [1000.0, 0.0]
+              ],
+              "blowout": {
+                "enable": false,
+                "params": {
+                  "location": "destination",
+                  "flowRate": 716.0
+                }
+              },
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "dispensePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[1.0, 716.0]],
+            "correctionByVolume": [[0.0, 0.0]],
+            "mix": {
+              "enable": false,
+              "params": {
+                "repetitions": 1,
+                "volume": 50
+              }
+            },
+            "pushOutByVolume": [[1.0, 20.0]],
+            "delay": {
+              "enable": false,
+              "params": {
+                "duration": 0.0
+              }
+            }
+          },
+          "multiDispense": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 100,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 50,
+              "airGapByVolume": [
+                [10.0, 10.0],
+                [990.0, 10.0],
+                [1000.0, 0.0]
+              ],
+              "blowout": {
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 716.0
+                }
+              },
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "dispensePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[1.0, 716.0]],
+            "correctionByVolume": [[0.0, 0.0]],
+            "conditioningByVolume": [
+              [1.0, 5.0],
+              [995.0, 5.0],
+              [1000.0, 0.0]
+            ],
+            "disposalByVolume": [
+              [1.0, 5.0],
+              [995.0, 5.0],
+              [1000.0, 0.0]
+            ],
+            "delay": {
+              "enable": false,
+              "params": {
+                "duration": 0.0
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "pipetteModel": "flex_8channel_1000",
+      "byTipType": [
+        {
+          "tiprack": "opentrons/opentrons_flex_96_tiprack_50ul/1",
+          "aspirate": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 100,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 50,
+              "airGapByVolume": [
+                [1.0, 0.1],
+                [49.0, 0.1],
+                [50.0, 0.0]
+              ],
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "aspiratePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [
+              [5.0, 318.0],
+              [10.0, 478.0],
+              [50.0, 478.0]
+            ],
+            "correctionByVolume": [[0.0, 0.0]],
+            "preWet": false,
+            "mix": {
+              "enable": false,
+              "params": {
+                "repetitions": 1,
+                "volume": 50
+              }
+            },
+            "delay": {
+              "enable": true,
+              "params": {
+                "duration": 1.0
+              }
+            }
+          },
+          "singleDispense": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 100,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 50,
+              "airGapByVolume": [
+                [1.0, 0.1],
+                [49.0, 0.1],
+                [50.0, 0.0]
+              ],
+              "blowout": {
+                "enable": true,
+                "params": {
+                  "location": "destination",
+                  "flowRate": 478.0
+                }
+              },
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "dispensePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [
+              [5.0, 318.0],
+              [10.0, 478.0],
+              [50.0, 478.0]
+            ],
+            "correctionByVolume": [[0.0, 0.0]],
+            "mix": {
+              "enable": false,
+              "params": {
+                "repetitions": 1,
+                "volume": 50
+              }
+            },
+            "pushOutByVolume": [[1.0, 5.0]],
+            "delay": {
+              "enable": false,
+              "params": {
+                "duration": 0.0
+              }
+            }
+          },
+          "multiDispense": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 100,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 50,
+              "airGapByVolume": [
+                [1.0, 1.0],
+                [49.0, 1.0],
+                [50.0, 0.0]
+              ],
+              "blowout": {
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 478.0
+                }
+              },
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "dispensePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [
+              [5.0, 318.0],
+              [10.0, 478.0],
+              [50.0, 478.0]
+            ],
+            "correctionByVolume": [[0.0, 0.0]],
+            "conditioningByVolume": [
+              [1.0, 5.0],
+              [45.0, 5.0],
+              [50.0, 0.0]
+            ],
+            "disposalByVolume": [
+              [1.0, 5.0],
+              [45.0, 5.0],
+              [50.0, 0.0]
+            ],
+            "delay": {
+              "enable": false,
+              "params": {
+                "duration": 0.0
+              }
+            }
+          }
+        },
+        {
+          "tiprack": "opentrons/opentrons_flex_96_filtertiprack_50ul/1",
+          "aspirate": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 100,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 50,
+              "airGapByVolume": [
+                [1.0, 0.1],
+                [49.0, 0.1],
+                [50.0, 0.0]
+              ],
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "aspiratePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [
+              [5.0, 318.0],
+              [10.0, 478.0],
+              [50.0, 478.0]
+            ],
+            "correctionByVolume": [[0.0, 0.0]],
+            "preWet": false,
+            "mix": {
+              "enable": false,
+              "params": {
+                "repetitions": 1,
+                "volume": 50
+              }
+            },
+            "delay": {
+              "enable": true,
+              "params": {
+                "duration": 0.5
+              }
+            }
+          },
+          "singleDispense": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 100,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 50,
+              "airGapByVolume": [
+                [1.0, 0.1],
+                [49.0, 0.1],
+                [50.0, 0.0]
+              ],
+              "blowout": {
+                "enable": true,
+                "params": {
+                  "location": "destination",
+                  "flowRate": 478.0
+                }
+              },
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "dispensePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [
+              [5.0, 318.0],
+              [10.0, 478.0],
+              [50.0, 478.0]
+            ],
+            "correctionByVolume": [[0.0, 0.0]],
+            "mix": {
+              "enable": false,
+              "params": {
+                "repetitions": 1,
+                "volume": 50
+              }
+            },
+            "pushOutByVolume": [[1.0, 5.0]],
+            "delay": {
+              "enable": false,
+              "params": {
+                "duration": 0.0
+              }
+            }
+          },
+          "multiDispense": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 100,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 50,
+              "airGapByVolume": [
+                [1.0, 1.0],
+                [49.0, 1.0],
+                [50.0, 0.0]
+              ],
+              "blowout": {
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 478.0
+                }
+              },
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "dispensePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [
+              [5.0, 318.0],
+              [10.0, 478.0],
+              [50.0, 478.0]
+            ],
+            "correctionByVolume": [[0.0, 0.0]],
+            "conditioningByVolume": [
+              [1.0, 5.0],
+              [45.0, 5.0],
+              [50.0, 0.0]
+            ],
+            "disposalByVolume": [
+              [1.0, 5.0],
+              [45.0, 5.0],
+              [50.0, 0.0]
+            ],
+            "delay": {
+              "enable": false,
+              "params": {
+                "duration": 0.0
+              }
+            }
+          }
+        },
+        {
+          "tiprack": "opentrons/opentrons_flex_96_tiprack_200ul/1",
+          "aspirate": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 100,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 50,
+              "airGapByVolume": [
+                [1.0, 5.0],
+                [195.0, 5.0],
+                [200.0, 0.0]
+              ],
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "aspiratePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[1.0, 716.0]],
+            "correctionByVolume": [[0.0, 0.0]],
+            "preWet": false,
+            "mix": {
+              "enable": false,
+              "params": {
+                "repetitions": 1,
+                "volume": 50
+              }
+            },
+            "delay": {
+              "enable": true,
+              "params": {
+                "duration": 0.75
+              }
+            }
+          },
+          "singleDispense": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 100,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 50,
+              "airGapByVolume": [
+                [1.0, 5.0],
+                [195.0, 5.0],
+                [200.0, 0.0]
+              ],
+              "blowout": {
+                "enable": false,
+                "params": {
+                  "location": "destination",
+                  "flowRate": 716.0
+                }
+              },
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "dispensePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[1.0, 716.0]],
+            "correctionByVolume": [[0.0, 0.0]],
+            "mix": {
+              "enable": false,
+              "params": {
+                "repetitions": 1,
+                "volume": 50
+              }
+            },
+            "pushOutByVolume": [[1.0, 15.0]],
+            "delay": {
+              "enable": false,
+              "params": {
+                "duration": 0.0
+              }
+            }
+          },
+          "multiDispense": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 100,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 50,
+              "airGapByVolume": [
+                [1.0, 5.0],
+                [195.0, 5.0],
+                [200.0, 0.0]
+              ],
+              "blowout": {
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 716.0
+                }
+              },
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "dispensePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[1.0, 716.0]],
+            "correctionByVolume": [[0.0, 0.0]],
+            "conditioningByVolume": [
+              [1.0, 5.0],
+              [195.0, 5.0],
+              [200.0, 0.0]
+            ],
+            "disposalByVolume": [
+              [1.0, 5.0],
+              [195.0, 5.0],
+              [200.0, 0.0]
+            ],
+            "delay": {
+              "enable": false,
+              "params": {
+                "duration": 0.0
+              }
+            }
+          }
+        },
+        {
+          "tiprack": "opentrons/opentrons_flex_96_filtertiprack_200ul/1",
+          "aspirate": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 100,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 50,
+              "airGapByVolume": [
+                [1.0, 5.0],
+                [195.0, 5.0],
+                [200.0, 0.0]
+              ],
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "aspiratePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[1.0, 716.0]],
+            "correctionByVolume": [[0.0, 0.0]],
+            "preWet": false,
+            "mix": {
+              "enable": false,
+              "params": {
+                "repetitions": 1,
+                "volume": 50
+              }
+            },
+            "delay": {
+              "enable": true,
+              "params": {
+                "duration": 0.5
+              }
+            }
+          },
+          "singleDispense": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 100,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 50,
+              "airGapByVolume": [
+                [1.0, 5.0],
+                [195.0, 5.0],
+                [200.0, 0.0]
+              ],
+              "blowout": {
+                "enable": false,
+                "params": {
+                  "location": "destination",
+                  "flowRate": 716.0
+                }
+              },
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "dispensePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[1.0, 716.0]],
+            "correctionByVolume": [[0.0, 0.0]],
+            "mix": {
+              "enable": false,
+              "params": {
+                "repetitions": 1,
+                "volume": 50
+              }
+            },
+            "pushOutByVolume": [[1.0, 20.0]],
+            "delay": {
+              "enable": false,
+              "params": {
+                "duration": 0.0
+              }
+            }
+          },
+          "multiDispense": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 100,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 50,
+              "airGapByVolume": [
+                [1.0, 5.0],
+                [195.0, 5.0],
+                [200.0, 0.0]
+              ],
+              "blowout": {
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 716.0
+                }
+              },
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "dispensePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[1.0, 716.0]],
+            "correctionByVolume": [[0.0, 0.0]],
+            "conditioningByVolume": [
+              [1.0, 5.0],
+              [195.0, 5.0],
+              [200.0, 0.0]
+            ],
+            "disposalByVolume": [
+              [1.0, 5.0],
+              [195.0, 5.0],
+              [200.0, 0.0]
+            ],
+            "delay": {
+              "enable": false,
+              "params": {
+                "duration": 0.0
+              }
+            }
+          }
+        },
+        {
+          "tiprack": "opentrons/opentrons_flex_96_tiprack_1000ul/1",
+          "aspirate": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 100,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 50,
+              "airGapByVolume": [
+                [10.0, 10.0],
+                [990.0, 10.0],
+                [1000.0, 0.0]
+              ],
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "aspiratePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[1.0, 716.0]],
+            "correctionByVolume": [[0.0, 0.0]],
+            "preWet": false,
+            "mix": {
+              "enable": false,
+              "params": {
+                "repetitions": 1,
+                "volume": 50
+              }
+            },
+            "delay": {
+              "enable": true,
+              "params": {
+                "duration": 0.5
+              }
+            }
+          },
+          "singleDispense": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 100,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 50,
+              "airGapByVolume": [
+                [10.0, 10.0],
+                [990.0, 10.0],
+                [1000.0, 0.0]
+              ],
+              "blowout": {
+                "enable": false,
+                "params": {
+                  "location": "destination",
+                  "flowRate": 716.0
+                }
+              },
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "dispensePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[1.0, 716.0]],
+            "correctionByVolume": [[0.0, 0.0]],
+            "mix": {
+              "enable": false,
+              "params": {
+                "repetitions": 1,
+                "volume": 50
+              }
+            },
+            "pushOutByVolume": [[1.0, 20.0]],
+            "delay": {
+              "enable": false,
+              "params": {
+                "duration": 0.0
+              }
+            }
+          },
+          "multiDispense": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 100,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 50,
+              "airGapByVolume": [
+                [10.0, 10.0],
+                [990.0, 10.0],
+                [1000.0, 0.0]
+              ],
+              "blowout": {
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 716.0
+                }
+              },
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "dispensePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[1.0, 716.0]],
+            "correctionByVolume": [[0.0, 0.0]],
+            "conditioningByVolume": [
+              [1.0, 5.0],
+              [995.0, 5.0],
+              [1000.0, 0.0]
+            ],
+            "disposalByVolume": [
+              [1.0, 5.0],
+              [995.0, 5.0],
+              [1000.0, 0.0]
+            ],
+            "delay": {
+              "enable": false,
+              "params": {
+                "duration": 0.0
+              }
+            }
+          }
+        },
+        {
+          "tiprack": "opentrons/opentrons_flex_96_filtertiprack_1000ul/1",
+          "aspirate": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 100,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 50,
+              "airGapByVolume": [
+                [10.0, 10.0],
+                [990.0, 10.0],
+                [1000.0, 0.0]
+              ],
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "aspiratePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[1.0, 716.0]],
+            "correctionByVolume": [[0.0, 0.0]],
+            "preWet": false,
+            "mix": {
+              "enable": false,
+              "params": {
+                "repetitions": 1,
+                "volume": 50
+              }
+            },
+            "delay": {
+              "enable": true,
+              "params": {
+                "duration": 0.5
+              }
+            }
+          },
+          "singleDispense": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 100,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 50,
+              "airGapByVolume": [
+                [10.0, 10.0],
+                [990.0, 10.0],
+                [1000.0, 0.0]
+              ],
+              "blowout": {
+                "enable": false,
+                "params": {
+                  "location": "destination",
+                  "flowRate": 716.0
+                }
+              },
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "dispensePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[1.0, 716.0]],
+            "correctionByVolume": [[0.0, 0.0]],
+            "mix": {
+              "enable": false,
+              "params": {
+                "repetitions": 1,
+                "volume": 50
+              }
+            },
+            "pushOutByVolume": [[1.0, 20.0]],
+            "delay": {
+              "enable": false,
+              "params": {
+                "duration": 0.0
+              }
+            }
+          },
+          "multiDispense": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 100,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 50,
+              "airGapByVolume": [
+                [10.0, 10.0],
+                [990.0, 10.0],
+                [1000.0, 0.0]
+              ],
+              "blowout": {
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 716.0
+                }
+              },
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "dispensePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[1.0, 716.0]],
+            "correctionByVolume": [[0.0, 0.0]],
+            "conditioningByVolume": [
+              [1.0, 5.0],
+              [995.0, 5.0],
+              [1000.0, 0.0]
+            ],
+            "disposalByVolume": [
+              [1.0, 5.0],
+              [995.0, 5.0],
+              [1000.0, 0.0]
+            ],
+            "delay": {
+              "enable": false,
+              "params": {
+                "duration": 0.0
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "pipetteModel": "flex_96channel_200",
+      "byTipType": [
+        {
+          "tiprack": "opentrons/opentrons_flex_96_tiprack_50ul/1",
+          "aspirate": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "airGapByVolume": [
+                [1.0, 0.1],
+                [49.0, 0.1],
+                [50.0, 0.0]
+              ],
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "aspiratePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[1.0, 200.0]],
+            "correctionByVolume": [[0.0, 0.0]],
+            "preWet": false,
+            "mix": {
+              "enable": false,
+              "params": {
+                "repetitions": 1,
+                "volume": 50
+              }
+            },
+            "delay": {
+              "enable": true,
+              "params": {
+                "duration": 0.5
+              }
+            }
+          },
+          "singleDispense": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "airGapByVolume": [
+                [1.0, 1.0],
+                [49.0, 1.0],
+                [50.0, 0.0]
+              ],
+              "blowout": {
+                "enable": false,
+                "params": {
+                  "location": "destination",
+                  "flowRate": 200.0
+                }
+              },
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "dispensePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[1.0, 200.0]],
+            "correctionByVolume": [[0.0, 0.0]],
+            "mix": {
+              "enable": false,
+              "params": {
+                "repetitions": 1,
+                "volume": 50
+              }
+            },
+            "pushOutByVolume": [[1.0, 5.0]],
+            "delay": {
+              "enable": false,
+              "params": {
+                "duration": 0.0
+              }
+            }
+          },
+          "multiDispense": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "airGapByVolume": [
+                [1.0, 1.0],
+                [49.0, 1.0],
+                [50.0, 0.0]
+              ],
+              "blowout": {
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 200.0
+                }
+              },
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "dispensePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[1.0, 200.0]],
+            "correctionByVolume": [[0.0, 0.0]],
+            "conditioningByVolume": [
+              [1.0, 5.0],
+              [45.0, 5.0],
+              [50.0, 0.0]
+            ],
+            "disposalByVolume": [
+              [1.0, 5.0],
+              [45.0, 5.0],
+              [50.0, 0.0]
+            ],
+            "delay": {
+              "enable": false,
+              "params": {
+                "duration": 0.0
+              }
+            }
+          }
+        },
+        {
+          "tiprack": "opentrons/opentrons_flex_96_filtertiprack_50ul/1",
+          "aspirate": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "airGapByVolume": [
+                [1.0, 1.0],
+                [49.0, 1.0],
+                [50.0, 0.0]
+              ],
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "aspiratePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[1.0, 200.0]],
+            "correctionByVolume": [[0.0, 0.0]],
+            "preWet": false,
+            "mix": {
+              "enable": false,
+              "params": {
+                "repetitions": 1,
+                "volume": 50
+              }
+            },
+            "delay": {
+              "enable": true,
+              "params": {
+                "duration": 0.5
+              }
+            }
+          },
+          "singleDispense": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "airGapByVolume": [
+                [1.0, 1.0],
+                [49.0, 1.0],
+                [50.0, 0.0]
+              ],
+              "blowout": {
+                "enable": false,
+                "params": {
+                  "location": "destination",
+                  "flowRate": 200.0
+                }
+              },
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "dispensePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[1.0, 200.0]],
+            "correctionByVolume": [[0.0, 0.0]],
+            "mix": {
+              "enable": false,
+              "params": {
+                "repetitions": 1,
+                "volume": 50
+              }
+            },
+            "pushOutByVolume": [[1.0, 5.0]],
+            "delay": {
+              "enable": false,
+              "params": {
+                "duration": 0.0
+              }
+            }
+          },
+          "multiDispense": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "airGapByVolume": [
+                [1.0, 1.0],
+                [49.0, 1.0],
+                [50.0, 0.0]
+              ],
+              "blowout": {
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 200.0
+                }
+              },
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "dispensePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[1.0, 200.0]],
+            "correctionByVolume": [[0.0, 0.0]],
+            "conditioningByVolume": [
+              [1.0, 5.0],
+              [45.0, 5.0],
+              [50.0, 0.0]
+            ],
+            "disposalByVolume": [
+              [1.0, 5.0],
+              [45.0, 5.0],
+              [50.0, 0.0]
+            ],
+            "delay": {
+              "enable": false,
+              "params": {
+                "duration": 0.0
+              }
+            }
+          }
+        },
+        {
+          "tiprack": "opentrons/opentrons_flex_96_tiprack_200ul/1",
+          "aspirate": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "airGapByVolume": [
+                [1.0, 5.0],
+                [195.0, 5.0],
+                [200.0, 0.0]
+              ],
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "aspiratePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[1.0, 200.0]],
+            "correctionByVolume": [[0.0, 0.0]],
+            "preWet": false,
+            "mix": {
+              "enable": false,
+              "params": {
+                "repetitions": 1,
+                "volume": 50
+              }
+            },
+            "delay": {
+              "enable": true,
+              "params": {
+                "duration": 0.75
+              }
+            }
+          },
+          "singleDispense": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "airGapByVolume": [
+                [1.0, 5.0],
+                [195.0, 5.0],
+                [200.0, 0.0]
+              ],
+              "blowout": {
+                "enable": false,
+                "params": {
+                  "location": "destination",
+                  "flowRate": 200.0
+                }
+              },
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "dispensePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[1.0, 200.0]],
+            "correctionByVolume": [[0.0, 0.0]],
+            "mix": {
+              "enable": false,
+              "params": {
+                "repetitions": 1,
+                "volume": 50
+              }
+            },
+            "pushOutByVolume": [[1.0, 5.0]],
+            "delay": {
+              "enable": false,
+              "params": {
+                "duration": 0.0
+              }
+            }
+          },
+          "multiDispense": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "airGapByVolume": [
+                [1.0, 5.0],
+                [195.0, 5.0],
+                [200.0, 0.0]
+              ],
+              "blowout": {
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 200.0
+                }
+              },
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "dispensePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[1.0, 200.0]],
+            "correctionByVolume": [[0.0, 0.0]],
+            "conditioningByVolume": [
+              [1.0, 5.0],
+              [195.0, 5.0],
+              [200.0, 0.0]
+            ],
+            "disposalByVolume": [
+              [1.0, 5.0],
+              [195.0, 5.0],
+              [200.0, 0.0]
+            ],
+            "delay": {
+              "enable": false,
+              "params": {
+                "duration": 0.0
+              }
+            }
+          }
+        },
+        {
+          "tiprack": "opentrons/opentrons_flex_96_filtertiprack_200ul/1",
+          "aspirate": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "airGapByVolume": [
+                [1.0, 5.0],
+                [195.0, 5.0],
+                [200.0, 0.0]
+              ],
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "aspiratePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[1.0, 200.0]],
+            "correctionByVolume": [[0.0, 0.0]],
+            "preWet": false,
+            "mix": {
+              "enable": false,
+              "params": {
+                "repetitions": 1,
+                "volume": 50
+              }
+            },
+            "delay": {
+              "enable": true,
+              "params": {
+                "duration": 0.75
+              }
+            }
+          },
+          "singleDispense": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "airGapByVolume": [
+                [1.0, 5.0],
+                [195.0, 5.0],
+                [200.0, 0.0]
+              ],
+              "blowout": {
+                "enable": false,
+                "params": {
+                  "location": "destination",
+                  "flowRate": 200.0
+                }
+              },
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "dispensePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[1.0, 200.0]],
+            "correctionByVolume": [[0.0, 0.0]],
+            "mix": {
+              "enable": false,
+              "params": {
+                "repetitions": 1,
+                "volume": 50
+              }
+            },
+            "pushOutByVolume": [[1.0, 5.0]],
+            "delay": {
+              "enable": false,
+              "params": {
+                "duration": 0.0
+              }
+            }
+          },
+          "multiDispense": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "airGapByVolume": [
+                [1.0, 5.0],
+                [195.0, 5.0],
+                [200.0, 0.0]
+              ],
+              "blowout": {
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 200.0
+                }
+              },
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "dispensePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[1.0, 200.0]],
+            "correctionByVolume": [[0.0, 0.0]],
+            "conditioningByVolume": [
+              [1.0, 5.0],
+              [195.0, 5.0],
+              [200.0, 0.0]
+            ],
+            "disposalByVolume": [
+              [1.0, 5.0],
+              [195.0, 5.0],
+              [200.0, 0.0]
+            ],
+            "delay": {
+              "enable": false,
+              "params": {
+                "duration": 0.0
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "pipetteModel": "flex_96channel_1000",
+      "byTipType": [
+        {
+          "tiprack": "opentrons/opentrons_flex_96_tiprack_50ul/1",
+          "aspirate": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "airGapByVolume": [
+                [1.0, 1.0],
+                [49.0, 1.0],
+                [50.0, 0.0]
+              ],
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "aspiratePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[1.0, 200.0]],
+            "correctionByVolume": [[0.0, 0.0]],
+            "preWet": false,
+            "mix": {
+              "enable": false,
+              "params": {
+                "repetitions": 1,
+                "volume": 50
+              }
+            },
+            "delay": {
+              "enable": true,
+              "params": {
+                "duration": 0.5
+              }
+            }
+          },
+          "singleDispense": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "airGapByVolume": [
+                [1.0, 1.0],
+                [49.0, 1.0],
+                [50.0, 0.0]
+              ],
+              "blowout": {
+                "enable": false,
+                "params": {
+                  "location": "destination",
+                  "flowRate": 200.0
+                }
+              },
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "dispensePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[1.0, 200.0]],
+            "correctionByVolume": [[0.0, 0.0]],
+            "mix": {
+              "enable": false,
+              "params": {
+                "repetitions": 1,
+                "volume": 50
+              }
+            },
+            "pushOutByVolume": [[1.0, 20.0]],
+            "delay": {
+              "enable": false,
+              "params": {
+                "duration": 0.0
+              }
+            }
+          },
+          "multiDispense": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "airGapByVolume": [
+                [1.0, 1.0],
+                [49.0, 1.0],
+                [50.0, 0.0]
+              ],
+              "blowout": {
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 200.0
+                }
+              },
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "dispensePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[1.0, 200.0]],
+            "correctionByVolume": [[0.0, 0.0]],
+            "conditioningByVolume": [
+              [1.0, 5.0],
+              [45.0, 5.0],
+              [50.0, 0.0]
+            ],
+            "disposalByVolume": [
+              [1.0, 5.0],
+              [45.0, 5.0],
+              [50.0, 0.0]
+            ],
+            "delay": {
+              "enable": false,
+              "params": {
+                "duration": 0.0
+              }
+            }
+          }
+        },
+        {
+          "tiprack": "opentrons/opentrons_flex_96_filtertiprack_50ul/1",
+          "aspirate": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "airGapByVolume": [
+                [1.0, 1.0],
+                [49.0, 1.0],
+                [50.0, 0.0]
+              ],
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "aspiratePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[1.0, 200.0]],
+            "correctionByVolume": [[0.0, 0.0]],
+            "preWet": false,
+            "mix": {
+              "enable": false,
+              "params": {
+                "repetitions": 1,
+                "volume": 50
+              }
+            },
+            "delay": {
+              "enable": true,
+              "params": {
+                "duration": 0.5
+              }
+            }
+          },
+          "singleDispense": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "airGapByVolume": [
+                [1.0, 1.0],
+                [49.0, 1.0],
+                [50.0, 0.0]
+              ],
+              "blowout": {
+                "enable": false,
+                "params": {
+                  "location": "destination",
+                  "flowRate": 200.0
+                }
+              },
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "dispensePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[1.0, 200.0]],
+            "correctionByVolume": [[0.0, 0.0]],
+            "mix": {
+              "enable": false,
+              "params": {
+                "repetitions": 1,
+                "volume": 50
+              }
+            },
+            "pushOutByVolume": [[1.0, 20.0]],
+            "delay": {
+              "enable": false,
+              "params": {
+                "duration": 0.0
+              }
+            }
+          },
+          "multiDispense": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "airGapByVolume": [
+                [1.0, 1.0],
+                [49.0, 1.0],
+                [50.0, 0.0]
+              ],
+              "blowout": {
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 200.0
+                }
+              },
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "dispensePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[1.0, 200.0]],
+            "correctionByVolume": [[0.0, 0.0]],
+            "conditioningByVolume": [
+              [1.0, 5.0],
+              [45.0, 5.0],
+              [50.0, 0.0]
+            ],
+            "disposalByVolume": [
+              [1.0, 5.0],
+              [45.0, 5.0],
+              [50.0, 0.0]
+            ],
+            "delay": {
+              "enable": false,
+              "params": {
+                "duration": 0.0
+              }
+            }
+          }
+        },
+        {
+          "tiprack": "opentrons/opentrons_flex_96_tiprack_200ul/1",
+          "aspirate": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "airGapByVolume": [
+                [1.0, 5.0],
+                [195.0, 5.0],
+                [200.0, 0.0]
+              ],
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "aspiratePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[1.0, 200.0]],
+            "correctionByVolume": [[0.0, 0.0]],
+            "preWet": false,
+            "mix": {
+              "enable": false,
+              "params": {
+                "repetitions": 1,
+                "volume": 50
+              }
+            },
+            "delay": {
+              "enable": true,
+              "params": {
+                "duration": 0.75
+              }
+            }
+          },
+          "singleDispense": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "airGapByVolume": [
+                [1.0, 5.0],
+                [195.0, 5.0],
+                [200.0, 0.0]
+              ],
+              "blowout": {
+                "enable": false,
+                "params": {
+                  "location": "destination",
+                  "flowRate": 200.0
+                }
+              },
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "dispensePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[1.0, 200.0]],
+            "correctionByVolume": [[0.0, 0.0]],
+            "mix": {
+              "enable": false,
+              "params": {
+                "repetitions": 1,
+                "volume": 50
+              }
+            },
+            "pushOutByVolume": [[1.0, 15.0]],
+            "delay": {
+              "enable": false,
+              "params": {
+                "duration": 0.0
+              }
+            }
+          },
+          "multiDispense": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "airGapByVolume": [
+                [1.0, 5.0],
+                [195.0, 5.0],
+                [200.0, 0.0]
+              ],
+              "blowout": {
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 200.0
+                }
+              },
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "dispensePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[1.0, 200.0]],
+            "correctionByVolume": [[0.0, 0.0]],
+            "conditioningByVolume": [
+              [1.0, 5.0],
+              [195.0, 5.0],
+              [200.0, 0.0]
+            ],
+            "disposalByVolume": [
+              [1.0, 5.0],
+              [195.0, 5.0],
+              [200.0, 0.0]
+            ],
+            "delay": {
+              "enable": false,
+              "params": {
+                "duration": 0.0
+              }
+            }
+          }
+        },
+        {
+          "tiprack": "opentrons/opentrons_flex_96_filtertiprack_200ul/1",
+          "aspirate": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "airGapByVolume": [
+                [1.0, 5.0],
+                [195.0, 5.0],
+                [200.0, 0.0]
+              ],
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "aspiratePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[1.0, 200.0]],
+            "correctionByVolume": [[0.0, 0.0]],
+            "preWet": false,
+            "mix": {
+              "enable": false,
+              "params": {
+                "repetitions": 1,
+                "volume": 50
+              }
+            },
+            "delay": {
+              "enable": true,
+              "params": {
+                "duration": 0.75
+              }
+            }
+          },
+          "singleDispense": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "airGapByVolume": [
+                [1.0, 5.0],
+                [195.0, 5.0],
+                [200.0, 0.0]
+              ],
+              "blowout": {
+                "enable": false,
+                "params": {
+                  "location": "destination",
+                  "flowRate": 200.0
+                }
+              },
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "dispensePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[1.0, 200.0]],
+            "correctionByVolume": [[0.0, 0.0]],
+            "mix": {
+              "enable": false,
+              "params": {
+                "repetitions": 1,
+                "volume": 50
+              }
+            },
+            "pushOutByVolume": [[1.0, 15.0]],
+            "delay": {
+              "enable": false,
+              "params": {
+                "duration": 0.0
+              }
+            }
+          },
+          "multiDispense": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "airGapByVolume": [
+                [1.0, 5.0],
+                [195.0, 5.0],
+                [200.0, 0.0]
+              ],
+              "blowout": {
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 200.0
+                }
+              },
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "dispensePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[1.0, 200.0]],
+            "correctionByVolume": [[0.0, 0.0]],
+            "conditioningByVolume": [
+              [1.0, 5.0],
+              [195.0, 5.0],
+              [200.0, 0.0]
+            ],
+            "disposalByVolume": [
+              [1.0, 5.0],
+              [195.0, 5.0],
+              [200.0, 0.0]
+            ],
+            "delay": {
+              "enable": false,
+              "params": {
+                "duration": 0.0
+              }
+            }
+          }
+        },
+        {
+          "tiprack": "opentrons/opentrons_flex_96_tiprack_1000ul/1",
+          "aspirate": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "airGapByVolume": [
+                [10.0, 10.0],
+                [990.0, 10.0],
+                [1000.0, 0.0]
+              ],
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "aspiratePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[1.0, 200.0]],
+            "correctionByVolume": [[0.0, 0.0]],
+            "preWet": false,
+            "mix": {
+              "enable": false,
+              "params": {
+                "repetitions": 1,
+                "volume": 50
+              }
+            },
+            "delay": {
+              "enable": true,
+              "params": {
+                "duration": 0.5
+              }
+            }
+          },
+          "singleDispense": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "airGapByVolume": [
+                [10.0, 10.0],
+                [990.0, 10.0],
+                [1000.0, 0.0]
+              ],
+              "blowout": {
+                "enable": false,
+                "params": {
+                  "location": "destination",
+                  "flowRate": 200.0
+                }
+              },
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "dispensePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[1.0, 200.0]],
+            "correctionByVolume": [[0.0, 0.0]],
+            "mix": {
+              "enable": false,
+              "params": {
+                "repetitions": 1,
+                "volume": 50
+              }
+            },
+            "pushOutByVolume": [[1.0, 20.0]],
+            "delay": {
+              "enable": false,
+              "params": {
+                "duration": 0.0
+              }
+            }
+          },
+          "multiDispense": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "airGapByVolume": [
+                [10.0, 10.0],
+                [990.0, 10.0],
+                [1000.0, 0.0]
+              ],
+              "blowout": {
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 200.0
+                }
+              },
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "dispensePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[1.0, 200.0]],
+            "correctionByVolume": [[0.0, 0.0]],
+            "conditioningByVolume": [
+              [1.0, 5.0],
+              [995.0, 5.0],
+              [1000.0, 0.0]
+            ],
+            "disposalByVolume": [
+              [1.0, 5.0],
+              [995.0, 5.0],
+              [1000.0, 0.0]
+            ],
+            "delay": {
+              "enable": false,
+              "params": {
+                "duration": 0.0
+              }
+            }
+          }
+        },
+        {
+          "tiprack": "opentrons/opentrons_flex_96_filtertiprack_1000ul/1",
+          "aspirate": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "airGapByVolume": [
+                [10.0, 10.0],
+                [990.0, 10.0],
+                [1000.0, 0.0]
+              ],
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "aspiratePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[1.0, 200.0]],
+            "correctionByVolume": [[0.0, 0.0]],
+            "preWet": false,
+            "mix": {
+              "enable": false,
+              "params": {
+                "repetitions": 1,
+                "volume": 50
+              }
+            },
+            "delay": {
+              "enable": true,
+              "params": {
+                "duration": 0.5
+              }
+            }
+          },
+          "singleDispense": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "airGapByVolume": [
+                [10.0, 10.0],
+                [990.0, 10.0],
+                [1000.0, 0.0]
+              ],
+              "blowout": {
+                "enable": false,
+                "params": {
+                  "location": "destination",
+                  "flowRate": 200.0
+                }
+              },
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "dispensePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[1.0, 200.0]],
+            "correctionByVolume": [[0.0, 0.0]],
+            "mix": {
+              "enable": false,
+              "params": {
+                "repetitions": 1,
+                "volume": 50
+              }
+            },
+            "pushOutByVolume": [[1.0, 20.0]],
+            "delay": {
+              "enable": false,
+              "params": {
+                "duration": 0.0
+              }
+            }
+          },
+          "multiDispense": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "airGapByVolume": [
+                [10.0, 10.0],
+                [990.0, 10.0],
+                [1000.0, 0.0]
+              ],
+              "blowout": {
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 200.0
+                }
+              },
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "dispensePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[1.0, 200.0]],
+            "correctionByVolume": [[0.0, 0.0]],
+            "conditioningByVolume": [
+              [1.0, 5.0],
+              [995.0, 5.0],
+              [1000.0, 0.0]
+            ],
+            "disposalByVolume": [
+              [1.0, 5.0],
+              [995.0, 5.0],
+              [1000.0, 0.0]
+            ],
+            "delay": {
+              "enable": false,
+              "params": {
+                "duration": 0.0
+              }
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/shared-data/liquid-class/definitions/1/water/2.json
+++ b/shared-data/liquid-class/definitions/1/water/2.json
@@ -3,7 +3,7 @@
   "displayName": "Aqueous",
   "description": "Deionized water",
   "schemaVersion": 1,
-  "version": 1,
+  "version": 2,
   "namespace": "opentrons",
   "byPipette": [
     {


### PR DESCRIPTION
# Overview

Now that we have versioning support in `get_liquid_class()` (PR #19408), this PR takes the updated liquid class values for `water` (PR #19141) and makes them available as version 2 of the `water` class. AUTH-2246

This PR also makes the preliminary values for the low-volume 96 `flex_96channel_200` pipette available in `water` v2, so that they can be used by hardware testing. If we decide that we don't want to release `flex_96channel_200` in the public RS 8.6.1 release, we'll delete the `flex_96channel_200` values again.

And this fixes the `test_gravimetric_protocol.py` test to stop failing. It's been failing since PR #19306 when we deleted the `flex_96channel_200` liquid class values from RS 8.6.0.

## Test Plan and Hands on Testing

Ran the updated `test_gravimetric_protocol.py` and confirmed that it passes.

Confirmed that `test_protocol_core.py` still passes.

## Risk assessment

Low. But remember to remove the `flex_96channel_200` values from `water` v2 if we don't want to release them.