### PR TITLE
fix(api): Ensure Pan field in CaptureImage command result is defaulted to None

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/capture_image.py
+++ b/api/src/opentrons/protocol_engine/commands/capture_image.py
@@ -79,7 +79,7 @@ class CaptureImageResult(BaseModel):
     """Result data from running an image capture."""
 
     fileId: Optional[str] = Field(
-        ...,
+        None,
         description="File ID for image files output as a result of an image capture action.",
     )
     resolution: Tuple[int, int] = Field(

--- a/api/src/opentrons/protocol_engine/commands/capture_image.py
+++ b/api/src/opentrons/protocol_engine/commands/capture_image.py
@@ -91,7 +91,7 @@ class CaptureImageResult(BaseModel):
         description="Multiplier used when cropping and scaling the captured image. Scale is 1.0 to 2.0.",
     )
     pan: Optional[Tuple[int, int]] = Field(
-        ...,
+        None,
         description="X/Y (pixels) position panned to.",
     )
     contrast: float = Field(
@@ -112,7 +112,7 @@ def _converted_image_params(params: CaptureImageParams) -> ImageParameters:
     return ImageParameters(
         resolution=params.resolution,
         zoom=params.zoom,
-        pan=params.pan if params.pan is not None else None,
+        pan=params.pan,
         contrast=(
             (params.contrast / 100) * 2.0 if params.contrast is not None else None
         ),

--- a/api/src/opentrons/protocol_engine/commands/capture_image.py
+++ b/api/src/opentrons/protocol_engine/commands/capture_image.py
@@ -112,7 +112,7 @@ def _converted_image_params(params: CaptureImageParams) -> ImageParameters:
     return ImageParameters(
         resolution=params.resolution,
         zoom=params.zoom,
-        pan=params.pan,
+        pan=params.pan if params.pan is not None else None,
         contrast=(
             (params.contrast / 100) * 2.0 if params.contrast is not None else None
         ),

--- a/api/tests/opentrons/protocol_engine/commands/test_capture_image.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_capture_image.py
@@ -330,3 +330,42 @@ async def test_capture_image_returns_expected_params(
             ),
             state_update=result.state_update,
         )
+
+
+async def test_capture_image_result_has_clean_defaults(
+    decoy: Decoy,
+    state_view: StateView,
+    file_provider: FileProvider,
+    camera_provider_image_capture: CameraProvider,
+) -> None:
+    """It should return the successful result of an image capture with all expected defaults."""
+    subject = CaptureImageImpl(
+        state_view=state_view,
+        file_provider=file_provider,
+        camera_provider=camera_provider_image_capture,
+    )
+    params = CaptureImageParams(
+        fileName="coolpic",
+        resolution=None,
+        zoom=None,
+        pan=None,
+        contrast=None,
+        brightness=None,
+        saturation=None,
+    )
+    decoy.when(state_view.files.get_filecount()).then_return(0)
+
+    with mock.patch("os.path.exists", mock.Mock(return_value=True)):
+        result = await subject.execute(params=params)
+        assert result == SuccessData(
+            public=CaptureImageResult(
+                fileId=None,
+                resolution=(1920, 1080),
+                zoom=1.0,
+                pan=None,
+                contrast=50,
+                brightness=50,
+                saturation=50,
+            ),
+            state_update=result.state_update,
+        )


### PR DESCRIPTION
# Overview
Covers RQA-4811

This change fixes the issue mentioned in the PR where a `Field required` error was returned on the value of `captureImage.result.pan` when attempting to download run logs.

## Test Plan and Hands on Testing
- [x] Run a protocol on a robot and ensure the logs can be downloaded after a run.
- [x] Implement unit test coverage

## Changelog

## Review requests

## Risk assessment
Low - faces new features only