### PR TITLE
fix(api): Capture images on error even when exception is interrupted

### DIFF
--- a/api/src/opentrons/protocol_engine/execution/command_executor.py
+++ b/api/src/opentrons/protocol_engine/execution/command_executor.py
@@ -241,7 +241,10 @@ class CommandExecutor:
     async def capture_error_image(self, running_command: Command) -> None:
         """Capture an image of an error event."""
         try:
-            camera_enablement = await self._camera_provider.get_camera_settings()
+            camera_enablement = self._state_store.camera.get_enablement_settings()
+            if camera_enablement is None:
+                # Utilize the global camera settings
+                camera_enablement = await self._camera_provider.get_camera_settings()
             # Only capture photos of errors if the setting to do so is enabled
             if (
                 camera_enablement.cameraEnabled

--- a/api/src/opentrons/protocol_engine/execution/command_executor.py
+++ b/api/src/opentrons/protocol_engine/execution/command_executor.py
@@ -155,6 +155,7 @@ class CommandExecutor:
         log.debug(
             f"Executing {running_command.id}, {running_command.commandType}, {running_command.params}"
         )
+        error_occurred = False
         try:
             result = await command_impl.execute(
                 running_command.params  # type: ignore[arg-type]
@@ -191,7 +192,7 @@ class CommandExecutor:
                     type=error_recovery_type,
                 )
             )
-            await self.capture_error_image(running_command)
+            error_occurred = True
 
         else:
             if isinstance(result, SuccessData):
@@ -227,6 +228,10 @@ class CommandExecutor:
                         type=error_recovery_type,
                     )
                 )
+                error_occurred = True
+        finally:
+            # Handle error image capture if appropriate
+            if error_occurred:
                 await self.capture_error_image(running_command)
 
     def cancel_tasks(self, message: str | None = None) -> None:


### PR DESCRIPTION
# Overview
Covers RQA-4842

Ensures we execute error image capture even if the original exception that prompted image capture gets interrupted by another exception.

## Test Plan and Hands on Testing

- [x] On an OT-2 trigger a smoothie error via collision and ensure an image is still captured.
- [x] Test with Flex Estop
- [x] Test with protocol cancelation
![EvilArtnold_FlexStackerCameraTest_20251112-191409_4_20251112-191425](https://github.com/user-attachments/assets/92e68bd5-6658-4db2-be6e-dfc6ebba763d)

## Changelog
Changed called for image capture via error to a `finally` case.

## Review requests
Should this cover us, or should this be relocated away from the `CommandExecutor` entirely incase external errors interrupt us? Would we even want a photo from one of those?

## Risk assessment
Low - reinforces new behavior.
