### PR TITLE
fix(protocol-designer): stacking icon svg size fix

### DIFF
--- a/components/src/organisms/DeckLabelSet/index.tsx
+++ b/components/src/organisms/DeckLabelSet/index.tsx
@@ -42,6 +42,9 @@ const DeckLabelSetComponent = (
     <RobotCoordsForeignDiv
       x={x}
       y={y}
+      //  +5 to leave room for the deck info label
+      width={showBorder ? '100%' : width + 5}
+      height={showBorder ? '100%' : height + 5}
       innerDivProps={{
         transform: `rotate(180deg) scaleX(-1) scaleY(${invert ? '-1' : '1'})`,
       }}

--- a/protocol-designer/src/pages/Designer/LabwareLabel.tsx
+++ b/protocol-designer/src/pages/Designer/LabwareLabel.tsx
@@ -1,16 +1,16 @@
-import { useEffect, useRef, useState } from 'react'
-import { useSelector } from 'react-redux'
+import { value useEffect, value useRef, value useState } from 'react'
+import { value useSelector } from 'react-redux'
 
-import { DeckLabelSet } from '@opentrons/components'
+import { value DeckLabelSet } from '@opentrons/components'
 
-import { selectors } from '../../labware-ingred/selectors'
-import { START_TERMINAL_ITEM_ID } from '../../steplist'
-import { getSelectedTerminalItemId } from '../../ui/steps'
+import { value selectors } from '../../labware-ingred/selectors'
+import { value START_TERMINAL_ITEM_ID } from '../../steplist'
+import { value getSelectedTerminalItemId } from '../../ui/steps'
 
-import type { DeckLabelProps } from '@opentrons/components'
+import type { value DeckLabelProps } from '@opentrons/components'
 import type {
-  CoordinateTuple,
-  LabwareDefinition2,
+  value CoordinateTuple,
+  value LabwareDefinition2,
 } from '@opentrons/shared-data'
 
 //  NOTE: the deck riser needs special values because the
@@ -29,7 +29,6 @@ interface LabwareLabelProps {
   showModuleIcon: boolean
   nestedLabwareInfo?: DeckLabelProps[]
   labelText?: string
-  showBorder?: boolean
 }
 export const LabwareLabel = (props: LabwareLabelProps): JSX.Element => {
   const {
@@ -40,7 +39,6 @@ export const LabwareLabel = (props: LabwareLabelProps): JSX.Element => {
     showModuleIcon,
     nestedLabwareInfo = [],
     labelText = labwareDef.metadata.displayName,
-    showBorder = true
   } = props
   const labelContainerRef = useRef<HTMLDivElement>(null)
   const selectedSlotInfo = useSelector(selectors.getZoomedInSlotInfo)
@@ -86,7 +84,6 @@ export const LabwareLabel = (props: LabwareLabelProps): JSX.Element => {
         (showDeckRiserAdjustments ? DECK_RISER_ADJUSTED_Z_DIMENSION : 0)
       }
       showModuleIcon={showModuleIcon}
-      showBorder={showBorder}
     />
   )
 }

--- a/protocol-designer/src/pages/Designer/LabwareLabel.tsx
+++ b/protocol-designer/src/pages/Designer/LabwareLabel.tsx
@@ -29,6 +29,7 @@ interface LabwareLabelProps {
   showModuleIcon: boolean
   nestedLabwareInfo?: DeckLabelProps[]
   labelText?: string
+  showBorder?: boolean
 }
 export const LabwareLabel = (props: LabwareLabelProps): JSX.Element => {
   const {
@@ -39,6 +40,7 @@ export const LabwareLabel = (props: LabwareLabelProps): JSX.Element => {
     showModuleIcon,
     nestedLabwareInfo = [],
     labelText = labwareDef.metadata.displayName,
+    showBorder = true
   } = props
   const labelContainerRef = useRef<HTMLDivElement>(null)
   const selectedSlotInfo = useSelector(selectors.getZoomedInSlotInfo)
@@ -84,6 +86,7 @@ export const LabwareLabel = (props: LabwareLabelProps): JSX.Element => {
         (showDeckRiserAdjustments ? DECK_RISER_ADJUSTED_Z_DIMENSION : 0)
       }
       showModuleIcon={showModuleIcon}
+      showBorder={showBorder}
     />
   )
 }

--- a/protocol-designer/src/pages/Designer/LabwareLabel.tsx
+++ b/protocol-designer/src/pages/Designer/LabwareLabel.tsx
@@ -1,16 +1,16 @@
-import { value useEffect, value useRef, value useState } from 'react'
-import { value useSelector } from 'react-redux'
+import { useEffect, useRef, useState } from 'react'
+import { useSelector } from 'react-redux'
 
-import { value DeckLabelSet } from '@opentrons/components'
+import { DeckLabelSet } from '@opentrons/components'
 
-import { value selectors } from '../../labware-ingred/selectors'
-import { value START_TERMINAL_ITEM_ID } from '../../steplist'
-import { value getSelectedTerminalItemId } from '../../ui/steps'
+import { selectors } from '../../labware-ingred/selectors'
+import { START_TERMINAL_ITEM_ID } from '../../steplist'
+import { getSelectedTerminalItemId } from '../../ui/steps'
 
-import type { value DeckLabelProps } from '@opentrons/components'
+import type { DeckLabelProps } from '@opentrons/components'
 import type {
-  value CoordinateTuple,
-  value LabwareDefinition2,
+  CoordinateTuple,
+  LabwareDefinition2,
 } from '@opentrons/shared-data'
 
 //  NOTE: the deck riser needs special values because the


### PR DESCRIPTION
closes RQA-4757

# Overview

This issue is that the stacking icon svg layer when zoomed out of the deck during deck setup was huge! so it covered other slots sometimes (depending on the slot), which meant that you couldn't interact with the neighboring slots.

The issue was with `deckLabelSet`. We didn't notice it before because that component was always used when you couldn't interact with other slots on the deck (like zoomed into the slot or creating a step). So i added branching logic that whenever you don't show the the border for `deckLabelSet`, you also set a certain width and height for the svg layer. Not the cleanest fix but we don't have much time to do this correctly 😬 

## Test Plan and Hands on Testing

Smoke test adding a lid stack and seeing that you can click on neighboring slots normally

## Changelog

fix svg layer size

## Risk assessment

low
