### PR TITLE
ci(api-docs): new deploy process

### DIFF
--- a/.github/workflows/docs-build.yaml
+++ b/.github/workflows/docs-build.yaml
@@ -1,31 +1,35 @@
 # This workflow builds API docs when either:
 #
-# * A commit is tagged like "docs@foo".
+# * A commit is tagged like "docs@foo" or "staging-docs@foo".
 #
-# * Someone pushes, to any branch, a commit that touches any of:
-#   * The parts of the api/ project that are used by the docs.
-#   * The docs source themselves;
-#   * The CI/makefile tooling used to build the docs.
+# * Someone pushes to either:
+#   * The `edge` branch, or
+#   * Any branch starting with "chore_release".
+#
+# * A pull request touches any of:
+#   * The api/**
+#   * The tooling used to build the docs.
+#
+# * Or when manually dispatched from the Actions tab.
 
 name: 'API docs build'
 
 on:
   push:
+    branches:
+      - edge
+      - 'chore_release*'
     tags:
       - 'docs@*'
-    branches:
-      # We don't want to do any filtering based on branch name.
-      # But because we specified `tags`, we need to specify `branches` too,
-      # or else GitHub will only run this workflow for tag matches
-      # and not for path matches.
-      - '**'
+      - 'staging-docs@*'
+  pull_request:
     paths:
       - 'api/**'
       - '.github/workflows/docs-build.yaml'
       - '.github/actions/python/**'
-      - '.github/actions/webstack/deploy-to-sandbox/**'
       - '.github/workflows/utils.js'
-  workflow_dispatch:
+      - 'scripts/static-deploy/**'
+  workflow_dispatch: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.ref_name != 'edge' || github.run_id}}-${{ github.ref_type != 'tag' || github.run_id }}
@@ -34,24 +38,48 @@ concurrency:
 defaults:
   run:
     shell: bash
+env:
+  CI: 'true'
+  # This is the artifact directory as a relative path
+  # to the working-directory of our tools: scripts/static-deploy
+  # our script deploy_ci_config.py expects this ENV variable is set
+  RELATIVE_ARTIFACT_DIR: '../../dist'
 
 jobs:
+  determine-deploy-config:
+    name: Determine Deployment Configuration
+    runs-on: ubuntu-24.04
+    outputs:
+      application: ${{ steps.deploy-config.outputs.APPLICATION }}
+      environment: ${{ steps.deploy-config.outputs.ENVIRONMENT }}
+      sandbox_prefix: ${{ steps.deploy-config.outputs.SANDBOX_PREFIX }}
+      relative_artifact_dir: ${{ steps.deploy-config.outputs.RELATIVE_ARTIFACT_DIR }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+      - uses: ./.github/actions/git/resolve-tag
+      - name: Setup UV
+        uses: astral-sh/setup-uv@v6
+        with:
+          python-version: '3.10'
+      - name: Setup Deploy Dependencies
+        working-directory: scripts/static-deploy
+        run: make setup
+      - name: Determine Deployment Configuration
+        id: deploy-config
+        working-directory: scripts/static-deploy
+        run: make resolve-ci
+
   build:
     name: opentrons documentation build
     runs-on: 'ubuntu-24.04'
-    permissions:
-      id-token: write
-      contents: read
+    timeout-minutes: 10
     steps:
       - uses: 'actions/checkout@v4'
         with:
           fetch-depth: 0
-      # https://github.com/actions/checkout/issues/290
-      - name: 'Fix actions/checkout odd handling of tags'
-        if: startsWith(github.ref, 'refs/tags')
-        run: |
-          git fetch -f origin ${{ github.ref }}:${{ github.ref }}
-          git checkout ${{ github.ref }}
+      - uses: ./.github/actions/git/resolve-tag
+      - uses: ./.github/actions/environment/complex-variables
       - uses: 'actions/setup-node@v4'
         with:
           node-version: '22.12.0'
@@ -61,21 +89,58 @@ jobs:
       - uses: './.github/actions/python/setup'
         with:
           project: 'api'
-      - name: 'set complex environment variables'
-        uses: actions/github-script@v6
-        with:
-          script: |
-            const { buildComplexEnvVars, } = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/utils.js`)
-            buildComplexEnvVars(core, context)
       - name: 'Build docs'
         run: |
           make -C api docs
+      - name: 'upload github artifact'
+        uses: actions/upload-artifact@v4
+        with:
+          name: 'docs-artifact'
+          path: api/docs/dist/
 
-      - name: 'Configure AWS Credentials for docs bucket'
+  deploy:
+    name: Deploy docs to S3
+    needs:
+      - determine-deploy-config
+      - build
+    runs-on: 'ubuntu-24.04'
+    timeout-minutes: 5
+    if: always() && needs.build.result == 'success' && needs.determine-deploy-config.result == 'success'
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/git/resolve-tag
+      - name: Setup UV
+        uses: astral-sh/setup-uv@v6
+        with:
+          python-version: '3.10'
+      - name: Setup Deploy Dependencies
+        working-directory: scripts/static-deploy
+        run: |
+          make setup
+      - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.DOCS_SANDBOX_ROLE }}
           aws-region: us-east-2
-      - name: 'Deploy docs to sandbox.docs bucket'
-        run: |
-          aws s3 sync ./api/docs/dist/ s3://sandbox.docs/${{ github.ref_name }}/
+          audience: sts.amazonaws.com
+          role-to-assume: ${{ secrets.DOCS_SANDBOX_ROLE }}
+      - name: Download Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: docs-artifact
+          path: ./dist # in the default workspace
+          # RELATIVE_ARTIFACT_DIR is set to ../../dist
+          # because that is the relative path from scripts/static-deploy
+          # to the this location
+      - name: Deploy to S3
+        working-directory: scripts/static-deploy
+        run: make deploy \
+          APPLICATION=${{ needs.determine-deploy-config.outputs.application }} \
+          ENVIRONMENT=${{ needs.determine-deploy-config.outputs.environment }} \
+          SANDBOX_PREFIX=${{ needs.determine-deploy-config.outputs.sandbox_prefix }} \
+          RELATIVE_ARTIFACT_DIR=${{ needs.determine-deploy-config.outputs.relative_artifact_dir }}

--- a/.github/workflows/ll-test-build-deploy.yaml
+++ b/.github/workflows/ll-test-build-deploy.yaml
@@ -13,14 +13,6 @@ on:
       - '.github/workflows/utils.js'
       - 'scripts/static-deploy/**'
   push:
-    paths:
-      - 'labware-library/**'
-      - 'shared-data/labware/**'
-      - 'components/**'
-      - 'package.json'
-      - '.github/workflows/ll-test-build-deploy.yaml'
-      - '.github/workflows/utils.js'
-      - 'scripts/static-deploy/**'
     branches:
       - 'edge'
       - 'chore_release*'

--- a/scripts/static-deploy/deploy.py
+++ b/scripts/static-deploy/deploy.py
@@ -56,7 +56,7 @@ def write_github_summary(
     app_display = {
         "labware_library": "Labware Library",
         "protocol_designer": "Protocol Designer",
-        "docs": "Docs",
+        "docs": "API Docs",
         "mkdocs": "MkDocs",
     }
 
@@ -88,41 +88,24 @@ def write_github_summary(
 | 🗑️ **Delete Sync** | Enabled (removes remote files not in local) |"""
 
     markdown_summary += f"""
-| 🌐 **Deployment URL** | [{deployment_url}]({deployment_url}/{sandbox_prefix}) |"""
+| 🌐 **Deployment URL** | [{deployment_url}]({deployment_url}) |"""
 
     if config.cloudfront_id:
         cache_status = "✅ Invalidated" if cloudfront_invalidated and not dry_run else ("🧪 Skipped (dry run)" if dry_run else "❌ Failed")
         markdown_summary += f"""
 | ☁️ **CloudFront** | `{config.cloudfront_id}` - {cache_status} |"""
 
+    markdown_summary += """
+---
+*Deployment executed by `deploy.py`*"""
+
     if dry_run:
         markdown_summary += """
-
 ### 🧪 Dry Run Notes
 - No files were actually uploaded or modified
 - S3 sync operations were simulated with `--dryrun`
 - CloudFront cache invalidation was skipped
 - All AWS operations were read-only"""
-
-    # Build GitHub Actions run URL
-    github_url = (
-        f"{os.environ.get('GITHUB_SERVER_URL', '')}"
-        f"/{os.environ.get('GITHUB_REPOSITORY', '')}"
-        f"/actions/runs/{os.environ.get('GITHUB_RUN_ID', '')}"
-    )
-
-    markdown_summary += f"""
-
-### Deployment Details
-
-- **AWS CLI Sync**: `aws s3 sync --exact-timestamps --only-show-errors{"" if config.name in ["docs", "mkdocs"] else " --delete"}`
-- **Content Type**: Automatic detection by AWS CLI
-- **GitHub Run ID**: `{os.environ.get("GITHUB_RUN_ID", "unknown")}`
-- **Run Details**: [{github_url}]({github_url})
-
----
-*Deployment executed by `deploy.py`*
-"""
 
     try:
         with open(github_step_summary, "a") as f:
@@ -340,6 +323,9 @@ def deploy_application(  # noqa: C901
     else:
         s3_prefix = ""
         deployment_url = config.url
+
+    if config.name == "docs":
+        deployment_url = f"{deployment_url}v2/index.html"
 
     console.print(f"Deploying to {environment} environment:")
     console.print(f"  Bucket: {config.s3_bucket}")

--- a/scripts/static-deploy/deploy.py
+++ b/scripts/static-deploy/deploy.py
@@ -22,6 +22,119 @@ from rich.console import Console
 console = Console()
 
 
+def write_github_summary(
+    config: ApplicationConfig,
+    environment: str,
+    deployment_url: str,
+    sandbox_prefix: Optional[str] = None,
+    dry_run: bool = False,
+    cloudfront_invalidated: bool = False,
+) -> None:
+    """Write deployment summary to GitHub Actions summary.
+
+    Args:
+        config: Application configuration used for deployment
+        environment: Environment deployed to
+        deployment_url: Final deployment URL
+        sandbox_prefix: Sandbox prefix if applicable
+        dry_run: Whether this was a dry run
+        cloudfront_invalidated: Whether CloudFront cache was invalidated
+    """
+    github_step_summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not github_step_summary:
+        console.print("⚠️  GITHUB_STEP_SUMMARY not set, skipping summary", style="yellow")
+        return
+
+    # Environment emoji mapping
+    env_emoji = {
+        "sandbox": "🏗️",
+        "staging": "🧪",
+        "production": "🌟",
+    }
+
+    # Application display name mapping
+    app_display = {
+        "labware_library": "Labware Library",
+        "protocol_designer": "Protocol Designer",
+        "docs": "Docs",
+        "mkdocs": "MkDocs",
+    }
+
+    # Determine deployment type icon and title
+    if dry_run:
+        deploy_icon = "🧪"
+        deploy_title = "Deployment Simulation (Dry Run)"
+    else:
+        deploy_icon = "🚀"
+        deploy_title = "Deployment Completed"
+
+    markdown_summary = f"""## {deploy_icon} {deploy_title}
+
+| Setting | Value |
+|---------|--------|
+| 📦 **Application** | {app_display.get(config.name, config.name)} |
+| {env_emoji.get(environment, "🔧")} **Environment** | {environment.title()} |
+| 🪣 **S3 Bucket** | `{config.s3_bucket}` |"""
+
+    if environment == "sandbox" and sandbox_prefix:
+        markdown_summary += f"""
+| 🌿 **Sandbox Prefix** | `{sandbox_prefix}` |"""
+
+    if config.name in ["docs", "mkdocs"]:
+        markdown_summary += """
+| 🗑️ **Delete Protection** | Enabled (preserves existing files) |"""
+    else:
+        markdown_summary += """
+| 🗑️ **Delete Sync** | Enabled (removes remote files not in local) |"""
+
+    markdown_summary += f"""
+| 🌐 **Deployment URL** | [{deployment_url}]({deployment_url}) |"""
+
+    if config.cloudfront_id:
+        cache_status = "✅ Invalidated" if cloudfront_invalidated and not dry_run else ("🧪 Skipped (dry run)" if dry_run else "❌ Failed")
+        markdown_summary += f"""
+| ☁️ **CloudFront** | `{config.cloudfront_id}` - {cache_status} |"""
+
+    if dry_run:
+        markdown_summary += """
+
+### 🧪 Dry Run Notes
+- No files were actually uploaded or modified
+- S3 sync operations were simulated with `--dryrun`
+- CloudFront cache invalidation was skipped
+- All AWS operations were read-only"""
+
+    # Build GitHub Actions run URL
+    github_url = (
+        f"{os.environ.get('GITHUB_SERVER_URL', '')}"
+        f"/{os.environ.get('GITHUB_REPOSITORY', '')}"
+        f"/actions/runs/{os.environ.get('GITHUB_RUN_ID', '')}"
+    )
+
+    markdown_summary += f"""
+
+### Deployment Details
+
+- **AWS CLI Sync**: `aws s3 sync --exact-timestamps --only-show-errors{"" if config.name in ["docs", "mkdocs"] else " --delete"}`
+- **Content Type**: Automatic detection by AWS CLI
+- **GitHub Run ID**: `{os.environ.get("GITHUB_RUN_ID", "unknown")}`
+- **Run Details**: [{github_url}]({github_url})
+
+---
+*Deployment executed by `deploy.py`*
+"""
+
+    try:
+        with open(github_step_summary, "a") as f:
+            f.write(markdown_summary)
+
+        console.print("✅ Wrote deployment summary to GitHub Actions", style="green")
+
+    except Exception as e:
+        console.print(f"❌ Failed to write GitHub summary: {e}", style="red")
+        # Don't exit here - summary is nice-to-have, not critical
+
+
 def _validate_artifact_directory(relative_artifact_dir: str) -> Path:
     """Validate that the artifact directory exists and is a directory.
 
@@ -240,11 +353,16 @@ def deploy_application(  # noqa: C901
     # Upload progress is handled by AWS CLI output
 
     try:
-        # No manual pre-clean: rely on aws s3 sync --delete in all environments
-        if dry_run:
-            console.print("Dry run: will simulate deletions via 'aws s3 sync --delete --dryrun'", style="blue")
+        # Determine if we should use --delete flag (skip for docs/mkdocs applications)
+        use_delete_flag = config.name not in ["docs", "mkdocs"]
+
+        if use_delete_flag:
+            if dry_run:
+                console.print("Dry run: will simulate deletions via 'aws s3 sync --delete --dryrun'", style="blue")
+            else:
+                console.print("Using 'aws s3 sync --delete' to remove remote files not present locally", style="blue")
         else:
-            console.print("Using 'aws s3 sync --delete' to remove remote files not present locally", style="blue")
+            console.print(f"Skipping --delete flag for {config.name} deployment to preserve existing remote files", style="blue")
 
         # Upload new artifacts using AWS CLI instead of boto3 for faster sync and automatic content-type
         try:
@@ -257,8 +375,11 @@ def deploy_application(  # noqa: C901
                 s3_uri,
                 "--only-show-errors",
                 "--exact-timestamps",
-                "--delete",
             ]
+
+            # Add --delete flag only for non-docs applications
+            if use_delete_flag:
+                cmd.append("--delete")
             # Dry run simulation
             if dry_run:
                 cmd.append("--dryrun")
@@ -284,6 +405,7 @@ def deploy_application(  # noqa: C901
             sys.exit(1)
 
         # Invalidate CloudFront cache if configured
+        cloudfront_invalidated = False
         if config.cloudfront_id and config.cloudfront_id != "":
             console.print(f"Invalidating CloudFront cache for distribution {config.cloudfront_id}...")
             try:
@@ -299,12 +421,23 @@ def deploy_application(  # noqa: C901
                         },
                     )
                     console.print("✅ CloudFront cache invalidation initiated", style="green")
+                    cloudfront_invalidated = True
             except Exception as e:
                 console.print(f"⚠️  CloudFront cache invalidation failed: {e}", style="yellow")
                 # Don't fail the deployment for CloudFront issues
 
         console.print(f"✅ Successfully deployed to {environment}!", style="green bold")
         console.print(f"📍 Deployed to: {deployment_url}", style="blue")
+
+        # Write GitHub Actions summary
+        write_github_summary(
+            config=config,
+            environment=environment,
+            deployment_url=deployment_url,
+            sandbox_prefix=sandbox_prefix,
+            dry_run=dry_run,
+            cloudfront_invalidated=cloudfront_invalidated,
+        )
 
     except Exception as e:
         console.print(f"❌ Deployment failed: {e}", style="red")

--- a/scripts/static-deploy/deploy.py
+++ b/scripts/static-deploy/deploy.py
@@ -88,7 +88,7 @@ def write_github_summary(
 | 🗑️ **Delete Sync** | Enabled (removes remote files not in local) |"""
 
     markdown_summary += f"""
-| 🌐 **Deployment URL** | [{deployment_url}]({deployment_url}) |"""
+| 🌐 **Deployment URL** | [{deployment_url}]({deployment_url}/{sandbox_prefix}) |"""
 
     if config.cloudfront_id:
         cache_status = "✅ Invalidated" if cloudfront_invalidated and not dry_run else ("🧪 Skipped (dry run)" if dry_run else "❌ Failed")

--- a/scripts/static-deploy/deploy_ci_config.py
+++ b/scripts/static-deploy/deploy_ci_config.py
@@ -55,8 +55,15 @@ def _determine_application(ref_type: str, ref_name: str) -> str:
             return "protocol_designer"
         elif "Labware Library test, build, and deploy" in workflow_name:
             return "labware_library"
+        elif "API docs build" in workflow_name:
+            return "docs"
 
-    return "labware_library"  # default
+    # No application could be determined - exit with error
+    raise ValueError(
+        f"Could not determine application from ref_type='{ref_type}', ref_name='{ref_name}', "
+        f"workflow (GITHUB_WORKFLOW)='{os.environ.get('GITHUB_WORKFLOW', 'unknown')}'. "
+        f"Please check tag naming or workflow configuration."
+    )
 
 
 def _determine_environment_and_prefix(event_name: str, ref_type: str, ref_name: str, head_ref: Optional[str]) -> tuple[str, str]:

--- a/scripts/static-deploy/deploy_config.py
+++ b/scripts/static-deploy/deploy_config.py
@@ -112,26 +112,26 @@ def get_deploy_config() -> DeployConfig:
         labware_library=ApplicationConfig(
             name="labware_library",
             s3_bucket="opentrons.sandbox.labware",
-            cloudfront_id=None,  # No CloudFront for sandbox
-            url="http://opentrons.sandbox.labware.s3-website.us-east-2.amazonaws.com/",
+            cloudfront_id=None,  # No CloudFront invalidation on sandbox
+            url="http://sandbox.labware.opentrons.com/",
         ),
         protocol_designer=ApplicationConfig(
             name="protocol_designer",
             s3_bucket="opentrons.sandbox.protocol-designer",
-            cloudfront_id=None,  # No CloudFront for sandbox
-            url="http://opentrons.sandbox.protocol-designer.s3-website.us-east-2.amazonaws.com/",
+            cloudfront_id=None,  # No CloudFront invalidation on sandbox
+            url="http://sandbox.designer.opentrons.com/",
         ),
         docs=ApplicationConfig(
             name="docs",
             s3_bucket="sandbox.docs",
-            cloudfront_id=None,  # No CloudFront for sandbox
-            url="http://sandbox.docs.s3-website.us-east-2.amazonaws.com/",
+            cloudfront_id=None,  # No CloudFront invalidation on sandbox
+            url="http://sandbox.docs.opentrons.com/",
         ),
         mkdocs=ApplicationConfig(
             name="mkdocs",
             s3_bucket="sandbox.docs",
-            cloudfront_id=None,  # No CloudFront for sandbox
-            url="http://sandbox.docs.s3-website.us-east-2.amazonaws.com/",
+            cloudfront_id=None,  # No CloudFront invalidation on sandbox
+            url="http://sandbox.docs.opentrons.com/",
         ),
     )
 

--- a/scripts/static-deploy/deploy_config.py
+++ b/scripts/static-deploy/deploy_config.py
@@ -35,6 +35,7 @@ class InvalidApplicationError(ValueError):
 class ApplicationConfig:
     """Configuration for a single application deployment."""
 
+    name: Application
     s3_bucket: str
     cloudfront_id: Optional[str]
     url: str
@@ -109,21 +110,25 @@ def get_deploy_config() -> DeployConfig:
     # Sandbox configuration
     sandbox_config = EnvironmentConfig(
         labware_library=ApplicationConfig(
+            name="labware_library",
             s3_bucket="opentrons.sandbox.labware",
             cloudfront_id=None,  # No CloudFront for sandbox
             url="http://opentrons.sandbox.labware.s3-website.us-east-2.amazonaws.com/",
         ),
         protocol_designer=ApplicationConfig(
+            name="protocol_designer",
             s3_bucket="opentrons.sandbox.protocol-designer",
             cloudfront_id=None,  # No CloudFront for sandbox
             url="http://opentrons.sandbox.protocol-designer.s3-website.us-east-2.amazonaws.com/",
         ),
         docs=ApplicationConfig(
+            name="docs",
             s3_bucket="sandbox.docs",
             cloudfront_id=None,  # No CloudFront for sandbox
             url="http://sandbox.docs.s3-website.us-east-2.amazonaws.com/",
         ),
         mkdocs=ApplicationConfig(
+            name="mkdocs",
             s3_bucket="sandbox.docs",
             cloudfront_id=None,  # No CloudFront for sandbox
             url="http://sandbox.docs.s3-website.us-east-2.amazonaws.com/",
@@ -133,21 +138,25 @@ def get_deploy_config() -> DeployConfig:
     # Staging configuration
     staging_config = EnvironmentConfig(
         labware_library=ApplicationConfig(
+            name="labware_library",
             s3_bucket="opentrons.staging.labware",
             cloudfront_id="E8IWASMDOWHYP",
             url="https://staging.labware.opentrons.com/",
         ),
         protocol_designer=ApplicationConfig(
+            name="protocol_designer",
             s3_bucket="opentrons.staging.protocol-designer",
             cloudfront_id="",  # Add CloudFront ID when available
             url="https://staging.protocol-designer.opentrons.com/",
         ),
         docs=ApplicationConfig(
+            name="docs",
             s3_bucket="opentrons.staging.docs",
             cloudfront_id="E8IWASMDOWHYP",
             url="https://staging.docs.opentrons.com/",
         ),
         mkdocs=ApplicationConfig(
+            name="mkdocs",
             s3_bucket="opentrons.staging.docs",
             cloudfront_id="E8IWASMDOWHYP",
             url="https://staging.docs.opentrons.com/",
@@ -157,21 +166,25 @@ def get_deploy_config() -> DeployConfig:
     # Production configuration
     production_config = EnvironmentConfig(
         labware_library=ApplicationConfig(
+            name="labware_library",
             s3_bucket="opentrons.production.labware",
             cloudfront_id="E16BZZXDTINN0S",
             url="https://labware.opentrons.com/",
         ),
         protocol_designer=ApplicationConfig(
+            name="protocol_designer",
             s3_bucket="opentrons.production.protocol-designer",
             cloudfront_id="",  # Add CloudFront ID when available
             url="https://protocol-designer.opentrons.com/",
         ),
         docs=ApplicationConfig(
+            name="docs",
             s3_bucket="opentrons.production.docs",
             cloudfront_id="E16BZZXDTINN0S",
             url="https://docs.opentrons.com/",
         ),
         mkdocs=ApplicationConfig(
+            name="mkdocs",
             s3_bucket="opentrons.production.docs",
             cloudfront_id="E16BZZXDTINN0S",
             url="https://docs.opentrons.com/",

--- a/scripts/static-deploy/tests/test_deploy.py
+++ b/scripts/static-deploy/tests/test_deploy.py
@@ -45,7 +45,7 @@ def test_parse_valid_sandbox_args_with_branch(tmp_path):
     # Check that we get the real config back
     assert isinstance(parsed.config, ApplicationConfig)
     assert parsed.config.s3_bucket == "opentrons.sandbox.protocol-designer"
-    assert parsed.config.url == "http://opentrons.sandbox.protocol-designer.s3-website.us-east-2.amazonaws.com/"
+    assert parsed.config.url == "http://sandbox.designer.opentrons.com/"
     assert parsed.relative_artifact_dir == str(artifact_dir)
     assert parsed.sandbox_prefix == "feature-branch"
     assert parsed.environment == "sandbox"

--- a/scripts/static-deploy/tests/test_deploy_config.py
+++ b/scripts/static-deploy/tests/test_deploy_config.py
@@ -343,4 +343,4 @@ def test_determine_deploy_config_from_args_sandbox_branch_url_suffix():
     assert cfg.environment == "sandbox"
     assert cfg.sandbox_prefix == "edge"
     assert cfg.bucket == "opentrons.sandbox.labware"
-    assert cfg.url == "http://opentrons.sandbox.labware.s3-website.us-east-2.amazonaws.com/edge/"
+    assert cfg.url == "http://sandbox.labware.opentrons.com/edge/"


### PR DESCRIPTION
# Sphinx API docs publishing

This PR updates the API docs build workflow to align with our new static site deployment process.

### Changes
- **tag push** triggers to build and deploy (`staging-docs@*`, `docs@*`) to staging and production automatically
- a developer will push the staging tag on a commit and then test in staging.  Then on the same commit will push the production tag to build and deploy to production.
- Ensure **continuous sandbox publish** of docs for `edge` and `chore_release*` branches.
- Remove redundant "any branch" push trigger → no unnecessary runs outside of pushes of tags and the edge and chore_release.
- Build on PR for the matching paths