### PR TITLE
fix(protocol-designer): do not null tiprack when updating pipette 

### DIFF
--- a/protocol-designer/src/components/organisms/EditInstrumentsModal/editPipettes.ts
+++ b/protocol-designer/src/components/organisms/EditInstrumentsModal/editPipettes.ts
@@ -213,6 +213,7 @@ export const editPipettes = (
         substitutionMap,
         startStepId: orderedStepIds[0],
         endStepId: last(orderedStepIds) ?? '',
+        newTiprackURI: Array.from(newTiprackUris)[0],
       })
     )
   }

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TiprackField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TiprackField.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 
@@ -21,12 +20,7 @@ interface TiprackFieldProps extends FieldProps {
   pipetteId?: unknown
 }
 export function TiprackField(props: TiprackFieldProps): JSX.Element {
-  const {
-    value,
-    updateValue,
-    pipetteId,
-    padding = `0 ${SPACING.spacing16}`,
-  } = props
+  const { value, pipetteId, padding = `0 ${SPACING.spacing16}` } = props
   const { t } = useTranslation('protocol_steps')
   const pipetteEntities = useSelector(getPipetteEntities)
   const options = useSelector(getTiprackOptions)
@@ -36,16 +30,6 @@ export function TiprackField(props: TiprackFieldProps): JSX.Element {
     defaultTiprackUris.includes(option.value)
   )
 
-  useEffect(() => {
-    //  if default value is not included in the pipette's tiprack uris then
-    //  change it so it is
-    if (
-      !defaultTiprackUris.includes(value as string) &&
-      defaultTiprackUris.length > 0
-    ) {
-      updateValue(defaultTiprackUris[0])
-    }
-  }, [defaultTiprackUris, value, updateValue])
   const hasMissingTiprack = defaultTiprackUris.length > tiprackOptions.length
   return (
     <>

--- a/protocol-designer/src/step-forms/actions/pipettes.ts
+++ b/protocol-designer/src/step-forms/actions/pipettes.ts
@@ -31,6 +31,8 @@ export interface SubstituteStepFormPipettesAction {
     endStepId: StepIdType
     // old pipette id -> new id
     substitutionMap: Record<string, string>
+    //  1st assosciated tiprack with the pipetteId
+    newTiprackURI: string
   }
 }
 export const substituteStepFormPipettes = (

--- a/protocol-designer/src/step-forms/reducers/index.ts
+++ b/protocol-designer/src/step-forms/reducers/index.ts
@@ -198,7 +198,12 @@ export const unsavedForm = (
 
     case 'SUBSTITUTE_STEP_FORM_PIPETTES': {
       // only substitute unsaved step form if its ID is in the start-end range
-      const { substitutionMap, startStepId, endStepId } = action.payload
+      const {
+        substitutionMap,
+        startStepId,
+        endStepId,
+        newTiprackURI,
+      } = action.payload
       const stepIdsToUpdate = getIdsInRange(
         rootState.orderedStepIds,
         startStepId,
@@ -218,6 +223,7 @@ export const unsavedForm = (
           ...handleFormChange(
             {
               pipette: substitutionMap[unsavedFormState.pipette],
+              tipRack: newTiprackURI,
             },
             unsavedFormState,
             _getPipetteEntitiesRootState(rootState),
@@ -783,7 +789,12 @@ export const savedStepForms = (
     }
 
     case 'SUBSTITUTE_STEP_FORM_PIPETTES': {
-      const { startStepId, endStepId, substitutionMap } = action.payload
+      const {
+        startStepId,
+        endStepId,
+        substitutionMap,
+        newTiprackURI,
+      } = action.payload
       const stepIdsToUpdate = getIdsInRange(
         rootState.orderedStepIds,
         startStepId,
@@ -800,6 +811,7 @@ export const savedStepForms = (
         const updatedFields = handleFormChange(
           {
             pipette: substitutionMap[prevStepForm.pipette],
+            // tipRack: newTiprackURI,
           },
           prevStepForm,
           _getPipetteEntitiesRootState(rootState),

--- a/protocol-designer/src/step-forms/reducers/index.ts
+++ b/protocol-designer/src/step-forms/reducers/index.ts
@@ -811,7 +811,7 @@ export const savedStepForms = (
         const updatedFields = handleFormChange(
           {
             pipette: substitutionMap[prevStepForm.pipette],
-            // tipRack: newTiprackURI,
+            tipRack: newTiprackURI,
           },
           prevStepForm,
           _getPipetteEntitiesRootState(rootState),

--- a/protocol-designer/src/step-forms/test/reducers.test.ts
+++ b/protocol-designer/src/step-forms/test/reducers.test.ts
@@ -1467,6 +1467,7 @@ describe('unsavedForm reducer', () => {
         },
         startStepId: '3',
         endStepId: '5',
+        newTiprackURI: 'mockURI',
       },
     }
     const rootState: RootState = {
@@ -1500,6 +1501,7 @@ describe('unsavedForm reducer', () => {
       [
         {
           pipette: 'newPipetteId',
+          tipRack: 'mockURI',
         },
         rootState.unsavedForm,
         'pipetteEntitiesPlaceholder',

--- a/protocol-designer/src/step-forms/utils/createPresavedStepForm.ts
+++ b/protocol-designer/src/step-forms/utils/createPresavedStepForm.ts
@@ -74,6 +74,13 @@ const _patchDefaultPipette = (args: {
     orderedStepIds,
     initialDeckSetup.pipettes
   )
+  const pipetteTipracks = pipetteEntities[defaultPipetteId].tiprackDefURI
+  const labwareURIsOnDeck = new Set(
+    Object.values(labwareEntities).map(({ labwareDefURI }) => labwareDefURI)
+  )
+  const firstDefaultTiprackURIOnDeck = pipetteTipracks.find(uri =>
+    labwareURIsOnDeck.has(uri)
+  )
   const hasPartialTipSupportedChannel =
     pipetteEntities[defaultPipetteId]?.spec.channels !== 1
   // If there is a `pipette` field in the form,
@@ -88,6 +95,7 @@ const _patchDefaultPipette = (args: {
       {
         pipette: defaultPipetteId,
         nozzles: hasPartialTipSupportedChannel ? ALL : null,
+        tipRack: firstDefaultTiprackURIOnDeck ?? null,
       },
       formData,
       pipetteEntities,

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMix.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMix.ts
@@ -124,7 +124,7 @@ const updatePatchOnPipetteChange = (
 
     return {
       ...patch,
-      ...getDefaultFields('aspirate_flowRate', 'dispense_flowRate', 'tipRack'),
+      ...getDefaultFields('aspirate_flowRate', 'dispense_flowRate'),
       nozzles,
     }
   }

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.ts
@@ -216,8 +216,7 @@ const updatePatchOnPipetteChange = (
         'dispense_mix_volume',
         'disposalVolume_volume',
         'aspirate_mmFromBottom',
-        'dispense_mmFromBottom',
-        'tipRack'
+        'dispense_mmFromBottom'
       ),
       nozzles,
       aspirate_airGap_volume: airGapVolume,
@@ -705,6 +704,7 @@ export function dependentFieldsUpdateMoveLiquid(
   pipetteEntities: PipetteEntities,
   labwareEntities: LabwareEntities
 ): FormPatch {
+  console.log('calling in here', originalPatch, rawForm)
   // sequentially modify parts of the patch until it's fully updated
   return chainPatchUpdaters(originalPatch, [
     chainPatch =>

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.ts
@@ -704,7 +704,6 @@ export function dependentFieldsUpdateMoveLiquid(
   pipetteEntities: PipetteEntities,
   labwareEntities: LabwareEntities
 ): FormPatch {
-  console.log('calling in here', originalPatch, rawForm)
   // sequentially modify parts of the patch until it's fully updated
   return chainPatchUpdaters(originalPatch, [
     chainPatch =>

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/test/mix.test.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/test/mix.test.ts
@@ -99,7 +99,6 @@ describe('well selection should update', () => {
       aspirate_flowRate: null,
       dispense_flowRate: null,
       nozzles: null,
-      tipRack: null,
     })
   })
   it('pipette single -> multi', () => {
@@ -112,7 +111,6 @@ describe('well selection should update', () => {
       aspirate_flowRate: null,
       dispense_flowRate: null,
       nozzles: ALL,
-      tipRack: null,
     })
   })
   it('pipette multi -> single', () => {
@@ -126,7 +124,6 @@ describe('well selection should update', () => {
       aspirate_flowRate: null,
       dispense_flowRate: null,
       nozzles: null,
-      tipRack: null,
     })
   })
   it('select single-well labware', () => {


### PR DESCRIPTION
closes AUTH-2263

# Overview

NOTE: i can change the targeted branch to 8.5.4, lmk @ddcc4 

So there is some craziness going on lol. 

Basically, the root of the bug is that when you delete you pipette then add a new one, the `tipRack` field for every mix/transfer form using that pipette would be set to `null`. Then since liquid classes/liquid specs need the `tipRack` info, it would white screen.

First, what I did is I removed setting the tipRack field to the default in the `updatePatchOnPipetteChange()` fn which is called whenever you have a form change. (If you look at the `savedStepForms` reducer and redux when getting the bug, you see that `SUBSTITUTE_STEP_FORM_PIPETTES` is being called and it calls `handleFormChange()` - which calls all the patches to update the fields according to what is being updated. So i removed `tipRack` being set to default for both trnasfer and mix steps.

This actually fixes the bug. BUT I realized we had a `useEffect()` in `TiprackField` directly that was setting the tiprack field to the 1st available option by default. Which is kinda sketchy... so i removed it and instead, i passed the tiprack uri down from when `SUBSTITUTE_STEP_FORM_PIPETTES` is being called. this means, that `handleFormChange()` is also passing in the tiprack and updating it. Additionally, i added `tipRack` being defaulted in the `createPresavedStepForm()` fn so a new form will have tip rack populated correctly. Basically, the overall refactor makes it so there are fewer sources of truth on how the tiprack is being populated by default and follows similar patterns of other fields.

LMK if you have questions or concerns with this approach.

## Test Plan and Hands on Testing

Follow the steps in the ticket and see that you don't get a whitescreen

Also, create a new transfer or mix step with 1 tiprack assigned to the pipette and see that you can make it without whitescreening.

## Changelog

pass `tiprackURI` down to the update path when the pipette is updated after being used in the form
remove setting the tiprack to null/the default in the `updatePatchOnPipetteChange()` fn

## Risk assessment

low
