### PR TITLE
fix(hardware-testing): rewrite dial indicator driver to fix garbage readings

### DIFF
--- a/hardware-testing/hardware_testing/drivers/mitutoyo_digimatic_indicator.py
+++ b/hardware-testing/hardware_testing/drivers/mitutoyo_digimatic_indicator.py
@@ -58,20 +58,21 @@ class Mitutoyo_Digimatic_Indicator:
 
     def read(self) -> float:
         """Reads dial indicator."""
-        data_list = []
         self.packet = self.GCODE["READ"]
+        self._send_packet(self.packet)
+        time.sleep(0.001)
         reading = True
+        value = 0.0  # Initialize value to avoid unbound error
         while reading:
-            self._send_packet(self.packet)
-            time.sleep(0.01)
-
             data = self._get_packet()
+            time.sleep(0.01)
             if data != "":
-                data_list.append(float(data[3:]))
-            if data != "" and len(data_list) > 5:  # read 5 times and get lasted number
-                reading = False
-        print("Data List:", data_list)
-        return float(data_list[-1])
+                try:
+                    value = float(data)
+                    reading = False
+                except ValueError:
+                    continue
+        return value
 
     def read_stable(self, timeout: float = 5) -> float:
         """Reads dial indicator with stable reading."""


### PR DESCRIPTION
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

@Carlos-fernandez rewrote the Mitutoyo Digimatic Indicator to fix garbage readings from serial encountered in version 8.6.0 alpha 11. 
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing

<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog

Rewrote "read()" function in opentrons\hardware-testing\hardware_testing\drivers\mitutoyo_digimatic_indicator.py

<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment

<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
