### PR TITLE
fix(robot-server): Fix RTP migrations from database schema 11 to schema 13

### DIFF
--- a/robot-server/robot_server/persistence/_migrations/v12_to_v13.py
+++ b/robot-server/robot_server/persistence/_migrations/v12_to_v13.py
@@ -46,27 +46,27 @@ class Migration12to13(Migration):  # noqa: D101
 
             with engine.connect() as connection:
                 connection.execute(sqlalchemy.text("PRAGMA foreign_keys = OFF"))
+                try:
+                    with connection.begin():
+                        old_data_files = connection.execute(
+                            sqlalchemy.select(schema_11.data_files_table)
+                        ).fetchall()
 
-                with connection.begin():
-                    old_data_files = connection.execute(
-                        sqlalchemy.select(schema_11.data_files_table)
-                    ).fetchall()
+                        old_analysis_csv = connection.execute(
+                            sqlalchemy.select(schema_11.analysis_csv_rtp_table)
+                        ).fetchall()
 
-                    old_analysis_csv = connection.execute(
-                        sqlalchemy.select(schema_11.analysis_csv_rtp_table)
-                    ).fetchall()
+                        old_run_csv = connection.execute(
+                            sqlalchemy.select(schema_11.run_csv_rtp_table)
+                        ).fetchall()
 
-                    old_run_csv = connection.execute(
-                        sqlalchemy.select(schema_11.run_csv_rtp_table)
-                    ).fetchall()
-
-                    _migrate_boolean_settings_table(connection)
-                    _migrate_data_files_tables(connection, old_data_files)
-                    _update_foreign_key_references(
-                        connection, old_analysis_csv, old_run_csv
-                    )
-
-                connection.execute(sqlalchemy.text("PRAGMA foreign_keys = ON"))
+                        _migrate_boolean_settings_table(connection)
+                        _migrate_data_files_tables(connection, old_data_files)
+                        _update_foreign_key_references(
+                            connection, old_analysis_csv, old_run_csv
+                        )
+                finally:
+                    connection.execute(sqlalchemy.text("PRAGMA foreign_keys = ON"))
 
 
 def _migrate_boolean_settings_table(connection: sqlalchemy.engine.Connection) -> None:

--- a/robot-server/robot_server/persistence/_migrations/v12_to_v13.py
+++ b/robot-server/robot_server/persistence/_migrations/v12_to_v13.py
@@ -44,24 +44,29 @@ class Migration12to13(Migration):  # noqa: D101
                 engine, schema_13.run_table.name, schema_13.run_table.c.output_file_ids
             )
 
-            with engine.begin() as transaction:
-                old_data_files = transaction.execute(
-                    sqlalchemy.select(schema_11.data_files_table)
-                ).fetchall()
+            with engine.connect() as connection:
+                connection.execute(sqlalchemy.text("PRAGMA foreign_keys = OFF"))
 
-                old_analysis_csv = transaction.execute(
-                    sqlalchemy.select(schema_11.analysis_csv_rtp_table)
-                ).fetchall()
+                with connection.begin():
+                    old_data_files = connection.execute(
+                        sqlalchemy.select(schema_11.data_files_table)
+                    ).fetchall()
 
-                old_run_csv = transaction.execute(
-                    sqlalchemy.select(schema_11.run_csv_rtp_table)
-                ).fetchall()
+                    old_analysis_csv = connection.execute(
+                        sqlalchemy.select(schema_11.analysis_csv_rtp_table)
+                    ).fetchall()
 
-                _migrate_boolean_settings_table(transaction)
-                _migrate_data_files_tables(transaction, old_data_files)
-                _update_foreign_key_references(
-                    transaction, old_analysis_csv, old_run_csv
-                )
+                    old_run_csv = connection.execute(
+                        sqlalchemy.select(schema_11.run_csv_rtp_table)
+                    ).fetchall()
+
+                    _migrate_boolean_settings_table(connection)
+                    _migrate_data_files_tables(connection, old_data_files)
+                    _update_foreign_key_references(
+                        connection, old_analysis_csv, old_run_csv
+                    )
+
+                connection.execute(sqlalchemy.text("PRAGMA foreign_keys = ON"))
 
 
 def _migrate_boolean_settings_table(connection: sqlalchemy.engine.Connection) -> None:


### PR DESCRIPTION
 Closes [RQA-4866](https://opentrons.atlassian.net/browse/RQA-4866)

# Overview

The database migration from schema 12 to 13 is a bit complex, partially due to the nature of the migration and partially based on how I wrote it, whoops. 

In `_update_foreign_key_references`, there's code that tries to update the `schema_13.input_data_files_table` but `schema_13.input_data_files_table` doesn't exist yet when `_update_foreign_key_references` is called before `_migrate_data_files_tables`. The `input_data_files_table` is only created `inside _migrate_data_files_tables`. 

It's possible to fix this by breaking down these functions a bit more and ensuring the drops happen first, then creates, then data migration - but this requires significant refactoring and is more error-prone. I think a reasonable fix here is proposed in the official [sqlite tutorial docs](https://www.techonthenet.com/sqlite/foreign_keys/foreign_keys.php): just toggle foreign key enforcement off during the migration. We just need to ensure we use a single connection for the entire migration.

## Test Plan and Hands on Testing

- [x] Reproduced the issue utilizing the database linked in the ticket.
- [x]  Verified that the schema 12 database could migrate to schema 13 with a [build from this branch](https://opentrons.slack.com/archives/C81CR4VCZ/p1763084794247319) without issue.

## Changelog

- Fixed robots occasionally failing to update from 8.7 to 8.8.

## Risk assessment

lowish given the test plan


[RQA-4866]: https://opentrons.atlassian.net/browse/RQA-4866?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ