### PR TITLE
refactor(shared-data,app-protocol-designer): getAllLabwareDefs() -> getAllDefinitions()

### DIFF
--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useFailedLabwareUtils.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useFailedLabwareUtils.ts
@@ -8,7 +8,7 @@ import {
 } from '@opentrons/components'
 import {
   FLEX_ROBOT_TYPE,
-  getAllLabwareDefs,
+  getAllDefinitions,
   getLabwareDisplayName,
   getLoadedLabwareDefinitionsByUri,
 } from '@opentrons/shared-data'
@@ -329,7 +329,7 @@ function useTipSelectionUtils(
   // Use this labware to represent all tip racks for manual tip selection.
   const tipSelectorDef = useMemo(
     () =>
-      getAllLabwareDefs()[
+      getAllDefinitions()[
         'opentrons/thermoscientificnunc_96_wellplate_1300ul/1'
       ],
     []

--- a/app/src/organisms/ODD/QuickTransferFlow/utils/getMatchingTipLiquidSpecsFromSpec.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/utils/getMatchingTipLiquidSpecsFromSpec.ts
@@ -1,4 +1,4 @@
-import { getAllLabwareDefs, LOW_VOLUME_PIPETTES } from '@opentrons/shared-data'
+import { getAllDefinitions, LOW_VOLUME_PIPETTES } from '@opentrons/shared-data'
 
 import { getPipetteNameFromSpecs } from './getPipetteNameFromSpecs'
 
@@ -11,7 +11,7 @@ export function getMatchingTipLiquidSpecsFromSpec(
   volume: number,
   tiprackUri: string
 ): SupportedTip {
-  const matchingLabwareDef = getAllLabwareDefs()[tiprackUri]
+  const matchingLabwareDef = getAllDefinitions()[tiprackUri]
   const pipetteName = getPipetteNameFromSpecs(pipetteSpecs)
 
   console.assert(

--- a/protocol-designer/src/labware-ingred/reducers/index.ts
+++ b/protocol-designer/src/labware-ingred/reducers/index.ts
@@ -4,7 +4,7 @@ import pickBy from 'lodash/pickBy'
 import { combineReducers } from 'redux'
 import { handleActions } from 'redux-actions'
 
-import { getAllLabwareDefs } from '@opentrons/shared-data'
+import { getAllDefinitions } from '@opentrons/shared-data'
 
 import { getPDMetadata } from '../../file-types'
 import { getOnlyLatestDefs } from '../../labware-defs'
@@ -184,7 +184,7 @@ export const containers: Reducer<ContainersState, any> = handleActions(
     ): ContainersState => {
       const { file } = action.payload
       const metadata = getPDMetadata(file)
-      const allLabwareDefs = getAllLabwareDefs()
+      const allLabwareDefs = getAllDefinitions()
       const latestDefs = getOnlyLatestDefs()
       const containers: ContainersState = Object.entries(
         metadata.labware
@@ -315,7 +315,7 @@ export const ingredLocations: Reducer<LocationsState, any> = handleActions(
     ): LocationsState => {
       const ingredLocations = getPDMetadata(action.payload.file).ingredLocations
       const labware = getPDMetadata(action.payload.file).labware
-      const allLabwareDefs = getAllLabwareDefs()
+      const allLabwareDefs = getAllDefinitions()
       const latestDefs = getOnlyLatestDefs()
 
       return Object.entries(ingredLocations).reduce(

--- a/protocol-designer/src/load-file/migration/7_0_0.ts
+++ b/protocol-designer/src/load-file/migration/7_0_0.ts
@@ -1,6 +1,6 @@
 import mapValues from 'lodash/mapValues'
 
-import { getAllLabwareDefs } from '@opentrons/shared-data'
+import { getAllDefinitions } from '@opentrons/shared-data'
 
 import { INITIAL_DECK_SETUP_STEP_ID } from '../../constants'
 import { uuid } from '../../utils'
@@ -65,7 +65,7 @@ export const migrateFile = (
     ].labwareLocationUpdate
   const ingredLocations = appData.designerApplication?.data?.ingredLocations
 
-  const allLabwareDefs = getAllLabwareDefs()
+  const allLabwareDefs = getAllDefinitions()
 
   const getIsAdapter = (labwareId: string): boolean => {
     const labwareEntity = labware[labwareId]

--- a/protocol-designer/src/load-file/migration/8_5_0.ts
+++ b/protocol-designer/src/load-file/migration/8_5_0.ts
@@ -5,7 +5,7 @@ import round from 'lodash/round'
 
 import {
   FLEX_ROBOT_TYPE,
-  getAllLabwareDefs,
+  getAllDefinitions,
   getAllLiquidClassDefs,
   getFlexNameConversion,
   getPipetteSpecsV2,
@@ -87,7 +87,7 @@ const getClippedFlowRateForMoveLiquid = (args: {
   const tipLiquidSpecs = liquidClass?.byPipette
     .find(byPipette => byPipette.pipetteModel === pipetteName)
     ?.byTipType.find(byTipType => byTipType.tiprack === tiprack)
-  const tiprackDef = getAllLabwareDefs()[tiprack]
+  const tiprackDef = getAllDefinitions()[tiprack]
   let correctionVolume: number = 0
   if (tipLiquidSpecs != null && flowRateType !== 'blowout') {
     const liquidClassLookup =
@@ -184,7 +184,7 @@ export const migrateFile = (
     //  for OpentronsAI
     Object.values(labwareDefinitions).length > 0
       ? labwareDefinitions
-      : getAllLabwareDefs()
+      : getAllDefinitions()
   const migratedIngredients: Ingredients = Object.entries(
     ingredients
   ).reduce<Ingredients>((acc, [id, ingredient]) => {

--- a/protocol-designer/src/pages/Designer/DeckSetup/SelectedItems.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/SelectedItems.tsx
@@ -2,7 +2,7 @@ import { useSelector } from 'react-redux'
 
 import { Module } from '@opentrons/components'
 import {
-  getAllLabwareDefs,
+  getAllDefinitions,
   getModuleDef,
   inferModuleOrientationFromXCoordinate,
 } from '@opentrons/shared-data'
@@ -40,7 +40,7 @@ export const SelectedItems = (props: SelectedItemsProps): JSX.Element => {
     selectedLidLabware,
   } = selectedSlotInfo
   const customLabwareDefs = useSelector(getCustomLabwareDefsByURI)
-  const defs = getAllLabwareDefs()
+  const defs = getAllDefinitions()
   const deckSetup = useSelector(getInitialDeckSetup)
   const { labware } = deckSetup
   const matchingSelectedTopLabwareOnDeck = Object.values(labware).find(

--- a/protocol-designer/src/pages/Designer/DeckSetup/__tests__/SelectedItems.test.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/__tests__/SelectedItems.test.tsx
@@ -9,7 +9,7 @@ import {
   fixture24Tuberack,
   fixtureTiprackAdapter,
   FLEX_ROBOT_TYPE,
-  getAllLabwareDefs,
+  getAllDefinitions,
   getDeckDefFromRobotType,
   HEATERSHAKER_MODULE_V1,
 } from '@opentrons/shared-data'
@@ -44,10 +44,10 @@ vi.mock('@opentrons/components', async importOriginal => {
   }
 })
 vi.mock('@opentrons/shared-data', async importOriginal => {
-  const actual = await importOriginal<typeof getAllLabwareDefs>()
+  const actual = await importOriginal<typeof getAllDefinitions>()
   return {
     ...actual,
-    getAllLabwareDefs: vi.fn(),
+    getAllDefinitions: vi.fn(),
   }
 })
 
@@ -66,7 +66,7 @@ describe('SelectedItems', () => {
       slotPosition: [0, 0, 0],
     }
     vi.mocked(getSelectedTerminalItemId).mockReturnValue(START_TERMINAL_ITEM_ID)
-    vi.mocked(getAllLabwareDefs).mockReturnValue({
+    vi.mocked(getAllDefinitions).mockReturnValue({
       [mockAdapterURI]: {
         ...fixture24Tuberack,
         metadata: {

--- a/protocol-designer/src/pages/Designer/utils.ts
+++ b/protocol-designer/src/pages/Designer/utils.ts
@@ -4,7 +4,7 @@ import { reduce } from 'lodash'
 
 import {
   FLEX_ROBOT_TYPE,
-  getAllLabwareDefs,
+  getAllDefinitions,
   getIsLid,
   getIsPipettableLabware,
   getIsTiprack,
@@ -93,7 +93,7 @@ export const getSlotInformation = (
     modules: deckSetupModules,
     additionalEquipmentOnDeck,
   } = deckSetup
-  const latestDefs = getAllLabwareDefs()
+  const latestDefs = getAllDefinitions()
   const lidLoadNames = Object.values(latestDefs)
     .filter(def => def.allowedRoles?.includes('lid'))
     ?.map(def => def.parameters.loadName)

--- a/protocol-designer/src/step-forms/reducers/index.ts
+++ b/protocol-designer/src/step-forms/reducers/index.ts
@@ -8,7 +8,6 @@ import { handleActions } from 'redux-actions'
 import {
   FLEX_SIMPLEST_DECK_CONFIG,
   getAllDefinitions,
-  getAllLabwareDefs,
   getLabwareDefaultEngageHeight,
   getLabwareDefURI,
   getModuleType,
@@ -1342,7 +1341,7 @@ export const pipetteInvariantProperties: Reducer<
     ): NormalizedPipetteById => {
       const { file } = action.payload
       const metadata = getPDMetadata(file)
-      const allLabwareDefs = getAllLabwareDefs()
+      const allLabwareDefs = getAllDefinitions()
       const latestDefs = getOnlyLatestDefs()
       const pipettes = Object.entries(metadata.pipettes).reduce(
         (

--- a/protocol-designer/src/utils/index.ts
+++ b/protocol-designer/src/utils/index.ts
@@ -3,7 +3,7 @@ import uuidv1 from 'uuid/v4'
 
 import {
   FLEX_ROBOT_TYPE,
-  getAllLabwareDefs,
+  getAllDefinitions,
   getDeckDefFromRobotType,
   getTiprackVolume,
   INTERACTIVE_WELL_DATA_ATTRIBUTE,
@@ -191,7 +191,7 @@ export function getMatchingTipLiquidSpecsFromSpec(
   volume: number,
   tiprackUri: string
 ): SupportedTip {
-  const matchingLabwareDef = getAllLabwareDefs()[tiprackUri]
+  const matchingLabwareDef = getAllDefinitions()[tiprackUri]
 
   console.assert(
     matchingLabwareDef,
@@ -247,10 +247,10 @@ export function getMatchingTipLiquidSpecs(
     ) ||
     // The `tiprack` from a step might not be in `pipetteEntity.tiprackLabwareDef`
     // anymore because the user removed the tiprack from the pipette. So we can try
-    // looking up the `tiprack` in getAllLabwareDefs() as well.
-    // TODO: But getAllLabwareDefs() only contains standard labware, so this would still
+    // looking up the `tiprack` in getAllDefinitions() as well.
+    // TODO: But getAllDefinitions() only contains standard labware, so this would still
     // fail if `tiprack` is a custom tiprack.
-    getAllLabwareDefs()[tiprack]
+    getAllDefinitions()[tiprack]
 
   console.assert(
     matchingLabwareDef,

--- a/shared-data/js/labware.ts
+++ b/shared-data/js/labware.ts
@@ -70,25 +70,17 @@ const schema3DefinitionsByURI = Object.fromEntries(
 
 // todo(mm, 2025-02-27): When calling code is ready, this should probably include
 // schema 3 definitions, not just schema 2 definitions.
-//
-// todo(mm, 2025-02-27): The only remaining difference between this and
-// getAllDefinitions() is that getAllDefinitions() has potentially dangerous caching
-// behavior (see the todo comment there). Delete this in favor of getAllDefinitions()
-// when that's resolved.
-export const getAllLabwareDefs = (): Record<string, LabwareDefinition2> =>
-  schema2DefinitionsByURI
-
 export function getAllDefinitions(
   blockList?: Set<string>
 ): LabwareDef2ByDefURI {
   if (blockList) {
     return Object.fromEntries(
-      Object.entries(getAllLabwareDefs()).filter(
+      Object.entries(schema2DefinitionsByURI).filter(
         ([, labwareDef]) => !blockList.has(labwareDef.parameters.loadName)
       )
     )
   } else {
-    return getAllLabwareDefs()
+    return schema2DefinitionsByURI
   }
 }
 


### PR DESCRIPTION
# Overview

*Make all of Max's dreams come true ...*

Part 4 in a chain of PRs for tiprack definition lookups in PD.

After PR #17631, we ended up with 2 functions for getting the labware definitions:
- `getAllLabwareDefs()` returned all the standard labware definitions.
- `getAllDefinitions(blockList)` returned all the standard labware definitions except the ones in `blockList`, and also implemented caching, but not quite correctly.

That PR left us with a TODO to combine the two functions.

We've fixed the caching issue now, so we can now go ahead and combine the two functions. This PR eliminates `getAllLabwareDefs()` and changes all the callers to call `getAllDefinitions()` instead.

## Test Plan and Hands on Testing

Ran `vitest` locally.
Ran CI tests.

## Risk assessment

Low-ish.