### PR TITLE
refactor(app): tell TypeScript that aspirateState/dispenseState are part of QuickTransferSummaryState

### DIFF
--- a/app/src/organisms/ODD/QuickTransferFlow/utils/retrieveLiquidClassValues.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/utils/retrieveLiquidClassValues.ts
@@ -166,7 +166,7 @@ const getNoLiquidClassValues = (
     dispenseMaxUiFlowRate
   )
 
-  const aspirateState = {
+  const aspirateState: Partial<QuickTransferSummaryState> = {
     aspirateFlowRate: aspirateFlowRateFields.aspirate_flowRate ?? 0,
     tipPositionAspirate: DEFAULT_MM_OFFSET_FROM_BOTTOM,
     submergeAspirate: {
@@ -193,7 +193,7 @@ const getNoLiquidClassValues = (
     conditionAspirate: actualConditioningVolume ?? 0,
   }
 
-  const dispenseState = {
+  const dispenseState: Partial<QuickTransferSummaryState> = {
     dispenseFlowRate: dispenseFlowRateFields.dispense_flowRate ?? 0,
     tipPositionDispense: DEFAULT_MM_OFFSET_FROM_BOTTOM,
     submergeDispense: {


### PR DESCRIPTION
# Overview

This is a type-hinting change to tell TypeScript that the `aspirateState`/`dispenseState` in `retrieveLiquidClassValues.ts` is part of `QuickTransferSummaryState`.

Without this, VS Code doesn't find this file when we're looking for places that touch `.disposalVolumeDispenseSettings`, wasting a lot of time for programmers trying to find what is setting that field.

Adding this annotation also helps TypeScript catch typos. For example, if this file had accidentally misspelled the field as `disposalVolumeDispenseSettingsxx`, TypeScript would now complain about it.

## Test Plan and Hands on Testing

Just run CI.

## Risk assessment

Very low. No functional change whatsoever.