### PR TITLE
feat(protocol-designer): migrate null nozzles field, fix selection logic

### DIFF
--- a/protocol-designer/src/load-file/migration/8_7_0.ts
+++ b/protocol-designer/src/load-file/migration/8_7_0.ts
@@ -1,8 +1,38 @@
+import { ALL, getPipetteSpecsV2, SINGLE } from '@opentrons/shared-data'
 import { AUTOMATIC } from '@opentrons/step-generation'
 
-import type { ProtocolFile } from '@opentrons/shared-data'
-import type { PDMetadata } from '/protocol-designer/file-types'
-import type { DesignerApplicationData } from './utils/getLoadLiquidCommands'
+import type {
+  NozzleConfigurationStyle,
+  ProtocolFile,
+} from '@opentrons/shared-data'
+import type { PDMetadata, Pipettes } from '/protocol-designer/file-types'
+
+const getDefaultNozzleConfiguration = (
+  rawNozzles: NozzleConfigurationStyle | null,
+  pipettes: Pipettes,
+  pipetteId: string
+): NozzleConfigurationStyle => {
+  if (rawNozzles != null) {
+    return rawNozzles
+  }
+  const pipetteName = pipettes?.[pipetteId]?.pipetteName ?? null
+  const pipetteSpecs =
+    pipetteName != null ? getPipetteSpecsV2(pipetteName) : null
+  const pipetteChannels = pipetteSpecs?.channels
+
+  switch (pipetteChannels) {
+    case 1:
+      return SINGLE
+    case 8:
+    case 96:
+      return ALL
+
+    // should not hit
+    default:
+      console.warn('Unknown pipette channels:', pipetteChannels)
+      return ALL
+  }
+}
 
 export const migrateFile = (
   appData: ProtocolFile<PDMetadata>
@@ -12,13 +42,18 @@ export const migrateFile = (
   if (designerApplication == null || designerApplication?.data == null) {
     throw Error('The designerApplication key in your file is corrupt.')
   }
-  const savedStepForms = designerApplication.data
-    ?.savedStepForms as DesignerApplicationData['savedStepForms']
+  const { savedStepForms, pipettes } = designerApplication.data
 
   const savedStepsWithUpdatedFields = Object.values(savedStepForms).reduce(
     (acc, form) => {
       const { stepType, id } = form
       if (stepType === 'moveLiquid' || stepType === 'mix') {
+        const { pipette, nozzles } = form
+        const convertedNozzleConfiguration = getDefaultNozzleConfiguration(
+          nozzles as NozzleConfigurationStyle,
+          pipettes,
+          pipette as string
+        )
         return {
           ...acc,
           [id]: {
@@ -26,6 +61,7 @@ export const migrateFile = (
             tip_tracking: AUTOMATIC,
             tiprack_selected: null,
             tips_selected: [],
+            nozzles: convertedNozzleConfiguration,
           },
         }
       }

--- a/protocol-designer/src/load-file/migration/8_7_0.ts
+++ b/protocol-designer/src/load-file/migration/8_7_0.ts
@@ -1,38 +1,12 @@
-import { ALL, getPipetteSpecsV2, SINGLE } from '@opentrons/shared-data'
 import { AUTOMATIC } from '@opentrons/step-generation'
+
+import { getDefaultNozzleConfiguration } from './utils/__tests__/getDefaultNozzleConfiguration'
 
 import type {
   NozzleConfigurationStyle,
   ProtocolFile,
 } from '@opentrons/shared-data'
-import type { PDMetadata, Pipettes } from '/protocol-designer/file-types'
-
-const getDefaultNozzleConfiguration = (
-  rawNozzles: NozzleConfigurationStyle | null,
-  pipettes: Pipettes,
-  pipetteId: string
-): NozzleConfigurationStyle => {
-  if (rawNozzles != null) {
-    return rawNozzles
-  }
-  const pipetteName = pipettes?.[pipetteId]?.pipetteName ?? null
-  const pipetteSpecs =
-    pipetteName != null ? getPipetteSpecsV2(pipetteName) : null
-  const pipetteChannels = pipetteSpecs?.channels
-
-  switch (pipetteChannels) {
-    case 1:
-      return SINGLE
-    case 8:
-    case 96:
-      return ALL
-
-    // should not hit
-    default:
-      console.warn('Unknown pipette channels:', pipetteChannels)
-      return ALL
-  }
-}
+import type { PDMetadata } from '/protocol-designer/file-types'
 
 export const migrateFile = (
   appData: ProtocolFile<PDMetadata>

--- a/protocol-designer/src/load-file/migration/utils/__tests__/getDefaultNozzleConfiguration.ts
+++ b/protocol-designer/src/load-file/migration/utils/__tests__/getDefaultNozzleConfiguration.ts
@@ -1,0 +1,31 @@
+import { ALL, getPipetteSpecsV2, SINGLE } from '@opentrons/shared-data'
+
+import type { NozzleConfigurationStyle } from '@opentrons/shared-data'
+import type { Pipettes } from '/protocol-designer/file-types'
+
+export const getDefaultNozzleConfiguration = (
+  rawNozzles: NozzleConfigurationStyle | null,
+  pipettes: Pipettes,
+  pipetteId: string
+): NozzleConfigurationStyle => {
+  if (rawNozzles != null) {
+    return rawNozzles
+  }
+  const pipetteName = pipettes?.[pipetteId]?.pipetteName ?? null
+  const pipetteSpecs =
+    pipetteName != null ? getPipetteSpecsV2(pipetteName) : null
+  const pipetteChannels = pipetteSpecs?.channels
+
+  switch (pipetteChannels) {
+    case 1:
+      return SINGLE
+    case 8:
+    case 96:
+      return ALL
+
+    // should not hit
+    default:
+      console.warn('Unknown pipette channels:', pipetteChannels)
+      return ALL
+  }
+}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/SelectTips.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/SelectTips.tsx
@@ -7,7 +7,9 @@ import {
   Chip,
   COLORS,
   Flex,
+  INACCESSIBLE,
   JUSTIFY_SPACE_BETWEEN,
+  NO,
   SELECTED,
   SELECTED_ERROR,
   SELECTED_USED,
@@ -216,9 +218,10 @@ export function SelectTips(
     const tipState = robotState?.tipState.tipracks[selectedTiprackId ?? '']
     const selectedWellsByIndex = selectedTips.reduce<Record<string, number>>(
       (acc, tipList, index) => {
-        const innerAcc = tipList.reduce<Record<string, number>>((acc, tip) => {
-          return { ...acc, [tip]: index }
-        }, {})
+        const innerAcc = tipList.reduce<Record<string, number>>(
+          (acc, tip) => ({ ...acc, [tip]: index }),
+          {}
+        )
         return { ...acc, ...innerAcc }
       },
       {}
@@ -230,6 +233,9 @@ export function SelectTips(
             (acc, [wellName, state]) => {
               const rawState = TIP_STATE_TO_TIP_TYPE[state]
               let status = rawState
+              if (!tipAccessibileStatusByWellName[wellName]) {
+                status = rawState === NO ? NO : INACCESSIBLE
+              }
               if (selectedTips.some(tipSet => tipSet.includes(wellName))) {
                 status = rawState === USED ? SELECTED_USED : SELECTED
               } else if (allWellsAffectedByHover.includes(wellName)) {

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/hooks/useMemoizedTipAccessibilityByTiprackIdByWellName.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/hooks/useMemoizedTipAccessibilityByTiprackIdByWellName.ts
@@ -11,6 +11,8 @@ import { OFFDECK } from '/protocol-designer/constants'
 import { getInvariantContext } from '/protocol-designer/step-forms/selectors'
 import { getRobotStateAtActiveItem } from '/protocol-designer/top-selectors/labware-locations'
 
+import { getAffectedWells } from '../utils'
+
 import type {
   NozzleConfigurationStyle,
   PipetteV2Specs,
@@ -95,8 +97,13 @@ export const useMemoizedTipAccessibilityByTiprackIdByWellName = (args: {
                 primaryNozzle,
                 nozzleConfiguration: nozzles,
               }) &&
-              // check if tip is not empty
-              tipState[wellName] !== EMPTY,
+              // check if tip(s) is/are not empty
+              getAffectedWells({
+                wellName,
+                labwareDef: def,
+                channels: pipetteSpecs.channels,
+                nozzles,
+              }).every(well => tipState[well] !== EMPTY),
           }),
           {}
         ),

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/index.tsx
@@ -13,7 +13,6 @@ import {
   getRobotStateAtActiveItem,
 } from '/protocol-designer/top-selectors/labware-locations'
 
-import { useMemoizedTipAccessibilityByTiprackIdByWellName } from './hooks'
 import { SelectTiprack } from './SelectTiprack'
 import { SelectTips } from './SelectTips'
 import { TipSelectionModal } from './TipSelectionModal'
@@ -36,6 +35,7 @@ interface TipSelectionWizardProps {
   selectedTips: string[][]
   setSelectedTips: Dispatch<SetStateAction<string[][]>>
   validTiprackIds: string[]
+  tipAccessibilityStatus: Record<string, Record<string, boolean>>
 }
 
 export function TipSelectionWizard(
@@ -53,6 +53,7 @@ export function TipSelectionWizard(
     selectedTips,
     setSelectedTips,
     validTiprackIds,
+    tipAccessibilityStatus,
   } = props
   const { t } = useTranslation('tip_selection')
   const [currentStepIndex, setCurrentStepIndex] = useState<number>(0)
@@ -76,16 +77,6 @@ export function TipSelectionWizard(
     nozzles,
     channels: pipetteSpecs.channels,
   })
-
-  const tipAccessibilityStatus =
-    useMemoizedTipAccessibilityByTiprackIdByWellName({
-      nozzles,
-      pipetteSpecs,
-      selectedTips,
-      primaryNozzle,
-      pipetteId,
-      tiprackUri: formTiprackUri,
-    })
 
   const deckDef = getDeckDefFromRobotType(robotType)
 

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/utils.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/utils.ts
@@ -174,11 +174,9 @@ export const getAffectedWells = (args: {
   if (channels === 1 || nozzles === SINGLE) {
     return [wellName]
   } else if (channels === 8 || (channels === 96 && nozzles === COLUMN)) {
-    const allWellsInColumn = getAllWellsInColumn(wellName, labwareDef)
-    return allWellsInColumn
+    return getAllWellsInColumn(wellName, labwareDef)
   } else if (channels === 96) {
-    const allWells = Object.keys(labwareDef.wells)
-    return allWells
+    return Object.keys(labwareDef.wells)
   }
   return []
 }

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipTrackingField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipTrackingField.tsx
@@ -19,6 +19,7 @@ import {
 } from '@opentrons/shared-data'
 import {
   AUTOMATIC,
+  getDefaultPrimaryNozzle,
   getTransferPlanAndReferenceVolumes,
   MANUAL,
 } from '@opentrons/step-generation'
@@ -143,12 +144,17 @@ export function TipTrackingField(props: TipTrackingFieldProps): JSX.Element {
     },
   ]
 
+  const primaryNozzle = getDefaultPrimaryNozzle({
+    nozzles: formData.nozzles,
+    channels: pipetteSpecs.channels,
+  })
+
   const tipAccessibilityStatus =
     useMemoizedTipAccessibilityByTiprackIdByWellName({
       nozzles: formData.nozzles,
       pipetteSpecs,
       selectedTips,
-      primaryNozzle: formData.primaryNozzle,
+      primaryNozzle,
       pipetteId: formData.pipette,
       tiprackUri: formData.tipRack,
     })
@@ -181,14 +187,13 @@ export function TipTrackingField(props: TipTrackingFieldProps): JSX.Element {
               onChange={() => {
                 propsForFields.tip_tracking.updateValue(value)
               }}
-              isSelected={propsForFields.tip_tracking.value === value}
+              isSelected={formData.tip_tracking === value}
               largeDesktopBorderRadius
             />
           ))}
         </Flex>
       </Flex>
-      {propsForFields.tip_tracking.value === MANUAL &&
-      hasValidTiprackForPickup ? (
+      {formData.tip_tracking === MANUAL && hasValidTiprackForPickup ? (
         <Flex className={styles.manual_container}>
           <StyledText desktopStyle="bodyDefaultRegular" color={COLORS.grey60}>
             {t('step_edit_form.field.tip_tracking.manual.title')}
@@ -220,8 +225,7 @@ export function TipTrackingField(props: TipTrackingFieldProps): JSX.Element {
           </ListButton>
         </Flex>
       ) : null}
-      {propsForFields.tip_tracking.value === MANUAL &&
-      !hasValidTiprackForPickup ? (
+      {formData.tip_tracking === MANUAL && !hasValidTiprackForPickup ? (
         <InlineNotification
           type="error"
           heading={t('tip_selection:no_valid_tips_available.title')}
@@ -231,9 +235,9 @@ export function TipTrackingField(props: TipTrackingFieldProps): JSX.Element {
       {showTipSelectionModal && (
         <TipSelectionWizard
           setShowTipSelectionModal={setShowTipSelectionModal}
-          formTiprackUri={propsForFields.tipRack.value as string}
-          pipetteId={propsForFields.pipette.value as string}
-          nozzles={propsForFields.nozzles.value as NozzleConfigurationStyle}
+          formTiprackUri={formData.tipRack as string}
+          pipetteId={formData.pipette as string}
+          nozzles={formData.nozzles as NozzleConfigurationStyle}
           numPickups={numPickups}
           tiprackSelected={formData.tiprack_selected}
           updateFormTiprackSelected={
@@ -243,6 +247,7 @@ export function TipTrackingField(props: TipTrackingFieldProps): JSX.Element {
           selectedTips={selectedTips}
           setSelectedTips={setSelectedTips}
           validTiprackIds={validTiprackIds}
+          tipAccessibilityStatus={tipAccessibilityStatus}
         />
       )}
     </Flex>


### PR DESCRIPTION
# Overview

This PR migrates nozzle fields for moveLiquid and mix steps to their default full nozzle configuration if the nozzle configuration was previously null. It also provides small fixes to `SelectTips` tip status rendering logic that I discovered while smoke testing.

Closes AUTH-2425

## Test Plan and Hands on Testing

Not too much to test in practice. Please just review code and smoke test tip selections

## Changelog

- add migration for `nozzles` field in mix and moveLiquid steps
- correctly render inaccessible and empty tips
- check all affected wells in `useMemoizedTipAccessibilityByTiprackIdByWellName` (for non-single nozzle configurations)

## Review requests

see test plan

## Risk assessment

low