### PR TITLE
fix(ci, slack): fix the notification, and don't fail

### DIFF
--- a/.github/actions/simple-build-alert/action.yml
+++ b/.github/actions/simple-build-alert/action.yml
@@ -38,6 +38,7 @@ runs:
     - name: 'Send Slack Alert'
       uses: slackapi/slack-github-action@v2.1.1
       with:
+        webhook-type: 'incoming-webhook'
         payload: |
           {
             "channel": "${{ steps.channel-config.outputs.channel }}",

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -388,6 +388,7 @@ jobs:
       - name: 'slack notify internal-release'
         uses: slackapi/slack-github-action@v1.14.0
         if: contains(fromJSON(needs.determine-build-type.outputs.variants), 'internal-release')
+        continue-on-error: true
         with:
           payload: '{"branch_or_tag":"${{ github.ref_name }}","build_type":"${{ needs.determine-build-type.outputs.type }}", "gh_linkback":"https://github.com/Opentrons/opentrons/tree/${{ github.ref_name }}", "windows_build":"${{ env._ACCESS_URL }}/${{steps.names.outputs.windows-internal-release}}", "mac_build":"${{ env._ACCESS_URL }}/${{steps.names.outputs.mac-internal-release}}", "linux_build":"${{ env._ACCESS_URL }}/${{steps.names.outputs.linux-internal-release}}"}'
         env:
@@ -396,6 +397,7 @@ jobs:
       - name: 'slack notify release'
         uses: slackapi/slack-github-action@v1.14.0
         if: contains(fromJSON(needs.determine-build-type.outputs.variants), 'release')
+        continue-on-error: true
         with:
           payload: '{"branch_or_tag":"${{ github.ref_name }}","build_type":"${{ needs.determine-build-type.outputs.type }}", "gh_linkback":"https://github.com/Opentrons/opentrons/tree/${{ github.ref_name }}", "windows_build":"${{ env._ACCESS_URL }}/${{steps.names.outputs.windows-release}}", "mac_build":"${{ env._ACCESS_URL }}/${{steps.names.outputs.mac-release}}", "linux_build":"${{ env._ACCESS_URL }}/${{steps.names.outputs.linux-release}}"}'
         env:
@@ -451,6 +453,7 @@ jobs:
         uses: actions/checkout@v4
       - name: 'Send success alert'
         uses: ./.github/actions/simple-build-alert
+        continue-on-error: true
         with:
           status: 'success'
           workflow_name: 'App test, build, and deploy'
@@ -494,6 +497,7 @@ jobs:
 
       - name: 'Send failure alert'
         uses: ./.github/actions/simple-build-alert
+        continue-on-error: true
         with:
           status: 'failure'
           workflow_name: 'App test, build, and deploy'
@@ -517,6 +521,7 @@ jobs:
         uses: actions/checkout@v4
       - name: 'Send cancelled alert'
         uses: ./.github/actions/simple-build-alert
+        continue-on-error: true
         with:
           status: 'cancelled'
           workflow_name: 'App test, build, and deploy'


### PR DESCRIPTION
# Fix Slack notifications to prevent workflow failures

Fixes two issues with Slack notifications:

1. **Added missing `webhook-type` input** to `simple-build-alert` action (required by `slackapi/slack-github-action@v2.1.1`)

2. **Made all Slack notifications non-blocking** by adding `continue-on-error: true` to 5 notification steps in `app-test-build-deploy.yaml`

Slack notification failures will no longer cause workflow failures, while still logging warnings for debugging.