### PR TITLE
refactor(protocol-designer): Fix types of cast form data

### DIFF
--- a/protocol-designer/src/form-types.ts
+++ b/protocol-designer/src/form-types.ts
@@ -285,7 +285,7 @@ export interface HydratedMoveLiquidFormData extends AnnotationFields {
   volume: number
   pushOut_volume: number | null
   pushOut_checkbox: boolean
-  aspirate_airGap_volume?: number | null
+  aspirate_airGap_volume?: string | null
   aspirate_delay_seconds?: number | null
   aspirate_flowRate?: number | null
   aspirate_mix_times?: number | null
@@ -314,7 +314,7 @@ export interface HydratedMoveLiquidFormData extends AnnotationFields {
   blowout_location?: string | null
   conditioning_checkbox: boolean | null
   conditioning_volume: number | null
-  dispense_airGap_volume?: number | null
+  dispense_airGap_volume?: string | null
   dispense_delay_seconds?: number | null
   dispense_flowRate?: number | null
   dispense_mix_times?: number | null
@@ -338,7 +338,7 @@ export interface HydratedMoveLiquidFormData extends AnnotationFields {
   dispense_x_position?: number | null
   dispense_y_position?: number | null
   dispense_position_reference: PositionReference
-  disposalVolume_volume?: number | null
+  disposalVolume_volume?: string | null
   dropTip_wellNames?: string[] | null
   pickUpTip_location?: string | null
   pickUpTip_wellNames?: string[] | null

--- a/protocol-designer/src/steplist/fieldLevel/index.ts
+++ b/protocol-designer/src/steplist/fieldLevel/index.ts
@@ -155,143 +155,164 @@ const getPipetteEntity = (
   return state.pipetteEntities[id] || null
 }
 
-interface StepFieldHelpers {
+interface StepFieldHelpers<ValueCasterT extends ValueCaster<any, any>> {
+  // todo(mm, 2025-10-09): Refine this type to also parametrize the exact types of the
+  // masked value and hydrated value.
   maskValue?: ValueMasker
-  castValue?: ValueCaster
   hydrate?: (state: InvariantContext, id: string) => unknown
+  castValue?: ValueCasterT
 }
-const stepFieldHelperMap: Record<StepFieldName, StepFieldHelpers> = {
-  aspirate_airGap_volume: {
+
+/**
+ * Construct a `StepFieldHelpers`.
+ *
+ * This is just a pass-through, for the benefit of type-checking the props of each
+ * `StepFieldHelpers` when we construct a bunch of them inside `stepFieldHelperMap`.
+ */
+function stepFieldHelpers<StepFieldHelpersT extends StepFieldHelpers<any>>(
+  input: StepFieldHelpersT
+): StepFieldHelpersT {
+  return input
+}
+
+// The processing steps to perform on each field, if any.
+//
+// Each key should be a `StepFieldName` and each value should be a `StepFieldHelpers`.
+// There's no type annotation up top here because we want TypeScript to infer the exact
+// type of each value separately.
+const stepFieldHelperMap = {
+  aspirate_airGap_volume: stepFieldHelpers({
     maskValue: composeMaskers(
       maskToFloat,
       onlyPositiveNumbers,
       trimDecimals(1)
     ),
     castValue: Number,
-  },
-  aspirate_labware: {
+  }),
+  aspirate_labware: stepFieldHelpers({
     hydrate: getLabwareOrAdditionalEquipmentEntity,
-  },
-  aspirate_mix_times: {
+  }),
+  aspirate_mix_times: stepFieldHelpers({
     maskValue: composeMaskers(maskToInteger, onlyPositiveNumbers, defaultTo(1)),
     castValue: Number,
-  },
-  aspirate_mix_volume: {
+  }),
+  aspirate_mix_volume: stepFieldHelpers({
     maskValue: composeMaskers(
       maskToFloat,
       onlyPositiveNumbers,
       trimDecimals(1)
     ),
     castValue: Number,
-  },
-  aspirate_mmFromBottom: {
+  }),
+  aspirate_mmFromBottom: stepFieldHelpers({
     castValue: numberOrNull,
-  },
-  aspirate_wells: {
+  }),
+  aspirate_wells: stepFieldHelpers({
     maskValue: defaultTo([]),
-  },
-  dispense_airGap_volume: {
+  }),
+  dispense_airGap_volume: stepFieldHelpers({
     maskValue: composeMaskers(
       maskToFloat,
       onlyPositiveNumbers,
       trimDecimals(1)
     ),
     castValue: Number,
-  },
-  dispense_labware: {
+  }),
+  dispense_labware: stepFieldHelpers({
     hydrate: getLabwareOrAdditionalEquipmentEntity,
-  },
-  dispense_mix_times: {
+  }),
+  dispense_mix_times: stepFieldHelpers({
     maskValue: composeMaskers(maskToInteger, onlyPositiveNumbers, defaultTo(1)),
     castValue: Number,
-  },
-  dispense_mix_volume: {
+  }),
+  dispense_mix_volume: stepFieldHelpers({
     maskValue: composeMaskers(
       maskToFloat,
       onlyPositiveNumbers,
       trimDecimals(1)
     ),
     castValue: Number,
-  },
-  dispense_mmFromBottom: {
+  }),
+  dispense_mmFromBottom: stepFieldHelpers({
     castValue: numberOrNull,
-  },
-  dispense_wells: {
+  }),
+  dispense_wells: stepFieldHelpers({
     maskValue: defaultTo([]),
-  },
-  disposalVolume_volume: {
+  }),
+  disposalVolume_volume: stepFieldHelpers({
     maskValue: composeMaskers(
       maskToFloat,
       onlyPositiveNumbers,
       trimDecimals(1)
     ),
     castValue: Number,
-  },
-  labware: {
+  }),
+  labware: stepFieldHelpers({
     hydrate: getLabwareOrAdditionalEquipmentEntity,
-  },
-  aspirate_delay_seconds: {
+  }),
+  aspirate_delay_checkbox: stepFieldHelpers({}),
+  aspirate_delay_seconds: stepFieldHelpers({
     maskValue: composeMaskers(
       maskToFloat,
       onlyPositiveNumbers,
       trimDecimals(1)
     ),
     castValue: Number,
-  },
-  aspirate_delay_mmFromBottom: {
+  }),
+  aspirate_delay_mmFromBottom: stepFieldHelpers({
     castValue: numberOrNull,
-  },
-  aspirate_touchTip_speed: {
+  }),
+  aspirate_touchTip_speed: stepFieldHelpers({
     maskValue: composeMaskers(maskToFloat, onlyPositiveNumbers),
     castValue: Number,
-  },
-  dispense_touchTip_speed: {
+  }),
+  dispense_touchTip_speed: stepFieldHelpers({
     maskValue: composeMaskers(maskToFloat, onlyPositiveNumbers),
     castValue: Number,
-  },
-  aspirate_touchTip_mmFromEdge: {
+  }),
+  aspirate_touchTip_mmFromEdge: stepFieldHelpers({
     maskValue: composeMaskers(maskToFloat, onlyPositiveNumbers),
     castValue: Number,
-  },
-  dispense_touchTip_mmFromEdge: {
+  }),
+  dispense_touchTip_mmFromEdge: stepFieldHelpers({
     maskValue: composeMaskers(maskToFloat, onlyPositiveNumbers),
     castValue: Number,
-  },
-  dispense_delay_seconds: {
+  }),
+  dispense_delay_seconds: stepFieldHelpers({
     maskValue: composeMaskers(
       maskToFloat,
       onlyPositiveNumbers,
       trimDecimals(1)
     ),
     castValue: Number,
-  },
-  dispense_delay_mmFromBottom: {
+  }),
+  dispense_delay_mmFromBottom: stepFieldHelpers({
     castValue: numberOrNull,
-  },
-  aspirate_submerge_delay_seconds: {
+  }),
+  aspirate_submerge_delay_seconds: stepFieldHelpers({
     maskValue: composeMaskers(maskToFloat, onlyPositiveNumbers),
     castValue: Number,
-  },
-  aspirate_retract_delay_seconds: {
+  }),
+  aspirate_retract_delay_seconds: stepFieldHelpers({
     maskValue: composeMaskers(maskToFloat, onlyPositiveNumbers),
     castValue: Number,
-  },
-  dispense_submerge_delay_seconds: {
+  }),
+  dispense_submerge_delay_seconds: stepFieldHelpers({
     maskValue: composeMaskers(maskToFloat, onlyPositiveNumbers),
     castValue: Number,
-  },
-  dispense_retract_delay_seconds: {
+  }),
+  dispense_retract_delay_seconds: stepFieldHelpers({
     maskValue: composeMaskers(maskToFloat, onlyPositiveNumbers),
     castValue: Number,
-  },
-  pipette: {
+  }),
+  pipette: stepFieldHelpers({
     hydrate: getPipetteEntity,
-  },
-  times: {
+  }),
+  times: stepFieldHelpers({
     maskValue: composeMaskers(maskToInteger, onlyPositiveNumbers, defaultTo(0)),
     castValue: Number,
-  },
-  volume: {
+  }),
+  volume: stepFieldHelpers({
     maskValue: composeMaskers(
       maskToFloat,
       onlyPositiveNumbers,
@@ -299,123 +320,123 @@ const stepFieldHelperMap: Record<StepFieldName, StepFieldHelpers> = {
       defaultTo(0)
     ),
     castValue: Number,
-  },
-  wells: {
+  }),
+  wells: stepFieldHelpers({
     maskValue: defaultTo([]),
-  },
-  engageHeight: {
+  }),
+  engageHeight: stepFieldHelpers({
     maskValue: composeMaskers(maskToFloat, trimDecimals(1)),
     castValue: Number,
-  },
-  targetTemperature: {
+  }),
+  targetTemperature: stepFieldHelpers({
     maskValue: composeMaskers(maskToInteger, onlyPositiveNumbers),
     castValue: Number,
-  },
-  targetHeaterShakerTemperature: {
+  }),
+  targetHeaterShakerTemperature: stepFieldHelpers({
     maskValue: composeMaskers(maskToInteger, onlyPositiveNumbers),
     castValue: Number,
-  },
-  targetSpeed: {
+  }),
+  targetSpeed: stepFieldHelpers({
     maskValue: composeMaskers(maskToInteger, onlyPositiveNumbers),
     castValue: Number,
-  },
-  heaterShakerTimer: {
+  }),
+  heaterShakerTimer: stepFieldHelpers({
     maskValue: composeMaskers(maskToTime),
     castValue: String,
-  },
-  pauseTime: {
+  }),
+  pauseTime: stepFieldHelpers({
     maskValue: composeMaskers(maskToTime),
     castValue: String,
-  },
-  pauseTemperature: {
+  }),
+  pauseTemperature: stepFieldHelpers({
     maskValue: composeMaskers(maskToInteger, onlyPositiveNumbers),
     castValue: Number,
-  },
-  blockTargetTemp: {
+  }),
+  blockTargetTemp: stepFieldHelpers({
     maskValue: composeMaskers(maskToInteger, onlyPositiveNumbers),
     castValue: Number,
-  },
-  lidTargetTemp: {
+  }),
+  lidTargetTemp: stepFieldHelpers({
     maskValue: composeMaskers(maskToInteger, onlyPositiveNumbers),
     castValue: Number,
-  },
-  profileVolume: {
+  }),
+  profileVolume: stepFieldHelpers({
     maskValue: composeMaskers(maskToFloat, onlyPositiveNumbers),
-  },
-  blockTargetTempHold: {
+  }),
+  blockTargetTempHold: stepFieldHelpers({
     maskValue: composeMaskers(maskToInteger, onlyPositiveNumbers),
     castValue: Number,
-  },
-  lidTargetTempHold: {
+  }),
+  lidTargetTempHold: stepFieldHelpers({
     maskValue: composeMaskers(maskToInteger, onlyPositiveNumbers),
     castValue: Number,
-  },
-  mix_mmFromBottom: {
+  }),
+  mix_mmFromBottom: stepFieldHelpers({
     castValue: numberOrNull,
-  },
-  newLocation: {
+  }),
+  newLocation: stepFieldHelpers({
     hydrate: getLabwareLocation,
-  },
-  aspirate_flowRate: {
+  }),
+  aspirate_flowRate: stepFieldHelpers({
     maskValue: composeMaskers(trimDecimals(1)),
     castValue: numberOrNull,
-  },
-  dispense_flowRate: {
+  }),
+  dispense_flowRate: stepFieldHelpers({
     maskValue: composeMaskers(trimDecimals(1)),
     castValue: numberOrNull,
-  },
-  mix_flowRate: {
+  }),
+  mix_flowRate: stepFieldHelpers({
     maskValue: composeMaskers(trimDecimals(1)),
     castValue: numberOrNull,
-  },
-  blowout_flowRate: {
+  }),
+  blowout_flowRate: stepFieldHelpers({
     maskValue: composeMaskers(trimDecimals(1)),
     castValue: numberOrNull,
-  },
-  pushOut_volume: {
+  }),
+  pushOut_volume: stepFieldHelpers({
     maskValue: composeMaskers(
       maskToFloat,
       onlyPositiveNumbers,
       trimDecimals(1)
     ),
     castValue: numberOrNull,
-  },
-  aspirate_submerge_speed: {
+  }),
+  aspirate_submerge_speed: stepFieldHelpers({
     maskValue: composeMaskers(
       maskToFloat,
       onlyPositiveNumbers,
       trimDecimals(1)
     ),
     castValue: numberOrNull,
-  },
-  aspirate_retract_speed: {
+  }),
+  aspirate_retract_speed: stepFieldHelpers({
     maskValue: composeMaskers(
       maskToFloat,
       onlyPositiveNumbers,
       trimDecimals(1)
     ),
     castValue: numberOrNull,
-  },
-  dispense_submerge_speed: {
+  }),
+  dispense_submerge_speed: stepFieldHelpers({
     maskValue: composeMaskers(
       maskToFloat,
       onlyPositiveNumbers,
       trimDecimals(1)
     ),
     castValue: numberOrNull,
-  },
-  dispense_retract_speed: {
+  }),
+  dispense_retract_speed: stepFieldHelpers({
     maskValue: composeMaskers(
       maskToFloat,
       onlyPositiveNumbers,
       trimDecimals(1)
     ),
     castValue: numberOrNull,
-  },
-  conditioning_volume: {
+  }),
+  conditioning_volume: stepFieldHelpers({
     maskValue: composeMaskers(maskToFloat, onlyPositiveNumbers),
     castValue: numberOrNull,
-  },
+  }),
 }
 export const castField = (name: StepFieldName, value: unknown): unknown => {
   const fieldCaster =
@@ -424,6 +445,9 @@ export const castField = (name: StepFieldName, value: unknown): unknown => {
 }
 export const maskField = (name: StepFieldName, value: unknown): unknown => {
   const fieldMasker =
+    // @ts-expect-error - TS doesn't want to let us index stepFieldHelperMap with a
+    // name that it doesn't necessarily contain. It's OK here because it'll just
+    // return undefined in the worst case, which this line handles.
     stepFieldHelperMap[name] && stepFieldHelperMap[name].maskValue
   return fieldMasker ? fieldMasker(value) : value
 }
@@ -432,6 +456,10 @@ export const hydrateField = (
   name: StepFieldName,
   value: string
 ): unknown => {
-  const hydrator = stepFieldHelperMap[name] && stepFieldHelperMap[name].hydrate
+  const hydrator =
+    // @ts-expect-error - TS doesn't want to let us index stepFieldHelperMap with a
+    // name that it doesn't necessarily contain. It's OK here because it'll just
+    // return undefined in the worst case, which this line handles.
+    stepFieldHelperMap[name] && stepFieldHelperMap[name].hydrate
   return hydrator ? hydrator(state, value) : value
 }

--- a/protocol-designer/src/steplist/fieldLevel/index.ts
+++ b/protocol-designer/src/steplist/fieldLevel/index.ts
@@ -26,9 +26,11 @@ import type {
   WasteChuteEntities,
 } from '@opentrons/step-generation'
 import type {
+  HydratedFormData,
   LabwareOrAdditionalEquipmentEntity,
   StepFieldName,
 } from '../../form-types'
+import type { AmalgamateUnion } from '../../utils/utilityTypes'
 import type { ValueCaster, ValueMasker } from './processing'
 
 export type { StepFieldName }
@@ -438,11 +440,19 @@ const stepFieldHelperMap = {
     castValue: numberOrNull,
   }),
 }
-export const castField = (name: StepFieldName, value: unknown): unknown => {
+
+export function castField<
+  FieldNameT extends string | number | symbol,
+  UncastValueT
+>(name: FieldNameT, value: UncastValueT): GetCastFieldType<FieldNameT> {
   const fieldCaster =
+    // @ts-expect-error - TS doesn't want to let us index stepFieldHelperMap with a
+    // name that it doesn't necessarily contain. It's OK here because it'll just
+    // return undefined in the worst case, which this line handles.
     stepFieldHelperMap[name] && stepFieldHelperMap[name].castValue
   return fieldCaster ? fieldCaster(value) : value
 }
+
 export const maskField = (name: StepFieldName, value: unknown): unknown => {
   const fieldMasker =
     // @ts-expect-error - TS doesn't want to let us index stepFieldHelperMap with a
@@ -451,6 +461,7 @@ export const maskField = (name: StepFieldName, value: unknown): unknown => {
     stepFieldHelperMap[name] && stepFieldHelperMap[name].maskValue
   return fieldMasker ? fieldMasker(value) : value
 }
+
 export const hydrateField = (
   state: InvariantContext,
   name: StepFieldName,
@@ -462,4 +473,37 @@ export const hydrateField = (
     // return undefined in the worst case, which this line handles.
     stepFieldHelperMap[name] && stepFieldHelperMap[name].hydrate
   return hydrator ? hydrator(state, value) : value
+}
+
+/**
+ * Returns the type that a field would have in `HydratedFormData`,
+ * assuming that field is being accessed on a form type where it actually exists.
+ */
+type GetHydratedFieldType<
+  FieldNameT extends string | number | symbol
+> = AmalgamateUnion<HydratedFormData> extends {
+  [Key in FieldNameT]: infer HydratedValueT
+}
+  ? HydratedValueT
+  : never // This should only happen if FieldNameT is an unrecognized field.
+
+/**
+ * Returns the type that a field would have after being passed through `castField`.
+ */
+export type GetCastFieldType<
+  FieldNameT extends string | number | symbol
+> = typeof stepFieldHelperMap extends {
+  [Key in FieldNameT]: {
+    castValue: (hydratedValue: any) => infer CastValueT
+  }
+}
+  ? CastValueT
+  : GetHydratedFieldType<FieldNameT>
+
+/**
+ * Returns what a given `HydratedFormData` type would be transformed to
+ * after running `castField` on all of its fields.
+ */
+export type GetCastFormData<HydratedFormDataT extends HydratedFormData> = {
+  [Key in keyof HydratedFormDataT]: GetCastFieldType<Key>
 }

--- a/protocol-designer/src/steplist/fieldLevel/processing.ts
+++ b/protocol-designer/src/steplist/fieldLevel/processing.ts
@@ -1,5 +1,7 @@
 export type ValueMasker = (value: unknown) => unknown
-export type ValueCaster = (value: unknown) => unknown
+export type ValueCaster<HydratedValueT, CastValueT> = (
+  value: HydratedValueT
+) => CastValueT
 
 /*********************
  **  Value Casters   **
@@ -36,7 +38,7 @@ export const maskToFloat = (rawValue: unknown): string =>
     : String(rawValue)
 export const trimDecimals = (
   decimals: number = DEFAULT_DECIMAL_PLACES
-): ValueCaster => (rawValue: unknown): string => {
+): ValueCaster<unknown, string> => (rawValue: unknown): string => {
   const trimRegex = new RegExp(`(\\d*[.]{1}\\d{${decimals}})(\\d*)`)
   return String(rawValue).replace(trimRegex, (match, group1) => group1)
 }

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/absorbanceReaderFormToArgs.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/absorbanceReaderFormToArgs.ts
@@ -9,7 +9,7 @@ import type { HydratedAbsorbanceReaderFormData } from '../../../form-types'
 import type { GetCastFormData } from '../../fieldLevel'
 
 export const absorbanceReaderFormToArgs = (
-  hydratedFormData: GetCastFormData<HydratedAbsorbanceReaderFormData>
+  formData: GetCastFormData<HydratedAbsorbanceReaderFormData>
 ): AbsorbanceReaderArgs | null => {
   const {
     absorbanceReaderFormType,
@@ -22,7 +22,7 @@ export const absorbanceReaderFormToArgs = (
     wavelengths,
     stepDetails,
     stepName,
-  } = hydratedFormData
+  } = formData
 
   const baseValues = { description: stepDetails, name: stepName }
   const lidAction = lidOpen

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/absorbanceReaderFormToArgs.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/absorbanceReaderFormToArgs.ts
@@ -6,9 +6,10 @@ import {
 
 import type { AbsorbanceReaderArgs } from '@opentrons/step-generation'
 import type { HydratedAbsorbanceReaderFormData } from '../../../form-types'
+import type { GetCastFormData } from '../../fieldLevel'
 
 export const absorbanceReaderFormToArgs = (
-  hydratedFormData: HydratedAbsorbanceReaderFormData
+  hydratedFormData: GetCastFormData<HydratedAbsorbanceReaderFormData>
 ): AbsorbanceReaderArgs | null => {
   const {
     absorbanceReaderFormType,
@@ -33,7 +34,11 @@ export const absorbanceReaderFormToArgs = (
         (mode === 'single' ? [wavelengths[0]] : wavelengths) ?? // only take first wavelength in single mode
         []
       return {
-        moduleId,
+        // todo(mm, 2025-10-09): form-types.ts is inconsistent about whether moduleId is nullable.
+        // This runtime behavior of assuming it can't be nullish here is inherited from prior code.
+        // Look into this.
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        moduleId: moduleId!,
         commandCreatorFnName: 'absorbanceReaderInitialize',
         measureMode: mode,
         sampleWavelengths: rawWavelengths?.map(wavelength =>
@@ -48,14 +53,22 @@ export const absorbanceReaderFormToArgs = (
       }
     case ABSORBANCE_READER_READ:
       return {
-        moduleId,
+        // todo(mm, 2025-10-09): form-types.ts is inconsistent about whether moduleId is nullable.
+        // This runtime behavior of assuming it can't be nullish here is inherited from prior code.
+        // Look into this.
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        moduleId: moduleId!,
         commandCreatorFnName: 'absorbanceReaderRead',
         fileName: fileName ?? null,
         ...baseValues,
       }
     case ABSORBANCE_READER_LID:
       return {
-        moduleId,
+        // todo(mm, 2025-10-09): form-types.ts is inconsistent about whether moduleId is nullable.
+        // This runtime behavior of assuming it can't be nullish here is inherited from prior code.
+        // Look into this.
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        moduleId: moduleId!,
         commandCreatorFnName: lidAction,
         ...baseValues,
       }

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/absorbanceReaderFormToArgs.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/absorbanceReaderFormToArgs.ts
@@ -9,7 +9,7 @@ import type { HydratedAbsorbanceReaderFormData } from '../../../form-types'
 import type { GetCastFormData } from '../../fieldLevel'
 
 export const absorbanceReaderFormToArgs = (
-  formData: GetCastFormData<HydratedAbsorbanceReaderFormData>
+  castFormData: GetCastFormData<HydratedAbsorbanceReaderFormData>
 ): AbsorbanceReaderArgs | null => {
   const {
     absorbanceReaderFormType,
@@ -22,7 +22,7 @@ export const absorbanceReaderFormToArgs = (
     wavelengths,
     stepDetails,
     stepName,
-  } = formData
+  } = castFormData
 
   const baseValues = { description: stepDetails, name: stepName }
   const lidAction = lidOpen

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/commentFormToArgs.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/commentFormToArgs.ts
@@ -1,8 +1,9 @@
 import type { CommentArgs } from '@opentrons/step-generation'
 import type { HydratedCommentFormData } from '../../../form-types'
+import type { GetCastFormData } from '../../fieldLevel'
 
 export const commentFormToArgs = (
-  hydratedFormData: HydratedCommentFormData
+  hydratedFormData: GetCastFormData<HydratedCommentFormData>
 ): CommentArgs => {
   const { message, stepName, stepDetails } = hydratedFormData
 

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/commentFormToArgs.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/commentFormToArgs.ts
@@ -3,9 +3,9 @@ import type { HydratedCommentFormData } from '../../../form-types'
 import type { GetCastFormData } from '../../fieldLevel'
 
 export const commentFormToArgs = (
-  formData: GetCastFormData<HydratedCommentFormData>
+  castFormData: GetCastFormData<HydratedCommentFormData>
 ): CommentArgs => {
-  const { message, stepName, stepDetails } = formData
+  const { message, stepName, stepDetails } = castFormData
 
   return {
     commandCreatorFnName: 'comment',

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/commentFormToArgs.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/commentFormToArgs.ts
@@ -3,9 +3,9 @@ import type { HydratedCommentFormData } from '../../../form-types'
 import type { GetCastFormData } from '../../fieldLevel'
 
 export const commentFormToArgs = (
-  hydratedFormData: GetCastFormData<HydratedCommentFormData>
+  formData: GetCastFormData<HydratedCommentFormData>
 ): CommentArgs => {
-  const { message, stepName, stepDetails } = hydratedFormData
+  const { message, stepName, stepDetails } = formData
 
   return {
     commandCreatorFnName: 'comment',

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/getDelayData.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/getDelayData.ts
@@ -10,11 +10,11 @@ import type {
 import type { GetCastFormData } from '../../fieldLevel'
 
 export const getMoveLiquidDelayData = (args: {
-  formData: GetCastFormData<HydratedMoveLiquidFormData>
+  castFormData: GetCastFormData<HydratedMoveLiquidFormData>
   secondsField: DelaySecondsMoveLiquidFields
   checkboxField?: DelayCheckboxMoveLiquidFields
 }): InnerDelayArgs | null => {
-  const { formData: hydratedFormData, checkboxField, secondsField } = args
+  const { castFormData: hydratedFormData, checkboxField, secondsField } = args
   const checkbox =
     checkboxField != null ? hydratedFormData[checkboxField] ?? false : true
   const seconds = hydratedFormData[secondsField] ?? 0
@@ -29,12 +29,12 @@ export const getMoveLiquidDelayData = (args: {
 }
 
 export const getMixDelayData = (
-  formData: GetCastFormData<HydratedMixFormData>,
+  castFormData: GetCastFormData<HydratedMixFormData>,
   checkboxField: DelayCheckboxBaseFields,
   secondsField: DelaySecondsBaseFields
 ): number | null => {
-  const checkbox = formData[checkboxField]
-  const seconds = formData[secondsField]
+  const checkbox = castFormData[checkboxField]
+  const seconds = castFormData[secondsField]
 
   if (checkbox && typeof seconds === 'number' && seconds > 0) {
     return seconds

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/getDelayData.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/getDelayData.ts
@@ -7,7 +7,7 @@ import type {
   HydratedMixFormData,
   HydratedMoveLiquidFormData,
 } from '../../../form-types'
-import { type GetCastFormData } from '../../fieldLevel'
+import type { GetCastFormData } from '../../fieldLevel'
 
 export const getMoveLiquidDelayData = (args: {
   formData: GetCastFormData<HydratedMoveLiquidFormData>

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/getDelayData.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/getDelayData.ts
@@ -7,13 +7,14 @@ import type {
   HydratedMixFormData,
   HydratedMoveLiquidFormData,
 } from '../../../form-types'
+import { type GetCastFormData } from '../../fieldLevel'
 
 export const getMoveLiquidDelayData = (args: {
-  hydratedFormData: HydratedMoveLiquidFormData
+  formData: GetCastFormData<HydratedMoveLiquidFormData>
   secondsField: DelaySecondsMoveLiquidFields
   checkboxField?: DelayCheckboxMoveLiquidFields
 }): InnerDelayArgs | null => {
-  const { hydratedFormData, checkboxField, secondsField } = args
+  const { formData: hydratedFormData, checkboxField, secondsField } = args
   const checkbox =
     checkboxField != null ? hydratedFormData[checkboxField] ?? false : true
   const seconds = hydratedFormData[secondsField] ?? 0
@@ -28,12 +29,12 @@ export const getMoveLiquidDelayData = (args: {
 }
 
 export const getMixDelayData = (
-  hydratedFormData: HydratedMixFormData,
+  formData: GetCastFormData<HydratedMixFormData>,
   checkboxField: DelayCheckboxBaseFields,
   secondsField: DelaySecondsBaseFields
 ): number | null => {
-  const checkbox = hydratedFormData[checkboxField]
-  const seconds = hydratedFormData[secondsField]
+  const checkbox = formData[checkboxField]
+  const seconds = formData[secondsField]
 
   if (checkbox && typeof seconds === 'number' && seconds > 0) {
     return seconds

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/heaterShakerFormToArgs.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/heaterShakerFormToArgs.ts
@@ -5,7 +5,7 @@ import type { HydratedHeaterShakerFormData } from '../../../form-types'
 import type { GetCastFormData } from '../../fieldLevel'
 
 export const heaterShakerFormToArgs = (
-  formData: GetCastFormData<HydratedHeaterShakerFormData>
+  castFormData: GetCastFormData<HydratedHeaterShakerFormData>
 ): HeaterShakerArgs => {
   const {
     moduleId,
@@ -16,7 +16,7 @@ export const heaterShakerFormToArgs = (
     latchOpen,
     stepDetails,
     stepName,
-  } = formData
+  } = castFormData
   console.assert(
     setHeaterShakerTemperature
       ? !Number.isNaN(targetHeaterShakerTemperature)
@@ -28,7 +28,7 @@ export const heaterShakerFormToArgs = (
     'heaterShakerFormToArgs expected targeShake to be a number when setShake is true'
   )
   const { hours, minutes, seconds } = getTimeFromForm(
-    formData.heaterShakerTimer
+    castFormData.heaterShakerTimer
   )
   const isNullTime = hours === 0 && minutes === 0 && seconds === 0
 

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/heaterShakerFormToArgs.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/heaterShakerFormToArgs.ts
@@ -2,9 +2,10 @@ import { getTimeFromForm } from '../../utils/getTimeFromForm'
 
 import type { HeaterShakerArgs } from '@opentrons/step-generation'
 import type { HydratedHeaterShakerFormData } from '../../../form-types'
+import type { GetCastFormData } from '../../fieldLevel'
 
 export const heaterShakerFormToArgs = (
-  formData: HydratedHeaterShakerFormData
+  formData: GetCastFormData<HydratedHeaterShakerFormData>
 ): HeaterShakerArgs => {
   const {
     moduleId,
@@ -33,19 +34,29 @@ export const heaterShakerFormToArgs = (
 
   const targetTemperature =
     setHeaterShakerTemperature && targetHeaterShakerTemperature != null
-      ? parseFloat(targetHeaterShakerTemperature)
+      ? // @ts-expect-error - todo(mm, 2025-10-09): Type error inherited from prior code.
+        // targetHeaterShakerTemperature seems to already be a number. Confirm that
+        // and remove this if it's safe.
+        parseFloat(targetHeaterShakerTemperature)
       : null
   const targetShake =
+    // @ts-expect-error - todo(mm, 2025-10-09): Type error inherited from prior code.
+    // targetSpeed seems to already be a number. Confirm that
+    // and remove this if it's safe.
     setShake && targetSpeed != null ? parseFloat(targetSpeed) : null
 
   return {
     commandCreatorFnName: 'heaterShaker',
     name: stepName,
     description: stepDetails,
-    moduleId,
-    targetTemperature: targetTemperature,
+    // todo(mm, 2025-10-09): form-types.ts is inconsistent about whether moduleId is nullable.
+    // This runtime behavior of assuming it can't be nullish here is inherited from prior code.
+    // Look into this.
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    moduleId: moduleId!,
+    targetTemperature,
     rpm: targetShake,
-    latchOpen: latchOpen,
+    latchOpen,
     timerHours: isNullTime ? null : hours,
     timerMinutes: isNullTime ? null : minutes,
     timerSeconds: isNullTime ? null : seconds,

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/index.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/index.ts
@@ -16,26 +16,19 @@ import type {
   CommandCreatorArgs,
   InvariantContext,
 } from '@opentrons/step-generation'
-import type {
-  HydratedAbsorbanceReaderFormData,
-  HydratedCommentFormData,
-  HydratedFormData,
-  HydratedHeaterShakerFormData,
-  HydratedMagnetFormData,
-  HydratedMixFormData,
-  HydratedMoveLabwareFormData,
-  HydratedMoveLiquidFormData,
-  HydratedPauseFormData,
-  HydratedTemperatureFormData,
-  HydratedThermocyclerFormData,
-} from '../../../form-types'
+import type { HydratedFormData } from '../../../form-types'
+import type { GetCastFormData } from '../../../steplist/fieldLevel'
 
 // NOTE: this acts as an adapter for the PD defined data shape of the step forms
 // to create arguments that the step generation service is expecting
 // in order to generate command creators
 type StepArgs = CommandCreatorArgs | null
-export const _castForm = (hydratedForm: HydratedFormData): any =>
-  mapValues(hydratedForm, (value, name) => castField(name, value))
+export function _castForm<HydratedFormDataT extends HydratedFormData>(
+  hydratedForm: HydratedFormDataT
+): GetCastFormData<HydratedFormDataT> {
+  // @ts-expect-error - todo(mm, 2025-10-09) See if TypeScript can be made to understand this.
+  return mapValues(hydratedForm, (value, name) => castField(name, value))
+}
 
 export const stepFormToArgs = (
   hydratedForm: HydratedFormData,
@@ -43,56 +36,47 @@ export const stepFormToArgs = (
 ): StepArgs => {
   const castForm = _castForm(hydratedForm)
   let stepArgs: StepArgs = null
-  switch (castForm.stepType) {
+  switch (hydratedForm.stepType) {
     case 'moveLiquid': {
-      stepArgs = moveLiquidFormToArgs(
-        castForm as HydratedMoveLiquidFormData,
-        contextualState
-      )
+      stepArgs = moveLiquidFormToArgs(_castForm(hydratedForm), contextualState)
       break
     }
     case 'pause': {
-      stepArgs = pauseFormToArgs(castForm as HydratedPauseFormData)
+      stepArgs = pauseFormToArgs(_castForm(hydratedForm))
       break
     }
     case 'mix': {
-      stepArgs = mixFormToArgs(castForm as HydratedMixFormData)
+      stepArgs = mixFormToArgs(_castForm(hydratedForm))
       break
     }
     case 'magnet': {
-      stepArgs = magnetFormToArgs(castForm as HydratedMagnetFormData)
+      stepArgs = magnetFormToArgs(_castForm(hydratedForm))
       break
     }
     case 'temperature': {
-      stepArgs = temperatureFormToArgs(castForm as HydratedTemperatureFormData)
+      stepArgs = temperatureFormToArgs(_castForm(hydratedForm))
       break
     }
     case 'thermocycler': {
-      stepArgs = thermocyclerFormToArgs(
-        castForm as HydratedThermocyclerFormData
-      )
+      stepArgs = thermocyclerFormToArgs(_castForm(hydratedForm))
       break
     }
     case 'heaterShaker': {
-      stepArgs = heaterShakerFormToArgs(
-        castForm as HydratedHeaterShakerFormData
-      )
+      stepArgs = heaterShakerFormToArgs(_castForm(hydratedForm))
       break
     }
     case 'moveLabware': {
-      stepArgs = moveLabwareFormToArgs(castForm as HydratedMoveLabwareFormData)
+      stepArgs = moveLabwareFormToArgs(_castForm(hydratedForm))
 
       break
     }
     case 'comment': {
-      stepArgs = commentFormToArgs(castForm as HydratedCommentFormData)
+      stepArgs = commentFormToArgs(_castForm(hydratedForm))
 
       break
     }
     case 'absorbanceReader': {
-      stepArgs = absorbanceReaderFormToArgs(
-        castForm as HydratedAbsorbanceReaderFormData
-      )
+      stepArgs = absorbanceReaderFormToArgs(_castForm(hydratedForm))
       break
     }
   }

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/magnetFormToArgs.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/magnetFormToArgs.ts
@@ -7,12 +7,12 @@ import type { GetCastFormData } from '../../fieldLevel'
 
 type MagnetArgs = EngageMagnetArgs | DisengageMagnetArgs
 export const magnetFormToArgs = (
-  formData: GetCastFormData<HydratedMagnetFormData>
+  castFormData: GetCastFormData<HydratedMagnetFormData>
 ): MagnetArgs => {
-  const { magnetAction, moduleId, stepDetails, stepName } = formData
+  const { magnetAction, moduleId, stepDetails, stepName } = castFormData
   // @ts-expect-error - todo(2025-10-09): Type error inherited from prior code.
   // engageHeight seems to already be a float. Confirm that and remove this if it's safe.
-  const engageHeight = parseFloat(formData.engageHeight)
+  const engageHeight = parseFloat(castFormData.engageHeight)
   console.assert(
     magnetAction === 'engage' ? !Number.isNaN(engageHeight) : true,
     'magnetFormToArgs expected (hydrated) engageHeight to be non-NaN if magnetAction is "engage"'

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/magnetFormToArgs.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/magnetFormToArgs.ts
@@ -3,13 +3,15 @@ import type {
   EngageMagnetArgs,
 } from '@opentrons/step-generation'
 import type { HydratedMagnetFormData } from '../../../form-types'
+import type { GetCastFormData } from '../../fieldLevel'
 
 type MagnetArgs = EngageMagnetArgs | DisengageMagnetArgs
 export const magnetFormToArgs = (
-  hydratedFormData: HydratedMagnetFormData
+  hydratedFormData: GetCastFormData<HydratedMagnetFormData>
 ): MagnetArgs => {
   const { magnetAction, moduleId, stepDetails, stepName } = hydratedFormData
-  //  @ts-expect-error
+  // @ts-expect-error - todo(2025-10-09): Type error inherited from prior code.
+  // engageHeight seems to already be a float. Confirm that and remove this if it's safe.
   const engageHeight = parseFloat(hydratedFormData.engageHeight)
   console.assert(
     magnetAction === 'engage' ? !Number.isNaN(engageHeight) : true,
@@ -19,7 +21,11 @@ export const magnetFormToArgs = (
   if (magnetAction === 'engage' && !Number.isNaN(engageHeight)) {
     return {
       commandCreatorFnName: 'engageMagnet',
-      moduleId,
+      // todo(mm, 2025-10-09): form-types.ts is inconsistent about whether moduleId is nullable.
+      // This runtime behavior of assuming it can't be nullish here is inherited from prior code.
+      // Look into this.
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      moduleId: moduleId!,
       height: engageHeight,
       description: stepDetails,
       name: stepName,
@@ -27,7 +33,11 @@ export const magnetFormToArgs = (
   } else {
     return {
       commandCreatorFnName: 'disengageMagnet',
-      moduleId,
+      // todo(mm, 2025-10-09): form-types.ts is inconsistent about whether moduleId is nullable.
+      // This runtime behavior of assuming it can't be nullish here is inherited from prior code.
+      // Look into this.
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      moduleId: moduleId!,
       description: stepDetails,
       name: stepName,
     }

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/magnetFormToArgs.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/magnetFormToArgs.ts
@@ -7,12 +7,12 @@ import type { GetCastFormData } from '../../fieldLevel'
 
 type MagnetArgs = EngageMagnetArgs | DisengageMagnetArgs
 export const magnetFormToArgs = (
-  hydratedFormData: GetCastFormData<HydratedMagnetFormData>
+  formData: GetCastFormData<HydratedMagnetFormData>
 ): MagnetArgs => {
-  const { magnetAction, moduleId, stepDetails, stepName } = hydratedFormData
+  const { magnetAction, moduleId, stepDetails, stepName } = formData
   // @ts-expect-error - todo(2025-10-09): Type error inherited from prior code.
   // engageHeight seems to already be a float. Confirm that and remove this if it's safe.
-  const engageHeight = parseFloat(hydratedFormData.engageHeight)
+  const engageHeight = parseFloat(formData.engageHeight)
   console.assert(
     magnetAction === 'engage' ? !Number.isNaN(engageHeight) : true,
     'magnetFormToArgs expected (hydrated) engageHeight to be non-NaN if magnetAction is "engage"'

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/mixFormToArgs.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/mixFormToArgs.ts
@@ -16,7 +16,7 @@ import type { GetCastFormData } from '../../fieldLevel'
 
 type MixStepArgs = MixArgs
 export const mixFormToArgs = (
-  formData: GetCastFormData<HydratedMixFormData>
+  castFormData: GetCastFormData<HydratedMixFormData>
 ): MixStepArgs => {
   const {
     volume: rawVolume,
@@ -36,13 +36,13 @@ export const mixFormToArgs = (
     blowout_z_offset,
     pushOut_checkbox,
     pushOut_volume,
-  } = formData
+  } = castFormData
   const matchingTipLiquidSpecs = getMatchingTipLiquidSpecs(
     pipette,
-    formData.volume,
-    formData.tipRack
+    castFormData.volume,
+    castFormData.tipRack
   )
-  const unorderedWells = formData.wells || []
+  const unorderedWells = castFormData.wells || []
   const orderedWells = getOrderedWells(
     unorderedWells,
     labware.def,
@@ -55,27 +55,27 @@ export const mixFormToArgs = (
   const volume = rawVolume || 0
   const times = rawTimes || 0
   const aspirateFlowRateUlSec =
-    formData.aspirate_flowRate ||
+    castFormData.aspirate_flowRate ||
     matchingTipLiquidSpecs?.defaultAspirateFlowRate.default
   const dispenseFlowRateUlSec =
-    formData.dispense_flowRate ||
+    castFormData.dispense_flowRate ||
     matchingTipLiquidSpecs?.defaultDispenseFlowRate.default
 
   const offsetFromBottomMm =
-    formData.mix_mmFromBottom || DEFAULT_MM_OFFSET_FROM_BOTTOM
+    castFormData.mix_mmFromBottom || DEFAULT_MM_OFFSET_FROM_BOTTOM
   // It's radiobutton, so one should always be selected.
   // One changeTip option should always be selected.
   console.assert(
-    formData.changeTip,
+    castFormData.changeTip,
     'mixFormToArgs expected non-falsey changeTip option'
   )
-  const changeTip = formData.changeTip || DEFAULT_CHANGE_TIP_OPTION
-  const blowoutLocation = formData.blowout_checkbox
-    ? formData.blowout_location
+  const changeTip = castFormData.changeTip || DEFAULT_CHANGE_TIP_OPTION
+  const blowoutLocation = castFormData.blowout_checkbox
+    ? castFormData.blowout_location
     : null
   // Blowout settings
   const blowoutFlowRateUlSec =
-    formData.blowout_flowRate ??
+    castFormData.blowout_flowRate ??
     matchingTipLiquidSpecs?.defaultBlowOutFlowRate.default
 
   const blowoutOffsetFromTopMm = blowoutLocation
@@ -83,19 +83,19 @@ export const mixFormToArgs = (
     : 0
   // Delay settings
   const aspirateDelaySeconds = getMixDelayData(
-    formData,
+    castFormData,
     'aspirate_delay_checkbox',
     'aspirate_delay_seconds'
   )
   const dispenseDelaySeconds = getMixDelayData(
-    formData,
+    castFormData,
     'dispense_delay_checkbox',
     'dispense_delay_seconds'
   )
   return {
     commandCreatorFnName: 'mix',
-    name: formData.stepName,
-    description: formData.stepDetails,
+    name: castFormData.stepName,
+    description: castFormData.stepDetails,
     labware: labware.id,
     wells: orderedWells,
     volume,
@@ -111,7 +111,7 @@ export const mixFormToArgs = (
     offsetFromBottomMm,
     blowoutOffsetFromTopMm,
     aspirateDelaySeconds,
-    tipRack: formData.tipRack,
+    tipRack: castFormData.tipRack,
     dispenseDelaySeconds,
     //  TODO(jr, 7/26/24): wire up wellNames
     dropTipLocation: dropTip_location,

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/mixFormToArgs.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/mixFormToArgs.ts
@@ -16,7 +16,7 @@ import type { GetCastFormData } from '../../fieldLevel'
 
 type MixStepArgs = MixArgs
 export const mixFormToArgs = (
-  hydratedFormData: GetCastFormData<HydratedMixFormData>
+  formData: GetCastFormData<HydratedMixFormData>
 ): MixStepArgs => {
   const {
     volume: rawVolume,
@@ -36,13 +36,13 @@ export const mixFormToArgs = (
     blowout_z_offset,
     pushOut_checkbox,
     pushOut_volume,
-  } = hydratedFormData
+  } = formData
   const matchingTipLiquidSpecs = getMatchingTipLiquidSpecs(
     pipette,
-    hydratedFormData.volume,
-    hydratedFormData.tipRack
+    formData.volume,
+    formData.tipRack
   )
-  const unorderedWells = hydratedFormData.wells || []
+  const unorderedWells = formData.wells || []
   const orderedWells = getOrderedWells(
     unorderedWells,
     labware.def,
@@ -55,27 +55,27 @@ export const mixFormToArgs = (
   const volume = rawVolume || 0
   const times = rawTimes || 0
   const aspirateFlowRateUlSec =
-    hydratedFormData.aspirate_flowRate ||
+    formData.aspirate_flowRate ||
     matchingTipLiquidSpecs?.defaultAspirateFlowRate.default
   const dispenseFlowRateUlSec =
-    hydratedFormData.dispense_flowRate ||
+    formData.dispense_flowRate ||
     matchingTipLiquidSpecs?.defaultDispenseFlowRate.default
 
   const offsetFromBottomMm =
-    hydratedFormData.mix_mmFromBottom || DEFAULT_MM_OFFSET_FROM_BOTTOM
+    formData.mix_mmFromBottom || DEFAULT_MM_OFFSET_FROM_BOTTOM
   // It's radiobutton, so one should always be selected.
   // One changeTip option should always be selected.
   console.assert(
-    hydratedFormData.changeTip,
+    formData.changeTip,
     'mixFormToArgs expected non-falsey changeTip option'
   )
-  const changeTip = hydratedFormData.changeTip || DEFAULT_CHANGE_TIP_OPTION
-  const blowoutLocation = hydratedFormData.blowout_checkbox
-    ? hydratedFormData.blowout_location
+  const changeTip = formData.changeTip || DEFAULT_CHANGE_TIP_OPTION
+  const blowoutLocation = formData.blowout_checkbox
+    ? formData.blowout_location
     : null
   // Blowout settings
   const blowoutFlowRateUlSec =
-    hydratedFormData.blowout_flowRate ??
+    formData.blowout_flowRate ??
     matchingTipLiquidSpecs?.defaultBlowOutFlowRate.default
 
   const blowoutOffsetFromTopMm = blowoutLocation
@@ -83,19 +83,19 @@ export const mixFormToArgs = (
     : 0
   // Delay settings
   const aspirateDelaySeconds = getMixDelayData(
-    hydratedFormData,
+    formData,
     'aspirate_delay_checkbox',
     'aspirate_delay_seconds'
   )
   const dispenseDelaySeconds = getMixDelayData(
-    hydratedFormData,
+    formData,
     'dispense_delay_checkbox',
     'dispense_delay_seconds'
   )
   return {
     commandCreatorFnName: 'mix',
-    name: hydratedFormData.stepName,
-    description: hydratedFormData.stepDetails,
+    name: formData.stepName,
+    description: formData.stepDetails,
     labware: labware.id,
     wells: orderedWells,
     volume,
@@ -111,7 +111,7 @@ export const mixFormToArgs = (
     offsetFromBottomMm,
     blowoutOffsetFromTopMm,
     aspirateDelaySeconds,
-    tipRack: hydratedFormData.tipRack,
+    tipRack: formData.tipRack,
     dispenseDelaySeconds,
     //  TODO(jr, 7/26/24): wire up wellNames
     dropTipLocation: dropTip_location,

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/mixFormToArgs.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/mixFormToArgs.ts
@@ -12,10 +12,11 @@ import { getMixDelayData } from './getDelayData'
 
 import type { MixArgs } from '@opentrons/step-generation'
 import type { HydratedMixFormData } from '../../../form-types'
+import type { GetCastFormData } from '../../fieldLevel'
 
 type MixStepArgs = MixArgs
 export const mixFormToArgs = (
-  hydratedFormData: HydratedMixFormData
+  hydratedFormData: GetCastFormData<HydratedMixFormData>
 ): MixStepArgs => {
   const {
     volume: rawVolume,

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/moveLabwareFormToArgs.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/moveLabwareFormToArgs.ts
@@ -3,15 +3,9 @@ import type { HydratedMoveLabwareFormData } from '../../../form-types'
 import type { GetCastFormData } from '../../fieldLevel'
 
 export const moveLabwareFormToArgs = (
-  hydratedFormData: GetCastFormData<HydratedMoveLabwareFormData>
+  formData: GetCastFormData<HydratedMoveLabwareFormData>
 ): MoveLabwareArgs => {
-  const {
-    labware,
-    useGripper,
-    newLocation,
-    stepName,
-    stepDetails,
-  } = hydratedFormData
+  const { labware, useGripper, newLocation, stepName, stepDetails } = formData
 
   return {
     commandCreatorFnName: 'moveLabware',

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/moveLabwareFormToArgs.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/moveLabwareFormToArgs.ts
@@ -3,9 +3,15 @@ import type { HydratedMoveLabwareFormData } from '../../../form-types'
 import type { GetCastFormData } from '../../fieldLevel'
 
 export const moveLabwareFormToArgs = (
-  formData: GetCastFormData<HydratedMoveLabwareFormData>
+  castFormData: GetCastFormData<HydratedMoveLabwareFormData>
 ): MoveLabwareArgs => {
-  const { labware, useGripper, newLocation, stepName, stepDetails } = formData
+  const {
+    labware,
+    useGripper,
+    newLocation,
+    stepName,
+    stepDetails,
+  } = castFormData
 
   return {
     commandCreatorFnName: 'moveLabware',

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/moveLabwareFormToArgs.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/moveLabwareFormToArgs.ts
@@ -1,9 +1,9 @@
-import type { LabwareMovementStrategy } from '@opentrons/shared-data'
 import type { MoveLabwareArgs } from '@opentrons/step-generation'
 import type { HydratedMoveLabwareFormData } from '../../../form-types'
+import type { GetCastFormData } from '../../fieldLevel'
 
 export const moveLabwareFormToArgs = (
-  hydratedFormData: HydratedMoveLabwareFormData
+  hydratedFormData: GetCastFormData<HydratedMoveLabwareFormData>
 ): MoveLabwareArgs => {
   const {
     labware,
@@ -19,8 +19,6 @@ export const moveLabwareFormToArgs = (
     description: stepDetails,
     labwareId: labware.id,
     newLocation,
-    strategy: useGripper
-      ? 'usingGripper'
-      : ('manualMoveWithPause' as LabwareMovementStrategy),
+    strategy: useGripper ? 'usingGripper' : 'manualMoveWithPause',
   }
 }

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/moveLiquidFormToArgs.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/moveLiquidFormToArgs.ts
@@ -31,12 +31,12 @@ import type { GetCastFormData } from '../../fieldLevel'
 
 // NOTE(sa, 2020-08-11): leaving this as fn so it can be expanded later for dispense air gap
 export function getAirGapData(
-  formData: GetCastFormData<HydratedMoveLiquidFormData>,
+  castFormData: GetCastFormData<HydratedMoveLiquidFormData>,
   checkboxField: 'aspirate_airGap_checkbox' | 'dispense_airGap_checkbox',
   volumeField: 'aspirate_airGap_volume' | 'dispense_airGap_volume'
 ): number | null {
-  const checkbox = formData[checkboxField]
-  const volume = formData[volumeField]
+  const checkbox = castFormData[checkboxField]
+  const volume = castFormData[volumeField]
 
   if (checkbox && typeof volume === 'number' && volume > 0) {
     return volume
@@ -45,14 +45,14 @@ export function getAirGapData(
   return null
 }
 export function getMixData(
-  formData: GetCastFormData<HydratedMoveLiquidFormData>,
+  castFormData: GetCastFormData<HydratedMoveLiquidFormData>,
   checkboxField: 'aspirate_mix_checkbox' | 'dispense_mix_checkbox',
   volumeField: 'aspirate_mix_volume' | 'dispense_mix_volume',
   timesField: 'aspirate_mix_times' | 'dispense_mix_times'
 ): InnerMixArgs | null | undefined {
-  const checkbox = formData[checkboxField]
-  const volume = formData[volumeField]
-  const times = formData[timesField]
+  const checkbox = castFormData[checkboxField]
+  const volume = castFormData[volumeField]
+  const times = castFormData[timesField]
 
   if (
     checkbox &&
@@ -71,11 +71,11 @@ export function getMixData(
 }
 
 const getCheckedPath = (
-  formData: GetCastFormData<HydratedMoveLiquidFormData>,
+  castFormData: GetCastFormData<HydratedMoveLiquidFormData>,
   contextualState: InvariantContext,
   path: PathOption
 ): PathOption => {
-  const { pipette, tipRack, volume } = formData
+  const { pipette, tipRack, volume } = castFormData
   const { spec: pipetteSpecs } = pipette
   const tiprackEntity = Object.values(contextualState.labwareEntities).find(
     lw => lw.labwareDefURI === tipRack
@@ -88,10 +88,10 @@ const getCheckedPath = (
   const { labwareDefURI: tiprackDefUri, def: tiprackDef } = tiprackEntity
   const allLiquidClassDefs = getAllLiquidClassDefs()
   const liquidClassValuesForTip = allLiquidClassDefs[
-    formData.liquidClass === NONE_LIQUID_CLASS_NAME ||
-    formData.liquidClass == null
+    castFormData.liquidClass === NONE_LIQUID_CLASS_NAME ||
+    castFormData.liquidClass == null
       ? WATER_LIQUID_CLASS_NAME
-      : formData.liquidClass ?? null
+      : castFormData.liquidClass ?? null
   ]?.byPipette
     .find(
       ({ pipetteModel }) => (pipetteModel = getFlexNameConversion(pipetteSpecs))
@@ -118,8 +118,8 @@ const getCheckedPath = (
           tiprackDefinition: tiprackDef,
           volume,
           path,
-          numAspirateWells: formData.aspirate_wells.length,
-          numDispenseWells: formData.dispense_wells.length,
+          numAspirateWells: castFormData.aspirate_wells.length,
+          numDispenseWells: castFormData.dispense_wells.length,
           aspirateAirGapByVolume: liquidClassValuesForTip.aspirate.retract
             .airGapByVolume as Array<[number, number]>,
           conditioningByVolume: null,
@@ -130,8 +130,8 @@ const getCheckedPath = (
           tiprackDefinition: tiprackDef,
           volume,
           path,
-          numAspirateWells: formData.aspirate_wells.length,
-          numDispenseWells: formData.dispense_wells.length,
+          numAspirateWells: castFormData.aspirate_wells.length,
+          numDispenseWells: castFormData.dispense_wells.length,
           aspirateAirGapByVolume: liquidClassValuesForTip.aspirate.retract
             .airGapByVolume as Array<[number, number]>,
           conditioningByVolume:
@@ -153,14 +153,14 @@ const getCheckedPath = (
 }
 type MoveLiquidStepArgs = ConsolidateArgs | DistributeArgs | TransferArgs | null
 export const moveLiquidFormToArgs = (
-  formData: GetCastFormData<HydratedMoveLiquidFormData>,
+  castFormData: GetCastFormData<HydratedMoveLiquidFormData>,
   contextualState: InvariantContext
 ): MoveLiquidStepArgs => {
   console.assert(
-    formData.stepType === 'moveLiquid',
-    `moveLiquidFormToArgs called with stepType ${formData.stepType}, expected "moveLiquid"`
+    castFormData.stepType === 'moveLiquid',
+    `moveLiquidFormToArgs called with stepType ${castFormData.stepType}, expected "moveLiquid"`
   )
-  const pipetteId = formData.pipette.id
+  const pipetteId = castFormData.pipette.id
   const {
     volume,
     aspirate_labware: sourceLabware,
@@ -177,12 +177,12 @@ export const moveLiquidFormToArgs = (
     dispense_y_position,
     pushOut_checkbox,
     pushOut_volume,
-  } = formData
+  } = castFormData
   let sourceWells = getOrderedWells(
-    formData.aspirate_wells,
+    castFormData.aspirate_wells,
     sourceLabware.def,
-    formData.aspirate_wellOrder_first,
-    formData.aspirate_wellOrder_second
+    castFormData.aspirate_wellOrder_first,
+    castFormData.aspirate_wellOrder_second
   )
 
   const isDispensingIntoDisposalLocation =
@@ -201,8 +201,8 @@ export const moveLiquidFormToArgs = (
       ? getOrderedWells(
           dispWells,
           def,
-          formData.dispense_wellOrder_first,
-          formData.dispense_wellOrder_second
+          castFormData.dispense_wellOrder_first,
+          castFormData.dispense_wellOrder_second
         )
       : null
 
@@ -218,88 +218,92 @@ export const moveLiquidFormToArgs = (
     }
   }
 
-  const disposalVolume = formData.disposalVolume_checkbox
-    ? formData.disposalVolume_volume
+  const disposalVolume = castFormData.disposalVolume_checkbox
+    ? castFormData.disposalVolume_volume
     : null
-  const touchTipAfterAspirate = Boolean(formData.aspirate_touchTip_checkbox)
+  const touchTipAfterAspirate = Boolean(castFormData.aspirate_touchTip_checkbox)
   const touchTipAfterAspirateOffsetMmFromTop =
-    formData.aspirate_touchTip_mmFromTop ?? DEFAULT_MM_TOUCH_TIP_OFFSET_FROM_TOP
-  const touchTipAfterAspirateSpeed = formData.aspirate_touchTip_speed ?? null
+    castFormData.aspirate_touchTip_mmFromTop ??
+    DEFAULT_MM_TOUCH_TIP_OFFSET_FROM_TOP
+  const touchTipAfterAspirateSpeed =
+    castFormData.aspirate_touchTip_speed ?? null
   const touchTipAfterAspirateMmFromEdge =
-    formData.aspirate_touchTip_mmFromEdge ?? null
-  const touchTipAfterDispense = Boolean(formData.dispense_touchTip_checkbox)
+    castFormData.aspirate_touchTip_mmFromEdge ?? null
+  const touchTipAfterDispense = Boolean(castFormData.dispense_touchTip_checkbox)
   const touchTipAfterDispenseOffsetMmFromTop =
-    formData.dispense_touchTip_mmFromTop ?? DEFAULT_MM_TOUCH_TIP_OFFSET_FROM_TOP
-  const touchTipAfterDispenseSpeed = formData.dispense_touchTip_speed ?? null
+    castFormData.dispense_touchTip_mmFromTop ??
+    DEFAULT_MM_TOUCH_TIP_OFFSET_FROM_TOP
+  const touchTipAfterDispenseSpeed =
+    castFormData.dispense_touchTip_speed ?? null
   const touchTipAfterDispenseMmFromEdge =
-    formData.dispense_touchTip_mmFromEdge ?? null
+    castFormData.dispense_touchTip_mmFromEdge ?? null
 
   const mixBeforeAspirate = getMixData(
-    formData,
+    castFormData,
     'aspirate_mix_checkbox',
     'aspirate_mix_volume',
     'aspirate_mix_times'
   )
   const mixInDestination = getMixData(
-    formData,
+    castFormData,
     'dispense_mix_checkbox',
     'dispense_mix_volume',
     'dispense_mix_times'
   )
   const aspirateDelay = getMoveLiquidDelayData({
-    formData,
+    castFormData: castFormData,
     secondsField: 'aspirate_delay_seconds',
     checkboxField: 'aspirate_delay_checkbox',
   })
   const dispenseDelay = getMoveLiquidDelayData({
-    formData,
+    castFormData: castFormData,
     secondsField: 'dispense_delay_seconds',
     checkboxField: 'dispense_delay_checkbox',
   })
   const aspirateSubmergeDelay = getMoveLiquidDelayData({
-    formData,
+    castFormData: castFormData,
     secondsField: 'aspirate_submerge_delay_seconds',
   })
   const dispenseSubmergeDelay = getMoveLiquidDelayData({
-    formData,
+    castFormData: castFormData,
     secondsField: 'dispense_submerge_delay_seconds',
   })
   const aspirateRetractDelay = getMoveLiquidDelayData({
-    formData,
+    castFormData: castFormData,
     secondsField: 'aspirate_retract_delay_seconds',
   })
   const dispenseRetractDelay = getMoveLiquidDelayData({
-    formData,
+    castFormData: castFormData,
     secondsField: 'dispense_retract_delay_seconds',
   })
   const blowoutLocation =
-    (formData.blowout_checkbox && formData.blowout_location) ||
-    (formData.disposalVolume_checkbox &&
+    (castFormData.blowout_checkbox && castFormData.blowout_location) ||
+    (castFormData.disposalVolume_checkbox &&
       path === 'multiDispense' &&
-      formData.disposalVolume_volume &&
-      formData.blowout_location) ||
+      castFormData.disposalVolume_volume &&
+      castFormData.blowout_location) ||
     null
 
   const aspirateAirGapVolume = getAirGapData(
-    formData,
+    castFormData,
     'aspirate_airGap_checkbox',
     'aspirate_airGap_volume'
   )
   const dispenseAirGapVolume = getAirGapData(
-    formData,
+    castFormData,
     'dispense_airGap_checkbox',
     'dispense_airGap_volume'
   )
   const matchingTipLiquidSpecs = getMatchingTipLiquidSpecs(
-    formData.pipette,
-    formData.volume,
+    castFormData.pipette,
+    castFormData.volume,
     tipRack
   )
   const conditioningVolume =
-    formData.conditioning_checkbox === true &&
-    formData.conditioning_volume != null &&
-    formData.conditioning_volume > 0
-      ? formData.conditioning_volume
+    castFormData.conditioning_checkbox === true &&
+    castFormData.conditioning_volume != null &&
+    castFormData.conditioning_volume > 0
+      ? castFormData.conditioning_volume
       : 0
 
   const commonFields = {
@@ -309,20 +313,20 @@ export const moveLiquidFormToArgs = (
     destLabware: destLabware.id,
     tipRack,
     aspirateFlowRateUlSec:
-      formData.aspirate_flowRate ||
+      castFormData.aspirate_flowRate ||
       matchingTipLiquidSpecs.defaultAspirateFlowRate.default,
     dispenseFlowRateUlSec:
-      formData.dispense_flowRate ||
+      castFormData.dispense_flowRate ||
       matchingTipLiquidSpecs.defaultDispenseFlowRate.default,
     aspirateOffsetFromBottomMm:
-      formData.aspirate_mmFromBottom || DEFAULT_MM_OFFSET_FROM_BOTTOM,
+      castFormData.aspirate_mmFromBottom || DEFAULT_MM_OFFSET_FROM_BOTTOM,
     dispenseOffsetFromBottomMm:
-      formData.dispense_mmFromBottom || DEFAULT_MM_OFFSET_FROM_BOTTOM,
+      castFormData.dispense_mmFromBottom || DEFAULT_MM_OFFSET_FROM_BOTTOM,
     blowoutFlowRateUlSec:
-      formData.blowout_flowRate ||
+      castFormData.blowout_flowRate ||
       matchingTipLiquidSpecs.defaultBlowOutFlowRate.default,
-    changeTip: formData.changeTip,
-    preWetTip: Boolean(formData.preWetTip),
+    changeTip: castFormData.changeTip,
+    preWetTip: Boolean(castFormData.preWetTip),
     aspirateDelay,
     dispenseDelay,
     aspirateSubmergeDelay,
@@ -339,50 +343,50 @@ export const moveLiquidFormToArgs = (
     touchTipAfterDispenseOffsetMmFromTop,
     touchTipAfterDispenseSpeed,
     touchTipAfterDispenseMmFromEdge,
-    description: formData.stepDetails,
-    name: formData.stepName,
+    description: castFormData.stepDetails,
+    name: castFormData.stepName,
     //  TODO(jr, 7/26/24): wire up wellNames
     dropTipLocation,
     nozzles,
     aspirateXOffset: aspirate_x_position ?? 0,
     aspirateYOffset: aspirate_y_position ?? 0,
     aspirateZOffset:
-      formData.aspirate_mmFromBottom ?? DEFAULT_MM_OFFSET_FROM_BOTTOM,
-    aspiratePositionReference: formData.aspirate_position_reference,
+      castFormData.aspirate_mmFromBottom ?? DEFAULT_MM_OFFSET_FROM_BOTTOM,
+    aspiratePositionReference: castFormData.aspirate_position_reference,
     dispenseXOffset: dispense_x_position ?? 0,
     dispenseYOffset: dispense_y_position ?? 0,
     dispenseZOffset:
-      formData.dispense_mmFromBottom ?? DEFAULT_MM_OFFSET_FROM_BOTTOM,
-    dispensePositionReference: formData.dispense_position_reference,
-    aspirateSubmergeSpeed: formData.aspirate_submerge_speed ?? null,
-    aspirateSubmergeXOffset: formData.aspirate_submerge_x_position ?? 0,
-    aspirateSubmergeYOffset: formData.aspirate_submerge_y_position ?? 0,
-    aspirateSubmergeZOffset: formData.aspirate_submerge_mmFromBottom ?? 0,
+      castFormData.dispense_mmFromBottom ?? DEFAULT_MM_OFFSET_FROM_BOTTOM,
+    dispensePositionReference: castFormData.dispense_position_reference,
+    aspirateSubmergeSpeed: castFormData.aspirate_submerge_speed ?? null,
+    aspirateSubmergeXOffset: castFormData.aspirate_submerge_x_position ?? 0,
+    aspirateSubmergeYOffset: castFormData.aspirate_submerge_y_position ?? 0,
+    aspirateSubmergeZOffset: castFormData.aspirate_submerge_mmFromBottom ?? 0,
     aspirateSubmergePositionReference:
-      formData.aspirate_submerge_position_reference,
-    aspirateRetractSpeed: formData.aspirate_retract_speed ?? null,
-    aspirateRetractXOffset: formData.aspirate_retract_x_position ?? 0,
-    aspirateRetractYOffset: formData.aspirate_retract_y_position ?? 0,
-    aspirateRetractZOffset: formData.aspirate_retract_mmFromBottom ?? 0,
+      castFormData.aspirate_submerge_position_reference,
+    aspirateRetractSpeed: castFormData.aspirate_retract_speed ?? null,
+    aspirateRetractXOffset: castFormData.aspirate_retract_x_position ?? 0,
+    aspirateRetractYOffset: castFormData.aspirate_retract_y_position ?? 0,
+    aspirateRetractZOffset: castFormData.aspirate_retract_mmFromBottom ?? 0,
     aspirateRetractPositionReference:
-      formData.aspirate_retract_position_reference,
-    dispenseSubmergeSpeed: formData.dispense_submerge_speed ?? null,
-    dispenseSubmergeXOffset: formData.dispense_submerge_x_position ?? 0,
-    dispenseSubmergeYOffset: formData.dispense_submerge_y_position ?? 0,
-    dispenseSubmergeZOffset: formData.dispense_submerge_mmFromBottom ?? 0,
+      castFormData.aspirate_retract_position_reference,
+    dispenseSubmergeSpeed: castFormData.dispense_submerge_speed ?? null,
+    dispenseSubmergeXOffset: castFormData.dispense_submerge_x_position ?? 0,
+    dispenseSubmergeYOffset: castFormData.dispense_submerge_y_position ?? 0,
+    dispenseSubmergeZOffset: castFormData.dispense_submerge_mmFromBottom ?? 0,
     dispenseSubmergePositionReference:
-      formData.dispense_submerge_position_reference,
-    dispenseRetractSpeed: formData.dispense_retract_speed ?? null,
-    dispenseRetractYOffset: formData.dispense_retract_y_position ?? 0,
-    dispenseRetractZOffset: formData.dispense_retract_mmFromBottom ?? 0,
+      castFormData.dispense_submerge_position_reference,
+    dispenseRetractSpeed: castFormData.dispense_retract_speed ?? null,
+    dispenseRetractYOffset: castFormData.dispense_retract_y_position ?? 0,
+    dispenseRetractZOffset: castFormData.dispense_retract_mmFromBottom ?? 0,
     dispenseRetractPositionReference:
-      formData.dispense_retract_position_reference,
-    dispenseRetractXOffset: formData.dispense_retract_x_position ?? 0,
+      castFormData.dispense_retract_position_reference,
+    dispenseRetractXOffset: castFormData.dispense_retract_x_position ?? 0,
     pushOut: pushOut_checkbox ? pushOut_volume : 0,
     liquidClass:
-      formData.liquidClass === NONE_LIQUID_CLASS_NAME // transform "none" (needed in step form) to null
+      castFormData.liquidClass === NONE_LIQUID_CLASS_NAME // transform "none" (needed in step form) to null
         ? null
-        : formData.liquidClass ?? null,
+        : castFormData.liquidClass ?? null,
   }
   console.assert(
     sourceWellsUnordered.length > 0,
@@ -405,7 +409,7 @@ export const moveLiquidFormToArgs = (
     'cannot distribute when destWells is null'
   )
 
-  const checkedPath = getCheckedPath(formData, contextualState, path)
+  const checkedPath = getCheckedPath(castFormData, contextualState, path)
 
   switch (checkedPath) {
     case 'single': {

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/moveLiquidFormToArgs.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/moveLiquidFormToArgs.ts
@@ -27,15 +27,16 @@ import type {
   TransferArgs,
 } from '@opentrons/step-generation'
 import type { HydratedMoveLiquidFormData } from '../../../form-types'
+import type { GetCastFormData } from '../../fieldLevel'
 
 // NOTE(sa, 2020-08-11): leaving this as fn so it can be expanded later for dispense air gap
 export function getAirGapData(
-  hydratedFormData: HydratedMoveLiquidFormData,
+  formData: GetCastFormData<HydratedMoveLiquidFormData>,
   checkboxField: 'aspirate_airGap_checkbox' | 'dispense_airGap_checkbox',
   volumeField: 'aspirate_airGap_volume' | 'dispense_airGap_volume'
 ): number | null {
-  const checkbox = hydratedFormData[checkboxField]
-  const volume = hydratedFormData[volumeField]
+  const checkbox = formData[checkboxField]
+  const volume = formData[volumeField]
 
   if (checkbox && typeof volume === 'number' && volume > 0) {
     return volume
@@ -44,14 +45,14 @@ export function getAirGapData(
   return null
 }
 export function getMixData(
-  hydratedFormData: any,
-  checkboxField: any,
-  volumeField: any,
-  timesField: any
+  formData: GetCastFormData<HydratedMoveLiquidFormData>,
+  checkboxField: 'aspirate_mix_checkbox' | 'dispense_mix_checkbox',
+  volumeField: 'aspirate_mix_volume' | 'dispense_mix_volume',
+  timesField: 'aspirate_mix_times' | 'dispense_mix_times'
 ): InnerMixArgs | null | undefined {
-  const checkbox = hydratedFormData[checkboxField]
-  const volume = hydratedFormData[volumeField]
-  const times = hydratedFormData[timesField]
+  const checkbox = formData[checkboxField]
+  const volume = formData[volumeField]
+  const times = formData[timesField]
 
   if (
     checkbox &&
@@ -70,11 +71,11 @@ export function getMixData(
 }
 
 const getCheckedPath = (
-  hydratedFormData: HydratedMoveLiquidFormData,
+  formData: GetCastFormData<HydratedMoveLiquidFormData>,
   contextualState: InvariantContext,
   path: PathOption
 ): PathOption => {
-  const { pipette, tipRack, volume } = hydratedFormData
+  const { pipette, tipRack, volume } = formData
   const { spec: pipetteSpecs } = pipette
   const tiprackEntity = Object.values(contextualState.labwareEntities).find(
     lw => lw.labwareDefURI === tipRack
@@ -87,10 +88,10 @@ const getCheckedPath = (
   const { labwareDefURI: tiprackDefUri, def: tiprackDef } = tiprackEntity
   const allLiquidClassDefs = getAllLiquidClassDefs()
   const liquidClassValuesForTip = allLiquidClassDefs[
-    hydratedFormData.liquidClass === NONE_LIQUID_CLASS_NAME ||
-    hydratedFormData.liquidClass == null
+    formData.liquidClass === NONE_LIQUID_CLASS_NAME ||
+    formData.liquidClass == null
       ? WATER_LIQUID_CLASS_NAME
-      : hydratedFormData.liquidClass ?? null
+      : formData.liquidClass ?? null
   ]?.byPipette
     .find(
       ({ pipetteModel }) => (pipetteModel = getFlexNameConversion(pipetteSpecs))
@@ -117,8 +118,8 @@ const getCheckedPath = (
           tiprackDefinition: tiprackDef,
           volume,
           path,
-          numAspirateWells: hydratedFormData.aspirate_wells.length,
-          numDispenseWells: hydratedFormData.dispense_wells.length,
+          numAspirateWells: formData.aspirate_wells.length,
+          numDispenseWells: formData.dispense_wells.length,
           aspirateAirGapByVolume: liquidClassValuesForTip.aspirate.retract
             .airGapByVolume as Array<[number, number]>,
           conditioningByVolume: null,
@@ -129,8 +130,8 @@ const getCheckedPath = (
           tiprackDefinition: tiprackDef,
           volume,
           path,
-          numAspirateWells: hydratedFormData.aspirate_wells.length,
-          numDispenseWells: hydratedFormData.dispense_wells.length,
+          numAspirateWells: formData.aspirate_wells.length,
+          numDispenseWells: formData.dispense_wells.length,
           aspirateAirGapByVolume: liquidClassValuesForTip.aspirate.retract
             .airGapByVolume as Array<[number, number]>,
           conditioningByVolume:
@@ -152,14 +153,14 @@ const getCheckedPath = (
 }
 type MoveLiquidStepArgs = ConsolidateArgs | DistributeArgs | TransferArgs | null
 export const moveLiquidFormToArgs = (
-  hydratedFormData: HydratedMoveLiquidFormData,
+  formData: GetCastFormData<HydratedMoveLiquidFormData>,
   contextualState: InvariantContext
 ): MoveLiquidStepArgs => {
   console.assert(
-    hydratedFormData.stepType === 'moveLiquid',
-    `moveLiquidFormToArgs called with stepType ${hydratedFormData.stepType}, expected "moveLiquid"`
+    formData.stepType === 'moveLiquid',
+    `moveLiquidFormToArgs called with stepType ${formData.stepType}, expected "moveLiquid"`
   )
-  const pipetteId = hydratedFormData.pipette.id
+  const pipetteId = formData.pipette.id
   const {
     volume,
     aspirate_labware: sourceLabware,
@@ -176,12 +177,12 @@ export const moveLiquidFormToArgs = (
     dispense_y_position,
     pushOut_checkbox,
     pushOut_volume,
-  } = hydratedFormData
+  } = formData
   let sourceWells = getOrderedWells(
-    hydratedFormData.aspirate_wells,
+    formData.aspirate_wells,
     sourceLabware.def,
-    hydratedFormData.aspirate_wellOrder_first,
-    hydratedFormData.aspirate_wellOrder_second
+    formData.aspirate_wellOrder_first,
+    formData.aspirate_wellOrder_second
   )
 
   const isDispensingIntoDisposalLocation =
@@ -200,8 +201,8 @@ export const moveLiquidFormToArgs = (
       ? getOrderedWells(
           dispWells,
           def,
-          hydratedFormData.dispense_wellOrder_first,
-          hydratedFormData.dispense_wellOrder_second
+          formData.dispense_wellOrder_first,
+          formData.dispense_wellOrder_second
         )
       : null
 
@@ -217,96 +218,88 @@ export const moveLiquidFormToArgs = (
     }
   }
 
-  const disposalVolume = hydratedFormData.disposalVolume_checkbox
-    ? hydratedFormData.disposalVolume_volume
+  const disposalVolume = formData.disposalVolume_checkbox
+    ? formData.disposalVolume_volume
     : null
-  const touchTipAfterAspirate = Boolean(
-    hydratedFormData.aspirate_touchTip_checkbox
-  )
+  const touchTipAfterAspirate = Boolean(formData.aspirate_touchTip_checkbox)
   const touchTipAfterAspirateOffsetMmFromTop =
-    hydratedFormData.aspirate_touchTip_mmFromTop ??
-    DEFAULT_MM_TOUCH_TIP_OFFSET_FROM_TOP
-  const touchTipAfterAspirateSpeed =
-    hydratedFormData.aspirate_touchTip_speed ?? null
+    formData.aspirate_touchTip_mmFromTop ?? DEFAULT_MM_TOUCH_TIP_OFFSET_FROM_TOP
+  const touchTipAfterAspirateSpeed = formData.aspirate_touchTip_speed ?? null
   const touchTipAfterAspirateMmFromEdge =
-    hydratedFormData.aspirate_touchTip_mmFromEdge ?? null
-  const touchTipAfterDispense = Boolean(
-    hydratedFormData.dispense_touchTip_checkbox
-  )
+    formData.aspirate_touchTip_mmFromEdge ?? null
+  const touchTipAfterDispense = Boolean(formData.dispense_touchTip_checkbox)
   const touchTipAfterDispenseOffsetMmFromTop =
-    hydratedFormData.dispense_touchTip_mmFromTop ??
-    DEFAULT_MM_TOUCH_TIP_OFFSET_FROM_TOP
-  const touchTipAfterDispenseSpeed =
-    hydratedFormData.dispense_touchTip_speed ?? null
+    formData.dispense_touchTip_mmFromTop ?? DEFAULT_MM_TOUCH_TIP_OFFSET_FROM_TOP
+  const touchTipAfterDispenseSpeed = formData.dispense_touchTip_speed ?? null
   const touchTipAfterDispenseMmFromEdge =
-    hydratedFormData.dispense_touchTip_mmFromEdge ?? null
+    formData.dispense_touchTip_mmFromEdge ?? null
 
   const mixBeforeAspirate = getMixData(
-    hydratedFormData,
+    formData,
     'aspirate_mix_checkbox',
     'aspirate_mix_volume',
     'aspirate_mix_times'
   )
   const mixInDestination = getMixData(
-    hydratedFormData,
+    formData,
     'dispense_mix_checkbox',
     'dispense_mix_volume',
     'dispense_mix_times'
   )
   const aspirateDelay = getMoveLiquidDelayData({
-    hydratedFormData,
+    formData,
     secondsField: 'aspirate_delay_seconds',
     checkboxField: 'aspirate_delay_checkbox',
   })
   const dispenseDelay = getMoveLiquidDelayData({
-    hydratedFormData,
+    formData,
     secondsField: 'dispense_delay_seconds',
     checkboxField: 'dispense_delay_checkbox',
   })
   const aspirateSubmergeDelay = getMoveLiquidDelayData({
-    hydratedFormData,
+    formData,
     secondsField: 'aspirate_submerge_delay_seconds',
   })
   const dispenseSubmergeDelay = getMoveLiquidDelayData({
-    hydratedFormData,
+    formData,
     secondsField: 'dispense_submerge_delay_seconds',
   })
   const aspirateRetractDelay = getMoveLiquidDelayData({
-    hydratedFormData,
+    formData,
     secondsField: 'aspirate_retract_delay_seconds',
   })
   const dispenseRetractDelay = getMoveLiquidDelayData({
-    hydratedFormData,
+    formData,
     secondsField: 'dispense_retract_delay_seconds',
   })
   const blowoutLocation =
-    (hydratedFormData.blowout_checkbox && hydratedFormData.blowout_location) ||
-    (hydratedFormData.disposalVolume_checkbox &&
+    (formData.blowout_checkbox && formData.blowout_location) ||
+    (formData.disposalVolume_checkbox &&
       path === 'multiDispense' &&
-      hydratedFormData.disposalVolume_volume &&
-      hydratedFormData.blowout_location) ||
+      formData.disposalVolume_volume &&
+      formData.blowout_location) ||
     null
 
   const aspirateAirGapVolume = getAirGapData(
-    hydratedFormData,
+    formData,
     'aspirate_airGap_checkbox',
     'aspirate_airGap_volume'
   )
   const dispenseAirGapVolume = getAirGapData(
-    hydratedFormData,
+    formData,
     'dispense_airGap_checkbox',
     'dispense_airGap_volume'
   )
   const matchingTipLiquidSpecs = getMatchingTipLiquidSpecs(
-    hydratedFormData.pipette,
-    hydratedFormData.volume,
+    formData.pipette,
+    formData.volume,
     tipRack
   )
   const conditioningVolume =
-    hydratedFormData.conditioning_checkbox === true &&
-    hydratedFormData.conditioning_volume != null &&
-    hydratedFormData.conditioning_volume > 0
-      ? hydratedFormData.conditioning_volume
+    formData.conditioning_checkbox === true &&
+    formData.conditioning_volume != null &&
+    formData.conditioning_volume > 0
+      ? formData.conditioning_volume
       : 0
 
   const commonFields = {
@@ -314,22 +307,22 @@ export const moveLiquidFormToArgs = (
     volume,
     sourceLabware: sourceLabware.id,
     destLabware: destLabware.id,
-    tipRack: tipRack,
+    tipRack,
     aspirateFlowRateUlSec:
-      hydratedFormData.aspirate_flowRate ||
+      formData.aspirate_flowRate ||
       matchingTipLiquidSpecs.defaultAspirateFlowRate.default,
     dispenseFlowRateUlSec:
-      hydratedFormData.dispense_flowRate ||
+      formData.dispense_flowRate ||
       matchingTipLiquidSpecs.defaultDispenseFlowRate.default,
     aspirateOffsetFromBottomMm:
-      hydratedFormData.aspirate_mmFromBottom || DEFAULT_MM_OFFSET_FROM_BOTTOM,
+      formData.aspirate_mmFromBottom || DEFAULT_MM_OFFSET_FROM_BOTTOM,
     dispenseOffsetFromBottomMm:
-      hydratedFormData.dispense_mmFromBottom || DEFAULT_MM_OFFSET_FROM_BOTTOM,
+      formData.dispense_mmFromBottom || DEFAULT_MM_OFFSET_FROM_BOTTOM,
     blowoutFlowRateUlSec:
-      hydratedFormData.blowout_flowRate ||
+      formData.blowout_flowRate ||
       matchingTipLiquidSpecs.defaultBlowOutFlowRate.default,
-    changeTip: hydratedFormData.changeTip,
-    preWetTip: Boolean(hydratedFormData.preWetTip),
+    changeTip: formData.changeTip,
+    preWetTip: Boolean(formData.preWetTip),
     aspirateDelay,
     dispenseDelay,
     aspirateSubmergeDelay,
@@ -346,52 +339,50 @@ export const moveLiquidFormToArgs = (
     touchTipAfterDispenseOffsetMmFromTop,
     touchTipAfterDispenseSpeed,
     touchTipAfterDispenseMmFromEdge,
-    description: hydratedFormData.stepDetails,
-    name: hydratedFormData.stepName,
+    description: formData.stepDetails,
+    name: formData.stepName,
     //  TODO(jr, 7/26/24): wire up wellNames
     dropTipLocation,
     nozzles,
     aspirateXOffset: aspirate_x_position ?? 0,
     aspirateYOffset: aspirate_y_position ?? 0,
     aspirateZOffset:
-      hydratedFormData.aspirate_mmFromBottom ?? DEFAULT_MM_OFFSET_FROM_BOTTOM,
-    aspiratePositionReference: hydratedFormData.aspirate_position_reference,
+      formData.aspirate_mmFromBottom ?? DEFAULT_MM_OFFSET_FROM_BOTTOM,
+    aspiratePositionReference: formData.aspirate_position_reference,
     dispenseXOffset: dispense_x_position ?? 0,
     dispenseYOffset: dispense_y_position ?? 0,
     dispenseZOffset:
-      hydratedFormData.dispense_mmFromBottom ?? DEFAULT_MM_OFFSET_FROM_BOTTOM,
-    dispensePositionReference: hydratedFormData.dispense_position_reference,
-    aspirateSubmergeSpeed: hydratedFormData.aspirate_submerge_speed ?? null,
-    aspirateSubmergeXOffset: hydratedFormData.aspirate_submerge_x_position ?? 0,
-    aspirateSubmergeYOffset: hydratedFormData.aspirate_submerge_y_position ?? 0,
-    aspirateSubmergeZOffset:
-      hydratedFormData.aspirate_submerge_mmFromBottom ?? 0,
+      formData.dispense_mmFromBottom ?? DEFAULT_MM_OFFSET_FROM_BOTTOM,
+    dispensePositionReference: formData.dispense_position_reference,
+    aspirateSubmergeSpeed: formData.aspirate_submerge_speed ?? null,
+    aspirateSubmergeXOffset: formData.aspirate_submerge_x_position ?? 0,
+    aspirateSubmergeYOffset: formData.aspirate_submerge_y_position ?? 0,
+    aspirateSubmergeZOffset: formData.aspirate_submerge_mmFromBottom ?? 0,
     aspirateSubmergePositionReference:
-      hydratedFormData.aspirate_submerge_position_reference,
-    aspirateRetractSpeed: hydratedFormData.aspirate_retract_speed ?? null,
-    aspirateRetractXOffset: hydratedFormData.aspirate_retract_x_position ?? 0,
-    aspirateRetractYOffset: hydratedFormData.aspirate_retract_y_position ?? 0,
-    aspirateRetractZOffset: hydratedFormData.aspirate_retract_mmFromBottom ?? 0,
+      formData.aspirate_submerge_position_reference,
+    aspirateRetractSpeed: formData.aspirate_retract_speed ?? null,
+    aspirateRetractXOffset: formData.aspirate_retract_x_position ?? 0,
+    aspirateRetractYOffset: formData.aspirate_retract_y_position ?? 0,
+    aspirateRetractZOffset: formData.aspirate_retract_mmFromBottom ?? 0,
     aspirateRetractPositionReference:
-      hydratedFormData.aspirate_retract_position_reference,
-    dispenseSubmergeSpeed: hydratedFormData.dispense_submerge_speed ?? null,
-    dispenseSubmergeXOffset: hydratedFormData.dispense_submerge_x_position ?? 0,
-    dispenseSubmergeYOffset: hydratedFormData.dispense_submerge_y_position ?? 0,
-    dispenseSubmergeZOffset:
-      hydratedFormData.dispense_submerge_mmFromBottom ?? 0,
+      formData.aspirate_retract_position_reference,
+    dispenseSubmergeSpeed: formData.dispense_submerge_speed ?? null,
+    dispenseSubmergeXOffset: formData.dispense_submerge_x_position ?? 0,
+    dispenseSubmergeYOffset: formData.dispense_submerge_y_position ?? 0,
+    dispenseSubmergeZOffset: formData.dispense_submerge_mmFromBottom ?? 0,
     dispenseSubmergePositionReference:
-      hydratedFormData.dispense_submerge_position_reference,
-    dispenseRetractSpeed: hydratedFormData.dispense_retract_speed ?? null,
-    dispenseRetractYOffset: hydratedFormData.dispense_retract_y_position ?? 0,
-    dispenseRetractZOffset: hydratedFormData.dispense_retract_mmFromBottom ?? 0,
+      formData.dispense_submerge_position_reference,
+    dispenseRetractSpeed: formData.dispense_retract_speed ?? null,
+    dispenseRetractYOffset: formData.dispense_retract_y_position ?? 0,
+    dispenseRetractZOffset: formData.dispense_retract_mmFromBottom ?? 0,
     dispenseRetractPositionReference:
-      hydratedFormData.dispense_retract_position_reference,
-    dispenseRetractXOffset: hydratedFormData.dispense_retract_x_position ?? 0,
+      formData.dispense_retract_position_reference,
+    dispenseRetractXOffset: formData.dispense_retract_x_position ?? 0,
     pushOut: pushOut_checkbox ? pushOut_volume : 0,
     liquidClass:
-      hydratedFormData.liquidClass === NONE_LIQUID_CLASS_NAME // transform "none" (needed in step form) to null
+      formData.liquidClass === NONE_LIQUID_CLASS_NAME // transform "none" (needed in step form) to null
         ? null
-        : hydratedFormData.liquidClass ?? null,
+        : formData.liquidClass ?? null,
   }
   console.assert(
     sourceWellsUnordered.length > 0,
@@ -414,7 +405,7 @@ export const moveLiquidFormToArgs = (
     'cannot distribute when destWells is null'
   )
 
-  const checkedPath = getCheckedPath(hydratedFormData, contextualState, path)
+  const checkedPath = getCheckedPath(formData, contextualState, path)
 
   switch (checkedPath) {
     case 'single': {

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/pauseFormToArgs.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/pauseFormToArgs.ts
@@ -10,15 +10,19 @@ import type {
   WaitForTemperatureArgs,
 } from '@opentrons/step-generation'
 import type { HydratedPauseFormData } from '../../../form-types'
+import type { GetCastFormData } from '../../fieldLevel'
 
 export const pauseFormToArgs = (
-  formData: HydratedPauseFormData
+  formData: GetCastFormData<HydratedPauseFormData>
 ): PauseArgs | WaitForTemperatureArgs | null => {
   const { hours, minutes, seconds } = getTimeFromForm(
     'pauseTime' in formData ? formData.pauseTime ?? null : null
   )
   const totalSeconds = (hours ?? 0) * 3600 + minutes * 60 + seconds
-  const temperature = parseFloat(formData.pauseTemperature as string)
+  // @ts-expect-error - todo(mm, 2025-10-09): Type error inherited from prior code.
+  // targetHeaterShakerTemperature seems to already be a number. Confirm that
+  // and remove this if it's safe.
+  const temperature = parseFloat(formData.pauseTemperature)
   const message = formData.pauseMessage ?? ''
 
   switch (formData.pauseAction) {

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/pauseFormToArgs.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/pauseFormToArgs.ts
@@ -13,34 +13,34 @@ import type { HydratedPauseFormData } from '../../../form-types'
 import type { GetCastFormData } from '../../fieldLevel'
 
 export const pauseFormToArgs = (
-  formData: GetCastFormData<HydratedPauseFormData>
+  castFormData: GetCastFormData<HydratedPauseFormData>
 ): PauseArgs | WaitForTemperatureArgs | null => {
   const { hours, minutes, seconds } = getTimeFromForm(
-    'pauseTime' in formData ? formData.pauseTime ?? null : null
+    'pauseTime' in castFormData ? castFormData.pauseTime ?? null : null
   )
   const totalSeconds = (hours ?? 0) * 3600 + minutes * 60 + seconds
   // @ts-expect-error - todo(mm, 2025-10-09): Type error inherited from prior code.
   // targetHeaterShakerTemperature seems to already be a number. Confirm that
   // and remove this if it's safe.
-  const temperature = parseFloat(formData.pauseTemperature)
-  const message = formData.pauseMessage ?? ''
+  const temperature = parseFloat(castFormData.pauseTemperature)
+  const message = castFormData.pauseMessage ?? ''
 
-  switch (formData.pauseAction) {
+  switch (castFormData.pauseAction) {
     case PAUSE_UNTIL_TEMP:
       return {
         commandCreatorFnName: 'waitForTemperature',
-        name: formData.stepName,
-        description: formData.stepDetails ?? '',
+        name: castFormData.stepName,
+        description: castFormData.stepDetails ?? '',
         celsius: temperature,
-        moduleId: formData.moduleId ?? '',
+        moduleId: castFormData.moduleId ?? '',
         message,
       }
 
     case PAUSE_UNTIL_TIME:
       return {
         commandCreatorFnName: 'delay',
-        name: formData.stepName,
-        description: formData.stepDetails ?? '',
+        name: castFormData.stepName,
+        description: castFormData.stepDetails ?? '',
         seconds: totalSeconds,
         message,
         meta: {
@@ -53,8 +53,8 @@ export const pauseFormToArgs = (
     case PAUSE_UNTIL_RESUME:
       return {
         commandCreatorFnName: 'delay',
-        name: formData.stepName,
-        description: formData.stepDetails ?? '',
+        name: castFormData.stepName,
+        description: castFormData.stepDetails ?? '',
         message,
         meta: {
           hours,

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/temperatureFormToArgs.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/temperatureFormToArgs.ts
@@ -3,15 +3,18 @@ import type {
   SetTemperatureArgs,
 } from '@opentrons/step-generation'
 import type { HydratedTemperatureFormData } from '../../../form-types'
+import type { GetCastFormData } from '../../fieldLevel'
 
 type TemperatureArgs = SetTemperatureArgs | DeactivateTemperatureArgs
 export const temperatureFormToArgs = (
-  hydratedFormData: HydratedTemperatureFormData
+  hydratedFormData: GetCastFormData<HydratedTemperatureFormData>
 ): TemperatureArgs => {
   const { moduleId, stepName, stepDetails } = hydratedFormData
   // cast values
   const setTemperature = hydratedFormData.setTemperature === 'true'
   // @ts-expect-error(sa, 2021-6-14): null check targetTemperature
+  // todo(mm, 2025-10-09): Pretty sure targetTemperature is actually non-nullable now,
+  // though it is a number, not a string, and so there is still a type error here.
   const targetTemperature = parseFloat(hydratedFormData.targetTemperature)
   console.assert(
     setTemperature ? !Number.isNaN(targetTemperature) : true,

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/temperatureFormToArgs.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/temperatureFormToArgs.ts
@@ -7,15 +7,15 @@ import type { GetCastFormData } from '../../fieldLevel'
 
 type TemperatureArgs = SetTemperatureArgs | DeactivateTemperatureArgs
 export const temperatureFormToArgs = (
-  hydratedFormData: GetCastFormData<HydratedTemperatureFormData>
+  formData: GetCastFormData<HydratedTemperatureFormData>
 ): TemperatureArgs => {
-  const { moduleId, stepName, stepDetails } = hydratedFormData
+  const { moduleId, stepName, stepDetails } = formData
   // cast values
-  const setTemperature = hydratedFormData.setTemperature === 'true'
+  const setTemperature = formData.setTemperature === 'true'
   // @ts-expect-error(sa, 2021-6-14): null check targetTemperature
   // todo(mm, 2025-10-09): Pretty sure targetTemperature is actually non-nullable now,
   // though it is a number, not a string, and so there is still a type error here.
-  const targetTemperature = parseFloat(hydratedFormData.targetTemperature)
+  const targetTemperature = parseFloat(formData.targetTemperature)
   console.assert(
     setTemperature ? !Number.isNaN(targetTemperature) : true,
     'temperatureFormToArgs expected (hydrated) targetTemperature to be a number when setTemperature is "true"'

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/temperatureFormToArgs.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/temperatureFormToArgs.ts
@@ -7,15 +7,15 @@ import type { GetCastFormData } from '../../fieldLevel'
 
 type TemperatureArgs = SetTemperatureArgs | DeactivateTemperatureArgs
 export const temperatureFormToArgs = (
-  formData: GetCastFormData<HydratedTemperatureFormData>
+  castFormData: GetCastFormData<HydratedTemperatureFormData>
 ): TemperatureArgs => {
-  const { moduleId, stepName, stepDetails } = formData
+  const { moduleId, stepName, stepDetails } = castFormData
   // cast values
-  const setTemperature = formData.setTemperature === 'true'
+  const setTemperature = castFormData.setTemperature === 'true'
   // @ts-expect-error(sa, 2021-6-14): null check targetTemperature
   // todo(mm, 2025-10-09): Pretty sure targetTemperature is actually non-nullable now,
   // though it is a number, not a string, and so there is still a type error here.
-  const targetTemperature = parseFloat(formData.targetTemperature)
+  const targetTemperature = parseFloat(castFormData.targetTemperature)
   console.assert(
     setTemperature ? !Number.isNaN(targetTemperature) : true,
     'temperatureFormToArgs expected (hydrated) targetTemperature to be a number when setTemperature is "true"'

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/absorbanceReaderFormToArgs.test.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/absorbanceReaderFormToArgs.test.ts
@@ -3,10 +3,11 @@ import { describe, expect, it } from 'vitest'
 import { absorbanceReaderFormToArgs } from '../absorbanceReaderFormToArgs'
 
 import type { HydratedAbsorbanceReaderFormData } from '/protocol-designer/form-types'
+import type { GetCastFormData } from '/protocol-designer/steplist/fieldLevel'
 
 describe('absorbanceReaderFormToArgs', () => {
   it('returns absorbance reader initialize command creator for single mode with reference', () => {
-    const formData: HydratedAbsorbanceReaderFormData = {
+    const formData: GetCastFormData<HydratedAbsorbanceReaderFormData> = {
       stepNumber: 1,
       absorbanceReaderFormType: 'absorbanceReaderInitialize',
       fileName: null,
@@ -34,7 +35,7 @@ describe('absorbanceReaderFormToArgs', () => {
     expect(absorbanceReaderFormToArgs(formData)).toEqual(expected)
   })
   it('returns absorbance reader initialize command creator for single mode with reference, ignorning wavelengths for i > 0', () => {
-    const formData: HydratedAbsorbanceReaderFormData = {
+    const formData: GetCastFormData<HydratedAbsorbanceReaderFormData> = {
       stepNumber: 1,
       absorbanceReaderFormType: 'absorbanceReaderInitialize',
       fileName: null,
@@ -62,7 +63,7 @@ describe('absorbanceReaderFormToArgs', () => {
     expect(absorbanceReaderFormToArgs(formData)).toEqual(expected)
   })
   it('returns absorbance reader initialize command creator for single mode without reference active', () => {
-    const formData: HydratedAbsorbanceReaderFormData = {
+    const formData: GetCastFormData<HydratedAbsorbanceReaderFormData> = {
       stepNumber: 1,
       absorbanceReaderFormType: 'absorbanceReaderInitialize',
       fileName: null,
@@ -89,7 +90,7 @@ describe('absorbanceReaderFormToArgs', () => {
     expect(absorbanceReaderFormToArgs(formData)).toEqual(expected)
   })
   it('returns absorbance reader initialize command creator for multi mode', () => {
-    const formData: HydratedAbsorbanceReaderFormData = {
+    const formData: GetCastFormData<HydratedAbsorbanceReaderFormData> = {
       stepNumber: 1,
       absorbanceReaderFormType: 'absorbanceReaderInitialize',
       fileName: null,
@@ -116,7 +117,7 @@ describe('absorbanceReaderFormToArgs', () => {
     expect(absorbanceReaderFormToArgs(formData)).toEqual(expected)
   })
   it('returns absorbance reader read command creator', () => {
-    const formData: HydratedAbsorbanceReaderFormData = {
+    const formData: GetCastFormData<HydratedAbsorbanceReaderFormData> = {
       stepNumber: 1,
       absorbanceReaderFormType: 'absorbanceReaderRead',
       fileName: 'output_path.csv',
@@ -142,7 +143,7 @@ describe('absorbanceReaderFormToArgs', () => {
     expect(absorbanceReaderFormToArgs(formData)).toEqual(expected)
   })
   it('returns absorbance reader lid command creator to open lid', () => {
-    const formData: HydratedAbsorbanceReaderFormData = {
+    const formData: GetCastFormData<HydratedAbsorbanceReaderFormData> = {
       stepNumber: 1,
       absorbanceReaderFormType: 'absorbanceReaderLid',
       fileName: null,
@@ -167,7 +168,7 @@ describe('absorbanceReaderFormToArgs', () => {
     expect(absorbanceReaderFormToArgs(formData)).toEqual(expected)
   })
   it('returns absorbance reader lid command creator to close lid', () => {
-    const formData: HydratedAbsorbanceReaderFormData = {
+    const formData: GetCastFormData<HydratedAbsorbanceReaderFormData> = {
       stepNumber: 1,
       absorbanceReaderFormType: 'absorbanceReaderLid',
       fileName: null,

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/getDelayData.test.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/getDelayData.test.ts
@@ -10,7 +10,7 @@ describe('getMoveLiquidDelayData', () => {
     }
     expect(
       getMoveLiquidDelayData({
-        formData: fields,
+        castFormData: fields,
         secondsField: 'aspirate_delay_seconds',
         checkboxField: 'aspirate_delay_checkbox',
       })
@@ -28,7 +28,7 @@ describe('getMoveLiquidDelayData', () => {
       }
       expect(
         getMoveLiquidDelayData({
-          formData: fields,
+          castFormData: fields,
           secondsField: 'aspirate_delay_seconds',
           checkboxField: 'aspirate_delay_checkbox',
         })
@@ -45,7 +45,7 @@ describe('getMoveLiquidDelayData', () => {
     }
     expect(
       getMoveLiquidDelayData({
-        formData: fields,
+        castFormData: fields,
         secondsField: 'aspirate_delay_seconds',
         checkboxField: 'aspirate_delay_checkbox',
       })
@@ -61,7 +61,7 @@ describe('getMoveLiquidDelayData', () => {
     }
     expect(
       getMoveLiquidDelayData({
-        formData: fields,
+        castFormData: fields,
         secondsField: 'aspirate_delay_seconds',
         checkboxField: 'aspirate_delay_checkbox',
       })

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/getDelayData.test.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/getDelayData.test.ts
@@ -10,7 +10,7 @@ describe('getMoveLiquidDelayData', () => {
     }
     expect(
       getMoveLiquidDelayData({
-        hydratedFormData: fields,
+        formData: fields,
         secondsField: 'aspirate_delay_seconds',
         checkboxField: 'aspirate_delay_checkbox',
       })
@@ -28,7 +28,7 @@ describe('getMoveLiquidDelayData', () => {
       }
       expect(
         getMoveLiquidDelayData({
-          hydratedFormData: fields,
+          formData: fields,
           secondsField: 'aspirate_delay_seconds',
           checkboxField: 'aspirate_delay_checkbox',
         })
@@ -45,7 +45,7 @@ describe('getMoveLiquidDelayData', () => {
     }
     expect(
       getMoveLiquidDelayData({
-        hydratedFormData: fields,
+        formData: fields,
         secondsField: 'aspirate_delay_seconds',
         checkboxField: 'aspirate_delay_checkbox',
       })
@@ -61,7 +61,7 @@ describe('getMoveLiquidDelayData', () => {
     }
     expect(
       getMoveLiquidDelayData({
-        hydratedFormData: fields,
+        formData: fields,
         secondsField: 'aspirate_delay_seconds',
         checkboxField: 'aspirate_delay_checkbox',
       })

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/heaterShakerFormToArgs.test.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/heaterShakerFormToArgs.test.ts
@@ -3,10 +3,85 @@ import { describe, expect, it } from 'vitest'
 import { heaterShakerFormToArgs } from '../heaterShakerFormToArgs'
 
 import type { HydratedHeaterShakerFormData } from '/protocol-designer/form-types'
+import type { GetCastFormData } from '/protocol-designer/steplist/fieldLevel'
 
 describe('heaterShakerFormToArgs', () => {
+  describe('with wrong (?) input types', () => {
+    // todo(mm, 2025-10-09)
+    // These are older tests. They pass input that, according to recently improved type
+    // hints, was not actually possible for prior stages to produce.
+    // We should clarify the expected input and delete these tests if it's safe to do so.
+    it('returns heater shaker command creator when temp, shaking, and timer is specified', () => {
+      const formData: GetCastFormData<HydratedHeaterShakerFormData> = {
+        stepNumber: 1,
+        stepType: 'heaterShaker',
+        id: 'id',
+        stepDetails: 'step details',
+        moduleId: 'moduleId',
+        heaterShakerSetTimer: true,
+        setHeaterShakerTemperature: true,
+        setShake: true,
+        latchOpen: false,
+        // @ts-expect-error See comment above.
+        targetHeaterShakerTemperature: '40',
+        // @ts-expect-error See comment above.
+        targetSpeed: '400',
+        heaterShakerTimer: '1:10',
+        stepName: 'heater shaker step',
+      }
+
+      const expected = {
+        commandCreatorFnName: 'heaterShaker',
+        moduleId: 'moduleId',
+        targetTemperature: 40,
+        rpm: 400,
+        latchOpen: false,
+        timerHours: 0,
+        timerMinutes: 1,
+        timerSeconds: 10,
+        name: 'heater shaker step',
+        description: 'step details',
+      }
+      expect(heaterShakerFormToArgs(formData)).toEqual(expected)
+    })
+    it('return heater shaker command creator when only temp is specified', () => {
+      const formData: GetCastFormData<HydratedHeaterShakerFormData> = {
+        stepNumber: 1,
+        stepType: 'heaterShaker',
+        id: 'id',
+        stepDetails: 'step details',
+        moduleId: 'moduleId',
+        heaterShakerSetTimer: false,
+        setHeaterShakerTemperature: true,
+        setShake: false,
+        latchOpen: false,
+        // @ts-expect-error See comment above.
+        targetHeaterShakerTemperature: '40',
+        // @ts-expect-error See comment above.
+        targetSpeed: null,
+        // @ts-expect-error See comment above.
+        heaterShakerTimer: null,
+        stepName: 'heater shaker step',
+      }
+
+      const expected = {
+        commandCreatorFnName: 'heaterShaker',
+        moduleId: 'moduleId',
+        targetTemperature: 40,
+        rpm: null,
+        latchOpen: false,
+        timerHours: null,
+        timerMinutes: null,
+        timerSeconds: null,
+        name: 'heater shaker step',
+        description: 'step details',
+      }
+      expect(heaterShakerFormToArgs(formData)).toEqual(expected)
+    })
+  })
+
   it('returns heater shaker command creator when temp, shaking, and timer is specified', () => {
-    const formData: HydratedHeaterShakerFormData = {
+    const formData: GetCastFormData<HydratedHeaterShakerFormData> = {
       stepNumber: 1,
       stepType: 'heaterShaker',
       id: 'id',
@@ -16,8 +91,8 @@ describe('heaterShakerFormToArgs', () => {
       setHeaterShakerTemperature: true,
       setShake: true,
       latchOpen: false,
-      targetHeaterShakerTemperature: '40',
-      targetSpeed: '400',
+      targetHeaterShakerTemperature: 40,
+      targetSpeed: 400,
       heaterShakerTimer: '1:10',
       stepName: 'heater shaker step',
     }
@@ -36,8 +111,9 @@ describe('heaterShakerFormToArgs', () => {
     }
     expect(heaterShakerFormToArgs(formData)).toEqual(expected)
   })
+
   it('return heater shaker command creator when only temp is specified', () => {
-    const formData: HydratedHeaterShakerFormData = {
+    const formData: GetCastFormData<HydratedHeaterShakerFormData> = {
       stepNumber: 1,
       stepType: 'heaterShaker',
       id: 'id',
@@ -47,9 +123,9 @@ describe('heaterShakerFormToArgs', () => {
       setHeaterShakerTemperature: true,
       setShake: false,
       latchOpen: false,
-      targetHeaterShakerTemperature: '40',
-      targetSpeed: null,
-      heaterShakerTimer: null,
+      targetHeaterShakerTemperature: 40,
+      targetSpeed: Number(null), // = 0. Based on what I think was the actual runtime behavior, not sure if this is actually what the input was intended to look like.
+      heaterShakerTimer: String(null), // = "null". Based on what I think was the actual runtime behavior, not sure if this is actually what the input was intended to look like.
       stepName: 'heater shaker step',
     }
 

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/mixFormToArgs.test.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/mixFormToArgs.test.ts
@@ -13,17 +13,18 @@ import { mixFormToArgs } from '../mixFormToArgs'
 
 import type { LabwareDefinition2 } from '@opentrons/shared-data'
 import type { HydratedMixFormData } from '/protocol-designer/form-types'
+import type { GetCastFormData } from '/protocol-designer/steplist/fieldLevel'
 
 vi.mock('../../../utils')
 
-let hydratedForm: HydratedMixFormData
+let castForm: GetCastFormData<HydratedMixFormData>
 const labwareDef = fixture_96_plate as LabwareDefinition2
 const labwareType = getLabwareDefURI(labwareDef)
 
 beforeEach(() => {
   vi.mocked(getOrderedWells).mockImplementation(wells => wells)
 
-  hydratedForm = {
+  castForm = {
     id: 'stepId',
     stepType: 'mix',
     stepName: 'Cool Mix Step',
@@ -65,8 +66,12 @@ beforeEach(() => {
     mix_touchTip_checkbox: false,
     mix_touchTip_mmFromTop: null,
     aspirate_delay_checkbox: false,
+    // @ts-expect-error - todo(mm, 2025-10-09): According to recently improved type hints, this should be a number.
+    // Clarify the expected input and change this to a number if it's safe.
     aspirate_delay_seconds: null,
     dispense_delay_checkbox: false,
+    // @ts-expect-error - todo(mm, 2025-10-09): According to recently improved type hints, this should be a number.
+    // Clarify the expected input and change this to a number if it's safe.
     dispense_delay_seconds: null,
   }
 })
@@ -77,7 +82,7 @@ afterEach(() => {
 
 describe('mix step form -> command creator args', () => {
   it('mixFormToArgs propagates form fields to MixStepArgs', () => {
-    const args = mixFormToArgs(hydratedForm)
+    const args = mixFormToArgs(castForm)
     expect(args).toMatchObject({
       commandCreatorFnName: 'mix',
       name: 'Cool Mix Step', // make sure name and description are present
@@ -107,11 +112,11 @@ describe('mix step form -> command creator args', () => {
   })
 
   it('mixFormToArgs calls getOrderedWells correctly', () => {
-    mixFormToArgs(hydratedForm)
+    mixFormToArgs(castForm)
 
     expect(getOrderedWells).toHaveBeenCalledTimes(1)
     expect(getOrderedWells).toHaveBeenCalledWith(
-      hydratedForm.wells,
+      castForm.wells,
       labwareDef,
       'l2r',
       't2b'
@@ -183,7 +188,7 @@ describe('mix step form -> command creator args', () => {
       it(`${checkboxField} toggles dependent fields`, () => {
         expect(
           mixFormToArgs({
-            ...hydratedForm,
+            ...castForm,
             [checkboxField]: false,
             ...formFields,
           })
@@ -191,7 +196,7 @@ describe('mix step form -> command creator args', () => {
 
         expect(
           mixFormToArgs({
-            ...hydratedForm,
+            ...castForm,
             [checkboxField]: true,
             ...formFields,
           })

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/moveLiquidFormToArgs.test.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/moveLiquidFormToArgs.test.ts
@@ -21,10 +21,8 @@ import {
 } from '../moveLiquidFormToArgs'
 
 import type { LabwareDefinition2 } from '@opentrons/shared-data'
-import type {
-  HydratedMoveLiquidFormData,
-  PathOption,
-} from '/protocol-designer/form-types'
+import type { HydratedMoveLiquidFormData } from '/protocol-designer/form-types'
+import type { GetCastFormData } from '/protocol-designer/steplist/fieldLevel'
 
 vi.mock('../../../utils')
 vi.mock('assert')
@@ -34,7 +32,7 @@ const DISPENSE_WELL = 'C3' // default dest in 96 flat for these tests
 const invariantContext = makeContext()
 
 describe('move liquid step form -> command creator args', () => {
-  let hydratedForm: HydratedMoveLiquidFormData
+  let castForm: GetCastFormData<HydratedMoveLiquidFormData>
   const sourceLabwareDef = fixture_12_trough as LabwareDefinition2
   const sourceLabwareType = getLabwareDefURI(sourceLabwareDef)
   const destLabwareDef = fixture_96_plate as LabwareDefinition2
@@ -44,7 +42,7 @@ describe('move liquid step form -> command creator args', () => {
     vi.mocked(getOrderedWells).mockImplementation(wells => wells)
 
     // the "base case" is a 1 to 1 transfer, single path
-    hydratedForm = {
+    castForm = {
       stepType: 'moveLiquid',
       stepName: 'Test Step',
       description: null,
@@ -81,9 +79,15 @@ describe('move liquid step form -> command creator args', () => {
       aspirate_touchTip_checkbox: false,
       aspirate_touchTip_mmFromTop: null,
       aspirate_mix_checkbox: false,
+      // @ts-expect-error - todo(mm, 2025-10-09): According to recently improved type
+      // hints, this can't be null. Investigate and change it if it's safe.
       aspirate_mix_volume: null,
+      // @ts-expect-error - todo(mm, 2025-10-09): According to recently improved type
+      // hints, this can't be null. Investigate and change it if it's safe.
       aspirate_mix_times: null,
       aspirate_delay_checkbox: false,
+      // @ts-expect-error - todo(mm, 2025-10-09): According to recently improved type
+      // hints, this can't be null. Investigate and change it if it's safe.
       aspirate_delay_seconds: null,
 
       dispense_labware: {
@@ -100,14 +104,22 @@ describe('move liquid step form -> command creator args', () => {
       dispense_touchTip_checkbox: false,
       dispense_touchTip_mmFromTop: null,
       dispense_mix_checkbox: false,
+      // @ts-expect-error - todo(mm, 2025-10-09): According to recently improved type
+      // hints, this can't be null. Investigate and change it if it's safe.
       dispense_mix_volume: null,
+      // @ts-expect-error - todo(mm, 2025-10-09): According to recently improved type
+      // hints, this can't be null. Investigate and change it if it's safe.
       dispense_mix_times: null,
       dispense_delay_checkbox: false,
+      // @ts-expect-error - todo(mm, 2025-10-09): According to recently improved type
+      // hints, this can't be null. Investigate and change it if it's safe.
       dispense_delay_seconds: null,
 
       aspirate_wells_grouped: false,
       preWetTip: false,
       disposalVolume_checkbox: false,
+      // @ts-expect-error - todo(mm, 2025-10-09): According to recently improved type
+      // hints, this can't be null. Investigate and change it if it's safe.
       disposalVolume_volume: null,
       disposalVolume_location: null,
       blowout_checkbox: false,
@@ -120,7 +132,7 @@ describe('move liquid step form -> command creator args', () => {
   })
 
   it('moveLiquidFormToArgs calls getOrderedWells correctly', () => {
-    moveLiquidFormToArgs(hydratedForm, invariantContext)
+    moveLiquidFormToArgs(castForm, invariantContext)
 
     expect(vi.mocked(getOrderedWells)).toHaveBeenCalledTimes(2)
     expect(vi.mocked(getOrderedWells)).toHaveBeenCalledWith(
@@ -140,7 +152,7 @@ describe('move liquid step form -> command creator args', () => {
   it('moveLiquidFormToArgs calls getOrderedWells only for aspirate when dispensing is into a waste chute', () => {
     moveLiquidFormToArgs(
       {
-        ...hydratedForm,
+        ...castForm,
         dispense_labware: {
           id: 'destLabwareId',
           name: 'wasteChute',
@@ -162,7 +174,7 @@ describe('move liquid step form -> command creator args', () => {
   })
 
   it('moveLiquid form with 1:1 single transfer translated to args', () => {
-    const result = moveLiquidFormToArgs(hydratedForm, invariantContext)
+    const result = moveLiquidFormToArgs(castForm, invariantContext)
 
     expect(result).toMatchObject({
       pipette: 'pipetteId',
@@ -279,7 +291,7 @@ describe('move liquid step form -> command creator args', () => {
         expect(
           moveLiquidFormToArgs(
             {
-              ...hydratedForm,
+              ...castForm,
 
               [checkboxField]: false,
               ...formFields,
@@ -291,7 +303,7 @@ describe('move liquid step form -> command creator args', () => {
         expect(
           moveLiquidFormToArgs(
             {
-              ...hydratedForm,
+              ...castForm,
               [checkboxField]: true,
               ...formFields,
             },
@@ -305,7 +317,7 @@ describe('move liquid step form -> command creator args', () => {
   describe('distribute: disposal volume / blowout behaviors', () => {
     const blowoutLabwareId = 'blowoutLabwareId'
     const disposalVolumeFields = {
-      path: 'multiDispense' as PathOption, // 'multiDispense' required to use `distribute` command creator
+      path: 'multiDispense' as const, // 'multiDispense' required to use `distribute` command creator
       blowout_location: blowoutLabwareId, // disposal volume uses `blowout_location` for the blowout
       disposalVolume_volume: 123,
       // NOTE: when spreading these in to hydratedForm fixture,
@@ -315,7 +327,7 @@ describe('move liquid step form -> command creator args', () => {
     it('disposal volume works when checkbox true', () => {
       const result = moveLiquidFormToArgs(
         {
-          ...hydratedForm,
+          ...castForm,
 
           ...disposalVolumeFields,
           disposalVolume_checkbox: true,
@@ -331,7 +343,7 @@ describe('move liquid step form -> command creator args', () => {
     it('blowout location works when checkbox true', () => {
       const result = moveLiquidFormToArgs(
         {
-          ...hydratedForm,
+          ...castForm,
 
           ...disposalVolumeFields,
           blowout_checkbox: true,
@@ -347,7 +359,7 @@ describe('move liquid step form -> command creator args', () => {
     it('disposal volume fields ignored when checkbox false', () => {
       const result = moveLiquidFormToArgs(
         {
-          ...hydratedForm,
+          ...castForm,
 
           ...disposalVolumeFields,
           disposalVolume_checkbox: false,
@@ -363,7 +375,7 @@ describe('move liquid step form -> command creator args', () => {
     it('disposal volume overrides blowout', () => {
       const result = moveLiquidFormToArgs(
         {
-          ...hydratedForm,
+          ...castForm,
 
           ...disposalVolumeFields,
           disposalVolume_checkbox: true,
@@ -381,7 +393,7 @@ describe('move liquid step form -> command creator args', () => {
     it('fallback to blowout when disposal volume unchecked', () => {
       const result = moveLiquidFormToArgs(
         {
-          ...hydratedForm,
+          ...castForm,
 
           ...disposalVolumeFields,
           disposalVolume_checkbox: false,
@@ -399,7 +411,7 @@ describe('move liquid step form -> command creator args', () => {
     it('should blow out into the destination when checkbox is true and blowout location is destination', () => {
       const result = moveLiquidFormToArgs(
         {
-          ...hydratedForm,
+          ...castForm,
 
           ...disposalVolumeFields,
           blowout_checkbox: true,
@@ -420,10 +432,10 @@ describe('getMixData', () => {
   it('return null if checkbox field is false', () => {
     expect(
       getMixData(
-        { checkboxField: false, volumeField: 30, timesField: 2 },
-        'checkboxField',
-        'volumeField',
-        'timesField'
+        { checkbox: false, volumeField: 30, timesField: 2 } as any,
+        'checkboxField' as any,
+        'volumeField' as any,
+        'timesField' as any
       )
     ).toBe(null)
   })
@@ -446,10 +458,10 @@ describe('getMixData', () => {
             checkboxField: true,
             volumeField: volumeValue,
             timesField: timesValue,
-          },
-          'checkboxField',
-          'volumeField',
-          'timesField'
+          } as any,
+          'checkboxField' as any,
+          'volumeField' as any,
+          'timesField' as any
         )
       ).toBe(null)
     })
@@ -458,10 +470,10 @@ describe('getMixData', () => {
   it('return volume & times if checkbox is checked', () => {
     expect(
       getMixData(
-        { checkboxField: true, volumeField: 30, timesField: 2 },
-        'checkboxField',
-        'volumeField',
-        'timesField'
+        { checkboxField: true, volumeField: 30, timesField: 2 } as any,
+        'checkboxField' as any,
+        'volumeField' as any,
+        'timesField' as any
       )
     ).toEqual({ volume: 30, times: 2 })
   })

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/pauseFormToArgs.test.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/pauseFormToArgs.test.ts
@@ -9,15 +9,45 @@ import {
 import { pauseFormToArgs } from '../pauseFormToArgs'
 
 import type { HydratedPauseFormData } from '/protocol-designer/form-types'
+import type { GetCastFormData } from '/protocol-designer/steplist/fieldLevel'
 
 describe('pauseFormToArgs', () => {
+  describe('with wrong (?) types', () => {
+    it('returns waitForTemperature command creator when form specifies pause until temp', () => {
+      // todo(mm, 2025-10-09)
+      // These are older tests. They pass input that, according to recently improved type
+      // hints, was not actually possible for prior stages to produce.
+      // We should clarify the expected input and delete these tests if it's safe to do so.
+      const formData: GetCastFormData<HydratedPauseFormData> = {
+        stepNumber: 1,
+        stepType: 'pause',
+        id: 'test_id',
+        pauseAction: PAUSE_UNTIL_TEMP,
+        // @ts-expect-error - See comment above.
+        pauseTemperature: '20',
+        pauseMessage: 'pause message',
+        moduleId: 'some_id',
+        stepName: 'pause step',
+        stepDetails: 'some details',
+      }
+      const expected = {
+        commandCreatorFnName: 'waitForTemperature',
+        celsius: 20,
+        message: 'pause message',
+        name: 'pause step',
+        description: 'some details',
+        moduleId: 'some_id',
+      }
+      expect(pauseFormToArgs(formData)).toEqual(expected)
+    })
+  })
   it('returns waitForTemperature command creator when form specifies pause until temp', () => {
-    const formData: HydratedPauseFormData = {
+    const formData: GetCastFormData<HydratedPauseFormData> = {
       stepNumber: 1,
       stepType: 'pause',
       id: 'test_id',
       pauseAction: PAUSE_UNTIL_TEMP,
-      pauseTemperature: '20',
+      pauseTemperature: 20,
       pauseMessage: 'pause message',
       moduleId: 'some_id',
       stepName: 'pause step',
@@ -34,7 +64,7 @@ describe('pauseFormToArgs', () => {
     expect(pauseFormToArgs(formData)).toEqual(expected)
   })
   it('returns delay command creator when form specifies pause until resume', () => {
-    const formData: HydratedPauseFormData = {
+    const formData: GetCastFormData<HydratedPauseFormData> = {
       stepNumber: 1,
       stepType: 'pause',
       id: 'test_id',
@@ -58,7 +88,7 @@ describe('pauseFormToArgs', () => {
   })
 
   it('returns delay command creator when form specifies pause until time', () => {
-    const formData: HydratedPauseFormData = {
+    const formData: GetCastFormData<HydratedPauseFormData> = {
       stepNumber: 1,
       stepType: 'pause',
       id: 'test_id',

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/stepFormToArgs.test.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/stepFormToArgs.test.ts
@@ -24,7 +24,7 @@ describe('form casting', () => {
       stepName: 'transfer',
       stepDetails: 'some details',
       aspirate_airGap_checkbox: false,
-      aspirate_airGap_volume: 1,
+      aspirate_airGap_volume: '1',
       aspirate_delay_checkbox: false,
       aspirate_delay_seconds: 1,
       aspirate_flowRate: 50,
@@ -54,7 +54,7 @@ describe('form casting', () => {
       dispense_wellOrder_second: 'l2r',
       dispense_wells: ['A1'],
       disposalVolume_checkbox: true,
-      disposalVolume_volume: 1,
+      disposalVolume_volume: '1',
       path: 'single',
       pipette: {} as PipetteEntity,
       preWetTip: false,
@@ -83,10 +83,8 @@ describe('form casting', () => {
     }
     expect(_castForm(input)).toEqual({
       ...input,
-      aspirate_mix_times: 0,
-      aspirate_mix_volume: 0,
-      dispense_mix_times: 0,
-      dispense_mix_volume: 0,
+      aspirate_airGap_volume: 1,
+      disposalVolume_volume: 1,
     })
   })
 

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/thermocyclerFormToArgs.test.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/thermocyclerFormToArgs.test.ts
@@ -13,17 +13,21 @@ import type {
   ThermocyclerStateStepArgs,
 } from '@opentrons/step-generation'
 import type { HydratedThermocyclerFormData } from '/protocol-designer/form-types'
+import type { GetCastFormData } from '/protocol-designer/steplist/fieldLevel'
 
 const tcModuleId = 'tcModuleId'
 
 describe('thermocyclerFormToArgs', () => {
   const testCases: Array<{
-    formData: HydratedThermocyclerFormData
+    formData: GetCastFormData<HydratedThermocyclerFormData>
     expected: ThermocyclerStateStepArgs | ThermocyclerProfileStepArgs
     testName: string
   }> = [
     {
-      testName: 'all active temps',
+      testName: 'all active temps - wrong (?) types',
+      // todo(mm, 2025-10-09): According to recently updated type hints, this input
+      // could not have been produced by earlier stages. Double-check that we don't
+      // actually need to handle this input shape, and delete this test if it's safe.
       formData: {
         ...getDefaultsForStepType('thermocycler'),
         stepType: 'thermocycler',
@@ -31,14 +35,18 @@ describe('thermocyclerFormToArgs', () => {
         moduleId: tcModuleId,
         thermocyclerFormType: THERMOCYCLER_STATE,
         blockIsActive: true,
+        // @ts-expect-error - See comment above.
         blockTargetTemp: '45',
         lidIsActive: true,
+        // @ts-expect-error - See comment above.
         lidTargetTemp: '40',
         lidOpen: false,
         blockIsActiveHold: false,
         lidIsActiveHold: false,
         lidOpenHold: false,
+        // @ts-expect-error - See comment above.
         blockTargetTempHold: null,
+        // @ts-expect-error - See comment above.
         lidTargetTempHold: null,
         orderedProfileItems: [],
         profileItemsById: {},
@@ -58,7 +66,45 @@ describe('thermocyclerFormToArgs', () => {
       },
     },
     {
-      testName: 'inactive block',
+      testName: 'all active temps',
+      formData: {
+        ...getDefaultsForStepType('thermocycler'),
+        stepType: 'thermocycler',
+        id: 'testId',
+        moduleId: tcModuleId,
+        thermocyclerFormType: THERMOCYCLER_STATE,
+        blockIsActive: true,
+        blockTargetTemp: 45,
+        lidIsActive: true,
+        lidTargetTemp: 40,
+        lidOpen: false,
+        blockIsActiveHold: false,
+        lidIsActiveHold: false,
+        lidOpenHold: false,
+        blockTargetTempHold: 0,
+        lidTargetTempHold: 0,
+        orderedProfileItems: [],
+        profileItemsById: {},
+        profileTargetLidTemp: null,
+        profileVolume: '10',
+        stepName: 'mock name',
+        stepDetails: 'mock details',
+        stepNumber: 1,
+      },
+      expected: {
+        commandCreatorFnName: THERMOCYCLER_STATE,
+
+        moduleId: tcModuleId,
+        blockTargetTemp: 45,
+        lidTargetTemp: 40,
+        lidOpen: false,
+      },
+    },
+    {
+      testName: 'inactive block - wrong (?) types',
+      // todo(mm, 2025-10-09): According to recently updated type hints, this input
+      // could not have been produced by earlier stages. Double-check that we don't
+      // actually need to handle this input shape, and delete this test if it's safe.
       formData: {
         ...getDefaultsForStepType('thermocycler'),
         stepType: 'thermocycler',
@@ -67,14 +113,18 @@ describe('thermocyclerFormToArgs', () => {
         moduleId: tcModuleId,
         thermocyclerFormType: THERMOCYCLER_STATE,
         blockIsActive: false,
+        // @ts-expect-error - See comment above.
         blockTargetTemp: '9999',
         lidIsActive: true,
+        // @ts-expect-error - See comment above.
         lidTargetTemp: '40',
         lidOpen: false,
         blockIsActiveHold: false,
         lidIsActiveHold: false,
         lidOpenHold: false,
+        // @ts-expect-error - See comment above.
         blockTargetTempHold: null,
+        // @ts-expect-error - See comment above.
         lidTargetTempHold: null,
         orderedProfileItems: [],
         profileItemsById: {},
@@ -93,7 +143,45 @@ describe('thermocyclerFormToArgs', () => {
       },
     },
     {
-      testName: 'profile with cycles',
+      testName: 'inactive block',
+      formData: {
+        ...getDefaultsForStepType('thermocycler'),
+        stepType: 'thermocycler',
+        id: 'testId',
+        stepNumber: 1,
+        moduleId: tcModuleId,
+        thermocyclerFormType: THERMOCYCLER_STATE,
+        blockIsActive: false,
+        blockTargetTemp: 9999,
+        lidIsActive: true,
+        lidTargetTemp: 40,
+        lidOpen: false,
+        blockIsActiveHold: false,
+        lidIsActiveHold: false,
+        lidOpenHold: false,
+        blockTargetTempHold: 0,
+        lidTargetTempHold: 0,
+        orderedProfileItems: [],
+        profileItemsById: {},
+        profileTargetLidTemp: null,
+        profileVolume: '10',
+        stepName: 'mock name',
+        stepDetails: 'mock details',
+      },
+      expected: {
+        commandCreatorFnName: THERMOCYCLER_STATE,
+
+        moduleId: tcModuleId,
+        blockTargetTemp: null,
+        lidTargetTemp: 40,
+        lidOpen: false,
+      },
+    },
+    {
+      testName: 'profile with cycles - wrong (?) types',
+      // todo(mm, 2025-10-09): According to recently updated type hints, this input
+      // could not have been produced by earlier stages. Double-check that we don't
+      // actually need to handle this input shape, and delete this test if it's safe.
       formData: {
         ...getDefaultsForStepType('thermocycler'),
         stepType: 'thermocycler',
@@ -102,8 +190,10 @@ describe('thermocyclerFormToArgs', () => {
         stepDetails: 'mock details',
         moduleId: tcModuleId,
         thermocyclerFormType: THERMOCYCLER_PROFILE,
+        // @ts-expect-error - See comment above.
         blockTargetTemp: '9999',
         lidIsActive: true,
+        // @ts-expect-error - See comment above.
         lidTargetTemp: '40',
         lidOpen: false,
         profileVolume: '4',
@@ -144,8 +234,14 @@ describe('thermocyclerFormToArgs', () => {
           },
         },
         blockIsActiveHold: true,
+        // @ts-expect-error - See comment above.
+        // blockTargetTemp and blockTargetTempHold can never be null according to their castValue,
+        // but that might be unintentional. thermocyclerFormToArgs() does try to handle the null case
+        // and emit null blockTargetTempHold / blockTargetTemp. We need to clarify what's intended
+        // and possibly fix these fields' castValue.
         blockTargetTempHold: null,
         lidIsActiveHold: true,
+        // @ts-expect-error - See comment above.
         lidTargetTempHold: '5',
         lidOpenHold: true,
         blockIsActive: false,
@@ -155,6 +251,121 @@ describe('thermocyclerFormToArgs', () => {
         moduleId: tcModuleId,
         description: 'mock details',
         blockTargetTempHold: null,
+        lidOpenHold: true,
+        lidTargetTempHold: 5,
+        profileSteps: [
+          // top-level step
+          { temperature: 5, holdTime: 50 },
+          // cycle rep 1
+          { temperature: 12, holdTime: 62 },
+          { temperature: 99, holdTime: 45 },
+          // cycle rep 2
+          { temperature: 12, holdTime: 62 },
+          { temperature: 99, holdTime: 45 },
+        ],
+        profileTargetLidTemp: 40,
+        profileVolume: 4,
+        meta: {
+          rawProfileItems: [
+            {
+              type: 'profileStep',
+              id: 'profileItem1',
+              title: 'Top level step',
+              temperature: '5',
+              durationMinutes: '',
+              durationSeconds: '50',
+            },
+            {
+              id: 'profileItem2',
+              type: 'profileCycle',
+              repetitions: '2',
+              steps: [
+                {
+                  type: 'profileStep',
+                  id: 'item2A',
+                  title: 'Step A in cycle',
+                  temperature: '12',
+                  durationMinutes: '1',
+                  durationSeconds: '2',
+                },
+                {
+                  type: 'profileStep',
+                  id: 'item2B',
+                  title: 'Step B in cycle',
+                  temperature: '99',
+                  durationMinutes: '',
+                  durationSeconds: '45',
+                },
+              ],
+            },
+          ],
+        },
+      },
+    },
+    {
+      testName: 'profile with cycles',
+      formData: {
+        ...getDefaultsForStepType('thermocycler'),
+        stepType: 'thermocycler',
+        id: 'testId',
+        stepName: 'mock name',
+        stepDetails: 'mock details',
+        moduleId: tcModuleId,
+        thermocyclerFormType: THERMOCYCLER_PROFILE,
+        blockTargetTemp: 9999,
+        lidIsActive: true,
+        lidTargetTemp: 40,
+        lidOpen: false,
+        profileVolume: '4',
+        profileTargetLidTemp: '40',
+        orderedProfileItems: ['profileItem1', 'profileItem2'],
+        stepNumber: 1,
+        profileItemsById: {
+          profileItem1: {
+            type: 'profileStep',
+            id: 'profileItem1',
+            title: 'Top level step',
+            temperature: '5',
+            durationMinutes: '',
+            durationSeconds: '50',
+          },
+          profileItem2: {
+            id: 'profileItem2',
+            type: 'profileCycle',
+            repetitions: '2',
+            steps: [
+              {
+                type: 'profileStep',
+                id: 'item2A',
+                title: 'Step A in cycle',
+                temperature: '12',
+                durationMinutes: '1',
+                durationSeconds: '2',
+              },
+              {
+                type: 'profileStep',
+                id: 'item2B',
+                title: 'Step B in cycle',
+                temperature: '99',
+                durationMinutes: '',
+                durationSeconds: '45',
+              },
+            ],
+          },
+        },
+        blockIsActiveHold: true,
+        blockTargetTempHold: 0,
+        lidIsActiveHold: true,
+        lidTargetTempHold: 5,
+        lidOpenHold: true,
+        blockIsActive: false,
+      },
+      expected: {
+        commandCreatorFnName: THERMOCYCLER_PROFILE,
+        moduleId: tcModuleId,
+        description: 'mock details',
+        // todo(mm, 2025-10-09): See comments above about blockTargetTemp and blockTargetTempHold nullability.
+        blockTargetTempHold: 0,
         lidOpenHold: true,
         lidTargetTempHold: 5,
         profileSteps: [

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/thermocyclerFormToArgs.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/thermocyclerFormToArgs.ts
@@ -50,9 +50,9 @@ const _flattenProfileSteps = (args: {
 }
 
 export const thermocyclerFormToArgs = (
-  formData: GetCastFormData<HydratedThermocyclerFormData>
+  castFormData: GetCastFormData<HydratedThermocyclerFormData>
 ): ThermocyclerProfileStepArgs | ThermocyclerStateStepArgs => {
-  const { thermocyclerFormType, stepDetails } = formData
+  const { thermocyclerFormType, stepDetails } = castFormData
 
   switch (thermocyclerFormType) {
     case THERMOCYCLER_STATE: {
@@ -61,26 +61,26 @@ export const thermocyclerFormToArgs = (
         // This runtime behavior of assuming it can't be nullish here is inherited from prior code.
         // Look into this.
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        moduleId: formData.moduleId!,
+        moduleId: castFormData.moduleId!,
         commandCreatorFnName: THERMOCYCLER_STATE,
         blockTargetTemp:
-          formData.blockIsActive && formData.blockTargetTemp !== null
-            ? Number(formData.blockTargetTemp)
+          castFormData.blockIsActive && castFormData.blockTargetTemp !== null
+            ? Number(castFormData.blockTargetTemp)
             : null,
         lidTargetTemp:
-          formData.lidIsActive && formData.lidTargetTemp !== null
-            ? Number(formData.lidTargetTemp)
+          castFormData.lidIsActive && castFormData.lidTargetTemp !== null
+            ? Number(castFormData.lidTargetTemp)
             : null,
         // todo(mm, 2025-10-09): Nullability error inherited from prior code. Look into this.
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        lidOpen: formData.lidOpen!,
+        lidOpen: castFormData.lidOpen!,
       }
     }
 
     case THERMOCYCLER_PROFILE: {
       const profileSteps = _flattenProfileSteps({
-        orderedProfileItems: formData.orderedProfileItems,
-        profileItemsById: formData.profileItemsById,
+        orderedProfileItems: castFormData.orderedProfileItems,
+        profileItemsById: castFormData.profileItemsById,
       })
 
       return {
@@ -88,25 +88,27 @@ export const thermocyclerFormToArgs = (
         // This runtime behavior of assuming it can't be nullish here is inherited from prior code.
         // Look into this.
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        moduleId: formData.moduleId!,
+        moduleId: castFormData.moduleId!,
         commandCreatorFnName: THERMOCYCLER_PROFILE,
         blockTargetTempHold:
-          formData.blockIsActiveHold && formData.blockTargetTempHold !== null
-            ? Number(formData.blockTargetTempHold)
+          castFormData.blockIsActiveHold &&
+          castFormData.blockTargetTempHold !== null
+            ? Number(castFormData.blockTargetTempHold)
             : null,
-        lidOpenHold: formData.lidOpenHold,
+        lidOpenHold: castFormData.lidOpenHold,
         lidTargetTempHold:
-          formData.lidIsActiveHold && formData.lidTargetTempHold !== null
-            ? Number(formData.lidTargetTempHold)
+          castFormData.lidIsActiveHold &&
+          castFormData.lidTargetTempHold !== null
+            ? Number(castFormData.lidTargetTempHold)
             : null,
         meta: {
-          rawProfileItems: formData.orderedProfileItems.map(
-            (itemId: string | number) => formData.profileItemsById[itemId]
+          rawProfileItems: castFormData.orderedProfileItems.map(
+            (itemId: string | number) => castFormData.profileItemsById[itemId]
           ),
         },
         profileSteps,
-        profileTargetLidTemp: Number(formData.profileTargetLidTemp),
-        profileVolume: Number(formData.profileVolume),
+        profileTargetLidTemp: Number(castFormData.profileTargetLidTemp),
+        profileVolume: Number(castFormData.profileVolume),
         description: stepDetails,
       }
     }

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/thermocyclerFormToArgs.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/thermocyclerFormToArgs.ts
@@ -10,6 +10,7 @@ import type {
   ProfileItem,
   ProfileStepItem,
 } from '../../../form-types'
+import type { GetCastFormData } from '../../fieldLevel'
 
 type FlatProfileSteps = ThermocyclerProfileStepArgs['profileSteps']
 
@@ -49,14 +50,18 @@ const _flattenProfileSteps = (args: {
 }
 
 export const thermocyclerFormToArgs = (
-  formData: HydratedThermocyclerFormData
-): ThermocyclerProfileStepArgs | ThermocyclerStateStepArgs | null => {
+  formData: GetCastFormData<HydratedThermocyclerFormData>
+): ThermocyclerProfileStepArgs | ThermocyclerStateStepArgs => {
   const { thermocyclerFormType, stepDetails } = formData
 
   switch (thermocyclerFormType) {
     case THERMOCYCLER_STATE: {
       return {
-        moduleId: formData.moduleId,
+        // todo(mm, 2025-10-09): form-types.ts is inconsistent about whether moduleId is nullable.
+        // This runtime behavior of assuming it can't be nullish here is inherited from prior code.
+        // Look into this.
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        moduleId: formData.moduleId!,
         commandCreatorFnName: THERMOCYCLER_STATE,
         blockTargetTemp:
           formData.blockIsActive && formData.blockTargetTemp !== null
@@ -66,7 +71,9 @@ export const thermocyclerFormToArgs = (
           formData.lidIsActive && formData.lidTargetTemp !== null
             ? Number(formData.lidTargetTemp)
             : null,
-        lidOpen: formData.lidOpen,
+        // todo(mm, 2025-10-09): Nullability error inherited from prior code. Look into this.
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        lidOpen: formData.lidOpen!,
       }
     }
 
@@ -77,7 +84,11 @@ export const thermocyclerFormToArgs = (
       })
 
       return {
-        moduleId: formData.moduleId,
+        // todo(mm, 2025-10-09): form-types.ts is inconsistent about whether moduleId is nullable.
+        // This runtime behavior of assuming it can't be nullish here is inherited from prior code.
+        // Look into this.
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        moduleId: formData.moduleId!,
         commandCreatorFnName: THERMOCYCLER_PROFILE,
         blockTargetTempHold:
           formData.blockIsActiveHold && formData.blockTargetTempHold !== null
@@ -100,7 +111,4 @@ export const thermocyclerFormToArgs = (
       }
     }
   }
-
-  // this should not happen, for Flow only
-  return null
 }

--- a/protocol-designer/src/utils/utilityTypes.ts
+++ b/protocol-designer/src/utils/utilityTypes.ts
@@ -1,0 +1,63 @@
+/** Types to operate on types. */
+
+/**
+ * Returns the keys that are mentioned by *any* element of a union.
+ *
+ * Constrast this with TypeScript's native `keyof UnionT`, which only returns the keys
+ * that are mentioned in *every* element of the union.
+ *
+ * @example
+ * type Food =
+ *   | { type: 'pizza', topping: 'shrooms' | 'pineapple' }
+ *   | { type: 'taco', topping: 'guac' | 'lime' }
+ *   | { type: 'dumpling', filling: 'meat' | 'veg' }
+ * type T = AllKeysOfUnion<Food>
+ * // T = 'type' | 'topping' | 'filling'
+ * // `keyof Food` would only return 'type'.
+ */
+// The `extends any` condition always returns true, so this always takes the `keyof UnionT` branch.
+// We need the condition because, as a side effect, it runs `keyof` on each element of the union
+// instead of on the union as a whole. See "distributive conditional types" in the TypeScript docs.
+export type AllKeysOfUnion<UnionT> = UnionT extends any ? keyof UnionT : never
+
+/**
+ * Given a key that appears in some elements of a union,
+ * return a union of all the possible value types for that key.
+ *
+ * @example
+ * type Food =
+ *   | { type: 'pizza', topping: 'shrooms' | 'pineapple' }
+ *   | { type: 'taco', topping: 'guac' | 'lime' }
+ *   | { type: 'dumpling', filling: 'meat' | 'veg' }
+ * type T = DistributivePick<'topping', Food>
+ * // T = 'shrooms' | 'pineapple' | 'guac' | 'lime'
+ */
+export type PickValuesFromUnion<
+  UnionT,
+  KeyT extends string | number | symbol
+> = UnionT extends {
+  [Key in KeyT]?: unknown
+}
+  ? UnionT[KeyT]
+  : never
+
+/**
+ * Combines a union of objects into a single object.
+ *
+ * It's easiest to explain what this means through an example:
+ *
+ * @example
+ * type Food =
+ *   | { type: 'pizza', topping: 'shrooms' | 'pineapple' }
+ *   | { type: 'taco', topping: 'guac' | 'lime' }
+ *   | { type: 'dumpling', filling: 'meat' | 'veg' }
+ * type T = SmooshUnion<Food>
+ * // T = {
+ * //   type: 'pizza' | 'taco' | 'dumpling'
+ * //   topping: 'shrooms' | 'pineapple' | 'guac' | 'lime'
+ * //   filling: 'meat' | 'veg'
+ * // }
+ */
+export type AmalgamateUnion<UnionT> = {
+  [Key in AllKeysOfUnion<UnionT>]: PickValuesFromUnion<UnionT, Key>
+}


### PR DESCRIPTION
## Overview

This is a batch of improvements to `protocol-designer`'s type checking.

## Test Plan and Hands on Testing

CI should be sufficient. See the risk assessment.

## Details

### Background

`protocol-designer` operates on a list of step forms. The step forms are populated with user input, and then they move through a long pipeline of transformations. Finally, they're fed to `step-generation`, which builds the protocol out of them. The pipeline looks like this:

```mermaid
flowchart TD
    user_input(["User input"]) --maskValue()--> FormData--hydrate()--> HydratedFormData --castValue()--> CastFormData["'Cast form data'"] --"moveLiquidFormToArgs(), etc."--> StepArgs --> step_generation([step-generation])
```

`FormData` is what most of the `protocol-designer` UI consumes, as far as I can tell. `HydratedFormData` is used for...something, I dunno. "Cast form data" (my term; there is no specific type for this in the code) is the input to functions like `moveLiquidFormToArgs()`. Finally, those functions output something that can be fed to step-generation.

[`stepFieldHelperMap`](https://github.com/Opentrons/opentrons/blob/6208bf5f59d8319d9ca8a7f8487453ec7676d81f/protocol-designer/src/steplist/fieldLevel/index.ts#L163-L419) is the central description of this pipeline.

### The problem, and what this PR changes

Historically, none of this was type-checked. We've been making improvements, e.g. PR #17308.

The specific area addressed by this PR is the bottom half of the pipeline.

Currently, [according to the type annotations](https://github.com/Opentrons/opentrons/blob/6208bf5f59d8319d9ca8a7f8487453ec7676d81f/protocol-designer/src/steplist/formLevel/stepFormToArgs/index.ts#L40-L53), `moveLiquidFormToArgs()` and friends operate directly on `HydratedFormData`. This isn't really true. As shown in the pipeline above, they really operate on `HydratedFormData` *after it's been transformed by `castValue()`.* For at least a few fields, this is a meaningful difference, like `string` vs. `number`. `HydratedFormData` cannot represent both at once. So our types have either been wrong for one half or the other.

## What this PR changes

* Get TypeScript to automatically compute how a `HydratedFormData` changes when its fields are passed through `castValue()`. This entails some trickery.
* Switch `moveLiquidFormToArgs()` and its brethren to use those new, automatically-computed types.
* With `HydratedFormData` now freed up to tell the truth for just its part of the pipeline, correct a few specific fields that I'm confident were off. I suspect we'll find more later, but so far, it's:

  * `aspirate_airGap_volume`: was `number`, should be `string`
  * `dispense_airGap_volume`: was `number`, should be `string`
  * `disposalVolume_volume`: was `number`, should be `string`

  To see that these new types are correct, you can either:

  * Add a `console.log()` somewhere like the very top of `stepFormToArgs()`.
  * Or look at these fields in the Redux devtools. They will probably be in a `FormData` at that point, not `HydratedFormData`. However, observe that these fields have no `hydrate()` function specified, so their types in `HydratedFormData` ought to match `FormData`.

## Review requests

* Does this fundamentally make sense?
* This shakes out several little type errors that we ought to look into. e.g. it looks like `thermocyclerFormToArgs()` [tries to preserve the nullishness of some of its args](https://github.com/Opentrons/opentrons/blob/6208bf5f59d8319d9ca8a7f8487453ec7676d81f/protocol-designer/src/steplist/formLevel/stepFormToArgs/thermocyclerFormToArgs.ts#L88), but [`null` is casted out before it gets that far](https://github.com/Opentrons/opentrons/blob/6208bf5f59d8319d9ca8a7f8487453ec7676d81f/protocol-designer/src/steplist/fieldLevel/index.ts#L351), which smells like a bug.

  Take a look through the todo comments and see what alarms you.

## Risk assessment

Functionally, low. Changes are 99% just type annotations, and the other 1% is trivial.

