### PR TITLE
fix(app): pass in LABWAREV2_DO_NOT_LIST into QT

### DIFF
--- a/app/src/organisms/ODD/QuickTransferFlow/SelectTipRack.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/SelectTipRack.tsx
@@ -7,7 +7,10 @@ import {
   RadioButton,
   SPACING,
 } from '@opentrons/components'
-import { getAllDefinitions } from '@opentrons/shared-data'
+import {
+  getAllDefinitions,
+  LABWAREV2_DO_NOT_LIST,
+} from '@opentrons/shared-data'
 
 import { ChildNavigation } from '/app/organisms/ODD/ChildNavigation'
 
@@ -31,7 +34,7 @@ export function SelectTipRack(props: SelectTipRackProps): JSX.Element {
   const { onNext, onBack, exitButtonProps, state, dispatch } = props
   const { i18n, t } = useTranslation(['quick_transfer', 'shared'])
 
-  const allLabwareDefinition2sByUri = getAllDefinitions()
+  const allLabwareDefinition2sByUri = getAllDefinitions(LABWAREV2_DO_NOT_LIST)
   const selectedPipetteDefaultTipracks =
     state.pipette?.liquids.default.defaultTipracks ?? []
 


### PR DESCRIPTION
closes RQA-4685

# Overview

We weren't passing in the `LABWAREV2_DO_NOT_LIST` into the list of labware definitions grabbed by the tipracks for QT before. it didn't really matter before because the tipracks were also based off of the pipette's default tiprack list from the labware defs. but since the 20uL tips aren't being launched yet and are listed in the default tiprack list, they were accidentally showing up. so i passed in the whole `do_not` list as a result, since the `do_not` list should apply for all of the app's labware lists.

## Test Plan and Hands on Testing

Test QT with the low volume 96 channel. thats the only pipette where this tiprack would've shown up for.

## Changelog

add the `LABWAREV2_DO_NOT_LIST` to the QT's tiprack selection component

## Risk assessment

low