### PR TITLE
(docs)api: dynamic pipetting actions

### DIFF
--- a/api/docs/v2/basic_commands/liquids.rst
+++ b/api/docs/v2/basic_commands/liquids.rst
@@ -402,44 +402,25 @@ And this example adds a push out of 10 µL after the final dispense in the mix::
 Dynamic Mix
 ===========
 
-The :py:meth:`~.InstrumentContext.dynamic_mix` method lets you aspirate and dispense repeatedly in multiple locations. Like the :py:meth:`~InstrumentContext.mix` method, it's designed to mix the contents of a well together using a single command rather than using multiple ``aspirate()`` and ``dispense()`` calls. Both methods includes argument that let you specify the number of times to mix, the volume (in µL) of liquid, and the well that contains the liquid you want to mix. :py:meth:`~.InstrumentContext.dynamic_mix` lets you additionally specify multiple aspirate and dispense locations:: 
+The :py:meth:`~.InstrumentContext.dynamic_mix` method lets you aspirate and dispense repeatedly in multiple locations. Like the :py:meth:`~.InstrumentContext.mix` method, it's designed to mix the contents of a well together using a single command rather than using multiple ``aspirate()`` and ``dispense()`` calls. Both methods includes argument that let you specify the number of times to mix, the volume (in µL) of liquid, and the well that contains the liquid you want to mix. :py:meth:`~.InstrumentContext.dynamic_mix` lets you additionally specify multiple aspirate and dispense locations:: 
 
-    
-
-This example draws 100 µL from the current well and mixes it three times::
-
-    pipette.mix(repetitions=3, volume=100)
-
-This example draws 100 µL from well B1 and mixes it three times::
-
-    pipette.mix(3, 100, plate["B1"])
-
-This example draws an amount equal to the pipette's maximum rated volume and mixes it three times::
-
-    pipette.mix(repetitions=3)
-
-Like an ``aspirate()`` or ``dispense()``, you can use optional arguments to specify the flow rate, a delay, or a push out after an aspirate or dispense in the mix.
-
-This example draws 100 µL from the current well and mixes it three times, aspirating at 50 µL/sec and with a 5 second delay after each aspirate::
-
-    pipette.mix(
-        repetitions=3,
-        volume=100,
-        aspirate_flow_rate=50,
-        aspirate_delay=5
+    depth = plate["A1"].bottom(z=2)
+    well_top = plate["A1"].top(z=-1)
+    pipette.dynamic_mix(
+        aspirate_start_location=depth
+        dispense_start_location=well_top
+        repetitions=3
+        volume=100
+        aspirate_end_location=well_top
+        dispense_end_location=depth
     )
 
-And this example adds a push out of 10 µL after the final dispense in the mix::
+Like the :py:meth:`~.InstrumentContext.mix` method, you can use other optional arguments customize your dynamic mix: 
+- specify the aspirate, dispense, or mix flow rate.
+- add a delay after an aspirate or dispense, or a ``movement_delay`` before moving to an ``end_location``.
+- include or a push out after an aspirate or dispense in the mix.
 
-    pipette.mix(repetitions=3, volume=100, final_push_out=10)
-
-.. note::
-
-    In API versions 2.2 and earlier, during a mix, the pipette moves up and out of the target well. In API versions 2.3 and later, the pipette does not move while mixing.
-
-.. versionadded:: 2.0
-.. versionchanged:: 2.24
-    Adds the ``aspirate_flow_rate``, ``dispense_flow_rate``, ``aspirate_delay``, ``dispense_delay``, and ``final_push_out`` parameters.
+.. versionadded:: 2.27
 
 .. _air-gap:
 

--- a/api/docs/v2/basic_commands/liquids.rst
+++ b/api/docs/v2/basic_commands/liquids.rst
@@ -39,6 +39,9 @@ The :py:meth:`~.InstrumentContext.aspirate` method includes the location paramet
 - ``location`` accepts either a :py:class:`.Well` or a :py:class:`~.types.Location`.
 - ``end_location`` can only be used in combination with the ``location`` parameter. Both must be a  :py:class:`~.types.Location`. 
 
+.. versionchanged:: 2.27
+    Use the ``end_location`` parameter to specify multiple locations during an aspirate. 
+
 If you specify a single ``location`` like the well ``"A1"``, the pipette will aspirate from a default position 1 mm above the bottom center of that well. To change the default clearance, first set the ``aspirate`` attribute of :py:obj:`.well_bottom_clearance`:: 
 
     pipette.pick_up_tip
@@ -67,6 +70,9 @@ This example measures the liquid height in well A2 of a plate and then immediate
         ) 
     # aspirates at 1 mm below the liquid meniscus
 
+.. versionadded:: 2.23
+    Set ``target="start"`` or ``"end"`` to target the liquid meniscus during an aspirate. 
+
 To ensure the pipette stays submerged while aspirating, set ``target="end"`` for the aspirate or use multiple location parameters. For more, see :ref:`well-meniscus`. 
 
 !!! note:: 
@@ -81,12 +87,13 @@ Use the ``location`` and ``end_location`` parameters in combination to direct th
         volume=200,
         location=well_top,
         end_location=depth
-        movement_delay=1
     )
 
-Here, the pipette begins aspirating at 1 mm below the well top, and finishes aspirating at 2 mm above the well bottom. When you use both the ``location`` and ``end_location`` parameters, you can optionally specify a ``movement_delay`` to ensure the pipette waits a set amount of time, like 1 second, before moving to the ``end_location``. 
+Here, the pipette begins aspirating at 1 mm below the well top, and finishes aspirating at 2 mm above the well bottom. 
 
-.. versionadded:: 2.23
+.. note:: 
+    When you use both the ``location`` and ``end_location`` parameters, you can optionally specify a ``movement_delay`` to ensure the pipette waits a set amount of time in seconds before moving to the ``end_location``. This can be useful when pipetting viscous liquids. An additional 1 second ``movement_delay`` can help build up pressure in the tip before liquid starts to flow. 
+
 .. versionchanged:: 2.27
     Use the ``end_location`` and ``movement_delay`` parameters when specifying multiple locations in a single aspirate. 
 
@@ -152,6 +159,9 @@ The :py:meth:`~.InstrumentContext.dispense` method includes the ``location`` par
 - ``location`` accepts either a :py:class:`.Well` or a :py:class:`~.types.Location`.
 - ``end_location`` can only be used in combination with the ``location`` parameter. Both must be a :py:class:`~.types.Location`. 
 
+.. versionchanged:: 2.27
+     Use the ``end_location`` parameter to specify multiple locations during a dispense. 
+
 If you specify a single ``location`` like the well ``"B1"``, the pipette will dispense from a default position 1 mm above the bottom center of that well. To change the default clearance, you would call :py:obj:`.well_bottom_clearance`::
 
     pipette.well_bottom_clearance.dispense=2 # tip is 2 mm above well bottom
@@ -177,6 +187,9 @@ This example measures the liquid height in well B1 of a plate and then immediate
         ) 
     # dispenses at 1 mm below the liquid meniscus
 
+.. versionadded:: 2.23
+    Set ``target="start"`` or ``"end"`` to target the liquid meniscus during a dispense.
+
 To ensure the pipette begins the dispense at the liquid meniscus, set ``target="start"``. See :ref:`well-meniscus` for more details on pipetting relative to the liquid meniscus. 
 
 !!! note::
@@ -196,7 +209,6 @@ You can use the ``location`` and ``end_location`` parameters in combination to d
 
 Here, the pipette begins dispensing at 2 mm above the well bottom, and finishes dispensing at 1 mm below the well top. When you use both the ``location`` and ``end_location`` parameters, you can optionally specify a ``movement_delay`` to ensure the pipette waits a set amount of time, like 1 second, before moving to the ``end_location``. 
 
-.. versionadded:: 2.23
 .. versionchanged:: 2.27
     Use the ``end_location`` and ``movement_delay`` parameters when specifying multiple locations in a single dispense.
 
@@ -224,8 +236,6 @@ You can also specify an absolute ``flow_rate`` to set the flow rate in µL/secon
     Add the dispense ``flow_rate`` parameter. 
 
 The ``rate`` and ``flow_rate`` parameters are mutually exclusive. If you specify both in the same command, the API will raise an error.  
-
-
 
 
 .. _push-out-dispense:
@@ -407,12 +417,12 @@ The :py:meth:`~.InstrumentContext.dynamic_mix` method lets you aspirate and disp
     depth = plate["A1"].bottom(z=2)
     well_top = plate["A1"].top(z=-1)
     pipette.dynamic_mix(
-        aspirate_start_location=depth
-        dispense_start_location=well_top
-        repetitions=3
+        aspirate_start_location=depth,
+        aspirate_end_location=well_top,
+        dispense_start_location=well_top,
+        dispense_end_location=depth,
+        repetitions=3,
         volume=100
-        aspirate_end_location=well_top
-        dispense_end_location=depth
     )
 
 Like the :py:meth:`~.InstrumentContext.mix` method, you can use other optional arguments customize your dynamic mix: 

--- a/api/docs/v2/basic_commands/liquids.rst
+++ b/api/docs/v2/basic_commands/liquids.rst
@@ -34,15 +34,18 @@ Now our pipette holds 300 µL.
 Aspirate by Well or Location
 ----------------------------
 
-The :py:meth:`~.InstrumentContext.aspirate` method includes a ``location`` parameter that accepts either a :py:class:`.Well` or a :py:class:`~.types.Location`. 
+The :py:meth:`~.InstrumentContext.aspirate` method includes the location parameters ``location`` and ``end_location``. Each accepts different location types:
 
-If you specify a well, like ``plate["A1"]``, the pipette will aspirate from a default position 1 mm above the bottom center of that well. To change the default clearance, first set the ``aspirate`` attribute of :py:obj:`.well_bottom_clearance`:: 
+- ``location`` accepts either a :py:class:`.Well` or a :py:class:`~.types.Location`.
+- ``end_location`` can only be used in combination with the ``location`` parameter. Both must be a  :py:class:`~.types.Location`. 
+
+If you specify a single ``location`` like the well ``"A1"``, the pipette will aspirate from a default position 1 mm above the bottom center of that well. To change the default clearance, first set the ``aspirate`` attribute of :py:obj:`.well_bottom_clearance`:: 
 
     pipette.pick_up_tip
     pipette.well_bottom_clearance.aspirate = 2  # tip is 2 mm above well bottom
     pipette.aspirate(200, plate["A1"])
 
-You can also aspirate from a location along the center vertical axis within a well using the :py:meth:`.Well.top` and :py:meth:`.Well.bottom` methods. These methods move the pipette to a specified distance relative to the top or bottom center of a well::
+You can also aspirate from a :py:class:`~.types.Location` along the center vertical axis within a well using the :py:meth:`.Well.top` and :py:meth:`.Well.bottom` methods. These methods move the pipette to a specified distance relative to the top or bottom center of a well::
 
     pipette.pick_up_tip()
     depth = plate["A1"].bottom(z=2) # tip is 2 mm above well bottom
@@ -52,7 +55,7 @@ You can also aspirate from a location along the center vertical axis within a we
 Use the :py:meth:`.Well.meniscus` method to aspirate relative to the meniscus of liquid in a well with a Flex pipette. First, you'll need to determine the amount of liquid in your well one of two ways: 
 
 - Specify your starting liquid volume with :py:meth:`~.Labware.load_liquid`.
-- Measure the height of the liquid with :py:meth:`~.InstrumentContext.measure_liquid_height`. 
+- Measure the height of the liquid with :py:meth:`~.InstrumentContext.measure_liquid_height`.
 
 This example measures the liquid height in well A2 of a plate and then immediately aspirates below the meniscus:: 
 
@@ -64,17 +67,35 @@ This example measures the liquid height in well A2 of a plate and then immediate
         ) 
     # aspirates at 1 mm below the liquid meniscus
 
-The liquid meniscus changes when you aspirate liquid from a well. Set ``target="end"`` to ensure the pipette stays submerged while aspirating. For more information, see :ref:`well-meniscus`.
+To ensure the pipette stays submerged while aspirating, set ``target="end"`` for the aspirate or use multiple location parameters. For more, see :ref:`well-meniscus`. 
 
-``measure_liquid_height()`` works best with a new pipette tip each time. To save time and tips throughout your protocol, use ``Labware.load_liquid`` instead to specify starting liquid volumes.
+!!! note:: 
+    ``measure_liquid_height()`` works best with a new pipette tip each time. To save time and tips throughout your protocol, use ``Labware.load_liquid`` instead to specify starting liquid volumes.
+
+Use the ``location`` and ``end_location`` parameters in combination to direct the pipette to move to specific locations while aspirating::
+
+    pipette.pick_up_tip()
+    well_top = plate["A1"].top(z=-1)
+    depth = plate["A1"].bottom(z=2)
+    pipette.aspirate(
+        volume=200,
+        location=well_top,
+        end_location=depth
+        movement_delay=1
+    )
+
+Here, the pipette begins aspirating at 1 mm below the well top, and finishes aspirating at 2 mm above the well bottom. When you use both the ``location`` and ``end_location`` parameters, you can optionally specify a ``movement_delay`` to ensure the pipette waits a set amount of time, like 1 second, before moving to the ``end_location``. 
 
 .. versionadded:: 2.23
+.. versionchanged:: 2.27
+    Use the ``end_location`` and ``movement_delay`` parameters when specifying multiple locations in a single aspirate. 
 
 See also:
 
 - :ref:`new-default-op-positions` for information about controlling pipette height for a particular pipette.
 - :ref:`position-relative-labware` for information about controlling pipette height from within a well.
 - :ref:`move-to` for information about moving a pipette to any reachable deck location.
+- :ref:`well-meniscus` for information about pipetting relative to the liquid meniscus as it changes during an aspirate. 
 
 Aspiration Flow Rates
 ---------------------
@@ -126,9 +147,12 @@ If the pipette doesn’t move, you can specify an additional dispense action wit
 Dispense by Well or Location
 ----------------------------
 
-The :py:meth:`~.InstrumentContext.dispense` method includes a ``location`` parameter that accepts either a :py:class:`.Well` or a :py:class:`~.types.Location`.
+The :py:meth:`~.InstrumentContext.dispense` method includes the ``location`` parameters ``location`` and ``end_location``. Each accepts different location types: 
 
-If you specify a well, like ``plate["B1"]``, the pipette will dispense from a default position 1 mm above the bottom center of that well. To change the default clearance, you would call :py:obj:`.well_bottom_clearance`::
+- ``location`` accepts either a :py:class:`.Well` or a :py:class:`~.types.Location`.
+- ``end_location`` can only be used in combination with the ``location`` parameter. Both must be a :py:class:`~.types.Location`. 
+
+If you specify a single ``location`` like the well ``"B1"``, the pipette will dispense from a default position 1 mm above the bottom center of that well. To change the default clearance, you would call :py:obj:`.well_bottom_clearance`::
 
     pipette.well_bottom_clearance.dispense=2 # tip is 2 mm above well bottom
     pipette.dispense(200, plate["B1"])
@@ -153,17 +177,35 @@ This example measures the liquid height in well B1 of a plate and then immediate
         ) 
     # dispenses at 1 mm below the liquid meniscus
 
-The liquid meniscus changes when you dispense liquid into a well. Set ``target="start"`` to ensure the pipette begins the dispense at the liquid meniscus. For more information, see :ref:`well-meniscus`.
+To ensure the pipette begins the dispense at the liquid meniscus, set ``target="start"``. See :ref:`well-meniscus` for more details on pipetting relative to the liquid meniscus. 
 
-``measure_liquid_height()`` works best with a new pipette tip each time. To save time and tips throughout your protocol, use ``Labware.load_liquid`` instead to specify starting liquid volumes.
+!!! note::
+    ``measure_liquid_height()`` works best with a new pipette tip each time. To save time and tips throughout your protocol, use ``Labware.load_liquid`` instead to specify starting liquid volumes. 
+
+
+You can use the ``location`` and ``end_location`` parameters in combination to direct the pipette to move to specific locations while dispensing:: 
+
+    well_top = plate["B1"].top(z=-1)
+    depth = plate["B1"].bottom(z=2)
+    pipette.dispense(
+        volume=200,
+        location=depth,
+        end_location=well_top,
+        movement_delay=1
+    )
+
+Here, the pipette begins dispensing at 2 mm above the well bottom, and finishes dispensing at 1 mm below the well top. When you use both the ``location`` and ``end_location`` parameters, you can optionally specify a ``movement_delay`` to ensure the pipette waits a set amount of time, like 1 second, before moving to the ``end_location``. 
 
 .. versionadded:: 2.23
+.. versionchanged:: 2.27
+    Use the ``end_location`` and ``movement_delay`` parameters when specifying multiple locations in a single dispense.
 
 See also:
 
 - :ref:`new-default-op-positions` for information about controlling pipette height for a particular pipette.
 - :ref:`position-relative-labware` for formation about controlling pipette height from within a well.
 - :ref:`move-to` for information about moving a pipette to any reachable deck location.
+- :ref:`well-meniscus` for information about pipetting relative to the liquid meniscus as it changes during a dispense. 
 
 Dispense Flow Rates
 -------------------
@@ -360,7 +402,9 @@ And this example adds a push out of 10 µL after the final dispense in the mix::
 Dynamic Mix
 ===========
 
-The :py:meth:`~.InstrumentContext.dynamic_mix` method aspirates and dispenses repeatedly in a multiple locations. It's designed to mix the contents of a well together using a single command rather than using multiple ``aspirate()`` and ``dispense()`` calls. This method includes arguments that let you specify the number of times to mix, the volume (in µL) of liquid, and the well that contains the liquid you want to mix.
+The :py:meth:`~.InstrumentContext.dynamic_mix` method lets you aspirate and dispense repeatedly in multiple locations. Like the :py:meth:`~InstrumentContext.mix` method, it's designed to mix the contents of a well together using a single command rather than using multiple ``aspirate()`` and ``dispense()`` calls. Both methods includes argument that let you specify the number of times to mix, the volume (in µL) of liquid, and the well that contains the liquid you want to mix. :py:meth:`~.InstrumentContext.dynamic_mix` lets you additionally specify multiple aspirate and dispense locations:: 
+
+    
 
 This example draws 100 µL from the current well and mixes it three times::
 

--- a/api/docs/v2/basic_commands/liquids.rst
+++ b/api/docs/v2/basic_commands/liquids.rst
@@ -418,7 +418,7 @@ The :py:meth:`~.InstrumentContext.dynamic_mix` method lets you aspirate and disp
 Like the :py:meth:`~.InstrumentContext.mix` method, you can use other optional arguments customize your dynamic mix: 
 - specify the aspirate, dispense, or mix flow rate.
 - add a delay after an aspirate or dispense, or a ``movement_delay`` before moving to an ``end_location``.
-- include or a push out after an aspirate or dispense in the mix.
+- include a push out after an aspirate or dispense in the mix.
 
 .. versionadded:: 2.27
 

--- a/api/docs/v2/basic_commands/liquids.rst
+++ b/api/docs/v2/basic_commands/liquids.rst
@@ -425,7 +425,8 @@ The :py:meth:`~.InstrumentContext.dynamic_mix` method lets you aspirate and disp
         volume=100
     )
 
-Like the :py:meth:`~.InstrumentContext.mix` method, you can use other optional arguments customize your dynamic mix: 
+Like the :py:meth:`~.InstrumentContext.mix` method, you can use other optional arguments to customize your dynamic mix: 
+
 - specify the aspirate, dispense, or mix flow rate.
 - add a delay after an aspirate or dispense, or a ``movement_delay`` before moving to an ``end_location``.
 - include a push out after an aspirate or dispense in the mix.

--- a/api/docs/v2/robot_position.rst
+++ b/api/docs/v2/robot_position.rst
@@ -101,6 +101,16 @@ The liquid meniscus in a well changes during aspirating or dispensing, so you'll
 - Set ``target="start"`` to target the existing liquid meniscus in the destination well before a dispense. 
 - Set ``target="end"`` to ensure the pipette stays submerged while aspirating, or to avoid touching liquid in the destination well while dispensing. 
 
+You can use the optional ``location`` and ``end_location`` parameters of the :py:meth:`~.InstrumentContext.aspirate` :py:meth:`~.InstrumentContext.dispense` methods to pipette relative to the liquid meniscus as it changes:: 
+
+    pipette.aspirate(
+        volume=100, 
+        location=plate["A1"].meniscus(z=-1, target="start"),
+        end_location=plate["A1"].meniscus(z=-1, target="end")
+    )
+
+Here, the pipette tip stays at 1 mm below the liquid meniscus, regardless of changes in liquid height during the aspirate. For more, see the :ref:`new-aspirate` and :ref:`new-dispense` sections.  
+
 .. note::
     To use the :py:meth:`~.Well.meniscus` method, you'll first need to specify the starting liquid volume with :py:meth:`~.Labware.load_liquid` or probe for liquid with :py:meth:`~.InstrumentContext.measure_liquid_height`.
 

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -264,7 +264,7 @@ class InstrumentContext(publisher.CommandPublisher):
         .. versionchanged:: 2.24
             Added the ``flow_rate`` parameter.
         .. versionchanged:: 2.27
-            Added the ``end_location`` and ``movement_delay`` parameters. 
+            Added the ``end_location`` and ``movement_delay`` parameters.
         """
         if flow_rate is not None:
             if self.api_version < APIVersion(2, 24):
@@ -512,9 +512,9 @@ class InstrumentContext(publisher.CommandPublisher):
         .. versionchanged:: 2.24
             ``location`` is no longer required if the pipette just moved to, dispensed, or blew out
             into a trash bin or waste chute.
-        
+
         .. versionchanged:: 2.27
-            Added the ``end_location`` and ``movement_delay`` parameters. 
+            Added the ``end_location`` and ``movement_delay`` parameters.
         """
         if self.api_version < APIVersion(2, 15) and push_out:
             raise APIVersionError(
@@ -2272,9 +2272,11 @@ class InstrumentContext(publisher.CommandPublisher):
                 trash_location=transfer_args.trash_location,
                 return_tip=return_tip,
                 keep_last_tip=verified_keep_last_tip,
-                tips=[tip._core for tip in transfer_args.tips]
-                if transfer_args.tips is not None
-                else None,
+                tips=(
+                    [tip._core for tip in transfer_args.tips]
+                    if transfer_args.tips is not None
+                    else None
+                ),
             )
 
         return self
@@ -2446,9 +2448,11 @@ class InstrumentContext(publisher.CommandPublisher):
                 trash_location=transfer_args.trash_location,
                 return_tip=return_tip,
                 keep_last_tip=verified_keep_last_tip,
-                tips=[tip._core for tip in transfer_args.tips]
-                if transfer_args.tips is not None
-                else None,
+                tips=(
+                    [tip._core for tip in transfer_args.tips]
+                    if transfer_args.tips is not None
+                    else None
+                ),
             )
 
         return self
@@ -2620,9 +2624,11 @@ class InstrumentContext(publisher.CommandPublisher):
                 trash_location=transfer_args.trash_location,
                 return_tip=return_tip,
                 keep_last_tip=verified_keep_last_tip,
-                tips=[tip._core for tip in transfer_args.tips]
-                if transfer_args.tips is not None
-                else None,
+                tips=(
+                    [tip._core for tip in transfer_args.tips]
+                    if transfer_args.tips is not None
+                    else None
+                ),
             )
 
         return self

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -246,10 +246,10 @@ class InstrumentContext(publisher.CommandPublisher):
             while aspirating liquid. When this argument is used, the ``location`` and
             ``end_location`` must both be a :py:class:`.Location`.
         :type end_location: :py:class:`.Location`
-        :param movement_delay: Time in seconds to delay the pipette's movement from the ``location`` to the ``end_location`` during a dynamic aspirate.
+        :param movement_delay: Time in seconds to delay after the pipette starts aspirating and before it begins moving from  ``location`` to ``end_location``.
             This option is only valid when using ``end_location``. When this argument
             is used, the pipette will wait the specified time after the pipette
-            starts to aspirate before moving. This may help when dispensing very viscous liquids
+            starts to aspirate before moving. This may help when aspirating very viscous liquids
             that need to build up some pressure before liquid starts to flow.
         :type movement_delay: float
         :returns: This instance.
@@ -485,7 +485,7 @@ class InstrumentContext(publisher.CommandPublisher):
             while dispensing liquid held in the pipette. When this argument is used,
             the ``location`` and ``end_location`` must both be a :py:class:`.Location`.
         :type end_location: :py:class:`.Location`
-        :param movement_delay: Time in seconds to delay the pipette's movement from the ``location`` to the ``end_location`` during a dynamic dispense.
+        :param movement_delay: Time in seconds to delay after the pipette starts dispensing and before it begins moving from  ``location`` to ``end_location``.
             This option is only valid when using ``end_location``. When this argument
             is used, the pipette will wait the specified time after the pipette
             starts to dispense before moving. This may help when dispensing very viscous liquids
@@ -889,7 +889,7 @@ class InstrumentContext(publisher.CommandPublisher):
                                pipette will not push out after earlier repetitions. If
                                not specified or ``None``, the pipette will push out the
                                default non-zero amount. See :ref:`push-out-dispense`.
-        :param movement_delay: Time in seconds to delay the pipette's movement during a dynamic mix.
+        :param movement_delay: Time in seconds to delay after the pipette starts aspirating or dispensing and before it begins moving from the ``aspirate_start_location`` or ``dispense_start_location`` to the ``aspirate_end_location`` or ``dispense_end_location``.
             This option is only valid when using ``aspirate_end_location`` or ``dispense_end_location``.
             When this argument is used, the pipette will wait the specified time
             after the pipette starts to aspirate or dispense before moving. This may help when mixing
@@ -900,10 +900,7 @@ class InstrumentContext(publisher.CommandPublisher):
 
         .. note::
 
-            All the arguments of ``dynamic_mix`` are optional. However, if you omit one of them,
-            all subsequent arguments must be passed as keyword arguments. For instance,
-            ``pipette.mix(1, location=wellplate['A1'])`` is a valid call, but
-            ``pipette.mix(1, wellplate['A1'])`` is not.
+            The ``aspirate_start_location`` and ``dispense_start_location`` arguments of ``dynamic_mix`` are required.
 
         """
         _log.debug(

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -242,13 +242,13 @@ class InstrumentContext(publisher.CommandPublisher):
         :param flow_rate: The absolute flow rate in µL/s. If ``flow_rate`` is specified,
                           ``rate`` must not be set.
         :type flow_rate: float
-        :param end_location: Tells the robot to move between location and end_location
-            while aspirating liquid. When this argument is used the location and
-            end_location must both be :py:class:`.Location`.
+        :param end_location: Tells the robot to move from the specified ``location`` to the specified ``end_location``
+            while aspirating liquid. When this argument is used, the ``location`` and
+            ``end_location`` must both be a :py:class:`.Location`.
         :type end_location: :py:class:`.Location`
-        :param movement_delay: Delay the x/y/z movement during a dynamic aspirate.
-            This option is only valid when using end_location. When this argument
-            is used, the x/y/z movement will wait movement_delay seconds after the pipette
+        :param movement_delay: Time in seconds to delay the pipette's movement from the ``location`` to the ``end_location`` during a dynamic aspirate.
+            This option is only valid when using ``end_location``. When this argument
+            is used, the pipette will wait the specified time after the pipette
             starts to aspirate before moving. This may help when dispensing very viscous liquids
             that need to build up some pressure before liquid starts to flow.
         :type movement_delay: float
@@ -263,6 +263,8 @@ class InstrumentContext(publisher.CommandPublisher):
 
         .. versionchanged:: 2.24
             Added the ``flow_rate`` parameter.
+        .. versionchanged:: 2.27
+            Added the ``end_location`` and ``movement_delay`` parameters. 
         """
         if flow_rate is not None:
             if self.api_version < APIVersion(2, 24):
@@ -479,13 +481,13 @@ class InstrumentContext(publisher.CommandPublisher):
                           ``rate`` must not be set.
         :type flow_rate: float
 
-        :param end_location: Tells the robot to move between location and end_location
-            while dispensing liquid held in the pipette. When this argument is used
-            the location and end_location must both be a :py:class:`.Location`.
+        :param end_location: Tells the robot to move from the specified ``location`` to the specified ``end_location``
+            while dispensing liquid held in the pipette. When this argument is used,
+            the ``location`` and ``end_location`` must both be a :py:class:`.Location`.
         :type end_location: :py:class:`.Location`
-        :param movement_delay: Delay the x/y/z movement during a dynamic dispense.
-            This option is only valid when using end_location. When this argument
-            is used, the x/y/z movement will wait movement_delay seconds after the pipette
+        :param movement_delay: Time in seconds to delay the pipette's movement from the ``location`` to the ``end_location`` during a dynamic dispense.
+            This option is only valid when using ``end_location``. When this argument
+            is used, the pipette will wait the specified time after the pipette
             starts to dispense before moving. This may help when dispensing very viscous liquids
             that need to build up some pressure before liquid starts to flow.
         :type movement_delay: float
@@ -510,6 +512,9 @@ class InstrumentContext(publisher.CommandPublisher):
         .. versionchanged:: 2.24
             ``location`` is no longer required if the pipette just moved to, dispensed, or blew out
             into a trash bin or waste chute.
+        
+        .. versionchanged:: 2.27
+            Added the ``end_location`` and ``movement_delay`` parameters. 
         """
         if self.api_version < APIVersion(2, 15) and push_out:
             raise APIVersionError(
@@ -860,13 +865,13 @@ class InstrumentContext(publisher.CommandPublisher):
                        it will behave the same as a volume of ``None``/unspecified: mix
                        the full working volume of the pipette. On API levels at or above 2.16,
                        no liquid will be mixed.
-        :param aspirate_start_location: The :py:class:`~.types.Location` where the pipette will aspirate from.
-        :param aspirate_end_location: The :py:class:`~.types.Location` If this argument is supplied
-                    the pipette will move between aspirate_start_location and aspirate_end_location
+        :param aspirate_start_location: The :py:class:`~.types.Location` where the pipette will start aspirating from.
+        :param aspirate_end_location: A :py:class:`~.types.Location`. If specified,
+                    the pipette will move between the ``aspirate_start_location`` and the ``aspirate_end_location``
                     while performing the aspirate.
-        :param dispense_start_location: The :py:class:`~.types.Location` where the pipette will dispense to.
-        :param dispense_end_location: The :py:class:`~.types.Location` If this argument is supplied
-                    the pipette will move between dispense_start_location and dispense_end_location
+        :param dispense_start_location: The :py:class:`~.types.Location` where the pipette will start dispensing to.
+        :param dispense_end_location: A :py:class:`~.types.Location`. If specified,
+                    the pipette will move between the ``dispense_start_location`` and the ``dispense_end_location``
                     while performing the dispense.
         :param rate: How quickly the pipette aspirates and dispenses liquid while
                      mixing. The aspiration flow rate is calculated as ``rate``
@@ -884,10 +889,10 @@ class InstrumentContext(publisher.CommandPublisher):
                                pipette will not push out after earlier repetitions. If
                                not specified or ``None``, the pipette will push out the
                                default non-zero amount. See :ref:`push-out-dispense`.
-        :param movement_delay: Delay the x/y/z movement during a dynamic mix.
-            This option is only valid when using aspirate_end_location or dispense_end_location.
-            When this argument is used, the x/y/z movement will wait movement_delay seconds
-            after the pipette starts to aspirate/dispense before moving. This may help when mixing
+        :param movement_delay: Time in seconds to delay the pipette's movement during a dynamic mix.
+            This option is only valid when using ``aspirate_end_location`` or ``dispense_end_location``.
+            When this argument is used, the pipette will wait the specified time
+            after the pipette starts to aspirate or dispense before moving. This may help when mixing
             very viscous liquids that need to build up some pressure before liquid starts to flow.
         :type movement_delay: float
         :raises: ``UnexpectedTipRemovalError`` -- If no tip is attached to the pipette.
@@ -895,7 +900,7 @@ class InstrumentContext(publisher.CommandPublisher):
 
         .. note::
 
-            All the arguments of ``mix`` are optional. However, if you omit one of them,
+            All the arguments of ``dynamic_mix`` are optional. However, if you omit one of them,
             all subsequent arguments must be passed as keyword arguments. For instance,
             ``pipette.mix(1, location=wellplate['A1'])`` is a valid call, but
             ``pipette.mix(1, wellplate['A1'])`` is not.


### PR DESCRIPTION
# Overview

Adding descriptions of available dynamic pipetting actions in API 2.27. See the changelog for a full list/description of my thoughts behind each section. 

## Test Plan and Hands on Testing

sandbox: https://sandbox.docs.opentrons.com/docs-dynamic-actions/v2/

## Changelog

Under **Liquid Control**: 
- Aspirate/Dispense by Well or Location: _describe the new ``end_location`` parameter and the difference between the two locations; include a new example with multiple location, dynamic pipetting, but keep the meniscus example simple_
- Dynamic Mix: _describe the differences between "regular" and dynamic mix; includes one example and an explanation of additional parameters that can be used to customize the mix_

Under **Labware and Deck Positions**: 
- Meniscus: _example of using the new ``end_location parameter to aspirate or dispense tracking the meniscus_. this *might* fit better under aspirate/dispense sections, but those sections are getting so lengthy I moved this here. 

I _don't_ cover the new ``target="dynamic"`` arg because per Ryan, the team would like to keep this hidden until additional testing is done. 

Light changes to the API ref as well. 

## Review requests

Are any of these Flex-specific (obviously meniscus actions are limited to Flex pipettes, but is anything else specifically blocked on the OT-2)? 

I don't include any warnings for new position moves for users that would move their pipettes outside of the liquid and therefore not aspirate the liquid they mean to, but we already don't explicitly warn against this in other sections. 

I don't provide an example of a z movement during an aspirate/dispense/mix, like Ryan has shown in all hands/on video. The aspirate and dispense sections are getting long. I'm interested in eventually adding an example of this and maybe even a gif/part of the video, but don't want to add even more text to the section. 

## Risk assessment

low. 
