### PR TITLE
fix(app): odd run start blocked if camera not setup even if camera is disabled

### DIFF
--- a/app/src/pages/ODD/ProtocolSetup/index.tsx
+++ b/app/src/pages/ODD/ProtocolSetup/index.tsx
@@ -365,7 +365,7 @@ function PrepareToRun({
     !isAnyNecessaryDefaultOffsetMissing &&
     // TODO(jh, 10-01-25): Eventually, only block the run if the camera is used in the protocol
     //  AND the camera is not in an enabled state (unconfirmed enabled is ok).
-    cameraSettingsConfirmed
+    (cameraSettingsConfirmed || !isCameraEnabled)
   const onPlay = (): void => {
     if (doorStatus.isDoorOpen) {
       if (


### PR DESCRIPTION
Fix RQA-4776
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
We shouldn't block run start for camera settings confirmation if the camera is disabled
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
Check that for a protocol that doesn't use the camera on the ODD, you are no longer blocked from run start once setup has been completed:
<img width="970" height="585" alt="Screenshot 2025-10-22 at 3 16 01 PM" src="https://github.com/user-attachments/assets/114f163d-0e6d-4147-920a-c70f4d735d55" />
Before this change, the play button was disabled
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
Add check for camera FF, only require camera setting confirmation if it is true 
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests
Does this logic hold when the camera FF is on, or do we need an additional check for whether the camera is required in the protocol?
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
Low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
