### PR TITLE
fix(robot-server): fix migration error with data files table drop

### DIFF
--- a/robot-server/robot_server/persistence/_migrations/v12_to_v13.py
+++ b/robot-server/robot_server/persistence/_migrations/v12_to_v13.py
@@ -101,6 +101,9 @@ def _migrate_data_files_tables(
     old_data_files: List[sqlalchemy.engine.Row],
 ) -> None:
     """Migrate data_files table to new schema with separate input/output tables."""
+    # these tables are associated with the data_files table, so we need to drop them before we can create the new tables
+    schema_11.analysis_csv_rtp_table.drop(connection)
+    schema_11.run_csv_rtp_table.drop(connection)
     schema_11.data_files_table.drop(connection)
 
     schema_13.data_files_table.create(connection)


### PR DESCRIPTION
# Overview

closes https://opentrons.atlassian.net/browse/RQA-4866.
bug migration fix for data_files table. 
the `data_files` table has 2 other tables referencing it so we need to drop them before droping the `data_files` table.

## Test Plan and Hands on Testing

steps to repro in ticket

## Changelog

drop tables `analysis_csv_rtp_table`, `run_csv_rtp_table`

## Review requests

should we recreate these tables? are they still in use? 

## Risk assessment

low. bug fix. 
