### PR TITLE
chore(cursor): Configure worktree setup

### DIFF
--- a/.cursor/worktrees.json
+++ b/.cursor/worktrees.json
@@ -1,0 +1,3 @@
+{
+  "setup-worktree": ["pyenv local 3.10", "make setup || make setup"]
+}


### PR DESCRIPTION
## Overview

Cursor can run agents in isolated Git worktrees to avoid disturbing your primary working copy, which is cool. Each new worktree needs to have its development environment set up, though. This tries to configure Cursor to do that automatically, so agents can jump straight to running things like `yarn vitest` without you having to manually run `make setup` first.

## Test Plan and Hands on Testing

1. Make sure Cursor is updated. I think older versions had a bug where the agent could start running commands before the initialization script completed.
2. Start a new agent [in worktree mode](https://cursor.com/docs/configuration/worktrees#basic-worktree-usage). Prompt it with something like:

   > Run `make check-js` to see if the environment is set up properly.

   This will take a few minutes, but it should run the command, and the command should complete without errors.

## Changelog

* Add a Cursor [worktree initialization script](https://cursor.com/docs/configuration/worktrees#initialization-script).

## Review requests

* If you use Cursor, run the test plan above and see if it works on your machine without modification. The script assumes things about how the global environment is set up—that it uses pyenv, for example, and that `yarn` is globally available. These assumptions match the recommendations in `DEV_SETUP.md`, but I still only give it a 50% chance of working. :)
* Another way of doing this would be to have a natural-language rule file pointing towards our `DEV_SETUP.md`, and then Cursor could theoretically just follow the instructions in there. That would be nice if it works, because it would benefit local mode as well as worktree mode. I haven't tried it, but I could, if we think it's worthwhile.

## Risk assessment

No risk.