### PR TITLE
refactor(js): Minor cleanups to the global scope

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -71,6 +71,14 @@ module.exports = {
         ],
       },
     ],
+
+    'no-restricted-globals': [
+      'error',
+      {
+        name: 'global',
+        message: "Use 'globalThis' instead.",
+      },
+    ],
   },
 
   globals: {},

--- a/app-shell-odd/src/preload.ts
+++ b/app-shell-odd/src/preload.ts
@@ -3,4 +3,4 @@
 // for security reasons
 import { ipcRenderer } from 'electron'
 
-global.APP_SHELL_REMOTE = { ipcRenderer }
+globalThis.APP_SHELL_REMOTE = { ipcRenderer }

--- a/app-shell-odd/src/preload.ts
+++ b/app-shell-odd/src/preload.ts
@@ -3,5 +3,4 @@
 // for security reasons
 import { ipcRenderer } from 'electron'
 
-// @ts-expect-error can't get TS to recognize global.d.ts
 global.APP_SHELL_REMOTE = { ipcRenderer }

--- a/app-shell-odd/typings/global.d.ts
+++ b/app-shell-odd/typings/global.d.ts
@@ -1,11 +1,6 @@
-declare global {
-  namespace NodeJS {
-    export interface Global {
-      APP_SHELL_REMOTE: {
-        ipcRenderer: IpcRenderer
-      }
-    }
-  }
+/* eslint-disable no-var */
+declare var APP_SHELL_REMOTE: {
+  ipcRenderer: IpcRenderer
 }
 
 declare const _PKG_VERSION_: string

--- a/app-shell-odd/vite.config.mts
+++ b/app-shell-odd/vite.config.mts
@@ -63,7 +63,6 @@ export default defineConfig(
           NODE_ENV: process.env.NODE_ENV,
           OPENTRONS_PROJECT: process.env.OPENTRONS_PROJECT,
         },
-        global: 'globalThis',
         _PKG_VERSION_: JSON.stringify(version),
         _PKG_PRODUCT_NAME_: JSON.stringify(pkg.productName),
         _PKG_BUGS_URL_: JSON.stringify(pkg.bugs.url),

--- a/app-shell/src/config/migrate.ts
+++ b/app-shell/src/config/migrate.ts
@@ -47,8 +47,11 @@ export const DEFAULTS_V0: ConfigV0 = {
 
   // app update config
   update: {
-    // @ts-expect-error can't get TS to recognize global.d.ts
-    channel: [].includes('beta') ? 'beta' : 'latest',
+    channel: 'latest',
+    // todo(mm, 2025-09-15): We used to set this more dynamically depending on _PKG_VERSION_,
+    // but that got dropped during the Vite migration, possibly because of type-checking problems
+    // that have since been resolved. Do we want to restore this?
+    // channel: _PKG_VERSION_.includes('beta') ? 'beta' : 'latest',
   },
 
   buildroot: {

--- a/app-shell/src/preload.ts
+++ b/app-shell/src/preload.ts
@@ -11,5 +11,4 @@ const getFilePathFrom = (file: File): Promise<string> => {
   return Promise.resolve(webUtils.getPathForFile(file))
 }
 
-// @ts-expect-error can't get TS to recognize global.d.ts
 global.APP_SHELL_REMOTE = { ipcRenderer, getFilePathFrom }

--- a/app-shell/src/preload.ts
+++ b/app-shell/src/preload.ts
@@ -11,4 +11,4 @@ const getFilePathFrom = (file: File): Promise<string> => {
   return Promise.resolve(webUtils.getPathForFile(file))
 }
 
-global.APP_SHELL_REMOTE = { ipcRenderer, getFilePathFrom }
+globalThis.APP_SHELL_REMOTE = { ipcRenderer, getFilePathFrom }

--- a/app-shell/typings/global.d.ts
+++ b/app-shell/typings/global.d.ts
@@ -1,7 +1,5 @@
 /* eslint-disable no-var */
-declare global {
-  var APP_SHELL_REMOTE: { ipcRenderer: IpcRenderer; [key: string]: any }
-}
+declare var APP_SHELL_REMOTE: { ipcRenderer: IpcRenderer; [key: string]: any }
 
 declare const _PKG_VERSION_: string
 declare const _PKG_PRODUCT_NAME_: string

--- a/app-shell/vite.config.mts
+++ b/app-shell/vite.config.mts
@@ -41,7 +41,6 @@ export default defineConfig(
           NODE_ENV: process.env.NODE_ENV,
           OPENTRONS_PROJECT: process.env.OPENTRONS_PROJECT,
         },
-        global: 'globalThis',
         _PKG_VERSION_: JSON.stringify(version),
         _PKG_PRODUCT_NAME_: JSON.stringify(pkg.productName),
         _PKG_BUGS_URL_: JSON.stringify(pkg.bugs.url),

--- a/app/src/App/portal.tsx
+++ b/app/src/App/portal.tsx
@@ -3,10 +3,16 @@ import { Box } from '@opentrons/components'
 export const TOP_PORTAL_ID = '__otAppTopPortalRoot'
 export const MODAL_PORTAL_ID = '__otAppModalPortalRoot'
 export function getTopPortalEl(): HTMLElement {
-  return global.document.getElementById(TOP_PORTAL_ID) ?? global.document.body
+  return (
+    globalThis.document.getElementById(TOP_PORTAL_ID) ??
+    globalThis.document.body
+  )
 }
 export function getModalPortalEl(): HTMLElement {
-  return global.document.getElementById(MODAL_PORTAL_ID) ?? global.document.body
+  return (
+    globalThis.document.getElementById(MODAL_PORTAL_ID) ??
+    globalThis.document.body
+  )
 }
 
 export function PortalRoot(): JSX.Element {

--- a/app/src/organisms/Desktop/Devices/RobotSettings/AdvancedTab/__tests__/OpenJupyterControl.test.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/AdvancedTab/__tests__/OpenJupyterControl.test.tsx
@@ -18,7 +18,7 @@ const mockIpAddress = '1.1.1.1'
 const mockLink = `http://${mockIpAddress}:48888`
 const trackEvent = vi.fn()
 
-global.window = Object.create(window)
+globalThis.window = Object.create(window)
 Object.defineProperty(window, 'open', { writable: true, configurable: true })
 window.open = vi.fn()
 

--- a/app/src/organisms/Desktop/RobotSettingsCalibration/__tests__/CalibrationDataDownload.test.tsx
+++ b/app/src/organisms/Desktop/RobotSettingsCalibration/__tests__/CalibrationDataDownload.test.tsx
@@ -78,17 +78,17 @@ const render = () => {
 }
 
 describe('CalibrationDataDownload', () => {
-  const realBlob = global.Blob
+  const realBlob = globalThis.Blob
 
   beforeAll(() => {
     // @ts-expect-error(sa, 2021-6-28): not a valid blob interface
-    global.Blob = function (content: any, options: any) {
+    globalThis.Blob = function (content: any, options: any) {
       return { content, options }
     }
   })
 
   afterAll(() => {
-    global.Blob = realBlob
+    globalThis.Blob = realBlob
   })
 
   beforeEach(() => {

--- a/app/src/redux/analytics/hash.ts
+++ b/app/src/redux/analytics/hash.ts
@@ -8,7 +8,7 @@ export function hash(source: string): Promise<string> {
   const data = encoder.encode(source)
 
   // https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/digest
-  return global.crypto.subtle
+  return globalThis.crypto.subtle
     .digest(ALGORITHM, data)
     .then((digest: ArrayBuffer) => arrayBufferToHex(digest))
 }

--- a/app/src/redux/robot-api/__tests__/http.test.ts
+++ b/app/src/redux/robot-api/__tests__/http.test.ts
@@ -23,7 +23,7 @@ describe('robot-api http client', () => {
   let robot: RobotHost
 
   beforeAll(() => {
-    ;(global as any).fetch = fetch
+    ;(globalThis as any).fetch = fetch
     testApp = express()
     testApp.use((express as any).json())
 
@@ -55,7 +55,7 @@ describe('robot-api http client', () => {
 
   afterAll(() => {
     // @ts-expect-error(sa, 2021-6-28): can't delete non optional properties
-    delete global.fetch
+    delete globalThis.fetch
 
     if (testServer) {
       const close = promisify(testServer.close.bind(testServer))

--- a/app/src/redux/shell/remote.ts
+++ b/app/src/redux/shell/remote.ts
@@ -12,15 +12,15 @@ const emptyRemote: Remote = {} as any
 export const remote: Remote = new Proxy(emptyRemote, {
   get(_target, propName: string): unknown {
     console.assert(
-      global.APP_SHELL_REMOTE,
+      globalThis.APP_SHELL_REMOTE,
       'Expected APP_SHELL_REMOTE to be attached to global scope; is app-shell/src/preload.ts properly configured?'
     )
 
     console.assert(
-      propName in global.APP_SHELL_REMOTE,
+      propName in globalThis.APP_SHELL_REMOTE,
       `Expected APP_SHELL_REMOTE.${propName} to exist, is app-shell/src/preload.ts properly configured?`
     )
-    return global.APP_SHELL_REMOTE[propName] as Remote
+    return globalThis.APP_SHELL_REMOTE[propName] as Remote
   },
 })
 

--- a/app/src/redux/shell/remote.ts
+++ b/app/src/redux/shell/remote.ts
@@ -12,15 +12,15 @@ const emptyRemote: Remote = {} as any
 export const remote: Remote = new Proxy(emptyRemote, {
   get(_target, propName: string): unknown {
     console.assert(
-      (global as any).APP_SHELL_REMOTE,
+      global.APP_SHELL_REMOTE,
       'Expected APP_SHELL_REMOTE to be attached to global scope; is app-shell/src/preload.ts properly configured?'
     )
 
     console.assert(
-      propName in (global as any).APP_SHELL_REMOTE,
+      propName in global.APP_SHELL_REMOTE,
       `Expected APP_SHELL_REMOTE.${propName} to exist, is app-shell/src/preload.ts properly configured?`
     )
-    return (global as any).APP_SHELL_REMOTE[propName] as Remote
+    return global.APP_SHELL_REMOTE[propName] as Remote
   },
 })
 

--- a/app/vite.config.mts
+++ b/app/vite.config.mts
@@ -56,7 +56,6 @@ export default defineConfig(
           OT_APP_MIXPANEL_ID: process.env.OT_APP_MIXPANEL_ID,
           OPENTRONS_PROJECT: process.env.OPENTRONS_PROJECT,
         },
-        global: 'globalThis',
         _PKG_VERSION_: JSON.stringify(version),
         _OPENTRONS_PROJECT_: JSON.stringify(project),
       },

--- a/components/vite.config.mts
+++ b/components/vite.config.mts
@@ -53,7 +53,6 @@ export default defineConfig({
   },
   define: {
     'process.env': process.env,
-    global: 'globalThis',
   },
   resolve: {
     alias: {

--- a/discovery-client/vite.config.mts
+++ b/discovery-client/vite.config.mts
@@ -52,7 +52,6 @@ export default defineConfig(
       },
       define: {
         'process.env': process.env,
-        global: 'globalThis',
         _PKG_VERSION_: JSON.stringify(version),
         _PKG_BUGS_URL_: JSON.stringify(pkg.bugs.url),
         _OPENTRONS_PROJECT_: JSON.stringify(project),

--- a/labware-designer/vite.config.mts
+++ b/labware-designer/vite.config.mts
@@ -39,7 +39,6 @@ export default defineConfig({
   },
   define: {
     'process.env': process.env,
-    global: 'globalThis',
   },
   resolve: {
     alias: {

--- a/labware-library/src/analytics/utils.ts
+++ b/labware-library/src/analytics/utils.ts
@@ -12,7 +12,7 @@ const persistAnalyticsCookie = (cookies: AnalyticsState): void => {
   const maxAge = 10 * 365 * 24 * 60 * 60 // 10 years
   const options = { COOKIE_DOMAIN, maxAge }
 
-  global.document.cookie = cookie.serialize(
+  globalThis.document.cookie = cookie.serialize(
     COOKIE_KEY_NAME,
     JSON.stringify(cookies),
     options
@@ -20,7 +20,7 @@ const persistAnalyticsCookie = (cookies: AnalyticsState): void => {
 }
 
 const getAnalyticsCookie = (): AnalyticsState => {
-  const cookies = cookie.parse(global.document.cookie)
+  const cookies = cookie.parse(globalThis.document.cookie)
   const analyticsCookie =
     cookies[COOKIE_KEY_NAME] != null ? JSON.parse(cookies[COOKIE_KEY_NAME]) : {}
   return analyticsCookie

--- a/labware-library/src/analytics/utils.ts
+++ b/labware-library/src/analytics/utils.ts
@@ -12,7 +12,7 @@ const persistAnalyticsCookie = (cookies: AnalyticsState): void => {
   const maxAge = 10 * 365 * 24 * 60 * 60 // 10 years
   const options = { COOKIE_DOMAIN, maxAge }
 
-  ;(global as any).document.cookie = cookie.serialize(
+  global.document.cookie = cookie.serialize(
     COOKIE_KEY_NAME,
     JSON.stringify(cookies),
     options
@@ -20,7 +20,7 @@ const persistAnalyticsCookie = (cookies: AnalyticsState): void => {
 }
 
 const getAnalyticsCookie = (): AnalyticsState => {
-  const cookies = cookie.parse((global as any).document.cookie as string)
+  const cookies = cookie.parse(global.document.cookie)
   const analyticsCookie =
     cookies[COOKIE_KEY_NAME] != null ? JSON.parse(cookies[COOKIE_KEY_NAME]) : {}
   return analyticsCookie

--- a/labware-library/vite.config.mts
+++ b/labware-library/vite.config.mts
@@ -50,7 +50,6 @@ export default defineConfig({
   },
   define: {
     'process.env': process.env,
-    global: 'globalThis',
   },
   resolve: {
     alias: {

--- a/opentrons-ai-client/src/OpentronsAI.tsx
+++ b/opentrons-ai-client/src/OpentronsAI.tsx
@@ -104,7 +104,7 @@ function OpentronsAIApp(): JSX.Element | null {
     return null
   }
 
-  global.enablePrereleaseMode = () => {
+  globalThis.enablePrereleaseMode = () => {
     setFeatureFlags({ enablePrereleaseMode: true })
   }
 

--- a/opentrons-ai-client/src/components/organisms/LabwareModal/index.tsx
+++ b/opentrons-ai-client/src/components/organisms/LabwareModal/index.tsx
@@ -263,7 +263,7 @@ export function LabwareModal({
               </Flex>
             </Flex>
           </Modal>,
-          global.document.body
+          globalThis.document.body
         )}
     </>
   )

--- a/opentrons-ai-client/src/pages/UpdateProtocol/__tests__/UpdateProtocol.test.tsx
+++ b/opentrons-ai-client/src/pages/UpdateProtocol/__tests__/UpdateProtocol.test.tsx
@@ -8,8 +8,8 @@ import { UpdateProtocol } from '../index'
 
 import type { NavigateFunction } from 'react-router-dom'
 
-// global.Blob = BlobPolyfill as any
-global.Blob = require('node:buffer').Blob
+// globalThis.Blob = BlobPolyfill as any
+globalThis.Blob = require('node:buffer').Blob
 
 const mockNavigate = vi.fn()
 const mockUseTrackEvent = vi.fn()

--- a/opentrons-ai-client/vite.config.mts
+++ b/opentrons-ai-client/vite.config.mts
@@ -44,7 +44,6 @@ export default defineConfig({
   },
   define: {
     'process.env': process.env,
-    global: 'globalThis',
   },
   resolve: {
     alias: {

--- a/protocol-designer/src/__tests__/persist.test.ts
+++ b/protocol-designer/src/__tests__/persist.test.ts
@@ -9,7 +9,7 @@ describe('persist', () => {
   let setItemSpy: MockInstance<(key: string, value: string) => void>
 
   beforeEach(() => {
-    const LocalStorageProto = Object.getPrototypeOf(global.localStorage)
+    const LocalStorageProto = Object.getPrototypeOf(globalThis.localStorage)
     getItemSpy = vi.spyOn(LocalStorageProto, 'getItem') as MockInstance<
       (key: string) => string | null
     >

--- a/protocol-designer/src/components/organisms/AssignLiquidsModal/LiquidToolbox.tsx
+++ b/protocol-designer/src/components/organisms/AssignLiquidsModal/LiquidToolbox.tsx
@@ -147,7 +147,7 @@ export function LiquidToolbox({
 
   const handleClearSelectedWells: () => void = () => {
     if (labwareId != null && selectedWells != null && selectionHasLiquids) {
-      if (global.confirm(t('application:are_you_sure') as string)) {
+      if (globalThis.confirm(t('application:are_you_sure') as string)) {
         dispatch(
           removeWellsContents({
             labwareId,
@@ -164,7 +164,9 @@ export function LiquidToolbox({
   const handleClearAllWells: () => void = () => {
     if (labwareId != null && activeItemHasLiquids) {
       if (
-        global.confirm(t('application:are_you_sure_clear_all_wells') as string)
+        globalThis.confirm(
+          t('application:are_you_sure_clear_all_wells') as string
+        )
       ) {
         dispatch(
           removeWellsContents({

--- a/protocol-designer/src/configureStore.ts
+++ b/protocol-designer/src/configureStore.ts
@@ -109,7 +109,7 @@ export function configureStore(): StoreType {
   store.dispatch(rehydratePersistedAction())
   store.subscribe(makePersistSubscriber(store))
 
-  global.enablePrereleaseMode = () => {
+  globalThis.enablePrereleaseMode = () => {
     store.dispatch({
       type: 'SET_FEATURE_FLAGS',
       payload: {

--- a/protocol-designer/src/labware-ingred/actions/actions.ts
+++ b/protocol-designer/src/labware-ingred/actions/actions.ts
@@ -149,7 +149,7 @@ export const deleteLiquidGroup: (
   const liquidIsOnDeck = allLiquidGroups.includes(liquidGroupId)
 
   const okToDelete = liquidIsOnDeck
-    ? global.confirm(
+    ? globalThis.confirm(
         'This liquid has been placed on the deck, are you sure you want to delete it?'
       )
     : true

--- a/protocol-designer/src/networking/opentronsWebApi.ts
+++ b/protocol-designer/src/networking/opentronsWebApi.ts
@@ -1,2 +1,2 @@
 export const getIsProduction = (): boolean =>
-  global.location.host === 'designer.opentrons.com'
+  globalThis.location.host === 'designer.opentrons.com'

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/ConnectedStepContainer.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/ConnectedStepContainer.tsx
@@ -124,9 +124,9 @@ export function ConnectedStepContainer(
   }
 
   useEffect(() => {
-    global.addEventListener('click', handleClick)
+    globalThis.addEventListener('click', handleClick)
     return () => {
-      global.removeEventListener('click', handleClick)
+      globalThis.removeEventListener('click', handleClick)
     }
   })
 

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/TimelineToolbox.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/TimelineToolbox.tsx
@@ -94,10 +94,10 @@ export function TimelineToolbox({
       handleKeyDown(e)
     }
 
-    global.addEventListener('keydown', onKeyDown, false)
+    globalThis.addEventListener('keydown', onKeyDown, false)
 
     return () => {
-      global.removeEventListener('keydown', onKeyDown, false)
+      globalThis.removeEventListener('keydown', onKeyDown, false)
     }
   }, [])
 

--- a/protocol-designer/src/persist.ts
+++ b/protocol-designer/src/persist.ts
@@ -18,7 +18,7 @@ export interface RehydratePersistedAction {
 }
 export const getLocalStorageItem = (path: string): unknown => {
   try {
-    const persisted = global.localStorage.getItem(_addStoragePrefix(path))
+    const persisted = globalThis.localStorage.getItem(_addStoragePrefix(path))
     return persisted ? JSON.parse(persisted) : undefined
   } catch (e) {
     console.error('Could not rehydrate:', e)
@@ -80,7 +80,7 @@ function transformBeforePersist(
 
 export const setLocalStorageItem = (path: string, value: any): void => {
   try {
-    global.localStorage.setItem(
+    globalThis.localStorage.setItem(
       _addStoragePrefix(path),
       JSON.stringify(transformBeforePersist(path, value))
     )

--- a/protocol-designer/src/ui/steps/actions/__tests__/actions.test.ts
+++ b/protocol-designer/src/ui/steps/actions/__tests__/actions.test.ts
@@ -135,7 +135,7 @@ describe('steps actions', () => {
         .calledWith(expect.anything())
         .thenReturn(null)
       const consoleWarnSpy = vi
-        .spyOn(global.console, 'warn')
+        .spyOn(globalThis.console, 'warn')
         .mockImplementation(() => null)
       const store: any = mockStore()
       store.dispatch(deselectAllSteps())

--- a/protocol-designer/src/ui/steps/utils.ts
+++ b/protocol-designer/src/ui/steps/utils.ts
@@ -10,7 +10,7 @@ export const MAIN_CONTENT_FORCED_SCROLL_CLASSNAME = 'main_content_forced_scroll'
 // being positioned absolute until we can figure out something better
 export const resetScrollElements = (): void => {
   forEach(
-    global.document.getElementsByClassName(
+    globalThis.document.getElementsByClassName(
       MAIN_CONTENT_FORCED_SCROLL_CLASSNAME
     ),
     elem => {

--- a/protocol-designer/vite.config.mts
+++ b/protocol-designer/vite.config.mts
@@ -82,7 +82,6 @@ export default defineConfig(
       },
       define: {
         'process.env': { ...process.env, OT_PD_VERSION, OT_PD_BUILD_DATE },
-        global: 'globalThis',
       },
       resolve: {
         alias: {

--- a/shared-data/vite.config.mts
+++ b/shared-data/vite.config.mts
@@ -20,6 +20,5 @@ export default defineConfig({
   },
   define: {
     'process.env': process.env,
-    global: 'globalThis',
   },
 })

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -42,7 +42,6 @@ export default defineConfig({
   },
   define: {
     'process.env': process.env,
-    global: 'globalThis',
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Overview

Minor improvements to our Vite config and TypeScript declarations.

## Changelog

* All of our projects were configuring Vite to replace `global` with `globalThis`. (As I understand it, `global` is a historical Node-ism, and `globalThis` is the modern standard cross-environment replacement.) With this PR, our source code just spells out `globalThis` directly, and we can delete that bit of Vite config. There's a lint rule to prevent us from using `global` in the future.
* Separately, fix some .d.ts problems and associated `// @ts-expect-error`s. The trick seems to be that if the .d.ts file is a module, you gotta wrap it with `declare global {}`, and if it's not a module, you gotta not. 🤷 

## Test Plan and Hands on Testing

Just CI.

## Review requests

None in particular.

## Risk assessment

Low.