### PR TITLE
fix(app): fix padding and text wrap in protocol details page

### DIFF
--- a/app/src/organisms/Desktop/ProtocolDetails/ProtocolDetailsHeader.tsx
+++ b/app/src/organisms/Desktop/ProtocolDetails/ProtocolDetailsHeader.tsx
@@ -100,9 +100,9 @@ export function ProtocolDetailsHeader({
   const creationMethod =
     mostRecentAnalysis != null
       ? (getCreationMethod(
-          mostRecentAnalysis.config,
-          mostRecentAnalysis.metadata
-        ) ?? t('shared:no_data'))
+        mostRecentAnalysis.config,
+        mostRecentAnalysis.metadata
+      ) ?? t('shared:no_data'))
       : t('shared:no_data')
 
   const author =
@@ -139,11 +139,11 @@ export function ProtocolDetailsHeader({
       <Flex
         flexDirection={DIRECTION_COLUMN}
         gridGap={SPACING.spacing16}
-        padding={`${SPACING.spacing16} 0 ${SPACING.spacing16} ${SPACING.spacing16}`}
+        padding={`${SPACING.spacing20} 0 ${SPACING.spacing16} ${SPACING.spacing16}`}
         width="100%"
       >
         {analysisStatus !== 'loading' &&
-        mostRecentAnalysis?.result === 'parameter-value-required' ? (
+          mostRecentAnalysis?.result === 'parameter-value-required' ? (
           <ProtocolStatusBanner />
         ) : null}
         {mostRecentAnalysis != null && analysisStatus === 'error' ? (
@@ -156,12 +156,12 @@ export function ProtocolDetailsHeader({
           <Flex flexDirection={DIRECTION_COLUMN} gap={SPACING.spacing16}>
             <Flex
               flexDirection={DIRECTION_ROW}
-              gap={SPACING.spacing4}
+              gap={SPACING.spacing24}
               justifyContent={JUSTIFY_SPACE_BETWEEN}
               alignItems={ALIGN_CENTER}
               paddingRight={SPACING.spacing24}
             >
-              <StyledText desktopStyle="headingSmallBold">
+              <StyledText desktopStyle="headingSmallBold" style={{ overflowWrap: 'anywhere' }}>
                 {protocolDisplayName}
               </StyledText>
               <Flex gridGap={SPACING.spacing8}>
@@ -223,7 +223,7 @@ export function ProtocolDetailsHeader({
                 type="default"
               />
               <Tag text={creationMethod} type="default" />
-              <Tag text={`Author:${author}`} type="default" />
+              <Tag text={`Author: ${author}`} type="default" />
             </Flex>
           </Flex>
         </Flex>

--- a/app/src/organisms/Desktop/ProtocolDetails/ProtocolDetailsHeader.tsx
+++ b/app/src/organisms/Desktop/ProtocolDetails/ProtocolDetailsHeader.tsx
@@ -139,7 +139,7 @@ export function ProtocolDetailsHeader({
       <Flex
         flexDirection={DIRECTION_COLUMN}
         gridGap={SPACING.spacing16}
-        padding={`${SPACING.spacing20} 0 ${SPACING.spacing16} ${SPACING.spacing16}`}
+        padding={`${SPACING.spacing16} 0 ${SPACING.spacing16} ${SPACING.spacing16}`}
         width="100%"
       >
         {analysisStatus !== 'loading' &&

--- a/app/src/organisms/Desktop/ProtocolDetails/ProtocolDetailsHeader.tsx
+++ b/app/src/organisms/Desktop/ProtocolDetails/ProtocolDetailsHeader.tsx
@@ -161,7 +161,7 @@ export function ProtocolDetailsHeader({
               alignItems={ALIGN_CENTER}
               paddingRight={SPACING.spacing24}
             >
-              <StyledText desktopStyle="headingSmallBold" style={{ overflowWrap: 'anywhere' }}>
+              <StyledText desktopStyle="headingSmallBold" style={{ whiteSpace: 'normal', overflowWrap: 'anywhere' }}>
                 {protocolDisplayName}
               </StyledText>
               <Flex gridGap={SPACING.spacing8}>

--- a/app/src/organisms/Desktop/ProtocolDetails/ProtocolDetailsHeader.tsx
+++ b/app/src/organisms/Desktop/ProtocolDetails/ProtocolDetailsHeader.tsx
@@ -100,9 +100,9 @@ export function ProtocolDetailsHeader({
   const creationMethod =
     mostRecentAnalysis != null
       ? (getCreationMethod(
-        mostRecentAnalysis.config,
-        mostRecentAnalysis.metadata
-      ) ?? t('shared:no_data'))
+          mostRecentAnalysis.config,
+          mostRecentAnalysis.metadata
+        ) ?? t('shared:no_data'))
       : t('shared:no_data')
 
   const author =
@@ -143,7 +143,7 @@ export function ProtocolDetailsHeader({
         width="100%"
       >
         {analysisStatus !== 'loading' &&
-          mostRecentAnalysis?.result === 'parameter-value-required' ? (
+        mostRecentAnalysis?.result === 'parameter-value-required' ? (
           <ProtocolStatusBanner />
         ) : null}
         {mostRecentAnalysis != null && analysisStatus === 'error' ? (
@@ -161,7 +161,10 @@ export function ProtocolDetailsHeader({
               alignItems={ALIGN_CENTER}
               paddingRight={SPACING.spacing24}
             >
-              <StyledText desktopStyle="headingSmallBold" style={{ whiteSpace: 'normal', overflowWrap: 'anywhere' }}>
+              <StyledText
+                desktopStyle="headingSmallBold"
+                style={{ whiteSpace: 'normal', overflowWrap: 'anywhere' }}
+              >
                 {protocolDisplayName}
               </StyledText>
               <Flex gridGap={SPACING.spacing8}>


### PR DESCRIPTION
# Overview
fix padding and text wrap in protocol details page

<img width="936" height="768" alt="Screenshot 2025-11-13 at 5 22 07 PM" src="https://github.com/user-attachments/assets/9cdfd8d6-dbea-4c54-bd0a-3c9bf4c2249a" />


close RQA-4900


## Test Plan and Hands on Testing
- go to protocol details page


## Changelog
- fix padding and text wrap


## Review requests

## Risk assessment
low

