### PR TITLE
fix(shared-data,app): Correctly ignore certain offsets in a labware stack

### DIFF
--- a/shared-data/js/helpers/__tests__/positionMath.test.ts
+++ b/shared-data/js/helpers/__tests__/positionMath.test.ts
@@ -8,6 +8,9 @@ import {
 
 describe('computeLabwareOrigin()', () => {
   test('legacy behavior of x and y when labware are stacked', () => {
+    // The adapter has a nonzero cornerOffsetFromSlot and the tip rack has a zero
+    // stackingOffsetWithLabware x and y. The x and y of the tip rack follow the
+    // x and y of the underlying slot, NOT of the adapter.
     const adapter = getAllDefinitions()[
       'opentrons/opentrons_flex_96_tiprack_adapter/1'
     ]

--- a/shared-data/js/helpers/__tests__/positionMath.test.ts
+++ b/shared-data/js/helpers/__tests__/positionMath.test.ts
@@ -21,10 +21,11 @@ describe('computeLabwareOrigin()', () => {
       deckDefinition: ot3StandardDeckV5 as any,
     })
     const expected = {
-      // Bottom-left of slot A1.
+      // x and y are the front-left of slot A1.
+      // z is on the surface of the adapter.
       x: 0.0,
       y: 321.0,
-      z: 0.0,
+      z: 11.0,
     }
     expect(result).toStrictEqual(expected)
   })

--- a/shared-data/js/helpers/__tests__/positionMath.test.ts
+++ b/shared-data/js/helpers/__tests__/positionMath.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  computeLabwareOrigin,
+  getAllDefinitions,
+  ot3StandardDeckV5,
+} from '../..'
+
+describe('computeLabwareOrigin()', () => {
+  test('legacy behavior of x and y when labware are stacked', () => {
+    const adapter = getAllDefinitions()[
+      'opentrons/opentrons_flex_96_tiprack_adapter/1'
+    ]
+    const tipRack = getAllDefinitions()[
+      'opentrons/opentrons_flex_96_tiprack_1000ul/1'
+    ]
+    const result = computeLabwareOrigin({
+      labwareDefinitionsTopToBottom: [tipRack, adapter],
+      moduleDefinition: null,
+      slotId: 'A1',
+      deckDefinition: ot3StandardDeckV5 as any,
+    })
+    const expected = {
+      // Bottom-left of slot A1.
+      x: 0.0,
+      y: 321.0,
+      z: 0.0,
+    }
+    expect(result).toStrictEqual(expected)
+  })
+})

--- a/shared-data/js/helpers/positionMath.ts
+++ b/shared-data/js/helpers/positionMath.ts
@@ -152,6 +152,7 @@ function getLabwareStackAsArray(
   if (labwareDefinitionsTopToBottom.length === 0) {
     return []
   }
+  const topLabware = labwareDefinitionsTopToBottom[0]
   const bottomLabware =
     labwareDefinitionsTopToBottom[labwareDefinitionsTopToBottom.length - 1]
 
@@ -161,16 +162,26 @@ function getLabwareStackAsArray(
     childLabwareDefinition,
     parentLabwareDefinition,
   ] of pairsFromArray(labwareDefinitionsTopToBottom)) {
+    const parentOriginToChildOrigin = getLabwareOriginToLabwareOrigin(
+      parentLabwareDefinition,
+      childLabwareDefinition
+    )
+
+    // Preserving legacy misbehavior:
+    // If we're computing the position of a schema 2 labware, the labware below
+    // it don't contribute anything to its x or y offset. Only z.
+    if (topLabware.schemaVersion === 2) {
+      parentOriginToChildOrigin.x = 0
+      parentOriginToChildOrigin.y = 0
+    }
+
     result.push({
       debugInfo: {
         type: 'labwareOnLabware',
         parentLabwareDefinition,
         childLabwareDefinition,
       },
-      offset: getLabwareOriginToLabwareOrigin(
-        parentLabwareDefinition,
-        childLabwareDefinition
-      ),
+      offset: parentOriginToChildOrigin,
     })
   }
 
@@ -185,16 +196,25 @@ function getLabwareStackAsArray(
       return null
     }
     const slotPosition = coordinateTupleToVector3D(slotPositionTuple)
+    const slotPositionToLabwareOrigin = getDeckSlotOriginToLabwareOrigin(
+      slotAddressableArea,
+      bottomLabware
+    )
+    // Preserving legacy misbehavior:
+    // If we're computing the position of a schema 2 labware, the labware below
+    // it don't contribute anything to its x or y offset. Only z.
+    if (bottomLabware !== topLabware && topLabware.schemaVersion === 2) {
+      slotPositionToLabwareOrigin.x = 0
+      slotPositionToLabwareOrigin.y = 0
+    }
+
     result.push({
       debugInfo: {
         type: 'labwareOnDeckSlot',
         parentSlotId: slotId,
         childLabwareDefinition: bottomLabware,
       },
-      offset: getDeckSlotOriginToLabwareOrigin(
-        slotAddressableArea,
-        bottomLabware
-      ),
+      offset: slotPositionToLabwareOrigin,
     })
     result.push({
       debugInfo: {
@@ -210,18 +230,27 @@ function getLabwareStackAsArray(
       return null
     }
     const slotPosition = coordinateTupleToVector3D(slotPositionTuple)
+    const slotPositionToLabwareOrigin = getModuleParentOriginToLabwareOrigin(
+      deckDefinition.otId,
+      slotId,
+      moduleDefinition,
+      bottomLabware
+    )
+    // Preserving legacy misbehavior:
+    // If we're computing the position of a schema 2 labware, the labware below
+    // it don't contribute anything to its x or y offset. Only z.
+    if (bottomLabware !== topLabware && topLabware.schemaVersion === 2) {
+      slotPositionToLabwareOrigin.x = 0
+      slotPositionToLabwareOrigin.y = 0
+    }
+
     result.push({
       debugInfo: {
         type: 'labwareOnModule',
         parentModuleDefinition: moduleDefinition,
         childLabwareDefinition: bottomLabware,
       },
-      offset: getModuleParentOriginToLabwareOrigin(
-        deckDefinition.otId,
-        slotId,
-        moduleDefinition,
-        bottomLabware
-      ),
+      offset: slotPositionToLabwareOrigin,
     })
     result.push({
       debugInfo: {
@@ -399,8 +428,11 @@ export function getLabwareOriginToLabwareOrigin(
     childDefinition.stackingOffsetWithLabware?.[
       parentDefinition.parameters.loadName
     ] ?? IDENTITY_VECTOR
-  const total = getVectorDifference(base, adjustment)
-  return total
+  return getVectorSum(base, {
+    x: adjustment.x,
+    y: adjustment.y,
+    z: -adjustment.z,
+  })
 }
 
 /**

--- a/shared-data/js/helpers/positionMath.ts
+++ b/shared-data/js/helpers/positionMath.ts
@@ -8,7 +8,6 @@ import { IDENTITY_AFFINE_TRANSFORM, multiplyMatrices } from './matrixMath'
 import { pairsFromArray } from './pairsFromArray'
 import {
   coordinateTupleToVector3D,
-  getVectorDifference,
   getVectorInverse,
   getVectorSum,
   IDENTITY_VECTOR,


### PR DESCRIPTION
## Overview

Closes RQA-4637.

We're trying to unify all of our frontend labware positioning math to a single place, and we're trying to get that single place to behave just like the backend, where we're pursuing similar unification.

In my crusade to do that, I made a bad assumption about where labware ends up when it's stacked. Labware definitions define offsets relative to each other, and I thought that you could sum up all of those offsets to compute the final value. That's probably how it *ought* to work, but it isn't, actually. In fact, the intermediate labwares basically only contribute to the final z offset, not the x or y offsets. Tip racks and adapters have been relying on this, so we can't change it.

This patches the math to emulate that oddity. It's kind of kludgy, sorry.

This also cherry-picks #19431.

## Test Plan and Hands on Testing

```python
requirements = {"apiLevel": "2.23", "robotType": "Flex"}


from opentrons import protocol_api


def run(protocol: protocol_api.ProtocolContext) -> None:
    tip_rack = protocol.load_labware(
        "opentrons_flex_96_tiprack_1000ul",
        "D1",
        adapter="opentrons_flex_96_tiprack_adapter",
    )

    protocol.move_labware(tip_rack, "D2", use_gripper=False)
```

## Review notes

This patch is sufficient to solve the specific problem called out by RQA-4637, but it doesn't cover all historical oddities. For example, there remains strangeness with `cornerOffsetFromSlot` that this code isn't (yet) correctly emulating.

## Risk assessment

Medium. We don't have good automated test coverage of this yet. (My fault, sorry.) However, it’s also only used by these animated deck maps, so far.