### PR TITLE
fix(protocol-designer): Fix step numbering after concurrent Thermocycler profiles

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/ConnectedStepContainer.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/ConnectedStepContainer.tsx
@@ -59,6 +59,8 @@ export interface ConnectedStepContainerProps {
   isStepAfterError?: boolean
 }
 
+// todo(mm, 2025-11-14): I've made a mess of ConnectedStepInfo and ConnectedStepContainer.
+// We should try to either merge them, or clarify each one's responsibilities.
 export function ConnectedStepContainer(
   props: ConnectedStepContainerProps
 ): JSX.Element {

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/ConnectedStepInfo.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/ConnectedStepInfo.tsx
@@ -47,7 +47,6 @@ import type { SelectMultipleStepsAction } from '/protocol-designer/ui/steps'
 
 export interface ConnectedStepInfoProps {
   stepId: StepIdType
-  stepNumber: number | null
   openedOverflowMenuId?: string | null
   setOpenedOverflowMenuId?: Dispatch<SetStateAction<string | null>>
   sidebarWidth: number
@@ -61,7 +60,6 @@ const DEBOUNCE_DURATION_MS = 500
 export function ConnectedStepInfo(props: ConnectedStepInfoProps): JSX.Element {
   const {
     stepId,
-    stepNumber,
     openedOverflowMenuId,
     setOpenedOverflowMenuId,
     sidebarWidth,
@@ -69,6 +67,9 @@ export function ConnectedStepInfo(props: ConnectedStepInfoProps): JSX.Element {
   const dispatch = useDispatch<ThunkDispatch<BaseState, any, any>>()
   const stepIds = useSelector(getOrderedStepIds)
   const step = useSelector(stepFormSelectors.getSavedStepForms)[stepId]
+  const stepNumber = useSelector(stepFormSelectors.getUserVisibleStepNumbers)[
+    stepId
+  ]
   const argsAndErrors = useSelector(stepFormSelectors.getArgsAndErrorsByStepId)[
     stepId
   ]

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/ConnectedStepInfo.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/ConnectedStepInfo.tsx
@@ -57,6 +57,8 @@ export interface ConnectedStepInfoProps {
 // gap but it's made out of internal padding), there are hover gaps in `ConcurrentStepGroup`s.
 const DEBOUNCE_DURATION_MS = 500
 
+// todo(mm, 2025-11-14): I've made a mess of ConnectedStepInfo and ConnectedStepContainer.
+// We should try to either merge them, or clarify each one's responsibilities.
 export function ConnectedStepInfo(props: ConnectedStepInfoProps): JSX.Element {
   const {
     stepId,

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/ConnectedStepInfo.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/ConnectedStepInfo.tsx
@@ -47,7 +47,7 @@ import type { SelectMultipleStepsAction } from '/protocol-designer/ui/steps'
 
 export interface ConnectedStepInfoProps {
   stepId: StepIdType
-  stepNumber: number
+  stepNumber: number | null
   openedOverflowMenuId?: string | null
   setOpenedOverflowMenuId?: Dispatch<SetStateAction<string | null>>
   sidebarWidth: number

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/DraggableSteps.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/DraggableSteps.tsx
@@ -22,7 +22,6 @@ import { getEnableConcurrentModuleActions } from '/protocol-designer/feature-fla
 import {
   getOrderedSavedForms,
   getSavedStepHierarchy,
-  getUserVisibleStepNumbers,
 } from '/protocol-designer/step-forms/selectors'
 import * as steplistActions from '/protocol-designer/steplist/actions'
 import {
@@ -56,7 +55,6 @@ export function DraggableSteps(props: DraggableStepsProps): JSX.Element | null {
   >(null)
 
   const stepHierarchy = useSelector(getSavedStepHierarchy)
-  const stepNumbers = useSelector(getUserVisibleStepNumbers)
 
   return (
     <Flex flexDirection={DIRECTION_COLUMN} width="100%">
@@ -65,7 +63,6 @@ export function DraggableSteps(props: DraggableStepsProps): JSX.Element | null {
           return (
             <DragDropStep
               key={`${nestedStepElement.stepId}`}
-              stepNumber={stepNumbers[nestedStepElement.stepId]}
               stepId={nestedStepElement.stepId}
               openedOverflowMenuId={openedOverflowMenuId}
               setOpenedOverflowMenuId={setOpenedOverflowMenuId}
@@ -104,7 +101,6 @@ interface DropType {
 
 interface ConnectedStepItemProps {
   stepId: StepIdType
-  stepNumber: number | null
   onStepContextMenu?: () => void
 }
 
@@ -122,7 +118,6 @@ interface DragDropStepProps extends ConnectedStepItemProps {
 function DragDropStep(props: DragDropStepProps): JSX.Element {
   const {
     stepId,
-    stepNumber,
     openedOverflowMenuId,
     setOpenedOverflowMenuId,
     sidebarWidth,
@@ -201,7 +196,6 @@ function DragDropStep(props: DragDropStepProps): JSX.Element {
       <ConnectedStepInfo
         openedOverflowMenuId={openedOverflowMenuId}
         setOpenedOverflowMenuId={setOpenedOverflowMenuId}
-        stepNumber={stepNumber}
         stepId={stepId}
         sidebarWidth={sidebarWidth}
       />
@@ -256,7 +250,6 @@ function ThermocyclerProfile(props: ThermocyclerProfileProps): JSX.Element {
     multiSelectItemIds != null && multiSelectItemIds.length > 0
       ? multiSelectItemIds.includes(thermocyclerProfileStepId)
       : selectedStepId === thermocyclerProfileStepId
-  const stepNumbers = useSelector(getUserVisibleStepNumbers)
 
   const { t } = useTranslation()
 
@@ -264,7 +257,6 @@ function ThermocyclerProfile(props: ThermocyclerProfileProps): JSX.Element {
     <div>
       <DragDropStep
         stepId={thermocyclerProfileStepId}
-        stepNumber={stepNumbers[thermocyclerProfileStepId]}
         openedOverflowMenuId={openedOverflowMenuId}
         setOpenedOverflowMenuId={setOpenedOverflowMenuId}
         sidebarWidth={sidebarWidth}
@@ -288,7 +280,6 @@ function ThermocyclerProfile(props: ThermocyclerProfileProps): JSX.Element {
           <ConcurrentGroupChild key={concurrentStepId} type="step">
             <DragDropStep
               stepId={concurrentStepId}
-              stepNumber={stepNumbers[concurrentStepId]}
               openedOverflowMenuId={openedOverflowMenuId}
               setOpenedOverflowMenuId={setOpenedOverflowMenuId}
               sidebarWidth={sidebarWidth}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/DraggableSteps.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/DraggableSteps.tsx
@@ -19,7 +19,11 @@ import {
 } from '/protocol-designer/components/molecules'
 import { DND_TYPES } from '/protocol-designer/constants'
 import { getEnableConcurrentModuleActions } from '/protocol-designer/feature-flags/selectors'
-import { getOrderedSavedForms } from '/protocol-designer/step-forms/selectors'
+import {
+  getOrderedSavedForms,
+  getSavedStepHierarchy,
+  getUserVisibleStepNumbers,
+} from '/protocol-designer/step-forms/selectors'
 import * as steplistActions from '/protocol-designer/steplist/actions'
 import {
   computeStepMove,
@@ -46,37 +50,22 @@ interface DraggableStepsProps {
  * terminal steps. The steps in here can be dragged and dropped to reorder them.
  */
 export function DraggableSteps(props: DraggableStepsProps): JSX.Element | null {
-  const enableConcurrentModuleActions = useSelector(
-    getEnableConcurrentModuleActions
-  )
   const { sidebarWidth } = props
   const [openedOverflowMenuId, setOpenedOverflowMenuId] = useState<
     string | null
   >(null)
 
-  const orderedSavedForms = useSelector(getOrderedSavedForms)
-  const orderedStepIds = orderedSavedForms.map(form => form.id)
-
-  // todo(mm, 2025-10-27): nestedSteps and findStepIndex probably ought to be Redux selectors, for efficiency.
-  const nestedSteps = convertStepArrayToHierarchy(
-    orderedSavedForms,
-    enableConcurrentModuleActions
-  )
-  // todo(mm, 2025-10-27): This implementation of findStepIndex returns the wrong number for steps that
-  // come after Thermocycler profiles, because it counts the invisible pause step. We want the numbering to
-  // skip over invisible steps.
-  const findStepIndex = (stepId: StepIdType): number =>
-    orderedStepIds.findIndex(id => stepId === id)
+  const stepHierarchy = useSelector(getSavedStepHierarchy)
+  const stepNumbers = useSelector(getUserVisibleStepNumbers)
 
   return (
     <Flex flexDirection={DIRECTION_COLUMN} width="100%">
-      {nestedSteps.topLevelItems.map(nestedStepElement => {
+      {stepHierarchy.topLevelItems.map(nestedStepElement => {
         if (nestedStepElement.type === 'standaloneStep') {
-          const index = findStepIndex(nestedStepElement.stepId)
           return (
             <DragDropStep
-              key={`${nestedStepElement.stepId}_${index}`}
-              stepNumber={index + 1}
+              key={`${nestedStepElement.stepId}`}
+              stepNumber={stepNumbers[nestedStepElement.stepId]}
               stepId={nestedStepElement.stepId}
               openedOverflowMenuId={openedOverflowMenuId}
               setOpenedOverflowMenuId={setOpenedOverflowMenuId}
@@ -96,7 +85,6 @@ export function DraggableSteps(props: DraggableStepsProps): JSX.Element | null {
               concurrentStepIds={nestedStepElement.concurrentSteps.map(
                 step => step.stepId
               )}
-              findStepIndex={findStepIndex}
               openedOverflowMenuId={openedOverflowMenuId}
               setOpenedOverflowMenuId={setOpenedOverflowMenuId}
               sidebarWidth={sidebarWidth}
@@ -116,7 +104,7 @@ interface DropType {
 
 interface ConnectedStepItemProps {
   stepId: StepIdType
-  stepNumber: number
+  stepNumber: number | null
   onStepContextMenu?: () => void
 }
 
@@ -241,8 +229,6 @@ interface ThermocyclerProfileProps {
   thermocyclerProfileStepId: StepIdType
   concurrentStepIds: StepIdType[]
 
-  findStepIndex: (stepId: StepIdType) => number
-
   openedOverflowMenuId?: string | null
   setOpenedOverflowMenuId?: Dispatch<SetStateAction<string | null>>
 
@@ -259,7 +245,6 @@ function ThermocyclerProfile(props: ThermocyclerProfileProps): JSX.Element {
   const {
     thermocyclerProfileStepId,
     concurrentStepIds,
-    findStepIndex,
     openedOverflowMenuId,
     setOpenedOverflowMenuId,
     sidebarWidth,
@@ -271,6 +256,7 @@ function ThermocyclerProfile(props: ThermocyclerProfileProps): JSX.Element {
     multiSelectItemIds != null && multiSelectItemIds.length > 0
       ? multiSelectItemIds.includes(thermocyclerProfileStepId)
       : selectedStepId === thermocyclerProfileStepId
+  const stepNumbers = useSelector(getUserVisibleStepNumbers)
 
   const { t } = useTranslation()
 
@@ -278,7 +264,7 @@ function ThermocyclerProfile(props: ThermocyclerProfileProps): JSX.Element {
     <div>
       <DragDropStep
         stepId={thermocyclerProfileStepId}
-        stepNumber={findStepIndex(thermocyclerProfileStepId) + 1}
+        stepNumber={stepNumbers[thermocyclerProfileStepId]}
         openedOverflowMenuId={openedOverflowMenuId}
         setOpenedOverflowMenuId={setOpenedOverflowMenuId}
         sidebarWidth={sidebarWidth}
@@ -302,7 +288,7 @@ function ThermocyclerProfile(props: ThermocyclerProfileProps): JSX.Element {
           <ConcurrentGroupChild key={concurrentStepId} type="step">
             <DragDropStep
               stepId={concurrentStepId}
-              stepNumber={findStepIndex(concurrentStepId) + 1}
+              stepNumber={stepNumbers[concurrentStepId]}
               openedOverflowMenuId={openedOverflowMenuId}
               setOpenedOverflowMenuId={setOpenedOverflowMenuId}
               sidebarWidth={sidebarWidth}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/PresavedStep.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/PresavedStep.tsx
@@ -21,7 +21,7 @@ export function PresavedStep({
 }: PresavedStepProps): JSX.Element | null {
   const { t } = useTranslation('application')
   const presavedStepForm = useSelector(stepFormSelectors.getPresavedStepForm)
-  const stepNumber = useSelector(stepFormSelectors.getOrderedStepIds).length + 1
+  const stepNumber = useSelector(stepFormSelectors.getNextUserVisibleStepNumber)
   const hovered = useSelector(getHoveredTerminalItemId) === PRESAVED_STEP_ID
   const selected = useSelector(getSelectedTerminalItemId) === PRESAVED_STEP_ID
   const dispatch = useDispatch()

--- a/protocol-designer/src/step-forms/selectors/index.ts
+++ b/protocol-designer/src/step-forms/selectors/index.ts
@@ -17,7 +17,11 @@ import {
 } from '@opentrons/shared-data'
 import { TEMPERATURE_DEACTIVATED } from '@opentrons/step-generation'
 
-import { convertStepArrayToHierarchy } from '/protocol-designer/steplist/utils/stepHierarchy'
+import { getStepVisibilities } from '/protocol-designer/steplist/utils/getStepVisibilities'
+import {
+  convertStepArrayToHierarchy,
+  convertStepHierarchyToArray,
+} from '/protocol-designer/steplist/utils/stepHierarchy'
 
 import { INITIAL_DECK_SETUP_STEP_ID } from '../../constants'
 import * as featureFlagSelectors from '../../feature-flags/selectors'
@@ -480,6 +484,45 @@ export const getSavedStepHierarchy: Selector<BaseState, StepHierarchy> =
       )
     }
   )
+
+/**
+ * A mapping from step IDs to the step's user-visible index in the timeline.
+ * This is more complicated than just .indexOf() because some steps are hidden and
+ * shouldn't be counted (see `StepHierarchy`).
+ *
+ * Hidden steps get a step number of `null`.
+ */
+export const getUserVisibleStepNumbers: Selector<
+  BaseState,
+  Record<StepIdType, number | null>
+> = createSelector(getSavedStepHierarchy, stepHierarchy => {
+  const visibilities = getStepVisibilities(stepHierarchy)
+  const allStepIdsAsFlatArray = convertStepHierarchyToArray(stepHierarchy)
+
+  const result: Record<StepIdType, number | null> = {}
+  let nextStepNumber = 1
+  for (const stepId of allStepIdsAsFlatArray) {
+    result[stepId] = visibilities[stepId].isVisibleToUser
+      ? nextStepNumber++
+      : null
+  }
+
+  return result
+})
+
+/** If a step is added to the end of the timeline, it will have this number. */
+export const getNextUserVisibleStepNumber: Selector<BaseState, number> =
+  createSelector(getUserVisibleStepNumbers, userVisibleStepNumbers => {
+    const isNonNull = (stepNumber: number | null): stepNumber is number =>
+      stepNumber !== null
+    const stepNumbers = Object.values(userVisibleStepNumbers)
+    return (
+      Math.max(
+        0, // In case there are no steps yet.
+        ...stepNumbers.filter(isNonNull)
+      ) + 1
+    )
+  })
 
 export const getCurrentFormHasUnsavedChanges: Selector<BaseState, boolean> =
   createSelector(

--- a/protocol-designer/src/step-forms/test/selectors.test.ts
+++ b/protocol-designer/src/step-forms/test/selectors.test.ts
@@ -1,10 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { StepHierarchy } from '/protocol-designer/steplist/utils/stepHierarchy'
+
 import {
   getBatchEditFormHasUnsavedChanges,
   getEquippedPipetteOptions,
+  getNextUserVisibleStepNumber,
   getUnsavedFormIsPristineHeaterShakerForm,
   getUnsavedFormIsPristineSetTempForm,
+  getUserVisibleStepNumbers,
 } from '../selectors'
 
 import type { FormData } from '../../form-types'
@@ -166,5 +170,52 @@ describe('getUnsavedFormIsPrestineSetHeaterShakerTempForm', () => {
       mockIsPresaved
     )
     expect(result).toEqual(expected)
+  })
+})
+
+describe('getUserVisibleStepNumbers() and getNextUserVisibleStepNumber()', () => {
+  it("should count steps, excluding hidden 'wait for Thermocycler profile' steps", () => {
+    const input: StepHierarchy = {
+      topLevelItems: [
+        { type: 'standaloneStep', stepId: 'a' },
+        {
+          type: 'thermocyclerProfileGroup',
+          thermocyclerProfileStepId: 'b',
+          concurrentSteps: [{ type: 'standaloneStep', stepId: 'c' }],
+          waitForThermocyclerProfileStepId: 'd',
+        },
+        { type: 'standaloneStep', stepId: 'e' },
+      ],
+    }
+
+    // @ts-expect-error(mm, 2025-11-14): resultFunc (from reselect) is not part of their Selector interface
+    const stepNumbersResult = getUserVisibleStepNumbers.resultFunc(input)
+    const nextStepNumberResult =
+      // @ts-expect-error(mm, 2025-11-14): resultFunc (from reselect) is not part of their Selector interface
+      getNextUserVisibleStepNumber.resultFunc(stepNumbersResult)
+
+    expect(stepNumbersResult).toStrictEqual({
+      a: 1,
+      b: 2,
+      c: 3,
+      d: null,
+      e: 4,
+    })
+    expect(nextStepNumberResult).toStrictEqual(5)
+  })
+
+  it('should tolerate empty input', () => {
+    const input: StepHierarchy = {
+      topLevelItems: [],
+    }
+
+    // @ts-expect-error(mm, 2025-11-14): resultFunc (from reselect) is not part of their Selector interface
+    const stepNumbersResult = getUserVisibleStepNumbers.resultFunc(input)
+    const nextStepNumberResult =
+      // @ts-expect-error(mm, 2025-11-14): resultFunc (from reselect) is not part of their Selector interface
+      getNextUserVisibleStepNumber.resultFunc(stepNumbersResult)
+
+    expect(stepNumbersResult).toStrictEqual({})
+    expect(nextStepNumberResult).toStrictEqual(1)
   })
 })

--- a/protocol-designer/src/step-forms/test/selectors.test.ts
+++ b/protocol-designer/src/step-forms/test/selectors.test.ts
@@ -1,7 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { StepHierarchy } from '/protocol-designer/steplist/utils/stepHierarchy'
-
 import {
   getBatchEditFormHasUnsavedChanges,
   getEquippedPipetteOptions,
@@ -11,6 +9,7 @@ import {
   getUserVisibleStepNumbers,
 } from '../selectors'
 
+import type { StepHierarchy } from '/protocol-designer/steplist/utils/stepHierarchy'
 import type { FormData } from '../../form-types'
 
 vi.mock('../../steplist/fieldLevel')

--- a/protocol-designer/src/steplist/test/getStepVisibilities.test.ts
+++ b/protocol-designer/src/steplist/test/getStepVisibilities.test.ts
@@ -40,4 +40,3 @@ describe('getStepVisibilities()', () => {
     expect(result).toStrictEqual({})
   })
 })
-

--- a/protocol-designer/src/steplist/test/getStepVisibilities.test.ts
+++ b/protocol-designer/src/steplist/test/getStepVisibilities.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+
+import { getStepVisibilities } from '../utils/getStepVisibilities'
+
+import type { StepHierarchy } from '../utils/stepHierarchy'
+
+describe('getStepVisibilities()', () => {
+  it('should mark Thermocycler profile wait steps as invisible', () => {
+    const input: StepHierarchy = {
+      topLevelItems: [
+        { type: 'standaloneStep', stepId: 'a' },
+        {
+          type: 'thermocyclerProfileGroup',
+          thermocyclerProfileStepId: 'b',
+          concurrentSteps: [{ type: 'standaloneStep', stepId: 'c' }],
+          waitForThermocyclerProfileStepId: 'd',
+        },
+        { type: 'standaloneStep', stepId: 'e' },
+      ],
+    }
+
+    const result = getStepVisibilities(input)
+
+    expect(result).toStrictEqual({
+      a: { isVisibleToUser: true },
+      b: { isVisibleToUser: true },
+      c: { isVisibleToUser: true },
+      d: { isVisibleToUser: false },
+      e: { isVisibleToUser: true },
+    })
+  })
+
+  it('should tolerate empty input', () => {
+    const input: StepHierarchy = {
+      topLevelItems: [],
+    }
+
+    const result = getStepVisibilities(input)
+
+    expect(result).toStrictEqual({})
+  })
+})
+

--- a/protocol-designer/src/steplist/utils/getStepToSelectAfterDeletion.ts
+++ b/protocol-designer/src/steplist/utils/getStepToSelectAfterDeletion.ts
@@ -1,3 +1,6 @@
+import { getStepVisibilities } from './getStepVisibilities'
+import { convertStepHierarchyToArray } from './stepHierarchy'
+
 import type { StepIdType } from '/protocol-designer/form-types'
 import type { StepHierarchy } from './stepHierarchy'
 
@@ -16,59 +19,24 @@ export function getStepToSelectAfterDeletion(
   originalStepHierarchy: StepHierarchy,
   stepsToDelete: Set<StepIdType>
 ): StepIdType | null {
-  const flatSteps = getFlatSteps(originalStepHierarchy)
-  const highestDeletedIndex = flatSteps.findLastIndex(value =>
-    stepsToDelete.has(value.stepId)
+  const flatStepIds = convertStepHierarchyToArray(originalStepHierarchy)
+  const visibilities = getStepVisibilities(originalStepHierarchy)
+  const highestDeletedIndex = flatStepIds.findLastIndex(stepId =>
+    stepsToDelete.has(stepId)
   )
   if (highestDeletedIndex === -1) {
     return null
   }
 
-  const stepIsSelectable = (step: Step): boolean =>
-    step.isVisibleToUser && !stepsToDelete.has(step.stepId)
+  const stepIsSelectable = (stepId: StepIdType): boolean =>
+    visibilities[stepId].isVisibleToUser && !stepsToDelete.has(stepId)
 
-  const nextSelectable = flatSteps
+  const nextSelectableId = flatStepIds
     .slice(highestDeletedIndex + 1)
     .find(stepIsSelectable)
-  const prevSelectable = flatSteps
+  const prevSelectableId = flatStepIds
     .slice(0, highestDeletedIndex)
     .findLast(stepIsSelectable)
 
-  return nextSelectable?.stepId ?? prevSelectable?.stepId ?? null
-}
-
-interface Step {
-  stepId: StepIdType
-  /**
-   * Thermocycler profiles have an implicit "wait for profile to complete" step at the
-   * end, not shown in the UI. This is `false` for steps like that. See `StepHierarchy`.
-   */
-  isVisibleToUser: boolean
-}
-
-function getFlatSteps(stepHierarchy: StepHierarchy): Step[] {
-  const getStepsContainedInTopLevelItem = (
-    topLevelItem: StepHierarchy['topLevelItems'][number]
-  ): Step[] => {
-    switch (topLevelItem.type) {
-      case 'standaloneStep':
-        return [{ stepId: topLevelItem.stepId, isVisibleToUser: true }]
-      case 'thermocyclerProfileGroup':
-        return [
-          {
-            stepId: topLevelItem.thermocyclerProfileStepId,
-            isVisibleToUser: true,
-          },
-          ...topLevelItem.concurrentSteps.map(step => ({
-            stepId: step.stepId,
-            isVisibleToUser: true,
-          })),
-          {
-            stepId: topLevelItem.waitForThermocyclerProfileStepId,
-            isVisibleToUser: false,
-          },
-        ]
-    }
-  }
-  return stepHierarchy.topLevelItems.flatMap(getStepsContainedInTopLevelItem)
+  return nextSelectableId ?? prevSelectableId ?? null
 }

--- a/protocol-designer/src/steplist/utils/getStepVisibilities.ts
+++ b/protocol-designer/src/steplist/utils/getStepVisibilities.ts
@@ -1,0 +1,45 @@
+import type { StepIdType } from '/protocol-designer/form-types'
+import type { StepHierarchy } from './stepHierarchy'
+
+interface StepVisibilities {
+  [key: StepIdType]: {
+    isVisibleToUser: boolean
+  }
+}
+
+/**
+ * Certain steps exist internally in state but are never shown to the user;
+ * they're managed implicitly by the system. e.g. Thermocycler profile steps are
+ * permanently paired with implicit "wait for profile" steps.
+ *
+ * This returns which steps are visible and which ones are invisible.
+ *
+ * This needs to stay in sync with what our React code actually renders.
+ */
+export function getStepVisibilities(
+  stepHierarchy: StepHierarchy
+): StepVisibilities {
+  return Object.fromEntries([...yieldStepVisibilities(stepHierarchy)])
+}
+
+function* yieldStepVisibilities(
+  stepHierarchy: StepHierarchy
+): Generator<[StepIdType, StepVisibilities[StepIdType]]> {
+  for (const topLevelItem of stepHierarchy.topLevelItems) {
+    if (topLevelItem.type === 'standaloneStep') {
+      yield [topLevelItem.stepId, { isVisibleToUser: true }]
+    } else if (topLevelItem.type === 'thermocyclerProfileGroup') {
+      yield [topLevelItem.thermocyclerProfileStepId, { isVisibleToUser: true }]
+      for (const concurrentStep of topLevelItem.concurrentSteps) {
+        concurrentStep.type satisfies 'standaloneStep'
+        yield [concurrentStep.stepId, { isVisibleToUser: true }]
+      }
+      yield [
+        topLevelItem.waitForThermocyclerProfileStepId,
+        { isVisibleToUser: false },
+      ]
+    } else {
+      topLevelItem satisfies never
+    }
+  }
+}

--- a/protocol-designer/src/types.ts
+++ b/protocol-designer/src/types.ts
@@ -1,4 +1,3 @@
-import type { OutputSelector } from 'reselect'
 import type { FC } from 'react'
 import type {
   HEATERSHAKER_MODULE_TYPE,
@@ -34,7 +33,6 @@ export interface BaseState {
 }
 export type GetState = () => BaseState
 export type Selector<T> = (arg: BaseState) => T
-export type MemoizedSelector<T> = OutputSelector<BaseState, void, T>
 // eslint-disable-next-line no-use-before-define
 export type ThunkDispatch<A> = (action: A | ThunkAction<A>) => A
 


### PR DESCRIPTION
## Overview

In internal state, concurrent Thermocycler profiles are represented like:

```
1. Start profile
2. Do concurrent steps
3. Wait for profile to complete
4. Do more stuff
```

But in the timeline UI, it looks more like:

```
1. Start profile
  2. Do concurrent steps
3. Do more stuff
```

This discrepancy caused a visual bug (unreleased, only in the concurrent module actions work in progress), where we were rendering it like:

```
1. Start profile
  2. Do concurrent steps
4. Do more stuff <-- skipped step 3 :(
```

This PR fixes that, closing EXEC-2025.

## Test Plan and Hands on Testing

1. Import [tc_dnd_demo.py](https://github.com/user-attachments/files/23195273/tc_dnd_demo.py).
6. Turn the "Enable concurrent module actions" feature flag on.
7. Drag steps around and make sure the numbering is correct.
8. Create a new step. While its form is open, before saving the form, check the number of the new step in the timeline to make sure it's correct.

## Changelog

* Pull the logic to get a given step's "user-visible index" into a Redux selector.
* Fix the logic so that it doesn't count "invisible" steps.

## Review requests

None in particular.

## Risk assessment

Low.
