### PR TITLE
feat(app, protocol-designer, step-generation): wire up formToArgs for tip selection

### DIFF
--- a/app/src/organisms/ODD/QuickTransferFlow/__tests__/utils/quickTransferStepCommands.test.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/__tests__/utils/quickTransferStepCommands.test.ts
@@ -7,6 +7,7 @@ import {
   POSITION_REFERENCE_BOTTOM,
 } from '@opentrons/shared-data'
 import {
+  AUTOMATIC,
   CLEAN,
   SOURCE_WELL_BLOWOUT_DESTINATION,
 } from '@opentrons/step-generation'
@@ -192,6 +193,9 @@ describe('quickTransferStepCommands', () => {
       name: 'transfer',
       description: 'transferring from 1 well to another',
       pushOut: null,
+      tip_tracking: AUTOMATIC,
+      tips_selected: [],
+      tiprack_selected: null,
     }
     expect(
       quickTransferStepCommands({
@@ -346,6 +350,9 @@ pipette.drop_tip()`.trimStart()
       name: 'transfer',
       description: 'transferring from 1 well to another',
       pushOut: null,
+      tip_tracking: AUTOMATIC,
+      tips_selected: [],
+      tiprack_selected: null,
     }
     expect(
       quickTransferStepCommands({
@@ -501,6 +508,9 @@ pipette.drop_tip()`.trimStart()
       description: 'transferring from 1 well to another',
       disposalVolume: null,
       pushOut: null,
+      tip_tracking: AUTOMATIC,
+      tips_selected: [],
+      tiprack_selected: null,
     }
     expect(
       quickTransferStepCommands({

--- a/app/src/organisms/ODD/QuickTransferFlow/utils/generateQuickTransferArgs.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/utils/generateQuickTransferArgs.ts
@@ -10,6 +10,7 @@ import {
   WASTE_CHUTE_FIXTURES,
 } from '@opentrons/shared-data'
 import {
+  AUTOMATIC,
   getSlotInLocationStack,
   makeInitialRobotState,
 } from '@opentrons/step-generation'
@@ -485,6 +486,10 @@ export function generateQuickTransferArgs(
       quickTransferState.touchTipAspirate ?? null,
     touchTipAfterDispenseMmFromEdge:
       quickTransferState.touchTipDispense ?? null,
+    // Tip selection not currently allowed in Quick Transfer, so we set to automatic
+    tip_tracking: AUTOMATIC,
+    tips_selected: [],
+    tiprack_selected: null,
   }
 
   switch (quickTransferState.path) {

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/mixFormToArgs.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/mixFormToArgs.ts
@@ -1,4 +1,5 @@
 import { POSITION_REFERENCE_BOTTOM } from '@opentrons/shared-data'
+import { AUTOMATIC } from '@opentrons/step-generation'
 
 import {
   DEFAULT_CHANGE_TIP_OPTION,
@@ -36,6 +37,9 @@ export const mixFormToArgs = (
     blowout_z_offset,
     pushOut_checkbox,
     pushOut_volume,
+    tip_tracking,
+    tips_selected,
+    tiprack_selected,
   } = castFormData
   const matchingTipLiquidSpecs = getMatchingTipLiquidSpecs(
     pipette,
@@ -122,5 +126,8 @@ export const mixFormToArgs = (
     positionReference: mix_position_reference ?? POSITION_REFERENCE_BOTTOM,
     finalPushOut:
       pushOut_checkbox && pushOut_volume != null ? pushOut_volume : 0,
+    tip_tracking: tip_tracking ?? AUTOMATIC,
+    tips_selected: tips_selected ?? [],
+    tiprack_selected: tiprack_selected ?? null,
   }
 }

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/moveLiquidFormToArgs.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/moveLiquidFormToArgs.ts
@@ -5,8 +5,10 @@ import {
   WATER_LIQUID_CLASS_NAME,
 } from '@opentrons/shared-data'
 import {
+  AUTOMATIC,
   DEST_WELL_BLOWOUT_DESTINATION,
   getTransferPlanAndReferenceVolumes,
+  MANUAL,
 } from '@opentrons/step-generation'
 
 import {
@@ -177,6 +179,9 @@ export const moveLiquidFormToArgs = (
     dispense_y_position,
     pushOut_checkbox,
     pushOut_volume,
+    tip_tracking,
+    tips_selected,
+    tiprack_selected,
   } = castFormData
   let sourceWells = getOrderedWells(
     castFormData.aspirate_wells,
@@ -387,6 +392,9 @@ export const moveLiquidFormToArgs = (
       castFormData.liquidClass === NONE_LIQUID_CLASS_NAME // transform "none" (needed in step form) to null
         ? null
         : (castFormData.liquidClass ?? null),
+    tip_tracking: tip_tracking ?? AUTOMATIC,
+    tips_selected: tips_selected ?? [],
+    tiprack_selected: tiprack_selected ?? null,
   }
   console.assert(
     sourceWellsUnordered.length > 0,
@@ -407,6 +415,19 @@ export const moveLiquidFormToArgs = (
   console.assert(
     !(path === 'multiDispense' && destWells == null),
     'cannot distribute when destWells is null'
+  )
+
+  console.assert(
+    !(tiprack_selected != null && tip_tracking === MANUAL),
+    'expected tiprack_selected to be set when tip_tracking is manual'
+  )
+
+  console.assert(
+    !(
+      (tips_selected == null || tips_selected.length === 0) &&
+      tip_tracking === MANUAL
+    ),
+    'expected tips_selected to be set when tip_tracking is manual'
   )
 
   const checkedPath = getCheckedPath(castFormData, contextualState, path)

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/mixFormToArgs.test.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/mixFormToArgs.test.ts
@@ -5,6 +5,7 @@ import {
   getLabwareDefURI,
 } from '@opentrons/shared-data'
 import { fixture_96_plate } from '@opentrons/shared-data/labware/fixtures/2'
+import { AUTOMATIC } from '@opentrons/step-generation'
 
 import { DEFAULT_MM_BLOWOUT_OFFSET_FROM_TOP } from '/protocol-designer/constants'
 
@@ -73,6 +74,9 @@ beforeEach(() => {
     // @ts-expect-error - todo(mm, 2025-10-09): According to recently improved type hints, this should be a number.
     // Clarify the expected input and change this to a number if it's safe.
     dispense_delay_seconds: null,
+    tip_tracking: AUTOMATIC,
+    tips_selected: [],
+    tiprack_selected: null,
   }
 })
 
@@ -108,6 +112,9 @@ describe('mix step form -> command creator args', () => {
       nozzles: undefined,
       xOffset: 0,
       yOffset: 0,
+      tip_tracking: AUTOMATIC,
+      tips_selected: [],
+      tiprack_selected: null,
     })
   })
 

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/moveLiquidFormToArgs.test.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/moveLiquidFormToArgs.test.ts
@@ -9,6 +9,7 @@ import {
   fixture_96_plate,
 } from '@opentrons/shared-data/labware/fixtures/2'
 import {
+  AUTOMATIC,
   DEST_WELL_BLOWOUT_DESTINATION,
   makeContext,
 } from '@opentrons/step-generation'
@@ -124,6 +125,9 @@ describe('move liquid step form -> command creator args', () => {
       disposalVolume_location: null,
       blowout_checkbox: false,
       blowout_location: null,
+      tip_tracking: AUTOMATIC,
+      tips_selected: [],
+      tiprack_selected: null,
     }
   })
 
@@ -184,6 +188,9 @@ describe('move liquid step form -> command creator args', () => {
       sourceWells: [ASPIRATE_WELL],
       destLabware: 'destLabwareId',
       destWells: [DISPENSE_WELL],
+      tip_tracking: AUTOMATIC,
+      tips_selected: [],
+      tiprack_selected: null,
     })
 
     // no form-specific fields should be passed along

--- a/protocol-designer/src/timelineMiddleware/__tests__/generateRobotStateTimeline.test.ts
+++ b/protocol-designer/src/timelineMiddleware/__tests__/generateRobotStateTimeline.test.ts
@@ -6,6 +6,7 @@ import {
   POSITION_REFERENCE_BOTTOM,
 } from '@opentrons/shared-data'
 import {
+  AUTOMATIC,
   DEFAULT_PIPETTE,
   DEST_LABWARE,
   FIXED_TRASH_ID,
@@ -97,6 +98,9 @@ describe('generateRobotStateTimeline', () => {
           touchTipAfterDispenseMmFromEdge: 0,
           dispenseSubmergeDelay: null,
           dispenseRetractDelay: null,
+          tip_tracking: AUTOMATIC,
+          tips_selected: [],
+          tiprack_selected: null,
         },
       },
       b: {
@@ -171,6 +175,9 @@ describe('generateRobotStateTimeline', () => {
           touchTipAfterDispenseMmFromEdge: 0,
           dispenseSubmergeDelay: null,
           dispenseRetractDelay: null,
+          tip_tracking: AUTOMATIC,
+          tips_selected: [],
+          tiprack_selected: null,
         },
       },
       c: {
@@ -203,6 +210,9 @@ describe('generateRobotStateTimeline', () => {
           finalPushOut: 0,
           zOffset: 0,
           positionReference: POSITION_REFERENCE_BOTTOM,
+          tip_tracking: AUTOMATIC,
+          tips_selected: [],
+          tiprack_selected: null,
         },
       },
     }

--- a/step-generation/src/__tests__/liquidClassUtils.test.tsx
+++ b/step-generation/src/__tests__/liquidClassUtils.test.tsx
@@ -9,6 +9,7 @@ import {
   POSITION_REFERENCE_TOP,
 } from '@opentrons/shared-data'
 
+import { AUTOMATIC } from '../constants'
 import {
   DEFAULT_PIPETTE,
   DEST_LABWARE,
@@ -91,6 +92,9 @@ describe('getCustomLiquidClassProperties', () => {
           dispenseRetractPositionReference: POSITION_REFERENCE_TOP,
           nozzles: null,
           stepNumber: 1,
+          tip_tracking: AUTOMATIC,
+          tips_selected: [],
+          tiprack_selected: null,
         },
         pipetteName: 'p20_single_gen2',
         tiprackUri: 'opentrons/opentrons_96_tiprack_20ul/1',
@@ -251,6 +255,9 @@ describe('getCustomLiquidClassProperties', () => {
           dispenseRetractPositionReference: POSITION_REFERENCE_TOP,
           nozzles: null,
           stepNumber: 1,
+          tip_tracking: AUTOMATIC,
+          tips_selected: [],
+          tiprack_selected: null,
         },
         pipetteName: 'p20_single_gen2',
         tiprackUri: 'opentrons/opentrons_96_tiprack_20ul/1',

--- a/step-generation/src/types.ts
+++ b/step-generation/src/types.ts
@@ -366,6 +366,9 @@ export type SharedTransferLikeArgs = CommonArgs & {
   dispenseRetractZOffset: number
   dispenseRetractPositionReference: PositionReference
   dispenseRetractDelay: InnerDelayArgs | null
+  tip_tracking: TipTrackingOption
+  tips_selected: string[]
+  tiprack_selected: string | null
 }
 
 export type ConsolidateArgs = SharedTransferLikeArgs & {
@@ -445,6 +448,9 @@ export type MixArgs = CommonArgs & {
   aspirateDelaySeconds: number | null | undefined
   dispenseDelaySeconds: number | null | undefined
   finalPushOut: number
+  tip_tracking: TipTrackingOption
+  tips_selected: string[]
+  tiprack_selected: string | null
 }
 
 export type PauseArgs = CommonArgs & {


### PR DESCRIPTION
# Overview

This PR updates args types and wires up tip selection fields in formToArgs for mix and moveLiquid steps. New fields to be wired up in formToArgs:
- `tip_tracking`
- `tiprack_selected`
- `tips_selected`

Closes AUTH-2413

## Test Plan and Hands on Testing

just review code please

## Changelog

- add new tip selection fields to step generation args types for transfer, consolidate, distribute, mix
- fix up all tests

## Review requests

nothin in particular

## Risk assessment

low. medium footprint by files, but mostly types and tests