### PR TITLE
feat(protocol-designer): add tip select modal skeleton and part 1

### DIFF
--- a/protocol-designer/src/assets/localization/en/index.ts
+++ b/protocol-designer/src/assets/localization/en/index.ts
@@ -17,6 +17,7 @@ import protocol_overview from './protocol_overview.json'
 import protocol_steps from './protocol_steps.json'
 import shared from './shared.json'
 import starting_deck_state from './starting_deck_state.json'
+import tip_selection from './tip_selection.json'
 import tooltip from './tooltip.json'
 import well_selection from './well_selection.json'
 
@@ -42,4 +43,5 @@ export const en = {
   starting_deck_state,
   tooltip,
   well_selection,
+  tip_selection,
 }

--- a/protocol-designer/src/assets/localization/en/tip_selection.json
+++ b/protocol-designer/src/assets/localization/en/tip_selection.json
@@ -1,0 +1,11 @@
+{
+  "back": "Go back",
+  "click_and_drag": "Click and drag to select tips in {{labwareName}}",
+  "continue": "Continue",
+  "no_tiprack_selected": "Select a tiprack to continue",
+  "select": "Select",
+  "selected": "Selected",
+  "select_tiprack": "Select a tip rack to pick up tips from",
+  "select_tips": "Select tips",
+  "select_tips_for_tracking": "Select tips for manual tip tracking"
+}

--- a/protocol-designer/src/assets/localization/en/tip_selection.json
+++ b/protocol-designer/src/assets/localization/en/tip_selection.json
@@ -1,7 +1,7 @@
 {
-  "back": "Go back",
   "click_and_drag": "Click and drag to select tips in {{labwareName}}",
   "continue": "Continue",
+  "go_back": "Go back",
   "no_tiprack_selected": "Select a tiprack to continue",
   "select": "Select",
   "selected": "Selected",

--- a/protocol-designer/src/components/organisms/LabwareOnDeck/index.tsx
+++ b/protocol-designer/src/components/organisms/LabwareOnDeck/index.tsx
@@ -55,7 +55,7 @@ export function LabwareOnDeck(props: LabwareOnDeckProps): JSX.Element {
           wellContents,
           liquidDisplayColors
         )}
-        highlightedWells={showHighlightedWells ? highlightedWells : undefined}
+        {...(showHighlightedWells ? { highlightedWells } : {})}
         missingTips={missingTips}
         highlight={highlight}
       />

--- a/protocol-designer/src/components/organisms/LabwareOnDeck/index.tsx
+++ b/protocol-designer/src/components/organisms/LabwareOnDeck/index.tsx
@@ -14,10 +14,18 @@ interface LabwareOnDeckProps {
   labwareOnDeck: LabwareOnDeckType
   x: number
   y: number
+  highlight?: boolean
+  showHighlightedWells?: boolean
 }
 
 export function LabwareOnDeck(props: LabwareOnDeckProps): JSX.Element {
-  const { labwareOnDeck, x, y } = props
+  const {
+    labwareOnDeck,
+    x,
+    y,
+    highlight = false,
+    showHighlightedWells = true,
+  } = props
   const missingAndUsedTipsByLabwareId = useSelector(
     tipContentsSelectors.getMissingAndUsedTipsByLabwareId
   )
@@ -47,8 +55,9 @@ export function LabwareOnDeck(props: LabwareOnDeckProps): JSX.Element {
           wellContents,
           liquidDisplayColors
         )}
-        highlightedWells={highlightedWells}
+        highlightedWells={showHighlightedWells ? highlightedWells : undefined}
         missingTips={missingTips}
+        highlight={highlight}
       />
     </g>
   )

--- a/protocol-designer/src/pages/Designer/DeckSetup/constants.ts
+++ b/protocol-designer/src/pages/Designer/DeckSetup/constants.ts
@@ -133,12 +133,17 @@ export const MAX_MOAM_MODULES = 7
 //  to be auto-generated
 export const MAX_MAGNETIC_BLOCKS = 10
 
-export const DECK_CONTROLS_STYLE = {
+export const DECK_CONTROLS_STYLE_BASE = {
   position: POSITION_ABSOLUTE,
   top: 0,
   right: 0,
   bottom: 0,
   left: 0,
+  cursor: CURSOR_POINTER,
+}
+
+export const DECK_CONTROLS_STYLE = {
+  ...DECK_CONTROLS_STYLE_BASE,
   transform: 'rotate(180deg) scaleX(-1)',
   zIndex: 1,
   backgroundColor: `${COLORS.black90}cc`,
@@ -147,5 +152,4 @@ export const DECK_CONTROLS_STYLE = {
   color: COLORS.white,
   fontSize: PRODUCT.TYPOGRAPHY.fontFamilyBodyDefaultRegular,
   borderRadius: BORDERS.borderRadius8,
-  cursor: CURSOR_POINTER,
 }

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/BaseDeckTipSelection.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/BaseDeckTipSelection.tsx
@@ -1,0 +1,264 @@
+import { Fragment } from 'react'
+import { useSelector } from 'react-redux'
+
+import {
+  COLORS,
+  FlexTrash,
+  Module,
+  RobotCoordinateSpaceWithRef,
+  SingleSlotFixture,
+  SlotLabels,
+  StagingAreaFixture,
+  WasteChuteFixture,
+  WasteChuteStagingAreaFixture,
+} from '@opentrons/components'
+import {
+  FLEX_ROBOT_TYPE,
+  getAddressableAreaFromSlotId,
+  getCutoutIdForAddressableArea,
+  getDeckDefFromRobotType,
+  getModuleDef,
+  getPositionFromSlotId,
+  inferModuleOrientationFromXCoordinate,
+  isAddressableAreaStandardSlot,
+  STAGING_AREA_CUTOUTS,
+  THERMOCYCLER_MODULE_TYPE,
+  TRASH_BIN_ADAPTER_FIXTURE,
+  WASTE_CHUTE_CUTOUT,
+} from '@opentrons/shared-data'
+import { getSlotInLocationStack } from '@opentrons/step-generation'
+
+import { LabwareOnDeck } from '/protocol-designer/components/organisms'
+import { getRobotType } from '/protocol-designer/file-data/selectors'
+import { getInitialDeckSetup } from '/protocol-designer/step-forms/selectors'
+import { getDeckSetupForActiveItem } from '/protocol-designer/top-selectors/labware-locations'
+import { getLabwaresOnModuleFromStack } from '/protocol-designer/utils'
+
+import type { StagingAreaLocation, TrashCutoutId } from '@opentrons/components'
+import type { CutoutId } from '@opentrons/shared-data'
+import type { AdditionalEquipmentEntity } from '@opentrons/step-generation'
+
+interface BaseDeckTipSelectionProps {
+  controls: JSX.Element
+  hover?: string | null
+  showSlotLabels?: boolean
+  viewBox?: string | null
+}
+
+export function BaseDeckTipSelection(
+  props: BaseDeckTipSelectionProps
+): JSX.Element {
+  const { controls, hover, showSlotLabels = true, viewBox } = props
+  const activeDeckSetup = useSelector(getDeckSetupForActiveItem)
+  const robotType = useSelector(getRobotType)
+  const deckDef = getDeckDefFromRobotType(robotType)
+  const filteredAddressableAreas = deckDef.locations.addressableAreas.filter(
+    aa => isAddressableAreaStandardSlot(aa.id, deckDef)
+  )
+  const initialDeckSetup = useSelector(getInitialDeckSetup)
+  const stagingAreaFixtures: AdditionalEquipmentEntity[] = Object.values(
+    activeDeckSetup.additionalEquipmentOnDeck
+  ).filter(
+    aE =>
+      STAGING_AREA_CUTOUTS.includes(aE.location as CutoutId) &&
+      aE.name === 'stagingArea'
+  )
+  const trash = Object.values(activeDeckSetup.additionalEquipmentOnDeck).find(
+    ae => ae.name === 'trashBin'
+  )
+  const trashBinFixtures = [
+    {
+      cutoutId: trash?.location as CutoutId,
+      cutoutFixtureId: TRASH_BIN_ADAPTER_FIXTURE,
+    },
+  ]
+  const wasteChuteFixtures = Object.values(
+    activeDeckSetup.additionalEquipmentOnDeck
+  ).filter(
+    aE =>
+      WASTE_CHUTE_CUTOUT.includes(aE.location as CutoutId) &&
+      aE.name === 'wasteChute'
+  )
+  const wasteChuteStagingAreaFixtures = Object.values(
+    activeDeckSetup.additionalEquipmentOnDeck
+  ).filter(
+    aE =>
+      STAGING_AREA_CUTOUTS.includes(aE.location as CutoutId) &&
+      aE.name === 'stagingArea' &&
+      aE.location === WASTE_CHUTE_CUTOUT &&
+      wasteChuteFixtures.length > 0
+  )
+  const allLabware = Object.values(activeDeckSetup.labware)
+  const allModules = Object.values(activeDeckSetup.modules)
+  return (
+    <RobotCoordinateSpaceWithRef
+      height="100%"
+      width="100%"
+      deckDef={deckDef}
+      viewBox={viewBox}
+      zoomed={viewBox != null}
+    >
+      {() => (
+        <>
+          {filteredAddressableAreas.map(addressableArea => {
+            const cutoutId = getCutoutIdForAddressableArea(
+              addressableArea.id,
+              deckDef.cutoutFixtures
+            )
+            return cutoutId != null ? (
+              <SingleSlotFixture
+                key={addressableArea.id}
+                cutoutId={cutoutId}
+                deckDefinition={deckDef}
+                slotClipColor={COLORS.grey60}
+                showExpansion={cutoutId === 'cutoutA1'}
+                fixtureBaseColor={COLORS.grey35}
+              />
+            ) : null
+          })}
+          {stagingAreaFixtures.map(fixture => {
+            return (
+              <StagingAreaFixture
+                key={fixture.id}
+                cutoutId={fixture.location as StagingAreaLocation}
+                deckDefinition={deckDef}
+                slotClipColor={COLORS.grey60}
+                fixtureBaseColor={COLORS.grey35}
+              />
+            )
+          })}
+          {trash != null
+            ? trashBinFixtures.map(({ cutoutId }) =>
+                cutoutId != null ? (
+                  <Fragment key={cutoutId}>
+                    <SingleSlotFixture
+                      cutoutId={cutoutId}
+                      deckDefinition={deckDef}
+                      slotClipColor={COLORS.transparent}
+                      fixtureBaseColor={COLORS.grey35}
+                    />
+                    <FlexTrash
+                      robotType={FLEX_ROBOT_TYPE}
+                      trashIconColor={COLORS.grey35}
+                      trashCutoutId={cutoutId as TrashCutoutId}
+                      backgroundColor={COLORS.grey50}
+                    />
+                  </Fragment>
+                ) : null
+              )
+            : null}
+          {wasteChuteFixtures.map(fixture => (
+            <WasteChuteFixture
+              key={fixture.id}
+              cutoutId={fixture.location as typeof WASTE_CHUTE_CUTOUT}
+              deckDefinition={deckDef}
+              fixtureBaseColor={COLORS.grey35}
+            />
+          ))}
+          {wasteChuteStagingAreaFixtures.map(fixture => (
+            <WasteChuteStagingAreaFixture
+              key={fixture.id}
+              cutoutId={fixture.location as typeof WASTE_CHUTE_CUTOUT}
+              deckDefinition={deckDef}
+              slotClipColor={COLORS.grey60}
+              fixtureBaseColor={COLORS.grey35}
+            />
+          ))}
+          {allModules.map(({ id, slot, model, moduleState }) => {
+            const slotId = slot
+            const slotPosition = getPositionFromSlotId(slotId, deckDef)
+            if (slotPosition == null) {
+              console.warn(`no slot ${slotId} for module ${id}`)
+              return null
+            }
+            const moduleDef = getModuleDef(model)
+            const { topMostId, rightBelowTopId } = getLabwaresOnModuleFromStack(
+              id,
+              allLabware
+            )
+            return (
+              <Fragment key={id}>
+                <Module
+                  key={slot}
+                  x={slotPosition[0]}
+                  y={slotPosition[1]}
+                  def={moduleDef}
+                  orientation={inferModuleOrientationFromXCoordinate(
+                    slotPosition[0]
+                  )}
+                  innerProps={
+                    moduleState.type === THERMOCYCLER_MODULE_TYPE
+                      ? { lidMotorState: 'open' }
+                      : {}
+                  }
+                  targetSlotId={slotId}
+                  targetDeckId={deckDef.otId}
+                  childrenPositioningMode="offsetToSlot"
+                >
+                  <>
+                    {rightBelowTopId != null ? (
+                      <LabwareOnDeck
+                        x={0}
+                        y={0}
+                        labwareOnDeck={
+                          initialDeckSetup.labware[rightBelowTopId]
+                        }
+                      />
+                    ) : null}
+                    {topMostId != null ? (
+                      <LabwareOnDeck
+                        x={0}
+                        y={0}
+                        labwareOnDeck={initialDeckSetup.labware[topMostId]}
+                      />
+                    ) : null}
+                  </>
+                </Module>
+              </Fragment>
+            )
+          })}
+
+          {allLabware.map(labware => {
+            if (
+              getSlotInLocationStack(labware.stack) === 'offDeck' ||
+              labware.stack.includes('fixedTrash') ||
+              allModules.some(m => labware.stack.includes(m.id))
+            ) {
+              return null
+            }
+            const slot = getSlotInLocationStack(labware.stack)
+
+            const slotPosition = getPositionFromSlotId(slot, deckDef)
+            const slotBoundingBox = getAddressableAreaFromSlotId(slot, deckDef)
+              ?.boundingBox
+            if (slotPosition == null || slotBoundingBox == null) {
+              console.warn(`no slot ${slot} for labware ${labware.id}!`)
+              return null
+            }
+            return (
+              <LabwareOnDeck
+                key={labware.id}
+                x={slotPosition[0]}
+                y={slotPosition[1]}
+                labwareOnDeck={labware}
+                highlight={labware.id === hover}
+                showHighlightedWells={false}
+              />
+            )
+          })}
+          {/* labware controls for selecting tiprack or tips */}
+          {controls}
+          {showSlotLabels ? (
+            <SlotLabels
+              robotType={robotType}
+              show4thColumn={
+                [...stagingAreaFixtures, ...wasteChuteStagingAreaFixtures]
+                  .length > 0
+              }
+            />
+          ) : null}
+        </>
+      )}
+    </RobotCoordinateSpaceWithRef>
+  )
+}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/BaseDeckTipSelection.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/BaseDeckTipSelection.tsx
@@ -40,7 +40,7 @@ import type { AdditionalEquipmentEntity } from '@opentrons/step-generation'
 
 interface BaseDeckTipSelectionProps {
   controls: JSX.Element
-  hover?: string | null
+  hoveredId?: string | null
   showSlotLabels?: boolean
   viewBox?: string | null
 }
@@ -48,7 +48,7 @@ interface BaseDeckTipSelectionProps {
 export function BaseDeckTipSelection(
   props: BaseDeckTipSelectionProps
 ): JSX.Element {
-  const { controls, hover, showSlotLabels = true, viewBox } = props
+  const { controls, hoveredId, showSlotLabels = true, viewBox } = props
   const activeDeckSetup = useSelector(getDeckSetupForActiveItem)
   const robotType = useSelector(getRobotType)
   const deckDef = getDeckDefFromRobotType(robotType)
@@ -241,7 +241,7 @@ export function BaseDeckTipSelection(
                 x={slotPosition[0]}
                 y={slotPosition[1]}
                 labwareOnDeck={labware}
-                highlight={labware.id === hover}
+                highlight={labware.id === hoveredId}
                 showHighlightedWells={false}
               />
             )

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/SelectTiprack.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/SelectTiprack.tsx
@@ -15,19 +15,9 @@ import { TiprackSelectHover } from './TiprackSelectHover'
 import styles from './tipselectionwizard.module.css'
 import { getIsTiprackSelectable } from './utils'
 
-import type { Dispatch, SetStateAction } from 'react'
-import type { DeckDefinition } from '@opentrons/shared-data'
-import type { AllTemporalPropertiesForTimelineFrame } from '/protocol-designer/step-forms/types'
+import type { TipSelectionBaseProps } from './types'
 
-interface SelectTiprackProps {
-  selectedTiprackId: string | null
-  setSelectedTiprackId: Dispatch<SetStateAction<string | null>>
-  formTiprackUri: string
-  activeDeckSetup: AllTemporalPropertiesForTimelineFrame
-  deckDef: DeckDefinition
-}
-
-export function SelectTiprack(props: SelectTiprackProps): JSX.Element {
+export function SelectTiprack(props: TipSelectionBaseProps): JSX.Element {
   const {
     selectedTiprackId,
     setSelectedTiprackId,
@@ -41,19 +31,20 @@ export function SelectTiprack(props: SelectTiprackProps): JSX.Element {
   const controls = (
     <>
       {Object.values(allLabware).map(labware => {
+        const { id, def, stack } = labware
         if (
-          getSlotInLocationStack(labware.stack) === 'offDeck' ||
-          labware.stack.includes('fixedTrash')
+          getSlotInLocationStack(stack) === 'offDeck' ||
+          stack.includes('fixedTrash')
         ) {
           return null
         }
-        const slot = getSlotInLocationStack(labware.stack)
+        const slot = getSlotInLocationStack(stack)
 
         const slotPosition = getPositionFromSlotId(slot, deckDef)
         const slotBoundingBox = getAddressableAreaFromSlotId(slot, deckDef)
           ?.boundingBox
         if (slotPosition == null || slotBoundingBox == null) {
-          console.warn(`no slot ${slot} for labware ${labware.id}!`)
+          console.warn(`no slot ${slot} for labware ${id}!`)
           return null
         }
         const isTiprackSelectable = getIsTiprackSelectable(
@@ -62,13 +53,13 @@ export function SelectTiprack(props: SelectTiprackProps): JSX.Element {
         )
         return isTiprackSelectable ? (
           <>
-            {labware.id === selectedTiprackId ? (
+            {id === selectedTiprackId ? (
               <LabwareLabel
                 isSelected
                 isLast={true}
                 position={slotPosition}
                 showModuleIcon={false}
-                labwareDef={labware.def}
+                labwareDef={def}
                 labelText={t('selected')}
               />
             ) : null}
@@ -77,7 +68,7 @@ export function SelectTiprack(props: SelectTiprackProps): JSX.Element {
               setHover={setHover}
               slotPosition={slotPosition}
               onClick={() => {
-                setSelectedTiprackId(labware.id)
+                setSelectedTiprackId(id)
               }}
             />
           </>

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/SelectTiprack.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/SelectTiprack.tsx
@@ -27,7 +27,7 @@ export function SelectTiprack(props: TipSelectionBaseProps): JSX.Element {
   } = props
   const { t } = useTranslation('tip_selection')
   const { labware: allLabware } = activeDeckSetup
-  const [hover, setHover] = useState<string | null>(null)
+  const [hoveredId, setHoveredId] = useState<string | null>(null)
   const controls = (
     <>
       {Object.values(allLabware).map(labware => {
@@ -65,7 +65,7 @@ export function SelectTiprack(props: TipSelectionBaseProps): JSX.Element {
             ) : null}
             <TiprackSelectHover
               labware={labware}
-              setHover={setHover}
+              setHover={setHoveredId}
               slotPosition={slotPosition}
               onClick={() => {
                 setSelectedTiprackId(id)
@@ -82,7 +82,7 @@ export function SelectTiprack(props: TipSelectionBaseProps): JSX.Element {
       <StyledText desktopStyle="headingSmallBold">
         {t('select_tiprack')}
       </StyledText>
-      <BaseDeckTipSelection hover={hover} controls={controls} />
+      <BaseDeckTipSelection hoveredId={hoveredId} controls={controls} />
     </div>
   )
 }

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/SelectTiprack.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/SelectTiprack.tsx
@@ -1,0 +1,97 @@
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { StyledText } from '@opentrons/components'
+import {
+  getAddressableAreaFromSlotId,
+  getPositionFromSlotId,
+} from '@opentrons/shared-data'
+import { getSlotInLocationStack } from '@opentrons/step-generation'
+
+import { LabwareLabel } from '/protocol-designer/pages/Designer/LabwareLabel'
+
+import { BaseDeckTipSelection } from './BaseDeckTipSelection'
+import { TiprackSelectHover } from './TiprackSelectHover'
+import styles from './tipselectionwizard.module.css'
+import { getIsTiprackSelectable } from './utils'
+
+import type { Dispatch, SetStateAction } from 'react'
+import type { DeckDefinition } from '@opentrons/shared-data'
+import type { AllTemporalPropertiesForTimelineFrame } from '/protocol-designer/step-forms/types'
+
+interface SelectTiprackProps {
+  selectedTiprackId: string | null
+  setSelectedTiprackId: Dispatch<SetStateAction<string | null>>
+  formTiprackUri: string
+  activeDeckSetup: AllTemporalPropertiesForTimelineFrame
+  deckDef: DeckDefinition
+}
+
+export function SelectTiprack(props: SelectTiprackProps): JSX.Element {
+  const {
+    selectedTiprackId,
+    setSelectedTiprackId,
+    formTiprackUri,
+    activeDeckSetup,
+    deckDef,
+  } = props
+  const { t } = useTranslation('tip_selection')
+  const { labware: allLabware } = activeDeckSetup
+  const [hover, setHover] = useState<string | null>(null)
+  const controls = (
+    <>
+      {Object.values(allLabware).map(labware => {
+        if (
+          getSlotInLocationStack(labware.stack) === 'offDeck' ||
+          labware.stack.includes('fixedTrash')
+        ) {
+          return null
+        }
+        const slot = getSlotInLocationStack(labware.stack)
+
+        const slotPosition = getPositionFromSlotId(slot, deckDef)
+        const slotBoundingBox = getAddressableAreaFromSlotId(slot, deckDef)
+          ?.boundingBox
+        if (slotPosition == null || slotBoundingBox == null) {
+          console.warn(`no slot ${slot} for labware ${labware.id}!`)
+          return null
+        }
+        const isTiprackSelectable = getIsTiprackSelectable(
+          labware,
+          formTiprackUri
+        )
+        return isTiprackSelectable ? (
+          <>
+            {labware.id === selectedTiprackId ? (
+              <LabwareLabel
+                isSelected
+                isLast={true}
+                position={slotPosition}
+                showModuleIcon={false}
+                labwareDef={labware.def}
+                labelText={t('selected')}
+              />
+            ) : null}
+            <TiprackSelectHover
+              labware={labware}
+              setHover={setHover}
+              slotPosition={slotPosition}
+              onClick={() => {
+                setSelectedTiprackId(labware.id)
+              }}
+            />
+          </>
+        ) : null
+      })}
+    </>
+  )
+
+  return (
+    <div className={styles.modal_body}>
+      <StyledText desktopStyle="headingSmallBold">
+        {t('select_tiprack')}
+      </StyledText>
+      <BaseDeckTipSelection hover={hover} controls={controls} />
+    </div>
+  )
+}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/SelectTips.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/SelectTips.tsx
@@ -9,28 +9,21 @@ import { BaseDeckTipSelection } from './BaseDeckTipSelection'
 import styles from './tipselectionwizard.module.css'
 import { getViewboxFromSelectedLabware } from './utils'
 
-import type { Dispatch, SetStateAction } from 'react'
-import type { DeckDefinition } from '@opentrons/shared-data'
-import type { AllTemporalPropertiesForTimelineFrame } from '/protocol-designer/step-forms/types'
+import type { TipSelectionBaseProps } from './types'
 
-interface SelectTipsProps {
-  selectedTiprackId: string | null
-  setSelectedTiprackId: Dispatch<SetStateAction<string | null>>
-  formTiprackUri: string
-  activeDeckSetup: AllTemporalPropertiesForTimelineFrame
-  deckDef: DeckDefinition
-}
-
-export function SelectTips(props: SelectTipsProps): JSX.Element {
+export function SelectTips(props: TipSelectionBaseProps): JSX.Element {
   const { t } = useTranslation('tip_selection')
   const { selectedTiprackId, activeDeckSetup, deckDef } = props
   const labwareNicknamesById = useSelector(getLabwareNicknamesById)
   const labwareName = labwareNicknamesById[selectedTiprackId ?? '']
-  const viewBox = getViewboxFromSelectedLabware(
-    selectedTiprackId ?? '',
-    activeDeckSetup,
-    deckDef
-  )
+  const viewBox =
+    selectedTiprackId != null
+      ? getViewboxFromSelectedLabware(
+          selectedTiprackId,
+          activeDeckSetup,
+          deckDef
+        )
+      : null
 
   if (viewBox == null) {
     console.warn(`no viewbox for selected tiprack ${selectedTiprackId}`)

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/SelectTips.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/SelectTips.tsx
@@ -1,0 +1,54 @@
+import { useTranslation } from 'react-i18next'
+import { useSelector } from 'react-redux'
+
+import { StyledText } from '@opentrons/components'
+
+import { getLabwareNicknamesById } from '/protocol-designer/ui/labware/selectors'
+
+import { BaseDeckTipSelection } from './BaseDeckTipSelection'
+import styles from './tipselectionwizard.module.css'
+import { getViewboxFromSelectedLabware } from './utils'
+
+import type { Dispatch, SetStateAction } from 'react'
+import type { DeckDefinition } from '@opentrons/shared-data'
+import type { AllTemporalPropertiesForTimelineFrame } from '/protocol-designer/step-forms/types'
+
+interface SelectTipsProps {
+  selectedTiprackId: string | null
+  setSelectedTiprackId: Dispatch<SetStateAction<string | null>>
+  formTiprackUri: string
+  activeDeckSetup: AllTemporalPropertiesForTimelineFrame
+  deckDef: DeckDefinition
+}
+
+export function SelectTips(props: SelectTipsProps): JSX.Element {
+  const { t } = useTranslation('tip_selection')
+  const { selectedTiprackId, activeDeckSetup, deckDef } = props
+  const labwareNicknamesById = useSelector(getLabwareNicknamesById)
+  const labwareName = labwareNicknamesById[selectedTiprackId ?? '']
+  const viewBox = getViewboxFromSelectedLabware(
+    selectedTiprackId ?? '',
+    activeDeckSetup,
+    deckDef
+  )
+
+  if (viewBox == null) {
+    console.warn(`no viewbox for selected tiprack ${selectedTiprackId}`)
+  }
+
+  // TODO: add controls for selecting tips
+  const controls = <></>
+
+  return (
+    <div className={styles.modal_body}>
+      <StyledText desktopStyle="headingSmallBold">
+        {t('click_and_drag', { labwareName })}
+      </StyledText>
+      <BaseDeckTipSelection
+        viewBox={viewBox}
+        showSlotLabels={false}
+        controls={controls}
+      />
+    </div>
+  )
+}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/TipSelectionModal.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/TipSelectionModal.tsx
@@ -53,7 +53,7 @@ export function TipSelectionModal(props: TipSelectionModalProps): JSX.Element {
   const footerElement = (
     <div className={styles.modal_footer}>
       {showBackButton ? (
-        <SecondaryButton onClick={onBack}>{t('back')}</SecondaryButton>
+        <SecondaryButton onClick={onBack}>{t('go_back')}</SecondaryButton>
       ) : null}
       <PrimaryButton onClick={onContinue}>{continueText}</PrimaryButton>
     </div>

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/TipSelectionModal.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/TipSelectionModal.tsx
@@ -1,0 +1,70 @@
+import { createPortal } from 'react-dom'
+import { useTranslation } from 'react-i18next'
+
+import {
+  Modal,
+  PrimaryButton,
+  SecondaryButton,
+  SPACING,
+  StyledText,
+} from '@opentrons/components'
+
+import { getMainPagePortalEl } from '/protocol-designer/components/organisms/Portal'
+
+import styles from './tipselectionwizard.module.css'
+
+import type { ReactNode } from 'react'
+
+interface TipSelectionModalProps {
+  onClose: () => void
+  onBack: () => void
+  onContinue: () => void
+  children: ReactNode
+  currentStepIndex: number
+  totalSteps: number
+  showBackButton?: boolean
+  continueText?: string
+}
+
+export function TipSelectionModal(props: TipSelectionModalProps): JSX.Element {
+  const {
+    onClose,
+    onBack,
+    onContinue,
+    children,
+    showBackButton,
+    continueText,
+    currentStepIndex,
+    totalSteps,
+  } = props
+  const { t } = useTranslation('tip_selection')
+  return createPortal(
+    <Modal
+      title={
+        <div className={styles.modal_header}>
+          <StyledText desktopStyle="bodyLargeSemiBold">
+            {t('select_tips_for_tracking')}
+          </StyledText>
+          <StyledText desktopStyle="bodyDefaultRegular">{`Step ${
+            currentStepIndex + 1
+          }/${totalSteps}`}</StyledText>
+        </div>
+      }
+      onClose={onClose}
+      closeOnOutsideClick
+      width="56.25rem"
+      childrenPadding={SPACING.spacing24}
+      footer={
+        <div className={styles.modal_footer}>
+          {showBackButton ? (
+            <SecondaryButton onClick={onBack}>{t('back')}</SecondaryButton>
+          ) : null}
+          <PrimaryButton onClick={onContinue}>{continueText}</PrimaryButton>
+        </div>
+      }
+    >
+      {children}
+    </Modal>,
+    getMainPagePortalEl()
+  )
+}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/TipSelectionModal.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/TipSelectionModal.tsx
@@ -38,30 +38,35 @@ export function TipSelectionModal(props: TipSelectionModalProps): JSX.Element {
     totalSteps,
   } = props
   const { t } = useTranslation('tip_selection')
+
+  const titleElement = (
+    <div className={styles.modal_header}>
+      <StyledText desktopStyle="bodyLargeSemiBold">
+        {t('select_tips_for_tracking')}
+      </StyledText>
+      <StyledText desktopStyle="bodyDefaultRegular">{`Step ${
+        currentStepIndex + 1
+      }/${totalSteps}`}</StyledText>
+    </div>
+  )
+
+  const footerElement = (
+    <div className={styles.modal_footer}>
+      {showBackButton ? (
+        <SecondaryButton onClick={onBack}>{t('back')}</SecondaryButton>
+      ) : null}
+      <PrimaryButton onClick={onContinue}>{continueText}</PrimaryButton>
+    </div>
+  )
+
   return createPortal(
     <Modal
-      title={
-        <div className={styles.modal_header}>
-          <StyledText desktopStyle="bodyLargeSemiBold">
-            {t('select_tips_for_tracking')}
-          </StyledText>
-          <StyledText desktopStyle="bodyDefaultRegular">{`Step ${
-            currentStepIndex + 1
-          }/${totalSteps}`}</StyledText>
-        </div>
-      }
+      title={titleElement}
       onClose={onClose}
       closeOnOutsideClick
       width="56.25rem"
       childrenPadding={SPACING.spacing24}
-      footer={
-        <div className={styles.modal_footer}>
-          {showBackButton ? (
-            <SecondaryButton onClick={onBack}>{t('back')}</SecondaryButton>
-          ) : null}
-          <PrimaryButton onClick={onContinue}>{continueText}</PrimaryButton>
-        </div>
-      }
+      footer={footerElement}
     >
       {children}
     </Modal>,

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/TiprackSelectHover.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/TiprackSelectHover.tsx
@@ -1,0 +1,75 @@
+import {
+  ALIGN_CENTER,
+  BORDERS,
+  COLORS,
+  CURSOR_POINTER,
+  Flex,
+  JUSTIFY_CENTER,
+  RobotCoordsForeignDiv,
+  SPACING,
+} from '@opentrons/components'
+
+import { DECK_CONTROLS_STYLE } from '/protocol-designer/pages/Designer/DeckSetup/constants'
+
+import type { Dispatch, SetStateAction } from 'react'
+import type { CoordinateTuple } from '@opentrons/shared-data'
+import type { LabwareOnDeck } from '/protocol-designer/step-forms'
+
+interface TiprackSelectHoverProps {
+  slotPosition: CoordinateTuple
+  labware: LabwareOnDeck
+  setHover: Dispatch<SetStateAction<string | null>>
+  onClick: () => void
+}
+
+export function TiprackSelectHover(
+  props: TiprackSelectHoverProps
+): JSX.Element {
+  const slotFill = (
+    <Flex
+      alignItems={ALIGN_CENTER}
+      backgroundColor={`${COLORS.black90}cc`}
+      borderRadius={BORDERS.borderRadius4}
+      color={COLORS.white}
+      gridGap={SPACING.spacing8}
+      justifyContent={JUSTIFY_CENTER}
+      width="100%"
+      height="100%"
+    />
+  )
+
+  const { slotPosition, setHover, labware, onClick } = props
+  const { def } = labware
+  const { xDimension, yDimension } = def.dimensions
+  const { cornerOffsetFromSlot } = def
+  const { x: xOffset, y: yOffset } = cornerOffsetFromSlot
+  const opacity = 0
+  return (
+    <RobotCoordsForeignDiv
+      {...{
+        x: slotPosition[0] + xOffset,
+        y: slotPosition[1] + yOffset,
+        width: xDimension,
+        height: yDimension,
+      }}
+      innerDivProps={{
+        opacity: opacity,
+        ...DECK_CONTROLS_STYLE,
+        zIndex: 20,
+        cursor: CURSOR_POINTER,
+        backgroundColor: 'black',
+      }}
+      innerDivEvents={{
+        onMouseEnter: () => {
+          setHover(labware.id)
+        },
+        onMouseLeave: () => {
+          setHover(null)
+        },
+        onClick,
+      }}
+    >
+      {slotFill}
+    </RobotCoordsForeignDiv>
+  )
+}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/TiprackSelectHover.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/TiprackSelectHover.tsx
@@ -1,15 +1,8 @@
-import {
-  ALIGN_CENTER,
-  BORDERS,
-  COLORS,
-  CURSOR_POINTER,
-  Flex,
-  JUSTIFY_CENTER,
-  RobotCoordsForeignDiv,
-  SPACING,
-} from '@opentrons/components'
+import { RobotCoordsForeignDiv } from '@opentrons/components'
 
-import { DECK_CONTROLS_STYLE } from '/protocol-designer/pages/Designer/DeckSetup/constants'
+import { DECK_CONTROLS_STYLE_BASE } from '/protocol-designer/pages/Designer/DeckSetup/constants'
+
+import styles from './tipselectionwizard.module.css'
 
 import type { Dispatch, SetStateAction } from 'react'
 import type { CoordinateTuple } from '@opentrons/shared-data'
@@ -25,25 +18,13 @@ interface TiprackSelectHoverProps {
 export function TiprackSelectHover(
   props: TiprackSelectHoverProps
 ): JSX.Element {
-  const slotFill = (
-    <Flex
-      alignItems={ALIGN_CENTER}
-      backgroundColor={`${COLORS.black90}cc`}
-      borderRadius={BORDERS.borderRadius4}
-      color={COLORS.white}
-      gridGap={SPACING.spacing8}
-      justifyContent={JUSTIFY_CENTER}
-      width="100%"
-      height="100%"
-    />
-  )
+  const slotFill = <div className={styles.slot_fill} />
 
   const { slotPosition, setHover, labware, onClick } = props
   const { def } = labware
   const { xDimension, yDimension } = def.dimensions
   const { cornerOffsetFromSlot } = def
   const { x: xOffset, y: yOffset } = cornerOffsetFromSlot
-  const opacity = 0
   return (
     <RobotCoordsForeignDiv
       {...{
@@ -52,13 +33,7 @@ export function TiprackSelectHover(
         width: xDimension,
         height: yDimension,
       }}
-      innerDivProps={{
-        opacity: opacity,
-        ...DECK_CONTROLS_STYLE,
-        zIndex: 20,
-        cursor: CURSOR_POINTER,
-        backgroundColor: 'black',
-      }}
+      innerDivProps={DECK_CONTROLS_STYLE_BASE}
       innerDivEvents={{
         onMouseEnter: () => {
           setHover(labware.id)

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/__tests__/utils.test.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/__tests__/utils.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { getIsTiprack, getPositionFromSlotId } from '@opentrons/shared-data'
+import { getSlotInLocationStack } from '@opentrons/step-generation'
+
+import { getIsTiprackSelectable, getViewboxFromSelectedLabware } from '../utils'
+
+import type { LabwareOnDeck } from '/protocol-designer/step-forms'
+
+vi.mock(import('@opentrons/step-generation'), async importOriginal => {
+  const actual = await importOriginal()
+  return {
+    ...actual,
+    getSlotInLocationStack: vi.fn(),
+  }
+})
+
+vi.mock('@opentrons/shared-data')
+
+const MOCK_TIPRACK_URI = 'mockTiprackUri'
+const MOCK_NON_TIPRACK_URI = 'mockNonTiprackUri'
+const BAD_LABWARE_URI = 'badLabwareUri'
+const MOCK_DECK_DEF = {
+  dimensions: [2, 1],
+} as any
+const activeDeckSetup = {
+  labware: {
+    [MOCK_TIPRACK_URI]: {
+      def: { dimensions: { xDimension: 100, yDimension: 100 } },
+    },
+  },
+} as any
+
+const labware = {
+  labwareDefURI: MOCK_TIPRACK_URI,
+} as LabwareOnDeck
+
+describe('getIsTiprackSelectable', () => {
+  beforeEach(() => {
+    vi.mocked(getSlotInLocationStack).mockReturnValue('A1')
+    vi.mocked(getIsTiprack).mockReturnValue(true)
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns true when the labware is a matching tiprack and in a pipettable slot', () => {
+    expect(getIsTiprackSelectable(labware, MOCK_TIPRACK_URI)).toBe(true)
+  })
+
+  it('returns false when the labware is not a matching tiprack', () => {
+    expect(getIsTiprackSelectable(labware, MOCK_NON_TIPRACK_URI)).toBe(false)
+  })
+
+  it('returns false when the labware is matching but in a non-pipettable slot', () => {
+    vi.mocked(getSlotInLocationStack).mockReturnValue('A4')
+    expect(getIsTiprackSelectable(labware, MOCK_TIPRACK_URI)).toBe(false)
+  })
+
+  it('returns false when the labware not a tiprack', () => {
+    vi.mocked(getIsTiprack).mockReturnValue(false)
+    expect(getIsTiprackSelectable(labware, MOCK_TIPRACK_URI)).toBe(false)
+  })
+})
+
+describe('getViewboxFromSelectedLabware', () => {
+  beforeEach(() => {
+    vi.mocked(getSlotInLocationStack).mockReturnValue('A1')
+    vi.mocked(getPositionFromSlotId).mockReturnValue([150, 150, 0])
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns correct viewbox when dimensions are provided', () => {
+    expect(
+      getViewboxFromSelectedLabware(
+        MOCK_TIPRACK_URI,
+        activeDeckSetup,
+        MOCK_DECK_DEF
+      )
+    ).toBe('100 125 200 150')
+  })
+
+  it('returns null if no labware is found', () => {
+    expect(
+      getViewboxFromSelectedLabware(
+        BAD_LABWARE_URI,
+        activeDeckSetup,
+        MOCK_DECK_DEF
+      )
+    ).toBe(null)
+  })
+
+  it('returns null if no slot position is found', () => {
+    vi.mocked(getPositionFromSlotId).mockReturnValue(null)
+    expect(
+      getViewboxFromSelectedLabware(
+        MOCK_TIPRACK_URI,
+        activeDeckSetup,
+        MOCK_DECK_DEF
+      )
+    ).toBe(null)
+  })
+})

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/index.tsx
@@ -4,10 +4,10 @@ import { useSelector } from 'react-redux'
 
 import { getDeckDefFromRobotType } from '@opentrons/shared-data'
 
+import { useKitchen } from '/protocol-designer/components/organisms/Kitchen/useKitchen'
 import { getRobotType } from '/protocol-designer/file-data/selectors'
 import { getDeckSetupForActiveItem } from '/protocol-designer/top-selectors/labware-locations'
 
-import { useKitchen } from '../../../../../../components/organisms/Kitchen/useKitchen'
 import { SelectTiprack } from './SelectTiprack'
 import { SelectTips } from './SelectTips'
 import { TipSelectionModal } from './TipSelectionModal'

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/index.tsx
@@ -1,0 +1,96 @@
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useSelector } from 'react-redux'
+
+import { getDeckDefFromRobotType } from '@opentrons/shared-data'
+
+import { getRobotType } from '/protocol-designer/file-data/selectors'
+import { getDeckSetupForActiveItem } from '/protocol-designer/top-selectors/labware-locations'
+
+import { useKitchen } from '../../../../../../components/organisms/Kitchen/useKitchen'
+import { SelectTiprack } from './SelectTiprack'
+import { SelectTips } from './SelectTips'
+import { TipSelectionModal } from './TipSelectionModal'
+
+import type { Dispatch, SetStateAction } from 'react'
+
+const NUM_TOTAL_STEPS = 2
+
+interface TipSelectionWizardProps {
+  formTiprackUri: string
+  setShowTipSelectionModal: Dispatch<SetStateAction<boolean>>
+}
+
+export function TipSelectionWizard(
+  props: TipSelectionWizardProps
+): JSX.Element {
+  const { setShowTipSelectionModal, formTiprackUri } = props
+  const { t } = useTranslation('tip_selection')
+  const [currentStepIndex, setCurrentStepIndex] = useState<number>(0)
+  const [selectedTiprackId, setSelectedTiprackId] = useState<string | null>(
+    null
+  )
+  const activeDeckSetup = useSelector(getDeckSetupForActiveItem)
+  const robotType = useSelector(getRobotType)
+  const { makeSnackbar } = useKitchen()
+  const deckDef = getDeckDefFromRobotType(robotType)
+
+  const handleContinue = (): void => {
+    if (selectedTiprackId == null) {
+      makeSnackbar(t('no_tiprack_selected') as string)
+    } else if (currentStepIndex === NUM_TOTAL_STEPS - 1) {
+      setShowTipSelectionModal(false)
+    } else {
+      setCurrentStepIndex(prevStepIndex => prevStepIndex + 1)
+    }
+  }
+
+  const handleGoBack = (): void => {
+    setCurrentStepIndex(prevStepIndex => prevStepIndex - 1)
+  }
+
+  const handleClose = (): void => {
+    setShowTipSelectionModal(false)
+  }
+
+  const baseProps = {
+    selectedTiprackId,
+    setSelectedTiprackId,
+    formTiprackUri,
+    activeDeckSetup,
+    deckDef,
+  }
+
+  let currentComponent: JSX.Element
+  switch (currentStepIndex) {
+    case 0:
+      currentComponent = <SelectTiprack {...baseProps} />
+      break
+    case 1:
+      currentComponent = <SelectTips {...baseProps} />
+      break
+    default:
+      // protective, should not hit
+      console.warn(`no current component for step index ${currentStepIndex}`)
+      currentComponent = <></>
+      break
+  }
+
+  return (
+    <TipSelectionModal
+      onClose={handleClose}
+      onBack={handleGoBack}
+      onContinue={handleContinue}
+      showBackButton={currentStepIndex > 0}
+      continueText={
+        currentStepIndex === NUM_TOTAL_STEPS - 1
+          ? t('select_tips')
+          : t('continue')
+      }
+      currentStepIndex={currentStepIndex}
+      totalSteps={NUM_TOTAL_STEPS}
+    >
+      {currentComponent}
+    </TipSelectionModal>
+  )
+}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/tipselectionwizard.module.css
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/tipselectionwizard.module.css
@@ -1,0 +1,20 @@
+.modal_body {
+  display: flex;
+  flex-direction: column;
+  grid-gap: var(--spacing-24);
+}
+
+.modal_footer {
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+  grid-gap: var(--spacing-4);
+  padding: 0 var(--spacing-24) var(--spacing-24);
+}
+
+.modal_header {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  grid-gap: var(--spacing-8);
+}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/tipselectionwizard.module.css
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/tipselectionwizard.module.css
@@ -8,8 +8,8 @@
   display: flex;
   flex-direction: row;
   justify-content: flex-end;
-  grid-gap: var(--spacing-4);
   padding: 0 var(--spacing-24) var(--spacing-24);
+  grid-gap: var(--spacing-4);
 }
 
 .modal_header {

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/tipselectionwizard.module.css
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/tipselectionwizard.module.css
@@ -9,7 +9,7 @@
   flex-direction: row;
   justify-content: flex-end;
   padding: 0 var(--spacing-24) var(--spacing-24);
-  grid-gap: var(--spacing-4);
+  grid-gap: var(--spacing-8);
 }
 
 .modal_header {

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/tipselectionwizard.module.css
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/tipselectionwizard.module.css
@@ -18,3 +18,10 @@
   align-items: center;
   grid-gap: var(--spacing-8);
 }
+
+.slot_fill {
+  display: flex;
+  width: 100%;
+  height: 100%;
+  border-radius: var(--border-radius-4);
+}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/types.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/types.ts
@@ -1,0 +1,11 @@
+import type { Dispatch, SetStateAction } from 'react'
+import type { DeckDefinition } from '@opentrons/shared-data'
+import type { AllTemporalPropertiesForTimelineFrame } from '/protocol-designer/step-forms/types'
+
+export interface TipSelectionBaseProps {
+  selectedTiprackId: string | null
+  setSelectedTiprackId: Dispatch<SetStateAction<string | null>>
+  formTiprackUri: string
+  activeDeckSetup: AllTemporalPropertiesForTimelineFrame
+  deckDef: DeckDefinition
+}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/utils.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/utils.ts
@@ -42,17 +42,14 @@ export const getViewboxFromSelectedLabware = (
   const ratio = deckYDimension / deckXDimension
 
   // preserve aspect ratio
-  const paddingMMY = PADDING_MM_X * ratio
+  const paddingMmY = PADDING_MM_X * ratio
   const { xDimension, yDimension } = selectedLabware.def.dimensions
   const slot = getSlotInLocationStack(selectedLabware.stack)
-  if (selectedLabwareId == null) {
-    return null
-  }
   const slotPosition = getPositionFromSlotId(slot, deckDef)
   if (slotPosition == null) {
     return null
   }
-  return `${slotPosition[0] - PADDING_MM_X} ${slotPosition[1] - paddingMMY} ${
+  return `${slotPosition[0] - PADDING_MM_X} ${slotPosition[1] - paddingMmY} ${
     xDimension + PADDING_MM_X * 2
-  } ${yDimension + paddingMMY * 2}`
+  } ${yDimension + paddingMmY * 2}`
 }

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/utils.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/utils.ts
@@ -1,0 +1,50 @@
+import { getIsTiprack, getPositionFromSlotId } from '@opentrons/shared-data'
+import { getSlotInLocationStack } from '@opentrons/step-generation'
+
+import type { DeckDefinition } from '@opentrons/shared-data'
+import type {
+  AllTemporalPropertiesForTimelineFrame,
+  LabwareOnDeck,
+} from '../../../../../../step-forms'
+
+export const getIsTiprackSelectable = (
+  labware: LabwareOnDeck,
+  formTiprackUri: string
+): boolean => {
+  // TODO: check if tiprack is reachable by pipette
+  const { def, labwareDefURI } = labware
+  return getIsTiprack(def) && labwareDefURI === formTiprackUri
+}
+
+// arbitrary constant to show slots surrounding the selected tiprack
+// TODO: confirm this padding with Design
+const PADDING_MM_X = 50
+
+export const getViewboxFromSelectedLabware = (
+  selectedLabwareId: string,
+  activeDeckSetup: AllTemporalPropertiesForTimelineFrame,
+  deckDef: DeckDefinition
+): string | null => {
+  const { labware } = activeDeckSetup
+  const selectedLabware = labware[selectedLabwareId]
+  if (selectedLabware == null) {
+    return null
+  }
+  const [deckXDimension, deckYDimension] = deckDef.dimensions
+  const ratio = deckYDimension / deckXDimension
+
+  // preserve aspect ratio
+  const paddingMMY = PADDING_MM_X * ratio
+  const { xDimension, yDimension } = selectedLabware.def.dimensions
+  const slot = getSlotInLocationStack(selectedLabware.stack)
+  if (selectedLabwareId == null) {
+    return null
+  }
+  const slotPosition = getPositionFromSlotId(slot, deckDef)
+  if (slotPosition == null) {
+    return null
+  }
+  return `${slotPosition[0] - PADDING_MM_X} ${slotPosition[1] - paddingMMY} ${
+    xDimension + PADDING_MM_X * 2
+  } ${yDimension + paddingMMY * 2}`
+}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/utils.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/utils.ts
@@ -1,5 +1,8 @@
 import { getIsTiprack, getPositionFromSlotId } from '@opentrons/shared-data'
-import { getSlotInLocationStack } from '@opentrons/step-generation'
+import {
+  COLUMN_4_SLOTS,
+  getSlotInLocationStack,
+} from '@opentrons/step-generation'
 
 import type { DeckDefinition } from '@opentrons/shared-data'
 import type {
@@ -11,9 +14,14 @@ export const getIsTiprackSelectable = (
   labware: LabwareOnDeck,
   formTiprackUri: string
 ): boolean => {
-  // TODO: check if tiprack is reachable by pipette
-  const { def, labwareDefURI } = labware
-  return getIsTiprack(def) && labwareDefURI === formTiprackUri
+  // TODO: check if tiprack is on stacker. Will bottom of stack still be slot?
+  const { def, labwareDefURI, stack } = labware
+  const slot = getSlotInLocationStack(stack)
+  return (
+    getIsTiprack(def) &&
+    labwareDefURI === formTiprackUri &&
+    !COLUMN_4_SLOTS.includes(slot)
+  )
 }
 
 // arbitrary constant to show slots surrounding the selected tiprack

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipTrackingField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipTrackingField.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import {
@@ -10,6 +11,7 @@ import {
 } from '@opentrons/components'
 import { AUTOMATIC, MANUAL } from '@opentrons/step-generation'
 
+import { TipSelectionWizard } from './TipSelectionWizard'
 import styles from './tiptrackingfield.module.css'
 
 import type { TipTrackingOption } from '@opentrons/step-generation'
@@ -23,7 +25,9 @@ interface TipTrackingFieldProps {
 export function TipTrackingField(props: TipTrackingFieldProps): JSX.Element {
   const { propsForFields } = props
   const { t } = useTranslation('form')
-
+  const [showTipSelectionModal, setShowTipSelectionModal] = useState<boolean>(
+    false
+  )
   const tipTrackingOptions: Array<{
     title: string
     description: string
@@ -80,7 +84,7 @@ export function TipTrackingField(props: TipTrackingFieldProps): JSX.Element {
             padding={`${SPACING.spacing20} ${SPACING.spacing12}`}
             type="noActive"
             onClick={() => {
-              console.log('TODO: tip select modal')
+              setShowTipSelectionModal(true)
             }}
           >
             <StyledText desktopStyle="bodyDefaultRegular">
@@ -90,6 +94,12 @@ export function TipTrackingField(props: TipTrackingFieldProps): JSX.Element {
             </StyledText>
           </ListButton>
         </Flex>
+      )}
+      {showTipSelectionModal && (
+        <TipSelectionWizard
+          setShowTipSelectionModal={setShowTipSelectionModal}
+          formTiprackUri={propsForFields.tipRack.value as string}
+        />
       )}
     </Flex>
   )

--- a/protocol-designer/src/pages/ProtocolOverview/SlotHover.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/SlotHover.tsx
@@ -37,10 +37,11 @@ interface SlotHoverProps {
   slotId: DeckSlotId
   slotPosition: CoordinateTuple | null
   robotType: RobotType
+  onClick?: () => void
 }
 
 export function SlotHover(props: SlotHoverProps): JSX.Element | null {
-  const { hover, setHover, slotId, slotPosition, robotType } = props
+  const { hover, setHover, slotId, slotPosition, robotType, onClick } = props
   const deckSetup = useSelector(getInitialDeckSetup)
   const { additionalEquipmentOnDeck, modules } = deckSetup
   const deckDef = useMemo(() => getDeckDefFromRobotType(robotType), [])
@@ -104,6 +105,7 @@ export function SlotHover(props: SlotHoverProps): JSX.Element | null {
           onMouseLeave: () => {
             setHover(null)
           },
+          onClick,
         }}
       >
         {slotFill}
@@ -134,6 +136,7 @@ export function SlotHover(props: SlotHoverProps): JSX.Element | null {
           onMouseLeave: () => {
             setHover(null)
           },
+          onClick,
         }}
       >
         {slotFill}

--- a/protocol-designer/src/pages/ProtocolOverview/SlotHover.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/SlotHover.tsx
@@ -37,11 +37,10 @@ interface SlotHoverProps {
   slotId: DeckSlotId
   slotPosition: CoordinateTuple | null
   robotType: RobotType
-  onClick?: () => void
 }
 
 export function SlotHover(props: SlotHoverProps): JSX.Element | null {
-  const { hover, setHover, slotId, slotPosition, robotType, onClick } = props
+  const { hover, setHover, slotId, slotPosition, robotType } = props
   const deckSetup = useSelector(getInitialDeckSetup)
   const { additionalEquipmentOnDeck, modules } = deckSetup
   const deckDef = useMemo(() => getDeckDefFromRobotType(robotType), [])
@@ -105,7 +104,6 @@ export function SlotHover(props: SlotHoverProps): JSX.Element | null {
           onMouseLeave: () => {
             setHover(null)
           },
-          onClick,
         }}
       >
         {slotFill}
@@ -136,7 +134,6 @@ export function SlotHover(props: SlotHoverProps): JSX.Element | null {
           onMouseLeave: () => {
             setHover(null)
           },
-          onClick,
         }}
       >
         {slotFill}


### PR DESCRIPTION
# Overview

This PR adds initial work for the new select tip modal in PD. Here, I add new components for tip select, including the tip select wizard orchestration component and step 1 for selecting a tiprack from the deck.

[Designs](https://www.figma.com/design/O2deVTZo5T10velrIwjMIF/Release--PD-8.7?node-id=7-1788&t=NraK6TTomIGA6sik-4)

Closes AUTH-2324

https://github.com/user-attachments/assets/a57023cb-7f9e-44e3-9cd5-8d132ecbf92b

## Test Plan and Hands on Testing

- create or import a protocol with multiple tipracks of a certain type (ensure at least one instance of this rack is on a staging area slot)
- add another tiprack of a different type
- create or import a transfer step, and select the tiprack type with multiple instances
- continue through the step form to step 4, and select "Manual tip tracking" > "No tips selected" list button
- verify that the select tip wizard opens in a modal, with the full deck rendering
- hover the selected tiprack types on pipettable slots, and verify that they are selectable
- hover the selected tiprack type on the staging area, and verify that it is _not_ selectable
- hover the tiprack that does not match the step form's tiprack type, and verify that it is _not_ selectable
- select a valid tiprack and continue
- verify that tiprack is zoomed in on the selected tiprack slot

## Changelog

- add `TipSelectionWizard` components, utils, and tests
- add initial translations
- extend PD `LabwareOnDeck` component to optionally pass highlight prop to `LabwareRender` and control whether to show highlighted wells

## Review requests

see test plan

## Risk assessment

low, new work behind FF