### PR TITLE
fix(app): fix tag's layout in protocol details page

### DIFF
--- a/app/src/organisms/Desktop/ProtocolDetails/ProtocolDetailsHeader.tsx
+++ b/app/src/organisms/Desktop/ProtocolDetails/ProtocolDetailsHeader.tsx
@@ -20,6 +20,7 @@ import {
   SPACING,
   StyledText,
   Tag,
+  WRAP,
 } from '@opentrons/components'
 
 import {
@@ -207,7 +208,11 @@ export function ProtocolDetailsHeader({
               </StyledText>
             </Flex>
             {/* tag section */}
-            <Flex flexDirection={DIRECTION_ROW} gap={SPACING.spacing4}>
+            <Flex
+              flexDirection={DIRECTION_ROW}
+              gap={SPACING.spacing4}
+              flexWrap={WRAP}
+            >
               <Tag
                 text={`${i18n.format(t('date_added'), 'titleCase')}:  ${format(
                   new Date(modified),


### PR DESCRIPTION


# Overview
fix tags' layout in protocol details page
<img width="605" height="768" alt="Screenshot 2025-11-14 at 11 54 21 AM" src="https://github.com/user-attachments/assets/84ff00ee-d58b-406b-80b5-b89a52361487" />
<img width="897" height="765" alt="Screenshot 2025-11-14 at 11 54 30 AM" src="https://github.com/user-attachments/assets/e23fc07f-67c6-4e20-9a44-e94b7d5d53a7" />
<img width="1218" height="769" alt="Screenshot 2025-11-14 at 11 54 40 AM" src="https://github.com/user-attachments/assets/5874c30d-37f8-46fd-bab0-aab775fa6002" />



close RUXD-2618

## Test Plan and Hands on Testing

Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.

## Changelog
- add flex-wrap

## Review requests


## Risk assessment
low 

