### PR TITLE
feat(robot-server, api, shared-data): persist images on the robot

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/absorbance_reader/read.py
+++ b/api/src/opentrons/protocol_engine/commands/absorbance_reader/read.py
@@ -179,7 +179,7 @@ class ReadAbsorbanceImpl(
                     csv_bytes = plate_read_result.build_csv_bytes(
                         measurement=measurement,
                     )
-                    file_id = await self._file_provider.write_file(
+                    file_info = await self._file_provider.write_file(
                         data=csv_bytes,
                         mime_type=MimeType.TEXT_CSV,
                         command_metadata=ReadCmdFileNameMetadata.model_construct(
@@ -187,7 +187,7 @@ class ReadAbsorbanceImpl(
                             wavelength=measurement.wavelength,
                         ),
                     )
-                    file_ids.append(file_id)
+                    file_ids.append(file_info.id)
 
                 state_update.files_added = update_types.FilesAddedUpdate(
                     file_ids=file_ids

--- a/api/src/opentrons/protocol_engine/resources/file_provider.py
+++ b/api/src/opentrons/protocol_engine/resources/file_provider.py
@@ -15,6 +15,7 @@ class MimeType(str, Enum):
     """File mime types."""
 
     TEXT_CSV = "text/csv"
+    IMAGE_JPEG = "image/jpeg"
 
 
 class ReadCmdFileNameMetadata(BaseModel):
@@ -24,7 +25,17 @@ class ReadCmdFileNameMetadata(BaseModel):
     wavelength: int
 
 
-CommandFileNameMetadata = ReadCmdFileNameMetadata | None
+class ImageCaptureCmdFileNameMetadata(BaseModel):
+    """Data from a camera capture command used to build the finalized file name."""
+
+    step_number: int
+    command_timestamp: datetime
+    base_filename: Optional[str]
+
+
+CommandFileNameMetadata = (
+    ReadCmdFileNameMetadata | ImageCaptureCmdFileNameMetadata | None
+)
 
 
 class FileData:

--- a/api/src/opentrons/protocol_engine/resources/file_provider.py
+++ b/api/src/opentrons/protocol_engine/resources/file_provider.py
@@ -5,8 +5,9 @@ from io import StringIO
 import csv
 from typing import List, Optional, Callable, Awaitable, Dict
 from pydantic import BaseModel
-from ..errors import StorageLimitReachedError
+from opentrons_shared_data.data_files import DataFileInfo, DataFileSource
 
+from ..errors import StorageLimitReachedError
 
 MAXIMUM_FILE_LIMIT = 400
 
@@ -150,7 +151,9 @@ class FileProvider:
 
     def __init__(
         self,
-        data_files_write_file_cb: Optional[Callable[[FileData], Awaitable[str]]] = None,
+        data_files_write_file_cb: Optional[
+            Callable[[FileData], Awaitable[DataFileInfo]]
+        ] = None,
         data_files_filecount: Optional[Callable[[], Awaitable[int]]] = None,
     ) -> None:
         """Initialize the interface callbacks of the File Provider for data file handling within the Protocol Engine.
@@ -167,8 +170,8 @@ class FileProvider:
         data: bytes,
         mime_type: MimeType,
         command_metadata: CommandFileNameMetadata = None,
-    ) -> str:
-        """Writes arbitrary data to a file in the Data Files directory. Returns the File ID of the file created."""
+    ) -> DataFileInfo:
+        """Writes arbitrary data to a file in the Data Files directory. Returns the `DataFileInfo` of the file created."""
         if self._data_files_filecount is not None:
             file_count = await self._data_files_filecount()
             if file_count >= MAXIMUM_FILE_LIMIT:
@@ -182,5 +185,11 @@ class FileProvider:
                     command_metadata=command_metadata,
                 )
                 return await self._data_files_write_file_cb(file_data)
-        # If we are in an analysis or simulation state, return an empty file ID
-        return ""
+        # If we are in an analysis or simulation state, return an empty `DataFileInfo`
+        return DataFileInfo(
+            id="",
+            name="",
+            file_hash="",
+            created_at=datetime.now(),
+            source=DataFileSource.GENERATED,
+        )

--- a/robot-server/robot_server/data_files/data_files_store.py
+++ b/robot-server/robot_server/data_files/data_files_store.py
@@ -1,8 +1,6 @@
 """Store and retrieve information about uploaded data files from the database."""
 from __future__ import annotations
 
-from dataclasses import dataclass
-from datetime import datetime
 from pathlib import Path
 from typing import Optional, List, Set
 
@@ -16,19 +14,9 @@ from robot_server.persistence.tables import (
     run_csv_rtp_table,
 )
 from robot_server.persistence.tables import DataFileSourceSQLEnum
+from opentrons_shared_data.data_files import DataFileInfo, DataFileSource
 
-from .models import DataFileSource, FileIdNotFoundError, FileInUseError
-
-
-@dataclass(frozen=True)
-class DataFileInfo:
-    """Metadata info of a saved data file."""
-
-    id: str
-    name: str
-    file_hash: str
-    created_at: datetime
-    source: DataFileSource
+from .models import FileIdNotFoundError, FileInUseError
 
 
 class DataFilesStore:
@@ -158,7 +146,6 @@ class DataFilesStore:
                 transaction.execute(select_ids_used_in_runs).scalars().all()
             )
             if len(files_used_in_analyses) + len(files_used_in_runs) > 0:
-
                 raise FileInUseError(
                     data_file_id=file_id,
                     ids_used_in_runs=files_used_in_runs,

--- a/robot-server/robot_server/data_files/file_auto_deleter.py
+++ b/robot-server/robot_server/data_files/file_auto_deleter.py
@@ -1,8 +1,8 @@
 """Auto-delete old user data files to make room for new ones."""
 from logging import getLogger
 
+from opentrons_shared_data.data_files import DataFileSource
 from robot_server.data_files.data_files_store import DataFilesStore
-from robot_server.data_files.models import DataFileSource
 from robot_server.deletion_planner import DataFileDeletionPlanner
 
 _log = getLogger(__name__)

--- a/robot-server/robot_server/data_files/models.py
+++ b/robot-server/robot_server/data_files/models.py
@@ -1,21 +1,14 @@
 """Data files models."""
 from datetime import datetime
 from typing import Literal, Set
-from enum import Enum
 
 from pydantic import Field
 
 from opentrons_shared_data.errors import GeneralError
+from opentrons_shared_data.data_files import DataFileSource
 
 from robot_server.errors.error_responses import ErrorDetails
 from robot_server.service.json_api import ResourceModel
-
-
-class DataFileSource(Enum):
-    """The source this data file is from."""
-
-    UPLOADED = "uploaded"
-    GENERATED = "generated"
 
 
 class DataFile(ResourceModel):

--- a/robot-server/robot_server/data_files/router.py
+++ b/robot-server/robot_server/data_files/router.py
@@ -21,11 +21,11 @@ from .dependencies import (
     get_data_files_store,
     get_data_file_auto_deleter,
 )
-from .data_files_store import DataFilesStore, DataFileInfo
+from .data_files_store import DataFilesStore
+from opentrons_shared_data.data_files import DataFileInfo, DataFileSource
 from .file_auto_deleter import DataFileAutoDeleter
 from .models import (
     DataFile,
-    DataFileSource,
     FileIdNotFoundError,
     FileIdNotFound,
     FileInUseError,

--- a/robot-server/robot_server/file_provider/fastapi_dependencies.py
+++ b/robot-server/robot_server/file_provider/fastapi_dependencies.py
@@ -4,6 +4,7 @@ from typing import Annotated
 
 import fastapi
 
+from robot_server.persistence.fastapi_dependencies import get_images_directory
 from robot_server.file_provider.provider import FileProviderExecutor
 from robot_server.data_files.dependencies import (
     get_data_files_directory,
@@ -16,10 +17,13 @@ from opentrons.protocol_engine.resources.file_provider import FileProvider
 async def get_file_provider_executor(
     data_files_directory: Annotated[Path, fastapi.Depends(get_data_files_directory)],
     data_files_store: Annotated[DataFilesStore, fastapi.Depends(get_data_files_store)],
+    images_directory: Annotated[Path, fastapi.Depends(get_images_directory)],
 ) -> FileProviderExecutor:
     """Return the server's singleton `FileProviderExecutor` which provides the engine related callbacks for FileProvider."""
     file_provider_wrapper = FileProviderExecutor(
-        data_files_directory=data_files_directory, data_files_store=data_files_store
+        data_files_directory=data_files_directory,
+        data_files_store=data_files_store,
+        images_directory=images_directory,
     )
 
     return file_provider_wrapper

--- a/robot-server/robot_server/file_provider/provider.py
+++ b/robot-server/robot_server/file_provider/provider.py
@@ -115,15 +115,21 @@ class FileProviderExecutor:
             assert self._run_metadata is not None
 
             cmd_metadata = file_data.command_metadata
-            base_name = cmd_metadata.base_filename or ""
+            base_name = (
+                f"{cmd_metadata.base_filename}_" if cmd_metadata.base_filename else ""
+            )
             protocol_name = self._run_metadata.protocol_name or ""
 
             return (
                 base_name
                 + self._run_metadata.robot_name
+                + "_"
                 + protocol_name
+                + "_"
                 + str(self._run_metadata.run_created_at)
+                + "_"
                 + str(cmd_metadata.step_number)
+                + "_"
                 + str(cmd_metadata.command_timestamp)
                 + ".jpeg"
             )

--- a/robot-server/robot_server/file_provider/provider.py
+++ b/robot-server/robot_server/file_provider/provider.py
@@ -1,11 +1,14 @@
 """Executor for Protocol Engine File Provider callbacks."""
 import os
 import asyncio
+import hashlib
 from pathlib import Path
 from typing import Annotated, Optional
 from fastapi import Depends
 from pydantic import BaseModel
 from datetime import datetime
+
+from robot_server.persistence.fastapi_dependencies import get_images_directory
 from robot_server.data_files.dependencies import (
     get_data_files_directory,
     get_data_files_store,
@@ -19,6 +22,7 @@ from robot_server.data_files.data_files_store import (
 from opentrons.protocol_engine.resources.file_provider import (
     FileData,
     ReadCmdFileNameMetadata,
+    ImageCaptureCmdFileNameMetadata,
 )
 
 
@@ -37,6 +41,7 @@ class FileProviderExecutor:
     def __init__(
         self,
         data_files_directory: Annotated[Path, Depends(get_data_files_directory)],
+        images_directory: Annotated[Path, Depends(get_images_directory)],
         data_files_store: Annotated[DataFilesStore, Depends(get_data_files_store)],
     ) -> None:
         """Initialize the file provider executor.
@@ -46,6 +51,7 @@ class FileProviderExecutor:
             data_files_store: The data files store utilized for database interaction when creating files.
         """
         self._data_files_directory = data_files_directory
+        self._images_directory = images_directory
         self._data_files_store = data_files_store
         self._run_metadata: RunFileNameMetadata | None = None
 
@@ -71,6 +77,7 @@ class FileProviderExecutor:
             final_filepath = self._format_filepath(
                 filename=final_filename, file_id=file_id, file_data=file_data
             )
+            md5sum = self._get_md5sum(file_data)
 
             os.makedirs(os.path.dirname(final_filepath), exist_ok=True)
 
@@ -81,7 +88,7 @@ class FileProviderExecutor:
             file_info = DataFileInfo(
                 id=file_id,
                 name=final_filename,
-                file_hash="",
+                file_hash=md5sum,
                 created_at=created_at,
                 source=DataFileSource.GENERATED,
             )
@@ -105,6 +112,23 @@ class FileProviderExecutor:
                 base_name = base_name[:-4]
 
             return base_name + str(metadata.wavelength) + "nm.csv"
+        elif isinstance(file_data.command_metadata, ImageCaptureCmdFileNameMetadata):
+            assert self._run_metadata is not None
+
+            cmd_metadata = file_data.command_metadata
+            base_name = cmd_metadata.base_filename or ""
+            protocol_name = self._run_metadata.protocol_name or ""
+
+            return (
+                base_name
+                + self._run_metadata.robot_name
+                + protocol_name
+                + str(self._run_metadata.run_created_at)
+                + str(cmd_metadata.step_number)
+                + str(cmd_metadata.command_timestamp)
+                + ".jpeg"
+            )
+
         else:
             return f"{file_id}.dat"
 
@@ -112,7 +136,15 @@ class FileProviderExecutor:
         self, filename: str, file_id: str, file_data: FileData
     ) -> Path:
         """Given a finalized filename, return the full filepath for the filename."""
+        assert self._run_metadata is not None
+
         if isinstance(file_data.command_metadata, ReadCmdFileNameMetadata):
             return self._data_files_directory / file_id / filename
+        elif isinstance(file_data.command_metadata, ImageCaptureCmdFileNameMetadata):
+            return self._images_directory / self._run_metadata.run_id / filename
         else:
             return self._data_files_directory / filename
+
+    def _get_md5sum(self, file_data: FileData) -> str:
+        """Returns the md5 checksum of the provided file data."""
+        return hashlib.md5(file_data.data).hexdigest()

--- a/robot-server/robot_server/file_provider/provider.py
+++ b/robot-server/robot_server/file_provider/provider.py
@@ -68,8 +68,8 @@ class FileProviderExecutor:
     async def write_file_cb(
         self,
         file_data: FileData,
-    ) -> str:
-        """Write the provided file data to disk. Returns the File ID of the created file."""
+    ) -> DataFileInfo:
+        """Write the provided file data to disk. Returns the `DataFileInfo` of the created file."""
         async with self._lock:
             file_id = await get_unique_id()
             final_filename = self._format_filename(file_data, file_id)
@@ -92,7 +92,7 @@ class FileProviderExecutor:
                 source=DataFileSource.GENERATED,
             )
             await self._data_files_store.insert(file_info)
-            return file_id
+            return file_info
 
     async def filecount_cb(self) -> int:
         """Return the current count of generated files stored within the data files directory."""

--- a/robot-server/robot_server/file_provider/provider.py
+++ b/robot-server/robot_server/file_provider/provider.py
@@ -26,6 +26,7 @@ class RunFileNameMetadata(BaseModel):
     """Data from the run used that may be used to build a finalized file name."""
 
     robot_name: str
+    run_id: str
     run_created_at: datetime
     protocol_name: Optional[str]
 

--- a/robot-server/robot_server/file_provider/provider.py
+++ b/robot-server/robot_server/file_provider/provider.py
@@ -13,11 +13,10 @@ from robot_server.data_files.dependencies import (
     get_data_files_directory,
     get_data_files_store,
 )
-from robot_server.data_files.models import DataFileSource
+from opentrons_shared_data.data_files import DataFileSource, DataFileInfo
 from ..service.dependencies import get_current_time, get_unique_id
 from robot_server.data_files.data_files_store import (
     DataFilesStore,
-    DataFileInfo,
 )
 from opentrons.protocol_engine.resources.file_provider import (
     FileData,

--- a/robot-server/robot_server/persistence/fastapi_dependencies.py
+++ b/robot-server/robot_server/persistence/fastapi_dependencies.py
@@ -311,7 +311,7 @@ async def initialize_images_directory(
         raise
 
 
-async def _get_images_directory(
+async def get_images_directory(
     app_state: Annotated[AppState, Depends(get_app_state)],
 ) -> Path:
     """Return the path to the server's images directory."""
@@ -323,7 +323,7 @@ async def _get_images_directory(
 
 
 async def get_images_resetter(
-    directory_to_reset: Annotated[Path, Depends(_get_images_directory)],
+    directory_to_reset: Annotated[Path, Depends(get_images_directory)],
 ) -> ImagesResetter:
     """Get an `ImagesResetter` to reset the robot-server's stored data."""
     return ImagesResetter(directory_to_reset)

--- a/robot-server/robot_server/protocols/protocol_store.py
+++ b/robot-server/robot_server/protocols/protocol_store.py
@@ -16,7 +16,8 @@ import sqlalchemy
 from opentrons.protocols.parse import PythonParseMode
 from opentrons.protocol_reader import ProtocolReader, ProtocolSource
 
-from robot_server.data_files.models import DataFile, DataFileSource
+from robot_server.data_files.models import DataFile
+from opentrons_shared_data.data_files import DataFileSource
 from robot_server.persistence.database import sqlite_rowid
 from robot_server.persistence.tables import (
     analysis_table,

--- a/robot-server/robot_server/runs/run_data_manager.py
+++ b/robot-server/robot_server/runs/run_data_manager.py
@@ -251,6 +251,7 @@ class RunDataManager:
         self._file_provider_executor.set_run_metadata(
             RunFileNameMetadata.model_construct(
                 robot_name=config.name(),
+                run_id=run_id,
                 run_created_at=created_at,
                 protocol_name=protocol_name,
             )

--- a/robot-server/tests/data_files/test_data_files_store.py
+++ b/robot-server/tests/data_files/test_data_files_store.py
@@ -10,11 +10,10 @@ from sqlalchemy.engine import Engine as SQLEngine
 
 from robot_server.data_files.data_files_store import (
     DataFilesStore,
-    DataFileInfo,
 )
+from opentrons_shared_data.data_files import DataFileSource, DataFileInfo
 from robot_server.deletion_planner import FileUsageInfo
 from robot_server.data_files.models import (
-    DataFileSource,
     FileIdNotFoundError,
     FileInUseError,
 )

--- a/robot-server/tests/data_files/test_file_auto_deleter.py
+++ b/robot-server/tests/data_files/test_file_auto_deleter.py
@@ -6,7 +6,7 @@ from decoy import Decoy
 
 from robot_server.data_files.data_files_store import DataFilesStore
 from robot_server.data_files.file_auto_deleter import DataFileAutoDeleter
-from robot_server.data_files.models import DataFileSource
+from opentrons_shared_data.data_files import DataFileSource
 from robot_server.deletion_planner import DataFileDeletionPlanner, FileUsageInfo
 
 

--- a/robot-server/tests/data_files/test_router.py
+++ b/robot-server/tests/data_files/test_router.py
@@ -12,14 +12,13 @@ from robot_server.service.json_api import MultiBodyMeta, SimpleEmptyBody
 
 from robot_server.data_files.data_files_store import (
     DataFilesStore,
-    DataFileInfo,
 )
 from robot_server.data_files.models import (
     DataFile,
-    DataFileSource,
     FileIdNotFoundError,
     FileInUseError,
 )
+from opentrons_shared_data.data_files import DataFileSource, DataFileInfo
 from robot_server.data_files.router import (
     upload_data_file,
     get_data_file_info_by_id,

--- a/robot-server/tests/protocols/test_completed_analysis_store.py
+++ b/robot-server/tests/protocols/test_completed_analysis_store.py
@@ -8,7 +8,7 @@ import pytest
 from sqlalchemy.engine import Engine
 from decoy import Decoy
 
-from robot_server.data_files.models import DataFileSource
+from opentrons_shared_data.data_files import DataFileSource, DataFileInfo
 from robot_server.persistence.tables import (
     analysis_table,
     analysis_primitive_type_rtp_table,
@@ -24,7 +24,6 @@ from opentrons.protocol_reader import (
 )
 from robot_server.data_files.data_files_store import (
     DataFilesStore,
-    DataFileInfo,
 )
 from robot_server.protocols.analysis_memcache import MemoryCache
 from robot_server.protocols.analysis_models import (

--- a/robot-server/tests/protocols/test_protocol_store.py
+++ b/robot-server/tests/protocols/test_protocol_store.py
@@ -18,9 +18,9 @@ from opentrons.protocol_reader import (
 
 from robot_server.data_files.data_files_store import (
     DataFilesStore,
-    DataFileInfo,
 )
-from robot_server.data_files.models import DataFile, DataFileSource
+from robot_server.data_files.models import DataFile
+from opentrons_shared_data.data_files import DataFileInfo, DataFileSource
 from robot_server.protocols.analysis_memcache import MemoryCache
 from robot_server.protocols.analysis_models import (
     CompletedAnalysis,

--- a/robot-server/tests/protocols/test_protocols_router.py
+++ b/robot-server/tests/protocols/test_protocols_router.py
@@ -32,9 +32,9 @@ from opentrons.protocol_reader import (
 
 from robot_server.data_files.data_files_store import (
     DataFilesStore,
-    DataFileInfo,
 )
-from robot_server.data_files.models import DataFile, DataFileSource
+from robot_server.data_files.models import DataFile
+from opentrons_shared_data.data_files import DataFileSource, DataFileInfo
 from robot_server.errors.error_responses import ApiError
 from robot_server.protocols.analyses_manager import AnalysesManager
 from robot_server.protocols.protocol_analyzer import ProtocolAnalyzer

--- a/robot-server/tests/runs/router/test_base_router.py
+++ b/robot-server/tests/runs/router/test_base_router.py
@@ -25,10 +25,9 @@ from opentrons.hardware_control.nozzle_manager import NozzleMap
 
 from robot_server.data_files.data_files_store import (
     DataFilesStore,
-    DataFileInfo,
 )
 
-from robot_server.data_files.models import DataFileSource
+from opentrons_shared_data.data_files import DataFileSource, DataFileInfo
 from robot_server.errors.error_responses import ApiError
 from robot_server.service.json_api import (
     RequestModel,

--- a/robot-server/tests/runs/test_run_data_manager.py
+++ b/robot-server/tests/runs/test_run_data_manager.py
@@ -358,6 +358,7 @@ async def test_create(
         mock_file_provider_wrapper.set_run_metadata(
             RunFileNameMetadata.model_construct(
                 robot_name=config.name(),
+                run_id=run_id,
                 run_created_at=created_at,
                 protocol_name="test_protocol",
             )

--- a/robot-server/tests/runs/test_run_store.py
+++ b/robot-server/tests/runs/test_run_store.py
@@ -8,7 +8,6 @@ import warnings
 import pytest
 from decoy import Decoy
 from robot_server.data_files.data_files_store import (
-    DataFileInfo,
     DataFilesStore,
 )
 from sqlalchemy.engine import Engine
@@ -17,7 +16,7 @@ from unittest import mock
 from opentrons_shared_data.pipette.types import PipetteNameType
 from opentrons_shared_data.errors.codes import ErrorCodes
 
-from robot_server.data_files.models import DataFileSource
+from opentrons_shared_data.data_files import DataFileSource, DataFileInfo
 from robot_server.protocols.protocol_store import ProtocolNotFoundError
 from robot_server.runs.run_store import (
     CSVParameterRunResource,

--- a/shared-data/python/opentrons_shared_data/data_files/__init__.py
+++ b/shared-data/python/opentrons_shared_data/data_files/__init__.py
@@ -1,0 +1,6 @@
+"""Types and functions for accessing data files."""
+
+from .types import DataFileInfo, DataFileSource
+
+
+__all__ = ["DataFileInfo", "DataFileSource"]

--- a/shared-data/python/opentrons_shared_data/data_files/types.py
+++ b/shared-data/python/opentrons_shared_data/data_files/types.py
@@ -1,3 +1,5 @@
+"""opentrons_shared_data.data_files.types: types for data files."""
+
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum

--- a/shared-data/python/opentrons_shared_data/data_files/types.py
+++ b/shared-data/python/opentrons_shared_data/data_files/types.py
@@ -1,0 +1,21 @@
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+
+
+class DataFileSource(Enum):
+    """The source this data file is from."""
+
+    UPLOADED = "uploaded"
+    GENERATED = "generated"
+
+
+@dataclass(frozen=True)
+class DataFileInfo:
+    """Metadata info of a saved data file."""
+
+    id: str
+    name: str
+    file_hash: str
+    created_at: datetime
+    source: DataFileSource


### PR DESCRIPTION
Closes [EXEC-1970](https://opentrons.atlassian.net/browse/EXEC-1970)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Saves to disk byte streams with image metadata to the injected `images_directory` path with filename structure described [here](https://www.figma.com/design/PDkgB4AZ9PiLLJkwBATcU3/Feature--Camera-Enablement?node-id=4356-13754&t=lFWMWMiOfvsPKMFn-4).

There is a lot of churn here due to some type refactoring. This PR is best viewed commit by commit.

ea59afe963a510693633d64de75930d260a4cbdb - We need the run id to build the full `images/runId/imageFileName` path.

bb9c1b707f24a83376a0799dad55dd4547678ca3 - Actually do the saving to disk. NOTE: There is a change to prior absorbance reader data file behavior here: previously, the data files table would always save a `DataFileInfo` with a `file_hash` as an empty string. We now save a hash of the byte stream. 

7087dc2d0301baef12d1d66fa5d6e005f93d07b5 - In prep for the subsequent commit, we need to move some of the data file types to a shared python location.

9fb66b33d86621e1c88f1ab3b8d969355be39fca - The PE injected `FileProvider.write_file()` now returns `DataFileInfo` instead of the simple file's set `id`. This will enable the actual PE command to return useful info like the filename and the md5sum. 

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- This will be fully tested when integrated alongside the https://github.com/Opentrons/opentrons/pull/19795 changes.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Images are now persisted in `/data/images/runid/image` using the Design-prescribed filename.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests
- I'm pretty sure it's ok to save the absorbance reader files with the md5sum, whereas before we were just saving this field as an empty string, but am I missing anything?
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
lowish - nothing is truly implemented here
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[EXEC-1970]: https://opentrons.atlassian.net/browse/EXEC-1970?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ