### PR TITLE
feat(step-generation): bump to 2.26 api version for emitted protocols

### DIFF
--- a/protocol-designer/src/file-data/__tests__/createFile.test.ts
+++ b/protocol-designer/src/file-data/__tests__/createFile.test.ts
@@ -152,7 +152,7 @@ metadata = {
     "source": "Protocol Designer",
 }
 
-requirements = {"robotType": "OT-2", "apiLevel": "2.25"}
+requirements = {"robotType": "OT-2", "apiLevel": "2.26"}
 
 def run(protocol: protocol_api.ProtocolContext) -> None:
     # Load Labware:

--- a/step-generation/src/__tests__/pythonFileUtils.test.ts
+++ b/step-generation/src/__tests__/pythonFileUtils.test.ts
@@ -93,11 +93,11 @@ metadata = {
 describe('pythonRequirements', () => {
   it('should generate requirements section', () => {
     expect(pythonRequirements(OT2_ROBOT_TYPE)).toBe(
-      `requirements = {"robotType": "OT-2", "apiLevel": "2.25"}`
+      `requirements = {"robotType": "OT-2", "apiLevel": "2.26"}`
     )
 
     expect(pythonRequirements(FLEX_ROBOT_TYPE)).toBe(
-      `requirements = {"robotType": "Flex", "apiLevel": "2.25"}`
+      `requirements = {"robotType": "Flex", "apiLevel": "2.26"}`
     )
   })
 })

--- a/step-generation/src/utils/pythonFileUtils.ts
+++ b/step-generation/src/utils/pythonFileUtils.ts
@@ -40,7 +40,7 @@ import type {
   WasteChuteEntities,
 } from '../types'
 
-const PAPI_VERSION = '2.25' // latest version from api/src/opentrons/protocols/api_support/definitions.py
+const PAPI_VERSION = '2.26' // latest version from api/src/opentrons/protocols/api_support/definitions.py
 export const PD_APPLICATION_VERSION = '8.6.0' // latest PD version to insert into DESIGNER_APPLICATION blob
 
 export function pythonImports(): string {


### PR DESCRIPTION
# Overview

Needed an api version bump to 2.26 for emitted protocols because the `lid_namespace` and `lid_version` args require API version 2.26

## Test Plan and Hands on Testing

test importing a protocol into the app and it should work and the api version should be 2.26

## Changelog

bump version number

## Risk assessment

low