### PR TITLE
fix(app): fix command step height issue

### DIFF
--- a/app/src/organisms/Desktop/ProtocolVisualization/CommandSteps/commandsteps.module.css
+++ b/app/src/organisms/Desktop/ProtocolVisualization/CommandSteps/commandsteps.module.css
@@ -30,7 +30,7 @@
 }
 
 .command_step_groups {
-  height: 39rem;
+  height: 100%;
   min-height: 0;
   flex: 1;
   overflow-y: auto;

--- a/app/src/pages/Desktop/Protocols/ProtocolVisualization/visualization.module.css
+++ b/app/src/pages/Desktop/Protocols/ProtocolVisualization/visualization.module.css
@@ -88,14 +88,13 @@
   position: relative;
   height: var(--spacing-4);
   border-radius: var(--border-radius-2);
-  background:
-    linear-gradient(
-      to right,
-      var(--blue-50) 0%,
-      var(--blue-50) var(--progress, 0%),
-      #ccc var(--progress, 0%),
-      #ccc 100%
-    );
+  background: linear-gradient(
+    to right,
+    var(--blue-50) 0%,
+    var(--blue-50) var(--progress, 0%),
+    #ccc var(--progress, 0%),
+    #ccc 100%
+  );
 }
 
 /* Hide thumb initially */
@@ -141,19 +140,6 @@
 .command_step {
   border-radius: var(--border-radius-8);
   background-color: var(--white);
-}
-
-.command_step_header {
-  display: flex;
-  justify-content: space-between;
-  padding: var(--spacing-16);
-}
-
-.command_step_groups {
-  height: 39rem;
-  min-height: 0;
-  flex: 1;
-  overflow-y: auto;
 }
 
 .slot_details {

--- a/app/src/pages/Desktop/Protocols/ProtocolVisualization/visualization.module.css
+++ b/app/src/pages/Desktop/Protocols/ProtocolVisualization/visualization.module.css
@@ -88,13 +88,14 @@
   position: relative;
   height: var(--spacing-4);
   border-radius: var(--border-radius-2);
-  background: linear-gradient(
-    to right,
-    var(--blue-50) 0%,
-    var(--blue-50) var(--progress, 0%),
-    #ccc var(--progress, 0%),
-    #ccc 100%
-  );
+  background:
+    linear-gradient(
+      to right,
+      var(--blue-50) 0%,
+      var(--blue-50) var(--progress, 0%),
+      #ccc var(--progress, 0%),
+      #ccc 100%
+    );
 }
 
 /* Hide thumb initially */


### PR DESCRIPTION

# Overview
fix command step height issue


### before
<img width="262" height="746" alt="Screenshot 2025-11-21 at 2 23 11 PM" src="https://github.com/user-attachments/assets/55d036c1-4a94-4658-9a47-dfa8f88eb9a3" />



### after

<img width="258" height="750" alt="Screenshot 2025-11-21 at 2 27 45 PM" src="https://github.com/user-attachments/assets/f8a1ec96-e031-4f18-882b-f89692e69bab" />
<img width="254" height="745" alt="Screenshot 2025-11-21 at 2 27 51 PM" src="https://github.com/user-attachments/assets/ae2eee7a-5f84-47ab-802d-fb5f9c15c1c3" />


close RQA-4890


## Test Plan and Hands on Testing
- select a protocol
- click `Visualization` button
check command steps

## Changelog
- remove the fixed height value
- clean up visualization.module.css 

## Review requests

- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.

## Risk assessment
low
