### PR TITLE
feat(api): PAPI capture_image command implementation

### DIFF
--- a/api/src/opentrons/legacy_commands/protocol_commands.py
+++ b/api/src/opentrons/legacy_commands/protocol_commands.py
@@ -75,7 +75,7 @@ def capture_Image(
         text += f" saturation of {saturation}%"
     text += "."
     return {
-        "name": command_types.CaptureImageCommand,
+        "name": command_types.CAPTURE_IMAGE,
         "payload": {
             "text": text,
             "resolution": resolution,

--- a/api/src/opentrons/legacy_commands/protocol_commands.py
+++ b/api/src/opentrons/legacy_commands/protocol_commands.py
@@ -54,6 +54,7 @@ def move_labware(text: str) -> command_types.MoveLabwareCommand:
         "payload": {"text": text},
     }
 
+
 def capture_Image(
     resolution: Optional[Tuple[int, int]],
     zoom: Optional[float],

--- a/api/src/opentrons/legacy_commands/protocol_commands.py
+++ b/api/src/opentrons/legacy_commands/protocol_commands.py
@@ -55,7 +55,7 @@ def move_labware(text: str) -> command_types.MoveLabwareCommand:
     }
 
 
-def capture_Image(
+def capture_image(
     resolution: Optional[Tuple[int, int]],
     zoom: Optional[float],
     contrast: Optional[float],

--- a/api/src/opentrons/legacy_commands/protocol_commands.py
+++ b/api/src/opentrons/legacy_commands/protocol_commands.py
@@ -1,5 +1,5 @@
 from datetime import timedelta
-from typing import Optional
+from typing import Optional, Tuple
 from . import types as command_types
 from opentrons.protocol_api.tasks import Task
 
@@ -52,6 +52,37 @@ def move_labware(text: str) -> command_types.MoveLabwareCommand:
     return {
         "name": command_types.MOVE_LABWARE,
         "payload": {"text": text},
+    }
+
+def capture_Image(
+    resolution: Optional[Tuple[int, int]],
+    zoom: Optional[float],
+    contrast: Optional[float],
+    brightness: Optional[float],
+    saturation: Optional[float],
+) -> command_types.CaptureImageCommand:
+    text = "Capturing an image"
+    if resolution:
+        text += f" with resolution {resolution[0]}x{resolution[1]}"
+    if zoom:
+        text += f" zoom of {zoom}X"
+    if contrast:
+        text += f" contrast of {contrast}%"
+    if brightness:
+        text += f" brightness of {brightness}%"
+    if saturation:
+        text += f" saturation of {saturation}%"
+    text += "."
+    return {
+        "name": command_types.CaptureImageCommand,
+        "payload": {
+            "text": text,
+            "resolution": resolution,
+            "zoom": zoom,
+            "contrast": contrast,
+            "brightness": brightness,
+            "saturation": saturation,
+        },
     }
 
 

--- a/api/src/opentrons/legacy_commands/types.py
+++ b/api/src/opentrons/legacy_commands/types.py
@@ -636,12 +636,14 @@ class MoveToDisposalLocationCommand(TypedDict):
 class MoveLabwareCommandPayload(TextOnlyPayload):
     pass
 
+
 class CaptureImageCommandPayload(TextOnlyPayload):
     resolution: Optional[Tuple[int, int]]
     zoom: Optional[float]
     contrast: Optional[float]
     brightness: Optional[float]
     saturation: Optional[float]
+
 
 class LiquidClassCommandPayload(TextOnlyPayload, SingleInstrumentPayload):
     liquid_class: LiquidClass
@@ -697,9 +699,11 @@ class MoveLabwareCommand(TypedDict):
     name: Literal["command.MOVE_LABWARE"]
     payload: MoveLabwareCommandPayload
 
+
 class CaptureImageCommand(TypedDict):
     name: Literal["command.CAPTURE_IMAGE"]
     payload: CaptureImageCommandPayload
+
 
 class SealCommand(TypedDict):
     name: Literal["command.SEAL"]

--- a/api/src/opentrons/legacy_commands/types.py
+++ b/api/src/opentrons/legacy_commands/types.py
@@ -854,6 +854,7 @@ Command = Union[
     PressurizeCommand,
     ConfigureForVolumeCommand,
     ConfigureNozzleLayoutCommand,
+    CaptureImageCommand,
     # Robot commands
     RobotMoveToCommand,
     RobotMoveAxisToCommand,
@@ -928,6 +929,7 @@ CommandPayload = Union[
     PressurizeCommandPayload,
     ConfigureForVolumePayload,
     ConfigureNozzleLayoutPayload,
+    CaptureImageCommandPayload,
     # Robot payloads
     RobotMoveToCommandPayload,
     RobotMoveAxisRelativeCommandPayload,

--- a/api/src/opentrons/legacy_commands/types.py
+++ b/api/src/opentrons/legacy_commands/types.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from typing_extensions import Literal, Final, TypedDict
-from typing import Optional, List, Sequence, TYPE_CHECKING, Union
+from typing import Optional, List, Sequence, TYPE_CHECKING, Union, Tuple
 from opentrons.hardware_control.modules import ThermocyclerStep
 
 if TYPE_CHECKING:
@@ -25,6 +25,7 @@ PAUSE: Final = "command.PAUSE"
 RESUME: Final = "command.RESUME"
 COMMENT: Final = "command.COMMENT"
 MOVE_LABWARE: Final = "command.MOVE_LABWARE"
+CAPTURE_IMAGE: Final = "command.CAPTURE_IMAGE"
 
 # Pipette #
 
@@ -635,6 +636,12 @@ class MoveToDisposalLocationCommand(TypedDict):
 class MoveLabwareCommandPayload(TextOnlyPayload):
     pass
 
+class CaptureImageCommandPayload(TextOnlyPayload):
+    resolution: Optional[Tuple[int, int]]
+    zoom: Optional[float]
+    contrast: Optional[float]
+    brightness: Optional[float]
+    saturation: Optional[float]
 
 class LiquidClassCommandPayload(TextOnlyPayload, SingleInstrumentPayload):
     liquid_class: LiquidClass
@@ -690,6 +697,9 @@ class MoveLabwareCommand(TypedDict):
     name: Literal["command.MOVE_LABWARE"]
     payload: MoveLabwareCommandPayload
 
+class CaptureImageCommand(TypedDict):
+    name: Literal["command.CAPTURE_IMAGE"]
+    payload: CaptureImageCommandPayload
 
 class SealCommand(TypedDict):
     name: Literal["command.SEAL"]

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -1822,7 +1822,7 @@ class ProtocolContext(CommandPublisher):
             )
         return None
 
-    @requires_version(2, 28)
+    @requires_version(2, 27)
     def capture_image(
         self,
         home_before: Optional[bool] = False,
@@ -1843,7 +1843,7 @@ class ProtocolContext(CommandPublisher):
         :param brightness: Brightness level to be applied to an image, range is 0% to 100%.
         :param saturation: Saturation level to be applied to an image, range is 0% to 100%.
 
-        .. versionadded:: 2.28
+        .. versionadded:: 2.27
 
         """
         if home_before is True:
@@ -1851,7 +1851,7 @@ class ProtocolContext(CommandPublisher):
 
         with publish_context(
             broker=self.broker,
-            command=cmds.capture_Image(
+            command=cmds.capture_image(
                 resolution=resolution,
                 zoom=zoom,
                 contrast=contrast,

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -1821,7 +1821,7 @@ class ProtocolContext(CommandPublisher):
                 core_map=self._core_map,
             )
         return None
-    
+
     @requires_version(2, 28)
     def capture_image(
         self,
@@ -1834,7 +1834,7 @@ class ProtocolContext(CommandPublisher):
         saturation: Optional[float] = None,
     ) -> None:
         """Capture an image using the camera. Captured images get saved as a result of the protocol run.
-        
+
         :param home_before: Boolean to home the pipette before capturing an image.
         :param filename: Filename to use when saving the captured image as a file.
         :param resolution: Width/height tuple to determine the resolution to use when capturing an image.

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -11,6 +11,7 @@ from typing import (
     Union,
     Mapping,
     cast,
+    Tuple,
 )
 
 from opentrons_shared_data.labware.types import LabwareDefinition
@@ -1818,6 +1819,53 @@ class ProtocolContext(CommandPublisher):
                 api_version=self._api_version,
                 protocol_core=self._core,
                 core_map=self._core_map,
+            )
+        return None
+    
+    @requires_version(2, 28)
+    def capture_image(
+        self,
+        home_before: Optional[bool] = False,
+        filename: Optional[str] = None,
+        resolution: Optional[Tuple[int, int]] = None,
+        zoom: Optional[float] = None,
+        contrast: Optional[float] = None,
+        brightness: Optional[float] = None,
+        saturation: Optional[float] = None,
+    ) -> None:
+        """Capture an image using the camera. Captured images get saved as a result of the protocol run.
+        
+        :param home_before: Boolean to home the pipette before capturing an image.
+        :param filename: Filename to use when saving the captured image as a file.
+        :param resolution: Width/height tuple to determine the resolution to use when capturing an image.
+        :param zoom: Optional zoom level, with minimum/default of 1x zoom and maximum of 2x zoom.
+        :param contrast: Contrast level to be applied to an image, range is 0% to 100%.
+        :param brightness: Brightness level to be applied to an image, range is 0% to 100%.
+        :param saturation: Saturation level to be applied to an image, range is 0% to 100%.
+
+        .. versionadded:: 2.28
+
+        """
+        if home_before is True:
+            self._core.home()
+
+        with publish_context(
+            broker=self.broker,
+            command=cmds.capture_Image(
+                resolution=resolution,
+                zoom=zoom,
+                contrast=contrast,
+                brightness=brightness,
+                saturation=saturation,
+            ),
+        ):
+            self._core.capture_image(
+                filename=filename,
+                resolution=resolution,
+                zoom=zoom,
+                contrast=contrast,
+                brightness=brightness,
+                saturation=saturation,
             )
         return None
 

--- a/api/tests/opentrons/protocol_api/test_protocol_context.py
+++ b/api/tests/opentrons/protocol_api/test_protocol_context.py
@@ -2229,6 +2229,34 @@ def test_customize_existing_liquid_class(
     )
 
 
+def test_capture_image(
+    decoy: Decoy,
+    mock_core: ProtocolCore,
+    subject: ProtocolContext,
+) -> None:
+    """It should handle the core execution for capture image using the provided parameters or defaults."""
+    subject.capture_image(
+        home_before=True,
+        filename="coolpic",
+        resolution=(1920, 1080),
+        zoom=2,
+        contrast=50,
+        saturation=52,
+    )
+
+    decoy.verify(mock_core.home())
+    decoy.verify(
+        mock_core.capture_image(
+            filename="coolpic",
+            resolution=(1920, 1080),
+            zoom=2,
+            contrast=50,
+            brightness=None,
+            saturation=52,
+        )
+    )
+
+
 def test_bundled_data(
     mock_core_map: LoadedCoreMap, mock_deck: Deck, mock_core: ProtocolCore
 ) -> None:


### PR DESCRIPTION
# Overview
EXEC-1951

Implements the `capture_image` PAPI command. This includes the `home_before` command behavior to give the option of a "clear airspace" to take pictures with.

## Test Plan and Hands on Testing

- [x] Unit test coverage
- [x] The following protocol should pass analysis and should generate photos on a flex:
```
from opentrons.protocol_api import ProtocolContext

metadata = {
    "protocolName": "Flex Stacker Camera Test",
    "author": "Opentrons <protocols@opentrons.com>",
}
requirements = {
    "robotType": "Flex",
    "apiLevel": "2.28",
}

def run(protocol: ProtocolContext) -> None:
    """Protocol."""
    tiprack = protocol.load_labware("opentrons_flex_96_tiprack_200ul", "C2", adapter="opentrons_flex_96_tiprack_adapter")
    #CONTRAST PICS
    protocol.capture_image(home_before=True, filename="2contrast_10", zoom=2.0, contrast=10)
    protocol.capture_image(home_before=True, filename="2contrast_50", zoom=2.0, contrast=50)
    protocol.capture_image(home_before=True, filename="2contrast_100", zoom=2.0, contrast=100)

    #BRIGHTNESS PICS
    protocol.capture_image(home_before=True, filename="2brightness_0", zoom=2.0, brightness=0.0)
    protocol.capture_image(home_before=True, filename="2brightness_50", zoom=2.0, brightness=50.0)
    protocol.capture_image(home_before=True, filename="2brightness100", zoom=2.0, brightness=100.0)

    #SATURATION PICS
    protocol.capture_image(home_before=True, filename="2saturation_0",zoom=2.0, saturation=0)
    protocol.capture_image(home_before=True, filename="2saturation_50",zoom=2.0, saturation=50)
    protocol.capture_image(home_before=True, filename="2saturation_100",zoom=2.0, saturation=100)
```

## Changelog
added `capture_image` to protocol context.

## Review requests
All good with the doc string?

## Risk assessment
Low - new behavior