### PR TITLE
fix(api): Default values for thermocycler max block volume when well volume is out of bounds

### DIFF
--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -982,9 +982,9 @@ class ThermocyclerContext(ModuleContext):
                     if isinstance(well_vol, float):
                         max_vol = max(max_vol, well_vol)
                     if max_vol > BLOCK_VOL_MAX:
-                        max_vol = 100
+                        max_vol = BLOCK_VOL_MAX
                     elif max_vol < BLOCK_VOL_MIN:
-                        max_vol = 25
+                        max_vol = BLOCK_VOL_MIN
         return max_vol
 
 

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -44,7 +44,7 @@ from .module_validation_and_errors import (
 from .labware import Labware
 from . import validation
 from . import Task
-
+from opentrons.drivers.thermocycler.driver import BLOCK_VOL_MIN, BLOCK_VOL_MAX
 
 _MAGNETIC_MODULE_HEIGHT_PARAM_REMOVED_IN = APIVersion(2, 14)
 
@@ -981,6 +981,10 @@ class ThermocyclerContext(ModuleContext):
                     # ignore simulated probe results
                     if isinstance(well_vol, float):
                         max_vol = max(max_vol, well_vol)
+                    if max_vol > BLOCK_VOL_MAX:
+                        max_vol = 100
+                    elif max_vol < BLOCK_VOL_MIN:
+                        max_vol = 25
         return max_vol
 
 

--- a/api/tests/opentrons/protocol_api/test_thermocycler_context.py
+++ b/api/tests/opentrons/protocol_api/test_thermocycler_context.py
@@ -379,6 +379,29 @@ def test_set_block_temperature(
     )
 
 
+def test_get_current_labware_max_volume(
+    decoy: Decoy,
+    mock_core: ThermocyclerCore,
+    mock_labware: Labware,
+    mock_well: Well,
+    subject: ThermocyclerContext,
+) -> None:
+    """It should return a max block volume within bounds."""
+    mock_labware_core = decoy.mock(cls=LabwareCore)
+    decoy.when(mock_well.has_tracked_liquid()).then_return(True)
+    decoy.when(mock_well.current_liquid_volume()).then_return(125.0)
+    decoy.when(mock_labware.wells()).then_return([mock_well])
+    decoy.when(subject._protocol_core.get_labware_on_module(mock_core)).then_return(
+        mock_labware_core
+    )
+    decoy.when(subject._core_map.get(mock_labware_core)).then_return(mock_labware)
+    result = subject._get_current_labware_max_vol()
+    assert result == 100.0
+    decoy.when(mock_well.current_liquid_volume()).then_return(-10.0)
+    result = subject._get_current_labware_max_vol()
+    assert result == 0.0
+
+
 def test_set_block_temperature_with_liquid_tracking(
     decoy: Decoy,
     mock_core: ThermocyclerCore,


### PR DESCRIPTION
# Overview

Add a default value for the thermocycler max block volume when the found well volume is out of bounds

## Test Plan and Hands on Testing

Simulated protocol `/Users/rhyannclarke/opentrons/abr-testing/abr_testing/protocols/active_protocols/4_Illumina DNA Enrichment.py` with apiLevel to 2.27 and received this error: `ProtocolCommandFailedError [line 299]: Error 4000 GENERAL_ERROR (ProtocolCommandFailedError): InvalidBlockVolumeError: Thermocycler max block volume must be between 0 and 100, but got 150.0.`

After the change was made, the protocol simulated successfully with `start_set_block_temperature()` and `set_block_temperature()`

## Changelog

- Added default block temperatures based on if it was higher than the max or lower than the min


## Risk assessment

low

Closes RQA-4820