### PR TITLE
refactor(protocol-designer): enable adding tiprack lid on a tiprack o…

### DIFF
--- a/protocol-designer/src/components/organisms/SelectLabwareModal/SelectLabwareOnAdapter.tsx
+++ b/protocol-designer/src/components/organisms/SelectLabwareModal/SelectLabwareOnAdapter.tsx
@@ -99,10 +99,56 @@ export function SelectLabwareOnAdapter(
         {has96Channel && loadName === ADAPTER_96_CHANNEL
           ? permittedTipracks.map((tiprackDefUri, index) => {
               const nestedDef = defs[tiprackDefUri]
+              const stackingLabwareDefUris = getStackerDefinitions(
+                {
+                  ...defs,
+                  ...customLabwareDefs,
+                },
+                undefined,
+                nestedDef.parameters.loadName,
+                nestedDef.metadata.displayCategory
+              )
+
+              const stackingProps: StackingProps | null =
+                stackingLabwareDefUris.length === 1 && slot !== 'offDeck'
+                  ? {
+                      inputTitle: t('labware_quantity'),
+                      errorMessage: t('unsupported_range'),
+                      checkboxCaption: t('with_lid', {
+                        name: defs[stackingLabwareDefUris[0]].metadata
+                          .displayName,
+                      }),
+                      checked: selectedLidLabware != null,
+                      onCheckboxChange: () => {
+                        dispatch(
+                          selectLid({
+                            labwareDefURI:
+                              selectedLidLabware === stackingLabwareDefUris[0]
+                                ? null
+                                : stackingLabwareDefUris[0],
+                          })
+                        )
+                      },
+                      inputCaption: t('valid_range', {
+                        max: defs[stackingLabwareDefUris[0]].stackLimit,
+                      }),
+                      definition: defs[stackingLabwareDefUris[0]],
+                      inputFieldValue: selectedTopLabware.amount ?? 1,
+                      onInputFieldChange: (e: ChangeEvent<any>) => {
+                        dispatch(
+                          selectTopLabwareAmount({
+                            amount: parseInt(e.target.value as string),
+                          })
+                        )
+                      },
+                    }
+                  : null
+
               return (
                 <CustomizeExpandButton
                   isNestedDefALid={false}
                   allowInputField={false}
+                  stackingProps={stackingProps ?? undefined}
                   key={`${index}_${category}_${loadName}_${tiprackDefUri}`}
                   id={`${index}_${category}_${loadName}_${tiprackDefUri}`}
                   buttonText={nestedDef?.metadata.displayName ?? ''}


### PR DESCRIPTION
…n an adapter

closes AUTH-2447

# Overview

Enable adding a tiprack lid onto a tiprack on an adapter

## Test Plan and Hands on Testing

smoke test that you can add a tiprack lid onto a tiprack on an adapter for a 96-channel. NOTE: there are 2 stacking icons that appear, will fix that in a follow up

<img width="619" height="668" alt="Screenshot 2025-11-05 at 07 55 06" src="https://github.com/user-attachments/assets/9db8f46b-6605-4e9d-adb1-e308cf4b2e07" />


## Changelog

add the stacking labware logic info when you're adding a tiprack onto an adapter

## Risk assessment

low