### PR TITLE
fix(app): increase QT versioning to 1.2.0 for liquid classes

### DIFF
--- a/app/src/organisms/ODD/QuickTransferFlow/utils/createQuickTransferFile.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/utils/createQuickTransferFile.ts
@@ -180,7 +180,7 @@ export function createQuickTransferFile(
     // see QuickTransferFlow/README.md for versioning details
     designerApplication: {
       name: 'opentrons/quick-transfer',
-      version: '1.1.0',
+      version: '1.2.0',
       data: quickTransferState,
     },
   }


### PR DESCRIPTION
closes AUTH-2273

# Overview

we forgot to update the versioning to from `1.1.0` to `1.2.0` which is to include liquid classes - this is purely for internal documentation purposes since there is no way to export a QT protocol from the robot

## Test Plan and Hands on Testing

just review the code 😄 

## Changelog

update the versioning

## Risk assessment

low
