### PR TITLE
feat(step-generation): introduce atomic flex stacker store and retrieve command creators

### DIFF
--- a/step-generation/src/__tests__/flexStackerRetrieve.test.ts
+++ b/step-generation/src/__tests__/flexStackerRetrieve.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  FLEX_STACKER_MODULE_TYPE,
+  FLEX_STACKER_MODULE_V1,
+} from '@opentrons/shared-data'
+
+import { flexStackerRetrieve } from '../commandCreators/atomic/flexStackerRetrieve'
+import { getInitialRobotStateStandard, makeContext } from '../fixtures'
+
+import type { InvariantContext, RobotState } from '../types'
+
+const moduleId = 'flexStackerId'
+vi.mock('../robotStateSelectors')
+
+describe('flexStackerStore', () => {
+  let invariantContext: InvariantContext
+  let robotState: RobotState
+  beforeEach(() => {
+    invariantContext = makeContext()
+    robotState = getInitialRobotStateStandard(invariantContext)
+    invariantContext.moduleEntities[moduleId] = {
+      id: moduleId,
+      type: FLEX_STACKER_MODULE_TYPE,
+      model: FLEX_STACKER_MODULE_V1,
+      pythonName: 'mock_flex_stacker_1',
+    }
+  })
+  it('creates flex stacker retrieve command', () => {
+    const result = flexStackerRetrieve(
+      {
+        moduleId,
+      },
+      invariantContext,
+      robotState
+    )
+    expect(result).toEqual({
+      commands: [
+        {
+          commandType: 'flexStacker/retrieve',
+          key: expect.any(String),
+          params: {
+            moduleId,
+          },
+        },
+      ],
+      python: 'mock_flex_stacker_1.retrieve()',
+    })
+  })
+})

--- a/step-generation/src/__tests__/flexStackerStore.test.ts
+++ b/step-generation/src/__tests__/flexStackerStore.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  FLEX_STACKER_MODULE_TYPE,
+  FLEX_STACKER_MODULE_V1,
+} from '@opentrons/shared-data'
+
+import { flexStackerStore } from '../commandCreators/atomic/flexStackerStore'
+import { getInitialRobotStateStandard, makeContext } from '../fixtures'
+
+import type { InvariantContext, RobotState } from '../types'
+
+const moduleId = 'flexStackerId'
+vi.mock('../robotStateSelectors')
+
+describe('flexStackerStore', () => {
+  let invariantContext: InvariantContext
+  let robotState: RobotState
+  beforeEach(() => {
+    invariantContext = makeContext()
+    robotState = getInitialRobotStateStandard(invariantContext)
+    invariantContext.moduleEntities[moduleId] = {
+      id: moduleId,
+      type: FLEX_STACKER_MODULE_TYPE,
+      model: FLEX_STACKER_MODULE_V1,
+      pythonName: 'mock_flex_stacker_1',
+    }
+  })
+  it('creates flex stacker store command', () => {
+    const result = flexStackerStore(
+      {
+        moduleId,
+        strategy: 'automatic',
+      },
+      invariantContext,
+      robotState
+    )
+    expect(result).toEqual({
+      commands: [
+        {
+          commandType: 'flexStacker/store',
+          key: expect.any(String),
+          params: {
+            moduleId,
+            strategy: 'automatic',
+          },
+        },
+      ],
+      python: 'mock_flex_stacker_1.store()',
+    })
+  })
+})

--- a/step-generation/src/commandCreators/atomic/flexStackerRetrieve.ts
+++ b/step-generation/src/commandCreators/atomic/flexStackerRetrieve.ts
@@ -1,0 +1,23 @@
+import { uuid } from '../../utils'
+
+import type { FlexStackerRetrieveCreateCommand } from '@opentrons/shared-data'
+import type { CommandCreator } from '../../types'
+
+export const flexStackerRetrieve: CommandCreator<
+  FlexStackerRetrieveCreateCommand['params']
+> = (args, invariantContext) => {
+  const { moduleId } = args
+  const pythonName = invariantContext.moduleEntities[moduleId].pythonName
+  return {
+    commands: [
+      {
+        commandType: 'flexStacker/retrieve',
+        key: uuid(),
+        params: {
+          moduleId,
+        },
+      },
+    ],
+    python: `${pythonName}.retrieve()`,
+  }
+}

--- a/step-generation/src/commandCreators/atomic/flexStackerStore.ts
+++ b/step-generation/src/commandCreators/atomic/flexStackerStore.ts
@@ -1,0 +1,24 @@
+import { uuid } from '../../utils'
+
+import type { FlexStackerStoreCreateCommand } from '@opentrons/shared-data'
+import type { CommandCreator } from '../../types'
+
+export const flexStackerStore: CommandCreator<
+  FlexStackerStoreCreateCommand['params']
+> = (args, invariantContext) => {
+  const { moduleId } = args
+  const pythonName = invariantContext.moduleEntities[moduleId].pythonName
+  return {
+    commands: [
+      {
+        commandType: 'flexStacker/store',
+        key: uuid(),
+        params: {
+          moduleId,
+          strategy: 'automatic', // hardcoding here, since 'manual' should only be used in error recovery
+        },
+      },
+    ],
+    python: `${pythonName}.store()`,
+  }
+}


### PR DESCRIPTION
# Overview

This PR creates atomic step generation command creators for `store` and `retrieve` commands.

Closes EXEC-1446

## Test Plan and Hands on Testing

- reviewed code and ensure typechecks pass
- wrote preliminary unit tests

## Changelog

- introduce atomic command creators for `flexStacker/store` and `flexStacker/retrieve` commands

## Review requests

- review code

## Risk assessment

low. nothing wired up yet