### PR TITLE
fix(app): default camera usage state to `disabled`

### DIFF
--- a/app/src/local-resources/images/hooks/useCameraUsageSettings.ts
+++ b/app/src/local-resources/images/hooks/useCameraUsageSettings.ts
@@ -22,9 +22,10 @@ export function useCameraUsageSettings(): UseCameraUsageSettingsResult {
   })
   const { mutateAsync: updateCamera } = useUpdateCamera()
 
-  const [isCameraEnabled, setIsCameraEnabled] = useState(true)
-  const [isLiveVideoEnabled, setIsLiveVideoEnabled] = useState(true)
-  const [isRecoveryCaptureEnabled, setIsRecoveryCaptureEnabled] = useState(true)
+  const [isCameraEnabled, setIsCameraEnabled] = useState(false)
+  const [isLiveVideoEnabled, setIsLiveVideoEnabled] = useState(false)
+  const [isRecoveryCaptureEnabled, setIsRecoveryCaptureEnabled] =
+    useState(false)
 
   useEffect(() => {
     if (cameraData) {


### PR DESCRIPTION
# Overview

#20100 ensures that configuring a camera usage setting 503s if the camera is disconnected, but the default state is to render the camera as `enabled` if we can't GET the camera usage settings. We should do the exact opposite of that.

https://github.com/user-attachments/assets/3d709636-c5a1-479d-a55d-de33c3b314ef

Note these changes sufficiently cover the ODD views, too.

## Test Plan and Hands on Testing

See video

## Changelog

- Fixed the desktop app and ODD showing the camera as "enabled" when it is disconnected.


## Risk assessment

very low
