### PR TITLE
fix(protocol-designer): make volume field title copy dynamic

### DIFF
--- a/protocol-designer/src/assets/localization/en/protocol_steps.json
+++ b/protocol-designer/src/assets/localization/en/protocol_steps.json
@@ -242,7 +242,11 @@
   "unoccupied_stack": "Stack of {{name}}",
   "valid_range": "Must be between 0.1 and {{max}} {{unit}}",
   "view_details": "View details",
-  "volume_per_well": "Volume per well",
+  "volume_per_well": {
+    "multiAspirate": "Aspirate volume per well",
+    "multiDispense": "Dispense volume per well",
+    "single": "Volume per well"
+  },
   "well_name": "Well {{wellName}}",
   "well_order_title": "{{prefix}} well order",
   "well_position": "Well position: X {{x}} Y {{y}} Z {{z}} (mm)",

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/VolumeField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/VolumeField.tsx
@@ -2,17 +2,24 @@ import { useTranslation } from 'react-i18next'
 
 import { InputStepFormField } from '/protocol-designer/components/molecules'
 
+import type { PathOption } from '/protocol-designer/form-types'
 import type { FieldProps } from '../types'
 
-export function VolumeField(props: FieldProps): JSX.Element {
+interface VolumeFieldProps {
+  fieldProps: FieldProps
+  path?: PathOption
+}
+
+export function VolumeField(props: VolumeFieldProps): JSX.Element {
   const { t } = useTranslation(['protocol_steps', 'application'])
+  const { fieldProps, path = 'single' } = props
 
   return (
     <InputStepFormField
-      title={t('volume_per_well')}
+      title={t(`volume_per_well.${path}`)}
       units={t('application:units.microliter')}
       showTooltip={false}
-      {...props}
+      {...fieldProps}
     />
   )
 }

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MixTools/FirstStepMixTools.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MixTools/FirstStepMixTools.tsx
@@ -66,7 +66,7 @@ export function FirstStepMixTools({
         hasFormError={propsForFields.wells.errorToShow != null}
       />
       <Divider marginY="0" />
-      <VolumeField {...propsForFields.volume} />
+      <VolumeField fieldProps={propsForFields.volume} />
       <Divider marginY="0" />
       <InputStepFormField
         {...propsForFields.times}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/FirstStepMoveLiquidTools.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/FirstStepMoveLiquidTools.tsx
@@ -120,7 +120,7 @@ export function FirstStepMoveLiquidTools({
         title={t('pipette_path')}
       />
       <Divider marginY="0" />
-      <VolumeField {...propsForFields.volume} />
+      <VolumeField fieldProps={propsForFields.volume} path={formData.path} />
     </Flex>
   )
 }


### PR DESCRIPTION
# Overview

Correctly reflect volume field title for moveLiquid volume field depending on path according to designs. The pattern is as follows:

- single path -> "Volume per well"
- distribute path -> "Dispense volume per well"
- consolidate path -> "Aspirate volume per well"

Closes AUTH-2543

## Test Plan and Hands on Testing

- open any protocol with a mix and moveLiquid step
- inspect moveLiquid step, toggle different paths and verify that copy matches pattern above
- open mix step and verify that copy remains "Volume per well"

## Changelog

- dynamic copy for `VolumeField` title depending on path
- prop refactoring in `FirstStep[Mix/MoveLiquid]Tools`
- new translations

## Review requests

see test plan

## Risk assessment

low