### PR TITLE
feat(abr-testing): attach robot logs to slack message when protocol fails

### DIFF
--- a/abr-testing/abr_testing/automation/slack.py
+++ b/abr-testing/abr_testing/automation/slack.py
@@ -1,10 +1,9 @@
 """Slack Functions for Robot Communication."""
 from slack_sdk import WebClient
-from slack_sdk.web.slack_response import SlackResponse
 import configparser
 import os
-from typing import Optional, List, cast
-from opentrons.protocols.parameters.types import ParameterChoice
+from typing import Optional, cast
+from pathlib import Path
 
 
 class Slack:
@@ -21,6 +20,7 @@ class Slack:
         self.client = WebClient(token=slack_token)
         self.channel = channel_name
         self.user_name = user_name
+        self.channel_id = self._get_channel_id_from_name(channel_name)
         # If user is a robot, then the icon will be the opentron logo
         if user_name.startswith("DVT") or user_name.startswith("PVT"):
             self.icon_emoji = ":robot_face:"
@@ -28,117 +28,78 @@ class Slack:
             self.icon_emoji = ":gear:"
             print("Using computer icon for non-robot user.")
 
-    def get_users_in_channel(self, channel_id: str) -> List[ParameterChoice]:
-        """Get all active, human users in a specific Slack channel."""
-        all_member_ids: List[str] = []
-        channel_cursor: Optional[str] = None
-
-        while True:
-            response_members: SlackResponse = self.client.conversations_members(
-                channel=channel_id, cursor=channel_cursor
+    def _get_channel_id_from_name(self, channel_name: str) -> str:
+        """Return the Slack channel ID given a channel name."""
+        cursor = None
+        try:
+            response = self.client.conversations_list(
+                exclude_archived=True,
+                limit=1000,
+                cursor=cursor,
             )
-            if not cast(dict, response_members).get("ok", False):
-                raise Exception("Failed to get channel members from Slack API.")
-
-            all_member_ids.extend(
-                cast(list, cast(dict, response_members).get("members", []))
-            )
-            channel_cursor = cast(
-                Optional[str],
-                cast(dict, response_members)
-                .get("response_metadata", {})
-                .get("next_cursor"),
-            )
-            if not channel_cursor:
-                break
-
-        user_list: List[ParameterChoice] = []
-        user_cursor: Optional[str] = None
-
-        while True:
-            response: SlackResponse = self.client.users_list(cursor=user_cursor)
-            if not cast(dict, response).get("ok", False):
-                raise Exception("Failed to get users from Slack API.")
-
-            users: List[dict] = cast(list, cast(dict, response).get("members", []))
-            for user in users:
-                user_id = user.get("id")
-                profile = user.get("profile", {})
-                if (
-                    user_id in all_member_ids
-                    and not user.get("deleted", False)
-                    and not user.get("is_bot", False)
-                ):
-                    first_name = profile.get("first_name", "").strip()
-                    last_name = profile.get("last_name", "").strip()
-                    display_name = (
-                        profile.get("real_name", "Unknown User")
-                        if not first_name and not last_name
-                        else f"{first_name} {last_name}".strip()
-                    )
-                    user_list.append(
-                        ParameterChoice(display_name=display_name, value=user_id)
-                    )
-            user_cursor = cast(
-                Optional[str],
-                cast(dict, response).get("response_metadata", {}).get("next_cursor"),
-            )
-            if not user_cursor:
-                break
-
-        return user_list
+            response_dict = cast(dict, response)
+        except Exception as e:
+            raise RuntimeError(f"Slack API error: {e}")
+        for channel in response_dict.get("channels", []):
+            if channel.get("name") == channel_name:
+                return channel["id"]
+        cursor = response_dict.get("response_metadata", {}).get("next_cursor")
+        if not cursor:
+            raise ValueError(f"Channel {channel_name} not found")
+        return ""
 
     def send_slack_message(
         self,
         message: str,
-        image_path: Optional[str] = None,
+        file_path: str | None = None,
         user_id: Optional[str] = None,
     ) -> None:
-        """Send slack message with or without image."""
-        tagged_user = f"<@{user_id}> " if user_id and user_id.lower() != "none" else ""
-        message = tagged_user + " " + message
-        if image_path:
-            response = self.client.files_upload(
-                channels=self.channel,
-                file=image_path,
-                title=os.path.basename(image_path).split(".")[0],
-            )
-            response.validate()
-            file_permalink = response["file"]["permalink"]
-            self.client.chat_postMessage(
-                channel=self.channel,
-                blocks=[
-                    {
-                        "type": "image",
-                        "image_url": file_permalink,
-                    }
-                ],
-                text=message,
-                username=self.user_name,
-                icon_emoji=self.icon_emoji,
-            )
+        """Send Slack message with or without a file attachment."""
+        icon = self.icon_emoji or ""
+        user = self.user_name or ""
+        if file_path:
+            full_message = f"{icon} *{user}*: {message}"
+            try:
+                if not Path(file_path.strip()).exists():
+                    print(f"File not found: {file_path}")
+                    return
+
+                with open(file_path, "rb") as file_content:
+                    response = self.client.files_upload_v2(
+                        file=file_content,
+                        filename=os.path.basename(file_path),
+                        title=os.path.basename(file_path).split(".")[0],
+                        channel=self.channel_id,
+                        initial_comment=full_message,
+                    )
+                    response.validate()
+            except Exception as e:
+                print(f"Failed to upload file to Slack: {e}")
         else:
-            self.client.chat_postMessage(
-                channel=self.channel,
-                text=message,
-                username=self.user_name,
-                icon_emoji=self.icon_emoji,
-            )
+            full_message = message
+            try:
+                response = self.client.chat_postMessage(
+                    channel=self.channel,
+                    text=full_message,
+                    username=self.user_name,
+                    icon_emoji=self.icon_emoji,
+                )
+                response.validate()
+            except Exception as e:
+                print(f"Failed to send message to Slack: {e}")
 
     def send_run_completed_message(
         self, protocol_name: str, user_id: Optional[str] = None
     ) -> None:
         """Send run completed message."""
-        tagged_user = f"<@{user_id}> " if user_id and user_id.lower() != "none" else ""
-        message = f"{tagged_user} {protocol_name} has completed successfully."
+        message = f"{protocol_name} has completed successfully."
         self.send_slack_message(message)
 
     def send_run_started_message(
         self, protocol_name: str, user_id: Optional[str] = None
     ) -> None:
         """Send run started message."""
-        tagged_user = f"<@{user_id}> " if user_id and user_id.lower() != "none" else ""
-        message = f"{tagged_user} Protocol: {protocol_name} has started."
+        message = f"Protocol: {protocol_name} has started."
         self.send_slack_message(message)
 
     def send_error_message(
@@ -149,8 +110,6 @@ class Slack:
         user_id: Optional[str] = None,
     ) -> None:
         """Send error message to Slack, optionally tagging a user."""
-        tagged_user = f"<@{user_id}> " if user_id and user_id.lower() != "none" else ""
-        message = f"{tagged_user} Protocol: {protocol_name} ended in error: {error_str}"
-
+        message = f"Protocol: {protocol_name} ended in error: {error_str}"
         self.icon_emoji = ":alert:"
         self.send_slack_message(message, image_path)

--- a/abr-testing/abr_testing/data_collection/abr_robot_error.py
+++ b/abr-testing/abr_testing/data_collection/abr_robot_error.py
@@ -594,7 +594,7 @@ if __name__ == "__main__":
     email = args.email[0]
     board_id = args.board_id[0]
     reporter_id = args.reporter_id[0]
-    file_paths = read_robot_logs.get_logs(storage_directory, ip)
+    log_zip_path = read_robot_logs.get_logs(storage_directory, ip)
     ticket = jira_tool.JiraTicket(url, api_token, email)
     users_file_path = ticket.get_jira_users(storage_directory)
     assignee_id = get_user_id(users_file_path, assignee)
@@ -683,7 +683,8 @@ if __name__ == "__main__":
         run_log_file_path,
         protocol_file_path,
         version_file_path,
-    ] + file_paths
+        log_zip_path,
+    ]
     error_folder_path = os.path.join(storage_directory, issue_key)
     os.makedirs(error_folder_path, exist_ok=True)
     for source_file in error_files:

--- a/abr-testing/abr_testing/data_collection/read_robot_logs.py
+++ b/abr-testing/abr_testing/data_collection/read_robot_logs.py
@@ -13,6 +13,8 @@ from typing import List, Dict, Any, Tuple, Set, Optional
 import time as t
 import json
 import requests
+from pathlib import Path
+import zipfile
 from abr_testing.tools import plate_reader
 
 
@@ -881,60 +883,105 @@ def get_calibration_offsets(
     return saved_file_path, calibration
 
 
-def get_logs(storage_directory: str, ip: str) -> List[str]:
-    """Get Robot logs."""
+def get_logs(storage_directory: str, ip: str) -> str:
+    """Get Robot logs and return a zip file path containing them."""
     log_types: List[Dict[str, Any]] = [
         {"log type": "api.log", "records": 10000},
         {"log type": "server.log", "records": 10000},
         {"log type": "serial.log", "records": 10000},
         {"log type": "touchscreen.log", "records": 10000},
     ]
-    all_paths = []
+    collected_files: List[str] = []
+    # Fetch HTTP logs
+    with open("/data/ODD/discovery.json") as f:
+        discovery_data = json.load(f)
+    robot_name = discovery_data["robots"][0].get("name", "unknown")
+    sw_version = discovery_data["robots"][0]["health"].get("api_version", "unknown")
     for log_type in log_types:
         try:
-            log_type_name = log_type["log type"]
-            print(log_type_name)
-            log_records = int(log_type["records"])
-            print(log_records)
+            log_type_name: str = log_type["log type"]
+            log_records: int = int(log_type["records"])
             response = requests.get(
                 f"http://{ip}:31950/logs/{log_type_name}",
                 headers={"log_identifier": log_type_name},
                 params={"records": log_records},
             )
             response.raise_for_status()
-            log_data = response.text
-            log_name = ip + "_" + log_type_name.split(".")[0] + ".log"
-            file_path = os.path.join(storage_directory, log_name)
-            with open(file_path, mode="w", encoding="utf-8") as file:
-                file.write(log_data)
-        except RuntimeError:
-            print(f"Request exception. Did not save {log_type_name}")
+            log_data: str = response.text
+            log_name: str = f"{robot_name}_{log_type_name.split('.')[0]}.log"
+            file_path: str = os.path.join(storage_directory, log_name)
+            with open(file_path, mode="w", encoding="utf-8") as f:
+                f.write(log_data)
+            collected_files.append(file_path)
+        except Exception as e:
+            print(f"Failed to fetch {log_type['log type']}: {e}")
             continue
-        all_paths.append(file_path)
+
     # Get weston.log using scp
-    # Split the path into parts
-    parts = storage_directory.split(os.sep)
-    # Find the index of 'Users'
-    index = parts.index("Users")
-    user_name = parts[index + 1]
-    # Define the SCP command
-    scp_command = [
-        "scp",
-        "-r",
-        "-i",
-        f"C:\\Users\\{user_name}\\.ssh\\robot_key",
-        f"root@{ip}:/var/log/weston.log",
-        storage_directory,
-    ]
-    # Execute the SCP command
+    collected_files = fetch_weston_log(
+        ip, storage_directory, collected_files, robot_name
+    )
+    timestamp = datetime.now().strftime("%Y-%m-%d")
+    # Create a ZIP archive with all collected files
+    zip_filename: str = os.path.join(
+        storage_directory, f"{robot_name}_{timestamp}_{sw_version}_logs.zip"
+    )
+    with zipfile.ZipFile(zip_filename, "w", zipfile.ZIP_DEFLATED) as zipf:
+        for file_path in collected_files:
+            arcname: str = os.path.basename(file_path)  # ✅ always str
+            zipf.write(file_path, arcname=arcname)
+    for file_path in collected_files:
+        try:
+            os.remove(file_path)
+        except Exception as e:
+            print(f"Failed to delete {file_path}: {e}")
+
+    return zip_filename
+
+
+def fetch_weston_log(
+    ip: str, storage_directory: str, collected_files: list, robot_name: str
+) -> list[str]:
+    """Get weston log using scp."""
     try:
-        subprocess.run(scp_command, check=True, capture_output=True, text=True)
-        file_path = os.path.join(storage_directory, "weston.log")
-        all_paths.append(file_path)
-    except subprocess.CalledProcessError as e:
-        print("Error during SCP command execution")
-        print("Return code:", e.returncode)
-        print("Output:", e.output)
-        print("Error output:", e.stderr)
-        subprocess.run(["scp", "weston.log", "root@10.14.19.40:/var/log/weston.log"])
-    return all_paths
+        # Ensure destination directory exists
+        storage_path = Path(storage_directory).resolve()
+        storage_path.mkdir(parents=True, exist_ok=True)
+
+        # Check if we're already on the robot (i.e., the file exists locally)
+        local_log_path = Path("/var/log/weston.log")
+
+        if local_log_path.exists():
+            # We're on the robot - just copy the file locally
+            destination_path = storage_path / "weston.log"
+            with open(local_log_path, "rb") as src, open(destination_path, "wb") as dst:
+                dst.write(src.read())
+            collected_files.append(str(destination_path))
+            return collected_files
+
+        # Otherwise, assume we need to SCP from the robot
+        ssh_key_path = Path.home() / ".ssh" / "robot_key"
+        if not ssh_key_path.exists():
+            return collected_files
+
+        scp_command = [
+            "scp",
+            "-r",
+            "-i",
+            str(ssh_key_path),
+            f"root@{ip}:/var/log/weston.log",
+            str(storage_path),
+        ]
+        subprocess.run(
+            scp_command, check=True, capture_output=True, text=True, timeout=30
+        )
+
+        file_path = storage_path / f"{robot_name}_weston.log"
+        if file_path.exists():
+            collected_files.append(str(file_path))
+            return collected_files
+        else:
+            print(f"'weston.log' not found at {file_path} after SCP.")
+    except Exception as e:
+        print(f"Unexpected error occurred: {e}")
+    return collected_files

--- a/abr-testing/abr_testing/data_collection/read_robot_logs.py
+++ b/abr-testing/abr_testing/data_collection/read_robot_logs.py
@@ -892,8 +892,18 @@ def get_logs(storage_directory: str, ip: str) -> str:
         {"log type": "touchscreen.log", "records": 10000},
     ]
     collected_files: List[str] = []
-    # Fetch HTTP logs
-    with open("/data/ODD/discovery.json") as f:
+    discovery_data_path = "/data/ODD/discovery.json"
+    if os.path.exists(discovery_data_path):
+        save_path = discovery_data_path
+    else:
+        save_dir = Path(f"{storage_directory}")
+        command = ["scp", "-r", f"root@{ip}:{discovery_data_path}", storage_directory]
+        try:
+            subprocess.run(command, check=True)  # type: ignore
+            save_path = os.path.join(save_dir, "discovery.json")
+        except subprocess.CalledProcessError as e:
+            print(f"Error during file transfer: {e}")
+    with open(save_path) as f:
         discovery_data = json.load(f)
     robot_name = discovery_data["robots"][0].get("name", "unknown")
     sw_version = discovery_data["robots"][0]["health"].get("api_version", "unknown")
@@ -942,46 +952,23 @@ def get_logs(storage_directory: str, ip: str) -> str:
 def fetch_weston_log(
     ip: str, storage_directory: str, collected_files: list, robot_name: str
 ) -> list[str]:
-    """Get weston log using scp."""
-    try:
-        # Ensure destination directory exists
-        storage_path = Path(storage_directory).resolve()
-        storage_path.mkdir(parents=True, exist_ok=True)
+    """Get weston log using scp or local copy, saved with robot name."""
+    local_log_path = Path("/var/log/weston.log")
+    destination_path = Path(storage_directory) / f"{robot_name}_weston.log"
 
-        # Check if we're already on the robot (i.e., the file exists locally)
-        local_log_path = Path("/var/log/weston.log")
-
-        if local_log_path.exists():
-            # We're on the robot - just copy the file locally
-            destination_path = storage_path / "weston.log"
-            with open(local_log_path, "rb") as src, open(destination_path, "wb") as dst:
-                dst.write(src.read())
+    if local_log_path.exists():
+        try:
+            with open(local_log_path, "rb") as src:
+                with open(destination_path, "wb") as dst:
+                    dst.write(src.read())
             collected_files.append(str(destination_path))
-            return collected_files
-
-        # Otherwise, assume we need to SCP from the robot
-        ssh_key_path = Path.home() / ".ssh" / "robot_key"
-        if not ssh_key_path.exists():
-            return collected_files
-
-        scp_command = [
-            "scp",
-            "-r",
-            "-i",
-            str(ssh_key_path),
-            f"root@{ip}:/var/log/weston.log",
-            str(storage_path),
-        ]
-        subprocess.run(
-            scp_command, check=True, capture_output=True, text=True, timeout=30
-        )
-
-        file_path = storage_path / f"{robot_name}_weston.log"
-        if file_path.exists():
-            collected_files.append(str(file_path))
-            return collected_files
-        else:
-            print(f"'weston.log' not found at {file_path} after SCP.")
-    except Exception as e:
-        print(f"Unexpected error occurred: {e}")
+        except Exception as e:
+            print(f"Error copying local weston.log: {e}")
+    else:
+        remote_path = f"root@{ip}:/var/log/weston.log"
+        try:
+            subprocess.run(["scp", remote_path, str(destination_path)], check=True)
+            collected_files.append(str(destination_path))
+        except subprocess.CalledProcessError as e:
+            print(f"Error during file transfer: {e}")
     return collected_files

--- a/abr-testing/abr_testing/protocols/active_protocols/10_ZymoBIOMICS_Magbead_DNA_Cells_Flex.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/10_ZymoBIOMICS_Magbead_DNA_Cells_Flex.py
@@ -587,5 +587,7 @@ def run(protocol: protocol_api.ProtocolContext) -> None:
             slack_bot.send_run_completed_message(metadata["protocolName"])
     except Exception as e:
         if not protocol.is_simulating():
-            slack_bot.send_error_message(metadata["protocolName"], str(e))
+            helpers.send_slack_error_message_with_log(
+                slack_bot, metadata["protocolName"], str(e)
+            )
         raise (e)

--- a/abr-testing/abr_testing/protocols/active_protocols/11_IDT xGen 1000 ul 96ch.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/11_IDT xGen 1000 ul 96ch.py
@@ -1464,5 +1464,7 @@ def run(protocol: ProtocolContext) -> None:
             slack_bot.send_run_completed_message(metadata["protocolName"])
     except Exception as e:
         if not protocol.is_simulating():
-            slack_bot.send_error_message(metadata["protocolName"], str(e))
+            helpers.send_slack_error_message_with_log(
+                slack_bot, metadata["protocolName"], str(e)
+            )
         raise (e)

--- a/abr-testing/abr_testing/protocols/active_protocols/12_Illumina RNA all parts.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/12_Illumina RNA all parts.py
@@ -2843,5 +2843,7 @@ def run(protocol: ProtocolContext) -> None:
             slack_bot.send_run_completed_message(metadata["protocolName"])
     except Exception as e:
         if not protocol.is_simulating():
-            slack_bot.send_error_message(metadata["protocolName"], str(e))
+            helpers.send_slack_error_message_with_log(
+                slack_bot, metadata["protocolName"], str(e)
+            )
         raise (e)

--- a/abr-testing/abr_testing/protocols/active_protocols/13_Stacker_Labware_Stamping_Test.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/13_Stacker_Labware_Stamping_Test.py
@@ -220,5 +220,7 @@ def run(ctx: ProtocolContext) -> None:
         )
     except Exception as e:
         if not ctx.is_simulating():
-            slack_bot.send_error_message(metadata["protocolName"], str(e))
+            helpers.send_slack_error_message_with_log(
+                slack_bot, metadata["protocolName"], str(e)
+            )
         raise (e)

--- a/abr-testing/abr_testing/protocols/active_protocols/14_IDT xGen 200 ul 96ch.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/14_IDT xGen 200 ul 96ch.py
@@ -1464,5 +1464,7 @@ def run(protocol: ProtocolContext) -> None:
             slack_bot.send_run_completed_message(metadata["protocolName"])
     except Exception as e:
         if not protocol.is_simulating():
-            slack_bot.send_error_message(metadata["protocolName"], str(e))
+            helpers.send_slack_error_message_with_log(
+                slack_bot, metadata["protocolName"], str(e)
+            )
         raise (e)

--- a/abr-testing/abr_testing/protocols/active_protocols/1_Simple Normalize Long Right.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/1_Simple Normalize Long Right.py
@@ -296,5 +296,7 @@ def run(protocol: ProtocolContext) -> None:
             slack_bot.send_run_completed_message(metadata["protocolName"])
     except Exception as e:
         if not protocol.is_simulating():
-            slack_bot.send_error_message(metadata["protocolName"], str(e))
+            helpers.send_slack_error_message_with_log(
+                slack_bot, metadata["protocolName"], str(e)
+            )
         raise (e)

--- a/abr-testing/abr_testing/protocols/active_protocols/2_BMS_PCR_Protocol.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/2_BMS_PCR_Protocol.py
@@ -243,5 +243,7 @@ def run(protocol: ProtocolContext) -> None:
             slack_bot.send_run_completed_message(metadata["protocolName"])
     except Exception as e:
         if not protocol.is_simulating():
-            slack_bot.send_error_message(metadata["protocolName"], str(e))
+            helpers.send_slack_error_message_with_log(
+                slack_bot, metadata["protocolName"], str(e)
+            )
         raise (e)

--- a/abr-testing/abr_testing/protocols/active_protocols/4_Illumina DNA Enrichment.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/4_Illumina DNA Enrichment.py
@@ -1087,5 +1087,7 @@ def run(protocol: ProtocolContext) -> None:
             slack_bot.send_run_completed_message(metadata["protocolName"])
     except Exception as e:
         if not protocol.is_simulating():
-            slack_bot.send_error_message(metadata["protocolName"], str(e))
+            helpers.send_slack_error_message_with_log(
+                slack_bot, metadata["protocolName"], str(e)
+            )
         raise (e)

--- a/abr-testing/abr_testing/protocols/active_protocols/5_MiSeq Library Preparation.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/5_MiSeq Library Preparation.py
@@ -350,5 +350,7 @@ def run(protocol: ProtocolContext) -> None:
             slack_bot.send_run_completed_message(metadata["protocolName"])
     except Exception as e:
         if not protocol.is_simulating():
-            slack_bot.send_error_message(metadata["protocolName"], str(e))
+            helpers.send_slack_error_message_with_log(
+                slack_bot, metadata["protocolName"], str(e)
+            )
         raise (e)

--- a/abr-testing/abr_testing/protocols/active_protocols/6_Olink_Target_48-96.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/6_Olink_Target_48-96.py
@@ -503,5 +503,7 @@ def run(protocol: ProtocolContext) -> None:
 
     except Exception as e:
         if not protocol.is_simulating():
-            slack_bot.send_error_message(metadata["protocolName"], str(e))
+            helpers.send_slack_error_message_with_log(
+                slack_bot, metadata["protocolName"], str(e)
+            )
         raise (e)

--- a/abr-testing/abr_testing/protocols/active_protocols/7_HDQ_DNA_Bacteria_Flex.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/7_HDQ_DNA_Bacteria_Flex.py
@@ -566,5 +566,7 @@ def run(protocol: ProtocolContext) -> None:
             slack_bot.send_run_completed_message(metadata["protocolName"])
     except Exception as e:
         if not protocol.is_simulating():
-            slack_bot.send_error_message(metadata["protocolName"], str(e))
+            helpers.send_slack_error_message_with_log(
+                slack_bot, metadata["protocolName"], str(e)
+            )
         raise (e)

--- a/abr-testing/abr_testing/protocols/active_protocols/9_Magmax_RNA_Cells_Flex.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/9_Magmax_RNA_Cells_Flex.py
@@ -638,5 +638,7 @@ def run(protocol: ProtocolContext) -> None:
             slack_bot.send_run_completed_message(metadata["protocolName"])
     except Exception as e:
         if not protocol.is_simulating():
-            slack_bot.send_error_message(metadata["protocolName"], str(e))
+            helpers.send_slack_error_message_with_log(
+                slack_bot, metadata["protocolName"], str(e)
+            )
         raise (e)

--- a/abr-testing/abr_testing/protocols/helpers.py
+++ b/abr-testing/abr_testing/protocols/helpers.py
@@ -15,6 +15,7 @@ from opentrons.protocol_api.module_contexts import (
     MagneticModuleContext,
     AbsorbanceReaderContext,
 )
+from abr_testing.data_collection.read_robot_logs import get_logs
 import configparser
 from pathlib import Path
 import json
@@ -22,6 +23,7 @@ from abr_testing.automation import slack
 from typing import List, Union, Dict, Tuple
 from opentrons.hardware_control.modules.types import ThermocyclerStep
 from datetime import datetime
+import subprocess
 
 # FUNCTIONS FOR LOADING COMMON CONFIGURATIONS
 
@@ -602,6 +604,27 @@ def set_up_slack() -> slack.Slack:
         channel_name="abr-robot-alerts",
         user_name=robot_name,
     )
+
+
+def create_robot_log_zip() -> str:
+    """Create a zip file of logs saved locally on robot."""
+    storage_directory = "/data/testing_data"
+    result = subprocess.run(
+        "ip route get 1.1.1.1 | awk '{print $7}'",
+        shell=True,
+        capture_output=True,
+        text=True,
+    )
+    ip = result.stdout.strip()
+    return get_logs(storage_directory, ip)
+
+
+def send_slack_error_message_with_log(
+    slack_bot: slack.Slack, protocol_name: str, error_str: str
+) -> None:
+    """Send error slack message with log files attached."""
+    log_path = create_robot_log_zip()
+    slack_bot.send_error_message(protocol_name, error_str, log_path)
 
 
 def comment_height_of_specific_labware(

--- a/abr-testing/abr_testing/protocols/test_protocols/75C_Condensation_recovery.py
+++ b/abr-testing/abr_testing/protocols/test_protocols/75C_Condensation_recovery.py
@@ -48,4 +48,6 @@ def run(protocol: protocol_api.ProtocolContext) -> None:
         thermocycler_module_1.deactivate_lid()
     except Exception as e:
         if not protocol.is_simulating():
-            slack_bot.send_error_message(metadata["protocolName"], str(e))
+            helpers.send_slack_error_message_with_log(
+                slack_bot, metadata["protocolName"], str(e)
+            )

--- a/abr-testing/abr_testing/protocols/test_protocols/95C_Condensation_recovery.py
+++ b/abr-testing/abr_testing/protocols/test_protocols/95C_Condensation_recovery.py
@@ -49,4 +49,6 @@ def run(protocol: protocol_api.ProtocolContext) -> None:
         thermocycler_module_1.deactivate_lid()
     except Exception as e:
         if not protocol.is_simulating():
-            slack_bot.send_error_message(metadata["protocolName"], str(e))
+            helpers.send_slack_error_message_with_log(
+                slack_bot, metadata["protocolName"], str(e)
+            )

--- a/abr-testing/abr_testing/protocols/test_protocols/evotips.py
+++ b/abr-testing/abr_testing/protocols/test_protocols/evotips.py
@@ -367,5 +367,7 @@ def run(protocol: ProtocolContext) -> None:
             slack_bot.send_run_completed_message(metadata["protocolName"])
     except Exception as e:
         if not protocol.is_simulating():
-            slack_bot.send_error_message(metadata["protocolName"], str(e))
+            helpers.send_slack_error_message_with_log(
+                slack_bot, metadata["protocolName"], str(e)
+            )
         raise (e)

--- a/abr-testing/abr_testing/protocols/test_protocols/tip_pick_up_test.py
+++ b/abr-testing/abr_testing/protocols/test_protocols/tip_pick_up_test.py
@@ -60,5 +60,7 @@ def run(protocol: ProtocolContext) -> None:
                 pipette.reset_tipracks()
     except Exception as e:
         if not protocol.is_simulating():
-            slack_bot.send_error_message(metadata["protocolName"], str(e))
+            helpers.send_slack_error_message_with_log(
+                slack_bot, metadata["protocolName"], str(e)
+            )
         raise (e)

--- a/abr-testing/abr_testing/tools/check_robot_status.py
+++ b/abr-testing/abr_testing/tools/check_robot_status.py
@@ -82,7 +82,6 @@ if __name__ == "__main__":
             configurations, "abr-robot-alerts", "Robot Status Checker"
         )
     # GET IP ADDRESSES OF INTEREST
-    available_users = slack_bot.get_users_in_channel("C04S59A3FHQ")
     robot_ips = [input("Enter IP of robot (type 'all' to run on all robots): ")]
     if robot_ips[0].lower() == "all":
         ip_file = configurations["DEFAULT"]["ips"]


### PR DESCRIPTION
# Overview

Attach robot logs to slack messages when protocol fails

When an ABR robot finishes a protocol and an error has occurred, the robot will save its logs and attach it to a slack message prior to raising the error message.

## Test Plan and Hands on Testing

- Tested on DVT1ABR2 by manually causing the protocol to fail. Below shows what this will look like in the `abr-robot-alerts` slack channel

<img width="836" height="242" alt="Screenshot 2025-09-15 at 4 37 05 PM" src="https://github.com/user-attachments/assets/f35cb489-470c-4a87-bc79-2fd609948f11" />
