### PR TITLE
fix(hardware): avoid divide by zero errors.

### DIFF
--- a/hardware/opentrons_hardware/hardware_control/motion_planning/move_manager.py
+++ b/hardware/opentrons_hardware/hardware_control/motion_planning/move_manager.py
@@ -80,7 +80,7 @@ class MoveManager(Generic[AxisKey]):
         target_axes = move_info.unit_vector.keys()
         for axis in axes:
             if axis in target_axes:
-                if abs(move_info.unit_vector[axis].item()) > 0:
+                if not isclose(abs(move_info.unit_vector[axis].item()), 0):
                     move_target = MoveTarget.build(  # type: ignore[type-var]
                         position=target,
                         max_speed=float(

--- a/hardware/opentrons_hardware/hardware_control/motion_planning/move_manager.py
+++ b/hardware/opentrons_hardware/hardware_control/motion_planning/move_manager.py
@@ -80,12 +80,15 @@ class MoveManager(Generic[AxisKey]):
         target_axes = move_info.unit_vector.keys()
         for axis in axes:
             if axis in target_axes:
-                move_target = MoveTarget.build(  # type: ignore[type-var]
-                    position=target,
-                    max_speed=float(
-                        speed * abs(1 / move_info.unit_vector[axis].item())
-                    ),
-                )
+                if abs(move_info.unit_vector[axis].item()) > 0:
+                    move_target = MoveTarget.build(  # type: ignore[type-var]
+                        position=target,
+                        max_speed=float(
+                            speed * abs(1 / move_info.unit_vector[axis].item())
+                        ),
+                    )
+                else:
+                    log.error("arguments to move resulted in a malformed target.")
         return move_target
 
     def ensure_pipette_flow_rate_unchanged(

--- a/hardware/tests/opentrons_hardware/hardware_control/test_motion_plan.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_motion_plan.py
@@ -337,3 +337,10 @@ async def test_plunger_devectorize(
     uv = blend_log[0][0].unit_vector
 
     assert devectorized.max_speed == speed
+
+    # make sure not to fail if passed a bad target.
+    origin = {"X": 0, "Y": 0, "Z": 0, "A": 0}
+    target = {"X": 5, "Y": 5, "Z": 5, "A": 0}
+    speed = 10
+    devectorized = manager.devectorize_axes(origin, target, speed, ["A"])
+    assert devectorized.max_speed == speed


### PR DESCRIPTION
# Overview
Apparently there are some rare instances in drop tip that can result in a malformed target where the plunger axes gets included in the target but ends up with a 0 unit vector.

I believe this has to be a result of numpy calculating a very very tiny float, for this move and when it gets used as a python native float it turns into 0.0

Added a check and unit test.
