### PR TITLE
fix(protocol-designer): filter incompatible lid parents in moveLabware

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLabwareTools/LabwareLocationField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLabwareTools/LabwareLocationField.tsx
@@ -18,6 +18,7 @@ import {
 import {
   getAdditionalEquipmentEntities,
   getLabwareEntities,
+  getModuleEntities,
 } from '/protocol-designer/step-forms/selectors'
 import {
   getDeckSetupForActiveItem,
@@ -45,6 +46,7 @@ export function LabwareLocationField(
   const { labware: deckSetupLabware } = useSelector(getDeckSetupForActiveItem)
   const dispatch = useDispatch()
   const labwareEntities = useSelector(getLabwareEntities)
+  const moduleEntities = useSelector(getModuleEntities)
   const additionalEquipmentEntities = useSelector(
     getAdditionalEquipmentEntities
   )
@@ -94,7 +96,29 @@ export function LabwareLocationField(
       )
   }
 
-  if (!isLabwareALid) {
+  // check lid-compatible labware and modules
+  if (isLabwareALid) {
+    const def = labwareEntities[labware]?.def
+    const compatibleParentLoadNames = new Set([
+      ...(def?.compatibleParentLabware ?? []),
+      ...Object.keys(def?.stackingOffsetWithLabware ?? {}),
+      ...Object.keys(def?.stackingOffsetWithModule ?? {}),
+    ])
+    unoccupiedLabwareLocationsOptions =
+      unoccupiedLabwareLocationsOptions.filter(({ value, name }) => {
+        let isCompatible = true
+        if (value in moduleEntities) {
+          isCompatible = compatibleParentLoadNames.has(
+            moduleEntities[value].model
+          )
+        } else if (value in labwareEntities) {
+          isCompatible = compatibleParentLoadNames.has(
+            labwareEntities[value].def.parameters.loadName
+          )
+        }
+        return name !== 'Trash bin' && isCompatible
+      })
+  } else {
     unoccupiedLabwareLocationsOptions =
       unoccupiedLabwareLocationsOptions.filter(
         option => option.name !== 'Trash bin'


### PR DESCRIPTION
# Overview

Filter out incompatibble lid move locations in LabwareLocationField. Potential labware or module move targets must be specified in the lid's definition under `stackingOffsetWithLabware`, `stackingOffsetWithModule`, or `comaptibleParentLabware` properties.

Closes RQA-4718

## Test Plan and Hands on Testing

- import protocol attached to the ticket
- open move step with the lid as a target
- open new location dropdown and verify that only compatible labware, empty slots, and waste chute are included

## Changelog

- filter labware or module move target for lid movements based on lid definition

## Review requests

QUESTION: should we perform this check for all labware, or just lids?

see test plan

## Risk assessment

lowish. does restrict lid movement