### PR TITLE
refactor(app): inline and delete the getAllDefs() function

### DIFF
--- a/app/src/local-resources/labware/utils/getAllDefinitions.ts
+++ b/app/src/local-resources/labware/utils/getAllDefinitions.ts
@@ -1,8 +1,9 @@
 import groupBy from 'lodash/groupBy'
 
-import { LABWAREV2_DO_NOT_LIST } from '@opentrons/shared-data'
-
-import { getAllDefs } from './getAllDefs'
+import {
+  getAllDefinitions,
+  LABWAREV2_DO_NOT_LIST,
+} from '@opentrons/shared-data'
 
 import type { LabwareDefinition } from '@opentrons/shared-data'
 
@@ -26,7 +27,7 @@ const getOnlyLatestDefs = (
 }
 
 export function getAllLatestDefs(): LabwareDefinition[] {
-  const allDefs = getAllDefs().filter(
+  const allDefs = Object.values(getAllDefinitions()).filter(
     (d: LabwareDefinition) =>
       // eslint-disable-next-line @typescript-eslint/prefer-includes
       LABWAREV2_DO_NOT_LIST.indexOf(d.parameters.loadName) === -1

--- a/app/src/local-resources/labware/utils/getAllDefs.ts
+++ b/app/src/local-resources/labware/utils/getAllDefs.ts
@@ -1,7 +1,0 @@
-import { getAllDefinitions } from '@opentrons/shared-data'
-
-import type { LabwareDefinition } from '@opentrons/shared-data'
-
-export function getAllDefs(): LabwareDefinition[] {
-  return Object.values(getAllDefinitions())
-}

--- a/app/src/local-resources/labware/utils/index.ts
+++ b/app/src/local-resources/labware/utils/index.ts
@@ -1,3 +1,2 @@
 export * from './getAllDefinitions'
 export * from './labwareImages'
-export * from './getAllDefs'

--- a/app/src/pages/Desktop/Labware/__tests__/hooks.test.tsx
+++ b/app/src/pages/Desktop/Labware/__tests__/hooks.test.tsx
@@ -4,9 +4,10 @@ import { renderHook } from '@testing-library/react'
 import { legacy_createStore } from 'redux'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { getAllDefinitions } from '@opentrons/shared-data'
+
 import { i18n } from '/app/i18n'
 import { useAllLabware } from '/app/local-resources/labware'
-import { getAllDefs } from '/app/local-resources/labware/utils/getAllDefs'
 import {
   getAddLabwareFailure,
   getAddNewLabwareName,
@@ -21,16 +22,25 @@ import { useLabwareFailure, useNewLabwareName } from '../hooks'
 
 import type { Store } from 'redux'
 import type { FunctionComponent, ReactNode } from 'react'
+import type * as SharedData from '@opentrons/shared-data'
 import type { FailedLabwareFile } from '/app/redux/custom-labware/types'
 import type { State } from '/app/redux/types'
 
 vi.mock('/app/redux/custom-labware')
-vi.mock('/app/local-resources/labware/utils/getAllDefs')
+vi.mock('@opentrons/shared-data', async importOriginal => {
+  const actualSharedData = await importOriginal<typeof SharedData>()
+  return {
+    ...actualSharedData,
+    getAllDefinitions: vi.fn(),
+  }
+})
 
 describe('useAllLabware hook', () => {
   const store: Store<State> = legacy_createStore(vi.fn(), {})
   beforeEach(() => {
-    vi.mocked(getAllDefs).mockReturnValue([mockDefinition])
+    vi.mocked(getAllDefinitions).mockReturnValue({
+      'custom/mock_definition/1': mockDefinition,
+    })
     vi.mocked(getValidCustomLabware).mockReturnValue([mockValidLabware])
     store.dispatch = vi.fn()
   })

--- a/app/src/redux/custom-labware/__fixtures__/index.ts
+++ b/app/src/redux/custom-labware/__fixtures__/index.ts
@@ -1,8 +1,11 @@
-import type { LabwareDefinition } from '@opentrons/shared-data'
+import type {
+  LabwareDefinition,
+  LabwareDefinition2,
+} from '@opentrons/shared-data'
 import type { LabwareWellGroupProperties } from '/app/local-resources/labware'
 import type * as Types from '../types'
 
-export const mockDefinition: LabwareDefinition = {
+export const mockDefinition: LabwareDefinition2 = {
   version: 1,
   schemaVersion: 2,
   namespace: 'custom',


### PR DESCRIPTION
# Overview

This is part 2 of a long chain of PRs for tiprack definition lookups in PD.

`app/src/local-resources/labware/utils/getAllDefs.ts` defines this function `getAllDefs()`. All it does is call shared-data's `getAllDefinitions()`.

So this PR deletes `getAllDefs.ts`, and makes its only user just call `getAllDefinitions()` directly.

Again, this is preparatory work for changes I want to make to `getAllDefinitions()` itself.

(If you're curious, `getAllDefs()` used to do more originally: PR #9612, but after a long series of refactorings, it's now just a thin wrapper around `getAllDefinitions()`.)

## Test Plan and Hands on Testing

Ran tests locally and on CI.

## Risk assessment

Low.