### PR TITLE
feat(robot-server): initialize `images` directory

### DIFF
--- a/robot-server/opentrons-robot-server.service
+++ b/robot-server/opentrons-robot-server.service
@@ -25,7 +25,7 @@ ExecStart=uvicorn robot_server.app:app --uds /run/aiohttp.sock --ws wsproto --li
 Environment=OT_SMOOTHIE_ID=AMA
 Environment=RUNNING_ON_PI=true
 Environment=OT_ROBOT_SERVER_persistence_directory=/data/opentrons_robot_server
-Environment=OT_ROBOT_SERVER_persistence_directory=/data/opentrons_robot_server/images
+Environment=OT_ROBOT_SERVER_persistence_directory=/data/images
 
 Restart=on-failure
 TimeoutStartSec=10min

--- a/robot-server/opentrons-robot-server.service
+++ b/robot-server/opentrons-robot-server.service
@@ -25,7 +25,7 @@ ExecStart=uvicorn robot_server.app:app --uds /run/aiohttp.sock --ws wsproto --li
 Environment=OT_SMOOTHIE_ID=AMA
 Environment=RUNNING_ON_PI=true
 Environment=OT_ROBOT_SERVER_persistence_directory=/data/opentrons_robot_server
-Environment=OT_ROBOT_SERVER_persistence_directory=/data/images
+Environment=OT_ROBOT_SERVER_persistence_directory=/data/opentrons_robot_server/images
 
 Restart=on-failure
 TimeoutStartSec=10min

--- a/robot-server/opentrons-robot-server.service
+++ b/robot-server/opentrons-robot-server.service
@@ -25,6 +25,7 @@ ExecStart=uvicorn robot_server.app:app --uds /run/aiohttp.sock --ws wsproto --li
 Environment=OT_SMOOTHIE_ID=AMA
 Environment=RUNNING_ON_PI=true
 Environment=OT_ROBOT_SERVER_persistence_directory=/data/opentrons_robot_server
+Environment=OT_ROBOT_SERVER_persistence_directory=/data/images
 
 Restart=on-failure
 TimeoutStartSec=10min

--- a/robot-server/robot_server/app_setup.py
+++ b/robot-server/robot_server/app_setup.py
@@ -19,6 +19,7 @@ from .hardware import (
 from .persistence.fastapi_dependencies import (
     start_initializing_persistence,
     clean_up_persistence,
+    initialize_images_directory,
 )
 from .router import router
 from .service.logging import initialize_logging
@@ -70,6 +71,10 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             ],
         )
         exit_stack.push_async_callback(clean_up_hardware, app.state)
+
+        await initialize_images_directory(
+            app_state=app.state, images_directory_root=settings.images_directory
+        )
 
         start_initializing_persistence(
             app_state=app.state,

--- a/robot-server/robot_server/persistence/fastapi_dependencies.py
+++ b/robot-server/robot_server/persistence/fastapi_dependencies.py
@@ -25,6 +25,7 @@ from .persistence_directory import (
     prepare_active_subdirectory,
     prepare_root,
 )
+from .images_directory import prepare_images_directory
 
 
 _log = logging.getLogger(__name__)
@@ -39,6 +40,7 @@ _active_persistence_directory_init_task_accessor = AppStateAccessor[
 _sql_engine_init_task_accessor = AppStateAccessor["asyncio.Task[SQLEngine]"](
     "persistence_sql_engine_init_task"
 )
+_images_directory_accessor = AppStateAccessor[Path]("images_directory")
 
 
 class DatabaseNotYetInitialized(ErrorDetails):
@@ -288,3 +290,34 @@ async def get_persistence_resetter(
 ) -> PersistenceResetter:
     """Get a `PersistenceResetter` to reset the robot-server's stored data."""
     return PersistenceResetter(directory_to_reset)
+
+
+async def initialize_images_directory(
+    app_state: AppState,
+    images_directory_root: Optional[Path],
+) -> None:
+    """Initialize the images directory and store it in app state.
+
+    This should be called exactly once, as part of server startup.
+    """
+    assert (
+        _images_directory_accessor.get_from(app_state) is None
+    ), "Cannot initialize images directory more than once."
+
+    try:
+        prepared_directory = await prepare_images_directory(images_directory_root)
+        _images_directory_accessor.set_on(app_state=app_state, value=prepared_directory)
+    except Exception:
+        _log.exception("Exception initializing images directory.")
+        raise
+
+
+async def get_images_directory(
+    app_state: Annotated[AppState, Depends(get_app_state)],
+) -> Path:
+    """Return the path to the server's images directory."""
+    images_directory = _images_directory_accessor.get_from(app_state)
+    assert (
+        images_directory is not None
+    ), "Forgot to initialize images directory as part of server startup?"
+    return images_directory

--- a/robot-server/robot_server/persistence/fastapi_dependencies.py
+++ b/robot-server/robot_server/persistence/fastapi_dependencies.py
@@ -25,8 +25,7 @@ from .persistence_directory import (
     prepare_active_subdirectory,
     prepare_root,
 )
-from .images_directory import prepare_images_directory
-
+from .images_directory import prepare_images_directory, ImagesResetter
 
 _log = logging.getLogger(__name__)
 
@@ -312,7 +311,7 @@ async def initialize_images_directory(
         raise
 
 
-async def get_images_directory(
+async def _get_images_directory(
     app_state: Annotated[AppState, Depends(get_app_state)],
 ) -> Path:
     """Return the path to the server's images directory."""
@@ -321,3 +320,10 @@ async def get_images_directory(
         images_directory is not None
     ), "Forgot to initialize images directory as part of server startup?"
     return images_directory
+
+
+async def get_images_resetter(
+    directory_to_reset: Annotated[Path, Depends(_get_images_directory)],
+) -> ImagesResetter:
+    """Get an `ImagesResetter` to reset the robot-server's stored data."""
+    return ImagesResetter(directory_to_reset)

--- a/robot-server/robot_server/persistence/images_directory.py
+++ b/robot-server/robot_server/persistence/images_directory.py
@@ -3,14 +3,42 @@
 from pathlib import Path
 from logging import getLogger
 from tempfile import mkdtemp
+from shutil import rmtree
 from typing import Optional
 from typing_extensions import Final
 
-from anyio import Path as AsyncPath
+from anyio import Path as AsyncPath, to_thread
 
-_TEMP_IMAGES_DIR_PREFIX: Final = "opentrons-robot-server-images-"
 
 _log = getLogger(__name__)
+
+
+_TEMP_IMAGES_DIR_PREFIX: Final = "opentrons-robot-server-images-"
+_RESET_MARKER_FILE_NAME: Final = "_TO_BE_DELETED_ON_REBOOT"
+_RESET_MARKER_FILE_CONTENTS: Final = """\
+This file was placed here by robot-server.
+It tells robot-server to clear this directory on the next boot,
+after which it will delete this file.
+"""
+
+
+# TODO(jh, 10-16-25): Much of this logic overlaps with the persistence directory lifecycle logic. Can we unify?
+class ImagesResetter:
+    """A FastAPI dependency to reset the server's image directory."""
+
+    def __init__(self, directory_to_reset: Path) -> None:
+        self._directory_to_reset = directory_to_reset
+
+    async def mark_directory_reset(self) -> None:
+        """Mark the directory to be deleted (reset) on the next boot.
+
+        We defer deletions to the next boot instead of doing them immediately
+        in order to avoid ongoing HTTP requests, runs, background protocol analysis
+        tasks, etc. trying to do stuff in the persistence directory during and after
+        the deletion.
+        """
+        file = AsyncPath(self._directory_to_reset / _RESET_MARKER_FILE_NAME)
+        await file.write_text(encoding="utf-8", data=_RESET_MARKER_FILE_CONTENTS)
 
 
 async def prepare_images_directory(images_directory: Optional[Path]) -> Path:
@@ -31,6 +59,19 @@ async def prepare_images_directory(images_directory: Optional[Path]) -> Path:
         )
         return new_temporary_directory
     else:
+        if await _is_marked_for_reset(directory_to_reset=images_directory):
+            _log.info(f"{images_directory} was marked for reset. Deleting it.")
+            # FIXME(jh, 2025-10-16): Like the persistance dir, this can leave the images dir
+            # in a half-deleted state if it deletes the marker file, and then some
+            # of the other files, and then the device is power-cycled before it can
+            # finish.
+            await to_thread.run_sync(rmtree, images_directory)
+
         await AsyncPath(images_directory).mkdir(parents=True, exist_ok=True)
         _log.info(f"Using directory {images_directory} for images.")
         return images_directory
+
+
+async def _is_marked_for_reset(directory_to_reset: Path) -> bool:
+    """Return whether the images directory has been marked to be reset."""
+    return await (AsyncPath(directory_to_reset) / _RESET_MARKER_FILE_NAME).exists()

--- a/robot-server/robot_server/persistence/images_directory.py
+++ b/robot-server/robot_server/persistence/images_directory.py
@@ -1,0 +1,36 @@
+"""Prepare the server's images directory."""
+
+from pathlib import Path
+from logging import getLogger
+from tempfile import mkdtemp
+from typing import Optional
+from typing_extensions import Final
+
+from anyio import Path as AsyncPath
+
+_TEMP_IMAGES_DIR_PREFIX: Final = "opentrons-robot-server-images-"
+
+_log = getLogger(__name__)
+
+
+async def prepare_images_directory(images_directory: Optional[Path]) -> Path:
+    """Return `images_directory` after preparing it, if necessary.
+
+    This will create the directory if it doesn't already exist.
+
+    If `images_directory` is `None`, this will return a fresh temporary
+    directory.
+    """
+    if images_directory is None:
+        # It's bad for this blocking I/O to be in this async function,
+        # but we don't have an async mkdtemp().
+        new_temporary_directory = Path(mkdtemp(prefix=_TEMP_IMAGES_DIR_PREFIX))
+        _log.info(
+            f"Using auto-created temporary directory {new_temporary_directory}"
+            f" for images."
+        )
+        return new_temporary_directory
+    else:
+        await AsyncPath(images_directory).mkdir(parents=True, exist_ok=True)
+        _log.info(f"Using directory {images_directory} for images.")
+        return images_directory

--- a/robot-server/robot_server/service/legacy/routers/settings.py
+++ b/robot-server/robot_server/service/legacy/routers/settings.py
@@ -54,8 +54,10 @@ from robot_server.service.legacy.models.settings import (
 )
 from robot_server.persistence.fastapi_dependencies import (
     get_persistence_resetter,
+    get_images_resetter,
 )
 from robot_server.persistence.persistence_directory import PersistenceResetter
+from robot_server.persistence.images_directory import ImagesResetter
 from opentrons_shared_data.robot.types import RobotTypeEnum
 
 log = logging.getLogger(__name__)
@@ -248,6 +250,7 @@ async def post_settings_reset_options(
     persistence_resetter: Annotated[
         PersistenceResetter, Depends(get_persistence_resetter)
     ],
+    images_resetter: Annotated[ImagesResetter, Depends(get_images_resetter)],
     deck_configuration_store: Annotated[
         Optional[DeckConfigurationStore], Depends(get_deck_configuration_store_failsafe)
     ],
@@ -274,6 +277,7 @@ async def post_settings_reset_options(
 
     if factory_reset_commands.get(reset_util.ResetOptionId.runs_history, False):
         await persistence_resetter.mark_directory_reset()
+        await images_resetter.mark_directory_reset()
 
     if factory_reset_commands.get(reset_util.ResetOptionId.on_device_display, False):
         await reset_odd.mark_odd_for_reset_next_boot()

--- a/robot-server/robot_server/settings.py
+++ b/robot-server/robot_server/settings.py
@@ -74,6 +74,16 @@ class RobotServerSettings(BaseSettings):
         ),
     )
 
+    images_directory: typing.Optional[Path] = Field(
+        default=None,
+        description=(
+            "A directory for the server to store captured images."
+            " If this directory doesn't already exist, the server will create it."
+            " If no directory is supplied, the server will use a fresh temporary directory"
+            " (effectively not persisting anything)."
+        ),
+    )
+
     maximum_runs: int = Field(
         default=20,
         gt=0,

--- a/robot-server/settings_schema.json
+++ b/robot-server/settings_schema.json
@@ -6,32 +6,24 @@
     "simulator_configuration_file_path": {
       "title": "Simulator Configuration File Path",
       "description": "Path to a json file that describes the hardware simulator.",
-      "env_names": [
-        "ot_robot_server_simulator_configuration_file_path"
-      ],
+      "env_names": ["ot_robot_server_simulator_configuration_file_path"],
       "type": "string"
     },
     "notification_server_subscriber_address": {
       "title": "Notification Server Subscriber Address",
       "description": "The endpoint to subscribe to notification server topics.",
       "default": "tcp://localhost:5555",
-      "env_names": [
-        "ot_robot_server_notification_server_subscriber_address"
-      ],
+      "env_names": ["ot_robot_server_notification_server_subscriber_address"],
       "type": "string"
     },
     "persistence_directory": {
       "title": "Persistence Directory",
       "description": "A directory for the server to store things persistently across boots. If this directory doesn't already exist, the server will create it. If this is the string `automatically_make_temporary`, the server will use a fresh temporary directory (effectively not persisting anything).\n\nNote that the `opentrons` library is also responsible for persisting certain things, and it has its own configuration.",
       "default": "automatically_make_temporary",
-      "env_names": [
-        "ot_robot_server_persistence_directory"
-      ],
+      "env_names": ["ot_robot_server_persistence_directory"],
       "anyOf": [
         {
-          "enum": [
-            "automatically_make_temporary"
-          ],
+          "enum": ["automatically_make_temporary"],
           "type": "string"
         },
         {
@@ -40,14 +32,19 @@
         }
       ]
     },
+    "images_directory": {
+      "title": "Images Directory",
+      "description": "A directory for the server to store captured images. If this directory doesn't already exist, the server will create it. If no directory is supplied, the server will use a fresh temporary directory (effectively not persisting anything).",
+      "env_names": ["ot_robot_server_images_directory"],
+      "type": "string",
+      "format": "path"
+    },
     "maximum_runs": {
       "title": "Maximum Runs",
       "description": "The maximum number of runs to allow HTTP clients to create before auto-deleting old ones.",
       "default": 20,
       "exclusiveMinimum": 0,
-      "env_names": [
-        "ot_robot_server_maximum_runs"
-      ],
+      "env_names": ["ot_robot_server_maximum_runs"],
       "type": "integer"
     },
     "maximum_unused_protocols": {
@@ -55,9 +52,7 @@
       "description": "The maximum number of \"unused protocols\" to allow before auto-deleting old ones. A protocol is \"unused\" if it isn't used by any run that currently exists.",
       "default": 5,
       "exclusiveMinimum": 0,
-      "env_names": [
-        "ot_robot_server_maximum_unused_protocols"
-      ],
+      "env_names": ["ot_robot_server_maximum_unused_protocols"],
       "type": "integer"
     },
     "maximum_quick_transfer_protocols": {
@@ -65,9 +60,7 @@
       "description": "The maximum number of \"quick transfer protocols\" to allow before auto-deleting old ones.",
       "default": 20,
       "exclusiveMinimum": 0,
-      "env_names": [
-        "ot_robot_server_maximum_quick_transfer_protocols"
-      ],
+      "env_names": ["ot_robot_server_maximum_quick_transfer_protocols"],
       "type": "integer"
     },
     "maximum_data_files": {
@@ -75,9 +68,7 @@
       "description": "The maximum number of data files to allow before auto-deleting old ones.",
       "default": 50,
       "exclusiveMinimum": 0,
-      "env_names": [
-        "ot_robot_server_maximum_data_files"
-      ],
+      "env_names": ["ot_robot_server_maximum_data_files"],
       "type": "integer"
     }
   },

--- a/robot-server/tests/service/legacy/routers/test_settings.py
+++ b/robot-server/tests/service/legacy/routers/test_settings.py
@@ -24,7 +24,11 @@ from robot_server.deck_configuration.fastapi_dependencies import (
 )
 from robot_server.deck_configuration.store import DeckConfigurationStore
 from robot_server.persistence.persistence_directory import PersistenceResetter
-from robot_server.persistence.fastapi_dependencies import get_persistence_resetter
+from robot_server.persistence.images_directory import ImagesResetter
+from robot_server.persistence.fastapi_dependencies import (
+    get_persistence_resetter,
+    get_images_resetter,
+)
 
 
 def test_get_robot_settings(api_client, hardware):
@@ -512,6 +516,20 @@ def mock_persistence_resetter(
 
 
 @pytest.fixture
+def mock_images_resetter(
+    decoy: Decoy,
+) -> Generator[ImagesResetter, None, None]:
+    mock_images_resetter = decoy.mock(cls=ImagesResetter)
+
+    async def mock_get_images_resetter() -> ImagesResetter:
+        return mock_images_resetter
+
+    app.dependency_overrides[get_images_resetter] = mock_get_images_resetter
+    yield mock_images_resetter
+    del app.dependency_overrides[get_images_resetter]
+
+
+@pytest.fixture
 def mock_deck_configuration_store_failsafe(
     decoy: Decoy,
 ) -> Generator[Optional[DeckConfigurationStore], None, None]:
@@ -580,6 +598,7 @@ def test_reset_success(
     api_client,
     mock_reset,
     mock_persistence_resetter: PersistenceResetter,
+    mock_images_resetter: ImagesResetter,
     mock_deck_configuration_store_failsafe: Optional[DeckConfigurationStore],
     body,
     called_with,
@@ -593,6 +612,7 @@ def test_reset_invalid_option(
     api_client,
     mock_reset,
     mock_persistence_resetter,
+    mock_images_resetter,
     mock_deck_configuration_store_failsafe,
 ):
     resp = api_client.post("/settings/reset", json={"aksgjajhadjasl": False})


### PR DESCRIPTION
Closes [EXEC-1969](https://opentrons.atlassian.net/browse/EXEC-1969)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

For the upcoming camera capture work, we'll need to persist image files on the robot. We don't want to handle saving images in our persistence directory, because doing so opens up issues when performing database migrations.

This PR adds a new robot setting, `images_directory`, which allows for specifying the directory in which images will be saved. We largely mirror the behavior of `persistence_directory` here: if no explicit env is passed, we create a temporary directory. By default via settings injection, if the persistence directory is `/data/opentrons_robot_server`, then the images directory is analogously specified as `/data/images`.

This PR has an oe-core analog found [here](https://github.com/Opentrons/oe-core/pull/228), which sets the path for the `images` directory in builds. 

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- [Here](https://opentrons.slack.com/archives/C81CR4VCZ/p1760543102361429) is a build based off this branch and the oe-core PR linked above. After uploading the build to a robot, the image directory exists as expected.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- The robot server now initializes the `images` directory during startup.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
lowish - code is pretty easy to audit and follows existing patterns
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[EXEC-1969]: https://opentrons.atlassian.net/browse/EXEC-1969?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ