### PR TITLE
fix(components): remove warnings from Icon component

### DIFF
--- a/components/src/hocs/withStyleProps.ts
+++ b/components/src/hocs/withStyleProps.ts
@@ -1,6 +1,6 @@
 import { createElement } from 'react'
 
-import { styleProps } from '../primitives'
+import { isntStyleProp, styleProps } from '../primitives'
 
 import type { ComponentProps, ComponentType } from 'react'
 import type { StyleProps } from '../primitives'
@@ -39,8 +39,18 @@ export function withStyleProps<T extends ComponentType<any>>(
     const stylePropsStyles = styleProps(props)
     const combinedStyles = { ...stylePropsStyles, ...style }
 
+    const forwardedProps = Object.entries(props).reduce(
+      (acc, [prop, value]) => {
+        if (isntStyleProp(prop)) {
+          acc[prop] = value
+        }
+        return acc
+      },
+      {} as Record<string, unknown>
+    )
+
     return createElement(Component, {
-      ...props,
+      ...(forwardedProps as ComponentProps<T>),
       style: combinedStyles,
     })
   }

--- a/components/src/hocs/withStyleProps.ts
+++ b/components/src/hocs/withStyleProps.ts
@@ -40,13 +40,13 @@ export function withStyleProps<T extends ComponentType<any>>(
     const combinedStyles = { ...stylePropsStyles, ...style }
 
     const forwardedProps = Object.entries(props).reduce(
-      (acc, [prop, value]) => {
+      (acc: Record<string, unknown>, [prop, value]) => {
         if (isntStyleProp(prop)) {
           acc[prop] = value
         }
         return acc
       },
-      {} as Record<string, unknown>
+      {}
     )
 
     return createElement(Component, {

--- a/components/src/icons/Icon.tsx
+++ b/components/src/icons/Icon.tsx
@@ -76,6 +76,8 @@ function IconComponent(props: IconProps): JSX.Element | null {
       fill="currentColor"
       viewBox={viewBox}
       className={clsx(className, { [styles.spin]: spin })}
+      // need this because this component needs to allow engineers to make some style overrides
+      // eslint-disable-next-line react/forbid-dom-props
       style={{ ...style }}
       {...svgProps}
     >


### PR DESCRIPTION

# Overview
remove warnings from Icon component

actually the issue is coming from withStyleProps.ts since it doesn't consider `isntStyleProp`.
this change will prevent populating warnings when we use withStyleProps for CSS Modules migration work.

<img width="1450" height="881" alt="Screenshot 2025-11-14 at 1 14 08 PM" src="https://github.com/user-attachments/assets/16dd0ece-55b2-43cf-bc3b-7a53f61fb99e" />

close AUTH-2505


Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.

## Test Plan and Hands on Testing

Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.

## Changelog
- update withStyleProps.ts for  `isntStyleProp`


## Review requests

- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.

## Risk assessment
low

