### PR TITLE
fix(app): Quick Transfer settings overview style

### DIFF
--- a/app/src/organisms/ODD/QuickTransferFlow/Overview.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/Overview.tsx
@@ -111,7 +111,7 @@ export function Overview(props: OverviewProps): JSX.Element | null {
         <ListItem type="default" key={displayItem.option} onClick={onClick}>
           <Flex justifyContent={JUSTIFY_SPACE_BETWEEN} width="100%">
             <StyledText
-              oddStyle="level4HeaderRegular"
+              oddStyle="level4HeaderSemiBold"
               width="20rem"
               whiteSpace={NO_WRAP}
             >


### PR DESCRIPTION
# Overview

Fixes the text style for overview settings in QuickTransfer (from regular -> semibold)

## Test Plan and Hands on Testing

- create or open a quick transfer protocl
- verify correct styling for overview settings items (level 4 header semibold)

## Changelog

- fix styling in settings

## Review requests

see test plan

## Risk assessment

⬇️ 