### PR TITLE
chore(protocol-designer): Add tslib back into Vite config to fix whitescreen

### DIFF
--- a/protocol-designer/vite.config.mts
+++ b/protocol-designer/vite.config.mts
@@ -113,6 +113,8 @@ export default defineConfig(async (): Promise<UserConfig> => {
       esbuildOptions: {
         target: 'es2020',
       },
+      // For unknown reasons, PD whitescreens on launch unless we have this.
+      include: ['tslib'],
     },
     css: {
       postcss: {
@@ -143,6 +145,8 @@ export default defineConfig(async (): Promise<UserConfig> => {
     },
     resolve: {
       conditions: ['browser'],
+      // For unknown reasons, PD whitescreens on launch unless we have this.
+      dedupe: ['tslib'],
       alias: {
         // todo(mm, 2025-10-27): These cross-project aliases cause trouble like
         // files being processed with the wrong config (the config from the


### PR DESCRIPTION
## Overview

In `edge`, PD is whitescreening with this console error:

```
13:11:30.678 index.js:3 Uncaught TypeError: Cannot destructure property '__extends' of 'import_tslib.default' as it is undefined.
    at index.js:3:5
(anonymous) @ index.js:3
13:13:18.067 (index):1 Unchecked runtime.lastError: Could not establish connection. Receiving end does not exist.
```

I do not understand any of this, but from `git bisect`ing, the apparent cause is #20207's removal of `include: ['tslib']` and/or `dedupe: ['tslib']` from our Vite config. None of our other projects need this, so it's likely that there's some PD-specific weirdness going on here—possibly some misconfiguration somewhere else—but I haven't looked into it. This PR reverts the change as a quick fix to unblock development.

## Test Plan and Hands on Testing

* [x] PD doesn't whitescreen now.

## Review requests

Any better ideas?

## Risk assessment

Low?