### PR TITLE
ci(protocol-designer): remove CloudFront invalidation of sandbox

### DIFF
--- a/.github/workflows/pd-test-build-deploy.yaml
+++ b/.github/workflows/pd-test-build-deploy.yaml
@@ -140,9 +140,6 @@ jobs:
         shell: bash
         run: |
           aws s3 sync ./dist "s3://sandbox.designer.opentrons.com/${OT_BRANCH}" --acl=public-read
-          # invalidate both sandbox.opentrons.com and www.sandbox.opentrons.com cloudfront caches
-          aws cloudfront create-invalidation --distribution-id ${{ secrets.PD_CLOUDFRONT_SANDBOX_DISTRIBUTION_ID }} --paths "/*"
-          aws cloudfront create-invalidation --distribution-id ${{ secrets.PD_CLOUDFRONT_SANDBOX_WWW_DISTRIBUTION_ID }} --paths "/*"
       - name: 'notify Sentry of prod deploy'
         if: github.ref_type == 'tag'
         uses: getsentry/action-release@v3


### PR DESCRIPTION
### Summary
This change was unintentionally left in or added without much thought. We don’t want to be running invalidations like this all the time. It was either left in the PR by mistake or added for some unrelated reason without thinking it through.

### Next Steps
- Migration to the new deployment pattern is coming soon after the Labware Library upgrade