### PR TITLE
feat(protocol-designer): add release note for z position updates

### DIFF
--- a/protocol-designer/release-notes.md
+++ b/protocol-designer/release-notes.md
@@ -19,6 +19,7 @@ This hotfix release addresses several bugs.
 - Set a custom aspirate tip position for any dispense location.
 - Protocol Designer correctly reassigns default tip settings when changing pipettes in your protocol.
 - Protocol Designer no longer crashes when encountering missing tip rack errors in imported protocols.
+- Protocol Designer uses default aspirate and dispense tip position of 1mm above the bottom of the well if you don't specify a position.
 
 ## Opentrons Protocol Designer Changes in 8.5.3
 

--- a/protocol-designer/release-notes.md
+++ b/protocol-designer/release-notes.md
@@ -19,7 +19,7 @@ This hotfix release addresses several bugs.
 - Set a custom aspirate tip position for any dispense location.
 - Protocol Designer correctly reassigns default tip settings when changing pipettes in your protocol.
 - Protocol Designer no longer crashes when encountering missing tip rack errors in imported protocols.
-- Protocol Designer uses default aspirate and dispense tip position of 1mm above the bottom of the well if you don't specify a position.
+- Aspirate and dispense tip positions default to 1 mm above the well bottom if unspecified in your protocols.
 
 ## Opentrons Protocol Designer Changes in 8.5.3
 


### PR DESCRIPTION
# Overview

Add bullet to release note explaining default behavior if the user does not specify an explicit z offset for aspirate/dispense/mix tip position

## Test Plan and Hands on Testing

@emilyburghardt to review copy

## Changelog

- add bullet explaining changes in [this PR](https://github.com/Opentrons/opentrons/pull/19650)

## Review requests

see test plan

## Risk assessment

low