### PR TITLE
fix(step-generation): ensure nozzles are configured for 8-channel partial tip

### DIFF
--- a/step-generation/src/commandCreators/compound/replaceTip.ts
+++ b/step-generation/src/commandCreators/compound/replaceTip.ts
@@ -213,7 +213,7 @@ export const replaceTip: CommandCreator<ReplaceTipArgs> = (
   const configureNozzleLayoutCommand: CurriedCommandCreator[] =
     //  only emit the command if previous nozzle state and tiprack state are different
     //  only check for the 96-channel since we do not support 8-channel partial tip yet
-    channels === 96 &&
+    channels !== 1 &&
     args.nozzles != null &&
     (args.nozzles !== stateNozzles || nextTiprack.tiprackId !== stateTiprack)
       ? [


### PR DESCRIPTION
# Overview

Fix the logical check for currying `configureNozzleLayout` in `replaceTip`, extending to 8-channel pipettes.

Closes RQA-4918

## Test Plan and Hands on Testing

- upload protocol from ticket
- verify that tiprack state updates properly by inspecting tip state at each step (single channel pickups)

## Changelog

- curry `configureNozzleLayout` for any non-single-channel pipettes (previously only 96)

## Review requests

- see test plan

## Risk assessment

low