### PR TITLE
feat(app): filter out loadCommands and home to the PV run log

### DIFF
--- a/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/index.tsx
@@ -83,6 +83,12 @@ export function AnnotatedSteps(props: AnnotatedStepsProps): JSX.Element {
 
   let commandNumber = 0
 
+  // temporarily filter out loadCommands and home commands for the PV MVP
+  const filteredCommands = analysis.commands.filter(
+    command =>
+      !command.commandType.includes('load') && command.commandType !== 'home'
+  )
+
   return (
     <div className={styles.annotated_steps_container}>
       <div className={styles.annotated_steps_wrap}>
@@ -130,7 +136,7 @@ export function AnnotatedSteps(props: AnnotatedStepsProps): JSX.Element {
                 )
               }
             })
-          : analysis.commands.map((command, index) => {
+          : filteredCommands.map((command, index) => {
               const currentCommandNumber = ++commandNumber
 
               return (


### PR DESCRIPTION
closes AUTH-2279

# Overview

filter out the `load-` and `home` commands from the protocol viz run log.

## Test Plan and Hands on Testing

test with a flex protocol and see that the load commands and home are not there. the percent complete will be fixed in a follow up pr

## Changelog

filter the commands in the run log

## Risk assessment

low