### PR TITLE
fix(protocol-designer): allow moving of labware<>lid combos

### DIFF
--- a/protocol-designer/src/pages/Designer/utils.ts
+++ b/protocol-designer/src/pages/Designer/utils.ts
@@ -297,6 +297,7 @@ export const useLabwareDropdownOptions = (
       const deckSlot = getSlotInLocationStack(
         deckSetupLabware[labwareId]?.stack
       )
+
       const isOffDeck = deckSlot === 'offDeck'
       const fullStackFromLabwares = getFullStackFromLabwares(
         deckSetupLabware,
@@ -304,6 +305,13 @@ export const useLabwareDropdownOptions = (
         labwareId
       )
       const isTopOfStack = fullStackFromLabwares[0] === labwareId
+      const topId = fullStackFromLabwares[0]
+      const isLabwareLidCombo =
+        (fullStackFromLabwares[1] === labwareId &&
+          labwareEntities[topId]?.def.allowedRoles?.includes('lid') &&
+          !def.allowedRoles?.includes('lid') &&
+          !def.allowedRoles?.includes('adapter')) ??
+        false
       const isLabwareInTrash =
         deckSlot === 'gripperWasteChute' ||
         MOVABLE_TRASH_ADDRESSABLE_AREAS.includes(
@@ -325,12 +333,14 @@ export const useLabwareDropdownOptions = (
         isOffDeck &&
         (type === 'labware' || (type === 'moveLabware' && useGripper))
 
+      //  TODO: refactor this to be easier to read
       const options: DropdownOption[] =
         isAdapter ||
         isLabwareInTrash ||
         (type === 'labware' && (isTiprack || isLid)) ||
         isFilterOffDeck ||
-        !isTopOfStack
+        (type === 'moveLabware' && !isTopOfStack && !isLabwareLidCombo) ||
+        (type === 'labware' && !isTopOfStack)
           ? acc
           : [
               ...acc,


### PR DESCRIPTION
closes RQA-4756

# Overview

Allow for moving labware<>lid or tiprack<>lid combos on the deck

## Test Plan and Hands on Testing

upload attached protocol and see the move labware steps and how it is moving a labware+lid, tiprack+lid, and just a lid. try making a new move labware step and see that you can move the lids by themselves or the lid+labware/tiprack+lid combos

[untitled (60).py](https://github.com/user-attachments/files/22931923/untitled.60.py)


## Changelog

only filter out stack items when its not a a labware<>lid combo

## Risk assessment

low
