### PR TITLE
fix(hardware-testing): update for module build changes

### DIFF
--- a/.github/workflows/hardware-testing.yaml
+++ b/.github/workflows/hardware-testing.yaml
@@ -23,6 +23,9 @@ on:
     paths:
       - 'Makefile'
       - 'hardware-testing/**'
+      - 'api/**'
+      - 'hardware/**'
+      - 'shared-data/**'
       - '.github/workflows/hardware-testing.yaml'
       - '.github/actions/python/**'
 

--- a/hardware-testing/hardware_testing/gravimetric/protocol_replacement/gravimetric.py
+++ b/hardware-testing/hardware_testing/gravimetric/protocol_replacement/gravimetric.py
@@ -36,7 +36,7 @@ from opentrons.protocol_api._nozzle_layout import NozzleLayout
 from opentrons.protocols.advanced_control.transfers import common as tx_ctl_lib
 
 metadata = {"protocolName": "Gravimetric QC"}
-requirements = {"robotType": "Flex", "apiLevel": "2.26"}
+requirements = {"robotType": "Flex", "apiLevel": "2.27"}
 
 SCALE_SECONDS_TO_TRUE_STABILIZE = 60 * 3
 

--- a/hardware-testing/hardware_testing/modules/flex_stacker/flex_stacker_cycle_qc/__main__.py
+++ b/hardware-testing/hardware_testing/modules/flex_stacker/flex_stacker_cycle_qc/__main__.py
@@ -1,4 +1,5 @@
 """FLEX Stacker Cycle QC Test."""
+
 from os import environ
 from serial.tools.list_ports import comports  # type: ignore[import]
 
@@ -13,6 +14,7 @@ from hardware_testing.data.csv_report import CSVReport
 
 from .config import TestSection, TestConfig, build_report, TESTS
 from opentrons.hardware_control.modules import FlexStacker
+from opentrons.hardware_control.execution_manager import ExecutionManager
 from opentrons.drivers.rpi_drivers.types import USBPort
 
 STACKER_VID = 0x483
@@ -38,6 +40,9 @@ async def build_stacker_report(
         usb_port=USBPort(port, 0),
         hw_control_loop=asyncio.get_running_loop(),
         simulating=is_simulating,
+        execution_manager=ExecutionManager(),
+        disconnected_callback=lambda *args: None,
+        error_callback=lambda *args: None,
     )
 
     report = build_report(test_name)

--- a/hardware-testing/hardware_testing/modules/flex_stacker/flex_stacker_qc/__main__.py
+++ b/hardware-testing/hardware_testing/modules/flex_stacker/flex_stacker_qc/__main__.py
@@ -1,4 +1,5 @@
 """FLEX Stacker QC."""
+
 from os import environ
 
 # NOTE: this is required to get WIFI test to work
@@ -16,6 +17,7 @@ from hardware_testing.data.csv_report import CSVReport
 
 from .config import TestSection, TestConfig, build_report, TESTS
 from .utils import find_stacker_port, get_estop
+from opentrons.hardware_control.execution_manager import ExecutionManager
 from opentrons.drivers.rpi_drivers.types import USBPort
 from opentrons.hardware_control.modules.flex_stacker import FlexStacker
 
@@ -34,6 +36,9 @@ async def build_stacker_report(
         hw_control_loop=asyncio.get_running_loop(),
         simulating=is_simulating,
         sim_serial_number="FLEX1234" if is_simulating else None,
+        execution_manager=ExecutionManager(),
+        disconnected_callback=lambda *args: None,
+        error_callback=lambda *args: None,
     )
     report = build_report(test_name)
     report.set_operator(


### PR DESCRIPTION
6d4aaada2016372ccbc4723b19e52194b0c913cb added some extra mandatory arguments to module building, which I forgot to add to hardware testing usages.

Also, we weren't checking the hardware testing lint on PRs, only on push, which is a bit of a case of closing the barn door after the horse left (rip Haru Urara)
