### PR TITLE
feat(shared-data): Introduce opentrons_tough_universal_lid v2, with a higher grip point

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/_default_labware_versions.py
+++ b/api/src/opentrons/protocol_api/core/engine/_default_labware_versions.py
@@ -143,6 +143,9 @@ DEFAULT_LABWARE_VERSIONS: DefaultLabwareVersions = {
         "usascientific_12_reservoir_22ml": 4,
         "usascientific_96_wellplate_2.4ml_deep": 4,
     },
+    APIVersion(2, 28): {
+        "opentrons_tough_universal_lid": 2,
+    },
 }
 
 

--- a/api/src/opentrons/protocols/api_support/definitions.py
+++ b/api/src/opentrons/protocols/api_support/definitions.py
@@ -1,6 +1,6 @@
 from .types import APIVersion
 
-MAX_SUPPORTED_VERSION = APIVersion(2, 27)
+MAX_SUPPORTED_VERSION = APIVersion(2, 28)
 """The maximum supported protocol API version in this release."""
 
 MIN_SUPPORTED_VERSION = APIVersion(2, 0)

--- a/hardware-testing/hardware_testing/gravimetric/protocol_replacement/gravimetric.py
+++ b/hardware-testing/hardware_testing/gravimetric/protocol_replacement/gravimetric.py
@@ -36,7 +36,7 @@ from opentrons.protocol_api._nozzle_layout import NozzleLayout
 from opentrons.protocols.advanced_control.transfers import common as tx_ctl_lib
 
 metadata = {"protocolName": "Gravimetric QC"}
-requirements = {"robotType": "Flex", "apiLevel": "2.27"}
+requirements = {"robotType": "Flex", "apiLevel": "2.28"}
 
 SCALE_SECONDS_TO_TRUE_STABILIZE = 60 * 3
 

--- a/shared-data/labware/definitions/2/opentrons_tough_universal_lid/2.json
+++ b/shared-data/labware/definitions/2/opentrons_tough_universal_lid/2.json
@@ -1,0 +1,101 @@
+{
+  "allowedRoles": ["labware", "lid"],
+  "ordering": [],
+  "brand": {
+    "brand": "Opentrons",
+    "brandId": ["999-00261"],
+    "links": [
+      "https://opentrons.com/products/opentrons-tough-universal-lid-50-count/"
+    ]
+  },
+  "metadata": {
+    "displayName": "Opentrons Tough Universal Lid",
+    "displayCategory": "lid",
+    "displayVolumeUnits": "µL",
+    "tags": []
+  },
+  "dimensions": {
+    "xDimension": 127.76,
+    "yDimension": 85.48,
+    "zDimension": 9.2
+  },
+  "wells": {},
+  "groups": [
+    {
+      "metadata": {},
+      "wells": []
+    }
+  ],
+  "cornerOffsetFromSlot": {
+    "x": 0,
+    "y": 0,
+    "z": 0
+  },
+  "parameters": {
+    "format": "irregular",
+    "quirks": [],
+    "isTiprack": false,
+    "isMagneticModuleCompatible": false,
+    "isDeckSlotCompatible": false,
+    "loadName": "opentrons_tough_universal_lid"
+  },
+  "namespace": "opentrons",
+  "version": 2,
+  "schemaVersion": 2,
+  "stackingOffsetWithLabware": {
+    "default": {
+      "x": 0,
+      "y": 0,
+      "z": 7.1
+    },
+    "opentrons_96_wellplate_200ul_pcr_full_skirt": {
+      "x": 0,
+      "y": 0,
+      "z": 6.1
+    },
+    "protocol_engine_lid_stack_object": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "opentrons_tough_universal_lid": {
+      "x": 0,
+      "y": 0,
+      "z": 1
+    },
+    "opentrons_flex_deck_riser": {
+      "x": 0,
+      "y": 0,
+      "z": 34
+    }
+  },
+  "stackLimit": 5,
+  "gripForce": 10,
+  "gripHeightFromLabwareBottom": 5.5,
+  "gripperOffsets": {
+    "default": {
+      "pickUpOffset": {
+        "x": 0,
+        "y": 0,
+        "z": 0
+      },
+      "dropOffset": {
+        "x": 0,
+        "y": 0,
+        "z": 3
+      }
+    },
+    "lidDisposalOffsets": {
+      "pickUpOffset": {
+        "x": 0,
+        "y": 0,
+        "z": 0
+      },
+      "dropOffset": {
+        "x": 0,
+        "y": 5.0,
+        "z": 50.0
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Overview

Closes EXEC-1987. See there for background.

## Changelog

* Introduce v2 of `opentrons_tough_univeral_lid`. It's identical to v1 except that its `gripHeightFromLabwareBottom` is 5.5 mm instead of 4.7 mm.
* Introduce Python Protocol API v2.28. When it loads `opentrons_tough_universal_lid`, make it load v2 by default.

## Test Plan and Hands on Testing

* [x] When picking up and dropping off a lid in an expansion slot, there should now be a more comfortable amount of clearance.
* [x] You should be able to stack two `opentrons_tough_universal_lid`s atop each other and pick up the stack from the lower lid, without accidentally snagging the upper lid.
  * I don't think this is actually supported in the Python API today? But it's probably worth checking whether it happens to work, physically.

## Review requests

* @jerader brought up that a different lid, `opentrons_tough_pcr_aut_sealing_lid` has `labware` as an allowed role: `"allowedRoles": ["lid", "labware"]`. This lid does the same thing. Do we want to remove `labware` from its `allowedRoles`?

## Risk assessment

Medium. This is a physical change so we gotta be sure we're not making gripping less reliable for anybody.