### PR TITLE
feat(protocol-designer): update required app version to 8.7.0

### DIFF
--- a/protocol-designer/src/pages/ProtocolOverview/ProtocolMetadata.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/ProtocolMetadata.tsx
@@ -19,7 +19,7 @@ import {
   LINK_BUTTON_STYLE,
 } from '../../components/atoms'
 
-const REQUIRED_APP_VERSION = '8.5.1'
+const REQUIRED_APP_VERSION = '8.7.0'
 
 type MetadataInfo = Array<{
   author?: string

--- a/protocol-designer/src/pages/ProtocolOverview/__tests__/ProtocolMetadata.test.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/__tests__/ProtocolMetadata.test.tsx
@@ -45,7 +45,7 @@ describe('ProtocolMetadata', () => {
     screen.getByText('Protocol Metadata')
     screen.getByText('Edit')
     screen.getByText('Required app version')
-    screen.getByText('8.5.1 or higher')
+    screen.getByText('8.7.0 or higher')
   })
 
   it('should render protocol metadata', () => {


### PR DESCRIPTION
closes AUTH-2245

# Overview

update require app version to `8.7.0` which will be the latest RS release before this PD release is out

## Test Plan and Hands on Testing

see that the protocol metadata in the overview section shows app 8.7.0 is required

## Changelog

update required app version to 8.7.0

## Risk assessment

low
