### PR TITLE
feat(shared-data): import preliminary liquid class v2 values for LV96

### DIFF
--- a/shared-data/liquid-class/definitions/1/ethanol_80/2.json
+++ b/shared-data/liquid-class/definitions/1/ethanol_80/2.json
@@ -5890,7 +5890,7 @@
             "delay": {
               "enable": true,
               "params": {
-                "duration": 2.0
+                "duration": 0.2
               }
             }
           },
@@ -5984,7 +5984,7 @@
             "delay": {
               "enable": true,
               "params": {
-                "duration": 2.0
+                "duration": 0.2
               }
             }
           },
@@ -6158,7 +6158,7 @@
             "delay": {
               "enable": true,
               "params": {
-                "duration": 2.0
+                "duration": 0.2
               }
             }
           },
@@ -6252,7 +6252,7 @@
             "delay": {
               "enable": true,
               "params": {
-                "duration": 2.0
+                "duration": 0.2
               }
             }
           },

--- a/shared-data/liquid-class/definitions/1/ethanol_80/2.json
+++ b/shared-data/liquid-class/definitions/1/ethanol_80/2.json
@@ -5806,6 +5806,1073 @@
           }
         }
       ]
+    },
+    {
+      "pipetteModel": "flex_96channel_200",
+      "byTipType": [
+        {
+          "tiprack": "opentrons/opentrons_flex_96_tiprack_50ul/1",
+          "aspirate": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "delay": {
+                "enable": true,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "airGapByVolume": [
+                [1.0, 5.0],
+                [45.0, 5.0],
+                [50.0, 0.0]
+              ],
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": true,
+                "params": {
+                  "duration": 0.5
+                }
+              }
+            },
+            "aspiratePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [
+              [1.0, 7.0],
+              [10.0, 10.0],
+              [50.0, 30.0]
+            ],
+            "correctionByVolume": [
+              [0.0, -0.1],
+              [5.0, -0.35],
+              [10.0, 0.08],
+              [50.0, -1.34]
+            ],
+            "preWet": false,
+            "mix": {
+              "enable": false,
+              "params": {
+                "repetitions": 1,
+                "volume": 50
+              }
+            },
+            "delay": {
+              "enable": true,
+              "params": {
+                "duration": 2.0
+              }
+            }
+          },
+          "singleDispense": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "airGapByVolume": [
+                [1.0, 5.0],
+                [45.0, 5.0],
+                [50.0, 0.0]
+              ],
+              "blowout": {
+                "enable": false,
+                "params": {
+                  "location": "destination",
+                  "flowRate": 100.0
+                }
+              },
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": true,
+                "params": {
+                  "duration": 0.5
+                }
+              }
+            },
+            "dispensePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [
+              [0.0, 7.0],
+              [10.0, 60.0],
+              [50.0, 60.0]
+            ],
+            "correctionByVolume": [
+              [0.0, -0.1],
+              [5.0, -0.35],
+              [10.0, 0.08],
+              [50.0, -1.34]
+            ],
+            "mix": {
+              "enable": false,
+              "params": {
+                "repetitions": 1,
+                "volume": 50
+              }
+            },
+            "pushOutByVolume": [
+              [5.0, 0.0],
+              [10.0, 0.0],
+              [45.0, 0.0],
+              [50.0, 0.0]
+            ],
+            "delay": {
+              "enable": true,
+              "params": {
+                "duration": 2.0
+              }
+            }
+          },
+          "multiDispense": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "airGapByVolume": [
+                [1.0, 5.0],
+                [45.0, 5.0],
+                [50.0, 0.0]
+              ],
+              "blowout": {
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 100.0
+                }
+              },
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": true,
+                "params": {
+                  "duration": 0.5
+                }
+              }
+            },
+            "dispensePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[0.0, 100.0]],
+            "correctionByVolume": [
+              [0.0, 0.0],
+              [5.0, -2.1],
+              [10.0, -1.7],
+              [50.0, -3.3]
+            ],
+            "conditioningByVolume": [
+              [1.0, 5.0],
+              [40.0, 5.0],
+              [45.0, 0.0],
+              [50.0, 0.0]
+            ],
+            "disposalByVolume": [
+              [1.0, 5.0],
+              [40.0, 5.0],
+              [45.0, 0.0],
+              [50.0, 0.0]
+            ],
+            "delay": {
+              "enable": true,
+              "params": {
+                "duration": 2.0
+              }
+            }
+          }
+        },
+        {
+          "tiprack": "opentrons/opentrons_flex_96_filtertiprack_50ul/1",
+          "aspirate": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "delay": {
+                "enable": true,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "airGapByVolume": [
+                [1.0, 5.0],
+                [45.0, 5.0],
+                [50.0, 0.0]
+              ],
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": true,
+                "params": {
+                  "duration": 0.5
+                }
+              }
+            },
+            "aspiratePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [
+              [1.0, 7.0],
+              [10.0, 10.0],
+              [50.0, 30.0]
+            ],
+            "correctionByVolume": [
+              [0.0, -0.1],
+              [5.0, -0.35],
+              [10.0, 0.08],
+              [50.0, -1.34]
+            ],
+            "preWet": false,
+            "mix": {
+              "enable": false,
+              "params": {
+                "repetitions": 1,
+                "volume": 50
+              }
+            },
+            "delay": {
+              "enable": true,
+              "params": {
+                "duration": 2.0
+              }
+            }
+          },
+          "singleDispense": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "airGapByVolume": [
+                [1.0, 5.0],
+                [45.0, 5.0],
+                [50.0, 0.0]
+              ],
+              "blowout": {
+                "enable": false,
+                "params": {
+                  "location": "destination",
+                  "flowRate": 100.0
+                }
+              },
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": true,
+                "params": {
+                  "duration": 0.5
+                }
+              }
+            },
+            "dispensePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [
+              [0.0, 7.0],
+              [10.0, 60.0],
+              [50.0, 60.0]
+            ],
+            "correctionByVolume": [
+              [0.0, -0.1],
+              [5.0, -0.35],
+              [10.0, 0.08],
+              [50.0, -1.34]
+            ],
+            "mix": {
+              "enable": false,
+              "params": {
+                "repetitions": 1,
+                "volume": 50
+              }
+            },
+            "pushOutByVolume": [
+              [5.0, 0.0],
+              [10.0, 0.0],
+              [45.0, 0.0],
+              [50.0, 0.0]
+            ],
+            "delay": {
+              "enable": true,
+              "params": {
+                "duration": 2.0
+              }
+            }
+          },
+          "multiDispense": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "airGapByVolume": [
+                [1.0, 5.0],
+                [45.0, 5.0],
+                [50.0, 0.0]
+              ],
+              "blowout": {
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 100.0
+                }
+              },
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": true,
+                "params": {
+                  "duration": 0.5
+                }
+              }
+            },
+            "dispensePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[0.0, 100.0]],
+            "correctionByVolume": [
+              [0.0, 0.0],
+              [5.0, -2.1],
+              [10.0, -1.7],
+              [50.0, -3.3]
+            ],
+            "conditioningByVolume": [
+              [1.0, 5.0],
+              [40.0, 5.0],
+              [45.0, 0.0],
+              [50.0, 0.0]
+            ],
+            "disposalByVolume": [
+              [1.0, 5.0],
+              [40.0, 5.0],
+              [45.0, 0.0],
+              [50.0, 0.0]
+            ],
+            "delay": {
+              "enable": true,
+              "params": {
+                "duration": 2.0
+              }
+            }
+          }
+        },
+        {
+          "tiprack": "opentrons/opentrons_flex_96_tiprack_200ul/1",
+          "aspirate": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "delay": {
+                "enable": true,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "airGapByVolume": [
+                [5.0, 10.0],
+                [190.0, 10.0],
+                [200.0, 0.0]
+              ],
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": true,
+                "params": {
+                  "duration": 0.5
+                }
+              }
+            },
+            "aspiratePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [
+              [5.0, 7.0],
+              [50.0, 50.0],
+              [200.0, 200.0]
+            ],
+            "correctionByVolume": [
+              [0.0, 0.0],
+              [5.0, 0.1],
+              [50.0, -2.2],
+              [200.0, -8.9]
+            ],
+            "preWet": false,
+            "mix": {
+              "enable": false,
+              "params": {
+                "repetitions": 1,
+                "volume": 50
+              }
+            },
+            "delay": {
+              "enable": true,
+              "params": {
+                "duration": 0.2
+              }
+            }
+          },
+          "singleDispense": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "airGapByVolume": [
+                [5.0, 10.0],
+                [190.0, 10.0],
+                [200.0, 0.0]
+              ],
+              "blowout": {
+                "enable": false,
+                "params": {
+                  "location": "destination",
+                  "flowRate": 100.0
+                }
+              },
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": true,
+                "params": {
+                  "duration": 0.5
+                }
+              }
+            },
+            "dispensePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[0.0, 7.0]],
+            "correctionByVolume": [
+              [0.0, 0.0],
+              [5.0, 0.1],
+              [50.0, -2.2],
+              [200.0, -8.9]
+            ],
+            "mix": {
+              "enable": false,
+              "params": {
+                "repetitions": 1,
+                "volume": 50
+              }
+            },
+            "pushOutByVolume": [
+              [5.0, 0.0],
+              [50.0, 0.0],
+              [200.0, 0.0]
+            ],
+            "delay": {
+              "enable": true,
+              "params": {
+                "duration": 2.0
+              }
+            }
+          },
+          "multiDispense": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "airGapByVolume": [
+                [5.0, 10.0],
+                [190.0, 10.0],
+                [200.0, 0.0]
+              ],
+              "blowout": {
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 100.0
+                }
+              },
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": true,
+                "params": {
+                  "duration": 0.5
+                }
+              }
+            },
+            "dispensePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[0.0, 100.0]],
+            "correctionByVolume": [
+              [0.0, 0.0],
+              [5.0, -1.5],
+              [50.0, -2.2],
+              [200.0, -7.4]
+            ],
+            "conditioningByVolume": [
+              [1.0, 5.0],
+              [190.0, 5.0],
+              [195.0, 0.0],
+              [200.0, 0.0]
+            ],
+            "disposalByVolume": [
+              [1.0, 5.0],
+              [190.0, 5.0],
+              [195.0, 0.0],
+              [200.0, 0.0]
+            ],
+            "delay": {
+              "enable": true,
+              "params": {
+                "duration": 1.0
+              }
+            }
+          }
+        },
+        {
+          "tiprack": "opentrons/opentrons_flex_96_filtertiprack_200ul/1",
+          "aspirate": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "delay": {
+                "enable": true,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "airGapByVolume": [
+                [5.0, 10.0],
+                [190.0, 10.0],
+                [200.0, 0.0]
+              ],
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": true,
+                "params": {
+                  "duration": 0.5
+                }
+              }
+            },
+            "aspiratePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [
+              [5.0, 7.0],
+              [50.0, 50.0],
+              [200.0, 200.0]
+            ],
+            "correctionByVolume": [
+              [0.0, 0.0],
+              [5.0, 0.1],
+              [50.0, -2.2],
+              [200.0, -8.9]
+            ],
+            "preWet": false,
+            "mix": {
+              "enable": false,
+              "params": {
+                "repetitions": 1,
+                "volume": 50
+              }
+            },
+            "delay": {
+              "enable": true,
+              "params": {
+                "duration": 0.2
+              }
+            }
+          },
+          "singleDispense": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "airGapByVolume": [
+                [5.0, 10.0],
+                [190.0, 10.0],
+                [200.0, 0.0]
+              ],
+              "blowout": {
+                "enable": false,
+                "params": {
+                  "location": "destination",
+                  "flowRate": 100.0
+                }
+              },
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": true,
+                "params": {
+                  "duration": 0.5
+                }
+              }
+            },
+            "dispensePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[0.0, 7.0]],
+            "correctionByVolume": [
+              [0.0, 0.0],
+              [5.0, 0.1],
+              [50.0, -2.2],
+              [200.0, -8.9]
+            ],
+            "mix": {
+              "enable": false,
+              "params": {
+                "repetitions": 1,
+                "volume": 50
+              }
+            },
+            "pushOutByVolume": [
+              [5.0, 0.0],
+              [50.0, 0.0],
+              [200.0, 0.0]
+            ],
+            "delay": {
+              "enable": true,
+              "params": {
+                "duration": 2.0
+              }
+            }
+          },
+          "multiDispense": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 35,
+              "airGapByVolume": [
+                [5.0, 10.0],
+                [190.0, 10.0],
+                [200.0, 0.0]
+              ],
+              "blowout": {
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 100.0
+                }
+              },
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": true,
+                "params": {
+                  "duration": 0.5
+                }
+              }
+            },
+            "dispensePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[0.0, 100.0]],
+            "correctionByVolume": [
+              [0.0, 0.0],
+              [5.0, -1.5],
+              [50.0, -2.2],
+              [200.0, -7.4]
+            ],
+            "conditioningByVolume": [
+              [1.0, 5.0],
+              [190.0, 5.0],
+              [195.0, 0.0],
+              [200.0, 0.0]
+            ],
+            "disposalByVolume": [
+              [1.0, 5.0],
+              [190.0, 5.0],
+              [195.0, 0.0],
+              [200.0, 0.0]
+            ],
+            "delay": {
+              "enable": true,
+              "params": {
+                "duration": 1.0
+              }
+            }
+          }
+        }
+      ]
     }
   ]
 }

--- a/shared-data/liquid-class/definitions/1/glycerol_50/2.json
+++ b/shared-data/liquid-class/definitions/1/glycerol_50/2.json
@@ -5526,6 +5526,1017 @@
           }
         }
       ]
+    },
+    {
+      "pipetteModel": "flex_96channel_200",
+      "byTipType": [
+        {
+          "tiprack": "opentrons/opentrons_flex_96_tiprack_50ul/1",
+          "aspirate": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 10,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 10,
+              "airGapByVolume": [[0.0, 0.0]],
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "aspiratePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [
+              [1.0, 7.0],
+              [10.0, 10.0],
+              [50.0, 40.0]
+            ],
+            "correctionByVolume": [
+              [0.0, -0.1],
+              [5.0, -0.25],
+              [10.0, 0.1],
+              [50.0, 0.2]
+            ],
+            "preWet": false,
+            "mix": {
+              "enable": false,
+              "params": {
+                "repetitions": 1,
+                "volume": 50
+              }
+            },
+            "delay": {
+              "enable": true,
+              "params": {
+                "duration": 2.0
+              }
+            }
+          },
+          "singleDispense": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 10,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 10,
+              "airGapByVolume": [[0.0, 0.0]],
+              "blowout": {
+                "enable": false,
+                "params": {
+                  "location": "destination",
+                  "flowRate": 40.0
+                }
+              },
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "dispensePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[0.0, 25.0]],
+            "correctionByVolume": [
+              [0.0, -0.1],
+              [5.0, -0.25],
+              [10.0, 0.1],
+              [50.0, 0.2]
+            ],
+            "mix": {
+              "enable": false,
+              "params": {
+                "repetitions": 1,
+                "volume": 50
+              }
+            },
+            "pushOutByVolume": [
+              [1.0, 11.7],
+              [4.999, 11.7],
+              [5.0, 3.9],
+              [50.0, 3.9]
+            ],
+            "delay": {
+              "enable": true,
+              "params": {
+                "duration": 1.0
+              }
+            }
+          },
+          "multiDispense": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 10,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 10,
+              "airGapByVolume": [[0.0, 0.0]],
+              "blowout": {
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 40.0
+                }
+              },
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "dispensePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [
+              [1.0, 7.0],
+              [10.0, 10.0],
+              [50.0, 40.0]
+            ],
+            "correctionByVolume": [
+              [0.0, 0.0],
+              [5.0, -0.3],
+              [10.0, -0.2],
+              [50.0, 0.0]
+            ],
+            "conditioningByVolume": [
+              [1.0, 5.0],
+              [40.0, 5.0],
+              [45.0, 0.0],
+              [50.0, 0.0]
+            ],
+            "disposalByVolume": [
+              [1.0, 5.0],
+              [40.0, 5.0],
+              [45.0, 0.0],
+              [50.0, 0.0]
+            ],
+            "delay": {
+              "enable": true,
+              "params": {
+                "duration": 1.0
+              }
+            }
+          }
+        },
+        {
+          "tiprack": "opentrons/opentrons_flex_96_filtertiprack_50ul/1",
+          "aspirate": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 10,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 10,
+              "airGapByVolume": [[0.0, 0.0]],
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "aspiratePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [
+              [1.0, 7.0],
+              [10.0, 10.0],
+              [50.0, 40.0]
+            ],
+            "correctionByVolume": [
+              [0.0, -0.1],
+              [5.0, -0.25],
+              [10.0, 0.1],
+              [50.0, 0.2]
+            ],
+            "preWet": false,
+            "mix": {
+              "enable": false,
+              "params": {
+                "repetitions": 1,
+                "volume": 50
+              }
+            },
+            "delay": {
+              "enable": true,
+              "params": {
+                "duration": 2.0
+              }
+            }
+          },
+          "singleDispense": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 10,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 10,
+              "airGapByVolume": [[0.0, 0.0]],
+              "blowout": {
+                "enable": false,
+                "params": {
+                  "location": "destination",
+                  "flowRate": 40.0
+                }
+              },
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "dispensePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[0.0, 25.0]],
+            "correctionByVolume": [
+              [0.0, -0.1],
+              [5.0, -0.25],
+              [10.0, 0.1],
+              [50.0, 0.2]
+            ],
+            "mix": {
+              "enable": false,
+              "params": {
+                "repetitions": 1,
+                "volume": 50
+              }
+            },
+            "pushOutByVolume": [
+              [1.0, 11.7],
+              [4.999, 11.7],
+              [5.0, 3.9],
+              [50.0, 3.9]
+            ],
+            "delay": {
+              "enable": true,
+              "params": {
+                "duration": 1.0
+              }
+            }
+          },
+          "multiDispense": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 10,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 10,
+              "airGapByVolume": [[0.0, 0.0]],
+              "blowout": {
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 40.0
+                }
+              },
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "dispensePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [
+              [1.0, 7.0],
+              [10.0, 10.0],
+              [50.0, 40.0]
+            ],
+            "correctionByVolume": [
+              [0.0, 0.0],
+              [5.0, -0.3],
+              [10.0, -0.2],
+              [50.0, 0.0]
+            ],
+            "conditioningByVolume": [
+              [1.0, 5.0],
+              [40.0, 5.0],
+              [45.0, 0.0],
+              [50.0, 0.0]
+            ],
+            "disposalByVolume": [
+              [1.0, 5.0],
+              [40.0, 5.0],
+              [45.0, 0.0],
+              [50.0, 0.0]
+            ],
+            "delay": {
+              "enable": true,
+              "params": {
+                "duration": 1.0
+              }
+            }
+          }
+        },
+        {
+          "tiprack": "opentrons/opentrons_flex_96_tiprack_200ul/1",
+          "aspirate": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 10,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 10,
+              "airGapByVolume": [[0.0, 0.0]],
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "aspiratePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [
+              [5.0, 10.0],
+              [50.0, 50.0],
+              [200.0, 200.0]
+            ],
+            "correctionByVolume": [
+              [0.0, 0.0],
+              [5.0, -0.2],
+              [50.0, -0.3],
+              [200.0, -0.8]
+            ],
+            "preWet": false,
+            "mix": {
+              "enable": false,
+              "params": {
+                "repetitions": 1,
+                "volume": 50
+              }
+            },
+            "delay": {
+              "enable": true,
+              "params": {
+                "duration": 1.0
+              }
+            }
+          },
+          "singleDispense": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 10,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 10,
+              "airGapByVolume": [[0.0, 0.0]],
+              "blowout": {
+                "enable": false,
+                "params": {
+                  "location": "destination",
+                  "flowRate": 50.0
+                }
+              },
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "dispensePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[0.0, 25.0]],
+            "correctionByVolume": [
+              [0.0, 0.0],
+              [5.0, -0.2],
+              [50.0, -0.3],
+              [200.0, -0.8]
+            ],
+            "mix": {
+              "enable": false,
+              "params": {
+                "repetitions": 1,
+                "volume": 50
+              }
+            },
+            "pushOutByVolume": [[0.0, 3.9]],
+            "delay": {
+              "enable": true,
+              "params": {
+                "duration": 0.5
+              }
+            }
+          },
+          "multiDispense": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 10,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 10,
+              "airGapByVolume": [[0.0, 0.0]],
+              "blowout": {
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 50.0
+                }
+              },
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "dispensePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[0.0, 50.0]],
+            "correctionByVolume": [
+              [0.0, 0.0],
+              [5.0, -0.3],
+              [50.0, -0.3],
+              [200.0, -0.8]
+            ],
+            "conditioningByVolume": [
+              [1.0, 5.0],
+              [190.0, 5.0],
+              [195.0, 0.0],
+              [200.0, 0.0]
+            ],
+            "disposalByVolume": [
+              [1.0, 5.0],
+              [190.0, 5.0],
+              [195.0, 0.0],
+              [200.0, 0.0]
+            ],
+            "delay": {
+              "enable": true,
+              "params": {
+                "duration": 0.5
+              }
+            }
+          }
+        },
+        {
+          "tiprack": "opentrons/opentrons_flex_96_filtertiprack_200ul/1",
+          "aspirate": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 10,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 10,
+              "airGapByVolume": [[0.0, 0.0]],
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "aspiratePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [
+              [5.0, 10.0],
+              [50.0, 50.0],
+              [200.0, 200.0]
+            ],
+            "correctionByVolume": [
+              [0.0, 0.0],
+              [5.0, -0.2],
+              [50.0, -0.3],
+              [200.0, -0.8]
+            ],
+            "preWet": false,
+            "mix": {
+              "enable": false,
+              "params": {
+                "repetitions": 1,
+                "volume": 50
+              }
+            },
+            "delay": {
+              "enable": true,
+              "params": {
+                "duration": 1.0
+              }
+            }
+          },
+          "singleDispense": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 10,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 10,
+              "airGapByVolume": [[0.0, 0.0]],
+              "blowout": {
+                "enable": false,
+                "params": {
+                  "location": "destination",
+                  "flowRate": 50.0
+                }
+              },
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "dispensePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[0.0, 25.0]],
+            "correctionByVolume": [
+              [0.0, 0.0],
+              [5.0, -0.2],
+              [50.0, -0.3],
+              [200.0, -0.8]
+            ],
+            "mix": {
+              "enable": false,
+              "params": {
+                "repetitions": 1,
+                "volume": 50
+              }
+            },
+            "pushOutByVolume": [[0.0, 3.9]],
+            "delay": {
+              "enable": true,
+              "params": {
+                "duration": 0.5
+              }
+            }
+          },
+          "multiDispense": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 10,
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0.0
+                }
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 10,
+              "airGapByVolume": [[0.0, 0.0]],
+              "blowout": {
+                "enable": true,
+                "params": {
+                  "location": "trash",
+                  "flowRate": 50.0
+                }
+              },
+              "touchTip": {
+                "enable": false,
+                "params": {
+                  "zOffset": -1,
+                  "mmFromEdge": 0.5,
+                  "speed": 30
+                }
+              },
+              "delay": {
+                "enable": false,
+                "params": {
+                  "duration": 0
+                }
+              }
+            },
+            "dispensePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 2
+              }
+            },
+            "flowRateByVolume": [[0.0, 50.0]],
+            "correctionByVolume": [
+              [0.0, 0.0],
+              [5.0, -0.3],
+              [50.0, -0.3],
+              [200.0, -0.8]
+            ],
+            "conditioningByVolume": [
+              [1.0, 5.0],
+              [190.0, 5.0],
+              [195.0, 0.0],
+              [200.0, 0.0]
+            ],
+            "disposalByVolume": [
+              [1.0, 5.0],
+              [190.0, 5.0],
+              [195.0, 0.0],
+              [200.0, 0.0]
+            ],
+            "delay": {
+              "enable": true,
+              "params": {
+                "duration": 0.5
+              }
+            }
+          }
+        }
+      ]
     }
   ]
 }

--- a/shared-data/liquid-class/definitions/1/water/2.json
+++ b/shared-data/liquid-class/definitions/1/water/2.json
@@ -4072,7 +4072,9 @@
                 "volume": 50
               }
             },
-            "pushOutByVolume": [[1.0, 5.0]],
+            "pushOutByVolume": [
+              [1.0, 5.0]
+            ],
             "delay": {
               "enable": false,
               "params": {

--- a/shared-data/liquid-class/definitions/1/water/2.json
+++ b/shared-data/liquid-class/definitions/1/water/2.json
@@ -3983,7 +3983,7 @@
                 "z": 2
               }
             },
-            "flowRateByVolume": [[1.0, 200.0]],
+            "flowRateByVolume": [[1.0, 6.5]],
             "correctionByVolume": [[0.0, 0.0]],
             "preWet": false,
             "mix": {
@@ -4034,10 +4034,10 @@
                 [50.0, 0.0]
               ],
               "blowout": {
-                "enable": false,
+                "enable": true,
                 "params": {
                   "location": "destination",
-                  "flowRate": 200.0
+                  "flowRate": 80.0
                 }
               },
               "touchTip": {
@@ -4063,7 +4063,7 @@
                 "z": 2
               }
             },
-            "flowRateByVolume": [[1.0, 200.0]],
+            "flowRateByVolume": [[1.0, 80.0]],
             "correctionByVolume": [[0.0, 0.0]],
             "mix": {
               "enable": false,
@@ -4072,7 +4072,9 @@
                 "volume": 50
               }
             },
-            "pushOutByVolume": [[1.0, 5.0]],
+            "pushOutByVolume": [
+              [1.0, 5.0]
+            ],
             "delay": {
               "enable": false,
               "params": {
@@ -4117,7 +4119,7 @@
                 "enable": true,
                 "params": {
                   "location": "trash",
-                  "flowRate": 200.0
+                  "flowRate": 80.0
                 }
               },
               "touchTip": {
@@ -4143,7 +4145,7 @@
                 "z": 2
               }
             },
-            "flowRateByVolume": [[1.0, 200.0]],
+            "flowRateByVolume": [[1.0, 80.0]],
             "correctionByVolume": [[0.0, 0.0]],
             "conditioningByVolume": [
               [1.0, 5.0],
@@ -4194,8 +4196,8 @@
               },
               "speed": 35,
               "airGapByVolume": [
-                [1.0, 1.0],
-                [49.0, 1.0],
+                [1.0, 0.1],
+                [49.0, 0.1],
                 [50.0, 0.0]
               ],
               "touchTip": {
@@ -4221,7 +4223,7 @@
                 "z": 2
               }
             },
-            "flowRateByVolume": [[1.0, 200.0]],
+            "flowRateByVolume": [[1.0, 6.5]],
             "correctionByVolume": [[0.0, 0.0]],
             "preWet": false,
             "mix": {
@@ -4272,10 +4274,10 @@
                 [50.0, 0.0]
               ],
               "blowout": {
-                "enable": false,
+                "enable": true,
                 "params": {
                   "location": "destination",
-                  "flowRate": 200.0
+                  "flowRate": 80.0
                 }
               },
               "touchTip": {
@@ -4301,7 +4303,7 @@
                 "z": 2
               }
             },
-            "flowRateByVolume": [[1.0, 200.0]],
+            "flowRateByVolume": [[1.0, 80.0]],
             "correctionByVolume": [[0.0, 0.0]],
             "mix": {
               "enable": false,
@@ -4310,7 +4312,12 @@
                 "volume": 50
               }
             },
-            "pushOutByVolume": [[1.0, 5.0]],
+            "pushOutByVolume": [
+              [1.0, 7.0],
+              [5.0, 2.0],
+              [10.0, 2.0],
+              [50.0, 5.0]
+            ],
             "delay": {
               "enable": false,
               "params": {
@@ -4355,7 +4362,7 @@
                 "enable": true,
                 "params": {
                   "location": "trash",
-                  "flowRate": 200.0
+                  "flowRate": 80.0
                 }
               },
               "touchTip": {
@@ -4381,7 +4388,7 @@
                 "z": 2
               }
             },
-            "flowRateByVolume": [[1.0, 200.0]],
+            "flowRateByVolume": [[1.0, 80.0]],
             "correctionByVolume": [[0.0, 0.0]],
             "conditioningByVolume": [
               [1.0, 5.0],
@@ -4432,8 +4439,9 @@
               },
               "speed": 35,
               "airGapByVolume": [
-                [1.0, 5.0],
-                [195.0, 5.0],
+                [1.0, 2],
+                [50, 3.5],
+                [198.0, 2.0],
                 [200.0, 0.0]
               ],
               "touchTip": {
@@ -4459,7 +4467,7 @@
                 "z": 2
               }
             },
-            "flowRateByVolume": [[1.0, 200.0]],
+            "flowRateByVolume": [[1.0, 80.0]],
             "correctionByVolume": [[0.0, 0.0]],
             "preWet": false,
             "mix": {
@@ -4510,10 +4518,10 @@
                 [200.0, 0.0]
               ],
               "blowout": {
-                "enable": false,
+                "enable": true,
                 "params": {
                   "location": "destination",
-                  "flowRate": 200.0
+                  "flowRate": 80.0
                 }
               },
               "touchTip": {
@@ -4539,7 +4547,7 @@
                 "z": 2
               }
             },
-            "flowRateByVolume": [[1.0, 200.0]],
+            "flowRateByVolume": [[1.0, 80.0]],
             "correctionByVolume": [[0.0, 0.0]],
             "mix": {
               "enable": false,
@@ -4548,7 +4556,12 @@
                 "volume": 50
               }
             },
-            "pushOutByVolume": [[1.0, 5.0]],
+            "pushOutByVolume": [
+              [1.0, 5.0],
+              [5.0, 5.0],
+              [50.0, 5.0],
+              [200.0, 5.0]
+            ],
             "delay": {
               "enable": false,
               "params": {
@@ -4593,7 +4606,7 @@
                 "enable": true,
                 "params": {
                   "location": "trash",
-                  "flowRate": 200.0
+                  "flowRate": 80.0
                 }
               },
               "touchTip": {
@@ -4697,7 +4710,7 @@
                 "z": 2
               }
             },
-            "flowRateByVolume": [[1.0, 200.0]],
+            "flowRateByVolume": [[1.0, 80.0]],
             "correctionByVolume": [[0.0, 0.0]],
             "preWet": false,
             "mix": {
@@ -4748,10 +4761,10 @@
                 [200.0, 0.0]
               ],
               "blowout": {
-                "enable": false,
+                "enable": true,
                 "params": {
                   "location": "destination",
-                  "flowRate": 200.0
+                  "flowRate": 80.0
                 }
               },
               "touchTip": {
@@ -4777,7 +4790,7 @@
                 "z": 2
               }
             },
-            "flowRateByVolume": [[1.0, 200.0]],
+            "flowRateByVolume": [[1.0, 80.0]],
             "correctionByVolume": [[0.0, 0.0]],
             "mix": {
               "enable": false,
@@ -4786,7 +4799,12 @@
                 "volume": 50
               }
             },
-            "pushOutByVolume": [[1.0, 5.0]],
+            "pushOutByVolume": [
+              [1.0, 5.0],
+              [5.0, 5.0],
+              [50.0, 2.0],
+              [200.0, 5.0]
+            ],
             "delay": {
               "enable": false,
               "params": {
@@ -4831,7 +4849,7 @@
                 "enable": true,
                 "params": {
                   "location": "trash",
-                  "flowRate": 200.0
+                  "flowRate": 80.0
                 }
               },
               "touchTip": {
@@ -4857,7 +4875,7 @@
                 "z": 2
               }
             },
-            "flowRateByVolume": [[1.0, 200.0]],
+            "flowRateByVolume": [[1.0, 80.0]],
             "correctionByVolume": [[0.0, 0.0]],
             "conditioningByVolume": [
               [1.0, 5.0],

--- a/shared-data/liquid-class/definitions/1/water/2.json
+++ b/shared-data/liquid-class/definitions/1/water/2.json
@@ -4072,9 +4072,7 @@
                 "volume": 50
               }
             },
-            "pushOutByVolume": [
-              [1.0, 5.0]
-            ],
+            "pushOutByVolume": [[1.0, 5.0]],
             "delay": {
               "enable": false,
               "params": {


### PR DESCRIPTION
# Overview

This imports @meh-di and @thassyopinto's liquid class values from their `EXEC-1671-96-lc-feature-8_5` branch, and makes them available as liquid class v2.

My understanding is that these values could be shipped now as-is, but we'd like to refine them a bit more if we have time.

In particular, this PR:
- Adds `flex_96channel_200` values to `ethanol_80/2.json` and `glycerol_50/2.json`.
- Edits the premilimary `flex_96channel_200` values for `water` that we had previously checked into `water/2.json`.

I want to commit these values now so that we can start testing LV96 in the PAPI, PD, and QT.

## Test Plan and Hands on Testing

I guess we and QA will be doing a lot of hands-on testing with these values.

## Changelog

I generated this PR thus:

First, I merged @andySigler's changes from RS 8.5 into `EXEC-1671-96-lc-feature-8_5` because `EXEC-1671-96-lc-feature-8_5` was cut before we finalized RS 8.5:
```sh
git checkout EXEC-1671-96-lc-feature-8_5 
git merge origin/chore_release-8.5.1
```
Then I copied the liquid class values from `EXEC-1671-96-lc-feature-8_5` into `2.json`:
```sh
for i in water ethanol_80 glycerol_50 ; do
  git show EXEC-1671-96-lc-feature-8_5:shared-data/liquid-class/definitions/1/$i/1.json | sed 's/"version": 1,/"version": 2,/g' > shared-data/liquid-class/definitions/1/$i/2.json
done
```

## Risk assessment

Medium.