### PR TITLE
fix(api): Raise error if the labware pool is incompatible with the stacker.

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/flex_stacker/common.py
+++ b/api/src/opentrons/protocol_engine/commands/flex_stacker/common.py
@@ -10,6 +10,10 @@ from opentrons_shared_data.errors import ErrorCodes
 from opentrons_shared_data.errors.exceptions import CommandPreconditionViolated
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition
 
+from opentrons.protocol_engine.errors.exceptions import (
+    LabwarePoolNotCompatibleWithModuleError,
+)
+
 
 from ...errors import ErrorOccurrence
 from ...types import (
@@ -34,6 +38,15 @@ if TYPE_CHECKING:
     from opentrons.protocol_engine.resources import ModelUtils
     from opentrons.protocol_engine.execution.equipment import LoadedLabwarePoolData
     from opentrons.protocol_engine.state.module_substates import FlexStackerSubState
+
+
+# The stacker cannot dispense labware where there is no gap between the top surface
+# of the bottom labware being dispensed, and bottom surface of the top labware.
+# This is because the stacker latch, which holds the labware stack, needs enough
+# empty space to free the bottom labware, but still hold the top labware once it
+# closes.
+STACKER_INCOMPATIBLE_LABWARE = set(["opentrons_tough_universal_lid"])
+
 
 INITIAL_COUNT_DESCRIPTION = dedent(
     """\
@@ -911,3 +924,25 @@ def build_retrieve_labware_move_updates(
             lid_offset_location,
         )
     return locations_for_ids, offset_ids_by_id
+
+
+def validate_labware_pool_compatible_with_stacker(
+    pool_primary_definition: LabwareDefinition,
+    pool_adapter_definition: LabwareDefinition | None,
+    pool_lid_definition: LabwareDefinition | None,
+) -> None:
+    """Verifies that the given labware pool is compatible with the stacker."""
+    labware_pool = set(
+        lw.parameters.loadName
+        for lw in [
+            pool_primary_definition,
+            pool_adapter_definition,
+            pool_lid_definition,
+        ]
+        if lw is not None
+    )
+    incompatible_labware = list(labware_pool & STACKER_INCOMPATIBLE_LABWARE)
+    if incompatible_labware:
+        raise LabwarePoolNotCompatibleWithModuleError(
+            f"The stacker cannot store {incompatible_labware}"
+        )

--- a/api/src/opentrons/protocol_engine/commands/flex_stacker/set_stored_labware.py
+++ b/api/src/opentrons/protocol_engine/commands/flex_stacker/set_stored_labware.py
@@ -31,6 +31,7 @@ from .common import (
     primary_location_sequences,
     adapter_location_sequences_with_default,
     lid_location_sequences_with_default,
+    validate_labware_pool_compatible_with_stacker,
 )
 
 if TYPE_CHECKING:
@@ -208,6 +209,12 @@ class SetStoredLabwareImpl(
             self._state_view.labware.stacker_labware_pool_to_ordered_list(
                 labware_def, lid_def, adapter_def
             )
+        )
+
+        validate_labware_pool_compatible_with_stacker(
+            pool_primary_definition=labware_def,
+            pool_adapter_definition=adapter_def,
+            pool_lid_definition=lid_def,
         )
 
         pool_height = self._state_view.geometry.get_height_of_labware_stack(

--- a/api/src/opentrons/protocol_engine/errors/exceptions.py
+++ b/api/src/opentrons/protocol_engine/errors/exceptions.py
@@ -1339,6 +1339,18 @@ class FlexStackerLabwarePoolNotYetDefinedError(ProtocolEngineError):
         super().__init__(ErrorCodes.GENERAL_ERROR, message, details, wrapping)
 
 
+class LabwarePoolNotCompatibleWithModuleError(ProtocolEngineError):
+    """Raised when attempting to use a labware pool that is incompatible with a module."""
+
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        details: Optional[dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        super().__init__(ErrorCodes.GENERAL_ERROR, message, details, wrapping)
+
+
 class InvalidLabwarePositionError(ProtocolEngineError):
     """Raised when a labware position is internally invalid."""
 


### PR DESCRIPTION
# Overview

The stacker cannot retrieve labware where there is no gap between the bottom and top labware because the stacker latch cannot separate the two pieces of labware. For now, we see this with the `opentrons_tough_universal_lid`, so let's disable using this labware with the stacker by adding a labware exclusion list.

Closes: [EXEC-2014](https://opentrons.atlassian.net/browse/EXEC-2014)

## Test Plan and Hands on Testing

The following protocol should fail analysis with a `LabwarePoolNotCompatibleError`

```python

from opentrons import protocol_api

requirements = {"robotType": "Flex", "apiLevel": "2.26"}

def run(protocol: protocol_api.ProtocolContext):

    # Modules
    tiprack_stacker = protocol.load_module("flexStackerModuleV1", "C4")
    tiprack_stacker.set_stored_labware(
        load_name="opentrons_flex_96_tiprack_200ul",
        count=5,
        lid="opentrons_flex_tiprack_lid",
    )

    plate_stacker = protocol.load_module("flexStackerModuleV1", "D4")
    plate_stacker.set_stored_labware(
        load_name="nest_96_wellplate_2ml_deep",
        count=2,
        lid="opentrons_tough_universal_lid",
    )
```

## Changelog

- Raise `LabwarePoolNotCompatibleError` when a stacker is configured with an incompatible labware pool.

## Review requests
## Risk assessment

[EXEC-2014]: https://opentrons.atlassian.net/browse/EXEC-2014?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ