### PR TITLE
feat(protocol-designer): Update Shift-click step selection to work with concurrent Thermocycler profiles

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/ConnectedStepInfo.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/ConnectedStepInfo.tsx
@@ -96,7 +96,7 @@ export function ConnectedStepInfo(props: ConnectedStepInfoProps): JSX.Element {
   const hoveredStep = useSelector(getHoveredStepId)
   const selectedStepId = useSelector(getSelectedStepId)
   const multiSelectItemIds = useSelector(getMultiSelectItemIds)
-  const orderedStepIds = useSelector(stepFormSelectors.getOrderedStepIds)
+  const stepHierarchy = useSelector(stepFormSelectors.getSavedStepHierarchy)
   const lastMultiSelectedStepId = useSelector(getMultiSelectLastSelected)
   const isMultiSelectMode = useSelector(getIsMultiSelectMode)
   const selected: boolean =
@@ -155,7 +155,7 @@ export function ConnectedStepInfo(props: ConnectedStepInfoProps): JSX.Element {
       if (isShiftKeyPressed) {
         stepsToSelect = getShiftSelectedSteps(
           selectedStepId,
-          orderedStepIds,
+          stepHierarchy,
           stepId,
           multiSelectItemIds,
           lastMultiSelectedStepId

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/__tests__/utils.test.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/__tests__/utils.test.tsx
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { capitalizeFirstLetterAfterNumber } from '../utils'
+import {
+  capitalizeFirstLetterAfterNumber,
+  getShiftSelectedSteps,
+} from '../utils'
+
+import type { StepHierarchy } from '/protocol-designer/steplist/utils/stepHierarchy'
 
 describe('capitalizeFirstLetterAfterNumber', () => {
   it('should capitalize the first letter of a step type', () => {
@@ -10,5 +15,81 @@ describe('capitalizeFirstLetterAfterNumber', () => {
     expect(capitalizeFirstLetterAfterNumber('22. thermocycler')).toBe(
       '22. Thermocycler'
     )
+  })
+})
+
+describe('getShiftSelectedSteps', () => {
+  it('should return a single step if no steps were selected before', () => {
+    const stepHierarchy: StepHierarchy = {
+      topLevelItems: [
+        { type: 'standaloneStep', stepId: 'step1' },
+        { type: 'standaloneStep', stepId: 'step2' },
+        { type: 'standaloneStep', stepId: 'step3' },
+      ],
+    }
+    expect(
+      getShiftSelectedSteps(null, stepHierarchy, 'step2', null, null)
+    ).toStrictEqual(['step2'])
+  })
+  it('should return a range if a single step was selected before', () => {
+    const stepHierarchy: StepHierarchy = {
+      topLevelItems: [
+        { type: 'standaloneStep', stepId: 'step1' },
+        {
+          type: 'thermocyclerProfileGroup',
+          thermocyclerProfileStepId: 'step2',
+          concurrentSteps: [
+            { type: 'standaloneStep', stepId: 'step3' },
+            { type: 'standaloneStep', stepId: 'step4' },
+          ],
+          waitForThermocyclerProfileStepId: 'step5',
+        },
+        { type: 'standaloneStep', stepId: 'step6' },
+        { type: 'standaloneStep', stepId: 'step7' },
+      ],
+    }
+    expect(
+      getShiftSelectedSteps('step3', stepHierarchy, 'step7', null, null)
+    ).toStrictEqual([
+      'step3',
+      'step4',
+      // step5 should be skipped because it's hidden in the UI
+      'step6',
+      'step7',
+    ])
+  })
+  it('should return a range if multiple steps were selected before', () => {
+    const stepHierarchy: StepHierarchy = {
+      topLevelItems: [
+        { type: 'standaloneStep', stepId: 'step1' },
+        {
+          type: 'thermocyclerProfileGroup',
+          thermocyclerProfileStepId: 'step2',
+          concurrentSteps: [
+            { type: 'standaloneStep', stepId: 'step3' },
+            { type: 'standaloneStep', stepId: 'step4' },
+          ],
+          waitForThermocyclerProfileStepId: 'step5',
+        },
+        { type: 'standaloneStep', stepId: 'step6' },
+        { type: 'standaloneStep', stepId: 'step7' },
+      ],
+    }
+    expect(
+      getShiftSelectedSteps(
+        null,
+        stepHierarchy,
+        'step7',
+        ['step2', 'step3'],
+        'step3'
+      )
+    ).toStrictEqual([
+      'step2',
+      'step3',
+      'step4',
+      // step5 should be skipped because it's hidden in the UI
+      'step6',
+      'step7',
+    ])
   })
 })

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/utils.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/utils.ts
@@ -36,58 +36,64 @@ export const formatPercentage = (part: number, total: number): string => {
 }
 
 export const getMetaSelectedSteps = (
-  multiSelectItemIds: StepIdType[] | null,
-  stepId: StepIdType,
-  selectedStepId: StepIdType | null
+  priorMultiSelectedItemIds: StepIdType[] | null,
+  newlySelectedStepId: StepIdType,
+  priorSingleSelectedStepId: StepIdType | null
 ): StepIdType[] => {
   let stepsToSelect: StepIdType[]
-  if (multiSelectItemIds?.length) {
+  if (priorMultiSelectedItemIds?.length) {
     // already have a selection, add/remove the meta-clicked item
-    stepsToSelect = multiSelectItemIds.includes(stepId)
-      ? multiSelectItemIds.filter(id => id !== stepId)
-      : [...multiSelectItemIds, stepId]
-  } else if (selectedStepId && selectedStepId === stepId) {
+    stepsToSelect = priorMultiSelectedItemIds.includes(newlySelectedStepId)
+      ? priorMultiSelectedItemIds.filter(id => id !== newlySelectedStepId)
+      : [...priorMultiSelectedItemIds, newlySelectedStepId]
+  } else if (
+    priorSingleSelectedStepId &&
+    priorSingleSelectedStepId === newlySelectedStepId
+  ) {
     // meta-clicked on the selected single step
-    stepsToSelect = [selectedStepId]
-  } else if (selectedStepId) {
+    stepsToSelect = [priorSingleSelectedStepId]
+  } else if (priorSingleSelectedStepId) {
     // meta-clicked on a different step, multi-select both
-    stepsToSelect = [selectedStepId, stepId]
+    stepsToSelect = [priorSingleSelectedStepId, newlySelectedStepId]
   } else {
     // meta-clicked on a step when a terminal item was selected
-    stepsToSelect = [stepId]
+    stepsToSelect = [newlySelectedStepId]
   }
   return stepsToSelect
 }
 
 export const getShiftSelectedSteps = (
-  selectedStepId: StepIdType | null,
+  priorSingleSelectedStepId: StepIdType | null,
   orderedStepIds: StepIdType[],
-  stepId: StepIdType,
-  multiSelectItemIds: StepIdType[] | null,
+  newlySelectedStepId: StepIdType,
+  priorMultiSelectedItemIds: StepIdType[] | null,
   lastMultiSelectedStepId: StepIdType | null
 ): StepIdType[] => {
   let stepsToSelect: StepIdType[]
-  if (selectedStepId) {
+  if (priorSingleSelectedStepId) {
     stepsToSelect = getOrderedStepsInRange(
-      selectedStepId,
-      stepId,
+      priorSingleSelectedStepId,
+      newlySelectedStepId,
       orderedStepIds
     )
-  } else if (multiSelectItemIds?.length && lastMultiSelectedStepId) {
+  } else if (priorMultiSelectedItemIds?.length && lastMultiSelectedStepId) {
     const potentialStepsToSelect = getOrderedStepsInRange(
       lastMultiSelectedStepId,
-      stepId,
+      newlySelectedStepId,
       orderedStepIds
     )
 
     const allSelected: boolean = potentialStepsToSelect
       .slice(1)
-      .every(stepId => multiSelectItemIds.includes(stepId))
+      .every(stepId => priorMultiSelectedItemIds.includes(stepId))
 
     if (allSelected) {
       // if they're all selected, deselect them all
-      if (multiSelectItemIds.length - potentialStepsToSelect.length > 0) {
-        stepsToSelect = multiSelectItemIds.filter(
+      if (
+        priorMultiSelectedItemIds.length - potentialStepsToSelect.length >
+        0
+      ) {
+        stepsToSelect = priorMultiSelectedItemIds.filter(
           (id: StepIdType) => !potentialStepsToSelect.includes(id)
         )
       } else {
@@ -95,10 +101,13 @@ export const getShiftSelectedSteps = (
         stepsToSelect = [potentialStepsToSelect[0]]
       }
     } else {
-      stepsToSelect = uniq([...multiSelectItemIds, ...potentialStepsToSelect])
+      stepsToSelect = uniq([
+        ...priorMultiSelectedItemIds,
+        ...potentialStepsToSelect,
+      ])
     }
   } else {
-    stepsToSelect = [stepId]
+    stepsToSelect = [newlySelectedStepId]
   }
   return stepsToSelect
 }

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/utils.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/utils.ts
@@ -2,8 +2,12 @@ import round from 'lodash/round'
 import uniq from 'lodash/uniq'
 import { UAParser } from 'ua-parser-js'
 
+import { getStepVisibilities } from '/protocol-designer/steplist/utils/getStepVisibilities'
+import { convertStepHierarchyToArray } from '/protocol-designer/steplist/utils/stepHierarchy'
+
 import type { MouseEvent } from 'react'
 import type { StepIdType } from '/protocol-designer/form-types'
+import type { StepHierarchy } from '/protocol-designer/steplist/utils/stepHierarchy'
 
 export const capitalizeFirstLetterAfterNumber = (title: string): string =>
   title.replace(
@@ -64,23 +68,23 @@ export const getMetaSelectedSteps = (
 
 export const getShiftSelectedSteps = (
   priorSingleSelectedStepId: StepIdType | null,
-  orderedStepIds: StepIdType[],
+  stepHierarchy: StepHierarchy,
   newlySelectedStepId: StepIdType,
   priorMultiSelectedItemIds: StepIdType[] | null,
   lastMultiSelectedStepId: StepIdType | null
 ): StepIdType[] => {
   let stepsToSelect: StepIdType[]
   if (priorSingleSelectedStepId) {
-    stepsToSelect = getOrderedStepsInRange(
+    stepsToSelect = getOrderedVisibleStepsInRange(
       priorSingleSelectedStepId,
       newlySelectedStepId,
-      orderedStepIds
+      stepHierarchy
     )
   } else if (priorMultiSelectedItemIds?.length && lastMultiSelectedStepId) {
-    const potentialStepsToSelect = getOrderedStepsInRange(
+    const potentialStepsToSelect = getOrderedVisibleStepsInRange(
       lastMultiSelectedStepId,
       newlySelectedStepId,
-      orderedStepIds
+      stepHierarchy
     )
 
     const allSelected: boolean = potentialStepsToSelect
@@ -112,17 +116,22 @@ export const getShiftSelectedSteps = (
   return stepsToSelect
 }
 
-const getOrderedStepsInRange = (
+const getOrderedVisibleStepsInRange = (
   lastSelectedStepId: StepIdType,
   stepId: StepIdType,
-  orderedStepIds: StepIdType[]
+  stepHierarchy: StepHierarchy
 ): StepIdType[] => {
+  const orderedStepIds = convertStepHierarchyToArray(stepHierarchy)
+  const stepVisibilities = getStepVisibilities(stepHierarchy)
+
   const prevIndex: number = orderedStepIds.indexOf(lastSelectedStepId)
   const currentIndex: number = orderedStepIds.indexOf(stepId)
-
   const [startIndex, endIndex] = [prevIndex, currentIndex].sort((a, b) => a - b)
-  const orderedSteps = orderedStepIds.slice(startIndex, endIndex + 1)
-  return orderedSteps
+
+  const orderedVisibleSteps = orderedStepIds
+    .slice(startIndex, endIndex + 1)
+    .filter(stepId => stepVisibilities[stepId].isVisibleToUser)
+  return orderedVisibleSteps
 }
 
 export const nonePressed = (keysPressed: boolean[]): boolean =>

--- a/protocol-designer/src/ui/steps/actions/actions.ts
+++ b/protocol-designer/src/ui/steps/actions/actions.ts
@@ -28,7 +28,6 @@ import type {
   selectDropdownItemAction,
   Selection,
   SelectMultipleStepsAction,
-  SelectMultipleStepsForGroupAction,
   SelectStepAction,
   SelectTerminalItemAction,
   SetWellSelectionLabwareKeyAction,
@@ -252,21 +251,6 @@ export const selectMultipleSteps =
   (dispatch: ThunkDispatch<any>, getState: GetState) => {
     const selectStepAction: SelectMultipleStepsAction = {
       type: 'SELECT_MULTIPLE_STEPS',
-      payload: {
-        stepIds,
-        lastSelected,
-      },
-    }
-    dispatch(selectStepAction)
-  }
-export const selectMultipleStepsForGroup =
-  (
-    stepIds: StepIdType[],
-    lastSelected: StepIdType
-  ): ThunkAction<SelectMultipleStepsForGroupAction> =>
-  (dispatch: ThunkDispatch<any>, getState: GetState) => {
-    const selectStepAction: SelectMultipleStepsForGroupAction = {
-      type: 'SELECT_MULTIPLE_STEPS_FOR_GROUP',
       payload: {
         stepIds,
         lastSelected,

--- a/protocol-designer/src/ui/steps/actions/actions.ts
+++ b/protocol-designer/src/ui/steps/actions/actions.ts
@@ -35,9 +35,11 @@ import type {
   ViewSubstep,
 } from './types'
 
-// adds an incremental integer ID for Step reducers.
-// NOTE: if this is an "add step" directly performed by the user,
-// addAndSelectStepWithHints is probably what you want
+/**
+ * adds an incremental integer ID for Step reducers.
+ * NOTE: if this is an "add step" directly performed by the user,
+ * addAndSelectStepWithHints is probably what you want
+ */
 export const addStep = (args: {
   stepType: StepType
   robotStateTimeline: Timeline
@@ -53,10 +55,12 @@ export const addStep = (args: {
     },
   }
 }
+
 export const hoverSelection = (args: Selection): hoverSelectionAction => ({
   type: 'HOVER_DROPDOWN_ITEM',
   payload: { id: args.id, text: args.text },
 })
+
 export const selectDropdownItem = (args: {
   selection: Selection | null
   mode: Mode
@@ -81,35 +85,41 @@ export const hoverOnSubstep = (
   type: 'HOVER_ON_SUBSTEP',
   payload: payload,
 })
+
 export const selectTerminalItem = (
   terminalId: TerminalItemId
 ): SelectTerminalItemAction => ({
   type: 'SELECT_TERMINAL_ITEM',
   payload: terminalId,
 })
+
 export const hoverOnStep = (
   stepId: StepIdType | null | undefined
 ): HoverOnStepAction => ({
   type: 'HOVER_ON_STEP',
   payload: stepId,
 })
+
 export const hoverOnTerminalItem = (
   terminalId: TerminalItemId | null | undefined
 ): HoverOnTerminalItemAction => ({
   type: 'HOVER_ON_TERMINAL_ITEM',
   payload: terminalId,
 })
+
 export const setWellSelectionLabwareKey = (
   labwareName: string | null | undefined
 ): SetWellSelectionLabwareKeyAction => ({
   type: 'SET_WELL_SELECTION_LABWARE_KEY',
   payload: labwareName,
 })
+
 export const clearWellSelectionLabwareKey =
   (): ClearWellSelectionLabwareKeyAction => ({
     type: 'CLEAR_WELL_SELECTION_LABWARE_KEY',
     payload: null,
   })
+
 export const resetSelectStep =
   (stepId: StepIdType): ThunkAction<any> =>
   (dispatch: ThunkDispatch<any>, getState: GetState) => {
@@ -226,6 +236,7 @@ export const populateForm =
     setSelection(formData, dispatch)
     resetScrollElements()
   }
+
 export const selectStep =
   (stepId: StepIdType): ThunkAction<any> =>
   (dispatch: ThunkDispatch<any>, getState: GetState) => {
@@ -242,6 +253,7 @@ export const selectStep =
     })
     setSelection(formData, dispatch)
   }
+
 // NOTE(sa, 2020-12-11): this is a thunk so that we can populate the batch edit form with things later
 export const selectMultipleSteps =
   (
@@ -258,6 +270,7 @@ export const selectMultipleSteps =
     }
     dispatch(selectStepAction)
   }
+
 export const selectAllSteps =
   (): ThunkAction<SelectMultipleStepsAction | AnalyticsEventAction> =>
   (
@@ -284,8 +297,10 @@ export const selectAllSteps =
       dispatch(analyticsEvent(selectAllStepsEvent))
     }
   }
+
 export const EXIT_BATCH_EDIT_MODE_BUTTON_PRESS: 'EXIT_BATCH_EDIT_MODE_BUTTON_PRESS' =
   'EXIT_BATCH_EDIT_MODE_BUTTON_PRESS'
+
 // todo(mm, 2025-10-31): "deselectAllSteps" is a bit of a misnomer, since this also selects a step.
 export const deselectAllSteps =
   (

--- a/protocol-designer/src/ui/steps/actions/types.ts
+++ b/protocol-designer/src/ui/steps/actions/types.ts
@@ -93,13 +93,6 @@ export interface SelectMultipleStepsAction {
   }
 }
 
-export interface SelectMultipleStepsForGroupAction {
-  type: 'SELECT_MULTIPLE_STEPS_FOR_GROUP'
-  payload: {
-    stepIds: StepIdType[]
-    lastSelected: StepIdType
-  }
-}
 export type ViewSubstep = StepIdType | null
 export interface ToggleViewSubstepAction {
   type: 'TOGGLE_VIEW_SUBSTEP'


### PR DESCRIPTION
## Overview

Protocol Designer lets the user Shift-click to select a range of steps in the timeline. Now that the timeline has nesting (concurrent Thermocycler profiles), we need to update that logic to account for some hazards when the range crosses the boundary of a nested group. This PR does that.

Closes EXEC-2060. See that ticket for a more full example of the problem we're solving.

## Test Plan and Hands on Testing

I've done this:

1. Import [tc_dnd_demo.py](https://github.com/user-attachments/files/23635028/tc_dnd_demo.py)
2. Make sure the "enable concurrent module actions" feature flag is enabled
3. Go through the test plan in EXEC-2060

## Changelog

* Update the logic in `getShiftSelectedSteps()` to avoid selecting steps that are not "user-visible"—i.e., the hidden "wait for profile to complete" step that implicitly comes at the end of every Thermocycler profile. Some of the other step CRUD actions are already doing the same thing.
* Various small renames for clarity.
* Delete `SelectMultipleStepsForGroupAction`, which was unused (never created, nor used in any reducer).

## Review requests

OK with deleting `SelectMultipleStepsForGroupAction`?

## Risk assessment

Low.
