### PR TITLE
chore(api): fix module test shutdown issues

### DIFF
--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -1312,9 +1312,10 @@ class API(
             self.is_simulator
         ), "Cannot build simulating module from non-simulating hardware control API"
 
-        return await self._backend.module_controls.build_module(
-            port="",
-            usb_port=USBPort(name="", port_number=1, port_group=PortGroup.MAIN),
+        return await self._backend.module_controls.register_simulated_module(
+            simulated_usb_port=USBPort(
+                name="", port_number=1, port_group=PortGroup.MAIN
+            ),
             type=modules.ModuleType.from_model(model),
             sim_model=model.value,
         )

--- a/api/src/opentrons/hardware_control/backends/controller.py
+++ b/api/src/opentrons/hardware_control/backends/controller.py
@@ -368,7 +368,11 @@ class Controller:
         if hasattr(self, "_module_controls") and self._module_controls is not None:
             await self._module_controls.clean_up()
         if hasattr(self, "_event_watcher"):
-            if loop.is_running() and self._event_watcher:
+            if (
+                loop.is_running()
+                and self._event_watcher
+                and not self._event_watcher.closed
+            ):
                 self._event_watcher.close()
         if hasattr(self, "gpio_chardev"):
             try:

--- a/api/src/opentrons/hardware_control/backends/controller.py
+++ b/api/src/opentrons/hardware_control/backends/controller.py
@@ -360,11 +360,13 @@ class Controller:
         """Run a probe and return the new position dict"""
         return await self._smoothie_driver.probe_axis(axis, distance)
 
-    async def clean_up(self) -> None:
+    async def clean_up(self) -> None:  # noqa: C901
         try:
             loop = asyncio.get_event_loop()
         except RuntimeError:
             return
+        if hasattr(self, "_module_controls") and self._module_controls is not None:
+            await self._module_controls.clean_up()
         if hasattr(self, "_event_watcher"):
             if loop.is_running() and self._event_watcher:
                 self._event_watcher.close()

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -686,9 +686,9 @@ class OT3Controller(FlexBackend):
         return (
             MoveGroupRunner(
                 move_groups=[move_group],
-                ignore_stalls=True
-                if not self._feature_flags.stall_detection_enabled
-                else False,
+                ignore_stalls=(
+                    True if not self._feature_flags.stall_detection_enabled else False
+                ),
             ),
             False,
         )
@@ -712,9 +712,9 @@ class OT3Controller(FlexBackend):
         return (
             MoveGroupRunner(
                 move_groups=[tip_motor_move_group],
-                ignore_stalls=True
-                if not self._feature_flags.stall_detection_enabled
-                else False,
+                ignore_stalls=(
+                    True if not self._feature_flags.stall_detection_enabled else False
+                ),
             ),
             True,
         )
@@ -939,9 +939,9 @@ class OT3Controller(FlexBackend):
 
         runner = MoveGroupRunner(
             move_groups=[move_group],
-            ignore_stalls=True
-            if not self._feature_flags.stall_detection_enabled
-            else False,
+            ignore_stalls=(
+                True if not self._feature_flags.stall_detection_enabled else False
+            ),
         )
         try:
             positions = await runner.run(can_messenger=self._messenger)
@@ -976,9 +976,9 @@ class OT3Controller(FlexBackend):
         move_group = self._build_tip_action_group(origin, targets)
         runner = MoveGroupRunner(
             move_groups=[move_group],
-            ignore_stalls=True
-            if not self._feature_flags.stall_detection_enabled
-            else False,
+            ignore_stalls=(
+                True if not self._feature_flags.stall_detection_enabled else False
+            ),
         )
         try:
             positions = await runner.run(can_messenger=self._messenger)
@@ -1397,6 +1397,9 @@ class OT3Controller(FlexBackend):
             loop = asyncio.get_event_loop()
         except RuntimeError:
             return
+
+        if hasattr(self, "_module_controls") and self._module_controls is not None:
+            await self._module_controls.clean_up()
 
         if hasattr(self, "_event_watcher"):
             if (

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -728,7 +728,8 @@ class OT3Simulator(FlexBackend):
     @ensure_yield
     async def clean_up(self) -> None:
         """Clean up."""
-        pass
+        if hasattr(self, "_module_controls") and self._module_controls is not None:
+            await self._module_controls.clean_up()
 
     @staticmethod
     def _get_home_position() -> Dict[Axis, float]:

--- a/api/src/opentrons/hardware_control/backends/simulator.py
+++ b/api/src/opentrons/hardware_control/backends/simulator.py
@@ -414,7 +414,8 @@ class Simulator:
 
     @ensure_yield
     async def clean_up(self) -> None:
-        pass
+        if hasattr(self, "_module_controls") and self._module_controls is not None:
+            await self._module_controls.clean_up()
 
     @ensure_yield
     async def configure_mount(

--- a/api/src/opentrons/hardware_control/module_control.py
+++ b/api/src/opentrons/hardware_control/module_control.py
@@ -55,6 +55,15 @@ class AttachedModulesControl:
         self._available_modules: List[modules.AbstractModule] = []
         self._api = api
         self._usb = usb
+        if not IS_ROBOT and not api.is_simulator:
+            # Start task that registers emulated modules.
+            self._emulation_listen_task: asyncio.Task[
+                None
+            ] | None = api.loop.create_task(
+                listen_module_connection(self.register_modules)
+            )
+        else:
+            self._emulation_listen_task = None
 
     def subscribe_to_api_event(self, module: modules.AbstractModule) -> None:
         self._api.add_status_bar_listener(module.event_listener)
@@ -75,17 +84,43 @@ class AttachedModulesControl:
         if not api_instance.is_simulator:
             # Do an initial scan of modules.
             await mc_instance.register_modules(mc_instance.scan())
-            if not IS_ROBOT:
-                # Start task that registers emulated modules.
-                api_instance.loop.create_task(
-                    listen_module_connection(mc_instance.register_modules)
-                )
 
         return mc_instance
 
     @property
     def available_modules(self) -> List[modules.AbstractModule]:
         return self._available_modules
+
+    async def clean_up(self) -> None:
+        """Clean up all registered modules and emulator scanning tasks (if any)."""
+        for module in self._available_modules:
+            await module.cleanup()
+        if self._emulation_listen_task is not None:
+            self._emulation_listen_task.cancel("cleanup")
+            try:
+                await self._emulation_listen_task
+            except asyncio.CancelledError:
+                pass
+            except Exception:
+                log.exception("Exception cleaning up emulation listen task")
+            finally:
+                self._emulation_listen_task = None
+
+    async def register_simulated_module(
+        self,
+        simulated_usb_port: types.USBPort,
+        type: modules.ModuleType,
+        sim_model: str,
+    ) -> modules.AbstractModule:
+        """Register a simulated module."""
+        module = await self.build_module(
+            "", simulated_usb_port, type, sim_model, sim_serial_number=None
+        )
+        self._available_modules.append(module)
+        self._available_modules = sorted(
+            self._available_modules, key=modules.AbstractModule.sort_key
+        )
+        return module
 
     async def build_module(
         self,

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -627,9 +627,10 @@ class OT3API(
             self.is_simulator
         ), "Cannot build simulating module from non-simulating hardware control API"
 
-        return await self._backend.module_controls.build_module(
-            port="",
-            usb_port=USBPort(name="", port_number=1, port_group=PortGroup.LEFT),
+        return await self._backend.module_controls.register_simulated_module(
+            simulated_usb_port=USBPort(
+                name="", port_number=1, port_group=PortGroup.LEFT
+            ),
             type=modules.ModuleType.from_model(model),
             sim_model=model.value,
         )

--- a/api/src/opentrons/hardware_control/thread_manager.py
+++ b/api/src/opentrons/hardware_control/thread_manager.py
@@ -1,5 +1,4 @@
 """Manager for the :py:class:`.hardware_control.API` thread."""
-
 import functools
 import threading
 import logging

--- a/api/src/opentrons/hardware_control/thread_manager.py
+++ b/api/src/opentrons/hardware_control/thread_manager.py
@@ -1,4 +1,5 @@
 """Manager for the :py:class:`.hardware_control.API` thread."""
+
 import functools
 import threading
 import logging

--- a/api/src/opentrons/protocol_runner/__init__.py
+++ b/api/src/opentrons/protocol_runner/__init__.py
@@ -3,6 +3,7 @@
 The main export of this module is the AbstractRunner class. See
 protocol_runner.py for more details.
 """
+
 from .protocol_runner import (
     AbstractRunner,
     RunResult,
@@ -13,6 +14,10 @@ from .protocol_runner import (
     AnyRunner,
 )
 from .run_orchestrator import RunOrchestrator
+from .create_simulating_orchestrator import (
+    SimulatingRunOrchestrator,
+    create_simulating_orchestrator,
+)
 
 __all__ = [
     "AbstractRunner",
@@ -23,4 +28,6 @@ __all__ = [
     "LiveRunner",
     "AnyRunner",
     "RunOrchestrator",
+    "SimulatingRunOrchestrator",
+    "create_simulating_orchestrator",
 ]

--- a/api/src/opentrons/protocol_runner/__init__.py
+++ b/api/src/opentrons/protocol_runner/__init__.py
@@ -14,10 +14,6 @@ from .protocol_runner import (
     AnyRunner,
 )
 from .run_orchestrator import RunOrchestrator
-from .create_simulating_orchestrator import (
-    SimulatingRunOrchestrator,
-    create_simulating_orchestrator,
-)
 
 __all__ = [
     "AbstractRunner",
@@ -28,6 +24,4 @@ __all__ = [
     "LiveRunner",
     "AnyRunner",
     "RunOrchestrator",
-    "SimulatingRunOrchestrator",
-    "create_simulating_orchestrator",
 ]

--- a/api/src/opentrons/protocol_runner/__init__.py
+++ b/api/src/opentrons/protocol_runner/__init__.py
@@ -3,7 +3,6 @@
 The main export of this module is the AbstractRunner class. See
 protocol_runner.py for more details.
 """
-
 from .protocol_runner import (
     AbstractRunner,
     RunResult,

--- a/api/src/opentrons/protocol_runner/create_simulating_orchestrator.py
+++ b/api/src/opentrons/protocol_runner/create_simulating_orchestrator.py
@@ -16,11 +16,38 @@ from opentrons_shared_data.robot.types import RobotType
 from .python_protocol_wrappers import SimulatingContextCreator
 from .run_orchestrator import RunOrchestrator
 from .protocol_runner import create_protocol_runner, LiveRunner
+from ..protocol_engine.types import (
+    PostRunHardwareState,
+)
+
+
+class SimulatingRunOrchestrator(RunOrchestrator):
+    """A RunOrchestrator that cleans up its simulating hardware controller.
+
+    This should only be created and returned by create_simulating_orchestrator, unless
+    you are sure it's appropriate to clean up the hardware controller.
+    """
+
+    async def finish(
+        self,
+        error: Exception | None = None,
+        drop_tips_after_run: bool = True,
+        set_run_status: bool = True,
+        post_run_hardware_state: PostRunHardwareState = PostRunHardwareState.HOME_AND_STAY_ENGAGED,
+    ) -> None:
+        """Finish the run and clean up the simulating hardware controller."""
+        await super().finish(
+            error=error,
+            drop_tips_after_run=drop_tips_after_run,
+            set_run_status=set_run_status,
+            post_run_hardware_state=post_run_hardware_state,
+        )
+        await self._hardware_api.clean_up()
 
 
 async def create_simulating_orchestrator(
     robot_type: RobotType, protocol_config: ProtocolConfig
-) -> RunOrchestrator:
+) -> SimulatingRunOrchestrator:
     """Create a RunOrchestrator wired to a simulating HardwareControlAPI.
 
     Example:
@@ -96,7 +123,7 @@ async def create_simulating_orchestrator(
         hardware_api=simulating_hardware_api,
     )
 
-    return RunOrchestrator(
+    return SimulatingRunOrchestrator(
         hardware_api=simulating_hardware_api,
         json_or_python_protocol_runner=runner,
         protocol_engine=protocol_engine,

--- a/api/src/opentrons/protocol_runner/run_orchestrator.py
+++ b/api/src/opentrons/protocol_runner/run_orchestrator.py
@@ -85,7 +85,6 @@ class RunOrchestrator:
     def __init__(
         self,
         protocol_engine: ProtocolEngine,
-        # todo(mm, 2024-07-05): This hardware_api param looks unused?
         hardware_api: HardwareControlAPI,
         fixit_runner: protocol_runner.LiveRunner,
         setup_runner: protocol_runner.LiveRunner,
@@ -115,6 +114,8 @@ class RunOrchestrator:
         self._fixit_runner.prepare()
         self._setup_runner.prepare()
         self._protocol_engine.set_and_start_queue_worker(self.command_generator)
+        # used by SimulatingRunOrchestrator to clean up the simulating hardware controller
+        self._hardware_api = hardware_api
 
     @property
     def run_id(self) -> str:

--- a/api/src/opentrons/simulate.py
+++ b/api/src/opentrons/simulate.py
@@ -3,6 +3,7 @@
 This module has functions that provide a console entrypoint for simulating
 a protocol from the command line.
 """
+
 import argparse
 import asyncio
 import atexit
@@ -24,6 +25,7 @@ from typing import (
     BinaryIO,
     Optional,
     Union,
+    Iterator,
 )
 from typing_extensions import Literal
 
@@ -81,6 +83,7 @@ if TYPE_CHECKING:
     from opentrons_shared_data.labware.types import (
         LabwareDefinition as LabwareDefinitionDict,
     )
+    from opentrons.protocol_engine import ProtocolEngine
 
 
 # See Jira RCORE-535.
@@ -309,6 +312,7 @@ def get_protocol_api(
             bundled_labware=bundled_labware,
             bundled_data=bundled_data,
             extra_labware=extra_labware,
+            clean_up_hardware=(hardware_simulator is None),
         )
     else:
         if bundled_labware is not None:
@@ -326,6 +330,7 @@ def get_protocol_api(
             bundled_data=bundled_data,
             extra_labware=extra_labware,
             use_pe_virtual_hardware=use_virtual_hardware,
+            clean_up_hardware=(hardware_simulator is None),
         )
 
     # Intentional difference from execute.get_protocol_api():
@@ -781,13 +786,15 @@ def _create_live_context_non_pe(
     extra_labware: Optional[Dict[str, "LabwareDefinitionDict"]],
     bundled_labware: Optional[Dict[str, "LabwareDefinitionDict"]],
     bundled_data: Optional[Dict[str, bytes]],
+    clean_up_hardware: bool,
 ) -> ProtocolContext:
     """Return a live ProtocolContext.
 
     This controls the robot through the older infrastructure, instead of through Protocol Engine.
     """
     assert api_version < ENGINE_CORE_API_VERSION
-    return protocol_api.create_protocol_context(
+
+    ctx = protocol_api.create_protocol_context(
         api_version=api_version,
         deck_type=deck_type,
         hardware_api=hardware_api,
@@ -795,6 +802,17 @@ def _create_live_context_non_pe(
         bundled_data=bundled_data,
         extra_labware=extra_labware,
     )
+    # Hack: we need to hook the protocol context cleanup in a way that isn't safe to put
+    # in the context generally, so we can do it like this and feel sad
+    original_cleanup = ctx.cleanup
+
+    def _cleanup_hook() -> None:
+        if clean_up_hardware:
+            ctx._hw_manager.hardware.clean_up()
+        original_cleanup()
+
+    ctx.cleanup = _cleanup_hook  # type: ignore[method-assign]
+    return ctx
 
 
 def _create_live_context_pe(
@@ -805,26 +823,40 @@ def _create_live_context_pe(
     extra_labware: Dict[str, "LabwareDefinitionDict"],
     bundled_data: Optional[Dict[str, bytes]],
     use_pe_virtual_hardware: bool = True,
+    clean_up_hardware: bool = True,
 ) -> ProtocolContext:
     """Return a live ProtocolContext that controls the robot through ProtocolEngine."""
     assert api_version >= ENGINE_CORE_API_VERSION
     hardware_api_wrapped = hardware_api.wrapped()
     global _LIVE_PROTOCOL_ENGINE_CONTEXTS
+
+    @contextmanager
+    def _cleanup_hardware_with_engine() -> (
+        Iterator[tuple["ProtocolEngine", asyncio.AbstractEventLoop]]
+    ):
+
+        try:
+            with create_protocol_engine_in_thread(
+                hardware_api=hardware_api_wrapped,
+                config=_get_protocol_engine_config(
+                    robot_type, use_pe_virtual_hardware=use_pe_virtual_hardware
+                ),
+                deck_configuration=None,
+                file_provider=None,
+                error_recovery_policy=error_recovery_policy.never_recover,
+                drop_tips_after_run=False,
+                post_run_hardware_state=PostRunHardwareState.STAY_ENGAGED_IN_PLACE,
+                load_fixed_trash=should_load_fixed_trash_labware_for_python_protocol(
+                    api_version
+                ),
+            ) as (engine, loop):
+                yield engine, loop
+        finally:
+            if clean_up_hardware:
+                hardware_api.clean_up()
+
     pe, loop = _LIVE_PROTOCOL_ENGINE_CONTEXTS.enter_context(
-        create_protocol_engine_in_thread(
-            hardware_api=hardware_api_wrapped,
-            config=_get_protocol_engine_config(
-                robot_type, use_pe_virtual_hardware=use_pe_virtual_hardware
-            ),
-            deck_configuration=None,
-            file_provider=None,
-            error_recovery_policy=error_recovery_policy.never_recover,
-            drop_tips_after_run=False,
-            post_run_hardware_state=PostRunHardwareState.STAY_ENGAGED_IN_PLACE,
-            load_fixed_trash=should_load_fixed_trash_labware_for_python_protocol(
-                api_version
-            ),
-        )
+        _cleanup_hardware_with_engine()
     )
 
     # `async def` so we can use loop.run_coroutine_threadsafe() to wait for its completion.
@@ -879,6 +911,7 @@ def _run_file_non_pe(
         extra_labware=extra_labware,
         bundled_labware=bundled_labware,
         bundled_data=bundled_data,
+        clean_up_hardware=False,
     )
 
     scraper = _CommandScraper(logger=logger, level=level, broker=context.broker)

--- a/api/tests/opentrons/hardware_control/integration/conftest.py
+++ b/api/tests/opentrons/hardware_control/integration/conftest.py
@@ -36,15 +36,27 @@ def emulation_app(emulator_settings: Settings) -> Iterator[None]:
         ModuleType.Thermocycler,
         ModuleType.Heatershaker,
     ]
+    in_thread_loop = asyncio.new_event_loop()
 
-    def _run_app() -> None:
-        async def _async_run() -> None:
+    def _run_app(thread_loop: asyncio.AbstractEventLoop) -> None:
+        asyncio.set_event_loop(thread_loop)
+
+        async def _main_task() -> None:
             await asyncio.gather(
                 run_smoothie.run(emulator_settings),
                 run_app.run(emulator_settings, modules=[m.value for m in modules]),
             )
 
-        asyncio.run(_async_run())
+        try:
+            thread_loop.run_until_complete(_main_task())
+        except Exception:
+            # this exception is from stopping the loop in the way that we will when
+            # the fixture closes (by just, well, stopping the loop, and then cleaning
+            # stuff up later). We can ignore it.
+            pass
+
+        thread_loop.run_until_complete(thread_loop.shutdown_asyncgens())
+        thread_loop.close()
 
     async def _wait_ready() -> None:
         c = await ModuleStatusClient.connect(
@@ -58,8 +70,9 @@ def emulation_app(emulator_settings: Settings) -> Iterator[None]:
     def _run_wait_ready() -> None:
         asyncio.run(_wait_ready())
 
+    # these threads are daemonized to make ctrl-c behavior a little better
     # Start the emulator thread.
-    t = threading.Thread(target=_run_app)
+    t = threading.Thread(target=_run_app, args=(in_thread_loop,))
     t.daemon = True
     t.start()
 
@@ -70,6 +83,8 @@ def emulation_app(emulator_settings: Settings) -> Iterator[None]:
     ready_proc.join()
 
     yield
+    in_thread_loop.call_soon_threadsafe(in_thread_loop.stop)
+    t.join()
 
 
 @pytest.fixture

--- a/api/tests/opentrons/hardware_control/integration/test_controller.py
+++ b/api/tests/opentrons/hardware_control/integration/test_controller.py
@@ -19,8 +19,11 @@ async def subject(
     assert isinstance(conf, RobotConfig)
     hc = await Controller.build(config=conf)
     await hc.connect(port=port)
-    yield hc
-    await hc._smoothie_driver.disconnect()
+    try:
+        yield hc
+    finally:
+        await hc.clean_up()
+        await hc._smoothie_driver.disconnect()
 
 
 async def test_get_fw_version(subject: Controller) -> None:

--- a/api/tests/opentrons/hardware_control/integration/test_heatershaker.py
+++ b/api/tests/opentrons/hardware_control/integration/test_heatershaker.py
@@ -25,8 +25,10 @@ async def heatershaker(
         execution_manager=execution_manager,
         poll_interval_seconds=poll_interval_seconds,
     )
-    yield module
-    await module.cleanup()
+    try:
+        yield module
+    finally:
+        await module.cleanup()
 
 
 def test_device_info(heatershaker: HeaterShaker) -> None:

--- a/api/tests/opentrons/hardware_control/integration/test_magdeck.py
+++ b/api/tests/opentrons/hardware_control/integration/test_magdeck.py
@@ -20,8 +20,10 @@ async def magdeck(
         port=emulator_settings.magdeck_proxy.driver_port,
         execution_manager=execution_manager,
     )
-    yield module
-    await module.cleanup()
+    try:
+        yield module
+    finally:
+        await module.cleanup()
 
 
 def test_device_info(magdeck: MagDeck) -> None:

--- a/api/tests/opentrons/hardware_control/integration/test_smoothie.py
+++ b/api/tests/opentrons/hardware_control/integration/test_smoothie.py
@@ -19,8 +19,10 @@ async def subject(emulator_settings: Settings) -> AsyncGenerator[SmoothieDriver,
         port=f"socket://127.0.0.1:{emulator_settings.smoothie.port}",
         config=build_config_ot2({}),
     )
-    yield d
-    await d.disconnect()
+    try:
+        yield d
+    finally:
+        await d.disconnect()
 
 
 @pytest.fixture

--- a/api/tests/opentrons/hardware_control/integration/test_tempdeck.py
+++ b/api/tests/opentrons/hardware_control/integration/test_tempdeck.py
@@ -21,8 +21,10 @@ async def tempdeck(
         execution_manager=execution_manager,
         poll_interval_seconds=poll_interval_seconds,
     )
-    yield module
-    await module.cleanup()
+    try:
+        yield module
+    finally:
+        await module.cleanup()
 
 
 def test_device_info(tempdeck: TempDeck) -> None:

--- a/api/tests/opentrons/hardware_control/integration/test_thermocycler.py
+++ b/api/tests/opentrons/hardware_control/integration/test_thermocycler.py
@@ -27,8 +27,10 @@ async def thermocycler(
         execution_manager=execution_manager,
         poll_interval_seconds=poll_interval_seconds,
     )
-    yield module
-    await module.cleanup()
+    try:
+        yield module
+    finally:
+        await module.cleanup()
 
 
 def test_device_info(thermocycler: Thermocycler) -> None:

--- a/api/tests/opentrons/protocol_runner/smoke_tests/test_legacy_command_mapper.py
+++ b/api/tests/opentrons/protocol_runner/smoke_tests/test_legacy_command_mapper.py
@@ -3,10 +3,10 @@
 Legacy ProtocolContext objects are prohibitively difficult to instansiate
 and mock in an isolated unit test environment.
 """
+
 from datetime import datetime
 from pathlib import Path
 from textwrap import dedent
-from typing import List
 
 import pytest
 from decoy import matchers
@@ -24,11 +24,12 @@ from opentrons.protocol_runner.create_simulating_orchestrator import (
     create_simulating_orchestrator,
 )
 from opentrons.protocol_runner.legacy_command_mapper import LegacyCommandParams
+from opentrons.protocol_engine.types import PostRunHardwareState
 from opentrons.types import MountType, DeckSlotName
 from opentrons_shared_data.pipette.types import PipetteNameType
 
 
-async def simulate_and_get_commands(protocol_file: Path) -> List[commands.Command]:
+async def simulate_and_get_commands(protocol_file: Path) -> list[commands.Command]:
     """Simulate a protocol, make sure it succeeds, and return its commands."""
     protocol_reader = ProtocolReader()
     protocol_source = await protocol_reader.read_saved(
@@ -41,7 +42,13 @@ async def simulate_and_get_commands(protocol_file: Path) -> List[commands.Comman
     result = await subject.run(deck_configuration=[], protocol_source=protocol_source)
     assert result.state_summary.errors == []
     assert result.state_summary.status == EngineStatus.SUCCEEDED
-    return result.commands
+    commands = [command for command in result.commands]
+    await subject.finish(
+        drop_tips_after_run=False,
+        set_run_status=False,
+        post_run_hardware_state=PostRunHardwareState.STAY_ENGAGED_IN_PLACE,
+    )
+    return commands
 
 
 # TODO(mm, 2023-01-09): Split this up into smaller, more focused tests.

--- a/api/tests/opentrons/protocol_runner/smoke_tests/test_legacy_custom_labware.py
+++ b/api/tests/opentrons/protocol_runner/smoke_tests/test_legacy_custom_labware.py
@@ -3,6 +3,7 @@
 Legacy ProtocolContext objects are prohibitively difficult to instansiate
 and mock in an isolated unit test environment.
 """
+
 import pytest
 import textwrap
 from decoy import matchers
@@ -68,3 +69,4 @@ async def test_legacy_custom_labware(custom_labware_protocol_files: List[Path]) 
 
     assert result.state_summary.errors == []
     assert expected_labware in result.state_summary.labware
+    await subject.finish()

--- a/api/tests/opentrons/protocol_runner/smoke_tests/test_legacy_module_commands.py
+++ b/api/tests/opentrons/protocol_runner/smoke_tests/test_legacy_module_commands.py
@@ -66,7 +66,8 @@ async def test_runner_with_modules_in_legacy_python(
         robot_type="OT-2 Standard", protocol_config=protocol_source.config
     )
     result = await subject.run(deck_configuration=[], protocol_source=protocol_source)
-    commands_result = result.commands
+    commands_result = [c for c in result.commands]
+    await subject.finish()
 
     assert len(commands_result) == 6
 

--- a/api/tests/opentrons/protocol_runner/smoke_tests/test_protocol_runner.py
+++ b/api/tests/opentrons/protocol_runner/smoke_tests/test_protocol_runner.py
@@ -8,6 +8,7 @@ disk into the runner, and the protocols are run to completion. From
 there, the ProtocolEngine state is inspected to check that
 everything was loaded and run as expected.
 """
+
 from datetime import datetime
 from decoy import matchers
 from pathlib import Path
@@ -108,6 +109,7 @@ async def test_runner_with_python(
     )
 
     assert expected_command in commands_result
+    await subject.finish()
 
 
 async def test_runner_with_json(json_protocol_file: Path) -> None:
@@ -170,6 +172,7 @@ async def test_runner_with_json(json_protocol_file: Path) -> None:
     )
 
     assert expected_command in commands_result
+    await subject.finish()
 
 
 async def test_runner_with_legacy_python(legacy_python_protocol_file: Path) -> None:
@@ -234,6 +237,7 @@ async def test_runner_with_legacy_python(legacy_python_protocol_file: Path) -> N
     )
 
     assert expected_command in commands_result
+    await subject.finish()
 
 
 async def test_runner_with_legacy_json(legacy_json_protocol_file: Path) -> None:
@@ -299,6 +303,7 @@ async def test_runner_with_legacy_json(legacy_json_protocol_file: Path) -> None:
     )
 
     assert expected_command in commands_result
+    await subject.finish()
 
 
 async def test_runner_with_python_and_run_time_parameters(
@@ -381,3 +386,4 @@ async def test_runner_with_python_and_run_time_parameters(
     )
 
     assert expected_command in commands_result
+    await subject.finish()

--- a/api/tests/opentrons/test_execute.py
+++ b/api/tests/opentrons/test_execute.py
@@ -6,7 +6,7 @@ import json
 import textwrap
 import mock
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Generator, List, TextIO, cast
+from typing import TYPE_CHECKING, Any, Callable, Generator, List, TextIO, cast, Iterator
 
 import pytest
 from _pytest.fixtures import SubRequest
@@ -30,6 +30,16 @@ if TYPE_CHECKING:
 
 
 HERE = Path(__file__).parent
+
+
+@pytest.fixture(autouse=True)
+def clean_up_hw() -> Iterator[None]:
+    """Make sure hardware objects are cleaned up."""
+    yield
+    execute._LIVE_PROTOCOL_ENGINE_CONTEXTS.close()
+    if execute._THREAD_MANAGED_HW is not None:
+        execute._THREAD_MANAGED_HW.clean_up()
+        execute._THREAD_MANAGED_HW = None
 
 
 @pytest.fixture(params=[APIVersion(2, 0), ENGINE_CORE_API_VERSION])

--- a/robot-server/tests/protocols/test_protocol_analyzer.py
+++ b/robot-server/tests/protocols/test_protocol_analyzer.py
@@ -1,4 +1,5 @@
 """Tests for the ProtocolAnalyzer."""
+
 import pytest
 from decoy import Decoy
 from datetime import datetime
@@ -93,7 +94,7 @@ async def test_load_orchestrator(
         analysis_store=analysis_store, protocol_resource=protocol_resource
     )
 
-    run_orchestrator = decoy.mock(cls=protocol_runner.RunOrchestrator)
+    run_orchestrator = decoy.mock(cls=protocol_runner.SimulatingRunOrchestrator)
     decoy.when(
         await simulating_runner.create_simulating_orchestrator(
             robot_type=robot_type,
@@ -167,7 +168,7 @@ async def test_analyze(
 
     command_annotation = pe_types.CustomCommandAnnotation(commandKeys=["abc", "xyz"])
 
-    orchestrator = decoy.mock(cls=protocol_runner.RunOrchestrator)
+    orchestrator = decoy.mock(cls=protocol_runner.SimulatingRunOrchestrator)
     decoy.when(
         await simulating_runner.create_simulating_orchestrator(
             robot_type=robot_type,
@@ -258,7 +259,7 @@ async def test_analyze_updates_pending_on_error(
         message="You got me!!",
     )
 
-    orchestrator = decoy.mock(cls=protocol_runner.RunOrchestrator)
+    orchestrator = decoy.mock(cls=protocol_runner.SimulatingRunOrchestrator)
     decoy.when(
         await simulating_runner.create_simulating_orchestrator(
             robot_type=robot_type,

--- a/robot-server/tests/protocols/test_protocol_analyzer.py
+++ b/robot-server/tests/protocols/test_protocol_analyzer.py
@@ -94,7 +94,7 @@ async def test_load_orchestrator(
         analysis_store=analysis_store, protocol_resource=protocol_resource
     )
 
-    run_orchestrator = decoy.mock(cls=protocol_runner.SimulatingRunOrchestrator)
+    run_orchestrator = decoy.mock(cls=simulating_runner.SimulatingRunOrchestrator)
     decoy.when(
         await simulating_runner.create_simulating_orchestrator(
             robot_type=robot_type,
@@ -168,7 +168,7 @@ async def test_analyze(
 
     command_annotation = pe_types.CustomCommandAnnotation(commandKeys=["abc", "xyz"])
 
-    orchestrator = decoy.mock(cls=protocol_runner.SimulatingRunOrchestrator)
+    orchestrator = decoy.mock(cls=simulating_runner.SimulatingRunOrchestrator)
     decoy.when(
         await simulating_runner.create_simulating_orchestrator(
             robot_type=robot_type,
@@ -259,7 +259,7 @@ async def test_analyze_updates_pending_on_error(
         message="You got me!!",
     )
 
-    orchestrator = decoy.mock(cls=protocol_runner.SimulatingRunOrchestrator)
+    orchestrator = decoy.mock(cls=simulating_runner.SimulatingRunOrchestrator)
     decoy.when(
         await simulating_runner.create_simulating_orchestrator(
             robot_type=robot_type,


### PR DESCRIPTION
There were a significant number of problems with the way we shut down things like module pollers throughout our software. These problems don't really matter to the actual robot - there, the lifetimes are long enough that we don't really care - but it meant that we would get nastygrams and leaks in tests.

This commit gets rid of all the annoying warnings about pollers failing because their executors are stopped (because they were never closed, and atexit handlers shut down the executor threads); the annoying warnings about emulator socket tasks not being awaited (because they were started automatically in certain test contexts and never closed); and even ideally fixes the flakiness of the integration tests generally.

Specifically,
- We now clean up all the module objects in the hardware controller backend object cleanups; previously these were never being cleaned up, at all
- Cleaning up a module now cleans up its poller reliably
- The task that listens for module emulators is now actually tracked, cancelled when the module controller is closed, and joined instead of leaked
- All the various tests that create various simulating hardware controllers now actually clean up those hardware controllers when they're done
- The simulating run orchestrator, as created from create_simulating_run_orchestrator, now cleans up the (largely unused) simulating hardware controller it creates

Should only matter for tests.