### PR TITLE
feat(api, robot-server): Error on disk space violations

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/absorbance_reader/read.py
+++ b/api/src/opentrons/protocol_engine/commands/absorbance_reader/read.py
@@ -9,13 +9,12 @@ from pydantic.json_schema import SkipJsonSchema
 
 from opentrons_shared_data.data_files import MimeType
 from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
-from ...errors import CannotPerformModuleAction, StorageLimitReachedError
+from ...errors import CannotPerformModuleAction
 from ...errors.error_occurrence import ErrorOccurrence
 
 from ...resources.file_provider import (
     PlateReaderData,
     ReadData,
-    MAXIMUM_FILE_LIMIT,
     ReadCmdFileNameMetadata,
 )
 from ...resources import FileProvider
@@ -94,21 +93,6 @@ class ReadAbsorbanceImpl(
             raise CannotPerformModuleAction(
                 "Absorbance Plate Reader can't read a plate with the lid open. Call `close_lid()` first."
             )
-
-        # TODO: we need to return a file ID and increase the file count even when a moduel is not attached
-        if (
-            params.fileName is not None
-            and abs_reader_substate.configured_wavelengths is not None
-        ):
-            # Validate that the amount of files we are about to generate does not put us higher than the limit
-            if (
-                self._state_view.files.get_filecount()
-                + len(abs_reader_substate.configured_wavelengths)
-                > MAXIMUM_FILE_LIMIT
-            ):
-                raise StorageLimitReachedError(
-                    message=f"Attempt to write file {params.fileName} exceeds file creation limit of {MAXIMUM_FILE_LIMIT} files."
-                )
 
         asbsorbance_result: Dict[int, Dict[str, float]] = {}
         transform_results = []

--- a/api/src/opentrons/protocol_engine/commands/capture_image.py
+++ b/api/src/opentrons/protocol_engine/commands/capture_image.py
@@ -11,13 +11,11 @@ from opentrons_shared_data.data_files import MimeType
 from ..types import PreconditionTypes
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
 from ..errors import (
-    StorageLimitReachedError,
     CameraDisabledError,
 )
 from ..errors.error_occurrence import ErrorOccurrence
 
 from ..resources.file_provider import (
-    MAXIMUM_FILE_LIMIT,
     ImageCaptureCmdFileNameMetadata,
 )
 from ..resources import FileProvider
@@ -122,13 +120,6 @@ class CaptureImageImpl(
         state_update.precondition_update = update_types.PreconditionUpdate(
             {PreconditionTypes.IS_CAMERA_USED: True}
         )
-
-        # todo (chb, 2025-10-13): Implement App image parameter setting pass through when core override parameters not provided.
-
-        if self._state_view.files.get_filecount() + 1 > MAXIMUM_FILE_LIMIT:
-            raise StorageLimitReachedError(
-                message=f"Attempt to write image file exceeds file creation limit of {MAXIMUM_FILE_LIMIT} files."
-            )
 
         # Handle capturing an image with the CameraProvider
         camera_settings = await self._camera_provider.get_camera_settings()

--- a/api/src/opentrons/protocol_engine/resources/file_provider.py
+++ b/api/src/opentrons/protocol_engine/resources/file_provider.py
@@ -13,8 +13,6 @@ from opentrons_shared_data.data_files import (
 
 from ..errors import StorageLimitReachedError
 
-MAXIMUM_FILE_LIMIT = 400
-
 
 @dataclass(frozen=True)
 class FileNameCmdMetadata:
@@ -162,7 +160,6 @@ class FileProvider:
         data_files_write_file_cb: Optional[
             Callable[[FileData], Awaitable[DataFileInfo]]
         ] = None,
-        data_files_filecount: Optional[Callable[[], Awaitable[int]]] = None,
     ) -> None:
         """Initialize the interface callbacks of the File Provider for data file handling within the Protocol Engine.
 
@@ -171,7 +168,6 @@ class FileProvider:
             data_files_filecount: Callback to check the amount of data files already present in the data files directory.
         """
         self._data_files_write_file_cb = data_files_write_file_cb
-        self._data_files_filecount = data_files_filecount
         self._run_metadata: RunFileNameMetadata | None = None
 
     async def write_file(
@@ -181,21 +177,16 @@ class FileProvider:
         command_metadata: CommandFileNameMetadata,
     ) -> DataFileInfo:
         """Writes arbitrary data to a file in the Data Files directory. Returns the `DataFileInfo` of the file created."""
-        if self._data_files_filecount is not None:
-            file_count = await self._data_files_filecount()
-            if file_count >= MAXIMUM_FILE_LIMIT:
-                raise StorageLimitReachedError(
-                    f"Not enough space to store file. Maximum file limit of {MAXIMUM_FILE_LIMIT} reached."
-                )
-            if self._data_files_write_file_cb is not None:
-                assert self._run_metadata is not None
-                file_data = FileData.build(
-                    data=data,
-                    mime_type=mime_type,
-                    command_metadata=command_metadata,
-                    run_metadata=self._run_metadata,
-                )
-                return await self._data_files_write_file_cb(file_data)
+        if self._data_files_write_file_cb is not None:
+            assert self._run_metadata is not None
+            file_data = FileData.build(
+                data=data,
+                mime_type=mime_type,
+                command_metadata=command_metadata,
+                run_metadata=self._run_metadata,
+            )
+
+            return await self._data_files_write_file_cb(file_data)
         # If we are in an analysis or simulation state, return an empty `DataFileInfo`
         return DataFileInfo(
             id="",

--- a/api/src/opentrons/protocol_engine/resources/file_provider.py
+++ b/api/src/opentrons/protocol_engine/resources/file_provider.py
@@ -11,8 +11,6 @@ from opentrons_shared_data.data_files import (
     RunFileNameMetadata,
 )
 
-from ..errors import StorageLimitReachedError
-
 
 @dataclass(frozen=True)
 class FileNameCmdMetadata:

--- a/api/src/opentrons/protocol_engine/resources/file_provider.py
+++ b/api/src/opentrons/protocol_engine/resources/file_provider.py
@@ -176,7 +176,13 @@ class FileProvider:
         mime_type: MimeType,
         command_metadata: CommandFileNameMetadata,
     ) -> DataFileInfo:
-        """Writes arbitrary data to a file in the Data Files directory. Returns the `DataFileInfo` of the file created."""
+        """Writes arbitrary data to a file in the Data Files directory.
+
+        Returns the `DataFileInfo` of the file created.
+
+        Raises:
+            Note that the callback may raise a StorageLimitReachedError.
+        """
         if self._data_files_write_file_cb is not None:
             assert self._run_metadata is not None
             file_data = FileData.build(

--- a/api/tests/opentrons/protocol_engine/commands/absorbance_reader/test_read.py
+++ b/api/tests/opentrons/protocol_engine/commands/absorbance_reader/test_read.py
@@ -9,7 +9,6 @@ from opentrons.drivers.types import ABSMeasurementMode, ABSMeasurementConfig
 from opentrons.hardware_control.modules import AbsorbanceReader
 from opentrons.protocol_engine.errors import (
     CannotPerformModuleAction,
-    StorageLimitReachedError,
 )
 
 from opentrons.protocol_engine.execution import EquipmentHandler
@@ -187,49 +186,4 @@ async def test_read_raises_cannot_preform_action(
     decoy.when(mabsorbance_module_substate.is_lid_on).then_return(False)
 
     with pytest.raises(CannotPerformModuleAction):
-        await subject.execute(params=params)
-
-
-async def test_read_raises_storage_limit(
-    decoy: Decoy,
-    state_view: StateView,
-    equipment: EquipmentHandler,
-    file_provider: FileProvider,
-) -> None:
-    """It should raise StorageLimitReachedError when not configured/lid is not on."""
-    subject = ReadAbsorbanceImpl(
-        state_view=state_view, equipment=equipment, file_provider=file_provider
-    )
-
-    params = ReadAbsorbanceParams(moduleId="unverified-module-id", fileName="test")
-
-    mabsorbance_module_substate = decoy.mock(cls=AbsorbanceReaderSubState)
-    absorbance_module_hw = decoy.mock(cls=AbsorbanceReader)
-
-    verified_module_id = AbsorbanceReaderId("module-id")
-
-    decoy.when(
-        state_view.modules.get_absorbance_reader_substate("unverified-module-id")
-    ).then_return(mabsorbance_module_substate)
-
-    decoy.when(mabsorbance_module_substate.module_id).then_return(verified_module_id)
-
-    decoy.when(equipment.get_module_hardware_api(verified_module_id)).then_return(
-        absorbance_module_hw
-    )
-    decoy.when(await absorbance_module_hw.start_measure()).then_return([[1.2, 1.3]])
-
-    decoy.when(absorbance_module_hw._measurement_config).then_return(
-        ABSMeasurementConfig(
-            measure_mode=ABSMeasurementMode.SINGLE,
-            sample_wavelengths=[1, 2],
-            reference_wavelength=None,
-        )
-    )
-    decoy.when(mabsorbance_module_substate.configured_wavelengths).then_return(
-        [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
-    )
-
-    decoy.when(state_view.files.get_filecount()).then_return(390)
-    with pytest.raises(StorageLimitReachedError):
         await subject.execute(params=params)

--- a/api/tests/opentrons/protocol_engine/commands/test_capture_image.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_capture_image.py
@@ -22,7 +22,6 @@ from opentrons.protocol_engine.errors import (
     CameraCaptureError,
     CameraDisabledError,
     CameraSettingsInvalidError,
-    StorageLimitReachedError,
 )
 from opentrons.system.camera import image_capture
 
@@ -65,25 +64,6 @@ def camera_provider_image_capture() -> CameraProvider:
     return CameraProvider(
         camera_settings_callback=None, image_capture_callback=image_capture
     )
-
-
-async def test_capture_image_raises_storage_limit(
-    decoy: Decoy,
-    state_view: StateView,
-    file_provider: FileProvider,
-    camera_provider: CameraProvider,
-) -> None:
-    """It should raise StorageLimitReachedError when it would generate too many images."""
-    subject = CaptureImageImpl(
-        state_view=state_view,
-        file_provider=file_provider,
-        camera_provider=camera_provider,
-    )
-    params = CaptureImageParams(fileName=None)
-
-    decoy.when(state_view.files.get_filecount()).then_return(400)
-    with pytest.raises(StorageLimitReachedError):
-        await subject.execute(params=params)
 
 
 @pytest.mark.parametrize(

--- a/robot-server/robot_server/file_provider/fastapi_dependencies.py
+++ b/robot-server/robot_server/file_provider/fastapi_dependencies.py
@@ -12,18 +12,25 @@ from robot_server.data_files.dependencies import (
 )
 from robot_server.data_files.data_files_store import DataFilesStore
 from opentrons.protocol_engine.resources.file_provider import FileProvider
+from robot_server.disk_monitor.dependencies import get_disk_monitor
+from robot_server.disk_monitor.monitor import DiskMonitor
+from robot_server.settings import get_settings, RobotServerSettings
 
 
 async def get_file_provider_executor(
     data_files_directory: Annotated[Path, fastapi.Depends(get_data_files_directory)],
     data_files_store: Annotated[DataFilesStore, fastapi.Depends(get_data_files_store)],
     images_directory: Annotated[Path, fastapi.Depends(get_images_directory)],
+    disk_monitor: Annotated[DiskMonitor, fastapi.Depends(get_disk_monitor)],
+    settings: Annotated[RobotServerSettings, fastapi.Depends(get_settings)],
 ) -> FileProviderExecutor:
     """Return the server's singleton `FileProviderExecutor` which provides the engine related callbacks for FileProvider."""
     file_provider_wrapper = FileProviderExecutor(
         data_files_directory=data_files_directory,
         data_files_store=data_files_store,
         images_directory=images_directory,
+        disk_monitor=disk_monitor,
+        settings=settings,
     )
 
     return file_provider_wrapper

--- a/robot-server/robot_server/file_provider/fastapi_dependencies.py
+++ b/robot-server/robot_server/file_provider/fastapi_dependencies.py
@@ -44,7 +44,6 @@ async def get_file_provider(
     """Return the engine `FileProvider` which accepts callbacks from FileProviderWrapper."""
     file_provider = FileProvider(
         data_files_write_file_cb=file_provider_executor.write_file_cb,
-        data_files_filecount=file_provider_executor.filecount_cb,
     )
 
     return file_provider

--- a/robot-server/robot_server/file_provider/provider.py
+++ b/robot-server/robot_server/file_provider/provider.py
@@ -62,7 +62,11 @@ class FileProviderExecutor:
         self,
         file_data: FileData,
     ) -> DataFileInfo:
-        """Write the provided file data to disk. Returns the `DataFileInfo` of the created file."""
+        """Write the provided file data to disk. Returns the `DataFileInfo` of the created file.
+
+        Raises:
+            A StorageLimitReachedError on disk space limit violations.
+        """
         if (
             isinstance(file_data.command_metadata, ImageCaptureCmdFileNameMetadata)
             and self._disk_monitor.is_images_directory_over_limit()

--- a/robot-server/robot_server/file_provider/provider.py
+++ b/robot-server/robot_server/file_provider/provider.py
@@ -116,11 +116,6 @@ class FileProviderExecutor:
             await self._data_files_store.insert_output_file(output_file_info)
             return file_info
 
-    async def filecount_cb(self) -> int:
-        """Return the current count of generated files stored within the data files directory."""
-        data_file_usage_info = self._data_files_store.get_usage_info(generated=True)
-        return len(data_file_usage_info)
-
     def _format_filename(self, file_data: FileData, file_id: str) -> str:
         """Build the finalized filename."""
         if isinstance(file_data.command_metadata, ReadCmdFileNameMetadata):

--- a/robot-server/robot_server/file_provider/provider.py
+++ b/robot-server/robot_server/file_provider/provider.py
@@ -16,10 +16,14 @@ from opentrons_shared_data.data_files import (
     DataFileInfo,
     CmdDataFileInfo,
 )
+from robot_server.settings import get_settings, RobotServerSettings
 from ..service.dependencies import get_current_time, get_unique_id
 from robot_server.data_files.data_files_store import (
     DataFilesStore,
 )
+from opentrons.protocol_engine.errors import StorageLimitReachedError
+from robot_server.disk_monitor.dependencies import get_disk_monitor
+from robot_server.disk_monitor.monitor import DiskMonitor
 from opentrons.protocol_engine.resources.file_provider import (
     FileData,
     ReadCmdFileNameMetadata,
@@ -35,6 +39,8 @@ class FileProviderExecutor:
         data_files_directory: Annotated[Path, Depends(get_data_files_directory)],
         images_directory: Annotated[Path, Depends(get_images_directory)],
         data_files_store: Annotated[DataFilesStore, Depends(get_data_files_store)],
+        disk_monitor: Annotated[DiskMonitor, Depends(get_disk_monitor)],
+        settings: Annotated[RobotServerSettings, Depends(get_settings)],
     ) -> None:
         """Initialize the file provider executor.
 
@@ -45,6 +51,9 @@ class FileProviderExecutor:
         self._data_files_directory = data_files_directory
         self._images_directory = images_directory
         self._data_files_store = data_files_store
+        self._disk_monitor = disk_monitor
+        self._images_directory_max_size_mb = settings.images_directory_max_size_mb
+        self._system_low_space_threshold_mb = settings.system_low_space_threshold_mb
 
         # data file store is not generally safe for concurrent access.
         self._lock = asyncio.Lock()
@@ -54,6 +63,21 @@ class FileProviderExecutor:
         file_data: FileData,
     ) -> DataFileInfo:
         """Write the provided file data to disk. Returns the `DataFileInfo` of the created file."""
+        if (
+            isinstance(file_data.command_metadata, ImageCaptureCmdFileNameMetadata)
+            and self._disk_monitor.is_images_directory_over_limit()
+        ):
+            raise StorageLimitReachedError(
+                message=f"Attempt to write file to disk exceeds file the "
+                f"image file storage limit of {self._images_directory_max_size_mb}MB"
+            )
+
+        if self._disk_monitor.is_disk_space_low():
+            raise StorageLimitReachedError(
+                message=f"Attempt to write file to disk exceeds file the "
+                f"system free disk space requirement of {self._system_low_space_threshold_mb}MB"
+            )
+
         async with self._lock:
             file_id = await get_unique_id()
             final_filename = self._format_filename(file_data, file_id)


### PR DESCRIPTION
Closes [EXEC-1963](https://opentrons.atlassian.net/browse/EXEC-1963)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Whenever a protocol command attempts to generate a data file, we should check if:

- The overall disk space is sufficient.
- If it's an image generating command, that the images directory disk space is sufficient.

If either of these conditions are violated, we should throw a `StorageLimitReachedError`.

Note that 15c409ec4301073703180d28c4cfc0e2de38a894 deprecates the hard file limit error we were using before. This is true for the absorbance reader file output as well - now we exclusively check disk space.


<img width="499" height="356" alt="Screenshot 2025-10-23 at 6 28 17 PM" src="https://github.com/user-attachments/assets/c0bfe6b0-947b-4f94-a769-8ca578e9e135" />

<img width="503" height="336" alt="Screenshot 2025-10-23 at 6 18 10 PM" src="https://github.com/user-attachments/assets/e9c8fc84-5938-4965-ad37-edbf8546af63" />


<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- See images above. These were generated by creating large files on a robot.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Protocol commands that generate data files as output can now fail if disk space is too low.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests
- Am I correctly propagating errors up the call chain? Ie, does the finalized, user-facing  error look correct?
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
- lowish - pretty dang easy to validate behavior here I think
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[EXEC-1963]: https://opentrons.atlassian.net/browse/EXEC-1963?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ