### PR TITLE
fix(protocol-designer): Error modal copy and CTA update first pr!!!

### DIFF
--- a/protocol-designer/src/assets/localization/en/alert.json
+++ b/protocol-designer/src/assets/localization/en/alert.json
@@ -43,8 +43,8 @@
       "body1": "Moving labware to the Waste Chute permanently discards it. You can’t use this labware in later steps. During a protocol run, the labware will be dropped in the chute and become irretrievable."
     },
     "has_errors": {
-      "title": "Protocol has errors",
-      "body1": "Some steps in this protocol have errors. The exported file will omit these steps. You should fix the errors before exporting."
+      "title": "Protocol has timeline errors",
+      "body1": "Fix timeline errors before running this protocol on a robot."
     }
   },
   "timeline": {

--- a/protocol-designer/src/components/organisms/BlockingHintModal/index.tsx
+++ b/protocol-designer/src/components/organisms/BlockingHintModal/index.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 import { useDispatch } from 'react-redux'
 
 import {
+  AlertPrimaryButton,
   ALIGN_CENTER,
   Check,
   COLORS,
@@ -11,7 +12,6 @@ import {
   JUSTIFY_SPACE_BETWEEN,
   Modal,
   PrimaryButton,
-  AlertPrimaryButton,
   SecondaryButton,
   SPACING,
   StyledText,
@@ -52,9 +52,6 @@ export function BlockingHintModal(props: HintProps): JSX.Element {
     handleContinue()
   }
 
-  const confirmButtonText =
-    hintKey === 'no_commands' || hintKey === 'has_errors' ? 'continue_with_export' : 'confirm'
-
   return createPortal(
     <Modal
       marginLeft="0"
@@ -83,12 +80,13 @@ export function BlockingHintModal(props: HintProps): JSX.Element {
               {t('shared:cancel')}
             </SecondaryButton>
             {hintKey === 'has_errors' || hintKey === 'no_commands' ? (
-            <AlertPrimaryButton onClick={onContinueClick}>
-              {i18n.format(t(`shared:${confirmButtonText}`), 'capitalize')}
-            </AlertPrimaryButton>) : (
-            <PrimaryButton onClick={onContinueClick}>
-              {i18n.format(t(`shared:${confirmButtonText}`), 'capitalize')}
-            </PrimaryButton>
+              <AlertPrimaryButton onClick={onContinueClick}>
+                {i18n.format(t(`shared:continue_with_export`), 'capitalize')}
+              </AlertPrimaryButton>
+            ) : (
+              <PrimaryButton onClick={onContinueClick}>
+                {i18n.format(t(`shared:confirm`), 'capitalize')}
+              </PrimaryButton>
             )}
           </Flex>
         </Flex>

--- a/protocol-designer/src/components/organisms/BlockingHintModal/index.tsx
+++ b/protocol-designer/src/components/organisms/BlockingHintModal/index.tsx
@@ -11,6 +11,7 @@ import {
   JUSTIFY_SPACE_BETWEEN,
   Modal,
   PrimaryButton,
+  AlertPrimaryButton,
   SecondaryButton,
   SPACING,
   StyledText,
@@ -52,7 +53,7 @@ export function BlockingHintModal(props: HintProps): JSX.Element {
   }
 
   const confirmButtonText =
-    hintKey === 'no_commands' ? 'continue_with_export' : 'confirm'
+    hintKey === 'no_commands' || hintKey === 'has_errors' ? 'continue_with_export' : 'confirm'
 
   return createPortal(
     <Modal
@@ -81,9 +82,14 @@ export function BlockingHintModal(props: HintProps): JSX.Element {
             <SecondaryButton onClick={onCancelClick}>
               {t('shared:cancel')}
             </SecondaryButton>
+            {hintKey === 'has_errors' || hintKey === 'no_commands' ? (
+            <AlertPrimaryButton onClick={onContinueClick}>
+              {i18n.format(t(`shared:${confirmButtonText}`), 'capitalize')}
+            </AlertPrimaryButton>) : (
             <PrimaryButton onClick={onContinueClick}>
               {i18n.format(t(`shared:${confirmButtonText}`), 'capitalize')}
             </PrimaryButton>
+            )}
           </Flex>
         </Flex>
       }

--- a/protocol-designer/src/resources/hooks/useProtocolExportHandler.tsx
+++ b/protocol-designer/src/resources/hooks/useProtocolExportHandler.tsx
@@ -37,9 +37,9 @@ export const useProtocolExportHandler = ({
 
   const content = (
     <StyledText desktopStyle="bodyDefaultRegular">
-      {!hasCommands
-        ? t('alert:export_warnings.redesign.no_commands.body1')
-        : t('alert:hint.has_errors.body1')}
+      {hasTimelineErrors || hasFormErrors
+        ? t('alert:hint.has_errors.body1')
+        : t('alert:export_warnings.redesign.no_commands.body1')}
     </StyledText>
   )
 


### PR DESCRIPTION
# Overview

This PR updates error modal copy for the modal that shows up when a user exports a protocol without fixing timeline errors. In addition, we also changed the CTA styling for the CTA used in the modal, going from a primary button to an alert primary button.

Finally, we also changed logic for exporting protocols with a single step with a timeline error. Previously if you had a single step with a timeline error we showed the "protocols has no steps" error. Now, we correctly show that there is a timeline error in the protocol.

## Test Plan and Hands on Testing

I tested this PR by running the branch locally and checking to make sure that the modal now has updated copy.

<img width="1437" height="700" alt="image" src="https://github.com/user-attachments/assets/e7025327-b225-4fc8-843a-8226ab8dddb9" />

<img width="1504" height="779" alt="image" src="https://github.com/user-attachments/assets/c4c46cd1-a450-4268-9a7c-c10163de2386" />

## Changelog

1. Change error modal copy for exporting with timeline errors
2. Change button CTA styling from primary button to alert button
3. Change logic for exporting a protocol to correctly recognize when protocols with 1 step (and a timeline error) have a timeline error.

## Review requests

I need SWEs with many more years of experience to review everything because this is my first PR.

## Risk assessment

Hoping that this is a low risk change.