### PR TITLE
refactor(protocol-designer): make PD_REQUIRED_APP_VERSION a Vite constant

### DIFF
--- a/protocol-designer/src/pages/ProtocolOverview/ProtocolMetadata.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/ProtocolMetadata.tsx
@@ -19,8 +19,6 @@ import {
   LINK_BUTTON_STYLE,
 } from '../../components/atoms'
 
-const REQUIRED_APP_VERSION = '8.7.0'
-
 type MetadataInfo = Array<{
   author?: string
   description?: string | null
@@ -106,7 +104,7 @@ export function ProtocolMetadata({
             content={
               <StyledText desktopStyle="bodyDefaultRegular">
                 {t('app_version', {
-                  version: REQUIRED_APP_VERSION,
+                  version: _OT_PD_REQUIRED_APP_VERSION_,
                 })}
               </StyledText>
             }

--- a/protocol-designer/src/pages/ProtocolOverview/__tests__/ProtocolMetadata.test.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/__tests__/ProtocolMetadata.test.tsx
@@ -45,7 +45,7 @@ describe('ProtocolMetadata', () => {
     screen.getByText('Protocol Metadata')
     screen.getByText('Edit')
     screen.getByText('Required app version')
-    screen.getByText('8.7.0 or higher')
+    screen.getByText('fake_app_version or higher')
   })
 
   it('should render protocol metadata', () => {

--- a/protocol-designer/typings/global.d.ts
+++ b/protocol-designer/typings/global.d.ts
@@ -20,6 +20,7 @@ declare const _NODE_ENV_: string | undefined
 declare const _OT_PD_BUILD_DATE_: string | undefined
 declare const _OT_PD_MIXPANEL_DEV_ID_: string | undefined
 declare const _OT_PD_MIXPANEL_ID_: string | undefined
+declare const _OT_PD_REQUIRED_APP_VERSION_: string | undefined
 declare const _OT_PD_SENTRY_DEV_DSN_: string | undefined
 declare const _OT_PD_SENTRY_DSN_: string | undefined
 declare const _OT_PD_VERSION_: string | undefined

--- a/protocol-designer/vite.config.mts
+++ b/protocol-designer/vite.config.mts
@@ -14,6 +14,8 @@ import { cssModuleSideEffect } from './cssModuleSideEffect'
 
 import type { UserConfig } from 'vite'
 
+const REQUIRED_APP_VERSION = '8.7.0' // PD requires this robot stack version or higher
+
 // eslint-disable-next-line import/no-default-export
 export default defineConfig(
   async (): Promise<UserConfig> => {
@@ -85,9 +87,14 @@ export default defineConfig(
         _FF_ENV_VARS_: getFeatureFlagEnvVars(),
         _NODE_ENV_: JSON.stringify(process.env.NODE_ENV),
         _OT_PD_BUILD_DATE_: JSON.stringify(OT_PD_BUILD_DATE),
-        _OT_PD_MIXPANEL_DEV_ID_: JSON.stringify(process.env.OT_PD_MIXPANEL_DEV_ID),
+        _OT_PD_MIXPANEL_DEV_ID_: JSON.stringify(
+          process.env.OT_PD_MIXPANEL_DEV_ID
+        ),
         _OT_PD_MIXPANEL_ID_: JSON.stringify(process.env.OT_PD_MIXPANEL_ID),
-        _OT_PD_SENTRY_DEV_DSN_: JSON.stringify(process.env.OT_PD_SENTRY_DEV_DSN),
+        _OT_PD_REQUIRED_APP_VERSION_: JSON.stringify(REQUIRED_APP_VERSION),
+        _OT_PD_SENTRY_DEV_DSN_: JSON.stringify(
+          process.env.OT_PD_SENTRY_DEV_DSN
+        ),
         _OT_PD_SENTRY_DSN_: JSON.stringify(process.env.OT_PD_SENTRY_DSN),
         _OT_PD_VERSION_: JSON.stringify(OT_PD_VERSION),
         global: 'globalThis',

--- a/setup-vitest.mts
+++ b/setup-vitest.mts
@@ -20,6 +20,7 @@ vi.mock('./app/src/resources/useNotifyDataReady', async () => {
 })
 
 global._OT_PD_VERSION_ = 'fake_PD_version'
+global._OT_PD_REQUIRED_APP_VERSION_ = 'fake_app_version'
 global._PKG_VERSION_ = 'test environment'
 global._OPENTRONS_PROJECT_ = 'robotics'
 global._PKG_PRODUCT_NAME_ = 'test product'


### PR DESCRIPTION
# Overview

Part 1 of 2 for AUTH-2225.

Previously, the Robot Stack version that PD requires was specified in `ProtocolOverview/ProtocolMetadata.tsx`. This PR makes it a Vite constant instead (called `_OT_PD_REQUIRED_APP_VERSION_`), so that it's available at build time.

An upcoming PR will use this constant to retrieve the labware definitions that are available in that version of the app.

## Test Plan and Hands on Testing

Ran PD locally and looked at the "Required app version" in http://localhost:5178/#/overview.

## Risk assessment

Low.