### PR TITLE
feat(robot-server): support deleting all images associated with a run at `/dataFiles/:runId/images`

### DIFF
--- a/robot-server/robot_server/data_files/router.py
+++ b/robot-server/robot_server/data_files/router.py
@@ -6,6 +6,10 @@ from typing import Annotated, Optional, Literal, Union, Final
 
 from fastapi import UploadFile, File, Form, Depends, Response, status, Query
 from opentrons.protocol_reader import FileHasher, FileReaderWriter
+from robot_server.runs.dependencies import get_run_data_manager
+from robot_server.runs.router.base_router import RunNotFound
+from robot_server.runs.run_data_manager import RunDataManager
+from robot_server.runs.run_models import RunNotFoundError
 from server_utils.fastapi_utils.light_router import LightRouter
 
 from robot_server.service.json_api import (
@@ -401,5 +405,47 @@ async def get_run_image_metadata(
 
     return await PydanticResponse.create(
         content=SimpleMultiBody.model_construct(data=data, meta=meta),
+        status_code=status.HTTP_200_OK,
+    )
+
+
+@PydanticResponse.wrap_route(
+    datafiles_router.delete,
+    path="/dataFiles/{runId}/images",
+    summary="Delete all camera images for a run",
+    description=dedent(
+        """
+        Delete all camera image files associated with a run from both the database
+        and filesystem storage.
+
+        This operation cannot be undone.
+        """
+    ),
+    responses={
+        status.HTTP_200_OK: {"model": SimpleEmptyBody},
+        status.HTTP_404_NOT_FOUND: {"model": ErrorBody[RunNotFound]},
+    },
+)
+async def delete_run_images(
+    runId: str,
+    data_files_store: Annotated[DataFilesStore, Depends(get_data_files_store)],
+    run_data_manager: Annotated[RunDataManager, Depends(get_run_data_manager)],
+) -> PydanticResponse[SimpleEmptyBody]:
+    """Delete all camera images for a run.
+
+    Arguments:
+        runId: The run ID whose images should be deleted.
+        data_files_store: Store for data files database access.
+        run_data_manager: Current and historical run data management.
+    """
+    try:
+        run_data_manager.get(runId)
+    except RunNotFoundError as e:
+        raise RunNotFound(detail=str(e)).as_error(status.HTTP_404_NOT_FOUND) from e
+
+    data_files_store.remove_all_by_run_id(runId)
+
+    return await PydanticResponse.create(
+        content=SimpleEmptyBody.model_construct(),
         status_code=status.HTTP_200_OK,
     )

--- a/robot-server/tests/data_files/test_router.py
+++ b/robot-server/tests/data_files/test_router.py
@@ -26,11 +26,14 @@ from robot_server.data_files.router import (
     get_all_data_files,
     delete_file_by_id,
     get_run_image_metadata,
+    delete_run_images,
 )
 from robot_server.data_files.data_files_store import DataFileWithCommandsInfoSlice
 from opentrons_shared_data.data_files import DataFileInfoWithCommands, CmdDataFileInfo
 from robot_server.data_files.file_auto_deleter import DataFileAutoDeleter
 from robot_server.errors.error_responses import ApiError
+from robot_server.runs.run_data_manager import RunDataManager
+from robot_server.runs.run_models import RunNotFoundError
 
 
 @pytest.fixture
@@ -55,6 +58,12 @@ def file_reader_writer(decoy: Decoy) -> FileReaderWriter:
 def file_auto_deleter(decoy: Decoy) -> DataFileAutoDeleter:
     """Get a mocked out DataFileAutoDeleter."""
     return decoy.mock(cls=DataFileAutoDeleter)
+
+
+@pytest.fixture
+def run_data_manager(decoy: Decoy) -> RunDataManager:
+    """Get a mocked out RunDataManager."""
+    return decoy.mock(cls=RunDataManager)
 
 
 async def test_upload_new_data_file(
@@ -577,3 +586,44 @@ async def test_get_run_image_metadata_with_pagination(
     assert len(result.content.data) == 1
     assert result.content.data[0].id == "file-id-3"
     assert result.content.meta == MultiBodyMeta(totalLength=5, cursor=2)
+
+
+async def test_delete_run_images(
+    decoy: Decoy,
+    data_files_store: DataFilesStore,
+    run_data_manager: RunDataManager,
+) -> None:
+    """It should delete all images for a run."""
+    decoy.when(run_data_manager.get("run-id")).then_return(decoy.mock(name="run_data"))
+    decoy.when(run_data_manager.current_run_id).then_return(None)
+
+    result = await delete_run_images(
+        runId="run-id",
+        data_files_store=data_files_store,
+        run_data_manager=run_data_manager,
+    )
+
+    decoy.verify(data_files_store.remove_all_by_run_id("run-id"))
+    assert result.content == SimpleEmptyBody()
+    assert result.status_code == 200
+
+
+async def test_delete_run_images_run_not_found(
+    decoy: Decoy,
+    data_files_store: DataFilesStore,
+    run_data_manager: RunDataManager,
+) -> None:
+    """It should raise an error if the run doesn't exist."""
+    decoy.when(run_data_manager.get("run-id")).then_raise(
+        RunNotFoundError(run_id="run-id")
+    )
+
+    with pytest.raises(ApiError) as exc_info:
+        await delete_run_images(
+            runId="run-id",
+            data_files_store=data_files_store,
+            run_data_manager=run_data_manager,
+        )
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.content["errors"][0]["id"] == "RunNotFound"


### PR DESCRIPTION
Closes [EXEC-1988](https://opentrons.atlassian.net/browse/EXEC-1988)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Adds HTTP API support for deleting all images associated with a run at `/dataFiles/:runId/images`.

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- Ran the following protocol, and then confirmed deletion of the run images via the HTTP API:
```
def run(protocol) -> None:
    instr = protocol.load_instrument("flex_96channel_200")
    protocol._core.capture_image(filename="contrast_10", zoom=2.0, contrast=10)
    protocol._core.capture_image(filename="contrast_50", zoom=2.0, contrast=50)
    protocol._core.capture_image(filename="contrast_100", zoom=2.0, contrast=100)
    protocol._core.capture_image(filename="brightness_0", zoom=2.0, brightness=0.0)
    protocol._core.capture_image(filename="brightness_50", zoom=2.0, brightness=50.0)
    protocol._core.capture_image(filename="brightness100", zoom=2.0, brightness=100.0)
    protocol._core.capture_image(filename="saturation_0",zoom=2.0, saturation=0)
    protocol._core.capture_image(filename="saturation_50",zoom=2.0, saturation=50)
    protocol._core.capture_image(filename="saturation_100",zoom=2.0, saturation=100)
    protocol._core.capture_image(filename="zoom_2x_with_home", zoom=2.0)
```
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Added HTTP API support for deleting all images associated with a run.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[EXEC-1988]: https://opentrons.atlassian.net/browse/EXEC-1988?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ