### PR TITLE
feat(api): add M200 GCODE + tests for vacuum module driver

### DIFF
--- a/api/src/opentrons/drivers/vacuum_module/driver.py
+++ b/api/src/opentrons/drivers/vacuum_module/driver.py
@@ -87,6 +87,11 @@ class VacuumModuleDriver(AbstractVacuumModuleDriver):
         """Check connection to vacuum module."""
         return await self._connection.is_open()
 
+    async def reset_serial_buffers(self) -> None:
+        """Reset the input and output serial buffers."""
+        self._connection._serial.reset_input_buffer()
+        self._connection._serial.reset_output_buffer()
+
     async def get_device_info(self) -> VacuumModuleInfo:
         """Get Device Info."""
         response = await self._connection.send_command(
@@ -100,17 +105,60 @@ class VacuumModuleDriver(AbstractVacuumModuleDriver):
         device_info.rr = reason
         return device_info
 
+    async def enter_programming_mode(self) -> None:
+        """Reboot into programming mode"""
+        command = GCODE.ENTER_BOOTLOADER.build_command()
+        await self._connection.send_dfu_command(command)
+        await self._connection.close()
+
     async def set_serial_number(self, sn: str) -> None:
         """Set Serial Number."""
         if not re.match(r"^VM[\w]{1}[\d]{2}[\d]{8}[\d]+$", sn):
             raise ValueError(
-                f"Invalid serial number: ({sn}) expected format: VMTA1020250119001"
+                f"Invalid serial number: ({sn}) expected format: VMA1020250119001"
             )
         resp = await self._connection.send_command(
             GCODE.SET_SERIAL_NUMBER.build_command().add_element(sn)
         )
         if not re.match(rf"^{GCODE.SET_SERIAL_NUMBER}$", resp):
             raise ValueError(f"Incorrect Response for set serial number: {resp}")
+
+    async def set_led(
+        self,
+        power: float,
+        color: Optional[LEDColor] = None,
+        external: Optional[bool] = None,
+        pattern: Optional[LEDPattern] = None,
+        duration: Optional[int] = None,
+        reps: Optional[int] = None,
+    ) -> None:
+        """Set LED Status bar color and pattern.
+
+        :param power: Power of the LED (0-1.0), 0 is off, 1 is full power
+        :param color: Color of the LED
+        :param external: True if external LED, False if internal LED
+        :param pattern: Animation pattern of the LED status bar
+        :param duration: Animation duration in milliseconds (25-10000), 10s max
+        :param reps: Number of times to repeat the animation (-1 - 10), -1 is forever.
+        """
+        power = max(0, min(power, 1.0))
+        command = GCODE.SET_LED.build_command().add_float(
+            "P", power, GCODE_ROUNDING_PRECISION
+        )
+        if color is not None:
+            command.add_int("C", color.value)
+        if external is not None:
+            command.add_int("K", int(external))
+        if pattern is not None:
+            command.add_int("A", pattern.value)
+        if duration is not None:
+            duration = max(MIN_DURATION_MS, min(duration, MAX_DURATION_MS))
+            command.add_int("D", duration)
+        if reps is not None:
+            command.add_int("R", max(-1, min(reps, MAX_REPS)))
+        resp = await self._connection.send_command(command)
+        if not re.match(rf"^{GCODE.SET_LED}$", resp):
+            raise ValueError(f"Incorrect Response for set led: {resp}")
 
     async def enable_pump(self) -> None:
         """Enables the vacuum pump, does not turn it on."""
@@ -158,26 +206,3 @@ class VacuumModuleDriver(AbstractVacuumModuleDriver):
     async def vent(self) -> None:
         """Release the vacuum in the module chamber."""
         ...
-
-    async def set_led(
-        self,
-        power: float,
-        color: Optional[LEDColor] = None,
-        external: Optional[bool] = None,
-        pattern: Optional[LEDPattern] = None,
-        duration: Optional[int] = None,  # Default firmware duration is 500ms
-        reps: Optional[int] = None,  # Default firmware reps is 0
-    ) -> None:
-        """Set LED Status bar color and pattern."""
-        ...
-
-    async def enter_programming_mode(self) -> None:
-        """Reboot into programming mode"""
-        command = GCODE.ENTER_BOOTLOADER.build_command()
-        await self._connection.send_dfu_command(command)
-        await self._connection.close()
-
-    async def reset_serial_buffers(self) -> None:
-        """Reset the input and output serial buffers."""
-        self._connection._serial.reset_input_buffer()
-        self._connection._serial.reset_output_buffer()

--- a/api/src/opentrons/drivers/vacuum_module/types.py
+++ b/api/src/opentrons/drivers/vacuum_module/types.py
@@ -11,6 +11,7 @@ class GCODE(str, Enum):
     GET_DEVICE_INFO = "M115"
     SET_SERIAL_NUMBER = "M996"
     ENTER_BOOTLOADER = "dfu"
+    SET_LED = "M200"
 
     def build_command(self) -> CommandBuilder:
         """Build command."""

--- a/api/tests/opentrons/drivers/vacuum_module/test_driver.py
+++ b/api/tests/opentrons/drivers/vacuum_module/test_driver.py
@@ -1,0 +1,115 @@
+import pytest
+from mock import AsyncMock, MagicMock
+from opentrons.drivers.asyncio.communication.serial_connection import (
+    AsyncResponseSerialConnection,
+)
+from opentrons.drivers.vacuum_module.driver import (
+    VacuumModuleDriver,
+)
+from opentrons.drivers.vacuum_module import types
+
+
+@pytest.fixture
+def connection() -> AsyncMock:
+    return AsyncMock(spec=AsyncResponseSerialConnection)
+
+
+@pytest.fixture
+def subject(connection: AsyncMock) -> VacuumModuleDriver:
+    connection.send_command.return_value = ""
+    connection._serial = MagicMock()
+    return VacuumModuleDriver(connection)
+
+
+async def test_get_device_info(
+    subject: VacuumModuleDriver, connection: AsyncMock
+) -> None:
+    """It should send a get device info command"""
+    connection.send_command.side_effect = [
+        "M115 FW:0.0.1 HW:Opentrons-vacuum-module-nff SerialNo:VMA120230605001",
+        "M114 R:0",
+    ]
+    response = await subject.get_device_info()
+    assert response == types.VacuumModuleInfo(
+        fw="0.0.1",
+        hw=types.HardwareRevision.NFF,
+        sn="VMA120230605001",
+        rr=0,
+    )
+
+    device_info = types.GCODE.GET_DEVICE_INFO.build_command()
+    reset_reason = types.GCODE.GET_RESET_REASON.build_command()
+    connection.send_command.assert_any_call(device_info)
+    connection.send_command.assert_called_with(reset_reason)
+    connection.reset_mock()
+
+    # Test invalid response
+    connection.send_command.side_effect = [
+        "M115 FW:0.0.1 SerialNo:VMA120230605001",
+        "M114 R:0",
+    ]
+
+    # This should raise ValueError
+    with pytest.raises(ValueError):
+        response = await subject.get_device_info()
+
+    device_info = types.GCODE.GET_DEVICE_INFO.build_command()
+    connection.send_command.assert_any_call(device_info)
+    # M115 response is invalid, so we dont send M114.
+    connection.send_command.assert_called_once()
+
+
+async def test_set_serial_number(
+    subject: VacuumModuleDriver, connection: AsyncMock
+) -> None:
+    """It should send a set serial number command"""
+    connection.send_command.return_value = "M996"
+
+    serial_number = "VMA1020250119001"
+    await subject.set_serial_number(serial_number)
+
+    set_serial_number = types.GCODE.SET_SERIAL_NUMBER.build_command().add_element(
+        serial_number
+    )
+    connection.send_command.assert_any_call(set_serial_number)
+    connection.reset_mock()
+
+    # Test invalid response
+    connection.send_command.return_value = "M9nn"
+    with pytest.raises(ValueError):
+        await subject.set_serial_number(serial_number)
+
+    set_serial_number = types.GCODE.SET_SERIAL_NUMBER.build_command().add_element(
+        serial_number
+    )
+    connection.send_command.assert_any_call(set_serial_number)
+    connection.reset_mock()
+
+    # Test invalid serial number
+    with pytest.raises(ValueError):
+        await subject.set_serial_number("invalid")
+
+    connection.send_command.assert_not_called()
+    connection.reset_mock()
+
+
+async def test_set_led(subject: VacuumModuleDriver, connection: AsyncMock) -> None:
+    """It should send a set led command"""
+    connection.send_command.return_value = "M200"
+    await subject.set_led(1, types.LEDColor.RED)
+
+    set_led = types.GCODE.SET_LED.build_command().add_float("P", 1).add_int("C", 1)
+    connection.send_command.assert_any_call(set_led)
+    connection.reset_mock()
+
+    # test setting only external leds
+    await subject.set_led(1, types.LEDColor.RED, external=True)
+
+    set_led = (
+        types.GCODE.SET_LED.build_command()
+        .add_float("P", 1)
+        .add_int("C", 1)
+        .add_int("K", 1)
+    )
+    connection.send_command.assert_any_call(set_led)
+    connection.reset_mock()


### PR DESCRIPTION
# Overview

Adds the `SET_LED = "M200"` GCODE to the vacuum module driver so we can set the status bar leds. Also adds the test_driver test suite.

## Test Plan and Hands on Testing

- [x] Make sure that we can set the status bar LEDs on the FLex robot using the VacuumModuleDriver class

## Changelog

- Adds the `SET_LED = "M200"` GCODE to the vacuum module driver so we can set the status bar leds. 
- Also adds the test_driver test suite.

## Review requests

## Risk assessment

Low, unreleased