### PR TITLE
fix(app): adding missing manual store and manual retrieve on ER

### DIFF
--- a/app/src/organisms/ErrorRecoveryFlows/shared/SkipStepInfo.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/SkipStepInfo.tsx
@@ -64,6 +64,7 @@ export function SkipStepInfo(props: RecoveryContentProps): JSX.Element {
           }
           break
         case STACKER_STALLED_STORE_SKIP.ROUTE:
+        case STACKER_SHUTTLE_EMPTY_STORE_SKIP.ROUTE:
           void manualStore().then(() => {
             skipFailedCommand()
           })

--- a/app/src/organisms/ErrorRecoveryFlows/shared/SkipStepInfo.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/SkipStepInfo.tsx
@@ -48,6 +48,7 @@ export function SkipStepInfo(props: RecoveryContentProps): JSX.Element {
         case STACKER_HOPPER_EMPTY_SKIP.ROUTE:
         case STACKER_SHUTTLE_EMPTY_SKIP.ROUTE:
         case STACKER_STALLED_SKIP.ROUTE:
+        case SHUTTLE_FULL_SKIP.ROUTE:
           if (
             failedCommand?.byRunRecord.commandType === 'flexStacker/retrieve'
           ) {

--- a/app/src/organisms/ErrorRecoveryFlows/shared/__tests__/SkipStepInfo.test.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/__tests__/SkipStepInfo.test.tsx
@@ -157,6 +157,7 @@ describe('SkipStepInfo', () => {
     RECOVERY_MAP.STACKER_SHUTTLE_EMPTY_SKIP.ROUTE,
     RECOVERY_MAP.STACKER_STALLED_SKIP.ROUTE,
     RECOVERY_MAP.STACKER_STALLED_STORE_SKIP.ROUTE,
+    RECOVERY_MAP.STACKER_SHUTTLE_EMPTY_STORE_SKIP.ROUTE,
   ])('calls manualStore when the route is %s', async route => {
     props.currentRecoveryOptionUtils.selectedRecoveryOption = route
     props.failedCommand = {

--- a/app/src/organisms/ErrorRecoveryFlows/shared/__tests__/SkipStepInfo.test.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/__tests__/SkipStepInfo.test.tsx
@@ -126,6 +126,7 @@ describe('SkipStepInfo', () => {
     RECOVERY_MAP.STACKER_HOPPER_EMPTY_SKIP.ROUTE,
     RECOVERY_MAP.STACKER_SHUTTLE_EMPTY_SKIP.ROUTE,
     RECOVERY_MAP.STACKER_STALLED_SKIP.ROUTE,
+    RECOVERY_MAP.SHUTTLE_FULL_SKIP.ROUTE,
   ])('calls manualRetreive when the route is %s', async route => {
     props.currentRecoveryOptionUtils.selectedRecoveryOption = route
     props.failedCommand = {


### PR DESCRIPTION
# Overview

closes https://opentrons.atlassian.net/browse/RQA-4702,
https://opentrons.atlassian.net/browse/RQA-4705.
POST manaulRetrieve and manualStore on missing ER flows:
- skip shuttle empty on store
- skip stacker full on store


## Test Plan and Hands on Testing

Tested on the FLEX and works as expected

## Risk assessment

low. bug fix
