### PR TITLE
fix(protocol-designer): do not filter tough plate in new location dropdown options

### DIFF
--- a/protocol-designer/src/pages/Designer/utils.ts
+++ b/protocol-designer/src/pages/Designer/utils.ts
@@ -361,8 +361,6 @@ export const useLabwareDropdownOptions = (
   return _sortLabwareDropdownOptions(labwareOptions)
 }
 
-const TOUGH_PLATE_LOADNAME = 'opentrons_96_wellplate_200ul_pcr_full_skirt'
-
 //  used for LabwareLocationField dropdown
 export const getUnoccupiedStackOptions = (args: {
   robotState: RobotState

--- a/protocol-designer/src/pages/Designer/utils.ts
+++ b/protocol-designer/src/pages/Designer/utils.ts
@@ -399,15 +399,15 @@ export const getUnoccupiedStackOptions = (args: {
       const isTopOfStack = fullStack[0] === labwareId
       const { def: labwareOnDeckDef } = labwareOnDeck
       const { displayName } = labwareOnDeckDef.metadata
-      const { loadName } = labwareOnDeckDef.parameters
+      const { loadName: labwareOnDeckLoadName } = labwareOnDeckDef.parameters
 
       //  NOTE: the tough plate is the only plate in the repo whose def allows for stacking
       //  on itself. We don't allow that pattern with any other well plate. So i'm hardcoding
       //  it in to filter it out for now. but in the future when we support labware stacking
       //  we need to make this logic more robust
       const isCompatible =
-        labwareCompatibleParentLabware?.includes(loadName) &&
-        loadName !== TOUGH_PLATE_LOADNAME
+        labwareCompatibleParentLabware?.includes(labwareOnDeckLoadName) ||
+        def.parameters.loadName !== TOUGH_PLATE_LOADNAME
       const isNotCurrentLabwareStack = !fullStack.includes(
         labwareIdFromDropdown
       )

--- a/protocol-designer/src/pages/Designer/utils.ts
+++ b/protocol-designer/src/pages/Designer/utils.ts
@@ -401,13 +401,10 @@ export const getUnoccupiedStackOptions = (args: {
       const { displayName } = labwareOnDeckDef.metadata
       const { loadName: labwareOnDeckLoadName } = labwareOnDeckDef.parameters
 
-      //  NOTE: the tough plate is the only plate in the repo whose def allows for stacking
-      //  on itself. We don't allow that pattern with any other well plate. So i'm hardcoding
-      //  it in to filter it out for now. but in the future when we support labware stacking
-      //  we need to make this logic more robust
-      const isCompatible =
-        labwareCompatibleParentLabware?.includes(labwareOnDeckLoadName) ||
-        def.parameters.loadName !== TOUGH_PLATE_LOADNAME
+      const isCompatible = labwareCompatibleParentLabware?.includes(
+        labwareOnDeckLoadName
+      )
+
       const isNotCurrentLabwareStack = !fullStack.includes(
         labwareIdFromDropdown
       )


### PR DESCRIPTION
closes RQA-4777

# Overview

basically reverts the change made to fix this: https://opentrons.atlassian.net/browse/RQA-4766

since it caused a lot of other issues

## Test Plan and Hands on Testing

upload attached protocol to the ticket, delete the lid on top of the thermocycler tough well plate and see that you can move a lid onto the well plate on the thermocycler

## Changelog


## Risk assessment

low
