### PR TITLE
feat(app): update QT version to 2.0.0 to include py generation

### DIFF
--- a/app/src/organisms/ODD/QuickTransferFlow/README.md
+++ b/app/src/organisms/ODD/QuickTransferFlow/README.md
@@ -177,15 +177,15 @@ export interface QuickTransferSummaryState {
 
 Introduction of Python protocol generation starting in robot stack v8.7.0.
 
-The shape of the python file is as follows:
+The shape of the Python file is as follows:
 
 ```ts
-  imports
-  metadata
-  requirements
-  commands
+imports
+metadata
+requirements
+commands
 ```
 
-Note that the `designerApplicationData` is not included in the generating python, therefore, cloning/editing the generated protocol is currently not possible (which is never has been).
+Note that the `designerApplicationData` is not included in the generated Python, therefore, cloning/editing the generated protocol is currently not possible (which is never has been).
 
 You can still generate JSON behind a feature flag.

--- a/app/src/organisms/ODD/QuickTransferFlow/README.md
+++ b/app/src/organisms/ODD/QuickTransferFlow/README.md
@@ -175,6 +175,6 @@ export interface QuickTransferSummaryState {
 
 ## Version 2.0.0
 
-Introduction of python protocol generation starting in robot stack v8.7.0.
+Introduction of Python protocol generation starting in robot stack v8.7.0.
 
-You can still export JSON behind a feature flag.
+You can still generate JSON behind a feature flag.

--- a/app/src/organisms/ODD/QuickTransferFlow/README.md
+++ b/app/src/organisms/ODD/QuickTransferFlow/README.md
@@ -177,4 +177,15 @@ export interface QuickTransferSummaryState {
 
 Introduction of Python protocol generation starting in robot stack v8.7.0.
 
+The shape of the python file is as follows:
+
+```ts
+  imports
+  metadata
+  requirements
+  commands
+```
+
+Note that the `designerApplicationData` is not included in the generating python, therefore, cloning/editing the generated protocol is currently not possible (which is never has been).
+
 You can still generate JSON behind a feature flag.

--- a/app/src/organisms/ODD/QuickTransferFlow/README.md
+++ b/app/src/organisms/ODD/QuickTransferFlow/README.md
@@ -57,7 +57,7 @@ touchTipAspirate = -(sourceWellHeight - prevTouchTipAspirate)
 touchTipDispense = -(destWellHeight - prevTouchTipDispense)
 ```
 
-## [WIP] Version 1.2.0
+## Version 1.2.0
 
 Due to changes in the Quick Transfer setup flow, there will be changes to QuickTransferWizardState and QuickTransferSummaryState. The changes are as follows:
 the comment `this has been added` will be removed before feature freeze.
@@ -172,3 +172,9 @@ export interface QuickTransferSummaryState {
   liquidClassValuesInitialized: boolean // this has been added
 }
 ```
+
+## Version 2.0.0
+
+Introduction of python protocol generation starting in robot stack v8.7.0.
+
+You can still export JSON behind a feature flag.

--- a/app/src/organisms/ODD/QuickTransferFlow/utils/createQuickTransferFile.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/utils/createQuickTransferFile.ts
@@ -281,7 +281,7 @@ export function createQuickTransferPythonFile(
     source: 'Quick Transfer',
     //  TODO: increase version for when we export python
     //  see QuickTransferFlow/README.md for versioning details
-    version: '1.1.0',
+    version: '2.0.0',
     category: null,
     subcategory: null,
     tags: [],

--- a/app/src/organisms/ODD/QuickTransferFlow/utils/createQuickTransferFile.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/utils/createQuickTransferFile.ts
@@ -279,7 +279,6 @@ export function createQuickTransferPythonFile(
       protocolName ?? `Quick Transfer ${quickTransferState.volume}µL`,
     description: `This quick transfer moves liquids from a ${sourceLabwareName} to a ${destinationLabwareName}`,
     source: 'Quick Transfer',
-    //  TODO: increase version for when we export python
     //  see QuickTransferFlow/README.md for versioning details
     version: '2.0.0',
     category: null,


### PR DESCRIPTION
# Overview

Update QT version to 2.0.0 and add v2.0.0 in the readme. This is all for internal documentation purposes only since you can't export the python protocol without turning on a ff and typing something in console (for internal uses only)

## Test Plan and Hands on Testing

nothing to test, just review the changes

## Changelog

update readme and version number in generating protocol

## Risk assessment

low