### PR TITLE
fix(api): add stacking_offset_z default None to set_stored_labware_items

### DIFF
--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -1338,7 +1338,7 @@ class FlexStackerContext(ModuleContext):
     def set_stored_labware_items(
         self,
         labware: list[Labware],
-        stacking_offset_z: float | None,
+        stacking_offset_z: float | None = None,
     ) -> None:
         """Configure the labware the Flex Stacker will store during a protocol by providing an initial list of stored labware objects. The start of the list represents the bottom of the Stacker,
         and the end of the list represents the top of the Stacker.


### PR DESCRIPTION
# Overview

`stacking_offset_z` should default to None for `set_stored_labware_items`