### PR TITLE
fix(protocol-designer): populate labwareId correclty for custom labware

### DIFF
--- a/protocol-designer/src/step-forms/reducers/index.ts
+++ b/protocol-designer/src/step-forms/reducers/index.ts
@@ -1202,7 +1202,7 @@ export const labwareInvariantProperties: Reducer<
           const latestLabwareId =
             latestDefURI != null
               ? `${labwareIdString}:${latestDefURI}`
-              : labwareDefURI
+              :`${labwareIdString}:${labwareDefURI}`
 
           acc[latestLabwareId] = {
             labwareDefURI: latestDefURI ?? labwareDefURI,

--- a/protocol-designer/src/step-forms/reducers/index.ts
+++ b/protocol-designer/src/step-forms/reducers/index.ts
@@ -1202,7 +1202,7 @@ export const labwareInvariantProperties: Reducer<
           const latestLabwareId =
             latestDefURI != null
               ? `${labwareIdString}:${latestDefURI}`
-              :`${labwareIdString}:${labwareDefURI}`
+              : `${labwareIdString}:${labwareDefURI}`
 
           acc[latestLabwareId] = {
             labwareDefURI: latestDefURI ?? labwareDefURI,


### PR DESCRIPTION
closes RQA-4754

# Overview

the labware entities for custom labware when importing a protocol was accidentally not including the uuid string as part of the labware id which caused a bunch of white screens down the line for matching that labware id with a labware def. So i fixed it, this  has probably existed in production for 3 months (when the code was last changed).

## Test Plan and Hands on Testing

Import protocol attached to the ticket, see that it doesn't whitescreen anymore

## Changelog

add the labware id string before the labware def uri for custom labware

## Risk assessment

low
