### PR TITLE
refactor(shared-data): simplify and fix caching in getAllDefinitions()

### DIFF
--- a/app/src/local-resources/labware/utils/getAllDefinitions.ts
+++ b/app/src/local-resources/labware/utils/getAllDefinitions.ts
@@ -27,11 +27,7 @@ const getOnlyLatestDefs = (
 }
 
 export function getAllLatestDefs(): LabwareDefinition[] {
-  const allDefs = Object.values(getAllDefinitions()).filter(
-    (d: LabwareDefinition) =>
-      // eslint-disable-next-line @typescript-eslint/prefer-includes
-      LABWAREV2_DO_NOT_LIST.indexOf(d.parameters.loadName) === -1
-  )
+  const allDefs = Object.values(getAllDefinitions(LABWAREV2_DO_NOT_LIST))
   const definitions = getOnlyLatestDefs(allDefs)
 
   return definitions

--- a/app/src/organisms/ODD/QuickTransferFlow/SelectTipRack.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/SelectTipRack.tsx
@@ -41,7 +41,7 @@ export function SelectTipRack(props: SelectTipRackProps): JSX.Element {
     state.pipette?.liquids.default.defaultTipracks.filter(tiprackUri => {
       // "opentrons/opentrons_flex_96_tiprack_20ul/1" -> "opentrons_flex_96_tiprack_20ul"
       const loadName = tiprackUri.split('/')[1]
-      const isBlockedTiprack = LABWAREV2_DO_NOT_LIST.includes(loadName)
+      const isBlockedTiprack = LABWAREV2_DO_NOT_LIST.has(loadName)
       return !isBlockedTiprack
     }) ?? []
 

--- a/labware-library/src/definitions.tsx
+++ b/labware-library/src/definitions.tsx
@@ -57,11 +57,7 @@ let definitions: LabwareList | null = null
 
 export function getAllDefinitions(): LabwareList {
   if (!definitions) {
-    const allDefs = _getAllDefs().filter(
-      (d: LabwareDefinition2) =>
-        // eslint-disable-next-line @typescript-eslint/prefer-includes
-        LABWAREV2_DO_NOT_LIST.indexOf(d.parameters.loadName) === -1
-    )
+    const allDefs = Object.values(_getAllDefinitions(LABWAREV2_DO_NOT_LIST))
     definitions = getOnlyLatestDefs(allDefs)
   }
 

--- a/opentrons-ai-client/src/resources/utils/labware.ts
+++ b/opentrons-ai-client/src/resources/utils/labware.ts
@@ -14,7 +14,7 @@ import type {
 
 let _definitions: LabwareDef2ByDefURI | null = null
 
-const BLOCK_LIST = [...RETIRED_LABWARE, ...LABWAREV2_DO_NOT_LIST]
+const BLOCK_LIST = new Set([...RETIRED_LABWARE, ...LABWAREV2_DO_NOT_LIST])
 
 export function getAllDefinitions(): LabwareDef2ByDefURI {
   if (_definitions == null) {

--- a/shared-data/js/getLabware.ts
+++ b/shared-data/js/getLabware.ts
@@ -15,7 +15,7 @@ import type {
 // do not list in any "available labware" UI.
 // TODO(mc, 2019-12-3): how should this correspond to RETIRED_LABWARE?
 // see shared-data/js/helpers/index.js
-export const LABWAREV2_DO_NOT_LIST = [
+export const LABWAREV2_DO_NOT_LIST = new Set([
   // Labware definitions only used for back-compat with legacy v1 defs:
   'opentrons_40_aluminumblock_eppendorf_24x2ml_safelock_snapcap_generic_16x0.2ml_pcr_strip',
   'opentrons_24_tuberack_eppendorf_2ml_safelock_snapcap_acrylic',
@@ -48,10 +48,10 @@ export const LABWAREV2_DO_NOT_LIST = [
   // temporarily blocking 20 uL Flex tip racks until they launch
   'opentrons_flex_96_tiprack_20ul',
   'opentrons_flex_96_filtertiprack_20ul',
-]
+])
 // NOTE(sa, 2020-7-14): in PD we do not want to list calibration blocks
 // or the adapter/labware combos since we migrated to splitting them up
-export const PD_DO_NOT_LIST = [
+export const PD_DO_NOT_LIST = new Set([
   'opentrons_calibrationblock_short_side_left',
   'opentrons_calibrationblock_short_side_right',
   'opentrons_96_aluminumblock_biorad_wellplate_200ul',
@@ -70,7 +70,7 @@ export const PD_DO_NOT_LIST = [
   // temporarily blocking 20 uL Flex tip racks until they launch
   'opentrons_flex_96_tiprack_20ul',
   'opentrons_flex_96_filtertiprack_20ul',
-]
+])
 
 export function getIsLabwareV1Tiprack(def: LabwareDefinition1): boolean {
   return Boolean(def?.metadata?.isTiprack)

--- a/shared-data/js/labware.ts
+++ b/shared-data/js/labware.ts
@@ -78,24 +78,18 @@ const schema3DefinitionsByURI = Object.fromEntries(
 export const getAllLabwareDefs = (): Record<string, LabwareDefinition2> =>
   schema2DefinitionsByURI
 
-let _definitions: LabwareDef2ByDefURI | null = null
 export function getAllDefinitions(
-  blockList: string[] = []
+  blockList?: Set<string>
 ): LabwareDef2ByDefURI {
-  // todo(mm, 2025-02-27): This looks suspicious: if we're called twice with two
-  // different blockList values, we'll return the same results for both.
-  if (_definitions == null) {
-    _definitions = Object.values(
-      getAllLabwareDefs()
-    ).reduce<LabwareDef2ByDefURI>((acc, labwareDef: LabwareDefinition2) => {
-      const labwareDefURI = getLabwareDefURI(labwareDef)
-      return blockList.includes(labwareDef.parameters.loadName)
-        ? acc
-        : { ...acc, [labwareDefURI]: labwareDef }
-    }, {})
+  if (blockList) {
+    return Object.fromEntries(
+      Object.entries(getAllLabwareDefs()).filter(
+        ([, labwareDef]) => !blockList.has(labwareDef.parameters.loadName)
+      )
+    )
+  } else {
+    return getAllLabwareDefs()
   }
-
-  return _definitions
 }
 
 export function getAllLegacyDefinitions(): LegacyLabwareDefByName {


### PR DESCRIPTION
# Overview

Part 3 of a chain of PRs to eventually fix tiprack lookups in PD.

We attempted to implement memoization in `getAllDefinitions(blockList: string[])` by caching the result to the global variable `_definitions`, but the implementation is incorrect and dangerous because there's only one `_definitions`, and once it's set, we'll keep returning it for all calls to `getAllDefinitions()` even if you specify a different `blockList` later (or no `blockList` at all).

This PR removes the caching entirely.

And I changed the blocklists `LABWAREV2_DO_NOT_LIST` and `PD_DO_NOT_LIST` into `Set`s. This means that we can check if any particular labware is in the blocklist in roughly O(1) time, so we don't have to feel bad about removing the caching. (I.e., building the return value for `getAllDefinitions()` would take about as long as calling `Object.values(...)` or `Object.entries(...)` on the definitions list, and we do those things *all the time*, so if we're OK with that, we should be OK with an uncached `getAllDefinitions()`.)

Furthermore, if you look at the files that use `getAllDefinitions()`, such as `labware-library/src/definitions.tsx`, they often implement **their own** layer of caching, so we really shouldn't feel bad about removing the caching from `getAllDefinitions()` to make it more correct.

## Test Plan and Hands on Testing

Ran `yarn vitest protocol-designer/ step-generation/ app/`.
Will run CI tests.

## Risk assessment

Low.