### PR TITLE
fix(protocol-designer): Fix newlocation/newLocation typo

### DIFF
--- a/protocol-designer/src/components/organisms/FlexHardware/getHardwareInSlotInUse.ts
+++ b/protocol-designer/src/components/organisms/FlexHardware/getHardwareInSlotInUse.ts
@@ -26,7 +26,7 @@ export function getHardwareInSlotInUse(
         //  module step
         ('moduleId' in step && step.moduleId === moduleOnDeck.id) ||
         //  moving labware to the module
-        ('newLocation' in step && step.newlocation === moduleOnDeck.id) ||
+        ('newLocation' in step && step.newLocation === moduleOnDeck.id) ||
         //  moving a labware from the module location
         ('labware' in step && step.labware === moduleOnDeck.id)
     )

--- a/protocol-designer/src/components/organisms/Ot2Modules/util.ts
+++ b/protocol-designer/src/components/organisms/Ot2Modules/util.ts
@@ -18,7 +18,7 @@ export function getModuleOnSlot(
         //  module step
         ('moduleId' in step && step.moduleId === moduleOnDeck.id) ||
         //  moving labware to the module
-        ('newLocation' in step && step.newlocation === moduleOnDeck.id) ||
+        ('newLocation' in step && step.newLocation === moduleOnDeck.id) ||
         //  moving a labware from the module location
         ('labware' in step && step.labware === moduleOnDeck.id)
     ) != null


### PR DESCRIPTION
## Overview

This fixes a logic bug where Protocol Designer was trying to read a nonexistent `newlocation` property. It should be `newLocation`, with a capital L.

TypeScript didn't catch this because we're typing `FormData` with `any`. That's a known problem that we hope we can fix, but it'd be too big for this PR.

## Test Plan and Hands on Testing

Just CI?

## Review requests

See below.

## Risk assessment

Low? It's pretty obvious what this code was trying to do.

Admittedly, I'm not sure what user-facing impact this code has. So I guess it's possible that this bug was masking some other bug. Is there anything in particular that we ought to manually test?