### PR TITLE
fix(protocol-designer): 8.5.5 migration to migrate the wrong tiprack …

### DIFF
--- a/protocol-designer/fixtures/protocol/8/doItAllV8.json
+++ b/protocol-designer/fixtures/protocol/8/doItAllV8.json
@@ -14,7 +14,7 @@
   },
   "designerApplication": {
     "name": "opentrons/protocol-designer",
-    "version": "8.5.0",
+    "version": "8.5.5",
     "data": {
       "_internalAppBuildDate": "Mon, 16 Jun 2025 20:43:09 GMT",
       "pipetteTiprackAssignments": {

--- a/protocol-designer/src/file-data/__tests__/createFile.test.ts
+++ b/protocol-designer/src/file-data/__tests__/createFile.test.ts
@@ -285,7 +285,7 @@ CUSTOM_LABWARE = json.loads("""{"fixture/fixture_trash/1":{"ordering":[["A1"]],"
             },
           },
         },
-        version: '8.5.0',
+        version: '8.5.5',
         name: 'opentrons/protocol-designer',
       },
       robot: { model: OT2_ROBOT_TYPE },

--- a/protocol-designer/src/load-file/migration/8_5_5.ts
+++ b/protocol-designer/src/load-file/migration/8_5_5.ts
@@ -1,0 +1,58 @@
+import type { ProtocolFile } from '@opentrons/shared-data'
+import type { PDMetadata } from '../../file-types'
+
+export const migrateFile = (
+  appData: ProtocolFile<PDMetadata>
+): ProtocolFile<PDMetadata> => {
+  const { designerApplication } = appData
+
+  if (designerApplication == null || designerApplication?.data == null) {
+    throw Error('The designerApplication key in your file is corrupt.')
+  }
+  const {
+    savedStepForms,
+    pipetteTiprackAssignments,
+    labware,
+  } = designerApplication.data
+
+  const savedStepsWithUpdatedPipettingFields = Object.entries(
+    savedStepForms
+  ).reduce((acc: typeof savedStepForms, [stepId, form]) => {
+    if (form.stepType === 'moveLiquid' || form.stepType === 'mix') {
+      const { tipRack, pipette } = form
+      const assignedTipracks = pipetteTiprackAssignments[pipette] ?? []
+
+      // if the tiprack assigned in the form step isn't in the pipette's assigned tipracks
+      // then update it
+      if (!assignedTipracks.includes(tipRack)) {
+        //  check that the new assigned tiprack is even a labware entity,
+        //  otherwise default to null
+        const newLoadLabwareInfo = Object.values(labware).find(lw =>
+          assignedTipracks.includes(lw.labwareDefURI)
+        )
+        acc[stepId] = {
+          ...form,
+          tipRack: newLoadLabwareInfo?.labwareDefURI ?? null,
+        }
+        return acc
+      }
+    }
+    // default: keep form as is
+    acc[stepId] = form
+    return acc
+  }, {})
+
+  return {
+    ...appData,
+    designerApplication: {
+      ...designerApplication,
+      data: {
+        ...designerApplication.data,
+        savedStepForms: {
+          ...designerApplication.data.savedStepForms,
+          ...savedStepsWithUpdatedPipettingFields,
+        },
+      },
+    },
+  }
+}

--- a/protocol-designer/src/load-file/migration/8_5_5.ts
+++ b/protocol-designer/src/load-file/migration/8_5_5.ts
@@ -24,7 +24,7 @@ export const migrateFile = (
 
       // if the tiprack assigned in the form step isn't in the pipette's assigned tipracks
       // then update it
-      if (!assignedTipracks.includes(tipRack)) {
+      if (!assignedTipracks.includes(tipRack as string)) {
         //  check that the new assigned tiprack is even a labware entity,
         //  otherwise default to null
         const newLoadLabwareInfo = Object.values(labware).find(lw =>
@@ -37,7 +37,6 @@ export const migrateFile = (
         return acc
       }
     }
-    // default: keep form as is
     acc[stepId] = form
     return acc
   }, {})

--- a/protocol-designer/src/load-file/migration/index.ts
+++ b/protocol-designer/src/load-file/migration/index.ts
@@ -16,6 +16,7 @@ import { migrateFile as migrateFileEightTwo } from './8_2_0'
 import { migrateFile as migrateFileEightTwoPointTwo } from './8_2_2'
 import { migrateFile as migrateFileEightFourFour } from './8_4_4'
 import { migrateFile as migrateFileEightFive } from './8_5_0'
+import { migrateFile as migrateFileEightFiveFive } from './8_5_5'
 
 import type {
   PDProtocolFile,
@@ -68,6 +69,8 @@ const allMigrationsByVersion: MigrationsByVersion = {
   '8.4.4': migrateFileEightFourFour,
   // @ts-expect-error
   '8.5.0': migrateFileEightFive,
+  // @ts-expect-error
+  '8.5.5': migrateFileEightFiveFive,
 }
 export const migration = (
   file: any

--- a/step-generation/src/utils/pythonFileUtils.ts
+++ b/step-generation/src/utils/pythonFileUtils.ts
@@ -39,7 +39,7 @@ import type {
 } from '../types'
 
 const PAPI_VERSION = '2.24' // latest version from api/src/opentrons/protocols/api_support/definitions.py
-export const PD_APPLICATION_VERSION = '8.5.0' // latest PD version to insert into DESIGNER_APPLICATION blob
+export const PD_APPLICATION_VERSION = '8.5.5' // latest PD version to insert into DESIGNER_APPLICATION blob
 
 export function pythonImports(): string {
   return ['import json', 'from opentrons import protocol_api, types'].join('\n')


### PR DESCRIPTION
…value

closes RQA-4707

# Overview

Follow up pr for RQA-4707 which adds a migration to migrate the tiprack field correctly.

## Test Plan and Hands on Testing

import attached protocol in the ticket and export and the python should be correct (with the correct tiprack for the liquid. class)/should pass analysis

## Changelog

add a migration file to migrate the tiprack field if it was populated incorrectly.

## Risk assessment

low
