### PR TITLE
feat(step-generation): add name and description to step comment in py…

### DIFF
--- a/protocol-designer/src/file-data/__fixtures__/createFile/v7Fixture.ts
+++ b/protocol-designer/src/file-data/__fixtures__/createFile/v7Fixture.ts
@@ -251,7 +251,7 @@ export const robotStateTimeline: Timeline = {
       ],
       robotState: initialRobotState,
       warnings: [],
-      stepNumber: 1,
+      stepInfo: { stepNumber: 1, description: 'v7 fixture', name: 'transfer' },
     },
   ],
   errors: null,

--- a/protocol-designer/src/file-data/__tests__/createFile.test.ts
+++ b/protocol-designer/src/file-data/__tests__/createFile.test.ts
@@ -181,7 +181,8 @@ def run(protocol: protocol_api.ProtocolContext) -> None:
 
     # PROTOCOL STEPS
 
-    # Step 1:
+    # Step 1: transfer
+    # v7 fixture
     pass
 
 CUSTOM_LABWARE = json.loads("""{"fixture/fixture_trash/1":{"ordering":[["A1"]],"schemaVersion":2,"version":1,"namespace":"fixture","metadata":{"displayCategory":"trash","displayVolumeUnits":"L","displayName":"Tall Fixed Trash","tags":["trash","opentrons","tall"]},"dimensions":{"xDimension":172.86,"yDimension":165.86,"zDimension":82},"parameters":{"format":"trash","isTiprack":false,"loadName":"fixture_trash","isMagneticModuleCompatible":false,"quirks":["fixedTrash","centerMultichannelOnWells","touchTipDisabled"]},"wells":{"A1":{"shape":"rectangular","yDimension":165.67,"xDimension":107.11,"totalLiquidVolume":1100000,"depth":77,"x":82.84,"y":53.56,"z":5}},"brand":{"brand":"Opentrons"},"groups":[{"wells":["A1"],"metadata":{}}],"cornerOffsetFromSlot":{"x":0,"y":0,"z":0}}}""")

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/index.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/index.ts
@@ -101,9 +101,10 @@ export const stepFormToArgs = (
     console.warn(`stepFormToArgs not implemented for ${castForm.stepType}`)
     return null
   }
-
   return {
     ...stepArgs,
     stepNumber: castForm.stepNumber,
+    name: castForm.stepName,
+    description: castForm.stepDetails,
   }
 }

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/thermocyclerFormToArgs.test.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/thermocyclerFormToArgs.test.ts
@@ -153,7 +153,7 @@ describe('thermocyclerFormToArgs', () => {
       expected: {
         commandCreatorFnName: THERMOCYCLER_PROFILE,
         moduleId: tcModuleId,
-
+        description: 'mock details',
         blockTargetTempHold: null,
         lidOpenHold: true,
         lidTargetTempHold: 5,

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/thermocyclerFormToArgs.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/thermocyclerFormToArgs.ts
@@ -51,7 +51,7 @@ const _flattenProfileSteps = (args: {
 export const thermocyclerFormToArgs = (
   formData: HydratedThermocyclerFormData
 ): ThermocyclerProfileStepArgs | ThermocyclerStateStepArgs | null => {
-  const { thermocyclerFormType } = formData
+  const { thermocyclerFormType, stepDetails } = formData
 
   switch (thermocyclerFormType) {
     case THERMOCYCLER_STATE: {
@@ -96,6 +96,7 @@ export const thermocyclerFormToArgs = (
         profileSteps,
         profileTargetLidTemp: Number(formData.profileTargetLidTemp),
         profileVolume: Number(formData.profileVolume),
+        description: stepDetails,
       }
     }
   }

--- a/protocol-designer/src/timelineMiddleware/generateRobotStateTimeline.ts
+++ b/protocol-designer/src/timelineMiddleware/generateRobotStateTimeline.ts
@@ -42,7 +42,6 @@ export const generateRobotStateTimeline = (
       stepIndex
     ): StepGeneration.CurriedCommandCreator[] => {
       const { stepNumber, description, name } = args
-      console.log('step', stepNumber, description, name)
       const baseCreator = commandCreatorFromStepArgs(args)
       // unsupported command creator in args.commandCreatorFnName
       if (baseCreator === null) {

--- a/protocol-designer/src/timelineMiddleware/generateRobotStateTimeline.ts
+++ b/protocol-designer/src/timelineMiddleware/generateRobotStateTimeline.ts
@@ -41,7 +41,8 @@ export const generateRobotStateTimeline = (
       args: StepGeneration.CommandCreatorArgs,
       stepIndex
     ): StepGeneration.CurriedCommandCreator[] => {
-      const stepNumber = args.stepNumber
+      const { stepNumber, description, name } = args
+      console.log('step', stepNumber, description, name)
       const baseCreator = commandCreatorFromStepArgs(args)
       // unsupported command creator in args.commandCreatorFnName
       if (baseCreator === null) {
@@ -117,7 +118,12 @@ export const generateRobotStateTimeline = (
         _prevRobotState
       ) => {
         const result = finalCreator(_invariantContext, _prevRobotState)
-        return { ...result, stepNumber }
+        return {
+          ...result,
+          stepNumber,
+          name,
+          description,
+        }
       }
 
       return [...acc, wrappedWithStepInfo]

--- a/protocol-designer/src/timelineMiddleware/generateRobotStateTimeline.ts
+++ b/protocol-designer/src/timelineMiddleware/generateRobotStateTimeline.ts
@@ -41,7 +41,7 @@ export const generateRobotStateTimeline = (
       args: StepGeneration.CommandCreatorArgs,
       stepIndex
     ): StepGeneration.CurriedCommandCreator[] => {
-      const { stepNumber, description, name } = args
+      const { stepNumber, name, description } = args
       const baseCreator = commandCreatorFromStepArgs(args)
       // unsupported command creator in args.commandCreatorFnName
       if (baseCreator === null) {

--- a/step-generation/src/__tests__/glue.test.ts
+++ b/step-generation/src/__tests__/glue.test.ts
@@ -363,6 +363,7 @@ describe('commandCreatorsTimeline', () => {
         {
           robotState: { count: 5 + 4 },
           commands: [{ command: 'add', params: { value: 4 } }],
+          stepInfo: {},
           warnings: [
             {
               message: 'adding 4 with warning example',
@@ -395,6 +396,7 @@ describe('commandCreatorsTimeline', () => {
       {
         robotState: { count: 8 },
         commands: [{ command: 'add', params: { value: 3 } }],
+        stepInfo: {},
         warnings: [
           {
             message: 'adding 3 with warning example',
@@ -406,12 +408,14 @@ describe('commandCreatorsTimeline', () => {
       {
         robotState: { count: 16 },
         commands: [{ command: 'multiply', params: { value: 2 } }],
+        stepInfo: {},
         warnings: [],
       },
       // add 1 w/ warning
       {
         robotState: { count: 17 },
         commands: [{ command: 'add', params: { value: 1 } }],
+        stepInfo: {},
         warnings: [
           {
             message: 'adding 1 with warning example',
@@ -422,6 +426,7 @@ describe('commandCreatorsTimeline', () => {
       // Python hello world
       {
         robotState: { count: 17 },
+        stepInfo: {},
         commands: [],
         warnings: [],
         python: 'print("Hello world")',

--- a/step-generation/src/types.ts
+++ b/step-generation/src/types.ts
@@ -754,12 +754,14 @@ export interface CommandCreatorWarning {
 
 interface StepInfo {
   stepNumber?: number
-  //  TODO: can extend to include stepName and stepDetails
+  name?: string | null
+  description?: string | null
 }
 
-export interface CommandsAndRobotState extends StepInfo {
+export interface CommandsAndRobotState {
   commands: CreateCommand[]
   robotState: RobotState
+  stepInfo?: StepInfo
   warnings?: CommandCreatorWarning[]
   python?: string
 }

--- a/step-generation/src/utils/commandCreatorsTimeline.ts
+++ b/step-generation/src/utils/commandCreatorsTimeline.ts
@@ -56,7 +56,11 @@ export const commandCreatorsTimeline = (
         commands: commandCreatorResult.commands,
         robotState: nextRobotStateAndWarnings.robotState,
         warnings: commandCreatorResult.warnings,
-        stepNumber: commandCreatorResult.stepNumber,
+        stepInfo: {
+          stepNumber: commandCreatorResult.stepNumber,
+          name: commandCreatorResult.name,
+          description: commandCreatorResult.description,
+        },
         python: commandCreatorResult.python,
       }
 

--- a/step-generation/src/utils/pythonFileUtils.ts
+++ b/step-generation/src/utils/pythonFileUtils.ts
@@ -497,18 +497,16 @@ export function getLoadWasteChute(
 }
 
 const formatDescription = (description?: string | null): string => {
-  // Keep valid printable Unicode
-  const safeDescription = description
-    ?.replace(/[\u0000-\u001F\u007F]/g, '')
-    .replace(/\r\n?/g, '\n')
-
-  return safeDescription != null && safeDescription.trim() !== ''
-    ? '\n' +
-        safeDescription
-          .split('\n')
-          .map(line => `# ${line}`)
-          .join('\n')
-    : ''
+  if (description == null) {
+    return ''
+  }
+  return (
+    `\n` +
+    description
+      .split(/\r\n|\r|\n/)
+      .map(line => `# ${line}`)
+      .join('\n')
+  )
 }
 
 export function stepCommands(robotStateTimeline: Timeline): string {

--- a/step-generation/src/utils/pythonFileUtils.ts
+++ b/step-generation/src/utils/pythonFileUtils.ts
@@ -496,16 +496,32 @@ export function getLoadWasteChute(
     : ''
 }
 
+const formatDescription = (description?: string | null): string => {
+  // Keep valid printable Unicode
+  const safeDescription = description
+    ?.replace(/[\u0000-\u001F\u007F]/g, '')
+    .replace(/\r\n?/g, '\n')
+
+  return safeDescription != null && safeDescription.trim() !== ''
+    ? '\n' +
+        safeDescription
+          .split('\n')
+          .map(line => `# ${line}`)
+          .join('\n')
+    : ''
+}
+
 export function stepCommands(robotStateTimeline: Timeline): string {
   return (
     '# PROTOCOL STEPS\n\n' +
     robotStateTimeline.timeline
-      .map(
-        timelineFrame =>
-          `# Step ${timelineFrame.stepNumber}:\n${
-            timelineFrame.python || 'pass'
-          }`
-      )
+      .map(timelineFrame => {
+        const { stepInfo } = timelineFrame
+        const description = stepInfo?.description
+        return `# Step ${stepInfo?.stepNumber}: ${
+          stepInfo?.name
+        }${formatDescription(description)}\n${timelineFrame.python || 'pass'}`
+      })
       .join('\n\n')
   )
 }


### PR DESCRIPTION
…thon

closes AUTH-2193

# Overview

Add the step name and description to the comment of the step number in the generated python. This is a temp workaround until we are able to add the info to some object that Jeremy is working on later on

## Test Plan and Hands on Testing

Test for yourself. test adding a description with multiple lines to see how it is formatted in py

## Changelog

- add the step name and description to the generated python extend in several areas
- fix tests

## Risk assessment

low
