### PR TITLE
feat(step-generation): add lid_namespace and lid_version to loadLabware

### DIFF
--- a/step-generation/src/__tests__/pythonFileUtils.test.ts
+++ b/step-generation/src/__tests__/pythonFileUtils.test.ts
@@ -189,7 +189,7 @@ const labwareRobotState: TimelineFrame['labware'] = {
   //  labware on a slot
   [labwareId5]: { stack: [labwareId5, 'C2'] },
   // lid on labware
-  [labwareId6]: { stack: [labwareId6, labwareId3, labwareId2, 'B2'] },
+  [labwareId6]: { stack: [labwareId6, labwareId4, moduleId3, 'A2'] },
 }
 
 const mockLabwareNicknames: Record<string, string> = {
@@ -335,13 +335,15 @@ well_plate_1 = adapter_2.load_labware(
     "fixture_96_plate",
     label="reagent plate",
     namespace="opentrons",
-    lid="mock_lid",
     version=1,
 )
 well_plate_2 = magnetic_block_2.load_labware(
     "fixture_96_plate",
     namespace="opentrons",
     version=1,
+    lid="mock_lid",
+    lid_namespace="opentrons",
+    lid_version=1,
 )
 well_plate_3 = protocol.load_labware_from_definition(
     CUSTOM_LABWARE["fixture/fixture_96_plate/1"],

--- a/step-generation/src/utils/pythonFileUtils.ts
+++ b/step-generation/src/utils/pythonFileUtils.ts
@@ -24,7 +24,12 @@ import {
   PROTOCOL_CONTEXT_NAME,
 } from './pythonFormat'
 
-import type { CutoutId, ProtocolFile, RobotType } from '@opentrons/shared-data'
+import type {
+  CutoutId,
+  LabwareDefinition2,
+  ProtocolFile,
+  RobotType,
+} from '@opentrons/shared-data'
 import type {
   ChangeTipOptions,
   InvariantContext,
@@ -246,6 +251,15 @@ export const getLoadLidStacks = (
   return pythonLidStacks ? `# Load Lid Stacks:\n${pythonLidStacks}` : ''
 }
 
+const getFormatLidParams = (def: LabwareDefinition2): string[] => {
+  const { parameters, namespace, version } = def
+  return [
+    `lid=${formatPyStr(parameters.loadName)}`,
+    `lid_namespace=${formatPyStr(namespace)}`,
+    `lid_version=${version}`,
+  ]
+}
+
 export function getLoadLabware(
   moduleEntities: ModuleEntities,
   allLabwareEntities: LabwareEntities,
@@ -300,10 +314,8 @@ export function getLoadLabware(
           ...(locationArg ? [locationArg] : []),
           ...(labelArg ? [labelArg] : []),
           `namespace=${formatPyStr(namespace)}`,
-          ...(lidEntity != null
-            ? [`lid=${formatPyStr(lidEntity.def.parameters.loadName)}`]
-            : []),
           `version=${version}`,
+          ...(lidEntity != null ? getFormatLidParams(lidEntity.def) : []),
         ].join(',\n')
         return [
           ...acc,


### PR DESCRIPTION
closes AUTH-2224

# Overview

NOTE: review the api version bump [pr](https://github.com/Opentrons/opentrons/pull/19471) first, because you can't test this otherwise (unless you manually increase the version) 

This PR wires up the lid namespace and lid version args when generating the load labware api command when there is a lid loading on the labware

## Test Plan and Hands on Testing

Create a protocol with a lid on the labware. export and see the new args and it should pass analysis.

## Changelog

extend args and make a util
add to test

## Risk assessment

low