### PR TITLE
fix(app): fix tip positions in Quick Transfer

### DIFF
--- a/app/src/assets/localization/en/quick_transfer.json
+++ b/app/src/assets/localization/en/quick_transfer.json
@@ -92,6 +92,7 @@
   "failed_analysis": "failed analysis",
   "flow_rate_value": "{{flow_rate}} µL/s",
   "from_bottom": "Between 0 and {{max}} mm",
+  "from_top": "Between {{min}} and 2 mm",
   "got_it": "Got it",
   "grid": "grid",
   "grids": "grids",

--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/Retract.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/Retract.tsx
@@ -188,6 +188,7 @@ function RetractSettingComponent({
   const { t } = useTranslation(['quick_transfer'])
   const keyboardRef = useRef<KeyboardReactInterface | null>(null)
 
+  // TODO: accommodate arbitrary position reference
   const positionText =
     positionReference === POSITION_REFERENCE_TOP
       ? t('distance_top_of_well_mm')
@@ -219,7 +220,16 @@ function RetractSettingComponent({
       )
     )
   }
-  const positionRange = { min: 1, max: Math.floor(wellHeight * 2) }
+  const positionRange =
+    positionReference === POSITION_REFERENCE_TOP
+      ? {
+          min: -wellHeight,
+          max: Math.floor(wellHeight * 2),
+        }
+      : {
+          min: 0,
+          max: wellHeight + 2,
+        }
   const positionError =
     position != null &&
     (position < positionRange.min || position > positionRange.max)
@@ -326,6 +336,10 @@ function RetractSettingComponent({
   }
 
   const positionSetting = (): JSX.Element => {
+    const caption =
+      positionReference === POSITION_REFERENCE_TOP
+        ? t('from_top', { min: -wellHeight })
+        : t('from_bottom', { max: wellHeight + 2 })
     return (
       <>
         <Flex
@@ -344,7 +358,7 @@ function RetractSettingComponent({
           />
           {positionError == null ? (
             <StyledText oddStyle="bodyTextRegular" color={COLORS.grey60}>
-              {t('from_bottom', { max: positionRange.max })}
+              {caption}
             </StyledText>
           ) : null}
         </Flex>
@@ -358,6 +372,7 @@ function RetractSettingComponent({
             keyboardRef={keyboardRef}
             initialValue={String(position ?? '')}
             onChange={handlePositionChange}
+            hasHyphen={positionReference === POSITION_REFERENCE_TOP}
           />
         </Flex>
       </>

--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/Retract.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/Retract.tsx
@@ -55,8 +55,8 @@ export function Retract({
   const [delayDuration, setDelayDuration] = useState<number | null>(
     retractSettings?.delayDuration ?? null
   )
-  const [position, setPosition] = useState<number | null>(
-    retractSettings?.position ?? null
+  const [position, setPosition] = useState<string | null>(
+    String(retractSettings?.position) ?? null
   )
   const positionReference =
     kind === 'aspirate'
@@ -87,7 +87,7 @@ export function Retract({
             retractSettings: {
               speed,
               delayDuration,
-              position,
+              position: Number(position),
               positionReference: positionReference ?? undefined,
             },
           })
@@ -115,7 +115,7 @@ export function Retract({
   if (delayDuration == null && currentStep === 2) {
     buttonIsDisabled = true
   }
-  if (position == null && currentStep === 3) {
+  if ((position == null || isNaN(Number(position))) && currentStep === 3) {
     buttonIsDisabled = true
   }
 
@@ -164,11 +164,11 @@ interface RetractSettingComponentProps {
   kind: FlowRateKind
   state: QuickTransferSummaryState
   setSpeed: (speed: number | null) => void
-  setPosition: (position: number | null) => void
+  setPosition: (position: string | null) => void
   delayDuration: number | null
   setDelayDuration: (delayDuration: number | null) => void
   speed: number | null
-  position: number | null
+  position: string | null
   currentStep: number
   positionReference?: PositionReference
 }
@@ -232,7 +232,8 @@ function RetractSettingComponent({
         }
   const positionError =
     position != null &&
-    (position < positionRange.min || position > positionRange.max)
+    (Number(position) < positionRange.min ||
+      Number(position) > positionRange.max)
       ? t(`value_out_of_range`, {
           min: positionRange.min,
           max: positionRange.max,
@@ -261,8 +262,7 @@ function RetractSettingComponent({
     if (userInput === '') {
       setPosition(null)
     } else {
-      const parsedValue = Number(userInput)
-      setPosition(!isNaN(parsedValue) ? parsedValue : null)
+      setPosition(userInput)
     }
   }
 
@@ -350,7 +350,7 @@ function RetractSettingComponent({
           marginTop={SPACING.spacing68}
         >
           <InputField
-            type="number"
+            type="text"
             value={position}
             error={positionError}
             title={positionText}

--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/Retract.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/Retract.tsx
@@ -224,7 +224,7 @@ function RetractSettingComponent({
     positionReference === POSITION_REFERENCE_TOP
       ? {
           min: -wellHeight,
-          max: Math.floor(wellHeight * 2),
+          max: 2,
         }
       : {
           min: 0,

--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/Submerge.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/Submerge.tsx
@@ -224,12 +224,14 @@ function SubmergeSettingComponent({
     positionReference === POSITION_REFERENCE_TOP
       ? {
           min: -wellHeight,
-          max: Math.floor(wellHeight * 2),
+          max: 2,
         }
       : {
           min: 0,
           max: wellHeight + 2,
         }
+
+  console.log(positionRange)
   const positionError =
     position != null &&
     (Number(position) < positionRange.min ||

--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/Submerge.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/Submerge.tsx
@@ -55,8 +55,8 @@ export function Submerge({
   const [delayDuration, setDelayDuration] = useState<number | null>(
     submergeSettings?.delayDuration ?? null
   )
-  const [position, setPosition] = useState<number | null>(
-    submergeSettings?.position ?? null
+  const [position, setPosition] = useState<string | null>(
+    String(submergeSettings?.position) ?? null
   )
   const positionReference =
     kind === 'aspirate'
@@ -87,7 +87,7 @@ export function Submerge({
             submergeSettings: {
               speed,
               delayDuration,
-              position,
+              position: Number(position),
               positionReference: positionReference ?? undefined,
             },
           })
@@ -115,7 +115,7 @@ export function Submerge({
   if (delayDuration == null && currentStep === 2) {
     buttonIsDisabled = true
   }
-  if (position == null && currentStep === 3) {
+  if ((position == null || isNaN(Number(position))) && currentStep === 3) {
     buttonIsDisabled = true
   }
 
@@ -164,11 +164,11 @@ interface SubmergeSettingComponentProps {
   kind: FlowRateKind
   state: QuickTransferSummaryState
   setSpeed: (speed: number | null) => void
-  setPosition: (position: number | null) => void
+  setPosition: (position: string | null) => void
   delayDuration: number | null
   setDelayDuration: (delayDuration: number | null) => void
   speed: number | null
-  position: number | null
+  position: string | null
   currentStep: number
   positionReference?: PositionReference
 }
@@ -232,7 +232,8 @@ function SubmergeSettingComponent({
         }
   const positionError =
     position != null &&
-    (position < positionRange.min || position > positionRange.max)
+    (Number(position) < positionRange.min ||
+      Number(position) > positionRange.max)
       ? t(`value_out_of_range`, {
           min: positionRange.min,
           max: positionRange.max,
@@ -261,8 +262,7 @@ function SubmergeSettingComponent({
     if (userInput === '') {
       setPosition(null)
     } else {
-      const parsedValue = Number(userInput)
-      setPosition(!isNaN(parsedValue) ? parsedValue : null)
+      setPosition(userInput)
     }
   }
 
@@ -349,7 +349,7 @@ function SubmergeSettingComponent({
           marginTop={SPACING.spacing68}
         >
           <InputField
-            type="number"
+            type="text"
             value={position}
             error={positionError}
             title={positionText}

--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/Submerge.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/Submerge.tsx
@@ -188,6 +188,7 @@ function SubmergeSettingComponent({
   const { t } = useTranslation(['quick_transfer'])
   const keyboardRef = useRef<KeyboardReactInterface | null>(null)
 
+  // TODO: accommodate arbitrary position reference
   const positionText =
     positionReference === POSITION_REFERENCE_TOP
       ? t('distance_top_of_well_mm')
@@ -219,7 +220,16 @@ function SubmergeSettingComponent({
       )
     )
   }
-  const positionRange = { min: 1, max: Math.floor(wellHeight * 2) }
+  const positionRange =
+    positionReference === POSITION_REFERENCE_TOP
+      ? {
+          min: -wellHeight,
+          max: Math.floor(wellHeight * 2),
+        }
+      : {
+          min: 0,
+          max: wellHeight + 2,
+        }
   const positionError =
     position != null &&
     (position < positionRange.min || position > positionRange.max)
@@ -325,6 +335,10 @@ function SubmergeSettingComponent({
   }
 
   const positionSetting = (): JSX.Element => {
+    const caption =
+      positionReference === POSITION_REFERENCE_TOP
+        ? t('from_top', { min: -wellHeight })
+        : t('from_bottom', { max: wellHeight + 2 })
     return (
       <>
         <Flex
@@ -343,7 +357,7 @@ function SubmergeSettingComponent({
           />
           {positionError == null ? (
             <StyledText oddStyle="bodyTextRegular" color={COLORS.grey60}>
-              {t('from_bottom', { max: positionRange.max })}
+              {caption}
             </StyledText>
           ) : null}
         </Flex>
@@ -358,6 +372,7 @@ function SubmergeSettingComponent({
             keyboardRef={keyboardRef}
             initialValue={String(position ?? '')}
             onChange={handlePositionChange}
+            hasHyphen={positionReference === POSITION_REFERENCE_TOP}
           />
         </Flex>
       </>

--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/TipPosition.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/TipPosition.tsx
@@ -63,8 +63,9 @@ export function TipPositionEntry(props: TipPositionEntryProps): JSX.Element {
     )
   }
 
-  // the maxiumum allowed position is 2x the height of the well
-  const tipPositionRange = { min: 1, max: Math.floor(wellHeight * 2) } // TODO: set this based on range
+  // the maxiumum allowed position is 2mm above the height of the well
+  // this currently assumes bottom position reference
+  const tipPositionRange = { min: 1, max: Math.floor(wellHeight + 2) } // TODO: set this based on range
 
   const textEntryCopy: string = t('distance_bottom_of_well_mm')
   const tipPositionAction =

--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/__tests__/Retract.test.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/__tests__/Retract.test.tsx
@@ -80,7 +80,12 @@ describe('Retract', () => {
   })
 
   it('renders test, buttons, input field, and keyboard for retract after aspirating - position', () => {
-    render(props)
+    render({
+      ...props,
+      state: {
+        retractAspirate: { positionReference: 'well-bottom', position: 0 },
+      } as any,
+    })
     fireEvent.click(screen.getByRole('button', { name: '1' }))
     fireEvent.click(screen.getByRole('button', { name: '1' }))
     fireEvent.click(screen.getByText('Continue'))

--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/__tests__/Retract.test.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/__tests__/Retract.test.tsx
@@ -90,11 +90,11 @@ describe('Retract', () => {
     fireEvent.click(screen.getByRole('button', { name: '6' }))
     fireEvent.click(screen.getByText('Continue'))
     screen.getByText('Distance from bottom of well (mm)')
-    screen.getByText('Between 0 and 2 mm')
+    screen.getByText('Between 0 and 3 mm')
     fireEvent.click(screen.getByRole('button', { name: '2' }))
     fireEvent.click(screen.getByRole('button', { name: '2' }))
     fireEvent.click(screen.getByRole('button', { name: '2' }))
-    screen.getByText('Value must be between 1 to 2')
+    screen.getByText('Value must be between 0 to 3')
     screen.getByText('Save')
   })
   it('calls dispatch with correct action and settings when save is clicked', () => {

--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/__tests__/Submerge.test.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/__tests__/Submerge.test.tsx
@@ -67,7 +67,12 @@ describe('Submerge', () => {
   })
 
   it('renders text, buttons, input field, and keyboard for submerge before aspirating - position', () => {
-    render(props)
+    render({
+      ...props,
+      state: {
+        submergeAspirate: { positionReference: 'well-bottom', position: 0 },
+      } as any,
+    })
     fireEvent.click(screen.getByRole('button', { name: '1' }))
     fireEvent.click(screen.getByRole('button', { name: '1' }))
     fireEvent.click(screen.getByText('Continue'))

--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/__tests__/Submerge.test.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/__tests__/Submerge.test.tsx
@@ -84,11 +84,11 @@ describe('Submerge', () => {
     fireEvent.click(screen.getByText('Continue'))
     screen.getByText('Save')
     screen.getByText('Distance from bottom of well (mm)')
-    screen.getByText('Between 0 and 2 mm')
+    screen.getByText('Between 0 and 3 mm')
     fireEvent.click(screen.getByRole('button', { name: '2' }))
     fireEvent.click(screen.getByRole('button', { name: '2' }))
     fireEvent.click(screen.getByRole('button', { name: '2' }))
-    screen.getByText('Value must be between 1 to 2')
+    screen.getByText('Value must be between 0 to 3')
   })
 
   it('should call dispatch when clicking save button', () => {

--- a/app/src/organisms/ODD/QuickTransferFlow/__tests__/QuickTransferAdvancedSettings/TipPosition.test.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/__tests__/QuickTransferAdvancedSettings/TipPosition.test.tsx
@@ -131,7 +131,7 @@ describe('TipPosition', () => {
     expect(vi.mocked(InputField)).toHaveBeenCalledWith(
       {
         title: 'Distance from bottom of well (mm)',
-        error: 'Value must be between 1 to 100',
+        error: 'Value must be between 1 to 52',
         readOnly: true,
         type: 'text',
         value: 0,
@@ -154,7 +154,7 @@ describe('TipPosition', () => {
     expect(vi.mocked(InputField)).toHaveBeenCalledWith(
       {
         title: 'Distance from bottom of well (mm)',
-        error: 'Value must be between 1 to 400',
+        error: 'Value must be between 1 to 202',
         readOnly: true,
         type: 'text',
         value: 0,


### PR DESCRIPTION
# Overview

In Quick Transfer, fix the tip position ranges and captions for aspirate/dispense and submerge/retract, respecting position reference 

Closes RQA-4668
Closes RQA-4669

## Test Plan and Hands on Testing

- create a quick transfer protocol
- fill out the initial settings and land on advanced settings
- select "aspirate" tab > "tip position"
- enter a too-big number (1000) and verify that the error caption instructs you to enter a number between 0 and 2mm > the well depth
- save and select "submerge"
- continue to the third page for tip positioning
- verify that the if the position reference is from the top (as it is in every case currently), the range is (-1 * well depth) to 2mm
- repeat with dispense and retract

## Changelog

- update range calculations depending on position reference for submerge/retract
- fix maximum for aspirate/dispense (previously was 2x the well height, now is 2mm above well)
- add hyphen to keyboard for submerge/retract if position reference is from top (negatives are allowed)
- fix tests

## Review requests

see test plan

## Risk assessment

lowish