### PR TITLE
feat(api): poll module error states and raise them

### DIFF
--- a/api/src/opentrons/drivers/asyncio/communication/serial_connection.py
+++ b/api/src/opentrons/drivers/asyncio/communication/serial_connection.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Optional, List, Type
+from typing import Type, Literal, AsyncIterator
 
 from opentrons.drivers.command_builder import CommandBuilder
 
@@ -25,7 +25,7 @@ class SerialConnection:
         port: str,
         baud_rate: int,
         timeout: float,
-        loop: Optional[asyncio.AbstractEventLoop],
+        loop: asyncio.AbstractEventLoop | None,
         reset_buffer_before_write: bool,
     ) -> AsyncSerial:
         return await AsyncSerial.create(
@@ -43,11 +43,11 @@ class SerialConnection:
         baud_rate: int,
         timeout: float,
         ack: str,
-        name: Optional[str] = None,
+        name: str | None = None,
         retry_wait_time_seconds: float = 0.1,
-        loop: Optional[asyncio.AbstractEventLoop] = None,
-        error_keyword: Optional[str] = None,
-        alarm_keyword: Optional[str] = None,
+        loop: asyncio.AbstractEventLoop | None = None,
+        error_keyword: str | None = None,
+        alarm_keyword: str | None = None,
         reset_buffer_before_write: bool = False,
         error_codes: Type[BaseErrorCode] = DefaultErrorCodes,
     ) -> "SerialConnection":
@@ -133,7 +133,7 @@ class SerialConnection:
         self._error_codes = error_codes
 
     async def send_command(
-        self, command: CommandBuilder, retries: int = 0, timeout: Optional[float] = None
+        self, command: CommandBuilder, retries: int = 0, timeout: float | None = None
     ) -> str:
         """
         Send a command and return the response.
@@ -165,7 +165,7 @@ class SerialConnection:
             await self._serial.write(data=encoded_command)
 
     async def send_data(
-        self, data: str, retries: int = 0, timeout: Optional[float] = None
+        self, data: str, retries: int = 0, timeout: float | None = None
     ) -> str:
         """
         Send data and return the response.
@@ -184,7 +184,7 @@ class SerialConnection:
         ):
             return await self._send_data(data=data, retries=retries)
 
-    async def _send_data(self, data: str, retries: int = 0) -> str:
+    async def _send_data(self, data: str, retries: int) -> str:
         """
         Send data and return the response.
 
@@ -351,14 +351,14 @@ class AsyncResponseSerialConnection(SerialConnection):
         baud_rate: int,
         timeout: float,
         ack: str,
-        name: Optional[str] = None,
+        name: str | None = None,
         retry_wait_time_seconds: float = 0.1,
-        loop: Optional[asyncio.AbstractEventLoop] = None,
-        error_keyword: Optional[str] = None,
-        alarm_keyword: Optional[str] = None,
+        loop: asyncio.AbstractEventLoop | None = None,
+        error_keyword: str | None = None,
+        alarm_keyword: str | None = None,
         reset_buffer_before_write: bool = False,
         error_codes: Type[BaseErrorCode] = DefaultErrorCodes,
-        async_error_ack: Optional[str] = None,
+        async_error_ack: str | None = None,
         number_of_retries: int = 0,
     ) -> AsyncResponseSerialConnection:
         """
@@ -461,8 +461,29 @@ class AsyncResponseSerialConnection(SerialConnection):
         self._alarm_keyword = alarm_keyword.lower()
         self._async_error_ack = async_error_ack.lower()
 
+    async def send_multiack_command(
+        self,
+        command: CommandBuilder,
+        retries: int = 0,
+        timeout: float | None = None,
+        acks: int = 1,
+    ) -> list[str]:
+        """Send a command and return the responses.
+
+        Some commands result in multiple responses; collate them and return them all.
+
+        Args:
+            command: A command builder.
+            retries: number of times to retry in case of timeout
+            timeout: optional override of default timeout in seconds
+            acks: the number of acks to expect
+        """
+        return await self.send_data_multiack(
+            data=command.build(), retries=retries, timeout=timeout, acks=acks
+        )
+
     async def send_command(
-        self, command: CommandBuilder, retries: int = 0, timeout: Optional[float] = None
+        self, command: CommandBuilder, retries: int = 0, timeout: float | None = None
     ) -> str:
         """
         Send a command and return the response.
@@ -482,8 +503,19 @@ class AsyncResponseSerialConnection(SerialConnection):
             timeout=timeout,
         )
 
+    async def send_data_multiack(
+        self, data: str, retries: int = 0, timeout: float | None = None, acks: int = 1
+    ) -> list[str]:
+        """Send data and return all responses."""
+        async with super().send_data_lock, self._serial.timeout_override(
+            "timeout", timeout
+        ):
+            return await self._send_data_multiack(
+                data=data, retries=retries or self._number_of_retries, acks=acks
+            )
+
     async def send_data(
-        self, data: str, retries: int = 0, timeout: Optional[float] = None
+        self, data: str, retries: int = 0, timeout: float | None = None
     ) -> str:
         """
         Send data and return the response.
@@ -504,54 +536,99 @@ class AsyncResponseSerialConnection(SerialConnection):
                 data=data, retries=retries or self._number_of_retries
             )
 
-    async def _send_data(self, data: str, retries: int = 0) -> str:
+    async def _consume_responses(
+        self, acks: int
+    ) -> AsyncIterator[tuple[Literal["response", "error", "empty-unknown"], bytes]]:
+        while acks > 0:
+            data = await self._serial.read_until(match=self._ack)
+            log.debug(f"{self._name}: Read <- {data!r}")
+            if self._async_error_ack.encode() in data:
+                yield "error", data
+            elif self._ack in data:
+                yield "response", data
+                acks -= 1
+            else:
+                # A read timeout, end
+                yield "empty-unknown", data
+
+    async def _send_one_retry(self, data: str, acks: int) -> list[str]:
+        data_encode = data.encode("utf-8")
+        log.debug(f"{self._name}: Write -> {data_encode!r}")
+        await self._serial.write(data=data_encode)
+
+        command_acks: list[bytes] = []
+        async_errors: list[bytes] = []
+        # consume responses before raising so we don't raise and orphan
+        # a response in the buffer
+        async for response_type, response in self._consume_responses(acks):
+            if response_type == "error":
+                async_errors.append(response)
+            elif response_type == "response":
+                command_acks.append(response)
+            else:
+                break
+
+        for async_error in async_errors:
+            # Remove ack from response
+            ackless_response = async_error.replace(self._ack, b"")
+            str_response = self.process_raw_response(
+                command=data, response=ackless_response.decode()
+            )
+            self.raise_on_error(response=str_response, request=data)
+
+        ackless_responses: list[str] = []
+        for command_ack in command_acks:
+            # Remove ack from response
+            ackless_response = command_ack.replace(self._ack, b"")
+            str_response = self.process_raw_response(
+                command=data, response=ackless_response.decode()
+            )
+            self.raise_on_error(response=str_response, request=data)
+            ackless_responses.append(str_response)
+        return ackless_responses
+
+    async def _send_data_multiack(
+        self, data: str, retries: int, acks: int
+    ) -> list[str]:
         """
-        Send data and return the response.
+        Send data and return the response(s).
 
         Args:
             data: The data to send.
             retries: number of times to retry in case of timeout
+            acks: The number of expected command responses
 
-        Returns: The command response
+        This function retries (resends the command) up to (retries) times, and waits
+        for (acks) responses. It also listens for async errors. These are an older
+        mechanism where at the moment an error occurs, some modules will send a message
+        like async error ERR:202:whatever
 
-        Raises: SerialException
+        This function will detect async error messages if they were sent before it
+        sent the command or if they are sent before the final ack for the command is
+        sent. It will not catch async errors otherwise.
+
+        This function will always try and consume all the acknowledgements specified for
+        its command if it sends the command, even if an async error happens in between.
+
+        This should all work together to make sure that there aren't any leftover acks
+        after the function ends, which could lead to the read/write mechanics getting out
+        of sync.
+
+        Returns: The command responses
+
+        Raises: SerialException from an error ack to this command or an async error.
         """
-        data_encode = data.encode()
         retries = retries or self._number_of_retries
+        responses: list[str] = []
 
         for retry in range(retries + 1):
-            log.debug(f"{self._name}: Write -> {data_encode!r}")
-            await self._serial.write(data=data_encode)
-
-            response: List[bytes] = []
-            response.append(await self._serial.read_until(match=self._ack))
-            log.debug(f"{self._name}: Read <- {response[-1]!r}")
-
-            while self._async_error_ack.encode() in response[-1].lower():
-                # check for multiple a priori async errors
-                response.append(await self._serial.read_until(match=self._ack))
-                log.debug(f"{self._name}: Read <- {response[-1]!r}")
-
-            for r in response:
-                if self._async_error_ack.encode() in r:
-                    # Remove ack from response
-                    ackless_response = r.replace(self._ack, b"")
-                    str_response = self.process_raw_response(
-                        command=data, response=ackless_response.decode()
-                    )
-                    self.raise_on_error(response=str_response, request=data)
-
-            if self._ack in response[-1]:
-                # Remove ack from response
-                ackless_response = response[-1].replace(self._ack, b"")
-                str_response = self.process_raw_response(
-                    command=data, response=ackless_response.decode()
-                )
-                self.raise_on_error(response=str_response, request=data)
-                return str_response
-
+            responses = await self._send_one_retry(data, acks)
+            if responses:
+                return responses
             log.info(f"{self._name}: retry number {retry}/{retries}")
-
             await self.on_retry()
 
         raise NoResponse(port=self._port, command=data)
+
+    async def _send_data(self, data: str, retries: int) -> str:
+        return (await self._send_data_multiack(data, retries, 1))[0]

--- a/api/src/opentrons/drivers/heater_shaker/abstract.py
+++ b/api/src/opentrons/drivers/heater_shaker/abstract.py
@@ -74,3 +74,8 @@ class AbstractHeaterShakerDriver(ABC):
     async def enter_programming_mode(self) -> None:
         """Reboot into programming mode"""
         ...
+
+    @abstractmethod
+    async def get_error_state(self) -> None:
+        """Raise if the module is in an error state."""
+        ...

--- a/api/src/opentrons/drivers/heater_shaker/driver.py
+++ b/api/src/opentrons/drivers/heater_shaker/driver.py
@@ -27,6 +27,7 @@ class GCODE(str, Enum):
     GET_LABWARE_LATCH_STATE = "M241"
     DEACTIVATE_HEATER = "M106"
     GET_RESET_REASON = "M114"
+    GET_ERROR_STATE = "M411"
 
 
 HS_BAUDRATE = 115200
@@ -202,3 +203,11 @@ class HeaterShakerDriver(AbstractHeaterShakerDriver):
             gcode=GCODE.DEACTIVATE_HEATER
         )
         await self._connection.send_command(command=c, retries=DEFAULT_COMMAND_RETRIES)
+
+    async def get_error_state(self) -> None:
+        """Raise if the module is in an error state."""
+        await self._connection.send_command(
+            command=CommandBuilder(terminator=HS_COMMAND_TERMINATOR).add_gcode(
+                gcode=GCODE.GET_ERROR_STATE
+            )
+        )

--- a/api/src/opentrons/drivers/heater_shaker/driver.py
+++ b/api/src/opentrons/drivers/heater_shaker/driver.py
@@ -206,8 +206,9 @@ class HeaterShakerDriver(AbstractHeaterShakerDriver):
 
     async def get_error_state(self) -> None:
         """Raise if the module is in an error state."""
-        await self._connection.send_command(
+        await self._connection.send_multiack_command(
             command=CommandBuilder(terminator=HS_COMMAND_TERMINATOR).add_gcode(
                 gcode=GCODE.GET_ERROR_STATE
-            )
+            ),
+            acks=2,
         )

--- a/api/src/opentrons/drivers/heater_shaker/simulator.py
+++ b/api/src/opentrons/drivers/heater_shaker/simulator.py
@@ -92,3 +92,7 @@ class SimulatingDriver(AbstractHeaterShakerDriver):
     @ensure_yield
     async def enter_programming_mode(self) -> None:
         pass
+
+    @ensure_yield
+    async def get_error_state(self) -> None:
+        return

--- a/api/src/opentrons/drivers/thermocycler/abstract.py
+++ b/api/src/opentrons/drivers/thermocycler/abstract.py
@@ -98,3 +98,8 @@ class AbstractThermocyclerDriver(ABC):
     async def jog_lid(self, angle: float) -> None:
         """Send the Jog Lid command."""
         ...
+
+    @abstractmethod
+    async def get_error_state(self) -> None:
+        """Raise if the thermocycler is in an error state."""
+        ...

--- a/api/src/opentrons/drivers/thermocycler/driver.py
+++ b/api/src/opentrons/drivers/thermocycler/driver.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from enum import Enum
-from typing import Optional, Dict, Union
+from typing import Optional, Dict, Union, TypeVar, Generic
 
 from opentrons.drivers import utils
 from opentrons.drivers.command_builder import CommandBuilder
@@ -74,7 +74,7 @@ class ThermocyclerDriverFactory:
     @staticmethod
     async def create(
         port: str, loop: Optional[asyncio.AbstractEventLoop]
-    ) -> ThermocyclerDriver:
+    ) -> ThermocyclerDriver | ThermocyclerDriverV2:
         """
         Create a thermocycler driver.
 
@@ -149,10 +149,15 @@ class ThermocyclerDriverFactory:
         return response.startswith(GCODE.DEVICE_INFO)
 
 
-class ThermocyclerDriver(AbstractThermocyclerDriver):
+_ConnectionKind = TypeVar(
+    "_ConnectionKind", SerialConnection, AsyncResponseSerialConnection
+)
+
+
+class _BaseThermocyclerDriver(AbstractThermocyclerDriver, Generic[_ConnectionKind]):
     def __init__(
         self,
-        connection: SerialKind,
+        connection: _ConnectionKind,
     ) -> None:
         """
         Constructor
@@ -160,7 +165,7 @@ class ThermocyclerDriver(AbstractThermocyclerDriver):
         Args:
             connection: SerialConnection to the thermocycler
         """
-        self._connection = connection
+        self._connection: _ConnectionKind = connection
 
     async def connect(self) -> None:
         """Connect to thermocycler"""
@@ -331,15 +336,14 @@ class ThermocyclerDriver(AbstractThermocyclerDriver):
         )
 
     async def get_error_state(self) -> None:
-        """Raise an error if the thermocycler is stuck in an error state."""
-        await self._connection.send_command(
-            command=CommandBuilder(terminator=TC_COMMAND_TERMINATOR).add_gcode(
-                gcode=GCODE.GET_ERROR_STATE
-            )
-        )
+        """For the gen1, do nothing."""
+        pass
 
 
-class ThermocyclerDriverV2(ThermocyclerDriver):
+ThermocyclerDriver = _BaseThermocyclerDriver[SerialConnection]
+
+
+class ThermocyclerDriverV2(_BaseThermocyclerDriver[AsyncResponseSerialConnection]):
     """
     This driver is for Thermocycler model Gen2.
     """
@@ -431,3 +435,12 @@ class ThermocyclerDriverV2(ThermocyclerDriver):
             .add_element("O")
         )
         await self._connection.send_command(command=c, retries=1)
+
+    async def get_error_state(self) -> None:
+        """Raise an error if the thermocycler is stuck in an error state."""
+        await self._connection.send_multiack_command(
+            command=CommandBuilder(terminator=TC_COMMAND_TERMINATOR).add_gcode(
+                gcode=GCODE.GET_ERROR_STATE
+            ),
+            acks=2,
+        )

--- a/api/src/opentrons/drivers/thermocycler/driver.py
+++ b/api/src/opentrons/drivers/thermocycler/driver.py
@@ -36,6 +36,7 @@ class GCODE(str, Enum):
     DEVICE_INFO = "M115"
     GET_RESET_REASON = "M114"
     ENTER_PROGRAMMING = "dfu"
+    GET_ERROR_STATE = "M411"
 
 
 LID_TARGET_DEFAULT = 105  # Degree celsius (floats)
@@ -327,6 +328,14 @@ class ThermocyclerDriver(AbstractThermocyclerDriver):
         NOT SUPPORTED on TC Gen1."""
         raise NotImplementedError(
             "Gen1 Thermocyclers do not support the Jog Lid command."
+        )
+
+    async def get_error_state(self) -> None:
+        """Raise an error if the thermocycler is stuck in an error state."""
+        await self._connection.send_command(
+            command=CommandBuilder(terminator=TC_COMMAND_TERMINATOR).add_gcode(
+                gcode=GCODE.GET_ERROR_STATE
+            )
         )
 
 

--- a/api/src/opentrons/drivers/thermocycler/simulator.py
+++ b/api/src/opentrons/drivers/thermocycler/simulator.py
@@ -126,3 +126,7 @@ class SimulatingDriver(AbstractThermocyclerDriver):
             if angle < 0
             else ThermocyclerLidStatus.OPEN
         )
+
+    @ensure_yield
+    async def get_error_state(self) -> None:
+        return

--- a/api/src/opentrons/hardware_control/emulation/abstract_emulator.py
+++ b/api/src/opentrons/hardware_control/emulation/abstract_emulator.py
@@ -10,12 +10,14 @@ class AbstractEmulator(ABC):
         """Handle a command and return a response."""
         ...
 
-    @staticmethod
-    def get_terminator() -> bytes:
+    def get_terminator(self) -> bytes:
         """Get the command terminator for messages coming from PI."""
         return b"\r\n\r\n"
 
-    @staticmethod
-    def get_ack() -> bytes:
+    def get_ack(self) -> bytes:
         """Get the command ack send to the PI."""
         return b"ok\r\nok\r\n"
+
+    def get_autoack(self) -> bool:
+        """Should this system automatically acknowledge messages?"""
+        return True

--- a/api/src/opentrons/hardware_control/emulation/connection_handler.py
+++ b/api/src/opentrons/hardware_control/emulation/connection_handler.py
@@ -27,12 +27,15 @@ class ConnectionHandler:
             try:
                 response = self._emulator.handle(line.decode().strip())
                 if response:
-                    response = f"{response}\r\n"
-                    logger.debug("%s Sending: %s", emulator_name, response)
-                    writer.write(response.encode())
+                    response_bytes = response.encode() + self._emulator.get_terminator()
+                    logger.debug(f"{emulator_name} Sending: {response_bytes!r}")
+                    writer.write(response_bytes)
             except Exception as e:
                 logger.exception("%s exception", emulator_name)
-                writer.write(f"Error: {str(e)}\r\n".encode())
+                writer.write(
+                    f"Error: {str(e)} ".encode() + self._emulator.get_terminator()
+                )
 
-            writer.write(self._emulator.get_ack())
+            if self._emulator.get_autoack():
+                writer.write(self._emulator.get_ack())
             await writer.drain()

--- a/api/src/opentrons/hardware_control/emulation/heater_shaker.py
+++ b/api/src/opentrons/hardware_control/emulation/heater_shaker.py
@@ -2,6 +2,7 @@
 
 The purpose is to provide a fake backend that responds to GCODE commands.
 """
+
 import logging
 from time import sleep
 from typing import (
@@ -50,6 +51,7 @@ class HeaterShakerEmulator(AbstractEmulator):
             GCODE.CLOSE_LABWARE_LATCH.value: self._close_labware_latch,
             GCODE.GET_LABWARE_LATCH_STATE.value: self._get_labware_latch_state,
             GCODE.DEACTIVATE_HEATER.value: self._deactivate_heater,
+            GCODE.GET_ERROR_STATE.value: self._get_error_state,
         }
         self.reset()
 
@@ -60,7 +62,6 @@ class HeaterShakerEmulator(AbstractEmulator):
         return None if not joined else joined
 
     def reset(self) -> None:
-
         self._temperature = Temperature(
             per_tick=self._settings.temperature.degrees_per_tick,
             current=self._settings.temperature.starting,
@@ -144,6 +145,9 @@ class HeaterShakerEmulator(AbstractEmulator):
     def _deactivate_heater(self, command: Command) -> str:
         self._temperature.deactivate(TEMPERATURE_ROOM)
         return "M106"
+
+    def _get_error_state(self, command: Command) -> str:
+        return "M411"
 
     @staticmethod
     def get_terminator() -> bytes:

--- a/api/src/opentrons/hardware_control/emulation/heater_shaker.py
+++ b/api/src/opentrons/hardware_control/emulation/heater_shaker.py
@@ -147,8 +147,13 @@ class HeaterShakerEmulator(AbstractEmulator):
         return "M106"
 
     def _get_error_state(self, command: Command) -> str:
-        return "M411"
+        return f"M411 {HS_ACK}M411"
 
-    @staticmethod
-    def get_terminator() -> bytes:
+    def get_terminator(self) -> bytes:
         return b"\n"
+
+    def get_ack(self) -> bytes:
+        return HS_ACK.encode()
+
+    def get_autoack(self) -> bool:
+        return False

--- a/api/src/opentrons/hardware_control/emulation/settings.py
+++ b/api/src/opentrons/hardware_control/emulation/settings.py
@@ -90,7 +90,7 @@ class Settings(BaseSettings):
     )
     thermocycler: ThermocyclerSettings = ThermocyclerSettings(
         serial_number="thermocycler_emulator",
-        model="v02",
+        model="thermocyclerModuleV2",
         version="v1.1.0",
         lid_temperature=TemperatureModelSettings(),
         plate_temperature=TemperatureModelSettings(),

--- a/api/src/opentrons/hardware_control/emulation/thermocycler.py
+++ b/api/src/opentrons/hardware_control/emulation/thermocycler.py
@@ -60,7 +60,7 @@ class ThermocyclerEmulator(AbstractEmulator):
         """Handle a line"""
         results = (self._handle(c) for c in self._parser.parse(line))
         joined = " ".join(f"{r} {self._ack}" for r in results if r)
-        return None if not joined else joined
+        return self._ack if not joined else joined
 
     def reset(self) -> None:
         self._lid_temperature = Temperature(

--- a/api/src/opentrons/hardware_control/emulation/thermocycler.py
+++ b/api/src/opentrons/hardware_control/emulation/thermocycler.py
@@ -5,8 +5,15 @@ The purpose is to provide a fake backend that responds to GCODE commands.
 
 import logging
 from typing import Optional
-from opentrons.drivers.thermocycler.driver import GCODE
+from opentrons.drivers.thermocycler.driver import (
+    GCODE,
+    TC_GEN2_ACK,
+    TC_GEN2_SERIAL_ACK,
+    TC_ACK as TC_GEN1_ACK,
+    SERIAL_ACK as TC_GEN1_SERIAL_ACK,
+)
 from opentrons.drivers.types import ThermocyclerLidStatus
+from opentrons.hardware_control.modules.types import ThermocyclerModuleModel
 from opentrons.hardware_control.emulation.parser import Parser, Command
 from opentrons.hardware_control.emulation.settings import ThermocyclerSettings
 
@@ -29,12 +36,30 @@ class ThermocyclerEmulator(AbstractEmulator):
     def __init__(self, parser: Parser, settings: ThermocyclerSettings) -> None:
         self._parser = parser
         self._settings = settings
+        # I hate this. These modules do not return anything like this for their actual versions
+        # (gen2 returns "Opentrons-thermocycler-gen2" for instance) and this is not what any of
+        # the settings anywhere use.
+        self._model = (
+            ThermocyclerModuleModel.THERMOCYCLER_V1
+            if settings.model in ["thermocyclerModuleV1", "v1", "v01"]
+            else ThermocyclerModuleModel.THERMOCYCLER_V2
+        )
+        self._terminator = (
+            TC_GEN1_SERIAL_ACK
+            if self._model is ThermocyclerModuleModel.THERMOCYCLER_V1
+            else TC_GEN2_SERIAL_ACK
+        )
+        self._ack = (
+            TC_GEN1_ACK
+            if self._model is ThermocyclerModuleModel.THERMOCYCLER_V1
+            else TC_GEN2_ACK
+        )
         self.reset()
 
     def handle(self, line: str) -> Optional[str]:
         """Handle a line"""
         results = (self._handle(c) for c in self._parser.parse(line))
-        joined = " ".join(r for r in results if r)
+        joined = " ".join(f"{r} {self._ack}" for r in results if r)
         return None if not joined else joined
 
     def reset(self) -> None:
@@ -50,6 +75,12 @@ class ThermocyclerEmulator(AbstractEmulator):
         self.plate_volume = util.OptionalValue[float]()
         self.plate_ramp_rate = util.OptionalValue[float]()
 
+    def _pref(self, command: Command) -> str:
+        if self._model is ThermocyclerModuleModel.THERMOCYCLER_V1:
+            return ""
+        else:
+            return f"{command.gcode} "
+
     def _handle(self, command: Command) -> Optional[str]:  # noqa: C901
         """
         Handle a command.
@@ -62,7 +93,7 @@ class ThermocyclerEmulator(AbstractEmulator):
         elif command.gcode == GCODE.CLOSE_LID:
             self.lid_status = ThermocyclerLidStatus.CLOSED
         elif command.gcode == GCODE.GET_LID_STATUS:
-            return f"Lid:{self.lid_status}"
+            return self._pref(command) + f"Lid:{self.lid_status}"
         elif command.gcode == GCODE.SET_LID_TEMP:
             temperature = command.params["S"]
             assert isinstance(
@@ -76,7 +107,7 @@ class ThermocyclerEmulator(AbstractEmulator):
                 f"H:none Total_H:none"
             )
             self._lid_temperature.tick()
-            return res
+            return self._pref(command) + res
         elif command.gcode == GCODE.EDIT_PID_PARAMS:
             pass
         elif command.gcode == GCODE.SET_PLATE_TEMP:
@@ -105,7 +136,7 @@ class ThermocyclerEmulator(AbstractEmulator):
                 f"Total_H:{plate_total_hold_time} "
             )
             self._plate_temperature.tick()
-            return res
+            return self._pref(command) + res
         elif command.gcode == GCODE.SET_RAMP_RATE:
             self.plate_ramp_rate.val = command.params["S"]
         elif command.gcode == GCODE.DEACTIVATE_ALL:
@@ -116,13 +147,34 @@ class ThermocyclerEmulator(AbstractEmulator):
         elif command.gcode == GCODE.DEACTIVATE_BLOCK:
             self._plate_temperature.deactivate(temperature=util.TEMPERATURE_ROOM)
         elif command.gcode == GCODE.DEVICE_INFO:
-            return (
-                f"serial:{self._settings.serial_number} "
-                f"model:{self._settings.model} "
-                f"version:{self._settings.version}"
-            )
-        return None
+            # the gen2 returns a completely different device info format than the
+            # gen1 which is pretty cool
+            if self._model == ThermocyclerModuleModel.THERMOCYCLER_V1:
+                return (
+                    f"serial:{self._settings.serial_number} "
+                    f"model:{self._settings.model} "
+                    f"version:{self._settings.version}"
+                )
+            else:
+                return (
+                    command.gcode
+                    + " "
+                    + (
+                        f"FW:{self._settings.version} "
+                        f"HW:{self._settings.model} "
+                        f"SerialNo:{self._settings.serial_number}"
+                    )
+                )
+        elif command.gcode == GCODE.GET_ERROR_STATE:
+            if self._model is ThermocyclerModuleModel.THERMOCYCLER_V2:
+                return self._pref(command) + self._ack + self._pref(command)
+        return self._pref(command)
 
-    @staticmethod
-    def get_terminator() -> bytes:
-        return b"\r\n"
+    def get_terminator(self) -> bytes:
+        return self._terminator.encode()
+
+    def get_ack(self) -> bytes:
+        return self._ack.encode()
+
+    def get_autoack(self) -> bool:
+        return False

--- a/api/src/opentrons/hardware_control/modules/heater_shaker.py
+++ b/api/src/opentrons/hardware_control/modules/heater_shaker.py
@@ -9,6 +9,7 @@ from opentrons.drivers.rpi_drivers.types import USBPort
 from opentrons.drivers.heater_shaker.driver import HeaterShakerDriver
 from opentrons.drivers.heater_shaker.abstract import AbstractHeaterShakerDriver
 from opentrons.drivers.heater_shaker.simulator import SimulatingDriver
+from opentrons.drivers.asyncio.communication.errors import UnhandledGcode
 from opentrons.drivers.types import Temperature, RPM, HeaterShakerLabwareLatchStatus
 from opentrons.hardware_control.execution_manager import ExecutionManager
 from opentrons.hardware_control.poller import Reader, Poller
@@ -425,6 +426,7 @@ class HeaterShakerReader(Reader):
         await self.read_temperature()
         await self.read_rpm()
         await self.read_labware_latch()
+        await self._read_errors()
         self._set_error(None)
 
     def on_error(self, exception: Exception) -> None:
@@ -449,3 +451,13 @@ class HeaterShakerReader(Reader):
                 self.error = str(exception.args[0])
             except Exception:
                 self.error = repr(exception)
+
+    async def _read_errors(self) -> None:
+        try:
+            await self._driver.get_error_state()
+        except UnhandledGcode:
+            # This device's firmware cannot accept this command, because it
+            # hasn't been updated or because it's a gen1. Ignore the result.
+            pass
+        # If the error is one we should let pass, raise it so the top level
+        # error handler can take it.

--- a/api/src/opentrons/hardware_control/modules/thermocycler.py
+++ b/api/src/opentrons/hardware_control/modules/thermocycler.py
@@ -712,7 +712,6 @@ class Thermocycler(mod_abc.AbstractModule):
             f"https://support.opentrons.com/en/articles/3469797-thermocycler-module"
             f" for troubleshooting."
         )
-        asyncio.run_coroutine_threadsafe(self.cleanup(), self._loop)
         self.error_callback(error)
 
 

--- a/api/src/opentrons/hardware_control/modules/thermocycler.py
+++ b/api/src/opentrons/hardware_control/modules/thermocycler.py
@@ -22,6 +22,7 @@ from opentrons.drivers.thermocycler import (
     ThermocyclerDriverV2,
     ThermocyclerDriverFactory,
 )
+from opentrons.drivers.asyncio.communication.errors import UnhandledGcode
 
 
 log = logging.getLogger(__name__)
@@ -764,6 +765,17 @@ class ThermocyclerReader(Reader):
         await self.read_lid_status()
         await self.read_lid_temperature()
         await self.read_block_temperature()
+        await self._read_errors()
+
+    async def _read_errors(self) -> None:
+        try:
+            await self._driver.get_error_state()
+        except UnhandledGcode:
+            # This device's firmware cannot accept this command, because it
+            # hasn't been updated or because it's a gen1. Ignore the result.
+            pass
+        # If the error is one we should let pass, raise it so the top level
+        # error handler can take it.
 
     async def read_lid_status(self) -> None:
         self.lid_status = await self._driver.get_lid_status()

--- a/api/src/opentrons/hardware_control/poller.py
+++ b/api/src/opentrons/hardware_control/poller.py
@@ -88,6 +88,12 @@ class Poller:
         except asyncio.InvalidStateError:
             log.warning("Poller waiter was already cancelled")
 
+    def _error_callback(self, exc: Exception) -> None:
+        try:
+            self._reader.on_error(exc)
+        except Exception:
+            log.exception("Exception in reader callback")
+
     async def _poll_once(self) -> None:
         """Trigger a single read, notifying listeners of success or error."""
         previous_waiters = self._poll_waiters
@@ -101,10 +107,10 @@ class Poller:
         except AbsorbanceReaderDisconnectedError as e:
             for waiter in previous_waiters:
                 Poller._set_waiter_complete(waiter, None)
-            self._reader.on_error(e)
+            self._error_callback(e)
         except Exception as e:
             log.exception("Polling exception")
-            self._reader.on_error(e)
+            self._error_callback(e)
             for waiter in previous_waiters:
                 Poller._set_waiter_complete(waiter, e)
         else:

--- a/api/src/opentrons/hardware_control/poller.py
+++ b/api/src/opentrons/hardware_control/poller.py
@@ -5,6 +5,7 @@ from abc import ABC, abstractmethod
 from typing import AsyncGenerator, List, Optional
 from opentrons.hardware_control.modules.errors import AbsorbanceReaderDisconnectedError
 from opentrons_shared_data.errors.exceptions import ModuleCommunicationError
+from opentrons.drivers.asyncio.communication.errors import SerialException
 
 
 log = logging.getLogger(__name__)
@@ -94,6 +95,12 @@ class Poller:
         except Exception:
             log.exception("Exception in reader callback")
 
+    def _complete_all(
+        self, exc: Exception | None, previous: List["asyncio.Future[None]"]
+    ) -> None:
+        for waiter in previous:
+            Poller._set_waiter_complete(waiter, exc)
+
     async def _poll_once(self) -> None:
         """Trigger a single read, notifying listeners of success or error."""
         previous_waiters = self._poll_waiters
@@ -105,14 +112,15 @@ class Poller:
         except asyncio.CancelledError:
             raise
         except AbsorbanceReaderDisconnectedError as e:
-            for waiter in previous_waiters:
-                Poller._set_waiter_complete(waiter, None)
             self._error_callback(e)
+            self._complete_all(e, previous_waiters)
+        except SerialException as se:
+            log.error(f"Polling gcode error: {se}")
+            self._error_callback(se)
+            self._complete_all(se, previous_waiters)
         except Exception as e:
             log.exception("Polling exception")
             self._error_callback(e)
-            for waiter in previous_waiters:
-                Poller._set_waiter_complete(waiter, e)
+            self._complete_all(e, previous_waiters)
         else:
-            for waiter in previous_waiters:
-                Poller._set_waiter_complete(waiter)
+            self._complete_all(None, previous_waiters)

--- a/api/src/opentrons/protocol_engine/protocol_engine.py
+++ b/api/src/opentrons/protocol_engine/protocol_engine.py
@@ -482,7 +482,7 @@ class ProtocolEngine:
             # we were paused between two commands, or imagine we were executing a waitForDuration.
             drop_tips_after_run = False
             post_run_hardware_state = PostRunHardwareState.DISENGAGE_IN_PLACE
-            if error is None:
+            if error is None and self._state_store.commands.get_error() is None:
                 error = EStopActivatedError()
 
         if error:

--- a/api/src/opentrons/protocol_engine/protocol_engine.py
+++ b/api/src/opentrons/protocol_engine/protocol_engine.py
@@ -391,6 +391,13 @@ class ProtocolEngine:
             module_model, serial
         ):
             return False
+
+        if self._state_store.commands.get_is_terminal():
+            # Do not stop multiple times; it will be common for this action to fire
+            # many times when a module enters an error state, and we don't want to do
+            # the stop behavior over and over
+            return False
+
         self._stop_from_asynchronous_error()
         # like self.request_stop, and unlike self.estop(), we must explicitly request that the
         # hardware stops execution, since not all asynchronous errors will cause the hardware

--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -516,10 +516,13 @@ class CommandStore(HasState[CommandState], HandlesActions):
         )
 
         if action.finish_error_details:
-            self._state.finish_error = self._map_finish_exception_to_error_occurrence(
-                action.finish_error_details.error_id,
-                action.finish_error_details.created_at,
-                action.finish_error_details.error,
+            self._state.finish_error = (
+                self._state.finish_error
+                or self._map_finish_exception_to_error_occurrence(
+                    action.finish_error_details.error_id,
+                    action.finish_error_details.created_at,
+                    action.finish_error_details.error,
+                )
             )
 
     def _handle_door_change_action(self, action: DoorChangeAction) -> None:

--- a/api/tests/opentrons/drivers/asyncio/communication/test_serial_connection.py
+++ b/api/tests/opentrons/drivers/asyncio/communication/test_serial_connection.py
@@ -231,7 +231,7 @@ async def test_send_data_with_async_error_before(
         encoded_successful_response,
     ]
 
-    response = await subject_raise_on_error_patched._send_data(data=data)
+    response = await subject_raise_on_error_patched._send_data(data=data, retries=0)
 
     assert response == successful_response
     mock_serial_port.read_until.assert_has_calls(
@@ -266,7 +266,7 @@ async def test_send_data_with_async_error_after(
         encoded_error_response,
     ]
 
-    response = await subject_raise_on_error_patched._send_data(data=data)
+    response = await subject_raise_on_error_patched._send_data(data=data, retries=0)
 
     assert response == successful_response
     mock_serial_port.read_until.assert_has_calls(
@@ -277,6 +277,98 @@ async def test_send_data_with_async_error_after(
     subject_raise_on_error_patched.raise_on_error.assert_has_calls(  # type: ignore[attr-defined]
         calls=[
             call(response=successful_response, request=data),
+        ]
+    )
+
+
+async def test_send_data_multiple_ack_ok(
+    mock_serial_port: AsyncMock,
+    async_subject: AsyncResponseSerialConnection,
+    ack: str,
+) -> None:
+    """It should return all acks."""
+    successful_response = "M411"
+    data = "M411"
+    serial_successful_response = f" {successful_response}  {ack}"
+    encoded_successful_response = serial_successful_response.encode()
+    mock_serial_port.read_until.side_effect = [
+        encoded_successful_response,
+        encoded_successful_response,
+        encoded_successful_response,
+    ]
+
+    responses = await async_subject._send_data_multiack(data=data, retries=0, acks=3)
+
+    assert responses == [successful_response] * 3
+    mock_serial_port.read_until.assert_has_calls(
+        calls=[
+            call(match=ack.encode()),
+            call(match=ack.encode()),
+            call(match=ack.encode()),
+        ]
+    )
+
+
+async def test_send_data_multiple_ack_some_errors(
+    mock_serial_port: AsyncMock,
+    async_subject: AsyncResponseSerialConnection,
+    ack: str,
+) -> None:
+    """It should return all acks."""
+    successful_response = "M411"
+    data = "M411"
+    error_response = "ERR003:test"
+    serial_successful_response = f" {successful_response}  {ack}"
+    encoded_successful_response = serial_successful_response.encode()
+    serial_error_response = f" {error_response}  {ack}"
+    encoded_error_response = serial_error_response.encode()
+    mock_serial_port.read_until.side_effect = [
+        encoded_successful_response,
+        encoded_error_response,
+        encoded_successful_response,
+    ]
+
+    with pytest.raises(ErrorResponse, match=error_response):
+        await async_subject._send_data_multiack(data=data, retries=0, acks=3)
+
+    mock_serial_port.read_until.assert_has_calls(
+        calls=[
+            call(match=ack.encode()),
+            call(match=ack.encode()),
+            call(match=ack.encode()),
+        ]
+    )
+
+
+async def test_send_data_multiple_ack_ok_with_async_error(
+    mock_serial_port: AsyncMock,
+    async_subject: AsyncResponseSerialConnection,
+    ack: str,
+) -> None:
+    """It should return all acks."""
+    successful_response = "M411"
+    data = "M411"
+    serial_successful_response = f" {successful_response}  {ack}"
+    encoded_successful_response = serial_successful_response.encode()
+    error_response = "async ERR106:main motor:speedsensor failed"
+    serial_error_response = f" {error_response}  {ack}"
+    encoded_error_response = serial_error_response.encode()
+    mock_serial_port.read_until.side_effect = [
+        encoded_error_response,
+        encoded_successful_response,
+        encoded_successful_response,
+        encoded_successful_response,
+    ]
+
+    with pytest.raises(ErrorResponse, match=error_response):
+        await async_subject._send_data_multiack(data=data, retries=0, acks=3)
+
+    mock_serial_port.read_until.assert_has_calls(
+        calls=[
+            call(match=ack.encode()),
+            call(match=ack.encode()),
+            call(match=ack.encode()),
+            call(match=ack.encode()),
         ]
     )
 

--- a/api/tests/opentrons/hardware_control/integration/test_heatershaker.py
+++ b/api/tests/opentrons/hardware_control/integration/test_heatershaker.py
@@ -42,6 +42,7 @@ def test_device_info(heatershaker: HeaterShaker) -> None:
 
 async def test_latch_status(heatershaker: HeaterShaker) -> None:
     """It should run open and close latch."""
+    await heatershaker._poller.wait_next_poll()
     assert heatershaker.labware_latch_status.value == "idle_open"
 
     await heatershaker.close_labware_latch()

--- a/api/tests/opentrons/hardware_control/integration/test_thermocycler.py
+++ b/api/tests/opentrons/hardware_control/integration/test_thermocycler.py
@@ -36,7 +36,7 @@ async def thermocycler(
 def test_device_info(thermocycler: Thermocycler) -> None:
     """It should have device info."""
     assert {
-        "model": "v02",
+        "model": "thermocyclerModuleV2",
         "serial": "thermocycler_emulator",
         "version": "v1.1.0",
     } == thermocycler.device_info

--- a/api/tests/opentrons/hardware_control/modules/test_hc_heatershaker.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_heatershaker.py
@@ -1,11 +1,11 @@
 import asyncio
-import mock
 from typing import Any, AsyncGenerator
 
 from decoy import Decoy
 import pytest
 
-from opentrons.hardware_control import modules, ExecutionManager
+from opentrons.hardware_control import modules, ExecutionManager, poller
+from opentrons.hardware_control.modules.heater_shaker import HeaterShakerReader
 from opentrons.hardware_control.modules.types import (
     TemperatureStatus,
     SpeedStatus,
@@ -16,6 +16,7 @@ from opentrons.hardware_control.modules.types import (
 from opentrons.drivers.rpi_drivers.types import USBPort
 from opentrons.drivers.types import HeaterShakerLabwareLatchStatus, Temperature, RPM
 from opentrons.drivers.heater_shaker.simulator import SimulatingDriver
+from opentrons.drivers.asyncio.communication.errors import UnhandledGcode, ErrorResponse
 
 
 @pytest.fixture
@@ -60,15 +61,37 @@ def mock_driver(decoy: Decoy) -> SimulatingDriver:
 
 
 @pytest.fixture
+async def reader_mocked_driver(mock_driver: SimulatingDriver) -> HeaterShakerReader:
+    """A reader with a mocked driver."""
+    return HeaterShakerReader(driver=mock_driver)
+
+
+@pytest.fixture
 async def simulating_module_driver_patched(
-    simulating_module: modules.HeaterShaker,
     mock_driver: SimulatingDriver,
+    usb_port: USBPort,
+    mock_execution_manager: ExecutionManager,
+    module_error_callback: ModuleErrorCallback,
+    module_disconnected_callback: ModuleDisconnectedCallback,
+    reader_mocked_driver: HeaterShakerReader,
 ) -> AsyncGenerator[modules.AbstractModule, None]:
     """Get a mocked module with a patched driver."""
-    with mock.patch.object(
-        simulating_module, "_driver", mock_driver
-    ), mock.patch.object(simulating_module._reader, "_driver", mock_driver):
-        yield simulating_module
+    poller_obj = poller.Poller(reader=reader_mocked_driver, interval=0.01)
+    module = modules.HeaterShaker(
+        port="/dev/ot_module_sim_heatershaker0",
+        usb_port=usb_port,
+        hw_control_loop=asyncio.get_running_loop(),
+        driver=mock_driver,
+        reader=reader_mocked_driver,
+        poller=poller_obj,
+        device_info={},
+        execution_manager=mock_execution_manager,
+        error_callback=module_error_callback,
+        disconnected_callback=module_disconnected_callback,
+    )
+    await poller_obj.start()
+    yield module
+    await module.cleanup()
 
 
 async def test_sim_state(simulating_module: modules.HeaterShaker) -> None:
@@ -229,15 +252,21 @@ async def test_async_error_response(
 ) -> None:
     """Test that asynchronous error is detected by poller and module live data and status are updated."""
     exc = Exception("Oh no, an asynchronous error!")
+    decoy.when(await mock_driver.get_error_state()).then_return(None)
+    decoy.when(await mock_driver.get_rpm()).then_return(RPM(current=500, target=500))
+    decoy.when(await mock_driver.get_labware_latch_status()).then_return(
+        HeaterShakerLabwareLatchStatus.IDLE_OPEN
+    )
+    decoy.when(await mock_driver.get_temperature()).then_return(
+        Temperature(current=50, target=50)
+    )
+    await simulating_module_driver_patched._poller.wait_next_poll()
     decoy.when(await mock_driver.get_temperature()).then_raise(exc)
     with pytest.raises(Exception):
         await simulating_module_driver_patched._poller.wait_next_poll()
     decoy.verify(
         module_error_callback(
-            exc,
-            "heaterShakerModuleV1",
-            "/dev/ot_module_sim_heatershaker0",
-            "dummySerialHS",
+            exc, "heaterShakerModuleV1", "/dev/ot_module_sim_heatershaker0", None
         )
     )
 
@@ -247,6 +276,7 @@ async def test_async_error_response(
     )
     assert simulating_module_driver_patched.status == HeaterShakerStatus.ERROR
     decoy.reset()
+    decoy.when(await mock_driver.get_error_state()).then_return(None)
     decoy.when(await mock_driver.get_temperature()).then_return(
         Temperature(current=50, target=50)
     )
@@ -257,3 +287,39 @@ async def test_async_error_response(
     await simulating_module_driver_patched._poller.wait_next_poll()
     assert simulating_module_driver_patched.live_data["data"]["errorDetails"] is None  # type: ignore[index,typeddict-item]
     assert simulating_module_driver_patched.status == HeaterShakerStatus.RUNNING  # type: ignore[comparison-overlap]
+
+
+async def test_reader_ignores_get_error_state_not_available(
+    mock_driver: SimulatingDriver,
+    reader_mocked_driver: HeaterShakerReader,
+    decoy: Decoy,
+) -> None:
+    """It should not raise if the module does not support get-error-state."""
+    err = UnhandledGcode(
+        "/dev/ot_module_sim_heatershaker0", "ERR:001:unhandled gcode", "M411"
+    )
+    decoy.when(await mock_driver.get_error_state()).then_raise(err)
+    await reader_mocked_driver.read()
+
+
+async def test_reader_raises_error_from_get_error(
+    mock_driver: SimulatingDriver,
+    module_error_callback: ModuleErrorCallback,
+    simulating_module_driver_patched: modules.HeaterShaker,
+    decoy: Decoy,
+) -> None:
+    """It should put the error all the way out to the error callback from the reader."""
+    error_state_response = ErrorResponse(
+        "/dev/ot_module_sim_heatershaker0", "ERR:666:you know what it is", "M411"
+    )
+    decoy.when(await mock_driver.get_error_state()).then_raise(error_state_response)
+    with pytest.raises(ErrorResponse):
+        await simulating_module_driver_patched._poller.wait_next_poll()
+    decoy.verify(
+        module_error_callback(
+            error_state_response,
+            model="heaterShakerModuleV1",
+            port="/dev/ot_module_sim_heatershaker0",
+            serial=None,
+        )
+    )

--- a/api/tests/opentrons/hardware_control/modules/test_hc_thermocycler.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_thermocycler.py
@@ -18,7 +18,7 @@ from opentrons.hardware_control.modules.thermocycler import (
     ThermocyclerReader,
     ThermocyclerError,
 )
-from opentrons.drivers.asyncio.communication.errors import ErrorResponse
+from opentrons.drivers.asyncio.communication.errors import ErrorResponse, UnhandledGcode
 
 
 POLL_PERIOD = 1.0
@@ -232,6 +232,21 @@ def simulator_set_plate_spy(
 
 
 @pytest.fixture
+def get_error_state_spy(simulator: SimulatingDriver) -> mock.AsyncMock:
+    """Build a spy for get error state."""
+    return mock.AsyncMock(wraps=simulator.get_error_state)
+
+
+@pytest.fixture
+def simulator_get_error_spy(
+    simulator: SimulatingDriver, get_error_state_spy: mock.AsyncMock
+) -> SimulatingDriver:
+    """Fixture that attaches a get error spy to the simulator."""
+    simulator.get_error_state = get_error_state_spy  # type: ignore[method-assign]
+    return simulator
+
+
+@pytest.fixture
 async def set_temperature_subject(
     usb_port: USBPort,
     simulator_set_plate_spy: SimulatingDriver,
@@ -256,6 +271,34 @@ async def set_temperature_subject(
         disconnected_callback=module_disconnected_callback,
     )
 
+    await poller.start()
+    yield hw_tc
+    await hw_tc.cleanup()
+
+
+@pytest.fixture
+async def get_error_subject(
+    usb_port: USBPort,
+    simulator_get_error_spy: SimulatingDriver,
+    mock_execution_manager: ExecutionManager,
+    module_error_callback: ModuleErrorCallback,
+    module_disconnected_callback: ModuleDisconnectedCallback,
+) -> AsyncGenerator[modules.Thermocycler, None]:
+    """Fixture that spys on get error."""
+    reader = ThermocyclerReader(driver=simulator_get_error_spy)
+    poller = Poller(reader=reader, interval=0.01)
+    hw_tc = modules.Thermocycler(
+        port="/dev/ot_module_sim_thermocycler0",
+        usb_port=usb_port,
+        hw_control_loop=asyncio.get_running_loop(),
+        driver=simulator_get_error_spy,
+        reader=reader,
+        poller=poller,
+        device_info={},
+        execution_manager=mock_execution_manager,
+        error_callback=module_error_callback,
+        disconnected_callback=module_disconnected_callback,
+    )
     await poller.start()
     yield hw_tc
     await hw_tc.cleanup()
@@ -533,3 +576,38 @@ def test_can_use_ramp_rate(subject: modules.Thermocycler) -> None:
     assert subject.can_use_ramp_rate() is False
     del subject._device_info["version"]
     assert subject.can_use_ramp_rate() is False
+
+
+async def test_reader_ignores_get_error_state_not_available(
+    get_error_state_spy: mock.AsyncMock,
+    simulator_get_error_spy: SimulatingDriver,
+) -> None:
+    """It should not raise if the module does not support get-error-state."""
+    reader = ThermocyclerReader(driver=simulator_get_error_spy)
+    get_error_state_spy.side_effect = UnhandledGcode(
+        "/dev/ot_module_sim_thermocycler0", "ERR001:unhandled gcode", "M411"
+    )
+    await reader.read()
+
+
+async def test_reader_raises_error_from_get_error(
+    get_error_subject: modules.Thermocycler,
+    get_error_state_spy: mock.AsyncMock,
+    module_error_callback: ModuleErrorCallback,
+    decoy: Decoy,
+) -> None:
+    """It should put the error all the way out to the error callback from the reader."""
+    error_state_response = ErrorResponse(
+        "/dev/ot_module_sim_thermocycler0", "ERR:666:you know what it is", "M411"
+    )
+    get_error_state_spy.side_effect = error_state_response
+    with pytest.raises(ErrorResponse):
+        await get_error_subject._poller.wait_next_poll()
+    decoy.verify(
+        module_error_callback(
+            error_state_response,
+            model="thermocyclerModuleV1",
+            port="/dev/ot_module_sim_thermocycler0",
+            serial=None,
+        )
+    )

--- a/g-code-testing/g_code_parsing/g_code.py
+++ b/g-code-testing/g_code_parsing/g_code.py
@@ -94,6 +94,7 @@ class GCode:
         THERMOCYCLER_G_CODE.DEACTIVATE_BLOCK.name: thermocycler.DeactivateBlockGCodeFunctionalityDef,
         THERMOCYCLER_G_CODE.DEACTIVATE_ALL.name: thermocycler.DeactivateAllGCodeFunctionalityDef,
         THERMOCYCLER_G_CODE.EDIT_PID_PARAMS.name: thermocycler.EditPIDParamsGCodeFunctionalityDef,
+        THERMOCYCLER_G_CODE.GET_ERROR_STATE.name: thermocycler.GetErrorStatusFunctionalityDef,
     }
 
     HEATER_SHAKER_G_CODE_EXPLANATION_MAPPING = {
@@ -106,6 +107,7 @@ class GCode:
         HEATER_SHAKER_G_CODE.OPEN_LABWARE_LATCH.name: heater_shaker.OpenLabwareLatchGCodeFunctionalityDef,
         HEATER_SHAKER_G_CODE.CLOSE_LABWARE_LATCH.name: heater_shaker.CloseLabwareLatchGCodeFunctionalityDef,
         HEATER_SHAKER_G_CODE.GET_LABWARE_LATCH_STATE.name: heater_shaker.GetLabwareLatchStateGCodeFunctionalityDef,
+        HEATER_SHAKER_G_CODE.GET_ERROR_STATE.name: heater_shaker.GetErrorStatusFunctionalityDef,
     }
 
     # Smoothie G-Code Parsing Characters
@@ -158,6 +160,8 @@ class GCode:
         THERMOCYCLER_G_CODE.GET_LID_TEMP.value,
         THERMOCYCLER_G_CODE.GET_PLATE_TEMP.value,
         THERMOCYCLER_G_CODE.GET_LID_STATUS.value,
+        THERMOCYCLER_G_CODE.GET_ERROR_STATE.value,
+        HEATER_SHAKER_G_CODE.GET_ERROR_STATE.value,
     ]
 
     @classmethod

--- a/g-code-testing/g_code_parsing/g_code_engine.py
+++ b/g-code-testing/g_code_parsing/g_code_engine.py
@@ -210,8 +210,8 @@ class GCodeEngine:
             else:
                 raise ValueError(f"APIVersion is {version}")
 
-    @contextmanager
-    def run_http(self, executable: Callable):
+    @asynccontextmanager
+    async def run_http(self, executable: Callable) -> AsyncGenerator:
         """
         Runs http request and returns all G-Code I/O from it
         :param executable: Function connected to HTTP Request to execute
@@ -219,5 +219,5 @@ class GCodeEngine:
         """
         with self._emulate() as h:
             with GCodeWatcher(emulator_settings=self._config) as watcher:
-                asyncio.run(executable(hardware=h))
+                await executable(hardware=h)
             yield GCodeProgram.from_g_code_watcher(watcher)

--- a/g-code-testing/g_code_parsing/g_code_functionality_defs/heater_shaker/__init__.py
+++ b/g-code-testing/g_code_parsing/g_code_functionality_defs/heater_shaker/__init__.py
@@ -11,6 +11,7 @@ from .home_functionality_def import HomeGCodeFunctionalityDef
 from .open_labware_latch_functionality_def import OpenLabwareLatchGCodeFunctionalityDef
 from .set_rpm_functionality_def import SetRPMGCodeFunctionalityDef
 from .set_temperature_functionality_def import SetTempGCodeFunctionalityDef
+from .get_error_status_functionality_def import GetErrorStatusFunctionalityDef
 
 __all__ = [
     "CloseLabwareLatchGCodeFunctionalityDef",
@@ -22,4 +23,5 @@ __all__ = [
     "OpenLabwareLatchGCodeFunctionalityDef",
     "SetRPMGCodeFunctionalityDef",
     "SetTempGCodeFunctionalityDef",
+    "GetErrorStatusFunctionalityDef",
 ]

--- a/g-code-testing/g_code_parsing/g_code_functionality_defs/heater_shaker/get_error_status_functionality_def.py
+++ b/g-code-testing/g_code_parsing/g_code_functionality_defs/heater_shaker/get_error_status_functionality_def.py
@@ -1,0 +1,14 @@
+from typing import Dict
+from g_code_parsing.g_code_functionality_defs.g_code_functionality_def_base import (
+    GCodeFunctionalityDefBase,
+)
+
+
+class GetErrorStatusFunctionalityDef(GCodeFunctionalityDefBase):
+    @classmethod
+    def _generate_command_explanation(cls, g_code_args: Dict[str, str]) -> str:
+        return "Getting heater-shaker error status"
+
+    @classmethod
+    def _generate_response_explanation(cls, response: str) -> str:
+        return "Status is OK"

--- a/g-code-testing/g_code_parsing/g_code_functionality_defs/thermocycler/__init__.py
+++ b/g-code-testing/g_code_parsing/g_code_functionality_defs/thermocycler/__init__.py
@@ -13,6 +13,7 @@ from .deactivate_block_g_code_functionality_def import (
 )
 from .deactivate_all_g_code_functionality_def import DeactivateAllGCodeFunctionalityDef
 from .edit_pid_params_g_code_functionality_def import EditPIDParamsGCodeFunctionalityDef
+from .get_error_status_functionality_def import GetErrorStatusFunctionalityDef
 
 __all__ = [
     "CloseLidGCodeFunctionalityDef",
@@ -28,4 +29,5 @@ __all__ = [
     "DeactivateBlockGCodeFunctionalityDef",
     "DeactivateAllGCodeFunctionalityDef",
     "EditPIDParamsGCodeFunctionalityDef",
+    "GetErrorStatusFunctionalityDef",
 ]

--- a/g-code-testing/g_code_parsing/g_code_functionality_defs/thermocycler/get_error_status_functionality_def.py
+++ b/g-code-testing/g_code_parsing/g_code_functionality_defs/thermocycler/get_error_status_functionality_def.py
@@ -1,0 +1,14 @@
+from typing import Dict
+from g_code_parsing.g_code_functionality_defs.g_code_functionality_def_base import (
+    GCodeFunctionalityDefBase,
+)
+
+
+class GetErrorStatusFunctionalityDef(GCodeFunctionalityDefBase):
+    @classmethod
+    def _generate_command_explanation(cls, g_code_args: Dict[str, str]) -> str:
+        return "Getting thermocycler error status"
+
+    @classmethod
+    def _generate_response_explanation(cls, response: str) -> str:
+        return "Status is OK"

--- a/g-code-testing/g_code_test_data/g_code_configuration.py
+++ b/g-code-testing/g_code_test_data/g_code_configuration.py
@@ -31,24 +31,26 @@ from pydantic import (
 )
 
 BUCKET_NAME = "g-code-comparison"
-COMPARISON_FILES_FOLDER_PATH = os.path.join(os.path.dirname(__file__), 'comparison_files')
+COMPARISON_FILES_FOLDER_PATH = os.path.join(
+    os.path.dirname(__file__), "comparison_files"
+)
 
 
 class SharedFunctionsMixin:
     """Functions that GCodeConfirmConfig classes share."""
+
     def add_mark(self, user_mark: Mark) -> None:
         self.marks.append(user_mark)
 
 
-
 class ProtocolGCodeConfirmConfig(BaseModel, SharedFunctionsMixin):
     path: str
-    name: Optional[Annotated[str, StringConstraints(pattern=r'^[a-z0-9_]*$')]] = None
+    name: Optional[Annotated[str, StringConstraints(pattern=r"^[a-z0-9_]*$")]] = None
     settings: Settings
     results_dir: ClassVar[str] = "protocols"
-    driver: str = 'protocol'
+    driver: str = "protocol"
     marks: List[Mark] = [pytest.mark.g_code_confirm]
-    versions: Set[Union[APIVersion,int]] = Field(..., min_length=1)
+    versions: Set[Union[APIVersion, int]] = Field(..., min_length=1)
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     @model_validator(mode="after")
@@ -61,9 +63,8 @@ class ProtocolGCodeConfirmConfig(BaseModel, SharedFunctionsMixin):
 
     def _get_full_path(self, version: APIVersion):
         return os.path.join(
-            COMPARISON_FILES_FOLDER_PATH,
-            self.get_comparison_file_path(version)
-            )
+            COMPARISON_FILES_FOLDER_PATH, self.get_comparison_file_path(version)
+        )
 
     def get_configuration_paths(self, version: APIVersion) -> str:
         """Get the configuration file path."""
@@ -77,12 +78,14 @@ class ProtocolGCodeConfirmConfig(BaseModel, SharedFunctionsMixin):
         """Pull comparison file and print it's content."""
         file_path = self._get_full_path(version)
         file = open(file_path, "r")
-        return ''.join(file.readlines()).strip()
+        return "".join(file.readlines()).strip()
 
     async def update_comparison(self, version: APIVersion) -> str:
         """Run config and override the comparison file with output."""
-        Path(os.path.dirname(self._get_full_path(version))).mkdir(parents=True, exist_ok=True)
-        with open(self._get_full_path(version), 'w') as file:
+        Path(os.path.dirname(self._get_full_path(version))).mkdir(
+            parents=True, exist_ok=True
+        )
+        with open(self._get_full_path(version), "w") as file:
             file.write(await self.execute(version))
         return "File uploaded successfully"
 
@@ -90,21 +93,25 @@ class ProtocolGCodeConfirmConfig(BaseModel, SharedFunctionsMixin):
         return os.path.exists(self._get_full_path(version))
 
     async def execute(self, version: APIVersion):
-        async with GCodeEngine(self.settings).run_protocol(self.path, version) as program:
+        async with GCodeEngine(self.settings).run_protocol(
+            self.path, version
+        ) as program:
             return program.get_text_explanation(SupportedTextModes.CONCISE)
 
 
 class HTTPGCodeConfirmConfig(BaseModel, SharedFunctionsMixin):
-    name: Annotated[str, StringConstraints(pattern=r'^[a-z0-9_]*$')]
+    name: Annotated[str, StringConstraints(pattern=r"^[a-z0-9_]*$")]
     executable: Callable
     settings: Settings
     results_dir: ClassVar[str] = "http"
-    driver: str = 'http'
+    driver: str = "http"
     marks: List[Mark] = [pytest.mark.g_code_confirm]
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     def _get_full_path(self) -> str:
-        return os.path.join(COMPARISON_FILES_FOLDER_PATH, self.get_comparison_file_path())
+        return os.path.join(
+            COMPARISON_FILES_FOLDER_PATH, self.get_comparison_file_path()
+        )
 
     def comparison_file_exists(self) -> bool:
         return os.path.exists(self._get_full_path())
@@ -120,14 +127,14 @@ class HTTPGCodeConfirmConfig(BaseModel, SharedFunctionsMixin):
     def get_comparison_file(self) -> str:
         """Pull comparison file and print it's content."""
         file = open(self._get_full_path(), "r")
-        return ''.join(file.readlines()).strip()
+        return "".join(file.readlines()).strip()
 
     async def update_comparison(self) -> str:
         """Run config and override the comparison file with output."""
-        with open(self._get_full_path(), 'w') as file:
+        with open(self._get_full_path(), "w") as file:
             file.write(await self.execute())
         return "File uploaded successfully"
 
-    def execute(self):
-        with GCodeEngine(self.settings).run_http(self.executable) as program:
+    async def execute(self):
+        async with GCodeEngine(self.settings).run_http(self.executable) as program:
             return program.get_text_explanation(SupportedTextModes.CONCISE)

--- a/g-code-testing/g_code_test_data/http/http_configurations.py
+++ b/g-code-testing/g_code_test_data/http/http_configurations.py
@@ -3,7 +3,12 @@ from g_code_test_data.http.modules.magdeck import MAGDECK_CONFIGURATIONS
 from g_code_test_data.http.modules.tempdeck import TEMPDECK_CONFIGURATIONS
 from g_code_test_data.http.modules.thermocycler import THERMOCYCLER_CONFIGURATIONS
 
-HTTP_CONFIGURATIONS = ROBOT_CONFIGURATIONS + \
-                      MAGDECK_CONFIGURATIONS + \
-                      TEMPDECK_CONFIGURATIONS + \
-                      THERMOCYCLER_CONFIGURATIONS
+HTTP_CONFIGURATIONS = (
+    ROBOT_CONFIGURATIONS
+    + MAGDECK_CONFIGURATIONS
+    + TEMPDECK_CONFIGURATIONS
+    + THERMOCYCLER_CONFIGURATIONS
+)
+
+for configuration in HTTP_CONFIGURATIONS:
+    configuration.settings.thermocycler.model = "thermocyclerModuleV1"

--- a/g-code-testing/g_code_test_data/protocol/protocol_configurations.py
+++ b/g-code-testing/g_code_test_data/protocol/protocol_configurations.py
@@ -152,7 +152,7 @@ PCR_PREP_PART_1 = ProtocolGCodeConfirmConfig(
 
 PCR_PREP_PART_2 = ProtocolGCodeConfirmConfig(
     path="protocol/protocols/fast/pcr_prep_part_2.py",
-    versions={APIVersion(2, 12), APIVersion(2, 13),APIVersion(2, 14)},
+    versions={APIVersion(2, 12), APIVersion(2, 13), APIVersion(2, 14)},
     settings=Settings(
         smoothie=SmoothieSettings(
             left=PipetteSettings(model="p300_multi_v2.1", id="P20SV202020070101"),
@@ -196,7 +196,7 @@ JSON_SMOKE = ProtocolGCodeConfirmConfig(
         smoothie=SmoothieSettings(
             left=PipetteSettings(model="p300_multi_v2.1", id="P20SV202020070101"),
             right=PipetteSettings(model="p20_single_v2.0", id="P20SV202020070101"),
-        )
+        ),
     ),
 )
 
@@ -228,3 +228,6 @@ FAST_PROTOCOLS = [
 ]
 
 PROTOCOL_CONFIGURATIONS = SLOW_PROTOCOLS + FAST_PROTOCOLS
+
+for configuration in PROTOCOL_CONFIGURATIONS:
+    configuration.settings.thermocycler.model = "thermocyclerModuleV1"

--- a/g-code-testing/tests/test_g_code_comparison.py
+++ b/g-code-testing/tests/test_g_code_comparison.py
@@ -18,9 +18,9 @@ RESULTS_PATH = Path(__file__).parent.parent / "results"
         for conf in HTTP_CONFIGURATIONS
     ],
 )
-def test_http(g_code_configuration: HTTPGCodeConfirmConfig):
+async def test_http(g_code_configuration: HTTPGCodeConfirmConfig):
     expected_output = g_code_configuration.get_comparison_file()
-    actual_output = g_code_configuration.execute()
+    actual_output = await g_code_configuration.execute()
     assert actual_output == expected_output, GCodeDiffer(
         actual_output, expected_output
     ).get_html_diff()


### PR DESCRIPTION
Use the new module gcodes that we recently added for heater-shaker and thermocycler to poll for module error status and toss it in the error callback.

## Other Cool Refactors
- The gcode tests need to know about the new polled gcode and not diff it 76f236197948abe8236791c510eec043d2b4b84a
- The modules need to not just turn themselves off after one error a5fa1a676638ae7201f6acfbfd311c9ac9b1adda
- The modules say they're in an error state over and over, so
   - We need to swallow repeated errors in the engine; if we don't suppress errors in the engine once we're in an error state, then we'll `finish()` over and over and make a nice disco from the z axis brakes 1beb9f9f35523fe65cbfb10fb8fe37e1043ecb47
   - We need to log gcode based errors in pollers less verbosely or we blow out the log c2c7e7058ea8f5cb3aa17f182ae213a383005d5b
- These commands have multiple acks! This will make the response parsers get out of sync forever. Fix this by looking for, well, two acks 6bf9a46f5b31f712abc76fd7e069e2d0e5eab8a8
- We need to not just step on the run error when we autoclear and pretend it's an estop a11f4203a089e5b724394b18fbcb3b24c525c0e4
- The module emulators were totally hosed and now they're less hosed 3bf832c135d5dbf5d54a20ded1edc2be08be54e2

All in all a good tour of the lesser-touched parts of our stack.

Closes EXEC-1703

## tests
- [x] connect a heater/shaker; push a version that sets a delayed error when you set a temperature; check that the async error happens
- [x] ditto thermocycler