### PR TITLE
feat(api): temperature module set_target_temperature runs concurrently and returns a task

### DIFF
--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[0161fbd0a6][Flex_S_2_15_MPL_langone_ribo_pt1_ramp].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[0161fbd0a6][Flex_S_2_15_MPL_langone_ribo_pt1_ramp].json
@@ -14786,7 +14786,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 4.0
+        "targetTemperature": 4.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[0903a95825][Flex_S_v2_19_QIASeq_FX_48x].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[0903a95825][Flex_S_v2_19_QIASeq_FX_48x].json
@@ -5391,7 +5391,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 4.0
+        "targetTemperature": 4.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[0a9ef592c8][Flex_S_v2_18_Illumina_DNA_Prep_48x].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[0a9ef592c8][Flex_S_v2_18_Illumina_DNA_Prep_48x].json
@@ -5391,7 +5391,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 4.0
+        "targetTemperature": 4.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[0babad786f][Flex_S_v2_16_PL_Zymo_Quick-RNA_Flex_96-Cells].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[0babad786f][Flex_S_v2_16_PL_Zymo_Quick-RNA_Flex_96-Cells].json
@@ -46890,7 +46890,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 55.0
+        "targetTemperature": 55.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"
@@ -49041,7 +49042,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 4.0
+        "targetTemperature": 4.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[0dad703b86][Flex_S_v2_18_PL_QIAseq-FX-48x].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[0dad703b86][Flex_S_v2_18_PL_QIAseq-FX-48x].json
@@ -5391,7 +5391,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 4.0
+        "targetTemperature": 4.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[10583ea444][Flex_S_v2_18_PL_QIAseq-Targeted-DNA-Pro-8x].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[10583ea444][Flex_S_v2_18_PL_QIAseq-Targeted-DNA-Pro-8x].json
@@ -5287,7 +5287,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 4.0
+        "targetTemperature": 4.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[109e77ecb1][Flex_S_v2_18_PL_imac-by-ni-nta-magnetic-agarose-beads-on-flex].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[109e77ecb1][Flex_S_v2_18_PL_imac-by-ni-nta-magnetic-agarose-beads-on-flex].json
@@ -53482,7 +53482,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 4.0
+        "targetTemperature": 4.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[12233269bc][Flex_S_v2_20_PL_evercode-whole-transcriptomeWT-kit-Parse-Biosciences-protocol2].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[12233269bc][Flex_S_v2_20_PL_evercode-whole-transcriptomeWT-kit-Parse-Biosciences-protocol2].json
@@ -10419,7 +10419,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 4.0
+        "targetTemperature": 4.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"
@@ -26605,7 +26606,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 4.0
+        "targetTemperature": 4.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"
@@ -31010,7 +31012,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 4.0
+        "targetTemperature": 4.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[12494feef2][Flex_S_2_16_MPL_QIAseq_FX_24x_Normalizer_Workflow_B].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[12494feef2][Flex_S_2_16_MPL_QIAseq_FX_24x_Normalizer_Workflow_B].json
@@ -15030,7 +15030,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 4.0
+        "targetTemperature": 4.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[134037b2aa][OT2_X_v6_P300M_P20S_HS_MM_TM_TC_AllMods].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[134037b2aa][OT2_X_v6_P300M_P20S_HS_MM_TM_TC_AllMods].json
@@ -7454,7 +7454,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 80.0
+        "targetTemperature": 80.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[13cc2361a9][Flex_S_v2_25_P50_P200_stacker_all_parts].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[13cc2361a9][Flex_S_v2_25_P50_P200_stacker_all_parts].json
@@ -28149,7 +28149,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 4.0
+        "targetTemperature": 4.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[149d9c9812][Flex_S_v2_18_PL_Illumina-DNA-Prep-48x].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[149d9c9812][Flex_S_v2_18_PL_Illumina-DNA-Prep-48x].json
@@ -5391,7 +5391,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 4.0
+        "targetTemperature": 4.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[1656293bfe][Flex_S_2_15_MPL_NiNTA_Flex_96well_final].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[1656293bfe][Flex_S_2_15_MPL_NiNTA_Flex_96well_final].json
@@ -53482,7 +53482,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 4.0
+        "targetTemperature": 4.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[180cffe1e4][Flex_S_v2_18_PL_Twist-EF-2_0].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[180cffe1e4][Flex_S_v2_18_PL_Twist-EF-2_0].json
@@ -6190,7 +6190,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 4.0
+        "targetTemperature": 4.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[1baf3666f4][Flex_X_v2_18_Illumina_Stranded_total_RNA_Ribo_Zero].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[1baf3666f4][Flex_X_v2_18_Illumina_Stranded_total_RNA_Ribo_Zero].json
@@ -15594,7 +15594,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 4.0
+        "targetTemperature": 4.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[21168793ea][Flex_S_v2_16_PL_invitrogen_elisa_targetcapture].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[21168793ea][Flex_S_v2_16_PL_invitrogen_elisa_targetcapture].json
@@ -25833,7 +25833,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 4.0
+        "targetTemperature": 4.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[2296026a1c][Flex_S_v2_18_PL_IDT-xGen-EZ-48x].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[2296026a1c][Flex_S_v2_18_PL_IDT-xGen-EZ-48x].json
@@ -5391,7 +5391,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 4.0
+        "targetTemperature": 4.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[26d6478878][Flex_S_2_17_MPL_sigdx_part2].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[26d6478878][Flex_S_2_17_MPL_sigdx_part2].json
@@ -1367,7 +1367,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 63.0
+        "targetTemperature": 63.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"
@@ -1398,7 +1399,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 63.0
+        "targetTemperature": 63.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"
@@ -29523,7 +29525,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 48.0
+        "targetTemperature": 48.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"
@@ -29554,7 +29557,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 48.0
+        "targetTemperature": 48.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[2a9760aa21][Flex_S_2_16_MPL_MagMax_RNA_Cells_Flex_multi].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[2a9760aa21][Flex_S_2_16_MPL_MagMax_RNA_Cells_Flex_multi].json
@@ -3852,7 +3852,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 4.0
+        "targetTemperature": 4.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[2aceb4fe25][Flex_S_v2_18_PL_Illumina-Stranded_total_RNA_Ribo-Zero].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[2aceb4fe25][Flex_S_v2_18_PL_Illumina-Stranded_total_RNA_Ribo-Zero].json
@@ -15580,7 +15580,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 4.0
+        "targetTemperature": 4.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[2b866b03f3][Flex_S_v2_21_P1000_96_GRIP_HS_MB_TC_TM_Smoke].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[2b866b03f3][Flex_S_v2_21_P1000_96_GRIP_HS_MB_TC_TM_Smoke].json
@@ -13785,7 +13785,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 38.0
+        "targetTemperature": 38.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[2eaf98de6a][Flex_S_v2_16_P1000_96_GRIP_HS_MB_TC_TM_TriggerPrepareForMountMovement].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[2eaf98de6a][Flex_S_v2_16_P1000_96_GRIP_HS_MB_TC_TM_TriggerPrepareForMountMovement].json
@@ -26219,7 +26219,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 80.0
+        "targetTemperature": 80.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"
@@ -26250,7 +26251,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 10.0
+        "targetTemperature": 10.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[3a469bddf5][Flex_S_2_15_MPL_Normalization_with_PCR].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[3a469bddf5][Flex_S_2_15_MPL_Normalization_with_PCR].json
@@ -5196,7 +5196,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 4.0
+        "targetTemperature": 4.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[3cf6a3778e][Flex_S_v2_18_P1000_96_GRIP_HS_MB_TC_TM_Smoke].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[3cf6a3778e][Flex_S_v2_18_P1000_96_GRIP_HS_MB_TC_TM_Smoke].json
@@ -15093,7 +15093,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 50.0
+        "targetTemperature": 50.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[3d6408144f][Flex_S_v2_16_PL_Magmax_RNA_Flex_Multi-Cells].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[3d6408144f][Flex_S_v2_16_PL_Magmax_RNA_Flex_Multi-Cells].json
@@ -3852,7 +3852,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 4.0
+        "targetTemperature": 4.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[4148613317][Flex_S_v2_19_ligseq].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[4148613317][Flex_S_v2_19_ligseq].json
@@ -11430,7 +11430,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 6.0
+        "targetTemperature": 6.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[43918caf53][Flex_S_v2_18_PL_immunoprecipitation-by-dynabeads-on-flex-reagents-in-15-ml-tubes].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[43918caf53][Flex_S_v2_18_PL_immunoprecipitation-by-dynabeads-on-flex-reagents-in-15-ml-tubes].json
@@ -56006,7 +56006,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 4.0
+        "targetTemperature": 4.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[43d2b3290b][Flex_S_2_16_MPL_Zymo_Quick_RNA_Cells_Flex_96_Channel].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[43d2b3290b][Flex_S_2_16_MPL_Zymo_Quick_RNA_Cells_Flex_96_Channel].json
@@ -46890,7 +46890,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 55.0
+        "targetTemperature": 55.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"
@@ -49041,7 +49042,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 4.0
+        "targetTemperature": 4.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[4420d0fb0d][Flex_S_v2_18_PL_pacbio-hifi-prep].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[4420d0fb0d][Flex_S_v2_18_PL_pacbio-hifi-prep].json
@@ -13301,7 +13301,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 4.0
+        "targetTemperature": 4.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[48d2ab1037][Flex_S_2_16_MPL_Takara_InFusionSnapAssembly_Flex].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[48d2ab1037][Flex_S_2_16_MPL_Takara_InFusionSnapAssembly_Flex].json
@@ -16156,7 +16156,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 50.0
+        "targetTemperature": 50.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"
@@ -16201,7 +16202,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 4.0
+        "targetTemperature": 4.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[4ff0682094][Flex_S_v2_18_PL_QIAseq-FX-Normalizer-Workflow-B-48x].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[4ff0682094][Flex_S_v2_18_PL_QIAseq-FX-Normalizer-Workflow-B-48x].json
@@ -10005,7 +10005,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 4.0
+        "targetTemperature": 4.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[555b2fff00][Flex_S_v2_19_Illumina_DNA_Prep_48x].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[555b2fff00][Flex_S_v2_19_Illumina_DNA_Prep_48x].json
@@ -5391,7 +5391,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 4.0
+        "targetTemperature": 4.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[55d9fd0f78][Flex_S_2_16_MPL_Zymo_Quick_RNA_Cells_Flex_multi].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[55d9fd0f78][Flex_S_2_16_MPL_Zymo_Quick_RNA_Cells_Flex_multi].json
@@ -2652,7 +2652,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 4.0
+        "targetTemperature": 4.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[59b00713a7][Flex_S_v2_18_ligseq].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[59b00713a7][Flex_S_v2_18_ligseq].json
@@ -11430,7 +11430,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 6.0
+        "targetTemperature": 6.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6a1d5a5b10][Flex_S_v2_18_PL_MN_RNA_Flex_Multi].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6a1d5a5b10][Flex_S_v2_18_PL_MN_RNA_Flex_Multi].json
@@ -21194,7 +21194,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 4.0
+        "targetTemperature": 4.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6b8f269aec][Flex_S_v2_18_PL_immunoprecipitation-by-dynabeads-on-flex].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6b8f269aec][Flex_S_v2_18_PL_immunoprecipitation-by-dynabeads-on-flex].json
@@ -41344,7 +41344,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 4.0
+        "targetTemperature": 4.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6c599fcf11][Flex_S_v2_18_PL_Illumina-DNA-Prep-96x].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6c599fcf11][Flex_S_v2_18_PL_Illumina-DNA-Prep-96x].json
@@ -15842,7 +15842,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 4.0
+        "targetTemperature": 4.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6e34343cfc][Flex_S_v2_15_P1000_96_GRIP_HS_MB_TM_MagMaxRNAExtraction].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6e34343cfc][Flex_S_v2_15_P1000_96_GRIP_HS_MB_TM_MagMaxRNAExtraction].json
@@ -25339,7 +25339,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 55.0
+        "targetTemperature": 55.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"
@@ -26706,7 +26707,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 4.0
+        "targetTemperature": 4.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"
@@ -40743,7 +40745,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 55.0
+        "targetTemperature": 55.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"
@@ -42110,7 +42113,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 4.0
+        "targetTemperature": 4.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"
@@ -56147,7 +56151,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 55.0
+        "targetTemperature": 55.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"
@@ -57514,7 +57519,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 4.0
+        "targetTemperature": 4.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6e90094352][Flex_S_v2_18_PL_ligseq].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6e90094352][Flex_S_v2_18_PL_ligseq].json
@@ -11430,7 +11430,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 6.0
+        "targetTemperature": 6.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[8203c1173d][Flex_S_2_18_MPL_Nanopore_Genomic_Ligation_v5_Final].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[8203c1173d][Flex_S_2_18_MPL_Nanopore_Genomic_Ligation_v5_Final].json
@@ -11430,7 +11430,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 6.0
+        "targetTemperature": 6.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[84f684cbc4][Flex_S_v2_18_IDT_xGen_EZ_48x].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[84f684cbc4][Flex_S_v2_18_IDT_xGen_EZ_48x].json
@@ -5391,7 +5391,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 4.0
+        "targetTemperature": 4.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[874fdce8c5][Flex_S_v2_18_PL_QIAseq-Targeted-DNA-Pro-48x].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[874fdce8c5][Flex_S_v2_18_PL_QIAseq-Targeted-DNA-Pro-48x].json
@@ -6483,7 +6483,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 4.0
+        "targetTemperature": 4.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[88095b83cd][Flex_S_2_15_MPL_langone_pt2_ribo].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[88095b83cd][Flex_S_2_15_MPL_langone_pt2_ribo].json
@@ -16461,7 +16461,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 4.0
+        "targetTemperature": 4.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[8d7ad02701][Flex_S_2_17_MPL_EM_seq_48Samples_AllSteps_Edits_150].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[8d7ad02701][Flex_S_2_17_MPL_EM_seq_48Samples_AllSteps_Edits_150].json
@@ -4829,7 +4829,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 4.0
+        "targetTemperature": 4.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"
@@ -4860,7 +4861,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 4.0
+        "targetTemperature": 4.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[8e63842620][Flex_S_v2_18_PL_QIAseq-miRNA-48x].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[8e63842620][Flex_S_v2_18_PL_QIAseq-miRNA-48x].json
@@ -14683,7 +14683,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 4.0
+        "targetTemperature": 4.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[94cd467de4][Flex_X_v2_19_Illumina_Stranded_total_RNA_Ribo_Zero].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[94cd467de4][Flex_X_v2_19_Illumina_Stranded_total_RNA_Ribo_Zero].json
@@ -15594,7 +15594,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 4.0
+        "targetTemperature": 4.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[9d4246b8ea][Flex_S_v2_16_PL_HDQ_DNA_Flex_Multi-Bacteria].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[9d4246b8ea][Flex_S_v2_16_PL_HDQ_DNA_Flex_Multi-Bacteria].json
@@ -19100,7 +19100,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 55.0
+        "targetTemperature": 55.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[9dda567b8b][Flex_S_v2_16_PL_Zymo_Quick-RNA_Flex_Multi-Cells].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[9dda567b8b][Flex_S_v2_16_PL_Zymo_Quick-RNA_Flex_Multi-Cells].json
@@ -2652,7 +2652,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 4.0
+        "targetTemperature": 4.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[9fefecf4bf][Flex_S_v2_18_PL_kapahyperplus].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[9fefecf4bf][Flex_S_v2_18_PL_kapahyperplus].json
@@ -2448,7 +2448,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 4.0
+        "targetTemperature": 4.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a3dfca7f0c][Flex_S_v2_19_Illumina_DNA_PCR_Free].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a3dfca7f0c][Flex_S_v2_19_Illumina_DNA_PCR_Free].json
@@ -2448,7 +2448,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 4.0
+        "targetTemperature": 4.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a437534569][Flex_S_v2_19_kapahyperplus].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a437534569][Flex_S_v2_19_kapahyperplus].json
@@ -2448,7 +2448,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 4.0
+        "targetTemperature": 4.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a750f8a161][Flex_S_v2_18_PL_QIAseq-Normalizer-Workflow-A-48x].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a750f8a161][Flex_S_v2_18_PL_QIAseq-Normalizer-Workflow-A-48x].json
@@ -7882,7 +7882,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 4.0
+        "targetTemperature": 4.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a94f22054f][Flex_S_v2_18_kapahyperplus].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a94f22054f][Flex_S_v2_18_kapahyperplus].json
@@ -2448,7 +2448,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 4.0
+        "targetTemperature": 4.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[ad247e5f7c][Flex_S_2_16_MPL_Omega_HDQ_DNA_Bacteria_Flex_multi].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[ad247e5f7c][Flex_S_2_16_MPL_Omega_HDQ_DNA_Bacteria_Flex_multi].json
@@ -19100,7 +19100,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 55.0
+        "targetTemperature": 55.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[b3dc4bb2a5][Flex_S_2_18_MPL_Hyperplus_tiptracking_V4_final].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[b3dc4bb2a5][Flex_S_2_18_MPL_Hyperplus_tiptracking_V4_final].json
@@ -2448,7 +2448,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 4.0
+        "targetTemperature": 4.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[b856a4edaa][Flex_S_v2_20_PL_evercode-whole-transcriptomeWT-kit-Parse-Biosciences-protocol3].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[b856a4edaa][Flex_S_v2_20_PL_evercode-whole-transcriptomeWT-kit-Parse-Biosciences-protocol3].json
@@ -11462,7 +11462,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 4.0
+        "targetTemperature": 4.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"
@@ -24724,7 +24725,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 24.0
+        "targetTemperature": 24.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[b9c04c58f9][Flex_S_2_16_MPL_MagMax_RNA_Cells_Flex_96_Channel].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[b9c04c58f9][Flex_S_2_16_MPL_MagMax_RNA_Cells_Flex_96_Channel].json
@@ -6901,7 +6901,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 4.0
+        "targetTemperature": 4.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c15790917f][Flex_S_v2_20_PL_evercode-whole-transcriptomeWT-kit-Parse-Biosciences-protocol1].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c15790917f][Flex_S_v2_20_PL_evercode-whole-transcriptomeWT-kit-Parse-Biosciences-protocol1].json
@@ -69142,7 +69142,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 4.0
+        "targetTemperature": 4.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c41d4198c8][Flex_S_2_18_MPL_Illumina_DNA_Prep_48x_v8].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c41d4198c8][Flex_S_2_18_MPL_Illumina_DNA_Prep_48x_v8].json
@@ -5391,7 +5391,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 4.0
+        "targetTemperature": 4.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c8d2ca0089][Flex_S_v2_18_QIASeq_FX_48x].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c8d2ca0089][Flex_S_v2_18_QIASeq_FX_48x].json
@@ -5391,7 +5391,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 4.0
+        "targetTemperature": 4.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[d1b4db3d02][Flex_S_v2_16_PL_invitrogen_elisa_captureabcoating].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[d1b4db3d02][Flex_S_v2_16_PL_invitrogen_elisa_captureabcoating].json
@@ -4846,7 +4846,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 4.0
+        "targetTemperature": 4.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[d598237327][Flex_S_v2_18_PL_Illumina-DNA-Prep-PCR-Free].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[d598237327][Flex_S_v2_18_PL_Illumina-DNA-Prep-PCR-Free].json
@@ -2448,7 +2448,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 4.0
+        "targetTemperature": 4.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[d61739e6a3][Flex_S_v2_19_IDT_xGen_EZ_48x].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[d61739e6a3][Flex_S_v2_19_IDT_xGen_EZ_48x].json
@@ -5391,7 +5391,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 4.0
+        "targetTemperature": 4.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[dabb7872d8][Flex_S_v2_19_P1000_96_GRIP_HS_MB_TC_TM_Smoke].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[dabb7872d8][Flex_S_v2_19_P1000_96_GRIP_HS_MB_TC_TM_Smoke].json
@@ -15093,7 +15093,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 50.0
+        "targetTemperature": 50.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[e18bdd6f5d][Flex_S_2_15_P1000M_P50M_GRIP_HS_TM_MB_TC_KAPALibraryQuantv4_8].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[e18bdd6f5d][Flex_S_2_15_P1000M_P50M_GRIP_HS_TM_MB_TC_KAPALibraryQuantv4_8].json
@@ -16731,7 +16731,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 4.0
+        "targetTemperature": 4.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[e4b5b30b2e][Flex_S_v2_18_Illumina_DNA_PCR_Free].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[e4b5b30b2e][Flex_S_v2_18_Illumina_DNA_PCR_Free].json
@@ -2448,7 +2448,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 4.0
+        "targetTemperature": 4.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[e4c3685417][OT2_S_v8_4_4P300GEN2_Smoke].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[e4c3685417][OT2_S_v8_4_4P300GEN2_Smoke].json
@@ -5846,7 +5846,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 40.0
+        "targetTemperature": 40.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[e670e626e3][Flex_S_2_18_MPL_QIASeq_FX_48x_v8].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[e670e626e3][Flex_S_2_18_MPL_QIASeq_FX_48x_v8].json
@@ -5391,7 +5391,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 4.0
+        "targetTemperature": 4.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[e7cf2a4f57][Flex_X_v8_PD_P1000_96_HS_GRIP_TC_TM_GripperCollisionWithTips].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[e7cf2a4f57][Flex_X_v8_PD_P1000_96_HS_GRIP_TC_TM_GripperCollisionWithTips].json
@@ -11876,7 +11876,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 50.0
+        "targetTemperature": 50.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[ed2f3800b6][Flex_S_2_18_P1000M_P50M_GRIP_HS_TM_MB_TC_IlluminaDNAPrep24xV4_7].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[ed2f3800b6][Flex_S_2_18_P1000M_P50M_GRIP_HS_TM_MB_TC_IlluminaDNAPrep24xV4_7].json
@@ -11172,7 +11172,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 4.0
+        "targetTemperature": 4.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f51172f73b][Flex_S_v2_16_P1000_96_GRIP_HS_MB_TC_TM_Smoke].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f51172f73b][Flex_S_v2_16_P1000_96_GRIP_HS_MB_TC_TM_Smoke].json
@@ -24329,7 +24329,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 80.0
+        "targetTemperature": 80.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"
@@ -24360,7 +24361,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 10.0
+        "targetTemperature": 10.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f61c4fcb30][Flex_S_v2_16_PL_Magmax_RNA_Flex_96-Cells].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f61c4fcb30][Flex_S_v2_16_PL_Magmax_RNA_Flex_96-Cells].json
@@ -6901,7 +6901,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 4.0
+        "targetTemperature": 4.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f7731d7e20][Flex_S_2_18_MPL_Illumina_DNA_PCR_Free].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f7731d7e20][Flex_S_2_18_MPL_Illumina_DNA_PCR_Free].json
@@ -2448,7 +2448,8 @@
         "moduleId": "UUID"
       },
       "result": {
-        "targetTemperature": 4.0
+        "targetTemperature": 4.0,
+        "taskId": "UUID"
       },
       "startedAt": "TIMESTAMP",
       "status": "succeeded"

--- a/analyses-snapshot-testing/tests/custom_json_snapshot_extension.py
+++ b/analyses-snapshot-testing/tests/custom_json_snapshot_extension.py
@@ -39,7 +39,7 @@ class CustomJSONSnapshotExtension(JSONSnapshotExtension):
             "lidLabwareId",
             "stackLabwareId",
             "lid_id",
-            "taskId"
+            "taskId",
         ]
         self.timestamp_keys_to_replace = [
             "createdAt",

--- a/analyses-snapshot-testing/tests/custom_json_snapshot_extension.py
+++ b/analyses-snapshot-testing/tests/custom_json_snapshot_extension.py
@@ -39,6 +39,7 @@ class CustomJSONSnapshotExtension(JSONSnapshotExtension):
             "lidLabwareId",
             "stackLabwareId",
             "lid_id",
+            "taskId"
         ]
         self.timestamp_keys_to_replace = [
             "createdAt",

--- a/api/src/opentrons/protocol_api/__init__.py
+++ b/api/src/opentrons/protocol_api/__init__.py
@@ -14,7 +14,7 @@ from opentrons.protocols.parameters.exceptions import (
     RuntimeParameterRequired as RuntimeParameterRequiredError,
 )
 from opentrons.protocols.parameters.csv_parameter_interface import CSVParameter
-
+from .tasks import Task
 from .protocol_context import ProtocolContext
 from .deck import Deck
 from .robot_context import RobotContext
@@ -30,7 +30,6 @@ from .module_contexts import (
     AbsorbanceReaderContext,
     FlexStackerContext,
 )
-from .tasks import Task
 from .disposal_locations import TrashBin, WasteChute
 from ._liquid import Liquid, LiquidClass
 from ._types import (

--- a/api/src/opentrons/protocol_api/core/engine/module_core.py
+++ b/api/src/opentrons/protocol_api/core/engine/module_core.py
@@ -51,6 +51,7 @@ from ..module import (
 from .exceptions import InvalidMagnetEngageHeightError
 
 from .labware import LabwareCore
+from .tasks import EngineTaskCore
 from . import load_labware_params
 
 if TYPE_CHECKING:
@@ -175,13 +176,17 @@ class TemperatureModuleCore(ModuleCore, AbstractTemperatureModuleCore[LabwareCor
 
     _sync_module_hardware: SynchronousAdapter[hw_modules.TempDeck]
 
-    def set_target_temperature(self, celsius: float) -> None:
+    def set_target_temperature(self, celsius: float) -> EngineTaskCore:
         """Set the Temperature Module's target temperature in °C."""
-        self._engine_client.execute_command(
+        result = self._engine_client.execute_command_without_recovery(
             cmd.temperature_module.SetTargetTemperatureParams(
                 moduleId=self.module_id, celsius=celsius
             )
         )
+        temperature_task = EngineTaskCore(
+            engine_client=self._engine_client, task_id=result.taskId
+        )
+        return temperature_task
 
     def wait_for_target_temperature(self, celsius: Optional[float] = None) -> None:
         """Wait until the module's target temperature is reached.

--- a/api/src/opentrons/protocol_api/core/engine/protocol.py
+++ b/api/src/opentrons/protocol_api/core/engine/protocol.py
@@ -879,7 +879,7 @@ class ProtocolCore(
 
     def wait_for_tasks(self, task_cores: Sequence[EngineTaskCore]) -> None:
         """Wait for specified tasks to complete."""
-        task_ids = [task._id for task in task_cores]
+        task_ids = task_ids = [task._id for task in task_cores if task._id is not None]
         self._engine_client.execute_command(cmd.WaitForTasksParams(task_ids=task_ids))
 
     def create_timer(self, seconds: float) -> EngineTaskCore:

--- a/api/src/opentrons/protocol_api/core/engine/tasks.py
+++ b/api/src/opentrons/protocol_api/core/engine/tasks.py
@@ -5,15 +5,24 @@ from opentrons.protocol_engine.errors.exceptions import NoTaskFoundError
 
 
 class EngineTaskCore(AbstractTaskCore):
-    def __init__(self, task_id: str, engine_client: ProtocolEngineClient) -> None:
+    def __init__(
+        self, task_id: str | None, engine_client: ProtocolEngineClient
+    ) -> None:
         self._id = task_id
         self._engine_client = engine_client
 
     def get_created_at_timestamp(self) -> datetime:
-        task = self._engine_client.state.tasks.get(self._id)
-        return task.createdAt
+        if self._id is None:
+            raise NoTaskFoundError
+        try:
+            task = self._engine_client.state.tasks.get(self._id)
+            return task.createdAt
+        except NoTaskFoundError:
+            raise NoTaskFoundError
 
     def is_done(self) -> bool:
+        if self._id is None:
+            raise NoTaskFoundError
         try:
             self._engine_client.state.tasks.get_finished(self._id)
             return True
@@ -21,6 +30,8 @@ class EngineTaskCore(AbstractTaskCore):
             return False
 
     def is_started(self) -> bool:
+        if self._id is None:
+            raise NoTaskFoundError
         try:
             self._engine_client.state.tasks.get_current(self._id)
             return True
@@ -28,6 +39,8 @@ class EngineTaskCore(AbstractTaskCore):
             return self.is_done()
 
     def get_finished_at_timestamp(self) -> datetime | None:
+        if self._id is None:
+            raise NoTaskFoundError
         try:
             finished_task = self._engine_client.state.tasks.get_finished(self._id)
             return finished_task.finishedAt

--- a/api/src/opentrons/protocol_api/core/legacy/legacy_module_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy/legacy_module_core.py
@@ -31,6 +31,7 @@ from ..module import (
 )
 
 from .legacy_labware_core import LegacyLabwareCore
+from .tasks import LegacyTaskCore
 from .module_geometry import ModuleGeometry, ThermocyclerGeometry, HeaterShakerGeometry
 from ...labware import Labware
 
@@ -116,9 +117,10 @@ class LegacyTemperatureModuleCore(
 
     _sync_module_hardware: SynchronousAdapter[hw_modules.TempDeck]
 
-    def set_target_temperature(self, celsius: float) -> None:
+    def set_target_temperature(self, celsius: float) -> LegacyTaskCore:
         """Set the Temperature Module's target temperature in °C."""
         self._sync_module_hardware.start_set_temperature(celsius)
+        return LegacyTaskCore()
 
     def wait_for_target_temperature(self, celsius: Optional[float] = None) -> None:
         """Wait until the module's target temperature is reached.

--- a/api/src/opentrons/protocol_api/core/legacy/tasks.py
+++ b/api/src/opentrons/protocol_api/core/legacy/tasks.py
@@ -3,8 +3,8 @@ from datetime import datetime
 
 
 class LegacyTaskCore(AbstractTaskCore):
-    def __init__(self, created_at: datetime) -> None:
-        raise NotImplementedError("Legacy protocols do not implement tasks.")
+    def __init__(self) -> None:
+        pass
 
     def get_created_at_timestamp(self) -> datetime:
         raise NotImplementedError("Legacy protocols do not implement tasks.")

--- a/api/src/opentrons/protocol_api/core/module.py
+++ b/api/src/opentrons/protocol_api/core/module.py
@@ -18,6 +18,7 @@ from opentrons.hardware_control.modules.types import (
     SpeedStatus,
 )
 from .labware import LabwareCoreType, AbstractLabware
+from .tasks import AbstractTaskCore
 from opentrons.protocol_engine.types import ABSMeasureMode
 from opentrons.types import DeckSlotName
 
@@ -59,7 +60,7 @@ class AbstractTemperatureModuleCore(
         """Get the module's unique hardware serial number."""
 
     @abstractmethod
-    def set_target_temperature(self, celsius: float) -> None:
+    def set_target_temperature(self, celsius: float) -> AbstractTaskCore:
         """Set the Temperature Module's target temperature in °C."""
 
     @abstractmethod

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -43,6 +43,7 @@ from .module_validation_and_errors import (
 )
 from .labware import Labware
 from . import validation
+from . import Task
 
 
 _MAGNETIC_MODULE_HEIGHT_PARAM_REMOVED_IN = APIVersion(2, 14)
@@ -447,18 +448,28 @@ class TemperatureModuleContext(ModuleContext):
         No other protocol commands will execute while waiting for the temperature.
 
         :param celsius: A value between 4 and 95, representing the target temperature in °C.
+
         """
         self._core.set_target_temperature(celsius)
         self._core.wait_for_target_temperature()
 
     @publish(command=cmds.tempdeck_set_temp)
     @requires_version(2, 3)
-    def start_set_temperature(self, celsius: float) -> None:
+    def start_set_temperature(self, celsius: float) -> Task:
         """Set the target temperature without waiting for the target to be hit.
 
+        .. versionchanged:: 2.27
+            Returns a task object that represents concurrent preheating.
+            Pass the task object to :py:meth:`ProtocolContext.wait_for_tasks` to wait for the preheat to complete.
+
+        On version 2.26 or below, this function returns ``None``.
         :param celsius: A value between 4 and 95, representing the target temperature in °C.
         """
-        self._core.set_target_temperature(celsius)
+        task = self._core.set_target_temperature(celsius)
+        if self._api_version >= APIVersion(2, 27):
+            return Task(api_version=self._api_version, core=task)
+        else:
+            return cast(Task, None)
 
     @publish(command=cmds.tempdeck_await_temp)
     @requires_version(2, 3)

--- a/api/src/opentrons/protocol_engine/clients/sync_client.py
+++ b/api/src/opentrons/protocol_engine/clients/sync_client.py
@@ -73,6 +73,12 @@ class SyncClient:
 
     @overload
     def execute_command_without_recovery(
+        self, params: commands.temperature_module.SetTargetTemperatureParams
+    ) -> commands.temperature_module.SetTargetTemperatureResult:
+        pass
+
+    @overload
+    def execute_command_without_recovery(
         self, params: commands.LoadModuleParams
     ) -> commands.LoadModuleResult:
         pass

--- a/api/src/opentrons/protocol_engine/commands/temperature_module/set_target_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/temperature_module/set_target_temperature.py
@@ -10,7 +10,7 @@ from ...errors.error_occurrence import ErrorOccurrence
 
 if TYPE_CHECKING:
     from opentrons.protocol_engine.state.state import StateView
-    from opentrons.protocol_engine.execution import EquipmentHandler
+    from opentrons.protocol_engine.execution import EquipmentHandler, TaskHandler
 
 SetTargetTemperatureCommandType = Literal["temperatureModule/setTargetTemperature"]
 
@@ -20,6 +20,9 @@ class SetTargetTemperatureParams(BaseModel):
 
     moduleId: str = Field(..., description="Unique ID of the Temperature Module.")
     celsius: float = Field(..., description="Target temperature in °C.")
+    taskId: str | None = Field(
+        None, description="Id for the background task that manages the temperature"
+    )
 
 
 class SetTargetTemperatureResult(BaseModel):
@@ -29,6 +32,9 @@ class SetTargetTemperatureResult(BaseModel):
         ...,
         description="The target temperature that was set after validation "
         "and type conversion (if any).",
+    )
+    taskId: str = Field(
+        ..., description="The task id for the setTargetTemperature task"
     )
 
 
@@ -43,10 +49,12 @@ class SetTargetTemperatureImpl(
         self,
         state_view: StateView,
         equipment: EquipmentHandler,
+        task_handler: TaskHandler,
         **unused_dependencies: object,
     ) -> None:
         self._state_view = state_view
         self._equipment = equipment
+        self._task_handler = task_handler
 
     async def execute(
         self, params: SetTargetTemperatureParams
@@ -56,19 +64,33 @@ class SetTargetTemperatureImpl(
         module_substate = self._state_view.modules.get_temperature_module_substate(
             module_id=params.moduleId
         )
-
         # Verify temperature from temperature module view
         validated_temp = module_substate.validate_target_temperature(params.celsius)
-
         # Allow propagation of ModuleNotAttachedError.
         temp_hardware_module = self._equipment.get_module_hardware_api(
             module_substate.module_id
         )
 
-        if temp_hardware_module is not None:
-            await temp_hardware_module.start_set_temperature(celsius=validated_temp)
+        async def start_set_temperature(task_handler: TaskHandler) -> None:
+            if temp_hardware_module is not None:
+                async with task_handler.synchronize_cancel_previous(
+                    module_substate.module_id
+                ):
+                    await temp_hardware_module.start_set_temperature(
+                        celsius=validated_temp
+                    )
+                    await temp_hardware_module.await_temperature(
+                        awaiting_temperature=validated_temp
+                    )
+
+        task = await self._task_handler.create_task(
+            task_function=start_set_temperature, id=params.taskId
+        )
+
         return SuccessData(
-            public=SetTargetTemperatureResult(targetTemperature=validated_temp),
+            public=SetTargetTemperatureResult(
+                targetTemperature=validated_temp, taskId=task.id
+            ),
         )
 
 

--- a/api/src/opentrons/protocol_engine/commands/temperature_module/set_target_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/temperature_module/set_target_temperature.py
@@ -40,9 +40,10 @@ class SetTargetTemperatureResult(BaseModel):
         description="The target temperature that was set after validation "
         "and type conversion (if any).",
     )
-    taskId: str = Field(
-        ...,
+    taskId: str | SkipJsonSchema[None] = Field(
+        None,
         description="The task id for the setTargetTemperature task",
+        json_schema_extra=_remove_default,
     )
 
 

--- a/api/src/opentrons/protocol_engine/commands/temperature_module/set_target_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/temperature_module/set_target_temperature.py
@@ -1,9 +1,10 @@
 """Command models to start heating a Temperature Module."""
 from __future__ import annotations
-from typing import Optional, TYPE_CHECKING
+from typing import Optional, TYPE_CHECKING, Any
 from typing_extensions import Literal, Type
 
 from pydantic import BaseModel, Field
+from pydantic.json_schema import SkipJsonSchema
 
 from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
 from ...errors.error_occurrence import ErrorOccurrence
@@ -15,13 +16,19 @@ if TYPE_CHECKING:
 SetTargetTemperatureCommandType = Literal["temperatureModule/setTargetTemperature"]
 
 
+def _remove_default(s: dict[str, Any]) -> None:
+    s.pop("default", None)
+
+
 class SetTargetTemperatureParams(BaseModel):
     """Input parameters to set a Temperature Module's target temperature."""
 
     moduleId: str = Field(..., description="Unique ID of the Temperature Module.")
     celsius: float = Field(..., description="Target temperature in °C.")
-    taskId: str | None = Field(
-        None, description="Id for the background task that manages the temperature"
+    taskId: str | SkipJsonSchema[None] = Field(
+        None,
+        description="Id for the background task that manages the temperature",
+        json_schema_extra=_remove_default,
     )
 
 
@@ -34,7 +41,8 @@ class SetTargetTemperatureResult(BaseModel):
         "and type conversion (if any).",
     )
     taskId: str = Field(
-        ..., description="The task id for the setTargetTemperature task"
+        ...,
+        description="The task id for the setTargetTemperature task",
     )
 
 

--- a/api/tests/opentrons/protocol_api/core/engine/test_temperature_module_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_temperature_module_core.py
@@ -9,6 +9,7 @@ from opentrons.hardware_control.modules.types import TemperatureStatus, ModuleTy
 
 from opentrons.protocol_engine import commands as cmd
 from opentrons.protocol_engine.clients import SyncClient as EngineClient
+from opentrons.protocol_api.core.engine.tasks import EngineTaskCore
 
 from opentrons.protocol_api.core.engine.module_core import TemperatureModuleCore
 from opentrons.protocol_api.core.engine.protocol import ProtocolCore
@@ -76,17 +77,23 @@ def test_set_target_temperature(
     subject: TemperatureModuleCore,
     mock_engine_client: EngineClient,
 ) -> None:
-    """Should verify EngineClient call to set_target_temperature."""
-    subject.set_target_temperature(38.9)
-
-    decoy.verify(
-        mock_engine_client.execute_command(
+    """Should verify EngineClient call to set_target_temperature and return an EngineTaskCore."""
+    task_mock = decoy.mock(cls=EngineTaskCore)
+    decoy.when(
+        mock_engine_client.execute_command_without_recovery(
             cmd.temperature_module.SetTargetTemperatureParams(
                 moduleId="1234", celsius=38.9
             )
         ),
-        times=1,
+    ).then_return(
+        cmd.temperature_module.SetTargetTemperatureResult(
+            targetTemperature=38.9, taskId="taskId"
+        )
     )
+    task_mock._id = "taskId"
+    result = subject.set_target_temperature(38.9)
+    assert isinstance(result, EngineTaskCore)
+    assert result._id == "taskId"
 
 
 def test_wait_for_target_temperature(

--- a/api/tests/opentrons/protocol_api/test_temperature_module_context.py
+++ b/api/tests/opentrons/protocol_api/test_temperature_module_context.py
@@ -4,6 +4,7 @@ from decoy import Decoy, matchers
 
 from opentrons.legacy_broker import LegacyBroker
 from opentrons.hardware_control.modules import TemperatureStatus
+from opentrons.protocol_api.tasks import Task
 from opentrons.protocols.api_support.types import APIVersion
 from opentrons.protocols.api_support.util import APIVersionError
 from opentrons.protocol_api import MAX_SUPPORTED_VERSION, TemperatureModuleContext
@@ -88,15 +89,19 @@ def test_set_temperature(
     )
 
 
-@pytest.mark.parametrize("api_version", [APIVersion(2, 3)])
+@pytest.mark.parametrize("api_version", [APIVersion(2, 3), APIVersion(2, 27)])
 def test_start_set_temperature(
     decoy: Decoy,
     mock_core: TemperatureModuleCore,
     mock_broker: LegacyBroker,
     subject: TemperatureModuleContext,
+    api_version: APIVersion,
 ) -> None:
-    """It should set the target temperature via the core."""
-    subject.start_set_temperature(42.0)
+    """It should set the target temperature via the core and return a task."""
+    subject._api_version = api_version
+    mock_task = decoy.mock(cls=Task)
+    decoy.when(mock_core.set_target_temperature(42.0)).then_return(mock_task._core)
+    result = subject.start_set_temperature(42.0)
 
     decoy.verify(
         mock_broker.publish(
@@ -109,13 +114,18 @@ def test_start_set_temperature(
                 }
             ),
         ),
-        mock_core.set_target_temperature(42.0),
         mock_broker.publish("command", matchers.DictMatching({"$": "after"})),
     )
 
     decoy.verify(
         mock_core.wait_for_target_temperature(), ignore_extra_args=True, times=0
     )
+    if api_version >= APIVersion(2, 27):
+        assert isinstance(result, Task)
+        assert result._core is mock_task._core
+        assert result._api_version == api_version
+    else:
+        assert result is None
 
 
 @pytest.mark.parametrize("api_version", [APIVersion(2, 2)])

--- a/api/tests/opentrons/protocol_engine/commands/conftest.py
+++ b/api/tests/opentrons/protocol_engine/commands/conftest.py
@@ -128,16 +128,22 @@ def state_store(decoy: Decoy) -> StateStore:
 
 
 @pytest.fixture
+def real_concurrency_provider() -> ConcurrencyProvider:
+    """Get a real concurrency provider."""
+    return ConcurrencyProvider()
+
+
+@pytest.fixture
 def real_task_handler(
     state_store: StateStore,
     action_dispatcher: ActionDispatcher,
     model_utils: ModelUtils,
-    concurrency_provider: ConcurrencyProvider,
+    real_concurrency_provider: ConcurrencyProvider,
 ) -> TaskHandler:
     """Get a real task handler with mocked dependencies."""
     return TaskHandler(
         state_store=state_store,
         action_dispatcher=action_dispatcher,
         model_utils=model_utils,
-        concurrency_provider=concurrency_provider,
+        concurrency_provider=real_concurrency_provider,
     )

--- a/api/tests/opentrons/protocol_engine/commands/temperature_module/test_set_target_temperature.py
+++ b/api/tests/opentrons/protocol_engine/commands/temperature_module/test_set_target_temperature.py
@@ -1,6 +1,5 @@
 """Test Temperature Module's set target temperature command implementation."""
-from decoy import Decoy
-
+from decoy import Decoy, matchers
 from opentrons.hardware_control.modules import TempDeck
 
 from opentrons.protocol_engine.state.state import StateView
@@ -8,25 +7,32 @@ from opentrons.protocol_engine.state.module_substates import (
     TemperatureModuleSubState,
     TemperatureModuleId,
 )
-from opentrons.protocol_engine.execution import EquipmentHandler
+from opentrons.protocol_engine.resources import ModelUtils
+from opentrons.protocol_engine.execution import EquipmentHandler, TaskHandler
+from opentrons.protocol_engine.actions import ActionDispatcher, Action, StartTaskAction
 from opentrons.protocol_engine.commands import temperature_module
 from opentrons.protocol_engine.commands.command import SuccessData
 from opentrons.protocol_engine.commands.temperature_module.set_target_temperature import (
     SetTargetTemperatureImpl,
 )
+from opentrons.protocol_engine.types.tasks import Task
 
 
 async def test_set_target_temperature(
     decoy: Decoy,
     state_view: StateView,
     equipment: EquipmentHandler,
+    real_task_handler: TaskHandler,
+    action_dispatcher: ActionDispatcher,
+    model_utils: ModelUtils,
 ) -> None:
     """It should be able to set the specified module's target temperature."""
-    subject = SetTargetTemperatureImpl(state_view=state_view, equipment=equipment)
+    subject = SetTargetTemperatureImpl(
+        state_view=state_view, equipment=equipment, task_handler=real_task_handler
+    )
 
     data = temperature_module.SetTargetTemperatureParams(
-        moduleId="tempdeck-id",
-        celsius=1.23,
+        moduleId="tempdeck-id", celsius=1.23, taskId="taskId"
     )
 
     module_substate = decoy.mock(cls=TemperatureModuleSubState)
@@ -35,7 +41,7 @@ async def test_set_target_temperature(
     decoy.when(
         state_view.modules.get_temperature_module_substate(module_id="tempdeck-id")
     ).then_return(module_substate)
-
+    decoy.when(model_utils.ensure_id("taskId")).then_return("taskId")
     decoy.when(module_substate.module_id).then_return(
         TemperatureModuleId("tempdeck-id")
     )
@@ -48,8 +54,27 @@ async def test_set_target_temperature(
         equipment.get_module_hardware_api(TemperatureModuleId("tempdeck-id"))
     ).then_return(tempdeck_hardware)
 
+    task: Task | None = None
+
+    def _capture_task(action: Action) -> None:
+        nonlocal task
+        assert isinstance(action, StartTaskAction)
+        task = action.task
+
+    decoy.when(
+        action_dispatcher.dispatch(StartTaskAction(task=matchers.Anything()))
+    ).then_do(_capture_task)
+
     result = await subject.execute(data)
-    decoy.verify(await tempdeck_hardware.start_set_temperature(celsius=1), times=1)
+    assert task is not None
+    await task.asyncioTask
+    decoy.verify(
+        await tempdeck_hardware.start_set_temperature(celsius=1),
+        times=1,
+    )
+    decoy.verify(await tempdeck_hardware.await_temperature(awaiting_temperature=1))
     assert result == SuccessData(
-        public=temperature_module.SetTargetTemperatureResult(targetTemperature=1),
+        public=temperature_module.SetTargetTemperatureResult(
+            targetTemperature=1, taskId="taskId"
+        ),
     )

--- a/api/tests/opentrons/protocol_engine/state/test_module_store_old.py
+++ b/api/tests/opentrons/protocol_engine/state/test_module_store_old.py
@@ -615,7 +615,9 @@ def test_handle_tempdeck_temperature_commands(
         params=temp_commands.SetTargetTemperatureParams(
             moduleId="module-id", celsius=42.4
         ),
-        result=temp_commands.SetTargetTemperatureResult(targetTemperature=42),
+        result=temp_commands.SetTargetTemperatureResult(
+            targetTemperature=42, taskId="taskId"
+        ),
     )
     deactivate_cmd = temp_commands.DeactivateTemperature.model_construct(  # type: ignore[call-arg]
         params=temp_commands.DeactivateTemperatureParams(moduleId="module-id"),

--- a/shared-data/command/schemas/15.json
+++ b/shared-data/command/schemas/15.json
@@ -6795,17 +6795,9 @@
           "type": "string"
         },
         "taskId": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
           "description": "Id for the background task that manages the temperature",
-          "title": "Taskid"
+          "title": "Taskid",
+          "type": "string"
         }
       },
       "required": ["moduleId", "celsius"],

--- a/shared-data/command/schemas/15.json
+++ b/shared-data/command/schemas/15.json
@@ -6793,6 +6793,19 @@
           "description": "Unique ID of the Temperature Module.",
           "title": "Moduleid",
           "type": "string"
+        },
+        "taskId": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Id for the background task that manages the temperature",
+          "title": "Taskid"
         }
       },
       "required": ["moduleId", "celsius"],


### PR DESCRIPTION
# Overview

Temperature Module `set_target_temperature()` runs concurrently and returns a task

This allows the robot to continue with other actions while the temperature module is reaching its target temperature.
Then allows you to base the start of other commands on the completion of `set_target_temperature()` by passing the result into `protocol_context.wait_for_tasks()`

## Test Plan and Hands on Testing

Ran this protocol on robot. The robot moved to the trash location before the preheat was finished. The robot did not home until the preheat was finished.

```
"""Test concurrent temp mod preheat."""
from opentrons import protocol_api
metadata = {
    "protocolName": "Test concurrent temp mod preheat",
}
requirements = {"robotType": "Flex", "apiLevel": "2.27"}
def run(protocol: protocol_api.ProtocolContext) -> None:
    """Run the protocol."""
    trash = protocol.load_trash_bin("A1")
    pipette = protocol.load_instrument("flex_8channel_1000", "right")
    temp_deck = protocol.load_module("temperature module gen2", "D3")
    timer1 = protocol.create_timer(5)
    temp_task = temp_deck.start_set_temperature(25)
    pipette.move_to(trash)
    protocol.wait_for_tasks([temp_task, timer1])
    protocol.create_timer(5)
    protocol.home()
    protocol.comment("Both timers are done!")
```

## Review Requests

The `start_set_temperature()` function only returns a Task if the API version is 2.27 or newer. For earlier versions, no Task is applicable, so we return None. The cast(Task, None) is used to satisfy type checking and keep annotations up to date with the most recent api version. Is another way to do this?


Closes EXEC-1665