### PR TITLE
fix(hardware): Fix plunger stalls during negative direction motion.

### DIFF
--- a/hardware/opentrons_hardware/hardware_control/motion_planning/move_manager.py
+++ b/hardware/opentrons_hardware/hardware_control/motion_planning/move_manager.py
@@ -82,7 +82,9 @@ class MoveManager(Generic[AxisKey]):
             if axis in target_axes:
                 move_target = MoveTarget.build(  # type: ignore[type-var]
                     position=target,
-                    max_speed=float(speed * abs(1 / move_info.unit_vector[axis].item())),
+                    max_speed=float(
+                        speed * abs(1 / move_info.unit_vector[axis].item())
+                    ),
                 )
         return move_target
 

--- a/hardware/opentrons_hardware/hardware_control/motion_planning/move_manager.py
+++ b/hardware/opentrons_hardware/hardware_control/motion_planning/move_manager.py
@@ -82,7 +82,7 @@ class MoveManager(Generic[AxisKey]):
             if axis in target_axes:
                 move_target = MoveTarget.build(  # type: ignore[type-var]
                     position=target,
-                    max_speed=float(speed * (1 / move_info.unit_vector[axis].item())),
+                    max_speed=float(speed * abs(1 / move_info.unit_vector[axis].item())),
                 )
         return move_target
 

--- a/hardware/tests/opentrons_hardware/hardware_control/test_motion_plan.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_motion_plan.py
@@ -322,3 +322,18 @@ async def test_plunger_devectorize(
     uv = blend_log[0][0].unit_vector
 
     assert devectorized.max_speed == speed
+
+    # make sure negative directions work
+    origin = {"A": 20}
+    target = {"A": 0}
+    speed = 10
+    devectorized = manager.devectorize_axes(origin, target, speed, ["A"])
+
+    converged, blend_log = manager.plan_motion(
+        origin=origin,
+        target_list=[devectorized],
+        iteration_limit=20,
+    )
+    uv = blend_log[0][0].unit_vector
+
+    assert devectorized.max_speed == speed


### PR DESCRIPTION
# Overview
Plunger moves in the negative direction were broken because the unit vector is negative and the plan motion function expects speed to always be positive.