### PR TITLE
chore(shared-data): update the pipette bounding boxes.

### DIFF
--- a/api/tests/opentrons/protocol_engine/resources/test_pipette_data_provider.py
+++ b/api/tests/opentrons/protocol_engine/resources/test_pipette_data_provider.py
@@ -113,8 +113,8 @@ def test_configure_virtual_pipette_for_volume(
         tip_configuration_lookup_table=result1.tip_configuration_lookup_table,
         nominal_tip_overlap=result1.nominal_tip_overlap,
         nozzle_map=result1.nozzle_map,
-        back_left_corner_offset=Point(-8.0, -22.0, -259.15),
-        front_right_corner_offset=Point(-8.0, -22.0, -259.15),
+        back_left_corner_offset=Point(-38, 0.0, -259.15),
+        front_right_corner_offset=Point(11.5, -64.0, -259.15),
         pipette_lld_settings={
             "t20": {"minHeight": 1.5, "minVolume": 0.0},
             "t50": {"minHeight": 1.0, "minVolume": 0.0},

--- a/api/tests/opentrons/protocol_engine/resources/test_pipette_data_provider.py
+++ b/api/tests/opentrons/protocol_engine/resources/test_pipette_data_provider.py
@@ -151,8 +151,8 @@ def test_configure_virtual_pipette_for_volume(
         tip_configuration_lookup_table=result2.tip_configuration_lookup_table,
         nominal_tip_overlap=result2.nominal_tip_overlap,
         nozzle_map=result2.nozzle_map,
-        back_left_corner_offset=Point(-8.0, -22.0, -259.15),
-        front_right_corner_offset=Point(-8.0, -22.0, -259.15),
+        back_left_corner_offset=Point(-38, 0.0, -259.15),
+        front_right_corner_offset=Point(11.5, -64.0, -259.15),
         pipette_lld_settings={
             "t20": {"minHeight": 1.5, "minVolume": 0.0},
             "t50": {"minHeight": 1.0, "minVolume": 0.0},

--- a/app/src/local-resources/instruments/__tests__/hooks.test.ts
+++ b/app/src/local-resources/instruments/__tests__/hooks.test.ts
@@ -97,8 +97,8 @@ const mockP1000V2Specs = {
   orderedColumns: expect.anything(),
   orderedRows: expect.anything(),
   pipetteBoundingBoxOffsets: {
-    backLeftCorner: [-8, -22, -259.15],
-    frontRightCorner: [-8, -22, -259.15],
+    backLeftCorner: [-38.0, 0.0, -259.15],
+    frontRightCorner: [11.5, -64.0, -259.15]
   },
   lldSettings: {
     t50: {

--- a/app/src/local-resources/instruments/__tests__/hooks.test.ts
+++ b/app/src/local-resources/instruments/__tests__/hooks.test.ts
@@ -98,7 +98,7 @@ const mockP1000V2Specs = {
   orderedRows: expect.anything(),
   pipetteBoundingBoxOffsets: {
     backLeftCorner: [-38.0, 0.0, -259.15],
-    frontRightCorner: [11.5, -64.0, -259.15]
+    frontRightCorner: [11.5, -64.0, -259.15],
   },
   lldSettings: {
     t50: {

--- a/shared-data/js/__tests__/pipettes.test.ts
+++ b/shared-data/js/__tests__/pipettes.test.ts
@@ -148,8 +148,8 @@ describe('pipette data accessors', () => {
         orderedColumns: expect.anything(),
         orderedRows: expect.anything(),
         pipetteBoundingBoxOffsets: {
-          backLeftCorner: [-8, -22, -259.15],
-          frontRightCorner: [-8, -22, -259.15],
+          backLeftCorner: [-38, 0, -259.15],
+          frontRightCorner: [11.5, -64, -259.15],
         },
         lldSettings: {
           t50: {

--- a/shared-data/pipette/definitions/2/geometry/ninety_six_channel/p1000/3_0.json
+++ b/shared-data/pipette/definitions/2/geometry/ninety_six_channel/p1000/3_0.json
@@ -3,7 +3,7 @@
   "pathTo3D": "pipette/definitions/2/geometry/ninety_six_channel/p1000/placeholder.gltf",
   "nozzleOffset": [-36.0, -25.5, -259.15],
   "pipetteBoundingBoxOffsets": {
-    "backLeftCorner": [-67.0, -3.5, -259.15],
+    "backLeftCorner": [-67.0, 0.0, -259.15],
     "frontRightCorner": [94.0, -113.0, -259.15]
   },
   "orderedRows": [

--- a/shared-data/pipette/definitions/2/geometry/ninety_six_channel/p1000/3_0.json
+++ b/shared-data/pipette/definitions/2/geometry/ninety_six_channel/p1000/3_0.json
@@ -4,7 +4,7 @@
   "nozzleOffset": [-36.0, -25.5, -259.15],
   "pipetteBoundingBoxOffsets": {
     "backLeftCorner": [-67.0, 0.0, -259.15],
-    "frontRightCorner": [94.0, -113.0, -259.15]
+    "frontRightCorner": [94.0, -116.0, -259.15]
   },
   "orderedRows": [
     {

--- a/shared-data/pipette/definitions/2/geometry/ninety_six_channel/p1000/3_0.json
+++ b/shared-data/pipette/definitions/2/geometry/ninety_six_channel/p1000/3_0.json
@@ -4,7 +4,7 @@
   "nozzleOffset": [-36.0, -25.5, -259.15],
   "pipetteBoundingBoxOffsets": {
     "backLeftCorner": [-67.0, 0.0, -259.15],
-    "frontRightCorner": [94.0, -116.0, -259.15]
+    "frontRightCorner": [94.0, -113.0, -259.15]
   },
   "orderedRows": [
     {

--- a/shared-data/pipette/definitions/2/geometry/ninety_six_channel/p1000/3_3.json
+++ b/shared-data/pipette/definitions/2/geometry/ninety_six_channel/p1000/3_3.json
@@ -3,8 +3,8 @@
   "pathTo3D": "pipette/definitions/2/geometry/ninety_six_channel/p1000/placeholder.gltf",
   "nozzleOffset": [-36.0, -25.5, -259.15],
   "pipetteBoundingBoxOffsets": {
-    "backLeftCorner": [-67.0, -3.5, -259.15],
-    "frontRightCorner": [94.0, -113.0, -259.15]
+    "backLeftCorner": [-67.0, 0.0, -259.15],
+    "frontRightCorner": [94.0, -116.0, -259.15]
   },
   "orderedRows": [
     {

--- a/shared-data/pipette/definitions/2/geometry/ninety_six_channel/p1000/3_3.json
+++ b/shared-data/pipette/definitions/2/geometry/ninety_six_channel/p1000/3_3.json
@@ -4,7 +4,7 @@
   "nozzleOffset": [-36.0, -25.5, -259.15],
   "pipetteBoundingBoxOffsets": {
     "backLeftCorner": [-67.0, 0.0, -259.15],
-    "frontRightCorner": [94.0, -116.0, -259.15]
+    "frontRightCorner": [94.0, -113.0, -259.15]
   },
   "orderedRows": [
     {

--- a/shared-data/pipette/definitions/2/geometry/ninety_six_channel/p1000/3_4.json
+++ b/shared-data/pipette/definitions/2/geometry/ninety_six_channel/p1000/3_4.json
@@ -3,8 +3,8 @@
   "pathTo3D": "pipette/definitions/2/geometry/ninety_six_channel/p1000/placeholder.gltf",
   "nozzleOffset": [-36.0, -25.5, -259.15],
   "pipetteBoundingBoxOffsets": {
-    "backLeftCorner": [-67.0, 0, -259.15],
-    "frontRightCorner": [94.0, -116.0, -259.15]
+    "backLeftCorner": [-67.0, 0.0, -259.15],
+    "frontRightCorner": [94.0, -113.0, -259.15]
   },
   "orderedRows": [
     {

--- a/shared-data/pipette/definitions/2/geometry/ninety_six_channel/p1000/3_4.json
+++ b/shared-data/pipette/definitions/2/geometry/ninety_six_channel/p1000/3_4.json
@@ -3,8 +3,8 @@
   "pathTo3D": "pipette/definitions/2/geometry/ninety_six_channel/p1000/placeholder.gltf",
   "nozzleOffset": [-36.0, -25.5, -259.15],
   "pipetteBoundingBoxOffsets": {
-    "backLeftCorner": [-67.0, -3.5, -259.15],
-    "frontRightCorner": [94.0, -113.0, -259.15]
+    "backLeftCorner": [-67.0, 0, -259.15],
+    "frontRightCorner": [94.0, -116.0, -259.15]
   },
   "orderedRows": [
     {

--- a/shared-data/pipette/definitions/2/geometry/ninety_six_channel/p1000/3_5.json
+++ b/shared-data/pipette/definitions/2/geometry/ninety_six_channel/p1000/3_5.json
@@ -3,8 +3,8 @@
   "pathTo3D": "pipette/definitions/2/geometry/ninety_six_channel/p1000/placeholder.gltf",
   "nozzleOffset": [-36.0, -25.5, -259.15],
   "pipetteBoundingBoxOffsets": {
-    "backLeftCorner": [-67.0, -3.5, -259.15],
-    "frontRightCorner": [94.0, -113.0, -259.15]
+    "backLeftCorner": [-67.0, 0.0, -259.15],
+    "frontRightCorner": [94.0, -116.0, -259.15]
   },
   "orderedRows": [
     {

--- a/shared-data/pipette/definitions/2/geometry/ninety_six_channel/p1000/3_5.json
+++ b/shared-data/pipette/definitions/2/geometry/ninety_six_channel/p1000/3_5.json
@@ -4,7 +4,7 @@
   "nozzleOffset": [-36.0, -25.5, -259.15],
   "pipetteBoundingBoxOffsets": {
     "backLeftCorner": [-67.0, 0.0, -259.15],
-    "frontRightCorner": [94.0, -116.0, -259.15]
+    "frontRightCorner": [94.0, -113.0, -259.15]
   },
   "orderedRows": [
     {

--- a/shared-data/pipette/definitions/2/geometry/ninety_six_channel/p1000/3_6.json
+++ b/shared-data/pipette/definitions/2/geometry/ninety_six_channel/p1000/3_6.json
@@ -3,8 +3,8 @@
   "pathTo3D": "pipette/definitions/2/geometry/ninety_six_channel/p1000/placeholder.gltf",
   "nozzleOffset": [-36.0, -25.5, -259.15],
   "pipetteBoundingBoxOffsets": {
-    "backLeftCorner": [-67.0, -3.5, -259.15],
-    "frontRightCorner": [94.0, -113.0, -259.15]
+    "backLeftCorner": [-67.0, 0.0, -259.15],
+    "frontRightCorner": [94.0, -116.0, -259.15]
   },
   "orderedRows": [
     {

--- a/shared-data/pipette/definitions/2/geometry/ninety_six_channel/p1000/3_6.json
+++ b/shared-data/pipette/definitions/2/geometry/ninety_six_channel/p1000/3_6.json
@@ -4,7 +4,7 @@
   "nozzleOffset": [-36.0, -25.5, -259.15],
   "pipetteBoundingBoxOffsets": {
     "backLeftCorner": [-67.0, 0.0, -259.15],
-    "frontRightCorner": [94.0, -116.0, -259.15]
+    "frontRightCorner": [94.0, -113.0, -259.15]
   },
   "orderedRows": [
     {

--- a/shared-data/pipette/definitions/2/geometry/ninety_six_channel/p200/3_0.json
+++ b/shared-data/pipette/definitions/2/geometry/ninety_six_channel/p200/3_0.json
@@ -3,8 +3,8 @@
   "pathTo3D": "pipette/definitions/2/geometry/ninety_six_channel/p200/placeholder.gltf",
   "nozzleOffset": [-36.0, -25.5, -259.15],
   "pipetteBoundingBoxOffsets": {
-    "backLeftCorner": [-67.0, -3.5, -259.15],
-    "frontRightCorner": [94.0, -113.0, -259.15]
+    "backLeftCorner": [-67.0, 0.0, -259.15],
+    "frontRightCorner": [94.0, -116.0, -259.15]
   },
   "orderedRows": [
     {

--- a/shared-data/pipette/definitions/2/geometry/ninety_six_channel/p200/3_0.json
+++ b/shared-data/pipette/definitions/2/geometry/ninety_six_channel/p200/3_0.json
@@ -4,7 +4,7 @@
   "nozzleOffset": [-36.0, -25.5, -259.15],
   "pipetteBoundingBoxOffsets": {
     "backLeftCorner": [-67.0, 0.0, -259.15],
-    "frontRightCorner": [94.0, -116.0, -259.15]
+    "frontRightCorner": [94.0, -113.0, -259.15]
   },
   "orderedRows": [
     {

--- a/shared-data/pipette/definitions/2/geometry/ninety_six_channel/p200/3_1.json
+++ b/shared-data/pipette/definitions/2/geometry/ninety_six_channel/p200/3_1.json
@@ -3,8 +3,8 @@
   "pathTo3D": "pipette/definitions/2/geometry/ninety_six_channel/p200/placeholder.gltf",
   "nozzleOffset": [-36.0, -25.5, -259.15],
   "pipetteBoundingBoxOffsets": {
-    "backLeftCorner": [-67.0, -3.5, -259.15],
-    "frontRightCorner": [94.0, -113.0, -259.15]
+    "backLeftCorner": [-67.0, 0.0, -259.15],
+    "frontRightCorner": [94.0, -116.0, -259.15]
   },
   "orderedRows": [
     {

--- a/shared-data/pipette/definitions/2/geometry/ninety_six_channel/p200/3_1.json
+++ b/shared-data/pipette/definitions/2/geometry/ninety_six_channel/p200/3_1.json
@@ -4,7 +4,7 @@
   "nozzleOffset": [-36.0, -25.5, -259.15],
   "pipetteBoundingBoxOffsets": {
     "backLeftCorner": [-67.0, 0.0, -259.15],
-    "frontRightCorner": [94.0, -116.0, -259.15]
+    "frontRightCorner": [94.0, -113.0, -259.15]
   },
   "orderedRows": [
     {

--- a/shared-data/pipette/definitions/2/geometry/ninety_six_channel/p200/3_2.json
+++ b/shared-data/pipette/definitions/2/geometry/ninety_six_channel/p200/3_2.json
@@ -3,8 +3,8 @@
   "pathTo3D": "pipette/definitions/2/geometry/ninety_six_channel/p200/placeholder.gltf",
   "nozzleOffset": [-36.0, -25.5, -259.15],
   "pipetteBoundingBoxOffsets": {
-    "backLeftCorner": [-67.0, -3.5, -259.15],
-    "frontRightCorner": [94.0, -113.0, -259.15]
+    "backLeftCorner": [-67.0, 0.0, -259.15],
+    "frontRightCorner": [94.0, -116.0, -259.15]
   },
   "orderedRows": [
     {

--- a/shared-data/pipette/definitions/2/geometry/ninety_six_channel/p200/3_2.json
+++ b/shared-data/pipette/definitions/2/geometry/ninety_six_channel/p200/3_2.json
@@ -4,7 +4,7 @@
   "nozzleOffset": [-36.0, -25.5, -259.15],
   "pipetteBoundingBoxOffsets": {
     "backLeftCorner": [-67.0, 0.0, -259.15],
-    "frontRightCorner": [94.0, -116.0, -259.15]
+    "frontRightCorner": [94.0, -113.0, -259.15]
   },
   "orderedRows": [
     {

--- a/shared-data/pipette/definitions/2/geometry/single_channel/p1000/3_0.json
+++ b/shared-data/pipette/definitions/2/geometry/single_channel/p1000/3_0.json
@@ -3,8 +3,8 @@
   "pathTo3D": "pipette/definitions/2/geometry/single_channel/p1000/placeholder.gltf",
   "nozzleOffset": [-8.0, -22.0, -259.15],
   "pipetteBoundingBoxOffsets": {
-    "backLeftCorner": [-8.0, -22.0, -259.15],
-    "frontRightCorner": [-8.0, -22.0, -259.15]
+    "backLeftCorner": [-38.0, 0.0, -259.15],
+    "frontRightCorner": [11.5, -64.0, -259.15]
   },
   "orderedRows": [{ "key": "A", "orderedNozzles": ["A1"] }],
   "orderedColumns": [{ "key": "1", "orderedNozzles": ["A1"] }],

--- a/shared-data/pipette/definitions/2/geometry/single_channel/p1000/3_3.json
+++ b/shared-data/pipette/definitions/2/geometry/single_channel/p1000/3_3.json
@@ -3,8 +3,8 @@
   "pathTo3D": "pipette/definitions/2/geometry/single_channel/p1000/placeholder.gltf",
   "nozzleOffset": [-8.0, -22.0, -259.15],
   "pipetteBoundingBoxOffsets": {
-    "backLeftCorner": [-8.0, -22.0, -259.15],
-    "frontRightCorner": [-8.0, -22.0, -259.15]
+    "backLeftCorner": [-38.0, 0.0, -259.15],
+    "frontRightCorner": [11.5, -64.0, -259.15]
   },
   "orderedRows": [{ "key": "A", "orderedNozzles": ["A1"] }],
   "orderedColumns": [{ "key": "1", "orderedNozzles": ["A1"] }],

--- a/shared-data/pipette/definitions/2/geometry/single_channel/p1000/3_4.json
+++ b/shared-data/pipette/definitions/2/geometry/single_channel/p1000/3_4.json
@@ -3,8 +3,8 @@
   "pathTo3D": "pipette/definitions/2/geometry/single_channel/p1000/placeholder.gltf",
   "nozzleOffset": [-8.0, -22.0, -259.15],
   "pipetteBoundingBoxOffsets": {
-    "backLeftCorner": [-8.0, -22.0, -259.15],
-    "frontRightCorner": [-8.0, -22.0, -259.15]
+    "backLeftCorner": [-38.0, 0.0, -259.15],
+    "frontRightCorner": [11.5, -64.0, -259.15]
   },
   "orderedRows": [{ "key": "A", "orderedNozzles": ["A1"] }],
   "orderedColumns": [{ "key": "1", "orderedNozzles": ["A1"] }],

--- a/shared-data/pipette/definitions/2/geometry/single_channel/p1000/3_5.json
+++ b/shared-data/pipette/definitions/2/geometry/single_channel/p1000/3_5.json
@@ -3,8 +3,8 @@
   "pathTo3D": "pipette/definitions/2/geometry/single_channel/p1000/placeholder.gltf",
   "nozzleOffset": [-8.0, -22.0, -259.15],
   "pipetteBoundingBoxOffsets": {
-    "backLeftCorner": [-8.0, -22.0, -259.15],
-    "frontRightCorner": [-8.0, -22.0, -259.15]
+    "backLeftCorner": [-38.0, 0.0, -259.15],
+    "frontRightCorner": [11.5, -64.0, -259.15]
   },
   "orderedRows": [{ "key": "A", "orderedNozzles": ["A1"] }],
   "orderedColumns": [{ "key": "1", "orderedNozzles": ["A1"] }],

--- a/shared-data/pipette/definitions/2/geometry/single_channel/p1000/3_6.json
+++ b/shared-data/pipette/definitions/2/geometry/single_channel/p1000/3_6.json
@@ -3,8 +3,8 @@
   "pathTo3D": "pipette/definitions/2/geometry/single_channel/p1000/placeholder.gltf",
   "nozzleOffset": [-8.0, -22.0, -259.15],
   "pipetteBoundingBoxOffsets": {
-    "backLeftCorner": [-8.0, -22.0, -259.15],
-    "frontRightCorner": [-8.0, -22.0, -259.15]
+    "backLeftCorner": [-38.0, 0.0, -259.15],
+    "frontRightCorner": [11.5, -64.0, -259.15]
   },
   "orderedRows": [{ "key": "A", "orderedNozzles": ["A1"] }],
   "orderedColumns": [{ "key": "1", "orderedNozzles": ["A1"] }],

--- a/shared-data/pipette/definitions/2/geometry/single_channel/p1000/3_7.json
+++ b/shared-data/pipette/definitions/2/geometry/single_channel/p1000/3_7.json
@@ -3,8 +3,8 @@
   "pathTo3D": "pipette/definitions/2/geometry/single_channel/p1000/placeholder.gltf",
   "nozzleOffset": [-8.0, -22.0, -259.15],
   "pipetteBoundingBoxOffsets": {
-    "backLeftCorner": [-8.0, -22.0, -259.15],
-    "frontRightCorner": [-8.0, -22.0, -259.15]
+    "backLeftCorner": [-38.0, 0.0, -259.15],
+    "frontRightCorner": [11.5, -64.0, -259.15]
   },
   "orderedRows": [{ "key": "A", "orderedNozzles": ["A1"] }],
   "orderedColumns": [{ "key": "1", "orderedNozzles": ["A1"] }],

--- a/shared-data/pipette/definitions/2/geometry/single_channel/p50/3_0.json
+++ b/shared-data/pipette/definitions/2/geometry/single_channel/p50/3_0.json
@@ -3,8 +3,8 @@
   "pathTo3D": "pipette/definitions/2/geometry/single_channel/p50/placeholder.gltf",
   "nozzleOffset": [-8.0, -22.0, -259.15],
   "pipetteBoundingBoxOffsets": {
-    "backLeftCorner": [-8.0, -22.0, -259.15],
-    "frontRightCorner": [-8.0, -22.0, -259.15]
+    "backLeftCorner": [-38.0, 0.0, -259.15],
+    "frontRightCorner": [11.5, -64.0, -259.15]
   },
   "orderedRows": [{ "key": "A", "orderedNozzles": ["A1"] }],
   "orderedColumns": [{ "key": "1", "orderedNozzles": ["A1"] }],

--- a/shared-data/pipette/definitions/2/geometry/single_channel/p50/3_3.json
+++ b/shared-data/pipette/definitions/2/geometry/single_channel/p50/3_3.json
@@ -3,8 +3,8 @@
   "pathTo3D": "pipette/definitions/2/geometry/single_channel/p50/placeholder.gltf",
   "nozzleOffset": [-8.0, -22.0, -259.15],
   "pipetteBoundingBoxOffsets": {
-    "backLeftCorner": [-8.0, -22.0, -259.15],
-    "frontRightCorner": [-8.0, -22.0, -259.15]
+    "backLeftCorner": [-38.0, 0.0, -259.15],
+    "frontRightCorner": [11.5, -64.0, -259.15]
   },
   "orderedRows": [{ "key": "A", "orderedNozzles": ["A1"] }],
   "orderedColumns": [{ "key": "1", "orderedNozzles": ["A1"] }],

--- a/shared-data/pipette/definitions/2/geometry/single_channel/p50/3_4.json
+++ b/shared-data/pipette/definitions/2/geometry/single_channel/p50/3_4.json
@@ -3,8 +3,8 @@
   "pathTo3D": "pipette/definitions/2/geometry/single_channel/p50/placeholder.gltf",
   "nozzleOffset": [-8.0, -22.0, -259.15],
   "pipetteBoundingBoxOffsets": {
-    "backLeftCorner": [-8.0, -22.0, -259.15],
-    "frontRightCorner": [-8.0, -22.0, -259.15]
+    "backLeftCorner": [-38.0, 0.0, -259.15],
+    "frontRightCorner": [11.5, -64.0, -259.15]
   },
   "orderedRows": [{ "key": "A", "orderedNozzles": ["A1"] }],
   "orderedColumns": [{ "key": "1", "orderedNozzles": ["A1"] }],

--- a/shared-data/pipette/definitions/2/geometry/single_channel/p50/3_5.json
+++ b/shared-data/pipette/definitions/2/geometry/single_channel/p50/3_5.json
@@ -3,8 +3,8 @@
   "pathTo3D": "pipette/definitions/2/geometry/single_channel/p50/placeholder.gltf",
   "nozzleOffset": [-8.0, -22.0, -259.15],
   "pipetteBoundingBoxOffsets": {
-    "backLeftCorner": [-8.0, -22.0, -259.15],
-    "frontRightCorner": [-8.0, -22.0, -259.15]
+    "backLeftCorner": [-38.0, 0.0, -259.15],
+    "frontRightCorner": [11.5, -64.0, -259.15]
   },
   "orderedRows": [{ "key": "A", "orderedNozzles": ["A1"] }],
   "orderedColumns": [{ "key": "1", "orderedNozzles": ["A1"] }],

--- a/shared-data/pipette/definitions/2/geometry/single_channel/p50/3_6.json
+++ b/shared-data/pipette/definitions/2/geometry/single_channel/p50/3_6.json
@@ -3,8 +3,8 @@
   "pathTo3D": "pipette/definitions/2/geometry/single_channel/p50/placeholder.gltf",
   "nozzleOffset": [-8.0, -22.0, -259.15],
   "pipetteBoundingBoxOffsets": {
-    "backLeftCorner": [-8.0, -22.0, -259.15],
-    "frontRightCorner": [-8.0, -22.0, -259.15]
+    "backLeftCorner": [-38.0, 0.0, -259.15],
+    "frontRightCorner": [11.5, -64.0, -259.15]
   },
   "orderedRows": [{ "key": "A", "orderedNozzles": ["A1"] }],
   "orderedColumns": [{ "key": "1", "orderedNozzles": ["A1"] }],


### PR DESCRIPTION
# Overview
 The bounding boxes were missing for the single channels and 96 channel Y was a little off due the assembly offsets when adding the 96ch mount adapter.