### PR TITLE
fix(app): refine when changing path to single in QT

### DIFF
--- a/app/src/organisms/ODD/QuickTransferFlow/__tests__/utils/getInitialSummaryState.test.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/__tests__/utils/getInitialSummaryState.test.ts
@@ -76,11 +76,14 @@ describe('getInitialSummaryState', () => {
       ...props,
       state: {
         ...props.state,
+        volume: 1,
+        path: 'multiAspirate',
         transferType: 'consolidate',
       },
     })
     expect(initialSummaryState).toEqual({
       ...props.state,
+      volume: 1,
       transferType: 'consolidate',
       aspirateFlowRate: 50,
       dispenseFlowRate: 75,
@@ -126,13 +129,14 @@ describe('getInitialSummaryState', () => {
       ...props,
       state: {
         ...props.state,
-        volume: 10,
+        volume: 1,
+        path: 'multiDispense',
         transferType: 'distribute',
       },
     })
     expect(initialSummaryState).toEqual({
       ...props.state,
-      volume: 10,
+      volume: 1,
       transferType: 'distribute',
       aspirateFlowRate: 50,
       dispenseFlowRate: 75,
@@ -145,7 +149,7 @@ describe('getInitialSummaryState', () => {
         cutoutId: 'cutoutA3',
         cutoutFixtureId: 'trashBinAdapter',
       },
-      disposalVolume: 10,
+      disposalVolume: 1,
       blowOutDispense: {
         location: { cutoutId: 'cutoutA3', cutoutFixtureId: 'trashBinAdapter' },
         flowRate: 75,

--- a/app/src/organisms/ODD/QuickTransferFlow/utils/getInitialSummaryState.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/utils/getInitialSummaryState.ts
@@ -59,17 +59,21 @@ export function getInitialSummaryState(
   let path: PathOption = state.path
   // for multiDispense the volume capacity must be at least 3x the volume per well
   // to account for the 1x volume per well disposal volume default
+  // otherwise, we set the path to single
   if (
     state.transferType === 'distribute' &&
-    maxTipCapacity >= state.volume * 3
+    maxTipCapacity < state.volume * 3 &&
+    state.path === 'multiDispense'
   ) {
-    path = 'multiDispense'
+    path = 'single'
     // for multiAspirate the volume capacity must be at least 2x the volume per well
+    // otherwise, we set the path to single
   } else if (
     state.transferType === 'consolidate' &&
-    maxTipCapacity >= state.volume * 2
+    maxTipCapacity < state.volume * 2 &&
+    state.path === 'multiAspirate'
   ) {
-    path = 'multiAspirate'
+    path = 'single'
   }
 
   const trashConfigCutout = deckConfig.find(


### PR DESCRIPTION
closes RQA-4690
# Overview

This fixes a bug in QT that i believe has been there for the past 14 months. Before, we were setting the path for `multiDispense` and `multiAspirate` based off of if the tip volume could handle 3 (or 2 for consoidate) of the transfer volume sizes. But that meant that if the user selected "single transfer" instead of a "distribute" for instance, the command generated would incorreclty be a `distribute`. Then this meant that if the tip change frequency was `per dest` which doesn't exist for a distribute, it would not generate the command and error in protocol analysis. The same pattern was true for a consolidate and `per source`. So i fixed it by refining the logic a bit.

## Test Plan and Hands on Testing

Look at the bug ticket but basically, choose 1 well for source and 2 wells for dest and choose "single transfer" instead of "distribute" and choose "per dest" for the tip frequency. you should be able to successfully make the protocol with no analysis errors.

## Changelog

be more deliberate about when to assign path multiDispense, multiAspirate, single

## Risk assessment

low
