### PR TITLE
fix(api): Implement coverage of column 4 modules in collision checking

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/pipette_movement_conflict.py
+++ b/api/src/opentrons/protocol_api/core/engine/pipette_movement_conflict.py
@@ -21,7 +21,11 @@ from opentrons.protocol_engine import (
     OnLabwareLocation,
     DropTipWellLocation,
 )
-from opentrons.protocol_engine.types import StagingSlotLocation, WellLocationType
+from opentrons.protocol_engine.types import (
+    StagingSlotLocation,
+    WellLocationType,
+    LoadedModule,
+)
 from opentrons.types import DeckSlotName, StagingSlotName, Point
 from . import point_calculations
 
@@ -136,22 +140,47 @@ def check_safe_for_pipette_movement(  # noqa: C901
             f" will result in collision with thermocycler lid in deck slot A1."
         )
 
+    def _check_for_column_4_module_collision(slot: DeckSlotName) -> None:
+        slot_module = engine_state.modules.get_by_slot(slot)
+        if (
+            slot_module
+            and engine_state.modules.is_column_4_module(slot_module.model)
+            and _slot_has_potential_colliding_object(
+                engine_state=engine_state,
+                pipette_bounds=pipette_bounds_at_well_location,
+                surrounding_location=slot_module,
+            )
+        ):
+            raise PartialTipMovementNotAllowedError(
+                f"Moving to {engine_state.labware.get_display_name(labware_id)} in slot"
+                f" {slot} with {primary_nozzle} nozzle partial configuration will"
+                f" result in collision with items on {slot_module.model} mounted in {slot}."
+            )
+
+    # We check the labware slot for a module that is mounted in the same cutout
+    # as the labwares slot but does not occupy the same heirarchy (like the stacker).
+    _check_for_column_4_module_collision(labware_slot)
+
     for regular_slot in surrounding_slots.regular_slots:
         if _slot_has_potential_colliding_object(
             engine_state=engine_state,
             pipette_bounds=pipette_bounds_at_well_location,
-            surrounding_slot=regular_slot,
+            surrounding_location=regular_slot,
         ):
             raise PartialTipMovementNotAllowedError(
                 f"Moving to {engine_state.labware.get_display_name(labware_id)} in slot"
                 f" {labware_slot} with {primary_nozzle} nozzle partial configuration"
                 f" will result in collision with items in deck slot {regular_slot}."
             )
+
+        # Check for Column 4 Modules that may be descendants of a given surrounding slot
+        _check_for_column_4_module_collision(regular_slot)
+
     for staging_slot in surrounding_slots.staging_slots:
         if _slot_has_potential_colliding_object(
             engine_state=engine_state,
             pipette_bounds=pipette_bounds_at_well_location,
-            surrounding_slot=staging_slot,
+            surrounding_location=staging_slot,
         ):
             raise PartialTipMovementNotAllowedError(
                 f"Moving to {engine_state.labware.get_display_name(labware_id)} in slot"
@@ -178,18 +207,45 @@ def _get_critical_point_to_use(
 def _slot_has_potential_colliding_object(
     engine_state: StateView,
     pipette_bounds: Tuple[Point, Point, Point, Point],
-    surrounding_slot: Union[DeckSlotName, StagingSlotName],
+    surrounding_location: Union[DeckSlotName, StagingSlotName, LoadedModule],
 ) -> bool:
-    """Return the slot, if any, that has an item that the pipette might collide into."""
-    # Check if slot overlaps with pipette position
-    slot_pos = engine_state.addressable_areas.get_addressable_area_position(
-        addressable_area_name=surrounding_slot.id,
-        do_compatibility_check=False,
-    )
-    slot_bounds = engine_state.addressable_areas.get_addressable_area_bounding_box(
-        addressable_area_name=surrounding_slot.id,
-        do_compatibility_check=False,
-    )
+    """Return the slot, if any, that has an item that the pipette might collide into.
+    Can be provided a Deck Slot, Staging Slot, or Column 4 Module.
+    """
+    if isinstance(surrounding_location, LoadedModule):
+        if (
+            engine_state.modules.is_column_4_module(surrounding_location.model)
+            and surrounding_location.location is not None
+        ):
+            module_area = (
+                engine_state.modules.ensure_and_convert_module_fixture_location(
+                    surrounding_location.location.slotName, surrounding_location.model
+                )
+            )
+            slot_pos = engine_state.addressable_areas.get_addressable_area_position(
+                addressable_area_name=module_area,
+                do_compatibility_check=False,
+            )
+            slot_bounds = (
+                engine_state.addressable_areas.get_addressable_area_bounding_box(
+                    addressable_area_name=module_area,
+                    do_compatibility_check=False,
+                )
+            )
+        else:
+            raise ValueError(
+                f"Error during collision validation, Module {surrounding_location.model} must be in Column 4."
+            )
+    else:
+        # Check if slot overlaps with pipette position
+        slot_pos = engine_state.addressable_areas.get_addressable_area_position(
+            addressable_area_name=surrounding_location.id,
+            do_compatibility_check=False,
+        )
+        slot_bounds = engine_state.addressable_areas.get_addressable_area_bounding_box(
+            addressable_area_name=surrounding_location.id,
+            do_compatibility_check=False,
+        )
     slot_back_left_coords = Point(slot_pos.x, slot_pos.y + slot_bounds.y, slot_pos.z)
     slot_front_right_coords = Point(slot_pos.x + slot_bounds.x, slot_pos.y, slot_pos.z)
 
@@ -199,13 +255,17 @@ def _slot_has_potential_colliding_object(
         rectangle2=(slot_back_left_coords, slot_front_right_coords),
     ):
         # Check z-height of items in overlapping slot
-        if isinstance(surrounding_slot, DeckSlotName):
+        if isinstance(surrounding_location, DeckSlotName):
             slot_highest_z = engine_state.geometry.get_highest_z_in_slot(
-                DeckSlotLocation(slotName=surrounding_slot)
+                DeckSlotLocation(slotName=surrounding_location)
+            )
+        elif isinstance(surrounding_location, LoadedModule):
+            slot_highest_z = engine_state.geometry.get_highest_z_of_column_4_module(
+                surrounding_location
             )
         else:
             slot_highest_z = engine_state.geometry.get_highest_z_in_slot(
-                StagingSlotLocation(slotName=surrounding_slot)
+                StagingSlotLocation(slotName=surrounding_location)
             )
         return slot_highest_z >= pipette_bounds[0].z
     return False

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -274,12 +274,20 @@ class GeometryView:
             try:
                 labware_id = self._labware.get_id_by_module(module_id=module_id)
             except LabwareNotLoadedOnModuleError:
-                return self._modules.get_module_highest_z(
-                    module_id=module_id,
-                    addressable_areas=self._addressable_areas,
-                )
+                # For the time being we will ignore column 4 modules in this check to avoid conflating results
+                if self._modules.is_column_4_module(slot_item.model) is False:
+                    return self._modules.get_module_highest_z(
+                        module_id=module_id,
+                        addressable_areas=self._addressable_areas,
+                    )
             else:
-                return self.get_highest_z_of_labware_stack(labware_id)
+                # For the time being we will ignore column 4 modules in this check to avoid conflating results
+                if self._modules.is_column_4_module(slot_item.model) is False:
+                    return self.get_highest_z_of_labware_stack(labware_id)
+            # todo (cb, 2025-09-15): For now we skip column 4 modules and handle them seperately in
+            # get_highest_z_of_column_4_module, so this will return 0. In the future we may want to consolidate
+            # this to make it more apparently at this point in the query process.
+            return 0
         elif isinstance(slot_item, LoadedLabware):
             # get stacked heights of all labware in the slot
             return self.get_highest_z_of_labware_stack(slot_item.id)
@@ -300,6 +308,26 @@ class GeometryView:
         except LabwareNotLoadedOnLabwareError:
             return self.get_labware_highest_z(labware_id)
         return self.get_highest_z_of_labware_stack(stacked_labware_id)
+
+    def get_highest_z_of_column_4_module(self, module: LoadedModule) -> float:
+        """Get the highest Z-point of the topmost labware in the stack of labware on the given column 4 module.
+
+        If there is no labware on the given module, returns highest z of the module.
+        """
+        if self._modules.is_column_4_module(module.model):
+            try:
+                labware_id = self._labware.get_id_by_module(module_id=module.id)
+            except LabwareNotLoadedOnModuleError:
+                return self._modules.get_module_highest_z(
+                    module_id=module.id,
+                    addressable_areas=self._addressable_areas,
+                )
+            else:
+                return self.get_highest_z_of_labware_stack(labware_id)
+        else:
+            raise ValueError(
+                "Module must be a Column 4 Module to determine maximum z height."
+            )
 
     def get_min_travel_z(
         self,

--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -1330,6 +1330,12 @@ class ModuleView:
                     f"Module {module.model} is already present at {location}."
                 )
 
+    def is_column_4_module(self, model: ModuleModel) -> bool:
+        """Determine whether or not a module is a Column 4 Module."""
+        if model in _COLUMN_4_MODULES:
+            return True
+        return False
+
     def get_default_gripper_offsets(
         self, module_id: str
     ) -> Optional[LabwareMovementOffsetData]:

--- a/api/tests/opentrons/protocol_api/core/engine/test_deck_conflict.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_deck_conflict.py
@@ -749,6 +749,19 @@ module = LoadedModule(
             ),
             170,
         ),
+        (
+            (
+                Point(x=150, y=250, z=40),
+                Point(x=250, y=201, z=40),
+                Point(x=150, y=201, z=40),
+                Point(x=250, y=250, z=40),
+            ),
+            pytest.raises(
+                pipette_movement_conflict.PartialTipMovementNotAllowedError,
+                match="result in collision with items on flexStackerModuleV1 mounted in B3.",
+            ),
+            170,
+        ),
     ],
 )
 def test_deck_conflict_raises_for_bad_pipette_move(
@@ -766,6 +779,8 @@ def test_deck_conflict_raises_for_bad_pipette_move(
     - we are checking for conflicts when moving to a labware in C2.
       For each test case, we are moving to a different point in the destination labware,
       with the same pipette and tip
+    - we are checking for conflicts when moving to a point that would collide with a
+      flex stacker in column 4 at position B4 but nothing in the ancestor slot of B3
 
     Note: this test does not stub out the slot overlap checker function
           in order to preserve readability of the test. That means the test does
@@ -842,6 +857,24 @@ def test_deck_conflict_raises_for_bad_pipette_move(
         )
     ).then_return(pipette_bounds)
 
+    stacker = LoadedModule(
+        id="fake-stacker-id",
+        model=ModuleModel.FLEX_STACKER_MODULE_V1,
+        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_B3),
+        serialNumber="serial-number",
+    )
+    decoy.when(mock_state_view.modules.get_by_slot(DeckSlotName.SLOT_B3)).then_return(
+        stacker
+    )
+    decoy.when(mock_state_view.modules.is_column_4_module(stacker.model)).then_return(
+        True
+    )
+    decoy.when(
+        mock_state_view.modules.ensure_and_convert_module_fixture_location(
+            DeckSlotName.SLOT_B3, stacker.model
+        )
+    ).then_return("flexStackerModuleV1B4")
+
     decoy.when(
         adjacent_slots_getters.get_surrounding_slots(5, robot_type="OT-3 Standard")
     ).then_return(
@@ -850,6 +883,7 @@ def test_deck_conflict_raises_for_bad_pipette_move(
                 DeckSlotName.SLOT_D1,
                 DeckSlotName.SLOT_D2,
                 DeckSlotName.SLOT_C1,
+                DeckSlotName.SLOT_B3,
             ],
             staging_slots=[StagingSlotName.SLOT_C4],
         )
@@ -887,6 +921,38 @@ def test_deck_conflict_raises_for_bad_pipette_move(
         mock_state_view.geometry.get_highest_z_in_slot(
             StagingSlotLocation(slotName=StagingSlotName.SLOT_C4)
         )
+    ).then_return(50)
+    decoy.when(
+        mock_state_view.addressable_areas.get_addressable_area_position(
+            addressable_area_name="B3", do_compatibility_check=False
+        )
+    ).then_return(Point(150, 200, 0))
+    decoy.when(
+        mock_state_view.addressable_areas.get_addressable_area_bounding_box(
+            addressable_area_name="B3", do_compatibility_check=False
+        )
+    ).then_return(Dimensions(90, 90, 0))
+
+    # Ensure slot B3 is empty so we can test the stacker
+    decoy.when(
+        mock_state_view.geometry.get_highest_z_in_slot(
+            DeckSlotLocation(slotName=DeckSlotName.SLOT_B3)
+        )
+    ).then_return(0)
+
+    decoy.when(
+        mock_state_view.addressable_areas.get_addressable_area_position(
+            addressable_area_name="flexStackerModuleV1B4", do_compatibility_check=False
+        )
+    ).then_return(Point(200, 200, 0))
+    decoy.when(
+        mock_state_view.addressable_areas.get_addressable_area_bounding_box(
+            addressable_area_name="flexStackerModuleV1B4", do_compatibility_check=False
+        )
+    ).then_return(Dimensions(90, 90, 0))
+
+    decoy.when(
+        mock_state_view.geometry.get_highest_z_of_column_4_module(stacker)
     ).then_return(50)
     for slot_name in [DeckSlotName.SLOT_C1, DeckSlotName.SLOT_D1, DeckSlotName.SLOT_D2]:
         decoy.when(

--- a/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
@@ -1131,6 +1131,9 @@ def test_get_highest_z_in_slot_with_single_module(
             addressable_areas=mock_addressable_area_view,
         )
     ).then_return(12345)
+    decoy.when(mock_module_view.is_column_4_module(module_in_slot.model)).then_return(
+        False
+    )
 
     assert (
         subject.get_highest_z_in_slot(DeckSlotLocation(slotName=DeckSlotName.SLOT_3))
@@ -1293,6 +1296,9 @@ def test_get_highest_z_in_slot_with_labware_stack_on_module(
             "magneticModuleV2Slot3"
         )
     ).then_return(Point(11, 22, 33))
+    decoy.when(mock_module_view.is_column_4_module(module_on_slot.model)).then_return(
+        False
+    )
 
     expected_highest_z = (
         33


### PR DESCRIPTION
# Overview
Covers RQA-4625

The logic which checks for potential collisions in the surrounding slots when handling a partial tip action did not have the capability to handle modules that occupy column 4. This is primarily because column 4 modules are actually sourced in column 3 when considering the cutout they descend from in the deck configuration. This lead to situations like the one in this ticket, where a stacker would return as the "tallest object in C3" (true if you only consider the cutouts, false if you are thinking in "slots"). The changes in this PR are a little bit gross, but will solve our problem for now without ripping out the slot based position checking of this section of code entirely. 

What we do now is validate two extra conditions:
1. For a given slot occupied by a labware, is there a module that spawns out of that slot that would occupy column 4? If so, check for a collision. Example: Labware is in B3, stacker is in B4. Check for a collision with that stacker.
2. For a given surrounding slot, is there a module that spawns out of that slot that would occupy column 4? If so, consider the heights of the labware or modules in the base surrounding slot, as well as the heights of the labware or modules that constitute the "column 4 module". Example: Labware in B3 is being pipetted with partial tip, in C3 there is nothing but in C4 there is a stacker with a tiprack. Check for possible collisions with the column 4 stackup.


## Test Plan and Hands on Testing
Ensure the following conditions fail in protocol analysis with the expected outcomes:
- [x] Stacker with a tiprack mounted on it adjacent to labware with partial tip overlap should raise a collision error
- [x] Stacker on slot surrounding labware with partial tip overlap should raise a collision error
- [x] Surrounding slow with tiprack with stacker attached should raise error independently 

## Changelog

- Expansion of slot collision checking logic to handle column 4 modules
- Censoring of column 4 modules from the `get_highest_z_in_slot` function
- Addition of `get_highest_z_of_column_4_module` supplemental function to support validation
- Expansion of collision checking unit test to include stacker validation

## Review requests

## Risk assessment
Low - this should fix our issue and allow protocols with stacker collisions to properly fail analysis now.