### PR TITLE
feat(protocol-designer): extend export modal to flag errors

### DIFF
--- a/protocol-designer/src/__testing-utils__/renderWithProviders.tsx
+++ b/protocol-designer/src/__testing-utils__/renderWithProviders.tsx
@@ -58,7 +58,7 @@ export function renderWithProviders<State>(
 export function getProviderWrapperForHooks<State>(
   initialState: State, // this is the state you need redux to be in, often times an empty state {} is fine
   i18nInstance?: ComponentProps<typeof I18nextProvider>['i18n'] // if your hook uses i18n
-) {
+): ComponentType<PropsWithChildren<{}>> {
   const store: Store<State> = legacy_createStore(vi.fn(), initialState)
   store.dispatch = vi.fn()
   store.getState = vi.fn(() => initialState) as () => State

--- a/protocol-designer/src/__testing-utils__/renderWithProviders.tsx
+++ b/protocol-designer/src/__testing-utils__/renderWithProviders.tsx
@@ -53,3 +53,32 @@ export function renderWithProviders<State>(
 
   return [render(Component, { wrapper: ProviderWrapper }), store]
 }
+
+//  to use for testing hooks that need access to a provider
+export function getProviderWrapperForHooks<State>(
+  initialState: State, // this is the state you need redux to be in, often times an empty state {} is fine
+  i18nInstance?: ComponentProps<typeof I18nextProvider>['i18n'] // if your hook uses i18n
+) {
+  const store: Store<State> = legacy_createStore(vi.fn(), initialState)
+  store.dispatch = vi.fn()
+  store.getState = vi.fn(() => initialState) as () => State
+
+  const queryClient = new QueryClient()
+
+  const ProviderWrapper: ComponentType<PropsWithChildren<{}>> = ({
+    children,
+  }) => {
+    const base = (
+      <QueryClientProvider client={queryClient}>
+        <Provider store={store}>{children}</Provider>
+      </QueryClientProvider>
+    )
+    return i18nInstance ? (
+      <I18nextProvider i18n={i18nInstance}>{base}</I18nextProvider>
+    ) : (
+      base
+    )
+  }
+
+  return ProviderWrapper
+}

--- a/protocol-designer/src/assets/localization/en/alert.json
+++ b/protocol-designer/src/assets/localization/en/alert.json
@@ -41,6 +41,10 @@
     "waste_chute_warning": {
       "title": "Disposing labware",
       "body1": "Moving labware to the Waste Chute permanently discards it. You can’t use this labware in later steps. During a protocol run, the labware will be dropped in the chute and become irretrievable."
+    },
+    "has_errors": {
+      "title": "Protocol has errors",
+      "body1": "Some steps in this protocol have errors. The exported file will omit these steps. You should fix the errors before exporting."
     }
   },
   "timeline": {

--- a/protocol-designer/src/pages/ProtocolOverview/__tests__/ProtocolOverview.test.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/__tests__/ProtocolOverview.test.tsx
@@ -14,6 +14,7 @@ import {
 import { selectors as labwareIngredSelectors } from '../../../labware-ingred/selectors'
 import {
   getAdditionalEquipmentEntities,
+  getArgsAndErrorsByStepId,
   getInitialDeckSetup,
   getSavedStepForms,
 } from '../../../step-forms/selectors'
@@ -67,6 +68,7 @@ describe('ProtocolOverview', () => {
     vi.mocked(labwareIngredSelectors.allIngredientGroupFields).mockReturnValue(
       {}
     )
+    vi.mocked(getArgsAndErrorsByStepId).mockReturnValue({})
     vi.mocked(getDismissedHints).mockReturnValue([])
     vi.mocked(getRobotType).mockReturnValue(FLEX_ROBOT_TYPE)
     vi.mocked(getInitialDeckSetup).mockReturnValue({

--- a/protocol-designer/src/resources/hooks/__tests__/useProtocolExportHandler.test.tsx
+++ b/protocol-designer/src/resources/hooks/__tests__/useProtocolExportHandler.test.tsx
@@ -29,7 +29,7 @@ describe('useProtocolExportHandler', () => {
     }
     vi.mocked(getArgsAndErrorsByStepId).mockReturnValue({})
     vi.mocked(getRobotStateTimeline).mockReturnValue({
-      timeline: {} as any,
+      timeline: [],
       errors: null,
     })
     vi.mocked(useBlockingHint).mockImplementation(({ enabled }) => {

--- a/protocol-designer/src/resources/hooks/__tests__/useProtocolExportHandler.test.tsx
+++ b/protocol-designer/src/resources/hooks/__tests__/useProtocolExportHandler.test.tsx
@@ -1,15 +1,23 @@
 import { act, renderHook } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { getProviderWrapperForHooks } from '/protocol-designer/__testing-utils__'
+import { getRobotStateTimeline } from '/protocol-designer/file-data/selectors'
+import { getArgsAndErrorsByStepId } from '/protocol-designer/step-forms/selectors'
+
 import { useBlockingHint } from '../../../components/organisms'
 import { useProtocolExportHandler } from '../useProtocolExportHandler'
 
 import type { UseProtocolExportHandlerProps } from '../useProtocolExportHandler'
 
 vi.mock('../../../components/organisms/BlockingHintModal/useBlockingHint')
+vi.mock('/protocol-designer/step-forms/selectors')
+vi.mock('/protocol-designer/file-data/selectors')
 
 const mockOnConfirmExport = vi.fn()
 const mockModal = <div>mock Modal</div>
+
+const wrapper = getProviderWrapperForHooks({})
 
 describe('useProtocolExportHandler', () => {
   let props: UseProtocolExportHandlerProps
@@ -19,7 +27,11 @@ describe('useProtocolExportHandler', () => {
       hasCommands: true,
       onConfirmExport: mockOnConfirmExport,
     }
-
+    vi.mocked(getArgsAndErrorsByStepId).mockReturnValue({})
+    vi.mocked(getRobotStateTimeline).mockReturnValue({
+      timeline: {} as any,
+      errors: null,
+    })
     vi.mocked(useBlockingHint).mockImplementation(({ enabled }) => {
       return enabled ? mockModal : null
     })
@@ -30,17 +42,41 @@ describe('useProtocolExportHandler', () => {
   })
 
   it('should return null for exportWarningModalElement initially when no warnings', () => {
-    const { result } = renderHook(() => useProtocolExportHandler(props))
+    const { result } = renderHook(() => useProtocolExportHandler(props), {
+      wrapper,
+    })
     expect(result.current.exportWarningModalElement).toBe(null)
   })
 
-  it('should return null initially, then the modal element after clicking export when warnings ARE present', () => {
+  it('should return null initially, then the modal element after clicking export when warnings ARE present for no commands', () => {
     props = {
       ...props,
       hasCommands: false,
     }
 
-    const { result } = renderHook(() => useProtocolExportHandler(props))
+    const { result } = renderHook(() => useProtocolExportHandler(props), {
+      wrapper,
+    })
+    expect(result.current.exportWarningModalElement).toBe(null)
+    act(() => {
+      result.current.handleExportClick()
+    })
+    expect(result.current.exportWarningModalElement).toEqual(mockModal)
+    expect(result.current.exportWarningModalElement).not.toBe(null)
+  })
+
+  it('should return null initially, then the modal element after clicking export when warnings ARE present for having errors', () => {
+    vi.mocked(getRobotStateTimeline).mockReturnValue({
+      timeline: {} as any,
+      errors: [{ message: 'mock error', type: 'RETRACT_BELOW_DISPENSE' }],
+    })
+    props = {
+      ...props,
+      hasCommands: true,
+    }
+    const { result } = renderHook(() => useProtocolExportHandler(props), {
+      wrapper,
+    })
     expect(result.current.exportWarningModalElement).toBe(null)
     act(() => {
       result.current.handleExportClick()
@@ -50,7 +86,9 @@ describe('useProtocolExportHandler', () => {
   })
 
   it('should call onConfirmExport directly when handleExportClick is called without warnings', () => {
-    const { result } = renderHook(() => useProtocolExportHandler(props))
+    const { result } = renderHook(() => useProtocolExportHandler(props), {
+      wrapper,
+    })
     expect(result.current.exportWarningModalElement).toBe(null)
     act(() => {
       result.current.handleExportClick()

--- a/protocol-designer/src/resources/hooks/useProtocolExportHandler.tsx
+++ b/protocol-designer/src/resources/hooks/useProtocolExportHandler.tsx
@@ -1,7 +1,14 @@
 import { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useSelector } from 'react-redux'
 
 import { StyledText } from '@opentrons/components'
+
+import { getRobotStateTimeline } from '/protocol-designer/file-data/selectors'
+import {
+  _hasFormLevelErrors,
+  getArgsAndErrorsByStepId,
+} from '/protocol-designer/step-forms/selectors'
 
 import { useBlockingHint } from '../../components/organisms'
 
@@ -23,12 +30,20 @@ export const useProtocolExportHandler = ({
   const [showModalWithWarning, setShowModalWithWarning] = useState<boolean>(
     false
   )
+  const argsAndErrorsByStepId = useSelector(getArgsAndErrorsByStepId)
+  const timeline = useSelector(getRobotStateTimeline)
+  const hasFormErrors = Object.values(argsAndErrorsByStepId).some(
+    step => step.errors
+  )
+  const hasTimelineErrors = timeline?.errors != null
 
-  const hasWarning = !hasCommands
+  const hasWarning = !hasCommands || hasFormErrors || hasTimelineErrors
 
   const content = (
     <StyledText desktopStyle="bodyDefaultRegular">
-      {t('alert:export_warnings.redesign.no_commands.body1')}
+      {!hasCommands
+        ? t('alert:export_warnings.redesign.no_commands.body1')
+        : t('alert:hint.has_errors.body1')}
     </StyledText>
   )
 
@@ -42,7 +57,7 @@ export const useProtocolExportHandler = ({
   }, [])
 
   const exportWarningModalElement = useBlockingHint({
-    hintKey: 'no_commands',
+    hintKey: hasFormErrors || hasTimelineErrors ? 'has_errors' : 'no_commands',
     enabled: showModalWithWarning,
     content: content,
     handleCancel: cancelExportWarning,

--- a/protocol-designer/src/resources/hooks/useProtocolExportHandler.tsx
+++ b/protocol-designer/src/resources/hooks/useProtocolExportHandler.tsx
@@ -5,10 +5,7 @@ import { useSelector } from 'react-redux'
 import { StyledText } from '@opentrons/components'
 
 import { getRobotStateTimeline } from '/protocol-designer/file-data/selectors'
-import {
-  _hasFormLevelErrors,
-  getArgsAndErrorsByStepId,
-} from '/protocol-designer/step-forms/selectors'
+import { getArgsAndErrorsByStepId } from '/protocol-designer/step-forms/selectors'
 
 import { useBlockingHint } from '../../components/organisms'
 

--- a/protocol-designer/src/tutorial/index.ts
+++ b/protocol-designer/src/tutorial/index.ts
@@ -11,6 +11,7 @@ type HintKey =
   // blocking hints
   | 'change_magnet_module_model'
   | 'no_commands'
+  | 'has_errors'
 
 // DEPRECATED HINTS (keep a record to avoid name collisions with old persisted dismissal states)
 // | 'export_v4_protocol'


### PR DESCRIPTION
closes AUTH-2237

# Overview

Extend the export modal when there are no commands to also raise if you have any timeline or form errors

## Test Plan and Hands on Testing

Upload a protocol and move the steps around to provide a timeline error .then export and see the export modal copy about the errors

## Changelog

add the hook wrapper for tests
extend the error to include `has_errors`
wire it into the component
add a test case

## Risk assessment

low
