### PR TITLE
(docs)api: using capture_image in 8.8 

### DIFF
--- a/api/docs/v2/basic_commands/utilities.rst
+++ b/api/docs/v2/basic_commands/utilities.rst
@@ -66,7 +66,7 @@ Call the :py:meth:`.ProtocolContext.comment` method if you want to write and dis
 
 .. versionadded:: 2.0
 
-Taking Camera Images 
+Capturing Images 
 =====================
 
 Use the :py:meth:`.ProtocolContext.capture_image` method to take an image during a protocol with the Flex or OT-2's built-in camera. You can use images to check on key protocol steps while spending more time away from the bench. 
@@ -74,7 +74,7 @@ Use the :py:meth:`.ProtocolContext.capture_image` method to take an image during
 This example uses optional parameters to home the pipette, clearing the camera's view, and save the image file as ``deck_view``::
     
     protocol.capture_image(
-        home_before="True",
+        home_before=True,
         filename="deck_view"
     )
 

--- a/api/docs/v2/basic_commands/utilities.rst
+++ b/api/docs/v2/basic_commands/utilities.rst
@@ -6,7 +6,7 @@
 Utility Commands
 ****************
 
-With utility commands, you can control various robot functions such as pausing or delaying a protocol, taking images with the built-in camera, turning robot lights on/off, and more. The following sections show you how to these utility commands and include sample code. The examples used here assume that you’ve loaded the pipettes and labware from the basic :ref:`protocol template <protocol-template>`.
+With utility commands, you can control various robot functions such as pausing or delaying a protocol, taking images with the built-in camera, turning robot lights on/off, and more. The following sections show you how to use these utility commands and include sample code. The examples used here assume that you’ve loaded the pipettes and labware from the basic :ref:`protocol template <protocol-template>`.
 
 Delay and Resume
 ================

--- a/api/docs/v2/basic_commands/utilities.rst
+++ b/api/docs/v2/basic_commands/utilities.rst
@@ -71,7 +71,7 @@ Capturing Images
 
 Use the :py:meth:`.ProtocolContext.capture_image` method to take an image during a protocol with the Flex or OT-2's built-in camera. You can use images to check on key protocol steps while spending more time away from the bench. 
 
-This example uses optional parameters to home the pipette, clearing the camera's view, and save the image file as ``deck_view``::
+This example uses optional parameters to home the pipette, clearing the camera's view, and give a custom name to the image file::
     
     protocol.capture_image(
         home_before=True,
@@ -79,6 +79,8 @@ This example uses optional parameters to home the pipette, clearing the camera's
     )
 
 .. versionadded:: 2.27
+
+Image filenames include your robot and protocol name, step number, and timestamps for the protocol and command running when the image was taken. Here, the custom filename ``deck_view`` is added to the beginning of the filename, making it easier to find the exact image you're looking for. 
 
 You can further customize your images using the :py:meth:`~.ProtocolContext.capture_image` method's optional parameters, including image resolution, zoom, brightness, and more. After a protocol run, access and download your images from the Recent Protocol Runs section of the Opentrons App's robot details page.
 

--- a/api/docs/v2/basic_commands/utilities.rst
+++ b/api/docs/v2/basic_commands/utilities.rst
@@ -6,7 +6,7 @@
 Utility Commands
 ****************
 
-With utility commands, you can control various robot functions such as pausing or delaying a protocol, checking the robot's door, turning robot lights on/off, and more. The following sections show you how to these utility commands and include sample code. The examples used here assume that you’ve loaded the pipettes and labware from the basic :ref:`protocol template <protocol-template>`.
+With utility commands, you can control various robot functions such as pausing or delaying a protocol, taking images with the built-in camera, turning robot lights on/off, and more. The following sections show you how to these utility commands and include sample code. The examples used here assume that you’ve loaded the pipettes and labware from the basic :ref:`protocol template <protocol-template>`.
 
 Delay and Resume
 ================
@@ -65,6 +65,22 @@ Call the :py:meth:`.ProtocolContext.comment` method if you want to write and dis
     protocol.comment("Hello, world!")
 
 .. versionadded:: 2.0
+
+Taking Camera Images 
+=====================
+
+Use the :py:meth:`.ProtocolContext.capture_image` method to take an image during a protocol with the Flex or OT-2's built-in camera. You can use images to check on key protocol steps while spending more time away from the bench. 
+
+This example uses optional parameters to home the pipette, clearing the camera's view, and save the image file as ``deck_view``::
+    
+    protocol.capture_image(
+        home_before="True",
+        filename="deck_view"
+    )
+
+.. versionadded:: 2.27
+
+You can further customize your images using the :py:meth:`~.ProtocolContext.capture_image` method's optional parameters, including image resolution, zoom, brightness, and more. After a protocol run, access and download your images from the Recent Protocol Runs section of the Opentrons App's robot details page.
 
 Control and Monitor Robot Rail Lights
 =====================================

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -1836,12 +1836,12 @@ class ProtocolContext(CommandPublisher):
         """Capture an image using the camera. Captured images are saved as during the protocol run.
 
         :param home_before: If `True`, homes the pipette before capturing an image.
-        :param filename: Name to use when saving the captured image as a file.
+        :param filename: Custom name to use when saving the captured image as a file. The custom name is added as the beginning of the filename, followed by the robot and protocol name, a timestamp for the protocol run, the step number, and a timestamp for the command running when the image was captured. 
         :param resolution: Accepts a width and height (as a tuple) to determine the camera's resolution when capturing the image.
         :param zoom: Zoom level the camera will use. Defaults to the minimum of 1x zoom and has a maximum of 2x zoom.
-        :param contrast: The contrast level to be applied to an image. The acceptable range is from 0% to 100%.
-        :param brightness: The brightness level to be applied to an image. The acceptable range is from 0% to 100%.
-        :param saturation: The saturation level to be applied to an image. The acceptable range is from 0% to 100%.
+        :param contrast: The contrast level to be applied to an image. The acceptable range is from 0 to 100; provided as a percentage (0.0 to 100.0).
+        :param brightness: The brightness level to be applied to an image. The acceptable range is from 0 to 100; provided as a percentage (0.0 to 100.0)..
+        :param saturation: The saturation level to be applied to an image. The acceptable range is from 0 to 100; provided as a percentage (0.0 to 100.0).
 
         """
         if home_before is True:

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -1836,7 +1836,7 @@ class ProtocolContext(CommandPublisher):
         """Capture an image using the camera. Captured images are saved as during the protocol run.
 
         :param home_before: If `True`, homes the pipette before capturing an image.
-        :param filename: Custom name to use when saving the captured image as a file. The custom name is added as the beginning of the filename, followed by the robot and protocol name, a timestamp for the protocol run, the step number, and a timestamp for the command running when the image was captured. 
+        :param filename: Custom name to use when saving the captured image as a file. The custom name is added as the beginning of the filename, followed by the robot and protocol name, a timestamp for the protocol run, the step number, and a timestamp for the command running when the image was captured.
         :param resolution: Accepts a width and height (as a tuple) to determine the camera's resolution when capturing the image.
         :param zoom: Zoom level the camera will use. Defaults to the minimum of 1x zoom and has a maximum of 2x zoom.
         :param contrast: The contrast level to be applied to an image. The acceptable range is from 0 to 100; provided as a percentage (0.0 to 100.0).

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -1835,13 +1835,13 @@ class ProtocolContext(CommandPublisher):
     ) -> None:
         """Capture an image using the camera. Captured images are saved as during the protocol run.
 
-        :param home_before: If `True`, homes the pipette before capturing an image.
+        :param home_before: If ``True``, homes the pipette before capturing an image.
         :param filename: Custom name to use when saving the captured image as a file. The custom name is added as the beginning of the filename, followed by the robot and protocol name, a timestamp for the protocol run, the step number, and a timestamp for the command running when the image was captured.
         :param resolution: Accepts a width and height (as a tuple) to determine the camera's resolution when capturing the image.
-        :param zoom: Zoom level the camera will use. Defaults to the minimum of 1x zoom and has a maximum of 2x zoom.
-        :param contrast: The contrast level to be applied to an image. The acceptable range is from 0 to 100; provided as a percentage (0.0 to 100.0).
-        :param brightness: The brightness level to be applied to an image. The acceptable range is from 0 to 100; provided as a percentage (0.0 to 100.0)..
-        :param saturation: The saturation level to be applied to an image. The acceptable range is from 0 to 100; provided as a percentage (0.0 to 100.0).
+        :param zoom: Zoom level the camera will use. Defaults to the minimum of 1x zoom (``1.0``) and has a maximum of 2x zoom (``2.0``).
+        :param contrast: The contrast level to be applied to the image. The acceptable range is from 0 to 100; provided as a percentage (``0.0`` to ``100.0``).
+        :param brightness: The brightness level to be applied to the image. The acceptable range is from 0 to 100; provided as a percentage (``0.0`` to ``100.0``).
+        :param saturation: The saturation level to be applied to the image. The acceptable range is from 0 to 100; provided as a percentage (``0.0`` to ``100.0``).
 
         """
         if home_before is True:

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -1833,17 +1833,15 @@ class ProtocolContext(CommandPublisher):
         brightness: Optional[float] = None,
         saturation: Optional[float] = None,
     ) -> None:
-        """Capture an image using the camera. Captured images get saved as a result of the protocol run.
+        """Capture an image using the camera. Captured images are saved as during the protocol run.
 
-        :param home_before: Boolean to home the pipette before capturing an image.
-        :param filename: Filename to use when saving the captured image as a file.
-        :param resolution: Width/height tuple to determine the resolution to use when capturing an image.
-        :param zoom: Optional zoom level, with minimum/default of 1x zoom and maximum of 2x zoom.
-        :param contrast: Contrast level to be applied to an image, range is 0% to 100%.
-        :param brightness: Brightness level to be applied to an image, range is 0% to 100%.
-        :param saturation: Saturation level to be applied to an image, range is 0% to 100%.
-
-        .. versionadded:: 2.27
+        :param home_before: If `True`, homes the pipette before capturing an image.
+        :param filename: Name to use when saving the captured image as a file.
+        :param resolution: Accepts a width and height (as a tuple) to determine the camera's resolution when capturing the image.
+        :param zoom: Zoom level the camera will use. Defaults to the minimum of 1x zoom and has a maximum of 2x zoom.
+        :param contrast: The contrast level to be applied to an image. The acceptable range is from 0% to 100%.
+        :param brightness: The brightness level to be applied to an image. The acceptable range is from 0% to 100%.
+        :param saturation: The saturation level to be applied to an image. The acceptable range is from 0% to 100%.
 
         """
         if home_before is True:


### PR DESCRIPTION
# Overview

adds a simple section to Utility Commands to show users how to take an image (and cover some optional command). 

## Test Plan and Hands on Testing

sandbox. 

## Changelog

Added a new section to Utility Commands with some very small updates to the API reference. 

## Review requests

I chose two optional parameters for the code sample that I thought users would use frequently without getting too complicated, but if we want the example to be slightly different that's totally fine by me. 

Should we link the Flex manual? You can do a lot more with the camera in 8.8 from the app/ODD; but I know we don't usually link out from the API docs. 

## Risk assessment

low. 
