### PR TITLE
refactor(protocol-designer): remove used vs unused lid check

### DIFF
--- a/protocol-designer/src/pages/Designer/utils.ts
+++ b/protocol-designer/src/pages/Designer/utils.ts
@@ -6,7 +6,6 @@ import {
   FLEX_ROBOT_TYPE,
   getAllDefinitions,
   getIsLid,
-  getIsPipettableLabware,
   getIsTiprack,
   getPositionFromSlotId,
   MOVABLE_TRASH_ADDRESSABLE_AREAS,
@@ -16,9 +15,7 @@ import {
 } from '@opentrons/shared-data'
 import {
   getFullStackFromLabwares,
-  getNearestParentInStack,
   getSlotInLocationStack,
-  TOUCHED_PIPETTABLE_LABWARE,
 } from '@opentrons/step-generation'
 
 import { getRobotType } from '../../file-data/selectors'
@@ -369,13 +366,7 @@ export const getUnoccupiedStackOptions = (args: {
   labwareEntities: LabwareEntities
   t: any
 }): Option[] => {
-  const {
-    robotState,
-    deckSetupLabware,
-    labwareIdFromDropdown,
-    labwareEntities,
-    t,
-  } = args
+  const { robotState, deckSetupLabware, labwareIdFromDropdown, t } = args
   if (deckSetupLabware[labwareIdFromDropdown] == null) {
     return []
   }
@@ -384,10 +375,6 @@ export const getUnoccupiedStackOptions = (args: {
   const labwareCompatibleParentLabware = def.compatibleParentLabware
 
   const { labware: labwareState } = robotState
-
-  const isLabwareToMoveUsedLid =
-    labwareState[labwareIdFromDropdown]?.sterility ===
-    TOUCHED_PIPETTABLE_LABWARE
 
   return Object.entries(labwareState).reduce<Option[]>(
     (acc, [labwareId, temporalLabwareOnDeck]) => {
@@ -423,18 +410,6 @@ export const getUnoccupiedStackOptions = (args: {
       const isNotCurrentLabwareStack = !fullStack.includes(
         labwareIdFromDropdown
       )
-
-      const nearestParentInStack = getNearestParentInStack(fullStack)
-      const isNearestParentPipettableLabware =
-        nearestParentInStack != null &&
-        labwareEntities[nearestParentInStack] != null &&
-        getIsPipettableLabware(labwareEntities[nearestParentInStack].def)
-
-      const isNewLabwarePipettable =
-        labwareOnDeckDef != null && getIsPipettableLabware(labwareOnDeckDef)
-      const isSafeLidMove =
-        !(isLabwareToMoveUsedLid && isNewLabwarePipettable) &&
-        !isNearestParentPipettableLabware
       const isInTrash =
         slot === 'gripperWasteChute' ||
         MOVABLE_TRASH_ADDRESSABLE_AREAS.includes(slot as AddressableAreaName) ||
@@ -444,8 +419,7 @@ export const getUnoccupiedStackOptions = (args: {
         isTopOfStack &&
         isCompatible &&
         isNotCurrentLabwareStack &&
-        !isInTrash &&
-        isSafeLidMove
+        !isInTrash
       ) {
         const similarLabwareStackIds = getAllLabwareIdsOfCertainURIOnStack(
           deckSetupLabware,

--- a/protocol-designer/src/steplist/fieldLevel/index.ts
+++ b/protocol-designer/src/steplist/fieldLevel/index.ts
@@ -67,12 +67,7 @@ const getIsStackingLocation = (
   newLocation: string,
   labwareEntities: LabwareEntities
 ): boolean => {
-  if (labwareEntities[newLocation] == null) {
-    return false
-  }
-  return (
-    labwareEntities[newLocation].def.allowedRoles?.includes('adapter') ?? false
-  )
+  return labwareEntities[newLocation] != null
 }
 
 const getIsAdditionalEquipmentLocation = (


### PR DESCRIPTION
closes AUTH-2395

# Overview

This PR removes the used/unused lid check when moving lids to other locations and then fixes how the new location field gets hydrated if its on top of another labware.

## Test Plan and Hands on Testing

Create a protocol for flex. add a new tiprack with a tiprack lid. create a move labware step to move that tiprack lid onto the other tiprack.

## Changelog

remove the used/unused lid check
fix how the stacked item gets hydrated

## Risk assessment

low
