### PR TITLE
fix(components): update TimelineScrubber background color

### DIFF
--- a/components/src/molecules/TimelineScrubber/timelinescrubber.module.css
+++ b/components/src/molecules/TimelineScrubber/timelinescrubber.module.css
@@ -36,7 +36,7 @@
 
 .track_background {
   width: 100%;
-  background-color: var(--grey-20);
+  background-color: var(--blue-30);
 }
 
 .track_progress {


### PR DESCRIPTION

# Overview
update TimelineScrubber background color grey to blue

<img width="447" height="228" alt="Screenshot 2025-11-14 at 4 43 42 PM" src="https://github.com/user-attachments/assets/a6c82cc3-89fa-4a6f-897d-f17e7c56c1ca" />

close RUXD-2625


## Test Plan and Hands on Testing
- select a protocol
- click `Visualize` button
check TimelineScrubber's background color is `blue-30`

Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.

## Changelog
- update TimelineScrubber background color


## Review requests



## Risk assessment
low
