### PR TITLE
fix(app,shared-data): Fix the position of a labware on a labware on a Stacker

### DIFF
--- a/shared-data/js/helpers/__tests__/positionMath.test.ts
+++ b/shared-data/js/helpers/__tests__/positionMath.test.ts
@@ -3,33 +3,82 @@ import { describe, expect, test } from 'vitest'
 import {
   computeLabwareOrigin,
   getAllDefinitions,
-  ot3StandardDeckV5,
+  getModuleDef,
+  ot3StandardDeckV5 as ot3StandardDeckV5Untyped,
 } from '../..'
 
+import type { DeckDefinition } from '../..'
+
+const OT3_DECK_DEF = (ot3StandardDeckV5Untyped as unknown) as DeckDefinition
+
 describe('computeLabwareOrigin()', () => {
-  test('legacy behavior of x and y when labware are stacked', () => {
-    // The adapter has a nonzero cornerOffsetFromSlot and the tip rack has a zero
-    // stackingOffsetWithLabware x and y. The x and y of the tip rack follow the
-    // x and y of the underlying slot, NOT of the adapter.
-    const adapter = getAllDefinitions()[
-      'opentrons/opentrons_flex_96_tiprack_adapter/1'
-    ]
-    const tipRack = getAllDefinitions()[
-      'opentrons/opentrons_flex_96_tiprack_1000ul/1'
-    ]
-    const result = computeLabwareOrigin({
-      labwareDefinitionsTopToBottom: [tipRack, adapter],
-      moduleDefinition: null,
-      slotId: 'A1',
-      deckDefinition: ot3StandardDeckV5 as any,
+  // Preserving legacy misbehavior:
+  // If we're computing the position of a schema 2 labware, the labware below
+  // it don't contribute anything to its x or y offset. Only z.
+  describe('legacy behavior of x and y when labware are stacked', () => {
+    test('where the base is a deck slot', () => {
+      // These test labware are chosen so the adapter has a nonzero cornerOffsetFromSlot,
+      // and the tip rack has a zero stackingOffsetWithLabware x and y.
+      //
+      // The remainder of this test will check that the final x and y of the tip rack
+      // follow the x and y of the underlying slot, NOT of the adapter.
+      const adapter = getAllDefinitions()[
+        'opentrons/opentrons_flex_96_tiprack_adapter/1'
+      ]
+      const tipRack = getAllDefinitions()[
+        'opentrons/opentrons_flex_96_tiprack_1000ul/1'
+      ]
+
+      const result = computeLabwareOrigin({
+        labwareDefinitionsTopToBottom: [tipRack, adapter],
+        moduleDefinition: null,
+        slotId: 'A1',
+        deckDefinition: OT3_DECK_DEF,
+      })
+      const expected = {
+        // x and y are the front-left of slot A1.
+        // z is on the surface of the adapter.
+        x: 0.0,
+        y: 321.0,
+        z: 11.0,
+      }
+      expect(result).toStrictEqual(expected)
     })
-    const expected = {
-      // x and y are the front-left of slot A1.
-      // z is on the surface of the adapter.
-      x: 0.0,
-      y: 321.0,
-      z: 11.0,
-    }
-    expect(result).toStrictEqual(expected)
+
+    test('where the base is a module', () => {
+      const stackerModuleDef = getModuleDef('flexStackerModuleV1')
+      const tipRackDef = getAllDefinitions()[
+        'opentrons/opentrons_flex_96_tiprack_1000ul/1'
+      ]
+      const lidDef = getAllDefinitions()[
+        'opentrons/opentrons_flex_tiprack_lid/1'
+      ]
+
+      const resultForTipRackAndLid = computeLabwareOrigin({
+        labwareDefinitionsTopToBottom: [lidDef, tipRackDef],
+        moduleDefinition: stackerModuleDef,
+        slotId: 'C3',
+        deckDefinition: OT3_DECK_DEF,
+      })
+      expect(resultForTipRackAndLid).toStrictEqual({
+        // todo(mm, 2025-09-17): These numbers seem wrong. Looks like an error in the module definition.
+        x: 489.125,
+        y: 105.875,
+        z: 66.425,
+      })
+
+      const resultForTipRackOnly = computeLabwareOrigin({
+        labwareDefinitionsTopToBottom: [tipRackDef],
+        moduleDefinition: stackerModuleDef,
+        slotId: 'C3',
+        deckDefinition: OT3_DECK_DEF,
+      })
+      expect(resultForTipRackOnly).toStrictEqual({
+        // todo(mm, 2025-09-17): These numbers seem wrong. Looks like an error in the module definition.
+        x: 489.125,
+        y: 105.875,
+        z: -18.325000000000003,
+      })
+    })
   })
 })

--- a/shared-data/js/helpers/positionMath.ts
+++ b/shared-data/js/helpers/positionMath.ts
@@ -127,6 +127,8 @@ export function computeLabwareOrigin(
     return null
   }
 
+  console.log(stack)
+
   const absolutePosition = getVectorSum(
     IDENTITY_VECTOR,
     ...stack.map(e => e.offset)
@@ -224,24 +226,17 @@ function getLabwareStackAsArray(
     })
   } else {
     // The bottom of the stack is a labware in a module in a deck slot.
-    const slotPositionTuple = getPositionFromSlotId(slotId, deckDefinition)
-    if (slotPositionTuple == null) {
+    const deckSlotPositionTuple = getPositionFromSlotId(slotId, deckDefinition)
+    if (deckSlotPositionTuple == null) {
       return null
     }
-    const slotPosition = coordinateTupleToVector3D(slotPositionTuple)
-    const slotPositionToLabwareOrigin = getModuleParentOriginToLabwareOrigin(
+    const deckSlotPosition = coordinateTupleToVector3D(deckSlotPositionTuple)
+    const deckSlotPositionToLabwareOrigin = getModuleParentOriginToLabwareOrigin(
       deckDefinition.otId,
       slotId,
       moduleDefinition,
       bottomLabware
     )
-    // Preserving legacy misbehavior:
-    // If we're computing the position of a schema 2 labware, the labware below
-    // it don't contribute anything to its x or y offset. Only z.
-    if (bottomLabware !== topLabware && topLabware.schemaVersion === 2) {
-      slotPositionToLabwareOrigin.x = 0
-      slotPositionToLabwareOrigin.y = 0
-    }
 
     result.push({
       debugInfo: {
@@ -249,7 +244,7 @@ function getLabwareStackAsArray(
         parentModuleDefinition: moduleDefinition,
         childLabwareDefinition: bottomLabware,
       },
-      offset: slotPositionToLabwareOrigin,
+      offset: deckSlotPositionToLabwareOrigin,
     })
     result.push({
       debugInfo: {
@@ -259,7 +254,7 @@ function getLabwareStackAsArray(
       },
       // Modules don't really have an origin of their own that's separate from the
       // origin of their parent deck slot.
-      offset: slotPosition,
+      offset: deckSlotPosition,
     })
   }
 

--- a/shared-data/js/helpers/positionMath.ts
+++ b/shared-data/js/helpers/positionMath.ts
@@ -127,8 +127,6 @@ export function computeLabwareOrigin(
     return null
   }
 
-  console.log(stack)
-
   const absolutePosition = getVectorSum(
     IDENTITY_VECTOR,
     ...stack.map(e => e.offset)


### PR DESCRIPTION
## Overview

Closes RQA-4673.

## Test Plan and Hands on Testing

* [x] Run the steps to reproduce in RQA-4673.

## Details

The bug is in code that I added in #19466 to preserve some legacy misbehavior, where we ignore x/y offsets from intermediate labware in a stack. I went a bridge too far and also ignored the x/y offsets from the *underlying module.* Oops.

## Review requests

None in particular.

## Risk assessment

Low. So far, this is only used by the "move labware" animated deck maps.
