### PR TITLE
fix(protocol-deisgner): render lid layer on top & fix moveLabwareForm

### DIFF
--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupDetails.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupDetails.tsx
@@ -457,7 +457,6 @@ export function DeckSetupDetails(props: DeckSetupDetailsProps): JSX.Element {
         ) {
           return null
         }
-        console.log(labware.stack)
         const slot = getSlotInLocationStack(labware.stack)
         const labwareAmount = labware.stack.reduce(
           (amount, item) => amount + (activeDeckSetup.labware[item] ? 1 : 0),

--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupDetails.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupDetails.tsx
@@ -188,6 +188,17 @@ export function DeckSetupDetails(props: DeckSetupDetailsProps): JSX.Element {
         )
       : null
 
+  // make sure the top labware (lid) is rendered first in the stack if
+  // it gets moved there later on
+  const sortedLabware = [...allLabware].sort((a, b) => {
+    // get how deep each labware is in its stack
+    const aDepth = a.stack.length
+    const bDepth = b.stack.length
+
+    // render deeper stacks last (on top)
+    return aDepth - bDepth
+  })
+
   return (
     <>
       {/* all modules */}
@@ -437,7 +448,7 @@ export function DeckSetupDetails(props: DeckSetupDetailsProps): JSX.Element {
         })}
 
       {/* all labware on deck NOT those in modules */}
-      {allLabware.map(labware => {
+      {sortedLabware.map(labware => {
         if (
           getSlotInLocationStack(labware.stack) === 'offDeck' ||
           allModules.some(m => labware.stack.includes(m.id)) ||
@@ -446,6 +457,7 @@ export function DeckSetupDetails(props: DeckSetupDetailsProps): JSX.Element {
         ) {
           return null
         }
+        console.log(labware.stack)
         const slot = getSlotInLocationStack(labware.stack)
         const labwareAmount = labware.stack.reduce(
           (amount, item) => amount + (activeDeckSetup.labware[item] ? 1 : 0),
@@ -460,6 +472,7 @@ export function DeckSetupDetails(props: DeckSetupDetailsProps): JSX.Element {
         }
         const labwareIsAdapter =
           labware.def.metadata.displayCategory === 'adapter'
+        console.log(' labware', labware)
 
         return (
           <Fragment key={labware.id}>

--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupDetails.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupDetails.tsx
@@ -472,7 +472,6 @@ export function DeckSetupDetails(props: DeckSetupDetailsProps): JSX.Element {
         }
         const labwareIsAdapter =
           labware.def.metadata.displayCategory === 'adapter'
-        console.log(' labware', labware)
 
         return (
           <Fragment key={labware.id}>

--- a/protocol-designer/src/steplist/formLevel/moveLabwareFormErrors.ts
+++ b/protocol-designer/src/steplist/formLevel/moveLabwareFormErrors.ts
@@ -34,10 +34,21 @@ const getMoveLabwareError = (
     const adapterLoadName =
       invariantContext.labwareEntities[newLocation.labwareId].def.parameters
         .loadName
-    errorString =
-      labware?.def.stackingOffsetWithLabware?.[adapterLoadName] == null
-        ? 'Labware incompatible with this adapter'
-        : null
+
+    if (labware?.def.parameters.loadName === 'opentrons_tough_universal_lid') {
+      errorString = null
+    } else if (
+      labware?.def.compatibleParentLabware?.some(
+        loadName => loadName === adapterLoadName
+      )
+    ) {
+      errorString = null
+    } else {
+      errorString =
+        labware?.def.stackingOffsetWithLabware?.[adapterLoadName] == null
+          ? 'Labware incompatible with this adapter'
+          : null
+    }
   }
   return errorString
 }


### PR DESCRIPTION
…Error

# Overview

note: this may not work properly without alex's changes that he is making here: https://github.com/Opentrons/opentrons/pull/19889

fixes 2 bugs:

1. the deck map wasn't rendering the top most layer lid on the deck if you move a lid to the labware later in the protocol. i think it has to do with the ordering of the labware listed in the labware entities or something? but anyway, this issue was only happening some times i think so i fixed it by ordering based off of the stack order

2. fixes the moveLabwareFormError by allowing you to move a universal lid onto a universal adapter and all adapters, technically. idk, spoke with alex who said that casey said the universal lid has to be truly universal minus the fact that it can't go on any tube racks, tipracks, aluminum blocks, other lids, and directly on modules 😬 

## Testing

create a protocol with a heater-shaker and a universal h-s adapter on top. add a universal lid to a separate slot. create a move labware step where you can move the universal lid onto the universal h-s adapter.

## Risk assessment

low
