### PR TITLE
chore(labware-designer): Fix reference to undefined `_NODE_ENV_` constant

### DIFF
--- a/api-client/vite.config.mts
+++ b/api-client/vite.config.mts
@@ -28,6 +28,10 @@ export default defineConfig({
   },
   resolve: {
     alias: {
+      // todo(mm, 2025-10-27): These cross-project aliases cause trouble like
+      // files being processed with the wrong config (the config from the
+      // consuming project vs. the config from the source project).
+      // Can these be replaced with regular package.json dependencies?
       '@opentrons/shared-data': path.resolve('../shared-data/js/index.ts'),
     },
   },

--- a/app-shell-odd/vite.config.mts
+++ b/app-shell-odd/vite.config.mts
@@ -69,6 +69,10 @@ export default defineConfig(
       },
       resolve: {
         alias: {
+          // todo(mm, 2025-10-27): These cross-project aliases cause trouble like
+          // files being processed with the wrong config (the config from the
+          // consuming project vs. the config from the source project).
+          // Can these be replaced with regular package.json dependencies?
           '@opentrons/components/styles': path.resolve(
             '../components/src/index.module.css'
           ),

--- a/app-shell/vite.config.mts
+++ b/app-shell/vite.config.mts
@@ -47,6 +47,10 @@ export default defineConfig(
       },
       resolve: {
         alias: {
+          // todo(mm, 2025-10-27): These cross-project aliases cause trouble like
+          // files being processed with the wrong config (the config from the
+          // consuming project vs. the config from the source project).
+          // Can these be replaced with regular package.json dependencies?
           '@opentrons/shared-data': path.resolve('../shared-data/js/index.ts'),
           '@opentrons/step-generation': path.resolve(
             '../step-generation/src/index.ts'

--- a/app/vite.config.mts
+++ b/app/vite.config.mts
@@ -65,6 +65,10 @@ export default defineConfig(
       },
       resolve: {
         alias: {
+          // todo(mm, 2025-10-27): These cross-project aliases cause trouble like
+          // files being processed with the wrong config (the config from the
+          // consuming project vs. the config from the source project).
+          // Can these be replaced with regular package.json dependencies?
           '@opentrons/components/styles/global': path.resolve(
             '../components/src/styles/global.css'
           ),

--- a/components/vite.config.mts
+++ b/components/vite.config.mts
@@ -58,6 +58,10 @@ export default defineConfig({
   },
   resolve: {
     alias: {
+      // todo(mm, 2025-10-27): These cross-project aliases cause trouble like
+      // files being processed with the wrong config (the config from the
+      // consuming project vs. the config from the source project).
+      // Can these be replaced with regular package.json dependencies?
       '@opentrons/shared-data': path.resolve('../shared-data/js/index.ts'),
       '@opentrons/components/styles': path.resolve(
         '../components/src/index.module.css'

--- a/discovery-client/vite.config.mts
+++ b/discovery-client/vite.config.mts
@@ -58,6 +58,10 @@ export default defineConfig(
       },
       resolve: {
         alias: {
+          // todo(mm, 2025-10-27): These cross-project aliases cause trouble like
+          // files being processed with the wrong config (the config from the
+          // consuming project vs. the config from the source project).
+          // Can these be replaced with regular package.json dependencies?
           '@opentrons/components/styles': path.resolve(
             '../components/src/index.module.css'
           ),

--- a/labware-designer/vite.config.mts
+++ b/labware-designer/vite.config.mts
@@ -44,6 +44,10 @@ export default defineConfig({
   },
   resolve: {
     alias: {
+      // todo(mm, 2025-10-27): These cross-project aliases cause trouble like
+      // files being processed with the wrong config (the config from the
+      // consuming project vs. the config from the source project).
+      // Can these be replaced with regular package.json dependencies?
       '@opentrons/components/styles': path.resolve('../components/src/index.module.css'),
       '@opentrons/components': path.resolve('../components/src/index.ts'),
       '@opentrons/shared-data': path.resolve('../shared-data/js/index.ts'),

--- a/labware-designer/vite.config.mts
+++ b/labware-designer/vite.config.mts
@@ -40,6 +40,7 @@ export default defineConfig({
   define: {
     // NOTE: For security, only include environment variables here if they're explicitly allowlisted.
     global: 'globalThis',
+    _NODE_ENV_: JSON.stringify(process.env.NODE_ENV),
   },
   resolve: {
     alias: {

--- a/labware-library/vite.config.mts
+++ b/labware-library/vite.config.mts
@@ -57,6 +57,10 @@ export default defineConfig({
   },
   resolve: {
     alias: {
+      // todo(mm, 2025-10-27): These cross-project aliases cause trouble like
+      // files being processed with the wrong config (the config from the
+      // consuming project vs. the config from the source project).
+      // Can these be replaced with regular package.json dependencies?
       '@opentrons/components/styles': path.resolve(
         '../components/src/index.module.css'
       ),

--- a/opentrons-ai-client/vite.config.mts
+++ b/opentrons-ai-client/vite.config.mts
@@ -50,6 +50,10 @@ export default defineConfig({
   },
   resolve: {
     alias: {
+      // todo(mm, 2025-10-27): These cross-project aliases cause trouble like
+      // files being processed with the wrong config (the config from the
+      // consuming project vs. the config from the source project).
+      // Can these be replaced with regular package.json dependencies?
       '@opentrons/components/styles/global': path.resolve(
         '../components/src/styles/global.css'
       ),

--- a/protocol-designer/vite.config.mts
+++ b/protocol-designer/vite.config.mts
@@ -119,6 +119,10 @@ export default defineConfig(
       },
       resolve: {
         alias: {
+          // todo(mm, 2025-10-27): These cross-project aliases cause trouble like
+          // files being processed with the wrong config (the config from the
+          // consuming project vs. the config from the source project).
+          // Can these be replaced with regular package.json dependencies?
           '@opentrons/components/styles/global': path.resolve(
             '../components/src/styles/global.css'
           ),

--- a/react-api-client/vite.config.mts
+++ b/react-api-client/vite.config.mts
@@ -28,6 +28,10 @@ export default defineConfig({
   },
   resolve: {
     alias: {
+      // todo(mm, 2025-10-27): These cross-project aliases cause trouble like
+      // files being processed with the wrong config (the config from the
+      // consuming project vs. the config from the source project).
+      // Can these be replaced with regular package.json dependencies?
       '@opentrons/shared-data': path.resolve('../shared-data/js/index.ts'),
       '@opentrons/api-client': path.resolve('../api-client/src/index.ts'),
     },

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -77,6 +77,10 @@ export default defineConfig({
   },
   resolve: {
     alias: {
+      // todo(mm, 2025-10-27): These cross-project aliases cause trouble like
+      // files being processed with the wrong config (the config from the
+      // consuming project vs. the config from the source project).
+      // Can these be replaced with regular package.json dependencies?
       '@opentrons/components/styles': path.resolve(
         './components/src/index.module.css'
       ),

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -35,6 +35,10 @@ export default mergeConfig(
     },
     resolve: {
       alias: {
+        // todo(mm, 2025-10-27): These cross-project aliases cause trouble like
+        // files being processed with the wrong config (the config from the
+        // consuming project vs. the config from the source project).
+        // Can these be replaced with regular package.json dependencies?
         '@opentrons/components/styles': path.resolve(
           './components/src/index.module.css'
         ),


### PR DESCRIPTION
## Overview

This fixes a broken `labware-designer` build. It was whitescreening with an error relating to `_NODE_ENV_` not being defined.

## Test Plan and Hands on Testing

* [x] A local build (`make dist && yarn vite preview`) works now.

## Details

`labware-designer` does not actually use `_NODE_ENV_` anywhere. However, some of its dependencies do. Those dependencies' configs try to define `_NODE_ENV_` for themselves, so things *ought* to work. But `labware-designer` includes those dependencies with a simple Vite import alias—naively including their source files as if they were part of `labware-designer` itself—so the dependencies' project configs are bypassed completely, and `_NODE_ENV_` is never defined.

The quick fix is for `labware-designer`'s Vite config to define `_NODE_ENV_` even though it shouldn't need to.

We've fixed other occurrences of this problem twice before: once in #19586, and once in a PR of @mjhuff's that I'm having trouble digging up. So this PR adds loud `# todo` comments to all of the config files to try to stop this from getting any worse.

## Review requests

Agreed with the new todo comments? I honestly haven't looked into the package.json strategy to see if that would even work, but does it seem like basically the right direction?

## Risk assessment

Low.