### PR TITLE
fix(app): hide module banners if subsystem update is ongoing

### DIFF
--- a/app/src/App/hooks.ts
+++ b/app/src/App/hooks.ts
@@ -13,6 +13,7 @@ import {
 import {
   useAllProtocolIdsQuery,
   useCreateLiveCommandMutation,
+  useCurrentAllSubsystemUpdatesQuery,
   useHost,
 } from '@opentrons/react-api-client'
 import {
@@ -41,6 +42,7 @@ const PROTOCOL_IDS_RECHECK_INTERVAL_MS = 3000
 const ATTACHED_MODULE_POLL_MS = 5000
 const DECK_CONFIG_POLL_MS = 5000
 const CURRENT_RUN_POLL = 5000
+const SUBSYSTEM_UPDATE_POLL = 5000
 
 export function useSoftwareUpdatePoll(): void {
   const dispatch = useDispatch<Dispatch>()
@@ -182,6 +184,16 @@ export function useModuleAttachedToast(
   const currentlySetuppableModules = useGetModulesNeedingSetupThatCanCurrentlyBeSetUp()
 
   const currentRunId = useCurrentRunId({ refetchInterval: CURRENT_RUN_POLL })
+  const {
+    data: currentSubsystemsUpdatesData,
+  } = useCurrentAllSubsystemUpdatesQuery({
+    refetchInterval: SUBSYSTEM_UPDATE_POLL,
+  })
+  const ongoingSubsystemUpdate = currentSubsystemsUpdatesData?.data.find(
+    update =>
+      update.updateStatus === 'queued' || update.updateStatus === 'updating'
+  )
+
   const { t, i18n } = useTranslation(['module_wizard_flows', 'shared'])
   const { makeToast, eatToast } = useToaster()
   const moduleSerials = currentlySetuppableModules.map(m => m.serialNumber)
@@ -193,7 +205,11 @@ export function useModuleAttachedToast(
 
   useEffect(() => {
     const newModuleSerials = difference(moduleSerials, moduleSerialsRef.current)
-    if (!runInProgress && newModuleSerials.length > 0) {
+    if (
+      !runInProgress &&
+      ongoingSubsystemUpdate == null &&
+      newModuleSerials.length > 0
+    ) {
       setToastID(
         makeToast(t('module_added') as string, 'info', {
           buttonText: i18n.format(t('shared:close'), 'capitalize'),

--- a/app/src/organisms/ModuleCard/__tests__/ModuleCard.test.tsx
+++ b/app/src/organisms/ModuleCard/__tests__/ModuleCard.test.tsx
@@ -2,6 +2,8 @@ import { fireEvent, screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { when } from 'vitest-when'
 
+import { useCurrentAllSubsystemUpdatesQuery } from '@opentrons/react-api-client'
+
 import { nestedTextMatcher, renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
 import { useToaster } from '/app/organisms/ToasterOven'
@@ -51,6 +53,7 @@ vi.mock('../ThermocyclerModuleData')
 vi.mock('../HeaterShakerModuleData')
 vi.mock('../FlexStackerModuleData')
 vi.mock('/app/redux/config')
+vi.mock('@opentrons/react-api-client')
 vi.mock('../ModuleOverflowMenu')
 vi.mock('../../ModuleWizardFlows')
 vi.mock('/app/resources/runs')
@@ -275,6 +278,9 @@ describe('ModuleCard', () => {
       isDoorOpen: true,
       moduleDoorLocation: null,
     })
+    vi.mocked(useCurrentAllSubsystemUpdatesQuery).mockReturnValue({
+      data: { data: [] },
+    } as any)
   })
   afterEach(() => {
     vi.resetAllMocks()

--- a/app/src/organisms/ModuleCard/index.tsx
+++ b/app/src/organisms/ModuleCard/index.tsx
@@ -23,7 +23,10 @@ import {
   useMenuHandleClickOutside,
   useOnClickOutside,
 } from '@opentrons/components'
-import { useHost } from '@opentrons/react-api-client'
+import {
+  useCurrentAllSubsystemUpdatesQuery,
+  useHost,
+} from '@opentrons/react-api-client'
 import {
   ABSORBANCE_READER_TYPE,
   FLEX_STACKER_MODULE_TYPE,
@@ -94,6 +97,8 @@ const NO_CALIBRATION_TYPE: ModuleType[] = [
   ABSORBANCE_READER_TYPE,
   FLEX_STACKER_MODULE_TYPE,
 ]
+
+const POLL_INTERVAL_MS = 5000
 
 interface ModuleCardProps {
   module: AttachedModule
@@ -177,9 +182,20 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
     }
   }
 
+  const {
+    data: currentSubsystemsUpdatesData,
+  } = useCurrentAllSubsystemUpdatesQuery({
+    refetchInterval: POLL_INTERVAL_MS,
+  })
+  const ongoingSubsystemUpdate = currentSubsystemsUpdatesData?.data.find(
+    update =>
+      update.updateStatus === 'queued' || update.updateStatus === 'updating'
+  )
+
   const isPending = latestRequest?.status === PENDING
 
-  const hideBanners = isPending || isRunRunning
+  const hideBanners =
+    isPending || isRunRunning || ongoingSubsystemUpdate != null
   const hotToTouch: IconProps = { name: 'ot-hot-to-touch' }
   const isFlex = useIsFlex(robotName)
   const deckConfig = useNotifyDeckConfigurationQuery().data


### PR DESCRIPTION
Fix RQA-4635
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This PR hides the setup banners on desktop app module card and the setup toast on ODD if there is an ongoing firmware update
For the ODD toast, I think changing the z-index is a better long term solution but too risky this close to release. Thread on how/if to go this route later on is here https://opentrons.slack.com/archives/CSCLVUW3C/p1756925082487469
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
Downgrade the robot, then upgrade again. See that after the robot restarts, firmware updates begin. The module setup toast and banners now don't appear until the updates have completed.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
Start polling for subsystem updates in module card and module setup toast so we can prevent these from showing up when a subsystem update is in progress
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests
Changes make sense?
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
Low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
