### PR TITLE
refactor(app,components): more renaming getAllLabwareDefs() -> getAllDefinitions() [cherrypick]

### DIFF
--- a/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useFailedLabwareUtils.test.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useFailedLabwareUtils.test.tsx
@@ -20,7 +20,7 @@ vi.mock('@opentrons/shared-data', async () => {
   return {
     ...actual,
     getLabwareDisplayName: vi.fn(() => 'Mock Labware Name'),
-    getAllLabwareDefs: vi.fn(() => ({
+    getAllDefinitions: vi.fn(() => ({
       'opentrons/thermoscientificnunc_96_wellplate_1300ul/1': {
         some: 'definition',
       },
@@ -46,7 +46,7 @@ vi.mock('@opentrons/shared-data', async () => {
   return {
     ...actual,
     getLabwareDisplayName: vi.fn(() => 'Mock Labware Name'),
-    getAllLabwareDefs: vi.fn(() => ({
+    getAllDefinitions: vi.fn(() => ({
       'opentrons/thermoscientificnunc_96_wellplate_1300ul/1': {
         some: 'definition',
       },

--- a/components/src/hardware-sim/Pipette/PipetteRender.stories.tsx
+++ b/components/src/hardware-sim/Pipette/PipetteRender.stories.tsx
@@ -1,6 +1,6 @@
 import { Fragment } from 'react'
 
-import { getAllLabwareDefs, getAllPipetteNames } from '@opentrons/shared-data'
+import { getAllDefinitions, getAllPipetteNames } from '@opentrons/shared-data'
 
 import { RobotWorkSpace } from '../Deck'
 import { LabwareRender } from '../Labware'
@@ -11,11 +11,11 @@ import type { LabwareDefinition, PipetteName } from '@opentrons/shared-data'
 
 const DECK_MAP_VIEWBOX = '0 -140 230 230'
 
-const opentrons300UlTiprack = getAllLabwareDefs().opentrons96Tiprack300UlV1
-const opentrons10UlTiprack = getAllLabwareDefs().opentrons96Tiprack10UlV1
-const nest12Reservoir15ml = getAllLabwareDefs().nest12Reservoir15MlV1
-const axygenReservoir90ml = getAllLabwareDefs().axygen1Reservoir90MlV1
-const opentrons6TuberackNest50mlConical = getAllLabwareDefs()
+const opentrons300UlTiprack = getAllDefinitions().opentrons96Tiprack300UlV1
+const opentrons10UlTiprack = getAllDefinitions().opentrons96Tiprack10UlV1
+const nest12Reservoir15ml = getAllDefinitions().nest12Reservoir15MlV1
+const axygenReservoir90ml = getAllDefinitions().axygen1Reservoir90MlV1
+const opentrons6TuberackNest50mlConical = getAllDefinitions()
   .opentrons6TuberackNest50MlConicalV1
 
 const labwareDefMap: Record<string, LabwareDefinition> = {


### PR DESCRIPTION
# Overview

This is a cherry-pick of PR #19916. In that PR, I said that I would only apply that change to `edge`, and leave the PD branch alone because `chore_release-pd-8.6.1` was frozen and about to be released, and the files with the obsolete call were not used by the PD CI tests at all.

Well, it turns out that a change I want to make to the PD branch now does trigger the `hardware-sim/` tests for some reason: https://github.com/Opentrons/opentrons/actions/runs/19088629372/job/54534570318

So now I need to cherrypick this change back into the PD branch.

## Test Plan and Hands on Testing

CI really really hard.

## Risk assessment

Low-ish.

(cherry picked from commit 04e051df4b06c66e32ae5b34782e670f2746b5f9)