### PR TITLE
test(api): silence the `func-returns-value not covered` lint warning

### DIFF
--- a/api/tests/opentrons/protocol_api/core/engine/test_transfer_components_executor.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_transfer_components_executor.py
@@ -1921,7 +1921,7 @@ def test_retract_after_dispense_touch_tip(
     )
 
     decoy.verify(
-        mock_instrument_core.touch_tip(),  # type: ignore[call-arg]
+        mock_instrument_core.touch_tip(),  # type: ignore[call-arg,func-returns-value]
         ignore_extra_args=True,
         times={
             # (destination type, blowout location, source touchable):


### PR DESCRIPTION
# Overview

lint-py is complaining that:
```
tests/opentrons/protocol_api/core/engine/test_transfer_components_executor.py:1924: note: Error code "func-returns-value" not covered by "type: ignore" comment
```

I had an `ignore[call-arg]` there because I just wanted to spy on how many times `mock_instrument_core.touch_tip()` was called without specifying the arguments (PR #19425). But the linter also wants me to add an `ignore[func-returns-value]` there.

## Test Plan and Hands on Testing

Ran `make lint-py` again.

## Risk assessment

Low. No change to code or functionality at all. Just tweaking a lint warning.
