### PR TITLE
fix(protocol-designer): adding a staging area slot retains previous s…

### DIFF
--- a/protocol-designer/release-notes.md
+++ b/protocol-designer/release-notes.md
@@ -22,6 +22,8 @@ Crashes and protocol loss no longer occur when:
 - deleting a Protocol Designer step title.
 - checking labware details after deleting a liquid.
 
+- Adding a Staging Area slot after initial deck setup retains all previous Staging Area slots.
+
 ## Opentrons Protocol Designer Changes in 8.5.2
 
 **Welcome to Protocol Designer 8.5.2!**

--- a/protocol-designer/src/components/organisms/FlexHardware/util.ts
+++ b/protocol-designer/src/components/organisms/FlexHardware/util.ts
@@ -160,7 +160,6 @@ export const updateInitialDeckState = (
         ) {
           makeSnackbar(t('conflict_on_slot_labware_fixture') as string)
         } else {
-          console.log('createFixture', value.type)
           dispatch(createDeckFixture(value.type as DeckFixture, value.cutoutId))
         }
       }

--- a/protocol-designer/src/components/organisms/FlexHardware/util.ts
+++ b/protocol-designer/src/components/organisms/FlexHardware/util.ts
@@ -83,14 +83,15 @@ export const updateInitialDeckState = (
     labware: labwareOnDeck,
   } = initialDeckSetup
   const deckDef = getDeckDefFromRobotType(FLEX_ROBOT_TYPE)
-
   values.forEach(value => {
     if (value.cutoutFixtureId === THERMOCYCLER_V2_REAR_FIXTURE) {
       return
     }
     const hasLabwareOnSlot = getSlotHasLabware(labwareOnDeck, value.cutoutId)
     const matchingFixture = Object.values(additionalEquipmentOnDeck).find(
-      ae => ae.name === (value.type as DeckFixture)
+      ae =>
+        ae.name === (value.type as DeckFixture) &&
+        ae.location === value.cutoutId
     )
     const fourthColumnSlot =
       matchingFixture != null
@@ -159,6 +160,7 @@ export const updateInitialDeckState = (
         ) {
           makeSnackbar(t('conflict_on_slot_labware_fixture') as string)
         } else {
+          console.log('createFixture', value.type)
           dispatch(createDeckFixture(value.type as DeckFixture, value.cutoutId))
         }
       }


### PR DESCRIPTION
…taging areas

closes RQA-4636

# Overview

Adding a staging area slot after initially adding one/some retains previous staging area slots

## Test Plan and Hands on Testing

See the steps outlined in the ticket and the video to replicate how to get the behavior. it should work in this branch

## Changelog

match the fixture based on type and location. This bug technically existed as well for the trash bin and waste chute but since we only allow one of each on the deck, we never noticed.

## Risk assessment

low