### PR TITLE
(fix:ci,protocol-designer): Pd deploy fix role

### DIFF
--- a/.github/workflows/pd-test-build-deploy.yaml
+++ b/.github/workflows/pd-test-build-deploy.yaml
@@ -152,7 +152,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.PD_SANDBOX_ROLE }}
+          role-to-assume: ${{ secrets.DOCS_SANDBOX_ROLE }}
           aws-region: us-east-2
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/scripts/static-deploy/deploy_config.py
+++ b/scripts/static-deploy/deploy_config.py
@@ -117,7 +117,7 @@ def get_deploy_config() -> DeployConfig:
         ),
         protocol_designer=ApplicationConfig(
             name="protocol_designer",
-            s3_bucket="sandbox.designer.opentrons.com",
+            s3_bucket="opentrons.sandbox.designer",
             cloudfront_id=None,  # No CloudFront invalidation on sandbox
             url="http://sandbox.designer.opentrons.com/",
         ),

--- a/scripts/static-deploy/tests/test_deploy.py
+++ b/scripts/static-deploy/tests/test_deploy.py
@@ -44,7 +44,7 @@ def test_parse_valid_sandbox_args_with_branch(tmp_path):
 
     # Check that we get the real config back
     assert isinstance(parsed.config, ApplicationConfig)
-    assert parsed.config.s3_bucket == "sandbox.designer.opentrons.com"
+    assert parsed.config.s3_bucket == "opentrons.sandbox.designer"
     assert parsed.config.url == "http://sandbox.designer.opentrons.com/"
     assert parsed.relative_artifact_dir == str(artifact_dir)
     assert parsed.sandbox_prefix == "feature-branch"

--- a/scripts/static-deploy/tests/test_deploy_config.py
+++ b/scripts/static-deploy/tests/test_deploy_config.py
@@ -104,7 +104,7 @@ def test_get_deploy_config_with_env_vars():
     assert sandbox_labware.s3_bucket == "opentrons.sandbox.labware"
     assert sandbox_labware.cloudfront_id is None  # No CloudFront for sandbox
     assert production_designer.s3_bucket == "opentrons.production.designer"
-    assert sandbox_designer.s3_bucket == "sandbox.designer.opentrons.com"
+    assert sandbox_designer.s3_bucket == "opentrons.sandbox.designer"
     assert staging_designer.s3_bucket == "opentrons.staging.designer"
 
 
@@ -118,7 +118,7 @@ def test_get_deploy_config_with_defaults():
     # Check that static configuration values are returned
     assert sandbox_labware.s3_bucket == "opentrons.sandbox.labware"
     assert sandbox_labware.cloudfront_id is None  # No CloudFront for sandbox
-    assert sandbox_designer.s3_bucket == "sandbox.designer.opentrons.com"
+    assert sandbox_designer.s3_bucket == "opentrons.sandbox.designer"
     assert sandbox_designer.cloudfront_id is None  # No CloudFront for sandbox
 
 


### PR DESCRIPTION
Fix Protocol Designer deployment AWS role and bucket configuration
Problem:
Protocol Designer deployment was failing with "Access denied to bucket opentrons.sandbox.designer" because it was using the wrong AWS role and bucket configuration.
Changes:
Updated Protocol Designer workflow to use DOCS_SANDBOX_ROLE instead of PD_SANDBOX_ROLE for consistency with docs/labware library deployments
Fixed sandbox bucket name from sandbox.designer.opentrons.com to opentrons.sandbox.designer to match the actual S3 bucket
Updated corresponding test assertions to reflect the new bucket name
Kept domain URLs unchanged (sandbox.designer.opentrons.com) as these are the user-facing URLs
Result:
Protocol Designer deployments should now have proper AWS permissions and target the correct S3 bucket.