### PR TITLE
refactor(step-generation): format as py string when move_lid arg is s…

### DIFF
--- a/step-generation/src/commandCreators/atomic/moveLabware.ts
+++ b/step-generation/src/commandCreators/atomic/moveLabware.ts
@@ -279,7 +279,9 @@ export const moveLabware: CommandCreator<MoveLabwareParams> = (
         prevRobotState.labware[slotName].stack
       )
       const isParentLid = getIsLid(labwareEntities[slotName].def)
-      location = isParentLid ? slot : labwareEntities[slotName].pythonName
+      location = isParentLid
+        ? formatPyStr(slot)
+        : labwareEntities[slotName].pythonName
       const newLocationStack = prevRobotState.labware[slotName].stack
       parentSlotForSlotCompatibility =
         newLocationStack[newLocationStack.length - 1]


### PR DESCRIPTION
…lotName

closes RQA-4670

# Overview

We were forgetting to format a slot name instance a string in the `move_lid()` arg

## Test Plan and Hands on Testing

look at protocol, step 4 shows a non formatted string slotname. it fails analysis

[untitled (46).py](https://github.com/user-attachments/files/22392419/untitled.46.py)

import it and export it in PD on this branch. should be a string now.

## Changelog

format to string

## Risk assessment

low