### PR TITLE
feat(app): enable visualizing ot-2 protocols

### DIFF
--- a/app/src/pages/Desktop/Protocols/ProtocolVisualization/DeckView.tsx
+++ b/app/src/pages/Desktop/Protocols/ProtocolVisualization/DeckView.tsx
@@ -3,6 +3,8 @@ import { useTranslation } from 'react-i18next'
 
 import {
   COLORS,
+  DeckFromLayers,
+  FixedTrashText,
   Flex,
   FlexTrash,
   RobotCoordinateSpaceWithRef,
@@ -17,6 +19,7 @@ import {
   getCutoutIdForAddressableArea,
   getDeckDefFromRobotType,
   isAddressableAreaStandardSlot,
+  OT2_ROBOT_TYPE,
   WASTE_CHUTE_CUTOUT,
 } from '@opentrons/shared-data'
 import { getSlotInLocationStack } from '@opentrons/step-generation'
@@ -52,6 +55,16 @@ const POTENTIAL_TRASH_COMMAND_TYPES = [
   'blowOutInPlace',
   'blowOut',
   'airGap',
+]
+const OT2_STANDARD_DECK_VIEW_LAYER_BLOCK_LIST: string[] = [
+  'calibrationMarkings',
+  'fixedBase',
+  'doorStops',
+  'metalFrame',
+  'removalHandle',
+  'removableDeckOutline',
+  'screwHoles',
+  'fixedTrash',
 ]
 
 interface DeckViewProps {
@@ -145,126 +158,138 @@ export function DeckView(props: DeckViewProps): JSX.Element {
         >
           {() => (
             <>
-              {filteredAddressableAreas.map(addressableArea => {
-                const cutoutId = getCutoutIdForAddressableArea(
-                  addressableArea.id,
-                  deckDef.cutoutFixtures
-                )
-                const labwareOnSlot = Object.entries(labware).find(
-                  ([_, lw]) =>
-                    getSlotInLocationStack(lw.stack) === addressableArea.id
-                )
-                const { isActiveLayerVisible } =
-                  labwareOnSlot != null
-                    ? getActiveLayer(
-                        Object.values(pipettes),
-                        labwareOnSlot[0],
-                        selectedRunTimeCommand
-                      )
-                    : { isActiveLayerVisible: false }
-                let fixtureBaseColor = lightFill
-                if (showDeckRenders) {
-                  if (isActiveLayerVisible) {
-                    fixtureBaseColor = COLORS.purple30
-                  } else if (
-                    !isActiveLayerVisible &&
-                    selectedSlot === addressableArea.id
-                  ) {
-                    fixtureBaseColor = COLORS.grey40
-                  }
-                }
-                return cutoutId != null ? (
-                  <SingleSlotFixture
-                    key={addressableArea.id}
-                    cutoutId={cutoutId}
-                    deckDefinition={deckDef}
-                    showExpansion={cutoutId === 'cutoutA1'}
-                    fixtureBaseColor={fixtureBaseColor}
-                    slotClipColor={darkFill}
-                    stroke={
-                      showDeckRenders &&
-                      (hoveredSlot === addressableArea.id ||
-                        selectedSlot === addressableArea.id)
-                        ? COLORS.purple50
-                        : 'none'
-                    }
+              {robotType === OT2_ROBOT_TYPE ? (
+                <>
+                  <DeckFromLayers
+                    robotType={robotType}
+                    layerBlocklist={OT2_STANDARD_DECK_VIEW_LAYER_BLOCK_LIST}
                   />
-                ) : null
-              })}
-              {Object.values(stagingAreaEntities).map(entity => (
-                <StagingAreaFixture
-                  key={entity.id}
-                  cutoutId={entity.location as StagingAreaLocation}
-                  deckDefinition={deckDef}
-                  fixtureBaseColor={lightFill}
-                  slotClipColor={darkFill}
-                />
-              ))}
-              {Object.values(trashBinEntities).length > 0
-                ? trashBinFixtures.map(({ cutoutId, slot, id }) => {
-                    // TODO: the dropTipInPlace, airGapInplace, and
-                    // blowoutInPlace commands don't have
-                    // any knowledge of where its dropping. would be
-                    // nice to expand the results key to include the
-                    // addressable area name
-                    const isPipetteOverTrash =
-                      Object.values(robotState.pipettes).some(
-                        pipette => pipette.entityId === id
-                      ) &&
-                      selectedRunTimeCommand != null &&
-                      POTENTIAL_TRASH_COMMAND_TYPES.includes(
-                        selectedRunTimeCommand.commandType
-                      )
-
-                    return (
-                      <Fragment key={cutoutId}>
-                        <SingleSlotFixture
-                          cutoutId={cutoutId}
-                          deckDefinition={deckDef}
-                          slotClipColor={COLORS.transparent}
-                          fixtureBaseColor={lightFill}
-                        />
-                        <FlexTrash
-                          robotType={robotType}
-                          trashIconColor={lightFill}
-                          trashCutoutId={cutoutId as TrashCutoutId}
-                          backgroundColor={getBackgroundColor(
-                            hoveredSlot,
-                            selectedSlot,
-                            slot,
-                            isPipetteOverTrash
-                          )}
-                          onClick={() => {
-                            setSelectedSlot(slot)
-                          }}
-                          onMouseEnter={() => {
-                            setHoveredSlot(slot)
-                          }}
-                          onMouseLeave={() => {
-                            setHoveredSlot(null)
-                          }}
-                        />
-                      </Fragment>
+                  <FixedTrashText />
+                </>
+              ) : (
+                <>
+                  {filteredAddressableAreas.map(addressableArea => {
+                    const cutoutId = getCutoutIdForAddressableArea(
+                      addressableArea.id,
+                      deckDef.cutoutFixtures
                     )
-                  })
-                : null}
-              {Object.values(wasteChuteEntities).map(entity => (
-                <WasteChuteFixture
-                  key={entity.id}
-                  cutoutId={entity.location as typeof WASTE_CHUTE_CUTOUT}
-                  deckDefinition={deckDef}
-                  fixtureBaseColor={lightFill}
-                />
-              ))}
-              {wasteChuteStagingAreaFixtures.map(fixture => (
-                <WasteChuteStagingAreaFixture
-                  key={fixture.id}
-                  cutoutId={fixture.location as typeof WASTE_CHUTE_CUTOUT}
-                  deckDefinition={deckDef}
-                  fixtureBaseColor={lightFill}
-                  slotClipColor={darkFill}
-                />
-              ))}
+                    const labwareOnSlot = Object.entries(labware).find(
+                      ([_, lw]) =>
+                        getSlotInLocationStack(lw.stack) === addressableArea.id
+                    )
+                    const { isActiveLayerVisible } =
+                      labwareOnSlot != null
+                        ? getActiveLayer(
+                            Object.values(pipettes),
+                            labwareOnSlot[0],
+                            selectedRunTimeCommand
+                          )
+                        : { isActiveLayerVisible: false }
+                    let fixtureBaseColor = lightFill
+                    if (showDeckRenders) {
+                      if (isActiveLayerVisible) {
+                        fixtureBaseColor = COLORS.purple30
+                      } else if (
+                        !isActiveLayerVisible &&
+                        selectedSlot === addressableArea.id
+                      ) {
+                        fixtureBaseColor = COLORS.grey40
+                      }
+                    }
+                    return cutoutId != null ? (
+                      <SingleSlotFixture
+                        key={addressableArea.id}
+                        cutoutId={cutoutId}
+                        deckDefinition={deckDef}
+                        showExpansion={cutoutId === 'cutoutA1'}
+                        fixtureBaseColor={fixtureBaseColor}
+                        slotClipColor={darkFill}
+                        stroke={
+                          showDeckRenders &&
+                          (hoveredSlot === addressableArea.id ||
+                            selectedSlot === addressableArea.id)
+                            ? COLORS.purple50
+                            : 'none'
+                        }
+                      />
+                    ) : null
+                  })}
+                  {Object.values(stagingAreaEntities).map(entity => (
+                    <StagingAreaFixture
+                      key={entity.id}
+                      cutoutId={entity.location as StagingAreaLocation}
+                      deckDefinition={deckDef}
+                      fixtureBaseColor={lightFill}
+                      slotClipColor={darkFill}
+                    />
+                  ))}
+                  {Object.values(trashBinEntities).length > 0
+                    ? trashBinFixtures.map(({ cutoutId, slot, id }) => {
+                        // TODO: the dropTipInPlace, airGapInplace, and
+                        // blowoutInPlace commands don't have
+                        // any knowledge of where its dropping. would be
+                        // nice to expand the results key to include the
+                        // addressable area name
+                        const isPipetteOverTrash =
+                          Object.values(robotState.pipettes).some(
+                            pipette => pipette.entityId === id
+                          ) &&
+                          selectedRunTimeCommand != null &&
+                          POTENTIAL_TRASH_COMMAND_TYPES.includes(
+                            selectedRunTimeCommand.commandType
+                          )
+
+                        return (
+                          <Fragment key={cutoutId}>
+                            <SingleSlotFixture
+                              cutoutId={cutoutId}
+                              deckDefinition={deckDef}
+                              slotClipColor={COLORS.transparent}
+                              fixtureBaseColor={lightFill}
+                            />
+                            <FlexTrash
+                              robotType={robotType}
+                              trashIconColor={lightFill}
+                              trashCutoutId={cutoutId as TrashCutoutId}
+                              backgroundColor={getBackgroundColor(
+                                hoveredSlot,
+                                selectedSlot,
+                                slot,
+                                isPipetteOverTrash
+                              )}
+                              onClick={() => {
+                                setSelectedSlot(slot)
+                              }}
+                              onMouseEnter={() => {
+                                setHoveredSlot(slot)
+                              }}
+                              onMouseLeave={() => {
+                                setHoveredSlot(null)
+                              }}
+                            />
+                          </Fragment>
+                        )
+                      })
+                    : null}
+                  {Object.values(wasteChuteEntities).map(entity => (
+                    <WasteChuteFixture
+                      key={entity.id}
+                      cutoutId={entity.location as typeof WASTE_CHUTE_CUTOUT}
+                      deckDefinition={deckDef}
+                      fixtureBaseColor={lightFill}
+                    />
+                  ))}
+                  {wasteChuteStagingAreaFixtures.map(fixture => (
+                    <WasteChuteStagingAreaFixture
+                      key={fixture.id}
+                      cutoutId={fixture.location as typeof WASTE_CHUTE_CUTOUT}
+                      deckDefinition={deckDef}
+                      fixtureBaseColor={lightFill}
+                      slotClipColor={darkFill}
+                    />
+                  ))}
+                </>
+              )}
               <DeckViewDetails
                 labwareEntitiesExtended={labwareEntitiesExtended}
                 liquids={liquids}

--- a/app/src/pages/Desktop/Protocols/ProtocolVisualization/DeckViewDetails.tsx
+++ b/app/src/pages/Desktop/Protocols/ProtocolVisualization/DeckViewDetails.tsx
@@ -148,11 +148,10 @@ export function DeckViewDetails(props: DeckViewDetailsProps): JSX.Element {
         }
         const tempInnerProps = getModuleInnerProps(moduleState)
         const isActive = selectedSlot === slot || hoveredSlot === slot
-
         const innerTCProps = {
           ...tempInnerProps,
           lidMotorState:
-            (tempInnerProps as ThermocyclerVizProps).lidMotorState !== 'open'
+            (tempInnerProps as ThermocyclerVizProps)?.lidMotorState !== 'open'
               ? 'closed'
               : 'open',
         }


### PR DESCRIPTION
closes AUTH-2391

# Overview

This enables protocol viz deck map to work for the ot-2! i also smoke tested a few longer protocols and they worked the whole way without white screening.

Next i will fix the hover states/overlay on the deck map.

## Test Plan and Hands on Testing

Test with an ot-2 protocol. the following is what i tested with

[doItAllV3MigratedToV8.json](https://github.com/user-attachments/files/22909798/doItAllV3MigratedToV8.json)

## Changelog

enable ot-2 deck map
fix whitescreen with the thermocycler lid status being unknown

## Risk assessment

low