### PR TITLE
fix(protocol-designer): filter labware for lid not all labwares for s…

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/AddStepButton.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/AddStepButton.tsx
@@ -111,9 +111,7 @@ export function AddStepButton({
   ).some(([labwareId, { stack }]) => {
     const labwareDef = labwareEntities[labwareId]?.def
     const slot = getSlotInLocationStack(stack)
-    const isLidOnSlot = Object.values(labwareEntities).some(({ def }) =>
-      getIsLid(def)
-    )
+    const isLidOnSlot = labwareDef != null ? getIsLid(labwareDef) : false
     return (
       labwareDef != null &&
       slot !== OFFDECK &&


### PR DESCRIPTION
…ome lid

closes RQA-4720

# Overview

Before we were checking if any of the labware had a lid and then filtering out the labware. but not we were checking if the labware itself has a lid and then filtering out only that labware

## Test Plan and Hands on Testing

Import protocol attached and see that the transfer/mix steps are visible. then delete the well plate and the 1 well reservoir and the transfer/mix steps should not be visible

[RQA4720.py](https://github.com/user-attachments/files/22852342/RQA4720.py)

## Changelog

make the logic check for only the labware def itself

## Risk assessment

loq