### PR TITLE
fix(protocol-designer): fix export button z-index issue

### DIFF
--- a/protocol-designer/src/components/organisms/SlotDetailModal/index.tsx
+++ b/protocol-designer/src/components/organisms/SlotDetailModal/index.tsx
@@ -107,6 +107,7 @@ export const SlotDetailModal = (
 
   return createPortal(
     <Modal
+      zIndexOverlay={1001}
       title={modalTitle}
       hasHeader
       onClose={closeModal}

--- a/protocol-designer/src/components/organisms/SlotDetailModal/index.tsx
+++ b/protocol-designer/src/components/organisms/SlotDetailModal/index.tsx
@@ -107,6 +107,7 @@ export const SlotDetailModal = (
 
   return createPortal(
     <Modal
+      // this z-index should be a temporary fix for 8.6.0
       zIndexOverlay={1001}
       title={modalTitle}
       hasHeader


### PR DESCRIPTION
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This is not an ideal fix but we would need to this because the better solution will need time to implement and comprehensive frontend architecture.

<img width="2185" height="964" alt="Screenshot 2025-10-13 at 5 32 27 PM" src="https://github.com/user-attachments/assets/3647931d-4b67-40c7-a6a5-1c56d3d7b6b3" />
<img width="2183" height="962" alt="Screenshot 2025-10-13 at 5 32 38 PM" src="https://github.com/user-attachments/assets/01ca97ee-120c-454a-a76f-f34e1d8fcb21" />


the followings are potential solutions
1. prop drilling (the modal to ProtocolSteps)
this is really ugly and need meaningless changes in tests

2. use useContext  
useContext in PD is for snackbar.
If we go with this, we will need a good design to avoid a nested provider structure like `app`

3. use Redux

close RQA-4750
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing

<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog

<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
