### PR TITLE
feat(api): Publicize `opentrons.protocol_api.OffDeckType`

### DIFF
--- a/api/docs/v2/new_protocol_api.rst
+++ b/api/docs/v2/new_protocol_api.rst
@@ -132,6 +132,8 @@ Useful Types
 .. autodata:: opentrons.protocol_api.OFF_DECK
    :no-value:
 
+.. autoclass:: opentrons.protocol_api.OffDeckType
+
 Executing and Simulating Protocols
 ==================================
 

--- a/api/src/opentrons/protocol_api/__init__.py
+++ b/api/src/opentrons/protocol_api/__init__.py
@@ -33,6 +33,7 @@ from .module_contexts import (
 from .disposal_locations import TrashBin, WasteChute
 from ._liquid import Liquid, LiquidClass
 from ._types import (
+    OffDeckType,
     OFF_DECK,
     PLUNGER_BLOWOUT,
     PLUNGER_TOP,
@@ -88,6 +89,7 @@ __all__ = [
     "ROW",
     "ALL",
     # Deck location types
+    "OffDeckType",
     "OFF_DECK",
     # Pipette plunger types
     "PLUNGER_BLOWOUT",

--- a/api/src/opentrons/protocol_api/_types.py
+++ b/api/src/opentrons/protocol_api/_types.py
@@ -3,6 +3,7 @@ from typing_extensions import Final
 import enum
 
 
+# Implemented with an enum to support type narrowing via `== OFF_DECK`.
 class OffDeckType(enum.Enum):
     """The type of the :py:obj:`OFF_DECK` constant.
 

--- a/api/src/opentrons/protocol_api/_types.py
+++ b/api/src/opentrons/protocol_api/_types.py
@@ -3,8 +3,12 @@ from typing_extensions import Final
 import enum
 
 
-# TODO (tz, 5-18-23): think about a better name for it that would also work when we include staging area slots in the type.
 class OffDeckType(enum.Enum):
+    """The type of the :py:obj:`OFF_DECK` constant.
+
+    Do not use directly, except in type annotations and ``isinstance`` calls.
+    """
+
     OFF_DECK = "off-deck"
 
 


### PR DESCRIPTION
## Overview

This exposes `OffDeckType`, which is the type of the special `OFF_DECK` constant, as a public interface of the Python Protocol API. This allows protocol authors to use it in type annotations. Closes #19473 / AUTH-2261.

## Changelog

* Allow importing `OffDeckType` from `opentrons.protocol_api`.
* Include `OffDeckType` in the reference documentation.

I'm not gating anything behind `apiLevel` because `apiLevel` in general can't really control things like this, having to do with `opentrons.protocol_api` import structure. For comparison, when the `OFF_DECK` constant was introduced, we couldn't gate its import behind `apiLevel`—we could only gate its usage in versioned `ProtocolContext` methods.

## Test Plan and Hands on Testing

* [x] Rendered Sphinx docs look reasonable

And this protocol should:

* [x] Not show type-checking problems when opened in an editor
* [x] Simulate without error

```python
from opentrons.protocol_api import ProtocolContext, OffDeckType, OFF_DECK, Labware
from opentrons.types import DeckLocation


requirements = {"apiLevel": "2.24"}


def load_labware_and_liquid(
    protocol: ProtocolContext,
    labware_name: str,
    deck_position: DeckLocation | OffDeckType,
    labware_label: str,
    liquid_name: str,
    liquid_description: str,
    color: str,
    reagent_volume: float,
) -> Labware:
    """Load a plate and put liquid in it"""
    plate = protocol.load_labware(labware_name, deck_position, label=labware_label)
    reagent = protocol.define_liquid(
        name=liquid_name, description=liquid_description, display_color=color
    )
    for well in plate.wells():
        well.load_liquid(liquid=reagent, volume=reagent_volume)
    return plate


def run(protocol: ProtocolContext) -> None:
    load_labware_and_liquid(
        protocol,
        "opentrons_96_wellplate_200ul_pcr_full_skirt",
        OFF_DECK,
        "labware label",
        "liquid name",
        "liquid description",
        "#00f",
        200,
    )
```

## Review requests

I feel like there are other sentinel values in `opentrons.protocol_api` that work like this, but I couldn't find any. Let me know if you can think of some.

## Risk assessment

Low.