### PR TITLE
refactor(protocol-designer): Delete dead (?) `StepDragPreview` code

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/DraggableSteps.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/DraggableSteps.tsx
@@ -154,48 +154,6 @@ export function DraggableSteps(props: DraggableStepsProps): JSX.Element | null {
           sidebarWidth={sidebarWidth}
         />
       ))}
-      <StepDragPreview sidebarWidth={sidebarWidth} />
-    </Flex>
-  )
-}
-
-interface StepDragPreviewProps {
-  sidebarWidth: number
-}
-
-function StepDragPreview({
-  sidebarWidth,
-}: StepDragPreviewProps): JSX.Element | null {
-  const [{ isDragging, itemType, item, currentOffset }] = useDrag(() => ({
-    type: DND_TYPES.STEP_ITEM,
-    collect: (monitor: DragLayerMonitor) => ({
-      currentOffset: monitor.getSourceClientOffset(),
-      isDragging: monitor.isDragging(),
-      itemType: monitor.getItemType(),
-      item: monitor.getItem() as { stepId: StepIdType },
-    }),
-  }))
-
-  const savedStepForms = useSelector(stepFormSelectors.getSavedStepForms)
-  const savedForm = item && savedStepForms[item.stepId]
-  const { stepType, stepName } = savedForm || {}
-
-  if (
-    itemType !== DND_TYPES.STEP_ITEM ||
-    !isDragging ||
-    stepType == null ||
-    currentOffset == null
-  ) {
-    return null
-  }
-
-  return (
-    <Flex cursor="grabbing" backgroundColor={COLORS.transparent}>
-      <ConnectedStepContainer
-        iconName={stepIconsByType[stepType]}
-        title={stepName || ''}
-        sidebarWidth={sidebarWidth}
-      />
     </Flex>
   )
 }

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/DraggableSteps.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/DraggableSteps.tsx
@@ -1,15 +1,11 @@
 import { useRef, useState } from 'react'
 import { useDrag, useDrop } from 'react-dnd'
 import { useTranslation } from 'react-i18next'
-import { useSelector } from 'react-redux'
 
-import { Box, COLORS, DIRECTION_COLUMN, Flex } from '@opentrons/components'
+import { Box, DIRECTION_COLUMN, Flex } from '@opentrons/components'
 
 import { DND_TYPES } from '/protocol-designer/constants'
-import { stepIconsByType } from '/protocol-designer/form-types'
-import { selectors as stepFormSelectors } from '/protocol-designer/step-forms'
 
-import { ConnectedStepContainer } from './ConnectedStepContainer'
 import { ConnectedStepInfo } from './ConnectedStepInfo'
 
 import type { Dispatch, SetStateAction } from 'react'


### PR DESCRIPTION
## Overview

This deletes a component that I think was always returning `null` (therefore, not rendering) in practice.

## Test Plan and Hands on Testing

* [x] Try interacting with the timeline and see if anything obvious is missing.
  * One problem is that you can't drag a step to the end of the timeline, but that problem was present before this change, too.

https://github.com/user-attachments/assets/bce20fa0-3d00-4eba-a422-647a0fd2a36f

## Review requests

Let me know if it seems like I'm missing anything.

Here's my understanding of why this was always returning `null`:

From some casual testing, `isDragging` was always `false`. The react-dnd docs say that `isDragging` would be true if:

> a drag operation is in progress, **and either the owner initiated the drag, or its isDragging()is defined and returns true.**

But the bold part of that statement would never have been true for this component. It could never have initiated the drag, because it starts out a returning `null`, and the user can't grab a `null`. And it doesn't define `isDragging` in the `useDrag()` [specification object](https://react-dnd.github.io/react-dnd/docs/api/use-drag#specification-object-members).

## Risk assessment

Medium?
