### PR TITLE
refactor(protocol-designer): Merge DELETE_STEP and DELETE_MULTIPLE_STEPS actions

### DIFF
--- a/protocol-designer/src/load-file/__tests__/reducers.test.ts
+++ b/protocol-designer/src/load-file/__tests__/reducers.test.ts
@@ -20,7 +20,6 @@ describe('unsavedChanges', () => {
       'REMOVE_WELLS_CONTENTS',
       'SET_WELL_CONTENTS',
       'ADD_STEP',
-      'DELETE_STEP',
       'DELETE_MULTIPLE_STEPS',
       'REORDER_STEPS',
       'REORDER_SELECTED_STEP',

--- a/protocol-designer/src/load-file/reducers.ts
+++ b/protocol-designer/src/load-file/reducers.ts
@@ -55,7 +55,6 @@ const unsavedChanges = (state: boolean = false, action: Action): boolean => {
     case 'REMOVE_WELLS_CONTENTS':
     case 'SET_WELL_CONTENTS':
     case 'ADD_STEP':
-    case 'DELETE_STEP':
     case 'DELETE_MULTIPLE_STEPS':
     case 'REORDER_STEPS':
     case 'REORDER_SELECTED_STEP':

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/ConnectedStepContainer.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/ConnectedStepContainer.tsx
@@ -33,7 +33,6 @@ import type {
   SetStateAction,
 } from 'react'
 import type { IconName } from '@opentrons/components'
-import type { StepIdType } from '/protocol-designer/form-types'
 import type { BaseState } from '/protocol-designer/types'
 
 const STARTING_DECK_STATE = 'Starting deck'
@@ -146,13 +145,9 @@ export function ConnectedStepContainer(
     cancel: cancelMultiDelete,
   } = useConditionalConfirm(onDeleteClickAction, true)
 
-  const deleteStep = (stepId: StepIdType): void => {
-    dispatch(steplistActions.deleteStep(stepId))
-  }
-
   const handleDelete = (): void => {
     if (stepId != null) {
-      deleteStep(stepId)
+      dispatch(steplistActions.deleteMultipleSteps([stepId]))
     } else {
       console.warn(
         'something went wrong, cannot delete a step without a step id'

--- a/protocol-designer/src/step-forms/reducers/index.ts
+++ b/protocol-designer/src/step-forms/reducers/index.ts
@@ -82,7 +82,6 @@ import type {
   ChangeFormInputAction,
   ChangeSavedStepFormAction,
   DeleteMultipleStepsAction,
-  DeleteStepAction,
   FormPatch,
   PopulateFormAction,
   ReorderStepsAction,
@@ -129,7 +128,6 @@ export type UnsavedFormActions =
   | PopulateFormAction
   | CancelStepFormAction
   | SaveStepFormAction
-  | DeleteStepAction
   | DeleteMultipleStepsAction
   | CreateModuleAction
   | DeleteModuleAction
@@ -195,7 +193,6 @@ export const unsavedForm = (
     case 'TOGGLE_IS_GRIPPER_REQUIRED':
     case 'CREATE_DECK_FIXTURE':
     case 'DELETE_DECK_FIXTURE':
-    case 'DELETE_STEP':
     case 'DELETE_MULTIPLE_STEPS':
     case 'SELECT_MULTIPLE_STEPS':
     case 'SAVE_STEP_FORM':
@@ -259,7 +256,6 @@ export const initialSavedStepFormsState: SavedStepFormState = {
 export type SavedStepFormsActions =
   | SaveStepFormAction
   | SaveStepFormsMultiAction
-  | DeleteStepAction
   | DeleteMultipleStepsAction
   | LoadFileAction
   | CreateContainerAction
@@ -362,10 +358,6 @@ export const savedStepForms = (
         }),
         { ...savedStepForms }
       )
-    }
-
-    case 'DELETE_STEP': {
-      return omit(savedStepForms, action.payload)
     }
 
     case 'DELETE_MULTIPLE_STEPS': {
@@ -1588,8 +1580,6 @@ export const orderedStepIds: Reducer<OrderedStepIdsState, any> = handleActions(
 
       return state
     },
-    DELETE_STEP: (state: OrderedStepIdsState, action: DeleteStepAction) =>
-      state.filter(stepId => stepId !== action.payload),
     DELETE_MULTIPLE_STEPS: (
       state: OrderedStepIdsState,
       action: DeleteMultipleStepsAction
@@ -1669,7 +1659,6 @@ export type PresavedStepFormState = {
 export type PresavedStepFormAction =
   | AddStepAction
   | CancelStepFormAction
-  | DeleteStepAction
   | DeleteMultipleStepsAction
   | SaveStepFormAction
   | SelectTerminalItemAction
@@ -1689,7 +1678,6 @@ export const presavedStepForm = (
       return action.payload === PRESAVED_STEP_ID ? state : null
 
     case 'CANCEL_STEP_FORM':
-    case 'DELETE_STEP':
     case 'DELETE_MULTIPLE_STEPS':
     case 'SAVE_STEP_FORM':
     case 'SELECT_STEP':

--- a/protocol-designer/src/step-forms/test/reducers.test.ts
+++ b/protocol-designer/src/step-forms/test/reducers.test.ts
@@ -95,14 +95,6 @@ describe('orderedStepIds reducer', () => {
     }
     expect(orderedStepIds(state, action)).toBe(state)
   })
-  it('should remove a saved step when the step is deleted', () => {
-    const state = ['1', '2', '3']
-    const action = {
-      type: 'DELETE_STEP',
-      payload: '2',
-    }
-    expect(orderedStepIds(state, action)).toEqual(['1', '3'])
-  })
   it('should remove multiple saved steps when multiple steps are deleted', () => {
     const state = ['1', '2', '3']
     const action = {
@@ -1198,23 +1190,6 @@ describe('savedStepForms reducer: initial deck setup step', () => {
         },
       }
     })
-    it('should delete one step', () => {
-      const action = {
-        type: 'DELETE_STEP',
-        payload: 'id1',
-      }
-      const expectedState = { ...savedStepFormsState }
-      delete expectedState.id1
-      expect(
-        savedStepForms(
-          // @ts-expect-error(sa, 2021-6-14): add missing keys to savedStepFormsState
-          {
-            savedStepForms: savedStepFormsState,
-          },
-          action
-        )
-      ).toEqual(expectedState)
-    })
     it('should delete multiple steps', () => {
       const action = {
         type: 'DELETE_MULTIPLE_STEPS',
@@ -1501,7 +1476,6 @@ describe('unsavedForm reducer', () => {
     'CANCEL_STEP_FORM',
     'CREATE_MODULE',
     'DELETE_MODULE',
-    'DELETE_STEP',
     'DELETE_MULTIPLE_STEPS',
     'SAVE_STEP_FORM',
     'SELECT_TERMINAL_ITEM',
@@ -1599,7 +1573,6 @@ describe('presavedStepForm reducer', () => {
   })
   const clearingActions: Array<PresavedStepFormAction['type']> = [
     'CANCEL_STEP_FORM',
-    'DELETE_STEP',
     'DELETE_MULTIPLE_STEPS',
     'SAVE_STEP_FORM',
     'SELECT_STEP',

--- a/protocol-designer/src/steplist/actions/actions.ts
+++ b/protocol-designer/src/steplist/actions/actions.ts
@@ -34,15 +34,6 @@ export interface PopulateFormAction {
   type: 'POPULATE_FORM'
   payload: FormData
 }
-// Create new step
-export interface DeleteStepAction {
-  type: 'DELETE_STEP'
-  payload: StepIdType
-}
-export const deleteStep = (stepId: StepIdType): DeleteStepAction => ({
-  type: 'DELETE_STEP',
-  payload: stepId,
-})
 export interface DeleteMultipleStepsAction {
   type: 'DELETE_MULTIPLE_STEPS'
   payload: StepIdType[]

--- a/protocol-designer/src/ui/steps/reducers.ts
+++ b/protocol-designer/src/ui/steps/reducers.ts
@@ -83,7 +83,6 @@ const selectedItem: Reducer<SelectedItemState, any> = handleActions(
       state: SelectedItemState,
       action: SelectTerminalItemAction
     ) => terminalItemIdHelper(action.payload),
-    DELETE_STEP: () => null,
     CLEAR_SELECTED_ITEM: () => null,
     SELECT_MULTIPLE_STEPS: (
       state: SelectedItemState,

--- a/protocol-designer/src/ui/steps/test/reducers.test.ts
+++ b/protocol-designer/src/ui/steps/test/reducers.test.ts
@@ -142,17 +142,4 @@ describe('selectedItem reducer', () => {
       })
     })
   })
-
-  it('should deselect on DELETE_STEP', () => {
-    const action = {
-      type: 'DELETE_STEP',
-      payload: 'someStepId',
-    }
-    expect(
-      selectedItem(
-        { selectionType: SINGLE_STEP_SELECTION_TYPE, id: 'anyId' },
-        action
-      )
-    ).toEqual(null)
-  })
 })


### PR DESCRIPTION
## Overview

This simplifies some of Protocol Designer's code for deleting steps. Goes towards EXEC-2024.

## Test Plan and Hands on Testing

* [x] Deleting a single step in the timeline from its 3-dot menu still works.
* [x] Deleting multiple steps in the timeline from one of their 3-dot menus still works.

## Details

Depending on how you delete a step in Protocol Designer, it either happens through the `DELETE_STEP` Redux action or the `DELETE_MULTIPLE_STEPS` Redux action.

The two actions have grown a small inconsistency between them, having to do with how they update the *selected* step. [`DELETE_MULTIPLE_STEPS` tries to automatically select a new step to replace it](https://github.com/Opentrons/opentrons/blob/4cd4ab98bd7fca0f8912f6d66aa31a0736ea67e1/protocol-designer/src/steplist/actions/actions.ts#L73), whereas [`DELETE_STEP` simply clears the selection](https://github.com/Opentrons/opentrons/blob/58619d35ebf4b59f2e69a4d7503d9ead001b3e42/protocol-designer/src/ui/steps/reducers.ts#L86). 

The algorithm for automatically selecting a new step would get more complicated with the feature of concurrent module actions, so I'm not sure whether we'll choose to preserve that behavior, or the simpler behavior of clearing the selection. But regardless of which behavior we choose, it's nicer if we don't have to keep two actions in sync with each other.

So, this removes the `DELETE_STEP` action. Instead, you can just dispatch `DELETE_MULTIPLE_STEPS` with a 1-element list.

## Review requests

Not sure. This was basically just a global find + replace. Any special PD or Redux hazards I ought to be aware of?

## Risk assessment

Low?
