### PR TITLE
fix(app): hide "edit settings" in camera card behind ff

### DIFF
--- a/app/src/organisms/Desktop/Devices/Peripherals/CameraCard.tsx
+++ b/app/src/organisms/Desktop/Devices/Peripherals/CameraCard.tsx
@@ -18,6 +18,7 @@ import systemCameraFlex from '/app/assets/images/system_camera_flex.png'
 import systemCameraOT2 from '/app/assets/images/system_camera_ot2.png'
 import { useCameraUsageSettings } from '/app/local-resources/images/hooks/useCameraUsageSettings'
 import { CameraControls } from '/app/organisms/Desktop/Camera/CameraControls'
+import { useFeatureFlag } from '/app/redux/config'
 import { useCurrentRunId } from '/app/resources/runs'
 
 import styles from './inputdevices.module.css'
@@ -129,6 +130,7 @@ function CameraCardOverflowMenu({
   navigateToUsageSettings: () => void
 }): JSX.Element {
   const { t } = useTranslation('device_details')
+  const cameraControlsEnabled = useFeatureFlag('camera')
 
   return (
     <div className={styles.card_overflow_menu_container}>
@@ -136,7 +138,9 @@ function CameraCardOverflowMenu({
         <MenuItem onClick={toggleCameraEnabled}>
           {cameraEnabled ? t('disable_camera') : t('enable_camera')}
         </MenuItem>
-        <MenuItem onClick={toggleControls}>{t('edit_settings')}</MenuItem>
+        {cameraControlsEnabled && (
+          <MenuItem onClick={toggleControls}>{t('edit_settings')}</MenuItem>
+        )}
         <Divider />
         <MenuItem onClick={navigateToUsageSettings}>
           {t('usage_settings')}

--- a/app/src/organisms/Desktop/Devices/Peripherals/__tests__/CameraCard.test.tsx
+++ b/app/src/organisms/Desktop/Devices/Peripherals/__tests__/CameraCard.test.tsx
@@ -9,6 +9,7 @@ import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
 import { useCameraUsageSettings } from '/app/local-resources/images/hooks/useCameraUsageSettings'
 import { CameraControls } from '/app/organisms/Desktop/Camera/CameraControls'
+import { useFeatureFlag } from '/app/redux/config'
 import { useCurrentRunId, useNotifyRunQuery } from '/app/resources/runs'
 
 import { CameraCard } from '../CameraCard'
@@ -19,6 +20,7 @@ import type { CameraCardProps } from '../CameraCard'
 vi.mock('/app/organisms/Desktop/Camera/CameraControls')
 vi.mock('/app/local-resources/images/hooks/useCameraUsageSettings')
 vi.mock('/app/resources/runs')
+vi.mock('/app/redux/config')
 
 const mockNavigate = vi.fn()
 vi.mock('react-router-dom', async () => {
@@ -59,6 +61,7 @@ describe('CameraCard', () => {
       isCameraEnabled: true,
       toggleCameraEnabled: mockToggleEnabled,
     } as any)
+    vi.mocked(useFeatureFlag).mockReturnValue(true)
   })
 
   it('renders camera card with OT-2 image for non-Flex robot', () => {


### PR DESCRIPTION
Closes [RQA-4809](https://opentrons.atlassian.net/browse/RQA-4809) and [RQA-4810](https://opentrons.atlassian.net/browse/RQA-4810)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Whoops, the camera-specific settings are not available in RS 8.8.0. I forgot to hide this one entry point behind a feature flag.

To fix, just hide the "edit settings" in the camera card overflow menu behind a feature flag.

<img width="1018" height="770" alt="Screenshot 2025-11-03 at 11 11 10 AM" src="https://github.com/user-attachments/assets/a34403c7-7674-4dc7-a320-2da348272f14" />

<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- See image. The "edit settings" is not visible unless the feature flag is enabled.
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Fixed "edit settings" appearing on the Camera card on the robot details page.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
very very low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[RQA-4809]: https://opentrons.atlassian.net/browse/RQA-4809?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RQA-4810]: https://opentrons.atlassian.net/browse/RQA-4810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ