### PR TITLE
fix(protocol-designer): disallow moving the tough wellPlate on itself

### DIFF
--- a/protocol-designer/src/pages/Designer/utils.ts
+++ b/protocol-designer/src/pages/Designer/utils.ts
@@ -351,6 +351,8 @@ export const useLabwareDropdownOptions = (
   return _sortLabwareDropdownOptions(labwareOptions)
 }
 
+const TOUGH_PLATE_LOADNAME = 'opentrons_96_wellplate_200ul_pcr_full_skirt'
+
 //  used for LabwareLocationField dropdown
 export const getUnoccupiedStackOptions = (args: {
   robotState: RobotState
@@ -389,7 +391,11 @@ export const getUnoccupiedStackOptions = (args: {
       const { displayName } = labwareOnDeckDef.metadata
       const { loadName } = labwareOnDeckDef.parameters
 
-      const isCompatible = labwareCompatibleParentLabware?.includes(loadName)
+      //  NOTE: the tough plate is the only plate in the repo whose def allows for stacking
+      //  on itself. We don't allow that pattern with any other well plate. So i'm hardcoding
+      //  it in to filter it out for now. but in the future when we support labware stacking
+      //  we need to make this logic more robust
+      const isCompatible = labwareCompatibleParentLabware?.includes(loadName) && loadName !== TOUGH_PLATE_LOADNAME
       const isNotCurrentLabwareStack = !fullStack.includes(
         labwareIdFromDropdown
       )

--- a/protocol-designer/src/pages/Designer/utils.ts
+++ b/protocol-designer/src/pages/Designer/utils.ts
@@ -395,7 +395,9 @@ export const getUnoccupiedStackOptions = (args: {
       //  on itself. We don't allow that pattern with any other well plate. So i'm hardcoding
       //  it in to filter it out for now. but in the future when we support labware stacking
       //  we need to make this logic more robust
-      const isCompatible = labwareCompatibleParentLabware?.includes(loadName) && loadName !== TOUGH_PLATE_LOADNAME
+      const isCompatible =
+        labwareCompatibleParentLabware?.includes(loadName) &&
+        loadName !== TOUGH_PLATE_LOADNAME
       const isNotCurrentLabwareStack = !fullStack.includes(
         labwareIdFromDropdown
       )


### PR DESCRIPTION
closes RQA-4766

# Overview

there is an edge case where the tough wellPlate is the only well plate whose def in the repo allows stacking on itself. So i'm specifically filtering it out for now from the new location field in the move labware form. 

## Test Plan and Hands on Testing

Upload protocol in the ticket. Open step 5. see that the new location dropdown does not list the thermocycler location. Delete step 5 and then see that it now passes protocol analysis in the app

## Changelog

filter out the tough plate

## Risk assessment

low
