### PR TITLE
fix(robot-server): Tolerate errors when reading individual protocols

### DIFF
--- a/robot-server/robot_server/protocols/protocol_models.py
+++ b/robot-server/robot_server/protocols/protocol_models.py
@@ -26,7 +26,6 @@ class ProtocolKind(str, Enum):
 class ProtocolFile(BaseModel):
     """A file in a protocol."""
 
-    # TODO(mc, 2021-11-12): add unique ID to file resource
     name: str = Field(..., description="The file's basename, including extension")
     role: ProtocolFileRole = Field(..., description="The file's role in the protocol.")
 

--- a/robot-server/robot_server/protocols/protocol_store.py
+++ b/robot-server/robot_server/protocols/protocol_store.py
@@ -8,6 +8,7 @@ from functools import lru_cache
 from logging import getLogger
 from pathlib import Path
 from typing import Dict, List, Optional, Set
+import shutil
 
 from anyio import Path as AsyncPath, create_task_group
 import sqlalchemy
@@ -98,7 +99,7 @@ class ProtocolStore:
         self,
         *,
         _sql_engine: sqlalchemy.engine.Engine,
-        _sources_by_id: Dict[str, ProtocolSource],
+        _sources_by_id: dict[str, ProtocolSource | _BadProtocolSource],
     ) -> None:
         """Do not call directly.
 
@@ -155,7 +156,7 @@ class ProtocolStore:
 
         sources_by_id = await _compute_protocol_sources(
             expected_protocol_ids=expected_ids,
-            protocols_directory=AsyncPath(protocols_directory),
+            protocols_directory=protocols_directory,
             protocol_reader=protocol_reader,
         )
 
@@ -169,16 +170,18 @@ class ProtocolStore:
 
         The resource must have a unique ID.
         """
-        self._sql_insert(
-            resource=_DBProtocolResource(
-                protocol_id=resource.protocol_id,
-                created_at=resource.created_at,
-                protocol_key=resource.protocol_key,
-                protocol_kind=_http_protocol_kind_to_sql(resource.protocol_kind),
+        try:
+            self._sql_insert(
+                resource=_DBProtocolResource(
+                    protocol_id=resource.protocol_id,
+                    created_at=resource.created_at,
+                    protocol_key=resource.protocol_key,
+                    protocol_kind=_http_protocol_kind_to_sql(resource.protocol_kind),
+                )
             )
-        )
-        self._sources_by_id[resource.protocol_id] = resource.source
-        self._clear_caches()
+            self._sources_by_id[resource.protocol_id] = resource.source
+        finally:
+            self._clear_caches()
 
     @lru_cache(maxsize=_CACHE_ENTRIES)
     def get(self, protocol_id: str) -> ProtocolResource:
@@ -188,30 +191,48 @@ class ProtocolStore:
             ProtocolNotFoundError
         """
         sql_resource = self._sql_get(protocol_id=protocol_id)
-        return ProtocolResource(
-            protocol_id=sql_resource.protocol_id,
-            created_at=sql_resource.created_at,
-            protocol_key=sql_resource.protocol_key,
-            protocol_kind=_sql_protocol_kind_to_http(sql_resource.protocol_kind),
-            source=self._sources_by_id[sql_resource.protocol_id],
-        )
+        protocol_source = self._sources_by_id[sql_resource.protocol_id]
+        match protocol_source:
+            case ProtocolSource() as protocol_source:
+                return ProtocolResource(
+                    protocol_id=sql_resource.protocol_id,
+                    created_at=sql_resource.created_at,
+                    protocol_key=sql_resource.protocol_key,
+                    protocol_kind=_sql_protocol_kind_to_http(
+                        sql_resource.protocol_kind
+                    ),
+                    source=protocol_source,
+                )
+            case _BadProtocolSource(reason=reason):
+                raise reason
 
     @lru_cache(maxsize=_CACHE_ENTRIES)
     def get_all(self) -> List[ProtocolResource]:
         """Get all protocols currently saved in this store.
 
         Results are ordered from first-added to last-added.
+
+        If there was an error processing a protocol, it's excluded from the returned
+        list. This can happen, for example, if a software downgrade left the robot with
+        protocol files that are too new for the software that it's running now.
         """
         all_sql_resources = self._sql_get_all()
+        all_sql_resources_and_protocol_sources = (
+            (r, self._sources_by_id[r.protocol_id]) for r in all_sql_resources
+        )
         return [
             ProtocolResource(
-                protocol_id=r.protocol_id,
-                created_at=r.created_at,
-                protocol_key=r.protocol_key,
-                protocol_kind=_sql_protocol_kind_to_http(r.protocol_kind),
-                source=self._sources_by_id[r.protocol_id],
+                protocol_id=sql_resource.protocol_id,
+                created_at=sql_resource.created_at,
+                protocol_key=sql_resource.protocol_key,
+                protocol_kind=_sql_protocol_kind_to_http(sql_resource.protocol_kind),
+                source=protocol_source,
             )
-            for r in all_sql_resources
+            for (
+                sql_resource,
+                protocol_source,
+            ) in all_sql_resources_and_protocol_sources
+            if not isinstance(protocol_source, _BadProtocolSource)
         ]
 
     @lru_cache(maxsize=_CACHE_ENTRIES)
@@ -256,17 +277,20 @@ class ProtocolStore:
             ProtocolUsedByRunError: the protocol could not be deleted because
                 there is a run currently referencing the protocol.
         """
-        self._sql_remove(protocol_id=protocol_id)
+        try:
+            self._sql_remove(protocol_id=protocol_id)
 
-        deleted_source = self._sources_by_id.pop(protocol_id)
-        protocol_dir = deleted_source.directory
-
-        for source_file in deleted_source.files:
-            source_file.path.unlink()
-        if protocol_dir:
-            protocol_dir.rmdir()
-
-        self._clear_caches()
+            deleted_source = self._sources_by_id.pop(protocol_id)
+            match deleted_source:
+                case ProtocolSource(directory=directory, files=files):
+                    for source_file in files:
+                        source_file.path.unlink()
+                    if directory:
+                        directory.rmdir()
+                case _BadProtocolSource(directory=directory):
+                    shutil.rmtree(directory, ignore_errors=True)
+        finally:
+            self._clear_caches()
 
     # Note that this is NOT cached like the other getters because we would need
     # to invalidate the cache whenever the runs table changes, which is not something
@@ -446,18 +470,11 @@ class ProtocolStore:
         self.has.cache_clear()
 
 
-# TODO(mm, 2022-04-18):
-# Restructure to degrade gracefully in the face of ProtocolReader failures.
-#
-# * ProtocolStore.get_all() should omit protocols for which it failed to compute
-#   a ProtocolSource.
-# * ProtocolStore.get(id) should continue to raise an exception if it failed to compute
-#   that protocol's ProtocolSource.
 async def _compute_protocol_sources(
     expected_protocol_ids: Set[str],
-    protocols_directory: AsyncPath,
+    protocols_directory: Path,
     protocol_reader: ProtocolReader,
-) -> Dict[str, ProtocolSource]:
+) -> dict[str, ProtocolSource | _BadProtocolSource]:
     """Compute `ProtocolSource` objects from protocol source files.
 
     We don't store these `ProtocolSource` objects in the SQL database because
@@ -473,19 +490,19 @@ async def _compute_protocol_sources(
         protocol_reader: An interface to use to compute `ProtocolSource`s.
 
     Returns:
-        A map from protocol ID to computed `ProtocolSource`.
+        A map from protocol ID to computed `ProtocolSource`, or an `Exception` if
+        there was a problem processing that particular protocol.
 
     Raises:
         Exception: This is not expected to raise anything,
             but it might if a software update makes ProtocolReader reject files
             that it formerly accepted.
     """
-    sources_by_id: Dict[str, ProtocolSource] = {}
+    sources_by_id: dict[str, ProtocolSource | _BadProtocolSource] = {}
 
-    directory_members = [m async for m in protocols_directory.iterdir()]
+    directory_members = [m async for m in AsyncPath(protocols_directory).iterdir()]
     directory_member_names = set(m.name for m in directory_members)
     extra_members = directory_member_names - expected_protocol_ids
-    missing_members = expected_protocol_ids - directory_member_names
 
     if extra_members:
         # Extra members may be left over from prior interrupted writes
@@ -496,38 +513,47 @@ async def _compute_protocol_sources(
             f" Ignoring them."
         )
 
-    if missing_members:
-        raise SubdirectoryMissingError(
-            f"Missing subdirectories for protocols: {missing_members}"
-        )
-
     async def compute_source(
-        protocol_id: str, protocol_subdirectory: AsyncPath
+        protocol_subdirectory: Path,
+    ) -> ProtocolSource | _BadProtocolSource:
+        try:
+            # Given that the expected protocol subdirectory exists,
+            # we trust that the files in it are correct.
+            # No extra files, and no files missing.
+            #
+            # This is a safe assumption as long as:
+            #  * Nobody has tampered with file the storage.
+            #  * We don't try to compute the source of any protocol whose insertion
+            #    failed halfway through and left files behind.
+            protocol_files = [
+                Path(f) async for f in AsyncPath(protocol_subdirectory).iterdir()
+            ]
+            protocol_source = await protocol_reader.read_saved(
+                files=protocol_files,
+                directory=Path(protocol_subdirectory),
+                files_are_prevalidated=True,
+                python_parse_mode=PythonParseMode.ALLOW_LEGACY_METADATA_AND_REQUIREMENTS,
+            )
+            return protocol_source
+        except Exception as exception:
+            # e.g. if a software downgrade left the robot with some protocol files that
+            # are too new for the software version that it's running now.
+            return _BadProtocolSource(directory=protocol_subdirectory, reason=exception)
+
+    async def compute_source_and_store_in_result_dict(
+        protocol_id: str, protocol_subdirectory: Path
     ) -> None:
-        # Given that the expected protocol subdirectory exists,
-        # we trust that the files in it are correct.
-        # No extra files, and no files missing.
-        #
-        # This is a safe assumption as long as:
-        #  * Nobody has tampered with file the storage.
-        #  * We don't try to compute the source of any protocol whose insertion
-        #    failed halfway through and left files behind.
-        protocol_files = [Path(f) async for f in protocol_subdirectory.iterdir()]
-        protocol_source = await protocol_reader.read_saved(
-            files=protocol_files,
-            directory=Path(protocol_subdirectory),
-            files_are_prevalidated=True,
-            python_parse_mode=PythonParseMode.ALLOW_LEGACY_METADATA_AND_REQUIREMENTS,
-        )
-        sources_by_id[protocol_id] = protocol_source
+        result = await compute_source(protocol_subdirectory)
+        sources_by_id[protocol_id] = result
 
     async with create_task_group() as task_group:
-        # Use a TaskGroup instead of asyncio.gather() so,
-        # if any task raises an unexpected exception,
-        # it cancels every other task and raises an exception to signal the bug.
         for protocol_id in expected_protocol_ids:
             protocol_subdirectory = protocols_directory / protocol_id
-            task_group.start_soon(compute_source, protocol_id, protocol_subdirectory)
+            task_group.start_soon(
+                compute_source_and_store_in_result_dict,
+                protocol_id,
+                protocol_subdirectory,
+            )
 
     for id in expected_protocol_ids:
         assert id in sources_by_id
@@ -543,6 +569,14 @@ class _DBProtocolResource:
     created_at: datetime
     protocol_key: Optional[str]
     protocol_kind: ProtocolKindSQLEnum
+
+
+@dataclass(frozen=True)
+class _BadProtocolSource:
+    """Information about files that we failed to process into a ProtocolSource."""
+
+    directory: Path
+    reason: Exception
 
 
 def _convert_sql_row_to_dataclass(

--- a/robot-server/robot_server/protocols/protocol_store.py
+++ b/robot-server/robot_server/protocols/protocol_store.py
@@ -538,6 +538,7 @@ async def _compute_protocol_sources(
         except Exception as exception:
             # e.g. if a software downgrade left the robot with some protocol files that
             # are too new for the software version that it's running now.
+            _log.exception(f"Error reading protocol in {protocol_subdirectory}.")
             return _BadProtocolSource(directory=protocol_subdirectory, reason=exception)
 
     async def compute_source_and_store_in_result_dict(

--- a/robot-server/robot_server/protocols/protocol_store.py
+++ b/robot-server/robot_server/protocols/protocol_store.py
@@ -117,8 +117,7 @@ class ProtocolStore:
         Params:
             sql_engine: A reference to the database that this ProtocolStore should
                 use as its backing storage.
-                This is expected to already have the proper tables set up;
-                see `add_tables_to_db()`.
+                This is expected to already have the proper tables set up.
                 This should have no protocol data currently stored.
                 If there is data, use `rehydrate()` instead.
         """
@@ -141,8 +140,7 @@ class ProtocolStore:
         Params:
             sql_engine: A reference to the database that this ProtocolStore should
                 use as its backing storage.
-                This is expected to already have the proper tables set up;
-                see `add_tables_to_db()`.
+                This is expected to already have the proper tables set up.
             protocols_directory: Where to look for protocol files while rehydrating.
                 This is expected to have one subdirectory per protocol,
                 named after its protocol ID.

--- a/robot-server/robot_server/protocols/router.py
+++ b/robot-server/robot_server/protocols/router.py
@@ -393,6 +393,8 @@ async def create_protocol(  # noqa: C901
         return await _get_cached_protocol_analysis()
 
     try:
+        # todo(mm, 2025-10-06): ProtocolStore should encapsulate protocol storage;
+        # this router function should not write directly into protocol_directory.
         source = await protocol_reader.save(
             files=buffered_files,
             directory=protocol_directory / protocol_id,
@@ -404,6 +406,8 @@ async def create_protocol(  # noqa: C901
         ) from e
 
     if source.robot_type != robot_type:
+        # fixme(mm, 2025-10-06): Since `source` has already been saved to the filesystem,
+        # this will leave permanent stray files inside `protocol_directory`.
         raise ProtocolRobotTypeMismatch(
             detail=(
                 f"This protocol is for {user_facing_robot_type(source.robot_type)} robots."

--- a/robot-server/tests/protocols/test_protocol_store.py
+++ b/robot-server/tests/protocols/test_protocol_store.py
@@ -1,4 +1,5 @@
 """Tests for the ProtocolStore interface."""
+import textwrap
 from opentrons.protocol_engine.types import CSVParameter, FileInfo
 import pytest
 from decoy import Decoy
@@ -7,6 +8,7 @@ from pathlib import Path
 
 from opentrons.protocols.api_support.types import APIVersion
 from opentrons.protocol_reader import (
+    ProtocolReader,
     ProtocolSource,
     ProtocolSourceFile,
     ProtocolFileRole,
@@ -677,3 +679,93 @@ async def test_get_referenced_data_files(
             source=DataFileSource.UPLOADED,
         ),
     ]
+
+
+async def test_error_tolerance(
+    decoy: Decoy, tmp_path: Path, sql_engine: SQLEngine
+) -> None:
+    """It should tolerate "corrupted" protocol files."""
+    id_1 = "id-1"
+    id_2 = "id-2"
+
+    root_protocol_dir = tmp_path / "protocols"
+    protocol_1_dir = root_protocol_dir / id_1
+    protocol_1_file = protocol_1_dir / "protocol.py"
+    protocol_2_dir = root_protocol_dir / id_2
+    protocol_2_file = protocol_2_dir / "protocol.py"
+
+    ok_python = textwrap.dedent(
+        """\
+        requirements = {"apiLevel": "2.0"}
+        def run(context):
+            pass
+        """
+    )
+    bad_python = textwrap.dedent(
+        """\
+        this ain't even Python
+        """
+    )
+
+    subject_1 = ProtocolStore.create_empty(sql_engine)
+
+    protocol_resource_1 = ProtocolResource(
+        protocol_id=id_1,
+        created_at=datetime(year=2021, month=1, day=1, tzinfo=timezone.utc),
+        source=ProtocolSource(
+            directory=protocol_1_dir,
+            main_file=protocol_1_file,
+            config=PythonProtocolConfig(APIVersion(2, 0)),
+            files=[],
+            metadata={},
+            robot_type="OT-2 Standard",
+            content_hash="abc123",
+        ),
+        protocol_key=None,
+        protocol_kind=ProtocolKind.STANDARD,
+    )
+    protocol_1_dir.mkdir(parents=True)
+    protocol_1_file.write_text(ok_python)
+    subject_1.insert(protocol_resource_1)
+
+    protocol_resource_2 = ProtocolResource(
+        protocol_id=id_2,
+        created_at=datetime(year=2021, month=1, day=1, tzinfo=timezone.utc),
+        source=ProtocolSource(
+            directory=protocol_2_dir,
+            main_file=protocol_2_file,
+            config=PythonProtocolConfig(APIVersion(99999, 99999)),
+            files=[],
+            metadata={},
+            robot_type="OT-2 Standard",
+            content_hash="def456",
+        ),
+        protocol_key=None,
+        protocol_kind=ProtocolKind.STANDARD,
+    )
+    protocol_2_dir.mkdir(parents=True)
+    protocol_2_file.write_text(ok_python)
+    subject_1.insert(protocol_resource_2)
+
+    # Baseline:
+    # With no corrupted files, all getters should work.
+    assert subject_1.get_all_ids() == [id_1, id_2]
+    assert [r.protocol_id for r in subject_1.get_all()] == [id_1, id_2]
+    subject_1.get(id_1)
+    subject_1.get(id_1)
+
+    protocol_2_file.write_text(bad_python)
+
+    subject_2 = await ProtocolStore.rehydrate(
+        sql_engine, root_protocol_dir, ProtocolReader()
+    )
+
+    # With corrupted files, getters that return details about the corrupted
+    # protocol should either silently omit it, if they were returning it as just one
+    # element of many in a collection; or raise the original error, if the caller
+    # was specifically asking for the corrupted protocol.
+    assert subject_2.get_all_ids() == [id_1, id_2]
+    assert [r.protocol_id for r in subject_2.get_all()] == [id_1]
+    subject_2.get(id_1)
+    with pytest.raises(Exception):
+        subject_2.get(id_2)


### PR DESCRIPTION
## Overview

Closes EXEC-1936.

## Test Plan and Hands on Testing

* [x] On a dev server, try uploading a new protocol when the server has been poisoned with a "corrupted" protocol like the one in EXEC-1936.

## Changelog

When the server starts up, if it finds a protocol that is "bad" for any reason (including a too-new `apiLevel`):

* Silently omit it from the list returned by `GET /protocols`.
* Continue to return it in the list returned by `GET /protocols/ids`. (?)
* If it's specifically individually requested through `GET /protocols/{protocolId}`, return an HTTP 500 error.

## Review requests

Does it make sense to continue returning the bad protocol in `GET /protocols/ids`?

## Risk assessment

I'm a little worried about this having knock-on effects when you take the frontend into account. In the worst case, stuff like whitescreens.

Historically, the server tried to detect errors eagerly upon boot, and present itself as "unhealthy" if it found any. Then, the app could block off most user interactions with the robot.

We've been trending towards more granular error tolerance. The whole robot shouldn't be unusable if a single run or protocol is bad. Sounds good, but it carries a risk of making things less forgiving when the app forgets to handle errors in one of its many places where it's requesting protocol info. For example, suppose you're looking at info for a run, and the frontend has a chained request to get some information from the associated protocol. Before, that request might have never even gotten a chance to run. Now, it will return a 500 response. Will the frontend handle that gracefully? I don't know.