### PR TITLE
fix: misspellings of "configuration"

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/move_to_addressable_area_for_drop_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/move_to_addressable_area_for_drop_tip.py
@@ -85,7 +85,7 @@ class MoveToAddressableAreaForDropTipParams(PipetteIdMixin, MovementMixin):
     ignoreTipConfiguration: bool | SkipJsonSchema[None] = Field(
         True,
         description=(
-            "Whether to utilize the critical point of the tip configuraiton when moving to an addressable area."
+            "Whether to utilize the critical point of the tip configuration when moving to an addressable area."
             " If True, this command will ignore the tip configuration and use the center of the entire instrument"
             " as the critical point for movement."
             " If False, this command will use the critical point provided by the current tip configuration."

--- a/api/src/opentrons/protocol_engine/types/module.py
+++ b/api/src/opentrons/protocol_engine/types/module.py
@@ -303,7 +303,7 @@ class StackerStoredLabwareGroup(BaseModel):
 
 @dataclass
 class StackerPoolDefinition:
-    """Represents an internal configuraiton of stored labware."""
+    """Represents an internal configuration of stored labware."""
 
     primaryLabwareDefinition: LabwareDefinition
     adapterLabwareDefinition: LabwareDefinition | SkipJsonSchema[None] = None

--- a/api/src/opentrons/system/camera.py
+++ b/api/src/opentrons/system/camera.py
@@ -127,7 +127,7 @@ async def update_live_stream_status(
 
     contents = load_stream_configuration_file_data()
     if contents is None:
-        log.error("Opentrons Live Stream Configuraiton file cannot be updated.")
+        log.error("Opentrons Live Stream Configuration file cannot be updated.")
         return None
 
     # Validate the stream status
@@ -216,7 +216,7 @@ def parse_stream_configuration_file_data(data: bytes) -> Dict[str, str] | None:
     enum_stream_keys = {stream_key.value for stream_key in StreamConfigurationKeys}
     if sorted(list(contents.keys())) != sorted(enum_stream_keys):
         log.error(
-            "Opentrons Live Stream Configuraiton file data is incorrect or missing."
+            "Opentrons Live Stream Configuration file data is incorrect or missing."
         )
         # We don't want to write bad or incomplete data to the file
         return None
@@ -232,7 +232,7 @@ def write_stream_configuration_file_data(data: Dict[str, str]) -> None:
     enum_stream_keys = {stream_key.value for stream_key in StreamConfigurationKeys}
     if sorted(list(data.keys())) != sorted(enum_stream_keys):
         log.error(
-            "Data provided to write is not compatible with Opentrons Live Stream Configuraiton file."
+            "Data provided to write is not compatible with Opentrons Live Stream Configuration file."
         )
         return None
 

--- a/shared-data/command/schemas/10.json
+++ b/shared-data/command/schemas/10.json
@@ -2351,7 +2351,7 @@
         },
         "ignoreTipConfiguration": {
           "title": "Ignoretipconfiguration",
-          "description": "Whether to utilize the critical point of the tip configuraiton when moving to an addressable area. If True, this command will ignore the tip configuration and use the center of the entire instrument as the critical point for movement. If False, this command will use the critical point provided by the current tip configuration.",
+          "description": "Whether to utilize the critical point of the tip configuration when moving to an addressable area. If True, this command will ignore the tip configuration and use the center of the entire instrument as the critical point for movement. If False, this command will use the critical point provided by the current tip configuration.",
           "default": true,
           "type": "boolean"
         }

--- a/shared-data/command/schemas/11.json
+++ b/shared-data/command/schemas/11.json
@@ -3048,7 +3048,7 @@
           "type": "boolean"
         },
         "ignoreTipConfiguration": {
-          "description": "Whether to utilize the critical point of the tip configuraiton when moving to an addressable area. If True, this command will ignore the tip configuration and use the center of the entire instrument as the critical point for movement. If False, this command will use the critical point provided by the current tip configuration.",
+          "description": "Whether to utilize the critical point of the tip configuration when moving to an addressable area. If True, this command will ignore the tip configuration and use the center of the entire instrument as the critical point for movement. If False, this command will use the critical point provided by the current tip configuration.",
           "title": "Ignoretipconfiguration",
           "type": "boolean"
         },

--- a/shared-data/command/schemas/12.json
+++ b/shared-data/command/schemas/12.json
@@ -3301,7 +3301,7 @@
           "type": "boolean"
         },
         "ignoreTipConfiguration": {
-          "description": "Whether to utilize the critical point of the tip configuraiton when moving to an addressable area. If True, this command will ignore the tip configuration and use the center of the entire instrument as the critical point for movement. If False, this command will use the critical point provided by the current tip configuration.",
+          "description": "Whether to utilize the critical point of the tip configuration when moving to an addressable area. If True, this command will ignore the tip configuration and use the center of the entire instrument as the critical point for movement. If False, this command will use the critical point provided by the current tip configuration.",
           "title": "Ignoretipconfiguration",
           "type": "boolean"
         },

--- a/shared-data/command/schemas/13.json
+++ b/shared-data/command/schemas/13.json
@@ -3336,7 +3336,7 @@
           "type": "boolean"
         },
         "ignoreTipConfiguration": {
-          "description": "Whether to utilize the critical point of the tip configuraiton when moving to an addressable area. If True, this command will ignore the tip configuration and use the center of the entire instrument as the critical point for movement. If False, this command will use the critical point provided by the current tip configuration.",
+          "description": "Whether to utilize the critical point of the tip configuration when moving to an addressable area. If True, this command will ignore the tip configuration and use the center of the entire instrument as the critical point for movement. If False, this command will use the critical point provided by the current tip configuration.",
           "title": "Ignoretipconfiguration",
           "type": "boolean"
         },

--- a/shared-data/command/schemas/14.json
+++ b/shared-data/command/schemas/14.json
@@ -3332,7 +3332,7 @@
           "type": "boolean"
         },
         "ignoreTipConfiguration": {
-          "description": "Whether to utilize the critical point of the tip configuraiton when moving to an addressable area. If True, this command will ignore the tip configuration and use the center of the entire instrument as the critical point for movement. If False, this command will use the critical point provided by the current tip configuration.",
+          "description": "Whether to utilize the critical point of the tip configuration when moving to an addressable area. If True, this command will ignore the tip configuration and use the center of the entire instrument as the critical point for movement. If False, this command will use the critical point provided by the current tip configuration.",
           "title": "Ignoretipconfiguration",
           "type": "boolean"
         },

--- a/shared-data/command/schemas/15.json
+++ b/shared-data/command/schemas/15.json
@@ -3546,7 +3546,7 @@
           "type": "boolean"
         },
         "ignoreTipConfiguration": {
-          "description": "Whether to utilize the critical point of the tip configuraiton when moving to an addressable area. If True, this command will ignore the tip configuration and use the center of the entire instrument as the critical point for movement. If False, this command will use the critical point provided by the current tip configuration.",
+          "description": "Whether to utilize the critical point of the tip configuration when moving to an addressable area. If True, this command will ignore the tip configuration and use the center of the entire instrument as the critical point for movement. If False, this command will use the critical point provided by the current tip configuration.",
           "title": "Ignoretipconfiguration",
           "type": "boolean"
         },

--- a/shared-data/command/schemas/8.json
+++ b/shared-data/command/schemas/8.json
@@ -2216,7 +2216,7 @@
         },
         "ignoreTipConfiguration": {
           "title": "Ignoretipconfiguration",
-          "description": "Whether to utilize the critical point of the tip configuraiton when moving to an addressable area. If True, this command will ignore the tip configuration and use the center of the entire instrument as the critical point for movement. If False, this command will use the critical point provided by the current tip configuration.",
+          "description": "Whether to utilize the critical point of the tip configuration when moving to an addressable area. If True, this command will ignore the tip configuration and use the center of the entire instrument as the critical point for movement. If False, this command will use the critical point provided by the current tip configuration.",
           "default": true,
           "type": "boolean"
         }

--- a/shared-data/command/schemas/9.json
+++ b/shared-data/command/schemas/9.json
@@ -2224,7 +2224,7 @@
         },
         "ignoreTipConfiguration": {
           "title": "Ignoretipconfiguration",
-          "description": "Whether to utilize the critical point of the tip configuraiton when moving to an addressable area. If True, this command will ignore the tip configuration and use the center of the entire instrument as the critical point for movement. If False, this command will use the critical point provided by the current tip configuration.",
+          "description": "Whether to utilize the critical point of the tip configuration when moving to an addressable area. If True, this command will ignore the tip configuration and use the center of the entire instrument as the critical point for movement. If False, this command will use the critical point provided by the current tip configuration.",
           "default": true,
           "type": "boolean"
         }


### PR DESCRIPTION


# Overview

We misspelled the word "configuration" a lot. Fortunately that's what find and replace is for.

## Test Plan and Hands on Testing

Automated tests only.

## Changelog

Find and replace across full monorepo. This appears to affect strings only, not functional code.

## Review requests

Is it a no-no to go back and fix this in old schema versions? It doesn't affect functionality as far as I know. But we can omit those if it would even possibly cause problems.

## Risk assessment

low