### PR TITLE
feat(docs): generate Flex manual PDF from single-page html

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -19,3 +19,8 @@ clean:
 .PHONY: serve
 serve:
 	uv run mkdocs serve -f ./mkdocs.yml
+
+.PHONY: pdf-flex
+pdf-flex:
+	uv run mkdocs build -f ./flex/mkdocs.yml && \
+	python flex/export_to_pdf.py flex/site/print_page/index.html site/Opentrons-Flex-Instruction-Manual.pdf 'Opentrons Flex Instruction Manual'

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -11,6 +11,7 @@ build:
 .PHONY: setup
 setup:
 	uv sync
+	uv run playwright install --with-deps chromium
 
 .PHONY: clean
 clean:
@@ -23,4 +24,4 @@ serve:
 .PHONY: pdf-flex
 pdf-flex:
 	uv run mkdocs build -f ./flex/mkdocs.yml && \
-	python flex/export_to_pdf.py flex/site/print_page/index.html site/Opentrons-Flex-Instruction-Manual.pdf 'Opentrons Flex Instruction Manual'
+	uv run python flex/export_to_pdf.py flex/site/print_page/index.html site/Opentrons-Flex-Instruction-Manual.pdf 'Opentrons Flex Instruction Manual'

--- a/docs/flex/docs/cover.tpl
+++ b/docs/flex/docs/cover.tpl
@@ -1,0 +1,21 @@
+<style>
+div.cover {
+  text-align: center;
+}
+
+p.title {
+  font-size: 2em;
+}
+</style>
+
+<div class="cover" markdown>
+<img src="../images/opentrons-flex-logo.svg" alt="Opentrons Flex" title="Opentrons Flex logo" style="width: 75%;" />
+
+<p class="title">Instruction Manual</p>
+
+<p><img src="../images/flex-hero.png" alt="Opentrons Flex robot" title="flex-hero.png" /></p>
+
+<p><strong>Opentrons Labworks Inc.</strong></p>
+
+<p>October 2025</p>
+</div>

--- a/docs/flex/docs/index.md
+++ b/docs/flex/docs/index.md
@@ -3,11 +3,12 @@ title: "Opentrons Flex Instruction Manual"
 ---
 
 <style>
-.md-content__inner {
+div.cover {
   text-align: center;
 }
 </style>
 
+<div class="cover" markdown>
 ![Opentrons Flex](images/opentrons-flex-logo.svg "Opentrons Flex logo"){ width="75%" }
 
 # Instruction Manual
@@ -17,3 +18,4 @@ title: "Opentrons Flex Instruction Manual"
 **Opentrons Labworks Inc.**
 
 May 2025
+</div>

--- a/docs/flex/docs/index.md
+++ b/docs/flex/docs/index.md
@@ -17,5 +17,5 @@ div.cover {
 
 **Opentrons Labworks Inc.**
 
-May 2025
+October 2025
 </div>

--- a/docs/flex/docs/print-pdf.css
+++ b/docs/flex/docs/print-pdf.css
@@ -1,0 +1,56 @@
+@page :first {
+  @bottom-right {
+    content: none;
+  }
+}
+
+@page {
+  size: letter;
+  margin: 0.75in;
+
+  @bottom-right {
+    content: "Page " counter(page);
+    font-size: 10pt;
+    font-family: "Public Sans", sans-serif;
+    color: #4A4C4E;
+    padding-top: 0.25in;
+    vertical-align: top;
+  }
+  
+  @top-right {
+    content: none;
+  }
+}
+
+@media print {
+  tr {
+    break-inside: avoid;
+  }
+  
+  h1 {
+    break-before: always;
+    page-break-before: always; /* deprecated but the PDF generator needs it */
+  }
+
+  h2, h3, h4, h5 {
+    break-after: avoid;
+  }
+
+  p {
+    orphans: 3;
+    widows: 3;
+    font-size: 11pt;
+  }
+  
+  .admonition p, .admonition li, th, td {
+    font-size: 11pt;
+  }
+  
+  figure {
+    break-inside: avoid;
+  }
+  
+  figure img {
+    max-height: 8in;
+  }
+}

--- a/docs/flex/export_to_pdf.py
+++ b/docs/flex/export_to_pdf.py
@@ -7,16 +7,6 @@ async def export_pdf(url, pdf_path, title):
     """
     Navigates to a given file:// URL and saves it as a PDF.
     """
-    
-    # Define header and footer templates, similar to the JS example
-    header_html = f"""
-    <div style="font-size: 10px; padding-right: 1em; text-align: right; width: 100%;">
-      <span>{title}</span>
-      <span class="pageNumber"></span> / <span class="totalPages"></span>
-    </div>
-    """
-    
-    footer_html = "<div></div>" # Empty footer
 
     print(f"Reading from {url}...")
     print(f"Saving PDF to {pdf_path}...")
@@ -25,12 +15,10 @@ async def export_pdf(url, pdf_path, title):
         browser = await p.chromium.launch()
         page = await browser.new_page()
         
-        # Go to the local file URL
-        # wait_until="networkidle" still works and is good practice,
-        # as it waits for any local JS (like themes) to finish.
+        # Load the local HTML file
         await page.goto(url, wait_until="networkidle")
         
-        # Generate the PDF with options matching the puppeteer script
+        # Generate the PDF with options
         await page.pdf(
             path=pdf_path,
             format="letter",
@@ -61,7 +49,6 @@ def main():
     pdf_path = sys.argv[2]
     title = sys.argv[3]
 
-    # --- NEW: Convert local file path to a file:// URL ---
     file_path = Path(html_file_path).resolve()
     
     # Check if the file exists before proceeding
@@ -73,7 +60,6 @@ def main():
         
     # Convert the Path object to a 'file://' URI
     file_url = file_path.as_uri()
-    # --- End of new logic ---
 
     # Run the async function
     asyncio.run(export_pdf(file_url, pdf_path, title))

--- a/docs/flex/export_to_pdf.py
+++ b/docs/flex/export_to_pdf.py
@@ -1,0 +1,84 @@
+import sys
+import asyncio
+from playwright.async_api import async_playwright
+from pathlib import Path # Import Path
+
+async def export_pdf(url, pdf_path, title):
+    """
+    Navigates to a given file:// URL and saves it as a PDF.
+    """
+    
+    # Define header and footer templates, similar to the JS example
+    header_html = f"""
+    <div style="font-size: 10px; padding-right: 1em; text-align: right; width: 100%;">
+      <span>{title}</span>
+      <span class="pageNumber"></span> / <span class="totalPages"></span>
+    </div>
+    """
+    
+    footer_html = "<div></div>" # Empty footer
+
+    print(f"Reading from {url}...")
+    print(f"Saving PDF to {pdf_path}...")
+
+    async with async_playwright() as p:
+        browser = await p.chromium.launch()
+        page = await browser.new_page()
+        
+        # Go to the local file URL
+        # wait_until="networkidle" still works and is good practice,
+        # as it waits for any local JS (like themes) to finish.
+        await page.goto(url, wait_until="networkidle")
+        
+        # Generate the PDF with options matching the puppeteer script
+        await page.pdf(
+            path=pdf_path,
+            format="A4",
+            display_header_footer=True,
+            header_template=header_html,
+            footer_template=footer_html,
+            print_background=True,
+            landscape=False,
+            scale=1,
+            margin={
+                "top": "80px",
+                "bottom": "80px",
+                "left": "30px",
+                "right": "30px"
+            }
+        )
+        
+        await browser.close()
+        print("PDF generation complete.")
+
+def main():
+    # Check for correct number of command-line arguments
+    if len(sys.argv) != 4:
+        print("Usage: python export_to_pdf.py <html_file_path> <pdf_path> <title>")
+        print("Example: python export_to_pdf.py site/print_site/index.html my_doc.pdf 'My Document'")
+        sys.exit(1)
+
+    # Get arguments from command line
+    html_file_path = sys.argv[1]
+    pdf_path = sys.argv[2]
+    title = sys.argv[3]
+
+    # --- NEW: Convert local file path to a file:// URL ---
+    file_path = Path(html_file_path).resolve()
+    
+    # Check if the file exists before proceeding
+    if not file_path.is_file():
+        print(f"Error: File not found at {html_file_path}")
+        print(f"       (Resolved to: {file_path})")
+        print("Did you run 'mkdocs build' first?")
+        sys.exit(1)
+        
+    # Convert the Path object to a 'file://' URI
+    file_url = file_path.as_uri()
+    # --- End of new logic ---
+
+    # Run the async function
+    asyncio.run(export_pdf(file_url, pdf_path, title))
+
+if __name__ == "__main__":
+    main()

--- a/docs/flex/export_to_pdf.py
+++ b/docs/flex/export_to_pdf.py
@@ -33,10 +33,8 @@ async def export_pdf(url, pdf_path, title):
         # Generate the PDF with options matching the puppeteer script
         await page.pdf(
             path=pdf_path,
-            format="A4",
-            display_header_footer=True,
-            header_template=header_html,
-            footer_template=footer_html,
+            format="letter",
+            display_header_footer=False,
             print_background=True,
             landscape=False,
             scale=1,

--- a/docs/flex/export_to_pdf.py
+++ b/docs/flex/export_to_pdf.py
@@ -1,7 +1,8 @@
 import sys
 import asyncio
 from playwright.async_api import async_playwright
-from pathlib import Path # Import Path
+from pathlib import Path
+
 
 async def export_pdf(url, pdf_path, title):
     """
@@ -14,10 +15,10 @@ async def export_pdf(url, pdf_path, title):
     async with async_playwright() as p:
         browser = await p.chromium.launch()
         page = await browser.new_page()
-        
+
         # Load the local HTML file
         await page.goto(url, wait_until="networkidle")
-        
+
         # Generate the PDF with options
         await page.pdf(
             path=pdf_path,
@@ -26,22 +27,20 @@ async def export_pdf(url, pdf_path, title):
             print_background=True,
             landscape=False,
             scale=1,
-            margin={
-                "top": "80px",
-                "bottom": "80px",
-                "left": "30px",
-                "right": "30px"
-            }
+            margin={"top": "80px", "bottom": "80px", "left": "30px", "right": "30px"},
         )
-        
+
         await browser.close()
         print("PDF generation complete.")
+
 
 def main():
     # Check for correct number of command-line arguments
     if len(sys.argv) != 4:
         print("Usage: python export_to_pdf.py <html_file_path> <pdf_path> <title>")
-        print("Example: python export_to_pdf.py site/print_site/index.html my_doc.pdf 'My Document'")
+        print(
+            "Example: python export_to_pdf.py site/print_site/index.html my_doc.pdf 'My Document'"
+        )
         sys.exit(1)
 
     # Get arguments from command line
@@ -50,19 +49,20 @@ def main():
     title = sys.argv[3]
 
     file_path = Path(html_file_path).resolve()
-    
+
     # Check if the file exists before proceeding
     if not file_path.is_file():
         print(f"Error: File not found at {html_file_path}")
         print(f"       (Resolved to: {file_path})")
         print("Did you run 'mkdocs build' first?")
         sys.exit(1)
-        
+
     # Convert the Path object to a 'file://' URI
     file_url = file_path.as_uri()
 
     # Run the async function
     asyncio.run(export_pdf(file_url, pdf_path, title))
+
 
 if __name__ == "__main__":
     main()

--- a/docs/flex/mkdocs.yml
+++ b/docs/flex/mkdocs.yml
@@ -85,6 +85,11 @@ plugins:
   - autorefs
   - parent-css
   - print-site:
+      exclude:
+        - index.md
+      add_cover_page: true
+      cover_page_template: "docs/cover.tpl"
+      include_css: false
       enumerate_headings: false
 
 markdown_extensions:
@@ -107,5 +112,6 @@ markdown_extensions:
 extra_css:
   - ../shared/instruction-manuals.css
   - ../shared/opentrons-theme.css
+  - print-pdf.css
 
 copyright: '© Opentrons 2025. All rights reserved. <br /> Trademarks: Opentrons®, Opentrons drop logo (Opentrons Labworks, Inc.). <br /> Registered names, trademarks, etc. used in this document, even when not specifically marked as such, are not to be considered unprotected by law.'

--- a/docs/flex/mkdocs.yml
+++ b/docs/flex/mkdocs.yml
@@ -84,6 +84,8 @@ plugins:
   - search
   - autorefs
   - parent-css
+  - print-site:
+      enumerate_headings: false
 
 markdown_extensions:
   - admonition
@@ -103,7 +105,7 @@ markdown_extensions:
       permalink: true
 
 extra_css:
-  - manual.css
-  - ../opentrons-theme.css
+  - ../shared/instruction-manuals.css
+  - ../shared/opentrons-theme.css
 
 copyright: '© Opentrons 2025. All rights reserved. <br /> Trademarks: Opentrons®, Opentrons drop logo (Opentrons Labworks, Inc.). <br /> Registered names, trademarks, etc. used in this document, even when not specifically marked as such, are not to be considered unprotected by law.'

--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -10,6 +10,8 @@ dependencies = [
     "mkdocs-material>=9.6.14",
     "mkdocs-monorepo-plugin>=1.1.2",
     "mkdocs-parent-css-plugin",
+    "mkdocs-print-site-plugin>=2.8",
+    "playwright>=1.55"
 ]
 
 [tool.uv.sources]

--- a/docs/uv.lock
+++ b/docs/uv.lock
@@ -125,6 +125,8 @@ dependencies = [
     { name = "mkdocs-material" },
     { name = "mkdocs-monorepo-plugin" },
     { name = "mkdocs-parent-css-plugin" },
+    { name = "mkdocs-print-site-plugin" },
+    { name = "playwright" },
 ]
 
 [package.metadata]
@@ -134,6 +136,8 @@ requires-dist = [
     { name = "mkdocs-material", specifier = ">=9.6.14" },
     { name = "mkdocs-monorepo-plugin", specifier = ">=1.1.2" },
     { name = "mkdocs-parent-css-plugin", editable = "mkdocs-parent-css-plugin" },
+    { name = "mkdocs-print-site-plugin", specifier = ">=2.8" },
+    { name = "playwright", specifier = ">=1.55" },
 ]
 
 [[package]]
@@ -146,6 +150,57 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d9/29/d40217cbe2f6b1359e00c6c307bb3fc876ba74068cbab3dde77f03ca0dc4/ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343", size = 10943, upload-time = "2022-05-02T15:47:16.11Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/ec/67fbef5d497f86283db54c22eec6f6140243aae73265799baaaa19cd17fb/ghp_import-2.1.0-py3-none-any.whl", hash = "sha256:8337dd7b50877f163d4c0289bc1f1c7f127550241988d568c1db512c4324a619", size = 11034, upload-time = "2022-05-02T15:47:14.552Z" },
+]
+
+[[package]]
+name = "greenlet"
+version = "3.2.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/b8/704d753a5a45507a7aab61f18db9509302ed3d0a27ac7e0359ec2905b1a6/greenlet-3.2.4.tar.gz", hash = "sha256:0dca0d95ff849f9a364385f36ab49f50065d76964944638be9691e1832e9f86d", size = 188260, upload-time = "2025-08-07T13:24:33.51Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/ed/6bfa4109fcb23a58819600392564fea69cdc6551ffd5e69ccf1d52a40cbc/greenlet-3.2.4-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:8c68325b0d0acf8d91dde4e6f930967dd52a5302cd4062932a6b2e7c2969f47c", size = 271061, upload-time = "2025-08-07T13:17:15.373Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/fc/102ec1a2fc015b3a7652abab7acf3541d58c04d3d17a8d3d6a44adae1eb1/greenlet-3.2.4-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:94385f101946790ae13da500603491f04a76b6e4c059dab271b3ce2e283b2590", size = 629475, upload-time = "2025-08-07T13:42:54.009Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/26/80383131d55a4ac0fb08d71660fd77e7660b9db6bdb4e8884f46d9f2cc04/greenlet-3.2.4-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f10fd42b5ee276335863712fa3da6608e93f70629c631bf77145021600abc23c", size = 640802, upload-time = "2025-08-07T13:45:25.52Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/7c/e7833dbcd8f376f3326bd728c845d31dcde4c84268d3921afcae77d90d08/greenlet-3.2.4-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c8c9e331e58180d0d83c5b7999255721b725913ff6bc6cf39fa2a45841a4fd4b", size = 636703, upload-time = "2025-08-07T13:53:12.622Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/49/547b93b7c0428ede7b3f309bc965986874759f7d89e4e04aeddbc9699acb/greenlet-3.2.4-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:58b97143c9cc7b86fc458f215bd0932f1757ce649e05b640fea2e79b54cedb31", size = 635417, upload-time = "2025-08-07T13:18:25.189Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/91/ae2eb6b7979e2f9b035a9f612cf70f1bf54aad4e1d125129bef1eae96f19/greenlet-3.2.4-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c2ca18a03a8cfb5b25bc1cbe20f3d9a4c80d8c3b13ba3df49ac3961af0b1018d", size = 584358, upload-time = "2025-08-07T13:18:23.708Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/85/433de0c9c0252b22b16d413c9407e6cb3b41df7389afc366ca204dbc1393/greenlet-3.2.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:9fe0a28a7b952a21e2c062cd5756d34354117796c6d9215a87f55e38d15402c5", size = 1113550, upload-time = "2025-08-07T13:42:37.467Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/8d/88f3ebd2bc96bf7747093696f4335a0a8a4c5acfcf1b757717c0d2474ba3/greenlet-3.2.4-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:8854167e06950ca75b898b104b63cc646573aa5fef1353d4508ecdd1ee76254f", size = 1137126, upload-time = "2025-08-07T13:18:20.239Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/6f/b60b0291d9623c496638c582297ead61f43c4b72eef5e9c926ef4565ec13/greenlet-3.2.4-cp310-cp310-win_amd64.whl", hash = "sha256:73f49b5368b5359d04e18d15828eecc1806033db5233397748f4ca813ff1056c", size = 298654, upload-time = "2025-08-07T13:50:00.469Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/de/f28ced0a67749cac23fecb02b694f6473f47686dff6afaa211d186e2ef9c/greenlet-3.2.4-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:96378df1de302bc38e99c3a9aa311967b7dc80ced1dcc6f171e99842987882a2", size = 272305, upload-time = "2025-08-07T13:15:41.288Z" },
+    { url = "https://files.pythonhosted.org/packages/09/16/2c3792cba130000bf2a31c5272999113f4764fd9d874fb257ff588ac779a/greenlet-3.2.4-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1ee8fae0519a337f2329cb78bd7a8e128ec0f881073d43f023c7b8d4831d5246", size = 632472, upload-time = "2025-08-07T13:42:55.044Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/8f/95d48d7e3d433e6dae5b1682e4292242a53f22df82e6d3dda81b1701a960/greenlet-3.2.4-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:94abf90142c2a18151632371140b3dba4dee031633fe614cb592dbb6c9e17bc3", size = 644646, upload-time = "2025-08-07T13:45:26.523Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/5e/405965351aef8c76b8ef7ad370e5da58d57ef6068df197548b015464001a/greenlet-3.2.4-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:4d1378601b85e2e5171b99be8d2dc85f594c79967599328f95c1dc1a40f1c633", size = 640519, upload-time = "2025-08-07T13:53:13.928Z" },
+    { url = "https://files.pythonhosted.org/packages/25/5d/382753b52006ce0218297ec1b628e048c4e64b155379331f25a7316eb749/greenlet-3.2.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0db5594dce18db94f7d1650d7489909b57afde4c580806b8d9203b6e79cdc079", size = 639707, upload-time = "2025-08-07T13:18:27.146Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/8e/abdd3f14d735b2929290a018ecf133c901be4874b858dd1c604b9319f064/greenlet-3.2.4-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2523e5246274f54fdadbce8494458a2ebdcdbc7b802318466ac5606d3cded1f8", size = 587684, upload-time = "2025-08-07T13:18:25.164Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/65/deb2a69c3e5996439b0176f6651e0052542bb6c8f8ec2e3fba97c9768805/greenlet-3.2.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:1987de92fec508535687fb807a5cea1560f6196285a4cde35c100b8cd632cc52", size = 1116647, upload-time = "2025-08-07T13:42:38.655Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/cc/b07000438a29ac5cfb2194bfc128151d52f333cee74dd7dfe3fb733fc16c/greenlet-3.2.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:55e9c5affaa6775e2c6b67659f3a71684de4c549b3dd9afca3bc773533d284fa", size = 1142073, upload-time = "2025-08-07T13:18:21.737Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/0f/30aef242fcab550b0b3520b8e3561156857c94288f0332a79928c31a52cf/greenlet-3.2.4-cp311-cp311-win_amd64.whl", hash = "sha256:9c40adce87eaa9ddb593ccb0fa6a07caf34015a29bf8d344811665b573138db9", size = 299100, upload-time = "2025-08-07T13:44:12.287Z" },
+    { url = "https://files.pythonhosted.org/packages/44/69/9b804adb5fd0671f367781560eb5eb586c4d495277c93bde4307b9e28068/greenlet-3.2.4-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3b67ca49f54cede0186854a008109d6ee71f66bd57bb36abd6d0a0267b540cdd", size = 274079, upload-time = "2025-08-07T13:15:45.033Z" },
+    { url = "https://files.pythonhosted.org/packages/46/e9/d2a80c99f19a153eff70bc451ab78615583b8dac0754cfb942223d2c1a0d/greenlet-3.2.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddf9164e7a5b08e9d22511526865780a576f19ddd00d62f8a665949327fde8bb", size = 640997, upload-time = "2025-08-07T13:42:56.234Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/16/035dcfcc48715ccd345f3a93183267167cdd162ad123cd93067d86f27ce4/greenlet-3.2.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f28588772bb5fb869a8eb331374ec06f24a83a9c25bfa1f38b6993afe9c1e968", size = 655185, upload-time = "2025-08-07T13:45:27.624Z" },
+    { url = "https://files.pythonhosted.org/packages/31/da/0386695eef69ffae1ad726881571dfe28b41970173947e7c558d9998de0f/greenlet-3.2.4-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:5c9320971821a7cb77cfab8d956fa8e39cd07ca44b6070db358ceb7f8797c8c9", size = 649926, upload-time = "2025-08-07T13:53:15.251Z" },
+    { url = "https://files.pythonhosted.org/packages/68/88/69bf19fd4dc19981928ceacbc5fd4bb6bc2215d53199e367832e98d1d8fe/greenlet-3.2.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c60a6d84229b271d44b70fb6e5fa23781abb5d742af7b808ae3f6efd7c9c60f6", size = 651839, upload-time = "2025-08-07T13:18:30.281Z" },
+    { url = "https://files.pythonhosted.org/packages/19/0d/6660d55f7373b2ff8152401a83e02084956da23ae58cddbfb0b330978fe9/greenlet-3.2.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b3812d8d0c9579967815af437d96623f45c0f2ae5f04e366de62a12d83a8fb0", size = 607586, upload-time = "2025-08-07T13:18:28.544Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/1a/c953fdedd22d81ee4629afbb38d2f9d71e37d23caace44775a3a969147d4/greenlet-3.2.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:abbf57b5a870d30c4675928c37278493044d7c14378350b3aa5d484fa65575f0", size = 1123281, upload-time = "2025-08-07T13:42:39.858Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/c7/12381b18e21aef2c6bd3a636da1088b888b97b7a0362fac2e4de92405f97/greenlet-3.2.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:20fb936b4652b6e307b8f347665e2c615540d4b42b3b4c8a321d8286da7e520f", size = 1151142, upload-time = "2025-08-07T13:18:22.981Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/08/b0814846b79399e585f974bbeebf5580fbe59e258ea7be64d9dfb253c84f/greenlet-3.2.4-cp312-cp312-win_amd64.whl", hash = "sha256:a7d4e128405eea3814a12cc2605e0e6aedb4035bf32697f72deca74de4105e02", size = 299899, upload-time = "2025-08-07T13:38:53.448Z" },
+    { url = "https://files.pythonhosted.org/packages/49/e8/58c7f85958bda41dafea50497cbd59738c5c43dbbea5ee83d651234398f4/greenlet-3.2.4-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:1a921e542453fe531144e91e1feedf12e07351b1cf6c9e8a3325ea600a715a31", size = 272814, upload-time = "2025-08-07T13:15:50.011Z" },
+    { url = "https://files.pythonhosted.org/packages/62/dd/b9f59862e9e257a16e4e610480cfffd29e3fae018a68c2332090b53aac3d/greenlet-3.2.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cd3c8e693bff0fff6ba55f140bf390fa92c994083f838fece0f63be121334945", size = 641073, upload-time = "2025-08-07T13:42:57.23Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/0b/bc13f787394920b23073ca3b6c4a7a21396301ed75a655bcb47196b50e6e/greenlet-3.2.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:710638eb93b1fa52823aa91bf75326f9ecdfd5e0466f00789246a5280f4ba0fc", size = 655191, upload-time = "2025-08-07T13:45:29.752Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/d6/6adde57d1345a8d0f14d31e4ab9c23cfe8e2cd39c3baf7674b4b0338d266/greenlet-3.2.4-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c5111ccdc9c88f423426df3fd1811bfc40ed66264d35aa373420a34377efc98a", size = 649516, upload-time = "2025-08-07T13:53:16.314Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3b/3a3328a788d4a473889a2d403199932be55b1b0060f4ddd96ee7cdfcad10/greenlet-3.2.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d76383238584e9711e20ebe14db6c88ddcedc1829a9ad31a584389463b5aa504", size = 652169, upload-time = "2025-08-07T13:18:32.861Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/43/3cecdc0349359e1a527cbf2e3e28e5f8f06d3343aaf82ca13437a9aa290f/greenlet-3.2.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:23768528f2911bcd7e475210822ffb5254ed10d71f4028387e5a99b4c6699671", size = 610497, upload-time = "2025-08-07T13:18:31.636Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/19/06b6cf5d604e2c382a6f31cafafd6f33d5dea706f4db7bdab184bad2b21d/greenlet-3.2.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:00fadb3fedccc447f517ee0d3fd8fe49eae949e1cd0f6a611818f4f6fb7dc83b", size = 1121662, upload-time = "2025-08-07T13:42:41.117Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/15/0d5e4e1a66fab130d98168fe984c509249c833c1a3c16806b90f253ce7b9/greenlet-3.2.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:d25c5091190f2dc0eaa3f950252122edbbadbb682aa7b1ef2f8af0f8c0afefae", size = 1149210, upload-time = "2025-08-07T13:18:24.072Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/55/2321e43595e6801e105fcfdee02b34c0f996eb71e6ddffca6b10b7e1d771/greenlet-3.2.4-cp313-cp313-win_amd64.whl", hash = "sha256:554b03b6e73aaabec3745364d6239e9e012d64c68ccd0b8430c64ccc14939a8b", size = 299685, upload-time = "2025-08-07T13:24:38.824Z" },
+    { url = "https://files.pythonhosted.org/packages/22/5c/85273fd7cc388285632b0498dbbab97596e04b154933dfe0f3e68156c68c/greenlet-3.2.4-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:49a30d5fda2507ae77be16479bdb62a660fa51b1eb4928b524975b3bde77b3c0", size = 273586, upload-time = "2025-08-07T13:16:08.004Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/75/10aeeaa3da9332c2e761e4c50d4c3556c21113ee3f0afa2cf5769946f7a3/greenlet-3.2.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:299fd615cd8fc86267b47597123e3f43ad79c9d8a22bebdce535e53550763e2f", size = 686346, upload-time = "2025-08-07T13:42:59.944Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/aa/687d6b12ffb505a4447567d1f3abea23bd20e73a5bed63871178e0831b7a/greenlet-3.2.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:c17b6b34111ea72fc5a4e4beec9711d2226285f0386ea83477cbb97c30a3f3a5", size = 699218, upload-time = "2025-08-07T13:45:30.969Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/8b/29aae55436521f1d6f8ff4e12fb676f3400de7fcf27fccd1d4d17fd8fecd/greenlet-3.2.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b4a1870c51720687af7fa3e7cda6d08d801dae660f75a76f3845b642b4da6ee1", size = 694659, upload-time = "2025-08-07T13:53:17.759Z" },
+    { url = "https://files.pythonhosted.org/packages/92/2e/ea25914b1ebfde93b6fc4ff46d6864564fba59024e928bdc7de475affc25/greenlet-3.2.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:061dc4cf2c34852b052a8620d40f36324554bc192be474b9e9770e8c042fd735", size = 695355, upload-time = "2025-08-07T13:18:34.517Z" },
+    { url = "https://files.pythonhosted.org/packages/72/60/fc56c62046ec17f6b0d3060564562c64c862948c9d4bc8aa807cf5bd74f4/greenlet-3.2.4-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44358b9bf66c8576a9f57a590d5f5d6e72fa4228b763d0e43fee6d3b06d3a337", size = 657512, upload-time = "2025-08-07T13:18:33.969Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/a5/6ddab2b4c112be95601c13428db1d8b6608a8b6039816f2ba09c346c08fc/greenlet-3.2.4-cp314-cp314-win_amd64.whl", hash = "sha256:e37ab26028f12dbb0ff65f29a8d3d44a765c61e729647bf2ddfbbed621726f01", size = 303425, upload-time = "2025-08-07T13:32:27.59Z" },
 ]
 
 [[package]]
@@ -353,6 +408,18 @@ dependencies = [
 requires-dist = [{ name = "mkdocs", specifier = ">=1.0" }]
 
 [[package]]
+name = "mkdocs-print-site-plugin"
+version = "2.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mkdocs-material" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/18/5c71f48b83191fb30cc58617fea20f56647eaa6cafd06a7fb34c738c5acb/mkdocs_print_site_plugin-2.8.tar.gz", hash = "sha256:ab1c89cdb468352975e3bb3bb0ef25dcc2bb88931b03f173206dc95ab02f843f", size = 231688, upload-time = "2025-08-03T14:15:07.579Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/3e/7513f2f37c563da65d1b91781e047f4a1c0ceac8206d4f6042428428e4ad/mkdocs_print_site_plugin-2.8-py3-none-any.whl", hash = "sha256:838bd0a9b7141c11c0f1fdaa51ffe70c35740bec1f07c0806f8018e92f93f9da", size = 21477, upload-time = "2025-08-03T14:15:06.301Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "25.0"
 source = { registry = "https://pypi.org/simple" }
@@ -386,6 +453,37 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fe/8b/3c73abc9c759ecd3f1f7ceff6685840859e8070c4d947c93fae71f6a0bf2/platformdirs-4.3.8.tar.gz", hash = "sha256:3d512d96e16bcb959a814c9f348431070822a6496326a4be0911c40b5a74c2bc", size = 21362, upload-time = "2025-05-07T22:47:42.121Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fe/39/979e8e21520d4e47a0bbe349e2713c0aac6f3d853d0e5b34d76206c439aa/platformdirs-4.3.8-py3-none-any.whl", hash = "sha256:ff7059bb7eb1179e2685604f4aaf157cfd9535242bd23742eadc3c13542139b4", size = 18567, upload-time = "2025-05-07T22:47:40.376Z" },
+]
+
+[[package]]
+name = "playwright"
+version = "1.55.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet" },
+    { name = "pyee" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/3a/c81ff76df266c62e24f19718df9c168f49af93cabdbc4608ae29656a9986/playwright-1.55.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:d7da108a95001e412effca4f7610de79da1637ccdf670b1ae3fdc08b9694c034", size = 40428109, upload-time = "2025-08-28T15:46:20.357Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/f5/bdb61553b20e907196a38d864602a9b4a461660c3a111c67a35179b636fa/playwright-1.55.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:8290cf27a5d542e2682ac274da423941f879d07b001f6575a5a3a257b1d4ba1c", size = 38687254, upload-time = "2025-08-28T15:46:23.925Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/64/48b2837ef396487807e5ab53c76465747e34c7143fac4a084ef349c293a8/playwright-1.55.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:25b0d6b3fd991c315cca33c802cf617d52980108ab8431e3e1d37b5de755c10e", size = 40428108, upload-time = "2025-08-28T15:46:27.119Z" },
+    { url = "https://files.pythonhosted.org/packages/08/33/858312628aa16a6de97839adc2ca28031ebc5391f96b6fb8fdf1fcb15d6c/playwright-1.55.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:c6d4d8f6f8c66c483b0835569c7f0caa03230820af8e500c181c93509c92d831", size = 45905643, upload-time = "2025-08-28T15:46:30.312Z" },
+    { url = "https://files.pythonhosted.org/packages/83/83/b8d06a5b5721931aa6d5916b83168e28bd891f38ff56fe92af7bdee9860f/playwright-1.55.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29a0777c4ce1273acf90c87e4ae2fe0130182100d99bcd2ae5bf486093044838", size = 45296647, upload-time = "2025-08-28T15:46:33.221Z" },
+    { url = "https://files.pythonhosted.org/packages/06/2e/9db64518aebcb3d6ef6cd6d4d01da741aff912c3f0314dadb61226c6a96a/playwright-1.55.0-py3-none-win32.whl", hash = "sha256:29e6d1558ad9d5b5c19cbec0a72f6a2e35e6353cd9f262e22148685b86759f90", size = 35476046, upload-time = "2025-08-28T15:46:36.184Z" },
+    { url = "https://files.pythonhosted.org/packages/46/4f/9ba607fa94bb9cee3d4beb1c7b32c16efbfc9d69d5037fa85d10cafc618b/playwright-1.55.0-py3-none-win_amd64.whl", hash = "sha256:7eb5956473ca1951abb51537e6a0da55257bb2e25fc37c2b75af094a5c93736c", size = 35476048, upload-time = "2025-08-28T15:46:38.867Z" },
+    { url = "https://files.pythonhosted.org/packages/21/98/5ca173c8ec906abde26c28e1ecb34887343fd71cc4136261b90036841323/playwright-1.55.0-py3-none-win_arm64.whl", hash = "sha256:012dc89ccdcbd774cdde8aeee14c08e0dd52ddb9135bf10e9db040527386bd76", size = 31225543, upload-time = "2025-08-28T15:46:41.613Z" },
+]
+
+[[package]]
+name = "pyee"
+version = "13.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/95/03/1fd98d5841cd7964a27d729ccf2199602fe05eb7a405c1462eb7277945ed/pyee-13.0.0.tar.gz", hash = "sha256:b391e3c5a434d1f5118a25615001dbc8f669cf410ab67d04c4d4e07c55481c37", size = 31250, upload-time = "2025-03-17T18:53:15.955Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/4d/b9add7c84060d4c1906abe9a7e5359f2a60f7a9a4f67268b2766673427d8/pyee-13.0.0-py3-none-any.whl", hash = "sha256:48195a3cddb3b1515ce0695ed76036b5ccc2ef3a9f963ff9f77aec0139845498", size = 15730, upload-time = "2025-03-17T18:53:14.532Z" },
 ]
 
 [[package]]
@@ -521,6 +619,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ab/e2/e9a00f0ccb71718418230718b3d900e71a5d16e701a3dae079a21e9cd8f8/text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93", size = 76885, upload-time = "2019-08-30T21:36:45.405Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a6/a5/c0b6468d3824fe3fde30dbb5e1f687b291608f9473681bbf7dabbf5a87d7/text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8", size = 78154, upload-time = "2019-08-30T21:37:03.543Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Overview

Adds a _very good_ PDF output of the Flex instruction manual to our mkdocs tooling. This lets us share the docs with people who need an offline version for compliance or other purposes. It is not meant to be a replacement for the in-browser docs experience, which remains primary.

This implementation uses [mkdocs-print-site-plugin](https://github.com/timvink/mkdocs-print-site-plugin), which is better than my [previous attempt](https://github.com/Opentrons/opentrons/pull/19934) with a different plugin in pretty much every way.

- All internal links within the Flex manual work. (Links to other mkdocs publications are inert.)
- All external links open in a web browser.
- Faster build (~13 seconds vs. ~17 seconds on my machine) because no individual PDF pages are built.
- Includes a table of contents.
- Preserves all original formatting and gives us separate control over PDF styling through CSS media queries.

## Test Plan and Hands on Testing

Running `mkdocs build` and the new `make pdf-flex` actions locally.

## Changelog

- Add `mkdocs-print-site-plugin` and configure it within the Flex manual project.
- Add a vibecoded Python script for using `playwright` to print HTML to PDF. This is inspired by the [JavaScript/puppeteer example](https://timvink.github.io/mkdocs-print-site-plugin/how-to/export-PDF.html#automated-export-using-nodejs-and-chrome) in the plugin documentation.
- Custom CSS for page numbers and sane page breaks.
- Replicate the `index.md` file in a `cover.tpl` file. This allows putting the cover before the TOC.
- Fixed broken references to shared stylesheets for building the Flex manual standalone.

## Review requests

- Run `make pdf-flex` and inspect the outcome.
- Please look for any jank in the Python script.
- Think about whether it makes sense to run this in CI or only locally.

## Risk assessment

Low. A couple new dependencies.