### PR TITLE
fix(api): Ensure PAPI provided params are within limits

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/capture_image.py
+++ b/api/src/opentrons/protocol_engine/commands/capture_image.py
@@ -19,6 +19,7 @@ from ..types import PreconditionTypes
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
 from ..errors import (
     CameraDisabledError,
+    CameraSettingsInvalidError,
     FileNameInvalidError,
 )
 from ..errors.error_occurrence import ErrorOccurrence
@@ -191,6 +192,26 @@ class CaptureImageImpl(
         ):
             raise FileNameInvalidError(
                 message=f"Capture image filename cannot contain character(s): {SPECIAL_CHARACTERS.intersection(set(params.fileName))}"
+            )
+
+        # Validate the image filter parameters
+        if params.brightness is not None and (
+            params.brightness < 0 or params.brightness > 100
+        ):
+            raise CameraSettingsInvalidError(
+                message="Capture image brightness must be a percentage from 0% to 100%."
+            )
+        if params.contrast is not None and (
+            params.contrast < 0 or params.contrast > 100
+        ):
+            raise CameraSettingsInvalidError(
+                message="Capture image contrast must be a percentage from 0% to 100%."
+            )
+        if params.saturation is not None and (
+            params.saturation < 0 or params.saturation > 100
+        ):
+            raise CameraSettingsInvalidError(
+                message="Capture image saturation must be a percentage from 0% to 100%."
             )
 
         # Handle capturing an image with the CameraProvider - Engine camera settings take priority

--- a/api/src/opentrons/system/camera.py
+++ b/api/src/opentrons/system/camera.py
@@ -37,6 +37,8 @@ STREAM_CONF_FILE_KEYS = [
 ]
 
 # Camera Parameter Globals
+RESOLUTION_MIN = (320, 240)
+RESOLUTION_MAX = (7680, 4320)
 RESOLUTION_DEFAULT = (1920, 1080)
 ZOOM_MIN = 1.0
 ZOOM_MAX = 2.0
@@ -277,7 +279,7 @@ def write_stream_configuration_file_data(data: Dict[str, str]) -> None:
         fd.writelines(file_lines)
 
 
-async def image_capture(
+async def image_capture(  # noqa: C901
     robot_type: RobotType, parameters: ImageParameters
 ) -> bytes | CameraError:
     """Process an Image Capture request with a Camera utilizing a given set of parameters."""
@@ -305,8 +307,16 @@ async def image_capture(
         parameters.saturation < SATURATION_MIN or parameters.saturation > SATURATION_MAX
     ):
         potential_invalid_param = "Saturation"
+    elif parameters.resolution is not None and (
+        parameters.resolution[0] < RESOLUTION_MIN[0]
+        or parameters.resolution[1] < RESOLUTION_MIN[1]
+        or parameters.resolution[0] > RESOLUTION_MAX[0]
+        or parameters.resolution[1] > RESOLUTION_MAX[1]
+    ):
+        potential_invalid_param = "Resolution"
     else:
         potential_invalid_param = None
+
     if potential_invalid_param is not None:
         return CameraError(
             message=f"{potential_invalid_param} parameter is outside the boundaries allowed for image capture.",

--- a/api/tests/opentrons/protocol_engine/commands/test_capture_image.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_capture_image.py
@@ -240,8 +240,8 @@ async def test_ensure_camera_used_precondition_set(
             50,
         ],
         [
-            (1, 2),
-            (1, 2),
+            (320, 240),
+            (320, 240),
             1.5,
             1.5,
             (3, 4),
@@ -254,8 +254,8 @@ async def test_ensure_camera_used_precondition_set(
             75,
         ],
         [
-            (1, 2),
-            (1, 2),
+            (320, 240),
+            (320, 240),
             2.0,
             2.0,
             (3, 4),
@@ -268,8 +268,8 @@ async def test_ensure_camera_used_precondition_set(
             25,
         ],
         [
-            (9999999, 9999999),
-            (9999999, 9999999),
+            (7680, 4320),
+            (7680, 4320),
             1.0,
             1.0,
             (25, 45),
@@ -388,4 +388,57 @@ async def test_raises_filename_error(
     for char in SPECIAL_CHARACTERS:
         params = CaptureImageParams(fileName="badname" + char)
         with pytest.raises(FileNameInvalidError):
+            await subject.execute(params=params)
+
+
+@pytest.mark.parametrize(
+    argnames=[
+        "zoom",
+        "contrast",
+        "brightness",
+        "saturation",
+        "resolution",
+    ],
+    argvalues=[
+        [0.9, 1, 1, 1, (1920, 1080)],
+        [2.1, 1, 1, 1, (1920, 1080)],
+        [1, -1, 1, 1, (1920, 1080)],
+        [1, 101, 1, 1, (1920, 1080)],
+        [1, 1, -1, 1, (1920, 1080)],
+        [1, 1, 101, 1, (1920, 1080)],
+        [1, 1, 1, -1, (1920, 1080)],
+        [1, 1, 1, 101, (1920, 1080)],
+        [1, 1, 1, 1, (0, 0)],
+        [1, 1, 1, 1, (10000, 10000)],
+    ],
+)
+async def test_raises_image_parameter_error(
+    decoy: Decoy,
+    state_view: StateView,
+    file_provider: FileProvider,
+    camera_provider_image_capture: CameraProvider,
+    zoom: float,
+    contrast: float,
+    brightness: float,
+    saturation: float,
+    resolution: Tuple[int, int],
+) -> None:
+    """It should raise CameraSettingsInvalidError when the capture image command is provided bad filter params."""
+    subject = CaptureImageImpl(
+        state_view=state_view,
+        file_provider=file_provider,
+        camera_provider=camera_provider_image_capture,
+    )
+    params = CaptureImageParams(
+        resolution=resolution,
+        zoom=zoom,
+        contrast=contrast,
+        brightness=brightness,
+        saturation=saturation,
+    )
+
+    decoy.when(state_view.files.get_filecount()).then_return(0)
+
+    with mock.patch("os.path.exists", mock.Mock(return_value=True)):
+        with pytest.raises(CameraSettingsInvalidError):
             await subject.execute(params=params)


### PR DESCRIPTION
# Overview
Covers RQA-4848

Previously we didn't enforce that the user had to provide a valid percentage from 0% through 100% for certain image filters, this meant that if you provided something like -1 it would get converted into a valid LUT value for FFMPEG. This technically still ends up inside our bounds, just inverse of the intention. 

## Test Plan and Hands on Testing

- [x] Unit test coverage to ensure we're accepting good param values only

## Changelog
Added value validation for the image filter values, and maximum and minimums for our acceptable resolution at the system end logic.

## Review requests

## Risk assessment
Low