### PR TITLE
test(api): I give up, spell out mock touch_tip() arguments

### DIFF
--- a/api/tests/opentrons/protocol_api/core/engine/test_transfer_components_executor.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_transfer_components_executor.py
@@ -1921,7 +1921,13 @@ def test_retract_after_dispense_touch_tip(
     )
 
     decoy.verify(
-        mock_instrument_core.touch_tip(),  # type: ignore[call-arg,func-returns-value]
+        mock_instrument_core.touch_tip(
+            location=matchers.Anything(),
+            well_core=matchers.Anything(),
+            radius=matchers.Anything(),
+            z_offset=matchers.Anything(),
+            speed=matchers.Anything(),
+        ),
         ignore_extra_args=True,
         times={
             # (destination type, blowout location, source touchable):


### PR DESCRIPTION
# Overview

I thought I could make the `test_transfer_components_executor.py` more succinct by leaving out the arguments to the mock `touch_tip()` and doing:
```
decoy.verify(
    mock_instrument_core.touch_tip(),  # type: ignore[call-arg]
    ignore_extra_args=True,
)
```
but lint didn't like that.

I fixed the lint warning, but then @jbleon95 discovered that pytest itself complains with the warning:
```
IncorrectCallWarning: missing a required argument: 'location'
```
The warning doesn't fail the test, but it does add a bit of noise to the logs.

To keep the test logs clean, I gave in and spelled out all the arguments to `touch_tip()`.

## Test Plan and Hands on Testing

Ran `test_transfer_components_executor.py` with warnings turned on.

## Risk assessment

Low, cosmetic change to test.