### PR TITLE
fix(shared-data): Enabled lid stacking for corning 96 wellplate 360mL lids

### DIFF
--- a/shared-data/labware/definitions/2/corning_96_wellplate_360ul_lid/1.json
+++ b/shared-data/labware/definitions/2/corning_96_wellplate_360ul_lid/1.json
@@ -14,7 +14,7 @@
   "dimensions": {
     "xDimension": 127,
     "yDimension": 85,
-    "zDimension": 9
+    "zDimension": 10
   },
   "wells": {},
   "groups": [

--- a/shared-data/labware/definitions/2/corning_96_wellplate_360ul_lid/1.json
+++ b/shared-data/labware/definitions/2/corning_96_wellplate_360ul_lid/1.json
@@ -14,7 +14,7 @@
   "dimensions": {
     "xDimension": 127,
     "yDimension": 85,
-    "zDimension": 10
+    "zDimension": 9
   },
   "wells": {},
   "groups": [
@@ -51,6 +51,11 @@
       "y": 0,
       "z": 6.5
     },
+    "corning_96_wellplate_360ul_lid": {
+      "x": 0,
+      "y": 0,
+      "z": 1
+    },
     "opentrons_flex_deck_riser": {
       "x": 0,
       "y": 0,
@@ -66,7 +71,8 @@
   "compatibleParentLabware": [
     "protocol_engine_lid_stack_object",
     "opentrons_flex_deck_riser",
-    "corning_96_wellplate_360ul_flat"
+    "corning_96_wellplate_360ul_flat",
+    "corning_96_wellplate_360ul_lid"
   ],
   "gripForce": 10,
   "gripHeightFromLabwareBottom": 7,


### PR DESCRIPTION
# Overview
Covers EXEC-1882

Ensured that the corning 96 wellplate lids can stack on eachother. Validated lid stacking offset measurements with calipers and live testing on a Flex. Lids were measured to 10mm. When two lids were stacked together, total stack heigh was measured to 19mm, creating a 1mm stacking offset. Five lids were tested in stacks together on the deck and on a deck riser. 

## Test Plan and Hands on Testing
- [x] The following protocol should pass analysis and during a live flex run it should move lids across stacks and onto a Corning wellplate labware cleanly and as expected:
```
def run(protocol: protocol_api.ProtocolContext):
    # Riser labware to host lid stacks
    stack = protocol.load_lid_stack("corning_96_wellplate_360ul_lid", "D2", 5)
    riser = protocol.load_adapter("opentrons_flex_deck_riser", location="C2")
    
    # Move lids to the stack
    protocol.move_lid(stack, riser, use_gripper=True)
    protocol.move_lid(stack, riser, use_gripper=True)
    protocol.move_lid(stack, riser, use_gripper=True)
    protocol.move_lid(stack, riser, use_gripper=True)
    protocol.move_lid(stack, riser, use_gripper=True)

    # Move lids back off the stack by referencing parent labware
    protocol.move_lid(riser, "D2", True)
    protocol.move_lid(riser, "D2", True)
    protocol.move_lid(riser, "D2", True)
    protocol.move_lid(riser, "D2", True)
    protocol.move_lid(riser, "D2", True)

    protocol.move_lid("D2", riser, True)
    protocol.move_lid("D2", riser, True)
    protocol.move_lid("D2", riser, True)
    protocol.move_lid("D2", riser, True)
    protocol.move_lid("D2", riser, True)

    plate = protocol.load_labware("corning_96_wellplate_360ul_flat", "D1")
    protocol.move_lid(riser, plate, True)
```

## Changelog
Updated corning 96 well 360mL lid definition

## Review requests

## Risk assessment
Low - enables behavior we desired and validated it on a live flex run
