### PR TITLE
fix(app): Hide tiprack lids in error recovery deck maps

### DIFF
--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useDeckMapUtils.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useDeckMapUtils.ts
@@ -35,6 +35,8 @@ import type { ErrorRecoveryFlowsProps } from '..'
 import type { ERUtilsProps, ERUtilsResults } from './useERUtils'
 import type { UseFailedLabwareUtilsResult } from './useFailedLabwareUtils'
 
+const TC_LID_DEFINITION_LOAD_NAME = 'opentrons_tough_pcr_auto_sealing_lid'
+
 interface UseDeckMapUtilsProps {
   runId: ErrorRecoveryFlowsProps['runId']
   protocolAnalysis: ErrorRecoveryFlowsProps['protocolAnalysis']
@@ -370,16 +372,22 @@ export function getRunCurrentLabwareInfo({
     )
 
     // Group labware by slotName
-    const labwareBySlot = allLabware.reduce<
-      Record<string, RunCurrentLabwareInfo[]>
-    >((acc, labware) => {
-      const slot = labware.slotName
-      if (!acc[slot]) {
-        acc[slot] = []
-      }
-      acc[slot].push(labware)
-      return acc
-    }, {})
+    const labwareBySlot = allLabware
+      // filter out lids we don't yet have custom SVG for
+      // TODO: (sarah, 9-16-25) change this behavior when we have SVG for lids
+      .filter(
+        labware =>
+          !labware.labwareDef.allowedRoles?.includes('lid') ||
+          labware.labwareDef.parameters.loadName === TC_LID_DEFINITION_LOAD_NAME
+      )
+      .reduce<Record<string, RunCurrentLabwareInfo[]>>((acc, labware) => {
+        const slot = labware.slotName
+        if (!acc[slot]) {
+          acc[slot] = []
+        }
+        acc[slot].push(labware)
+        return acc
+      }, {})
 
     // For each slot, return either:
     // 1. The first labware where no other labware has its 'labwareId' as a location


### PR DESCRIPTION
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
For error recovery deck maps we render the top most labware in each slot. Since we don't have custom SVG for tiprack lids yet, they just render as white rectangles and because of [this bug](https://opentrons.atlassian.net/browse/EXEC-1784) they render a little out of place. Until these things are in place, this change will hide all lids except for TC lids
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
<img width="1020" height="789" alt="Screenshot 2025-09-16 at 2 34 39 PM" src="https://github.com/user-attachments/assets/52f5fcd8-b7ae-489e-b24f-eaabf0d3519c" />
Test that on error recovery deck maps, the underlying tiprack is shown instead of the tiprack lid, but if there is a tc lid on top of a well plate we show the tc lid
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
Filter out labware with role `lid` if it is not a TC lid 
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests
Quick check
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
Low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
