### PR TITLE
feat(api): add ramp rate arguments to hc layer

### DIFF
--- a/api/src/opentrons/drivers/thermocycler/abstract.py
+++ b/api/src/opentrons/drivers/thermocycler/abstract.py
@@ -55,6 +55,7 @@ class AbstractThermocyclerDriver(ABC):
         temp: float,
         hold_time: Optional[float] = None,
         volume: Optional[float] = None,
+        ramp_rate: Optional[float] = None,
     ) -> None:
         """Send set plate temperature command"""
         ...

--- a/api/src/opentrons/drivers/thermocycler/driver.py
+++ b/api/src/opentrons/drivers/thermocycler/driver.py
@@ -226,6 +226,7 @@ class ThermocyclerDriver(AbstractThermocyclerDriver):
         temp: float,
         hold_time: Optional[float] = None,
         volume: Optional[float] = None,
+        ramp_rate: Optional[float] = None,
     ) -> None:
         """Send set plate temperature command"""
         temp = min(BLOCK_TARGET_MAX, max(BLOCK_TARGET_MIN, temp))

--- a/api/src/opentrons/drivers/thermocycler/simulator.py
+++ b/api/src/opentrons/drivers/thermocycler/simulator.py
@@ -72,6 +72,7 @@ class SimulatingDriver(AbstractThermocyclerDriver):
         self._plate_temperature.target = temp
         self._plate_temperature.current = temp
         self._plate_temperature.hold = 0
+        self._ramp_rate = ramp_rate
 
     @ensure_yield
     async def get_plate_temperature(self) -> PlateTemperature:

--- a/api/src/opentrons/drivers/thermocycler/simulator.py
+++ b/api/src/opentrons/drivers/thermocycler/simulator.py
@@ -67,6 +67,7 @@ class SimulatingDriver(AbstractThermocyclerDriver):
         temp: float,
         hold_time: Optional[float] = None,
         volume: Optional[float] = None,
+        ramp_rate: Optional[float] = None,
     ) -> None:
         self._plate_temperature.target = temp
         self._plate_temperature.current = temp

--- a/api/src/opentrons/hardware_control/modules/thermocycler.py
+++ b/api/src/opentrons/hardware_control/modules/thermocycler.py
@@ -320,11 +320,8 @@ class Thermocycler(mod_abc.AbstractModule):
         total_seconds = seconds + (minutes * 60)
         hold_time = total_seconds if total_seconds > 0 else 0
 
-        if ramp_rate is not None:
-            await self._driver.set_ramp_rate(ramp_rate=ramp_rate)
-
         await self._driver.set_plate_temperature(
-            temp=temperature, hold_time=hold_time, volume=volume
+            temp=temperature, hold_time=hold_time, volume=volume, ramp_rate=ramp_rate
         )
 
         task = self._loop.create_task(self._wait_for_block_target())
@@ -437,10 +434,12 @@ class Thermocycler(mod_abc.AbstractModule):
             celsius: The target block temperature, in degrees celsius.
         """
         await self.wait_for_is_running()
+
         await self._driver.set_plate_temperature(
             temp=celsius,
             hold_time=hold_time_seconds,
             volume=volume,
+            ramp_rate=ramp_rate,
         )
         await self._reader.read_block_temperature()
 
@@ -605,11 +604,12 @@ class Thermocycler(mod_abc.AbstractModule):
         temperature = step.get("temperature")
         hold_time_minutes = step.get("hold_time_minutes", None)
         hold_time_seconds = step.get("hold_time_seconds", None)
+        ramp_rate = step.get("ramp_rate", None)
         await self._set_temperature_no_pause(
             temperature=temperature,  # type: ignore
             hold_time_minutes=hold_time_minutes,
             hold_time_seconds=hold_time_seconds,
-            ramp_rate=None,
+            ramp_rate=ramp_rate,
             volume=volume,
         )
 

--- a/api/tests/opentrons/hardware_control/modules/test_hc_thermocycler.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_thermocycler.py
@@ -309,7 +309,19 @@ async def test_set_temperature_with_volume(
 ) -> None:
     """It should call set_plate_temperature with volume param"""
     await set_temperature_subject.set_temperature(30, volume=35)
-    set_plate_temp_spy.assert_called_once_with(temp=30, hold_time=0, volume=35)
+    set_plate_temp_spy.assert_called_once_with(
+        temp=30, hold_time=0, volume=35, ramp_rate=None
+    )
+
+
+async def test_set_temperature_with_ramp_rate(
+    set_temperature_subject: modules.Thermocycler, set_plate_temp_spy: mock.AsyncMock
+) -> None:
+    """It should call set_plate_temperature with volume param"""
+    await set_temperature_subject.set_temperature(30, volume=35, ramp_rate=5.0)
+    set_plate_temp_spy.assert_called_once_with(
+        temp=30, hold_time=0, volume=35, ramp_rate=5.0
+    )
 
 
 async def test_set_temperature_mixed_hold(
@@ -320,7 +332,9 @@ async def test_set_temperature_mixed_hold(
     await set_temperature_subject.set_temperature(
         30, hold_time_seconds=20, hold_time_minutes=1
     )
-    set_plate_temp_spy.assert_called_once_with(temp=30, hold_time=80, volume=None)
+    set_plate_temp_spy.assert_called_once_with(
+        temp=30, hold_time=80, volume=None, ramp_rate=None
+    )
 
 
 async def test_set_temperature_just_seconds_hold(
@@ -329,7 +343,9 @@ async def test_set_temperature_just_seconds_hold(
     """ "It should call set_plate_temperature with total second count computed from
     just seconds."""
     await set_temperature_subject.set_temperature(20, hold_time_seconds=30)
-    set_plate_temp_spy.assert_called_once_with(temp=20, hold_time=30, volume=None)
+    set_plate_temp_spy.assert_called_once_with(
+        temp=20, hold_time=30, volume=None, ramp_rate=None
+    )
 
 
 async def test_set_temperature_just_minutes_hold(
@@ -338,7 +354,9 @@ async def test_set_temperature_just_minutes_hold(
     """ "It should call set_plate_temperature with total second count computed from
     just minutes."""
     await set_temperature_subject.set_temperature(40, hold_time_minutes=5.5)
-    set_plate_temp_spy.assert_called_once_with(temp=40, hold_time=330, volume=None)
+    set_plate_temp_spy.assert_called_once_with(
+        temp=40, hold_time=330, volume=None, ramp_rate=None
+    )
 
 
 async def test_cycle_temperature(
@@ -362,10 +380,10 @@ async def test_cycle_temperature(
     assert (
         set_plate_temp_spy.call_args_list
         == [
-            mock.call(temp=42, hold_time=30, volume=123),
-            mock.call(temp=50, hold_time=60, volume=123),
-            mock.call(temp=60, hold_time=150, volume=123),
-            mock.call(temp=70, hold_time=0, volume=123),
+            mock.call(temp=42, hold_time=30, volume=123, ramp_rate=None),
+            mock.call(temp=50, hold_time=60, volume=123, ramp_rate=None),
+            mock.call(temp=60, hold_time=150, volume=123, ramp_rate=None),
+            mock.call(temp=70, hold_time=0, volume=123, ramp_rate=None),
         ]
         * 5
     )
@@ -397,38 +415,38 @@ async def test_execute_profile(
         volume=123,
     )
     assert set_plate_temp_spy.call_args_list == [
-        mock.call(temp=42, hold_time=30, volume=123),
-        mock.call(temp=20, hold_time=60, volume=123),
-        mock.call(temp=30, hold_time=1, volume=123),
-        mock.call(temp=20, hold_time=60, volume=123),
-        mock.call(temp=30, hold_time=1, volume=123),
-        mock.call(temp=20, hold_time=60, volume=123),
-        mock.call(temp=30, hold_time=1, volume=123),
-        mock.call(temp=20, hold_time=60, volume=123),
-        mock.call(temp=30, hold_time=1, volume=123),
-        mock.call(temp=20, hold_time=60, volume=123),
-        mock.call(temp=30, hold_time=1, volume=123),
-        mock.call(temp=90, hold_time=2, volume=123),
-        mock.call(temp=10, hold_time=120, volume=123),
-        mock.call(temp=20, hold_time=5, volume=123),
-        mock.call(temp=10, hold_time=120, volume=123),
-        mock.call(temp=20, hold_time=5, volume=123),
-        mock.call(temp=10, hold_time=120, volume=123),
-        mock.call(temp=20, hold_time=5, volume=123),
-        mock.call(temp=10, hold_time=120, volume=123),
-        mock.call(temp=20, hold_time=5, volume=123),
-        mock.call(temp=10, hold_time=120, volume=123),
-        mock.call(temp=20, hold_time=5, volume=123),
-        mock.call(temp=10, hold_time=120, volume=123),
-        mock.call(temp=20, hold_time=5, volume=123),
-        mock.call(temp=10, hold_time=120, volume=123),
-        mock.call(temp=20, hold_time=5, volume=123),
-        mock.call(temp=10, hold_time=120, volume=123),
-        mock.call(temp=20, hold_time=5, volume=123),
-        mock.call(temp=10, hold_time=120, volume=123),
-        mock.call(temp=20, hold_time=5, volume=123),
-        mock.call(temp=10, hold_time=120, volume=123),
-        mock.call(temp=20, hold_time=5, volume=123),
+        mock.call(temp=42, hold_time=30, volume=123, ramp_rate=None),
+        mock.call(temp=20, hold_time=60, volume=123, ramp_rate=None),
+        mock.call(temp=30, hold_time=1, volume=123, ramp_rate=None),
+        mock.call(temp=20, hold_time=60, volume=123, ramp_rate=None),
+        mock.call(temp=30, hold_time=1, volume=123, ramp_rate=None),
+        mock.call(temp=20, hold_time=60, volume=123, ramp_rate=None),
+        mock.call(temp=30, hold_time=1, volume=123, ramp_rate=None),
+        mock.call(temp=20, hold_time=60, volume=123, ramp_rate=None),
+        mock.call(temp=30, hold_time=1, volume=123, ramp_rate=None),
+        mock.call(temp=20, hold_time=60, volume=123, ramp_rate=None),
+        mock.call(temp=30, hold_time=1, volume=123, ramp_rate=None),
+        mock.call(temp=90, hold_time=2, volume=123, ramp_rate=None),
+        mock.call(temp=10, hold_time=120, volume=123, ramp_rate=None),
+        mock.call(temp=20, hold_time=5, volume=123, ramp_rate=None),
+        mock.call(temp=10, hold_time=120, volume=123, ramp_rate=None),
+        mock.call(temp=20, hold_time=5, volume=123, ramp_rate=None),
+        mock.call(temp=10, hold_time=120, volume=123, ramp_rate=None),
+        mock.call(temp=20, hold_time=5, volume=123, ramp_rate=None),
+        mock.call(temp=10, hold_time=120, volume=123, ramp_rate=None),
+        mock.call(temp=20, hold_time=5, volume=123, ramp_rate=None),
+        mock.call(temp=10, hold_time=120, volume=123, ramp_rate=None),
+        mock.call(temp=20, hold_time=5, volume=123, ramp_rate=None),
+        mock.call(temp=10, hold_time=120, volume=123, ramp_rate=None),
+        mock.call(temp=20, hold_time=5, volume=123, ramp_rate=None),
+        mock.call(temp=10, hold_time=120, volume=123, ramp_rate=None),
+        mock.call(temp=20, hold_time=5, volume=123, ramp_rate=None),
+        mock.call(temp=10, hold_time=120, volume=123, ramp_rate=None),
+        mock.call(temp=20, hold_time=5, volume=123, ramp_rate=None),
+        mock.call(temp=10, hold_time=120, volume=123, ramp_rate=None),
+        mock.call(temp=20, hold_time=5, volume=123, ramp_rate=None),
+        mock.call(temp=10, hold_time=120, volume=123, ramp_rate=None),
+        mock.call(temp=20, hold_time=5, volume=123, ramp_rate=None),
     ]
 
 


### PR DESCRIPTION


# Overview


Keeping it short and sweet with this one, will implement the driver layer as part of another EXEC ticket.

This just takes the argument passed to the HC layer from the engine layer and connects it through to the drivers.
