### PR TITLE
fix(api): Ensure live stream camera default migrates to new default

### DIFF
--- a/api/src/opentrons/system/camera.py
+++ b/api/src/opentrons/system/camera.py
@@ -21,8 +21,7 @@ from opentrons.system import ffmpeg
 log = logging.getLogger(__name__)
 
 # Default System Cameras
-FLEX_EMBEDDED_CAMERA = "/dev/video2"
-OT2_CAMERA = "/dev/video0"
+DEFAULT_SYSTEM_CAMERA = "/dev/ot_system_camera"
 
 # Stream Globals
 DEFAULT_CONF_FILE = (
@@ -278,9 +277,7 @@ async def image_capture(
     robot_type: RobotType, parameters: ImageParameters
 ) -> bytes | CameraError:
     """Process an Image Capture request with a Camera utilizing a given set of parameters."""
-    camera = (
-        FLEX_EMBEDDED_CAMERA if ARCHITECTURE == SystemArchitecture.YOCTO else OT2_CAMERA
-    )
+    camera = DEFAULT_SYSTEM_CAMERA
 
     # We must always validate the camera exists
     if not os.path.exists(camera):

--- a/api/src/opentrons/system/camera.py
+++ b/api/src/opentrons/system/camera.py
@@ -245,6 +245,10 @@ def parse_stream_configuration_file_data(data: bytes) -> Dict[str, str] | None:
         )
         # We don't want to write bad or incomplete data to the file
         return None
+
+    # Migrate old camera default file data to new uniform default
+    if contents[StreamConfigurationKeys.SOURCE] == "NONE":
+        contents[StreamConfigurationKeys.SOURCE] = DEFAULT_SYSTEM_CAMERA
     return contents
 
 

--- a/api/src/opentrons/system/ffmpeg.py
+++ b/api/src/opentrons/system/ffmpeg.py
@@ -45,6 +45,8 @@ async def ffmpeg_capture_image_bytes(
             "auto",
             "-video_size",
             f"{resolution[0]}x{resolution[1]}",
+            "-f",
+            "v4l2",
             "-i",
             f"{camera}",
             "-vf",

--- a/api/src/opentrons/system/ffmpeg.py
+++ b/api/src/opentrons/system/ffmpeg.py
@@ -66,6 +66,8 @@ async def ffmpeg_capture_image_bytes(
             "auto",
             "-video_size",
             f"{resolution[0]}x{resolution[1]}",
+            "-f",
+            "v4l2",
             "-i",
             f"{camera}",
             "-vf",


### PR DESCRIPTION
# Overview
Originally the live stream default file we copied if the live stream configuration didn't exist had the camera set to "NONE". Now, thanks to some oe-core changes [here](https://github.com/Opentrons/oe-core/pull/236) that is no longer the case. For any robot that made a copy of this file with out-of date data we should clean up the mutable configuration file.

## Test Plan and Hands on Testing
Run this on a robot with a mutable live stream configuraiton file under the `/data` folder and ensure it writes with the new default.

## Changelog


## Review requests
Do we want to do this, or do we want any robot that had alphas to just delete their mutable file? We won't have this kind of problem on any new robots in the field that are going to 8.8 for the first time, only bots that ran alphas.

## Risk assessment
Low