### PR TITLE
fix(api): Correctly update engine state during tracking aspirate/dispense

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/aspirate_while_tracking.py
+++ b/api/src/opentrons/protocol_engine/commands/aspirate_while_tracking.py
@@ -147,7 +147,17 @@ class AspirateWhileTrackingImplementation(
             model_utils=self._model_utils,
             movement_delay=params.movement_delay,
         )
+        state_update.append(aspirate_result.state_update)
         if isinstance(aspirate_result, DefinedErrorData):
+            state_update.set_liquid_operated(
+                labware_id=params.labwareId,
+                well_names=self._state_view.geometry.get_wells_covered_by_pipette_with_active_well(
+                    params.labwareId,
+                    params.wellName,
+                    params.pipetteId,
+                ),
+                volume_added=CLEAR,
+            )
             if isinstance(aspirate_result.public, OverpressureError):
                 return DefinedErrorData(
                     public=OverpressureError(
@@ -156,15 +166,7 @@ class AspirateWhileTrackingImplementation(
                         wrappedErrors=aspirate_result.public.wrappedErrors,
                         errorInfo=aspirate_result.public.errorInfo,
                     ),
-                    state_update=aspirate_result.state_update.set_liquid_operated(
-                        labware_id=params.labwareId,
-                        well_names=self._state_view.geometry.get_wells_covered_by_pipette_with_active_well(
-                            params.labwareId,
-                            params.wellName,
-                            params.pipetteId,
-                        ),
-                        volume_added=CLEAR,
-                    ),
+                    state_update=state_update,
                     state_update_if_false_positive=aspirate_result.state_update_if_false_positive,
                 )
             elif isinstance(aspirate_result.public, StallOrCollisionError):
@@ -175,15 +177,7 @@ class AspirateWhileTrackingImplementation(
                         wrappedErrors=aspirate_result.public.wrappedErrors,
                         errorInfo=aspirate_result.public.errorInfo,
                     ),
-                    state_update=aspirate_result.state_update.set_liquid_operated(
-                        labware_id=params.labwareId,
-                        well_names=self._state_view.geometry.get_wells_covered_by_pipette_with_active_well(
-                            params.labwareId,
-                            params.wellName,
-                            params.pipetteId,
-                        ),
-                        volume_added=CLEAR,
-                    ),
+                    state_update=state_update,
                     state_update_if_false_positive=aspirate_result.state_update_if_false_positive,
                 )
 
@@ -200,7 +194,7 @@ class AspirateWhileTrackingImplementation(
                 volume=aspirate_result.public.volume,
                 position=result_deck_point,
             ),
-            state_update=aspirate_result.state_update.set_liquid_operated(
+            state_update=state_update.set_liquid_operated(
                 labware_id=params.labwareId,
                 well_names=self._state_view.geometry.get_wells_covered_by_pipette_with_active_well(
                     params.labwareId,

--- a/api/src/opentrons/protocol_engine/commands/dispense_while_tracking.py
+++ b/api/src/opentrons/protocol_engine/commands/dispense_while_tracking.py
@@ -143,8 +143,17 @@ class DispenseWhileTrackingImplementation(
             model_utils=self._model_utils,
             movement_delay=params.movement_delay,
         )
-
+        state_update.append(dispense_result.state_update)
         if isinstance(dispense_result, DefinedErrorData):
+            state_update.set_liquid_operated(
+                labware_id=params.labwareId,
+                well_names=self._state_view.geometry.get_wells_covered_by_pipette_with_active_well(
+                    params.labwareId,
+                    params.wellName,
+                    params.pipetteId,
+                ),
+                volume_added=CLEAR,
+            )
             if isinstance(dispense_result.public, OverpressureError):
                 return DefinedErrorData(
                     public=OverpressureError(
@@ -153,15 +162,7 @@ class DispenseWhileTrackingImplementation(
                         wrappedErrors=dispense_result.public.wrappedErrors,
                         errorInfo=dispense_result.public.errorInfo,
                     ),
-                    state_update=dispense_result.state_update.set_liquid_operated(
-                        labware_id=params.labwareId,
-                        well_names=self._state_view.geometry.get_wells_covered_by_pipette_with_active_well(
-                            params.labwareId,
-                            params.wellName,
-                            params.pipetteId,
-                        ),
-                        volume_added=CLEAR,
-                    ),
+                    state_update=state_update,
                     state_update_if_false_positive=dispense_result.state_update_if_false_positive,
                 )
             elif isinstance(dispense_result.public, StallOrCollisionError):
@@ -172,15 +173,7 @@ class DispenseWhileTrackingImplementation(
                         wrappedErrors=dispense_result.public.wrappedErrors,
                         errorInfo=dispense_result.public.errorInfo,
                     ),
-                    state_update=dispense_result.state_update.set_liquid_operated(
-                        labware_id=params.labwareId,
-                        well_names=self._state_view.geometry.get_wells_covered_by_pipette_with_active_well(
-                            params.labwareId,
-                            params.wellName,
-                            params.pipetteId,
-                        ),
-                        volume_added=CLEAR,
-                    ),
+                    state_update=state_update,
                     state_update_if_false_positive=dispense_result.state_update_if_false_positive,
                 )
 
@@ -197,7 +190,7 @@ class DispenseWhileTrackingImplementation(
                 volume=dispense_result.public.volume,
                 position=result_deck_point,
             ),
-            state_update=dispense_result.state_update.set_liquid_operated(
+            state_update=state_update.set_liquid_operated(
                 labware_id=params.labwareId,
                 well_names=self._state_view.geometry.get_wells_covered_by_pipette_with_active_well(
                     params.labwareId,

--- a/api/tests/opentrons/protocol_engine/commands/test_aspirate_while_tracking.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_aspirate_while_tracking.py
@@ -36,6 +36,7 @@ from opentrons.protocol_engine.types import (
     WellOrigin,
     WellOffset,
     DeckPoint,
+    LabwareWellId,
 )
 from opentrons.protocol_engine.state import update_types
 
@@ -195,6 +196,13 @@ async def test_aspirate_while_tracking_implementation(
                     pipette_id="pipette-id-abc",
                     fluid=AspiratedFluid(kind=FluidKind.LIQUID, volume=123),
                 ),
+                pipette_location=update_types.PipetteLocationUpdate(
+                    pipette_id="pipette-id-abc",
+                    new_location=LabwareWellId(
+                        labware_id="funky-labware", well_name="funky-well"
+                    ),
+                    new_deck_point=DeckPoint(x=4, y=5, z=6),
+                ),
             ),
         )
     else:
@@ -212,6 +220,13 @@ async def test_aspirate_while_tracking_implementation(
                     labware_id="funky-labware",
                     well_names=["A3", "A4"],
                     volume_added=-246.0,
+                ),
+                pipette_location=update_types.PipetteLocationUpdate(
+                    pipette_id="pipette-id-abc",
+                    new_location=LabwareWellId(
+                        labware_id="funky-labware", well_name="funky-well"
+                    ),
+                    new_deck_point=DeckPoint(x=4, y=5, z=6),
                 ),
             ),
         )
@@ -465,6 +480,13 @@ async def test_overpressure_error(
                 pipette_aspirated_fluid=update_types.PipetteUnknownFluidUpdate(
                     pipette_id="pipette-id-abc"
                 ),
+                pipette_location=update_types.PipetteLocationUpdate(
+                    pipette_id="pipette-id-abc",
+                    new_location=LabwareWellId(
+                        labware_id="funky-labware", well_name="funky-well"
+                    ),
+                    new_deck_point=DeckPoint(x=4, y=5, z=6),
+                ),
             ),
         )
     else:
@@ -483,6 +505,13 @@ async def test_overpressure_error(
                     labware_id="funky-labware",
                     well_names=["A3", "A4"],
                     volume_added=update_types.CLEAR,
+                ),
+                pipette_location=update_types.PipetteLocationUpdate(
+                    pipette_id="pipette-id-abc",
+                    new_location=LabwareWellId(
+                        labware_id="funky-labware", well_name="funky-well"
+                    ),
+                    new_deck_point=DeckPoint(x=4, y=5, z=6),
                 ),
             ),
         )

--- a/api/tests/opentrons/protocol_engine/commands/test_dispense_while_tracking.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_dispense_while_tracking.py
@@ -31,6 +31,7 @@ from opentrons.protocol_engine.types import (
     WellOrigin,
     WellOffset,
     DeckPoint,
+    LabwareWellId,
 )
 from opentrons.protocol_engine.state import update_types
 
@@ -191,6 +192,13 @@ async def test_dispense_while_tracking_implementation(
                 ready_to_aspirate=update_types.PipetteAspirateReadyUpdate(
                     pipette_id="pipette-id-abc", ready_to_aspirate=False
                 ),
+                pipette_location=update_types.PipetteLocationUpdate(
+                    pipette_id="pipette-id-abc",
+                    new_location=LabwareWellId(
+                        labware_id="funky-labware", well_name="funky-well"
+                    ),
+                    new_deck_point=DeckPoint(x=4, y=5, z=6),
+                ),
             ),
         )
     else:
@@ -211,6 +219,13 @@ async def test_dispense_while_tracking_implementation(
                     labware_id="funky-labware",
                     well_names=["A3", "A4"],
                     volume_added=84.0,
+                ),
+                pipette_location=update_types.PipetteLocationUpdate(
+                    pipette_id="pipette-id-abc",
+                    new_location=LabwareWellId(
+                        labware_id="funky-labware", well_name="funky-well"
+                    ),
+                    new_deck_point=DeckPoint(x=4, y=5, z=6),
                 ),
             ),
         )
@@ -354,6 +369,13 @@ async def test_overpressure_error(
                 ready_to_aspirate=update_types.PipetteAspirateReadyUpdate(
                     pipette_id="pipette-id", ready_to_aspirate=False
                 ),
+                pipette_location=update_types.PipetteLocationUpdate(
+                    pipette_id="pipette-id",
+                    new_location=LabwareWellId(
+                        labware_id="funky-labware", well_name="funky-well"
+                    ),
+                    new_deck_point=DeckPoint(x=4, y=5, z=6),
+                ),
             ),
         )
     else:
@@ -375,6 +397,13 @@ async def test_overpressure_error(
                 ),
                 ready_to_aspirate=update_types.PipetteAspirateReadyUpdate(
                     pipette_id="pipette-id", ready_to_aspirate=False
+                ),
+                pipette_location=update_types.PipetteLocationUpdate(
+                    pipette_id="pipette-id",
+                    new_location=LabwareWellId(
+                        labware_id="funky-labware", well_name="funky-well"
+                    ),
+                    new_deck_point=DeckPoint(x=4, y=5, z=6),
                 ),
             ),
             state_update_if_false_positive=update_types.StateUpdate(),


### PR DESCRIPTION
# Overview
We were not appending the aspirate/dispense result to the move result. This means that the engine's state was not getting updated with the current labware, so the *_while_tracking commands were not updating the pipettes current location. 

This means that if you did an action in labware_1, then did a aspirate/dispense_while_tracking in labware_2 and then moved back to labware_1 the engine would think that the pipettes current location was still in labware 1 and it would calculate the safe Z movement and properly use waypoints to travel back to labware_1.

