### PR TITLE
feat(app): support left col responsiveness

### DIFF
--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -46,6 +46,10 @@ module.exports = {
           'lost-unit',
           'lost-utility',
           'lost-waffle',
+
+          // TODO(kk, 2025-11-10) remove when #19993 is merged to edge
+          'container-type',
+          'container-name',
         ],
       },
     ],
@@ -61,6 +65,9 @@ module.exports = {
           // TODO(mc, 2018-02-09): use stylelint-config-lost once stylelint-
           // config-css-modules at-rule-no-unknown no longer conflicts
           'lost',
+
+          // TODO(kk, 2025-11-10) remove when #19993 is merged to edge
+          'container',
         ],
       },
     ],

--- a/app/src/pages/Desktop/Protocols/ProtocolVisualization/CommandSteps/__tests__/CommandSteps.test.tsx
+++ b/app/src/pages/Desktop/Protocols/ProtocolVisualization/CommandSteps/__tests__/CommandSteps.test.tsx
@@ -1,0 +1,43 @@
+import { screen } from '@testing-library/react'
+import { beforeEach, describe, it, vi } from 'vitest'
+
+import { renderWithProviders } from '/app/__testing-utils__'
+import { i18n } from '/app/i18n'
+import { AnnotatedSteps } from '/app/organisms/Desktop/ProtocolDetails/AnnotatedSteps'
+
+import { CommandSteps } from '../'
+
+import type { ComponentProps } from 'react'
+
+vi.mock('/app/organisms/Desktop/ProtocolDetails/AnnotatedSteps')
+
+const render = (props: ComponentProps<typeof CommandSteps>) => {
+  return renderWithProviders(<CommandSteps {...props} />, {
+    i18nInstance: i18n,
+  })
+}
+
+describe('CommandSteps', () => {
+  let props: ComponentProps<typeof CommandSteps>
+  beforeEach(() => {
+    props = {
+      groupedCommands: null,
+      analysis: {} as any,
+      setSelectedCommand: vi.fn(),
+      percentComplete: 50,
+      handlePause: vi.fn(),
+      currentCommandIndex: 1,
+    }
+    vi.mocked(AnnotatedSteps).mockReturnValue(<div>mock AnnotatedSteps</div>)
+  })
+  it('should render header text', () => {
+    render(props)
+    screen.getByText('Timeline')
+    screen.getByText('50% complete')
+  })
+
+  it('should render mock AnnotatedSteps', () => {
+    render(props)
+    screen.getByText('mock AnnotatedSteps')
+  })
+})

--- a/app/src/pages/Desktop/Protocols/ProtocolVisualization/CommandSteps/commandsteps.module.css
+++ b/app/src/pages/Desktop/Protocols/ProtocolVisualization/CommandSteps/commandsteps.module.css
@@ -4,8 +4,8 @@
   flex-direction: column;
   border-radius: var(--border-radius-8);
   background-color: var(--white);
-  container-type: inline-size;
   container-name: detail-container;
+  container-type: inline-size;
 }
 
 .command_step {
@@ -15,17 +15,16 @@
 
 .command_step_header {
   display: flex;
-  padding: var(--spacing-16);
-
   flex-direction: column;
+  padding: var(--spacing-16);
   gap: var(--spacing-8, 8px);
 }
 
 @container detail-container (min-width: 273px) {
   .command_step_header {
     flex-direction: row;
-    justify-content: space-between;
     align-items: center;
+    justify-content: space-between;
     gap: unset; /* reset the gap */
   }
 }

--- a/app/src/pages/Desktop/Protocols/ProtocolVisualization/CommandSteps/commandsteps.module.css
+++ b/app/src/pages/Desktop/Protocols/ProtocolVisualization/CommandSteps/commandsteps.module.css
@@ -1,0 +1,38 @@
+.detail_container {
+  display: flex;
+  height: 100%;
+  flex-direction: column;
+  border-radius: var(--border-radius-8);
+  background-color: var(--white);
+  container-type: inline-size;
+  container-name: detail-container;
+}
+
+.command_step {
+  border-radius: var(--border-radius-8);
+  background-color: var(--white);
+}
+
+.command_step_header {
+  display: flex;
+  padding: var(--spacing-16);
+
+  flex-direction: column;
+  gap: var(--spacing-8, 8px);
+}
+
+@container detail-container (min-width: 273px) {
+  .command_step_header {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+    gap: unset; /* reset the gap */
+  }
+}
+
+.command_step_groups {
+  height: 39rem;
+  min-height: 0;
+  flex: 1;
+  overflow-y: auto;
+}

--- a/app/src/pages/Desktop/Protocols/ProtocolVisualization/CommandSteps/index.tsx
+++ b/app/src/pages/Desktop/Protocols/ProtocolVisualization/CommandSteps/index.tsx
@@ -4,7 +4,7 @@ import { COLORS, StyledText } from '@opentrons/components'
 
 import { AnnotatedSteps } from '/app/organisms/Desktop/ProtocolDetails/AnnotatedSteps'
 
-import styles from './visualization.module.css'
+import styles from './commandsteps.module.css'
 
 import type { Dispatch, SetStateAction } from 'react'
 import type { ProtocolAnalysisOutput } from '@opentrons/shared-data'
@@ -20,12 +20,12 @@ interface CommandStepsProps {
 }
 export function CommandSteps(props: CommandStepsProps): JSX.Element {
   const {
-    currentCommandIndex,
     groupedCommands,
     analysis,
     setSelectedCommand,
-    handlePause,
     percentComplete,
+    handlePause,
+    currentCommandIndex,
   } = props
   const { t } = useTranslation('protocol_visualization')
   return (

--- a/app/src/pages/Desktop/Protocols/ProtocolVisualization/VisualizerContainer.tsx
+++ b/app/src/pages/Desktop/Protocols/ProtocolVisualization/VisualizerContainer.tsx
@@ -24,7 +24,7 @@ import type { ProtocolAnalysisOutput } from '@opentrons/shared-data'
 import type { GroupedCommands } from '/app/redux/protocol-storage'
 
 const INITIAL_MILLISECONDS_PER_FRAME = 2000
-const INITIAL_WIDTH_PX = 200
+const INITIAL_WIDTH_PX = 230
 const MIN_CENTER_WIDTH_PX = 200
 const MIN_COLUMN_WIDTH_PX = 100
 const MAX_COLUMN_WIDTH_PX = 400

--- a/app/src/pages/Desktop/Protocols/ProtocolVisualization/visualizercontainer.module.css
+++ b/app/src/pages/Desktop/Protocols/ProtocolVisualization/visualizercontainer.module.css
@@ -9,7 +9,8 @@
 .left_column {
   position: relative;
   display: flex;
-  min-width: 200px;
+  min-width: 9.25rem; /* 148px */
+  max-width: 37.5rem; /* 600px */
   flex-direction: column;
   flex-shrink: 0;
   overflow-y: auto;


### PR DESCRIPTION
# Overview
support left col responsiveness and update the initial width from 200px to 230px


https://github.com/user-attachments/assets/79ce7c43-a2e7-4f33-a14d-c846f958dedf


close AUTH-2478

the blue line for resizing will be fix by a following DQA pr.

## Test Plan and Hands on Testing
- click a protocol and go to the protocol details page
- click visualization button
- drag & drop the right edge of the left col
- update the left col min-width:148px and max-width: 600px

Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.

## Changelog
- update the initial col width from 200px to 230px
- create a new css file for CommandSteps
- add the basic tests for CommandSteps 

## Review requests

## Risk assessment
low

