### PR TITLE
fix(protocol-designer): instrumentation to see why getMinXYDimension() is failing

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/SecondStepsMoveLiquidTools.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/SecondStepsMoveLiquidTools.tsx
@@ -170,11 +170,17 @@ export const SecondStepsMoveLiquidTools = ({
       formData.tipRack,
     ]
   )
+  const labwareId = formData[`${tab}_labware`]
+  // The getMinXYDimension() call below is crashing quite often, but I'm not sure why
+  if (!labwareEntities[labwareId]?.def) {
+    throw new Error(
+      `missing ${tab}_labware def for ${labwareId}, ` +
+        `in labwareEntities: ${!!labwareEntities[labwareId]}`
+    )
+  }
   const minXYDimension = isDestinationTrash
     ? null
-    : getMinXYDimension(labwareEntities[formData[`${tab}_labware`]]?.def, [
-        'A1',
-      ])
+    : getMinXYDimension(labwareEntities[labwareId]?.def, ['A1'])
   const minRadiusForTouchTip =
     minXYDimension != null ? round(minXYDimension / 2, 1) : null
 


### PR DESCRIPTION
# Overview

We have a long-outstanding PD crash when we try to call `getMinXYDimension()` in `SecondStepsMoveLiquidTools.tsx`, but I can't figure out why it's failing: https://opentrons-76.sentry.io/issues/6804827811/?project=4509363266387968

I'm not sure if it's because `formData['aspirate/dispense_labware']` is blank, or if the labware is not in `labwareEntities`, or if the labware is in `labwareEntities` but its `def` is missing for some reason.

This PR adds some instrumentation to try to catch the problem earlier, and give us more information about why it's failing.

## Test Plan and Hands on Testing

Ran PD locally.

## Risk assessment

Low.