### PR TITLE
fix(hardware-testing): use up to date motion speed references.

### DIFF
--- a/hardware-testing/hardware_testing/gravimetric/protocol_replacement/gravimetric.py
+++ b/hardware-testing/hardware_testing/gravimetric/protocol_replacement/gravimetric.py
@@ -863,9 +863,14 @@ def override_retract_discontinuity(fixture_settings: FixtureSettings) -> None:
     if _should_alter_discontinuity(fixture_settings):
         hw_api = fixture_settings.ctx._core.get_hardware()
         if fixture_settings.pipette_channels == 96:
-            hw_api.config.motion_settings.max_speed_discontinuity.high_throughput[
-                OT3AxisKind.Z
-            ] = fixture_settings.retract_discontinuity
+            if fixture_settings.pipette_volume == 200:
+                hw_api.config.motion_settings.max_speed_discontinuity.high_throughput_200[
+                    OT3AxisKind.Z
+                ] = fixture_settings.retract_discontinuity
+            else:
+                hw_api.config.motion_settings.max_speed_discontinuity.high_throughput_1000[
+                    OT3AxisKind.Z
+                ] = fixture_settings.retract_discontinuity
         else:
             hw_api.config.motion_settings.max_speed_discontinuity.low_throughput[
                 OT3AxisKind.Z


### PR DESCRIPTION
# Overview
I didn't change the references to 'high_throughput' to 'high_throughput_200' or 'high_throughput_1000' everywhere and since it's gated behind pipette serials and therefor can't run during simulate this led to a runtime only bug.