### PR TITLE
refactor(hardware): Implement EEPROM SKU changes to hardware

### DIFF
--- a/hardware/opentrons_hardware/drivers/eeprom/eeprom.py
+++ b/hardware/opentrons_hardware/drivers/eeprom/eeprom.py
@@ -26,6 +26,10 @@ DEFAULT_BUS = 3
 DEFAULT_ADDRESS = "0050"
 DEFAULT_READ_SIZE = 64
 
+# The expected datagram lengths for EEPROM conent
+DEFAULT_MIN_SERIAL_LENGTH = 17
+DEFAULT_MIN_SKU_LENGTH = 9
+
 
 class EEPROMDriver:
     """This class lets you read/write to the eeprom using a sysfs file."""
@@ -241,7 +245,10 @@ class EEPROMDriver:
         for prop in self._properties:
             if prop.id == PropId.FORMAT_VERSION:
                 self._eeprom_data.format_version = prop.value
-            elif prop.id == PropId.SERIAL_NUMBER and len(prop.value) >= 17:
+            elif (
+                prop.id == PropId.SERIAL_NUMBER
+                and len(prop.value) >= DEFAULT_MIN_SERIAL_LENGTH
+            ):
                 self._eeprom_data.serial_number = prop.value
                 self._eeprom_data.machine_type = prop.value[:3]
                 self._eeprom_data.machine_version = prop.value[3:6]
@@ -250,6 +257,17 @@ class EEPROMDriver:
                     date_string, "%Y%m%d"
                 )
                 self._eeprom_data.unit_number = int(prop.value[14:17])
-            elif prop.id == PropId.SKU and len(prop.value) >= 9:
+            elif (
+                prop.id == PropId.SERIAL_NUMBER
+                and len(prop.value) < DEFAULT_MIN_SERIAL_LENGTH
+            ):
+                logging.error(
+                    f"Could not populate eeprom data with serial number, data length of {DEFAULT_MIN_SERIAL_LENGTH} or higher required."
+                )
+            elif prop.id == PropId.SKU and len(prop.value) >= DEFAULT_MIN_SKU_LENGTH:
                 self._eeprom_data.sku = str(prop.value)
+            elif prop.id == PropId.SKU and len(prop.value) < DEFAULT_MIN_SKU_LENGTH:
+                logging.error(
+                    f"Could not populate eeprom data with device SKU, data length of {DEFAULT_MIN_SKU_LENGTH} or higher required."
+                )
         return self._eeprom_data

--- a/hardware/opentrons_hardware/drivers/eeprom/eeprom.py
+++ b/hardware/opentrons_hardware/drivers/eeprom/eeprom.py
@@ -250,4 +250,6 @@ class EEPROMDriver:
                     date_string, "%Y%m%d"
                 )
                 self._eeprom_data.unit_number = int(prop.value[14:17])
+            elif prop.id == PropId.SKU and len(prop.value) >= 9:
+                self._eeprom_data.sku = str(prop.value)
         return self._eeprom_data

--- a/hardware/opentrons_hardware/drivers/eeprom/types.py
+++ b/hardware/opentrons_hardware/drivers/eeprom/types.py
@@ -81,4 +81,4 @@ class EEPROMData:
             eeprom_set.add((PropId.SERIAL_NUMBER, self.serial_number))
         if self.sku:
             eeprom_set.add((PropId.SKU, self.sku))
-        return eeprom_set   
+        return eeprom_set

--- a/hardware/opentrons_hardware/drivers/eeprom/types.py
+++ b/hardware/opentrons_hardware/drivers/eeprom/types.py
@@ -21,6 +21,7 @@ class PropId(Enum):
     INVALID = 0xFF
     FORMAT_VERSION = 1
     SERIAL_NUMBER = 2
+    SKU = 3
 
 
 class PropType(Enum):
@@ -37,6 +38,7 @@ class PropType(Enum):
 PROP_ID_TYPES = {
     PropId.FORMAT_VERSION: PropType.BYTE,
     PropId.SERIAL_NUMBER: PropType.STR,
+    PropId.SKU: PropType.STR,
 }
 
 PROP_TYPE_SIZE = {
@@ -69,3 +71,14 @@ class EEPROMData:
     machine_version: Optional[str] = None
     programmed_date: Optional[datetime] = None
     unit_number: Optional[int] = None
+    sku: Optional[str] = None
+
+    def to_set(self) -> set[tuple[PropId, str | int]]:
+        """Returns a set of expected data values paired with a property id."""
+        eeprom_set: set[tuple[PropId, str | int]] = set()
+        eeprom_set.add((PropId.FORMAT_VERSION, self.format_version))
+        if self.serial_number:
+            eeprom_set.add((PropId.SERIAL_NUMBER, self.serial_number))
+        if self.sku:
+            eeprom_set.add((PropId.SKU, self.sku))
+        return eeprom_set   


### PR DESCRIPTION
# Overview
Originally this was part of This PR: https://github.com/Opentrons/opentrons/pull/20081

This has been broken out into a separate PR to reduce factory hardware testing dependency on repository changes.

## Test Plan and Hands on Testing


## Changelog


## Review requests


## Risk assessment
Low - we're extending the existing EEPROM data to include the SKU optionally, for now only ultima robots with no cameras will have that info.