### PR TITLE
fix(app): copy change for camera tab in protocol setup

### DIFF
--- a/app/src/assets/localization/en/run_details.json
+++ b/app/src/assets/localization/en/run_details.json
@@ -121,7 +121,7 @@
   "protocol_completed": "Protocol completed",
   "protocol_end": "Protocol end",
   "protocol_files": "Protocol files",
-  "protocol_images_viewable": "Protocol images can be viewed once captured and downloaded when the run is complete.",
+  "protocol_images_viewable": "Images can be viewed immediately after capture and downloaded once the run is complete.",
   "protocol_paused_for": "Protocol paused for",
   "protocol_run_canceled": "Protocol run canceled",
   "protocol_run_complete": "Protocol run complete",

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunCamera/ImageGalleryContainer/__tests__/ImageGalleryContainer.test.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunCamera/ImageGalleryContainer/__tests__/ImageGalleryContainer.test.tsx
@@ -81,7 +81,7 @@ describe('ImageGalleryContainer', () => {
     screen.getByText('Image Gallery')
     screen.getByText('3 photos')
     screen.getByText(
-      'Protocol images can be viewed once captured and downloaded when the run is complete.'
+      'Images can be viewed immediately after capture and downloaded once the run is complete.'
     )
   })
 


### PR DESCRIPTION
# Overview

This PR is meant to make a copy change for the Opentrons app. We are addressing this bug here https://opentrons.atlassian.net/browse/RQA-4829.

## Test Plan and Hands on Testing

<img width="1027" height="797" alt="image" src="https://github.com/user-attachments/assets/b873f547-19da-4ef8-a99f-1fd279b41d68" />

## Changelog

1. Copy change for description copy under Image Gallery

## Review requests

Take a look and let me know if anything else is needed for this change! I changed both the copy in the dictionary as well as the unit test that tests the copy.

## Risk assessment

Low
