### PR TITLE
feat(api): add a leak check analysis cli

### DIFF
--- a/analyses-snapshot-testing/automation/analyze.py
+++ b/analyses-snapshot-testing/automation/analyze.py
@@ -75,7 +75,7 @@ def _subprocess_entrypoint():
     json_output_stream = io.BytesIO()
     outputs = [_Output(to_file=json_output_stream, kind="json")]
     try:
-        exit_code = asyncio.run(_analyze(files, args.rtp_values, args.rtp_files, outputs, args.check))
+        exit_code = asyncio.run(_analyze(files, args.rtp_values, args.rtp_files, outputs, args.check, False, False))
     except Exception as e:
         print(json.dumps({"error": f"Exception: {str(e)}"}), file=sys.stdout)
         sys.exit(1)

--- a/api/src/opentrons/cli/analyze.py
+++ b/api/src/opentrons/cli/analyze.py
@@ -402,21 +402,16 @@ async def _analyze(  # noqa: C901
     # the debug option.
     if fail_on_leak or debug_on_leak:
         gc.collect()
-        try:
-            leaked_engine = [  # noqa: F841
-                obj for obj in gc.get_objects() if isinstance(obj, ProtocolEngine)
-            ][0]
-        except IndexError:
-            pass
-        else:
+        leaked_engine = next(
+            (obj for obj in gc.get_objects() if isinstance(obj, ProtocolEngine)), None
+        )
+        if leaked_engine:
             if fail_on_leak:
                 print(
-                    (
-                        "A ProtocolEngine instance exists even after garbage collection; "
-                        "some thing (likely in the protocol) has caused it to be leaked, ",
-                        "likely by reference to the engine or something that refers to the ",
-                        "engine after the run function ends.",
-                    ),
+                    "A ProtocolEngine instance exists even after garbage collection; "
+                    "some thing (likely in the protocol) has caused it to be leaked, "
+                    "likely by reference to the engine or something that refers to the "
+                    "engine after the run function ends.",
                     file=sys.stderr,
                 )
                 return_code = -2

--- a/api/src/opentrons/cli/analyze.py
+++ b/api/src/opentrons/cli/analyze.py
@@ -372,7 +372,7 @@ async def _do_analyze(
     return await orchestrator.run(deck_configuration=[])
 
 
-async def _analyze(
+async def _analyze(  # noqa: C901
     files_and_dirs: Sequence[Path],
     rtp_values: str,
     rtp_files: str,
@@ -403,7 +403,7 @@ async def _analyze(
     if fail_on_leak or debug_on_leak:
         gc.collect()
         try:
-            leaked_engine = [
+            leaked_engine = [  # noqa: F841
                 obj for obj in gc.get_objects() if isinstance(obj, ProtocolEngine)
             ][0]
         except IndexError:
@@ -411,24 +411,18 @@ async def _analyze(
         else:
             if fail_on_leak:
                 print(
-                    "A ProtocolEngine instance exists even after garbage collection; ",
+                    (
+                        "A ProtocolEngine instance exists even after garbage collection; "
+                        "some thing (likely in the protocol) has caused it to be leaked, ",
+                        "likely by reference to the engine or something that refers to the ",
+                        "engine after the run function ends.",
+                    ),
                     file=sys.stderr,
                 )
-                print(
-                    "some thing (likely in the protocol) has caused it to be leaked, ",
-                    file=sys.stderr,
-                )
-                print(
-                    "likely by reference to the engine or something that refers to the ",
-                    file=sys.stderr,
-                )
-                print("engine after the run function ends.", file=sys.stderr)
                 return_code = -2
             if debug_on_leak:
                 print(
-                    f"You are now in an interactive PDB (https://docs.python.org/3.10/library/pdb.html) "
-                )
-                print(
+                    "You are now in an interactive PDB (https://docs.python.org/3.10/library/pdb.html) "
                     "session; the leaked engine is bound to the variable leaked_engine."
                 )
                 breakpoint()

--- a/api/src/opentrons/cli/analyze.py
+++ b/api/src/opentrons/cli/analyze.py
@@ -1,4 +1,5 @@
 """Opentrons analyze CLI."""
+
 import click
 
 from anyio import run
@@ -365,6 +366,16 @@ async def _analyze(
 
     analysis = await _do_analyze(protocol_source, parsed_rtp_values, rtp_paths)
     return_code = _get_return_code(analysis)
+    import gc
+    from opentrons.protocol_engine import ProtocolEngine
+
+    gc.collect()
+    leaked_engine = [e for e in gc.get_objects() if isinstance(e, ProtocolEngine)]
+    if leaked_engine:
+        print("leak, check leaked_engine")
+        breakpoint()
+    else:
+        print("no leak")
 
     if not outputs:
         return return_code

--- a/api/src/opentrons/cli/analyze.py
+++ b/api/src/opentrons/cli/analyze.py
@@ -25,7 +25,9 @@ from typing import (
 import logging
 import sys
 import json
+import gc
 
+from opentrons.protocol_engine import ProtocolEngine
 from opentrons.protocol_engine.types import (
     RunTimeParameter,
     CSVRuntimeParamPaths,
@@ -96,6 +98,18 @@ class _Output:
     type=click.File(mode="wb"),
 )
 @click.option(
+    "--leaks",
+    help="Fail (via exit code) if the analysis engine has not been garbage collected after analysis is complete.",
+    is_flag=True,
+    default=False,
+)
+@click.option(
+    "--leaks-debug",
+    help="Drop into a PDB shell if a leak is detected",
+    is_flag=True,
+    default=False,
+)
+@click.option(
     "--check",
     help="Fail (via exit code) if the protocol had an error. If not specified, always succeed.",
     is_flag=True,
@@ -134,6 +148,8 @@ def analyze(
     log_output: str,
     log_level: str,
     check: bool,
+    leaks: bool,
+    leaks_debug: bool,
 ) -> int:
     """Analyze a protocol.
 
@@ -148,7 +164,18 @@ def analyze(
 
     try:
         with _capture_logs(log_output, log_level):
-            sys.exit(run(_analyze, files, rtp_values, rtp_files, outputs, check))
+            sys.exit(
+                run(
+                    _analyze,
+                    files,
+                    rtp_values,
+                    rtp_files,
+                    outputs,
+                    check,
+                    leaks or leaks_debug,
+                    leaks_debug,
+                )
+            )
     except click.ClickException:
         raise
     except Exception as e:
@@ -351,6 +378,8 @@ async def _analyze(
     rtp_files: str,
     outputs: Sequence[_Output],
     check: bool,
+    fail_on_leak: bool,
+    debug_on_leak: bool,
 ) -> int:
     input_files = _get_input_files(files_and_dirs)
     parsed_rtp_values = _get_runtime_parameter_values(rtp_values)
@@ -366,16 +395,43 @@ async def _analyze(
 
     analysis = await _do_analyze(protocol_source, parsed_rtp_values, rtp_paths)
     return_code = _get_return_code(analysis)
-    import gc
-    from opentrons.protocol_engine import ProtocolEngine
 
-    gc.collect()
-    leaked_engine = [e for e in gc.get_objects() if isinstance(e, ProtocolEngine)]
-    if leaked_engine:
-        print("leak, check leaked_engine")
-        breakpoint()
-    else:
-        print("no leak")
+    # This ugly code checks to see if an engine remains past garbage collection
+    # after analysis is complete.
+    # It should be here and open coded to make it a little easier to present
+    # the debug option.
+    if fail_on_leak or debug_on_leak:
+        gc.collect()
+        try:
+            leaked_engine = [
+                obj for obj in gc.get_objects() if isinstance(obj, ProtocolEngine)
+            ][0]
+        except IndexError:
+            pass
+        else:
+            if fail_on_leak:
+                print(
+                    "A ProtocolEngine instance exists even after garbage collection; ",
+                    file=sys.stderr,
+                )
+                print(
+                    "some thing (likely in the protocol) has caused it to be leaked, ",
+                    file=sys.stderr,
+                )
+                print(
+                    "likely by reference to the engine or something that refers to the ",
+                    file=sys.stderr,
+                )
+                print("engine after the run function ends.", file=sys.stderr)
+                return_code = -2
+            if debug_on_leak:
+                print(
+                    f"You are now in an interactive PDB (https://docs.python.org/3.10/library/pdb.html) "
+                )
+                print(
+                    "session; the leaked engine is bound to the variable leaked_engine."
+                )
+                breakpoint()
 
     if not outputs:
         return return_code


### PR DESCRIPTION
We've realized that it's actually pretty easy for protocols with complex code and functionality to accidentally leak a protocol engine. The long term fix for this is to get protocols running in their own processes, or at the very least their own interpreters; for now though, what we can do is add a flag to the analysis cli that checks for the presence of such a leak.

## Testing
- [x] leak an engine in a protocol and check that this prints it (I can provide one that does this)
- [x] have a protocol that doesn't and see that it doens't print that

We should probably get this running automatically on our test harness.