### PR TITLE
fix(api): Concurrency provider classes for different actions on the same module

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/set_shake_speed.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/set_shake_speed.py
@@ -97,18 +97,16 @@ class SetShakeSpeedImpl(
             hs_module_substate.module_id
         )
 
-        async with self._task_handler.synchronize_cancel_latest(
-            hs_module_substate.module_id
-        ):
-
-            async def start_shake(task_handler: TaskHandler) -> None:
-                if hs_hardware_module is not None:
+        async def start_shake(task_handler: TaskHandler) -> None:
+            if hs_hardware_module is not None:
+                async with task_handler.synchronize_cancel_previous(
+                    hs_module_substate.module_id
+                ):
                     await hs_hardware_module.set_speed(rpm=validated_speed)
 
-            task = await self._task_handler.create_task(
-                task_function=start_shake,
-                id=params.taskId,
-            )
+        task = await self._task_handler.create_task(
+            task_function=start_shake, id=params.taskId
+        )
         return SuccessData(
             public=SetShakeSpeedResult(
                 pipetteRetracted=pipette_should_retract, taskId=task.id

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/set_shake_speed.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/set_shake_speed.py
@@ -99,8 +99,8 @@ class SetShakeSpeedImpl(
 
         async def start_shake(task_handler: TaskHandler) -> None:
             if hs_hardware_module is not None:
-                async with task_handler.synchronize_cancel_previous(
-                    hs_module_substate.module_id
+                async with task_handler.synchronize_cancel_latest(
+                    hs_module_substate.module_id + "-shake"
                 ):
                     await hs_hardware_module.set_speed(rpm=validated_speed)
 

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/set_shake_speed.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/set_shake_speed.py
@@ -99,7 +99,7 @@ class SetShakeSpeedImpl(
 
         async def start_shake(task_handler: TaskHandler) -> None:
             if hs_hardware_module is not None:
-                async with task_handler.synchronize_cancel_latest(
+                async with task_handler.synchronize_cancel_previous(
                     hs_module_substate.module_id + "-shake"
                 ):
                     await hs_hardware_module.set_speed(rpm=validated_speed)

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/set_shake_speed.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/set_shake_speed.py
@@ -97,16 +97,18 @@ class SetShakeSpeedImpl(
             hs_module_substate.module_id
         )
 
-        async def start_shake(task_handler: TaskHandler) -> None:
-            if hs_hardware_module is not None:
-                async with task_handler.synchronize_cancel_previous(
-                    hs_module_substate.module_id
-                ):
+        async with self._task_handler.synchronize_cancel_latest(
+            hs_module_substate.module_id
+        ):
+
+            async def start_shake(task_handler: TaskHandler) -> None:
+                if hs_hardware_module is not None:
                     await hs_hardware_module.set_speed(rpm=validated_speed)
 
-        task = await self._task_handler.create_task(
-            task_function=start_shake, id=params.taskId
-        )
+            task = await self._task_handler.create_task(
+                task_function=start_shake,
+                id=params.taskId,
+            )
         return SuccessData(
             public=SetShakeSpeedResult(
                 pipetteRetracted=pipette_should_retract, taskId=task.id

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/set_target_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/set_target_temperature.py
@@ -81,8 +81,8 @@ class SetTargetTemperatureImpl(
 
         async def start_set_temperature(task_handler: TaskHandler) -> None:
             if hs_hardware_module is not None:
-                async with task_handler.synchronize_cancel_previous(
-                    hs_module_substate.module_id
+                async with task_handler.synchronize_cancel_latest(
+                    hs_module_substate.module_id + "-temp"
                 ):
                     await hs_hardware_module.start_set_temperature(validated_temp)
                     await hs_hardware_module.await_temperature(validated_temp)

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/set_target_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/set_target_temperature.py
@@ -78,18 +78,18 @@ class SetTargetTemperatureImpl(
         hs_hardware_module = self._equipment.get_module_hardware_api(
             hs_module_substate.module_id
         )
+        async with self._task_handler.synchronize_cancel_latest(
+            hs_module_substate.module_id
+        ):
 
-        async def start_set_temperature(task_handler: TaskHandler) -> None:
-            if hs_hardware_module is not None:
-                async with task_handler.synchronize_cancel_previous(
-                    hs_module_substate.module_id
-                ):
+            async def start_set_temperature(task_handler: TaskHandler) -> None:
+                if hs_hardware_module is not None:
                     await hs_hardware_module.start_set_temperature(validated_temp)
                     await hs_hardware_module.await_temperature(validated_temp)
 
-        task = await self._task_handler.create_task(
-            task_function=start_set_temperature, id=params.taskId
-        )
+            task = await self._task_handler.create_task(
+                task_function=start_set_temperature, id=params.taskId
+            )
         return SuccessData(
             public=SetTargetTemperatureResult(taskId=task.id),
         )

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/set_target_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/set_target_temperature.py
@@ -81,7 +81,7 @@ class SetTargetTemperatureImpl(
 
         async def start_set_temperature(task_handler: TaskHandler) -> None:
             if hs_hardware_module is not None:
-                async with task_handler.synchronize_cancel_latest(
+                async with task_handler.synchronize_cancel_previous(
                     hs_module_substate.module_id + "-temp"
                 ):
                     await hs_hardware_module.start_set_temperature(validated_temp)

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/set_target_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/set_target_temperature.py
@@ -78,18 +78,18 @@ class SetTargetTemperatureImpl(
         hs_hardware_module = self._equipment.get_module_hardware_api(
             hs_module_substate.module_id
         )
-        async with self._task_handler.synchronize_cancel_latest(
-            hs_module_substate.module_id
-        ):
 
-            async def start_set_temperature(task_handler: TaskHandler) -> None:
-                if hs_hardware_module is not None:
+        async def start_set_temperature(task_handler: TaskHandler) -> None:
+            if hs_hardware_module is not None:
+                async with task_handler.synchronize_cancel_previous(
+                    hs_module_substate.module_id
+                ):
                     await hs_hardware_module.start_set_temperature(validated_temp)
                     await hs_hardware_module.await_temperature(validated_temp)
 
-            task = await self._task_handler.create_task(
-                task_function=start_set_temperature, id=params.taskId
-            )
+        task = await self._task_handler.create_task(
+            task_function=start_set_temperature, id=params.taskId
+        )
         return SuccessData(
             public=SetTargetTemperatureResult(taskId=task.id),
         )

--- a/api/src/opentrons/protocol_engine/commands/temperature_module/set_target_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/temperature_module/set_target_temperature.py
@@ -82,7 +82,7 @@ class SetTargetTemperatureImpl(
 
         async def start_set_temperature(task_handler: TaskHandler) -> None:
             if temp_hardware_module is not None:
-                async with task_handler.synchronize_cancel_latest(
+                async with task_handler.synchronize_cancel_previous(
                     module_substate.module_id
                 ):
                     await temp_hardware_module.start_set_temperature(

--- a/api/src/opentrons/protocol_engine/commands/temperature_module/set_target_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/temperature_module/set_target_temperature.py
@@ -80,11 +80,12 @@ class SetTargetTemperatureImpl(
             module_substate.module_id
         )
 
-        async def start_set_temperature(task_handler: TaskHandler) -> None:
-            if temp_hardware_module is not None:
-                async with task_handler.synchronize_cancel_previous(
-                    module_substate.module_id
-                ):
+        async with self._task_handler.synchronize_cancel_latest(
+            module_substate.module_id
+        ):
+
+            async def start_set_temperature(task_handler: TaskHandler) -> None:
+                if temp_hardware_module is not None:
                     await temp_hardware_module.start_set_temperature(
                         celsius=validated_temp
                     )

--- a/api/src/opentrons/protocol_engine/commands/temperature_module/set_target_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/temperature_module/set_target_temperature.py
@@ -82,7 +82,7 @@ class SetTargetTemperatureImpl(
 
         async def start_set_temperature(task_handler: TaskHandler) -> None:
             if temp_hardware_module is not None:
-                async with task_handler.synchronize_cancel_previous(
+                async with task_handler.synchronize_cancel_latest(
                     module_substate.module_id
                 ):
                     await temp_hardware_module.start_set_temperature(

--- a/api/src/opentrons/protocol_engine/commands/temperature_module/set_target_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/temperature_module/set_target_temperature.py
@@ -80,12 +80,11 @@ class SetTargetTemperatureImpl(
             module_substate.module_id
         )
 
-        async with self._task_handler.synchronize_cancel_latest(
-            module_substate.module_id
-        ):
-
-            async def start_set_temperature(task_handler: TaskHandler) -> None:
-                if temp_hardware_module is not None:
+        async def start_set_temperature(task_handler: TaskHandler) -> None:
+            if temp_hardware_module is not None:
+                async with task_handler.synchronize_cancel_previous(
+                    module_substate.module_id
+                ):
                     await temp_hardware_module.start_set_temperature(
                         celsius=validated_temp
                     )

--- a/api/src/opentrons/protocol_engine/commands/thermocycler/set_target_block_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/thermocycler/set_target_block_temperature.py
@@ -122,13 +122,16 @@ class SetTargetBlockTemperatureImpl(
 
         async def set_target_block_temperature(task_handler: TaskHandler) -> None:
             if thermocycler_hardware is not None:
-                await thermocycler_hardware.set_target_block_temperature(
-                    celsius=target_temperature,
-                    volume=target_volume,
-                    ramp_rate=target_ramp_rate,
-                    hold_time_seconds=hold_time,
-                )
-                await thermocycler_hardware.wait_for_block_target()
+                async with task_handler.synchronize_cancel_latest(
+                    thermocycler_state.module_id + "-block"
+                ):
+                    await thermocycler_hardware.set_target_block_temperature(
+                        celsius=target_temperature,
+                        volume=target_volume,
+                        ramp_rate=target_ramp_rate,
+                        hold_time_seconds=hold_time,
+                    )
+                    await thermocycler_hardware.wait_for_block_target()
 
         task = await self._task_handler.create_task(
             task_function=set_target_block_temperature, id=params.taskId

--- a/api/src/opentrons/protocol_engine/commands/thermocycler/set_target_lid_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/thermocycler/set_target_lid_temperature.py
@@ -82,10 +82,13 @@ class SetTargetLidTemperatureImpl(
 
         async def set_target_lid_temperature(task_handler: TaskHandler) -> None:
             if thermocycler_hardware is not None:
-                await thermocycler_hardware.set_target_lid_temperature(
-                    target_temperature
-                )
-                await thermocycler_hardware.wait_for_lid_target()
+                async with task_handler.synchronize_cancel_latest(
+                    thermocycler_state.module_id + "-lid"
+                ):
+                    await thermocycler_hardware.set_target_lid_temperature(
+                        target_temperature
+                    )
+                    await thermocycler_hardware.wait_for_lid_target()
 
         task = await self._task_handler.create_task(
             task_function=set_target_lid_temperature, id=params.taskId

--- a/api/src/opentrons/protocol_engine/commands/thermocycler/start_run_extended_profile.py
+++ b/api/src/opentrons/protocol_engine/commands/thermocycler/start_run_extended_profile.py
@@ -150,7 +150,7 @@ class StartRunExtendedProfileImpl(
         async def start_run_profile(task_handler: TaskHandler) -> None:
             if thermocycler_hardware is not None:
                 async with task_handler.synchronize_cancel_latest(
-                    thermocycler_state.module_id
+                    thermocycler_state.module_id + "-block"
                 ):
                     await thermocycler_hardware.execute_profile(
                         profile=profile, volume=target_volume


### PR DESCRIPTION
# Overview

Tasks sent to the same module should cancel the previous/current one before starting the new one.
`wait_for_tasks` should fail if a task passed in was canceled.
Modules use different concurrency classes based on the type of action (ie: lid vs block, shake vs heat)

## Test Plan and Hands on Testing
- Tested temperature module - `wait_for_tasks` did fail when waiting for a previously canceled task.
```
temp_mod: TemperatureModuleContext = ctx.load_module(
            "temperature module gen2", "D3"
        )  # type: ignore[assignment]
        # Concurrent Command - should pick up tips immediately
        temp_task = temp_mod.start_set_temperature(15)
        temp_task_2 = temp_mod.start_set_temperature(30)
        ctx.wait_for_tasks([temp_task, temp_task_2])
        pipette.pick_up_tip()
        pipette.return_tip()
 ```

Closes RQA-4786