### PR TITLE
fix(protocol-designer): show stacking icon all the time on deck

### DIFF
--- a/components/src/organisms/DeckLabelSet/index.tsx
+++ b/components/src/organisms/DeckLabelSet/index.tsx
@@ -20,6 +20,7 @@ interface DeckLabelSetProps {
   height: number
   invert?: boolean
   showModuleIcon?: boolean
+  showBorder?: boolean
 }
 
 const DeckLabelSetComponent = (
@@ -34,6 +35,7 @@ const DeckLabelSetComponent = (
     height,
     invert = false,
     showModuleIcon = false,
+    showBorder = true,
   } = props
 
   return (
@@ -50,6 +52,7 @@ const DeckLabelSetComponent = (
           height={height}
           isZoomed={deckLabels.length > 0 ? deckLabels[0].isZoomed : true}
           data-testid="DeckLabeSet"
+          showBorder={showBorder}
         />
         {showModuleIcon && (
           <IconWrapper leftPosition={width - 16}>
@@ -83,12 +86,17 @@ export const DeckLabelSet = forwardRef<HTMLDivElement, DeckLabelSetProps>(
 
 interface StyledBoxProps {
   isZoomed: boolean
+  showBorder: boolean
 }
 
 const StyledBox = styled(Box)<StyledBoxProps>`
   border-radius: ${BORDERS.borderRadius4};
-  border: ${({ isZoomed }) =>
-    isZoomed ? `1.5px solid ${COLORS.blue50}` : `3px solid ${COLORS.blue50}`};
+  border: ${({ isZoomed, showBorder }) =>
+    !showBorder
+      ? 'none'
+      : isZoomed
+      ? `1.5px solid ${COLORS.blue50}`
+      : `3px solid ${COLORS.blue50}`};
 `
 
 const LabelContainer = styled.div`

--- a/components/src/organisms/DeckLabelSet/index.tsx
+++ b/components/src/organisms/DeckLabelSet/index.tsx
@@ -91,12 +91,13 @@ interface StyledBoxProps {
 
 const StyledBox = styled(Box)<StyledBoxProps>`
   border-radius: ${BORDERS.borderRadius4};
-  border: ${({ isZoomed, showBorder }) =>
-    !showBorder
-      ? 'none'
-      : isZoomed
-      ? `1.5px solid ${COLORS.blue50}`
-      : `3px solid ${COLORS.blue50}`};
+  border: ${({ isZoomed, showBorder }) => {
+    if (!showBorder) {
+      return 'none'
+    }
+    const width = isZoomed ? '1.5px' : '3px'
+    return `${width} solid ${COLORS.blue50}`
+  }};
 `
 
 const LabelContainer = styled.div`

--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupDetails.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupDetails.tsx
@@ -475,7 +475,7 @@ export function DeckSetupDetails(props: DeckSetupDetailsProps): JSX.Element {
                 y={slotPosition[1]}
                 width={labware.def.dimensions.xDimension}
                 height={labware.def.dimensions.yDimension}
-                showModuleIcon={true}
+                showModuleIcon
                 showBorder={false}
               />
             ) : null}

--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupDetails.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupDetails.tsx
@@ -2,7 +2,7 @@ import { Fragment, useCallback, useEffect, useMemo, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import values from 'lodash/values'
 
-import { Module } from '@opentrons/components'
+import { DeckLabelSet, Module } from '@opentrons/components'
 import {
   getAddressableAreaFromSlotId,
   getModuleDef,
@@ -447,6 +447,10 @@ export function DeckSetupDetails(props: DeckSetupDetailsProps): JSX.Element {
           return null
         }
         const slot = getSlotInLocationStack(labware.stack)
+        const labwareAmount = labware.stack.reduce(
+          (amount, item) => amount + (activeDeckSetup.labware[item] ? 1 : 0),
+          0
+        )
         const slotPosition = getPositionFromSlotId(slot, deckDef)
         const slotBoundingBox = getAddressableAreaFromSlotId(slot, deckDef)
           ?.boundingBox
@@ -464,6 +468,17 @@ export function DeckSetupDetails(props: DeckSetupDetailsProps): JSX.Element {
               y={slotPosition[1]}
               labwareOnDeck={labware}
             />
+            {labwareAmount > 1 ? (
+              <DeckLabelSet
+                deckLabels={[]}
+                x={slotPosition[0]}
+                y={slotPosition[1]}
+                width={labware.def.dimensions.xDimension}
+                height={labware.def.dimensions.yDimension}
+                showModuleIcon={true}
+                showBorder={false}
+              />
+            ) : null}
             <HighlightLabware
               labwareOnDeck={labware}
               position={slotPosition}


### PR DESCRIPTION
closes RQA-4746

# Overview

Show the deck map stacking icon at all times when you have a stack on the deck, not only when you are interacting with the labware in the stack

## Test Plan and Hands on Testing

See that the deck stack label shows up at all times on the lid stack
[untitled (57).py](https://github.com/user-attachments/files/22890413/untitled.57.py)

## Changelog

modify to add the ability to not show the border in the deck label set component
show the stacking icon at all times on the deckmap

## Risk assessment

low
