### PR TITLE
fix(ci): handle special branches in sandbox

### DIFF
--- a/scripts/static-deploy/deploy_ci_config.py
+++ b/scripts/static-deploy/deploy_ci_config.py
@@ -22,6 +22,10 @@ from rich.console import Console
 
 console = Console()
 
+PR_SPECIAL_BRANCH_PREFIXES: tuple[str, ...] = ("chore_release",)
+PR_SPECIAL_BRANCH_NAMES: tuple[str, ...] = ("edge", "release")
+PR_SANDBOX_SUFFIX = "-pr"
+
 
 @dataclass(frozen=True)
 class CIConfig:
@@ -73,6 +77,8 @@ def _determine_environment_and_prefix(event_name: str, ref_type: str, ref_name: 
         # Handle empty or null head_ref values
         if head_ref and head_ref.lower() not in ["", "null", "none"]:
             sandbox_prefix = head_ref
+            if _is_special_pr_branch(head_ref):
+                sandbox_prefix = _alternate_pr_sandbox_prefix(head_ref)
         else:
             sandbox_prefix = "unknown"
         return environment, sandbox_prefix
@@ -93,6 +99,23 @@ def _determine_environment_and_prefix(event_name: str, ref_type: str, ref_name: 
             return "sandbox", ref_name
 
     raise ValueError(f"No deployment configuration found for event: {event_name}, ref_type: {ref_type}")
+
+
+def _is_special_pr_branch(branch_name: str) -> bool:
+    """Return True if the PR branch should use an alternate sandbox prefix."""
+    normalized = branch_name.lower()
+    if normalized in PR_SPECIAL_BRANCH_NAMES:
+        return True
+
+    return any(normalized.startswith(prefix) for prefix in PR_SPECIAL_BRANCH_PREFIXES)
+
+
+def _alternate_pr_sandbox_prefix(branch_name: str) -> str:
+    """Build the alternate sandbox prefix for special PR branches."""
+    if branch_name.endswith(PR_SANDBOX_SUFFIX):
+        return branch_name
+
+    return f"{branch_name}{PR_SANDBOX_SUFFIX}"
 
 
 def parse_github_event_context(

--- a/scripts/static-deploy/tests/test_deploy_ci_config.py
+++ b/scripts/static-deploy/tests/test_deploy_ci_config.py
@@ -75,6 +75,42 @@ def test_resolve_ci_config_sandbox():
     assert config.relative_artifact_dir == "/test/artifacts"
 
 
+def test_resolve_ci_config_pull_request_special_branch_suffix():
+    """Special PR branches should deploy to alternate sandbox prefixes."""
+    env = {
+        "GITHUB_EVENT_NAME": "pull_request",
+        "GITHUB_REF": "refs/pull/123/merge",
+        "GITHUB_REF_NAME": "123/merge",
+        "GITHUB_WORKFLOW": "PD test, build, and deploy",
+        "RELATIVE_ARTIFACT_DIR": "../../dist",
+        "GITHUB_HEAD_REF": "chore_release-pd-8.6.0",
+    }
+
+    with patch.dict(os.environ, env, clear=False):
+        config = resolve_ci_config()
+
+    assert config.environment == "sandbox"
+    assert config.sandbox_prefix == "chore_release-pd-8.6.0-pr"
+
+
+def test_resolve_ci_config_pull_request_regular_branch_passthrough():
+    """Non-special PR branches should preserve the branch name prefix."""
+    env = {
+        "GITHUB_EVENT_NAME": "pull_request",
+        "GITHUB_REF": "refs/pull/42/merge",
+        "GITHUB_REF_NAME": "42/merge",
+        "GITHUB_WORKFLOW": "PD test, build, and deploy",
+        "RELATIVE_ARTIFACT_DIR": "../../dist",
+        "GITHUB_HEAD_REF": "feature-add-new-widget",
+    }
+
+    with patch.dict(os.environ, env, clear=False):
+        config = resolve_ci_config()
+
+    assert config.environment == "sandbox"
+    assert config.sandbox_prefix == "feature-add-new-widget"
+
+
 def test_resolve_ci_config_staging():
     """Test CI config resolution for staging environment."""
     env = {

--- a/scripts/static-deploy/tests/test_deploy_ci_config.py
+++ b/scripts/static-deploy/tests/test_deploy_ci_config.py
@@ -93,6 +93,24 @@ def test_resolve_ci_config_pull_request_special_branch_suffix():
     assert config.sandbox_prefix == "chore_release-pd-8.6.0-pr"
 
 
+def test_resolve_ci_config_pull_request_edge_branch_suffix():
+    """Edge PRs should deploy to alternate sandbox prefixes."""
+    env = {
+        "GITHUB_EVENT_NAME": "pull_request",
+        "GITHUB_REF": "refs/pull/321/merge",
+        "GITHUB_REF_NAME": "321/merge",
+        "GITHUB_WORKFLOW": "PD test, build, and deploy",
+        "RELATIVE_ARTIFACT_DIR": "../../dist",
+        "GITHUB_HEAD_REF": "edge",
+    }
+
+    with patch.dict(os.environ, env, clear=False):
+        config = resolve_ci_config()
+
+    assert config.environment == "sandbox"
+    assert config.sandbox_prefix == "edge-pr"
+
+
 def test_resolve_ci_config_pull_request_regular_branch_passthrough():
     """Non-special PR branches should preserve the branch name prefix."""
     env = {


### PR DESCRIPTION
- Adjusted PR sandbox prefix resolution so `chore_release*`, `edge`, and `release` branches deploy to -pr suffixed sandboxes, keeping push-trigger deployments intact.
- Added coverage for both special and regular PR branches in [test_deploy_ci_config.py](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html).
- This change fixes this problem for all static-deploy sites