### PR TITLE
fix(app, app-shell): Refresh secondary window stream on new run

### DIFF
--- a/app-shell/src/secondary-windows/camera-stream/index.ts
+++ b/app-shell/src/secondary-windows/camera-stream/index.ts
@@ -14,7 +14,6 @@ interface CameraStreamDetails extends SecondaryWindowDetails {
 }
 
 interface OpenCameraStreamParams {
-  runId: string
   windowTitle: string
   robotIp: string
   robotName: string
@@ -34,19 +33,18 @@ function getWindowIdCameraStream(robotIp: string): string {
   return `camera-stream-${robotIp}`
 }
 
-const STREAM_URL = (robotName: string, runId: string): string =>
+const STREAM_URL = (robotName: string): string =>
   `${
     SECONDARY_WINDOW_CONFIG.url.protocol
   }//${SECONDARY_WINDOW_URL_PATH}#/devices/${encodeURIComponent(
     robotName
-  )}/camera-stream?runId=${encodeURIComponent(runId)}`
+  )}/camera-stream`
 
 function createCameraStreamUi({
   log,
   robotName,
   windowTitle,
   robotIp,
-  runId,
 }: OpenCameraStreamParams): BrowserWindow {
   log.debug('Creating camera stream window', {
     robotIp,
@@ -63,9 +61,9 @@ function createCameraStreamUi({
     }
   )
 
-  log.info(`Loading camera stream from ${STREAM_URL(robotName, runId)}`)
+  log.info(`Loading camera stream from ${STREAM_URL(robotName)}`)
   // eslint-disable-next-line @typescript-eslint/no-floating-promises
-  cameraStreamWindow.loadURL(STREAM_URL(robotName, runId), {
+  cameraStreamWindow.loadURL(STREAM_URL(robotName), {
     extraHeaders: 'pragma: no-cache\n',
   })
 

--- a/app-shell/src/secondary-windows/index.ts
+++ b/app-shell/src/secondary-windows/index.ts
@@ -62,7 +62,6 @@ function detailsByActionType(action: Action): SecondaryWindowDetails | null {
   switch (action.type) {
     case CAMERA_STREAM_OPEN:
       return openCameraStream({
-        runId: action.payload.runId,
         windowTitle: action.payload.windowTitle,
         robotIp: action.payload.hostname,
         robotName: action.payload.robotName,

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunCamera/LaunchLivestreamBtn.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunCamera/LaunchLivestreamBtn.tsx
@@ -35,7 +35,6 @@ export function LaunchLivestreamBtn({
       cameraStreamOpenAction(
         host?.hostname ?? 'UNKNOWN',
         host?.robotName ?? 'UNKNOWN',
-        runId,
         t('branded:livestream_window_title') as string
       )
     )

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunCamera/__tests__/LaunchLivestreamBtn.test.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunCamera/__tests__/LaunchLivestreamBtn.test.tsx
@@ -59,7 +59,6 @@ describe('LaunchLivestreamBtn', () => {
       payload: {
         hostname: 'test-hostname',
         robotName: 'test-robot',
-        runId: 'MOCK-RUN-ID',
         windowTitle: 'Opentrons Live Camera',
       },
       meta: { shell: true },

--- a/app/src/pages/Desktop/LivestreamViewer/hooks/useHlsVideo.ts
+++ b/app/src/pages/Desktop/LivestreamViewer/hooks/useHlsVideo.ts
@@ -6,7 +6,7 @@ import { useHost } from '@opentrons/react-api-client'
 import { isTerminalRunStatus } from '/app/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/utils'
 
 import type { RefObject } from 'react'
-import type { RunStatus } from '@opentrons/api-client'
+import type { CameraData, RunStatus } from '@opentrons/api-client'
 
 // TODO(jh, 09-05-25): /GET this from the /stream endpoint eventually.
 const STREAM_URL = (robotIp: string): string =>
@@ -19,7 +19,10 @@ export interface UseHlsVideoResult {
   videoError: string | null
 }
 
-export function useHlsVideo(runStatus: RunStatus | null): UseHlsVideoResult {
+export function useHlsVideo(
+  runStatus: RunStatus | null,
+  cameraData: CameraData | null
+): UseHlsVideoResult {
   const host = useHost()
   const videoRef = useRef<HTMLVideoElement>(null)
   const hlsRef = useRef<Hls | null>(null)
@@ -28,6 +31,12 @@ export function useHlsVideo(runStatus: RunStatus | null): UseHlsVideoResult {
   const retryTimeoutRef = useRef<NodeJS.Timeout | null>(null)
 
   const setupHls = useRef<() => void>()
+
+  const setLivestreamError = (msg: string): void => {
+    if (cameraData?.liveStreamEnabled) {
+      setError(msg)
+    }
+  }
 
   useEffect(() => {
     if (error) {
@@ -44,7 +53,7 @@ export function useHlsVideo(runStatus: RunStatus | null): UseHlsVideoResult {
 
     setupHls.current = () => {
       if (!Hls.isSupported()) {
-        setError('HLS streaming not supported in this browser.')
+        setLivestreamError('HLS streaming not supported in this browser.')
         return
       }
 
@@ -76,7 +85,9 @@ export function useHlsVideo(runStatus: RunStatus | null): UseHlsVideoResult {
         setError(null)
         video.play().catch(e => {
           console.error('Auto-play failed:', e)
-          setError('Auto-play failed. Please close and reopen the stream.')
+          setLivestreamError(
+            'Auto-play failed. Please close and reopen the stream.'
+          )
         })
       })
 
@@ -84,7 +95,8 @@ export function useHlsVideo(runStatus: RunStatus | null): UseHlsVideoResult {
         // `fatal` prevents refetching over-aggressively, ex, when the buffer is temporarily depleted.
         if (data.fatal && !isTerminalRunStatus(runStatus)) {
           retryCountRef.current++
-          setError(
+
+          setLivestreamError(
             `Service unavailable. Retrying (${retryCountRef.current})...`
           )
 
@@ -95,7 +107,7 @@ export function useHlsVideo(runStatus: RunStatus | null): UseHlsVideoResult {
       })
 
       const handleVideoError = (e: ErrorEvent): void => {
-        setError(`Video playback error: ${e.message}`)
+        setLivestreamError(`Video playback error: ${e.message}`)
       }
 
       video.addEventListener('error', handleVideoError)

--- a/app/src/pages/Desktop/LivestreamViewer/index.tsx
+++ b/app/src/pages/Desktop/LivestreamViewer/index.tsx
@@ -1,5 +1,5 @@
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useSearchParams } from 'react-router-dom'
 
 import { Chip } from '@opentrons/components'
 
@@ -8,25 +8,39 @@ import {
   LivestreamInfoScreen,
   useLivestreamInfoScreen,
 } from '/app/pages/Desktop/LivestreamViewer/LivestreamInfoScreen'
-import { useNotifyRunQuery } from '/app/resources/runs'
+import { useCurrentRunId, useNotifyRunQuery } from '/app/resources/runs'
 
 import styles from './livestream.module.css'
 
 const RUN_POLLING_INTERVAL_MS = 5000
 
 export function LivestreamViewer(): JSX.Element {
-  const [searchParams] = useSearchParams()
-  const runId = searchParams.get('runId') ?? ''
-  const { data: runData, isLoading: isRunLoading } = useNotifyRunQuery(runId, {
+  // We make UI affordances when a run has ended, even if it is un-currented.
+  // The livestream viewer makes the assumption that it will not *initially* render
+  // for a run that is already historical.
+  const [retainedRunId, setRetainedRunId] = useState<string | null>(null)
+  const currentRunId = useCurrentRunId({
     refetchInterval: RUN_POLLING_INTERVAL_MS,
   })
+
+  if (currentRunId != null && currentRunId !== retainedRunId) {
+    setRetainedRunId(currentRunId)
+  }
+
+  const { data: runData, isLoading: isRunLoading } = useNotifyRunQuery(
+    retainedRunId,
+    {
+      refetchInterval: RUN_POLLING_INTERVAL_MS,
+    }
+  )
+  const isCurrentRunLoading = retainedRunId == null || isRunLoading
   const runStatus = runData?.data.status ?? null
   const cameraData = runData?.data.cameraSettings ?? null
-  const { videoRef, videoError } = useHlsVideo(runStatus)
+  const { videoRef, videoError } = useHlsVideo(runStatus, cameraData)
   const infoScreenType = useLivestreamInfoScreen(
     runStatus,
     cameraData,
-    isRunLoading,
+    isCurrentRunLoading,
     videoError
   )
 

--- a/app/src/redux/shell/actions.ts
+++ b/app/src/redux/shell/actions.ts
@@ -135,11 +135,10 @@ export const notifySubscribeAction = (
 export const cameraStreamOpenAction = (
   hostname: string,
   robotName: string,
-  runId: string,
   windowTitle: string
 ): CameraStreamOpenAction => ({
   type: CAMERA_STREAM_OPEN,
-  payload: { hostname, robotName, runId, windowTitle },
+  payload: { hostname, robotName, windowTitle },
   meta: { shell: true },
 })
 

--- a/app/src/redux/shell/types.ts
+++ b/app/src/redux/shell/types.ts
@@ -184,7 +184,6 @@ export interface CameraStreamOpenAction {
   payload: {
     hostname: string
     robotName: string
-    runId: string
     windowTitle: string
   }
   meta: { shell: true }


### PR DESCRIPTION
# Overview

Currently, we inject the `runId` into the secondary window, and that `runId` serves as the basis for determining whether or not we should render the stream. However, if a user keeps the secondary window open when creating a new run on the same robot, the stream still reflects the old run.

To fix, we check if this robot has a current run, and use that as the basis for rendering the livestream. All of this works as expected largely because we block the "show livestream" button for historical runs.

https://github.com/user-attachments/assets/1e58175d-6dc9-4cde-a4e3-c59d31fbeef2

## Test Plan and Hands on Testing

See video

## Changelog

- The livestream window properly reloads on the start of a new run.


## Risk assessment

low
