### PR TITLE
refactor(app): Update zipfile timestamp to reflect robot-server filenames

### DIFF
--- a/app/src/organisms/Desktop/Devices/HistoricalProtocolRunDrawer.tsx
+++ b/app/src/organisms/Desktop/Devices/HistoricalProtocolRunDrawer.tsx
@@ -390,9 +390,9 @@ function ImagesFileDataRow({
     robotType: robotType,
   })
   const { data: imagesZipFile, isLoading } = useAllRunImagesRaw(run.id)
-  const runTimestamp = format(new Date(run.createdAt), 'M/d/yy_HH:mm:ss')
+  const formattedRunTs = format(new Date(run.createdAt), 'yyyyMMdd-HHmmss')
   const buildImagesZipName = (): string =>
-    `${robotName}_${protocolName}_${runTimestamp}_${t('images')}.zip`
+    `${robotName}_${protocolName}_${formattedRunTs}_${t('images')}.zip`
 
   return (
     <Flex
@@ -415,7 +415,7 @@ function ImagesFileDataRow({
         </LegacyStyledText>
       </Flex>
       <Box width="33%">
-        <LegacyStyledText as="p">{runTimestamp}</LegacyStyledText>
+        <LegacyStyledText as="p">{formattedRunTs}</LegacyStyledText>
       </Box>
       <Box width="34%">
         <Link

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunCamera/ImageGalleryContainer/GalleryContainerOverflowMenu.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunCamera/ImageGalleryContainer/GalleryContainerOverflowMenu.tsx
@@ -50,7 +50,7 @@ export function GalleryContainerOverflowMenu({
     source: SOURCE_RUN_RECORD,
     robotType,
   })
-  const formattedRunTs = format(new Date(runTimestamp), 'M/d/yy_HH:mm:ss')
+  const formattedRunTs = format(new Date(runTimestamp), 'yyyyMMdd-HHmmss')
   const buildImagesZipName = (): string =>
     `${robotName}_${protocolName}_${formattedRunTs}_${t('images')}.zip`
 

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunCamera/ImageGalleryContainer/GalleryContainerOverflowMenu.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunCamera/ImageGalleryContainer/GalleryContainerOverflowMenu.tsx
@@ -50,7 +50,15 @@ export function GalleryContainerOverflowMenu({
     source: SOURCE_RUN_RECORD,
     robotType,
   })
-  const formattedRunTs = format(new Date(runTimestamp), 'yyyyMMdd-HHmmss')
+  const formattedRunTs = (() => {
+    try {
+      if (runTimestamp == null) return ''
+      return format(new Date(runTimestamp), 'yyyyMMdd-HHmmss')
+    } catch (error) {
+      console.warn('Invalid timestamp:', runTimestamp)
+      return ''
+    }
+  })()
   const buildImagesZipName = (): string =>
     `${robotName}_${protocolName}_${formattedRunTs}_${t('images')}.zip`
 

--- a/app/src/resources/dataFiles/useImageInfo.ts
+++ b/app/src/resources/dataFiles/useImageInfo.ts
@@ -49,13 +49,26 @@ export function useImageInfo(runId: string): UseImagesInfoResult {
   )
   const items = useMemo(() => {
     if (data == null) return []
-    return data.data.map(img => ({
-      imageId: img.id,
-      filename: img.filename,
-      stepCommandId: img.commandId ?? '',
-      previousStepCommandId: img.prevCommandId ?? '',
-      timestamp: format(new Date(String(img.createdAt)), 'M/d/yy HH:mm:ss'),
-    }))
+
+    return data.data.map(img => {
+      const timestamp = (() => {
+        try {
+          if (img?.createdAt == null) return ''
+          return format(new Date(String(img.createdAt)), 'M/d/yy HH:mm:ss')
+        } catch (error) {
+          console.warn('Invalid timestamp:', img?.createdAt)
+          return ''
+        }
+      })()
+
+      return {
+        imageId: img.id,
+        filename: img.filename,
+        stepCommandId: img.commandId ?? '',
+        previousStepCommandId: img.prevCommandId ?? '',
+        timestamp,
+      }
+    })
   }, [data])
   return { items, protocolAnalysis, isLoadingImages, allRunDefs }
 }


### PR DESCRIPTION
# Overview

On the server, we've recently updated the timestamps so they are more compatible with all OSs. We just want to reflect the same filenaming convention in the app.

<img width="1002" height="760" alt="Screenshot 2025-11-06 at 4 39 07 PM" src="https://github.com/user-attachments/assets/b85becb1-3fc5-46f8-a094-df22fd483170" />


## Test Plan and Hands on Testing

See image

## Changelog

Updated zipfile naming convention to match the way we save data files on the server.

## Risk assessment

very low