### PR TITLE
refactor(step-generation): HOPPER_STACKER_LOCATION const and fix retrieve command creator

### DIFF
--- a/step-generation/src/__tests__/flexStackerRetrieve.test.ts
+++ b/step-generation/src/__tests__/flexStackerRetrieve.test.ts
@@ -4,13 +4,13 @@ import {
   fixture96Plate,
   FLEX_STACKER_MODULE_TYPE,
   FLEX_STACKER_MODULE_V1,
-  LabwareDefinition2,
 } from '@opentrons/shared-data'
 
 import { flexStackerRetrieve } from '../commandCreators/atomic/flexStackerRetrieve'
 import { HOPPER_STACKER_LOCATION } from '../constants'
 import { getInitialRobotStateStandard, makeContext } from '../fixtures'
 
+import type { LabwareDefinition2 } from '@opentrons/shared-data'
 import type { InvariantContext, RobotState } from '../types'
 
 const mockLabwareId = 'labwareId'

--- a/step-generation/src/__tests__/flexStackerRetrieve.test.ts
+++ b/step-generation/src/__tests__/flexStackerRetrieve.test.ts
@@ -1,35 +1,90 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
+  fixture96Plate,
   FLEX_STACKER_MODULE_TYPE,
   FLEX_STACKER_MODULE_V1,
+  LabwareDefinition2,
 } from '@opentrons/shared-data'
 
 import { flexStackerRetrieve } from '../commandCreators/atomic/flexStackerRetrieve'
+import { HOPPER_STACKER_LOCATION } from '../constants'
 import { getInitialRobotStateStandard, makeContext } from '../fixtures'
 
 import type { InvariantContext, RobotState } from '../types'
 
-const moduleId = 'flexStackerId'
+const mockLabwareId = 'labwareId'
+const mockLabwareId2 = 'labwareId2'
+const mockLabwareId3 = 'labwareId3'
+const mockModuleId = 'flexStackerId'
 vi.mock('../robotStateSelectors')
 
-describe('flexStackerStore', () => {
+describe('flexStackerRetrieve', () => {
   let invariantContext: InvariantContext
   let robotState: RobotState
   beforeEach(() => {
     invariantContext = makeContext()
     robotState = getInitialRobotStateStandard(invariantContext)
-    invariantContext.moduleEntities[moduleId] = {
-      id: moduleId,
+    invariantContext.moduleEntities[mockModuleId] = {
+      id: mockModuleId,
       type: FLEX_STACKER_MODULE_TYPE,
       model: FLEX_STACKER_MODULE_V1,
       pythonName: 'mock_flex_stacker_1',
     }
   })
   it('creates flex stacker retrieve command', () => {
+    robotState = {
+      ...robotState,
+      modules: {
+        [mockModuleId]: {
+          slot: 'D3',
+          moduleState: {} as any,
+        },
+      },
+      labware: {
+        [mockLabwareId]: {
+          stack: [mockLabwareId, HOPPER_STACKER_LOCATION, mockModuleId, 'D3'],
+        },
+        [mockLabwareId2]: {
+          stack: [
+            mockLabwareId2,
+            mockLabwareId,
+            HOPPER_STACKER_LOCATION,
+            mockModuleId,
+            'D3',
+          ],
+        },
+        [mockLabwareId3]: {
+          stack: [mockLabwareId3, mockModuleId, 'D3'],
+        },
+      },
+    }
+    invariantContext = {
+      ...invariantContext,
+      labwareEntities: {
+        [mockLabwareId]: {
+          labwareDefURI: 'mockURI',
+          def: fixture96Plate as LabwareDefinition2,
+          pythonName: 'wellPlate_1',
+          id: mockLabwareId,
+        },
+        [mockLabwareId2]: {
+          labwareDefURI: 'mockURI',
+          def: fixture96Plate as LabwareDefinition2,
+          pythonName: 'wellPlate_2',
+          id: mockLabwareId2,
+        },
+        [mockLabwareId3]: {
+          labwareDefURI: 'mockURI',
+          def: fixture96Plate as LabwareDefinition2,
+          pythonName: 'wellPlate_3',
+          id: mockLabwareId3,
+        },
+      },
+    }
     const result = flexStackerRetrieve(
       {
-        moduleId,
+        moduleId: mockModuleId,
       },
       invariantContext,
       robotState
@@ -40,11 +95,11 @@ describe('flexStackerStore', () => {
           commandType: 'flexStacker/retrieve',
           key: expect.any(String),
           params: {
-            moduleId,
+            moduleId: mockModuleId,
           },
         },
       ],
-      python: 'mock_flex_stacker_1.retrieve()',
+      python: 'wellPlate_1 = mock_flex_stacker_1.retrieve()',
     })
   })
 })

--- a/step-generation/src/commandCreators/atomic/flexStackerRetrieve.ts
+++ b/step-generation/src/commandCreators/atomic/flexStackerRetrieve.ts
@@ -1,13 +1,22 @@
-import { uuid } from '../../utils'
+import { getLargestStackInSlot, uuid } from '../../utils'
 
 import type { FlexStackerRetrieveCreateCommand } from '@opentrons/shared-data'
 import type { CommandCreator } from '../../types'
 
 export const flexStackerRetrieve: CommandCreator<
   FlexStackerRetrieveCreateCommand['params']
-> = (args, invariantContext) => {
+> = (args, invariantContext, robotState) => {
   const { moduleId } = args
-  const pythonName = invariantContext.moduleEntities[moduleId].pythonName
+  const { modules, labware } = robotState
+  const { moduleEntities, labwareEntities } = invariantContext
+  const modulePythonName = moduleEntities[moduleId].pythonName
+  const moduleLocation = modules[moduleId].slot
+  const largestStackInSlot = getLargestStackInSlot(labware, moduleLocation)
+  // -4 to account for slot, Hopper const, and moduleId that occurs before it
+  const labwareIdOnModule = largestStackInSlot[largestStackInSlot.length - 4]
+  const labwarePythonName = labwareEntities[labwareIdOnModule]?.pythonName
+  //  TODO: add error creator if there is no labware in the stack
+
   return {
     commands: [
       {
@@ -18,6 +27,6 @@ export const flexStackerRetrieve: CommandCreator<
         },
       },
     ],
-    python: `${pythonName}.retrieve()`,
+    python: `${labwarePythonName} = ${modulePythonName}.retrieve()`,
   }
 }

--- a/step-generation/src/commandCreators/atomic/flexStackerRetrieve.ts
+++ b/step-generation/src/commandCreators/atomic/flexStackerRetrieve.ts
@@ -1,4 +1,4 @@
-import { getLargestStackInSlot, uuid } from '../../utils'
+import { getLabwareIdOnHopper, uuid } from '../../utils'
 
 import type { FlexStackerRetrieveCreateCommand } from '@opentrons/shared-data'
 import type { CommandCreator } from '../../types'
@@ -11,9 +11,7 @@ export const flexStackerRetrieve: CommandCreator<
   const { moduleEntities, labwareEntities } = invariantContext
   const modulePythonName = moduleEntities[moduleId].pythonName
   const moduleLocation = modules[moduleId].slot
-  const largestStackInSlot = getLargestStackInSlot(labware, moduleLocation)
-  // -4 to account for slot, Hopper const, and moduleId that occurs before it
-  const labwareIdOnModule = largestStackInSlot[largestStackInSlot.length - 4]
+  const labwareIdOnModule = getLabwareIdOnHopper(labware, moduleLocation)
   const labwarePythonName = labwareEntities[labwareIdOnModule]?.pythonName
   //  TODO: add error creator if there is no labware in the stack
 

--- a/step-generation/src/commandCreators/atomic/flexStackerRetrieve.ts
+++ b/step-generation/src/commandCreators/atomic/flexStackerRetrieve.ts
@@ -13,7 +13,7 @@ export const flexStackerRetrieve: CommandCreator<
   const moduleLocation = modules[moduleId].slot
   const labwareIdOnModule = getLabwareIdOnHopper(labware, moduleLocation)
   const labwarePythonName = labwareEntities[labwareIdOnModule]?.pythonName
-  //  TODO: add error creator if there is no labware in the stack
+  //  TODO: add error creator if there is no labware in the hopper
 
   return {
     commands: [

--- a/step-generation/src/constants.ts
+++ b/step-generation/src/constants.ts
@@ -95,3 +95,5 @@ export const AUTOMATIC: 'automatic' = 'automatic'
 export const MANUAL: 'manual' = 'manual'
 
 export const STAGING_AREA_SLOTS = ['A4', 'B4', 'C4', 'D4']
+
+export const HOPPER_STACKER_LOCATION = 'hopper'

--- a/step-generation/src/utils/misc.ts
+++ b/step-generation/src/utils/misc.ts
@@ -34,7 +34,13 @@ import {
   dispenseInTrash,
   dispenseInWasteChute,
 } from '../commandCreators/compound'
-import { CLEAN, EMPTY, STAGING_AREA_SLOTS, ZERO_OFFSET } from '../constants'
+import {
+  CLEAN,
+  EMPTY,
+  HOPPER_STACKER_LOCATION,
+  STAGING_AREA_SLOTS,
+  ZERO_OFFSET,
+} from '../constants'
 import { curryCommandCreator } from './curryCommandCreator'
 import { reduceCommandCreators, uuid } from './index'
 
@@ -1344,4 +1350,16 @@ export function createStagingAreaForInvariantContext(
     }
   }
   return {}
+}
+
+export const getLabwareIdOnHopper = (
+  labware: {
+    [labwareId: string]: LabwareTemporalProperties
+  },
+  moduleSlotLocation: string
+): string => {
+  const largestStackInSlot = getLargestStackInSlot(labware, moduleSlotLocation)
+  const indexOfHopper = largestStackInSlot.indexOf(HOPPER_STACKER_LOCATION)
+  const labwareIdOnModule = largestStackInSlot[indexOfHopper - 1]
+  return labwareIdOnModule
 }


### PR DESCRIPTION
closes EXEC-2802

# Overview

create `HOPPER_STACKER_LOCATION` const in constants and then add the python name you are retrieving to the retrieve command creator/python generation

## Test Plan and Hands on Testing

review the code, no way to smoke test this yet. i added a test case so it should work

## Changelog

fix up the retrieve command creator and create the hopper constant

## Risk assessment

low
