### PR TITLE
(docs): add low-volume 96-channel pipette specs to manual

### DIFF
--- a/docs/flex/docs/system-description/pipettes.md
+++ b/docs/flex/docs/system-description/pipettes.md
@@ -72,7 +72,7 @@ Flex 1-channel pipettes meet the following accuracy and precision specifications
       <td>0.40%</td>
     </tr>
     <tr>
-      <td rowspan="4"><b>1-1000 µL</b></td>
+      <td rowspan="4"><b>5-1000 µL</b></td>
       <td>50 µL</td>
       <td>5 µL</td>
       <td>± 5.00%</td>
@@ -134,7 +134,7 @@ Flex 8-channel pipettes meet the following accuracy and precision specifications
       <td>0.60%</td>
     </tr>
     <tr>
-      <td rowspan="4"><b>1-1000 µL</b></td>
+      <td rowspan="4"><b>5-1000 µL</b></td>
       <td>50 µL</td>
       <td>5 µL</td>
       <td>± 8.00%</td>

--- a/docs/flex/docs/system-description/pipettes.md
+++ b/docs/flex/docs/system-description/pipettes.md
@@ -35,7 +35,7 @@ Opentrons Flex pipettes are designed to handle a wide range of liquid volumes an
 !!!note
     You *do not* have to calibrate the volume that your pipettes dispense before use. You only have to perform positional calibration. See [Pipette calibration](pipettes.md#pipette-calibration) below, as well as the [Pipette Installation section][pipette-installation] of the Installation and Relocation chapter, for details.
 
-The following tables list the accuracy and precision specifications for Opentrons Flex 1-, 8-, and 96-channel pipettes.
+The following tables list the accuracy and precision specifications for Opentrons Flex pipettes.
 
 
 ### 1-channel pipette specifications

--- a/docs/flex/docs/system-description/pipettes.md
+++ b/docs/flex/docs/system-description/pipettes.md
@@ -72,7 +72,7 @@ Flex 1-channel pipettes meet the following accuracy and precision specifications
       <td>0.40%</td>
     </tr>
     <tr>
-      <td rowspan="4"><b>1-1000 µL</td>
+      <td rowspan="4"><b>1-1000 µL</b></td>
       <td>50 µL</td>
       <td>5 µL</td>
       <td>± 5.00%</td>
@@ -176,7 +176,8 @@ Flex 96-channel pipettes meet the following accuracy and precision specification
     </tr>
   </thead>
   <tbody>
-    <td rowspan="4"><b>1-200 µL</b></td>
+    <tr>
+      <td rowspan="4"><b>1-200 µL</b></td>
       <td>50 µL</td>
       <td>1 µL</td>
       <td>± 10%</td>

--- a/docs/flex/docs/system-description/pipettes.md
+++ b/docs/flex/docs/system-description/pipettes.md
@@ -53,47 +53,47 @@ Flex 1-channel pipettes meet the following accuracy and precision specifications
   </thead>
   <tbody>
     <tr>
-      <td rowspan="3"><b>1-50 µL</b></td>
-      <td>50 µL</td>
-      <td>1 µL</td>
-      <td>± 8.00%</td>
+      <td rowspan="3"><b>1–50 µL</b></td>
+      <td>50 µL</td>
+      <td>1 µL</td>
+      <td>±8.00%</td>
       <td>7.00%</td>
     </tr>
     <tr>
       <td>50 µL</td>
       <td>10 µL</td>
-      <td>± 1.50%</td>
+      <td>±1.50%</td>
       <td>0.50%</td>
     </tr>
     <tr>
       <td>50 µL</td>
       <td>50 µL</td>
-      <td>± 1.25%</td>
+      <td>±1.25%</td>
       <td>0.40%</td>
     </tr>
     <tr>
-      <td rowspan="4"><b>5-1000 µL</b></td>
+      <td rowspan="4"><b>5-1000 µL</b></td>
       <td>50 µL</td>
       <td>5 µL</td>
-      <td>± 5.00%</td>
+      <td>±5.00%</td>
       <td>2.50%</td>
     </tr>
     <tr>
       <td>50 µL</td>
       <td>50 µL</td>
-      <td>± 0.50%</td>
+      <td>±0.50%</td>
       <td>0.30%</td>
     </tr>
     <tr>
       <td>200 µL</td>
       <td>200 µL</td>
-      <td>± 0.50%</td>
+      <td>±0.50%</td>
       <td>0.15%</td>
     </tr>
     <tr>
       <td>1000 µL</td>
       <td>1000 µL</td>
-      <td>± 0.50%</td>
+      <td>±0.50%</td>
       <td>0.15%</td>
     </tr>
   </tbody>
@@ -115,41 +115,41 @@ Flex 8-channel pipettes meet the following accuracy and precision specifications
   </thead>
   <tbody>
     <tr>
-      <td rowspan="3"><b>1-50 µL</b></td>
+      <td rowspan="3"><b>1–50 µL</b></td>
       <td>50 µL</td>
       <td>1 µL</td>
-      <td>± 10.00%</td>
+      <td>±10.00%</td>
       <td>8.00%</td>
     </tr>
     <tr>
       <td>50 µL</td>
       <td>10 µL</td>
-      <td>± 2.50%</td>
+      <td>±2.50%</td>
       <td>1.00%</td>
     </tr>
     <tr>
       <td>50 µL</td>
       <td>50 µL</td>
-      <td>± 1.25%</td>
+      <td>±1.25%</td>
       <td>0.60%</td>
     </tr>
     <tr>
-      <td rowspan="4"><b>5-1000 µL</b></td>
+      <td rowspan="4"><b>5–1000 µL</b></td>
       <td>50 µL</td>
       <td>5 µL</td>
-      <td>± 8.00%</td>
+      <td>±8.00%</td>
       <td>4%</td>
     </tr>
     <tr>
       <td>50 µL</td>
       <td>50 µL</td>
-      <td>± 2.50%</td>
+      <td>±2.50%</td>
       <td>0.60%</td>
     </tr>
     <tr>
       <td>200 µL</td>
       <td>200 µL</td>
-      <td>± 1.00%</td>
+      <td>±1.00%</td>
       <td>0.25%</td>
     </tr>
     <tr>
@@ -177,53 +177,53 @@ Flex 96-channel pipettes meet the following accuracy and precision specification
   </thead>
   <tbody>
     <tr>
-      <td rowspan="4"><b>1-200 µL</b></td>
-      <td>50 µL</td>
+      <td rowspan="4"><b>1–200 µL</b></td>
+      <td>50 µL</td>
       <td>1 µL</td>
-      <td>± 10%</td>
+      <td>±10%</td>
       <td>6%</td>
     </tr>
     <tr>
-      <td>50 µL</td>
-      <td>5 µL</td>
-      <td>± 4%</td>
-      <td>2 %</td>
-    </tr>
-    <tr>
-      <td>50 µL</td>
-      <td>50 µL</td>
-      <td>± 1.5%</td>
-      <td>1%</td>
-    </tr>
-    <tr>
-      <td>200 µL</td>
-      <td>200 µL</td>
-      <td>± 1%</td>
-      <td>1%</td>
-    </tr>
-    <tr>
-      <td rowspan="4"><b>5-1000 µL</b></td>
       <td>50 µL</td>
       <td>5 µL</td>
-      <td>± 10%</td>
+      <td>±4%</td>
+      <td>2%</td>
+    </tr>
+    <tr>
+      <td>50 µL</td>
+      <td>50 µL</td>
+      <td>±1.5%</td>
+      <td>1%</td>
+    </tr>
+    <tr>
+      <td>200 µL</td>
+      <td>200 µL</td>
+      <td>±1%</td>
+      <td>1%</td>
+    </tr>
+    <tr>
+      <td rowspan="4"><b>5–1000 µL</b></td>
+      <td>50 µL</td>
+      <td>5 µL</td>
+      <td>±10%</td>
       <td>5%</td>
     </tr>
     <tr>
       <td>50 µL</td>
       <td>50 µL</td>
-      <td>± 2.5%</td>
+      <td>±2.5%</td>
       <td>1.25%</td>
     </tr>
     <tr>
-      <td>200 µL</td>
-      <td>200 µL</td>
-      <td>± 1.5%</td>
+      <td>200 µL</td>
+      <td>200 µL</td>
+      <td>±1.5%</td>
       <td>1.25%</td>
     </tr>
     <tr>
       <td>1000 µL</td>
       <td>1000 µL</td>
-      <td>± 1.5%</td>
+      <td>±1.5%</td>
       <td>1.5%</td>
     </tr>
 </table>

--- a/docs/flex/docs/system-description/pipettes.md
+++ b/docs/flex/docs/system-description/pipettes.md
@@ -72,7 +72,7 @@ Flex 1-channel pipettes meet the following accuracy and precision specifications
       <td>0.40%</td>
     </tr>
     <tr>
-      <td rowspan="4"><b>5-1000 µL</b></td>
+      <td rowspan="4"><b>5–1000 µL</b></td>
       <td>50 µL</td>
       <td>5 µL</td>
       <td>±5.00%</td>

--- a/docs/flex/docs/system-description/pipettes.md
+++ b/docs/flex/docs/system-description/pipettes.md
@@ -37,7 +37,6 @@ Opentrons Flex pipettes are designed to handle a wide range of liquid volumes an
 
 The following tables list the accuracy and precision specifications for Opentrons Flex pipettes.
 
-
 ### 1-channel pipette specifications
 
 Flex 1-channel pipettes meet the following accuracy and precision specifications.

--- a/docs/flex/docs/system-description/pipettes.md
+++ b/docs/flex/docs/system-description/pipettes.md
@@ -12,6 +12,8 @@ Opentrons *pipettes* are configurable devices used to move liquids throughout th
 
 - Opentrons Flex 8-Channel Pipette (5–1000 µL)
 
+- Opentrons Flex 96-Channel Pipette (1–200 µL)
+
 - Opentrons Flex 96-Channel Pipette (5–1000 µL)
 
 Pipettes attach to the gantry using captive screws on the front of the pipette. 1-channel and 8-channel pipettes each occupy one *pipette mount* (left or right); the 96-channel pipette occupies both mounts. For details on installing pipettes, see [Instrument Installation and Calibration](../installation/instruments.md).
@@ -23,10 +25,169 @@ Pipettes attach to the gantry using captive screws on the front of the pipette. 
 
 The pipettes pick up disposable plastic *tips* by pressing them onto the pipette *nozzles*, and then use the tips to aspirate and dispense liquids. The amount of total force required for pickup increases as more tips get picked up simultaneously. For smaller numbers of tips, the pipette attaches tips by pushing each pipette nozzle down into a tip. To achieve the necessary force to pick up a full rack of tips, the 96-channel pipette also pulls the tips upward onto the nozzles. This pulling action requires placing tip racks into a *tip rack adapter*, rather than directly in a deck slot. To discard tips (or return them to their rack), the pipette *ejector* mechanism pushes the tips off of the nozzles.
 
-## Pipette specifications
+## Pipette accuracy and precision
 
-Opentrons Flex pipettes are designed to handle a wide range of volumes.
-Because of their wide overall range, they can use multiple sizes of tips, which affect their liquid-handling characteristics. Opentrons has tested Flex pipettes for accuracy and precision in a number of tip and liquid volume combinations:
+Opentrons Flex pipettes are designed to handle a wide range of liquid volumes and are compatible with multiple tip sizes. To help ensure accuracy and precision, Opentrons has tested the performance of these instruments with multiple tip and liquid volume combinations. The following tables list the accuracy and precision specifications for Opentrons Flex 1-, 8-, and 96-channel pipettes.
+
+### Flex 1-channel specifications
+
+<table>
+  <thead>
+    <tr>
+      <th>Instrument</th>
+      <th>Tip Capacity</th>
+      <th>Tested Volume</th>
+      <th>Accuracy %D</th>
+      <th>Precision %CV</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td rowspan="3"><b>1-Channel<br>(1-50 µL)</b></td>
+      <td>50 µL</td>
+      <td>1 µL</td>
+      <td>8.00%</td>
+      <td>7.00%</td>
+    </tr>
+    <tr>
+      <td>50 µL</td>
+      <td>10 µL</td>
+      <td>1.50%</td>
+      <td>0.50%</td>
+    </tr>
+    <tr>
+      <td>50 µL</td>
+      <td>50 µL</td>
+      <td>1.25%</td>
+      <td>0.40%</td>
+    </tr>
+    <tr>
+      <td rowspan="4"><b>1-Channel<br>(1-1000 µL)</b></td>
+      <td>50 µL</td>
+      <td>5 µL</td>
+      <td>5.00%</td>
+      <td>2.50%</td>
+    </tr>
+    <tr>
+      <td>50 µL</td>
+      <td>50 µL</td>
+      <td>0.50%</td>
+      <td>0.30%</td>
+    </tr>
+    <tr>
+      <td>200 µL</td>
+      <td>200 µL</td>
+      <td>0.50%</td>
+      <td>0.15%</td>
+    </tr>
+    <tr>
+      <td>1000 µL</td>
+      <td>1000 µL</td>
+      <td>0.50%</td>
+      <td>0.15%</td>
+    </tr>
+  </tbody>
+</table>
+
+### Flex 8-channel specifications
+
+<table>
+  <thead>
+    <tr>
+      <th>Pipette</th>
+      <th>Tip Capacity</th>
+      <th>Tested Volume</th>
+      <th>Accuracy %D</th>
+      <th>Precision %CV</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td rowspan="3"><b>Flex 8-Channel 50 µL</b></td>
+      <td>50 µL</td>
+      <td>1 µL</td>
+      <td>10.00%</td>
+      <td>8.00%</td>
+    </tr>
+    <tr>
+      <td>50 µL</td>
+      <td>10 µL</td>
+      <td>2.50%</td>
+      <td>1.00%</td>
+    </tr>
+    <tr>
+      <td>50 µL</td>
+      <td>50 µL</td>
+      <td>1.25%</td>
+      <td>0.60%</td>
+    </tr>
+    <tr>
+      <td rowspan="4"><b>Flex 8-Channel 1000 µL</b></td>
+      <td>50 µL</td>
+      <td>5 µL</td>
+      <td>8.00%</td>
+      <td>4.00%</td>
+    </tr>
+    <tr>
+      <td>50 µL</td>
+      <td>50 µL</td>
+      <td>2.50%</td>
+      <td>0.60%</td>
+    </tr>
+    <tr>
+      <td>200 µL</td>
+      <td>200 µL</td>
+      <td>1.00%</td>
+      <td>0.25%</td>
+    </tr>
+    <tr>
+      <td>1000 µL</td>
+      <td>1000 µL</td>
+      <td>0.70%</td>
+      <td>0.15%</td>
+    </tr>
+  </tbody>
+</table>
+
+### Flex 96-channel specifications
+
+<table>
+  <thead>
+    <tr>
+      <th>Pipette</th>
+      <th>Tip Capacity</th>
+      <th>Tested Volume</th>
+      <th>Accuracy %D</th>
+      <th>Precision %CV</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td rowspan="4"><b>Flex 96-Channel 1000 µL</b></td>
+      <td>50 µL</td>
+      <td>5 µL</td>
+      <td>10.00%</td>
+      <td>5.00%</td>
+    </tr>
+    <tr>
+      <td>50 µL</td>
+      <td>50 µL</td>
+      <td>2.50%</td>
+      <td>1.25%</td>
+    </tr>
+    <tr>
+      <td>200 µL</td>
+      <td>200 µL</td>
+      <td>1.50%</td>
+      <td>1.25%</td>
+    </tr>
+    <tr>
+      <td>1000 µL</td>
+      <td>1000 µL</td>
+      <td>1.50%</td>
+      <td>1.50%</td>
+    </tr>
+</table>
 
 <table>
   <thead>

--- a/docs/flex/docs/system-description/pipettes.md
+++ b/docs/flex/docs/system-description/pipettes.md
@@ -25,16 +25,19 @@ Pipettes attach to the gantry using captive screws on the front of the pipette. 
 
 The pipettes pick up disposable plastic *tips* by pressing them onto the pipette *nozzles*, and then use the tips to aspirate and dispense liquids. The amount of total force required for pickup increases as more tips get picked up simultaneously. For smaller numbers of tips, the pipette attaches tips by pushing each pipette nozzle down into a tip. To achieve the necessary force to pick up a full rack of tips, the 96-channel pipette also pulls the tips upward onto the nozzles. This pulling action requires placing tip racks into a *tip rack adapter*, rather than directly in a deck slot. To discard tips (or return them to their rack), the pipette *ejector* mechanism pushes the tips off of the nozzles.
 
-## Pipette accuracy and precision
+## Pipette specifications
 
-Opentrons Flex pipettes are designed to handle a wide range of liquid volumes and are compatible with multiple tip sizes. To help ensure accuracy and precision, Opentrons has tested the performance of these instruments with multiple tip and liquid volume combinations. The following tables list the accuracy and precision specifications for Opentrons Flex 1-, 8-, and 96-channel pipettes.
+Opentrons Flex pipettes are designed to handle a wide range of liquid volumes and are compatible with multiple tip sizes. To help ensure performance and quality, Opentrons has tested these instruments with different tips and liquid volume combinations. The following tables list the accuracy and precision specifications for Opentrons Flex 1-, 8-, and 96-channel pipettes.
+
+!!!tip
+    Refer to these tables when choosing tips for your pipette. For best results you should use the smallest tips that meet the needs of your protocol.
 
 ### Flex 1-channel specifications
 
 <table>
   <thead>
     <tr>
-      <th>Instrument</th>
+      <th>Pipette</th>
       <th>Tip Capacity</th>
       <th>Tested Volume</th>
       <th>Accuracy %D</th>
@@ -103,7 +106,7 @@ Opentrons Flex pipettes are designed to handle a wide range of liquid volumes an
   </thead>
   <tbody>
     <tr>
-      <td rowspan="3"><b>Flex 8-Channel 50 µL</b></td>
+      <td rowspan="3"><b>8-Channel<br>(1-50 µL)</b></td>
       <td>50 µL</td>
       <td>1 µL</td>
       <td>10.00%</td>
@@ -122,7 +125,7 @@ Opentrons Flex pipettes are designed to handle a wide range of liquid volumes an
       <td>0.60%</td>
     </tr>
     <tr>
-      <td rowspan="4"><b>Flex 8-Channel 1000 µL</b></td>
+      <td rowspan="4"><b>8-Channel<br>(1-1000 µL)</b></td>
       <td>50 µL</td>
       <td>5 µL</td>
       <td>8.00%</td>
@@ -163,7 +166,7 @@ Opentrons Flex pipettes are designed to handle a wide range of liquid volumes an
   </thead>
   <tbody>
     <tr>
-      <td rowspan="4"><b>Flex 96-Channel 1000 µL</b></td>
+      <td rowspan="4"><b>96-Channel<br>(1-1000 µL)</b></td>
       <td>50 µL</td>
       <td>5 µL</td>
       <td>10.00%</td>
@@ -187,8 +190,33 @@ Opentrons Flex pipettes are designed to handle a wide range of liquid volumes an
       <td>1.50%</td>
       <td>1.50%</td>
     </tr>
+    <td rowspan="4"><b>96-Channel<br>(1-200 µL)</b></td>
+      <td> µL</td>
+      <td> µL</td>
+      <td></td>
+      <td></td>
+    </tr>
+    <tr>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+    </tr>
+    <tr>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+    </tr>
+    <tr>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+    </tr>
 </table>
 
+<!-- hide original, temporary
 <table>
   <thead>
     <tr>
@@ -315,15 +343,10 @@ Opentrons Flex pipettes are designed to handle a wide range of liquid volumes an
     </tr>
   </tbody>
 </table>
-
-Keep this accuracy information in mind when choosing tips for your
-pipette. In general, for best results you should use the smallest tips
-that meet the needs of your protocol.
+-->
 
 !!! note
     Opentrons performs volumetric testing of Flex pipettes to ensure that they meet the accuracy and precision specifications listed above. You *do not* have to calibrate the volume that your pipettes dispense before use. You only have to perform positional calibration. See the next section, as well as the [Pipette Installation section][pipette-installation] of the Installation and Relocation chapter, for details.
-
-    The Opentrons Care and Opentrons Care Plus services include yearly pipette replacement and certificates of calibration. See the [Servicing Flex section](../maintenance/service.md) of the Maintenance and Service chapter for details.
 
 ## Pipette calibration
 

--- a/docs/flex/docs/system-description/pipettes.md
+++ b/docs/flex/docs/system-description/pipettes.md
@@ -27,10 +27,16 @@ The pipettes pick up disposable plastic *tips* by pressing them onto the pipette
 
 ## Pipette specifications
 
-Opentrons Flex pipettes are designed to handle a wide range of liquid volumes and are compatible with multiple tip sizes. To help ensure performance and quality, Opentrons has tested these instruments with different tips and liquid volume combinations. The following tables list the accuracy and precision specifications for Opentrons Flex 1-, 8-, and 96-channel pipettes.
+Opentrons Flex pipettes are designed to handle a wide range of liquid volumes and are compatible with multiple tip sizes. To help ensure performance and quality, Opentrons has tested these instruments with different tips and liquid volume combinations.
 
 !!!tip
-    Refer to these tables when choosing tips for your pipette. For best results you should use the smallest tips that meet the needs of your protocol.
+    For best results, use the smallest capacity tips that meet the needs of your protocol.
+
+!!!note
+    You *do not* have to calibrate the volume that your pipettes dispense before use. You only have to perform positional calibration. See [Pipette calibration](pipettes.md#pipette-calibration) below, as well as the [Pipette Installation section][pipette-installation] of the Installation and Relocation chapter, for details.
+
+The following tables list the accuracy and precision specifications for Opentrons Flex 1-, 8-, and 96-channel pipettes.
+
 
 ### 1-channel pipette specifications
 
@@ -211,7 +217,7 @@ Flex 96-channel pipettes meet the following accuracy and precision specification
     <tr>
       <td>200 µL</td>
       <td>200 µL</td>
-      <td>1.5%</td>
+      <td>± 1.5%</td>
       <td>1.25%</td>
     </tr>
     <tr>
@@ -221,138 +227,6 @@ Flex 96-channel pipettes meet the following accuracy and precision specification
       <td>1.5%</td>
     </tr>
 </table>
-
-<!-- hide original, temporary
-<table>
-  <thead>
-    <tr>
-      <th>Pipette</th>
-      <th>Tip Capacity</th>
-      <th>Tested Volume</th>
-      <th>Accuracy %D</th>
-      <th>Precision %CV</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td rowspan="3"><b>Flex 1-Channel 50 µL</b></td>
-      <td>50 µL</td>
-      <td>1 µL</td>
-      <td>8.00%</td>
-      <td>7.00%</td>
-    </tr>
-    <tr>
-      <td>50 µL</td>
-      <td>10 µL</td>
-      <td>1.50%</td>
-      <td>0.50%</td>
-    </tr>
-    <tr>
-      <td>50 µL</td>
-      <td>50 µL</td>
-      <td>1.25%</td>
-      <td>0.40%</td>
-    </tr>
-    <tr>
-      <td rowspan="4"><b>Flex 1-Channel 1000 µL</b></td>
-      <td>50 µL</td>
-      <td>5 µL</td>
-      <td>5.00%</td>
-      <td>2.50%</td>
-    </tr>
-    <tr>
-      <td>50 µL</td>
-      <td>50 µL</td>
-      <td>0.50%</td>
-      <td>0.30%</td>
-    </tr>
-    <tr>
-      <td>200 µL</td>
-      <td>200 µL</td>
-      <td>0.50%</td>
-      <td>0.15%</td>
-    </tr>
-    <tr>
-      <td>1000 µL</td>
-      <td>1000 µL</td>
-      <td>0.50%</td>
-      <td>0.15%</td>
-    </tr>
-    <tr>
-      <td rowspan="3"><b>Flex 8-Channel 50 µL</b></td>
-      <td>50 µL</td>
-      <td>1 µL</td>
-      <td>10.00%</td>
-      <td>8.00%</td>
-    </tr>
-    <tr>
-      <td>50 µL</td>
-      <td>10 µL</td>
-      <td>2.50%</td>
-      <td>1.00%</td>
-    </tr>
-    <tr>
-      <td>50 µL</td>
-      <td>50 µL</td>
-      <td>1.25%</td>
-      <td>0.60%</td>
-    </tr>
-    <tr>
-      <td rowspan="4"><b>Flex 8-Channel 1000 µL</b></td>
-      <td>50 µL</td>
-      <td>5 µL</td>
-      <td>8.00%</td>
-      <td>4.00%</td>
-    </tr>
-    <tr>
-      <td>50 µL</td>
-      <td>50 µL</td>
-      <td>2.50%</td>
-      <td>0.60%</td>
-    </tr>
-    <tr>
-      <td>200 µL</td>
-      <td>200 µL</td>
-      <td>1.00%</td>
-      <td>0.25%</td>
-    </tr>
-    <tr>
-      <td>1000 µL</td>
-      <td>1000 µL</td>
-      <td>0.70%</td>
-      <td>0.15%</td>
-    </tr>
-    <tr>
-      <td rowspan="4"><b>Flex 96-Channel 1000 µL</b></td>
-      <td>50 µL</td>
-      <td>5 µL</td>
-      <td>10.00%</td>
-      <td>5.00%</td>
-    </tr>
-    <tr>
-      <td>50 µL</td>
-      <td>50 µL</td>
-      <td>2.50%</td>
-      <td>1.25%</td>
-    </tr>
-    <tr>
-      <td>200 µL</td>
-      <td>200 µL</td>
-      <td>1.50%</td>
-      <td>1.25%</td>
-    </tr>
-    <tr>
-      <td>1000 µL</td>
-      <td>1000 µL</td>
-      <td>1.50%</td>
-      <td>1.50%</td>
-    </tr>
-  </tbody>
-</table>
--->
-
-!!! note
-    Opentrons performs volumetric testing of Flex pipettes to ensure that they meet the accuracy and precision specifications listed above. You *do not* have to calibrate the volume that your pipettes dispense before use. You only have to perform positional calibration. See the next section, as well as the [Pipette Installation section][pipette-installation] of the Installation and Relocation chapter, for details.
 
 ## Pipette calibration
 

--- a/docs/flex/docs/system-description/pipettes.md
+++ b/docs/flex/docs/system-description/pipettes.md
@@ -155,7 +155,7 @@ Flex 8-channel pipettes meet the following accuracy and precision specifications
     <tr>
       <td>1000 µL</td>
       <td>1000 µL</td>
-      <td>0.70%</td>
+      <td>±0.70%</td>
       <td>0.15%</td>
     </tr>
   </tbody>

--- a/docs/flex/docs/system-description/pipettes.md
+++ b/docs/flex/docs/system-description/pipettes.md
@@ -32,12 +32,14 @@ Opentrons Flex pipettes are designed to handle a wide range of liquid volumes an
 !!!tip
     Refer to these tables when choosing tips for your pipette. For best results you should use the smallest tips that meet the needs of your protocol.
 
-### Flex 1-channel specifications
+### 1-channel pipette specifications
+
+Flex 1-channel pipettes meet the following accuracy and precision specifications.
 
 <table>
   <thead>
     <tr>
-      <th>Pipette</th>
+      <th>Pipette Capacity</th>
       <th>Tip Capacity</th>
       <th>Tested Volume</th>
       <th>Accuracy %D</th>
@@ -46,58 +48,60 @@ Opentrons Flex pipettes are designed to handle a wide range of liquid volumes an
   </thead>
   <tbody>
     <tr>
-      <td rowspan="3"><b>1-Channel<br>(1-50 µL)</b></td>
+      <td rowspan="3"><b>1-50 µL</b></td>
       <td>50 µL</td>
       <td>1 µL</td>
-      <td>8.00%</td>
+      <td>± 8.00%</td>
       <td>7.00%</td>
     </tr>
     <tr>
-      <td>50 µL</td>
-      <td>10 µL</td>
-      <td>1.50%</td>
+      <td>50 µL</td>
+      <td>10 µL</td>
+      <td>± 1.50%</td>
       <td>0.50%</td>
     </tr>
     <tr>
-      <td>50 µL</td>
-      <td>50 µL</td>
-      <td>1.25%</td>
+      <td>50 µL</td>
+      <td>50 µL</td>
+      <td>± 1.25%</td>
       <td>0.40%</td>
     </tr>
     <tr>
-      <td rowspan="4"><b>1-Channel<br>(1-1000 µL)</b></td>
-      <td>50 µL</td>
-      <td>5 µL</td>
-      <td>5.00%</td>
+      <td rowspan="4"><b>1-1000 µL</td>
+      <td>50 µL</td>
+      <td>5 µL</td>
+      <td>± 5.00%</td>
       <td>2.50%</td>
     </tr>
     <tr>
-      <td>50 µL</td>
-      <td>50 µL</td>
-      <td>0.50%</td>
+      <td>50 µL</td>
+      <td>50 µL</td>
+      <td>± 0.50%</td>
       <td>0.30%</td>
     </tr>
     <tr>
-      <td>200 µL</td>
-      <td>200 µL</td>
-      <td>0.50%</td>
+      <td>200 µL</td>
+      <td>200 µL</td>
+      <td>± 0.50%</td>
       <td>0.15%</td>
     </tr>
     <tr>
-      <td>1000 µL</td>
-      <td>1000 µL</td>
-      <td>0.50%</td>
+      <td>1000 µL</td>
+      <td>1000 µL</td>
+      <td>± 0.50%</td>
       <td>0.15%</td>
     </tr>
   </tbody>
 </table>
 
-### Flex 8-channel specifications
+### 8-channel pipette specifications
+
+Flex 8-channel pipettes meet the following accuracy and precision specifications.
 
 <table>
   <thead>
     <tr>
-      <th>Pipette</th>
+      <th>Pipette Capacity</th>
       <th>Tip Capacity</th>
       <th>Tested Volume</th>
       <th>Accuracy %D</th>
@@ -106,58 +110,60 @@ Opentrons Flex pipettes are designed to handle a wide range of liquid volumes an
   </thead>
   <tbody>
     <tr>
-      <td rowspan="3"><b>8-Channel<br>(1-50 µL)</b></td>
-      <td>50 µL</td>
-      <td>1 µL</td>
-      <td>10.00%</td>
+      <td rowspan="3"><b>1-50 µL</b></td>
+      <td>50 µL</td>
+      <td>1 µL</td>
+      <td>± 10.00%</td>
       <td>8.00%</td>
     </tr>
     <tr>
-      <td>50 µL</td>
-      <td>10 µL</td>
-      <td>2.50%</td>
+      <td>50 µL</td>
+      <td>10 µL</td>
+      <td>± 2.50%</td>
       <td>1.00%</td>
     </tr>
     <tr>
-      <td>50 µL</td>
-      <td>50 µL</td>
-      <td>1.25%</td>
+      <td>50 µL</td>
+      <td>50 µL</td>
+      <td>± 1.25%</td>
       <td>0.60%</td>
     </tr>
     <tr>
-      <td rowspan="4"><b>8-Channel<br>(1-1000 µL)</b></td>
-      <td>50 µL</td>
-      <td>5 µL</td>
-      <td>8.00%</td>
-      <td>4.00%</td>
+      <td rowspan="4"><b>1-1000 µL</b></td>
+      <td>50 µL</td>
+      <td>5 µL</td>
+      <td>± 8.00%</td>
+      <td>4%</td>
     </tr>
     <tr>
-      <td>50 µL</td>
-      <td>50 µL</td>
-      <td>2.50%</td>
+      <td>50 µL</td>
+      <td>50 µL</td>
+      <td>± 2.50%</td>
       <td>0.60%</td>
     </tr>
     <tr>
-      <td>200 µL</td>
-      <td>200 µL</td>
-      <td>1.00%</td>
+      <td>200 µL</td>
+      <td>200 µL</td>
+      <td>± 1.00%</td>
       <td>0.25%</td>
     </tr>
     <tr>
-      <td>1000 µL</td>
-      <td>1000 µL</td>
+      <td>1000 µL</td>
+      <td>1000 µL</td>
       <td>0.70%</td>
       <td>0.15%</td>
     </tr>
   </tbody>
 </table>
 
-### Flex 96-channel specifications
+### 96-channel pipette specifications
+
+Flex 96-channel pipettes meet the following accuracy and precision specifications.
 
 <table>
   <thead>
     <tr>
-      <th>Pipette</th>
+      <th>Pipette Capacity</th>
       <th>Tip Capacity</th>
       <th>Tested Volume</th>
       <th>Accuracy %D</th>
@@ -165,54 +171,54 @@ Opentrons Flex pipettes are designed to handle a wide range of liquid volumes an
     </tr>
   </thead>
   <tbody>
+    <td rowspan="4"><b>1-200 µL</b></td>
+      <td>50 µL</td>
+      <td>1 µL</td>
+      <td>± 10%</td>
+      <td>6%</td>
+    </tr>
     <tr>
-      <td rowspan="4"><b>96-Channel<br>(1-1000 µL)</b></td>
       <td>50 µL</td>
       <td>5 µL</td>
-      <td>10.00%</td>
-      <td>5.00%</td>
+      <td>± 4%</td>
+      <td>2 %</td>
     </tr>
     <tr>
       <td>50 µL</td>
       <td>50 µL</td>
-      <td>2.50%</td>
+      <td>± 1.5%</td>
+      <td>1%</td>
+    </tr>
+    <tr>
+      <td>200 µL</td>
+      <td>200 µL</td>
+      <td>± 1%</td>
+      <td>1%</td>
+    </tr>
+    <tr>
+      <td rowspan="4"><b>5-1000 µL</b></td>
+      <td>50 µL</td>
+      <td>5 µL</td>
+      <td>± 10%</td>
+      <td>5%</td>
+    </tr>
+    <tr>
+      <td>50 µL</td>
+      <td>50 µL</td>
+      <td>± 2.5%</td>
       <td>1.25%</td>
     </tr>
     <tr>
       <td>200 µL</td>
       <td>200 µL</td>
-      <td>1.50%</td>
+      <td>1.5%</td>
       <td>1.25%</td>
     </tr>
     <tr>
-      <td>1000 µL</td>
-      <td>1000 µL</td>
-      <td>1.50%</td>
-      <td>1.50%</td>
-    </tr>
-    <td rowspan="4"><b>96-Channel<br>(1-200 µL)</b></td>
-      <td> µL</td>
-      <td> µL</td>
-      <td></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td></td>
-      <td></td>
-      <td></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td></td>
-      <td></td>
-      <td></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td></td>
-      <td></td>
-      <td></td>
-      <td></td>
+      <td>1000 µL</td>
+      <td>1000 µL</td>
+      <td>± 1.5%</td>
+      <td>1.5%</td>
     </tr>
 </table>
 


### PR DESCRIPTION
# Overview

This PR adds low-volume, 96-channel precision and accuracy data to the pipettes section of the manual (system description > pipettes).

RTC-628

## Test Plan and Hands on Testing

For testing and evaluation, just looking at the markdown may not convey enough of what these revisions look like. Here are some screenshots.

**Section intro**
<img width="969" height="553" alt="Screenshot 2025-09-17 at 11 27 45 AM" src="https://github.com/user-attachments/assets/a6ebe8e1-28f8-4a93-8ad7-cca95cbb50fa" />

**Sample revised table**
<img width="969" height="566" alt="Screenshot 2025-09-17 at 11 27 30 AM" src="https://github.com/user-attachments/assets/f1ff9a22-0c87-4ef9-a86a-93853075618d" />

You'll note the first column of the table. The section title and intro fit cleanly on the screen in a laptop, which is why I omitted the name "1-channel pipette" from each row.

The use of ± also matches the website.

## Changelog

**Original:** One very long table that listed specs for all the pipettes.

**Change:** 
- Revise the H2 intro, move tip and note callouts into the intro section.
- Add low vol. pipette data to appropriate section.
- Give each pipette an H3 section with a table that shows data specs. This is nice 'cause it shows up on the page-level TOC.
- Make sure the specs tables match corresponding tables on the website. What we put on the Opentrons site should be similar or match the manual. Differences in quantitative data like these specs creates uncertainty.

ps: there are typos on the website.

## Review requests

Does the new layout work. I think it is an improvement if we move specs for pipette types into separate tables instead of one big table.

## Risk assessment

Low, docs only. Let's give it a go.
