### PR TITLE
feat(step-generation): add all load commands to invariantContext construct in PV

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/SubStepsToolbox.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/SubStepsToolbox.tsx
@@ -44,6 +44,7 @@ export function SubStepsToolbox(
   const substeps = useSelector(getSubsteps)[stepId]
   const formData = useSelector(getSavedStepForms)[stepId]
   const hoveredSubstep = useSelector(getHoveredSubstep)
+  console.log('hoveredSubstep', hoveredSubstep)
   const highlightSubstep = (payload: SubstepIdentifier): HoverOnSubstepAction =>
     dispatch(hoverOnSubstep(payload))
 

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/SubStepsToolbox.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/SubStepsToolbox.tsx
@@ -44,7 +44,6 @@ export function SubStepsToolbox(
   const substeps = useSelector(getSubsteps)[stepId]
   const formData = useSelector(getSavedStepForms)[stepId]
   const hoveredSubstep = useSelector(getHoveredSubstep)
-  console.log('hoveredSubstep', hoveredSubstep)
   const highlightSubstep = (payload: SubstepIdentifier): HoverOnSubstepAction =>
     dispatch(hoverOnSubstep(payload))
 

--- a/step-generation/src/utils/constructInvariantContextFromRunCommands.ts
+++ b/step-generation/src/utils/constructInvariantContextFromRunCommands.ts
@@ -31,8 +31,8 @@ export function constructInvariantContextFromRunCommands(
         const amount = params.quantity
 
         if (
-          result.definition?.schemaVersion === 2 &&
-          result.definition != null
+          result.definition != null &&
+          result.definition.schemaVersion === 2
         ) {
           const def = result.definition
           const labwareDefURI = getLabwareDefURI(def)

--- a/step-generation/src/utils/constructInvariantContextFromRunCommands.ts
+++ b/step-generation/src/utils/constructInvariantContextFromRunCommands.ts
@@ -26,12 +26,41 @@ export function constructInvariantContextFromRunCommands(
 ): InvariantContext {
   return commands.reduce(
     (acc: InvariantContext, command: RunTimeCommand) => {
-      if (command.commandType === 'loadLabware' && command.result != null) {
+      let labwareEntities: LabwareEntities = { ...acc.labwareEntities }
+      if (command.commandType === 'loadLidStack' && command.result != null) {
         const result = command.result
-
+        if (result.lidStackDefinition.schemaVersion === 2) {
+          const labwareDefURI = getLabwareDefURI(result.lidStackDefinition)
+          const lidId = `${uuid()}:${labwareDefURI}`
+          labwareEntities = {
+            ...labwareEntities,
+            [lidId]: {
+              id: lidId,
+              labwareDefURI,
+              def: result.lidStackDefinition,
+              //  ProtocolTimelineScrubber won't need access to pythonNames
+              pythonName: 'n/a',
+            },
+          }
+          return {
+            ...acc,
+            labwareEntities,
+          }
+        } else {
+          // loadLabware commands from the backend can have schema 3 labware definitions.
+          // step-generation, and this function by extension, are not prepared to handle
+          // schema 3 yet.
+          return acc
+        }
+      } else if (
+        (command.commandType === 'loadLabware' ||
+          command.commandType === 'loadLid') &&
+        command.result != null
+      ) {
+        const { result } = command
         if (result.definition.schemaVersion === 2) {
-          const labwareEntities: LabwareEntities = {
-            ...acc.labwareEntities,
+          labwareEntities = {
+            ...labwareEntities,
             [result.labwareId]: {
               id: result.labwareId,
               labwareDefURI: getLabwareDefURI(result.definition),

--- a/step-generation/src/utils/constructInvariantContextFromRunCommands.ts
+++ b/step-generation/src/utils/constructInvariantContextFromRunCommands.ts
@@ -28,20 +28,26 @@ export function constructInvariantContextFromRunCommands(
     (acc: InvariantContext, command: RunTimeCommand) => {
       let labwareEntities: LabwareEntities = { ...acc.labwareEntities }
       if (command.commandType === 'loadLidStack' && command.result != null) {
-        const result = command.result
-        if (result.lidStackDefinition.schemaVersion === 2) {
-          const labwareDefURI = getLabwareDefURI(result.lidStackDefinition)
-          const lidId = `${uuid()}:${labwareDefURI}`
-          labwareEntities = {
-            ...labwareEntities,
-            [lidId]: {
-              id: lidId,
-              labwareDefURI,
-              def: result.lidStackDefinition,
-              //  ProtocolTimelineScrubber won't need access to pythonNames
-              pythonName: 'n/a',
-            },
+        const { result, params } = command
+        const amount = params.quantity
+        if (
+          result.definition?.schemaVersion === 2 &&
+          result.definition != null
+        ) {
+          const labwareDefURI = getLabwareDefURI(result.definition)
+          for (let i = 0; i < amount; i++) {
+            const labwareId = result.labwareIds[i]
+            labwareEntities = {
+              ...labwareEntities,
+              [labwareId]: {
+                id: labwareId,
+                labwareDefURI,
+                def: result.definition,
+                pythonName: 'n/a',
+              },
+            }
           }
+
           return {
             ...acc,
             labwareEntities,

--- a/step-generation/src/utils/constructInvariantContextFromRunCommands.ts
+++ b/step-generation/src/utils/constructInvariantContextFromRunCommands.ts
@@ -26,31 +26,35 @@ export function constructInvariantContextFromRunCommands(
 ): InvariantContext {
   return commands.reduce(
     (acc: InvariantContext, command: RunTimeCommand) => {
-      let labwareEntities: LabwareEntities = { ...acc.labwareEntities }
       if (command.commandType === 'loadLidStack' && command.result != null) {
         const { result, params } = command
         const amount = params.quantity
+
         if (
           result.definition?.schemaVersion === 2 &&
           result.definition != null
         ) {
-          const labwareDefURI = getLabwareDefURI(result.definition)
-          for (let i = 0; i < amount; i++) {
-            const labwareId = result.labwareIds[i]
-            labwareEntities = {
-              ...labwareEntities,
-              [labwareId]: {
-                id: labwareId,
-                labwareDefURI,
-                def: result.definition,
-                pythonName: 'n/a',
-              },
-            }
-          }
+          const def = result.definition
+          const labwareDefURI = getLabwareDefURI(def)
+
+          const stackLabwareEntities = result.labwareIds
+            .slice(0, amount)
+            .reduce(
+              (entities: LabwareEntities, labwareId) => ({
+                ...entities,
+                [labwareId]: {
+                  id: labwareId,
+                  labwareDefURI,
+                  def,
+                  pythonName: 'n/a',
+                },
+              }),
+              acc.labwareEntities
+            )
 
           return {
             ...acc,
-            labwareEntities,
+            labwareEntities: stackLabwareEntities,
           }
         } else {
           // loadLabware commands from the backend can have schema 3 labware definitions.
@@ -65,8 +69,8 @@ export function constructInvariantContextFromRunCommands(
       ) {
         const { result } = command
         if (result.definition.schemaVersion === 2) {
-          labwareEntities = {
-            ...labwareEntities,
+          const labwareEntities = {
+            ...acc.labwareEntities,
             [result.labwareId]: {
               id: result.labwareId,
               labwareDefURI: getLabwareDefURI(result.definition),

--- a/step-generation/src/utils/createTimelineFromRunCommands.ts
+++ b/step-generation/src/utils/createTimelineFromRunCommands.ts
@@ -70,7 +70,10 @@ export function getResultingTimelineFrameFromRunCommands(
             (acc: Record<string, LabwareLocationSequence>, subArray) => {
               const firstLabware:
                 | OnLabwareLocationSequenceComponent
-                | undefined = subArray.find(item => item.kind === 'onLabware')
+                | undefined = subArray.find(
+                (item): item is OnLabwareLocationSequenceComponent =>
+                  item.kind === 'onLabware'
+              )
               if (firstLabware != null) {
                 acc[firstLabware.labwareId] = subArray
               }

--- a/step-generation/src/utils/createTimelineFromRunCommands.ts
+++ b/step-generation/src/utils/createTimelineFromRunCommands.ts
@@ -6,6 +6,7 @@ import { getStackForLabwareLocation, makeInitialRobotState } from './misc'
 
 import type {
   LabwareLocationSequence,
+  OnLabwareLocationSequenceComponent,
   RunTimeCommand,
 } from '@opentrons/shared-data'
 import type {
@@ -67,10 +68,10 @@ export function getResultingTimelineFrameFromRunCommands(
         if (locationSequences != null) {
           const sequenceMap = locationSequences.reduce(
             (acc: Record<string, LabwareLocationSequence>, subArray) => {
-              const firstLabware = subArray.find(
-                item => item.kind === 'onLabware'
-              )
-              if (firstLabware?.labwareId) {
+              const firstLabware:
+                | OnLabwareLocationSequenceComponent
+                | undefined = subArray.find(item => item.kind === 'onLabware')
+              if (firstLabware != null) {
                 acc[firstLabware.labwareId] = subArray
               }
               return acc

--- a/step-generation/src/utils/createTimelineFromRunCommands.ts
+++ b/step-generation/src/utils/createTimelineFromRunCommands.ts
@@ -2,9 +2,12 @@ import { getModuleDef, locationIsOffDeck } from '@opentrons/shared-data'
 
 import { MODULE_INITIAL_STATE_BY_TYPE } from '../constants'
 import { getNextRobotStateAndWarnings } from '../getNextRobotStateAndWarnings'
-import { makeInitialRobotState } from './misc'
+import { getStackForLabwareLocation, makeInitialRobotState } from './misc'
 
-import type { RunTimeCommand } from '@opentrons/shared-data'
+import type {
+  LabwareLocationSequence,
+  RunTimeCommand,
+} from '@opentrons/shared-data'
 import type {
   InvariantContext,
   RobotState,
@@ -56,7 +59,44 @@ export function getResultingTimelineFrameFromRunCommands(
 
   const labwareLocations = commands.reduce<RobotState['labware']>(
     (acc, command) => {
-      if (command.commandType === 'loadLabware' && command.result != null) {
+      if (command.commandType === 'loadLidStack' && command.result != null) {
+        const { result } = command
+        const locationSequences = result.locationSequences
+        const labwareIds = result.labwareIds
+
+        if (locationSequences != null) {
+          const sequenceMap = locationSequences.reduce(
+            (acc: Record<string, LabwareLocationSequence>, subArray) => {
+              const firstLabware = subArray.find(
+                item => item.kind === 'onLabware'
+              )
+              if (firstLabware?.labwareId) {
+                acc[firstLabware.labwareId] = subArray
+              }
+              return acc
+            },
+            {}
+          )
+          const labwareStacks = labwareIds.reduce(
+            (acc: Record<string, { stack: string[] }>, id) => {
+              const sequence = sequenceMap[id]
+              if (sequence != null) {
+                acc[id] = { stack: getStackForLabwareLocation(sequence) }
+              }
+              return acc
+            },
+            {}
+          )
+          return {
+            ...acc,
+            ...labwareStacks,
+          }
+        }
+      } else if (
+        (command.commandType === 'loadLabware' ||
+          command.commandType === 'loadLid') &&
+        command.result != null
+      ) {
         const stack = [command.result.labwareId]
         if (locationIsOffDeck(command.params.location)) {
           stack.push(command.params.location)
@@ -85,7 +125,6 @@ export function getResultingTimelineFrameFromRunCommands(
     },
     {}
   )
-
   const initialRobotState = makeInitialRobotState({
     invariantContext,
     labwareLocations,

--- a/step-generation/src/utils/misc.ts
+++ b/step-generation/src/utils/misc.ts
@@ -1290,24 +1290,20 @@ export const getIsRetractSafeForAirGap = (args: {
 
 export const getStackForLabwareLocation = (
   locationSequence: LabwareLocationSequence
-): string[] => {
-  const stack: string[] = []
-
-  locationSequence
-    .filter(item => item.kind !== 'onCutoutFixture')
-    .forEach(item => {
-      if (item.kind === 'onLabware') {
-        stack.push(item.labwareId)
-      } else if (item.kind === 'onModule') {
-        stack.push(item.moduleId)
-      } else if (item.kind === 'inStackerHopper') {
-        stack.push(item.moduleId)
-      } else if (item.kind === 'onAddressableArea') {
-        stack.push(item.addressableAreaName)
-      } else {
-        stack.push(item.logicalLocationName)
-      }
-    })
-
-  return stack
-}
+): string[] =>
+  locationSequence.reduce<string[]>((acc, item) => {
+    const { kind } = item
+    if (kind === 'onCutoutFixture') {
+      return acc
+    }
+    if (kind === 'onLabware') {
+      return [...acc, item.labwareId]
+    }
+    if (kind === 'onModule' || kind === 'inStackerHopper') {
+      return [...acc, item.moduleId]
+    }
+    if (kind === 'onAddressableArea') {
+      return [...acc, item.addressableAreaName]
+    }
+    return [...acc, item.logicalLocationName]
+  }, [])

--- a/step-generation/src/utils/misc.ts
+++ b/step-generation/src/utils/misc.ts
@@ -44,6 +44,7 @@ import type {
   CutoutFixtureId,
   CutoutId,
   LabwareDefinition2,
+  LabwareLocationSequence,
   PipetteChannels,
   PipetteV2Specs,
   PositionReference,
@@ -1285,4 +1286,28 @@ export const getIsRetractSafeForAirGap = (args: {
   }
   const retractZOffsetFromTop = retractMmFromBottom - wellDepth
   return retractZOffsetFromTop >= SAFE_MOVE_TO_WELL_OFFSET_FROM_TOP_MM
+}
+
+export const getStackForLabwareLocation = (
+  locationSequence: LabwareLocationSequence
+): string[] => {
+  const stack: string[] = []
+
+  locationSequence
+    .filter(item => item.kind !== 'onCutoutFixture')
+    .forEach(item => {
+      if (item.kind === 'onLabware') {
+        stack.push(item.labwareId)
+      } else if (item.kind === 'onModule') {
+        stack.push(item.moduleId)
+      } else if (item.kind === 'inStackerHopper') {
+        stack.push(item.moduleId)
+      } else if (item.kind === 'onAddressableArea') {
+        stack.push(item.addressableAreaName)
+      } else {
+        stack.push(item.logicalLocationName)
+      }
+    })
+
+  return stack
 }


### PR DESCRIPTION
closes AUTH-2411

# Overview

This PR adds support for `loadLid` and `loadLidStack` in `invariantContext` and initial robot state in PV by updating labware locations and labware entities 

## Test Plan and Hands on Testing

upload attached protocol and see that in PV when you scroll to the final step, the labware all render on the deck which includes a tiprack, a well plate with lid, and a stack of lids

## Changelog

add support for `loadLid` and `loadLidStack` to `invariantContext` and initial robot state in PV

## Risk assessment

low
