### PR TITLE
Docs stacker retrofit sn revision

### DIFF
--- a/docs/flex/docs/modules/stacker.md
+++ b/docs/flex/docs/modules/stacker.md
@@ -62,7 +62,7 @@ Any Flex with a serial number that includes **A10** or **A20** _requires_ a Stac
 - Allows early model robots to recognize and communicate with the Staker.
 - Prevents the HEPA/UV module from operating if the Stacker is improperly installed.
 
-For additional information, see the [HEPA/UV compatibility section](../../stacker/compliance.md#stacker-and-hepauv-compatibility) of the Stacker instruction manual. You can also contact [Opentrons Sales](https://opentrons.com/contact) if you're unsure about a robot's manufacture date and/or have a model that needs to be upgraded.
+For additional information, see the [HEPA/UV compatibility section](../../stacker/compliance.md#flex-stacker-and-hepauv-compatibility) of the Stacker instruction manual. You can also contact [Opentrons Sales](https://opentrons.com/contact) if you're unsure about a robot's manufacture date and/or have a model that needs to be upgraded.
 
 ### Software control
 

--- a/docs/flex/docs/modules/stacker.md
+++ b/docs/flex/docs/modules/stacker.md
@@ -57,9 +57,10 @@ The Stacker accepts Opentrons Flex tip racks, selected items in our [Labware Lib
 
 ### Module compatibility
 
-The Stacker is compatible with all other Flex modules.
+Any Flex with a serial number that includes **A10** or **A20** _requires_ a Stacker retrofit kit. Robots with serial numbers containing **A30** (or higher) are fully compatible with the Stacker; the retrofit kit is not required. The kit adds new firmware and hardware to your Flex which:
 
-If you want to use a Stacker on a Flex robot manufactured before September 2025, you will need an upgrade kit. This kit, which adds new hardware and electronics to your Flex, prevents the HEPA/UV module from operating if the Stacker is improperly installed. Robots manufactured after September 2025 have these safety features built-in and do not require this upgrade. _The upgrade must be performed by an Opentrons field service technician_.
+- Allows early model robots to recognize and communicate with the Staker.
+- Prevents the HEPA/UV module from operating if the Stacker is improperly installed.
 
 For additional information, see the [HEPA/UV compatibility section](../../stacker/compliance.md#stacker-and-hepauv-compatibility) of the Stacker instruction manual. You can also contact [Opentrons Sales](https://opentrons.com/contact) if you're unsure about a robot's manufacture date and/or have a model that needs to be upgraded.
 

--- a/docs/flex/docs/modules/stacker.md
+++ b/docs/flex/docs/modules/stacker.md
@@ -57,7 +57,7 @@ The Stacker accepts Opentrons Flex tip racks, selected items in our [Labware Lib
 
 ### Module compatibility
 
-Any Flex with a serial number that includes **A10** or **A20** _requires_ a Stacker retrofit kit. Robots with serial numbers containing **A30** (or higher) are fully compatible with the Stacker; the retrofit kit is not required. The kit adds new firmware and hardware to your Flex which:
+Any Flex with a [serial number version](../system-description/specs.md#serial-number) that includes **A10** or **A20** _requires_ a Stacker retrofit kit. Robots with serial number version **A30** (or higher) are fully compatible with the Stacker; the retrofit kit is not required. The kit adds new firmware and hardware to your Flex which:
 
 - Allows early model robots to recognize and communicate with the Staker.
 - Prevents the HEPA/UV module from operating if the Stacker is improperly installed.

--- a/docs/stacker/docs/compliance.md
+++ b/docs/stacker/docs/compliance.md
@@ -150,17 +150,26 @@ You can install and use Stackers with the [Opentrons Flex HEPA/UV Module](https:
 |Side panels | The replacement side panel that comes with the User Kit is opaque to UV-C light. The other panels on the robot block UV-spectrum light to below a level which represents an exposure risk. |
 | Attachment sensors | The Stacker and HEPA/UV Module each use sensors and switches to determine if they’re installed properly. These devices deactivate/disable the UV lights when the Stacker door is open, or these components are improperly installed, removed during operation, or misaligned.|
 
-## Stacker and HEPA/UV Compatibility
+## Flex, Stacker, and HEPA/UV Compatibility
 
-Flex robots manufactured before September 2025 require an upgrade kit. This kit adds new hardware to your Flex, preventing the HEPA/UV module from operating if the Stacker is improperly installed.
+Any Flex with a serial number that includes **A10** or **A20** _requires_ a Stacker retrofit kit, even if you don't have the HEPA/UV module installed. Robots with serial numbers containing **A30** (or higher) are fully compatible with the Stacker; the retrofit kit is not required. The kit adds new firmware and hardware to your Flex which:
+
+- Allows early model robots to recognize and communicate with the Staker.
+- Prevents the HEPA/UV module from operating if the Stacker is improperly installed.
+
+The serial number can be found on the certification sticker on the back of each Flex near the on/off switch, or under the touchscreen, or in the Opentrons App under the **Advanced** tab.
+
+![Flex serial number](images/serial-number-cropped2.png){width="50%"}
 
 !!!note
     The upgrade kit must be installed by an Opentrons field service technician only.
 
-Refer to your robot's serial number to determine if an upgrade is required. Robots with a version identifier of A30 or higher are compatible with the Stacker and the HEPA/UV Module without the kit. For example, serial number FLX**A30**20250902003 indicates HEPA/UV compatibility, whereas robots with A20 or A10 version identifiers require an upgrade.
+Compare these serial number examples to the serial number on your robot to determine if it needs the Stacker retrofit kit installed.
 
-![Flex serial number](images/serial-number-cropped2.png){width="50%"}
-
-The serial number can be found on the certification sticker on the back of each Flex near the on/off switch, or under the touchscreen, or in the Opentrons App under the **Advanced** tab.
+| Serial number identifier | Example | Retrofit required |
+|----|----|----|
+| A10 | FLX**A10**20240201234 | Yes |
+| A20 | FLX**A20**20250321003 | Yes |
+| A30 | FLX**A30**20250908004 | No |
 
 Contact [Opentrons Sales](https://opentrons.com/contact) if you're unsure about your robot's manufacture date and/or have a robot that needs to be upgraded.

--- a/docs/stacker/docs/compliance.md
+++ b/docs/stacker/docs/compliance.md
@@ -152,7 +152,7 @@ You can install and use Stackers with the [Opentrons Flex HEPA/UV Module](https:
 
 ## Flex, Stacker, and HEPA/UV Compatibility
 
-Any Flex with a serial number that includes **A10** or **A20** _requires_ a Stacker retrofit kit, even if you don't have the HEPA/UV module installed. Robots with serial numbers containing **A30** (or higher) are fully compatible with the Stacker; the retrofit kit is not required. The kit adds new firmware and hardware to your Flex which:
+Any Flex with a serial number version that includes **A10** or **A20** _requires_ a Stacker retrofit kit, even if you don't have the HEPA/UV module installed. Robots with serial number version **A30** (or higher) are fully compatible with the Stacker; the retrofit kit is not required. The kit adds new firmware and hardware to your Flex which:
 
 - Allows early model robots to recognize and communicate with the Staker.
 - Prevents the HEPA/UV module from operating if the Stacker is improperly installed.
@@ -164,9 +164,9 @@ The serial number can be found on the certification sticker on the back of each 
 !!!note
     The upgrade kit must be installed by an Opentrons field service technician only.
 
-Compare these serial number examples to the serial number on your robot to determine if it needs the Stacker retrofit kit installed.
+Compare these serial number versions to the serial number on your robot to determine if it needs the Stacker retrofit kit installed.
 
-| Serial number identifier | Example | Retrofit required |
+| Version | Example | Retrofit required |
 |----|----|----|
 | A10 | FLX**A10**20240201234 | Yes |
 | A20 | FLX**A20**20250321003 | Yes |


### PR DESCRIPTION
# Overview

Text for the Stacker upgrade kit is causing some confusion in the field. This change strengthens language in the Flex and Stacker manuals that indicates the upgrade kit is _required_ if a Flex has A10 or A20 in the serial number, with or without the HEPA/UV module.

Robots with **A30** in their serial numbers do not require this upgrade.

**Sandbox:**
- Stacker manual: https://sandbox.docs.opentrons.com/docs-stacker-retrofit-sn-revision/stacker/compliance/#flex-stacker-and-hepauv-compatibility

- Flex manual: https://sandbox.docs.opentrons.com/docs-stacker-retrofit-sn-revision/flex/modules/stacker/#module-compatibility

RTC-893

## Test Plan and Hands on Testing

Read the wordz for clarity and accuracy.

## Changelog

Revises text here:

- `flex/docs/modules/stacker.md#module-compatibility`
- `stacker/docs/compliance#flex-stacker-and-hepa/uv-compatibility`

This change will also update the [retrofit kit guide](https://docs.google.com/document/d/1UxfxRWObhTvgp34Y_7ZcCkdmS3bi65ohzewiHTC0QjY/edit?usp=sharing) with the more comprehensive text used by the Stacker manual after this PR is reviewed and approved.

## Review requests

Does this change make it clear that the retrofit kit is required for older model robots, even without the HEPA module?

## Risk assessment

Medium: can cause field service confusion.
