### PR TITLE
fix(protocol-designer): fix continue logic for OT-2

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepFormToolbox.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepFormToolbox.tsx
@@ -378,38 +378,53 @@ export function StepFormToolbox(props: StepFormToolboxProps): JSX.Element {
   // For consistency and correct error rendering, we actually want the OT-2 mix/moveLiquid steps to contain 3 pages,
   // even though only 2 are shown to the user (liquid class selection omitted).
   // We will use this variable to determine the correct step stride and title page count.
+  const isLiquidHandlingStepType =
+    formData.stepType === 'moveLiquid' || formData.stepType === 'mix'
   const isToolboxIndexTransformNeeded =
-    robotType === OT2_ROBOT_TYPE &&
-    (formData.stepType === 'moveLiquid' || formData.stepType === 'mix')
+    robotType === OT2_ROBOT_TYPE && isLiquidHandlingStepType
 
   const strideForContinueOrBack = isToolboxIndexTransformNeeded ? 2 : 1
+
+  // Require confirmation for a liquid handling step, page 1 on OT-2 or page 2 on Flex
+  const isOnPageRequiringConfirmation =
+    toolboxStep === (robotType === FLEX_ROBOT_TYPE ? 1 : 0) &&
+    isLiquidHandlingStepType
+
   const handleContinue = (): void => {
-    if (
-      // for OT-2, call continue logic after step 1 (pipette, tiprack, volume, etc.) rather than step 2 (liquid class selection)
-      toolboxStep === (robotType === FLEX_ROBOT_TYPE ? 1 : 0) &&
-      numStepFormPages > 2
-    ) {
-      if (isConfirmationRequired) {
-        setShowConfirmationModal(true)
+    // Early return for confirmation modal
+    if (isOnPageRequiringConfirmation && isConfirmationRequired) {
+      setShowConfirmationModal(true)
+      return
+    }
+
+    // Handle error cases
+    if (isErrorOnCurrentPage) {
+      setShowFormErrors(true)
+      handleScrollToTop()
+      return
+    }
+
+    // Handle page requiring confirmation (without modal)
+    if (isOnPageRequiringConfirmation) {
+      if (!hasSeenAdvancedSettings && currentFormIsPresaved) {
+        handleUpdateLiquidClassValues()
       } else {
-        if (!hasSeenAdvancedSettings && currentFormIsPresaved) {
-          // don't overwrite values for saved form
-          handleUpdateLiquidClassValues()
-        } else {
-          setToolboxStep(currentStep => currentStep + strideForContinueOrBack)
-        }
-      }
-    } else if (isMultiStepToolbox && toolboxStep < numStepFormPages - 1) {
-      if (!isErrorOnCurrentPage) {
         setToolboxStep(currentStep => currentStep + strideForContinueOrBack)
-        setShowFormErrors(false)
-      } else {
-        setShowFormErrors(true)
       }
       handleScrollToTop()
-    } else {
-      handleSaveClick()
+      return
     }
+
+    // Handle multi-step toolbox with more pages
+    if (isMultiStepToolbox && toolboxStep < numStepFormPages - 1) {
+      setToolboxStep(currentStep => currentStep + strideForContinueOrBack)
+      setShowFormErrors(false)
+      handleScrollToTop()
+      return
+    }
+
+    // Handle final page
+    handleSaveClick()
   }
 
   const handleBack = (): void => {

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepFormToolbox.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepFormToolbox.tsx
@@ -384,11 +384,11 @@ export function StepFormToolbox(props: StepFormToolboxProps): JSX.Element {
     robotType === OT2_ROBOT_TYPE && isLiquidHandlingStepType
 
   const strideForContinueOrBack = isToolboxIndexTransformNeeded ? 2 : 1
+  const pageIndexRequiringConfirmation = robotType === FLEX_ROBOT_TYPE ? 1 : 0
 
   // Require confirmation for a liquid handling step, page 1 on OT-2 or page 2 on Flex
   const isOnPageRequiringConfirmation =
-    toolboxStep === (robotType === FLEX_ROBOT_TYPE ? 1 : 0) &&
-    isLiquidHandlingStepType
+    toolboxStep === pageIndexRequiringConfirmation && isLiquidHandlingStepType
 
   const handleContinue = (): void => {
     // Early return for confirmation modal


### PR DESCRIPTION
# Overview

This PR fixes up `handleContinue` logic, specifically for OT-2 liquid handling forms. Here, I correctly display errors if clicking 'continue' when errors exist on the current page of the stepform, whereas previously, clicking 'continue' advanced the stepform page with null values, resulting in a whitescreen. I also refactor the `handleContinue` logic for readability.

Closes RQA-4759

## Test Plan and Hands on Testing

- unzip and import [this protocol](https://github.com/user-attachments/files/22930707/waah.py.zip)
- create a transfer/mix form and verify that clicking continue without filling in required fields results in errors being shown
- resolve the errors and verify 'continue' moves you to the next page

## Changelog

- fix `handleContinue` logic for OT-2
- refactor for readability

## Review requests

see test plan

## Risk assessment

mediumish. Fixes a longstanding bug for OT-2 presumably introduced during Liquid Class release, but touches core continue logic. I smoke tested thoroughly for Flex/OT-2 presaved/saved step forms successfully.