### PR TITLE
fix(api): Ensure parent to lid stack is valid source for move lid action

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/protocol.py
+++ b/api/src/opentrons/protocol_api/core/engine/protocol.py
@@ -497,13 +497,28 @@ class ProtocolCore(
             )
         # if this is a labware with a lid, we just need to find its lid_id
         else:
-            lid = self._engine_client.state.labware.get_lid_by_labware_id(
-                labware.labware_id
+            # we need to check to see if this labware is hosting a lid stack
+            potential_lid_stack = (
+                self._engine_client.state.labware.get_next_child_labware(
+                    labware.labware_id
+                )
             )
-            if lid is not None:
-                lid_id = lid.id
+            if potential_lid_stack and labware_validation.is_lid_stack(
+                self._engine_client.state.labware.get_load_name(potential_lid_stack)
+            ):
+                lid_id = self._engine_client.state.labware.get_highest_child_labware(
+                    labware.labware_id
+                )
             else:
-                raise ValueError("Cannot move a lid off of a labware with no lid.")
+                lid = self._engine_client.state.labware.get_lid_by_labware_id(
+                    labware.labware_id
+                )
+                if lid is not None:
+                    lid_id = lid.id
+                else:
+                    raise ValueError(
+                        f"Cannot move a lid off of a labware with no lid. {labware.get_display_name()}"
+                    )
 
         _pick_up_offset = (
             LabwareOffsetVector(
@@ -607,6 +622,9 @@ class ProtocolCore(
         )
 
         # Handle leftover empty lid stack if there is one
+        potential_lid_stack = self._engine_client.state.labware.get_next_child_labware(
+            labware.labware_id
+        )
         if (
             labware_validation.is_lid_stack(labware.load_name)
             and self._engine_client.state.labware.get_highest_child_labware(
@@ -618,6 +636,25 @@ class ProtocolCore(
             self._engine_client.execute_command(
                 cmd.MoveLabwareParams(
                     labwareId=labware.labware_id,
+                    newLocation=SYSTEM_LOCATION,
+                    strategy=LabwareMovementStrategy.MANUAL_MOVE_WITHOUT_PAUSE,
+                    pickUpOffset=None,
+                    dropOffset=None,
+                )
+            )
+        elif (
+            potential_lid_stack
+            and labware_validation.is_lid_stack(
+                self._engine_client.state.labware.get_load_name(potential_lid_stack)
+            )
+            and self._engine_client.state.labware.get_highest_child_labware(
+                potential_lid_stack
+            )
+            == potential_lid_stack
+        ):
+            self._engine_client.execute_command(
+                cmd.MoveLabwareParams(
+                    labwareId=potential_lid_stack,
                     newLocation=SYSTEM_LOCATION,
                     strategy=LabwareMovementStrategy.MANUAL_MOVE_WITHOUT_PAUSE,
                     pickUpOffset=None,

--- a/api/src/opentrons/protocol_api/core/engine/protocol.py
+++ b/api/src/opentrons/protocol_api/core/engine/protocol.py
@@ -517,7 +517,7 @@ class ProtocolCore(
                     lid_id = lid.id
                 else:
                     raise ValueError(
-                        f"Cannot move a lid off of a labware with no lid. {labware.get_display_name()}"
+                        f"Cannot move a lid off of {labware.get_display_name()} because it has no lid."
                     )
 
         _pick_up_offset = (

--- a/api/tests/opentrons/protocol_api/test_protocol_context.py
+++ b/api/tests/opentrons/protocol_api/test_protocol_context.py
@@ -1122,6 +1122,112 @@ def test_move_lids_from_stack(
     assert isinstance(result, Labware)
 
 
+@pytest.mark.parametrize("api_version", [APIVersion(2, 23)])
+def test_move_lids_from_stack_via_stack_parent(
+    decoy: Decoy,
+    mock_core: ProtocolCore,
+    mock_core_map: LoadedCoreMap,
+    api_version: APIVersion,
+    subject: ProtocolContext,
+) -> None:
+    """It should move a lid onto an empty riser, create a stack, and then move the lid back off by referencing the riser."""
+    decoy.when(mock_core.robot_type).then_return("OT-3 Standard")
+    decoy.when(
+        mock_validation.ensure_and_convert_deck_slot(42, api_version, "OT-3 Standard")
+    ).then_return(DeckSlotName.SLOT_C1)
+    mock_riser_core = decoy.mock(cls=LabwareCore)
+    decoy.when(mock_validation.ensure_lowercase_name("RISER_LABWARE")).then_return(
+        "riser_labware"
+    )
+    decoy.when(
+        mock_core.load_labware(
+            load_name="riser_labware",
+            location=DeckSlotName.SLOT_C1,
+            label=None,
+            namespace="some_namespace",
+            version=1337,
+        )
+    ).then_return(mock_riser_core)
+
+    decoy.when(mock_riser_core.get_name()).then_return("RISER_LABWARE")
+    decoy.when(mock_riser_core.get_display_name()).then_return("")
+    decoy.when(mock_riser_core.get_well_columns()).then_return([])
+
+    riser_lw = subject.load_labware(
+        load_name="RISER_LABWARE",
+        location=42,
+        label=None,
+        namespace="some_namespace",
+        version=1337,
+    )
+    assert isinstance(riser_lw, Labware)
+
+    # Load the lid stack on top of the riser
+    mock_lid_core = decoy.mock(cls=LabwareCore)
+    decoy.when(mock_validation.ensure_lowercase_name("UPPERCASE_LID")).then_return(
+        "lowercase_lid"
+    )
+    decoy.when(mock_core.robot_type).then_return("OT-3 Standard")
+    decoy.when(
+        mock_core.load_lid_stack(
+            load_name="lowercase_lid",
+            location=riser_lw._core,
+            quantity=1,
+            namespace="some_namespace",
+            version=1337,
+        )
+    ).then_return(mock_lid_core)
+
+    decoy.when(mock_lid_core.get_name()).then_return("STACK_OBJECT")
+    decoy.when(mock_lid_core.get_display_name()).then_return("")
+    decoy.when(mock_lid_core.get_well_columns()).then_return([])
+
+    result = subject.load_lid_stack(
+        load_name="UPPERCASE_LID",
+        location=riser_lw,
+        quantity=1,
+        namespace="some_namespace",
+        version=1337,
+    )
+
+    assert isinstance(result, Labware)
+    assert result.name == "STACK_OBJECT"
+
+    # Move the lid, by referencing only the riser itself
+    subject.move_lid(riser_lw, "D3")
+
+    # Load another lid stack where the lidstack once was, verifying its engine object is gone
+    mock_lid_core_2 = decoy.mock(cls=LabwareCore)
+    decoy.when(mock_validation.ensure_lowercase_name("UPPERCASE_LID_2")).then_return(
+        "lowercase_lid_2"
+    )
+    decoy.when(mock_core.robot_type).then_return("OT-3 Standard")
+    decoy.when(
+        mock_core.load_lid_stack(
+            load_name="lowercase_lid_2",
+            location=riser_lw._core,
+            quantity=1,
+            namespace="some_namespace",
+            version=1337,
+        )
+    ).then_return(mock_lid_core_2)
+
+    decoy.when(mock_lid_core_2.get_name()).then_return("STACK_OBJECT_2")
+    decoy.when(mock_lid_core_2.get_display_name()).then_return("")
+    decoy.when(mock_lid_core_2.get_well_columns()).then_return([])
+
+    result_2 = subject.load_lid_stack(
+        load_name="UPPERCASE_LID_2",
+        location=riser_lw,
+        quantity=1,
+        namespace="some_namespace",
+        version=1337,
+    )
+
+    assert isinstance(result_2, Labware)
+    assert result_2.name == "STACK_OBJECT_2"
+
+
 @pytest.mark.parametrize("api_version", [APIVersion(2, 22)])
 def test_move_labware_lids_old(
     decoy: Decoy,


### PR DESCRIPTION
# Overview
Partially covers RESC-498

In testing the protocol related to the issue in the ticket mentioned, it was discovered that if a user supplies the parent labware to a dynamically allocated lid stack as a source for a `move_lid` command then they will get an error. Providing labware as a source for a lid stack is something that our API allows, but in the case of dynamically created stacks it was not working. This PR fixes that by allowing the `move_lid logic` to identify lid stacks by their relative parent as an extension of their base behavior.

## Test Plan and Hands on Testing

- [x] Implement unit test to enforce behavior
- [x] The following protocol should pass analysis:
```
def run(protocol: protocol_api.ProtocolContext):
    dest_plate_1 = protocol.load_labware("corning_96_wellplate_360ul_flat", location="A2", lid ="corning_96_wellplate_360ul_flat_lid")
    dest_plate_2 = protocol.load_labware("corning_96_wellplate_360ul_flat", location="A3", lid ="corning_96_wellplate_360ul_flat_lid")
    dest_plate_3 = protocol.load_labware("corning_96_wellplate_360ul_flat", location="B1", lid ="corning_96_wellplate_360ul_flat_lid")
    dest_plate_4 = protocol.load_labware("corning_96_wellplate_360ul_flat", location="B2", lid ="corning_96_wellplate_360ul_flat_lid")

    # Riser labware to host lid stacks
    riser = protocol.load_adapter("opentrons_flex_deck_riser", location="B4")
    
    # Move lids to the stack
    protocol.move_lid(dest_plate_1, riser, use_gripper=True)
    protocol.move_lid(dest_plate_2, riser, use_gripper=True)
    protocol.move_lid(dest_plate_3, riser, use_gripper=True)
    protocol.move_lid(dest_plate_4, riser, use_gripper=True)

    # Move lids back off the stack by referencing parent labware
    protocol.move_lid(riser, dest_plate_1, True)
    protocol.move_lid(riser, dest_plate_2, True)
    protocol.move_lid(riser, dest_plate_3, True)
    protocol.move_lid(riser, dest_plate_4, True)
```

## Changelog
Update `move_lid` function to correctly identify child lid stacks by a given parent labware

## Review requests

## Risk assessment
Med/Low - Fixes an existing bug regarding acceptable fields for the `move_lid` command