### PR TITLE
fix(app): fix resizable cols style to align with the design

### DIFF
--- a/app/src/organisms/Desktop/ProtocolVisualization/Controls/controls.module.css
+++ b/app/src/organisms/Desktop/ProtocolVisualization/Controls/controls.module.css
@@ -75,13 +75,14 @@
   position: relative;
   height: var(--spacing-4);
   border-radius: var(--border-radius-2);
-  background: linear-gradient(
-    to right,
-    var(--blue-50) 0%,
-    var(--blue-50) var(--progress, 0%),
-    #ccc var(--progress, 0%),
-    #ccc 100%
-  );
+  background:
+    linear-gradient(
+      to right,
+      var(--blue-50) 0%,
+      var(--blue-50) var(--progress, 0%),
+      #ccc var(--progress, 0%),
+      #ccc 100%
+    );
 }
 
 .range_input::-webkit-slider-thumb {
@@ -97,13 +98,14 @@
 .range_input::-moz-range-track {
   height: var(--spacing-4);
   border-radius: var(--border-radius-2);
-  background: linear-gradient(
-    to right,
-    var(--blue-50) 0%,
-    var(--blue-50) var(--progress, 0%),
-    #ccc var(--progress, 0%),
-    #ccc 100%
-  );
+  background:
+    linear-gradient(
+      to right,
+      var(--blue-50) 0%,
+      var(--blue-50) var(--progress, 0%),
+      #ccc var(--progress, 0%),
+      #ccc 100%
+    );
 }
 
 .range_input::-moz-range-thumb {

--- a/app/src/organisms/Desktop/ProtocolVisualization/Controls/controls.module.css
+++ b/app/src/organisms/Desktop/ProtocolVisualization/Controls/controls.module.css
@@ -1,5 +1,5 @@
 .container {
-  padding: 0 var(--spacing-16) var(--spacing-16);
+  padding: 0 0 var(--spacing-16);
 }
 
 .controls_container {
@@ -75,14 +75,13 @@
   position: relative;
   height: var(--spacing-4);
   border-radius: var(--border-radius-2);
-  background:
-    linear-gradient(
-      to right,
-      var(--blue-50) 0%,
-      var(--blue-50) var(--progress, 0%),
-      #ccc var(--progress, 0%),
-      #ccc 100%
-    );
+  background: linear-gradient(
+    to right,
+    var(--blue-50) 0%,
+    var(--blue-50) var(--progress, 0%),
+    #ccc var(--progress, 0%),
+    #ccc 100%
+  );
 }
 
 .range_input::-webkit-slider-thumb {
@@ -98,14 +97,13 @@
 .range_input::-moz-range-track {
   height: var(--spacing-4);
   border-radius: var(--border-radius-2);
-  background:
-    linear-gradient(
-      to right,
-      var(--blue-50) 0%,
-      var(--blue-50) var(--progress, 0%),
-      #ccc var(--progress, 0%),
-      #ccc 100%
-    );
+  background: linear-gradient(
+    to right,
+    var(--blue-50) 0%,
+    var(--blue-50) var(--progress, 0%),
+    #ccc var(--progress, 0%),
+    #ccc 100%
+  );
 }
 
 .range_input::-moz-range-thumb {

--- a/app/src/pages/Desktop/Protocols/ProtocolVisualization/VisualizerContainer.tsx
+++ b/app/src/pages/Desktop/Protocols/ProtocolVisualization/VisualizerContainer.tsx
@@ -25,10 +25,11 @@ import type { GroupedCommands } from '/app/redux/protocol-storage'
 
 const INITIAL_MILLISECONDS_PER_FRAME = 2000
 const INITIAL_WIDTH_PX = 230
-const MIN_CENTER_WIDTH_PX = 200
-const MIN_COLUMN_WIDTH_PX = 100
-const MAX_COLUMN_WIDTH_PX = 400
-const CONTAINER_PADDING_PX = 32 // 16px * 2
+const MIN_CENTER_WIDTH_PX = 148
+const MIN_LEFT_COLUMN_WIDTH_PX = 148
+const MIN_RIGHT_COLUMN_WIDTH_PX = 172
+const MAX_COLUMN_WIDTH_PX = 600
+const GUTTER_WIDTH_PX = 16 // left and right gutters
 
 type ResizableColumn = 'left' | 'right'
 
@@ -38,6 +39,7 @@ interface VisualizerContainerProps {
   protocolKey: string
   srcFileNames: string[]
 }
+
 export function VisualizerContainer(
   props: VisualizerContainerProps
 ): JSX.Element {
@@ -49,10 +51,12 @@ export function VisualizerContainer(
   const [milliSecondsPerFrame, setMilliSecondsPerFrame] = useState<number>(
     INITIAL_MILLISECONDS_PER_FRAME
   )
+  const [isDragging, setIsDragging] = useState<boolean>(false)
 
   const [selectedCommandId, setSelectedCommand] = useState<string | null>(
     commands[0]?.id ?? null
   )
+
   // for resizable columns
   const [leftWidth, setLeftWidth] = useState<number>(INITIAL_WIDTH_PX)
   const [rightWidth, setRightWidth] = useState<number>(INITIAL_WIDTH_PX)
@@ -62,6 +66,7 @@ export function VisualizerContainer(
   const startWidthRef = useRef<number>(0)
   const leftWidthRef = useRef<number>(leftWidth)
   const rightWidthRef = useRef<number>(rightWidth)
+
   useEffect(() => {
     leftWidthRef.current = leftWidth
   }, [leftWidth])
@@ -153,6 +158,7 @@ export function VisualizerContainer(
     column: ResizableColumn
   ): void => {
     e.preventDefault()
+    setIsDragging(true)
     resizingRef.current = column
     startXRef.current = e.clientX
     startWidthRef.current = column === 'left' ? leftWidth : rightWidth
@@ -173,10 +179,10 @@ export function VisualizerContainer(
       const newWidth = startWidthRef.current + deltaX
       // calculate the remaining width of the center column
       const centerWidth =
-        containerWidth - newWidth - rightWidthRef.current - CONTAINER_PADDING_PX
+        containerWidth - newWidth - rightWidthRef.current - 2 * GUTTER_WIDTH_PX
 
       if (
-        newWidth >= MIN_COLUMN_WIDTH_PX &&
+        newWidth >= MIN_LEFT_COLUMN_WIDTH_PX &&
         newWidth <= MAX_COLUMN_WIDTH_PX &&
         centerWidth >= MIN_CENTER_WIDTH_PX
       ) {
@@ -185,10 +191,10 @@ export function VisualizerContainer(
     } else if (resizingRef.current === 'right') {
       const newWidth = startWidthRef.current - deltaX
       const centerWidth =
-        containerWidth - leftWidthRef.current - newWidth - CONTAINER_PADDING_PX
+        containerWidth - leftWidthRef.current - newWidth - 2 * GUTTER_WIDTH_PX
 
       if (
-        newWidth >= MIN_COLUMN_WIDTH_PX &&
+        newWidth >= MIN_RIGHT_COLUMN_WIDTH_PX &&
         newWidth <= MAX_COLUMN_WIDTH_PX &&
         centerWidth >= MIN_CENTER_WIDTH_PX
       ) {
@@ -197,7 +203,8 @@ export function VisualizerContainer(
     }
   }, [])
 
-  const handleMouseUp = useCallback(() => {
+  const handleMouseUp = useCallback((): void => {
+    setIsDragging(false)
     resizingRef.current = null
     window.removeEventListener('mousemove', handleMouseMove)
     window.removeEventListener('mouseup', handleMouseUp)
@@ -232,16 +239,14 @@ export function VisualizerContainer(
             setIsPlaying(false)
           }}
         />
-        {/* Left column resizer */}
-        <div
-          className={`${styles.resizer} ${styles.resizer_right}`}
-          onMouseDown={(e: MouseEvent<HTMLDivElement>) => {
-            handleMouseDown(e, 'left')
-          }}
-        />
       </div>
-
-      {/* Center Column is not resizable the width will be changed by the left and right column */}
+      {/* Gutter between left & center */}
+      <div
+        className={`${styles.gutter} ${isDragging ? styles.grabbing : ''}`}
+        onMouseDown={(e: MouseEvent<HTMLDivElement>) => {
+          handleMouseDown(e, 'left')
+        }}
+      />
       <div className={styles.center_column}>
         <Controls
           protocolName={protocolDisplayName}
@@ -292,15 +297,15 @@ export function VisualizerContainer(
           selectedRunTimeCommand={selectedRunTimeCommand}
         />
       </div>
+      {/* Gutter between center & right */}
+      <div
+        className={`${styles.gutter} ${isDragging ? styles.grabbing : ''}`}
+        onMouseDown={(e: MouseEvent<HTMLDivElement>) => {
+          handleMouseDown(e, 'right')
+        }}
+      />
       {/* Right Column is resizable */}
       <div className={styles.right_column} style={{ width: `${rightWidth}px` }}>
-        {/* Right column resizer */}
-        <div
-          className={`${styles.resizer} ${styles.resizer_left}`}
-          onMouseDown={(e: MouseEvent<HTMLDivElement>) => {
-            handleMouseDown(e, 'right')
-          }}
-        />
         {selectedRunTimeCommand != null ? (
           <StepDetailContainer
             protocolKey={protocolKey}

--- a/app/src/pages/Desktop/Protocols/ProtocolVisualization/visualization.module.css
+++ b/app/src/pages/Desktop/Protocols/ProtocolVisualization/visualization.module.css
@@ -186,7 +186,6 @@
 
 .deck_view_padding {
   height: 100%;
-  padding: 0 var(--spacing-12);
 }
 
 .align_deck_modules {

--- a/app/src/pages/Desktop/Protocols/ProtocolVisualization/visualizercontainer.module.css
+++ b/app/src/pages/Desktop/Protocols/ProtocolVisualization/visualizercontainer.module.css
@@ -34,24 +34,35 @@
   overflow-y: auto;
 }
 
-.resizer {
+.gutter {
+  position: relative;
+  flex-shrink: 0;
+  width: 1rem; /* 16px: align with GUTTER_WIDTH_PX */
+}
+
+/* line when hovering */
+.gutter::before {
+  content: '';
   position: absolute;
-  z-index: 1;
-  top: 0;
-  bottom: 0;
-  width: 8px;
-  cursor: col-resize;
+  top: var(--spacing-8);
+  bottom: var(--spacing-8);
+  left: 50%;
+  width: 2px;
+  transform: translateX(-50%);
+  border-radius: 9999px;
+  background-color: transparent;
   transition: background-color 0.2s;
 }
 
-.resizer:hover {
-  background-color: var(--blue-50);
+.gutter:hover {
+  cursor: grab;
 }
 
-.resizer_right {
-  right: -4px;
+.gutter:hover::before {
+  background-color: var(--grey-40);
 }
 
-.resizer_left {
-  left: -4px;
+.gutter.grabbing,
+.gutter.grabbing:hover {
+  cursor: grabbing;
 }

--- a/app/src/pages/Desktop/Protocols/ProtocolVisualization/visualizercontainer.module.css
+++ b/app/src/pages/Desktop/Protocols/ProtocolVisualization/visualizercontainer.module.css
@@ -47,7 +47,7 @@
   top: var(--spacing-8);
   bottom: var(--spacing-8);
   left: 50%;
-  width: 2px;
+  width: 1px;
   transform: translateX(-50%);
   border-radius: 9999px;
   background-color: transparent;

--- a/app/src/pages/Desktop/Protocols/ProtocolVisualization/visualizercontainer.module.css
+++ b/app/src/pages/Desktop/Protocols/ProtocolVisualization/visualizercontainer.module.css
@@ -43,13 +43,13 @@
 /* line when hovering */
 .gutter::before {
   position: absolute;
-  content: '';
   top: var(--spacing-8);
   bottom: var(--spacing-8);
   left: 50%;
   width: 1px;
-  transform: translateX(-50%);
   background-color: transparent;
+  content: '';
+  transform: translateX(-50%);
   transition: background-color 0.2s;
 }
 

--- a/app/src/pages/Desktop/Protocols/ProtocolVisualization/visualizercontainer.module.css
+++ b/app/src/pages/Desktop/Protocols/ProtocolVisualization/visualizercontainer.module.css
@@ -36,20 +36,19 @@
 
 .gutter {
   position: relative;
-  flex-shrink: 0;
   width: 1rem; /* 16px: align with GUTTER_WIDTH_PX */
+  flex-shrink: 0;
 }
 
 /* line when hovering */
 .gutter::before {
-  content: '';
   position: absolute;
+  content: '';
   top: var(--spacing-8);
   bottom: var(--spacing-8);
   left: 50%;
   width: 1px;
   transform: translateX(-50%);
-  border-radius: 9999px;
   background-color: transparent;
   transition: background-color 0.2s;
 }


### PR DESCRIPTION


# Overview
fix resizable cols style to align with the design



https://github.com/user-attachments/assets/504205c2-fca5-4b23-b276-bfe09a6c4429



close RUXD-2623


## Test Plan and Hands on Testing
- open the Desktop app
- select a protocol and click it
- click `Visualize` button
- move mouse the space between the left col and the center col or between the center col and the right col


## Changelog
- update VisualizeContainer and its CSS
- modify the left and right col min-width


## Review requests


## Risk assessment
low