### PR TITLE
fix(app): fix pipette card disablement during run

### DIFF
--- a/app/src/assets/localization/en/device_details.json
+++ b/app/src/assets/localization/en/device_details.json
@@ -169,7 +169,7 @@
   "reset_estop": "Reset E-stop",
   "resume_operation": "Resume operation",
   "right": "right",
-  "robot_control_not_available": "Some robot controls are not available when run is in progress or robot is busy",
+  "robot_control_not_available": "Some robot controls are not available when run is in progress",
   "robot_initializing": "Initializing...",
   "run": "Run",
   "run_a_protocol": "Run a protocol",

--- a/app/src/organisms/Desktop/Devices/GripperCard/__tests__/GripperCard.test.tsx
+++ b/app/src/organisms/Desktop/Devices/GripperCard/__tests__/GripperCard.test.tsx
@@ -39,7 +39,7 @@ describe('GripperCard', () => {
         },
       } as GripperData,
       isCalibrated: true,
-      isRobotBusy: false,
+      isRunActive: false,
       isEstopNotDisengaged: false,
     }
     vi.mocked(GripperWizardFlows).mockReturnValue(<>wizard flow launched</>)
@@ -79,7 +79,7 @@ describe('GripperCard', () => {
         },
       } as GripperData,
       isCalibrated: false,
-      isRobotBusy: false,
+      isRunActive: false,
       isEstopNotDisengaged: false,
     }
 
@@ -102,7 +102,7 @@ describe('GripperCard', () => {
         },
       } as GripperData,
       isCalibrated: false,
-      isRobotBusy: false,
+      isRunActive: false,
       isEstopNotDisengaged: true,
     }
 
@@ -145,7 +145,7 @@ describe('GripperCard', () => {
     props = {
       attachedGripper: null,
       isCalibrated: false,
-      isRobotBusy: false,
+      isRunActive: false,
       isEstopNotDisengaged: false,
     }
     render(props)
@@ -163,7 +163,7 @@ describe('GripperCard', () => {
         ok: false,
       } as any,
       isCalibrated: false,
-      isRobotBusy: false,
+      isRunActive: false,
       isEstopNotDisengaged: false,
     }
     render(props)
@@ -182,7 +182,7 @@ describe('GripperCard', () => {
         ok: false,
       } as any,
       isCalibrated: true,
-      isRobotBusy: false,
+      isRunActive: false,
       isEstopNotDisengaged: false,
     }
     render(props)

--- a/app/src/organisms/Desktop/Devices/GripperCard/index.tsx
+++ b/app/src/organisms/Desktop/Devices/GripperCard/index.tsx
@@ -20,7 +20,7 @@ import type { GripperWizardFlowType } from '/app/organisms/GripperWizardFlows/ty
 interface GripperCardProps {
   attachedGripper: GripperData | BadGripper | null
   isCalibrated: boolean
-  isRobotBusy: boolean
+  isRunActive: boolean
   isEstopNotDisengaged: boolean
 }
 
@@ -39,7 +39,7 @@ const POLL_DURATION_MS = 5000
 export function GripperCard({
   attachedGripper,
   isCalibrated,
-  isRobotBusy,
+  isRunActive,
   isEstopNotDisengaged,
 }: GripperCardProps): JSX.Element {
   const { t, i18n } = useTranslation(['device_details', 'shared'])
@@ -89,7 +89,7 @@ export function GripperCard({
       ? [
           {
             label: t('attach_gripper'),
-            disabled: attachedGripper != null || isRobotBusy,
+            disabled: attachedGripper != null || isRunActive,
             onClick: handleAttach,
           },
         ]
@@ -99,12 +99,12 @@ export function GripperCard({
               attachedGripper.data.calibratedOffset?.last_modified != null
                 ? t('recalibrate_gripper')
                 : t('calibrate_gripper'),
-            disabled: attachedGripper == null || isRobotBusy,
+            disabled: attachedGripper == null || isRunActive,
             onClick: handleCalibrate,
           },
           {
             label: t('detach_gripper'),
-            disabled: attachedGripper == null || isRobotBusy,
+            disabled: attachedGripper == null || isRunActive,
             onClick: handleDetach,
           },
           {

--- a/app/src/organisms/Desktop/Devices/InstrumentsAndModules.tsx
+++ b/app/src/organisms/Desktop/Devices/InstrumentsAndModules.tsx
@@ -24,6 +24,7 @@ import { ModuleCard } from '/app/organisms/ModuleCard'
 import { useModuleApiRequests } from '/app/organisms/ModuleCard/utils'
 import { useIsFlex } from '/app/redux-resources/robots'
 import { useIsEstopNotDisengaged } from '/app/resources/devices/hooks/useIsEstopNotDisengaged'
+import { useCurrentRunId, useRunStatuses } from '/app/resources/runs'
 import { getShowPipetteCalibrationWarning } from '/app/transformations/instruments'
 
 import { GripperCard } from './GripperCard'
@@ -42,13 +43,11 @@ const EQUIPMENT_POLL_MS = 5000
 interface InstrumentsAndModulesProps {
   robotName: string
   isRobotViewable: boolean
-  isRobotBusy: boolean
 }
 
 export function InstrumentsAndModules({
   robotName,
   isRobotViewable,
-  isRobotBusy,
 }: InstrumentsAndModulesProps): JSX.Element | null {
   const { t } = useTranslation(['device_details', 'shared'])
   const isFlex = useIsFlex(robotName)
@@ -59,6 +58,8 @@ export function InstrumentsAndModules({
       enabled: !isFlex,
     }
   )?.data ?? { left: undefined, right: undefined }
+  const currentRunId = useCurrentRunId()
+  const { isRunTerminal, isRunRunning } = useRunStatuses()
   const isEstopNotDisengaged = useIsEstopNotDisengaged(robotName)
   const [getLatestRequestId, handleModuleApiRequests] = useModuleApiRequests()
 
@@ -138,7 +139,7 @@ export function InstrumentsAndModules({
         width="100%"
         flexDirection={DIRECTION_COLUMN}
       >
-        {isRobotBusy && (
+        {currentRunId != null && !isRunTerminal && (
           <Flex
             paddingBottom={SPACING.spacing16}
             flexDirection={DIRECTION_COLUMN}
@@ -150,7 +151,7 @@ export function InstrumentsAndModules({
         )}
         {isRobotViewable &&
         getShowPipetteCalibrationWarning(attachedInstruments) &&
-        !isRobotBusy ? (
+        (isRunTerminal || currentRunId == null) ? (
           <Flex paddingBottom={SPACING.spacing16} width="100%">
             <PipetteRecalibrationWarning />
           </Flex>
@@ -173,7 +174,7 @@ export function InstrumentsAndModules({
                   }
                   mount={LEFT}
                   robotName={robotName}
-                  isRobotBusy={isRobotBusy}
+                  isRunActive={currentRunId != null && isRunRunning}
                   isEstopNotDisengaged={isEstopNotDisengaged}
                 />
               ) : (
@@ -188,7 +189,7 @@ export function InstrumentsAndModules({
                         : null
                     }
                     mount={LEFT}
-                    isRobotBusy={isRobotBusy}
+                    isRunActive={currentRunId != null && isRunRunning}
                     isEstopNotDisengaged={isEstopNotDisengaged}
                   />
                   <GripperCard
@@ -198,7 +199,7 @@ export function InstrumentsAndModules({
                       attachedGripper?.data?.calibratedOffset?.last_modified !=
                         null
                     }
-                    isRobotBusy={isRobotBusy}
+                    isRunActive={currentRunId != null && isRunRunning}
                     isEstopNotDisengaged={isEstopNotDisengaged}
                   />
                 </>
@@ -235,7 +236,7 @@ export function InstrumentsAndModules({
                   }
                   mount={RIGHT}
                   robotName={robotName}
-                  isRobotBusy={isRobotBusy}
+                  isRunActive={currentRunId != null && isRunRunning}
                   isEstopNotDisengaged={isEstopNotDisengaged}
                 />
               ) : null}
@@ -250,7 +251,7 @@ export function InstrumentsAndModules({
                       : null
                   }
                   mount={RIGHT}
-                  isRobotBusy={isRobotBusy}
+                  isRunActive={currentRunId != null && isRunRunning}
                   isEstopNotDisengaged={isEstopNotDisengaged}
                 />
               ) : null}

--- a/app/src/organisms/Desktop/Devices/PipetteCard/FlexPipetteCard.tsx
+++ b/app/src/organisms/Desktop/Devices/PipetteCard/FlexPipetteCard.tsx
@@ -42,7 +42,7 @@ interface FlexPipetteCardProps {
   attachedPipette: PipetteData | BadPipette | null
   pipetteModelSpecs: PipetteModelSpecs | null
   mount: Mount
-  isRobotBusy: boolean
+  isRunActive: boolean
   isEstopNotDisengaged: boolean
 }
 
@@ -62,7 +62,7 @@ export function FlexPipetteCard({
   pipetteModelSpecs,
   attachedPipette,
   mount,
-  isRobotBusy,
+  isRunActive,
   isEstopNotDisengaged,
 }: FlexPipetteCardProps): JSX.Element {
   const { t, i18n } = useTranslation(['device_details', 'shared'])
@@ -144,7 +144,7 @@ export function FlexPipetteCard({
       ? [
           {
             label: t('attach_pipette'),
-            disabled: attachedPipette != null || isRobotBusy,
+            disabled: attachedPipette != null || isRunActive,
             onClick: handleChoosePipette,
           },
         ]
@@ -154,12 +154,12 @@ export function FlexPipetteCard({
               attachedPipette.data.calibratedOffset?.last_modified != null
                 ? t('recalibrate_pipette')
                 : t('calibrate_pipette'),
-            disabled: attachedPipette == null || isRobotBusy,
+            disabled: attachedPipette == null || isRunActive,
             onClick: handleCalibrate,
           },
           {
             label: t('detach_pipette'),
-            disabled: attachedPipette == null || isRobotBusy,
+            disabled: attachedPipette == null || isRunActive,
             onClick: handleDetach,
           },
           {
@@ -171,7 +171,7 @@ export function FlexPipetteCard({
           },
           {
             label: i18n.format(t('drop_tips'), 'capitalize'),
-            disabled: attachedPipette == null || isRobotBusy,
+            disabled: attachedPipette == null || isRunActive,
             onClick: () => {
               enableDTWiz()
             },

--- a/app/src/organisms/Desktop/Devices/PipetteCard/__tests__/FlexPipetteCard.test.tsx
+++ b/app/src/organisms/Desktop/Devices/PipetteCard/__tests__/FlexPipetteCard.test.tsx
@@ -58,7 +58,7 @@ describe('FlexPipetteCard', () => {
         },
       } as PipetteData,
       mount: 'left',
-      isRobotBusy: false,
+      isRunActive: false,
       isEstopNotDisengaged: false,
     }
     vi.mocked(useCurrentSubsystemUpdateQuery).mockReturnValue({
@@ -110,7 +110,7 @@ describe('FlexPipetteCard', () => {
         },
       } as PipetteData,
       mount: 'left',
-      isRobotBusy: false,
+      isRunActive: false,
       isEstopNotDisengaged: false,
     }
     render(props)
@@ -136,7 +136,7 @@ describe('FlexPipetteCard', () => {
         },
       } as PipetteData,
       mount: 'left',
-      isRobotBusy: false,
+      isRunActive: false,
       isEstopNotDisengaged: false,
     }
 
@@ -164,7 +164,7 @@ describe('FlexPipetteCard', () => {
         },
       } as PipetteData,
       mount: 'left',
-      isRobotBusy: false,
+      isRunActive: false,
       isEstopNotDisengaged: true,
     }
 
@@ -187,7 +187,7 @@ describe('FlexPipetteCard', () => {
       mount: 'left',
       attachedPipette: null,
       pipetteModelSpecs: null,
-      isRobotBusy: false,
+      isRunActive: false,
       isEstopNotDisengaged: false,
     }
     render(props)
@@ -236,7 +236,7 @@ describe('FlexPipetteCard', () => {
       } as any,
       mount: 'left',
       pipetteModelSpecs: null,
-      isRobotBusy: false,
+      isRunActive: false,
       isEstopNotDisengaged: false,
     }
     render(props)
@@ -256,7 +256,7 @@ describe('FlexPipetteCard', () => {
       } as any,
       mount: 'left',
       pipetteModelSpecs: null,
-      isRobotBusy: false,
+      isRunActive: false,
       isEstopNotDisengaged: false,
     }
     render(props)

--- a/app/src/organisms/Desktop/Devices/PipetteCard/__tests__/PipetteCard.test.tsx
+++ b/app/src/organisms/Desktop/Devices/PipetteCard/__tests__/PipetteCard.test.tsx
@@ -45,7 +45,7 @@ describe('PipetteCard', () => {
       mount: LEFT,
       robotName: mockRobotName,
       pipetteId: 'id',
-      isRobotBusy: false,
+      isRunActive: false,
       isEstopNotDisengaged: false,
     }
     vi.mocked(PipetteOverflowMenu).mockReturnValue(
@@ -72,7 +72,7 @@ describe('PipetteCard', () => {
       mount: LEFT,
       robotName: mockRobotName,
       pipetteId: 'id',
-      isRobotBusy: false,
+      isRunActive: false,
       isEstopNotDisengaged: false,
     }
     render(props)
@@ -86,7 +86,7 @@ describe('PipetteCard', () => {
       mount: RIGHT,
       robotName: mockRobotName,
       pipetteId: 'id',
-      isRobotBusy: false,
+      isRunActive: false,
       isEstopNotDisengaged: false,
     }
     render(props)
@@ -98,7 +98,7 @@ describe('PipetteCard', () => {
       pipetteModelSpecs: null,
       mount: RIGHT,
       robotName: mockRobotName,
-      isRobotBusy: false,
+      isRunActive: false,
       isEstopNotDisengaged: false,
     }
     render(props)
@@ -110,7 +110,7 @@ describe('PipetteCard', () => {
       pipetteModelSpecs: null,
       mount: LEFT,
       robotName: mockRobotName,
-      isRobotBusy: false,
+      isRunActive: false,
       isEstopNotDisengaged: false,
     }
     render(props)
@@ -122,7 +122,7 @@ describe('PipetteCard', () => {
       pipetteModelSpecs: mockLeftSpecs,
       mount: LEFT,
       robotName: mockRobotName,
-      isRobotBusy: false,
+      isRunActive: false,
       isEstopNotDisengaged: false,
     }
     render(props)
@@ -133,7 +133,7 @@ describe('PipetteCard', () => {
       pipetteModelSpecs: mockRightSpecs,
       mount: RIGHT,
       robotName: mockRobotName,
-      isRobotBusy: false,
+      isRunActive: false,
       isEstopNotDisengaged: false,
     }
     render(props)

--- a/app/src/organisms/Desktop/Devices/PipetteCard/index.tsx
+++ b/app/src/organisms/Desktop/Devices/PipetteCard/index.tsx
@@ -40,7 +40,7 @@ interface PipetteCardProps {
   pipetteId?: AttachedPipette['id'] | null
   mount: Mount
   robotName: string
-  isRobotBusy: boolean
+  isRunActive: boolean
   isEstopNotDisengaged: boolean
 }
 
@@ -54,7 +54,7 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
     mount,
     robotName,
     pipetteId,
-    isRobotBusy,
+    isRunActive,
     isEstopNotDisengaged,
   } = props
   const {
@@ -212,7 +212,7 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
               handleSettingsSlideout={handleSettingsSlideout}
               handleAboutSlideout={handleAboutSlideout}
               pipetteSettings={settings}
-              isRunActive={isRobotBusy}
+              isRunActive={isRunActive}
             />
           </Box>
           {menuOverlay}

--- a/app/src/organisms/Desktop/Devices/__tests__/InstrumentsAndModules.test.tsx
+++ b/app/src/organisms/Desktop/Devices/__tests__/InstrumentsAndModules.test.tsx
@@ -61,7 +61,6 @@ describe('InstrumentsAndModules', () => {
     props = {
       robotName: ROBOT_NAME,
       isRobotViewable: true,
-      isRobotBusy: false,
     }
     vi.mocked(useCurrentRunId).mockReturnValue(null)
     vi.mocked(useRunStatuses).mockReturnValue({
@@ -125,9 +124,9 @@ describe('InstrumentsAndModules', () => {
   })
   it('renders the protocol loaded banner when protocol is loaded and not terminal state', () => {
     vi.mocked(useCurrentRunId).mockReturnValue('RUNID')
-    render({ ...props, isRobotBusy: true })
+    render({ ...props })
     screen.getByText(
-      'Some robot controls are not available when run is in progress or robot is busy'
+      'Some robot controls are not available when run is in progress'
     )
   })
   it('renders 1 pipette card when a 96 channel is attached', () => {

--- a/app/src/pages/Desktop/Devices/DeviceDetails/DeviceDetailsComponent.tsx
+++ b/app/src/pages/Desktop/Devices/DeviceDetails/DeviceDetailsComponent.tsx
@@ -83,7 +83,6 @@ export function DeviceDetailsComponent({
         <InstrumentsAndModules
           robotName={robotName}
           isRobotViewable={isRobotViewable}
-          isRobotBusy={isRobotBusy}
         />
         {isRobotViewable && (
           <>


### PR DESCRIPTION
Closes [RQA-4921](https://opentrons.atlassian.net/browse/RQA-4921)

# Overview

In https://github.com/Opentrons/opentrons/pull/20088, we simplified the "robot is busy" banner state in robot settings by using a simplified conditional check, `useRobotIsBusy`. That works great for the robot settings page, and while we tried to harmonize the "busy" state logic by extending it to the robot details page, that didn't work out as well: we want users to be able to swap/calibrate pipettes on this page while a run is being set up. It's the only way to do so on the OT-2, too, so we definitely can't block it. 

This PR effectively reverts the changes made in #20088 to the robot details page. 

### Current Behavior

<img width="1017" height="762" alt="Screenshot 2025-12-01 at 2 55 51 PM" src="https://github.com/user-attachments/assets/201d3aa7-6248-40b5-91e3-a8c2ff9f8d63" />

### Fixed Behavior

<img width="1025" height="771" alt="Screenshot 2025-12-01 at 3 23 05 PM" src="https://github.com/user-attachments/assets/2a9b8e5d-08f9-4fa0-af6b-148bd0b1b064" />


## Test Plan and Hands on Testing

- See screenshot.

## Changelog

- Fixed the pipette attachment/calibration and drop tip flows being disabled during a run. 

## Risk assessment

very low, just a reversion of changes made from a previous PR

[RQA-4921]: https://opentrons.atlassian.net/browse/RQA-4921?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ