### PR TITLE
fix(protocol-designer): FlowRateField: don't call getMatchingTipLiquidSpecs() with tiprack=null

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/FlowRateField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/FlowRateField.tsx
@@ -65,7 +65,7 @@ export function FlowRateField(props: FlowRateFieldProps): JSX.Element {
   )
 
   const matchingTipLiquidSpecs =
-    pipette != null
+    pipette != null && tiprack != null
       ? getMatchingTipLiquidSpecs(pipette, volume as number, tiprack as string)
       : null
   const tiprackDef =


### PR DESCRIPTION
# Overview

This is fix 1/n to fix the many `Cannot read properties of null` errors when we call `matchingTipLiquidSpecs()`.

This PR addresses https://opentrons-76.sentry.io/issues/6892806132?project=4509363266387968.

## Test Plan and Hands on Testing

Ran `yarn vitest step-generation/ protocol-designer/` locally.
Will look at results from CI test.

## Risk assessment

Low.
