### PR TITLE
feat(api): Enable use of wait_for_tasks() and create_timer() in protocol context 

### DIFF
--- a/api/docs/v2/conf.py
+++ b/api/docs/v2/conf.py
@@ -452,6 +452,6 @@ nitpick_ignore_regex = [
     ("py:class", r".*protocol_api.module_contexts.ModuleContext*"),
     (
         "py:class",
-        r".*AbstractLabware|APIVersion|LabwareLike|LoadedCoreMap|ModuleTypes|NoneType|OffDeckType|ProtocolCore|WellCore",
+        r".*AbstractLabware|APIVersion|LabwareLike|LoadedCoreMap|ModuleTypes|NoneType|OffDeckType|ProtocolCore|TaskCore|WellCore",
     ),  # laundry list of not fully qualified things
 ]

--- a/api/docs/v2/new_protocol_api.rst
+++ b/api/docs/v2/new_protocol_api.rst
@@ -16,7 +16,7 @@ Protocols
    :members:
    :exclude-members: location_cache, cleanup, clear_commands
 
-.. autoclass:: opentrons.protocol_api.tasks
+.. autoclass:: opentrons.protocol_api.Task
    :members:
 
 Instruments

--- a/api/src/opentrons/legacy_commands/protocol_commands.py
+++ b/api/src/opentrons/legacy_commands/protocol_commands.py
@@ -56,7 +56,7 @@ def move_labware(text: str) -> command_types.MoveLabwareCommand:
 
 
 def wait_for_tasks(tasks: list[Task]) -> command_types.WaitForTasksCommand:
-    task_ids = [task._core.id for task in tasks]
+    task_ids = [task._core.get_id() for task in tasks]
     msg = f"Waiting for tasks, {task_ids}."
     return {
         "name": command_types.WAIT_FOR_TASKS,

--- a/api/src/opentrons/legacy_commands/protocol_commands.py
+++ b/api/src/opentrons/legacy_commands/protocol_commands.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 from typing import Optional
 from . import types as command_types
+from opentrons.protocol_api.tasks import Task
 
 
 def comment(msg: str) -> command_types.CommentCommand:
@@ -54,10 +55,12 @@ def move_labware(text: str) -> command_types.MoveLabwareCommand:
     }
 
 
-def wait_for_tasks() -> command_types.WaitForTasksCommand:
+def wait_for_tasks(tasks: list[Task]) -> command_types.WaitForTasksCommand:
+    task_ids = [task._core.id for task in tasks]
+    msg = f"Waiting for tasks, {task_ids}."
     return {
         "name": command_types.WAIT_FOR_TASKS,
-        "payload": {"text": "Waiting for tasks."},
+        "payload": {"text": msg},
     }
 
 

--- a/api/src/opentrons/legacy_commands/protocol_commands.py
+++ b/api/src/opentrons/legacy_commands/protocol_commands.py
@@ -56,8 +56,8 @@ def move_labware(text: str) -> command_types.MoveLabwareCommand:
 
 
 def wait_for_tasks(tasks: list[Task]) -> command_types.WaitForTasksCommand:
-    task_ids = [task.id for task in tasks]
-    msg = f"Waiting for tasks, {task_ids}."
+    task_ids = [task.created_at.strftime("%Y-%m-%d %H:%M:%S") for task in tasks]
+    msg = f"Waiting for tasks that started at: {task_ids}."
     return {
         "name": command_types.WAIT_FOR_TASKS,
         "payload": {"text": msg},

--- a/api/src/opentrons/legacy_commands/protocol_commands.py
+++ b/api/src/opentrons/legacy_commands/protocol_commands.py
@@ -52,3 +52,20 @@ def move_labware(text: str) -> command_types.MoveLabwareCommand:
         "name": command_types.MOVE_LABWARE,
         "payload": {"text": text},
     }
+
+
+def wait_for_tasks() -> command_types.WaitForTasksCommand:
+    return {
+        "name": command_types.WAIT_FOR_TASKS,
+        "payload": {"text": "Waiting for tasks."},
+    }
+
+
+def create_timer(seconds: float) -> command_types.CreateTimerCommand:
+    return {
+        "name": command_types.CREATE_TIMER,
+        "payload": {
+            "text": f"Creating background timer for {seconds} seconds.",
+            "time": seconds,
+        },
+    }

--- a/api/src/opentrons/legacy_commands/protocol_commands.py
+++ b/api/src/opentrons/legacy_commands/protocol_commands.py
@@ -56,7 +56,7 @@ def move_labware(text: str) -> command_types.MoveLabwareCommand:
 
 
 def wait_for_tasks(tasks: list[Task]) -> command_types.WaitForTasksCommand:
-    task_ids = [task._core.get_id() for task in tasks]
+    task_ids = [task.id for task in tasks]
     msg = f"Waiting for tasks, {task_ids}."
     return {
         "name": command_types.WAIT_FOR_TASKS,

--- a/api/src/opentrons/legacy_commands/types.py
+++ b/api/src/opentrons/legacy_commands/types.py
@@ -102,6 +102,10 @@ ROBOT_MOVE_RELATIVE_TO: Final = "command.ROBOT_MOVE_RELATIVE_TO"
 ROBOT_OPEN_GRIPPER_JAW: Final = "command.ROBOT_OPEN_GRIPPER_JAW"
 ROBOT_CLOSE_GRIPPER_JAW: Final = "command.ROBOT_CLOSE_GRIPPER_JAW"
 
+# Tasks #
+WAIT_FOR_TASKS: Final = "command.WAIT_FOR_TASKS"
+CREATE_TIMER: Final = "command.CREATE_TIMER"
+
 
 class TextOnlyPayload(TypedDict):
     text: str
@@ -714,6 +718,27 @@ class RobotCloseGripperJawCommand(TypedDict):
     payload: GripperCommandPayload
 
 
+# Task Commands and Payloads
+
+
+class WaitForTasksPayload(TextOnlyPayload):
+    pass
+
+
+class CreateTimerPayload(TextOnlyPayload):
+    time: float
+
+
+class WaitForTasksCommand(TypedDict):
+    name: Literal["command.WAIT_FOR_TASKS"]
+    payload: WaitForTasksPayload
+
+
+class CreateTimerCommand(TypedDict):
+    name: Literal["command.CREATE_TIMER"]
+    payload: CreateTimerPayload
+
+
 Command = Union[
     DropTipCommand,
     DropTipInDisposalLocationCommand,
@@ -782,6 +807,9 @@ Command = Union[
     FlexStackerStoreCommand,
     FlexStackerEmptyCommand,
     FlexStackerFillCommand,
+    # Task commands
+    WaitForTasksCommand,
+    CreateTimerCommand,
 ]
 
 
@@ -842,6 +870,9 @@ CommandPayload = Union[
     RobotMoveAxisRelativeCommandPayload,
     RobotMoveAxisToCommandPayload,
     GripperCommandPayload,
+    # Task payloads
+    WaitForTasksPayload,
+    CreateTimerPayload,
 ]
 
 
@@ -1124,6 +1155,14 @@ class RobotCloseGripperJawMessage(CommandMessageFields, RobotCloseGripperJawComm
     pass
 
 
+class WaitForTasksMessage(CommandMessageFields, WaitForTasksCommand):
+    pass
+
+
+class CreateTimerMessage(CommandMessageFields, CreateTimerCommand):
+    pass
+
+
 CommandMessage = Union[
     DropTipMessage,
     DropTipInDisposalLocationMessage,
@@ -1183,4 +1222,7 @@ CommandMessage = Union[
     FlexStackerStoreMessage,
     FlexStackerEmptyMessage,
     FlexStackerFillMessage,
+    # Task Messages
+    WaitForTasksMessage,
+    CreateTimerMessage,
 ]

--- a/api/src/opentrons/protocol_api/core/common.py
+++ b/api/src/opentrons/protocol_api/core/common.py
@@ -31,5 +31,5 @@ MagneticBlockCore = AbstractMagneticBlockCore[LabwareCore]
 AbsorbanceReaderCore = AbstractAbsorbanceReaderCore[LabwareCore]
 FlexStackerCore = AbstractFlexStackerCore[LabwareCore]
 RobotCore = AbstractRobot
-ProtocolCore = AbstractProtocol[InstrumentCore, LabwareCore, ModuleCore]
 TaskCore = AbstractTaskCore
+ProtocolCore = AbstractProtocol[InstrumentCore, LabwareCore, ModuleCore, TaskCore]

--- a/api/src/opentrons/protocol_api/core/engine/protocol.py
+++ b/api/src/opentrons/protocol_api/core/engine/protocol.py
@@ -1,7 +1,7 @@
 """ProtocolEngine-based Protocol API core implementation."""
 
 from __future__ import annotations
-from typing import Dict, Optional, Type, Union, List, Tuple, TYPE_CHECKING
+from typing import Dict, Optional, Type, Union, List, Tuple, TYPE_CHECKING, Sequence
 
 from opentrons_shared_data.liquid_classes import LiquidClassDefinitionDoesNotExist
 from opentrons_shared_data.deck.types import DeckDefinitionV5, SlotDefV3
@@ -64,6 +64,7 @@ from ...disposal_locations import TrashBin, WasteChute
 from ..protocol import AbstractProtocol
 from ..labware import LabwareLoadParams
 from .labware import LabwareCore
+from .tasks import EngineTaskCore
 from .instrument import InstrumentCore
 from .robot import RobotCore
 from .module_core import (
@@ -95,6 +96,7 @@ class ProtocolCore(
         InstrumentCore,
         LabwareCore,
         Union[ModuleCore, NonConnectedModuleCore],
+        EngineTaskCore,
     ]
 ):
     """Protocol API core using a ProtocolEngine.
@@ -874,6 +876,21 @@ class ProtocolCore(
         self._engine_client.execute_command(
             cmd.WaitForDurationParams(seconds=seconds, message=msg)
         )
+
+    def wait_for_tasks(self, task_cores: Sequence[EngineTaskCore]) -> None:
+        """Wait for specified tasks to complete."""
+        task_ids = [task._id for task in task_cores]
+        self._engine_client.execute_command(cmd.WaitForTasksParams(task_ids=task_ids))
+
+    def create_timer(self, seconds: float) -> EngineTaskCore:
+        """Create a timer task that runs in the background."""
+        result = self._engine_client.execute_command_without_recovery(
+            cmd.CreateTimerParams(time=seconds)
+        )
+        timer_task = EngineTaskCore(
+            engine_client=self._engine_client, task_id=result.task_id
+        )
+        return timer_task
 
     def home(self) -> None:
         """Move all axes to their home positions."""

--- a/api/src/opentrons/protocol_api/core/engine/tasks.py
+++ b/api/src/opentrons/protocol_api/core/engine/tasks.py
@@ -5,8 +5,8 @@ from opentrons.protocol_engine.errors.exceptions import NoTaskFoundError
 
 
 class EngineTaskCore(AbstractTaskCore):
-    def __init__(self, id: str, engine_client: ProtocolEngineClient) -> None:
-        self._id = id
+    def __init__(self, task_id: str, engine_client: ProtocolEngineClient) -> None:
+        self._id = task_id
         self._engine_client = engine_client
 
     def get_created_at_timestamp(self) -> datetime:

--- a/api/src/opentrons/protocol_api/core/engine/tasks.py
+++ b/api/src/opentrons/protocol_api/core/engine/tasks.py
@@ -9,6 +9,9 @@ class EngineTaskCore(AbstractTaskCore):
         self._id = task_id
         self._engine_client = engine_client
 
+    def get_id(self) -> str:
+        return self._id
+
     def get_created_at_timestamp(self) -> datetime:
         task = self._engine_client.state.tasks.get(self._id)
         return task.createdAt

--- a/api/src/opentrons/protocol_api/core/engine/tasks.py
+++ b/api/src/opentrons/protocol_api/core/engine/tasks.py
@@ -9,9 +9,6 @@ class EngineTaskCore(AbstractTaskCore):
         self._id = task_id
         self._engine_client = engine_client
 
-    def get_id(self) -> str:
-        return self._id
-
     def get_created_at_timestamp(self) -> datetime:
         task = self._engine_client.state.tasks.get(self._id)
         return task.createdAt

--- a/api/src/opentrons/protocol_api/core/legacy/legacy_protocol_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy/legacy_protocol_core.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict, List, Optional, Set, Union, cast, Tuple
+from typing import Dict, List, Optional, Set, Union, cast, Tuple, Sequence
 
 from opentrons_shared_data.deck.types import DeckDefinitionV5, SlotDefV3
 from opentrons_shared_data.labware.types import LabwareDefinition
@@ -34,6 +34,7 @@ from .legacy_instrument_core import LegacyInstrumentCore
 from .labware_offset_provider import AbstractLabwareOffsetProvider
 from .legacy_labware_core import LegacyLabwareCore
 from .load_info import LoadInfo, InstrumentLoadInfo, LabwareLoadInfo, ModuleLoadInfo
+from .tasks import LegacyTaskCore
 
 logger = logging.getLogger(__name__)
 
@@ -43,6 +44,7 @@ class LegacyProtocolCore(
         LegacyInstrumentCore,
         LegacyLabwareCore,
         legacy_module_core.LegacyModuleCore,
+        LegacyTaskCore,
     ]
 ):
     def __init__(
@@ -610,3 +612,11 @@ class LegacyProtocolCore(
     ]:
         """Get labware parent location."""
         assert False, "get_labware_location only supported on engine core"
+
+    def wait_for_tasks(self, task: Sequence[LegacyTaskCore]) -> None:
+        """Wait for list of tasks to complete before executing subsequent commands."""
+        assert False, "wait_for_tasks only supported on engine core"
+
+    def create_timer(self, seconds: float) -> LegacyTaskCore:
+        """Create a timer task that runs in the background."""
+        assert False, "create_timer only supported on engine core"

--- a/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_protocol_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_protocol_core.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict, Optional
+from typing import Dict, Optional, Sequence
 
 from opentrons_shared_data.pipette.types import PipetteNameType
 from opentrons_shared_data.pipette.pipette_load_name_conversions import (
@@ -16,6 +16,7 @@ from ..legacy.legacy_module_core import LegacyModuleCore
 from ..legacy.load_info import InstrumentLoadInfo
 
 from .legacy_instrument_core import LegacyInstrumentCoreSimulator
+from .tasks import LegacyTaskCore
 
 logger = logging.getLogger(__name__)
 
@@ -23,7 +24,10 @@ logger = logging.getLogger(__name__)
 class LegacyProtocolCoreSimulator(
     LegacyProtocolCore,
     AbstractProtocol[
-        LegacyInstrumentCoreSimulator, LegacyLabwareCore, LegacyModuleCore
+        LegacyInstrumentCoreSimulator,
+        LegacyLabwareCore,
+        LegacyModuleCore,
+        LegacyTaskCore,
     ],
 ):
     _instruments: Dict[Mount, Optional[LegacyInstrumentCoreSimulator]]  # type: ignore[assignment]
@@ -83,3 +87,11 @@ class LegacyProtocolCoreSimulator(
         )
 
         return new_instr
+
+        def wait_for_tasks(self, task: Sequence[LegacyTaskCore]) -> None:
+            """Wait for list of tasks to complete before executing subsequent commands."""
+            assert False, "wait_for_tasks only supported on engine core"
+
+        def create_timer(self, seconds: float) -> LegacyTaskCore:
+            """Create a timer task that runs in the background."""
+            assert False, "create_timer only supported on engine core"

--- a/api/src/opentrons/protocol_api/core/protocol.py
+++ b/api/src/opentrons/protocol_api/core/protocol.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from abc import abstractmethod, ABC
-from typing import Generic, List, Optional, Union, Tuple, Dict, TYPE_CHECKING
+from typing import Generic, List, Optional, Union, Tuple, Dict, TYPE_CHECKING, Sequence
 
 from opentrons_shared_data.deck.types import DeckDefinitionV5, SlotDefV3
 from opentrons_shared_data.pipette.types import PipetteNameType
@@ -24,6 +24,7 @@ from opentrons.protocols.api_support.util import AxisMaxSpeeds
 from .instrument import InstrumentCoreType
 from .labware import LabwareCoreType, LabwareLoadParams
 from .module import ModuleCoreType
+from .tasks import TaskCoreType
 from .._liquid import Liquid, LiquidClass
 from .robot import AbstractRobot
 from .._types import OffDeckType
@@ -34,7 +35,7 @@ if TYPE_CHECKING:
 
 
 class AbstractProtocol(
-    ABC, Generic[InstrumentCoreType, LabwareCoreType, ModuleCoreType]
+    ABC, Generic[InstrumentCoreType, LabwareCoreType, ModuleCoreType, TaskCoreType]
 ):
     @property
     @abstractmethod
@@ -190,6 +191,14 @@ class AbstractProtocol(
 
     @abstractmethod
     def delay(self, seconds: float, msg: Optional[str]) -> None:
+        ...
+
+    @abstractmethod
+    def wait_for_tasks(self, task_cores: Sequence[TaskCoreType]) -> None:
+        ...
+
+    @abstractmethod
+    def create_timer(self, seconds: float) -> TaskCoreType:
         ...
 
     @abstractmethod

--- a/api/src/opentrons/protocol_api/core/tasks.py
+++ b/api/src/opentrons/protocol_api/core/tasks.py
@@ -4,12 +4,10 @@ from typing import TypeVar
 
 
 class AbstractTaskCore(ABC):
-    def __init__(self, task_id: str) -> None:
-        self._id = task_id
-
-    @property
-    def id(self) -> str:
-        return self._id
+    @abstractmethod
+    def get_id(self) -> str:
+        """Get the ID of the task."""
+        ...
 
     @abstractmethod
     def get_created_at_timestamp(self) -> datetime:

--- a/api/src/opentrons/protocol_api/core/tasks.py
+++ b/api/src/opentrons/protocol_api/core/tasks.py
@@ -5,11 +5,6 @@ from typing import TypeVar
 
 class AbstractTaskCore(ABC):
     @abstractmethod
-    def get_id(self) -> str:
-        """Get the ID of the task."""
-        ...
-
-    @abstractmethod
     def get_created_at_timestamp(self) -> datetime:
         """Get the createdAt timestamp of the task."""
         ...

--- a/api/src/opentrons/protocol_api/core/tasks.py
+++ b/api/src/opentrons/protocol_api/core/tasks.py
@@ -1,5 +1,6 @@
 from abc import abstractmethod, ABC
 from datetime import datetime
+from typing import TypeVar
 
 
 class AbstractTaskCore(ABC):
@@ -25,3 +26,6 @@ class AbstractTaskCore(ABC):
         Returns ``None`` if the task hasn't finished yet.
         """
         ...
+
+
+TaskCoreType = TypeVar("TaskCoreType", bound=AbstractTaskCore)

--- a/api/src/opentrons/protocol_api/core/tasks.py
+++ b/api/src/opentrons/protocol_api/core/tasks.py
@@ -10,15 +10,18 @@ class AbstractTaskCore(ABC):
 
     @abstractmethod
     def is_done(self) -> bool:
-        """Return whether the task is done."""
+        """Returns ``True`` if the task is done."""
         ...
 
     @abstractmethod
     def is_started(self) -> bool:
-        """Return whether the task has started."""
+        """Returns ``True`` if the task has started."""
         ...
 
     @abstractmethod
     def get_finished_at_timestamp(self) -> datetime | None:
-        """Get the finishedAt timestamp of the task, or None if not finished."""
+        """The timestamp of the when the task finished.
+
+        Returns ``None`` if the task hasn't finished yet.
+        """
         ...

--- a/api/src/opentrons/protocol_api/core/tasks.py
+++ b/api/src/opentrons/protocol_api/core/tasks.py
@@ -4,6 +4,13 @@ from typing import TypeVar
 
 
 class AbstractTaskCore(ABC):
+    def __init__(self, task_id: str) -> None:
+        self._id = task_id
+
+    @property
+    def id(self) -> str:
+        return self._id
+
     @abstractmethod
     def get_created_at_timestamp(self) -> datetime:
         """Get the createdAt timestamp of the task."""

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -1287,6 +1287,7 @@ class ProtocolContext(CommandPublisher):
         delay_time = seconds + minutes * 60
         self._core.delay(seconds=delay_time, msg=msg)
 
+    @publish(command=cmds.wait_for_tasks)
     @requires_version(2, 27)
     def wait_for_tasks(self, tasks: list[Task]) -> None:
         """Wait for a list of tasks to complete before executing subsequent commands.
@@ -1298,6 +1299,7 @@ class ProtocolContext(CommandPublisher):
         task_cores = [task._core for task in tasks]
         self._core.wait_for_tasks(task_cores)
 
+    @publish(command=cmds.create_timer)
     @requires_version(2, 27)
     def create_timer(self, seconds: float) -> Task:
         """Create a timer task that runs in the background.

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -89,6 +89,7 @@ from .module_contexts import (
     FlexStackerContext,
     ModuleContext,
 )
+from .tasks import Task
 from ._parameters import Parameters
 
 
@@ -1285,6 +1286,28 @@ class ProtocolContext(CommandPublisher):
         """
         delay_time = seconds + minutes * 60
         self._core.delay(seconds=delay_time, msg=msg)
+
+    @requires_version(2, 27)
+    def wait_for_tasks(self, tasks: list[Task]) -> None:
+        """Wait for a list of tasks to complete before executing subsequent commands.
+
+        :param list Task: tasks: A list of Task objects to wait for.
+
+        Task objects can be commands that are allowed to run concurrently.
+        """
+        task_cores = [task._core for task in tasks]
+        self._core.wait_for_tasks(task_cores)
+
+    @requires_version(2, 27)
+    def create_timer(self, seconds: float) -> Task:
+        """Create a timer task that runs in the background.
+
+        :param float seconds: The time to delay in seconds.
+
+        This timer will continue to run until it is complete and will not block subsequent commands.
+        """
+        task_core = self._core.create_timer(seconds=seconds)
+        return Task(core=task_core, api_version=self._api_version)
 
     @requires_version(2, 0)
     def home(self) -> None:

--- a/api/src/opentrons/protocol_api/tasks.py
+++ b/api/src/opentrons/protocol_api/tasks.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
 
 
 class Task:
-    """A concurrent protocol task created by a protocol api function.
+    """A concurrent protocol task created by a protocol API function.
 
     .. versionadded:: 2.27
     """
@@ -28,18 +28,21 @@ class Task:
     @property
     @requires_version(2, 27)
     def done(self) -> bool:
-        """Whether the task is done."""
+        """Returns ``True`` if the task is done."""
         return self._core.is_done()
 
     @property
     @requires_version(2, 27)
     def started(self) -> bool:
-        """Whether the task has started."""
+        """WReturns ``True`` if the task is started."""
         return self._core.is_started()
         ...
 
     @property
     @requires_version(2, 27)
     def finished_at(self) -> datetime | None:
-        """The timestamp of the when the task is finished, none if not finished."""
+        """The timestamp of the when the task finished.
+
+        Returns ``None`` if the task hasn't finished yet.
+        """
         return self._core.get_finished_at_timestamp()

--- a/api/src/opentrons/protocol_api/tasks.py
+++ b/api/src/opentrons/protocol_api/tasks.py
@@ -21,12 +21,6 @@ class Task:
 
     @property
     @requires_version(2, 27)
-    def id(self) -> str:
-        """The unique ID of the task."""
-        return self._core.get_id()
-
-    @property
-    @requires_version(2, 27)
     def created_at(self) -> datetime:
         """The timestamp of when the task was created."""
         return self._core.get_created_at_timestamp()

--- a/api/src/opentrons/protocol_api/tasks.py
+++ b/api/src/opentrons/protocol_api/tasks.py
@@ -21,6 +21,12 @@ class Task:
 
     @property
     @requires_version(2, 27)
+    def id(self) -> str:
+        """The unique ID of the task."""
+        return self._core.get_id()
+
+    @property
+    @requires_version(2, 27)
     def created_at(self) -> datetime:
         """The timestamp of when the task was created."""
         return self._core.get_created_at_timestamp()

--- a/api/src/opentrons/protocol_api/tasks.py
+++ b/api/src/opentrons/protocol_api/tasks.py
@@ -34,7 +34,7 @@ class Task:
     @property
     @requires_version(2, 27)
     def started(self) -> bool:
-        """WReturns ``True`` if the task is started."""
+        """Returns ``True`` if the task has started."""
         return self._core.is_started()
         ...
 

--- a/api/src/opentrons/protocol_engine/clients/sync_client.py
+++ b/api/src/opentrons/protocol_engine/clients/sync_client.py
@@ -67,6 +67,12 @@ class SyncClient:
 
     @overload
     def execute_command_without_recovery(
+        self, params: commands.CreateTimerParams
+    ) -> commands.CreateTimerResult:
+        pass
+
+    @overload
+    def execute_command_without_recovery(
         self, params: commands.LoadModuleParams
     ) -> commands.LoadModuleResult:
         pass

--- a/api/tests/opentrons/protocol_api/core/engine/test_protocol_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_protocol_core.py
@@ -87,6 +87,7 @@ from opentrons.protocol_api.core.engine.module_core import (
     HeaterShakerModuleCore,
     NonConnectedModuleCore,
 )
+from opentrons.protocol_api.core.engine.tasks import EngineTaskCore
 from opentrons.protocol_api import validation, MAX_SUPPORTED_VERSION
 
 from opentrons.protocols.api_support.types import APIVersion
@@ -1675,6 +1676,42 @@ def test_delay(
             cmd.WaitForDurationParams(seconds=seconds, message=message)
         )
     )
+
+
+def test_wait_for_tasks(
+    decoy: Decoy,
+    mock_engine_client: EngineClient,
+    subject: ProtocolCore,
+) -> None:
+    """It should issue a waitForTasks command."""
+    task1 = decoy.mock(cls=EngineTaskCore)
+    task2 = decoy.mock(cls=EngineTaskCore)
+    tasks = [task1, task2]
+    task_ids = ["task-id-1", "task-id-2"]
+
+    decoy.when(task1._id).then_return(task_ids[0])
+    decoy.when(task2._id).then_return(task_ids[1])
+
+    subject.wait_for_tasks(task_cores=tasks)
+    decoy.verify(
+        mock_engine_client.execute_command(cmd.WaitForTasksParams(task_ids=task_ids))
+    )
+
+
+def test_create_timer(
+    decoy: Decoy,
+    mock_engine_client: EngineClient,
+    subject: ProtocolCore,
+) -> None:
+    """It should issue a createTimer command."""
+    decoy.when(
+        mock_engine_client.execute_command_without_recovery(
+            cmd.CreateTimerParams(time=0.1)
+        )
+    ).then_return(cmd.CreateTimerResult(task_id="taskid", time=0.1))
+    result = subject.create_timer(seconds=0.1)
+    assert result._id == "taskid"
+    assert result._engine_client == mock_engine_client
 
 
 def test_comment(

--- a/api/tests/opentrons/protocol_api/test_protocol_context.py
+++ b/api/tests/opentrons/protocol_api/test_protocol_context.py
@@ -57,6 +57,7 @@ from opentrons.protocol_api.core.common import (
     MagneticBlockCore,
     FlexStackerCore,
 )
+from opentrons.protocol_api.tasks import Task
 from opentrons.protocol_api.disposal_locations import TrashBin, WasteChute
 from opentrons.protocols.api_support.deck_type import (
     NoTrashDefinedError,
@@ -1902,6 +1903,33 @@ def test_home(
     """It should home all axes."""
     subject.home()
     decoy.verify(mock_core.home(), times=1)
+
+
+def test_wait_for_tasks(
+    decoy: Decoy,
+    mock_core: ProtocolCore,
+    subject: ProtocolContext,
+) -> None:
+    """It should wait for all tasks to complete."""
+    task1 = decoy.mock(cls=Task)
+    task2 = decoy.mock(cls=Task)
+    decoy.when(task1._core).then_return(sentinel.task1_core)
+    decoy.when(task2._core).then_return(sentinel.task2_core)
+    subject.wait_for_tasks([task1, task2])
+    decoy.verify(
+        mock_core.wait_for_tasks([sentinel.task1_core, sentinel.task2_core]), times=1
+    )
+
+
+def test_create_timer(
+    decoy: Decoy,
+    mock_core: ProtocolCore,
+    subject: ProtocolContext,
+) -> None:
+    """It should create a timer."""
+    decoy.when(mock_core.create_timer(seconds=0.1)).then_return(sentinel.task1_core)
+    result = subject.create_timer(seconds=0.1)
+    assert result._core is sentinel.task1_core
 
 
 def test_define_liquid(


### PR DESCRIPTION
## Overview
Enables the use of `wait_for_tasks()` and `create_timer()` commands in protocol context.

Currently, you can create multiple timers of different durations. These timers will run in the background. Then use `wait_for_tasks()` to continue with the rest of the protocol commands until all of the timers are done.

## Test Plan and Hands on Testing

- Created. protocol using these commands below and it simulated successfully

```
def run(protocol: protocol_api.ProtocolContext) -> None:
    """Run the protocol."""
    trash = protocol.load_trash_bin("A1")
    pipette = protocol.load_instrument("flex_8channel_1000", "right")
    timer1 = protocol.create_timer(5)
    pipette.move_to(trash)
    timer2 = protocol.create_timer(10)
    protocol.wait_for_tasks([timer1, timer2])
    protocol.comment("Both timers are done!")
```

Simulate prints out like this: 
<img width="890" height="113" alt="Screenshot 2025-09-15 at 12 08 03 PM" src="https://github.com/user-attachments/assets/93b9dc3c-e1b8-4599-95ab-40c938f186e9" />



Closes EXEC-1682
Closes EXEC-1685