### PR TITLE
chore(js): Fix TypeScript configuration for Vitest globals

### DIFF
--- a/app/src/__testing-utils__/matchers.ts
+++ b/app/src/__testing-utils__/matchers.ts
@@ -18,6 +18,3 @@ export const nestedTextMatcher =
 
     return nodeHasText && childrenDontHaveText
   }
-
-// need componentPropsMatcher
-// need partialComponentPropsMatcher

--- a/components/src/testing/utils/matchers.ts
+++ b/components/src/testing/utils/matchers.ts
@@ -1,15 +1,4 @@
-import { when } from 'vitest-when'
-
 import type { Matcher } from '@testing-library/react'
-
-// these are needed because under the hood react calls components with two arguments (props and some second argument nobody seems to know)
-// https://github.com/timkindberg/jest-when/issues/66
-// use partialComponentPropsMatcher to only verify the props you pass into partialComponentPropsMatcher
-export const partialComponentPropsMatcher = (argsToMatch: unknown): any =>
-  // @ts-expect-error(sa, 2021-08-03): when.allArgs not part of type definition yet for jest-when
-  when.allArgs((args, equals) =>
-    equals(args[0], expect.objectContaining(argsToMatch))
-  )
 
 // Match things like <p>Some <strong>nested</strong> text</p>
 // Use with either string match: getByText(nestedTextMatcher("Some nested text"))

--- a/opentrons-ai-client/src/__testing-utils__/matchers.ts
+++ b/opentrons-ai-client/src/__testing-utils__/matchers.ts
@@ -18,6 +18,3 @@ export const nestedTextMatcher =
 
     return nodeHasText && childrenDontHaveText
   }
-
-// need componentPropsMatcher
-// need partialComponentPropsMatcher

--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -12,6 +12,6 @@
     "noErrorTruncation": true,
     "skipLibCheck": true,
     "moduleResolution": "node",
-    "types": ["vite/client", "vitest/globals", "@testing-library/jest-dom"]
+    "types": ["vite/client", "@testing-library/jest-dom"]
   }
 }


### PR DESCRIPTION
## Overview

I keep forgetting to explicitly import Vitest's APIs like `describe()`, `it()`, `test()`, and `expect()`. TypeScript keeps forgetting to complain about it, leaving it to be an annoying test-time error.

The reason TypeScript hasn't been complaining is that we've had it misconfigured. We've had it configured as if those APIs are available as implicit globals, even though they're not.

## Test Plan and Hands on Testing

Just CI.

## Changelog

* Fix the TypeScript config so it correctly complains when we forget to explicitly import Vitest APIs. See: https://vitest.dev/config/globals.html#globals
* That turns up one test helper, `partialComponentPropsMatcher()`, that was forgetting to import `expect()`. Nothing was using that helper, so I just deleted it instead of fixing it.

## Review requests

* OK with deleting `partialComponentPropsMatcher()`?

## Risk assessment

No risk.