### PR TITLE
fix(protocol-designer): tiprack dependent field

### DIFF
--- a/protocol-designer/release-notes.md
+++ b/protocol-designer/release-notes.md
@@ -8,6 +8,12 @@ By using Opentrons Protocol Designer, you agree to the Opentrons End-User Licens
 
 ---
 
+## Opentrons Protocol Designer Changes in 8.5.5
+
+**Welcome to Protocol Designer 8.5.5!**
+
+This hotfix release fixes the tiprack selected by default for the second pipette attached.
+
 ## Opentrons Protocol Designer Changes in 8.5.4
 
 **Welcome to Protocol Designer 8.5.4!**

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMix.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMix.ts
@@ -127,7 +127,7 @@ const updatePatchOnPipetteChange = (
         Object.values(labwareEntities).map(({ labwareDefURI }) => labwareDefURI)
       )
       firstDefaultTiprackURIOnDeck =
-        pipetteTipracks.find(uri => labwareURIsOnDeck.has(uri)) ?? null
+        pipetteTipracks?.find(uri => labwareURIsOnDeck.has(uri)) ?? null
     }
 
     return {

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMix.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMix.ts
@@ -108,24 +108,33 @@ const updatePatchOnPipetteChannelChange = (
 const updatePatchOnPipetteChange = (
   patch: FormPatch,
   rawForm: FormData,
-  pipetteEntities: PipetteEntities
+  pipetteEntities: PipetteEntities,
+  labwareEntities: LabwareEntities
 ): FormPatch => {
   // when pipette ID is changed (to another ID, or to null),
   // set any flow rates to null
   if (fieldHasChanged(rawForm, patch, 'pipette')) {
     let nozzles: NozzleConfigurationStyle | null = null
+    let firstDefaultTiprackURIOnDeck: string | null = null
     const newPipette = patch.pipette
 
     if (typeof newPipette === 'string' && newPipette in pipetteEntities) {
       const hasPartialTipSupportedChannel =
         pipetteEntities[newPipette].spec.channels !== 1
       nozzles = hasPartialTipSupportedChannel ? ALL : null
+      const pipetteTipracks = pipetteEntities[newPipette].tiprackDefURI
+      const labwareURIsOnDeck = new Set(
+        Object.values(labwareEntities).map(({ labwareDefURI }) => labwareDefURI)
+      )
+      firstDefaultTiprackURIOnDeck =
+        pipetteTipracks.find(uri => labwareURIsOnDeck.has(uri)) ?? null
     }
 
     return {
       ...patch,
       ...getDefaultFields('aspirate_flowRate', 'dispense_flowRate'),
       nozzles,
+      tipRack: firstDefaultTiprackURIOnDeck,
     }
   }
 
@@ -169,7 +178,12 @@ export function dependentFieldsUpdateMix(
         pipetteEntities
       ),
     chainPatch =>
-      updatePatchOnPipetteChange(chainPatch, rawForm, pipetteEntities),
+      updatePatchOnPipetteChange(
+        chainPatch,
+        rawForm,
+        pipetteEntities,
+        labwareEntities
+      ),
     chainPatch => updatePatchOnTiprackChange(chainPatch, rawForm),
   ])
 }

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.ts
@@ -189,7 +189,8 @@ const updatePatchOnLabwareChange = (
 const updatePatchOnPipetteChange = (
   patch: FormPatch,
   rawForm: FormData,
-  pipetteEntities: PipetteEntities
+  pipetteEntities: PipetteEntities,
+  labwareEntities: LabwareEntities
 ): FormPatch => {
   // when pipette ID is changed (to another ID, or to null),
   // set any flow rates, mix volumes, or disposal volumes to null
@@ -198,9 +199,15 @@ const updatePatchOnPipetteChange = (
     const newPipette = patch.pipette
     let airGapVolume: string | null = null
     let nozzles: NozzleConfigurationStyle | null = null
-
+    let firstDefaultTiprackURIOnDeck: string | null = null
     if (typeof newPipette === 'string' && newPipette in pipetteEntities) {
       const minVolume = getMinPipetteVolume(pipetteEntities[newPipette])
+      const pipetteTipracks = pipetteEntities[newPipette].tiprackDefURI
+      const labwareURIsOnDeck = new Set(
+        Object.values(labwareEntities).map(({ labwareDefURI }) => labwareDefURI)
+      )
+      firstDefaultTiprackURIOnDeck =
+        pipetteTipracks.find(uri => labwareURIsOnDeck.has(uri)) ?? null
       airGapVolume = minVolume.toString()
       const hasPartialTipSupportedChannel =
         pipetteEntities[newPipette].spec.channels !== 1
@@ -221,6 +228,7 @@ const updatePatchOnPipetteChange = (
       nozzles,
       aspirate_airGap_volume: airGapVolume,
       dispense_airGap_volume: airGapVolume,
+      tipRack: firstDefaultTiprackURIOnDeck,
     }
   }
 
@@ -721,7 +729,12 @@ export function dependentFieldsUpdateMoveLiquid(
         pipetteEntities
       ),
     chainPatch =>
-      updatePatchOnPipetteChange(chainPatch, rawForm, pipetteEntities),
+      updatePatchOnPipetteChange(
+        chainPatch,
+        rawForm,
+        pipetteEntities,
+        labwareEntities
+      ),
     chainPatch => updatePatchOnWellRatioChange(chainPatch, rawForm),
     chainPatch =>
       updatePatchDisposalVolumeFields(chainPatch, rawForm, pipetteEntities),

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.ts
@@ -207,7 +207,7 @@ const updatePatchOnPipetteChange = (
         Object.values(labwareEntities).map(({ labwareDefURI }) => labwareDefURI)
       )
       firstDefaultTiprackURIOnDeck =
-        pipetteTipracks.find(uri => labwareURIsOnDeck.has(uri)) ?? null
+        pipetteTipracks?.find(uri => labwareURIsOnDeck.has(uri)) ?? null
       airGapVolume = minVolume.toString()
       const hasPartialTipSupportedChannel =
         pipetteEntities[newPipette].spec.channels !== 1

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/test/mix.test.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/test/mix.test.ts
@@ -99,6 +99,7 @@ describe('well selection should update', () => {
       aspirate_flowRate: null,
       dispense_flowRate: null,
       nozzles: null,
+      tipRack: null,
     })
   })
   it('pipette single -> multi', () => {
@@ -111,6 +112,7 @@ describe('well selection should update', () => {
       aspirate_flowRate: null,
       dispense_flowRate: null,
       nozzles: ALL,
+      tipRack: null,
     })
   })
   it('pipette multi -> single', () => {
@@ -124,6 +126,7 @@ describe('well selection should update', () => {
       aspirate_flowRate: null,
       dispense_flowRate: null,
       nozzles: null,
+      tipRack: null,
     })
   })
   it('select single-well labware', () => {

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/moveLiquidFormToArgs.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/moveLiquidFormToArgs.ts
@@ -183,7 +183,6 @@ export const moveLiquidFormToArgs = (
     hydratedFormData.aspirate_wellOrder_first,
     hydratedFormData.aspirate_wellOrder_second
   )
-  console.log('form to args tiprack', tipRack)
 
   const isDispensingIntoDisposalLocation =
     'name' in destLabware &&

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/moveLiquidFormToArgs.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/moveLiquidFormToArgs.ts
@@ -183,6 +183,7 @@ export const moveLiquidFormToArgs = (
     hydratedFormData.aspirate_wellOrder_first,
     hydratedFormData.aspirate_wellOrder_second
   )
+  console.log('form to args tiprack', tipRack)
 
   const isDispensingIntoDisposalLocation =
     'name' in destLabware &&


### PR DESCRIPTION
RQA-4707

# Overview

Fixes an issue where the default selected tiprack for the 2nd pipette was wrong

## Test Plan and Hands on Testing

Upload attached protocol to the ticket
on the 2nd transfer step, open it and change the pipette to the other one then back to the first one.
export
should pass protocol analysis

## Changelog

populate the dependent tiprack string correctly when the pipette changes

## Risk assessment

low
