### PR TITLE
fix(app): waste chute hover bug fix for PV

### DIFF
--- a/app/src/organisms/Desktop/ProtocolVisualization/DeckView/DeckViewOverlay/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/DeckView/DeckViewOverlay/index.tsx
@@ -18,6 +18,7 @@ import {
   getFlexHoverDimensions,
   getOT2HoverDimensions,
   THERMOCYCLER_MODULE_TYPE,
+  WASTE_CHUTE_CUTOUT,
 } from '@opentrons/shared-data'
 
 import styles from './deckviewoverlay.module.css'
@@ -71,7 +72,7 @@ export function DeckViewOverlay(props: SlotOverlayProps): JSX.Element | null {
   const stagingAreaLocations = Object.values(stagingAreaEntities)?.map(
     stagingArea => stagingArea.location as string
   )
-  const wasteChuteOnSlot =
+  const isWasteChuteOnSlot =
     Object.values(wasteChuteEntities).length > 0 && slotId === 'D3'
 
   const cutoutId =
@@ -138,7 +139,7 @@ export function DeckViewOverlay(props: SlotOverlayProps): JSX.Element | null {
         </RobotCoordsForeignObject>
         {/* This is to render the waste chute above the hover border - very gnarly but this
             is what design wanted */}
-        {wasteChuteOnSlot != null ? (
+        {isWasteChuteOnSlot ? (
           <RobotCoordsForeignObject
             width={WASTE_CHUTE_WIDTH}
             height={WASTE_CHUTE_HEIGHT}

--- a/app/src/organisms/Desktop/ProtocolVisualization/DeckView/DeckViewOverlay/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/DeckView/DeckViewOverlay/index.tsx
@@ -18,7 +18,6 @@ import {
   getFlexHoverDimensions,
   getOT2HoverDimensions,
   THERMOCYCLER_MODULE_TYPE,
-  WASTE_CHUTE_CUTOUT,
 } from '@opentrons/shared-data'
 
 import styles from './deckviewoverlay.module.css'


### PR DESCRIPTION
# Overview

fix the waste chute appearing on hover incorrectly

## Test Plan and Hands on Testing

hover over the flex deck map and shouldn't see the waste chute fixture

## Changelog

correctly check the boolean value instead of a value that can be null

## Risk assessment

low