### PR TITLE
refactor(shared-data,app,pd): unify LabwareDefinitionsByURI definitions

### DIFF
--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useDeckMapUtils.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useDeckMapUtils.ts
@@ -22,7 +22,7 @@ import type {
   CutoutConfigProtocolSpec,
   DeckDefinition,
   LabwareDefinition,
-  LabwareDefinitionsByUri,
+  LabwareDefinitionsByURI,
   LabwareLocation,
   LoadedLabware,
   LoadedModule,
@@ -414,7 +414,7 @@ export function getRunCurrentLabwareInfo({
 
 const getLabwareDefinition = (
   labware: LoadedLabware,
-  protocolLabwareDefinitionsByUri: LabwareDefinitionsByUri
+  protocolLabwareDefinitionsByUri: LabwareDefinitionsByURI
 ): LabwareDefinition => {
   if (labware.id === 'fixedTrash') {
     return getFixedTrashLabwareDefinition()

--- a/app/src/organisms/InterventionModal/__fixtures__/index.ts
+++ b/app/src/organisms/InterventionModal/__fixtures__/index.ts
@@ -7,7 +7,7 @@ import {
 import type { RunData } from '@opentrons/api-client'
 import type {
   LabwareDefinition,
-  LabwareDefinitionsByUri,
+  LabwareDefinitionsByURI,
   Liquid,
   LoadedLabware,
   LoadedModule,
@@ -171,7 +171,7 @@ export const mockLabwareDefinition = ({
 
 export const mockLabwareDefinitionsByUri = {
   'opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1': mockLabwareDefinition,
-} as LabwareDefinitionsByUri
+} as LabwareDefinitionsByURI
 
 export const mockModule: LoadedModule = {
   id: 'mockModuleID',

--- a/app/src/organisms/InterventionModal/utils/getRunModuleRenderInfo.ts
+++ b/app/src/organisms/InterventionModal/utils/getRunModuleRenderInfo.ts
@@ -10,7 +10,7 @@ import type { Module } from '@opentrons/components'
 import type {
   DeckDefinition,
   LabwareDefinition,
-  LabwareDefinitionsByUri,
+  LabwareDefinitionsByURI,
   ModuleDefinition,
 } from '@opentrons/shared-data'
 
@@ -33,7 +33,7 @@ export interface RunModuleInfo {
 export function getRunModuleRenderInfo(
   runData: RunData,
   deckDef: DeckDefinition,
-  labwareDefs: LabwareDefinitionsByUri
+  labwareDefs: LabwareDefinitionsByURI
 ): RunModuleInfo[] {
   if (runData.modules.length > 0) {
     return runData.modules.reduce<RunModuleInfo[]>((acc, module) => {

--- a/protocol-designer/src/labware-defs/types.ts
+++ b/protocol-designer/src/labware-defs/types.ts
@@ -1,6 +1,9 @@
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type {
+  LabwareDef2ByDefURI,
+  LabwareDefinition2,
+} from '@opentrons/shared-data'
 
-export type LabwareDefByDefURI = Record<string, LabwareDefinition2>
+export type LabwareDefByDefURI = LabwareDef2ByDefURI
 export type LabwareUploadMessageType =
   | 'INVALID_JSON_FILE'
   | 'NOT_JSON'

--- a/shared-data/js/helpers/getLabwareDefinitionsByURIForProtocol.ts
+++ b/shared-data/js/helpers/getLabwareDefinitionsByURIForProtocol.ts
@@ -7,11 +7,7 @@ import type {
   LoadLidStackRunTimeCommand,
   RunTimeCommand,
 } from '../../protocol'
-import type { LabwareDefinition } from '../types'
-
-export interface LabwareDefinitionsByURI {
-  [labwareDefURI: string]: LabwareDefinition
-}
+import type { LabwareDefinition, LabwareDefinitionsByURI } from '../types'
 
 const defPair = (
   maybeDef?: LabwareDefinition

--- a/shared-data/js/helpers/getLoadedLabwareDefinitionsByUri.ts
+++ b/shared-data/js/helpers/getLoadedLabwareDefinitionsByUri.ts
@@ -1,7 +1,10 @@
 import { getLabwareDefURI } from '.'
-import { LabwareDefinitionsByURI } from '../types'
 
-import type { LabwareDefinition, RunTimeCommand } from '..'
+import type {
+  LabwareDefinition,
+  LabwareDefinitionsByURI,
+  RunTimeCommand,
+} from '..'
 
 export function getLoadedLabwareDefinitionsByUri(
   commands: RunTimeCommand[]

--- a/shared-data/js/helpers/getLoadedLabwareDefinitionsByUri.ts
+++ b/shared-data/js/helpers/getLoadedLabwareDefinitionsByUri.ts
@@ -1,14 +1,11 @@
 import { getLabwareDefURI } from '.'
+import { LabwareDefinitionsByURI } from '../types'
 
 import type { LabwareDefinition, RunTimeCommand } from '..'
 
-export interface LabwareDefinitionsByUri {
-  [defURI: string]: LabwareDefinition
-}
-
 export function getLoadedLabwareDefinitionsByUri(
   commands: RunTimeCommand[]
-): LabwareDefinitionsByUri {
+): LabwareDefinitionsByURI {
   return commands.reduce((acc, command) => {
     if (
       command.commandType === 'loadLabware' ||

--- a/shared-data/js/types.ts
+++ b/shared-data/js/types.ts
@@ -346,6 +346,9 @@ export interface LabwareDefinition3 {
 // I'm pretty sure nothing in the frontend needs to deal with it anymore.
 export type LabwareDefinition = LabwareDefinition2 | LabwareDefinition3
 
+export interface LabwareDefinitionsByURI {
+  [defURI: string]: LabwareDefinition
+}
 export interface LabwareDef2ByDefURI {
   [defUri: string]: LabwareDefinition2
 }


### PR DESCRIPTION
# Overview

We've ended up with many definitions for the type "labware definitions by URI", including:
- `LabwareDefinitionsByURI` in `getLabwareDefinitionsByURIForProtocol.ts`
- `LabwareDefinitionsByUri` in `getLoadedLabwareDefinitionsByUri.ts`
- `LabwareDefByDefURI` in `protocol-designer`

Due to re-exports, the first 2 are exported at the top level of `@opentrons/shared-data`.

I suspect that when writing code, people just click on whichever pops up first in their IDE autocomplete. They would probably be surprised at which file their import is coming from.

This PR merges the first 2 definitions and moves them to `shared-data/js/types.ts`. The 3rd definition is a PD-specific alias for `LabwareDef2ByDefURI`, and this PR changes it to a proper alias.

(Note that there's also `RunLoadedLabwareDefinitionsByUri`, which I'm not going to touch for now because its name is a less tempting target for autocomplete.)

## Test Plan and Hands on Testing

Run CI.

## Risk assessment

Low.