### PR TITLE
fix(api): replace labware ID in error messages with user readable names

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/touch_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/touch_tip.py
@@ -114,7 +114,7 @@ class TouchTipImplementation(
 
         if self._state_view.labware.get_has_quirk(labware_id, "touchTipDisabled"):
             raise TouchTipDisabledError(
-                f"Touch tip not allowed on labware {labware_id}"
+                f"Touch tip not allowed on labware {self._state_view.labware.get_display_name(labware_id)}"
             )
 
         if self._state_view.labware.is_tiprack(labware_id):

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -711,7 +711,7 @@ class GeometryView:
 
         if well_def.shape != "circular":
             raise errors.LabwareIsNotTipRackError(
-                f"Well {well_name} in labware {labware_id} is not circular."
+                f"Well {well_name} in labware {self._labware.get_display_name(labware_id)} is not circular."
             )
 
         return TipGeometry(
@@ -802,7 +802,7 @@ class GeometryView:
                 slot_name = DeckSlotName.from_primitive(area_name)
         elif labware.location == OFF_DECK_LOCATION:
             raise errors.LabwareNotOnDeckError(
-                f"Labware {labware_id} does not have a slot associated with it"
+                f"Labware {self._labware.get_display_name(labware_id)} does not have a slot associated with it"
                 f" since it is no longer on the deck."
             )
         else:
@@ -2086,7 +2086,8 @@ class GeometryView:
             except InvalidLiquidHeightFound as _exception:
                 raise InvalidLiquidHeightFound(
                     message=_exception.message
-                    + f"for well {well_name} of {self._labware.get_display_name(labware_id)} on slot {self.get_ancestor_slot_name(labware_id)}"
+                    + f"for well {well_name} of {self._labware.get_display_name(labware_id)}"
+                    f" on slot {self.get_ancestor_slot_name(labware_id)}"
                 )
             # if meniscus volume is a simulated value, comparisons aren't meaningful
             if isinstance(meniscus_volume, SimulatedProbeResult):
@@ -2094,13 +2095,16 @@ class GeometryView:
             remaining_volume = well_volumetric_capacity - meniscus_volume
             if volume > remaining_volume:
                 raise errors.InvalidDispenseVolumeError(
-                    f"Attempting to dispense {volume}µL of liquid into a well that can currently only hold {remaining_volume}µL (well {well_name} in labware_id: {labware_id})"
+                    f"Attempting to dispense {volume}µL of liquid into a well that can currently only hold"
+                    f" {remaining_volume}µL (well {well_name} in labware {self._labware.get_display_name(labware_id)})"
                 )
         else:
             # TODO(pbm, 10-08-24): factor in well (LabwareStore) state volume
             if volume > well_volumetric_capacity:
                 raise errors.InvalidDispenseVolumeError(
-                    f"Attempting to dispense {volume}µL of liquid into a well that can only hold {well_volumetric_capacity}µL (well {well_name} in labware_id: {labware_id})"
+                    f"Attempting to dispense {volume}µL of liquid into a well that can only hold"
+                    f" {well_volumetric_capacity}µL (well {well_name} in"
+                    f" labware {self._labware.get_display_name(labware_id)})"
                 )
 
     def get_wells_covered_by_pipette_with_active_well(

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -399,7 +399,7 @@ class LabwareView:
             return self._state.labware_by_id[labware_id]
         except KeyError as e:
             raise errors.LabwareNotLoadedError(
-                f"Labware {labware_id} not found."
+                f"Labware with id {labware_id} not found."
             ) from e
 
     def known(self, labware_id: str) -> bool:
@@ -428,7 +428,7 @@ class LabwareView:
             ):
                 return labware.id
         raise errors.exceptions.LabwareNotLoadedOnLabwareError(
-            f"There is not labware loaded onto labware {labware_id}"
+            f"There is not labware loaded onto labware {self.get_display_name(labware_id)}"
         )
 
     def raise_if_labware_has_non_lid_labware_on_top(self, labware_id: str) -> None:
@@ -441,7 +441,8 @@ class LabwareView:
                 and candidate_id != lid_id
             ):
                 raise errors.LabwareIsInStackError(
-                    f"Cannot access labware {labware_id} because it has a non-lid labware stacked on top."
+                    f"Cannot access labware {self.get_display_name(labware_id)} because it has"
+                    " a non-lid labware stacked on top."
                 )
 
     def raise_if_labware_has_labware_on_top(self, labware_id: str) -> None:
@@ -452,7 +453,8 @@ class LabwareView:
                 and labware.location.labwareId == labware_id
             ):
                 raise errors.LabwareIsInStackError(
-                    f"Cannot access labware {labware_id} because it has another labware stacked on top."
+                    f"Cannot access labware {self.get_display_name(labware_id)} because it has"
+                    " another labware stacked on top."
                 )
 
     def get_by_slot(
@@ -687,7 +689,7 @@ class LabwareView:
             return definition.wells[well_name]
         except KeyError as e:
             raise errors.WellDoesNotExistError(
-                f"{well_name} does not exist in {labware_id}."
+                f"{well_name} does not exist in {self.get_display_name(labware_id)}."
             ) from e
 
     def get_well_geometry(
@@ -697,19 +699,21 @@ class LabwareView:
         labware_def = self.get_definition(labware_id)
         if labware_def.innerLabwareGeometry is None:
             raise errors.IncompleteLabwareDefinitionError(
-                message=f"No innerLabwareGeometry found in labware definition for labware_id: {labware_id}."
+                message=f"No innerLabwareGeometry found in labware definition for {self.get_display_name(labware_id)}."
             )
         well_def = self.get_well_definition(labware_id, well_name)
         geometry_id = well_def.geometryDefinitionId
         if geometry_id is None:
             raise errors.IncompleteWellDefinitionError(
-                message=f"No geometryDefinitionId found in well definition for well: {well_name} in labware_id: {labware_id}"
+                message=f"No geometryDefinitionId found in well definition for well {well_name}"
+                f" for {self.get_display_name(labware_id)}"
             )
         else:
             well_geometry = labware_def.innerLabwareGeometry.get(geometry_id)
             if well_geometry is None:
                 raise errors.IncompleteLabwareDefinitionError(
-                    message=f"No innerLabwareGeometry found in labware definition for well_id: {geometry_id} in labware_id: {labware_id}"
+                    message=f"No innerLabwareGeometry found in labware definition for geometry id {geometry_id}"
+                    f" for {self.get_display_name(labware_id)}"
                 )
             return well_geometry
 
@@ -778,15 +782,15 @@ class LabwareView:
         contains_wells = all(well_name in labware_wells for well_name in iter(wells))
         if labware_definition.parameters.isTiprack:
             raise errors.LabwareIsTipRackError(
-                f"Given labware: {labware_id} is a tiprack. Can not load liquid."
+                f"Given labware {self.get_display_name(labware_id)} is a tip rack. Can not load liquid."
             )
         if LabwareRole.adapter in labware_definition.allowedRoles:
             raise errors.LabwareIsAdapterError(
-                f"Given labware: {labware_id} is an adapter. Can not load liquid."
+                f"Given labware {self.get_display_name(labware_id)} is an adapter. Can not load liquid."
             )
         if not contains_wells:
             raise errors.WellDoesNotExistError(
-                f"Some of the supplied wells do not match the labwareId: {labware_id}."
+                f"Some of the supplied wells do not match the labware {self.get_display_name(labware_id)}."
             )
         return list(wells)
 
@@ -795,7 +799,7 @@ class LabwareView:
         definition = self.get_definition(labware_id)
         if definition.parameters.tipLength is None:
             raise errors.LabwareIsNotTipRackError(
-                f"Labware {labware_id} has no tip length defined."
+                f"Labware {self.get_display_name(labware_id)} has no tip length defined."
             )
 
         return definition.parameters.tipLength - overlap

--- a/api/src/opentrons/protocol_engine/state/motion.py
+++ b/api/src/opentrons/protocol_engine/state/motion.py
@@ -97,7 +97,8 @@ class MotionView:
         subwells_12 = self._labware.get_has_12_subwells(labware_id)
         if subwells_12 and subwells_96:
             log.warning(
-                f"{labware_id} has both offsetPipetteFor96GridSubwells and offsetPipetteFor12GridSubwells quirks."
+                f"{self._labware.get_display_name(labware_id)} has both offsetPipetteFor96GridSubwells and"
+                " offsetPipetteFor12GridSubwells quirks."
             )
 
         pipette_rows = self._pipettes.get_nozzle_configuration(pipette_id).rows

--- a/api/tests/opentrons/protocol_engine/state/test_labware_view_old.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_view_old.py
@@ -201,7 +201,7 @@ def test_get_id_by_labware() -> None:
 
 
 def test_get_id_by_labware_raises_error() -> None:
-    """Should raise error that labware not found."""
+    """Should raise an error that labware not found."""
     subject = get_labware_view(
         labware_by_id={
             "labware-id": LoadedLabware(
@@ -209,11 +209,12 @@ def test_get_id_by_labware_raises_error() -> None:
                 loadName="test",
                 definitionUri="test-uri",
                 location=OnLabwareLocation(labwareId="other-labware-id"),
-            )
-        }
+                displayName="The Labware",
+            ),
+        },
     )
     with pytest.raises(errors.exceptions.LabwareNotLoadedOnLabwareError):
-        subject.get_id_by_labware(labware_id="no-labware-id")
+        subject.get_id_by_labware(labware_id="labware-id")
 
 
 def test_raise_if_labware_has_non_lid_labware_on_top() -> None:
@@ -225,6 +226,7 @@ def test_raise_if_labware_has_non_lid_labware_on_top() -> None:
                 loadName="test",
                 definitionUri="test-uri",
                 location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
+                displayName="lorem",
             ),
             "bottom-labware-2": LoadedLabware(
                 id="bottom-labware-2",
@@ -232,24 +234,28 @@ def test_raise_if_labware_has_non_lid_labware_on_top() -> None:
                 definitionUri="test-uri",
                 location=DeckSlotLocation(slotName=DeckSlotName.SLOT_2),
                 lid_id="lid-labware-a",
+                displayName="ipsum",
             ),
             "bottom-labware-3": LoadedLabware(
                 id="bottom-labware-3",
                 loadName="test",
                 definitionUri="test-uri",
                 location=DeckSlotLocation(slotName=DeckSlotName.SLOT_3),
+                displayName="dolor",
             ),
             "lid-labware-a": LoadedLabware(
                 id="lid-labware-a",
                 loadName="lid",
                 definitionUri="lid-uri",
                 location=OnLabwareLocation(labwareId="bottom-labware-2"),
+                displayName="sit",
             ),
             "top-labware-b": LoadedLabware(
                 id="top-labware-b",
                 loadName="test",
                 definitionUri="test-uri",
                 location=OnLabwareLocation(labwareId="bottom-labware-3"),
+                displayName="amet",
             ),
         }
     )
@@ -270,6 +276,7 @@ def test_raise_if_labware_has_labware_on_top() -> None:
                 loadName="test",
                 definitionUri="test-uri",
                 location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
+                displayName="lorem",
             ),
             "bottom-labware-2": LoadedLabware(
                 id="bottom-labware-2",
@@ -277,24 +284,28 @@ def test_raise_if_labware_has_labware_on_top() -> None:
                 definitionUri="test-uri",
                 location=ModuleLocation(moduleId="module-id"),
                 lid_id="lid-labware-a",
+                displayName="ipsum",
             ),
             "bottom-labware-3": LoadedLabware(
                 id="bottom-labware-3",
                 loadName="test",
                 definitionUri="test-uri",
                 location=DeckSlotLocation(slotName=DeckSlotName.SLOT_3),
+                displayName="dolor",
             ),
             "lid-labware-a": LoadedLabware(
                 id="lid-labware-a",
                 loadName="test-lid",
                 definitionUri="lid-uri",
                 location=OnLabwareLocation(labwareId="bottom-labware-2"),
+                displayName="sit",
             ),
             "top-labware-b": LoadedLabware(
                 id="top-labware-b",
                 loadName="test",
                 definitionUri="test-uri",
                 location=OnLabwareLocation(labwareId="bottom-labware-3"),
+                displayName="amet",
             ),
         }
     )
@@ -616,12 +627,14 @@ def test_validate_liquid_allowed_raises_incompatible_labware() -> None:
                 loadName="test1",
                 definitionUri="some-tiprack-uri",
                 location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
+                displayName="Tip Rack",
             ),
             "adapter-id": LoadedLabware(
                 id="adapter-id",
                 loadName="test2",
                 definitionUri="some-adapter-uri",
                 location=DeckSlotLocation(slotName=DeckSlotName.SLOT_2),
+                displayName="Some adapter",
             ),
         },
         definitions_by_uri={


### PR DESCRIPTION
# Overview

Since the dawn of ~~time~~ computers, error messages have been printed when something goes wrong. In the world of Opentrons, there's a number of error messages that relate to labware that print out the labware ID to indicate what labware has caused this issue.

The problem with this is the labware ID is for any written protocol a randomly generated UUID, which usually provides little value to developers and engineers and absolutely zero value to customers who are usually confused at the string of digits and characters that change every time they run the protocol. And while usually the line number is enough to debug any issue and the labware UUID can be cross-referenced with the analysis or run result, this provides an extra and unnecessary step to the debugging process.

To fix this, I've replaced almost all direct printing of labware IDs with calling `LabwareView.get_display_name()`, which will print the user-given display name/label if one exists, otherwise falling back on the load name. Now instead of a raw UUID-4, users will at worst see a camelCase load name of their labware, which should make customer's, support's and engineer's lives easier.

The one place the labware ID has been left in an error message is when a labware cannot be found associated with that ID, which should not occur in a user protocol and in that case it is actually useful for debugging.

## Test Plan and Hands on Testing

This is mostly an error text change, I did not test every single one of the changed errors (many of which can't actually be created easily in a protocol and exist more for developers), but the following protocol now prints the labware's load name

```
requirements = {
    "robotType": "Flex",
    "apiLevel": "2.25"
}


metadata = {
    "protocolName":'Causing an error that previously had a labware ID',
    'author':'Jeremy'
}

def run(protocol_context):
    tiprack = protocol_context.load_labware("opentrons_flex_96_tiprack_50ul", "C2")
    purple_liquid = protocol_context.define_liquid(
        name="Purple",
        description="The mysterious color made by mixing red and blue",
        display_color="#6e3ab1",
    )
    tiprack.load_liquid(
        wells=tiprack.wells(),
        volume=50,
        liquid=purple_liquid
    )
```

## Changelog

- replaced a bunch of places where we were printing out the labware ID and replaced it with printing out a human readable name

## Review requests

Did I go too far in some places? Not far enough? I found all of these by searching for `labware_id}` and then checking the few places where we do `.format()`, so it is possible I missed somewhere. I also stopped at changing the language of the error messages besides for removing references for labware IDs and some small clarifications, but if any changes are wanted/needed those can be added to this PR.

## Risk assessment

Low-medium, there is now some added code to these error messages, but I checked that at the point where these errors should appear the labware already has been verified to exist. And if it doesn't exist, that is only illuminating a further bug (and the protocol would be failing anyways at that point)