### PR TITLE
refactor(protocol-designer): Delete old unused forced scroll workaround

### DIFF
--- a/protocol-designer/src/ui/steps/actions/actions.ts
+++ b/protocol-designer/src/ui/steps/actions/actions.ts
@@ -9,7 +9,6 @@ import {
 import { selectors as stepFormSelectors } from '../../../step-forms'
 import { PRESAVED_STEP_ID } from '../../../steplist/types'
 import { getMultiSelectLastSelected } from '../selectors'
-import { resetScrollElements } from '../utils'
 
 import type { Timeline } from '@opentrons/step-generation'
 import type { AnalyticsEventAction } from '../../../analytics/actions'
@@ -142,7 +141,6 @@ export const resetSelectStep =
         mode: 'clear',
       },
     })
-    resetScrollElements()
   }
 
 const setSelection = (
@@ -234,7 +232,6 @@ export const populateForm =
       payload: formData,
     })
     setSelection(formData, dispatch)
-    resetScrollElements()
   }
 
 export const selectStep =

--- a/protocol-designer/src/ui/steps/utils.ts
+++ b/protocol-designer/src/ui/steps/utils.ts
@@ -1,23 +1,5 @@
-import forEach from 'lodash/forEach'
-
 import type { StepFieldName } from '../../form-types'
 
-export const MAIN_CONTENT_FORCED_SCROLL_CLASSNAME = 'main_content_forced_scroll'
-// scroll to top of all elements with the special class (probably the main page wrapper)
-//
-// TODO (ka 2019-10-28): This is a workaround, see #4446
-// but it solves the modal positioning problem caused by main page wrapper
-// being positioned absolute until we can figure out something better
-export const resetScrollElements = (): void => {
-  forEach(
-    global.document.getElementsByClassName(
-      MAIN_CONTENT_FORCED_SCROLL_CLASSNAME
-    ),
-    elem => {
-      elem.scrollTop = 0
-    }
-  )
-}
 type DisabledFields = Record<string, string>
 const batchEditMoveLiquidPipetteDifferentDisabledFieldNames: StepFieldName[] = [
   // aspirate


### PR DESCRIPTION
## Overview

This deletes an old hack, having something to do with modal positioning, that hasn't been used since the code for the old designs got deleted in #16653.

## Test Plan and Hands on Testing

* [x] Search the code for `MAIN_CONTENT_FORCED_SCROLL_CLASSNAME` and `main_content_forced_scroll` and make sure nothing is using this anymore.

## Review requests

None in particular.

## Risk assessment

Low.