### PR TITLE
fix(ci): PD sentry settings

### DIFF
--- a/.github/workflows/pd-test-build-deploy.yaml
+++ b/.github/workflows/pd-test-build-deploy.yaml
@@ -1,28 +1,28 @@
 # Run tests, build PD, and deploy
 
-name: 'PD test, build, and deploy'
+name: "PD test, build, and deploy"
 
 on:
   pull_request:
     paths:
-      - 'protocol-designer/**'
-      - 'step-generation/**'
-      - 'shared-data/**'
-      - 'components/**'
-      - 'package.json'
-      - '.github/workflows/pd-test-build-deploy.yaml'
-      - '.github/actions/js/setup/action.yml'
-      - '.github/actions/git/resolve-tag/action.yml'
-      - '.github/actions/environment/complex-variables/action.yml'
-      - 'scripts/static-deploy/**'
-      - 'scripts/git-version-protocol-designer.mjs'
+      - "protocol-designer/**"
+      - "step-generation/**"
+      - "shared-data/**"
+      - "components/**"
+      - "package.json"
+      - ".github/workflows/pd-test-build-deploy.yaml"
+      - ".github/actions/js/setup/action.yml"
+      - ".github/actions/git/resolve-tag/action.yml"
+      - ".github/actions/environment/complex-variables/action.yml"
+      - "scripts/static-deploy/**"
+      - "scripts/git-version-protocol-designer.mjs"
   push:
     branches:
-      - 'edge'
-      - 'chore_release*'
+      - "edge"
+      - "chore_release*"
     tags:
-      - 'protocol-designer*'
-      - 'staging-protocol-designer*'
+      - "protocol-designer*"
+      - "staging-protocol-designer*"
   workflow_dispatch: {}
 
 concurrency:
@@ -34,11 +34,11 @@ defaults:
     shell: bash
 
 env:
-  CI: 'true'
+  CI: "true"
   # This is the artifact directory as a relative path
   # to the working-directory of our tools: scripts/static-deploy
   # our script deploy_ci_config.py expects this ENV variable is set
-  RELATIVE_ARTIFACT_DIR: '../../dist'
+  RELATIVE_ARTIFACT_DIR: "../../dist"
 
 jobs:
   determine-deploy-config:
@@ -56,7 +56,7 @@ jobs:
       - name: Setup UV
         uses: astral-sh/setup-uv@v6
         with:
-          python-version: '3.10'
+          python-version: "3.10"
       - name: Setup Deploy Dependencies
         working-directory: scripts/static-deploy
         run: make setup
@@ -67,44 +67,44 @@ jobs:
         run: make resolve-ci
 
   unit-test:
-    name: 'protocol designer unit tests'
-    runs-on: 'ubuntu-24.04'
+    name: "protocol designer unit tests"
+    runs-on: "ubuntu-24.04"
     timeout-minutes: 20
     if: ${{ !startsWith(github.ref, 'refs/tags/') }}
     steps:
-      - name: 'Checkout Repository'
+      - name: "Checkout Repository"
         uses: actions/checkout@v4
       - uses: ./.github/actions/js/setup
-      - name: 'run unit tests'
+      - name: "run unit tests"
         run: make -C protocol-designer test-cov
-      - name: 'Upload coverage report'
+      - name: "Upload coverage report"
         uses: codecov/codecov-action@v5
         with:
           flags: protocol-designer
           token: ${{ secrets.CODECOV_TOKEN }}
 
   e2e-test:
-    name: 'protocol designer e2e tests'
-    runs-on: 'ubuntu-24.04'
+    name: "protocol designer e2e tests"
+    runs-on: "ubuntu-24.04"
     timeout-minutes: 20
     if: ${{ !startsWith(github.ref, 'refs/tags/') }}
     steps:
-      - name: 'Checkout Repository'
+      - name: "Checkout Repository"
         uses: actions/checkout@v4
         with:
           fetch-depth: 0 # PD needs to see labware in other release branches
       - uses: ./.github/actions/js/setup
-      - name: 'run test-e2e'
+      - name: "run test-e2e"
         run: make -C protocol-designer test-e2e
 
   build-pd:
     timeout-minutes: 20
-    name: 'build protocol designer'
+    name: "build protocol designer"
     needs:
       - determine-deploy-config
       - unit-test
       - e2e-test
-    runs-on: 'ubuntu-24.04'
+    runs-on: "ubuntu-24.04"
     if: always() && (needs.unit-test.result == 'success' || needs.unit-test.result == 'skipped') && (needs.e2e-test.result == 'success' || needs.e2e-test.result == 'skipped')
     steps:
       - uses: actions/checkout@v4
@@ -113,16 +113,16 @@ jobs:
       - id: resolve-tag
         uses: ./.github/actions/git/resolve-tag
       - uses: ./.github/actions/js/setup
-      - name: 'build PD'
+      - name: "build PD"
         env:
-          NODE_OPTIONS: '--max-old-space-size=5120'
+          NODE_OPTIONS: "--max-old-space-size=5120"
           OT_PD_MIXPANEL_ID: ${{ secrets.OT_PD_MIXPANEL_ID }}
           OT_PD_MIXPANEL_DEV_ID: ${{ secrets.OT_PD_MIXPANEL_DEV_ID }}
           OT_PD_SENTRY_DSN: ${{ secrets.OT_PD_SENTRY_DSN }}
           OT_PD_SENTRY_DEV_DSN: ${{ secrets.OT_PD_SENTRY_DEV_DSN }}
         run: |
           make -C protocol-designer NODE_ENV=${{ needs.determine-deploy-config.outputs.environment == 'production' && 'production' || 'development' }}
-      - name: 'upload sourcemaps to Sentry'
+      - name: "upload sourcemaps to Sentry"
         # Only on production releases (tagged with protocol-designer*)
         if: github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/protocol-designer')
         uses: getsentry/action-release@v3
@@ -137,19 +137,19 @@ jobs:
           ignore_missing: true
           finalize: false
           environment: production
-      - name: 'upload github artifact'
+      - name: "upload github artifact"
         uses: actions/upload-artifact@v4
         with:
-          name: 'pd-artifact'
+          name: "pd-artifact"
           path: protocol-designer/dist
 
   deploy-pd:
     timeout-minutes: 10
-    name: 'deploy protocol designer'
+    name: "deploy protocol designer"
     needs:
       - determine-deploy-config
       - build-pd
-    runs-on: 'ubuntu-24.04'
+    runs-on: "ubuntu-24.04"
     if: always() && needs.build-pd.result == 'success' && needs.determine-deploy-config.result == 'success'
     permissions:
       id-token: write
@@ -169,14 +169,14 @@ jobs:
       - name: Setup UV
         uses: astral-sh/setup-uv@v6
         with:
-          python-version: '3.10'
+          python-version: "3.10"
       - name: Setup Deploy Dependencies
         working-directory: scripts/static-deploy
         run: |
           make setup
 
-      - name: 'download PD build'
-        uses: 'actions/download-artifact@v4'
+      - name: "download PD build"
+        uses: "actions/download-artifact@v4"
         with:
           name: pd-artifact
           path: ./dist # in the default workspace
@@ -190,7 +190,7 @@ jobs:
           ENVIRONMENT=${{ needs.determine-deploy-config.outputs.environment }} \
           SANDBOX_PREFIX=${{ needs.determine-deploy-config.outputs.sandbox_prefix }} \
           RELATIVE_ARTIFACT_DIR=${{ needs.determine-deploy-config.outputs.relative_artifact_dir }}
-      - name: 'notify Sentry of prod deploy'
+      - name: "finalize the production release in Sentry"
         # Only on production releases (tagged with protocol-designer*)
         if: github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/protocol-designer')
         uses: getsentry/action-release@v3

--- a/.github/workflows/pd-test-build-deploy.yaml
+++ b/.github/workflows/pd-test-build-deploy.yaml
@@ -112,6 +112,9 @@ jobs:
           fetch-depth: 0 # Unlimited fetch depth. Required for getsentry/action-release.
       - id: resolve-tag
         uses: ./.github/actions/git/resolve-tag
+      - name: "extract version from tag"
+        id: version
+        run: echo "number=${GITHUB_REF_NAME##*@}" >> $GITHUB_OUTPUT
       - uses: ./.github/actions/js/setup
       - name: "build PD"
         env:
@@ -131,7 +134,7 @@ jobs:
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
         with:
-          release: ${{ steps.resolve-tag.outputs.tag }}
+          release: ${{ steps.version.outputs.number }}
           sourcemaps: protocol-designer/dist
           set_commits: auto
           ignore_missing: true
@@ -166,6 +169,9 @@ jobs:
           fetch-depth: 0
       - id: resolve-tag
         uses: ./.github/actions/git/resolve-tag
+      - name: "extract version from tag"
+        id: version
+        run: echo "number=${GITHUB_REF_NAME##*@}" >> $GITHUB_OUTPUT
       - name: Setup UV
         uses: astral-sh/setup-uv@v6
         with:
@@ -199,5 +205,5 @@ jobs:
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
         with:
-          release: ${{ steps.resolve-tag.outputs.tag }}
+          release: ${{ steps.version.outputs.number }}
           finalize: true

--- a/.github/workflows/pd-test-build-deploy.yaml
+++ b/.github/workflows/pd-test-build-deploy.yaml
@@ -135,6 +135,8 @@ jobs:
           sourcemaps: protocol-designer/dist
           set_commits: auto
           ignore_missing: true
+          finalize: false
+          environment: production
       - name: 'upload github artifact'
         uses: actions/upload-artifact@v4
         with:
@@ -197,6 +199,6 @@ jobs:
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
         with:
-          # version is deprecated, use release instead
           release: ${{ steps.resolve-tag.outputs.tag }}
+          finalize: true
           environment: production

--- a/.github/workflows/pd-test-build-deploy.yaml
+++ b/.github/workflows/pd-test-build-deploy.yaml
@@ -201,4 +201,3 @@ jobs:
         with:
           release: ${{ steps.resolve-tag.outputs.tag }}
           finalize: true
-          environment: production

--- a/protocol-designer/vite.config.mts
+++ b/protocol-designer/vite.config.mts
@@ -60,8 +60,8 @@ export default defineConfig(
         sentryVitePlugin({
           org: 'opentrons-76',
           project: 'protocol-designer',
-          authToken: process.env.OT_SENTRY_AUTH_TOKEN,
-          release: OT_PD_VERSION,
+          // Don't provide authToken - we don't want to upload during build
+          // Uploads happen in dedicated workflow steps in GitHub Actions
           telemetry: false,
           reactComponentAnnotation: {
             enabled: true,
@@ -70,8 +70,8 @@ export default defineConfig(
           sourcemaps: {
             assets: ['./dist/**'],
             ignore: ['./node_modules/**'],
-            filesToDeleteAfterUpload:
-              mode === 'production' ? ['./dist/**/*.js.map'] : undefined,
+            // Don't delete sourcemaps - they need to be uploaded in workflow steps
+            filesToDeleteAfterUpload: undefined,
           },
         }),
         {

--- a/protocol-designer/vite.config.mts
+++ b/protocol-designer/vite.config.mts
@@ -70,8 +70,6 @@ export default defineConfig(
           sourcemaps: {
             assets: ['./dist/**'],
             ignore: ['./node_modules/**'],
-            // Don't delete sourcemaps - they need to be uploaded in workflow steps
-            filesToDeleteAfterUpload: undefined,
           },
         }),
         {


### PR DESCRIPTION
### Sentry Release + Sourcemaps Notes

See the workflow and inline comments for full context — but here’s the cleaned-up explanation of the fix:

---

We **only** want to generate sourcemaps in the Vite build — **not** upload them.  
Uploads must happen in the dedicated GitHub Actions steps.

During the **8.6.1** deploy job  
(https://github.com/Opentrons/opentrons/actions/runs/18844549836/job/53765218611#step:7:54)
Sentry behaved like this:

1. **First `getsentry/action-release@v3` call**
   - ✅ Created the release
   - ✅ Uploaded the 3 sourcemap files
2. **Second call**
   - Included `environment:` again but **no sourcemaps**
   - ❌ Action interpreted this as **re-creating** the release
   - ❌ New release version ended up **without sourcemaps**
   - ✅ App code was still linked to that version (so errors showed up but with no mapping)

#### Additionally the release was not actually being set

`${{ steps.resolve-tag.outputs.tag }}` is undefined

---

### ✅ The Fix

The **second Sentry action** should only **finalize** the already-created release —  
**no `environment:` and no `sourcemaps:`** on that step.

This prevents the action from rebuilding the release and discarding the sourcemaps we uploaded earlier.

---

So:  
**First call → create + upload sourcemaps**  
**Second call → finalize only** ✅