### PR TITLE
fix(protocol-designer): getMatchingTipLiquidSpecs() take tiprackDef directly

### DIFF
--- a/protocol-designer/src/components/organisms/TipPositionModal/__tests__/TipPositionModal.test.tsx
+++ b/protocol-designer/src/components/organisms/TipPositionModal/__tests__/TipPositionModal.test.tsx
@@ -6,6 +6,7 @@ import { FLEX_ROBOT_TYPE } from '@opentrons/shared-data'
 import { renderWithProviders } from '/protocol-designer/__testing-utils__'
 import { i18n } from '/protocol-designer/assets/localization'
 import { getRobotType } from '/protocol-designer/file-data/selectors'
+import { getLabwareDefsByURI } from '/protocol-designer/labware-defs/selectors'
 import {
   getAdditionalEquipmentEntities,
   getLabwareEntities,
@@ -21,6 +22,7 @@ import type { MoveLiquidPrefixType } from '../../../../resources/types'
 vi.mock('../TipPositionSideView')
 vi.mock('/protocol-designer/file-data/selectors')
 vi.mock('/protocol-designer/step-forms/selectors')
+vi.mock('/protocol-designer/labware-defs/selectors')
 const render = (props: ComponentProps<typeof TipPositionModal>) => {
   return renderWithProviders(<TipPositionModal {...props} />, {
     i18nInstance: i18n,
@@ -38,6 +40,7 @@ describe('TipPositionModal', () => {
     vi.mocked(getPipetteEntities).mockReturnValue({})
     vi.mocked(getLabwareEntities).mockReturnValue({})
     vi.mocked(getAdditionalEquipmentEntities).mockReturnValue({})
+    vi.mocked(getLabwareDefsByURI).mockReturnValue({})
     vi.mocked(getRobotType).mockReturnValue(FLEX_ROBOT_TYPE)
     props = {
       formData: {

--- a/protocol-designer/src/components/organisms/TipPositionModal/hooks/useDefaultPosition.tsx
+++ b/protocol-designer/src/components/organisms/TipPositionModal/hooks/useDefaultPosition.tsx
@@ -1,9 +1,9 @@
 import { useSelector } from 'react-redux'
 
 import { getRobotType } from '/protocol-designer/file-data/selectors'
+import { getLabwareDefsByURI } from '/protocol-designer/labware-defs/selectors'
 import {
   getAdditionalEquipmentEntities,
-  getLabwareEntities,
   getPipetteEntities,
 } from '/protocol-designer/step-forms/selectors'
 import { getLiquidClassesValues } from '/protocol-designer/steplist/formLevel/handleFormChange/utils'
@@ -17,10 +17,10 @@ export function useDefaultPosition(
   prefix: MoveLiquidPrefixType
 ): WellLocation {
   const pipetteEntities = useSelector(getPipetteEntities)
-  const labwareEntities = useSelector(getLabwareEntities)
   const additionalEquipmentEntities = useSelector(
     getAdditionalEquipmentEntities
   )
+  const allLabwareDefs = useSelector(getLabwareDefsByURI)
   const robotType = useSelector(getRobotType)
   if (formData == null) {
     return {}
@@ -28,8 +28,8 @@ export function useDefaultPosition(
   const liquidClassDefaultValues = getLiquidClassesValues({
     rawForm: formData,
     pipetteEntities,
-    labwareEntities,
     additionalEquipmentEntities,
+    allLabwareDefs,
     robotType,
   })
   return {

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/FlowRateField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/FlowRateField.tsx
@@ -14,6 +14,7 @@ import { getTransferPlanAndReferenceVolumes } from '@opentrons/step-generation'
 
 import { InputStepFormField } from '/protocol-designer/components/molecules'
 import { getRobotType } from '/protocol-designer/file-data/selectors'
+import { getLabwareDefsByURI } from '/protocol-designer/labware-defs/selectors'
 import { selectors as stepFormSelectors } from '/protocol-designer/step-forms'
 import { getMatchingTipLiquidSpecs } from '/protocol-designer/utils'
 
@@ -49,7 +50,7 @@ export function FlowRateField(props: FlowRateFieldProps): JSX.Element {
   const [isPristine, setIsPristine] = useState<boolean>(true)
   const pipetteEntities = useSelector(stepFormSelectors.getPipetteEntities)
   const pipette = pipetteId != null ? pipetteEntities[pipetteId] : null
-  const labwareEntities = useSelector(stepFormSelectors.getLabwareEntities)
+  const tiprackDef = useSelector(getLabwareDefsByURI)[tiprack as string]
   const robotType = useSelector(getRobotType)
   const allLiquidClassDefs = getAllLiquidClassDefs()
   const liquidClassDef =
@@ -66,12 +67,8 @@ export function FlowRateField(props: FlowRateFieldProps): JSX.Element {
 
   const matchingTipLiquidSpecs =
     pipette != null && tiprack != null
-      ? getMatchingTipLiquidSpecs(pipette, volume as number, tiprack as string)
+      ? getMatchingTipLiquidSpecs(pipette, volume as number, tiprackDef)
       : null
-  const tiprackDef =
-    Object.values(labwareEntities).find(
-      ({ labwareDefURI }) => labwareDefURI === tiprack
-    )?.def ?? null
 
   let airGapByVolume: Array<[number, number]> = []
   // no air gap included for mix step

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepFormToolbox.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepFormToolbox.tsx
@@ -39,6 +39,7 @@ import {
   getRobotType,
 } from '/protocol-designer/file-data/selectors'
 import { stepIconsByType } from '/protocol-designer/form-types'
+import { getLabwareDefsByURI } from '/protocol-designer/labware-defs/selectors'
 import {
   getAdditionalEquipmentEntities,
   getCurrentFormIsPresaved,
@@ -156,10 +157,11 @@ export function StepFormToolbox(props: StepFormToolboxProps): JSX.Element {
     dispatch(actions.changeFormInput({ update: { [name]: maskedValue } }))
   }
 
-  const { pipetteEntities, labwareEntities } = useSelector(getInvariantContext)
+  const { pipetteEntities } = useSelector(getInvariantContext)
   const additionalEquipmentEntities = useSelector(
     getAdditionalEquipmentEntities
   )
+  const allLabwareDefs = useSelector(getLabwareDefsByURI)
   const formWarningsForSelectedStep = useSelector(
     getFormWarningsForSelectedStep
   )
@@ -315,8 +317,8 @@ export function StepFormToolbox(props: StepFormToolboxProps): JSX.Element {
       propsForFields,
       rawForm: formData,
       pipetteEntities,
-      labwareEntities,
       additionalEquipmentEntities,
+      allLabwareDefs,
       robotType,
     })
     setToolboxStep(currentStep => currentStep + strideForContinueOrBack)

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MixTools/SecondStepMixTools.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MixTools/SecondStepMixTools.tsx
@@ -18,10 +18,10 @@ import {
 } from '/protocol-designer/components/molecules'
 import { ResetSettingsModal } from '/protocol-designer/components/organisms/ResetSettingsModal'
 import { getRobotType } from '/protocol-designer/file-data/selectors'
+import { getLabwareDefsByURI } from '/protocol-designer/labware-defs/selectors'
 
 import {
   getAdditionalEquipmentEntities,
-  getLabwareEntities,
   getPipetteEntities,
 } from '../../../../../../step-forms/selectors'
 import { updateFieldsForLiquidClass } from '../../../../../../steplist/formLevel/handleFormChange/utils'
@@ -59,10 +59,10 @@ export function SecondStepMixTools({
   const { t, i18n } = useTranslation(['application', 'form'])
   const toolsComponentRef = useRef<HTMLDivElement | null>(null)
   const pipetteEntities = useSelector(getPipetteEntities)
-  const labwareEntities = useSelector(getLabwareEntities)
   const additionalEquipmentEntities = useSelector(
     getAdditionalEquipmentEntities
   )
+  const allLabwareDefs = useSelector(getLabwareDefsByURI)
   const robotType = useSelector(getRobotType)
   const [showResetModal, setShowResetModal] = useState<boolean>(false)
   const aspirateTab = {
@@ -106,8 +106,8 @@ export function SecondStepMixTools({
               propsForFields,
               rawForm: formData,
               pipetteEntities,
-              labwareEntities,
               additionalEquipmentEntities,
+              allLabwareDefs,
               liquidHandlingAction: tab,
               robotType,
             })

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/SecondStepsMoveLiquidTools.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/SecondStepsMoveLiquidTools.tsx
@@ -34,6 +34,7 @@ import {
 import { ResetSettingsModal } from '/protocol-designer/components/organisms/ResetSettingsModal'
 import { getEnableByVolumeBuilder } from '/protocol-designer/feature-flags/selectors'
 import { getRobotType } from '/protocol-designer/file-data/selectors'
+import { getLabwareDefsByURI } from '/protocol-designer/labware-defs/selectors'
 
 import {
   getAdditionalEquipmentEntities,
@@ -90,6 +91,7 @@ export const SecondStepsMoveLiquidTools = ({
   const additionalEquipmentEntities = useSelector(
     getAdditionalEquipmentEntities
   )
+  const allLabwareDefs = useSelector(getLabwareDefsByURI)
   const { trashBinEntities, wasteChuteEntities } = useSelector(
     getInvariantContext
   )
@@ -310,8 +312,8 @@ export const SecondStepsMoveLiquidTools = ({
               propsForFields,
               rawForm: formData,
               pipetteEntities,
-              labwareEntities,
               additionalEquipmentEntities,
+              allLabwareDefs,
               liquidHandlingAction: tab,
               robotType,
             })

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/utils.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/utils.ts
@@ -56,6 +56,7 @@ import type {
   PipetteEntity,
   ReferenceVolumes,
 } from '@opentrons/step-generation'
+import type { LabwareDefByDefURI } from '/protocol-designer/labware-defs'
 import type { FormData, PathOption, StepFieldName } from '../../../form-types'
 import type {
   FieldPropsByName,
@@ -530,16 +531,16 @@ const getNoLiquidClassValuesMoveLiquid = (args: {
   convertedPipetteName: string
   liquidHandlingAction: LiquidClassSettingsType
   robotType: RobotType
-  labwareEntities: LabwareEntities
   pipetteEntity: PipetteEntity
+  tiprackDef: LabwareDefinition2
 }): Record<string, any> => {
   const {
     rawForm,
     convertedPipetteName,
     liquidHandlingAction,
     robotType,
-    labwareEntities,
     pipetteEntity,
+    tiprackDef,
   } = args
   const { tipRack: tiprack, path, volume: rawVolume, stepType } = rawForm
   if (stepType !== 'moveLiquid') {
@@ -547,10 +548,6 @@ const getNoLiquidClassValuesMoveLiquid = (args: {
     return {}
   }
   const volume = Number(rawVolume)
-  const tiprackEntity =
-    Object.values(labwareEntities).find(
-      ({ labwareDefURI }) => labwareDefURI === tiprack
-    ) ?? null
   const referenceLiquidClass = getAllLiquidClassDefs()[WATER_LIQUID_CLASS_NAME]
   const liquidClassValuesForPipette = referenceLiquidClass.byPipette.find(
     ({ pipetteModel }) => convertedPipetteName === pipetteModel
@@ -573,11 +570,7 @@ const getNoLiquidClassValuesMoveLiquid = (args: {
     const allOT2Defaults = getDefaultsForStepType('moveLiquid')
     const matchingTipLiquidSpecs =
       pipetteEntity != null
-        ? getMatchingTipLiquidSpecs(
-            pipetteEntity,
-            volume,
-            rawForm.tipRack as string
-          )
+        ? getMatchingTipLiquidSpecs(pipetteEntity, volume, tiprackDef)
         : null
     const aspirateOT2Defaults = {
       aspirate_wellOrder_first: allOT2Defaults.aspirate_wellOrder_first,
@@ -604,11 +597,11 @@ const getNoLiquidClassValuesMoveLiquid = (args: {
         allOT2Defaults.aspirate_retract_delay_seconds,
     }
     const pushOutVolume =
-      tiprackEntity != null
+      tiprackDef != null
         ? getDefaultPushOutVolume(
             Number(rawForm.volume),
             pipetteSpecs,
-            tiprackEntity.def
+            tiprackDef
           )
         : 0
     const dispenseOT2Defaults = {
@@ -682,11 +675,7 @@ const getNoLiquidClassValuesMoveLiquid = (args: {
 
   const matchingTipLiquidSpecs =
     pipetteEntity != null
-      ? getMatchingTipLiquidSpecs(
-          pipetteEntity,
-          volume,
-          rawForm.tipRack as string
-        )
+      ? getMatchingTipLiquidSpecs(pipetteEntity, volume, tiprackDef)
       : null
 
   const aspirateCorrectionVolume =
@@ -853,6 +842,7 @@ const getNoLiquidClassValuesMix = (args: {
   convertedPipetteName: string
   liquidHandlingAction: LiquidClassSettingsType
   pipetteEntity: PipetteEntity
+  tiprackDef: LabwareDefinition2
   robotType: RobotType
 }): Record<string, any> => {
   const {
@@ -860,6 +850,7 @@ const getNoLiquidClassValuesMix = (args: {
     convertedPipetteName,
     liquidHandlingAction,
     pipetteEntity,
+    tiprackDef,
     robotType,
   } = args
   const { tipRack: tiprack, volume: rawVolume, stepType } = rawForm
@@ -879,11 +870,7 @@ const getNoLiquidClassValuesMix = (args: {
 
   const matchingTipLiquidSpecs =
     pipetteEntity != null
-      ? getMatchingTipLiquidSpecs(
-          pipetteEntity,
-          volume,
-          rawForm.tipRack as string
-        )
+      ? getMatchingTipLiquidSpecs(pipetteEntity, volume, tiprackDef)
       : null
   const aspirateCorrectionVolume =
     linearInterpolate(
@@ -1008,23 +995,23 @@ const getNoLiquidClassValuesMix = (args: {
 const getLiquidClassValuesMoveLiquid = (args: {
   rawForm: FormData
   liquidClassValuesForTip: ByTipTypeSetting
-  labwareEntities: LabwareEntities
   additionalEquipmentEntities: AdditionalEquipmentEntities
   liquidHandlingAction: LiquidClassSettingsType
   pipetteEntity: PipetteEntity
+  tiprackDef: LabwareDefinition2
   robotType: RobotType
 }): Record<string, any> => {
   const {
     rawForm,
     liquidClassValuesForTip,
-    labwareEntities,
     additionalEquipmentEntities,
     liquidHandlingAction,
     pipetteEntity,
+    tiprackDef,
     robotType,
   } = args
   const { aspirate, singleDispense, multiDispense } = liquidClassValuesForTip
-  const { path, tipRack, volume: rawVolume } = rawForm
+  const { path, volume: rawVolume } = rawForm
   const { spec: pipetteSpecs } = pipetteEntity
   const volume = Number(rawVolume)
   const {
@@ -1062,16 +1049,12 @@ const getLiquidClassValuesMoveLiquid = (args: {
     [number, number]
   >
   const disposalByVolume = rawDisposalByVolume as Array<[number, number]>
-  const tiprackDefinition =
-    Object.values(labwareEntities).find(
-      ({ labwareDefURI }) => labwareDefURI === tipRack
-    )?.def ?? null
   const {
     referenceVolumes: byVolumeLookup,
     multiWellHandling,
   } = getTransferPlanAndReferenceVolumes({
     pipetteSpecs,
-    tiprackDefinition,
+    tiprackDefinition: tiprackDef,
     conditioningByVolume,
     disposalByVolume,
     volume,
@@ -1091,11 +1074,7 @@ const getLiquidClassValuesMoveLiquid = (args: {
   const aspirateOffsetFields = getOffsetFields(aspirateOffset, 'aspirate')
   const matchingTipLiquidSpecs =
     pipetteEntity != null
-      ? getMatchingTipLiquidSpecs(
-          pipetteEntity,
-          volume,
-          rawForm.tipRack as string
-        )
+      ? getMatchingTipLiquidSpecs(pipetteEntity, volume, tiprackDef)
       : null
 
   const aspirateCorrectionVolume =
@@ -1292,6 +1271,7 @@ const getLiquidClassValuesMix = (args: {
   additionalEquipmentEntities: AdditionalEquipmentEntities
   liquidHandlingAction: LiquidClassSettingsType
   pipetteEntity: PipetteEntity
+  tiprackDef: LabwareDefinition2
   robotType: RobotType
 }): Record<string, any> => {
   const {
@@ -1300,6 +1280,7 @@ const getLiquidClassValuesMix = (args: {
     additionalEquipmentEntities,
     liquidHandlingAction,
     pipetteEntity,
+    tiprackDef,
     robotType,
   } = args
   const { volume: rawVolume } = rawForm
@@ -1321,11 +1302,7 @@ const getLiquidClassValuesMix = (args: {
 
   const matchingTipLiquidSpecs =
     pipetteEntity != null
-      ? getMatchingTipLiquidSpecs(
-          pipetteEntity,
-          volume,
-          rawForm.tipRack as string
-        )
+      ? getMatchingTipLiquidSpecs(pipetteEntity, volume, tiprackDef)
       : null
 
   const aspirateCorrectionVolume =
@@ -1448,16 +1425,16 @@ const getLiquidClassValuesMix = (args: {
 export const getLiquidClassesValues = (args: {
   rawForm: FormData
   pipetteEntities: PipetteEntities
-  labwareEntities: LabwareEntities
   additionalEquipmentEntities: AdditionalEquipmentEntities
+  allLabwareDefs: LabwareDefByDefURI
   liquidHandlingAction?: LiquidClassSettingsType
   robotType: RobotType
 }): Record<string, any> => {
   const {
     rawForm,
     pipetteEntities,
-    labwareEntities,
     additionalEquipmentEntities,
+    allLabwareDefs,
     liquidHandlingAction = 'all',
     robotType,
   } = args
@@ -1468,6 +1445,7 @@ export const getLiquidClassesValues = (args: {
   }
 
   const pipetteEntity = pipetteEntities[pipette]
+  const tiprackDef = allLabwareDefs[tipRack]
   const liquidClasses = getAllLiquidClassDefs()
   const liquidClassDef = liquidClasses[liquidClass]
   if (pipetteEntity == null) {
@@ -1482,14 +1460,15 @@ export const getLiquidClassesValues = (args: {
           convertedPipetteName,
           liquidHandlingAction,
           robotType,
-          labwareEntities,
           pipetteEntity,
+          tiprackDef,
         })
       : getNoLiquidClassValuesMix({
           rawForm,
           convertedPipetteName,
           liquidHandlingAction,
           pipetteEntity,
+          tiprackDef,
           robotType,
         })
   }
@@ -1512,16 +1491,17 @@ export const getLiquidClassesValues = (args: {
       additionalEquipmentEntities,
       liquidHandlingAction,
       pipetteEntity,
+      tiprackDef,
       robotType,
     })
   }
   return getLiquidClassValuesMoveLiquid({
     rawForm,
     liquidClassValuesForTip,
-    labwareEntities,
     additionalEquipmentEntities,
     liquidHandlingAction,
     pipetteEntity,
+    tiprackDef,
     robotType,
   })
 }
@@ -1530,8 +1510,8 @@ export const updateFieldsForLiquidClass = (args: {
   propsForFields: FieldPropsByName
   rawForm: FormData
   pipetteEntities: PipetteEntities
-  labwareEntities: LabwareEntities
   additionalEquipmentEntities: AdditionalEquipmentEntities
+  allLabwareDefs: LabwareDefByDefURI
   liquidHandlingAction?: LiquidClassSettingsType
   robotType: RobotType
 }): void => {
@@ -1539,16 +1519,16 @@ export const updateFieldsForLiquidClass = (args: {
     propsForFields,
     rawForm,
     pipetteEntities,
-    labwareEntities,
     additionalEquipmentEntities,
+    allLabwareDefs,
     liquidHandlingAction = 'all',
     robotType,
   } = args
   const fieldUpdates = getLiquidClassesValues({
     rawForm,
     pipetteEntities,
-    labwareEntities,
     additionalEquipmentEntities,
+    allLabwareDefs,
     liquidHandlingAction,
     robotType,
   })

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/mixFormToArgs.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/mixFormToArgs.ts
@@ -39,8 +39,7 @@ export const mixFormToArgs = (
   const matchingTipLiquidSpecs = getMatchingTipLiquidSpecs(
     pipette,
     hydratedFormData.volume,
-    // TODO: change getMatchingTipLiquidSpecs() to use tipRack definition directly
-    hydratedFormData.tipRack?.tiprackDefURI
+    hydratedFormData.tipRack
   )
   const unorderedWells = hydratedFormData.wells || []
   const orderedWells = getOrderedWells(

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/moveLiquidFormToArgs.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/moveLiquidFormToArgs.ts
@@ -296,8 +296,7 @@ export const moveLiquidFormToArgs = (
   const matchingTipLiquidSpecs = getMatchingTipLiquidSpecs(
     hydratedFormData.pipette,
     hydratedFormData.volume,
-    tipRack?.tiprackDefURI
-    // TODO: change getMatchingTipLiquidSpecs() to use the tipRack definition directly
+    tipRack
   )
   const conditioningVolume =
     hydratedFormData.conditioning_checkbox === true &&

--- a/protocol-designer/src/utils/index.ts
+++ b/protocol-designer/src/utils/index.ts
@@ -3,7 +3,6 @@ import uuidv1 from 'uuid/v4'
 
 import {
   FLEX_ROBOT_TYPE,
-  getAllDefinitions,
   getDeckDefFromRobotType,
   getTiprackVolume,
   INTERACTIVE_WELL_DATA_ATTRIBUTE,
@@ -232,30 +231,14 @@ export function getMatchingTipLiquidSpecsFromSpec(
 export function getMatchingTipLiquidSpecs(
   pipetteEntity: PipetteEntity,
   volume: number,
-  tiprack: string
+  tiprackDef: LabwareDefinition2
 ): SupportedTip {
-  const matchingLabwareDef =
-    Object.values(pipetteEntity.tiprackLabwareDef).find(def =>
-      tiprack.includes(def.parameters.loadName)
-    ) ||
-    // The `tiprack` from a step might not be in `pipetteEntity.tiprackLabwareDef`
-    // anymore because the user removed the tiprack from the pipette. So we can try
-    // looking up the `tiprack` in getAllDefinitions() as well.
-    // TODO: But getAllDefinitions() only contains standard labware, so this would still
-    // fail if `tiprack` is a custom tiprack.
-    getAllDefinitions()[tiprack]
-
-  console.assert(
-    matchingLabwareDef,
-    `expected to find a matching labware def with tiprack ${tiprack} but could not`
-  )
-
-  const tipLength = matchingLabwareDef?.parameters.tipLength ?? 0
+  const tipLength = tiprackDef?.parameters.tipLength ?? 0
 
   if (tipLength === 0) {
     console.error(
       `expected to find a tiplength with tiprack ${
-        matchingLabwareDef?.metadata.displayName ?? 'unknown displayName'
+        tiprackDef?.metadata.displayName ?? 'unknown displayName'
       } but could not`
     )
   }
@@ -278,7 +261,7 @@ export function getMatchingTipLiquidSpecs(
   console.assert(
     matchingTipLiquidSpecs,
     `expected to find the tip liquid specs but could not with pipette tiprack displayname ${
-      matchingLabwareDef?.metadata.displayName ?? 'unknown displayname'
+      tiprackDef?.metadata.displayName ?? 'unknown displayname'
     }`
   )
 


### PR DESCRIPTION
# Overview

`getMatchingTipLiquidSpecs()` takes a tiprack URI string, and tries to find the labware definition for the tiprack. This has been causing a ton of failures because the tiprack might not be in `PipetteEntity.tiprackLabwareDef` (if the tiprack has been disassociated from the pipette) nor in `InvariantContext.labwareEntities` (if the tiprack has been removed from the deck). A previous bandaid tried to fall back to looking up the tiprack in `getAllDefinitions()` (PR #19874), but that would still fail if tiprack is custom, because `getAllDefinitions()` only contains standard labware.

In this final long-term fix, we change `getMatchingTipLiquidSpecs()` to take in the tiprack definition instead of the tiprack URI string. The caller is responsible for supplying the correct tiprack definition:

- When the caller is using the `HydratedFormData`, such as in `mixFormToArgs.ts` and `moveLiquidFormToArgs.ts`, the caller can just get the tiprack definition from `HydratedFormData.tipRack`. We previously changed hydration to put the tiprack definition into `.tipRack` (PR #20034), and that works correctly for both custom and default tipracks.
- When the caller is using the `rawForm`, such as in `StepFormToolbox.tsx` and other React components, the caller can `useSelector(getLabwareDefsByURI)` to get the tiprack definition. This selector returns both custom and default labware, so it also works correctly.

Sorry this is kind of long.

## Test Plan and Hands on Testing

Updated unit tests.
Ran `yarn vitest --silent=false step-generation/ protocol-designer/ app/`.
Smoke-tested PD running locally.
Will run CI tests.

## Risk assessment

Low-ish. 