### PR TITLE
feat(api): improve gripper error checking

### DIFF
--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -1780,7 +1780,13 @@ class OT3Controller(FlexBackend):
         log.info(
             f"Checking gripper position: current {jaw_width}; hard limits {hard_limit_lower}, {hard_limit_upper}; expected {expected_gripper_position_min}, {expected_grip_width}, {expected_gripper_position_max}; uncertainty {grip_width_uncertainty_narrower}, {grip_width_uncertainty_wider}"
         )
-        if isclose(current_gripper_position, hard_limit_lower):
+        if (
+            isclose(current_gripper_position, hard_limit_lower)
+            # this odd check handles internal backlash that can lead the position to read as if
+            # the gripper has overshot its lower bound; this is physically impossible and an
+            # artifact of the gearing, so it always indicates a hard stop
+            or current_gripper_position < hard_limit_lower
+        ):
             raise FailedGripperPickupError(
                 message="Failed to grip: jaws all the way closed",
                 details={

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -1777,6 +1777,9 @@ class OT3Controller(FlexBackend):
             expected_grip_width + grip_width_uncertainty_wider
         )
         current_gripper_position = jaw_width
+        log.info(
+            f"Checking gripper position: current {jaw_width}; hard limits {hard_limit_lower}, {hard_limit_upper}; expected {expected_gripper_position_min}, {expected_grip_width}, {expected_gripper_position_max}; uncertainty {grip_width_uncertainty_narrower}, {grip_width_uncertainty_wider}"
+        )
         if isclose(current_gripper_position, hard_limit_lower):
             raise FailedGripperPickupError(
                 message="Failed to grip: jaws all the way closed",

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -686,9 +686,9 @@ class OT3Controller(FlexBackend):
         return (
             MoveGroupRunner(
                 move_groups=[move_group],
-                ignore_stalls=True
-                if not self._feature_flags.stall_detection_enabled
-                else False,
+                ignore_stalls=(
+                    True if not self._feature_flags.stall_detection_enabled else False
+                ),
             ),
             False,
         )
@@ -712,9 +712,9 @@ class OT3Controller(FlexBackend):
         return (
             MoveGroupRunner(
                 move_groups=[tip_motor_move_group],
-                ignore_stalls=True
-                if not self._feature_flags.stall_detection_enabled
-                else False,
+                ignore_stalls=(
+                    True if not self._feature_flags.stall_detection_enabled else False
+                ),
             ),
             True,
         )
@@ -939,9 +939,9 @@ class OT3Controller(FlexBackend):
 
         runner = MoveGroupRunner(
             move_groups=[move_group],
-            ignore_stalls=True
-            if not self._feature_flags.stall_detection_enabled
-            else False,
+            ignore_stalls=(
+                True if not self._feature_flags.stall_detection_enabled else False
+            ),
         )
         try:
             positions = await runner.run(can_messenger=self._messenger)
@@ -976,9 +976,9 @@ class OT3Controller(FlexBackend):
         move_group = self._build_tip_action_group(origin, targets)
         runner = MoveGroupRunner(
             move_groups=[move_group],
-            ignore_stalls=True
-            if not self._feature_flags.stall_detection_enabled
-            else False,
+            ignore_stalls=(
+                True if not self._feature_flags.stall_detection_enabled else False
+            ),
         )
         try:
             positions = await runner.run(can_messenger=self._messenger)
@@ -1778,7 +1778,7 @@ class OT3Controller(FlexBackend):
         )
         current_gripper_position = jaw_width
         log.info(
-            f"Checking gripper position: current {jaw_width}; hard limits {hard_limit_lower}, {hard_limit_upper}; expected {expected_gripper_position_min}, {expected_grip_width}, {expected_gripper_position_max}; uncertainty {grip_width_uncertainty_narrower}, {grip_width_uncertainty_wider}"
+            f"Checking gripper position: current {jaw_width}; max error {max_allowed_grip_error}; hard limits {hard_limit_lower}, {hard_limit_upper}; expected {expected_gripper_position_min}, {expected_grip_width}, {expected_gripper_position_max}; uncertainty {grip_width_uncertainty_narrower}, {grip_width_uncertainty_wider}"
         )
         if (
             isclose(current_gripper_position, hard_limit_lower)

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1480,8 +1480,8 @@ class OT3API(
             grip_width_uncertainty_narrower,
             gripper.jaw_width,
             gripper.max_allowed_grip_error,
-            gripper.max_jaw_width,
             gripper.min_jaw_width,
+            gripper.max_jaw_width,
         )
 
     def gripper_jaw_can_home(self) -> bool:

--- a/api/src/opentrons/protocol_engine/execution/labware_movement.py
+++ b/api/src/opentrons/protocol_engine/execution/labware_movement.py
@@ -234,23 +234,17 @@ class LabwareMovementHandler:
                     # we only want to check position after the gripper has opened and
                     # should be holding labware
                     if holding_labware:
-                        labware_bbox = self._state_store.labware.get_dimensions(
+                        grip_specs = self._state_store.labware.get_gripper_width_specs(
                             labware_definition=labware_definition
                         )
-                        well_bbox = self._state_store.labware.get_well_bbox(
-                            labware_definition=labware_definition
-                        )
+
                         # todo(mm, 2024-09-26): This currently raises a lower-level 2015 FailedGripperPickupError.
                         # Convert this to a higher-level 3001 LabwareDroppedError or 3002 LabwareNotPickedUpError,
                         # depending on what waypoint we're at, to propagate a more specific error code to users.
                         ot3api.raise_error_if_gripper_pickup_failed(
-                            expected_grip_width=labware_bbox.y,
-                            grip_width_uncertainty_wider=abs(
-                                max(well_bbox.y - labware_bbox.y, 0)
-                            ),
-                            grip_width_uncertainty_narrower=abs(
-                                min(well_bbox.y - labware_bbox.y, 0)
-                            ),
+                            expected_grip_width=grip_specs.targetY,
+                            grip_width_uncertainty_wider=grip_specs.uncertaintyWider,
+                            grip_width_uncertainty_narrower=grip_specs.uncertaintyNarrower,
                         )
                 await ot3api.move_to(
                     mount=gripper_mount, abs_position=waypoint_data.position

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -1449,7 +1449,7 @@ class LabwareView:
         """
         if well_bbox.y == 0:
             # This labware has no wells; use a fixed minimum
-            return 10
+            return 5
         if well_bbox.y > labware_bbox.y:
             # This labware has a very odd definition with wells outside its dimensions.
             # Return the smaller value.

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -46,6 +46,7 @@ from ..types import (
     AddressableAreaLocation,
     NonStackedLocation,
     Dimensions,
+    GripSpecs,
     LabwareOffset,
     LabwareOffsetVector,
     LabwareOffsetLocationSequence,
@@ -1430,3 +1431,68 @@ class LabwareView:
         ):
             return Dimensions(0, 0, 0)
         return Dimensions(max_x - min_x, max_y - min_y, max_z)
+
+    def _gripper_uncertainty_narrower(
+        self, labware_bbox: Dimensions, well_bbox: Dimensions, target_grip_width: float
+    ) -> float:
+        """Most narrower the gripper can be than the target while still likely gripping successfully.
+
+        This number can't just be the 0, because that is not going to be accurate if the labware is
+        skirted - the dimensions are a full bounding box including the skirt, and the labware is
+        narrower than that at the point where it is gripped. The general heuristic is that we can't
+        get to the wells; but some labware don't have wells, so we need alternate values.
+
+        The number will be interpreted relative to the target width, which is (for now) the labware
+        outer bounding box.
+
+        TODO: This should be a number looked up from the definition.
+        """
+        if well_bbox.y == 0:
+            # This labware has no wells; use a fixed minimum
+            return 5
+        if well_bbox.y > labware_bbox.y:
+            # This labware has a very odd definition with wells outside its dimensions.
+            # Return the smaller value.
+            return 0
+        # An ok heuristic for successful grip is if we don't get all the way to the wells.
+        return target_grip_width - well_bbox.y
+
+    def _gripper_uncertainty_wider(
+        self, labware_bbox: Dimensions, well_bbox: Dimensions, target_grip_width: float
+    ) -> float:
+        """Most wider the gripper can be than the target while still likely gripping successfully.
+
+        This can be a lot closer to 0, since the bounding box of the labware will certainly be the
+        widest point (if it's defined without error), but since there might be error in the
+        definition we allow some slop.
+
+        The number will be interpreted relative to the target width, which is (for now) the labware
+        outer bounding box.
+
+        TODO: This should be a number looked up from the definition.
+        """
+        # This will be 0 unless the wells are wider than the labware
+        return max(well_bbox.y - target_grip_width, 0)
+
+    def get_gripper_width_specs(
+        self, labware_definition: LabwareDefinition
+    ) -> GripSpecs:
+        """Get the target and bounds for a successful grip of this labware."""
+        outer_bounds = self.get_dimensions(labware_definition=labware_definition)
+        well_bounds = self.get_well_bbox(labware_definition=labware_definition)
+        narrower = self._gripper_uncertainty_narrower(
+            labware_bbox=outer_bounds,
+            well_bbox=well_bounds,
+            target_grip_width=outer_bounds.y,
+        )
+        wider = self._gripper_uncertainty_wider(
+            labware_bbox=outer_bounds,
+            well_bbox=well_bounds,
+            target_grip_width=outer_bounds.y,
+        )
+        return GripSpecs(
+            # TODO: This should be a number looked up from the definition.
+            targetY=outer_bounds.y,
+            uncertaintyNarrower=narrower,
+            uncertaintyWider=wider,
+        )

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -1449,7 +1449,7 @@ class LabwareView:
         """
         if well_bbox.y == 0:
             # This labware has no wells; use a fixed minimum
-            return 5
+            return 10
         if well_bbox.y > labware_bbox.y:
             # This labware has a very odd definition with wells outside its dimensions.
             # Return the smaller value.

--- a/api/src/opentrons/protocol_engine/types/__init__.py
+++ b/api/src/opentrons/protocol_engine/types/__init__.py
@@ -102,6 +102,7 @@ from .labware import (
     LoadedLabware,
     LabwareParentDefinition,
     LabwareWellId,
+    GripSpecs,
 )
 from .liquid import HexColor, EmptyLiquidId, LiquidId, Liquid, FluidKind, AspiratedFluid
 from .labware_offset_location import (
@@ -257,6 +258,7 @@ __all__ = [
     "LabwareOffsetVector",
     "LabwareParentDefinition",
     "LabwareWellId",
+    "GripSpecs",
     # Liquids
     "HexColor",
     "EmptyLiquidId",

--- a/api/src/opentrons/protocol_engine/types/labware.py
+++ b/api/src/opentrons/protocol_engine/types/labware.py
@@ -23,6 +23,15 @@ from .module import ModuleDefinition
 from .deck_configuration import DeckLocationDefinition
 
 
+@dataclass(frozen=True)
+class GripSpecs:
+    """Data for how a labware should be gripped."""
+
+    uncertaintyWider: float
+    uncertaintyNarrower: float
+    targetY: float
+
+
 class OverlapOffset(Vec3f):
     """Offset representing overlap space of one labware on top of another labware or module."""
 

--- a/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
@@ -1316,8 +1316,8 @@ def test_grip_error_detection(
             narrower,
             actual_grip_width,
             allowed_error,
-            hard_max,
             hard_min,
+            hard_max,
         )
 
 

--- a/api/tests/opentrons/protocol_engine/execution/test_labware_movement_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_labware_movement_handler.py
@@ -1,4 +1,5 @@
 """Test labware movement command execution side effects."""
+
 from __future__ import annotations
 
 from datetime import datetime
@@ -24,6 +25,7 @@ from opentrons.protocol_engine.types import (
     NonStackedLocation,
     LabwareMovementOffsetData,
     Dimensions,
+    GripSpecs,
 )
 from opentrons.protocol_engine.execution.thermocycler_plate_lifter import (
     ThermocyclerPlateLifter,
@@ -212,16 +214,10 @@ async def test_raise_error_if_gripper_pickup_failed(
     ).then_return(Point(201, 202, 219.5))
 
     decoy.when(
-        state_store.labware.get_dimensions(
+        state_store.labware.get_gripper_width_specs(
             labware_definition=sentinel.my_teleporting_labware_def
         )
-    ).then_return(Dimensions(x=100, y=85, z=0))
-
-    decoy.when(
-        state_store.labware.get_well_bbox(
-            labware_definition=sentinel.my_teleporting_labware_def
-        )
-    ).then_return(Dimensions(x=99, y=80, z=1))
+    ).then_return(GripSpecs(targetY=100, uncertaintyNarrower=5, uncertaintyWider=10))
 
     await subject.move_labware_with_gripper(
         labware_id="my-teleporting-labware",
@@ -239,20 +235,20 @@ async def test_raise_error_if_gripper_pickup_failed(
         await ot3_hardware_api.ungrip(),
         await ot3_hardware_api.grip(force_newtons=100),
         ot3_hardware_api.raise_error_if_gripper_pickup_failed(
-            expected_grip_width=85,
-            grip_width_uncertainty_wider=0,
+            expected_grip_width=100,
+            grip_width_uncertainty_wider=10,
             grip_width_uncertainty_narrower=5,
         ),
         await ot3_hardware_api.grip(force_newtons=100),
         ot3_hardware_api.raise_error_if_gripper_pickup_failed(
-            expected_grip_width=85,
-            grip_width_uncertainty_wider=0,
+            expected_grip_width=100,
+            grip_width_uncertainty_wider=10,
             grip_width_uncertainty_narrower=5,
         ),
         await ot3_hardware_api.grip(force_newtons=100),
         ot3_hardware_api.raise_error_if_gripper_pickup_failed(
-            expected_grip_width=85,
-            grip_width_uncertainty_wider=0,
+            expected_grip_width=100,
+            grip_width_uncertainty_wider=10,
             grip_width_uncertainty_narrower=5,
         ),
         await ot3_hardware_api.disengage_axes([Axis.Z_G]),
@@ -361,6 +357,12 @@ async def test_move_labware_with_gripper(
             labware_location=from_location
         )
     ).then_return(mock_tc_context_manager)
+
+    decoy.when(
+        state_store.labware.get_gripper_width_specs(
+            labware_definition=sentinel.my_teleporting_labware_def
+        )
+    ).then_return(GripSpecs(targetY=100, uncertaintyNarrower=5, uncertaintyWider=10))
 
     expected_waypoints = [
         Point(100, 100, 999),  # move to above slot 1
@@ -515,6 +517,7 @@ async def test_labware_movement_raises_without_gripper(
     """It should raise an error when attempting a gripper movement without a gripper."""
     decoy.when(state_store.config.use_virtual_gripper).then_return(False)
     decoy.when(ot3_hardware_api.has_gripper()).then_return(False)
+
     with pytest.raises(GripperNotAttachedError):
         await subject.move_labware_with_gripper(
             labware_id="labware-id",

--- a/api/tests/opentrons/protocol_engine/state/test_labware_view_old.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_view_old.py
@@ -1865,7 +1865,7 @@ def test_calculates_well_bounding_box(
     [
         (
             "opentrons_universal_flat_adapter",
-            GripSpecs(targetY=75, uncertaintyNarrower=10, uncertaintyWider=0),
+            GripSpecs(targetY=75, uncertaintyNarrower=5, uncertaintyWider=0),
         ),
         # well min: 7.81
         # well max: 77.67
@@ -1883,11 +1883,11 @@ def test_calculates_well_bounding_box(
         ),
         (
             "opentrons_tough_universal_lid",
-            GripSpecs(targetY=85.48, uncertaintyNarrower=10, uncertaintyWider=0),
+            GripSpecs(targetY=85.48, uncertaintyNarrower=5, uncertaintyWider=0),
         ),
         (
             "opentrons_flex_tiprack_lid",
-            GripSpecs(targetY=78.75, uncertaintyNarrower=10, uncertaintyWider=0),
+            GripSpecs(targetY=78.75, uncertaintyNarrower=5, uncertaintyWider=0),
         ),
         # well min 7.175
         # well max 78.305

--- a/api/tests/opentrons/protocol_engine/state/test_labware_view_old.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_view_old.py
@@ -5,10 +5,12 @@ longer helpful. Try to add new tests to test_labware_state.py, where they can be
 tested together, treating LabwareState as a private implementation detail.
 """
 
-import pytest
 from datetime import datetime
 from typing import Dict, Optional, cast, ContextManager, Any, Union, List
 from contextlib import nullcontext as does_not_raise
+
+import pytest
+from numpy import isclose
 
 from opentrons_shared_data.deck.types import DeckDefinitionV5
 from opentrons_shared_data.pipette.types import LabwareUri
@@ -45,6 +47,7 @@ from opentrons.protocol_engine.types import (
     LabwareMovementOffsetData,
     OnAddressableAreaOffsetLocationSequenceComponent,
     OnModuleOffsetLocationSequenceComponent,
+    GripSpecs,
 )
 from opentrons.protocol_engine.state._move_types import EdgePathType
 from opentrons.protocol_engine.state.labware import (
@@ -1855,3 +1858,55 @@ def test_calculates_well_bounding_box(
     assert subject.get_well_bbox(definition).x == pytest.approx(well_bbox.x)
     assert subject.get_well_bbox(definition).y == pytest.approx(well_bbox.y)
     assert subject.get_well_bbox(definition).z == pytest.approx(well_bbox.z)
+
+
+@pytest.mark.parametrize(
+    "labware_to_check,gripper_specs",
+    [
+        (
+            "opentrons_universal_flat_adapter",
+            GripSpecs(targetY=75, uncertaintyNarrower=5, uncertaintyWider=0),
+        ),
+        # well min: 7.81
+        # well max: 77.67
+        # well bbox: 69.86
+        (
+            "corning_96_wellplate_360ul_flat",
+            GripSpecs(targetY=85.47, uncertaintyNarrower=15.61, uncertaintyWider=0),
+        ),
+        # well min 7.18
+        # well max 78.38
+        # well bbox 71.2
+        (
+            "nest_12_reservoir_15ml",
+            GripSpecs(targetY=85.48, uncertaintyNarrower=14.28, uncertaintyWider=0),
+        ),
+        (
+            "opentrons_tough_universal_lid",
+            GripSpecs(targetY=85.48, uncertaintyNarrower=5, uncertaintyWider=0),
+        ),
+        (
+            "opentrons_flex_tiprack_lid",
+            GripSpecs(targetY=78.75, uncertaintyNarrower=5, uncertaintyWider=0),
+        ),
+        # well min 7.175
+        # well max 78.305
+        # well bbox 71.13
+        (
+            "corning_384_wellplate_112ul_flat",
+            GripSpecs(targetY=85.47, uncertaintyNarrower=14.34, uncertaintyWider=0),
+        ),
+    ],
+)
+def test_calculates_gripper_positions(
+    labware_to_check: str, gripper_specs: GripSpecs
+) -> None:
+    """It should calculate gripper positions."""
+    definition = labware_definition_type_adapter.validate_python(
+        load_definition(labware_to_check, 1)
+    )
+    subject = get_labware_view()
+    specs = subject.get_gripper_width_specs(definition)
+    assert isclose(specs.targetY, gripper_specs.targetY)
+    assert isclose(specs.uncertaintyNarrower, gripper_specs.uncertaintyNarrower)
+    assert isclose(specs.uncertaintyWider, gripper_specs.uncertaintyWider)

--- a/api/tests/opentrons/protocol_engine/state/test_labware_view_old.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_view_old.py
@@ -1865,7 +1865,7 @@ def test_calculates_well_bounding_box(
     [
         (
             "opentrons_universal_flat_adapter",
-            GripSpecs(targetY=75, uncertaintyNarrower=5, uncertaintyWider=0),
+            GripSpecs(targetY=75, uncertaintyNarrower=10, uncertaintyWider=0),
         ),
         # well min: 7.81
         # well max: 77.67
@@ -1883,11 +1883,11 @@ def test_calculates_well_bounding_box(
         ),
         (
             "opentrons_tough_universal_lid",
-            GripSpecs(targetY=85.48, uncertaintyNarrower=5, uncertaintyWider=0),
+            GripSpecs(targetY=85.48, uncertaintyNarrower=10, uncertaintyWider=0),
         ),
         (
             "opentrons_flex_tiprack_lid",
-            GripSpecs(targetY=78.75, uncertaintyNarrower=5, uncertaintyWider=0),
+            GripSpecs(targetY=78.75, uncertaintyNarrower=10, uncertaintyWider=0),
         ),
         # well min 7.175
         # well max 78.305


### PR DESCRIPTION
When we move labware during the gripper, we use the position of the
labware jaw while labware is nominally gripped to determine whether we
successfully grabbed the labware or not. We compare the position to some
fact of the labware's geometry.

Because the geometry doesn't actually contain the width at the point
that it's gripped (it only has the bounding box, which includes e.g. a
skirt that the gripper doesn't interact with) and because the gripper's
jaw width position tracking can have problems, we also allow
uncertainty.

There were a couple problems that are now fixed, such as
- We were doing an exact position comparison for the
gripper-fully-closed case; this is not really safe because the encoder
can be a little off, so add a less-than check to make sure we detect it
- The big one: we determined our uncertainty values by the difference
between the well bounding box and the labware bounding box. For labware
that doesn't have wells, that means the uncertainty is effectively
infinite. Instead, use a fixed distance.
- Also, refactor some stuff to support it.

The behavior for things that have wells should be unchanged.

## testing
- see if we can detect failed lid pickups now!

Closes EXEC-1783
