### PR TITLE
fix(api): p200_96 now correctly identifies as a 96 channel

### DIFF
--- a/api/src/opentrons/protocol_api/robot_context.py
+++ b/api/src/opentrons/protocol_api/robot_context.py
@@ -15,7 +15,6 @@ from opentrons.legacy_commands import publisher
 from opentrons.hardware_control import SyncHardwareAPI
 from opentrons.protocols.api_support.util import requires_version
 from opentrons.protocols.api_support.types import APIVersion
-from opentrons_shared_data.pipette.types import PipetteNameType
 
 from . import validation
 from .core.common import ProtocolCore, RobotCore

--- a/api/src/opentrons/protocol_api/robot_context.py
+++ b/api/src/opentrons/protocol_api/robot_context.py
@@ -125,7 +125,7 @@ class RobotContext(publisher.CommandPublisher):
 
         """
         instrument_on_left = self._core.get_pipette_type_from_engine(Mount.LEFT)
-        is_96_channel = instrument_on_left == PipetteNameType.P1000_96
+        is_96_channel = validation.is_pipette_96_channel(instrument_on_left)
         axis_map = validation.ensure_axis_map_type(
             axis_map, self._protocol_core.robot_type, is_96_channel
         )
@@ -162,7 +162,7 @@ class RobotContext(publisher.CommandPublisher):
         :param float speed: The maximum speed with which to move all axes in mm/s.
         """
         instrument_on_left = self._core.get_pipette_type_from_engine(Mount.LEFT)
-        is_96_channel = instrument_on_left == PipetteNameType.P1000_96
+        is_96_channel = validation.is_pipette_96_channel(instrument_on_left)
 
         axis_map = validation.ensure_axis_map_type(
             axis_map, self._protocol_core.robot_type, is_96_channel
@@ -313,7 +313,7 @@ class RobotContext(publisher.CommandPublisher):
 
         """
         instrument_on_left = self._core.get_pipette_type_from_engine(Mount.LEFT)
-        is_96_channel = instrument_on_left == PipetteNameType.P1000_96
+        is_96_channel = validation.is_pipette_96_channel(instrument_on_left)
 
         return validation.ensure_axis_map_type(
             axis_map, self._protocol_core.robot_type, is_96_channel

--- a/api/src/opentrons/protocol_api/validation.py
+++ b/api/src/opentrons/protocol_api/validation.py
@@ -99,11 +99,16 @@ class InvalidFixtureLocationError(ValueError):
     """An error raised when attempting to load a fixture in an invalid cutout."""
 
 
+def is_pipette_96_channel(pipette: PipetteNameType) -> bool:
+    """Return if this pipette type is a 96 channel."""
+    return pipette in [PipetteNameType.P1000_96, PipetteNameType.P200_96]
+
+
 def ensure_mount_for_pipette(
     mount: Union[str, Mount, None], pipette: PipetteNameType
 ) -> Mount:
     """Ensure that an input value represents a valid mount, and is valid for the given pipette."""
-    if pipette in [PipetteNameType.P1000_96, PipetteNameType.P200_96]:
+    if is_pipette_96_channel(pipette):
         # Always validate the raw mount input, even if the pipette is a 96-channel and we're not going
         # to use the mount value.
         if mount is not None:

--- a/api/src/opentrons/protocol_api/validation.py
+++ b/api/src/opentrons/protocol_api/validation.py
@@ -99,9 +99,11 @@ class InvalidFixtureLocationError(ValueError):
     """An error raised when attempting to load a fixture in an invalid cutout."""
 
 
-def is_pipette_96_channel(pipette: PipetteNameType) -> bool:
+def is_pipette_96_channel(pipette: Optional[PipetteNameType]) -> bool:
     """Return if this pipette type is a 96 channel."""
-    return pipette in [PipetteNameType.P1000_96, PipetteNameType.P200_96]
+    if pipette is not None:
+        return pipette in [PipetteNameType.P1000_96, PipetteNameType.P200_96]
+    return False
 
 
 def ensure_mount_for_pipette(

--- a/api/tests/opentrons/protocol_api/test_validation.py
+++ b/api/tests/opentrons/protocol_api/test_validation.py
@@ -913,3 +913,9 @@ def test_ensure_valid_trash_location_for_transfer_v2_raises(decoy: Decoy) -> Non
         subject.ensure_valid_trash_location_for_transfer_v2(
             Location(point=Point(x=1, y=1, z=1), labware=None)
         )
+
+
+def test_is_96_channel() -> None:
+    """Iterate through the pipette names and make sure that validation identifies 96 channels."""
+    for name in PipetteNameType:
+        assert subject.is_pipette_96_channel(name) == ("96" in name.value)


### PR DESCRIPTION
# Overview
Robot context was incorrectly kicking back that the p200_96 was not a 96 channel when someone tried to use it for resin tips.

This just centeralizes the test into validation and adds a test that iterates through all the pipette names to make sure everything is working properly now.