### PR TITLE
refactor(app): Support livestream during run setup

### DIFF
--- a/app/src/assets/localization/en/run_details.json
+++ b/app/src/assets/localization/en/run_details.json
@@ -34,6 +34,8 @@
   "comment": "Comment",
   "comment_step": "Comment",
   "complete_protocol_to_download": "Complete the protocol to download the run log",
+  "confirm_camera_preferences": "Confirm camera preferences",
+  "confirm_camera_preferences_desc": "Confirm camera preferences to view the livestream during run setup",
   "csv_available_download": "All files associated with the run are available on the robot’s Recent Runs screen.",
   "current_step": "Current Step",
   "current_step_pause": "Current Step - Paused by User",

--- a/app/src/pages/Desktop/LivestreamViewer/LivestreamInfoScreen.tsx
+++ b/app/src/pages/Desktop/LivestreamViewer/LivestreamInfoScreen.tsx
@@ -1,38 +1,32 @@
 import { useTranslation } from 'react-i18next'
 
 import { InfoScreen } from '@opentrons/components'
-import { useCamera } from '@opentrons/react-api-client'
 
 import { isTerminalRunStatus } from '/app/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/utils'
 
-import type { RunStatus } from '@opentrons/api-client'
-
-const CAMERA_POLLING_INTERVAL_MS = 5000
+import type { CameraData, RunStatus } from '@opentrons/api-client'
 
 type LiveStreamInfoScreenType =
   | 'loading'
   | 'error'
   | 'disabled'
+  | 'run-setup'
   | 'run-terminal'
   | null
 
 export function useLivestreamInfoScreen(
   runStatus: RunStatus | null,
+  cameraData: CameraData | null,
   isRunLoading: boolean,
   videoError: string | null
 ): LiveStreamInfoScreenType {
-  const { data: cameraData, isLoading: isCameraSettingsLoading } = useCamera({
-    refetchInterval: CAMERA_POLLING_INTERVAL_MS,
-  })
-  const isCameraEnabled = cameraData?.cameraEnabled ?? false
-
   if (isTerminalRunStatus(runStatus)) {
     return 'run-terminal'
   } else if (videoError != null) {
     return 'error'
-  } else if (isRunLoading || isCameraSettingsLoading) {
+  } else if (isRunLoading || cameraData == null) {
     return 'loading'
-  } else if (!isCameraEnabled) {
+  } else if (!cameraData.cameraEnabled) {
     return 'disabled'
   } else {
     return null

--- a/app/src/pages/Desktop/LivestreamViewer/LivestreamInfoScreen.tsx
+++ b/app/src/pages/Desktop/LivestreamViewer/LivestreamInfoScreen.tsx
@@ -1,5 +1,9 @@
 import { useTranslation } from 'react-i18next'
 
+import {
+  RUN_STATUS_BLOCKED_BY_OPEN_DOOR,
+  RUN_STATUS_IDLE,
+} from '@opentrons/api-client'
 import { InfoScreen } from '@opentrons/components'
 
 import { isTerminalRunStatus } from '/app/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/utils'
@@ -20,13 +24,22 @@ export function useLivestreamInfoScreen(
   isRunLoading: boolean,
   videoError: string | null
 ): LiveStreamInfoScreenType {
-  if (isTerminalRunStatus(runStatus)) {
+  // camera data can only undefined before a run starts unless actively being fetched.
+  const unconfirmedSettingsDuringRunSetup =
+    cameraData == null &&
+    !isRunLoading &&
+    (runStatus === RUN_STATUS_BLOCKED_BY_OPEN_DOOR ||
+      runStatus === RUN_STATUS_IDLE)
+
+  if (unconfirmedSettingsDuringRunSetup) {
+    return 'run-setup'
+  } else if (isRunLoading) {
+    return 'loading'
+  } else if (isTerminalRunStatus(runStatus)) {
     return 'run-terminal'
   } else if (videoError != null) {
     return 'error'
-  } else if (isRunLoading || cameraData == null) {
-    return 'loading'
-  } else if (!cameraData.cameraEnabled) {
+  } else if (!cameraData?.liveStreamEnabled) {
     return 'disabled'
   } else {
     return null
@@ -52,6 +65,13 @@ export function LivestreamInfoScreen({
       )
     case 'disabled':
       return <InfoScreen content={t('camera_disabled')} />
+    case 'run-setup':
+      return (
+        <InfoScreen
+          content={t('confirm_camera_preferences')}
+          subContent={t('confirm_camera_preferences_desc')}
+        />
+      )
     case 'run-terminal':
       return <InfoScreen content={t('live_video_ended')} />
     default:

--- a/app/src/pages/Desktop/LivestreamViewer/__tests__/LivestreamInfoScreen.test.tsx
+++ b/app/src/pages/Desktop/LivestreamViewer/__tests__/LivestreamInfoScreen.test.tsx
@@ -35,4 +35,12 @@ describe('LivestreamInfoScreen', () => {
     render('run-terminal')
     screen.getByText('Live video has ended')
   })
+
+  it('renders run-setup state', () => {
+    render('run-setup')
+    screen.getByText('Confirm camera preferences')
+    screen.getByText(
+      'Confirm camera preferences to view the livestream during run setup'
+    )
+  })
 })

--- a/app/src/pages/Desktop/LivestreamViewer/index.tsx
+++ b/app/src/pages/Desktop/LivestreamViewer/index.tsx
@@ -23,9 +23,11 @@ export function LivestreamViewer(): JSX.Element {
     refetchInterval: RUN_POLLING_INTERVAL_MS,
   })
   const runStatus = runData?.data.status ?? null
+  const cmaeraData = runData?.data.cameraSettings ?? null
   const { videoRef, videoError } = useHlsVideo(runStatus)
   const infoScreenType = useLivestreamInfoScreen(
     runStatus,
+    cmaeraData,
     isRunLoading,
     videoError
   )

--- a/app/src/pages/Desktop/LivestreamViewer/index.tsx
+++ b/app/src/pages/Desktop/LivestreamViewer/index.tsx
@@ -23,11 +23,11 @@ export function LivestreamViewer(): JSX.Element {
     refetchInterval: RUN_POLLING_INTERVAL_MS,
   })
   const runStatus = runData?.data.status ?? null
-  const cmaeraData = runData?.data.cameraSettings ?? null
+  const cameraData = runData?.data.cameraSettings ?? null
   const { videoRef, videoError } = useHlsVideo(runStatus)
   const infoScreenType = useLivestreamInfoScreen(
     runStatus,
-    cmaeraData,
+    cameraData,
     isRunLoading,
     videoError
   )


### PR DESCRIPTION
Works towards [EXEC-2032](https://opentrons.atlassian.net/browse/EXEC-2032)

# Overview

This PR addresses the FE work required to support live stream during run setup. A user must confirm their preferences on the desktop/ODD first, and then those run-specific preferences are utilized to populate the livestream view.

NOTE: Design is out this week, so this copy is just holdover until they provide feedback.

<img width="495" height="414" alt="Screenshot 2025-11-05 at 11 46 45 AM" src="https://github.com/user-attachments/assets/0de82359-3d8b-498d-b637-779610c88692" />

## Test Plan and Hands on Testing

See image.

## Changelog

Added copy explaining why the livestream is not enabled until a user confirms camera preferences during run setup.

## Risk assessment
low


[EXEC-2032]: https://opentrons.atlassian.net/browse/EXEC-2032?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ