### PR TITLE
fix(protocol-designer): fix tip position svg

### DIFF
--- a/protocol-designer/src/components/organisms/TipPositionModal/TipPositionSideView.tsx
+++ b/protocol-designer/src/components/organisms/TipPositionModal/TipPositionSideView.tsx
@@ -17,6 +17,8 @@ import TOP_LAYER from '/protocol-designer/assets/images/tip_side_top_layer.svg'
 const WELL_HEIGHT_PIXELS = 78
 const WELL_WIDTH_PIXELS = 80
 const PIXEL_DECIMALS = 2
+const SCALE_FACTOR_HEIGHT = 1.12
+const WELL_BOTTOM_OFFSET_PIXELS = 5
 
 interface TipPositionAllVizProps {
   mmFromBottom: number
@@ -30,7 +32,8 @@ export function TipPositionSideView(
 ): JSX.Element {
   const { mmFromBottom, xPosition, wellDepthMm, xWidthMm } = props
   const { t } = useTranslation('application')
-  const fractionOfWellHeight = mmFromBottom / wellDepthMm
+  const fractionOfWellHeight =
+    (mmFromBottom / wellDepthMm) * SCALE_FACTOR_HEIGHT
   const pixelsFromBottom =
     fractionOfWellHeight * WELL_HEIGHT_PIXELS - WELL_HEIGHT_PIXELS
   const roundedPixelsFromBottom = round(pixelsFromBottom, PIXEL_DECIMALS)
@@ -58,7 +61,7 @@ export function TipPositionSideView(
         style={{
           position: POSITION_ABSOLUTE,
           transform: `translate(${roundedXPositionPixels}px)`,
-          bottom: `calc(${bottomPx}px + 10px)`,
+          bottom: `calc(${bottomPx}px + ${WELL_BOTTOM_OFFSET_PIXELS}px)`,
         }}
         alt="mid layer"
       />

--- a/protocol-designer/src/components/organisms/TipPositionModal/index.tsx
+++ b/protocol-designer/src/components/organisms/TipPositionModal/index.tsx
@@ -429,14 +429,14 @@ export function TipPositionModal(
                     : defaultMmFromBottom
                 }
                 wellDepthMm={wellDepthMm}
-                xPosition={parseInt(xValue ?? '0')}
+                xPosition={parseFloat(xValue ?? '0')}
                 xWidthMm={wellXWidthMm}
               />
             ) : (
               <TipPositionTopView
-                xPosition={parseInt(xValue ?? '0')}
+                xPosition={parseFloat(xValue ?? '0')}
                 xWidthMm={wellXWidthMm}
-                yPosition={parseInt(yValue ?? '0')}
+                yPosition={parseFloat(yValue ?? '0')}
                 yWidthMm={wellYWidthMm}
               />
             )}


### PR DESCRIPTION
# Overview

This PR fixes offsets and scalars for tip position SVG in transfer and mix forms (TipPositionSideView component). The math in this component is very fudge-y and is likely worth a more significant refactor in the future.

Closes RQA-4483

## Test Plan and Hands on Testing

- create or import a protocol with a mix/transfer form 
- open the form and navigate to advanced settings > tip position
- in the side view modal, set the tip z position to the bottom of the well and verify that the SVG accurately shows the tip at the bottom of the well
- set the z position to the top of the well and and verify that the SVG accurately shows the tip flush with the top of the well

### Bottom

Before 

<img width="728" height="383" alt="Screenshot 2025-09-17 at 10 14 21 AM" src="https://github.com/user-attachments/assets/5bf5e43c-d61d-4262-8140-e18ece2a5220" />

After 

<img width="724" height="383" alt="Screenshot 2025-09-17 at 10 09 06 AM" src="https://github.com/user-attachments/assets/12da2f4a-3007-40d7-96a5-5cc58079acf0" />

### Top

Before

<img width="711" height="382" alt="Screenshot 2025-09-17 at 10 17 07 AM" src="https://github.com/user-attachments/assets/472722ce-d4d8-4921-9748-0618598eb2f5" />

After

<img width="713" height="372" alt="Screenshot 2025-09-17 at 10 16 30 AM" src="https://github.com/user-attachments/assets/23486168-54af-4fc2-adc7-35b02a6f3cb2" />

## Changelog

- add scalar for tip position from bottom
- allow float for x and y positions

## Review requests

see test plan

## Risk assessment

low