### PR TITLE
feat(opentrons-ai-server): update prompts

### DIFF
--- a/opentrons-ai-server/api/domain/config_anthropic.py
+++ b/opentrons-ai-server/api/domain/config_anthropic.py
@@ -316,9 +316,9 @@ Follow these instructions to handle the user's prompt:
    as a reference to generate a basic protocol. For serial dilution please refer to <source>serial_dilution_examples.md</source>.
 
 8. If the request is to update the protocol by giving the type of update, then follow the instructions.
-   For example, for adding runtime parameters to a PD-produced Python protocol, do not replace 
-   transfer() by transfer_with_liquid_class() vice versa. You should not do it unless the customer 
-   explicitly asks for it. 
+   For example, for adding runtime parameters to a PD-produced Python protocol, do not replace
+   transfer() by transfer_with_liquid_class() vice versa. You should not do it unless the customer
+   explicitly asks for it.
 
 9. Remember to use the information provided in order: first read any uploaded files (PDFs, CSVs, Python scripts),
 then use the get_relevant_api_docs tool if needed for API-specific information, then refer to <document></document>.

--- a/opentrons-ai-server/api/domain/config_anthropic.py
+++ b/opentrons-ai-server/api/domain/config_anthropic.py
@@ -93,7 +93,7 @@ Follow these instructions to handle the user's prompt:
     - A tool calling. If a user calls simulate protocol explicity, then call.
     - A greeting. Respond kindly.
     - A protocol type (e.g., serial dilution, before generation see <source>serial_dilution_examples.md</source> in <document>
-
+    - A request to update the protocol e.g., add runtime parameters
     Note: when you respond you do not need mention the category or the type.
 
     <Tool Usage Guidelines>:
@@ -315,8 +315,12 @@ Follow these instructions to handle the user's prompt:
 7. If the request lacks sufficient information to generate a protocol, use <source> casual_examples.md </source>
    as a reference to generate a basic protocol. For serial dilution please refer to <source>serial_dilution_examples.md</source>.
 
+8. If the request is to update the protocol by giving the type of update, then follow the instructions.
+   For example, for adding runtime parameters to a PD-produced Python protocol, do not replace 
+   transfer() by transfer_with_liquid_class() vice versa. You should not do it unless the customer 
+   explicitly asks for it. 
 
-8. Remember to use the information provided in order: first read any uploaded files (PDFs, CSVs, Python scripts),
+9. Remember to use the information provided in order: first read any uploaded files (PDFs, CSVs, Python scripts),
 then use the get_relevant_api_docs tool if needed for API-specific information, then refer to <document></document>.
 Do not introduce any external information or assumptions.
 


### PR DESCRIPTION

# Overview

Closes AUTH-2269

When adding runtime parameters to a PD-produced Python protocol, OpentronsAI simplified the protocol by using transfer() instead of transfer_with_liquid_class(). We shouldn’t have OpentronsAI do this unless the customer explicitly asks for it. 



## Review requests
- Create a Flex protocol using PD
- Then upload to OpentronsAI and Select Add Runtime Parameters
<img width="867" height="665" alt="image" src="https://github.com/user-attachments/assets/10dd3268-7756-4034-9563-803982b046bb" />
- You should see the generated protocol with runtime parameters.


## Risk assessment

Low