### PR TITLE
fix(api): Migrate the max API version back to 2 27

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/_default_labware_versions.py
+++ b/api/src/opentrons/protocol_api/core/engine/_default_labware_versions.py
@@ -142,8 +142,6 @@ DEFAULT_LABWARE_VERSIONS: DefaultLabwareVersions = {
         "opentrons_96_aluminumblock_generic_pcr_strip_200ul": 4,
         "usascientific_12_reservoir_22ml": 4,
         "usascientific_96_wellplate_2.4ml_deep": 4,
-    },
-    APIVersion(2, 28): {
         "opentrons_tough_universal_lid": 2,
     },
 }

--- a/api/src/opentrons/protocols/api_support/definitions.py
+++ b/api/src/opentrons/protocols/api_support/definitions.py
@@ -1,6 +1,6 @@
 from .types import APIVersion
 
-MAX_SUPPORTED_VERSION = APIVersion(2, 28)
+MAX_SUPPORTED_VERSION = APIVersion(2, 27)
 """The maximum supported protocol API version in this release."""
 
 MIN_SUPPORTED_VERSION = APIVersion(2, 0)


### PR DESCRIPTION
# Overview
The API was bumped to version 2.28 to accommodate the universal lid, however the API was already bumped to v2.27 for the 8.8 release, making the API 2.28 bump redundant. Historically speaking API 2.26 was used for the 8.7 release.

## Test Plan and Hands on Testing

## Changelog
Reverted `MAX_SUPPORTED_VERSION` back to 2.27
Included the `opentrons_tough_universal_lid` v2 definition in the default labware version list for 2.27

## Review requests
Nothing else that I could see was using API 2.28, did I miss anything?

## Risk assessment
Low?