### PR TITLE
fix(api): preserve critical points in tracking end

### DIFF
--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -3089,6 +3089,7 @@ class OT3API(
         volume: float,
         rate: float = 1.0,
         movement_delay: Optional[float] = None,
+        end_critical_point: Optional[CriticalPoint] = None,
     ) -> None:
         """
         Aspirate a volume of liquid (in microliters/uL) while moving the z axis synchronously.
@@ -3108,7 +3109,7 @@ class OT3API(
         end_position = target_position_from_absolute(
             realmount,
             end_point,
-            self.critical_point_for,
+            partial(self.critical_point_for, cp_override=end_critical_point),
             top_types.Point(*self._config.left_mount_offset),
             top_types.Point(*self._config.right_mount_offset),
             top_types.Point(*self._config.gripper_mount_offset),
@@ -3123,6 +3124,9 @@ class OT3API(
         delay: Optional[Tuple[List[Axis], float]] = None
         if movement_delay is not None:
             delay = ([Axis.X, Axis.Y, Axis.Z_L, Axis.Z_R], movement_delay)
+        self._log.info(
+            f"aspirate_while_tracking: end at {end_point} {end_critical_point}, machine pos {end_position}, with plunger {target_pos}, delay {delay}"
+        )
         try:
             await self._backend.set_active_current(
                 {aspirate_spec.axis: aspirate_spec.current}
@@ -3158,6 +3162,7 @@ class OT3API(
         rate: float = 1.0,
         is_full_dispense: bool = False,
         movement_delay: Optional[float] = None,
+        end_critical_point: Optional[CriticalPoint] = None,
     ) -> None:
         """
         Dispense a volume of liquid (in microliters/uL) while moving the z axis synchronously.
@@ -3177,7 +3182,7 @@ class OT3API(
         end_position = target_position_from_absolute(
             realmount,
             end_point,
-            self.critical_point_for,
+            partial(self.critical_point_for, cp_override=end_critical_point),
             top_types.Point(*self._config.left_mount_offset),
             top_types.Point(*self._config.right_mount_offset),
             top_types.Point(*self._config.gripper_mount_offset),
@@ -3192,7 +3197,9 @@ class OT3API(
         delay: Optional[Tuple[List[Axis], float]] = None
         if movement_delay is not None:
             delay = ([Axis.X, Axis.Y, Axis.Z_L, Axis.Z_R], movement_delay)
-
+        self._log.info(
+            f"dispense_while_tracking: end at {end_point} {end_critical_point}, machine pos {end_position}, with plunger {target_pos}, delay {delay}"
+        )
         try:
             await self._backend.set_active_current(
                 {dispense_spec.axis: dispense_spec.current}

--- a/api/src/opentrons/hardware_control/protocols/liquid_handler.py
+++ b/api/src/opentrons/hardware_control/protocols/liquid_handler.py
@@ -129,15 +129,17 @@ class LiquidHandler(
         volume: float,
         flow_rate: float = 1.0,
         movement_delay: Optional[float] = None,
+        end_critical_point: Optional[CriticalPoint] = None,
     ) -> None:
         """
         Aspirate a volume of liquid (in microliters/uL) while moving the z axis synchronously.
 
         :param mount: A robot mount that the instrument is on.
-        :param z_distance: The distance the z axis will move during apsiration.
+        :param end_point: The deck coordinate point to move the tip to during the aspirate.
         :param volume: The volume of liquid to be aspirated.
         :param flow_rate: The flow rate to aspirate with.
         :param movement_delay: Time to wait after the pipette starts aspirating before x/y/z movement.
+        :param end_critical_point: The critical point for the end_point position.
         """
         ...
 
@@ -172,15 +174,17 @@ class LiquidHandler(
         flow_rate: float = 1.0,
         is_full_dispense: bool = False,
         movement_delay: Optional[float] = None,
+        end_critical_point: Optional[CriticalPoint] = None,
     ) -> None:
         """
         Dispense a volume of liquid (in microliters/uL) while moving the z axis synchronously.
 
         :param mount: A robot mount that the instrument is on.
-        :param z_distance: The distance the z axis will move during dispensing.
+        :param end_point: The deck coordinate point to move the tip to during the dispense.
         :param volume: The volume of liquid to be dispensed.
         :param flow_rate: The flow rate to dispense with.
         :param movement_delay: Time to wait after the pipette starts dispensing before x/y/z movement.
+        :param end_critical_point: The critical point for the end_point position.
         """
         ...
 

--- a/api/src/opentrons/protocol_api/core/engine/pipette_movement_conflict.py
+++ b/api/src/opentrons/protocol_api/core/engine/pipette_movement_conflict.py
@@ -1,8 +1,8 @@
 """A Protocol-Engine-friendly wrapper for opentrons.motion_planning.deck_conflict."""
+
 from __future__ import annotations
 import logging
 from typing import (
-    Optional,
     Tuple,
     Union,
     List,
@@ -12,7 +12,6 @@ from opentrons_shared_data.errors.exceptions import MotionPlanningFailureError
 from opentrons.protocol_engine.errors import LocationIsStagingSlotError
 from opentrons_shared_data.module import FLEX_TC_LID_COLLISION_ZONE
 
-from opentrons.hardware_control import CriticalPoint
 from opentrons.motion_planning import adjacent_slots_getters
 
 from opentrons.protocol_engine import (
@@ -101,7 +100,9 @@ def check_safe_for_pipette_movement(  # noqa: C901
     )
     primary_nozzle = engine_state.pipettes.get_primary_nozzle(pipette_id)
 
-    destination_cp = _get_critical_point_to_use(engine_state, labware_id)
+    destination_cp = engine_state.motion.get_critical_point_for_wells_in_labware(
+        labware_id
+    )
     pipette_bounds_at_well_location = (
         engine_state.pipettes.get_pipette_bounds_at_specified_move_to_position(
             pipette_id=pipette_id,
@@ -187,21 +188,6 @@ def check_safe_for_pipette_movement(  # noqa: C901
                 f" {labware_slot} with {primary_nozzle} nozzle partial configuration"
                 f" will result in collision with items in staging slot {staging_slot}."
             )
-
-
-def _get_critical_point_to_use(
-    engine_state: StateView, labware_id: str
-) -> Optional[CriticalPoint]:
-    """Return the critical point to use when accessing the given labware."""
-    # TODO (spp, 2024-09-17): looks like Y_CENTER of column is the same as its XY_CENTER.
-    #   I'm using this if-else ladder to be consistent with what we do in
-    #   `MotionPlanning.get_movement_waypoints_to_well()`.
-    #   We should probably use only XY_CENTER in both places.
-    if engine_state.labware.get_should_center_column_on_target_well(labware_id):
-        return CriticalPoint.Y_CENTER
-    elif engine_state.labware.get_should_center_pipette_on_target_well(labware_id):
-        return CriticalPoint.XY_CENTER
-    return None
 
 
 def _slot_has_potential_colliding_object(

--- a/api/src/opentrons/protocol_engine/execution/pipetting.py
+++ b/api/src/opentrons/protocol_engine/execution/pipetting.py
@@ -1,4 +1,5 @@
 """Pipetting command handling."""
+
 from typing import Optional, Iterator, Tuple
 from typing_extensions import Protocol as TypingProtocol
 from contextlib import contextmanager
@@ -208,6 +209,9 @@ class HardwarePipettingHandler(PipettingHandler):
                 end_point=end_point,
                 volume=adjusted_volume,
                 movement_delay=movement_delay,
+                end_critical_point=self.get_state_view().motion.get_critical_point_for_wells_in_labware(
+                    labware_id
+                ),
             )
         return adjusted_volume
 
@@ -239,6 +243,9 @@ class HardwarePipettingHandler(PipettingHandler):
                 push_out=push_out,
                 is_full_dispense=is_full_dispense,
                 movement_delay=movement_delay,
+                end_critical_point=self.get_state_view().motion.get_critical_point_for_wells_in_labware(
+                    labware_id
+                ),
             )
         return adjusted_volume
 

--- a/api/src/opentrons/protocol_engine/state/motion.py
+++ b/api/src/opentrons/protocol_engine/state/motion.py
@@ -1,4 +1,5 @@
 """Motion state store and getters."""
+
 from dataclasses import dataclass
 from typing import List, Optional, Union
 import logging
@@ -78,14 +79,9 @@ class MotionView:
             isinstance(current_location, CurrentWell)
             and current_location.pipette_id == pipette_id
         ):
-            if self._labware.get_should_center_column_on_target_well(
+            critical_point = self.get_critical_point_for_wells_in_labware(
                 current_location.labware_id
-            ):
-                critical_point = CriticalPoint.Y_CENTER
-            elif self._labware.get_should_center_pipette_on_target_well(
-                current_location.labware_id
-            ):
-                critical_point = CriticalPoint.XY_CENTER
+            )
         return PipetteLocationData(mount=mount, critical_point=critical_point)
 
     def _get_pipette_offset_for_reservoirs(
@@ -124,6 +120,17 @@ class MotionView:
             x_offset = -1 * well_x_dim / 24
         return Point(x=x_offset, y=y_offset)
 
+    def get_critical_point_for_wells_in_labware(
+        self, labware_id: str
+    ) -> CriticalPoint | None:
+        """Get the appropriate critical point override for this labware."""
+        if self._labware.get_should_center_column_on_target_well(labware_id):
+            return CriticalPoint.Y_CENTER
+        elif self._labware.get_should_center_pipette_on_target_well(labware_id):
+            return CriticalPoint.XY_CENTER
+        else:
+            return None
+
     def get_movement_waypoints_to_well(
         self,
         pipette_id: str,
@@ -142,11 +149,7 @@ class MotionView:
         """Calculate waypoints to a destination that's specified as a well."""
         location = current_well or self._pipettes.get_current_location()
 
-        destination_cp: Optional[CriticalPoint] = None
-        if self._labware.get_should_center_column_on_target_well(labware_id):
-            destination_cp = CriticalPoint.Y_CENTER
-        elif self._labware.get_should_center_pipette_on_target_well(labware_id):
-            destination_cp = CriticalPoint.XY_CENTER
+        destination_cp = self.get_critical_point_for_wells_in_labware(labware_id)
 
         destination = self._geometry.get_well_position(
             labware_id=labware_id,
@@ -397,12 +400,7 @@ class MotionView:
             mm_from_edge=mm_from_edge,
             edge_path_type=edge_path_type,
         )
-        critical_point: Optional[CriticalPoint] = None
-
-        if self._labware.get_should_center_column_on_target_well(labware_id):
-            critical_point = CriticalPoint.Y_CENTER
-        elif self._labware.get_should_center_pipette_on_target_well(labware_id):
-            critical_point = CriticalPoint.XY_CENTER
+        critical_point = self.get_critical_point_for_wells_in_labware(labware_id)
 
         return [
             motion_planning.Waypoint(position=p, critical_point=critical_point)

--- a/api/tests/opentrons/protocol_api/core/engine/test_deck_conflict.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_deck_conflict.py
@@ -840,15 +840,10 @@ def test_deck_conflict_raises_for_bad_pipette_move(
         )
     ).then_return(destination_well_point)
     decoy.when(
-        mock_state_view.labware.get_should_center_column_on_target_well(
+        mock_state_view.motion.get_critical_point_for_wells_in_labware(
             "destination-labware-id"
         )
-    ).then_return(False)
-    decoy.when(
-        mock_state_view.labware.get_should_center_pipette_on_target_well(
-            "destination-labware-id"
-        )
-    ).then_return(False)
+    ).then_return(None)
     decoy.when(
         mock_state_view.pipettes.get_pipette_bounds_at_specified_move_to_position(
             pipette_id="pipette-id",
@@ -1013,10 +1008,10 @@ def test_deck_conflict_raises_for_collision_with_tc_lid(
     ).then_return(destination_well_point)
 
     decoy.when(
-        mock_state_view.labware.get_should_center_column_on_target_well(
+        mock_state_view.motion.get_critical_point_for_wells_in_labware(
             "destination-labware-id"
         )
-    ).then_return(True)
+    ).then_return(CriticalPoint.Y_CENTER)
     decoy.when(
         mock_state_view.pipettes.get_pipette_bounds_at_specified_move_to_position(
             pipette_id="pipette-id",

--- a/api/tests/opentrons/protocol_engine/execution/test_pipetting_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_pipetting_handler.py
@@ -9,6 +9,7 @@ from decoy import Decoy
 from opentrons.types import Mount, Point
 from opentrons.hardware_control import API as HardwareAPI
 from opentrons.hardware_control.dev_types import PipetteDict
+from opentrons.hardware_control.types import CriticalPoint
 
 from opentrons.protocol_engine.state.state import StateView
 from opentrons.protocol_engine.state.pipettes import HardwarePipette
@@ -286,6 +287,88 @@ async def test_hw_dispense_in_place_raises_invalid_push_out(
         )
 
 
+async def test_hw_dispense_while_tracking(
+    decoy: Decoy,
+    mock_state_view: StateView,
+    mock_hardware_api: HardwareAPI,
+    mock_labware_view: LabwareView,
+    mock_well_view: WellView,
+    hardware_subject: HardwarePipettingHandler,
+) -> None:
+    """Should set flow_rate and call hardware_api aspirate."""
+    decoy.when(mock_labware_view.get_well_definition("labware-id", "A1")).then_return(
+        RectangularWellDefinition3.model_construct(totalLiquidVolume=1100000)  # type: ignore[call-arg]
+    )
+    decoy.when(mock_labware_view.get_well_geometry("labware-id", "A1")).then_return(
+        _TEST_INNER_WELL_GEOMETRY
+    )
+
+    decoy.when(mock_state_view.pipettes.get_working_volume("pipette-id")).then_return(
+        25
+    )
+    decoy.when(mock_state_view.pipettes.get_aspirated_volume("pipette-id")).then_return(
+        25
+    )
+
+    decoy.when(mock_hardware_api.attached_instruments).then_return({})
+    decoy.when(
+        mock_state_view.pipettes.get_hardware_pipette(
+            pipette_id="pipette-id",
+            attached_pipettes={},
+        )
+    ).then_return(
+        HardwarePipette(
+            mount=Mount.LEFT,
+            config=cast(
+                PipetteDict,
+                {
+                    "aspirate_flow_rate": 1.23,
+                    "dispense_flow_rate": 4.56,
+                    "blow_out_flow_rate": 7.89,
+                },
+            ),
+        )
+    )
+
+    decoy.when(
+        mock_state_view.geometry.get_liquid_handling_z_change(
+            labware_id="labware-id",
+            well_name="A1",
+            pipette_id="pipette-id",
+            operation_volume=25.0,
+        )
+    ).then_return(4.544)
+
+    decoy.when(
+        mock_state_view.motion.get_critical_point_for_wells_in_labware("labware-id")
+    ).then_return(CriticalPoint.XY_CENTER)
+
+    result = await hardware_subject.dispense_while_tracking(
+        pipette_id="pipette-id",
+        labware_id="labware-id",
+        well_name="A1",
+        volume=25,
+        flow_rate=2.5,
+        end_point=Point(0, 0, 0),
+        push_out=2.0,
+        is_full_dispense=True,
+        movement_delay=3.0,
+    )
+    # make sure hw dispense_while_tracking runs without error
+    assert result == 25
+    decoy.verify(
+        await mock_hardware_api.dispense_while_tracking(
+            mount=Mount.LEFT,
+            end_point=Point(0, 0, 0),
+            volume=25,
+            end_critical_point=CriticalPoint.XY_CENTER,
+            push_out=2.0,
+            is_full_dispense=True,
+            movement_delay=3.0,
+        )
+    )
+
+
 async def test_hw_aspirate_while_tracking(
     decoy: Decoy,
     mock_state_view: StateView,
@@ -339,6 +422,10 @@ async def test_hw_aspirate_while_tracking(
         )
     ).then_return(4.544)
 
+    decoy.when(
+        mock_state_view.motion.get_critical_point_for_wells_in_labware("labware-id")
+    ).then_return(CriticalPoint.Y_CENTER)
+
     result = await hardware_subject.aspirate_while_tracking(
         pipette_id="pipette-id",
         labware_id="labware-id",
@@ -347,6 +434,7 @@ async def test_hw_aspirate_while_tracking(
         flow_rate=2.5,
         end_point=Point(0, 0, 0),
         command_note_adder=mock_command_note_adder,
+        movement_delay=3.0,
     )
     # make sure hw aspirate_while_tracking runs without error
     assert result == 25
@@ -355,7 +443,8 @@ async def test_hw_aspirate_while_tracking(
             mount=Mount.LEFT,
             end_point=Point(0, 0, 0),
             volume=25,
-            movement_delay=None,
+            movement_delay=3.0,
+            end_critical_point=CriticalPoint.Y_CENTER,
         )
     )
 


### PR DESCRIPTION
When we calculate the move target for the tracking gantry/z move, we need to take into account any critical point overrides from things like multichannels needing to be centered on 1-channel reservoirs.

Luckily, this is low-risk since the functions the tracking mechanism in hardware control uses to calculate the position take a critical point, and the engine knows how to calculate critical points, so we're not actually making any decisions here - just plumbing additional data through.

## Testing
- Do a tracking aspirate and dispense using any multiple pipette layout (8-channel pipette in all-tips mode, 96-channel pipette in any mode but single) on a 1-well reservoir, or any column layout (8-channel pipette in all-tips mode or 96-channel pipette in column mode on one column or all-tips mode on well A1) on any kind of reservoir. The pipette should not move in X or Y while aspirating or dispensing.

Closes RQA-4875

