### PR TITLE
fix(robot-server, api-client, app): Populate filename with server-generated value

### DIFF
--- a/api-client/src/dataFiles/types.ts
+++ b/api-client/src/dataFiles/types.ts
@@ -38,6 +38,7 @@ export interface ImageFilesDataResponse {
 }
 export interface RunDataFileMetadata {
   id: string
+  filename: string
   stored: boolean
   generated: boolean
   mimeType: MimeType

--- a/api-client/src/dataFiles/types.ts
+++ b/api-client/src/dataFiles/types.ts
@@ -17,6 +17,7 @@ export interface CsvFileData {
 
 export interface ImageFileData {
   id: string
+  filename: string
   createdAt: string
   cameraId: string
   commandId?: string

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunCamera/ImageGalleryContainer/GalleryItemCard.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunCamera/ImageGalleryContainer/GalleryItemCard.tsx
@@ -147,11 +147,8 @@ export function GalleryItemCard(props: GalleryItemCardProps): JSX.Element {
         runId={runId}
         currentCommand={currentCommand}
         imagePath={imagePath}
+        imageFilename={item.filename}
         robotName={props.robotName}
-        runTimestamp={props.runTimestamp}
-        commandStep={commandStep}
-        imageTimestamp={item.timestamp}
-        protocolName={props.protocolName}
       />
     </div>
   )

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunCamera/ImageGalleryContainer/GalleryItemOverflowMenu.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunCamera/ImageGalleryContainer/GalleryItemOverflowMenu.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { format } from 'date-fns'
 
 import {
   MenuItem,
@@ -18,22 +17,16 @@ export interface GalleryItemOverflowMenuProps {
   runId: string
   currentCommand: RunTimeCommand | null
   imagePath: string | null
-  commandStep: number | null
-  imageTimestamp: string
-  runTimestamp: string
+  imageFilename: string
   robotName: string
-  protocolName: string
 }
 
 export function GalleryItemOverflowMenu({
   runId,
   currentCommand,
   imagePath,
-  commandStep,
-  imageTimestamp,
-  runTimestamp,
+  imageFilename,
   robotName,
-  protocolName,
 }: GalleryItemOverflowMenuProps): JSX.Element {
   const { t } = useTranslation('run_details')
 
@@ -50,7 +43,7 @@ export function GalleryItemOverflowMenu({
   const onDownloadImage = (): void => {
     setShowOverflowMenu(false)
     const a = document.createElement('a')
-    a.download = buildFileName()
+    a.download = imageFilename
     a.href = imagePath ?? ''
     a.click()
 
@@ -61,12 +54,6 @@ export function GalleryItemOverflowMenu({
     setShowOverflowMenu(false)
     setShowErrorModal(!showErrorModal)
   }
-
-  const formattedRunTs = format(new Date(runTimestamp), 'M/d/yy_HH:mm:ss')
-  const formattedImgTs = format(new Date(imageTimestamp), 'M/d/yy_HH:mm:ss')
-
-  const buildFileName = (): string =>
-    `${robotName}_${protocolName}_${formattedRunTs}_${commandStep}_${formattedImgTs}.jpeg`
 
   return (
     <div className={styles.overflow_container}>

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunCamera/ImageGalleryContainer/__tests__/GalleryItemCard.test.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunCamera/ImageGalleryContainer/__tests__/GalleryItemCard.test.tsx
@@ -38,6 +38,7 @@ const MOCK_IMAGE_ITEM = {
   stepCommandId: 'step1',
   previousStepCommandId: 'step2',
   timestamp: '2024-01-01 12:00:00',
+  filename: 'test-filename',
 }
 const MOCK_RUN_ID = 'run123'
 describe('GalleryItemCard', () => {

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunCamera/ImageGalleryContainer/__tests__/ImageGalleryContainer.test.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunCamera/ImageGalleryContainer/__tests__/ImageGalleryContainer.test.tsx
@@ -39,18 +39,21 @@ const mockImagesInfo: UseImagesInfoItem[] = [
     stepCommandId: 'Step 1 command',
     previousStepCommandId: 'Previous step 1',
     timestamp: '2024-01-01 10:00:00',
+    filename: 'filename-1',
   },
   {
     imageId: '/path/to/image2.jpg',
     stepCommandId: 'Step 2 command',
     previousStepCommandId: 'Previous step 2',
     timestamp: '2024-01-01 11:00:00',
+    filename: 'filename-2',
   },
   {
     imageId: '/path/to/image3.jpg',
     stepCommandId: 'Step 3 command',
     previousStepCommandId: 'Previous step 3',
     timestamp: '2024-01-01 12:00:00',
+    filename: 'filename-3',
   },
 ]
 

--- a/app/src/organisms/ODD/RunningProtocol/ImageGalleryList/GalleryListItem.tsx
+++ b/app/src/organisms/ODD/RunningProtocol/ImageGalleryList/GalleryListItem.tsx
@@ -11,32 +11,29 @@ import { useImage } from '/app/resources/dataFiles/useImage'
 
 import styles from './gallery.module.css'
 
+import type {
+  CompletedProtocolAnalysis,
+  LabwareDefinition,
+  RobotType,
+} from '@opentrons/shared-data'
 import type { UseImagesInfoItem } from '/app/resources/dataFiles/useImageInfo'
 
-export interface GalleryListItemProps extends UseImagesInfoItem {
-  protocolAnalysis: any
+export interface GalleryListItemProps {
+  protocolAnalysis: CompletedProtocolAnalysis | null
   runId: string
-  robotType: any
-  allRunDefs: any
+  robotType: RobotType
+  allRunDefs: LabwareDefinition[]
+  item: UseImagesInfoItem
 }
 
 export function GalleryListItem(props: GalleryListItemProps): JSX.Element {
   const { t } = useTranslation('run_details')
-  const {
-    timestamp,
-    imageId,
-    stepCommandId,
-    previousStepCommandId,
-    runId,
-    protocolAnalysis,
-    robotType,
-    allRunDefs,
-  } = props
+  const { item, runId, protocolAnalysis, robotType, allRunDefs } = props
 
-  const imagePath = useImage(imageId)
+  const imagePath = useImage(item.imageId)
   const { previousCommandString, isLoading, currentCommand } =
     useImageGalleryData({
-      item: { imageId, stepCommandId, previousStepCommandId, timestamp },
+      item,
       protocolAnalysis,
       runId,
       robotType,
@@ -65,7 +62,9 @@ export function GalleryListItem(props: GalleryListItemProps): JSX.Element {
       <div className={styles.list_item_container}>
         <div className={styles.list_item_content_container}>
           <div>
-            <StyledText oddStyle="bodyTextSemiBold">{timestamp}</StyledText>
+            <StyledText oddStyle="bodyTextSemiBold">
+              {item.timestamp}
+            </StyledText>
           </div>
           <div className={styles.list_item_step}>
             {!isSkeleton && isCurrentCmdError && (
@@ -102,7 +101,7 @@ export function GalleryListItem(props: GalleryListItemProps): JSX.Element {
               onClick={() => {
                 handleCameraPhotoModal({
                   imagePath,
-                  timestamp,
+                  timestamp: item.timestamp,
                   stepCountStr: modalStepCountStr,
                 })
               }}

--- a/app/src/organisms/ODD/RunningProtocol/ImageGalleryList/__tests__/GalleryListItem.test.tsx
+++ b/app/src/organisms/ODD/RunningProtocol/ImageGalleryList/__tests__/GalleryListItem.test.tsx
@@ -2,6 +2,8 @@ import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { FLEX_ROBOT_TYPE } from '@opentrons/shared-data'
+
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
 import { useImageGalleryData } from '/app/local-resources/images/hooks/useImageGalleryData'
@@ -10,7 +12,8 @@ import { useImage } from '/app/resources/dataFiles/useImage'
 
 import { GalleryListItem } from '../GalleryListItem'
 
-// Mock the modal handler
+import type { GalleryListItemProps } from '../GalleryListItem'
+
 vi.mock(
   '/app/organisms/ODD/RunningProtocol/ImageGalleryList/CameraPhotoModal',
   () => ({
@@ -30,15 +33,18 @@ const mockProtocolAnalysis = {
   labware: [],
 } as any
 
-const mockProps = {
-  imageId: 'imageId',
-  stepCommandId: 'commandId',
-  previousStepCommandId: 'previouscommandId',
-  timestamp: MOCK_TIMESTAMP,
+const mockProps: GalleryListItemProps = {
   runId: 'run123',
   protocolAnalysis: mockProtocolAnalysis,
-  robotType: 'OT3-Standard',
+  robotType: FLEX_ROBOT_TYPE,
   allRunDefs: [],
+  item: {
+    imageId: 'imageId',
+    stepCommandId: 'commandId',
+    previousStepCommandId: 'previouscommandId',
+    timestamp: MOCK_TIMESTAMP,
+    filename: 'test-filename',
+  },
 }
 
 const render = (props = mockProps) =>

--- a/app/src/organisms/ODD/RunningProtocol/ImageGalleryList/__tests__/ImageGalleryList.test.tsx
+++ b/app/src/organisms/ODD/RunningProtocol/ImageGalleryList/__tests__/ImageGalleryList.test.tsx
@@ -38,12 +38,14 @@ const mockImagesInfo = {
       stepCommandId: 'commandId1',
       previousStepCommandId: 'previouscommandId1',
       timestamp: '2024-01-01 10:00:00',
+      filename: 'test-name',
     },
     {
       imageId: 'imageId2',
       stepCommandId: 'commandId2',
       previousStepCommandId: 'previouscommandId2',
       timestamp: '2024-01-01 11:00:00',
+      filename: 'test-name-2',
     },
   ],
   protocolAnalysis: mockProtocolAnalysis,
@@ -67,8 +69,8 @@ describe('ImageGalleryList', () => {
     }
 
     vi.mocked(useImageInfo).mockReturnValue(mockImagesInfo)
-    vi.mocked(GalleryListItem).mockImplementation(({ timestamp }) => (
-      <div>MOCK_GALLERY_LIST_ITEM_{timestamp}</div>
+    vi.mocked(GalleryListItem).mockImplementation(({ item }) => (
+      <div>MOCK_GALLERY_LIST_ITEM_{item.timestamp}</div>
     ))
     vi.mocked(ProtocolPlayPauseHeader).mockImplementation(() => (
       <div>MOCK_PROTOCOL_PLAY_PAUSE_HEADER</div>

--- a/app/src/organisms/ODD/RunningProtocol/ImageGalleryList/index.tsx
+++ b/app/src/organisms/ODD/RunningProtocol/ImageGalleryList/index.tsx
@@ -96,7 +96,7 @@ function GalleryListContent({
       {imagesInfo.map(item => (
         <GalleryListItem
           key={item.timestamp}
-          {...item}
+          item={item}
           protocolAnalysis={protocolAnalysis}
           runId={runId}
           robotType={robotType}

--- a/app/src/resources/dataFiles/useImageInfo.ts
+++ b/app/src/resources/dataFiles/useImageInfo.ts
@@ -17,6 +17,7 @@ const IMAGE_METADATA_POLL_MS = 5000
 
 export interface UseImagesInfoItem {
   imageId: string
+  filename: string
   stepCommandId: string
   previousStepCommandId: string
   timestamp: string
@@ -50,6 +51,7 @@ export function useImageInfo(runId: string): UseImagesInfoResult {
     if (data == null) return []
     return data.data.map(img => ({
       imageId: img.id,
+      filename: img.filename,
       stepCommandId: img.commandId ?? '',
       previousStepCommandId: img.prevCommandId ?? '',
       timestamp: format(new Date(String(img.createdAt)), 'M/d/yy HH:mm:ss'),

--- a/robot-server/robot_server/data_files/models.py
+++ b/robot-server/robot_server/data_files/models.py
@@ -113,6 +113,7 @@ class DataFileMetadataResponse(BaseModel):
     """Response model for data file metadata without command information."""
 
     id: str = Field(..., description="A unique identifier for this file.")
+    filename: str = Field(..., description="The name of the data file.")
     stored: bool = Field(..., description="Whether the file is currently stored.")
     generated: bool = Field(
         ..., description="Whether the file was generated as output during a run."

--- a/robot-server/robot_server/data_files/models.py
+++ b/robot-server/robot_server/data_files/models.py
@@ -92,6 +92,7 @@ class ImageFileMetadata(BaseModel):
         description="The id of the camera image file."
         " This id is identical to the filename of the camera image file.",
     )
+    filename: str = Field(..., description="The name of the data file.")
     cameraId: str = Field(
         ..., description="The ID of the camera used to capture the image file."
     )

--- a/robot-server/robot_server/data_files/router.py
+++ b/robot-server/robot_server/data_files/router.py
@@ -481,6 +481,7 @@ async def get_run_image_metadata(
     data = [
         ImageFileMetadata.model_construct(
             id=file.id,
+            filename=file.name,
             cameraId=DEFAULT_CAMERA_ID,
             commandId=file.command_info.command_id,
             prevCommandId=file.command_info.prev_command_id,

--- a/robot-server/robot_server/data_files/router.py
+++ b/robot-server/robot_server/data_files/router.py
@@ -393,6 +393,7 @@ async def get_data_files_by_run_id(
         response_data.append(
             DataFileMetadataResponse(
                 id=file_info.id,
+                filename=file_info.name,
                 stored=file_info.stored,
                 generated=file_info.generated,
                 mimeType=file_info.mime_type,
@@ -403,6 +404,7 @@ async def get_data_files_by_run_id(
         response_data.append(
             DataFileMetadataResponse(
                 id=file_info.id,
+                filename=file_info.name,
                 stored=file_info.stored,
                 generated=file_info.generated,
                 mimeType=file_info.mime_type,

--- a/robot-server/tests/data_files/test_router.py
+++ b/robot-server/tests/data_files/test_router.py
@@ -940,6 +940,7 @@ async def test_get_data_files_by_run_id(
 
         for response_file, expected_file in zip(result.content.data, all_files):
             assert response_file.id == expected_file.id
+            assert response_file.filename == expected_file.name
             assert response_file.stored == expected_file.stored
             assert response_file.generated == expected_file.generated
             assert response_file.mimeType == expected_file.mime_type


### PR DESCRIPTION
Closes [RQA-4813](https://opentrons.atlassian.net/browse/RQA-4813)

# Overview

In the desktop app's image gallery, there is an overflow menu that enables users to download a single image. Clicking that option renders an OS download dialogue and populates the filename with an app-generated filename, which follows a Design-specified naming convention.

However, generating the filename on the app fails to capture the PAPI `image_capture` command's ability to specify a prefix to the naming convention via the `filename` param. The filename exists in its entirety on the server in the data files table, so let's just bubble that filename up through a few data file metadata endpoints instead of requiring the app to attempt to reflect the behavior of the server. 

<img width="1019" height="763" alt="Screenshot 2025-11-04 at 8 04 40 AM" src="https://github.com/user-attachments/assets/33a7ecd3-b6de-4a3f-b639-56e8de7e7a32" />


## Test Plan and Hands on Testing
- See image.


## Changelog
- Downloading an individual file on the desktop app properly includes the PAPI `image_capture` `filename` param if supplied.


## Risk assessment
low

[RQA-4813]: https://opentrons.atlassian.net/browse/RQA-4813?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ