### PR TITLE
refactor(protocol-designer): getMaxConditioningVolume() takes tiprackDef instead of URI

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/SecondStepsMoveLiquidTools.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/SecondStepsMoveLiquidTools.tsx
@@ -34,6 +34,7 @@ import {
 import { ResetSettingsModal } from '/protocol-designer/components/organisms/ResetSettingsModal'
 import { getEnableByVolumeBuilder } from '/protocol-designer/feature-flags/selectors'
 import { getRobotType } from '/protocol-designer/file-data/selectors'
+import { selectors as labwareDefSelectors } from '/protocol-designer/labware-defs'
 
 import {
   getAdditionalEquipmentEntities,
@@ -119,6 +120,9 @@ export const SecondStepsMoveLiquidTools = ({
 
   const robotType = useSelector(getRobotType)
   const pipetteSpec = useSelector(getPipetteEntities)[formData.pipette]?.spec
+  const tiprackDef = useSelector(labwareDefSelectors.getLabwareDefsByURI)[
+    formData.tipRack
+  ]
   const [showResetModal, setShowResetModal] = useState<boolean>(false)
   const [showChart, setShowChart] = useState<boolean>(false)
 
@@ -205,8 +209,7 @@ export const SecondStepsMoveLiquidTools = ({
             ? Number(formData.disposalVolume_volume)
             : 0,
         pipetteSpecs: pipetteSpec,
-        labwareEntities: labwareEntities,
-        tiprackDefUri: formData.tipRack,
+        tiprackDef: tiprackDef,
       }),
     [
       formData.transferVolume,

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/SecondStepsMoveLiquidTools.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/SecondStepsMoveLiquidTools.tsx
@@ -34,7 +34,7 @@ import {
 import { ResetSettingsModal } from '/protocol-designer/components/organisms/ResetSettingsModal'
 import { getEnableByVolumeBuilder } from '/protocol-designer/feature-flags/selectors'
 import { getRobotType } from '/protocol-designer/file-data/selectors'
-import { selectors as labwareDefSelectors } from '/protocol-designer/labware-defs'
+import { getLabwareDefsByURI } from '/protocol-designer/labware-defs/selectors'
 
 import {
   getAdditionalEquipmentEntities,
@@ -120,9 +120,7 @@ export const SecondStepsMoveLiquidTools = ({
 
   const robotType = useSelector(getRobotType)
   const pipetteSpec = useSelector(getPipetteEntities)[formData.pipette]?.spec
-  const tiprackDef = useSelector(labwareDefSelectors.getLabwareDefsByURI)[
-    formData.tipRack
-  ]
+  const tiprackDef = useSelector(getLabwareDefsByURI)[formData.tipRack]
   const [showResetModal, setShowResetModal] = useState<boolean>(false)
   const [showChart, setShowChart] = useState<boolean>(false)
 

--- a/protocol-designer/src/steplist/formLevel/errors.ts
+++ b/protocol-designer/src/steplist/formLevel/errors.ts
@@ -1424,9 +1424,7 @@ export const conditioningVolumeOutOfRange = (
     disposalVolume:
       disposalVolume_checkbox === true ? Number(disposalVolume_volume) : 0,
     pipetteSpecs: pipette.spec,
-    labwareEntities: labwareEntities ?? {},
-    tiprackDefUri: tipRack?.tiprackDefURI,
-    // TODO: change getMaxConditioningVolume() to use the tipRack definition directly
+    tiprackDef: tipRack,
   })
   return conditioning_checkbox && conditioning_volume > maxConditioningVolume
     ? CONDITIONING_VOLUME_OUT_OF_RANGE

--- a/protocol-designer/src/utils/__tests__/utils.test.ts
+++ b/protocol-designer/src/utils/__tests__/utils.test.ts
@@ -69,20 +69,13 @@ describe('getMaxConditioningVolume', () => {
     const args = {
       transferVolume: 10,
       disposalVolume: 5,
-      tiprackDefUri: 'opentrons/opentrons_96_tiprack_300ul/1',
-      labwareEntities: {
-        tiprack: {
-          id: 'tiprack',
-          labwareDefURI: 'opentrons/opentrons_96_tiprack_300ul/1',
-          def: {
-            parameters: {
-              loadName: 'opentrons_96_tiprack_300ul',
-            },
-            wells: {
-              A1: {
-                totalLiquidVolume: 300,
-              },
-            },
+      tiprackDef: {
+        parameters: {
+          loadName: 'opentrons_96_tiprack_300ul',
+        },
+        wells: {
+          A1: {
+            totalLiquidVolume: 300,
           },
         },
       },
@@ -104,8 +97,7 @@ describe('getMaxConditioningVolume', () => {
     const args = {
       transferVolume: 10,
       disposalVolume: 5,
-      tiprackDefUri: 'opentrons/opentrons_96_tiprack_300ul/1',
-      labwareEntities: {},
+      tiprackDefUri: {},
       pipetteSpecs: {
         liquids: {
           default: {
@@ -124,20 +116,13 @@ describe('getMaxConditioningVolume', () => {
     const args = {
       transferVolume: 10,
       disposalVolume: 0,
-      tiprackDefUri: 'opentrons/opentrons_96_tiprack_300ul/1',
-      labwareEntities: {
-        tiprack: {
-          id: 'tiprack',
-          labwareDefURI: 'opentrons/opentrons_96_tiprack_300ul/1',
-          def: {
-            parameters: {
-              loadName: 'opentrons_96_tiprack_300ul',
-            },
-            wells: {
-              A1: {
-                totalLiquidVolume: 300,
-              },
-            },
+      tiprackDef: {
+        parameters: {
+          loadName: 'opentrons_96_tiprack_300ul',
+        },
+        wells: {
+          A1: {
+            totalLiquidVolume: 300,
           },
         },
       },

--- a/protocol-designer/src/utils/index.ts
+++ b/protocol-designer/src/utils/index.ts
@@ -397,26 +397,16 @@ export const getDefaultPushOutVolume = (
 export const getMaxConditioningVolume = (args: {
   transferVolume: number
   disposalVolume: number
-  tiprackDefUri: string
-  labwareEntities: LabwareEntities
+  tiprackDef: LabwareDefinition2
   pipetteSpecs: PipetteV2Specs
 }): number => {
-  const {
-    transferVolume,
-    disposalVolume,
-    labwareEntities,
-    tiprackDefUri,
-    pipetteSpecs,
-  } = args
+  const { transferVolume, disposalVolume, tiprackDef, pipetteSpecs } = args
   const { liquids } = pipetteSpecs
   const minVolumeForMultiDispense = transferVolume * 2
   const isInLowVolumeMode =
     minVolumeForMultiDispense < liquids.default.minVolume &&
     'lowVolumeDefault' in liquids
-  const tiprack = Object.values(labwareEntities).find(
-    ({ labwareDefURI }) => labwareDefURI === tiprackDefUri
-  )
-  const tipMaxVolume = tiprack != null ? getTiprackVolume(tiprack.def) : null
+  const tipMaxVolume = tiprackDef != null ? getTiprackVolume(tiprackDef) : null
 
   const maxWorkingVolume = Math.min(
     isInLowVolumeMode


### PR DESCRIPTION
# Overview

The `getMaxConditioningVolume()` function previously took a tiprack URI and tried to look up the tiprack definition in `labwareEntities`. However, that could be unreliable if the tiprack URI refers to a tiprack that has been removed from the deck, because the tiprack would no longer be in `labwareEntities`.

Now that the tiprack definition is available in the hydrated form, this PR changes `getMaxConditioningVolume()` to just take in the tiprack definition directly instead of trying to look it up in `labwareEntities`.

## Test Plan and Hands on Testing

Smoke tested PD running locally.
Ran `yarn vitest --silent=false step-generation/ protocol-designer/ app/`.
Will run CI tests.

## Risk assessment

Low-ish.