### PR TITLE
chore: exclude tsc output from vitest

### DIFF
--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -17,13 +17,14 @@ export default mergeConfig(
     test: {
       environment: 'jsdom',
       allowOnly: true,
-      exclude: [...configDefaults.exclude, '**/node_modules/**', '**/dist/**'],
+      exclude: [...configDefaults.exclude, '**/node_modules/**', '**/dist/**', '**/lib/**'],
       setupFiles: ['./setup-vitest.mts'],
       coverage: {
         exclude: [
           '**/node_modules/**',
           '**/dist/**',
           '**/__tests__/**',
+          '**/lib/**',
           'protocol-designer/cypress/**/*',
           'labware-library/cypress/**/*',
           ...configDefaults.exclude,


### PR DESCRIPTION
Because then we'll run tests twice.
