### PR TITLE
fix(step-generation): use tip rack from previous step if changeTip=never

### DIFF
--- a/step-generation/src/__tests__/transfer.test.ts
+++ b/step-generation/src/__tests__/transfer.test.ts
@@ -147,7 +147,7 @@ describe('pick up tip if no tip on pipette', () => {
 
     robotStateWithTip.tipState.pipettes.p300SingleId = {
       hasTip: true,
-      tiprackURI: 'tiprackId',
+      tiprackURI: 'tiprack1Id',
     }
 
     noTipArgs = {
@@ -2364,7 +2364,7 @@ describe('single transfer exceeding pipette max', () => {
     // begin with tip on pipette
     robotStateWithTip.tipState.pipettes.p300SingleId = {
       hasTip: true,
-      tiprackURI: 'tiprackId',
+      tiprackURI: 'tiprack1Id',
     }
 
     const result = transfer(transferArgs, invariantContext, robotStateWithTip)
@@ -2660,7 +2660,7 @@ describe('single transfer exceeding pipette max', () => {
     // begin with tip on pipette
     robotStateWithTip.tipState.pipettes.p300SingleId = {
       hasTip: true,
-      tiprackURI: 'tiprackId',
+      tiprackURI: 'tiprack1Id',
     }
 
     const result = transfer(transferArgs, invariantContext, robotStateWithTip)

--- a/step-generation/src/commandCreators/compound/consolidate.ts
+++ b/step-generation/src/commandCreators/compound/consolidate.ts
@@ -65,6 +65,7 @@ import type {
   CommandCreatorError,
   ConsolidateArgs,
   CurriedCommandCreator,
+  LabwareEntity,
 } from '../../types'
 
 export const consolidate: CommandCreator<ConsolidateArgs> = (
@@ -138,7 +139,7 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
     pushOut,
     sourceLabware,
     sourceWells,
-    tipRack,
+    tipRack: userSelectedTipRackURI, // the tiprack the user selected, not necessarily the one used for this step
     tipTracking,
     tiprackSelected,
     tipsSelected,
@@ -231,19 +232,31 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
     errors.push(errorCreators.dropTipLocationDoesNotExist())
   }
 
-  const tiprack = Object.values(labwareEntities).find(
-    ({ labwareDefURI }) => labwareDefURI === tipRack
-  )
-  if (tiprack == null) {
+  let tiprackEntity: LabwareEntity | undefined, tiprackURI: string
+  // TODO: We currently ask users to select a tip rack even if the tip handling policy
+  // for this step is `never`, in which case we must ignore the tip rack the user selected
+  // and use the tip rack from the previous step where we actually picked up the tip.
+  if (changeTip === 'never') {
+    const prevTiprackID = prevRobotState.tipState.pipettes[pipette]?.tiprackURI
+    // pipettes[pipette].tiprackURI is a misnomer: it's an labwareID, not a URI
+    tiprackEntity = invariantContext.labwareEntities[prevTiprackID ?? '']
+    tiprackURI = tiprackEntity?.labwareDefURI
+  } else {
+    tiprackEntity = Object.values(labwareEntities).find(
+      ({ labwareDefURI }) => labwareDefURI === userSelectedTipRackURI
+    )
+    tiprackURI = userSelectedTipRackURI
+  }
+
+  if (tiprackEntity == null) {
     errors.push(
       errorCreators.labwareDoesNotExist({
         actionName,
-        labware: tipRack,
+        labware: tiprackURI,
       })
     )
   }
-  const { def: tiprackDefinition = null, labwareDefURI: tiprackDefUri } =
-    tiprack ?? {}
+  const { def: tiprackDefinition = null } = tiprackEntity ?? {}
   const {
     spec: pipetteSpecs,
     name: pipetteName,
@@ -259,7 +272,7 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
         ({ pipetteModel }) =>
           pipetteModel === getFlexNameConversion(pipetteSpecs)
       )
-      ?.byTipType.find(({ tiprack }) => tiprack === tiprackDefUri) ?? null
+      ?.byTipType.find(({ tiprack }) => tiprack === tiprackURI) ?? null
   const { aspirate } = liquidClassValuesForTip ?? {}
   const { multiWellHandling } = getTransferPlanAndReferenceVolumes({
     pipetteSpecs,
@@ -347,7 +360,7 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
   }
   const { tipracks } = getNextTiprack(
     pipette,
-    tipRack,
+    tiprackURI,
     invariantContext,
     prevRobotState,
     ...(nozzles != null ? [nozzles] : [])
@@ -357,7 +370,7 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
     getByVolumeValue({
       liquidClass,
       pipetteSpecs,
-      tiprackDefUri: tipRack,
+      tiprackDefUri: tiprackURI,
       targetVolume: volume,
       liquidHandlingAction: 'aspirate',
       byVolumeProperty: 'correctionByVolume',
@@ -396,7 +409,7 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
       pipetteName: isFlexPipette(pipetteName)
         ? getFlexNameConversion(pipetteSpecs)
         : pipetteName,
-      tiprackUri: tipRack,
+      tiprackUri: tiprackURI,
       liquidClassValuesForTip,
     })}`,
   ]
@@ -513,7 +526,7 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
     getByVolumeValue({
       liquidClass,
       pipetteSpecs,
-      tiprackDefUri: tipRack,
+      tiprackDefUri: tiprackURI,
       targetVolume: dispenseAirGapVolume,
       liquidHandlingAction: 'aspirate',
       byVolumeProperty: 'correctionByVolume',
@@ -532,7 +545,7 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
     getByVolumeValue({
       liquidClass,
       pipetteSpecs,
-      tiprackDefUri: tipRack,
+      tiprackDefUri: tiprackURI,
       targetVolume: aspirateAirGapVolume,
       liquidHandlingAction: 'aspirate',
       byVolumeProperty: 'flowRateByVolume',
@@ -542,7 +555,7 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
     getByVolumeValue({
       liquidClass,
       pipetteSpecs,
-      tiprackDefUri: tipRack,
+      tiprackDefUri: tiprackURI,
       targetVolume: aspirateAirGapVolume,
       liquidHandlingAction: 'singleDispense',
       byVolumeProperty: 'flowRateByVolume',
@@ -552,7 +565,7 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
     getByVolumeValue({
       liquidClass,
       pipetteSpecs,
-      tiprackDefUri: tipRack,
+      tiprackDefUri: tiprackURI,
       targetVolume: dispenseAirGapVolume,
       liquidHandlingAction: 'aspirate',
       byVolumeProperty: 'flowRateByVolume',
@@ -562,7 +575,7 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
     getByVolumeValue({
       liquidClass,
       pipetteSpecs,
-      tiprackDefUri: tipRack,
+      tiprackDefUri: tiprackURI,
       targetVolume: dispenseAirGapVolume,
       liquidHandlingAction: 'singleDispense',
       byVolumeProperty: 'flowRateByVolume',
@@ -672,7 +685,7 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
               isReturnTip && fallBackTrashLikeId != null
                 ? fallBackTrashLikeId
                 : dropTipLocation,
-            tipRack,
+            tipRack: tiprackURI,
             ...(nozzles != null ? { nozzles } : {}),
             ...(tipTracking === MANUAL &&
             nextTip != null &&
@@ -746,7 +759,7 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
             getByVolumeValue({
               liquidClass,
               pipetteSpecs,
-              tiprackDefUri: tipRack,
+              tiprackDefUri: tiprackURI,
               targetVolume: airGapInTip,
               liquidHandlingAction: 'singleDispense',
               byVolumeProperty: 'correctionByVolume',
@@ -883,7 +896,7 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
             getByVolumeValue({
               liquidClass,
               pipetteSpecs,
-              tiprackDefUri: tipRack,
+              tiprackDefUri: tiprackURI,
               targetVolume: aspirateAirGapVolume,
               liquidHandlingAction: 'aspirate',
               byVolumeProperty: 'correctionByVolume',
@@ -983,7 +996,7 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
         getByVolumeValue({
           liquidClass,
           pipetteSpecs,
-          tiprackDefUri: tipRack,
+          tiprackDefUri: tiprackURI,
           targetVolume: aspirateAirGapVolume,
           liquidHandlingAction: 'singleDispense',
           byVolumeProperty: 'correctionByVolume',
@@ -1047,7 +1060,7 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
         getByVolumeValue({
           liquidClass,
           pipetteSpecs,
-          tiprackDefUri: tipRack,
+          tiprackDefUri: tiprackURI,
           targetVolume: totalSampleDispenseVolume,
           liquidHandlingAction: 'singleDispense',
           byVolumeProperty: 'correctionByVolume',
@@ -1070,7 +1083,7 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
           ? getByVolumeValue({
               liquidClass,
               pipetteSpecs,
-              tiprackDefUri: tipRack,
+              tiprackDefUri: tiprackURI,
               targetVolume: mixInDestination.volume,
               liquidHandlingAction: 'aspirate',
               byVolumeProperty: 'flowRateByVolume',
@@ -1082,7 +1095,7 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
           ? getByVolumeValue({
               liquidClass,
               pipetteSpecs,
-              tiprackDefUri: tipRack,
+              tiprackDefUri: tiprackURI,
               targetVolume: mixInDestination.volume,
               liquidHandlingAction: 'singleDispense',
               byVolumeProperty: 'flowRateByVolume',
@@ -1102,7 +1115,7 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
               finalPushOut: pushOut,
               invariantContext,
               liquidClass,
-              tiprack: tipRack,
+              tiprack: tiprackURI,
               generatePython: false,
             })
           : []
@@ -1167,7 +1180,7 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
           ? [
               curryWithoutPython(dropTip, {
                 pipette,
-                dropTipLocation: tipRack,
+                dropTipLocation: tiprackURI,
                 isReturnTip,
               }),
             ]

--- a/step-generation/src/commandCreators/compound/distribute.ts
+++ b/step-generation/src/commandCreators/compound/distribute.ts
@@ -68,6 +68,7 @@ import type {
   CommandCreatorError,
   CurriedCommandCreator,
   DistributeArgs,
+  LabwareEntity,
 } from '../../types'
 
 export const distribute: CommandCreator<DistributeArgs> = (
@@ -143,7 +144,7 @@ export const distribute: CommandCreator<DistributeArgs> = (
     pushOut,
     sourceLabware,
     sourceWell,
-    tipRack,
+    tipRack: userSelectedTipRackURI, // the tiprack the user selected, not necessarily the one used for this step
     tipTracking,
     tiprackSelected,
     tipsSelected,
@@ -249,19 +250,31 @@ export const distribute: CommandCreator<DistributeArgs> = (
     errors.push(errorCreators.dropTipLocationDoesNotExist())
   }
 
-  const tiprack = Object.values(labwareEntities).find(
-    ({ labwareDefURI }) => labwareDefURI === tipRack
-  )
-  if (tiprack == null) {
+  let tiprackEntity: LabwareEntity | undefined, tiprackURI: string
+  // TODO: We currently ask users to select a tip rack even if the tip handling policy
+  // for this step is `never`, in which case we must ignore the tip rack the user selected
+  // and use the tip rack from the previous step where we actually picked up the tip.
+  if (changeTip === 'never') {
+    const prevTiprackID = prevRobotState.tipState.pipettes[pipette]?.tiprackURI
+    // pipettes[pipette].tiprackURI is a misnomer: it's an labwareID, not a URI
+    tiprackEntity = invariantContext.labwareEntities[prevTiprackID ?? '']
+    tiprackURI = tiprackEntity?.labwareDefURI
+  } else {
+    tiprackEntity = Object.values(labwareEntities).find(
+      ({ labwareDefURI }) => labwareDefURI === userSelectedTipRackURI
+    )
+    tiprackURI = userSelectedTipRackURI
+  }
+
+  if (tiprackEntity == null) {
     errors.push(
       errorCreators.labwareDoesNotExist({
         actionName,
-        labware: tipRack,
+        labware: tiprackURI,
       })
     )
   }
-  const { def: tiprackDefinition = null, labwareDefURI: tiprackDefUri } =
-    tiprack ?? {}
+  const { def: tiprackDefinition = null } = tiprackEntity ?? {}
   const {
     spec: pipetteSpecs,
     name: pipetteName,
@@ -278,7 +291,7 @@ export const distribute: CommandCreator<DistributeArgs> = (
         ({ pipetteModel }) =>
           pipetteModel === getFlexNameConversion(pipetteSpecs)
       )
-      ?.byTipType.find(({ tiprack }) => tiprack === tiprackDefUri) ?? null
+      ?.byTipType.find(({ tiprack }) => tiprack === tiprackURI) ?? null
   const { aspirate, multiDispense } = liquidClassValuesForTip ?? {}
   const { multiWellHandling } = getTransferPlanAndReferenceVolumes({
     pipetteSpecs,
@@ -372,7 +385,7 @@ export const distribute: CommandCreator<DistributeArgs> = (
   ]
 
   const maxVolume =
-    getPipetteWithTipMaxVol(pipette, invariantContext, tipRack) -
+    getPipetteWithTipMaxVol(pipette, invariantContext, tiprackURI) -
     aspirateAirGapVolume
   const maxWellsPerChunk = Math.floor((maxVolume - disposalVolume) / volume)
 
@@ -393,7 +406,7 @@ export const distribute: CommandCreator<DistributeArgs> = (
     }
   const { tipracks } = getNextTiprack(
     pipette,
-    tipRack,
+    tiprackURI,
     invariantContext,
     prevRobotState,
     ...(nozzles != null ? [nozzles] : [])
@@ -403,7 +416,7 @@ export const distribute: CommandCreator<DistributeArgs> = (
     getByVolumeValue({
       liquidClass,
       pipetteSpecs,
-      tiprackDefUri: tipRack,
+      tiprackDefUri: tiprackURI,
       targetVolume: volume,
       liquidHandlingAction: 'multiDispense',
       byVolumeProperty: 'correctionByVolume',
@@ -441,7 +454,7 @@ export const distribute: CommandCreator<DistributeArgs> = (
       pipetteName: isFlexPipette(pipetteName)
         ? getFlexNameConversion(pipetteSpecs)
         : pipetteName,
-      tiprackUri: tipRack,
+      tiprackUri: tiprackURI,
       liquidClassValuesForTip,
     })}`,
   ]
@@ -560,7 +573,7 @@ export const distribute: CommandCreator<DistributeArgs> = (
     getByVolumeValue({
       liquidClass,
       pipetteSpecs,
-      tiprackDefUri: tipRack,
+      tiprackDefUri: tiprackURI,
       targetVolume: aspirateAirGapVolume,
       liquidHandlingAction: 'aspirate',
       byVolumeProperty: 'flowRateByVolume',
@@ -570,7 +583,7 @@ export const distribute: CommandCreator<DistributeArgs> = (
     getByVolumeValue({
       liquidClass,
       pipetteSpecs,
-      tiprackDefUri: tipRack,
+      tiprackDefUri: tiprackURI,
       targetVolume: aspirateAirGapVolume,
       liquidHandlingAction: 'multiDispense',
       byVolumeProperty: 'flowRateByVolume',
@@ -580,7 +593,7 @@ export const distribute: CommandCreator<DistributeArgs> = (
     getByVolumeValue({
       liquidClass,
       pipetteSpecs,
-      tiprackDefUri: tipRack,
+      tiprackDefUri: tiprackURI,
       targetVolume: dispenseAirGapVolume,
       liquidHandlingAction: 'aspirate',
       byVolumeProperty: 'flowRateByVolume',
@@ -590,7 +603,7 @@ export const distribute: CommandCreator<DistributeArgs> = (
     getByVolumeValue({
       liquidClass,
       pipetteSpecs,
-      tiprackDefUri: tipRack,
+      tiprackDefUri: tiprackURI,
       targetVolume: dispenseAirGapVolume,
       liquidHandlingAction: 'multiDispense',
       byVolumeProperty: 'flowRateByVolume',
@@ -652,7 +665,7 @@ export const distribute: CommandCreator<DistributeArgs> = (
               isReturnTip && fallBackTrashLikeId != null
                 ? fallBackTrashLikeId
                 : dropTipLocation,
-            tipRack,
+            tipRack: tiprackURI,
             ...(nozzles != null ? { nozzles } : {}),
             ...(tipTracking === MANUAL &&
             nextTip != null &&
@@ -689,7 +702,7 @@ export const distribute: CommandCreator<DistributeArgs> = (
         getByVolumeValue({
           liquidClass,
           pipetteSpecs,
-          tiprackDefUri: tipRack,
+          tiprackDefUri: tiprackURI,
           targetVolume: dispenseAirGapVolume,
           liquidHandlingAction: 'multiDispense',
           byVolumeProperty: 'correctionByVolume',
@@ -781,7 +794,7 @@ export const distribute: CommandCreator<DistributeArgs> = (
             finalPushOut: 0, // according to transfer_components_executor, don't push out here
             invariantContext,
             liquidClass,
-            tiprack: tipRack,
+            tiprack: tiprackURI,
             generatePython: false,
           })
         : []
@@ -798,7 +811,7 @@ export const distribute: CommandCreator<DistributeArgs> = (
               finalPushOut: 0, // according to transfer_components_executor, don't push out here
               invariantContext,
               liquidClass,
-              tiprack: tipRack,
+              tiprack: tiprackURI,
               generatePython: false,
             })
           : []
@@ -843,7 +856,7 @@ export const distribute: CommandCreator<DistributeArgs> = (
         getByVolumeValue({
           liquidClass,
           pipetteSpecs,
-          tiprackDefUri: tipRack,
+          tiprackDefUri: tiprackURI,
           targetVolume: aspirateAirGapVolume,
           liquidHandlingAction: 'aspirate',
           byVolumeProperty: 'correctionByVolume',
@@ -871,7 +884,7 @@ export const distribute: CommandCreator<DistributeArgs> = (
         getByVolumeValue({
           liquidClass,
           pipetteSpecs,
-          tiprackDefUri: tipRack,
+          tiprackDefUri: tiprackURI,
           targetVolume: totalGrossAspirateVolume,
           liquidHandlingAction: 'aspirate',
           byVolumeProperty: 'correctionByVolume',
@@ -881,7 +894,7 @@ export const distribute: CommandCreator<DistributeArgs> = (
         getByVolumeValue({
           liquidClass,
           pipetteSpecs,
-          tiprackDefUri: tipRack,
+          tiprackDefUri: tiprackURI,
           targetVolume: conditioningVolume,
           liquidHandlingAction: 'multiDispense',
           byVolumeProperty: 'correctionByVolume',
@@ -955,7 +968,7 @@ export const distribute: CommandCreator<DistributeArgs> = (
             getByVolumeValue({
               liquidClass,
               pipetteSpecs,
-              tiprackDefUri: tipRack,
+              tiprackDefUri: tiprackURI,
               targetVolume: airGapInTip,
               liquidHandlingAction: 'multiDispense',
               byVolumeProperty: 'correctionByVolume',
@@ -1091,7 +1104,7 @@ export const distribute: CommandCreator<DistributeArgs> = (
             getByVolumeValue({
               liquidClass,
               pipetteSpecs,
-              tiprackDefUri: tipRack,
+              tiprackDefUri: tiprackURI,
               targetVolume: dispenseAirGapVolume,
               liquidHandlingAction: 'aspirate',
               byVolumeProperty: 'correctionByVolume',
@@ -1270,7 +1283,7 @@ export const distribute: CommandCreator<DistributeArgs> = (
           ? [
               curryWithoutPython(dropTip, {
                 pipette,
-                dropTipLocation: tipRack,
+                dropTipLocation: tiprackURI,
                 isReturnTip,
               }),
             ]

--- a/step-generation/src/commandCreators/compound/transfer.ts
+++ b/step-generation/src/commandCreators/compound/transfer.ts
@@ -68,6 +68,7 @@ import type {
   CommandCreator,
   CommandCreatorError,
   CurriedCommandCreator,
+  LabwareEntity,
   TransferArgs,
 } from '../../types'
 
@@ -153,7 +154,7 @@ export const transfer: CommandCreator<TransferArgs> = (
     sourceLabware,
     nozzles,
     sourceWells,
-    tipRack,
+    tipRack: userSelectedTipRackURI, // the tiprack the user selected, not necessarily the one used for this step
     tipTracking,
     tiprackSelected,
     tipsSelected,
@@ -283,14 +284,28 @@ export const transfer: CommandCreator<TransferArgs> = (
     errors.push(errorCreators.equipmentDoesNotExist())
   }
 
-  const tiprack = Object.values(labwareEntities).find(
-    ({ labwareDefURI }) => labwareDefURI === tipRack
-  )
+  let tiprack: LabwareEntity | undefined, tiprackURI: string
+
+  // TODO: We currently ask users to select a tip rack even if the tip handling policy
+  // for this step is `never`, in which case we must ignore the tip rack the user selected
+  // and use the tip rack from the previous step where we actually picked up the tip.
+  if (changeTip === 'never') {
+    const prevTiprackID = prevRobotState.tipState.pipettes[pipette]?.tiprackURI
+    // pipettes[pipette].tiprackURI is a misnomer: it's an labwareID, not a URI
+    tiprack = invariantContext.labwareEntities[prevTiprackID ?? '']
+    tiprackURI = tiprack?.labwareDefURI
+  } else {
+    tiprackURI = userSelectedTipRackURI
+    tiprack = Object.values(labwareEntities).find(
+      ({ labwareDefURI }) => labwareDefURI === tiprackURI
+    )
+  }
+
   if (tiprack == null) {
     errors.push(
       errorCreators.labwareDoesNotExist({
         actionName,
-        labware: tipRack,
+        labware: tiprackURI,
       })
     )
   }
@@ -304,7 +319,7 @@ export const transfer: CommandCreator<TransferArgs> = (
   const aspirateAirGapVol = aspirateAirGapVolume || 0
   const dispenseAirGapVol = dispenseAirGapVolume || 0
   const effectiveTransferVol =
-    getPipetteWithTipMaxVol(pipette, invariantContext, tipRack) -
+    getPipetteWithTipMaxVol(pipette, invariantContext, tiprackURI) -
     aspirateAirGapVol
 
   const chunksPerSubTransfer = Math.ceil(volume / effectiveTransferVol)
@@ -363,10 +378,10 @@ export const transfer: CommandCreator<TransferArgs> = (
     pythonName: pythonPipetteName,
   } = pipetteEntities[args.pipette]
 
-  const { labwareDefURI: tiprackDefUri } = tiprack ?? {}
   const { tipracks } = getNextTiprack(
+    // TODO: This lookup is pointless for tip handling = `never`
     pipette,
-    tipRack,
+    tiprackURI,
     invariantContext,
     prevRobotState,
     ...(nozzles != null ? [nozzles] : [])
@@ -381,13 +396,13 @@ export const transfer: CommandCreator<TransferArgs> = (
         ({ pipetteModel }) =>
           pipetteModel === getFlexNameConversion(pipetteSpecs)
       )
-      ?.byTipType.find(({ tiprack }) => tiprack === tiprackDefUri) ?? null
+      ?.byTipType.find(({ tiprack }) => tiprack === tiprackURI) ?? null
 
   const dispenseCorrectionVolumeForSubtransferTarget =
     getByVolumeValue({
       liquidClass: args.liquidClass,
       pipetteSpecs,
-      tiprackDefUri: args.tipRack,
+      tiprackDefUri: tiprackURI,
       targetVolume: subTransferVol,
       liquidHandlingAction: 'singleDispense',
       byVolumeProperty: 'correctionByVolume',
@@ -398,7 +413,7 @@ export const transfer: CommandCreator<TransferArgs> = (
     getByVolumeValue({
       liquidClass: args.liquidClass,
       pipetteSpecs,
-      tiprackDefUri: args.tipRack,
+      tiprackDefUri: tiprackURI,
       targetVolume: subTransferVol,
       liquidHandlingAction: 'aspirate',
       byVolumeProperty: 'correctionByVolume',
@@ -439,7 +454,7 @@ export const transfer: CommandCreator<TransferArgs> = (
       pipetteName: isFlexPipette(pipetteName)
         ? getFlexNameConversion(pipetteSpecs)
         : pipetteName,
-      tiprackUri: tipRack,
+      tiprackUri: tiprackURI,
       liquidClassValuesForTip,
     })}`,
   ]
@@ -515,7 +530,7 @@ export const transfer: CommandCreator<TransferArgs> = (
     getByVolumeValue({
       liquidClass,
       pipetteSpecs,
-      tiprackDefUri: tipRack,
+      tiprackDefUri: tiprackURI,
       targetVolume: aspirateAirGapVol,
       liquidHandlingAction: 'aspirate',
       byVolumeProperty: 'flowRateByVolume',
@@ -525,7 +540,7 @@ export const transfer: CommandCreator<TransferArgs> = (
     getByVolumeValue({
       liquidClass,
       pipetteSpecs,
-      tiprackDefUri: tipRack,
+      tiprackDefUri: tiprackURI,
       targetVolume: aspirateAirGapVol,
       liquidHandlingAction: 'singleDispense',
       byVolumeProperty: 'flowRateByVolume',
@@ -535,7 +550,7 @@ export const transfer: CommandCreator<TransferArgs> = (
     getByVolumeValue({
       liquidClass,
       pipetteSpecs,
-      tiprackDefUri: tipRack,
+      tiprackDefUri: tiprackURI,
       targetVolume: dispenseAirGapVol,
       liquidHandlingAction: 'aspirate',
       byVolumeProperty: 'flowRateByVolume',
@@ -545,7 +560,7 @@ export const transfer: CommandCreator<TransferArgs> = (
     getByVolumeValue({
       liquidClass,
       pipetteSpecs,
-      tiprackDefUri: tipRack,
+      tiprackDefUri: tiprackURI,
       targetVolume: dispenseAirGapVol,
       liquidHandlingAction: 'singleDispense',
       byVolumeProperty: 'flowRateByVolume',
@@ -609,7 +624,7 @@ export const transfer: CommandCreator<TransferArgs> = (
                   isReturnTip && fallBackTrashLikeId != null
                     ? fallBackTrashLikeId
                     : dropTipLocation,
-                tipRack,
+                tipRack: tiprackURI,
                 ...(nozzles != null ? { nozzles } : {}),
                 ...(tipTracking === MANUAL &&
                 nextTip != null &&
@@ -725,7 +740,7 @@ export const transfer: CommandCreator<TransferArgs> = (
             getByVolumeValue({
               liquidClass,
               pipetteSpecs,
-              tiprackDefUri: tipRack,
+              tiprackDefUri: tiprackURI,
               targetVolume: dispenseAirGapVol,
               liquidHandlingAction: 'singleDispense',
               byVolumeProperty: 'correctionByVolume',
@@ -816,7 +831,7 @@ export const transfer: CommandCreator<TransferArgs> = (
                 finalPushOut: 0, // according to transfer_components_executor, don't push out here
                 invariantContext,
                 liquidClass,
-                tiprack: tipRack,
+                tiprack: tiprackURI,
                 generatePython: false,
               })
             : []
@@ -833,7 +848,7 @@ export const transfer: CommandCreator<TransferArgs> = (
                   finalPushOut: 0, // according to transfer_components_executor, don't push out here
                   invariantContext,
                   liquidClass,
-                  tiprack: tipRack,
+                  tiprack: tiprackURI,
                   generatePython: false,
                 })
               : []
@@ -877,7 +892,7 @@ export const transfer: CommandCreator<TransferArgs> = (
             getByVolumeValue({
               liquidClass,
               pipetteSpecs,
-              tiprackDefUri: tipRack,
+              tiprackDefUri: tiprackURI,
               targetVolume: aspirateAirGapVol,
               liquidHandlingAction: 'aspirate',
               byVolumeProperty: 'correctionByVolume',
@@ -938,7 +953,7 @@ export const transfer: CommandCreator<TransferArgs> = (
             getByVolumeValue({
               liquidClass,
               pipetteSpecs,
-              tiprackDefUri: tipRack,
+              tiprackDefUri: tiprackURI,
               targetVolume: aspirateAirGapVol,
               liquidHandlingAction: 'singleDispense',
               byVolumeProperty: 'correctionByVolume',
@@ -1046,7 +1061,7 @@ export const transfer: CommandCreator<TransferArgs> = (
                   finalPushOut: pushOut,
                   invariantContext,
                   liquidClass,
-                  tiprack: tipRack,
+                  tiprack: tiprackURI,
                   generatePython: false,
                 })
               : []
@@ -1082,7 +1097,7 @@ export const transfer: CommandCreator<TransferArgs> = (
             getByVolumeValue({
               liquidClass,
               pipetteSpecs,
-              tiprackDefUri: tipRack,
+              tiprackDefUri: tiprackURI,
               targetVolume: dispenseAirGapVol,
               liquidHandlingAction: 'aspirate',
               byVolumeProperty: 'correctionByVolume',
@@ -1245,7 +1260,7 @@ export const transfer: CommandCreator<TransferArgs> = (
               ? [
                   curryWithoutPython(dropTip, {
                     pipette,
-                    dropTipLocation: tipRack,
+                    dropTipLocation: tiprackURI,
                     isReturnTip,
                   }),
                 ]

--- a/step-generation/src/commandCreators/compound/transfer.ts
+++ b/step-generation/src/commandCreators/compound/transfer.ts
@@ -282,7 +282,6 @@ export const transfer: CommandCreator<TransferArgs> = (
   }
 
   let tiprackEntity: LabwareEntity | undefined, tiprackURI: string
-
   // TODO: We currently ask users to select a tip rack even if the tip handling policy
   // for this step is `never`, in which case we must ignore the tip rack the user selected
   // and use the tip rack from the previous step where we actually picked up the tip.
@@ -292,10 +291,10 @@ export const transfer: CommandCreator<TransferArgs> = (
     tiprackEntity = invariantContext.labwareEntities[prevTiprackID ?? '']
     tiprackURI = tiprackEntity?.labwareDefURI
   } else {
-    tiprackURI = userSelectedTipRackURI
     tiprackEntity = Object.values(labwareEntities).find(
-      ({ labwareDefURI }) => labwareDefURI === tiprackURI
+      ({ labwareDefURI }) => labwareDefURI === userSelectedTipRackURI
     )
+    tiprackURI = userSelectedTipRackURI
   }
 
   if (tiprackEntity == null) {

--- a/step-generation/src/fixtures/robotStateFixtures.ts
+++ b/step-generation/src/fixtures/robotStateFixtures.ts
@@ -352,7 +352,7 @@ export const getRobotStateWithTipStandard = (
   })
   robotStateWithTip.tipState.pipettes[DEFAULT_PIPETTE] = {
     hasTip: true,
-    tiprackURI: 'tiprackId',
+    tiprackURI: 'tiprack1Id',
   }
   return robotStateWithTip
 }
@@ -368,7 +368,7 @@ export const getRobotStatePickedUpTipStandard = (
   })
   robotStatePickedUpOneTip.tipState.pipettes[DEFAULT_PIPETTE] = {
     hasTip: true,
-    tiprackURI: 'tiprackId',
+    tiprackURI: 'tiprack1Id',
   }
   robotStatePickedUpOneTip.tipState.tipracks.tiprack1Id.A1 = EMPTY
   return robotStatePickedUpOneTip

--- a/step-generation/src/getNextRobotStateAndWarnings/forDropTip.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/forDropTip.ts
@@ -7,10 +7,6 @@ import { DIRTY } from '../constants'
 import type { DropTipParams } from '@opentrons/shared-data/protocol/types/schemaV6/command/pipetting'
 import type { InvariantContext, RobotStateAndWarnings } from '../types'
 
-//  NOTE(jr, 12/1/23): this state update is not in use currently for PD 8.0
-//  since we only support dropping tip into the waste chute or trash bin
-//  which are both addressableAreas (so the commands are moveToAddressableArea
-//  and dropTipInPlace) We will use this again when we add return tip.
 export function forDropTip(
   params: DropTipParams,
   invariantContext: InvariantContext,


### PR DESCRIPTION
# Overview

This is a temporary Python-only fix for AUTH-2537:

Previously, in step-generation for Transfer steps, we would emit a liquid class with:
```
pipette.transfer_with_liquid_class(
  liquid_class=protocol.define_liquid_class(
    properties={ ... : {"tip rack the user selected for this step": {
      ...
    }
  )
)
```
But this is wrong if the user wants a tip handling policy of "never" for this step, because "never" means we need to perform this transfer with the tip that we picked up from a **previous** step, which could have come from a different tip rack than the one the user selected for this step.

This bug would cause the generated protocol to fail analysis.

This PR changes step-generation to use the tip rack from `robotState.tipState.pipettes[pipette].tiprackURI` when generating Python for `changeTip=="never"`.

## Test Plan and Hands on Testing

Here is a protocol from PD before this fix, that demonstrates the bug. In Step 1, it uses `opentrons_96_tiprack_20ul`. In Step 2, it tries to use `opentrons_96_tiprack_10ul` with tip handling "never". PD successfully exports the protocol, but it fails in analysis: [Tip_Management_Never.py](https://github.com/user-attachments/files/23862930/Tip_Management_Never.py)

The protocol will pass analysis when it's re-exported from PD with this PR.

## Risk assessment

Low-medium. This logic is somewhat tricky.