### PR TITLE
fix(components,-protocol-designer): fix step number in tip selection modal header

### DIFF
--- a/components/src/molecules/WizardHeader/index.tsx
+++ b/components/src/molecules/WizardHeader/index.tsx
@@ -10,7 +10,6 @@ interface WizardHeaderProps {
   /* Optional copy override for the exit button. */
   exitButtonCopy?: string
   totalSteps?: number | null
-  // 1-indexed
   currentStep?: number | null
   exitDisabled?: boolean
   hideStepText?: boolean

--- a/components/src/molecules/WizardHeader/index.tsx
+++ b/components/src/molecules/WizardHeader/index.tsx
@@ -10,6 +10,7 @@ interface WizardHeaderProps {
   /* Optional copy override for the exit button. */
   exitButtonCopy?: string
   totalSteps?: number | null
+  // 1-indexed
   currentStep?: number | null
   exitDisabled?: boolean
   hideStepText?: boolean

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/TipSelectionModal.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/TipSelectionModal.tsx
@@ -50,7 +50,7 @@ export function TipSelectionModal(props: TipSelectionModalProps): JSX.Element {
   const header = (
     <WizardHeader
       title={t('select_tips_for_tracking')}
-      currentStep={currentStepIndex}
+      currentStep={currentStepIndex + 1}
       totalSteps={totalSteps}
       onExit={onClose}
     />


### PR DESCRIPTION
# Overview

ensure the `currentStep` prop passed to `WizardHeader` from `TipSelectionModal` is 1-indexed

Closes AUTH-2544

## Test Plan and Hands on Testing

- create transfer/mix step and open tip selection modal
- click through and ensure step number is present and accurate in wizard header

## Changelog

- fix prop passing to WizardHeader in TipSelectionModal
- add comment to `currentStep` prop in WizardHeader for clarity

## Review requests

see test plan

## Risk assessment

⬇️ 