### PR TITLE
feat(protocol-designer): reset selected tips if user changes `changeTip` field

### DIFF
--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMix.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMix.ts
@@ -168,6 +168,19 @@ const updatePatchOnNozzlesChange = (
   return patch
 }
 
+const updatePatchOnChangeTipChange = (
+  patch: FormPatch,
+  rawForm: FormData
+): FormPatch => {
+  if (fieldHasChanged(rawForm, patch, 'changeTip')) {
+    return {
+      ...patch,
+      ...getDefaultFields('tips_selected'),
+    }
+  }
+  return patch
+}
+
 export function dependentFieldsUpdateMix(
   originalPatch: FormPatch,
   rawForm: FormData, // raw = NOT hydrated
@@ -199,5 +212,6 @@ export function dependentFieldsUpdateMix(
       ),
     chainPatch => updatePatchOnTiprackChange(chainPatch, rawForm),
     chainPatch => updatePatchOnNozzlesChange(chainPatch, rawForm),
+    chainPatch => updatePatchOnChangeTipChange(chainPatch, rawForm),
   ])
 }

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.ts
@@ -719,6 +719,19 @@ const updatePatchOnNozzlesChange = (
   return patch
 }
 
+const updatePatchOnChangeTipChange = (
+  patch: FormPatch,
+  rawForm: FormData
+): FormPatch => {
+  if (fieldHasChanged(rawForm, patch, 'changeTip')) {
+    return {
+      ...patch,
+      ...getDefaultFields('tips_selected'),
+    }
+  }
+  return patch
+}
+
 export function dependentFieldsUpdateMoveLiquid(
   originalPatch: FormPatch,
   rawForm: FormData, // raw = NOT hydrated
@@ -765,5 +778,6 @@ export function dependentFieldsUpdateMoveLiquid(
     chainPatch => updatePatchOnConditioningVolumeChange(chainPatch, rawForm),
     chainPatch => updatePatchOnPathChange(chainPatch, rawForm, pipetteEntities),
     chainPatch => updatePatchOnNozzlesChange(chainPatch, rawForm),
+    chainPatch => updatePatchOnChangeTipChange(chainPatch, rawForm),
   ])
 }

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/test/mix.test.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/test/mix.test.ts
@@ -166,3 +166,14 @@ describe('well selection should update', () => {
     })
   })
 })
+
+describe('change tip', () => {
+  it('should update the tips_selected field when the changeTip field is changed', () => {
+    const form = {
+      changeTip: 'always',
+      tips_selected: [['A1']],
+    }
+    const result = handleFormHelper({ changeTip: 'once' }, form)
+    expect(result.tips_selected).toEqual([])
+  })
+})

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/test/moveLiquid.test.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/test/moveLiquid.test.ts
@@ -693,3 +693,14 @@ describe('air gap > dispense volume', () => {
     })
   })
 })
+
+describe('change tip', () => {
+  it('should update the tips_selected field when the changeTip field is changed', () => {
+    const form = {
+      changeTip: 'always',
+      tips_selected: [['A1']],
+    }
+    const result = handleFormHelper({ changeTip: 'once' }, form)
+    expect(result.tips_selected).toEqual([])
+  })
+})


### PR DESCRIPTION
# Overview

Reset `tips_selected` field for move liquid and mix forms when `changeTip` field is updated, since the number of tip pickups required for the transfer/mix will likely change.

## Test Plan and Hands on Testing

- inspected moveLiquid/mix forms tip settings
- set a `changeTip` policy and selected manual tip tracking, tiprack, and tips
- changed `changeTip` policy, and verified that the previously selected tips were set to an empty array

## Changelog

- add patch updaters for moveLiquid and mix forms to reset `tips_selected` when `changeTip` is updated
- add unit tests

## Review requests

see test plan

## Risk assessment

low