### PR TITLE
fix(app): Give app access to constants for labware-library

### DIFF
--- a/app/vite.config.mts
+++ b/app/vite.config.mts
@@ -53,10 +53,15 @@ export default defineConfig(
       define: {
         // NOTE: For security, only include environment variables here if they're explicitly allowlisted.
         global: 'globalThis',
-        _PKG_VERSION_: JSON.stringify(version),
-        _OPENTRONS_PROJECT_: JSON.stringify(project),
         _NODE_ENV_: JSON.stringify(process.env.NODE_ENV),
+        _OPENTRONS_PROJECT_: JSON.stringify(project),
         _OT_APP_MIXPANEL_ID_: JSON.stringify(process.env.OT_APP_MIXPANEL_ID),
+        // _OT_LL_ variables because app/ imports files directly from labware-library/,
+        // causing them to be processed in the context of this Vite config instead of
+        // labware-library's Vite config.
+        _OT_LL_MIXPANEL_DEV_ID_: JSON.stringify(process.env.OT_LL_MIXPANEL_DEV_ID),
+        _OT_LL_MIXPANEL_ID_: JSON.stringify(process.env.OT_LL_MIXPANEL_ID),
+        _PKG_VERSION_: JSON.stringify(version),
       },
       resolve: {
         alias: {


### PR DESCRIPTION
## Overview

Fixes a bug from #19561 that was causing the desktop app to whitescreen.

## Changelog

It was this exact problem from #19561's risk analysis:

> Project A imports a file from project B. Project B tries to access a constant that project B's config provides, but project A's config does not provide. This is, unfortunately, an actual hazard that I believe we'll have as long as projects access each other via tsconfig's paths and vite.config's resolve.alias. If this happens, maybe it would have some user-facing effect, maybe it wouldn't.

The quick fix here is to just add "project B"'s variables (labware-library) to "project A"'s config (app).

## Test Plan and Hands on Testing

* [x] App doesn't whitescreen now.
* [x] Launch other projects to make sure they don't whitescreen
  * [x] `make -C app dev`
  * [x] `make -C app dev-odd`
  * [x] `make -C components dev`
  * [x] `make -C labware-designer dev`
  * [x] `make -C labware-library dev`
  * [x] `make -C opentrons-ai-client dev`
  * [x] `make -C protocol-designer dev`

## Review requests

It strikes me as generally dangerous that we're importing files cross-project like this. In the long term, is there any way for us to avoid it?

## Risk assessment

Low for this particular change, but there's a continued medium risk of this happening somewhere else, I guess. I'm not sure how this happened without it causing an error in #19561's automated or manual testing. The same thing happened for other projects and it *did* cause an error for them.