### PR TITLE
fix(api): fix error propagation in dynamic pipetting. 

### DIFF
--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -52,6 +52,7 @@ from opentrons_shared_data.errors.exceptions import (
     InvalidActuator,
     FirmwareUpdateFailedError,
     PipetteLiquidNotFoundError,
+    PipetteOverpressureError,
 )
 
 from .util import use_or_initialize_loop, check_motion_bounds
@@ -3136,6 +3137,11 @@ class OT3API(
                     home_flagged_axes=False,
                     delay=delay,
                 )
+        except PipetteOverpressureError:
+            self._log.exception("Aspirate failed with overpressure")
+            # refresh positions during an over pressure here so we know where the gantry stopped.
+            await self.refresh_positions()
+            raise
         except Exception:
             self._log.exception("Aspirate failed")
             aspirate_spec.instr.set_current_volume(0)
@@ -3201,6 +3207,11 @@ class OT3API(
                     home_flagged_axes=False,
                     delay=delay,
                 )
+        except PipetteOverpressureError:
+            self._log.exception("Aspirate failed with overpressure")
+            # refresh positions during an over pressure here so we know where the gantry stopped.
+            await self.refresh_positions()
+            raise
         except Exception:
             self._log.exception("dispense failed")
             dispense_spec.instr.set_current_volume(0)

--- a/api/src/opentrons/protocol_engine/commands/aspirate_while_tracking.py
+++ b/api/src/opentrons/protocol_engine/commands/aspirate_while_tracking.py
@@ -147,6 +147,46 @@ class AspirateWhileTrackingImplementation(
             model_utils=self._model_utils,
             movement_delay=params.movement_delay,
         )
+        if isinstance(aspirate_result, DefinedErrorData):
+            if isinstance(aspirate_result.public, OverpressureError):
+                return DefinedErrorData(
+                    public=OverpressureError(
+                        id=aspirate_result.public.id,
+                        createdAt=aspirate_result.public.createdAt,
+                        wrappedErrors=aspirate_result.public.wrappedErrors,
+                        errorInfo=aspirate_result.public.errorInfo,
+                    ),
+                    state_update=aspirate_result.state_update.set_liquid_operated(
+                        labware_id=params.labwareId,
+                        well_names=self._state_view.geometry.get_wells_covered_by_pipette_with_active_well(
+                            params.labwareId,
+                            params.wellName,
+                            params.pipetteId,
+                        ),
+                        volume_added=CLEAR,
+                    ),
+                    state_update_if_false_positive=aspirate_result.state_update_if_false_positive,
+                )
+            elif isinstance(aspirate_result.public, StallOrCollisionError):
+                return DefinedErrorData(
+                    public=StallOrCollisionError(
+                        id=aspirate_result.public.id,
+                        createdAt=aspirate_result.public.createdAt,
+                        wrappedErrors=aspirate_result.public.wrappedErrors,
+                        errorInfo=aspirate_result.public.errorInfo,
+                    ),
+                    state_update=aspirate_result.state_update.set_liquid_operated(
+                        labware_id=params.labwareId,
+                        well_names=self._state_view.geometry.get_wells_covered_by_pipette_with_active_well(
+                            params.labwareId,
+                            params.wellName,
+                            params.pipetteId,
+                        ),
+                        volume_added=CLEAR,
+                    ),
+                    state_update_if_false_positive=aspirate_result.state_update_if_false_positive,
+                )
+
         position_after_aspirate = await self._gantry_mover.get_position(
             params.pipetteId
         )
@@ -155,21 +195,6 @@ class AspirateWhileTrackingImplementation(
             y=position_after_aspirate.y,
             z=position_after_aspirate.z,
         )
-        if isinstance(aspirate_result, DefinedErrorData):
-            return DefinedErrorData(
-                public=aspirate_result.public,
-                state_update=aspirate_result.state_update.set_liquid_operated(
-                    labware_id=params.labwareId,
-                    well_names=self._state_view.geometry.get_wells_covered_by_pipette_with_active_well(
-                        params.labwareId,
-                        params.wellName,
-                        params.pipetteId,
-                    ),
-                    volume_added=CLEAR,
-                ),
-                state_update_if_false_positive=aspirate_result.state_update_if_false_positive,
-            )
-
         return SuccessData(
             public=AspirateWhileTrackingResult(
                 volume=aspirate_result.public.volume,

--- a/api/src/opentrons/protocol_engine/commands/dispense_while_tracking.py
+++ b/api/src/opentrons/protocol_engine/commands/dispense_while_tracking.py
@@ -143,6 +143,47 @@ class DispenseWhileTrackingImplementation(
             model_utils=self._model_utils,
             movement_delay=params.movement_delay,
         )
+
+        if isinstance(dispense_result, DefinedErrorData):
+            if isinstance(dispense_result.public, OverpressureError):
+                return DefinedErrorData(
+                    public=OverpressureError(
+                        id=dispense_result.public.id,
+                        createdAt=dispense_result.public.createdAt,
+                        wrappedErrors=dispense_result.public.wrappedErrors,
+                        errorInfo=dispense_result.public.errorInfo,
+                    ),
+                    state_update=dispense_result.state_update.set_liquid_operated(
+                        labware_id=params.labwareId,
+                        well_names=self._state_view.geometry.get_wells_covered_by_pipette_with_active_well(
+                            params.labwareId,
+                            params.wellName,
+                            params.pipetteId,
+                        ),
+                        volume_added=CLEAR,
+                    ),
+                    state_update_if_false_positive=dispense_result.state_update_if_false_positive,
+                )
+            elif isinstance(dispense_result.public, StallOrCollisionError):
+                return DefinedErrorData(
+                    public=StallOrCollisionError(
+                        id=dispense_result.public.id,
+                        createdAt=dispense_result.public.createdAt,
+                        wrappedErrors=dispense_result.public.wrappedErrors,
+                        errorInfo=dispense_result.public.errorInfo,
+                    ),
+                    state_update=dispense_result.state_update.set_liquid_operated(
+                        labware_id=params.labwareId,
+                        well_names=self._state_view.geometry.get_wells_covered_by_pipette_with_active_well(
+                            params.labwareId,
+                            params.wellName,
+                            params.pipetteId,
+                        ),
+                        volume_added=CLEAR,
+                    ),
+                    state_update_if_false_positive=dispense_result.state_update_if_false_positive,
+                )
+
         position_after_dispense = await self._gantry_mover.get_position(
             params.pipetteId
         )
@@ -151,22 +192,6 @@ class DispenseWhileTrackingImplementation(
             y=position_after_dispense.y,
             z=position_after_dispense.z,
         )
-
-        if isinstance(dispense_result, DefinedErrorData):
-            return DefinedErrorData(
-                public=dispense_result.public,
-                state_update=dispense_result.state_update.set_liquid_operated(
-                    labware_id=params.labwareId,
-                    well_names=self._state_view.geometry.get_wells_covered_by_pipette_with_active_well(
-                        params.labwareId,
-                        params.wellName,
-                        params.pipetteId,
-                    ),
-                    volume_added=CLEAR,
-                ),
-                state_update_if_false_positive=dispense_result.state_update_if_false_positive,
-            )
-
         return SuccessData(
             public=DispenseWhileTrackingResult(
                 volume=dispense_result.public.volume,

--- a/api/src/opentrons/protocol_engine/commands/pipetting_common.py
+++ b/api/src/opentrons/protocol_engine/commands/pipetting_common.py
@@ -9,10 +9,15 @@ from pydantic import BaseModel, Field
 from opentrons_shared_data.errors import ErrorCodes
 from opentrons.protocol_engine.errors.error_occurrence import ErrorOccurrence
 from opentrons.protocol_engine.types import AspiratedFluid, FluidKind
-from opentrons_shared_data.errors.exceptions import PipetteOverpressureError
+from opentrons_shared_data.errors.exceptions import (
+    PipetteOverpressureError,
+    StallOrCollisionDetectedError,
+)
 from .command import DefinedErrorData, SuccessData
 from opentrons.protocol_engine.state.update_types import StateUpdate
 from opentrons.types import Point
+
+from .movement_common import StallOrCollisionError
 
 if TYPE_CHECKING:
     from ..execution.pipetting import PipettingHandler
@@ -247,7 +252,9 @@ async def aspirate_while_tracking(
     pipetting: PipettingHandler,
     model_utils: ModelUtils,
     movement_delay: Optional[float] = None,
-) -> SuccessData[BaseLiquidHandlingResult] | DefinedErrorData[OverpressureError]:
+) -> SuccessData[BaseLiquidHandlingResult] | DefinedErrorData[
+    OverpressureError
+] | DefinedErrorData[StallOrCollisionError]:
     """Execute an aspirate while tracking microoperation."""
     try:
         volume_aspirated = await pipetting.aspirate_while_tracking(
@@ -275,6 +282,21 @@ async def aspirate_while_tracking(
             ),
             state_update=StateUpdate().set_fluid_unknown(pipette_id=pipette_id),
         )
+    except StallOrCollisionDetectedError as e:
+        return DefinedErrorData(
+            public=StallOrCollisionError(
+                id=model_utils.generate_id(),
+                createdAt=model_utils.get_timestamp(),
+                wrappedErrors=[
+                    ErrorOccurrence.from_failed(
+                        id=model_utils.generate_id(),
+                        createdAt=model_utils.get_timestamp(),
+                        error=e,
+                    )
+                ],
+            ),
+            state_update=StateUpdate().clear_all_pipette_locations(),
+        )
     else:
         return SuccessData(
             public=BaseLiquidHandlingResult(
@@ -299,7 +321,9 @@ async def dispense_while_tracking(
     pipetting: PipettingHandler,
     model_utils: ModelUtils,
     movement_delay: Optional[float] = None,
-) -> SuccessData[BaseLiquidHandlingResult] | DefinedErrorData[OverpressureError]:
+) -> SuccessData[BaseLiquidHandlingResult] | DefinedErrorData[
+    OverpressureError
+] | DefinedErrorData[StallOrCollisionError]:
     """Execute an dispense while tracking microoperation."""
     # The current volume won't be none since it passed validation
     current_volume = (
@@ -337,6 +361,21 @@ async def dispense_while_tracking(
             .set_pipette_ready_to_aspirate(
                 pipette_id=pipette_id, ready_to_aspirate=False
             ),
+        )
+    except StallOrCollisionDetectedError as e:
+        return DefinedErrorData(
+            public=StallOrCollisionError(
+                id=model_utils.generate_id(),
+                createdAt=model_utils.get_timestamp(),
+                wrappedErrors=[
+                    ErrorOccurrence.from_failed(
+                        id=model_utils.generate_id(),
+                        createdAt=model_utils.get_timestamp(),
+                        error=e,
+                    )
+                ],
+            ),
+            state_update=StateUpdate().clear_all_pipette_locations(),
         )
     else:
         return SuccessData(


### PR DESCRIPTION
# Overview
Previously:
When overpressures happened, they were not updating the machine position and would then fail to recover.
Stalls were not caught at all and would create a Motion Failed error.

Now
Updates automatically require machine position when an overpressure occurs during a dynamic pipetting action.
Overpressures and Stalls are properly caught and reported out of the protocol engine command.

Tested this on alpha 5 and both types of errors now correctly trigger error recovery.