### PR TITLE
refactor(step-generation): render stagingAreaEntities from commands f…

### DIFF
--- a/step-generation/src/constants.ts
+++ b/step-generation/src/constants.ts
@@ -93,3 +93,5 @@ export const EMPTY: 'EMPTY' = 'EMPTY'
 
 export const AUTOMATIC: 'automatic' = 'automatic'
 export const MANUAL: 'manual' = 'manual'
+
+export const STAGING_AREA_SLOTS = ['A4', 'B4', 'C4', 'D4']

--- a/step-generation/src/utils/constructInvariantContextFromRunCommands.ts
+++ b/step-generation/src/utils/constructInvariantContextFromRunCommands.ts
@@ -34,28 +34,29 @@ export function constructInvariantContextFromRunCommands(
 
         const newStagingAreaEntities: StagingAreaEntities =
           createStagingAreaForInvariantContext(params)
-        let newLabwareEntities: LabwareEntities = {}
-
-        if (
-          result.definition != null &&
-          result.definition.schemaVersion === 2
-        ) {
-          const def = result.definition
-          const labwareDefURI = getLabwareDefURI(def)
-
-          newLabwareEntities = result.labwareIds.slice(0, amount).reduce(
-            (entities: LabwareEntities, labwareId) => ({
-              ...entities,
-              [labwareId]: {
-                id: labwareId,
-                labwareDefURI,
-                def,
-                pythonName: 'n/a',
-              },
-            }),
-            {}
-          )
-        }
+        const newLabwareEntities: LabwareEntities =
+          // loadLabware commands from the backend can have schema 3 labware definitions.
+          // step-generation, and this function by extension, are not prepared to handle
+          // schema 3 yet. Just ignore those definitions for now.
+          // See also the loadPipette handling, below.
+          result.definition != null && result.definition.schemaVersion === 2
+            ? (() => {
+                const def = result.definition
+                const labwareDefURI = getLabwareDefURI(def)
+                return result.labwareIds.slice(0, amount).reduce(
+                  (entities: LabwareEntities, labwareId) => ({
+                    ...entities,
+                    [labwareId]: {
+                      id: labwareId,
+                      labwareDefURI,
+                      def,
+                      pythonName: 'n/a',
+                    },
+                  }),
+                  {}
+                )
+              })()
+            : {}
 
         return {
           ...acc,
@@ -77,24 +78,23 @@ export function constructInvariantContextFromRunCommands(
 
         const newStagingAreaEntities: StagingAreaEntities =
           createStagingAreaForInvariantContext(params)
-        let newLabwareEntities: LabwareEntities = {}
-
-        // todo(mm, 2025-05-16):
-        // loadLabware commands from the backend can have schema 3 labware definitions.
-        // step-generation, and this function by extension, are not prepared to handle
-        // schema 3 yet. Just ignore those definitions for now.
-        // See also the loadPipette handling, below.
-        if (result.definition.schemaVersion === 2) {
-          newLabwareEntities = {
-            [result.labwareId]: {
-              id: result.labwareId,
-              labwareDefURI: getLabwareDefURI(result.definition),
-              def: result.definition,
-              //  ProtocolTimelineScrubber won't need access to pythonNames
-              pythonName: 'n/a',
-            },
-          }
-        }
+        const newLabwareEntities: LabwareEntities =
+          // todo(mm, 2025-05-16):
+          // loadLabware commands from the backend can have schema 3 labware definitions.
+          // step-generation, and this function by extension, are not prepared to handle
+          // schema 3 yet. Just ignore those definitions for now.
+          // See also the loadPipette handling, below.
+          result.definition != null && result.definition.schemaVersion === 2
+            ? {
+                [result.labwareId]: {
+                  id: result.labwareId,
+                  labwareDefURI: getLabwareDefURI(result.definition),
+                  def: result.definition,
+                  // ProtocolTimelineScrubber won't need access to pythonNames
+                  pythonName: 'n/a',
+                },
+              }
+            : {}
 
         return {
           ...acc,

--- a/step-generation/src/utils/constructInvariantContextFromRunCommands.ts
+++ b/step-generation/src/utils/constructInvariantContextFromRunCommands.ts
@@ -6,6 +6,7 @@ import {
 
 import { uuid } from '.'
 import { GRIPPER_LOCATION } from '../constants'
+import { createStagingAreaForInvariantContext } from './misc'
 
 import type {
   LoadLabwareRunTimeCommand,
@@ -17,6 +18,7 @@ import type {
   LabwareEntities,
   ModuleEntities,
   PipetteEntities,
+  StagingAreaEntities,
   TrashBinEntities,
   WasteChuteEntities,
 } from '../types'
@@ -30,6 +32,10 @@ export function constructInvariantContextFromRunCommands(
         const { result, params } = command
         const amount = params.quantity
 
+        const newStagingAreaEntities: StagingAreaEntities =
+          createStagingAreaForInvariantContext(params)
+        let newLabwareEntities: LabwareEntities = {}
+
         if (
           result.definition != null &&
           result.definition.schemaVersion === 2
@@ -37,40 +43,49 @@ export function constructInvariantContextFromRunCommands(
           const def = result.definition
           const labwareDefURI = getLabwareDefURI(def)
 
-          const stackLabwareEntities = result.labwareIds
-            .slice(0, amount)
-            .reduce(
-              (entities: LabwareEntities, labwareId) => ({
-                ...entities,
-                [labwareId]: {
-                  id: labwareId,
-                  labwareDefURI,
-                  def,
-                  pythonName: 'n/a',
-                },
-              }),
-              acc.labwareEntities
-            )
+          newLabwareEntities = result.labwareIds.slice(0, amount).reduce(
+            (entities: LabwareEntities, labwareId) => ({
+              ...entities,
+              [labwareId]: {
+                id: labwareId,
+                labwareDefURI,
+                def,
+                pythonName: 'n/a',
+              },
+            }),
+            {}
+          )
+        }
 
-          return {
-            ...acc,
-            labwareEntities: stackLabwareEntities,
-          }
-        } else {
-          // loadLabware commands from the backend can have schema 3 labware definitions.
-          // step-generation, and this function by extension, are not prepared to handle
-          // schema 3 yet.
-          return acc
+        return {
+          ...acc,
+          labwareEntities: {
+            ...acc.labwareEntities,
+            ...newLabwareEntities,
+          },
+          stagingAreaEntities: {
+            ...acc.stagingAreaEntities,
+            ...newStagingAreaEntities,
+          },
         }
       } else if (
         (command.commandType === 'loadLabware' ||
           command.commandType === 'loadLid') &&
         command.result != null
       ) {
-        const { result } = command
+        const { result, params } = command
+
+        const newStagingAreaEntities: StagingAreaEntities =
+          createStagingAreaForInvariantContext(params)
+        let newLabwareEntities: LabwareEntities = {}
+
+        // todo(mm, 2025-05-16):
+        // loadLabware commands from the backend can have schema 3 labware definitions.
+        // step-generation, and this function by extension, are not prepared to handle
+        // schema 3 yet. Just ignore those definitions for now.
+        // See also the loadPipette handling, below.
         if (result.definition.schemaVersion === 2) {
-          const labwareEntities = {
-            ...acc.labwareEntities,
+          newLabwareEntities = {
             [result.labwareId]: {
               id: result.labwareId,
               labwareDefURI: getLabwareDefURI(result.definition),
@@ -79,17 +94,18 @@ export function constructInvariantContextFromRunCommands(
               pythonName: 'n/a',
             },
           }
-          return {
-            ...acc,
-            labwareEntities,
-          }
-        } else {
-          // todo(mm, 2025-05-16):
-          // loadLabware commands from the backend can have schema 3 labware definitions.
-          // step-generation, and this function by extension, are not prepared to handle
-          // schema 3 yet. Just ignore those definitions for now.
-          // See also the loadPipette handling, below.
-          return acc
+        }
+
+        return {
+          ...acc,
+          labwareEntities: {
+            ...acc.labwareEntities,
+            ...newLabwareEntities,
+          },
+          stagingAreaEntities: {
+            ...acc.stagingAreaEntities,
+            ...newStagingAreaEntities,
+          },
         }
       } else if (
         command.commandType === 'loadModule' &&
@@ -207,9 +223,8 @@ export function constructInvariantContextFromRunCommands(
       pipetteEntities: {},
       wasteChuteEntities: {},
       trashBinEntities: {},
-      //  this util is used for the timeline scrubber. It grabs staging area info from
-      //  command analysis. Also, it does not visualize the gripper right now
       stagingAreaEntities: {},
+      //  the timeline scrubber doesn't visualize gripper right now
       gripperEntities: {},
       //  this util is used for the timeline scrubber. It grabs liquid info from analysis
       //  so this will not be wired up right now

--- a/step-generation/src/utils/misc.ts
+++ b/step-generation/src/utils/misc.ts
@@ -34,9 +34,9 @@ import {
   dispenseInTrash,
   dispenseInWasteChute,
 } from '../commandCreators/compound'
-import { CLEAN, EMPTY, ZERO_OFFSET } from '../constants'
+import { CLEAN, EMPTY, STAGING_AREA_SLOTS, ZERO_OFFSET } from '../constants'
 import { curryCommandCreator } from './curryCommandCreator'
-import { reduceCommandCreators } from './index'
+import { reduceCommandCreators, uuid } from './index'
 
 import type {
   AddressableAreaName,
@@ -45,6 +45,9 @@ import type {
   CutoutId,
   LabwareDefinition2,
   LabwareLocationSequence,
+  LoadLabwareRunTimeCommand,
+  LoadLidParams,
+  LoadLidStackRunTimeCommand,
   PipetteChannels,
   PipetteV2Specs,
   PositionReference,
@@ -63,6 +66,7 @@ import type {
   PipetteEntity,
   RobotState,
   SourceAndDest,
+  StagingAreaEntities,
   TrashBinEntities,
   TrashBinEntity,
   WasteChuteEntities,
@@ -1307,3 +1311,37 @@ export const getStackForLabwareLocation = (
     }
     return [...acc, item.logicalLocationName]
   }, [])
+
+const FOURTH_COLUMN_TO_CUTOUT_MAP = {
+  A4: 'cutoutA3',
+  B4: 'cutoutB3',
+  C4: 'cutoutC3',
+  D4: 'cutoutD3',
+}
+
+export function createStagingAreaForInvariantContext(
+  params:
+    | LoadLidStackRunTimeCommand['params']
+    | LoadLabwareRunTimeCommand['params']
+    | LoadLidParams
+): StagingAreaEntities {
+  if (
+    params.location !== 'offDeck' &&
+    params.location !== 'systemLocation' &&
+    params.location !== 'wasteChuteLocation' &&
+    'addressableAreaName' in params.location &&
+    STAGING_AREA_SLOTS.includes(params.location.addressableAreaName)
+  ) {
+    const id = uuid()
+    const addressableAreaName = params.location.addressableAreaName
+    const location =
+      FOURTH_COLUMN_TO_CUTOUT_MAP[
+        addressableAreaName as keyof typeof FOURTH_COLUMN_TO_CUTOUT_MAP
+      ] ?? addressableAreaName // fallback if the addressableArea name doesn't match the map, but shoudln't run into this
+
+    return {
+      [id]: { id, location },
+    }
+  }
+  return {}
+}


### PR DESCRIPTION
…or PV

closes AUTH-2427

# Overview

Creates the staging area entities from invariant context created from the command analysis and then renders them on the deck map for protocol viz

## Test Plan and Hands on Testing

upload attached protocol to the app, should have 1 staging area slot when you scroll to the 1 command in the protocol

[untitled (75).py](https://github.com/user-attachments/files/23396427/untitled.75.py)

## Changelog

create a util to create staging area entities
wire up the util in the invariant context construction fn

## Risk assessment

low
