### PR TITLE
refactor(app-shell): extend discovery client to support multiple windows

### DIFF
--- a/app-shell/src/__tests__/discovery.test.ts
+++ b/app-shell/src/__tests__/discovery.test.ts
@@ -13,7 +13,9 @@ import * as DiscoveryClient from '@opentrons/discovery-client'
 import * as Cfg from '../config'
 import {
   __resetDiscoveryForTesting,
-  registerDiscovery,
+  initializeDiscovery,
+  registerDiscoveryMainWindow,
+  registerDiscoverySecondaryWindow,
   unregisterDiscovery,
 } from '../discovery'
 import * as SysInfo from '../system-info'
@@ -28,18 +30,22 @@ vi.mock('../system-info')
 vi.mock('../log', () => {
   return {
     createLogger: () => {
-      return { debug: () => null }
+      return {
+        debug: () => null,
+        warn: () => null,
+        error: () => null,
+        info: () => null,
+      }
     },
   }
 })
 vi.mock('../notifications')
 
-let mockGet = vi.fn(property => {
-  return []
-})
+let mockGet = vi.fn()
 let mockOnDidChange = vi.fn()
 let mockDelete = vi.fn()
 let mockSet = vi.fn()
+
 describe('app-shell/discovery', () => {
   const dispatch = vi.fn()
   const dispatch2 = vi.fn()
@@ -94,8 +100,8 @@ describe('app-shell/discovery', () => {
     vi.resetAllMocks()
   })
 
-  it('registerDiscovery creates a DiscoveryClient', () => {
-    registerDiscovery(dispatch)
+  it('initializeDiscovery creates a DiscoveryClient', () => {
+    initializeDiscovery()
 
     expect(
       vi.mocked(DiscoveryClient.createDiscoveryClient)
@@ -106,17 +112,17 @@ describe('app-shell/discovery', () => {
     )
   })
 
-  it('registerDiscovery creates a DiscoveryClient only once for multiple dispatchers', () => {
-    registerDiscovery(dispatch)
-    registerDiscovery(dispatch2)
+  it('initializeDiscovery can only be called once', () => {
+    initializeDiscovery()
+    initializeDiscovery()
 
     expect(
       vi.mocked(DiscoveryClient.createDiscoveryClient)
     ).toHaveBeenCalledTimes(1)
   })
 
-  it('calls client.start on discovery registration', () => {
-    registerDiscovery(dispatch)
+  it('calls client.start on initialization', () => {
+    initializeDiscovery()
 
     expect(mockClient.start).toHaveBeenCalledTimes(1)
     expect(mockClient.start).toHaveBeenCalledWith({
@@ -127,113 +133,131 @@ describe('app-shell/discovery', () => {
     })
   })
 
-  it('sends current robots to secondary dispatchers immediately', () => {
+  it('sends current robots to all dispatchers on registration', () => {
     const robots = [{ name: 'robot1' }, { name: 'robot2' }]
     mockClient.getRobots.mockReturnValue(robots)
 
-    registerDiscovery(dispatch)
-    registerDiscovery(dispatch2)
+    initializeDiscovery()
+    registerDiscoveryMainWindow(dispatch)
+    registerDiscoverySecondaryWindow(dispatch2)
 
+    expect(dispatch).toHaveBeenCalledWith({
+      type: 'discovery:UPDATE_LIST',
+      payload: { robots },
+    })
     expect(dispatch2).toHaveBeenCalledWith({
       type: 'discovery:UPDATE_LIST',
       payload: { robots },
     })
   })
 
+  it('cannot register multiple main windows', () => {
+    initializeDiscovery()
+    registerDiscoveryMainWindow(dispatch)
+
+    const handleAction = registerDiscoveryMainWindow(dispatch2)
+
+    mockClient.start.mockClear()
+    handleAction(startDiscovery())
+    expect(mockClient.start).not.toHaveBeenCalled()
+  })
+
   it('calls client.stop when electron app emits "will-quit"', () => {
     expect(vi.mocked(app.once)).toHaveBeenCalledTimes(0)
 
-    registerDiscovery(dispatch)
+    initializeDiscovery()
 
     expect(mockClient.stop).toHaveBeenCalledTimes(0)
+
     expect(vi.mocked(app.once)).toHaveBeenCalledTimes(1)
 
     const [event, handler] = vi.mocked(app.once).mock.calls[0]
+
     expect(event).toEqual('will-quit')
 
-    // trigger event handler
     handler()
+
     expect(mockClient.stop).toHaveBeenCalledTimes(1)
   })
 
-  it('sets poll speed on "discovery:START" and "discovery:FINISH"', () => {
-    const handleAction = registerDiscovery(dispatch)
+  it('sets poll speed on "discovery:START" and "discovery:FINISH" via main window', () => {
+    initializeDiscovery()
+    const handleAction = registerDiscoveryMainWindow(dispatch)
 
+    mockClient.start.mockClear()
     handleAction(startDiscovery())
+
     expect(mockClient.start).toHaveBeenLastCalledWith({
       healthPollInterval: 3000,
     })
 
     handleAction(finishDiscovery())
+
     expect(mockClient.start).toHaveBeenLastCalledWith({
       healthPollInterval: 15000,
     })
   })
 
-  it('sets poll speed on "discovery:START" and "discovery:FINISH" only for main dispatcher', () => {
-    const handleAction1 = registerDiscovery(dispatch)
-    const handleAction2 = registerDiscovery(dispatch2)
+  it('secondary windows cannot control discovery client', () => {
+    initializeDiscovery()
+    registerDiscoveryMainWindow(dispatch)
+    const handleAction2 = registerDiscoverySecondaryWindow(dispatch2)
 
-    const initialCallCount = mockClient.start.mock.calls.length
-
-    handleAction1(startDiscovery())
-    expect(mockClient.start).toHaveBeenCalledTimes(initialCallCount + 1)
-
+    mockClient.start.mockClear()
     handleAction2(startDiscovery())
-    expect(mockClient.start).toHaveBeenCalledTimes(initialCallCount + 1)
 
-    handleAction1(finishDiscovery())
-    expect(mockClient.start).toHaveBeenCalledTimes(initialCallCount + 2)
+    expect(mockClient.start).not.toHaveBeenCalled()
 
     handleAction2(finishDiscovery())
-    expect(mockClient.start).toHaveBeenCalledTimes(initialCallCount + 2)
+
+    expect(mockClient.start).not.toHaveBeenCalled()
   })
 
-  it('sets poll speed on "shell:UI_INTIALIZED"', () => {
-    const handleAction = registerDiscovery(dispatch)
+  it('sets poll speed on "shell:UI_INITIALIZED" via main window', () => {
+    initializeDiscovery()
+    const handleAction = registerDiscoveryMainWindow(dispatch)
 
+    mockClient.start.mockClear()
     handleAction({ type: 'shell:UI_INITIALIZED', meta: { shell: true } })
     expect(mockClient.start).toHaveBeenLastCalledWith({
       healthPollInterval: 3000,
     })
   })
 
-  it('sets poll speed on "shell:UI_INTIALIZED" only for main dispatcher', () => {
-    const handleAction1 = registerDiscovery(dispatch)
-    const handleAction2 = registerDiscovery(dispatch2)
-
-    const initialCallCount = mockClient.start.mock.calls.length
-
-    handleAction1({ type: 'shell:UI_INITIALIZED', meta: { shell: true } })
-    expect(mockClient.start).toHaveBeenCalledTimes(initialCallCount + 1)
-
-    handleAction2({ type: 'shell:UI_INITIALIZED', meta: { shell: true } })
-    expect(mockClient.start).toHaveBeenCalledTimes(initialCallCount + 1)
-  })
-
-  it('always sends "discovery:UPDATE_LIST" on "discovery:START"', () => {
+  it('always sends "discovery:UPDATE_LIST" on "discovery:START" from main window', () => {
     const expected = [
       { name: 'opentrons', health: null, serverHealth: null, addresses: [] },
     ]
 
+    initializeDiscovery()
+
     mockClient.getRobots.mockReturnValue(expected)
-    registerDiscovery(dispatch)(startDiscovery())
+
+    const handleAction = registerDiscoveryMainWindow(dispatch)
+    dispatch.mockClear()
+    handleAction(startDiscovery())
+
     expect(dispatch).toHaveBeenCalledWith({
       type: 'discovery:UPDATE_LIST',
       payload: { robots: expected },
     })
   })
 
-  it('sends "discovery:UPDATE_LIST" to all dispatchers on "discovery:START"', () => {
+  it('sends "discovery:UPDATE_LIST" to all dispatchers on robot list change', () => {
     const expected = [
       { name: 'opentrons', health: null, serverHealth: null, addresses: [] },
     ]
 
-    mockClient.getRobots.mockReturnValue(expected)
-    const handleAction1 = registerDiscovery(dispatch)
-    registerDiscovery(dispatch2)
+    initializeDiscovery()
 
-    handleAction1(startDiscovery())
+    mockClient.getRobots.mockReturnValue(expected)
+
+    registerDiscoveryMainWindow(dispatch)
+    registerDiscoverySecondaryWindow(dispatch2)
+
+    dispatch.mockClear()
+    dispatch2.mockClear()
+    emitListChange()
 
     expect(dispatch).toHaveBeenCalledWith({
       type: 'discovery:UPDATE_LIST',
@@ -245,8 +269,10 @@ describe('app-shell/discovery', () => {
     })
   })
 
-  it('calls client.removeRobot on discovery:REMOVE', () => {
-    const handleAction = registerDiscovery(dispatch)
+  it('calls client.removeRobot on discovery:REMOVE from main window', () => {
+    initializeDiscovery()
+    const handleAction = registerDiscoveryMainWindow(dispatch)
+
     handleAction({
       type: 'discovery:REMOVE',
       payload: { robotName: 'robot-name' },
@@ -256,48 +282,30 @@ describe('app-shell/discovery', () => {
     expect(mockClient.removeRobot).toHaveBeenCalledWith('robot-name')
   })
 
-  it('calls client.removeRobot on discovery:REMOVE only for main dispatcher', () => {
-    const handleAction1 = registerDiscovery(dispatch)
-    const handleAction2 = registerDiscovery(dispatch2)
-
-    handleAction1({
-      type: 'discovery:REMOVE',
-      payload: { robotName: 'robot-name' },
-      meta: { shell: true },
-    })
-    expect(mockClient.removeRobot).toHaveBeenCalledWith('robot-name')
-
-    mockClient.removeRobot.mockClear()
-    handleAction2({
-      type: 'discovery:REMOVE',
-      payload: { robotName: 'robot-name' },
-      meta: { shell: true },
-    })
-    expect(mockClient.removeRobot).not.toHaveBeenCalled()
-  })
-
-  it('unregisterDiscovery removes dispatcher from the set', () => {
+  it('unregisterDiscovery removes secondary dispatcher from the set', () => {
     const robots = [{ name: 'robot1' }]
     mockClient.getRobots.mockReturnValue(robots)
-
-    registerDiscovery(dispatch)
-    registerDiscovery(dispatch2)
-
+    initializeDiscovery()
+    registerDiscoveryMainWindow(dispatch)
+    registerDiscoverySecondaryWindow(dispatch2)
     unregisterDiscovery(dispatch2)
 
+    dispatch.mockClear()
+    dispatch2.mockClear()
     emitListChange()
 
     expect(dispatch).toHaveBeenCalledWith({
       type: 'discovery:UPDATE_LIST',
       payload: { robots },
     })
-    // dispatch2 should only have been called once during registration, not from emitListChange
-    expect(dispatch2).toHaveBeenCalledTimes(1)
+    expect(dispatch2).not.toHaveBeenCalled()
   })
 
   describe('robot list caching', () => {
-    it('stores services to when onListUpdate is called', () => {
-      registerDiscovery(dispatch)
+    it('stores robots when onListUpdate is called', () => {
+      initializeDiscovery()
+      registerDiscoveryMainWindow(dispatch)
+
       expect(Store).toHaveBeenCalledWith({
         name: 'discovery',
         defaults: { robots: [] },
@@ -313,8 +321,12 @@ describe('app-shell/discovery', () => {
     })
 
     it('sends updates to all dispatchers when robot list changes', () => {
-      registerDiscovery(dispatch)
-      registerDiscovery(dispatch2)
+      initializeDiscovery()
+      registerDiscoveryMainWindow(dispatch)
+      registerDiscoverySecondaryWindow(dispatch2)
+
+      dispatch.mockClear()
+      dispatch2.mockClear()
 
       mockClient.getRobots.mockReturnValue([{ name: 'foo' }, { name: 'bar' }])
       emitListChange()
@@ -337,7 +349,8 @@ describe('app-shell/discovery', () => {
         return null as any
       })
 
-      registerDiscovery(dispatch)
+      initializeDiscovery()
+
       expect(mockClient.start).toHaveBeenCalledWith(
         expect.objectContaining({
           initialRobots: [mockRobot],
@@ -423,7 +436,8 @@ describe('app-shell/discovery', () => {
         return null as any
       })
 
-      registerDiscovery(dispatch)
+      initializeDiscovery()
+
       expect(mockDelete).toHaveBeenCalledWith('services')
       expect(mockClient.start).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -476,9 +490,10 @@ describe('app-shell/discovery', () => {
       )
     })
 
-    it('can delete cached robots', () => {
-      const handleAction = registerDiscovery(dispatch)
-      mockClient.start.mockReset()
+    it('can delete cached robots via main window', () => {
+      initializeDiscovery()
+      const handleAction = registerDiscoveryMainWindow(dispatch)
+      mockClient.start.mockClear()
 
       handleAction({
         type: 'discovery:CLEAR_CACHE',
@@ -492,23 +507,12 @@ describe('app-shell/discovery', () => {
       )
     })
 
-    it('can delete cached robots only via main dispatcher', () => {
-      const handleAction1 = registerDiscovery(dispatch)
-      const handleAction2 = registerDiscovery(dispatch2)
-      mockClient.start.mockReset()
+    it('secondary windows cannot clear cache', () => {
+      initializeDiscovery()
+      registerDiscoveryMainWindow(dispatch)
+      const handleAction2 = registerDiscoverySecondaryWindow(dispatch2)
+      mockClient.start.mockClear()
 
-      handleAction1({
-        type: 'discovery:CLEAR_CACHE',
-        meta: { shell: true },
-      })
-
-      expect(mockClient.start).toHaveBeenCalledWith(
-        expect.objectContaining({
-          initialRobots: [],
-        })
-      )
-
-      mockClient.start.mockReset()
       handleAction2({
         type: 'discovery:CLEAR_CACHE',
         meta: { shell: true },
@@ -532,7 +536,7 @@ describe('app-shell/discovery', () => {
         return null as any
       })
 
-      registerDiscovery(dispatch)
+      initializeDiscovery()
 
       // should not contain above entry
       expect(mockClient.start).toHaveBeenCalledWith(
@@ -557,7 +561,7 @@ describe('app-shell/discovery', () => {
         return null as any
       })
 
-      registerDiscovery(dispatch)
+      initializeDiscovery()
 
       const disableCacheCall = vi
         .mocked(Cfg.handleConfigChange)
@@ -586,7 +590,7 @@ describe('app-shell/discovery', () => {
         discovery: { cacheDisabled: false, candidates: ['1.2.3.4'] },
       } as unknown) as Cfg.Config)
 
-      registerDiscovery(dispatch)
+      initializeDiscovery()
 
       expect(mockClient.start).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -603,7 +607,7 @@ describe('app-shell/discovery', () => {
         discovery: { cacheDisabled: false, candidates: '1.2.3.4' },
       } as unknown) as Cfg.Config)
 
-      registerDiscovery(dispatch)
+      initializeDiscovery()
 
       expect(mockClient.start).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/app-shell/src/__tests__/discovery.test.ts
+++ b/app-shell/src/__tests__/discovery.test.ts
@@ -11,7 +11,11 @@ import {
 import * as DiscoveryClient from '@opentrons/discovery-client'
 
 import * as Cfg from '../config'
-import { registerDiscovery } from '../discovery'
+import {
+  __resetDiscoveryForTesting,
+  registerDiscovery,
+  unregisterDiscovery,
+} from '../discovery'
 import * as SysInfo from '../system-info'
 import { getSerialPortHttpAgent } from '../usb'
 
@@ -38,6 +42,7 @@ let mockDelete = vi.fn()
 let mockSet = vi.fn()
 describe('app-shell/discovery', () => {
   const dispatch = vi.fn()
+  const dispatch2 = vi.fn()
   const mockClient = {
     start: vi.fn(),
     stop: vi.fn(),
@@ -50,11 +55,15 @@ describe('app-shell/discovery', () => {
       .calls[
       vi.mocked(DiscoveryClient.createDiscoveryClient).mock.calls.length - 1
     ]
-    const { onListChange } = lastCall[0]
-    onListChange([])
+    if (lastCall && lastCall[0]) {
+      const { onListChange } = lastCall[0]
+      onListChange([])
+    }
   }
 
   beforeEach(() => {
+    __resetDiscoveryForTesting()
+
     mockGet = vi.fn(property => {
       return []
     })
@@ -97,6 +106,15 @@ describe('app-shell/discovery', () => {
     )
   })
 
+  it('registerDiscovery creates a DiscoveryClient only once for multiple dispatchers', () => {
+    registerDiscovery(dispatch)
+    registerDiscovery(dispatch2)
+
+    expect(
+      vi.mocked(DiscoveryClient.createDiscoveryClient)
+    ).toHaveBeenCalledTimes(1)
+  })
+
   it('calls client.start on discovery registration', () => {
     registerDiscovery(dispatch)
 
@@ -106,6 +124,19 @@ describe('app-shell/discovery', () => {
       initialRobots: [],
       // support for legacy (pre-v3.3.0) IPv6 wired robots
       manualAddresses: [{ ip: 'fd00:0:cafe:fefe::1', port: 31950 }],
+    })
+  })
+
+  it('sends current robots to secondary dispatchers immediately', () => {
+    const robots = [{ name: 'robot1' }, { name: 'robot2' }]
+    mockClient.getRobots.mockReturnValue(robots)
+
+    registerDiscovery(dispatch)
+    registerDiscovery(dispatch2)
+
+    expect(dispatch2).toHaveBeenCalledWith({
+      type: 'discovery:UPDATE_LIST',
+      payload: { robots },
     })
   })
 
@@ -139,6 +170,25 @@ describe('app-shell/discovery', () => {
     })
   })
 
+  it('sets poll speed on "discovery:START" and "discovery:FINISH" only for main dispatcher', () => {
+    const handleAction1 = registerDiscovery(dispatch)
+    const handleAction2 = registerDiscovery(dispatch2)
+
+    const initialCallCount = mockClient.start.mock.calls.length
+
+    handleAction1(startDiscovery())
+    expect(mockClient.start).toHaveBeenCalledTimes(initialCallCount + 1)
+
+    handleAction2(startDiscovery())
+    expect(mockClient.start).toHaveBeenCalledTimes(initialCallCount + 1)
+
+    handleAction1(finishDiscovery())
+    expect(mockClient.start).toHaveBeenCalledTimes(initialCallCount + 2)
+
+    handleAction2(finishDiscovery())
+    expect(mockClient.start).toHaveBeenCalledTimes(initialCallCount + 2)
+  })
+
   it('sets poll speed on "shell:UI_INTIALIZED"', () => {
     const handleAction = registerDiscovery(dispatch)
 
@@ -146,6 +196,19 @@ describe('app-shell/discovery', () => {
     expect(mockClient.start).toHaveBeenLastCalledWith({
       healthPollInterval: 3000,
     })
+  })
+
+  it('sets poll speed on "shell:UI_INTIALIZED" only for main dispatcher', () => {
+    const handleAction1 = registerDiscovery(dispatch)
+    const handleAction2 = registerDiscovery(dispatch2)
+
+    const initialCallCount = mockClient.start.mock.calls.length
+
+    handleAction1({ type: 'shell:UI_INITIALIZED', meta: { shell: true } })
+    expect(mockClient.start).toHaveBeenCalledTimes(initialCallCount + 1)
+
+    handleAction2({ type: 'shell:UI_INITIALIZED', meta: { shell: true } })
+    expect(mockClient.start).toHaveBeenCalledTimes(initialCallCount + 1)
   })
 
   it('always sends "discovery:UPDATE_LIST" on "discovery:START"', () => {
@@ -161,6 +224,27 @@ describe('app-shell/discovery', () => {
     })
   })
 
+  it('sends "discovery:UPDATE_LIST" to all dispatchers on "discovery:START"', () => {
+    const expected = [
+      { name: 'opentrons', health: null, serverHealth: null, addresses: [] },
+    ]
+
+    mockClient.getRobots.mockReturnValue(expected)
+    const handleAction1 = registerDiscovery(dispatch)
+    registerDiscovery(dispatch2)
+
+    handleAction1(startDiscovery())
+
+    expect(dispatch).toHaveBeenCalledWith({
+      type: 'discovery:UPDATE_LIST',
+      payload: { robots: expected },
+    })
+    expect(dispatch2).toHaveBeenCalledWith({
+      type: 'discovery:UPDATE_LIST',
+      payload: { robots: expected },
+    })
+  })
+
   it('calls client.removeRobot on discovery:REMOVE', () => {
     const handleAction = registerDiscovery(dispatch)
     handleAction({
@@ -170,6 +254,45 @@ describe('app-shell/discovery', () => {
     })
 
     expect(mockClient.removeRobot).toHaveBeenCalledWith('robot-name')
+  })
+
+  it('calls client.removeRobot on discovery:REMOVE only for main dispatcher', () => {
+    const handleAction1 = registerDiscovery(dispatch)
+    const handleAction2 = registerDiscovery(dispatch2)
+
+    handleAction1({
+      type: 'discovery:REMOVE',
+      payload: { robotName: 'robot-name' },
+      meta: { shell: true },
+    })
+    expect(mockClient.removeRobot).toHaveBeenCalledWith('robot-name')
+
+    mockClient.removeRobot.mockClear()
+    handleAction2({
+      type: 'discovery:REMOVE',
+      payload: { robotName: 'robot-name' },
+      meta: { shell: true },
+    })
+    expect(mockClient.removeRobot).not.toHaveBeenCalled()
+  })
+
+  it('unregisterDiscovery removes dispatcher from the set', () => {
+    const robots = [{ name: 'robot1' }]
+    mockClient.getRobots.mockReturnValue(robots)
+
+    registerDiscovery(dispatch)
+    registerDiscovery(dispatch2)
+
+    unregisterDiscovery(dispatch2)
+
+    emitListChange()
+
+    expect(dispatch).toHaveBeenCalledWith({
+      type: 'discovery:UPDATE_LIST',
+      payload: { robots },
+    })
+    // dispatch2 should only have been called once during registration, not from emitListChange
+    expect(dispatch2).toHaveBeenCalledTimes(1)
   })
 
   describe('robot list caching', () => {
@@ -187,6 +310,23 @@ describe('app-shell/discovery', () => {
         { name: 'foo' },
         { name: 'bar' },
       ])
+    })
+
+    it('sends updates to all dispatchers when robot list changes', () => {
+      registerDiscovery(dispatch)
+      registerDiscovery(dispatch2)
+
+      mockClient.getRobots.mockReturnValue([{ name: 'foo' }, { name: 'bar' }])
+      emitListChange()
+
+      expect(dispatch).toHaveBeenCalledWith({
+        type: 'discovery:UPDATE_LIST',
+        payload: { robots: [{ name: 'foo' }, { name: 'bar' }] },
+      })
+      expect(dispatch2).toHaveBeenCalledWith({
+        type: 'discovery:UPDATE_LIST',
+        payload: { robots: [{ name: 'foo' }, { name: 'bar' }] },
+      })
     })
 
     it('loads robots from cache on client initialization', () => {
@@ -352,6 +492,31 @@ describe('app-shell/discovery', () => {
       )
     })
 
+    it('can delete cached robots only via main dispatcher', () => {
+      const handleAction1 = registerDiscovery(dispatch)
+      const handleAction2 = registerDiscovery(dispatch2)
+      mockClient.start.mockReset()
+
+      handleAction1({
+        type: 'discovery:CLEAR_CACHE',
+        meta: { shell: true },
+      })
+
+      expect(mockClient.start).toHaveBeenCalledWith(
+        expect.objectContaining({
+          initialRobots: [],
+        })
+      )
+
+      mockClient.start.mockReset()
+      handleAction2({
+        type: 'discovery:CLEAR_CACHE',
+        meta: { shell: true },
+      })
+
+      expect(mockClient.start).not.toHaveBeenCalled()
+    })
+
     it('does not update services from store when caching disabled', () => {
       // cache has been disabled
       vi.mocked(Cfg.getFullConfig).mockReturnValue(({
@@ -394,10 +559,14 @@ describe('app-shell/discovery', () => {
 
       registerDiscovery(dispatch)
 
-      // the 'discovery.disableCache' change handler
-      const changeHandler = vi.mocked(Cfg.handleConfigChange).mock.calls[1][1]
+      const disableCacheCall = vi
+        .mocked(Cfg.handleConfigChange)
+        .mock.calls.find(call => call[0] === 'discovery.disableCache')
+      expect(disableCacheCall).toBeDefined()
+
+      const changeHandler = disableCacheCall?.[1]
       const disableCache = true
-      changeHandler(disableCache, false)
+      changeHandler?.(disableCache, false)
 
       expect(mockSet).toHaveBeenCalledWith('robots', [])
 

--- a/app-shell/src/discovery.ts
+++ b/app-shell/src/discovery.ts
@@ -47,16 +47,122 @@ interface DiscoveryStore {
   services?: LegacyService[]
 }
 
-let config: ConfigV1['discovery']
-let store: Store<DiscoveryStore>
-let client: DiscoveryClient
-let isClientInitialized = false
-const dispatchers = new Set<Dispatch>()
+interface DiscoveryState {
+  config: ConfigV1['discovery']
+  store: Store<DiscoveryStore>
+  client: DiscoveryClient
+  dispatchers: Set<Dispatch>
+  primaryDispatcher: Dispatch | null
+}
 
-const makeManualAddresses = (addrs: string | string[]): Address[] => {
-  return ['fd00:0:cafe:fefe::1']
-    .concat(addrs)
-    .map(ip => ({ ip, port: DEFAULT_PORT }))
+let discoveryState: DiscoveryState | null = null
+
+export function initializeDiscovery(): void {
+  if (discoveryState != null) {
+    log.warn('Discovery already initialized')
+    return
+  }
+
+  const state = getDiscoveryState()
+  let initialRobots: DiscoveryClientRobot[] = []
+
+  // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+  if (!state.config.disableCache) {
+    const legacyCachedServices: LegacyService[] | undefined = state.store.get(
+      'services',
+      // @ts-expect-error(mc, 2021-02-16): tweak these type definitions
+      null
+    )
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+    if (legacyCachedServices) {
+      initialRobots = migrateLegacyServices(legacyCachedServices)
+      state.store.delete('services')
+    } else {
+      initialRobots = state.store.get('robots', [])
+    }
+  }
+
+  state.client.start({
+    initialRobots,
+    healthPollInterval: SLOW_POLL_INTERVAL_MS,
+    manualAddresses: makeManualAddresses(state.config.candidates),
+  })
+
+  handleConfigChange('discovery.candidates', (value: string | string[]) => {
+    state.client.start({ manualAddresses: makeManualAddresses(value) })
+  })
+
+  handleConfigChange('discovery.disableCache', (value: boolean) => {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-boolean-literal-compare
+    if (value === true) {
+      state.config.disableCache = value
+      state.store.set('robots', [])
+      clearClientRobotCache()
+    }
+  })
+
+  app.once('will-quit', () => {
+    state.client.stop()
+  })
+
+  log.debug('Discovery initialized')
+}
+
+// Register a dispatcher to mediate discovery client actions.
+// See createPrimaryActionHandler.
+export function registerDiscoveryMainWindow(
+  dispatch: Dispatch
+): (action: Action) => unknown {
+  const state = getDiscoveryState()
+
+  if (state.primaryDispatcher != null) {
+    log.error(
+      'Attempted to register main window discovery when primary dispatcher already exists.'
+    )
+    return createSecondaryActionHandler()
+  }
+
+  state.primaryDispatcher = dispatch
+  state.dispatchers.add(dispatch)
+
+  const robots = state.client.getRobots()
+  dispatch({
+    type: 'discovery:UPDATE_LIST',
+    payload: { robots },
+  })
+
+  return createPrimaryActionHandler(state)
+}
+
+// Register a dispatcher as a "listener". This dispatcher only receives
+// discovery updates. Only the primary dispatcher (the main window) should
+// drive discovery client behavior.
+export function registerDiscoverySecondaryWindow(
+  dispatch: Dispatch
+): (action: Action) => unknown {
+  const state = getDiscoveryState()
+
+  state.dispatchers.add(dispatch)
+
+  const robots = state.client.getRobots()
+  dispatch({
+    type: 'discovery:UPDATE_LIST',
+    payload: { robots },
+  })
+
+  return createSecondaryActionHandler()
+}
+
+export function unregisterDiscovery(dispatch: Dispatch): void {
+  if (discoveryState != null) {
+    if (discoveryState.primaryDispatcher === dispatch) {
+      log.error(
+        'Attempted to unregister the primary dispatch, the main window.'
+      )
+    } else {
+      discoveryState.dispatchers.delete(dispatch)
+    }
+  }
 }
 
 const migrateLegacyServices = (
@@ -86,101 +192,105 @@ const migrateLegacyServices = (
   })
 }
 
-export function registerDiscovery(
-  dispatch: Dispatch
-): (action: Action) => unknown {
-  const handleRobotListChange = throttle(handleRobots, UPDATE_THROTTLE_MS)
+const makeManualAddresses = (addrs: string | string[]): Address[] => {
+  return ['fd00:0:cafe:fefe::1']
+    .concat(addrs)
+    .map(ip => ({ ip, port: DEFAULT_PORT }))
+}
 
-  dispatchers.add(dispatch)
+const getDiscoveryState = (): DiscoveryState => {
+  if (discoveryState != null) {
+    return discoveryState
+  }
 
-  if (!isClientInitialized) {
-    config = getFullConfig().discovery
-    store = new Store({
-      name: 'discovery',
-      defaults: { robots: [] as DiscoveryClientRobot[] },
-    })
+  const config = getFullConfig().discovery
+  const store = new Store({
+    name: 'discovery',
+    defaults: { robots: [] as DiscoveryClientRobot[] },
+  })
 
-    let initialRobots: DiscoveryClientRobot[] = []
+  const dispatchers = new Set<Dispatch>()
 
-    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-    if (!config.disableCache) {
-      const legacyCachedServices: LegacyService[] | undefined = store.get(
-        'services',
-        // @ts-expect-error(mc, 2021-02-16): tweak these type definitions
-        null
-      )
-      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-      if (legacyCachedServices) {
-        initialRobots = migrateLegacyServices(legacyCachedServices)
-        store.delete('services')
-      } else {
-        initialRobots = store.get('robots', [])
-      }
-    }
+  const handleRobots = (): void => {
+    const robots = discoveryState?.client.getRobots() ?? []
+    handleNotificationConnectionsFor(robots)
+    if (!config.disableCache) store.set('robots', robots)
 
-    client = createDiscoveryClient({
-      onListChange: handleRobotListChange,
-      logger: log,
-    })
-
-    client.start({
-      initialRobots,
-      healthPollInterval: SLOW_POLL_INTERVAL_MS,
-      manualAddresses: makeManualAddresses(config.candidates),
-    })
-
-    handleConfigChange('discovery.candidates', (value: string | string[]) => {
-      client.start({ manualAddresses: makeManualAddresses(value) })
-    })
-
-    handleConfigChange('discovery.disableCache', (value: boolean) => {
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-boolean-literal-compare
-      if (value === true) {
-        config.disableCache = value
-        store.set('robots', [])
-        clearCache()
-      }
-    })
-
-    app.once('will-quit', () => {
-      client.stop()
-    })
-
-    isClientInitialized = true
-  } else {
-    const robots = client.getRobots()
-    dispatch({
-      type: 'discovery:UPDATE_LIST',
-      payload: { robots },
+    dispatchers.forEach(dispatcher => {
+      dispatcher({
+        type: 'discovery:UPDATE_LIST',
+        payload: { robots },
+      })
     })
   }
 
-  return function handleIncomingAction(action: Action) {
-    log.debug('handling action in discovery', { action })
+  const handleRobotListChange = throttle(handleRobots, UPDATE_THROTTLE_MS)
 
-    // Only first dispatcher handles client control actions
-    const isMainDispatcher = dispatchers.values().next().value === dispatch
-    if (!isMainDispatcher) {
-      return
+  const client = createDiscoveryClient({
+    onListChange: handleRobotListChange,
+    logger: log,
+  })
+
+  discoveryState = {
+    config,
+    store,
+    client,
+    dispatchers,
+    primaryDispatcher: null,
+  }
+
+  return discoveryState
+}
+
+// Only one dispatcher, the primary action handler (ie, the main window), should mediate
+// discovery client actions. This prevents duplicated discovery actions that may
+// lead to unexpected behavior.
+function createPrimaryActionHandler(
+  state: DiscoveryState
+): (action: Action) => void {
+  const handleRobots = (): void => {
+    const robots = state.client.getRobots()
+
+    handleNotificationConnectionsFor(robots)
+
+    if (!state.config.disableCache) {
+      state.store.set('robots', robots)
     }
+
+    state.dispatchers.forEach(dispatcher => {
+      dispatcher({
+        type: 'discovery:UPDATE_LIST',
+        payload: { robots },
+      })
+    })
+  }
+
+  const clearCache = (): void => {
+    state.client.start({ initialRobots: [], manualAddresses: [] })
+  }
+
+  return function handleIncomingAction(action: Action) {
+    log.debug('handling action in discovery (primary)', { action })
 
     switch (action.type) {
       case UI_INITIALIZED:
       case DISCOVERY_START: {
         handleRobots()
-        client.start({
+        state.client.start({
           healthPollInterval: FAST_POLL_INTERVAL_MS,
         })
         return
       }
       case DISCOVERY_FINISH: {
-        client.start({
+        state.client.start({
           healthPollInterval: SLOW_POLL_INTERVAL_MS,
         })
         return
       }
       case DISCOVERY_REMOVE: {
-        client.removeRobot((action.payload as { robotName: string }).robotName)
+        state.client.removeRobot(
+          (action.payload as { robotName: string }).robotName
+        )
         return
       }
       case CLEAR_CACHE: {
@@ -190,7 +300,7 @@ export function registerDiscovery(
       case USB_HTTP_REQUESTS_START: {
         const usbHttpAgent = getSerialPortHttpAgent()
 
-        client.start({
+        state.client.start({
           healthPollInterval: FAST_POLL_INTERVAL_MS,
           manualAddresses: [
             {
@@ -203,7 +313,7 @@ export function registerDiscovery(
         break
       }
       case USB_HTTP_REQUESTS_STOP: {
-        client.start({
+        state.client.start({
           healthPollInterval: FAST_POLL_INTERVAL_MS,
           manualAddresses: [
             {
@@ -216,30 +326,20 @@ export function registerDiscovery(
       }
     }
   }
+}
 
-  function handleRobots(): void {
-    const robots = client.getRobots()
-    handleNotificationConnectionsFor(robots)
-    if (!config.disableCache) store.set('robots', robots)
-
-    dispatchers.forEach(dispatcher => {
-      dispatcher({
-        type: 'discovery:UPDATE_LIST',
-        payload: { robots },
-      })
-    })
-  }
-
-  function clearCache(): void {
-    client.start({ initialRobots: [], manualAddresses: [] })
+// Secondary dispatchers don't handle client control actions.
+function createSecondaryActionHandler(): (action: Action) => void {
+  return function handleIncomingAction(action: Action) {
+    log.debug('handling action in discovery (secondary - no-op)', { action })
   }
 }
 
-export function unregisterDiscovery(dispatch: Dispatch): void {
-  dispatchers.delete(dispatch)
+function clearClientRobotCache(): void {
+  const state = getDiscoveryState()
+  state.client.start({ initialRobots: [], manualAddresses: [] })
 }
 
 export function __resetDiscoveryForTesting(): void {
-  isClientInitialized = false
-  dispatchers.clear()
+  discoveryState = null
 }

--- a/app-shell/src/discovery.ts
+++ b/app-shell/src/discovery.ts
@@ -50,6 +50,8 @@ interface DiscoveryStore {
 let config: ConfigV1['discovery']
 let store: Store<DiscoveryStore>
 let client: DiscoveryClient
+let isClientInitialized = false
+const dispatchers = new Set<Dispatch>()
 
 const makeManualAddresses = (addrs: string | string[]): Address[] => {
   return ['fd00:0:cafe:fefe::1']
@@ -61,7 +63,6 @@ const migrateLegacyServices = (
   legacyServices: LegacyService[]
 ): DiscoveryClientRobot[] => {
   const servicesByName = groupBy<LegacyService>(legacyServices, 'name')
-
   return Object.keys(servicesByName).map((name: string) => {
     const services = servicesByName[name]
     const addresses = services.flatMap((service: LegacyService) => {
@@ -81,7 +82,6 @@ const migrateLegacyServices = (
           ]
         : []
     })
-
     return { name, health: null, serverHealth: null, addresses }
   })
 }
@@ -91,62 +91,78 @@ export function registerDiscovery(
 ): (action: Action) => unknown {
   const handleRobotListChange = throttle(handleRobots, UPDATE_THROTTLE_MS)
 
-  config = getFullConfig().discovery
-  store = new Store({
-    name: 'discovery',
-    defaults: { robots: [] as DiscoveryClientRobot[] },
-  })
+  dispatchers.add(dispatch)
 
-  let disableCache = config.disableCache
-  let initialRobots: DiscoveryClientRobot[] = []
+  if (!isClientInitialized) {
+    config = getFullConfig().discovery
+    store = new Store({
+      name: 'discovery',
+      defaults: { robots: [] as DiscoveryClientRobot[] },
+    })
 
-  // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-  if (!disableCache) {
-    const legacyCachedServices: LegacyService[] | undefined = store.get(
-      'services',
-      // @ts-expect-error(mc, 2021-02-16): tweak these type definitions
-      null
-    )
+    let initialRobots: DiscoveryClientRobot[] = []
 
     // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-    if (legacyCachedServices) {
-      initialRobots = migrateLegacyServices(legacyCachedServices)
-      store.delete('services')
-    } else {
-      initialRobots = store.get('robots', [])
+    if (!config.disableCache) {
+      const legacyCachedServices: LegacyService[] | undefined = store.get(
+        'services',
+        // @ts-expect-error(mc, 2021-02-16): tweak these type definitions
+        null
+      )
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+      if (legacyCachedServices) {
+        initialRobots = migrateLegacyServices(legacyCachedServices)
+        store.delete('services')
+      } else {
+        initialRobots = store.get('robots', [])
+      }
     }
+
+    client = createDiscoveryClient({
+      onListChange: handleRobotListChange,
+      logger: log,
+    })
+
+    client.start({
+      initialRobots,
+      healthPollInterval: SLOW_POLL_INTERVAL_MS,
+      manualAddresses: makeManualAddresses(config.candidates),
+    })
+
+    handleConfigChange('discovery.candidates', (value: string | string[]) => {
+      client.start({ manualAddresses: makeManualAddresses(value) })
+    })
+
+    handleConfigChange('discovery.disableCache', (value: boolean) => {
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-boolean-literal-compare
+      if (value === true) {
+        config.disableCache = value
+        store.set('robots', [])
+        clearCache()
+      }
+    })
+
+    app.once('will-quit', () => {
+      client.stop()
+    })
+
+    isClientInitialized = true
+  } else {
+    const robots = client.getRobots()
+    dispatch({
+      type: 'discovery:UPDATE_LIST',
+      payload: { robots },
+    })
   }
-
-  client = createDiscoveryClient({
-    onListChange: handleRobotListChange,
-    logger: log,
-  })
-
-  client.start({
-    initialRobots,
-    healthPollInterval: SLOW_POLL_INTERVAL_MS,
-    manualAddresses: makeManualAddresses(config.candidates),
-  })
-
-  handleConfigChange('discovery.candidates', (value: string | string[]) => {
-    client.start({ manualAddresses: makeManualAddresses(value) })
-  })
-
-  handleConfigChange('discovery.disableCache', (value: boolean) => {
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-boolean-literal-compare
-    if (value === true) {
-      disableCache = value
-      store.set('robots', [])
-      clearCache()
-    }
-  })
-
-  app.once('will-quit', () => {
-    client.stop()
-  })
 
   return function handleIncomingAction(action: Action) {
     log.debug('handling action in discovery', { action })
+
+    // Only first dispatcher handles client control actions
+    const isMainDispatcher = dispatchers.values().next().value === dispatch
+    if (!isMainDispatcher) {
+      return
+    }
 
     switch (action.type) {
       case UI_INITIALIZED:
@@ -204,16 +220,26 @@ export function registerDiscovery(
   function handleRobots(): void {
     const robots = client.getRobots()
     handleNotificationConnectionsFor(robots)
+    if (!config.disableCache) store.set('robots', robots)
 
-    if (!disableCache) store.set('robots', robots)
-
-    dispatch({
-      type: 'discovery:UPDATE_LIST',
-      payload: { robots },
+    dispatchers.forEach(dispatcher => {
+      dispatcher({
+        type: 'discovery:UPDATE_LIST',
+        payload: { robots },
+      })
     })
   }
 
   function clearCache(): void {
     client.start({ initialRobots: [], manualAddresses: [] })
   }
+}
+
+export function unregisterDiscovery(dispatch: Dispatch): void {
+  dispatchers.delete(dispatch)
+}
+
+export function __resetDiscoveryForTesting(): void {
+  isClientInitialized = false
+  dispatchers.clear()
 }

--- a/app-shell/src/main.ts
+++ b/app-shell/src/main.ts
@@ -6,7 +6,12 @@ import electronDebug from 'electron-debug'
 import * as electronDevtoolsInstaller from 'electron-devtools-installer'
 
 import { getConfig, getOverrides, getStore, registerConfig } from './config'
-import { registerDiscovery, unregisterDiscovery } from './discovery'
+import {
+  initializeDiscovery,
+  registerDiscoveryMainWindow,
+  registerDiscoverySecondaryWindow,
+  unregisterDiscovery,
+} from './discovery'
 import { registerLabware } from './labware'
 import { createLogger } from './log'
 import { initializeMenu } from './menu'
@@ -90,7 +95,7 @@ function getOrCreateHandlerSet(window: BrowserWindow): HandlerSet | null {
     const handlers: Dispatch[] = isMainWindow(window)
       ? [
           registerConfig(dispatch),
-          registerDiscovery(dispatch),
+          registerDiscoveryMainWindow(dispatch),
           registerProtocolAnalysis(dispatch, window),
           registerUpdate(dispatch),
           registerRobotUpdate(dispatch),
@@ -106,7 +111,7 @@ function getOrCreateHandlerSet(window: BrowserWindow): HandlerSet | null {
       : // Only register necessary subset for secondary windows.
         [
           registerConfig(dispatch),
-          registerDiscovery(dispatch),
+          registerDiscoverySecondaryWindow(dispatch),
           registerUsb(dispatch),
           registerSystemInfo(dispatch),
           registerNotify(dispatch, window),
@@ -143,6 +148,7 @@ function startUp(): void {
     log.error('Uncaught Promise rejection: ', { reason })
   )
 
+  initializeDiscovery()
   mainWindow = createUi()
   rendererLogger = createRendererLogger()
 

--- a/app-shell/src/main.ts
+++ b/app-shell/src/main.ts
@@ -6,7 +6,7 @@ import electronDebug from 'electron-debug'
 import * as electronDevtoolsInstaller from 'electron-devtools-installer'
 
 import { getConfig, getOverrides, getStore, registerConfig } from './config'
-import { registerDiscovery } from './discovery'
+import { registerDiscovery, unregisterDiscovery } from './discovery'
 import { registerLabware } from './labware'
 import { createLogger } from './log'
 import { initializeMenu } from './menu'
@@ -118,6 +118,7 @@ function getOrCreateHandlerSet(window: BrowserWindow): HandlerSet | null {
     handlerSets.set(windowId, { handlers, dispatch })
 
     window.on('closed', () => {
+      unregisterDiscovery(dispatch)
       handlerSets.delete(windowId)
       log.debug(`Cleaned up handlers for ${windowId}`)
     })


### PR DESCRIPTION
Closes [EXEC-1887](https://opentrons.atlassian.net/browse/EXEC-1887)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

So currently, when a secondary window opens, the main window navigates back to `/devices`. After following the debug trail, the core issue that we `registerDiscoveryClient` any time we open a secondary window, but the internals of this function _clear_ the discovery cache and start the discovery client anew every time we register.

We don't need (and probably do not ever want) secondary windows to manage the discovery client lifecycle. Let's leave the internals of that management to the main window (the current behavior) and instead, let's just ensure that discovery client correctly dispatches appropriate list updates to secondary windows via a cache mechanism.

### Current Behavior

https://github.com/user-attachments/assets/88565686-b141-44af-bce2-19d976c61642

### Fixed Behavior 

https://github.com/user-attachments/assets/d35b0d95-1667-4bf3-ad77-7802794239b3

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- See videos.
- Added testing.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- The discovery client cache and internals no longer reset when a secondary window opens.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
lowish-med - Honestly, I'm pretty happy with the added testing, here. This is pretty core functionality we're touching, though.
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[EXEC-1887]: https://opentrons.atlassian.net/browse/EXEC-1887?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ