### PR TITLE
fix(api): correctly update and reset flow rates and restore pipette state after liquid class transfers

### DIFF
--- a/api/src/opentrons/hardware_control/dev_types.py
+++ b/api/src/opentrons/hardware_control/dev_types.py
@@ -105,7 +105,7 @@ class PipetteDict(InstrumentDict):
     plunger_positions: Dict[str, float]
     shaft_ul_per_mm: float
     available_sensors: AvailableSensorDefinition
-    volume_mode: LiquidClasses
+    volume_mode: LiquidClasses  # LiquidClasses refer to volume mode in this context
 
 
 class PipetteStateDict(TypedDict):

--- a/api/src/opentrons/hardware_control/dev_types.py
+++ b/api/src/opentrons/hardware_control/dev_types.py
@@ -14,8 +14,9 @@ from opentrons_shared_data.pipette.types import (
     PipetteModel,
     PipetteName,
     ChannelCount,
+    PipetteTipType,
+    LiquidClasses,
 )
-from opentrons_shared_data.pipette.types import PipetteTipType
 from opentrons_shared_data.pipette.pipette_definition import (
     PipetteConfigurations,
     SupportedTipsDefinition,
@@ -104,6 +105,7 @@ class PipetteDict(InstrumentDict):
     plunger_positions: Dict[str, float]
     shaft_ul_per_mm: float
     available_sensors: AvailableSensorDefinition
+    volume_mode: LiquidClasses
 
 
 class PipetteStateDict(TypedDict):

--- a/api/src/opentrons/hardware_control/instruments/ot2/pipette_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot2/pipette_handler.py
@@ -267,6 +267,7 @@ class PipetteHandlerProvider(Generic[MountType]):
                 "drop_tip": instr.plunger_positions.drop_tip,
             }
             result["shaft_ul_per_mm"] = instr.config.shaft_ul_per_mm
+            result["volume_mode"] = instr.liquid_class_name
         return cast(PipetteDict, result)
 
     @property

--- a/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
@@ -294,6 +294,7 @@ class OT3PipetteHandler:
             }
             result["shaft_ul_per_mm"] = instr.config.shaft_ul_per_mm
             result["available_sensors"] = instr.config.available_sensors
+            result["volume_mode"] = instr.liquid_class_name
         return cast(PipetteDict, result)
 
     @property

--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -135,7 +135,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         self._user_aspirate_flow_rate: Optional[float] = None
         self._user_dispense_flow_rate: Optional[float] = None
         self._user_blow_out_flow_rate: Optional[float] = None
-        if self._protocol_core.api_version < _DISPENSE_VOLUME_VALIDATION_ADDED_IN:
+        if self._protocol_core.api_version < _DEFAULT_FLOW_RATE_BUG_FIXED_IN:
             # TODO also look into why we were using MAX_SUPPORTED_VERSION here and if that makes sense to keep
             self._user_aspirate_flow_rate = find_value_for_api_version(
                 MAX_SUPPORTED_VERSION, self._initial_default_flow_rates.default_aspirate

--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -135,17 +135,8 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         self._user_aspirate_flow_rate: Optional[float] = None
         self._user_dispense_flow_rate: Optional[float] = None
         self._user_blow_out_flow_rate: Optional[float] = None
-        if self._protocol_core.api_version < _DEFAULT_FLOW_RATE_BUG_FIXED_IN:
-            # TODO also look into why we were using MAX_SUPPORTED_VERSION here and if that makes sense to keep
-            self._user_aspirate_flow_rate = find_value_for_api_version(
-                MAX_SUPPORTED_VERSION, self._initial_default_flow_rates.default_aspirate
-            )
-            self._user_dispense_flow_rate = find_value_for_api_version(
-                MAX_SUPPORTED_VERSION, self._initial_default_flow_rates.default_dispense
-            )
-            self._user_blow_out_flow_rate = find_value_for_api_version(
-                MAX_SUPPORTED_VERSION, self._initial_default_flow_rates.default_blow_out
-            )
+        # Call this to ensure pre 2.26 buggy flow rate behavior is maintained
+        self._reset_flow_rates()
         self._flow_rates = FlowRates(self)
 
         self.set_default_speed(speed=default_movement_speed)
@@ -1102,34 +1093,22 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
 
         return blow_out_flow_rate * rate
 
-    def reset_aspirate_flow_rate(self) -> None:
-        """Resets the user-set aspirate flow rate to allow the automatic default to be used."""
+    def _reset_flow_rates(self) -> None:
+        """Resets the user-set flow rates to allow the automatic default to be used."""
         if self._protocol_core.api_version >= _DEFAULT_FLOW_RATE_BUG_FIXED_IN:
             self._user_aspirate_flow_rate = None
-        else:
-            # Set to the initial default to preserve buggy behavior where the default was not correctly updated
-            self._user_aspirate_flow_rate = find_value_for_api_version(
-                MAX_SUPPORTED_VERSION, self._initial_default_flow_rates.default_aspirate
-            )
-
-    def reset_dispense_flow_rate(self) -> None:
-        """Resets the user-set dispense flow rate to allow the automatic default to be used."""
-        if self._protocol_core.api_version >= _DEFAULT_FLOW_RATE_BUG_FIXED_IN:
             self._user_dispense_flow_rate = None
-        else:
-            # Set to the initial default to preserve buggy behavior where the default was not correctly updated
-            self._user_dispense_flow_rate = find_value_for_api_version(
-                MAX_SUPPORTED_VERSION, self._initial_default_flow_rates.default_dispense
-            )
-
-    def reset_blow_out_flow_rate(self) -> None:
-        """Resets the user-set dispense flow rate to allow the automatic default to be used."""
-        if self._protocol_core.api_version >= _DEFAULT_FLOW_RATE_BUG_FIXED_IN:
             self._user_blow_out_flow_rate = None
         else:
-            # Set to the initial default to preserve buggy behavior where the default was not correctly updated
+            # Set to the initial defaults to preserve buggy behavior where the default was not correctly updated
+            self._user_aspirate_flow_rate = find_value_for_api_version(
+                self._protocol_core.api_version, self._initial_default_flow_rates.default_aspirate
+            )
+            self._user_dispense_flow_rate = find_value_for_api_version(
+                self._protocol_core.api_version, self._initial_default_flow_rates.default_dispense
+            )
             self._user_blow_out_flow_rate = find_value_for_api_version(
-                MAX_SUPPORTED_VERSION, self._initial_default_flow_rates.default_blow_out
+                self._protocol_core.api_version, self._initial_default_flow_rates.default_blow_out
             )
 
     def get_nozzle_configuration(self) -> NozzleConfigurationType:
@@ -1198,6 +1177,8 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                 ),
             )
         )
+        if self._protocol_core.api_version >= _DEFAULT_FLOW_RATE_BUG_FIXED_IN:
+            self._reset_flow_rates()
 
     def prepare_to_aspirate(self) -> None:
         self._engine_client.execute_command(

--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -101,6 +101,9 @@ _RESIN_TIP_DEFAULT_FLOW_RATE = 10.0
 _FLEX_PIPETTE_NAMES_FIXED_IN = APIVersion(2, 23)
 """The version after which InstrumentContext.name returns the correct API-specific names of Flex pipettes."""
 
+_DEFAULT_FLOW_RATE_BUG_FIXED_IN = APIVersion(2, 26)
+"""The version after which default flow rates correctly update when pipette tip or volume changes."""
+
 
 class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
     """Instrument API core using a ProtocolEngine.
@@ -122,18 +125,27 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         self._sync_hardware_api = sync_hardware_api
         self._protocol_core = protocol_core
 
-        # TODO(jbl 2022-11-03) flow_rates should not live in the cores, and should be moved to the protocol context
-        #   along with other rate related refactors (for the hardware API)
-        flow_rates = self._engine_client.state.pipettes.get_flow_rates(pipette_id)
-        self._aspirate_flow_rate = find_value_for_api_version(
-            MAX_SUPPORTED_VERSION, flow_rates.default_aspirate
+        # TODO(jbl 2025): The way to fix flow_rates is something like:
+        #   Have something called user_flow_rate that defaults to None (except for older API versions)
+        #   When calling a flow_rate, if a user_flow_rate exists use that, otherwise ping the engine
+        #   For older API versions, cheat by setting the user_flow_rate to the default so that incorrectly stays
+        self._initial_default_flow_rates = (
+            self._engine_client.state.pipettes.get_flow_rates(pipette_id)
         )
-        self._dispense_flow_rate = find_value_for_api_version(
-            MAX_SUPPORTED_VERSION, flow_rates.default_dispense
-        )
-        self._blow_out_flow_rate = find_value_for_api_version(
-            MAX_SUPPORTED_VERSION, flow_rates.default_blow_out
-        )
+        self._user_aspirate_flow_rate: Optional[float] = None
+        self._user_dispense_flow_rate: Optional[float] = None
+        self._user_blow_out_flow_rate: Optional[float] = None
+        if self._protocol_core.api_version < _DISPENSE_VOLUME_VALIDATION_ADDED_IN:
+            # TODO also look into why we were using MAX_SUPPORTED_VERSION here and if that makes sense to keep
+            self._user_aspirate_flow_rate = find_value_for_api_version(
+                MAX_SUPPORTED_VERSION, self._initial_default_flow_rates.default_aspirate
+            )
+            self._user_dispense_flow_rate = find_value_for_api_version(
+                MAX_SUPPORTED_VERSION, self._initial_default_flow_rates.default_dispense
+            )
+            self._user_blow_out_flow_rate = find_value_for_api_version(
+                MAX_SUPPORTED_VERSION, self._initial_default_flow_rates.default_blow_out
+            )
         self._flow_rates = FlowRates(self)
 
         self.set_default_speed(speed=default_movement_speed)
@@ -1031,13 +1043,94 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         return self._flow_rates
 
     def get_aspirate_flow_rate(self, rate: float = 1.0) -> float:
-        return self._aspirate_flow_rate * rate
+        """Returns the user-set aspirate flow rate if that's been modified, otherwise return the default.
+
+        Note that in API versions 2.25 and below `_user_aspirate_flow_rate` will automatically be set to the initial
+        default flow rate when the pipette is loaded (which is the same as the max tip capacity). This is to preserve
+        buggy behavior in which the default was never correctly updated when the pipette picked up or dropped a tip or
+        had its volume configuration changed.
+        """
+        aspirate_flow_rate = (
+            self._user_aspirate_flow_rate
+            or find_value_for_api_version(
+                self._protocol_core.api_version,
+                self._engine_client.state.pipettes.get_flow_rates(
+                    self._pipette_id
+                ).default_aspirate,
+            )
+        )
+
+        return aspirate_flow_rate * rate
 
     def get_dispense_flow_rate(self, rate: float = 1.0) -> float:
-        return self._dispense_flow_rate * rate
+        """Returns the user-set dispense flow rate if that's been modified, otherwise return the default.
+
+        Note that in API versions 2.25 and below `_user_dispense_flow_rate` will automatically be set to the initial
+        default flow rate when the pipette is loaded (which is the same as the max tip capacity). This is to preserve
+        buggy behavior in which the default was never correctly updated when the pipette picked up or dropped a tip or
+        had its volume configuration changed.
+        """
+        dispense_flow_rate = (
+            self._user_dispense_flow_rate
+            or find_value_for_api_version(
+                self._protocol_core.api_version,
+                self._engine_client.state.pipettes.get_flow_rates(
+                    self._pipette_id
+                ).default_dispense,
+            )
+        )
+
+        return dispense_flow_rate * rate
 
     def get_blow_out_flow_rate(self, rate: float = 1.0) -> float:
-        return self._blow_out_flow_rate * rate
+        """Returns the user-set blow-out flow rate if that's been modified, otherwise return the default.
+
+        Note that in API versions 2.25 and below `_user_dispense_flow_rate` will automatically be set to the initial
+        default flow rate when the pipette is loaded (which is the same as the max tip capacity). This is to preserve
+        buggy behavior in which the default was never correctly updated when the pipette picked up or dropped a tip or
+        had its volume configuration changed.
+        """
+        blow_out_flow_rate = (
+            self._user_dispense_flow_rate
+            or find_value_for_api_version(
+                self._protocol_core.api_version,
+                self._engine_client.state.pipettes.get_flow_rates(
+                    self._pipette_id
+                ).default_dispense,
+            )
+        )
+
+        return blow_out_flow_rate * rate
+
+    def reset_aspirate_flow_rate(self) -> None:
+        """Resets the user-set aspirate flow rate to allow the automatic default to be used."""
+        if self._protocol_core.api_version >= _DEFAULT_FLOW_RATE_BUG_FIXED_IN:
+            self._user_aspirate_flow_rate = None
+        else:
+            # Set to the initial default to preserve buggy behavior where the default was not correctly updated
+            self._user_aspirate_flow_rate = find_value_for_api_version(
+                MAX_SUPPORTED_VERSION, self._initial_default_flow_rates.default_aspirate
+            )
+
+    def reset_dispense_flow_rate(self) -> None:
+        """Resets the user-set dispense flow rate to allow the automatic default to be used."""
+        if self._protocol_core.api_version >= _DEFAULT_FLOW_RATE_BUG_FIXED_IN:
+            self._user_dispense_flow_rate = None
+        else:
+            # Set to the initial default to preserve buggy behavior where the default was not correctly updated
+            self._user_dispense_flow_rate = find_value_for_api_version(
+                MAX_SUPPORTED_VERSION, self._initial_default_flow_rates.default_dispense
+            )
+
+    def reset_blow_out_flow_rate(self) -> None:
+        """Resets the user-set dispense flow rate to allow the automatic default to be used."""
+        if self._protocol_core.api_version >= _DEFAULT_FLOW_RATE_BUG_FIXED_IN:
+            self._user_blow_out_flow_rate = None
+        else:
+            # Set to the initial default to preserve buggy behavior where the default was not correctly updated
+            self._user_blow_out_flow_rate = find_value_for_api_version(
+                MAX_SUPPORTED_VERSION, self._initial_default_flow_rates.default_blow_out
+            )
 
     def get_nozzle_configuration(self) -> NozzleConfigurationType:
         return self._engine_client.state.pipettes.get_nozzle_layout_type(
@@ -1084,13 +1177,13 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
     ) -> None:
         if aspirate is not None:
             assert aspirate > 0
-            self._aspirate_flow_rate = aspirate
+            self._user_aspirate_flow_rate = aspirate
         if dispense is not None:
             assert dispense > 0
-            self._dispense_flow_rate = dispense
+            self._user_dispense_flow_rate = dispense
         if blow_out is not None:
             assert blow_out > 0
-            self._blow_out_flow_rate = blow_out
+            self._user_blow_out_flow_rate = blow_out
 
     def set_liquid_presence_detection(self, enable: bool) -> None:
         self._liquid_presence_detection = enable

--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -124,10 +124,6 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         self._sync_hardware_api = sync_hardware_api
         self._protocol_core = protocol_core
 
-        # TODO(jbl 2025): The way to fix flow_rates is something like:
-        #   Have something called user_flow_rate that defaults to None (except for older API versions)
-        #   When calling a flow_rate, if a user_flow_rate exists use that, otherwise ping the engine
-        #   For older API versions, cheat by setting the user_flow_rate to the default so that incorrectly stays
         self._initial_default_flow_rates = (
             self._engine_client.state.pipettes.get_flow_rates(pipette_id)
         )

--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -66,7 +66,6 @@ from opentrons.protocol_engine.types.automatic_tip_selection import (
 )
 from opentrons.protocol_engine.errors.exceptions import TipNotAttachedError
 from opentrons.protocol_engine.clients import SyncClient as EngineClient
-from opentrons.protocols.api_support.definitions import MAX_SUPPORTED_VERSION
 from opentrons_shared_data.pipette.types import (
     PIPETTE_API_NAMES_MAP,
     LIQUID_PROBE_START_OFFSET_FROM_WELL_TOP,
@@ -1087,7 +1086,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                 self._protocol_core.api_version,
                 self._engine_client.state.pipettes.get_flow_rates(
                     self._pipette_id
-                ).default_dispense,
+                ).default_blow_out,
             )
         )
 
@@ -1102,13 +1101,16 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         else:
             # Set to the initial defaults to preserve buggy behavior where the default was not correctly updated
             self._user_aspirate_flow_rate = find_value_for_api_version(
-                self._protocol_core.api_version, self._initial_default_flow_rates.default_aspirate
+                self._protocol_core.api_version,
+                self._initial_default_flow_rates.default_aspirate,
             )
             self._user_dispense_flow_rate = find_value_for_api_version(
-                self._protocol_core.api_version, self._initial_default_flow_rates.default_dispense
+                self._protocol_core.api_version,
+                self._initial_default_flow_rates.default_dispense,
             )
             self._user_blow_out_flow_rate = find_value_for_api_version(
-                self._protocol_core.api_version, self._initial_default_flow_rates.default_blow_out
+                self._protocol_core.api_version,
+                self._initial_default_flow_rates.default_blow_out,
             )
 
     def get_nozzle_configuration(self) -> NozzleConfigurationType:

--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -1101,27 +1101,6 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
 
         return blow_out_flow_rate * rate
 
-    def _reset_flow_rates(self) -> None:
-        """Resets the user-set flow rates to allow the automatic default to be used."""
-        if self._protocol_core.api_version >= _DEFAULT_FLOW_RATE_BUG_FIXED_IN:
-            self._user_aspirate_flow_rate = None
-            self._user_dispense_flow_rate = None
-            self._user_blow_out_flow_rate = None
-        else:
-            # Set to the initial defaults to preserve buggy behavior where the default was not correctly updated
-            self._user_aspirate_flow_rate = find_value_for_api_version(
-                self._protocol_core.api_version,
-                self._initial_default_flow_rates.default_aspirate,
-            )
-            self._user_dispense_flow_rate = find_value_for_api_version(
-                self._protocol_core.api_version,
-                self._initial_default_flow_rates.default_dispense,
-            )
-            self._user_blow_out_flow_rate = find_value_for_api_version(
-                self._protocol_core.api_version,
-                self._initial_default_flow_rates.default_blow_out,
-            )
-
     def get_nozzle_configuration(self) -> NozzleConfigurationType:
         return self._engine_client.state.pipettes.get_nozzle_layout_type(
             self._pipette_id

--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -1081,7 +1081,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         had its volume configuration changed.
         """
         blow_out_flow_rate = (
-            self._user_dispense_flow_rate
+            self._user_blow_out_flow_rate
             or find_value_for_api_version(
                 self._protocol_core.api_version,
                 self._engine_client.state.pipettes.get_flow_rates(

--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -134,8 +134,21 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         self._user_aspirate_flow_rate: Optional[float] = None
         self._user_dispense_flow_rate: Optional[float] = None
         self._user_blow_out_flow_rate: Optional[float] = None
-        # Call this to ensure pre 2.26 buggy flow rate behavior is maintained
-        self._reset_flow_rates()
+
+        if self._protocol_core.api_version < _DEFAULT_FLOW_RATE_BUG_FIXED_IN:
+            # Set to the initial defaults to preserve buggy behavior where the default was not correctly updated
+            self._user_aspirate_flow_rate = find_value_for_api_version(
+                self._protocol_core.api_version,
+                self._initial_default_flow_rates.default_aspirate,
+            )
+            self._user_dispense_flow_rate = find_value_for_api_version(
+                self._protocol_core.api_version,
+                self._initial_default_flow_rates.default_dispense,
+            )
+            self._user_blow_out_flow_rate = find_value_for_api_version(
+                self._protocol_core.api_version,
+                self._initial_default_flow_rates.default_blow_out,
+            )
         self._flow_rates = FlowRates(self)
 
         self.set_default_speed(speed=default_movement_speed)
@@ -1180,7 +1193,9 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             )
         )
         if self._protocol_core.api_version >= _DEFAULT_FLOW_RATE_BUG_FIXED_IN:
-            self._reset_flow_rates()
+            self._user_aspirate_flow_rate = None
+            self._user_dispense_flow_rate = None
+            self._user_blow_out_flow_rate = None
 
     def prepare_to_aspirate(self) -> None:
         self._engine_client.execute_command(

--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -1364,6 +1364,13 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             tiprack_uri=tiprack_uri_for_transfer_props,
         )
 
+        original_aspirate_flow_rate = self._user_aspirate_flow_rate
+        original_dispense_flow_rate = self._user_dispense_flow_rate
+        original_blow_out_flow_rate = self._user_blow_out_flow_rate
+        in_low_volume_mode = self._engine_client.state.pipettes.get_is_low_volume_mode(
+            self._pipette_id
+        )
+
         target_destinations: Sequence[
             Union[Tuple[Location, WellCore], TrashBin, WasteChute]
         ]
@@ -1457,6 +1464,14 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
 
         if not keep_last_tip:
             self._drop_tip_for_liquid_class(trash_location, return_tip)
+
+        if self._protocol_core.api_version < _DEFAULT_FLOW_RATE_BUG_FIXED_IN:
+            self._restore_pipette_flow_rates_and_volume_mode(
+                aspirate_flow_rate=original_aspirate_flow_rate,
+                dispense_flow_rate=original_dispense_flow_rate,
+                blow_out_flow_rate=original_blow_out_flow_rate,
+                is_low_volume=in_low_volume_mode,
+            )
 
     def distribute_with_liquid_class(  # noqa: C901
         self,
@@ -1563,6 +1578,13 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             name=liquid_class.name,
             transfer_properties=transfer_props,
             tiprack_uri=tiprack_uri_for_transfer_props,
+        )
+
+        original_aspirate_flow_rate = self._user_aspirate_flow_rate
+        original_dispense_flow_rate = self._user_dispense_flow_rate
+        original_blow_out_flow_rate = self._user_blow_out_flow_rate
+        in_low_volume_mode = self._engine_client.state.pipettes.get_is_low_volume_mode(
+            self._pipette_id
         )
 
         # This will return a generator that provides pairs of destination well and
@@ -1708,6 +1730,14 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         if not keep_last_tip:
             self._drop_tip_for_liquid_class(trash_location, return_tip)
 
+        if self._protocol_core.api_version < _DEFAULT_FLOW_RATE_BUG_FIXED_IN:
+            self._restore_pipette_flow_rates_and_volume_mode(
+                aspirate_flow_rate=original_aspirate_flow_rate,
+                dispense_flow_rate=original_dispense_flow_rate,
+                blow_out_flow_rate=original_blow_out_flow_rate,
+                is_low_volume=in_low_volume_mode,
+            )
+
     def _tip_can_hold_volume_for_multi_dispensing(
         self,
         transfer_volume: float,
@@ -1803,6 +1833,13 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             tiprack_uri=tiprack_uri_for_transfer_props,
         )
 
+        original_aspirate_flow_rate = self._user_aspirate_flow_rate
+        original_dispense_flow_rate = self._user_dispense_flow_rate
+        original_blow_out_flow_rate = self._user_blow_out_flow_rate
+        in_low_volume_mode = self._engine_client.state.pipettes.get_is_low_volume_mode(
+            self._pipette_id
+        )
+
         working_volume = self.get_working_volume_for_tip_rack(tip_racks[0][1])
 
         source_per_volume_step = (
@@ -1886,6 +1923,14 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
 
         if not keep_last_tip:
             self._drop_tip_for_liquid_class(trash_location, return_tip)
+
+        if self._protocol_core.api_version < _DEFAULT_FLOW_RATE_BUG_FIXED_IN:
+            self._restore_pipette_flow_rates_and_volume_mode(
+                aspirate_flow_rate=original_aspirate_flow_rate,
+                dispense_flow_rate=original_dispense_flow_rate,
+                blow_out_flow_rate=original_blow_out_flow_rate,
+                is_low_volume=in_low_volume_mode,
+            )
 
     def _get_location_and_well_core_from_next_tip_info(
         self,
@@ -1994,6 +2039,20 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                 home_after=False,
                 alternate_drop_location=True,
             )
+
+    def _restore_pipette_flow_rates_and_volume_mode(
+        self,
+        aspirate_flow_rate: Optional[float],
+        dispense_flow_rate: Optional[float],
+        blow_out_flow_rate: Optional[float],
+        is_low_volume: bool,
+    ) -> None:
+        self._user_aspirate_flow_rate = aspirate_flow_rate
+        self._user_dispense_flow_rate = dispense_flow_rate
+        self._user_blow_out_flow_rate = blow_out_flow_rate
+        # TODO(jbl 2025-09-17) this works for p50 low volume mode but is not guaranteed to work for future low volume
+        #   modes, this should be replaced with something less flaky
+        self.configure_for_volume(self.get_max_volume() if not is_low_volume else 1)
 
     def aspirate_liquid_class(
         self,

--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -1465,7 +1465,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         if not keep_last_tip:
             self._drop_tip_for_liquid_class(trash_location, return_tip)
 
-        if self._protocol_core.api_version < _DEFAULT_FLOW_RATE_BUG_FIXED_IN:
+        if self._protocol_core.api_version >= _DEFAULT_FLOW_RATE_BUG_FIXED_IN:
             self._restore_pipette_flow_rates_and_volume_mode(
                 aspirate_flow_rate=original_aspirate_flow_rate,
                 dispense_flow_rate=original_dispense_flow_rate,
@@ -1730,7 +1730,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         if not keep_last_tip:
             self._drop_tip_for_liquid_class(trash_location, return_tip)
 
-        if self._protocol_core.api_version < _DEFAULT_FLOW_RATE_BUG_FIXED_IN:
+        if self._protocol_core.api_version >= _DEFAULT_FLOW_RATE_BUG_FIXED_IN:
             self._restore_pipette_flow_rates_and_volume_mode(
                 aspirate_flow_rate=original_aspirate_flow_rate,
                 dispense_flow_rate=original_dispense_flow_rate,
@@ -1924,7 +1924,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         if not keep_last_tip:
             self._drop_tip_for_liquid_class(trash_location, return_tip)
 
-        if self._protocol_core.api_version < _DEFAULT_FLOW_RATE_BUG_FIXED_IN:
+        if self._protocol_core.api_version >= _DEFAULT_FLOW_RATE_BUG_FIXED_IN:
             self._restore_pipette_flow_rates_and_volume_mode(
                 aspirate_flow_rate=original_aspirate_flow_rate,
                 dispense_flow_rate=original_dispense_flow_rate,
@@ -2047,12 +2047,12 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         blow_out_flow_rate: Optional[float],
         is_low_volume: bool,
     ) -> None:
-        self._user_aspirate_flow_rate = aspirate_flow_rate
-        self._user_dispense_flow_rate = dispense_flow_rate
-        self._user_blow_out_flow_rate = blow_out_flow_rate
         # TODO(jbl 2025-09-17) this works for p50 low volume mode but is not guaranteed to work for future low volume
         #   modes, this should be replaced with something less flaky
         self.configure_for_volume(self.get_max_volume() if not is_low_volume else 1)
+        self._user_aspirate_flow_rate = aspirate_flow_rate
+        self._user_dispense_flow_rate = dispense_flow_rate
+        self._user_blow_out_flow_rate = blow_out_flow_rate
 
     def aspirate_liquid_class(
         self,

--- a/api/src/opentrons/protocol_engine/resources/pipette_data_provider.py
+++ b/api/src/opentrons/protocol_engine/resources/pipette_data_provider.py
@@ -70,6 +70,7 @@ class LoadedStaticPipetteData:
     plunger_positions: Dict[str, float]
     shaft_ul_per_mm: float
     available_sensors: pipette_definition.AvailableSensorDefinition
+    volume_mode: pip_types.LiquidClasses  # pip_types Liquid Classes refers to volume modes
 
 
 class VirtualPipetteDataProvider:
@@ -298,6 +299,7 @@ class VirtualPipetteDataProvider:
             shaft_ul_per_mm=config.shaft_ul_per_mm,
             available_sensors=config.available_sensors
             or pipette_definition.AvailableSensorDefinition(sensors=[]),
+            volume_mode=liquid_class,
         )
 
     def get_virtual_pipette_static_config(
@@ -353,6 +355,7 @@ def get_pipette_static_config(
         plunger_positions=pipette_dict["plunger_positions"],
         shaft_ul_per_mm=pipette_dict["shaft_ul_per_mm"],
         available_sensors=available_sensors,
+        volume_mode=pipette_dict["volume_mode"],
     )
 
 

--- a/api/src/opentrons/protocol_engine/state/pipettes.py
+++ b/api/src/opentrons/protocol_engine/state/pipettes.py
@@ -212,7 +212,7 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
                         # we identify tip classes - looking things up by volume is not enough.
                         tip_configuration = list(
                             static_config.tip_configuration_lookup_table.values()
-                        )[0]
+                        )[-1]
                     self._state.flow_rates_by_id[pipette_id] = FlowRates(
                         default_blow_out=tip_configuration.default_blowout_flowrate.values_by_api_level,
                         default_aspirate=tip_configuration.default_aspirate_flowrate.values_by_api_level,
@@ -230,7 +230,7 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
                     # TODO(seth,9/11/2023): bad way to do defaulting, see above.
                     tip_configuration = list(
                         static_config.tip_configuration_lookup_table.values()
-                    )[0]
+                    )[-1]
                     self._state.flow_rates_by_id[pipette_id] = FlowRates(
                         default_blow_out=tip_configuration.default_blowout_flowrate.values_by_api_level,
                         default_aspirate=tip_configuration.default_aspirate_flowrate.values_by_api_level,

--- a/api/src/opentrons/protocol_engine/state/pipettes.py
+++ b/api/src/opentrons/protocol_engine/state/pipettes.py
@@ -19,7 +19,7 @@ from opentrons_shared_data.pipette import pipette_definition
 from opentrons_shared_data.pipette.ul_per_mm import calculate_ul_per_mm
 from opentrons_shared_data.pipette.types import (
     UlPerMmAction,
-    LiquidClasses as VolumeClasses,
+    LiquidClasses as VolumeModes,
 )
 
 from opentrons.config.defaults_ot2 import Z_RETRACT_DISTANCE
@@ -110,7 +110,7 @@ class StaticPipetteConfig:
     plunger_positions: Dict[str, float]
     shaft_ul_per_mm: float
     available_sensors: pipette_definition.AvailableSensorDefinition
-    volume_mode: VolumeClasses
+    volume_mode: VolumeModes
 
 
 @dataclasses.dataclass
@@ -874,7 +874,7 @@ class PipetteView:
 
     def get_is_low_volume_mode(self, pipette_id: str) -> bool:
         """Determine if the pipette is currently in low volume mode."""
-        return self.get_config(pipette_id).volume_mode == VolumeClasses.lowVolumeDefault
+        return self.get_config(pipette_id).volume_mode == VolumeModes.lowVolumeDefault
 
     def lookup_volume_to_mm_conversion(
         self, pipette_id: str, volume: float, action: str

--- a/api/src/opentrons/protocol_engine/state/pipettes.py
+++ b/api/src/opentrons/protocol_engine/state/pipettes.py
@@ -17,7 +17,10 @@ from typing_extensions import assert_never
 
 from opentrons_shared_data.pipette import pipette_definition
 from opentrons_shared_data.pipette.ul_per_mm import calculate_ul_per_mm
-from opentrons_shared_data.pipette.types import UlPerMmAction
+from opentrons_shared_data.pipette.types import (
+    UlPerMmAction,
+    LiquidClasses as VolumeClasses,
+)
 
 from opentrons.config.defaults_ot2 import Z_RETRACT_DISTANCE
 from opentrons.hardware_control.dev_types import PipetteDict
@@ -107,6 +110,7 @@ class StaticPipetteConfig:
     plunger_positions: Dict[str, float]
     shaft_ul_per_mm: float
     available_sensors: pipette_definition.AvailableSensorDefinition
+    volume_mode: VolumeClasses
 
 
 @dataclasses.dataclass
@@ -313,6 +317,7 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
                 plunger_positions=config.plunger_positions,
                 shaft_ul_per_mm=config.shaft_ul_per_mm,
                 available_sensors=config.available_sensors,
+                volume_mode=config.volume_mode,
             )
             self._state.flow_rates_by_id[
                 state_update.pipette_config.pipette_id
@@ -866,6 +871,10 @@ class PipetteView:
         ):
             return False
         return True
+
+    def get_is_low_volume_mode(self, pipette_id: str) -> bool:
+        """Determine if the pipette is currently in low volume mode."""
+        return self.get_config(pipette_id).volume_mode == VolumeClasses.lowVolumeDefault
 
     def lookup_volume_to_mm_conversion(
         self, pipette_id: str, volume: float, action: str

--- a/api/tests/opentrons/protocol_api/core/engine/test_instrument_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_instrument_core.py
@@ -2902,3 +2902,131 @@ def test_get_next_tip_raises_for_starting_tip_with_partial_config(
             tip_racks=tip_racks,
             starting_well=mock_starting_well,
         )
+
+
+@pytest.mark.parametrize("version", versions_at_or_above(APIVersion(2, 26)))
+def test_flow_rates_use_defaults_on_newer_api_versions(
+    decoy: Decoy,
+    mock_engine_client: EngineClient,
+    mock_sync_hardware: SyncHardwareAPI,
+    mock_protocol_core: ProtocolCore,
+    version: APIVersion,
+) -> None:
+    """It should default to getting the flow rates from the engine when not set by a user."""
+    decoy.when(mock_engine_client.state.pipettes.get("abc123")).then_return(
+        LoadedPipette.model_construct(mount=MountType.LEFT)  # type: ignore[call-arg]
+    )
+
+    decoy.when(mock_protocol_core.api_version).then_return(version)
+
+    decoy.when(mock_engine_client.state.pipettes.get_flow_rates("abc123")).then_return(
+        FlowRates(
+            default_aspirate={"1.2": 2.3},
+            default_dispense={"3.4": 4.5},
+            default_blow_out={"5.6": 6.7},
+        ),
+    )
+
+    subject = InstrumentCore(
+        pipette_id="abc123",
+        engine_client=mock_engine_client,
+        sync_hardware_api=mock_sync_hardware,
+        protocol_core=mock_protocol_core,
+        default_movement_speed=1337,
+    )
+
+    # Flow rates should default to the engine core
+    assert subject.get_aspirate_flow_rate() == 2.3
+    assert subject.get_dispense_flow_rate() == 4.5
+    assert subject.get_blow_out_flow_rate() == 6.7
+
+    decoy.when(mock_engine_client.state.pipettes.get_flow_rates("abc123")).then_return(
+        FlowRates(
+            default_aspirate={"1.2": 9.8},
+            default_dispense={"3.4": 7.6},
+            default_blow_out={"5.6": 5.4},
+        ),
+    )
+
+    # Now that the flow rates from the engine have "changed" these calls should reflect that
+    assert subject.get_aspirate_flow_rate() == 9.8
+    assert subject.get_dispense_flow_rate() == 7.6
+    assert subject.get_blow_out_flow_rate() == 5.4
+
+    # Flow rates should use user set ones
+    subject.set_flow_rate(aspirate=99.9, dispense=66.6, blow_out=33.3)
+
+    assert subject.get_aspirate_flow_rate() == 99.9
+    assert subject.get_dispense_flow_rate() == 66.6
+    assert subject.get_blow_out_flow_rate() == 33.3
+
+    # Resetting them via configure for volume should go back to engine defaults
+    subject.configure_for_volume(1337)
+
+    assert subject.get_aspirate_flow_rate() == 9.8
+    assert subject.get_dispense_flow_rate() == 7.6
+    assert subject.get_blow_out_flow_rate() == 5.4
+
+
+@pytest.mark.parametrize("version", versions_below(APIVersion(2, 26), flex_only=True))
+def test_flow_rates_use_maintains_buggy_defaults_on_older_versions(
+    decoy: Decoy,
+    mock_engine_client: EngineClient,
+    mock_sync_hardware: SyncHardwareAPI,
+    mock_protocol_core: ProtocolCore,
+    version: APIVersion,
+) -> None:
+    """It should only use the initial defaults on pre 2.26 API versions."""
+    decoy.when(mock_engine_client.state.pipettes.get("abc123")).then_return(
+        LoadedPipette.model_construct(mount=MountType.LEFT)  # type: ignore[call-arg]
+    )
+
+    decoy.when(mock_protocol_core.api_version).then_return(version)
+
+    decoy.when(mock_engine_client.state.pipettes.get_flow_rates("abc123")).then_return(
+        FlowRates(
+            default_aspirate={"1.2": 2.3},
+            default_dispense={"3.4": 4.5},
+            default_blow_out={"5.6": 6.7},
+        ),
+    )
+
+    subject = InstrumentCore(
+        pipette_id="abc123",
+        engine_client=mock_engine_client,
+        sync_hardware_api=mock_sync_hardware,
+        protocol_core=mock_protocol_core,
+        default_movement_speed=1337,
+    )
+
+    # Flow rates should default to the engine core
+    assert subject.get_aspirate_flow_rate() == 2.3
+    assert subject.get_dispense_flow_rate() == 4.5
+    assert subject.get_blow_out_flow_rate() == 6.7
+
+    decoy.when(mock_engine_client.state.pipettes.get_flow_rates("abc123")).then_return(
+        FlowRates(
+            default_aspirate={"1.2": 9.8},
+            default_dispense={"3.4": 7.6},
+            default_blow_out={"5.6": 5.4},
+        ),
+    )
+
+    # Flow rates should stay with their initial default
+    assert subject.get_aspirate_flow_rate() == 2.3
+    assert subject.get_dispense_flow_rate() == 4.5
+    assert subject.get_blow_out_flow_rate() == 6.7
+
+    # Flow rates should use user set ones
+    subject.set_flow_rate(aspirate=99.9, dispense=66.6, blow_out=33.3)
+
+    assert subject.get_aspirate_flow_rate() == 99.9
+    assert subject.get_dispense_flow_rate() == 66.6
+    assert subject.get_blow_out_flow_rate() == 33.3
+
+    # Resetting them via configure for volume should NOT reset the user set ones for older buggy versions
+    subject.configure_for_volume(1337)
+
+    assert subject.get_aspirate_flow_rate() == 99.9
+    assert subject.get_dispense_flow_rate() == 66.6
+    assert subject.get_blow_out_flow_rate() == 33.3

--- a/api/tests/opentrons/protocol_api/core/engine/test_instrument_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_instrument_core.py
@@ -175,6 +175,8 @@ def subject(
         LoadedPipette.model_construct(mount=MountType.LEFT)  # type: ignore[call-arg]
     )
 
+    decoy.when(mock_protocol_core.api_version).then_return(MAX_SUPPORTED_VERSION)
+
     decoy.when(mock_engine_client.state.pipettes.get_flow_rates("abc123")).then_return(
         FlowRates(
             default_aspirate={"1.2": 2.3},

--- a/api/tests/opentrons/protocol_engine/commands/test_configure_for_volume.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_configure_for_volume.py
@@ -20,7 +20,7 @@ from opentrons.protocol_engine.commands.configure_for_volume import (
 )
 from opentrons_shared_data.pipette.types import (
     PipetteNameType,
-    LiquidClasses as VolumeClasses,
+    LiquidClasses as VolumeModes,
 )
 from opentrons_shared_data.pipette.pipette_definition import AvailableSensorDefinition
 from ..pipette_fixtures import get_default_nozzle_map
@@ -81,7 +81,7 @@ async def test_configure_for_volume_implementation(
         },
         shaft_ul_per_mm=5.0,
         available_sensors=available_sensors,
-        volume_mode=VolumeClasses.lowVolumeDefault,
+        volume_mode=VolumeModes.lowVolumeDefault,
     )
 
     decoy.when(

--- a/api/tests/opentrons/protocol_engine/commands/test_configure_for_volume.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_configure_for_volume.py
@@ -18,7 +18,10 @@ from opentrons.protocol_engine.commands.configure_for_volume import (
     ConfigureForVolumeResult,
     ConfigureForVolumeImplementation,
 )
-from opentrons_shared_data.pipette.types import PipetteNameType
+from opentrons_shared_data.pipette.types import (
+    PipetteNameType,
+    LiquidClasses as VolumeClasses,
+)
 from opentrons_shared_data.pipette.pipette_definition import AvailableSensorDefinition
 from ..pipette_fixtures import get_default_nozzle_map
 from opentrons.types import Point
@@ -78,6 +81,7 @@ async def test_configure_for_volume_implementation(
         },
         shaft_ul_per_mm=5.0,
         available_sensors=available_sensors,
+        volume_mode=VolumeClasses.lowVolumeDefault,
     )
 
     decoy.when(

--- a/api/tests/opentrons/protocol_engine/commands/test_liquid_probe.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_liquid_probe.py
@@ -23,7 +23,7 @@ from opentrons_shared_data.pipette.pipette_definition import (
 
 from opentrons_shared_data.pipette.types import (
     PipetteNameType,
-    LiquidClasses as VolumeClasses,
+    LiquidClasses as VolumeModes,
 )
 
 from opentrons.protocol_engine.commands.pipetting_common import LiquidNotFoundError
@@ -237,7 +237,7 @@ async def test_liquid_probe_implementation(
             },
             shaft_ul_per_mm=5.0,
             available_sensors=available_sensors,
-            volume_mode=VolumeClasses.default,
+            volume_mode=VolumeModes.default,
         )
     )
 
@@ -333,7 +333,7 @@ async def test_liquid_not_found_error(
             },
             shaft_ul_per_mm=5.0,
             available_sensors=available_sensors,
-            volume_mode=VolumeClasses.default,
+            volume_mode=VolumeModes.default,
         )
     )
     decoy.when(
@@ -461,7 +461,7 @@ async def test_liquid_probe_tip_checking(
             },
             shaft_ul_per_mm=5.0,
             available_sensors=available_sensors,
-            volume_mode=VolumeClasses.default,
+            volume_mode=VolumeModes.default,
         )
     )
     with pytest.raises(TipNotAttachedError):
@@ -525,7 +525,7 @@ async def test_liquid_probe_plunger_preparedness_checking(
             },
             shaft_ul_per_mm=5.0,
             available_sensors=available_sensors,
-            volume_mode=VolumeClasses.default,
+            volume_mode=VolumeModes.default,
         )
     )
     decoy.when(state_view.pipettes.get_aspirated_volume(pipette_id)).then_return(None)
@@ -591,7 +591,7 @@ async def test_liquid_probe_volume_checking(
             },
             shaft_ul_per_mm=5.0,
             available_sensors=available_sensors,
-            volume_mode=VolumeClasses.default,
+            volume_mode=VolumeModes.default,
         )
     )
     decoy.when(
@@ -665,7 +665,7 @@ async def test_liquid_probe_location_checking(
             },
             shaft_ul_per_mm=5.0,
             available_sensors=available_sensors,
-            volume_mode=VolumeClasses.default,
+            volume_mode=VolumeModes.default,
         )
     )
     decoy.when(
@@ -736,7 +736,7 @@ async def test_liquid_probe_stall(
             },
             shaft_ul_per_mm=5.0,
             available_sensors=available_sensors,
-            volume_mode=VolumeClasses.default,
+            volume_mode=VolumeModes.default,
         )
     )
     decoy.when(

--- a/api/tests/opentrons/protocol_engine/commands/test_liquid_probe.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_liquid_probe.py
@@ -21,7 +21,10 @@ from opentrons_shared_data.pipette.pipette_definition import (
     SupportedTipsDefinition,
 )
 
-from opentrons_shared_data.pipette.types import PipetteNameType
+from opentrons_shared_data.pipette.types import (
+    PipetteNameType,
+    LiquidClasses as VolumeClasses,
+)
 
 from opentrons.protocol_engine.commands.pipetting_common import LiquidNotFoundError
 from opentrons.protocol_engine.state.state import StateView
@@ -234,6 +237,7 @@ async def test_liquid_probe_implementation(
             },
             shaft_ul_per_mm=5.0,
             available_sensors=available_sensors,
+            volume_mode=VolumeClasses.default,
         )
     )
 
@@ -329,6 +333,7 @@ async def test_liquid_not_found_error(
             },
             shaft_ul_per_mm=5.0,
             available_sensors=available_sensors,
+            volume_mode=VolumeClasses.default,
         )
     )
     decoy.when(
@@ -456,6 +461,7 @@ async def test_liquid_probe_tip_checking(
             },
             shaft_ul_per_mm=5.0,
             available_sensors=available_sensors,
+            volume_mode=VolumeClasses.default,
         )
     )
     with pytest.raises(TipNotAttachedError):
@@ -519,6 +525,7 @@ async def test_liquid_probe_plunger_preparedness_checking(
             },
             shaft_ul_per_mm=5.0,
             available_sensors=available_sensors,
+            volume_mode=VolumeClasses.default,
         )
     )
     decoy.when(state_view.pipettes.get_aspirated_volume(pipette_id)).then_return(None)
@@ -584,6 +591,7 @@ async def test_liquid_probe_volume_checking(
             },
             shaft_ul_per_mm=5.0,
             available_sensors=available_sensors,
+            volume_mode=VolumeClasses.default,
         )
     )
     decoy.when(
@@ -657,6 +665,7 @@ async def test_liquid_probe_location_checking(
             },
             shaft_ul_per_mm=5.0,
             available_sensors=available_sensors,
+            volume_mode=VolumeClasses.default,
         )
     )
     decoy.when(
@@ -727,6 +736,7 @@ async def test_liquid_probe_stall(
             },
             shaft_ul_per_mm=5.0,
             available_sensors=available_sensors,
+            volume_mode=VolumeClasses.default,
         )
     )
     decoy.when(

--- a/api/tests/opentrons/protocol_engine/commands/test_load_pipette.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_load_pipette.py
@@ -11,7 +11,7 @@ from decoy import Decoy
 
 from opentrons_shared_data.pipette.types import (
     PipetteNameType,
-    LiquidClasses as VolumeClasses,
+    LiquidClasses as VolumeModes,
 )
 from opentrons_shared_data.robot.types import RobotType
 from opentrons_shared_data.pipette.pipette_definition import AvailableSensorDefinition
@@ -89,7 +89,7 @@ async def test_load_pipette_implementation(
         },
         shaft_ul_per_mm=5.0,
         available_sensors=available_sensors,
-        volume_mode=VolumeClasses.default,
+        volume_mode=VolumeModes.default,
     )
 
     decoy.when(
@@ -170,7 +170,7 @@ async def test_load_pipette_implementation_96_channel(
         },
         shaft_ul_per_mm=5.0,
         available_sensors=available_sensors,
-        volume_mode=VolumeClasses.lowVolumeDefault,
+        volume_mode=VolumeModes.lowVolumeDefault,
     )
 
     decoy.when(

--- a/api/tests/opentrons/protocol_engine/commands/test_load_pipette.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_load_pipette.py
@@ -9,7 +9,10 @@ from opentrons.protocol_engine.state.update_types import (
 import pytest
 from decoy import Decoy
 
-from opentrons_shared_data.pipette.types import PipetteNameType
+from opentrons_shared_data.pipette.types import (
+    PipetteNameType,
+    LiquidClasses as VolumeClasses,
+)
 from opentrons_shared_data.robot.types import RobotType
 from opentrons_shared_data.pipette.pipette_definition import AvailableSensorDefinition
 from opentrons.types import MountType, Point
@@ -86,6 +89,7 @@ async def test_load_pipette_implementation(
         },
         shaft_ul_per_mm=5.0,
         available_sensors=available_sensors,
+        volume_mode=VolumeClasses.default,
     )
 
     decoy.when(
@@ -166,6 +170,7 @@ async def test_load_pipette_implementation_96_channel(
         },
         shaft_ul_per_mm=5.0,
         available_sensors=available_sensors,
+        volume_mode=VolumeClasses.lowVolumeDefault,
     )
 
     decoy.when(

--- a/api/tests/opentrons/protocol_engine/execution/test_equipment_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_equipment_handler.py
@@ -9,7 +9,10 @@ from typing import Any, Optional, cast, Dict
 import pytest
 from _pytest.fixtures import SubRequest
 
-from opentrons_shared_data.pipette.types import PipetteNameType
+from opentrons_shared_data.pipette.types import (
+    PipetteNameType,
+    LiquidClasses as VolumeClasses,
+)
 from opentrons_shared_data.pipette import pipette_definition
 from opentrons_shared_data.labware.types import LabwareUri
 
@@ -178,6 +181,7 @@ def loaded_static_pipette_data(
         },
         shaft_ul_per_mm=5.0,
         available_sensors=available_sensors,
+        volume_mode=VolumeClasses.default,
     )
 
 

--- a/api/tests/opentrons/protocol_engine/execution/test_equipment_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_equipment_handler.py
@@ -11,7 +11,7 @@ from _pytest.fixtures import SubRequest
 
 from opentrons_shared_data.pipette.types import (
     PipetteNameType,
-    LiquidClasses as VolumeClasses,
+    LiquidClasses as VolumeModes,
 )
 from opentrons_shared_data.pipette import pipette_definition
 from opentrons_shared_data.labware.types import LabwareUri
@@ -181,7 +181,7 @@ def loaded_static_pipette_data(
         },
         shaft_ul_per_mm=5.0,
         available_sensors=available_sensors,
-        volume_mode=VolumeClasses.default,
+        volume_mode=VolumeModes.default,
     )
 
 

--- a/api/tests/opentrons/protocol_engine/resources/test_pipette_data_provider.py
+++ b/api/tests/opentrons/protocol_engine/resources/test_pipette_data_provider.py
@@ -2,7 +2,11 @@
 from typing import Dict
 from sys import maxsize
 import pytest
-from opentrons_shared_data.pipette.types import PipetteNameType, PipetteModel
+from opentrons_shared_data.pipette.types import (
+    PipetteNameType,
+    PipetteModel,
+    LiquidClasses as VolumeClasses,
+)
 from opentrons_shared_data.pipette import pipette_definition, types as pip_types
 from opentrons_shared_data.pipette.pipette_definition import (
     PipetteBoundingBoxOffsetDefinition,
@@ -81,6 +85,7 @@ def test_get_virtual_pipette_static_config(
         },
         shaft_ul_per_mm=0.785,
         available_sensors=AvailableSensorDefinition(sensors=[]),
+        volume_mode=VolumeClasses.default,
     )
 
 
@@ -122,6 +127,7 @@ def test_configure_virtual_pipette_for_volume(
         },
         shaft_ul_per_mm=0.785,
         available_sensors=available_sensors,
+        volume_mode=VolumeClasses.default,
     )
     subject_instance.configure_virtual_pipette_for_volume(
         "my-pipette", 1, result1.model
@@ -159,6 +165,7 @@ def test_configure_virtual_pipette_for_volume(
         },
         shaft_ul_per_mm=0.785,
         available_sensors=available_sensors,
+        volume_mode=VolumeClasses.lowVolumeDefault,
     )
 
 
@@ -197,6 +204,7 @@ def test_load_virtual_pipette_by_model_string(
         },
         shaft_ul_per_mm=9.621,
         available_sensors=AvailableSensorDefinition(sensors=[]),
+        volume_mode=VolumeClasses.default,
     )
 
 
@@ -298,6 +306,7 @@ def pipette_dict(
         "plunger_positions": {"top": 100, "bottom": 20, "blow_out": 10, "drop_tip": 0},
         "shaft_ul_per_mm": 5.0,
         "available_sensors": available_sensors,
+        "volume_mode": VolumeClasses.lowVolumeDefault,
     }
 
 
@@ -348,6 +357,7 @@ def test_get_pipette_static_config(
         plunger_positions={"top": 100, "bottom": 20, "blow_out": 10, "drop_tip": 0},
         shaft_ul_per_mm=5.0,
         available_sensors=available_sensors,
+        volume_mode=VolumeClasses.lowVolumeDefault,
     )
 
 

--- a/api/tests/opentrons/protocol_engine/resources/test_pipette_data_provider.py
+++ b/api/tests/opentrons/protocol_engine/resources/test_pipette_data_provider.py
@@ -5,7 +5,7 @@ import pytest
 from opentrons_shared_data.pipette.types import (
     PipetteNameType,
     PipetteModel,
-    LiquidClasses as VolumeClasses,
+    LiquidClasses as VolumeModes,
 )
 from opentrons_shared_data.pipette import pipette_definition, types as pip_types
 from opentrons_shared_data.pipette.pipette_definition import (
@@ -85,7 +85,7 @@ def test_get_virtual_pipette_static_config(
         },
         shaft_ul_per_mm=0.785,
         available_sensors=AvailableSensorDefinition(sensors=[]),
-        volume_mode=VolumeClasses.default,
+        volume_mode=VolumeModes.default,
     )
 
 
@@ -127,7 +127,7 @@ def test_configure_virtual_pipette_for_volume(
         },
         shaft_ul_per_mm=0.785,
         available_sensors=available_sensors,
-        volume_mode=VolumeClasses.default,
+        volume_mode=VolumeModes.default,
     )
     subject_instance.configure_virtual_pipette_for_volume(
         "my-pipette", 1, result1.model
@@ -165,7 +165,7 @@ def test_configure_virtual_pipette_for_volume(
         },
         shaft_ul_per_mm=0.785,
         available_sensors=available_sensors,
-        volume_mode=VolumeClasses.lowVolumeDefault,
+        volume_mode=VolumeModes.lowVolumeDefault,
     )
 
 
@@ -204,7 +204,7 @@ def test_load_virtual_pipette_by_model_string(
         },
         shaft_ul_per_mm=9.621,
         available_sensors=AvailableSensorDefinition(sensors=[]),
-        volume_mode=VolumeClasses.default,
+        volume_mode=VolumeModes.default,
     )
 
 
@@ -306,7 +306,7 @@ def pipette_dict(
         "plunger_positions": {"top": 100, "bottom": 20, "blow_out": 10, "drop_tip": 0},
         "shaft_ul_per_mm": 5.0,
         "available_sensors": available_sensors,
-        "volume_mode": VolumeClasses.lowVolumeDefault,
+        "volume_mode": VolumeModes.lowVolumeDefault,
     }
 
 
@@ -357,7 +357,7 @@ def test_get_pipette_static_config(
         plunger_positions={"top": 100, "bottom": 20, "blow_out": 10, "drop_tip": 0},
         shaft_ul_per_mm=5.0,
         available_sensors=available_sensors,
-        volume_mode=VolumeClasses.lowVolumeDefault,
+        volume_mode=VolumeModes.lowVolumeDefault,
     )
 
 

--- a/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
@@ -32,7 +32,7 @@ from opentrons.types import (
 )
 from opentrons_shared_data.pipette.types import (
     PipetteNameType,
-    LiquidClasses as VolumeClasses,
+    LiquidClasses as VolumeModes,
 )
 from opentrons_shared_data.labware.labware_definition import (
     CuboidalFrustum,
@@ -3350,7 +3350,7 @@ def test_get_next_drop_tip_location(
             },
             shaft_ul_per_mm=5.0,
             available_sensors=available_sensors,
-            volume_mode=VolumeClasses.default,
+            volume_mode=VolumeModes.default,
         )
     )
     decoy.when(mock_pipette_view.get_mount("pip-123")).then_return(pipette_mount)

--- a/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
@@ -30,7 +30,10 @@ from opentrons.types import (
     StagingSlotName,
     MeniscusTrackingTarget,
 )
-from opentrons_shared_data.pipette.types import PipetteNameType
+from opentrons_shared_data.pipette.types import (
+    PipetteNameType,
+    LiquidClasses as VolumeClasses,
+)
 from opentrons_shared_data.labware.labware_definition import (
     CuboidalFrustum,
     InnerWellGeometry,
@@ -3347,6 +3350,7 @@ def test_get_next_drop_tip_location(
             },
             shaft_ul_per_mm=5.0,
             available_sensors=available_sensors,
+            volume_mode=VolumeClasses.default,
         )
     )
     decoy.when(mock_pipette_view.get_mount("pip-123")).then_return(pipette_mount)

--- a/api/tests/opentrons/protocol_engine/state/test_pipette_state.py
+++ b/api/tests/opentrons/protocol_engine/state/test_pipette_state.py
@@ -9,7 +9,10 @@ from collections import OrderedDict
 import pytest
 
 from opentrons_shared_data.pipette import pipette_definition
-from opentrons_shared_data.pipette.types import PipetteNameType
+from opentrons_shared_data.pipette.types import (
+    PipetteNameType,
+    LiquidClasses as VolumeClasses,
+)
 
 from opentrons.hardware_control.nozzle_manager import NozzleMap
 from opentrons.protocol_engine import actions, commands
@@ -84,6 +87,7 @@ def test_handle_pipette_config_action(
             available_sensors=pipette_definition.AvailableSensorDefinition(
                 sensors=["pressure", "capacitive", "environment"]
             ),
+            volume_mode=VolumeClasses.default,
         ),
     )
     subject.handle_action(
@@ -199,6 +203,7 @@ def test_active_channels(
             available_sensors=pipette_definition.AvailableSensorDefinition(
                 sensors=["pressure", "capacitive", "environment"]
             ),
+            volume_mode=VolumeClasses.default,
         ),
     )
     subject.handle_action(

--- a/api/tests/opentrons/protocol_engine/state/test_pipette_state.py
+++ b/api/tests/opentrons/protocol_engine/state/test_pipette_state.py
@@ -11,7 +11,7 @@ import pytest
 from opentrons_shared_data.pipette import pipette_definition
 from opentrons_shared_data.pipette.types import (
     PipetteNameType,
-    LiquidClasses as VolumeClasses,
+    LiquidClasses as VolumeModes,
 )
 
 from opentrons.hardware_control.nozzle_manager import NozzleMap
@@ -87,7 +87,7 @@ def test_handle_pipette_config_action(
             available_sensors=pipette_definition.AvailableSensorDefinition(
                 sensors=["pressure", "capacitive", "environment"]
             ),
-            volume_mode=VolumeClasses.default,
+            volume_mode=VolumeModes.default,
         ),
     )
     subject.handle_action(
@@ -203,7 +203,7 @@ def test_active_channels(
             available_sensors=pipette_definition.AvailableSensorDefinition(
                 sensors=["pressure", "capacitive", "environment"]
             ),
-            volume_mode=VolumeClasses.default,
+            volume_mode=VolumeModes.default,
         ),
     )
     subject.handle_action(

--- a/api/tests/opentrons/protocol_engine/state/test_pipette_store_old.py
+++ b/api/tests/opentrons/protocol_engine/state/test_pipette_store_old.py
@@ -8,7 +8,7 @@ import pytest
 
 from opentrons_shared_data.pipette.types import (
     PipetteNameType,
-    LiquidClasses as VolumeClasses,
+    LiquidClasses as VolumeModes,
 )
 from opentrons_shared_data.pipette import pipette_definition
 
@@ -226,7 +226,7 @@ def test_handles_load_pipette(
         },
         shaft_ul_per_mm=5.0,
         available_sensors=available_sensors,
-        volume_mode=VolumeClasses.default,
+        volume_mode=VolumeModes.default,
     )
     config_update = update_types.PipetteConfigUpdate(
         pipette_id="pipette-id",
@@ -668,7 +668,7 @@ def test_add_pipette_config(
         },
         shaft_ul_per_mm=5.0,
         available_sensors=available_sensors,
-        volume_mode=VolumeClasses.default,
+        volume_mode=VolumeModes.default,
     )
 
     subject.handle_action(
@@ -715,7 +715,7 @@ def test_add_pipette_config(
         },
         shaft_ul_per_mm=5.0,
         available_sensors=available_sensors,
-        volume_mode=VolumeClasses.default,
+        volume_mode=VolumeModes.default,
     )
     assert subject.state.flow_rates_by_id["pipette-id"].default_aspirate == {"a": 1.0}
     assert subject.state.flow_rates_by_id["pipette-id"].default_dispense == {"b": 2.0}

--- a/api/tests/opentrons/protocol_engine/state/test_pipette_store_old.py
+++ b/api/tests/opentrons/protocol_engine/state/test_pipette_store_old.py
@@ -6,7 +6,10 @@ treating PipetteState as a private implementation detail.
 """
 import pytest
 
-from opentrons_shared_data.pipette.types import PipetteNameType
+from opentrons_shared_data.pipette.types import (
+    PipetteNameType,
+    LiquidClasses as VolumeClasses,
+)
 from opentrons_shared_data.pipette import pipette_definition
 
 from opentrons.protocol_engine.state import update_types
@@ -223,6 +226,7 @@ def test_handles_load_pipette(
         },
         shaft_ul_per_mm=5.0,
         available_sensors=available_sensors,
+        volume_mode=VolumeClasses.default,
     )
     config_update = update_types.PipetteConfigUpdate(
         pipette_id="pipette-id",
@@ -664,6 +668,7 @@ def test_add_pipette_config(
         },
         shaft_ul_per_mm=5.0,
         available_sensors=available_sensors,
+        volume_mode=VolumeClasses.default,
     )
 
     subject.handle_action(
@@ -710,6 +715,7 @@ def test_add_pipette_config(
         },
         shaft_ul_per_mm=5.0,
         available_sensors=available_sensors,
+        volume_mode=VolumeClasses.default,
     )
     assert subject.state.flow_rates_by_id["pipette-id"].default_aspirate == {"a": 1.0}
     assert subject.state.flow_rates_by_id["pipette-id"].default_dispense == {"b": 2.0}

--- a/api/tests/opentrons/protocol_engine/state/test_pipette_view_old.py
+++ b/api/tests/opentrons/protocol_engine/state/test_pipette_view_old.py
@@ -14,7 +14,7 @@ from decoy import Decoy
 
 from opentrons_shared_data.pipette.types import (
     PipetteNameType,
-    LiquidClasses as VolumeClasses,
+    LiquidClasses as VolumeModes,
 )
 from opentrons_shared_data.pipette import pipette_definition
 from opentrons_shared_data.pipette.pipette_definition import (
@@ -324,7 +324,7 @@ def test_get_pipette_working_volume(
                 },
                 shaft_ul_per_mm=5.0,
                 available_sensors=available_sensors,
-                volume_mode=VolumeClasses.default,
+                volume_mode=VolumeModes.default,
             )
         },
     )
@@ -365,7 +365,7 @@ def test_get_pipette_working_volume_raises_if_tip_volume_is_none(
                 },
                 shaft_ul_per_mm=5.0,
                 available_sensors=available_sensors,
-                volume_mode=VolumeClasses.default,
+                volume_mode=VolumeModes.default,
             )
         },
     )
@@ -418,7 +418,7 @@ def test_get_pipette_available_volume(
                 },
                 shaft_ul_per_mm=5.0,
                 available_sensors=available_sensors,
-                volume_mode=VolumeClasses.default,
+                volume_mode=VolumeModes.default,
             ),
             "pipette-id-none": StaticPipetteConfig(
                 min_volume=1,
@@ -443,7 +443,7 @@ def test_get_pipette_available_volume(
                 },
                 shaft_ul_per_mm=5.0,
                 available_sensors=available_sensors,
-                volume_mode=VolumeClasses.default,
+                volume_mode=VolumeModes.default,
             ),
         },
     )
@@ -565,7 +565,7 @@ def test_get_static_config(
         },
         shaft_ul_per_mm=5.0,
         available_sensors=available_sensors,
-        volume_mode=VolumeClasses.default,
+        volume_mode=VolumeModes.default,
     )
 
     subject = get_pipette_view(
@@ -626,7 +626,7 @@ def test_get_nominal_tip_overlap(
         },
         shaft_ul_per_mm=5.0,
         available_sensors=available_sensors,
-        volume_mode=VolumeClasses.default,
+        volume_mode=VolumeModes.default,
     )
 
     subject = get_pipette_view(static_config_by_id={"pipette-id": config})
@@ -1062,7 +1062,7 @@ def test_get_pipette_bounds_at_location(
                 },
                 shaft_ul_per_mm=5.0,
                 available_sensors=available_sensors,
-                volume_mode=VolumeClasses.default,
+                volume_mode=VolumeModes.default,
             )
         },
     )

--- a/api/tests/opentrons/protocol_engine/state/test_pipette_view_old.py
+++ b/api/tests/opentrons/protocol_engine/state/test_pipette_view_old.py
@@ -12,7 +12,10 @@ import pytest
 from decoy import Decoy
 
 
-from opentrons_shared_data.pipette.types import PipetteNameType
+from opentrons_shared_data.pipette.types import (
+    PipetteNameType,
+    LiquidClasses as VolumeClasses,
+)
 from opentrons_shared_data.pipette import pipette_definition
 from opentrons_shared_data.pipette.pipette_definition import (
     ValidNozzleMaps,
@@ -321,6 +324,7 @@ def test_get_pipette_working_volume(
                 },
                 shaft_ul_per_mm=5.0,
                 available_sensors=available_sensors,
+                volume_mode=VolumeClasses.default,
             )
         },
     )
@@ -361,6 +365,7 @@ def test_get_pipette_working_volume_raises_if_tip_volume_is_none(
                 },
                 shaft_ul_per_mm=5.0,
                 available_sensors=available_sensors,
+                volume_mode=VolumeClasses.default,
             )
         },
     )
@@ -413,6 +418,7 @@ def test_get_pipette_available_volume(
                 },
                 shaft_ul_per_mm=5.0,
                 available_sensors=available_sensors,
+                volume_mode=VolumeClasses.default,
             ),
             "pipette-id-none": StaticPipetteConfig(
                 min_volume=1,
@@ -437,6 +443,7 @@ def test_get_pipette_available_volume(
                 },
                 shaft_ul_per_mm=5.0,
                 available_sensors=available_sensors,
+                volume_mode=VolumeClasses.default,
             ),
         },
     )
@@ -558,6 +565,7 @@ def test_get_static_config(
         },
         shaft_ul_per_mm=5.0,
         available_sensors=available_sensors,
+        volume_mode=VolumeClasses.default,
     )
 
     subject = get_pipette_view(
@@ -618,6 +626,7 @@ def test_get_nominal_tip_overlap(
         },
         shaft_ul_per_mm=5.0,
         available_sensors=available_sensors,
+        volume_mode=VolumeClasses.default,
     )
 
     subject = get_pipette_view(static_config_by_id={"pipette-id": config})
@@ -1053,6 +1062,7 @@ def test_get_pipette_bounds_at_location(
                 },
                 shaft_ul_per_mm=5.0,
                 available_sensors=available_sensors,
+                volume_mode=VolumeClasses.default,
             )
         },
     )


### PR DESCRIPTION
# Overview

Closes AUTH-2317

This PR fixes a long-standing bug in the Python API code, where default flow rates would not correctly update in response to different capacity tips being picked up or volume mode being changed. Instead, the flow rates for the largest volume tip the pipette supported for the default volume mode would be applied, and would never change unless the user set a flow rate. These values were being correctly tracked and updated in Protocol Engine, but the correct values were never being accessed by the PAPI layer and therefore never actually being used.

Now we will use the accurate flow rates by default, which will now correctly change depending on what tip is attached and if the volume mode has been changed. This will stay true until the user sets a custom flow rate, in which case we will use that flow rate no matter what tip is used.

Flow rates however **will** be reset to use the defaults now when `configure_for_volume` is called, no matter if the volume made changes or not. This is what the documentation described it as doing and it now accurately does so.

Because of the volume mode flow rate resetting changes, and because the existing `_with_liquid_class` transfers unconditionally use `configure_for_volume` to ensure the pipette is in the correct mode before an aspirate, with the changes above the user would be guaranteed to lose any custom flow rates they set before (in current versions there was also a small bug where blow-out flow rate could be overwritten as well). To fix this, code has been added to restore the pipettes flow rates and volume mode to what it was before the liquid class transfer was called.

All of the above changes and fixes have been version gated to `2.26` and any previously buggy behavior has been maintained for any API versions below that.

## Test Plan and Hands on Testing

The following two protocols testing defaults updating and preserving flow rates after a transfer both pass analysis and run on a robot

```python
requirements = {
    "robotType": "Flex",
    "apiLevel": "2.26"
}

metadata = {
    "protocolName":'Flow rates tip selection test 2.26 fix',
    'author':'Jeremy'
}

def run(protocol_context):
    tiprack_50 = protocol_context.load_labware("opentrons_flex_96_tiprack_50ul", "C1")
    tiprack_200 = protocol_context.load_labware("opentrons_flex_96_tiprack_200ul", "C2")
    trash = protocol_context.load_trash_bin('A3')
    pipette_1000 = protocol_context.load_instrument("flex_1channel_1000", "left")
    pipette_50 = protocol_context.load_instrument("flex_1channel_50", "right")

    protocol_context.comment(
        f"P1000 default flow rate should be 716 µL/s, actual flow rate: {pipette_1000.flow_rate.aspirate} µL/s"
    )

    pipette_1000.pick_up_tip(tiprack_50)
    protocol_context.comment(
        f"P1000 default flow rate for 50 µL tip should be 478 µL/s, actual flow rate: {pipette_1000.flow_rate.aspirate} µL/s"
    )

    pipette_1000.drop_tip()
    protocol_context.comment(
        f"P1000 default flow rate should be 716 µL/s, actual flow rate: {pipette_1000.flow_rate.aspirate} µL/s"
    )

    pipette_1000.pick_up_tip(tiprack_200)
    protocol_context.comment(
        f"P1000 default flow rate for 200 µL tip  should be 716 µL/s, actual flow rate: {pipette_1000.flow_rate.aspirate} µL/s"
    )

    pipette_1000.drop_tip()
    protocol_context.comment(
        f"P1000 default flow rate should be 716 µL/s, actual flow rate: {pipette_1000.flow_rate.aspirate} µL/s"
    )

    pipette_1000.pick_up_tip(tiprack_50)
    protocol_context.comment(
        f"P1000 default flow rate for 50 µL tip should be 478 µL/s, actual flow rate: {pipette_1000.flow_rate.aspirate} µL/s"
    )
    pipette_1000.drop_tip()

    protocol_context.comment(
        f"P50 default flow rate should be 35 µL/s, actual flow rate: {pipette_50.flow_rate.aspirate} µL/s"
    )
    pipette_50.configure_for_volume(1)
    protocol_context.comment(
        f"P50 default low volume flow rate should be 26.7 µL/s, actual flow rate: {pipette_50.flow_rate.aspirate} µL/s"
    )
    pipette_50.configure_for_volume(50)
    protocol_context.comment(
        f"P50 default flow rate should be 35 µL/s, actual flow rate: {pipette_50.flow_rate.aspirate} µL/s"
    )
```

```python
requirements = {
    "robotType": "Flex",
    "apiLevel": "2.26"
}

metadata = {
    "protocolName":'Test transfer preserves flow rates and volume mode',
    'author':'Jeremy'
}

def run(protocol_context):
    tiprack_50 = protocol_context.load_labware("opentrons_flex_96_tiprack_50ul", "C1")
    trash = protocol_context.load_trash_bin('A3')
    pipette = protocol_context.load_instrument("flex_1channel_50", "left", tip_racks=[tiprack_50])
    water = protocol_context.get_liquid_class('water')

    plate = protocol_context.load_labware(
        load_name="opentrons_96_wellplate_200ul_pcr_full_skirt",
        location="C3"
    )

    pipette.configure_for_volume(1)
    pipette.flow_rate.aspirate = 20.1
    pipette.flow_rate.dispense = 20.2
    pipette.flow_rate.blow_out = 20.3

    assert pipette.max_volume == 30
    assert pipette.flow_rate.aspirate == 20.1
    assert pipette.flow_rate.dispense == 20.2
    assert pipette.flow_rate.blow_out == 20.3

    pipette.transfer_with_liquid_class(
        liquid_class=water,
        volume=50,
        source=[plate['A1']],
        dest=[plate['A2']],
        new_tip='always',
    )

    assert pipette.max_volume == 30
    assert pipette.flow_rate.aspirate == 20.1
    assert pipette.flow_rate.dispense == 20.2
    assert pipette.flow_rate.blow_out == 20.3
```

## Changelog

- use accurate default flow rates depending on tip size and volume mode for API versions 2.26 and above
- `configure_for_volume` now clears user-set flow rates for API versions 2.26 and above
- `transfer_with_liquid_class`, `distribute_with_liquid_class`, and `consolidate_with_liquid_class` preserve flow rates and volume mode used before it was called in API versions 2.26 and above

## Review requests


## Risk assessment

Medium, the flow rates are now more accurate but they will now be different in newer protocols that leave flow rates untouched. `configure_for_volume` is now also resetting flow rates when called which is another change in behavior that would lead to flow rates being different if a protocol's API version is updated.