### PR TITLE
fix(protocol-designer): migrate old liquid class names

### DIFF
--- a/protocol-designer/src/load-file/migration/8_6_0.ts
+++ b/protocol-designer/src/load-file/migration/8_6_0.ts
@@ -78,7 +78,7 @@ export const migrateFile = (
           [id]: {
             ...form,
             //  migrate from old liquidClass name
-            liquidClass: getMigratedLiquidClassNames(liquidClass),
+            liquidClass: getMigratedLiquidClassNames(liquidClass as string),
             aspirate_mmFromBottom:
               aspirate_mmFromBottom != null
                 ? aspirate_mmFromBottom
@@ -98,7 +98,7 @@ export const migrateFile = (
           [id]: {
             ...form,
             //  migrate from old liquidClass name
-            liquidClass: getMigratedLiquidClassNames(liquidClass),
+            liquidClass: getMigratedLiquidClassNames(liquidClass as string),
           },
         }
       }

--- a/protocol-designer/src/load-file/migration/8_6_0.ts
+++ b/protocol-designer/src/load-file/migration/8_6_0.ts
@@ -1,7 +1,6 @@
 import {
   ETHANOL_LIQUID_CLASS_NAME,
   GLYCEROL_LIQUID_CLASS_NAME,
-  NONE_LIQUID_CLASS_NAME,
   WATER_LIQUID_CLASS_NAME,
 } from '@opentrons/shared-data'
 
@@ -30,9 +29,7 @@ const getMigratedLiquidClassNames = (liquidClass: string): string => {
     return GLYCEROL_LIQUID_CLASS_NAME
   } else if (liquidClass === ETHANOL_LIQUID_CLASS_NAME_V1) {
     return ETHANOL_LIQUID_CLASS_NAME
-  } else {
-    return NONE_LIQUID_CLASS_NAME
-  }
+  } else return liquidClass
 }
 
 export const migrateFile = (

--- a/protocol-designer/src/load-file/migration/8_6_0.ts
+++ b/protocol-designer/src/load-file/migration/8_6_0.ts
@@ -1,14 +1,38 @@
+import {
+  ETHANOL_LIQUID_CLASS_NAME,
+  GLYCEROL_LIQUID_CLASS_NAME,
+  NONE_LIQUID_CLASS_NAME,
+  WATER_LIQUID_CLASS_NAME,
+} from '@opentrons/shared-data'
+
 import { DEFAULT_MM_OFFSET_FROM_BOTTOM } from '/protocol-designer/constants'
 
 import type { ProtocolFile } from '@opentrons/shared-data'
 import type { PDMetadata } from '/protocol-designer/file-types'
 import type { DesignerApplicationData } from './utils/getLoadLiquidCommands'
 
+// deprecated liquid class names!
+const WATER_LIQUID_CLASS_NAME_V1 = 'waterV1'
+const GLYCEROL_LIQUID_CLASS_NAME_V1 = 'glycerol50V1'
+const ETHANOL_LIQUID_CLASS_NAME_V1 = 'ethanol80V1'
+
 const getNormalizedTime = (time: string): string => {
   const timeParts = time.split(':').map(Number)
   const missing = 3 - timeParts.length
   const normalized = [...Array(missing).fill(0), ...timeParts]
   return normalized.join(':')
+}
+
+const getMigratedLiquidClassNames = (liquidClass: string): string => {
+  if (liquidClass === WATER_LIQUID_CLASS_NAME_V1) {
+    return WATER_LIQUID_CLASS_NAME
+  } else if (liquidClass === GLYCEROL_LIQUID_CLASS_NAME_V1) {
+    return GLYCEROL_LIQUID_CLASS_NAME
+  } else if (liquidClass === ETHANOL_LIQUID_CLASS_NAME_V1) {
+    return ETHANOL_LIQUID_CLASS_NAME
+  } else {
+    return NONE_LIQUID_CLASS_NAME
+  }
 }
 
 export const migrateFile = (
@@ -42,12 +66,19 @@ export const migrateFile = (
       //  fixes a bug where the aspirate/dispense z-offset in the commands was
       //  defaulting to 1mm but the form fields were null
       if (form.stepType === 'moveLiquid') {
-        const { id, aspirate_mmFromBottom, dispense_mmFromBottom } = form
+        const {
+          id,
+          aspirate_mmFromBottom,
+          dispense_mmFromBottom,
+          liquidClass,
+        } = form
 
         return {
           ...acc,
           [id]: {
             ...form,
+            //  migrate from old liquidClass name
+            liquidClass: getMigratedLiquidClassNames(liquidClass),
             aspirate_mmFromBottom:
               aspirate_mmFromBottom != null
                 ? aspirate_mmFromBottom
@@ -56,6 +87,18 @@ export const migrateFile = (
               dispense_mmFromBottom != null
                 ? dispense_mmFromBottom
                 : DEFAULT_MM_OFFSET_FROM_BOTTOM,
+          },
+        }
+      }
+
+      if (form.stepType === 'mix') {
+        const { id, liquidClass } = form
+        return {
+          ...acc,
+          [id]: {
+            ...form,
+            //  migrate from old liquidClass name
+            liquidClass: getMigratedLiquidClassNames(liquidClass),
           },
         }
       }


### PR DESCRIPTION
closes RQA-4769

# Overview

migrate the old liquid class field in forms to be the new generic liquid class names. i.e. the protocol in the ticket has `waterV1` as the liquid class name but the new names are keyed without the version, like just `water`. So i migrated those old liquid class names to match the new names

## Test Plan and Hands on Testing

import attached protocol to the ticket and see that you can scroll through the timeline steps and the deck map still populates and updates as normal

## Changelog

migrate liquid class names

## Risk assessment

low