### PR TITLE
fix(app): remove scrollbar from second window

### DIFF
--- a/app/src/organisms/Desktop/ProtocolVisualization/SlotDetails/slotdetails.module.css
+++ b/app/src/organisms/Desktop/ProtocolVisualization/SlotDetails/slotdetails.module.css
@@ -1,16 +1,20 @@
 .slot_container {
   display: flex;
   width: 100%;
+  height: 100%;
   flex-direction: column;
-  padding-right: var(--spacing-16);
   gap: var(--spacing-8);
 }
 
 .slot_details {
-  height: 100vh;
+  height: 100%;
   border-radius: var(--border-radius-8);
   background-color: var(--white);
-  overflow-y: scroll;
+  overflow-y: auto;
+}
+
+.slot_details::-webkit-scrollbar {
+  display: none;
 }
 
 .command_step_header {


### PR DESCRIPTION


# Overview
remove scrollbar from second window

### before
<img width="501" height="453" alt="Screenshot 2025-12-01 at 6 12 29 PM" src="https://github.com/user-attachments/assets/39fa145a-0a7c-43b7-8bea-057f41c1702a" />

### after
<img width="501" height="444" alt="Screenshot 2025-12-01 at 6 27 04 PM" src="https://github.com/user-attachments/assets/5f6b34e1-097b-4c74-a292-069cc9f8d098" />

AUTH-2534

## Test Plan and Hands on Testing
- select a protocol from the protocol landing page
- click visualization button
- click deck view to open the second window
check that the second window doesn't display scrollbar 

## Changelog
- modify slotdetails.module.css

## Review requests


## Risk assessment
low

