### PR TITLE
fix(hardware-testing): Improve pipetting dispense accuracy with touch tip setting and delays

### DIFF
--- a/hardware-testing/hardware_testing/protocols/labware_protocols/inner-well-geometry-creator.py
+++ b/hardware-testing/hardware_testing/protocols/labware_protocols/inner-well-geometry-creator.py
@@ -709,7 +709,9 @@ def build_IWG_definition(
     """Build inner well geometry definition for the labware."""
     if not ctx.is_simulating():
         passed_trials = [
-            trial for trial in trial_results if trial.status in ("pass", "final", "none")
+            trial
+            for trial in trial_results
+            if trial.status in ("pass", "final", "none")
         ]
         frusta_data = np.array(
             [(trial.dispense_volume, trial.height) for trial in passed_trials]

--- a/hardware-testing/hardware_testing/protocols/labware_protocols/inner-well-geometry-creator.py
+++ b/hardware-testing/hardware_testing/protocols/labware_protocols/inner-well-geometry-creator.py
@@ -709,7 +709,7 @@ def build_IWG_definition(
     """Build inner well geometry definition for the labware."""
     if not ctx.is_simulating():
         passed_trials = [
-            trial for trial in trial_results if trial.status in ("pass", "final")
+            trial for trial in trial_results if trial.status in ("pass", "final", "none")
         ]
         frusta_data = np.array(
             [(trial.dispense_volume, trial.height) for trial in passed_trials]
@@ -733,7 +733,7 @@ def get_transfer_props(
     # changes dispense offset based on the "expected" liquid level.
 
     if volume > 15:
-        dispense_offset = max(2.0, expected_liquid_level + 1.0)
+        dispense_offset = max(2.0, expected_liquid_level + 5)
     else:
         dispense_offset = max(2.0, expected_liquid_level + 0.1)
 
@@ -767,6 +767,8 @@ def get_transfer_props(
         ethanol_props.dispense.retract.blowout.enabled = True  # disable if bubbles
         ethanol_props.dispense.retract.end_position.position_reference = wt
         ethanol_props.dispense.retract.end_position.offset.z = 10.0
+        ethanol_props.dispense.retract.delay.enabled = True
+        ethanol_props.dispense.retract.delay.duration = 3.0
 
 
 def prepare_transfer(
@@ -827,9 +829,9 @@ def geometry_creator(
         # Precheck if there's clearance for touch tip
         if (
             trial.corrected_height + config.target_height
-            <= config.labware["A1"].depth - 4.0
+            <= config.labware["A1"].depth - 1.0
         ):
-            config.liq_pipette.touch_tip()
+            config.liq_pipette.touch_tip(v_offset=-0.5, speed=30)
 
         trial.get_liquid_height(ctx, config)
         trial.compute_height_delta()

--- a/hardware-testing/hardware_testing/protocols/labware_protocols/labware-iwg-validator.py
+++ b/hardware-testing/hardware_testing/protocols/labware_protocols/labware-iwg-validator.py
@@ -494,7 +494,7 @@ def get_transfer_props(volume: float, config: SetupState) -> None:
     """Get aspirate/dispense properties for ethanol liquid class. You can change these."""
     # this tries to mitigate liquid forming on the tip for small dispenses.
     if volume > 15:
-        dispense_offset = 1.0
+        dispense_offset = 5.0
     else:
         dispense_offset = 0.1
 
@@ -527,6 +527,8 @@ def get_transfer_props(volume: float, config: SetupState) -> None:
         ethanol_props.dispense.retract.blowout.enabled = True
         ethanol_props.dispense.retract.end_position.position_reference = wt
         ethanol_props.dispense.retract.end_position.offset.z = 5
+        ethanol_props.dispense.retract.delay.enabled = True
+        ethanol_props.dispense.retract.delay.duration = 3.0
 
 
 def prepare_transfer(
@@ -588,8 +590,8 @@ def aspirate_dispense_measure(
         )
 
         # Touch tip if clearance allows
-        if trial.expected_height <= config.labware["A1"].depth - 4:
-            config.liq_pipette.touch_tip()
+        if trial.expected_height <= config.labware["A1"].depth - 1.0:
+            config.liq_pipette.touch_tip(v_offset=-0.5, speed=30)
 
         height = trial.get_height_of_liquid_in_well(ctx, config)
         trial.measured_height = height + trial.tip_z_error


### PR DESCRIPTION
# Overview

Fixed issue with first frustum not being calculated. Changed dispense settings to add a small delay, and increased the height of dispenses

## Test Plan and Hands on Testing

-reran both protocols

## Changelog

-Added 3s delay to retract after dispense
-Changed dispense offset to be higher 
-fixed issue with the first frustum not being calculated in IWG creator 

