### PR TITLE
fix(protocol-designer): when changing pipettes, delete only old tips …

### DIFF
--- a/protocol-designer/src/components/organisms/EditInstrumentsModal/editPipettes.ts
+++ b/protocol-designer/src/components/organisms/EditInstrumentsModal/editPipettes.ts
@@ -3,7 +3,7 @@ import isEmpty from 'lodash/isEmpty'
 import last from 'lodash/last'
 import mapValues from 'lodash/mapValues'
 
-import { FLEX_96_CHANNEL_PIPETTES } from '@opentrons/shared-data'
+import { FLEX_96_CHANNEL_PIPETTES, getIsTiprack } from '@opentrons/shared-data'
 
 import { INITIAL_DECK_SETUP_STEP_ID } from '/protocol-designer/constants'
 import { getOnlyLatestDefs } from '/protocol-designer/labware-defs'
@@ -215,7 +215,10 @@ export const editPipettes = (
   const newTiprackUriArray = Array.from(newTiprackUris)
 
   const oldEntities = Object.values(labware).filter(
-    ({ labwareDefURI }) => !newTiprackUriArray.includes(labwareDefURI)
+    ({ labwareDefURI, def }) =>
+      !newTiprackUriArray.includes(labwareDefURI) &&
+      (getIsTiprack(def) ||
+        def.parameters.quirks?.includes('tiprackAdapterFor96Channel'))
   )
   // substitute deleted pipettes with new pipettes on the same mount, if any
   if (!isEmpty(substitutionMap) && orderedStepIds.length > 0) {


### PR DESCRIPTION
…& adapters

closes RQA-4752 RQA-4753

# Overview

So before there was a bug where when you change pipettes, the old tiprack and 96 channel adapter (if applicable) wasn't getting deleted. So i fixed it but it wasn't specific enough, i fixed it initially to delete all labware on deck that weren't listed in the new pipette's tiprack list. Here, i modified the logic to make sure that you are deleting on the old tiprack defs and 96 channel adapter defs, not all the old defs lol

## Test Plan and Hands on Testing

Upload a protocol with steps and labware and then change the pipette. see that only the old tipracks get deleted.

## Changelog

more robust filtering to make sure you aren't deleting all old labware

## Risk assessment

low
