### PR TITLE
fix(robot-server): Harmonize error recovery camera field name

### DIFF
--- a/api/src/opentrons/protocol_engine/execution/command_executor.py
+++ b/api/src/opentrons/protocol_engine/execution/command_executor.py
@@ -248,7 +248,7 @@ class CommandExecutor:
             # Only capture photos of errors if the setting to do so is enabled
             if (
                 camera_enablement.cameraEnabled
-                and camera_enablement.errorRecoveryEnabled
+                and camera_enablement.errorRecoveryCameraEnabled
             ):
                 # todo(chb, 2025-10-25): Eventually we will need to pass in client provided global settings here
                 image_data = await self._camera_provider.capture_image(

--- a/api/src/opentrons/protocol_engine/resources/camera_provider.py
+++ b/api/src/opentrons/protocol_engine/resources/camera_provider.py
@@ -83,7 +83,7 @@ class CameraProvider:
             return self._camera_settings_callback()
         # If we are in analysis or simulation, return as if the camera is enabled
         return CameraSettings(
-            cameraEnabled=True, liveStreamEnabled=True, errorRecoveryEnabled=True
+            cameraEnabled=True, liveStreamEnabled=True, errorRecoveryCameraEnabled=True
         )
 
     async def capture_image(

--- a/api/src/opentrons/protocol_engine/resources/camera_provider.py
+++ b/api/src/opentrons/protocol_engine/resources/camera_provider.py
@@ -27,7 +27,7 @@ class CameraSettings(BaseModel):
     liveStreamEnabled: bool = Field(
         ..., description="Enablement status for the Opentrons Live Stream service."
     )
-    errorRecoveryEnabled: bool = Field(
+    errorRecoveryCameraEnabled: bool = Field(
         ..., description="Enablement status for camera usage with Error Recovery."
     )
 

--- a/api/tests/opentrons/protocol_engine/commands/test_capture_image.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_capture_image.py
@@ -136,7 +136,7 @@ async def test_raises_camera_disabled_error(
         CameraSettings(
             cameraEnabled=False,
             liveStreamEnabled=False,
-            errorRecoveryEnabled=False,
+            errorRecoveryCameraEnabled=False,
         )
     )
 

--- a/api/tests/opentrons/protocol_engine/execution/test_command_executor.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_command_executor.py
@@ -566,7 +566,7 @@ async def test_execute_undefined_error(
             CameraSettings(
                 cameraEnabled=True,
                 liveStreamEnabled=True,
-                errorRecoveryEnabled=True,
+                errorRecoveryCameraEnabled=True,
             )
         )
 
@@ -743,7 +743,7 @@ async def test_execute_defined_error(
             CameraSettings(
                 cameraEnabled=True,
                 liveStreamEnabled=True,
-                errorRecoveryEnabled=True,
+                errorRecoveryCameraEnabled=True,
             )
         )
 

--- a/api/tests/opentrons/protocol_engine/test_protocol_engine.py
+++ b/api/tests/opentrons/protocol_engine/test_protocol_engine.py
@@ -1328,7 +1328,7 @@ def test_add_camera_settings(
 ) -> None:
     """It should dispatch an AddCameraSettingsAction action."""
     settings = CameraSettings(
-        cameraEnabled=True, liveStreamEnabled=True, errorRecoveryEnabled=True
+        cameraEnabled=True, liveStreamEnabled=True, errorRecoveryCameraEnabled=True
     )
     decoy.when(subject.state_view.camera.get_enablement_settings()).then_return(
         settings

--- a/robot-server/robot_server/camera/provider.py
+++ b/robot-server/robot_server/camera/provider.py
@@ -35,7 +35,7 @@ class CameraProviderWrapper:
         return CameraSettings(
             cameraEnabled=self._camera_settings_store.get_camera_enabled(),
             liveStreamEnabled=self._camera_settings_store.get_live_stream_enabled(),
-            errorRecoveryEnabled=self._camera_settings_store.get_error_recovery_camera_enabled(),
+            errorRecoveryCameraEnabled=self._camera_settings_store.get_error_recovery_camera_enabled(),
         )
 
     async def process_image_capture(

--- a/robot-server/robot_server/runs/router/camera_router.py
+++ b/robot-server/robot_server/runs/router/camera_router.py
@@ -86,7 +86,7 @@ async def add_camera_settings(
         liveStreamEnabled=request_body.data.liveStreamEnabled
         if request_body.data.liveStreamEnabled is not None
         else False,
-        errorRecoveryEnabled=request_body.data.errorRecoveryCameraEnabled
+        errorRecoveryCameraEnabled=request_body.data.errorRecoveryCameraEnabled
         if request_body.data.errorRecoveryCameraEnabled is not None
         else False,
     )
@@ -111,7 +111,7 @@ async def add_camera_settings(
             data=CameraEnable(
                 cameraEnabled=response_data.cameraEnabled,
                 liveStreamEnabled=response_data.liveStreamEnabled,
-                errorRecoveryCameraEnabled=response_data.errorRecoveryEnabled,
+                errorRecoveryCameraEnabled=response_data.errorRecoveryCameraEnabled,
             )
         ),
         status_code=status.HTTP_201_CREATED,


### PR DESCRIPTION
Closes [RQA-4807](https://opentrons-sandbox.atlassian.net/browse/RQA-4807)

# Overview

To denote image capture on protocol error, the HTTP API uses the `errorRecoveryCameraEnabled` field except for `GET /camera`, in which case we use `errorRecoveryEnabled`. The JS code expects the shape of the camera settings to conform to the pattern elsewhere. To keep the HTTP API and the app consistent, let's update our one usage of `errorRecoveryEnabled` to `errorRecoveryCameraEnabled`. 

0a142c1fc0daae20dddd255d9c5a82ad1724c4d8 - The isolated change
4f074670573e273c25bd1e2210bdea97e7b44412 - pure lint updates in a separate commit just due to the noise

## Test Plan and Hands on Testing

- Verified on the robot that the ODD UI reflects the correct status of the error recovery toggle, see ticket.

## Changelog

- Fixed the "capture on protocol error enabled" toggle updating to an incorrect value when a user confirmed camera preferences.

## Review requests

This bug is purely a UI issue:  when a user clicks "confirms preferences", the UI reflects a falsey value always, but the server (and engine) report the correct value. This seems like confusing behavior for users and is probably worth fixing, but I'm open to thoughts/comments/concerns.

## Risk assessment

- low in theory, this is just a find and replace PR. The FE doesn't reflect historical camera settings yet, so the app is at no risk of white screening with the property name changing. 

[RQA-4807]: https://opentrons.atlassian.net/browse/RQA-4807?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ