### PR TITLE
fix(robot-server): Ensure camera device existence is validate for all endpoints

### DIFF
--- a/api/src/opentrons/system/camera.py
+++ b/api/src/opentrons/system/camera.py
@@ -363,3 +363,9 @@ def get_boot_id() -> str:
         return Path("/proc/sys/kernel/random/boot_id").read_text().strip()
     else:
         return "SIMULATED_BOOT_ID"
+
+
+def camera_exists() -> bool:
+    """Validate whether or not the camera device exists."""
+    return os.path.exists(DEFAULT_SYSTEM_CAMERA)
+    # todo(chb, 2025-11-10): Eventually when we support multiple cameras this should accept a camera parameter to check for

--- a/robot-server/robot_server/runs/router/camera_router.py
+++ b/robot-server/robot_server/runs/router/camera_router.py
@@ -9,7 +9,8 @@ from server_utils.fastapi_utils.light_router import LightRouter
 from opentrons.protocol_engine.resources.camera_provider import CameraSettings
 from opentrons.system import camera
 
-from robot_server.errors.error_responses import ErrorBody
+from opentrons_shared_data.errors import ErrorCodes
+from robot_server.errors.error_responses import ErrorBody, LegacyErrorResponse
 from robot_server.service.json_api import (
     RequestModel,
     SimpleBody,
@@ -47,6 +48,7 @@ camera_router = LightRouter()
         status.HTTP_201_CREATED: {"model": SimpleBody[CameraSettings]},
         status.HTTP_404_NOT_FOUND: {"model": ErrorBody[RunNotFound]},
         status.HTTP_409_CONFLICT: {"model": ErrorBody[Union[RunStopped, RunNotIdle]]},
+        status.HTTP_503_SERVICE_UNAVAILABLE: {},
     },
 )
 async def add_camera_settings(
@@ -67,6 +69,11 @@ async def add_camera_settings(
         robot_type: Used to validate robot type for live stream service.
         camera_provider: Access to the camera settings and related services.
     """
+    if not camera.camera_exists():
+        raise LegacyErrorResponse(
+            message="Video device is unavailable.",
+            errorCode=ErrorCodes.GENERAL_ERROR.value.code,
+        ).as_error(status.HTTP_503_SERVICE_UNAVAILABLE)
     if run.current is False:
         raise RunStopped(detail=f"Run {run.id} is not the current run").as_error(
             status.HTTP_409_CONFLICT

--- a/robot-server/robot_server/service/legacy/routers/camera.py
+++ b/robot-server/robot_server/service/legacy/routers/camera.py
@@ -221,6 +221,7 @@ async def get_live_stream(
     RTMP:
         The full RTMP stream URL is formatted as: rtmp://{ROBOT_IP}/live/stream
     """
+    _validate_camera_present()
     enable_status = camera_settings_store.get_live_stream_enabled()
     return LiveStreamData(
         enabled=enable_status,
@@ -252,6 +253,7 @@ async def post_live_stream_settings(
     Arguments:
         request_body: Input payload from the request body.
     """
+    _validate_camera_present()
     if camera.robot_supports_livestream(robot_type) is False:
         raise LegacyErrorResponse(
             message="Opentrons Live Stream service is not available on OT-2.",
@@ -347,6 +349,7 @@ async def get_live_stream_settings(
 
 
 def _get_stream_settings() -> LiveStreamSettings:
+    _validate_camera_present()
     contents = camera.load_stream_configuration_file_data()
     if contents is None:
         raise LegacyErrorResponse(
@@ -411,7 +414,7 @@ def _live_stream_settings_to_configuration_file(
 
 
 def _validate_camera_present() -> None:
-    if IS_ROBOT and not os.path.exists(DEFAULT_CAMERA_PATH):
+    if IS_ROBOT and not camera.camera_exists():
         # todo(chb, 2025-09-19): for the time being we will just be checking that the embedded flex camera exists to satisfy requirements
         # incase the camera isn't present, however eventually we can change this to support dynamically set third party cameras
         raise LegacyErrorResponse(


### PR DESCRIPTION
# Overview
Covers RQA-4839

This PR ensures that the camera device is always validated to exist first before any action is taken regarding any camera behavior anywhere.

## Test Plan and Hands on Testing

- [x] Ensure any given camera endpoint returns a 503 or related error when talking to a device with no cameras

## Changelog


## Review requests


## Risk assessment
Low - affects new behavior