### PR TITLE
fix(app): Mag block showing as required when you just need a staging area

### DIFF
--- a/app/src/resources/deck_configuration/utils.ts
+++ b/app/src/resources/deck_configuration/utils.ts
@@ -121,7 +121,7 @@ export const getFilteredDeckConfigFixtureCompatibility = (
         // if there is a magnetic block combination fixture, separate it out
         // and show two line items in the table
         if (
-          compatabilityItem.compatibleCutoutFixtureIds.some(fixtureId =>
+          compatabilityItem.compatibleCutoutFixtureIds.every(fixtureId =>
             MAGNETIC_BLOCK_FIXTURES.includes(fixtureId)
           )
         ) {


### PR DESCRIPTION
Fix [ RQA-4478](https://opentrons.atlassian.net/browse/RQA-4778)
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
We were requiring a magblock in deck conflict resolution if there was an item in the required section where a possible match was the mag block + staging area fixture. We need to change this to only list a mag block as required if every fixture in the compatible fixtures list includes a mag block
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
For the protocol linked in Boren's slack message, see that without this change you are prompted to add a mag block:
<img width="1020" height="796" alt="Screenshot 2025-10-20 at 4 18 00 PM" src="https://github.com/user-attachments/assets/b8e68090-94a5-40a3-a3cd-c02def915ee1" />
With this change, we require a staging area (this is the correct behavior)
<img width="1025" height="798" alt="Screenshot 2025-10-20 at 4 18 56 PM" src="https://github.com/user-attachments/assets/65e8fe21-794a-468a-a2e1-f3663385f9b6" />
I also tested this with a protocol that requires both a mag block + staging area to ensure this change doesn't break this case
<img width="1023" height="793" alt="Screenshot 2025-10-20 at 4 25 21 PM" src="https://github.com/user-attachments/assets/c3c4388d-bb83-4cde-96d1-07cc8c8f1c6f" />

<!--

Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
Change the `getFilteredDeckConfigFixtureCompatibility` to add a mag block requirement if `every` item in the list is a mag block fixture, not just if `some` item in the list is a mag block fixture
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests
Quick logic check
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
Low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
