### PR TITLE
fix(protocol-designer): allow universal lid to stack on itself

### DIFF
--- a/protocol-designer/src/pages/Designer/utils.ts
+++ b/protocol-designer/src/pages/Designer/utils.ts
@@ -399,9 +399,13 @@ export const getUnoccupiedStackOptions = (args: {
       const { displayName } = labwareOnDeckDef.metadata
       const { loadName: labwareOnDeckLoadName } = labwareOnDeckDef.parameters
 
-      const isCompatible = labwareCompatibleParentLabware?.includes(
-        labwareOnDeckLoadName
-      )
+      const isCompatible =
+        labwareCompatibleParentLabware?.includes(
+          labwareOnDeckLoadName
+          //  allow universal lid to go on itself, special-case since it doesn't have a compatibleParentLabware array
+        ) ||
+        (def.parameters.loadName === 'opentrons_tough_universal_lid' &&
+          labwareOnDeckLoadName === 'opentrons_tough_universal_lid')
 
       const isNotCurrentLabwareStack = !fullStack.includes(
         labwareIdFromDropdown


### PR DESCRIPTION
closes RQA-4777

# Overview

Fixes a bug where the universal lid stack wouldn't allow more universal lids, this is because the universal lid def doesn't include a `compatibleParentLabware` array

## Test Plan and Hands on Testing

Upload attached protocol to the comment in the ticket and see that you can create a move labware step to move the universal lid on the temperature module and block onto a stack of universal lids

## Changelog

allow universal lid stacking on itself

## Risk assessment

low