### PR TITLE
fix(app): always assign a liquid color if one is not passed in

### DIFF
--- a/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabware/SetupLabwareMap.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabware/SetupLabwareMap.tsx
@@ -89,7 +89,8 @@ export function SetupLabwareMap({
           ? getWellFillFromLabwareId(
               topLabwareInfo.labwareId,
               protocolAnalysis.liquids,
-              labwareByLiquidId
+              labwareByLiquidId,
+              protocolAnalysis.commands
             )
           : undefined
       const moduleType = getModuleType(module.moduleModel)
@@ -161,7 +162,8 @@ export function SetupLabwareMap({
     const wellFill = getWellFillFromLabwareId(
       topLabwareInfo.labwareId,
       protocolAnalysis.liquids,
-      labwareByLiquidId
+      labwareByLiquidId,
+      protocolAnalysis.commands
     )
 
     return {

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabware/SlotDetailModal.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabware/SlotDetailModal.tsx
@@ -82,8 +82,9 @@ export const SlotDetailModal = (
   const [selectedLabware, setSelectedLabware] = useState(labwareInStack[0])
   const wellFill = getWellFillFromLabwareId(
     selectedLabware.labwareId,
-    protocolData?.liquids ?? [],
-    labwareByLiquidId
+    protocolData.liquids,
+    labwareByLiquidId,
+    protocolData.commands
   )
 
   const labwareDefinition = definitionsByURI[selectedLabware.definitionUri]

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupLabware/LabwareMapView.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupLabware/LabwareMapView.tsx
@@ -56,7 +56,8 @@ export function LabwareMapView(props: LabwareMapViewProps): JSX.Element {
           ? getWellFillFromLabwareId(
               topLabwareInfo.labwareId,
               mostRecentAnalysis?.liquids ?? [],
-              labwareByLiquidId
+              labwareByLiquidId,
+              mostRecentAnalysis?.commands ?? []
             )
           : undefined
       return {
@@ -94,7 +95,8 @@ export function LabwareMapView(props: LabwareMapViewProps): JSX.Element {
     const wellFill = getWellFillFromLabwareId(
       topLabwareInfo.labwareId,
       mostRecentAnalysis?.liquids ?? [],
-      labwareByLiquidId
+      labwareByLiquidId,
+      mostRecentAnalysis?.commands ?? []
     )
 
     return {

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupLabware/SetupLabwareStackView.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupLabware/SetupLabwareStackView.tsx
@@ -86,8 +86,9 @@ export function SetupLabwareStackView({
 
   const wellFill = getWellFillFromLabwareId(
     selectedLabware.labwareId,
-    mostRecentAnalysis?.liquids ?? [],
-    labwareByLiquidId
+    mostRecentAnalysis.liquids,
+    labwareByLiquidId,
+    mostRecentAnalysis.commands
   )
   const hasLiquids = Object.keys(wellFill).length > 0
   const labwareDefinition =

--- a/app/src/transformations/analysis/__tests__/liquids.test.ts
+++ b/app/src/transformations/analysis/__tests__/liquids.test.ts
@@ -7,41 +7,15 @@ import {
   getLiquidsByIdForLabware,
   getTotalVolumePerLiquidId,
   getTotalVolumePerLiquidLabwarePair,
-  getWellFillFromLabwareId,
   getWellGroupForLiquidId,
 } from '../liquids'
 
-import type { LabwareByLiquidId, Liquid } from '@opentrons/shared-data'
+import type { LabwareByLiquidId } from '@opentrons/shared-data'
 
 const LABWARE_ID =
   '60e8b050-3412-11eb-ad93-ed232a2337cf:opentrons/corning_24_wellplate_3.4ml_flat/1'
 const LIQUID_ID = '7'
-const MOCK_LIQUIDS_IN_LOAD_ORDER: Liquid[] = [
-  {
-    description: 'water',
-    displayColor: '#00d781',
-    displayName: 'liquid 2',
-    id: '7',
-  },
-  {
-    description: 'saline',
-    displayColor: '#0076ff',
-    displayName: 'liquid 1',
-    id: '123',
-  },
-  {
-    description: 'reagent',
-    displayColor: '#ff4888',
-    displayName: 'liquid 3',
-    id: '19',
-  },
-  {
-    description: 'saliva',
-    displayColor: '#B925FF',
-    displayName: 'liquid 4',
-    id: '4',
-  },
-]
+
 const MOCK_LABWARE_BY_LIQUID_ID: LabwareByLiquidId = {
   '4': [
     {
@@ -201,44 +175,6 @@ const MOCK_VOLUME_BY_WELL = {
   D3: 100,
   D4: 100,
 }
-
-describe('getWellFillFromLabwareId', () => {
-  it('returns wellfill object for the labwareId', () => {
-    const expected = {
-      A1: '#00d781',
-      A2: '#00d781',
-      A3: '#B925FF',
-      A4: '#B925FF',
-      A5: '#ff4888',
-      A6: '#ff4888',
-      B1: '#00d781',
-      B2: '#00d781',
-      B3: '#B925FF',
-      B4: '#B925FF',
-      B5: '#ff4888',
-      B6: '#ff4888',
-      C1: '#00d781',
-      C2: '#00d781',
-      C3: '#B925FF',
-      C4: '#B925FF',
-      C5: '#ff4888',
-      C6: '#ff4888',
-      D1: '#00d781',
-      D2: '#00d781',
-      D3: '#B925FF',
-      D4: '#B925FF',
-      D5: '#ff4888',
-      D6: '#ff4888',
-    }
-    expect(
-      getWellFillFromLabwareId(
-        LABWARE_ID,
-        MOCK_LIQUIDS_IN_LOAD_ORDER,
-        MOCK_LABWARE_BY_LIQUID_ID
-      )
-    ).toEqual(expected)
-  })
-})
 
 describe('getTotalVolumePerLiquidId', () => {
   it('returns volume of liquid needed accross all labware', () => {

--- a/app/src/transformations/analysis/liquids.ts
+++ b/app/src/transformations/analysis/liquids.ts
@@ -3,33 +3,6 @@ import { COLORS } from '@opentrons/components'
 import type { WellGroup } from '@opentrons/components'
 import type { LabwareByLiquidId, Liquid } from '@opentrons/shared-data'
 
-export function getWellFillFromLabwareId(
-  labwareId: string,
-  liquidsInLoadOrder: Liquid[],
-  labwareByLiquidId: LabwareByLiquidId
-): { [well: string]: string } {
-  let labwareWellFill: { [well: string]: string } = {}
-  const liquidIds = Object.keys(labwareByLiquidId)
-  const labwareInfo = Object.values(labwareByLiquidId)
-
-  labwareInfo.forEach((labwareArray, index) => {
-    labwareArray.forEach(labware => {
-      if (labware.labwareId === labwareId) {
-        const liquidId = liquidIds[index]
-        const liquid = liquidsInLoadOrder.find(liquid => liquid.id === liquidId)
-        const wellFill: {
-          [well: string]: string
-        } = {}
-        Object.keys(labware.volumeByWell).forEach(key => {
-          wellFill[key] = liquid?.displayColor ?? COLORS.transparent
-        })
-        labwareWellFill = { ...labwareWellFill, ...wellFill }
-      }
-    })
-  })
-  return labwareWellFill
-}
-
 export function getDisabledWellFillFromLabwareId(
   labwareId: string,
   liquidsInLoadOrder: Liquid[],

--- a/components/src/organisms/ProtocolDeck/index.tsx
+++ b/components/src/organisms/ProtocolDeck/index.tsx
@@ -68,7 +68,8 @@ export function ProtocolDeck(props: ProtocolDeckProps): JSX.Element | null {
             ? getWellFillFromLabwareId(
                 topLabwareInfo.labwareId,
                 protocolAnalysis.liquids,
-                labwareByLiquidId
+                labwareByLiquidId,
+                protocolAnalysis.commands
               )
             : undefined,
       }
@@ -90,7 +91,8 @@ export function ProtocolDeck(props: ProtocolDeckProps): JSX.Element | null {
           wellFill: getWellFillFromLabwareId(
             topLabwareInfo.labwareId,
             protocolAnalysis.liquids,
-            labwareByLiquidId
+            labwareByLiquidId,
+            protocolAnalysis.commands
           ),
         }
       : null

--- a/shared-data/js/helpers/__tests__/getWellFillFromLabwareId.test.ts
+++ b/shared-data/js/helpers/__tests__/getWellFillFromLabwareId.test.ts
@@ -3,7 +3,8 @@ import { describe, expect, it, vi } from 'vitest'
 import { getWellFillFromLabwareId } from '../getWellFillFromLabwareId'
 import { parseLiquidsInLoadOrder } from '../parseProtocolCommands'
 
-import type { LabwareByLiquidId, Liquid } from '@opentrons/shared-data'
+import type { Liquid } from '../../types'
+import type { LabwareByLiquidId } from '../getLabwareInfoByLiquidId'
 
 vi.mock('../parseProtocolCommands')
 

--- a/shared-data/js/helpers/__tests__/getWellFillFromLabwareId.test.ts
+++ b/shared-data/js/helpers/__tests__/getWellFillFromLabwareId.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { getWellFillFromLabwareId } from '../getWellFillFromLabwareId'
+import { parseLiquidsInLoadOrder } from '../parseProtocolCommands'
+
+import type { LabwareByLiquidId, Liquid } from '@opentrons/shared-data'
+
+vi.mock('../parseProtocolCommands')
+
+const LABWARE_ID =
+  '60e8b050-3412-11eb-ad93-ed232a2337cf:opentrons/corning_24_wellplate_3.4ml_flat/1'
+const MOCK_LIQUIDS_IN_LOAD_ORDER: Liquid[] = [
+  {
+    description: 'water',
+    displayColor: '#00d781',
+    displayName: 'liquid 2',
+    id: '7',
+  },
+  {
+    description: 'saline',
+    displayColor: '#0076ff',
+    displayName: 'liquid 1',
+    id: '123',
+  },
+  {
+    description: 'reagent',
+    displayColor: '#ff4888',
+    displayName: 'liquid 3',
+    id: '19',
+  },
+  {
+    description: 'saliva',
+    displayColor: '#B925FF',
+    displayName: 'liquid 4',
+    id: '4',
+  },
+]
+const MOCK_LABWARE_BY_LIQUID_ID: LabwareByLiquidId = {
+  '4': [
+    {
+      labwareId:
+        '60e8b050-3412-11eb-ad93-ed232a2337cf:opentrons/corning_24_wellplate_3.4ml_flat/1',
+      volumeByWell: {
+        A3: 100,
+        A4: 100,
+        B3: 100,
+        B4: 100,
+        C3: 100,
+        C4: 100,
+        D3: 100,
+        D4: 100,
+      },
+    },
+  ],
+  '7': [
+    {
+      labwareId:
+        '60e8b050-3412-11eb-ad93-ed232a2337cf:opentrons/corning_24_wellplate_3.4ml_flat/1',
+      volumeByWell: {
+        A1: 100,
+        A2: 100,
+        B1: 100,
+        B2: 100,
+        C1: 100,
+        C2: 100,
+        D1: 100,
+        D2: 100,
+      },
+    },
+    {
+      labwareId: '53d3b350-a9c0-11eb-bce6-9f1d5b9c1a1b',
+      volumeByWell: {
+        A3: 50,
+        B1: 50,
+        C1: 50,
+        D1: 50,
+      },
+    },
+  ],
+  '19': [
+    {
+      labwareId:
+        '60e8b050-3412-11eb-ad93-ed232a2337cf:opentrons/corning_24_wellplate_3.4ml_flat/1',
+      volumeByWell: {
+        A5: 100,
+        A6: 100,
+        B5: 100,
+        B6: 100,
+        C5: 100,
+        C6: 100,
+        D5: 100,
+        D6: 100,
+      },
+    },
+  ],
+  '123': [
+    {
+      labwareId:
+        '5ae317e0-3412-11eb-ad93-ed232a2337cf:opentrons/nest_1_reservoir_195ml/1',
+      volumeByWell: {
+        A1: 1000,
+      },
+    },
+  ],
+}
+
+describe('getWellFillFromLabwareId', () => {
+  it('returns wellfill object for the labwareId', () => {
+    const expected = {
+      A1: '#00d781',
+      A2: '#00d781',
+      A3: '#B925FF',
+      A4: '#B925FF',
+      A5: '#ff4888',
+      A6: '#ff4888',
+      B1: '#00d781',
+      B2: '#00d781',
+      B3: '#B925FF',
+      B4: '#B925FF',
+      B5: '#ff4888',
+      B6: '#ff4888',
+      C1: '#00d781',
+      C2: '#00d781',
+      C3: '#B925FF',
+      C4: '#B925FF',
+      C5: '#ff4888',
+      C6: '#ff4888',
+      D1: '#00d781',
+      D2: '#00d781',
+      D3: '#B925FF',
+      D4: '#B925FF',
+      D5: '#ff4888',
+      D6: '#ff4888',
+    }
+    vi.mocked(parseLiquidsInLoadOrder).mockReturnValue(
+      MOCK_LIQUIDS_IN_LOAD_ORDER as any
+    )
+    expect(
+      getWellFillFromLabwareId(LABWARE_ID, [], MOCK_LABWARE_BY_LIQUID_ID, [])
+    ).toEqual(expected)
+  })
+})

--- a/shared-data/js/helpers/getWellFillFromLabwareId.ts
+++ b/shared-data/js/helpers/getWellFillFromLabwareId.ts
@@ -1,3 +1,6 @@
+import { parseLiquidsInLoadOrder } from './parseProtocolCommands'
+
+import type { RunTimeCommand } from '../../protocol'
 import type { Liquid } from '../types'
 import type { LabwareByLiquidId } from './getLabwareInfoByLiquidId'
 
@@ -5,10 +8,12 @@ export type WellFill = Record<string, string>
 
 export function getWellFillFromLabwareId(
   labwareId: string,
-  liquidsInLoadOrder: Liquid[],
-  labwareByLiquidId: LabwareByLiquidId
+  liquids: Liquid[],
+  labwareByLiquidId: LabwareByLiquidId,
+  commands: RunTimeCommand[]
 ): WellFill {
   let labwareWellFill: WellFill = {}
+  const liquidsInLoadOrder = parseLiquidsInLoadOrder(liquids, commands)
   const liquidIds = Object.keys(labwareByLiquidId)
   const labwareInfo = Object.values(labwareByLiquidId)
 


### PR DESCRIPTION
Fix [RABR-813](https://opentrons.atlassian.net/browse/RABR-813)
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
In the liquids modal for run setup we assign a color based on load order to liquids that don't have one when passed in. This same assignment wasn't happening in certain deck maps, so the liquids here would be black but then would have a color when you clicked into the modal.
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
Create a protocol with liquids but don't assign the liquids a color. See that in both protocol deck maps, run setup, and liquid modals, the liquids have a persistent assigned color.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->
<img width="843" height="608" alt="Screenshot 2025-09-11 at 11 57 08 AM" src="https://github.com/user-attachments/assets/9cc419b4-dfdd-4f68-9128-be9f8dce8e2d" />
<img width="885" height="640" alt="Screenshot 2025-09-11 at 11 57 03 AM" src="https://github.com/user-attachments/assets/70eb95b8-afa8-41c2-b1d4-fa55e2ddfbfe" />
<img width="937" height="769" alt="Screenshot 2025-09-11 at 11 21 15 AM" src="https://github.com/user-attachments/assets/f5d093e4-f9d9-4da1-851c-9831893fb379" />

## Changelog
The utility `getWellFillFromLabwareId` was relying on the input from another util, `parseLiquidsInLoadOrder` being passed in, but most often we were just passing in the analysis liquids. I refactored `getWellFillFromLabwareId` to call `parseLiquidsInLoadOrder` itself to eliminate this discrepancy. I also noticed there was a duplicate `getWellFillFromLabwareId` in the app directory that wasn't being used. I removed this and move it's test to the shared-data version.

<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests
Verify fix
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
Low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RABR-813]: https://opentrons.atlassian.net/browse/RABR-813?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ