### PR TITLE
refactor(app): display progress for active runs and allow log download on completion 

### DIFF
--- a/app/src/assets/localization/en/run_details.json
+++ b/app/src/assets/localization/en/run_details.json
@@ -37,7 +37,7 @@
   "confirm_camera_preferences": "Confirm camera preferences",
   "confirm_camera_preferences_desc": "Confirm camera preferences to view the livestream during run setup",
   "csv_available_download": "All files associated with the run are available on the robot’s Recent Runs screen.",
-  "current_step": "Current Step",
+  "current_step": "Step",
   "current_step_pause": "Current Step - Paused by User",
   "current_step_pause_timer": "Timer",
   "current_temperature": "Current: {{temperature}} °C",

--- a/app/src/organisms/Desktop/ProtocolsLanding/ProtocolCard.tsx
+++ b/app/src/organisms/Desktop/ProtocolsLanding/ProtocolCard.tsx
@@ -320,60 +320,54 @@ function AnalysisInfo(props: AnalysisInfoProps): JSX.Element {
                   }[analysisStatus]
                 }
               </Flex>
-              <Flex gridGap={SPACING.spacing4}>
+              <Flex
+                flexDirection={DIRECTION_COLUMN}
+                width="100%"
+                gridGap={SPACING.spacing4}
+                flex="0 0 6rem"
+              >
+                {requiredModuleTypes.length > 0 ? (
+                  <>
+                    <StyledText
+                      desktopStyle="bodyDefaultRegular"
+                      color={COLORS.grey60}
+                    >
+                      {i18n.format('modules', 'capitalize')}
+                    </StyledText>
+                    <Flex>
+                      {requiredModuleTypes.map((moduleType, index) => (
+                        <ModuleIcon
+                          key={index}
+                          color={COLORS.grey50}
+                          moduleType={moduleType}
+                          height="1rem"
+                          marginRight={SPACING.spacing8}
+                        />
+                      ))}
+                    </Flex>
+                  </>
+                ) : null}
+              </Flex>
+              {hasPeripherals && (
                 <Flex
                   flex="0 0 6rem"
                   flexDirection={DIRECTION_COLUMN}
                   gridGap={SPACING.spacing4}
-                  width="85px"
+                  width="100%"
                 >
-                  {requiredModuleTypes.length > 0 ? (
-                    <>
-                      <StyledText
-                        desktopStyle="bodyDefaultRegular"
-                        color={COLORS.grey60}
-                      >
-                        {i18n.format('modules', 'capitalize')}
-                      </StyledText>
-                      <Flex flexWrap={WRAP}>
-                        {requiredModuleTypes.map((moduleType, index) => (
-                          <ModuleIcon
-                            key={index}
-                            color={COLORS.grey50}
-                            moduleType={moduleType}
-                            height="1rem"
-                            marginRight={SPACING.spacing8}
-                          />
-                        ))}
-                      </Flex>
-                    </>
-                  ) : null}
+                  <>
+                    <StyledText
+                      desktopStyle="bodyDefaultRegular"
+                      color={COLORS.grey60}
+                    >
+                      {t('peripherals')}
+                    </StyledText>
+                    <Flex flexWrap={WRAP}>
+                      <Icon color={COLORS.grey50} name="camera" height="1rem" />
+                    </Flex>
+                  </>
                 </Flex>
-                {hasPeripherals && (
-                  <Flex
-                    flex="0 0 6rem"
-                    flexDirection={DIRECTION_COLUMN}
-                    gridGap={SPACING.spacing4}
-                    width="85px"
-                  >
-                    <>
-                      <StyledText
-                        desktopStyle="bodyDefaultRegular"
-                        color={COLORS.grey60}
-                      >
-                        {t('peripherals')}
-                      </StyledText>
-                      <Flex flexWrap={WRAP}>
-                        <Icon
-                          color={COLORS.grey50}
-                          name="photo-camera"
-                          height="1rem"
-                        />
-                      </Flex>
-                    </>
-                  </Flex>
-                )}
-              </Flex>
+              )}
             </Flex>
             <Flex
               justifyContent={JUSTIFY_FLEX_END}

--- a/app/src/organisms/Desktop/ProtocolsLanding/ProtocolCard.tsx
+++ b/app/src/organisms/Desktop/ProtocolsLanding/ProtocolCard.tsx
@@ -320,54 +320,60 @@ function AnalysisInfo(props: AnalysisInfoProps): JSX.Element {
                   }[analysisStatus]
                 }
               </Flex>
-              <Flex
-                flexDirection={DIRECTION_COLUMN}
-                width="100%"
-                gridGap={SPACING.spacing4}
-                flex="0 0 6rem"
-              >
-                {requiredModuleTypes.length > 0 ? (
-                  <>
-                    <StyledText
-                      desktopStyle="bodyDefaultRegular"
-                      color={COLORS.grey60}
-                    >
-                      {i18n.format('modules', 'capitalize')}
-                    </StyledText>
-                    <Flex>
-                      {requiredModuleTypes.map((moduleType, index) => (
-                        <ModuleIcon
-                          key={index}
-                          color={COLORS.grey50}
-                          moduleType={moduleType}
-                          height="1rem"
-                          marginRight={SPACING.spacing8}
-                        />
-                      ))}
-                    </Flex>
-                  </>
-                ) : null}
-              </Flex>
-              {hasPeripherals && (
+              <Flex gridGap={SPACING.spacing4}>
                 <Flex
                   flex="0 0 6rem"
                   flexDirection={DIRECTION_COLUMN}
                   gridGap={SPACING.spacing4}
-                  width="100%"
+                  width="85px"
                 >
-                  <>
-                    <StyledText
-                      desktopStyle="bodyDefaultRegular"
-                      color={COLORS.grey60}
-                    >
-                      {t('peripherals')}
-                    </StyledText>
-                    <Flex flexWrap={WRAP}>
-                      <Icon color={COLORS.grey50} name="camera" height="1rem" />
-                    </Flex>
-                  </>
+                  {requiredModuleTypes.length > 0 ? (
+                    <>
+                      <StyledText
+                        desktopStyle="bodyDefaultRegular"
+                        color={COLORS.grey60}
+                      >
+                        {i18n.format('modules', 'capitalize')}
+                      </StyledText>
+                      <Flex flexWrap={WRAP}>
+                        {requiredModuleTypes.map((moduleType, index) => (
+                          <ModuleIcon
+                            key={index}
+                            color={COLORS.grey50}
+                            moduleType={moduleType}
+                            height="1rem"
+                            marginRight={SPACING.spacing8}
+                          />
+                        ))}
+                      </Flex>
+                    </>
+                  ) : null}
                 </Flex>
-              )}
+                {hasPeripherals && (
+                  <Flex
+                    flex="0 0 6rem"
+                    flexDirection={DIRECTION_COLUMN}
+                    gridGap={SPACING.spacing4}
+                    width="85px"
+                  >
+                    <>
+                      <StyledText
+                        desktopStyle="bodyDefaultRegular"
+                        color={COLORS.grey60}
+                      >
+                        {t('peripherals')}
+                      </StyledText>
+                      <Flex flexWrap={WRAP}>
+                        <Icon
+                          color={COLORS.grey50}
+                          name="photo-camera"
+                          height="1rem"
+                        />
+                      </Flex>
+                    </>
+                  </Flex>
+                )}
+              </Flex>
             </Flex>
             <Flex
               justifyContent={JUSTIFY_FLEX_END}

--- a/app/src/organisms/Desktop/RunProgressMeter/__tests__/RunProgressMeter.test.tsx
+++ b/app/src/organisms/Desktop/RunProgressMeter/__tests__/RunProgressMeter.test.tsx
@@ -122,6 +122,7 @@ describe('RunProgressMeter', () => {
     expect(screen.getByText('Step N/A:')).toBeTruthy()
     expect(screen.queryByText('MOCK PROGRESS BAR')).toBeFalsy()
   })
+
   it('should give no step info when run status is idle', () => {
     vi.mocked(useCommandQuery).mockReturnValue({ data: null } as any)
     vi.mocked(useRunStatus).mockReturnValue(RUN_STATUS_IDLE)

--- a/app/src/organisms/Desktop/RunProgressMeter/__tests__/RunProgressMeter.test.tsx
+++ b/app/src/organisms/Desktop/RunProgressMeter/__tests__/RunProgressMeter.test.tsx
@@ -119,16 +119,14 @@ describe('RunProgressMeter', () => {
       reportModuleCommand: vi.fn(),
     } as any)
     render(props)
-    expect(screen.getByText('Current Step N/A:')).toBeTruthy()
+    expect(screen.getByText('Step N/A:')).toBeTruthy()
     expect(screen.queryByText('MOCK PROGRESS BAR')).toBeFalsy()
   })
-  it('should give the correct info when run status is idle', () => {
+  it('should give no step info when run status is idle', () => {
     vi.mocked(useCommandQuery).mockReturnValue({ data: null } as any)
     vi.mocked(useRunStatus).mockReturnValue(RUN_STATUS_IDLE)
     render(props)
-    screen.getByText('Current Step:')
-    screen.getByText('Not started yet')
-    screen.getByText('Download run log')
+    expect(screen.queryByText(/Step/)).toBeNull()
   })
 
   it('should render an intervention modal when showInterventionModal is true', () => {
@@ -144,7 +142,7 @@ describe('RunProgressMeter', () => {
     screen.getByText('MOCK_INTERVENTION_MODAL')
   })
 
-  it('should render the correct run status when run status is completed', () => {
+  it('should render no text when run status is completed', () => {
     vi.mocked(useCommandQuery).mockReturnValue({ data: null } as any)
     vi.mocked(useRunStatus).mockReturnValue(RUN_STATUS_SUCCEEDED)
     vi.mocked(useRunningStepCounts).mockReturnValue({
@@ -153,13 +151,13 @@ describe('RunProgressMeter', () => {
       hasRunDiverged: false,
     })
     render(props)
-    screen.getByText('Final Step 10/10:')
+    expect(screen.queryByText(/Step/)).toBeNull()
   })
 
-  it('should render the correct step info when the run is cancelled before running', () => {
+  it('should render no text when the run is cancelled before running', () => {
     vi.mocked(useCommandQuery).mockReturnValue({ data: null } as any)
     vi.mocked(useRunStatus).mockReturnValue(RUN_STATUS_STOPPED)
     render(props)
-    screen.getByText('Final Step: N/A')
+    expect(screen.queryByText(/Step/)).toBeNull()
   })
 })

--- a/app/src/organisms/Desktop/RunProgressMeter/__tests__/RunProgressMeter.test.tsx
+++ b/app/src/organisms/Desktop/RunProgressMeter/__tests__/RunProgressMeter.test.tsx
@@ -119,7 +119,7 @@ describe('RunProgressMeter', () => {
       reportModuleCommand: vi.fn(),
     } as any)
     render(props)
-    expect(screen.getByText('Step N/A:')).toBeTruthy()
+    expect(screen.getByText('Step: N/A')).toBeTruthy()
     expect(screen.queryByText('MOCK PROGRESS BAR')).toBeFalsy()
   })
 

--- a/app/src/organisms/Desktop/RunProgressMeter/hooks/useRunProgressCopy.tsx
+++ b/app/src/organisms/Desktop/RunProgressMeter/hooks/useRunProgressCopy.tsx
@@ -4,12 +4,12 @@ import { useTranslation } from 'react-i18next'
 import {
   RUN_STATUS_BLOCKED_BY_OPEN_DOOR,
   RUN_STATUS_IDLE,
+  RUN_STATUS_SUCCEEDED,
 } from '@opentrons/api-client'
 import {
   CommandText,
   getCommandTextData,
   getLabwareDefinitionsFromCommands,
-  LegacyStyledText,
 } from '@opentrons/components'
 
 import { useModuleCommandAnalytics } from '/app/redux-resources/analytics/'
@@ -72,8 +72,8 @@ export function useRunProgressCopy({
   )
 
   const currentStepContents = ((): JSX.Element | null => {
-    if (runHasNotBeenStarted) {
-      return <LegacyStyledText as="h2">{t('not_started_yet')}</LegacyStyledText>
+    if (runStatus === RUN_STATUS_SUCCEEDED || runHasNotBeenStarted) {
+      return null
     } else if (analysis != null && !hasRunDiverged) {
       return (
         <CommandText
@@ -106,30 +106,29 @@ export function useRunProgressCopy({
     : (currentStepNumber! / analysisCommands.length) * 100
 
   const stepCountStr = ((): string | null => {
-    if (runStatus == null) {
+    if (
+      runStatus == null ||
+      runStatus === RUN_STATUS_SUCCEEDED ||
+      runHasNotBeenStarted
+    ) {
       return null
+    }
+
+    const isTerminalStatus = TERMINAL_RUN_STATUSES.includes(runStatus)
+    const stepType = isTerminalStatus ? '' : t('current_step')
+
+    if (isTerminalStatus && currentStepNumber == null) {
+      return `${stepType}: ${t('na')}`
+    } else if (hasRunDiverged) {
+      return `${stepType} ${t('na')}:`
     } else {
-      const isTerminalStatus = TERMINAL_RUN_STATUSES.includes(runStatus)
-      const stepType = isTerminalStatus ? t('final_step') : t('current_step')
-
-      if (runStatus === RUN_STATUS_IDLE) {
-        return `${stepType}:`
-      } else if (isTerminalStatus && currentStepNumber == null) {
-        return `${stepType}: ${t('na')}`
-      } else if (hasRunDiverged) {
-        return `${stepType} ${t('na')}:`
-      } else {
-        const getCountString = (): string => {
-          const current = currentStepNumber ?? '?'
-          const total = totalStepCount ?? '?'
-
-          return `${current}/${total}`
-        }
-
-        const countString = getCountString()
-
-        return `${stepType} ${countString}:`
+      const getCountString = (): string => {
+        const current = currentStepNumber ?? '?'
+        const total = totalStepCount ?? '?'
+        return `${current}/${total}`
       }
+
+      return `${stepType} ${getCountString()}:`
     }
   })()
   const { reportModuleCommand } = useModuleCommandAnalytics()

--- a/app/src/organisms/Desktop/RunProgressMeter/hooks/useRunProgressCopy.tsx
+++ b/app/src/organisms/Desktop/RunProgressMeter/hooks/useRunProgressCopy.tsx
@@ -4,7 +4,6 @@ import { useTranslation } from 'react-i18next'
 import {
   RUN_STATUS_BLOCKED_BY_OPEN_DOOR,
   RUN_STATUS_IDLE,
-  RUN_STATUS_SUCCEEDED,
 } from '@opentrons/api-client'
 import {
   CommandText,
@@ -14,7 +13,7 @@ import {
 
 import { useModuleCommandAnalytics } from '/app/redux-resources/analytics/'
 
-import { TERMINAL_RUN_STATUSES } from '../constants'
+import { isTerminalRunStatus } from '../../Devices/ProtocolRun/ProtocolRunHeader/utils'
 
 import type { ReactNode } from 'react'
 import type { CommandDetail, RunStatus } from '@opentrons/api-client'
@@ -72,7 +71,7 @@ export function useRunProgressCopy({
   )
 
   const currentStepContents = ((): JSX.Element | null => {
-    if (runStatus === RUN_STATUS_SUCCEEDED || runHasNotBeenStarted) {
+    if (isTerminalRunStatus(runStatus) || runHasNotBeenStarted) {
       return null
     } else if (analysis != null && !hasRunDiverged) {
       return (
@@ -106,21 +105,14 @@ export function useRunProgressCopy({
     : (currentStepNumber! / analysisCommands.length) * 100
 
   const stepCountStr = ((): string | null => {
-    if (
-      runStatus == null ||
-      runStatus === RUN_STATUS_SUCCEEDED ||
-      runHasNotBeenStarted
-    ) {
+    if (isTerminalRunStatus(runStatus) || runStatus === RUN_STATUS_IDLE) {
       return null
     }
 
-    const isTerminalStatus = TERMINAL_RUN_STATUSES.includes(runStatus)
-    const stepType = isTerminalStatus ? '' : t('current_step')
-
-    if (isTerminalStatus && currentStepNumber == null) {
-      return `${stepType}: ${t('na')}`
+    if (isTerminalRunStatus(runStatus) && currentStepNumber == null) {
+      return `${t(`current_step`)}: ${t('na')}`
     } else if (hasRunDiverged) {
-      return `${stepType} ${t('na')}:`
+      return `${t(`current_step`)} ${t('na')}:`
     } else {
       const getCountString = (): string => {
         const current = currentStepNumber ?? '?'
@@ -128,7 +120,7 @@ export function useRunProgressCopy({
         return `${current}/${total}`
       }
 
-      return `${stepType} ${getCountString()}:`
+      return `${t(`current_step`)} ${getCountString()}:`
     }
   })()
   const { reportModuleCommand } = useModuleCommandAnalytics()

--- a/app/src/organisms/Desktop/RunProgressMeter/hooks/useRunProgressCopy.tsx
+++ b/app/src/organisms/Desktop/RunProgressMeter/hooks/useRunProgressCopy.tsx
@@ -108,8 +108,7 @@ export function useRunProgressCopy({
     if (isTerminalRunStatus(runStatus) || runStatus === RUN_STATUS_IDLE) {
       return null
     }
-
-    if (isTerminalRunStatus(runStatus) && currentStepNumber == null) {
+    if (currentStepNumber == null) {
       return `${t(`current_step`)}: ${t('na')}`
     } else if (hasRunDiverged) {
       return `${t(`current_step`)} ${t('na')}:`

--- a/app/src/organisms/Desktop/RunProgressMeter/index.tsx
+++ b/app/src/organisms/Desktop/RunProgressMeter/index.tsx
@@ -2,9 +2,7 @@ import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
 import { css } from 'styled-components'
 
-import {
-  RUN_STATUS_BLOCKED_BY_OPEN_DOOR
-} from '@opentrons/api-client'
+import { RUN_STATUS_BLOCKED_BY_OPEN_DOOR } from '@opentrons/api-client'
 import {
   ALIGN_CENTER,
   BORDERS,

--- a/app/src/organisms/Desktop/RunProgressMeter/index.tsx
+++ b/app/src/organisms/Desktop/RunProgressMeter/index.tsx
@@ -4,28 +4,21 @@ import { css } from 'styled-components'
 
 import {
   RUN_STATUS_BLOCKED_BY_OPEN_DOOR,
-  RUN_STATUS_FINISHING,
-  RUN_STATUS_IDLE,
-  RUN_STATUS_RUNNING,
+  RUN_STATUS_FAILED,
+  RUN_STATUS_SUCCEEDED,
 } from '@opentrons/api-client'
 import {
   ALIGN_CENTER,
   BORDERS,
   COLORS,
-  CURSOR_DEFAULT,
-  CURSOR_POINTER,
   DIRECTION_COLUMN,
   Flex,
   Icon,
   JUSTIFY_SPACE_BETWEEN,
-  LegacyStyledText,
-  Link,
+  SecondaryButton,
   SIZE_1,
   SPACING,
-  Tooltip,
-  TOOLTIP_LEFT,
-  TYPOGRAPHY,
-  useHoverTooltip,
+  StyledText,
 } from '@opentrons/components'
 import { useCommandQuery } from '@opentrons/react-api-client'
 
@@ -62,9 +55,6 @@ export function RunProgressMeter(props: RunProgressMeterProps): JSX.Element {
   const robotType = useRobotType(robotName)
   const runStatus = useRunStatus(runId)
   const { play } = useRunControls(runId)
-  const [targetProps, tooltipProps] = useHoverTooltip({
-    placement: TOOLTIP_LEFT,
-  })
   const { data: runRecord } = useNotifyRunQuery(runId)
   const runData = runRecord?.data ?? null
 
@@ -84,15 +74,12 @@ export function RunProgressMeter(props: RunProgressMeterProps): JSX.Element {
   const { currentStepNumber, totalStepCount, hasRunDiverged } =
     useRunningStepCounts(runId, mostRecentCommandData)
 
-  const downloadIsDisabled =
-    runStatus === RUN_STATUS_RUNNING ||
-    runStatus === RUN_STATUS_IDLE ||
-    runStatus === RUN_STATUS_FINISHING
+  const downloadEnabled =
+    runStatus === RUN_STATUS_SUCCEEDED || runStatus === RUN_STATUS_FAILED
 
   const { downloadRunLog } = useDownloadRunLog(robotName, runId)
 
-  const onDownloadClick: MouseEventHandler<HTMLAnchorElement> = e => {
-    if (downloadIsDisabled) return false
+  const onDownloadClick: MouseEventHandler<HTMLButtonElement> = e => {
     e.preventDefault()
     e.stopPropagation()
     downloadRunLog()
@@ -120,6 +107,7 @@ export function RunProgressMeter(props: RunProgressMeterProps): JSX.Element {
       hasRunDiverged,
     })
 
+  console.log('🚀 ~ RunProgressMeter ~ downloadEnabled:', downloadEnabled)
   return (
     <>
       {showIntervention
@@ -131,41 +119,23 @@ export function RunProgressMeter(props: RunProgressMeterProps): JSX.Element {
       <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing4}>
         <Flex justifyContent={JUSTIFY_SPACE_BETWEEN}>
           <Flex gridGap={SPACING.spacing8}>
-            <LegacyStyledText
-              as="h2"
-              fontWeight={TYPOGRAPHY.fontWeightSemiBold}
+            <StyledText
+              color={COLORS.black90}
+              desktopStyle={'bodyDefaultSemiBold'}
             >
               {stepCountStr}
-            </LegacyStyledText>
-
+            </StyledText>
             {currentStepContents}
           </Flex>
-          <Link
-            {...targetProps}
-            role="button"
-            css={css`
-              ${TYPOGRAPHY.darkLinkH4SemiBold}
-              &:hover {
-                color: ${downloadIsDisabled ? COLORS.grey40 : COLORS.black90};
-              }
-              cursor: ${downloadIsDisabled ? CURSOR_DEFAULT : CURSOR_POINTER};
-            `}
-            textTransform={TYPOGRAPHY.textTransformCapitalize}
-            onClick={onDownloadClick}
-          >
-            <Flex
-              gridGap={SPACING.spacing2}
-              alignItems={ALIGN_CENTER}
-              color={COLORS.grey60}
-            >
-              <Icon name="download" size={SIZE_1} />
-              {t('download_run_log')}
+          {downloadEnabled ? (
+            <Flex gridGap={SPACING.spacing2} alignItems={ALIGN_CENTER}>
+              <SecondaryButton border-width={1} onClick={onDownloadClick}>
+                <Flex gridGap={SPACING.spacing2} alignItems={ALIGN_CENTER}>
+                  <Icon name="download" size={SIZE_1} />
+                  {t('download_run_log')}
+                </Flex>
+              </SecondaryButton>
             </Flex>
-          </Link>
-          {downloadIsDisabled ? (
-            <Tooltip tooltipProps={tooltipProps}>
-              {t('complete_protocol_to_download')}
-            </Tooltip>
           ) : null}
         </Flex>
         {!hasRunDiverged ? (

--- a/app/src/organisms/Desktop/RunProgressMeter/index.tsx
+++ b/app/src/organisms/Desktop/RunProgressMeter/index.tsx
@@ -3,9 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { css } from 'styled-components'
 
 import {
-  RUN_STATUS_BLOCKED_BY_OPEN_DOOR,
-  RUN_STATUS_FAILED,
-  RUN_STATUS_SUCCEEDED,
+  RUN_STATUS_BLOCKED_BY_OPEN_DOOR
 } from '@opentrons/api-client'
 import {
   ALIGN_CENTER,
@@ -39,6 +37,7 @@ import {
 } from '/app/resources/runs'
 
 import { useDownloadRunLog } from '../Devices/hooks'
+import { isTerminalRunStatus } from '../Devices/ProtocolRun/ProtocolRunHeader/utils'
 import { useRunProgressCopy } from './hooks'
 import { InterventionTicks } from './InterventionTicks'
 
@@ -74,8 +73,7 @@ export function RunProgressMeter(props: RunProgressMeterProps): JSX.Element {
   const { currentStepNumber, totalStepCount, hasRunDiverged } =
     useRunningStepCounts(runId, mostRecentCommandData)
 
-  const downloadEnabled =
-    runStatus === RUN_STATUS_SUCCEEDED || runStatus === RUN_STATUS_FAILED
+  const downloadEnabled = isTerminalRunStatus(runStatus)
 
   const { downloadRunLog } = useDownloadRunLog(robotName, runId)
 

--- a/app/src/organisms/Desktop/RunProgressMeter/index.tsx
+++ b/app/src/organisms/Desktop/RunProgressMeter/index.tsx
@@ -107,7 +107,6 @@ export function RunProgressMeter(props: RunProgressMeterProps): JSX.Element {
       hasRunDiverged,
     })
 
-  console.log('🚀 ~ RunProgressMeter ~ downloadEnabled:', downloadEnabled)
   return (
     <>
       {showIntervention


### PR DESCRIPTION
# Overview

Displays run progress steps only when run is active and shows download run log button upon completion.


## Test Plan and Hands on Testing

Smoke tested
<img width="1008" height="336" alt="Screenshot 2025-11-10 at 10 12 34 AM" src="https://github.com/user-attachments/assets/095dd596-98b7-486e-b767-fd23f6e607ef" />
<img width="897" height="239" alt="Screenshot 2025-11-10 at 10 13 37 AM" src="https://github.com/user-attachments/assets/3ab8346e-0f52-4732-a0b0-1db92bb019c4" />
<img width="898" height="200" alt="Screenshot 2025-11-10 at 10 13 52 AM" src="https://github.com/user-attachments/assets/f87fff94-c563-48dc-9433-afcb6a1a9c0a" />



## Changelog

List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.


## Risk assessment

low

Closes EXEC-2043