### PR TITLE
fix(protocol-designer): Fix some possible type bugs in the `lastSelected` state

### DIFF
--- a/protocol-designer/src/ui/steps/actions/actions.ts
+++ b/protocol-designer/src/ui/steps/actions/actions.ts
@@ -281,22 +281,24 @@ export const selectAllSteps =
     getState: GetState
   ) => {
     const allStepIds = stepFormSelectors.getOrderedStepIds(getState())
-    const selectStepAction: SelectMultipleStepsAction = {
-      type: 'SELECT_MULTIPLE_STEPS',
-      payload: {
-        stepIds: allStepIds,
-        // @ts-expect-error(sa, 2021-6-15): find could return undefined, need to null check PipetteSpecsV2
-        lastSelected: last(allStepIds),
-      },
+    if (allStepIds.length > 0) {
+      const lastStepId = last(allStepIds)!
+      const selectStepAction: SelectMultipleStepsAction = {
+        type: 'SELECT_MULTIPLE_STEPS',
+        payload: {
+          stepIds: allStepIds,
+          lastSelected: lastStepId,
+        },
+      }
+      dispatch(selectStepAction)
+      // dispatch an analytics event to indicate all steps have been selected
+      // because there is no 'SELECT_ALL_STEPS' action that middleware can catch
+      const selectAllStepsEvent: AnalyticsEvent = {
+        name: SELECT_ALL_STEPS_EVENT,
+        properties: {},
+      }
+      dispatch(analyticsEvent(selectAllStepsEvent))
     }
-    dispatch(selectStepAction)
-    // dispatch an analytics event to indicate all steps have been selected
-    // because there is no 'SELECT_ALL_STEPS' action that middleware can catch
-    const selectAllStepsEvent: AnalyticsEvent = {
-      name: SELECT_ALL_STEPS_EVENT,
-      properties: {},
-    }
-    dispatch(analyticsEvent(selectAllStepsEvent))
   }
 export const EXIT_BATCH_EDIT_MODE_BUTTON_PRESS: 'EXIT_BATCH_EDIT_MODE_BUTTON_PRESS' =
   'EXIT_BATCH_EDIT_MODE_BUTTON_PRESS'

--- a/protocol-designer/src/ui/steps/actions/thunks/index.ts
+++ b/protocol-designer/src/ui/steps/actions/thunks/index.ts
@@ -231,8 +231,7 @@ export const duplicateMultipleSteps: (
   stepIds => (dispatch, getState) => {
     const orderedStepIds = getOrderedStepIds(getState())
     const lastSelectedItemId = getMultiSelectLastSelected(getState())
-    // @ts-expect-error(sa, 2021-6-15): lastSelectedItemId might be null, which you cannot pass to indexOf
-    const indexOfLastSelected = orderedStepIds.indexOf(lastSelectedItemId)
+    const indexOfLastSelected = orderedStepIds.indexOf(lastSelectedItemId!)
     stepIds.sort(
       (a, b) => orderedStepIds.indexOf(a) - orderedStepIds.indexOf(b)
     )
@@ -254,8 +253,7 @@ export const duplicateMultipleSteps: (
       type: 'SELECT_MULTIPLE_STEPS',
       payload: {
         stepIds: duplicateIds,
-        // @ts-expect-error(sa, 2021-6-15): last might return undefined
-        lastSelected: last(duplicateIds),
+        lastSelected: last(duplicateIds)!,
       },
     }
     dispatch(duplicateMultipleStepsAction)

--- a/step-generation/src/__tests__/thermocyclerUpdates.test.ts
+++ b/step-generation/src/__tests__/thermocyclerUpdates.test.ts
@@ -22,6 +22,7 @@ import {
 
 import type {
   ModuleOnlyParams,
+  TCProfileParams,
   TemperatureParams,
   ThermocyclerSetTargetBlockTemperatureParams,
 } from '@opentrons/shared-data/protocol/types/schemaV6/command/module'
@@ -216,12 +217,12 @@ describe('thermocycler state updaters', () => {
       testName: 'forThermocyclerOpenLid should set lidOpen to true',
     },
   ]
-  const profileCases: TestCases<any> = [
+  const profileCases: TestCases<TCProfileParams> = [
     {
       params: {
         moduleId,
         profile: [],
-        volume: 10,
+        blockMaxVolumeUl: 10,
       },
       moduleStateBefore: {},
       expectedUpdate: {},
@@ -233,19 +234,19 @@ describe('thermocycler state updaters', () => {
         moduleId,
         profile: [
           {
-            holdTime: 10,
-            temperature: 50,
+            holdSeconds: 10,
+            celsius: 50,
           },
           {
-            holdTime: 10,
-            temperature: 30,
+            holdSeconds: 10,
+            celsius: 30,
           },
           {
-            holdTime: 10,
-            temperature: 0,
+            holdSeconds: 10,
+            celsius: 0,
           },
         ],
-        volume: 10,
+        blockMaxVolumeUl: 10,
       },
       moduleStateBefore: {
         blockTargetTemp: 42,
@@ -261,19 +262,19 @@ describe('thermocycler state updaters', () => {
         moduleId,
         profile: [
           {
-            holdTime: 10,
-            temperature: 0,
+            holdSeconds: 10,
+            celsius: 0,
           },
           {
-            holdTime: 10,
-            temperature: 50,
+            holdSeconds: 10,
+            celsius: 50,
           },
           {
-            holdTime: 10,
-            temperature: 20,
+            holdSeconds: 10,
+            celsius: 20,
           },
         ],
-        volume: 10,
+        blockMaxVolumeUl: 10,
       },
       moduleStateBefore: {
         blockTargetTemp: 42,
@@ -289,11 +290,11 @@ describe('thermocycler state updaters', () => {
         moduleId,
         profile: [
           {
-            holdTime: 10,
-            temperature: 30,
+            holdSeconds: 10,
+            celsius: 30,
           },
         ],
-        volume: 10,
+        blockMaxVolumeUl: 10,
       },
       moduleStateBefore: {
         blockTargetTemp: 42,

--- a/step-generation/src/getNextRobotStateAndWarnings/thermocyclerUpdates.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/thermocyclerUpdates.ts
@@ -139,7 +139,6 @@ export const forThermocyclerRunProfile = (
   const moduleState = _getThermocyclerModuleState(robotState, moduleId)
 
   if (profile.length > 0) {
-    // @ts-expect-error (sa, 2021-05-03): last might return undefined
-    moduleState.blockTargetTemp = last(profile).temperature
+    moduleState.blockTargetTemp = last(profile)!.celsius
   }
 }

--- a/step-generation/src/utils/commandCreatorsTimeline.ts
+++ b/step-generation/src/utils/commandCreatorsTimeline.ts
@@ -21,8 +21,7 @@ export const commandCreatorsTimeline = (
       const prevRobotState =
         acc.timeline.length === 0
           ? initialRobotState
-          : // @ts-expect-error(SA, 2021-05-03): last might return undefined
-            last(acc.timeline).robotState
+          : last(acc.timeline)!.robotState
 
       if (acc.errors != null) {
         // error short-circuit


### PR DESCRIPTION
## Overview

The `lastSelected` state keeps track of the most recently selected step. It's supposed to always be a `string`, but a few places looked like they were possibly setting it to `null` or `undefined`. This fixes those.

## Test Plan and Hands on Testing

None?

## Changelog

See comments.

## Review requests

See comments.

## Risk assessment

Low.
