### PR TITLE
fix(api): set_stored_labware(): preserve prior behavior for lid/adapter namespace/version

### DIFF
--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -1467,16 +1467,61 @@ class FlexStackerContext(ModuleContext):
               - Labware with lid and adapter: the adapter (bottom side) of the upper labware unit overlaps with the lid (top side) of the unit below.
         """
 
+        if self._api_version < validation.NAMESPACE_VERSION_ADAPTER_LID_VERSION_GATE:
+            if adapter_namespace is not None:
+                raise APIVersionError(
+                    api_element="The `adapter_namespace` parameter",
+                    until_version=str(
+                        validation.NAMESPACE_VERSION_ADAPTER_LID_VERSION_GATE
+                    ),
+                    current_version=str(self._api_version),
+                )
+            if adapter_version is not None:
+                raise APIVersionError(
+                    api_element="The `adapter_version` parameter",
+                    until_version=str(
+                        validation.NAMESPACE_VERSION_ADAPTER_LID_VERSION_GATE
+                    ),
+                    current_version=str(self._api_version),
+                )
+            if lid_namespace is not None:
+                raise APIVersionError(
+                    api_element="The `lid_namespace` parameter",
+                    until_version=str(
+                        validation.NAMESPACE_VERSION_ADAPTER_LID_VERSION_GATE
+                    ),
+                    current_version=str(self._api_version),
+                )
+            if lid_version is not None:
+                raise APIVersionError(
+                    api_element="The `lid_version` parameter",
+                    until_version=str(
+                        validation.NAMESPACE_VERSION_ADAPTER_LID_VERSION_GATE
+                    ),
+                    current_version=str(self._api_version),
+                )
+
+        if self._api_version < validation.NAMESPACE_VERSION_ADAPTER_LID_VERSION_GATE:
+            checked_adapter_namespace = namespace
+            checked_adapter_version = version
+            checked_lid_namespace = namespace
+            checked_lid_version = version
+        else:
+            checked_lid_namespace = lid_namespace
+            checked_lid_version = lid_version
+            checked_adapter_namespace = adapter_namespace
+            checked_adapter_version = adapter_version
+
         self._core.set_stored_labware(
             main_load_name=load_name,
             main_namespace=namespace,
             main_version=version,
             lid_load_name=lid,
-            lid_namespace=lid_namespace,
-            lid_version=lid_version,
+            lid_namespace=checked_lid_namespace,
+            lid_version=checked_lid_version,
             adapter_load_name=adapter,
-            adapter_namespace=adapter_namespace,
-            adapter_version=adapter_version,
+            adapter_namespace=checked_adapter_namespace,
+            adapter_version=checked_adapter_version,
             count=count,
             stacking_offset_z=stacking_offset_z,
         )

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -1507,10 +1507,10 @@ class FlexStackerContext(ModuleContext):
             checked_lid_namespace = namespace
             checked_lid_version = version
         else:
-            checked_lid_namespace = lid_namespace
-            checked_lid_version = lid_version
             checked_adapter_namespace = adapter_namespace
             checked_adapter_version = adapter_version
+            checked_lid_namespace = lid_namespace
+            checked_lid_version = lid_version
 
         self._core.set_stored_labware(
             main_load_name=load_name,

--- a/api/tests/opentrons/protocol_api/test_flex_stacker_context.py
+++ b/api/tests/opentrons/protocol_api/test_flex_stacker_context.py
@@ -17,7 +17,7 @@ from opentrons.protocol_api.core.common import (
 )
 from opentrons.protocol_api.core.core_map import LoadedCoreMap
 
-from . import versions_at_or_above, versions_between
+from . import versions_at_or_above, versions_below, versions_between
 
 
 @pytest.fixture
@@ -175,7 +175,7 @@ def test_set_stored_labware(
         low_inclusive_bound=APIVersion(2, 25), high_exclusive_bound=APIVersion(2, 26)
     ),
 )
-def test_set_stored_labware_namespace_version_param_minimum_version(
+def test_set_stored_labware_namespace_version_params_minimum_version(
     subject: FlexStackerContext,
 ) -> None:
     """{adapter,lid}_{namespace,version} params were unavailable before version 2.26."""
@@ -223,6 +223,48 @@ def test_set_stored_labware_namespace_version_param_minimum_version(
             stacking_offset_z=1.0,
             lid_version=123,
         )
+
+
+@pytest.mark.parametrize(
+    "api_version",
+    versions_between(
+        low_inclusive_bound=APIVersion(2, 25), high_exclusive_bound=APIVersion(2, 26)
+    ),
+)
+def test_set_stored_labware_namespace_version_params_legacy_behavior(
+    decoy: Decoy,
+    mock_core: FlexStackerCore,
+    subject: FlexStackerContext,
+) -> None:
+    """Test legacy (version <2.26) behavior when the {adapter,lid}_{namespace,version} params were omitted.
+
+    The adapter and lid namespace and version were taken from the main labware's namespace and version.
+    """
+    subject.set_stored_labware(
+        load_name=sentinel.main_load_name,
+        namespace=sentinel.main_namespace,
+        version=sentinel.main_version,
+        adapter=sentinel.adapter_load_name,
+        lid=sentinel.lid_load_name,
+        count=sentinel.count,
+        stacking_offset_z=sentinel.stacking_offset_z,
+    )
+
+    decoy.verify(
+        mock_core.set_stored_labware(
+            main_load_name=sentinel.main_load_name,
+            main_namespace=sentinel.main_namespace,
+            main_version=sentinel.main_version,
+            lid_load_name=sentinel.lid_load_name,
+            lid_namespace=sentinel.main_namespace,
+            lid_version=sentinel.main_version,
+            adapter_load_name=sentinel.adapter_load_name,
+            adapter_namespace=sentinel.main_namespace,
+            adapter_version=sentinel.main_version,
+            count=sentinel.count,
+            stacking_offset_z=sentinel.stacking_offset_z,
+        )
+    )
 
 
 @pytest.mark.parametrize(

--- a/api/tests/opentrons/protocol_api/test_flex_stacker_context.py
+++ b/api/tests/opentrons/protocol_api/test_flex_stacker_context.py
@@ -17,7 +17,7 @@ from opentrons.protocol_api.core.common import (
 )
 from opentrons.protocol_api.core.core_map import LoadedCoreMap
 
-from . import versions_at_or_above, versions_below, versions_between
+from . import versions_at_or_above, versions_between
 
 
 @pytest.fixture

--- a/api/tests/opentrons/protocol_api/test_flex_stacker_context.py
+++ b/api/tests/opentrons/protocol_api/test_flex_stacker_context.py
@@ -3,6 +3,7 @@
 import pytest
 from decoy import Decoy, matchers
 
+from opentrons.protocols.api_support.util import APIVersionError
 from opentrons.types import DeckSlotName
 from opentrons.legacy_broker import LegacyBroker
 from opentrons.protocols.api_support.types import APIVersion
@@ -14,7 +15,7 @@ from opentrons.protocol_api.core.common import (
 )
 from opentrons.protocol_api.core.core_map import LoadedCoreMap
 
-from . import versions_at_or_above
+from . import versions_at_or_above, versions_between
 
 
 @pytest.fixture
@@ -156,6 +157,62 @@ def test_set_stored_labware(
             stacking_offset_z=1.0,
         )
     )
+
+
+@pytest.mark.parametrize(
+    "api_version",
+    versions_between(
+        low_inclusive_bound=APIVersion(2, 25), high_exclusive_bound=APIVersion(2, 26)
+    ),
+)
+def test_set_stored_labware_namespace_version_param_minimum_version(
+    subject: FlexStackerContext,
+) -> None:
+    """{adapter,lid}_{namespace,version} params were unavailable before version 2.26."""
+    with pytest.raises(APIVersionError):
+        subject.set_stored_labware(
+            "load_name",
+            "namespace",
+            1,
+            "adapter",
+            "lid",
+            2,
+            stacking_offset_z=1.0,
+            adapter_namespace="foo",
+        )
+    with pytest.raises(APIVersionError):
+        subject.set_stored_labware(
+            "load_name",
+            "namespace",
+            1,
+            "adapter",
+            "lid",
+            2,
+            stacking_offset_z=1.0,
+            adapter_version=123,
+        )
+    with pytest.raises(APIVersionError):
+        subject.set_stored_labware(
+            "load_name",
+            "namespace",
+            1,
+            "adapter",
+            "lid",
+            2,
+            stacking_offset_z=1.0,
+            lid_namespace="foo",
+        )
+    with pytest.raises(APIVersionError):
+        subject.set_stored_labware(
+            "load_name",
+            "namespace",
+            1,
+            "adapter",
+            "lid",
+            2,
+            stacking_offset_z=1.0,
+            lid_version=123,
+        )
 
 
 @pytest.mark.parametrize(

--- a/api/tests/opentrons/protocol_api/test_flex_stacker_context.py
+++ b/api/tests/opentrons/protocol_api/test_flex_stacker_context.py
@@ -1,5 +1,7 @@
 """Tests for Protocol API Flex Stacker contexts."""
 
+from unittest.mock import sentinel
+
 import pytest
 from decoy import Decoy, matchers
 
@@ -106,55 +108,63 @@ def test_empty(
 
 
 @pytest.mark.parametrize(
-    "api_version", versions_at_or_above(from_version=APIVersion(2, 25))
+    "api_version", versions_at_or_above(from_version=APIVersion(2, 26))
 )
 def test_set_stored_labware(
     decoy: Decoy, mock_core: FlexStackerCore, subject: FlexStackerContext
 ) -> None:
     """It should route arguments appropriately."""
     subject.set_stored_labware(
-        "load_name", "namespace", 1, "adapter", "lid", 2, stacking_offset_z=1.0
+        load_name=sentinel.main_load_name,
+        namespace=sentinel.main_namespace,
+        version=sentinel.main_version,
+        adapter=sentinel.adapter_load_name,
+        lid=sentinel.lid_load_name,
+        count=sentinel.count,
+        stacking_offset_z=sentinel.stacking_offset_z,
     )
     decoy.verify(
         mock_core.set_stored_labware(
-            main_load_name="load_name",
-            main_namespace="namespace",
-            main_version=1,
-            lid_load_name="lid",
+            main_load_name=sentinel.main_load_name,
+            main_namespace=sentinel.main_namespace,
+            main_version=sentinel.main_version,
+            lid_load_name=sentinel.lid_load_name,
             lid_namespace=None,
             lid_version=None,
-            adapter_load_name="adapter",
+            adapter_load_name=sentinel.adapter_load_name,
             adapter_namespace=None,
             adapter_version=None,
-            count=2,
-            stacking_offset_z=1.0,
+            count=sentinel.count,
+            stacking_offset_z=sentinel.stacking_offset_z,
         )
     )
 
     subject.set_stored_labware(
-        "load_name",
-        "namespace",
-        1,
-        "adapter",
-        "lid",
-        2,
-        stacking_offset_z=1.0,
-        adapter_namespace="adapter_namespace",
-        adapter_version=3,
+        load_name=sentinel.main_load_name,
+        namespace=sentinel.main_namespace,
+        version=sentinel.main_version,
+        adapter=sentinel.adapter_load_name,
+        lid=sentinel.lid_load_name,
+        count=sentinel.count,
+        stacking_offset_z=sentinel.stacking_offset_z,
+        adapter_namespace=sentinel.adapter_namespace,
+        adapter_version=sentinel.adapter_version,
+        lid_namespace=sentinel.lid_namespace,
+        lid_version=sentinel.lid_version,
     )
     decoy.verify(
         mock_core.set_stored_labware(
-            main_load_name="load_name",
-            main_namespace="namespace",
-            main_version=1,
-            lid_load_name="lid",
-            lid_namespace=None,
-            lid_version=None,
-            adapter_load_name="adapter",
-            adapter_namespace="adapter_namespace",
-            adapter_version=3,
-            count=2,
-            stacking_offset_z=1.0,
+            main_load_name=sentinel.main_load_name,
+            main_namespace=sentinel.main_namespace,
+            main_version=sentinel.main_version,
+            lid_load_name=sentinel.lid_load_name,
+            lid_namespace=sentinel.lid_namespace,
+            lid_version=sentinel.lid_version,
+            adapter_load_name=sentinel.adapter_load_name,
+            adapter_namespace=sentinel.adapter_namespace,
+            adapter_version=sentinel.adapter_version,
+            count=sentinel.count,
+            stacking_offset_z=sentinel.stacking_offset_z,
         )
     )
 


### PR DESCRIPTION
## Overview

This fixes a backwards compatibility bug in my implementation of #19348 / EXEC-1750.

## Details

#19348 did two things, in various places:

1. It added new params
   * `adapter_namespace`
   * `adapter_version`
   * `lid_namespace`
   * `lid_version`
2. It adjusted the behavior when those params were omitted

In one of those places, I forgot:

* to raise an error if you tried using the new params on an older `apiLevel`s
* to preserve the old behavior when the params were omitted

This PR adds that backwards-compatibility behavior, following the pattern from the rest of #19348.

This is targeting `chore_release-8.7.0`. v8.7.0 is the first robot software release that would have the changes from #19348.

## Test Plan and Hands on Testing

Just unit tests?

## Review requests

I think just careful code review to make sure I didn't miss anything else in #19348.

## Risk assessment

Low.