### PR TITLE
fix(api): Ensure that bad zoom and resolution values fail during app analysis

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/capture_image.py
+++ b/api/src/opentrons/protocol_engine/commands/capture_image.py
@@ -12,7 +12,11 @@ from opentrons.system.camera import (
     CONTRAST_DEFAULT,
     BRIGHTNESS_DEFAULT,
     SATURATION_DEFAULT,
+    ZOOM_MIN,
+    ZOOM_MAX,
     ZOOM_DEFAULT,
+    RESOLUTION_MIN,
+    RESOLUTION_MAX,
     RESOLUTION_DEFAULT,
 )
 from ..types import PreconditionTypes
@@ -161,6 +165,47 @@ def _revert_image_parameters(
     )
 
 
+def _validate_image_params(params: CaptureImageParams) -> None:
+    # Validate the filename param provided to fail analysis
+    if params.fileName is not None and set(SPECIAL_CHARACTERS).intersection(
+        set(params.fileName)
+    ):
+        raise FileNameInvalidError(
+            message=f"Capture image filename cannot contain character(s): {SPECIAL_CHARACTERS.intersection(set(params.fileName))}"
+        )
+
+    # Validate the image filter parameters
+    if params.zoom is not None and (params.zoom < ZOOM_MIN or params.zoom > ZOOM_MAX):
+        raise CameraSettingsInvalidError(
+            message="Capture image zoom must be a valid value from 1.0X to 2.0X zoom."
+        )
+    if params.resolution is not None and (
+        params.resolution[0] < RESOLUTION_MIN[0]
+        or params.resolution[1] < RESOLUTION_MIN[1]
+        or params.resolution[0] > RESOLUTION_MAX[0]
+        or params.resolution[1] > RESOLUTION_MAX[1]
+    ):
+        raise CameraSettingsInvalidError(
+            message="Capture image resolution must be a valid resolution from 240p through 8K resolutuon."
+        )
+    if params.brightness is not None and (
+        params.brightness < 0 or params.brightness > 100
+    ):
+        raise CameraSettingsInvalidError(
+            message="Capture image brightness must be a percentage from 0% to 100%."
+        )
+    if params.contrast is not None and (params.contrast < 0 or params.contrast > 100):
+        raise CameraSettingsInvalidError(
+            message="Capture image contrast must be a percentage from 0% to 100%."
+        )
+    if params.saturation is not None and (
+        params.saturation < 0 or params.saturation > 100
+    ):
+        raise CameraSettingsInvalidError(
+            message="Capture image saturation must be a percentage from 0% to 100%."
+        )
+
+
 class CaptureImageImpl(
     AbstractCommandImpl[CaptureImageParams, SuccessData[CaptureImageResult]]
 ):
@@ -186,33 +231,8 @@ class CaptureImageImpl(
             {PreconditionTypes.IS_CAMERA_USED: True}
         )
 
-        # Validate the filename param provided to fail analysis
-        if params.fileName is not None and set(SPECIAL_CHARACTERS).intersection(
-            set(params.fileName)
-        ):
-            raise FileNameInvalidError(
-                message=f"Capture image filename cannot contain character(s): {SPECIAL_CHARACTERS.intersection(set(params.fileName))}"
-            )
-
-        # Validate the image filter parameters
-        if params.brightness is not None and (
-            params.brightness < 0 or params.brightness > 100
-        ):
-            raise CameraSettingsInvalidError(
-                message="Capture image brightness must be a percentage from 0% to 100%."
-            )
-        if params.contrast is not None and (
-            params.contrast < 0 or params.contrast > 100
-        ):
-            raise CameraSettingsInvalidError(
-                message="Capture image contrast must be a percentage from 0% to 100%."
-            )
-        if params.saturation is not None and (
-            params.saturation < 0 or params.saturation > 100
-        ):
-            raise CameraSettingsInvalidError(
-                message="Capture image saturation must be a percentage from 0% to 100%."
-            )
+        # Validate that the provided parameters are all acceptable
+        _validate_image_params()
 
         # Handle capturing an image with the CameraProvider - Engine camera settings take priority
         camera_settings = await self._camera_provider.get_camera_settings()

--- a/api/src/opentrons/protocol_engine/commands/capture_image.py
+++ b/api/src/opentrons/protocol_engine/commands/capture_image.py
@@ -231,8 +231,8 @@ class CaptureImageImpl(
             {PreconditionTypes.IS_CAMERA_USED: True}
         )
 
-        # Validate that the provided parameters are all acceptable
-        _validate_image_params()
+        # Validate that the provided parameters are all acceptable. We do this here and in system/camera.py to ensure analysis fails properly.
+        _validate_image_params(params)
 
         # Handle capturing an image with the CameraProvider - Engine camera settings take priority
         camera_settings = await self._camera_provider.get_camera_settings()

--- a/api/tests/opentrons/protocol_engine/commands/test_capture_image.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_capture_image.py
@@ -442,3 +442,30 @@ async def test_raises_image_parameter_error(
     with mock.patch("os.path.exists", mock.Mock(return_value=True)):
         with pytest.raises(CameraSettingsInvalidError):
             await subject.execute(params=params)
+
+
+async def test_raises_bad_resolution_and_zoom(
+    state_view: StateView,
+    file_provider: FileProvider,
+    camera_provider: CameraProvider,
+) -> None:
+    """It should raise CameraSettingsInvalidError when the capture image command is provided a bad resolution or zoom, even when the camera callback is unavailable."""
+    subject = CaptureImageImpl(
+        state_view=state_view,
+        file_provider=file_provider,
+        camera_provider=camera_provider,
+    )
+
+    params = CaptureImageParams(resolution=(319, 239))
+    with pytest.raises(CameraSettingsInvalidError):
+        await subject.execute(params=params)
+    params = CaptureImageParams(resolution=(7681, 4321))
+    with pytest.raises(CameraSettingsInvalidError):
+        await subject.execute(params=params)
+
+    params = CaptureImageParams(zoom=0.9)
+    with pytest.raises(CameraSettingsInvalidError):
+        await subject.execute(params=params)
+    params = CaptureImageParams(zoom=2.1)
+    with pytest.raises(CameraSettingsInvalidError):
+        await subject.execute(params=params)


### PR DESCRIPTION
# Overview
Covers RQA-4848

We were only validating zoom and resolution in `system/camera.py` because unlike the filters they were not being scaled to new values. However, this means that an invalid zoom or resolution were passing app analysis, since the camera callback isn't available during app analysis. Checking them at both ends gives us the desired coverage.


## Test Plan and Hands on Testing

- [x] Ensure this protocol fails analysis:
```
from opentrons.protocol_api import ProtocolContext

metadata = {
    "protocolName": "Camera Test",
    "author": "Opentrons <protocols@opentrons.com>",
}
requirements = {
    "robotType": "Flex",
    "apiLevel": "2.27",
}

def run(protocol: ProtocolContext) -> None:
    protocol.capture_image(home_before=False, filename="below_min", zoom=1, contrast=50 , saturation = 50, brightness = 50, resolution= (0,0))

```

## Changelog

## Review requests


## Risk assessment
Low