### PR TITLE
fix: handle wasteChuteLocation in frontend

### DIFF
--- a/app/src/molecules/LabwareOffsetSnippet/createSnippet/buildLoadCommandCopy.ts
+++ b/app/src/molecules/LabwareOffsetSnippet/createSnippet/buildLoadCommandCopy.ts
@@ -2,7 +2,7 @@ import isEqual from 'lodash/isEqual'
 
 import {
   getLoadedLabwareDefinitionsByUri,
-  locationIsOnDeck,
+  locationIsOffDeck,
 } from '@opentrons/shared-data'
 
 import { getLwOffsetLocSeqFromLocSeq } from '/app/local-resources/offsets'
@@ -147,7 +147,7 @@ function buildLoadCopy(
 ): string {
   const location = command.params.location
 
-  if (!locationIsOnDeck(location)) {
+  if (locationIsOffDeck(location)) {
     return `labware_${labwareCount} = protocol.load_labware("${loadName}", location="offDeck")`
   } else if ('slotName' in location) {
     const { slotName } = location

--- a/app/src/molecules/LabwareOffsetSnippet/createSnippet/buildLoadCommandCopy.ts
+++ b/app/src/molecules/LabwareOffsetSnippet/createSnippet/buildLoadCommandCopy.ts
@@ -1,6 +1,9 @@
 import isEqual from 'lodash/isEqual'
 
-import { getLoadedLabwareDefinitionsByUri } from '@opentrons/shared-data'
+import {
+  getLoadedLabwareDefinitionsByUri,
+  locationIsOnDeck,
+} from '@opentrons/shared-data'
 
 import { getLwOffsetLocSeqFromLocSeq } from '/app/local-resources/offsets'
 import { getLegacyLabwareOffsetLocation } from '/app/transformations/analysis'
@@ -144,7 +147,7 @@ function buildLoadCopy(
 ): string {
   const location = command.params.location
 
-  if (location === 'offDeck' || location === 'systemLocation') {
+  if (!locationIsOnDeck(location)) {
     return `labware_${labwareCount} = protocol.load_labware("${loadName}", location="offDeck")`
   } else if ('slotName' in location) {
     const { slotName } = location

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useDeckMapUtils.test.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useDeckMapUtils.test.ts
@@ -412,6 +412,16 @@ describe('getSlotNameAndLwLocFrom', () => {
     expect(result).toEqual([null, null])
   })
 
+  it('should return [null, null] if location is "systemLocation"', () => {
+    const result = getSlotNameAndLwLocFrom('systemLocation', {} as any, false)
+    expect(result).toEqual([null, null])
+  })
+
+  it('should return [null, null] if location is "wasteChuteLocation"', () => {
+    const result = getSlotNameAndLwLocFrom('systemLocation', {} as any, false)
+    expect(result).toEqual([null, null])
+  })
+
   it('should return [null, null] if location has a moduleId and moduleModel and excludeModules is true', () => {
     vi.mocked(getLabwareLocation).mockReturnValue({
       slotName: 'A1',

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useDeckMapUtils.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useDeckMapUtils.ts
@@ -10,7 +10,7 @@ import {
   getModuleType,
   getPositionFromSlotId,
   getSimplestDeckConfigForProtocol,
-  locationIsOnDeck,
+  locationIsOffDeck,
   OT2_ROBOT_TYPE,
   THERMOCYCLER_MODULE_V1,
 } from '@opentrons/shared-data'
@@ -446,7 +446,7 @@ export function getSlotNameAndLwLocFrom(
     getModuleType(onModuleModel) === FLEX_STACKER_MODULE_TYPE
       ? (labwareLocationObject?.slotName.charAt(0) ?? null)
       : (labwareLocationObject?.slotName ?? null)
-  if (location == null || !locationIsOnDeck(location)) {
+  if (location == null || locationIsOffDeck(location)) {
     return [null, null]
   } else if (excludeModules && onModuleModel != null) {
     return [null, null]

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useDeckMapUtils.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useDeckMapUtils.ts
@@ -10,6 +10,7 @@ import {
   getModuleType,
   getPositionFromSlotId,
   getSimplestDeckConfigForProtocol,
+  locationIsOnDeck,
   OT2_ROBOT_TYPE,
   THERMOCYCLER_MODULE_V1,
 } from '@opentrons/shared-data'
@@ -445,11 +446,7 @@ export function getSlotNameAndLwLocFrom(
     getModuleType(onModuleModel) === FLEX_STACKER_MODULE_TYPE
       ? (labwareLocationObject?.slotName.charAt(0) ?? null)
       : (labwareLocationObject?.slotName ?? null)
-  if (
-    location == null ||
-    location === 'offDeck' ||
-    location === 'systemLocation'
-  ) {
+  if (location == null || !locationIsOnDeck(location)) {
     return [null, null]
   } else if (excludeModules && onModuleModel != null) {
     return [null, null]

--- a/app/src/organisms/LegacyApplyHistoricOffsets/hooks/getLegacyLabwareLocationCombos.ts
+++ b/app/src/organisms/LegacyApplyHistoricOffsets/hooks/getLegacyLabwareLocationCombos.ts
@@ -3,7 +3,7 @@ import isEqual from 'lodash/isEqual'
 import {
   FLEX_SINGLE_SLOT_ADDRESSABLE_AREAS,
   getLabwareDefURI,
-  locationIsOnDeck,
+  locationIsOffDeck,
   OT2_SINGLE_SLOT_ADDRESSABLE_AREAS,
 } from '@opentrons/shared-data'
 
@@ -38,7 +38,7 @@ export function getLegacyLabwareLocationCombos(
         )
           return acc
         const definitionUri = getLabwareDefURI(command.result.definition)
-        if (!locationIsOnDeck(command.params.location)) {
+        if (locationIsOffDeck(command.params.location)) {
           return acc
         } else if ('moduleId' in command.params.location) {
           const { moduleId } = command.params.location
@@ -89,7 +89,7 @@ export function getLegacyLabwareLocationCombos(
           )
           return acc
         }
-        if (!locationIsOnDeck(command.params.newLocation)) {
+        if (locationIsOffDeck(command.params.newLocation)) {
           return acc
         } else if ('moduleId' in command.params.newLocation) {
           const modLocation = resolveModuleLocation(
@@ -228,7 +228,7 @@ function resolveAdapterLocation(
 
   let moduleIdUnderAdapter
   let adapterOffsetLocation: LegacyLabwareOffsetLocation | null = null
-  if (!locationIsOnDeck(labwareEntity.location)) {
+  if (locationIsOffDeck(labwareEntity.location)) {
     return { adapterOffsetLocation: null }
     // can't have adapter on top of an adapter
   } else if ('labwareId' in labwareEntity.location) {

--- a/app/src/organisms/LegacyApplyHistoricOffsets/hooks/getLegacyLabwareLocationCombos.ts
+++ b/app/src/organisms/LegacyApplyHistoricOffsets/hooks/getLegacyLabwareLocationCombos.ts
@@ -3,6 +3,7 @@ import isEqual from 'lodash/isEqual'
 import {
   FLEX_SINGLE_SLOT_ADDRESSABLE_AREAS,
   getLabwareDefURI,
+  locationIsOnDeck,
   OT2_SINGLE_SLOT_ADDRESSABLE_AREAS,
 } from '@opentrons/shared-data'
 
@@ -37,10 +38,7 @@ export function getLegacyLabwareLocationCombos(
         )
           return acc
         const definitionUri = getLabwareDefURI(command.result.definition)
-        if (
-          command.params.location === 'offDeck' ||
-          command.params.location === 'systemLocation'
-        ) {
+        if (!locationIsOnDeck(command.params.location)) {
           return acc
         } else if ('moduleId' in command.params.location) {
           const { moduleId } = command.params.location
@@ -91,10 +89,7 @@ export function getLegacyLabwareLocationCombos(
           )
           return acc
         }
-        if (
-          command.params.newLocation === 'offDeck' ||
-          command.params.newLocation === 'systemLocation'
-        ) {
+        if (!locationIsOnDeck(command.params.newLocation)) {
           return acc
         } else if ('moduleId' in command.params.newLocation) {
           const modLocation = resolveModuleLocation(
@@ -233,10 +228,7 @@ function resolveAdapterLocation(
 
   let moduleIdUnderAdapter
   let adapterOffsetLocation: LegacyLabwareOffsetLocation | null = null
-  if (
-    labwareEntity.location === 'offDeck' ||
-    labwareEntity.location === 'systemLocation'
-  ) {
+  if (!locationIsOnDeck(labwareEntity.location)) {
     return { adapterOffsetLocation: null }
     // can't have adapter on top of an adapter
   } else if ('labwareId' in labwareEntity.location) {

--- a/app/src/organisms/LegacyLabwarePositionCheck/utils/labware.ts
+++ b/app/src/organisms/LegacyLabwarePositionCheck/utils/labware.ts
@@ -5,6 +5,8 @@ import {
   getIsTiprack,
   getLabwareDefURI,
   getTiprackVolume,
+  locationIsOnDeck,
+  locationIsOnSlot,
 } from '@opentrons/shared-data'
 
 import { getModuleInitialLoadInfo } from '/app/transformations/commands'
@@ -70,10 +72,7 @@ export const getTiprackIdsInOrder = (
           ...tipRackLocations.map(loc => ({
             definition: labwareDef,
             labwareId: labwareId,
-            slot:
-              loc !== 'offDeck' && loc !== 'systemLocation' && 'slotName' in loc
-                ? loc.slotName
-                : '',
+            slot: locationIsOnSlot(loc) ? loc.slotName : '',
           })),
         ]
       }
@@ -132,10 +131,7 @@ export const getAllTipracksIdsThatPipetteUsesInOrder = (
         ...tipRackLocations.map(loc => ({
           labwareId: tipRackId,
           definition,
-          slot:
-            loc !== 'offDeck' && loc !== 'systemLocation' && 'slotName' in loc
-              ? loc.slotName
-              : '',
+          slot: locationIsOnSlot(loc) ? loc.slotName : '',
         })),
       ]
     }, [])
@@ -174,7 +170,7 @@ export const getLabwareIdsInOrder = (
         ...acc,
         ...labwareLocations.reduce<LabwareToOrder[]>((innerAcc, loc) => {
           let slot = ''
-          if (loc === 'offDeck' || loc === 'systemLocation') {
+          if (!locationIsOnDeck(loc)) {
             slot = 'offDeck'
           } else if ('moduleId' in loc) {
             slot = getModuleInitialLoadInfo(loc.moduleId, commands).location
@@ -186,10 +182,7 @@ export const getLabwareIdsInOrder = (
                 command.result?.labwareId === loc.labwareId
             )
             const adapterLocation = matchingAdapter?.params.location
-            if (
-              adapterLocation === 'offDeck' ||
-              adapterLocation === 'systemLocation'
-            ) {
+            if (adapterLocation == null || !locationIsOnDeck(adapterLocation)) {
               slot = 'offDeck'
             } else if (
               adapterLocation != null &&

--- a/app/src/organisms/LegacyLabwarePositionCheck/utils/labware.ts
+++ b/app/src/organisms/LegacyLabwarePositionCheck/utils/labware.ts
@@ -5,7 +5,7 @@ import {
   getIsTiprack,
   getLabwareDefURI,
   getTiprackVolume,
-  locationIsOnDeck,
+  locationIsOffDeck,
   locationIsOnSlot,
 } from '@opentrons/shared-data'
 
@@ -170,7 +170,7 @@ export const getLabwareIdsInOrder = (
         ...acc,
         ...labwareLocations.reduce<LabwareToOrder[]>((innerAcc, loc) => {
           let slot = ''
-          if (!locationIsOnDeck(loc)) {
+          if (locationIsOffDeck(loc)) {
             slot = 'offDeck'
           } else if ('moduleId' in loc) {
             slot = getModuleInitialLoadInfo(loc.moduleId, commands).location
@@ -182,7 +182,7 @@ export const getLabwareIdsInOrder = (
                 command.result?.labwareId === loc.labwareId
             )
             const adapterLocation = matchingAdapter?.params.location
-            if (adapterLocation == null || !locationIsOnDeck(adapterLocation)) {
+            if (adapterLocation == null || locationIsOffDeck(adapterLocation)) {
               slot = 'offDeck'
             } else if (
               adapterLocation != null &&

--- a/app/src/transformations/analysis/getLegacyLabwareOffsetLocation.ts
+++ b/app/src/transformations/analysis/getLegacyLabwareOffsetLocation.ts
@@ -1,3 +1,5 @@
+import { locationIsOnDeck } from '@opentrons/shared-data'
+
 import {
   getLabwareLocation,
   getModuleInitialLoadInfo,
@@ -22,7 +24,7 @@ export const getLegacyLabwareOffsetLocation = (
 ): LegacyLabwareOffsetLocation | null => {
   const labwareLocation = getLabwareLocation(labwareId, commands)
 
-  if (labwareLocation === 'offDeck' || labwareLocation === 'systemLocation') {
+  if (!locationIsOnDeck(labwareLocation)) {
     return null
   } else if ('moduleId' in labwareLocation) {
     const module = modules.find(
@@ -36,11 +38,7 @@ export const getLegacyLabwareOffsetLocation = (
     return { slotName, moduleModel }
   } else if ('labwareId' in labwareLocation) {
     const adapter = labware.find(lw => lw.id === labwareLocation.labwareId)
-    if (
-      adapter == null ||
-      adapter.location === 'offDeck' ||
-      adapter.location === 'systemLocation'
-    ) {
+    if (adapter == null || !locationIsOnDeck(adapter.location)) {
       return null
     } else if ('slotName' in adapter.location) {
       return {

--- a/app/src/transformations/analysis/getLegacyLabwareOffsetLocation.ts
+++ b/app/src/transformations/analysis/getLegacyLabwareOffsetLocation.ts
@@ -1,4 +1,4 @@
-import { locationIsOnDeck } from '@opentrons/shared-data'
+import { locationIsOffDeck } from '@opentrons/shared-data'
 
 import {
   getLabwareLocation,
@@ -24,7 +24,7 @@ export const getLegacyLabwareOffsetLocation = (
 ): LegacyLabwareOffsetLocation | null => {
   const labwareLocation = getLabwareLocation(labwareId, commands)
 
-  if (!locationIsOnDeck(labwareLocation)) {
+  if (locationIsOffDeck(labwareLocation)) {
     return null
   } else if ('moduleId' in labwareLocation) {
     const module = modules.find(
@@ -38,7 +38,7 @@ export const getLegacyLabwareOffsetLocation = (
     return { slotName, moduleModel }
   } else if ('labwareId' in labwareLocation) {
     const adapter = labware.find(lw => lw.id === labwareLocation.labwareId)
-    if (adapter == null || !locationIsOnDeck(adapter.location)) {
+    if (adapter == null || locationIsOffDeck(adapter.location)) {
       return null
     } else if ('slotName' in adapter.location) {
       return {

--- a/app/src/transformations/commands/transformations/__tests__/getLocationInfoNames.test.ts
+++ b/app/src/transformations/commands/transformations/__tests__/getLocationInfoNames.test.ts
@@ -155,7 +155,16 @@ const MOCK_ADAPTER_EXTENSION_COMMANDS = [
   },
 ]
 
-vi.mock('@opentrons/shared-data')
+vi.mock('@opentrons/shared-data', async importOriginal => {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+  const original =
+    await importOriginal<typeof import('@opentrons/shared-data')>()
+  return {
+    ...original,
+    getLabwareDisplayName: vi.fn(),
+    getLabwareStackCountAndLocation: vi.fn(),
+  }
+})
 
 describe('getLocationInfoNames', () => {
   beforeEach(() => {

--- a/app/src/transformations/commands/transformations/__tests__/getLocationInfoNames.test.ts
+++ b/app/src/transformations/commands/transformations/__tests__/getLocationInfoNames.test.ts
@@ -156,8 +156,8 @@ const MOCK_ADAPTER_EXTENSION_COMMANDS = [
 ]
 
 vi.mock('@opentrons/shared-data', async importOriginal => {
-  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
   const original =
+    // eslint-disable-next-line @typescript-eslint/consistent-type-imports
     await importOriginal<typeof import('@opentrons/shared-data')>()
   return {
     ...original,

--- a/app/src/transformations/commands/transformations/getLabwareSetupItemGroups.ts
+++ b/app/src/transformations/commands/transformations/getLabwareSetupItemGroups.ts
@@ -1,6 +1,9 @@
 import partition from 'lodash/partition'
 
-import { getLabwareDisplayName } from '@opentrons/shared-data'
+import {
+  getLabwareDisplayName,
+  locationIsOnModule,
+} from '@opentrons/shared-data'
 
 import type {
   LabwareDefinition,
@@ -39,11 +42,7 @@ export function getLabwareSetupItemGroups(
         if (definition == null) return acc
         let moduleModel = null
         let moduleLocation = null
-        if (
-          location !== 'offDeck' &&
-          location !== 'systemLocation' &&
-          'moduleId' in location
-        ) {
+        if (locationIsOnModule(location)) {
           const loadModuleCommand = commands.find(
             (c): c is LoadModuleRunTimeCommand =>
               c.commandType === 'loadModule' &&

--- a/app/src/transformations/commands/transformations/getLocationInfoNames.ts
+++ b/app/src/transformations/commands/transformations/getLocationInfoNames.ts
@@ -3,7 +3,6 @@ import {
   getLabwareStackCountAndLocation,
   locationIsOffDeck,
   locationIsOnAddressableArea,
-  locationIsOnDeck,
   locationIsOnModule,
   locationIsOnSlot,
 } from '@opentrons/shared-data'

--- a/app/src/transformations/commands/transformations/getLocationInfoNames.ts
+++ b/app/src/transformations/commands/transformations/getLocationInfoNames.ts
@@ -1,6 +1,10 @@
 import {
   getLabwareDisplayName,
   getLabwareStackCountAndLocation,
+  locationIsOnAddressableArea,
+  locationIsOnDeck,
+  locationIsOnModule,
+  locationIsOnSlot,
 } from '@opentrons/shared-data'
 
 import type {
@@ -53,7 +57,7 @@ export function getLocationInfoNames(
     loadLabwareCommands
   )
 
-  if (labwareLocation === 'offDeck' || labwareLocation === 'systemLocation') {
+  if (!locationIsOnDeck(labwareLocation)) {
     return { slotName: 'Off deck', labwareName, labwareQuantity }
   } else if ('slotName' in labwareLocation) {
     return { slotName: labwareLocation.slotName, labwareName, labwareQuantity }
@@ -89,11 +93,7 @@ export function getLocationInfoNames(
         `expected to find an adapter under the labware but could not with labwareId ${labwareLocation.labwareId}`
       )
       return { slotName: '', labwareName: labwareName, labwareQuantity }
-    } else if (
-      loadedAdapterCommand?.params.location !== 'offDeck' &&
-      loadedAdapterCommand?.params.location !== 'systemLocation' &&
-      'slotName' in loadedAdapterCommand?.params.location
-    ) {
+    } else if (locationIsOnSlot(loadedAdapterCommand?.params.location)) {
       return {
         slotName: loadedAdapterCommand?.params.location.slotName,
         labwareName,
@@ -104,9 +104,7 @@ export function getLocationInfoNames(
         labwareQuantity,
       }
     } else if (
-      loadedAdapterCommand?.params.location !== 'offDeck' &&
-      loadedAdapterCommand?.params.location !== 'systemLocation' &&
-      'addressableAreaName' in loadedAdapterCommand?.params.location
+      locationIsOnAddressableArea(loadedAdapterCommand?.params.location)
     ) {
       return {
         slotName: loadedAdapterCommand?.params.location.addressableAreaName,
@@ -117,11 +115,7 @@ export function getLocationInfoNames(
         adapterId: loadedAdapterCommand?.result?.labwareId,
         labwareQuantity,
       }
-    } else if (
-      loadedAdapterCommand?.params.location !== 'offDeck' &&
-      loadedAdapterCommand?.params.location !== 'systemLocation' &&
-      'moduleId' in loadedAdapterCommand?.params.location
-    ) {
+    } else if (locationIsOnModule(loadedAdapterCommand?.params.location)) {
       const moduleId = loadedAdapterCommand?.params.location.moduleId
       const loadModuleCommandUnderAdapter = loadModuleCommands?.find(
         command => command.result?.moduleId === moduleId

--- a/app/src/transformations/commands/transformations/getLocationInfoNames.ts
+++ b/app/src/transformations/commands/transformations/getLocationInfoNames.ts
@@ -1,6 +1,7 @@
 import {
   getLabwareDisplayName,
   getLabwareStackCountAndLocation,
+  locationIsOffDeck,
   locationIsOnAddressableArea,
   locationIsOnDeck,
   locationIsOnModule,
@@ -56,8 +57,7 @@ export function getLocationInfoNames(
     labwareId,
     loadLabwareCommands
   )
-
-  if (!locationIsOnDeck(labwareLocation)) {
+  if (locationIsOffDeck(labwareLocation)) {
     return { slotName: 'Off deck', labwareName, labwareQuantity }
   } else if ('slotName' in labwareLocation) {
     return { slotName: labwareLocation.slotName, labwareName, labwareQuantity }
@@ -90,7 +90,8 @@ export function getLocationInfoNames(
     )
     if (loadedAdapterCommand?.params == null) {
       console.warn(
-        `expected to find an adapter under the labware but could not with labwareId ${labwareLocation.labwareId}`
+        'getLocationInfoNames: expected to find an adapter under the labware but could not with labwareId',
+        labwareLocation.labwareId
       )
       return { slotName: '', labwareName: labwareName, labwareQuantity }
     } else if (locationIsOnSlot(loadedAdapterCommand?.params.location)) {
@@ -135,6 +136,10 @@ export function getLocationInfoNames(
           }
         : { slotName: '', labwareName, labwareQuantity }
     } else {
+      console.warn(
+        'getLocationInfoNames: unhandled adapter location',
+        loadedAdapterCommand?.params.location
+      )
       //  shouldn't hit this
       return { slotName: '', labwareName, labwareQuantity }
     }

--- a/app/src/transformations/commands/transformations/getNestedLabwareInfo.ts
+++ b/app/src/transformations/commands/transformations/getNestedLabwareInfo.ts
@@ -1,3 +1,5 @@
+import { locationIsOnDeck, locationIsOnLabware } from '@opentrons/shared-data'
+
 import type {
   LabwareDefinition,
   LoadLabwareRunTimeCommand,
@@ -20,18 +22,13 @@ export function getNestedLabwareInfo(
   const nestedLabware = commands.find(
     (command): command is LoadLabwareRunTimeCommand =>
       command.commandType === 'loadLabware' &&
-      command.params.location !== 'offDeck' &&
-      command.params.location !== 'systemLocation' &&
-      'labwareId' in command.params.location &&
+      locationIsOnLabware(command.params.location) &&
       command.params.location.labwareId === labwareSetupItem.labwareId
   )
   if (nestedLabware == null) return null
 
   let sharedSlotId: string = ''
-  if (
-    labwareSetupItem.initialLocation !== 'offDeck' &&
-    labwareSetupItem.initialLocation !== 'systemLocation'
-  ) {
+  if (locationIsOnDeck(labwareSetupItem.initialLocation)) {
     const adapterLocation = labwareSetupItem.initialLocation
     if ('slotName' in adapterLocation) {
       sharedSlotId = adapterLocation.slotName

--- a/app/src/transformations/commands/transformations/getRequiredLabwareDetailsFromLoadCommands.ts
+++ b/app/src/transformations/commands/transformations/getRequiredLabwareDetailsFromLoadCommands.ts
@@ -1,4 +1,4 @@
-import { getLabwareDefURI } from '@opentrons/shared-data'
+import { getLabwareDefURI, locationIsOnLabware } from '@opentrons/shared-data'
 
 import type {
   FlexStackerFillRunTimeCommand,
@@ -85,9 +85,7 @@ export function getRequiredLabwareDetailsFromLoadCommands(
       const lidCommand = loadLabwareCommands.find(
         (c): c is LoadLidRunTimeCommand =>
           c.commandType === 'loadLid' &&
-          c.params.location !== 'offDeck' &&
-          c.params.location !== 'systemLocation' &&
-          'labwareId' in c.params.location &&
+          locationIsOnLabware(c.params.location) &&
           c.params.location.labwareId === command.result?.labwareId
       )
       let defUri = getLabwareDefURI(command.result?.definition)

--- a/components/src/hardware-sim/BaseDeck/BaseDeck.tsx
+++ b/components/src/hardware-sim/BaseDeck/BaseDeck.tsx
@@ -9,7 +9,7 @@ import {
   getPositionFromSlotId,
   HEATERSHAKER_MODULE_V1,
   inferModuleOrientationFromXCoordinate,
-  locationIsOnDeck,
+  locationIsOffDeck,
   locationIsOnSlot,
   MODULE_FIXTURES_BY_MODEL,
   MOVABLE_TRASH_CUTOUTS,
@@ -484,7 +484,7 @@ export function BaseDeck(props: BaseDeckProps): JSX.Element {
             highlightShadow,
           }) => {
             if (
-              !locationIsOnDeck(labwareLocation) ||
+              locationIsOffDeck(labwareLocation) ||
               !locationIsOnSlot(labwareLocation) ||
               // for legacy protocols that list fixed trash as a labware, do not render
               definition.parameters.loadName ===
@@ -561,7 +561,7 @@ export function BaseDeck(props: BaseDeckProps): JSX.Element {
         {labwareOnDeck.map(
           ({ labwareLocation, definition, stacked = false }) => {
             if (
-              !locationIsOnDeck(labwareLocation) ||
+              locationIsOffDeck(labwareLocation) ||
               !locationIsOnSlot(labwareLocation) ||
               // for legacy protocols that list fixed trash as a labware, do not render
               definition.parameters.loadName ===

--- a/components/src/hardware-sim/BaseDeck/BaseDeck.tsx
+++ b/components/src/hardware-sim/BaseDeck/BaseDeck.tsx
@@ -9,6 +9,8 @@ import {
   getPositionFromSlotId,
   HEATERSHAKER_MODULE_V1,
   inferModuleOrientationFromXCoordinate,
+  locationIsOnDeck,
+  locationIsOnSlot,
   MODULE_FIXTURES_BY_MODEL,
   MOVABLE_TRASH_CUTOUTS,
   OT2_ROBOT_TYPE,
@@ -482,9 +484,8 @@ export function BaseDeck(props: BaseDeckProps): JSX.Element {
             highlightShadow,
           }) => {
             if (
-              labwareLocation === 'offDeck' ||
-              labwareLocation === 'systemLocation' ||
-              !('slotName' in labwareLocation) ||
+              !locationIsOnDeck(labwareLocation) ||
+              !locationIsOnSlot(labwareLocation) ||
               // for legacy protocols that list fixed trash as a labware, do not render
               definition.parameters.loadName ===
                 'opentrons_1_trash_3200ml_fixed'
@@ -560,9 +561,8 @@ export function BaseDeck(props: BaseDeckProps): JSX.Element {
         {labwareOnDeck.map(
           ({ labwareLocation, definition, stacked = false }) => {
             if (
-              labwareLocation === 'offDeck' ||
-              labwareLocation === 'systemLocation' ||
-              !('slotName' in labwareLocation) ||
+              !locationIsOnDeck(labwareLocation) ||
+              !locationIsOnSlot(labwareLocation) ||
               // for legacy protocols that list fixed trash as a labware, do not render
               definition.parameters.loadName ===
                 'opentrons_1_trash_3200ml_fixed'

--- a/components/src/hardware-sim/Deck/__tests__/resolveLabwareLocation.test.ts
+++ b/components/src/hardware-sim/Deck/__tests__/resolveLabwareLocation.test.ts
@@ -75,37 +75,40 @@ it('should resolve a labware location', () => {
 
   expect(result).toStrictEqual(expectedResult)
 })
+;(['offDeck', 'systemLocation', 'wasteChuteLocation'] as const).forEach(
+  offDeckLocation => {
+    it(`should return offDeck if the labware location is ${offDeckLocation}`, () => {
+      const labwareAUri = 'opentrons/nest_12_reservoir_15ml/1'
+      const labwareBUri = 'opentrons/agilent_1_reservoir_290ml/1'
+      const labwareADefinition = getAllDefinitions()[labwareAUri]
+      const labwareBDefinition = getAllDefinitions()[labwareBUri]
 
-it('should return offDeck if the labware is off-deck', () => {
-  const labwareAUri = 'opentrons/nest_12_reservoir_15ml/1'
-  const labwareBUri = 'opentrons/agilent_1_reservoir_290ml/1'
-  const labwareADefinition = getAllDefinitions()[labwareAUri]
-  const labwareBDefinition = getAllDefinitions()[labwareBUri]
+      const deckDefinition = getDeckDefinitions().ot3_standard
 
-  const deckDefinition = getDeckDefinitions().ot3_standard
+      const result = resolveLabwareLocation({
+        targetLabwareDef: labwareADefinition,
+        targetLabwareLocation: {
+          labwareId: 'labware-b-id',
+        },
+        otherLoadedLabware: [
+          {
+            id: 'labware-b-id',
+            definitionUri: labwareBUri,
+            location: offDeckLocation,
+            loadName: '',
+          },
+        ],
+        deckDef: deckDefinition,
+        otherLabwareDefinitions: [labwareBDefinition],
+        loadedModules: [],
+      })
 
-  const result = resolveLabwareLocation({
-    targetLabwareDef: labwareADefinition,
-    targetLabwareLocation: {
-      labwareId: 'labware-b-id',
-    },
-    otherLoadedLabware: [
-      {
-        id: 'labware-b-id',
-        definitionUri: labwareBUri,
-        location: 'offDeck',
-        loadName: '',
-      },
-    ],
-    deckDef: deckDefinition,
-    otherLabwareDefinitions: [labwareBDefinition],
-    loadedModules: [],
-  })
+      const expectedResult: typeof result = 'offDeck'
 
-  const expectedResult: typeof result = 'offDeck'
-
-  expect(result).toStrictEqual(expectedResult)
-})
+      expect(result).toStrictEqual(expectedResult)
+    })
+  }
+)
 
 it('should return error if something is missing from the input definitions', () => {
   const labwareAUri = 'opentrons/nest_12_reservoir_15ml/1'

--- a/components/src/hardware-sim/Deck/resolveLabwareLocation.ts
+++ b/components/src/hardware-sim/Deck/resolveLabwareLocation.ts
@@ -1,7 +1,7 @@
 import {
   getLabwareDefURI,
   getModuleDef,
-  locationIsOnDeck,
+  locationIsOffDeck,
 } from '@opentrons/shared-data'
 
 import type {
@@ -53,7 +53,7 @@ export function resolveLabwareLocation({
   const bottomLabwareLocation =
     labwareTopToBottom[labwareTopToBottom.length - 1].location
 
-  if (!locationIsOnDeck(bottomLabwareLocation)) {
+  if (locationIsOffDeck(bottomLabwareLocation)) {
     return 'offDeck'
   }
 

--- a/components/src/hardware-sim/Deck/resolveLabwareLocation.ts
+++ b/components/src/hardware-sim/Deck/resolveLabwareLocation.ts
@@ -1,4 +1,8 @@
-import { getLabwareDefURI, getModuleDef } from '@opentrons/shared-data'
+import {
+  getLabwareDefURI,
+  getModuleDef,
+  locationIsOnDeck,
+} from '@opentrons/shared-data'
 
 import type {
   ComputeLabwareOriginInput,
@@ -49,10 +53,7 @@ export function resolveLabwareLocation({
   const bottomLabwareLocation =
     labwareTopToBottom[labwareTopToBottom.length - 1].location
 
-  if (
-    bottomLabwareLocation === 'offDeck' ||
-    bottomLabwareLocation === 'systemLocation'
-  ) {
+  if (!locationIsOnDeck(bottomLabwareLocation)) {
     return 'offDeck'
   }
 

--- a/components/src/organisms/CommandText/useCommandTextString/utils/__tests__/getLabwareDisplayLocation.test.tsx
+++ b/components/src/organisms/CommandText/useCommandTextString/utils/__tests__/getLabwareDisplayLocation.test.tsx
@@ -81,6 +81,22 @@ describe('getLabwareDisplayLocation with translations', () => {
       screen.getByText('off deck')
     })
 
+    it('should return "off deck" for system location', () => {
+      render({
+        location: 'systemLocation',
+        params: defaultParams,
+      })
+      screen.getByText('off deck')
+    })
+
+    it('should return "off deck" for thrown-through-waste-chute location', () => {
+      render({
+        location: 'wasteChuteLocation',
+        params: defaultParams,
+      })
+      screen.getByText('off deck')
+    })
+
     it('should return a slot name for slot location', () => {
       render({
         location: { slotName: 'A1' },

--- a/components/src/organisms/CommandText/useCommandTextString/utils/commandText/getLoadCommandText.ts
+++ b/components/src/organisms/CommandText/useCommandTextString/utils/commandText/getLoadCommandText.ts
@@ -7,6 +7,8 @@ import {
   getModuleType,
   getOccludedSlotCountForModule,
   getPipetteSpecsV2,
+  locationIsOnDeck,
+  locationIsOnLabware,
 } from '@opentrons/shared-data'
 
 import { getLabwareDisplayLocation } from '../getLabwareDisplayLocation'
@@ -72,10 +74,7 @@ export const getLoadCommandText = ({
 
       // use in preposition for modules and slots, on for labware and adapters
       let displayLocation = t('in_location', { location })
-      if (
-        command.params.location === 'offDeck' ||
-        command.params.location === 'systemLocation'
-      ) {
+      if (!locationIsOnDeck(command.params.location)) {
         displayLocation = location
       } else if ('labwareId' in command.params.location) {
         displayLocation = t('on_location', { location })
@@ -104,11 +103,7 @@ export const getLoadCommandText = ({
           : ''
       // use in preposition for modules and slots, on for labware and adapters
       let displayLocation = t('in_location', { location })
-      if (
-        command.params.location !== 'systemLocation' &&
-        command.params.location !== 'offDeck' &&
-        'labwareId' in command.params.location
-      ) {
+      if (locationIsOnLabware(command.params.location)) {
         displayLocation = t('on_location', { location })
       }
       const lidName = command.result.definition.metadata.displayName

--- a/components/src/organisms/CommandText/useCommandTextString/utils/commandText/getLoadCommandText.ts
+++ b/components/src/organisms/CommandText/useCommandTextString/utils/commandText/getLoadCommandText.ts
@@ -7,7 +7,7 @@ import {
   getModuleType,
   getOccludedSlotCountForModule,
   getPipetteSpecsV2,
-  locationIsOnDeck,
+  locationIsOffDeck,
   locationIsOnLabware,
 } from '@opentrons/shared-data'
 
@@ -74,7 +74,7 @@ export const getLoadCommandText = ({
 
       // use in preposition for modules and slots, on for labware and adapters
       let displayLocation = t('in_location', { location })
-      if (!locationIsOnDeck(command.params.location)) {
+      if (locationIsOffDeck(command.params.location)) {
         displayLocation = location
       } else if ('labwareId' in command.params.location) {
         displayLocation = t('on_location', { location })

--- a/components/src/organisms/CommandText/useCommandTextString/utils/getLabwareDisplayLocation.tsx
+++ b/components/src/organisms/CommandText/useCommandTextString/utils/getLabwareDisplayLocation.tsx
@@ -1,4 +1,5 @@
 import {
+  changeAnyUseOfMeToPreserveStructure_thisIsAnOffDeckLocationInASlotName,
   FLEX_STACKER_MODULE_TYPE,
   getModuleDeckLabel,
   getModuleDisplayName,
@@ -65,12 +66,12 @@ export function getLabwareDisplayLocation(
 
   const { slotName, moduleModel, adapterName } = locationResult
 
-  if (slotName === 'offDeck' || slotName === 'systemLocation') {
+  if (
+    changeAnyUseOfMeToPreserveStructure_thisIsAnOffDeckLocationInASlotName(
+      slotName
+    )
+  ) {
     return t('off_deck')
-  } else if (slotName === 'systemLocation') {
-    // returning system location for slot name which we'll use to swap out
-    // run log copy, this should never reach the user
-    return slotName
   }
   // Simple slot location
   else if (moduleModel == null && adapterName == null) {

--- a/components/src/organisms/CommandText/useCommandTextString/utils/getLabwareLocation.tsx
+++ b/components/src/organisms/CommandText/useCommandTextString/utils/getLabwareLocation.tsx
@@ -7,6 +7,7 @@ import {
   getModuleModelFromAddressableArea,
   getModuleType,
   getSlotFromAddressableAreaName,
+  locationIsOnDeck,
   MOVABLE_TRASH_ADDRESSABLE_AREAS,
   WASTE_CHUTE_ADDRESSABLE_AREAS,
 } from '@opentrons/shared-data'
@@ -193,6 +194,8 @@ export function getLabwareLocation(
     return { slotName: 'offDeck' }
   } else if (location === 'systemLocation') {
     return { slotName: 'systemLocation' }
+  } else if (location === 'wasteChuteLocation') {
+    return { slotName: 'wasteChuteLocation' }
   } else if ('slotName' in location) {
     return { slotName: location.slotName }
   } else if ('addressableAreaName' in location) {
@@ -239,10 +242,7 @@ export function getLabwareLocation(
       const adapterName =
         adapterDef != null ? getLabwareDisplayName(adapterDef) : ''
 
-      if (
-        adapter.location === 'offDeck' ||
-        adapter.location === 'systemLocation'
-      ) {
+      if (!locationIsOnDeck(adapter.location)) {
         return { slotName: 'offDeck', adapterName }
       } else if (
         'slotName' in adapter.location ||

--- a/components/src/organisms/CommandText/useCommandTextString/utils/getLabwareLocation.tsx
+++ b/components/src/organisms/CommandText/useCommandTextString/utils/getLabwareLocation.tsx
@@ -7,7 +7,7 @@ import {
   getModuleModelFromAddressableArea,
   getModuleType,
   getSlotFromAddressableAreaName,
-  locationIsOnDeck,
+  locationIsOffDeck,
   MOVABLE_TRASH_ADDRESSABLE_AREAS,
   WASTE_CHUTE_ADDRESSABLE_AREAS,
 } from '@opentrons/shared-data'
@@ -242,7 +242,7 @@ export function getLabwareLocation(
       const adapterName =
         adapterDef != null ? getLabwareDisplayName(adapterDef) : ''
 
-      if (!locationIsOnDeck(adapter.location)) {
+      if (locationIsOffDeck(adapter.location)) {
         return { slotName: 'offDeck', adapterName }
       } else if (
         'slotName' in adapter.location ||

--- a/protocol-designer/src/load-file/migration/utils/getAdditionalEquipmentLocationUpdate.ts
+++ b/protocol-designer/src/load-file/migration/utils/getAdditionalEquipmentLocationUpdate.ts
@@ -18,6 +18,7 @@ import { getUnoccupiedSlotForTrash } from '../../../step-forms'
 import type {
   AddressableAreaName,
   CreateCommand,
+  LabwareLocation,
   LoadLabwareCreateCommand,
   MoveLabwareCreateCommand,
   MoveToAddressableAreaCreateCommand,
@@ -76,8 +77,10 @@ const getStagingAreaSlotNames = (
           command
         ): command is MoveLabwareCreateCommand | LoadLabwareCreateCommand =>
           command.commandType === commandType &&
-          //  @ts-expect-error: ts doesn't trust that locationkey is actually found in the command params
-          locationIsOnAddressableArea(command.params[locationKey]) &&
+          locationIsOnAddressableArea(
+            //  @ts-expect-error: ts doesn't trust that locationkey is actually found in the command params
+            command.params[locationKey] as any as LabwareLocation
+          ) &&
           COLUMN_4_SLOTS.includes(
             //  @ts-expect-error
             command.params[locationKey]

--- a/protocol-designer/src/load-file/migration/utils/getAdditionalEquipmentLocationUpdate.ts
+++ b/protocol-designer/src/load-file/migration/utils/getAdditionalEquipmentLocationUpdate.ts
@@ -1,5 +1,6 @@
 import {
   FLEX_ROBOT_TYPE,
+  locationIsOnAddressableArea,
   MOVABLE_TRASH_ADDRESSABLE_AREAS,
   OT2_ROBOT_TYPE,
   WASTE_CHUTE_ADDRESSABLE_AREAS,
@@ -76,11 +77,7 @@ const getStagingAreaSlotNames = (
         ): command is MoveLabwareCreateCommand | LoadLabwareCreateCommand =>
           command.commandType === commandType &&
           //  @ts-expect-error: ts doesn't trust that locationkey is actually found in the command params
-          command.params[locationKey] !== 'offDeck' &&
-          //  @ts-expect-error
-          command.params[locationKey] !== 'systemLocation' &&
-          //  @ts-expect-error
-          'addressableAreaName' in command.params[locationKey] &&
+          locationIsOnAddressableArea(command.params[locationKey]) &&
           COLUMN_4_SLOTS.includes(
             //  @ts-expect-error
             command.params[locationKey]
@@ -113,9 +110,7 @@ export const getAdditionalEquipmentLocationUpdate = (
           command.params.addressableAreaName as AddressableAreaName
         )) ||
       (command.commandType === 'moveLabware' &&
-        command.params.newLocation !== 'offDeck' &&
-        command.params.newLocation !== 'systemLocation' &&
-        'addressableAreaName' in command.params.newLocation &&
+        locationIsOnAddressableArea(command.params.newLocation) &&
         WASTE_CHUTE_ADDRESSABLE_AREAS.includes(
           command.params.newLocation.addressableAreaName as AddressableAreaName
         ))

--- a/protocol-designer/src/step-forms/utils/index.ts
+++ b/protocol-designer/src/step-forms/utils/index.ts
@@ -7,6 +7,7 @@ import {
   GEN_ONE_MULTI_PIPETTES,
   getCutoutDisplayName,
   getPipetteSpecsV2,
+  locationIsOnSlot,
   OT2_CUTOUT_BY_SLOT_ID,
   OT2_ROBOT_TYPE,
   THERMOCYCLER_MODULE_TYPE,
@@ -264,12 +265,7 @@ export const getUnoccupiedSlotForTrash = (
     )
     .reduce((acc: string[], command) => {
       const location = command.params.location
-      if (
-        location !== 'offDeck' &&
-        location !== 'systemLocation' &&
-        location !== null &&
-        'slotName' in location
-      ) {
+      if (location !== null && locationIsOnSlot(location)) {
         return [...acc, location.slotName]
       }
       return acc
@@ -296,12 +292,7 @@ export const getUnoccupiedSlotForTrash = (
     )
     .reduce((acc: string[], command) => {
       const newLocation = command.params.newLocation
-      if (
-        newLocation !== 'offDeck' &&
-        newLocation !== 'systemLocation' &&
-        newLocation !== null &&
-        'slotName' in newLocation
-      ) {
+      if (newLocation !== null && locationIsOnSlot(newLocation)) {
         return [...acc, newLocation.slotName]
       }
       return acc

--- a/protocol-designer/src/steplist/formLevel/moveLabwareFormErrors.ts
+++ b/protocol-designer/src/steplist/formLevel/moveLabwareFormErrors.ts
@@ -1,4 +1,7 @@
-import { getLabwareDefIsStandard } from '@opentrons/shared-data'
+import {
+  getLabwareDefIsStandard,
+  locationIsOnDeck,
+} from '@opentrons/shared-data'
 
 import { getLabwareCompatibleWithModule } from '../../utils/labwareModuleCompatibility'
 
@@ -19,8 +22,7 @@ const getMoveLabwareError = (
   if (
     labware == null ||
     newLocation == null ||
-    newLocation === 'offDeck' ||
-    newLocation === 'systemLocation' ||
+    !locationIsOnDeck(newLocation) ||
     !getLabwareDefIsStandard(labware?.def)
   )
     return null

--- a/protocol-designer/src/steplist/formLevel/moveLabwareFormErrors.ts
+++ b/protocol-designer/src/steplist/formLevel/moveLabwareFormErrors.ts
@@ -1,6 +1,6 @@
 import {
   getLabwareDefIsStandard,
-  locationIsOnDeck,
+  locationIsOffDeck,
 } from '@opentrons/shared-data'
 
 import { getLabwareCompatibleWithModule } from '../../utils/labwareModuleCompatibility'
@@ -22,7 +22,7 @@ const getMoveLabwareError = (
   if (
     labware == null ||
     newLocation == null ||
-    !locationIsOnDeck(newLocation) ||
+    locationIsOffDeck(newLocation) ||
     !getLabwareDefIsStandard(labware?.def)
   )
     return null

--- a/shared-data/command/types/setup.ts
+++ b/shared-data/command/types/setup.ts
@@ -152,6 +152,7 @@ export type SetupCreateCommand =
 export type LabwareLocation =
   | 'offDeck'
   | 'systemLocation'
+  | 'wasteChuteLocation'
   | { slotName: string }
   | { moduleId: string }
   | { labwareId: string }
@@ -198,7 +199,7 @@ export interface OnAddressableAreaLocationSequenceComponent {
 
 export interface NotOnDeckLocationSequenceComponent {
   kind: 'notOnDeck'
-  logicalLocationName: 'offDeck' | 'systemLocation'
+  logicalLocationName: 'offDeck' | 'systemLocation' | 'wasteChuteLocation'
 }
 
 export interface OnCutoutFixtureLocationSequenceComponent {

--- a/shared-data/js/helpers/__tests__/parseProtocolCommands.test.ts
+++ b/shared-data/js/helpers/__tests__/parseProtocolCommands.test.ts
@@ -246,6 +246,35 @@ describe('parseInitialLoadedLabwareByAdapter', () => {
         startedAt: '2022-04-01T15:46:01.745870+00:00',
         completedAt: '2022-04-01T15:46:01.745870+00:00',
       },
+      {
+        createdAt: '2022-04-01T15:46:01.745870+00:00',
+        commandType: 'moveLabware',
+        key: 'commands.MOVE_LABWARE-1',
+        status: 'succeeded',
+        params: {
+          labwareId: 'labware-2',
+          newLocation: 'wasteChuteLocation',
+          strategy: 'usingGripper',
+        },
+        result: {
+          offsetId: '',
+          eventualDestinationLocationSequence: [
+            { kind: 'notOnDeck', logicalLocationName: 'wasteChuteLocation' },
+          ],
+          immediateDestinationLocationSequence: [
+            { kind: 'notOnDeck', logicalLocationName: 'wasteChuteLocation' },
+          ],
+          originLocationSequence: [
+            {
+              kind: 'onAddressableArea',
+              addressableAreaName: 'temperatureModuleV1A1',
+            },
+          ],
+        },
+        error: null,
+        startedAt: '2022-04-01T15:46:01.745870+00:00',
+        completedAt: '2022-04-01T15:46:01.745870+00:00',
+      },
     ] as any as RunTimeCommand[]
     const labware2 = 'labware-2'
 

--- a/shared-data/js/helpers/getAddressableAreasInProtocol.ts
+++ b/shared-data/js/helpers/getAddressableAreasInProtocol.ts
@@ -3,6 +3,10 @@ import {
   getAddressableAreaFromSlotId,
   getAddressableAreaNamesFromLoadedModule,
 } from '../fixtures'
+import {
+  locationIsOnAddressableArea,
+  locationIsOnSlot,
+} from './symbolicPositionHelpers'
 
 import type { AddressableAreaName } from '../../deck'
 import type { ProtocolAnalysisOutput } from '../../protocol'
@@ -19,9 +23,7 @@ export function getAddressableAreasInProtocol(
       const { commandType, params } = command
       if (
         commandType === 'moveLabware' &&
-        params.newLocation !== 'offDeck' &&
-        params.newLocation !== 'systemLocation' &&
-        'slotName' in params.newLocation &&
+        locationIsOnSlot(params.newLocation) &&
         !acc.includes(params.newLocation.slotName as AddressableAreaName)
       ) {
         const addressableAreaName = getAddressableAreaFromSlotId(
@@ -36,9 +38,7 @@ export function getAddressableAreasInProtocol(
         }
       } else if (
         commandType === 'moveLabware' &&
-        params.newLocation !== 'offDeck' &&
-        params.newLocation !== 'systemLocation' &&
-        'addressableAreaName' in params.newLocation &&
+        locationIsOnAddressableArea(params.newLocation) &&
         !acc.includes(params.newLocation.addressableAreaName)
       ) {
         return [...acc, params.newLocation.addressableAreaName]
@@ -46,9 +46,7 @@ export function getAddressableAreasInProtocol(
         (commandType === 'loadLabware' ||
           commandType === 'loadLid' ||
           commandType === 'loadLidStack') &&
-        params.location !== 'offDeck' &&
-        params.location !== 'systemLocation' &&
-        'slotName' in params.location &&
+        locationIsOnSlot(params.location) &&
         !acc.includes(params.location.slotName as AddressableAreaName)
       ) {
         const addressableAreaName = getAddressableAreaFromSlotId(
@@ -80,9 +78,7 @@ export function getAddressableAreasInProtocol(
         (commandType === 'loadLabware' ||
           commandType === 'loadLid' ||
           commandType === 'loadLidStack') &&
-        params.location !== 'offDeck' &&
-        params.location !== 'systemLocation' &&
-        'addressableAreaName' in params.location &&
+        locationIsOnAddressableArea(params.location) &&
         !acc.includes(params.location.addressableAreaName)
       ) {
         return [...acc, params.location.addressableAreaName]
@@ -107,9 +103,7 @@ export function getAddressableAreasInProtocol(
   const legacyTrashAddressableArea = labware.some(
     ({ loadName, location }) =>
       loadName === 'opentrons_1_trash_3200ml_fixed' &&
-      location !== 'offDeck' &&
-      location !== 'systemLocation' &&
-      'slotName' in location &&
+      locationIsOnSlot(location) &&
       location.slotName === 'A3'
   )
     ? MOVABLE_TRASH_A3_ADDRESSABLE_AREA

--- a/shared-data/js/helpers/getStackedItemsOnStartingDeck.ts
+++ b/shared-data/js/helpers/getStackedItemsOnStartingDeck.ts
@@ -12,6 +12,7 @@ import { getLabwareDefinitionsByURIForProtocol } from './getLabwareDefinitionsBy
 import { getLabwareDefURI } from './getLabwareDefURI'
 import { getLiquidsByIdForLabware } from './getLiquidsByIdForLabware'
 import { getSlotFromAddressableAreaName } from './parseAddressableArea'
+import { locationIsOnLabware } from './symbolicPositionHelpers'
 
 import type { CutoutId } from '../../deck'
 import type {
@@ -90,9 +91,7 @@ export function getStackedItemsOnStartingDeck(
   const loadLidCommands = commands.filter(
     (command): command is LoadLidOnLabwareCommad =>
       command.commandType === 'loadLid' &&
-      command.params.location !== 'offDeck' &&
-      command.params.location !== 'systemLocation' &&
-      'labwareId' in command.params.location
+      locationIsOnLabware(command.params.location)
   )
   const labwareAndLidOnDeck = commands
     .filter(

--- a/shared-data/js/helpers/index.ts
+++ b/shared-data/js/helpers/index.ts
@@ -63,6 +63,7 @@ export * from './getWellFillFromLabwareId'
 export * from './getModuleDeckLabel'
 export * from './deckConfig'
 export * from './testHelpers'
+export * from './symbolicPositionHelpers'
 
 export const getLabwareDefIsStandard = (def: LabwareDefinition): boolean =>
   def?.namespace === OPENTRONS_LABWARE_NAMESPACE

--- a/shared-data/js/helpers/parseProtocolCommands.ts
+++ b/shared-data/js/helpers/parseProtocolCommands.ts
@@ -5,6 +5,7 @@ import { DEFAULT_LIQUID_COLORS } from '../constants'
 import { getModuleType } from '../modules'
 import { getLabwareDefURI } from './getLabwareDefURI'
 import { getModuleDeckLabel } from './getModuleDeckLabel'
+import { locationIsOnLabware } from './symbolicPositionHelpers'
 
 import type {
   LabwareLocation,
@@ -154,12 +155,10 @@ export function getTopLabwareInfo(
   const nestedCommand = loadLabwareCommands.find(
     command =>
       command.commandType === 'loadLabware' &&
-      command.params.location !== 'offDeck' &&
-      command.params.location !== 'systemLocation' &&
-      'labwareId' in command.params.location &&
+      locationIsOnLabware(command.params.location) &&
       command.params.location.labwareId === labwareId
   )
-  // prevent recurssion errors (like labware stacked on itself)
+  // prevent recursion errors (like labware stacked on itself)
   // by enforcing a max stack height
   if (nestedCommand == null || currentStackHeight > 5) {
     const loadCommand = loadLabwareCommands.find(
@@ -211,11 +210,7 @@ export function getLabwareStackCountAndLocation(
 
   const labwareLocation = loadLabwareCommand.params.location
 
-  if (
-    labwareLocation !== 'offDeck' &&
-    labwareLocation !== 'systemLocation' &&
-    'labwareId' in labwareLocation
-  ) {
+  if (locationIsOnLabware(labwareLocation)) {
     const lowerLabwareCommand = loadLabwareCommands?.find(command =>
       command.result != null
         ? command.result?.labwareId === labwareLocation.labwareId
@@ -223,7 +218,7 @@ export function getLabwareStackCountAndLocation(
     )
     if (lowerLabwareCommand?.result?.labwareId == null) {
       console.warn(
-        `could not find the load labware command assosciated with thie labwareId: ${labwareLocation.labwareId}`
+        `could not find the load labware command associated with this labwareId: ${labwareLocation.labwareId}`
       )
       return { labwareLocation: 'offDeck', labwareQuantity: 0 }
     }

--- a/shared-data/js/helpers/symbolicPositionHelpers.ts
+++ b/shared-data/js/helpers/symbolicPositionHelpers.ts
@@ -1,0 +1,38 @@
+import type {
+  LabwareLocation,
+  OnDeckLabwareLocation,
+} from '../../command/types/setup'
+import type { AddressableAreaName } from '../../js'
+
+export const changeAnyUseOfMeToPreserveStructure_thisIsAnOffDeckLocationInASlotName =
+  (quoteUnquoteSlotName: string): boolean =>
+    ['offDeck', 'systemLocation', 'wasteChuteLocation'].includes(
+      quoteUnquoteSlotName
+    )
+
+export const locationIsOnDeck = (
+  labwareLocation: LabwareLocation
+): labwareLocation is OnDeckLabwareLocation =>
+  labwareLocation !== 'offDeck' &&
+  labwareLocation !== 'systemLocation' &&
+  labwareLocation !== 'wasteChuteLocation'
+
+export const locationIsOnLabware = (
+  labwareLocation: LabwareLocation
+): labwareLocation is { labwareId: string } =>
+  locationIsOnDeck(labwareLocation) && 'labwareId' in labwareLocation
+
+export const locationIsOnSlot = (
+  labwareLocation: LabwareLocation
+): labwareLocation is { slotName: string } =>
+  locationIsOnDeck(labwareLocation) && 'slotName' in labwareLocation
+
+export const locationIsOnModule = (
+  labwareLocation: LabwareLocation
+): labwareLocation is { moduleId: string } =>
+  locationIsOnDeck(labwareLocation) && 'moduleId' in labwareLocation
+
+export const locationIsOnAddressableArea = (
+  labwareLocation: LabwareLocation
+): labwareLocation is { addressableAreaName: AddressableAreaName } =>
+  locationIsOnDeck(labwareLocation) && 'addressableAreaName' in labwareLocation

--- a/shared-data/js/helpers/symbolicPositionHelpers.ts
+++ b/shared-data/js/helpers/symbolicPositionHelpers.ts
@@ -10,12 +10,17 @@ export const changeAnyUseOfMeToPreserveStructure_thisIsAnOffDeckLocationInASlotN
       quoteUnquoteSlotName
     )
 
+export const locationIsOffDeck = (
+  labwareLocation: LabwareLocation
+): labwareLocation is 'offDeck' | 'systemLocation' | 'wasteChuteLocation' =>
+  labwareLocation === 'offDeck' ||
+  labwareLocation === 'systemLocation' ||
+  labwareLocation === 'wasteChuteLocation'
+
 export const locationIsOnDeck = (
   labwareLocation: LabwareLocation
 ): labwareLocation is OnDeckLabwareLocation =>
-  labwareLocation !== 'offDeck' &&
-  labwareLocation !== 'systemLocation' &&
-  labwareLocation !== 'wasteChuteLocation'
+  !locationIsOffDeck(labwareLocation)
 
 export const locationIsOnLabware = (
   labwareLocation: LabwareLocation

--- a/step-generation/src/commandCreators/atomic/moveLabware.ts
+++ b/step-generation/src/commandCreators/atomic/moveLabware.ts
@@ -4,6 +4,10 @@ import {
   FLEX_STAGING_AREA_SLOT_ADDRESSABLE_AREAS,
   getIsLid,
   HEATERSHAKER_MODULE_TYPE,
+  locationIsOnAddressableArea,
+  locationIsOnDeck,
+  locationIsOnLabware,
+  locationIsOnModule,
   MOVABLE_TRASH_ADDRESSABLE_AREAS,
   OT2_ROBOT_TYPE,
   THERMOCYCLER_MODULE_TYPE,
@@ -75,9 +79,7 @@ export const moveLabware: CommandCreator<MoveLabwareParams> = (
   const warnings: CommandCreatorWarning[] = []
 
   const newLocationInWasteChute =
-    newLocation !== 'offDeck' &&
-    newLocation !== 'systemLocation' &&
-    'addressableAreaName' in newLocation &&
+    locationIsOnAddressableArea(newLocation) &&
     newLocation.addressableAreaName === 'gripperWasteChute'
 
   if (!labwareId || !prevRobotState.labware[labwareId]) {
@@ -174,18 +176,13 @@ export const moveLabware: CommandCreator<MoveLabwareParams> = (
     }
   }
   const destModuleId =
-    newLocation !== 'offDeck' &&
-    newLocation !== 'systemLocation' &&
-    'moduleId' in newLocation
+    locationIsOnModule(newLocation) && 'moduleId' in newLocation
       ? newLocation.moduleId
       : null
 
-  const destAdapterId =
-    newLocation !== 'offDeck' &&
-    newLocation !== 'systemLocation' &&
-    'labwareId' in newLocation
-      ? newLocation.labwareId
-      : null
+  const destAdapterId = locationIsOnLabware(newLocation)
+    ? newLocation.labwareId
+    : null
 
   const destModuleOrSlotUnderAdapterId =
     destAdapterId != null
@@ -231,8 +228,7 @@ export const moveLabware: CommandCreator<MoveLabwareParams> = (
   if (
     isLabwareIdATiprackLid &&
     newLocation != null &&
-    newLocation !== 'offDeck' &&
-    newLocation !== 'systemLocation' &&
+    locationIsOnDeck(newLocation) &&
     ('slotName' in newLocation ||
       ('addressableAreaName' in newLocation &&
         FLEX_STAGING_AREA_SLOT_ADDRESSABLE_AREAS.includes(
@@ -263,6 +259,9 @@ export const moveLabware: CommandCreator<MoveLabwareParams> = (
     location = OFF_DECK
   } else if (newLocation === 'systemLocation') {
     location = 'system_location' // NOTE: i think this is for LPC but shouldn't be used in PD
+  } else if (newLocation === 'wasteChuteLocation') {
+    location = OFF_DECK // NOTE: this should never happen; labware should only be here if moved
+    // to the waste chute
   } else if ('labwareId' in newLocation) {
     location = labwareEntities[newLocation.labwareId].pythonName
     const newLocationStack = prevRobotState.labware[newLocation.labwareId].stack

--- a/step-generation/src/getNextRobotStateAndWarnings/forMoveLabware.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/forMoveLabware.ts
@@ -1,7 +1,7 @@
 import {
   getIsLid,
   getIsPipettableLabware,
-  locationIsOnDeck,
+  locationIsOffDeck,
 } from '@opentrons/shared-data'
 
 import { TOUCHED_PIPETTABLE_LABWARE } from '../types'
@@ -32,7 +32,7 @@ export function forMoveLabware(
   let isParentPipettableLabware: boolean = false
 
   const newLocationStack: string[] = []
-  if (!locationIsOnDeck(newLocation)) {
+  if (locationIsOffDeck(newLocation)) {
     newLocationStack.push(newLocation)
   } else if ('moduleId' in newLocation) {
     newLocationStack.push(

--- a/step-generation/src/getNextRobotStateAndWarnings/forMoveLabware.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/forMoveLabware.ts
@@ -1,4 +1,8 @@
-import { getIsLid, getIsPipettableLabware } from '@opentrons/shared-data'
+import {
+  getIsLid,
+  getIsPipettableLabware,
+  locationIsOnDeck,
+} from '@opentrons/shared-data'
 
 import { TOUCHED_PIPETTABLE_LABWARE } from '../types'
 import { getFullStackFromLabwares, getSlotInLocationStack } from '../utils'
@@ -28,7 +32,7 @@ export function forMoveLabware(
   let isParentPipettableLabware: boolean = false
 
   const newLocationStack: string[] = []
-  if (newLocation === 'offDeck' || newLocation === 'systemLocation') {
+  if (!locationIsOnDeck(newLocation)) {
     newLocationStack.push(newLocation)
   } else if ('moduleId' in newLocation) {
     newLocationStack.push(

--- a/step-generation/src/utils/createTimelineFromRunCommands.ts
+++ b/step-generation/src/utils/createTimelineFromRunCommands.ts
@@ -1,4 +1,4 @@
-import { getModuleDef } from '@opentrons/shared-data'
+import { getModuleDef, locationIsOnDeck } from '@opentrons/shared-data'
 
 import { MODULE_INITIAL_STATE_BY_TYPE } from '../constants'
 import { getNextRobotStateAndWarnings } from '../getNextRobotStateAndWarnings'
@@ -58,10 +58,7 @@ export function getResultingTimelineFrameFromRunCommands(
     (acc, command) => {
       if (command.commandType === 'loadLabware' && command.result != null) {
         const stack = [command.result.labwareId]
-        if (
-          command.params.location === 'offDeck' ||
-          command.params.location === 'systemLocation'
-        ) {
+        if (!locationIsOnDeck(command.params.location)) {
           stack.push(command.params.location)
         } else if ('slotName' in command.params.location) {
           stack.push(command.params.location.slotName)

--- a/step-generation/src/utils/createTimelineFromRunCommands.ts
+++ b/step-generation/src/utils/createTimelineFromRunCommands.ts
@@ -1,4 +1,4 @@
-import { getModuleDef, locationIsOnDeck } from '@opentrons/shared-data'
+import { getModuleDef, locationIsOffDeck } from '@opentrons/shared-data'
 
 import { MODULE_INITIAL_STATE_BY_TYPE } from '../constants'
 import { getNextRobotStateAndWarnings } from '../getNextRobotStateAndWarnings'
@@ -58,7 +58,7 @@ export function getResultingTimelineFrameFromRunCommands(
     (acc, command) => {
       if (command.commandType === 'loadLabware' && command.result != null) {
         const stack = [command.result.labwareId]
-        if (!locationIsOnDeck(command.params.location)) {
+        if (locationIsOffDeck(command.params.location)) {
           stack.push(command.params.location)
         } else if ('slotName' in command.params.location) {
           stack.push(command.params.location.slotName)

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -17,13 +17,14 @@ export default mergeConfig(
     test: {
       environment: 'jsdom',
       allowOnly: true,
-      exclude: [...configDefaults.exclude, '**/node_modules/**', '**/dist/**'],
+      exclude: [...configDefaults.exclude, '**/node_modules/**', '**/dist/**', '**/lib/**'],
       setupFiles: ['./setup-vitest.mts'],
       coverage: {
         exclude: [
           '**/node_modules/**',
           '**/dist/**',
           '**/__tests__/**',
+          '**/lib/**',
           'protocol-designer/cypress/**/*',
           'labware-library/cypress/**/*',
           ...configDefaults.exclude,


### PR DESCRIPTION
This is a new kind of legacy location added in https://github.com/Opentrons/opentrons/pull/19684 (
b801f7f5fda47a36a7b9fbc869fa002a9701a8bc ) to present better information when a protocol tries to use a labware that has been thrown away. Add a type binding for it in the LabwareLocation type that PE load commands
can take and emit, and some ts type predicates for figuring out when it's present.

This is a whole lot of code across the entire FE. it's validated by ts but I need to add tests throughout and do some manual tests.

The PR is organized so each commit is a different subsystem, which might be a nicer way to read it.

## Todo
- [x] update unit tests
- [x] test manually with associated protocol (anything that throws a labware away)

Closes RQA-4772
