### PR TITLE
fix(protocol-designer): default null aspirate & dispense offsets to 1 in migration

### DIFF
--- a/protocol-designer/src/load-file/migration/8_5_0.ts
+++ b/protocol-designer/src/load-file/migration/8_5_0.ts
@@ -18,6 +18,7 @@ import { getTransferPlanAndReferenceVolumes } from '@opentrons/step-generation'
 
 import {
   CHANNELS_MAPPED_TO_MAX_SPEED,
+  DEFAULT_MM_OFFSET_FROM_BOTTOM,
   DEFAULT_MM_TOUCH_TIP_OFFSET_FROM_EDGE,
   PROTOCOL_DESIGNER_SOURCE,
 } from '../../constants'
@@ -238,6 +239,8 @@ export const migrateFile = (
         aspirate_delay_mmFromBottom,
         dispense_delay_mmFromBottom,
         blowout_z_offset,
+        aspirate_mmFromBottom,
+        dispense_mmFromBottom,
         ...rest
       } = form
       const aspirateLabwareUri = labware[aspirate_labware].labwareDefURI
@@ -330,6 +333,14 @@ export const migrateFile = (
         [id]: {
           ...rest,
           id,
+          aspirate_mmFromBottom:
+            aspirate_mmFromBottom !== 0
+              ? aspirate_mmFromBottom
+              : DEFAULT_MM_OFFSET_FROM_BOTTOM,
+          dispense_mmFromBottom:
+            dispense_mmFromBottom !== 0
+              ? dispense_mmFromBottom
+              : DEFAULT_MM_OFFSET_FROM_BOTTOM,
           aspirate_labware,
           dispense_labware,
           aspirate_touchTip_checkbox: isAspirateLabwareTouchtipDisabled

--- a/protocol-designer/src/load-file/migration/8_6_0.ts
+++ b/protocol-designer/src/load-file/migration/8_6_0.ts
@@ -1,3 +1,5 @@
+import { DEFAULT_MM_OFFSET_FROM_BOTTOM } from '/protocol-designer/constants'
+
 import type { ProtocolFile } from '@opentrons/shared-data'
 import type { PDMetadata } from '/protocol-designer/file-types'
 import type { DesignerApplicationData } from './utils/getLoadLiquidCommands'
@@ -20,25 +22,47 @@ export const migrateFile = (
   const savedStepForms = designerApplication.data
     ?.savedStepForms as DesignerApplicationData['savedStepForms']
 
-  const savedStepsWithUpdatedHeaterShakerTimerField = Object.values(
-    savedStepForms
-  ).reduce((acc, form) => {
-    if (form.stepType === 'heaterShaker') {
-      const { id, heaterShakerTimer } = form
+  const savedStepsWithUpdatedFields = Object.values(savedStepForms).reduce(
+    (acc, form) => {
+      //  introduction of allowing hours to heater-shaker timer field
+      if (form.stepType === 'heaterShaker') {
+        const { id, heaterShakerTimer } = form
 
-      return {
-        ...acc,
-        [id]: {
-          ...form,
-          heaterShakerTimer:
-            heaterShakerTimer != null
-              ? getNormalizedTime(heaterShakerTimer as string)
-              : null,
-        },
+        return {
+          ...acc,
+          [id]: {
+            ...form,
+            heaterShakerTimer:
+              heaterShakerTimer != null
+                ? getNormalizedTime(heaterShakerTimer as string)
+                : null,
+          },
+        }
       }
-    }
-    return acc
-  }, {})
+      //  fixes a bug where the aspirate/dispense z-offset in the commands was
+      //  defaulting to 1mm but the form fields were null
+      if (form.stepType === 'moveLiquid') {
+        const { id, aspirate_mmFromBottom, dispense_mmFromBottom } = form
+
+        return {
+          ...acc,
+          [id]: {
+            ...form,
+            aspirate_mmFromBottom:
+              aspirate_mmFromBottom != null && aspirate_mmFromBottom !== 0
+                ? aspirate_mmFromBottom
+                : DEFAULT_MM_OFFSET_FROM_BOTTOM,
+            dispense_mmFromBottom:
+              dispense_mmFromBottom != null && dispense_mmFromBottom !== 0
+                ? dispense_mmFromBottom
+                : DEFAULT_MM_OFFSET_FROM_BOTTOM,
+          },
+        }
+      }
+      return acc
+    },
+    {}
+  )
 
   return {
     ...appData,
@@ -48,7 +72,7 @@ export const migrateFile = (
         ...designerApplication.data,
         savedStepForms: {
           ...designerApplication.data.savedStepForms,
-          ...savedStepsWithUpdatedHeaterShakerTimerField,
+          ...savedStepsWithUpdatedFields,
         },
       },
     },

--- a/protocol-designer/src/load-file/migration/8_6_0.ts
+++ b/protocol-designer/src/load-file/migration/8_6_0.ts
@@ -49,11 +49,11 @@ export const migrateFile = (
           [id]: {
             ...form,
             aspirate_mmFromBottom:
-              aspirate_mmFromBottom != null && aspirate_mmFromBottom !== 0
+              aspirate_mmFromBottom != null
                 ? aspirate_mmFromBottom
                 : DEFAULT_MM_OFFSET_FROM_BOTTOM,
             dispense_mmFromBottom:
-              dispense_mmFromBottom != null && dispense_mmFromBottom !== 0
+              dispense_mmFromBottom != null
                 ? dispense_mmFromBottom
                 : DEFAULT_MM_OFFSET_FROM_BOTTOM,
           },

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/moveLiquidFormToArgs.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/moveLiquidFormToArgs.ts
@@ -353,13 +353,11 @@ export const moveLiquidFormToArgs = (
     nozzles,
     aspirateXOffset: aspirate_x_position ?? 0,
     aspirateYOffset: aspirate_y_position ?? 0,
-    aspirateZOffset:
-      hydratedFormData.aspirate_mmFromBottom ?? DEFAULT_MM_OFFSET_FROM_BOTTOM,
+    aspirateZOffset: hydratedFormData.aspirate_mmFromBottom ?? 0,
     aspiratePositionReference: hydratedFormData.aspirate_position_reference,
     dispenseXOffset: dispense_x_position ?? 0,
     dispenseYOffset: dispense_y_position ?? 0,
-    dispenseZOffset:
-      hydratedFormData.dispense_mmFromBottom ?? DEFAULT_MM_OFFSET_FROM_BOTTOM,
+    dispenseZOffset: hydratedFormData.dispense_mmFromBottom ?? 0,
     dispensePositionReference: hydratedFormData.dispense_position_reference,
     aspirateSubmergeSpeed: hydratedFormData.aspirate_submerge_speed ?? null,
     aspirateSubmergeXOffset: hydratedFormData.aspirate_submerge_x_position ?? 0,

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/moveLiquidFormToArgs.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/moveLiquidFormToArgs.ts
@@ -353,11 +353,13 @@ export const moveLiquidFormToArgs = (
     nozzles,
     aspirateXOffset: aspirate_x_position ?? 0,
     aspirateYOffset: aspirate_y_position ?? 0,
-    aspirateZOffset: hydratedFormData.aspirate_mmFromBottom ?? 0,
+    aspirateZOffset:
+      hydratedFormData.aspirate_mmFromBottom ?? DEFAULT_MM_OFFSET_FROM_BOTTOM,
     aspiratePositionReference: hydratedFormData.aspirate_position_reference,
     dispenseXOffset: dispense_x_position ?? 0,
     dispenseYOffset: dispense_y_position ?? 0,
-    dispenseZOffset: hydratedFormData.dispense_mmFromBottom ?? 0,
+    dispenseZOffset:
+      hydratedFormData.dispense_mmFromBottom ?? DEFAULT_MM_OFFSET_FROM_BOTTOM,
     dispensePositionReference: hydratedFormData.dispense_position_reference,
     aspirateSubmergeSpeed: hydratedFormData.aspirate_submerge_speed ?? null,
     aspirateSubmergeXOffset: hydratedFormData.aspirate_submerge_x_position ?? 0,


### PR DESCRIPTION
closes AUTH-2346

# Overview

This is a continuation of this fix: https://github.com/Opentrons/opentrons/pull/19650
But basically, we needed to fix 2 migrations:

1. `8.5.0` -> so users who purposefully set `0` but then step-generation generated `1` for the z-offsets. We are fixing it so it is converted to 1, to match the commands.
2. `8.6.0` -> users who somehow have `null` values are converted to `1` for the z-offsets.

## Test Plan and Hands on Testing

Review the code and test for yourself too. there is a lid bug in edge rn though that we need to fix before you can smoke test the protocol

## Changelog

migrate the fields if `0` or `null` in the 2 migrations

## Risk assessment

low
