### PR TITLE
refactor(app): clean up and fix svg deck map layers PV

### DIFF
--- a/app/src/pages/Desktop/Protocols/ProtocolVisualization/DeckView.tsx
+++ b/app/src/pages/Desktop/Protocols/ProtocolVisualization/DeckView.tsx
@@ -26,7 +26,11 @@ import { getSlotInLocationStack } from '@opentrons/step-generation'
 
 import { POTENTIAL_TRASH_COMMAND_TYPES } from './consants'
 import { DeckViewDetails } from './DeckViewDetails'
-import { getActiveLayer, getBackgroundColor, isCutoutA1Active } from './utils'
+import {
+  getActiveLayer,
+  getBackgroundColor,
+  getIsCutoutA1Active,
+} from './utils'
 import styles from './visualization.module.css'
 
 import type { Dispatch, SetStateAction } from 'react'
@@ -184,7 +188,7 @@ export function DeckView(props: DeckViewProps): JSX.Element {
                         showExpansion={cutoutId === 'cutoutA1'}
                         fixtureBaseColor={
                           isActiveLayerVisible ||
-                          isCutoutA1Active(
+                          getIsCutoutA1Active(
                             labware,
                             modules,
                             cutoutId,

--- a/app/src/pages/Desktop/Protocols/ProtocolVisualization/DeckView.tsx
+++ b/app/src/pages/Desktop/Protocols/ProtocolVisualization/DeckView.tsx
@@ -26,7 +26,7 @@ import { getSlotInLocationStack } from '@opentrons/step-generation'
 
 import { POTENTIAL_TRASH_COMMAND_TYPES } from './consants'
 import { DeckViewDetails } from './DeckViewDetails'
-import { getActiveLayer, getBackgroundColor } from './utils'
+import { getActiveLayer, getBackgroundColor, isCutoutA1Active } from './utils'
 import styles from './visualization.module.css'
 
 import type { Dispatch, SetStateAction } from 'react'
@@ -92,7 +92,7 @@ export function DeckView(props: DeckViewProps): JSX.Element {
     stagingAreaEntities,
     labwareEntities,
   } = invariantContext
-  const { labware } = robotState
+  const { labware, modules } = robotState
   const loadLabwareCommands = commands.filter(
     command => command.commandType === 'loadLabware'
   )
@@ -175,11 +175,6 @@ export function DeckView(props: DeckViewProps): JSX.Element {
                             selectedRunTimeCommand
                           )
                         : { isActiveLayerVisible: false }
-                    let strokeColor = 'none'
-
-                    if (hoveredSlot === addressableArea.id) {
-                      strokeColor = COLORS.purple50
-                    }
 
                     return cutoutId != null ? (
                       <SingleSlotFixture
@@ -188,10 +183,17 @@ export function DeckView(props: DeckViewProps): JSX.Element {
                         deckDefinition={deckDef}
                         showExpansion={cutoutId === 'cutoutA1'}
                         fixtureBaseColor={
-                          isActiveLayerVisible ? COLORS.purple30 : lightFill
+                          isActiveLayerVisible ||
+                          isCutoutA1Active(
+                            labware,
+                            modules,
+                            cutoutId,
+                            selectedRunTimeCommand
+                          )
+                            ? COLORS.purple30
+                            : lightFill
                         }
                         slotClipColor={darkFill}
-                        stroke={strokeColor}
                       />
                     ) : null
                   })}
@@ -241,12 +243,6 @@ export function DeckView(props: DeckViewProps): JSX.Element {
                               onClick={() => {
                                 setSelectedSlot(slot)
                               }}
-                              onMouseEnter={() => {
-                                setHoveredSlot(slot)
-                              }}
-                              onMouseLeave={() => {
-                                setHoveredSlot(null)
-                              }}
                             />
                           </Fragment>
                         )
@@ -277,7 +273,6 @@ export function DeckView(props: DeckViewProps): JSX.Element {
                 hoveredSlot={hoveredSlot}
                 setHoveredSlot={setHoveredSlot}
                 robotType={robotType}
-                selectedSlot={selectedSlot}
                 setSelectedSlot={setSelectedSlot}
                 robotState={robotState}
                 invariantContext={invariantContext}

--- a/app/src/pages/Desktop/Protocols/ProtocolVisualization/DeckViewDetails.tsx
+++ b/app/src/pages/Desktop/Protocols/ProtocolVisualization/DeckViewDetails.tsx
@@ -1,37 +1,16 @@
-import { Fragment } from 'react'
-
-import {
-  COLORS,
-  Module,
-  SingleSlotFixture,
-  StyledText,
-} from '@opentrons/components'
 import {
   getAddressableAreaFromSlotId,
-  getModuleDef,
   getPositionFromSlotId,
-  inferModuleOrientationFromXCoordinate,
-  isAddressableAreaStandardSlot,
-  THERMOCYCLER_MODULE_TYPE,
 } from '@opentrons/shared-data'
-import { getSlotInLocationStack } from '@opentrons/step-generation'
 
 import { POTENTIAL_TRASH_COMMAND_TYPES } from './consants'
-import { DeckViewOverlay } from './DeckViewOverlay'
+import { DeckViewLabware } from './DeckViewLabware'
+import { DeckViewModules } from './DeckViewModules'
+import { DeckViewSlots } from './DeckViewSlots'
 import { FixtureCommandSummary } from './FixtureCommandSummary'
-import { LabwareCommandSummary } from './LabwareCommandSummary'
-import { LabwareOnDeck } from './LabwareOnDeck'
-import { ModuleCommandSummary } from './ModuleCommandSummary'
-import {
-  getActiveLayer,
-  getSlotIdsBlockedBySpanningForThermocycler,
-  getSlotIsEmpty,
-  getStagingAreaAddressableAreas,
-  getTopmostLabwareOnModuleFromStack,
-} from './utils'
+import { getSlotIdsBlockedBySpanningForThermocycler } from './utils'
 
-import type { ComponentProps, Dispatch, SetStateAction } from 'react'
-import type { ThermocyclerVizProps } from '@opentrons/components'
+import type { Dispatch, SetStateAction } from 'react'
 import type {
   CutoutId,
   DeckDefinition,
@@ -41,7 +20,6 @@ import type {
 } from '@opentrons/shared-data'
 import type {
   InvariantContext,
-  ModuleTemporalProperties,
   TimelineFrame,
 } from '@opentrons/step-generation'
 import type { LabwareEntityExtended } from './DeckView'
@@ -51,7 +29,6 @@ interface DeckViewDetailsProps {
   liquids: Liquid[]
   robotState: TimelineFrame
   robotType: RobotType
-  selectedSlot: string | null
   setSelectedSlot: Dispatch<SetStateAction<string | null>>
   stagingAreaCutoutIds: CutoutId[]
   invariantContext: InvariantContext
@@ -64,7 +41,6 @@ export function DeckViewDetails(props: DeckViewDetailsProps): JSX.Element {
   const {
     robotState,
     robotType,
-    selectedSlot,
     deckDef,
     setSelectedSlot,
     stagingAreaCutoutIds,
@@ -75,15 +51,12 @@ export function DeckViewDetails(props: DeckViewDetailsProps): JSX.Element {
     liquids,
     labwareEntitiesExtended,
   } = props
-  const { labware, modules } = robotState
-  const { labwareEntities, moduleEntities, trashBinEntities } = invariantContext
+  const { modules } = robotState
+  const { moduleEntities, trashBinEntities } = invariantContext
   const slotIdsBlockedBySpanning = getSlotIdsBlockedBySpanningForThermocycler(
     modules,
     moduleEntities,
     robotType
-  )
-  const trashSlots = Object.values(trashBinEntities).map(
-    trash => trash.location.split('cutout')[1]
   )
   const pipetteCurrentTrashId = Object.values(robotState.pipettes).find(
     pipette =>
@@ -107,395 +80,43 @@ export function DeckViewDetails(props: DeckViewDetailsProps): JSX.Element {
   return (
     <>
       {/* all modules */}
-      {Object.entries(modules).map(([id, { slot, moduleState }]) => {
-        const slotPosition = getPositionFromSlotId(slot, deckDef)
-        if (slotPosition == null) {
-          console.warn(`no slot ${slot} for module ${id}`)
-          return null
-        }
-        const labwareLoadedOnModuleId = getTopmostLabwareOnModuleFromStack(
-          id,
-          Object.values(labware)
-        )
-        const isStepAssosciatedWithModule =
-          selectedRunTimeCommand != null &&
-          'moduleId' in selectedRunTimeCommand.params &&
-          selectedRunTimeCommand.params.moduleId === id
-        const { isActiveLayerVisible } = getActiveLayer(
-          labwareLoadedOnModuleId,
-          selectedRunTimeCommand
-        )
-        const moduleDef = getModuleDef(moduleEntities[id].model)
-        const moduleType = moduleEntities[id].type
-
-        const getModuleInnerProps = (
-          moduleState: ModuleTemporalProperties['moduleState']
-        ): ComponentProps<typeof Module>['innerProps'] => {
-          if (moduleState.type === THERMOCYCLER_MODULE_TYPE) {
-            let lidMotorState = 'unknown'
-            if (moduleState.lidOpen) {
-              lidMotorState = 'open'
-            } else if (moduleState.lidOpen === false) {
-              lidMotorState = 'closed'
-            }
-            return {
-              lidMotorState,
-              blockTargetTemp: moduleState.blockTargetTemp,
-            }
-          } else if (
-            'targetTemperature' in moduleState &&
-            moduleState.type === 'temperatureModuleType'
-          ) {
-            return {
-              targetTemperature: moduleState.targetTemperature,
-            }
-          } else if ('targetTemp' in moduleState) {
-            return {
-              targetTemp: moduleState.targetTemp,
-            }
-          }
-        }
-        const tempInnerProps = getModuleInnerProps(moduleState)
-        const innerTCProps = {
-          ...tempInnerProps,
-          lidMotorState:
-            (tempInnerProps as ThermocyclerVizProps)?.lidMotorState !== 'open'
-              ? 'closed'
-              : 'open',
-        }
-
-        const fixtureBaseColor =
-          isStepAssosciatedWithModule || isActiveLayerVisible
-            ? COLORS.purple30
-            : COLORS.grey35
-        let strokeColor = 'none'
-
-        if (
-          hoveredSlot === slot ||
-          (moduleType === THERMOCYCLER_MODULE_TYPE && hoveredSlot === 'B1')
-        ) {
-          strokeColor = COLORS.purple50
-        }
-        return (
-          <Fragment key={id}>
-            {
-              <>
-                {moduleType === THERMOCYCLER_MODULE_TYPE ? (
-                  <SingleSlotFixture
-                    key="A1"
-                    cutoutId="cutoutA1"
-                    deckDefinition={deckDef}
-                    showExpansion={true}
-                    fixtureBaseColor={fixtureBaseColor}
-                    slotClipColor={COLORS.grey60}
-                    stroke={strokeColor}
-                  />
-                ) : null}
-                <SingleSlotFixture
-                  key={slot}
-                  cutoutId={`cutout${slot}` as CutoutId}
-                  deckDefinition={deckDef}
-                  showExpansion={false}
-                  fixtureBaseColor={fixtureBaseColor}
-                  slotClipColor={COLORS.grey60}
-                  stroke={strokeColor}
-                />
-                <Module
-                  key={id}
-                  x={slotPosition[0]}
-                  y={slotPosition[1]}
-                  def={moduleDef}
-                  orientation={inferModuleOrientationFromXCoordinate(
-                    slotPosition[0]
-                  )}
-                  innerProps={
-                    moduleType === THERMOCYCLER_MODULE_TYPE
-                      ? innerTCProps
-                      : tempInnerProps
-                  }
-                  targetSlotId={slot}
-                  targetDeckId={deckDef.otId}
-                  childrenPositioningMode="offsetToSlot"
-                  setSelectedSlot={setSelectedSlot}
-                  setHoveredSlot={setHoveredSlot}
-                >
-                  {labwareLoadedOnModuleId != null ? (
-                    <>
-                      <LabwareOnDeck
-                        robotState={robotState}
-                        labwareDef={
-                          labwareEntities[labwareLoadedOnModuleId].def
-                        }
-                        liquids={liquids}
-                        labwareId={labwareLoadedOnModuleId}
-                        x={0}
-                        y={0}
-                        setSelectedSlot={setSelectedSlot}
-                        setHoveredSlot={setHoveredSlot}
-                      />
-                      {hoveredSlot === slot ? (
-                        moduleType === THERMOCYCLER_MODULE_TYPE ? (
-                          <DeckViewOverlay
-                            key={slot}
-                            slotId={slot}
-                            slotPosition={[0, 0, 0]}
-                            opacity={0.9}
-                            slotFillColor={COLORS.purple50}
-                            robotType={robotType}
-                            invariantContext={invariantContext}
-                            robotState={robotState}
-                            setSelectedSlot={setSelectedSlot}
-                            setHoveredSlot={setHoveredSlot}
-                          >
-                            <StyledText
-                              desktopStyle="captionRegular"
-                              color={COLORS.white}
-                            >
-                              {
-                                labwareEntities[labwareLoadedOnModuleId].def
-                                  .metadata.displayName
-                              }
-                            </StyledText>
-                          </DeckViewOverlay>
-                        ) : (
-                          <DeckViewOverlay
-                            key={slot}
-                            slotId={slot}
-                            slotPosition={slotPosition}
-                            opacity={0.9}
-                            slotFillColor={COLORS.purple50}
-                            robotType={robotType}
-                            invariantContext={invariantContext}
-                            robotState={robotState}
-                            setSelectedSlot={setSelectedSlot}
-                            setHoveredSlot={setHoveredSlot}
-                          >
-                            <StyledText
-                              desktopStyle="captionRegular"
-                              color={COLORS.white}
-                            >
-                              {labwareEntitiesExtended[id].nickName ??
-                                labwareEntities[labwareLoadedOnModuleId].def
-                                  .metadata.displayName}
-                            </StyledText>
-                          </DeckViewOverlay>
-                        )
-                      ) : null}
-                    </>
-                  ) : null}
-                </Module>
-                {(isActiveLayerVisible || isStepAssosciatedWithModule) &&
-                selectedRunTimeCommand != null ? (
-                  <ModuleCommandSummary
-                    robotType={robotType}
-                    moduleModel={moduleDef.model}
-                    commandType={selectedRunTimeCommand.commandType}
-                    position={slotPosition}
-                    showModuleIcon={false}
-                    slot={slot}
-                    orientation={inferModuleOrientationFromXCoordinate(
-                      slotPosition[0]
-                    )}
-                  />
-                ) : null}
-              </>
-            }
-          </Fragment>
-        )
-      })}
+      <DeckViewModules
+        robotState={robotState}
+        invariantContext={invariantContext}
+        liquids={liquids}
+        robotType={robotType}
+        deckDef={deckDef}
+        labwareEntitiesExtended={labwareEntitiesExtended}
+        setSelectedSlot={setSelectedSlot}
+        setHoveredSlot={setHoveredSlot}
+        hoveredSlot={hoveredSlot}
+        selectedRunTimeCommand={selectedRunTimeCommand}
+      />
       {/* SlotControls for all empty deck */}
-      {deckDef.locations.addressableAreas
-        .filter(addressableArea => {
-          const stagingAreaAddressableAreas =
-            getStagingAreaAddressableAreas(stagingAreaCutoutIds)
-
-          const addressableAreas =
-            isAddressableAreaStandardSlot(addressableArea.id, deckDef) ||
-            stagingAreaAddressableAreas.includes(addressableArea.id)
-          return (
-            addressableAreas &&
-            !slotIdsBlockedBySpanning.includes(addressableArea.id) &&
-            getSlotIsEmpty(robotState, addressableArea.id) &&
-            !trashSlots.includes(addressableArea.id)
-          )
-        })
-
-        .map(addressableArea => {
-          return (
-            <Fragment key={addressableArea.id}>
-              <SingleSlotFixture
-                onMouseEnter={() => {
-                  setHoveredSlot(addressableArea.id)
-                }}
-                onMouseLeave={() => {
-                  setHoveredSlot(null)
-                }}
-                onClick={() => {
-                  setSelectedSlot(addressableArea.id)
-                }}
-                cursor="pointer"
-                cutoutId={`cutout${addressableArea.id}` as CutoutId}
-                deckDefinition={deckDef}
-                slotClipColor={
-                  selectedSlot === addressableArea.id ||
-                  hoveredSlot === addressableArea.id
-                    ? COLORS.grey60
-                    : COLORS.transparent
-                }
-                fixtureBaseColor={COLORS.transparent}
-                stroke={
-                  hoveredSlot === addressableArea.id ? COLORS.purple50 : 'none'
-                }
-              />
-            </Fragment>
-          )
-        })}
-      {/* all labware on deck NOT those in modules */}
-      {Object.entries(labware).map(([id, lw]) => {
-        if (
-          Object.keys(modules).some(moduleId => lw.stack.includes(moduleId))
-        ) {
-          return null
-        }
-        const slot = getSlotInLocationStack(lw.stack)
-        const slotPosition = getPositionFromSlotId(slot, deckDef)
-        const slotBoundingBox = getAddressableAreaFromSlotId(
-          slot,
-          deckDef
-        )?.boundingBox
-        if (slotPosition == null || slotBoundingBox == null) {
-          console.warn(
-            `no slot ${slot} for labware ${Object.keys(labware)[0]}!`
-          )
-          return null
-        }
-        const { isActiveLayerVisible } = getActiveLayer(
-          id,
-          selectedRunTimeCommand
-        )
-        return (
-          <Fragment key={id}>
-            <LabwareOnDeck
-              x={slotPosition[0]}
-              y={slotPosition[1]}
-              robotState={robotState}
-              labwareDef={labwareEntities[id].def}
-              liquids={liquids}
-              labwareId={id}
-              setSelectedSlot={setSelectedSlot}
-              setHoveredSlot={setHoveredSlot}
-            />
-            {hoveredSlot === slot ? (
-              <DeckViewOverlay
-                key={`${slot}_hoveredSlot_labware`}
-                slotId={slot}
-                slotPosition={slotPosition}
-                slotFillColor={COLORS.purple50}
-                opacity={0.9}
-                robotType={robotType}
-                invariantContext={invariantContext}
-                robotState={robotState}
-                setSelectedSlot={setSelectedSlot}
-                setHoveredSlot={setHoveredSlot}
-              >
-                <StyledText desktopStyle="captionRegular" color={COLORS.white}>
-                  {labwareEntitiesExtended[id].nickName ??
-                    labwareEntities[id].def.metadata.displayName}
-                </StyledText>
-              </DeckViewOverlay>
-            ) : null}
-            {isActiveLayerVisible && selectedRunTimeCommand != null ? (
-              <LabwareCommandSummary
-                commandType={selectedRunTimeCommand.commandType}
-                position={slotPosition}
-                labwareDef={labwareEntities[id].def}
-                showModuleIcon={false}
-              />
-            ) : null}
-          </Fragment>
-        )
-      })}
-      {/* all nested labwares */}
-      {Object.entries(labware).map(([id, lw]) => {
-        if (
-          Object.keys(modules).some(moduleId => lw.stack.includes(moduleId))
-        ) {
-          return null
-        }
-        if (
-          deckDef.locations.addressableAreas.some(addressableArea =>
-            lw.stack.includes(addressableArea.id)
-          )
-        ) {
-          return null
-        }
-        const slotForOnTheDeck = getSlotInLocationStack(lw.stack)
-        const moduleId = Object.values(moduleEntities).find(
-          mod => mod.id === slotForOnTheDeck
-        )?.id
-        const slotForOnMod = moduleId != null ? modules[moduleId].slot : null
-        let slotPosition = null
-        if (slotForOnMod != null) {
-          slotPosition = getPositionFromSlotId(slotForOnMod, deckDef)
-        } else if (slotForOnTheDeck != null) {
-          slotPosition = getPositionFromSlotId(slotForOnTheDeck, deckDef)
-        }
-        if (slotPosition == null) {
-          console.warn(
-            `no slot ${slotForOnTheDeck} for labware ${
-              Object.keys(labware)[0]
-            }!`
-          )
-          return null
-        }
-        const { isActiveLayerVisible } = getActiveLayer(
-          id,
-          selectedRunTimeCommand
-        )
-
-        return (
-          <Fragment key={id}>
-            <LabwareOnDeck
-              x={slotPosition[0]}
-              y={slotPosition[1]}
-              robotState={robotState}
-              labwareDef={labwareEntities[id].def}
-              liquids={liquids}
-              labwareId={id}
-              setSelectedSlot={setSelectedSlot}
-              setHoveredSlot={setHoveredSlot}
-            />
-            {hoveredSlot === slotForOnTheDeck ? (
-              <DeckViewOverlay
-                key={`${slotForOnTheDeck}_hoveredSlot_labware`}
-                slotId={slotForOnTheDeck}
-                slotPosition={slotPosition}
-                slotFillColor={COLORS.purple50}
-                opacity={0.9}
-                robotType={robotType}
-                invariantContext={invariantContext}
-                robotState={robotState}
-                setSelectedSlot={setSelectedSlot}
-                setHoveredSlot={setHoveredSlot}
-              >
-                <StyledText desktopStyle="captionRegular" color={COLORS.white}>
-                  {labwareEntitiesExtended[id].nickName ??
-                    labwareEntities[id].def.metadata.displayName}
-                </StyledText>
-              </DeckViewOverlay>
-            ) : null}
-            {isActiveLayerVisible && selectedRunTimeCommand != null ? (
-              <LabwareCommandSummary
-                commandType={selectedRunTimeCommand.commandType}
-                position={slotPosition}
-                labwareDef={labwareEntities[id].def}
-                showModuleIcon={false}
-              />
-            ) : null}
-          </Fragment>
-        )
-      })}
-
+      <DeckViewSlots
+        robotState={robotState}
+        invariantContext={invariantContext}
+        robotType={robotType}
+        deckDef={deckDef}
+        setSelectedSlot={setSelectedSlot}
+        setHoveredSlot={setHoveredSlot}
+        hoveredSlot={hoveredSlot}
+        stagingAreaCutoutIds={stagingAreaCutoutIds}
+        slotIdsBlockedBySpanning={slotIdsBlockedBySpanning}
+      />
+      {/* all labware on deck/stacks NOT those in modules */}
+      <DeckViewLabware
+        robotState={robotState}
+        invariantContext={invariantContext}
+        liquids={liquids}
+        robotType={robotType}
+        deckDef={deckDef}
+        labwareEntitiesExtended={labwareEntitiesExtended}
+        setSelectedSlot={setSelectedSlot}
+        setHoveredSlot={setHoveredSlot}
+        hoveredSlot={hoveredSlot}
+        selectedRunTimeCommand={selectedRunTimeCommand}
+      />
       {/* when commandSummary happens on a fixture */}
       {isPipetteOverTrash &&
       selectedRunTimeCommand != null &&

--- a/app/src/pages/Desktop/Protocols/ProtocolVisualization/DeckViewLabware.tsx
+++ b/app/src/pages/Desktop/Protocols/ProtocolVisualization/DeckViewLabware.tsx
@@ -1,0 +1,122 @@
+import { Fragment } from 'react'
+
+import { COLORS, StyledText } from '@opentrons/components'
+import {
+  getAddressableAreaFromSlotId,
+  getPositionFromSlotId,
+} from '@opentrons/shared-data'
+import { getSlotInLocationStack } from '@opentrons/step-generation'
+
+import { DeckViewOverlay } from './DeckViewOverlay'
+import { LabwareCommandSummary } from './LabwareCommandSummary'
+import { LabwareOnDeck } from './LabwareOnDeck'
+import { getActiveLayer } from './utils'
+
+import type { Dispatch, SetStateAction } from 'react'
+import type {
+  DeckDefinition,
+  Liquid,
+  RobotType,
+  RunTimeCommand,
+} from '@opentrons/shared-data'
+import type { InvariantContext, RobotState } from '@opentrons/step-generation'
+import type { LabwareEntityExtended } from './DeckView'
+
+interface DeckViewLabwareProps {
+  robotState: RobotState
+  invariantContext: InvariantContext
+  liquids: Liquid[]
+  deckDef: DeckDefinition
+  robotType: RobotType
+  labwareEntitiesExtended: Record<string, LabwareEntityExtended>
+  setSelectedSlot: Dispatch<SetStateAction<string | null>>
+  setHoveredSlot: Dispatch<SetStateAction<string | null>>
+  hoveredSlot: string | null
+  selectedRunTimeCommand?: RunTimeCommand
+}
+
+export function DeckViewLabware(props: DeckViewLabwareProps): JSX.Element {
+  const {
+    robotState,
+    invariantContext,
+    liquids,
+    deckDef,
+    robotType,
+    labwareEntitiesExtended,
+    setSelectedSlot,
+    setHoveredSlot,
+    hoveredSlot,
+    selectedRunTimeCommand,
+  } = props
+  const { labware, modules } = robotState
+  return (
+    <>
+      {Object.entries(labware).map(([id, lw]) => {
+        if (
+          Object.keys(modules).some(moduleId => lw.stack.includes(moduleId))
+        ) {
+          return null
+        }
+        const slot = getSlotInLocationStack(lw.stack)
+        const slotPosition = getPositionFromSlotId(slot, deckDef)
+        const slotBoundingBox = getAddressableAreaFromSlotId(
+          slot,
+          deckDef
+        )?.boundingBox
+        if (slotPosition == null || slotBoundingBox == null) {
+          console.warn(
+            `no slot ${slot} for labware ${Object.keys(labware)[0]}!`
+          )
+          return null
+        }
+        const { isActiveLayerVisible } = getActiveLayer(
+          id,
+          selectedRunTimeCommand
+        )
+        const showCommandSummary =
+          isActiveLayerVisible && selectedRunTimeCommand != null
+        return (
+          <Fragment key={id}>
+            <LabwareOnDeck
+              x={slotPosition[0]}
+              y={slotPosition[1]}
+              robotState={robotState}
+              labwareDef={labwareEntitiesExtended[id].def}
+              liquids={liquids}
+              labwareId={id}
+              setSelectedSlot={setSelectedSlot}
+              setHoveredSlot={setHoveredSlot}
+            />
+            <DeckViewOverlay
+              key={`${slot}_hoveredSlot_labware`}
+              slotId={slot}
+              slotPosition={slotPosition}
+              slotFillColor={COLORS.purple50}
+              robotType={robotType}
+              invariantContext={invariantContext}
+              robotState={robotState}
+              setSelectedSlot={setSelectedSlot}
+              setHoveredSlot={setHoveredSlot}
+              hover={hoveredSlot}
+            >
+              {showCommandSummary ? null : (
+                <StyledText desktopStyle="captionRegular" color={COLORS.white}>
+                  {labwareEntitiesExtended[id].nickName ??
+                    labwareEntitiesExtended[id].def.metadata.displayName}
+                </StyledText>
+              )}
+            </DeckViewOverlay>
+            {showCommandSummary ? (
+              <LabwareCommandSummary
+                commandType={selectedRunTimeCommand.commandType}
+                position={slotPosition}
+                labwareDef={labwareEntitiesExtended[id].def}
+                showModuleIcon={false}
+              />
+            ) : null}
+          </Fragment>
+        )
+      })}
+    </>
+  )
+}

--- a/app/src/pages/Desktop/Protocols/ProtocolVisualization/DeckViewModules.tsx
+++ b/app/src/pages/Desktop/Protocols/ProtocolVisualization/DeckViewModules.tsx
@@ -1,0 +1,244 @@
+import { Fragment } from 'react'
+
+import { COLORS, Module, StyledText } from '@opentrons/components'
+import {
+  getModuleDef,
+  getPositionFromSlotId,
+  inferModuleOrientationFromXCoordinate,
+  THERMOCYCLER_MODULE_TYPE,
+} from '@opentrons/shared-data'
+
+import { DeckViewOverlay } from './DeckViewOverlay'
+import { LabwareOnDeck } from './LabwareOnDeck'
+import { ModuleCommandSummary } from './ModuleCommandSummary'
+import { getActiveLayer, getTopmostLabwareOnModuleFromStack } from './utils'
+
+import type { ComponentProps, Dispatch, SetStateAction } from 'react'
+import type { ThermocyclerVizProps } from '@opentrons/components'
+import type {
+  DeckDefinition,
+  Liquid,
+  RobotType,
+  RunTimeCommand,
+} from '@opentrons/shared-data'
+import type {
+  InvariantContext,
+  ModuleTemporalProperties,
+  RobotState,
+} from '@opentrons/step-generation'
+import type { LabwareEntityExtended } from './DeckView'
+
+interface DeckViewModulesProps {
+  robotState: RobotState
+  invariantContext: InvariantContext
+  liquids: Liquid[]
+  deckDef: DeckDefinition
+  robotType: RobotType
+  labwareEntitiesExtended: Record<string, LabwareEntityExtended>
+  setSelectedSlot: Dispatch<SetStateAction<string | null>>
+  setHoveredSlot: Dispatch<SetStateAction<string | null>>
+  hoveredSlot: string | null
+  selectedRunTimeCommand?: RunTimeCommand
+}
+
+export function DeckViewModules(props: DeckViewModulesProps): JSX.Element {
+  const {
+    robotState,
+    invariantContext,
+    liquids,
+    deckDef,
+    robotType,
+    setHoveredSlot,
+    setSelectedSlot,
+    hoveredSlot,
+    labwareEntitiesExtended,
+    selectedRunTimeCommand,
+  } = props
+  const { moduleEntities } = invariantContext
+  const { modules, labware } = robotState
+
+  return (
+    <>
+      {Object.entries(modules).map(([id, { slot, moduleState }]) => {
+        const slotPosition = getPositionFromSlotId(slot, deckDef)
+        if (slotPosition == null) {
+          console.warn(`no slot ${slot} for module ${id}`)
+          return null
+        }
+        const labwareLoadedOnModuleId = getTopmostLabwareOnModuleFromStack(
+          id,
+          Object.values(labware)
+        )
+        const isStepAssosciatedWithModule =
+          selectedRunTimeCommand != null &&
+          'moduleId' in selectedRunTimeCommand.params &&
+          selectedRunTimeCommand.params.moduleId === id
+        const { isActiveLayerVisible } = getActiveLayer(
+          labwareLoadedOnModuleId,
+          selectedRunTimeCommand
+        )
+        const moduleDef = getModuleDef(moduleEntities[id].model)
+        const moduleType = moduleEntities[id].type
+
+        const getModuleInnerProps = (
+          moduleState: ModuleTemporalProperties['moduleState']
+        ): ComponentProps<typeof Module>['innerProps'] => {
+          if (moduleState.type === THERMOCYCLER_MODULE_TYPE) {
+            let lidMotorState = 'unknown'
+            if (moduleState.lidOpen) {
+              lidMotorState = 'open'
+            } else if (moduleState.lidOpen === false) {
+              lidMotorState = 'closed'
+            }
+            return {
+              lidMotorState,
+              blockTargetTemp: moduleState.blockTargetTemp,
+            }
+          } else if (
+            'targetTemperature' in moduleState &&
+            moduleState.type === 'temperatureModuleType'
+          ) {
+            return {
+              targetTemperature: moduleState.targetTemperature,
+            }
+          } else if ('targetTemp' in moduleState) {
+            return {
+              targetTemp: moduleState.targetTemp,
+            }
+          }
+        }
+        const tempInnerProps = getModuleInnerProps(moduleState)
+        const innerTCProps = {
+          ...tempInnerProps,
+          lidMotorState:
+            (tempInnerProps as ThermocyclerVizProps)?.lidMotorState !== 'open'
+              ? 'closed'
+              : 'open',
+        }
+        const showModuleCommandSummary =
+          (isActiveLayerVisible || isStepAssosciatedWithModule) &&
+          selectedRunTimeCommand != null
+
+        return (
+          <Fragment key={id}>
+            {
+              <>
+                <Module
+                  key={id}
+                  x={slotPosition[0]}
+                  y={slotPosition[1]}
+                  def={moduleDef}
+                  orientation={inferModuleOrientationFromXCoordinate(
+                    slotPosition[0]
+                  )}
+                  innerProps={
+                    moduleType === THERMOCYCLER_MODULE_TYPE
+                      ? innerTCProps
+                      : tempInnerProps
+                  }
+                  targetSlotId={slot}
+                  targetDeckId={deckDef.otId}
+                  childrenPositioningMode="offsetToSlot"
+                  setSelectedSlot={setSelectedSlot}
+                  setHoveredSlot={setHoveredSlot}
+                >
+                  {labwareLoadedOnModuleId != null ? (
+                    <>
+                      <LabwareOnDeck
+                        robotState={robotState}
+                        labwareDef={
+                          labwareEntitiesExtended[labwareLoadedOnModuleId].def
+                        }
+                        liquids={liquids}
+                        labwareId={labwareLoadedOnModuleId}
+                        x={0}
+                        y={0}
+                        setSelectedSlot={setSelectedSlot}
+                        setHoveredSlot={setHoveredSlot}
+                      />
+                      {moduleType === THERMOCYCLER_MODULE_TYPE ? (
+                        <DeckViewOverlay
+                          key={slot}
+                          slotId={slot}
+                          slotPosition={[0, 0, 0]}
+                          slotFillColor={COLORS.purple50}
+                          robotType={robotType}
+                          invariantContext={invariantContext}
+                          robotState={robotState}
+                          setSelectedSlot={setSelectedSlot}
+                          setHoveredSlot={setHoveredSlot}
+                          hover={hoveredSlot}
+                        >
+                          {showModuleCommandSummary ? null : (
+                            <StyledText
+                              desktopStyle="captionRegular"
+                              color={COLORS.white}
+                            >
+                              {
+                                labwareEntitiesExtended[labwareLoadedOnModuleId]
+                                  .def.metadata.displayName
+                              }
+                            </StyledText>
+                          )}
+                        </DeckViewOverlay>
+                      ) : (
+                        <DeckViewOverlay
+                          key={slot}
+                          slotId={slot}
+                          slotPosition={slotPosition}
+                          slotFillColor={COLORS.purple50}
+                          robotType={robotType}
+                          invariantContext={invariantContext}
+                          robotState={robotState}
+                          setSelectedSlot={setSelectedSlot}
+                          setHoveredSlot={setHoveredSlot}
+                          hover={hoveredSlot}
+                        >
+                          {showModuleCommandSummary ? null : (
+                            <StyledText
+                              desktopStyle="captionRegular"
+                              color={COLORS.white}
+                            >
+                              {labwareEntitiesExtended[id].nickName ??
+                                labwareEntitiesExtended[labwareLoadedOnModuleId]
+                                  .def.metadata.displayName}
+                            </StyledText>
+                          )}
+                        </DeckViewOverlay>
+                      )}
+                    </>
+                  ) : null}
+                  <DeckViewOverlay
+                    key={slot}
+                    slotId={slot}
+                    slotPosition={[0, 0, 0]}
+                    slotFillColor={COLORS.purple50}
+                    robotType={robotType}
+                    invariantContext={invariantContext}
+                    robotState={robotState}
+                    setSelectedSlot={setSelectedSlot}
+                    setHoveredSlot={setHoveredSlot}
+                    hover={hoveredSlot}
+                  />
+                </Module>
+                {showModuleCommandSummary ? (
+                  <ModuleCommandSummary
+                    robotType={robotType}
+                    moduleModel={moduleDef.model}
+                    commandType={selectedRunTimeCommand.commandType}
+                    position={slotPosition}
+                    showModuleIcon={false}
+                    slot={slot}
+                    orientation={inferModuleOrientationFromXCoordinate(
+                      slotPosition[0]
+                    )}
+                  />
+                ) : null}
+              </>
+            }
+          </Fragment>
+        )
+      })}
+    </>
+  )
+}

--- a/app/src/pages/Desktop/Protocols/ProtocolVisualization/DeckViewModules.tsx
+++ b/app/src/pages/Desktop/Protocols/ProtocolVisualization/DeckViewModules.tsx
@@ -2,7 +2,6 @@ import { Fragment } from 'react'
 
 import { COLORS, Module, StyledText } from '@opentrons/components'
 import {
-  FLEX_SINGLE_SLOT_ADDRESSABLE_AREAS,
   getModuleDef,
   getPositionFromSlotId,
   inferModuleOrientationFromXCoordinate,

--- a/app/src/pages/Desktop/Protocols/ProtocolVisualization/DeckViewModules.tsx
+++ b/app/src/pages/Desktop/Protocols/ProtocolVisualization/DeckViewModules.tsx
@@ -57,7 +57,7 @@ export function DeckViewModules(props: DeckViewModulesProps): JSX.Element {
   } = props
   const { moduleEntities } = invariantContext
   const { modules, labware } = robotState
-  FLEX_SINGLE_SLOT_ADDRESSABLE_AREAS
+
   return (
     <>
       {Object.entries(modules).map(([id, { slot, moduleState }]) => {

--- a/app/src/pages/Desktop/Protocols/ProtocolVisualization/DeckViewModules.tsx
+++ b/app/src/pages/Desktop/Protocols/ProtocolVisualization/DeckViewModules.tsx
@@ -2,6 +2,7 @@ import { Fragment } from 'react'
 
 import { COLORS, Module, StyledText } from '@opentrons/components'
 import {
+  FLEX_SINGLE_SLOT_ADDRESSABLE_AREAS,
   getModuleDef,
   getPositionFromSlotId,
   inferModuleOrientationFromXCoordinate,
@@ -11,9 +12,13 @@ import {
 import { DeckViewOverlay } from './DeckViewOverlay'
 import { LabwareOnDeck } from './LabwareOnDeck'
 import { ModuleCommandSummary } from './ModuleCommandSummary'
-import { getActiveLayer, getTopmostLabwareOnModuleFromStack } from './utils'
+import {
+  getActiveLayer,
+  getModuleInnerProps,
+  getTopmostLabwareOnModuleFromStack,
+} from './utils'
 
-import type { ComponentProps, Dispatch, SetStateAction } from 'react'
+import type { Dispatch, SetStateAction } from 'react'
 import type { ThermocyclerVizProps } from '@opentrons/components'
 import type {
   DeckDefinition,
@@ -21,11 +26,7 @@ import type {
   RobotType,
   RunTimeCommand,
 } from '@opentrons/shared-data'
-import type {
-  InvariantContext,
-  ModuleTemporalProperties,
-  RobotState,
-} from '@opentrons/step-generation'
+import type { InvariantContext, RobotState } from '@opentrons/step-generation'
 import type { LabwareEntityExtended } from './DeckView'
 
 interface DeckViewModulesProps {
@@ -56,7 +57,7 @@ export function DeckViewModules(props: DeckViewModulesProps): JSX.Element {
   } = props
   const { moduleEntities } = invariantContext
   const { modules, labware } = robotState
-
+  FLEX_SINGLE_SLOT_ADDRESSABLE_AREAS
   return (
     <>
       {Object.entries(modules).map(([id, { slot, moduleState }]) => {
@@ -79,34 +80,6 @@ export function DeckViewModules(props: DeckViewModulesProps): JSX.Element {
         )
         const moduleDef = getModuleDef(moduleEntities[id].model)
         const moduleType = moduleEntities[id].type
-
-        const getModuleInnerProps = (
-          moduleState: ModuleTemporalProperties['moduleState']
-        ): ComponentProps<typeof Module>['innerProps'] => {
-          if (moduleState.type === THERMOCYCLER_MODULE_TYPE) {
-            let lidMotorState = 'unknown'
-            if (moduleState.lidOpen) {
-              lidMotorState = 'open'
-            } else if (moduleState.lidOpen === false) {
-              lidMotorState = 'closed'
-            }
-            return {
-              lidMotorState,
-              blockTargetTemp: moduleState.blockTargetTemp,
-            }
-          } else if (
-            'targetTemperature' in moduleState &&
-            moduleState.type === 'temperatureModuleType'
-          ) {
-            return {
-              targetTemperature: moduleState.targetTemperature,
-            }
-          } else if ('targetTemp' in moduleState) {
-            return {
-              targetTemp: moduleState.targetTemp,
-            }
-          }
-        }
         const tempInnerProps = getModuleInnerProps(moduleState)
         const innerTCProps = {
           ...tempInnerProps,
@@ -121,121 +94,119 @@ export function DeckViewModules(props: DeckViewModulesProps): JSX.Element {
 
         return (
           <Fragment key={id}>
-            {
-              <>
-                <Module
-                  key={id}
-                  x={slotPosition[0]}
-                  y={slotPosition[1]}
-                  def={moduleDef}
+            <>
+              <Module
+                key={id}
+                x={slotPosition[0]}
+                y={slotPosition[1]}
+                def={moduleDef}
+                orientation={inferModuleOrientationFromXCoordinate(
+                  slotPosition[0]
+                )}
+                innerProps={
+                  moduleType === THERMOCYCLER_MODULE_TYPE
+                    ? innerTCProps
+                    : tempInnerProps
+                }
+                targetSlotId={slot}
+                targetDeckId={deckDef.otId}
+                childrenPositioningMode="offsetToSlot"
+                setSelectedSlot={setSelectedSlot}
+                setHoveredSlot={setHoveredSlot}
+              >
+                {labwareLoadedOnModuleId != null ? (
+                  <>
+                    <LabwareOnDeck
+                      robotState={robotState}
+                      labwareDef={
+                        labwareEntitiesExtended[labwareLoadedOnModuleId].def
+                      }
+                      liquids={liquids}
+                      labwareId={labwareLoadedOnModuleId}
+                      x={0}
+                      y={0}
+                      setSelectedSlot={setSelectedSlot}
+                      setHoveredSlot={setHoveredSlot}
+                    />
+                    {moduleType === THERMOCYCLER_MODULE_TYPE ? (
+                      <DeckViewOverlay
+                        key={slot}
+                        slotId={slot}
+                        slotPosition={[0, 0, 0]}
+                        slotFillColor={COLORS.purple50}
+                        robotType={robotType}
+                        invariantContext={invariantContext}
+                        robotState={robotState}
+                        setSelectedSlot={setSelectedSlot}
+                        setHoveredSlot={setHoveredSlot}
+                        hover={hoveredSlot}
+                      >
+                        {showModuleCommandSummary ? null : (
+                          <StyledText
+                            desktopStyle="captionRegular"
+                            color={COLORS.white}
+                          >
+                            {
+                              labwareEntitiesExtended[labwareLoadedOnModuleId]
+                                .def.metadata.displayName
+                            }
+                          </StyledText>
+                        )}
+                      </DeckViewOverlay>
+                    ) : (
+                      <DeckViewOverlay
+                        key={slot}
+                        slotId={slot}
+                        slotPosition={slotPosition}
+                        slotFillColor={COLORS.purple50}
+                        robotType={robotType}
+                        invariantContext={invariantContext}
+                        robotState={robotState}
+                        setSelectedSlot={setSelectedSlot}
+                        setHoveredSlot={setHoveredSlot}
+                        hover={hoveredSlot}
+                      >
+                        {showModuleCommandSummary ? null : (
+                          <StyledText
+                            desktopStyle="captionRegular"
+                            color={COLORS.white}
+                          >
+                            {labwareEntitiesExtended[id].nickName ??
+                              labwareEntitiesExtended[labwareLoadedOnModuleId]
+                                .def.metadata.displayName}
+                          </StyledText>
+                        )}
+                      </DeckViewOverlay>
+                    )}
+                  </>
+                ) : null}
+                <DeckViewOverlay
+                  key={slot}
+                  slotId={slot}
+                  slotPosition={[0, 0, 0]}
+                  slotFillColor={COLORS.purple50}
+                  robotType={robotType}
+                  invariantContext={invariantContext}
+                  robotState={robotState}
+                  setSelectedSlot={setSelectedSlot}
+                  setHoveredSlot={setHoveredSlot}
+                  hover={hoveredSlot}
+                />
+              </Module>
+              {showModuleCommandSummary ? (
+                <ModuleCommandSummary
+                  robotType={robotType}
+                  moduleModel={moduleDef.model}
+                  commandType={selectedRunTimeCommand.commandType}
+                  position={slotPosition}
+                  showModuleIcon={false}
+                  slot={slot}
                   orientation={inferModuleOrientationFromXCoordinate(
                     slotPosition[0]
                   )}
-                  innerProps={
-                    moduleType === THERMOCYCLER_MODULE_TYPE
-                      ? innerTCProps
-                      : tempInnerProps
-                  }
-                  targetSlotId={slot}
-                  targetDeckId={deckDef.otId}
-                  childrenPositioningMode="offsetToSlot"
-                  setSelectedSlot={setSelectedSlot}
-                  setHoveredSlot={setHoveredSlot}
-                >
-                  {labwareLoadedOnModuleId != null ? (
-                    <>
-                      <LabwareOnDeck
-                        robotState={robotState}
-                        labwareDef={
-                          labwareEntitiesExtended[labwareLoadedOnModuleId].def
-                        }
-                        liquids={liquids}
-                        labwareId={labwareLoadedOnModuleId}
-                        x={0}
-                        y={0}
-                        setSelectedSlot={setSelectedSlot}
-                        setHoveredSlot={setHoveredSlot}
-                      />
-                      {moduleType === THERMOCYCLER_MODULE_TYPE ? (
-                        <DeckViewOverlay
-                          key={slot}
-                          slotId={slot}
-                          slotPosition={[0, 0, 0]}
-                          slotFillColor={COLORS.purple50}
-                          robotType={robotType}
-                          invariantContext={invariantContext}
-                          robotState={robotState}
-                          setSelectedSlot={setSelectedSlot}
-                          setHoveredSlot={setHoveredSlot}
-                          hover={hoveredSlot}
-                        >
-                          {showModuleCommandSummary ? null : (
-                            <StyledText
-                              desktopStyle="captionRegular"
-                              color={COLORS.white}
-                            >
-                              {
-                                labwareEntitiesExtended[labwareLoadedOnModuleId]
-                                  .def.metadata.displayName
-                              }
-                            </StyledText>
-                          )}
-                        </DeckViewOverlay>
-                      ) : (
-                        <DeckViewOverlay
-                          key={slot}
-                          slotId={slot}
-                          slotPosition={slotPosition}
-                          slotFillColor={COLORS.purple50}
-                          robotType={robotType}
-                          invariantContext={invariantContext}
-                          robotState={robotState}
-                          setSelectedSlot={setSelectedSlot}
-                          setHoveredSlot={setHoveredSlot}
-                          hover={hoveredSlot}
-                        >
-                          {showModuleCommandSummary ? null : (
-                            <StyledText
-                              desktopStyle="captionRegular"
-                              color={COLORS.white}
-                            >
-                              {labwareEntitiesExtended[id].nickName ??
-                                labwareEntitiesExtended[labwareLoadedOnModuleId]
-                                  .def.metadata.displayName}
-                            </StyledText>
-                          )}
-                        </DeckViewOverlay>
-                      )}
-                    </>
-                  ) : null}
-                  <DeckViewOverlay
-                    key={slot}
-                    slotId={slot}
-                    slotPosition={[0, 0, 0]}
-                    slotFillColor={COLORS.purple50}
-                    robotType={robotType}
-                    invariantContext={invariantContext}
-                    robotState={robotState}
-                    setSelectedSlot={setSelectedSlot}
-                    setHoveredSlot={setHoveredSlot}
-                    hover={hoveredSlot}
-                  />
-                </Module>
-                {showModuleCommandSummary ? (
-                  <ModuleCommandSummary
-                    robotType={robotType}
-                    moduleModel={moduleDef.model}
-                    commandType={selectedRunTimeCommand.commandType}
-                    position={slotPosition}
-                    showModuleIcon={false}
-                    slot={slot}
-                    orientation={inferModuleOrientationFromXCoordinate(
-                      slotPosition[0]
-                    )}
-                  />
-                ) : null}
-              </>
-            }
+                />
+              ) : null}
+            </>
           </Fragment>
         )
       })}

--- a/app/src/pages/Desktop/Protocols/ProtocolVisualization/DeckViewOverlay.tsx
+++ b/app/src/pages/Desktop/Protocols/ProtocolVisualization/DeckViewOverlay.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react'
 
 import {
   ALIGN_CENTER,
+  COLORS,
   CURSOR_POINTER,
   RobotCoordsForeignObject,
 } from '@opentrons/components'
@@ -9,10 +10,11 @@ import {
   FLEX_ROBOT_TYPE,
   getCutoutIdForAddressableArea,
   getDeckDefFromRobotType,
+  getFlexHoverDimensions,
+  getOT2HoverDimensions,
   THERMOCYCLER_MODULE_TYPE,
 } from '@opentrons/shared-data'
 
-import { getFlexHoverDimensions } from './utils'
 import styles from './visualization.module.css'
 
 import type { Dispatch, ReactNode, SetStateAction } from 'react'
@@ -28,17 +30,14 @@ interface SlotOverlayProps {
   slotId: DeckSlotId
   slotPosition: CoordinateTuple | null
   slotFillColor: string
-  children: ReactNode
-  robotType: RobotType
   invariantContext: InvariantContext
   robotState: RobotState
   setSelectedSlot: Dispatch<SetStateAction<string | null>>
   setHoveredSlot: Dispatch<SetStateAction<string | null>>
-  opacity?: number
+  robotType: RobotType
+  hover: string | null
+  children?: ReactNode
 }
-
-const TC_X_OFFSET = 20
-const TC_Y_OFFSET = 68
 
 export function DeckViewOverlay(props: SlotOverlayProps): JSX.Element | null {
   const {
@@ -51,7 +50,7 @@ export function DeckViewOverlay(props: SlotOverlayProps): JSX.Element | null {
     robotState,
     setSelectedSlot,
     setHoveredSlot,
-    opacity = 1,
+    hover,
   } = props
   const { stagingAreaEntities, moduleEntities } = invariantContext
   const { modules } = robotState
@@ -76,48 +75,101 @@ export function DeckViewOverlay(props: SlotOverlayProps): JSX.Element | null {
   if (slotPosition === null || (hasTCOnSlot && tcSlots.includes(slotId))) {
     return null
   }
+  const hoverOpacity = hover != null && hover === slotId ? 0.9 : 0
 
-  // TODO: extend for Ot-2
-  const { width, x, y } = getFlexHoverDimensions(
-    stagingAreaLocations,
-    cutoutId,
-    slotId,
-    hasTCOnSlot != null,
-    slotPosition
-  )
+  if (robotType === FLEX_ROBOT_TYPE) {
+    const { width, x, y, height } = getFlexHoverDimensions(
+      stagingAreaLocations,
+      cutoutId,
+      slotId,
+      hasTCOnSlot != null,
+      slotPosition
+    )
 
-  return (
-    <RobotCoordsForeignObject
-      key={`${robotType.toLowerCase()}_slotOverlay`}
-      width={width}
-      height="6%"
-      x={x + (hasTCOnSlot ? TC_X_OFFSET : 0)}
-      y={y - (hasTCOnSlot ? TC_Y_OFFSET : 0)}
-      flexProps={{ flex: '1' }}
-      foreignObjectProps={{
-        opacity: opacity,
-        flex: '1',
-        cursor: CURSOR_POINTER,
-        textAlign: ALIGN_CENTER,
-      }}
-      foreignObjectEvents={{
-        onClick: () => {
-          setSelectedSlot(slotId)
-        },
-        onMouseEnter: () => {
-          setHoveredSlot(slotId)
-        },
-        onMouseLeave: () => {
-          setHoveredSlot(null)
-        },
-      }}
-    >
-      <div
-        className={styles.deck_overlay}
-        style={{ backgroundColor: slotFillColor }}
+    return (
+      <RobotCoordsForeignObject
+        key={`${robotType.toLowerCase()}_slotOverlay`}
+        width={width}
+        height={height}
+        x={x}
+        y={y}
+        flexProps={{ flex: '1' }}
+        foreignObjectProps={{
+          opacity: hoverOpacity,
+          flex: '1',
+          cursor: CURSOR_POINTER,
+          textAlign: ALIGN_CENTER,
+          border: `3px solid ${COLORS.purple50}`,
+          borderRadius: '6px',
+        }}
+        foreignObjectEvents={{
+          onClick: () => {
+            setSelectedSlot(slotId)
+          },
+          onMouseEnter: () => {
+            setHoveredSlot(slotId)
+          },
+          onMouseLeave: () => {
+            setHoveredSlot(null)
+          },
+        }}
       >
-        {children}
-      </div>
-    </RobotCoordsForeignObject>
-  )
+        {children != null ? (
+          <div className={styles.deck_overlay}>
+            <div
+              className={styles.text_background}
+              style={{ backgroundColor: slotFillColor }}
+            >
+              {children}
+            </div>
+          </div>
+        ) : null}
+      </RobotCoordsForeignObject>
+    )
+  } else {
+    const { width, x, y, height } = getOT2HoverDimensions(
+      hasTCOnSlot != null,
+      slotPosition
+    )
+
+    return (
+      <RobotCoordsForeignObject
+        key="ot2_hover"
+        width={width}
+        height={height}
+        x={x}
+        y={y}
+        flexProps={{ flex: '1' }}
+        foreignObjectProps={{
+          opacity: hoverOpacity,
+          flex: '1',
+          cursor: CURSOR_POINTER,
+          border: `3px solid ${COLORS.purple50}`,
+          borderRadius: '6px',
+        }}
+        foreignObjectEvents={{
+          onClick: () => {
+            setSelectedSlot(slotId)
+          },
+          onMouseEnter: () => {
+            setHoveredSlot(slotId)
+          },
+          onMouseLeave: () => {
+            setHoveredSlot(null)
+          },
+        }}
+      >
+        {children != null ? (
+          <div className={styles.deck_overlay}>
+            <div
+              className={styles.text_background}
+              style={{ backgroundColor: slotFillColor }}
+            >
+              {children}
+            </div>
+          </div>
+        ) : null}
+      </RobotCoordsForeignObject>
+    )
+  }
 }

--- a/app/src/pages/Desktop/Protocols/ProtocolVisualization/DeckViewOverlay.tsx
+++ b/app/src/pages/Desktop/Protocols/ProtocolVisualization/DeckViewOverlay.tsx
@@ -100,7 +100,7 @@ export function DeckViewOverlay(props: SlotOverlayProps): JSX.Element | null {
           cursor: CURSOR_POINTER,
           textAlign: ALIGN_CENTER,
           border: `3px solid ${COLORS.purple50}`,
-          borderRadius: '6px',
+          borderRadius: '6px', // no const but matches the labware svg radius
         }}
         foreignObjectEvents={{
           onClick: () => {

--- a/app/src/pages/Desktop/Protocols/ProtocolVisualization/DeckViewSlots.tsx
+++ b/app/src/pages/Desktop/Protocols/ProtocolVisualization/DeckViewSlots.tsx
@@ -1,0 +1,85 @@
+import { Fragment } from 'react'
+
+import { COLORS } from '@opentrons/components'
+import {
+  getPositionFromSlotId,
+  isAddressableAreaStandardSlot,
+} from '@opentrons/shared-data'
+
+import { DeckViewOverlay } from './DeckViewOverlay'
+import { getSlotIsEmpty, getStagingAreaAddressableAreas } from './utils'
+
+import type { Dispatch, SetStateAction } from 'react'
+import type {
+  CutoutId,
+  DeckDefinition,
+  RobotType,
+} from '@opentrons/shared-data'
+import type { InvariantContext, RobotState } from '@opentrons/step-generation'
+
+interface DeckViewSlotsProps {
+  deckDef: DeckDefinition
+  robotType: RobotType
+  setSelectedSlot: Dispatch<SetStateAction<string | null>>
+  setHoveredSlot: Dispatch<SetStateAction<string | null>>
+  hoveredSlot: string | null
+  robotState: RobotState
+  invariantContext: InvariantContext
+  stagingAreaCutoutIds: CutoutId[]
+  slotIdsBlockedBySpanning: string[]
+}
+
+export function DeckViewSlots(props: DeckViewSlotsProps): JSX.Element {
+  const {
+    deckDef,
+    robotType,
+    setSelectedSlot,
+    setHoveredSlot,
+    hoveredSlot,
+    robotState,
+    invariantContext,
+    stagingAreaCutoutIds,
+    slotIdsBlockedBySpanning,
+  } = props
+  return (
+    <>
+      {deckDef.locations.addressableAreas
+        .filter(addressableArea => {
+          const stagingAreaAddressableAreas =
+            getStagingAreaAddressableAreas(stagingAreaCutoutIds)
+
+          const addressableAreas =
+            isAddressableAreaStandardSlot(addressableArea.id, deckDef) ||
+            stagingAreaAddressableAreas.includes(addressableArea.id)
+          return (
+            addressableArea.id === 'fixedTrash' ||
+            (addressableAreas &&
+              !slotIdsBlockedBySpanning.includes(addressableArea.id) &&
+              getSlotIsEmpty(robotState, addressableArea.id))
+          )
+        })
+        .map(addressableArea => {
+          const slotPosition = getPositionFromSlotId(
+            addressableArea.id,
+            deckDef
+          )
+          return (
+            <Fragment key={addressableArea.id}>
+              <DeckViewOverlay
+                key={`${addressableArea.id}_hoveredSlot_labware`}
+                slotId={addressableArea.id}
+                slotPosition={slotPosition}
+                slotFillColor={COLORS.purple50}
+                robotType={robotType}
+                invariantContext={invariantContext}
+                robotState={robotState}
+                setSelectedSlot={setSelectedSlot}
+                setHoveredSlot={setHoveredSlot}
+                hover={hoveredSlot}
+              />
+            </Fragment>
+          )
+        })}
+    </>
+  )
+}

--- a/app/src/pages/Desktop/Protocols/ProtocolVisualization/DeckViewSlots.tsx
+++ b/app/src/pages/Desktop/Protocols/ProtocolVisualization/DeckViewSlots.tsx
@@ -1,5 +1,3 @@
-import { Fragment } from 'react'
-
 import { COLORS } from '@opentrons/components'
 import {
   getPositionFromSlotId,

--- a/app/src/pages/Desktop/Protocols/ProtocolVisualization/DeckViewSlots.tsx
+++ b/app/src/pages/Desktop/Protocols/ProtocolVisualization/DeckViewSlots.tsx
@@ -43,28 +43,25 @@ export function DeckViewSlots(props: DeckViewSlotsProps): JSX.Element {
   } = props
   return (
     <>
-      {deckDef.locations.addressableAreas
-        .filter(addressableArea => {
+      {deckDef.locations.addressableAreas.reduce<JSX.Element[]>(
+        (acc, addressableArea) => {
           const stagingAreaAddressableAreas =
             getStagingAreaAddressableAreas(stagingAreaCutoutIds)
-
           const addressableAreas =
             isAddressableAreaStandardSlot(addressableArea.id, deckDef) ||
             stagingAreaAddressableAreas.includes(addressableArea.id)
-          return (
-            addressableArea.id === 'fixedTrash' ||
-            (addressableAreas &&
-              !slotIdsBlockedBySpanning.includes(addressableArea.id) &&
-              getSlotIsEmpty(robotState, addressableArea.id))
-          )
-        })
-        .map(addressableArea => {
           const slotPosition = getPositionFromSlotId(
             addressableArea.id,
             deckDef
           )
-          return (
-            <Fragment key={addressableArea.id}>
+          if (
+            addressableArea.id === 'fixedTrash' ||
+            (addressableAreas &&
+              !slotIdsBlockedBySpanning.includes(addressableArea.id) &&
+              getSlotIsEmpty(robotState, addressableArea.id))
+          ) {
+            return [
+              ...acc,
               <DeckViewOverlay
                 key={`${addressableArea.id}_hoveredSlot_labware`}
                 slotId={addressableArea.id}
@@ -76,10 +73,13 @@ export function DeckViewSlots(props: DeckViewSlotsProps): JSX.Element {
                 setSelectedSlot={setSelectedSlot}
                 setHoveredSlot={setHoveredSlot}
                 hover={hoveredSlot}
-              />
-            </Fragment>
-          )
-        })}
+              />,
+            ]
+          }
+          return acc
+        },
+        []
+      )}
     </>
   )
 }

--- a/app/src/pages/Desktop/Protocols/ProtocolVisualization/utils.ts
+++ b/app/src/pages/Desktop/Protocols/ProtocolVisualization/utils.ts
@@ -22,7 +22,8 @@ import {
   getVolumesPerLiquid,
 } from '@opentrons/step-generation'
 
-import type { WellGroup } from '@opentrons/components'
+import type { ComponentProps } from 'react'
+import type { Module, WellGroup } from '@opentrons/components'
 import type {
   AddressableAreaName,
   CutoutId,
@@ -37,6 +38,7 @@ import type {
   DeckSlot,
   LabwareTemporalProperties,
   ModuleEntities,
+  ModuleTemporalProperties,
   RobotState,
   SingleLabwareLiquidState,
 } from '@opentrons/step-generation'
@@ -312,7 +314,7 @@ export const getThermocyclerOverlayText = (
   }
 }
 
-export const isCutoutA1Active = (
+export const getIsCutoutA1Active = (
   labware: RobotState['labware'],
   modules: RobotState['modules'],
   cutoutId: CutoutId,
@@ -331,4 +333,32 @@ export const isCutoutA1Active = (
       : { isActiveLayerVisible: false }
 
   return isThermocyclerActive && hasThermocycler && cutoutId === 'cutoutA1'
+}
+
+export const getModuleInnerProps = (
+  moduleState: ModuleTemporalProperties['moduleState']
+): ComponentProps<typeof Module>['innerProps'] => {
+  if (moduleState.type === THERMOCYCLER_MODULE_TYPE) {
+    let lidMotorState = 'unknown'
+    if (moduleState.lidOpen) {
+      lidMotorState = 'open'
+    } else if (moduleState.lidOpen === false) {
+      lidMotorState = 'closed'
+    }
+    return {
+      lidMotorState,
+      blockTargetTemp: moduleState.blockTargetTemp,
+    }
+  } else if (
+    'targetTemperature' in moduleState &&
+    moduleState.type === 'temperatureModuleType'
+  ) {
+    return {
+      targetTemperature: moduleState.targetTemperature,
+    }
+  } else if ('targetTemp' in moduleState) {
+    return {
+      targetTemp: moduleState.targetTemp,
+    }
+  }
 }

--- a/app/src/pages/Desktop/Protocols/ProtocolVisualization/utils.ts
+++ b/app/src/pages/Desktop/Protocols/ProtocolVisualization/utils.ts
@@ -25,7 +25,6 @@ import {
 import type { WellGroup } from '@opentrons/components'
 import type {
   AddressableAreaName,
-  CoordinateTuple,
   CutoutId,
   LabwareDefinition2,
   Liquid,
@@ -43,63 +42,12 @@ import type {
 } from '@opentrons/step-generation'
 import type { GroupedCommands } from '/app/redux/protocol-storage'
 
-interface HoverDimensions {
-  width: number
-  height: number
-  x: number
-  y: number
-}
 interface LiquidDetailInfo {
   totalVolume: number
   color: string
   displayName: string
 }
 type WellContentsByLabware = Record<string, ContentsByWell>
-
-const FOURTH_COLUMN_SLOTS = ['A4', 'B4', 'C4', 'D4']
-
-export const getFlexHoverDimensions = (
-  stagingAreaLocations: string[],
-  cutoutId: CutoutId,
-  slotId: string,
-  hasTCOnSlot: boolean,
-  slotPosition: CoordinateTuple
-): HoverDimensions => {
-  const hasStagingArea = stagingAreaLocations.includes(cutoutId)
-
-  const X_ADJUSTMENT_LEFT_SIDE = -101.5
-  const X_ADJUSTMENT = -17
-  const X_DIMENSION_MIDDLE_SLOTS = 160.3
-  const X_DIMENSION_OUTER_SLOTS = hasStagingArea ? 160.0 : 246.5
-  const X_DIMENSION_4TH_COLUMN_SLOTS = 175.0
-  const Y_DIMENSION = hasTCOnSlot ? 294.0 : 106.0
-
-  const slotFromCutout = slotId
-  const isLeftSideofDeck =
-    slotFromCutout === 'A1' ||
-    slotFromCutout === 'B1' ||
-    slotFromCutout === 'C1' ||
-    slotFromCutout === 'D1'
-  const xAdjustment = isLeftSideofDeck ? X_ADJUSTMENT_LEFT_SIDE : X_ADJUSTMENT
-  const xSlotPosition = slotPosition[0] + xAdjustment
-
-  const yAdjustment = -10
-  const ySlotPosition = slotPosition[1] + yAdjustment
-
-  const isMiddleOfDeck =
-    slotId === 'A2' || slotId === 'B2' || slotId === 'C2' || slotId === 'D2'
-
-  let xDimension = X_DIMENSION_OUTER_SLOTS
-  if (isMiddleOfDeck) {
-    xDimension = X_DIMENSION_MIDDLE_SLOTS
-  } else if (FOURTH_COLUMN_SLOTS.includes(slotId)) {
-    xDimension = X_DIMENSION_4TH_COLUMN_SLOTS
-  }
-  const x = xSlotPosition
-  const y = ySlotPosition
-
-  return { width: xDimension, height: Y_DIMENSION, x, y }
-}
 
 export const getStagingAreaAddressableAreas = (
   cutoutIds: CutoutId[],
@@ -131,7 +79,6 @@ export const getSlotIsEmpty = (
       return slot.includes(moduleTemporalProperties.slot)
     }
   )
-
   const labwareInSlot = values(robotState.labware).filter(
     labwareTemporalProperties =>
       getSlotInLocationStack(labwareTemporalProperties.stack) === slot
@@ -363,4 +310,25 @@ export const getThermocyclerOverlayText = (
       //  TODO: the rest of the copy isn't needed for protocol viz user testing purposes
       return 'Changing thermocycler state'
   }
+}
+
+export const isCutoutA1Active = (
+  labware: RobotState['labware'],
+  modules: RobotState['modules'],
+  cutoutId: CutoutId,
+  selectedRunTimeCommand?: RunTimeCommand
+): boolean => {
+  const labwareOnB1 = Object.entries(labware).find(
+    ([_, lw]) => getSlotInLocationStack(lw.stack) === 'B1'
+  )
+  const hasThermocycler = Object.values(modules).some(
+    module => module.moduleState.type === THERMOCYCLER_MODULE_TYPE
+  )
+
+  const { isActiveLayerVisible: isThermocyclerActive } =
+    labwareOnB1 != null
+      ? getActiveLayer(labwareOnB1[0], selectedRunTimeCommand)
+      : { isActiveLayerVisible: false }
+
+  return isThermocyclerActive && hasThermocycler && cutoutId === 'cutoutA1'
 }

--- a/app/src/pages/Desktop/Protocols/ProtocolVisualization/visualization.module.css
+++ b/app/src/pages/Desktop/Protocols/ProtocolVisualization/visualization.module.css
@@ -88,13 +88,14 @@
   position: relative;
   height: var(--spacing-4);
   border-radius: var(--border-radius-2);
-  background: linear-gradient(
-    to right,
-    var(--blue-50) 0%,
-    var(--blue-50) var(--progress, 0%),
-    #ccc var(--progress, 0%),
-    #ccc 100%
-  );
+  background:
+    linear-gradient(
+      to right,
+      var(--blue-50) 0%,
+      var(--blue-50) var(--progress, 0%),
+      #ccc var(--progress, 0%),
+      #ccc 100%
+    );
 }
 
 /* Hide thumb initially */
@@ -354,19 +355,19 @@
   display: flex;
   width: 100%;
   height: 100%;
-  justify-content: center;
   align-items: flex-end;
+  justify-content: center;
   border-radius: var(--border-radius-4);
-  gap: var(--spacing-8);
   background-color: transparent;
+  gap: var(--spacing-8);
 }
 
 .text_background {
   display: flex;
-  justify-content: center;
   width: 100%;
-  background-color: var(--slot-fill-color);
+  justify-content: center;
   border-radius: 0 0 var(--border-radius-4) var(--border-radius-4);
+  background-color: var(--slot-fill-color);
 }
 
 .controls_overflow_menu {

--- a/app/src/pages/Desktop/Protocols/ProtocolVisualization/visualization.module.css
+++ b/app/src/pages/Desktop/Protocols/ProtocolVisualization/visualization.module.css
@@ -88,14 +88,13 @@
   position: relative;
   height: var(--spacing-4);
   border-radius: var(--border-radius-2);
-  background:
-    linear-gradient(
-      to right,
-      var(--blue-50) 0%,
-      var(--blue-50) var(--progress, 0%),
-      #ccc var(--progress, 0%),
-      #ccc 100%
-    );
+  background: linear-gradient(
+    to right,
+    var(--blue-50) 0%,
+    var(--blue-50) var(--progress, 0%),
+    #ccc var(--progress, 0%),
+    #ccc 100%
+  );
 }
 
 /* Hide thumb initially */
@@ -355,10 +354,19 @@
   display: flex;
   width: 100%;
   height: 100%;
-  align-items: center;
   justify-content: center;
+  align-items: flex-end;
   border-radius: var(--border-radius-4);
   gap: var(--spacing-8);
+  background-color: transparent;
+}
+
+.text_background {
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  background-color: var(--slot-fill-color);
+  border-radius: 0 0 var(--border-radius-4) var(--border-radius-4);
 }
 
 .controls_overflow_menu {

--- a/protocol-designer/src/pages/Designer/DeckSetup/Overlays/SlotOverlay.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/Overlays/SlotOverlay.tsx
@@ -14,13 +14,13 @@ import {
   FLEX_ROBOT_TYPE,
   getCutoutIdForAddressableArea,
   getDeckDefFromRobotType,
+  getFlexHoverDimensions,
+  getOT2HoverDimensions,
   THERMOCYCLER_MODULE_TYPE,
 } from '@opentrons/shared-data'
 
 import { getRobotType } from '/protocol-designer/file-data/selectors'
 import { getInitialDeckSetup } from '/protocol-designer/step-forms/selectors'
-
-import { getFlexHoverDimensions, getOT2HoverDimensions } from '../utils'
 
 import type { MutableRefObject, ReactNode } from 'react'
 import type {

--- a/protocol-designer/src/pages/Designer/DeckSetup/utils.ts
+++ b/protocol-designer/src/pages/Designer/DeckSetup/utils.ts
@@ -34,7 +34,6 @@ import {
 import type { Dispatch, SetStateAction } from 'react'
 import type {
   AddressableAreaName,
-  CoordinateTuple,
   CutoutFixture,
   CutoutId,
   DeckDefinition,
@@ -490,73 +489,6 @@ export const getSwapBlockedAdapter = (
       : false
 
   return labwareSourceToDestBlocked || labwareDestToSourceBlocked
-}
-
-interface HoverDimensions {
-  width: number
-  height: number
-  x: number
-  y: number
-}
-
-const FOURTH_COLUMN_SLOTS = ['A4', 'B4', 'C4', 'D4']
-
-export const getFlexHoverDimensions = (
-  columnFourLocations: string[],
-  cutoutId: CutoutId,
-  slotId: string,
-  hasTCOnSlot: boolean,
-  slotPosition: CoordinateTuple
-): HoverDimensions => {
-  const columnFourIsOccupied = columnFourLocations.includes(cutoutId)
-
-  const X_ADJUSTMENT_LEFT_SIDE = -101.5
-  const X_ADJUSTMENT = -17
-  const X_DIMENSION_MIDDLE_SLOTS = 160.3
-  const X_DIMENSION_OUTER_SLOTS = columnFourIsOccupied ? 160.0 : 246.5
-  const X_DIMENSION_4TH_COLUMN_SLOTS = 175.0
-  const Y_DIMENSION = hasTCOnSlot ? 294.0 : 106.0
-
-  const slotFromCutout = slotId
-  const isLeftSideofDeck =
-    slotFromCutout === 'A1' ||
-    slotFromCutout === 'B1' ||
-    slotFromCutout === 'C1' ||
-    slotFromCutout === 'D1'
-  const xAdjustment = isLeftSideofDeck ? X_ADJUSTMENT_LEFT_SIDE : X_ADJUSTMENT
-  const xSlotPosition = slotPosition[0] + xAdjustment
-
-  const yAdjustment = -10
-  const ySlotPosition = slotPosition[1] + yAdjustment
-
-  const isMiddleOfDeck =
-    slotId === 'A2' || slotId === 'B2' || slotId === 'C2' || slotId === 'D2'
-
-  let xDimension = X_DIMENSION_OUTER_SLOTS
-  if (isMiddleOfDeck) {
-    xDimension = X_DIMENSION_MIDDLE_SLOTS
-  } else if (FOURTH_COLUMN_SLOTS.includes(slotId)) {
-    xDimension = X_DIMENSION_4TH_COLUMN_SLOTS
-  }
-  const x = hasTCOnSlot ? xSlotPosition + 20 : xSlotPosition
-  const y = hasTCOnSlot ? ySlotPosition - 70 : ySlotPosition
-
-  return { width: xDimension, height: Y_DIMENSION, x, y }
-}
-
-export const getOT2HoverDimensions = (
-  hasTCOnSlot: boolean,
-  slotPosition: CoordinateTuple
-): HoverDimensions => {
-  const y = slotPosition[1]
-  const x = slotPosition[0]
-
-  return {
-    width: hasTCOnSlot ? 260 : 128,
-    height: hasTCOnSlot ? 178 : 85,
-    x,
-    y: hasTCOnSlot ? y - 72 : y,
-  }
 }
 
 export const getSVGContainerWidth = (

--- a/protocol-designer/src/pages/ProtocolOverview/SlotHover.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/SlotHover.tsx
@@ -16,15 +16,13 @@ import {
   getCutoutIdForAddressableArea,
   getCutoutIdForSlotName,
   getDeckDefFromRobotType,
+  getFlexHoverDimensions,
   getModuleType,
+  getOT2HoverDimensions,
   THERMOCYCLER_MODULE_TYPE,
 } from '@opentrons/shared-data'
 
 import { getInitialDeckSetup } from '../../step-forms/selectors'
-import {
-  getFlexHoverDimensions,
-  getOT2HoverDimensions,
-} from '../Designer/DeckSetup/utils'
 
 import type { Dispatch, SetStateAction } from 'react'
 import type {

--- a/shared-data/js/helpers/index.ts
+++ b/shared-data/js/helpers/index.ts
@@ -64,6 +64,7 @@ export * from './getModuleDeckLabel'
 export * from './deckConfig'
 export * from './testHelpers'
 export * from './symbolicPositionHelpers'
+export * from './slotHovers'
 
 export const getLabwareDefIsStandard = (def: LabwareDefinition): boolean =>
   def?.namespace === OPENTRONS_LABWARE_NAMESPACE

--- a/shared-data/js/helpers/slotHovers.ts
+++ b/shared-data/js/helpers/slotHovers.ts
@@ -1,0 +1,69 @@
+import type { CoordinateTuple } from '..'
+import type { CutoutId } from '../../deck'
+
+interface HoverDimensions {
+  width: number
+  height: number
+  x: number
+  y: number
+}
+
+const FOURTH_COLUMN_SLOTS = ['A4', 'B4', 'C4', 'D4']
+
+export const getFlexHoverDimensions = (
+  columnFourLocations: string[],
+  cutoutId: CutoutId,
+  slotId: string,
+  hasTCOnSlot: boolean,
+  slotPosition: CoordinateTuple
+): HoverDimensions => {
+  const columnFourIsOccupied = columnFourLocations.includes(cutoutId)
+
+  const X_ADJUSTMENT_LEFT_SIDE = -101.5
+  const X_ADJUSTMENT = -17
+  const X_DIMENSION_MIDDLE_SLOTS = 160.3
+  const X_DIMENSION_OUTER_SLOTS = columnFourIsOccupied ? 160.0 : 246.5
+  const X_DIMENSION_4TH_COLUMN_SLOTS = 175.0
+  const Y_DIMENSION = hasTCOnSlot ? 294.0 : 106.0
+
+  const slotFromCutout = slotId
+  const isLeftSideofDeck =
+    slotFromCutout === 'A1' ||
+    slotFromCutout === 'B1' ||
+    slotFromCutout === 'C1' ||
+    slotFromCutout === 'D1'
+  const xAdjustment = isLeftSideofDeck ? X_ADJUSTMENT_LEFT_SIDE : X_ADJUSTMENT
+  const xSlotPosition = slotPosition[0] + xAdjustment
+
+  const yAdjustment = -10
+  const ySlotPosition = slotPosition[1] + yAdjustment
+
+  const isMiddleOfDeck =
+    slotId === 'A2' || slotId === 'B2' || slotId === 'C2' || slotId === 'D2'
+
+  let xDimension = X_DIMENSION_OUTER_SLOTS
+  if (isMiddleOfDeck) {
+    xDimension = X_DIMENSION_MIDDLE_SLOTS
+  } else if (FOURTH_COLUMN_SLOTS.includes(slotId)) {
+    xDimension = X_DIMENSION_4TH_COLUMN_SLOTS
+  }
+  const x = hasTCOnSlot ? xSlotPosition + 20 : xSlotPosition
+  const y = hasTCOnSlot ? ySlotPosition - 70 : ySlotPosition
+
+  return { width: xDimension, height: Y_DIMENSION, x, y }
+}
+
+export const getOT2HoverDimensions = (
+  hasTCOnSlot: boolean,
+  slotPosition: CoordinateTuple
+): HoverDimensions => {
+  const y = slotPosition[1]
+  const x = slotPosition[0]
+
+  return {
+    width: hasTCOnSlot ? 260 : 128,
+    height: hasTCOnSlot ? 178 : 85,
+    x,
+    y: hasTCOnSlot ? y - 72 : y,
+  }
+}


### PR DESCRIPTION
closes AUTH-2423 AUTH-2428

# Overview

clean up the deck view components and fix how the hovers work, extending it to the ot-2.


https://github.com/user-attachments/assets/c6c0015e-8898-4ffc-961c-113958f87877



## Test Plan and Hands on Testing

Test with a flex and ot-2 protocol. you can use what is attached since there are still bugs with some longer/less common command protocols

Flex:
[P50MTransferMulti_MOD (2).py](https://github.com/user-attachments/files/23463641/P50MTransferMulti_MOD.2.py)

Ot-2:
[2024-04-18_96well_ROSGradient_v3 (1).json](https://github.com/user-attachments/files/23463652/2024-04-18_96well_ROSGradient_v3.1.json)

## Changelog

clean up `DeckViewDetails` by splitting into different components for modules, labware and empty slots.
clean up `DeckViewOverlay` and take ot-2 into account
move `getFlexHoverDimensions` and `getOT2HoverDimensions` into shared-data and use those utils in both PD and PV
clean up where the hover logic goes and try to keep it mostly in `DeckViewOverlay`, cleaning up `DeckView`

## Risk assessment

low