### PR TITLE
fix(scripts/static-deploy): update CF id for docs

### DIFF
--- a/scripts/static-deploy/deploy_config.py
+++ b/scripts/static-deploy/deploy_config.py
@@ -152,13 +152,13 @@ def get_deploy_config() -> DeployConfig:
         docs=ApplicationConfig(
             name="docs",
             s3_bucket="opentrons.staging.docs",
-            cloudfront_id="E8IWASMDOWHYP",
+            cloudfront_id="E2DBE0K9VT8YB9",
             url="https://staging.docs.opentrons.com/",
         ),
         mkdocs=ApplicationConfig(
             name="mkdocs",
             s3_bucket="opentrons.staging.docs",
-            cloudfront_id="E8IWASMDOWHYP",
+            cloudfront_id="E2DBE0K9VT8YB9",
             url="https://staging.docs.opentrons.com/",
         ),
     )
@@ -180,13 +180,13 @@ def get_deploy_config() -> DeployConfig:
         docs=ApplicationConfig(
             name="docs",
             s3_bucket="opentrons.production.docs",
-            cloudfront_id="E16BZZXDTINN0S",
+            cloudfront_id="E2PSPUXND1RQWG",
             url="https://docs.opentrons.com/",
         ),
         mkdocs=ApplicationConfig(
             name="mkdocs",
             s3_bucket="opentrons.production.docs",
-            cloudfront_id="E16BZZXDTINN0S",
+            cloudfront_id="E2PSPUXND1RQWG",
             url="https://docs.opentrons.com/",
         ),
     )

--- a/scripts/static-deploy/tests/test_deploy_config.py
+++ b/scripts/static-deploy/tests/test_deploy_config.py
@@ -327,7 +327,7 @@ def test_determine_deploy_config_from_args_staging_mkdocs():
     assert cfg.sandbox_prefix == "staging-mkdocs-v1.2.3"
     assert cfg.bucket == "opentrons.staging.docs"
     assert cfg.url == "https://staging.docs.opentrons.com/"
-    assert cfg.cloudfront_id == "E8IWASMDOWHYP"
+    assert cfg.cloudfront_id == "E2DBE0K9VT8YB9"
 
 
 def test_determine_deploy_config_from_args_sandbox_branch_url_suffix():


### PR DESCRIPTION
Everything went pretty smoothly with the MKDocs and API Docs deployment yesterday to production and staging 🎉 — except the invalidation didn’t happen because we had the wrong CloudFront ID in the config.  

This update fixes that issue.  
@neo-jesse  can you please double-check that I’ve got the correct CloudFront IDs for the staging and production Docs and MakeDocs?