### PR TITLE
feat(step-generation): add -whileTracking commands to robotState

### DIFF
--- a/step-generation/src/getNextRobotStateAndWarnings/index.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/index.ts
@@ -60,9 +60,11 @@ function _getNextRobotStateAndWarningsSingleCommand(
 ): void {
   assert(command, 'undefined command passed to getNextRobotStateAndWarning')
   switch (command.commandType) {
-    // TODO: add this in case 'aspirateWhileTracking':
+    case 'aspirateWhileTracking':
     case 'aspirate':
     case 'aspirateInPlace':
+      //  TODO: robot state will be updated for air gaps in PV since completedProtocolAnalysis
+      //  won't have isAirGap... so we need to figure out a fix for this but not sure how
       if (command.meta?.isAirGap === true) {
         break
       } else {
@@ -70,9 +72,11 @@ function _getNextRobotStateAndWarningsSingleCommand(
       }
       break
 
-    // TODO: add this in case 'dispenseWhileTracking':
+    case 'dispenseWhileTracking':
     case 'dispense':
     case 'dispenseInPlace':
+      //  TODO: robot state will be updated for air gaps in PV since completedProtocolAnalysis
+      //  won't have isAirGap... so we need to figure out a fix for this but not sure how
       if (command.meta?.isAirGap === true) {
         break
       } else {


### PR DESCRIPTION
closes AUTH-2401

# Overview

this is needed for PV

wire up `aspirateWhileTracking` and `dispenseWhileTracking` to robot state also leave some TODOs for air gap updating robot state.

## Test Plan and Hands on Testing

review the code 😄 

## Changelog

add the while tracking commands to the switch statement

TODO: need to add something to the state update util so it errors if you add a new command type and that command isn't accounted for... maybe i need to write a unit test for it. but i'll do that later

## Risk assessment

low