### PR TITLE
feat(docs): add partial theme override with opentrons.com link

### DIFF
--- a/docs/shared/opentrons-theme.css
+++ b/docs/shared/opentrons-theme.css
@@ -90,3 +90,10 @@ article ul li::marker {
   font-style: normal;
   color: #737578;
 }
+
+/* Tab bar link to opentrons.com */
+
+.md-tabs__list li:last-child {
+  margin-left: auto;
+  padding-right: 0;
+}

--- a/docs/shared/partials/tabs.html
+++ b/docs/shared/partials/tabs.html
@@ -1,0 +1,32 @@
+{% import "partials/tabs-item.html" as item with context %}
+
+<!-- Navigation tabs -->
+<nav
+  class="md-tabs"
+  aria-label="{{ lang.t('tabs') }}"
+  data-md-component="tabs"
+>
+  <div class="md-grid">
+    <ul class="md-tabs__list">
+      {% for nav_item in nav.items %}
+        {{ item.render(nav_item) }}
+      {% endfor %}
+      <li class="md-tabs__item">
+            <a class="md-tabs__link" href="https://opentrons.com" target="_blank">
+            opentrons.com 
+            <svg viewBox="-1 -3 51 51" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin-left: .35em; height: .7rem; width: .7rem;">
+                <g clip-path="url(#clip0_2035_69)">
+                <path d="M43.65 49.99H6.34002C2.86002 49.99 0.0200195 47.15 0.0200195 43.67V6.36001C0.0200195 2.88001 2.86002 0.0400085 6.34002 0.0400085H15.6C16.43 0.0400085 17.1 0.710009 17.1 1.54001C17.1 2.37001 16.43 3.04001 15.6 3.04001H6.34002C4.51002 3.04001 3.02002 4.53001 3.02002 6.36001V43.67C3.02002 45.5 4.51002 46.99 6.34002 46.99H43.65C45.48 46.99 46.97 45.5 46.97 43.67V34.41C46.97 33.58 47.64 32.91 48.47 32.91C49.3 32.91 49.97 33.58 49.97 34.41V43.67C49.97 47.16 47.13 49.99 43.65 49.99Z" fill="#FFFFFF" stroke="#FFFFFF" stroke-width="2"/>
+                <path d="M48.59 23.16C47.76 23.16 47.09 22.49 47.09 21.66V5.11L15.66 36.54C15.37 36.83 14.98 36.98 14.6 36.98C14.22 36.98 13.83 36.83 13.54 36.54C12.95 35.95 12.95 35 13.54 34.42L44.9 3.06H28.48C27.65 3.06 26.98 2.39 26.98 1.56C26.98 0.729998 27.65 0.0599976 28.48 0.0599976H48.59C49.42 0.0599976 50.09 0.729998 50.09 1.56V21.67C50.09 22.5 49.42 23.17 48.59 23.17V23.16Z" fill="#FFFFFF" stroke="#FFFFFF" stroke-width="2"/>
+                </g>
+                <defs>
+                <clipPath id="clip0_2035_69">
+                <rect width="50" height="50" fill="white"/>
+                </clipPath>
+                </defs>
+            </svg>
+            </a>
+        </li>
+    </ul>
+  </div>
+</nav>


### PR DESCRIPTION
# Overview

Link to opentrons.com in the header of docs.opentrons.com pages.

Addresses RTC-815.

<img width="1223" height="323" alt="image" src="https://github.com/user-attachments/assets/2d0fe920-cad0-49f3-8732-4f3f1c35ac70" />


## Test Plan and Hands on Testing

[Sandbox](https://sandbox.docs.opentrons.com/mkdocs-link-to-dotcom/)

## Changelog

- Add new partial override with extra <li> and hardcoded <svg> (our icon library version is black only).

## Review requests

Is this the best way to do this?
Do we need the link to remain visible in the smallest responsive designs, when the tab bar collapses to a sidebar?

## Risk assessment

low
