### PR TITLE
feat(protocol-designer): change submerge/retract copy

### DIFF
--- a/protocol-designer/src/assets/localization/en/protocol_steps.json
+++ b/protocol-designer/src/assets/localization/en/protocol_steps.json
@@ -173,6 +173,7 @@
   "single": "Single transfer",
   "single_nozzle": "Single",
   "speed": "Speed",
+  "start_point": "{{prefix}} start point",
   "starting_deck": "Starting deck",
   "step_substeps": "{{stepType}} details",
   "submerge": "Submerge",

--- a/protocol-designer/src/assets/localization/en/shared.json
+++ b/protocol-designer/src/assets/localization/en/shared.json
@@ -123,6 +123,7 @@
   "software_manual": "Software manual",
   "source_well": "Source well",
   "stagingArea": "Staging area",
+  "start_point": "Edit {{prefix}} start point",
   "step_count": "Step {{current}}",
   "step": "Step {{current}} / {{max}}",
   "swap_view": "Swap view",

--- a/protocol-designer/src/components/organisms/TipPositionModal/index.tsx
+++ b/protocol-designer/src/components/organisms/TipPositionModal/index.tsx
@@ -275,15 +275,18 @@ export function TipPositionModal(
       ? utils.getIsZValueAtBottom(zValue, wellDepthMm, reference)
       : false
 
+  const titleText =
+    prefix === 'aspirate' || prefix === 'dispense' || prefix === 'mix'
+      ? t('shared:tip_position', { prefix: MoveLiquidPrefixToAction[prefix] })
+      : t('shared:start_point', { prefix: MoveLiquidPrefixToAction[prefix] })
+
   return createPortal(
     <Modal
       marginLeft="0"
       type="info"
       width="47rem"
       closeOnOutsideClick
-      title={t('shared:tip_position', {
-        prefix: MoveLiquidPrefixToAction[prefix],
-      })}
+      title={titleText}
       onClose={handleCancel}
       footer={
         <Flex

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/PositionField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/PositionField.tsx
@@ -192,6 +192,15 @@ export function PositionField(props: PositionFieldProps): JSX.Element {
     `protocol_steps:reference_positions.${referencePosition}`
   )
 
+  const titleText =
+    prefix === 'aspirate' || prefix === 'dispense' || prefix === 'mix'
+      ? t('protocol_steps:tip_position', {
+          prefix: MoveLiquidPrefixToAction[prefix],
+        })
+      : t('protocol_steps:start_point', {
+          prefix: MoveLiquidPrefixToAction[prefix],
+        })
+
   return (
     <>
       <Tooltip tooltipProps={tooltipProps}>{tooltipContent}</Tooltip>
@@ -204,12 +213,7 @@ export function PositionField(props: PositionFieldProps): JSX.Element {
           flexDirection={DIRECTION_COLUMN}
         >
           <StyledText desktopStyle="bodyDefaultRegular" color={COLORS.grey60}>
-            {i18n.format(
-              t('protocol_steps:tip_position', {
-                prefix: MoveLiquidPrefixToAction[prefix],
-              }),
-              'capitalize'
-            )}
+            {i18n.format(titleText, 'capitalize')}
           </StyledText>
           <ListButton
             padding={SPACING.spacing12}


### PR DESCRIPTION
# Overview

Per design input, change the language around submerge/retract from "Submerge/Retract tip position" to "Submerge/Retract start point"

closes AUTH-2506

## Test Plan and Hands on Testing

- open a move liquid form
- navigate to advanced settings
- verify that title for submerge/retract position fields reads "submerge/retract start point" rather than "submerge/retract start point"
- open modal and verify that title reads "Edit submerge/retract start point"

## Changelog

- change submerge/retract copy in move liquid forms

## Review requests

see test plan

## Risk assessment

low