### PR TITLE
fix(step-generation): delay args should be False when duration is 0

### DIFF
--- a/step-generation/src/utils/liquidClassUtils.ts
+++ b/step-generation/src/utils/liquidClassUtils.ts
@@ -51,13 +51,17 @@ export const getCustomLiquidClassProperties = (
     },
     flow_rate_by_volume: [[0, args.dispenseFlowRateUlSec ?? 0]],
     delay: {
-      enabled: args.dispenseDelay != null,
-      duration: args.dispenseDelay?.seconds ?? undefined,
+      enabled: !!args.dispenseDelay?.seconds,
+      ...(args.dispenseDelay?.seconds
+        ? { duration: args.dispenseDelay?.seconds }
+        : {}),
     },
     submerge: {
       delay: {
-        enabled: args.dispenseSubmergeDelay != null,
-        duration: args.dispenseSubmergeDelay?.seconds ?? undefined,
+        enabled: !!args.dispenseSubmergeDelay?.seconds,
+        ...(args.dispenseSubmergeDelay?.seconds
+          ? { duration: args.dispenseSubmergeDelay?.seconds }
+          : {}),
       },
       speed: args.dispenseSubmergeSpeed ?? undefined,
       start_position: {
@@ -72,8 +76,10 @@ export const getCustomLiquidClassProperties = (
     retract: {
       air_gap_by_volume: [[0, args.dispenseAirGapVolume ?? 0]],
       delay: {
-        enabled: args.dispenseRetractDelay != null,
-        duration: args.dispenseRetractDelay?.seconds ?? undefined,
+        enabled: !!args.dispenseRetractDelay?.seconds,
+        ...(args.dispenseRetractDelay?.seconds
+          ? { duration: args.dispenseRetractDelay?.seconds }
+          : {}),
       },
       end_position: {
         offset: {
@@ -127,8 +133,10 @@ export const getCustomLiquidClassProperties = (
           correction_by_volume: liquidClassValuesForTip?.aspirate
             .correctionByVolume ?? [[0, 0]], // nullish coalescing for type checks. Should never hit
           delay: {
-            enabled: args.aspirateDelay != null,
-            duration: args.aspirateDelay?.seconds ?? undefined,
+            enabled: !!args.aspirateDelay?.seconds,
+            ...(args.aspirateDelay?.seconds
+              ? { duration: args.aspirateDelay?.seconds }
+              : {}),
           },
           mix: {
             enabled: !!aspirateMixArgs?.volume,
@@ -141,8 +149,10 @@ export const getCustomLiquidClassProperties = (
           },
           submerge: {
             delay: {
-              enabled: args.aspirateSubmergeDelay != null,
-              duration: args.aspirateSubmergeDelay?.seconds ?? undefined,
+              enabled: !!args.aspirateSubmergeDelay?.seconds,
+              ...(args.aspirateSubmergeDelay?.seconds
+                ? { duration: args.aspirateSubmergeDelay?.seconds }
+                : {}),
             },
             speed: args.aspirateSubmergeSpeed ?? undefined,
             start_position: {
@@ -157,8 +167,10 @@ export const getCustomLiquidClassProperties = (
           retract: {
             air_gap_by_volume: [[0, args.aspirateAirGapVolume ?? 0]],
             delay: {
-              enabled: args.aspirateRetractDelay != null,
-              duration: args.aspirateRetractDelay?.seconds ?? undefined,
+              enabled: !!args.aspirateRetractDelay?.seconds,
+              ...(args.aspirateRetractDelay?.seconds
+                ? { duration: args.aspirateRetractDelay?.seconds }
+                : {}),
             },
             end_position: {
               offset: {


### PR DESCRIPTION
closes RQA-4691

# Overview

QT generates the delay fields as delay.seconds = 0, but in the `generateCustomLiquidClassProperties()`, we were generating the delays as all `True` by default with the seconds as `0`. Nothing was technically causing issues i don't think but this cleans that up so they're all populated as `False` when the seconds is `0`.

## Test Plan and Hands on Testing

Check the generated code with this change, it should populate all the `delays` as `False` by default in QT and PD too

## Changelog

type protection a bit better by only populating as enabled if seconds is not falsey.

## Risk assessment

low