### PR TITLE
fix(api): correct image filenames

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/capture_image.py
+++ b/api/src/opentrons/protocol_engine/commands/capture_image.py
@@ -222,7 +222,7 @@ class CaptureImageImpl(
                 data=camera_data,
                 mime_type=MimeType.IMAGE_JPEG,
                 command_metadata=ImageCaptureCmdFileNameMetadata(
-                    step_number=len(self._state_view.commands.get_all()) + 1,
+                    step_number=len(self._state_view.commands.get_all()),
                     command_timestamp=datetime.now(),
                     base_filename=params.fileName,
                     command_id=this_cmd_id or "",


### PR DESCRIPTION
# Overview

The step number that is a part of image data file names is off by one. The underlying `commands.get_all()` includes the current command as a part of state, whoops.

## Test Plan and Hands on Testing

- Verified that individual image file names reflect the protocol command step that produced the image.

## Changelog

- Image filenames now reflect the actual step at which they occurred.

## Risk assessment
- very low, just impacts filenames.
