### PR TITLE
feat(api): cancel protocols on module disconnects

### DIFF
--- a/api/src/opentrons/hardware_control/module_control.py
+++ b/api/src/opentrons/hardware_control/module_control.py
@@ -30,6 +30,7 @@ from .types import (
     StatusBarUpdateEvent,
     HardwareEvent,
     AsynchronousModuleErrorNotification,
+    ModuleDisconnectedNotification,
 )
 from . import modules
 
@@ -164,13 +165,28 @@ class AttachedModulesControl:
         self.subscribe_to_api_event(mod)
         return mod
 
-    def _disconnected_callback(self, port: str, serial: Optional[str]) -> None:
+    def _disconnected_callback(
+        self, model: str, port: str, serial: Optional[str]
+    ) -> None:
         """Used by the module to indicate that it was disconnected and should be deleted."""
         mod = ModuleAtPort(port=port, serial=serial, name="")
         asyncio.run_coroutine_threadsafe(
             self.unregister_modules([mod]),
             self._api.loop,
         )
+        try:
+            self._api.loop.call_soon(
+                self._event_callback,
+                ModuleDisconnectedNotification(
+                    module_serial=serial,
+                    module_model=modules.module_model_from_string(model),
+                    port=port,
+                ),
+            )
+        except Exception:
+            log.exception(
+                f"Module disconnect callback for module {model} {serial} at {port} failed"
+            )
 
     def _async_error_callback(
         self,
@@ -218,10 +234,15 @@ class AttachedModulesControl:
         for removed_mod in removed_modules:
             try:
                 self._available_modules.remove(removed_mod)
+                # Important: this wants to be after the remove because this may trigger
+                # recursion back to here; we therefore want the module to already be
+                # removed so that the recursion terminates next loop
+                removed_mod.disconnected_callback()
             except ValueError:
-                log.exception(
+                log.warning(
                     f"Removed Module {removed_mod} not found in attached modules"
                 )
+
         for removed_mod in removed_modules:
             log.info(
                 f"Module {removed_mod.name()} detached from port {removed_mod.port}"

--- a/api/src/opentrons/hardware_control/modules/mod_abc.py
+++ b/api/src/opentrons/hardware_control/modules/mod_abc.py
@@ -105,7 +105,7 @@ class AbstractModule(abc.ABC):
     def disconnected_callback(self) -> None:
         """Called from within the module object to signify the object is no longer connected"""
         if self._disconnected_callback is not None:
-            self._disconnected_callback(self.port, self.serial_number)
+            self._disconnected_callback(self.model(), self.port, self.serial_number)
 
     def error_callback(self, exc: Exception) -> None:
         """Called from within the module object when an asynchronous hardware error occurrs."""

--- a/api/src/opentrons/hardware_control/modules/types.py
+++ b/api/src/opentrons/hardware_control/modules/types.py
@@ -59,7 +59,7 @@ UploadFunction = Callable[[str, str, Dict[str, Any]], Awaitable[Tuple[bool, str]
 class ModuleDisconnectedCallback(Protocol):
     """Protocol for the callback when the module should be disconnected."""
 
-    def __call__(self, port: str, serial: str | None) -> None:
+    def __call__(self, model: str, port: str, serial: str | None) -> None:
         ...
 
 

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -75,6 +75,7 @@ from .types import (
     ErrorMessageNotification,
     HardwareEvent,
     AsynchronousModuleErrorNotification,
+    ModuleDisconnectedNotification,
     HardwareEventHandler,
     HardwareAction,
     HepaFanState,
@@ -371,7 +372,10 @@ class OT3API(
     def _send_module_notification(self, event: HardwareEvent) -> None:
         if not isinstance(
             event,
-            AsynchronousModuleErrorNotification,
+            (
+                AsynchronousModuleErrorNotification,
+                ModuleDisconnectedNotification,
+            ),
         ):
             return
         mod_log.info(

--- a/api/src/opentrons/hardware_control/types.py
+++ b/api/src/opentrons/hardware_control/types.py
@@ -399,6 +399,7 @@ class HardwareEventType(enum.Enum):
     ERROR_MESSAGE = enum.auto()
     ESTOP_CHANGE = enum.auto()
     ASYNCHRONOUS_MODULE_ERROR = enum.auto()
+    MODULE_DISCONNECTED = enum.auto()
 
 
 @dataclass
@@ -454,6 +455,16 @@ class AsynchronousModuleErrorNotification:
     ] = HardwareEventType.ASYNCHRONOUS_MODULE_ERROR
 
 
+@dataclass(frozen=True)
+class ModuleDisconnectedNotification:
+    module_serial: str | None
+    module_model: "ModuleModel"
+    port: str
+    event: Literal[
+        HardwareEventType.MODULE_DISCONNECTED
+    ] = HardwareEventType.MODULE_DISCONNECTED
+
+
 # new event types get new dataclasses
 # when we add more event types we add them here
 HardwareEvent = Union[
@@ -461,6 +472,7 @@ HardwareEvent = Union[
     ErrorMessageNotification,
     EstopStateNotification,
     AsynchronousModuleErrorNotification,
+    ModuleDisconnectedNotification,
 ]
 
 HardwareEventHandler = Callable[[HardwareEvent], None]

--- a/api/src/opentrons/protocol_engine/protocol_engine.py
+++ b/api/src/opentrons/protocol_engine/protocol_engine.py
@@ -405,6 +405,39 @@ class ProtocolEngine:
         await self._do_hardware_stop()
         return True
 
+    async def module_disconnected(
+        self, module_model: ModuleModel, serial: str | None
+    ) -> bool:
+        """Signal to the engine that a module has disconnected.
+
+        The return value of this function signals whether the module was relevant to this
+        protocol or not. If the function returns True, the module was relevant. The engine
+        will stop, and the caller should call `finish()` with an appropriate error to indicate
+        the missing module. If the function returns False, the error is not relevant. The engine
+        will not stop, and the caller should not call `finish()`.
+
+        Module disconnects are signaled when a hardware module's status poller indicates that the
+        module is no logner connected - for instance, someone unplugs the module, or it crashes.
+        These errors are not related to a particular command, even a currently-happening module
+        control command for the module in the error state.
+
+        Similar to an estop error, the error can occur at any time relative to the lifecycle
+        of the engine run or of any particular command.
+
+        Unlike an estop, the motion control hardware will not be raising an error and will not
+        stop on its own; the stop action derived from this call will do that.
+        """
+        if not self._state_store.modules.get_has_module_probably_matching_hardware_details(
+            module_model, serial
+        ):
+            return False
+        self._stop_from_asynchronous_error()
+        # like self.request_stop, and unlike self.estop(), we must explicitly request that the
+        # hardware stops execution, since not all asynchronous errors will cause the hardware
+        # to know that it should stop.
+        await self._do_hardware_stop()
+        return True
+
     async def _do_hardware_stop(self) -> None:
         """Make the hardware stop now."""
         if self._hardware_api.is_movement_execution_taskified():

--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -239,7 +239,10 @@ class CommandState:
     """Whether the run has entered error recovery."""
 
     stopped_by_async_error: bool
-    """If this is set to True, the engine was stopped by an estop event."""
+    """If this is set to True, the engine was stopped by an async event."""
+
+    is_stopping_because_of_async_error: bool
+    """If this is set to True, the engine was stopped by an asynch event and hasn't finished stopping."""
 
     error_recovery_policy: ErrorRecoveryPolicy
     """See `CommandView.get_error_recovery_policy()`."""
@@ -273,6 +276,7 @@ class CommandStore(HasState[CommandState], HandlesActions):
             run_started_at=None,
             latest_protocol_command_hash=None,
             stopped_by_async_error=False,
+            is_stopping_because_of_async_error=False,
             error_recovery_policy=error_recovery_policy,
             has_entered_error_recovery=False,
         )
@@ -474,6 +478,7 @@ class CommandStore(HasState[CommandState], HandlesActions):
 
             if action.from_asynchronous_error:
                 self._state.stopped_by_async_error = True
+                self._state.is_stopping_because_of_async_error = True
                 self._state.run_result = RunResult.FAILED
             else:
                 self._state.run_result = RunResult.STOPPED
@@ -499,14 +504,29 @@ class CommandStore(HasState[CommandState], HandlesActions):
                     action.error_details.error,
                 )
         else:
-            # HACK(sf): There needs to be a better way to set
-            # an estop error than this else clause
-            if self._state.stopped_by_async_error and action.error_details:
+            # HACK(sf): There needs to be a better way to handle async errors than this logic
+            # which is way too nonlocal. The idea here is that
+            # (1) there's an async error that calls one of the engine async error handlers,
+            # which emits a stop action and then tells the orchestrator to call finish
+            # (2) calling stop normally would lock out the run error field (since the idea is that
+            # stop happens in the handler of the error that stops the run, and thus the failed
+            # command has already set the run error), but here either the command didn't fail or
+            # the command failed with an error that isn't relevant or is duplicative, so we want
+            # to override that
+            # (3) but we don't want to override it twice, because some other error handler might
+            # tell us to finish with the cancelled error that happens because a command was cancelled
+            # in reaction to (2)
+            # So we set and clear this stopped_by_async_error and it's awful. Let's figure out a better
+            # way.
+
+            if self._state.is_stopping_because_of_async_error and action.error_details:
                 self._state.run_error = self._map_run_exception_to_error_occurrence(
                     action.error_details.error_id,
                     action.error_details.created_at,
                     action.error_details.error,
                 )
+                self._state.is_stopping_because_of_async_error = False
+                self._state.stopped_by_async_error = True
 
     def _handle_hardware_stopped_action(self, action: HardwareStoppedAction) -> None:
         self._state.queue_status = QueueStatus.PAUSED

--- a/api/src/opentrons/protocol_runner/run_orchestrator.py
+++ b/api/src/opentrons/protocol_runner/run_orchestrator.py
@@ -396,6 +396,18 @@ class RunOrchestrator:
             module_model=ModuleModel.from_hardware(module_model), serial=module_serial
         )
 
+    async def module_disconnected(
+        self, module_model: HardwareModuleModel, module_serial: str | None
+    ) -> bool:
+        """Handle an unexpected module disconnection.
+
+        If this function returns true, the caller should call finish() immediately; if it returns
+        False, the caller should not call finish() until it otherwise would.
+        """
+        return await self._protocol_engine.module_disconnected(
+            module_model=ModuleModel.from_hardware(module_model), serial=module_serial
+        )
+
     async def use_attached_modules(
         self, modules_by_id: Dict[str, HardwareModuleAPI]
     ) -> None:

--- a/api/tests/opentrons/protocol_engine/state/test_command_store_old.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_store_old.py
@@ -333,6 +333,7 @@ def test_command_store_handles_pause_action(pause_source: PauseSource) -> None:
         recovery_target=None,
         latest_protocol_command_hash=None,
         stopped_by_async_error=False,
+        is_stopping_because_of_async_error=False,
         error_recovery_policy=matchers.Anything(),
         has_entered_error_recovery=False,
     )
@@ -362,6 +363,7 @@ def test_command_store_handles_play_action(pause_source: PauseSource) -> None:
         run_started_at=datetime(year=2021, month=1, day=1),
         latest_protocol_command_hash=None,
         stopped_by_async_error=False,
+        is_stopping_because_of_async_error=False,
         error_recovery_policy=matchers.Anything(),
         has_entered_error_recovery=False,
     )
@@ -396,6 +398,7 @@ def test_command_store_handles_finish_action() -> None:
         run_started_at=datetime(year=2021, month=1, day=1),
         latest_protocol_command_hash=None,
         stopped_by_async_error=False,
+        is_stopping_because_of_async_error=False,
         error_recovery_policy=matchers.Anything(),
         has_entered_error_recovery=False,
     )
@@ -450,6 +453,7 @@ def test_command_store_handles_stop_action(
         run_started_at=datetime(year=2021, month=1, day=1),
         latest_protocol_command_hash=None,
         stopped_by_async_error=from_asynchronous_error,
+        is_stopping_because_of_async_error=from_asynchronous_error,
         error_recovery_policy=matchers.Anything(),
         has_entered_error_recovery=False,
     )
@@ -487,6 +491,7 @@ def test_command_store_handles_stop_action_when_awaiting_recovery() -> None:
         run_started_at=datetime(year=2021, month=1, day=1),
         latest_protocol_command_hash=None,
         stopped_by_async_error=False,
+        is_stopping_because_of_async_error=False,
         error_recovery_policy=matchers.Anything(),
         has_entered_error_recovery=False,
     )
@@ -520,6 +525,7 @@ def test_command_store_cannot_restart_after_should_stop() -> None:
         run_started_at=None,
         latest_protocol_command_hash=None,
         stopped_by_async_error=False,
+        is_stopping_because_of_async_error=False,
         error_recovery_policy=matchers.Anything(),
         has_entered_error_recovery=False,
     )
@@ -666,6 +672,7 @@ def test_command_store_wraps_unknown_errors() -> None:
         recovery_target=None,
         latest_protocol_command_hash=None,
         stopped_by_async_error=False,
+        is_stopping_because_of_async_error=False,
         error_recovery_policy=matchers.Anything(),
         has_entered_error_recovery=False,
     )
@@ -735,6 +742,7 @@ def test_command_store_preserves_enumerated_errors() -> None:
         run_started_at=None,
         latest_protocol_command_hash=None,
         stopped_by_async_error=False,
+        is_stopping_because_of_async_error=False,
         error_recovery_policy=matchers.Anything(),
         has_entered_error_recovery=False,
     )
@@ -770,6 +778,7 @@ def test_command_store_ignores_stop_after_graceful_finish() -> None:
         run_started_at=datetime(year=2021, month=1, day=1),
         latest_protocol_command_hash=None,
         stopped_by_async_error=False,
+        is_stopping_because_of_async_error=False,
         error_recovery_policy=matchers.Anything(),
         has_entered_error_recovery=False,
     )
@@ -805,6 +814,7 @@ def test_command_store_ignores_finish_after_non_graceful_stop() -> None:
         run_started_at=datetime(year=2021, month=1, day=1),
         latest_protocol_command_hash=None,
         stopped_by_async_error=False,
+        is_stopping_because_of_async_error=False,
         error_recovery_policy=matchers.Anything(),
         has_entered_error_recovery=False,
     )
@@ -840,6 +850,7 @@ def test_handles_hardware_stopped() -> None:
         run_started_at=None,
         latest_protocol_command_hash=None,
         stopped_by_async_error=False,
+        is_stopping_because_of_async_error=False,
         error_recovery_policy=matchers.Anything(),
         has_entered_error_recovery=False,
     )

--- a/api/tests/opentrons/protocol_engine/state/test_command_view_old.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_view_old.py
@@ -120,6 +120,7 @@ def get_command_view(  # noqa: C901
         run_started_at=run_started_at,
         latest_protocol_command_hash=latest_command_hash,
         stopped_by_async_error=False,
+        is_stopping_because_of_async_error=False,
         has_entered_error_recovery=has_entered_error_recovery,
         error_recovery_policy=_placeholder_error_recovery_policy,
     )

--- a/robot-server/robot_server/runs/run_orchestrator_store.py
+++ b/robot-server/robot_server/runs/run_orchestrator_store.py
@@ -15,6 +15,7 @@ from opentrons.protocol_engine.types import (
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition
 from opentrons_shared_data.robot.types import RobotType
 from opentrons_shared_data.robot.types import RobotTypeEnum
+from opentrons_shared_data.errors.exceptions import ModuleNotPresent
 
 from opentrons.config import feature_flags
 from opentrons.hardware_control import HardwareControlAPI
@@ -24,6 +25,7 @@ from opentrons.hardware_control.types import (
     EstopStateNotification,
     HardwareEventHandler,
     AsynchronousModuleErrorNotification,
+    ModuleDisconnectedNotification,
 )
 from opentrons.protocols.api_support.deck_type import should_load_fixed_trash
 from opentrons.protocol_runner import (
@@ -72,7 +74,7 @@ class NoRunOrchestrator(RuntimeError):
     """Raised if you try to get the current run orchestrator while there is none."""
 
 
-async def _do_handle_hardware_event(
+async def _do_handle_hardware_event(  # noqa: C901
     run_orchestrator_store: "RunOrchestratorStore", event: HardwareEvent
 ) -> None:
     if isinstance(event, EstopStateNotification):
@@ -96,6 +98,20 @@ async def _do_handle_hardware_event(
         )
         if should_finish:
             await run_orchestrator_store.run_orchestrator.finish(error=event.exception)
+    elif isinstance(event, ModuleDisconnectedNotification):
+        if run_orchestrator_store.current_run_id is None:
+            return
+        should_finish = (
+            await run_orchestrator_store.run_orchestrator.module_disconnected(
+                module_model=event.module_model, module_serial=event.module_serial
+            )
+        )
+        if should_finish:
+            await run_orchestrator_store.run_orchestrator.finish(
+                error=ModuleNotPresent(
+                    identifier=event.module_serial or event.module_model
+                )
+            )
 
 
 async def handle_hardware_event(


### PR DESCRIPTION
When you disconnect a module that is used by the protocol, cancel the protocol.

There's one other weird thing: I've made the details of how run errors get set much worse, unfortunately. 

The way they're intended to be set is that a command fails; something catches the command failure and sets the run error to be the command's error; then several things call finish() and that has no errors that can be carried. But async errors come with finish(), and the order in which the finish() call comes in relative to the command failure (that is caused by the cancellation) isn't well defined.

So now let's always set the error from finish, if there is one, and it's async, overriding any command failure related errors; and let's set it only once, so that subsequent command failures don't break it.

## testing
- [x] on a flex, run a protocol that uses a module and disconnect the module; the protocol should cancel
- [x] on a flex, run a protocol that uses a module and disconnect a different module; the protocol shouldn't care

Closes EXEC-1707
Closes EXEC-861