### PR TITLE
fix(protocol-designer): always show aspirate tip position button

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/SecondStepsMoveLiquidTools.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/SecondStepsMoveLiquidTools.tsx
@@ -314,7 +314,7 @@ export const SecondStepsMoveLiquidTools = ({
             />
           </>
         )}
-        {isDestinationTrash ? null : (
+        {isDestinationTrash && tab === 'dispense' ? null : (
           <>
             <Divider marginY="0" />
             <PositionField


### PR DESCRIPTION
# Overview

This PR fixes a bug wherein selecting trash for destination labware incorrectly hid tip position from aspirate advanced settings. In this case, we should only hide tip position from dispense settings.

Closes RQA-4686

## Test Plan and Hands on Testing

- create or open a transfer step form
- set the destination to be a trash or waste chute
- navigate to advanced settings
- in aspirate tab, verify that tip position button is present
- in dispense tab, verify that tip position button is _not_ present

## Changelog

- add dispense tab check when determining whether or not to render tip position button

## Review requests

see test plan

## Risk assessment

low