### PR TITLE
docs: stacker-hepa-upgrade

### DIFF
--- a/docs/stacker/docs/compliance.md
+++ b/docs/stacker/docs/compliance.md
@@ -154,6 +154,9 @@ You can install and use Stackers with the [Opentrons Flex HEPA/UV Module](https:
 
 Flex robots manufactured before September 2025 require an upgrade kit. This kit adds new hardware to your Flex, preventing the HEPA/UV module from operating if the Stacker is improperly installed.
 
+!!!note
+    The upgrade kit must be installed by an Opentrons field service technician only.
+
 Refer to your robot's serial number to determine if an upgrade is required. Robots with a version identifier of A30 or higher are compatible with the Stacker and the HEPA/UV Module without the kit. For example, serial number FLX**A30**20250902003 indicates HEPA/UV compatibility, whereas robots with A20 or A10 version identifiers require an upgrade.
 
 ![Flex serial number](images/serial-number-cropped2.png){width="50%"}


### PR DESCRIPTION
# Overview

Stacker instruction manual indicates some Stackers need an upgrade to work with the HEPA module. However, the info is unclear about _who_ performs the upgrade/installs the kit.

Update Stacker manual to clearly indicate installing the upgrade kit is an Opentrons technician function only. Users are not expected to, and shouldn't, install the kit.

Flex manual already includes this and does not require a change.

RTC-852

## Test Plan and Hands on Testing

Read it to make sure this makes sense.

## Changelog

Adds a `note` callout to the Stacker compatibility section in `compliance.md`.

> The upgrade kit must be installed by an Opentrons field service technician only.

## Review requests

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment

Low, docs only.