### PR TITLE
chore(api): use our published numbers for the bounds on ramp rate

### DIFF
--- a/api/src/opentrons/protocol_engine/state/module_substates/thermocycler_module_substate.py
+++ b/api/src/opentrons/protocol_engine/state/module_substates/thermocycler_module_substate.py
@@ -24,9 +24,9 @@ from opentrons.hardware_control.modules import ModuleData, ModuleDataValidator
 
 ThermocyclerModuleId = NewType("ThermocyclerModuleId", str)
 
-# TODO(Ryan) add a real max heating and cooling rate
-MAX_HEATING_RATE = 100.0
-MAX_COOLING_RATE = 100.0
+# These are our published numbers, and from testing they are good bounds
+MAX_HEATING_RATE = 4.25
+MAX_COOLING_RATE = 2.0
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
# Overview
Tested the public facing numbers and they are good bounds on ramp rate, the machine does top out at those rates.
4.25 C/s heating, 2.0C/s cooling
