### PR TITLE
fix(app): Waste chute removal pages for 96ch calibration

### DIFF
--- a/app/src/assets/localization/en/pipette_wizard_flows.json
+++ b/app/src/assets/localization/en/pipette_wizard_flows.json
@@ -87,10 +87,10 @@
   "unscrew_and_detach": "Loosen Screws and Detach Mounting Plate",
   "unscrew_at_top": "<block>Loosen the captive screw on the top right of the  carriage. This releases the right pipette mount, which should then freely move up and down.</block>",
   "unscrew_carriage": "unscrew z-axis carriage",
-  "waste_chute_attach_warning": "Re-attach waste chute to match current deck configuration.",
   "waste_chute_error": "Remove waste chute before calibrating.",
   "waste_chute_warning": "A collision will occur with the pipette if the waste chute remains on deck.",
   "waste_chute_warning_probe": "If the waste chute is installed, remove it from the Deck Plate Adapter before proceeding.",
+  "waste_chute_attach_warning": "Re-attach waste chute to match current deck configuration.",
   "wrong_pip": "wrong instrument installed",
   "z_axis_still_attached": "z-axis screw still secure"
 }

--- a/app/src/organisms/PipetteWizardFlows/AttachProbe.tsx
+++ b/app/src/organisms/PipetteWizardFlows/AttachProbe.tsx
@@ -69,7 +69,7 @@ export const AttachProbe = (props: AttachProbeProps): JSX.Element | null => {
     proceed()
   }
 
-  const { t, i18n } = useTranslation('pipette_wizard_flows')
+  const { t, i18n } = useTranslation(['pipette_wizard_flows', 'shared'])
   const pipetteWizardStep = { mount, flowType, section: SECTIONS.ATTACH_PROBE }
   const [showUnableToDetect, setShowUnableToDetect] = useState<boolean>(false)
   const pipetteId = attachedPipettes[mount]?.serialNumber
@@ -199,7 +199,7 @@ export const AttachProbe = (props: AttachProbeProps): JSX.Element | null => {
       }
       proceedButtonText={
         is96Channel && isWasteChuteOnDeck(deckConfig)
-          ? capitalize('shared:continue')
+          ? t('shared:continue')
           : t('begin_calibration')
       }
       proceed={

--- a/app/src/organisms/PipetteWizardFlows/AttachProbe.tsx
+++ b/app/src/organisms/PipetteWizardFlows/AttachProbe.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
-import capitalize from 'lodash/capitalize'
 import { css } from 'styled-components'
 
 import {


### PR DESCRIPTION
# Overview

Additional pages added for warning to remove waste chute before 96 ch calibration

## Test Plan and Hands on Testing

- smoke on robot on app

https://github.com/user-attachments/assets/6a99a747-c439-4955-8a50-58b91e1f61ca

## Changelog

- fixed merge conflicts
- fixed continue string copy error

## Risk assessment

low