### PR TITLE
fix(mkdocs): remove acl argument on s3 sync

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -20,7 +20,7 @@ deploy:
 	@if [ -n "$$CI" ]; then \
 		echo "If you need to run this locally, set the variable AWS_PROFILE."; \
 	fi
-	aws s3 sync ./site/ s3://$(SANDBOX_S3_BUCKET)/$(BRANCH)/ --acl public-read $(if $(AWS_PROFILE),--profile $(AWS_PROFILE))
+	aws s3 sync ./site/ s3://$(SANDBOX_S3_BUCKET)/$(BRANCH)/  $(if $(AWS_PROFILE),--profile $(AWS_PROFILE))
 
 .PHONY: serve-flex-manual
 serve-flex-manual:
@@ -35,4 +35,4 @@ deploy-flex-manual:
 	@if [ -n "$$CI" ]; then \
 		echo "If you need to run this locally, set the variable AWS_PROFILE."; \
 	fi
-	aws s3 sync $(FLEX_MANUAL_PREFIX)/site/ s3://$(SANDBOX_S3_BUCKET)/$(BRANCH)/$(FLEX_MANUAL_PREFIX)/ --delete --acl public-read $(if $(AWS_PROFILE),--profile $(AWS_PROFILE))
+	aws s3 sync $(FLEX_MANUAL_PREFIX)/site/ s3://$(SANDBOX_S3_BUCKET)/$(BRANCH)/$(FLEX_MANUAL_PREFIX)/ --delete  $(if $(AWS_PROFILE),--profile $(AWS_PROFILE))


### PR DESCRIPTION
- `edge` branch uses scripts that do **not** rely on `--acl public-read`.  
- All docs are served through **CloudFront**.  The bucket does not allow public ACL for access.  
- Prior to the Edge upgrade, we did use the public ACL for access, which is no longer needed.  

### Notes
- This is a **temporary fix** to ensure the sandbox deployment works for the `chore_release-8.6.0` branch.
- We should not merge this, just proving this is the correct diagnosis.
