### PR TITLE
chore: switch to fully external buildroot tree

### DIFF
--- a/api/buildroot.mk
+++ b/api/buildroot.mk
@@ -37,5 +37,4 @@ export OPENTRONS_GIT_DIR=$(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)
 # Calling inner-python-package directly instead of using python-package macro
 # because our directory layout doesn’t conform to buildroot’s expectation of
 # having the directory name be the package name
-$(eval $(call inner-python-package,$(ot_api_name),$(call UPPERCASE,$(ot_api_name)),$(call UPPERCASE,$(ot_api_name)),target))
-
+$(eval $(call inner-python-hatch-package,$(ot_api_name),$(call UPPERCASE,$(ot_api_name)),$(call UPPERCASE,$(ot_api_name)),target))

--- a/external.mk
+++ b/external.mk
@@ -1,8 +1,2 @@
 # Makefile inclusions for buildroot integration
-include $(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)/api/buildroot.mk
-include $(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)/update-server/buildroot.mk
-include $(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)/robot-server/buildroot.mk
-include $(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)/shared-data/buildroot.mk
-include $(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)/system-server/buildroot.mk
-include $(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)/server-utils/buildroot.mk
-include $(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)/hardware/buildroot.mk
+include $(sort $(wildcard $(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)/*/buildroot.mk))

--- a/hardware/buildroot.mk
+++ b/hardware/buildroot.mk
@@ -33,5 +33,4 @@ export OPENTRONS_GIT_DIR=$(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)
 # Calling inner-python-package directly instead of using python-package macro
 # because our directory layout doesn’t conform to buildroot’s expectation of
 # having the directory name be the package name
-$(eval $(call inner-python-package,$(ot_hardware_name),$(call UPPERCASE,$(ot_hardware_name)),$(call UPPERCASE,$(ot_hardware_name)),target))
-
+$(eval $(call inner-python-hatch-package,$(ot_hardware_name),$(call UPPERCASE,$(ot_hardware_name)),$(call UPPERCASE,$(ot_hardware_name)),target))

--- a/robot-server/buildroot.mk
+++ b/robot-server/buildroot.mk
@@ -43,5 +43,4 @@ export OPENTRONS_GIT_DIR=$(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)
 # Calling inner-python-package directly instead of using python-package macro
 # because our directory layout doesn’t conform to buildroot’s expectation of
 # having the directory name be the package name
-$(eval $(call inner-python-package,$(ot_robot_server_name),$(call UPPERCASE,$(ot_robot_server_name)),$(call UPPERCASE,$(ot_robot_server_name)),target))
-
+$(eval $(call inner-python-hatch-package,$(ot_robot_server_name),$(call UPPERCASE,$(ot_robot_server_name)),$(call UPPERCASE,$(ot_robot_server_name)),target))

--- a/server-utils/buildroot.mk
+++ b/server-utils/buildroot.mk
@@ -32,5 +32,4 @@ ot_server_utils_name := python-opentrons-server-utils
 # Calling inner-python-package directly instead of using python-package macro
 # because our directory layout doesn’t conform to buildroot’s expectation of
 # having the directory name be the package name
-$(eval $(call inner-python-package,$(ot_server_utils_name),$(call UPPERCASE,$(ot_server_utils_name)),$(call UPPERCASE,$(ot_server_utils_name)),target))
-
+$(eval $(call inner-python-hatch-package,$(ot_server_utils_name),$(call UPPERCASE,$(ot_server_utils_name)),$(call UPPERCASE,$(ot_server_utils_name)),target))

--- a/shared-data/buildroot.mk
+++ b/shared-data/buildroot.mk
@@ -32,4 +32,4 @@ export OPENTRONS_GIT_DIR=$(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)
 # Calling inner-python-package directly instead of using python-package macro
 # because our directory layout doesn’t conform to buildroot’s expectation of
 # having the directory name be the package name
-$(eval $(call inner-python-package,$(ot_sd_name),$(call UPPERCASE,$(ot_sd_name)),$(call UPPERCASE,$(ot_sd_name)),target))
+$(eval $(call inner-python-hatch-package,$(ot_sd_name),$(call UPPERCASE,$(ot_sd_name)),$(call UPPERCASE,$(ot_sd_name)),target))

--- a/system-server/buildroot.mk
+++ b/system-server/buildroot.mk
@@ -44,5 +44,4 @@ export OPENTRONS_GIT_DIR=$(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)
 # Calling inner-python-package directly instead of using python-package macro
 # because our directory layout doesn’t conform to buildroot’s expectation of
 # having the directory name be the package name
-$(eval $(call inner-python-package,$(ot_system_server_name),$(call UPPERCASE,$(ot_system_server_name)),$(call UPPERCASE,$(ot_system_server_name)),target))
-
+$(eval $(call inner-python-hatch-package,$(ot_system_server_name),$(call UPPERCASE,$(ot_system_server_name)),$(call UPPERCASE,$(ot_system_server_name)),target))

--- a/update-server/buildroot.mk
+++ b/update-server/buildroot.mk
@@ -46,5 +46,4 @@ export OPENTRONS_GIT_DIR=$(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)
 # Calling inner-python-package directly instead of using python-package macro
 # because our directory layout doesn’t conform to buildroot’s expectation of
 # having the directory name be the package name
-$(eval $(call inner-python-package,$(otupdate_name),$(call UPPERCASE,$(otupdate_name)),$(call UPPERCASE,$(otupdate_name)),target))
-
+$(eval $(call inner-python-hatch-package,$(otupdate_name),$(call UPPERCASE,$(otupdate_name)),$(call UPPERCASE,$(otupdate_name)),target))


### PR DESCRIPTION
This is the monorepo side of switching to having all our buildroot changes managed in a so-called "external tree", as opposed to just committed to a fork of the upstream buildroot repo. The changes here are not compatible with the current kind of setup.

In this repo, all that has to be done is switching the package builders to use our backports of future hatch tooling from upstream. When we update buildroot, we'll be able to switch this back.

For this PR and its buildroot partner, there should be no functional difference on a running OT-2 before and after the change - this does not include any package upgrades or behavior changes. It's all about how we store our customizations and how we build.

This is the monorepo side of https://github.com/Opentrons/buildroot/pull/266 and isn't really reviewable without that context.

## testing
- [x] put the builds of this on an ot-2 and see if it works