### PR TITLE
docs: revise Flex manual text on pipette tip sterility

### DIFF
--- a/docs/flex/docs/labware/types.md
+++ b/docs/flex/docs/labware/types.md
@@ -59,7 +59,7 @@ Opentrons Flex tips come in racks that hold 96 tips. Currently, we offer tips in
 
 ### Tip sterility
 
-Sealed, unopened packages of Opentrons pipette tips are certified to be free of contaminants and sterilized based on ANSI/AAMI/ISO 11137 standards with irradiation at a Sterility Assurance Level (SAL) of 10<sup>-6</sup>. Each package of tips ships with a letter describing our test procedures and certifies that each lot of tips are free of common contaminants such as DNase/RNase, endotoxins (Pyrogens), human DNA, PCR inhibitors, and protease.
+Sealed, unopened packages of Opentrons pipette tips are certified to be free of contaminants. Tips are sterilized based on ANSI/AAMI/ISO 11137 standard with irradiation at a Sterility Assurance Level (SAL) of 10<sup>-6</sup>. Each package includes a letter describing our test procedures and certifies that every lot is free of common contaminants such as DNase/RNase, endotoxins (Pyrogens), human DNA, PCR inhibitors, and protease.
 
 ### Tip racks 
 

--- a/docs/flex/docs/labware/types.md
+++ b/docs/flex/docs/labware/types.md
@@ -59,7 +59,7 @@ Opentrons Flex tips come in racks that hold 96 tips. Currently, we offer tips in
 
 ### Tip sterility
 
-Sealed, unopened packages of Opentrons pipette tips are certified to be free of contaminants. Tips are sterilized based on ANSI/AAMI/ISO 11137 standard with irradiation at a Sterility Assurance Level (SAL) of 10<sup>-6</sup>. Each package includes a letter describing our test procedures and certifies that every lot is free of common contaminants such as DNase/RNase, endotoxins (Pyrogens), human DNA, PCR inhibitors, and protease.
+Sealed, unopened packages of Opentrons pipette tips are certified to be free of contaminants. Tips are sterilized based on ANSI/AAMI/ISO 11137 standards with irradiation at a Sterility Assurance Level (SAL) of 10<sup>-6</sup>. Each package includes a letter describing our test procedures and certifies that every lot is free of common contaminants such as DNase/RNase, endotoxins (Pyrogens), human DNA, PCR inhibitors, and protease.
 
 ### Tip racks 
 

--- a/docs/flex/docs/labware/types.md
+++ b/docs/flex/docs/labware/types.md
@@ -55,13 +55,17 @@ For a full example of a well plate lid, reference the [Opentrons Tough PCR Auto-
 
 ## Tips and tip racks 
 
-Opentrons Flex tips come in 50 µL, 200 µL, and 1000 µL sizes. These are clear, non-conducting polypropylene tips that are available with or without filters. They're packaged sterile in racks that hold 96 tips and are free of DNase, RNase, protease, pyrogens, human DNA, endotoxins, and PCR inhibitors. Racks also include lot numbers and expiration dates. 
+Opentrons Flex tips come in racks that hold 96 tips. Currently, we offer tips in 50 µL, 200 µL, and 1000 µL sizes. These are clear, non-conducting polypropylene tips that are available with or without filters.
+
+### Tip sterility
+
+Sealed, unopened packages of Opentrons pipette tips are certified to be free of contaminants and sterilized based on ANSI/AAMI/ISO 11137 standards with irradiation at a Sterility Assurance Level (SAL) of 10<sup>-6</sup>. Each package of tips ships with a letter describing our test procedures and certifies that each lot of tips are free of common contaminants such as DNase/RNase, endotoxins (Pyrogens), human DNA, PCR inhibitors, and protease.
 
 ### Tip racks 
 
 Unfiltered and filtered tips are bundled into a rack that consists of a reusable base plate, a mid-plate that holds 96 tips, and a lid. 
 
-To help with identification, the tip rack mid-plates are color coded based on tip size: 
+To help with identification, each tip rack package includes an 8-digit lot number in YYYYMMDD format, which reflects the production date. Opentrons recommends using sealed tips within three years from the production date. Additionally, racks are color coded based on the maximum rated volume for each tip type: 
 
 - 50 µL: magenta 
 - 200 µL: yellow 

--- a/docs/flex/docs/labware/types.md
+++ b/docs/flex/docs/labware/types.md
@@ -59,7 +59,7 @@ Opentrons Flex tips come in racks that hold 96 tips. Currently, we offer tips in
 
 ### Tip sterility
 
-Sealed, unopened packages of Opentrons pipette tips are certified to be free of contaminants. Tips are sterilized based on ANSI/AAMI/ISO 11137 standards with irradiation at a Sterility Assurance Level (SAL) of 10<sup>-6</sup>. Each package includes a letter describing our test procedures and certifies that every lot is free of common contaminants such as DNase/RNase, endotoxins (Pyrogens), human DNA, PCR inhibitors, and protease.
+Sealed, unopened packages of Opentrons pipette tips are certified to be free of contaminants. Tips are sterilized based on ANSI/AAMI/ISO 11137 standards with irradiation at a Sterility Assurance Level (SAL) of 10<sup>-6</sup>. Each package includes a letter describing our test procedures and certifies that every lot is free of common contaminants such as DNase, RNase, endotoxins (pyrogens), human DNA, PCR inhibitors, and protease.
 
 ### Tip racks 
 


### PR DESCRIPTION
# Overview

Changes to the sterility certification that ships with our pipette tips could help improve related text in the Flex manual. This is in Labware > Labware types > Tips and tip racks.

The proposed changes here do some small reorganization and improve clarity about our sterility specs based on the revised sterility cert (linked in jira below).

Sandbox: https://sandbox.docs.opentrons.com/docs-pipette-tip-sterility/

RTC-868

## Test Plan and Hands on Testing

Read for accuracy, clarity.

## Changelog

Changes `types.md`, specifically revises the "Tips and tip racks" intro and adds H3s with more technical detail about sterility practices.

## Review requests

Do these changes seem reasonable and helpful?

## Risk assessment

Low, minor revisions to existing content.
