### PR TITLE
fix(protocol-designer): fix copy for heater shaker shake field

### DIFF
--- a/protocol-designer/src/assets/localization/en/protocol_steps.json
+++ b/protocol-designer/src/assets/localization/en/protocol_steps.json
@@ -154,6 +154,7 @@
   "select_volume": "Select a volume",
   "select_wells": "Select wells using a {{displayName}}",
   "shake": "Shake",
+  "shake_speed": "Shake speed",
   "single": "Single transfer",
   "single_nozzle": "Single",
   "speed": "Speed",

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/HeaterShakerTools/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/HeaterShakerTools/index.tsx
@@ -78,7 +78,7 @@ export function HeaterShakerTools(props: StepFormProps): JSX.Element {
           toggleValue={propsForFields.setShake.value}
           toggleUpdateValue={propsForFields.setShake.updateValue}
           title={t('form:step_edit_form.field.heaterShaker.shaker.setShake')}
-          fieldTitle={t('protocol_steps:speed')}
+          fieldTitle={t('protocol_steps:shake_speed')}
           isSelected={formData.setShake === true}
           units={t('units.rpm')}
           onLabel={t('form:step_edit_form.field.heaterShaker.shaker.toggleOn')}


### PR DESCRIPTION
# Overview

Update title to match designs: "Shake" -> "Shake speed"

Closes RQA-4731

<img width="341" height="608" alt="Screenshot 2025-10-15 at 12 50 36 PM" src="https://github.com/user-attachments/assets/b3dea7f3-19bf-40b5-884b-18673d943869" />

## Test Plan and Hands on Testing

- create or open a heater shaker form [example protocol](https://github.com/user-attachments/files/22932331/master.json)
- open "shake" field
- verify that title of the field says "Shake speed" instead of "Speed"

## Changelog

- update copy in heater shake shake field

## Review requests

see test plan

## Risk assessment

low