### PR TITLE
fix(api): fix a zero move length error

### DIFF
--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -664,11 +664,11 @@ class OT3Controller(FlexBackend):
             return None, False
         # Create a target that doesn't incorporate the plunger into a joint axis with the gantry
         plunger_axes = [Axis.P_L, Axis.P_R]
-        move_target = self._move_manager.devectorize_axes(
-            origin, target, speed, plunger_axes
-        )
 
         try:
+            move_target = self._move_manager.devectorize_axes(
+                origin, target, speed, plunger_axes
+            )
             _, movelist = self._move_manager.plan_motion(
                 origin=origin, target_list=[move_target]
             )

--- a/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
@@ -1454,6 +1454,32 @@ def move_group_run_side_effect(
             },
             None,
         ],
+        [
+            {
+                Axis.X: 0,
+                Axis.Y: 0,
+                Axis.Z_L: 0,
+                Axis.Z_R: 0,
+                Axis.P_L: 0,
+            },
+            {
+                Axis.X: 0,  # Zero Length Move, make sure it doesn't raise an error
+                Axis.Y: 0,
+                Axis.Z_L: 0,
+                Axis.P_L: 0,
+            },
+            {
+                Axis.X: 0,
+                Axis.Y: 0,
+                Axis.Z_L: 0,
+                Axis.Z_R: 0,
+                Axis.P_L: 0,
+                Axis.P_R: 0,
+                Axis.Z_G: 0,
+                Axis.G: 0,
+            },
+            None,
+        ],
     ],
 )
 async def test_controller_move(


### PR DESCRIPTION
# Overview
new motion planning from dynamic pipetting can trigger a zero move length error in a new spot so that call needs to be added into the try/except portion.