### PR TITLE
test(shared-data): show command when useCommandTypeSummaries test fails

### DIFF
--- a/components/src/hooks/__tests__/useCommandTypeSummaries.test.tsx
+++ b/components/src/hooks/__tests__/useCommandTypeSummaries.test.tsx
@@ -45,9 +45,9 @@ describe('useCommandTypeSummaries', () => {
       })
 
       // Make sure it returns something non-empty and not the fallback string
-      expect(result.current).toBeDefined()
-      expect(result.current).not.toBe('')
-      expect(result.current).not.toBe('Unknown')
+      expect(result.current, cmd).toBeDefined()
+      expect(result.current, cmd).not.toBe('')
+      expect(result.current, cmd).not.toBe('Unknown')
     }
   })
 })


### PR DESCRIPTION
# Overview

When `useCommandTypeSummaries.test.tsx` fails, it emits the error
```
AssertionError: expected 'Unknown' not to be 'Unknown'
```
which is not very helpful for explaining what's wrong. (AUTH-2353)

This PR adds the offending command to the error message:
```
captureImage: expected 'Unknown' not to be 'Unknown'
```
which is slightly more informative.

## Test Plan and Hands on Testing

Ran `yarn vitest` locally.

## Risk assessment

Low.