### PR TITLE
refactor(protocol-designer): block transfer & mix when labware is lid

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/AddStepButton.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/AddStepButton.tsx
@@ -111,7 +111,7 @@ export function AddStepButton({
   ).some(([labwareId, { stack }]) => {
     const labwareDef = labwareEntities[labwareId]?.def
     const slot = getSlotInLocationStack(stack)
-    const lidOnSlot = Object.values(labwareEntities).some(({ def }) =>
+    const isLidOnSlot = Object.values(labwareEntities).some(({ def }) =>
       getIsLid(def)
     )
     return (
@@ -119,7 +119,7 @@ export function AddStepButton({
       slot !== OFFDECK &&
       !getIsTiprack(labwareDef) &&
       !getIsAdapterFromDef(labwareDef) &&
-      !lidOnSlot
+      !isLidOnSlot
     )
   })
   const getSupportedSteps = (): Array<

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/AddStepButton.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/AddStepButton.tsx
@@ -110,12 +110,16 @@ export function AddStepButton({
     labwareAtLastState
   ).some(([labwareId, { stack }]) => {
     const labwareDef = labwareEntities[labwareId]?.def
+    const slot = getSlotInLocationStack(stack)
+    const lidOnSlot = Object.values(labwareEntities).some(entity =>
+      getIsLid(entity.def)
+    )
     return (
       labwareDef != null &&
-      getSlotInLocationStack(stack) !== OFFDECK &&
+      slot !== OFFDECK &&
       !getIsTiprack(labwareDef) &&
       !getIsAdapterFromDef(labwareDef) &&
-      !getIsLid(labwareDef)
+      !lidOnSlot
     )
   })
   const getSupportedSteps = (): Array<

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/AddStepButton.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/AddStepButton.tsx
@@ -111,8 +111,8 @@ export function AddStepButton({
   ).some(([labwareId, { stack }]) => {
     const labwareDef = labwareEntities[labwareId]?.def
     const slot = getSlotInLocationStack(stack)
-    const lidOnSlot = Object.values(labwareEntities).some(entity =>
-      getIsLid(entity.def)
+    const lidOnSlot = Object.values(labwareEntities).some(({ def }) =>
+      getIsLid(def)
     )
     return (
       labwareDef != null &&

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/__tests__/AddStepButton.test.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/__tests__/AddStepButton.test.tsx
@@ -47,6 +47,7 @@ const render = (props: ComponentProps<typeof AddStepButton>) => {
   })[0]
 }
 
+const MOCK_LID_ID = 'mockLidId'
 const MOCK_TIPRACK_ID = 'mockTiprackId'
 const MOCK_TUBERACK_ID = 'mockTuberackId'
 const MOCK_TIPRACK_ENTITY = {
@@ -55,6 +56,12 @@ const MOCK_TIPRACK_ENTITY = {
     parameters: {
       isTiprack: true,
     } as LabwareParameters,
+  } as LabwareDefinition2,
+} as LabwareEntity
+const MOCK_LID_ENTITY = {
+  id: MOCK_LID_ID,
+  def: {
+    allowedRoles: ['lid'],
   } as LabwareDefinition2,
 } as LabwareEntity
 const MOCK_TIPRACK_LABWARE = {
@@ -184,6 +191,22 @@ describe('AddStepButton', () => {
   it('should not render liquid handling steps if no compatible labware is present in entities', () => {
     vi.mocked(getLabwareEntities).mockReturnValue({
       [MOCK_TIPRACK_ID]: MOCK_TIPRACK_ENTITY,
+    })
+    render(props)
+    fireEvent.click(screen.getByText('Add Step'))
+    screen.getByText('Comment')
+    expect(screen.queryByText('Transfer')).not.toBeInTheDocument()
+    expect(screen.queryByText('Mix')).not.toBeInTheDocument()
+    screen.getByText('Pause')
+    screen.getByText('Thermocycler')
+    screen.getByText('Heater-Shaker')
+    screen.getByText('Temperature')
+    screen.getByText('Magnet')
+  })
+
+  it('should not render liquid handling steps if only labware has a lid on top in entities', () => {
+    vi.mocked(getLabwareEntities).mockReturnValue({
+      [MOCK_LID_ID]: MOCK_LID_ENTITY,
     })
     render(props)
     fireEvent.click(screen.getByText('Add Step'))


### PR DESCRIPTION
closes RQA-4665

# Overview

Fixes a small bug where you can still open a transfer/mix step when the only available labware has a lid on top

## Test Plan and Hands on Testing

Create a protocol and add a well plate with a lid on top. see that the transfer and mix steps don't show up from the add step dropdown.

## Changelog

look for matching labware entities on the slot that are lid and block them

## Risk assessment

low
