### PR TITLE
fix(protocol-designer): fix LabwareLabel offsets

### DIFF
--- a/protocol-designer/src/pages/Designer/LabwareLabel.tsx
+++ b/protocol-designer/src/pages/Designer/LabwareLabel.tsx
@@ -73,7 +73,7 @@ export const LabwareLabel = (props: LabwareLabelProps): JSX.Element => {
       ref={labelContainerRef}
       deckLabels={deckLabels}
       x={
-        position[0] -
+        position[0] +
         labwareDef.cornerOffsetFromSlot.x -
         (showDeckRiserAdjustments ? DECK_RISER_ADJUSTED_X : 0)
       }


### PR DESCRIPTION
# Overview

Correct the labware offset from slot application in `LabwareLabel`. We should be adding the offset, and assume that sign for the definition's offset is correct.

Closes AUTH-2446

## Test Plan and Hands on Testing

- imported a protocol with a 96-channel tiprack adapter
- selected the adapter -> edit labware
- verified that the adapter is correctly highlighted 
- smoke test other labware labels to verify they are not impacted

#### Before

<img width="894" height="641" alt="Screenshot 2025-11-05 at 1 55 51 PM" src="https://github.com/user-attachments/assets/1b99149f-7fc5-4ab2-afa7-4638ed37e682" />

#### After

<img width="806" height="616" alt="Screenshot 2025-11-05 at 1 55 29 PM" src="https://github.com/user-attachments/assets/ff2195d4-f4f5-4008-8a58-48b9f3614d4c" />

## Changelog

- apply `cornerOffsetFromSlot` via addition in `LabwareLabel` (sign of this offset should determine whether the label is shifted to the left or right

## Review requests

Follow test plan and verify visual alignment of labware label

## Risk assessment

low