### PR TITLE
feat(protocol-designer): get latest labware versions as of an app version

### DIFF
--- a/.github/workflows/pd-test-build-deploy.yaml
+++ b/.github/workflows/pd-test-build-deploy.yaml
@@ -90,9 +90,8 @@ jobs:
     steps:
       - name: 'Checkout Repository'
         uses: actions/checkout@v4
-      - name: 'Check out release tags and chore_release branches'
-        # need this because PD examines the app release branch for labware
-        run: git fetch origin '+refs/heads/chore_release-*:refs/remotes/origin/chore_release-*' '+refs/tags/v*:refs/tags/v*'
+        with:
+          fetch-depth: 0 # PD needs to see labware in other release branches
       - uses: ./.github/actions/js/setup
       - name: 'run test-e2e'
         run: make -C protocol-designer test-e2e

--- a/.github/workflows/pd-test-build-deploy.yaml
+++ b/.github/workflows/pd-test-build-deploy.yaml
@@ -90,6 +90,9 @@ jobs:
     steps:
       - name: 'Checkout Repository'
         uses: actions/checkout@v4
+      - name: 'Check out release tags and chore_release branches'
+        # need this because PD examines the app release branch for labware
+        run: git fetch origin '+refs/heads/chore_release-*:refs/remotes/origin/chore_release-*' '+refs/tags/v*:refs/tags/v*'
       - uses: ./.github/actions/js/setup
       - name: 'run test-e2e'
         run: make -C protocol-designer test-e2e

--- a/protocol-designer/typings/global.d.ts
+++ b/protocol-designer/typings/global.d.ts
@@ -18,6 +18,7 @@ declare module '*.md' {
 declare const _FF_ENV_VARS_: Record<string, string | undefined>
 declare const _NODE_ENV_: string | undefined
 declare const _OT_PD_BUILD_DATE_: string | undefined
+declare const _OT_PD_LATEST_LABWARE_VERSIONS_: Record<string, Number>
 declare const _OT_PD_MIXPANEL_DEV_ID_: string | undefined
 declare const _OT_PD_MIXPANEL_ID_: string | undefined
 declare const _OT_PD_REQUIRED_APP_VERSION_: string | undefined

--- a/protocol-designer/vite.config.mts
+++ b/protocol-designer/vite.config.mts
@@ -9,7 +9,10 @@ import postCssPresetEnv from 'postcss-preset-env'
 import { defineConfig } from 'vite'
 import { analyzer } from 'vite-bundle-analyzer'
 
-import { versionForProject } from '../scripts/git-version.mjs'
+import {
+  latestLabwareVersions,
+  versionForProject,
+} from '../scripts/git-version.mjs'
 import { cssModuleSideEffect } from './cssModuleSideEffect'
 
 import type { UserConfig } from 'vite'
@@ -21,6 +24,9 @@ export default defineConfig(
   async (): Promise<UserConfig> => {
     const OT_PD_VERSION = await versionForProject('protocol-designer')
     const OT_PD_BUILD_DATE = new Date().toUTCString()
+    const OT_PD_LATEST_LABWARE_VERSIONS = await latestLabwareVersions(
+      REQUIRED_APP_VERSION
+    )
     const mode = process.env.NODE_ENV ?? 'development'
     return {
       // this makes imports relative rather than absolute
@@ -87,6 +93,7 @@ export default defineConfig(
         _FF_ENV_VARS_: getFeatureFlagEnvVars(),
         _NODE_ENV_: JSON.stringify(process.env.NODE_ENV),
         _OT_PD_BUILD_DATE_: JSON.stringify(OT_PD_BUILD_DATE),
+        _OT_PD_LATEST_LABWARE_VERSIONS_: OT_PD_LATEST_LABWARE_VERSIONS,
         _OT_PD_MIXPANEL_DEV_ID_: JSON.stringify(
           process.env.OT_PD_MIXPANEL_DEV_ID
         ),

--- a/scripts/git-version.mjs
+++ b/scripts/git-version.mjs
@@ -14,10 +14,10 @@
 //
 // What that all boils down to is that we need, and this module provides, an interface to get the version of a
 // given project that currently exists in the monorepo.
-
-import git from 'simple-git'
 import { dirname } from 'path'
 import { fileURLToPath } from 'url'
+import git from 'simple-git'
+
 const REPO_BASE = dirname(dirname(fileURLToPath(import.meta.url)))
 
 export function monorepoGit() {
@@ -60,4 +60,39 @@ export async function versionForProject(project) {
       )
       return '0.0.0-dev'
     })
+}
+
+export async function latestLabwareVersions(appVersion) {
+  // Returns a map of {labware load name -> highest available version number}
+  // as of app release `appVersion`.
+
+  // Max says PD only needs to worry about labware schema 2:
+  const labwareDir = 'shared-data/labware/definitions/2/'
+  // Fetch all labware definition files that existed in the app at `version`:
+  const lstreeCmd = ['ls-tree', '-r', '--name-only', '-z']
+  // We will first look for a release tag named `v${version}`.
+  // If that doesn't exist, look for a branch named `chore_release-${version}`.
+  const releaseTag = `v${appVersion}`
+  const choreBranch = `origin/chore_release-${appVersion}`
+  const labwareFiles = (
+    await monorepoGit()
+      .raw([...lstreeCmd, releaseTag, labwareDir])
+      .catch(error =>
+        monorepoGit().raw([...lstreeCmd, choreBranch, labwareDir])
+      )
+  )
+    .split('\0')
+    .slice(0, -1) // git puts an extra '\0' at the end, remove it
+    .map(filename => filename.replace(labwareDir, ''))
+  // labwareFiles is a list like: ['agilent_1_reservoir_290ml/1.json', ...]
+
+  // For each loadname in labwareFiles, return the highest labware version:
+  return labwareFiles.reduce((acc, filename) => {
+    const [loadName, jsonFilename] = filename.split('/')
+    const labwareVersion = Number(jsonFilename.replace('.json', ''))
+    if (!acc[loadName] || labwareVersion > acc[loadName]) {
+      acc[loadName] = labwareVersion
+    }
+    return acc
+  }, {})
 }


### PR DESCRIPTION
# Overview

Part 2 for AUTH-2225.

This implements a new Vite constant `_OT_PD_LATEST_LABWARE_VERSIONS_`, which is a map of:
```
{ labware loadname -> highest available version of that labware }
```
as of the app version specified in `REQUIRED_APP_VERSION`.

The map is built by asking git to list all the files in `shared-data/labware/definitions/2/` as of `REQUIRED_APP_VERSION`. (To find the files in that app version, we first try looking for a release tag named `v#.#.#`, and if that doesn't exist, we look for a branch named `chore_release-#.#.#`.)

You can then refer to `_OT_PD_LATEST_LABWARE_VERSIONS_` from any PD file to access the map.

@jerader Let me know if the format of the map works for you. I can tweak the format if you need.

## Test Plan and Hands on Testing

Ran PD locally. I tried `console.log()`ing the new `_OT_PD_LATEST_LABWARE_VERSIONS_` and it looks reasonable.

## Risk assessment

Low.