### PR TITLE
fix(protocol-designer): Sentry: ignore `Non-Error promise rejection` error

### DIFF
--- a/protocol-designer/src/resources/sentry.ts
+++ b/protocol-designer/src/resources/sentry.ts
@@ -49,7 +49,13 @@ export const initializeSentry = (state: BaseState): void => {
         ],
         replaysSessionSampleRate: 0.0, // No Session Replay
         replaysOnErrorSampleRate: 0.0, // No Session Replay
-        ignoreErrors: [/Failed to fetch/i], // Ignore the fetch since PD doesn't use fetch
+        ignoreErrors: [
+          // Ignore the fetch since PD doesn't use fetch
+          /Failed to fetch/i,
+          // Most likely triggered by MS Defender trying to run PD. Nothing we can do but ignore it:
+          // https://github.com/getsentry/sentry-javascript/issues/3440
+          'Non-Error promise rejection captured with value: Object Not Found Matching Id:',
+        ],
       })
       isSentryInitialized = true
       console.log('Sentry.init done')


### PR DESCRIPTION
# Overview

We're getting like 100 Sentry reports per day of `UnhandledRejection: Non-Error promise rejection captured with value: Object Not Found Matching Id:..., MethodName:update, ParamCount:...`
https://opentrons-76.sentry.io/issues/6805881397/?project=4509363266387968

This seems to be caused by the Microsoft Defender "Safe Links" feature that tries to run PD in a simulated browser environment to scan for malware, especially when someone mentions the PD URL in a message in Outlook. This is a widely reported issue by Sentry users, and there's nothing we can do about it besides just ignoring the error:
- https://github.com/getsentry/sentry-javascript/issues/3440
- https://forum.sentry.io/t/unhandledrejection-non-error-promise-rejection-captured-with-value/14062

## Test Plan and Hands on Testing

Ran PD locally.
Will run CI tests.

## Risk assessment

Low.