### PR TITLE
fix(app): dont use live commands for module setup

### DIFF
--- a/app/src/local-resources/modules/utils/getModulePrepCommands.ts
+++ b/app/src/local-resources/modules/utils/getModulePrepCommands.ts
@@ -39,57 +39,55 @@ export type ModulePrepCommandsType =
 export function getModulePrepCommands(
   module: AttachedModule
 ): ModulePrepCommandsType[] {
-  let modulePrepCommands: ModulePrepCommandsType[] = []
-  if (module.id != null && module.moduleType === THERMOCYCLER_MODULE_TYPE) {
-    modulePrepCommands = [
-      {
-        commandType: 'thermocycler/deactivateLid',
-        params: { moduleId: module.id },
-      },
-      {
-        commandType: 'thermocycler/deactivateBlock',
-        params: { moduleId: module.id },
-      },
-      {
-        commandType: 'thermocycler/openLid',
-        params: { moduleId: module.id },
-      },
-    ]
-  } else if (
-    module.id != null &&
-    module.moduleType === HEATERSHAKER_MODULE_TYPE
-  ) {
-    modulePrepCommands = [
-      {
-        commandType: 'heaterShaker/closeLabwareLatch',
-        params: { moduleId: module.id },
-      },
-      {
-        commandType: 'heaterShaker/deactivateHeater',
-        params: { moduleId: module.id },
-      },
-      {
-        commandType: 'heaterShaker/deactivateShaker',
-        params: { moduleId: module.id },
-      },
-      {
-        commandType: 'heaterShaker/openLabwareLatch',
-        params: { moduleId: module.id },
-      },
-    ]
-  } else if (
-    module.id != null &&
-    module.moduleType === TEMPERATURE_MODULE_TYPE
-  ) {
-    modulePrepCommands = [
-      {
-        commandType: 'temperatureModule/deactivate',
-        params: { moduleId: module.id },
-      },
-    ]
+  if (module.id == null) {
+    console.error('No module id for module prep commands', module)
+    return []
   }
-
-  return modulePrepCommands
+  switch (module.moduleType) {
+    case THERMOCYCLER_MODULE_TYPE:
+      return [
+        {
+          commandType: 'thermocycler/deactivateLid',
+          params: { moduleId: module.id },
+        },
+        {
+          commandType: 'thermocycler/deactivateBlock',
+          params: { moduleId: module.id },
+        },
+        {
+          commandType: 'thermocycler/openLid',
+          params: { moduleId: module.id },
+        },
+      ]
+    case HEATERSHAKER_MODULE_TYPE:
+      return [
+        {
+          commandType: 'heaterShaker/closeLabwareLatch',
+          params: { moduleId: module.id },
+        },
+        {
+          commandType: 'heaterShaker/deactivateHeater',
+          params: { moduleId: module.id },
+        },
+        {
+          commandType: 'heaterShaker/deactivateShaker',
+          params: { moduleId: module.id },
+        },
+        {
+          commandType: 'heaterShaker/openLabwareLatch',
+          params: { moduleId: module.id },
+        },
+      ]
+    case TEMPERATURE_MODULE_TYPE:
+      return [
+        {
+          commandType: 'temperatureModule/deactivate',
+          params: { moduleId: module.id },
+        },
+      ]
+    default:
+      return []
+  }
 }
 
 export function getFlexStackerPrepCommands(

--- a/app/src/organisms/ModuleWizardFlows/PlaceAdapter.tsx
+++ b/app/src/organisms/ModuleWizardFlows/PlaceAdapter.tsx
@@ -1,6 +1,6 @@
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { css } from 'styled-components'
-import { v4 as uuidv4 } from 'uuid'
 
 import {
   AnimationVideo,
@@ -27,11 +27,13 @@ import HeaterShaker_PlaceAdapter_R from '/app/assets/videos/module_wizard_flows/
 import TempModule_PlaceAdapter_L from '/app/assets/videos/module_wizard_flows/TempModule_PlaceAdapter_L.webm'
 import TempModule_PlaceAdapter_R from '/app/assets/videos/module_wizard_flows/TempModule_PlaceAdapter_R.webm'
 import Thermocycler_PlaceAdapter from '/app/assets/videos/module_wizard_flows/Thermocycler_PlaceAdapter.webm'
+import { getModulePrepCommands } from '/app/local-resources/modules'
 import { GenericWizardTile } from '/app/molecules/GenericWizardTile'
 import { SimpleWizardInProgressBody } from '/app/molecules/SimpleWizardBody'
 
 import { LEFT_SLOTS } from './constants'
 
+import type { CommandData } from '@opentrons/api-client'
 import type { CreateCommand, DeckConfiguration } from '@opentrons/shared-data'
 import type { ModuleSetupWizardRequiresPipetteStepProps } from './types'
 
@@ -64,6 +66,8 @@ export function PlaceAdapter(props: PlaceAdapterProps): JSX.Element {
   } = props
   const { t } = useTranslation('module_wizard_flows')
 
+  const [didSetup, setDidSetup] = useState<boolean>(false)
+
   const mount = attachedPipette.mount
   const cutoutId = deckConfig.find(
     cc =>
@@ -73,6 +77,74 @@ export function PlaceAdapter(props: PlaceAdapterProps): JSX.Element {
   )?.cutoutId
   const slotName =
     cutoutId != null ? FLEX_SINGLE_SLOT_BY_CUTOUT_ID[cutoutId] : null
+  if (!didSetup && !!chainRunCommands) {
+    // Run the module setup commands. This is a little finicky because we might run
+    // them several times if this component is mounted and unmounted.
+    const calibrationAdapterLoadName = getCalibrationAdapterLoadName(
+      attachedModule.moduleModel
+    )
+    if (calibrationAdapterLoadName == null) {
+      setErrorMessage(
+        `could not get calibration adapter load name for ${attachedModule.moduleModel}`
+      )
+    }
+    if (slotName == null) {
+      setErrorMessage(
+        `could not load module ${attachedModule.moduleModel} into location ${slotName}`
+      )
+    }
+
+    const calibrationAdapterId = `${attachedModule.id}-calibration-adapter`
+    // it's always ok to run loadmodule because if you load a module twice we
+    // override the previous one
+    chainRunCommands(
+      [
+        {
+          commandType: 'loadModule',
+          params: {
+            location: { slotName: slotName ?? '' },
+            model: attachedModule.moduleModel,
+            moduleId: attachedModule.id,
+          },
+        },
+      ],
+      false
+    )
+      .then(() =>
+        chainRunCommands(
+          [
+            {
+              commandType: 'loadLabware',
+              params: {
+                labwareId: calibrationAdapterId,
+                location: { moduleId: attachedModule.id },
+                version: 1,
+                namespace: 'opentrons',
+                loadName: calibrationAdapterLoadName ?? '',
+              },
+            },
+          ],
+          true
+        )
+      )
+      // it's not always safe to load labware since the position might be taken,
+      // but this is such a limited interaction that we can be confident that we'll
+      // only fail because that labware was already loaded, and since we load with
+      // fixed ids we can be confident that a labware exists at that id to use
+      .catch(
+        () =>
+          new Promise<CommandData[]>(resolve => {
+            resolve([])
+          })
+      )
+      .finally(() => {
+        setCreatedAdapterId(calibrationAdapterId)
+      })
+      .then(() =>
+        chainRunCommands(getModulePrepCommands(attachedModule), false)
+      )
+    setDidSetup(true)
+  }
   const handleOnClick = (): void => {
     const calibrationAdapterLoadName = getCalibrationAdapterLoadName(
       attachedModule.moduleModel
@@ -88,26 +160,7 @@ export function PlaceAdapter(props: PlaceAdapterProps): JSX.Element {
       )
     }
 
-    const calibrationAdapterId = uuidv4()
-    const commands: CreateCommand[] = [
-      {
-        commandType: 'loadModule',
-        params: {
-          location: { slotName: slotName ?? '' },
-          model: attachedModule.moduleModel,
-          moduleId: attachedModule.id,
-        },
-      },
-      {
-        commandType: 'loadLabware',
-        params: {
-          labwareId: calibrationAdapterId,
-          location: { moduleId: attachedModule.id },
-          version: 1,
-          namespace: 'opentrons',
-          loadName: calibrationAdapterLoadName ?? '',
-        },
-      },
+    const moveToPositionCommands: CreateCommand[] = [
       { commandType: 'home' as const, params: {} },
       {
         commandType: 'calibration/moveToMaintenancePosition',
@@ -118,10 +171,7 @@ export function PlaceAdapter(props: PlaceAdapterProps): JSX.Element {
       },
     ]
 
-    chainRunCommands?.(commands, false)
-      .then(() => {
-        setCreatedAdapterId(calibrationAdapterId)
-      })
+    chainRunCommands?.(moveToPositionCommands, false)
       .then(() => {
         proceed()
       })
@@ -205,7 +255,9 @@ export function PlaceAdapter(props: PlaceAdapterProps): JSX.Element {
         proceedButtonText={t('confirm_placement')}
         proceed={handleOnClick}
         proceedIsDisabled={maintenanceRunId == null}
-        back={goBack}
+        back={() => {
+          goBack()
+        }}
       />
     )
   }

--- a/app/src/organisms/ModuleWizardFlows/SelectLocation.tsx
+++ b/app/src/organisms/ModuleWizardFlows/SelectLocation.tsx
@@ -92,11 +92,14 @@ export function SelectLocation(props: SelectLocationProps): JSX.Element {
 
   const handleOnClick = (): void => {
     if (maintenanceRunId == null) {
-      createMaintenanceRun({}).catch(error => {
-        setErrorMessage(error.message as string)
-      })
+      createMaintenanceRun({})
+        .catch(error => {
+          setErrorMessage(error.message as string)
+        })
+        .then(proceed)
+    } else {
+      proceed()
     }
-    proceed()
   }
   const { updateDeckConfiguration } = useUpdateDeckConfigurationMutation()
   const deckDef = getDeckDefFromRobotType(FLEX_ROBOT_TYPE)

--- a/app/src/organisms/ModuleWizardFlows/useModuleSetupWizard.ts
+++ b/app/src/organisms/ModuleWizardFlows/useModuleSetupWizard.ts
@@ -3,7 +3,6 @@ import { useSelector } from 'react-redux'
 
 import { useDeleteMaintenanceRunMutation } from '@opentrons/react-api-client'
 
-import { getModulePrepCommands } from '/app/local-resources/modules'
 import { getIsOnDevice } from '/app/redux/config'
 import { useNotifyDeckConfigurationQuery } from '/app/resources/deck_configuration'
 import { useAttachedPipettesFromInstrumentsQuery } from '/app/resources/instruments'
@@ -11,10 +10,7 @@ import {
   useChainMaintenanceCommands,
   useNotifyCurrentMaintenanceRun,
 } from '/app/resources/maintenance_runs'
-import {
-  useChainLiveCommands,
-  useCreateTargetedMaintenanceRunMutation,
-} from '/app/resources/runs'
+import { useCreateTargetedMaintenanceRunMutation } from '/app/resources/runs'
 
 import { ACTIONS } from './constants'
 import { useSendIdentifyStacker } from './hooks'
@@ -98,8 +94,6 @@ export function useModuleSetupWizard(
 
   const { chainRunCommands, isCommandMutationLoading } =
     useChainMaintenanceCommands()
-  const { chainLiveCommands, isCommandMutationLoading: isLiveCommandLoading } =
-    useChainLiveCommands()
 
   const { createTargetedMaintenanceRun, isLoading: isCreateLoading } =
     useCreateTargetedMaintenanceRunMutation({
@@ -143,14 +137,24 @@ export function useModuleSetupWizard(
   const handleCleanUpAndClose = (): void => {
     setIsExiting(true)
     if (attachedModule != null) sendIdentifyStacker(attachedModule, false)
-    if (maintenanceRunId == null) handleClose()
-    else {
+    if (maintenanceRunId == null) {
+      console.log(
+        'closing module setup wizard: no maintenance run, not deleting'
+      )
+      handleClose()
+    } else {
+      console.log(
+        'closing module setup wizard: homing and clearing maintenance run'
+      )
       chainRunCommands(
         maintenanceRunId,
         [{ commandType: 'home' as const, params: {} }],
-        false
+        true
       )
         .then(() => {
+          console.log(
+            'closing module setup wizard: homed, clearing maintenance run'
+          )
           deleteMaintenanceRun(maintenanceRunId)
           handleClose()
         })
@@ -174,22 +178,12 @@ export function useModuleSetupWizard(
   const [isModuleUpdating, setIsModuleUpdating] = useState<boolean>(false)
 
   useEffect(() => {
-    if (
-      isCommandMutationLoading ||
-      isExiting ||
-      isCreateLoading ||
-      isLiveCommandLoading
-    ) {
+    if (isCommandMutationLoading || isExiting || isCreateLoading) {
       setIsRobotMoving(true)
     } else {
       setIsRobotMoving(false)
     }
-  }, [
-    isCommandMutationLoading,
-    isExiting,
-    isCreateLoading,
-    isLiveCommandLoading,
-  ])
+  }, [isCommandMutationLoading, isExiting, isCreateLoading])
 
   let chainMaintenanceRunCommands
 
@@ -221,15 +215,6 @@ export function useModuleSetupWizard(
   const buildFlowForSelectedModule = (
     selectedModuleToBuildFlow: AttachedModule
   ): void => {
-    const modulePrepCommands = getModulePrepCommands(selectedModuleToBuildFlow)
-    if (modulePrepCommands.length > 0) {
-      chainLiveCommands(
-        getModulePrepCommands(selectedModuleToBuildFlow),
-        false
-      ).catch((e: Error) => {
-        setErrorMessage(e.message)
-      })
-    }
     dispatch({
       type: ACTIONS.BUILD_FLOW,
       attachedModule: selectedModuleToBuildFlow,


### PR DESCRIPTION
Live commands don't really work that well in general and really really don't work that well for modules, which have their state synced to the engine from hardware once when they're loaded (since the engine otherwise is the thing that's in control of them). Since we're creating a maintenance run for module setup anyway, let's use that maintenance run to run the module prep commands.

How to do this is a little trickier; the prep commands want to run before we display the UI to put the calibration adapter in place (since most of the time the thing you're prepping is the module's ability to take the adapter, such as opening the thermocycler lid). We can do this with a gross run-once hook in the appropriate component, but that run-once machinery goes away when the component is unmounted... which it is when you go backwards in the flow... and then we try and load everything again and fail. Luckily, with a little more interaction with the robot and knowledge of some peculiarities of the engine, we can get that squared away by using a known labware ID, and bob's your uncle.

Closes RQA-2020

## Testing
- Run module setup