### PR TITLE
feat(protocol-designer): handle full tip selection

### DIFF
--- a/protocol-designer/src/assets/localization/en/tip_selection.json
+++ b/protocol-designer/src/assets/localization/en/tip_selection.json
@@ -1,4 +1,6 @@
 {
+  "all_pickups_selected": "All pickups have been selected",
+  "all_tips_selected": "All tips selected",
   "click_to_select": "Click to select tips in {{labwareName}}",
   "continue": "Continue",
   "go_back": "Go back",
@@ -20,9 +22,9 @@
   "select": "Select",
   "selected": "Selected",
   "select_tiprack": "Select a tip rack to pick up tips from",
-  "select_tip": "Select tip",
   "select_tips": "Select tips",
   "select_tips_for_tracking": "Select tips for manual tip tracking",
+  "tip_accessible": { "deselect": "Deselect tip", "select": "Select tip" },
   "tip_inaccessible": {
     "collision": "Selection will cause a collision",
     "incomplete": "Selection will be incomplete",

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/PipetteShadows/PipetteShadow.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/PipetteShadows/PipetteShadow.tsx
@@ -146,7 +146,7 @@ export function PipetteShadow(props: {
         ? t('tip_accessible.deselect')
         : t('tip_accessible.select')
     }
-    console.warn('No label text found')
+    console.error('No label text found')
     return ''
   })()
 

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/PipetteShadows/PipetteShadow.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/PipetteShadows/PipetteShadow.tsx
@@ -54,6 +54,8 @@ export function PipetteShadow(props: {
   labwareState: AllTemporalPropertiesForTimelineFrame['labware']
   isAccessible: boolean
   inaccessibleReason: InaccessibleReason | null
+  isHoveredWellSelected: boolean
+  hasPickupsRemaining: boolean
   primaryNozzle: string
   robotType: RobotType
   enclosingViewbox: string | null
@@ -66,6 +68,8 @@ export function PipetteShadow(props: {
     labwareState,
     isAccessible,
     inaccessibleReason,
+    isHoveredWellSelected,
+    hasPickupsRemaining,
     primaryNozzle,
     robotType,
     enclosingViewbox,
@@ -94,15 +98,24 @@ export function PipetteShadow(props: {
   const { backLeftCorner, frontRightCorner } = pipetteBoundingBoxOffsets
   const width = frontRightCorner[0] - backLeftCorner[0]
   const height = backLeftCorner[1] - frontRightCorner[1]
+
+  const isError =
+    !isAccessible || (!hasPickupsRemaining && !isHoveredWellSelected)
+
   const shadowProps = {
     x: slotX + xOffset,
     y: slotY + yOffset,
     width,
     height,
-    stroke: isAccessible ? COLORS.blue50 : COLORS.red50,
-    fill: isAccessible
-      ? `${COLORS.black90}${COLORS.opacity20HexCode}`
-      : `${COLORS.red50}${COLORS.opacity20HexCode}`,
+    ...(isError
+      ? {
+          fill: `${COLORS.red50}${COLORS.opacity20HexCode}`,
+          stroke: COLORS.red50,
+        }
+      : {
+          fill: `${COLORS.black90}${COLORS.opacity20HexCode}`,
+          stroke: COLORS.blue50,
+        }),
   }
 
   const labelPlacement = getPlacementByViewboxAndPipetteSpec({
@@ -121,10 +134,22 @@ export function PipetteShadow(props: {
     shadowWidth: width,
     shadowHeight: height,
   })
-  const labelText =
-    !isAccessible && inaccessibleReason != null
-      ? t(`tip_inaccessible.${inaccessibleReason}`)
-      : t('select_tip')
+  const labelText = (() => {
+    if (!hasPickupsRemaining && !isHoveredWellSelected) {
+      return t('all_pickups_selected')
+    }
+    if (!isAccessible && inaccessibleReason != null) {
+      return t(`tip_inaccessible.${inaccessibleReason}`)
+    }
+    if (isAccessible) {
+      return isHoveredWellSelected
+        ? t('tip_accessible.deselect')
+        : t('tip_accessible.select')
+    }
+    console.warn('No label text found')
+    return ''
+  })()
+
   return (
     <g className={styles.shadow_overlay}>
       <PipetteLabel
@@ -134,7 +159,7 @@ export function PipetteShadow(props: {
         x={slotX + xOffset + labelOffsetX}
         y={slotY + yOffset + labelOffsetY}
         placement={labelPlacement}
-        isError={!isAccessible}
+        isError={isError}
       />
       <ShadowComponent {...shadowProps} />
     </g>

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/SelectTips.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/SelectTips.tsx
@@ -153,6 +153,7 @@ export function SelectTips(
         : acc
     }, null)
   const numPickupsRemaining = numTotalPickups - selectedTips.length
+  const hasPickupsRemaining = numPickupsRemaining > 0
 
   const handleUnselectWell = (unselectIndex: number): void => {
     setSelectedTips(selectedTips.slice(0, unselectIndex))
@@ -183,14 +184,14 @@ export function SelectTips(
       if (wellName in prevSelectedTipsByIndex) {
         const indexToUnselect = prevSelectedTipsByIndex[wellName]
         handleUnselectWell(indexToUnselect)
-      } else if (numPickupsRemaining > 0) {
+      } else if (hasPickupsRemaining) {
         setSelectedTips(prevTips => [...prevTips, [wellName]])
       }
     } else if (channels === 8 || (channels === 96 && nozzles === COLUMN)) {
       if (wellName in prevSelectedTipsByIndex) {
         const indexToUnselect = prevSelectedTipsByIndex[wellName]
         handleUnselectWell(indexToUnselect)
-      } else if (numPickupsRemaining > 0) {
+      } else if (hasPickupsRemaining) {
         const allWellsInColumn = getAllWellsInColumn(wellName, labwareDef)
         setSelectedTips(prevTips => {
           const newTips = [...prevTips]
@@ -203,7 +204,7 @@ export function SelectTips(
       if (wellName in prevSelectedTipsByIndex) {
         const indexToUnselect = prevSelectedTipsByIndex[wellName]
         handleUnselectWell(indexToUnselect)
-      } else if (numPickupsRemaining > 0) {
+      } else if (hasPickupsRemaining) {
         setSelectedTips(prevTips => [...prevTips, allWells])
       }
     }
@@ -272,10 +273,13 @@ export function SelectTips(
               if (!tipAccessibileStatusByWellName[wellName].isAccessible) {
                 status = rawState === NO ? NO : INACCESSIBLE
               }
-              if (selectedTips.some(tipSet => tipSet.includes(wellName))) {
+              if (selectedTips.flat().some(tip => tip === wellName)) {
                 status = rawState === USED ? SELECTED_USED : SELECTED
               } else if (allWellsAffectedByHover.includes(wellName)) {
-                if (areAllHoveredWellsAccessibleAndOccupied) {
+                if (
+                  areAllHoveredWellsAccessibleAndOccupied &&
+                  hasPickupsRemaining
+                ) {
                   status = rawState === USED ? SELECTED_USED : SELECTED
                 } else {
                   status = SELECTED_ERROR
@@ -315,6 +319,10 @@ export function SelectTips(
             hoveredWell={hoveredWell}
             selectedTiprackId={selectedTiprackId}
             labwareState={activeDeckSetup.labware}
+            isHoveredWellSelected={selectedTips
+              .flat()
+              .some(tip => tip === hoveredWell)}
+            hasPickupsRemaining={hasPickupsRemaining}
             isAccessible={hoveredWellsInaccessibilityStatus == null}
             inaccessibleReason={hoveredWellsInaccessibilityStatus}
             primaryNozzle={primaryNozzle}
@@ -331,13 +339,15 @@ export function SelectTips(
         <StyledText desktopStyle="headingSmallBold">
           {t('click_to_select', { labwareName })}
         </StyledText>
-        {numPickupsRemaining > 0 ? (
-          <Chip
-            text={t('pickups_remaining', { count: numPickupsRemaining })}
-            type="info"
-            hasIcon={false}
-          />
-        ) : null}
+        <Chip
+          {...(hasPickupsRemaining
+            ? {
+                text: t('pickups_remaining', { count: numPickupsRemaining }),
+                type: 'info',
+              }
+            : { text: t('all_tips_selected'), type: 'success' })}
+          hasIcon={false}
+        />
       </Flex>
       <div className={styles.modal_body_select_tips}>
         <div className={styles.select_tips_deck_container}>


### PR DESCRIPTION
# Overview

This PR adds the correct state for the SelectTips component for when all pickup selections have been made. Specifically, it wires up the success Chip component in the top right of the component above the deck map, and adds an error state for all non-deselect hovers if there are no pickups remaining.

To do:
- [ ] add unit tests

Closes AUTH-2477

https://github.com/user-attachments/assets/4043df30-c1d8-4382-a5c3-7d6c5151e8fc

## Test Plan and Hands on Testing

- create or import a protocol with a liquid handling step with manual tip selection
- navigate to select tips
- select the full number of pickups required
- verify that the chip in the top right turns to success type, and has text "All tips selected"
- hover a selected tip, and verify that the pipette shadow reads "Deselect tip"
- hover any other tips, and verify that the pipette shadow is in error state, and reads "All pickups have been selected"

## Changelog

#### `SelectTips.tsx`
- implement `Chip` component correctly according to designs, ensuring success state for when all pickups have been selected
- check number of pickups remaining when determining tip well state 

#### `PipetteShadow.tsx`
- pass logic for whether hovered well is selected, and whether pickups are remaining
- use above booleans to determine copy and success/error state of pipette shadow and label

#### tip_selection.json
- add and refactor translations for all tips selected state

## Review requests

see test plan

## Risk assessment

low