### PR TITLE
feat(api): Capture an image when an error occurs during a run

### DIFF
--- a/api/src/opentrons/protocol_engine/execution/command_executor.py
+++ b/api/src/opentrons/protocol_engine/execution/command_executor.py
@@ -10,12 +10,15 @@ from opentrons_shared_data.errors.exceptions import (
     EnumeratedError,
     PythonException,
 )
+from opentrons_shared_data.data_files import MimeType
 
 from opentrons.protocol_engine.commands.command import SuccessData
 from opentrons.protocol_engine.notes import make_error_recovery_debug_note
 
 from ..state.state import StateStore
 from ..resources import ModelUtils, FileProvider, CameraProvider
+from ..resources.file_provider import ImageCaptureCmdFileNameMetadata
+from ..resources.camera_provider import ImageParameters
 from ..commands import CommandStatus
 from ..actions import (
     ActionDispatcher,
@@ -36,6 +39,7 @@ from .run_control import RunControlHandler
 from .rail_lights import RailLightsHandler
 from .status_bar import StatusBarHandler
 from .task_handler import TaskHandler
+from ..commands import Command
 
 
 log = getLogger(__name__)
@@ -174,6 +178,7 @@ class CommandExecutor:
                 running_command,
                 None,
             )
+
             note_tracker(make_error_recovery_debug_note(error_recovery_type))
             self._action_dispatcher.dispatch(
                 FailCommandAction(
@@ -186,6 +191,7 @@ class CommandExecutor:
                     type=error_recovery_type,
                 )
             )
+            await self.capture_error_image(running_command)
 
         else:
             if isinstance(result, SuccessData):
@@ -221,7 +227,43 @@ class CommandExecutor:
                         type=error_recovery_type,
                     )
                 )
+                await self.capture_error_image(running_command)
 
     def cancel_tasks(self, message: str | None = None) -> None:
         """Cancel all concurrent tasks."""
         self._task_handler.cancel_all(message=message)
+
+    async def capture_error_image(self, running_command: Command) -> None:
+        """Capture an image of an error event."""
+        try:
+            camera_enablement = await self._camera_provider.get_camera_settings()
+            # Only capture photos of errors if the setting to do so is enabled
+            if (
+                camera_enablement.camera_enabled
+                and camera_enablement.error_recovery_enabled
+            ):
+                # todo(chb, 2025-10-25): Eventually we will need to pass in client provided global settings here
+                image_data = await self._camera_provider.capture_image(
+                    ImageParameters()
+                )
+                commands = self._state_store.commands.get_all()
+                prev_command_id = commands[-2].id if len(commands) > 1 else ""
+                if image_data:
+                    write_result = await self._file_provider.write_file(
+                        data=image_data,
+                        mime_type=MimeType.IMAGE_JPEG,
+                        command_metadata=ImageCaptureCmdFileNameMetadata(
+                            command_id=running_command.id,
+                            prev_command_id=prev_command_id,
+                            step_number=len(commands),
+                            base_filename=None,
+                            command_timestamp=running_command.createdAt,
+                        ),
+                    )
+                    log.info(
+                        f"Image captured of error event with file name: {write_result.name}"
+                    )
+        except Exception as e:
+            log.info(
+                f"Failed to capture image of error with the following exception: {e}"
+            )

--- a/api/tests/opentrons/protocol_engine/execution/test_command_executor.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_command_executor.py
@@ -21,6 +21,10 @@ from opentrons.protocol_engine.errors.exceptions import (
     EStopActivatedError as PE_EStopActivatedError,
 )
 from opentrons.protocol_engine.resources import ModelUtils, FileProvider, CameraProvider
+from opentrons.protocol_engine.resources.camera_provider import (
+    CameraSettings,
+    ImageParameters,
+)
 from opentrons.protocol_engine.state.state import StateStore
 from opentrons.protocol_engine.actions import (
     ActionDispatcher,
@@ -396,23 +400,37 @@ async def test_execute(
 
 
 @pytest.mark.parametrize(
-    ["command_error", "expected_error"],
+    ["command_error", "expected_error", "use_camera"],
     [
         (
             errors.ProtocolEngineError(message="oh no"),
             matchers.ErrorMatching(errors.ProtocolEngineError, match="oh no"),
+            False,
         ),
         (
             EStopActivatedError(),
             matchers.ErrorMatching(PE_EStopActivatedError),
+            False,
         ),
         (
             RuntimeError("oh no"),
             matchers.ErrorMatching(PythonException, match="oh no"),
+            False,
         ),
         (
             asyncio.CancelledError(),
             matchers.ErrorMatching(errors.RunStoppedError),
+            False,
+        ),
+        (
+            errors.ProtocolEngineError(message="oh no"),
+            matchers.ErrorMatching(errors.ProtocolEngineError, match="oh no"),
+            True,
+        ),
+        (
+            RuntimeError("oh no"),
+            matchers.ErrorMatching(PythonException, match="oh no"),
+            True,
         ),
     ],
 )
@@ -439,6 +457,7 @@ async def test_execute_undefined_error(
     error_recovery_policy: ErrorRecoveryPolicy,
     command_error: Exception,
     expected_error: Any,
+    use_camera: bool,
 ) -> None:
     """It should handle an undefined error raised from execution."""
     TestCommandImplCls = decoy.mock(func=_TestCommandImpl)
@@ -542,6 +561,15 @@ async def test_execute_undefined_error(
 
     decoy.when(command_note_tracker.get_notes()).then_return(command_notes)
 
+    if use_camera:
+        decoy.when(await subject._camera_provider.get_camera_settings()).then_return(
+            CameraSettings(
+                camera_enabled=True,
+                live_stream_enabled=True,
+                error_recovery_enabled=True,
+            )
+        )
+
     await subject.execute("command-id")
 
     decoy.verify(
@@ -558,7 +586,23 @@ async def test_execute_undefined_error(
         ),
     )
 
+    if use_camera:
+        decoy.verify(
+            await subject._camera_provider.capture_image(ImageParameters()), times=1
+        )
+    else:
+        decoy.verify(
+            await subject._camera_provider.capture_image(ImageParameters()), times=0
+        )
 
+
+@pytest.mark.parametrize(
+    "use_camera",
+    [
+        True,
+        False,
+    ],
+)
 async def test_execute_defined_error(
     decoy: Decoy,
     subject: CommandExecutor,
@@ -580,6 +624,7 @@ async def test_execute_defined_error(
     model_utils: ModelUtils,
     command_note_tracker: CommandNoteTracker,
     error_recovery_policy: ErrorRecoveryPolicy,
+    use_camera: bool,
 ) -> None:
     """It should handle a defined error returned from execution."""
     TestCommandImplCls = decoy.mock(func=_TestCommandImpl)
@@ -687,6 +732,15 @@ async def test_execute_defined_error(
         )
     ).then_return(ErrorRecoveryType.WAIT_FOR_RECOVERY)
 
+    if use_camera:
+        decoy.when(await subject._camera_provider.get_camera_settings()).then_return(
+            CameraSettings(
+                camera_enabled=True,
+                live_stream_enabled=True,
+                error_recovery_enabled=True,
+            )
+        )
+
     await subject.execute("command-id")
 
     decoy.verify(
@@ -702,3 +756,12 @@ async def test_execute_defined_error(
             )
         )
     )
+
+    if use_camera:
+        decoy.verify(
+            await subject._camera_provider.capture_image(ImageParameters()), times=1
+        )
+    else:
+        decoy.verify(
+            await subject._camera_provider.capture_image(ImageParameters()), times=0
+        )


### PR DESCRIPTION
# Overview
EXEC-2006

Whenever an error occurs capture an image, even if we aren't going to enter error recovery. 

## Test Plan and Hands on Testing

- [x] Implement unit tests
- [x] Run the following protocol and ENSURE the stacker is empty. When the error occurs, we should see a new picture with properly formatted metadata in the `/data/images` directory:
```
from opentrons import protocol_api
requirements = {"robotType": "Flex", "apiLevel": "2.27"}


def run(protocol: protocol_api.ProtocolContext):
    stacker_d = protocol.load_module("flexStackerModuleV1", "D4")

    stacker_d.set_stored_labware(load_name="opentrons_flex_96_tiprack_1000ul", count=1)
    tiprack = stacker_d.retrieve()
```
Cool result (notice the stuck stacker in D4):
![PlatypusExpansion_stacker_protocol py_2025-10-24 20:17:42 412799+00:00_4_2025-10-24 20:18:03 704451+00:00](https://github.com/user-attachments/assets/417b9ce9-0d0f-4a3a-93cf-63e9c9604a4f)


## Changelog
Added image capture call to the commander executor when handling errors

## Review requests
Is this the proper place to do this kind of thing? I thought about doing it in the action handler for `FailCommandAction` but adding in something like `run_until_complete` there for these async callbacks seemed kind of gross.

## Risk assessment
Low, new behavior and on failure does not block error handling or command execution.