### PR TITLE
(docs): revise autoclave-safe text in cleaning section

### DIFF
--- a/docs/flex/docs/maintenance/cleaning.md
+++ b/docs/flex/docs/maintenance/cleaning.md
@@ -204,5 +204,4 @@ To set up the Thermocycler with a clean seal:
 
 ## Autoclave safe labware
 
-Opentrons doesn't recommend re-using autoclaved labware with a Flex. The heat and pressure may cause it to warp or shrink, even if it's considered "autoclave safe." While autoclaved labware may be acceptable for quick, proof-of-concept testing, it's always better to use fresh labware for production runs, which helps ensure the best results. You can find and order Flex-compatible labware in the [Opentrons Labware Library](https://labware.opentrons.com/) and on the [Tips & Labware section](https://opentrons.com/products/categories/tips-&-labware) of our website.
-
+Opentrons doesn't recommend re-using autoclaved labware with a Flex. The heat and pressure may cause items to warp or shrink, even if they're considered "autoclave safe." While autoclaved labware may be acceptable for quick, proof-of-concept testing, it's always better to use fresh labware for production runs, which helps ensure the best results. You can find Flex-compatible labware in the [Opentrons Labware Library](https://labware.opentrons.com/) and on the [Tips & Labware section](https://opentrons.com/products/categories/tips-&-labware) of our website.

--- a/docs/flex/docs/maintenance/cleaning.md
+++ b/docs/flex/docs/maintenance/cleaning.md
@@ -202,41 +202,7 @@ To set up the Thermocycler with a clean seal:
 
 ![Location of the automation seal on the inside lid of the Thermocycler](../images/thermocycler-seal.svg "Thermocycler seal"){width="50%"}
 
-## Autoclave-safe labware
+## Autoclave safe labware
 
-The following table lists labware sold by Opentrons that we have verified as autoclave-safe. When you can't determine whether a piece of labware is autoclave-safe, just replace it with new, clean labware. You can [purchase replacement labware](https://opentrons.com/products/categories/tips-&-labware) from the Opentrons shop.
+Opentrons doesn't recommend re-using autoclaved labware with a Flex. The heat and pressure may cause it to warp or shrink, even if it's considered "autoclave safe." While autoclaved labware may be acceptable for quick, proof-of-concept testing, it's always better to use fresh labware for production runs, which helps ensure the best results. You can find and order Flex-compatible labware in the [Opentrons Labware Library](https://labware.opentrons.com/) and on the [Tips & Labware section](https://opentrons.com/products/categories/tips-&-labware) of our website.
 
-<table>
-  <thead>
-    <tr>
-      <th>Labware type</th>
-      <th>Autoclave-safe items</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><strong>Reservoirs</strong></td>
-      <td>NEST 1-well reservoirs</td>
-    </tr>
-    <tr>
-      <td><strong>Sample vials</strong></td>
-      <td>Eppendorf Safe-Lock 1.5 mL and 2.0 mL vials (when left open at 121 °C, 20 min)</td>
-    </tr>
-    <tr>
-      <td><strong>Tip racks and tips</strong></td>
-      <td>All Flex tip racks and tips</td>
-    </tr>
-    <tr>
-      <td><strong>Well plates</strong></td>
-      <td>
-        <ul>
-          <li>Thermo Scientific Nunc 96-Well Plate, 1300 μL</li>
-          <li>Thermo Scientific Nunc 96-Well Plate, 2000 μL</li>
-          <li>USA Scientific 96 Deep Well Plate, 2.4 mL</li>
-        </ul>
-      </td>
-    </tr>
-  </tbody>
-</table>
-
-If you're using labware from a manufacturer that's not listed here, refer to their website to see whether those items can be autoclaved.

--- a/docs/flex/docs/maintenance/cleaning.md
+++ b/docs/flex/docs/maintenance/cleaning.md
@@ -202,6 +202,6 @@ To set up the Thermocycler with a clean seal:
 
 ![Location of the automation seal on the inside lid of the Thermocycler](../images/thermocycler-seal.svg "Thermocycler seal"){width="50%"}
 
-## Autoclave safe labware
+## Autoclaving labware
 
 Opentrons doesn't recommend re-using autoclaved labware with a Flex. The heat and pressure may cause items to warp or shrink, even if they're considered "autoclave safe." While autoclaved labware may be acceptable for quick, proof-of-concept testing, it's always better to use fresh labware for production runs, which helps ensure the best results. You can find Flex-compatible labware in the [Opentrons Labware Library](https://labware.opentrons.com/) and on the [Tips & Labware section](https://opentrons.com/products/categories/tips-&-labware) of our website.


### PR DESCRIPTION
# Overview

This PR is prompted by a Slack conversation about labware. The recommendation here is to discourage the use of autoclaved plastic labware. This change to the cleaning section of the Flex manual attempts to address these concerns. See the Jira item linked below.

RTC-821

## Test Plan and Hands on Testing

Make sure links work and there are no unusual characters.

## Changelog

- Remove table of mfg certified labware.
- Replace with generic text that recommends always using fresh labware for production runs.
- Maybe also say autoclaved labware is ok for testing, but use new with a real protocol.
- Link to LL and Opentrons shop.
- Let's get out of the business of maintaining tables about other mfg labware.

## Review requests

Do these revisions seem reasonable? 
Another idea is to remove any mention of autoclaved labware completely.

## Risk assessment

Low, docs only.
