### PR TITLE
refactor(protocol-designer): fix styling and copy of release notes

### DIFF
--- a/protocol-designer/release-notes.md
+++ b/protocol-designer/release-notes.md
@@ -22,7 +22,7 @@ This hotfix release addresses several bugs.
   - deleting a Protocol Designer step title.
   - checking labware details after deleting a liquid.
 
-- Add additional staging area slots to your robot deck without removing any added during setup.
+- All staging area slots remain when adding new staging areas after initial deck setup.
 
 ## Opentrons Protocol Designer Changes in 8.5.2
 

--- a/protocol-designer/release-notes.md
+++ b/protocol-designer/release-notes.md
@@ -16,13 +16,12 @@ This hotfix release addresses several bugs.
 
 ### Bug Fixes
 
-Crashes and protocol loss no longer occur when:
+- Crashes and protocol loss no longer occur when:
+    - deleting a pipette involved in a mix step.
+    - deleting a Protocol Designer step title.
+    - checking labware details after deleting a liquid.
 
-- deleting a pipette involved in a mix step.
-- deleting a Protocol Designer step title.
-- checking labware details after deleting a liquid.
-
-- Adding a Staging Area slot after initial deck setup retains all previous Staging Area slots.
+- Add additional staging area slots to your robot deck without removing any added during setup.
 
 ## Opentrons Protocol Designer Changes in 8.5.2
 

--- a/protocol-designer/release-notes.md
+++ b/protocol-designer/release-notes.md
@@ -17,9 +17,10 @@ This hotfix release addresses several bugs.
 ### Bug Fixes
 
 - Crashes and protocol loss no longer occur when:
-    - deleting a pipette involved in a mix step.
-    - deleting a Protocol Designer step title.
-    - checking labware details after deleting a liquid.
+
+  - deleting a pipette involved in a mix step.
+  - deleting a Protocol Designer step title.
+  - checking labware details after deleting a liquid.
 
 - Add additional staging area slots to your robot deck without removing any added during setup.
 


### PR DESCRIPTION
# Overview

modify release notes copy and formatting

hmmm i guess we can just get this change in if we need another alpha?  but shouldn't need to be smoke tested so we can make the release tag off of this pr if need be.

## Test Plan and Hands on Testing

look at copy and should match the comment that Emily left [here](https://github.com/Opentrons/opentrons/pull/19447#pullrequestreview-3182065078)

## Changelog

fix copy

## Risk assessment

low
