### PR TITLE
feat(protocol-designer): fallback to waterV2 liquid class values for …

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/SecondStepsMoveLiquidTools.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/SecondStepsMoveLiquidTools.tsx
@@ -19,6 +19,7 @@ import {
   getMaxPushOutVolume,
   getMinXYDimension,
   NONE_LIQUID_CLASS_NAME,
+  WATER_LIQUID_CLASS_NAME_V2,
 } from '@opentrons/shared-data'
 import {
   getPipetteWithTipMaxVol,
@@ -105,7 +106,7 @@ export const SecondStepsMoveLiquidTools = ({
     [
       formData.liquidClass !== NONE_LIQUID_CLASS_NAME
         ? formData.liquidClass
-        : 'waterV1'
+        : WATER_LIQUID_CLASS_NAME_V2
     ].byPipette.find(
       ({ pipetteModel }) => pipetteModel === getFlexNameConversion(pipetteSpecs)
     )


### PR DESCRIPTION
…byVolume
# Overview

fixes a whitescreen in edge when making a transfer, as a result of 1) updating to v2 liquid class defs and 2) @ncdiehl11 's prototype pr to add the graphs visuals. this is a quick fix. i wanna refactor the liquid class util soon and we can just default to the latest version always here in the future. will work on that later today/next week

## Test Plan and Hands on Testing

shouldn't white screen when you make a transfer 

## Risk assessment

low
