### PR TITLE
feat(step-generation): introduce flex stacker fill atomic command creator

### DIFF
--- a/step-generation/src/__tests__/flexStackerFill.test.ts
+++ b/step-generation/src/__tests__/flexStackerFill.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  FLEX_STACKER_MODULE_TYPE,
+  FLEX_STACKER_MODULE_V1,
+} from '@opentrons/shared-data'
+
+import { flexStackerFill } from '../commandCreators/atomic/flexStackerFill'
+import { getInitialRobotStateStandard, makeContext } from '../fixtures'
+
+import type { InvariantContext, RobotState } from '../types'
+
+const moduleId = 'flexStackerId'
+vi.mock('../robotStateSelectors')
+
+describe('flexStackerStore', () => {
+  let invariantContext: InvariantContext
+  let robotState: RobotState
+  beforeEach(() => {
+    invariantContext = makeContext()
+    robotState = getInitialRobotStateStandard(invariantContext)
+    invariantContext.moduleEntities[moduleId] = {
+      id: moduleId,
+      type: FLEX_STACKER_MODULE_TYPE,
+      model: FLEX_STACKER_MODULE_V1,
+      pythonName: 'mock_flex_stacker_1',
+    }
+  })
+  it('creates flex stacker fill command with count', () => {
+    const result = flexStackerFill(
+      {
+        moduleId,
+        count: 10,
+        strategy: 'manualWithPause',
+      },
+      invariantContext,
+      robotState
+    )
+    expect(result).toEqual({
+      commands: [
+        {
+          commandType: 'flexStacker/fill',
+          key: expect.any(String),
+          params: {
+            moduleId,
+            strategy: 'manualWithPause',
+            count: 10,
+          },
+        },
+      ],
+      python: 'mock_flex_stacker_1.fill(count=10)',
+    })
+  })
+  it('creates flex stacker fill command with message', () => {
+    const result = flexStackerFill(
+      {
+        moduleId,
+        message: 'Filling...',
+        strategy: 'manualWithPause',
+      },
+      invariantContext,
+      robotState
+    )
+    expect(result).toEqual({
+      commands: [
+        {
+          commandType: 'flexStacker/fill',
+          key: expect.any(String),
+          params: {
+            moduleId,
+            strategy: 'manualWithPause',
+            message: 'Filling...',
+          },
+        },
+      ],
+      python: 'mock_flex_stacker_1.fill(message="Filling...")',
+    })
+  })
+})

--- a/step-generation/src/commandCreators/atomic/flexStackerFill.ts
+++ b/step-generation/src/commandCreators/atomic/flexStackerFill.ts
@@ -1,0 +1,35 @@
+import { formatPyStr, uuid } from '../../utils'
+
+import type { FlexStackerFillCreateCommand } from '@opentrons/shared-data'
+import type { CommandCreator } from '../../types'
+
+export const flexStackerFill: CommandCreator<
+  FlexStackerFillCreateCommand['params']
+> = (args, invariantContext) => {
+  const { moduleId, message, count, labwareToStore } = args
+  const pythonName = invariantContext.moduleEntities[moduleId].pythonName
+
+  // TODO: add error creators
+
+  const pythonArgs = [
+    ...(count != null ? [`count=${count}`] : []),
+    ...(message != null ? [`message=${formatPyStr(message)}`] : []),
+  ]
+
+  return {
+    commands: [
+      {
+        commandType: 'flexStacker/fill',
+        key: uuid(),
+        params: {
+          moduleId,
+          strategy: 'manualWithPause',
+          message,
+          count,
+          labwareToStore,
+        },
+      },
+    ],
+    python: `${pythonName}.fill(${pythonArgs.join(', ')})`,
+  }
+}


### PR DESCRIPTION
# Overview

This PR creates atomic step generation command creators for `fill` command.

Closes EXEC-1447

## Test Plan and Hands on Testing

- reviewed code and ensure typechecks pass
- wrote preliminary unit tests

## Changelog

- introduce atomic command creators for `flexStacker/fill` command

## Review requests

- review code

## Risk assessment

low. nothing wired up yet