### PR TITLE
feat(labware-library): build info page

### DIFF
--- a/.github/workflows/ll-test-build-deploy.yaml
+++ b/.github/workflows/ll-test-build-deploy.yaml
@@ -12,6 +12,7 @@ on:
       - '.github/workflows/ll-test-build-deploy.yaml'
       - '.github/workflows/utils.js'
       - 'scripts/static-deploy/**'
+      - 'scripts/git-version-v2.mjs'
   push:
     branches:
       - 'edge'
@@ -47,10 +48,10 @@ jobs:
       relative_artifact_dir: ${{ steps.deploy-config.outputs.RELATIVE_ARTIFACT_DIR }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - uses: ./.github/actions/git/resolve-tag
       - name: Setup UV
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: '3.10'
       - name: Setup Deploy Dependencies
@@ -68,7 +69,7 @@ jobs:
     runs-on: 'ubuntu-24.04'
     if: ${{ !startsWith(github.ref, 'refs/tags/') }}
     steps:
-      - uses: 'actions/checkout@v4'
+      - uses: 'actions/checkout@v5'
       - uses: ./.github/actions/js/setup
       - name: 'run labware library unit tests'
         run: make -C labware-library test-cov
@@ -84,7 +85,7 @@ jobs:
     runs-on: 'ubuntu-24.04'
     if: ${{ !startsWith(github.ref, 'refs/tags/') }}
     steps:
-      - uses: 'actions/checkout@v4'
+      - uses: 'actions/checkout@v5'
       - uses: ./.github/actions/js/setup
       - name: 'test-e2e'
         env:
@@ -93,12 +94,10 @@ jobs:
         run: make -C labware-library test-e2e
   build-ll:
     name: 'build labware library artifact'
-    needs: ['js-unit-test', 'e2e-test']
     timeout-minutes: 10
     runs-on: 'ubuntu-24.04'
-    if: always() && (needs.js-unit-test.result == 'success' || needs.js-unit-test.result == 'skipped') && (needs.e2e-test.result == 'success' || needs.e2e-test.result == 'skipped')
     steps:
-      - uses: 'actions/checkout@v4'
+      - uses: 'actions/checkout@v5'
         with:
           fetch-depth: 0
       - uses: ./.github/actions/js/setup
@@ -125,12 +124,12 @@ jobs:
       contents: read
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - uses: ./.github/actions/git/resolve-tag
       - name: Setup UV
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: '3.10'
       - name: Setup Deploy Dependencies
@@ -167,7 +166,7 @@ jobs:
     if: always() && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && (needs.js-unit-test.result == 'success' || needs.js-unit-test.result == 'skipped') && needs.build-ll.result == 'success' && needs.deploy-ll.result == 'success'
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: 'Send success alert'
         uses: ./.github/actions/simple-build-alert
         with:
@@ -182,7 +181,7 @@ jobs:
     if: always() && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && (needs.js-unit-test.result == 'failure' || needs.build-ll.result == 'failure' || needs.deploy-ll.result == 'failure')
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: 'Determine failed jobs'
         id: failed-jobs
         shell: bash
@@ -216,7 +215,7 @@ jobs:
     if: always() && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && (needs.js-unit-test.result == 'cancelled' || needs.build-ll.result == 'cancelled' || needs.deploy-ll.result == 'cancelled')
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: 'Send cancelled alert'
         uses: ./.github/actions/simple-build-alert
         with:

--- a/.github/workflows/pd-test-build-deploy.yaml
+++ b/.github/workflows/pd-test-build-deploy.yaml
@@ -15,7 +15,7 @@ on:
       - ".github/actions/git/resolve-tag/action.yml"
       - ".github/actions/environment/complex-variables/action.yml"
       - "scripts/static-deploy/**"
-      - "scripts/git-version-protocol-designer.mjs"
+      - "scripts/git-version-v2.mjs"
   push:
     branches:
       - "edge"

--- a/labware-library/vite.config.mts
+++ b/labware-library/vite.config.mts
@@ -7,6 +7,11 @@ import postColorModFunction from 'postcss-color-mod-function'
 import postCssPresetEnv from 'postcss-preset-env'
 import lostCss from 'lost'
 import { cssModuleSideEffect } from './cssModuleSideEffect'
+import createGitVersionToolkit from '../scripts/git-version-v2.mjs'
+
+const { generateBuildInfoHtml } = createGitVersionToolkit({
+  project: 'labware-library',
+})
 
 export default defineConfig({
   // this makes imports relative rather than absolute
@@ -31,6 +36,13 @@ export default defineConfig({
       },
     }),
     cssModuleSideEffect(), // Note for treeshake
+    {
+      name: 'build-info-generator',
+      closeBundle: async () => {
+        const outputPath = path.resolve(__dirname, 'dist', 'info', 'index.html')
+        await generateBuildInfoHtml(outputPath)
+      },
+    },
   ],
   optimizeDeps: {
     esbuildOptions: {

--- a/protocol-designer/vite.config.mts
+++ b/protocol-designer/vite.config.mts
@@ -11,16 +11,16 @@ import { analyzer } from 'vite-bundle-analyzer'
 
 import { latestLabwareVersions } from '../scripts/git-version.mjs'
 
-import {
-  getVersion,
-  generateBuildInfoHtml,
-} from '../scripts/git-version-protocol-designer.mjs'
+import createGitVersionToolkit from '../scripts/git-version-v2.mjs'
 
 import { cssModuleSideEffect } from './cssModuleSideEffect'
 
 import type { UserConfig } from 'vite'
 
 const REQUIRED_APP_VERSION = '8.7.0' // PD requires this robot stack version or higher
+const { getVersion, generateBuildInfoHtml } = createGitVersionToolkit({
+  project: 'protocol-designer',
+})
 
 // eslint-disable-next-line import/no-default-export
 export default defineConfig(

--- a/scripts/GIT_VERSION_V2_README.md
+++ b/scripts/GIT_VERSION_V2_README.md
@@ -1,12 +1,17 @@
-# Git Version Protocol Designer - Semantic Version Resolution
+# Git Version Toolkit - Semantic Version Resolution
 
 ## Summary
 
-`scripts/git-version-protocol-designer.mjs` provides semantic version-based tag resolution and build information generation for Protocol Designer.
+`scripts/git-version-v2.mjs` is the shared semantic-version toolkit that powers build information generation for multiple web apps.
+
+### Current Consumers
+
+1. **Protocol Designer** – configured via `createGitVersionToolkit({ project: 'protocol-designer' })` inside `protocol-designer/vite.config.mts`
+2. **Labware Library** – configured via `createGitVersionToolkit({ project: 'labware-library' })` inside `labware-library/vite.config.mts`
 
 ### Key Features
 
-1. **Semantic version resolution**: Finds the highest semantic version among all tags reachable from `HEAD` for both production (`protocol-designer@`) and staging (`staging-protocol-designer@`) prefixes.
+1. **Semantic version resolution**: Finds the highest semantic version among all tags reachable from `HEAD` for each project's production (`<project>@`) and staging (`staging-<project>@`) prefixes.
 2. **Prerelease support**: Properly handles prerelease versions like `-alpha.0`, `-beta.1`, etc., following semver precedence rules.
 3. **Prefix priority**: When production and staging tags have identical versions, production tags win.
 4. **Simple version output**: Always returns the portion to the right of `@`.
@@ -14,7 +19,7 @@
 
 ### Tag Priority and Semver Rules
 
-For the `protocol-designer` project:
+For any supported project (Protocol Designer and Labware Library today):
 
 - **Version comparison**: Tags are compared using semantic versioning (semver) rules
   - Stable releases take precedence over prerelease versions of the same version (e.g., `8.6.0` > `8.6.0-beta.1`)
@@ -23,10 +28,10 @@ For the `protocol-designer` project:
   - Prerelease numbers are compared numerically (e.g., `alpha.2` > `alpha.1`)
 
 - **Prefix priority** (tie-breaker when versions are identical):
-  1. `protocol-designer@*` (production)
-  2. `staging-protocol-designer@*` (staging)
+  1. `<project>@*` (production)
+  2. `staging-<project>@*` (staging)
 
-When production and staging tags have the exact same version, the production prefix wins.
+When production and staging tags have the exact same version, the production prefix wins (e.g., `protocol-designer@*` beats `staging-protocol-designer@*`, `labware-library@*` beats `staging-labware-library@*`).
 
 ### Version Resolution Logic
 
@@ -51,6 +56,7 @@ When production and staging tags have the exact same version, the production pre
      - `protocol-designer@8.6.0` → `8.6.0`
      - `staging-protocol-designer@8.7.0-alpha.1` → `8.7.0-alpha.1`
      - `protocol-designer@8.6.0-beta.2` → `8.6.0-beta.2`
+     - `labware-library@5.3.0` → `5.3.0`
 
 5. **No tags available**
    - If no matching tags are found, log an error and return `0.0.0-dev`.
@@ -74,8 +80,10 @@ The script automatically generates a comprehensive build information page at `di
 
 ### Accessing Build Info
 
-- Local deployment: `http://localhost:5178/info/` — available during `make serve`
-- Production: `https://designer.opentrons.com/info/` (or your deployed URL)
+- Protocol Designer (local): `http://localhost:5178/info/` — available during `make serve`
+- Labware Library (local): `http://localhost:5173/info/` — served by `make serve`
+- Protocol Designer (production): `https://designer.opentrons.com/info/`
+- Labware Library (production): `https://labware.opentrons.com/info/`
 
 ## Testing Results
 
@@ -103,6 +111,8 @@ The script automatically generates a comprehensive build information page at `di
   - History: No `protocol-designer@` or `staging-protocol-designer@` tags
   - Result: ✅ Falls back to `0.0.0-dev`
 
+Equivalent scenarios apply to Labware Library, substituting `labware-library@` and `staging-labware-library@` tag prefixes.
+
 ## Implementation Notes
 
 - **Semantic versioning**: Uses the `semver` package to properly compare versions according to semver rules.
@@ -113,4 +123,5 @@ The script automatically generates a comprehensive build information page at `di
 
 ## Integration
 
-The script is integrated into Protocol Designer's build process via a Vite plugin in `vite.config.mts`, ensuring the build info page is generated after every build.
+- **Protocol Designer**: `protocol-designer/vite.config.mts` registers a Vite plugin that invokes `generateBuildInfoHtml` after bundling, ensuring `/info/index.html` ships with every build.
+- **Labware Library**: `labware-library/vite.config.mts` wires the same helper into its build so both the creator and main surfaces expose `/info/index.html`.

--- a/scripts/git-version-v2.mjs
+++ b/scripts/git-version-v2.mjs
@@ -6,92 +6,122 @@ import git from 'simple-git'
 import semver from 'semver'
 
 const REPO_BASE = dirname(dirname(fileURLToPath(import.meta.url)))
-const PROJECT = 'protocol-designer'
-
-// Tag prefixes in priority order (production > staging)
-const TAG_PREFIXES = [
-    `${PROJECT}@`,
-    `staging-${PROJECT}@`
-]
 
 export function monorepoGit() {
-    return git({ baseDir: REPO_BASE })
+  return git({ baseDir: REPO_BASE })
 }
 
-export const versionFromTag = tag => {
-    // Extract version from tag format: protocol-designer@8.6.0 or staging-protocol-designer@8.6.0
-    const parts = tag.split('@')
-    return parts[1]
+function defaultTagPrefixes(project) {
+  if (project === 'robot-stack') {
+    return ['v']
+  }
+
+  return [`${project}@`, `staging-${project}@`]
 }
 
-export async function getTagsPointingAtHead() {
+function normalizeTagPrefixes(project, tagPrefixes) {
+  const prefixes = tagPrefixes?.length ? tagPrefixes : defaultTagPrefixes(project)
+  const unique = [...new Set(prefixes.filter(Boolean))]
+
+  if (unique.length === 0) {
+    throw new Error('At least one tag prefix is required')
+  }
+
+  return unique
+}
+
+function parseTagWithPrefixes(tag, prefixes) {
+  for (const prefix of prefixes) {
+    if (tag.startsWith(prefix)) {
+      return { prefix, version: tag.slice(prefix.length) }
+    }
+  }
+  return null
+}
+
+export function createGitVersionToolkit(options) {
+  const {
+    project,
+    tagPrefixes,
+  } = options ?? {}
+
+  if (!project) {
+    throw new Error('project is required')
+  }
+
+  const prefixes = normalizeTagPrefixes(project, tagPrefixes)
+
+  async function getTagsPointingAtHead() {
     try {
-        const tags = (
-            await monorepoGit().raw([
-                'tag',
-                '--points-at',
-                'HEAD',
-                '--list',
-                ...TAG_PREFIXES.map(prefix => `${prefix}*`),
-            ])
-        ).trim()
+      const tags = (
+        await monorepoGit().raw([
+          'tag',
+          '--points-at',
+          'HEAD',
+          '--list',
+          ...prefixes.map(prefix => `${prefix}*`),
+        ])
+      ).trim()
 
-        if (tags) {
-            return tags.split('\n').filter(t => t.length > 0)
-        }
+      if (tags) {
+        return tags.split('\n').filter(t => t.length > 0)
+      }
     } catch (error) {
-        // No tags found or git error
+      // ignore errors and fall through to empty list
     }
 
     return []
-}
+  }
 
-export async function getCurrentBranchName() {
+  async function getCurrentBranchName() {
     const isCI = process.env.CI === 'true'
 
     try {
-        const branch = (
-            await monorepoGit().raw(['rev-parse', '--abbrev-ref', 'HEAD'])
-        ).trim()
+      const branch = (
+        await monorepoGit().raw(['rev-parse', '--abbrev-ref', 'HEAD'])
+      ).trim()
+
+      if (isCI) {
+        console.log(`[git-version-v2] git rev-parse result: ${branch}`)
+      }
+
+      if (branch === 'HEAD') {
+        let ciBranch = process.env.GITHUB_HEAD_REF || process.env.GITHUB_REF_NAME
+
+        if (
+          ciBranch === process.env.GITHUB_REF_NAME &&
+          process.env.GITHUB_REF_TYPE === 'tag'
+        ) {
+          ciBranch = null
+        }
 
         if (isCI) {
-            console.log(`[git-version2] git rev-parse result: ${branch}`)
+          console.log(`[git-version-v2] Resolved CI branch: ${ciBranch}`)
         }
 
-        if (branch === 'HEAD') {
-            // Detached HEAD state - try CI environment variables
-            let ciBranch = process.env.GITHUB_HEAD_REF || process.env.GITHUB_REF_NAME
+        return ciBranch || null
+      }
 
-            // Skip if this is a tag ref, not a branch
-            if (ciBranch === process.env.GITHUB_REF_NAME &&
-                process.env.GITHUB_REF_TYPE === 'tag') {
-                ciBranch = null
-            }
-
-            if (isCI) {
-                console.log(`[git-version2] Resolved CI branch: ${ciBranch}`)
-            }
-
-            return ciBranch || null
-        }
-
-        return branch
+      return branch
     } catch (error) {
-        const fallbackBranch = process.env.GITHUB_HEAD_REF ||
-            process.env.GITHUB_REF_NAME ||
-            process.env.CI_COMMIT_REF_NAME ||
-            process.env.CIRCLE_BRANCH ||
-            null
+      const fallbackBranch =
+        process.env.GITHUB_HEAD_REF ||
+        process.env.GITHUB_REF_NAME ||
+        process.env.CI_COMMIT_REF_NAME ||
+        process.env.CIRCLE_BRANCH ||
+        null
 
-        if (isCI) {
-            console.log(`[git-version2] git command failed, using fallback: ${fallbackBranch}`)
-        }
+      if (isCI) {
+        console.log(
+          `[git-version-v2] git command failed, using fallback: ${fallbackBranch}`
+        )
+      }
 
-        return fallbackBranch
+      return fallbackBranch
     }
-}
+  }
 
-export function getTimestamp() {
+  function getTimestamp() {
     const now = new Date()
     const year = now.getUTCFullYear()
     const month = String(now.getUTCMonth() + 1).padStart(2, '0')
@@ -100,112 +130,104 @@ export function getTimestamp() {
     const minutes = String(now.getUTCMinutes()).padStart(2, '0')
     const seconds = String(now.getUTCSeconds()).padStart(2, '0')
     return `${year}${month}${day}-${hours}${minutes}${seconds}`
-}
+  }
 
-export async function getLatestTag() {
+  async function getLatestTag() {
     const gitClient = monorepoGit()
     const candidates = []
 
-    // Get all tags reachable from HEAD (all prefixes in one call)
     try {
-        const tagsOutput = (
-            await gitClient.raw([
-                'tag',
-                '--merged',
-                'HEAD',
-                '--list',
-                ...TAG_PREFIXES.map(prefix => `${prefix}*`),
-            ])
-        ).trim()
+      const tagsOutput = (
+        await gitClient.raw([
+          'tag',
+          '--merged',
+          'HEAD',
+          '--list',
+          ...prefixes.map(prefix => `${prefix}*`),
+        ])
+      ).trim()
 
-        if (tagsOutput.length === 0) {
-            throw new Error(`No matching tags found for ${PROJECT}.`)
+      if (tagsOutput.length === 0) {
+        throw new Error(`No matching tags found for ${project}.`)
+      }
+
+      const tags = tagsOutput.split('\n').filter(t => t.length > 0)
+
+      for (const tag of tags) {
+        const parsed = parseTagWithPrefixes(tag, prefixes)
+        if (!parsed) continue
+
+        const semverVersion = semver.parse(parsed.version)
+        if (semverVersion) {
+          candidates.push({
+            tag,
+            version: semverVersion,
+            prefix: parsed.prefix,
+          })
         }
-
-        const tags = tagsOutput.split('\n').filter(t => t.length > 0)
-
-        // Parse version from each tag and add to candidates
-        for (const tag of tags) {
-            try {
-                const version = versionFromTag(tag)
-                const parsedVersion = semver.parse(version)
-
-                if (parsedVersion != null) {
-                    // Determine which prefix this tag uses
-                    const prefix = TAG_PREFIXES.find(p => tag.startsWith(p))
-                    
-                    candidates.push({
-                        tag,
-                        version: parsedVersion,
-                        prefix,
-                    })
-                }
-            } catch (error) {
-                // Skip tags that don't have valid semver
-                continue
-            }
-        }
+      }
     } catch (error) {
-        throw new Error(`No matching tags found for ${PROJECT}.`)
+      throw new Error(`No matching tags found for ${project}.`)
     }
 
     if (candidates.length === 0) {
-        throw new Error(`No matching tags found for ${PROJECT}.`)
+      throw new Error(`No matching tags found for ${project}.`)
     }
 
-    // Sort by semantic version (highest first), then by prefix priority
     candidates.sort((a, b) => {
-        // Compare semantic versions
-        const versionCompare = semver.rcompare(a.version, b.version)
-        
-        if (versionCompare !== 0) {
-            return versionCompare
-        }
-
-        // If versions are equal, use prefix priority (production > staging)
-        return TAG_PREFIXES.indexOf(a.prefix) - TAG_PREFIXES.indexOf(b.prefix)
+      const versionCompare = semver.rcompare(a.version, b.version)
+      if (versionCompare !== 0) {
+        return versionCompare
+      }
+      return prefixes.indexOf(a.prefix) - prefixes.indexOf(b.prefix)
     })
 
     return candidates[0].tag
-}
+  }
 
-export async function getVersion() {
+  async function getVersion() {
     return getLatestTag()
-        .then(tag => versionFromTag(tag))
-        .catch(error => {
-            console.error(
-                `Could not find a version for ${PROJECT} (${error}) - no tags yet or no tags fetched? Using 0.0.0-dev`
-            )
-            return '0.0.0-dev'
-        })
-}
+      .then(tag => parseTagWithPrefixes(tag, prefixes)?.version)
+      .catch(error => {
+        console.error(
+          `Could not find a version for ${project} (${error}) - using 0.0.0-dev`
+        )
+        return '0.0.0-dev'
+      })
+  }
 
-export async function generateBuildInfoHtml(outputPath) {
+  async function generateBuildInfoHtml(outputPath) {
     const version = await getVersion()
     const timestamp = getTimestamp()
     const isCI = process.env.CI === 'true'
 
     let gitInfo = {}
     try {
-        const branch = await getCurrentBranchName()
-        const tags = await getTagsPointingAtHead()
-        const commitSha = (await monorepoGit().raw(['rev-parse', 'HEAD'])).trim()
-        const shortSha = commitSha.substring(0, 7)
-        const commitMessage = (await monorepoGit().raw(['log', '-1', '--pretty=%B'])).trim()
-        const commitAuthor = (await monorepoGit().raw(['log', '-1', '--pretty=%an'])).trim()
-        const commitDate = (await monorepoGit().raw(['log', '-1', '--pretty=%ci'])).trim()
+      const branch = await getCurrentBranchName()
+      const tags = await getTagsPointingAtHead()
+      const commitSha = (await monorepoGit().raw(['rev-parse', 'HEAD'])).trim()
+      const shortSha = commitSha.substring(0, 7)
+      const commitMessage = (
+        await monorepoGit().raw(['log', '-1', '--pretty=%B'])
+      ).trim()
+      const commitAuthor = (
+        await monorepoGit().raw(['log', '-1', '--pretty=%an'])
+      ).trim()
+      const commitDate = (
+        await monorepoGit().raw(['log', '-1', '--pretty=%ci'])
+      ).trim()
 
-        gitInfo = {
-            branch,
-            tags: tags.length > 0 ? tags : ['(none)'],
-            commitSha,
-            shortSha,
-            commitMessage,
-            commitAuthor,
-            commitDate
-        }
+      gitInfo = {
+        branch,
+        tags: tags.length > 0 ? tags : ['(none)'],
+        commitSha,
+        shortSha,
+        commitMessage,
+        commitAuthor,
+        commitDate,
+      }
     } catch (error) {
-        gitInfo = { error: error.message }
+      gitInfo = { error: error.message }
     }
 
     const serverUrl = process.env.GITHUB_SERVER_URL || 'https://github.com'
@@ -215,79 +237,69 @@ export async function generateBuildInfoHtml(outputPath) {
     const baseRef = process.env.GITHUB_BASE_REF
 
     const githubInfo = {
-        // Run information
-        runId: runId || 'N/A',
-        runNumber: process.env.GITHUB_RUN_NUMBER || 'N/A',
-        runAttempt: process.env.GITHUB_RUN_ATTEMPT || 'N/A',
-        job: process.env.GITHUB_JOB || 'N/A',
-
-        // Workflow information
-        workflow: process.env.GITHUB_WORKFLOW || 'N/A',
-        workflowRef: process.env.GITHUB_WORKFLOW_REF || 'N/A',
-        workflowSha: process.env.GITHUB_WORKFLOW_SHA || 'N/A',
-
-        // Actor information
-        actor: process.env.GITHUB_ACTOR || 'N/A',
-        actorId: process.env.GITHUB_ACTOR_ID || 'N/A',
-        triggeringActor: process.env.GITHUB_TRIGGERING_ACTOR || 'N/A',
-
-        // Event information
-        event: process.env.GITHUB_EVENT_NAME || 'N/A',
-        eventPath: process.env.GITHUB_EVENT_PATH || 'N/A',
-
-        // Ref information
-        ref: process.env.GITHUB_REF || 'N/A',
-        refName: process.env.GITHUB_REF_NAME || 'N/A',
-        refType: process.env.GITHUB_REF_TYPE || 'N/A',
-        refProtected: process.env.GITHUB_REF_PROTECTED || 'N/A',
-        headRef: headRef || 'N/A',
-        baseRef: baseRef || 'N/A',
-
-        // Repository information
-        repository: repository,
-        repositoryId: process.env.GITHUB_REPOSITORY_ID || 'N/A',
-        repositoryOwner: process.env.GITHUB_REPOSITORY_OWNER || 'N/A',
-        repositoryOwnerId: process.env.GITHUB_REPOSITORY_OWNER_ID || 'N/A',
-
-        // Environment
-        environment: process.env.GITHUB_ENV || 'N/A',
-
-        // URLs
-        serverUrl: serverUrl,
-        apiUrl: process.env.GITHUB_API_URL || 'https://api.github.com',
-        graphqlUrl: process.env.GITHUB_GRAPHQL_URL || 'https://api.github.com/graphql',
-
-        // Constructed links
-        runUrl: runId && repository
-            ? `${serverUrl}/${repository}/actions/runs/${runId}`
-            : null,
-        compareUrl: headRef && baseRef && repository
-            ? `${serverUrl}/${repository}/compare/${baseRef}...${headRef}`
-            : null,
-        prUrl: headRef && repository && process.env.GITHUB_EVENT_NAME === 'pull_request'
-            ? `${serverUrl}/${repository}/pull/${process.env.GITHUB_REF_NAME?.replace('refs/pull/', '').replace('/merge', '')}`
-            : null,
-        branchUrl: process.env.GITHUB_REF_TYPE === 'branch' && process.env.GITHUB_REF_NAME && repository
-            ? `${serverUrl}/${repository}/tree/${process.env.GITHUB_REF_NAME}`
-            : null,
-        tagUrl: process.env.GITHUB_REF_TYPE === 'tag' && process.env.GITHUB_REF_NAME && repository
-            ? `${serverUrl}/${repository}/releases/tag/${process.env.GITHUB_REF_NAME}`
-            : null
+      runId: runId || 'N/A',
+      runNumber: process.env.GITHUB_RUN_NUMBER || 'N/A',
+      runAttempt: process.env.GITHUB_RUN_ATTEMPT || 'N/A',
+      job: process.env.GITHUB_JOB || 'N/A',
+      workflow: process.env.GITHUB_WORKFLOW || 'N/A',
+      workflowRef: process.env.GITHUB_WORKFLOW_REF || 'N/A',
+      workflowSha: process.env.GITHUB_WORKFLOW_SHA || 'N/A',
+      actor: process.env.GITHUB_ACTOR || 'N/A',
+      actorId: process.env.GITHUB_ACTOR_ID || 'N/A',
+      triggeringActor: process.env.GITHUB_TRIGGERING_ACTOR || 'N/A',
+      event: process.env.GITHUB_EVENT_NAME || 'N/A',
+      eventPath: process.env.GITHUB_EVENT_PATH || 'N/A',
+      ref: process.env.GITHUB_REF || 'N/A',
+      refName: process.env.GITHUB_REF_NAME || 'N/A',
+      refType: process.env.GITHUB_REF_TYPE || 'N/A',
+      refProtected: process.env.GITHUB_REF_PROTECTED || 'N/A',
+      headRef: headRef || 'N/A',
+      baseRef: baseRef || 'N/A',
+      repository,
+      repositoryId: process.env.GITHUB_REPOSITORY_ID || 'N/A',
+      repositoryOwner: process.env.GITHUB_REPOSITORY_OWNER || 'N/A',
+      repositoryOwnerId: process.env.GITHUB_REPOSITORY_OWNER_ID || 'N/A',
+      environment: process.env.GITHUB_ENV || 'N/A',
+      serverUrl,
+      apiUrl: process.env.GITHUB_API_URL || 'https://api.github.com',
+      graphqlUrl: process.env.GITHUB_GRAPHQL_URL || 'https://api.github.com/graphql',
+      runUrl:
+        runId && repository ? `${serverUrl}/${repository}/actions/runs/${runId}` : null,
+      compareUrl:
+        headRef && baseRef && repository
+          ? `${serverUrl}/${repository}/compare/${baseRef}...${headRef}`
+          : null,
+      prUrl:
+        headRef &&
+        repository &&
+        process.env.GITHUB_EVENT_NAME === 'pull_request'
+          ? `${serverUrl}/${repository}/pull/${process.env.GITHUB_REF_NAME?.replace('refs/pull/', '').replace('/merge', '')}`
+          : null,
+      branchUrl:
+        process.env.GITHUB_REF_TYPE === 'branch' &&
+        process.env.GITHUB_REF_NAME &&
+        repository
+          ? `${serverUrl}/${repository}/tree/${process.env.GITHUB_REF_NAME}`
+          : null,
+      tagUrl:
+        process.env.GITHUB_REF_TYPE === 'tag' &&
+        process.env.GITHUB_REF_NAME &&
+        repository
+          ? `${serverUrl}/${repository}/releases/tag/${process.env.GITHUB_REF_NAME}`
+          : null,
     }
 
-    // Build information
     const buildInfo = {
-        project: PROJECT,
-        version,
-        timestamp,
-        buildDate: new Date().toISOString(),
-        nodeVersion: process.version,
-        platform: process.platform,
-        arch: process.arch,
-        isCI
+      project,
+      version,
+      timestamp,
+      buildDate: new Date().toISOString(),
+      nodeVersion: process.version,
+      platform: process.platform,
+      arch: process.arch,
+      isCI,
     }
 
-    // Generate HTML
     const html = `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -667,7 +679,8 @@ export async function generateBuildInfoHtml(outputPath) {
                     ` : ''}
                     ${githubInfo.baseRef !== 'N/A' ? `
                     <div class="info-item">
-                        <div class="info-label">Base Ref (PR)</div>
+                        <div class="info-label">Base Ref (PR)
+                        </div>
                         <div class="info-value">${githubInfo.baseRef}</div>
                     </div>
                     ` : ''}
@@ -685,7 +698,8 @@ export async function generateBuildInfoHtml(outputPath) {
                     </div>
                     <div class="info-item">
                         <div class="info-label">Repository ID</div>
-                        <div class="info-value">${githubInfo.repositoryId}</div>
+                        <div class="info-value">${githubInfo.repositoryId}
+                        </div>
                     </div>
                     <div class="info-item">
                         <div class="info-label">Repository Owner</div>
@@ -706,24 +720,35 @@ export async function generateBuildInfoHtml(outputPath) {
         </div>
         
         <div class="footer">
-            Generated by git-version2.mjs on ${new Date().toLocaleString()}
+            Generated by git-version-v2.mjs on ${new Date().toLocaleString()}
         </div>
     </div>
 </body>
 </html>`
 
-    // Write the HTML file
     const fs = await import('fs')
     const path = await import('path')
 
-    // Ensure output directory exists
     const outputDir = path.dirname(outputPath)
     await fs.promises.mkdir(outputDir, { recursive: true })
 
-    // Write the file
     await fs.promises.writeFile(outputPath, html, 'utf-8')
 
     console.log(`✅ Build info HTML generated: ${outputPath}`)
 
     return outputPath
+  }
+
+  return {
+    project,
+    tagPrefixes: prefixes,
+    getTagsPointingAtHead,
+    getCurrentBranchName,
+    getTimestamp,
+    getLatestTag,
+    getVersion,
+    generateBuildInfoHtml,
+  }
 }
+
+export default createGitVersionToolkit


### PR DESCRIPTION
## Summary

Labware Library `3.7.0` (which will ship after `8.8.0`) will be built from the `chore_release-8.8.0` branch. This PR adds the build-info HTML page to the Labware Library built environment, matching the pattern we already use in Protocol Designer.

Including this page makes it much easier to trace deployment back to the exact job and commit that produced it.

[Sandbox link to the page for this branch](https://d2dn8e5p20ckdu.cloudfront.net/labware-library-build-page/info/)

## Details

- Introduces the same build-metadata HTML page used by Protocol Designer.
- Refactors version and info page into `git-version-2`:
  - It has been stable and reliable in PD.
  - This PR parameterizes it so it can be reused cleanly for Labware Library.

## Why This Matters

This improves traceability and aligns Labware Library with our standardized deployment practices, reducing ambiguity when diagnosing issues in production and tightening the feedback loop between releases and CI.
