### PR TITLE
feat(api): automatically use liquid tracking information in no other value is passed to set_block_temperature

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/well.py
+++ b/api/src/opentrons/protocol_api/core/engine/well.py
@@ -216,6 +216,14 @@ class WellCore(AbstractWellCore):
             labware_id=labware_id, well_name=well_name
         )
 
+    def has_tracked_liquid(self) -> bool:
+        """Return true if liquid has been loaded or probed."""
+        labware_id = self.labware_id
+        well_name = self._name
+        return self._engine_client.state.geometry.well_has_tracked_liquid(
+            labware_id=labware_id, well_name=well_name
+        )
+
     def get_liquid_volume(self) -> LiquidTrackingType:
         """Return the current volume in a well."""
         labware_id = self.labware_id

--- a/api/src/opentrons/protocol_api/core/legacy/legacy_well_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy/legacy_well_core.py
@@ -151,6 +151,10 @@ class LegacyWellCore(AbstractWellCore):
         """Return the volume contained in a well at any height."""
         return 0.0
 
+    def has_tracked_liquid(self) -> bool:
+        """Return true if liquid has been loaded or probed."""
+        return False
+
     # TODO(mc, 2022-10-28): is this used and/or necessary?
     def __repr__(self) -> str:
         """Use the well's display name as its repr."""

--- a/api/src/opentrons/protocol_api/core/well.py
+++ b/api/src/opentrons/protocol_api/core/well.py
@@ -112,5 +112,9 @@ class AbstractWellCore(ABC):
     def volume_from_height(self, height: LiquidTrackingType) -> LiquidTrackingType:
         """Return the volume contained in a well at any height."""
 
+    @abstractmethod
+    def has_tracked_liquid(self) -> bool:
+        """Return true if liquid has been loaded or probed."""
+
 
 WellCoreType = TypeVar("WellCoreType", bound=AbstractWellCore)

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -347,6 +347,11 @@ class Well:
         """Get the current liquid volume in a well."""
         return self._core.get_liquid_volume()
 
+    @requires_version(2, 27)
+    def has_tracked_liquid(self) -> bool:
+        """Get the current liquid volume in a well."""
+        return self._core.has_tracked_liquid()
+
     @requires_version(2, 24)
     def volume_from_height(self, height: LiquidTrackingType) -> LiquidTrackingType:
         """Return the volume contained in a well at any height."""

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -690,6 +690,10 @@ class ThermocyclerContext(ModuleContext):
         :param block_max_volume: The greatest volume of liquid contained in any
                                  individual well of the loaded labware, in µL.
                                  If not specified, the default is 25 µL.
+                                 After API version 2.27 it will attempt to use
+                                 the liquid tracking of the labware first and
+                                 then fall back to the 25 if there is no probed
+                                 or loaded liquid.
 
         .. note::
 
@@ -700,6 +704,8 @@ class ThermocyclerContext(ModuleContext):
         seconds = validation.ensure_hold_time_seconds(
             seconds=hold_time_seconds, minutes=hold_time_minutes
         )
+        if self._api_version >= APIVersion(2, 27) and block_max_volume is None:
+            block_max_volume = self._get_current_labware_max_vol()
         task = self._core.set_target_block_temperature(
             celsius=temperature,
             hold_time_seconds=seconds,
@@ -924,6 +930,19 @@ class ThermocyclerContext(ModuleContext):
     def current_step_index(self) -> Optional[int]:
         """Index of the current step within the current cycle"""
         return self._core.get_current_step_index()
+
+    def _get_current_labware_max_vol(self) -> Optional[float]:
+        max_vol: Optional[float] = None
+        if self.labware is not None:
+            for well in self.labware.wells():
+                if well.has_tracked_liquid():
+                    # make sure that max vol is a float first if we have liquid
+                    max_vol = 0.0 if max_vol is None else max_vol
+                    well_vol = well.current_liquid_volume()
+                    # ignore simulated probe results
+                    if isinstance(well_vol, float):
+                        max_vol = max(max_vol, well_vol)
+        return max_vol
 
 
 class HeaterShakerContext(ModuleContext):

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -1867,6 +1867,15 @@ class GeometryView:
         else:
             return initial_handling_height
 
+    def well_has_tracked_liquid(
+        self,
+        labware_id: str,
+        well_name: str,
+    ) -> bool:
+        """Returns true if this well has had a liquid loaded or a probe result."""
+        last_updated = self._wells.get_last_liquid_update(labware_id, well_name)
+        return last_updated is not None
+
     def get_current_well_volume(
         self,
         labware_id: str,

--- a/api/tests/opentrons/protocol_api/test_thermocycler_context.py
+++ b/api/tests/opentrons/protocol_api/test_thermocycler_context.py
@@ -387,7 +387,6 @@ def test_set_block_temperature_with_liquid_tracking(
             block_max_volume=42,
             ramp_rate=5.6,
         ),
-        mock_core.wait_for_block_temperature(),
         mock_broker.publish(
             "command",
             matchers.DictMatching(

--- a/api/tests/opentrons/protocol_api/test_thermocycler_context.py
+++ b/api/tests/opentrons/protocol_api/test_thermocycler_context.py
@@ -13,8 +13,13 @@ from opentrons.protocol_api import (
     ThermocyclerContext,
     validation as mock_validation,
 )
-from opentrons.protocol_api.core.common import ProtocolCore, ThermocyclerCore
+from opentrons.protocol_api.core.common import (
+    ProtocolCore,
+    ThermocyclerCore,
+    LabwareCore,
+)
 from opentrons.protocol_api.core.core_map import LoadedCoreMap
+from opentrons.protocol_api.labware import Labware, Well
 
 
 @pytest.fixture(autouse=True)
@@ -45,6 +50,18 @@ def mock_core_map(decoy: Decoy) -> LoadedCoreMap:
 def mock_broker(decoy: Decoy) -> LegacyBroker:
     """Get a mock command message broker."""
     return decoy.mock(cls=LegacyBroker)
+
+
+@pytest.fixture
+def mock_labware(decoy: Decoy) -> Labware:
+    """Get a mock command message broker."""
+    return decoy.mock(cls=Labware)
+
+
+@pytest.fixture
+def mock_well(decoy: Decoy) -> Well:
+    """Get a mock command message broker."""
+    return decoy.mock(cls=Well)
 
 
 @pytest.fixture
@@ -320,6 +337,69 @@ def test_set_block_temperature(
         assert result._api_version == api_version
     else:
         assert result is None
+
+
+def test_set_block_temperature_with_liquid_tracking(
+    decoy: Decoy,
+    mock_core: ThermocyclerCore,
+    mock_broker: LegacyBroker,
+    mock_labware: Labware,
+    mock_well: Well,
+    subject: ThermocyclerContext,
+) -> None:
+    """It should set the block temperature via the core."""
+    mock_labware_core = decoy.mock(cls=LabwareCore)
+    decoy.when(mock_well.has_tracked_liquid()).then_return(True)
+    decoy.when(mock_well.current_liquid_volume()).then_return(42.0)
+    decoy.when(mock_labware.wells()).then_return([mock_well])
+    decoy.when(subject._protocol_core.get_labware_on_module(mock_core)).then_return(
+        mock_labware_core
+    )
+    decoy.when(subject._core_map.get(mock_labware_core)).then_return(mock_labware)
+
+    decoy.when(
+        mock_validation.ensure_hold_time_seconds(seconds=1.2, minutes=3.4)
+    ).then_return(5.6)
+
+    subject.set_block_temperature(
+        temperature=42.0,
+        hold_time_seconds=1.2,
+        hold_time_minutes=3.4,
+        ramp_rate=5.6,
+    )
+
+    decoy.verify(
+        mock_broker.publish(
+            "command",
+            matchers.DictMatching(
+                {
+                    "$": "before",
+                    "name": "command.THERMOCYCLER_SET_BLOCK_TEMP",
+                    "payload": matchers.DictMatching(
+                        {"temperature": 42.0, "hold_time": 205.2}
+                    ),
+                }
+            ),
+        ),
+        mock_core.set_target_block_temperature(
+            celsius=42.0,
+            hold_time_seconds=5.6,
+            block_max_volume=42,
+            ramp_rate=5.6,
+        ),
+        mock_core.wait_for_block_temperature(),
+        mock_broker.publish(
+            "command",
+            matchers.DictMatching(
+                {
+                    "$": "after",
+                    "payload": matchers.DictMatching(
+                        {"temperature": 42.0, "hold_time": 205.2}
+                    ),
+                }
+            ),
+        ),
+    )
 
 
 def test_set_lid_temperature(


### PR DESCRIPTION
# Overview

We use the "max volume" argument in set_block_temperature to calculate the overshoot value we should use.

previously if nothing was provided it would default to 25ul. Now it will attempt to search through the wells of the labware inside the thermocycler and find the max value. If none of the wells have liquid information or there is no defined labware in the TC then it defaults back to the 25ul arg.
