### PR TITLE
feat(robot-server): add support for retrieving all datafile metadata associated with a run

### DIFF
--- a/robot-server/robot_server/data_files/data_files_store.py
+++ b/robot-server/robot_server/data_files/data_files_store.py
@@ -37,6 +37,14 @@ class DataFileWithCommandsInfoSlice:
     total_length: int
 
 
+@dataclass(frozen=True)
+class DataFilesByRunInfo:
+    """Container for input and output data file metadata for a run."""
+
+    input_files: List[DataFileInfo]
+    output_files: List[DataFileInfo]
+
+
 class DataFilesStore:
     """Store and retrieve info about uploaded data files."""
 
@@ -212,6 +220,37 @@ class DataFilesStore:
         with self._sql_engine.begin() as transaction:
             all_rows = transaction.execute(statement).all()
         return [_convert_row_to_data_file_info(sql_row) for sql_row in all_rows]
+
+    def get_data_files_by_run_id(self, run_id: str) -> DataFilesByRunInfo:
+        """Get all input and output data files associated with a run."""
+        input_statement = (
+            sqlalchemy.select(data_files_table)
+            .join(
+                input_data_files_table,
+                data_files_table.c.id == input_data_files_table.c.file_id,
+            )
+            .where(input_data_files_table.c.run_id == run_id)
+            .order_by(data_files_table.c.created_at.desc())
+        )
+
+        output_statement = (
+            sqlalchemy.select(data_files_table)
+            .join(
+                output_data_files_table,
+                data_files_table.c.id == output_data_files_table.c.file_id,
+            )
+            .where(output_data_files_table.c.run_id == run_id)
+            .order_by(data_files_table.c.created_at.desc())
+        )
+
+        with self._sql_engine.begin() as transaction:
+            input_rows = transaction.execute(input_statement).all()
+            input_files = [_convert_row_to_data_file_info(row) for row in input_rows]
+
+            output_rows = transaction.execute(output_statement).all()
+            output_files = [_convert_row_to_data_file_info(row) for row in output_rows]
+
+        return DataFilesByRunInfo(input_files=input_files, output_files=output_files)
 
     def get_usage_info(self, generated: Optional[bool] = None) -> List[FileUsageInfo]:
         """Return information about usage of all the existing data files in runs & analyses.

--- a/robot-server/robot_server/data_files/models.py
+++ b/robot-server/robot_server/data_files/models.py
@@ -5,7 +5,7 @@ from typing import Literal, Set, Optional
 from pydantic import Field, BaseModel
 
 from opentrons_shared_data.errors import GeneralError
-from opentrons_shared_data.data_files import DataFileSource
+from opentrons_shared_data.data_files import DataFileSource, MimeType
 
 from robot_server.errors.error_responses import ErrorDetails
 from robot_server.service.json_api import ResourceModel
@@ -93,3 +93,14 @@ class ImageFileMetadata(BaseModel):
     createdAt: datetime = Field(
         ..., description="The time the camera image file was created."
     )
+
+
+class DataFileMetadataResponse(BaseModel):
+    """Response model for data file metadata without command information."""
+
+    id: str = Field(..., description="A unique identifier for this file.")
+    stored: bool = Field(..., description="Whether the file is currently stored.")
+    generated: bool = Field(
+        ..., description="Whether the file was generated as output during a run."
+    )
+    mimeType: MimeType = Field(..., description="MIME type of the file.")

--- a/robot-server/robot_server/data_files/router.py
+++ b/robot-server/robot_server/data_files/router.py
@@ -36,6 +36,7 @@ from .models import (
     FileIdNotFound,
     FileInUseError,
     ImageFileMetadata,
+    DataFileMetadataResponse,
 )
 from ..protocols.dependencies import get_file_hasher, get_file_reader_writer
 from ..service.dependencies import get_current_time, get_unique_id
@@ -342,11 +343,71 @@ async def delete_file_by_id(
 
 @PydanticResponse.wrap_route(
     datafiles_router.get,
+    path="/dataFiles/{runId}/all",
+    summary="Get metadata for all data files associated with a run",
+    description="""
+        Get metadata for all data files associated with a specific run.
+
+        Metadata includes the related command id when applicable.
+    """,
+    responses={
+        status.HTTP_200_OK: {"model": SimpleMultiBody[DataFileMetadataResponse]},
+        status.HTTP_404_NOT_FOUND: {"model": ErrorBody[RunNotFound]},
+    },
+)
+async def get_data_files_by_run_id(
+    runId: str,
+    data_files_store: Annotated[DataFilesStore, Depends(get_data_files_store)],
+    run_data_manager: Annotated[RunDataManager, Depends(get_run_data_manager)],
+) -> PydanticResponse[SimpleBody[DataFileMetadataResponse]]:
+    """Get all data files associated with a run.
+
+    Args:
+        runId: The unique identifier of the run to query for data files.
+        data_files_store: Store for accessing data file information from the database.
+        run_data_manager: Current and historical run data management.
+    """
+    try:
+        run_data_manager.get(runId)
+    except RunNotFoundError as e:
+        raise RunNotFound(detail=str(e)).as_error(status.HTTP_404_NOT_FOUND) from e
+
+    data_files_info = data_files_store.get_data_files_by_run_id(runId)
+    response_data = []
+
+    for file_info in data_files_info.input_files:
+        response_data.append(
+            DataFileMetadataResponse(
+                id=file_info.id,
+                stored=file_info.stored,
+                generated=file_info.generated,
+                mimeType=file_info.mime_type,
+            )
+        )
+
+    for file_info in data_files_info.output_files:
+        response_data.append(
+            DataFileMetadataResponse(
+                id=file_info.id,
+                stored=file_info.stored,
+                generated=file_info.generated,
+                mimeType=file_info.mime_type,
+            )
+        )
+
+    return await PydanticResponse.create(
+        content=SimpleBody.model_construct(data=response_data),
+        status_code=status.HTTP_200_OK,
+    )
+
+
+@PydanticResponse.wrap_route(
+    datafiles_router.get,
     path="/dataFiles/{runId}/images",
-    summary="Get a list of metadata for all camera image files associated with a given run.",
+    summary="Get a list of image-specific metadata for all camera image files associated with a given run.",
     description=dedent(
         """
-        Get a list of metadata for camera image files associated with a given run.
+        Get a list of image-specific metadata for camera image files associated with a given run.
         "\n\n"
         The camera image file metadata are returned in order from newest to oldest.
         "\n\n"

--- a/robot-server/robot_server/data_files/router.py
+++ b/robot-server/robot_server/data_files/router.py
@@ -359,7 +359,7 @@ async def get_data_files_by_run_id(
     runId: str,
     data_files_store: Annotated[DataFilesStore, Depends(get_data_files_store)],
     run_data_manager: Annotated[RunDataManager, Depends(get_run_data_manager)],
-) -> PydanticResponse[SimpleBody[DataFileMetadataResponse]]:
+) -> PydanticResponse[SimpleMultiBody[DataFileMetadataResponse]]:
     """Get all data files associated with a run.
 
     Args:
@@ -396,7 +396,10 @@ async def get_data_files_by_run_id(
         )
 
     return await PydanticResponse.create(
-        content=SimpleBody.model_construct(data=response_data),
+        content=SimpleMultiBody.model_construct(
+            data=response_data,
+            meta=MultiBodyMeta(cursor=0, totalLength=len(response_data)),
+        ),
         status_code=status.HTTP_200_OK,
     )
 

--- a/robot-server/tests/data_files/test_data_files_store.py
+++ b/robot-server/tests/data_files/test_data_files_store.py
@@ -606,3 +606,105 @@ async def test_get_files_info_by_run_mime_type(
     assert result.total_length == 1
     assert result.file_info[0].id == "jpeg-run1"
     assert result.file_info[0].command_info.command_id == "command-1"
+
+
+async def test_get_data_files_by_run_id(
+    subject: DataFilesStore,
+) -> None:
+    """It should retrieve all input and output files for a run, ordered by creation time."""
+    _create_run_in_db(subject._sql_engine, "run-id")
+
+    input_file_1 = DataFileInfo(
+        id="input-file-1",
+        name="input1.csv",
+        file_hash="hash-input-1",
+        created_at=datetime(year=2025, month=10, day=21, tzinfo=timezone.utc),
+        mime_type=MimeType.TEXT_CSV,
+        path="data_files/input-file-1/input1.csv",
+        generated=False,
+        stored=True,
+    )
+
+    input_file_2 = DataFileInfo(
+        id="input-file-2",
+        name="input2.csv",
+        file_hash="hash-input-2",
+        created_at=datetime(year=2025, month=10, day=22, tzinfo=timezone.utc),
+        mime_type=MimeType.TEXT_CSV,
+        path="data_files/input-file-2/input2.csv",
+        generated=False,
+        stored=True,
+    )
+
+    output_file_1 = DataFileInfo(
+        id="output-file-1",
+        name="output1.csv",
+        file_hash="hash-output-1",
+        created_at=datetime(year=2025, month=10, day=22, tzinfo=timezone.utc),
+        mime_type=MimeType.TEXT_CSV,
+        path="data_files/output-file-1/output1.csv",
+        generated=True,
+        stored=True,
+    )
+
+    output_file_2 = DataFileInfo(
+        id="output-file-2",
+        name="output2.csv",
+        file_hash="hash-output-2",
+        created_at=datetime(year=2025, month=10, day=23, tzinfo=timezone.utc),
+        mime_type=MimeType.TEXT_CSV,
+        path="data_files/output-file-2/output2.csv",
+        generated=True,
+        stored=True,
+    )
+
+    await subject.insert(input_file_1)
+    await subject.insert(input_file_2)
+    await subject.insert(output_file_1)
+    await subject.insert(output_file_2)
+
+    await subject.insert_input_file(
+        InputDataFileInfo(
+            file_id="input-file-1",
+            run_id="run-id",
+            command_info=None,
+        )
+    )
+    await subject.insert_input_file(
+        InputDataFileInfo(
+            file_id="input-file-2",
+            run_id="run-id",
+            command_info=None,
+        )
+    )
+
+    await subject.insert_output_file(
+        OutputDataFileInfo(
+            file_id="output-file-1",
+            run_id="run-id",
+            command_info=CmdDataFileInfo(
+                command_id="command-1",
+                prev_command_id="prev-1",
+            ),
+        )
+    )
+    await subject.insert_output_file(
+        OutputDataFileInfo(
+            file_id="output-file-2",
+            run_id="run-id",
+            command_info=CmdDataFileInfo(
+                command_id="command-2",
+                prev_command_id="prev-2",
+            ),
+        )
+    )
+
+    result = subject.get_data_files_by_run_id("run-id")
+
+    assert len(result.input_files) == 2
+    assert result.input_files[0] == input_file_2
+    assert result.input_files[1] == input_file_1
+
+    assert len(result.output_files) == 2
+    assert result.output_files[0] == output_file_2
+    assert result.output_files[1] == output_file_1

--- a/robot-server/tests/data_files/test_router.py
+++ b/robot-server/tests/data_files/test_router.py
@@ -668,7 +668,7 @@ async def test_delete_run_images_run_not_found(
 
 
 @pytest.mark.parametrize(
-    argnames=["input_files", "output_files"],
+    argnames=["input_files", "output_files", "expected_length"],
     argvalues=[
         pytest.param(
             [
@@ -715,11 +715,13 @@ async def test_delete_run_images_run_not_found(
                     stored=True,
                 ),
             ],
+            4,
             id="multiple_input_and_output_files",
         ),
         pytest.param(
             [],
             [],
+            0,
             id="empty_result",
         ),
         pytest.param(
@@ -736,6 +738,7 @@ async def test_delete_run_images_run_not_found(
                 ),
             ],
             [],
+            1,
             id="only_input_files",
         ),
         pytest.param(
@@ -752,6 +755,7 @@ async def test_delete_run_images_run_not_found(
                     stored=True,
                 ),
             ],
+            1,
             id="only_output_files",
         ),
     ],
@@ -762,6 +766,7 @@ async def test_get_data_files_by_run_id(
     run_data_manager: RunDataManager,
     input_files: List[DataFileInfo],
     output_files: List[DataFileInfo],
+    expected_length: int,
 ) -> None:
     """It should return metadata for all data files associated with a run."""
     decoy.when(run_data_manager.get("run-id")).then_return(decoy.mock(name="run_data"))
@@ -779,12 +784,15 @@ async def test_get_data_files_by_run_id(
         run_data_manager=run_data_manager,
     )
 
-    all_files = input_files + output_files
-    for i, file_info in enumerate(all_files):
-        assert result.content.data[i].id == file_info.id
-        assert result.content.data[i].stored == file_info.stored
-        assert result.content.data[i].generated == file_info.generated
-        assert result.content.data[i].mimeType == file_info.mime_type
+    assert len(result.content.data) == expected_length
+    if expected_length > 0:
+        all_files = input_files + output_files
+
+        for response_file, expected_file in zip(result.content.data, all_files):
+            assert response_file.id == expected_file.id
+            assert response_file.stored == expected_file.stored
+            assert response_file.generated == expected_file.generated
+            assert response_file.mimeType == expected_file.mime_type
 
 
 async def test_get_data_files_by_run_id_run_not_found(

--- a/robot-server/tests/data_files/test_router.py
+++ b/robot-server/tests/data_files/test_router.py
@@ -1,5 +1,7 @@
 """Tests for data_files router."""
 import io
+from typing import List
+
 import pytest
 from datetime import datetime
 from pathlib import Path
@@ -12,6 +14,7 @@ from robot_server.service.json_api import MultiBodyMeta, SimpleEmptyBody
 
 from robot_server.data_files.data_files_store import (
     DataFilesStore,
+    DataFilesByRunInfo,
 )
 from robot_server.data_files.models import (
     DataFile,
@@ -27,6 +30,7 @@ from robot_server.data_files.router import (
     delete_file_by_id,
     get_run_image_metadata,
     delete_run_images,
+    get_data_files_by_run_id,
 )
 from robot_server.data_files.data_files_store import DataFileWithCommandsInfoSlice
 from opentrons_shared_data.data_files import DataFileInfoWithCommands, CmdDataFileInfo
@@ -654,6 +658,147 @@ async def test_delete_run_images_run_not_found(
 
     with pytest.raises(ApiError) as exc_info:
         await delete_run_images(
+            runId="run-id",
+            data_files_store=data_files_store,
+            run_data_manager=run_data_manager,
+        )
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.content["errors"][0]["id"] == "RunNotFound"
+
+
+@pytest.mark.parametrize(
+    argnames=["input_files", "output_files"],
+    argvalues=[
+        pytest.param(
+            [
+                DataFileInfo(
+                    id="input-file-1",
+                    name="input1.csv",
+                    file_hash="hash-input-1",
+                    created_at=datetime(year=2024, month=6, day=20),
+                    mime_type=MimeType.TEXT_CSV,
+                    path="data_files/input-file-1/input1.csv",
+                    generated=False,
+                    stored=True,
+                ),
+                DataFileInfo(
+                    id="input-file-2",
+                    name="input2.csv",
+                    file_hash="hash-input-2",
+                    created_at=datetime(year=2024, month=6, day=21),
+                    mime_type=MimeType.TEXT_CSV,
+                    path="data_files/input-file-2/input2.csv",
+                    generated=False,
+                    stored=True,
+                ),
+            ],
+            [
+                DataFileInfo(
+                    id="output-file-1",
+                    name="output1.csv",
+                    file_hash="hash-output-1",
+                    created_at=datetime(year=2024, month=6, day=22),
+                    mime_type=MimeType.TEXT_CSV,
+                    path="data_files/output-file-1/output1.csv",
+                    generated=True,
+                    stored=True,
+                ),
+                DataFileInfo(
+                    id="output-file-2",
+                    name="output2.csv",
+                    file_hash="hash-output-2",
+                    created_at=datetime(year=2024, month=6, day=23),
+                    mime_type=MimeType.TEXT_CSV,
+                    path="data_files/output-file-2/output2.csv",
+                    generated=True,
+                    stored=True,
+                ),
+            ],
+            id="multiple_input_and_output_files",
+        ),
+        pytest.param(
+            [],
+            [],
+            id="empty_result",
+        ),
+        pytest.param(
+            [
+                DataFileInfo(
+                    id="input-file-1",
+                    name="input1.csv",
+                    file_hash="hash-input-1",
+                    created_at=datetime(year=2024, month=6, day=20),
+                    mime_type=MimeType.TEXT_CSV,
+                    path="data_files/input-file-1/input1.csv",
+                    generated=False,
+                    stored=True,
+                ),
+            ],
+            [],
+            id="only_input_files",
+        ),
+        pytest.param(
+            [],
+            [
+                DataFileInfo(
+                    id="output-file-1",
+                    name="output1.csv",
+                    file_hash="hash-output-1",
+                    created_at=datetime(year=2024, month=6, day=22),
+                    mime_type=MimeType.TEXT_CSV,
+                    path="data_files/output-file-1/output1.csv",
+                    generated=True,
+                    stored=True,
+                ),
+            ],
+            id="only_output_files",
+        ),
+    ],
+)
+async def test_get_data_files_by_run_id(
+    decoy: Decoy,
+    data_files_store: DataFilesStore,
+    run_data_manager: RunDataManager,
+    input_files: List[DataFileInfo],
+    output_files: List[DataFileInfo],
+) -> None:
+    """It should return metadata for all data files associated with a run."""
+    decoy.when(run_data_manager.get("run-id")).then_return(decoy.mock(name="run_data"))
+
+    decoy.when(data_files_store.get_data_files_by_run_id("run-id")).then_return(
+        DataFilesByRunInfo(
+            input_files=input_files,
+            output_files=output_files,
+        )
+    )
+
+    result = await get_data_files_by_run_id(
+        runId="run-id",
+        data_files_store=data_files_store,
+        run_data_manager=run_data_manager,
+    )
+
+    all_files = input_files + output_files
+    for i, file_info in enumerate(all_files):
+        assert result.content.data[i].id == file_info.id
+        assert result.content.data[i].stored == file_info.stored
+        assert result.content.data[i].generated == file_info.generated
+        assert result.content.data[i].mimeType == file_info.mime_type
+
+
+async def test_get_data_files_by_run_id_run_not_found(
+    decoy: Decoy,
+    data_files_store: DataFilesStore,
+    run_data_manager: RunDataManager,
+) -> None:
+    """It should raise an error if the run doesn't exist."""
+    decoy.when(run_data_manager.get("run-id")).then_raise(
+        RunNotFoundError(run_id="run-id")
+    )
+
+    with pytest.raises(ApiError) as exc_info:
+        await get_data_files_by_run_id(
             runId="run-id",
             data_files_store=data_files_store,
             run_data_manager=run_data_manager,


### PR DESCRIPTION
Closes [EXEC-1998](https://opentrons.atlassian.net/browse/EXEC-1998)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Currently, the app uses a run record's `outputFileIds` to A) indicate whether any output data files were generated during a run, and B) provide download links for absorbance reader output files.

This approach worked when the absorbance reader files were the only type of output file, but camera-captured images are now also stored in this `outputFieldIds`, which means the app now has no great way of determining whether the files generated are absorbance reader output files or camera-captured image files. Sure, we can query `/dataFiles/:id` for each output file and get the relevant metadata that way, but that's clearly not ideal.

To solve this problem and future-proof us a bit, let's add a resource at `/dataFiles/:runId/all` which returns metadata about every run-related data file. Each metadata object contains the following info:

- The data file id.
- Whether the data file is currently stored on the robot.
- Whether the data file was generated as output during the run (ie, whether this is an input data file or an output data file for this run).
- The mime type of the data file.

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- Verified that querying the endpoint with a valid run id works as expected.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Added an HTTP API resource for obtaining metadata about all data files associated with a specific run.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests
- I believe the information provided here is sufficient for the camera enablement work, but I'm happy to include more fields to the returned data structure if we feel we should.
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[EXEC-1998]: https://opentrons.atlassian.net/browse/EXEC-1998?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ