### PR TITLE
fix(step-generation): ensure disposal + conditioning volume is aspirated in distribute

### DIFF
--- a/step-generation/src/commandCreators/compound/distribute.ts
+++ b/step-generation/src/commandCreators/compound/distribute.ts
@@ -106,7 +106,6 @@ export const distribute: CommandCreator<DistributeArgs> = (
     blowoutFlowRateUlSec,
     blowoutLocation,
     changeTip,
-    conditioningVolume,
     destLabware,
     destWells,
     dispenseDelay,
@@ -164,6 +163,10 @@ export const distribute: CommandCreator<DistributeArgs> = (
   const disposalVolume =
     args.disposalVolume != null && args.disposalVolume > 0
       ? args.disposalVolume
+      : 0
+  const conditioningVolume =
+    args.conditioningVolume != null && args.conditioningVolume > 0
+      ? args.conditioningVolume
       : 0
   // TODO: Ian 2019-04-19 revisit these pipetteDoesNotExist errors, how to do it DRY?
   if (
@@ -531,7 +534,8 @@ export const distribute: CommandCreator<DistributeArgs> = (
     destWellChunks,
     (destWellChunk: string[], chunkIndex: number): CurriedCommandCreator[] => {
       const numDestsPerAsp = destWellChunk.length // can differ on final chunk
-      const totalSampleAspirateVolume = volume * numDestsPerAsp
+      const totalSampleAspirateVolume =
+        volume * numDestsPerAsp + disposalVolume + conditioningVolume
       const isFirstChunk = chunkIndex === 0
       const isLastChunk = chunkIndex === destWellChunks.length - 1
       const changeTipNow =
@@ -763,9 +767,7 @@ export const distribute: CommandCreator<DistributeArgs> = (
           pipetteSpecs,
           tiprackDefUri: tipRack,
           targetVolume:
-            totalSampleAspirateVolume +
-            (disposalVolume ?? 0) +
-            (conditioningVolume ?? 0),
+            totalSampleAspirateVolume + disposalVolume + conditioningVolume,
           liquidHandlingAction: 'aspirate',
           byVolumeProperty: 'correctionByVolume',
           defaultValue: 0,
@@ -775,7 +777,7 @@ export const distribute: CommandCreator<DistributeArgs> = (
           liquidClass,
           pipetteSpecs,
           tiprackDefUri: tipRack,
-          targetVolume: conditioningVolume ?? 0,
+          targetVolume: conditioningVolume,
           liquidHandlingAction: 'multiDispense',
           byVolumeProperty: 'correctionByVolume',
           defaultValue: 0,
@@ -842,7 +844,7 @@ export const distribute: CommandCreator<DistributeArgs> = (
           } else if (
             !isFirstWellInChunk &&
             dispenseAirGapVolume > 0 &&
-            (conditioningVolume == null || conditioningVolume === 0)
+            conditioningVolume === 0
           ) {
             airGapInTip = dispenseAirGapVolume
             airGapDispenseFlowRate = dispenseAirGapDispenseFlowRate
@@ -999,11 +1001,7 @@ export const distribute: CommandCreator<DistributeArgs> = (
           ): CurriedCommandCreator[] =>
             dispenseAirGapVolume > 0 &&
             // don't air gap if not last well in chunk and conditioning volume is present
-            !(
-              wellIndex < destWellChunk.length - 1 &&
-              conditioningVolume != null &&
-              conditioningVolume > 0
-            ) &&
+            !(wellIndex < destWellChunk.length - 1 && conditioningVolume > 0) &&
             // don't air gap if end of full transfer and not changing tip
             !(
               changeTip === 'never' &&

--- a/step-generation/src/commandCreators/compound/distribute.ts
+++ b/step-generation/src/commandCreators/compound/distribute.ts
@@ -534,8 +534,9 @@ export const distribute: CommandCreator<DistributeArgs> = (
     destWellChunks,
     (destWellChunk: string[], chunkIndex: number): CurriedCommandCreator[] => {
       const numDestsPerAsp = destWellChunk.length // can differ on final chunk
-      const totalSampleAspirateVolume =
-        volume * numDestsPerAsp + disposalVolume + conditioningVolume
+      const totalSampleAspirateVolume = volume * numDestsPerAsp
+      const totalGrossAspirateVolume =
+        totalSampleAspirateVolume + disposalVolume + conditioningVolume
       const isFirstChunk = chunkIndex === 0
       const isLastChunk = chunkIndex === destWellChunks.length - 1
       const changeTipNow =
@@ -548,7 +549,7 @@ export const distribute: CommandCreator<DistributeArgs> = (
         ? [
             curryWithoutPython(configureForVolume, {
               pipetteId: pipette,
-              volume: totalSampleAspirateVolume,
+              volume: totalGrossAspirateVolume,
             }),
           ]
         : []
@@ -766,8 +767,7 @@ export const distribute: CommandCreator<DistributeArgs> = (
           liquidClass,
           pipetteSpecs,
           tiprackDefUri: tipRack,
-          targetVolume:
-            totalSampleAspirateVolume + disposalVolume + conditioningVolume,
+          targetVolume: totalGrossAspirateVolume,
           liquidHandlingAction: 'aspirate',
           byVolumeProperty: 'correctionByVolume',
           defaultValue: 0,
@@ -798,10 +798,7 @@ export const distribute: CommandCreator<DistributeArgs> = (
       const aspirateCommands = [
         curryWithoutPython(aspirateInPlace, {
           pipetteId: pipette,
-          volume:
-            totalSampleAspirateVolume +
-            (disposalVolume ?? 0) +
-            (conditioningVolume ?? 0),
+          volume: totalGrossAspirateVolume,
           flowRate: aspirateFlowRateUlSec,
           correctionVolume: aspirateCorrectionVolumeForTotalAspiration,
         }),


### PR DESCRIPTION
# Overview

This PR fixes a bug in JSON step generation in which disposal and conditioning volumes were not correctly aspirated with the sample volume.

## Test Plan and Hands on Testing

Since we exclusively export Python protocols in production, you can just check out diff in `distribute.ts`. To be thorough, you can export JSON (with feature flag turned on) and verify that a distribute using disposal/conditioning volume > 0, and check the aspiration command to ensure the full sample + disposal + conditioning volume is aspirated.

## Changelog

- add disposal and conditioning volume to aspiration command

## Review requests

see test plan

## Risk assessment

low