### PR TITLE
chore: remove configs that are related to pd cypress

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -13,7 +13,6 @@
 !api/release-notes.md
 !app-shell/build/release-notes.md
 **/.yarn-cache/**
-protocol-designer/cypress/downloads/**
 
 # components library
 storybook-static

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -17,7 +17,12 @@ export default mergeConfig(
     test: {
       environment: 'jsdom',
       allowOnly: true,
-      exclude: [...configDefaults.exclude, '**/node_modules/**', '**/dist/**', '**/lib/**'],
+      exclude: [
+        ...configDefaults.exclude,
+        '**/node_modules/**',
+        '**/dist/**',
+        '**/lib/**',
+      ],
       setupFiles: ['./setup-vitest.mts'],
       coverage: {
         exclude: [
@@ -25,7 +30,6 @@ export default mergeConfig(
           '**/dist/**',
           '**/__tests__/**',
           '**/lib/**',
-          'protocol-designer/cypress/**/*',
           'labware-library/cypress/**/*',
           ...configDefaults.exclude,
         ],


### PR DESCRIPTION
# Overview
remove configs that are related to pd cypress

this repo still has some configurations for cypress because labware-library uses cypress (probably not maintained for a while).

## Test Plan and Hands on Testing

## Changelog
- remove configs that are related to cypress in pd


## Review requests



## Risk assessment
low
