### PR TITLE
fix(robot-server): Fix broken /redoc page

### DIFF
--- a/robot-server/robot_server/app_setup.py
+++ b/robot-server/robot_server/app_setup.py
@@ -5,6 +5,8 @@ from pathlib import Path
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.openapi.docs import get_redoc_html
+from fastapi.responses import HTMLResponse
 
 from server_utils.fastapi_utils.server_timing_middleware import server_timing_middleware
 
@@ -34,6 +36,9 @@ from .service.notifications import (
     set_up_notification_client,
     initialize_pe_publisher_notifier,
 )
+
+
+_REDOC_CDN_URL = "https://cdn.jsdelivr.net/npm/redoc@2/bundles/redoc.standalone.js"
 
 
 @contextlib.asynccontextmanager
@@ -108,8 +113,30 @@ app = FastAPI(
     # Disable documentation hosting via Swagger UI, normally at /docs.
     # We instead focus on the docs hosted by ReDoc, at /redoc.
     docs_url=None,
+    # redoc_url is replaced by our own /redoc router, below.
+    redoc_url=None,
     lifespan=_lifespan,
 )
+
+
+# This is a workaround for a broken /redoc page in versions of FastAPI <0.115.3.
+# The page loads Redoc from a CDN, and the problem is that the default CDN URL
+# uses a fragile version tag.
+# https://github.com/Redocly/redoc/issues/2743
+# https://github.com/fastapi/fastapi/pull/9700
+@app.get("/redoc", include_in_schema=False)
+async def redoc_html() -> HTMLResponse:  # noqa: D103
+    if app.openapi_url is None:
+        raise RuntimeError(
+            "Couldn't get OpenAPI URL from FastAPI."
+            + " This is probably some kind of misconfiguration."
+        )
+    return get_redoc_html(
+        openapi_url=app.openapi_url,
+        title=app.title,
+        redoc_js_url=_REDOC_CDN_URL,
+    )
+
 
 app.add_middleware(
     CORSMiddleware,


### PR DESCRIPTION
## Overview

This fixes robot-server's `/redoc` page not loading. Closes RQA-4929.

## Test Plan and Hands on Testing

* [x] `make -C robot-server dev` still boots
* [x] Visiting http://localhost:31950/redoc shows HTTP API documentation again

## Changelog

robot-server serves documentation for its HTTP API at `/redoc`. The way that works is that FastAPI serves a minimal static HTML file that loads the [Redoc](https://github.com/Redocly/redoc) JavaScript bundle from a CDN. The JavaScript bundle then fetches `./openapi.json`, extracts information about the HTTP API, and builds the actual page.

In our version of FastAPI, the Redoc CDN link is https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js. This started 404ing recently, for reasons that probably have to do with [the `@next` version tag being problematic](https://github.com/Redocly/redoc/issues/2743), causing the `/redoc` page to just show a white screen. [Newer versions of FastAPI use `@2` instead.](https://github.com/fastapi/fastapi/pull/9700)

The workaround here is to override the CDN URL to `@2` [following FastAPI's recommended pattern](https://fastapi.tiangolo.com/how-to/custom-docs-ui-assets/#custom-cdn-for-javascript-and-css).

## Review requests

None in particular.

## Risk assessment

Low. This won't affect any robot or app behavior.

This does upgrade the Redoc version that you'll see at <robot host>:31950/redoc. The new version will probably more closely match what we've been publishing online.
