### PR TITLE
chore(protocol-designer): Enable OT_PD_PRERELEASE_MODE for sandbox builds, so all feature flags are accessible

### DIFF
--- a/.github/workflows/pd-test-build-deploy.yaml
+++ b/.github/workflows/pd-test-build-deploy.yaml
@@ -124,7 +124,7 @@ jobs:
           OT_PD_SENTRY_DSN: ${{ secrets.OT_PD_SENTRY_DSN }}
           OT_PD_SENTRY_DEV_DSN: ${{ secrets.OT_PD_SENTRY_DEV_DSN }}
         run: |
-          make -C protocol-designer NODE_ENV=${{ needs.determine-deploy-config.outputs.environment == 'production' && 'production' || 'development' }}
+          make -C protocol-designer ${{ needs.determine-deploy-config.outputs.environment == 'production' && 'NODE_ENV=production OT_PD_PRERELEASE_MODE=0' || 'NODE_ENV=development OT_PD_PRERELEASE_MODE=1' }}
       - name: "upload sourcemaps to Sentry"
         # Only on production releases (tagged with protocol-designer*)
         if: github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/protocol-designer')

--- a/.github/workflows/pd-test-build-deploy.yaml
+++ b/.github/workflows/pd-test-build-deploy.yaml
@@ -124,7 +124,7 @@ jobs:
           OT_PD_SENTRY_DSN: ${{ secrets.OT_PD_SENTRY_DSN }}
           OT_PD_SENTRY_DEV_DSN: ${{ secrets.OT_PD_SENTRY_DEV_DSN }}
         run: |
-          make -C protocol-designer ${{ needs.determine-deploy-config.outputs.environment == 'production' && 'NODE_ENV=production OT_PD_PRERELEASE_MODE=0' || 'NODE_ENV=development OT_PD_PRERELEASE_MODE=1' }}
+          make -C protocol-designer NODE_ENV=${{ needs.determine-deploy-config.outputs.environment == 'production' && 'production' || 'development' }} OT_PD_PRERELEASE_MODE=${{ needs.determine-deploy-config.outputs.environment == 'sandbox' && '1' || '0' }}
       - name: "upload sourcemaps to Sentry"
         # Only on production releases (tagged with protocol-designer*)
         if: github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/protocol-designer')


### PR DESCRIPTION
## Overview

Protocol Designer feature flags come in two flavors: "user-facing" and "non-user-facing." User-facing flags are always accessible through the UI, even in production builds. Non-user-facing flags are also accessible through the UI, but only if the project was built with a `OT_PD_PRERELEASE_MODE=1` environment variable.

Features in development are usually gated behind non-user-facing flags. So, to test those features in the sandbox, the sandbox builds need to set `OT_PD_PRERELEASE_MODE=1`.

Goes towards EXEC-1666 in general.

## Test Plan and Hands on Testing

I've done this:

1. Clear sandbox.designer.opentrons.com localstorage. (This is necessary to avoid confusing behavior where PD will, sometimes, remember the last value of `OT_PD_PRERELEASE_MODE`).
2. Visit [the sandbox link built from this PR](https://sandbox.designer.opentrons.com/prerelease_feature_flags_in_sandbox_builds/). Go to the gear menu in the top-right. It should list all feature flags through the UI, not just the user-facing feature flags. For example, it should list "Enable Concurrent Module Actions."

## Changelog

Update the GitHub Actions workflow to set `OT_PD_PRERELEASE_MODE=1` for builds deemed "sandbox" and `OT_PD_PRERELEASE_MODE=0` for builds deemed anything else (production or staging).

## Review requests

* Is this a good idea?
* Scrutinize my GitHub Actions YAML syntax.
* The other way of solving this would have been to change Protocol Designer to look at `NODE_ENV`, which the workflow already sets, instead of `OT_PD_PRERELEASE_MODE`. My vague instinct, though, is that that wouldn't be proper. It feels like `NODE_ENV=development` should only control debug features in the build tools themselves, not control what the build produces. Like, in my mind, if this were C, `NODE_ENV=development` should be like using a debug build of `gcc`—it's different from running `gcc -g -O0`. See also https://vite.dev/guide/env-and-mode.html#node-env-and-modes.

## Risk assessment

Medium. Might break the build. Might accidentally expose non-user-facing feature flags in production builds.