### PR TITLE
feat(app): add step numbering and percentage

### DIFF
--- a/app/src/assets/localization/en/protocol_visualization.json
+++ b/app/src/assets/localization/en/protocol_visualization.json
@@ -3,5 +3,6 @@
   "left_right_mount": "LEFT + RIGHT MOUNT",
   "none_attached": "None attached",
   "pipette": "Pipette",
-  "right_mount": "RIGHT MOUNT"
+  "right_mount": "RIGHT MOUNT",
+  "step": "Step {{number}}"
 }

--- a/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/index.tsx
@@ -83,6 +83,12 @@ export function AnnotatedSteps(props: AnnotatedStepsProps): JSX.Element {
 
   let commandNumber = 0
 
+  // temporarily filter out loadCommands and home commands for the PV MVP
+  const filteredCommands = analysis.commands.filter(
+    command =>
+      !command.commandType.includes('load') && command.commandType !== 'home'
+  )
+
   return (
     <div className={styles.annotated_steps_container}>
       <div className={styles.annotated_steps_wrap}>
@@ -130,7 +136,7 @@ export function AnnotatedSteps(props: AnnotatedStepsProps): JSX.Element {
                 )
               }
             })
-          : analysis.commands.map((command, index) => {
+          : filteredCommands.map((command, index) => {
               const currentCommandNumber = ++commandNumber
 
               return (

--- a/app/src/pages/Desktop/Protocols/ProtocolVisualization/DeckView.tsx
+++ b/app/src/pages/Desktop/Protocols/ProtocolVisualization/DeckView.tsx
@@ -1,7 +1,9 @@
 import { Fragment, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 
 import {
   COLORS,
+  Flex,
   FlexTrash,
   RobotCoordinateSpaceWithRef,
   SingleSlotFixture,
@@ -79,6 +81,7 @@ export function DeckView(props: DeckViewProps): JSX.Element {
     liquids,
     commands,
   } = props
+  const { t } = useTranslation('protocol_visualization')
   const [hoveredSlot, setHoveredSlot] = useState<string | null>(null)
   const deckDef = useMemo(() => getDeckDefFromRobotType(robotType), [robotType])
   const {
@@ -120,10 +123,20 @@ export function DeckView(props: DeckViewProps): JSX.Element {
     aa => isAddressableAreaStandardSlot(aa.id, deckDef)
   )
 
+  const selectedCommandIndex =
+    selectedRunTimeCommand != null
+      ? commands.findIndex(command => command.id === selectedRunTimeCommand.id)
+      : 0
+
   return (
     <div className={styles.deck_view_padding}>
       <div className={styles.deck_view_container}>
-        <StyledText desktopStyle="bodyLargeSemiBold">Deck View</StyledText>
+        <Flex justifyContent="space-between" with="100%">
+          <StyledText desktopStyle="bodyLargeSemiBold">Deck View</StyledText>
+          <StyledText color={COLORS.grey60} desktopStyle="bodyDefaultRegular">
+            {t('step', { number: selectedCommandIndex })}
+          </StyledText>
+        </Flex>
         <RobotCoordinateSpaceWithRef
           height="100%"
           width="100%"

--- a/app/src/pages/Desktop/Protocols/ProtocolVisualization/VisualizerContainer.tsx
+++ b/app/src/pages/Desktop/Protocols/ProtocolVisualization/VisualizerContainer.tsx
@@ -78,7 +78,7 @@ export function VisualizerContainer(
   const selectedCommandIndex = commands.findIndex(
     command => command.id === selectedCommandId
   )
-  const selectedCommandIndexFiltered = filteredCommands.findIndex(
+  const filteredSelectedCommandIndex = filteredCommands.findIndex(
     command => command.id === selectedCommandId
   )
 
@@ -129,8 +129,8 @@ export function VisualizerContainer(
     analysis
   )
   const percentComplete =
-    selectedCommandIndexFiltered != null
-      ? (selectedCommandIndexFiltered / filteredCommands.length) * 100
+    filteredSelectedCommandIndex != null
+      ? (filteredSelectedCommandIndex / filteredCommands.length) * 100
       : 0
 
   const thermocyclerSlots = ['A1', '8', '10', '11']
@@ -265,7 +265,7 @@ export function VisualizerContainer(
           protocolName={protocolDisplayName}
           numErrors={analysis.errors.length}
           numCommandLength={filteredCommands.length}
-          currentCommandIndex={selectedCommandIndexFiltered}
+          currentCommandIndex={filteredSelectedCommandIndex}
           setSelectedCommand={setSelectedCommand}
           handlePlayPause={handlePlayPause}
           isPlaying={isPlaying}

--- a/app/src/pages/Desktop/Protocols/ProtocolVisualization/VisualizerContainer.tsx
+++ b/app/src/pages/Desktop/Protocols/ProtocolVisualization/VisualizerContainer.tsx
@@ -69,7 +69,16 @@ export function VisualizerContainer(
     rightWidthRef.current = rightWidth
   }, [rightWidth])
 
+  // temporarily filter out loadCommands and home commands for the PV MVP
+  const filteredCommands = commands.filter(
+    command =>
+      !command.commandType.includes('load') && command.commandType !== 'home'
+  )
+
   const selectedCommandIndex = commands.findIndex(
+    command => command.id === selectedCommandId
+  )
+  const selectedCommandIndexFiltered = filteredCommands.findIndex(
     command => command.id === selectedCommandId
   )
 
@@ -119,10 +128,9 @@ export function VisualizerContainer(
     srcFileNames,
     analysis
   )
-  const commandLength = analysis.commands.length
   const percentComplete =
-    selectedCommandIndex != null
-      ? (selectedCommandIndex / commandLength) * 100
+    selectedCommandIndexFiltered != null
+      ? (selectedCommandIndexFiltered / filteredCommands.length) * 100
       : 0
 
   const thermocyclerSlots = ['A1', '8', '10', '11']
@@ -256,12 +264,12 @@ export function VisualizerContainer(
         <Controls
           protocolName={protocolDisplayName}
           numErrors={analysis.errors.length}
-          numCommandLength={commands.length}
-          currentCommandIndex={selectedCommandIndex}
+          numCommandLength={filteredCommands.length}
+          currentCommandIndex={selectedCommandIndexFiltered}
           setSelectedCommand={setSelectedCommand}
           handlePlayPause={handlePlayPause}
           isPlaying={isPlaying}
-          commands={commands}
+          commands={filteredCommands}
           groupedCommands={groupedCommands}
           setShowDeckRenders={setShowDeckRenders}
           showDeckRenders={showDeckRenders}


### PR DESCRIPTION
closes AUTH-2282 AUTH-2289

# Overview

merge this pr in first: https://github.com/Opentrons/opentrons/pull/19779 since i built off of that commit here.

This pr adds both the step number based off of the full commands (including load commands) and the percentage based off of the filtered commands (not including load commands)

## Test Plan and Hands on Testing

test with any flex protocol and see the percentage and step on

## Changelog

change the step numbering and percentage depending on the step you are on in the protocol

## Risk assessment

low
