### PR TITLE
refactor(protocol-designer): Delete some unused Redux state and selectors

### DIFF
--- a/protocol-designer/src/ui/steps/index.ts
+++ b/protocol-designer/src/ui/steps/index.ts
@@ -4,7 +4,6 @@ import * as _thunks from './actions/thunks'
 export { rootReducer } from './reducers'
 export {
   rootSelector,
-  getSelectedStepTitleInfo,
   getSelectedStepId,
   getMultiSelectItemIds,
   getIsMultiSelectMode,

--- a/protocol-designer/src/ui/steps/index.ts
+++ b/protocol-designer/src/ui/steps/index.ts
@@ -16,7 +16,6 @@ export {
   getActiveItem,
   getHoveredSubstep,
   getWellSelectionLabwareKey,
-  getCollapsedSteps,
 } from './selectors'
 export * from './actions/types'
 export const actions = { ..._actions, ..._thunks }

--- a/protocol-designer/src/ui/steps/reducers.ts
+++ b/protocol-designer/src/ui/steps/reducers.ts
@@ -1,17 +1,10 @@
-import omit from 'lodash/omit'
 import { combineReducers } from 'redux'
 import { handleActions } from 'redux-actions'
 
-import { getPDMetadata } from '../../file-types'
 import { PRESAVED_STEP_ID, START_TERMINAL_ITEM_ID } from '../../steplist/types'
 
 import type { Reducer } from 'redux'
 import type { StepIdType } from '../../form-types'
-import type { LoadFileAction } from '../../load-file'
-import type {
-  DeleteMultipleStepsAction,
-  DeleteStepAction,
-} from '../../steplist/actions'
 import type { SubstepIdentifier, TerminalItemId } from '../../steplist/types'
 import type { SaveStepFormAction } from '../steps/actions/thunks'
 import type {
@@ -25,41 +18,6 @@ import type {
   SelectTerminalItemAction,
 } from './actions/types'
 
-export type CollapsedStepsState = Record<StepIdType, boolean>
-// @ts-expect-error(sa, 2021-6-10): cannot use string literals as action type
-// TODO IMMEDIATELY: refactor this to the old fashioned way if we cannot have type safety: https://github.com/redux-utilities/redux-actions/issues/282#issuecomment-595163081
-const collapsedSteps: Reducer<CollapsedStepsState, any> = handleActions(
-  {
-    SAVE_STEP_FORM: (
-      state: CollapsedStepsState,
-      action: SaveStepFormAction
-    ) => {
-      const id = action.payload.id
-
-      if (!(id in state)) {
-        // if step saved for the first time, initialize collapsed state
-        return { ...state, [id]: false }
-      }
-
-      return state
-    },
-    DELETE_STEP: (state: CollapsedStepsState, action: DeleteStepAction) =>
-      omit(state, action.payload.toString()),
-    DELETE_MULTIPLE_STEPS: (
-      state: CollapsedStepsState,
-      action: DeleteMultipleStepsAction
-    ) => omit(state, action.payload),
-    LOAD_FILE: (
-      state: CollapsedStepsState,
-      action: LoadFileAction // default all steps to collapsed
-    ) =>
-      getPDMetadata(action.payload.file).orderedStepIds.reduce(
-        (acc: CollapsedStepsState, stepId) => ({ ...acc, [stepId]: true }),
-        {}
-      ),
-  },
-  {}
-)
 export const SINGLE_STEP_SELECTION_TYPE: 'SINGLE_STEP_SELECTION_TYPE' =
   'SINGLE_STEP_SELECTION_TYPE'
 export const MULTI_STEP_SELECTION_TYPE: 'MULTI_STEP_SELECTION_TYPE' =
@@ -233,7 +191,6 @@ const selectedDropdownItem: Reducer<Selection[], any> = handleActions(
   []
 )
 export interface StepsState {
-  collapsedSteps: CollapsedStepsState
   selectedItem: SelectedItemState
   hoveredItem: HoveredItemState
   hoveredSubstep: SubstepIdentifier
@@ -243,7 +200,6 @@ export interface StepsState {
   selectedDropdownItem: Selection[]
 }
 export const _allReducers = {
-  collapsedSteps,
   selectedItem,
   hoveredItem,
   hoveredSubstep,

--- a/protocol-designer/src/ui/steps/selectors.ts
+++ b/protocol-designer/src/ui/steps/selectors.ts
@@ -33,12 +33,7 @@ import type {
 import type { SubstepIdentifier, TerminalItemId } from '../../steplist/types'
 import type { BaseState, Selector } from '../../types'
 import type { Selection } from './actions/types'
-import type {
-  CollapsedStepsState,
-  HoverableItem,
-  SelectableItem,
-  StepsState,
-} from './reducers'
+import type { HoverableItem, SelectableItem, StepsState } from './reducers'
 
 export const rootSelector = (state: BaseState): StepsState => state.ui.steps
 // ======= Selectors ===============================================
@@ -192,11 +187,7 @@ export const getActiveItem: Selector<HoverableItem | null> = createSelector(
     }
   }
 )
-// TODO: BC 2018-12-17 refactor as react state
-export const getCollapsedSteps: Selector<CollapsedStepsState> = createSelector(
-  rootSelector,
-  (state: StepsState) => state.collapsedSteps
-)
+
 interface StepTitleInfo {
   stepName: string
   stepType: StepType

--- a/protocol-designer/src/ui/steps/selectors.ts
+++ b/protocol-designer/src/ui/steps/selectors.ts
@@ -4,7 +4,6 @@ import { createSelector } from 'reselect'
 
 import { selectors as stepFormSelectors } from '../../step-forms'
 import { getDefaultsForStepType } from '../../steplist/formLevel/getDefaultsForStepType'
-import { PRESAVED_STEP_ID } from '../../steplist/types'
 import { getLabwareOnModule } from '../modules/utils'
 import {
   initialSelectedItemState,
@@ -188,34 +187,6 @@ export const getActiveItem: Selector<HoverableItem | null> = createSelector(
   }
 )
 
-interface StepTitleInfo {
-  stepName: string
-  stepType: StepType
-}
-
-const _stepToTitleInfo = (stepForm: FormData): StepTitleInfo => ({
-  stepName: stepForm.stepName,
-  stepType: stepForm.stepType,
-})
-
-export const getSelectedStepTitleInfo: Selector<StepTitleInfo | null> =
-  createSelector(
-    stepFormSelectors.getUnsavedForm,
-    stepFormSelectors.getSavedStepForms,
-    getSelectedStepId,
-    getSelectedTerminalItemId,
-    (unsavedForm, savedStepForms, selectedStepId, terminalItemId) => {
-      if (unsavedForm != null && terminalItemId === PRESAVED_STEP_ID) {
-        return _stepToTitleInfo(unsavedForm)
-      }
-
-      if (selectedStepId == null) {
-        return null
-      }
-
-      return _stepToTitleInfo(savedStepForms[selectedStepId])
-    }
-  )
 export const getWellSelectionLabwareKey: Selector<string | null> =
   createSelector(
     rootSelector,

--- a/protocol-designer/src/ui/steps/test/reducers.test.ts
+++ b/protocol-designer/src/ui/steps/test/reducers.test.ts
@@ -13,63 +13,7 @@ import type { SelectableItem } from '../reducers'
 
 vi.mock('../../../labware-defs/utils')
 
-const { collapsedSteps, selectedItem } = _allReducers
-
-describe('collapsedSteps reducer', () => {
-  it('should add a collapsed step when a new step is saved for the first time', () => {
-    const state = { '1': true, '2': false }
-    const action = {
-      type: 'SAVE_STEP_FORM',
-      payload: { id: '3' },
-    }
-    expect(collapsedSteps(state, action)).toEqual({
-      '1': true,
-      '2': false,
-      '3': false,
-    })
-  })
-  it('should not update when an existing step form is saved', () => {
-    const state = { '1': true, '2': false }
-    const action = {
-      type: 'SAVE_STEP_FORM',
-      payload: { id: '1' },
-    }
-    expect(collapsedSteps(state, action)).toBe(state)
-  })
-  it('should remove the collapsed step when deleted', () => {
-    const state = {
-      '1': true,
-      '2': false,
-      '3': true,
-      '4': true,
-    }
-    const action = {
-      type: 'DELETE_STEP',
-      payload: '3',
-    }
-    expect(collapsedSteps(state, action)).toEqual({
-      '1': true,
-      '2': false,
-      '4': true,
-    })
-  })
-  it('should remove multiple collapsed steps when multiple steps get deleted', () => {
-    const state = {
-      '1': true,
-      '2': false,
-      '3': true,
-      '4': true,
-    }
-    const action = {
-      type: 'DELETE_MULTIPLE_STEPS',
-      payload: ['2', '3'],
-    }
-    expect(collapsedSteps(state, action)).toEqual({
-      '1': true,
-      '4': true,
-    })
-  })
-})
+const { selectedItem } = _allReducers
 
 describe('selectedItem reducer', () => {
   it('should select the presaved step item on ADD_STEP', () => {

--- a/protocol-designer/src/ui/steps/test/selectors.test.ts
+++ b/protocol-designer/src/ui/steps/test/selectors.test.ts
@@ -3,11 +3,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { TEMPERATURE_MODULE_TYPE } from '@opentrons/shared-data'
 
 import { getMockMixStep, getMockMoveLiquidStep } from '../__fixtures__'
-import {
-  END_TERMINAL_ITEM_ID,
-  PRESAVED_STEP_ID,
-  START_TERMINAL_ITEM_ID,
-} from '../../../steplist/types'
 import * as utils from '../../modules/utils'
 import {
   MULTI_STEP_SELECTION_TYPE,

--- a/protocol-designer/src/ui/steps/test/selectors.test.ts
+++ b/protocol-designer/src/ui/steps/test/selectors.test.ts
@@ -23,7 +23,6 @@ import {
   getMultiSelectDisabledFields,
   getMultiSelectFieldValues,
   getMultiSelectLastSelected,
-  getSelectedStepTitleInfo,
 } from '../selectors'
 
 import type { MoveLabwareArgs } from '@opentrons/step-generation'
@@ -213,57 +212,6 @@ describe('getHoveredStepLabware', () => {
       )
 
       expect(result).toEqual([])
-    })
-  })
-})
-
-describe('getSelectedStepTitleInfo', () => {
-  it('should return title info of the presaved form when the presaved terminal item is selected', () => {
-    const unsavedForm = { stepName: 'The Step', stepType: 'transfer' }
-    // @ts-expect-error(sa, 2021-6-15): resultFunc not part of Selector type
-    const result = getSelectedStepTitleInfo.resultFunc(
-      unsavedForm,
-      {},
-      null,
-      PRESAVED_STEP_ID
-    )
-    expect(result).toEqual({
-      stepName: unsavedForm.stepName,
-      stepType: unsavedForm.stepType,
-    })
-  })
-
-  it('should return null when the start or end terminal item is selected', () => {
-    const terminals = [START_TERMINAL_ITEM_ID, END_TERMINAL_ITEM_ID]
-    terminals.forEach(terminalId => {
-      const unsavedForm = { stepName: 'The Step', stepType: 'transfer' }
-      // @ts-expect-error(sa, 2021-6-15): resultFunc not part of Selector type
-      const result = getSelectedStepTitleInfo.resultFunc(
-        unsavedForm,
-        {},
-        null,
-        PRESAVED_STEP_ID
-      )
-      expect(result).toEqual({
-        stepName: unsavedForm.stepName,
-        stepType: unsavedForm.stepType,
-      })
-    })
-  })
-
-  it('should return title info of the saved step when a saved step is selected', () => {
-    const savedForm = { stepName: 'The Step', stepType: 'transfer' }
-    const stepId = 'selectedAndSavedStepId'
-    // @ts-expect-error(sa, 2021-6-15): resultFunc not part of Selector type
-    const result = getSelectedStepTitleInfo.resultFunc(
-      null,
-      { [stepId]: savedForm },
-      stepId,
-      null
-    )
-    expect(result).toEqual({
-      stepName: savedForm.stepName,
-      stepType: savedForm.stepType,
     })
   })
 })


### PR DESCRIPTION
## Overview

Just deleting some dead code.

## Test Plan and Hands on Testing

None needed.

## Changelog

* Delete the `collapsedSteps` part of Redux state, and its sole selector `getCollapsedSteps()`.
* Delete the `getSelectedStepTitleInfo()` selector.

## Review requests

Anything we want to keep?

## Risk assessment

Very low.