### PR TITLE
fix(protocol-designer): don't crash if LabwareDefinition.parameters is null

### DIFF
--- a/protocol-designer/src/utils/index.ts
+++ b/protocol-designer/src/utils/index.ts
@@ -4,6 +4,7 @@ import uuidv1 from 'uuid/v4'
 import {
   FLEX_ROBOT_TYPE,
   getDeckDefFromRobotType,
+  getLabwareDefURI,
   getTiprackVolume,
   INTERACTIVE_WELL_DATA_ATTRIBUTE,
   isAddressableAreaStandardSlot,
@@ -188,13 +189,11 @@ export function getMatchingTipLiquidSpecs(
   volume: number,
   tiprackDef: LabwareDefinition2
 ): SupportedTip {
-  const tipLength = tiprackDef?.parameters.tipLength ?? 0
+  const tipLength = tiprackDef?.parameters?.tipLength ?? 0
 
   if (tipLength === 0) {
     console.error(
-      `expected to find a tiplength with tiprack ${
-        tiprackDef?.metadata.displayName ?? 'unknown displayName'
-      } but could not`
+      `expected to find a tiplength for tiprack ${getLabwareDefURI(tiprackDef)} but could not`
     )
   }
 
@@ -217,9 +216,7 @@ export function getMatchingTipLiquidSpecs(
   })[0]
   console.assert(
     matchingTipLiquidSpecs,
-    `expected to find the tip liquid specs but could not with pipette tiprack displayname ${
-      tiprackDef?.metadata.displayName ?? 'unknown displayname'
-    }`
+    `expected to find the tip liquid specs but could not for tiprack ${getLabwareDefURI(tiprackDef)}`
   )
 
   return matchingTipLiquidSpecs


### PR DESCRIPTION
# Overview

`.parameters` is supposed to be a mandatory field in the `LabwareDefinition`, but PD is apparently getting `LabwareDefinition`s where `parameters` is null:
- https://opentrons-76.sentry.io/issues/7025189023/?project=4509363266387968
- https://opentrons-76.sentry.io/issues/7025189038/?project=4509363266387968
- https://opentrons-76.sentry.io/issues/7025189640/?project=4509363266387968

I suspect these are users who are importing custom tiprack definitions that are malformed.

Nonetheless, we should try to avoid crashing on them.

## Test Plan and Hands on Testing

Run CI tests.

## Risk assessment

Low.