### PR TITLE
fix(protocol-designer): special-case when showing the tiprack lid sta…

### DIFF
--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupDetails.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupDetails.tsx
@@ -468,6 +468,7 @@ export function DeckSetupDetails(props: DeckSetupDetailsProps): JSX.Element {
           (amount, item) => amount + (activeDeckSetup.labware[item] ? 1 : 0),
           0
         )
+        const isTopLabware = labware.stack[0] === labware.id
         const slotPosition = getPositionFromSlotId(slot, deckDef)
         const slotBoundingBox = getAddressableAreaFromSlotId(
           slot,
@@ -480,6 +481,12 @@ export function DeckSetupDetails(props: DeckSetupDetailsProps): JSX.Element {
         const labwareIsAdapter =
           labware.def.metadata.displayCategory === 'adapter'
 
+        //  TODO: delete this special-case when the tiprackLid svg bug is fixed!!!!
+        const showDeckLabwareSetWithTiprackLid =
+          labware.def.parameters.loadName === 'opentrons_flex_tiprack_lid'
+            ? selectedZoomInSlot == null
+            : true
+
         return (
           <Fragment key={labware.id}>
             <LabwareOnDeck
@@ -487,7 +494,9 @@ export function DeckSetupDetails(props: DeckSetupDetailsProps): JSX.Element {
               y={slotPosition[1]}
               labwareOnDeck={labware}
             />
-            {labwareAmount > 1 ? (
+            {labwareAmount > 1 &&
+            isTopLabware &&
+            showDeckLabwareSetWithTiprackLid ? (
               <DeckLabelSet
                 deckLabels={[]}
                 x={slotPosition[0]}


### PR DESCRIPTION
…ck icon

closes AUTH-2445

# Overview

fixes a bug with showing duplicate stacking icons and then has to special-case the tiprack lid svg stacking icon since it shows up in the wrong spot due to the tprack lid svg bug

<img width="630" height="479" alt="Screenshot 2025-11-06 at 09 19 04" src="https://github.com/user-attachments/assets/617b2cec-ea85-4162-9999-b1540661cc5e" />

## Test Plan and Hands on Testing

see that there is no double stacking icon on a tiprack with a tiprack lid

## Changelog

show the deck labware stacking icon only once when the deck map is zoomed out

## Risk assessment

low