### PR TITLE
chore(protocol-designer): Add tslib back into protocol-designer/vite.config.mts.

### DIFF
--- a/protocol-designer/vite.config.mts
+++ b/protocol-designer/vite.config.mts
@@ -113,6 +113,8 @@ export default defineConfig(async (): Promise<UserConfig> => {
       esbuildOptions: {
         target: 'es2020',
       },
+      // For unknown reasons, PD whitescreens on launch unless we have this.
+      include: ['tslib'],
     },
     css: {
       postcss: {
@@ -143,6 +145,8 @@ export default defineConfig(async (): Promise<UserConfig> => {
     },
     resolve: {
       conditions: ['browser'],
+      // For unknown reasons, PD whitescreens on launch unless we have this.
+      dedupe: ['tslib'],
       alias: {
         // todo(mm, 2025-10-27): These cross-project aliases cause trouble like
         // files being processed with the wrong config (the config from the


### PR DESCRIPTION
# Overview

reflect vite config fix from https://github.com/Opentrons/opentrons/pull/20229

## Test Plan and Hands on Testing

- build PD dev server and make sure the app is built
- just checkout the linked PR and make sure it looks good

## Changelog

cherry-pick fix targeting `edge`

## Review requests

see test plan

## Risk assessment

low