### PR TITLE
fix(api): `SetShakeSpeed` should set heatershaker state `is_plate_shaking` to true

### DIFF
--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -267,6 +267,7 @@ class ModuleStore(HasState[ModuleState], HandlesActions):
                 heater_shaker.SetTargetTemperatureResult,
                 heater_shaker.DeactivateHeaterResult,
                 heater_shaker.SetAndWaitForShakeSpeedResult,
+                heater_shaker.SetShakeSpeedResult,
                 heater_shaker.DeactivateShakerResult,
                 heater_shaker.OpenLabwareLatchResult,
                 heater_shaker.CloseLabwareLatchResult,
@@ -430,6 +431,7 @@ class ModuleStore(HasState[ModuleState], HandlesActions):
             heater_shaker.SetTargetTemperature,
             heater_shaker.DeactivateHeater,
             heater_shaker.SetAndWaitForShakeSpeed,
+            heater_shaker.SetShakeSpeed,
             heater_shaker.DeactivateShaker,
             heater_shaker.OpenLabwareLatch,
             heater_shaker.CloseLabwareLatch,
@@ -459,6 +461,13 @@ class ModuleStore(HasState[ModuleState], HandlesActions):
                 plate_target_temperature=None,
             )
         elif isinstance(command.result, heater_shaker.SetAndWaitForShakeSpeedResult):
+            self._state.substate_by_module_id[module_id] = HeaterShakerModuleSubState(
+                module_id=HeaterShakerModuleId(module_id),
+                labware_latch_status=prev_state.labware_latch_status,
+                is_plate_shaking=True,
+                plate_target_temperature=prev_state.plate_target_temperature,
+            )
+        elif isinstance(command.result, heater_shaker.SetShakeSpeedResult):
             self._state.substate_by_module_id[module_id] = HeaterShakerModuleSubState(
                 module_id=HeaterShakerModuleId(module_id),
                 labware_latch_status=prev_state.labware_latch_status,

--- a/api/tests/opentrons/protocol_engine/state/test_module_store_old.py
+++ b/api/tests/opentrons/protocol_engine/state/test_module_store_old.py
@@ -486,10 +486,15 @@ def test_handle_hs_shake_commands(heater_shaker_v1_def: ModuleDefinition) -> Non
         params=hs_commands.SetAndWaitForShakeSpeedParams(moduleId="module-id", rpm=111),
         result=hs_commands.SetAndWaitForShakeSpeedResult(pipetteRetracted=False),
     )
+    start_set_shake_cmd = hs_commands.SetShakeSpeed.model_construct(  # type: ignore[call-arg]
+        params=hs_commands.SetShakeSpeedParams(moduleId="module-id", rpm=111),
+        result=hs_commands.SetShakeSpeedResult(pipetteRetracted=False, taskId="taskId"),
+    )
     deactivate_cmd = hs_commands.DeactivateShaker.model_construct(  # type: ignore[call-arg]
         params=hs_commands.DeactivateShakerParams(moduleId="module-id"),
         result=hs_commands.DeactivateShakerResult(),
     )
+
     subject = ModuleStore(
         config=_OT2_STANDARD_CONFIG,
         deck_fixed_labware=[],
@@ -508,6 +513,15 @@ def test_handle_hs_shake_commands(heater_shaker_v1_def: ModuleDefinition) -> Non
         )
     )
     subject.handle_action(actions.SucceedCommandAction(command=set_shake_cmd))
+    assert subject.state.substate_by_module_id == {
+        "module-id": HeaterShakerModuleSubState(
+            module_id=HeaterShakerModuleId("module-id"),
+            labware_latch_status=HeaterShakerLatchStatus.UNKNOWN,
+            is_plate_shaking=True,
+            plate_target_temperature=None,
+        )
+    }
+    subject.handle_action(actions.SucceedCommandAction(command=start_set_shake_cmd))
     assert subject.state.substate_by_module_id == {
         "module-id": HeaterShakerModuleSubState(
             module_id=HeaterShakerModuleId("module-id"),


### PR DESCRIPTION
# Overview

Adds `SetShakeSpeed` to heatershaker state updates

Protocol analysis will now raise an error if you use `set_shake_speed` and then try to open the labware latch without deactivating the shaker first.

## Test Plan and Hands on Testing

Simulated the protocol attached in the ticket, and error was raised
`ProtocolCommandFailedError [line 491]: Error 4000 GENERAL_ERROR (ProtocolCommandFailedError): CannotPerformModuleAction: Heater-Shaker cannot open its labware latch while it is shaking.`
<img width="921" height="488" alt="Screenshot 2025-11-04 at 12 20 44 PM" src="https://github.com/user-attachments/assets/0898ca36-b09d-4b0b-b239-f5e43659e917" />

## Risk assessment

low

Closes RQA-4814
