### PR TITLE
fix(protocol-designer): include stack traces for console events to Sentry

### DIFF
--- a/protocol-designer/src/resources/sentry.ts
+++ b/protocol-designer/src/resources/sentry.ts
@@ -41,6 +41,7 @@ export const initializeSentry = (state: BaseState): void => {
           replayIntegration(),
           browserTracingIntegration(),
         ],
+        attachStacktrace: true, // include stack traces in captureConsoleIntegration
         tracesSampleRate: 1.0,
         tracePropagationTargets: [
           'localhost',


### PR DESCRIPTION
# Overview

We previously started capturing `console.assert()` failures to Sentry. However, by default, these events do NOT report the stack trace to Sentry. Without the stack trace, Sentry has no way to tell that `console.assert()` failures are coming from the same place in the code, so we end up with dozens of separate `expected to find a matching labware def` reports in Sentry.

This PR configures Sentry to send the stack trace with these `console.assert()` messages. After this change, Sentry should be able to group them together if they are coming from the same place in the code. https://docs.sentry.io/platforms/javascript/configuration/options/#attachStacktrace

## Test Plan and Hands on Testing

Run CI tests. But we'd have to deploy to see the effect.

## Risk assessment

Low.