### PR TITLE
fix(components): Render waste chute fixture in stacker D3 location to preserve ordering

### DIFF
--- a/components/src/hardware-sim/BaseDeck/BaseDeck.tsx
+++ b/components/src/hardware-sim/BaseDeck/BaseDeck.tsx
@@ -320,7 +320,10 @@ export function BaseDeck(props: BaseDeckProps): JSX.Element {
                   fixtureBaseColor={lightFill}
                 />
                 {wasteChuteStackerFixtures.map(fixture => {
-                  if (fixture.cutoutId === WASTE_CHUTE_CUTOUT) {
+                  if (
+                    fixture.cutoutId === WASTE_CHUTE_CUTOUT &&
+                    moduleLocation.slotName === 'D3'
+                  ) {
                     return (
                       <WasteChuteFixture
                         key={fixture.cutoutId}


### PR DESCRIPTION
Fix [RQA-4634](https://opentrons.atlassian.net/browse/RQA-4634)
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
I am completely uncertain why this was happening for some protocols with multiple waste chutes and a waste chute + stacker combination but not for others. Regardless, sometimes we were rendering the waste chute on top of _any_ stacker, not the stacker in D3 which messed with ordering and caused the stacker module in D3 to be rendered underneath the waste chute. This fixes that.
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
Before:
<img width="918" height="732" alt="Screenshot 2025-09-02 at 5 47 11 PM" src="https://github.com/user-attachments/assets/4ce0d5a6-8830-42b8-956d-83dbea4bd6c4" />

After:
<img width="919" height="662" alt="Screenshot 2025-09-02 at 5 46 50 PM" src="https://github.com/user-attachments/assets/fbe39ebf-8e39-4ea6-9237-6c4c4f143e4f" />

<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
Render waste chute based on the module location and fixture id, not fixture id alone
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests
Share in my anger at SVG ordering
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
Low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-4634]: https://opentrons.atlassian.net/browse/RQA-4634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ