### PR TITLE
docs: add error recovery status light info

### DIFF
--- a/docs/flex/docs/glossary.md
+++ b/docs/flex/docs/glossary.md
@@ -272,7 +272,7 @@ Staging area slots are ANSI/SLAS compatible deck pieces that replace the standar
 
 ##### Status light
 
-A strip of color LEDs along the top front of the robot. This light provides at-a-glance information about the robot. Different colors and patterns of illumination can communicate various success, failure, or idle states. See the [Touchscreen and LED displays section][status-light-flex] in the System Description chapter.
+A strip of color LEDs along the top front of the robot. This light provides at-a-glance information about the robot. Different colors and patterns of illumination can communicate various success, failure, or idle states. See the [Status Light section][status-light-flex] in the System Description chapter.
 
 ##### Thermal adapter
 
@@ -292,7 +292,7 @@ An aluminum bracket used by the 96-channel pipette to attach a full rack of pipe
 
 ##### Touchscreen
 
-The interactive LCD screen mounted to the front of the robot. See the [Touchscreen and LED displays section][touchscreen-display] in the System Description chapter.
+The interactive LCD screen mounted to the front of the robot. See the [Touchscreen display section][touchscreen-display] in the System Description chapter.
 
 ##### Trash bin
 

--- a/docs/flex/docs/glossary.md
+++ b/docs/flex/docs/glossary.md
@@ -272,7 +272,7 @@ Staging area slots are ANSI/SLAS compatible deck pieces that replace the standar
 
 ##### Status light
 
-A strip of color LEDs along the top front of the robot. This light provides at-a-glance information about the robot. Different colors and patterns of illumination can communicate various success, failure, or idle states. See the [Touchscreen and LED displays section][touchscreen-and-led-displays] in the System Description chapter.
+A strip of color LEDs along the top front of the robot. This light provides at-a-glance information about the robot. Different colors and patterns of illumination can communicate various success, failure, or idle states. See the [Touchscreen and LED displays section][status-light-flex] in the System Description chapter.
 
 ##### Thermal adapter
 
@@ -292,7 +292,7 @@ An aluminum bracket used by the 96-channel pipette to attach a full rack of pipe
 
 ##### Touchscreen
 
-The interactive LCD screen mounted to the front of the robot. See the [Touchscreen and LED displays section][touchscreen-and-led-displays] in the System Description chapter.
+The interactive LCD screen mounted to the front of the robot. See the [Touchscreen and LED displays section][touchscreen-display] in the System Description chapter.
 
 ##### Trash bin
 

--- a/docs/flex/docs/system-description/index.md
+++ b/docs/flex/docs/system-description/index.md
@@ -5,5 +5,5 @@ title: "Opentrons Flex: System Description"
 This chapter describes the hardware systems of Opentrons Flex, which underlie its core lab automation features. 
 
 - The [deck][deck-and-working-area], [gantry](robot.md#gantry), and instrument mounts of Opentrons Flex enable the use of precision liquid handling and labware movement components. 
-- The [on-device touchscreen][touchscreen-and-led-displays] enables running protocols and checking on the robot's status without needing to bring your computer to the lab bench. 
+- The [on-device touchscreen][touchscreen-display] enables running protocols and checking on the robot's status without needing to bring your computer to the lab bench. 
 - [Wired and wireless connectivity](connections.md) enables additional control from the Opentrons App (see the [Opentrons App chapter](../opentrons-app.md) for more details) and extending the system's features by attaching peripherals (see the [Modules chapter](../modules/index.md)).

--- a/docs/flex/docs/system-description/robot.md
+++ b/docs/flex/docs/system-description/robot.md
@@ -119,7 +119,7 @@ The electronics contained in the gantry provide 36 VDC power and communications 
 <figcaption>Location of instrument mounts on Flex.</figcaption>
 </figure>
 
-## Touchscreen and LED displays
+## Touchscreen display
 
 The primary user interface is the 7-inch LCD *touchscreen*, located on the front right of the robot. The touchscreen is covered with Gorilla Glass 3 for scratch and damage resistance. Access many features of Flex right on the touchscreen, including:
 
@@ -136,6 +136,8 @@ The primary user interface is the 7-inch LCD *touchscreen*, located on the front
 - Operation logs and error notifications
 
 For more information on using Flex via the touchscreen, see the [Touchscreen chapter](../touchscreen/index.md).
+
+## Status light { #status-light-flex }
 
 The *status light* is a strip of LEDs along the top front of the robot that provides at-a-glance information about the robot. Different colors and patterns of illumination can communicate various success, failure, or idle states:
 
@@ -176,9 +178,13 @@ The *status light* is a strip of LEDs along the top front of the robot that prov
       <td>Protocol is paused</td>
     </tr>
     <tr>
-      <td><span class="status-dot yellow"></span> Yellow<br>Abnormal states</td>
+      <td rowspan="2"><span class="status-dot yellow"></span> Yellow<br>Abnormal states</td>
       <td>Solid</td>
       <td>Software error</td>
+    </tr>
+    <tr>
+      <td>Pulsing</td>
+      <td><a href="../../touchscreen/protocol-run/#error-recovery">Error recovery mode</a></td>
     </tr>
     <tr>
       <td><span class="status-dot red"></span> Red<br>Emergency states</td>


### PR DESCRIPTION
# Overview

The table of status light states didn't include the pulsing yellow light for error recovery. Now it does.

## Test Plan and Hands on Testing

[Sandbox](https://sandbox.docs.opentrons.com/docs-error-recover-lights/flex/system-description/robot/#status-light-flex)

## Changelog

- Add one line to status light table.
- Add `## Status light` header so it's easier to find this info.
- Fix up links that went to the old header.

## Review requests

- Well I misspelled my branch name so make sure I didn't do anything else silly here.
- Does the link in the table look dumb?

## Risk assessment

none, docs only