### PR TITLE
fix(protocol-designer): bandaid fix getMatchingTipLiquidSpecs() missing tiprack

### DIFF
--- a/protocol-designer/src/utils/index.ts
+++ b/protocol-designer/src/utils/index.ts
@@ -241,9 +241,16 @@ export function getMatchingTipLiquidSpecs(
   volume: number,
   tiprack: string
 ): SupportedTip {
-  const matchingLabwareDef = Object.values(
-    pipetteEntity.tiprackLabwareDef
-  ).find(def => tiprack.includes(def.parameters.loadName))
+  const matchingLabwareDef =
+    Object.values(pipetteEntity.tiprackLabwareDef).find(def =>
+      tiprack.includes(def.parameters.loadName)
+    ) ||
+    // The `tiprack` from a step might not be in `pipetteEntity.tiprackLabwareDef`
+    // anymore because the user removed the tiprack from the pipette. So we can try
+    // looking up the `tiprack` in getAllLabwareDefs() as well.
+    // TODO: But getAllLabwareDefs() only contains standard labware, so this would still
+    // fail if `tiprack` is a custom tiprack.
+    getAllLabwareDefs()[tiprack]
 
   console.assert(
     matchingLabwareDef,


### PR DESCRIPTION
# Overview

We have thousands of Sentry errors for `getMatchingTipLiquidSpecs: expected to find a matching labware def with tiprack ... but could not`.

This is happening because `getMatchingTipLiquidSpecs()` is trying to look up the tiprack definition in `pipetteEntity.tiprackLabwareDef`, but if the user changes the tipracks on a pipette, the tiprack that a step uses would no longer available in `pipetteEntity.tiprackLabwareDef`.

In this fix, if we don't find the tiprack definition in `pipetteEntity.tiprackLabwareDef`, we'll try to find it in `getAllLabwareDefs()`.

This fix is just a bandaid because `getAllLabwareDefs()` only contains **standard** labware. If the step was using a custom tiprack, and the user removed that custom tiprack from the pipette, the code would continue to fail.

But this should make life better for the majority of our users who are using standard tipracks.

## Test Plan and Hands on Testing

Tried it locally before and after.

## Risk assessment

Low.