### PR TITLE
refactor(app): Block robot settings: camera settings if run exists

### DIFF
--- a/app/src/organisms/Desktop/Devices/Peripherals/CameraCard.tsx
+++ b/app/src/organisms/Desktop/Devices/Peripherals/CameraCard.tsx
@@ -3,7 +3,6 @@ import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
 
-import { RUN_STATUS_IDLE } from '@opentrons/api-client'
 import {
   Chip,
   Divider,
@@ -19,11 +18,9 @@ import systemCameraFlex from '/app/assets/images/system_camera_flex.png'
 import systemCameraOT2 from '/app/assets/images/system_camera_ot2.png'
 import { CameraControls } from '/app/organisms/Desktop/Camera/CameraControls'
 import { useCameraUsageSettings } from '/app/organisms/Desktop/Devices/RobotSettings/RobotSettingsCamera/hooks/useCameraUsageSettings'
-import { useCurrentRunId, useNotifyRunQuery } from '/app/resources/runs'
+import { useCurrentRunId } from '/app/resources/runs'
 
 import styles from './inputdevices.module.css'
-
-const RUN_REFETCH_INTERVAL_MS = 5000
 
 export interface CameraCardProps {
   isFlex: boolean
@@ -45,14 +42,8 @@ export function CameraCard({
   }
 
   const runId = useCurrentRunId()
-  const run = useNotifyRunQuery(runId, {
-    refetchInterval: RUN_REFETCH_INTERVAL_MS,
-  })
 
-  // TODO (jh, 09-26-25): This disabled check will eventually be replaced with
-  //  "have settings been confirmed during run setup" logic.
   const doesRunExist = runId != null
-  const isRunIdle = run?.data?.data.status === RUN_STATUS_IDLE
 
   const cardOverflowWrapperRef = useOnClickOutside<HTMLDivElement>({
     onClickOutside: () => {
@@ -99,7 +90,7 @@ export function CameraCard({
         <OverflowBtn
           aria-label="overflow"
           onClick={handleOverflowClick}
-          disabled={doesRunExist && !isRunIdle}
+          disabled={doesRunExist}
         />
       </div>
       {showOverflowMenu && (

--- a/app/src/organisms/Desktop/Devices/Peripherals/__tests__/CameraCard.test.tsx
+++ b/app/src/organisms/Desktop/Devices/Peripherals/__tests__/CameraCard.test.tsx
@@ -106,18 +106,6 @@ describe('CameraCard', () => {
     expect(overflowButton).not.toBeDisabled()
   })
 
-  it('overflow button is not disabled when run is idle', () => {
-    vi.mocked(useCurrentRunId).mockReturnValue('test-run-id')
-    vi.mocked(useNotifyRunQuery).mockReturnValue({
-      data: { data: { status: RUN_STATUS_IDLE } },
-    } as any)
-
-    render(mockProps)
-
-    const overflowButton = screen.getByLabelText('overflow')
-    expect(overflowButton).not.toBeDisabled()
-  })
-
   it('overflow button is disabled when run exists and is not idle', () => {
     vi.mocked(useCurrentRunId).mockReturnValue('test-run-id')
     vi.mocked(useNotifyRunQuery).mockReturnValue({

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsCamera/CameraStatusContainer.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsCamera/CameraStatusContainer.tsx
@@ -10,11 +10,13 @@ import type { JSX } from 'react'
 export interface CameraStatusContainerProps {
   toggleCameraEnabled: () => void
   isCameraEnabled: boolean
+  toggleDisabled: boolean
 }
 
 export function CameraStatusContainer({
   toggleCameraEnabled,
   isCameraEnabled,
+  toggleDisabled,
 }: CameraStatusContainerProps): JSX.Element {
   const { t } = useTranslation('device_settings')
 
@@ -40,6 +42,7 @@ export function CameraStatusContainer({
           label={t('camera_status')}
           toggledOn={isCameraEnabled}
           onClick={toggleCameraEnabled}
+          disabled={toggleDisabled}
         />
       </div>
     </div>

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsCamera/RobotSettingsCameraUsage.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsCamera/RobotSettingsCameraUsage.tsx
@@ -12,6 +12,7 @@ export interface CameraUsageSettingsProps {
   isLiveVideoEnabled: boolean
   toggleRecoveryCaptureEnabled: () => void
   isRecoveryCaptureEnabled: boolean
+  toggleDisabled: boolean
 }
 
 export function RobotSettingsCameraUsage({
@@ -19,6 +20,7 @@ export function RobotSettingsCameraUsage({
   toggleRecoveryCaptureEnabled,
   isRecoveryCaptureEnabled,
   isLiveVideoEnabled,
+  toggleDisabled,
 }: CameraUsageSettingsProps): JSX.Element {
   const { t } = useTranslation('device_settings')
 
@@ -40,6 +42,7 @@ export function RobotSettingsCameraUsage({
           label={t('live_video')}
           toggledOn={isLiveVideoEnabled}
           onClick={toggleLiveVideoEnabled}
+          disabled={toggleDisabled}
         />
       </div>
       <Divider />
@@ -56,6 +59,7 @@ export function RobotSettingsCameraUsage({
           label={t('live_video')}
           toggledOn={isRecoveryCaptureEnabled}
           onClick={toggleRecoveryCaptureEnabled}
+          disabled={toggleDisabled}
         />
       </div>
     </div>

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsCamera/__tests__/CameraStatusContainer.test.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsCamera/__tests__/CameraStatusContainer.test.tsx
@@ -22,6 +22,7 @@ describe('CameraStatusContainer', () => {
     mockProps = {
       toggleCameraEnabled: vi.fn(),
       isCameraEnabled: false,
+      toggleDisabled: false,
     }
   })
 
@@ -63,5 +64,12 @@ describe('CameraStatusContainer', () => {
     await user.click(toggleButton)
 
     expect(mockProps.toggleCameraEnabled).toHaveBeenCalledTimes(1)
+  })
+
+  it('disables toggle button when toggleDisabled is true', () => {
+    render({ ...mockProps, toggleDisabled: true })
+
+    const toggleButton = screen.getByRole('switch')
+    expect(toggleButton).toBeDisabled()
   })
 })

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsCamera/__tests__/RobotSettingsCameraUsage.test.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsCamera/__tests__/RobotSettingsCameraUsage.test.tsx
@@ -24,6 +24,7 @@ describe('RobotSettingsCameraUsage', () => {
       isLiveVideoEnabled: false,
       toggleRecoveryCaptureEnabled: vi.fn(),
       isRecoveryCaptureEnabled: false,
+      toggleDisabled: false,
     }
   })
 
@@ -69,5 +70,13 @@ describe('RobotSettingsCameraUsage', () => {
     await user.click(toggleButtons[1])
 
     expect(mockProps.toggleRecoveryCaptureEnabled).toHaveBeenCalledTimes(1)
+  })
+
+  it('disables both toggle buttons when toggleDisabled is true', () => {
+    render({ ...mockProps, toggleDisabled: true })
+
+    const toggleButtons = screen.getAllByRole('switch')
+    expect(toggleButtons[0]).toBeDisabled()
+    expect(toggleButtons[1]).toBeDisabled()
   })
 })

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsCamera/index.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsCamera/index.tsx
@@ -1,5 +1,7 @@
 import { Divider } from '@opentrons/components'
 
+import { useCurrentRunId } from '/app/resources/runs'
+
 import styles from './camerasettings.module.css'
 import { CameraStatusContainer } from './CameraStatusContainer'
 import { useCameraUsageSettings } from './hooks/useCameraUsageSettings'
@@ -17,12 +19,15 @@ export function RobotSettingsCamera(): JSX.Element {
     toggleRecoveryCaptureEnabled,
     isRecoveryCaptureEnabled,
   } = useCameraUsageSettings()
+  const runId = useCurrentRunId()
+  const doesRunExist = runId != null
 
   return (
     <div className={styles.container}>
       <CameraStatusContainer
         toggleCameraEnabled={toggleCameraEnabled}
         isCameraEnabled={isCameraEnabled}
+        toggleDisabled={doesRunExist}
       />
       {isCameraEnabled && (
         <>
@@ -31,6 +36,7 @@ export function RobotSettingsCamera(): JSX.Element {
             isRecoveryCaptureEnabled={isRecoveryCaptureEnabled}
             toggleLiveVideoEnabled={toggleLiveVideoEnabled}
             toggleRecoveryCaptureEnabled={toggleRecoveryCaptureEnabled}
+            toggleDisabled={doesRunExist}
           />
           <Divider />
           <RobotSettingsCameraControls />

--- a/app/src/pages/Desktop/Devices/RobotSettings/index.tsx
+++ b/app/src/pages/Desktop/Devices/RobotSettings/index.tsx
@@ -34,6 +34,7 @@ import {
 } from '/app/redux/discovery'
 import { getRobotUpdateSession } from '/app/redux/robot-update'
 import { appShellRequestor } from '/app/redux/shell/remote'
+import { useCurrentRunId } from '/app/resources/runs'
 
 import type { DesktopRouteParams, RobotSettingsTab } from '/app/App/types'
 
@@ -47,7 +48,12 @@ export function RobotSettings(): JSX.Element | null {
   const isNetworkingDisabled = robot?.status === UNREACHABLE
   const [showRobotBusyBanner, setShowRobotBusyBanner] = useState<boolean>(false)
   const robotUpdateSession = useSelector(getRobotUpdateSession)
+  const doesRunExist = useCurrentRunId() != null
   const isCameraEnabled = useFeatureFlag('camera')
+
+  if (!showRobotBusyBanner && doesRunExist) {
+    setShowRobotBusyBanner(true)
+  }
 
   const updateRobotStatus = (isRobotBusy: boolean): void => {
     if (isRobotBusy) setShowRobotBusyBanner(true)


### PR DESCRIPTION
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

If a run exists, we want users to only adjust camera settings on the run setup page. This pattern is consistent with the rest of our settings, and prevents surprising behavior during run setup.

<img width="908" height="558" alt="Screenshot 2025-10-31 at 11 06 13 AM" src="https://github.com/user-attachments/assets/c32372d2-6af9-4987-b6c3-1a79db9642f5" />

e47cd430c3888cd58c2706c04ea5de43fa2862f9 - The camera card disabled logic was a bit too permissive when we first added it. Updated to ensure we disable this entirely when a run exists.

2cbbe02b0afa562dbe96a9f6a4ccdccee1b5b9be - Adds the disabled logic for the robot settings page. See pic.

749f4dfdf6ed130c39ba5059b868dda8c52643d3 - We've had reports of the run warnings banner not rendering properly, and on further investigation, it's because each individual page contains various logic for rendering that banner. We always want to render it if a run exists, so let's ensure we do that.

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- See image
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog

<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
