### PR TITLE
fix(odd): stop polluting console log with "▶ Object"

### DIFF
--- a/app/src/redux/shell/epic.ts
+++ b/app/src/redux/shell/epic.ts
@@ -42,9 +42,7 @@ const receiveActionFromShellEpic: Epic = () =>
     (_: unknown, incoming: Action) => incoming
   ).pipe<Action>(
     tap(incoming => {
-      log.debug('Received action from main via IPC', {
-        actionType: incoming.type,
-      })
+      log.debug(`Received action from main via IPC: ${incoming.type}`)
     })
   )
 


### PR DESCRIPTION
# Overview

The JavaScript console for the ODD was filling up with log messages of:
```
[app//opt/opentrons-app/resources/app.asar/ui/assets/index-XXX.js] debug: Received action from main via IPC
--------------------------------------------------
▶ Object
```
which is not very helpful.

This PR is a small tweak to inline the action into the log message so that you can see it without clicking on `▶ Object`, decluttering the console.

#### Before:
<img width="1176" height="586" alt="image" src="https://github.com/user-attachments/assets/fb503f36-337a-4031-a026-2067db8df67f" />

#### After:
<img width="1166" height="432" alt="image" src="https://github.com/user-attachments/assets/ec79376f-c692-4b1f-a9b4-b7bfcb7c7fab" />

## Test Plan and Hands on Testing

Built the ODD and deployed it to AuthorshipPVT for hands-on testing.

## Risk assessment

Low.