### PR TITLE
fix(step-generation): do not emit touchTip when blowout in touchTipDi…

### DIFF
--- a/step-generation/src/commandCreators/compound/distribute.ts
+++ b/step-generation/src/commandCreators/compound/distribute.ts
@@ -158,7 +158,9 @@ export const distribute: CommandCreator<DistributeArgs> = (
   const actionName = 'distribute'
   const errors: CommandCreatorError[] = []
   const isMultiChannelPipette = pipetteEntities[pipette]?.spec.channels !== 1
-
+  const isTouchTipDisabled = labwareEntities[
+    sourceLabware
+  ]?.def.parameters.quirks?.includes('touchTipDisabled')
   const aspirateAirGapVolume = args.aspirateAirGapVolume ?? 0
   const dispenseAirGapVolume = args.dispenseAirGapVolume ?? 0
   const disposalVolume =
@@ -1103,8 +1105,9 @@ export const distribute: CommandCreator<DistributeArgs> = (
                 },
               }),
               ...blowoutInPlaceCommand,
-              // touch tip at source well with dispense touch tip parameters
-              ...(touchTipAfterDispense
+              // touch tip at source well with source touch tip parameters
+              // only if source is touchTip-able
+              ...(touchTipAfterDispense && !isTouchTipDisabled
                 ? [
                     curryWithoutPython(touchTip, {
                       pipetteId: pipette,

--- a/step-generation/src/commandCreators/compound/transfer.ts
+++ b/step-generation/src/commandCreators/compound/transfer.ts
@@ -170,6 +170,10 @@ export const transfer: CommandCreator<TransferArgs> = (
     args.destLabware
   )
 
+  const isTouchTipDisabled = labwareEntities[
+    sourceLabware
+  ]?.def.parameters.quirks?.includes('touchTipDisabled')
+
   if (
     (trashOrLabware === 'labware' &&
       destWells != null &&
@@ -1079,8 +1083,9 @@ export const transfer: CommandCreator<TransferArgs> = (
                   },
                 }),
                 blowoutInPlaceCommand,
-                // touch tip at source well with dispense touch tip parameters
-                ...(touchTipAfterDispense
+                // touch tip at source well with source touch tip parameters
+                // only if source is touchTip-able
+                ...(touchTipAfterDispense && !isTouchTipDisabled
                   ? [
                       curryWithoutPython(touchTip, {
                         pipetteId: pipette,


### PR DESCRIPTION
…sabled source

closes RQA-4684

# Overview

We were touchtipping in a source labware that didn't allow touch tip if blow out was happening in the source. so this pr fixes it to not emit touch tip command for transfer and distribute. you can only test for transfer right now since there is a form bug for blow out 😢 

## Test Plan and Hands on Testing

test the steps in the ticket but also make sure the ff is turned on to emit JSON. it should pass analysis

## Changelog

disallow touchtip if the blowout is happening on a source that doesn't allow touchtip to match what python does

## Risk assessment

low
