### PR TITLE
feat(app): PV timeline design fixes and highlight commands

### DIFF
--- a/app/src/assets/localization/en/protocol_visualization.json
+++ b/app/src/assets/localization/en/protocol_visualization.json
@@ -15,11 +15,13 @@
   "step": "Step {{number}}",
   "quantity": "Quantity: {{quantity}}",
   "tipPickup": "Tip pickup",
+  "percent_complete": "{{percent}}% complete",
   "tip_disposal": "Tip disposal",
   "remaining_tips": "{{remaining}} tips",
   "tips_remaining": "Tips remaining",
   "tips_in_trash": "Tips in trash",
   "lids_in_trash": "Lids in trash",
   "trash_bin": "TRASH BIN",
+  "timeline": "Timeline",
   "well_name": "Well {{wellName}}"
 }

--- a/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/index.tsx
@@ -136,9 +136,8 @@ export function AnnotatedSteps(props: AnnotatedStepsProps): JSX.Element {
                 )
               }
             })
-          : filteredCommands.map((command, index) => {
+          : filteredCommands.map(command => {
               const currentCommandNumber = ++commandNumber
-
               return (
                 <IndividualCommand
                   scrollTargetId={scrollTargetId}
@@ -146,7 +145,10 @@ export function AnnotatedSteps(props: AnnotatedStepsProps): JSX.Element {
                   key={`individual_${command.id}`}
                   command={command}
                   commandNumber={currentCommandNumber}
-                  isHighlighted={index === currentCommandIndex}
+                  isHighlighted={
+                    currentCommandIndex != null &&
+                    filteredCommands[currentCommandIndex]?.id === command.id
+                  }
                   analysis={analysis}
                   allRunDefs={allRunDefs}
                   setSelectedCommand={setSelectedCommand}

--- a/app/src/pages/Desktop/Protocols/ProtocolVisualization/CommandSteps.tsx
+++ b/app/src/pages/Desktop/Protocols/ProtocolVisualization/CommandSteps.tsx
@@ -1,4 +1,6 @@
-import { COLORS, Divider, StyledText } from '@opentrons/components'
+import { useTranslation } from 'react-i18next'
+
+import { COLORS, StyledText } from '@opentrons/components'
 
 import { AnnotatedSteps } from '/app/organisms/Desktop/ProtocolDetails/AnnotatedSteps'
 
@@ -25,17 +27,18 @@ export function CommandSteps(props: CommandStepsProps): JSX.Element {
     handlePause,
     percentComplete,
   } = props
+  const { t } = useTranslation('protocol_visualization')
   return (
     <div className={styles.detail_container}>
       <div className={styles.command_step}>
         <div className={styles.command_step_header}>
-          <StyledText desktopStyle="bodyDefaultSemiBold">Timeline</StyledText>
-          <StyledText
-            desktopStyle="bodyDefaultRegular"
-            color={COLORS.grey60}
-          >{`${percentComplete.toFixed(0)}% complete`}</StyledText>
+          <StyledText desktopStyle="bodyDefaultSemiBold">
+            {t('timeline')}
+          </StyledText>
+          <StyledText desktopStyle="bodyDefaultRegular" color={COLORS.grey60}>
+            {t('percent_complete', { percent: percentComplete.toFixed(0) })}
+          </StyledText>
         </div>
-        <Divider />
         <div className={styles.command_step_groups}>
           <AnnotatedSteps
             currentCommandIndex={currentCommandIndex}

--- a/app/src/pages/Desktop/Protocols/ProtocolVisualization/VisualizerContainer.tsx
+++ b/app/src/pages/Desktop/Protocols/ProtocolVisualization/VisualizerContainer.tsx
@@ -222,7 +222,7 @@ export function VisualizerContainer(
       <div className={styles.left_column} style={{ width: `${leftWidth}px` }}>
         <CommandSteps
           analysis={analysis}
-          currentCommandIndex={selectedCommandIndex}
+          currentCommandIndex={filteredSelectedCommandIndex}
           groupedCommands={groupedCommands}
           setSelectedCommand={setSelectedCommand}
           percentComplete={percentComplete}

--- a/app/src/pages/Desktop/Protocols/ProtocolVisualization/preview.module.css
+++ b/app/src/pages/Desktop/Protocols/ProtocolVisualization/preview.module.css
@@ -130,7 +130,6 @@
   display: flex;
   height: 100%;
   flex-direction: column;
-  padding: var(--spacing-12);
   border-radius: var(--border-radius-8);
   background-color: var(--white);
 }


### PR DESCRIPTION
closes AUTH-2301

# Overview

Timeline design fixes for individual steps (not groups)

## Test Plan and Hands on Testing

upload a basic protocol with no stacking or partial tip, like doItAllv8 and see that the timeline column looks good and matches the designs according to the ticket. when you click on a step, it should highlight purple

## Changelog

fix when individual command is highlighted
some design fixes for timeline

## Risk assessment

low