### PR TITLE
feat(app): update min-width and max-width of the right col in protocol visualization page

### DIFF
--- a/app/src/pages/Desktop/Protocols/ProtocolVisualization/VisualizerContainer.tsx
+++ b/app/src/pages/Desktop/Protocols/ProtocolVisualization/VisualizerContainer.tsx
@@ -49,7 +49,6 @@ export function VisualizerContainer(
   const [milliSecondsPerFrame, setMilliSecondsPerFrame] = useState<number>(
     INITIAL_MILLISECONDS_PER_FRAME
   )
-
   const [selectedCommandId, setSelectedCommand] = useState<string | null>(
     commands[0]?.id ?? null
   )

--- a/app/src/pages/Desktop/Protocols/ProtocolVisualization/VisualizerContainer.tsx
+++ b/app/src/pages/Desktop/Protocols/ProtocolVisualization/VisualizerContainer.tsx
@@ -49,6 +49,7 @@ export function VisualizerContainer(
   const [milliSecondsPerFrame, setMilliSecondsPerFrame] = useState<number>(
     INITIAL_MILLISECONDS_PER_FRAME
   )
+
   const [selectedCommandId, setSelectedCommand] = useState<string | null>(
     commands[0]?.id ?? null
   )

--- a/app/src/pages/Desktop/Protocols/ProtocolVisualization/__tests__/VisualizerContainer.test.tsx
+++ b/app/src/pages/Desktop/Protocols/ProtocolVisualization/__tests__/VisualizerContainer.test.tsx
@@ -1,0 +1,98 @@
+import { screen } from '@testing-library/react'
+import { beforeEach, describe, it, vi } from 'vitest'
+
+import { renderWithProviders } from '/app/__testing-utils__'
+import { Controls } from '/app/organisms/Desktop/ProtocolVisualization/Controls'
+import { StepDetailContainer } from '/app/organisms/Desktop/ProtocolVisualization/StepDetailContainer'
+
+import { CommandSteps } from '../CommandSteps'
+import { DeckView } from '../DeckView'
+import { VisualizerContainer } from '../VisualizerContainer'
+
+import type { ComponentProps } from 'react'
+
+vi.mock('/app/organisms/Desktop/ProtocolVisualization/Controls')
+vi.mock('/app/organisms/Desktop/ProtocolVisualization/StepDetailContainer')
+vi.mock('../CommandSteps')
+vi.mock('../DeckView')
+
+const render = (props: ComponentProps<typeof VisualizerContainer>) => {
+  return renderWithProviders(<VisualizerContainer {...props} />)[0]
+}
+
+const mockProtocolKey = 'mockProtocolKey'
+const mockSrcFileNames = ['mockFile.py']
+
+const mockAnalysis = {
+  createdAt: '2025-10-21T21:19:44.432392Z',
+  files: [
+    {
+      name: 'mockFile.py',
+      role: 'main',
+    },
+    {
+      name: '12x125ml_update.json',
+      role: 'labware',
+    },
+  ],
+  config: {
+    protocolType: 'python',
+    apiVersion: [2, 26],
+  },
+  metadata: {
+    protocolName: 'mock protocol',
+    author: 'test',
+    description: 'mock protocol',
+    created: '2025-10-16T22:43:10.289Z',
+    lastModified: '2025-10-16T23:07:43.336Z',
+    protocolDesigner:
+      'protocol-designer@chore_release-pd-8.6.0-20251016-222252',
+    source: 'Protocol Designer',
+  },
+  result: 'ok',
+  robotType: 'OT-3 Standard',
+  runTimeParameters: [],
+  commands: [
+    {
+      id: '3bf9268c-c37c-4d62-a248-a1688816ba1f',
+      createdAt: '2025-10-21T21:19:44.407651Z',
+      commandType: 'home',
+      key: '50c7ae73a4e3f7129874f39dfb514803',
+      status: 'succeeded',
+      params: {},
+      result: {},
+      startedAt: '2025-10-21T21:19:44.408338Z',
+      completedAt: '2025-10-21T21:19:44.408410Z',
+      notes: [],
+    },
+  ],
+  errors: [],
+  commandAnnotations: [],
+} as any
+
+describe('VisualizerContainer', () => {
+  let props: ComponentProps<typeof VisualizerContainer>
+
+  beforeEach(() => {
+    props = {
+      analysis: mockAnalysis,
+      groupedCommands: [],
+      protocolKey: mockProtocolKey,
+      srcFileNames: mockSrcFileNames,
+    }
+    vi.mocked(Controls).mockReturnValue(<div>mock Controls</div>)
+    vi.mocked(StepDetailContainer).mockReturnValue(
+      <div>mock StepDetailContainer</div>
+    )
+    vi.mocked(CommandSteps).mockReturnValue(<div>mock CommandSteps</div>)
+    vi.mocked(DeckView).mockReturnValue(<div>mock DeckView</div>)
+  })
+
+  it('should render mock components', () => {
+    render(props)
+    screen.getByText('mock Controls')
+    screen.getByText('mock StepDetailContainer')
+    screen.getByText('mock CommandSteps')
+    screen.getByText('mock DeckView')
+  })
+})

--- a/app/src/pages/Desktop/Protocols/ProtocolVisualization/visualizercontainer.module.css
+++ b/app/src/pages/Desktop/Protocols/ProtocolVisualization/visualizercontainer.module.css
@@ -18,7 +18,7 @@
 
 .center_column {
   display: flex;
-  min-width: 200px;
+  min-width: 9.25rem; /* 148px */
   flex: 1;
   flex-direction: column;
   overflow-y: auto;
@@ -27,7 +27,7 @@
 .right_column {
   position: relative;
   display: flex;
-  min-width: 9.25rem; /* 148px */
+  min-width: 10.75rem; /* 172px */
   max-width: 37.5rem; /* 600px */
   flex-direction: column;
   flex-shrink: 0;

--- a/app/src/pages/Desktop/Protocols/ProtocolVisualization/visualizercontainer.module.css
+++ b/app/src/pages/Desktop/Protocols/ProtocolVisualization/visualizercontainer.module.css
@@ -27,7 +27,8 @@
 .right_column {
   position: relative;
   display: flex;
-  min-width: 200px;
+  min-width: 9.25rem; /* 148px */
+  max-width: 37.5rem; /* 600px */
   flex-direction: column;
   flex-shrink: 0;
   overflow-y: auto;


### PR DESCRIPTION

# Overview
update min-width and max-width and add the basic test for VisualizerContainer component.
as i metioned in the ticket, the switching padding should be implemeted in each item in StepDetailContainer.


<img width="313" height="765" alt="Screenshot 2025-11-12 at 2 31 17 PM" src="https://github.com/user-attachments/assets/0b8dc9dd-7898-4d05-b60e-27e7caf89646" />

close AUTH-2480

```
the left col min 148px & max 600px 
the center col min 148px & max none
the right col min 172px & max 600px
```

## Test Plan and Hands on Testing
- click a protocol and go to the details page
- click `Visualization` button and go to the visualization page
- drag and drop the left edge of the right column
check the min is 148px and max is 600px

Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.

## Changelog
- update VisualizerContainer CSS
- add the basic test for VisualizerContainer

## Review requests


## Risk assessment
low