### PR TITLE
feat(api): python API binding for tasks

### DIFF
--- a/api/docs/v2/new_protocol_api.rst
+++ b/api/docs/v2/new_protocol_api.rst
@@ -16,7 +16,7 @@ Protocols
    :members:
    :exclude-members: location_cache, cleanup, clear_commands
 
-.. autoclass:: opentrons.protocol_api.Tasks
+.. autoclass:: opentrons.protocol_api.tasks
    :members:
 
 Instruments

--- a/api/docs/v2/new_protocol_api.rst
+++ b/api/docs/v2/new_protocol_api.rst
@@ -16,6 +16,9 @@ Protocols
    :members:
    :exclude-members: location_cache, cleanup, clear_commands
 
+.. autoclass:: opentrons.protocol_api.Tasks
+   :members:
+
 Instruments
 ===========
 .. autoclass:: opentrons.protocol_api.InstrumentContext

--- a/api/src/opentrons/protocol_api/__init__.py
+++ b/api/src/opentrons/protocol_api/__init__.py
@@ -30,6 +30,7 @@ from .module_contexts import (
     AbsorbanceReaderContext,
     FlexStackerContext,
 )
+from .tasks import Task
 from .disposal_locations import TrashBin, WasteChute
 from ._liquid import Liquid, LiquidClass
 from ._types import (
@@ -101,6 +102,8 @@ __all__ = [
     "BLOWOUT_ACTION",
     "RuntimeParameterRequiredError",
     "CSVParameter",
+    # Concurrent task types
+    "Task",
     # For internal Opentrons use only:
     "create_protocol_context",
     "ProtocolEngineCoreRequiredError",

--- a/api/src/opentrons/protocol_api/core/common.py
+++ b/api/src/opentrons/protocol_api/core/common.py
@@ -16,6 +16,7 @@ from .module import (
 from .protocol import AbstractProtocol
 from .well import AbstractWellCore
 from .robot import AbstractRobot
+from .tasks import AbstractTaskCore
 
 
 WellCore = AbstractWellCore
@@ -31,3 +32,4 @@ AbsorbanceReaderCore = AbstractAbsorbanceReaderCore[LabwareCore]
 FlexStackerCore = AbstractFlexStackerCore[LabwareCore]
 RobotCore = AbstractRobot
 ProtocolCore = AbstractProtocol[InstrumentCore, LabwareCore, ModuleCore]
+TaskCore = AbstractTaskCore

--- a/api/src/opentrons/protocol_api/core/engine/tasks.py
+++ b/api/src/opentrons/protocol_api/core/engine/tasks.py
@@ -1,0 +1,35 @@
+from datetime import datetime
+from ..tasks import AbstractTaskCore
+from opentrons.protocol_engine.clients import SyncClient as ProtocolEngineClient
+from opentrons.protocol_engine.errors.exceptions import NoTaskFoundError
+
+
+class EngineTaskCore(AbstractTaskCore):
+    def __init__(self, id: str, engine_client: ProtocolEngineClient) -> None:
+        self._id = id
+        self._engine_client = engine_client
+
+    def get_created_at_timestamp(self) -> datetime:
+        task = self._engine_client.state.tasks.get(self._id)
+        return task.createdAt
+
+    def is_done(self) -> bool:
+        try:
+            self._engine_client.state.tasks.get_finished(self._id)
+            return True
+        except NoTaskFoundError:
+            return False
+
+    def is_started(self) -> bool:
+        try:
+            self._engine_client.state.tasks.get_current(self._id)
+            return True
+        except NoTaskFoundError:
+            return self.is_done()
+
+    def get_finished_at_timestamp(self) -> datetime | None:
+        try:
+            finished_task = self._engine_client.state.tasks.get_finished(self._id)
+            return finished_task.finishedAt
+        except NoTaskFoundError:
+            return None

--- a/api/src/opentrons/protocol_api/core/legacy/tasks.py
+++ b/api/src/opentrons/protocol_api/core/legacy/tasks.py
@@ -1,0 +1,19 @@
+from ..tasks import AbstractTaskCore
+from datetime import datetime
+
+
+class LegacyTaskCore(AbstractTaskCore):
+    def __init__(self, created_at: datetime) -> None:
+        raise NotImplementedError("Legacy protocols do not implement tasks.")
+
+    def get_created_at_timestamp(self) -> datetime:
+        raise NotImplementedError("Legacy protocols do not implement tasks.")
+
+    def is_done(self) -> bool:
+        raise NotImplementedError("Legacy protocols do not implement tasks.")
+
+    def is_started(self) -> bool:
+        raise NotImplementedError("Legacy protocols do not implement tasks.")
+
+    def get_finished_at_timestamp(self) -> datetime | None:
+        raise NotImplementedError("Legacy protocols do not implement tasks.")

--- a/api/src/opentrons/protocol_api/core/legacy_simulator/tasks.py
+++ b/api/src/opentrons/protocol_api/core/legacy_simulator/tasks.py
@@ -8,12 +8,12 @@ class LegacyTaskCore(AbstractTaskCore):
 
     def get_created_at_timestamp(self) -> datetime:
         raise NotImplementedError("Legacy protocols do not implement tasks.")
-    
+
     def is_done(self) -> bool:
         raise NotImplementedError("Legacy protocols do not implement tasks.")
-    
+
     def is_started(self) -> bool:
         raise NotImplementedError("Legacy protocols do not implement tasks.")
-    
+
     def get_finished_at_timestamp(self) -> datetime | None:
         raise NotImplementedError("Legacy protocols do not implement tasks.")

--- a/api/src/opentrons/protocol_api/core/legacy_simulator/tasks.py
+++ b/api/src/opentrons/protocol_api/core/legacy_simulator/tasks.py
@@ -1,0 +1,19 @@
+from ..tasks import AbstractTaskCore
+from datetime import datetime
+
+
+class LegacyTaskCore(AbstractTaskCore):
+    def __init__(self, created_at: datetime) -> None:
+        raise NotImplementedError("Legacy protocols do not implement tasks.")
+
+    def get_created_at_timestamp(self) -> datetime:
+        raise NotImplementedError("Legacy protocols do not implement tasks.")
+    
+    def is_done(self) -> bool:
+        raise NotImplementedError("Legacy protocols do not implement tasks.")
+    
+    def is_started(self) -> bool:
+        raise NotImplementedError("Legacy protocols do not implement tasks.")
+    
+    def get_finished_at_timestamp(self) -> datetime | None:
+        raise NotImplementedError("Legacy protocols do not implement tasks.")

--- a/api/src/opentrons/protocol_api/core/tasks.py
+++ b/api/src/opentrons/protocol_api/core/tasks.py
@@ -1,0 +1,24 @@
+from abc import abstractmethod, ABC
+from datetime import datetime
+
+
+class AbstractTaskCore(ABC):
+    @abstractmethod
+    def get_created_at_timestamp(self) -> datetime:
+        """Get the createdAt timestamp of the task."""
+        ...
+
+    @abstractmethod
+    def is_done(self) -> bool:
+        """Return whether the task is done."""
+        ...
+
+    @abstractmethod
+    def is_started(self) -> bool:
+        """Return whether the task has started."""
+        ...
+
+    @abstractmethod
+    def get_finished_at_timestamp(self) -> datetime | None:
+        """Get the finishedAt timestamp of the task, or None if not finished."""
+        ...

--- a/api/src/opentrons/protocol_api/tasks.py
+++ b/api/src/opentrons/protocol_api/tasks.py
@@ -1,0 +1,45 @@
+"""Data for concurrent protocol tasks."""
+from typing import TYPE_CHECKING
+from datetime import datetime
+from opentrons.protocols.api_support.util import requires_version
+from opentrons.protocols.api_support.types import APIVersion
+
+if TYPE_CHECKING:
+    from .core.common import TaskCore
+
+
+class Task:
+    """A concurrent protocol task created by a protocol api function.
+
+    .. versionadded:: 2.27
+    """
+
+    def __init__(self, core: "TaskCore", api_version: APIVersion) -> None:
+        """Initialize a Task."""
+        self._core = core
+        self._api_version = api_version
+
+    @property
+    @requires_version(2, 27)
+    def created_at(self) -> datetime:
+        """The timestamp of when the task was created."""
+        return self._core.get_created_at_timestamp()
+
+    @property
+    @requires_version(2, 27)
+    def done(self) -> bool:
+        """Whether the task is done."""
+        return self._core.is_done()
+
+    @property
+    @requires_version(2, 27)
+    def started(self) -> bool:
+        """Whether the task has started."""
+        return self._core.is_started()
+        ...
+
+    @property
+    @requires_version(2, 27)
+    def finished_at(self) -> datetime | None:
+        """The timestamp of the when the task is finished, none if not finished."""
+        return self._core.get_finished_at_timestamp()

--- a/api/src/opentrons/protocols/api_support/definitions.py
+++ b/api/src/opentrons/protocols/api_support/definitions.py
@@ -1,6 +1,6 @@
 from .types import APIVersion
 
-MAX_SUPPORTED_VERSION = APIVersion(2, 26)
+MAX_SUPPORTED_VERSION = APIVersion(2, 27)
 """The maximum supported protocol API version in this release."""
 
 MIN_SUPPORTED_VERSION = APIVersion(2, 0)

--- a/api/tests/opentrons/protocol_api/core/engine/test_tasks.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_tasks.py
@@ -1,0 +1,46 @@
+"""Test engine task core."""
+from decoy import Decoy, matchers
+import pytest
+from opentrons.protocol_engine.clients import SyncClient as EngineClient
+
+
+@pytest.fixture
+def mock_engine_client(decoy: Decoy) -> EngineClient:
+    """Get a mock ProtocolEngine synchronous client."""
+    return decoy.mock(cls=EngineClient)
+
+
+def test_get_created_at_timestamp(
+    decoy: Decoy, mock_engine_client: EngineClient
+) -> None:
+    """It should get the created at timestamp from the engine."""
+    task_id = "some-id"
+    decoy.when(mock_engine_client.state.tasks.get(task_id)).then_return(
+        matchers.Anything()
+    )
+
+
+def test_is_done(decoy: Decoy, mock_engine_client: EngineClient) -> None:
+    """It should get whether the task is done from the engine."""
+    task_id = "some-id"
+    decoy.when(mock_engine_client.state.tasks.get_finished(task_id)).then_return(
+        matchers.Anything()
+    )
+
+
+def test_is_started(decoy: Decoy, mock_engine_client: EngineClient) -> None:
+    """It should get whether the task is started from the engine."""
+    task_id = "some-id"
+    decoy.when(mock_engine_client.state.tasks.get_current(task_id)).then_return(
+        matchers.Anything()
+    )
+
+
+def test_get_finished_at_timestamp(
+    decoy: Decoy, mock_engine_client: EngineClient
+) -> None:
+    """It should get the finished at timestamp from the engine."""
+    task_id = "some-id"
+    decoy.when(mock_engine_client.state.tasks.get_finished(task_id)).then_return(
+        matchers.Anything()
+    )


### PR DESCRIPTION
# Overview

Creates python API binding for tasks.

This allows users to view results (created/finished timestamps, if it is running or finished) of a task.
`NOTE` API level 2.27 gates the use of concurrent tasks.

Closes EXEC-1681