### PR TITLE
fix(protocol-designer): handle missing pipette in pipetteTiprackAssignments

### DIFF
--- a/protocol-designer/src/step-forms/reducers/index.ts
+++ b/protocol-designer/src/step-forms/reducers/index.ts
@@ -1244,7 +1244,10 @@ export const pipetteInvariantProperties: Reducer<
           acc: NormalizedPipetteById,
           [id, pipetteLoadInfo]: [string, PipetteLoadInfo]
         ) => {
-          const tiprackDefURI = metadata.pipetteTiprackAssignments[id]
+          const tiprackDefURI = metadata.pipetteTiprackAssignments[id] ?? []
+          // If the pipette doesn't exist in the metadata.pipetteTiprackAssignments,
+          // then the protocol file is malformed, but there's nothing we can do about
+          // that, so just assign an empty tiprackDefURI to the pipette in that case.
 
           return {
             ...acc,


### PR DESCRIPTION
# Overview

`NormalizedPipetteById.tiprackDefURI` is supposed to be an array of tipracks. But in https://opentrons-76.sentry.io/issues/6835148279/events/92c51920d13e42f68c4a59586ca32716/?project=4509363266387968, we we crashing because `.tiprackDefURI` was **undefined** (rather than just being an empty array).

I scoured the code for how `.tiprackDefURI` could be set to `undefined`, and found only one potential place during `LOAD_FILE`:
https://github.com/Opentrons/opentrons/blob/ec8d0d6710d4dfee0b0a1335e584b89c270d499a/protocol-designer/src/step-forms/reducers/index.ts#L1247

In the protocol file, `designerApplication.pipetteTiprackAssignments` is supposed to contain an entry for every pipette ID. I suspect what's happening is that the pipette ID is simply missing in `pipetteTiprackAssignments` (perhaps because the user deleted the pipette, but we didn't completely eliminate all references to that pipette in `savedStepForms` or `commands`).

If that's the case, the protocol file is malformed, but there's nothing we can do about it. So this PR just defaults to an empty `tiprackDefURI` if the pipette ID does not exist in `pipetteTiprackAssignments`.

## Test Plan and Hands on Testing

Smoke-tested on local PD.

## Risk assessment

Low.