### PR TITLE
fix(app): conditionally render the livestream toggle by robot type

### DIFF
--- a/app/src/local-resources/images/hooks/useCameraUsageSettings.ts
+++ b/app/src/local-resources/images/hooks/useCameraUsageSettings.ts
@@ -15,7 +15,7 @@ export interface UseCameraUsageSettingsResult {
   toggleRecoveryCaptureEnabled: () => void
 }
 
-// general camera usage settings. inteded for out of run setup use only.
+// general camera usage settings. intended for out of run setup use only.
 export function useCameraUsageSettings(): UseCameraUsageSettingsResult {
   const { data: cameraData } = useCamera({
     refetchInterval: CAMERA_POLLING_INTERVAL_MS,

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/SetupCamera/SetupRunCameraSettings.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/SetupCamera/SetupRunCameraSettings.tsx
@@ -1,12 +1,15 @@
 import { useTranslation } from 'react-i18next'
 
 import { StyledText } from '@opentrons/components'
+import { OT2_ROBOT_TYPE } from '@opentrons/shared-data'
 
 import { ToggleButton } from '/app/atoms/buttons'
+import { useRobotType } from '/app/redux-resources/robots'
 
 import styles from './setupcamera.module.css'
 
 export interface SetupCameraProps {
+  robotName: string
   liveStreamEnabled: boolean
   recoveryEnabled: boolean
   cameraConfirmed: boolean
@@ -15,6 +18,7 @@ export interface SetupCameraProps {
 }
 
 export function SetupRunCameraUsage({
+  robotName,
   liveStreamEnabled,
   recoveryEnabled,
   cameraConfirmed,
@@ -22,6 +26,7 @@ export function SetupRunCameraUsage({
   toggleLiveStreamEnabled,
 }: SetupCameraProps): JSX.Element {
   const { t } = useTranslation('device_settings')
+  const robotType = useRobotType(robotName)
 
   return (
     <div className={styles.usage_settings_container}>
@@ -29,14 +34,16 @@ export function SetupRunCameraUsage({
         {t('usage_settings')}
       </StyledText>
       <div className={styles.usage_settings_card_container}>
-        <SettingCard
-          title={t('live_video')}
-          subtext={t('view_realtime_video')}
-          toggleLabelText={t('live_video')}
-          enabled={liveStreamEnabled}
-          onToggle={toggleLiveStreamEnabled}
-          isToggleDisabled={cameraConfirmed}
-        />
+        {robotType !== OT2_ROBOT_TYPE && (
+          <SettingCard
+            title={t('live_video')}
+            subtext={t('view_realtime_video')}
+            toggleLabelText={t('live_video')}
+            enabled={liveStreamEnabled}
+            onToggle={toggleLiveStreamEnabled}
+            isToggleDisabled={cameraConfirmed}
+          />
+        )}
         <SettingCard
           title={t('error_recovery')}
           subtext={t('automatically_capture_image')}

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/SetupCamera/__tests__/SetupRunCameraSettings.test.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/SetupCamera/__tests__/SetupRunCameraSettings.test.tsx
@@ -2,12 +2,17 @@ import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { FLEX_ROBOT_TYPE, OT2_ROBOT_TYPE } from '@opentrons/shared-data'
+
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
+import { useRobotType } from '/app/redux-resources/robots'
 
 import { SetupRunCameraUsage } from '../SetupRunCameraSettings'
 
 import type { SetupCameraProps } from '../SetupRunCameraSettings'
+
+vi.mock('/app/redux-resources/robots')
 
 const render = (props: SetupCameraProps) => {
   return renderWithProviders(<SetupRunCameraUsage {...props} />, {
@@ -25,7 +30,9 @@ describe('SetupRunCameraUsage', () => {
       cameraConfirmed: false,
       toggleLiveStreamEnabled: vi.fn(),
       toggleRecoveryEnabled: vi.fn(),
+      robotName: 'MOCK-NAME',
     }
+    vi.mocked(useRobotType).mockReturnValue(FLEX_ROBOT_TYPE)
   })
 
   it('renders usage settings header', () => {
@@ -41,6 +48,18 @@ describe('SetupRunCameraUsage', () => {
     screen.getByText(
       'View real-time video of the deck while a running a protocol.'
     )
+  })
+
+  it('does not render live video card if the robot is an OT-2', () => {
+    vi.mocked(useRobotType).mockReturnValue(OT2_ROBOT_TYPE)
+    render(mockProps)
+
+    expect(screen.queryByText('Live Video')).not.toBeInTheDocument()
+    expect(
+      screen.queryByText(
+        'View real-time video of the deck while a running a protocol.'
+      )
+    ).not.toBeInTheDocument()
   })
 
   it('renders error recovery setting card', () => {

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/SetupCamera/index.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/SetupCamera/index.tsx
@@ -92,6 +92,7 @@ export function SetupCamera({
       {cameraEnabled && (
         <>
           <SetupRunCameraUsage
+            robotName={robotName}
             liveStreamEnabled={liveStreamEnabled}
             recoveryEnabled={recoveryEnabled}
             toggleRecoveryEnabled={toggleRecoveryEnabled}

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsCamera/RobotSettingsCameraUsage.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsCamera/RobotSettingsCameraUsage.tsx
@@ -1,13 +1,16 @@
 import { useTranslation } from 'react-i18next'
 
 import { Divider, StyledText } from '@opentrons/components'
+import { OT2_ROBOT_TYPE } from '@opentrons/shared-data'
 
 import { ToggleButton } from '/app/atoms/buttons'
 import styles from '/app/organisms/Desktop/Devices/RobotSettings/RobotSettingsCamera/camerasettings.module.css'
 
 import type { JSX } from 'react'
+import type { RobotType } from '@opentrons/shared-data'
 
 export interface CameraUsageSettingsProps {
+  robotType: RobotType
   toggleLiveVideoEnabled: () => void
   isLiveVideoEnabled: boolean
   toggleRecoveryCaptureEnabled: () => void
@@ -21,6 +24,7 @@ export function RobotSettingsCameraUsage({
   isRecoveryCaptureEnabled,
   isLiveVideoEnabled,
   toggleDisabled,
+  robotType,
 }: CameraUsageSettingsProps): JSX.Element {
   const { t } = useTranslation('device_settings')
 
@@ -29,23 +33,27 @@ export function RobotSettingsCameraUsage({
       <StyledText desktopStyle="bodyLargeSemiBold">
         {t('usage_settings')}
       </StyledText>
-      <div className={styles.usage_item_container}>
-        <div className={styles.usage_item_text_container}>
-          <StyledText desktopStyle="bodyDefaultSemiBold">
-            {t('live_video')}
-          </StyledText>
-          <StyledText desktopStyle="bodyDefaultRegular">
-            {t('view_realtime_video')}
-          </StyledText>
-        </div>
-        <ToggleButton
-          label={t('live_video')}
-          toggledOn={isLiveVideoEnabled}
-          onClick={toggleLiveVideoEnabled}
-          disabled={toggleDisabled}
-        />
-      </div>
-      <Divider />
+      {robotType !== OT2_ROBOT_TYPE && (
+        <>
+          <div className={styles.usage_item_container}>
+            <div className={styles.usage_item_text_container}>
+              <StyledText desktopStyle="bodyDefaultSemiBold">
+                {t('live_video')}
+              </StyledText>
+              <StyledText desktopStyle="bodyDefaultRegular">
+                {t('view_realtime_video')}
+              </StyledText>
+            </div>
+            <ToggleButton
+              label={t('live_video')}
+              toggledOn={isLiveVideoEnabled}
+              onClick={toggleLiveVideoEnabled}
+              disabled={toggleDisabled}
+            />
+          </div>
+          <Divider />
+        </>
+      )}
       <div className={styles.usage_item_container}>
         <div className={styles.usage_item_text_container}>
           <StyledText desktopStyle="bodyDefaultSemiBold">

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsCamera/__tests__/RobotSettingsCameraUsage.test.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsCamera/__tests__/RobotSettingsCameraUsage.test.tsx
@@ -2,6 +2,8 @@ import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { FLEX_ROBOT_TYPE, OT2_ROBOT_TYPE } from '@opentrons/shared-data'
+
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
 
@@ -25,6 +27,7 @@ describe('RobotSettingsCameraUsage', () => {
       toggleRecoveryCaptureEnabled: vi.fn(),
       isRecoveryCaptureEnabled: false,
       toggleDisabled: false,
+      robotType: FLEX_ROBOT_TYPE,
     }
   })
 
@@ -50,6 +53,17 @@ describe('RobotSettingsCameraUsage', () => {
     screen.getByText(
       'Automatically capture an image of the deck in the event of an error.'
     )
+  })
+
+  it('does not render live video section  if the robot is an OT-2', () => {
+    render({ ...mockProps, robotType: OT2_ROBOT_TYPE })
+
+    expect(screen.queryByText('Live Video')).not.toBeInTheDocument()
+    expect(
+      screen.queryByText(
+        'View real-time video of the deck while a running a protocol.'
+      )
+    ).not.toBeInTheDocument()
   })
 
   it('calls toggleLiveVideoEnabled when live video toggle is clicked', async () => {

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsCamera/index.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsCamera/index.tsx
@@ -68,6 +68,7 @@ export function RobotSettingsCamera({
             toggleLiveVideoEnabled={handleToggleLiveStream}
             toggleRecoveryCaptureEnabled={handleToggleRecovery}
             toggleDisabled={isRobotBusy}
+            robotType={robotType}
           />
           {isCameraSettingsEnabled && (
             <>


### PR DESCRIPTION
Closes [RQA-4849](https://opentrons.atlassian.net/browse/RQA-4849)

# Overview

If the robot is an OT-2, we shouldn't show the livestream toggle, because, ya know, the OT-2 doesn't support livestreaming.

<img width="1022" height="768" alt="Screenshot 2025-11-12 at 4 42 31 PM" src="https://github.com/user-attachments/assets/b794da0e-2e05-4098-96fd-a55016cc4120" />

<img width="1024" height="770" alt="Screenshot 2025-11-12 at 4 41 48 PM" src="https://github.com/user-attachments/assets/7073b48d-980a-4dc4-a7eb-063836c56fff" />


## Test Plan and Hands on Testing

- See images.
- Sufficiently covered by unit testing.

## Changelog

- Fixed the live stream toggle displaying when the robot is an OT-2.

## Risk assessment

very low

[RQA-4849]: https://opentrons.atlassian.net/browse/RQA-4849?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ