### PR TITLE
fix(robot-server, api): Ensure live stream visible during run setup

### DIFF
--- a/api/src/opentrons/protocol_runner/run_orchestrator.py
+++ b/api/src/opentrons/protocol_runner/run_orchestrator.py
@@ -12,7 +12,6 @@ from opentrons_shared_data.labware.types import LabwareUri
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition
 from opentrons_shared_data.errors import GeneralError
 from opentrons_shared_data.robot.types import RobotType
-from opentrons.system import camera
 
 from . import protocol_runner, RunResult, JsonRunner, PythonAndLegacyRunner
 from ..hardware_control import HardwareControlAPI
@@ -195,13 +194,6 @@ class RunOrchestrator:
         run_time_param_values: Optional[PrimitiveRunTimeParamValuesType] = None,
     ) -> RunResult:
         """Start the run."""
-        if self._camera_provider:
-            await camera.update_live_stream_status(
-                self.get_robot_type(),
-                True,
-                self._camera_provider,
-                self._protocol_engine.state_view.camera.get_enablement_settings(),
-            )
         if self._protocol_runner:
             return await self._protocol_runner.run(
                 deck_configuration=deck_configuration,

--- a/api/src/opentrons/system/camera.py
+++ b/api/src/opentrons/system/camera.py
@@ -160,7 +160,7 @@ async def update_live_stream_status(
         raw_device = str(contents["SOURCE"])[1:-1]
         if not os.path.exists(raw_device):
             log.error(
-                "Opentrons Live Stream cannot sample the camera. No video device found with device path: {raw_device}"
+                f"Opentrons Live Stream cannot sample the camera. No video device found with device path: {raw_device}"
             )
         # Enable the stream
         status = "ON"

--- a/robot-server/robot_server/runs/router/camera_router.py
+++ b/robot-server/robot_server/runs/router/camera_router.py
@@ -7,6 +7,7 @@ from fastapi import Depends, status
 from server_utils.fastapi_utils.light_router import LightRouter
 
 from opentrons.protocol_engine.resources.camera_provider import CameraSettings
+from opentrons.system import camera
 
 from robot_server.errors.error_responses import ErrorBody
 from robot_server.service.json_api import (
@@ -14,6 +15,12 @@ from robot_server.service.json_api import (
     SimpleBody,
     PydanticResponse,
 )
+from robot_server.hardware import get_robot_type
+from opentrons_shared_data.robot.types import RobotType
+from robot_server.camera.fastapi_dependencies import (
+    get_camera_provider,
+)
+from opentrons.protocol_engine.resources.camera_provider import CameraProvider
 
 from ..run_models import Run
 from ..run_orchestrator_store import RunOrchestratorStore
@@ -48,6 +55,8 @@ async def add_camera_settings(
         RunOrchestratorStore, Depends(get_run_orchestrator_store)
     ],
     run: Annotated[Run, Depends(get_run_data_from_url)],
+    robot_type: Annotated[RobotType, Depends(get_robot_type)],
+    camera_provider: Annotated[CameraProvider, Depends(get_camera_provider)],
 ) -> PydanticResponse[SimpleBody[CameraEnable]]:
     """Add unique camera settings to a run to be used in place of the global camera settings.
 
@@ -55,6 +64,8 @@ async def add_camera_settings(
         request_body: New camera settings from request body.
         run_orchestrator_store: Engine storage interface.
         run: Run response data by ID from URL; ensures 404 if run not found.
+        robot_type: Used to validate robot type for live stream service.
+        camera_provider: Access to the camera settings and related services.
     """
     if run.current is False:
         raise RunStopped(detail=f"Run {run.id} is not the current run").as_error(
@@ -77,6 +88,16 @@ async def add_camera_settings(
         camera_settings
     )
     log.info(f'Added unique camera settings "{request_body.data}" to run "{run.id}".')
+
+    # Restart the stream with any the newest live stream settings
+    await camera.update_live_stream_status(
+        robot_type=robot_type,
+        stream_status=response_data.liveStreamEnabled
+        if response_data.cameraEnabled is True
+        else False,
+        camera_provider=camera_provider,
+        override_settings=camera_settings,
+    )
 
     return await PydanticResponse.create(
         content=SimpleBody.model_construct(

--- a/robot-server/robot_server/runs/run_data_manager.py
+++ b/robot-server/robot_server/runs/run_data_manager.py
@@ -40,7 +40,7 @@ from opentrons.protocol_engine.types import DeckConfigurationType, RunTimeParame
 from opentrons.protocol_engine.resources.file_provider import FileProvider
 from opentrons.protocol_engine.resources.camera_provider import CameraProvider
 from opentrons.protocol_engine.state.module_substates import FlexStackerSubState
-
+from opentrons.system import camera
 
 _INITIAL_ERROR_RECOVERY_RULES: list[ErrorRecoveryRule] = []
 
@@ -281,6 +281,13 @@ class RunDataManager:
             get_recovery_target_command=self.get_recovery_target_command,
             get_state_summary=self._get_good_state_summary,
             run_id=run_id,
+        )
+
+        await camera.update_live_stream_status(
+            self._run_orchestrator_store._robot_type,
+            True,
+            camera_provider,
+            state_summary.cameraSettings,
         )
 
         return _build_run(


### PR DESCRIPTION
# Overview
Covers EXEC-2032

Ensures the live stream is visible during run setup, and that live stream restarts if run specific enablement occurs in run setup. Originally we only made this determination when the user pressed play and began a run, but now we do it when the run is created instead.

## Test Plan and Hands on Testing

- [x] Start robot with camera disabled, enter run setup (stream should be off), enable live stream for run, stream should be visible
- [x] Start robot with camera enabled, enter run setup, stream should be visible
- [x] works when the run starts in case they never touch the settings

## Changelog
Refactored stream update logic to enable streaming from run setup.

## Review requests


## Risk assessment
Low, effects new behavior