### PR TITLE
fix(components): change ListItems colors from green/yellow/red35 to 30

### DIFF
--- a/components/src/atoms/ListItem/__tests__/ListItem.test.tsx
+++ b/components/src/atoms/ListItem/__tests__/ListItem.test.tsx
@@ -28,7 +28,7 @@ describe('ListItem', () => {
     render(props)
     screen.getByText('mock listitem content')
     const listItem = screen.getByTestId('ListItem_error')
-    expect(listItem).toHaveStyle(`backgroundColor: ${COLORS.red35}`)
+    expect(listItem).toHaveStyle(`backgroundColor: ${COLORS.red30}`)
     expect(listItem).toHaveStyle(`borderRadius: ${BORDERS.borderRadius4}`)
   })
 
@@ -46,7 +46,7 @@ describe('ListItem', () => {
     render(props)
     screen.getByText('mock listitem content')
     const listItem = screen.getByTestId('ListItem_success')
-    expect(listItem).toHaveStyle(`backgroundColor: ${COLORS.green35}`)
+    expect(listItem).toHaveStyle(`backgroundColor: ${COLORS.green30}`)
     expect(listItem).toHaveStyle(`borderRadius: ${BORDERS.borderRadius4}`)
   })
 
@@ -55,7 +55,7 @@ describe('ListItem', () => {
     render(props)
     screen.getByText('mock listitem content')
     const listItem = screen.getByTestId('ListItem_warning')
-    expect(listItem).toHaveStyle(`backgroundColor: ${COLORS.yellow35}`)
+    expect(listItem).toHaveStyle(`backgroundColor: ${COLORS.yellow30}`)
     expect(listItem).toHaveStyle(`borderRadius: ${BORDERS.borderRadius4}`)
   })
 

--- a/components/src/atoms/ListItem/index.tsx
+++ b/components/src/atoms/ListItem/index.tsx
@@ -36,16 +36,16 @@ const LISTITEM_PROPS_BY_TYPE: Record<
   { backgroundColor: string; color?: string }
 > = {
   error: {
-    backgroundColor: COLORS.red35,
+    backgroundColor: COLORS.red30,
   },
   default: {
     backgroundColor: COLORS.grey20,
   },
   success: {
-    backgroundColor: COLORS.green35,
+    backgroundColor: COLORS.green30,
   },
   warning: {
-    backgroundColor: COLORS.yellow35,
+    backgroundColor: COLORS.yellow30,
   },
   unavailable: {
     backgroundColor: COLORS.grey20,


### PR DESCRIPTION
# Overview

Felix and @mmencarelli confirmed that the `ListItem` colors should be green30/yellow30/red30 instead of green35/yellow35/red35.

(The original green35/yellow35/red35 colors were added back in PR #14317.)

## Test Plan and Hands on Testing

Looked at the colors.

I couldn't find an easy-to-access place in PD that currently has a `ListItem` that can be in an error state, but I'm about to add one in an upcoming PR (for when the user creates a transfer step without selecting a tiprack).

## Risk assessment

Low.