### PR TITLE
fix(build): build py dists before deploy

### DIFF
--- a/.github/workflows/api-test-lint-deploy.yaml
+++ b/.github/workflows/api-test-lint-deploy.yaml
@@ -214,6 +214,10 @@ jobs:
       - uses: './.github/actions/python/setup'
         with:
           project: 'api'
+      - name: 'build api distributables'
+        shell: bash
+        run: make -C api sdist wheel
+
       # creds and repository configuration for deploying python wheels
       - if: ${{ !env.OT_TAG }}
         name: 'upload to test pypi'

--- a/.github/workflows/shared-data-test-lint-deploy.yaml
+++ b/.github/workflows/shared-data-test-lint-deploy.yaml
@@ -184,6 +184,10 @@ jobs:
           script: |
             const { buildComplexEnvVars, } = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/utils.js`)
             buildComplexEnvVars(core, context)
+      - name: 'build shared-data wheel'
+        shell: bash
+        run: make -C shared-data dist-py
+
       # creds and repository configuration for deploying python wheels
       - if: ${{ !env.OT_TAG }}
         name: 'upload to test pypi'


### PR DESCRIPTION
The old opentrons deploy actions would build the distributables as well as deploy them; now that we're using the pypi-maintained deploy actions, we need to build them explicitly (we can't use the ones we already built because that happened in a different job aka vm).

## Testing
Unfortunately there's not much we can do here, but this is already broken and this is pretty straightforward.