### PR TITLE
fix(step-generation): add prepareToAspirate before airGapInPlace dispense 

### DIFF
--- a/app/src/organisms/ODD/QuickTransferFlow/utils/createQuickTransferFile.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/utils/createQuickTransferFile.ts
@@ -48,7 +48,8 @@ export function createQuickTransferFile(
   } = generateQuickTransferArgs(quickTransferState, deckConfig)
   const pipetteEntity = Object.values(invariantContext.pipetteEntities)[0]
   const { name, id, spec } = pipetteEntity
-
+  console.log('quickTransferState', quickTransferState)
+  console.log('stepArgs', stepArgs)
   const loadPipetteCommand: LoadPipetteCreateCommand = {
     key: uuid(),
     commandType: 'loadPipette' as const,
@@ -154,7 +155,7 @@ export function createQuickTransferFile(
     robotStateTimeline.timeline,
     timelineFrame => timelineFrame.commands
   )
-
+  console.log('nonLoadCommands', nonLoadCommands)
   const commands: CreateCommand[] = [
     loadPipetteCommand,
     ...loadAdapterCommands,

--- a/app/src/organisms/ODD/QuickTransferFlow/utils/createQuickTransferFile.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/utils/createQuickTransferFile.ts
@@ -48,8 +48,6 @@ export function createQuickTransferFile(
   } = generateQuickTransferArgs(quickTransferState, deckConfig)
   const pipetteEntity = Object.values(invariantContext.pipetteEntities)[0]
   const { name, id, spec } = pipetteEntity
-  console.log('quickTransferState', quickTransferState)
-  console.log('stepArgs', stepArgs)
   const loadPipetteCommand: LoadPipetteCreateCommand = {
     key: uuid(),
     commandType: 'loadPipette' as const,

--- a/app/src/organisms/ODD/QuickTransferFlow/utils/createQuickTransferFile.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/utils/createQuickTransferFile.ts
@@ -153,7 +153,6 @@ export function createQuickTransferFile(
     robotStateTimeline.timeline,
     timelineFrame => timelineFrame.commands
   )
-  console.log('nonLoadCommands', nonLoadCommands)
   const commands: CreateCommand[] = [
     loadPipetteCommand,
     ...loadAdapterCommands,

--- a/step-generation/src/__tests__/transfer.test.ts
+++ b/step-generation/src/__tests__/transfer.test.ts
@@ -6346,6 +6346,13 @@ mock_pipette.transfer_with_liquid_class(
           },
         },
         {
+          commandType: 'prepareToAspirate',
+          key: expect.any(String),
+          params: {
+            pipetteId: 'p300SingleId',
+          },
+        },
+        {
           commandType: 'airGapInPlace',
           key: expect.any(String),
           params: {
@@ -6520,6 +6527,13 @@ mock_pipette.transfer_with_liquid_class(
             wellLocation: {
               origin: 'top',
             },
+          },
+        },
+        {
+          commandType: 'prepareToAspirate',
+          key: expect.any(String),
+          params: {
+            pipetteId: 'p300SingleId',
           },
         },
         {

--- a/step-generation/src/commandCreators/compound/transfer.ts
+++ b/step-generation/src/commandCreators/compound/transfer.ts
@@ -1000,6 +1000,9 @@ export const transfer: CommandCreator<TransferArgs> = (
                   ...(considerRetractSafety
                     ? preDispenseAirGapMoveToCommand
                     : []),
+                  curryWithoutPython(prepareToAspirate, {
+                    pipetteId: pipette,
+                  }),
                   curryWithoutPython(airGapInPlace, {
                     pipetteId: pipette,
                     volume: dispenseAirGapVol,

--- a/step-generation/src/fixtures/commandFixtures.ts
+++ b/step-generation/src/fixtures/commandFixtures.ts
@@ -584,6 +584,13 @@ export const blowoutInTrashCommands = (args: {
     ...(dispenseAirGap > 0
       ? [
           {
+            commandType: 'prepareToAspirate',
+            key: expect.any(String),
+            params: {
+              pipetteId: 'p300SingleId',
+            },
+          },
+          {
             commandType: 'airGapInPlace',
             key: expect.any(String),
             params: {
@@ -850,6 +857,13 @@ export const dispenseHelperLiquidClass = (params: {
               wellLocation: isRetractSafeForAirGap
                 ? retractLocation
                 : SAFE_MOVE_TO_WELL_LOCATION,
+            },
+          },
+          {
+            commandType: 'prepareToAspirate',
+            key: expect.any(String),
+            params: {
+              pipetteId: 'p300SingleId',
             },
           },
           {


### PR DESCRIPTION
closes AUTH-2272

# Overview

Adds in the missing `prepareToAspirate` command for an air gap in dispense. It only needed to be added in `transfer.ts` because we remembered to to add it for `consolidate` and `distribute`. Also, it didn't need to be added for air gap in aspirate because that that time, we will have aspirated all the liquid so we don't want to prepare to aspirate and lose all the liquid in the tip.

## Test Plan and Hands on Testing

create a protocol in QT and add an air gap to the dispense, make sure its a transfer and not a distribute or consolidate. should no longer see the analysis error

## Changelog

add in the missing prepare to aspirate command and fix tests

## Risk assessment

medium