### PR TITLE
docs: Fix bad link to help center and add class rule to procedures

### DIFF
--- a/docs/flex/docs/advanced-operation/command-line.md
+++ b/docs/flex/docs/advanced-operation/command-line.md
@@ -14,6 +14,8 @@ An SSH key is required to perform these tasks and to issue commands from the ter
 
 Follow these steps to create an SSH key on your Mac, Windows, or Linux computer:
 
+<div class="instruction-list" markdown>
+
 1. Open a terminal window and type this command:
 
     ```
@@ -29,6 +31,8 @@ Follow these steps to create an SSH key on your Mac, Windows, or Linux computer:
 
 4. Eject the USB drive.
 
+</div>
+
 ## Making a wireless SSH connection
 
 !!!note
@@ -36,9 +40,11 @@ Follow these steps to create an SSH key on your Mac, Windows, or Linux computer:
 
 To make an SSH connection:
 
-1. Insert the USB drive that holds the SSH key created earlier into a USB port on your Flex.
+<div class="instruction-list" markdown>
 
-2. On your computer, open a terminal window and type the commands shown below. Replace `ROBOT_IP` with the IP address of your Flex.
+5. Insert the USB drive that holds the SSH key created earlier into a USB port on your Flex.
+
+6. On your computer, open a terminal window and type the commands shown below. Replace `ROBOT_IP` with the IP address of your Flex.
 
     ```
     curl \
@@ -47,13 +53,15 @@ To make an SSH connection:
     ```
     The command is successful when you see a response message that indicates a new key was added.
 
-3. After adding the key, type the command shown below. Replace `ROBOT_IP` with the IP address of your Flex.
+7. After adding the key, type the command shown below. Replace `ROBOT_IP` with the IP address of your Flex.
 
     ```
     ssh -i robot_key root@ROBOT_IP
     ```
 
-4. Type the passphrase you set when creating the SSH key.
+8. Type the passphrase you set when creating the SSH key.
+
+</div>
 
 When an SSH connection is successful, the terminal command prompt changes to `root@` followed by the serial number of your robot (e.g., `root@FLXA1020231007001:~#`). You can now interact with the robot via the terminal window.
 
@@ -74,6 +82,8 @@ When disconnected from a network, your Flex will assign itself an IP address and
 
 You can get the IP address range and subnet mask from the robot by connecting it to your computer and checking the Opentrons App:
 
+<div class="instruction-list" markdown>
+
 1. If the robot is connected by Ethernet cable to a switch or wall jack, disconnect it. Then establish a physical Ethernet connection to your computer, as described above.
 
 2. Launch the Opentrons App.
@@ -84,6 +94,8 @@ You can get the IP address range and subnet mask from the robot by connecting it
         If your robot appears as inactive or inaccessible in the app, wait a few moments. Flex will configure itself and eventually become available again. If this does not happen, turn the robot's power off, wait a few seconds, turn the power back on, and check the app again after the robot boots up.
 
 4. After locating your robot in the app, click the three-dot menu (⋮), select **Robot settings**, and then click the **Networking** tab.
+
+</div>
 
 The Networking tab will show you the IP address and subnet mask of your robot. When disconnected from a network, Flex will assign itself a non-routing IP address. Here's an example of a self-assigned IP address on a Flex:
 

--- a/docs/flex/docs/advanced-operation/log-files.md
+++ b/docs/flex/docs/advanced-operation/log-files.md
@@ -25,6 +25,8 @@ The records in these log files can be difficult to interpret and understand but 
 
 Follow these instructions to download the Flex log files:
 
+<div class="instruction-list" markdown>
+
 1. From the Opentrons App, click **Devices** and locate the robot that you want the logs from.
 
 2. For your selected robot, click the three-dot menu ( ⋮ ) and then click **Robot settings**.
@@ -37,3 +39,5 @@ Follow these instructions to download the Flex log files:
         Flex produces a single `.zip` file that contains the logs. The file name includes the robot’s name followed by `_logs.zip`. For example, if your robot is called “Flex1," the log file will be named `Flex1_logs.zip`.
 
 5. _(Optional)_ To read the logs, double-click the downloaded file to decompress it. The individual logs will expand into a new folder in the same location as the downloaded file. Any text editor should be able to open these files.
+
+</div>

--- a/docs/flex/docs/touchscreen/settings.md
+++ b/docs/flex/docs/touchscreen/settings.md
@@ -41,7 +41,7 @@ Flex records what it's doing in several log files that are stored on the robot. 
 
 - **Display Usage:** Data about how the touchscreen draws its graphics.
 
-If you opt out of automatic data sharing, you can still [download your Flex log files](https://support.opentrons.com/s/article/How-to-download-the-logs-on-Opentrons-Flex) for your own use or to manually send them to Opentrons Support for troubleshooting.
+If you opt out of automatic data sharing, you can still download Flex log files for your own use or to send them to Opentrons Support for troubleshooting. See [Downloading Flex Log Files](../advanced-operation/log-files.md#downloading-flex-log-files) for instructions.
 
 !!! note
     There are separate privacy controls in the Opentrons App. Turning sharing on or off from the touchscreen only affects data collected and sent by the robot. Your laptop or desktop computer will still automatically share data if this feature is enabled in the Opentrons App.


### PR DESCRIPTION
# Overview

This PR adds the instruction list class rule to procedures documented in the `log-files.md` and `command-line.md` files.

In `settings.md` this PR also removes an obsolete link to the Help Center and instead points to the "download" section of the log files doc included above.

## Test Plan and Hands on Testing

Check links to make sure they're working properly.
Check opening and closing `<div>` tags to make sure they're properly wrapping the ordered lists used in these files.

## Changelog

Updates:

- `settings.md#privacy`
- `command-line.md`
- `log-files.md`

## Review requests

Is this ok?

## Risk assessment

Low
