### PR TITLE
refactor(protocol-designer): call getMatchingTipLiquidSpecsFromSpec() with tiprackDef

### DIFF
--- a/protocol-designer/src/load-file/migration/8_5_0.ts
+++ b/protocol-designer/src/load-file/migration/8_5_0.ts
@@ -87,7 +87,9 @@ const getClippedFlowRateForMoveLiquid = (args: {
   const tipLiquidSpecs = liquidClass?.byPipette
     .find(byPipette => byPipette.pipetteModel === pipetteName)
     ?.byTipType.find(byTipType => byTipType.tiprack === tiprack)
+  // TODO: this won't find the definition for a custom tiprack
   const tiprackDef = getAllDefinitions()[tiprack]
+  console.assert(tiprackDef, `could not find labware definition for ${tiprack}`)
   let correctionVolume: number = 0
   if (tipLiquidSpecs != null && flowRateType !== 'blowout') {
     const liquidClassLookup =
@@ -130,7 +132,7 @@ const getClippedFlowRateForMoveLiquid = (args: {
   const matchingTipLiquidSpecs = getMatchingTipLiquidSpecsFromSpec(
     pipetteSpecs,
     volume,
-    formData.tipRack as string
+    tiprackDef
   )
 
   const shaftULperMM = pipetteSpecs?.shaftULperMM

--- a/protocol-designer/src/load-file/migration/8_5_0.ts
+++ b/protocol-designer/src/load-file/migration/8_5_0.ts
@@ -89,7 +89,10 @@ const getClippedFlowRateForMoveLiquid = (args: {
     ?.byTipType.find(byTipType => byTipType.tiprack === tiprack)
   // TODO: this won't find the definition for a custom tiprack
   const tiprackDef = getAllDefinitions()[tiprack]
-  console.assert(tiprackDef != null, `could not find labware definition for ${tiprack}`)
+  console.assert(
+    tiprackDef != null,
+    `could not find labware definition for ${tiprack}`
+  )
   let correctionVolume: number = 0
   if (tipLiquidSpecs != null && flowRateType !== 'blowout') {
     const liquidClassLookup =

--- a/protocol-designer/src/load-file/migration/8_5_0.ts
+++ b/protocol-designer/src/load-file/migration/8_5_0.ts
@@ -89,7 +89,7 @@ const getClippedFlowRateForMoveLiquid = (args: {
     ?.byTipType.find(byTipType => byTipType.tiprack === tiprack)
   // TODO: this won't find the definition for a custom tiprack
   const tiprackDef = getAllDefinitions()[tiprack]
-  console.assert(tiprackDef, `could not find labware definition for ${tiprack}`)
+  console.assert(tiprackDef != null, `could not find labware definition for ${tiprack}`)
   let correctionVolume: number = 0
   if (tipLiquidSpecs != null && flowRateType !== 'blowout') {
     const liquidClassLookup =

--- a/protocol-designer/src/utils/index.ts
+++ b/protocol-designer/src/utils/index.ts
@@ -189,21 +189,14 @@ export const getStagingAreaAddressableAreas = (
 export function getMatchingTipLiquidSpecsFromSpec(
   pipetteSpecs: PipetteV2Specs,
   volume: number,
-  tiprackUri: string
+  tiprackDef: LabwareDefinition2
 ): SupportedTip {
-  const matchingLabwareDef = getAllDefinitions()[tiprackUri]
-
-  console.assert(
-    matchingLabwareDef,
-    `expected to find a matching labware def with tiprack ${tiprackUri} but could not`
-  )
-
-  const tipLength = matchingLabwareDef?.parameters.tipLength ?? 0
+  const tipLength = tiprackDef?.parameters.tipLength ?? 0
 
   if (tipLength === 0) {
     console.error(
       `expected to find a tiplength with tiprack ${
-        matchingLabwareDef?.metadata.displayName ?? 'unknown displayName'
+        tiprackDef?.metadata.displayName ?? 'unknown displayName'
       } but could not`
     )
   }
@@ -229,7 +222,7 @@ export function getMatchingTipLiquidSpecsFromSpec(
   console.assert(
     matchingTipLiquidSpecs,
     `expected to find the tip liquid specs but could not with pipette tiprack displayname ${
-      matchingLabwareDef?.metadata.displayName ?? 'unknown displayname'
+      tiprackDef?.metadata.displayName ?? 'unknown displayname'
     }`
   )
 


### PR DESCRIPTION
# Overview

Part 5 for tiprack definition lookups in PD.

Back in PR #19041, @ncdiehl11 introduced the function `getMatchingTipLiquidSpecsFromSpec()` that takes a tiprack URI and tries to look up the tiprack definition. It sometimes fails, producing Sentry errors like:
- https://opentrons-76.sentry.io/issues/6912737526/?project=4509363266387968
- https://opentrons-76.sentry.io/issues/6912737527/?project=4509363266387968

However, there is no need for `getMatchingTipLiquidSpecsFromSpec()` itself to look up the tiprack definition, because the caller already has the tiprack definition.

So this PR changes `getMatchingTipLiquidSpecsFromSpec()` to take a tiprack labware definition instead of a tiprack URI.

Note that the existing implementation in `load-file/migration/8_5_0.ts` to find the tiprack definition is not quite correct, and would fail for custom tipracks. But we'll fix that in a future PR.

## Test Plan and Hands on Testing

CI tests.

## Risk assessment

Low.