### PR TITLE
feat(app): add DESIGNER_APPLICATION blob to end of QT protocols

### DIFF
--- a/app/src/organisms/ODD/QuickTransferFlow/utils/createQuickTransferFile.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/utils/createQuickTransferFile.ts
@@ -181,7 +181,7 @@ export function createQuickTransferFile(
     // see QuickTransferFlow/README.md for versioning details
     designerApplication: {
       name: 'opentrons/quick-transfer',
-      version: '1.2.0',
+      version: '2.0.0',
       data: quickTransferState,
     },
   }
@@ -301,17 +301,17 @@ export function createQuickTransferPythonFile(
       pythonMetadata(fileMetadata),
       pythonRequirements(FLEX_ROBOT_TYPE),
       pythonDef(quickTransferState, deckConfig),
+      designerApplicationBlob,
     ]
       .filter(section => section)
       .join('\n\n') + '\n'
-  const protocol = protocolContents + designerApplicationBlob
 
   // temporary logging for debugging
   if (enableQuickTransferProtocolContentsLog) {
     console.group('🧪 Quick Transfer Protocol Contents')
-    console.log(protocol)
+    console.log(protocolContents)
     const downloadProtocolPython = (): void => {
-      const blob = new Blob([protocol], { type: 'text/x-python' })
+      const blob = new Blob([protocolContents], { type: 'text/x-python' })
       const url = URL.createObjectURL(blob)
       const link = document.createElement('a')
       link.href = url
@@ -330,7 +330,7 @@ export function createQuickTransferPythonFile(
     console.groupEnd()
   }
 
-  return new File([protocol], `${fileMetadata.protocolName}.py`, {
+  return new File([protocolContents], `${fileMetadata.protocolName}.py`, {
     type: 'text/x-python',
   })
 }

--- a/app/src/organisms/ODD/QuickTransferFlow/utils/createQuickTransferFile.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/utils/createQuickTransferFile.ts
@@ -287,6 +287,14 @@ export function createQuickTransferPythonFile(
     tags: [],
   }
 
+  const designerApplication = {
+    name: 'opentrons/quick-transfer',
+    version: '2.0.0',
+    data: quickTransferState,
+  }
+  const stringifiedDesignerApplication = JSON.stringify(designerApplication)
+  const designerApplicationBlob = `\nDESIGNER_APPLICATION = """${stringifiedDesignerApplication}"""\n`
+
   const protocolContents =
     [
       pythonImports(),
@@ -296,13 +304,14 @@ export function createQuickTransferPythonFile(
     ]
       .filter(section => section)
       .join('\n\n') + '\n'
+  const protocol = protocolContents + designerApplicationBlob
 
   // temporary logging for debugging
   if (enableQuickTransferProtocolContentsLog) {
     console.group('🧪 Quick Transfer Protocol Contents')
-    console.log(protocolContents)
+    console.log(protocol)
     const downloadProtocolPython = (): void => {
-      const blob = new Blob([protocolContents], { type: 'text/x-python' })
+      const blob = new Blob([protocol], { type: 'text/x-python' })
       const url = URL.createObjectURL(blob)
       const link = document.createElement('a')
       link.href = url
@@ -321,7 +330,7 @@ export function createQuickTransferPythonFile(
     console.groupEnd()
   }
 
-  return new File([protocolContents], `${fileMetadata.protocolName}.py`, {
+  return new File([protocol], `${fileMetadata.protocolName}.py`, {
     type: 'text/x-python',
   })
 }


### PR DESCRIPTION
AUTH-2349

# Overview

add designer application blob to the end of QT generated protocols so you can clone/edit the protocol in the future when we add that feature

## Test Plan and Hands on Testing

create a QT protocol and look at console.log to see it (make sure the QT contents ff is turned on)

## Changelog

add designer application blob

## Risk assessment
low
