### PR TITLE
fix(robot-server): Ensure maintenance runs properly cleanup and manage live stream

### DIFF
--- a/api/src/opentrons/system/camera.py
+++ b/api/src/opentrons/system/camera.py
@@ -158,7 +158,7 @@ async def update_live_stream_status(
         and camera_enable_settings.liveStreamEnabled
     ):
         # Check to see if the camera device is available
-        raw_device = str(contents["SOURCE"])[1:-1]
+        raw_device = str(contents["SOURCE"])
         if not os.path.exists(raw_device):
             log.error(
                 f"Opentrons Live Stream cannot sample the camera. No video device found with device path: {raw_device}"

--- a/robot-server/robot_server/maintenance_runs/maintenance_run_data_manager.py
+++ b/robot-server/robot_server/maintenance_runs/maintenance_run_data_manager.py
@@ -19,7 +19,10 @@ from .maintenance_run_models import MaintenanceRun, MaintenanceRunNotFoundError
 from opentrons.protocol_engine.types import DeckConfigurationType
 
 from robot_server.service.notifications import MaintenanceRunsPublisher
-from opentrons.protocol_engine.resources.camera_provider import CameraProvider
+from opentrons.protocol_engine.resources.camera_provider import (
+    CameraProvider,
+    CameraSettings,
+)
 from opentrons.system import camera
 
 
@@ -163,13 +166,17 @@ class MaintenanceRunDataManager:
         )
 
     async def delete(
-        self, run_id: str, run_exists: bool, camera_provider: CameraProvider
+        self,
+        run_id: str,
+        camera_settings: CameraSettings | None,
+        camera_provider: CameraProvider,
     ) -> None:
         """Delete a maintenance run.
 
         Args:
             run_id: The identifier of the run to remove.
-            run_exists: Whether or not a standard run exists outside of the maintenance run.
+            camera_settings: Optional set of camera settings form an external run. If None do not attempt to restart the live stream.
+            camera_provider: Utility for accessing image capture and camera settings.
 
         Raises:
             RunConflictError: If deleting the current run, the current run
@@ -177,17 +184,16 @@ class MaintenanceRunDataManager:
             RunNotFoundError: The given run identifier was not found.
         """
         if run_id == self._run_orchestrator_store.current_run_id:
-            state_summary = self._get_state_summary(run_id)
             await self._run_orchestrator_store.clear()
             await self._maintenance_runs_publisher.publish_current_maintenance_run_async()
 
-            if run_exists and state_summary is not None:
-                # Restart the live stream for now that the maintenance run has ended.
+            if camera_settings is not None:
+                # Restart the live stream for the external run when the maintenance run has ended.
                 await camera.update_live_stream_status(
                     self._run_orchestrator_store._robot_type,
                     True,
                     camera_provider,
-                    state_summary.cameraSettings,
+                    camera_settings,
                 )
 
         else:

--- a/robot-server/robot_server/maintenance_runs/maintenance_run_data_manager.py
+++ b/robot-server/robot_server/maintenance_runs/maintenance_run_data_manager.py
@@ -19,6 +19,8 @@ from .maintenance_run_models import MaintenanceRun, MaintenanceRunNotFoundError
 from opentrons.protocol_engine.types import DeckConfigurationType
 
 from robot_server.service.notifications import MaintenanceRunsPublisher
+from opentrons.protocol_engine.resources.camera_provider import CameraProvider
+from opentrons.system import camera
 
 
 def _build_run(
@@ -92,6 +94,7 @@ class MaintenanceRunDataManager:
         labware_offsets: Sequence[LabwareOffsetCreate | LegacyLabwareOffsetCreate],
         deck_configuration: DeckConfigurationType,
         notify_publishers: Callable[[], None],
+        camera_provider: CameraProvider,
     ) -> MaintenanceRun:
         """Create a new, current maintenance run.
 
@@ -100,6 +103,7 @@ class MaintenanceRunDataManager:
             created_at: Creation datetime.
             labware_offsets: Labware offsets to initialize the engine with.
             notify_publishers: Utilized by the engine to notify publishers of state changes.
+            camera_provider: Utility for accessing image capture and camera settings.
 
         Returns:
             The run resource.
@@ -113,6 +117,13 @@ class MaintenanceRunDataManager:
             labware_offsets=labware_offsets,
             deck_configuration=deck_configuration,
             notify_publishers=notify_publishers,
+        )
+
+        await camera.update_live_stream_status(
+            self._run_orchestrator_store._robot_type,
+            True,
+            camera_provider,
+            state_summary.cameraSettings,
         )
 
         maintenance_run_data = _build_run(
@@ -151,11 +162,14 @@ class MaintenanceRunDataManager:
             state_summary=state_summary,
         )
 
-    async def delete(self, run_id: str) -> None:
+    async def delete(
+        self, run_id: str, run_exists: bool, camera_provider: CameraProvider
+    ) -> None:
         """Delete a maintenance run.
 
         Args:
             run_id: The identifier of the run to remove.
+            run_exists: Whether or not a standard run exists outside of the maintenance run.
 
         Raises:
             RunConflictError: If deleting the current run, the current run
@@ -163,8 +177,18 @@ class MaintenanceRunDataManager:
             RunNotFoundError: The given run identifier was not found.
         """
         if run_id == self._run_orchestrator_store.current_run_id:
+            state_summary = self._get_state_summary(run_id)
             await self._run_orchestrator_store.clear()
             await self._maintenance_runs_publisher.publish_current_maintenance_run_async()
+
+            if run_exists and state_summary is not None:
+                # Restart the live stream for now that the maintenance run has ended.
+                await camera.update_live_stream_status(
+                    self._run_orchestrator_store._robot_type,
+                    True,
+                    camera_provider,
+                    state_summary.cameraSettings,
+                )
 
         else:
             raise MaintenanceRunNotFoundError(run_id=run_id)

--- a/robot-server/robot_server/maintenance_runs/router/base_router.py
+++ b/robot-server/robot_server/maintenance_runs/router/base_router.py
@@ -35,12 +35,18 @@ from ..maintenance_run_models import (
 from ..maintenance_run_orchestrator_store import RunConflictError
 from ..maintenance_run_data_manager import MaintenanceRunDataManager
 from ..dependencies import get_maintenance_run_data_manager
+from robot_server.runs.dependencies import get_run_data_manager
+from robot_server.runs.run_data_manager import RunDataManager
 
 from robot_server.deck_configuration.fastapi_dependencies import (
     get_deck_configuration_store,
 )
 from robot_server.deck_configuration.store import DeckConfigurationStore
 from robot_server.service.notifications import get_pe_notify_publishers
+from robot_server.camera.fastapi_dependencies import (
+    get_camera_provider,
+)
+from opentrons.protocol_engine.resources.camera_provider import CameraProvider
 
 log = logging.getLogger(__name__)
 base_router = LightRouter()
@@ -157,6 +163,7 @@ async def create_run(
         DeckConfigurationStore, Depends(get_deck_configuration_store)
     ],
     notify_publishers: Annotated[Callable[[], None], Depends(get_pe_notify_publishers)],
+    camera_provider: Annotated[CameraProvider, Depends(get_camera_provider)],
     request_body: Optional[RequestModel[MaintenanceRunCreate]] = None,
 ) -> PydanticResponse[SimpleBody[MaintenanceRun]]:
     """Create a new maintenance run.
@@ -169,6 +176,7 @@ async def create_run(
         is_ok_to_create_maintenance_run: Verify if a maintenance run may be created if a protocol run exists.
         check_estop: Dependency to verify the estop is in a valid state.
         deck_configuration_store: Dependency to fetch the deck configuration.
+        camera_provider: Dependency to provide access to the Camera Settings to the run.
         notify_publishers: Utilized by the engine to notify publishers of state changes.
     """
     if not is_ok_to_create_maintenance_run:
@@ -185,6 +193,7 @@ async def create_run(
         labware_offsets=offsets,
         deck_configuration=deck_configuration,
         notify_publishers=notify_publishers,
+        camera_provider=camera_provider,
     )
 
     log.info(f'Created an empty run "{run_id}"".')
@@ -267,18 +276,22 @@ async def get_run(
 )
 async def remove_run(
     runId: str,
-    run_data_manager: Annotated[
+    maintenance_run_data_manager: Annotated[
         MaintenanceRunDataManager, Depends(get_maintenance_run_data_manager)
     ],
+    run_data_manager: Annotated[RunDataManager, Depends(get_run_data_manager)],
+    camera_provider: Annotated[CameraProvider, Depends(get_camera_provider)],
 ) -> PydanticResponse[SimpleEmptyBody]:
     """Delete a maintenance run by its ID.
 
     Arguments:
         runId: Run ID pulled from URL.
+        maintenance_run_data_manager: Current maintenance run data management.
         run_data_manager: Current run data management.
     """
     try:
-        await run_data_manager.delete(runId)
+        run_exists = True if run_data_manager.current_run_id is not None else False
+        await maintenance_run_data_manager.delete(runId, run_exists, camera_provider)
 
     except RunConflictError as e:
         raise RunNotIdle().as_error(status.HTTP_409_CONFLICT) from e

--- a/robot-server/robot_server/maintenance_runs/router/base_router.py
+++ b/robot-server/robot_server/maintenance_runs/router/base_router.py
@@ -47,6 +47,7 @@ from robot_server.camera.fastapi_dependencies import (
     get_camera_provider,
 )
 from opentrons.protocol_engine.resources.camera_provider import CameraProvider
+from opentrons.protocol_engine.types import EngineStatus
 
 log = logging.getLogger(__name__)
 base_router = LightRouter()
@@ -288,10 +289,24 @@ async def remove_run(
         runId: Run ID pulled from URL.
         maintenance_run_data_manager: Current maintenance run data management.
         run_data_manager: Current run data management.
+        camera_provider: Utility for accessing image capture and camera settings.
     """
     try:
-        run_exists = True if run_data_manager.current_run_id is not None else False
-        await maintenance_run_data_manager.delete(runId, run_exists, camera_provider)
+        camera_settings = None
+        if run_data_manager.current_run_id is not None:
+            # Import the camera settings from an external run if one exists
+            state_summary = run_data_manager._get_good_state_summary(
+                run_data_manager.current_run_id
+            )
+            if (
+                state_summary is not None
+                and state_summary.status is not EngineStatus.FINISHING
+            ):
+                camera_settings = state_summary.cameraSettings
+
+        await maintenance_run_data_manager.delete(
+            runId, camera_settings, camera_provider
+        )
 
     except RunConflictError as e:
         raise RunNotIdle().as_error(status.HTTP_409_CONFLICT) from e

--- a/robot-server/robot_server/runs/run_data_manager.py
+++ b/robot-server/robot_server/runs/run_data_manager.py
@@ -207,6 +207,7 @@ class RunDataManager:
             created_at: Creation datetime.
             labware_offsets: Labware offsets to initialize the engine with.
             deck_configuration: A mapping of fixtures to cutout fixtures the deck will be loaded with.
+            camera_provider: Utility for accessing image capture and camera settings.
             notify_publishers: Utilized by the engine to notify publishers of state changes.
             run_time_param_values: Any runtime parameter values to set.
             run_time_param_paths: Any runtime filepath to set.

--- a/robot-server/tests/maintenance_runs/router/conftest.py
+++ b/robot-server/tests/maintenance_runs/router/conftest.py
@@ -8,6 +8,7 @@ from robot_server.maintenance_runs.maintenance_run_orchestrator_store import (
 from robot_server.maintenance_runs.maintenance_run_data_manager import (
     MaintenanceRunDataManager,
 )
+from robot_server.runs.run_data_manager import RunDataManager
 from opentrons.protocol_engine import ProtocolEngine
 from robot_server.deck_configuration.store import DeckConfigurationStore
 
@@ -28,8 +29,14 @@ def mock_protocol_engine(decoy: Decoy) -> ProtocolEngine:
 
 @pytest.fixture
 def mock_maintenance_run_data_manager(decoy: Decoy) -> MaintenanceRunDataManager:
-    """Get a mock RunDataManager."""
+    """Get a mock MaintenanceRunDataManager."""
     return decoy.mock(cls=MaintenanceRunDataManager)
+
+
+@pytest.fixture
+def mock_run_data_manager(decoy: Decoy) -> RunDataManager:
+    """Get a mock RunDataManager."""
+    return decoy.mock(cls=RunDataManager)
 
 
 @pytest.fixture

--- a/robot-server/tests/maintenance_runs/router/test_base_router.py
+++ b/robot-server/tests/maintenance_runs/router/test_base_router.py
@@ -6,6 +6,7 @@ from decoy import Decoy
 
 from opentrons.types import DeckSlotName
 from opentrons.protocol_engine import types as pe_types
+from opentrons.protocol_engine import StateSummary, EngineStatus
 
 from robot_server.errors.error_responses import ApiError
 from robot_server.service.json_api import (
@@ -26,6 +27,7 @@ from robot_server.maintenance_runs.maintenance_run_orchestrator_store import (
 from robot_server.maintenance_runs.maintenance_run_data_manager import (
     MaintenanceRunDataManager,
 )
+from robot_server.runs.run_data_manager import RunDataManager
 
 from robot_server.maintenance_runs.router.base_router import (
     create_run,
@@ -37,7 +39,10 @@ from robot_server.maintenance_runs.router.base_router import (
 )
 
 from robot_server.deck_configuration.store import DeckConfigurationStore
-from opentrons.protocol_engine.resources import CameraProvider
+from opentrons.protocol_engine.resources.camera_provider import (
+    CameraProvider,
+    CameraSettings,
+)
 from robot_server.camera.provider import CameraProviderWrapper
 
 
@@ -287,13 +292,79 @@ async def test_get_no_current_run(
 async def test_delete_run_by_id(
     decoy: Decoy,
     mock_maintenance_run_data_manager: MaintenanceRunDataManager,
+    mock_run_data_manager: RunDataManager,
+    mock_camera_provider: CameraProvider,
 ) -> None:
     """It should be able to remove a run by ID."""
     result = await remove_run(
-        runId="run-id", run_data_manager=mock_maintenance_run_data_manager
+        runId="run-id",
+        maintenance_run_data_manager=mock_maintenance_run_data_manager,
+        run_data_manager=mock_run_data_manager,
+        camera_provider=mock_camera_provider,
     )
 
-    decoy.verify(await mock_maintenance_run_data_manager.delete("run-id"), times=1)
+    decoy.verify(
+        await mock_maintenance_run_data_manager.delete(
+            "run-id", None, camera_provider=mock_camera_provider
+        ),
+        times=1,
+    )
+
+    assert result.content == SimpleEmptyBody()
+    assert result.status_code == 200
+
+
+async def test_delete_run_by_id_with_external_run(
+    decoy: Decoy,
+    mock_maintenance_run_data_manager: MaintenanceRunDataManager,
+    mock_run_data_manager: RunDataManager,
+    mock_camera_provider: CameraProvider,
+) -> None:
+    """It should pass in external camera settings if an external run exists when deleting a maintenance run."""
+    assert mock_run_data_manager.current_run_id is not None
+    decoy.when(
+        mock_run_data_manager._get_good_state_summary(
+            mock_run_data_manager.current_run_id
+        )
+    ).then_return(
+        StateSummary(
+            status=EngineStatus.IDLE,
+            errors=[],
+            labware=[],
+            pipettes=[],
+            modules=[],
+            labwareOffsets=[],
+            liquids=[],
+            wells=[],
+            files=[],
+            liquidClasses=[],
+            tasks=[],
+            cameraSettings=CameraSettings(
+                cameraEnabled=True,
+                liveStreamEnabled=True,
+                errorRecoveryCameraEnabled=True,
+            ),
+        )
+    )
+    result = await remove_run(
+        runId="run-id",
+        maintenance_run_data_manager=mock_maintenance_run_data_manager,
+        run_data_manager=mock_run_data_manager,
+        camera_provider=mock_camera_provider,
+    )
+
+    decoy.verify(
+        await mock_maintenance_run_data_manager.delete(
+            "run-id",
+            CameraSettings(
+                cameraEnabled=True,
+                liveStreamEnabled=True,
+                errorRecoveryCameraEnabled=True,
+            ),
+            camera_provider=mock_camera_provider,
+        ),
+        times=1,
+    )
 
     assert result.content == SimpleEmptyBody()
     assert result.status_code == 200
@@ -302,15 +373,22 @@ async def test_delete_run_by_id(
 async def test_delete_run_with_bad_id(
     decoy: Decoy,
     mock_maintenance_run_data_manager: MaintenanceRunDataManager,
+    mock_run_data_manager: RunDataManager,
+    mock_camera_provider: CameraProvider,
 ) -> None:
     """It should 404 if the run ID does not exist."""
-    decoy.when(await mock_maintenance_run_data_manager.delete("run-id")).then_raise(
-        MaintenanceRunNotFoundError("uh oh")
-    )
+    decoy.when(
+        await mock_maintenance_run_data_manager.delete(
+            "run-id", None, camera_provider=mock_camera_provider
+        )
+    ).then_raise(MaintenanceRunNotFoundError("uh oh"))
 
     with pytest.raises(ApiError) as exc_info:
         await remove_run(
-            runId="run-id", run_data_manager=mock_maintenance_run_data_manager
+            runId="run-id",
+            maintenance_run_data_manager=mock_maintenance_run_data_manager,
+            run_data_manager=mock_run_data_manager,
+            camera_provider=mock_camera_provider,
         )
 
     assert exc_info.value.status_code == 404
@@ -320,15 +398,22 @@ async def test_delete_run_with_bad_id(
 async def test_delete_active_run(
     decoy: Decoy,
     mock_maintenance_run_data_manager: MaintenanceRunDataManager,
+    mock_run_data_manager: RunDataManager,
+    mock_camera_provider: CameraProvider,
 ) -> None:
     """It should 409 if the run is not finished."""
-    decoy.when(await mock_maintenance_run_data_manager.delete("run-id")).then_raise(
-        RunConflictError("oh no")
-    )
+    decoy.when(
+        await mock_maintenance_run_data_manager.delete(
+            "run-id", None, camera_provider=mock_camera_provider
+        )
+    ).then_raise(RunConflictError("oh no"))
 
     with pytest.raises(ApiError) as exc_info:
         await remove_run(
-            runId="run-id", run_data_manager=mock_maintenance_run_data_manager
+            runId="run-id",
+            maintenance_run_data_manager=mock_maintenance_run_data_manager,
+            run_data_manager=mock_run_data_manager,
+            camera_provider=mock_camera_provider,
         )
 
     assert exc_info.value.status_code == 409

--- a/robot-server/tests/maintenance_runs/router/test_base_router.py
+++ b/robot-server/tests/maintenance_runs/router/test_base_router.py
@@ -37,6 +37,8 @@ from robot_server.maintenance_runs.router.base_router import (
 )
 
 from robot_server.deck_configuration.store import DeckConfigurationStore
+from opentrons.protocol_engine.resources import CameraProvider
+from robot_server.camera.provider import CameraProviderWrapper
 
 
 def mock_notify_publishers() -> None:
@@ -54,11 +56,26 @@ def labware_offset_create() -> pe_types.LegacyLabwareOffsetCreate:
     )
 
 
+@pytest.fixture()
+def mock_camera_provider_wrapper(decoy: Decoy) -> CameraProviderWrapper:
+    """Return a mock CameraProviderWrapper."""
+    return decoy.mock(cls=CameraProviderWrapper)
+
+
+@pytest.fixture()
+def mock_camera_provider(
+    decoy: Decoy, mock_camera_provider_wrapper: CameraProviderWrapper
+) -> CameraProvider:
+    """Return a mock CameraProvider."""
+    return decoy.mock(cls=CameraProvider)
+
+
 async def test_create_run(
     decoy: Decoy,
     mock_maintenance_run_data_manager: MaintenanceRunDataManager,
     labware_offset_create: pe_types.LabwareOffsetCreate,
     mock_deck_configuration_store: DeckConfigurationStore,
+    mock_camera_provider: CameraProvider,
 ) -> None:
     """It should be able to create a basic run."""
     run_id = "run-id"
@@ -90,6 +107,7 @@ async def test_create_run(
             labware_offsets=[labware_offset_create],
             deck_configuration=[],
             notify_publishers=mock_notify_publishers,
+            camera_provider=mock_camera_provider,
         )
     ).then_return(expected_response)
 
@@ -103,6 +121,7 @@ async def test_create_run(
         is_ok_to_create_maintenance_run=True,
         deck_configuration_store=mock_deck_configuration_store,
         notify_publishers=mock_notify_publishers,
+        camera_provider=mock_camera_provider,
         check_estop=True,
     )
 
@@ -114,6 +133,7 @@ async def test_create_maintenance_run_with_protocol_run_conflict(
     decoy: Decoy,
     mock_maintenance_run_data_manager: MaintenanceRunDataManager,
     mock_deck_configuration_store: DeckConfigurationStore,
+    mock_camera_provider: CameraProvider,
 ) -> None:
     """It should respond with a conflict error if protocol run is active during maintenance run creation."""
     created_at = datetime(year=2021, month=1, day=1)
@@ -130,6 +150,7 @@ async def test_create_maintenance_run_with_protocol_run_conflict(
             deck_configuration_store=mock_deck_configuration_store,
             check_estop=True,
             notify_publishers=mock_notify_publishers,
+            camera_provider=mock_camera_provider,
         )
     assert exc_info.value.status_code == 409
     assert exc_info.value.content["errors"][0]["id"] == "ProtocolRunIsActive"

--- a/robot-server/tests/maintenance_runs/test_run_data_manager.py
+++ b/robot-server/tests/maintenance_runs/test_run_data_manager.py
@@ -316,6 +316,7 @@ async def test_get_run_not_current(
 async def test_delete_current_run(
     decoy: Decoy,
     mock_maintenance_run_orchestrator_store: MaintenanceRunOrchestratorStore,
+    mock_camera_provider: CameraProvider,
     subject: MaintenanceRunDataManager,
 ) -> None:
     """It should delete the current run from the engine."""
@@ -324,7 +325,9 @@ async def test_delete_current_run(
         run_id
     )
 
-    await subject.delete(run_id=run_id)
+    await subject.delete(
+        run_id=run_id, camera_settings=None, camera_provider=mock_camera_provider
+    )
 
     decoy.verify(
         await mock_maintenance_run_orchestrator_store.clear(),

--- a/robot-server/tests/maintenance_runs/test_run_data_manager.py
+++ b/robot-server/tests/maintenance_runs/test_run_data_manager.py
@@ -34,6 +34,8 @@ from robot_server.service.notifications import (
 )
 
 from opentrons.protocol_engine import Liquid
+from opentrons.protocol_engine.resources import CameraProvider
+from robot_server.camera.provider import CameraProviderWrapper
 
 
 def mock_notify_publishers() -> None:
@@ -103,11 +105,26 @@ def subject(
     )
 
 
+@pytest.fixture()
+def mock_camera_provider_wrapper(decoy: Decoy) -> CameraProviderWrapper:
+    """Return a mock CameraProviderWrapper."""
+    return decoy.mock(cls=CameraProviderWrapper)
+
+
+@pytest.fixture()
+def mock_camera_provider(
+    decoy: Decoy, mock_camera_provider_wrapper: CameraProviderWrapper
+) -> CameraProvider:
+    """Return a mock CameraProvider."""
+    return decoy.mock(cls=CameraProvider)
+
+
 async def test_create(
     decoy: Decoy,
     mock_maintenance_run_orchestrator_store: MaintenanceRunOrchestratorStore,
     subject: MaintenanceRunDataManager,
     engine_state_summary: StateSummary,
+    mock_camera_provider: CameraProvider,
 ) -> None:
     """It should create an engine and a persisted run resource."""
     run_id = "hello world"
@@ -131,6 +148,7 @@ async def test_create(
         labware_offsets=[],
         deck_configuration=[],
         notify_publishers=mock_notify_publishers,
+        camera_provider=mock_camera_provider,
     )
 
     assert result == MaintenanceRun(
@@ -155,6 +173,7 @@ async def test_create_with_options(
     mock_maintenance_run_orchestrator_store: MaintenanceRunOrchestratorStore,
     subject: MaintenanceRunDataManager,
     engine_state_summary: StateSummary,
+    mock_camera_provider: CameraProvider,
 ) -> None:
     """It should handle creation with labware offsets."""
     run_id = "hello world"
@@ -185,6 +204,7 @@ async def test_create_with_options(
         labware_offsets=[labware_offset],
         deck_configuration=[],
         notify_publishers=mock_notify_publishers,
+        camera_provider=mock_camera_provider,
     )
 
     assert result == MaintenanceRun(
@@ -208,6 +228,7 @@ async def test_create_engine_error(
     decoy: Decoy,
     mock_maintenance_run_orchestrator_store: MaintenanceRunOrchestratorStore,
     subject: MaintenanceRunDataManager,
+    mock_camera_provider: CameraProvider,
 ) -> None:
     """It should not create a resource if engine creation fails."""
     run_id = "hello world"
@@ -233,6 +254,7 @@ async def test_create_engine_error(
             labware_offsets=[],
             deck_configuration=[],
             notify_publishers=mock_notify_publishers,
+            camera_provider=mock_camera_provider,
         )
 
 


### PR DESCRIPTION
# Overview
Covers [RQA-4810](https://opentrons-sandbox.atlassian.net/browse/RQA-4810)

Originally the maintenance run didn't purposefully interface with the live stream at all. However because when a run finishes the livestream status is set to "Off" as part of post-run cleanup, maintenance runs were unintentionally disabling the live stream for an existing "encapsulating" run. For example, if a live stream was enabled and pulled up during run setup, and the client opens the pipette calibration flow, as soon as the maintenance run ends the live stream would also end, even though the primary run hadn't begun yet. This addresses that by ensuring we handle live stream creation and shutdown under maintenance runs the same way we do for real runs, and also when a maintenance run is deleted if an existing run is present it's camera settings will be used in a stream service update request.

## Test Plan and Hands on Testing

- [x] Unit test coverage
- [x] Start a run setup on a Flex, open live stream and confirm it is visible. 
- [x] Start pipette attach flow, and make sure the stream is still visible.
- [x] End the pipette attach flow, and make sure the primary stream for the run is still visible.
- [x] Finish the run and ensure the stream ends.

## Changelog
Added live stream update coverage to maintenance run behavior.

## Review requests

## Risk assessment
Low - effects new stream behavior.

[RQA-4810]: https://opentrons.atlassian.net/browse/RQA-4810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ