### PR TITLE
fix(protocol-designer): hydrate Form.tipRack to support custom tipracks

### DIFF
--- a/protocol-designer/src/form-types.ts
+++ b/protocol-designer/src/form-types.ts
@@ -8,6 +8,7 @@ import type {
   ChangeTipOptions,
   LabwareEntity,
   PipetteEntity,
+  TipRackWithDef,
   TrashBinEntity,
   WasteChuteEntity,
 } from '@opentrons/step-generation'
@@ -280,8 +281,9 @@ export interface HydratedMoveLiquidFormData extends AnnotationFields {
   liquidClassesSupported: boolean
   nozzles: NozzleConfigurationStyle | null
   path: PathOption
+  // the existing code claims that pipette and tipRack are not nullable, but they are:
   pipette: PipetteEntity
-  tipRack: string
+  tipRack: TipRackWithDef
   volume: number
   pushOut_volume: number | null
   pushOut_checkbox: boolean
@@ -375,7 +377,7 @@ export interface HydratedMixFormData extends AnnotationFields {
   nozzles: NozzleConfigurationStyle | null
   pipette: PipetteEntity // can be null if user deletes pipette
   stepType: 'mix'
-  tipRack: string
+  tipRack: TipRackWithDef
   volume: number
   wells: string[]
   aspirate_delay_seconds?: number | null

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/index.tsx
@@ -11,6 +11,7 @@ import {
   ConfirmDeleteModal,
   DELETE_STEP_FORM,
 } from '/protocol-designer/components/organisms'
+import { selectors as labwareDefSelectors } from '/protocol-designer/labware-defs'
 import {
   getHydratedForm,
   selectors as stepFormSelectors,
@@ -29,6 +30,7 @@ import type {
   StepFieldName,
   StepIdType,
 } from '/protocol-designer/form-types'
+import type { LabwareDefByDefURI } from '/protocol-designer/labware-defs'
 import type { BaseState, ThunkDispatch } from '/protocol-designer/types'
 
 interface StateProps {
@@ -38,6 +40,7 @@ interface StateProps {
   isPristineSetTempForm: boolean
   isPristineSetHeaterShakerTempForm: boolean
   invariantContext: InvariantContext
+  allLabwareDefs: LabwareDefByDefURI
   formData?: FormData | null
 }
 interface DispatchProps {
@@ -63,6 +66,7 @@ function StepFormManager(props: StepFormManagerProps): JSX.Element | null {
     saveHeaterShakerFormWithAddedPauseUntilTemp,
     saveStepForm,
     invariantContext,
+    allLabwareDefs,
   } = props
   const [focusedField, setFocusedField] = useState<string | null>(null)
   const [dirtyFields, setDirtyFields] = useState<StepFieldName[]>(
@@ -117,7 +121,11 @@ function StepFormManager(props: StepFormManagerProps): JSX.Element | null {
   if (formData == null) {
     return null
   }
-  const hydratedForm = getHydratedForm(formData, invariantContext)
+  const hydratedForm = getHydratedForm(
+    formData,
+    invariantContext,
+    allLabwareDefs
+  )
   const focusHandlers = {
     focusedField,
     dirtyFields,
@@ -200,6 +208,7 @@ const mapStateToProps = (state: BaseState): StateProps => {
       state
     ),
     invariantContext: getInvariantContext(state),
+    allLabwareDefs: labwareDefSelectors.getLabwareDefsByURI(state),
   }
 }
 

--- a/protocol-designer/src/step-forms/selectors/index.ts
+++ b/protocol-designer/src/step-forms/selectors/index.ts
@@ -699,11 +699,14 @@ export const getHydratedUnsavedForm: Selector<
 > = createSelector(
   getUnsavedForm,
   getInvariantContext,
-  (unsavedForm, invariantContext) => {
+  labwareDefSelectors.getLabwareDefsByURI,
+  (unsavedForm, invariantContext, allLabwareDefs) => {
     if (unsavedForm == null) return null
-
-    const hydratedForm = getHydratedForm(unsavedForm, invariantContext)
-
+    const hydratedForm = getHydratedForm(
+      unsavedForm,
+      invariantContext,
+      allLabwareDefs
+    )
     return hydratedForm ?? null
   }
 )
@@ -759,12 +762,16 @@ export const getArgsAndErrorsByStepId: Selector<
 > = createSelector(
   getOrderedSavedForms,
   getInvariantContext,
-  (stepForms, contextualState) => {
+  labwareDefSelectors.getLabwareDefsByURI,
+  (stepForms, contextualState, allLabwareDefs) => {
     return reduce(
       stepForms,
       (acc, stepForm, index) => {
-        const hydratedForm = getHydratedForm(stepForm, contextualState)
-
+        const hydratedForm = getHydratedForm(
+          stepForm,
+          contextualState,
+          allLabwareDefs
+        )
         const errors = _formHasErrors(hydratedForm, contextualState)
         const nextStepData = !errors
           ? {
@@ -817,11 +824,14 @@ export const getFormLevelWarningsForUnsavedForm: Selector<
 > = createSelector(
   getUnsavedForm,
   getInvariantContext,
-  (unsavedForm, contextualState) => {
+  labwareDefSelectors.getLabwareDefsByURI,
+  (unsavedForm, contextualState, allLabwareDefs) => {
     if (!unsavedForm) return []
-
-    const hydratedForm = getHydratedForm(unsavedForm, contextualState)
-
+    const hydratedForm = getHydratedForm(
+      unsavedForm,
+      contextualState,
+      allLabwareDefs
+    )
     return getFormWarnings(unsavedForm.stepType, hydratedForm)
   }
 )
@@ -831,12 +841,15 @@ export const getFormLevelWarningsPerStep: Selector<
 > = createSelector(
   getSavedStepForms,
   getInvariantContext,
-  (forms, contextualState) =>
+  labwareDefSelectors.getLabwareDefsByURI,
+  (forms, contextualState, allLabwareDefs) =>
     mapValues(forms, (form, stepId) => {
       if (!form) return []
-
-      const hydratedForm = getHydratedForm(form, contextualState)
-
+      const hydratedForm = getHydratedForm(
+        form,
+        contextualState,
+        allLabwareDefs
+      )
       return getFormWarnings(form.stepType, hydratedForm)
     })
 )

--- a/protocol-designer/src/step-forms/utils/index.ts
+++ b/protocol-designer/src/step-forms/utils/index.ts
@@ -234,10 +234,11 @@ export const getIsModuleOnDeck = (
 
 export function getHydratedForm(
   rawForm: FormData,
-  invariantContext: InvariantContext
+  invariantContext: InvariantContext,
+  allLabwareDefs: LabwareDefByDefURI
 ): HydratedFormData {
   const hydratedForm = mapValues(rawForm, (value, name) =>
-    hydrateField(invariantContext, name, value as string)
+    hydrateField(invariantContext, name, value as string, allLabwareDefs)
   )
   //  @ts-expect-error because hydrateField doesn't hydrate every formField type
   //  need to udpate to hdyrate every field, will do this in a followup

--- a/protocol-designer/src/steplist/fieldLevel/index.ts
+++ b/protocol-designer/src/steplist/fieldLevel/index.ts
@@ -22,6 +22,7 @@ import type {
   LabwareEntities,
   PipetteEntity,
   StagingAreaEntities,
+  TipRackWithDef,
   TrashBinEntities,
   WasteChuteEntities,
 } from '@opentrons/step-generation'
@@ -29,6 +30,7 @@ import type {
   LabwareOrAdditionalEquipmentEntity,
   StepFieldName,
 } from '../../form-types'
+import type { LabwareDefByDefURI } from '../../labware-defs'
 import type { ValueCaster, ValueMasker } from './processing'
 
 export type { StepFieldName }
@@ -155,10 +157,22 @@ const getPipetteEntity = (
   return state.pipetteEntities[id] || null
 }
 
+const getTipRackDefinition = (
+  state: InvariantContext,
+  tiprackDefURI: string,
+  allLabwareDefs: LabwareDefByDefURI
+): TipRackWithDef => {
+  return { tiprackDefURI: tiprackDefURI, ...allLabwareDefs[tiprackDefURI] }
+}
+
 interface StepFieldHelpers {
   maskValue?: ValueMasker
   castValue?: ValueCaster
-  hydrate?: (state: InvariantContext, id: string) => unknown
+  hydrate?: (
+    state: InvariantContext,
+    id: string,
+    allLabwareDefs: LabwareDefByDefURI
+  ) => unknown
 }
 const stepFieldHelperMap: Record<StepFieldName, StepFieldHelpers> = {
   aspirate_airGap_volume: {
@@ -287,6 +301,7 @@ const stepFieldHelperMap: Record<StepFieldName, StepFieldHelpers> = {
   pipette: {
     hydrate: getPipetteEntity,
   },
+  tipRack: { hydrate: getTipRackDefinition },
   times: {
     maskValue: composeMaskers(maskToInteger, onlyPositiveNumbers, defaultTo(0)),
     castValue: Number,
@@ -430,8 +445,9 @@ export const maskField = (name: StepFieldName, value: unknown): unknown => {
 export const hydrateField = (
   state: InvariantContext,
   name: StepFieldName,
-  value: string
+  value: string,
+  allLabwareDefs: LabwareDefByDefURI
 ): unknown => {
   const hydrator = stepFieldHelperMap[name] && stepFieldHelperMap[name].hydrate
-  return hydrator ? hydrator(state, value) : value
+  return hydrator ? hydrator(state, value, allLabwareDefs) : value
 }

--- a/protocol-designer/src/steplist/formLevel/errors.ts
+++ b/protocol-designer/src/steplist/formLevel/errors.ts
@@ -768,7 +768,8 @@ export const volumeTooHigh = (
   }
   const volume = Number(fields.volume)
 
-  const pipetteCapacity = getPipetteCapacity(pipette, tipRack)
+  // TODO: change getPipetteCapacity() to use tipRack definition directly
+  const pipetteCapacity = getPipetteCapacity(pipette, tipRack?.tiprackDefURI)
   if (
     !Number.isNaN(volume) &&
     !Number.isNaN(pipetteCapacity) &&
@@ -1424,7 +1425,8 @@ export const conditioningVolumeOutOfRange = (
       disposalVolume_checkbox === true ? Number(disposalVolume_volume) : 0,
     pipetteSpecs: pipette.spec,
     labwareEntities: labwareEntities ?? {},
-    tiprackDefUri: tipRack,
+    tiprackDefUri: tipRack?.tiprackDefURI,
+    // TODO: change getMaxConditioningVolume() to use the tipRack definition directly
   })
   return conditioning_checkbox && conditioning_volume > maxConditioningVolume
     ? CONDITIONING_VOLUME_OUT_OF_RANGE

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/mixFormToArgs.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/mixFormToArgs.ts
@@ -39,7 +39,8 @@ export const mixFormToArgs = (
   const matchingTipLiquidSpecs = getMatchingTipLiquidSpecs(
     pipette,
     hydratedFormData.volume,
-    hydratedFormData.tipRack
+    // TODO: change getMatchingTipLiquidSpecs() to use tipRack definition directly
+    hydratedFormData.tipRack?.tiprackDefURI
   )
   const unorderedWells = hydratedFormData.wells || []
   const orderedWells = getOrderedWells(
@@ -110,7 +111,7 @@ export const mixFormToArgs = (
     offsetFromBottomMm,
     blowoutOffsetFromTopMm,
     aspirateDelaySeconds,
-    tipRack: hydratedFormData.tipRack,
+    tipRack: hydratedFormData.tipRack?.tiprackDefURI,
     dispenseDelaySeconds,
     //  TODO(jr, 7/26/24): wire up wellNames
     dropTipLocation: dropTip_location,

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/moveLiquidFormToArgs.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/moveLiquidFormToArgs.ts
@@ -76,15 +76,11 @@ const getCheckedPath = (
 ): PathOption => {
   const { pipette, tipRack, volume } = hydratedFormData
   const { spec: pipetteSpecs } = pipette
-  const tiprackEntity = Object.values(contextualState.labwareEntities).find(
-    lw => lw.labwareDefURI === tipRack
-  )
   // should not hit
-  if (tiprackEntity == null) {
-    console.error('Tiprack for transfer has no associated labware entity.')
+  if (tipRack == null) {
+    console.error('Transfer has no associated tipRack.')
     return path
   }
-  const { labwareDefURI: tiprackDefUri, def: tiprackDef } = tiprackEntity
   const allLiquidClassDefs = getAllLiquidClassDefs()
   const liquidClassValuesForTip = allLiquidClassDefs[
     hydratedFormData.liquidClass === NONE_LIQUID_CLASS_NAME ||
@@ -95,7 +91,7 @@ const getCheckedPath = (
     .find(
       ({ pipetteModel }) => (pipetteModel = getFlexNameConversion(pipetteSpecs))
     )
-    ?.byTipType.find(({ tiprack }) => tiprack === tiprackDefUri)
+    ?.byTipType.find(({ tiprack }) => tiprack === tipRack?.tiprackDefURI)
 
   // be permissive with path if no liquid class tip values found
   if (liquidClassValuesForTip == null) {
@@ -114,7 +110,7 @@ const getCheckedPath = (
     path === 'multiAspirate'
       ? getTransferPlanAndReferenceVolumes({
           pipetteSpecs,
-          tiprackDefinition: tiprackDef,
+          tiprackDefinition: tipRack,
           volume,
           path,
           numAspirateWells: hydratedFormData.aspirate_wells.length,
@@ -126,7 +122,7 @@ const getCheckedPath = (
         })
       : getTransferPlanAndReferenceVolumes({
           pipetteSpecs,
-          tiprackDefinition: tiprackDef,
+          tiprackDefinition: tipRack,
           volume,
           path,
           numAspirateWells: hydratedFormData.aspirate_wells.length,
@@ -300,7 +296,8 @@ export const moveLiquidFormToArgs = (
   const matchingTipLiquidSpecs = getMatchingTipLiquidSpecs(
     hydratedFormData.pipette,
     hydratedFormData.volume,
-    tipRack
+    tipRack?.tiprackDefURI
+    // TODO: change getMatchingTipLiquidSpecs() to use the tipRack definition directly
   )
   const conditioningVolume =
     hydratedFormData.conditioning_checkbox === true &&
@@ -314,7 +311,7 @@ export const moveLiquidFormToArgs = (
     volume,
     sourceLabware: sourceLabware.id,
     destLabware: destLabware.id,
-    tipRack: tipRack,
+    tipRack: tipRack?.tiprackDefURI,
     aspirateFlowRateUlSec:
       hydratedFormData.aspirate_flowRate ||
       matchingTipLiquidSpecs.defaultAspirateFlowRate.default,

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/mixFormToArgs.test.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/mixFormToArgs.test.ts
@@ -23,6 +23,16 @@ const labwareType = getLabwareDefURI(labwareDef)
 beforeEach(() => {
   vi.mocked(getOrderedWells).mockImplementation(wells => wells)
 
+  const tiprackLabwareDef = {
+    parameters: {
+      tipLength: 10,
+      loadName: 'mockTiprack',
+    },
+    metadata: {
+      displayName: 'mock display name',
+    },
+  } as LabwareDefinition2
+
   hydratedForm = {
     id: 'stepId',
     stepType: 'mix',
@@ -40,21 +50,11 @@ beforeEach(() => {
     blowout_checkbox: false,
     blowout_location: null,
     mix_mmFromBottom: 0.5,
-    tipRack: 'mockTiprack',
+    tipRack: { tiprackDefURI: 'mockTiprack', ...tiprackLabwareDef },
     pipette: {
       id: 'pipetteId',
       spec: fixtureP10SingleV2Specs,
-      tiprackLabwareDef: [
-        {
-          parameters: {
-            tipLength: 10,
-            loadName: 'mockTiprack',
-          },
-          metadata: {
-            displayName: 'mock display name',
-          },
-        },
-      ] as any,
+      tiprackLabwareDef: [tiprackLabwareDef] as any,
     } as any,
     // @ts-expect-error(sa, 2021-6-15): volume should be a number
     volume: '12',

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/moveLiquidFormToArgs.test.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/moveLiquidFormToArgs.test.ts
@@ -39,6 +39,15 @@ describe('move liquid step form -> command creator args', () => {
   const sourceLabwareType = getLabwareDefURI(sourceLabwareDef)
   const destLabwareDef = fixture_96_plate as LabwareDefinition2
   const destLabwareType = getLabwareDefURI(destLabwareDef)
+  const tiprackLabwareDef = {
+    parameters: {
+      tipLength: 10,
+      loadName: 'mockTiprack',
+    },
+    metadata: {
+      displayName: 'mock display name',
+    },
+  } as LabwareDefinition2
   beforeEach(() => {
     vi.mocked(getOrderedWells).mockClear()
     vi.mocked(getOrderedWells).mockImplementation(wells => wells)
@@ -51,17 +60,7 @@ describe('move liquid step form -> command creator args', () => {
       pipette: {
         id: 'pipetteId',
         spec: fixtureP10SingleV2Specs,
-        tiprackLabwareDef: [
-          {
-            parameters: {
-              tipLength: 10,
-              loadName: 'mockTiprack',
-            },
-            metadata: {
-              displayName: 'mock display name',
-            },
-          },
-        ] as any,
+        tiprackLabwareDef: [tiprackLabwareDef] as any,
       } as any,
       volume: 10,
       path: 'single',
@@ -72,7 +71,7 @@ describe('move liquid step form -> command creator args', () => {
         type: sourceLabwareType,
         def: sourceLabwareDef,
       },
-      tipRack: 'tiprack1Id',
+      tipRack: { tiprackDefURI: 'tiprack1Id', ...tiprackLabwareDef } as any,
       aspirate_wells: [ASPIRATE_WELL],
       aspirate_wellOrder_first: 'l2r',
       aspirate_wellOrder_second: 't2b',

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/stepFormToArgs.test.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/stepFormToArgs.test.ts
@@ -4,7 +4,11 @@ import { POSITION_REFERENCE_BOTTOM } from '@opentrons/shared-data'
 
 import { _castForm } from '../index'
 
-import type { LabwareEntity, PipetteEntity } from '@opentrons/step-generation'
+import type {
+  LabwareEntity,
+  PipetteEntity,
+  TipRackWithDef,
+} from '@opentrons/step-generation'
 import type {
   HydratedMagnetFormData,
   HydratedMixFormData,
@@ -62,7 +66,7 @@ describe('form casting', () => {
       dispense_airGap_checkbox: false,
       dropTip_location: 'some location',
       nozzles: null,
-      tipRack: 'some tiprack',
+      tipRack: { tiprackDefURI: 'some tiprack' } as TipRackWithDef,
       liquidClassesSupported: true,
       aspirate_retract_position_reference: POSITION_REFERENCE_BOTTOM,
       aspirate_submerge_mmFromBottom: 1,
@@ -115,7 +119,7 @@ describe('form casting', () => {
       dropTip_location: 'some location',
       mix_touchTip_checkbox: false,
       nozzles: null,
-      tipRack: 'some tiprack',
+      tipRack: { tiprackDefURI: 'some tiprack' } as TipRackWithDef,
       liquidClassesSupported: true,
       pushOut_checkbox: false,
       pushOut_volume: null,

--- a/protocol-designer/src/steplist/formLevel/test/warnings.test.ts
+++ b/protocol-designer/src/steplist/formLevel/test/warnings.test.ts
@@ -185,7 +185,9 @@ describe('liquid class compatibility', () => {
       pipette: {
         spec: { channels: 1, liquids: { default: { maxVolume: 1000 } } },
       },
-      tipRack: 'opentrons/opentrons_flex_96_tiprack_1000ul/1',
+      tipRack: {
+        tiprackDefURI: 'opentrons/opentrons_flex_96_tiprack_1000ul/1',
+      },
       liquidClass: 'glycerol_50',
       path: 'singleDispense',
     }
@@ -234,7 +236,7 @@ describe('liquid class compatibility', () => {
   it('should return liquid classes incompatible with the pipette warning if tiprack incompatible with all liquid classes', () => {
     fields = {
       ...fields,
-      tipRack: 'badTiprack',
+      tipRack: { tiprackDefURI: 'badTiprack' },
     }
     expect(incompatibleLiquidClass(fields)?.type).toBe(
       'INCOMPATIBLE_TIP_RACK_ALL'

--- a/protocol-designer/src/steplist/formLevel/warnings.tsx
+++ b/protocol-designer/src/steplist/formLevel/warnings.tsx
@@ -299,7 +299,7 @@ export const incompatibleLiquidClass: (
     }
 
     const tipRackObject = pipetteObject.byTipType.find(
-      ({ tiprack }) => tiprack === tipRack
+      ({ tiprack }) => tiprack === tipRack?.tiprackDefURI
     )
 
     if (tipRackObject == null) {

--- a/step-generation/src/types.ts
+++ b/step-generation/src/types.ts
@@ -228,7 +228,7 @@ export type NormalizedPipette = NormalizedPipetteById[keyof NormalizedPipetteByI
 // the opentrons_flex_96_tiprack_200ul). This is used in e.g. the hydrated step
 // forms, where the user selects a tip rack type rather than a specific tip
 // rack on the deck.
-// This interfaces packages together the tiprack URI and the tip rack labware
+// This interfaces packages together the tip rack URI and the tip rack labware
 // definition for convenience.
 export interface TipRackWithDef extends LabwareDefinition2 {
   tiprackDefURI: string

--- a/step-generation/src/types.ts
+++ b/step-generation/src/types.ts
@@ -223,6 +223,17 @@ export type NormalizedPipette = NormalizedPipetteById[keyof NormalizedPipetteByI
 
 // "entities" have only properties that are time-invariant
 // when they are de-normalized, the definitions they reference are baked in
+
+// Use this when you need to refer to a particular TYPE of tip rack (such as
+// the opentrons_flex_96_tiprack_200ul). This is used in e.g. the hydrated step
+// forms, where the user selects a tip rack type rather than a specific tip
+// rack on the deck.
+// This interfaces packages together the tiprack URI and the tip rack labware
+// definition for convenience.
+export interface TipRackWithDef extends LabwareDefinition2 {
+  tiprackDefURI: string
+}
+
 // =========== PIPETTES ========
 export type PipetteEntity = NormalizedPipette & {
   tiprackLabwareDef: LabwareDefinition2[]


### PR DESCRIPTION
# Overview

(This is Part 6 of tiprack definition fixes for PD.)

The problem we're trying to solve: `Hydrated{MoveLiquid/Mix}FormData.tipRack` contains the URI of a tiprack, which could be standard or custom labware. Then the lower-level functions have to look up the tiprack definition for that URI. There are 3 ways they try to do that:

1. Get the definition from `InvariantContext.labwareEntities`.
2. Get the definition from `PipetteEntity.tiprackLabwareDef`.
3. Get it from `getAllDefinitions()[tiprackURI]`.

The problem with (1) and (2) is that the tiprack is removed from `InvariantContext` and `PipetteEntity` when the user unselects a tiprack from the pipette, but a step form can still refer to the deleted tiprack's URI. The problem with (3) is that `getAllDefinitions()` only contains standard labware, and doesn't work for custom tipracks.

We could solve this problem if any function could look up a tiprack definition whenever it needed to, whether the tiprack is custom or not. But PD does not make that easy. The custom tiprack definitions are available in `BaseState`, but most functions only have access to the `InvariantContext`, which does **not** have all the custom labware definitions.

I think the best approach is to **hydrate the tiprack definition into the `HydratedMoveLiquidFormData/HydratedMixFormData`**. So this PR changes `.tipRack` from a URI string into a tiprack labware definition. Then any function using `Hydrated*FormData` would have the tiprack definition without having to implement its own lookup.

(There is a precedent for this: we do the same thing when we hydrate `.pipette` in `Hydrated*FormData`, turning the field from a string into a `PipetteEntity`.)

In order to hydrate the tiprack definition into `Hydrated*FormData.tipRack`, we need to pass the labware definitions down to the hydration functions, which this PR does by calling the `getLabwareDefsByURI()` selector.

## Test Plan and Hands on Testing

Tested PD by hand locally.
Ran all the CI tests.

## Risk assessment

Low-ish. This PR doesn't change any functionality yet, it just hydrates the tiprack definition into `Hydrated*FormData`. An upcoming PR will change the low-level functions to use the hydrated tiprack definition in `Hydrated*FormData.tipRack`.