### PR TITLE
feat(protocol-designer): add tip selection fields to step form

### DIFF
--- a/protocol-designer/cypress/e2e/mixSettings.cy.ts
+++ b/protocol-designer/cypress/e2e/mixSettings.cy.ts
@@ -1,4 +1,7 @@
-import { verifyImportProtocolPage } from '../support/Import'
+import {
+  verifyImportProtocolPage,
+  verifyOldProtocolModal,
+} from '../support/Import'
 import { MixSteps, MixVerifications } from '../support/MixSteps'
 import { SetupSteps } from '../support/SetupSteps'
 import { StepExecutor } from '../support/StepBuilder'
@@ -12,6 +15,7 @@ describe('Redesigned Mixing Steps - Happy Path', () => {
     const protocol = getTestFile(TestFilePath.DoItAllV8)
     cy.importProtocol(protocol.path)
     verifyImportProtocolPage(protocol)
+    verifyOldProtocolModal()
     cy.contains('Edit protocol').click()
     cy.get('[id="AddStepButton"]').contains('Add Step').click()
     cy.verifyOverflowBtn()

--- a/protocol-designer/cypress/e2e/thermocycler.cy.ts
+++ b/protocol-designer/cypress/e2e/thermocycler.cy.ts
@@ -1,4 +1,7 @@
-import { verifyImportProtocolPage } from '../support/Import'
+import {
+  verifyImportProtocolPage,
+  verifyOldProtocolModal,
+} from '../support/Import'
 import { StepExecutor } from '../support/StepBuilder'
 import { getTestFile, TestFilePath } from '../support/TestFiles'
 import {
@@ -18,6 +21,7 @@ describe('Redesigned Thermocycler Set Up Steps - Happy Path', () => {
     const protocol = getTestFile(TestFilePath.DoItAllV8)
     cy.importProtocol(protocol.path)
     verifyImportProtocolPage(protocol)
+    verifyOldProtocolModal()
     cy.contains('Edit protocol').click()
   })
 

--- a/protocol-designer/src/file-data/__tests__/createFile.test.ts
+++ b/protocol-designer/src/file-data/__tests__/createFile.test.ts
@@ -284,7 +284,7 @@ CUSTOM_LABWARE = json.loads("""{"fixture/fixture_trash/1":{"ordering":[["A1"]],"
             },
           },
         },
-        version: '8.6.0',
+        version: '8.7.0',
         name: 'opentrons/protocol-designer',
       },
       robot: { model: OT2_ROBOT_TYPE },

--- a/protocol-designer/src/load-file/migration/8_6_0.ts
+++ b/protocol-designer/src/load-file/migration/8_6_0.ts
@@ -1,5 +1,3 @@
-import { AUTOMATIC } from '@opentrons/step-generation'
-
 import { DEFAULT_MM_OFFSET_FROM_BOTTOM } from '/protocol-designer/constants'
 
 import type { ProtocolFile } from '@opentrons/shared-data'
@@ -59,14 +57,7 @@ export const migrateFile = (
               dispense_mmFromBottom != null
                 ? dispense_mmFromBottom
                 : DEFAULT_MM_OFFSET_FROM_BOTTOM,
-            tip_tracking: AUTOMATIC,
           },
-        }
-      }
-      if (form.stepType === 'mix') {
-        return {
-          ...acc,
-          [id]: { ...form, tip_tracking: AUTOMATIC },
         }
       }
       return acc

--- a/protocol-designer/src/load-file/migration/8_7_0.ts
+++ b/protocol-designer/src/load-file/migration/8_7_0.ts
@@ -1,0 +1,51 @@
+import { AUTOMATIC } from '@opentrons/step-generation'
+
+import type { ProtocolFile } from '@opentrons/shared-data'
+import type { PDMetadata } from '/protocol-designer/file-types'
+import type { DesignerApplicationData } from './utils/getLoadLiquidCommands'
+
+export const migrateFile = (
+  appData: ProtocolFile<PDMetadata>
+): ProtocolFile<PDMetadata> => {
+  const { designerApplication } = appData
+
+  if (designerApplication == null || designerApplication?.data == null) {
+    throw Error('The designerApplication key in your file is corrupt.')
+  }
+  const savedStepForms = designerApplication.data
+    ?.savedStepForms as DesignerApplicationData['savedStepForms']
+
+  const savedStepsWithUpdatedFields = Object.values(savedStepForms).reduce(
+    (acc, form) => {
+      //  introduction of allowing hours to heater-shaker timer field
+      const { stepType, id } = form
+      if (stepType === 'moveLiquid' || stepType === 'mix') {
+        return {
+          ...acc,
+          [id]: {
+            ...form,
+            tip_tracking: AUTOMATIC,
+            tiprack_selected: null,
+            tips_selected: [],
+          },
+        }
+      }
+      return acc
+    },
+    {}
+  )
+
+  return {
+    ...appData,
+    designerApplication: {
+      ...designerApplication,
+      data: {
+        ...designerApplication.data,
+        savedStepForms: {
+          ...designerApplication.data.savedStepForms,
+          ...savedStepsWithUpdatedFields,
+        },
+      },
+    },
+  }
+}

--- a/protocol-designer/src/load-file/migration/8_7_0.ts
+++ b/protocol-designer/src/load-file/migration/8_7_0.ts
@@ -17,7 +17,6 @@ export const migrateFile = (
 
   const savedStepsWithUpdatedFields = Object.values(savedStepForms).reduce(
     (acc, form) => {
-      //  introduction of allowing hours to heater-shaker timer field
       const { stepType, id } = form
       if (stepType === 'moveLiquid' || stepType === 'mix') {
         return {

--- a/protocol-designer/src/load-file/migration/index.ts
+++ b/protocol-designer/src/load-file/migration/index.ts
@@ -18,6 +18,7 @@ import { migrateFile as migrateFileEightFourFour } from './8_4_4'
 import { migrateFile as migrateFileEightFive } from './8_5_0'
 import { migrateFile as migrateFileEightFiveFive } from './8_5_5'
 import { migrateFile as migrateFileEightSix } from './8_6_0'
+import { migrateFile as migrateFileEightSeven } from './8_7_0'
 
 import type {
   PDProtocolFile,
@@ -74,6 +75,8 @@ const allMigrationsByVersion: MigrationsByVersion = {
   '8.5.5': migrateFileEightFiveFive,
   // @ts-expect-error
   '8.6.0': migrateFileEightSix,
+  // @ts-expect-error
+  '8.7.0': migrateFileEightSeven,
 }
 export const migration = (
   file: any

--- a/protocol-designer/src/step-forms/test/createPresavedStepForm.test.ts
+++ b/protocol-designer/src/step-forms/test/createPresavedStepForm.test.ts
@@ -235,6 +235,8 @@ describe('createPresavedStepForm', () => {
       liquidClass: 'none',
       stepNumber: 0,
       tip_tracking: 'automatic',
+      tiprack_selected: null,
+      tips_selected: [],
     })
   })
   describe('mix step', () => {
@@ -282,6 +284,8 @@ describe('createPresavedStepForm', () => {
         pushOut_volume: null,
         mix_position_reference: 'well-bottom',
         tip_tracking: 'automatic',
+        tiprack_selected: null,
+        tips_selected: [],
       })
     })
   })

--- a/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.ts
+++ b/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.ts
@@ -56,6 +56,8 @@ export function getDefaultsForStepType(
         times: null,
         tipRack: null,
         tip_tracking: AUTOMATIC,
+        tiprack_selected: null,
+        tips_selected: [],
         volume: undefined,
         wells: [],
       }
@@ -149,6 +151,8 @@ export function getDefaultsForStepType(
         pushOut_volume: null,
         tipRack: null,
         tip_tracking: AUTOMATIC,
+        tiprack_selected: null,
+        tips_selected: [],
         volume: null,
       }
 

--- a/protocol-designer/src/steplist/formLevel/test/getDefaultsForStepType.test.ts
+++ b/protocol-designer/src/steplist/formLevel/test/getDefaultsForStepType.test.ts
@@ -106,6 +106,8 @@ describe('getDefaultsForStepType', () => {
         liquidClassesSupported: true,
         liquidClass: 'none',
         tip_tracking: 'automatic',
+        tiprack_selected: null,
+        tips_selected: [],
       })
     })
   })
@@ -147,6 +149,8 @@ describe('getDefaultsForStepType', () => {
         pushOut_volume: null,
         mix_position_reference: 'well-bottom',
         tip_tracking: 'automatic',
+        tiprack_selected: null,
+        tips_selected: [],
       })
     })
   })

--- a/protocol-designer/src/ui/steps/test/selectors.test.ts
+++ b/protocol-designer/src/ui/steps/test/selectors.test.ts
@@ -713,6 +713,13 @@ describe('_getSavedMultiSelectFieldValues', () => {
           isIndeterminate: false,
           value: undefined,
         },
+        // tip selection wizard fields
+        tiprack_selected: {
+          isIndeterminate: false,
+        },
+        tips_selected: {
+          isIndeterminate: false,
+        },
       })
     })
   })
@@ -1094,6 +1101,12 @@ describe('_getSavedMultiSelectFieldValues', () => {
           isIndeterminate: false,
           value: undefined,
         },
+        tiprack_selected: {
+          isIndeterminate: false,
+        },
+        tips_selected: {
+          isIndeterminate: false,
+        },
       })
     })
   })
@@ -1188,6 +1201,12 @@ describe('_getSavedMultiSelectFieldValues', () => {
         tip_tracking: {
           isIndeterminate: false,
           value: undefined,
+        },
+        tiprack_selected: {
+          isIndeterminate: false,
+        },
+        tips_selected: {
+          isIndeterminate: false,
         },
       })
     })
@@ -1300,6 +1319,12 @@ describe('_getSavedMultiSelectFieldValues', () => {
         tip_tracking: {
           isIndeterminate: false,
           value: undefined,
+        },
+        tiprack_selected: {
+          isIndeterminate: false,
+        },
+        tips_selected: {
+          isIndeterminate: false,
         },
       })
     })

--- a/step-generation/src/utils/pythonFileUtils.ts
+++ b/step-generation/src/utils/pythonFileUtils.ts
@@ -46,7 +46,7 @@ import type {
 } from '../types'
 
 const PAPI_VERSION = '2.26' // latest version from api/src/opentrons/protocols/api_support/definitions.py
-export const PD_APPLICATION_VERSION = '8.6.0' // latest PD version to insert into DESIGNER_APPLICATION blob
+export const PD_APPLICATION_VERSION = '8.7.0' // latest PD version to insert into DESIGNER_APPLICATION blob
 
 export function pythonImports(): string {
   return ['import json', 'from opentrons import protocol_api, types'].join('\n')


### PR DESCRIPTION
# Overview

This PR adds new fields for `tip_tracking`, `tiprack_selected`, and `tips_selected` to moveLiquid and mix forms in PD. Also adds migration for 8.7.0

Closes AUTH-2408

## Test Plan and Hands on Testing

Not much! just checkout code

## Changelog

- add new fields for mix and moveLiquid
- create new migration
- momve old migration to 8.7

## Risk assessment

low