### PR TITLE
feat(api) add the ramp rate to gcode layer

### DIFF
--- a/api/src/opentrons/drivers/thermocycler/driver.py
+++ b/api/src/opentrons/drivers/thermocycler/driver.py
@@ -344,10 +344,38 @@ class ThermocyclerDriverV2(ThermocyclerDriver):
         """
         super().__init__(connection)
 
-    async def set_ramp_rate(self, ramp_rate: float) -> None:
-        """Send a set ramp rate command"""
-        # This command is fully unsupported on TC Gen2
-        return None
+    async def set_plate_temperature(
+        self,
+        temp: float,
+        hold_time: Optional[float] = None,
+        volume: Optional[float] = None,
+        ramp_rate: Optional[float] = None,
+    ) -> None:
+        """Send set plate temperature command"""
+        temp = min(BLOCK_TARGET_MAX, max(BLOCK_TARGET_MIN, temp))
+
+        c = (
+            CommandBuilder(terminator=TC_COMMAND_TERMINATOR)
+            .add_gcode(gcode=GCODE.SET_PLATE_TEMP)
+            .add_float(
+                prefix="S", value=temp, precision=utils.TC_GCODE_ROUNDING_PRECISION
+            )
+        )
+        if hold_time is not None:
+            c = c.add_float(
+                prefix="H", value=hold_time, precision=utils.TC_GCODE_ROUNDING_PRECISION
+            )
+        if volume is not None:
+            c = c.add_float(
+                prefix="V", value=volume, precision=utils.TC_GCODE_ROUNDING_PRECISION
+            )
+
+        if ramp_rate is not None:
+            c = c.add_float(
+                prefix="R", value=ramp_rate, precision=utils.TC_GCODE_ROUNDING_PRECISION
+            )
+
+        await self._connection.send_command(command=c, retries=DEFAULT_COMMAND_RETRIES)
 
     async def get_device_info(self) -> Dict[str, str]:
         """Send get device info command"""

--- a/api/src/opentrons/hardware_control/modules/thermocycler.py
+++ b/api/src/opentrons/hardware_control/modules/thermocycler.py
@@ -276,7 +276,9 @@ class Thermocycler(mod_abc.AbstractModule):
         await self._wait_for_lid_status(ThermocyclerLidStatus.OPEN)
 
     def can_use_ramp_rate(self) -> bool:
-        version_as_num = int("".join([c for c in self._device_info["version"] if c.isdigit()]))
+        version_as_num = int(
+            "".join([c for c in self._device_info["version"] if c.isdigit()])
+        )
         return version_as_num >= _TC_RAMP_RATE_ADDED_VERSION
 
     async def set_temperature(

--- a/api/src/opentrons/hardware_control/modules/thermocycler.py
+++ b/api/src/opentrons/hardware_control/modules/thermocycler.py
@@ -37,6 +37,8 @@ DFU_PID = "df11"
 _TC_PLATE_LIFT_OPEN_DEGREES = 20
 _TC_PLATE_LIFT_RETURN_DEGREES = 23
 
+_TC_RAMP_RATE_ADDED_VERSION = 108  # v1.0.8
+
 
 class ThermocyclerError(Exception):
     pass
@@ -273,6 +275,10 @@ class Thermocycler(mod_abc.AbstractModule):
         await self.open()
         await self._wait_for_lid_status(ThermocyclerLidStatus.OPEN)
 
+    def can_use_ramp_rate(self) -> bool:
+        version_as_num = int("".join([c for c in self._device_info["version"] if c.isdigit()]))
+        return version_as_num >= _TC_RAMP_RATE_ADDED_VERSION
+
     async def set_temperature(
         self,
         temperature: float,
@@ -298,6 +304,11 @@ class Thermocycler(mod_abc.AbstractModule):
 
         Returns: None
         """
+        if ramp_rate and not self.can_use_ramp_rate():
+            raise ThermocyclerError(
+                "Ramp rate is not supported by this thermocycler's firmware version, please update."
+            )
+
         await self.wait_for_is_running()
         await self._set_temperature_no_pause(
             temperature=temperature,
@@ -319,6 +330,11 @@ class Thermocycler(mod_abc.AbstractModule):
         minutes = hold_time_minutes if hold_time_minutes is not None else 0
         total_seconds = seconds + (minutes * 60)
         hold_time = total_seconds if total_seconds > 0 else 0
+
+        if ramp_rate and not self.can_use_ramp_rate():
+            raise ThermocyclerError(
+                "Ramp rate is not supported by this thermocycler's firmware version, please update."
+            )
 
         await self._driver.set_plate_temperature(
             temp=temperature, hold_time=hold_time, volume=volume, ramp_rate=ramp_rate
@@ -434,6 +450,11 @@ class Thermocycler(mod_abc.AbstractModule):
             celsius: The target block temperature, in degrees celsius.
         """
         await self.wait_for_is_running()
+
+        if ramp_rate and not self.can_use_ramp_rate():
+            raise ThermocyclerError(
+                "Ramp rate is not supported by this thermocycler's firmware version, please update."
+            )
 
         await self._driver.set_plate_temperature(
             temp=celsius,

--- a/api/tests/opentrons/drivers/thermocycler/test_gen2_driver.py
+++ b/api/tests/opentrons/drivers/thermocycler/test_gen2_driver.py
@@ -119,14 +119,15 @@ async def test_get_lid_temp(
 
 
 @pytest.mark.parametrize(
-    argnames=["temp", "hold_time", "volume", "expected_body"],
+    argnames=["temp", "hold_time", "volume", "ramp_rate", "expected_body"],
     argvalues=[
-        [50, 2, 32, "S50 H2 V32"],
-        [50, None, None, "S50"],
-        [50, 2, None, "S50 H2"],
-        [50, None, 32, "S50 V32"],
-        [-5, 2, 32, "S0 H2 V32"],
-        [102, 2, 32, "S99 H2 V32"],
+        [50, 2, 32, None, "S50 H2 V32"],
+        [50, None, None, None, "S50"],
+        [50, 2, None, None, "S50 H2"],
+        [50, None, 32, None, "S50 V32"],
+        [-5, 2, 32, None, "S0 H2 V32"],
+        [102, 2, 32, None, "S99 H2 V32"],
+        [102, 2, 32, 1.0, "S99 H2 V32 R1.0"],
     ],
 )
 async def test_set_plate_temp(
@@ -135,10 +136,13 @@ async def test_set_plate_temp(
     temp: float,
     hold_time: Optional[float],
     volume: Optional[float],
+    ramp_rate: Optional[float],
     expected_body: str,
 ) -> None:
     """It should send a set plate temperature command."""
-    await subject.set_plate_temperature(temp=temp, hold_time=hold_time, volume=volume)
+    await subject.set_plate_temperature(
+        temp=temp, hold_time=hold_time, volume=volume, ramp_rate=ramp_rate
+    )
 
     expected = (
         CommandBuilder(terminator=driver.TC_COMMAND_TERMINATOR)
@@ -168,12 +172,18 @@ async def test_get_plate_temp(
 
 
 async def test_set_ramp_rate(
-    subject: driver.ThermocyclerDriverV2, connection: AsyncMock
+    subject: driver.ThermocyclerDriver, connection: AsyncMock
 ) -> None:
-    """It should not send a set ramp rate command."""
+    """It should send a set ramp rate command."""
     await subject.set_ramp_rate(ramp_rate=22)
 
-    assert not connection.send_command.called
+    expected = (
+        CommandBuilder(terminator=driver.TC_COMMAND_TERMINATOR)
+        .add_gcode(gcode="M566")
+        .add_float(prefix="S", value=22, precision=TC_GCODE_ROUNDING_PRECISION)
+    )
+
+    connection.send_command.assert_called_once_with(command=expected, retries=3)
 
 
 async def test_deactivate_all(

--- a/api/tests/opentrons/hardware_control/modules/test_hc_thermocycler.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_thermocycler.py
@@ -14,7 +14,10 @@ from opentrons.drivers.rpi_drivers.types import USBPort
 from opentrons.drivers.thermocycler import SimulatingDriver
 from opentrons.hardware_control import modules, ExecutionManager
 from opentrons.hardware_control.poller import Poller
-from opentrons.hardware_control.modules.thermocycler import ThermocyclerReader, ThermocyclerError
+from opentrons.hardware_control.modules.thermocycler import (
+    ThermocyclerReader,
+    ThermocyclerError,
+)
 from opentrons.drivers.asyncio.communication.errors import ErrorResponse
 
 
@@ -319,10 +322,10 @@ async def test_set_temperature_with_ramp_rate(
 ) -> None:
     """It should call set_plate_temperature with volume param"""
     set_temperature_subject._device_info = {
-            "serial": "dummySerialTC",
-            "model": "dummyModelTC",
-            "version": "v1.0.8",
-        }
+        "serial": "dummySerialTC",
+        "model": "dummyModelTC",
+        "version": "v1.0.8",
+    }
     await set_temperature_subject.set_temperature(30, volume=35, ramp_rate=5.0)
     set_plate_temp_spy.assert_called_once_with(
         temp=30, hold_time=0, volume=35, ramp_rate=5.0
@@ -334,12 +337,13 @@ async def test_set_temperature_with_ramp_rate_with_old_firmware(
 ) -> None:
     """It should call set_plate_temperature with volume param"""
     set_temperature_subject._device_info = {
-            "serial": "dummySerialTC",
-            "model": "dummyModelTC",
-            "version": "v1.0.7",
-        }
+        "serial": "dummySerialTC",
+        "model": "dummyModelTC",
+        "version": "v1.0.7",
+    }
     with pytest.raises(ThermocyclerError):
         await set_temperature_subject.set_temperature(30, volume=35, ramp_rate=5.0)
+
 
 async def test_set_temperature_mixed_hold(
     set_temperature_subject: modules.Thermocycler, set_plate_temp_spy: mock.AsyncMock

--- a/api/tests/opentrons/hardware_control/modules/test_hc_thermocycler.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_thermocycler.py
@@ -14,7 +14,7 @@ from opentrons.drivers.rpi_drivers.types import USBPort
 from opentrons.drivers.thermocycler import SimulatingDriver
 from opentrons.hardware_control import modules, ExecutionManager
 from opentrons.hardware_control.poller import Poller
-from opentrons.hardware_control.modules.thermocycler import ThermocyclerReader
+from opentrons.hardware_control.modules.thermocycler import ThermocyclerReader, ThermocyclerError
 from opentrons.drivers.asyncio.communication.errors import ErrorResponse
 
 
@@ -318,11 +318,28 @@ async def test_set_temperature_with_ramp_rate(
     set_temperature_subject: modules.Thermocycler, set_plate_temp_spy: mock.AsyncMock
 ) -> None:
     """It should call set_plate_temperature with volume param"""
+    set_temperature_subject._device_info = {
+            "serial": "dummySerialTC",
+            "model": "dummyModelTC",
+            "version": "v1.0.8",
+        }
     await set_temperature_subject.set_temperature(30, volume=35, ramp_rate=5.0)
     set_plate_temp_spy.assert_called_once_with(
         temp=30, hold_time=0, volume=35, ramp_rate=5.0
     )
 
+
+async def test_set_temperature_with_ramp_rate_with_old_firmware(
+    set_temperature_subject: modules.Thermocycler, set_plate_temp_spy: mock.AsyncMock
+) -> None:
+    """It should call set_plate_temperature with volume param"""
+    set_temperature_subject._device_info = {
+            "serial": "dummySerialTC",
+            "model": "dummyModelTC",
+            "version": "v1.0.7",
+        }
+    with pytest.raises(ThermocyclerError):
+        await set_temperature_subject.set_temperature(30, volume=35, ramp_rate=5.0)
 
 async def test_set_temperature_mixed_hold(
     set_temperature_subject: modules.Thermocycler, set_plate_temp_spy: mock.AsyncMock


### PR DESCRIPTION
# Overview
This re-enables the gen 2 set_ramp_rate gcode messages by removing the 'return none' override from the shared driver.
It also adds the ramp rate as an additional argument to the set plate temperature gcode when it is not none