### PR TITLE
fix(protocol-designer): Fix `step.stepName !== undefined` check

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/ConnectedStepInfo.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/ConnectedStepInfo.tsx
@@ -248,9 +248,8 @@ export function ConnectedStepInfo(props: ConnectedStepInfoProps): JSX.Element {
         iconName={hasError || hasWarnings ? 'alert-circle' : iconName}
         stepNumber={stepNumber}
         // add empty check to avoid causing undefined issue when calling titleCase
-        // todo(mm, 2025-09-05): `stepName !== undefined || stepName !== ''` will always evaluate to true, won't it?
         text={
-          step.stepName !== undefined || step.stepName !== ''
+          step.stepName !== undefined && step.stepName !== ''
             ? i18n.format(step.stepName, 'titleCase')
             : t(`stepType.${step.stepType}`)
         }


### PR DESCRIPTION
## Overview

Following up on #19357, this fixes what I think was just some flipped logic.

Before, if `stepName` were `undefined`, we would accidentally still use it:

```javascript
step.stepName !== undefined || step.stepName !== ''

undefined !== undefined || undefined !== ''

false || true

true
```

## Test Plan and Hands on Testing

None.

## Review requests

Is this right?

## Risk assessment

Low.