### PR TITLE
fix(app): fix conditional css for camera preferences

### DIFF
--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunSetup.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunSetup.tsx
@@ -428,7 +428,7 @@ export function ProtocolRunSetup({
         completeText: t('camera_enabled'),
         incompleteText: t('check_preferences'),
         incompleteElement: null,
-        disabledHardware: !cameraEnabled,
+        disabledHardware: !cameraEnabled && isCameraRequired,
         missingHardware: !!storageInfo?.isImageStorageLow,
         missingHardwareText: t('check_preferences'),
       },


### PR DESCRIPTION
Closes [RQA-4862](https://opentrons.atlassian.net/browse/RQA-4862)

# Overview

When the camera is disabled for a run, we are currently always displaying the "camera preferences" text as red regardless of whether the camera is required for the run or not. If the camera isn't required, the text shouldn't be red when the camera is disabled.

<img width="1008" height="769" alt="Screenshot 2025-11-13 at 12 52 10 PM" src="https://github.com/user-attachments/assets/31934933-6028-42e6-b1c7-361307b7ae17" />


## Test Plan and Hands on Testing

- See image. Verified that the "confirm preferences" text is red if a camera is required for a run, otherwise it is grey. 

## Changelog

- Fixed the "confirm preferences" text always display when the camera is disabled.

## Risk assessment

very low

[RQA-4862]: https://opentrons.atlassian.net/browse/RQA-4862?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ