### PR TITLE
refactor(app): Deprecate `outputFileIds` usage

### DIFF
--- a/app/src/organisms/Desktop/Devices/HistoricalProtocolRun.tsx
+++ b/app/src/organisms/Desktop/Devices/HistoricalProtocolRun.tsx
@@ -16,6 +16,7 @@ import {
   SPACING,
 } from '@opentrons/components'
 
+import { useOutputCsvDataFileIds } from '/app/resources/dataFiles/useCsvDataFiles'
 import { EMPTY_TIMESTAMP } from '/app/resources/runs'
 import { formatInterval } from '/app/transformations/commands'
 import { formatTimestamp } from '/app/transformations/runs'
@@ -45,15 +46,14 @@ export function HistoricalProtocolRun(
   const { t } = useTranslation('run_details')
   const { run, protocolName, robotIsBusy, robotName, protocolKey } = props
   const [drawerOpen, setDrawerOpen] = useState(false)
-  let countRunDataFiles =
+  const csvDataFileIds = useOutputCsvDataFileIds(run.id)
+  const countRunDataFiles =
     'runTimeParameters' in run
       ? run?.runTimeParameters.filter(
           parameter => parameter.type === 'csv_file'
-        ).length
-      : 0
-  if ('outputFileIds' in run) {
-    countRunDataFiles += run.outputFileIds.length
-  }
+        ).length + csvDataFileIds.length
+      : csvDataFileIds.length
+
   const runStatus = run.status
   const runDisplayName = formatTimestamp(run.createdAt)
   let duration = EMPTY_TIMESTAMP

--- a/app/src/organisms/Desktop/Devices/HistoricalProtocolRunDrawer.tsx
+++ b/app/src/organisms/Desktop/Devices/HistoricalProtocolRunDrawer.tsx
@@ -34,6 +34,7 @@ import {
 
 import { LegacyOffsetVector } from '/app/molecules/LegacyOffsetVector'
 import { useIsFlex } from '/app/redux-resources/robots'
+import { useOutputCsvDataFileIds } from '/app/resources/dataFiles/useCsvDataFiles'
 import { useMostRecentCompletedAnalysis } from '/app/resources/runs'
 
 import { DownloadCsvFileLink } from './DownloadCsvFileLink'
@@ -53,6 +54,7 @@ export function HistoricalProtocolRunDrawer(
   const { i18n, t } = useTranslation('run_details')
   const { run, robotName } = props
   const isFlex = useIsFlex(robotName)
+  const csvDataFileIds = useOutputCsvDataFileIds(run.id)
   const allLabwareOffsets: LabwareOffset[] =
     run.labwareOffsets?.sort(
       (a, b) =>
@@ -69,9 +71,7 @@ export function HistoricalProtocolRunDrawer(
           return acc
         }, [])
       : []
-  if ('outputFileIds' in run && run.outputFileIds.length > 0) {
-    runDataFileIds.push(...run.outputFileIds)
-  }
+  runDataFileIds.push(...csvDataFileIds)
 
   const uniqueLabwareOffsets = allLabwareOffsets.filter(
     (offset, index, array) => {

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/__tests__/ProtocolRunHeader.test.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/__tests__/ProtocolRunHeader.test.tsx
@@ -8,6 +8,7 @@ import { useModulesQuery } from '@opentrons/react-api-client'
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
 import { useIsRobotViewable } from '/app/redux-resources/robots'
+import { useOutputCsvDataFileIds } from '/app/resources/dataFiles/useCsvDataFiles'
 import {
   useCloseCurrentRun,
   useNotifyRunQuery,
@@ -39,6 +40,7 @@ vi.mock('../RunHeaderBannerContainer')
 vi.mock('../RunHeaderContent')
 vi.mock('../../../../RunProgressMeter')
 vi.mock('../RunHeaderProtocolName')
+vi.mock('/app/resources/dataFiles/useCsvDataFiles')
 vi.mock('../hooks')
 
 const MOCK_PROTOCOL = 'MOCK_PROTOCOL'
@@ -74,6 +76,7 @@ describe('ProtocolRunHeader', () => {
       isClosingCurrentRun: false,
       closeCurrentRun: vi.fn(),
     })
+    vi.mocked(useOutputCsvDataFileIds).mockReturnValue([])
     vi.mocked(useRunAnalytics).mockImplementation(() => {})
     vi.mocked(useRunErrors).mockReturnValue([] as any)
     vi.mocked(useRunHeaderRunControls).mockReturnValue({} as any)

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/index.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/index.tsx
@@ -13,6 +13,7 @@ import {
 import { useModulesQuery } from '@opentrons/react-api-client'
 
 import { useIsRobotViewable } from '/app/redux-resources/robots'
+import { useOutputCsvDataFileIds } from '/app/resources/dataFiles/useCsvDataFiles'
 import {
   useCloseCurrentRun,
   useNotifyRunQuery,
@@ -90,6 +91,7 @@ export function ProtocolRunHeader(
   }
 
   useRunAnalytics({ runId, robotName, enteredER })
+  const csvDataFileIds = useOutputCsvDataFileIds(runId)
 
   return (
     <>
@@ -108,11 +110,7 @@ export function ProtocolRunHeader(
           isResetRunLoading={isResetRunLoadingRef.current}
           runErrors={runErrors}
           runHeaderModalContainerUtils={runHeaderModalContainerUtils}
-          hasDownloadableFiles={
-            runRecord?.data != null &&
-            'outputFileIds' in runRecord.data &&
-            runRecord.data.outputFileIds.length > 0
-          }
+          hasDownloadableFiles={csvDataFileIds.length > 0}
           {...props}
         />
         <RunHeaderContent

--- a/app/src/resources/dataFiles/constants.ts
+++ b/app/src/resources/dataFiles/constants.ts
@@ -1,0 +1,4 @@
+export const MIME_TYPES = {
+  CSV: 'text/csv',
+  IMAGE: 'image/jpeg',
+} as const

--- a/app/src/resources/dataFiles/useCsvDataFiles.ts
+++ b/app/src/resources/dataFiles/useCsvDataFiles.ts
@@ -1,0 +1,14 @@
+import { useRunDataFileMetadata } from '@opentrons/react-api-client'
+
+import { MIME_TYPES } from './constants'
+
+// Returns the data file ids for all csv files generated as output during a run.
+export function useOutputCsvDataFileIds(runId: string): string[] {
+  const { data } = useRunDataFileMetadata(runId)
+
+  return (
+    data?.data
+      .filter(data => data.mimeType === MIME_TYPES.CSV && data.generated)
+      .map(data => data.id) ?? []
+  )
+}


### PR DESCRIPTION
Closes [EXEC-2004](https://opentrons.atlassian.net/browse/EXEC-2004)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

The app currently assumes the `outputFileIds` from the run record comprises entirely of data file ids that are CSV files, but that is no longer the case. These assumptions lead to unintended behaviors like rendering download links for each individual image file, and trying to parse jpegs as CSVs. We have a hook for providing descriptive metadata about each data file id, so let's create a utility hook that uses that metadata to filter for data file ids that are exclusively csv file ids. 

309592cc2c7537f8d5b77a041ad090d819f1a62a - Creates that hook
92fd723c2594ce0405aca0c759e6b8a9788a0aed - Updates all app usages of `outputFileIds` to utilize this new hook.

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- Verified that the app no longer displays individual download links for images but does so for absorbance reader CSV files.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low - behavior is quite auditable and there are no functional changes here
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[EXEC-2004]: https://opentrons.atlassian.net/browse/EXEC-2004?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ