### PR TITLE
refactor(app,components): more renaming getAllLabwareDefs() -> getAllDefinitions()

### DIFF
--- a/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useFailedLabwareUtils.test.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useFailedLabwareUtils.test.tsx
@@ -20,7 +20,7 @@ vi.mock('@opentrons/shared-data', async () => {
   return {
     ...actual,
     getLabwareDisplayName: vi.fn(() => 'Mock Labware Name'),
-    getAllLabwareDefs: vi.fn(() => ({
+    getAllDefinitions: vi.fn(() => ({
       'opentrons/thermoscientificnunc_96_wellplate_1300ul/1': {
         some: 'definition',
       },
@@ -46,7 +46,7 @@ vi.mock('@opentrons/shared-data', async () => {
   return {
     ...actual,
     getLabwareDisplayName: vi.fn(() => 'Mock Labware Name'),
-    getAllLabwareDefs: vi.fn(() => ({
+    getAllDefinitions: vi.fn(() => ({
       'opentrons/thermoscientificnunc_96_wellplate_1300ul/1': {
         some: 'definition',
       },

--- a/components/src/hardware-sim/Pipette/PipetteRender.stories.tsx
+++ b/components/src/hardware-sim/Pipette/PipetteRender.stories.tsx
@@ -1,6 +1,6 @@
 import { Fragment } from 'react'
 
-import { getAllLabwareDefs, getAllPipetteNames } from '@opentrons/shared-data'
+import { getAllDefinitions, getAllPipetteNames } from '@opentrons/shared-data'
 
 import { RobotWorkSpace } from '../Deck'
 import { LabwareRender } from '../Labware'
@@ -11,12 +11,12 @@ import type { LabwareDefinition, PipetteName } from '@opentrons/shared-data'
 
 const DECK_MAP_VIEWBOX = '0 -140 230 230'
 
-const opentrons300UlTiprack = getAllLabwareDefs().opentrons96Tiprack300UlV1
-const opentrons10UlTiprack = getAllLabwareDefs().opentrons96Tiprack10UlV1
-const nest12Reservoir15ml = getAllLabwareDefs().nest12Reservoir15MlV1
-const axygenReservoir90ml = getAllLabwareDefs().axygen1Reservoir90MlV1
+const opentrons300UlTiprack = getAllDefinitions().opentrons96Tiprack300UlV1
+const opentrons10UlTiprack = getAllDefinitions().opentrons96Tiprack10UlV1
+const nest12Reservoir15ml = getAllDefinitions().nest12Reservoir15MlV1
+const axygenReservoir90ml = getAllDefinitions().axygen1Reservoir90MlV1
 const opentrons6TuberackNest50mlConical =
-  getAllLabwareDefs().opentrons6TuberackNest50MlConicalV1
+  getAllDefinitions().opentrons6TuberackNest50MlConicalV1
 
 const labwareDefMap: Record<string, LabwareDefinition> = {
   [opentrons300UlTiprack.metadata.displayName]: opentrons300UlTiprack,


### PR DESCRIPTION
# Overview

Sorry! There were some more files with references to `getAllLabwareDefs()` that were not caught by the presubmit CI testing.

This PR does a global search-and-replace for `getAllLabwareDefs()` -> `getAllDefinitions()`. This should get all the stragglers now.

## Test Plan and Hands on Testing

CI really really hard.

## Risk assessment

Low-ish.