### PR TITLE
feat(step-generation): add missing run log commands to robotState

### DIFF
--- a/step-generation/src/getNextRobotStateAndWarnings/index.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/index.ts
@@ -60,6 +60,7 @@ function _getNextRobotStateAndWarningsSingleCommand(
 ): void {
   assert(command, 'undefined command passed to getNextRobotStateAndWarning')
   switch (command.commandType) {
+    // TODO: add this in case 'aspirateWhileTracking':
     case 'aspirate':
     case 'aspirateInPlace':
       if (command.meta?.isAirGap === true) {
@@ -69,6 +70,7 @@ function _getNextRobotStateAndWarningsSingleCommand(
       }
       break
 
+    // TODO: add this in case 'dispenseWhileTracking':
     case 'dispense':
     case 'dispenseInPlace':
       if (command.meta?.isAirGap === true) {
@@ -106,6 +108,26 @@ function _getNextRobotStateAndWarningsSingleCommand(
       forMoveLabware(command.params, invariantContext, robotStateAndWarnings)
       break
 
+    //  for concurrent modules
+    //  TODO: wire these up if they change state
+    //  for concurrent module support
+    case 'createTimer':
+    case 'waitForTasks':
+      break
+
+    //  for flex stacker
+    //  TODO: wire these up if they change state
+    //  for flex stacker support
+    case 'flexStacker/closeLatch':
+    case 'flexStacker/empty':
+    case 'flexStacker/fill':
+    case 'flexStacker/openLatch':
+    case 'flexStacker/prepareShuttle':
+    case 'flexStacker/retrieve':
+    case 'flexStacker/setStoredLabware':
+    case 'flexStacker/store':
+      break
+
     // the following commands currently don't effect tracked robot state
     case 'touchTip': // pipetting
     case 'configureForVolume':
@@ -127,7 +149,17 @@ function _getNextRobotStateAndWarningsSingleCommand(
     case 'prepareToAspirate':
     case 'liquidProbe':
     case 'loadLiquidClass':
+    case 'loadLidStack':
+    case 'loadLid':
+    case 'getTipPresence':
+    case 'identifyModule':
     case 'getNextTip':
+    case 'retractAxis':
+    case 'sealPipetteToTip':
+    case 'tryLiquidProbe':
+    case 'unsealPipetteFromTip':
+    case 'verifyTipPresence':
+    case 'pressureDispense': //  evo tip specific command
       break
 
     case 'moveToAddressableArea':

--- a/step-generation/src/getNextRobotStateAndWarnings/index.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/index.ts
@@ -363,8 +363,7 @@ function _getNextRobotStateAndWarningsSingleCommand(
     case 'absorbanceReader/read':
       break
     default:
-      assert(
-        false,
+      console.error(
         `unknown command: ${command.commandType} passed to getNextRobotStateAndWarning`
       )
   }


### PR DESCRIPTION
closes AUTH-2391

# Overview

Oof, there are a bunch of commands missing from robot state that can appear in the run log. For now, i just wired them up to not update the robot state at all and left various TODOs. If these commands aren't listed at all, it causes protocol viz to whitescreen if the protocol you are visualizing uses one of the missing commands.

1. the concurrent module commands: left a TODO for @SyntaxColoring to wire them up for concurrent module work
2. the flex stacker commands: left a TODO for @smb2268 to wire them up for Flex stacker work
3. the `aspirateWhileTracking` and `dispenseWhileTracking` commands -> i'm assuming they can update robot state but not sure yet or what all their params are since those commands are still being finalized by @ryanthecoder. Left a follow up ticket to finish wiring up in robot state later: https://opentrons.atlassian.net/browse/AUTH-2401

## Test Plan and Hands on Testing

Review the commands i added

## Changelog

add a bunch of missing commands to step-generation's robot state and leave various TODOs

## Review requests

let me know if i missed a command that can appear in the run. also, should any of the ones i added update the state?

## Risk assessment

low
