### PR TITLE
feat(step-generation): don't emit step description if it's blank

### DIFF
--- a/step-generation/src/utils/pythonFileUtils.ts
+++ b/step-generation/src/utils/pythonFileUtils.ts
@@ -509,7 +509,7 @@ export function getLoadWasteChute(
 }
 
 const formatDescription = (description?: string | null): string => {
-  if (description == null) {
+  if (!description) {
     return ''
   }
   return (


### PR DESCRIPTION
# Overview

Followup to PR #19440 AUTH-2193:

Before:
```
# Step 1: Heater-Shaker
# 
heater_shaker_module_1.set_target_temperature(35)
heater_shaker_module_1.open_labware_latch()
```

After:
```
# Step 1: Heater-Shaker
heater_shaker_module_1.set_target_temperature(35)
heater_shaker_module_1.open_labware_latch()
```

## Test Plan and Hands on Testing

Tried exporting a protocol with a blank step description.

## Risk assessment

Low, mostly cosmetic change.