### PR TITLE
feat(api): Ensure image capture and filters work on OT-2

### DIFF
--- a/api/src/opentrons/system/camera.py
+++ b/api/src/opentrons/system/camera.py
@@ -336,6 +336,7 @@ async def image_capture(
         )
 
         result = await ffmpeg.ffmpeg_capture_image_bytes(
+            robot_type=robot_type,
             resolution=resolution,
             camera=camera,
             zoom=zoom,

--- a/api/src/opentrons/system/ffmpeg.py
+++ b/api/src/opentrons/system/ffmpeg.py
@@ -37,8 +37,8 @@ async def ffmpeg_capture_image_bytes(
     """Execute an FFMPEG command to capture an image based on various image parameters."""
     if robot_type == "OT-2 Standard":
         ot2_brightness: float = (
-            (brightness / 128) * -1
-        )  # OT-2's equilizer field takes a value of -1.0 to 1.0 for brightness
+            brightness / 128
+        ) * -1  # OT-2's equilizer field takes a value of -1.0 to 1.0 for brightness
         command = [
             "ffmpeg",
             "-hwaccel",

--- a/api/src/opentrons/system/ffmpeg.py
+++ b/api/src/opentrons/system/ffmpeg.py
@@ -3,6 +3,7 @@ import asyncio
 import logging
 from typing import Tuple
 from opentrons.protocol_engine.resources.camera_provider import CameraError
+from opentrons_shared_data.robot.types import RobotType
 
 log = logging.getLogger(__name__)
 
@@ -24,6 +25,7 @@ log = logging.getLogger(__name__)
 
 
 async def ffmpeg_capture_image_bytes(
+    robot_type: RobotType,
     resolution: Tuple[int, int],
     camera: str,
     zoom: float,
@@ -33,27 +35,52 @@ async def ffmpeg_capture_image_bytes(
     saturation: float,
 ) -> bytes | CameraError:
     """Execute an FFMPEG command to capture an image based on various image parameters."""
-    command = [
-        "ffmpeg",
-        "-hwaccel",
-        "auto",
-        "-video_size",
-        f"{resolution[0]}x{resolution[1]}",
-        "-i",
-        f"{camera}",
-        "-vf",
-        f"crop=iw/{zoom}:ih/{zoom}:(iw-iw/{zoom})/{zoom}:(ih-ih/{zoom})/{zoom},"
-        f"scale={resolution[0]}:{resolution[1]},"
-        f"lut=y=(val-128)*{contrast}+128-{brightness},"
-        f"hue=s={saturation},format=nv12",
-        "-frames:v",
-        "1",
-        "-f",
-        "image2pipe",
-        "-vcodec",
-        "mjpeg",
-        "-",
-    ]
+    if robot_type == "OT-2 Standard":
+        ot2_brightness: float = (
+            brightness / 128
+        )  # OT-2's equilizer field takes a value of -1.0 to 1.0 for brightness
+        command = [
+            "ffmpeg",
+            "-hwaccel",
+            "auto",
+            "-video_size",
+            f"{resolution[0]}x{resolution[1]}",
+            "-i",
+            f"{camera}",
+            "-vf",
+            f"crop=iw/{zoom}:ih/{zoom}:(iw-iw/{zoom})/{zoom}:(ih-ih/{zoom})/{zoom},"
+            f"scale={resolution[0]}:{resolution[1]},"
+            f"eq=brightness={ot2_brightness}:contrast={contrast}:saturation={saturation}",
+            "-frames:v",
+            "1",
+            "-f",
+            "image2pipe",
+            "-vcodec",
+            "mjpeg",
+            "-",
+        ]
+    else:
+        command = [
+            "ffmpeg",
+            "-hwaccel",
+            "auto",
+            "-video_size",
+            f"{resolution[0]}x{resolution[1]}",
+            "-i",
+            f"{camera}",
+            "-vf",
+            f"crop=iw/{zoom}:ih/{zoom}:(iw-iw/{zoom})/{zoom}:(ih-ih/{zoom})/{zoom},"
+            f"scale={resolution[0]}:{resolution[1]},"
+            f"lut=y=(val-128)*{contrast}+128-{brightness},"
+            f"hue=s={saturation},format=nv12",
+            "-frames:v",
+            "1",
+            "-f",
+            "image2pipe",
+            "-vcodec",
+            "mjpeg",
+            "-",
+        ]
 
     subprocess = await asyncio.create_subprocess_exec(
         *command,

--- a/api/src/opentrons/system/ffmpeg.py
+++ b/api/src/opentrons/system/ffmpeg.py
@@ -37,7 +37,7 @@ async def ffmpeg_capture_image_bytes(
     """Execute an FFMPEG command to capture an image based on various image parameters."""
     if robot_type == "OT-2 Standard":
         ot2_brightness: float = (
-            brightness / 128
+            (brightness / 128) * -1
         )  # OT-2's equilizer field takes a value of -1.0 to 1.0 for brightness
         command = [
             "ffmpeg",


### PR DESCRIPTION
# Overview
OT-2 utilizes a different build of FFMPEG than the Flex, and thus will make use of the `eq` equalizer filter fields instead of the `lut` Look-up-table fields of the Flex.


## Test Plan and Hands on Testing

- [x] Run the following protocol on OT-2 and ensure images come out as expected:
```
from opentrons.protocol_api import ProtocolContext

metadata = {
    "protocolName": "OT-2 Camera Test",
    "author": "Opentrons <protocols@opentrons.com>",
}
requirements = {
    "robotType": "OT-2",
    "apiLevel": "2.27",
}

def run(protocol: ProtocolContext) -> None:
    """Protocol."""
    protocol.capture_image(
        home_before=False, 
        filename="normal_pic",
        resolution=(1920, 1080),
        zoom=1.0,
    )

    # BRIGHTNESS
    protocol.capture_image(
        home_before=False, 
        filename="brightness_100",
        resolution=(1920, 1080),
        zoom=1.0,
        brightness=100,
    )
    protocol.capture_image(
        home_before=False, 
        filename="brightness_0",
        resolution=(1920, 1080),
        zoom=1.0,
        brightness=0,
    )

    # CONTRAST
    protocol.capture_image(
        home_before=False, 
        filename="contrast_100",
        resolution=(1920, 1080),
        zoom=1.0,
        contrast=100,
    )
    protocol.capture_image(
        home_before=False, 
        filename="contrast_10",
        resolution=(1920, 1080),
        zoom=1.0,
        contrast=10,
    )

    # SATURATION
    protocol.capture_image(
        home_before=False, 
        filename="saturation_0",
        resolution=(1920, 1080),
        zoom=1.0,
        saturation=0,
    )
    protocol.capture_image(
        home_before=False, 
        filename="saturation_100",
        resolution=(1920, 1080),
        zoom=1.0,
        saturation=100
    )
```

## Changelog
Updated FFMPEG image capture handler to account for robot type when building out filter fields.

## Review requests


## Risk assessment
Low - extends feature set for OT-2