### PR TITLE
fix(step-generation): pass `trash_location` arg if return tip and blowout

### DIFF
--- a/step-generation/src/__tests__/distribute.test.ts
+++ b/step-generation/src/__tests__/distribute.test.ts
@@ -2278,6 +2278,7 @@ mock_pipette.distribute_with_liquid_class(
     dest=[mock_dest_plate["A2"], mock_dest_plate["A3"], mock_dest_plate["A4"]],
     new_tip="always",
     return_tip=True,
+    trash_location=trash_bin_1,
     tip_racks=[mock_tip_rack_1, mock_tip_rack_2],
     liquid_class=protocol.define_liquid_class(
         name="distribute_step_1",
@@ -2378,6 +2379,7 @@ mock_pipette.distribute_with_liquid_class(
     dest=[mock_dest_plate["A2"], mock_dest_plate["A3"], mock_dest_plate["A4"]],
     new_tip="always",
     return_tip=True,
+    trash_location=trash_bin_1,
     tip_racks=[mock_tip_rack_1, mock_tip_rack_2],
     liquid_class=protocol.define_liquid_class(
         name="distribute_step_1",

--- a/step-generation/src/commandCreators/compound/consolidate.ts
+++ b/step-generation/src/commandCreators/compound/consolidate.ts
@@ -370,6 +370,11 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
   const trashPipetteName =
     trashBinEntities[dropTipLocation]?.pythonName ??
     wasteChuteEntities[dropTipLocation]?.pythonName
+  const blowoutTrashPythonName =
+    blowoutLocation == null
+      ? null
+      : (trashBinEntities[blowoutLocation]?.pythonName ??
+        wasteChuteEntities[blowoutLocation]?.pythonName)
   const sourceLabwarePythonName = labwareEntities[sourceLabware].pythonName
   const destLabwarePythonName = labwareEntities[destLabware]?.pythonName
   const pythonSourceWells = sourceWells
@@ -433,8 +438,13 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
     }`,
     `new_tip=${formatPyStr(formatChangeTipArg(changeTip))}`,
     ...(isReturnTip
-      ? [`return_tip=True`]
-      : [`trash_location=${trashPipetteName}`, `keep_last_tip=True`]),
+      ? [
+          'return_tip=True',
+          ...(blowoutTrashPythonName != null
+            ? [`trash_location=${blowoutTrashPythonName}`]
+            : []),
+        ]
+      : [`trash_location=${trashPipetteName}`, 'keep_last_tip=True']),
     ...(pipetteSpecs.channels > 1 ? [`group_wells=False`] : []),
     ...(tipracks.filteredSortedTiprackIds.length > 0
       ? [

--- a/step-generation/src/commandCreators/compound/distribute.ts
+++ b/step-generation/src/commandCreators/compound/distribute.ts
@@ -416,6 +416,11 @@ export const distribute: CommandCreator<DistributeArgs> = (
   const trashPipetteName =
     trashBinEntities[dropTipLocation]?.pythonName ??
     wasteChuteEntities[dropTipLocation]?.pythonName
+  const blowoutTrashPythonName =
+    blowoutLocation == null
+      ? null
+      : (trashBinEntities[blowoutLocation]?.pythonName ??
+        wasteChuteEntities[blowoutLocation]?.pythonName)
   const sourceLabwarePythonName = labwareEntities[sourceLabware].pythonName
   const destLabwarePythonName = labwareEntities[destLabware]?.pythonName
   const pythonSourceWells = `${sourceLabwarePythonName}[${formatPyStr(
@@ -476,8 +481,13 @@ export const distribute: CommandCreator<DistributeArgs> = (
     `dest=[${pythonDestWells ?? destTrashPipetteName}]`,
     `new_tip=${formatPyStr(formatChangeTipArg(changeTip))}`,
     ...(isReturnTip
-      ? [`return_tip=True`]
-      : [`trash_location=${trashPipetteName}`, `keep_last_tip=True`]),
+      ? [
+          'return_tip=True',
+          ...(blowoutTrashPythonName != null
+            ? [`trash_location=${blowoutTrashPythonName}`]
+            : []),
+        ]
+      : [`trash_location=${trashPipetteName}`, 'keep_last_tip=True']),
     ...(pipetteSpecs.channels > 1 ? [`group_wells=False`] : []),
     ...(tipracks.filteredSortedTiprackIds.length > 0
       ? [

--- a/step-generation/src/commandCreators/compound/transfer.ts
+++ b/step-generation/src/commandCreators/compound/transfer.ts
@@ -412,6 +412,11 @@ export const transfer: CommandCreator<TransferArgs> = (
   const trashPipetteName =
     trashBinEntities[dropTipLocation]?.pythonName ??
     wasteChuteEntities[dropTipLocation]?.pythonName
+  const blowoutTrashPythonName =
+    blowoutLocation == null
+      ? null
+      : (trashBinEntities[blowoutLocation]?.pythonName ??
+        wasteChuteEntities[blowoutLocation]?.pythonName)
   const sourceLabwarePythonName = labwareEntities[sourceLabware].pythonName
   const destLabwarePythonName = labwareEntities[destLabware]?.pythonName
   const pythonSourceWells = sourceWells
@@ -477,8 +482,13 @@ export const transfer: CommandCreator<TransferArgs> = (
     }`,
     `new_tip=${formatPyStr(formatChangeTipArg(changeTip))}`,
     ...(isReturnTip
-      ? [`return_tip=True`]
-      : [`trash_location=${trashPipetteName}`, `keep_last_tip=True`]),
+      ? [
+          'return_tip=True',
+          ...(blowoutTrashPythonName != null
+            ? [`trash_location=${blowoutTrashPythonName}`]
+            : []),
+        ]
+      : [`trash_location=${trashPipetteName}`, 'keep_last_tip=True']),
     ...(pipetteSpecs.channels > 1 ? [`group_wells=False`] : []),
     ...(tipracks.filteredSortedTiprackIds.length > 0
       ? [


### PR DESCRIPTION
# Overview

If a user specifies 1) return tip with 2) blowout enabled 3) in a trash-like entity, we need to pass a `trash_location` Python arg accordingly.

## Test Plan and Hands on Testing

- create a moveLiquid step form that returns tip to tiprack and also specifies a blowout into a trash bin/waste chute
- export and verify that the selected blowout location's Python name populates the emitted `trash_location` arg

## Changelog

- add logic for emitting Python `trash_location` arg if returning tip and blowout occurs in trash-like entity to `distribute`, `consolidate`, and `transfer`
- update tests

## Review requests

see test plan

## Risk assessment

lowish