### PR TITLE
refactor(protocol-designer): Remove an unused call to `useConditionalConfirm()`

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/index.tsx
@@ -24,10 +24,7 @@ import { getDirtyFields } from './utils'
 
 import type { ConnectedComponent } from 'react-redux'
 import type { InvariantContext } from '@opentrons/step-generation'
-import type {
-  FormData,
-  StepFieldName,
-} from '/protocol-designer/form-types'
+import type { FormData, StepFieldName } from '/protocol-designer/form-types'
 import type { BaseState, ThunkDispatch } from '/protocol-designer/types'
 
 interface StateProps {

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/index.tsx
@@ -43,7 +43,6 @@ interface StateProps {
   formData?: FormData | null
 }
 interface DispatchProps {
-  deleteStep: (stepId: string) => void
   handleClose: () => void
   saveSetTempFormWithAddedPauseUntilTemp: () => void
   saveHeaterShakerFormWithAddedPauseUntilTemp: () => void
@@ -54,7 +53,6 @@ type StepFormManagerProps = StateProps & DispatchProps
 function StepFormManager(props: StepFormManagerProps): JSX.Element | null {
   const {
     canSave,
-    deleteStep,
     formData,
     formHasChanges,
     handleClose,
@@ -82,21 +80,6 @@ function StepFormManager(props: StepFormManagerProps): JSX.Element | null {
       return prevDirtyFields
     })
   }
-  const stepId = formData?.id
-  const handleDelete = (): void => {
-    if (stepId != null) {
-      deleteStep(stepId)
-    } else {
-      console.error(
-        `StepEditForm: tried to delete step with no step id, this should not happen`
-      )
-    }
-  }
-  const {
-    confirm: confirmDelete,
-    showConfirmation: showConfirmDeleteModal,
-    cancel: cancelDelete,
-  } = useConditionalConfirm(handleDelete, true)
   const {
     confirm: confirmClose,
     showConfirmation: showConfirmCancelModal,
@@ -139,13 +122,6 @@ function StepFormManager(props: StepFormManagerProps): JSX.Element | null {
 
   return (
     <>
-      {showConfirmDeleteModal && (
-        <ConfirmDeleteModal
-          modalType={DELETE_STEP_FORM}
-          onCancelClick={cancelDelete}
-          onContinueClick={confirmDelete}
-        />
-      )}
       {showConfirmCancelModal && (
         <ConfirmDeleteModal
           modalType={
@@ -233,8 +209,6 @@ const mapStateToProps = (state: BaseState): StateProps => {
 }
 
 const mapDispatchToProps = (dispatch: ThunkDispatch<any>): DispatchProps => {
-  const deleteStep = (stepId: StepIdType): void =>
-    dispatch(actions.deleteStep(stepId))
   const handleClose = (): void => dispatch(actions.cancelStepForm())
   const saveHeaterShakerFormWithAddedPauseUntilTemp = (): void =>
     dispatch(stepsActions.saveHeaterShakerFormWithAddedPauseUntilTemp())
@@ -243,7 +217,6 @@ const mapDispatchToProps = (dispatch: ThunkDispatch<any>): DispatchProps => {
   const saveStepForm = (): void => dispatch(stepsActions.saveStepForm())
 
   return {
-    deleteStep,
     handleClose,
     saveSetTempFormWithAddedPauseUntilTemp,
     saveStepForm,

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/index.tsx
@@ -9,7 +9,6 @@ import {
   CLOSE_STEP_FORM_WITH_CHANGES,
   CLOSE_UNSAVED_STEP_FORM,
   ConfirmDeleteModal,
-  DELETE_STEP_FORM,
 } from '/protocol-designer/components/organisms'
 import { getEnableConcurrentModuleActions } from '/protocol-designer/feature-flags/selectors'
 import {
@@ -28,7 +27,6 @@ import type { InvariantContext } from '@opentrons/step-generation'
 import type {
   FormData,
   StepFieldName,
-  StepIdType,
 } from '/protocol-designer/form-types'
 import type { BaseState, ThunkDispatch } from '/protocol-designer/types'
 


### PR DESCRIPTION
## Overview

This removes what I think is some dead code. This goes towards EXEC-2024 by simplifying deletion logic.

## Test Plan and Hands on Testing

* [x] You can still delete a step through its 3-dot menu in the timeline

## Review requests

Double-check my thinking on this, but it looks like this `useConditionalConfirm` was only used by "itself."

1. We had a dialog whose confirm and cancel buttons were wired up to `confirmDelete()` and `cancelDelete()`.
2. Nothing other than the dialog ever called `confirmDelete()`.
3. We only showed the dialog when `showConfirmDeleteModal` was true.
4. `showConfirmDeleteModal` would only ever be `true` after something called `confirmDelete()`.

Therefore, in practice, this dialog could never actually render, and `confirmDelete()` could never actually be called.

## Risk assessment

Low?