### PR TITLE
refactor(app): rename getAllDefinitions.ts `getAllDefinitions()` -> `getAllLatestDefs()`

### DIFF
--- a/app/src/local-resources/labware/hooks/useAllLabware.ts
+++ b/app/src/local-resources/labware/hooks/useAllLabware.ts
@@ -2,7 +2,7 @@ import { useSelector } from 'react-redux'
 
 import { getValidCustomLabware } from '/app/redux/custom-labware'
 
-import { getAllDefinitions } from '../utils'
+import { getAllLatestDefs } from '../utils'
 
 import type { LabwareDefAndDate, LabwareFilter, LabwareSort } from '../types'
 
@@ -13,7 +13,7 @@ export function useAllLabware(
   filterBy: LabwareFilter
 ): LabwareDefAndDate[] {
   const fullLabwareList: LabwareDefAndDate[] = []
-  const labwareDefinitions = getAllDefinitions().filter(
+  const labwareDefinitions = getAllLatestDefs().filter(
     def => !LABWARE_LOADNAME_BLOCKLIST.includes(def.parameters.loadName)
   )
   labwareDefinitions.forEach(def => fullLabwareList.push({ definition: def }))

--- a/app/src/local-resources/labware/utils/getAllDefinitions.ts
+++ b/app/src/local-resources/labware/utils/getAllDefinitions.ts
@@ -25,7 +25,7 @@ const getOnlyLatestDefs = (
   })
 }
 
-export function getAllDefinitions(): LabwareDefinition[] {
+export function getAllLatestDefs(): LabwareDefinition[] {
   const allDefs = getAllDefs().filter(
     (d: LabwareDefinition) =>
       // eslint-disable-next-line @typescript-eslint/prefer-includes

--- a/app/src/organisms/ODD/QuickTransferFlow/utils/generateCompatibleLabwareForPipette.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/utils/generateCompatibleLabwareForPipette.ts
@@ -1,6 +1,6 @@
 import { getLabwareDefURI, makeWellSetHelpers } from '@opentrons/shared-data'
 
-import { getAllDefinitions as getAllLatestDefValues } from '/app/local-resources/labware'
+import { getAllLatestDefs } from '/app/local-resources/labware'
 
 import { QUICK_TRANSFER_INCOMPATIBLE_LABWARE } from '../constants'
 
@@ -9,7 +9,7 @@ import type { PipetteV2Specs, WellSetHelpers } from '@opentrons/shared-data'
 export function generateCompatibleLabwareForPipette(
   pipetteSpecs: PipetteV2Specs
 ): string[] {
-  const allLabwareDefinitions = getAllLatestDefValues()
+  const allLabwareDefinitions = getAllLatestDefs()
   const wellSetHelpers: WellSetHelpers = makeWellSetHelpers()
   const { canPipetteUseLabware } = wellSetHelpers
 


### PR DESCRIPTION
# Overview

This is part 1 in a long chain of PRs to fix tiprack lookups in PD.

Yes, at first glance, the code in this PR has nothing to do with PD. But `app/src/local-resources/labware/utils/getAllDefinitions.ts` defines this function called `getAllDefinitions()` that contrary to its name, does **not** return all labware definitions. Instead, it filters the list to only return the latest definitions.

This has nothing to do with PD. But it's getting in my way because there is **another** function in `shared-data/js/labware.ts` called `getAllDefinitions()` that **does** return all labware definitions. I'm about to do some refactoring that will look very confusing if we have 2 functions with the same name.

So this first PR renames `getAllDefinitions()` to `getAllLatestDefs()`.

This will probably all make sense in about 10 more PRs.

## Test Plan and Hands on Testing

Global search for all the references to the renamed function.
Run the unit tests in CI.

## Risk assessment

Low, so far.