### PR TITLE
fix(app): blowout and disposal volume form fix

### DIFF
--- a/app/src/organisms/ODD/QuickTransferFlow/Dispense/hooks/useDispenseSettingsConfig.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/Dispense/hooks/useDispenseSettingsConfig.ts
@@ -32,7 +32,6 @@ export function useDispenseSettingsConfig({
 }: UseDispenseSettingsConfigProps): SettingItem[] {
   const { t, i18n } = useTranslation(['quick_transfer', 'shared'])
   const { makeSnackbar } = useToaster()
-  console.log('state', state.blowOutDispense)
   const getBlowoutValueCopy = (): string | undefined => {
     if (state.blowOutDispense == null) {
       return t('option_disabled')
@@ -184,7 +183,11 @@ export function useDispenseSettingsConfig({
           : i18n.format(getBlowoutValueCopy(), 'capitalize'),
       enabled: state.transferType !== 'distribute',
       onClick: () => {
-        setSelectedSetting('dispense_blow_out')
+        if (state.transferType === 'distribute') {
+          makeSnackbar(t('dispense_setting_disabled') as string)
+        } else {
+          setSelectedSetting('dispense_blow_out')
+        }
       },
     },
     {
@@ -204,7 +207,11 @@ export function useDispenseSettingsConfig({
           : t('option_disabled'),
       enabled: isMultiTransfer,
       onClick: () => {
-        setSelectedSetting('dispense_disposal_volume')
+        if (isMultiTransfer) {
+          setSelectedSetting('dispense_disposal_volume')
+        } else {
+          makeSnackbar(t('dispense_setting_disabled') as string)
+        }
       },
     },
     {

--- a/app/src/organisms/ODD/QuickTransferFlow/Dispense/hooks/useDispenseSettingsConfig.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/Dispense/hooks/useDispenseSettingsConfig.ts
@@ -1,3 +1,4 @@
+import { stat } from 'fs'
 import { useTranslation } from 'react-i18next'
 
 import {
@@ -32,7 +33,7 @@ export function useDispenseSettingsConfig({
 }: UseDispenseSettingsConfigProps): SettingItem[] {
   const { t, i18n } = useTranslation(['quick_transfer', 'shared'])
   const { makeSnackbar } = useToaster()
-
+  console.log('state', state.blowOutDispense)
   const getBlowoutValueCopy = (): string | undefined => {
     if (state.blowOutDispense == null) {
       return t('option_disabled')
@@ -179,23 +180,19 @@ export function useDispenseSettingsConfig({
       option: 'dispense_blow_out',
       copy: t('blow_out'),
       value:
-        state.transferType === 'distribute' && hasLiquidClass
+        state.transferType === 'distribute'
           ? t('disabled')
           : i18n.format(getBlowoutValueCopy(), 'capitalize'),
       enabled: state.transferType !== 'distribute',
       onClick: () => {
-        if (state.transferType === 'distribute') {
-          makeSnackbar(t('dispense_setting_disabled') as string)
-        } else {
-          setSelectedSetting('dispense_blow_out')
-        }
+        setSelectedSetting('dispense_blow_out')
       },
     },
     {
       option: 'dispense_disposal_volume',
       copy: t('disposal_volume'),
       value:
-        state.disposalVolumeDispenseSettings != null
+        state.disposalVolumeDispenseSettings != null && isMultiTransfer
           ? t('disposal_volume_label', {
               volume: state.disposalVolumeDispenseSettings.volume,
               location:
@@ -208,11 +205,7 @@ export function useDispenseSettingsConfig({
           : t('option_disabled'),
       enabled: isMultiTransfer,
       onClick: () => {
-        if (isMultiTransfer) {
-          setSelectedSetting('dispense_disposal_volume')
-        } else {
-          makeSnackbar(t('dispense_setting_disabled') as string)
-        }
+        setSelectedSetting('dispense_disposal_volume')
       },
     },
     {

--- a/app/src/organisms/ODD/QuickTransferFlow/Dispense/hooks/useDispenseSettingsConfig.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/Dispense/hooks/useDispenseSettingsConfig.ts
@@ -1,4 +1,3 @@
-import { stat } from 'fs'
 import { useTranslation } from 'react-i18next'
 
 import {


### PR DESCRIPTION
closes RQA-4687

# Overview

some fixes with consolidate and distribute.

For consolidate: disposal volume should be truly disabled, with the disabled copy, it was only CTA disabled.
For distribute: we are disabling blowout always since you can't not set a disposal volume. whether this is right or wrong behavior, changing disposal volume to not always be populated is i think too big of a scope for 8.7.0

## Test Plan and Hands on Testing

smoke test that a distribute doesn't allow a blow out- only in the disposal volume
smoke test that consolidate does allow a blow out but disposal volume field is always disabled.

## Changelog

fix fields accordingly

## Risk assessment

low