### PR TITLE
fix(protocol-designer): fix meta data error

### DIFF
--- a/protocol-designer/src/pages/ProtocolOverview/PeripheralsInfo/__tests__/PeripheralsInfo.test.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/PeripheralsInfo/__tests__/PeripheralsInfo.test.tsx
@@ -7,16 +7,16 @@ import { PeripheralsInfo } from '..'
 import { renderWithProviders } from '../../../../__testing-utils__'
 import { i18n } from '../../../../assets/localization'
 
-import type { PeripheralsInfoProps } from '..'
+import type { ComponentProps } from 'react'
 
-const render = (props: PeripheralsInfoProps) => {
+const render = (props: ComponentProps<typeof PeripheralsInfo>) => {
   return renderWithProviders(<PeripheralsInfo {...props} />, {
     i18nInstance: i18n,
   })
 }
 
 describe('PeripheralsInfo', () => {
-  let mockProps: PeripheralsInfoProps
+  let mockProps: ComponentProps<typeof PeripheralsInfo>
 
   beforeEach(() => {
     mockProps = {

--- a/protocol-designer/src/pages/ProtocolOverview/PeripheralsInfo/index.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/PeripheralsInfo/index.tsx
@@ -12,7 +12,7 @@ import styles from './peripherals.module.css'
 
 import type { RobotType } from '@opentrons/shared-data'
 
-export interface PeripheralsInfoProps {
+interface PeripheralsInfoProps {
   robotType: RobotType
 }
 
@@ -30,7 +30,7 @@ export function PeripheralsInfo({
         </StyledText>
       </div>
       <div className={styles.list_container}>
-        <ListItem type="default" key={`InputDeviceInfo_camera`}>
+        <ListItem type="default" key="InputDeviceInfo_camera">
           <ListItemDescriptor
             type="large"
             description={

--- a/protocol-designer/src/pages/ProtocolOverview/ProtocolMetadata.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/ProtocolMetadata.tsx
@@ -19,16 +19,14 @@ import {
   LINK_BUTTON_STYLE,
 } from '../../components/atoms'
 
-type MetadataInfo = Array<{
-  author?: string
-  description?: string | null
-  created?: string
-  modified?: string
-}>
+interface MetadataItem {
+  title: string
+  value: string | null
+}
 
 interface ProtocolMetadataProps {
   setShowEditMetadataModal: (showEditMetadataModal: boolean) => void
-  metaDataInfo: MetadataInfo
+  metaDataInfo: MetadataItem[]
 }
 
 export function ProtocolMetadata({
@@ -59,40 +57,31 @@ export function ProtocolMetadata({
         </Flex>
       </Flex>
       <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing4}>
-        {metaDataInfo.map(info => {
-          const [title, value] = Object.entries(info)[0]
-          const displayValue =
-            value == null ||
-            (typeof value === 'object' && Object.keys(value).length === 0)
-              ? t('na')
-              : String(value)
-
-          return (
-            <ListItem type="default" key={`ProtocolOverview_${title}`}>
-              <ListItemDescriptor
-                type="large"
-                description={
-                  <Flex minWidth="13.75rem">
-                    <StyledText
-                      desktopStyle="bodyDefaultRegular"
-                      color={COLORS.grey60}
-                    >
-                      {t(`${title}`)}
-                    </StyledText>
-                  </Flex>
-                }
-                content={
+        {metaDataInfo.map(({ title, value }) => (
+          <ListItem type="default" key={`ProtocolOverview_${title}`}>
+            <ListItemDescriptor
+              type="large"
+              description={
+                <Flex minWidth="13.75rem">
                   <StyledText
                     desktopStyle="bodyDefaultRegular"
-                    css={LINE_CLAMP_TEXT_STYLE(2)}
+                    color={COLORS.grey60}
                   >
-                    {displayValue}
+                    {t(`${title}`)}
                   </StyledText>
-                }
-              />
-            </ListItem>
-          )
-        })}
+                </Flex>
+              }
+              content={
+                <StyledText
+                  desktopStyle="bodyDefaultRegular"
+                  css={LINE_CLAMP_TEXT_STYLE(2)}
+                >
+                  {value ?? t('na')}
+                </StyledText>
+              }
+            />
+          </ListItem>
+        ))}
         <ListItem type="default" key="ProtocolOverview_robotVersion">
           <ListItemDescriptor
             type="large"

--- a/protocol-designer/src/pages/ProtocolOverview/ProtocolMetadata.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/ProtocolMetadata.tsx
@@ -61,6 +61,11 @@ export function ProtocolMetadata({
       <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing4}>
         {metaDataInfo.map(info => {
           const [title, value] = Object.entries(info)[0]
+          const displayValue =
+            value == null ||
+            (typeof value === 'object' && Object.keys(value).length === 0)
+              ? t('na')
+              : String(value)
 
           return (
             <ListItem type="default" key={`ProtocolOverview_${title}`}>
@@ -81,7 +86,7 @@ export function ProtocolMetadata({
                     desktopStyle="bodyDefaultRegular"
                     css={LINE_CLAMP_TEXT_STYLE(2)}
                   >
-                    {value ?? t('na')}
+                    {displayValue}
                   </StyledText>
                 }
               />

--- a/protocol-designer/src/pages/ProtocolOverview/__tests__/ProtocolMetadata.test.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/__tests__/ProtocolMetadata.test.tsx
@@ -10,17 +10,21 @@ import type { ComponentProps } from 'react'
 const mockSetShowEditMetadataModal = vi.fn()
 const mockMetaDataInfo = [
   {
-    description:
+    title: 'description',
+    value:
       'Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.',
   },
   {
-    author: 'Opentrons',
+    title: 'author',
+    value: 'Opentrons',
   },
   {
-    created: 'June 10, 2024',
+    title: 'created',
+    value: 'June 10, 2024',
   },
   {
-    modified: 'September 20, 2024 | 3:44 PM',
+    title: 'modified',
+    value: 'September 20, 2024 | 3:44 PM',
   },
 ] as any
 

--- a/protocol-designer/src/pages/ProtocolOverview/index.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/index.tsx
@@ -122,12 +122,16 @@ export function ProtocolOverview(): JSX.Element {
   const { protocolName, description, created, lastModified, author } =
     formValues
   const metaDataInfo = [
-    { description },
-    { author },
-    { created: created != null ? format(created, DATE_ONLY_FORMAT) : t('na') },
+    { title: 'description', value: description ?? null },
+    { title: 'author', value: author ?? null },
     {
-      modified:
-        lastModified != null ? format(lastModified, DATETIME_FORMAT) : t('na'),
+      title: 'created',
+      value: created != null ? format(created, DATE_ONLY_FORMAT) : null,
+    },
+    {
+      title: 'modified',
+      value:
+        lastModified != null ? format(lastModified, DATETIME_FORMAT) : null,
     },
   ]
 


### PR DESCRIPTION
# Overview
The issue is that `{value}` tries to render non-string type (probably object).
update the interface to avoid rendering invalid value as a react child.
while investigating a bug, I noticed this and removed the interface export from `PeripheralsInfo.tsx`.

close AUTH-2507

## Test Plan and Hands on Testing


## Changelog
- update metadata interface in metadata component and overview component 
- update remove export from PeripheralsInfo.tsx

## Review requests


## Risk assessment
low 

