### PR TITLE
chore(abr-testing): Update api levels to test 8.7

### DIFF
--- a/abr-testing/abr_testing/protocols/active_protocols/10_ZymoBIOMICS_Magbead_DNA_Cells_Flex.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/10_ZymoBIOMICS_Magbead_DNA_Cells_Flex.py
@@ -19,7 +19,7 @@ metadata = {
 }
 
 
-requirements = {"robotType": "Flex", "apiLevel": "2.25"}
+requirements = {"robotType": "Flex", "apiLevel": "2.26"}
 """
 Slot A1: Tips 1000
 Slot A2: Tips 1000
@@ -76,7 +76,7 @@ def run(protocol: protocol_api.ProtocolContext) -> None:
     deactivate_modules_bool = protocol.params.deactivate_modules  # type: ignore[attr-defined]
     probe_height_bool = protocol.params.probe_liquid_height  # type: ignore[attr-defined]
     meniscus_z = protocol.params.meniscus_z  # type: ignore[attr-defined]
-    helpers.comment_protocol_version(protocol, "02")
+    helpers.comment_protocol_version(protocol, "03")
     if not protocol.is_simulating():
         slack_bot = helpers.set_up_slack()
         slack_bot.send_run_started_message(metadata["protocolName"])

--- a/abr-testing/abr_testing/protocols/active_protocols/11_IDT xGen 1000 ul 96ch.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/11_IDT xGen 1000 ul 96ch.py
@@ -18,7 +18,7 @@ metadata = {
 }
 requirements = {
     "robotType": "Flex",
-    "apiLevel": "2.25",
+    "apiLevel": "2.26",
 }
 
 
@@ -95,6 +95,7 @@ def run(protocol: ProtocolContext) -> None:
     ONDECK_THERMO = True  # Default True    | On Deck Thermocycler
     ONDECK_TEMP = True
     NOLABEL = False  # Default False   | True = Do not include Liquid Labeling,
+    helpers.comment_protocol_version(protocol, "02")
 
     # =============================== PIPETTE ===============================
     p1000 = protocol.load_instrument("flex_96channel_1000", "left")

--- a/abr-testing/abr_testing/protocols/active_protocols/12_Illumina RNA all parts.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/12_Illumina RNA all parts.py
@@ -21,7 +21,7 @@ metadata = {
 }
 requirements = {
     "robotType": "Flex",
-    "apiLevel": "2.25",
+    "apiLevel": "2.26",
 }
 
 
@@ -70,6 +70,8 @@ def add_parameters(parameters: ParameterContext) -> None:
 
 def run(protocol: ProtocolContext) -> None:
     """Protocol."""
+    helpers.comment_protocol_version(protocol, "02")
+
     # ======================== DOWNLOADED PARAMETERS ========================
     global REUSE_ANY_50_TIPS  # T/F Whether or not Reusing any p50
     global REUSE_ANY_200_TIPS  # T/F Whether or not Reusing any p200

--- a/abr-testing/abr_testing/protocols/active_protocols/13_Stacker_Labware_Stamping_Test.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/13_Stacker_Labware_Stamping_Test.py
@@ -18,7 +18,7 @@ metadata = {
     "author": "Rhyann Clarke <rhyann.clarke@opentrons.com",
 }
 
-requirements = {"robotType": "Flex", "apiLevel": "2.25"}
+requirements = {"robotType": "Flex", "apiLevel": "2.26"}
 
 
 DECK_SLOTS = ["A2", "A3", "B1", "B2", "B3", "C1", "C2", "C3", "D2", "D3"]
@@ -127,6 +127,8 @@ def run(ctx: ProtocolContext) -> None:
     use_temp_mod = ctx.params.use_temp_mod  # type: ignore[attr-defined]
     if not ctx.is_simulating():
         from abr_testing.protocols import helpers
+
+        helpers.comment_protocol_version(ctx, "02")
 
         slack_bot = helpers.set_up_slack()
         slack_bot.send_run_started_message(metadata["protocolName"])

--- a/abr-testing/abr_testing/protocols/active_protocols/1_Simple Normalize Long Right.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/1_Simple Normalize Long Right.py
@@ -15,7 +15,7 @@ metadata = {
     "source": "Protocol Library",
 }
 
-requirements = {"robotType": "Flex", "apiLevel": "2.25"}
+requirements = {"robotType": "Flex", "apiLevel": "2.26"}
 
 
 def add_parameters(parameters: ParameterContext) -> None:
@@ -31,7 +31,7 @@ def run(protocol: ProtocolContext) -> None:
     probe_height_bool = protocol.params.probe_liquid_height  # type: ignore[attr-defined]
     meniscus_z = protocol.params.meniscus_z  # type: ignore[attr-defined]
     data = all_data[1:]
-    helpers.comment_protocol_version(protocol, "03")
+    helpers.comment_protocol_version(protocol, "04")
     if not protocol.is_simulating():
         slack_bot = helpers.set_up_slack()
         slack_bot.send_run_started_message(metadata["protocolName"])

--- a/abr-testing/abr_testing/protocols/active_protocols/2_BMS_PCR_Protocol.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/2_BMS_PCR_Protocol.py
@@ -14,7 +14,7 @@ metadata = {
     "protocolName": "PCR Protocol with TC Auto Sealing Lid",
     "author": "Rami Farawi <ndiehl@opentrons.com",
 }
-requirements = {"robotType": "Flex", "apiLevel": "2.25"}
+requirements = {"robotType": "Flex", "apiLevel": "2.26"}
 
 
 def add_parameters(parameters: ParameterContext) -> None:
@@ -37,7 +37,7 @@ def run(protocol: ProtocolContext) -> None:
     deactivate_modules_bool = protocol.params.deactivate_modules  # type: ignore[attr-defined]
     probe_height_bool = protocol.params.probe_liquid_height  # type: ignore[attr-defined]
     meniscus_z = protocol.params.meniscus_z  # type: ignore[attr-defined]
-    helpers.comment_protocol_version(protocol, "04")
+    helpers.comment_protocol_version(protocol, "05")
     if not protocol.is_simulating():
         slack_bot = helpers.set_up_slack()
         slack_bot.send_run_started_message(metadata["protocolName"])

--- a/abr-testing/abr_testing/protocols/active_protocols/4_Illumina DNA Enrichment.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/4_Illumina DNA Enrichment.py
@@ -25,7 +25,7 @@ metadata = {
 
 requirements = {
     "robotType": "Flex",
-    "apiLevel": "2.25",
+    "apiLevel": "2.26",
 }
 
 
@@ -82,7 +82,7 @@ def run(protocol: ProtocolContext) -> None:
     probe_liquid_height_bool = protocol.params.probe_liquid_height  # type: ignore[attr-defined]
     deactivate_modules_bool = protocol.params.deactivate_modules  # type: ignore[attr-defined]
     meniscus_z = protocol.params.meniscus_z  # type: ignore[attr-defined]
-    helpers.comment_protocol_version(protocol, "03")
+    helpers.comment_protocol_version(protocol, "04")
     if not protocol.is_simulating():
         slack_bot = helpers.set_up_slack()
         slack_bot.send_run_started_message(metadata["protocolName"])

--- a/abr-testing/abr_testing/protocols/active_protocols/5_MiSeq Library Preparation.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/5_MiSeq Library Preparation.py
@@ -22,7 +22,7 @@ metadata = {
 }
 
 
-requirements = {"robotType": "Flex", "apiLevel": "2.25"}
+requirements = {"robotType": "Flex", "apiLevel": "2.26"}
 
 
 def add_parameters(parameters: ParameterContext) -> None:
@@ -49,6 +49,7 @@ def run(protocol: ProtocolContext) -> None:
     if not protocol.is_simulating():
         slack_bot = helpers.set_up_slack()
         slack_bot.send_run_started_message(metadata["protocolName"])
+    helpers.comment_protocol_version(protocol, "02")
 
     def transfer(
         pipette: InstrumentContext,

--- a/abr-testing/abr_testing/protocols/active_protocols/6_Olink_Target_48-96.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/6_Olink_Target_48-96.py
@@ -16,7 +16,7 @@ metadata = {
     "author": "Zachary Galluzzo <zachary.galluzzo@opentrons.com>",
 }
 
-requirements = {"robotType": "Flex", "apiLevel": "2.25"}
+requirements = {"robotType": "Flex", "apiLevel": "2.26"}
 
 open_location: Any = "A4"
 
@@ -102,6 +102,7 @@ def run(protocol: ProtocolContext) -> None:
         open_location = "B2"
 
     ninety_six = True if num_samples == 96 else False
+    helpers.comment_protocol_version(protocol, "02")
 
     protocol.comment(f"\n********\nStarting Target {num_samples} Protocol\n********\n")
 

--- a/abr-testing/abr_testing/protocols/active_protocols/7_HDQ_DNA_Bacteria_Flex.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/7_HDQ_DNA_Bacteria_Flex.py
@@ -23,7 +23,7 @@ metadata = {
 
 requirements = {
     "robotType": "Flex",
-    "apiLevel": "2.25",
+    "apiLevel": "2.26",
 }
 """
 Slot A1: Tips 1000
@@ -68,7 +68,7 @@ def run(protocol: ProtocolContext) -> None:
     deactivate_modules_bool = protocol.params.deactivate_modules  # type: ignore[attr-defined]
     probe_height_bool = protocol.params.probe_liquid_height  # type: ignore[attr-defined]
     meniscus_z = protocol.params.meniscus_z  # type: ignore[attr-defined]
-    helpers.comment_protocol_version(protocol, "03")
+    helpers.comment_protocol_version(protocol, "04")
     if not protocol.is_simulating():
         slack_bot = helpers.set_up_slack()
         slack_bot.send_run_started_message(metadata["protocolName"])

--- a/abr-testing/abr_testing/protocols/active_protocols/9_Magmax_RNA_Cells_Flex.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/9_Magmax_RNA_Cells_Flex.py
@@ -26,7 +26,7 @@ metadata = {
 
 requirements = {
     "robotType": "Flex",
-    "apiLevel": "2.25",
+    "apiLevel": "2.26",
 }
 """
 Slot A1: Tips 200
@@ -99,7 +99,7 @@ def run(protocol: ProtocolContext) -> None:
         slack_bot = helpers.set_up_slack()
         slack_bot.send_run_started_message(metadata["protocolName"])
 
-    helpers.comment_protocol_version(protocol, "03")
+    helpers.comment_protocol_version(protocol, "04")
     plate_name_str = "hellma_plate_" + str(plate_orientation)
 
     # Protocol Parameters


### PR DESCRIPTION
# Overview

Update ABR robot protocols to `apiLevel: 2.27` for `v8.7` testing


## Test Plan and Hands on Testing

Simulate and run on robot

