### PR TITLE
refactor(shared-data): getAllLabwareDefs() -> getAllDefinitions() for new code in `edge`

### DIFF
--- a/shared-data/js/__tests__/labwareImages.test.ts
+++ b/shared-data/js/__tests__/labwareImages.test.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs'
 import * as path from 'path'
 import { describe, expect, it } from 'vitest'
 
-import { getAllLabwareDefs, labwareImages } from '../labware'
+import { getAllDefinitions, labwareImages } from '../labware'
 
 const ignoredLoadNames = new Set([
   'opentrons_1_trash_1100ml_fixed',
@@ -22,7 +22,7 @@ const ignoredLoadNames = new Set([
 
 const loadNames = Array.from(
   new Set(
-    Object.keys(getAllLabwareDefs()).map(uri => {
+    Object.keys(getAllDefinitions()).map(uri => {
       const parts = uri.split('/')
       return parts[1] ?? uri
     })

--- a/shared-data/js/labware.ts
+++ b/shared-data/js/labware.ts
@@ -105,7 +105,7 @@ function getAllImages(): Record<string, string> {
 
 const loadNames = Array.from(
   new Set(
-    Object.keys(getAllLabwareDefs()).map(uri => {
+    Object.keys(getAllDefinitions()).map(uri => {
       const parts = uri.split('/')
       return parts[1] ?? uri
     })


### PR DESCRIPTION
# Overview

In the PD 8.6.1 branch, we replaced `getAllLabwareDefs()` with `getAllDefinitions()`, satisfying this old TODO: https://github.com/Opentrons/opentrons/blob/238586e8376170e27b751198be78c749f75498ba/shared-data/js/labware.ts#L71-L75

However, @rclarke0's PR #19088 introduced some new calls to `getAllLabwareDefs()` in `edge` that are not in the PD 8.6.1 branch. So this PR migrates those calls too to unbreak `edge`.

## Test Plan and Hands on Testing

Hopefully the CI tests will pass now.

## Risk assessment

Low-ish.