### PR TITLE
fix(api): Fix Python Protocol API version error message for loading lids as labware

### DIFF
--- a/api/src/opentrons/protocol_api/validation.py
+++ b/api/src/opentrons/protocol_api/validation.py
@@ -377,7 +377,7 @@ def ensure_definition_is_not_lid_after_api_version(
         and api_version >= LID_STACK_VERSION_GATE
     ):
         raise APIVersionError(
-            f"Labware Lids cannot be loaded like standard labware in Protocols written with an API version greater than {LID_STACK_VERSION_GATE}."
+            f"Labware Lids cannot be loaded like standard labware in Protocols written with an API version of {LID_STACK_VERSION_GATE} or higher."
         )
 
 


### PR DESCRIPTION
## Overview

Just correcting the text of an error message.

The code was doing `api_version >= LID_STACK_VERSION_GATE`, but the text of the error message was saying `api_version > LID_STACK_VERSION_GATE`. (Greater-than-or-equal vs. greater-than.)

## Test Plan and Hands on Testing

None needed.

## Review requests

None in particular.

## Risk assessment

Low.
