### PR TITLE
fix(app): QT: show the disposal volume with µL units

### DIFF
--- a/app/src/assets/localization/en/quick_transfer.json
+++ b/app/src/assets/localization/en/quick_transfer.json
@@ -78,7 +78,7 @@
   "dispense_volume_µL": "Dispense volume per well (µL)",
   "disposal_volume": "Disposal volume",
   "disposal_volume_flow_rate": "Between {{min}} and {{max}}",
-  "disposal_volume_label": "{{volume}}, {{location}}, {{flowRate}} µL/s",
+  "disposal_volume_label": "{{volume}} µL, {{location}}, {{flowRate}} µL/s",
   "disposal_volume_µL": "Disposal volume (µL)",
   "distance_bottom_of_well_mm": "Distance from bottom of well (mm)",
   "distance_from_bottom": "Distance from bottom of well (mm)",


### PR DESCRIPTION
# Overview

A small follow-up to PR #20183: In the settings bar for "Disposal volume," show the units as `µL`.

#### Before:
<img width="1624" height="988" alt="image" src="https://github.com/user-attachments/assets/d1f48d43-cd87-442e-a613-23072a863aac" />

#### After:
<img width="1622" height="1000" alt="image" src="https://github.com/user-attachments/assets/2b74c6a2-3c25-439a-82bd-0a8b63f1419b" />

## Test Plan and Hands on Testing

Pushed the change to `authorshipPVT` and tried it.

## Risk assessment

Low.