### PR TITLE
feat(protocol-designer): Add subtext to pause steps

### DIFF
--- a/protocol-designer/src/assets/localization/en/protocol_steps.json
+++ b/protocol-designer/src/assets/localization/en/protocol_steps.json
@@ -112,9 +112,9 @@
   "of": "of",
   "off_deck": "Off-Deck",
   "pause": {
-    "untilResume": "Pausing until manually told to resume",
-    "untilTemperature": "<text>Pausing until</text><semiBoldText>{{module}}</semiBoldText><text>reaches</text><tag/>",
-    "untilTime": "<text>Pausing for</text><tag/>"
+    "pausingUntilResume": "Pausing until manually told to resume",
+    "pausingUntilTemperature": "<text>Pausing until</text><semiBoldText>{{module}}</semiBoldText><text>reaches</text><tag/>",
+    "pausingForDuration": "<text>Pausing for</text><tag/>"
   },
   "pipette": "Pipette",
   "pipette_path": "Pipette path",

--- a/protocol-designer/src/assets/localization/en/protocol_steps.json
+++ b/protocol-designer/src/assets/localization/en/protocol_steps.json
@@ -114,7 +114,10 @@
   "pause": {
     "pausingUntilResume": "Pausing until manually told to resume",
     "pausingUntilTemperature": "<text>Pausing until</text><semiBoldText>{{module}}</semiBoldText><text>reaches</text><tag/>",
-    "pausingForDuration": "<text>Pausing for</text><tag/>"
+    "pausingForDuration": "<text>Pausing for</text><tag/>",
+    "untilResume": "Until told to resume",
+    "untilTemperature": "Until {{temperature}} °C reached",
+    "forDuration": "For {{duration}}"
   },
   "pipette": "Pipette",
   "pipette_path": "Pipette path",

--- a/protocol-designer/src/components/organisms/StepSummary/index.tsx
+++ b/protocol-designer/src/components/organisms/StepSummary/index.tsx
@@ -177,7 +177,7 @@ export function StepSummary(props: StepSummaryProps): JSX.Element | null {
         case 'untilResume':
           stepSummaryContent = (
             <StyledText desktopStyle="bodyDefaultRegular">
-              {t('protocol_steps:pause.untilResume')}
+              {t('protocol_steps:pause.pausingUntilResume')}
             </StyledText>
           )
           break
@@ -189,7 +189,7 @@ export function StepSummary(props: StepSummaryProps): JSX.Element | null {
               : unknownModule
           stepSummaryContent = (
             <StyledTrans
-              i18nKey="protocol_steps:pause.untilTemperature"
+              i18nKey="protocol_steps:pause.pausingUntilTemperature"
               values={{ module: pauseModuleDisplayName }}
               tagText={`${pauseTemperature}${t('application:units.degrees')}`}
             />
@@ -198,7 +198,7 @@ export function StepSummary(props: StepSummaryProps): JSX.Element | null {
         case 'untilTime':
           stepSummaryContent = (
             <StyledTrans
-              i18nKey={t('protocol_steps:pause.untilTime')}
+              i18nKey={t('protocol_steps:pause.pausingForDuration')}
               tagText={formatTime(pauseTime as string)}
             />
           )

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/ConnectedStepInfo.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/ConnectedStepInfo.tsx
@@ -277,7 +277,7 @@ function useStepText(step: FormData): { text: string; subtext: string | null } {
 
   let subtext = null
   if (enableConcurrentModuleActions && step.stepType === 'pause') {
-    // todo(mm, 2025-09-10): Improve FormData typing to make this type-safe.`
+    // todo(mm, 2025-09-10): Improve FormData typing to make this type-safe.
     if (step.pauseAction === PAUSE_UNTIL_RESUME) {
       subtext = t('protocol_steps:pause.untilResume')
     } else if (step.pauseAction === PAUSE_UNTIL_TEMP) {

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/ConnectedStepInfo.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/ConnectedStepInfo.tsx
@@ -10,7 +10,13 @@ import {
   CLOSE_UNSAVED_STEP_FORM,
   ConfirmDeleteModal,
 } from '/protocol-designer/components/organisms'
+import {
+  PAUSE_UNTIL_RESUME,
+  PAUSE_UNTIL_TEMP,
+  PAUSE_UNTIL_TIME,
+} from '/protocol-designer/constants'
 import { selectors as dismissSelectors } from '/protocol-designer/dismiss'
+import { getEnableConcurrentModuleActions } from '/protocol-designer/feature-flags/selectors'
 import { selectors as fileDataSelectors } from '/protocol-designer/file-data'
 import { stepIconsByType } from '/protocol-designer/form-types'
 import { selectors as stepFormSelectors } from '/protocol-designer/step-forms'
@@ -30,6 +36,7 @@ import {
   toggleViewSubstep,
 } from '/protocol-designer/ui/steps/actions/actions'
 
+import { formatTime } from '../../utils'
 import { ConnectedStepContainer } from './ConnectedStepContainer'
 import {
   getMetaSelectedSteps,
@@ -41,7 +48,7 @@ import {
 import type { ThunkDispatch } from 'redux-thunk'
 import type { Dispatch, MouseEvent, SetStateAction } from 'react'
 import type { DeleteModalType } from '/protocol-designer/components/organisms'
-import type { StepIdType } from '/protocol-designer/form-types'
+import type { FormData, StepIdType } from '/protocol-designer/form-types'
 import type { BaseState, ThunkAction } from '/protocol-designer/types'
 import type { SelectMultipleStepsAction } from '/protocol-designer/ui/steps'
 
@@ -65,7 +72,6 @@ export function ConnectedStepInfo(props: ConnectedStepInfoProps): JSX.Element {
     setOpenedOverflowMenuId,
     sidebarWidth,
   } = props
-  const { i18n, t } = useTranslation('application')
   const dispatch = useDispatch<ThunkDispatch<BaseState, any, any>>()
   const stepIds = useSelector(getOrderedStepIds)
   const step = useSelector(stepFormSelectors.getSavedStepForms)[stepId]
@@ -85,6 +91,7 @@ export function ConnectedStepInfo(props: ConnectedStepInfoProps): JSX.Element {
     errorStepId != null ? stepIds.slice(stepIds.indexOf(errorStepId) + 1) : []
   const stepAfterError =
     stepId != null ? stepListAfterErrors.includes(stepId) : false
+  const { text, subtext } = useStepText(step)
 
   const hasWarnings =
     hasTimelineWarningsPerStep[stepId] || hasFormLevelWarningsPerStep[stepId]
@@ -247,15 +254,42 @@ export function ConnectedStepInfo(props: ConnectedStepInfoProps): JSX.Element {
         onMouseEnter={handleMouseEnter}
         iconName={hasError || hasWarnings ? 'alert-circle' : iconName}
         stepNumber={stepNumber}
-        // add empty check to avoid causing undefined issue when calling titleCase
-        text={
-          step.stepName !== undefined && step.stepName !== ''
-            ? i18n.format(step.stepName, 'titleCase')
-            : t(`stepType.${step.stepType}`)
-        }
+        text={text}
+        subtext={subtext}
         dragHovered={dragHovered}
         sidebarWidth={sidebarWidth}
       />
     </>
   )
+}
+
+function useStepText(step: FormData): { text: string; subtext: string | null } {
+  const { i18n, t } = useTranslation(['application', 'protocol_steps'])
+  const enableConcurrentModuleActions = useSelector(
+    getEnableConcurrentModuleActions
+  )
+
+  // add empty check to avoid causing undefined issue when calling titleCase
+  const text =
+    step.stepName !== undefined && step.stepName !== ''
+      ? i18n.format(step.stepName, 'titleCase')
+      : t(`stepType.${step.stepType}`)
+
+  let subtext = null
+  if (enableConcurrentModuleActions && step.stepType === 'pause') {
+    // todo(mm, 2025-09-10): Improve FormData typing to make this type-safe.`
+    if (step.pauseAction === PAUSE_UNTIL_RESUME) {
+      subtext = t('protocol_steps:pause.untilResume')
+    } else if (step.pauseAction === PAUSE_UNTIL_TEMP) {
+      subtext = t('protocol_steps:pause.untilTemperature', {
+        temperature: step.pauseTemperature,
+      })
+    } else if (step.pauseAction === PAUSE_UNTIL_TIME) {
+      subtext = t('protocol_steps:pause.forDuration', {
+        duration: formatTime(step.pauseTime as string),
+      })
+    }
+  }
+
+  return { text, subtext }
 }

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/ConnectedStepInfo.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/ConnectedStepInfo.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useMemo } from 'react'
-import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 import debounce from 'lodash/debounce'
 
@@ -10,13 +9,7 @@ import {
   CLOSE_UNSAVED_STEP_FORM,
   ConfirmDeleteModal,
 } from '/protocol-designer/components/organisms'
-import {
-  PAUSE_UNTIL_RESUME,
-  PAUSE_UNTIL_TEMP,
-  PAUSE_UNTIL_TIME,
-} from '/protocol-designer/constants'
 import { selectors as dismissSelectors } from '/protocol-designer/dismiss'
-import { getEnableConcurrentModuleActions } from '/protocol-designer/feature-flags/selectors'
 import { selectors as fileDataSelectors } from '/protocol-designer/file-data'
 import { stepIconsByType } from '/protocol-designer/form-types'
 import { selectors as stepFormSelectors } from '/protocol-designer/step-forms'
@@ -36,8 +29,8 @@ import {
   toggleViewSubstep,
 } from '/protocol-designer/ui/steps/actions/actions'
 
-import { formatTime } from '../../utils'
 import { ConnectedStepContainer } from './ConnectedStepContainer'
+import { useStepText } from './useStepText'
 import {
   getMetaSelectedSteps,
   getMouseClickKeyInfo,
@@ -48,7 +41,7 @@ import {
 import type { ThunkDispatch } from 'redux-thunk'
 import type { Dispatch, MouseEvent, SetStateAction } from 'react'
 import type { DeleteModalType } from '/protocol-designer/components/organisms'
-import type { FormData, StepIdType } from '/protocol-designer/form-types'
+import type { StepIdType } from '/protocol-designer/form-types'
 import type { BaseState, ThunkAction } from '/protocol-designer/types'
 import type { SelectMultipleStepsAction } from '/protocol-designer/ui/steps'
 
@@ -261,35 +254,4 @@ export function ConnectedStepInfo(props: ConnectedStepInfoProps): JSX.Element {
       />
     </>
   )
-}
-
-function useStepText(step: FormData): { text: string; subtext: string | null } {
-  const { i18n, t } = useTranslation(['application', 'protocol_steps'])
-  const enableConcurrentModuleActions = useSelector(
-    getEnableConcurrentModuleActions
-  )
-
-  // add empty check to avoid causing undefined issue when calling titleCase
-  const text =
-    step.stepName !== undefined && step.stepName !== ''
-      ? i18n.format(step.stepName, 'titleCase')
-      : t(`stepType.${step.stepType}`)
-
-  let subtext = null
-  if (enableConcurrentModuleActions && step.stepType === 'pause') {
-    // todo(mm, 2025-09-10): Improve FormData typing to make this type-safe.
-    if (step.pauseAction === PAUSE_UNTIL_RESUME) {
-      subtext = t('protocol_steps:pause.untilResume')
-    } else if (step.pauseAction === PAUSE_UNTIL_TEMP) {
-      subtext = t('protocol_steps:pause.untilTemperature', {
-        temperature: step.pauseTemperature,
-      })
-    } else if (step.pauseAction === PAUSE_UNTIL_TIME) {
-      subtext = t('protocol_steps:pause.forDuration', {
-        duration: formatTime(step.pauseTime as string),
-      })
-    }
-  }
-
-  return { text, subtext }
 }

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/PresavedStep.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/PresavedStep.tsx
@@ -48,6 +48,7 @@ export function PresavedStep({
       stepNumber={stepNumber}
       iconName={stepIconsByType[stepType]}
       text={t(`stepType.${stepType}`)}
+      subtext={null}
       sidebarWidth={sidebarWidth}
     />
   )

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/TerminalItemStep.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/TerminalItemStep.tsx
@@ -104,6 +104,7 @@ export function TerminalItemStep(props: TerminalItemStepProps): JSX.Element {
             id === START_TERMINAL_ITEM_ID
               ? t('starting_deck')
               : t('ending_deck'),
+          subtext: null,
           onClick,
           onMouseEnter,
           onMouseLeave,

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/__tests__/useStepText.test.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/__tests__/useStepText.test.tsx
@@ -26,252 +26,122 @@ const render = (step: FormData) => {
 }
 
 describe('useStepText', () => {
-  let mockStep: FormData
-  let mockEnableConcurrentModuleActions: boolean
-
-  beforeEach(() => {
-    vi.clearAllMocks()
-    mockEnableConcurrentModuleActions = false
-    vi.mocked(getEnableConcurrentModuleActions).mockReturnValue(
-      mockEnableConcurrentModuleActions
-    )
-
-    mockStep = {
+  it('should return custom step name when stepName is provided', () => {
+    const mockStep: FormData = {
       stepType: 'pause',
       id: 'test-step-id',
       stepName: 'Custom Step Name',
     }
-  })
-
-  describe('text generation', () => {
-    it('should return custom step name when stepName is provided', () => {
-      const { result } = render(mockStep)
-      expect(result.current.text).toBe('Custom Step Name')
-    })
-
-    it('should return step type translation when stepName is undefined', () => {
-      mockStep = { ...mockStep, stepName: undefined }
-      const { result } = render(mockStep)
-      expect(result.current.text).toBe('pause')
-    })
-
-    it('should return step type translation when stepName is empty string', () => {
-      mockStep = { ...mockStep, stepName: '' }
-      const { result } = render(mockStep)
-      expect(result.current.text).toBe('pause')
-    })
-
-    it('should handle different step types', () => {
-      mockStep = { ...mockStep, stepType: 'moveLiquid', stepName: undefined }
-      const { result } = render(mockStep)
-      expect(result.current.text).toBe('transfer')
-    })
-
-    it('should format step name with titleCase', () => {
-      mockStep = { ...mockStep, stepName: 'custom step name' }
-      const { result } = render(mockStep)
-      expect(result.current.text).toBe('Custom Step Name')
+    vi.mocked(getEnableConcurrentModuleActions).mockReturnValue(false)
+    const { result } = render(mockStep)
+    expect(result.current).toStrictEqual({
+      text: 'Custom Step Name',
+      subtext: null,
     })
   })
 
-  describe('subtext generation', () => {
-    beforeEach(() => {
-      mockEnableConcurrentModuleActions = true
-      vi.mocked(getEnableConcurrentModuleActions).mockReturnValue(
-        mockEnableConcurrentModuleActions
-      )
-    })
-
-    it('should return null subtext when feature flag is disabled', () => {
-      vi.mocked(getEnableConcurrentModuleActions).mockReturnValue(false)
-      mockStep = {
-        ...mockStep,
-        stepType: 'pause',
-        pauseAction: PAUSE_UNTIL_RESUME,
-      }
-      const { result } = render(mockStep)
-      expect(result.current.subtext).toBeNull()
-    })
-
-    it('should return null subtext when step type is not pause', () => {
-      mockStep = {
-        ...mockStep,
-        stepType: 'moveLiquid',
-        pauseAction: PAUSE_UNTIL_RESUME,
-      }
-      const { result } = render(mockStep)
-      expect(result.current.subtext).toBeNull()
-    })
-
-    it('should return untilResume subtext for PAUSE_UNTIL_RESUME action', () => {
-      mockStep = {
-        ...mockStep,
-        stepType: 'pause',
-        pauseAction: PAUSE_UNTIL_RESUME,
-      }
-      const { result } = render(mockStep)
-      expect(result.current.subtext).toBe('Until told to resume')
-    })
-
-    it('should return untilTemperature subtext for PAUSE_UNTIL_TEMP action', () => {
-      mockStep = {
-        ...mockStep,
-        stepType: 'pause',
-        pauseAction: PAUSE_UNTIL_TEMP,
-        pauseTemperature: '25',
-      }
-      const { result } = render(mockStep)
-      expect(result.current.subtext).toBe('Until 25 °C reached')
-    })
-
-    it('should return forDuration subtext for PAUSE_UNTIL_TIME action', () => {
-      mockStep = {
-        ...mockStep,
-        stepType: 'pause',
-        pauseAction: PAUSE_UNTIL_TIME,
-        pauseTime: '01:30:45',
-      }
-      const { result } = render(mockStep)
-      expect(result.current.subtext).toBe('For 01:30:45')
-    })
-
-    it('should handle different time formats in PAUSE_UNTIL_TIME', () => {
-      mockStep = {
-        ...mockStep,
-        stepType: 'pause',
-        pauseAction: PAUSE_UNTIL_TIME,
-        pauseTime: '2:15',
-      }
-      const { result } = render(mockStep)
-      expect(result.current.subtext).toBe('For 02:15')
-    })
-
-    it('should return null subtext when pauseAction is undefined', () => {
-      mockStep = {
-        ...mockStep,
-        stepType: 'pause',
-        pauseAction: undefined,
-      }
-      const { result } = render(mockStep)
-      expect(result.current.subtext).toBeNull()
-    })
-
-    it('should return null subtext when pauseAction is not one of the expected values', () => {
-      mockStep = {
-        ...mockStep,
-        stepType: 'pause',
-        pauseAction: 'unknownAction' as any,
-      }
-      const { result } = render(mockStep)
-      expect(result.current.subtext).toBeNull()
+  it('should return a default step name when stepName is undefined', () => {
+    const mockStep: FormData = {
+      stepType: 'absorbanceReader',
+      id: 'test-step-id',
+      stepName: undefined,
+    }
+    vi.mocked(getEnableConcurrentModuleActions).mockReturnValue(false)
+    const { result } = render(mockStep)
+    expect(result.current).toStrictEqual({
+      text: 'absorbance plate reader',
+      subtext: null,
     })
   })
 
-  describe('integration tests', () => {
-    it('should return both text and subtext for pause step with untilResume action', () => {
-      mockEnableConcurrentModuleActions = true
-      vi.mocked(getEnableConcurrentModuleActions).mockReturnValue(
-        mockEnableConcurrentModuleActions
-      )
-      mockStep = {
-        ...mockStep,
-        stepType: 'pause',
-        stepName: 'Custom Pause Step',
-        pauseAction: PAUSE_UNTIL_RESUME,
-      }
-      const { result } = render(mockStep)
-      expect(result.current.text).toBe('Custom Pause Step')
-      expect(result.current.subtext).toBe('Until told to resume')
-    })
-
-    it('should return both text and subtext for pause step with untilTemperature action', () => {
-      mockEnableConcurrentModuleActions = true
-      vi.mocked(getEnableConcurrentModuleActions).mockReturnValue(
-        mockEnableConcurrentModuleActions
-      )
-      mockStep = {
-        ...mockStep,
-        stepType: 'pause',
-        stepName: 'Temperature Pause',
-        pauseAction: PAUSE_UNTIL_TEMP,
-        pauseTemperature: '37',
-      }
-      const { result } = render(mockStep)
-      expect(result.current.text).toBe('Temperature Pause')
-      expect(result.current.subtext).toBe('Until 37 °C reached')
-    })
-
-    it('should return both text and subtext for pause step with untilTime action', () => {
-      mockEnableConcurrentModuleActions = true
-      vi.mocked(getEnableConcurrentModuleActions).mockReturnValue(
-        mockEnableConcurrentModuleActions
-      )
-      mockStep = {
-        ...mockStep,
-        stepType: 'pause',
-        stepName: 'Timed Pause',
-        pauseAction: PAUSE_UNTIL_TIME,
-        pauseTime: '00:05:30',
-      }
-      const { result } = render(mockStep)
-      expect(result.current.text).toBe('Timed Pause')
-      expect(result.current.subtext).toBe('For 00:05:30')
-    })
-
-    it('should return only text for non-pause step types', () => {
-      mockStep = {
-        ...mockStep,
-        stepType: 'moveLiquid',
-        stepName: 'Move Liquid Step',
-      }
-      const { result } = render(mockStep)
-      expect(result.current.text).toBe('Move Liquid Step')
-      expect(result.current.subtext).toBeNull()
+  it('should return a default step name when stepName is the empty string', () => {
+    const mockStep: FormData = {
+      stepType: 'absorbanceReader',
+      id: 'test-step-id',
+      stepName: '',
+    }
+    vi.mocked(getEnableConcurrentModuleActions).mockReturnValue(false)
+    const { result } = render(mockStep)
+    expect(result.current).toStrictEqual({
+      text: 'absorbance plate reader',
+      subtext: null,
     })
   })
 
-  describe('edge cases', () => {
-    it('should handle step with minimal required properties', () => {
-      mockStep = {
-        stepType: 'comment',
-        id: 'minimal-step',
-      }
-      const { result } = render(mockStep)
-      expect(result.current.text).toBe('comment')
-      expect(result.current.subtext).toBeNull()
+  it('should return null subtext when feature flag is disabled', () => {
+    const mockStep: FormData = {
+      stepType: 'pause',
+      id: 'test-step-id',
+      stepName: 'Custom Step Name',
+      pauseAction: PAUSE_UNTIL_RESUME,
+    }
+    vi.mocked(getEnableConcurrentModuleActions).mockReturnValue(false)
+    const { result } = render(mockStep)
+    expect(result.current).toStrictEqual({
+      text: 'Custom Step Name',
+      subtext: null,
     })
+  })
 
-    it('should handle step with empty stepName and pause action', () => {
-      mockEnableConcurrentModuleActions = true
-      vi.mocked(getEnableConcurrentModuleActions).mockReturnValue(
-        mockEnableConcurrentModuleActions
-      )
-      mockStep = {
-        ...mockStep,
-        stepName: '',
-        stepType: 'pause',
-        pauseAction: PAUSE_UNTIL_RESUME,
-      }
-      const { result } = render(mockStep)
-      expect(result.current.text).toBe('pause')
-      expect(result.current.subtext).toBe('Until told to resume')
+  it('should return null subtext when step type is not pause', () => {
+    const mockStep: FormData = {
+      stepType: 'moveLiquid',
+      id: 'test-step-id',
+      stepName: 'Custom Step Name',
+      pauseAction: PAUSE_UNTIL_RESUME,
+    }
+    vi.mocked(getEnableConcurrentModuleActions).mockReturnValue(true)
+    const { result } = render(mockStep)
+    expect(result.current).toStrictEqual({
+      text: 'Custom Step Name',
+      subtext: null,
     })
+  })
 
-    it('should handle step with null pauseTemperature', () => {
-      mockEnableConcurrentModuleActions = true
-      vi.mocked(getEnableConcurrentModuleActions).mockReturnValue(
-        mockEnableConcurrentModuleActions
-      )
-      mockStep = {
-        ...mockStep,
-        stepType: 'pause',
-        pauseAction: PAUSE_UNTIL_TEMP,
-        pauseTemperature: null,
-      }
-      const { result } = render(mockStep)
-      expect(result.current.text).toBe('Custom Step Name')
-      expect(result.current.subtext).toBe('Until  °C reached')
+  it('should return untilResume subtext for PAUSE_UNTIL_RESUME action', () => {
+    const mockStep: FormData = {
+      stepType: 'pause',
+      id: 'test-step-id',
+      stepName: 'Custom Step Name',
+      pauseAction: PAUSE_UNTIL_RESUME,
+    }
+    vi.mocked(getEnableConcurrentModuleActions).mockReturnValue(true)
+    const { result } = render(mockStep)
+    expect(result.current).toStrictEqual({
+      text: 'Custom Step Name',
+      subtext: 'Until told to resume',
     })
+  })
 
+  it('should return untilTemperature subtext for PAUSE_UNTIL_TEMP action', () => {
+    const mockStep: FormData = {
+      stepType: 'pause',
+      id: 'test-step-id',
+      stepName: 'Custom Step Name',
+      pauseAction: PAUSE_UNTIL_TEMP,
+      pauseTemperature: '25',
+    }
+    vi.mocked(getEnableConcurrentModuleActions).mockReturnValue(true)
+    const { result } = render(mockStep)
+    expect(result.current).toStrictEqual({
+      text: 'Custom Step Name',
+      subtext: 'Until 25 °C reached',
+    })
+  })
+
+  it('should return forDuration subtext for PAUSE_UNTIL_TIME action', () => {
+    const mockStep: FormData = {
+      stepType: 'pause',
+      id: 'test-step-id',
+      stepName: 'Custom Step Name',
+      pauseAction: PAUSE_UNTIL_TIME,
+      pauseTime: '1:2:34',
+    }
+    vi.mocked(getEnableConcurrentModuleActions).mockReturnValue(true)
+    const { result } = render(mockStep)
+    expect(result.current).toStrictEqual({
+      text: 'Custom Step Name',
+      subtext: 'For 01:02:34',
+    })
   })
 })

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/__tests__/useStepText.test.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/__tests__/useStepText.test.tsx
@@ -1,0 +1,277 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import '@testing-library/jest-dom/vitest'
+
+import { renderHook } from '@testing-library/react'
+
+import { getProviderWrapperForHooks } from '/protocol-designer/__testing-utils__'
+import { i18n } from '/protocol-designer/assets/localization'
+import {
+  PAUSE_UNTIL_RESUME,
+  PAUSE_UNTIL_TEMP,
+  PAUSE_UNTIL_TIME,
+} from '/protocol-designer/constants'
+import { getEnableConcurrentModuleActions } from '/protocol-designer/feature-flags/selectors'
+
+import { useStepText } from '../useStepText'
+
+import type { FormData } from '/protocol-designer/form-types'
+
+vi.mock('/protocol-designer/feature-flags/selectors')
+
+const wrapper = getProviderWrapperForHooks({}, i18n)
+
+const render = (step: FormData) => {
+  return renderHook(() => useStepText(step), { wrapper })
+}
+
+describe('useStepText', () => {
+  let mockStep: FormData
+  let mockEnableConcurrentModuleActions: boolean
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockEnableConcurrentModuleActions = false
+    vi.mocked(getEnableConcurrentModuleActions).mockReturnValue(
+      mockEnableConcurrentModuleActions
+    )
+
+    mockStep = {
+      stepType: 'pause',
+      id: 'test-step-id',
+      stepName: 'Custom Step Name',
+    }
+  })
+
+  describe('text generation', () => {
+    it('should return custom step name when stepName is provided', () => {
+      const { result } = render(mockStep)
+      expect(result.current.text).toBe('Custom Step Name')
+    })
+
+    it('should return step type translation when stepName is undefined', () => {
+      mockStep = { ...mockStep, stepName: undefined }
+      const { result } = render(mockStep)
+      expect(result.current.text).toBe('pause')
+    })
+
+    it('should return step type translation when stepName is empty string', () => {
+      mockStep = { ...mockStep, stepName: '' }
+      const { result } = render(mockStep)
+      expect(result.current.text).toBe('pause')
+    })
+
+    it('should handle different step types', () => {
+      mockStep = { ...mockStep, stepType: 'moveLiquid', stepName: undefined }
+      const { result } = render(mockStep)
+      expect(result.current.text).toBe('transfer')
+    })
+
+    it('should format step name with titleCase', () => {
+      mockStep = { ...mockStep, stepName: 'custom step name' }
+      const { result } = render(mockStep)
+      expect(result.current.text).toBe('Custom Step Name')
+    })
+  })
+
+  describe('subtext generation', () => {
+    beforeEach(() => {
+      mockEnableConcurrentModuleActions = true
+      vi.mocked(getEnableConcurrentModuleActions).mockReturnValue(
+        mockEnableConcurrentModuleActions
+      )
+    })
+
+    it('should return null subtext when feature flag is disabled', () => {
+      vi.mocked(getEnableConcurrentModuleActions).mockReturnValue(false)
+      mockStep = {
+        ...mockStep,
+        stepType: 'pause',
+        pauseAction: PAUSE_UNTIL_RESUME,
+      }
+      const { result } = render(mockStep)
+      expect(result.current.subtext).toBeNull()
+    })
+
+    it('should return null subtext when step type is not pause', () => {
+      mockStep = {
+        ...mockStep,
+        stepType: 'moveLiquid',
+        pauseAction: PAUSE_UNTIL_RESUME,
+      }
+      const { result } = render(mockStep)
+      expect(result.current.subtext).toBeNull()
+    })
+
+    it('should return untilResume subtext for PAUSE_UNTIL_RESUME action', () => {
+      mockStep = {
+        ...mockStep,
+        stepType: 'pause',
+        pauseAction: PAUSE_UNTIL_RESUME,
+      }
+      const { result } = render(mockStep)
+      expect(result.current.subtext).toBe('Until told to resume')
+    })
+
+    it('should return untilTemperature subtext for PAUSE_UNTIL_TEMP action', () => {
+      mockStep = {
+        ...mockStep,
+        stepType: 'pause',
+        pauseAction: PAUSE_UNTIL_TEMP,
+        pauseTemperature: '25',
+      }
+      const { result } = render(mockStep)
+      expect(result.current.subtext).toBe('Until 25 °C reached')
+    })
+
+    it('should return forDuration subtext for PAUSE_UNTIL_TIME action', () => {
+      mockStep = {
+        ...mockStep,
+        stepType: 'pause',
+        pauseAction: PAUSE_UNTIL_TIME,
+        pauseTime: '01:30:45',
+      }
+      const { result } = render(mockStep)
+      expect(result.current.subtext).toBe('For 01:30:45')
+    })
+
+    it('should handle different time formats in PAUSE_UNTIL_TIME', () => {
+      mockStep = {
+        ...mockStep,
+        stepType: 'pause',
+        pauseAction: PAUSE_UNTIL_TIME,
+        pauseTime: '2:15',
+      }
+      const { result } = render(mockStep)
+      expect(result.current.subtext).toBe('For 02:15')
+    })
+
+    it('should return null subtext when pauseAction is undefined', () => {
+      mockStep = {
+        ...mockStep,
+        stepType: 'pause',
+        pauseAction: undefined,
+      }
+      const { result } = render(mockStep)
+      expect(result.current.subtext).toBeNull()
+    })
+
+    it('should return null subtext when pauseAction is not one of the expected values', () => {
+      mockStep = {
+        ...mockStep,
+        stepType: 'pause',
+        pauseAction: 'unknownAction' as any,
+      }
+      const { result } = render(mockStep)
+      expect(result.current.subtext).toBeNull()
+    })
+  })
+
+  describe('integration tests', () => {
+    it('should return both text and subtext for pause step with untilResume action', () => {
+      mockEnableConcurrentModuleActions = true
+      vi.mocked(getEnableConcurrentModuleActions).mockReturnValue(
+        mockEnableConcurrentModuleActions
+      )
+      mockStep = {
+        ...mockStep,
+        stepType: 'pause',
+        stepName: 'Custom Pause Step',
+        pauseAction: PAUSE_UNTIL_RESUME,
+      }
+      const { result } = render(mockStep)
+      expect(result.current.text).toBe('Custom Pause Step')
+      expect(result.current.subtext).toBe('Until told to resume')
+    })
+
+    it('should return both text and subtext for pause step with untilTemperature action', () => {
+      mockEnableConcurrentModuleActions = true
+      vi.mocked(getEnableConcurrentModuleActions).mockReturnValue(
+        mockEnableConcurrentModuleActions
+      )
+      mockStep = {
+        ...mockStep,
+        stepType: 'pause',
+        stepName: 'Temperature Pause',
+        pauseAction: PAUSE_UNTIL_TEMP,
+        pauseTemperature: '37',
+      }
+      const { result } = render(mockStep)
+      expect(result.current.text).toBe('Temperature Pause')
+      expect(result.current.subtext).toBe('Until 37 °C reached')
+    })
+
+    it('should return both text and subtext for pause step with untilTime action', () => {
+      mockEnableConcurrentModuleActions = true
+      vi.mocked(getEnableConcurrentModuleActions).mockReturnValue(
+        mockEnableConcurrentModuleActions
+      )
+      mockStep = {
+        ...mockStep,
+        stepType: 'pause',
+        stepName: 'Timed Pause',
+        pauseAction: PAUSE_UNTIL_TIME,
+        pauseTime: '00:05:30',
+      }
+      const { result } = render(mockStep)
+      expect(result.current.text).toBe('Timed Pause')
+      expect(result.current.subtext).toBe('For 00:05:30')
+    })
+
+    it('should return only text for non-pause step types', () => {
+      mockStep = {
+        ...mockStep,
+        stepType: 'moveLiquid',
+        stepName: 'Move Liquid Step',
+      }
+      const { result } = render(mockStep)
+      expect(result.current.text).toBe('Move Liquid Step')
+      expect(result.current.subtext).toBeNull()
+    })
+  })
+
+  describe('edge cases', () => {
+    it('should handle step with minimal required properties', () => {
+      mockStep = {
+        stepType: 'comment',
+        id: 'minimal-step',
+      }
+      const { result } = render(mockStep)
+      expect(result.current.text).toBe('comment')
+      expect(result.current.subtext).toBeNull()
+    })
+
+    it('should handle step with empty stepName and pause action', () => {
+      mockEnableConcurrentModuleActions = true
+      vi.mocked(getEnableConcurrentModuleActions).mockReturnValue(
+        mockEnableConcurrentModuleActions
+      )
+      mockStep = {
+        ...mockStep,
+        stepName: '',
+        stepType: 'pause',
+        pauseAction: PAUSE_UNTIL_RESUME,
+      }
+      const { result } = render(mockStep)
+      expect(result.current.text).toBe('pause')
+      expect(result.current.subtext).toBe('Until told to resume')
+    })
+
+    it('should handle step with null pauseTemperature', () => {
+      mockEnableConcurrentModuleActions = true
+      vi.mocked(getEnableConcurrentModuleActions).mockReturnValue(
+        mockEnableConcurrentModuleActions
+      )
+      mockStep = {
+        ...mockStep,
+        stepType: 'pause',
+        pauseAction: PAUSE_UNTIL_TEMP,
+        pauseTemperature: null,
+      }
+      const { result } = render(mockStep)
+      expect(result.current.text).toBe('Custom Step Name')
+      expect(result.current.subtext).toBe('Until  °C reached')
+    })
+
+  })
+})

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/__tests__/useStepText.test.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/__tests__/useStepText.test.tsx
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import '@testing-library/jest-dom/vitest'
 

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/useStepText.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/useStepText.tsx
@@ -1,0 +1,46 @@
+import { useTranslation } from 'react-i18next'
+import { useSelector } from 'react-redux'
+
+import {
+  PAUSE_UNTIL_RESUME,
+  PAUSE_UNTIL_TEMP,
+  PAUSE_UNTIL_TIME,
+} from '/protocol-designer/constants'
+import { getEnableConcurrentModuleActions } from '/protocol-designer/feature-flags/selectors'
+
+import { formatTime } from '../../utils'
+
+import type { FormData } from '/protocol-designer/form-types'
+
+export function useStepText(
+  step: FormData
+): { text: string; subtext: string | null } {
+  const { i18n, t } = useTranslation(['application', 'protocol_steps'])
+  const enableConcurrentModuleActions = useSelector(
+    getEnableConcurrentModuleActions
+  )
+
+  // add empty check to avoid causing undefined issue when calling titleCase
+  const text =
+    step.stepName !== undefined && step.stepName !== ''
+      ? i18n.format(step.stepName, 'titleCase')
+      : t(`stepType.${step.stepType}`)
+
+  let subtext = null
+  if (enableConcurrentModuleActions && step.stepType === 'pause') {
+    // todo(mm, 2025-09-10): Improve FormData typing to make this type-safe.
+    if (step.pauseAction === PAUSE_UNTIL_RESUME) {
+      subtext = t('protocol_steps:pause.untilResume')
+    } else if (step.pauseAction === PAUSE_UNTIL_TEMP) {
+      subtext = t('protocol_steps:pause.untilTemperature', {
+        temperature: step.pauseTemperature,
+      })
+    } else if (step.pauseAction === PAUSE_UNTIL_TIME) {
+      subtext = t('protocol_steps:pause.forDuration', {
+        duration: formatTime(step.pauseTime as string),
+      })
+    }
+  }
+
+  return { text, subtext }
+}


### PR DESCRIPTION
## Overview

Closes EXEC-1748. Adds a second line of text, the "subtext," to pause steps in the timeline.

## Test Plan and Hands on Testing

* [x] With the concurrent module actions feature flag disabled, no change.
* [x] With the concurrent module actions feature flag enabled, pause steps in the timeline now have subtext, according to what kind of pause they are.
  <img width="291" height="572" alt="Screenshot 2025-09-10 at 4 54 21 PM" src="https://github.com/user-attachments/assets/4f305a26-9f6b-473e-91e1-880148c3b02e" />
* [x] The step summary text is unaffected.

## Review requests

See comments.

## Risk assessment

Medium because of the type safety thing. See comments.
