### PR TITLE
fix(api): dynamic pipetting bug fixes

### DIFF
--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -3086,7 +3086,7 @@ class OT3API(
         mount: Union[top_types.Mount, OT3Mount],
         end_point: top_types.Point,
         volume: float,
-        flow_rate: float = 1.0,
+        rate: float = 1.0,
         movement_delay: Optional[float] = None,
     ) -> None:
         """
@@ -3095,12 +3095,12 @@ class OT3API(
         :param mount: A robot mount that the instrument is on.
         :param z_distance: The distance the z axis will move during apsiration.
         :param volume: The volume of liquid to be aspirated.
-        :param flow_rate: The flow rate to aspirate with.
+        :param rate: The rate multiplier to aspirate with.
         :param movement_delay: Time to wait after the pipette starts aspirating before x/y/z movement.
         """
         realmount = OT3Mount.from_mount(mount)
         aspirate_spec = self._pipette_handler.plan_check_aspirate(
-            realmount, volume, flow_rate
+            realmount, volume, rate
         )
         if not aspirate_spec:
             return
@@ -3149,7 +3149,7 @@ class OT3API(
         end_point: top_types.Point,
         volume: float,
         push_out: Optional[float],
-        flow_rate: float = 1.0,
+        rate: float = 1.0,
         is_full_dispense: bool = False,
         movement_delay: Optional[float] = None,
     ) -> None:
@@ -3159,12 +3159,12 @@ class OT3API(
         :param mount: A robot mount that the instrument is on.
         :param z_distance: The distance the z axis will move during dispensing.
         :param volume: The volume of liquid to be dispensed.
-        :param flow_rate: The flow rate to dispense with.
+        :param rate: The rate multiplier to dispense with.
         :param movement_delay: Time to wait after the pipette starts dispensing before x/y/z movement.
         """
         realmount = OT3Mount.from_mount(mount)
         dispense_spec = self._pipette_handler.plan_check_dispense(
-            realmount, volume, flow_rate, push_out, is_full_dispense
+            realmount, volume, rate, push_out, is_full_dispense
         )
         if not dispense_spec:
             return

--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -220,6 +220,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         """
         if meniscus_tracking == MeniscusTrackingTarget.START and end_location is None:
             raise ValueError("Cannot aspirate at the starting liquid height.")
+        final_location = location
         if well_core is None:
             if not in_place:
                 self._engine_client.execute_command(
@@ -280,6 +281,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                     location_type=WellLocationFunction.LIQUID_HANDLING,
                     meniscus_tracking=end_meniscus_tracking,
                 )
+                final_location=end_location
                 assert isinstance(end_well_location, LiquidHandlingWellLocation)
                 self._engine_client.execute_command(
                     cmd.AspirateWhileTrackingParams(
@@ -307,7 +309,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                     )
                 )
 
-        self._protocol_core.set_last_location(location=location, mount=self.get_mount())
+        self._protocol_core.set_last_location(location=final_location, mount=self.get_mount())
 
     def dispense(
         self,
@@ -343,7 +345,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             # Newer API versions raise an error if you try to dispense more than
             # you can. Let the error come from Protocol Engine's validation.
             pass
-
+        final_location=location
         if well_core is None:
             if not in_place:
                 if isinstance(location, (TrashBin, WasteChute)):
@@ -402,6 +404,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             if dynamic_liquid_tracking or end_location is not None:
                 if end_location is None:
                     end_location = location
+                final_location=end_location
                 (
                     end_well_location,
                     _,
@@ -441,7 +444,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                     )
                 )
 
-        self._protocol_core.set_last_location(location=location, mount=self.get_mount())
+        self._protocol_core.set_last_location(location=final_location, mount=self.get_mount())
 
     def blow_out(
         self,

--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -281,7 +281,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                     location_type=WellLocationFunction.LIQUID_HANDLING,
                     meniscus_tracking=end_meniscus_tracking,
                 )
-                final_location=end_location
+                final_location = end_location
                 assert isinstance(end_well_location, LiquidHandlingWellLocation)
                 self._engine_client.execute_command(
                     cmd.AspirateWhileTrackingParams(
@@ -309,7 +309,9 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                     )
                 )
 
-        self._protocol_core.set_last_location(location=final_location, mount=self.get_mount())
+        self._protocol_core.set_last_location(
+            location=final_location, mount=self.get_mount()
+        )
 
     def dispense(
         self,
@@ -345,7 +347,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             # Newer API versions raise an error if you try to dispense more than
             # you can. Let the error come from Protocol Engine's validation.
             pass
-        final_location=location
+        final_location = location
         if well_core is None:
             if not in_place:
                 if isinstance(location, (TrashBin, WasteChute)):
@@ -404,7 +406,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             if dynamic_liquid_tracking or end_location is not None:
                 if end_location is None:
                     end_location = location
-                final_location=end_location
+                final_location = end_location
                 (
                     end_well_location,
                     _,
@@ -444,7 +446,9 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
                     )
                 )
 
-        self._protocol_core.set_last_location(location=final_location, mount=self.get_mount())
+        self._protocol_core.set_last_location(
+            location=final_location, mount=self.get_mount()
+        )
 
     def blow_out(
         self,

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1052,9 +1052,13 @@ class InstrumentContext(publisher.CommandPublisher):
                     # starting in 2.16, we disable push_out on all but the last
                     # dispense() to prevent the tip from jumping out of the liquid
                     # during the mix (PR #14004):
+                    self.move_to(dispense_start_location, force_direct=True)
                     dispense_with_delay(push_out=0.0)
+                    self.move_to(aspirate_start_location, force_direct=True)
                     aspirate_with_delay()
                     repetitions -= 1
+
+                self.move_to(dispense_start_location, force_direct=True)
                 if final_push_out is not None:
                     dispense_with_delay(push_out=final_push_out)
                 else:

--- a/api/src/opentrons/protocol_engine/execution/pipetting.py
+++ b/api/src/opentrons/protocol_engine/execution/pipetting.py
@@ -206,7 +206,6 @@ class HardwarePipettingHandler(PipettingHandler):
             await self._hardware_api.aspirate_while_tracking(
                 mount=hw_pipette.mount,
                 end_point=end_point,
-                flow_rate=flow_rate,
                 volume=adjusted_volume,
                 movement_delay=movement_delay,
             )
@@ -236,7 +235,6 @@ class HardwarePipettingHandler(PipettingHandler):
             await self._hardware_api.dispense_while_tracking(
                 mount=hw_pipette.mount,
                 end_point=end_point,
-                flow_rate=flow_rate,
                 volume=adjusted_volume,
                 push_out=push_out,
                 is_full_dispense=is_full_dispense,

--- a/api/tests/opentrons/protocol_engine/execution/test_pipetting_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_pipetting_handler.py
@@ -354,7 +354,6 @@ async def test_hw_aspirate_while_tracking(
         await mock_hardware_api.aspirate_while_tracking(
             mount=Mount.LEFT,
             end_point=Point(0, 0, 0),
-            flow_rate=2.5,
             volume=25,
             movement_delay=None,
         )


### PR DESCRIPTION
# Overview
Found a few slight issues when testing.

Couldn't set a flow rate below max because we didn't update the flow_rate vs rate change for dynamic pipetting and it was trying to go at flow_rate^2

Mix was coming out of the liquid between aspirate and dispense because the normal waypoint motion planner for aspirate was doing a square move. Now it does a force direct move between points.

Slight problem with setting the last location in pipette core.