### PR TITLE
fix(docs): swap comment on set_offset() and calibrated_offset()

### DIFF
--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -822,8 +822,8 @@ class Labware:
     def set_offset(self, x: float, y: float, z: float) -> None:
         """Set the labware's position offset.
 
-        The offset is an x, y, z vector in deck coordinates
-        (see :ref:`protocol-api-deck-coords`).
+        An offset of `(x=0, y=0, z=0)` means the labware's uncalibrated position before
+        any offset from Labware Position Check is applied.
 
         How the motion system applies the offset depends on the API level of the protocol.
 
@@ -881,6 +881,9 @@ class Labware:
     @requires_version(2, 0)
     def calibrated_offset(self) -> Point:
         """The front-left-bottom corner of the labware, including its labware offset.
+
+        The offset is an x, y, z vector in deck coordinates
+        (see :ref:`protocol-api-deck-coords`).
 
         When running a protocol in the Opentrons App or on the touchscreen, Labware
         Position Check sets the labware offset.


### PR DESCRIPTION
# Overview

Previously, the `Labware.set_offset()` function claimed that
```
The offset is an x, y, z vector in deck coordinates (see :ref:`protocol-api-deck-coords`).
```
This is misleading because a deck coordinate of `(0, 0, 0)` means the front left corner of the deck, but `set_offset(0, 0, 0)` would **not** put the labware on the front left corner of the deck.

Then there's also the `Labware.calibrated_offset` property, which **does** return deck coordinates, but is not documented as doing so.

This PR swaps the deck coordinates comment from `Labware.set_offset()` to `Labware.calibrated_offset`.

## Test Plan and Hands on Testing

No change to functionality at all, just a docstring change.

## Risk assessment

Low.