### PR TITLE
fix(protocol-designer): null out labware field in moveLabware from de…

### DIFF
--- a/protocol-designer/src/step-forms/reducers/index.ts
+++ b/protocol-designer/src/step-forms/reducers/index.ts
@@ -774,6 +774,14 @@ export const savedStepForms = (
             ...savedForm,
             labwareLocationUpdate: updatedLabwareLocation,
           }
+        } else if (
+          savedForm.stepType === 'moveLabware' &&
+          savedForm.labware === labwareIdToDelete
+        ) {
+          return {
+            ...savedForm,
+            labware: null,
+          }
         }
 
         const deleteLabwareUpdate = reduce<FormData, FormData>(


### PR DESCRIPTION
…leted labware

closes RQA-4642

# Overview

This was probably a bug before honestly. but when you delete a labware, the move labware command errors because its still populating the old labware id. this PR fixes it by just nulling out the labware id.

I thought about populating the labware id to the labware underneath it if its in a stack but that feels presumptuous to me and i think the user can just update it manually on their own.

## Test Plan and Hands on Testing

Create a protocol and add a move labware step. delete the labware that is being moved. see that the move labware step has a field error saying you need to select a labware to move.

## Changelog

null out labware field in reducer

## Risk assessment

low
