### PR TITLE
feat(hardare-testing): Dial indicator parameter & pipette compatibility for IWG / Validator protocol

### DIFF
--- a/hardware-testing/hardware_testing/protocols/labware_protocols/inner-well-geometry-creator.py
+++ b/hardware-testing/hardware_testing/protocols/labware_protocols/inner-well-geometry-creator.py
@@ -217,7 +217,7 @@ def add_parameters(parameters: ParameterContext) -> None:
     parameters.add_bool(
         variable_name="dial_indicator_used",
         display_name="Dial Indicator Use",
-        description="Dial Indicator Used.",
+        description="Used to calibrate tip overlap.",
         default=True,
     )
 

--- a/hardware-testing/hardware_testing/protocols/labware_protocols/inner-well-geometry-creator.py
+++ b/hardware-testing/hardware_testing/protocols/labware_protocols/inner-well-geometry-creator.py
@@ -82,7 +82,7 @@ class SetupState:
     probe_pipette: InstrumentContext
     labware: Labware
     src: Labware
-    dial: Labware
+    dial: Optional[Labware]
     first_dispense: float
     target_height: float
     labware_type: str
@@ -165,6 +165,8 @@ def add_parameters(parameters: ParameterContext) -> None:
         choices=[
             {"display_name": "1ch 50ul", "value": "flex_1channel_50"},
             {"display_name": "1ch 1000ul", "value": "flex_1channel_1000"},
+            {"display_name": "8ch 50ul", "value": "flex_8channel_50"},
+            {"display_name": "8ch 1000ul", "value": "flex_8channel_1000"},
             {"display_name": "None", "value": "none"},
         ],
         default="flex_1channel_50",
@@ -175,10 +177,10 @@ def add_parameters(parameters: ParameterContext) -> None:
         display_name="Right Mount",
         description="Liquid Pipette Type on Right Mount.",
         choices=[
-            {"display_name": "8ch 50ul", "value": "flex_8channel_50"},
-            {"display_name": "8ch 1000ul", "value": "flex_8channel_1000"},
             {"display_name": "1ch 50ul", "value": "flex_1channel_50"},
             {"display_name": "1ch 1000ul", "value": "flex_1channel_1000"},
+            {"display_name": "8ch 50ul", "value": "flex_8channel_50"},
+            {"display_name": "8ch 1000ul", "value": "flex_8channel_1000"},
             {"display_name": "None", "value": "none"},
         ],
         default="flex_1channel_1000",
@@ -212,6 +214,13 @@ def add_parameters(parameters: ParameterContext) -> None:
         default="1000",
     )
 
+    parameters.add_bool(
+        variable_name="dial_indicator_used",
+        display_name="Dial Indicator Use",
+        description="Dial Indicator Used.",
+        default=True,
+    )
+
 
 def _setup(ctx: ProtocolContext) -> SetupState:
     """Sets up the static data for the protocol."""
@@ -223,6 +232,7 @@ def _setup(ctx: ProtocolContext) -> SetupState:
     liq_tip_size = ctx.params.liq_tip_size  # type: ignore[attr-defined]
     left_mount = ctx.params.left_mount  # type: ignore[attr-defined]
     right_mount = ctx.params.right_mount  # type: ignore[attr-defined]
+    dial_indicator_used = ctx.params.dial_indicator_used  # type: ignore[attr-defined]
 
     # tipracks
     liquid_racks = [
@@ -237,6 +247,10 @@ def _setup(ctx: ProtocolContext) -> SetupState:
     probe_pipette = ctx.load_instrument(
         left_mount, PROBING_MOUNT, tip_racks=[probing_rack]
     )
+    if probe_pipette.channels == 8:
+        probe_pipette.configure_nozzle_layout(
+            style=SINGLE, start="H1", tip_racks=[probing_rack]
+        )
     liq_pipette = ctx.load_instrument(right_mount, LIQUID_MOUNT, tip_racks=liquid_racks)
     if liq_pipette.channels == 8:
         liq_pipette.configure_nozzle_layout(
@@ -249,7 +263,10 @@ def _setup(ctx: ProtocolContext) -> SetupState:
     wells = list(labware.wells_by_name().keys())
     src = ctx.load_labware(RESERVOIR, SLOT_RESERVOIR)
     ctx.load_trash_bin("A3")
-    dial = ctx.load_labware("dial_indicator", SLOT_DIAL)
+
+    dial: Optional[Labware] = None
+    if dial_indicator_used:
+        dial = ctx.load_labware("dial_indicator", SLOT_DIAL)
 
     # below threshold, alpha low. above threshold, alpha high
     threshold = 4.5
@@ -269,17 +286,11 @@ def _setup(ctx: ProtocolContext) -> SetupState:
     src["A1"].load_liquid(ethanol_liq, src["A1"].max_volume - 1000)
     ethanol = ctx.get_liquid_class(name="ethanol_80")
 
-    if not ctx.is_simulating() and DIAL_PORT is None:
+    if not ctx.is_simulating():
         from hardware_testing.data import create_file_name, create_run_id
-        from hardware_testing.drivers.mitutoyo_digimatic_indicator import (
-            Mitutoyo_Digimatic_Indicator,
-        )
 
-        DIAL_PORT = Mitutoyo_Digimatic_Indicator(port=DIAL_PORT_NAME)
-        DIAL_PORT.connect()
         RUN_ID = create_run_id()
         FILE_NAME = create_file_name(metadata["protocolName"], RUN_ID, labware_type)
-
         _write_line_to_csv(ctx, [RUN_ID])
         _write_line_to_csv(ctx, [right_mount])
         _write_line_to_csv(ctx, [left_mount])
@@ -288,6 +299,14 @@ def _setup(ctx: ProtocolContext) -> SetupState:
         _write_line_to_csv(ctx, ["depth", str(labware["A1"].depth)])
         lpc = str(labware._core.get_calibrated_offset())
         _write_line_to_csv(ctx, ["LPC Offset", labware.load_name, lpc])
+
+        if dial is not None:
+            from hardware_testing.drivers.mitutoyo_digimatic_indicator import (
+                Mitutoyo_Digimatic_Indicator,
+            )
+
+            DIAL_PORT = Mitutoyo_Digimatic_Indicator(port=DIAL_PORT_NAME)
+            DIAL_PORT.connect()
 
     return SetupState(
         liq_pipette=liq_pipette,
@@ -639,7 +658,8 @@ def geometry_creator(
 ) -> List[TrialResult]:
     """Run liquid dispense + measure loop and return trial results."""
     # initial protocol steps
-    _store_dial_baseline(ctx, state.probe_pipette, state.dial)
+    if state.dial is not None:
+        _store_dial_baseline(ctx, state.probe_pipette, state.dial)
     _write_line_to_csv(ctx, CSV_HEADER)  # log 0th step as a baseline
     write_trial_log(ctx, ts)
     state.liq_pipette.pick_up_tip()
@@ -671,7 +691,8 @@ def geometry_creator(
         get_dispense_props(state, ts)
 
         pick_up_tips(state.liq_pipette, state.probe_pipette)
-        ts.tip_z_error = _get_tip_z_error(ctx, state.probe_pipette, state.dial)
+        if state.dial is not None:
+            ts.tip_z_error = _get_tip_z_error(ctx, state.probe_pipette, state.dial)
 
         state.liq_pipette.transfer_with_liquid_class(
             liquid_class=state.ethanol,

--- a/hardware-testing/hardware_testing/protocols/labware_protocols/labware-iwg-validator.py
+++ b/hardware-testing/hardware_testing/protocols/labware_protocols/labware-iwg-validator.py
@@ -19,7 +19,7 @@ from opentrons.types import Point
 from opentrons.protocol_engine.types.liquid_level_detection import SimulatedProbeResult
 
 # LABWARE TYPE
-LABWARE = "eppendorf_96_wellplate_500ul"  # change to desired labware
+LABWARE = "example_labware"  # change to desired labware
 
 # SLOTS
 SLOT_LIQUID_TIPRACKS = ["D3", "B3"]

--- a/hardware-testing/hardware_testing/protocols/labware_protocols/labware-iwg-validator.py
+++ b/hardware-testing/hardware_testing/protocols/labware_protocols/labware-iwg-validator.py
@@ -99,7 +99,7 @@ def add_parameters(parameters: ParameterContext) -> None:
     parameters.add_bool(
         variable_name="dial_indicator_used",
         display_name="Dial Indicator Use",
-        description="Dial Indicator Used.",
+        description="Used to calibrate tip overlap",
         default=True,
     )
 

--- a/hardware-testing/hardware_testing/protocols/labware_protocols/labware-iwg-validator.py
+++ b/hardware-testing/hardware_testing/protocols/labware_protocols/labware-iwg-validator.py
@@ -19,7 +19,7 @@ from opentrons.types import Point
 from opentrons.protocol_engine.types.liquid_level_detection import SimulatedProbeResult
 
 # LABWARE TYPE
-LABWARE = "example_labware"  # change to desired labware
+LABWARE = "eppendorf_96_wellplate_500ul"  # change to desired labware
 
 # SLOTS
 SLOT_LIQUID_TIPRACKS = ["D3", "B3"]
@@ -47,20 +47,22 @@ def add_parameters(parameters: ParameterContext) -> None:
         choices=[
             {"display_name": "1ch 50ul", "value": "flex_1channel_50"},
             {"display_name": "1ch 1000ul", "value": "flex_1channel_1000"},
+            {"display_name": "8ch 50ul", "value": "flex_8channel_50"},
+            {"display_name": "8ch 1000ul", "value": "flex_8channel_1000"},
             {"display_name": "None", "value": "none"},
         ],
         default="flex_1channel_50",
     )
-    # Right Mount
+
     parameters.add_str(
         variable_name="right_mount",
         display_name="Right Mount",
         description="Liquid Pipette Type on Right Mount.",
         choices=[
-            {"display_name": "8ch 50ul", "value": "flex_8channel_50"},
-            {"display_name": "8ch 1000ul", "value": "flex_8channel_1000"},
             {"display_name": "1ch 50ul", "value": "flex_1channel_50"},
             {"display_name": "1ch 1000ul", "value": "flex_1channel_1000"},
+            {"display_name": "8ch 50ul", "value": "flex_8channel_50"},
+            {"display_name": "8ch 1000ul", "value": "flex_8channel_1000"},
             {"display_name": "None", "value": "none"},
         ],
         default="flex_1channel_1000",
@@ -94,6 +96,13 @@ def add_parameters(parameters: ParameterContext) -> None:
         default="1000",
     )
 
+    parameters.add_bool(
+        variable_name="dial_indicator_used",
+        display_name="Dial Indicator Use",
+        description="Dial Indicator Used.",
+        default=True,
+    )
+
 
 def _setup(
     ctx: ProtocolContext,
@@ -103,7 +112,7 @@ def _setup(
     Labware,
     Labware,
     List[float],
-    Labware,
+    Optional[Labware],
     int,
     str,
     List[Labware],
@@ -124,12 +133,16 @@ def _setup(
     ethanol_liq = ctx.define_liquid("Ethanol", display_color="#FFFFC5")
     src["A1"].load_liquid(ethanol_liq, src["A1"].max_volume - 1000)
     ctx.load_trash_bin("A3")
-    dial = ctx.load_labware("dial_indicator", SLOT_DIAL)
     left_mount = ctx.params.left_mount  # type: ignore[attr-defined]
     right_mount = ctx.params.right_mount  # type: ignore[attr-defined]
     liq_tip_size = ctx.params.liq_tip_size  # type: ignore[attr-defined]
     n_regions = ctx.params.n_regions  # type: ignore[attr-defined]
     number_of_trials = ctx.params.number_of_trials  # type: ignore[attr-defined]
+    dial_indicator_used = ctx.params.dial_indicator_used  # type: ignore[attr-defined]
+
+    dial: Optional[Labware] = None
+    if dial_indicator_used:
+        dial = ctx.load_labware("dial_indicator", SLOT_DIAL)
 
     liquid_racks = [
         ctx.load_labware(f"opentrons_flex_96_tiprack_{liq_tip_size}ul", slot)
@@ -147,15 +160,9 @@ def _setup(
         )
 
     # Connect dial indicator and create data sheet
-
-    if not ctx.is_simulating() and DIAL_PORT is None:
+    if not ctx.is_simulating():
         from hardware_testing.data import create_file_name, create_run_id
-        from hardware_testing.drivers.mitutoyo_digimatic_indicator import (
-            Mitutoyo_Digimatic_Indicator,
-        )
 
-        DIAL_PORT = Mitutoyo_Digimatic_Indicator(port=DIAL_PORT_NAME)
-        DIAL_PORT.connect()
         RUN_ID = create_run_id()
         FILE_NAME = create_file_name(metadata["protocolName"], RUN_ID, labware_type)
         _write_line_to_csv(ctx, [RUN_ID])
@@ -168,6 +175,14 @@ def _setup(
             "Error %",
         ]
         _write_line_to_csv(ctx, heading_for_csv)
+
+        if dial is not None:
+            from hardware_testing.drivers.mitutoyo_digimatic_indicator import (
+                Mitutoyo_Digimatic_Indicator,
+            )
+
+            DIAL_PORT = Mitutoyo_Digimatic_Indicator(port=DIAL_PORT_NAME)
+            DIAL_PORT.connect()
 
     depth = labware["A1"].depth
 
@@ -288,7 +303,7 @@ def aspirate_dispense_measure(
     volumes_dict: Dict,
     labware: Labware,
     src: Labware,
-    dial: Labware,
+    dial: Optional[Labware],
     probe_pipette: InstrumentContext,
     liq_pipette: InstrumentContext,
     expected_heights: List[float],
@@ -314,7 +329,10 @@ def aspirate_dispense_measure(
             else:
                 break
 
-        tip_z_error = _get_tip_z_error(ctx, probe_pipette, dial)
+        if dial is not None:
+            tip_z_error = _get_tip_z_error(ctx, probe_pipette, dial)
+        else:
+            tip_z_error = 0.0
         dispense_vol = float(expected_vol / liq_pipette.active_channels)
         expected_height = expected_heights[i]
 
@@ -430,7 +448,8 @@ def run(ctx: ProtocolContext) -> None:
         volume = labware["A1"].volume_from_height(height)
         volumes.setdefault(well, []).append(volume)
 
-    _store_dial_baseline(ctx, probe_pipette, dial)
+    if dial is not None:
+        _store_dial_baseline(ctx, probe_pipette, dial)
     pick_up_tips(probe_pipette, liq_pipette)
     _get_height_of_liquid_in_well(liq_pipette, src["A1"], ctx.is_simulating())
     liq_pipette.blow_out()


### PR DESCRIPTION
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Made the use of the Mitotuyo Dial Indicator optional in both the IWG creator protocol and IWG validator protocol so that FAS doesn't need to bring the dial indicator in the field.  Also added additional pipettes that could be used in both protocols. 

Results of dial indicator vs no dial indicator:
todo 

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing

Tested both protocols with and without the dial indicator. Results linked above

-Tested IWG creator with and without dial indicator
-Tested IWG validator with and without dial indicator
-Tested both without dial indicator and with different tiprack batches 


<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog

<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment

<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
