### PR TITLE
fix(components): fix PlaceholderStyledText <text> is not an HTML tag

### DIFF
--- a/components/src/atoms/StyledText/PlaceholderStyledText.tsx
+++ b/components/src/atoms/StyledText/PlaceholderStyledText.tsx
@@ -38,8 +38,8 @@ export const PlaceholderStyledText = (
     oddStyle != null ? styleMap[oddStyle as StyleKey] : null
   )
   return (
-    <text className={combinedClassName} style={{ color: color ?? '' }}>
+    <span className={combinedClassName} style={{ color: color ?? '' }}>
       {children}
-    </text>
+    </span>
   )
 }


### PR DESCRIPTION
# Overview

This fixes a minor error that's cluttering up the JavaScript console:
`
Warning: The tag <text> is unrecognized in this browser. If you meant to render a React component, start its name with an uppercase letter.
`

It looks like `<text>` is only valid inside SVG. For HTML documents, you're supposed to use `<span>` for a span of text.

## Test Plan and Hands on Testing

Running `vitest`.

## Review requests

I haven't really touched our frontend components before. Does this look right?

## Risk assessment

Low.