### PR TITLE
fix(protocol-designer): fix migratedLabwareId for custom labware

### DIFF
--- a/protocol-designer/src/labware-ingred/utils.ts
+++ b/protocol-designer/src/labware-ingred/utils.ts
@@ -148,7 +148,9 @@ export const getMigratedLabwareId = (
   )?.[0]
   const labwareIdString = oldLabwareId.split(':')[0]
   const latestLabwareId =
-    latestURI != null ? `${labwareIdString}:${latestURI}` : oldLabwareId // fallback to original labwareId for custom labware
+    latestURI != null
+      ? `${labwareIdString}:${latestURI}`
+      : `${labwareIdString}:${defURI}` // fallback to original labwareId & defURI for custom labware
 
   return latestLabwareId
 }

--- a/protocol-designer/src/labware-ingred/utils.ts
+++ b/protocol-designer/src/labware-ingred/utils.ts
@@ -146,6 +146,13 @@ export const getMigratedLabwareId = (
   const latestURI = Object.entries(latestDefs).find(
     ([_, def]) => def.parameters.loadName === loadName
   )?.[0]
+
+  if (defURI == null) {
+    console.error(
+      `expected to find a matching defURI with labwareId ${oldLabwareId} but could not`
+    )
+  }
+
   const labwareIdString = oldLabwareId.split(':')[0]
   const latestLabwareId =
     latestURI != null


### PR DESCRIPTION
closes RESC-508

# Overview

The issue is that we were relying on all custom labware's `labwareLocationUpdate` to match the pattern of `labwareId:labwareDefURI` but that wasn't the case for all custom labware. I think the issue stems back from historical creations of custom labware in PD where we used to only have the `labwareId` with no labware def uri appended to the end of the string. Anyway, my fix is to always append the `labwareDefURI` at the end, no matter what.

## Test Plan and Hands on Testing

Upload protocol attached ot the ticket and see that it passes analysis

## Changelog

fix how the `labwareId` gets created for custom labware in `labwareEntities`

## Risk assessment

low
