### PR TITLE
feat(step-generation): wire up tip selection in JSON step generation

### DIFF
--- a/protocol-designer/src/file-data/__tests__/createFile.test.ts
+++ b/protocol-designer/src/file-data/__tests__/createFile.test.ts
@@ -152,7 +152,7 @@ metadata = {
     "source": "Protocol Designer",
 }
 
-requirements = {"robotType": "OT-2", "apiLevel": "2.26"}
+requirements = {"robotType": "OT-2", "apiLevel": "2.27"}
 
 def run(protocol: protocol_api.ProtocolContext) -> None:
     # Load Labware:

--- a/protocol-designer/src/file-data/__tests__/createFile.test.ts
+++ b/protocol-designer/src/file-data/__tests__/createFile.test.ts
@@ -15,6 +15,7 @@ import {
   fixture_tiprack_10_ul,
   fixture_tiprack_300_ul,
 } from '@opentrons/shared-data/labware/fixtures/2'
+import { formatPyStr, PAPI_VERSION } from '@opentrons/step-generation'
 
 import {
   dismissedWarnings,
@@ -152,7 +153,7 @@ metadata = {
     "source": "Protocol Designer",
 }
 
-requirements = {"robotType": "OT-2", "apiLevel": "2.27"}
+requirements = {"robotType": "OT-2", "apiLevel": ${formatPyStr(PAPI_VERSION)}}
 
 def run(protocol: protocol_api.ProtocolContext) -> None:
     # Load Labware:

--- a/step-generation/src/__tests__/mix.test.ts
+++ b/step-generation/src/__tests__/mix.test.ts
@@ -8,6 +8,7 @@ import {
 } from '@opentrons/shared-data'
 
 import { mix } from '../commandCreators/compound/mix'
+import { MANUAL } from '../constants'
 import {
   blowoutHelper,
   DEFAULT_PIPETTE,
@@ -872,6 +873,94 @@ mock_pipette.mix(
     dispense_flow_rate=2.2,
 )
 mock_pipette.drop_tip(location=mock_tip_rack_1["C1"])`
+    )
+  })
+  it('should return tip if changeTip is once', () => {
+    args.dropTipLocation = 'fixture/fixture_tiprack_300_ul/1'
+    args.wells = ['A1', 'B1', 'C1']
+    args.changeTip = 'once'
+    const result = mix(args, invariantContext, robotStateWithTip)
+    expect(getSuccessResult(result).python).toBe(
+      `mock_pipette.drop_tip()
+mock_pipette.pick_up_tip(location=mock_tip_rack_1)
+mock_pipette.mix(
+    repetitions=2,
+    volume=8,
+    location=mock_source_plate["A1"].bottom(z=3.2),
+    aspirate_flow_rate=2.1,
+    dispense_flow_rate=2.2,
+)
+mock_pipette.mix(
+    repetitions=2,
+    volume=8,
+    location=mock_source_plate["B1"].bottom(z=3.2),
+    aspirate_flow_rate=2.1,
+    dispense_flow_rate=2.2,
+)
+mock_pipette.mix(
+    repetitions=2,
+    volume=8,
+    location=mock_source_plate["C1"].bottom(z=3.2),
+    aspirate_flow_rate=2.1,
+    dispense_flow_rate=2.2,
+)
+mock_pipette.drop_tip(location=mock_tip_rack_1["A1"])`
+    )
+  })
+})
+
+describe('mix: select tip', () => {
+  let args: MixArgs
+  beforeEach(() => {
+    args = {
+      ...mixinArgs,
+      volume: 8,
+      times: 2,
+      dropTipLocation: 'fixture/fixture_tiprack_300_ul/1',
+      wells: ['A1', 'B1', 'C1'],
+      changeTip: 'always',
+    } as MixArgs
+  })
+  it('should select tips if tipTracking is manual', () => {
+    args = {
+      ...args,
+      dropTipLocation: 'fixture/fixture_tiprack_300_ul/1',
+      wells: ['A1', 'B1', 'C1'],
+      changeTip: 'always',
+      tipTracking: MANUAL,
+      tipsSelected: [['E5'], ['F5'], ['G5']],
+      tiprackSelected: 'tiprack1Id',
+    }
+    const result = mix(args, invariantContext, robotStateWithTip)
+    expect(getSuccessResult(result).python).toBe(
+      `mock_pipette.drop_tip()
+mock_pipette.pick_up_tip(location=mock_tip_rack_1["E5"])
+mock_pipette.mix(
+    repetitions=2,
+    volume=8,
+    location=mock_source_plate["A1"].bottom(z=3.2),
+    aspirate_flow_rate=2.1,
+    dispense_flow_rate=2.2,
+)
+mock_pipette.drop_tip(location=mock_tip_rack_1["E5"])
+mock_pipette.pick_up_tip(location=mock_tip_rack_1["F5"])
+mock_pipette.mix(
+    repetitions=2,
+    volume=8,
+    location=mock_source_plate["B1"].bottom(z=3.2),
+    aspirate_flow_rate=2.1,
+    dispense_flow_rate=2.2,
+)
+mock_pipette.drop_tip(location=mock_tip_rack_1["F5"])
+mock_pipette.pick_up_tip(location=mock_tip_rack_1["G5"])
+mock_pipette.mix(
+    repetitions=2,
+    volume=8,
+    location=mock_source_plate["C1"].bottom(z=3.2),
+    aspirate_flow_rate=2.1,
+    dispense_flow_rate=2.2,
+)
+mock_pipette.drop_tip(location=mock_tip_rack_1["G5"])`
     )
   })
   it('should return tip if changeTip is once', () => {

--- a/step-generation/src/__tests__/pythonFileUtils.test.ts
+++ b/step-generation/src/__tests__/pythonFileUtils.test.ts
@@ -94,11 +94,11 @@ metadata = {
 describe('pythonRequirements', () => {
   it('should generate requirements section', () => {
     expect(pythonRequirements(OT2_ROBOT_TYPE)).toBe(
-      `requirements = {"robotType": "OT-2", "apiLevel": "2.26"}`
+      `requirements = {"robotType": "OT-2", "apiLevel": "2.27"}`
     )
 
     expect(pythonRequirements(FLEX_ROBOT_TYPE)).toBe(
-      `requirements = {"robotType": "Flex", "apiLevel": "2.26"}`
+      `requirements = {"robotType": "Flex", "apiLevel": "2.27"}`
     )
   })
 })

--- a/step-generation/src/__tests__/pythonFileUtils.test.ts
+++ b/step-generation/src/__tests__/pythonFileUtils.test.ts
@@ -20,6 +20,7 @@ import {
 
 import {
   formatChangeTipArg,
+  formatPyStr,
   getDefineLiquids,
   getLoadAdapters,
   getLoadLabware,
@@ -30,6 +31,7 @@ import {
   getLoadPipettes,
   getLoadTrashBins,
   getLoadWasteChute,
+  PAPI_VERSION,
   pythonMetadata,
   pythonRequirements,
 } from '../utils'
@@ -94,11 +96,11 @@ metadata = {
 describe('pythonRequirements', () => {
   it('should generate requirements section', () => {
     expect(pythonRequirements(OT2_ROBOT_TYPE)).toBe(
-      `requirements = {"robotType": "OT-2", "apiLevel": "2.27"}`
+      `requirements = {"robotType": "OT-2", "apiLevel": ${formatPyStr(PAPI_VERSION)}}`
     )
 
     expect(pythonRequirements(FLEX_ROBOT_TYPE)).toBe(
-      `requirements = {"robotType": "Flex", "apiLevel": "2.27"}`
+      `requirements = {"robotType": "Flex", "apiLevel": ${formatPyStr(PAPI_VERSION)}}`
     )
   })
 })

--- a/step-generation/src/__tests__/replaceTip.test.ts
+++ b/step-generation/src/__tests__/replaceTip.test.ts
@@ -344,6 +344,36 @@ describe('replaceTip', () => {
         type: 'DROP_TIP_LOCATION_DOES_NOT_EXIST',
       })
     })
+    it('Single-channel: manual tip selection', () => {
+      invariantContext = {
+        ...invariantContext,
+        wasteChuteEntities: {},
+        trashBinEntities: {},
+      }
+      const result = replaceTip(
+        {
+          pipette: p300SingleId,
+          dropTipLocation: FIXED_TRASH_ID,
+          tipRack: tiprackURI1,
+          tipSelectionArgs: {
+            tipRackId: tiprack1Id,
+            tipWell: 'C5',
+          },
+        },
+        (invariantContext = {
+          ...invariantContext,
+          wasteChuteEntities: {},
+          trashBinEntities: {},
+        }),
+        initialRobotState
+      )
+      expect(getSuccessResult(result).commands).toEqual([
+        pickUpTipHelper('C5', {
+          pipetteId: p300SingleId,
+          labwareId: tiprack1Id,
+        }),
+      ])
+    })
   })
   describe('replaceTip: multi-channel', () => {
     it('multi-channel, all tipracks have tips', () => {

--- a/step-generation/src/commandCreators/atomic/pickUpTip.ts
+++ b/step-generation/src/commandCreators/atomic/pickUpTip.ts
@@ -1,9 +1,10 @@
-import { COLUMN_4_SLOTS } from '../../constants'
+import { AUTOMATIC, COLUMN_4_SLOTS, MANUAL } from '../../constants'
 import {
   pipettingIntoColumn4,
   possiblePipetteCollision,
 } from '../../errorCreators'
 import {
+  formatPyStr,
   getIsSafePipetteMovement,
   getSlotInLocationStack,
   uuid,
@@ -13,10 +14,15 @@ import type {
   NozzleConfigurationStyle,
   PickUpTipParams,
 } from '@opentrons/shared-data'
-import type { CommandCreator, CommandCreatorError } from '../../types'
+import type {
+  CommandCreator,
+  CommandCreatorError,
+  TipTrackingOption,
+} from '../../types'
 
 interface PickUpTipAtomicParams extends PickUpTipParams {
   nozzles?: NozzleConfigurationStyle
+  tipTrackingOption?: TipTrackingOption
 }
 
 export const pickUpTip: CommandCreator<PickUpTipAtomicParams> = (
@@ -24,7 +30,7 @@ export const pickUpTip: CommandCreator<PickUpTipAtomicParams> = (
   invariantContext,
   prevRobotState
 ) => {
-  const { pipetteId, labwareId, wellName } = args
+  const { pipetteId, labwareId, wellName, tipTrackingOption = AUTOMATIC } = args
   const errors: CommandCreatorError[] = []
 
   const isMultiChannelPipette =
@@ -66,7 +72,7 @@ export const pickUpTip: CommandCreator<PickUpTipAtomicParams> = (
   // We don't specify the tip well because it would make it hard for users to modify
   // the Python protocol. We do specify the tip rack because multiple tip racks could be
   // assigned to the pipette, and the UI makes the user choose which tip rack to use.
-  const python = `${pipettePythonName}.pick_up_tip(location=${tiprackPythonName})`
+  const python = `${pipettePythonName}.pick_up_tip(location=${tiprackPythonName}${tipTrackingOption === MANUAL ? `[${formatPyStr(wellName)}]` : ''})`
 
   if (errors.length > 0) {
     return { errors }

--- a/step-generation/src/commandCreators/compound/consolidate.ts
+++ b/step-generation/src/commandCreators/compound/consolidate.ts
@@ -651,19 +651,31 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
         // path is in ['always', 'once', 'never']
         changeTip === 'always' || (changeTip === 'once' && isFirstChunk)
 
-      const tipCommands = changeTipNow
-        ? [
-            curryCommandCreator(replaceTip, {
-              pipette,
-              dropTipLocation:
-                isReturnTip && fallBackTrashLikeId != null
-                  ? fallBackTrashLikeId
-                  : dropTipLocation,
-              tipRack,
-              ...(nozzles != null ? { nozzles } : {}),
-            }),
-          ]
-        : []
+      let tipCommands: CurriedCommandCreator[] = []
+      if (changeTipNow) {
+        const nextTip = targetTips?.shift()
+        tipCommands = [
+          curryCommandCreator(replaceTip, {
+            pipette,
+            dropTipLocation:
+              isReturnTip && fallBackTrashLikeId != null
+                ? fallBackTrashLikeId
+                : dropTipLocation,
+            tipRack,
+            ...(nozzles != null ? { nozzles } : {}),
+            ...(tipTracking === MANUAL &&
+            nextTip != null &&
+            tiprackSelected != null
+              ? {
+                  tipSelectionArgs: {
+                    tipRackId: tiprackSelected,
+                    tipWell: nextTip,
+                  },
+                }
+              : {}),
+          }),
+        ]
+      }
 
       // Aspirate commands for all source wells in the chunk
       const aspirateCommands = flatMap(

--- a/step-generation/src/commandCreators/compound/distribute.ts
+++ b/step-generation/src/commandCreators/compound/distribute.ts
@@ -631,19 +631,31 @@ export const distribute: CommandCreator<DistributeArgs> = (
           ]
         : []
 
-      const tipCommands = changeTipNow
-        ? [
-            curryCommandCreator(replaceTip, {
-              pipette,
-              dropTipLocation:
-                isReturnTip && fallBackTrashLikeId != null
-                  ? fallBackTrashLikeId
-                  : dropTipLocation,
-              tipRack,
-              ...(nozzles != null ? { nozzles } : {}),
-            }),
-          ]
-        : []
+      let tipCommands: CurriedCommandCreator[] = []
+      if (changeTipNow) {
+        const nextTip = targetTips?.shift()
+        tipCommands = [
+          curryCommandCreator(replaceTip, {
+            pipette,
+            dropTipLocation:
+              isReturnTip && fallBackTrashLikeId != null
+                ? fallBackTrashLikeId
+                : dropTipLocation,
+            tipRack,
+            ...(nozzles != null ? { nozzles } : {}),
+            ...(tipTracking === MANUAL &&
+            nextTip != null &&
+            tiprackSelected != null
+              ? {
+                  tipSelectionArgs: {
+                    tipRackId: tiprackSelected,
+                    tipWell: nextTip,
+                  },
+                }
+              : {}),
+          }),
+        ]
+      }
       // TODO (nd, 05/20/2025): uncomment and refine below logic once meniscus-relative pipetting is supported in PD
       // let liquidProbeCommand: CurriedCommandCreator[] = []
       // if (changeTipNow && !probedWells.has(sourceWell)) {

--- a/step-generation/src/commandCreators/compound/mix.ts
+++ b/step-generation/src/commandCreators/compound/mix.ts
@@ -1,6 +1,7 @@
 import flatMap from 'lodash/flatMap'
 
 import {
+  ALL,
   getByVolumeValue,
   getIsTiprack,
   GRIPPER_WASTE_CHUTE_ADDRESSABLE_AREA,
@@ -8,14 +9,17 @@ import {
   WELL_ORIGIN_BOTTOM,
 } from '@opentrons/shared-data'
 
+import { MANUAL } from '../../constants'
 import * as errorCreators from '../../errorCreators'
 import {
   curryCommandCreator,
   curryWithoutPython,
   formatPyStr,
   formatPyWellLocation,
+  getDefaultPrimaryNozzle,
   getIsSafePipetteMovement,
   getSlotInLocationStack,
+  getTargetTipsFromWellSets,
   indentPyLines,
   mixBlowoutLocationHelper,
   reduceCommandCreators,
@@ -274,6 +278,9 @@ export const mix: CommandCreator<MixArgs> = (
     yOffset,
     finalPushOut,
     nozzles,
+    tipsSelected,
+    tiprackSelected,
+    tipTracking,
   } = data
 
   const aspirateDelaySeconds = data.aspirateDelaySeconds ?? 0
@@ -389,6 +396,25 @@ export const mix: CommandCreator<MixArgs> = (
         ]
       : []
 
+  const pipetteSpecs = invariantContext.pipetteEntities[pipette].spec
+  const shouldSelectManualTips =
+    tipTracking === MANUAL &&
+    tiprackSelected != null &&
+    tipsSelected != null &&
+    tipsSelected.length > 0
+  const primaryNozzle = getDefaultPrimaryNozzle({
+    nozzles: nozzles ?? ALL,
+    channels: pipetteSpecs.channels,
+  })
+  const targetTips = shouldSelectManualTips
+    ? getTargetTipsFromWellSets({
+        wellSets: tipsSelected,
+        nozzles: nozzles ?? ALL,
+        channels: pipetteSpecs.channels,
+        primaryNozzle,
+      })
+    : null
+
   // Command generation
   const commandCreators = flatMap(
     wells,
@@ -396,6 +422,7 @@ export const mix: CommandCreator<MixArgs> = (
       let tipCommands: CurriedCommandCreator[] = []
 
       if (changeTip === 'always' || (changeTip === 'once' && wellIndex === 0)) {
+        const nextTip = targetTips?.shift()
         tipCommands = [
           curryCommandCreator(replaceTip, {
             pipette,
@@ -406,6 +433,16 @@ export const mix: CommandCreator<MixArgs> = (
                 : dropTipLocation,
             tipRack,
             ...(nozzles != null ? { nozzles } : {}),
+            ...(tipTracking === MANUAL &&
+            nextTip != null &&
+            tiprackSelected != null
+              ? {
+                  tipSelectionArgs: {
+                    tipRackId: tiprackSelected,
+                    tipWell: nextTip,
+                  },
+                }
+              : {}),
             isFromMixCommand: true,
           }),
         ]

--- a/step-generation/src/commandCreators/compound/replaceTip.ts
+++ b/step-generation/src/commandCreators/compound/replaceTip.ts
@@ -76,7 +76,7 @@ export const replaceTip: CommandCreator<ReplaceTipArgs> = (
         errors: [errorCreators.noTipSelected()],
       }
     }
-    const result = getNextTiprack(
+    const nextTiprackResult = getNextTiprack(
       pipette,
       tipRack,
       invariantContext,
@@ -84,11 +84,10 @@ export const replaceTip: CommandCreator<ReplaceTipArgs> = (
       nozzles
     )
 
-    nextTiprack = result.nextTiprack
-    const tipracks = result.tipracks
+    nextTiprack = nextTiprackResult.nextTiprack
+    const tipracks = nextTiprackResult.tipracks
 
-    const excludedBy96Channel = tipracks?.excludedBy96Channel
-    const excludedByLid = tipracks?.excludedByLid
+    const { excludedBy96Channel, excludedByLid } = tipracks ?? {}
 
     const is96ChannelTipracksAvailable =
       nextTiprack == null && channels === 96 && excludedBy96Channel > 0

--- a/step-generation/src/commandCreators/compound/replaceTip.ts
+++ b/step-generation/src/commandCreators/compound/replaceTip.ts
@@ -3,20 +3,20 @@ import {
   COLUMN,
   FLEX_ROBOT_TYPE,
   OT2_ROBOT_TYPE,
-  SINGLE,
 } from '@opentrons/shared-data'
 
+import { AUTOMATIC, MANUAL } from '../../constants'
 import * as errorCreators from '../../errorCreators'
 import { getNextTiprack } from '../../robotStateSelectors'
 import {
   curryCommandCreator,
   curryWithoutPython,
+  getDefaultPrimaryNozzle,
   getIsHeaterShakerEastWestMultiChannelPipette,
   getIsHeaterShakerEastWestWithLatchOpen,
   getLabwareSlot,
   modulePipetteCollision,
   pipetteAdjacentHeaterShakerWhileShaking,
-  PRIMARY_NOZZLE,
   reduceCommandCreators,
 } from '../../utils'
 import { configureNozzleLayout } from '../atomic/configureNozzleLayout'
@@ -31,11 +31,17 @@ import type { CommandCreator, CurriedCommandCreator } from '../../types'
 interface ReplaceTipArgs {
   pipette: string
   dropTipLocation: string
+  // tipRack URI with which to automatically find next tip
   tipRack: string | null
   nozzles?: NozzleConfigurationStyle
   //  we need to emit atomic commands for python
   //  if this replaceTip is for the mix compound command
   isFromMixCommand?: boolean
+  // optional explicit tiprack id and well name to pickup from (if not provided, will automatically find next tip from tipRack URI)
+  tipSelectionArgs?: {
+    tipRackId: string
+    tipWell: string
+  }
 }
 
 /**
@@ -54,43 +60,59 @@ export const replaceTip: CommandCreator<ReplaceTipArgs> = (
     nozzles,
     tipRack,
     isFromMixCommand = false,
+    tipSelectionArgs,
   } = args
   const stateNozzles = prevRobotState.pipettes[pipette].nozzles
   const stateTiprack = prevRobotState.pipettes[pipette].tiprackId
-  if (tipRack == null) {
-    return {
-      errors: [errorCreators.noTipSelected()],
-    }
-  }
-  const { nextTiprack, tipracks } = getNextTiprack(
-    pipette,
-    tipRack,
-    invariantContext,
-    prevRobotState,
-    nozzles
-  )
   const pipetteSpec = invariantContext.pipetteEntities[pipette]?.spec
   const channels = pipetteSpec?.channels
 
-  const excludedBy96Channel = tipracks?.excludedBy96Channel
-  const excludedByLid = tipracks?.excludedByLid
+  let nextTiprack: { tiprackId: string; well: string } | null = null
 
-  const is96ChannelTipracksAvailable =
-    nextTiprack == null && channels === 96 && excludedBy96Channel > 0
-  if (nozzles === ALL && is96ChannelTipracksAvailable) {
-    return {
-      errors: [errorCreators.missingAdapter()],
+  if (tipSelectionArgs == null) {
+    // automatic tip selection (legacy)
+    if (tipRack == null) {
+      return {
+        errors: [errorCreators.noTipSelected()],
+      }
     }
-  }
+    const result = getNextTiprack(
+      pipette,
+      tipRack,
+      invariantContext,
+      prevRobotState,
+      nozzles
+    )
 
-  if (nozzles === COLUMN && is96ChannelTipracksAvailable) {
-    return {
-      errors: [errorCreators.removeAdapter()],
+    nextTiprack = result.nextTiprack
+    const tipracks = result.tipracks
+
+    const excludedBy96Channel = tipracks?.excludedBy96Channel
+    const excludedByLid = tipracks?.excludedByLid
+
+    const is96ChannelTipracksAvailable =
+      nextTiprack == null && channels === 96 && excludedBy96Channel > 0
+    if (nozzles === ALL && is96ChannelTipracksAvailable) {
+      return {
+        errors: [errorCreators.missingAdapter()],
+      }
     }
-  }
-  if (excludedByLid > 0 && nextTiprack == null) {
-    return {
-      errors: [errorCreators.nextTiprackHasLid()],
+
+    if (nozzles === COLUMN && is96ChannelTipracksAvailable) {
+      return {
+        errors: [errorCreators.removeAdapter()],
+      }
+    }
+    if (excludedByLid > 0 && nextTiprack == null) {
+      return {
+        errors: [errorCreators.nextTiprackHasLid()],
+      }
+    }
+  } else {
+    // manual tip selection
+    nextTiprack = {
+      tiprackId: tipSelectionArgs.tipRackId,
+      well: tipSelectionArgs.tipWell,
     }
   }
 
@@ -182,14 +204,10 @@ export const replaceTip: CommandCreator<ReplaceTipArgs> = (
     }
   }
 
-  let primaryNozzle
-  if (nozzles === COLUMN) {
-    primaryNozzle = PRIMARY_NOZZLE
-  } else if (nozzles === SINGLE && channels === 96) {
-    primaryNozzle = 'H12'
-  } else if (nozzles === SINGLE && channels === 8) {
-    primaryNozzle = 'H1'
-  }
+  const primaryNozzle = getDefaultPrimaryNozzle({
+    nozzles: nozzles ?? ALL,
+    channels,
+  })
 
   const curryCommand = isFromMixCommand
     ? curryCommandCreator
@@ -211,6 +229,8 @@ export const replaceTip: CommandCreator<ReplaceTipArgs> = (
         ]
       : []
 
+  const tipTrackingOption = tipSelectionArgs ? MANUAL : AUTOMATIC
+
   let commandCreators: CurriedCommandCreator[] = [
     curryCommand(dropTip, {
       pipette,
@@ -222,6 +242,7 @@ export const replaceTip: CommandCreator<ReplaceTipArgs> = (
       labwareId: nextTiprack.tiprackId,
       wellName: nextTiprack.well,
       nozzles: args.nozzles,
+      tipTrackingOption,
     }),
   ]
   if (isWasteChute) {
@@ -237,6 +258,7 @@ export const replaceTip: CommandCreator<ReplaceTipArgs> = (
         labwareId: nextTiprack.tiprackId,
         wellName: nextTiprack.well,
         nozzles: args.nozzles,
+        tipTrackingOption,
       }),
     ]
   }
@@ -253,6 +275,7 @@ export const replaceTip: CommandCreator<ReplaceTipArgs> = (
         labwareId: nextTiprack.tiprackId,
         wellName: nextTiprack.well,
         nozzles: args.nozzles,
+        tipTrackingOption,
       }),
     ]
   }

--- a/step-generation/src/commandCreators/compound/transfer.ts
+++ b/step-generation/src/commandCreators/compound/transfer.ts
@@ -589,20 +589,31 @@ export const transfer: CommandCreator<TransferArgs> = (
                 }),
               ]
             : []
-
-          const tipCommands = changeTipNow
-            ? [
-                curryCommandCreator(replaceTip, {
-                  pipette,
-                  dropTipLocation:
-                    isReturnTip && fallBackTrashLikeId != null
-                      ? fallBackTrashLikeId
-                      : dropTipLocation,
-                  tipRack,
-                  ...(nozzles != null ? { nozzles } : {}),
-                }),
-              ]
-            : []
+          let tipCommands: CurriedCommandCreator[] = []
+          if (changeTipNow) {
+            const nextTip = targetTips?.shift()
+            tipCommands = [
+              curryCommandCreator(replaceTip, {
+                pipette,
+                dropTipLocation:
+                  isReturnTip && fallBackTrashLikeId != null
+                    ? fallBackTrashLikeId
+                    : dropTipLocation,
+                tipRack,
+                ...(nozzles != null ? { nozzles } : {}),
+                ...(tipTracking === MANUAL &&
+                nextTip != null &&
+                tiprackSelected != null
+                  ? {
+                      tipSelectionArgs: {
+                        tipRackId: tiprackSelected,
+                        tipWell: nextTip,
+                      },
+                    }
+                  : {}),
+              }),
+            ]
+          }
 
           const aspirateWellDepth =
             labwareEntities[sourceLabware]?.def.wells[sourceWell]?.depth ?? null

--- a/step-generation/src/utils/pythonFileUtils.ts
+++ b/step-generation/src/utils/pythonFileUtils.ts
@@ -45,7 +45,7 @@ import type {
   WasteChuteEntities,
 } from '../types'
 
-export const PAPI_VERSION = '2.26' // latest version from api/src/opentrons/protocols/api_support/definitions.py
+export const PAPI_VERSION = '2.27' // latest version from api/src/opentrons/protocols/api_support/definitions.py
 export const PD_APPLICATION_VERSION = '8.7.0' // latest PD version to insert into DESIGNER_APPLICATION blob
 
 export function pythonImports(): string {


### PR DESCRIPTION
# Overview

This PR updates JSON step generation for manual tip selection, which is required for proper state tracking and error handling in the PD application before export.

Closes AUTH-2433, Closes AUTH-2443

## Test Plan and Hands on Testing

Extensive smoke and unit testing

Practical steps:
- create a protocol with mix + transfer steps with manual tip selection (see [test_manual_pickup.py](https://github.com/user-attachments/files/23241991/test.16.py))
- verify that tip state correctly updates when hovering downstream steps
- export and verify that Python emitted is correct
- import to Opentrons app (running `edge`) and verify that visualization/run log are correct according to specified tip pickups

## Changelog

- implement tip selection in `replaceTip` command creator
- wire up args updates in transfer, consolidate, distribute, and mix command creators
- pass optional arg to `pickUpTip` command creator to explicitly pickup at a well location
- write and update unit tests
- update emitted PAPI version to 2.27

## Review requests



## Risk assessment

low