### PR TITLE
refactor(robot-server, api-client): Add disk utilization details to `/health`

### DIFF
--- a/api-client/src/health/types.ts
+++ b/api-client/src/health/types.ts
@@ -1,3 +1,8 @@
+export interface DiskDetails {
+  systemAvailableMb: number
+  imagesDirectorySizeMb: number
+}
+
 export interface Health {
   name: string
   api_version: string
@@ -8,6 +13,7 @@ export interface Health {
   system_version: string
   maximum_protocol_api_version: [major: number, minor: number]
   minimum_protocol_api_version: [major: number, minor: number]
+  disk_details: DiskDetails
   links: HealthLinks
 }
 

--- a/robot-server/robot_server/health/models.py
+++ b/robot-server/robot_server/health/models.py
@@ -5,6 +5,17 @@ from opentrons_shared_data.deck.types import RobotModel
 from robot_server.service.json_api import BaseResponseBody
 
 
+class DiskDetails(BaseModel):
+    """System disk usage details."""
+
+    systemAvailableMb: float = Field(
+        ..., description="The system's available disk space in MB."
+    )
+    imagesDirectorySizeMb: float = Field(
+        ..., description="The system's images directory disk size in MB."
+    )
+
+
 class HealthLinks(BaseModel):
     """Useful server links."""
 
@@ -119,5 +130,8 @@ class Health(BaseResponseBody):
         default=None,
         description="The robot serial number. Should be used if present; if not present, use result of /server/update/health.",
         examples=["OT2CEP20190604A02"],
+    )
+    disk_details: DiskDetails = Field(
+        ..., description="Information concerning the system's disk."
     )
     links: HealthLinks

--- a/robot-server/robot_server/health/router.py
+++ b/robot-server/robot_server/health/router.py
@@ -15,10 +15,12 @@ from robot_server.persistence.fastapi_dependencies import (
     get_sql_engine as ensure_sql_engine_is_ready,
 )
 from robot_server.service.legacy.models import V1BasicResponse
+from robot_server.disk_monitor.monitor import DiskMonitor
+from robot_server.disk_monitor.dependencies import get_disk_monitor
 
 from opentrons_shared_data.robot.types import RobotType
 
-from .models import Health, HealthLinks
+from .models import Health, HealthLinks, DiskDetails
 
 _log = logging.getLogger(__name__)
 
@@ -138,6 +140,7 @@ async def get_health(
     sql_engine: Annotated[object, Depends(ensure_sql_engine_is_ready)],
     versions: Annotated[ComponentVersions, Depends(get_versions)],
     robot_type: Annotated[RobotType, Depends(get_robot_type)],
+    disk_monitor: Annotated[DiskMonitor, Depends(get_disk_monitor)],
 ) -> Health:
     """Get information about the health of the robot server.
 
@@ -173,4 +176,8 @@ async def get_health(
         robot_model=robot_type,
         links=health_links,
         robot_serial=(await hardware.get_serial_number()),
+        disk_details=DiskDetails(
+            systemAvailableMb=disk_monitor.get_available_disk_space_mb(),
+            imagesDirectorySizeMb=disk_monitor.get_images_directory_size_mb(),
+        ),
     )

--- a/robot-server/tests/health/test_health_router.py
+++ b/robot-server/tests/health/test_health_router.py
@@ -1,23 +1,61 @@
 """Tests for the /health router."""
 import pytest
 from typing import Dict, Iterator
+from pathlib import Path
 from mock import MagicMock, patch
-from starlette.testclient import TestClient
+from decoy import Decoy
 
 from opentrons.protocol_api import MAX_SUPPORTED_VERSION, MIN_SUPPORTED_VERSION
+from opentrons_shared_data.robot.types import RobotType
 
-from robot_server.health.router import ComponentVersions, get_versions, _get_version
+from robot_server.health.router import (
+    ComponentVersions,
+    get_versions,
+    _get_version,
+    get_health,
+)
+from robot_server.disk_monitor.monitor import DiskMonitor
 
 
-def test_get_health(
-    api_client: TestClient, hardware: MagicMock, versions: MagicMock
+@pytest.fixture
+def images_directory(tmp_path: Path) -> Path:
+    """Return a directory for storing camera capture files."""
+    subdirectory = tmp_path / "images"
+    subdirectory.mkdir()
+    return subdirectory
+
+
+@pytest.fixture
+def disk_monitor(decoy: Decoy) -> DiskMonitor:
+    """Get a mocked out DiskMonitor interface."""
+    mock = decoy.mock(cls=DiskMonitor)
+    decoy.when(mock.get_available_disk_space_mb()).then_return(1000.0)
+    decoy.when(mock.get_images_directory_size_mb()).then_return(500.0)
+    return mock
+
+
+async def test_get_health(
+    hardware: MagicMock,
+    disk_monitor: DiskMonitor,
+    images_directory: Path,
 ) -> None:
-    """Test GET /health."""
+    """Test get_health function."""
     hardware.fw_version = "FW111"
     hardware.board_revision = "BR2.1"
     hardware.get_serial_number.return_value = "mytestserial"
-    versions.return_value = ComponentVersions(
+
+    versions = ComponentVersions(
         api_version="mytestapiversion", system_version="mytestsystemversion"
+    )
+
+    robot_type: RobotType = "OT-2 Standard"
+
+    result = await get_health(
+        hardware=hardware,
+        sql_engine=MagicMock(),
+        versions=versions,
+        robot_type=robot_type,
+        disk_monitor=disk_monitor,
     )
 
     expected = {
@@ -43,24 +81,37 @@ def test_get_health(
             "systemTime": "/system/time",
         },
         "robot_serial": "mytestserial",
+        "disk_details": {
+            "systemAvailableMb": 1000.0,
+            "imagesDirectorySizeMb": 500.0,
+        },
     }
 
-    resp = api_client.get("/health")
-    text = resp.json()
-
-    assert resp.status_code == 200
-    assert text == expected
+    assert result.model_dump(mode="json", exclude_none=True) == expected
 
 
-def test_get_health_with_none_version(
-    api_client: TestClient, hardware: MagicMock, versions: MagicMock
+async def test_get_health_with_none_version(
+    hardware: MagicMock,
+    disk_monitor: DiskMonitor,
+    images_directory: Path,
 ) -> None:
-    """Test GET /health with no serial number."""
+    """Test get_health function with no serial number."""
     hardware.fw_version = "FW111"
     hardware.board_revision = "BR2.1"
     hardware.get_serial_number.return_value = None
-    versions.return_value = ComponentVersions(
+
+    versions = ComponentVersions(
         api_version="mytestapiversion", system_version="mytestsystemversion"
+    )
+
+    robot_type: RobotType = "OT-2 Standard"
+
+    result = await get_health(
+        hardware=hardware,
+        sql_engine=MagicMock(),
+        versions=versions,
+        robot_type=robot_type,
+        disk_monitor=disk_monitor,
     )
 
     expected = {
@@ -85,13 +136,13 @@ def test_get_health_with_none_version(
             "apiSpec": "/openapi.json",
             "systemTime": "/system/time",
         },
+        "disk_details": {
+            "systemAvailableMb": 1000.0,
+            "imagesDirectorySizeMb": 500.0,
+        },
     }
 
-    resp = api_client.get("/health")
-    text = resp.json()
-
-    assert resp.status_code == 200
-    assert text == expected
+    assert result.model_dump(mode="json", exclude_none=True) == expected
 
 
 @pytest.fixture

--- a/robot-server/tests/integration/fixtures.py
+++ b/robot-server/tests/integration/fixtures.py
@@ -39,6 +39,12 @@ def check_health_response(response: Response) -> None:
     }
     got = response.json()
 
+    # We avoid checking the disk details in `expected` due to testing environment variance.
+    assert "disk_details" in got
+    assert "systemAvailableMb" in got["disk_details"]
+    assert "imagesDirectorySizeMb" in got["disk_details"]
+    got.pop("disk_details", None)
+
     assert got == expected, f"health response failed:\n {got}"
 
 
@@ -71,6 +77,12 @@ def check_ot3_health_response(response: Response) -> None:
         "robot_serial": "simulator",
     }
     got = response.json()
+
+    # We avoid checking the disk details in `expected` due to testing environment variance.
+    assert "disk_details" in got
+    assert "systemAvailableMb" in got["disk_details"]
+    assert "imagesDirectorySizeMb" in got["disk_details"]
+    got.pop("disk_details", None)
 
     assert got == expected, f"health response failed:\n {got}"
 


### PR DESCRIPTION
Closes [EXEC-2003](https://opentrons.atlassian.net/browse/EXEC-2003)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Adds disk usage details to `/health`, providing clients for the ability to query for general disk availability (in mb) and the current size of the images directory (in mb).

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- Verified `/health` contains disk utilization details.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[EXEC-2003]: https://opentrons.atlassian.net/browse/EXEC-2003?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ