### PR TITLE
fix(protocol-designer): don't crash in volumeTooHigh() if tipRack is null

### DIFF
--- a/protocol-designer/src/steplist/formLevel/errors.ts
+++ b/protocol-designer/src/steplist/formLevel/errors.ts
@@ -764,6 +764,8 @@ export const volumeTooHigh = (
   const { pipette, tipRack } = fields
   if (!pipette || !tipRack) {
     // pipette is null if user deletes pipette
+    // I haven't been able to reproduce when tipRack alone becomes null, but it
+    // probably happens if the user deletes or changes the tip racks somehow.
     return null
   }
   const volume = Number(fields.volume)

--- a/protocol-designer/src/steplist/formLevel/errors.ts
+++ b/protocol-designer/src/steplist/formLevel/errors.ts
@@ -762,7 +762,7 @@ export const volumeTooHigh = (
   fields: HydratedMixFormData
 ): FormError | null => {
   const { pipette, tipRack } = fields
-  if (!pipette) {
+  if (!pipette || !tipRack) {
     // pipette is null if user deletes pipette
     return null
   }


### PR DESCRIPTION
# Overview

I have not been able to reproduce these PD crashes reported in Sentry:
- https://opentrons-76.sentry.io/issues/6867128274/?project=4509363266387968
- https://opentrons-76.sentry.io/issues/6867128191/?project=4509363266387968

But from the stack trace, they seem to be happening because we're calling `volumeTooHigh()` with a null `tipRack` from the form, which in turn calls `getPipetteCapacity()` and `getTiprackVolume()`, where we crash.

Note we previously fixed the crash in `volumeTooHigh()` caused by `pipette` being null (PR #19353), so we can fix the crash caused by `tipRack` being null in the same way.

## Test Plan and Hands on Testing

Smoke tested PD running locally.

## Risk assessment

Low.