### PR TITLE
fix(protocol-designer): improve logic of eager tip dropping in `generateRobotStateTimeline`

### DIFF
--- a/protocol-designer/src/timelineMiddleware/__tests__/generateRobotStateTimeline.test.ts
+++ b/protocol-designer/src/timelineMiddleware/__tests__/generateRobotStateTimeline.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   fixtureTiprack300ul,
@@ -24,8 +24,9 @@ import type { StepArgsAndErrorsById } from '../../steplist'
 vi.mock('../../labware-defs/utils')
 
 describe('generateRobotStateTimeline', () => {
-  it('performs eager tip dropping', () => {
-    const allStepArgsAndErrors: StepArgsAndErrorsById = {
+  let allStepArgsAndErrors: StepArgsAndErrorsById
+  beforeEach(() => {
+    allStepArgsAndErrors = {
       a: {
         errors: false,
         stepArgs: {
@@ -216,6 +217,9 @@ describe('generateRobotStateTimeline', () => {
         },
       },
     }
+  })
+
+  it('performs eager tip dropping', () => {
     const orderedStepIds = ['a', 'b', 'c']
     const invariantContext = makeContext()
     const initialRobotState = getInitialRobotStateStandard(invariantContext)
@@ -303,6 +307,56 @@ describe('generateRobotStateTimeline', () => {
       `
 mock_pipette.transfer_with_liquid_class(...)
 mock_pipette.drop_tip()
+`.trim(),
+      // Step b:
+      `
+mock_pipette_p300_multi.transfer_with_liquid_class(...)
+mock_pipette_p300_multi.drop_tip()
+`.trim(),
+      // Step c:
+      `
+mock_pipette.pick_up_tip(location=mock_tip_rack_1)
+mock_pipette.mix(...)
+mock_pipette.drop_tip()
+mock_pipette.pick_up_tip(location=mock_tip_rack_1)
+mock_pipette.mix(...)
+mock_pipette.drop_tip()
+`.trim(),
+    ])
+  })
+
+  it('does not perform eager tip dropping if the step returns tip', () => {
+    allStepArgsAndErrors = {
+      ...allStepArgsAndErrors,
+      a: {
+        ...allStepArgsAndErrors.a,
+        stepArgs: {
+          ...allStepArgsAndErrors.a.stepArgs,
+          dropTipLocation: getLabwareDefURI(
+            fixtureTiprack300ul as LabwareDefinition2
+          ),
+        },
+      },
+    } as StepArgsAndErrorsById
+    const orderedStepIds = ['a', 'b', 'c']
+    const invariantContext = makeContext()
+    const initialRobotState = getInitialRobotStateStandard(invariantContext)
+    const result = generateRobotStateTimeline({
+      allStepArgsAndErrors,
+      orderedStepIds,
+      initialRobotState,
+      invariantContext,
+    })
+    expect(result.errors).toBe(null)
+
+    // The regex elides all the indented arguments in the Python code
+    const pythonCommandsOverview = result.timeline.map(frame =>
+      frame.python?.replaceAll(/(\n\s+.*)+\n/g, '...')
+    )
+    expect(pythonCommandsOverview).toEqual([
+      // Step a:
+      `
+mock_pipette.transfer_with_liquid_class(...)
 `.trim(),
       // Step b:
       `

--- a/protocol-designer/src/timelineMiddleware/generateRobotStateTimeline.ts
+++ b/protocol-designer/src/timelineMiddleware/generateRobotStateTimeline.ts
@@ -1,3 +1,4 @@
+import { getIsTiprack } from '@opentrons/shared-data'
 import {
   commandCreatorsTimeline,
   curryCommandCreator,
@@ -56,11 +57,22 @@ export const generateRobotStateTimeline = (
       // we know the current tip(s) aren't going to be reused, so we can drop them
       // immediately after the current step is done.
       const pipetteId = getPipetteIdFromCCArgs(args)
+
       const dropTipLocation =
         'dropTipLocation' in args ? args.dropTipLocation : null
 
       //  assume that whenever we have a pipetteId we also have a dropTipLocation
       if (pipetteId != null && dropTipLocation != null) {
+        const prevNozzleConfiguration = 'nozzles' in args ? args.nozzles : null
+
+        // no eager tip dropping if this step returns tip
+        const dropTipLabware =
+          'dropTipLocation' in args
+            ? invariantContext.labwareEntities[args.dropTipLocation]
+            : null
+        const isReturnTip =
+          dropTipLabware != null ? getIsTiprack(dropTipLabware.def) : false
+
         const nextStepArgsForPipette = continuousStepArgs
           .slice(stepIndex + 1)
           .find(
@@ -69,7 +81,9 @@ export const generateRobotStateTimeline = (
         const willReuseTip =
           nextStepArgsForPipette != null &&
           'changeTip' in nextStepArgsForPipette &&
-          nextStepArgsForPipette.changeTip === 'never'
+          nextStepArgsForPipette.changeTip === 'never' &&
+          nextStepArgsForPipette.nozzles === prevNozzleConfiguration &&
+          !isReturnTip
 
         const isWasteChute =
           invariantContext.wasteChuteEntities[dropTipLocation] != null


### PR DESCRIPTION
# Overview

"Eager tip dropping" is the term we use to describe handling dropping tip at the end of a liquid handling step step if 1) the pipette used in that step is reused, and 2) the first instance in which it is reused specifies tip handling policy that is not `never`, meaning it will not require the tips from the pipette's previous step. This allows us to not arbitrarily keep "dirty" tips on the pipette until its next use if those tips will not actually be used.

There are two issues with the current logic of eager tip drop:
1. We inappropriately emit an eager drop tip command even if the pipette returns tip (in other words, we say drop tip after the tips have already been returned!)
2. We _do not_ emit an eager drop tip command if the nozzle configuration for the pipette's next step changes. If we step 1 uses an 8-channel pipette with `ALL` nozzle configuration , and step 5 uses that same pipette with `SINGLE` nozzle configuration, we incorrectly do not eagerly drop tips after step 1.

This PR adds logic for skipping eager tip dropping if the step returns tips to its tiprack. It also adds eager tip dropping if the pipette is used in the future, but its nozzle configuration differs from its previous use.

## Test Plan and Hands on Testing

Upload the attached protocol

Please review source code logic

## Changelog

- eagerly drop tip if nozzle configuration changes for next step using that pipette
- don't eagerly drop tip if step returns tip (previously would no-op, but this is correct)
- add unit tests

## Review requests

see test plan

## Risk assessment

low-medium. core drop tip logic touched 