### PR TITLE
fix(robot-server): delete input/output data file associations when removing runs

### DIFF
--- a/robot-server/robot_server/runs/run_store.py
+++ b/robot-server/robot_server/runs/run_store.py
@@ -35,6 +35,8 @@ from robot_server.persistence.tables import (
     run_command_table,
     action_table,
     run_csv_rtp_table,
+    input_data_files_table,
+    output_data_files_table,
 )
 from robot_server.persistence.pydantic import (
     json_to_pydantic,
@@ -684,14 +686,7 @@ class RunStore:
         return _parse_command(command)
 
     def remove(self, run_id: str) -> None:
-        """Remove a run by its unique identifier.
-
-        Arguments:
-            run_id: The run's unique identifier.
-
-        Raises:
-            RunNotFoundError: The specified run ID was not found.
-        """
+        """Remove a run by its unique identifier."""
         delete_run = sqlalchemy.delete(run_table).where(run_table.c.id == run_id)
         delete_actions = sqlalchemy.delete(action_table).where(
             action_table.c.run_id == run_id
@@ -702,10 +697,19 @@ class RunStore:
         delete_csv_rtps = sqlalchemy.delete(run_csv_rtp_table).where(
             run_csv_rtp_table.c.run_id == run_id
         )
+        delete_input_files = sqlalchemy.delete(input_data_files_table).where(
+            input_data_files_table.c.run_id == run_id
+        )
+        delete_output_files = sqlalchemy.delete(output_data_files_table).where(
+            output_data_files_table.c.run_id == run_id
+        )
+
         with self._sql_engine.begin() as transaction:
             transaction.execute(delete_actions)
             transaction.execute(delete_commands)
             transaction.execute(delete_csv_rtps)
+            transaction.execute(delete_input_files)
+            transaction.execute(delete_output_files)
             result = transaction.execute(delete_run)
 
         if result.rowcount < 1:


### PR DESCRIPTION
Closes [RABR-839](https://opentrons.atlassian.net/browse/RABR-839)

# Overview

Currently, if a run is started and the 21st run is a CSV protocol, the run cannot start.

Run deletion is failing with a FOREIGN KEY constraint error when auto-deleting old runs to make room for new ones. The error occurred because `run_store.remove()` is not deleting associations in the `input_data_files_table` and `output_data_files_table` before attempting to delete the run record in the `RunAutoDeleter`.

To fix, we just add deletion of input and output data file associations in `RunStore.remove()` before deleting the run record itself. This ensures all foreign key constraints are satisfied during the deletion cascade.


Note that there is currently a 1:1 relationship between input files:runs and output files: runs, and we may have to revisit this logic in the future.
## Test Plan and Hands on Testing

- Verified the changes resolve the issues present on the robots outlined in the ticket.

## Changelog

- Fixed CSV protocols not loading onto a robot under certain conditions.

## Risk assessment

lowish if I'm thinking about this correctly


[RABR-839]: https://opentrons.atlassian.net/browse/RABR-839?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ