### PR TITLE
fix(api): Use the get_histogram retry mechanism instead of the AsyncResponseSerial one.

### DIFF
--- a/api/src/opentrons/drivers/asyncio/communication/serial_connection.py
+++ b/api/src/opentrons/drivers/asyncio/communication/serial_connection.py
@@ -464,8 +464,8 @@ class AsyncResponseSerialConnection(SerialConnection):
     async def send_command(
         self,
         command: CommandBuilder,
-        retries: Optional[int] = None,
-        timeout: Optional[float] = None,
+        retries: int | None = None,
+        timeout: float | None = None,
     ) -> str:
         """
         Send a command and return the response.
@@ -486,7 +486,7 @@ class AsyncResponseSerialConnection(SerialConnection):
         )
 
     async def send_data(
-        self, data: str, retries: int = 0, timeout: Optional[float] = None
+        self, data: str, retries: int | None = None, timeout: float | None = None
     ) -> str:
         """
         Send data and return the response.
@@ -503,7 +503,10 @@ class AsyncResponseSerialConnection(SerialConnection):
         async with super().send_data_lock, self._serial.timeout_override(
             "timeout", timeout
         ):
-            return await self._send_data(data=data, retries=retries)
+            return await self._send_data(
+                data=data,
+                retries=retries if retries is not None else self._number_of_retries,
+            )
 
     async def _send_data(self, data: str, retries: int = 0) -> str:
         """

--- a/api/src/opentrons/drivers/asyncio/communication/serial_connection.py
+++ b/api/src/opentrons/drivers/asyncio/communication/serial_connection.py
@@ -462,7 +462,10 @@ class AsyncResponseSerialConnection(SerialConnection):
         self._async_error_ack = async_error_ack.lower()
 
     async def send_command(
-        self, command: CommandBuilder, retries: int = 0, timeout: Optional[float] = None
+        self,
+        command: CommandBuilder,
+        retries: Optional[int] = None,
+        timeout: Optional[float] = None,
     ) -> str:
         """
         Send a command and return the response.
@@ -478,7 +481,7 @@ class AsyncResponseSerialConnection(SerialConnection):
         """
         return await self.send_data(
             data=command.build(),
-            retries=retries or self._number_of_retries,
+            retries=retries if retries is not None else self._number_of_retries,
             timeout=timeout,
         )
 
@@ -500,9 +503,7 @@ class AsyncResponseSerialConnection(SerialConnection):
         async with super().send_data_lock, self._serial.timeout_override(
             "timeout", timeout
         ):
-            return await self._send_data(
-                data=data, retries=retries or self._number_of_retries
-            )
+            return await self._send_data(data=data, retries=retries)
 
     async def _send_data(self, data: str, retries: int = 0) -> str:
         """
@@ -517,7 +518,6 @@ class AsyncResponseSerialConnection(SerialConnection):
         Raises: SerialException
         """
         data_encode = data.encode()
-        retries = retries or self._number_of_retries
 
         for retry in range(retries + 1):
             log.debug(f"{self._name}: Write -> {data_encode!r}")

--- a/api/src/opentrons/drivers/flex_stacker/driver.py
+++ b/api/src/opentrons/drivers/flex_stacker/driver.py
@@ -461,7 +461,12 @@ class FlexStackerDriver(AbstractFlexStackerDriver):
         command = GCODE.GET_TOF_MEASUREMENT.build_command().add_element(sensor.name)
         if resend:
             command.add_element("R")
-        resp = await self._connection.send_command(command)
+
+        # Note: We DONT want to auto resend the request if it fails, because the
+        # firmware will send the next frame id instead of the current one missed.
+        # So lets set `retries=0` so we only send the frame once and we can
+        # use the retry mechanism of the `get_tof_histogram` method instead.
+        resp = await self._connection.send_command(command, retries=0)
         return self.parse_get_tof_measurement(resp)
 
     async def get_tof_histogram(self, sensor: TOFSensor) -> TOFMeasurementResult:

--- a/api/tests/opentrons/drivers/asyncio/communication/test_serial_connection.py
+++ b/api/tests/opentrons/drivers/asyncio/communication/test_serial_connection.py
@@ -130,19 +130,18 @@ async def test_send_command_with_retry(
 
 
 async def test_send_command_with_zero_retries(
-        mock_serial_port: AsyncMock, subject: SerialKind, ack: str
+    mock_serial_port: AsyncMock, async_subject: AsyncResponseSerialConnection, ack: str
 ) -> None:
     """It should a command once"""
-    mock_serial_port.read_until.return_value = b""
+    mock_serial_port.read_until.side_effect = (b"", b"")
 
     # Set the default number of retries to 1, we want to overide this with
     # the retries from the subject.send_data(data, retries=0) method call.
-    subject._number_of_retries = 1
-
-    print(subject._number_of_retries)
+    async_subject._number_of_retries = 1
 
     with pytest.raises(NoResponse):
-        await subject.send_data(data="send data")
+        # We want this to overwrite the internal `_number_of_retries`
+        await async_subject.send_data(data="send data", retries=0)
 
     mock_serial_port.timeout_override.assert_called_once_with("timeout", None)
     mock_serial_port.write.assert_called_once_with(data=b"send data")

--- a/api/tests/opentrons/drivers/asyncio/communication/test_serial_connection.py
+++ b/api/tests/opentrons/drivers/asyncio/communication/test_serial_connection.py
@@ -129,6 +129,28 @@ async def test_send_command_with_retry(
     )
 
 
+async def test_send_command_with_zero_retries(
+        mock_serial_port: AsyncMock, subject: SerialKind, ack: str
+) -> None:
+    """It should a command once"""
+    mock_serial_port.read_until.return_value = b""
+
+    # Set the default number of retries to 1, we want to overide this with
+    # the retries from the subject.send_data(data, retries=0) method call.
+    subject._number_of_retries = 1
+
+    print(subject._number_of_retries)
+
+    with pytest.raises(NoResponse):
+        await subject.send_data(data="send data")
+
+    mock_serial_port.timeout_override.assert_called_once_with("timeout", None)
+    mock_serial_port.write.assert_called_once_with(data=b"send data")
+    mock_serial_port.read_until.assert_called_once_with(match=ack.encode())
+    mock_serial_port.close.assert_called_once()
+    mock_serial_port.open.assert_called_once()
+
+
 async def test_send_command_with_retry_exhausted(
     mock_serial_port: AsyncMock, subject: SerialKind
 ) -> None:

--- a/api/tests/opentrons/drivers/flex_stacker/test_driver.py
+++ b/api/tests/opentrons/drivers/flex_stacker/test_driver.py
@@ -4,6 +4,7 @@ import pytest
 from binascii import Error as BinError
 from decoy import Decoy
 from mock import AsyncMock, MagicMock
+from opentrons.drivers.asyncio.communication.errors import NoResponse
 from opentrons.drivers.asyncio.communication.serial_connection import (
     AsyncResponseSerialConnection,
 )
@@ -591,7 +592,7 @@ async def test_get_tof_histogram_frame(
     get_measurement = types.GCODE.GET_TOF_MEASUREMENT.build_command().add_element(
         types.TOFSensor.X.name
     )
-    connection.send_command.assert_any_call(get_measurement)
+    connection.send_command.assert_any_call(get_measurement, retries=0)
     connection.reset_mock()
 
     # Test cancel transfer
@@ -611,7 +612,7 @@ async def test_get_tof_histogram_frame(
         .add_element(types.TOFSensor.X.name)
         .add_element("R")
     )
-    connection.send_command.assert_any_call(get_measurement)
+    connection.send_command.assert_any_call(get_measurement, retries=0)
     connection.reset_mock()
 
     # Test invalid index response
@@ -675,7 +676,7 @@ async def test_get_tof_histogram(
         types.TOFSensor.X.name
     )
     connection.send_command.assert_any_call(manage_measurement)
-    connection.send_command.assert_any_call(get_measurement)
+    connection.send_command.assert_any_call(get_measurement, retries=0)
     connection.reset_mock()
 
     # Test invalid frame_id
@@ -699,7 +700,33 @@ async def test_get_tof_histogram(
         types.TOFSensor.X.name
     )
     connection.send_command.assert_any_call(manage_measurement)
-    connection.send_command.assert_any_call(get_measurement)
+    connection.send_command.assert_any_call(get_measurement, retries=0)
+    connection.reset_mock()
+
+    # Test resend mechanism
+    get_measurement = (
+        types.GCODE.GET_TOF_MEASUREMENT.build_command()
+        .add_element(types.TOFSensor.X.name)
+        .add_element("R")
+    )
+    payload = [p for p in get_histogram_payload(30)]
+    connection.send_command.side_effect = [
+        "M215 X:1 T:2 M:3",
+        "M225 X K:0 C:1 L:3840",
+        payload[0],
+        payload[1],
+        # We raise NoResponse on frame 3 to simulate a timeout and force a resend
+        NoResponse("", "Timeout"),
+        # After the timeout we expect the same packet to be resent
+        payload[2]
+        # Then the rest of the packets
+    ] + payload[3:]
+
+    response = await subject.get_tof_histogram(types.TOFSensor.X)
+
+    connection.send_command.assert_any_call(manage_measurement)
+    # Assert that the M226 GCODE with `R` (resend) element was sent
+    connection.send_command.assert_any_call(get_measurement, retries=0)
     connection.reset_mock()
 
 


### PR DESCRIPTION
# Overview

The `GET_TOF_MEASUREMENT = "M226"` GCODE for the Flex Stacker has a built-in frame caching mechanism, so the host can request the current frame to be resent in case of a timeout, invalid packet, etc. By default, the `M226` GCODE sends the next frame, unless we add the `R` element when requesting the frame. Which means that if internally this packet is retried, then it will request the NEXT frame when we are expecting the previous. Since we have this built-in mechanism, let's disable retries when sending the "M226" GCODE in the `_get_tof_histogram_frame` method and instead rely on the retry mechanism in the `get_tof_histogram ` method.

Closes: [RABR-834](https://opentrons.atlassian.net/browse/RABR-834)

## Test Plan and Hands on Testing

- [x] Make sure we can send and receive serial data
- [x] Make sure we don't resend "M226" GCODES when there is a timeout or parsing error
- [x] Make sure we send the "M226" GCODE with the `R` element in case of timeout or parsing error.

## Changelog

- Change the `AsyncSerialConnection.send_data` kwarg `retries` from int to `Optional[int] = None`
- Use the ternary operator to check that `retries` is not None instead of the `or` operator, so that `0` is considered a valid value.
- Set the `retries=0` in the `_get_tof_histogram_frame ` function when sending the "M226" GCODE

## Review requests
## Risk assessment

[RABR-834]: https://opentrons.atlassian.net/browse/RABR-834?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ