### PR TITLE
fix(app): Fix "setup" / "set up" UX copy in module wizard flows

### DIFF
--- a/app/src/assets/localization/en/module_wizard_flows.json
+++ b/app/src/assets/localization/en/module_wizard_flows.json
@@ -40,9 +40,9 @@
   "location_must_be_correct": "The location must be correct for successful calibration.",
   "location_occupied": "A {{fixture}} is currently specified here on the deck configuration",
   "look_for_pulsing_lights": "Look for pulsing lights on the module that you are setting up",
-  "module_added": "New module detected. Setup the module for use.",
+  "module_added": "New module detected. Set up the module for use.",
   "module_added_link": "Launch Setup",
-  "module_attached_multiple": "Multiple new modules detected. Which module do you want to setup?",
+  "module_attached_multiple": "Multiple new modules detected. Which module do you want to set up?",
   "module_attached_select": "{{module}} in {{port}}",
   "module_attached_to_port": "New {{module}} attached to {{port}}!",
   "module_calibrating": "Stand back, {{moduleName}} is calibrating",
@@ -64,7 +64,7 @@
   "recalibrate": "Recalibrate",
   "select_location": "Select module location",
   "select_the_slot": "Select the slot where you installed the {{module}} connected to {{port}}.",
-  "setup_another_module": "Setup another module",
+  "setup_another_module": "Set up another module",
   "shuttle_install_fail": "Shuttle installed incorrectly",
   "shuttle_install_fail_description": "There was an issue with the install of the shuttle. Please try installing again or contact support.",
   "skip": "Skip",
@@ -72,6 +72,6 @@
   "stand_back": "Stand back, calibration in progress",
   "stand_back_robot_in_motion": "Stand back, robot is in motion",
   "start_setup": "Start setup",
-  "successfully_setup": "{{module}} successfully setup",
+  "successfully_setup": "{{module}} successfully set up",
   "try_again": "Try Again"
 }


### PR DESCRIPTION
## Overview

This fixes some UX copy. Per our UX style guide, when "set up" is used as a verb, it should be two words, not "setup."

## Test Plan and Hands on Testing

None needed.

## Review requests

None.

## Risk assessment

Low.
