### PR TITLE
fix(app): display 96 channel cam in robot context

### DIFF
--- a/app/src/assets/localization/en/protocol_command_text.json
+++ b/app/src/assets/localization/en/protocol_command_text.json
@@ -70,6 +70,7 @@
   "move_to_slot": "Moving to Slot {{slot_name}}",
   "move_to_well": "Moving to X {{xOffset}} Y {{yOffset}} Z {{zOffset}} relative to {{positionRelative}} of well {{wellName}} of {{labware}} in {{displayLocation}}",
   "multiple": "multiple",
+  "ninety_six_channel_cam": "pipette tip attach cam",
   "notes": "notes",
   "off_deck": "off deck",
   "offdeck": "offdeck",

--- a/components/src/assets/localization/en/protocol_command_text.json
+++ b/components/src/assets/localization/en/protocol_command_text.json
@@ -69,6 +69,7 @@
   "move_to_coordinates": "Moving to (X: {{x}}, Y: {{y}}, Z: {{z}})",
   "move_to_slot": "Moving to Slot {{slot_name}}",
   "move_to_well": "Moving to X {{xOffset}} Y {{yOffset}} Z {{zOffset}} relative to {{positionRelative}} of well {{wellName}} of {{labware}} in {{displayLocation}}",
+  "ninety_six_channel_cam": "pipette tip attach cam",
   "multiple": "multiple",
   "notes": "notes",
   "off_deck": "off deck",

--- a/components/src/organisms/CommandText/useCommandTextString/utils/commandText/__tests__/getRobotCommandText.test.tsx
+++ b/components/src/organisms/CommandText/useCommandTextString/utils/commandText/__tests__/getRobotCommandText.test.tsx
@@ -56,11 +56,12 @@ describe('getRobotCommandText', () => {
           leftPlunger: 6,
           rightPlunger: 7,
           extensionJaw: 8,
+          axis96ChannelCam: 9,
         },
       },
     })
     screen.getByText(
-      'Moving robot to (X: 1, Y: 2, left Z: 3, right Z: 4, extension Z: 5, left plunger: 6, right plunger: 7, extension jaw: 8)'
+      'Moving robot to (X: 1, Y: 2, left Z: 3, right Z: 4, extension Z: 5, left plunger: 6, right plunger: 7, extension jaw: 8, pipette tip attach cam: 9)'
     )
   })
   it('should render moveAxesTo with not all axes', () => {
@@ -92,11 +93,12 @@ describe('getRobotCommandText', () => {
           leftPlunger: 6,
           rightPlunger: 7,
           extensionJaw: 8,
+          axis96ChannelCam: 9,
         },
       },
     })
     screen.getByText(
-      'Moving robot by (X: 1, Y: 2, left Z: 3, right Z: 4, extension Z: 5, left plunger: 6, right plunger: 7, extension jaw: 8)'
+      'Moving robot by (X: 1, Y: 2, left Z: 3, right Z: 4, extension Z: 5, left plunger: 6, right plunger: 7, extension jaw: 8, pipette tip attach cam: 9)'
     )
   })
   it('should render moveAxesRelative with not all axes', () => {

--- a/components/src/organisms/CommandText/useCommandTextString/utils/commandText/getRobotCommandText.ts
+++ b/components/src/organisms/CommandText/useCommandTextString/utils/commandText/getRobotCommandText.ts
@@ -22,6 +22,7 @@ const formatAxisMap = (axisMap: RobotMotorAxisMap, t: TFunction): string => {
     'leftPlunger',
     'rightPlunger',
     'extensionJaw',
+    'axis96ChannelCam',
   ] as const
   const names: Record<MotorAxis, string> = {
     x: 'X',
@@ -32,6 +33,7 @@ const formatAxisMap = (axisMap: RobotMotorAxisMap, t: TFunction): string => {
     rightPlunger: t('right_plunger'),
     extensionZ: t('extension_z'),
     extensionJaw: t('extension_jaw'),
+    axis96ChannelCam: t('ninety_six_channel_cam'),
   }
   const coordinateStr = sortedAxes
     .map(axis => {

--- a/protocol-designer/src/assets/localization/en/protocol_command_text.json
+++ b/protocol-designer/src/assets/localization/en/protocol_command_text.json
@@ -70,6 +70,7 @@
   "move_to_slot": "Moving to Slot {{slot_name}}",
   "move_to_well": "Moving to X {{xOffset}} Y {{yOffset}} Z {{zOffset}} relative to {{positionRelative}} of well {{wellName}} of {{labware}} in {{displayLocation}}",
   "multiple": "multiple",
+  "ninety_six_channel_cam": "pipette tip attach cam",
   "notes": "notes",
   "off_deck": "off deck",
   "offdeck": "offdeck",

--- a/shared-data/js/types.ts
+++ b/shared-data/js/types.ts
@@ -1076,6 +1076,7 @@ export type MotorAxis =
   | 'rightPlunger'
   | 'extensionZ'
   | 'extensionJaw'
+  | 'axis96ChannelCam'
 
 export type MotorAxes = MotorAxis[]
 


### PR DESCRIPTION
It's not called Q it's called axis96ChannelCam, and also it needs to be in some other types.

<img width="357" height="130" alt="Screenshot 2025-09-11 at 3 40 44 PM" src="https://github.com/user-attachments/assets/ffacdf79-551e-4a5a-975c-ba9f4cc0bd49" />


Closes RQA-4571
