### PR TITLE
fix(protocol-designer): allow return tip for single channel

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/DropTipField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/DropTipField.tsx
@@ -2,7 +2,7 @@ import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 
-import { ALL } from '@opentrons/shared-data'
+import { ALL, SINGLE } from '@opentrons/shared-data'
 
 import { DropdownStepFormField } from '/protocol-designer/components/molecules'
 import {
@@ -11,16 +11,26 @@ import {
 } from '/protocol-designer/step-forms/selectors'
 
 import type { DropdownOption } from '@opentrons/components'
-import type { NozzleConfigurationStyle } from '@opentrons/shared-data'
+import type {
+  NozzleConfigurationStyle,
+  PipetteChannels,
+} from '@opentrons/shared-data'
 import type { FieldProps } from '../types'
 
 interface DropTipFieldProps extends FieldProps {
   nozzles: NozzleConfigurationStyle | null
+  channels: PipetteChannels
   tiprackDefUri: string
 }
 
 export function DropTipField(props: DropTipFieldProps): JSX.Element {
-  const { value: dropdownItem, updateValue, nozzles, tiprackDefUri } = props
+  const {
+    value: dropdownItem,
+    updateValue,
+    nozzles,
+    tiprackDefUri,
+    channels,
+  } = props
   const { t, i18n } = useTranslation(['form', 'shared'])
   const additionalEquipment = useSelector(getAdditionalEquipmentEntities)
   const labwareEntities = useSelector(getLabwareEntities)
@@ -49,7 +59,8 @@ export function DropTipField(props: DropTipFieldProps): JSX.Element {
     value: tiprackDefUri,
   }
 
-  const isReturnTipValid = nozzles === ALL || nozzles == null
+  const isReturnTipValid =
+    nozzles === ALL || nozzles == null || (channels === 1 && nozzles === SINGLE)
 
   const isTipDropLocationReturnTip = Object.values(labwareEntities).some(
     ({ labwareDefURI }) => labwareDefURI === tiprackDefUri

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/TipSettings.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/TipSettings.tsx
@@ -9,7 +9,10 @@ import {
 } from '@opentrons/components'
 
 import { getEnableTipSelection } from '/protocol-designer/feature-flags/selectors'
-import { getAdditionalEquipmentEntities } from '/protocol-designer/step-forms/selectors'
+import {
+  getAdditionalEquipmentEntities,
+  getPipetteEntities,
+} from '/protocol-designer/step-forms/selectors'
 
 import { DropTipField } from '../../PipetteFields'
 import { ChangeTipField } from '../../PipetteFields/ChangeTipField'
@@ -27,7 +30,8 @@ interface TipSettingsProps {
 export function TipSettings(props: TipSettingsProps): JSX.Element {
   const { t } = useTranslation('protocol_steps')
   const { propsForFields, formData, stepType } = props
-
+  const pipetteEntities = useSelector(getPipetteEntities)
+  const channels = pipetteEntities[formData.pipette as string].spec.channels
   const additionalEquipmentEntities = useSelector(
     getAdditionalEquipmentEntities
   )
@@ -73,6 +77,7 @@ export function TipSettings(props: TipSettingsProps): JSX.Element {
           <DropTipField
             {...propsForFields.dropTip_location}
             nozzles={formData.nozzles}
+            channels={channels}
             tiprackDefUri={formData.tipRack}
             tooltipContent={null}
             padding="0"


### PR DESCRIPTION
# Overview

This PR unblocks single channel return tip

## Test Plan and Hands on Testing

- create a single-channel moveLiquid/mix step
- navigate to tip settings
- verify that tip rack is a valid dropdown option for "Tip drop location"

## Changelog

- add logic for single channel pipette with single nozzle configuration for allowing return tip

## Review requests

see test plan

## Risk assessment

low