### PR TITLE
feat(api): add z movement delay arguments to aspirate/dispense

### DIFF
--- a/api/src/opentrons/hardware_control/backends/flex_protocol.py
+++ b/api/src/opentrons/hardware_control/backends/flex_protocol.py
@@ -176,6 +176,7 @@ class FlexBackend(Protocol):
         speed: float,
         stop_condition: HWStopCondition = HWStopCondition.none,
         nodes_in_moves_only: bool = True,
+        delay: Optional[Tuple[List[Axis], float]] = None,
     ) -> None:
         """Move to a position.
 

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -49,6 +49,7 @@ from .ot3utils import (
     gripper_jaw_state_from_fw,
     get_system_constraints,
     get_system_constraints_for_plunger_acceleration,
+    add_delay_to_move_group,
 )
 from .tip_presence_manager import TipPresenceManager
 
@@ -657,6 +658,7 @@ class OT3Controller(FlexBackend):
         speed: float,
         stop_condition: HWStopCondition,
         nodes_in_moves_only: bool,
+        delay: Optional[Tuple[List[Axis], float]] = None,
     ) -> Tuple[Optional[MoveGroupRunner], bool]:
         if not target:
             return None, False
@@ -683,6 +685,14 @@ class OT3Controller(FlexBackend):
         move_group, _ = create_move_group(
             origin, moves, ordered_nodes, MoveStopCondition[stop_condition.name]
         )
+
+        if delay is not None:
+            delay_axes, delay_time = delay
+            delay_nodes = [axis_to_node(ax) for ax in delay_axes]
+            move_group = add_delay_to_move_group(
+                move_group, ordered_nodes, (delay_nodes, delay_time)
+            )
+
         return (
             MoveGroupRunner(
                 move_groups=[move_group],
@@ -728,6 +738,7 @@ class OT3Controller(FlexBackend):
         speed: float,
         stop_condition: HWStopCondition = HWStopCondition.none,
         nodes_in_moves_only: bool = True,
+        delay: Optional[Tuple[List[Axis], float]] = None,
     ) -> None:
         """Move to a position.
 
@@ -750,7 +761,7 @@ class OT3Controller(FlexBackend):
 
         maybe_runners = (
             self._build_move_node_axis_runner(
-                origin, target, speed, stop_condition, nodes_in_moves_only
+                origin, target, speed, stop_condition, nodes_in_moves_only, delay
             ),
             self._build_move_gear_axis_runner(
                 possible_q_axis_origin,

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -367,6 +367,7 @@ class OT3Simulator(FlexBackend):
         speed: Optional[float] = None,
         stop_condition: HWStopCondition = HWStopCondition.none,
         nodes_in_moves_only: bool = True,
+        delay: Optional[Tuple[List[Axis], float]] = None,
     ) -> None:
         """Move to a position.
 

--- a/api/src/opentrons/hardware_control/backends/ot3utils.py
+++ b/api/src/opentrons/hardware_control/backends/ot3utils.py
@@ -1,4 +1,5 @@
 """Shared utilities for ot3 hardware control."""
+import copy
 from typing import Dict, Iterable, List, Set, Tuple, TypeVar, cast, Sequence, Optional
 from typing_extensions import Literal
 from logging import getLogger
@@ -57,6 +58,8 @@ from opentrons_hardware.hardware_control.motion import (
     MoveStopCondition,
     create_gripper_jaw_step,
     create_tip_action_step,
+    SingleMoveStep,
+    MoveGroupSingleAxisStep,
 )
 from opentrons_hardware.hardware_control.constants import interrupts_per_sec
 
@@ -374,6 +377,40 @@ def motor_nodes(devices: Set[FirmwareTarget]) -> Set[NodeId]:
     motor_nodes -= hepa_uv_nodes
     # filter out usb nodes
     return {NodeId(target) for target in motor_nodes if target in NodeId}
+
+
+def add_delay_to_move_group(
+    group: MoveGroup,
+    present_nodes: Iterable[NodeId],
+    delay: Tuple[List[NodeId], float],
+) -> MoveGroup:
+    delay_nodes, delay_time = delay
+    if delay_time == 0.0:
+        return group
+
+    as_single_moves: Dict[NodeId, List[SingleMoveStep]] = {}
+    for node in present_nodes:
+        as_single_moves[node] = [step[node] for step in group]
+
+    delay_step = MoveGroupSingleAxisStep(
+        distance_mm=np.float64(0),
+        velocity_mm_sec=np.float64(0),
+        duration_sec=np.float64(delay_time),
+    )
+    for node in present_nodes:
+        if node in delay_nodes:
+            # Add the delay at the beginning
+            as_single_moves[node] = [copy.deepcopy(delay_step)] + as_single_moves[node]
+        else:
+            # Add the delay at the end.
+            as_single_moves[node] = as_single_moves[node] + [copy.deepcopy(delay_step)]
+
+    new_move_group: MoveGroup = []
+    for i in range(len(group) + 1):
+        new_move_group.append(
+            {node: as_single_moves[node][i] for node in present_nodes}
+        )
+    return new_move_group
 
 
 def create_move_group(

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1524,6 +1524,7 @@ class OT3API(
         acquire_lock: bool = True,
         check_bounds: MotionChecks = MotionChecks.NONE,
         expect_stalls: bool = False,
+        delay: Optional[Tuple[List[Axis], float]] = None,
     ) -> None:
         """Worker function to apply robot motion."""
         machine_pos = machine_from_deck(
@@ -1557,6 +1558,7 @@ class OT3API(
                     machine_pos,
                     speed or 400.0,
                     HWStopCondition.stall if expect_stalls else HWStopCondition.none,
+                    delay=delay,
                 )
             except Exception:
                 self._log.exception("Move failed")
@@ -3085,6 +3087,7 @@ class OT3API(
         end_point: top_types.Point,
         volume: float,
         flow_rate: float = 1.0,
+        movement_delay: Optional[float] = None,
     ) -> None:
         """
         Aspirate a volume of liquid (in microliters/uL) while moving the z axis synchronously.
@@ -3115,6 +3118,9 @@ class OT3API(
             end_position,
         )
 
+        delay: Optional[Tuple[List[Axis], float]] = None
+        if movement_delay is not None:
+            delay = ([Axis.X, Axis.Y, Axis.Z_L, Axis.Z_R], movement_delay)
         try:
             await self._backend.set_active_current(
                 {aspirate_spec.axis: aspirate_spec.current}
@@ -3127,6 +3133,7 @@ class OT3API(
                     target_pos,
                     speed=aspirate_spec.speed,
                     home_flagged_axes=False,
+                    delay=delay,
                 )
         except Exception:
             self._log.exception("Aspirate failed")
@@ -3143,6 +3150,7 @@ class OT3API(
         push_out: Optional[float],
         flow_rate: float = 1.0,
         is_full_dispense: bool = False,
+        movement_delay: Optional[float] = None,
     ) -> None:
         """
         Dispense a volume of liquid (in microliters/uL) while moving the z axis synchronously.
@@ -3173,6 +3181,10 @@ class OT3API(
             end_position,
         )
 
+        delay: Optional[Tuple[List[Axis], float]] = None
+        if movement_delay is not None:
+            delay = ([Axis.X, Axis.Y, Axis.Z_L, Axis.Z_R], movement_delay)
+
         try:
             await self._backend.set_active_current(
                 {dispense_spec.axis: dispense_spec.current}
@@ -3185,6 +3197,7 @@ class OT3API(
                     target_pos,
                     speed=dispense_spec.speed,
                     home_flagged_axes=False,
+                    delay=delay,
                 )
         except Exception:
             self._log.exception("dispense failed")

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -3096,6 +3096,7 @@ class OT3API(
         :param z_distance: The distance the z axis will move during apsiration.
         :param volume: The volume of liquid to be aspirated.
         :param flow_rate: The flow rate to aspirate with.
+        :param movement_delay: Time to wait after the pipette starts aspirating before x/y/z movement.
         """
         realmount = OT3Mount.from_mount(mount)
         aspirate_spec = self._pipette_handler.plan_check_aspirate(
@@ -3159,6 +3160,7 @@ class OT3API(
         :param z_distance: The distance the z axis will move during dispensing.
         :param volume: The volume of liquid to be dispensed.
         :param flow_rate: The flow rate to dispense with.
+        :param movement_delay: Time to wait after the pipette starts dispensing before x/y/z movement.
         """
         realmount = OT3Mount.from_mount(mount)
         dispense_spec = self._pipette_handler.plan_check_dispense(

--- a/api/src/opentrons/hardware_control/protocols/liquid_handler.py
+++ b/api/src/opentrons/hardware_control/protocols/liquid_handler.py
@@ -128,6 +128,7 @@ class LiquidHandler(
         end_point: Point,
         volume: float,
         flow_rate: float = 1.0,
+        movement_delay: Optional[float] = None,
     ) -> None:
         """
         Aspirate a volume of liquid (in microliters/uL) while moving the z axis synchronously.
@@ -136,6 +137,7 @@ class LiquidHandler(
         :param z_distance: The distance the z axis will move during apsiration.
         :param volume: The volume of liquid to be aspirated.
         :param flow_rate: The flow rate to aspirate with.
+        :param movement_delay: Time to wait after the pipette starts aspirating before x/y/z movement.
         """
         ...
 
@@ -169,6 +171,7 @@ class LiquidHandler(
         push_out: Optional[float],
         flow_rate: float = 1.0,
         is_full_dispense: bool = False,
+        movement_delay: Optional[float] = None,
     ) -> None:
         """
         Dispense a volume of liquid (in microliters/uL) while moving the z axis synchronously.
@@ -177,6 +180,7 @@ class LiquidHandler(
         :param z_distance: The distance the z axis will move during dispensing.
         :param volume: The volume of liquid to be dispensed.
         :param flow_rate: The flow rate to dispense with.
+        :param movement_delay: Time to wait after the pipette starts dispensing before x/y/z movement.
         """
         ...
 

--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -206,6 +206,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         end_location: Optional[Location] = None,
         end_meniscus_tracking: Optional[MeniscusTrackingTarget] = None,
         correction_volume: Optional[float] = None,
+        movement_delay: Optional[float] = None,
     ) -> None:
         """Aspirate a given volume of liquid from the specified location.
         Args:
@@ -290,6 +291,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                         volume=volume,
                         flowRate=flow_rate,
                         correctionVolume=correction_volume,
+                        movement_delay=movement_delay,
                     )
                 )
             else:
@@ -320,6 +322,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         end_location: Optional[Location] = None,
         end_meniscus_tracking: Optional[MeniscusTrackingTarget] = None,
         correction_volume: Optional[float] = None,
+        movement_delay: Optional[float] = None,
     ) -> None:
         """Dispense a given volume of liquid into the specified location.
         Args:
@@ -421,6 +424,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                         flowRate=flow_rate,
                         pushOut=push_out,
                         correctionVolume=correction_volume,
+                        movement_delay=movement_delay,
                     )
                 )
             else:

--- a/api/src/opentrons/protocol_api/core/instrument.py
+++ b/api/src/opentrons/protocol_api/core/instrument.py
@@ -51,6 +51,7 @@ class AbstractInstrument(ABC, Generic[WellCoreType, LabwareCoreType]):
         end_location: Optional[types.Location] = None,
         end_meniscus_tracking: Optional[types.MeniscusTrackingTarget] = None,
         correction_volume: Optional[float] = None,
+        movement_delay: Optional[float] = None,
     ) -> None:
         """Aspirate a given volume of liquid from the specified location.
         Args:
@@ -79,6 +80,7 @@ class AbstractInstrument(ABC, Generic[WellCoreType, LabwareCoreType]):
         end_location: Optional[types.Location] = None,
         end_meniscus_tracking: Optional[types.MeniscusTrackingTarget] = None,
         correction_volume: Optional[float] = None,
+        movement_delay: Optional[float] = None,
     ) -> None:
         """Dispense a given volume of liquid into the specified location.
         Args:

--- a/api/src/opentrons/protocol_api/core/legacy/legacy_instrument_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy/legacy_instrument_core.py
@@ -96,6 +96,7 @@ class LegacyInstrumentCore(AbstractInstrument[LegacyWellCore, LegacyLabwareCore]
         end_location: Optional[types.Location] = None,
         end_meniscus_tracking: Optional[types.MeniscusTrackingTarget] = None,
         correction_volume: Optional[float] = None,
+        movement_delay: Optional[float] = None,
     ) -> None:
         """Aspirate a given volume of liquid from the specified location.
         Args:
@@ -144,6 +145,7 @@ class LegacyInstrumentCore(AbstractInstrument[LegacyWellCore, LegacyLabwareCore]
         end_location: Optional[types.Location] = None,
         end_meniscus_tracking: Optional[types.MeniscusTrackingTarget] = None,
         correction_volume: Optional[float] = None,
+        movement_delay: Optional[float] = None,
     ) -> None:
         """Dispense a given volume of liquid into the specified location.
         Args:

--- a/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_instrument_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_instrument_core.py
@@ -109,6 +109,7 @@ class LegacyInstrumentCoreSimulator(
         end_location: Optional[types.Location] = None,
         end_meniscus_tracking: Optional[types.MeniscusTrackingTarget] = None,
         correction_volume: Optional[float] = None,
+        movement_delay: Optional[float] = None,
     ) -> None:
         if self.get_current_volume() == 0:
             # Make sure we're at the top of the labware and clear of any
@@ -154,6 +155,7 @@ class LegacyInstrumentCoreSimulator(
         end_location: Optional[types.Location] = None,
         end_meniscus_tracking: Optional[types.MeniscusTrackingTarget] = None,
         correction_volume: Optional[float] = None,
+        movement_delay: Optional[float] = None,
     ) -> None:
         if isinstance(location, (TrashBin, WasteChute)):
             raise APIVersionError(

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -200,6 +200,7 @@ class InstrumentContext(publisher.CommandPublisher):
         rate: float = 1.0,
         flow_rate: Optional[float] = None,
         end_location: Optional[types.Location] = None,
+        movement_delay: Optional[float] = None,
     ) -> InstrumentContext:
         """
         Draw liquid into a pipette tip.
@@ -243,7 +244,12 @@ class InstrumentContext(publisher.CommandPublisher):
             while aspirating liquid. When this argument is used the location and
             end_location must both be :py:class:`.Location`.
         :type end_location: :py:class:`.Location`
-
+        :param movement_delay: Delay the x/y/z movement during a dynamic aspirate.
+            This option is only valid when using end_location. When this argument
+            is used, the x/y/z movement will wait movement_delay seconds after the pipette
+            starts to aspirate before moving. This may help when dispensing very viscous liquids
+            that need to build up some pressure before liquid starts to flow.
+        :type movement_delay: float
         :returns: This instance.
 
         .. note::
@@ -395,6 +401,7 @@ class InstrumentContext(publisher.CommandPublisher):
                 meniscus_tracking=meniscus_tracking,
                 end_location=end_move_to_location,
                 end_meniscus_tracking=end_meniscus_tracking,
+                movement_delay=movement_delay,
             )
 
         return self
@@ -410,6 +417,7 @@ class InstrumentContext(publisher.CommandPublisher):
         push_out: Optional[float] = None,
         flow_rate: Optional[float] = None,
         end_location: Optional[types.Location] = None,
+        movement_delay: Optional[float] = None,
     ) -> InstrumentContext:
         """
         Dispense liquid from a pipette tip.
@@ -483,7 +491,12 @@ class InstrumentContext(publisher.CommandPublisher):
             while dispensing liquid held in the pipette. When this argument is used
             the location and end_location must both be a :py:class:`.Location`.
         :type end_location: :py:class:`.Location`
-
+        :param movement_delay: Delay the x/y/z movement during a dynamic dispense.
+            This option is only valid when using end_location. When this argument
+            is used, the x/y/z movement will wait movement_delay seconds after the pipette
+            starts to dispense before moving. This may help when dispensing very viscous liquids
+            that need to build up some pressure before liquid starts to flow.
+        :type movement_delay: float
         :returns: This instance.
 
         .. note::
@@ -572,6 +585,7 @@ class InstrumentContext(publisher.CommandPublisher):
                     meniscus_tracking=None,
                     end_location=None,
                     end_meniscus_tracking=None,
+                    movement_delay=movement_delay,
                 )
             return self
 

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -585,7 +585,7 @@ class InstrumentContext(publisher.CommandPublisher):
                     meniscus_tracking=None,
                     end_location=None,
                     end_meniscus_tracking=None,
-                    movement_delay=movement_delay,
+                    movement_delay=None,
                 )
             return self
 
@@ -676,6 +676,7 @@ class InstrumentContext(publisher.CommandPublisher):
                 meniscus_tracking=meniscus_tracking,
                 end_location=end_move_to_location,
                 end_meniscus_tracking=end_meniscus_tracking,
+                movement_delay=movement_delay,
             )
 
         return self

--- a/api/src/opentrons/protocol_engine/commands/aspirate_while_tracking.py
+++ b/api/src/opentrons/protocol_engine/commands/aspirate_while_tracking.py
@@ -145,6 +145,7 @@ class AspirateWhileTrackingImplementation(
             command_note_adder=self._command_note_adder,
             pipetting=self._pipetting,
             model_utils=self._model_utils,
+            movement_delay=params.movement_delay,
         )
         position_after_aspirate = await self._gantry_mover.get_position(
             params.pipetteId

--- a/api/src/opentrons/protocol_engine/commands/dispense_while_tracking.py
+++ b/api/src/opentrons/protocol_engine/commands/dispense_while_tracking.py
@@ -141,6 +141,7 @@ class DispenseWhileTrackingImplementation(
             },
             pipetting=self._pipetting,
             model_utils=self._model_utils,
+            movement_delay=params.movement_delay,
         )
         position_after_dispense = await self._gantry_mover.get_position(
             params.pipetteId

--- a/api/src/opentrons/protocol_engine/commands/movement_common.py
+++ b/api/src/opentrons/protocol_engine/commands/movement_common.py
@@ -81,6 +81,15 @@ class DynamicLiquidHandlingWellLocationMixin(LiquidHandlingWellMixin):
         default_factory=LiquidHandlingWellLocation,
         description="Relative well location at which to end the operation",
     )
+    movement_delay: float | SkipJsonSchema[None] = Field(
+        None,
+        description=(
+            "Optional movement delay in seconds."
+            " When this argument is used, the x/y/z movement will wait movement_delay seconds"
+            " after the pipetting action starts before beginning the x/y/z move."
+        ),
+        json_schema_extra=_remove_default,
+    )
 
 
 class MovementMixin(BaseModel):

--- a/api/src/opentrons/protocol_engine/commands/pipetting_common.py
+++ b/api/src/opentrons/protocol_engine/commands/pipetting_common.py
@@ -246,6 +246,7 @@ async def aspirate_while_tracking(
     command_note_adder: CommandNoteAdder,
     pipetting: PipettingHandler,
     model_utils: ModelUtils,
+    movement_delay: Optional[float] = None,
 ) -> SuccessData[BaseLiquidHandlingResult] | DefinedErrorData[OverpressureError]:
     """Execute an aspirate while tracking microoperation."""
     try:
@@ -297,6 +298,7 @@ async def dispense_while_tracking(
     location_if_error: ErrorLocationInfo,
     pipetting: PipettingHandler,
     model_utils: ModelUtils,
+    movement_delay: Optional[float] = None,
 ) -> SuccessData[BaseLiquidHandlingResult] | DefinedErrorData[OverpressureError]:
     """Execute an dispense while tracking microoperation."""
     # The current volume won't be none since it passed validation

--- a/api/src/opentrons/protocol_engine/execution/pipetting.py
+++ b/api/src/opentrons/protocol_engine/execution/pipetting.py
@@ -63,6 +63,7 @@ class PipettingHandler(TypingProtocol):
         flow_rate: float,
         end_point: Point,
         command_note_adder: CommandNoteAdder,
+        movement_delay: Optional[float] = None,
     ) -> float:
         """Set flow-rate and aspirate while tracking."""
 
@@ -76,6 +77,7 @@ class PipettingHandler(TypingProtocol):
         end_point: Point,
         push_out: Optional[float],
         is_full_dispense: bool = False,
+        movement_delay: Optional[float] = None,
     ) -> float:
         """Set flow-rate and dispense while tracking."""
 
@@ -188,6 +190,7 @@ class HardwarePipettingHandler(PipettingHandler):
         flow_rate: float,
         end_point: Point,
         command_note_adder: CommandNoteAdder,
+        movement_delay: Optional[float] = None,
     ) -> float:
         """Set flow-rate and aspirate.
 
@@ -205,6 +208,7 @@ class HardwarePipettingHandler(PipettingHandler):
                 end_point=end_point,
                 flow_rate=flow_rate,
                 volume=adjusted_volume,
+                movement_delay=movement_delay,
             )
         return adjusted_volume
 
@@ -218,6 +222,7 @@ class HardwarePipettingHandler(PipettingHandler):
         end_point: Point,
         push_out: Optional[float],
         is_full_dispense: bool = False,
+        movement_delay: Optional[float] = None,
     ) -> float:
         """Set flow-rate and dispense.
 
@@ -235,6 +240,7 @@ class HardwarePipettingHandler(PipettingHandler):
                 volume=adjusted_volume,
                 push_out=push_out,
                 is_full_dispense=is_full_dispense,
+                movement_delay=movement_delay,
             )
         return adjusted_volume
 
@@ -464,6 +470,7 @@ class VirtualPipettingHandler(PipettingHandler):
         flow_rate: float,
         end_point: Point,
         command_note_adder: CommandNoteAdder,
+        movement_delay: Optional[float] = None,
     ) -> float:
         """Virtually aspirate (no-op)."""
         self._validate_tip_attached(pipette_id=pipette_id, command_name="aspirate")
@@ -485,6 +492,7 @@ class VirtualPipettingHandler(PipettingHandler):
         end_point: Point,
         push_out: Optional[float],
         is_full_dispense: bool = False,
+        movement_delay: Optional[float] = None,
     ) -> float:
         """Virtually dispense (no-op)."""
         # TODO (tz, 8-23-23): add a check for push_out not larger that the max volume allowed when working on this https://opentrons.atlassian.net/browse/RSS-329

--- a/api/tests/opentrons/hardware_control/backends/test_ot3_utils.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_utils.py
@@ -35,6 +35,45 @@ def test_create_step() -> None:
     for step in move_group:
         assert set(present_nodes) == set(step.keys())
 
+def test_add_group_delay() -> None:
+    origin = {
+        Axis.X: 0,
+        Axis.Y: 0,
+        Axis.Z_L: 0,
+        Axis.Z_R: 0,
+        Axis.P_L: 0,
+        Axis.P_R: 0,
+    }
+    moves = [Move.build_dummy([Axis.X, Axis.Y, Axis.Z_L, Axis.Z_R, Axis.P_L])]
+    for block in moves[0].blocks:
+        block.distance = f64(25.0)
+        block.time = f64(1.0)
+        block.initial_speed = f64(25.0)
+        block.acceleration = f64(0.0)
+        block.final_speed = f64(25.0)
+    present_nodes = [NodeId.gantry_x, NodeId.gantry_y, NodeId.head_l]
+    move_group, final_pos = ot3utils.create_move_group(
+        origin=origin,
+        moves=moves,
+        present_nodes=present_nodes,
+    )
+    assert len(move_group) == 3
+
+    new_move_group = ot3utils.add_delay_to_move_group(move_group, present_nodes, ([NodeId.gantry_x], 3.0))
+    # new group should be one step longer
+    assert len(new_move_group) == 4
+    # all nodes have the same duration of all steps
+    for node in present_nodes:
+        assert sum([step[node].duration_sec for step in new_move_group]) == 6.0
+
+    assert new_move_group[0][NodeId.gantry_x].duration_sec == 3.0
+    assert new_move_group[0][NodeId.gantry_y].duration_sec == 1.0
+    assert new_move_group[0][NodeId.head_l].duration_sec == 1.0
+    assert new_move_group[3][NodeId.gantry_x].duration_sec == 1.0
+    assert new_move_group[3][NodeId.gantry_y].duration_sec == 3.0
+    assert new_move_group[3][NodeId.head_l].duration_sec == 3.0
+
+
 
 def test_filter_zero_duration_step() -> None:
     origin = {

--- a/api/tests/opentrons/hardware_control/backends/test_ot3_utils.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_utils.py
@@ -35,6 +35,7 @@ def test_create_step() -> None:
     for step in move_group:
         assert set(present_nodes) == set(step.keys())
 
+
 def test_add_group_delay() -> None:
     origin = {
         Axis.X: 0,
@@ -59,7 +60,9 @@ def test_add_group_delay() -> None:
     )
     assert len(move_group) == 3
 
-    new_move_group = ot3utils.add_delay_to_move_group(move_group, present_nodes, ([NodeId.gantry_x], 3.0))
+    new_move_group = ot3utils.add_delay_to_move_group(
+        move_group, present_nodes, ([NodeId.gantry_x], 3.0)
+    )
     # new group should be one step longer
     assert len(new_move_group) == 4
     # all nodes have the same duration of all steps
@@ -72,7 +75,6 @@ def test_add_group_delay() -> None:
     assert new_move_group[3][NodeId.gantry_x].duration_sec == 1.0
     assert new_move_group[3][NodeId.gantry_y].duration_sec == 3.0
     assert new_move_group[3][NodeId.head_l].duration_sec == 3.0
-
 
 
 def test_filter_zero_duration_step() -> None:

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -368,6 +368,7 @@ def test_aspirate(
             meniscus_tracking=None,
             end_location=None,
             end_meniscus_tracking=None,
+            movement_delay=None,
         ),
         times=1,
     )
@@ -403,6 +404,7 @@ def test_aspirate_well_location(
             meniscus_tracking=None,
             end_location=None,
             end_meniscus_tracking=None,
+            movement_delay=None,
         ),
         times=1,
     )
@@ -438,6 +440,7 @@ def test_aspirate_meniscus_well_location(
             meniscus_tracking=None,
             end_location=None,
             end_meniscus_tracking=None,
+            movement_delay=None,
         ),
         times=1,
     )
@@ -472,6 +475,7 @@ def test_aspirate_from_coordinates(
             meniscus_tracking=None,
             end_location=None,
             end_meniscus_tracking=None,
+            movement_delay=None,
         ),
         times=1,
     )
@@ -518,6 +522,7 @@ def test_aspirate_flow_rate(
             meniscus_tracking=None,
             end_location=None,
             end_meniscus_tracking=None,
+            movement_delay=None,
         ),
         times=1,
     )
@@ -1087,6 +1092,7 @@ def test_dispense_with_location(
             meniscus_tracking=None,
             end_location=None,
             end_meniscus_tracking=None,
+            movement_delay=None,
         ),
         times=1,
     )
@@ -1123,6 +1129,7 @@ def test_dispense_with_well_location(
             meniscus_tracking=None,
             end_location=None,
             end_meniscus_tracking=None,
+            movement_delay=None,
         ),
         times=1,
     )
@@ -1160,6 +1167,7 @@ def test_dispense_with_well(
             meniscus_tracking=None,
             end_location=None,
             end_meniscus_tracking=None,
+            movement_delay=None,
         ),
         times=1,
     )
@@ -1222,6 +1230,7 @@ def test_dispense_flow_rate(
             meniscus_tracking=None,
             end_location=None,
             end_meniscus_tracking=None,
+            movement_delay=None,
         ),
         times=1,
     )
@@ -1488,6 +1497,7 @@ def test_dispense_0_volume_means_dispense_everything(
             meniscus_tracking=None,
             end_location=None,
             end_meniscus_tracking=None,
+            movement_delay=None,
         ),
         times=1,
     )
@@ -1517,6 +1527,7 @@ def test_dispense_0_volume_means_dispense_nothing(
             meniscus_tracking=None,
             end_location=None,
             end_meniscus_tracking=None,
+            movement_delay=None,
         ),
         times=1,
     )
@@ -1554,6 +1565,7 @@ def test_aspirate_0_volume_means_aspirate_everything(
             meniscus_tracking=None,
             end_location=None,
             end_meniscus_tracking=None,
+            movement_delay=None,
         ),
         times=1,
     )
@@ -1591,6 +1603,7 @@ def test_aspirate_0_volume_means_aspirate_nothing(
             meniscus_tracking=None,
             end_location=None,
             end_meniscus_tracking=None,
+            movement_delay=None,
         ),
         times=1,
     )
@@ -1624,6 +1637,7 @@ def test_dispense_with_trash_last_location(
             meniscus_tracking=None,
             end_location=None,
             end_meniscus_tracking=None,
+            movement_delay=None,
         ),
         times=1,
     )
@@ -1774,6 +1788,7 @@ def test_mix_no_lpd(
             None,
             None,
             None,
+            movement_delay=None,
         ),
         times=10,
     )
@@ -1792,37 +1807,40 @@ def test_mix_no_lpd(
                 None,
                 None,
                 None,
+                movement_delay=None,
             ),
             times=10,
         )
     else:
         decoy.verify(
             mock_instrument_core.dispense(
-                bottom_location,
-                mock_well._core,
-                10.0,
-                1.23,
-                5.67,
-                True,
-                0.0,
-                None,
-                None,
-                None,
+                location=bottom_location,
+                well_core=mock_well._core,
+                volume=10.0,
+                rate=1.23,
+                flow_rate=5.67,
+                in_place=True,
+                push_out=0.0,
+                meniscus_tracking=None,
+                end_location=None,
+                end_meniscus_tracking=None,
+                movement_delay=None,
             ),
             times=9,
         )
         decoy.verify(
             mock_instrument_core.dispense(
-                bottom_location,
-                mock_well._core,
-                10.0,
-                1.23,
-                5.67,
-                True,
-                None,
-                None,
-                None,
-                None,
+                location=bottom_location,
+                well_core=mock_well._core,
+                volume=10.0,
+                rate=1.23,
+                flow_rate=5.67,
+                in_place=True,
+                push_out=None,
+                meniscus_tracking=None,
+                end_location=None,
+                end_meniscus_tracking=None,
+                movement_delay=None,
             ),
             times=1,
         )
@@ -1877,36 +1895,39 @@ def test_mix_with_lpd(
             None,
             None,
             None,
+            movement_delay=None,
         ),
         times=10,
     )
     decoy.verify(
         mock_instrument_core.dispense(
-            bottom_location,
-            mock_well._core,
-            10.0,
-            1.23,
-            5.67,
-            True,
-            0.0,
-            None,
-            None,
-            None,
+            location=bottom_location,
+            well_core=mock_well._core,
+            volume=10.0,
+            rate=1.23,
+            flow_rate=5.67,
+            in_place=True,
+            push_out=0.0,
+            meniscus_tracking=None,
+            end_location=None,
+            end_meniscus_tracking=None,
+            movement_delay=None,
         ),
         times=9,
     )
     decoy.verify(
         mock_instrument_core.dispense(
-            bottom_location,
-            mock_well._core,
-            10.0,
-            1.23,
-            5.67,
-            True,
-            None,
-            None,
-            None,
-            None,
+            location=bottom_location,
+            well_core=mock_well._core,
+            volume=10.0,
+            rate=1.23,
+            flow_rate=5.67,
+            in_place=True,
+            push_out=None,
+            meniscus_tracking=None,
+            end_location=None,
+            end_meniscus_tracking=None,
+            movement_delay=None,
         ),
         times=1,
     )
@@ -1951,6 +1972,7 @@ def test_mix_with_flow_rates(
             meniscus_tracking=None,
             end_location=None,
             end_meniscus_tracking=None,
+            movement_delay=None,
         ),
         mock_instrument_core.dispense(
             location=input_location,
@@ -1963,6 +1985,7 @@ def test_mix_with_flow_rates(
             meniscus_tracking=None,
             end_location=None,
             end_meniscus_tracking=None,
+            movement_delay=None,
         ),
     )
 
@@ -1998,6 +2021,7 @@ def test_mix_with_flow_rates(
             meniscus_tracking=None,
             end_location=None,
             end_meniscus_tracking=None,
+            movement_delay=None,
         ),
         mock_instrument_core.dispense(
             location=input_location,
@@ -2010,6 +2034,7 @@ def test_mix_with_flow_rates(
             meniscus_tracking=None,
             end_location=None,
             end_meniscus_tracking=None,
+            movement_delay=None,
         ),
     )
 
@@ -2050,6 +2075,7 @@ def test_mix_with_delay_and_final_push_out(
             meniscus_tracking=None,
             end_location=None,
             end_meniscus_tracking=None,
+            movement_delay=None,
         ),
         mock_protocol_core.delay(3, msg=None),  # aspirate delay
         mock_instrument_core.dispense(
@@ -2063,6 +2089,7 @@ def test_mix_with_delay_and_final_push_out(
             meniscus_tracking=None,
             end_location=None,
             end_meniscus_tracking=None,
+            movement_delay=None,
         ),
         mock_protocol_core.delay(4, msg=None),  # dispense delay
         mock_instrument_core.aspirate(
@@ -2075,6 +2102,7 @@ def test_mix_with_delay_and_final_push_out(
             meniscus_tracking=None,
             end_location=None,
             end_meniscus_tracking=None,
+            movement_delay=None,
         ),
         mock_protocol_core.delay(3, msg=None),  # aspirate delay
         mock_instrument_core.dispense(
@@ -2088,6 +2116,7 @@ def test_mix_with_delay_and_final_push_out(
             meniscus_tracking=None,
             end_location=None,
             end_meniscus_tracking=None,
+            movement_delay=None,
         ),
         mock_protocol_core.delay(4, msg=None),  # dispense delay
     )
@@ -2136,6 +2165,7 @@ def test_aspirate_with_lpd(
             None,
             None,
             None,
+            movement_delay=None,
         ),
         times=1,
     )

--- a/api/tests/opentrons/protocol_engine/execution/test_pipetting_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_pipetting_handler.py
@@ -356,6 +356,7 @@ async def test_hw_aspirate_while_tracking(
             end_point=Point(0, 0, 0),
             flow_rate=2.5,
             volume=25,
+            movement_delay=None,
         )
     )
 

--- a/shared-data/command/schemas/15.json
+++ b/shared-data/command/schemas/15.json
@@ -422,6 +422,11 @@
           "title": "Labwareid",
           "type": "string"
         },
+        "movement_delay": {
+          "description": "Optional movement delay in seconds. When this argument is used, the x/y/z movement will wait movement_delay seconds after the pipetting action starts before beginning the x/y/z move.",
+          "title": "Movement Delay",
+          "type": "number"
+        },
         "pipetteId": {
           "description": "Identifier of pipette to use for liquid handling.",
           "title": "Pipetteid",
@@ -1819,6 +1824,11 @@
           "description": "Identifier of labware to use.",
           "title": "Labwareid",
           "type": "string"
+        },
+        "movement_delay": {
+          "description": "Optional movement delay in seconds. When this argument is used, the x/y/z movement will wait movement_delay seconds after the pipetting action starts before beginning the x/y/z move.",
+          "title": "Movement Delay",
+          "type": "number"
         },
         "pipetteId": {
           "description": "Identifier of pipette to use for liquid handling.",


### PR DESCRIPTION

# Overview
For some liquids, specifically very viscous ones we need to start the z movement some amount of time after the pipetting action starts. 
This results in a form of phase shift where the pipetting starts and ends earlier than the liquid level change starts and ends.
<img width="1555" height="824" alt="image" src="https://github.com/user-attachments/assets/b3807c7f-58a9-4f6b-99c8-2f05183d66c2" />


This PR touches pretty much every layer here, from the base up:

1. The movement planner takes a previously blended move group, and then adds extra steps for each axis. For the axis that need to be delayed, they add a 0 speed, 0 acceleration move with X duration in front of the first step For the axis that don't need to be delayed this same move is added after the last step. This results in a move group where each axis has one extra step and everything will still complete all at the same time.
2. python api is able to take a delay argument in it's aspirate/dispense_while_tracking commands and apply this delay to gantry and Z moves.
3. Protocol engine's aspirate/dispense while tracking commands pass this argument down to python api
4. protocol api now adds an extra argument to aspirate and dispense that takes a float and passes that down to protocol engine. Protocol api also raises an error if this delay is supplied without the end location being applied since we can't delay x/y/z movement if we're not moving x/y/z