### PR TITLE
fix(app): Fix "robot is busy" banners

### DIFF
--- a/app/src/assets/localization/en/device_details.json
+++ b/app/src/assets/localization/en/device_details.json
@@ -168,7 +168,7 @@
   "reset_estop": "Reset E-stop",
   "resume_operation": "Resume operation",
   "right": "right",
-  "robot_control_not_available": "Some robot controls are not available when run is in progress",
+  "robot_control_not_available": "Some robot controls are not available when run is in progress or robot is busy",
   "robot_initializing": "Initializing...",
   "run": "Run",
   "run_a_protocol": "Run a protocol",

--- a/app/src/assets/localization/en/device_settings.json
+++ b/app/src/assets/localization/en/device_settings.json
@@ -347,7 +347,7 @@
   "slider_value": "{{value}}%",
   "software_is_up_to_date": "Your software is already up to date!",
   "software_update_error": "Software update error",
-  "some_robot_controls_are_not_available": "Some robot controls are not available when run is in progress",
+  "some_robot_controls_are_not_available": "Some robot controls are not available when run is in progress or robot is busy",
   "ssh_public_keys": "SSH public keys",
   "subnet_mask": "Subnet Mask",
   "successfully_connected": "Successfully connected!",

--- a/app/src/assets/localization/en/shared.json
+++ b/app/src/assets/localization/en/shared.json
@@ -27,7 +27,7 @@
   "disabled_cannot_connect": "Cannot connect to robot",
   "disabled_connect_to_robot": "Connect to robot to control",
   "disabled_no_pipette_attached": "Attach a pipette to proceed",
-  "disabled_protocol_is_running": "Protocol is running",
+  "disabled_robot_is_busy": "Robot is busy",
   "dont_show_me_again": "Don’t show me again",
   "drag_and_drop": "Drag and drop or <a>browse</a> your files",
   "empty": "empty",

--- a/app/src/organisms/Desktop/Devices/GripperCard/__tests__/GripperCard.test.tsx
+++ b/app/src/organisms/Desktop/Devices/GripperCard/__tests__/GripperCard.test.tsx
@@ -39,7 +39,7 @@ describe('GripperCard', () => {
         },
       } as GripperData,
       isCalibrated: true,
-      isRunActive: false,
+      isRobotBusy: false,
       isEstopNotDisengaged: false,
     }
     vi.mocked(GripperWizardFlows).mockReturnValue(<>wizard flow launched</>)
@@ -79,7 +79,7 @@ describe('GripperCard', () => {
         },
       } as GripperData,
       isCalibrated: false,
-      isRunActive: false,
+      isRobotBusy: false,
       isEstopNotDisengaged: false,
     }
 
@@ -102,7 +102,7 @@ describe('GripperCard', () => {
         },
       } as GripperData,
       isCalibrated: false,
-      isRunActive: false,
+      isRobotBusy: false,
       isEstopNotDisengaged: true,
     }
 
@@ -145,7 +145,7 @@ describe('GripperCard', () => {
     props = {
       attachedGripper: null,
       isCalibrated: false,
-      isRunActive: false,
+      isRobotBusy: false,
       isEstopNotDisengaged: false,
     }
     render(props)
@@ -163,7 +163,7 @@ describe('GripperCard', () => {
         ok: false,
       } as any,
       isCalibrated: false,
-      isRunActive: false,
+      isRobotBusy: false,
       isEstopNotDisengaged: false,
     }
     render(props)
@@ -182,7 +182,7 @@ describe('GripperCard', () => {
         ok: false,
       } as any,
       isCalibrated: true,
-      isRunActive: false,
+      isRobotBusy: false,
       isEstopNotDisengaged: false,
     }
     render(props)

--- a/app/src/organisms/Desktop/Devices/GripperCard/index.tsx
+++ b/app/src/organisms/Desktop/Devices/GripperCard/index.tsx
@@ -20,7 +20,7 @@ import type { GripperWizardFlowType } from '/app/organisms/GripperWizardFlows/ty
 interface GripperCardProps {
   attachedGripper: GripperData | BadGripper | null
   isCalibrated: boolean
-  isRunActive: boolean
+  isRobotBusy: boolean
   isEstopNotDisengaged: boolean
 }
 
@@ -39,7 +39,7 @@ const POLL_DURATION_MS = 5000
 export function GripperCard({
   attachedGripper,
   isCalibrated,
-  isRunActive,
+  isRobotBusy,
   isEstopNotDisengaged,
 }: GripperCardProps): JSX.Element {
   const { t, i18n } = useTranslation(['device_details', 'shared'])
@@ -89,7 +89,7 @@ export function GripperCard({
       ? [
           {
             label: t('attach_gripper'),
-            disabled: attachedGripper != null || isRunActive,
+            disabled: attachedGripper != null || isRobotBusy,
             onClick: handleAttach,
           },
         ]
@@ -99,12 +99,12 @@ export function GripperCard({
               attachedGripper.data.calibratedOffset?.last_modified != null
                 ? t('recalibrate_gripper')
                 : t('calibrate_gripper'),
-            disabled: attachedGripper == null || isRunActive,
+            disabled: attachedGripper == null || isRobotBusy,
             onClick: handleCalibrate,
           },
           {
             label: t('detach_gripper'),
-            disabled: attachedGripper == null || isRunActive,
+            disabled: attachedGripper == null || isRobotBusy,
             onClick: handleDetach,
           },
           {

--- a/app/src/organisms/Desktop/Devices/InstrumentsAndModules.tsx
+++ b/app/src/organisms/Desktop/Devices/InstrumentsAndModules.tsx
@@ -24,7 +24,6 @@ import { ModuleCard } from '/app/organisms/ModuleCard'
 import { useModuleApiRequests } from '/app/organisms/ModuleCard/utils'
 import { useIsFlex } from '/app/redux-resources/robots'
 import { useIsEstopNotDisengaged } from '/app/resources/devices/hooks/useIsEstopNotDisengaged'
-import { useCurrentRunId, useRunStatuses } from '/app/resources/runs'
 import { getShowPipetteCalibrationWarning } from '/app/transformations/instruments'
 
 import { GripperCard } from './GripperCard'
@@ -43,11 +42,13 @@ const EQUIPMENT_POLL_MS = 5000
 interface InstrumentsAndModulesProps {
   robotName: string
   isRobotViewable: boolean
+  isRobotBusy: boolean
 }
 
 export function InstrumentsAndModules({
   robotName,
   isRobotViewable,
+  isRobotBusy,
 }: InstrumentsAndModulesProps): JSX.Element | null {
   const { t } = useTranslation(['device_details', 'shared'])
   const isFlex = useIsFlex(robotName)
@@ -58,8 +59,6 @@ export function InstrumentsAndModules({
       enabled: !isFlex,
     }
   )?.data ?? { left: undefined, right: undefined }
-  const currentRunId = useCurrentRunId()
-  const { isRunTerminal, isRunRunning } = useRunStatuses()
   const isEstopNotDisengaged = useIsEstopNotDisengaged(robotName)
   const [getLatestRequestId, handleModuleApiRequests] = useModuleApiRequests()
 
@@ -141,7 +140,7 @@ export function InstrumentsAndModules({
         width="100%"
         flexDirection={DIRECTION_COLUMN}
       >
-        {currentRunId != null && !isRunTerminal && (
+        {isRobotBusy && (
           <Flex
             paddingBottom={SPACING.spacing16}
             flexDirection={DIRECTION_COLUMN}
@@ -153,7 +152,7 @@ export function InstrumentsAndModules({
         )}
         {isRobotViewable &&
         getShowPipetteCalibrationWarning(attachedInstruments) &&
-        (isRunTerminal || currentRunId == null) ? (
+        !isRobotBusy ? (
           <Flex paddingBottom={SPACING.spacing16} width="100%">
             <PipetteRecalibrationWarning />
           </Flex>
@@ -176,7 +175,7 @@ export function InstrumentsAndModules({
                   }
                   mount={LEFT}
                   robotName={robotName}
-                  isRunActive={currentRunId != null && isRunRunning}
+                  isRobotBusy={isRobotBusy}
                   isEstopNotDisengaged={isEstopNotDisengaged}
                 />
               ) : (
@@ -191,7 +190,7 @@ export function InstrumentsAndModules({
                         : null
                     }
                     mount={LEFT}
-                    isRunActive={currentRunId != null && isRunRunning}
+                    isRobotBusy={isRobotBusy}
                     isEstopNotDisengaged={isEstopNotDisengaged}
                   />
                   <GripperCard
@@ -201,7 +200,7 @@ export function InstrumentsAndModules({
                       attachedGripper?.data?.calibratedOffset?.last_modified !=
                         null
                     }
-                    isRunActive={currentRunId != null && isRunRunning}
+                    isRobotBusy={isRobotBusy}
                     isEstopNotDisengaged={isEstopNotDisengaged}
                   />
                 </>
@@ -238,7 +237,7 @@ export function InstrumentsAndModules({
                   }
                   mount={RIGHT}
                   robotName={robotName}
-                  isRunActive={currentRunId != null && isRunRunning}
+                  isRobotBusy={isRobotBusy}
                   isEstopNotDisengaged={isEstopNotDisengaged}
                 />
               ) : null}
@@ -253,7 +252,7 @@ export function InstrumentsAndModules({
                       : null
                   }
                   mount={RIGHT}
-                  isRunActive={currentRunId != null && isRunRunning}
+                  isRobotBusy={isRobotBusy}
                   isEstopNotDisengaged={isEstopNotDisengaged}
                 />
               ) : null}

--- a/app/src/organisms/Desktop/Devices/Peripherals/CameraCard.tsx
+++ b/app/src/organisms/Desktop/Devices/Peripherals/CameraCard.tsx
@@ -24,18 +24,19 @@ import {
 } from '/app/redux-resources/analytics/'
 import { useRobotType } from '/app/redux-resources/robots'
 import { useFeatureFlag } from '/app/redux/config'
-import { useCurrentRunId } from '/app/resources/runs'
 
 import styles from './inputdevices.module.css'
 
 export interface CameraCardProps {
   isFlex: boolean
   robotName: string
+  isRobotBusy: boolean
 }
 
 export function CameraCard({
   isFlex,
   robotName,
+  isRobotBusy,
 }: CameraCardProps): JSX.Element {
   const { t } = useTranslation('device_details')
   const { handleOverflowClick, showOverflowMenu, setShowOverflowMenu } =
@@ -47,9 +48,7 @@ export function CameraCard({
     return isFlex ? systemCameraFlex : systemCameraOT2
   }
 
-  const runId = useCurrentRunId()
   const robotType = useRobotType(robotName)
-  const doesRunExist = runId != null
 
   const cardOverflowWrapperRef = useOnClickOutside<HTMLDivElement>({
     onClickOutside: () => {
@@ -113,7 +112,7 @@ export function CameraCard({
         <OverflowBtn
           aria-label="overflow"
           onClick={handleOverflowClick}
-          disabled={doesRunExist}
+          disabled={isRobotBusy}
         />
       </div>
       {showOverflowMenu && (

--- a/app/src/organisms/Desktop/Devices/Peripherals/__tests__/CameraCard.test.tsx
+++ b/app/src/organisms/Desktop/Devices/Peripherals/__tests__/CameraCard.test.tsx
@@ -3,14 +3,11 @@ import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { RUN_STATUS_IDLE, RUN_STATUS_RUNNING } from '@opentrons/api-client'
-
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
 import { useCameraUsageSettings } from '/app/local-resources/images/hooks/useCameraUsageSettings'
 import { CameraControls } from '/app/organisms/Desktop/Camera/CameraControls'
 import { useFeatureFlag } from '/app/redux/config'
-import { useCurrentRunId, useNotifyRunQuery } from '/app/resources/runs'
 
 import { CameraCard } from '../CameraCard'
 
@@ -19,7 +16,6 @@ import type { CameraCardProps } from '../CameraCard'
 
 vi.mock('/app/organisms/Desktop/Camera/CameraControls')
 vi.mock('/app/local-resources/images/hooks/useCameraUsageSettings')
-vi.mock('/app/resources/runs')
 vi.mock('/app/redux/config')
 vi.mock('/app/redux/discovery/selectors')
 
@@ -51,13 +47,10 @@ describe('CameraCard', () => {
     mockProps = {
       isFlex: false,
       robotName: 'test-robot',
+      isRobotBusy: false,
     }
     mockToggleEnabled = vi.fn()
     vi.mocked(CameraControls).mockReturnValue(<div>MOCK_CAMERA_CONTROLS</div>)
-    vi.mocked(useCurrentRunId).mockReturnValue(null)
-    vi.mocked(useNotifyRunQuery).mockReturnValue({
-      data: { data: { status: RUN_STATUS_IDLE } },
-    } as any)
     vi.mocked(useCameraUsageSettings).mockReturnValue({
       isCameraEnabled: true,
       toggleCameraEnabled: mockToggleEnabled,
@@ -109,12 +102,7 @@ describe('CameraCard', () => {
   })
 
   it('overflow button is disabled when run exists and is not idle', () => {
-    vi.mocked(useCurrentRunId).mockReturnValue('test-run-id')
-    vi.mocked(useNotifyRunQuery).mockReturnValue({
-      data: { data: { status: RUN_STATUS_RUNNING } },
-    } as any)
-
-    render(mockProps)
+    render({ ...mockProps, isRobotBusy: true })
 
     const overflowButton = screen.getByLabelText('overflow')
     expect(overflowButton).toBeDisabled()

--- a/app/src/organisms/Desktop/Devices/Peripherals/__tests__/Peripherals.test.tsx
+++ b/app/src/organisms/Desktop/Devices/Peripherals/__tests__/Peripherals.test.tsx
@@ -24,6 +24,7 @@ describe('Peripherals', () => {
     mockProps = {
       isFlex: false,
       robotName: 'test-otie',
+      isRobotBusy: false,
     }
     vi.mocked(CameraCard).mockReturnValue(<div>MOCK_CAMERA_CARD</div>)
   })
@@ -42,6 +43,7 @@ describe('Peripherals', () => {
       {
         isFlex: false,
         robotName: 'test-otie',
+        isRobotBusy: false,
       },
       {}
     )
@@ -60,6 +62,7 @@ describe('Peripherals', () => {
       {
         isFlex: true,
         robotName: 'test-flex',
+        isRobotBusy: false,
       },
       {}
     )

--- a/app/src/organisms/Desktop/Devices/Peripherals/index.tsx
+++ b/app/src/organisms/Desktop/Devices/Peripherals/index.tsx
@@ -5,14 +5,14 @@ import { StyledText } from '@opentrons/components'
 import { CameraCard } from './CameraCard'
 import styles from './inputdevices.module.css'
 
-export interface PeripheralsProps {
-  isFlex: boolean
-  robotName: string
-}
+import type { CameraCardProps } from './CameraCard'
+
+export type PeripheralsProps = CameraCardProps
 
 export function Peripherals({
   isFlex,
   robotName,
+  isRobotBusy,
 }: PeripheralsProps): JSX.Element {
   const { t } = useTranslation('device_details')
 
@@ -21,7 +21,11 @@ export function Peripherals({
       <StyledText desktopStyle="bodyLargeSemiBold">
         {t('peripherals')}
       </StyledText>
-      <CameraCard isFlex={isFlex} robotName={robotName} />
+      <CameraCard
+        isFlex={isFlex}
+        robotName={robotName}
+        isRobotBusy={isRobotBusy}
+      />
     </div>
   )
 }

--- a/app/src/organisms/Desktop/Devices/PipetteCard/FlexPipetteCard.tsx
+++ b/app/src/organisms/Desktop/Devices/PipetteCard/FlexPipetteCard.tsx
@@ -42,7 +42,7 @@ interface FlexPipetteCardProps {
   attachedPipette: PipetteData | BadPipette | null
   pipetteModelSpecs: PipetteModelSpecs | null
   mount: Mount
-  isRunActive: boolean
+  isRobotBusy: boolean
   isEstopNotDisengaged: boolean
 }
 
@@ -62,7 +62,7 @@ export function FlexPipetteCard({
   pipetteModelSpecs,
   attachedPipette,
   mount,
-  isRunActive,
+  isRobotBusy,
   isEstopNotDisengaged,
 }: FlexPipetteCardProps): JSX.Element {
   const { t, i18n } = useTranslation(['device_details', 'shared'])
@@ -144,7 +144,7 @@ export function FlexPipetteCard({
       ? [
           {
             label: t('attach_pipette'),
-            disabled: attachedPipette != null || isRunActive,
+            disabled: attachedPipette != null || isRobotBusy,
             onClick: handleChoosePipette,
           },
         ]
@@ -154,12 +154,12 @@ export function FlexPipetteCard({
               attachedPipette.data.calibratedOffset?.last_modified != null
                 ? t('recalibrate_pipette')
                 : t('calibrate_pipette'),
-            disabled: attachedPipette == null || isRunActive,
+            disabled: attachedPipette == null || isRobotBusy,
             onClick: handleCalibrate,
           },
           {
             label: t('detach_pipette'),
-            disabled: attachedPipette == null || isRunActive,
+            disabled: attachedPipette == null || isRobotBusy,
             onClick: handleDetach,
           },
           {
@@ -171,7 +171,7 @@ export function FlexPipetteCard({
           },
           {
             label: i18n.format(t('drop_tips'), 'capitalize'),
-            disabled: attachedPipette == null || isRunActive,
+            disabled: attachedPipette == null || isRobotBusy,
             onClick: () => {
               enableDTWiz()
             },

--- a/app/src/organisms/Desktop/Devices/PipetteCard/__tests__/FlexPipetteCard.test.tsx
+++ b/app/src/organisms/Desktop/Devices/PipetteCard/__tests__/FlexPipetteCard.test.tsx
@@ -58,7 +58,7 @@ describe('FlexPipetteCard', () => {
         },
       } as PipetteData,
       mount: 'left',
-      isRunActive: false,
+      isRobotBusy: false,
       isEstopNotDisengaged: false,
     }
     vi.mocked(useCurrentSubsystemUpdateQuery).mockReturnValue({
@@ -110,7 +110,7 @@ describe('FlexPipetteCard', () => {
         },
       } as PipetteData,
       mount: 'left',
-      isRunActive: false,
+      isRobotBusy: false,
       isEstopNotDisengaged: false,
     }
     render(props)
@@ -136,7 +136,7 @@ describe('FlexPipetteCard', () => {
         },
       } as PipetteData,
       mount: 'left',
-      isRunActive: false,
+      isRobotBusy: false,
       isEstopNotDisengaged: false,
     }
 
@@ -164,7 +164,7 @@ describe('FlexPipetteCard', () => {
         },
       } as PipetteData,
       mount: 'left',
-      isRunActive: false,
+      isRobotBusy: false,
       isEstopNotDisengaged: true,
     }
 
@@ -187,7 +187,7 @@ describe('FlexPipetteCard', () => {
       mount: 'left',
       attachedPipette: null,
       pipetteModelSpecs: null,
-      isRunActive: false,
+      isRobotBusy: false,
       isEstopNotDisengaged: false,
     }
     render(props)
@@ -236,7 +236,7 @@ describe('FlexPipetteCard', () => {
       } as any,
       mount: 'left',
       pipetteModelSpecs: null,
-      isRunActive: false,
+      isRobotBusy: false,
       isEstopNotDisengaged: false,
     }
     render(props)
@@ -256,7 +256,7 @@ describe('FlexPipetteCard', () => {
       } as any,
       mount: 'left',
       pipetteModelSpecs: null,
-      isRunActive: false,
+      isRobotBusy: false,
       isEstopNotDisengaged: false,
     }
     render(props)

--- a/app/src/organisms/Desktop/Devices/PipetteCard/__tests__/PipetteCard.test.tsx
+++ b/app/src/organisms/Desktop/Devices/PipetteCard/__tests__/PipetteCard.test.tsx
@@ -45,7 +45,7 @@ describe('PipetteCard', () => {
       mount: LEFT,
       robotName: mockRobotName,
       pipetteId: 'id',
-      isRunActive: false,
+      isRobotBusy: false,
       isEstopNotDisengaged: false,
     }
     vi.mocked(PipetteOverflowMenu).mockReturnValue(
@@ -72,7 +72,7 @@ describe('PipetteCard', () => {
       mount: LEFT,
       robotName: mockRobotName,
       pipetteId: 'id',
-      isRunActive: false,
+      isRobotBusy: false,
       isEstopNotDisengaged: false,
     }
     render(props)
@@ -86,7 +86,7 @@ describe('PipetteCard', () => {
       mount: RIGHT,
       robotName: mockRobotName,
       pipetteId: 'id',
-      isRunActive: false,
+      isRobotBusy: false,
       isEstopNotDisengaged: false,
     }
     render(props)
@@ -98,7 +98,7 @@ describe('PipetteCard', () => {
       pipetteModelSpecs: null,
       mount: RIGHT,
       robotName: mockRobotName,
-      isRunActive: false,
+      isRobotBusy: false,
       isEstopNotDisengaged: false,
     }
     render(props)
@@ -110,7 +110,7 @@ describe('PipetteCard', () => {
       pipetteModelSpecs: null,
       mount: LEFT,
       robotName: mockRobotName,
-      isRunActive: false,
+      isRobotBusy: false,
       isEstopNotDisengaged: false,
     }
     render(props)
@@ -122,7 +122,7 @@ describe('PipetteCard', () => {
       pipetteModelSpecs: mockLeftSpecs,
       mount: LEFT,
       robotName: mockRobotName,
-      isRunActive: false,
+      isRobotBusy: false,
       isEstopNotDisengaged: false,
     }
     render(props)
@@ -133,7 +133,7 @@ describe('PipetteCard', () => {
       pipetteModelSpecs: mockRightSpecs,
       mount: RIGHT,
       robotName: mockRobotName,
-      isRunActive: false,
+      isRobotBusy: false,
       isEstopNotDisengaged: false,
     }
     render(props)

--- a/app/src/organisms/Desktop/Devices/PipetteCard/index.tsx
+++ b/app/src/organisms/Desktop/Devices/PipetteCard/index.tsx
@@ -40,7 +40,7 @@ interface PipetteCardProps {
   pipetteId?: AttachedPipette['id'] | null
   mount: Mount
   robotName: string
-  isRunActive: boolean
+  isRobotBusy: boolean
   isEstopNotDisengaged: boolean
 }
 
@@ -54,7 +54,7 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
     mount,
     robotName,
     pipetteId,
-    isRunActive,
+    isRobotBusy,
     isEstopNotDisengaged,
   } = props
   const {
@@ -212,7 +212,7 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
               handleSettingsSlideout={handleSettingsSlideout}
               handleAboutSlideout={handleAboutSlideout}
               pipetteSettings={settings}
-              isRunActive={isRunActive}
+              isRunActive={isRobotBusy}
             />
           </Box>
           {menuOverlay}

--- a/app/src/organisms/Desktop/Devices/RobotSettings/AdvancedTab/UpdateRobotSoftware.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/AdvancedTab/UpdateRobotSoftware.tsx
@@ -21,11 +21,13 @@ import {
 
 import { TertiaryButton } from '/app/atoms/buttons'
 import { ExternalLink } from '/app/atoms/Link/ExternalLink'
+import { isTerminalRunStatus } from '/app/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/utils'
 import { getRobotUpdateDisplayInfo } from '/app/redux/robot-update'
 import { useDispatchStartRobotUpdate } from '/app/redux/robot-update/hooks'
 import { remote } from '/app/redux/shell/remote'
 
 import type { ChangeEventHandler, MouseEventHandler } from 'react'
+import type { Run } from '@opentrons/api-client'
 import type { State } from '/app/redux/types'
 
 const OT_APP_UPDATE_PAGE_LINK = 'https://opentrons.com/ot-app/'
@@ -37,13 +39,13 @@ const HIDDEN_CSS = css`
 interface UpdateRobotSoftwareProps {
   robotName: string
   onUpdateStart: () => void
-  isRobotBusy: boolean
+  currentRun: Run | null
 }
 
 export function UpdateRobotSoftware({
   robotName,
   onUpdateStart,
-  isRobotBusy,
+  currentRun,
 }: UpdateRobotSoftwareProps): JSX.Element {
   const { t } = useTranslation(['device_settings', 'branded'])
   const { updateFromFileDisabledReason } = useSelector((state: State) => {
@@ -53,6 +55,8 @@ export function UpdateRobotSoftware({
   const [updateButtonProps, updateButtonTooltipProps] = useHoverTooltip()
   const inputRef = useRef<HTMLInputElement>(null)
   const dispatchStartRobotUpdate = useDispatchStartRobotUpdate()
+  const isRunActive =
+    currentRun != null && !isTerminalRunStatus(currentRun.data.status)
 
   const handleChange: ChangeEventHandler<HTMLInputElement> = event => {
     const { files } = event.target
@@ -98,7 +102,7 @@ export function UpdateRobotSoftware({
           marginLeft={SPACING_AUTO}
           id="AdvancedSettings_softwareUpdateButton"
           {...updateButtonProps}
-          disabled={updateDisabled || isRobotBusy}
+          disabled={updateDisabled || isRunActive}
           onClick={handleClick}
         >
           {t('browse_file_system')}

--- a/app/src/organisms/Desktop/Devices/RobotSettings/AdvancedTab/__tests__/UpdateRobotSoftware.test.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/AdvancedTab/__tests__/UpdateRobotSoftware.test.tsx
@@ -5,11 +5,15 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import '@testing-library/jest-dom/vitest'
 
+import { RUN_STATUS_RUNNING } from '@opentrons/api-client'
+
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
 import { getRobotUpdateDisplayInfo } from '/app/redux/robot-update'
 
 import { UpdateRobotSoftware } from '../UpdateRobotSoftware'
+
+import type { ComponentProps } from 'react'
 
 vi.mock('/app/redux/robot-settings/selectors')
 vi.mock('/app/redux/discovery')
@@ -18,13 +22,15 @@ vi.mock('../../../hooks')
 
 const mockOnUpdateStart = vi.fn()
 
-const render = () => {
+const render = (
+  props?: Partial<ComponentProps<typeof UpdateRobotSoftware>>
+) => {
   return renderWithProviders(
     <MemoryRouter>
       <UpdateRobotSoftware
         robotName="otie"
-        isRobotBusy={false}
         onUpdateStart={mockOnUpdateStart}
+        currentRun={props?.currentRun ?? null}
       />
     </MemoryRouter>,
     { i18nInstance: i18n }
@@ -64,6 +70,12 @@ describe('RobotSettings UpdateRobotSoftware', () => {
       updateFromFileDisabledReason: 'mock reason',
     })
     render()
+    const button = screen.getByText('Browse file system')
+    expect(button).toBeDisabled()
+  })
+
+  it('should be disabled if a run is running', () => {
+    render({ currentRun: { data: { status: RUN_STATUS_RUNNING } } } as any)
     const button = screen.getByText('Browse file system')
     expect(button).toBeDisabled()
   })

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsAdvanced.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsAdvanced.tsx
@@ -15,11 +15,7 @@ import {
 import { getTopPortalEl } from '/app/App/portal'
 import { ToggleButton } from '/app/atoms/buttons'
 import { Divider } from '/app/atoms/structure'
-import {
-  useIsFlex,
-  useIsRobotBusy,
-  useRobot,
-} from '/app/redux-resources/robots'
+import { useIsFlex, useRobot } from '/app/redux-resources/robots'
 import { getRobotSerialNumber, UNREACHABLE } from '/app/redux/discovery'
 import {
   fetchSettings,
@@ -62,12 +58,12 @@ import type { Dispatch, State } from '/app/redux/types'
 
 interface RobotSettingsAdvancedProps {
   robotName: string
-  updateRobotStatus: (isRobotBusy: boolean) => void
+  isRobotBusy: boolean
 }
 
 export function RobotSettingsAdvanced({
   robotName,
-  updateRobotStatus,
+  isRobotBusy,
 }: RobotSettingsAdvancedProps): JSX.Element {
   const [showRenameRobotSlideout, setShowRenameRobotSlideout] =
     useState<boolean>(false)
@@ -78,7 +74,6 @@ export function RobotSettingsAdvanced({
   const [showFactoryModeSlideout, setShowFactoryModeSlideout] =
     useState<boolean>(false)
 
-  const isRobotBusy = useIsRobotBusy({ poll: true })
   const isEstopNotDisengaged = useIsEstopNotDisengaged(robotName)
 
   const robot = useRobot(robotName)
@@ -124,10 +119,6 @@ export function RobotSettingsAdvanced({
   useEffect(() => {
     dispatch(fetchSettings(robotName))
   }, [dispatch, robotName])
-
-  useEffect(() => {
-    updateRobotStatus(isRobotBusy)
-  }, [isRobotBusy, updateRobotStatus])
 
   return (
     <>

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsAdvanced.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsAdvanced.tsx
@@ -23,6 +23,7 @@ import {
   updateSetting,
 } from '/app/redux/robot-settings'
 import { useIsEstopNotDisengaged } from '/app/resources/devices/hooks/useIsEstopNotDisengaged'
+import { useCurrentRun } from '/app/resources/runs'
 
 import {
   DeviceReset,
@@ -75,6 +76,7 @@ export function RobotSettingsAdvanced({
     useState<boolean>(false)
 
   const isEstopNotDisengaged = useIsEstopNotDisengaged(robotName)
+  const currentRun = useCurrentRun()
 
   const robot = useRobot(robotName)
   const isFlex = useIsFlex(robotName)
@@ -223,7 +225,7 @@ export function RobotSettingsAdvanced({
         <Divider marginY={SPACING.spacing16} />
         <UpdateRobotSoftware
           robotName={robotName}
-          isRobotBusy={isRobotBusy}
+          currentRun={currentRun}
           onUpdateStart={() => {
             handleUpdateBuildroot(robot)
           }}

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsCamera/index.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsCamera/index.tsx
@@ -6,7 +6,6 @@ import {
   useCameraAnalytics,
 } from '/app/redux-resources/analytics'
 import { useFeatureFlag } from '/app/redux/config'
-import { useCurrentRunId } from '/app/resources/runs'
 
 import styles from './camerasettings.module.css'
 import { CameraStatusContainer } from './CameraStatusContainer'
@@ -18,9 +17,11 @@ import type { RobotType } from '@opentrons/shared-data'
 
 export interface RobotSettingsCameraProps {
   robotType: RobotType
+  isRobotBusy: boolean
 }
 export function RobotSettingsCamera({
   robotType,
+  isRobotBusy,
 }: RobotSettingsCameraProps): JSX.Element {
   const {
     toggleCameraEnabled,
@@ -34,8 +35,6 @@ export function RobotSettingsCamera({
     source: SOURCE_ROBOT_SETTINGS,
     robotType: robotType,
   })
-  const runId = useCurrentRunId()
-  const doesRunExist = runId != null
   const isCameraSettingsEnabled = useFeatureFlag('camera')
   const handleToggleLiveStream = (): void => {
     toggleLiveVideoEnabled()
@@ -59,7 +58,7 @@ export function RobotSettingsCamera({
       <CameraStatusContainer
         toggleCameraEnabled={toggleCameraEnabled}
         isCameraEnabled={isCameraEnabled}
-        toggleDisabled={doesRunExist}
+        toggleDisabled={isRobotBusy}
       />
       {isCameraEnabled && (
         <>
@@ -68,7 +67,7 @@ export function RobotSettingsCamera({
             isRecoveryCaptureEnabled={isRecoveryCaptureEnabled}
             toggleLiveVideoEnabled={handleToggleLiveStream}
             toggleRecoveryCaptureEnabled={handleToggleRecovery}
-            toggleDisabled={doesRunExist}
+            toggleDisabled={isRobotBusy}
           />
           {isCameraSettingsEnabled && (
             <>

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsNetworking.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsNetworking.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
@@ -21,7 +21,7 @@ import {
 import { getModalPortalEl } from '/app/App/portal'
 import { ExternalLink } from '/app/atoms/Link/ExternalLink'
 import { Divider } from '/app/atoms/structure'
-import { useIsFlex, useIsRobotBusy } from '/app/redux-resources/robots'
+import { useIsFlex } from '/app/redux-resources/robots'
 import {
   getRobotAddressesByName,
   HEALTH_STATUS_OK,
@@ -38,7 +38,7 @@ import type { Dispatch, State } from '/app/redux/types'
 
 interface NetworkingProps {
   robotName: string
-  updateRobotStatus: (isRobotBusy: boolean) => void
+  isRobotBusy: boolean
 }
 
 const HELP_CENTER_URL =
@@ -48,12 +48,11 @@ const LIST_REFRESH_MS = 10000
 
 export function RobotSettingsNetworking({
   robotName,
-  updateRobotStatus,
+  isRobotBusy,
 }: NetworkingProps): JSX.Element {
   const { t } = useTranslation('device_settings')
   const wifiList = useWifiList(robotName, LIST_REFRESH_MS)
   const dispatch = useDispatch<Dispatch>()
-  const isRobotBusy = useIsRobotBusy({ poll: true })
   const isFlex = useIsFlex(robotName)
 
   const [showDisconnectModal, setShowDisconnectModal] = useState<boolean>(false)
@@ -87,10 +86,6 @@ export function RobotSettingsNetworking({
     usbAddress != null && usbAddress.healthStatus === HEALTH_STATUS_OK
 
   useInterval(() => dispatch(fetchStatus(robotName)), STATUS_REFRESH_MS, true)
-
-  useEffect(() => {
-    updateRobotStatus(isRobotBusy)
-  }, [isRobotBusy, updateRobotStatus])
 
   return (
     <>

--- a/app/src/organisms/Desktop/Devices/RobotSettings/__tests__/RobotSettingsAdvanced.test.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/__tests__/RobotSettingsAdvanced.test.tsx
@@ -56,15 +56,10 @@ vi.mock('../AdvancedTab/UsageSettings')
 vi.mock('../AdvancedTab/UseOlderAspirateBehavior')
 vi.mock('../AdvancedTab/DisableStackerSensors')
 
-const mockUpdateRobotStatus = vi.fn()
-
 const render = () => {
   return renderWithProviders(
     <MemoryRouter>
-      <RobotSettingsAdvanced
-        robotName="otie"
-        updateRobotStatus={mockUpdateRobotStatus}
-      />
+      <RobotSettingsAdvanced robotName="otie" isRobotBusy={false} />
     </MemoryRouter>,
     {
       i18nInstance: i18n,

--- a/app/src/organisms/Desktop/Devices/RobotSettings/__tests__/RobotSettingsAdvanced.test.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/__tests__/RobotSettingsAdvanced.test.tsx
@@ -9,6 +9,7 @@ import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
 import { useIsFlex, useIsRobotBusy } from '/app/redux-resources/robots'
 import { getShellUpdateState } from '/app/redux/shell'
+import { useCurrentRun } from '/app/resources/runs'
 
 import {
   DeviceReset,
@@ -55,6 +56,7 @@ vi.mock('../AdvancedTab/UpdateRobotSoftware')
 vi.mock('../AdvancedTab/UsageSettings')
 vi.mock('../AdvancedTab/UseOlderAspirateBehavior')
 vi.mock('../AdvancedTab/DisableStackerSensors')
+vi.mock('/app/resources/runs')
 
 const render = () => {
   return renderWithProviders(
@@ -117,6 +119,7 @@ describe('RobotSettings Advanced tab', () => {
       <div>Mock DisableStackerSensors Section</div>
     )
     vi.mocked(useIsRobotBusy).mockReturnValue(false)
+    vi.mocked(useCurrentRun).mockReturnValue(null)
   })
 
   afterEach(() => {

--- a/app/src/organisms/Desktop/Devices/RobotSettings/__tests__/RobotSettingsNetworking.test.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/__tests__/RobotSettingsNetworking.test.tsx
@@ -33,18 +33,13 @@ vi.mock('/app/redux-resources/robots')
 vi.mock('../ConnectNetwork/DisconnectModal')
 vi.mock('/app/resources/devices/hooks/useIsEstopNotDisengaged')
 
-const mockUpdateRobotStatus = vi.fn()
-
 const getNetworkInterfaces = Networking.getNetworkInterfaces
 const ROBOT_NAME = 'otie'
 
 const render = () => {
   return renderWithProviders(
     <MemoryRouter>
-      <RobotSettingsNetworking
-        robotName={ROBOT_NAME}
-        updateRobotStatus={mockUpdateRobotStatus}
-      />
+      <RobotSettingsNetworking robotName={ROBOT_NAME} isRobotBusy={false} />
     </MemoryRouter>,
     {
       i18nInstance: i18n,

--- a/app/src/organisms/Desktop/Devices/RobotSettings/__tests__/RobotSettingsNetworking.test.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/__tests__/RobotSettingsNetworking.test.tsx
@@ -22,6 +22,7 @@ import { useCanDisconnect, useWifiList } from '/app/resources/networking/hooks'
 import { DisconnectModal } from '../ConnectNetwork/DisconnectModal'
 import { RobotSettingsNetworking } from '../RobotSettingsNetworking'
 
+import type { ComponentProps } from 'react'
 import type { DiscoveryClientRobotAddress } from '/app/redux/discovery/types'
 import type { State } from '/app/redux/types'
 
@@ -36,10 +37,15 @@ vi.mock('/app/resources/devices/hooks/useIsEstopNotDisengaged')
 const getNetworkInterfaces = Networking.getNetworkInterfaces
 const ROBOT_NAME = 'otie'
 
-const render = () => {
+const render = (
+  props?: Partial<ComponentProps<typeof RobotSettingsNetworking>>
+) => {
   return renderWithProviders(
     <MemoryRouter>
-      <RobotSettingsNetworking robotName={ROBOT_NAME} isRobotBusy={false} />
+      <RobotSettingsNetworking
+        robotName={ROBOT_NAME}
+        isRobotBusy={props?.isRobotBusy ?? false}
+      />
     </MemoryRouter>,
     {
       i18nInstance: i18n,
@@ -315,8 +321,7 @@ describe('RobotSettingsNetworking', () => {
   it('should not render Disconnect from Wi-Fi button when robot is busy', () => {
     when(useWifiList).calledWith(ROBOT_NAME).thenReturn([])
     when(useCanDisconnect).calledWith(ROBOT_NAME).thenReturn(true)
-    when(useIsRobotBusy).calledWith({ poll: true }).thenReturn(true)
-    render()
+    render({ isRobotBusy: true })
 
     expect(
       screen.queryByRole('button', { name: 'Disconnect from Wi-Fi' })

--- a/app/src/organisms/Desktop/Devices/__tests__/InstrumentsAndModules.test.tsx
+++ b/app/src/organisms/Desktop/Devices/__tests__/InstrumentsAndModules.test.tsx
@@ -61,6 +61,7 @@ describe('InstrumentsAndModules', () => {
     props = {
       robotName: ROBOT_NAME,
       isRobotViewable: true,
+      isRobotBusy: false,
     }
     vi.mocked(useCurrentRunId).mockReturnValue(null)
     vi.mocked(useRunStatuses).mockReturnValue({
@@ -124,9 +125,9 @@ describe('InstrumentsAndModules', () => {
   })
   it('renders the protocol loaded banner when protocol is loaded and not terminal state', () => {
     vi.mocked(useCurrentRunId).mockReturnValue('RUNID')
-    render(props)
+    render({ ...props, isRobotBusy: true })
     screen.getByText(
-      'Some robot controls are not available when run is in progress'
+      'Some robot controls are not available when run is in progress or robot is busy'
     )
   })
   it('renders 1 pipette card when a 96 channel is attached', () => {

--- a/app/src/organisms/Desktop/RobotSettingsCalibration/CalibrationDetails/ModuleCalibrationItems.tsx
+++ b/app/src/organisms/Desktop/RobotSettingsCalibration/CalibrationDetails/ModuleCalibrationItems.tsx
@@ -21,16 +21,16 @@ import type { FormattedPipetteOffsetCalibration } from '..'
 
 interface ModuleCalibrationItemsProps {
   attachedModules: AttachedModule[]
-  updateRobotStatus: (isRobotBusy: boolean) => void
   formattedPipetteOffsetCalibrations: FormattedPipetteOffsetCalibration[]
   robotName: string
+  isRobotBusy: boolean
 }
 
 export function ModuleCalibrationItems({
   attachedModules,
-  updateRobotStatus,
   formattedPipetteOffsetCalibrations,
   robotName,
+  isRobotBusy,
 }: ModuleCalibrationItemsProps): JSX.Element {
   const { t } = useTranslation('device_settings')
 
@@ -78,11 +78,11 @@ export function ModuleCalibrationItems({
                       attachedModule.moduleOffset?.last_modified != null
                     }
                     attachedModule={attachedModule}
-                    updateRobotStatus={updateRobotStatus}
                     formattedPipetteOffsetCalibrations={
                       formattedPipetteOffsetCalibrations
                     }
                     robotName={robotName}
+                    isRobotBusy={isRobotBusy}
                   />
                 ) : null}
               </StyledTableCell>

--- a/app/src/organisms/Desktop/RobotSettingsCalibration/CalibrationDetails/ModuleCalibrationOverflowMenu.tsx
+++ b/app/src/organisms/Desktop/RobotSettingsCalibration/CalibrationDetails/ModuleCalibrationOverflowMenu.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import {
@@ -19,7 +18,6 @@ import { useHost } from '@opentrons/react-api-client'
 
 import { handleModuleWizardFlows } from '/app/organisms/ModuleWizardFlows'
 import { useIsEstopNotDisengaged } from '/app/resources/devices/hooks/useIsEstopNotDisengaged'
-import { useRunStatuses } from '/app/resources/runs'
 import { getModuleTooHot } from '/app/transformations/modules'
 
 import type { HostConfig } from '@opentrons/api-client'
@@ -28,16 +26,16 @@ import type { FormattedPipetteOffsetCalibration } from '..'
 
 interface ModuleCalibrationOverflowMenuProps {
   isCalibrated: boolean
+  isRobotBusy: boolean
   attachedModule: AttachedModule
-  updateRobotStatus: (isRobotBusy: boolean) => void
   formattedPipetteOffsetCalibrations: FormattedPipetteOffsetCalibration[]
   robotName: string
 }
 
 export function ModuleCalibrationOverflowMenu({
   isCalibrated,
+  isRobotBusy,
   attachedModule,
-  updateRobotStatus,
   formattedPipetteOffsetCalibrations,
   robotName,
 }: ModuleCalibrationOverflowMenuProps): JSX.Element {
@@ -55,7 +53,6 @@ export function ModuleCalibrationOverflowMenu({
     setShowOverflowMenu,
   } = useMenuHandleClickOutside()
 
-  const { isRunRunning: isRunning } = useRunStatuses()
   const [targetProps, tooltipProps] = useHoverTooltip()
 
   const OverflowMenuRef = useOnClickOutside<HTMLDivElement>({
@@ -78,12 +75,6 @@ export function ModuleCalibrationOverflowMenu({
       host,
     })
   }
-
-  useEffect(() => {
-    if (isRunning) {
-      updateRobotStatus(true)
-    }
-  }, [isRunning, updateRobotStatus])
 
   return (
     <Flex flexDirection={DIRECTION_COLUMN} position={POSITION_RELATIVE}>
@@ -109,7 +100,7 @@ export function ModuleCalibrationOverflowMenu({
           <MenuItem
             onClick={handleCalibration}
             disabled={
-              isRunning ||
+              isRobotBusy ||
               requiredAttachOrCalibratePipette ||
               getModuleTooHot(attachedModule)
             }

--- a/app/src/organisms/Desktop/RobotSettingsCalibration/CalibrationDetails/OverflowMenu/__tests__/OverflowMenu.test.tsx
+++ b/app/src/organisms/Desktop/RobotSettingsCalibration/CalibrationDetails/OverflowMenu/__tests__/OverflowMenu.test.tsx
@@ -82,8 +82,6 @@ const RUN_STATUSES = {
   isRunIdle: false,
 }
 
-const mockUpdateRobotStatus = vi.fn()
-
 describe('OverflowMenu', () => {
   let props: ComponentProps<typeof OverflowMenu>
   const mockDeleteCalibration = vi.fn()
@@ -94,8 +92,8 @@ describe('OverflowMenu', () => {
       robotName: ROBOT_NAME,
       mount: 'left' as Mount,
       serialNumber: 'serialNumber',
-      updateRobotStatus: mockUpdateRobotStatus,
       pipetteName: PIPETTE_NAME,
+      isRobotBusy: false,
       tiprackDefURI: 'mock/tiprack/uri',
     }
     vi.mocked(useAttachedPipettesFromInstrumentsQuery).mockReturnValue({
@@ -323,13 +321,9 @@ describe('OverflowMenu', () => {
   })
 
   it('should disable the calibration overflow menu option when the run is running', () => {
-    vi.mocked(useRunStatuses).mockReturnValue({
-      ...RUN_STATUSES,
-      isRunRunning: true,
-    })
     vi.mocked(isFlexPipette).mockReturnValue(true)
 
-    render(props)
+    render({ ...props, isRobotBusy: true })
 
     fireEvent.click(
       screen.getByLabelText('CalibrationOverflowMenu_button_pipetteOffset')

--- a/app/src/organisms/Desktop/RobotSettingsCalibration/CalibrationDetails/OverflowMenu/index.tsx
+++ b/app/src/organisms/Desktop/RobotSettingsCalibration/CalibrationDetails/OverflowMenu/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { saveAs } from 'file-saver'
 import { css } from 'styled-components'
@@ -33,7 +33,6 @@ import {
 } from '/app/redux/analytics'
 import { useIsEstopNotDisengaged } from '/app/resources/devices'
 import { useAttachedPipettesFromInstrumentsQuery } from '/app/resources/instruments'
-import { useRunStatuses } from '/app/resources/runs'
 
 import { ConfirmDeleteCalibrationModal } from './ConfirmDeleteCalibrationModal'
 
@@ -46,9 +45,9 @@ import type { SelectablePipettes } from '/app/organisms/PipetteWizardFlows/types
 interface OverflowMenuProps {
   calType: 'pipetteOffset' | 'tipLength'
   robotName: string
+  isRobotBusy: boolean
   mount: Mount
   serialNumber: string | null
-  updateRobotStatus: (isRobotBusy: boolean) => void
   pipetteName?: string | null
   tiprackDefURI?: string | null
 }
@@ -56,9 +55,9 @@ interface OverflowMenuProps {
 export function OverflowMenu({
   calType,
   robotName,
+  isRobotBusy,
   mount,
   serialNumber,
-  updateRobotStatus,
   pipetteName,
   tiprackDefURI = null,
 }: OverflowMenuProps): JSX.Element {
@@ -92,7 +91,6 @@ export function OverflowMenu({
     useAllPipetteOffsetCalibrationsQuery().data?.data
 
   const tipLengthCalibrations = useAllTipLengthCalibrationsQuery().data?.data
-  const { isRunRunning: isRunning } = useRunStatuses()
   const isEstopNotDisengaged = useIsEstopNotDisengaged(robotName)
   const isPipetteForFlex = isFlexPipette(pipetteName as PipetteName)
   const ot3PipCal =
@@ -113,7 +111,7 @@ export function OverflowMenu({
   const handleRecalibrate = (e: MouseEvent): void => {
     e.preventDefault()
     if (
-      !isRunning &&
+      !isRobotBusy &&
       isPipetteForFlex &&
       calType === 'pipetteOffset' &&
       pipetteName != null
@@ -143,12 +141,6 @@ export function OverflowMenu({
     }
     setShowOverflowMenu(currentShowOverflowMenu => !currentShowOverflowMenu)
   }
-
-  useEffect(() => {
-    if (isRunning) {
-      updateRobotStatus(true)
-    }
-  }, [isRunning, updateRobotStatus])
 
   const { deleteCalibration } = useDeleteCalibrationMutation()
 
@@ -222,7 +214,7 @@ export function OverflowMenu({
               css={css`
                 border-radius: ${BORDERS.borderRadius8};
               `}
-              disabled={isRunning}
+              disabled={isRobotBusy}
               aria-label={`CalibrationOverflowMenu_button_calibrate`}
             >
               {t(

--- a/app/src/organisms/Desktop/RobotSettingsCalibration/CalibrationDetails/PipetteOffsetCalibrationItems.tsx
+++ b/app/src/organisms/Desktop/RobotSettingsCalibration/CalibrationDetails/PipetteOffsetCalibrationItems.tsx
@@ -50,14 +50,14 @@ const BODY_STYLE = css`
 `
 interface PipetteOffsetCalibrationItemsProps {
   robotName: string
+  isRobotBusy: boolean
   formattedPipetteOffsetCalibrations: FormattedPipetteOffsetCalibration[]
-  updateRobotStatus: (isRobotBusy: boolean) => void
 }
 
 export function PipetteOffsetCalibrationItems({
   robotName,
+  isRobotBusy,
   formattedPipetteOffsetCalibrations,
-  updateRobotStatus,
 }: PipetteOffsetCalibrationItemsProps): JSX.Element {
   const { t } = useTranslation('device_settings')
 
@@ -147,9 +147,9 @@ export function PipetteOffsetCalibrationItems({
                   <OverflowMenu
                     calType="pipetteOffset"
                     robotName={robotName}
+                    isRobotBusy={isRobotBusy}
                     mount={calibration.mount}
                     serialNumber={calibration.serialNumber ?? null}
-                    updateRobotStatus={updateRobotStatus}
                     pipetteName={
                       isFlex
                         ? (attachedPipetteFromInstrumentQuery[calibration.mount]

--- a/app/src/organisms/Desktop/RobotSettingsCalibration/CalibrationDetails/TipLengthCalibrationItems.tsx
+++ b/app/src/organisms/Desktop/RobotSettingsCalibration/CalibrationDetails/TipLengthCalibrationItems.tsx
@@ -45,16 +45,16 @@ const BODY_STYLE = css`
 `
 interface TipLengthCalibrationItemsProps {
   robotName: string
+  isRobotBusy: boolean
   formattedPipetteOffsetCalibrations: FormattedPipetteOffsetCalibration[]
   formattedTipLengthCalibrations: FormattedTipLengthCalibration[]
-  updateRobotStatus: (isRobotBusy: boolean) => void
 }
 
 export function TipLengthCalibrationItems({
   robotName,
+  isRobotBusy,
   formattedPipetteOffsetCalibrations,
   formattedTipLengthCalibrations,
-  updateRobotStatus,
 }: TipLengthCalibrationItemsProps): JSX.Element {
   const { t } = useTranslation('device_settings')
   const customLabwareDefs = useSelector((state: State) => {
@@ -126,13 +126,13 @@ export function TipLengthCalibrationItems({
               <OverflowMenu
                 calType="tipLength"
                 robotName={robotName}
+                isRobotBusy={isRobotBusy}
                 serialNumber={calibration.serialNumber}
                 mount={
                   calibration.mount != null
                     ? calibration.mount
                     : checkMountWithAttachedPipettes(calibration.serialNumber)
                 }
-                updateRobotStatus={updateRobotStatus}
                 tiprackDefURI={calibration.tiprackDefURI}
               />
             </StyledTableCell>

--- a/app/src/organisms/Desktop/RobotSettingsCalibration/CalibrationDetails/__tests__/ModuleCalibrationItems.test.tsx
+++ b/app/src/organisms/Desktop/RobotSettingsCalibration/CalibrationDetails/__tests__/ModuleCalibrationItems.test.tsx
@@ -71,9 +71,9 @@ describe('ModuleCalibrationItems', () => {
   beforeEach(() => {
     props = {
       attachedModules: mockFetchModulesSuccessActionPayloadModules,
-      updateRobotStatus: vi.fn(),
       formattedPipetteOffsetCalibrations: [],
       robotName: ROBOT_NAME,
+      isRobotBusy: false,
     }
     vi.mocked(ModuleCalibrationOverflowMenu).mockReturnValue(
       <div>mock ModuleCalibrationOverflowMenu</div>

--- a/app/src/organisms/Desktop/RobotSettingsCalibration/CalibrationDetails/__tests__/ModuleCalibrationOverflowMenu.test.tsx
+++ b/app/src/organisms/Desktop/RobotSettingsCalibration/CalibrationDetails/__tests__/ModuleCalibrationOverflowMenu.test.tsx
@@ -104,9 +104,9 @@ describe('ModuleCalibrationOverflowMenu', () => {
     props = {
       isCalibrated: false,
       attachedModule: mockThermocyclerGen2,
-      updateRobotStatus: vi.fn(),
       formattedPipetteOffsetCalibrations: mockPipetteOffsetCalibrations,
       robotName: ROBOT_NAME,
+      isRobotBusy: false,
     }
     vi.mocked(useRunStatuses).mockReturnValue({
       isRunRunning: false,

--- a/app/src/organisms/Desktop/RobotSettingsCalibration/CalibrationDetails/__tests__/PipetteOffsetCalibrationItems.test.tsx
+++ b/app/src/organisms/Desktop/RobotSettingsCalibration/CalibrationDetails/__tests__/PipetteOffsetCalibrationItems.test.tsx
@@ -72,7 +72,6 @@ const mockAttachedPipettes: AttachedPipettesByMount = {
   left: mockAttachedPipette,
   right: mockAttachedPipette,
 } as any
-const mockUpdateRobotStatus = vi.fn()
 
 describe('PipetteOffsetCalibrationItems', () => {
   let props: ComponentProps<typeof PipetteOffsetCalibrationItems>
@@ -88,7 +87,7 @@ describe('PipetteOffsetCalibrationItems', () => {
     props = {
       robotName: ROBOT_NAME,
       formattedPipetteOffsetCalibrations: mockPipetteOffsetCalibrations,
-      updateRobotStatus: mockUpdateRobotStatus,
+      isRobotBusy: false,
     }
   })
 

--- a/app/src/organisms/Desktop/RobotSettingsCalibration/CalibrationDetails/__tests__/TipLengthCalibrationItems.test.tsx
+++ b/app/src/organisms/Desktop/RobotSettingsCalibration/CalibrationDetails/__tests__/TipLengthCalibrationItems.test.tsx
@@ -55,8 +55,6 @@ const mockTipLengthCalibrations = [
   },
 ]
 
-const mockUpdateRobotStatus = vi.fn()
-
 const render = (
   props: ComponentProps<typeof TipLengthCalibrationItems>
 ): ReturnType<typeof renderWithProviders> => {
@@ -73,7 +71,7 @@ describe('TipLengthCalibrationItems', () => {
       robotName: ROBOT_NAME,
       formattedPipetteOffsetCalibrations: mockPipetteOffsetCalibrations,
       formattedTipLengthCalibrations: mockTipLengthCalibrations,
-      updateRobotStatus: mockUpdateRobotStatus,
+      isRobotBusy: false,
     }
   })
 

--- a/app/src/organisms/Desktop/RobotSettingsCalibration/CalibrationHealthCheck.tsx
+++ b/app/src/organisms/Desktop/RobotSettingsCalibration/CalibrationHealthCheck.tsx
@@ -31,7 +31,6 @@ import {
   useAttachedPipetteCalibrations,
   useAttachedPipettes,
 } from '/app/resources/instruments'
-import { useRunStatuses } from '/app/resources/runs'
 
 import { AskForCalibrationBlockModal } from '../CalibrateTipLength/AskForCalibrationBlockModal'
 
@@ -46,6 +45,7 @@ interface CalibrationHealthCheckProps {
   dispatchRequests: DispatchRequestsType
   isPending: boolean
   robotName: string
+  isRobotBusy: boolean
 }
 
 const attachedPipetteCalPresent: (
@@ -64,6 +64,7 @@ export function CalibrationHealthCheck({
   dispatchRequests,
   isPending,
   robotName,
+  isRobotBusy,
 }: CalibrationHealthCheckProps): JSX.Element {
   const { t } = useTranslation([
     'device_settings',
@@ -80,8 +81,6 @@ export function CalibrationHealthCheck({
   const deckCalibrationStatus = useDeckCalibrationStatus(robotName)
   const attachedPipettes = useAttachedPipettes()
   const attachedPipetteCalibrations = useAttachedPipetteCalibrations()
-
-  const { isRunRunning: isRunning } = useRunStatuses()
 
   const pipetteCalPresent = attachedPipetteCalPresent(
     attachedPipettes,
@@ -105,7 +104,7 @@ export function CalibrationHealthCheck({
     pipettePresent
 
   const calCheckButtonDisabled = healthCheckIsPossible
-    ? Boolean(buttonDisabledReason) || isPending || isRunning
+    ? Boolean(buttonDisabledReason) || isPending || isRobotBusy
     : true
 
   const handleHealthCheck = (

--- a/app/src/organisms/Desktop/RobotSettingsCalibration/RobotSettingsModuleCalibration.tsx
+++ b/app/src/organisms/Desktop/RobotSettingsCalibration/RobotSettingsModuleCalibration.tsx
@@ -15,16 +15,16 @@ import type { FormattedPipetteOffsetCalibration } from '.'
 
 interface RobotSettingsModuleCalibrationProps {
   attachedModules: AttachedModule[]
-  updateRobotStatus: (isRobotBusy: boolean) => void
   formattedPipetteOffsetCalibrations: FormattedPipetteOffsetCalibration[]
   robotName: string
+  isRobotBusy: boolean
 }
 
 export function RobotSettingsModuleCalibration({
   attachedModules,
-  updateRobotStatus,
   formattedPipetteOffsetCalibrations,
   robotName,
+  isRobotBusy,
 }: RobotSettingsModuleCalibrationProps): JSX.Element {
   const { t } = useTranslation('device_settings')
 
@@ -43,11 +43,11 @@ export function RobotSettingsModuleCalibration({
       {attachedModules.length > 0 ? (
         <ModuleCalibrationItems
           attachedModules={attachedModules}
-          updateRobotStatus={updateRobotStatus}
           formattedPipetteOffsetCalibrations={
             formattedPipetteOffsetCalibrations
           }
           robotName={robotName}
+          isRobotBusy={isRobotBusy}
         />
       ) : (
         <LegacyStyledText as="label" marginTop={SPACING.spacing8}>

--- a/app/src/organisms/Desktop/RobotSettingsCalibration/RobotSettingsPipetteOffsetCalibration.tsx
+++ b/app/src/organisms/Desktop/RobotSettingsCalibration/RobotSettingsPipetteOffsetCalibration.tsx
@@ -22,13 +22,13 @@ import type { FormattedPipetteOffsetCalibration } from '.'
 interface RobotSettingsPipetteOffsetCalibrationProps {
   formattedPipetteOffsetCalibrations: FormattedPipetteOffsetCalibration[]
   robotName: string
-  updateRobotStatus: (isRobotBusy: boolean) => void
+  isRobotBusy: boolean
 }
 
 export function RobotSettingsPipetteOffsetCalibration({
   formattedPipetteOffsetCalibrations,
   robotName,
-  updateRobotStatus,
+  isRobotBusy,
 }: RobotSettingsPipetteOffsetCalibrationProps): JSX.Element {
   const { t } = useTranslation('device_settings')
 
@@ -76,10 +76,10 @@ export function RobotSettingsPipetteOffsetCalibration({
       {showPipetteOffsetCalItems ? (
         <PipetteOffsetCalibrationItems
           robotName={robotName}
+          isRobotBusy={isRobotBusy}
           formattedPipetteOffsetCalibrations={
             formattedPipetteOffsetCalibrations
           }
-          updateRobotStatus={updateRobotStatus}
         />
       ) : (
         <LegacyStyledText as="label" marginTop={SPACING.spacing8}>

--- a/app/src/organisms/Desktop/RobotSettingsCalibration/RobotSettingsTipLengthCalibration.tsx
+++ b/app/src/organisms/Desktop/RobotSettingsCalibration/RobotSettingsTipLengthCalibration.tsx
@@ -22,7 +22,7 @@ import type { FormattedPipetteOffsetCalibration } from '.'
 interface RobotSettingsTipLengthCalibrationProps {
   formattedPipetteOffsetCalibrations: FormattedPipetteOffsetCalibration[]
   robotName: string
-  updateRobotStatus: (isRobotBusy: boolean) => void
+  isRobotBusy: boolean
 }
 
 export interface FormattedTipLengthCalibration {
@@ -36,7 +36,7 @@ export interface FormattedTipLengthCalibration {
 export function RobotSettingsTipLengthCalibration({
   formattedPipetteOffsetCalibrations,
   robotName,
-  updateRobotStatus,
+  isRobotBusy,
 }: RobotSettingsTipLengthCalibrationProps): JSX.Element {
   const { t } = useTranslation('device_settings')
 
@@ -89,9 +89,9 @@ export function RobotSettingsTipLengthCalibration({
       </LegacyStyledText>
       <TipLengthCalibrationItems
         robotName={robotName}
+        isRobotBusy={isRobotBusy}
         formattedPipetteOffsetCalibrations={formattedPipetteOffsetCalibrations}
         formattedTipLengthCalibrations={formattedTipLengthCalibrations}
-        updateRobotStatus={updateRobotStatus}
       />
     </Flex>
   )

--- a/app/src/organisms/Desktop/RobotSettingsCalibration/__tests__/CalibrationHealthCheck.test.tsx
+++ b/app/src/organisms/Desktop/RobotSettingsCalibration/__tests__/CalibrationHealthCheck.test.tsx
@@ -10,28 +10,14 @@ import {
   ANALYTICS_CALIBRATION_HEALTH_CHECK_BUTTON_CLICKED,
   useTrackEvent,
 } from '/app/redux/analytics'
-import {
-  mockPipetteOffsetCalibration1,
-  mockPipetteOffsetCalibration2,
-} from '/app/redux/calibration/pipette-offset/__fixtures__'
-import {
-  mockTipLengthCalibration1,
-  mockTipLengthCalibration2,
-} from '/app/redux/calibration/tip-length/__fixtures__'
 import { mockAttachedPipette } from '/app/redux/pipettes/__fixtures__'
-import {
-  useAttachedPipetteCalibrations,
-  useAttachedPipettes,
-} from '/app/resources/instruments'
+import { useAttachedPipettes } from '/app/resources/instruments'
 import { useRunStatuses } from '/app/resources/runs'
 
 import { CalibrationHealthCheck } from '../CalibrationHealthCheck'
 
 import type { ComponentProps } from 'react'
-import type {
-  AttachedPipettesByMount,
-  PipetteCalibrationsByMount,
-} from '/app/redux/pipettes/types'
+import type { AttachedPipettesByMount } from '/app/redux/pipettes/types'
 
 vi.mock('/app/redux/analytics')
 vi.mock('/app/redux/config')
@@ -43,16 +29,6 @@ vi.mock('/app/redux-resources/robots')
 const mockAttachedPipettes: AttachedPipettesByMount = {
   left: mockAttachedPipette,
   right: mockAttachedPipette,
-} as any
-const mockAttachedPipetteCalibrations: PipetteCalibrationsByMount = {
-  left: {
-    offset: mockPipetteOffsetCalibration1,
-    tipLength: mockTipLengthCalibration1,
-  },
-  right: {
-    offset: mockPipetteOffsetCalibration2,
-    tipLength: mockTipLengthCalibration2,
-  },
 } as any
 
 const RUN_STATUSES = {
@@ -74,6 +50,7 @@ const render = (
       dispatchRequests={mockDispatchRequests}
       isPending={false}
       robotName="otie"
+      isRobotBusy={props?.isRobotBusy ?? false}
       {...props}
     />,
     {
@@ -118,11 +95,7 @@ describe('CalibrationHealthCheck', () => {
   })
 
   it('Health check button is disabled when a robot is running', () => {
-    vi.mocked(useRunStatuses).mockReturnValue({
-      ...RUN_STATUSES,
-      isRunRunning: true,
-    })
-    render()
+    render({ isRobotBusy: true })
     const button = screen.getByRole('button', { name: 'Check health' })
     expect(button).toBeDisabled()
   })
@@ -146,19 +119,5 @@ describe('CalibrationHealthCheck', () => {
         )
       ).toBeInTheDocument()
     })
-  })
-
-  it('health check button should be disabled if there is a running protocol', () => {
-    vi.mocked(useAttachedPipettes).mockReturnValue(mockAttachedPipettes)
-    vi.mocked(useAttachedPipetteCalibrations).mockReturnValue(
-      mockAttachedPipetteCalibrations
-    )
-    vi.mocked(useRunStatuses).mockReturnValue({
-      ...RUN_STATUSES,
-      isRunRunning: true,
-    })
-    render()
-    const button = screen.getByRole('button', { name: 'Check health' })
-    expect(button).toBeDisabled()
   })
 })

--- a/app/src/organisms/Desktop/RobotSettingsCalibration/__tests__/RobotSettingsCalibration.test.tsx
+++ b/app/src/organisms/Desktop/RobotSettingsCalibration/__tests__/RobotSettingsCalibration.test.tsx
@@ -77,14 +77,9 @@ const RUN_STATUSES = {
   isRunIdle: false,
 }
 
-const mockUpdateRobotStatus = vi.fn()
-
 const render = () => {
   return renderWithProviders(
-    <RobotSettingsCalibration
-      robotName="otie"
-      updateRobotStatus={mockUpdateRobotStatus}
-    />,
+    <RobotSettingsCalibration robotName="otie" isRobotBusy={false} />,
     {
       i18nInstance: i18n,
     }

--- a/app/src/organisms/Desktop/RobotSettingsCalibration/__tests__/RobotSettingsModuleCalibration.test.tsx
+++ b/app/src/organisms/Desktop/RobotSettingsCalibration/__tests__/RobotSettingsModuleCalibration.test.tsx
@@ -28,9 +28,9 @@ describe('RobotSettingsModuleCalibration', () => {
   beforeEach(() => {
     props = {
       attachedModules: mockFetchModulesSuccessActionPayloadModules,
-      updateRobotStatus: vi.fn(),
       formattedPipetteOffsetCalibrations: [],
       robotName: ROBOT_NAME,
+      isRobotBusy: false,
     }
     vi.mocked(ModuleCalibrationItems).mockReturnValue(
       <div>mock ModuleCalibrationItems</div>

--- a/app/src/organisms/Desktop/RobotSettingsCalibration/__tests__/RobotSettingsPipetteOffsetCalibration.test.tsx
+++ b/app/src/organisms/Desktop/RobotSettingsCalibration/__tests__/RobotSettingsPipetteOffsetCalibration.test.tsx
@@ -27,7 +27,6 @@ vi.mock('../CalibrationDetails/PipetteOffsetCalibrationItems')
 
 const mockFormattedPipetteOffsetCalibrations: FormattedPipetteOffsetCalibration[] =
   []
-const mockUpdateRobotStatus = vi.fn()
 
 const render = (
   props?: Partial<ComponentProps<typeof RobotSettingsPipetteOffsetCalibration>>
@@ -38,7 +37,7 @@ const render = (
         mockFormattedPipetteOffsetCalibrations
       }
       robotName="otie"
-      updateRobotStatus={mockUpdateRobotStatus}
+      isRobotBusy={false}
       {...props}
     />,
     {

--- a/app/src/organisms/Desktop/RobotSettingsCalibration/__tests__/RobotSettingsTipLengthCalibration.test.tsx
+++ b/app/src/organisms/Desktop/RobotSettingsCalibration/__tests__/RobotSettingsTipLengthCalibration.test.tsx
@@ -27,8 +27,6 @@ vi.mock('/app/resources/instruments')
 const mockFormattedPipetteOffsetCalibrations: FormattedPipetteOffsetCalibration[] =
   []
 
-const mockUpdateRobotStatus = vi.fn()
-
 const render = () => {
   return renderWithProviders(
     <RobotSettingsTipLengthCalibration
@@ -36,7 +34,7 @@ const render = () => {
         mockFormattedPipetteOffsetCalibrations
       }
       robotName="otie"
-      updateRobotStatus={mockUpdateRobotStatus}
+      isRobotBusy={false}
     />,
     {
       i18nInstance: i18n,

--- a/app/src/organisms/Desktop/RobotSettingsCalibration/index.tsx
+++ b/app/src/organisms/Desktop/RobotSettingsCalibration/index.tsx
@@ -25,7 +25,6 @@ import * as RobotApi from '/app/redux/robot-api'
 import * as Sessions from '/app/redux/sessions'
 import { getDeckCalibrationSession } from '/app/redux/sessions/deck-calibration/selectors'
 import { useAttachedPipettesFromInstrumentsQuery } from '/app/resources/instruments'
-import { useRunStatuses } from '/app/resources/runs'
 
 import { CalibrateDeck } from '../CalibrateDeck'
 import { CalibrationStatusCard } from '../CalibrationStatusCard'
@@ -52,7 +51,7 @@ const CALS_FETCH_MS = 5000
 
 interface CalibrationProps {
   robotName: string
-  updateRobotStatus: (isRobotBusy: boolean) => void
+  isRobotBusy: boolean
 }
 
 export interface FormattedPipetteOffsetCalibration {
@@ -70,7 +69,7 @@ const spinnerCommandBlockList: SessionCommandString[] = [
 
 export function RobotSettingsCalibration({
   robotName,
-  updateRobotStatus,
+  isRobotBusy,
 }: CalibrationProps): JSX.Element {
   const { t } = useTranslation([
     'device_settings',
@@ -143,7 +142,6 @@ export function RobotSettingsCalibration({
       (i): i is GripperData => i.instrumentType === 'gripper' && i.ok
     ) ?? null
   const attachedPipettes = useAttachedPipettesFromInstrumentsQuery()
-  const { isRunRunning: isRunning } = useRunStatuses()
   const pipettePresent =
     !(attachedPipettes.left == null) || !(attachedPipettes.right == null)
 
@@ -178,8 +176,8 @@ export function RobotSettingsCalibration({
   let buttonDisabledReason: string | null = null
   if (notConnectable) {
     buttonDisabledReason = t('shared:disabled_cannot_connect')
-  } else if (isRunning) {
-    buttonDisabledReason = t('shared:disabled_protocol_is_running')
+  } else if (isRobotBusy) {
+    buttonDisabledReason = t('shared:disabled_robot_is_busy')
   } else if (!pipettePresent) {
     buttonDisabledReason = t('shared:disabled_no_pipette_attached')
   }
@@ -332,7 +330,7 @@ export function RobotSettingsCalibration({
               formattedPipetteOffsetCalibrations
             }
             robotName={robotName}
-            updateRobotStatus={updateRobotStatus}
+            isRobotBusy={isRobotBusy}
           />
           <Divider marginY={0} />
           <RobotSettingsGripperCalibration
@@ -342,11 +340,11 @@ export function RobotSettingsCalibration({
           <Divider marginY={0} />
           <RobotSettingsModuleCalibration
             attachedModules={attachedModules}
-            updateRobotStatus={updateRobotStatus}
             formattedPipetteOffsetCalibrations={
               formattedPipetteOffsetCalibrations
             }
             robotName={robotName}
+            isRobotBusy={isRobotBusy}
           />
         </>
       ) : (
@@ -361,7 +359,7 @@ export function RobotSettingsCalibration({
               formattedPipetteOffsetCalibrations
             }
             robotName={robotName}
-            updateRobotStatus={updateRobotStatus}
+            isRobotBusy={isRobotBusy}
           />
           <Divider marginY={0} />
           <RobotSettingsTipLengthCalibration
@@ -369,7 +367,7 @@ export function RobotSettingsCalibration({
               formattedPipetteOffsetCalibrations
             }
             robotName={robotName}
-            updateRobotStatus={updateRobotStatus}
+            isRobotBusy={isRobotBusy}
           />
           <Divider marginY={0} />
           <CalibrationHealthCheck
@@ -377,6 +375,7 @@ export function RobotSettingsCalibration({
             dispatchRequests={dispatchRequests}
             isPending={isPending}
             robotName={robotName}
+            isRobotBusy={isRobotBusy}
           />
           <Divider marginBottom={SPACING.spacing24} />
           <CalibrationDataDownload

--- a/app/src/pages/Desktop/Devices/DeviceDetails/DeviceDetailsComponent.tsx
+++ b/app/src/pages/Desktop/Devices/DeviceDetails/DeviceDetailsComponent.tsx
@@ -20,7 +20,11 @@ import { RecentProtocolRuns } from '/app/organisms/Desktop/Devices/RecentProtoco
 import { RobotOverview } from '/app/organisms/Desktop/Devices/RobotOverview'
 import { DeviceDetailsDeckConfiguration } from '/app/organisms/DeviceDetailsDeckConfiguration'
 import { DISENGAGED, useEstopContext } from '/app/organisms/EmergencyStop'
-import { useIsFlex, useIsRobotViewable } from '/app/redux-resources/robots'
+import {
+  useIsFlex,
+  useIsRobotBusy,
+  useIsRobotViewable,
+} from '/app/redux-resources/robots'
 
 interface DeviceDetailsComponentProps {
   robotName: string
@@ -36,6 +40,7 @@ export function DeviceDetailsComponent({
   })
   const { isEmergencyStopModalDismissed } = useEstopContext()
   const isRobotViewable = useIsRobotViewable(robotName)
+  const isRobotBusy = useIsRobotBusy({ poll: true })
 
   // If we are explicitly redirected to an anchor link on this page,
   // scroll to it.
@@ -78,11 +83,16 @@ export function DeviceDetailsComponent({
         <InstrumentsAndModules
           robotName={robotName}
           isRobotViewable={isRobotViewable}
+          isRobotBusy={isRobotBusy}
         />
         {isRobotViewable && (
           <>
             <Divider width="100%" />
-            <Peripherals isFlex={isFlex} robotName={robotName} />
+            <Peripherals
+              isFlex={isFlex}
+              robotName={robotName}
+              isRobotBusy={isRobotBusy}
+            />
           </>
         )}
       </Flex>

--- a/app/src/pages/Desktop/Devices/RobotSettings/index.tsx
+++ b/app/src/pages/Desktop/Devices/RobotSettings/index.tsx
@@ -24,7 +24,11 @@ import { RobotSettingsCamera } from '/app/organisms/Desktop/Devices/RobotSetting
 import { RobotSettingsFeatureFlags } from '/app/organisms/Desktop/Devices/RobotSettings/RobotSettingsFeatureFlags'
 import { RobotSettingsNetworking } from '/app/organisms/Desktop/Devices/RobotSettings/RobotSettingsNetworking'
 import { RobotSettingsCalibration } from '/app/organisms/Desktop/RobotSettingsCalibration'
-import { useRobot, useRobotType } from '/app/redux-resources/robots'
+import {
+  useIsRobotBusy,
+  useRobot,
+  useRobotType,
+} from '/app/redux-resources/robots'
 import { getDevtoolsEnabled } from '/app/redux/config'
 import {
   CONNECTABLE,
@@ -34,29 +38,47 @@ import {
 } from '/app/redux/discovery'
 import { getRobotUpdateSession } from '/app/redux/robot-update'
 import { appShellRequestor } from '/app/redux/shell/remote'
-import { useCurrentRunId } from '/app/resources/runs'
 
 import type { DesktopRouteParams, RobotSettingsTab } from '/app/App/types'
+import type { DiscoveredRobot } from '/app/redux/discovery/types'
 
-export function RobotSettings(): JSX.Element | null {
+export function RobotSettings(): JSX.Element {
+  const { robotName } = useParams<
+    keyof DesktopRouteParams
+  >() as DesktopRouteParams
+  const robot = useRobot(robotName)
+
+  return (
+    <ApiHostProvider
+      hostname={robot?.ip ?? null}
+      port={robot?.port ?? null}
+      requestor={robot?.ip === OPENTRONS_USB ? appShellRequestor : undefined}
+    >
+      <RobotSettingsComponent robot={robot} />
+    </ApiHostProvider>
+  )
+}
+
+export function RobotSettingsComponent({
+  robot,
+}: {
+  robot: DiscoveredRobot | null
+}): JSX.Element | null {
   const { t } = useTranslation('device_settings')
   const { robotName, robotSettingsTab } = useParams<
     keyof DesktopRouteParams
   >() as DesktopRouteParams
-  const robot = useRobot(robotName)
   const robotType = useRobotType(robotName)
   const isCalibrationDisabled = robot?.status !== CONNECTABLE
   const isNetworkingDisabled = robot?.status === UNREACHABLE
   const [showRobotBusyBanner, setShowRobotBusyBanner] = useState<boolean>(false)
   const robotUpdateSession = useSelector(getRobotUpdateSession)
-  const doesRunExist = useCurrentRunId() != null
+  const isRobotBusy = useIsRobotBusy({ poll: true })
 
-  if (!showRobotBusyBanner && doesRunExist) {
+  if (isRobotBusy && !showRobotBusyBanner) {
     setShowRobotBusyBanner(true)
-  }
-
-  const updateRobotStatus = (isRobotBusy: boolean): void => {
-    if (isRobotBusy) setShowRobotBusyBanner(true)
+  } else if (!isRobotBusy && showRobotBusyBanner) {
+    setShowRobotBusyBanner(false)
   }
 
   const robotSettingsContentByTab: {
@@ -65,21 +87,20 @@ export function RobotSettings(): JSX.Element | null {
     calibration: (
       <RobotSettingsCalibration
         robotName={robotName}
-        updateRobotStatus={updateRobotStatus}
+        isRobotBusy={isRobotBusy}
       />
     ),
     networking: (
       <RobotSettingsNetworking
         robotName={robotName}
-        updateRobotStatus={updateRobotStatus}
+        isRobotBusy={isRobotBusy}
       />
     ),
-    camera: <RobotSettingsCamera robotType={robotType} />,
+    camera: (
+      <RobotSettingsCamera robotType={robotType} isRobotBusy={isRobotBusy} />
+    ),
     advanced: (
-      <RobotSettingsAdvanced
-        robotName={robotName}
-        updateRobotStatus={updateRobotStatus}
-      />
+      <RobotSettingsAdvanced robotName={robotName} isRobotBusy={isRobotBusy} />
     ),
     'feature-flags': <RobotSettingsFeatureFlags robotName={robotName} />,
   }
@@ -163,26 +184,18 @@ export function RobotSettings(): JSX.Element | null {
         </Flex>
       </Box>
       <Box padding={`${SPACING.spacing24} ${SPACING.spacing16}`}>
-        <ApiHostProvider
-          hostname={robot?.ip ?? null}
-          port={robot?.port ?? null}
-          requestor={
-            robot?.ip === OPENTRONS_USB ? appShellRequestor : undefined
-          }
+        <Flex
+          width="100%"
+          flexDirection={DIRECTION_COLUMN}
+          justifyContent={JUSTIFY_SPACE_AROUND}
+          backgroundColor={COLORS.white}
+          borderRadius={BORDERS.borderRadius8}
+          marginBottom={SPACING.spacing16}
+          paddingX={SPACING.spacing16}
+          paddingY={SPACING.spacing16}
         >
-          <Flex
-            width="100%"
-            flexDirection={DIRECTION_COLUMN}
-            justifyContent={JUSTIFY_SPACE_AROUND}
-            backgroundColor={COLORS.white}
-            borderRadius={BORDERS.borderRadius8}
-            marginBottom={SPACING.spacing16}
-            paddingX={SPACING.spacing16}
-            paddingY={SPACING.spacing16}
-          >
-            {robotSettingsContent}
-          </Flex>
-        </ApiHostProvider>
+          {robotSettingsContent}
+        </Flex>
       </Box>
     </>
   )

--- a/app/src/redux-resources/robots/hooks/useIsRobotBusy.ts
+++ b/app/src/redux-resources/robots/hooks/useIsRobotBusy.ts
@@ -9,7 +9,8 @@ import { useIsFlex } from '/app/redux-resources/robots'
 import { useNotifyCurrentMaintenanceRun } from '/app/resources/maintenance_runs'
 import { useNotifyAllRunsQuery } from '/app/resources/runs'
 
-const ROBOT_STATUS_POLL_MS = 30000
+const ROBOT_SUBSTATE_POLL_MS = 30000
+const ROBOT_STATUS_POLL_MS = 5000
 
 interface UseIsRobotBusyOptions {
   poll: boolean
@@ -35,7 +36,7 @@ export function useIsRobotBusy(
   })
   const { data: currentSubsystemsUpdatesData } =
     useCurrentAllSubsystemUpdatesQuery({
-      refetchInterval: ROBOT_STATUS_POLL_MS,
+      refetchInterval: ROBOT_SUBSTATE_POLL_MS,
     })
   const isSubsystemUpdating =
     currentSubsystemsUpdatesData?.data.some(

--- a/app/src/resources/runs/useCurrentRun.ts
+++ b/app/src/resources/runs/useCurrentRun.ts
@@ -7,7 +7,7 @@ const REFETCH_INTERVAL = 5000
 
 // TODO: doesn't have to fetch after status is terminal
 export function useCurrentRun(): Run | null {
-  const currentRunId = useCurrentRunId()
+  const currentRunId = useCurrentRunId({ refetchInterval: REFETCH_INTERVAL })
   const { data: runRecord } = useNotifyRunQuery(currentRunId, {
     refetchInterval: REFETCH_INTERVAL,
   })


### PR DESCRIPTION
# Overview

There is a lot of noise here, but all the changes stem from exactly three files:
```
RobotSettings/index.tsx
DeviceDetails/DeviceDetailsComponent.tsx
AdvancedTab/UpdateRobotSoftware.tsx
```

We render "robot is busy" banners on the robot details and robot settings views, however, the conditions in which we disable certain actions (ex., uploading zip files to a robot or allowing recalibration) are inconsistent from the conditions in which we render the banner. 

Currently, we disable or enable certain actions based on a variety of factors:

- Whether the robot is "busy", which is roughly defined as whether there is a maintenance run or protocol run in progress, or there is an active subsystem update.
- Whether a protocol run exists.
- Whether a user has clicked specific module CTAs. The implementation of this one currently lacks a way to disable the "robot is busy" state, so once those specific items were clicked, the robot was busy so long as a user was on the robot settings page.

Another downstream consequence of this logic is that we permit desktop users to launch a maintenance run flow while another maintenance run is active.

The proposed solution in this PR is the following:

- No actions of any kind should be permitted if the robot is busy (see the first bullet, above). This is the most conservative approach, but it is by far the least surprising to end-users. There's no more confusion why certain settings are disabled without the banner rendering and vice versa. For example, we _could_ in theory update camera settings while a run is in progress, but under this proposal, a user wouldn't be permitted to do so. The additional (and more important benefit I think), is the code is significantly more auditable - we invoke the `useIsRobotBusy` hook exactly once at the top level component responsible for rendering all the settings, and that's it.
- We only block updating by zip file if there is a current, non-terminal run.

NOTE: The one spot that is quite annoying is still the whole "run uncurrenting" logic, which will cause the banner to persist when an end-user may think it shouldn't. This isn't a regression introduced by this PR, but yeah, if a user over-eagerly navigates away from a run and the ODD can't implicitly close the run context, then the banner persists...but that's a different problem for a different day I think. 

<img width="941" height="764" alt="Screenshot 2025-11-08 at 1 35 21 PM" src="https://github.com/user-attachments/assets/041be479-a472-4b16-a551-aca7ad43c663" />

## Test Plan and Hands on Testing
- Smoke tested the Flex and the OT-2, starting runs, clicking all options in the Robot Settings views, verifying that the banners render and de-render appropriately.

## Changelog

- Fixed desktop robot settings and robot details pages inconsistently disabling items.
- Fixed desktop "robot busy" banners rendering or not rendering appropriately when certain settings or flows are not available on the robot settings and robot details pages.

## Risk assessment

mediumish - I think the real risk here comes from any sort of downstream bug, like, if we aren't properly closing a maintenance run somewhere, and this gets the robot stuck in a busy state.
