### PR TITLE
fix(ci): dont caceh python

### DIFF
--- a/.github/workflows/e2e-test-checks.yaml
+++ b/.github/workflows/e2e-test-checks.yaml
@@ -36,7 +36,6 @@ jobs:
           cache-dependency-glob: |
               e2e-testing/uv.lock
               e2e-testing/pyproject.toml
-          cache-python: "true"
 
       - name: "Install E2E test dependencies"
         working-directory: e2e-testing

--- a/.github/workflows/pd-e2e-test.yaml
+++ b/.github/workflows/pd-e2e-test.yaml
@@ -58,7 +58,6 @@ jobs:
           cache-dependency-glob: |
               e2e-testing/uv.lock
               e2e-testing/pyproject.toml
-          cache-python: "true"
 
       - name: "Install E2E test dependencies"
         working-directory: e2e-testing


### PR DESCRIPTION
# Silly cache

I thought since we use 3.10 I should cache python but that is not what this setting does.
Remove it.