### PR TITLE
refactor(app): Robot settings tabs and remove canceled banner

### DIFF
--- a/app/src/molecules/RoundTab/index.tsx
+++ b/app/src/molecules/RoundTab/index.tsx
@@ -1,0 +1,88 @@
+import { NavLink } from 'react-router-dom'
+import styled, { css } from 'styled-components'
+
+import {
+  BORDERS,
+  COLORS,
+  LegacyStyledText,
+  POSITION_RELATIVE,
+  SPACING,
+  Tooltip,
+  TYPOGRAPHY,
+  useHoverTooltip,
+} from '@opentrons/components'
+
+const baseRoundTabStyling = css`
+  ${TYPOGRAPHY.pSemiBold}
+  color: ${COLORS.black90};
+  background-color: ${COLORS.purple30};
+  border: 0px ${BORDERS.styleSolid} ${COLORS.purple30};
+  border-radius: ${BORDERS.borderRadius8};
+  padding: ${SPACING.spacing8} ${SPACING.spacing16};
+  position: ${POSITION_RELATIVE};
+
+  &:hover {
+    background-color: ${COLORS.purple35};
+  }
+
+  &:focus-visible {
+    outline: 2px ${BORDERS.styleSolid} ${COLORS.yellow50};
+  }
+`
+const disabledRoundTabStyling = css`
+  ${baseRoundTabStyling}
+  color: ${COLORS.grey40};
+  background-color: ${COLORS.grey30};
+
+  &:hover {
+    background-color: ${COLORS.grey30};
+  }
+`
+
+const RoundNavLink = styled(NavLink)`
+  ${baseRoundTabStyling}
+  color: ${COLORS.black90};
+
+  &:hover {
+    background-color: ${COLORS.purple35};
+  }
+
+  &.active {
+    background-color: ${COLORS.purple50};
+    color: ${COLORS.white};
+
+    &:hover {
+      background-color: ${COLORS.purple55};
+    }
+  }
+`
+
+interface RoundTabProps {
+  disabled: boolean
+  tabDisabledReason?: string
+  to: string
+  tabName: string
+}
+
+export function RoundTab({
+  disabled,
+  tabDisabledReason,
+  to,
+  tabName,
+}: RoundTabProps): JSX.Element {
+  const [targetProps, tooltipProps] = useHoverTooltip()
+  return disabled ? (
+    <>
+      <LegacyStyledText css={disabledRoundTabStyling} {...targetProps}>
+        {tabName}
+      </LegacyStyledText>
+      {tabDisabledReason != null ? (
+        <Tooltip tooltipProps={tooltipProps}>{tabDisabledReason}</Tooltip>
+      ) : null}
+    </>
+  ) : (
+    <RoundNavLink to={to} replace>
+      {tabName}
+    </RoundNavLink>
+  )
+}

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderBannerContainer/getShowGenericRunHeaderBanners.ts
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderBannerContainer/getShowGenericRunHeaderBanners.ts
@@ -2,7 +2,6 @@ import {
   RUN_STATUS_AWAITING_RECOVERY_BLOCKED_BY_OPEN_DOOR,
   RUN_STATUS_AWAITING_RECOVERY_PAUSED,
   RUN_STATUS_BLOCKED_BY_OPEN_DOOR,
-  RUN_STATUS_STOPPED,
 } from '@opentrons/api-client'
 
 import { NOT_CONFIGURED } from '../../../../../DoorOpenControl/useIsDoorOpen'
@@ -18,7 +17,6 @@ interface ShowGenericRunHeaderBannersParams {
 }
 
 interface ShowGenericRunHeaderBannersResult {
-  showRunCanceledBanner: boolean
   showDoorOpenDuringRunBanner: boolean
   showDoorOpenBeforeRunBanner: boolean
   showStackerDoorOpenDuringRunBanner: boolean
@@ -39,8 +37,6 @@ export function getShowGenericRunHeaderBanners({
     runStatus !== RUN_STATUS_BLOCKED_BY_OPEN_DOOR &&
     runStatus !== RUN_STATUS_AWAITING_RECOVERY_BLOCKED_BY_OPEN_DOOR &&
     runStatus !== RUN_STATUS_AWAITING_RECOVERY_PAUSED
-
-  const showRunCanceledBanner = runStatus === RUN_STATUS_STOPPED && !enteredER
 
   const showDoorOpenBeforeRunBanner =
     doorStatus.moduleDoorLocation === null && beforeRunCondition
@@ -67,7 +63,6 @@ export function getShowGenericRunHeaderBanners({
     doorStatus.moduleDoorLocation !== NOT_CONFIGURED
 
   return {
-    showRunCanceledBanner,
     showDoorOpenBeforeRunBanner,
     showDoorOpenDuringRunBanner,
     showStackerDoorOpenDuringRunBanner,

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderBannerContainer/index.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderBannerContainer/index.tsx
@@ -55,7 +55,6 @@ export function RunHeaderBannerContainer(
   const doorStatus = useIsDoorOpen(robotName)
 
   const {
-    showRunCanceledBanner,
     showDoorOpenBeforeRunBanner,
     showDoorOpenDuringRunBanner,
     showStackerDoorOpenBeforeRunBanner,
@@ -97,11 +96,6 @@ export function RunHeaderBannerContainer(
         <ProtocolAnalysisErrorBanner
           errors={analysisErrorModalUtils.modalProps.errors}
         />
-      ) : null}
-      {showRunCanceledBanner ? (
-        <Banner type="warning" iconMarginLeft={SPACING.spacing4}>
-          {t('run_canceled')}
-        </Banner>
       ) : null}
       {doorBannerText ? (
         <Banner type="warning" iconMarginLeft={SPACING.spacing4}>

--- a/app/src/pages/Desktop/Devices/ProtocolRunDetails/index.tsx
+++ b/app/src/pages/Desktop/Devices/ProtocolRunDetails/index.tsx
@@ -1,9 +1,8 @@
 import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useDispatch } from 'react-redux'
-import { Navigate, NavLink, useNavigate, useParams } from 'react-router-dom'
+import { Navigate, useNavigate, useParams } from 'react-router-dom'
 import isEmpty from 'lodash/isEmpty'
-import styled, { css } from 'styled-components'
 
 import { RUN_STATUS_IDLE } from '@opentrons/api-client'
 import {
@@ -14,16 +13,12 @@ import {
   DIRECTION_ROW,
   Flex,
   JUSTIFY_SPACE_AROUND,
-  LegacyStyledText,
   OVERFLOW_SCROLL,
-  POSITION_RELATIVE,
   SPACING,
-  Tooltip,
-  TYPOGRAPHY,
-  useHoverTooltip,
 } from '@opentrons/components'
 import { ApiHostProvider } from '@opentrons/react-api-client'
 
+import { RoundTab } from '/app/molecules/RoundTab'
 import { useSyncRobotClock } from '/app/organisms/Desktop/Devices/hooks'
 import { BackToTopButton } from '/app/organisms/Desktop/Devices/ProtocolRun/BackToTopButton'
 import { ProtocolRunCamera } from '/app/organisms/Desktop/Devices/ProtocolRun/ProtocolRunCamera'
@@ -49,83 +44,7 @@ import type { ViewportListRef } from 'react-viewport-list'
 import type { DesktopRouteParams, ProtocolRunDetailsTab } from '/app/App/types'
 import type { Dispatch } from '/app/redux/types'
 
-const baseRoundTabStyling = css`
-  ${TYPOGRAPHY.pSemiBold}
-  color: ${COLORS.black90};
-  background-color: ${COLORS.purple30};
-  border: 0px ${BORDERS.styleSolid} ${COLORS.purple30};
-  border-radius: ${BORDERS.borderRadius8};
-  padding: ${SPACING.spacing8} ${SPACING.spacing16};
-  position: ${POSITION_RELATIVE};
-
-  &:hover {
-    background-color: ${COLORS.purple35};
-  }
-
-  &:focus-visible {
-    outline: 2px ${BORDERS.styleSolid} ${COLORS.yellow50};
-  }
-`
-
-const disabledRoundTabStyling = css`
-  ${baseRoundTabStyling}
-  color: ${COLORS.grey40};
-  background-color: ${COLORS.grey30};
-
-  &:hover {
-    background-color: ${COLORS.grey30};
-  }
-`
-
-const RoundNavLink = styled(NavLink)`
-  ${baseRoundTabStyling}
-  color: ${COLORS.black90};
-
-  &:hover {
-    background-color: ${COLORS.purple35};
-  }
-
-  &.active {
-    background-color: ${COLORS.purple50};
-    color: ${COLORS.white};
-
-    &:hover {
-      background-color: ${COLORS.purple55};
-    }
-  }
-`
-
 const JUMP_OFFSET_FROM_TOP_PX = 20
-
-interface RoundTabProps {
-  disabled: boolean
-  tabDisabledReason?: string
-  to: string
-  tabName: string
-}
-
-export function RoundTab({
-  disabled,
-  tabDisabledReason,
-  to,
-  tabName,
-}: RoundTabProps): JSX.Element {
-  const [targetProps, tooltipProps] = useHoverTooltip()
-  return disabled ? (
-    <>
-      <LegacyStyledText css={disabledRoundTabStyling} {...targetProps}>
-        {tabName}
-      </LegacyStyledText>
-      {tabDisabledReason != null ? (
-        <Tooltip tooltipProps={tooltipProps}>{tabDisabledReason}</Tooltip>
-      ) : null}
-    </>
-  ) : (
-    <RoundNavLink to={to} replace>
-      {tabName}
-    </RoundNavLink>
-  )
-}
 
 export function ProtocolRunDetails(): JSX.Element | null {
   const { robotName, runId, protocolRunDetailsTab } = useParams<

--- a/app/src/pages/Desktop/Devices/ProtocolRunDetails/index.tsx
+++ b/app/src/pages/Desktop/Devices/ProtocolRunDetails/index.tsx
@@ -104,7 +104,7 @@ interface RoundTabProps {
   tabName: string
 }
 
-function RoundTab({
+export function RoundTab({
   disabled,
   tabDisabledReason,
   to,

--- a/app/src/pages/Desktop/Devices/RobotSettings/index.tsx
+++ b/app/src/pages/Desktop/Devices/RobotSettings/index.tsx
@@ -17,13 +17,13 @@ import {
 } from '@opentrons/components'
 import { ApiHostProvider } from '@opentrons/react-api-client'
 
+import { RoundTab } from '/app/molecules/RoundTab'
 import { ReachableBanner } from '/app/organisms/Desktop/Devices/ReachableBanner'
 import { RobotSettingsAdvanced } from '/app/organisms/Desktop/Devices/RobotSettings/RobotSettingsAdvanced'
 import { RobotSettingsCamera } from '/app/organisms/Desktop/Devices/RobotSettings/RobotSettingsCamera'
 import { RobotSettingsFeatureFlags } from '/app/organisms/Desktop/Devices/RobotSettings/RobotSettingsFeatureFlags'
 import { RobotSettingsNetworking } from '/app/organisms/Desktop/Devices/RobotSettings/RobotSettingsNetworking'
 import { RobotSettingsCalibration } from '/app/organisms/Desktop/RobotSettingsCalibration'
-import { RoundTab } from '/app/pages/Desktop/Devices/ProtocolRunDetails'
 import { useRobot } from '/app/redux-resources/robots'
 import { getDevtoolsEnabled, useFeatureFlag } from '/app/redux/config'
 import {

--- a/app/src/pages/Desktop/Devices/RobotSettings/index.tsx
+++ b/app/src/pages/Desktop/Devices/RobotSettings/index.tsx
@@ -17,13 +17,13 @@ import {
 } from '@opentrons/components'
 import { ApiHostProvider } from '@opentrons/react-api-client'
 
-import { NavTab } from '/app/molecules/NavTab'
 import { ReachableBanner } from '/app/organisms/Desktop/Devices/ReachableBanner'
 import { RobotSettingsAdvanced } from '/app/organisms/Desktop/Devices/RobotSettings/RobotSettingsAdvanced'
 import { RobotSettingsCamera } from '/app/organisms/Desktop/Devices/RobotSettings/RobotSettingsCamera'
 import { RobotSettingsFeatureFlags } from '/app/organisms/Desktop/Devices/RobotSettings/RobotSettingsFeatureFlags'
 import { RobotSettingsNetworking } from '/app/organisms/Desktop/Devices/RobotSettings/RobotSettingsNetworking'
 import { RobotSettingsCalibration } from '/app/organisms/Desktop/RobotSettingsCalibration'
+import { RoundTab } from '/app/pages/Desktop/Devices/ProtocolRunDetails'
 import { useRobot } from '/app/redux-resources/robots'
 import { getDevtoolsEnabled, useFeatureFlag } from '/app/redux/config'
 import {
@@ -111,11 +111,11 @@ export function RobotSettings(): JSX.Element | null {
         minHeight="calc(100vh - 3.5rem)"
         width="100%"
       >
-        <Box paddingX={SPACING.spacing16}>
+        <Box paddingX={SPACING.spacing16} paddingY={SPACING.spacing16}>
           <Box
             color={COLORS.black90}
             css={TYPOGRAPHY.h1Default}
-            padding={`${SPACING.spacing24} 0`}
+            padding={`${SPACING.spacing10} 0`}
           >
             {t('robot_settings')}
           </Box>
@@ -131,31 +131,34 @@ export function RobotSettings(): JSX.Element | null {
               </LegacyStyledText>
             </Banner>
           )}
-          <Flex gridGap={SPACING.spacing16}>
-            <NavTab
+          <Flex gridGap={SPACING.spacing4}>
+            <RoundTab
               to={`/devices/${robotName}/robot-settings/calibration`}
               tabName={t('calibration')}
               disabled={isCalibrationDisabled}
             />
-            <NavTab
+            <RoundTab
               to={`/devices/${robotName}/robot-settings/networking`}
               tabName={t('networking')}
               disabled={isNetworkingDisabled}
             />
             {isCameraEnabled ? (
-              <NavTab
+              <RoundTab
                 to={`/devices/${robotName}/robot-settings/camera`}
                 tabName={t('camera')}
+                disabled={false}
               />
             ) : null}
-            <NavTab
+            <RoundTab
               to={`/devices/${robotName}/robot-settings/advanced`}
               tabName={t('advanced')}
+              disabled={false}
             />
             {devToolsOn ? (
-              <NavTab
+              <RoundTab
                 to={`/devices/${robotName}/robot-settings/feature-flags`}
                 tabName={t('feature_flags')}
+                disabled={false}
               />
             ) : null}
           </Flex>

--- a/app/src/pages/Desktop/Devices/RobotSettings/index.tsx
+++ b/app/src/pages/Desktop/Devices/RobotSettings/index.tsx
@@ -9,8 +9,8 @@ import {
   Box,
   COLORS,
   DIRECTION_COLUMN,
-  Divider,
   Flex,
+  JUSTIFY_SPACE_AROUND,
   LegacyStyledText,
   SPACING,
   TYPOGRAPHY,
@@ -102,80 +102,84 @@ export function RobotSettings(): JSX.Element | null {
   )
 
   return (
-    <Box minWidth="32rem" height="max-content" padding={SPACING.spacing16}>
-      <Flex
-        backgroundColor={COLORS.white}
-        borderRadius={BORDERS.borderRadius8}
-        flexDirection={DIRECTION_COLUMN}
-        marginBottom={SPACING.spacing16}
-        minHeight="calc(100vh - 3.5rem)"
-        width="100%"
-      >
-        <Box paddingX={SPACING.spacing16} paddingY={SPACING.spacing16}>
-          <Box
-            color={COLORS.black90}
-            css={TYPOGRAPHY.h1Default}
-            padding={`${SPACING.spacing10} 0`}
-          >
-            {t('robot_settings')}
-          </Box>
+    <>
+      <Box paddingX={SPACING.spacing16} paddingY={SPACING.spacing16}>
+        <Flex
+          color={COLORS.black90}
+          flexDirection={DIRECTION_COLUMN}
+          css={TYPOGRAPHY.h1Default}
+          gridGap={SPACING.spacing4}
+        >
+          {t('robot_settings')}
           {robot != null && (
             <Box marginBottom={SPACING.spacing16}>
               <ReachableBanner robot={robot} />
             </Box>
           )}
           {showRobotBusyBanner && (
-            <Banner type="warning" marginBottom={SPACING.spacing16}>
+            <Banner type="warning" marginBottom={SPACING.spacing8}>
               <LegacyStyledText as="p">
                 {t('some_robot_controls_are_not_available')}
               </LegacyStyledText>
             </Banner>
           )}
-          <Flex gridGap={SPACING.spacing4}>
+        </Flex>
+      </Box>
+      <Box paddingX={SPACING.spacing16}>
+        <Flex gridGap={SPACING.spacing4}>
+          <RoundTab
+            to={`/devices/${robotName}/robot-settings/calibration`}
+            tabName={t('calibration')}
+            disabled={isCalibrationDisabled}
+          />
+          <RoundTab
+            to={`/devices/${robotName}/robot-settings/networking`}
+            tabName={t('networking')}
+            disabled={isNetworkingDisabled}
+          />
+          {isCameraEnabled ? (
             <RoundTab
-              to={`/devices/${robotName}/robot-settings/calibration`}
-              tabName={t('calibration')}
-              disabled={isCalibrationDisabled}
-            />
-            <RoundTab
-              to={`/devices/${robotName}/robot-settings/networking`}
-              tabName={t('networking')}
-              disabled={isNetworkingDisabled}
-            />
-            {isCameraEnabled ? (
-              <RoundTab
-                to={`/devices/${robotName}/robot-settings/camera`}
-                tabName={t('camera')}
-                disabled={false}
-              />
-            ) : null}
-            <RoundTab
-              to={`/devices/${robotName}/robot-settings/advanced`}
-              tabName={t('advanced')}
+              to={`/devices/${robotName}/robot-settings/camera`}
+              tabName={t('camera')}
               disabled={false}
             />
-            {devToolsOn ? (
-              <RoundTab
-                to={`/devices/${robotName}/robot-settings/feature-flags`}
-                tabName={t('feature_flags')}
-                disabled={false}
-              />
-            ) : null}
-          </Flex>
-        </Box>
-        <Divider marginY="0" />
-        <Box padding={`${SPACING.spacing24} ${SPACING.spacing16}`}>
-          <ApiHostProvider
-            hostname={robot?.ip ?? null}
-            port={robot?.port ?? null}
-            requestor={
-              robot?.ip === OPENTRONS_USB ? appShellRequestor : undefined
-            }
+          ) : null}
+          <RoundTab
+            to={`/devices/${robotName}/robot-settings/advanced`}
+            tabName={t('advanced')}
+            disabled={false}
+          />
+          {devToolsOn ? (
+            <RoundTab
+              to={`/devices/${robotName}/robot-settings/feature-flags`}
+              tabName={t('feature_flags')}
+              disabled={false}
+            />
+          ) : null}
+        </Flex>
+      </Box>
+      <Box padding={`${SPACING.spacing24} ${SPACING.spacing16}`}>
+        <ApiHostProvider
+          hostname={robot?.ip ?? null}
+          port={robot?.port ?? null}
+          requestor={
+            robot?.ip === OPENTRONS_USB ? appShellRequestor : undefined
+          }
+        >
+          <Flex
+            width="100%"
+            flexDirection={DIRECTION_COLUMN}
+            justifyContent={JUSTIFY_SPACE_AROUND}
+            backgroundColor={COLORS.white}
+            borderRadius={BORDERS.borderRadius8}
+            marginBottom={SPACING.spacing16}
+            paddingX={SPACING.spacing16}
+            paddingY={SPACING.spacing16}
           >
             {robotSettingsContent}
-          </ApiHostProvider>
-        </Box>
-      </Flex>
-    </Box>
+          </Flex>
+        </ApiHostProvider>
+      </Box>
+    </>
   )
 }


### PR DESCRIPTION
# Overview

Match robot settings page to protocol set up

Remove canceled run banner

## Test Plan and Hands on Testing

- Smoke checked robot with canceled run and simulated app to look at robot settings page

## Changelog
<img width="923" height="529" alt="Screenshot 2025-10-20 at 3 38 38 PM" src="https://github.com/user-attachments/assets/bc636144-2374-454d-8e9f-a5f7265d1d47" />

- Moved RoundTab to be a shared component since it is now being used by `RobotSettings` and `ProtocolRunDetails`

## Review requests

- Each page on the settings tab looks like the text is formatted differently. Probably want to do a follow up PR to fix that at some point
- 
<img width="928" height="508" alt="Screenshot 2025-10-20 at 10 27 33 AM" src="https://github.com/user-attachments/assets/7bdfb253-3324-49c8-a816-2864ac418fa9" />
<img width="933" height="379" alt="Screenshot 2025-10-20 at 10 27 27 AM" src="https://github.com/user-attachments/assets/7f936fff-770b-44d7-b7c7-77270cffb415" />

Closes EXEC-1860
Closes EXEC-1979
Closes EXEC-1982