### PR TITLE
fix(robot-server, api): Ensure live stream update always resets boot id

### DIFF
--- a/api/src/opentrons/config/__init__.py
+++ b/api/src/opentrons/config/__init__.py
@@ -308,7 +308,7 @@ CONFIG_ELEMENTS = (
         "The dir where performance metrics are stored",
     ),
     ConfigElement(
-        "live_stream_configuration_file",
+        "live_stream_environment_file",
         "Live Stream Configuration",
         Path("opentrons-live-stream.env"),
         ConfigElementType.FILE,

--- a/api/src/opentrons/config/__init__.py
+++ b/api/src/opentrons/config/__init__.py
@@ -310,7 +310,7 @@ CONFIG_ELEMENTS = (
     ConfigElement(
         "live_stream_configuration_file",
         "Live Stream Configuration",
-        Path("opentrons-live-stream.conf"),
+        Path("opentrons-live-stream.env"),
         ConfigElementType.FILE,
         "The file storing the Opentrons Live Stream Configuration values.",
     ),

--- a/api/src/opentrons/protocol_engine/protocol_engine.py
+++ b/api/src/opentrons/protocol_engine/protocol_engine.py
@@ -481,7 +481,7 @@ class ProtocolEngine:
         )
         self._state_store.commands.raise_fatal_command_error()
 
-    async def finish(
+    async def finish(  # noqa: C901
         self,
         error: Optional[Exception] = None,
         drop_tips_after_run: bool = True,

--- a/api/src/opentrons/protocol_engine/protocol_engine.py
+++ b/api/src/opentrons/protocol_engine/protocol_engine.py
@@ -13,6 +13,7 @@ from opentrons_shared_data.labware.labware_definition import LabwareDefinition
 from opentrons.hardware_control import HardwareControlAPI
 from opentrons.hardware_control.modules import AbstractModule as HardwareModuleAPI
 from opentrons.hardware_control.types import PauseType as HardwarePauseType
+from opentrons.system import camera
 
 from .actions.actions import (
     ResumeFromRecoveryAction,
@@ -593,6 +594,11 @@ class ProtocolEngine:
             )
         else:
             finish_error_details = None
+
+        try:
+            await camera.update_live_stream_status(False, self._camera_provider)
+        except Exception as e:
+            _log.exception(f"Exception during live stream post-run cleanup: {e}")
 
         self._action_dispatcher.dispatch(
             HardwareStoppedAction(

--- a/api/src/opentrons/protocol_runner/run_orchestrator.py
+++ b/api/src/opentrons/protocol_runner/run_orchestrator.py
@@ -223,9 +223,6 @@ class RunOrchestrator:
                 set_run_status=False,
                 post_run_hardware_state=PostRunHardwareState.STAY_ENGAGED_IN_PLACE,
             )
-        # Shut down the live stream, if there is one
-        if self._camera_provider:
-            await camera.update_live_stream_status(False, self._camera_provider)
 
     def resume_from_recovery(self, reconcile_false_positive: bool) -> None:
         """Resume the run from recovery."""

--- a/api/src/opentrons/system/camera.py
+++ b/api/src/opentrons/system/camera.py
@@ -107,7 +107,7 @@ async def take_picture(filename: Path) -> None:
 
 def get_stream_configuration_filepath() -> Path:
     """Return the file path to the Opentrons Live Stream Configuration file."""
-    filepath = get_opentrons_path("live_stream_configuration_file")
+    filepath = get_opentrons_path("live_stream_environment_file")
     if IS_ROBOT and not os.path.exists(filepath):
         # If the dynamic configuration file doesn't exist make it using our defaults file
         with open(DEFAULT_CONF_FILE, "r") as default_config:

--- a/api/src/opentrons/system/camera.py
+++ b/api/src/opentrons/system/camera.py
@@ -23,7 +23,7 @@ FLEX_EMBEDDED_CAMERA = "/dev/video2"
 OT2_CAMERA = "/dev/video0"
 
 # Stream Globals
-STREAM_CONF_FILE = "opentrons-live-stream.env"
+DEFAULT_CONF_FILE = "/lib/systemd/system/opentrons-live-stream/opentrons-live-stream.env"
 STREAM_CONF_FILE_KEYS = [
     "BOOT_ID",
     "STATUS",
@@ -105,7 +105,14 @@ async def take_picture(filename: Path) -> None:
 
 def get_stream_configuration_filepath() -> Path:
     """Return the file path to the Opentrons Live Stream Configuration file."""
-    return get_opentrons_path("live_stream_configuration_file")
+    filepath = get_opentrons_path("live_stream_configuration_file")
+    if IS_ROBOT and not os.path.exists(filepath):
+        # If the dynamic configuration file doesn't exist make it using our defaults file
+        with open(DEFAULT_CONF_FILE, 'r') as default_config:
+            content = default_config.read()
+        with open(filepath, 'w') as new_config_file:
+            new_config_file.write(content)
+    return filepath
 
 
 async def update_live_stream_status(

--- a/api/src/opentrons/system/camera.py
+++ b/api/src/opentrons/system/camera.py
@@ -2,11 +2,13 @@ import asyncio
 import os
 from pathlib import Path
 import logging
+from functools import lru_cache
 from enum import Enum
 from typing import Dict
 from opentrons.config import ARCHITECTURE, SystemArchitecture, get_opentrons_path
 from opentrons_shared_data.errors.exceptions import CommunicationError
 from opentrons_shared_data.errors.codes import ErrorCodes
+from opentrons.config import IS_ROBOT
 from opentrons.protocol_engine.resources.camera_provider import (
     CameraProvider,
     ImageParameters,
@@ -132,6 +134,7 @@ async def update_live_stream_status(
         # Enable the stream
         status = "ON"
     # Overwrite the contents
+    contents["BOOT_ID"] = get_boot_id()
     contents["STATUS"] = status
     write_stream_configuration_file_data(contents)
     await restart_live_stream()
@@ -307,3 +310,11 @@ async def image_capture(parameters: ImageParameters) -> bytes | CameraError:
         # Restart the live stream service
         await restart_live_stream()
     return result
+
+
+@lru_cache(maxsize=1)
+def get_boot_id() -> str:
+    if IS_ROBOT:
+        return Path("/proc/sys/kernel/random/boot_id").read_text().strip()
+    else:
+        return "SIMULATED_BOOT_ID"

--- a/api/src/opentrons/system/camera.py
+++ b/api/src/opentrons/system/camera.py
@@ -23,7 +23,7 @@ FLEX_EMBEDDED_CAMERA = "/dev/video2"
 OT2_CAMERA = "/dev/video0"
 
 # Stream Globals
-STREAM_CONF_FILE = "opentrons-live-stream.conf"
+STREAM_CONF_FILE = "opentrons-live-stream.env"
 STREAM_CONF_FILE_KEYS = [
     "BOOT_ID",
     "STATUS",

--- a/api/src/opentrons/system/camera.py
+++ b/api/src/opentrons/system/camera.py
@@ -23,7 +23,9 @@ FLEX_EMBEDDED_CAMERA = "/dev/video2"
 OT2_CAMERA = "/dev/video0"
 
 # Stream Globals
-DEFAULT_CONF_FILE = "/lib/systemd/system/opentrons-live-stream/opentrons-live-stream.env"
+DEFAULT_CONF_FILE = (
+    "/lib/systemd/system/opentrons-live-stream/opentrons-live-stream.env"
+)
 STREAM_CONF_FILE_KEYS = [
     "BOOT_ID",
     "STATUS",
@@ -108,9 +110,9 @@ def get_stream_configuration_filepath() -> Path:
     filepath = get_opentrons_path("live_stream_configuration_file")
     if IS_ROBOT and not os.path.exists(filepath):
         # If the dynamic configuration file doesn't exist make it using our defaults file
-        with open(DEFAULT_CONF_FILE, 'r') as default_config:
+        with open(DEFAULT_CONF_FILE, "r") as default_config:
             content = default_config.read()
-        with open(filepath, 'w') as new_config_file:
+        with open(filepath, "w") as new_config_file:
             new_config_file.write(content)
     return filepath
 

--- a/api/src/opentrons/system/camera.py
+++ b/api/src/opentrons/system/camera.py
@@ -121,6 +121,10 @@ async def update_live_stream_status(
     stream_status: bool, camera_provider: CameraProvider
 ) -> None:
     """Update and handle a change in the Opentrons Live Stream status."""
+    if not IS_ROBOT:
+        # If we are not on a robot we simply no-op updating the stream
+        return None
+
     contents = load_stream_configuration_file_data()
     if contents is None:
         log.error("Opentrons Live Stream Configuraiton file cannot be updated.")

--- a/robot-server/robot_server/service/legacy/routers/camera.py
+++ b/robot-server/robot_server/service/legacy/routers/camera.py
@@ -2,7 +2,6 @@ import logging
 import os
 import io
 import tempfile
-from functools import lru_cache
 from typing import Annotated
 from pathlib import Path
 from fastapi import APIRouter, HTTPException, Depends
@@ -382,7 +381,7 @@ def _live_stream_settings_to_configuration_file(
     settings: LiveStreamSettings, stream_status: StreamStatusType
 ) -> None:
     contents: dict[str, str] = {
-        StreamConfigurationKeys.BOOT_ID: _get_boot_id(),
+        StreamConfigurationKeys.BOOT_ID: camera.get_boot_id(),
         StreamConfigurationKeys.STATUS: stream_status,
         StreamConfigurationKeys.SOURCE: settings.source,
         StreamConfigurationKeys.RESOLUTION: f"{settings.resolution.width}x{settings.resolution.height}",
@@ -400,11 +399,3 @@ def _validate_camera_present() -> None:
             message=f"No video device found with device path: {DEFAULT_CAMERA}",
             errorCode=ErrorCodes.GENERAL_ERROR.value.code,
         ).as_error(status.HTTP_503_SERVICE_UNAVAILABLE)
-
-
-@lru_cache(maxsize=1)
-def _get_boot_id() -> str:
-    if IS_ROBOT:
-        return Path("/proc/sys/kernel/random/boot_id").read_text().strip()
-    else:
-        return "SIMULATED_BOOT_ID"


### PR DESCRIPTION
# Overview
Fixes a small oversight where the boot ID used to validate live stream settings between power cycles would not updated if no changes were made to stream settings or camera enablement. We now always update the boot ID anytime a call is made to update the live stream status.

## Test Plan and Hands on Testing
Run some power cycle stream tests on a Flex:

- [x] Update and enable stream, ensure it comes up
- [x] Power cycler robot, stream should not automatically begin
- [x] Begin a protocol run, stream should come up

## Changelog
Relocated the boot ID assignment to `system/camera`

## Review requests

## Risk assessment
Low - updates to the new camera behavior