### PR TITLE
feat(api): add dynamic locations to papi

### DIFF
--- a/api/src/opentrons/legacy_commands/commands.py
+++ b/api/src/opentrons/legacy_commands/commands.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING, List, Sequence, Union, overload
+from typing import TYPE_CHECKING, List, Sequence, Union, overload, Optional
 
 
 from .helpers import (
@@ -31,10 +31,21 @@ def aspirate(
     location: Location,
     flow_rate: float,
     rate: float,
+    end_location: Optional[Location],
 ) -> command_types.AspirateCommand:
     location_text = stringify_location(location)
-    template = "Aspirating {volume} uL from {location} at {flow} uL/sec"
-    text = template.format(volume=float(volume), location=location_text, flow=flow_rate)
+    end_location_text = (
+        f" while moving to {stringify_location(end_location)}"
+        if end_location is not None
+        else ""
+    )
+    template = "Aspirating {volume} uL from {location} at {flow} uL/sec{end}"
+    text = template.format(
+        volume=float(volume),
+        location=location_text,
+        flow=flow_rate,
+        end=end_location_text,
+    )
 
     return {
         "name": command_types.ASPIRATE,
@@ -44,6 +55,7 @@ def aspirate(
             "location": location,
             "rate": rate,
             "text": text,
+            "end_location": end_location,
         },
     }
 
@@ -54,10 +66,21 @@ def dispense(
     location: Location,
     flow_rate: float,
     rate: float,
+    end_location: Optional[Location],
 ) -> command_types.DispenseCommand:
     location_text = stringify_location(location)
-    template = "Dispensing {volume} uL into {location} at {flow} uL/sec"
-    text = template.format(volume=float(volume), location=location_text, flow=flow_rate)
+    end_location_text = (
+        f" while moving to {stringify_location(end_location)}"
+        if end_location is not None
+        else ""
+    )
+    template = "Dispensing {volume} uL into {location} at {flow} uL/sec{end}"
+    text = template.format(
+        volume=float(volume),
+        location=location_text,
+        flow=flow_rate,
+        end=end_location_text,
+    )
 
     return {
         "name": command_types.DISPENSE,
@@ -67,6 +90,7 @@ def dispense(
             "location": location,
             "rate": rate,
             "text": text,
+            "end_location": end_location,
         },
     }
 

--- a/api/src/opentrons/legacy_commands/types.py
+++ b/api/src/opentrons/legacy_commands/types.py
@@ -445,6 +445,7 @@ class AspirateDispenseCommandPayload(TextOnlyPayload, SingleInstrumentPayload):
     location: Location
     volume: float
     rate: float
+    end_location: Optional[Location]
 
 
 class AspirateCommand(TypedDict):

--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -203,6 +203,8 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         flow_rate: float,
         in_place: bool,
         meniscus_tracking: Optional[MeniscusTrackingTarget] = None,
+        end_location: Optional[Location] = None,
+        end_meniscus_tracking: Optional[MeniscusTrackingTarget] = None,
         correction_volume: Optional[float] = None,
     ) -> None:
         """Aspirate a given volume of liquid from the specified location.
@@ -215,7 +217,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             in_place: whether this is a in-place command.
             meniscus_tracking: Optional data about where to aspirate from.
         """
-        if meniscus_tracking == MeniscusTrackingTarget.START:
+        if meniscus_tracking == MeniscusTrackingTarget.START and end_location is None:
             raise ValueError("Cannot aspirate at the starting liquid height.")
         if well_core is None:
             if not in_place:
@@ -262,9 +264,8 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                 well_location=well_location,
             )
             assert isinstance(well_location, LiquidHandlingWellLocation)
-            if dynamic_liquid_tracking:
-                # TODO replace this declaration with an argument, leaving it like this until I do that ticket
-                end_location: Optional[Location] = None
+            # the dynamic liquid tracking flag is for the prototype dynamic tracking method
+            if dynamic_liquid_tracking or end_location is not None:
                 # Keep this part when above TODO is done
                 if end_location is None:
                     end_location = location
@@ -276,7 +277,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                     well_name=well_name,
                     absolute_point=end_location.point,
                     location_type=WellLocationFunction.LIQUID_HANDLING,
-                    meniscus_tracking=meniscus_tracking,
+                    meniscus_tracking=end_meniscus_tracking,
                 )
                 assert isinstance(end_well_location, LiquidHandlingWellLocation)
                 self._engine_client.execute_command(
@@ -316,6 +317,8 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         in_place: bool,
         push_out: Optional[float],
         meniscus_tracking: Optional[MeniscusTrackingTarget] = None,
+        end_location: Optional[Location] = None,
+        end_meniscus_tracking: Optional[MeniscusTrackingTarget] = None,
         correction_volume: Optional[float] = None,
     ) -> None:
         """Dispense a given volume of liquid into the specified location.
@@ -392,10 +395,8 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                 well_name=well_name,
                 well_location=well_location,
             )
-            if dynamic_liquid_tracking:
-                # TODO replace this declaration with an argument, leaving it like this until I do that ticket
-                end_location: Optional[Location] = None
-                # Keep this part when above TODO is done
+            # the dynamic liquid tracking flag is for the prototype dynamic tracking method
+            if dynamic_liquid_tracking or end_location is not None:
                 if end_location is None:
                     end_location = location
                 (
@@ -406,7 +407,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                     well_name=well_name,
                     absolute_point=end_location.point,
                     location_type=WellLocationFunction.LIQUID_HANDLING,
-                    meniscus_tracking=meniscus_tracking,
+                    meniscus_tracking=end_meniscus_tracking,
                 )
                 assert isinstance(end_well_location, LiquidHandlingWellLocation)
                 self._engine_client.execute_command(

--- a/api/src/opentrons/protocol_api/core/instrument.py
+++ b/api/src/opentrons/protocol_api/core/instrument.py
@@ -48,6 +48,8 @@ class AbstractInstrument(ABC, Generic[WellCoreType, LabwareCoreType]):
         flow_rate: float,
         in_place: bool,
         meniscus_tracking: Optional[types.MeniscusTrackingTarget] = None,
+        end_location: Optional[types.Location] = None,
+        end_meniscus_tracking: Optional[types.MeniscusTrackingTarget] = None,
         correction_volume: Optional[float] = None,
     ) -> None:
         """Aspirate a given volume of liquid from the specified location.
@@ -74,6 +76,8 @@ class AbstractInstrument(ABC, Generic[WellCoreType, LabwareCoreType]):
         in_place: bool,
         push_out: Optional[float],
         meniscus_tracking: Optional[types.MeniscusTrackingTarget] = None,
+        end_location: Optional[types.Location] = None,
+        end_meniscus_tracking: Optional[types.MeniscusTrackingTarget] = None,
         correction_volume: Optional[float] = None,
     ) -> None:
         """Dispense a given volume of liquid into the specified location.

--- a/api/src/opentrons/protocol_api/core/legacy/legacy_instrument_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy/legacy_instrument_core.py
@@ -93,6 +93,8 @@ class LegacyInstrumentCore(AbstractInstrument[LegacyWellCore, LegacyLabwareCore]
         flow_rate: float,
         in_place: bool,
         meniscus_tracking: Optional[types.MeniscusTrackingTarget] = None,
+        end_location: Optional[types.Location] = None,
+        end_meniscus_tracking: Optional[types.MeniscusTrackingTarget] = None,
         correction_volume: Optional[float] = None,
     ) -> None:
         """Aspirate a given volume of liquid from the specified location.
@@ -139,6 +141,8 @@ class LegacyInstrumentCore(AbstractInstrument[LegacyWellCore, LegacyLabwareCore]
         in_place: bool,
         push_out: Optional[float],
         meniscus_tracking: Optional[types.MeniscusTrackingTarget] = None,
+        end_location: Optional[types.Location] = None,
+        end_meniscus_tracking: Optional[types.MeniscusTrackingTarget] = None,
         correction_volume: Optional[float] = None,
     ) -> None:
         """Dispense a given volume of liquid into the specified location.

--- a/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_instrument_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_instrument_core.py
@@ -106,6 +106,8 @@ class LegacyInstrumentCoreSimulator(
         flow_rate: float,
         in_place: bool,
         meniscus_tracking: Optional[types.MeniscusTrackingTarget] = None,
+        end_location: Optional[types.Location] = None,
+        end_meniscus_tracking: Optional[types.MeniscusTrackingTarget] = None,
         correction_volume: Optional[float] = None,
     ) -> None:
         if self.get_current_volume() == 0:
@@ -149,6 +151,8 @@ class LegacyInstrumentCoreSimulator(
         in_place: bool,
         push_out: Optional[float],
         meniscus_tracking: Optional[types.MeniscusTrackingTarget] = None,
+        end_location: Optional[types.Location] = None,
+        end_meniscus_tracking: Optional[types.MeniscusTrackingTarget] = None,
         correction_volume: Optional[float] = None,
     ) -> None:
         if isinstance(location, (TrashBin, WasteChute)):

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -199,6 +199,7 @@ class InstrumentContext(publisher.CommandPublisher):
         location: Optional[Union[types.Location, labware.Well]] = None,
         rate: float = 1.0,
         flow_rate: Optional[float] = None,
+        end_location: Optional[types.Location] = None,
     ) -> InstrumentContext:
         """
         Draw liquid into a pipette tip.
@@ -291,6 +292,22 @@ class InstrumentContext(publisher.CommandPublisher):
         move_to_location, well, meniscus_tracking = self._handle_aspirate_target(
             target=target
         )
+        end_target: Optional[validation.ValidTarget] = None
+        if end_location is not None:
+            if location is None:
+                raise ValueError("Location must be supplied if using an End Location.")
+            end_target = validation.validate_location(
+                location=end_location, last_location=None
+            )
+            if isinstance(end_target, validation.DisposalTarget):
+                raise ValueError(
+                    "Trash Bin and Waste Chute are not acceptable location parameters for Aspirate commands."
+                )
+            (
+                end_move_to_location,
+                end_well,
+                end_meniscus_tracking,
+            ) = self._handle_aspirate_target(target=end_target)
         if self.api_version >= APIVersion(2, 11):
             instrument.validate_takes_liquid(
                 location=move_to_location,
@@ -346,6 +363,7 @@ class InstrumentContext(publisher.CommandPublisher):
         rate: float = 1.0,
         push_out: Optional[float] = None,
         flow_rate: Optional[float] = None,
+        end_location: Optional[types.Location] = None,
     ) -> InstrumentContext:
         """
         Dispense liquid from a pipette tip.
@@ -507,6 +525,22 @@ class InstrumentContext(publisher.CommandPublisher):
         move_to_location, well, meniscus_tracking = self._handle_dispense_target(
             target=target
         )
+        end_target: Optional[validation.ValidTarget] = None
+        if end_location is not None:
+            if location is None:
+                raise ValueError("Location must be supplied if using an End Location.")
+            end_target = validation.validate_location(
+                location=end_location, last_location=None
+            )
+            if isinstance(end_target, validation.DisposalTarget):
+                raise ValueError(
+                    "Trash Bin and Waste Chute are not acceptable location parameters for dynamic pipetting commands."
+                )
+            (
+                end_move_to_location,
+                end_well,
+                end_meniscus_tracking,
+            ) = self._handle_dispense_target(target=end_target)
 
         if self.api_version >= APIVersion(2, 11):
             instrument.validate_takes_liquid(
@@ -534,6 +568,8 @@ class InstrumentContext(publisher.CommandPublisher):
                 in_place=target.in_place,
                 push_out=push_out,
                 meniscus_tracking=meniscus_tracking,
+                end_location=end_move_to_location,
+                end_meniscus_tracking=end_meniscus_tracking,
             )
 
         return self

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -377,6 +377,7 @@ class InstrumentContext(publisher.CommandPublisher):
                 location=move_to_location,
                 flow_rate=flow_rate,
                 rate=rate,
+                end_location=end_move_to_location,
             ),
         ):
             self._core.aspirate(
@@ -637,6 +638,7 @@ class InstrumentContext(publisher.CommandPublisher):
                 location=move_to_location,
                 rate=rate,
                 flow_rate=flow_rate,
+                end_location=end_move_to_location,
             ),
         ):
             self._core.dispense(

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -292,6 +292,34 @@ class InstrumentContext(publisher.CommandPublisher):
         move_to_location, well, meniscus_tracking = self._handle_aspirate_target(
             target=target
         )
+        if (
+            meniscus_tracking is not None
+            and meniscus_tracking == types.MeniscusTrackingTarget.DYNAMIC
+        ):
+            # we're using the old dynamic pipetting
+            if end_location is not None:
+                raise ValueError(
+                    "Dynamic target is depreciated and you cannot use a dynamic target and and end location."
+                )
+            # re-work the dynamic location as a start and end location
+            new_start_location = types.Location(
+                point=move_to_location.point,
+                labware=move_to_location.labware,
+                _meniscus_tracking=types.MeniscusTrackingTarget.START,
+            )
+            target = validation.validate_location(
+                location=new_start_location, last_location=last_location
+            )
+            # Target already checked for this above, this is just for lint
+            assert not isinstance(target, validation.DisposalTarget)
+            move_to_location, well, meniscus_tracking = self._handle_aspirate_target(
+                target=target
+            )
+            end_location = types.Location(
+                point=move_to_location.point,
+                labware=move_to_location.labware,
+                _meniscus_tracking=types.MeniscusTrackingTarget.END,
+            )
         end_move_to_location: Optional[types.Location] = None
         end_meniscus_tracking: Optional[types.MeniscusTrackingTarget] = None
         if end_location is not None:
@@ -539,6 +567,34 @@ class InstrumentContext(publisher.CommandPublisher):
         move_to_location, well, meniscus_tracking = self._handle_dispense_target(
             target=target
         )
+        if (
+            meniscus_tracking is not None
+            and meniscus_tracking == types.MeniscusTrackingTarget.DYNAMIC
+        ):
+            # we're using the old dynamic pipetting
+            if end_location is not None:
+                raise ValueError(
+                    "Dynamic target is depreciated and you cannot use a dynamic target and and end location."
+                )
+            # re-work the dynamic location as a start and end location
+            new_start_location = types.Location(
+                point=move_to_location.point,
+                labware=move_to_location.labware,
+                _meniscus_tracking=types.MeniscusTrackingTarget.START,
+            )
+            target = validation.validate_location(
+                location=new_start_location, last_location=last_location
+            )
+            # Target already checked for this above, this is just for lint
+            assert not isinstance(target, validation.DisposalTarget)
+            move_to_location, well, meniscus_tracking = self._handle_dispense_target(
+                target=target
+            )
+            end_location = types.Location(
+                point=move_to_location.point,
+                labware=move_to_location.labware,
+                _meniscus_tracking=types.MeniscusTrackingTarget.END,
+            )
         end_move_to_location: Optional[types.Location] = None
         end_meniscus_tracking: Optional[types.MeniscusTrackingTarget] = None
         if end_location is not None:

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -238,12 +238,12 @@ class InstrumentContext(publisher.CommandPublisher):
         :type rate: float
         :param flow_rate: The absolute flow rate in µL/s. If ``flow_rate`` is specified,
                           ``rate`` must not be set.
-
+        :type flow_rate: float
         :param end_location: Tells the robot to move between location and end_location
             while aspirating liquid. When this argument is used the location and
             end_location must both be :py:class:`.Location`.
-        :type end_location::py:class:`.Location`
-        :type flow_rate: float
+        :type end_location: :py:class:`.Location`
+
         :returns: This instance.
 
         .. note::
@@ -481,8 +481,8 @@ class InstrumentContext(publisher.CommandPublisher):
 
         :param end_location: Tells the robot to move between location and end_location
             while dispensing liquid held in the pipette. When this argument is used
-            the location and end_location must both be :py:class:`.Location`.
-        :type end_location::py:class:`.Location`
+            the location and end_location must both be a :py:class:`.Location`.
+        :type end_location: :py:class:`.Location`
 
         :returns: This instance.
 

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -310,6 +310,14 @@ class InstrumentContext(publisher.CommandPublisher):
                 end_well,
                 end_meniscus_tracking,
             ) = self._handle_aspirate_target(target=end_target)
+        elif (
+            meniscus_tracking is not None
+            and meniscus_tracking == types.MeniscusTrackingTarget.DYNAMIC
+        ):
+            # Preserve the old behavior
+            meniscus_tracking = types.MeniscusTrackingTarget.START
+            end_move_to_location = move_to_location
+            end_meniscus_tracking = types.MeniscusTrackingTarget.END
         if self.api_version >= APIVersion(2, 11):
             instrument.validate_takes_liquid(
                 location=move_to_location,
@@ -549,6 +557,14 @@ class InstrumentContext(publisher.CommandPublisher):
                 end_well,
                 end_meniscus_tracking,
             ) = self._handle_dispense_target(target=end_target)
+        elif (
+            meniscus_tracking is not None
+            and meniscus_tracking == types.MeniscusTrackingTarget.DYNAMIC
+        ):
+            # Preserve the old behavior
+            meniscus_tracking = types.MeniscusTrackingTarget.START
+            end_move_to_location = move_to_location
+            end_meniscus_tracking = types.MeniscusTrackingTarget.END
 
         if self.api_version >= APIVersion(2, 11):
             instrument.validate_takes_liquid(

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -238,6 +238,11 @@ class InstrumentContext(publisher.CommandPublisher):
         :type rate: float
         :param flow_rate: The absolute flow rate in µL/s. If ``flow_rate`` is specified,
                           ``rate`` must not be set.
+
+        :param end_location: Tells the robot to move between location and end_location
+            while aspirating liquid. When this argument is used the location and
+            end_location must both be :py:class:`.Location`.
+        :type end_location::py:class:`.Location`
         :type flow_rate: float
         :returns: This instance.
 
@@ -473,6 +478,11 @@ class InstrumentContext(publisher.CommandPublisher):
         :param flow_rate: The absolute flow rate in µL/s. If ``flow_rate`` is specified,
                           ``rate`` must not be set.
         :type flow_rate: float
+
+        :param end_location: Tells the robot to move between location and end_location
+            while dispensing liquid held in the pipette. When this argument is used
+            the location and end_location must both be :py:class:`.Location`.
+        :type end_location::py:class:`.Location`
 
         :returns: This instance.
 

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -292,8 +292,10 @@ class InstrumentContext(publisher.CommandPublisher):
         move_to_location, well, meniscus_tracking = self._handle_aspirate_target(
             target=target
         )
-        end_target: Optional[validation.ValidTarget] = None
+        end_move_to_location: Optional[types.Location] = None
+        end_meniscus_tracking: Optional[types.MeniscusTrackingTarget] = None
         if end_location is not None:
+            end_target: Optional[validation.ValidTarget] = None
             if location is None:
                 raise ValueError("Location must be supplied if using an End Location.")
             end_target = validation.validate_location(
@@ -349,6 +351,8 @@ class InstrumentContext(publisher.CommandPublisher):
                 flow_rate=flow_rate,
                 in_place=target.in_place,
                 meniscus_tracking=meniscus_tracking,
+                end_location=end_move_to_location,
+                end_meniscus_tracking=end_meniscus_tracking,
             )
 
         return self
@@ -519,14 +523,18 @@ class InstrumentContext(publisher.CommandPublisher):
                     in_place=target.in_place,
                     push_out=push_out,
                     meniscus_tracking=None,
+                    end_location=None,
+                    end_meniscus_tracking=None,
                 )
             return self
 
         move_to_location, well, meniscus_tracking = self._handle_dispense_target(
             target=target
         )
-        end_target: Optional[validation.ValidTarget] = None
+        end_move_to_location: Optional[types.Location] = None
+        end_meniscus_tracking: Optional[types.MeniscusTrackingTarget] = None
         if end_location is not None:
+            end_target: Optional[validation.ValidTarget] = None
             if location is None:
                 raise ValueError("Location must be supplied if using an End Location.")
             end_target = validation.validate_location(

--- a/api/src/opentrons/protocol_engine/commands/dispense_while_tracking.py
+++ b/api/src/opentrons/protocol_engine/commands/dispense_while_tracking.py
@@ -104,7 +104,7 @@ class DispenseWhileTrackingImplementation(
         end_point = self._state_view.geometry.get_well_position(
             labware_id=params.labwareId,
             well_name=params.wellName,
-            well_location=params.trackFromLocation,
+            well_location=params.trackToLocation,
             operation_volume=params.volume,
             pipette_id=params.pipetteId,
         )

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -637,7 +637,9 @@ class GeometryView:
         if meniscus_tracking:
             location = LiquidHandlingWellLocation(
                 origin=WellOrigin.MENISCUS,
-                offset=WellOffset(x=absolute_point.x, y=absolute_point.y, z=absolute_point.z),
+                offset=WellOffset(
+                    x=absolute_point.x, y=absolute_point.y, z=absolute_point.z
+                ),
             )
             # TODO(cm): handle operationVolume being a float other than 0
             if meniscus_tracking == MeniscusTrackingTarget.END:

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -637,7 +637,7 @@ class GeometryView:
         if meniscus_tracking:
             location = LiquidHandlingWellLocation(
                 origin=WellOrigin.MENISCUS,
-                offset=WellOffset(x=0, y=0, z=absolute_point.z),
+                offset=WellOffset(x=absolute_point.x, y=absolute_point.y, z=absolute_point.z),
             )
             # TODO(cm): handle operationVolume being a float other than 0
             if meniscus_tracking == MeniscusTrackingTarget.END:

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -366,6 +366,8 @@ def test_aspirate(
             rate=1.23,
             flow_rate=5.67,
             meniscus_tracking=None,
+            end_location=None,
+            end_meniscus_tracking=None,
         ),
         times=1,
     )
@@ -399,6 +401,8 @@ def test_aspirate_well_location(
             rate=1.23,
             flow_rate=5.67,
             meniscus_tracking=None,
+            end_location=None,
+            end_meniscus_tracking=None,
         ),
         times=1,
     )
@@ -432,6 +436,8 @@ def test_aspirate_meniscus_well_location(
             rate=1.23,
             flow_rate=5.67,
             meniscus_tracking=None,
+            end_location=None,
+            end_meniscus_tracking=None,
         ),
         times=1,
     )
@@ -464,6 +470,8 @@ def test_aspirate_from_coordinates(
             rate=1.23,
             flow_rate=5.67,
             meniscus_tracking=None,
+            end_location=None,
+            end_meniscus_tracking=None,
         ),
         times=1,
     )
@@ -508,6 +516,8 @@ def test_aspirate_flow_rate(
             rate=1.5,  # requested flow_rate is 1.5 times default of 400
             flow_rate=600,
             meniscus_tracking=None,
+            end_location=None,
+            end_meniscus_tracking=None,
         ),
         times=1,
     )
@@ -1075,6 +1085,8 @@ def test_dispense_with_location(
             flow_rate=5.67,
             push_out=None,
             meniscus_tracking=None,
+            end_location=None,
+            end_meniscus_tracking=None,
         ),
         times=1,
     )
@@ -1109,6 +1121,8 @@ def test_dispense_with_well_location(
             flow_rate=3.0,
             push_out=7,
             meniscus_tracking=None,
+            end_location=None,
+            end_meniscus_tracking=None,
         ),
         times=1,
     )
@@ -1144,6 +1158,8 @@ def test_dispense_with_well(
             flow_rate=5.67,
             push_out=None,
             meniscus_tracking=None,
+            end_location=None,
+            end_meniscus_tracking=None,
         ),
         times=1,
     )
@@ -1204,6 +1220,8 @@ def test_dispense_flow_rate(
             in_place=True,
             push_out=None,
             meniscus_tracking=None,
+            end_location=None,
+            end_meniscus_tracking=None,
         ),
         times=1,
     )
@@ -1468,6 +1486,8 @@ def test_dispense_0_volume_means_dispense_everything(
             flow_rate=5.67,
             push_out=None,
             meniscus_tracking=None,
+            end_location=None,
+            end_meniscus_tracking=None,
         ),
         times=1,
     )
@@ -1495,6 +1515,8 @@ def test_dispense_0_volume_means_dispense_nothing(
             flow_rate=5.67,
             push_out=None,
             meniscus_tracking=None,
+            end_location=None,
+            end_meniscus_tracking=None,
         ),
         times=1,
     )
@@ -1530,6 +1552,8 @@ def test_aspirate_0_volume_means_aspirate_everything(
             rate=1.23,
             flow_rate=5.67,
             meniscus_tracking=None,
+            end_location=None,
+            end_meniscus_tracking=None,
         ),
         times=1,
     )
@@ -1565,6 +1589,8 @@ def test_aspirate_0_volume_means_aspirate_nothing(
             rate=1.23,
             flow_rate=5.67,
             meniscus_tracking=None,
+            end_location=None,
+            end_meniscus_tracking=None,
         ),
         times=1,
     )
@@ -1596,6 +1622,8 @@ def test_dispense_with_trash_last_location(
             flow_rate=6.7,
             push_out=None,
             meniscus_tracking=None,
+            end_location=None,
+            end_meniscus_tracking=None,
         ),
         times=1,
     )
@@ -1744,6 +1772,8 @@ def test_mix_no_lpd(
             5.67,
             matchers.Anything(),  # first one is not in_place, the other 9 are in_place
             None,
+            None,
+            None,
         ),
         times=10,
     )
@@ -1760,6 +1790,8 @@ def test_mix_no_lpd(
                 True,
                 None,
                 None,
+                None,
+                None,
             ),
             times=10,
         )
@@ -1774,6 +1806,8 @@ def test_mix_no_lpd(
                 True,
                 0.0,
                 None,
+                None,
+                None,
             ),
             times=9,
         )
@@ -1785,6 +1819,8 @@ def test_mix_no_lpd(
                 1.23,
                 5.67,
                 True,
+                None,
+                None,
                 None,
                 None,
             ),
@@ -1839,6 +1875,8 @@ def test_mix_with_lpd(
             5.67,
             matchers.Anything(),  # first one is not in_place, the other 9 are in_place
             None,
+            None,
+            None,
         ),
         times=10,
     )
@@ -1852,6 +1890,8 @@ def test_mix_with_lpd(
             True,
             0.0,
             None,
+            None,
+            None,
         ),
         times=9,
     )
@@ -1863,6 +1903,8 @@ def test_mix_with_lpd(
             1.23,
             5.67,
             True,
+            None,
+            None,
             None,
             None,
         ),
@@ -1907,6 +1949,8 @@ def test_mix_with_flow_rates(
             flow_rate=300.0,
             in_place=True,
             meniscus_tracking=None,
+            end_location=None,
+            end_meniscus_tracking=None,
         ),
         mock_instrument_core.dispense(
             location=input_location,
@@ -1917,6 +1961,8 @@ def test_mix_with_flow_rates(
             in_place=True,
             push_out=None,
             meniscus_tracking=None,
+            end_location=None,
+            end_meniscus_tracking=None,
         ),
     )
 
@@ -1950,6 +1996,8 @@ def test_mix_with_flow_rates(
             flow_rate=300.0,
             in_place=True,
             meniscus_tracking=None,
+            end_location=None,
+            end_meniscus_tracking=None,
         ),
         mock_instrument_core.dispense(
             location=input_location,
@@ -1960,6 +2008,8 @@ def test_mix_with_flow_rates(
             in_place=True,
             push_out=None,
             meniscus_tracking=None,
+            end_location=None,
+            end_meniscus_tracking=None,
         ),
     )
 
@@ -1998,6 +2048,8 @@ def test_mix_with_delay_and_final_push_out(
             flow_rate=4.56,
             in_place=True,
             meniscus_tracking=None,
+            end_location=None,
+            end_meniscus_tracking=None,
         ),
         mock_protocol_core.delay(3, msg=None),  # aspirate delay
         mock_instrument_core.dispense(
@@ -2009,6 +2061,8 @@ def test_mix_with_delay_and_final_push_out(
             in_place=True,
             push_out=0.0,
             meniscus_tracking=None,
+            end_location=None,
+            end_meniscus_tracking=None,
         ),
         mock_protocol_core.delay(4, msg=None),  # dispense delay
         mock_instrument_core.aspirate(
@@ -2019,6 +2073,8 @@ def test_mix_with_delay_and_final_push_out(
             flow_rate=4.56,
             in_place=True,
             meniscus_tracking=None,
+            end_location=None,
+            end_meniscus_tracking=None,
         ),
         mock_protocol_core.delay(3, msg=None),  # aspirate delay
         mock_instrument_core.dispense(
@@ -2030,6 +2086,8 @@ def test_mix_with_delay_and_final_push_out(
             in_place=True,
             push_out=2,  # final push out
             meniscus_tracking=None,
+            end_location=None,
+            end_meniscus_tracking=None,
         ),
         mock_protocol_core.delay(4, msg=None),  # dispense delay
     )
@@ -2075,6 +2133,8 @@ def test_aspirate_with_lpd(
             1.23,
             5.67,
             False,
+            None,
+            None,
             None,
         ),
         times=1,


### PR DESCRIPTION

# Overview
Hook up end location to the protocol api layer. 

- update all the tests
- add in a check for the old dynamic pipetting version and use the new version to preserve behavior
- pass start and end locations down to the engine commands.