### PR TITLE
fix(app): ER error details and text copy for shuttle full

### DIFF
--- a/app/src/assets/localization/en/error_recovery.json
+++ b/app/src/assets/localization/en/error_recovery.json
@@ -182,5 +182,9 @@
   "view_recovery_options": "View recovery options",
   "you_can_still_drop_tips": "You can still drop the attached tips before proceeding to tip selection.",
   "stacker_shuttle_store_empty_error_occurs_when": "Shuttle empty errors occur when the robot tries to store labware into a stacker from an empty shuttle",
-  "load_labware_shuttle_to_proceed": "Load the shuttle with the correct labware to complete the stacker store step"
+  "load_labware_shuttle_to_proceed": "Load the shuttle with the correct labware to complete the stacker store step",
+  "stacker_shuttle_occupied_error_occurs_when": "Stacker shuttle full errors occur when the shuttle has labware when it should be empty",
+  "remove_labware_from_shuttle_to_proceed": "Remove the labware from the shuttle to complete the stacker retrieve step",
+  "stacker_hopper_or_shuttle_empty_error_occurs_when": "Stacker errors occur when the stacker is empty when the robot expects the stacker to be filled, or when labware is stuck on the labware latch",
+  "troubleshoot_issue_complete_retrieve_step": "Troubleshoot the issue to complete the stacker retrieve step"
 }

--- a/app/src/assets/localization/en/error_recovery.json
+++ b/app/src/assets/localization/en/error_recovery.json
@@ -183,7 +183,7 @@
   "you_can_still_drop_tips": "You can still drop the attached tips before proceeding to tip selection.",
   "stacker_shuttle_store_empty_error_occurs_when": "Shuttle empty errors occur when the robot tries to store labware into a stacker from an empty shuttle",
   "load_labware_shuttle_to_proceed": "Load the shuttle with the correct labware to complete the stacker store step",
-  "stacker_shuttle_occupied_error_occurs_when": "Stacker shuttle in use errors occur when the shuttle has labware when it should be empty",
+  "stacker_shuttle_occupied_error_occurs_when": "The shuttle has labware when it should be empty",
   "remove_labware_from_shuttle_to_proceed": "Remove the labware from the shuttle to complete the stacker retrieve step",
   "stacker_hopper_or_shuttle_empty_error_occurs_when": "Stacker errors occur when the stacker is empty when the robot expects the stacker to be filled, or when labware is stuck on the labware latch",
   "troubleshoot_issue_complete_retrieve_step": "Troubleshoot the issue to complete the stacker retrieve step"

--- a/app/src/assets/localization/en/error_recovery.json
+++ b/app/src/assets/localization/en/error_recovery.json
@@ -152,7 +152,7 @@
   "stacker_latch_is_jammed": "Stacker latch is jammed",
   "stacker_latch_jammed_errors_occur_when": "Stacker latch jammed errors occur when labware gets stuck in between the stacker latch. This is usually caused by improperly placed labware or inaccurate labware definitions",
   "stacker_latch_will_reengage": "The stacker latch will re-engage so that you can reload the stacker. Make sure that any obstructions have been cleared.",
-  "stacker_shuttle_full": "Stacker shuttle full",
+  "stacker_shuttle_full": "Stacker shuttle in use",
   "stacker_shuttle_missing_error_occurs_when": "Stacker shuttle missing errors occur when the shuttle is not placed correctly on the track",
   "stacker_stall_or_collision_error": "Stacker stalled",
   "stacker_shuttle_store_empty": "Shuttle empty",
@@ -183,7 +183,7 @@
   "you_can_still_drop_tips": "You can still drop the attached tips before proceeding to tip selection.",
   "stacker_shuttle_store_empty_error_occurs_when": "Shuttle empty errors occur when the robot tries to store labware into a stacker from an empty shuttle",
   "load_labware_shuttle_to_proceed": "Load the shuttle with the correct labware to complete the stacker store step",
-  "stacker_shuttle_occupied_error_occurs_when": "Stacker shuttle full errors occur when the shuttle has labware when it should be empty",
+  "stacker_shuttle_occupied_error_occurs_when": "Stacker shuttle in use errors occur when the shuttle has labware when it should be empty",
   "remove_labware_from_shuttle_to_proceed": "Remove the labware from the shuttle to complete the stacker retrieve step",
   "stacker_hopper_or_shuttle_empty_error_occurs_when": "Stacker errors occur when the stacker is empty when the robot expects the stacker to be filled, or when labware is stuck on the labware latch",
   "troubleshoot_issue_complete_retrieve_step": "Troubleshoot the issue to complete the stacker retrieve step"

--- a/app/src/organisms/ErrorRecoveryFlows/shared/ErrorDetailsModal.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/ErrorDetailsModal.tsx
@@ -76,6 +76,8 @@ export function ErrorDetailsModal(props: ErrorDetailsModalProps): JSX.Element {
       case ERROR_KINDS.STACKER_SHUTTLE_EMPTY:
       case ERROR_KINDS.STACKER_SHUTTLE_MISSING:
       case ERROR_KINDS.STACKER_SHUTTLE_STORE_EMPTY:
+      case ERROR_KINDS.STACKER_SHUTTLE_OCCUPIED:
+      case ERROR_KINDS.STACKER_HOPPER_OR_SHUTTLE_EMPTY:
         return true
       default:
         return false
@@ -236,6 +238,10 @@ export function NotificationBanner({
         return <StackerShuttleMissingErrorBanner />
       case ERROR_KINDS.STACKER_SHUTTLE_STORE_EMPTY:
         return <StackerShuttleStoreEmptyErrorBanner />
+      case ERROR_KINDS.STACKER_SHUTTLE_OCCUPIED:
+        return <StackerShuttleOccupiedErrorBanner />
+      case ERROR_KINDS.STACKER_HOPPER_OR_SHUTTLE_EMPTY:
+        return <StackerHopperOrShuttleEmptyErrorBanner />
       default:
         console.error('Handle error kind notification banners explicitly.')
         return <div />
@@ -337,6 +343,30 @@ export function StackerShuttleStoreEmptyErrorBanner(): JSX.Element {
       type="alert"
       heading={t('stacker_shuttle_store_empty_error_occurs_when')}
       message={t('load_labware_shuttle_to_proceed')}
+    />
+  )
+}
+
+export function StackerShuttleOccupiedErrorBanner(): JSX.Element {
+  const { t } = useTranslation('error_recovery')
+
+  return (
+    <InlineNotification
+      type="alert"
+      heading={t('stacker_shuttle_occupied_error_occurs_when')}
+      message={t('remove_labware_from_shuttle_to_proceed')}
+    />
+  )
+}
+
+export function StackerHopperOrShuttleEmptyErrorBanner(): JSX.Element {
+  const { t } = useTranslation('error_recovery')
+
+  return (
+    <InlineNotification
+      type="alert"
+      heading={t('stacker_hopper_or_shuttle_empty_error_occurs_when')}
+      message={t('troubleshoot_issue_complete_retrieve_step')}
     />
   )
 }

--- a/app/src/organisms/ErrorRecoveryFlows/shared/__tests__/ErrorDetailsModal.test.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/__tests__/ErrorDetailsModal.test.tsx
@@ -15,7 +15,9 @@ import {
   LabwareMissingOnShuttleErrorBanner,
   NoLiquidDetectedBanner,
   OverpressureBanner,
+  StackerHopperOrShuttleEmptyErrorBanner,
   StackerShuttleMissingErrorBanner,
+  StackerShuttleOccupiedErrorBanner,
   StackerShuttleStoreEmptyErrorBanner,
   StackerStallErrorBanner,
   StallErrorBanner,
@@ -239,6 +241,35 @@ describe('renders the InlineNotification', () => {
         type: 'alert',
         heading: `A stall or collision is detected when the robot's motors are blocked`,
         message: 'Clear obstructions before proceeding',
+      }),
+      {}
+    )
+  })
+  it('renders the InlineNotification for StackerShuttleOccupiedErrorBanner', () => {
+    renderWithProviders(<StackerShuttleOccupiedErrorBanner />, {
+      i18nInstance: i18n,
+    })
+    expect(vi.mocked(InlineNotification)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'alert',
+        heading:
+          'Stacker shuttle full errors occur when the shuttle has labware when it should be empty',
+        message:
+          'Remove the labware from the shuttle to complete the stacker retrieve step',
+      }),
+      {}
+    )
+  })
+  it('renders the InlineNotification for StackerHopperOrShuttleEmptyErrorBanner', () => {
+    renderWithProviders(<StackerHopperOrShuttleEmptyErrorBanner />, {
+      i18nInstance: i18n,
+    })
+    expect(vi.mocked(InlineNotification)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'alert',
+        heading:
+          'Stacker errors occur when the stacker is empty when the robot expects the stacker to be filled, or when labware is stuck on the labware latch',
+        message: 'Troubleshoot the issue to complete the stacker retrieve step',
       }),
       {}
     )

--- a/app/src/organisms/ErrorRecoveryFlows/shared/__tests__/ErrorDetailsModal.test.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/__tests__/ErrorDetailsModal.test.tsx
@@ -253,7 +253,7 @@ describe('renders the InlineNotification', () => {
       expect.objectContaining({
         type: 'alert',
         heading:
-          'Stacker shuttle full errors occur when the shuttle has labware when it should be empty',
+          'Stacker shuttle in use errors occur when the shuttle has labware when it should be empty',
         message:
           'Remove the labware from the shuttle to complete the stacker retrieve step',
       }),

--- a/app/src/organisms/ErrorRecoveryFlows/shared/__tests__/ErrorDetailsModal.test.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/__tests__/ErrorDetailsModal.test.tsx
@@ -252,8 +252,7 @@ describe('renders the InlineNotification', () => {
     expect(vi.mocked(InlineNotification)).toHaveBeenCalledWith(
       expect.objectContaining({
         type: 'alert',
-        heading:
-          'The shuttle has labware when it should be empty',
+        heading: 'The shuttle has labware when it should be empty',
         message:
           'Remove the labware from the shuttle to complete the stacker retrieve step',
       }),

--- a/app/src/organisms/ErrorRecoveryFlows/shared/__tests__/ErrorDetailsModal.test.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/__tests__/ErrorDetailsModal.test.tsx
@@ -253,7 +253,7 @@ describe('renders the InlineNotification', () => {
       expect.objectContaining({
         type: 'alert',
         heading:
-          'Stacker shuttle in use errors occur when the shuttle has labware when it should be empty',
+          'The shuttle has labware when it should be empty',
         message:
           'Remove the labware from the shuttle to complete the stacker retrieve step',
       }),


### PR DESCRIPTION
# Overview

closes https://opentrons.atlassian.net/browse/EXEC-1444.
added missing error details for shuttle full and stacker error flows.
changed text copy from shuttle full to shuttle in use.

## Test Plan and Hands on Testing

<img width="770" height="426" alt="Screenshot 2025-10-01 at 10 15 52 AM" src="https://github.com/user-attachments/assets/86781f81-7dad-4b4a-bbbf-d134a4449b07" />

<img width="764" height="423" alt="Screenshot 2025-10-01 at 11 50 34 AM" src="https://github.com/user-attachments/assets/50c2a1f8-e86b-49c7-9dca-366bfb42318e" />

<img width="753" height="411" alt="Screenshot 2025-10-01 at 12 40 58 PM" src="https://github.com/user-attachments/assets/5f9681de-a20e-442e-b441-ad88d2873563" />


## Risk assessment

low. bug fixes
