### PR TITLE
chore(release): 8.8 release notes placeholder

### DIFF
--- a/api/release-notes.md
+++ b/api/release-notes.md
@@ -8,6 +8,12 @@ By installing and using Opentrons software, you agree to the Opentrons End-User 
 
 ---
 
+## Opentrons Robot Software Changes in 8.8.0
+
+### TODO
+
+---
+
 ## Opentrons Robot Software Changes in 8.7.0
 
 Welcome to the v8.7.0 release of the Opentrons robot software! This release adds improvements and bug fixes.

--- a/app-shell/build/release-notes.md
+++ b/app-shell/build/release-notes.md
@@ -5,6 +5,11 @@ log][]. For a list of currently known issues, please see the [Opentrons issue tr
 [opentrons issue tracker]: https://github.com/Opentrons/opentrons/issues?q=is%3Aopen+is%3Aissue+label%3Abug
 
 By installing and using Opentrons software, you agree to the Opentrons End-User License Agreement (EULA). You can view the EULA at [opentrons.com/eula](https://opentrons.com/eula).
+---
+
+## Opentrons App Changes in 8.8.0
+
+### TODO
 
 ---
 


### PR DESCRIPTION
### 8.8 release notes placeholder

A little something so we can tell in the app we are upgrading on the 8.8 alpha until the actual notes are ready.