### PR TITLE
fix(step-generation, components): update timeline error copy & alert …

### DIFF
--- a/components/src/molecules/Banner/index.tsx
+++ b/components/src/molecules/Banner/index.tsx
@@ -50,12 +50,12 @@ const BANNER_PROPS_BY_TYPE: Record<
     color: COLORS.green60,
   },
   error: {
-    icon: { name: 'ot-circle' },
+    icon: { name: 'ot-alert' },
     backgroundColor: COLORS.red30,
     color: COLORS.red60,
   },
   warning: {
-    icon: { name: 'ot-circle' },
+    icon: { name: 'ot-alert' },
     backgroundColor: COLORS.yellow30,
     color: COLORS.yellow60,
   },

--- a/components/src/molecules/Banner/index.tsx
+++ b/components/src/molecules/Banner/index.tsx
@@ -50,12 +50,12 @@ const BANNER_PROPS_BY_TYPE: Record<
     color: COLORS.green60,
   },
   error: {
-    icon: { name: 'alert-circle' },
+    icon: { name: 'ot-circle' },
     backgroundColor: COLORS.red30,
     color: COLORS.red60,
   },
   warning: {
-    icon: { name: 'alert-circle' },
+    icon: { name: 'ot-circle' },
     backgroundColor: COLORS.yellow30,
     color: COLORS.yellow60,
   },

--- a/step-generation/src/errorCreators.ts
+++ b/step-generation/src/errorCreators.ts
@@ -343,7 +343,7 @@ export const closingThermocyclerWithInvalidLid = (args: {
 }): CommandCreatorError => {
   return {
     type: 'CLOSING_THERMOCYCLER_WITH_INVALID_LABWARE_LID',
-    message: `Cannot close thermocycler lid with ${args.lidDisplayName}`,
+    message: `Closing the Thermocycler lid with ${args.lidDisplayName} in place will cause damage`,
   }
 }
 


### PR DESCRIPTION
…icon

closes RQA-4741

# Overview

update banner icon to match the ticket and update the timeline error copy

## Test Plan and Hands on Testing

See that the timeline error for thermocycler lid closing with a lid that is incompatible has correct title copy and icon

## Changelog

update icon
update copy

## Risk assessment

low
