### PR TITLE
feat(robot-server,app): Show incompatible module banner for the Flex Stacker based on the rear-panel revision.

### DIFF
--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -781,7 +781,7 @@ class OT3Simulator(FlexBackend):
                 next_fw_version=1,
                 fw_update_needed=False,
                 current_fw_sha="simulated",
-                pcba_revision="A1",
+                pcba_revision="A1.0",
                 update_state=None,
             )
             for axis in self._present_axes

--- a/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
@@ -258,7 +258,7 @@ def _subsystems_entry(info: DeviceInfoCache) -> Tuple[SubSystem, SubSystemState]
         current_fw_version=info.version,
         next_fw_version=2,
         current_fw_sha=info.shortsha,
-        pcba_revision="A1",
+        pcba_revision="A1.0",
         update_state=None,
         fw_update_needed=False,
     )

--- a/api/tests/opentrons/hardware_control/backends/test_ot3_subsystem_manager.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_subsystem_manager.py
@@ -92,7 +92,7 @@ def default_fw_version() -> int:
 
 
 def default_revision() -> types.PCBARevision:
-    return types.PCBARevision("A1")
+    return types.PCBARevision("A1.0")
 
 
 def device_info_for(

--- a/app/src/App/hooks.ts
+++ b/app/src/App/hooks.ts
@@ -157,9 +157,10 @@ export function useGetModulesNeedingSetup(): AttachedModule[] {
       .map(m => m.opentronsModuleSerialNumber)
     return attachedModules.filter(
       m =>
-        !modulesInDeckConfig.includes(m.serialNumber) ||
-        (!MODULES_NOT_REQUIRING_CALIBRATION.includes(m.moduleType) &&
-          m.moduleOffset === undefined)
+        m.compatibleWithRobot &&
+        (!modulesInDeckConfig.includes(m.serialNumber) ||
+          (!MODULES_NOT_REQUIRING_CALIBRATION.includes(m.moduleType) &&
+            m.moduleOffset === undefined))
     )
   }
   return []

--- a/hardware/opentrons_hardware/hardware_control/types.py
+++ b/hardware/opentrons_hardware/hardware_control/types.py
@@ -1,7 +1,9 @@
 """Types and definitions for hardware bindings."""
-from typing import Mapping, TypeVar, Dict, List, Optional, Tuple
+import re
 from dataclasses import dataclass
 from enum import Enum
+from typing import Mapping, TypeVar, Dict, List, Optional, Tuple
+from functools import total_ordering
 
 from opentrons_hardware.firmware_bindings.constants import NodeId, MoveAckId
 
@@ -14,7 +16,8 @@ NodeList = List[NodeId]
 NodeDict = Dict[NodeId, MapPayload]
 
 
-@dataclass
+@total_ordering
+@dataclass(frozen=True)
 class PCBARevision:
     """The electrical revision of a PCBA."""
 
@@ -23,9 +26,35 @@ class PCBARevision:
     tertiary: Optional[str] = None
     #: An often-not-present tertiary
 
+    @classmethod
+    def from_string(cls, rev: str) -> "PCBARevision":
+        """Parse a revision string of the form 'xy.z'."""
+        match = re.match(r"^([A-Za-z]\d+)(?:\.(\d+))?$", rev)
+        if not match:
+            raise ValueError(f"Invalid revision format: {rev}")
+        main, tertiary = match.groups()
+        return cls(main, tertiary)
+
     def __repr__(self) -> str:
         """Readable representation of the PCB revision."""
         return f"{self.main}.{self.tertiary or 0}".upper()
+
+    def _as_tuple(self) -> Tuple[str, int, int]:
+        if not self.main:
+            return ("", 0, 0)
+
+        prim = self.main[0]
+        sec = int(self.main[1:]) if len(self.main) > 1 else 0
+        tert = int(self.tertiary) if self.tertiary else 0
+        return (prim, sec, tert)
+
+    def __gt__(self, other: "PCBARevision") -> bool:
+        return self._as_tuple() > other._as_tuple()
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, PCBARevision):
+            return False
+        return self._as_tuple() == other._as_tuple()
 
 
 class MoveCompleteAck(Enum):

--- a/hardware/opentrons_hardware/hardware_control/types.py
+++ b/hardware/opentrons_hardware/hardware_control/types.py
@@ -23,6 +23,10 @@ class PCBARevision:
     tertiary: Optional[str] = None
     #: An often-not-present tertiary
 
+    def __repr__(self) -> str:
+        """Readable representation of the PCB revision."""
+        return f"{self.main}.{self.tertiary or 0}".upper()
+
 
 class MoveCompleteAck(Enum):
     """Move Complete Ack."""

--- a/robot-server/robot_server/modules/module_data_mapper.py
+++ b/robot-server/robot_server/modules/module_data_mapper.py
@@ -2,8 +2,9 @@
 from typing import Annotated, List, Type, cast, Optional
 from fastapi import Depends
 
-from opentrons.hardware_control import HardwareControlAPI
 from opentrons.hardware_control.types import SubSystem
+from opentrons_hardware.hardware_control.types import PCBARevision
+from opentrons.hardware_control import HardwareControlAPI
 from opentrons_shared_data.module import load_definition
 
 from opentrons.hardware_control.modules import (
@@ -197,12 +198,12 @@ class ModuleDataMapper:
             # support the Stacker.
             compatible_with_robot = False
             if self.deck_type == DeckType.OT3_STANDARD:
-                compatible_with_robot = (
+                rear_panel_rev = PCBARevision.from_string(
                     self.hardware.attached_subsystems[
                         SubSystem.rear_panel
                     ].pcba_revision
-                    >= "D1.0"
                 )
+                compatible_with_robot = rear_panel_rev >= PCBARevision("D1")
         else:
             assert False, f"Invalid module type {module_type}"
 

--- a/robot-server/robot_server/modules/module_data_mapper.py
+++ b/robot-server/robot_server/modules/module_data_mapper.py
@@ -2,6 +2,8 @@
 from typing import Annotated, List, Type, cast, Optional
 from fastapi import Depends
 
+from opentrons.hardware_control import HardwareControlAPI
+from opentrons.hardware_control.types import SubSystem
 from opentrons_shared_data.module import load_definition
 
 from opentrons.hardware_control.modules import (
@@ -48,14 +50,19 @@ from .module_models import (
     UsbPort,
 )
 
-from robot_server.hardware import get_deck_type
+from robot_server.hardware import get_deck_type, get_hardware
 
 
 class ModuleDataMapper:
     """Map hardware control modules to module response."""
 
-    def __init__(self, deck_type: Annotated[DeckType, Depends(get_deck_type)]) -> None:
+    def __init__(
+        self,
+        deck_type: Annotated[DeckType, Depends(get_deck_type)],
+        hardware: Annotated[HardwareControlAPI, Depends(get_hardware)],
+    ) -> None:
         self.deck_type = deck_type
+        self.hardware = hardware
 
     def map_data(
         self,
@@ -73,6 +80,9 @@ class ModuleDataMapper:
         module_cls: Type[AttachedModule]
         module_data: AttachedModuleData
         module_definition = load_definition(model_or_loadname=model, version="3")
+        compatible_with_robot = (
+            self.deck_type.value not in module_definition["incompatibleWithDecks"]
+        )
 
         # rely on Pydantic to check/coerce data fields from dicts at run time
         if module_type == ModuleType.MAGNETIC:
@@ -164,6 +174,7 @@ class ModuleDataMapper:
                 referenceWavelength=cast(
                     int, live_data["data"].get("referenceWavelength")
                 ),
+                errorDetails=cast(str, live_data["data"].get("errorDetails")),
             )
         elif module_type == ModuleType.FLEX_STACKER:
             module_cls = FlexStackerModule
@@ -178,7 +189,20 @@ class ModuleDataMapper:
                     HopperDoorState, live_data["data"].get("hopperDoorState")
                 ),
                 installDetected=cast(bool, live_data["data"].get("installDetected")),
+                errorDetails=cast(str, live_data["data"].get("errorDetails")),
             )
+
+            # Make sure this robot is compatible with the Flex Stacker by
+            # checking the rear panel revision, which has been updated to D1 to
+            # support the Stacker.
+            compatible_with_robot = False
+            if self.deck_type == DeckType.OT3_STANDARD:
+                compatible_with_robot = (
+                    self.hardware.attached_subsystems[
+                        SubSystem.rear_panel
+                    ].pcba_revision
+                    >= "D1.0"
+                )
         else:
             assert False, f"Invalid module type {module_type}"
 
@@ -188,9 +212,7 @@ class ModuleDataMapper:
             firmwareVersion=module_identity.firmware_version,
             hardwareRevision=module_identity.hardware_revision,
             hasAvailableUpdate=has_available_update,
-            compatibleWithRobot=(
-                not (self.deck_type.value in module_definition["incompatibleWithDecks"])
-            ),
+            compatibleWithRobot=compatible_with_robot,
             usbPort=UsbPort(
                 port=usb_port.port_number,
                 portGroup=usb_port.port_group,

--- a/robot-server/robot_server/modules/module_data_mapper.py
+++ b/robot-server/robot_server/modules/module_data_mapper.py
@@ -65,7 +65,7 @@ class ModuleDataMapper:
         self.deck_type = deck_type
         self.hardware = hardware
 
-    def map_data(
+    def map_data(  # noqa: C901
         self,
         model: str,
         module_identity: ModuleIdentity,
@@ -198,12 +198,11 @@ class ModuleDataMapper:
             # support the Stacker.
             compatible_with_robot = False
             if self.deck_type == DeckType.OT3_STANDARD:
-                rear_panel_rev = PCBARevision.from_string(
-                    self.hardware.attached_subsystems[
-                        SubSystem.rear_panel
-                    ].pcba_revision
-                )
-                compatible_with_robot = rear_panel_rev >= PCBARevision("D1")
+                compatible_with_robot = self.hardware.is_simulator
+                rear_panel = self.hardware.attached_subsystems.get(SubSystem.rear_panel)
+                if rear_panel is not None:
+                    rear_panel_rev = PCBARevision.from_string(rear_panel.pcba_revision)
+                    compatible_with_robot = rear_panel_rev >= PCBARevision("D1")
         else:
             assert False, f"Invalid module type {module_type}"
 

--- a/robot-server/robot_server/modules/module_models.py
+++ b/robot-server/robot_server/modules/module_models.py
@@ -336,6 +336,13 @@ class AbsorbanceReaderModuleData(BaseModel):
         ...,
         description="The reference wavelength used for single measurement mode.",
     )
+    errorDetails: Optional[str] = Field(
+        ...,
+        description=(
+            "Error details, if the module hardware has encountered something"
+            " unexpected and unrecoverable."
+        ),
+    )
 
 
 class AbsorbanceReaderModule(
@@ -366,6 +373,13 @@ class FlexStackerModuleData(BaseModel):
     )
     installDetected: bool = Field(
         ..., description="The install state of the Stacker on the Flex."
+    )
+    errorDetails: Optional[str] = Field(
+        ...,
+        description=(
+            "Error details, if the module hardware has encountered something"
+            " unexpected and unrecoverable."
+        ),
     )
 
 

--- a/robot-server/tests/instruments/test_router.py
+++ b/robot-server/tests/instruments/test_router.py
@@ -160,7 +160,7 @@ async def test_get_all_attached_instruments(
                     next_fw_version=11,
                     fw_update_needed=False,
                     current_fw_sha="some-sha",
-                    pcba_revision="A1",
+                    pcba_revision="A1.0",
                     update_state=None,
                 ),
                 HWSubSystem.pipette_right: SubSystemState(
@@ -169,7 +169,7 @@ async def test_get_all_attached_instruments(
                     next_fw_version=11,
                     fw_update_needed=False,
                     current_fw_sha="some-other-sha",
-                    pcba_revision="A1",
+                    pcba_revision="A1.0",
                     update_state=None,
                 ),
                 HWSubSystem.gripper: SubSystemState(
@@ -178,7 +178,7 @@ async def test_get_all_attached_instruments(
                     next_fw_version=11,
                     fw_update_needed=False,
                     current_fw_sha="some-other-sha",
-                    pcba_revision="A1",
+                    pcba_revision="A1.0",
                     update_state=None,
                 ),
             }
@@ -412,7 +412,7 @@ async def test_get_instrument_not_ok(
                 next_fw_version=11,
                 fw_update_needed=True,
                 current_fw_sha="some-sha",
-                pcba_revision="A1",
+                pcba_revision="A1.0",
                 update_state=None,
             ),
             HWSubSystem.pipette_right: SubSystemState(
@@ -421,7 +421,7 @@ async def test_get_instrument_not_ok(
                 next_fw_version=11,
                 fw_update_needed=True,
                 current_fw_sha="some-other-sha",
-                pcba_revision="A1",
+                pcba_revision="A1.0",
                 update_state=None,
             ),
             HWSubSystem.gripper: SubSystemState(
@@ -430,7 +430,7 @@ async def test_get_instrument_not_ok(
                 next_fw_version=11,
                 fw_update_needed=True,
                 current_fw_sha="some-other-sha",
-                pcba_revision="A1",
+                pcba_revision="A1.0",
                 update_state=None,
             ),
         }

--- a/robot-server/tests/modules/test_module_data_mapper.py
+++ b/robot-server/tests/modules/test_module_data_mapper.py
@@ -1,13 +1,18 @@
 """Tests for robot_server.modules.module_data_mapper."""
+from decoy import Decoy
+from opentrons.hardware_control import HardwareControlAPI
+from opentrons.hardware_control.types import SubSystem, SubSystemState
 import pytest
 
 from opentrons.protocol_engine import ModuleModel, DeckType
 from opentrons.protocol_engine.types import Vec3f
 from opentrons.drivers.rpi_drivers.types import USBPort as HardwareUSBPort, PortGroup
 from opentrons.hardware_control.modules import (
+    FlexStackerStatus,
     LiveData,
     ModuleType,
     MagneticStatus,
+    PlatformState,
     TemperatureStatus,
     HeaterShakerStatus,
     types as hc_types,
@@ -18,6 +23,8 @@ from robot_server.modules.module_identifier import ModuleIdentity
 from robot_server.modules.module_data_mapper import ModuleDataMapper
 
 from robot_server.modules.module_models import (
+    FlexStackerModule,
+    FlexStackerModuleData,
     UsbPort,
     MagneticModule,
     MagneticModuleData,
@@ -114,6 +121,7 @@ def test_maps_magnetic_module_data(
     input_data: LiveData,
     expected_output_data: MagneticModuleData,
     expected_compatible: bool,
+    hardware_api: HardwareControlAPI,
 ) -> None:
     """It should map hardware data to a magnetic module."""
     module_identity = ModuleIdentity(
@@ -132,7 +140,7 @@ def test_maps_magnetic_module_data(
         device_path="/dev/null",
     )
 
-    subject = ModuleDataMapper(deck_type=deck_type)
+    subject = ModuleDataMapper(deck_type=deck_type, hardware=hardware_api)
     result = subject.map_data(
         model=input_model,
         module_identity=module_identity,
@@ -187,6 +195,7 @@ def test_maps_temperature_module_data(
     expected_compatible: bool,
     status: str,
     data: hc_types.TemperatureModuleData,
+    hardware_api: HardwareControlAPI,
 ) -> None:
     """It should map hardware data to a magnetic module."""
     input_data: LiveData = {"status": status, "data": data}
@@ -206,7 +215,7 @@ def test_maps_temperature_module_data(
         device_path="/dev/null",
     )
 
-    subject = ModuleDataMapper(deck_type=deck_type)
+    subject = ModuleDataMapper(deck_type=deck_type, hardware=hardware_api)
     result = subject.map_data(
         model=input_model,
         module_identity=module_identity,
@@ -297,6 +306,7 @@ def test_maps_thermocycler_module_data(
     expected_compatible: bool,
     status: str,
     data: hc_types.ThermocyclerData,
+    hardware_api: HardwareControlAPI,
 ) -> None:
     """It should map hardware data to a magnetic module."""
     input_data: LiveData = {"status": status, "data": data}
@@ -316,7 +326,7 @@ def test_maps_thermocycler_module_data(
         device_path="/dev/null",
     )
 
-    subject = ModuleDataMapper(deck_type=deck_type)
+    subject = ModuleDataMapper(deck_type=deck_type, hardware=hardware_api)
     result = subject.map_data(
         model=input_model,
         module_identity=module_identity,
@@ -402,7 +412,11 @@ def test_maps_thermocycler_module_data(
     ],
 )
 def test_maps_heater_shaker_module_data(
-    input_model: str, deck_type: DeckType, status: str, data: hc_types.HeaterShakerData
+    input_model: str,
+    deck_type: DeckType,
+    status: str,
+    data: hc_types.HeaterShakerData,
+    hardware_api: HardwareControlAPI,
 ) -> None:
     """It should map hardware data to a magnetic module."""
     input_data: LiveData = {"status": status, "data": data}
@@ -422,7 +436,7 @@ def test_maps_heater_shaker_module_data(
         device_path="/dev/null",
     )
 
-    subject = ModuleDataMapper(deck_type=deck_type)
+    subject = ModuleDataMapper(deck_type=deck_type, hardware=hardware_api)
     result = subject.map_data(
         model=input_model,
         module_identity=module_identity,
@@ -460,6 +474,118 @@ def test_maps_heater_shaker_module_data(
             temperatureStatus=data["temperatureStatus"],  # type: ignore[arg-type]
             currentTemperature=data["currentTemp"],
             targetTemperature=data["targetTemp"],
+            errorDetails=data["errorDetails"],
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    "input_model,deck_type,rear_panel_rev,compatible",
+    [
+        ("flexStackerModuleV1", DeckType("ot2_standard"), "", False),
+        ("flexStackerModuleV1", DeckType("ot3_standard"), "C1", False),
+        ("flexStackerModuleV1", DeckType("ot3_standard"), "D1", True),
+    ],
+)
+@pytest.mark.parametrize(
+    "status,data",
+    [
+        (
+            "idle",
+            {
+                "latchState": "closed",
+                "platformState": "extended",
+                "hopperDoorState": "closed",
+                "installDetected": True,
+                "errorDetails": "",
+            },
+        ),
+        (
+            "dispensing",
+            {
+                "latchState": "closed",
+                "platformState": "retracted",
+                "hopperDoorState": "closed",
+                "installDetected": True,
+                "errorDetails": "",
+            },
+        ),
+    ],
+)
+def test_maps_flex_stacker_module_data(
+    input_model: str,
+    deck_type: DeckType,
+    rear_panel_rev: str,
+    compatible: bool,
+    status: str,
+    data: hc_types.FlexStackerData,
+    hardware_api: HardwareControlAPI,
+    decoy: Decoy,
+) -> None:
+    """It should map hardware data to a flex stacker."""
+    input_data: LiveData = {"status": status, "data": data}
+    module_identity = ModuleIdentity(
+        module_id="module-id",
+        serial_number="serial-number",
+        firmware_version="1.2.3",
+        hardware_revision="4.5.6",
+    )
+
+    hardware_usb_port = HardwareUSBPort(
+        name="abc",
+        port_number=101,
+        port_group=PortGroup.RIGHT,
+        hub=True,
+        hub_port=1,
+        device_path="1.0/tty/ttyACM1/dev",
+    )
+    decoy.when(hardware_api.attached_subsystems).then_return(
+        {
+            SubSystem.rear_panel: SubSystemState(
+                ok=True,
+                current_fw_version=63,
+                next_fw_version=63,
+                fw_update_needed=False,
+                current_fw_sha="",
+                pcba_revision=rear_panel_rev,
+                update_state=None,
+            )
+        }
+    )
+
+    subject = ModuleDataMapper(deck_type=deck_type, hardware=hardware_api)
+    result = subject.map_data(
+        model=input_model,
+        module_identity=module_identity,
+        has_available_update=False,
+        live_data=input_data,
+        usb_port=hardware_usb_port,
+        module_offset=None,
+    )
+
+    assert result == FlexStackerModule(
+        id="module-id",
+        serialNumber="serial-number",
+        firmwareVersion="1.2.3",
+        hardwareRevision="4.5.6",
+        hasAvailableUpdate=False,
+        moduleType=ModuleType.FLEX_STACKER,
+        compatibleWithRobot=compatible,
+        moduleModel=ModuleModel(input_model),  # type: ignore[arg-type]
+        usbPort=UsbPort(
+            port=101,
+            portGroup=PortGroup.RIGHT,
+            hub=True,
+            hubPort=1,
+            path="1.0/tty/ttyACM1/dev",
+        ),
+        moduleOffset=None,
+        data=FlexStackerModuleData(
+            status=FlexStackerStatus(status),
+            latchState=hc_types.LatchState(data["latchState"]),
+            platformState=PlatformState(data["platformState"]),
+            hopperDoorState=hc_types.HopperDoorState(data["hopperDoorState"]),
+            installDetected=data["installDetected"],
             errorDetails=data["errorDetails"],
         ),
     )


### PR DESCRIPTION
# Overview

The Flex Stacker requires new hardware on the Flex to operate safely. The new hardware comes in a new rear panel rev D1. So, let's set the `compatibleWithRobot` flag returned in the `GET /modules` endpoint based on the revision. This then allows the front end to display a "Incompatible" module banner that prevents the use of the Flex/OT-2 until the incompatible module is removed.

Closes: [EXEC-1807](https://opentrons.atlassian.net/browse/EXEC-1807)

## Desktop App
<img width="1024" height="793" alt="Screenshot 2025-09-09 at 2 14 52 PM" src="https://github.com/user-attachments/assets/fc815a99-3a4a-4df1-9adc-5e3f602fd2a5" />

## On Device Display
<img width="1027" height="630" alt="Screenshot 2025-09-09 at 3 00 20 PM" src="https://github.com/user-attachments/assets/02bfc6d5-ccb7-4cb4-b5a5-7c6488e8d98d" />


## Test Plan and Hands on Testing

- [x] Make sure you can't use the Flex Stacker on Flex robots with rear-panel rev < D1
- [x] Make sure you can't use the Flex Stacker on the OT-2
- [x] Make sure the "Module Setup" toast does not show for "incompatible" modules.

## Changelog

- Set the `compatibleWithRobot` flag in the module_data_mapper for the Flex Stacker based on the rear-panel revision.
- Add a __repr__ method for the PCBRevision data class to return revs in the "xy.z" format.
- Use the `compatibleWithRobot` flag in the `useGetModulesNeedingSetup` hook of the app, to filter out incompatible modules so we don't show the "Module Setup" banner or toast.

## Review requests
## Risk assessment

Low

[EXEC-1807]: https://opentrons.atlassian.net/browse/EXEC-1807?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ