### PR TITLE
fix(api): use StateUpdate when mapping legacy module loads

### DIFF
--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[004ebb2b82][OT2_S_v2_11_P10S_P300M_MM_TC1_TM_Swift].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[004ebb2b82][OT2_S_v2_11_P10S_P300M_MM_TC1_TM_Swift].json
@@ -16515,7 +16515,32 @@
   "metadata": {
     "apiLevel": "2.11"
   },
-  "modules": [],
+  "modules": [
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "1"
+      },
+      "model": "magneticModuleV2",
+      "serialNumber": "UUID"
+    },
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "4"
+      },
+      "model": "temperatureModuleV1",
+      "serialNumber": "UUID"
+    },
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "7"
+      },
+      "model": "thermocyclerModuleV1",
+      "serialNumber": "UUID"
+    }
+  ],
   "pipettes": [
     {
       "id": "UUID",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[010f0c3a8d][OT2_S_v2_11_PL_IDT-xGen-EZ-24x-for-OT2].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[010f0c3a8d][OT2_S_v2_11_PL_IDT-xGen-EZ-24x-for-OT2].json
@@ -9688,7 +9688,32 @@
     "protocolName": "IDT xGEN EZ",
     "source": "Protocol Library"
   },
-  "modules": [],
+  "modules": [
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "1"
+      },
+      "model": "magneticModuleV2",
+      "serialNumber": "UUID"
+    },
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "3"
+      },
+      "model": "temperatureModuleV2",
+      "serialNumber": "UUID"
+    },
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "7"
+      },
+      "model": "thermocyclerModuleV1",
+      "serialNumber": "UUID"
+    }
+  ],
   "pipettes": [
     {
       "id": "UUID",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[0602eebc82][OT2_S_v2_13_PL_transient_transfection_of_HeLacells_Protocol_2].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[0602eebc82][OT2_S_v2_13_PL_transient_transfection_of_HeLacells_Protocol_2].json
@@ -9133,7 +9133,16 @@
     "description": "Protocol to transfect HeLa cells using the OT-2",
     "protocolName": "Transfection using Lipofectamine 3000 and Fugene HD Reagent"
   },
-  "modules": [],
+  "modules": [
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "1"
+      },
+      "model": "heaterShakerModuleV1",
+      "serialNumber": "UUID"
+    }
+  ],
   "pipettes": [
     {
       "id": "UUID",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[160f3e77e4][OT2_S_v2_9_PL_macherey-nagel-nucleomag-virus].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[160f3e77e4][OT2_S_v2_9_PL_macherey-nagel-nucleomag-virus].json
@@ -76663,7 +76663,16 @@
     "author": "Macherey-Nagel <automation-bio@mn-net.com>",
     "protocolName": "NucleoMag_Virus_Rev01"
   },
-  "modules": [],
+  "modules": [
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "10"
+      },
+      "model": "magneticModuleV2",
+      "serialNumber": "UUID"
+    }
+  ],
   "pipettes": [
     {
       "id": "UUID",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[1c19a2055c][OT2_S_v2_4_P300M_None_MM_TM_Zymo].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[1c19a2055c][OT2_S_v2_4_P300M_None_MM_TM_Zymo].json
@@ -81635,7 +81635,24 @@
     "author": "Opentrons <protocols@opentrons.com>",
     "protocolName": "Zymo Direct-zol96 Magbead RNA"
   },
-  "modules": [],
+  "modules": [
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "6"
+      },
+      "model": "magneticModuleV2",
+      "serialNumber": "UUID"
+    },
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "1"
+      },
+      "model": "temperatureModuleV2",
+      "serialNumber": "UUID"
+    }
+  ],
   "pipettes": [
     {
       "id": "UUID",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[1c5eb55b4b][OT2_S_v2_4_PL_sci-macherey-nagel-nucleomag].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[1c5eb55b4b][OT2_S_v2_4_PL_sci-macherey-nagel-nucleomag].json
@@ -19414,7 +19414,16 @@
     "author": "Opentrons <protocols@opentrons.com>",
     "protocolName": "NucleoMagÂ® Virus Viral DNA/RNA Isolation"
   },
-  "modules": [],
+  "modules": [
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "6"
+      },
+      "model": "magneticModuleV2",
+      "serialNumber": "UUID"
+    }
+  ],
   "pipettes": [
     {
       "id": "UUID",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[20048cb3d1][OT2_S_v2_9_PL_macherey-nagel-nucleomag-size-select].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[20048cb3d1][OT2_S_v2_9_PL_macherey-nagel-nucleomag-size-select].json
@@ -45141,7 +45141,16 @@
     "author": "Macherey-Nagel <automation-bio@mn-net.com>",
     "protocolName": "NucleoMag_NGS_double-size_select_Rev01"
   },
-  "modules": [],
+  "modules": [
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "10"
+      },
+      "model": "magneticModuleV2",
+      "serialNumber": "UUID"
+    }
+  ],
   "pipettes": [
     {
       "id": "UUID",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[3251c6e175][OT2_S_v2_2_P300S_None_MM1_MM2_EngageMagHeightFromBase].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[3251c6e175][OT2_S_v2_2_P300S_None_MM1_MM2_EngageMagHeightFromBase].json
@@ -1397,7 +1397,24 @@
   "metadata": {
     "apiLevel": "2.2"
   },
-  "modules": [],
+  "modules": [
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "1"
+      },
+      "model": "magneticModuleV1",
+      "serialNumber": "UUID"
+    },
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "4"
+      },
+      "model": "magneticModuleV2",
+      "serialNumber": "UUID"
+    }
+  ],
   "pipettes": [
     {
       "id": "UUID",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[38b7ac4410][OT2_S_v2_10_PL_swift-2s-turbo-pt1].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[38b7ac4410][OT2_S_v2_10_PL_swift-2s-turbo-pt1].json
@@ -9127,7 +9127,16 @@
     "protocolName": "Swift 2S Turbo DNA Library Kit Protocol: Part 1/3 -     Enzymatic Prep & Ligation",
     "source": "Protocol Library"
   },
-  "modules": [],
+  "modules": [
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "3"
+      },
+      "model": "temperatureModuleV1",
+      "serialNumber": "UUID"
+    }
+  ],
   "pipettes": [
     {
       "id": "UUID",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[463830e283][OT2_S_v2_9_PL_macherey-nagel-nucleomag-dna-food].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[463830e283][OT2_S_v2_9_PL_macherey-nagel-nucleomag-dna-food].json
@@ -104968,7 +104968,16 @@
     "author": "Macherey-Nagel <automation-bio@mn-net.com>",
     "protocolName": "NucleoMag_DNA_Food_Rev01"
   },
-  "modules": [],
+  "modules": [
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "10"
+      },
+      "model": "magneticModuleV2",
+      "serialNumber": "UUID"
+    }
+  ],
   "pipettes": [
     {
       "id": "UUID",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[552e4bfb25][OT2_S_v2_13_PL_transient_transfection_of_HeLacells_Protocol_1].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[552e4bfb25][OT2_S_v2_13_PL_transient_transfection_of_HeLacells_Protocol_1].json
@@ -3274,7 +3274,16 @@
     "description": "Protocol to transfect HeLa and A549 cells using the OT-2",
     "protocolName": "Transfection using Lipofectamine 3000 Reagent"
   },
-  "modules": [],
+  "modules": [
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "1"
+      },
+      "model": "heaterShakerModuleV1",
+      "serialNumber": "UUID"
+    }
+  ],
   "pipettes": [
     {
       "id": "UUID",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[56c0c2e8fc][OT2_S_v2_9_PL_macherey-nagel-nucleomag-tissue].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[56c0c2e8fc][OT2_S_v2_9_PL_macherey-nagel-nucleomag-tissue].json
@@ -91054,7 +91054,16 @@
     "author": "Macherey-Nagel <automation-bio@mn-net.com>",
     "protocolName": "NucleoMag_Tissue_Rev01"
   },
-  "modules": [],
+  "modules": [
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "10"
+      },
+      "model": "magneticModuleV2",
+      "serialNumber": "UUID"
+    }
+  ],
   "pipettes": [
     {
       "id": "UUID",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[5a248d53c7][OT2_S_v2_9_PL_macherey-nagel-nucleomag-rna].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[5a248d53c7][OT2_S_v2_9_PL_macherey-nagel-nucleomag-rna].json
@@ -143866,7 +143866,16 @@
     "author": "Macherey-Nagel <automation-bio@mn-net.com>",
     "protocolName": "NucleoMag_RNA_Rev01"
   },
-  "modules": [],
+  "modules": [
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "10"
+      },
+      "model": "magneticModuleV2",
+      "serialNumber": "UUID"
+    }
+  ],
   "pipettes": [
     {
       "id": "UUID",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[5cdd930bc8][OT2_S_v2_9_PL_sci-neb-next-ultra].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[5cdd930bc8][OT2_S_v2_9_PL_sci-neb-next-ultra].json
@@ -44905,7 +44905,32 @@
     "protocolName": "NEBNext® Ultra™ II DNA Library Prep Kit for Illumina®",
     "source": "Protocol Library"
   },
-  "modules": [],
+  "modules": [
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "7"
+      },
+      "model": "thermocyclerModuleV1",
+      "serialNumber": "UUID"
+    },
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "1"
+      },
+      "model": "magneticModuleV2",
+      "serialNumber": "UUID"
+    },
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "3"
+      },
+      "model": "temperatureModuleV2",
+      "serialNumber": "UUID"
+    }
+  ],
   "pipettes": [
     {
       "id": "UUID",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[5f50127d90][OT2_S_v2_4_PL_sci-mag-bind-blood-tissue-kit].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[5f50127d90][OT2_S_v2_4_PL_sci-mag-bind-blood-tissue-kit].json
@@ -21776,7 +21776,16 @@
     "author": "Opentrons <protocols@opentrons.com>",
     "protocolName": "Mag-BindÂ® Blood & Tissue DNA HDQ 96 Kit"
   },
-  "modules": [],
+  "modules": [
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "6"
+      },
+      "model": "magneticModuleV1",
+      "serialNumber": "UUID"
+    }
+  ],
   "pipettes": [
     {
       "id": "UUID",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[60ea56b776][OT2_S_v2_9_PL_macherey-nagel-nucleomag-clean-up].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[60ea56b776][OT2_S_v2_9_PL_macherey-nagel-nucleomag-clean-up].json
@@ -62896,7 +62896,16 @@
     "author": "Macherey-Nagel <automation-bio@mn-net.com>",
     "protocolName": "NucleoMag_NGS_clean_up_Rev01"
   },
-  "modules": [],
+  "modules": [
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "10"
+      },
+      "model": "magneticModuleV2",
+      "serialNumber": "UUID"
+    }
+  ],
   "pipettes": [
     {
       "id": "UUID",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6f3e297a11][OT2_S_v2_3_P300S_None_MM1_MM2_TM_Mix].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6f3e297a11][OT2_S_v2_3_P300S_None_MM1_MM2_TM_Mix].json
@@ -2792,7 +2792,32 @@
   "metadata": {
     "apiLevel": "2.3"
   },
-  "modules": [],
+  "modules": [
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "1"
+      },
+      "model": "magneticModuleV1",
+      "serialNumber": "UUID"
+    },
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "4"
+      },
+      "model": "magneticModuleV2",
+      "serialNumber": "UUID"
+    },
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "6"
+      },
+      "model": "temperatureModuleV2",
+      "serialNumber": "UUID"
+    }
+  ],
   "pipettes": [
     {
       "id": "UUID",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[7fba7321ed][OT2_S_v2_4_PL_sci-omegabiotek-extraction-fa].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[7fba7321ed][OT2_S_v2_4_PL_sci-omegabiotek-extraction-fa].json
@@ -171789,7 +171789,16 @@
     "protocolName": "Mag-BindÂ® Blood & Tissue DNA HDQ 96 Kit",
     "source": "Custom Protocol Request"
   },
-  "modules": [],
+  "modules": [
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "6"
+      },
+      "model": "magneticModuleV1",
+      "serialNumber": "UUID"
+    }
+  ],
   "pipettes": [
     {
       "id": "UUID",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[83bde2a1d4][OT2_S_v2_9_PL_macherey-nagel-nucleomag-dna-microbiome].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[83bde2a1d4][OT2_S_v2_9_PL_macherey-nagel-nucleomag-dna-microbiome].json
@@ -119551,7 +119551,16 @@
     "author": "Macherey-Nagel <automation-bio@mn-net.com>",
     "protocolName": "NucleoMag_DNA_Microbiome_Rev01"
   },
-  "modules": [],
+  "modules": [
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "10"
+      },
+      "model": "magneticModuleV2",
+      "serialNumber": "UUID"
+    }
+  ],
   "pipettes": [
     {
       "id": "UUID",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[8543b2a5aa][OT2_S_v2_4_PL_sci-omegabiotek-magbind-total-rna-96].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[8543b2a5aa][OT2_S_v2_4_PL_sci-omegabiotek-magbind-total-rna-96].json
@@ -32409,7 +32409,24 @@
     "author": "Opentrons <protocols@opentrons.com>",
     "protocolName": "Mag-BindÂ® Total RNA 96 Kit"
   },
-  "modules": [],
+  "modules": [
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "6"
+      },
+      "model": "magneticModuleV1",
+      "serialNumber": "UUID"
+    },
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "1"
+      },
+      "model": "temperatureModuleV2",
+      "serialNumber": "UUID"
+    }
+  ],
   "pipettes": [
     {
       "id": "UUID",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[88d6e7fc09][OT2_S_v2_13_PL_MagneSil_RNA_OT2].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[88d6e7fc09][OT2_S_v2_13_PL_MagneSil_RNA_OT2].json
@@ -29963,7 +29963,32 @@
     "author": "Opentrons <protocols@opentrons.com>",
     "protocolName": "Promega MagneSil Total RNA Extraction from Cells & Bacteria"
   },
-  "modules": [],
+  "modules": [
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "6"
+      },
+      "model": "magneticModuleV2",
+      "serialNumber": "UUID"
+    },
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "1"
+      },
+      "model": "temperatureModuleV2",
+      "serialNumber": "UUID"
+    },
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "10"
+      },
+      "model": "heaterShakerModuleV1",
+      "serialNumber": "UUID"
+    }
+  ],
   "pipettes": [
     {
       "id": "UUID",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[9618a6623c][OT2_X_v2_11_P300S_TC1_TC2_ThermocyclerMoamError].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[9618a6623c][OT2_X_v2_11_P300S_TC1_TC2_ThermocyclerMoamError].json
@@ -2706,7 +2706,16 @@
   "metadata": {
     "apiLevel": "2.11"
   },
-  "modules": [],
+  "modules": [
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "7"
+      },
+      "model": "thermocyclerModuleV2",
+      "serialNumber": "UUID"
+    }
+  ],
   "pipettes": [
     {
       "id": "UUID",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[96daaa8fbf][OT2_S_v2_9_PL_macherey-nagel-nucleomag-pathogen].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[96daaa8fbf][OT2_S_v2_9_PL_macherey-nagel-nucleomag-pathogen].json
@@ -96898,7 +96898,16 @@
     "author": "Macherey-Nagel <automation-bio@mn-net.com>",
     "protocolName": "NucleoMag_Pathogen_Rev01"
   },
-  "modules": [],
+  "modules": [
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "10"
+      },
+      "model": "magneticModuleV2",
+      "serialNumber": "UUID"
+    }
+  ],
   "pipettes": [
     {
       "id": "UUID",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a181c1ff39][OT2_S_v2_13_PL_cell_viability_and_cytotoxicity_assay_A549_cells].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a181c1ff39][OT2_S_v2_13_PL_cell_viability_and_cytotoxicity_assay_A549_cells].json
@@ -14709,7 +14709,16 @@
     "description": "To measure viability and cytotoxicity of A549 cells\ntreated with Thapsigargin using the OT-2",
     "protocolName": "Cell Viability and Cytotoxicity Assay"
   },
-  "modules": [],
+  "modules": [
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "1"
+      },
+      "model": "heaterShakerModuleV1",
+      "serialNumber": "UUID"
+    }
+  ],
   "pipettes": [
     {
       "id": "UUID",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a66d700ed6][OT2_S_v2_13_P300M_P20S_HS_TC_TM_SmokeTestV3].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a66d700ed6][OT2_S_v2_13_P300M_P20S_HS_TC_TM_SmokeTestV3].json
@@ -13192,7 +13192,32 @@
     "protocolName": "🛠️ 2.13 Smoke Test V3 🪄",
     "source": "Software Testing Team"
   },
-  "modules": [],
+  "modules": [
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "1"
+      },
+      "model": "heaterShakerModuleV1",
+      "serialNumber": "UUID"
+    },
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "9"
+      },
+      "model": "temperatureModuleV2",
+      "serialNumber": "UUID"
+    },
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "7"
+      },
+      "model": "thermocyclerModuleV2",
+      "serialNumber": "UUID"
+    }
+  ],
   "pipettes": [
     {
       "id": "UUID",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[ad957852f3][OT2_S_v2_4_PL_sci-promega-magnesil-total-rna-mini-isolation-system].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[ad957852f3][OT2_S_v2_4_PL_sci-promega-magnesil-total-rna-mini-isolation-system].json
@@ -145895,7 +145895,24 @@
     "author": "Opentrons <protocols@opentrons.com>",
     "protocolName": "MagneSil Total RNA Promega"
   },
-  "modules": [],
+  "modules": [
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "6"
+      },
+      "model": "magneticModuleV1",
+      "serialNumber": "UUID"
+    },
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "1"
+      },
+      "model": "temperatureModuleV2",
+      "serialNumber": "UUID"
+    }
+  ],
   "pipettes": [
     {
       "id": "UUID",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[b9b15682f9][OT2_S_v2_12_PL_sci-amplex-red].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[b9b15682f9][OT2_S_v2_12_PL_sci-amplex-red].json
@@ -32026,7 +32026,16 @@
     "description": "Protocol to measure hydrogen peroxide levels from THP-1 cells using the OT-2",
     "protocolName": "Amplex Red Hydrogen Peroxide Assay"
   },
-  "modules": [],
+  "modules": [
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "3"
+      },
+      "model": "temperatureModuleV1",
+      "serialNumber": "UUID"
+    }
+  ],
   "pipettes": [
     {
       "id": "UUID",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[bb91ddef8c][OT2_S_v2_9_PL_sci-idt-normalase].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[bb91ddef8c][OT2_S_v2_9_PL_sci-idt-normalase].json
@@ -6791,7 +6791,32 @@
     "protocolName": "IDT Normalase",
     "source": "Protocol Library"
   },
-  "modules": [],
+  "modules": [
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "1"
+      },
+      "model": "magneticModuleV2",
+      "serialNumber": "UUID"
+    },
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "3"
+      },
+      "model": "temperatureModuleV2",
+      "serialNumber": "UUID"
+    },
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "7"
+      },
+      "model": "thermocyclerModuleV1",
+      "serialNumber": "UUID"
+    }
+  ],
   "pipettes": [
     {
       "id": "UUID",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c821e64fad][OT2_S_v2_13_P300M_P20S_MM_TC_TM_Smoke620Release].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c821e64fad][OT2_S_v2_13_P300M_P20S_MM_TC_TM_Smoke620Release].json
@@ -10528,7 +10528,32 @@
     "protocolName": "🛠 Logo-Modules-CustomLabware 🛠",
     "source": "Software Testing Team"
   },
-  "modules": [],
+  "modules": [
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "9"
+      },
+      "model": "magneticModuleV2",
+      "serialNumber": "UUID"
+    },
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "4"
+      },
+      "model": "temperatureModuleV1",
+      "serialNumber": "UUID"
+    },
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "7"
+      },
+      "model": "thermocyclerModuleV2",
+      "serialNumber": "UUID"
+    }
+  ],
   "pipettes": [
     {
       "id": "UUID",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c8d4237127][OT2_S_v2_9_PL_sci-idt-xgen-mc].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c8d4237127][OT2_S_v2_9_PL_sci-idt-xgen-mc].json
@@ -9701,7 +9701,32 @@
     "protocolName": "IDT xGEN MC",
     "source": "Protocol Library"
   },
-  "modules": [],
+  "modules": [
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "1"
+      },
+      "model": "magneticModuleV2",
+      "serialNumber": "UUID"
+    },
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "3"
+      },
+      "model": "temperatureModuleV2",
+      "serialNumber": "UUID"
+    },
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "7"
+      },
+      "model": "thermocyclerModuleV1",
+      "serialNumber": "UUID"
+    }
+  ],
   "pipettes": [
     {
       "id": "UUID",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c9e6e3d59d][OT2_X_v4_P300M_P20S_MM_TC1_TM_e2eTests].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c9e6e3d59d][OT2_X_v4_P300M_P20S_MM_TC1_TM_e2eTests].json
@@ -6589,7 +6589,32 @@
     "subcategory": null,
     "tags": []
   },
-  "modules": [],
+  "modules": [
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "1"
+      },
+      "model": "magneticModuleV2",
+      "serialNumber": "UUID"
+    },
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "3"
+      },
+      "model": "temperatureModuleV2",
+      "serialNumber": "UUID"
+    },
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "7"
+      },
+      "model": "thermocyclerModuleV1",
+      "serialNumber": "UUID"
+    }
+  ],
   "pipettes": [
     {
       "id": "UUID",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[cdeb821849][OT2_S_v2_13_PL_Zymo_Magbead_DNA_OT2].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[cdeb821849][OT2_S_v2_13_PL_Zymo_Magbead_DNA_OT2].json
@@ -37278,7 +37278,24 @@
     "author": "Zach Galluzzo <zachary.galluzzo@opentrons.com>",
     "protocolName": "ZymoBIOMICs Magbead DNA Extraction from Cells"
   },
-  "modules": [],
+  "modules": [
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "6"
+      },
+      "model": "magneticModuleV2",
+      "serialNumber": "UUID"
+    },
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "10"
+      },
+      "model": "heaterShakerModuleV1",
+      "serialNumber": "UUID"
+    }
+  ],
   "pipettes": [
     {
       "id": "UUID",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[d50ea72948][OT2_S_v2_2_PL_omega_biotek_magbind_totalpure_ngs].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[d50ea72948][OT2_S_v2_2_PL_omega_biotek_magbind_totalpure_ngs].json
@@ -115181,7 +115181,16 @@
     "protocolName": "Omega Bio-tek Mag-Bind TotalPure NGS",
     "source": "Protocol Library"
   },
-  "modules": [],
+  "modules": [
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "1"
+      },
+      "model": "magneticModuleV1",
+      "serialNumber": "UUID"
+    }
+  ],
   "pipettes": [
     {
       "id": "UUID",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[e4660ca6df][OT2_S_v4_P300S_None_MM_TM_TM_MOAMTemps].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[e4660ca6df][OT2_S_v4_P300S_None_MM_TM_TM_MOAMTemps].json
@@ -1531,7 +1531,32 @@
     "subcategory": null,
     "tags": []
   },
-  "modules": [],
+  "modules": [
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "1"
+      },
+      "model": "magneticModuleV2",
+      "serialNumber": "UUID"
+    },
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "3"
+      },
+      "model": "temperatureModuleV2",
+      "serialNumber": "UUID"
+    },
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "6"
+      },
+      "model": "temperatureModuleV2",
+      "serialNumber": "UUID"
+    }
+  ],
   "pipettes": [
     {
       "id": "UUID",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[e58704f21b][OT2_S_v2_10_PL_swift-fully-automated].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[e58704f21b][OT2_S_v2_10_PL_swift-fully-automated].json
@@ -26773,7 +26773,32 @@
     "protocolName": "Swift 2S Turbo DNA Library Kit Protocol: Fully Automated",
     "source": "Protocol Library"
   },
-  "modules": [],
+  "modules": [
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "1"
+      },
+      "model": "magneticModuleV1",
+      "serialNumber": "UUID"
+    },
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "3"
+      },
+      "model": "temperatureModuleV1",
+      "serialNumber": "UUID"
+    },
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "7"
+      },
+      "model": "thermocyclerModuleV1",
+      "serialNumber": "UUID"
+    }
+  ],
   "pipettes": [
     {
       "id": "UUID",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[e898f1b208][OT2_S_v2_4_PL_sci-zymo-directzol-magbead].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[e898f1b208][OT2_S_v2_4_PL_sci-zymo-directzol-magbead].json
@@ -28897,7 +28897,24 @@
     "author": "Opentrons <protocols@opentrons.com>",
     "protocolName": "Zymo Research Direct-zolâ„¢-96 MagBead RNA Kit"
   },
-  "modules": [],
+  "modules": [
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "6"
+      },
+      "model": "magneticModuleV1",
+      "serialNumber": "UUID"
+    },
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "1"
+      },
+      "model": "temperatureModuleV2",
+      "serialNumber": "UUID"
+    }
+  ],
   "pipettes": [
     {
       "id": "UUID",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[e9ea6f5739][OT2_S_v2_9_PL_Illumina-DNA-Prep-24x-for-OT2].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[e9ea6f5739][OT2_S_v2_9_PL_Illumina-DNA-Prep-24x-for-OT2].json
@@ -97410,7 +97410,32 @@
     "protocolName": "Illumina DNA Prep",
     "source": "Protocol Library"
   },
-  "modules": [],
+  "modules": [
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "1"
+      },
+      "model": "magneticModuleV2",
+      "serialNumber": "UUID"
+    },
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "3"
+      },
+      "model": "temperatureModuleV2",
+      "serialNumber": "UUID"
+    },
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "7"
+      },
+      "model": "thermocyclerModuleV1",
+      "serialNumber": "UUID"
+    }
+  ],
   "pipettes": [
     {
       "id": "UUID",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f345e8e33a][OT2_S_v4_P300M_P20S_MM_TM_TC1_PD40].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f345e8e33a][OT2_S_v4_P300M_P20S_MM_TM_TC1_PD40].json
@@ -10030,7 +10030,32 @@
     "subcategory": null,
     "tags": []
   },
-  "modules": [],
+  "modules": [
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "1"
+      },
+      "model": "magneticModuleV2",
+      "serialNumber": "UUID"
+    },
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "3"
+      },
+      "model": "temperatureModuleV2",
+      "serialNumber": "UUID"
+    },
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "7"
+      },
+      "model": "thermocyclerModuleV1",
+      "serialNumber": "UUID"
+    }
+  ],
   "pipettes": [
     {
       "id": "UUID",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f62f9ee647][OT2_S_v2_13_PL_transient_transfection_of_A549cells_Protocol_2].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f62f9ee647][OT2_S_v2_13_PL_transient_transfection_of_A549cells_Protocol_2].json
@@ -9197,7 +9197,16 @@
     "description": "Protocol to transfect A549 cells using the OT-2",
     "protocolName": "Transfection using Lipofectamine 3000 and Fugene HD Reagent"
   },
-  "modules": [],
+  "modules": [
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "1"
+      },
+      "model": "heaterShakerModuleV1",
+      "serialNumber": "UUID"
+    }
+  ],
   "pipettes": [
     {
       "id": "UUID",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f967029946][OT2_S_v2_13_PL_cell_viability_and_cytotoxicity_assay_K562_cells].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f967029946][OT2_S_v2_13_PL_cell_viability_and_cytotoxicity_assay_K562_cells].json
@@ -14709,7 +14709,16 @@
     "description": "To measure viability and cytotoxicity of K562 cells \ntreated with Bortezomib using the OT-2",
     "protocolName": "Cell Viability and Cytotoxicity Assay"
   },
-  "modules": [],
+  "modules": [
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "1"
+      },
+      "model": "heaterShakerModuleV1",
+      "serialNumber": "UUID"
+    }
+  ],
   "pipettes": [
     {
       "id": "UUID",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[fa24954076][OT2_S_v2_9_PL_bc-rnadvance-viral].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[fa24954076][OT2_S_v2_9_PL_bc-rnadvance-viral].json
@@ -84147,7 +84147,24 @@
     "author": "Opentrons <protocols@opentrons.com>",
     "protocolName": "Beckman Coulter RNAdvance Viral RNA Isolation"
   },
-  "modules": [],
+  "modules": [
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "6"
+      },
+      "model": "magneticModuleV2",
+      "serialNumber": "UUID"
+    },
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "1"
+      },
+      "model": "temperatureModuleV2",
+      "serialNumber": "UUID"
+    }
+  ],
   "pipettes": [
     {
       "id": "UUID",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[ff4a494935][OT2_S_v2_4_PL_nucleic_acid_purification_with_magnetic_beads].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[ff4a494935][OT2_S_v2_4_PL_nucleic_acid_purification_with_magnetic_beads].json
@@ -33546,7 +33546,16 @@
     "protocolName": "DNA Purification",
     "source": "Protocol Library"
   },
-  "modules": [],
+  "modules": [
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "1"
+      },
+      "model": "magneticModuleV1",
+      "serialNumber": "UUID"
+    }
+  ],
   "pipettes": [
     {
       "id": "UUID",

--- a/api/src/opentrons/protocol_runner/legacy_command_mapper.py
+++ b/api/src/opentrons/protocol_runner/legacy_command_mapper.py
@@ -846,7 +846,7 @@ class LegacyCommandMapper:
             module_id=module_id,
             definition=loaded_definition,
             slot_name=module_load_info.deck_slot,
-            requested_model=loaded_model,
+            requested_model=requested_model,
             serial_number=module_load_info.module_serial,
         )
         succeed_action = pe_actions.SucceedCommandAction(

--- a/api/src/opentrons/protocol_runner/legacy_command_mapper.py
+++ b/api/src/opentrons/protocol_runner/legacy_command_mapper.py
@@ -841,8 +841,16 @@ class LegacyCommandMapper:
             # We just set this above, so we know it's not None.
             started_at=succeeded_command.startedAt,  # type: ignore[arg-type]
         )
+        state_update = StateUpdate()
+        state_update.set_load_module(
+            module_id=module_id,
+            definition=loaded_definition,
+            slot_name=module_load_info.deck_slot,
+            requested_model=loaded_model,
+            serial_number=module_load_info.module_serial,
+        )
         succeed_action = pe_actions.SucceedCommandAction(
-            command=succeeded_command, state_update=StateUpdate()
+            command=succeeded_command, state_update=state_update
         )
 
         self._command_count["LOAD_MODULE"] = count + 1

--- a/api/tests/opentrons/protocol_runner/test_legacy_command_mapper.py
+++ b/api/tests/opentrons/protocol_runner/test_legacy_command_mapper.py
@@ -466,7 +466,7 @@ def test_map_module_load(
                 module_id=matchers.IsA(str),
                 definition=test_definition,
                 slot_name=DeckSlotName.SLOT_1,
-                requested_model=ModuleModel.TEMPERATURE_MODULE_V2,
+                requested_model=ModuleModel.TEMPERATURE_MODULE_V1,
                 serial_number="module-serial",
             )
         ),

--- a/api/tests/opentrons/protocol_runner/test_legacy_command_mapper.py
+++ b/api/tests/opentrons/protocol_runner/test_legacy_command_mapper.py
@@ -7,6 +7,7 @@ from typing import cast
 from opentrons.protocol_engine.state.update_types import (
     LoadPipetteUpdate,
     LoadedLabwareUpdate,
+    LoadModuleUpdate,
     PipetteConfigUpdate,
     StateUpdate,
 )
@@ -459,6 +460,15 @@ def test_map_module_load(
                 model=ModuleModel.TEMPERATURE_MODULE_V2,
             ),
             notes=[],
+        ),
+        state_update=StateUpdate(
+            loaded_module=LoadModuleUpdate(
+                module_id=matchers.IsA(str),
+                definition=test_definition,
+                slot_name=DeckSlotName.SLOT_1,
+                requested_model=ModuleModel.TEMPERATURE_MODULE_V2,
+                serial_number="module-serial",
+            )
         ),
     )
 


### PR DESCRIPTION
# Overview

In RESC-513, a customer reported a magnetic module not appearing on the deck layout or in LPC after updating from robot release 8.5.0 to 8.7.0.

Upon further investigation, the problem was found to be related to the refactor of updating PE state from the command results to `StateUpdate` handling. The change was made in #18639 but the corresponding updates to the legacy command mapper were not made. This has the effect of breaking anything that relies on that module field of the analysis results to be filled, which most obviously are the deck layout and LPC.

The fix for this is putting in the legacy command mapper the correct state update, which was already being done for pipette and labware commands.

## Test Plan and Hands on Testing

The customer's protocol in the linked ticket was tested, but this minimal reproducible protocol was tested too and now works as expected:

```python
requirements = {
    "robotType": "OT-2",
    "apiLevel": "2.8",
}

metadata = {
    "protocolName":'OT-2 module loading test',
}

def run(protocol_context):
    tiprack_1 = protocol_context.load_labware('opentrons_96_tiprack_300ul', 8)
    tiprack_2 = protocol_context.load_labware('opentrons_96_tiprack_300ul', 9)

    pipette = protocol_context.load_instrument('p300_multi_gen2', 'left', tip_racks=[tiprack_1, tiprack_2])

    magdeck = protocol_context.load_module('magnetic module gen2', 7)
    mag_plate = magdeck.load_labware('armadillo_96_wellplate_200ul_pcr_full_skirt')
    heater_shaker = protocol_context.load_module('temperatureModuleV2', 1)

    pipette.pick_up_tip()
    pipette.aspirate(50, mag_plate.wells()[0].top(-1))
    pipette.dispense()
    pipette.drop_tip()
```

## Changelog

- call `set_load_module` on `StateUpdate` in legacy command mapper `_map_module_load`

## Review requests


## Risk assessment

Low, this only affects OT-2 protocols on versions 2.13 and below and this fix follows the existing pattern we have for pipette and labware loads, which do work on older versions.