### PR TITLE
Merge back 'hold-for-8.6.1' into 'edge'

### DIFF
--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -640,6 +640,9 @@ class Labware:
         lid: Optional[str] = None,
         namespace: Optional[str] = None,
         version: Optional[int] = None,
+        *,
+        lid_namespace: Optional[str] = None,
+        lid_version: Optional[int] = None,
     ) -> Labware:
         """Load a compatible labware onto the labware using its load parameters.
 
@@ -650,6 +653,24 @@ class Labware:
 
         :returns: The initialized and loaded labware object.
         """
+        if self._api_version < validation.NAMESPACE_VERSION_ADAPTER_LID_VERSION_GATE:
+            if lid_namespace is not None:
+                raise APIVersionError(
+                    api_element="The `lid_namespace` parameter",
+                    until_version=str(
+                        validation.NAMESPACE_VERSION_ADAPTER_LID_VERSION_GATE
+                    ),
+                    current_version=str(self._api_version),
+                )
+            if lid_version is not None:
+                raise APIVersionError(
+                    api_element="The `lid_version` parameter",
+                    until_version=str(
+                        validation.NAMESPACE_VERSION_ADAPTER_LID_VERSION_GATE
+                    ),
+                    current_version=str(self._api_version),
+                )
+
         labware_core = self._protocol_core.load_labware(
             load_name=name,
             label=label,
@@ -674,11 +695,24 @@ class Labware:
                     until_version="2.23",
                     current_version=f"{self._api_version}",
                 )
+            if (
+                self._api_version
+                < validation.NAMESPACE_VERSION_ADAPTER_LID_VERSION_GATE
+            ):
+                checked_lid_namespace = namespace
+                checked_lid_version = version
+            else:
+                # This is currently impossible to reach because of the
+                # `if self._api_version < validation.validation.LID_STACK_VERSION_GATE`
+                # check above. This is here for now in case that check is removed in
+                # the future, and for symmetry with the other labware load methods.
+                checked_lid_namespace = lid_namespace
+                checked_lid_version = lid_version
             self._protocol_core.load_lid(
                 load_name=lid,
                 location=labware_core,
-                namespace=namespace,
-                version=version,
+                namespace=checked_lid_namespace,
+                version=checked_lid_version,
             )
 
         return labware

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -123,7 +123,7 @@ class ModuleContext(CommandPublisher):
 
         return core.geometry.add_labware(labware)
 
-    def load_labware(
+    def load_labware(  # noqa: C901
         self,
         name: str,
         label: Optional[str] = None,
@@ -131,6 +131,11 @@ class ModuleContext(CommandPublisher):
         version: Optional[int] = None,
         adapter: Optional[str] = None,
         lid: Optional[str] = None,
+        *,
+        adapter_namespace: Optional[str] = None,
+        adapter_version: Optional[int] = None,
+        lid_namespace: Optional[str] = None,
+        lid_version: Optional[int] = None,
     ) -> Labware:
         """Load a labware onto the module using its load parameters.
 
@@ -142,7 +147,11 @@ class ModuleContext(CommandPublisher):
         :returns: The initialized and loaded labware object.
 
         .. versionadded:: 2.1
-            The *label,* *namespace,* and *version* parameters.
+            The ``label``, ``namespace``, and ``version`` parameters.
+
+        .. versionadded:: 2.26
+            The ``adapter_namespace``, ``adapter_version``,
+            ``lid_namespace``, and ``lid_version`` parameters.
         """
         if self._api_version < APIVersion(2, 1) and (
             label is not None or namespace is not None or version != 1
@@ -152,6 +161,40 @@ class ModuleContext(CommandPublisher):
                 "are trying to utilize new load_labware parameters in 2.1"
             )
 
+        if self._api_version < validation.NAMESPACE_VERSION_ADAPTER_LID_VERSION_GATE:
+            if adapter_namespace is not None:
+                raise APIVersionError(
+                    api_element="The `adapter_namespace` parameter",
+                    until_version=str(
+                        validation.NAMESPACE_VERSION_ADAPTER_LID_VERSION_GATE
+                    ),
+                    current_version=str(self._api_version),
+                )
+            if adapter_version is not None:
+                raise APIVersionError(
+                    api_element="The `adapter_version` parameter",
+                    until_version=str(
+                        validation.NAMESPACE_VERSION_ADAPTER_LID_VERSION_GATE
+                    ),
+                    current_version=str(self._api_version),
+                )
+            if lid_namespace is not None:
+                raise APIVersionError(
+                    api_element="The `lid_namespace` parameter",
+                    until_version=str(
+                        validation.NAMESPACE_VERSION_ADAPTER_LID_VERSION_GATE
+                    ),
+                    current_version=str(self._api_version),
+                )
+            if lid_version is not None:
+                raise APIVersionError(
+                    api_element="The `lid_version` parameter",
+                    until_version=str(
+                        validation.NAMESPACE_VERSION_ADAPTER_LID_VERSION_GATE
+                    ),
+                    current_version=str(self._api_version),
+                )
+
         load_location: Union[ModuleCore, LabwareCore]
         if adapter is not None:
             if self._api_version < APIVersion(2, 15):
@@ -160,9 +203,21 @@ class ModuleContext(CommandPublisher):
                     until_version="2.15",
                     current_version=f"{self._api_version}",
                 )
+
+            if (
+                self._api_version
+                < validation.NAMESPACE_VERSION_ADAPTER_LID_VERSION_GATE
+            ):
+                checked_adapter_namespace = namespace
+                checked_adapter_version = None
+            else:
+                checked_adapter_namespace = adapter_namespace
+                checked_adapter_version = adapter_version
+
             loaded_adapter = self.load_adapter(
                 name=adapter,
-                namespace=namespace,
+                namespace=checked_adapter_namespace,
+                version=checked_adapter_version,
             )
             load_location = loaded_adapter._core
         else:
@@ -193,11 +248,22 @@ class ModuleContext(CommandPublisher):
                     until_version="2.23",
                     current_version=f"{self._api_version}",
                 )
+
+            if (
+                self._api_version
+                < validation.NAMESPACE_VERSION_ADAPTER_LID_VERSION_GATE
+            ):
+                checked_lid_namespace = namespace
+                checked_lid_version = None
+            else:
+                checked_lid_namespace = lid_namespace
+                checked_lid_version = lid_version
+
             self._protocol_core.load_lid(
                 load_name=lid,
                 location=labware_core,
-                namespace=namespace,
-                version=version,
+                namespace=checked_lid_namespace,
+                version=checked_lid_version,
             )
 
         if isinstance(self._core, LegacyModuleCore):
@@ -1327,6 +1393,11 @@ class FlexStackerContext(ModuleContext):
         lid: str | None = None,
         count: int | None = None,
         stacking_offset_z: float | None = None,
+        *,
+        adapter_namespace: str | None = None,
+        adapter_version: int | None = None,
+        lid_namespace: str | None = None,
+        lid_version: int | None = None,
     ) -> None:
         """Configure the type and starting quantity of labware the Flex Stacker will store during a protocol. This is the only type of labware you'll be able to store in the Stacker until it's reconfigured.
 
@@ -1335,6 +1406,7 @@ class FlexStackerContext(ModuleContext):
         :param str load_name: A string to use for looking up a labware definition.
             You can find the ``load_name`` for any Opentrons-verified labware on the
             `Labware Library <https://labware.opentrons.com>`__.
+
         :param str namespace: The namespace that the labware definition belongs to.
             If unspecified, the API will automatically search two namespaces:
 
@@ -1345,19 +1417,34 @@ class FlexStackerContext(ModuleContext):
             You might need to specify an explicit ``namespace`` if you have a custom
             definition whose ``load_name`` is the same as an Opentrons-verified
             definition, and you want to explicitly choose one or the other.
+
         :param version: The version of the labware definition. You should normally
             leave this unspecified to let the method choose a version
             automatically.
+
         :param adapter: An adapter to load the labware on top of. Accepts the same
-            values as the ``load_name`` parameter of :py:meth:`.load_adapter`. The
-            adapter will use the same namespace as the labware, and the API will
-            choose the adapter's version automatically.
+            values as the ``load_name`` parameter of :py:meth:`.load_adapter`.
+
+        :param adapter_namespace: Applies to ``adapter`` the same way that ``namespace``
+            applies to ``load_name``.
+
+        :param adapter_version: Applies to ``adapter`` the same way that ``version``
+            applies to ``load_name``.
+
         :param lid: A lid to load the on top of the main labware. Accepts the same
             values as the ``load_name`` parameter of :py:meth:`~.ProtocolContext.load_lid_stack`. The
             lid will use the same namespace as the labware, and the API will
             choose the lid's version automatically.
+
+        :param lid_namespace: Applies to ``lid`` the same way that ``namespace``
+            applies to ``load_name``.
+
+        :param lid_version: Applies to ``lid`` the same way that ``version``
+            applies to ``load_name``.
+
         :param count: The number of labware that the Flex Stacker should store. If not specified, this will be the maximum amount of this kind of
             labware that the Flex Stacker is capable of storing.
+
         :param stacking_offset_z: Stacking ``z`` offset in mm of stored labware. If specified, this overrides the
             calculated value in the labware definition.
 
@@ -1375,18 +1462,18 @@ class FlexStackerContext(ModuleContext):
               - Labware on adapter: the adapter (bottom side) of the upper labware unit overlaps with the top side of the labware below.
               - Labware with lid: the labware (bottom side) of the upper labware unit overlaps with the lid (top side) of the unit below.
               - Labware with lid and adapter: the adapter (bottom side) of the upper labware unit overlaps with the lid (top side) of the unit below.
-
         """
+
         self._core.set_stored_labware(
             main_load_name=load_name,
             main_namespace=namespace,
             main_version=version,
             lid_load_name=lid,
-            lid_namespace=namespace,
-            lid_version=version,
+            lid_namespace=lid_namespace,
+            lid_version=lid_version,
             adapter_load_name=adapter,
-            adapter_namespace=namespace,
-            adapter_version=version,
+            adapter_namespace=adapter_namespace,
+            adapter_version=adapter_version,
             count=count,
             stacking_offset_z=stacking_offset_z,
         )

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -405,7 +405,7 @@ class ProtocolContext(CommandPublisher):
         )
 
     @requires_version(2, 0)
-    def load_labware(
+    def load_labware(  # noqa: C901
         self,
         load_name: str,
         location: Union[DeckLocation, OffDeckType],
@@ -414,6 +414,11 @@ class ProtocolContext(CommandPublisher):
         version: Optional[int] = None,
         adapter: Optional[str] = None,
         lid: Optional[str] = None,
+        *,
+        adapter_namespace: Optional[str] = None,
+        adapter_version: Optional[int] = None,
+        lid_namespace: Optional[str] = None,
+        lid_version: Optional[int] = None,
     ) -> Labware:
         """Load a labware onto a location.
 
@@ -454,18 +459,52 @@ class ProtocolContext(CommandPublisher):
         :param version: The version of the labware definition. You should normally
             leave this unspecified to let ``load_labware()`` choose a version
             automatically.
-        :param adapter: An adapter to load the labware on top of. Accepts the same
-            values as the ``load_name`` parameter of :py:meth:`.load_adapter`. The
-            adapter will use the same namespace as the labware, and the API will
-            choose the adapter's version automatically.
 
-                        .. versionadded:: 2.15
+        :param adapter: The load name of an adapter to load the labware on top of. Accepts
+            the same values as the ``load_name`` parameter of :py:meth:`.load_adapter`.
+
+            .. versionadded:: 2.15
+
+        :param adapter_namespace: The namespace of the adapter being loaded.
+            Applies to ``adapter`` the same way that ``namespace`` applies to ``load_name``.
+
+            .. versionchanged:: 2.26
+               ``adapter_namespace`` may now be specified explicitly.
+               Also, when you've specified ``namespace`` but not ``adapter_namespace``,
+               ``adapter_namespace`` will now independently follow the same search rules
+               described in ``namespace``. Formerly, it took ``namespace``'s exact value.
+
+        :param adapter_version: The version of the adapter being loaded.
+            Applies to ``adapter`` the same way that ``version`` applies to ``load_name``.
+
+            .. versionchanged:: 2.26
+               ``adapter_version`` may now be specified explicitly. Also, when it's unspecified,
+               the algorithm to select a version automatically has improved to avoid
+               selecting versions that do not exist.
+
         :param lid: A lid to load on the top of the main labware. Accepts the same
             values as the ``load_name`` parameter of :py:meth:`.load_lid_stack`. The
             lid will use the same namespace as the labware, and the API will
             choose the lid's version automatically.
 
-                        .. versionadded:: 2.23
+            .. versionadded:: 2.23
+
+        :param lid_namespace: The namespace of the lid being loaded.
+            Applies to ``lid`` the same way that ``namespace`` applies to ``load_name``.
+
+            .. versionchanged:: 2.26
+               ``lid_namespace`` may now be specified explicitly.
+               Also, when you've specified ``namespace`` but not ``lid_namespace``,
+               ``lid_namespace`` will now independently follow the same search rules
+               described in ``namespace``. Formerly, it took ``namespace``'s exact value.
+
+        :param lid_version: The version of the adapter being loaded.
+            Applies to ``lid`` the same way that ``version`` applies to ``load_name``.
+
+            .. versionchanged:: 2.26
+               ``lid_version`` may now be specified explicitly. Also, when it's unspecified,
+               the algorithm to select a version automatically has improved to avoid
+               selecting versions that do not exist.
         """
 
         if isinstance(location, OffDeckType) and self._api_version < APIVersion(2, 15):
@@ -474,6 +513,40 @@ class ProtocolContext(CommandPublisher):
                 until_version="2.15",
                 current_version=f"{self._api_version}",
             )
+
+        if self._api_version < validation.NAMESPACE_VERSION_ADAPTER_LID_VERSION_GATE:
+            if adapter_namespace is not None:
+                raise APIVersionError(
+                    api_element="The `adapter_namespace` parameter",
+                    until_version=str(
+                        validation.NAMESPACE_VERSION_ADAPTER_LID_VERSION_GATE
+                    ),
+                    current_version=str(self._api_version),
+                )
+            if adapter_version is not None:
+                raise APIVersionError(
+                    api_element="The `adapter_version` parameter",
+                    until_version=str(
+                        validation.NAMESPACE_VERSION_ADAPTER_LID_VERSION_GATE
+                    ),
+                    current_version=str(self._api_version),
+                )
+            if lid_namespace is not None:
+                raise APIVersionError(
+                    api_element="The `lid_namespace` parameter",
+                    until_version=str(
+                        validation.NAMESPACE_VERSION_ADAPTER_LID_VERSION_GATE
+                    ),
+                    current_version=str(self._api_version),
+                )
+            if lid_version is not None:
+                raise APIVersionError(
+                    api_element="The `lid_version` parameter",
+                    until_version=str(
+                        validation.NAMESPACE_VERSION_ADAPTER_LID_VERSION_GATE
+                    ),
+                    current_version=str(self._api_version),
+                )
 
         load_name = validation.ensure_lowercase_name(load_name)
         load_location: Union[OffDeckType, DeckSlotName, StagingSlotName, LabwareCore]
@@ -484,10 +557,22 @@ class ProtocolContext(CommandPublisher):
                     until_version="2.15",
                     current_version=f"{self._api_version}",
                 )
+
+            if (
+                self._api_version
+                < validation.NAMESPACE_VERSION_ADAPTER_LID_VERSION_GATE
+            ):
+                checked_adapter_namespace = namespace
+                checked_adapter_version = None
+            else:
+                checked_adapter_namespace = adapter_namespace
+                checked_adapter_version = adapter_version
+
             loaded_adapter = self.load_adapter(
                 load_name=adapter,
                 location=location,
-                namespace=namespace,
+                namespace=checked_adapter_namespace,
+                version=checked_adapter_version,
             )
             load_location = loaded_adapter._core
         elif isinstance(location, OffDeckType):
@@ -512,11 +597,22 @@ class ProtocolContext(CommandPublisher):
                     until_version=f"{validation.LID_STACK_VERSION_GATE}",
                     current_version=f"{self._api_version}",
                 )
+
+            if (
+                self._api_version
+                < validation.NAMESPACE_VERSION_ADAPTER_LID_VERSION_GATE
+            ):
+                checked_lid_namespace = namespace
+                checked_lid_version = version
+            else:
+                checked_lid_namespace = lid_namespace
+                checked_lid_version = lid_version
+
             self._core.load_lid(
                 load_name=lid,
                 location=labware_core,
-                namespace=namespace,
-                version=version,
+                namespace=checked_lid_namespace,
+                version=checked_lid_version,
             )
 
         labware = Labware(
@@ -1464,6 +1560,9 @@ class ProtocolContext(CommandPublisher):
         adapter: Optional[str] = None,
         namespace: Optional[str] = None,
         version: Optional[int] = None,
+        *,
+        adapter_namespace: Optional[str] = None,
+        adapter_version: Optional[int] = None,
     ) -> Labware:
         """
         Load a stack of Opentrons Tough Auto-Sealing Lids onto a valid deck location or adapter.
@@ -1471,13 +1570,17 @@ class ProtocolContext(CommandPublisher):
         :param str load_name: A string to use for looking up a lid definition.
             You can find the ``load_name`` for any compatible lid on the Opentrons
             `Labware Library <https://labware.opentrons.com>`_.
+
         :param location: Either a :ref:`deck slot <deck-slots>`,
             like ``1``, ``"1"``, or ``"D1"``, or a valid Opentrons Adapter.
+
         :param int quantity: The quantity of lids to be loaded in the stack.
+
         :param adapter: An adapter to load the lid stack on top of. Accepts the same
             values as the ``load_name`` parameter of :py:meth:`.load_adapter`. The
             adapter will use the same namespace as the lid labware, and the API will
             choose the adapter's version automatically.
+
         :param str namespace: The namespace that the lid labware definition belongs to.
             If unspecified, the API will automatically search two namespaces:
 
@@ -1493,6 +1596,21 @@ class ProtocolContext(CommandPublisher):
             leave this unspecified to let ``load_lid_stack()`` choose a version
             automatically.
 
+        :param adapter_namespace: The namespace of the adapter being loaded.
+            Applies to ``adapter`` the same way that ``namespace`` applies to ``load_name``.
+
+            .. versionchanged:: 2.26
+               ``adapter_namespace`` may now be specified explicitly.
+               Also, when you've specified ``namespace`` but not ``adapter_namespace``,
+               ``adapter_namespace`` will now independently follow the same search rules
+               described in ``namespace``. Formerly, it took ``namespace``'s exact value.
+
+        :param adapter_version: The version of the adapter being loaded.
+            Applies to ``adapter`` the same way that ``version`` applies to ``load_name``.
+
+            .. versionadded:: 2.26
+               ``adapter_version`` may now be specified explicitly.
+
         :return:  The initialized and loaded labware object representing the lid stack.
 
         .. versionadded:: 2.23
@@ -1504,6 +1622,24 @@ class ProtocolContext(CommandPublisher):
                 until_version=f"{validation.LID_STACK_VERSION_GATE}",
                 current_version=f"{self._api_version}",
             )
+
+        if self._api_version < validation.NAMESPACE_VERSION_ADAPTER_LID_VERSION_GATE:
+            if adapter_namespace is not None:
+                raise APIVersionError(
+                    api_element="The `adapter_namespace` parameter",
+                    until_version=str(
+                        validation.NAMESPACE_VERSION_ADAPTER_LID_VERSION_GATE
+                    ),
+                    current_version=str(self._api_version),
+                )
+            if adapter_version is not None:
+                raise APIVersionError(
+                    api_element="The `adapter_version` parameter",
+                    until_version=str(
+                        validation.NAMESPACE_VERSION_ADAPTER_LID_VERSION_GATE
+                    ),
+                    current_version=str(self._api_version),
+                )
 
         load_location: Union[DeckSlotName, StagingSlotName, LabwareCore]
         if isinstance(location, Labware):
@@ -1517,10 +1653,21 @@ class ProtocolContext(CommandPublisher):
             if isinstance(load_location, DeckSlotName) or isinstance(
                 load_location, StagingSlotName
             ):
+                if (
+                    self._api_version
+                    < validation.NAMESPACE_VERSION_ADAPTER_LID_VERSION_GATE
+                ):
+                    checked_adapter_namespace = namespace
+                    checked_adapter_version = None
+                else:
+                    checked_adapter_namespace = adapter_namespace
+                    checked_adapter_version = adapter_version
+
                 loaded_adapter = self.load_adapter(
                     load_name=adapter,
                     location=load_location.value,
-                    namespace=namespace,
+                    namespace=checked_adapter_namespace,
+                    version=checked_adapter_version,
                 )
                 load_location = loaded_adapter._core
             else:

--- a/api/src/opentrons/protocol_api/validation.py
+++ b/api/src/opentrons/protocol_api/validation.py
@@ -62,6 +62,10 @@ LID_STACK_VERSION_GATE = APIVersion(2, 23)
 # The first APIVersion where Python protocols can use the Flex Stacker module.
 FLEX_STACKER_VERSION_GATE = APIVersion(2, 23)
 
+# The first APIVersion where various "multi labware load" methods allow you to specify
+# the namespace and version of adapters and lids separately from the main labware.
+NAMESPACE_VERSION_ADAPTER_LID_VERSION_GATE = APIVersion(2, 26)
+
 
 class InvalidPipetteMountError(ValueError):
     """An error raised when attempting to load pipettes on an invalid mount."""

--- a/api/src/opentrons/protocols/api_support/definitions.py
+++ b/api/src/opentrons/protocols/api_support/definitions.py
@@ -1,6 +1,6 @@
 from .types import APIVersion
 
-MAX_SUPPORTED_VERSION = APIVersion(2, 25)
+MAX_SUPPORTED_VERSION = APIVersion(2, 26)
 """The maximum supported protocol API version in this release."""
 
 MIN_SUPPORTED_VERSION = APIVersion(2, 0)

--- a/api/tests/opentrons/protocol_api/core/engine/test_load_labware_params.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_load_labware_params.py
@@ -8,10 +8,7 @@ from opentrons.protocol_engine.state.labware import LabwareLoadParams
 from opentrons.protocols.api_support.constants import OPENTRONS_NAMESPACE
 from opentrons.protocols.api_support.types import APIVersion
 
-from tests.opentrons.protocol_api import (
-    versions_at_or_above,
-    versions_between,
-)
+from tests.opentrons.protocol_api import versions_between
 
 
 @pytest.mark.parametrize(
@@ -95,7 +92,13 @@ def test_resolve_load_labware_params(
                 high_inclusive_bound=APIVersion(2, 22),
             )
         ],
-        *[(api_version, 4) for api_version in versions_at_or_above(APIVersion(2, 25))],
+        *[
+            (api_version, 4)
+            for api_version in versions_between(
+                low_inclusive_bound=APIVersion(2, 25),
+                high_exclusive_bound=(APIVersion(2, 26)),
+            )
+        ],
     ],
 )
 def test_default_labware_version_dependent_on_api_version(

--- a/api/tests/opentrons/protocol_api/test_flex_stacker_context.py
+++ b/api/tests/opentrons/protocol_api/test_flex_stacker_context.py
@@ -120,11 +120,38 @@ def test_set_stored_labware(
             main_namespace="namespace",
             main_version=1,
             lid_load_name="lid",
-            lid_namespace="namespace",
-            lid_version=1,
+            lid_namespace=None,
+            lid_version=None,
             adapter_load_name="adapter",
-            adapter_namespace="namespace",
-            adapter_version=1,
+            adapter_namespace=None,
+            adapter_version=None,
+            count=2,
+            stacking_offset_z=1.0,
+        )
+    )
+
+    subject.set_stored_labware(
+        "load_name",
+        "namespace",
+        1,
+        "adapter",
+        "lid",
+        2,
+        stacking_offset_z=1.0,
+        adapter_namespace="adapter_namespace",
+        adapter_version=3,
+    )
+    decoy.verify(
+        mock_core.set_stored_labware(
+            main_load_name="load_name",
+            main_namespace="namespace",
+            main_version=1,
+            lid_load_name="lid",
+            lid_namespace=None,
+            lid_version=None,
+            adapter_load_name="adapter",
+            adapter_namespace="adapter_namespace",
+            adapter_version=3,
             count=2,
             stacking_offset_z=1.0,
         )

--- a/api/tests/opentrons/protocol_api/test_module_context.py
+++ b/api/tests/opentrons/protocol_api/test_module_context.py
@@ -294,7 +294,7 @@ def test_load_labware_with_adapter(
     decoy.when(
         mock_protocol_core.load_adapter(
             load_name="adaptation",
-            namespace="ideal",
+            namespace=None,
             version=None,
             location=mock_core,
         )

--- a/api/tests/opentrons/protocol_api/test_protocol_context.py
+++ b/api/tests/opentrons/protocol_api/test_protocol_context.py
@@ -2,6 +2,7 @@
 
 import inspect
 from typing import cast, Dict
+from unittest.mock import sentinel
 
 import pytest
 from decoy import Decoy, matchers
@@ -62,6 +63,10 @@ from opentrons.protocols.api_support.deck_type import (
 )
 from opentrons.protocol_engine.errors import LabwareMovementNotAllowedError
 from opentrons.protocol_engine.clients import SyncClient as EngineClient
+from tests.opentrons.protocol_api import (
+    versions_at_or_above,
+    versions_between,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -743,10 +748,80 @@ def test_load_adapter_on_staging_slot(
     decoy.verify(mock_core_map.add(mock_labware_core, result), times=1)
 
 
+@pytest.mark.parametrize("api_version", [APIVersion(2, 25)])
+def test_load_labware_lid_adapter_namespace_version_requires_new_api_version(
+    subject: ProtocolContext,
+) -> None:
+    """Make sure parameters new to apiLevel 2.26 raise, if given in older apiLevels."""
+    with pytest.raises(APIVersionError, match="adapter_namespace"):
+        subject.load_labware("load_name", "A1", adapter_namespace="foo")
+
+    with pytest.raises(APIVersionError, match="adapter_version"):
+        subject.load_labware("load_name", "A1", adapter_version=123)
+
+    with pytest.raises(APIVersionError, match="lid_namespace"):
+        subject.load_labware("load_name", "A1", lid_namespace="foo")
+
+    with pytest.raises(APIVersionError, match="lid_version"):
+        subject.load_labware("load_name", "A1", lid_version=123)
+
+
+@pytest.mark.parametrize(
+    (
+        "api_version",
+        "input_adapter_namespace",
+        "input_adapter_version",
+        "expected_adapter_namespace",
+        "expected_adapter_version",
+    ),
+    [
+        *[
+            # Old APIVersion: Adapter namespace and version cannot be specified explicitly.
+            # Adapter namespace always follows main labware, and adapter version is always None.
+            (
+                v,
+                None,
+                None,
+                sentinel.input_namespace,
+                None,
+            )
+            for v in versions_between(
+                low_inclusive_bound=APIVersion(2, 15),
+                high_exclusive_bound=APIVersion(2, 26),
+            )
+        ],
+        *[
+            # New APIVersion: Adapter namespace and version are used as-is if specified explicitly.
+            (
+                v,
+                sentinel.input_adapter_namespace,
+                sentinel.input_adapter_version,
+                sentinel.input_adapter_namespace,
+                sentinel.input_adapter_version,
+            )
+            for v in versions_at_or_above(APIVersion(2, 26))
+        ],
+        *[
+            # New APIVersion: Adapter namespace and version default to None if not provided.
+            (
+                v,
+                None,
+                None,
+                None,
+                None,
+            )
+            for v in versions_at_or_above(APIVersion(2, 26))
+        ],
+    ],
+)
 def test_load_labware_on_adapter(
     decoy: Decoy,
     mock_core: ProtocolCore,
     mock_core_map: LoadedCoreMap,
+    input_adapter_namespace: str | None,
+    input_adapter_version: int | None,
+    expected_adapter_namespace: str | None,
+    expected_adapter_version: int | None,
     api_version: APIVersion,
     subject: ProtocolContext,
 ) -> None:
@@ -754,23 +829,25 @@ def test_load_labware_on_adapter(
     mock_labware_core = decoy.mock(cls=LabwareCore)
     mock_adapter_core = decoy.mock(cls=LabwareCore)
 
-    decoy.when(mock_validation.ensure_lowercase_name("UPPERCASE_LABWARE")).then_return(
-        "lowercase_labware"
-    )
+    decoy.when(
+        mock_validation.ensure_lowercase_name(sentinel.input_load_name)
+    ).then_return(sentinel.lowercase_input_load_name)
 
-    decoy.when(mock_validation.ensure_lowercase_name("UPPERCASE_ADAPTER")).then_return(
-        "lowercase_adapter"
-    )
+    decoy.when(
+        mock_validation.ensure_lowercase_name(sentinel.input_adapter)
+    ).then_return(sentinel.lowercase_input_adapter)
     decoy.when(mock_core.robot_type).then_return("OT-3 Standard")
     decoy.when(
-        mock_validation.ensure_and_convert_deck_slot(42, api_version, "OT-3 Standard")
-    ).then_return(DeckSlotName.SLOT_5)
+        mock_validation.ensure_and_convert_deck_slot(
+            sentinel.input_location, api_version, "OT-3 Standard"
+        )
+    ).then_return(sentinel.validated_location)
     decoy.when(
         mock_core.load_adapter(
-            load_name="lowercase_adapter",
-            location=DeckSlotName.SLOT_5,
-            namespace="some_namespace",
-            version=None,
+            load_name=sentinel.lowercase_input_adapter,
+            location=sentinel.validated_location,
+            namespace=expected_adapter_namespace,
+            version=expected_adapter_version,
         )
     ).then_return(mock_adapter_core)
 
@@ -778,11 +855,11 @@ def test_load_labware_on_adapter(
 
     decoy.when(
         mock_core.load_labware(
-            load_name="lowercase_labware",
+            load_name=sentinel.lowercase_input_load_name,
             location=mock_adapter_core,
-            label="some_display_name",
-            namespace="some_namespace",
-            version=1337,
+            label="input_label",
+            namespace=sentinel.input_namespace,
+            version=sentinel.input_version,
         )
     ).then_return(mock_labware_core)
 
@@ -791,12 +868,14 @@ def test_load_labware_on_adapter(
     decoy.when(mock_labware_core.get_well_columns()).then_return([])
 
     result = subject.load_labware(
-        load_name="UPPERCASE_LABWARE",
-        location=42,
-        label="some_display_name",
-        namespace="some_namespace",
-        version=1337,
-        adapter="UPPERCASE_ADAPTER",
+        load_name=sentinel.input_load_name,
+        location=sentinel.input_location,
+        label="input_label",
+        namespace=sentinel.input_namespace,
+        version=sentinel.input_version,
+        adapter=sentinel.input_adapter,
+        adapter_namespace=input_adapter_namespace,
+        adapter_version=input_adapter_version,
     )
 
     assert isinstance(result, Labware)
@@ -805,69 +884,117 @@ def test_load_labware_on_adapter(
     decoy.verify(mock_core_map.add(mock_labware_core, result), times=1)
 
 
-@pytest.mark.parametrize("api_version", [APIVersion(2, 23)])
+@pytest.mark.parametrize(
+    (
+        "api_version",
+        "input_lid_namespace",
+        "input_lid_version",
+        "expected_lid_namespace",
+        "expected_lid_version",
+    ),
+    [
+        *[
+            # Old APIVersion: Lid namespace and version cannot be specified explicitly.
+            # Lid namespace and version always follow main labware.
+            (
+                v,
+                None,
+                None,
+                sentinel.input_namespace,
+                sentinel.input_version,
+            )
+            for v in versions_between(
+                low_inclusive_bound=APIVersion(2, 23),
+                high_exclusive_bound=APIVersion(2, 26),
+            )
+        ],
+        *[
+            # New APIVersion: Lid namespace and version are used as-is if specified explicitly.
+            (
+                v,
+                sentinel.input_lid_namespace,
+                sentinel.input_lid_version,
+                sentinel.input_lid_namespace,
+                sentinel.input_lid_version,
+            )
+            for v in versions_at_or_above(APIVersion(2, 26))
+        ],
+        *[
+            # New APIVersion: Lid namespace and version default to None if not provided.
+            (
+                v,
+                None,
+                None,
+                None,
+                None,
+            )
+            for v in versions_at_or_above(APIVersion(2, 26))
+        ],
+    ],
+)
 def test_load_labware_with_lid(
     decoy: Decoy,
     mock_core: ProtocolCore,
     mock_core_map: LoadedCoreMap,
+    input_lid_namespace: str | None,
+    input_lid_version: int | None,
+    expected_lid_namespace: str | None,
+    expected_lid_version: int | None,
     api_version: APIVersion,
     subject: ProtocolContext,
 ) -> None:
     """It should create a labware with a lid on it using its execution core."""
     mock_labware_core = decoy.mock(cls=LabwareCore)
-    mock_lid_core = decoy.mock(cls=LabwareCore)
 
-    decoy.when(mock_validation.ensure_lowercase_name("UPPERCASE_LABWARE")).then_return(
-        "lowercase_labware"
-    )
+    decoy.when(
+        mock_validation.ensure_lowercase_name(sentinel.input_load_name)
+    ).then_return(sentinel.lowercase_input_load_name)
 
-    decoy.when(mock_validation.ensure_lowercase_name("UPPERCASE_LID")).then_return(
-        "lowercase_lid"
-    )
     decoy.when(mock_core.robot_type).then_return("OT-3 Standard")
     decoy.when(
-        mock_validation.ensure_and_convert_deck_slot(42, api_version, "OT-3 Standard")
-    ).then_return(DeckSlotName.SLOT_C1)
+        mock_validation.ensure_and_convert_deck_slot(
+            sentinel.input_location, api_version, "OT-3 Standard"
+        )
+    ).then_return(sentinel.validated_location)
 
     decoy.when(
         mock_core.load_labware(
-            load_name="lowercase_labware",
-            location=DeckSlotName.SLOT_C1,
-            label="some_display_name",
-            namespace="some_namespace",
-            version=1337,
+            load_name=sentinel.lowercase_input_load_name,
+            location=sentinel.validated_location,
+            label="input_label",
+            namespace=sentinel.input_namespace,
+            version=sentinel.input_version,
         )
     ).then_return(mock_labware_core)
-    decoy.when(mock_lid_core.get_well_columns()).then_return([])
-
-    decoy.when(
-        mock_core.load_lid(
-            load_name="lowercase_lid",
-            location=mock_labware_core,
-            namespace="some_namespace",
-            version=1337,
-        )
-    ).then_return(mock_lid_core)
 
     decoy.when(mock_labware_core.get_name()).then_return("Full Name")
     decoy.when(mock_labware_core.get_display_name()).then_return("Display Name")
     decoy.when(mock_labware_core.get_well_columns()).then_return([])
 
-    decoy.when(mock_validation.ensure_lowercase_name("UPPERCASE_LABWARE")).then_return(
-        "lowercase_labware"
-    )
-
     result = subject.load_labware(
-        load_name="UPPERCASE_LABWARE",
-        location=42,
-        label="some_display_name",
-        namespace="some_namespace",
-        version=1337,
-        lid="lowercase_lid",
+        load_name=sentinel.input_load_name,
+        location=sentinel.input_location,
+        label="input_label",
+        namespace=sentinel.input_namespace,
+        version=sentinel.input_version,
+        lid=sentinel.input_lid,
+        lid_namespace=input_lid_namespace,
+        lid_version=input_lid_version,
     )
 
     assert isinstance(result, Labware)
     assert result.name == "Full Name"
+
+    decoy.verify(
+        mock_core.load_lid(
+            # todo(mm, 2025-08-26): We're passing load_name=input_lid directly without lowercasing it,
+            # unlike how we lowercase adapter names. Is this a bug?
+            load_name=sentinel.input_lid,
+            location=mock_labware_core,
+            namespace=expected_lid_namespace,
+            version=expected_lid_version,
+        )
+    )
 
     decoy.verify(mock_core_map.add(mock_labware_core, result), times=1)
 
@@ -1416,7 +1543,7 @@ def test_load_trash_bin_raises_for_staging_slot(
         subject.load_trash_bin("bleh")
 
 
-def test_load_wast_chute(
+def test_load_waste_chute(
     decoy: Decoy,
     mock_core: ProtocolCore,
     api_version: APIVersion,

--- a/shared-data/labware/definitions/2/opentrons_tough_universal_lid/1.json
+++ b/shared-data/labware/definitions/2/opentrons_tough_universal_lid/1.json
@@ -17,7 +17,7 @@
   "dimensions": {
     "xDimension": 127.76,
     "yDimension": 85.48,
-    "zDimension": 8.8
+    "zDimension": 9.2
   },
   "wells": {},
   "groups": [
@@ -46,12 +46,12 @@
     "default": {
       "x": 0,
       "y": 0,
-      "z": 6.6
+      "z": 7.1
     },
     "opentrons_96_wellplate_200ul_pcr_full_skirt": {
       "x": 0,
       "y": 0,
-      "z": 7.1
+      "z": 6.1
     },
     "protocol_engine_lid_stack_object": {
       "x": 0,
@@ -61,12 +61,12 @@
     "opentrons_tough_universal_lid": {
       "x": 0,
       "y": 0,
-      "z": 0.8
+      "z": 1
     }
   },
   "stackLimit": 5,
   "gripForce": 10,
-  "gripHeightFromLabwareBottom": 5.3,
+  "gripHeightFromLabwareBottom": 4.7,
   "gripperOffsets": {
     "default": {
       "pickUpOffset": {


### PR DESCRIPTION
This propagates our pending RS 8.6.1 changes into `edge`.