### PR TITLE
docs(github): simplify pull request template, stop checking in HTML comments

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,43 +1,22 @@
-<!--
-Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:
-
-https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests
-
-GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:
-
-https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax
-
-To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
--->
-
 # Overview
 
-<!--
 Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
--->
 
 ## Test Plan and Hands on Testing
 
-<!--
 Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
--->
 
 ## Changelog
 
-<!--
 List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
--->
 
 ## Review requests
 
-<!--
 - What do you need from reviewers to feel confident this PR is ready to merge?
 - Ask questions.
--->
 
 ## Risk assessment
 
-<!--
 - Indicate the level of attention this PR needs.
 - Provide context to guide reviewers.
 - Discuss trade-offs, coupling, and side effects.
@@ -45,4 +24,3 @@ List changes introduced by this PR considering future developers and the end use
   - For instance, changing return tip behavior may also change the behavior of labware calibration.
 - How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
 - Especially in high risk PRs, explain how you know your testing is enough.
--->


### PR DESCRIPTION
# Overview

Despite my admonishments, we continue to check in commits that begin with:
```
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure
you've read the "Opening Pull Requests" section of our Contributing
Guide:
...
```
This is noisy and distracting, especially when I examine the git log from the command line. (Github hides HTML comments when you preview the text via the web UI, but the HTML comments are included verbatim in the git commit.)

This change deletes the introductory text, and changes all the other instructions in the template from comments into body text.

I'm hoping that this will make authors delete the instructions as they fill in each section, because if they don't, the instructions will show up very obviously in Github and in the email messages.

## Risk assessment

Low.