### PR TITLE
fix(protocol-designer): filter for correct TC overlapping slots for OT-2

### DIFF
--- a/protocol-designer/src/components/organisms/Ot2Modules/index.tsx
+++ b/protocol-designer/src/components/organisms/Ot2Modules/index.tsx
@@ -81,7 +81,7 @@ const mapModTypeToStepTypeOt2: Record<OT2ModuleType, StepType> = {
   thermocyclerModuleType: 'thermocycler',
 }
 
-const THERMOCYCLER_SLOTS = ['8', '9', '10', '11']
+const THERMOCYCLER_SLOTS = ['7', '8', '10', '11']
 
 const OT2_STANDARD_DECK_VIEW_LAYER_BLOCK_LIST: string[] = [
   'calibrationMarkings',
@@ -172,11 +172,15 @@ export function Ot2Modules(): JSX.Element {
           COMPATIBLE_LABWARE_ALLOWLIST_BY_MODULE_TYPE[moduleType]
         ).includes(lw.def.parameters.loadName)
     )?.def.metadata.displayName
-    const incompatibleLabwareSlots = Object.values(labware)
-      .filter(lw =>
-        THERMOCYCLER_SLOTS.includes(getSlotInLocationStack(lw.stack))
-      )
-      ?.map(lw => getSlotInLocationStack(lw.stack))
+    const incompatibleLabwareSlots = [
+      ...new Set(
+        Object.values(labware)
+          .filter(lw =>
+            THERMOCYCLER_SLOTS.includes(getSlotInLocationStack(lw.stack))
+          )
+          .map(lw => getSlotInLocationStack(lw.stack))
+      ),
+    ]
     if (somethingInSlotModule) {
       makeSnackbar(t('protocol_overview:conflict_on_slot_module') as string)
     } else if (


### PR DESCRIPTION
closes RQA-4767

# Overview

Whoops, there were 2 bugs technically. 1: i accidentally initially list slot 9 as an occupied slot for the TC. 2: if you have a stack of lids on a TC slot, it'll list that slot for every item in the stack. So i turned it into a set to remove duplicates

## Test Plan and Hands on Testing

Upload attached protocol to the ticket and try to add a TC to the deck map, see that it is added with no issues

## Changelog

fix occupied slots and remove duplicates

## Risk assessment

low
