### PR TITLE
fix(api): Ensure the backend uses the ot_system_camera

### DIFF
--- a/api/src/opentrons/system/camera.py
+++ b/api/src/opentrons/system/camera.py
@@ -21,8 +21,7 @@ from opentrons.system import ffmpeg
 log = logging.getLogger(__name__)
 
 # Default System Cameras
-FLEX_EMBEDDED_CAMERA = "/dev/video2"
-OT2_CAMERA = "/dev/video0"
+DEFAULT_SYSTEM_CAMERA = "/dev/ot_system_camera"
 
 # Stream Globals
 DEFAULT_CONF_FILE = (
@@ -278,9 +277,7 @@ async def image_capture(
     robot_type: RobotType, parameters: ImageParameters
 ) -> bytes | CameraError:
     """Process an Image Capture request with a Camera utilizing a given set of parameters."""
-    camera = (
-        FLEX_EMBEDDED_CAMERA if ARCHITECTURE == SystemArchitecture.YOCTO else OT2_CAMERA
-    )
+    camera = DEFAULT_SYSTEM_CAMERA
 
     # We must always validate the camera exists
     if not os.path.exists(camera):

--- a/api/src/opentrons/system/ffmpeg.py
+++ b/api/src/opentrons/system/ffmpeg.py
@@ -45,6 +45,8 @@ async def ffmpeg_capture_image_bytes(
             "auto",
             "-video_size",
             f"{resolution[0]}x{resolution[1]}",
+            "-f",
+            "v4l2",
             "-i",
             f"{camera}",
             "-vf",

--- a/api/src/opentrons/system/ffmpeg.py
+++ b/api/src/opentrons/system/ffmpeg.py
@@ -66,6 +66,8 @@ async def ffmpeg_capture_image_bytes(
             "auto",
             "-video_size",
             f"{resolution[0]}x{resolution[1]}",
+            "-f",
+            "v4l2",
             "-i",
             f"{camera}",
             "-vf",


### PR DESCRIPTION
# Overview
We originally used hardcoded `/dev/videoN` devices for OT2 and Flex based on architecture. Now we will use the uniform `/dev/ot_system_camera` symlink across all platforms.

## Test Plan and Hands on Testing

- [x] Run a camera protocol on a Flex ensure all photos are taken without device errors.
- [x] Run a camera protocol on a OT-2 ensure all photos are taken without device errors.

## Changelog
Got rid of the platform-specific video device names.

## Review requests


## Risk assessment
Low