### PR TITLE
fix(step-generation): fix substep whitescreen bug

### DIFF
--- a/step-generation/src/commandCreators/compound/consolidate.ts
+++ b/step-generation/src/commandCreators/compound/consolidate.ts
@@ -721,6 +721,7 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
                           correctionVolume: dispenseCorrectionVolumeForDispenseAirGap,
                         }
                       : {}),
+                    isAirGap: true,
                     pushOut: 0,
                   }),
                   ...delayAfterDispenseCommands,
@@ -934,6 +935,7 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
                 flowRate: aspirateAirGapDispenseFlowRate,
                 pushOut: 0,
                 correctionVolume: dispenseCorrectionVolumeForAspirateAirGap,
+                isAirGap: true,
               }),
               ...delayAfterDispenseCommands,
             ]


### PR DESCRIPTION
# Overview

Ensure air gap aspirate and dispense in place commands in consolidate command creator include `{ isAirGap: true }` for proper omission in substep generation.

Closes RQA-4791

## Test Plan and Hands on Testing

- import protocol attached to ticket
- view substeps for step 5
- hover over all steps and verify that no whitescreen occurs, and wells highlight correctly

## Changelog

- pass `isAirGap` properly in `consolidate` command creator

## Review requests

see test plan

## Risk assessment

low