### PR TITLE
fix(api): improve ramp rate version checking

### DIFF
--- a/api/src/opentrons/hardware_control/modules/thermocycler.py
+++ b/api/src/opentrons/hardware_control/modules/thermocycler.py
@@ -280,7 +280,7 @@ class Thermocycler(mod_abc.AbstractModule):
         if version_string.startswith("v"):
             version_string = version_string[1:]
         try:
-            version_tuple = tuple(int(c) for c in version_string[1:].split("."))
+            version_tuple = tuple(int(c) for c in version_string.split("."))
             return version_tuple >= _TC_RAMP_RATE_ADDED_VERSION
         except (ValueError, IndexError):
             log.error(

--- a/api/src/opentrons/hardware_control/modules/thermocycler.py
+++ b/api/src/opentrons/hardware_control/modules/thermocycler.py
@@ -277,6 +277,8 @@ class Thermocycler(mod_abc.AbstractModule):
 
     def can_use_ramp_rate(self) -> bool:
         version_string = self._device_info.get("version", "v")
+        if version_string.startswith("v"):
+            version_string = version_string[1:]
         try:
             version_tuple = tuple(int(c) for c in version_string[1:].split("."))
             return version_tuple >= _TC_RAMP_RATE_ADDED_VERSION

--- a/api/src/opentrons/hardware_control/modules/thermocycler.py
+++ b/api/src/opentrons/hardware_control/modules/thermocycler.py
@@ -37,7 +37,7 @@ DFU_PID = "df11"
 _TC_PLATE_LIFT_OPEN_DEGREES = 20
 _TC_PLATE_LIFT_RETURN_DEGREES = 23
 
-_TC_RAMP_RATE_ADDED_VERSION = 108  # v1.0.8
+_TC_RAMP_RATE_ADDED_VERSION = (1, 0, 8)  # v1.0.8
 
 
 class ThermocyclerError(Exception):
@@ -276,10 +276,15 @@ class Thermocycler(mod_abc.AbstractModule):
         await self._wait_for_lid_status(ThermocyclerLidStatus.OPEN)
 
     def can_use_ramp_rate(self) -> bool:
-        version_as_num = int(
-            "".join([c for c in self._device_info["version"] if c.isdigit()])
-        )
-        return version_as_num >= _TC_RAMP_RATE_ADDED_VERSION
+        version_string = self._device_info.get("version", "v")
+        try:
+            version_tuple = tuple(int(c) for c in version_string[1:].split("."))
+            return version_tuple >= _TC_RAMP_RATE_ADDED_VERSION
+        except (ValueError, IndexError):
+            log.error(
+                f"Invalid version from device: {self._device_info.get('version', '')}"
+            )
+            return False
 
     async def set_temperature(
         self,

--- a/api/tests/opentrons/hardware_control/modules/test_hc_thermocycler.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_thermocycler.py
@@ -523,9 +523,9 @@ async def test_async_error_response_to_poller(
 
 def test_can_use_ramp_rate(subject: modules.Thermocycler) -> None:
     """It should handle various malformed versions without failing."""
-    subject._device_info["version"] = "1.0.9"
+    subject._device_info["version"] = "v1.0.9"
     assert subject.can_use_ramp_rate()
-    subject._device_info["version"] = "1.0.7"
+    subject._device_info["version"] = "v1.0.7"
     assert subject.can_use_ramp_rate() is False
     subject._device_info["version"] = "asdasvasd"
     assert subject.can_use_ramp_rate() is False

--- a/api/tests/opentrons/hardware_control/modules/test_hc_thermocycler.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_thermocycler.py
@@ -519,3 +519,17 @@ async def test_async_error_response_to_poller(
             "dummySerialTC",
         )
     )
+
+
+def test_can_use_ramp_rate(subject: modules.Thermocycler) -> None:
+    """It should handle various malformed versions without failing."""
+    subject._device_info["version"] = "1.0.9"
+    assert subject.can_use_ramp_rate()
+    subject._device_info["version"] = "1.0.7"
+    assert subject.can_use_ramp_rate() is False
+    subject._device_info["version"] = "asdasvasd"
+    assert subject.can_use_ramp_rate() is False
+    subject._device_info["version"] = ""
+    assert subject.can_use_ramp_rate() is False
+    del subject._device_info["version"]
+    assert subject.can_use_ramp_rate() is False

--- a/robot-server/simulators/test-flex.json
+++ b/robot-server/simulators/test-flex.json
@@ -10,7 +10,7 @@
       "model": "p50_single_3.4",
       "id": "123_flex"
     },
-    "gripper":{
+    "gripper": {
       "model": "gripper_1.3",
       "id": "1234_flex_gripper"
     }
@@ -27,7 +27,6 @@
               "temperature": 3,
               "hold_time_seconds": 1,
               "hold_time_minutes": 2,
-              "ramp_rate": 4,
               "volume": 5
             }
           },

--- a/robot-server/simulators/test.json
+++ b/robot-server/simulators/test.json
@@ -21,7 +21,6 @@
               "temperature": 3,
               "hold_time_seconds": 1,
               "hold_time_minutes": 2,
-              "ramp_rate": 4,
               "volume": 5
             }
           },


### PR DESCRIPTION
Make the version checking a little more resilient to odd version numbers (in general, defaulting to ramp-rate-not-allowed if we don't understand it).

Also, the dev server was running a set temperature with ramp rate; now that that's not ignored, it's actually not allowed unless the thermocycler supports it, and we don't have a way for the simulator to express a module firmware version. So for now just get rid of it. We'll have to add the ability to specify the firmware version in the simulator configs.

## testing
- [x] tests don't hang
- [x] `make -C robot-server dev-flex` starts a robot server