### PR TITLE
fix(shared-data): Adjust thermocycler auto sealing lid offsets to account for grip point calculations

### DIFF
--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c3b37eae0f][Flex_S_v2_25_P200_stacker_2].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c3b37eae0f][Flex_S_v2_25_P200_stacker_2].json
@@ -9820,12 +9820,12 @@
               "dropOffset": {
                 "x": 0,
                 "y": 0.52,
-                "z": -6
+                "z": 0
               },
               "pickUpOffset": {
                 "x": 0,
                 "y": 0,
-                "z": 1.5
+                "z": 0
               }
             },
             "lidDisposalOffsets": {

--- a/shared-data/labware/definitions/2/opentrons_tough_pcr_auto_sealing_lid/2.json
+++ b/shared-data/labware/definitions/2/opentrons_tough_pcr_auto_sealing_lid/2.json
@@ -98,12 +98,12 @@
       "pickUpOffset": {
         "x": 0,
         "y": 0,
-        "z": 1.5
+        "z": 0
       },
       "dropOffset": {
         "x": 0,
         "y": 0.52,
-        "z": -6
+        "z": 0
       }
     },
     "lidOffsets": {


### PR DESCRIPTION
# Overview
Covers RABR-840

Originally we had to bake in certain pick up and drop offsets for this labwares Z axis gripper positions due to errors in how our grip point math was calculated. In [this PR](https://github.com/Opentrons/opentrons/pull/19437) the movement of labwares was fixed. This means that the baked in pickup and drop offsets now introduce an overcorrection, causing the lid to be picked up too high and dropped too low. When dropped in a standard deck slot, this causes the gripper to crash into the deck slot.

## Test Plan and Hands on Testing

- [x] Run the following protocol, ensure the auto sealing lid moves onto and off of all expected surfaces with the correct performance:
```
from opentrons.protocol_api import ProtocolContext

metadata = {"protocolName": "Opentrons Flex Deck Riser with TC Lids Test"}
requirements = {"robotType": "Flex", "apiLevel": "2.27"}

LID_QUANTITY = 5

def run(protocol: ProtocolContext):
    trash = protocol.load_trash_bin("A3")

    # Load lids
    deck_riser_adapter = protocol.load_adapter("opentrons_flex_deck_riser", 'C2')
    lids = deck_riser_adapter.load_lid_stack(load_name="opentrons_tough_pcr_auto_sealing_lid", quantity=LID_QUANTITY)
    
    thermocycler = protocol.load_module("thermocyclerModuleV2")
    thermocycler.open_lid()
    plate_in_cycler = thermocycler.load_labware(
        "armadillo_96_wellplate_200ul_pcr_full_skirt"
    )
    plate_on_deck = protocol.load_labware("armadillo_96_wellplate_200ul_pcr_full_skirt", "B2")

    # Move the lids to all the spots on the deck we usually move lids
    # This means: 
    # 1. Move a lid from the riser lid stack to a labware in the thermocycler
    # 2. Move a lid from the plate in the cyclr to a plate on deck
    # 3. Move a lid from the plate on deck back to an active stack of lids on the riser
    # 4. Move a lid to a new stacking location in B3
    # -- AFTER ALL LIDS MOVED THROUGH PHASE 1 --
    # 5. Move all lids back to riser to restack from the deck slot
    # 6. Move all lids from the riser to the trash bin
    for i in range(LID_QUANTITY):
        protocol.move_lid(lids, plate_in_cycler, True)
        protocol.move_lid(plate_in_cycler, plate_on_deck, True)
        protocol.move_lid(plate_on_deck, deck_riser_adapter, True)
        protocol.move_lid(deck_riser_adapter, "B3", True)
    
    for i in range(LID_QUANTITY):
        protocol.move_lid("B3", deck_riser_adapter, True)
    
    for i in range(LID_QUANTITY):
        protocol.move_lid(deck_riser_adapter, trash, True)

```

## Changelog
Updated and tested the auto sealing lids with the special drop offsets removed.

## Review requests
Are there any other special labware this applies to?

## Risk assessment
Relatively low risk.