### PR TITLE
feat(protocol-designer): allow for stacking universal lid on itself o…

### DIFF
--- a/protocol-designer/src/pages/Designer/DeckSetup/utils.ts
+++ b/protocol-designer/src/pages/Designer/DeckSetup/utils.ts
@@ -222,7 +222,8 @@ export const getStackerDefinitions = (
     return []
   }
   const universalLid =
-    category != null && !CATEGORIES_WITH_NO_LID.includes(category)
+    (category != null && !CATEGORIES_WITH_NO_LID.includes(category)) ||
+    loadName === 'opentrons_tough_universal_lid'
       ? universalLidURI
       : null
   const supportedDefs = getStackerDefinitionsFromLoadName(defs, loadName)


### PR DESCRIPTION
…n the deck

closes RQA-4643

# Overview

allow stacking of the universal lid directly on the deck

<img width="620" height="562" alt="Screenshot 2025-09-10 at 06 40 16" src="https://github.com/user-attachments/assets/2018e4d6-4f05-4609-9d42-e5f3b94a4a30" />

## Test Plan and Hands on Testing

Create a protocol and click on the "lid" category and then the universal lid and see that you can stack it directly on the deck

## Changelog

add to the universal lid logic for the option in stacking. universal lid is unique because it can go on a bunch of plates except for a few categories

## Risk assessment

low
