### PR TITLE
feat(robot-server): Support image data file notifications

### DIFF
--- a/robot-server/robot_server/data_files/router.py
+++ b/robot-server/robot_server/data_files/router.py
@@ -50,6 +50,10 @@ from ..protocols.dependencies import (
     get_protocol_store,
 )
 from ..service.dependencies import get_current_time, get_unique_id
+from robot_server.service.notifications.publishers import (
+    DataFilePublisher,
+    get_data_file_publisher,
+)
 
 datafiles_router = LightRouter()
 
@@ -515,6 +519,7 @@ async def delete_run_images(
     runId: str,
     data_files_store: Annotated[DataFilesStore, Depends(get_data_files_store)],
     run_data_manager: Annotated[RunDataManager, Depends(get_run_data_manager)],
+    data_file_publisher: Annotated[DataFilePublisher, Depends(get_data_file_publisher)],
 ) -> PydanticResponse[SimpleEmptyBody]:
     """Delete all camera images for a run.
 
@@ -522,6 +527,7 @@ async def delete_run_images(
         runId: The run ID whose images should be deleted.
         data_files_store: Store for data files database access.
         run_data_manager: Current and historical run data management.
+        data_file_publisher: The data file MQTT event publisher.
     """
     try:
         run_data_manager.get(runId)
@@ -529,6 +535,7 @@ async def delete_run_images(
         raise RunNotFound(detail=str(e)).as_error(status.HTTP_404_NOT_FOUND) from e
 
     data_files_store.remove_all_by_run_id(runId)
+    data_file_publisher.publish_run_images(runId)
 
     return await PydanticResponse.create(
         content=SimpleEmptyBody.model_construct(),

--- a/robot-server/robot_server/file_provider/fastapi_dependencies.py
+++ b/robot-server/robot_server/file_provider/fastapi_dependencies.py
@@ -15,6 +15,10 @@ from opentrons.protocol_engine.resources.file_provider import FileProvider
 from robot_server.disk_monitor.dependencies import get_disk_monitor
 from robot_server.disk_monitor.monitor import DiskMonitor
 from robot_server.settings import get_settings, RobotServerSettings
+from robot_server.service.notifications.publishers import (
+    DataFilePublisher,
+    get_data_file_publisher,
+)
 
 
 async def get_file_provider_executor(
@@ -23,6 +27,7 @@ async def get_file_provider_executor(
     images_directory: Annotated[Path, fastapi.Depends(get_images_directory)],
     disk_monitor: Annotated[DiskMonitor, fastapi.Depends(get_disk_monitor)],
     settings: Annotated[RobotServerSettings, fastapi.Depends(get_settings)],
+    publisher: Annotated[DataFilePublisher, fastapi.Depends(get_data_file_publisher)],
 ) -> FileProviderExecutor:
     """Return the server's singleton `FileProviderExecutor` which provides the engine related callbacks for FileProvider."""
     file_provider_wrapper = FileProviderExecutor(
@@ -31,6 +36,7 @@ async def get_file_provider_executor(
         images_directory=images_directory,
         disk_monitor=disk_monitor,
         settings=settings,
+        publisher=publisher,
     )
 
     return file_provider_wrapper

--- a/robot-server/robot_server/file_provider/provider.py
+++ b/robot-server/robot_server/file_provider/provider.py
@@ -15,6 +15,7 @@ from opentrons_shared_data.data_files import (
     OutputDataFileInfo,
     DataFileInfo,
     CmdDataFileInfo,
+    MimeType,
 )
 from robot_server.settings import get_settings, RobotServerSettings
 from ..service.dependencies import get_current_time, get_unique_id
@@ -29,6 +30,10 @@ from opentrons.protocol_engine.resources.file_provider import (
     ReadCmdFileNameMetadata,
     ImageCaptureCmdFileNameMetadata,
 )
+from robot_server.service.notifications.publishers import (
+    DataFilePublisher,
+    get_data_file_publisher,
+)
 
 
 class FileProviderExecutor:
@@ -41,6 +46,7 @@ class FileProviderExecutor:
         data_files_store: Annotated[DataFilesStore, Depends(get_data_files_store)],
         disk_monitor: Annotated[DiskMonitor, Depends(get_disk_monitor)],
         settings: Annotated[RobotServerSettings, Depends(get_settings)],
+        publisher: Annotated[DataFilePublisher, Depends(get_data_file_publisher)],
     ) -> None:
         """Initialize the file provider executor.
 
@@ -54,6 +60,7 @@ class FileProviderExecutor:
         self._disk_monitor = disk_monitor
         self._images_directory_max_size_mb = settings.images_directory_max_size_mb
         self._system_low_space_threshold_mb = settings.system_low_space_threshold_mb
+        self._publisher = publisher
 
         # data file store is not generally safe for concurrent access.
         self._lock = asyncio.Lock()
@@ -118,6 +125,10 @@ class FileProviderExecutor:
 
             await self._data_files_store.insert(file_info)
             await self._data_files_store.insert_output_file(output_file_info)
+
+            if file_data.mime_type == MimeType.IMAGE_JPEG:
+                self._publisher.publish_run_images(file_data.run_metadata.run_id)
+
             return file_info
 
     def _format_filename(self, file_data: FileData, file_id: str) -> str:

--- a/robot-server/robot_server/service/notifications/publishers/__init__.py
+++ b/robot-server/robot_server/service/notifications/publishers/__init__.py
@@ -8,6 +8,7 @@ from .maintenance_runs_publisher import (
     get_maintenance_runs_publisher,
 )
 from .runs_publisher import RunsPublisher, get_runs_publisher
+from .data_file_publisher import DataFilePublisher, get_data_file_publisher
 from .deck_configuration_publisher import (
     DeckConfigurationPublisher,
     get_deck_configuration_publisher,
@@ -18,8 +19,10 @@ __all__ = [
     "MaintenanceRunsPublisher",
     "RunsPublisher",
     "DeckConfigurationPublisher",
+    "DataFilePublisher",
     # for use by FastAPI
     "get_maintenance_runs_publisher",
     "get_runs_publisher",
     "get_deck_configuration_publisher",
+    "get_data_file_publisher",
 ]

--- a/robot-server/robot_server/service/notifications/publishers/data_file_publisher.py
+++ b/robot-server/robot_server/service/notifications/publishers/data_file_publisher.py
@@ -1,0 +1,29 @@
+from typing import Annotated
+import fastapi
+from robot_server.service.notifications import topics
+from robot_server.service.notifications.notification_client import (
+    NotificationClient,
+    get_notification_client,
+)
+
+
+class DataFilePublisher:
+    """Publishes dataFile topics."""
+
+    def __init__(self, client: NotificationClient) -> None:
+        self._client = client
+
+    def publish_run_images(self, run_id: str) -> None:
+        """Publish the equivalent of `GET /dataFiles/{runId}/images`."""
+        self._client.publish_advise_refetch(
+            topic=topics.TopicName(f"{topics.DATA_FILES}/{run_id}/images")
+        )
+
+
+async def get_data_file_publisher(
+    notification_client: Annotated[
+        NotificationClient, fastapi.Depends(get_notification_client)
+    ],
+) -> DataFilePublisher:
+    """Return a DataFilePublisher for use by FastAPI endpoints."""
+    return DataFilePublisher(notification_client)

--- a/robot-server/robot_server/service/notifications/topics.py
+++ b/robot-server/robot_server/service/notifications/topics.py
@@ -31,6 +31,7 @@ RUNS = TopicName(f"{_TOPIC_BASE}/runs")
 DECK_CONFIGURATION = TopicName(f"{_TOPIC_BASE}/deck_configuration")
 RUNS_PRE_SERIALIZED_COMMANDS = TopicName(f"{_TOPIC_BASE}/runs/pre_serialized_commands")
 LABWARE_OFFSETS = TopicName(f"{_TOPIC_BASE}/labwareOffsets")
+DATA_FILES = TopicName(f"{_TOPIC_BASE}/dataFiles")
 
 
 def client_data(key: str) -> TopicName:

--- a/robot-server/tests/data_files/test_router.py
+++ b/robot-server/tests/data_files/test_router.py
@@ -41,6 +41,7 @@ from robot_server.runs.run_models import RunNotFoundError
 from robot_server.data_files.router import download_run_images
 from robot_server.runs.run_store import RunStore
 from robot_server.protocols.protocol_store import ProtocolStore
+from robot_server.service.notifications.publishers import DataFilePublisher
 
 
 @pytest.fixture
@@ -83,6 +84,12 @@ def run_store(decoy: Decoy) -> RunStore:
 def protocol_store(decoy: Decoy) -> ProtocolStore:
     """Get a mocked out ProtocolStore."""
     return decoy.mock(cls=ProtocolStore)
+
+
+@pytest.fixture
+def data_file_publisher(decoy: Decoy) -> DataFilePublisher:
+    """Get a mocked out DataFilePublisher."""
+    return decoy.mock(cls=DataFilePublisher)
 
 
 async def test_upload_new_data_file(
@@ -645,6 +652,7 @@ async def test_delete_run_images(
     decoy: Decoy,
     data_files_store: DataFilesStore,
     run_data_manager: RunDataManager,
+    data_file_publisher: DataFilePublisher,
 ) -> None:
     """It should delete all images for a run."""
     decoy.when(run_data_manager.get("run-id")).then_return(decoy.mock(name="run_data"))
@@ -654,9 +662,12 @@ async def test_delete_run_images(
         runId="run-id",
         data_files_store=data_files_store,
         run_data_manager=run_data_manager,
+        data_file_publisher=data_file_publisher,
     )
 
     decoy.verify(data_files_store.remove_all_by_run_id("run-id"))
+    decoy.verify(data_file_publisher.publish_run_images("run-id"))
+
     assert result.content == SimpleEmptyBody()
     assert result.status_code == 200
 
@@ -665,6 +676,7 @@ async def test_delete_run_images_run_not_found(
     decoy: Decoy,
     data_files_store: DataFilesStore,
     run_data_manager: RunDataManager,
+    data_file_publisher: DataFilePublisher,
 ) -> None:
     """It should raise an error if the run doesn't exist."""
     decoy.when(run_data_manager.get("run-id")).then_raise(
@@ -676,6 +688,7 @@ async def test_delete_run_images_run_not_found(
             runId="run-id",
             data_files_store=data_files_store,
             run_data_manager=run_data_manager,
+            data_file_publisher=data_file_publisher,
         )
 
     assert exc_info.value.status_code == 404


### PR DESCRIPTION
Works towards [EXEC-2017](https://opentrons.atlassian.net/browse/EXEC-2017)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Adds MQTT support for the GET/DELETE `/dataFiles/:runId/images` paths via a new publisher, the `DataFilesPublisher`.

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- Verified via Postman that publish events fire when appropriate, utilizing the following protocol:
```
def run(protocol) -> None:
    protocol.load_instrument("flex_96channel_200")
    protocol.capture_image(filename="contrast_10", zoom=2.0, contrast=10)
    protocol.capture_image(filename="contrast_50", zoom=2.0, contrast=50)
    protocol.capture_image(filename="contrast_100", zoom=2.0, contrast=100)
    protocol.capture_image(filename="brightness_0", zoom=2.0, brightness=0.0)
    protocol.capture_image(filename="brightness_50", zoom=2.0, brightness=50.0)
    protocol.capture_image(filename="brightness100", zoom=2.0, brightness=100.0)
    protocol.capture_image(filename="saturation_0",zoom=2.0, saturation=0)
    protocol.capture_image(filename="saturation_50",zoom=2.0, saturation=50)
    protocol.capture_image(filename="saturation_100",zoom=2.0, saturation=100)
    protocol.capture_image(filename="zoom_2x_with_home", zoom=2.0)
```
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Added MQTT support for GET/DELETE `/dataFiles/:runId/images`.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[EXEC-2017]: https://opentrons.atlassian.net/browse/EXEC-2017?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ