### PR TITLE
feat(protocol-designer): Automatically add "wait for Thermocycler profile" steps

### DIFF
--- a/protocol-designer/src/components/organisms/BonusStepModal/index.tsx
+++ b/protocol-designer/src/components/organisms/BonusStepModal/index.tsx
@@ -18,8 +18,11 @@ import {
 
 import type { PropsWithChildren } from 'react'
 
-interface HandleClickProps {
+interface HandleSkipPauseClickProps {
   handleSkipPauseClick: () => void
+}
+
+interface HandleAddPauseClickProps {
   handleAddPauseClick: () => void
 }
 
@@ -32,18 +35,19 @@ type BonusStepModalProps =
         | 'explainWaitForThermocyclerBlockTemp'
         | 'explainWaitForThermocyclerLidTemp'
       displayTemperature: string
-    } & HandleClickProps)
+    } & HandleAddPauseClickProps)
   | ({
       modalType: 'explainWaitForThermocyclerProfile'
       displayTemperature?: null
-    } & HandleClickProps)
+    } & HandleAddPauseClickProps)
   | ({
       // "Would you like to add a ___ step"
       // todo(mm, 2025-09-26): Delete this modal type when enableConcurrentModuleActions FF is deleted
       modalType: 'optionallyWaitForTemp'
       displayTemperature: string
       displayModule: string
-    } & HandleClickProps)
+    } & HandleAddPauseClickProps &
+      HandleSkipPauseClickProps)
 
 export type BonusStepModalType = BonusStepModalProps['modalType']
 
@@ -52,13 +56,18 @@ export type BonusStepModalType = BonusStepModalProps['modalType']
  * would you like to also add a pause step."
  */
 export const BonusStepModal = (props: BonusStepModalProps): JSX.Element => {
-  const { modalType, handleSkipPauseClick, handleAddPauseClick } = props
+  const { modalType } = props
   const { t } = useTranslation()
   const [rememberDismissal, setRememberDismissal] = useState(false)
 
   // todo(mm, 2025-09-26): Delete this modal type when enableConcurrentModuleActions FF is deleted
   if (modalType === 'optionallyWaitForTemp') {
-    const { displayModule, displayTemperature } = props
+    const {
+      displayModule,
+      displayTemperature,
+      handleSkipPauseClick,
+      handleAddPauseClick,
+    } = props
     return (
       <Modal
         marginLeft="0"
@@ -102,6 +111,8 @@ export const BonusStepModal = (props: BonusStepModalProps): JSX.Element => {
       </Modal>
     )
   } else {
+    const { displayTemperature, handleAddPauseClick } = props
+
     const titleKey: string = (() => {
       switch (modalType) {
         case 'explainWaitForTemperatureModuleTemp':
@@ -117,7 +128,7 @@ export const BonusStepModal = (props: BonusStepModalProps): JSX.Element => {
         // default omitted, for exhaustiveness checking.
       }
     })()
-    const title = t(titleKey, { temperature: props.displayTemperature })
+    const title = t(titleKey, { temperature: displayTemperature })
 
     const bodyParagraphsKey: string = (() => {
       switch (modalType) {
@@ -139,7 +150,7 @@ export const BonusStepModal = (props: BonusStepModalProps): JSX.Element => {
       <Trans
         t={t}
         i18nKey={bodyParagraphsKey}
-        values={{ temperature: props.displayTemperature }}
+        values={{ temperature: displayTemperature }}
         components={{ p: <BodyParagraph /> }}
       />
     )

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/index.tsx
@@ -25,6 +25,7 @@ import { getDirtyFields } from './utils'
 
 import type { ConnectedComponent } from 'react-redux'
 import type { InvariantContext } from '@opentrons/step-generation'
+import type { BonusStepModalType } from '/protocol-designer/components/organisms'
 import type { FormData, StepFieldName } from '/protocol-designer/form-types'
 import type { LabwareDefByDefURI } from '/protocol-designer/labware-defs'
 import type { BaseState, ThunkDispatch } from '/protocol-designer/types'
@@ -33,18 +34,15 @@ interface StateProps {
   canSave: boolean
   formHasChanges: boolean
   isNewStep: boolean
-  isPristineSetTempForm: boolean
-  isPristineSetHeaterShakerTempForm: boolean
+  bonusStepModalType: BonusStepModalType | null
   invariantContext: InvariantContext
   allLabwareDefs: LabwareDefByDefURI
   enableConcurrentModuleActions: boolean
   formData?: FormData | null
 }
 interface DispatchProps {
-  handleClose: () => void
-  saveSetTempFormWithAddedPauseUntilTemp: () => void
-  saveHeaterShakerFormWithAddedPauseUntilTemp: () => void
-  saveStepForm: () => void
+  cancelStepForm: () => void
+  saveStepForm: (options?: { userWantsBonusStep?: boolean }) => void
 }
 type StepFormManagerProps = StateProps & DispatchProps
 
@@ -53,21 +51,19 @@ function StepFormManager(props: StepFormManagerProps): JSX.Element | null {
     canSave,
     formData,
     formHasChanges,
-    handleClose,
+    cancelStepForm,
     isNewStep,
-    isPristineSetTempForm,
-    isPristineSetHeaterShakerTempForm,
-    saveSetTempFormWithAddedPauseUntilTemp,
-    saveHeaterShakerFormWithAddedPauseUntilTemp,
+    bonusStepModalType,
     saveStepForm,
     invariantContext,
     allLabwareDefs,
-    enableConcurrentModuleActions,
   } = props
+
   const [focusedField, setFocusedField] = useState<string | null>(null)
   const [dirtyFields, setDirtyFields] = useState<StepFieldName[]>(
     getDirtyFields(isNewStep, formData)
   )
+
   const handleBlur = (fieldName: StepFieldName): void => {
     if (fieldName === focusedField) {
       setFocusedField(null)
@@ -79,25 +75,16 @@ function StepFormManager(props: StepFormManagerProps): JSX.Element | null {
       return prevDirtyFields
     })
   }
+
   const {
     confirm: confirmClose,
     showConfirmation: showConfirmCancelModal,
     cancel: cancelClose,
-  } = useConditionalConfirm(handleClose, isNewStep || formHasChanges)
-  const {
-    confirm: confirmAddPauseUntilTempStep,
-    showConfirmation: showAddPauseUntilTempStepModal,
-  } = useConditionalConfirm(
-    saveSetTempFormWithAddedPauseUntilTemp,
-    isPristineSetTempForm
-  )
-  const {
-    confirm: confirmAddPauseUntilHeaterShakerTempStep,
-    showConfirmation: showAddPauseUntilHeaterShakerTempStepModal,
-  } = useConditionalConfirm(
-    saveHeaterShakerFormWithAddedPauseUntilTemp,
-    isPristineSetHeaterShakerTempForm
-  )
+  } = useConditionalConfirm(cancelStepForm, isNewStep || formHasChanges)
+
+  const [currentBonusStepDialogType, setCurrentBonusStepDialogType] =
+    useState<BonusStepModalType | null>(null)
+
   // no form selected
   if (formData == null) {
     return null
@@ -113,14 +100,24 @@ function StepFormManager(props: StepFormManagerProps): JSX.Element | null {
     focus: setFocusedField,
     blur: handleBlur,
   }
-  let handleSave = saveStepForm
-  if (isPristineSetTempForm) {
-    handleSave = confirmAddPauseUntilTempStep
-  } else if (
-    isPristineSetHeaterShakerTempForm &&
-    formData.heaterShakerSetTimer !== true
-  ) {
-    handleSave = confirmAddPauseUntilHeaterShakerTempStep
+
+  const handleSave = (): void => {
+    if (bonusStepModalType == null) {
+      // No dialog to show. Just save the step directly.
+      saveStepForm()
+    } else {
+      // There's a dialog we have to show before saving the step.
+      // Its confirm/cancel handlers will be the thing that saves the step.
+      setCurrentBonusStepDialogType(bonusStepModalType)
+    }
+  }
+  const handleSkipPauseClick = (): void => {
+    saveStepForm({ userWantsBonusStep: false })
+    setCurrentBonusStepDialogType(null)
+  }
+  const handleAddPauseClick = (): void => {
+    saveStepForm({ userWantsBonusStep: true })
+    setCurrentBonusStepDialogType(null)
   }
 
   return (
@@ -134,52 +131,47 @@ function StepFormManager(props: StepFormManagerProps): JSX.Element | null {
           onContinueClick={confirmClose}
         />
       )}
-      {showAddPauseUntilTempStepModal &&
-        (enableConcurrentModuleActions ? (
-          <BonusStepModal
-            modalType="explainWaitForTemperatureModuleTemp"
-            displayTemperature={formData?.targetTemperature ?? '?'}
-            handleAddPauseClick={handleSave}
-            handleSkipPauseClick={saveStepForm}
-          />
-        ) : (
-          <BonusStepModal
-            modalType="optionallyWaitForTemp"
-            displayTemperature={formData?.targetTemperature ?? '?'}
-            displayModule={
-              formData.moduleId != null
-                ? getModuleDisplayName(
-                    invariantContext.moduleEntities[formData.moduleId].model
-                  )
-                : ''
-            }
-            handleSkipPauseClick={saveStepForm}
-            handleAddPauseClick={handleSave}
-          />
-        ))}
-      {showAddPauseUntilHeaterShakerTempStepModal &&
-        (enableConcurrentModuleActions ? (
-          <BonusStepModal
-            modalType="explainWaitForHeaterShakerTemp"
-            displayTemperature={formData?.targetHeaterShakerTemperature ?? '?'}
-            handleSkipPauseClick={saveStepForm}
-            handleAddPauseClick={handleSave}
-          />
-        ) : (
-          <BonusStepModal
-            modalType="optionallyWaitForTemp"
-            displayTemperature={formData?.targetHeaterShakerTemperature ?? '?'}
-            displayModule={
-              formData.moduleId != null
-                ? getModuleDisplayName(
-                    invariantContext.moduleEntities[formData.moduleId].model
-                  )
-                : ''
-            }
-            handleSkipPauseClick={saveStepForm}
-            handleAddPauseClick={handleSave}
-          />
-        ))}
+
+      {currentBonusStepDialogType === 'explainWaitForTemperatureModuleTemp' && (
+        <BonusStepModal
+          modalType={currentBonusStepDialogType}
+          displayTemperature={formData.targetTemperature ?? '?'}
+          handleAddPauseClick={handleAddPauseClick}
+        />
+      )}
+      {currentBonusStepDialogType === 'explainWaitForHeaterShakerTemp' && (
+        <BonusStepModal
+          modalType={currentBonusStepDialogType}
+          displayTemperature={formData.targetHeaterShakerTemperature ?? '?'}
+          handleAddPauseClick={handleAddPauseClick}
+        />
+      )}
+      {currentBonusStepDialogType === 'explainWaitForThermocyclerProfile' && (
+        <BonusStepModal
+          modalType={currentBonusStepDialogType}
+          handleAddPauseClick={handleAddPauseClick}
+        />
+      )}
+      {currentBonusStepDialogType === 'optionallyWaitForTemp' && (
+        <BonusStepModal
+          modalType="optionallyWaitForTemp"
+          displayTemperature={
+            formData.targetTemperature ??
+            formData.targetHeaterShakerTemperature ??
+            '?'
+          }
+          displayModule={
+            formData.moduleId != null
+              ? getModuleDisplayName(
+                  invariantContext.moduleEntities[formData.moduleId].model
+                )
+              : ''
+          }
+          handleAddPauseClick={handleAddPauseClick}
+          handleSkipPauseClick={handleSkipPauseClick}
+        />
+      )}
+
       <StepFormToolbox
         {...{
           canSave,
@@ -202,10 +194,7 @@ const mapStateToProps = (state: BaseState): StateProps => {
     formData: stepFormSelectors.getUnsavedForm(state),
     formHasChanges: stepFormSelectors.getCurrentFormHasUnsavedChanges(state),
     isNewStep: stepFormSelectors.getCurrentFormIsPresaved(state),
-    isPristineSetHeaterShakerTempForm:
-      stepFormSelectors.getUnsavedFormIsPristineHeaterShakerForm(state),
-    isPristineSetTempForm:
-      stepFormSelectors.getUnsavedFormIsPristineSetTempForm(state),
+    bonusStepModalType: stepFormSelectors.getBonusStepModalType(state),
     invariantContext: getInvariantContext(state),
     allLabwareDefs: labwareDefSelectors.getLabwareDefsByURI(state),
     enableConcurrentModuleActions: getEnableConcurrentModuleActions(state),
@@ -213,18 +202,13 @@ const mapStateToProps = (state: BaseState): StateProps => {
 }
 
 const mapDispatchToProps = (dispatch: ThunkDispatch<any>): DispatchProps => {
-  const handleClose = (): void => dispatch(actions.cancelStepForm())
-  const saveHeaterShakerFormWithAddedPauseUntilTemp = (): void =>
-    dispatch(stepsActions.saveHeaterShakerFormWithAddedPauseUntilTemp())
-  const saveSetTempFormWithAddedPauseUntilTemp = (): void =>
-    dispatch(stepsActions.saveSetTempFormWithAddedPauseUntilTemp())
-  const saveStepForm = (): void => dispatch(stepsActions.saveStepForm())
+  const cancelStepForm = (): void => dispatch(actions.cancelStepForm())
+  const saveStepForm = (options?: { userWantsBonusStep?: boolean }): void =>
+    dispatch(stepsActions.saveStepForm(options))
 
   return {
-    handleClose,
-    saveSetTempFormWithAddedPauseUntilTemp,
+    cancelStepForm,
     saveStepForm,
-    saveHeaterShakerFormWithAddedPauseUntilTemp,
   }
 }
 

--- a/protocol-designer/src/step-forms/selectors/index.ts
+++ b/protocol-designer/src/step-forms/selectors/index.ts
@@ -54,6 +54,7 @@ import type {
   TrashBinEntities,
   WasteChuteEntities,
 } from '@opentrons/step-generation'
+import type { BonusStepModalType } from '/protocol-designer/components/organisms'
 import type { StepHierarchy } from '/protocol-designer/steplist/utils/stepHierarchy'
 import type {
   FormData,
@@ -819,26 +820,50 @@ export const getArgsAndErrorsByStepId: Selector<
   }
 )
 
-export const getUnsavedFormIsPristineSetTempForm = createSelector(
+export const getBonusStepModalType = createSelector(
   getUnsavedForm,
   getCurrentFormIsPresaved,
-  (unsavedForm, isPresaved): boolean => {
-    const isSetTempForm =
+  featureFlagSelectors.getEnableConcurrentModuleActions,
+  (
+    unsavedForm,
+    currentFormIsPresaved,
+    enableConcurrentModuleActions
+  ): BonusStepModalType | null => {
+    // NOTE: This logic to decide whether a bonus step is warranted should be kept in
+    // sync with saveStepForm().
+
+    const isTempModSetTempForm =
       unsavedForm?.stepType === 'temperature' &&
       unsavedForm?.targetTemperature != null
-    return isPresaved && isSetTempForm
-  }
-)
-
-export const getUnsavedFormIsPristineHeaterShakerForm = createSelector(
-  getUnsavedForm,
-  getCurrentFormIsPresaved,
-  (unsavedForm, isPresaved): boolean => {
-    const isSetHsTempForm =
+    const isHSSetTempForm =
       unsavedForm?.stepType === 'heaterShaker' &&
-      unsavedForm?.targetHeaterShakerTemperature != null
+      unsavedForm?.targetHeaterShakerTemperature != null &&
+      unsavedForm?.heaterShakerSetTimer !== true
+    const isTCProfileForm =
+      unsavedForm?.stepType === 'thermocycler' &&
+      unsavedForm?.thermocyclerFormType === 'thermocyclerProfile'
 
-    return isPresaved && isSetHsTempForm
+    const isFirstTimeSavingThisForm = currentFormIsPresaved
+
+    // todo(mm, 2025-11-24): These should also be conditional on "Don't show again"
+    // not having been clicked before. https://opentrons.atlassian.net/browse/EXEC-1925
+    if (isTempModSetTempForm && isFirstTimeSavingThisForm) {
+      return enableConcurrentModuleActions
+        ? 'explainWaitForTemperatureModuleTemp'
+        : 'optionallyWaitForTemp'
+    } else if (isHSSetTempForm && isFirstTimeSavingThisForm) {
+      return enableConcurrentModuleActions
+        ? 'explainWaitForHeaterShakerTemp'
+        : 'optionallyWaitForTemp'
+    } else if (
+      enableConcurrentModuleActions &&
+      isTCProfileForm &&
+      isFirstTimeSavingThisForm
+    ) {
+      return 'explainWaitForThermocyclerProfile'
+    } else {
+      return null
+    }
   }
 )
 

--- a/protocol-designer/src/step-forms/selectors/index.ts
+++ b/protocol-designer/src/step-forms/selectors/index.ts
@@ -818,6 +818,7 @@ export const getArgsAndErrorsByStepId: Selector<
     )
   }
 )
+
 export const getUnsavedFormIsPristineSetTempForm = createSelector(
   getUnsavedForm,
   getCurrentFormIsPresaved,
@@ -840,6 +841,7 @@ export const getUnsavedFormIsPristineHeaterShakerForm = createSelector(
     return isPresaved && isSetHsTempForm
   }
 )
+
 export const getFormLevelWarningsForUnsavedForm: Selector<
   BaseState,
   FormWarning[]
@@ -857,6 +859,7 @@ export const getFormLevelWarningsForUnsavedForm: Selector<
     return getFormWarnings(unsavedForm.stepType, hydratedForm)
   }
 )
+
 export const getFormLevelWarningsPerStep: Selector<
   BaseState,
   Record<string, FormWarning[]>

--- a/protocol-designer/src/step-forms/test/selectors.test.ts
+++ b/protocol-designer/src/step-forms/test/selectors.test.ts
@@ -2,10 +2,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   getBatchEditFormHasUnsavedChanges,
+  getBonusStepModalType,
   getEquippedPipetteOptions,
   getNextUserVisibleStepNumber,
-  getUnsavedFormIsPristineHeaterShakerForm,
-  getUnsavedFormIsPristineSetTempForm,
   getUserVisibleStepNumbers,
 } from '../selectors'
 
@@ -103,63 +102,84 @@ describe('getBatchEditFormHasUnsavedChanges', () => {
   })
 })
 
-describe('getUnsavedFormIsPristineSetTempForm', () => {
-  const mockIsPresaved = true
-  it('should return true if temperature mod set temp is true formData ', () => {
-    // @ts-expect-error(jr, 4/8/22): missing module id
+describe('getBonusStepModalType', () => {
+  it('should handle temperature module set temp form', () => {
     const formData: FormData = {
+      id: 'step_123',
       stepType: 'temperature',
       targetTemperature: 33,
     }
-    const expected = true
-    const result = getUnsavedFormIsPristineSetTempForm.resultFunc(
-      formData,
-      mockIsPresaved
-    )
-    expect(result).toEqual(expected)
-  })
-  it('should return false if temperature mod is false in formData ', () => {
-    // @ts-expect-error(jr, 4/8/22): missing module id
-    const formData: FormData = {
-      stepType: 'temperature',
-      setTemperature: null,
-    }
-    const expected = false
-    const result = getUnsavedFormIsPristineSetTempForm.resultFunc(
-      formData,
-      mockIsPresaved
-    )
-    expect(result).toEqual(expected)
-  })
-})
+    const mockIsPresaved = true
 
-describe('getUnsavedFormIsPrestineSetHeaterShakerTempForm', () => {
-  const mockIsPresaved = true
-  it('should return true if heater shaker temperature is true in formData ', () => {
-    // @ts-expect-error(jr, 4/8/22): missing module id
+    const resultWithoutConcurrentModuleActions =
+      getBonusStepModalType.resultFunc(formData, mockIsPresaved, false)
+    expect(resultWithoutConcurrentModuleActions).toEqual(
+      'optionallyWaitForTemp'
+    )
+
+    const resultWithConcurrentModuleActions = getBonusStepModalType.resultFunc(
+      formData,
+      mockIsPresaved,
+      true
+    )
+    expect(resultWithConcurrentModuleActions).toEqual(
+      'explainWaitForTemperatureModuleTemp'
+    )
+  })
+  it('should handle heater shaker set temp form', () => {
     const formData: FormData = {
+      id: 'step_123',
       stepType: 'heaterShaker',
       targetHeaterShakerTemperature: '10',
     }
-    const expected = true
-    const result = getUnsavedFormIsPristineHeaterShakerForm.resultFunc(
-      formData,
-      mockIsPresaved
+    const mockIsPresaved = true
+
+    const resultWithoutConcurrentModuleActions =
+      getBonusStepModalType.resultFunc(formData, mockIsPresaved, false)
+    expect(resultWithoutConcurrentModuleActions).toEqual(
+      'optionallyWaitForTemp'
     )
-    expect(result).toEqual(expected)
+
+    const resultWithConcurrentModuleActions = getBonusStepModalType.resultFunc(
+      formData,
+      mockIsPresaved,
+      true
+    )
+    expect(resultWithConcurrentModuleActions).toEqual(
+      'explainWaitForHeaterShakerTemp'
+    )
   })
-  it('should return false if heater shaker temperature is false in formData ', () => {
-    // @ts-expect-error(jr, 4/8/22): missing module id
+  it('should handle thermocycler profile form', () => {
     const formData: FormData = {
-      stepType: 'heaterShaker',
-      targetHeaterShakerTemperature: null,
+      id: 'step_123',
+      stepType: 'thermocycler',
+      thermocyclerFormType: 'thermocyclerProfile',
     }
-    const expected = false
-    const result = getUnsavedFormIsPristineHeaterShakerForm.resultFunc(
+    const mockIsPresaved = true
+
+    const resultWithoutConcurrentModuleActions =
+      getBonusStepModalType.resultFunc(formData, mockIsPresaved, false)
+    expect(resultWithoutConcurrentModuleActions).toEqual(null)
+
+    const resultWithConcurrentModuleActions = getBonusStepModalType.resultFunc(
       formData,
-      mockIsPresaved
+      mockIsPresaved,
+      true
     )
-    expect(result).toEqual(expected)
+    expect(resultWithConcurrentModuleActions).toEqual(
+      'explainWaitForThermocyclerProfile'
+    )
+  })
+  it('should return null when formData is null', () => {
+    const formData: FormData | null = null
+    const mockIsPresaved = true
+    const mockEnableConcurrentModuleActions = false
+    const result = getBonusStepModalType.resultFunc(
+      formData,
+      mockIsPresaved,
+      mockEnableConcurrentModuleActions
+    )
+    expect(result).toEqual(null)
   })
 })
 

--- a/protocol-designer/src/steplist/formLevel/errors.ts
+++ b/protocol-designer/src/steplist/formLevel/errors.ts
@@ -1599,3 +1599,5 @@ export const composeErrors: ComposeErrors =
     errorCheckers
       .map(checker => checker(formData, moduleEntities, labwareEntities))
       .filter((error): error is FormError => error !== null)
+
+// TODO: Some kind of error here for "does this point to a valid TC module that's currently profiling?"

--- a/protocol-designer/src/steplist/formLevel/errors.ts
+++ b/protocol-designer/src/steplist/formLevel/errors.ts
@@ -1599,5 +1599,3 @@ export const composeErrors: ComposeErrors =
     errorCheckers
       .map(checker => checker(formData, moduleEntities, labwareEntities))
       .filter((error): error is FormError => error !== null)
-
-// TODO: Some kind of error here for "does this point to a valid TC module that's currently profiling?"

--- a/protocol-designer/src/types.ts
+++ b/protocol-designer/src/types.ts
@@ -33,9 +33,10 @@ export interface BaseState {
 }
 export type GetState = () => BaseState
 export type Selector<T> = (arg: BaseState) => T
-// eslint-disable-next-line no-use-before-define
 export type ThunkDispatch<A> = (action: A | ThunkAction<A>) => A
 
+// todo(mm, 2025-10-15): Replace with Redux's native ThunkAction. This type definition
+// predates our use of TypeScript and may predate TypeScript support in Redux.
 export type ThunkAction<A> =
   | ((dispatch: ThunkDispatch<A>, getState: GetState) => A)
   | ((dispatch: ThunkDispatch<A>, getState: GetState) => void)

--- a/protocol-designer/src/ui/steps/actions/__tests__/actions.test.ts
+++ b/protocol-designer/src/ui/steps/actions/__tests__/actions.test.ts
@@ -4,8 +4,10 @@ import { thunk } from 'redux-thunk'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { when } from 'vitest-when'
 
+import * as featureFlagSelectors from '/protocol-designer/feature-flags/selectors'
 import { getRobotStateTimeline } from '/protocol-designer/file-data/selectors'
 import * as stepFormSelectors from '/protocol-designer/step-forms/selectors'
+import * as tutorialSelectors from '/protocol-designer/tutorial/selectors'
 import * as utils from '/protocol-designer/utils'
 
 import {
@@ -14,13 +16,10 @@ import {
   getSelectedStepId,
 } from '../../selectors'
 import { deselectAllSteps, selectAllSteps } from '../actions'
-import {
-  duplicateSelectedSteps,
-  saveHeaterShakerFormWithAddedPauseUntilTemp,
-  saveSetTempFormWithAddedPauseUntilTemp,
-} from '../thunks'
+import { duplicateSelectedSteps, saveStepForm } from '../thunks'
 
-import type { RobotState, Timeline } from '@opentrons/step-generation/src/types'
+import type { Timeline } from '@opentrons/step-generation/src/types'
+import type { FormData } from '/protocol-designer/form-types'
 import type {
   DuplicateSelectedStepsAction,
   SelectMultipleStepsAction,
@@ -28,40 +27,12 @@ import type {
 } from '../types'
 
 vi.mock('/protocol-designer/step-forms/selectors')
+vi.mock('/protocol-designer/feature-flags/selectors')
+vi.mock('/protocol-designer/tutorial/selectors')
 vi.mock('../../selectors')
 vi.mock('/protocol-designer/file-data/selectors')
 
 const mockStore = legacy_configureStore([thunk] as any)
-
-const initialRobotState: RobotState = {
-  labware: {
-    fixedTrash: {
-      stack: ['fixedTrash', '12'],
-    },
-    tiprackId: {
-      stack: ['tiprackId', '1'],
-    },
-    plateId: {
-      stack: ['plateId', '7'],
-    },
-  },
-  modules: {},
-  pipettes: {
-    pipetteId: {
-      mount: 'left',
-    },
-  },
-  liquidState: {
-    pipettes: {},
-    labware: {},
-    trashBins: {},
-    wasteChute: {},
-  },
-  tipState: {
-    pipettes: {},
-    tipracks: {},
-  },
-}
 
 describe('steps actions', () => {
   describe('selectAllSteps', () => {
@@ -280,294 +251,219 @@ describe('steps actions', () => {
     })
   })
 
-  describe('saveHeaterShakerFormWithAddedPauseUntilTemp', () => {
-    const mockRobotStateTimeline: Timeline = {
-      timeline: [
-        {
-          commands: [
-            {
-              commandType: 'heaterShaker/waitForTemperature',
-
-              params: {
-                moduleId: 'heaterShakerId',
-              },
-            },
-          ],
-          robotState: initialRobotState,
-          warnings: [],
-        },
-      ],
-      errors: null,
-    }
-
+  describe('saveStepForm', () => {
     beforeEach(() => {
-      when(vi.mocked(stepFormSelectors.getUnsavedForm))
-        .calledWith(expect.anything())
-        .thenReturn({
-          stepType: 'heaterShaker',
-          targetHeaterShakerTemperature: '10',
-        } as any)
+      vi.mocked(getRobotStateTimeline).mockReturnValue({
+        timeline: [],
+        errors: null,
+      } as Timeline)
+      vi.mocked(tutorialSelectors.shouldShowCoolingHint).mockReturnValue(false)
+      vi.mocked(tutorialSelectors.shouldShowWasteChuteHint).mockReturnValue(
+        false
+      )
       vi.mocked(
-        stepFormSelectors.getUnsavedFormIsPristineHeaterShakerForm
+        featureFlagSelectors.getEnableConcurrentModuleActions
       ).mockReturnValue(true)
-      vi.mocked(getRobotStateTimeline).mockReturnValue(mockRobotStateTimeline)
     })
 
     afterEach(() => {
+      vi.resetAllMocks()
       vi.restoreAllMocks()
     })
 
-    it('should save heater shaker step with a pause until temp is reached', () => {
-      const HsStepWithPause = [
+    describe('temperature module form', () => {
+      it.each([
         {
-          payload: {
+          description:
+            'should add bonus step when enableConcurrentModuleActions is false and userWantsBonusStep is true',
+          isPresaved: true,
+          userWantsBonusStep: true,
+          shouldAddBonusStep: true,
+          expectedPauseTemperature: 25,
+        },
+        {
+          description:
+            'should NOT add bonus step when userWantsBonusStep is false',
+          isPresaved: true,
+          userWantsBonusStep: false,
+          shouldAddBonusStep: false,
+        },
+        {
+          description: 'should add bonus step when userWantsBonusStep is true',
+          isPresaved: true,
+          userWantsBonusStep: true,
+          shouldAddBonusStep: true,
+        },
+      ])(
+        '$description',
+        ({
+          isPresaved,
+          userWantsBonusStep,
+          shouldAddBonusStep,
+          expectedPauseTemperature,
+        }) => {
+          const temperatureForm: FormData = {
+            id: 'step_123',
+            stepType: 'temperature',
+            targetTemperature: 25,
+            moduleId: 'temperatureId',
+          }
+
+          when(vi.mocked(stepFormSelectors.getUnsavedForm))
+            .calledWith(expect.anything())
+            .thenReturn(temperatureForm)
+          when(vi.mocked(stepFormSelectors.getCurrentFormIsPresaved))
+            .calledWith(expect.anything())
+            .thenReturn(isPresaved)
+
+          const store: any = mockStore()
+          store.dispatch(saveStepForm({ userWantsBonusStep }))
+
+          const actions = store.getActions()
+          expect(actions[0]).toEqual({
+            type: 'SAVE_STEP_FORM',
+            payload: temperatureForm,
+          })
+          if (shouldAddBonusStep) {
+            expect(actions[1].type).toStrictEqual('ADD_STEP')
+            expect(actions[2].payload.update.pauseAction).toStrictEqual(
+              'untilTemperature'
+            )
+            if (expectedPauseTemperature !== undefined) {
+              expect(actions[3].payload.update.moduleId).toStrictEqual(
+                'temperatureId'
+              )
+              expect(actions[4].payload.update.pauseTemperature).toStrictEqual(
+                expectedPauseTemperature
+              )
+              expect(actions[5].type).toStrictEqual('SAVE_STEP_FORM')
+            }
+          } else {
+            expect(actions.length).toStrictEqual(1)
+          }
+        }
+      )
+    })
+
+    describe('heater shaker form', () => {
+      it.each([
+        {
+          description: 'should add bonus step when userWantsBonusStep is true',
+          userWantsBonusStep: true,
+          shouldAddBonusStep: true,
+          expectedPauseTemperature: '10',
+        },
+        {
+          description:
+            'should NOT add bonus step when userWantsBonusStep is false',
+          userWantsBonusStep: false,
+          shouldAddBonusStep: false,
+        },
+      ])(
+        '$description',
+        ({
+          userWantsBonusStep,
+          shouldAddBonusStep,
+          expectedPauseTemperature,
+        }) => {
+          const heaterShakerForm: FormData = {
+            id: 'step_123',
             stepType: 'heaterShaker',
             targetHeaterShakerTemperature: '10',
-          },
-          type: 'SAVE_STEP_FORM',
-        },
+            moduleId: 'heaterShakerId',
+          }
 
-        {
-          meta: {
-            robotStateTimeline: {
-              errors: null,
-              timeline: [
-                {
-                  commands: [
-                    {
-                      commandType: 'heaterShaker/waitForTemperature',
-                      params: {
-                        moduleId: 'heaterShakerId',
-                      },
-                    },
-                  ],
-                  robotState: {
-                    labware: {
-                      fixedTrash: {
-                        stack: ['fixedTrash', '12'],
-                      },
-                      tiprackId: {
-                        stack: ['tiprackId', '1'],
-                      },
-                      plateId: {
-                        stack: ['plateId', '7'],
-                      },
-                    },
-                    liquidState: {
-                      labware: {},
-                      pipettes: {},
-                      trashBins: {},
-                      wasteChute: {},
-                    },
-                    modules: {},
-                    pipettes: {
-                      pipetteId: {
-                        mount: 'left',
-                      },
-                    },
-                    tipState: {
-                      pipettes: {},
-                      tipracks: {},
-                    },
-                  },
-                  warnings: [],
-                },
-              ],
-            },
-          },
-          payload: {
-            id: '__presaved_step__',
-            stepType: 'pause',
-          },
-          type: 'ADD_STEP',
-        },
-        {
-          payload: {
-            update: {
-              pauseAction: 'untilTemperature',
-            },
-          },
-          type: 'CHANGE_FORM_INPUT',
-        },
-        {
-          payload: {
-            update: {
-              moduleId: undefined,
-            },
-          },
-          type: 'CHANGE_FORM_INPUT',
-        },
-        {
-          payload: {
-            update: {
-              pauseTemperature: '10',
-            },
-          },
-          type: 'CHANGE_FORM_INPUT',
-        },
-        {
-          payload: {
-            stepType: 'heaterShaker',
-            targetHeaterShakerTemperature: '10',
-          },
-          type: 'SAVE_STEP_FORM',
-        },
-      ]
+          when(vi.mocked(stepFormSelectors.getUnsavedForm))
+            .calledWith(expect.anything())
+            .thenReturn(heaterShakerForm)
+          when(vi.mocked(stepFormSelectors.getCurrentFormIsPresaved))
+            .calledWith(expect.anything())
+            .thenReturn(true)
 
-      const store: any = mockStore()
-      store.dispatch(saveHeaterShakerFormWithAddedPauseUntilTemp())
+          const store: any = mockStore()
+          store.dispatch(saveStepForm({ userWantsBonusStep }))
 
-      expect(store.getActions()).toEqual(HsStepWithPause)
-    })
-  })
-
-  describe('saveSetTempFormWithAddedPauseUntilTemp', () => {
-    const mockRobotStateTimeline: Timeline = {
-      timeline: [
-        {
-          commands: [
-            {
-              commandType: 'temperatureModule/setTargetTemperature',
-
-              params: {
-                moduleId: 'temperatureId',
-                celsius: 25,
-              },
-            },
-          ],
-          robotState: initialRobotState,
-          warnings: [],
-        },
-      ],
-      errors: null,
-    }
-
-    beforeEach(() => {
-      when(vi.mocked(stepFormSelectors.getUnsavedForm))
-        .calledWith(expect.anything())
-        .thenReturn({
-          stepType: 'temperature',
-          setTemperature: 'true',
-          targetTemperature: 10,
-          moduleId: 'mockTemp',
-        } as any)
-      vi.mocked(
-        stepFormSelectors.getUnsavedFormIsPristineSetTempForm
-      ).mockReturnValue(true)
-      vi.mocked(getRobotStateTimeline).mockReturnValue(mockRobotStateTimeline)
+          const actions = store.getActions()
+          expect(actions[0]).toEqual({
+            type: 'SAVE_STEP_FORM',
+            payload: heaterShakerForm,
+          })
+          if (shouldAddBonusStep) {
+            expect(actions[1].type).toStrictEqual('ADD_STEP')
+            expect(actions[2].payload.update.pauseAction).toStrictEqual(
+              'untilTemperature'
+            )
+            if (expectedPauseTemperature !== undefined) {
+              expect(actions[3].payload.update.moduleId).toStrictEqual(
+                'heaterShakerId'
+              )
+              expect(actions[4].payload.update.pauseTemperature).toStrictEqual(
+                expectedPauseTemperature
+              )
+              expect(actions[5].type).toStrictEqual('SAVE_STEP_FORM')
+            }
+          }
+        }
+      )
     })
 
-    afterEach(() => {
-      vi.restoreAllMocks()
-    })
+    describe('thermocycler profile form', () => {
+      it.each([
+        {
+          description:
+            'should automatically add bonus step when enableConcurrentModuleActions is true',
+          enableConcurrentModuleActions: true,
+          shouldAddBonusStep: true,
+        },
+        {
+          description:
+            'should NOT add bonus step when enableConcurrentModuleActions is false',
+          enableConcurrentModuleActions: false,
+          shouldAddBonusStep: false,
+        },
+      ])(
+        '$description',
+        ({ enableConcurrentModuleActions, shouldAddBonusStep }) => {
+          const thermocyclerForm: FormData = {
+            id: 'step_123',
+            stepType: 'thermocycler',
+            thermocyclerFormType: 'thermocyclerProfile',
+            moduleId: 'thermocyclerId',
+          }
 
-    it('should save temperature step with a pause until temp is reached', () => {
-      const temperatureStepWithPause = [
-        {
-          payload: {
-            setTemperature: 'true',
-            stepType: 'temperature',
-            targetTemperature: 10,
-            moduleId: 'mockTemp',
-          },
-          type: 'SAVE_STEP_FORM',
-        },
+          when(vi.mocked(stepFormSelectors.getUnsavedForm))
+            .calledWith(expect.anything())
+            .thenReturn(thermocyclerForm)
+          when(vi.mocked(stepFormSelectors.getCurrentFormIsPresaved))
+            .calledWith(expect.anything())
+            .thenReturn(true)
+          when(vi.mocked(featureFlagSelectors.getEnableConcurrentModuleActions))
+            .calledWith(expect.anything())
+            .thenReturn(enableConcurrentModuleActions)
 
-        {
-          meta: {
-            robotStateTimeline: {
-              errors: null,
-              timeline: [
-                {
-                  commands: [
-                    {
-                      commandType: 'temperatureModule/setTargetTemperature',
-                      params: {
-                        moduleId: 'temperatureId',
-                        celsius: 25,
-                      },
-                    },
-                  ],
-                  robotState: {
-                    labware: {
-                      plateId: {
-                        stack: ['plateId', '7'],
-                      },
-                      tiprackId: {
-                        stack: ['tiprackId', '1'],
-                      },
+          const store: any = mockStore()
+          store.dispatch(saveStepForm())
 
-                      fixedTrash: {
-                        stack: ['fixedTrash', '12'],
-                      },
-                    },
-                    liquidState: {
-                      labware: {},
-                      pipettes: {},
-                      trashBins: {},
-                      wasteChute: {},
-                    },
-                    modules: {},
-                    pipettes: {
-                      pipetteId: {
-                        mount: 'left',
-                      },
-                    },
-                    tipState: {
-                      pipettes: {},
-                      tipracks: {},
-                    },
-                  },
-                  warnings: [],
-                },
-              ],
-            },
-          },
-          payload: {
-            id: '__presaved_step__',
-            stepType: 'pause',
-          },
-          type: 'ADD_STEP',
-        },
-        {
-          payload: {
-            update: {
-              pauseAction: 'untilTemperature',
-            },
-          },
-          type: 'CHANGE_FORM_INPUT',
-        },
-        {
-          payload: {
-            update: {
-              moduleId: 'mockTemp',
-            },
-          },
-          type: 'CHANGE_FORM_INPUT',
-        },
-        {
-          payload: {
-            update: {
-              pauseTemperature: 10,
-            },
-          },
-          type: 'CHANGE_FORM_INPUT',
-        },
-        {
-          payload: {
-            setTemperature: 'true',
-            stepType: 'temperature',
-            targetTemperature: 10,
-            moduleId: 'mockTemp',
-          },
-          type: 'SAVE_STEP_FORM',
-        },
-      ]
+          const actions = store.getActions()
+          expect(actions[0]).toEqual({
+            type: 'SAVE_STEP_FORM',
+            payload: thermocyclerForm,
+          })
 
-      const store: any = mockStore()
-      store.dispatch(saveSetTempFormWithAddedPauseUntilTemp())
-
-      expect(store.getActions()).toEqual(temperatureStepWithPause)
+          if (shouldAddBonusStep) {
+            expect(actions[1].type).toStrictEqual('ADD_STEP')
+            expect(actions[2].payload.update.pauseAction).toStrictEqual(
+              'untilThermocyclerProfileComplete'
+            )
+            expect(actions[3].payload.update.moduleId).toStrictEqual(
+              'thermocyclerId'
+            )
+            expect(actions[4].type).toStrictEqual('SAVE_STEP_FORM')
+          } else {
+            expect(actions.length).toStrictEqual(1)
+          }
+        }
+      )
     })
   })
 })

--- a/protocol-designer/src/ui/steps/actions/thunks/index.ts
+++ b/protocol-designer/src/ui/steps/actions/thunks/index.ts
@@ -350,7 +350,6 @@ export const saveStepForm: (options?: {
     return
   }
 
-  // TODO: Understand these hints.
   if (tutorialSelectors.shouldShowCoolingHint(initialState)) {
     dispatch(tutorialActions.addHint('thermocycler_lid_passive_cooling'))
   }

--- a/protocol-designer/src/ui/steps/actions/thunks/index.ts
+++ b/protocol-designer/src/ui/steps/actions/thunks/index.ts
@@ -8,14 +8,17 @@ import {
   THERMOCYCLER_MODULE_TYPE,
 } from '@opentrons/shared-data'
 
-import { PAUSE_UNTIL_TEMP } from '/protocol-designer/constants'
+import {
+  PAUSE_UNTIL_TC_PROFILE_COMPLETE,
+  PAUSE_UNTIL_TEMP,
+} from '/protocol-designer/constants'
+import { getEnableConcurrentModuleActions } from '/protocol-designer/feature-flags/selectors'
 import * as fileDataSelectors from '/protocol-designer/file-data/selectors'
 import {
+  getCurrentFormIsPresaved,
   getInitialDeckSetup,
   getSavedStepHierarchy,
   getUnsavedForm,
-  getUnsavedFormIsPristineHeaterShakerForm,
-  getUnsavedFormIsPristineSetTempForm,
 } from '/protocol-designer/step-forms/selectors'
 import { changeFormInput } from '/protocol-designer/steplist/actions/actions'
 import { PRESAVED_STEP_ID } from '/protocol-designer/steplist/types'
@@ -319,71 +322,190 @@ export const _saveStepForm = (form: FormData): SaveStepFormAction => {
   }
 }
 
-/** take unsavedForm state and put it into the payload */
-export const saveStepForm: () => ThunkAction<any> =
-  () => (dispatch, getState) => {
-    const initialState = getState()
-    const unsavedForm = getUnsavedForm(initialState)
+/**
+ * Take the current unsaved form and save it.
+ *
+ * Certain forms, when saved, also save a "bonus step" under certain circumstances.
+ * e.g. saving a Temperature Module step may also save a "wait for temperature" step.
+ * The bonus step might either be mandatory, in which case this thunk will always save it,
+ * or optional as decided by the user, in which case the user's preference should be
+ * passed in.
+ */
+export const saveStepForm: (options?: {
+  userWantsBonusStep?: boolean
+}) => ThunkAction<any> = options => (dispatch, getState) => {
+  const { userWantsBonusStep = false } = options ?? {}
+  const initialState = getState()
+  const unsavedForm = getUnsavedForm(initialState)
+  const isFirstTimeSavingThisForm = getCurrentFormIsPresaved(initialState)
+  const enableConcurrentModuleActions =
+    getEnableConcurrentModuleActions(initialState)
 
-    // this check is only for TypeScript. At this point, unsavedForm should always be populated
-    if (!unsavedForm) {
-      console.assert(
-        false,
-        'Tried to saveStepForm with falsey unsavedForm. This should never be able to happen.'
-      )
-      return
-    }
-
-    if (tutorialSelectors.shouldShowCoolingHint(initialState)) {
-      dispatch(tutorialActions.addHint('thermocycler_lid_passive_cooling'))
-    }
-
-    if (tutorialSelectors.shouldShowWasteChuteHint(initialState)) {
-      dispatch(tutorialActions.addHint('waste_chute_warning'))
-    }
-
-    // save the form
-    dispatch(_saveStepForm(unsavedForm))
+  // this check is only for TypeScript. At this point, unsavedForm should always be populated
+  if (unsavedForm == null) {
+    console.assert(
+      false,
+      'Tried to saveStepForm with falsey unsavedForm. This should never be able to happen.'
+    )
+    return
   }
 
-/** "power action", mimicking saving the never-saved "set temperature X" step,
- ** then creating and saving a "pause until temp X" step */
-export const saveSetTempFormWithAddedPauseUntilTemp: () => ThunkAction<any> =
-  () => (dispatch, getState) => {
-    const initialState = getState()
-    const unsavedSetTemperatureForm = getUnsavedForm(initialState)
-    const isPristineSetTempForm =
-      getUnsavedFormIsPristineSetTempForm(initialState)
+  // TODO: Understand these hints.
+  if (tutorialSelectors.shouldShowCoolingHint(initialState)) {
+    dispatch(tutorialActions.addHint('thermocycler_lid_passive_cooling'))
+  }
 
-    // this check is only for TypeScript. At this point, unsavedForm should always be populated
-    if (!unsavedSetTemperatureForm) {
-      console.assert(
-        false,
-        'Tried to saveSetTempFormWithAddedPauseUntilTemp with falsey unsavedForm. This should never be able to happen.'
-      )
-      return
-    }
+  if (tutorialSelectors.shouldShowWasteChuteHint(initialState)) {
+    dispatch(tutorialActions.addHint('waste_chute_warning'))
+  }
 
-    const { id } = unsavedSetTemperatureForm
+  // save the form
+  dispatch(_saveStepForm(unsavedForm))
 
-    if (!isPristineSetTempForm) {
-      // this check should happen upstream (before dispatching saveSetTempFormWithAddedPauseUntilTemp in the first place)
-      console.assert(
-        false,
-        `tried to saveSetTempFormWithAddedPauseUntilTemp but form ${id} is not a pristine set temp form`
-      )
-      return
-    }
+  // Save any bonus steps that come with it.
+  // NOTE: This logic to decide whether a bonus step is warranted should be kept in sync
+  // with getBonusStepDialogType().
+  const isTempModSetTempForm =
+    unsavedForm?.stepType === 'temperature' &&
+    unsavedForm?.targetTemperature != null
+  const isHSSetTempForm =
+    unsavedForm?.stepType === 'heaterShaker' &&
+    unsavedForm?.targetHeaterShakerTemperature != null &&
+    unsavedForm?.heaterShakerSetTimer !== true
+  const isTCProfileForm =
+    unsavedForm?.stepType === 'thermocycler' &&
+    unsavedForm?.thermocyclerFormType === 'thermocyclerProfile'
+  if (isTempModSetTempForm && userWantsBonusStep) {
+    dispatch(saveWaitForTemperatureModuleTemp(unsavedForm))
+  } else if (isHSSetTempForm && userWantsBonusStep) {
+    dispatch(saveWaitForHeaterShakerTemp(unsavedForm))
+  } else if (
+    isTCProfileForm &&
+    // todo(mm, 2025-11-25): isFirstTimeSavingThisForm is not quite sufficient here.
+    // We also need to cover the case where the form existed before as a non-profile step
+    // and now it's being edited into a profile step.
+    // https://opentrons.atlassian.net/browse/EXEC-2024
+    isFirstTimeSavingThisForm &&
+    // With enableConcurrentModuleActions, TC profile forms are interpreted as
+    // "start profile" steps and they're always paired with separate "wait for profile
+    // to complete" steps. Without enableConcurrentModuleActions, TC profile forms are
+    // interpreted as blocking "start profile and wait for it to complete" steps,
+    // without a separate wait step.
+    enableConcurrentModuleActions
+  ) {
+    dispatch(saveWaitForThermocyclerProfile(unsavedForm))
+  }
+}
 
-    const temperature = unsavedSetTemperatureForm?.targetTemperature
+const saveWaitForTemperatureModuleTemp: (
+  unsavedSetTemperatureForm: FormData
+) => ThunkAction<any> = unsavedSetTemperatureForm => (dispatch, getState) => {
+  const tempertureModuleId = unsavedSetTemperatureForm?.moduleId
+  const temperature = unsavedSetTemperatureForm.targetTemperature
 
+  console.assert(
+    temperature != null && temperature !== '',
+    `tried to auto-add a pause until temp, but targetTemperature is missing: ${temperature}`
+  )
+
+  dispatch(
+    addStep({
+      stepType: 'pause',
+      robotStateTimeline: fileDataSelectors.getRobotStateTimeline(getState()),
+    })
+  )
+  // NOTE: fields should be set one at a time b/c dependentFieldsUpdate fns can filter out inputs
+  // contingent on other inputs (eg changing the pauseAction radio button may clear the pauseTemperature).
+  dispatch(
+    changeFormInput({
+      update: {
+        pauseAction: PAUSE_UNTIL_TEMP,
+      },
+    })
+  )
+  dispatch(
+    changeFormInput({
+      update: {
+        moduleId: tempertureModuleId,
+      },
+    })
+  )
+  dispatch(
+    changeFormInput({
+      update: {
+        pauseTemperature: temperature,
+      },
+    })
+  )
+
+  // finally save the new pause form
+  const unsavedPauseForm = getUnsavedForm(getState())
+  if (unsavedPauseForm != null) {
+    dispatch(_saveStepForm(unsavedPauseForm))
+  } else {
+    // this conditional is for TypeScript, the unsaved form should always exist
     console.assert(
-      temperature != null && temperature !== '',
-      `tried to auto-add a pause until temp, but targetTemperature is missing: ${temperature}`
+      false,
+      'could not auto-save pause form, getUnsavedForm returned nullish'
     )
-    // save the set temperature step form that is currently open
-    dispatch(_saveStepForm(unsavedSetTemperatureForm))
-    // add a new pause step form
+  }
+}
+
+const saveWaitForHeaterShakerTemp: (
+  unsavedHeaterShakerForm: FormData
+) => ThunkAction<any> = unsavedHeaterShakerForm => (dispatch, getState) => {
+  const heaterShakerModuleId = unsavedHeaterShakerForm.moduleId
+  const temperature = unsavedHeaterShakerForm.targetHeaterShakerTemperature
+
+  dispatch(
+    addStep({
+      stepType: 'pause',
+      robotStateTimeline: fileDataSelectors.getRobotStateTimeline(getState()),
+    })
+  )
+  // NOTE: fields should be set one at a time b/c dependentFieldsUpdate fns can filter out inputs
+  // contingent on other inputs (eg changing the pauseAction radio button may clear the pauseTemperature).
+  dispatch(
+    changeFormInput({
+      update: {
+        pauseAction: PAUSE_UNTIL_TEMP,
+      },
+    })
+  )
+  dispatch(
+    changeFormInput({
+      update: {
+        moduleId: heaterShakerModuleId,
+      },
+    })
+  )
+  dispatch(
+    changeFormInput({
+      update: {
+        pauseTemperature: temperature,
+      },
+    })
+  )
+
+  // finally save the new pause form
+  const unsavedPauseForm = getUnsavedForm(getState())
+  if (unsavedPauseForm != null) {
+    dispatch(_saveStepForm(unsavedPauseForm))
+  } else {
+    // this conditional is for TypeScript, the unsaved form should always exist
+    console.assert(
+      false,
+      'could not auto-save pause form, getUnsavedForm returned nullish'
+    )
+  }
+}
+
+const saveWaitForThermocyclerProfile: (
+  unsavedThermocyclerProfileForm: FormData
+) => ThunkAction<any> =
+  unsavedThermocyclerProfileForm => (dispatch, getState) => {
+    const thermocyclerModuleId = unsavedThermocyclerProfileForm.moduleId
+
     dispatch(
       addStep({
         stepType: 'pause',
@@ -395,109 +517,28 @@ export const saveSetTempFormWithAddedPauseUntilTemp: () => ThunkAction<any> =
     dispatch(
       changeFormInput({
         update: {
-          pauseAction: PAUSE_UNTIL_TEMP,
+          pauseAction: PAUSE_UNTIL_TC_PROFILE_COMPLETE,
         },
       })
     )
-    const tempertureModuleId = unsavedSetTemperatureForm?.moduleId
+
     dispatch(
       changeFormInput({
         update: {
-          moduleId: tempertureModuleId,
+          moduleId: thermocyclerModuleId,
         },
       })
     )
-    dispatch(
-      changeFormInput({
-        update: {
-          pauseTemperature: temperature,
-        },
-      })
-    )
+
     // finally save the new pause form
     const unsavedPauseForm = getUnsavedForm(getState())
-
-    // this conditional is for TypeScript, the unsaved form should always exist
     if (unsavedPauseForm != null) {
       dispatch(_saveStepForm(unsavedPauseForm))
     } else {
+      // this conditional is for TypeScript, the unsaved form should always exist
       console.assert(
         false,
-        'could not auto-save pause form, getUnsavedForm returned'
-      )
-    }
-  }
-
-export const saveHeaterShakerFormWithAddedPauseUntilTemp: () => ThunkAction<any> =
-  () => (dispatch, getState) => {
-    const initialState = getState()
-    const unsavedHeaterShakerForm = getUnsavedForm(initialState)
-    const isPristineSetHeaterShakerTempForm =
-      getUnsavedFormIsPristineHeaterShakerForm(initialState)
-
-    if (!unsavedHeaterShakerForm) {
-      console.assert(
-        false,
-        'Tried to saveSetHeaterShakerTempFormWithAddedPauseUntilTemp with falsey unsavedForm. This should never be able to happen.'
-      )
-      return
-    }
-
-    const { id } = unsavedHeaterShakerForm
-
-    if (!isPristineSetHeaterShakerTempForm) {
-      console.assert(
-        false,
-        `tried to saveSetHeaterShakerTempFormWithAddedPauseUntilTemp but form ${id} is not a pristine set heater shaker temp form`
-      )
-      return
-    }
-
-    const temperature = unsavedHeaterShakerForm?.targetHeaterShakerTemperature
-
-    console.assert(
-      temperature != null && temperature !== '',
-      `tried to auto-add a pause until temp, but targetHeaterShakerTemperature is missing: ${temperature}`
-    )
-    dispatch(_saveStepForm(unsavedHeaterShakerForm))
-    dispatch(
-      addStep({
-        stepType: 'pause',
-        robotStateTimeline: fileDataSelectors.getRobotStateTimeline(getState()),
-      })
-    )
-    dispatch(
-      changeFormInput({
-        update: {
-          pauseAction: PAUSE_UNTIL_TEMP,
-        },
-      })
-    )
-    const heaterShakerModuleId = unsavedHeaterShakerForm.moduleId
-    dispatch(
-      changeFormInput({
-        update: {
-          moduleId: heaterShakerModuleId,
-        },
-      })
-    )
-
-    dispatch(
-      changeFormInput({
-        update: {
-          pauseTemperature: temperature,
-        },
-      })
-    )
-    const unsavedPauseForm = getUnsavedForm(getState())
-
-    // this conditional is for TypeScript, the unsaved form should always exist
-    if (unsavedPauseForm != null) {
-      dispatch(_saveStepForm(unsavedPauseForm))
-    } else {
-      console.assert(
-        false,
-        'could not auto-save pause form, getUnsavedForm returned'
+        'could not auto-save pause form, getUnsavedForm returned nullish'
       )
     }
   }

--- a/protocol-designer/src/ui/steps/actions/thunks/index.ts
+++ b/protocol-designer/src/ui/steps/actions/thunks/index.ts
@@ -325,7 +325,7 @@ export const saveStepForm: () => ThunkAction<any> =
     const initialState = getState()
     const unsavedForm = getUnsavedForm(initialState)
 
-    // this check is only for Flow. At this point, unsavedForm should always be populated
+    // this check is only for TypeScript. At this point, unsavedForm should always be populated
     if (!unsavedForm) {
       console.assert(
         false,
@@ -355,7 +355,7 @@ export const saveSetTempFormWithAddedPauseUntilTemp: () => ThunkAction<any> =
     const isPristineSetTempForm =
       getUnsavedFormIsPristineSetTempForm(initialState)
 
-    // this check is only for Flow. At this point, unsavedForm should always be populated
+    // this check is only for TypeScript. At this point, unsavedForm should always be populated
     if (!unsavedSetTemperatureForm) {
       console.assert(
         false,
@@ -417,7 +417,7 @@ export const saveSetTempFormWithAddedPauseUntilTemp: () => ThunkAction<any> =
     // finally save the new pause form
     const unsavedPauseForm = getUnsavedForm(getState())
 
-    // this conditional is for Flow, the unsaved form should always exist
+    // this conditional is for TypeScript, the unsaved form should always exist
     if (unsavedPauseForm != null) {
       dispatch(_saveStepForm(unsavedPauseForm))
     } else {
@@ -491,6 +491,7 @@ export const saveHeaterShakerFormWithAddedPauseUntilTemp: () => ThunkAction<any>
     )
     const unsavedPauseForm = getUnsavedForm(getState())
 
+    // this conditional is for TypeScript, the unsaved form should always exist
     if (unsavedPauseForm != null) {
       dispatch(_saveStepForm(unsavedPauseForm))
     } else {


### PR DESCRIPTION
## Overview

With the new feature of concurrent module actions, every Thermocycler profile step will be coupled permanently to a "wait for profile to complete" step. That step is never visible in the UI—[instead, the UI shows a nested group](https://github.com/Opentrons/opentrons/pull/19924)—but it will always exist behind the scenes.

This PR makes sure the wait step is always created when you save a profile step. This goes towards EXEC-2024.

This depends on #20249 and will need to merge after it.

## Changelog

Depending on feature flags and user interaction, we *sometimes* want to show a dialog when a step is saved, and we *sometimes* want to add a bonus step. See the test plan below for details.

So, to give us a space to implement all of that:

* A new selector returns what kind of modal should be shown after the current step form is saved, if any.
* The `saveStepForm()` thunk now takes a `userWantsBonusStep` boolean argument. Depending on that, and depending on the type of the original step form, it saves the original step form, and, possibly, an additional automatically-created bonus step.

And finally:

* The existing Heater-Shaker and Temperature Module behavior is ported to the new selector and thunk.
* With the new selector and thunk, Thermocycler profile steps will now automatically pop a dialog and add a pause step.

## Test Plan and Hands on Testing

I will run through this test plan.

With the "Enable concurrent module actions" feature flag off:

* Adding a Heater-Shaker step
  * [x] "Add pause step" dialog has old copy
  * [x] Dialog only shows the first time the step is saved
  * [x] Pause step is added if dialog is approved
  * [x] Pause step is not added if dialog does not show, or if dialog is not approved
* Adding a Temperature Module step
  * [x] "Add pause step" dialog has old copy
  * [x] Dialog only shows the first time the step is saved
  * [x] Pause step is added if dialog is approved
  * [x] Pause step is not added if dialog does not show, or if dialog is not approved
* Adding a Thermocycler step
  * [x] No dialog

With the "Enable concurrent module actions" feature flag on:

* Adding a Heater-Shaker step
  * [x] "Add pause step" dialog has new copy
  * [x] Dialog only shows the first time the step is saved
  * [x] Dialog can only be approved, not canceled
  * [x] Pause step is added after dialog is approved
* Adding a Temperature Module step
  * [x] "Add pause step" dialog has new copy
  * [x] Dialog only shows the first time the step is saved
  * [x] Dialog can only be approved, not canceled
  * [x] Pause step is added after dialog is approved
* Adding a Thermocycler step
  * [x] "Add pause step" dialog has new copy
  * [x] Dialog only shows the first time the step is saved
  * [x] Dialog can only be approved, not canceled
  * [x] Pause step is added after dialog is approved
    * In the timeline, if "Start profile" and "Wait for profile to complete" are shown after the Thermocycler profile step, that indicates things are working properly

Editing a preexisting Thermocycler step is not expected to work yet. 

## Review requests

One thing that I really dislike about my new code is that the logic for determining what modal to show needs to be manually kept in sync with the logic for determining what kind of bonus step to add. I did this because, as you can see above, there's a lot of conditionality in whether the modal is shown, and what kind; and those conditions don't necessarily exactly match whether the bonus step is actually added. And I wanted it to be impossible, at a low level, to add a Thermocycler profile without its corresponding pause step. But I think it turned out pretty iffy. The old code did this with `useConditionalConfirm()`, which was confusing in different ways.

Roughly, the future direction of this code is that the "would you like us to add a pause step" modals (`modalType` of `optionallyWaitForTemp`) are going to get phased out in favor of the "we have added a pause step for you" modals (`modalType` of `explainWaitForTemperatureModuleTemp`, ...). And this will get simpler after that happens. But that could take a while.

## Risk assessment

Medium.