### PR TITLE
feat(protocol-designer): link to version-specific release notes in GitHub

### DIFF
--- a/protocol-designer/src/components/organisms/KnowledgeLink.tsx
+++ b/protocol-designer/src/components/organisms/KnowledgeLink.tsx
@@ -8,8 +8,7 @@ interface KnowledgeLinkProps {
   children: ReactNode
 }
 
-export const RELEASE_NOTES_URL =
-  'https://github.com/Opentrons/opentrons/blob/edge/protocol-designer/release-notes.md'
+export const RELEASE_NOTES_URL = `https://github.com/Opentrons/opentrons/blob/protocol-designer@${_OT_PD_VERSION_}/protocol-designer/release-notes.md`
 
 export const DOC_URL = 'https://docs.opentrons.com/protocol-designer/'
 


### PR DESCRIPTION
# Overview

Previously, the `Release notes` link in PD would point to `protocol-designer/release-notes.md` in Github from `edge`, which means that users would see notes we checked into `edge` that do not apply to the version of PD they are running. https://opentrons.slack.com/archives/C07E9T2NAQK/p1757943749805359

This PD changes the `Release notes` link to point to the release notes from the same git tag as the PD release.

## Test Plan and Hands on Testing

Tried it locally.

Ran `yarn vitest --silent=false step-generation/ protocol-designer/`.

## Risk assessment

Low.