### PR TITLE
feat(api): cancel protocols for asynch module errors

### DIFF
--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -44,6 +44,7 @@ from .execution_manager import ExecutionManagerProvider
 from .pause_manager import PauseManager
 from .module_control import AttachedModulesControl
 from .types import (
+    AsynchronousModuleErrorNotification,
     Axis,
     CriticalPoint,
     DoorState,
@@ -51,6 +52,7 @@ from .types import (
     ErrorMessageNotification,
     HardwareEventHandler,
     HardwareAction,
+    HardwareEvent,
     MotionChecks,
     PauseType,
     StatusBarState,
@@ -167,6 +169,18 @@ class API(
             except Exception:
                 mod_log.exception("Errored during door state event callback")
 
+    def _send_module_notification(self, event: HardwareEvent) -> None:
+        if not isinstance(event, AsynchronousModuleErrorNotification):
+            return
+        mod_log.info(
+            f"Forwarding module event {event.event} for {event.module_model} {event.module_serial} at {event.port}"
+        )
+        for cb in self._callbacks:
+            try:
+                cb(event)
+            except Exception:
+                mod_log.exception("Errored during module asynchronous callback")
+
     def _reset_last_mount(self) -> None:
         self._last_moved_mount = None
 
@@ -247,7 +261,9 @@ class API(
             )
             await api_instance.cache_instruments()
             module_controls = await AttachedModulesControl.build(
-                api_instance, board_revision=backend.board_revision
+                api_instance,
+                board_revision=backend.board_revision,
+                event_callback=api_instance._send_module_notification,
             )
             backend.module_controls = module_controls
             checked_loop.create_task(backend.watch(loop=checked_loop))
@@ -306,7 +322,9 @@ class API(
         )
         await api_instance.cache_instruments()
         module_controls = await AttachedModulesControl.build(
-            api_instance, board_revision=backend.board_revision
+            api_instance,
+            board_revision=backend.board_revision,
+            event_callback=api_instance._send_module_notification,
         )
         backend.module_controls = module_controls
         await backend.watch()

--- a/api/src/opentrons/hardware_control/module_control.py
+++ b/api/src/opentrons/hardware_control/module_control.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
-from typing import TYPE_CHECKING, List, Optional, Union
+from typing import TYPE_CHECKING, List, Optional, Union, Callable
 from glob import glob
+
+from opentrons_shared_data.errors.exceptions import EnumeratedError
 
 from opentrons.config import IS_ROBOT, IS_LINUX
 from opentrons.drivers.rpi_drivers import types, interfaces, usb, usb_simulator
@@ -19,8 +21,16 @@ from opentrons.hardware_control.modules.module_calibration import (
 from opentrons.hardware_control.modules.types import ModuleAtPort, ModuleType
 from opentrons.hardware_control.modules import SimulatingModuleAtPort
 
+
 from opentrons.types import Point
-from .types import AionotifyEvent, BoardRevision, OT3Mount, StatusBarUpdateEvent
+from .types import (
+    AionotifyEvent,
+    BoardRevision,
+    OT3Mount,
+    StatusBarUpdateEvent,
+    HardwareEvent,
+    AsynchronousModuleErrorNotification,
+)
 from . import modules
 
 if TYPE_CHECKING:
@@ -51,10 +61,12 @@ class AttachedModulesControl:
         self,
         api: Union["API", "OT3API"],
         usb: interfaces.USBDriverInterface,
+        event_callback: Callable[[HardwareEvent], None],
     ) -> None:
         self._available_modules: List[modules.AbstractModule] = []
         self._api = api
         self._usb = usb
+        self._event_callback = event_callback
         if not IS_ROBOT and not api.is_simulator:
             # Start task that registers emulated modules.
             self._emulation_listen_task: asyncio.Task[
@@ -73,13 +85,16 @@ class AttachedModulesControl:
         cls,
         api_instance: Union["API", "OT3API"],
         board_revision: BoardRevision,
+        event_callback: Callable[[HardwareEvent], None],
     ) -> AttachedModulesControl:
         usb_instance = (
             usb.USBBus(board_revision)
             if not api_instance.is_simulator and IS_ROBOT
             else usb_simulator.USBBusSimulator()
         )
-        mc_instance = cls(api=api_instance, usb=usb_instance)
+        mc_instance = cls(
+            api=api_instance, usb=usb_instance, event_callback=event_callback
+        )
 
         if not api_instance.is_simulator:
             # Do an initial scan of modules.
@@ -140,6 +155,7 @@ class AttachedModulesControl:
             sim_model=sim_model,
             sim_serial_number=sim_serial_number,
             disconnected_callback=self._disconnected_callback,
+            error_callback=self._async_error_callback,
         )
         last_event = StatusBarUpdateEvent(
             self._api.get_status_bar_state(), self._api.get_status_bar_enabled()
@@ -155,6 +171,29 @@ class AttachedModulesControl:
             self.unregister_modules([mod]),
             self._api.loop,
         )
+
+    def _async_error_callback(
+        self,
+        exc: Exception,
+        model: str,
+        port: str,
+        serial: str | None,
+    ) -> None:
+        """Used by the module to indicate it saw an error from its data poller."""
+        try:
+            self._api.loop.call_soon(
+                self._event_callback,
+                AsynchronousModuleErrorNotification(
+                    exception=EnumeratedError.ensure(exc),
+                    module_serial=serial,
+                    module_model=modules.module_model_from_string(model),
+                    port=port,
+                ),
+            )
+        except Exception:
+            log.exception(
+                f"Async error callback for module {model} {serial} at {port} for exc {exc} failed"
+            )
 
     async def unregister_modules(
         self,

--- a/api/src/opentrons/hardware_control/modules/__init__.py
+++ b/api/src/opentrons/hardware_control/modules/__init__.py
@@ -27,7 +27,9 @@ from .types import (
     LiveData,
     ModuleData,
     ModuleDataValidator,
+    module_model_from_string,
 )
+
 from .errors import (
     UpdateError,
     AbsorbanceReaderDisconnectedError,
@@ -66,4 +68,5 @@ __all__ = [
     "FlexStackerStatus",
     "PlatformState",
     "StackerAxisState",
+    "module_model_from_string",
 ]

--- a/api/src/opentrons/hardware_control/modules/absorbance_reader.py
+++ b/api/src/opentrons/hardware_control/modules/absorbance_reader.py
@@ -21,6 +21,7 @@ from opentrons.hardware_control.poller import Poller, Reader
 from opentrons.hardware_control.modules import mod_abc
 from opentrons.hardware_control.modules.types import (
     ModuleDisconnectedCallback,
+    ModuleErrorCallback,
     ModuleType,
     AbsorbanceReaderStatus,
     LiveData,
@@ -104,12 +105,13 @@ class AbsorbanceReader(mod_abc.AbstractModule):
         port: str,
         usb_port: USBPort,
         hw_control_loop: asyncio.AbstractEventLoop,
-        execution_manager: Optional[ExecutionManager] = None,
+        execution_manager: ExecutionManager,
+        disconnected_callback: ModuleDisconnectedCallback,
+        error_callback: ModuleErrorCallback,
         poll_interval_seconds: Optional[float] = None,
         simulating: bool = False,
         sim_model: Optional[str] = None,
         sim_serial_number: Optional[str] = None,
-        disconnected_callback: ModuleDisconnectedCallback = None,
     ) -> "AbsorbanceReader":
         """
         Build and connect to an AbsorbanceReader
@@ -152,6 +154,7 @@ class AbsorbanceReader(mod_abc.AbstractModule):
             hw_control_loop=hw_control_loop,
             execution_manager=execution_manager,
             disconnected_callback=disconnected_callback,
+            error_callback=error_callback,
         )
 
         try:
@@ -170,8 +173,9 @@ class AbsorbanceReader(mod_abc.AbstractModule):
         poller: Poller,
         device_info: Mapping[str, str],
         hw_control_loop: asyncio.AbstractEventLoop,
-        execution_manager: Optional[ExecutionManager] = None,
-        disconnected_callback: ModuleDisconnectedCallback = None,
+        execution_manager: ExecutionManager,
+        disconnected_callback: ModuleDisconnectedCallback,
+        error_callback: ModuleErrorCallback,
     ) -> None:
         """
         Constructor
@@ -193,6 +197,7 @@ class AbsorbanceReader(mod_abc.AbstractModule):
             hw_control_loop=hw_control_loop,
             execution_manager=execution_manager,
             disconnected_callback=disconnected_callback,
+            error_callback=error_callback,
         )
         self._device_info = device_info
         self._reader = reader
@@ -371,3 +376,5 @@ class AbsorbanceReader(mod_abc.AbstractModule):
         self._error = str(error)
         if isinstance(error, AbsorbanceReaderDisconnectedError):
             self.disconnected_callback()
+        else:
+            self.error_callback(error)

--- a/api/src/opentrons/hardware_control/modules/flex_stacker.py
+++ b/api/src/opentrons/hardware_control/modules/flex_stacker.py
@@ -44,6 +44,7 @@ from opentrons.hardware_control.modules.types import (
     FlexStackerStatus,
     HopperDoorState,
     LatchState,
+    ModuleErrorCallback,
     ModuleDisconnectedCallback,
     ModuleType,
     PlatformState,
@@ -215,12 +216,13 @@ class FlexStacker(mod_abc.AbstractModule):
         port: str,
         usb_port: USBPort,
         hw_control_loop: asyncio.AbstractEventLoop,
-        execution_manager: Optional[ExecutionManager] = None,
-        poll_interval_seconds: Optional[float] = None,
+        execution_manager: ExecutionManager,
+        disconnected_callback: ModuleDisconnectedCallback,
+        error_callback: ModuleErrorCallback,
+        poll_interval_seconds: float | None = None,
         simulating: bool = False,
         sim_model: Optional[str] = None,
         sim_serial_number: Optional[str] = None,
-        disconnected_callback: ModuleDisconnectedCallback = None,
     ) -> "FlexStacker":
         """
         Build a FlexStacker
@@ -259,10 +261,8 @@ class FlexStacker(mod_abc.AbstractModule):
             hw_control_loop=hw_control_loop,
             execution_manager=execution_manager,
             disconnected_callback=disconnected_callback,
+            error_callback=error_callback,
         )
-
-        # Set initialized callback
-        reader.set_initialized_callback(module._initialized_callback)
 
         # Enable stallguard
         for axis, config in STALLGUARD_CONFIG.items():
@@ -286,8 +286,9 @@ class FlexStacker(mod_abc.AbstractModule):
         poller: Poller,
         device_info: Mapping[str, str],
         hw_control_loop: asyncio.AbstractEventLoop,
-        execution_manager: Optional[ExecutionManager] = None,
-        disconnected_callback: ModuleDisconnectedCallback = None,
+        execution_manager: ExecutionManager,
+        disconnected_callback: ModuleDisconnectedCallback,
+        error_callback: ModuleErrorCallback,
     ):
         super().__init__(
             port=port,
@@ -295,6 +296,7 @@ class FlexStacker(mod_abc.AbstractModule):
             hw_control_loop=hw_control_loop,
             execution_manager=execution_manager,
             disconnected_callback=disconnected_callback,
+            error_callback=error_callback,
         )
         self._device_info = device_info
         self._driver = driver
@@ -304,11 +306,19 @@ class FlexStacker(mod_abc.AbstractModule):
         self._stacker_status = FlexStackerStatus.IDLE
         self._last_status_bar_event: Optional[StatusBarUpdateEvent] = None
         self._should_identify = False
+        # Set initialized callback
+        self._unsubscribe_init = reader.set_initialized_callback(
+            self._initialized_callback
+        )
+        self._unsubscribe_error = reader.set_error_callback(self._async_error_callback)
 
     async def _initialized_callback(self) -> None:
         """Called by the reader once the module is initialized."""
         if self._last_status_bar_event:
             await self._handle_status_bar_event(self._last_status_bar_event)
+
+    def _async_error_callback(self, exception: Exception) -> None:
+        self.error_callback(exception)
 
     async def cleanup(self) -> None:
         """Stop the poller task"""
@@ -864,10 +874,27 @@ class FlexStackerReader(Reader):
         self.installation_detected = False
         self._refresh_state = False
         self._initialized_callback: Optional[Callable[[], Awaitable[None]]] = None
+        self._error_callback: Optional[Callable[[Exception], None]] = None
 
-    def set_initialized_callback(self, callback: Callable[[], Awaitable[None]]) -> None:
+    def set_initialized_callback(
+        self, callback: Callable[[], Awaitable[None]]
+    ) -> Callable[[], None]:
         """Sets the callback used when done initializing the module."""
         self._initialized_callback = callback
+        return self._remove_init_callback
+
+    def _remove_init_callback(self) -> None:
+        self._initialized_callback = None
+
+    def set_error_callback(
+        self, error_callback: Callable[[Exception], None]
+    ) -> Callable[[], None]:
+        """Register a handler for asynchronous hardware errors."""
+        self._error_callback = error_callback
+        return self._remove_error_callback
+
+    def _remove_error_callback(self) -> None:
+        self._error_callback = None
 
     async def read(self) -> None:
         await self.get_door_closed()
@@ -942,6 +969,8 @@ class FlexStackerReader(Reader):
         if exception is None:
             self.error = None
         else:
+            if self._error_callback:
+                self._error_callback(exception)
             try:
                 self.error = str(exception.args[0])
             except Exception:

--- a/api/src/opentrons/hardware_control/modules/heater_shaker.py
+++ b/api/src/opentrons/hardware_control/modules/heater_shaker.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Optional, Mapping
+from typing import Optional, Mapping, Callable
 from typing_extensions import Final
 
 from opentrons.drivers.rpi_drivers.types import USBPort
@@ -15,6 +15,7 @@ from opentrons.hardware_control.poller import Reader, Poller
 from opentrons.hardware_control.modules import mod_abc, update
 from opentrons.hardware_control.modules.types import (
     ModuleDisconnectedCallback,
+    ModuleErrorCallback,
     ModuleType,
     TemperatureStatus,
     SpeedStatus,
@@ -47,12 +48,13 @@ class HeaterShaker(mod_abc.AbstractModule):
         port: str,
         usb_port: USBPort,
         hw_control_loop: asyncio.AbstractEventLoop,
-        execution_manager: Optional[ExecutionManager] = None,
+        execution_manager: ExecutionManager,
+        disconnected_callback: ModuleDisconnectedCallback,
+        error_callback: ModuleErrorCallback,
         poll_interval_seconds: Optional[float] = None,
         simulating: bool = False,
         sim_model: Optional[str] = None,
         sim_serial_number: Optional[str] = None,
-        disconnected_callback: ModuleDisconnectedCallback = None,
     ) -> "HeaterShaker":
         """
         Build a HeaterShaker
@@ -67,6 +69,7 @@ class HeaterShaker(mod_abc.AbstractModule):
             loop: Loop
             sim_model: The model name used by simulator
             disconnected_callback: Callback to inform the module controller that the device was disconnected
+            error_callback: Callback to inform the module controller of an asynchronous error
 
         Returns:
             HeaterShaker instance
@@ -91,6 +94,7 @@ class HeaterShaker(mod_abc.AbstractModule):
             hw_control_loop=hw_control_loop,
             execution_manager=execution_manager,
             disconnected_callback=disconnected_callback,
+            error_callback=error_callback,
         )
 
         try:
@@ -109,8 +113,9 @@ class HeaterShaker(mod_abc.AbstractModule):
         poller: Poller,
         device_info: Mapping[str, str],
         hw_control_loop: asyncio.AbstractEventLoop,
-        execution_manager: Optional[ExecutionManager] = None,
-        disconnected_callback: ModuleDisconnectedCallback = None,
+        execution_manager: ExecutionManager,
+        disconnected_callback: ModuleDisconnectedCallback,
+        error_callback: ModuleErrorCallback,
     ):
         super().__init__(
             port=port,
@@ -118,14 +123,22 @@ class HeaterShaker(mod_abc.AbstractModule):
             hw_control_loop=hw_control_loop,
             execution_manager=execution_manager,
             disconnected_callback=disconnected_callback,
+            error_callback=error_callback,
         )
         self._device_info = device_info
         self._driver = driver
         self._reader = reader
         self._poller = poller
+        self._unsubscribe_reader = self._reader.register_error_handler(
+            self._handle_error
+        )
+
+    def _handle_error(self, error: Exception) -> None:
+        self.error_callback(error)
 
     async def cleanup(self) -> None:
         """Stop the poller task"""
+        self._unsubscribe_reader()
         await self._poller.stop()
         await self._driver.disconnect()
 
@@ -397,6 +410,16 @@ class HeaterShakerReader(Reader):
         self.labware_latch = HeaterShakerLabwareLatchStatus.IDLE_UNKNOWN
         self.error: Optional[str] = None
         self._driver = driver
+        self._handle_error: Callable[[Exception], None] | None = None
+
+    def register_error_handler(
+        self, handle_error: Callable[[Exception], None]
+    ) -> Callable[[], None]:
+        self._handle_error = handle_error
+        return self._unsubscribe_error_handler
+
+    def _unsubscribe_error_handler(self) -> None:
+        self._handle_error = None
 
     async def read(self) -> None:
         await self.read_temperature()
@@ -420,6 +443,8 @@ class HeaterShakerReader(Reader):
         if exception is None:
             self.error = None
         else:
+            if self._handle_error:
+                self._handle_error(exception)
             try:
                 self.error = str(exception.args[0])
             except Exception:

--- a/api/src/opentrons/hardware_control/modules/magdeck.py
+++ b/api/src/opentrons/hardware_control/modules/magdeck.py
@@ -49,12 +49,13 @@ class MagDeck(mod_abc.AbstractModule):
         port: str,
         usb_port: USBPort,
         hw_control_loop: asyncio.AbstractEventLoop,
-        execution_manager: Optional[ExecutionManager] = None,
+        execution_manager: ExecutionManager,
+        disconnected_callback: types.ModuleDisconnectedCallback,
+        error_callback: types.ModuleErrorCallback,
         poll_interval_seconds: Optional[float] = None,
         simulating: bool = False,
         sim_model: Optional[str] = None,
         sim_serial_number: Optional[str] = None,
-        disconnected_callback: types.ModuleDisconnectedCallback = None,
     ) -> "MagDeck":
         """Factory function."""
         driver: AbstractMagDeckDriver
@@ -73,6 +74,7 @@ class MagDeck(mod_abc.AbstractModule):
             device_info=await driver.get_device_info(),
             driver=driver,
             disconnected_callback=disconnected_callback,
+            error_callback=error_callback,
         )
         return mod
 
@@ -83,8 +85,9 @@ class MagDeck(mod_abc.AbstractModule):
         hw_control_loop: asyncio.AbstractEventLoop,
         driver: AbstractMagDeckDriver,
         device_info: Dict[str, str],
-        execution_manager: Optional[ExecutionManager] = None,
-        disconnected_callback: types.ModuleDisconnectedCallback = None,
+        execution_manager: ExecutionManager,
+        disconnected_callback: types.ModuleDisconnectedCallback,
+        error_callback: types.ModuleErrorCallback,
     ) -> None:
         """Constructor"""
         super().__init__(
@@ -93,6 +96,7 @@ class MagDeck(mod_abc.AbstractModule):
             hw_control_loop=hw_control_loop,
             execution_manager=execution_manager,
             disconnected_callback=disconnected_callback,
+            error_callback=error_callback,
         )
         self._device_info = device_info
         self._driver = driver

--- a/api/src/opentrons/hardware_control/modules/mod_abc.py
+++ b/api/src/opentrons/hardware_control/modules/mod_abc.py
@@ -11,6 +11,7 @@ from ..execution_manager import ExecutionManager
 from .types import (
     BundledFirmware,
     ModuleDisconnectedCallback,
+    ModuleErrorCallback,
     UploadFunction,
     LiveData,
     ModuleType,
@@ -47,12 +48,13 @@ class AbstractModule(abc.ABC):
         port: str,
         usb_port: USBPort,
         hw_control_loop: asyncio.AbstractEventLoop,
-        execution_manager: Optional[ExecutionManager] = None,
-        poll_interval_seconds: Optional[float] = None,
+        execution_manager: ExecutionManager,
+        disconnected_callback: ModuleDisconnectedCallback,
+        error_callback: ModuleErrorCallback,
+        poll_interval_seconds: float | None = None,
         simulating: bool = False,
         sim_model: Optional[str] = None,
         sim_serial_number: Optional[str] = None,
-        disconnected_callback: ModuleDisconnectedCallback = None,
     ) -> "AbstractModule":
         """Modules should always be created using this factory.
 
@@ -65,8 +67,9 @@ class AbstractModule(abc.ABC):
         port: str,
         usb_port: USBPort,
         hw_control_loop: asyncio.AbstractEventLoop,
-        execution_manager: Optional[ExecutionManager] = None,
-        disconnected_callback: ModuleDisconnectedCallback = None,
+        execution_manager: ExecutionManager,
+        disconnected_callback: ModuleDisconnectedCallback,
+        error_callback: ModuleErrorCallback,
     ) -> None:
         self._port = port
         self._usb_port = usb_port
@@ -75,6 +78,7 @@ class AbstractModule(abc.ABC):
         self._bundled_fw: Optional[BundledFirmware] = self.get_bundled_fw()
         self._disconnected_callback = disconnected_callback
         self._updating = False
+        self._error_callback = error_callback
 
     @staticmethod
     def sort_key(inst: "AbstractModule") -> int:
@@ -102,6 +106,10 @@ class AbstractModule(abc.ABC):
         """Called from within the module object to signify the object is no longer connected"""
         if self._disconnected_callback is not None:
             self._disconnected_callback(self.port, self.serial_number)
+
+    def error_callback(self, exc: Exception) -> None:
+        """Called from within the module object when an asynchronous hardware error occurrs."""
+        self._error_callback(exc, self.model(), self.port, self.serial_number)
 
     def get_bundled_fw(self) -> Optional[BundledFirmware]:
         """Get absolute path to bundled version of module fw if available."""

--- a/api/src/opentrons/hardware_control/modules/tempdeck.py
+++ b/api/src/opentrons/hardware_control/modules/tempdeck.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Dict, Optional
+from typing import Dict, Optional, Callable
 
 from opentrons.hardware_control.modules.types import (
     ModuleDisconnectedCallback,
+    ModuleErrorCallback,
     TemperatureStatus,
 )
 from opentrons.hardware_control.poller import Reader, Poller
@@ -38,12 +39,13 @@ class TempDeck(mod_abc.AbstractModule):
         port: str,
         usb_port: USBPort,
         hw_control_loop: asyncio.AbstractEventLoop,
-        execution_manager: Optional[ExecutionManager] = None,
+        execution_manager: ExecutionManager,
+        disconnected_callback: ModuleDisconnectedCallback,
+        error_callback: ModuleErrorCallback,
         poll_interval_seconds: Optional[float] = None,
         simulating: bool = False,
         sim_model: Optional[str] = None,
         sim_serial_number: Optional[str] = None,
-        disconnected_callback: ModuleDisconnectedCallback = None,
     ) -> "TempDeck":
         """
         Build a TempDeck
@@ -83,6 +85,7 @@ class TempDeck(mod_abc.AbstractModule):
             device_info=await driver.get_device_info(),
             hw_control_loop=hw_control_loop,
             disconnected_callback=disconnected_callback,
+            error_callback=error_callback,
         )
 
         try:
@@ -101,8 +104,9 @@ class TempDeck(mod_abc.AbstractModule):
         poller: Poller,
         device_info: Dict[str, str],
         hw_control_loop: asyncio.AbstractEventLoop,
-        execution_manager: Optional[ExecutionManager] = None,
-        disconnected_callback: ModuleDisconnectedCallback = None,
+        execution_manager: ExecutionManager,
+        disconnected_callback: ModuleDisconnectedCallback,
+        error_callback: ModuleErrorCallback,
     ) -> None:
         """Constructor"""
         super().__init__(
@@ -111,11 +115,13 @@ class TempDeck(mod_abc.AbstractModule):
             hw_control_loop=hw_control_loop,
             execution_manager=execution_manager,
             disconnected_callback=disconnected_callback,
+            error_callback=error_callback,
         )
         self._device_info = device_info
         self._driver = driver
         self._reader = reader
         self._poller = poller
+        self._reader.set_error_callback(self.error_callback)
 
     async def cleanup(self) -> None:
         """Stop the poller task."""
@@ -293,7 +299,21 @@ class TempDeckReader(Reader):
     def __init__(self, driver: AbstractTempDeckDriver) -> None:
         self.temperature = Temperature(current=25, target=None)
         self._driver = driver
+        self._error_callback: Optional[Callable[[Exception], None]] = None
 
     async def read(self) -> None:
         """Read the module's current and target temperatures."""
         self.temperature = await self._driver.get_temperature()
+
+    def set_error_callback(
+        self, error_callback: Callable[[Exception], None]
+    ) -> Callable[[], None]:
+        self._error_callback = error_callback
+        return self._remove_error_callback
+
+    def _remove_error_callback(self) -> None:
+        self._error_callback = None
+
+    def on_error(self, exception: Exception) -> None:
+        if self._error_callback:
+            self._error_callback(exception)

--- a/api/src/opentrons/hardware_control/modules/thermocycler.py
+++ b/api/src/opentrons/hardware_control/modules/thermocycler.py
@@ -9,6 +9,7 @@ from opentrons.hardware_control.modules.lid_temp_status import LidTemperatureSta
 from opentrons.hardware_control.modules.plate_temp_status import PlateTemperatureStatus
 from opentrons.hardware_control.modules.types import (
     ModuleDisconnectedCallback,
+    ModuleErrorCallback,
     TemperatureStatus,
 )
 from opentrons.hardware_control.poller import Reader, Poller
@@ -62,12 +63,13 @@ class Thermocycler(mod_abc.AbstractModule):
         port: str,
         usb_port: USBPort,
         hw_control_loop: asyncio.AbstractEventLoop,
-        execution_manager: Optional[ExecutionManager] = None,
+        execution_manager: ExecutionManager,
+        disconnected_callback: ModuleDisconnectedCallback,
+        error_callback: ModuleErrorCallback,
         poll_interval_seconds: Optional[float] = None,
         simulating: bool = False,
         sim_model: Optional[str] = None,
         sim_serial_number: Optional[str] = None,
-        disconnected_callback: ModuleDisconnectedCallback = None,
     ) -> "Thermocycler":
         """
         Build and connect to a Thermocycler
@@ -108,6 +110,7 @@ class Thermocycler(mod_abc.AbstractModule):
             hw_control_loop=hw_control_loop,
             execution_manager=execution_manager,
             disconnected_callback=disconnected_callback,
+            error_callback=error_callback,
         )
 
         try:
@@ -126,8 +129,9 @@ class Thermocycler(mod_abc.AbstractModule):
         poller: Poller,
         device_info: Dict[str, str],
         hw_control_loop: asyncio.AbstractEventLoop,
-        execution_manager: Optional[ExecutionManager] = None,
-        disconnected_callback: ModuleDisconnectedCallback = None,
+        execution_manager: ExecutionManager,
+        disconnected_callback: ModuleDisconnectedCallback,
+        error_callback: ModuleErrorCallback,
     ) -> None:
         """
         Constructor
@@ -150,6 +154,7 @@ class Thermocycler(mod_abc.AbstractModule):
             hw_control_loop=hw_control_loop,
             execution_manager=execution_manager,
             disconnected_callback=disconnected_callback,
+            error_callback=error_callback,
         )
         self._device_info = device_info
         self._reader = reader
@@ -159,10 +164,13 @@ class Thermocycler(mod_abc.AbstractModule):
         self._total_step_count: Optional[int] = None
         self._current_step_index: Optional[int] = None
         self._error: Optional[str] = None
-        self._reader.register_error_handler(self._enter_error_state)
+        self._unsubscribe_reader = self._reader.register_error_handler(
+            self._enter_error_state
+        )
 
     async def cleanup(self) -> None:
         """Stop the poller task."""
+        self._unsubscribe_reader()
         await self._poller.stop()
         await self._driver.disconnect()
 
@@ -674,6 +682,7 @@ class Thermocycler(mod_abc.AbstractModule):
             f" for troubleshooting."
         )
         asyncio.run_coroutine_threadsafe(self.cleanup(), self._loop)
+        self.error_callback(error)
 
 
 class ThermocyclerReader(Reader):
@@ -711,8 +720,14 @@ class ThermocyclerReader(Reader):
         if self._handle_error is not None:
             self._handle_error(exception)
 
-    def register_error_handler(self, handle_error: Callable[[Exception], None]) -> None:
+    def register_error_handler(
+        self, handle_error: Callable[[Exception], None]
+    ) -> Callable[[], None]:
         self._handle_error = handle_error
+        return self._unsubscribe_error_handler
+
+    def _unsubscribe_error_handler(self) -> None:
+        self._handle_error = None
 
     async def read(self) -> None:
         """Poll the thermocycler."""

--- a/api/src/opentrons/hardware_control/modules/types.py
+++ b/api/src/opentrons/hardware_control/modules/types.py
@@ -11,6 +11,7 @@ from typing import (
     Awaitable,
     Union,
     Optional,
+    Protocol,
     cast,
     TYPE_CHECKING,
     TypeGuard,
@@ -54,7 +55,24 @@ class ThermocyclerCycle(TypedDict):
 UploadFunction = Callable[[str, str, Dict[str, Any]], Awaitable[Tuple[bool, str]]]
 
 
-ModuleDisconnectedCallback = Optional[Callable[[str, str | None], None]]
+class ModuleDisconnectedCallback(Protocol):
+    """Protocol for the callback when the module should be disconnected."""
+
+    def __call__(self, port: str, serial: str | None) -> None:
+        ...
+
+
+class ModuleErrorCallback(Protocol):
+    """Protocol for the callback when the module sees a hardware error."""
+
+    def __call__(
+        self,
+        exc: Exception,
+        model: str,
+        port: str,
+        serial: str | None,
+    ) -> None:
+        ...
 
 
 class MagneticModuleData(TypedDict):

--- a/api/src/opentrons/hardware_control/modules/utils.py
+++ b/api/src/opentrons/hardware_control/modules/utils.py
@@ -6,7 +6,12 @@ from opentrons.drivers.rpi_drivers.types import USBPort
 
 from ..execution_manager import ExecutionManager
 
-from .types import ModuleDisconnectedCallback, ModuleType, SpeedStatus
+from .types import (
+    ModuleDisconnectedCallback,
+    ModuleType,
+    SpeedStatus,
+    ModuleErrorCallback,
+)
 from .mod_abc import AbstractModule
 from .tempdeck import TempDeck
 from .magdeck import MagDeck
@@ -46,10 +51,11 @@ async def build(
     simulating: bool,
     usb_port: USBPort,
     hw_control_loop: asyncio.AbstractEventLoop,
-    execution_manager: Optional[ExecutionManager] = None,
+    execution_manager: ExecutionManager,
+    disconnected_callback: ModuleDisconnectedCallback,
+    error_callback: ModuleErrorCallback,
     sim_model: Optional[str] = None,
     sim_serial_number: Optional[str] = None,
-    disconnected_callback: ModuleDisconnectedCallback = None,
 ) -> AbstractModule:
     return await _MODULE_CLS_BY_TYPE[type].build(
         port=port,
@@ -57,9 +63,10 @@ async def build(
         simulating=simulating,
         hw_control_loop=hw_control_loop,
         execution_manager=execution_manager,
+        disconnected_callback=disconnected_callback,
+        error_callback=error_callback,
         sim_model=sim_model,
         sim_serial_number=sim_serial_number,
-        disconnected_callback=disconnected_callback,
     )
 
 

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -74,6 +74,7 @@ from .types import (
     DoorStateNotification,
     ErrorMessageNotification,
     HardwareEvent,
+    AsynchronousModuleErrorNotification,
     HardwareEventHandler,
     HardwareAction,
     HepaFanState,
@@ -367,6 +368,21 @@ class OT3API(
 
         return futures
 
+    def _send_module_notification(self, event: HardwareEvent) -> None:
+        if not isinstance(
+            event,
+            AsynchronousModuleErrorNotification,
+        ):
+            return
+        mod_log.info(
+            f"Forwarding module event {event.event} for {event.module_model} {event.module_serial} at {event.port}"
+        )
+        for cb in self._callbacks:
+            try:
+                cb(event)
+            except Exception:
+                mod_log.exception("Errored during module asynchronous callback")
+
     def _reset_last_mount(self) -> None:
         self._last_moved_mount = None
 
@@ -422,7 +438,9 @@ class OT3API(
 
         await api_instance.set_status_bar_enabled(status_bar_enabled)
         module_controls = await AttachedModulesControl.build(
-            api_instance, board_revision=backend.board_revision
+            api_instance,
+            board_revision=backend.board_revision,
+            event_callback=api_instance._send_module_notification,
         )
         backend.module_controls = module_controls
         await backend.build_estop_detector()
@@ -484,7 +502,9 @@ class OT3API(
         )
         await api_instance.cache_instruments()
         module_controls = await AttachedModulesControl.build(
-            api_instance, board_revision=backend.board_revision
+            api_instance,
+            board_revision=backend.board_revision,
+            event_callback=api_instance._send_module_notification,
         )
         backend.module_controls = module_controls
         await backend.watch(api_instance.loop)

--- a/api/src/opentrons/hardware_control/scripts/update_module_fw.py
+++ b/api/src/opentrons/hardware_control/scripts/update_module_fw.py
@@ -1,4 +1,5 @@
 """Module Firmware update script."""
+
 import argparse
 import asyncio
 from glob import glob
@@ -14,6 +15,7 @@ from opentrons.hardware_control import modules
 from opentrons.hardware_control.modules.mod_abc import AbstractModule
 from opentrons.hardware_control.modules.update import update_firmware
 from opentrons.hardware_control.types import BoardRevision
+from opentrons.hardware_control.execution_manager import ExecutionManager
 
 
 # Constants for checking if module is back online
@@ -84,6 +86,9 @@ async def build_module(
             port=port,
             usb_port=mod.usb_port,
             type=modules.MODULE_TYPE_BY_NAME[mod.name],
+            execution_manager=ExecutionManager(),
+            disconnected_callback=lambda *args: None,
+            error_callback=lambda *args: None,
             simulating=False,
             hw_control_loop=loop,
         )

--- a/api/src/opentrons/hardware_control/types.py
+++ b/api/src/opentrons/hardware_control/types.py
@@ -2,14 +2,25 @@ from asyncio import Queue
 import enum
 import logging
 from dataclasses import dataclass
-from typing import cast, Tuple, Union, List, Callable, Dict, TypeVar, Type
+from typing import (
+    cast,
+    Tuple,
+    Union,
+    List,
+    Callable,
+    Dict,
+    TypeVar,
+    Type,
+    TYPE_CHECKING,
+)
 from typing_extensions import Literal
 from opentrons import types as top_types
 from opentrons_shared_data.pipette.types import PipetteChannelType
 from opentrons_shared_data.errors.exceptions import EnumeratedError
 from opentrons.config import feature_flags
-from opentrons.drivers.rpi_drivers.types import USBPort
-from .modules.types import ModuleModel
+
+if TYPE_CHECKING:
+    from .modules.types import ModuleModel
 
 MODULE_LOG = logging.getLogger(__name__)
 
@@ -435,9 +446,9 @@ class ErrorMessageNotification:
 @dataclass(frozen=True)
 class AsynchronousModuleErrorNotification:
     exception: EnumeratedError
-    module_serial: str
-    module_model: ModuleModel
-    port: USBPort
+    module_serial: str | None
+    module_model: "ModuleModel"
+    port: str
     event: Literal[
         HardwareEventType.ASYNCHRONOUS_MODULE_ERROR
     ] = HardwareEventType.ASYNCHRONOUS_MODULE_ERROR
@@ -446,7 +457,10 @@ class AsynchronousModuleErrorNotification:
 # new event types get new dataclasses
 # when we add more event types we add them here
 HardwareEvent = Union[
-    DoorStateNotification, ErrorMessageNotification, EstopStateNotification
+    DoorStateNotification,
+    ErrorMessageNotification,
+    EstopStateNotification,
+    AsynchronousModuleErrorNotification,
 ]
 
 HardwareEventHandler = Callable[[HardwareEvent], None]

--- a/api/src/opentrons/hardware_control/types.py
+++ b/api/src/opentrons/hardware_control/types.py
@@ -6,7 +6,10 @@ from typing import cast, Tuple, Union, List, Callable, Dict, TypeVar, Type
 from typing_extensions import Literal
 from opentrons import types as top_types
 from opentrons_shared_data.pipette.types import PipetteChannelType
+from opentrons_shared_data.errors.exceptions import EnumeratedError
 from opentrons.config import feature_flags
+from opentrons.drivers.rpi_drivers.types import USBPort
+from .modules.types import ModuleModel
 
 MODULE_LOG = logging.getLogger(__name__)
 
@@ -384,6 +387,7 @@ class HardwareEventType(enum.Enum):
     DOOR_SWITCH_CHANGE = enum.auto()
     ERROR_MESSAGE = enum.auto()
     ESTOP_CHANGE = enum.auto()
+    ASYNCHRONOUS_MODULE_ERROR = enum.auto()
 
 
 @dataclass
@@ -426,6 +430,17 @@ class EstopStateNotification:
 class ErrorMessageNotification:
     message: str
     event: Literal[HardwareEventType.ERROR_MESSAGE] = HardwareEventType.ERROR_MESSAGE
+
+
+@dataclass(frozen=True)
+class AsynchronousModuleErrorNotification:
+    exception: EnumeratedError
+    module_serial: str
+    module_model: ModuleModel
+    port: USBPort
+    event: Literal[
+        HardwareEventType.ASYNCHRONOUS_MODULE_ERROR
+    ] = HardwareEventType.ASYNCHRONOUS_MODULE_ERROR
 
 
 # new event types get new dataclasses

--- a/api/src/opentrons/protocol_engine/actions/actions.py
+++ b/api/src/opentrons/protocol_engine/actions/actions.py
@@ -3,6 +3,7 @@
 Actions can be passed to the ActionDispatcher, where they will trigger
 reactions in objects that subscribe to the pipeline, like the StateStore.
 """
+
 import dataclasses
 from datetime import datetime
 from enum import Enum
@@ -62,7 +63,7 @@ class PauseAction:
 class StopAction:
     """Request engine execution to stop soon."""
 
-    from_estop: bool = False
+    from_asynchronous_error: bool = False
 
 
 @dataclasses.dataclass(frozen=True)

--- a/api/src/opentrons/protocol_engine/protocol_engine.py
+++ b/api/src/opentrons/protocol_engine/protocol_engine.py
@@ -322,24 +322,10 @@ class ProtocolEngine:
         )
         return completed_command
 
-    def estop(self) -> None:
-        """Signal to the engine that an E-stop event occurred.
-
-        If an estop happens while the robot is moving, lower layers physically stop
-        motion and raise the event as an exception, which fails the Protocol Engine
-        command. No action from the `ProtocolEngine` caller is needed to handle that.
-
-        However, if an estop happens in between commands, or in the middle of
-        a command like `comment` or `waitForDuration` that doesn't access the hardware,
-        `ProtocolEngine` needs to be told about it so it can interrupt the command
-        and stop executing any more. This method is how to do that.
-
-        This acts roughly like `request_stop()`. After calling this, you should call
-        `finish()` with an EStopActivatedError.
-        """
+    def _stop_from_asynchronous_error(self) -> None:
         try:
             action = self._state_store.commands.validate_action_allowed(
-                StopAction(from_estop=True)
+                StopAction(from_asynchronous_error=True)
             )
         except Exception:  # todo(mm, 2024-04-16): Catch a more specific type.
             # This is likely called from some hardware API callback that doesn't care
@@ -358,9 +344,72 @@ class ProtocolEngine:
         # do this because we want to make sure non-hardware commands, like
         # `waitForDuration`, are also interrupted.
         self._get_queue_worker.cancel()
+
+    def estop(self) -> None:
+        """Signal to the engine that an E-stop event occurred.
+
+        If an estop happens while the robot is moving, lower layers physically stop
+        motion and raise the event as an exception, which fails the Protocol Engine
+        command. No action from the `ProtocolEngine` caller is needed to handle that.
+
+        However, if an estop happens in between commands, or in the middle of
+        a command like `comment` or `waitForDuration` that doesn't access the hardware,
+        `ProtocolEngine` needs to be told about it so it can interrupt the command
+        and stop executing any more. This method is how to do that.
+
+        This acts roughly like `request_stop()`. After calling this, you should call
+        `finish()` with an EStopActivatedError.
+        """
         # Unlike self.request_stop(), we don't need to do
         # self._hardware_api.cancel_execution_and_running_tasks(). Since this was an
         # E-stop event, the hardware API already knows.
+        self._stop_from_asynchronous_error()
+
+    async def async_module_error(
+        self, module_model: ModuleModel, serial: str | None
+    ) -> bool:
+        """Signal to the engine that an asynchronous module error occured.
+
+        The return value of this function signals whether the error is relevant to the protocol
+        or not. If the function returns True, the error is relevant. The engine will stop, and
+        the caller should call `finish()` with the error object that signaled the error. If
+        the function returns False, the error is not relevant. The engine will not stop, and the
+        caller should not call `finish()`.
+
+        Asynchronous module errors are signaled when a module enters a hardware error state
+        - for instance, a thermocycler's thermistors fail because of condensation, or a
+        heater-shaker's wires fray and snap, or a module is accidentally disconnected. These
+        errors are not related to a particular command, even a currently-happening module
+        control command for the module in the error state.
+
+        Similar to an estop error, the error can occur at any time relative to the lifecycle
+        of the engine run or of any particular command.
+
+        Unlike an estop, the motion control hardware will not be raising an error and will not
+        stop on its own; the stop action derived from this call will do that.
+        """
+        if not self._state_store.modules.get_has_module_probably_matching_hardware_details(
+            module_model, serial
+        ):
+            return False
+        self._stop_from_asynchronous_error()
+        # like self.request_stop, and unlike self.estop(), we must explicitly request that the
+        # hardware stops execution, since not all asynchronous errors will cause the hardware
+        # to know that it should stop.
+        await self._do_hardware_stop()
+        return True
+
+    async def _do_hardware_stop(self) -> None:
+        """Make the hardware stop now."""
+        if self._hardware_api.is_movement_execution_taskified():
+            # We 'taskify' hardware controller movement functions when running protocols
+            # that are not backed by the engine. Such runs cannot be stopped by cancelling
+            # the queue worker and hence need to be stopped via the execution manager.
+            # `cancel_execution_and_running_tasks()` sets the execution manager in a CANCELLED state
+            # and cancels the running tasks, which raises an error and gets us out of the
+            # run function execution, just like `_queue_worker.cancel()` does for
+            # engine-backed runs.
+            await self._hardware_api.cancel_execution_and_running_tasks()
 
     async def request_stop(self) -> None:
         """Make command execution stop soon.
@@ -378,15 +427,7 @@ class ProtocolEngine:
         action = self._state_store.commands.validate_action_allowed(StopAction())
         self._action_dispatcher.dispatch(action)
         self._get_queue_worker.cancel()
-        if self._hardware_api.is_movement_execution_taskified():
-            # We 'taskify' hardware controller movement functions when running protocols
-            # that are not backed by the engine. Such runs cannot be stopped by cancelling
-            # the queue worker and hence need to be stopped via the execution manager.
-            # `cancel_execution_and_running_tasks()` sets the execution manager in a CANCELLED state
-            # and cancels the running tasks, which raises an error and gets us out of the
-            # run function execution, just like `_queue_worker.cancel()` does for
-            # engine-backed runs.
-            await self._hardware_api.cancel_execution_and_running_tasks()
+        await self._do_hardware_stop()
 
     async def wait_until_complete(self) -> None:
         """Wait until there are no more commands to execute.
@@ -429,7 +470,7 @@ class ProtocolEngine:
             post_run_hardware_state: The state in which to leave the gantry and motors in
                 after the run is over.
         """
-        if self._state_store.commands.get_is_stopped_by_estop():
+        if self._state_store.commands.get_is_stopped_by_async_error():
             # This handles the case where the E-stop was pressed while we were *not* in the middle
             # of some hardware interaction that would raise it as an exception. For example, imagine
             # we were paused between two commands, or imagine we were executing a waitForDuration.

--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -238,7 +238,7 @@ class CommandState:
     has_entered_error_recovery: bool
     """Whether the run has entered error recovery."""
 
-    stopped_by_estop: bool
+    stopped_by_async_error: bool
     """If this is set to True, the engine was stopped by an estop event."""
 
     error_recovery_policy: ErrorRecoveryPolicy
@@ -272,7 +272,7 @@ class CommandStore(HasState[CommandState], HandlesActions):
             run_completed_at=None,
             run_started_at=None,
             latest_protocol_command_hash=None,
-            stopped_by_estop=False,
+            stopped_by_async_error=False,
             error_recovery_policy=error_recovery_policy,
             has_entered_error_recovery=False,
         )
@@ -472,8 +472,8 @@ class CommandStore(HasState[CommandState], HandlesActions):
             self._state.recovery_target = None
             self._state.queue_status = QueueStatus.PAUSED
 
-            if action.from_estop:
-                self._state.stopped_by_estop = True
+            if action.from_asynchronous_error:
+                self._state.stopped_by_async_error = True
                 self._state.run_result = RunResult.FAILED
             else:
                 self._state.run_result = RunResult.STOPPED
@@ -501,7 +501,7 @@ class CommandStore(HasState[CommandState], HandlesActions):
         else:
             # HACK(sf): There needs to be a better way to set
             # an estop error than this else clause
-            if self._state.stopped_by_estop and action.error_details:
+            if self._state.stopped_by_async_error and action.error_details:
                 self._state.run_error = self._map_run_exception_to_error_occurrence(
                     action.error_details.error_id,
                     action.error_details.created_at,
@@ -952,9 +952,9 @@ class CommandView:
         """Get whether an engine stop has completed."""
         return self._state.run_completed_at is not None
 
-    def get_is_stopped_by_estop(self) -> bool:
+    def get_is_stopped_by_async_error(self) -> bool:
         """Return whether the engine was stopped specifically by an E-stop."""
-        return self._state.stopped_by_estop
+        return self._state.stopped_by_async_error
 
     def has_been_played(self) -> bool:
         """Get whether engine has started."""

--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -1505,3 +1505,24 @@ class ModuleView:
                 f"Provided overlap offset {overlap_offset} does not match "
                 f"configured {configured}."
             )
+
+    def get_has_module_probably_matching_hardware_details(
+        self, module_model: ModuleModel, module_serial: str | None
+    ) -> bool:
+        """Get the ID of a model that possibly matches the provided details.
+
+        If the provided serial is not None, return True if there is a module with the same serial or
+        False if there is not.
+        If the provided serial is None, return True if there is a module with the same model or False if
+        there is not.
+
+        This is intended to provide a good probability that a module matching the provided details
+        is or is not present in the state store. It is used to drive whether the engine cancels a protocol
+        in response to an asynchronous module error or not.
+        """
+        for module_id, module in self._state.hardware_by_module_id.items():
+            if module_serial is not None and module_serial == module.serial_number:
+                return True
+            if module_serial is None and module.definition.model == module_model:
+                return True
+        return False

--- a/api/src/opentrons/protocol_engine/types/module.py
+++ b/api/src/opentrons/protocol_engine/types/module.py
@@ -21,6 +21,7 @@ from opentrons_shared_data.labware.types import LocatingFeatures
 
 from opentrons.hardware_control.modules import (
     ModuleType as ModuleType,
+    ModuleModel as HardwareModuleModel,
 )
 
 from .location import DeckSlotLocation
@@ -42,6 +43,11 @@ class ModuleModel(str, Enum):
     MAGNETIC_BLOCK_V1 = "magneticBlockV1"
     ABSORBANCE_READER_V1 = "absorbanceReaderV1"
     FLEX_STACKER_MODULE_V1 = "flexStackerModuleV1"
+
+    @classmethod
+    def from_hardware(cls, hardware_model: HardwareModuleModel) -> "ModuleModel":
+        """Convert from the hardware model representation."""
+        return cls(hardware_model.value)
 
     def as_type(self) -> ModuleType:
         """Get the ModuleType of this model."""

--- a/api/src/opentrons/protocol_runner/run_orchestrator.py
+++ b/api/src/opentrons/protocol_runner/run_orchestrator.py
@@ -15,7 +15,10 @@ from opentrons_shared_data.robot.types import RobotType
 
 from . import protocol_runner, RunResult, JsonRunner, PythonAndLegacyRunner
 from ..hardware_control import HardwareControlAPI
-from ..hardware_control.modules import AbstractModule as HardwareModuleAPI
+from ..hardware_control.modules import (
+    AbstractModule as HardwareModuleAPI,
+    ModuleModel as HardwareModuleModel,
+)
 from ..protocol_engine import (
     ProtocolEngine,
     CommandCreate,
@@ -380,6 +383,18 @@ class RunOrchestrator:
     def estop(self) -> None:
         """Handle an E-stop event from the hardware API."""
         return self._protocol_engine.estop()
+
+    async def asynchronous_module_error(
+        self, module_model: HardwareModuleModel, module_serial: str | None
+    ) -> bool:
+        """Handle an asynchronous module error reported by hardware.
+
+        If this function returns true, the caller should call finish() immediately; if it returns
+        False, the caller should not call finish() until it otherwise would.
+        """
+        return await self._protocol_engine.async_module_error(
+            module_model=ModuleModel.from_hardware(module_model), serial=module_serial
+        )
 
     async def use_attached_modules(
         self, modules_by_id: Dict[str, HardwareModuleAPI]

--- a/api/tests/opentrons/hardware_control/conftest.py
+++ b/api/tests/opentrons/hardware_control/conftest.py
@@ -1,0 +1,23 @@
+from decoy import Decoy
+import pytest
+
+from opentrons.hardware_control.modules.types import (
+    ModuleDisconnectedCallback,
+    ModuleErrorCallback,
+)
+from opentrons.hardware_control.execution_manager import ExecutionManager
+
+
+@pytest.fixture
+def module_disconnected_callback(decoy: Decoy) -> ModuleDisconnectedCallback:
+    return decoy.mock(cls=ModuleDisconnectedCallback)
+
+
+@pytest.fixture
+def module_error_callback(decoy: Decoy) -> ModuleErrorCallback:
+    return decoy.mock(cls=ModuleErrorCallback)
+
+
+@pytest.fixture
+def mock_execution_manager(decoy: Decoy) -> ExecutionManager:
+    return decoy.mock(cls=ExecutionManager)

--- a/api/tests/opentrons/hardware_control/integration/build_module.py
+++ b/api/tests/opentrons/hardware_control/integration/build_module.py
@@ -1,4 +1,5 @@
 """Build a module emulator for integration tests."""
+
 import asyncio
 from typing import Optional, Type, TypeVar, cast
 
@@ -30,6 +31,8 @@ async def build_module(
     module = await module_cls.build(
         port=f"socket://127.0.0.1:{port}",
         execution_manager=execution_manager,
+        disconnected_callback=lambda *args: None,
+        error_callback=lambda *args: None,
         usb_port=USBPort(
             name="",
             port_number=1,

--- a/api/tests/opentrons/hardware_control/modules/test_hc_flexstacker.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_flexstacker.py
@@ -1,8 +1,12 @@
 import asyncio
-import pytest
 import mock
 from contextlib import nullcontext as does_not_raise
 from typing import AsyncGenerator, ContextManager, Any
+
+import pytest
+from decoy import Decoy, matchers
+
+
 from opentrons.drivers.flex_stacker.simulator import SimulatingDriver
 from opentrons.drivers.flex_stacker.types import (
     Direction,
@@ -11,6 +15,12 @@ from opentrons.drivers.flex_stacker.types import (
     StackerAxis,
     LEDColor,
     LEDPattern,
+    TOFSensorStatus,
+    TOFSensor,
+    TOFSensorState,
+    TOFSensorMode,
+    StackerInfo,
+    HardwareRevision,
 )
 from opentrons.hardware_control import modules, ExecutionManager
 from opentrons.drivers.rpi_drivers.types import USBPort
@@ -24,7 +34,11 @@ from opentrons.hardware_control.modules.flex_stacker import (
     STACKER_MOTION_CONFIG,
     FlexStackerReader,
 )
-from opentrons.hardware_control.modules.types import PlatformState
+from opentrons.hardware_control.modules.types import (
+    PlatformState,
+    ModuleErrorCallback,
+    ModuleDisconnectedCallback,
+)
 from opentrons.hardware_control.poller import Poller
 from opentrons.hardware_control.types import StatusBarState, StatusBarUpdateEvent
 from opentrons_shared_data.errors.exceptions import (
@@ -36,6 +50,7 @@ from opentrons_shared_data.errors.exceptions import (
 
 @pytest.fixture
 def usb_port() -> USBPort:
+    """Token USB port."""
     return USBPort(
         name="",
         port_number=0,
@@ -44,16 +59,21 @@ def usb_port() -> USBPort:
 
 
 @pytest.fixture
-def mock_driver() -> mock.AsyncMock:
-    return mock.AsyncMock(spec=SimulatingDriver)
+def mock_driver(decoy: Decoy) -> SimulatingDriver:
+    """Mocked simulating driver."""
+    return decoy.mock(cls=SimulatingDriver)
 
 
 @pytest.fixture
 async def subject(
     usb_port: USBPort,
-    mock_driver: mock.AsyncMock,
+    mock_driver: SimulatingDriver,
+    mock_execution_manager: ExecutionManager,
+    module_error_callback: ModuleErrorCallback,
+    module_disconnected_callback: ModuleDisconnectedCallback,
+    decoy: Decoy,
 ) -> AsyncGenerator[modules.FlexStacker, None]:
-    """Test subject with mocked driver"""
+    """Test subject with mocked driver."""
     reader = FlexStackerReader(driver=mock_driver)
     poller = Poller(reader=reader, interval=SIMULATING_POLL_PERIOD)
     stacker = modules.FlexStacker(
@@ -68,8 +88,30 @@ async def subject(
             "version": "stacker-fw",
         },
         hw_control_loop=asyncio.get_running_loop(),
-        execution_manager=ExecutionManager(),
+        execution_manager=mock_execution_manager,
+        error_callback=module_error_callback,
+        disconnected_callback=module_disconnected_callback,
     )
+    decoy.when(await mock_driver.get_device_info()).then_return(
+        StackerInfo(fw="stacker-fw", hw=HardwareRevision.EVT, sn="dummySerialFS")
+    )
+    decoy.when(await mock_driver.get_tof_sensor_status(TOFSensor.X)).then_return(
+        TOFSensorStatus(
+            TOFSensor.X, TOFSensorState.IDLE, TOFSensorMode.MEASURE, ok=True
+        )
+    )
+    decoy.when(await mock_driver.get_tof_sensor_status(TOFSensor.Z)).then_return(
+        TOFSensorStatus(
+            TOFSensor.Z, TOFSensorState.IDLE, TOFSensorMode.MEASURE, ok=True
+        )
+    )
+    decoy.when(await mock_driver.get_platform_status()).then_return(
+        PlatformStatus(False, False)
+    )
+    decoy.when(await mock_driver.get_limit_switches_status()).then_return(
+        LimitSwitchStatus(False, True, False, False, False)
+    )
+
     await poller.start()
     try:
         yield stacker
@@ -78,6 +120,7 @@ async def subject(
 
 
 async def test_sim_state(subject: modules.FlexStacker) -> None:
+    """It should forward state."""
     status = subject.device_info
     assert status["serial"] == "dummySerialFS"
     assert status["model"] == "a1"
@@ -85,17 +128,9 @@ async def test_sim_state(subject: modules.FlexStacker) -> None:
 
 
 async def test_set_run_hold_current(
-    subject: modules.FlexStacker, mock_driver: mock.AsyncMock
+    subject: modules.FlexStacker, mock_driver: SimulatingDriver, decoy: Decoy
 ) -> None:
-    mock_driver.get_platform_status.side_effect = [
-        PlatformStatus(True, False),
-        PlatformStatus(False, True),
-    ]
-    mock_driver.get_limit_switches_status.side_effect = [
-        LimitSwitchStatus(False, True, False, False, False),
-        LimitSwitchStatus(True, True, False, False, False),
-    ]
-
+    """It should set currents."""
     # Test move_axis
 
     # run and hold current are 0 by default
@@ -106,54 +141,81 @@ async def test_set_run_hold_current(
     # Call the move_axis function with default current
     await subject.move_axis(StackerAxis.X, Direction.EXTEND, 44)
     # set_run_current should be called and run_current recorded
-    mock_driver.set_run_current.assert_called_with(StackerAxis.X, default.run_current)
-    mock_driver.set_ihold_current.assert_called_with(
-        StackerAxis.X, default.hold_current
+    decoy.verify(await mock_driver.set_run_current(StackerAxis.X, default.run_current))
+    decoy.verify(
+        await mock_driver.set_ihold_current(StackerAxis.X, default.hold_current)
     )
     motion_params = subject._reader.motion_params[StackerAxis.X]
     assert motion_params.run_current == default.run_current
     assert motion_params.hold_current == default.hold_current
-    mock_driver.set_run_current.reset_mock()
-    mock_driver.set_ihold_current.reset_mock()
+    decoy.reset()
+
+    decoy.when(await mock_driver.get_platform_status()).then_return(
+        PlatformStatus(False, True)
+    )
+    decoy.when(await mock_driver.get_limit_switches_status()).then_return(
+        LimitSwitchStatus(True, True, False, False, False)
+    )
 
     # Make sure set_run_current and set_ihold_current are not called again
     await subject.move_axis(StackerAxis.X, Direction.EXTEND, 44)
-    mock_driver.set_run_current.assert_not_called()
-    mock_driver.set_ihold_current.assert_not_called()
+    decoy.verify(
+        await mock_driver.set_run_current(matchers.Anything(), matchers.Anything()),
+        times=0,
+    )
+    decoy.verify(
+        await mock_driver.set_ihold_current(matchers.Anything(), matchers.Anything()),
+        times=0,
+    )
     motion_params = subject._reader.motion_params[StackerAxis.X]
     assert motion_params.run_current == default.run_current
     assert motion_params.hold_current == default.hold_current
 
     # Test home_axis
-
+    decoy.reset()
     # Reset the run/hold current recorded
     default = STACKER_MOTION_CONFIG[StackerAxis.X]["home"]
     subject._reader.motion_params[StackerAxis.X].run_current = 0
     subject._reader.motion_params[StackerAxis.X].hold_current = 0
+    decoy.when(await mock_driver.get_platform_status()).then_return(
+        PlatformStatus(False, True)
+    )
+    decoy.when(await mock_driver.get_limit_switches_status()).then_return(
+        LimitSwitchStatus(True, True, False, False, False)
+    )
 
     # Call the home_axis function with default current
     await subject.home_axis(StackerAxis.X, Direction.EXTEND)
-    mock_driver.set_run_current.assert_called_with(StackerAxis.X, default.run_current)
-    mock_driver.set_ihold_current.assert_called_with(
-        StackerAxis.X, default.hold_current
+    decoy.verify(await mock_driver.set_run_current(StackerAxis.X, default.run_current))
+    decoy.verify(
+        await mock_driver.set_ihold_current(StackerAxis.X, default.hold_current)
     )
     motion_params = subject._reader.motion_params[StackerAxis.X]
     assert motion_params.run_current == default.run_current
     assert motion_params.hold_current == default.hold_current
-    mock_driver.set_run_current.reset_mock()
-    mock_driver.set_ihold_current.reset_mock()
+    decoy.reset()
+    decoy.when(await mock_driver.get_platform_status()).then_return(
+        PlatformStatus(False, True)
+    )
+    decoy.when(await mock_driver.get_limit_switches_status()).then_return(
+        LimitSwitchStatus(True, True, False, False, False)
+    )
 
     # Make sure set_run_current and set_ihold_current are not called again
     await subject.home_axis(StackerAxis.X, Direction.EXTEND, 44)
-    mock_driver.set_run_current.assert_not_called()
-    mock_driver.set_ihold_current.assert_not_called()
+    decoy.verify(
+        await mock_driver.set_run_current(matchers.Anything(), matchers.Anything()),
+        times=0,
+    )
+    decoy.verify(
+        await mock_driver.set_ihold_current(matchers.Anything(), matchers.Anything()),
+        times=0,
+    )
 
     # The recorded run/hold current should stay the same
     motion_params = subject._reader.motion_params[StackerAxis.X]
     assert motion_params.run_current == default.run_current
     assert motion_params.hold_current == default.hold_current
-    mock_driver.set_run_current.reset_mock()
-    mock_driver.set_ihold_current.reset_mock()
 
 
 PLATFORM_STATUS_UNKNOWN = PlatformStatus(False, False)
@@ -175,14 +237,15 @@ X_RETRACTED = LimitSwitchStatus(False, True, False, False, False)
 )
 async def test_platform_state(
     subject: modules.FlexStacker,
-    mock_driver: mock.AsyncMock,
+    mock_driver: SimulatingDriver,
     x_status: LimitSwitchStatus,
     platform_status: PlatformStatus,
     expected: PlatformState,
+    decoy: Decoy,
 ) -> None:
     """Test that the platform state is correctly determined."""
-    mock_driver.get_platform_status.return_value = platform_status
-    mock_driver.get_limit_switches_status.return_value = x_status
+    decoy.when(await mock_driver.get_platform_status()).then_return(platform_status)
+    decoy.when(await mock_driver.get_limit_switches_status()).then_return(x_status)
 
     # update the cached value
     await subject._reader.get_limit_switch_status()
@@ -200,13 +263,17 @@ async def test_platform_state(
 )
 async def test_platform_state_unknown(
     subject: modules.FlexStacker,
-    mock_driver: mock.AsyncMock,
+    mock_driver: SimulatingDriver,
     x_status: LimitSwitchStatus,
     expected: PlatformState,
+    decoy: Decoy,
 ) -> None:
     """Test that the platform state is correctly determined."""
-    mock_driver.get_platform_status.return_value = PLATFORM_STATUS_UNKNOWN
-    mock_driver.get_limit_switches_status.return_value = x_status
+
+    decoy.when(await mock_driver.get_platform_status()).then_return(
+        PLATFORM_STATUS_UNKNOWN
+    )
+    decoy.when(await mock_driver.get_limit_switches_status()).then_return(x_status)
 
     # update the value
     await subject._reader.get_limit_switch_status()
@@ -305,22 +372,26 @@ async def test_platform_state_unknown(
 )
 async def test_stacker_status_bar_event_handler(
     subject: modules.FlexStacker,
-    mock_driver: mock.AsyncMock,
+    mock_driver: SimulatingDriver,
     should_identify: bool,
     hopper_door: bool,
     event: StatusBarUpdateEvent,
     result_params: tuple[float, LEDColor, LEDPattern, int | None],
+    decoy: Decoy,
 ) -> None:
-    mock_driver.get_hopper_door_closed.return_value = hopper_door
+    """It should handle LED lights."""
+    decoy.when(await mock_driver.get_hopper_door_closed()).then_return(hopper_door)
     subject.set_stacker_identify(should_identify)
     await subject._reader.get_door_closed()
     await subject._handle_status_bar_event(event)
-    mock_driver.set_led.assert_called_with(
-        result_params[0],
-        color=result_params[1],
-        pattern=result_params[2],
-        duration=result_params[3],
-        reps=None,
+    decoy.verify(
+        await mock_driver.set_led(
+            result_params[0],
+            color=result_params[1],
+            pattern=result_params[2],
+            duration=result_params[3],
+            reps=None,
+        )
     )
 
 
@@ -329,12 +400,9 @@ async def test_stacker_status_bar_event_handler(
     [(16), (100)],
 )
 async def test_store_labware_motion_sequence(
-    subject: modules.FlexStacker,
-    labware_height: float,
+    subject: modules.FlexStacker, labware_height: float
 ) -> None:
-    """
-    Test successful storage labware with labware sensing enforced.
-    """
+    """It should store labware with sensing on."""
     with (
         mock.patch.object(
             subject, "_prepare_for_action", mock.AsyncMock()
@@ -541,15 +609,12 @@ async def test_dispense_labware_error_handling(
     [(0), (-10), (200)],
 )
 async def test_invalid_labware_height(
-    subject: modules.FlexStacker,
-    labware_height: float,
+    subject: modules.FlexStacker, labware_height: float
 ) -> None:
     """Raise a ValueError if the labware_height is invalid"""
-    with (
-        mock.patch.object(
-            subject, "_prepare_for_action", mock.AsyncMock()
-        ) as _prepare_for_action
-    ):
+    with mock.patch.object(
+        subject, "_prepare_for_action", mock.AsyncMock()
+    ) as _prepare_for_action:
         # Test invalid labware height
         with pytest.raises(ValueError):
             await subject.store_labware(
@@ -557,3 +622,26 @@ async def test_invalid_labware_height(
                 enforce_shuttle_lw_sensing=True,
             )
         _prepare_for_action.assert_not_called()
+
+
+async def test_error_callback(
+    subject: modules.FlexStacker,
+    mock_driver: SimulatingDriver,
+    module_error_callback: ModuleErrorCallback,
+    decoy: Decoy,
+) -> None:
+    """It should forward an error from the poller to the callback."""
+    # There are no asynchronous errors from the stacker (the door is handled
+    # differently) so just inject a random exception.
+    exc = Exception("Oh no!")
+    decoy.when(mock_driver.get_hopper_door_closed()).then_raise(exc)
+    with pytest.raises(Exception, match="Oh no!"):
+        await subject._poller.wait_next_poll()
+    decoy.verify(
+        module_error_callback(
+            exc,
+            "flexStackerModuleV1",
+            "/dev/ot_module_sim_flexstacker0",
+            "dummySerialFS",
+        )
+    )

--- a/api/tests/opentrons/hardware_control/modules/test_hc_heatershaker.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_heatershaker.py
@@ -1,20 +1,26 @@
 import asyncio
-import pytest
 import mock
 from typing import Any, AsyncGenerator
-import typing
+
+from decoy import Decoy
+import pytest
+
 from opentrons.hardware_control import modules, ExecutionManager
 from opentrons.hardware_control.modules.types import (
     TemperatureStatus,
     SpeedStatus,
     HeaterShakerStatus,
+    ModuleDisconnectedCallback,
+    ModuleErrorCallback,
 )
 from opentrons.drivers.rpi_drivers.types import USBPort
 from opentrons.drivers.types import HeaterShakerLabwareLatchStatus, Temperature, RPM
+from opentrons.drivers.heater_shaker.simulator import SimulatingDriver
 
 
 @pytest.fixture
 def usb_port() -> USBPort:
+    """A token USB port."""
     return USBPort(
         name="",
         port_number=0,
@@ -25,14 +31,20 @@ def usb_port() -> USBPort:
 @pytest.fixture
 async def simulating_module(
     usb_port: USBPort,
+    mock_execution_manager: ExecutionManager,
+    module_error_callback: ModuleErrorCallback,
+    module_disconnected_callback: ModuleDisconnectedCallback,
 ) -> AsyncGenerator[modules.AbstractModule, None]:
+    """Get a mocked simulating subject."""
     module = await modules.build(
         port=usb_port.device_path,
         usb_port=usb_port,
         type=modules.ModuleType["HEATER_SHAKER"],
         simulating=True,
         hw_control_loop=asyncio.get_running_loop(),
-        execution_manager=ExecutionManager(),
+        execution_manager=mock_execution_manager,
+        error_callback=module_error_callback,
+        disconnected_callback=module_disconnected_callback,
     )
     assert isinstance(module, modules.AbstractModule)
     try:
@@ -42,17 +54,25 @@ async def simulating_module(
 
 
 @pytest.fixture
+def mock_driver(decoy: Decoy) -> SimulatingDriver:
+    """Get a mocked simulating driver."""
+    return decoy.mock(cls=SimulatingDriver)
+
+
+@pytest.fixture
 async def simulating_module_driver_patched(
     simulating_module: modules.HeaterShaker,
+    mock_driver: SimulatingDriver,
 ) -> AsyncGenerator[modules.AbstractModule, None]:
-    driver_mock = mock.MagicMock()
+    """Get a mocked module with a patched driver."""
     with mock.patch.object(
-        simulating_module, "_driver", driver_mock
-    ), mock.patch.object(simulating_module._reader, "_driver", driver_mock):
+        simulating_module, "_driver", mock_driver
+    ), mock.patch.object(simulating_module._reader, "_driver", mock_driver):
         yield simulating_module
 
 
 async def test_sim_state(simulating_module: modules.HeaterShaker) -> None:
+    """It should forward simulated state."""
     assert simulating_module.temperature == 23
     assert simulating_module.speed == 0
     assert simulating_module.target_temperature is None
@@ -68,6 +88,7 @@ async def test_sim_state(simulating_module: modules.HeaterShaker) -> None:
 
 
 async def test_sim_update(simulating_module: modules.HeaterShaker) -> None:
+    """It should update its simulated state."""
     await simulating_module.start_set_temperature(10)
     await simulating_module.await_temperature(10)
     assert simulating_module.temperature == 10
@@ -91,6 +112,7 @@ async def test_sim_update(simulating_module: modules.HeaterShaker) -> None:
 
 
 async def test_await_both(simulating_module: modules.HeaterShaker) -> None:
+    """It should wait for speed and temp."""
     await simulating_module.start_set_temperature(10)
     await simulating_module.set_speed(2000)
     await simulating_module.await_temperature(10)
@@ -99,6 +121,7 @@ async def test_await_both(simulating_module: modules.HeaterShaker) -> None:
 
 
 async def test_labware_latch(simulating_module: modules.HeaterShaker) -> None:
+    """It should handle the latch."""
     await simulating_module.open_labware_latch()
     assert (
         await simulating_module._driver.get_labware_latch_status()
@@ -198,29 +221,39 @@ async def fake_get_latch_status(
     return HeaterShakerLabwareLatchStatus.IDLE_OPEN
 
 
-@typing.no_type_check
 async def test_async_error_response(
     simulating_module_driver_patched: modules.HeaterShaker,
+    module_error_callback: ModuleErrorCallback,
+    mock_driver: SimulatingDriver,
+    decoy: Decoy,
 ) -> None:
     """Test that asynchronous error is detected by poller and module live data and status are updated."""
-    # TODO(mc, 2022-10-13): driver is too deep a level to mock in this test
-    # mock the reader, instead
-    simulating_module_driver_patched._driver.get_temperature.side_effect = Exception()
+    exc = Exception("Oh no, an asynchronous error!")
+    decoy.when(await mock_driver.get_temperature()).then_raise(exc)
     with pytest.raises(Exception):
         await simulating_module_driver_patched._poller.wait_next_poll()
+    decoy.verify(
+        module_error_callback(
+            exc,
+            "heaterShakerModuleV1",
+            "/dev/ot_module_sim_heatershaker0",
+            "dummySerialHS",
+        )
+    )
 
     assert (
-        simulating_module_driver_patched.live_data["data"]["errorDetails"]
-        == "Exception()"
+        simulating_module_driver_patched.live_data["data"]["errorDetails"]  # type: ignore[index,typeddict-item]
+        == "Oh no, an asynchronous error!"
     )
     assert simulating_module_driver_patched.status == HeaterShakerStatus.ERROR
-    simulating_module_driver_patched._driver.get_temperature.side_effect = (
-        fake_get_temperature
+    decoy.reset()
+    decoy.when(await mock_driver.get_temperature()).then_return(
+        Temperature(current=50, target=50)
     )
-    simulating_module_driver_patched._driver.get_rpm.side_effect = fake_get_rpm
-    simulating_module_driver_patched._driver.get_labware_latch_status.side_effect = (
-        fake_get_latch_status
+    decoy.when(await mock_driver.get_rpm()).then_return(RPM(current=500, target=500))
+    decoy.when(await mock_driver.get_labware_latch_status()).then_return(
+        HeaterShakerLabwareLatchStatus.IDLE_OPEN
     )
     await simulating_module_driver_patched._poller.wait_next_poll()
-    assert simulating_module_driver_patched.live_data["data"]["errorDetails"] is None
-    assert simulating_module_driver_patched.status == HeaterShakerStatus.RUNNING
+    assert simulating_module_driver_patched.live_data["data"]["errorDetails"] is None  # type: ignore[index,typeddict-item]
+    assert simulating_module_driver_patched.status == HeaterShakerStatus.RUNNING  # type: ignore[comparison-overlap]

--- a/api/tests/opentrons/hardware_control/modules/test_hc_magdeck.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_magdeck.py
@@ -1,14 +1,21 @@
 import asyncio
+from typing import AsyncGenerator
 
-from opentrons.hardware_control.modules.magdeck import MagDeck
 import pytest
 
 from opentrons.hardware_control import modules, ExecutionManager
+from opentrons.hardware_control.modules.types import (
+    ModuleDisconnectedCallback,
+    ModuleErrorCallback,
+)
 from opentrons.drivers.rpi_drivers.types import USBPort
+
+from opentrons.hardware_control.modules.magdeck import MagDeck
 
 
 @pytest.fixture
 def usb_port() -> USBPort:
+    """Token USB port."""
     return USBPort(
         name="",
         port_number=0,
@@ -16,67 +23,63 @@ def usb_port() -> USBPort:
     )
 
 
-async def test_sim_initialization(usb_port: USBPort) -> None:
+@pytest.fixture
+async def subject(
+    usb_port: USBPort,
+    mock_execution_manager: ExecutionManager,
+    module_error_callback: ModuleErrorCallback,
+    module_disconnected_callback: ModuleDisconnectedCallback,
+) -> AsyncGenerator[modules.AbstractModule, None]:
+    """Test subject."""
     mag = await modules.build(
         port="/dev/ot_module_sim_magdeck0",
         usb_port=usb_port,
         type=modules.ModuleType["MAGNETIC"],
         simulating=True,
         hw_control_loop=asyncio.get_running_loop(),
-        execution_manager=ExecutionManager(),
+        execution_manager=mock_execution_manager,
+        error_callback=module_error_callback,
+        disconnected_callback=module_disconnected_callback,
     )
-    assert isinstance(mag, modules.AbstractModule)
+    try:
+        yield mag
+    finally:
+        await mag.cleanup()
 
 
-async def test_sim_data(usb_port: USBPort) -> None:
-    mag = await modules.build(
-        port="/dev/ot_module_sim_magdeck0",
-        usb_port=usb_port,
-        type=modules.ModuleType["MAGNETIC"],
-        simulating=True,
-        hw_control_loop=asyncio.get_running_loop(),
-        execution_manager=ExecutionManager(),
-    )
-    assert mag.status == "disengaged"
-    assert mag.device_info["serial"] == "dummySerialMD"
+async def test_sim_initialization(subject: modules.MagDeck) -> None:
+    """It should initialize to an AbstractModule."""
+    assert isinstance(subject, modules.AbstractModule)
+
+
+async def test_sim_data(subject: modules.MagDeck) -> None:
+    """It should forward simulated data."""
+    assert subject.status == "disengaged"
+    assert subject.device_info["serial"] == "dummySerialMD"
     # return v1 when sim_model is not passed
-    assert mag.device_info["model"] == "mag_deck_v1.1"
-    assert mag.device_info["version"] == "dummyVersionMD"
-    assert mag.live_data["status"] == mag.status
-    assert "data" in mag.live_data
+    assert subject.device_info["model"] == "mag_deck_v1.1"
+    assert subject.device_info["version"] == "dummyVersionMD"
+    assert subject.live_data["status"] == subject.status
+    assert "data" in subject.live_data
 
 
-async def test_sim_state_update(usb_port: USBPort) -> None:
-    mag = await modules.build(
-        port="/dev/ot_module_sim_magdeck0",
-        usb_port=usb_port,
-        type=modules.ModuleType["MAGNETIC"],
-        simulating=True,
-        hw_control_loop=asyncio.get_running_loop(),
-        execution_manager=ExecutionManager(),
-    )
-    assert isinstance(mag, MagDeck)
-    await mag.calibrate()
-    assert mag.status == "disengaged"
-    await mag.engage(2)
-    assert mag.status == "engaged"
-    await mag.deactivate()
-    assert mag.status == "disengaged"
+async def test_sim_state_update(subject: modules.MagDeck) -> None:
+    """It should update simulated state."""
+    assert isinstance(subject, MagDeck)
+    await subject.calibrate()
+    assert subject.status == "disengaged"
+    await subject.engage(2)
+    assert subject.status == "engaged"
+    await subject.deactivate()
+    assert subject.status == "disengaged"
 
 
-async def test_revision_model_parsing(usb_port: USBPort) -> None:
-    mag = await modules.build(
-        port="",
-        type=modules.ModuleType["MAGNETIC"],
-        simulating=True,
-        usb_port=usb_port,
-        hw_control_loop=asyncio.get_running_loop(),
-        execution_manager=ExecutionManager(),
-    )
-    assert isinstance(mag, MagDeck)
-    mag._device_info["model"] = "mag_deck_v1.1"
-    assert mag.model() == "magneticModuleV1"
-    mag._device_info["model"] = "mag_deck_v20"
-    assert mag.model() == "magneticModuleV2"
-    del mag._device_info["model"]
-    assert mag.model() == "magneticModuleV1"
+async def test_revision_model_parsing(subject: modules.MagDeck) -> None:
+    """It should parse its own revision."""
+    assert isinstance(subject, MagDeck)
+    subject._device_info["model"] = "mag_deck_v1.1"
+    assert subject.model() == "magneticModuleV1"
+    subject._device_info["model"] = "mag_deck_v20"
+    assert subject.model() == "magneticModuleV2"
+    del subject._device_info["model"]
+    assert subject.model() == "magneticModuleV1"

--- a/api/tests/opentrons/hardware_control/modules/test_hc_tempdeck.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_tempdeck.py
@@ -1,15 +1,21 @@
 import asyncio
+from typing import AsyncGenerator
 
-from opentrons.hardware_control.modules.tempdeck import TempDeck
+from decoy import Decoy
 import pytest
 
+from opentrons.hardware_control.modules.types import (
+    ModuleDisconnectedCallback,
+    ModuleErrorCallback,
+)
 from opentrons.drivers.rpi_drivers.types import USBPort
 from opentrons.hardware_control import modules, ExecutionManager
-from typing import AsyncGenerator
+from opentrons.hardware_control.modules.tempdeck import TempDeck
 
 
 @pytest.fixture
 def usb_port() -> USBPort:
+    """Token USB port."""
     return USBPort(
         name="",
         port_number=0,
@@ -18,7 +24,12 @@ def usb_port() -> USBPort:
 
 
 @pytest.fixture
-async def subject(usb_port: USBPort) -> AsyncGenerator[modules.AbstractModule, None]:
+async def subject(
+    usb_port: USBPort,
+    mock_execution_manager: ExecutionManager,
+    module_error_callback: ModuleErrorCallback,
+    module_disconnected_callback: ModuleDisconnectedCallback,
+) -> AsyncGenerator[modules.AbstractModule, None]:
     """Test subject"""
     temp = await modules.build(
         port="/dev/ot_module_sim_tempdeck0",
@@ -26,17 +37,23 @@ async def subject(usb_port: USBPort) -> AsyncGenerator[modules.AbstractModule, N
         type=modules.ModuleType["TEMPERATURE"],
         simulating=True,
         hw_control_loop=asyncio.get_running_loop(),
-        execution_manager=ExecutionManager(),
+        execution_manager=mock_execution_manager,
+        error_callback=module_error_callback,
+        disconnected_callback=module_disconnected_callback,
     )
-    yield temp
-    await temp.cleanup()
+    try:
+        yield temp
+    finally:
+        await temp.cleanup()
 
 
 async def test_sim_initialization(subject: modules.AbstractModule) -> None:
+    """It should build a tempdeck."""
     assert isinstance(subject, modules.AbstractModule)
 
 
 async def test_sim_state(subject: modules.AbstractModule) -> None:
+    """It sohuld forward state."""
     assert isinstance(subject, TempDeck)
     assert subject.temperature == 0
     assert subject.target is None
@@ -55,6 +72,7 @@ async def test_sim_state(subject: modules.AbstractModule) -> None:
 
 
 async def test_sim_update(subject: modules.AbstractModule) -> None:
+    """It should update state."""
     assert isinstance(subject, TempDeck)
     await subject.start_set_temperature(10)
     await subject.await_temperature(None)
@@ -68,6 +86,7 @@ async def test_sim_update(subject: modules.AbstractModule) -> None:
 
 
 async def test_revision_model_parsing(subject: modules.AbstractModule) -> None:
+    """It should parse its model."""
     assert isinstance(subject, TempDeck)
     subject._device_info["model"] = "temp_deck_v20"
     assert subject.model() == "temperatureModuleV2"
@@ -77,3 +96,23 @@ async def test_revision_model_parsing(subject: modules.AbstractModule) -> None:
     assert subject.model() == "temperatureModuleV1"
     subject._device_info["model"] = "temp_deck_v1.1"
     assert subject.model() == "temperatureModuleV1"
+
+
+async def test_error_callback(
+    subject: modules.TempDeck,
+    monkeypatch: pytest.MonkeyPatch,
+    decoy: Decoy,
+    module_error_callback: ModuleErrorCallback,
+) -> None:
+    """It should forward temperature check errors."""
+    mock_get_temp = decoy.mock(func=subject._driver.get_temperature)
+    exc = Exception("oh no!")
+    decoy.when(await mock_get_temp()).then_raise(exc)
+    monkeypatch.setattr(subject._driver, "get_temperature", mock_get_temp)
+    with pytest.raises(Exception, match="oh no!"):
+        await subject._poller.wait_next_poll()
+    decoy.verify(
+        module_error_callback(
+            exc, "temperatureModuleV1", "/dev/ot_module_sim_tempdeck0", "dummySerialTD"
+        )
+    )

--- a/api/tests/opentrons/hardware_control/modules/test_hc_thermocycler.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_thermocycler.py
@@ -1,10 +1,15 @@
 import asyncio
 import mock
 from typing import Any, AsyncGenerator, cast
-from opentrons.drivers.types import Temperature, PlateTemperature, ThermocyclerLidStatus
 
 import pytest
+from decoy import Decoy
 
+from opentrons.hardware_control.modules.types import (
+    ModuleErrorCallback,
+    ModuleDisconnectedCallback,
+)
+from opentrons.drivers.types import Temperature, PlateTemperature, ThermocyclerLidStatus
 from opentrons.drivers.rpi_drivers.types import USBPort
 from opentrons.drivers.thermocycler import SimulatingDriver
 from opentrons.hardware_control import modules, ExecutionManager
@@ -19,6 +24,7 @@ SIMULATING_POLL_PERIOD = POLL_PERIOD / 20.0
 
 @pytest.fixture
 def usb_port() -> USBPort:
+    """Token USB port."""
     return USBPort(
         name="",
         port_number=0,
@@ -27,30 +33,44 @@ def usb_port() -> USBPort:
 
 
 @pytest.fixture
-async def subject(usb_port: USBPort) -> AsyncGenerator[modules.Thermocycler, None]:
-    """Test subject"""
+async def subject(
+    usb_port: USBPort,
+    module_error_callback: ModuleErrorCallback,
+    module_disconnected_callback: ModuleDisconnectedCallback,
+    mock_execution_manager: ExecutionManager,
+) -> AsyncGenerator[modules.Thermocycler, None]:
+    """V1 test subject."""
     therm = await modules.build(
         port="/dev/ot_module_sim_thermocycler0",
         usb_port=usb_port,
         type=modules.ModuleType["THERMOCYCLER"],
         simulating=True,
         hw_control_loop=asyncio.get_running_loop(),
-        execution_manager=ExecutionManager(),
+        execution_manager=mock_execution_manager,
+        error_callback=module_error_callback,
+        disconnected_callback=module_disconnected_callback,
     )
     yield cast(modules.Thermocycler, therm)
     await therm.cleanup()
 
 
 @pytest.fixture
-async def subject_v2(usb_port: USBPort) -> AsyncGenerator[modules.Thermocycler, None]:
-    """Test subject"""
+async def subject_v2(
+    usb_port: USBPort,
+    module_error_callback: ModuleErrorCallback,
+    module_disconnected_callback: ModuleDisconnectedCallback,
+    mock_execution_manager: ExecutionManager,
+) -> AsyncGenerator[modules.Thermocycler, None]:
+    """V2 test subject."""
     therm = await modules.build(
         port="/dev/ot_module_sim_thermocycler0",
         usb_port=usb_port,
         type=modules.ModuleType["THERMOCYCLER"],
         simulating=True,
         hw_control_loop=asyncio.get_running_loop(),
-        execution_manager=ExecutionManager(),
+        execution_manager=mock_execution_manager,
+        error_callback=module_error_callback,
+        disconnected_callback=module_disconnected_callback,
         sim_model="thermocyclerModuleV2",
     )
     yield cast(modules.Thermocycler, therm)
@@ -58,10 +78,12 @@ async def subject_v2(usb_port: USBPort) -> AsyncGenerator[modules.Thermocycler, 
 
 
 async def test_sim_initialization(subject: modules.Thermocycler) -> None:
+    """It should build a sim object."""
     assert isinstance(subject, modules.AbstractModule)
 
 
 async def test_lid(subject: modules.Thermocycler) -> None:
+    """It should handle lid status."""
     await subject.open()
     assert subject.lid_status == "open"
 
@@ -78,6 +100,7 @@ async def test_lid(subject: modules.Thermocycler) -> None:
 async def test_plate_lift(
     subject: modules.Thermocycler, subject_v2: modules.Thermocycler
 ) -> None:
+    """It should handle plate lift."""
     # First test Gen1 behavior
     await subject.close()
     with pytest.raises(NotImplementedError):
@@ -99,6 +122,7 @@ async def test_plate_lift(
 async def test_raise_plate(
     subject: modules.Thermocycler, subject_v2: modules.Thermocycler
 ) -> None:
+    """It should handle plate raise."""
     # First test Gen1 behavior
     await subject.open()
     with pytest.raises(NotImplementedError):
@@ -122,6 +146,7 @@ async def test_raise_plate(
 
 
 async def test_sim_state(subject: modules.Thermocycler) -> None:
+    """It should forward simulated state."""
     assert subject.temperature == 23
     assert subject.target is None
     assert subject.status == "idle"
@@ -137,6 +162,7 @@ async def test_sim_state(subject: modules.Thermocycler) -> None:
 
 
 async def test_sim_update(subject: modules.Thermocycler) -> None:
+    """It should update simulated state."""
     await subject.set_temperature(
         temperature=10, hold_time_seconds=None, hold_time_minutes=None, volume=50
     )
@@ -183,11 +209,13 @@ async def test_sim_update(subject: modules.Thermocycler) -> None:
 
 @pytest.fixture
 def simulator() -> SimulatingDriver:
+    """Build a driver simulator."""
     return SimulatingDriver()
 
 
 @pytest.fixture
 def set_plate_temp_spy(simulator: SimulatingDriver) -> mock.AsyncMock:
+    """Build a spy for set plate temp."""
     return mock.AsyncMock(wraps=simulator.set_plate_temperature)
 
 
@@ -202,7 +230,11 @@ def simulator_set_plate_spy(
 
 @pytest.fixture
 async def set_temperature_subject(
-    usb_port: USBPort, simulator_set_plate_spy: SimulatingDriver
+    usb_port: USBPort,
+    simulator_set_plate_spy: SimulatingDriver,
+    mock_execution_manager: ExecutionManager,
+    module_error_callback: ModuleErrorCallback,
+    module_disconnected_callback: ModuleDisconnectedCallback,
 ) -> AsyncGenerator[modules.Thermocycler, None]:
     """Fixture that spys on set_plate_temperature"""
     reader = ThermocyclerReader(driver=simulator_set_plate_spy)
@@ -212,11 +244,13 @@ async def set_temperature_subject(
         port="/dev/ot_module_sim_thermocycler0",
         usb_port=usb_port,
         hw_control_loop=asyncio.get_running_loop(),
-        execution_manager=ExecutionManager(),
         driver=simulator_set_plate_spy,
         reader=reader,
         poller=poller,
         device_info={},
+        execution_manager=mock_execution_manager,
+        error_callback=module_error_callback,
+        disconnected_callback=module_disconnected_callback,
     )
 
     await poller.start()
@@ -226,6 +260,7 @@ async def set_temperature_subject(
 
 @pytest.fixture
 def mock_driver(simulator: SimulatingDriver) -> mock.AsyncMock:
+    """Build a fully mocked driver."""
     return mock.AsyncMock(spec=simulator)
 
 
@@ -233,6 +268,9 @@ def mock_driver(simulator: SimulatingDriver) -> mock.AsyncMock:
 async def subject_mocked_driver(
     usb_port: USBPort,
     mock_driver: mock.AsyncMock,
+    mock_execution_manager: ExecutionManager,
+    module_disconnected_callback: ModuleDisconnectedCallback,
+    module_error_callback: ModuleErrorCallback,
 ) -> AsyncGenerator[modules.Thermocycler, None]:
     """Test subject with mocked driver"""
     reader = ThermocyclerReader(driver=mock_driver)
@@ -249,7 +287,9 @@ async def subject_mocked_driver(
             "version": "dummyVersionTC",
         },
         hw_control_loop=asyncio.get_running_loop(),
-        execution_manager=ExecutionManager(),
+        execution_manager=mock_execution_manager,
+        disconnected_callback=module_disconnected_callback,
+        error_callback=module_error_callback,
     )
     mock_driver.get_lid_temperature.return_value = Temperature(current=10, target=None)
     mock_driver.get_lid_status.return_value = ThermocyclerLidStatus.OPEN
@@ -419,12 +459,24 @@ async def test_sync_error_response_to_poller(
 async def test_async_error_response_to_poller(
     subject_mocked_driver: modules.Thermocycler,
     mock_driver: mock.AsyncMock,
+    module_error_callback: ModuleErrorCallback,
+    decoy: Decoy,
 ) -> None:
     """Test that asynchronous error is detected by poller and module live data and status are updated."""
     mock_driver.get_lid_temperature.return_value = Temperature(current=50, target=50)
     mock_driver.get_lid_status.return_value = ThermocyclerLidStatus.OPEN
-    mock_driver.get_plate_temperature.side_effect = Exception()
+    mock_driver.model.return_value = "some-model"
+    exc = Exception("oh no!")
+    mock_driver.get_plate_temperature.side_effect = exc
     with pytest.raises(Exception):
         await subject_mocked_driver._poller.wait_next_poll()
     assert subject_mocked_driver.live_data["status"] == "error"
     assert subject_mocked_driver.status == modules.TemperatureStatus.ERROR
+    decoy.verify(
+        module_error_callback(
+            exc,
+            "some-model",
+            "/dev/ot_module_sim_thermocycler0",
+            "dummySerialTC",
+        )
+    )

--- a/api/tests/opentrons/hardware_control/test_module_control.py
+++ b/api/tests/opentrons/hardware_control/test_module_control.py
@@ -1,11 +1,12 @@
 """Tests for opentrons.hardware_control.module_control."""
+
 import pytest
 from decoy import Decoy, matchers
 from typing import Awaitable, Callable, cast, Union, List
 
 from opentrons.drivers.rpi_drivers.types import USBPort
 from opentrons.drivers.rpi_drivers.interfaces import USBDriverInterface
-from opentrons.hardware_control import API as HardwareAPI
+from opentrons.hardware_control import API as HardwareAPI, types
 from opentrons.hardware_control.modules import AbstractModule
 from opentrons.hardware_control.modules.types import (
     ModuleAtPort,
@@ -45,12 +46,20 @@ def build_module(decoy: Decoy) -> Callable[..., Awaitable[AbstractModule]]:
 
 
 @pytest.fixture()
+def event_callback(decoy: Decoy) -> Callable[[types.HardwareEvent], None]:
+    return decoy.mock(name="event_callback")  # type: ignore[no-any-return]
+
+
+@pytest.fixture()
 def subject(
     hardware_api: HardwareAPI,
     usb_bus: USBDriverInterface,
     build_module: Callable[..., Awaitable[AbstractModule]],
+    event_callback: Callable[[types.HardwareEvent], None],
 ) -> AttachedModulesControl:
-    modules_control = AttachedModulesControl(api=hardware_api, usb=usb_bus)
+    modules_control = AttachedModulesControl(
+        api=hardware_api, usb=usb_bus, event_callback=event_callback
+    )
 
     # TODO(mc, 2022-03-01): partial patching the class under test creates
     # a contaminated test subject that reduces the value of these tests

--- a/api/tests/opentrons/hardware_control/test_modules.py
+++ b/api/tests/opentrons/hardware_control/test_modules.py
@@ -19,6 +19,8 @@ from opentrons.hardware_control.modules.types import (
     AbsorbanceReaderModel,
     FlexStackerModuleModel,
     ModuleType,
+    ModuleDisconnectedCallback,
+    ModuleErrorCallback,
 )
 from opentrons.hardware_control.modules import (
     TempDeck,
@@ -137,7 +139,11 @@ async def test_create_simulating_module(
 
 
 @pytest.fixture
-async def mod_tempdeck() -> AsyncIterator[AbstractModule]:
+async def mod_tempdeck(
+    module_disconnected_callback: ModuleDisconnectedCallback,
+    module_error_callback: ModuleErrorCallback,
+    mock_execution_manager: ExecutionManager,
+) -> AsyncIterator[AbstractModule]:
 
     usb_port = USBPort(
         name="",
@@ -152,7 +158,9 @@ async def mod_tempdeck() -> AsyncIterator[AbstractModule]:
         type=ModuleType.TEMPERATURE,
         simulating=True,
         hw_control_loop=asyncio.get_running_loop(),
-        execution_manager=ExecutionManager(),
+        execution_manager=mock_execution_manager,
+        disconnected_callback=module_disconnected_callback,
+        error_callback=module_error_callback,
         sim_model="temperatureModuleV2",
     )
     yield tempdeck
@@ -160,7 +168,11 @@ async def mod_tempdeck() -> AsyncIterator[AbstractModule]:
 
 
 @pytest.fixture
-async def mod_magdeck() -> AsyncIterator[AbstractModule]:
+async def mod_magdeck(
+    module_disconnected_callback: ModuleDisconnectedCallback,
+    module_error_callback: ModuleErrorCallback,
+    mock_execution_manager: ExecutionManager,
+) -> AsyncIterator[AbstractModule]:
     usb_port = USBPort(
         name="",
         hub=False,
@@ -174,14 +186,20 @@ async def mod_magdeck() -> AsyncIterator[AbstractModule]:
         type=ModuleType.MAGNETIC,
         simulating=True,
         hw_control_loop=asyncio.get_running_loop(),
-        execution_manager=ExecutionManager(),
+        execution_manager=mock_execution_manager,
+        disconnected_callback=module_disconnected_callback,
+        error_callback=module_error_callback,
     )
     yield magdeck
     await magdeck.cleanup()
 
 
 @pytest.fixture
-async def mod_thermocycler() -> AsyncIterator[AbstractModule]:
+async def mod_thermocycler(
+    module_disconnected_callback: ModuleDisconnectedCallback,
+    module_error_callback: ModuleErrorCallback,
+    mock_execution_manager: ExecutionManager,
+) -> AsyncIterator[AbstractModule]:
     usb_port = USBPort(
         name="",
         hub=False,
@@ -195,14 +213,20 @@ async def mod_thermocycler() -> AsyncIterator[AbstractModule]:
         type=ModuleType.THERMOCYCLER,
         simulating=True,
         hw_control_loop=asyncio.get_running_loop(),
-        execution_manager=ExecutionManager(),
+        execution_manager=mock_execution_manager,
+        disconnected_callback=module_disconnected_callback,
+        error_callback=module_error_callback,
     )
     yield thermocycler
     await thermocycler.cleanup()
 
 
 @pytest.fixture
-async def mod_thermocycler_gen2() -> AsyncIterator[AbstractModule]:
+async def mod_thermocycler_gen2(
+    module_disconnected_callback: ModuleDisconnectedCallback,
+    module_error_callback: ModuleErrorCallback,
+    mock_execution_manager: ExecutionManager,
+) -> AsyncIterator[AbstractModule]:
     usb_port = USBPort(
         name="",
         hub=False,
@@ -216,7 +240,9 @@ async def mod_thermocycler_gen2() -> AsyncIterator[AbstractModule]:
         type=ModuleType.THERMOCYCLER,
         simulating=True,
         hw_control_loop=asyncio.get_running_loop(),
-        execution_manager=ExecutionManager(),
+        execution_manager=mock_execution_manager,
+        disconnected_callback=module_disconnected_callback,
+        error_callback=module_error_callback,
         sim_model="thermocyclerModuleV2",
     )
     yield thermocycler
@@ -224,7 +250,11 @@ async def mod_thermocycler_gen2() -> AsyncIterator[AbstractModule]:
 
 
 @pytest.fixture
-async def mod_heatershaker() -> AsyncIterator[AbstractModule]:
+async def mod_heatershaker(
+    module_disconnected_callback: ModuleDisconnectedCallback,
+    module_error_callback: ModuleErrorCallback,
+    mock_execution_manager: ExecutionManager,
+) -> AsyncIterator[AbstractModule]:
     usb_port = USBPort(
         name="",
         hub=False,
@@ -238,14 +268,20 @@ async def mod_heatershaker() -> AsyncIterator[AbstractModule]:
         type=ModuleType.HEATER_SHAKER,
         simulating=True,
         hw_control_loop=asyncio.get_running_loop(),
-        execution_manager=ExecutionManager(),
+        execution_manager=mock_execution_manager,
+        disconnected_callback=module_disconnected_callback,
+        error_callback=module_error_callback,
     )
     yield heatershaker
     await heatershaker.cleanup()
 
 
 @pytest.fixture
-async def mod_absorbancereader() -> AsyncIterator[AbstractModule]:
+async def mod_absorbancereader(
+    module_disconnected_callback: ModuleDisconnectedCallback,
+    module_error_callback: ModuleErrorCallback,
+    mock_execution_manager: ExecutionManager,
+) -> AsyncIterator[AbstractModule]:
     usb_port = USBPort(
         name="",
         hub=False,
@@ -259,14 +295,20 @@ async def mod_absorbancereader() -> AsyncIterator[AbstractModule]:
         type=ModuleType.ABSORBANCE_READER,
         simulating=True,
         hw_control_loop=asyncio.get_running_loop(),
-        execution_manager=ExecutionManager(),
+        execution_manager=mock_execution_manager,
+        disconnected_callback=module_disconnected_callback,
+        error_callback=module_error_callback,
     )
     yield absorbancereader
     await absorbancereader.cleanup()
 
 
 @pytest.fixture
-async def mod_flexstacker() -> AsyncIterator[AbstractModule]:
+async def mod_flexstacker(
+    module_disconnected_callback: ModuleDisconnectedCallback,
+    module_error_callback: ModuleErrorCallback,
+    mock_execution_manager: ExecutionManager,
+) -> AsyncIterator[AbstractModule]:
     usb_port = USBPort(
         name="",
         hub=False,
@@ -280,7 +322,9 @@ async def mod_flexstacker() -> AsyncIterator[AbstractModule]:
         type=ModuleType.FLEX_STACKER,
         simulating=True,
         hw_control_loop=asyncio.get_running_loop(),
-        execution_manager=ExecutionManager(),
+        execution_manager=mock_execution_manager,
+        disconnected_callback=module_disconnected_callback,
+        error_callback=module_error_callback,
     )
     yield flexstacker
     await flexstacker.cleanup()

--- a/api/tests/opentrons/protocol_engine/state/test_command_state.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_state.py
@@ -1020,8 +1020,8 @@ def test_recovery_target_tracking() -> None:
 @pytest.mark.parametrize(
     "ending_action",
     [
-        actions.StopAction(from_estop=False),
-        actions.StopAction(from_estop=True),
+        actions.StopAction(from_asynchronous_error=False),
+        actions.StopAction(from_asynchronous_error=True),
         actions.FinishAction(set_run_status=False),
         actions.FinishAction(
             set_run_status=True,
@@ -1089,7 +1089,7 @@ def test_final_state_after_estop() -> None:
         detail="E-stop activated.",
     )
 
-    subject.handle_action(actions.StopAction(from_estop=True))
+    subject.handle_action(actions.StopAction(from_asynchronous_error=True))
     subject.handle_action(actions.FinishAction(error_details=error_details))
     subject.handle_action(
         actions.HardwareStoppedAction(

--- a/api/tests/opentrons/protocol_engine/state/test_command_store_old.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_store_old.py
@@ -5,7 +5,6 @@ Try to add new tests to test_command_state.py, where they can be tested together
 treating CommandState as a private implementation detail.
 """
 
-
 from decoy import matchers
 import pytest
 from datetime import datetime
@@ -333,7 +332,7 @@ def test_command_store_handles_pause_action(pause_source: PauseSource) -> None:
         command_error_recovery_types={},
         recovery_target=None,
         latest_protocol_command_hash=None,
-        stopped_by_estop=False,
+        stopped_by_async_error=False,
         error_recovery_policy=matchers.Anything(),
         has_entered_error_recovery=False,
     )
@@ -362,7 +361,7 @@ def test_command_store_handles_play_action(pause_source: PauseSource) -> None:
         recovery_target=None,
         run_started_at=datetime(year=2021, month=1, day=1),
         latest_protocol_command_hash=None,
-        stopped_by_estop=False,
+        stopped_by_async_error=False,
         error_recovery_policy=matchers.Anything(),
         has_entered_error_recovery=False,
     )
@@ -396,7 +395,7 @@ def test_command_store_handles_finish_action() -> None:
         recovery_target=None,
         run_started_at=datetime(year=2021, month=1, day=1),
         latest_protocol_command_hash=None,
-        stopped_by_estop=False,
+        stopped_by_async_error=False,
         error_recovery_policy=matchers.Anything(),
         has_entered_error_recovery=False,
     )
@@ -421,11 +420,11 @@ def test_command_store_handles_finish_action_with_stopped() -> None:
 
 
 @pytest.mark.parametrize(
-    ["from_estop", "expected_run_result"],
+    ["from_asynchronous_error", "expected_run_result"],
     [(True, RunResult.FAILED), (False, RunResult.STOPPED)],
 )
 def test_command_store_handles_stop_action(
-    from_estop: bool, expected_run_result: RunResult
+    from_asynchronous_error: bool, expected_run_result: RunResult
 ) -> None:
     """It should mark the engine as non-gracefully stopped on StopAction."""
     subject = CommandStore(
@@ -435,7 +434,7 @@ def test_command_store_handles_stop_action(
     )
 
     subject.handle_action(PlayAction(requested_at=datetime(year=2021, month=1, day=1)))
-    subject.handle_action(StopAction(from_estop=from_estop))
+    subject.handle_action(StopAction(from_asynchronous_error=from_asynchronous_error))
 
     assert subject.state == CommandState(
         command_history=CommandHistory(),
@@ -450,7 +449,7 @@ def test_command_store_handles_stop_action(
         recovery_target=None,
         run_started_at=datetime(year=2021, month=1, day=1),
         latest_protocol_command_hash=None,
-        stopped_by_estop=from_estop,
+        stopped_by_async_error=from_asynchronous_error,
         error_recovery_policy=matchers.Anything(),
         has_entered_error_recovery=False,
     )
@@ -487,7 +486,7 @@ def test_command_store_handles_stop_action_when_awaiting_recovery() -> None:
         recovery_target=None,
         run_started_at=datetime(year=2021, month=1, day=1),
         latest_protocol_command_hash=None,
-        stopped_by_estop=False,
+        stopped_by_async_error=False,
         error_recovery_policy=matchers.Anything(),
         has_entered_error_recovery=False,
     )
@@ -520,7 +519,7 @@ def test_command_store_cannot_restart_after_should_stop() -> None:
         recovery_target=None,
         run_started_at=None,
         latest_protocol_command_hash=None,
-        stopped_by_estop=False,
+        stopped_by_async_error=False,
         error_recovery_policy=matchers.Anything(),
         has_entered_error_recovery=False,
     )
@@ -666,7 +665,7 @@ def test_command_store_wraps_unknown_errors() -> None:
         command_error_recovery_types={},
         recovery_target=None,
         latest_protocol_command_hash=None,
-        stopped_by_estop=False,
+        stopped_by_async_error=False,
         error_recovery_policy=matchers.Anything(),
         has_entered_error_recovery=False,
     )
@@ -735,7 +734,7 @@ def test_command_store_preserves_enumerated_errors() -> None:
         recovery_target=None,
         run_started_at=None,
         latest_protocol_command_hash=None,
-        stopped_by_estop=False,
+        stopped_by_async_error=False,
         error_recovery_policy=matchers.Anything(),
         has_entered_error_recovery=False,
     )
@@ -770,7 +769,7 @@ def test_command_store_ignores_stop_after_graceful_finish() -> None:
         recovery_target=None,
         run_started_at=datetime(year=2021, month=1, day=1),
         latest_protocol_command_hash=None,
-        stopped_by_estop=False,
+        stopped_by_async_error=False,
         error_recovery_policy=matchers.Anything(),
         has_entered_error_recovery=False,
     )
@@ -805,7 +804,7 @@ def test_command_store_ignores_finish_after_non_graceful_stop() -> None:
         recovery_target=None,
         run_started_at=datetime(year=2021, month=1, day=1),
         latest_protocol_command_hash=None,
-        stopped_by_estop=False,
+        stopped_by_async_error=False,
         error_recovery_policy=matchers.Anything(),
         has_entered_error_recovery=False,
     )
@@ -840,7 +839,7 @@ def test_handles_hardware_stopped() -> None:
         recovery_target=None,
         run_started_at=None,
         latest_protocol_command_hash=None,
-        stopped_by_estop=False,
+        stopped_by_async_error=False,
         error_recovery_policy=matchers.Anything(),
         has_entered_error_recovery=False,
     )

--- a/api/tests/opentrons/protocol_engine/state/test_command_view_old.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_view_old.py
@@ -5,7 +5,6 @@ Try to add new tests to test_command_state.py, where they can be tested together
 treating CommandState as a private implementation detail.
 """
 
-
 import pytest
 from contextlib import nullcontext as does_not_raise, AbstractContextManager
 from datetime import datetime
@@ -110,15 +109,17 @@ def get_command_view(  # noqa: C901
         finish_error=finish_error,
         failed_command=failed_command,
         command_error_recovery_types=command_error_recovery_types or {},
-        recovery_target=_RecoveryTargetInfo(
-            command_id=recovery_target_command_id,
-            state_update_if_false_positive=StateUpdate(),
-        )
-        if recovery_target_command_id is not None
-        else None,
+        recovery_target=(
+            _RecoveryTargetInfo(
+                command_id=recovery_target_command_id,
+                state_update_if_false_positive=StateUpdate(),
+            )
+            if recovery_target_command_id is not None
+            else None
+        ),
         run_started_at=run_started_at,
         latest_protocol_command_hash=latest_command_hash,
-        stopped_by_estop=False,
+        stopped_by_async_error=False,
         has_entered_error_recovery=has_entered_error_recovery,
         error_recovery_policy=_placeholder_error_recovery_policy,
     )

--- a/api/tests/opentrons/protocol_engine/state/test_module_view_old.py
+++ b/api/tests/opentrons/protocol_engine/state/test_module_view_old.py
@@ -2101,3 +2101,69 @@ def test_stacker_max_pool_count_by_height(
         )
         == expected_pool_count
     )
+
+
+@pytest.mark.parametrize(
+    "module_model,module_serial,has_match",
+    [
+        (ModuleModel.TEMPERATURE_MODULE_V2, "serial-3", True),
+        (
+            ModuleModel.TEMPERATURE_MODULE_V1,
+            "serial-3",
+            True,
+        ),  # serial number is prioritized over model
+        (ModuleModel.TEMPERATURE_MODULE_V2, "serial-2", True),
+        (ModuleModel.TEMPERATURE_MODULE_V2, "serial-7", False),
+        (ModuleModel.TEMPERATURE_MODULE_V2, None, True),
+        (ModuleModel.FLEX_STACKER_MODULE_V1, "serial-1", True),
+        (ModuleModel.FLEX_STACKER_MODULE_V1, "serial-4", True),
+        (ModuleModel.FLEX_STACKER_MODULE_V1, "serial-9", False),
+        (ModuleModel.FLEX_STACKER_MODULE_V1, None, True),
+    ],
+)
+def test_get_has_module_probably_matching_hardware_details(
+    module_model: ModuleModel,
+    module_serial: str | None,
+    has_match: bool,
+    flex_stacker_v1_def: ModuleDefinition,
+    thermocycler_v2_def: ModuleDefinition,
+    tempdeck_v2_def: ModuleDefinition,
+) -> None:
+    """It should appropriately match hardware module details."""
+    subject = make_module_view(
+        slot_by_module_id={
+            "module-1": DeckSlotName.SLOT_D3,
+            "module-2": DeckSlotName.SLOT_A1,
+            "module-3": DeckSlotName.SLOT_D1,
+            "module-4": DeckSlotName.SLOT_C3,
+        },
+        requested_model_by_module_id={
+            "module-1": ModuleModel.FLEX_STACKER_MODULE_V1,
+            "module-2": ModuleModel.THERMOCYCLER_MODULE_V2,
+            "module-3": ModuleModel.TEMPERATURE_MODULE_V2,
+            "module-4": ModuleModel.FLEX_STACKER_MODULE_V1,
+        },
+        hardware_by_module_id={
+            "module-1": HardwareModule(
+                serial_number="serial-1",
+                definition=flex_stacker_v1_def,
+            ),
+            "module-2": HardwareModule(
+                serial_number="serial-2",
+                definition=thermocycler_v2_def,
+            ),
+            "module-3": HardwareModule(
+                serial_number="serial-3",
+                definition=tempdeck_v2_def,
+            ),
+            "module-4": HardwareModule(
+                serial_number="serial-4", definition=flex_stacker_v1_def
+            ),
+        },
+    )
+    assert (
+        subject.get_has_module_probably_matching_hardware_details(
+            module_model, module_serial
+        )
+        is has_match
+    )

--- a/api/tests/opentrons/protocol_engine/test_protocol_engine.py
+++ b/api/tests/opentrons/protocol_engine/test_protocol_engine.py
@@ -704,7 +704,7 @@ async def test_finish(
     """It should be able to gracefully tell the engine it's done."""
     completed_at = datetime(2021, 1, 1, 0, 0)
 
-    decoy.when(state_store.commands.get_is_stopped_by_estop()).then_return(False)
+    decoy.when(state_store.commands.get_is_stopped_by_async_error()).then_return(False)
     decoy.when(model_utils.get_timestamp()).then_return(completed_at)
 
     await subject.finish(
@@ -739,7 +739,7 @@ async def test_finish_with_defaults(
     state_store: StateStore,
 ) -> None:
     """It should be able to gracefully tell the engine it's done."""
-    decoy.when(state_store.commands.get_is_stopped_by_estop()).then_return(False)
+    decoy.when(state_store.commands.get_is_stopped_by_async_error()).then_return(False)
     await subject.finish()
 
     decoy.verify(
@@ -781,7 +781,7 @@ async def test_finish_with_error(
         error=error,
     )
 
-    decoy.when(state_store.commands.get_is_stopped_by_estop()).then_return(
+    decoy.when(state_store.commands.get_is_stopped_by_async_error()).then_return(
         stopped_by_estop
     )
     decoy.when(model_utils.generate_id()).then_return("error-id")
@@ -881,7 +881,7 @@ async def test_finish_stops_hardware_if_queue_worker_join_fails(
         await queue_worker.join(),
     ).then_raise(exception)
 
-    decoy.when(state_store.commands.get_is_stopped_by_estop()).then_return(False)
+    decoy.when(state_store.commands.get_is_stopped_by_async_error()).then_return(False)
 
     error_id = "error-id"
     completed_at = datetime(2021, 1, 1, 0, 0)
@@ -979,6 +979,96 @@ async def test_stop_for_legacy_core_protocols(
     )
 
 
+async def test_async_module_error_stops_on_match(
+    decoy: Decoy,
+    action_dispatcher: ActionDispatcher,
+    queue_worker: QueueWorker,
+    state_store: StateStore,
+    subject: ProtocolEngine,
+) -> None:
+    """It should be stop the engine if a matching module exists."""
+    module_model = ModuleModel.THERMOCYCLER_MODULE_V1
+    serial = "hello"
+    expected_action = StopAction(from_asynchronous_error=True)
+    validated_action = sentinel.validated_action
+    decoy.when(
+        state_store.commands.validate_action_allowed(expected_action),
+    ).then_return(validated_action)
+    decoy.when(
+        state_store.modules.get_has_module_probably_matching_hardware_details(
+            module_model, serial
+        )
+    ).then_return(True)
+
+    assert await subject.async_module_error(module_model, serial) is True
+
+    decoy.verify(
+        action_dispatcher.dispatch(action=validated_action),
+        queue_worker.cancel(),
+    )
+
+
+async def test_async_module_error_noops_on_no_match(
+    decoy: Decoy,
+    action_dispatcher: ActionDispatcher,
+    queue_worker: QueueWorker,
+    state_store: StateStore,
+    subject: ProtocolEngine,
+) -> None:
+    """It should be stop the engine if a matching module exists."""
+    module_model = ModuleModel.THERMOCYCLER_MODULE_V1
+    serial = "hello"
+    validated_action = sentinel.validated_action
+    decoy.when(
+        state_store.modules.get_has_module_probably_matching_hardware_details(
+            module_model, serial
+        )
+    ).then_return(False)
+
+    assert await subject.async_module_error(module_model, serial) is False
+
+    decoy.verify(
+        action_dispatcher.dispatch(action=validated_action),
+        queue_worker.cancel(),
+        times=0,
+    )
+
+
+async def test_async_module_error_noops_if_invalid(
+    decoy: Decoy,
+    action_dispatcher: ActionDispatcher,
+    queue_worker: QueueWorker,
+    state_store: StateStore,
+    subject: ProtocolEngine,
+) -> None:
+    """It should no-op if a stop is invalid right now.."""
+    module_model = ModuleModel.THERMOCYCLER_MODULE_V1
+    serial = "hello"
+    expected_action = StopAction(from_asynchronous_error=True)
+    decoy.when(
+        state_store.modules.get_has_module_probably_matching_hardware_details(
+            module_model, serial
+        )
+    ).then_return(True)
+    decoy.when(
+        state_store.commands.validate_action_allowed(expected_action),
+    ).then_raise(RuntimeError("unable to stop; this machine craves flesh"))
+
+    assert (
+        await subject.async_module_error(module_model, serial) is True
+    )  # Should not raise, should act as-if it worked
+
+    decoy.verify(
+        action_dispatcher.dispatch(expected_action),
+        times=0,
+    )
+    decoy.verify(
+        queue_worker.cancel(),
+        ignore_extra_args=True,
+        times=0,
+    )
+
+
 async def test_estop(
     decoy: Decoy,
     action_dispatcher: ActionDispatcher,
@@ -987,7 +1077,7 @@ async def test_estop(
     subject: ProtocolEngine,
 ) -> None:
     """It should be able to stop the engine."""
-    expected_action = StopAction(from_estop=True)
+    expected_action = StopAction(from_asynchronous_error=True)
     validated_action = sentinel.validated_action
     decoy.when(
         state_store.commands.validate_action_allowed(expected_action),
@@ -1009,7 +1099,7 @@ async def test_estop_noops_if_invalid(
     subject: ProtocolEngine,
 ) -> None:
     """It should no-op if a stop is invalid right now.."""
-    expected_action = StopAction(from_estop=True)
+    expected_action = StopAction(from_asynchronous_error=True)
     decoy.when(
         state_store.commands.validate_action_allowed(expected_action),
     ).then_raise(RuntimeError("unable to stop; this machine craves flesh"))

--- a/api/tests/opentrons/protocol_engine/test_types.py
+++ b/api/tests/opentrons/protocol_engine/test_types.py
@@ -8,6 +8,17 @@ from opentrons.protocol_engine.types import (
     SimulatedProbeResult,
     LiquidTrackingType,
     WellInfoSummary,
+    ModuleModel,
+)
+from opentrons.hardware_control.modules.types import (
+    MagneticModuleModel,
+    TemperatureModuleModel,
+    ThermocyclerModuleModel,
+    HeaterShakerModuleModel,
+    MagneticBlockModel,
+    AbsorbanceReaderModel,
+    FlexStackerModuleModel,
+    ModuleModel as HWModuleModel,
 )
 
 
@@ -101,3 +112,19 @@ def test_simulated_probe_result_operand_math(
         _error = _e
     assert _error is None
     assert r is not None
+
+
+@pytest.mark.parametrize(
+    "hardware_module_model",
+    [m for m in MagneticModuleModel]
+    + [m for m in TemperatureModuleModel]
+    + [m for m in ThermocyclerModuleModel]
+    + [m for m in HeaterShakerModuleModel]
+    + [m for m in MagneticBlockModel]
+    + [m for m in AbsorbanceReaderModel]
+    + [m for m in FlexStackerModuleModel],
+)
+def test_module_model_translation(hardware_module_model: HWModuleModel) -> None:
+    """It should turn every hardware module model into an engine model."""
+    engine_module = ModuleModel.from_hardware(hardware_module_model)
+    assert engine_module.value == hardware_module_model.value

--- a/api/tests/opentrons/protocol_runner/test_run_orchestrator.py
+++ b/api/tests/opentrons/protocol_runner/test_run_orchestrator.py
@@ -1,4 +1,5 @@
 """Tests for the RunOrchestrator."""
+
 from pathlib import Path
 
 import pytest
@@ -13,9 +14,15 @@ from opentrons.protocol_engine.errors import RunStoppedError
 from opentrons.protocol_engine.state.state import StateStore
 from opentrons.protocols.api_support.types import APIVersion
 from opentrons.protocol_engine import ProtocolEngine
-from opentrons.protocol_engine.types import PostRunHardwareState
+from opentrons.protocol_engine.types import (
+    PostRunHardwareState,
+    ModuleModel as EngineModuleModel,
+)
 from opentrons.protocol_engine import commands as pe_commands
 from opentrons.hardware_control import API as HardwareAPI
+from opentrons.hardware_control.modules.types import (
+    TemperatureModuleModel as HardwareTemperatureModuleModel,
+)
 from opentrons.protocol_reader import (
     JsonProtocolConfig,
     PythonProtocolConfig,
@@ -534,3 +541,24 @@ def test_create_error_recovery_policy(
     policy = decoy.mock(cls=ErrorRecoveryPolicy)
     live_protocol_subject.set_error_recovery_policy(policy)
     decoy.verify(mock_protocol_engine.set_error_recovery_policy(policy))
+
+
+async def test_transform_module_model_in_ame(
+    decoy: Decoy,
+    python_protocol_subject: RunOrchestrator,
+    mock_protocol_engine: ProtocolEngine,
+) -> None:
+    """It should make the module model the PE kind in its asynch module error call."""
+    decoy.when(
+        await mock_protocol_engine.async_module_error(
+            module_model=EngineModuleModel.TEMPERATURE_MODULE_V2,
+            serial="whatever",
+        )
+    ).then_return(True)
+    assert (
+        await python_protocol_subject.asynchronous_module_error(
+            module_model=HardwareTemperatureModuleModel.TEMPERATURE_V2,
+            module_serial="whatever",
+        )
+        is True
+    )

--- a/robot-server/robot_server/runs/run_orchestrator_store.py
+++ b/robot-server/robot_server/runs/run_orchestrator_store.py
@@ -23,6 +23,7 @@ from opentrons.hardware_control.types import (
     HardwareEvent,
     EstopStateNotification,
     HardwareEventHandler,
+    AsynchronousModuleErrorNotification,
 )
 from opentrons.protocols.api_support.deck_type import should_load_fixed_trash
 from opentrons.protocol_runner import (
@@ -71,7 +72,33 @@ class NoRunOrchestrator(RuntimeError):
     """Raised if you try to get the current run orchestrator while there is none."""
 
 
-async def handle_estop_event(
+async def _do_handle_hardware_event(
+    run_orchestrator_store: "RunOrchestratorStore", event: HardwareEvent
+) -> None:
+    if isinstance(event, EstopStateNotification):
+        if event.new_state is not EstopState.PHYSICALLY_ENGAGED:
+            return
+        if run_orchestrator_store.current_run_id is None:
+            return
+        # todo(mm, 2024-04-17): This estop teardown sequencing belongs in the
+        # runner layer.
+        run_orchestrator_store.run_orchestrator.estop()
+        await run_orchestrator_store.run_orchestrator.finish(
+            error=EStopActivatedError()
+        )
+    elif isinstance(event, AsynchronousModuleErrorNotification):
+        if run_orchestrator_store.current_run_id is None:
+            return
+        should_finish = (
+            await run_orchestrator_store.run_orchestrator.asynchronous_module_error(
+                module_model=event.module_model, module_serial=event.module_serial
+            )
+        )
+        if should_finish:
+            await run_orchestrator_store.run_orchestrator.finish(error=event.exception)
+
+
+async def handle_hardware_event(
     run_orchestrator_store: "RunOrchestratorStore", event: HardwareEvent
 ) -> None:
     """Handle an E-stop event from the hardware API.
@@ -80,26 +107,18 @@ async def handle_estop_event(
 
     This is a public function for unit-testing purposes, but it's an implementation
     detail of the store.
+
+    Implementation is in _do_handle_hardware_event, so this can just catch exceptions.
     """
     try:
-        if isinstance(event, EstopStateNotification):
-            if event.new_state is not EstopState.PHYSICALLY_ENGAGED:
-                return
-            if run_orchestrator_store.current_run_id is None:
-                return
-            # todo(mm, 2024-04-17): This estop teardown sequencing belongs in the
-            # runner layer.
-            run_orchestrator_store.run_orchestrator.estop()
-            await run_orchestrator_store.run_orchestrator.finish(
-                error=EStopActivatedError()
-            )
+        await _do_handle_hardware_event(run_orchestrator_store, event)
     except Exception:
         # This is a background task kicked off by a hardware event,
         # so there's no one to propagate this exception to.
         _log.exception("Exception handling E-stop event.")
 
 
-def _get_estop_listener(
+def _get_hardware_listener(
     run_orchestrator_store: "RunOrchestratorStore",
 ) -> HardwareEventHandler:
     """Create a callback for estop events.
@@ -112,7 +131,7 @@ def _get_estop_listener(
         event: HardwareEvent,
     ) -> None:
         asyncio.run_coroutine_threadsafe(
-            handle_estop_event(run_orchestrator_store, event), engine_loop
+            handle_hardware_event(run_orchestrator_store, event), engine_loop
         )
 
     return run_handler_in_engine_thread_from_hardware_thread
@@ -140,7 +159,7 @@ class RunOrchestratorStore:
         self._deck_type = deck_type
         self._run_orchestrator: Optional[RunOrchestrator] = None
         self._default_run_orchestrator: Optional[RunOrchestrator] = None
-        hardware_api.register_callback(_get_estop_listener(self))
+        hardware_api.register_callback(_get_hardware_listener(self))
 
     @property
     def run_orchestrator(self) -> RunOrchestrator:

--- a/robot-server/tests/runs/test_run_orchestrator_store.py
+++ b/robot-server/tests/runs/test_run_orchestrator_store.py
@@ -7,12 +7,18 @@ import pytest
 from decoy import Decoy, matchers
 
 from opentrons_shared_data.robot.types import RobotType
+from opentrons_shared_data.errors.exceptions import ModuleCommunicationError
 
 from opentrons.protocol_engine.error_recovery_policy import never_recover
 from opentrons.protocol_engine.errors.exceptions import EStopActivatedError
 from opentrons.types import DeckSlotName
 from opentrons.hardware_control import HardwareControlAPI, API
-from opentrons.hardware_control.types import EstopStateNotification, EstopState
+from opentrons.hardware_control.types import (
+    EstopStateNotification,
+    EstopState,
+    AsynchronousModuleErrorNotification,
+)
+from opentrons.hardware_control.modules.types import TemperatureModuleModel
 from opentrons.protocol_engine import (
     StateSummary,
     types as pe_types,
@@ -25,7 +31,7 @@ from robot_server.runs.run_orchestrator_store import (
     RunOrchestratorStore,
     RunConflictError,
     NoRunOrchestrator,
-    handle_estop_event,
+    handle_hardware_event,
 )
 from robot_server.protocols.protocol_store import ProtocolResource
 from robot_server.protocols.protocol_models import ProtocolKind
@@ -365,7 +371,7 @@ async def test_estop_callback(
     )
 
     decoy.when(run_orchestrator_store.current_run_id).then_return(None)
-    await handle_estop_event(run_orchestrator_store, disengage_event)
+    await handle_hardware_event(run_orchestrator_store, disengage_event)
     assert run_orchestrator_store.run_orchestrator is not None
     decoy.verify(
         run_orchestrator_store.run_orchestrator.estop(),
@@ -379,7 +385,7 @@ async def test_estop_callback(
     )
 
     decoy.when(run_orchestrator_store.current_run_id).then_return("fake-run-id")
-    await handle_estop_event(run_orchestrator_store, engage_event)
+    await handle_hardware_event(run_orchestrator_store, engage_event)
     assert run_orchestrator_store._run_orchestrator is not None
     decoy.verify(
         run_orchestrator_store.run_orchestrator.estop(),
@@ -387,4 +393,86 @@ async def test_estop_callback(
             error=matchers.IsA(EStopActivatedError)
         ),
         times=1,
+    )
+
+
+async def test_async_module_callback_noops_with_no_engine(decoy: Decoy) -> None:
+    """It should noop without a run."""
+    run_orchestrator_store = decoy.mock(cls=RunOrchestratorStore)
+
+    exc = ModuleCommunicationError()
+    error_event = AsynchronousModuleErrorNotification(
+        exception=exc,
+        module_serial="some-serial",
+        module_model=TemperatureModuleModel.TEMPERATURE_V2,
+        port="some-port",
+    )
+
+    decoy.when(run_orchestrator_store.current_run_id).then_return(None)
+    await handle_hardware_event(run_orchestrator_store, error_event)
+    assert run_orchestrator_store.run_orchestrator is not None
+    decoy.verify(
+        await run_orchestrator_store.run_orchestrator.asynchronous_module_error(
+            module_model=matchers.Anything(), module_serial=matchers.Anything()
+        ),
+        times=0,
+    )
+    decoy.verify(
+        await run_orchestrator_store.finish(error=None),
+        ignore_extra_args=True,
+        times=0,
+    )
+
+
+async def test_async_module_callback_noops_if_engine_says_no(decoy: Decoy) -> None:
+    """It shouldn't finish if the engine doesn't want it to."""
+    run_orchestrator_store = decoy.mock(cls=RunOrchestratorStore)
+
+    exc = ModuleCommunicationError()
+    error_event = AsynchronousModuleErrorNotification(
+        exception=exc,
+        module_serial="some-serial",
+        module_model=TemperatureModuleModel.TEMPERATURE_V2,
+        port="some-port",
+    )
+
+    decoy.when(run_orchestrator_store.current_run_id).then_return("fake-run-id")
+    decoy.when(
+        await run_orchestrator_store.run_orchestrator.asynchronous_module_error(
+            module_model=TemperatureModuleModel.TEMPERATURE_V2,
+            module_serial="some-serial",
+        )
+    ).then_return(False)
+    await handle_hardware_event(run_orchestrator_store, error_event)
+    assert run_orchestrator_store._run_orchestrator is not None
+    decoy.verify(
+        await run_orchestrator_store.run_orchestrator.finish(error=None),
+        ignore_extra_args=True,
+        times=0,
+    )
+
+
+async def test_async_module_callback_finishes_if_engine_says_so(decoy: Decoy) -> None:
+    """It should finish with the error if the engine says it should."""
+    run_orchestrator_store = decoy.mock(cls=RunOrchestratorStore)
+
+    exc = ModuleCommunicationError()
+    error_event = AsynchronousModuleErrorNotification(
+        exception=exc,
+        module_serial="some-serial",
+        module_model=TemperatureModuleModel.TEMPERATURE_V2,
+        port="some-port",
+    )
+    decoy.when(run_orchestrator_store.current_run_id).then_return("fake-run-id")
+
+    decoy.when(
+        await run_orchestrator_store.run_orchestrator.asynchronous_module_error(
+            module_model=TemperatureModuleModel.TEMPERATURE_V2,
+            module_serial="some-serial",
+        )
+    ).then_return(True)
+    await handle_hardware_event(run_orchestrator_store, error_event)
+    assert run_orchestrator_store._run_orchestrator is not None
+    decoy.verify(
+        await run_orchestrator_store.run_orchestrator.finish(error=exc),
     )

--- a/robot-server/tests/service/legacy/routers/test_modules.py
+++ b/robot-server/tests/service/legacy/routers/test_modules.py
@@ -32,6 +32,8 @@ async def magdeck():
         simulating=True,
         execution_manager=ExecutionManager(),
         hw_control_loop=asyncio.get_running_loop(),
+        error_callback=lambda *args: None,
+        disconnected_callback=lambda *args: None,
     )
     MagDeck.current_height = PropertyMock(return_value=321)
 
@@ -56,6 +58,8 @@ async def tempdeck():
         type=ModuleType.TEMPERATURE,
         simulating=True,
         execution_manager=ExecutionManager(),
+        error_callback=lambda *args: None,
+        disconnected_callback=lambda *args: None,
         hw_control_loop=asyncio.get_running_loop(),
     )
     TempDeck.temperature = PropertyMock(return_value=123.0)
@@ -83,6 +87,8 @@ async def thermocycler():
         simulating=True,
         execution_manager=ExecutionManager(),
         hw_control_loop=asyncio.get_running_loop(),
+        error_callback=lambda *args: None,
+        disconnected_callback=lambda *args: None,
     )
 
     Thermocycler.lid_status = PropertyMock(return_value="open")
@@ -119,6 +125,8 @@ async def heater_shaker():
         simulating=True,
         execution_manager=ExecutionManager(),
         hw_control_loop=asyncio.get_running_loop(),
+        error_callback=lambda *args: None,
+        disconnected_callback=lambda *args: None,
     )
 
     HeaterShaker.live_data = PropertyMock(

--- a/shared-data/python/opentrons_shared_data/errors/exceptions.py
+++ b/shared-data/python/opentrons_shared_data/errors/exceptions.py
@@ -1,6 +1,18 @@
 """Exception hierarchy for error codes."""
 
-from typing import Dict, Any, Optional, List, Iterator, Union, Sequence, overload
+from __future__ import annotations
+from typing import (
+    Dict,
+    Any,
+    Optional,
+    List,
+    Iterator,
+    Union,
+    Sequence,
+    overload,
+    Type,
+    TypeVar,
+)
 from logging import getLogger
 from traceback import format_exception_only, format_tb
 import inspect
@@ -15,6 +27,18 @@ log = getLogger(__name__)
 
 class EnumeratedError(Exception):
     """The root class of error-code-bearing exceptions."""
+
+    @classmethod
+    def ensure(cls: Type[_ET], exception: Exception) -> _ET:
+        """Ensure that an exception is enumerated.
+
+        If the passed exception is an EnumeratedError, returns it; otherwise, wraps it in an appropriate
+        child class.
+        """
+        if isinstance(exception, cls):
+            return exception
+        else:
+            return PythonException(exception)  # type: ignore[return-value]
 
     def __init__(
         self,
@@ -48,6 +72,9 @@ class EnumeratedError(Exception):
             and self.detail == other.detail
             and self.wrapping == other.wrapping
         )
+
+
+_ET = TypeVar("_ET", bound=EnumeratedError, covariant=True)
 
 
 class CommunicationError(EnumeratedError):


### PR DESCRIPTION
Sometimes, our modules notice that an error has occurred while they're doing ongoing and generally less-monitored work like maintaining a static temperature. This work is usually not tied to a specific command or task (and still won't be after we have concurrent module actions, because the concurrent module action "preheat" is considered to end once the module has reached its temperature, but the module is still controlling at that temperature thereafter). The errors are usually noticed by the modules' status pollers, which are always running in the background while the modules are connected to make sure that callers like the app have up-to-date status data.

Today, when there's an error noticed only by the status poller, essentially nothing happens; the error doesn't go anywhere. Usually, the status poller just fails and the module is dead, but nothing will notice until and unless it sends another module status request that might get the module hardware to respond with the ongoing error (typically, if a module has a subsystem error it will respond with an error code to commands that affect that subsystem). If there is no such command, the module failure goes unnoticed.

To fix this, take the hardware callback mechanism that we use today for estop and for door status and extend it to asynchronous module errors. 

There are two beefy commits that each implement half the work: extending the hardware error callback up through the server and protocol engine happens in 3c252e72bbd10cf1ec0f270e3beecfe6cc3fba3c , and extending the hardware error callback down to the module pollers happens in a63d3892001e0c4f90cd7dc614bfc5f465180eda .

## extending up through the engine
3c252e72bbd10cf1ec0f270e3beecfe6cc3fba3c adds the new kind of error to the hardware callback and sends it through the run orchestrator store to the run orchestrator and thence the engine. This is a convoluted path because the same callback handles things like the estop, which needs to be signalled even if there's no engine. We react to asynch errors by:
- Doing nothing, if there's no current run at all (the orchestrator store swallows the error if there's no run)
- Doing nothing, if the module that got the error does not appear to be used in the protocol
   - This means that all asynchronous errors will be ignored until and unless somebody runs a load module command, including during protocol setup. Do we want this?
- Cancelling the run by stopping the engine, if the module that got the error is used in the protocol

I think that what's here does an adequate job of patching the _practical_ problem - that if you keep a thermocycler at 4C, occasionally condensation breaks a thermistor, which probably won't happen in the preprotocol - but we probably want to enhance the logic to add more considered reactions in odd situations. I think we have a good basis for adding that logic, here.

## extending down through the modules
3c252e72bbd10cf1ec0f270e3beecfe6cc3fba3c adds a new kind of callback down through modules and refactors some stuff along the way. The error callback (and the disconnected callback) become mandatory, which simplifies some logic and just removes a complexity doubling; this needs some test refactors, which is annoying but should improve things.

There was actually already an error callback mechanism in the pollers themselves; the errors just weren't really hooked up to anything but a local cache that wouldn't be queried by the engine in the way that we need. We can link the hardware callback from the previous commit to the reader callbacks that already exist, and hey presto we can raise asynchronous errors.

## Testing
~We need to actually have some asynchronous errors happen in modules. These are pretty annoying to actually create, so we can probably do it with a hacked-up module firmware to just create an error condition when you set a temperature in e.g. a tempdeck. Then you can test this by running a protocol that uses the module, and checking that it fails; and exercise the preprotocol and out of protocol variants by commanding the module from the app.~

You can't actually test this all the way through from a module because none of them express errors in the commands these pollers run. Happily, this means we can just merge this without doing it (as long as normal runs work, which they do) because the error won't be triggered.

I plan to do the end to end testing when I implement the modules actually returning asynch errors in their polling in subsequent work.

## further work
Should probably give the same treatment to module disconnections.
Should probably change what happens when there's an error for a module during the pre-protocol flow.

Closes EXEC-1705