### PR TITLE
feat(protocol-designer): handle singular/plural for `PipetteLabel` text

### DIFF
--- a/protocol-designer/src/assets/localization/en/tip_selection.json
+++ b/protocol-designer/src/assets/localization/en/tip_selection.json
@@ -24,7 +24,12 @@
   "select_tiprack": "Select a tip rack to pick up tips from",
   "select_tips": "Select tips",
   "select_tips_for_tracking": "Select tips for manual tip tracking",
-  "tip_accessible": { "deselect": "Deselect tip", "select": "Select tip" },
+  "tip_accessible": {
+    "deselect_multiple": "Deselect tips",
+    "deselect_one": "Deselect tip",
+    "select_multiple": "Select tips",
+    "select_one": "Select tip"
+  },
   "tip_inaccessible": {
     "collision": "Selection will cause a collision",
     "incomplete": "Selection will be incomplete",

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/PipetteShadows/PipetteShadow.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/PipetteShadows/PipetteShadow.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { COLORS } from '@opentrons/components'
-import { FLEX_ROBOT_TYPE, OT2_ROBOT_TYPE } from '@opentrons/shared-data'
+import { FLEX_ROBOT_TYPE, OT2_ROBOT_TYPE, SINGLE } from '@opentrons/shared-data'
 
 import styles from '../tipselectionwizard.module.css'
 import {
@@ -20,6 +20,7 @@ import { SingleChannelFlexShadow } from './SingleChannelShadow'
 import type { Channels } from '@opentrons/components'
 import type {
   CoordinateTuple,
+  NozzleConfigurationStyle,
   PipetteV2Specs,
   RobotType,
 } from '@opentrons/shared-data'
@@ -59,6 +60,7 @@ export function PipetteShadow(props: {
   primaryNozzle: string
   robotType: RobotType
   enclosingViewbox: string | null
+  nozzles: NozzleConfigurationStyle
 }): JSX.Element {
   const {
     pipetteSpec,
@@ -73,12 +75,15 @@ export function PipetteShadow(props: {
     primaryNozzle,
     robotType,
     enclosingViewbox,
+    nozzles,
   } = props
   const [slotX, slotY] = slotPosition
   const { t } = useTranslation('tip_selection')
   const labelRef = useRef<HTMLDivElement>(null)
   const [labelWidth, setLabelWidth] = useState(0)
   const [labelHeight, setLabelHeight] = useState(0)
+
+  const isSingleTipPickup = nozzles === SINGLE
 
   const labelText = (() => {
     if (!hasPickupsRemaining && !isHoveredWellSelected) {
@@ -87,10 +92,11 @@ export function PipetteShadow(props: {
     if (!isAccessible && inaccessibleReason != null) {
       return t(`tip_inaccessible.${inaccessibleReason}`)
     }
+    const pluralKey = isSingleTipPickup ? 'one' : 'multiple'
     if (isAccessible) {
       return isHoveredWellSelected
-        ? t('tip_accessible.deselect')
-        : t('tip_accessible.select')
+        ? t(`tip_accessible.deselect_${pluralKey}`)
+        : t(`tip_accessible.select_${pluralKey}`)
     }
     console.error('No label text found')
     return ''

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/SelectTips.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/SelectTips.tsx
@@ -327,6 +327,7 @@ export function SelectTips(
             inaccessibleReason={hoveredWellsInaccessibilityStatus}
             primaryNozzle={primaryNozzle}
             enclosingViewbox={viewBox}
+            nozzles={nozzles}
           />
         ) : null}
       </>


### PR DESCRIPTION
# Overview

Correctly render singular/plural "tip"/"tips" text in `PipetteLabel` depending on nozzle configuration.

## Test Plan and Hands on Testing

- create or import a protocol with an 8/96-channel pipette
- configure single nozzle
- continue to tip settings and select manual tip selection
- in tip selection modal, hover an accessible tip and verify that copy reads "Select tip" (SINGULAR)
- select and stay hovering, and verify that copy reads "Deselect tip" (SINGULAR)
- go back and configure 8/96 nozzles
- repeat above, verifying "Select tips" and "Deselect tips" (PLURAL)

## Changelog

- add logic to `PipetteShadow` to render singular or plural `PipetteLabel` text from nozzle configuration
- add translations accordingly

## Review requests

see test plan

## Risk assessment

low