### PR TITLE
fix(app): allow the ability to change blowout settings

### DIFF
--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/BlowOut.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/BlowOut.tsx
@@ -244,7 +244,7 @@ export function BlowOut(props: BlowOutProps): JSX.Element {
       numAspirateWells: state.sourceWells.length,
       numDispenseWells: state.destinationWells.length,
       aspirateAirGapByVolume:
-        (retract?.airGapByVolume as Array<[number, number]>) ?? null,
+        (retract?.airGapByVolume as Array<[number, number]>) ?? [],
       conditioningByVolume:
         (correctionByVolume as Array<[number, number]>) ?? null,
       disposalByVolume: null, // note always null because blowout is available only for single dispense


### PR DESCRIPTION
closes AUTH-2271

# Overview

fixes the ability to edit the blow out field.

## Test Plan and Hands on Testing

follow steps in the ticket to repro. should allow you to change the field now

## Changelog

fix the type to be an empty array by default

## Risk assessment

low