### PR TITLE
refactor(mono, robot-server, app): Add notification support for `/camera`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -72,6 +72,7 @@ module.exports = {
               'useAllCommandsAsPreSerializedList',
               'useSearchLabwareOffsets',
               'useImageFileQuery',
+              'useCamera',
             ],
             message:
               'HTTP hook deprecated. Use the equivalent notification wrapper (useNotifyXYZ).',

--- a/app/src/local-resources/images/hooks/useCameraUsageSettings.ts
+++ b/app/src/local-resources/images/hooks/useCameraUsageSettings.ts
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react'
 
-import { useCamera, useUpdateCamera } from '@opentrons/react-api-client'
+import { useUpdateCamera } from '@opentrons/react-api-client'
+
+import { useNotifyCamera } from '/app/resources/camera/useNotifyCamera'
 
 const CAMERA_POLLING_INTERVAL_MS = 5000
 
@@ -17,7 +19,7 @@ export interface UseCameraUsageSettingsResult {
 
 // general camera usage settings. inteded for out of run setup use only.
 export function useCameraUsageSettings(): UseCameraUsageSettingsResult {
-  const { data: cameraData } = useCamera({
+  const { data: cameraData } = useNotifyCamera({
     refetchInterval: CAMERA_POLLING_INTERVAL_MS,
   })
   const { mutateAsync: updateCamera } = useUpdateCamera()

--- a/app/src/local-resources/images/hooks/useInitializeCameraState.ts
+++ b/app/src/local-resources/images/hooks/useInitializeCameraState.ts
@@ -13,7 +13,7 @@ import { useNotifyRunQuery } from '/app/resources/runs'
 //  otherwise, populate the toggles with the camera settings once the network
 //  request completes.
 export function useInitializeCameraState(runId: string): void {
-  const { data: cameraSettings } = useNotifyCamera()
+  const { data: cameraSettings } = useNotifyCamera({ staleTime: Infinity })
   const { data } = useNotifyRunQuery(runId)
   const dispatch = useDispatch()
   const runCameraSettings = data?.data.cameraSettings

--- a/app/src/local-resources/images/hooks/useInitializeCameraState.ts
+++ b/app/src/local-resources/images/hooks/useInitializeCameraState.ts
@@ -1,20 +1,19 @@
 import { useEffect } from 'react'
 import { useDispatch } from 'react-redux'
 
-import { useCamera } from '@opentrons/react-api-client'
-
 import {
   updateCameraEnablement,
   updateCameraRecoveryEnablement,
   updateCameraStreamEnablement,
 } from '/app/redux/protocol-runs'
+import { useNotifyCamera } from '/app/resources/camera/useNotifyCamera'
 import { useNotifyRunQuery } from '/app/resources/runs'
 
 // Populate the toggles with the run settings if they have been set,
 //  otherwise, populate the toggles with the camera settings once the network
 //  request completes.
 export function useInitializeCameraState(runId: string): void {
-  const { data: cameraSettings } = useCamera()
+  const { data: cameraSettings } = useNotifyCamera()
   const { data } = useNotifyRunQuery(runId)
   const dispatch = useDispatch()
   const runCameraSettings = data?.data.cameraSettings

--- a/app/src/organisms/Desktop/Devices/RobotCard.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotCard.tsx
@@ -20,7 +20,6 @@ import {
   WRAP,
 } from '@opentrons/components'
 import {
-  useCamera,
   useInstrumentsQuery,
   useModulesQuery,
   usePipettesQuery,
@@ -37,6 +36,7 @@ import { InstrumentContainer } from '/app/atoms/InstrumentContainer'
 import { ModuleIcon } from '/app/molecules/ModuleIcon'
 import { useIsFlex } from '/app/redux-resources/robots'
 import { CONNECTABLE, getRobotModelByName } from '/app/redux/discovery'
+import { useNotifyCamera } from '/app/resources/camera/useNotifyCamera'
 
 import { UpdateRobotBanner } from '../UpdateRobotBanner'
 import {
@@ -173,7 +173,7 @@ function AttachedModules(props: { robotName: string }): JSX.Element | null {
 function AttachedDevices(props: { robotName: string }): JSX.Element | null {
   const { robotName } = props
   const { t } = useTranslation('devices_landing')
-  const { data } = useCamera()
+  const { data } = useNotifyCamera()
 
   return data?.cameraEnabled ? (
     <Flex

--- a/app/src/organisms/Desktop/Devices/RobotCard.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotCard.tsx
@@ -52,6 +52,8 @@ import type { GripperModel } from '@opentrons/shared-data'
 import type { DiscoveredRobot } from '/app/redux/discovery/types'
 import type { State } from '/app/redux/types'
 
+const CAMERA_REFETCH_MS = 5000
+
 interface RobotCardProps {
   robot: DiscoveredRobot
 }
@@ -173,7 +175,7 @@ function AttachedModules(props: { robotName: string }): JSX.Element | null {
 function AttachedDevices(props: { robotName: string }): JSX.Element | null {
   const { robotName } = props
   const { t } = useTranslation('devices_landing')
-  const { data } = useNotifyCamera()
+  const { data } = useNotifyCamera({ refetchInterval: CAMERA_REFETCH_MS })
 
   return data?.cameraEnabled ? (
     <Flex

--- a/app/src/pages/ODD/ProtocolSetup/index.tsx
+++ b/app/src/pages/ODD/ProtocolSetup/index.tsx
@@ -24,7 +24,6 @@ import {
 } from '@opentrons/components'
 import {
   useAddCameraSettingsToRunMutation,
-  useCamera,
   useInstrumentsQuery,
   useProtocolAnalysisAsDocumentQuery,
   useProtocolQuery,
@@ -92,6 +91,7 @@ import {
   updateCameraEnablement,
 } from '/app/redux/protocol-runs'
 import { useStoredProtocolAnalysis } from '/app/resources/analysis'
+import { useNotifyCamera } from '/app/resources/camera/useNotifyCamera'
 import { useDeckConfigurationCompatibility } from '/app/resources/deck_configuration/hooks'
 import { getRequiredDeckConfig } from '/app/resources/deck_configuration/utils'
 import { useRobotStorageInfo } from '/app/resources/health/useIsImageStorageLow'
@@ -847,7 +847,7 @@ export function ProtocolSetup(): JSX.Element {
   const { applyOffsets, isApplyingOffsets } = useApplyOffsets(runId)
 
   const [cameraSettingsConfirmed, setCameraSettingsConfirmed] = useState(false)
-  const { data: initialRobotCameraSettings } = useCamera()
+  const { data: initialRobotCameraSettings } = useNotifyCamera()
 
   // The initial app-internal camera state should match the server state.
   useEffect(() => {

--- a/app/src/pages/ODD/ProtocolSetup/index.tsx
+++ b/app/src/pages/ODD/ProtocolSetup/index.tsx
@@ -847,7 +847,9 @@ export function ProtocolSetup(): JSX.Element {
   const { applyOffsets, isApplyingOffsets } = useApplyOffsets(runId)
 
   const [cameraSettingsConfirmed, setCameraSettingsConfirmed] = useState(false)
-  const { data: initialRobotCameraSettings } = useNotifyCamera()
+  const { data: initialRobotCameraSettings } = useNotifyCamera({
+    staleTime: Infinity,
+  })
 
   // The initial app-internal camera state should match the server state.
   useEffect(() => {

--- a/app/src/redux/shell/types.ts
+++ b/app/src/redux/shell/types.ts
@@ -161,6 +161,7 @@ export type NotifyTopic =
   | `robot-server/runs/${string}`
   | `robot-server/runs/pre_serialized_commands/${string}`
   | `robot-server/dataFiles/${string}/images`
+  | 'robot-server/camera'
 
 export interface NotifySubscribeAction {
   type: 'shell:NOTIFY_SUBSCRIBE'

--- a/app/src/resources/camera/useNotifyCamera.ts
+++ b/app/src/resources/camera/useNotifyCamera.ts
@@ -1,0 +1,24 @@
+import { useCamera } from '@opentrons/react-api-client'
+
+import { useNotifyDataReady } from '../useNotifyDataReady'
+
+import type { UseQueryResult } from 'react-query'
+import type { CameraResponse } from '@opentrons/api-client'
+import type { QueryOptionsWithPolling } from '../useNotifyDataReady'
+
+export function useNotifyCamera(
+  options: QueryOptionsWithPolling<CameraResponse, unknown> = {}
+): UseQueryResult<CameraResponse> {
+  const { shouldRefetch, queryOptionsNotify } = useNotifyDataReady({
+    topic: `robot-server/camera`,
+    options,
+  })
+
+  const httpQueryResult = useCamera(queryOptionsNotify)
+
+  if (shouldRefetch) {
+    void httpQueryResult.refetch()
+  }
+
+  return httpQueryResult
+}

--- a/robot-server/tests/conftest.py
+++ b/robot-server/tests/conftest.py
@@ -24,6 +24,7 @@ from opentrons.calibration_storage import (
     helpers,
     save_robot_deck_attitude,
 )
+from server_utils.fastapi_utils.app_state import AppState, get_app_state
 
 # NOTE(FS 10-24-2023), the fixtures using these functions currently ONLY
 # get pulled in by OT-2 server tests. If this ever changes, we need to
@@ -47,6 +48,10 @@ from robot_server.persistence.fastapi_dependencies import get_sql_engine
 from robot_server.health.router import ComponentVersions, get_versions
 from robot_server.runs.run_data_manager import RunDataManager
 from robot_server.runs.dependencies import get_run_data_manager
+from robot_server.service.notifications.notification_client import (
+    NotificationClient,
+    _notification_client_accessor,
+)
 
 test_router = routing.APIRouter()
 
@@ -179,11 +184,29 @@ def _override_run_data_manager_with_mock(run_data: MagicMock) -> Iterator[None]:
 
 
 @pytest.fixture
+def _override_app_state_with_notification_client(decoy: Decoy) -> Iterator[None]:
+    """Override app_state to include a mocked notification client."""
+    mock_app_state = AppState()
+    mock_notification_client = decoy.mock(cls=NotificationClient)
+
+    _notification_client_accessor.set_on(mock_app_state, mock_notification_client)
+
+    async def get_app_state_override() -> AppState:
+        """Override for get_app_state."""
+        return mock_app_state
+
+    app.dependency_overrides[get_app_state] = get_app_state_override
+    yield
+    del app.dependency_overrides[get_app_state]
+
+
+@pytest.fixture
 def api_client(
     _override_hardware_with_mock: None,
     _override_sql_engine_with_mock: None,
     _override_version_with_mock: None,
     _override_ot2_hardware_with_mock: None,
+    _override_app_state_with_notification_client: None,
 ) -> TestClient:
     client = TestClient(app)
     client.headers.update(
@@ -199,6 +222,7 @@ def api_client_camera_overrides(
     _override_version_with_mock: None,
     _override_ot2_hardware_with_mock: None,
     _override_run_data_manager_with_mock: None,
+    _override_app_state_with_notification_client: None,
 ) -> TestClient:
     client = TestClient(app)
     client.headers.update(


### PR DESCRIPTION
# Overview

The people, they yearn for notifications - camera notificaitons, specifically.

The app does a bit of polling for `/camera` resources, and we don't have to do that thanks to the power of MQTT.

https://github.com/user-attachments/assets/41f9dd6e-3c3e-4326-9ae8-6cd5be14c43f


## Test Plan and Hands on Testing

See video.

## Changelog

- Added notification support for camera usage settings.

## Risk assessment

low
