### PR TITLE
fix(protocol-designer): Fix the Enter button reloading the page when it's pressed in the "Rename step" form

### DIFF
--- a/protocol-designer/src/components/organisms/RenameStepModal/index.tsx
+++ b/protocol-designer/src/components/organisms/RenameStepModal/index.tsx
@@ -73,16 +73,14 @@ export function RenameStepModal(props: RenameStepModalProps): JSX.Element {
           <PrimaryButton
             data-testid="RenameStepModal_saveButton"
             disabled={stepName.length >= MAX_STEP_NAME_LENGTH}
-            onClick={() => {
-              handleSave()
-            }}
+            onClick={handleSave}
           >
             {t('shared:save')}
           </PrimaryButton>
         </Flex>
       }
     >
-      <form>
+      <form onSubmit={handleSave}>
         <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing12}>
           <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing4}>
             <StyledText color={COLORS.grey60} desktopStyle="captionRegular">


### PR DESCRIPTION
## Overview

Closes AUTH-2265.

## Test Plan and Hands on Testing

* [x] Run the steps to reproduce from AUTH-2265.
* [x] Grep for `<form` and look for other places where we might have forgotten `onSubmit`.

## Changelog

Just supply a missing `onSubmit` handler on the `<form>` itself.

I was a little worried that we would have to rearrange the modal's DOM hierarchy to put the submit button inside the `<form>`. But looking at the other `<form>`s in PD, it looks like we don't worry about those semantics. So this just follows the same pattern that they do.

## Review requests

None in particular.

## Risk assessment

Low.