### PR TITLE
fix(protocol-designer): Reordering steps should count as modifying the protocol

### DIFF
--- a/protocol-designer/src/components/organisms/Navigation/index.tsx
+++ b/protocol-designer/src/components/organisms/Navigation/index.tsx
@@ -47,6 +47,9 @@ export function Navigation(): JSX.Element | null {
     }
   }
 
+  // todo(mm, 2025-10-27): Unlike the "create new" button, the "import" button
+  // will not warn you if you're overwriting a protocol with unsaved changes.
+  // Should it?
   const handleImport = (): void => {
     if (fileInputRef.current != null) {
       fileInputRef.current.click()

--- a/protocol-designer/src/load-file/__tests__/reducers.test.ts
+++ b/protocol-designer/src/load-file/__tests__/reducers.test.ts
@@ -22,6 +22,7 @@ describe('unsavedChanges', () => {
       'ADD_STEP',
       'DELETE_STEP',
       'DELETE_MULTIPLE_STEPS',
+      'REORDER_STEPS',
       'SAVE_STEP_FORM',
       'SAVE_FILE_METADATA',
       'REPLACE_CUSTOM_LABWARE_DEF',

--- a/protocol-designer/src/load-file/__tests__/reducers.test.ts
+++ b/protocol-designer/src/load-file/__tests__/reducers.test.ts
@@ -23,6 +23,7 @@ describe('unsavedChanges', () => {
       'DELETE_STEP',
       'DELETE_MULTIPLE_STEPS',
       'REORDER_STEPS',
+      'REORDER_SELECTED_STEP',
       'SAVE_STEP_FORM',
       'SAVE_FILE_METADATA',
       'REPLACE_CUSTOM_LABWARE_DEF',

--- a/protocol-designer/src/load-file/reducers.ts
+++ b/protocol-designer/src/load-file/reducers.ts
@@ -58,6 +58,7 @@ const unsavedChanges = (state: boolean = false, action: Action): boolean => {
     case 'DELETE_STEP':
     case 'DELETE_MULTIPLE_STEPS':
     case 'REORDER_STEPS':
+    case 'REORDER_SELECTED_STEP':
     case 'SAVE_STEP_FORM':
     case 'SAVE_FILE_METADATA':
     case 'REPLACE_CUSTOM_LABWARE_DEF':

--- a/protocol-designer/src/load-file/reducers.ts
+++ b/protocol-designer/src/load-file/reducers.ts
@@ -57,6 +57,7 @@ const unsavedChanges = (state: boolean = false, action: Action): boolean => {
     case 'ADD_STEP':
     case 'DELETE_STEP':
     case 'DELETE_MULTIPLE_STEPS':
+    case 'REORDER_STEPS':
     case 'SAVE_STEP_FORM':
     case 'SAVE_FILE_METADATA':
     case 'REPLACE_CUSTOM_LABWARE_DEF':


### PR DESCRIPTION
## Overview

In Protocol Designer, when you click the "Create new" button to create a new protocol, it warns you if that would take you away from a protocol that has unsaved changes.

Its mechanism for tracking that involves a hand-coded list of all the things that count as modifying a protocol. That list was missing `REORDER_STEPS` and `REORDER_SELECTED_STEP`. So if you changed the order of steps in the timeline and did nothing else, it wouldn't warn you when you clicked "Create new."

Closes AUTH-2438.

## Test Plan and Hands on Testing

* [x] It should now warn you if you reorder steps and then immediately click the "Create new" button, either by drag-n-drop or by Alt + arrow key.

## Review requests

* Does it seem like this list is missing anything else?
* Any thoughts on the todo comment I added, where this check is only applied on the "Create new" button and not the "Import" button?

## Risk assessment

Low.
