### PR TITLE
(docs)api: versioning updates for 2.27

### DIFF
--- a/api/docs/v2/basic_commands/liquids.rst
+++ b/api/docs/v2/basic_commands/liquids.rst
@@ -407,7 +407,7 @@ And this example adds a push out of 10 µL after the final dispense in the mix::
 .. versionchanged:: 2.24
     Adds the ``aspirate_flow_rate``, ``dispense_flow_rate``, ``aspirate_delay``, ``dispense_delay``, and ``final_push_out`` parameters. 
 
-.. _dynamic_mix:
+.. _dynamic-mix:
 
 Dynamic Mix
 ===========

--- a/api/docs/v2/conf.py
+++ b/api/docs/v2/conf.py
@@ -99,7 +99,7 @@ extensions += ['sphinx-prompt', 'sphinx_substitution_extensions']
 # use rst_prolog to hold the subsitution
 # update the apiLevel value whenever a new minor version is released
 rst_prolog = f"""
-.. |apiLevel| replace:: 2.25
+.. |apiLevel| replace:: 2.27
 .. |release| replace:: {release}
 """
 

--- a/api/docs/v2/new_protocol_api.rst
+++ b/api/docs/v2/new_protocol_api.rst
@@ -112,7 +112,7 @@ Temperature Module
 
 .. autoclass:: opentrons.protocol_api.TemperatureModuleContext
    :members:
-   :exclude-members: start_set_temperature, await_temperature, broker, geometry, load_labware_object
+   :exclude-members: await_temperature, broker, geometry, load_labware_object
    :inherited-members:
 
 Thermocycler

--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -150,13 +150,14 @@ Changes in API Versions
 
 Version 2.27
 ------------
-- Adds concurrent commands to perform Temperature, Heater-Shaker, or Thermocycler Module actions alongside other protocol steps: 
+- Adds :ref:`concurrent module commands <concurrent-module>` to perform Temperature, Heater-Shaker, or Thermocycler Module actions alongside other protocol steps: 
     - :py:meth:`.TemperatureModuleContext.start_set_temperature`
     - :py:meth:`.HeaterShakerContext.set_shake_speed`
     - :py:meth:`.ThermocyclerContext.start_set_block_temperature`, :py:meth:`.ThermocyclerContext.start_set_lid_temperature`, and :py:meth:`.ThermocyclerContext.start_execute_profile`
 - Control pipette movement while aspirating or dispensing: 
-    - Use the ``end_location`` and ``movement_delay`` parameters control pipette movement during an :py:meth:`~.InstrumentContext.aspirate` or :py:meth:`~.InstrumentContext.dispense`, including pipetting relative to the liquid meniscus as liquid level changes. See :ref:`new-aspirate` and :ref:`_new-dispense`. 
-    -  Set aspirate and dispense locations during a :ref:`dynamic-mix`. 
+    - Use the ``end_location`` and ``movement_delay`` parameters to control pipette movement while :ref:`aspirating <new-aspirate>` or :ref:`dispensing <new-dispense>`.
+    - Pipette relative to the :ref:`liquid meniscus <well-meniscus>` as liquid level changes.
+    -  Set locations to start and end aspirating and dispensing in a :ref:`dynamic-mix`. 
 - Take images using the Flex or OT-2's built in-camera with the new :py:meth:`.ProtocolContext.capture_image` method.
 - Use the ``tips`` parameter to select tips to use during a :py:meth:`~.InstrumentContext.transfer_with_liquid_class`. 
 

--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -68,7 +68,7 @@ The maximum supported API version for your robot is listed in the Opentrons App 
 
 If you upload a protocol that specifies a higher API level than the maximum supported, your robot won't be able to analyze or run your protocol. You can increase the maximum supported version by updating your robot software and Opentrons App. 
 
-Opentrons robots running the latest software (8.7.0) support the following version ranges: 
+Opentrons robots running the latest software (8.8.0) support the following version ranges: 
 
     * **Flex:** version 2.15–|apiLevel|.
     * **OT-2:** versions 2.0–|apiLevel|.
@@ -84,6 +84,8 @@ This table lists the correspondence between Protocol API versions and robot soft
 +-------------+------------------------------+
 | API Version | Introduced in Robot Software |
 +=============+==============================+
+|     2.27    |          8.8.0               |
++-------------+------------------------------+
 |     2.26    |          8.7.0               |
 +-------------+------------------------------+
 |     2.25    |          8.6.0               |
@@ -145,6 +147,18 @@ This table lists the correspondence between Protocol API versions and robot soft
 
 Changes in API Versions
 =======================
+
+Version 2.27
+------------
+- Adds concurrent commands to perform Temperature, Heater-Shaker, or Thermocycler Module actions alongside other protocol steps: 
+    - :py:meth:`.TemperatureModuleContext.start_set_temperature`
+    - :py:meth:`.HeaterShakerContext.set_shake_speed`
+    - :py:meth:`.ThermocyclerContext.start_set_block_temperature`, :py:meth:`.ThermocyclerContext.start_set_lid_temperature`, and :py:meth:`.ThermocyclerContext.start_execute_profile`
+- Control pipette movement while aspirating or dispensing: 
+    - Use the ``end_location`` and ``movement_delay`` parameters control pipette movement during an :py:meth:`~.InstrumentContext.aspirate` or :py:meth:`~.InstrumentContext.dispense`, including pipetting relative to the liquid meniscus as liquid level changes. See :ref:`new-aspirate` and :ref:`_new-dispense`. 
+    -  Set aspirate and dispense locations during a :ref:`dynamic-mix`. 
+- Take images using the Flex or OT-2's built in-camera with the new :py:meth:`.ProtocolContext.capture_image` method.
+- Use the ``tips`` parameter to select tips to use during a :py:meth:`~.InstrumentContext.transfer_with_liquid_class`. 
 
 Version 2.26
 -------------

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -854,7 +854,7 @@ class InstrumentContext(publisher.CommandPublisher):
         """
         Mix a volume of liquid by repeatedly aspirating and dispensing it in a multiple locations.
 
-        See :ref:`dynamic_mix` for examples.
+        See :ref:`dynamic-mix` for examples.
 
         :param repetitions: Number of times to mix (default is 1).
         :param volume: The volume to mix, measured in µL. If unspecified, defaults


### PR DESCRIPTION
# Overview

Updating versioning in API docs for 2.27. 


## Test Plan and Hands on Testing



## Changelog



## Review requests



## Risk assessment

low
