### PR TITLE
fix(app-shell, app-shell-odd): Report window type on hard refresh

### DIFF
--- a/app-shell-odd/src/ui.ts
+++ b/app-shell-odd/src/ui.ts
@@ -70,6 +70,11 @@ export function waitForRobotServerAndShowMainWindow(
 ): void {
   mainWindow.show()
   mainWindow.webContents.send('window-type', 'odd-main')
+
+  mainWindow.webContents.on('did-finish-load', () => {
+    mainWindow.webContents.send('window-type', 'odd-main')
+  })
+
   _NODE_ENV_ !== 'development' &&
     setTimeout(function () {
       systemd

--- a/app-shell/src/secondary-windows/index.ts
+++ b/app-shell/src/secondary-windows/index.ts
@@ -137,7 +137,7 @@ function openWindow(details: SecondaryWindowDetails): void {
   const newWindow = createUi()
   secondaryWindows.set(windowId, newWindow)
 
-  newWindow.webContents.once('did-finish-load', () => {
+  newWindow.webContents.on('did-finish-load', () => {
     log.debug(`Did finish load for ${type}`)
     newWindow.webContents.send('window-type', 'secondary')
   })

--- a/app-shell/src/ui.ts
+++ b/app-shell/src/ui.ts
@@ -43,14 +43,18 @@ const WINDOW_OPTS = {
 export function createUi(): BrowserWindow {
   log.debug('Creating main window', { options: WINDOW_OPTS })
 
-  const mainWindow = new BrowserWindow(WINDOW_OPTS).once(
-    'ready-to-show',
-    () => {
-      log.debug('Main window ready to show')
-      mainWindow.show()
-      mainWindow.webContents.send('window-type', 'desktop-main')
-    }
-  )
+  const mainWindow = new BrowserWindow(WINDOW_OPTS)
+
+  mainWindow.once('ready-to-show', () => {
+    log.debug('Main window ready to show')
+    mainWindow.show()
+    mainWindow.webContents.send('window-type', 'desktop-main')
+  })
+
+  // For hard app refreshes.
+  mainWindow.webContents.on('did-finish-load', () => {
+    mainWindow.webContents.send('window-type', 'desktop-main')
+  })
 
   log.info(`Loading ${url}`)
   // eslint-disable-next-line @typescript-eslint/no-floating-promises


### PR DESCRIPTION
Closes [RQA-4773](https://opentrons.atlassian.net/browse/RQA-4773)

# Overview

We report the window type when the app initially renders in `App.tsx`, and this window type determines the specific render tree for a given renderer process. However, we weren't reporting this when a user hard refreshes an app, because the report only happens on initial render. To fix, we can report the event on `did-finish-load` continuously after the initial window load.


https://github.com/user-attachments/assets/5f32a1ff-e082-45f9-8b09-c144e3455525

## Test Plan and Hands on Testing

- See video. 
- Verified correct behavior for the ODD and secondary windows as well.

## Changelog

- Hard refreshing the app no longer causes it to whitescreen.

## Review requests

- This is a seemingly low risk change, but I'm happy to punt this to 8.9 if we don't think it's worth getting in now.

## Risk assessment

lowish


[RQA-4773]: https://opentrons.atlassian.net/browse/RQA-4773?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ