### PR TITLE
refactor(protocol-designer): allow for duplicating stacks

### DIFF
--- a/protocol-designer/src/labware-ingred/actions/thunks.ts
+++ b/protocol-designer/src/labware-ingred/actions/thunks.ts
@@ -159,7 +159,7 @@ export const duplicateLabware: (
       : getNextAvailableDeckSlot(initialDeckSetup, robotType, labwareDef)
 
     //  ensure templateSlot is not null
-    if (templateSlot == null && !isOffDeck) {
+    if (templateSlot == null) {
       console.error('no slots available, cannot duplicate labware')
       return
     }

--- a/protocol-designer/src/labware-ingred/actions/thunks.ts
+++ b/protocol-designer/src/labware-ingred/actions/thunks.ts
@@ -137,13 +137,11 @@ export const duplicateLabware: (
       id => labwareEntities[id]?.labwareDefURI
     )
 
-    if (templateLabwareDefURIs.some(uri => uri == null)) {
-      console.error(
-        'Missing labwareDefURI for one or more templateLabwareIds:',
-        templateLabwareIds
-      )
-      return
-    }
+    console.assert(
+      !templateLabwareDefURIs.some(uri => uri == null),
+      'Missing labwareDefURI for one or more templateLabwareIds:',
+      templateLabwareIds
+    )
 
     // determine if duplicating off-deck
     const firstTemplateId = templateLabwareIds[0]

--- a/protocol-designer/src/labware-ingred/actions/thunks.ts
+++ b/protocol-designer/src/labware-ingred/actions/thunks.ts
@@ -123,68 +123,72 @@ export const createContainer: (
 }
 
 export const duplicateLabware: (
-  templateLabwareId: string
+  templateLabwareIds: string[]
 ) => ThunkAction<DuplicateLabwareAction> =
-  templateLabwareId => (dispatch, getState) => {
+  templateLabwareIds => (dispatch, getState) => {
     const state = getState()
     const robotType = state.fileData.robotType
-    const templateLabwareDefURI =
-      stepFormSelectors.getLabwareEntities(state)[templateLabwareId]
-        .labwareDefURI
-    console.assert(
-      templateLabwareDefURI,
-      `no labwareDefURI for labware ${templateLabwareId}, cannot run duplicateLabware thunk`
-    )
+    const labwareEntities = stepFormSelectors.getLabwareEntities(state)
+    const labwareDefsByURI = labwareDefSelectors.getLabwareDefsByURI(state)
     const initialDeckSetup = stepFormSelectors.getInitialDeckSetup(state)
-    const templateLabwareIdIsOffDeck =
-      getSlotInLocationStack(
-        initialDeckSetup.labware[templateLabwareId].stack
-      ) === 'offDeck'
-    const labwareDef =
-      labwareDefSelectors.getLabwareDefsByURI(state)[templateLabwareDefURI]
-    const displayCategory = labwareDef.metadata.displayCategory
-    const duplicateSlot = getNextAvailableDeckSlot(
-      initialDeckSetup,
-      robotType,
-      labwareDef
-    )
-    if (duplicateSlot == null && !templateLabwareIdIsOffDeck) {
-      console.error('no slots available, cannot duplicate labware')
-    }
     const allNicknamesById = uiLabwareSelectors.getLabwareNicknamesById(state)
-    const templateNickname = allNicknamesById[templateLabwareId]
-    const duplicateLabwareNickname = getNextNickname(
-      Object.keys(allNicknamesById).map((id: string) => allNicknamesById[id]), // NOTE: flow won't do Object.values here >:(
-      templateNickname
-    )
-    const duplicateLabwareId = uuid() + ':' + templateLabwareDefURI
 
-    if (templateLabwareDefURI) {
-      if (templateLabwareIdIsOffDeck) {
-        dispatch({
-          type: 'DUPLICATE_LABWARE',
-          payload: {
-            duplicateLabwareNickname,
-            templateLabwareId,
-            duplicateLabwareId,
-            slot: 'offDeck',
-            displayCategory,
-          },
-        })
-      }
+    const templateLabwareDefURIs = templateLabwareIds.map(
+      id => labwareEntities[id]?.labwareDefURI
+    )
+
+    if (templateLabwareDefURIs.some(uri => uri == null)) {
+      console.error(
+        'Missing labwareDefURI for one or more templateLabwareIds:',
+        templateLabwareIds
+      )
+      return
     }
-    if (duplicateSlot != null && !templateLabwareIdIsOffDeck) {
+
+    // determine if duplicating off-deck
+    const firstTemplateId = templateLabwareIds[0]
+    const firstLabwareStack = initialDeckSetup.labware[firstTemplateId].stack
+    const isOffDeck = getSlotInLocationStack(firstLabwareStack) === 'offDeck'
+
+    const firstLabwareDefURI = templateLabwareDefURIs[0] as string
+    const labwareDef = labwareDefsByURI[firstLabwareDefURI]
+    const displayCategory = labwareDef?.metadata?.displayCategory
+
+    const templateSlot = isOffDeck
+      ? 'offDeck'
+      : getNextAvailableDeckSlot(initialDeckSetup, robotType, labwareDef)
+
+    //  ensure templateSlot is not null
+    if (templateSlot == null && !isOffDeck) {
+      console.error('no slots available, cannot duplicate labware')
+      return
+    }
+
+    const duplicateNicknames = templateLabwareIds.map(id => {
+      const templateNickname = allNicknamesById[id]
+      return getNextNickname(Object.values(allNicknamesById), templateNickname)
+    })
+
+    let slot: string = templateSlot as string
+    templateLabwareIds.reverse().forEach((templateLabwareId, index) => {
+      const defURI = labwareEntities[templateLabwareId].labwareDefURI
+      const duplicateLabwareId = `${uuid()}:${defURI}`
+
       dispatch({
         type: 'DUPLICATE_LABWARE',
         payload: {
-          duplicateLabwareNickname,
+          duplicateLabwareNickname: duplicateNicknames[index],
           templateLabwareId,
           duplicateLabwareId,
-          slot: duplicateSlot,
+          slot,
           displayCategory,
         },
       })
-    }
+
+      if (!isOffDeck) {
+        slot = duplicateLabwareId
+      }
+    })
   }
 
 export interface EditMultipleLabwareAction {

--- a/protocol-designer/src/pages/Designer/DeckSetup/SlotOverflowMenu.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/SlotOverflowMenu.tsx
@@ -138,12 +138,7 @@ export function SlotOverflowMenu(
       makeSnackbar(t('deck_slots_full') as string)
       return
     }
-
-    labwareStackOnSlot.forEach(labware => {
-      if (!deckSetupLabware[labware].def.allowedRoles?.includes('adapter')) {
-        dispatch(duplicateLabware(deckSetupLabware[labware].id))
-      }
-    })
+    dispatch(duplicateLabware(labwareStackOnSlot))
     setShowMenuList(false)
   }
 


### PR DESCRIPTION
closes AUTH-2452 AUTH-2451

# Overview

Clean up the `duplicateLabware` thunk and allow for duplicating a whole stack, which includes adapters + labwares + lids. 

## Test Plan and Hands on Testing

Create a stack: tiprack + lid, adapter + labware, labware + lid, etc. If you hit "duplicate", it should duplicate the whole stack onto the first available slot

## Changelog

clean up the `ducpliateLabware` thunk and add support for duplicating a stack

## Risk assessment

low
