### PR TITLE
var was incorrectly being called

### DIFF
--- a/.github/actions/simple-build-alert/action.yml
+++ b/.github/actions/simple-build-alert/action.yml
@@ -78,4 +78,4 @@ runs:
             ]
           }
       env:
-        SLACK_WEBHOOK_URL: ${{ secrets[steps.channel-config.outputs.webhook_secret] }}
+        SLACK_WEBHOOK_URL: ${{ secrets.OT_APP_RELEASE_SLACK_NOTIFICATION_WEBHOOK_URL }}


### PR DESCRIPTION
### Fix GitHub Actions syntax error in simple-build-alert

Problem:
The simple-build-alert action was failing with a template validation error:

Root Cause:
GitHub Actions doesn't support dynamic key access with the secrets context using bracket notation like secrets[variable].

Solution:
Changed from ${{ secrets[steps.channel-config.outputs.webhook_secret] }}
To ${{ secrets.OT_APP_RELEASE_SLACK_NOTIFICATION_WEBHOOK_URL }}
Since both code paths were already outputting the same secret name, using the literal name directly is the correct approach

Testing:
Workflow should now run without template validation errors
Slack notifications will continue to work as expected
