### PR TITLE
fix(protocol-designer): allow moving the universal lid on compatible …

### DIFF
--- a/protocol-designer/src/pages/Designer/utils.ts
+++ b/protocol-designer/src/pages/Designer/utils.ts
@@ -398,14 +398,19 @@ export const getUnoccupiedStackOptions = (args: {
       const { def: labwareOnDeckDef } = labwareOnDeck
       const { displayName } = labwareOnDeckDef.metadata
       const { loadName: labwareOnDeckLoadName } = labwareOnDeckDef.parameters
+      const isUniversalLid =
+        def.parameters.loadName === 'opentrons_tough_universal_lid'
+      const isLabwareOnSlotTubeOrBlock =
+        labwareOnDeckDef.metadata.displayCategory === 'tubeRack' ||
+        labwareOnDeckDef.metadata.displayCategory === 'aluminumBlock'
+      const isLabwareOnSlotTiprack = labwareOnDeckDef.parameters.isTiprack
 
       const isCompatible =
-        labwareCompatibleParentLabware?.includes(
-          labwareOnDeckLoadName
-          //  allow universal lid to go on itself, special-case since it doesn't have a compatibleParentLabware array
-        ) ||
-        (def.parameters.loadName === 'opentrons_tough_universal_lid' &&
-          labwareOnDeckLoadName === 'opentrons_tough_universal_lid')
+        labwareCompatibleParentLabware?.includes(labwareOnDeckLoadName) ||
+        (isUniversalLid &&
+          !isLabwareOnSlotTubeOrBlock &&
+          !isLabwareOnSlotTiprack &&
+          labwareOnDeckDef.allowedRoles?.includes('lid'))
 
       const isNotCurrentLabwareStack = !fullStack.includes(
         labwareIdFromDropdown

--- a/protocol-designer/src/pages/Designer/utils.ts
+++ b/protocol-designer/src/pages/Designer/utils.ts
@@ -407,6 +407,8 @@ export const getUnoccupiedStackOptions = (args: {
 
       const isCompatible =
         labwareCompatibleParentLabware?.includes(labwareOnDeckLoadName) ||
+        // allow universal lid can go anywhere except for tubeRacks, aluminum blocks, and tipracks and other lids
+        // since it doesn't have a labwareCompatibleLabware array, we need to special-case it, huhu
         (isUniversalLid &&
           !isLabwareOnSlotTubeOrBlock &&
           !isLabwareOnSlotTiprack &&

--- a/protocol-designer/src/pages/Designer/utils.ts
+++ b/protocol-designer/src/pages/Designer/utils.ts
@@ -400,8 +400,9 @@ export const getUnoccupiedStackOptions = (args: {
       const { loadName: labwareOnDeckLoadName } = labwareOnDeckDef.parameters
       const isUniversalLid =
         def.parameters.loadName === 'opentrons_tough_universal_lid'
-      const isLabwareOnSlotTubeOrBlock =
-        labwareOnDeckDef.metadata.displayCategory === 'tubeRack' ||
+      const isLabwareOnSlotTuberack =
+        labwareOnDeckDef.metadata.displayCategory === 'tubeRack'
+      const isLabwareOnSlotAluminumBlock =
         labwareOnDeckDef.metadata.displayCategory === 'aluminumBlock'
       const isLabwareOnSlotTiprack = labwareOnDeckDef.parameters.isTiprack
 
@@ -410,7 +411,8 @@ export const getUnoccupiedStackOptions = (args: {
         // allow universal lid can go anywhere except for tubeRacks, aluminum blocks, and tipracks and other lids
         // since it doesn't have a labwareCompatibleLabware array, we need to special-case it, huhu
         (isUniversalLid &&
-          !isLabwareOnSlotTubeOrBlock &&
+          !isLabwareOnSlotTuberack &&
+          !isLabwareOnSlotAluminumBlock &&
           !isLabwareOnSlotTiprack &&
           labwareOnDeckDef.allowedRoles?.includes('lid'))
 


### PR DESCRIPTION
…labware

closes RQA-4780

# Overview

allow moving universal lid onto other labware

## Test Plan and Hands on Testing

test that you can move the universal lid onto other labware and other universal lid stacks but not aluminum blocks, tipracks, tube racks

## Changelog

allow moving universal lid onto other labware

## Risk assessment

low
