### PR TITLE
fix(shared-data): Zero out some additional questionable `cornerOffsetFromSlot`s

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/_default_labware_versions.py
+++ b/api/src/opentrons/protocol_api/core/engine/_default_labware_versions.py
@@ -144,6 +144,11 @@ DEFAULT_LABWARE_VERSIONS: DefaultLabwareVersions = {
         "usascientific_12_reservoir_22ml": 4,
         "usascientific_96_wellplate_2.4ml_deep": 4,
     },
+    APIVersion(2, 28): {
+        "black_96_well_microtiter_plate_lid": 2,
+        "corning_96_wellplate_360ul_lid": 2,
+        "corning_falcon_384_wellplate_130ul_flat_lid": 2,
+    },
 }
 
 

--- a/shared-data/labware/definitions/2/black_96_well_microtiter_plate_lid/2.json
+++ b/shared-data/labware/definitions/2/black_96_well_microtiter_plate_lid/2.json
@@ -1,0 +1,110 @@
+{
+  "allowedRoles": ["labware", "lid"],
+  "ordering": [],
+  "brand": {
+    "brand": "greiner",
+    "brandId": []
+  },
+  "metadata": {
+    "displayName": "Black 96-well Microtiter Plate Lid",
+    "displayCategory": "lid",
+    "displayVolumeUnits": "\u00b5L",
+    "tags": []
+  },
+  "dimensions": {
+    "xDimension": 127.5,
+    "yDimension": 85,
+    "zDimension": 10
+  },
+  "wells": {},
+  "groups": [
+    {
+      "metadata": {},
+      "wells": []
+    }
+  ],
+  "cornerOffsetFromSlot": {
+    "x": 0,
+    "y": 0,
+    "z": 0
+  },
+  "parameters": {
+    "format": "irregular",
+    "quirks": ["stackingMaxFive"],
+    "isTiprack": false,
+    "isMagneticModuleCompatible": false,
+    "loadName": "black_96_well_microtiter_plate_lid"
+  },
+  "namespace": "opentrons",
+  "version": 2,
+  "schemaVersion": 2,
+  "stackingOffsetWithLabware": {
+    "milliplex_r_96_well_microtiter_plate": {
+      "x": 0,
+      "y": 0,
+      "z": 7.4
+    },
+    "black_96_well_microtiter_plate_lid": {
+      "x": 0,
+      "y": 0,
+      "z": 1
+    },
+    "opentrons_flex_deck_riser": {
+      "x": 0,
+      "y": 0,
+      "z": 34
+    },
+    "protocol_engine_lid_stack_object": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    }
+  },
+  "stackLimit": 5,
+  "compatibleParentLabware": [
+    "protocol_engine_lid_stack_object",
+    "opentrons_flex_deck_riser",
+    "milliplex_r_96_well_microtiter_plate",
+    "black_96_well_microtiter_plate_lid"
+  ],
+  "gripForce": 10,
+  "gripHeightFromLabwareBottom": 7,
+  "gripperOffsets": {
+    "default": {
+      "pickUpOffset": {
+        "x": 0,
+        "y": 0,
+        "z": 0
+      },
+      "dropOffset": {
+        "x": 0,
+        "y": 0,
+        "z": -5
+      }
+    },
+    "lidOffsets": {
+      "pickUpOffset": {
+        "x": 0,
+        "y": 0,
+        "z": -5
+      },
+      "dropOffset": {
+        "x": 0,
+        "y": 0,
+        "z": -5
+      }
+    },
+    "lidDisposalOffsets": {
+      "pickUpOffset": {
+        "x": 0,
+        "y": 0,
+        "z": 0
+      },
+      "dropOffset": {
+        "x": 0,
+        "y": 5.0,
+        "z": 50.0
+      }
+    }
+  }
+}

--- a/shared-data/labware/definitions/2/corning_96_wellplate_360ul_lid/2.json
+++ b/shared-data/labware/definitions/2/corning_96_wellplate_360ul_lid/2.json
@@ -1,0 +1,117 @@
+{
+  "allowedRoles": ["labware", "lid"],
+  "ordering": [],
+  "brand": {
+    "brand": "Corning",
+    "brandId": []
+  },
+  "metadata": {
+    "displayName": "Corning 96 Wellplate 360ul Lid",
+    "displayCategory": "lid",
+    "displayVolumeUnits": "\u00b5L",
+    "tags": []
+  },
+  "dimensions": {
+    "xDimension": 127,
+    "yDimension": 85,
+    "zDimension": 10
+  },
+  "wells": {},
+  "groups": [
+    {
+      "metadata": {},
+      "wells": []
+    }
+  ],
+  "cornerOffsetFromSlot": {
+    "x": 0,
+    "y": 0,
+    "z": 0
+  },
+  "parameters": {
+    "format": "irregular",
+    "quirks": ["stackingMaxFive"],
+    "isTiprack": false,
+    "isMagneticModuleCompatible": false,
+    "loadName": "corning_96_wellplate_360ul_lid"
+  },
+  "namespace": "opentrons",
+  "version": 2,
+  "schemaVersion": 2,
+  "stackingOffsetWithModule": {
+    "thermocyclerModuleV2": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    }
+  },
+  "stackingOffsetWithLabware": {
+    "corning_96_wellplate_360ul_flat": {
+      "x": 0,
+      "y": 0,
+      "z": 6.5
+    },
+    "corning_96_wellplate_360ul_lid": {
+      "x": 0,
+      "y": 0,
+      "z": 1
+    },
+    "opentrons_flex_deck_riser": {
+      "x": 0,
+      "y": 0,
+      "z": 34
+    },
+    "protocol_engine_lid_stack_object": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    }
+  },
+  "stackLimit": 5,
+  "compatibleParentLabware": [
+    "protocol_engine_lid_stack_object",
+    "opentrons_flex_deck_riser",
+    "corning_96_wellplate_360ul_flat",
+    "corning_96_wellplate_360ul_lid"
+  ],
+  "gripForce": 10,
+  "gripHeightFromLabwareBottom": 7,
+  "gripperOffsets": {
+    "default": {
+      "pickUpOffset": {
+        "x": 0,
+        "y": 0,
+        "z": 0
+      },
+      "dropOffset": {
+        "x": 0,
+        "y": 0,
+        "z": -6
+      }
+    },
+    "lidOffsets": {
+      "pickUpOffset": {
+        "x": 0.5,
+        "y": 0,
+        "z": -5
+      },
+      "dropOffset": {
+        "x": 0.5,
+        "y": 0,
+        "z": -1
+      }
+    },
+    "lidDisposalOffsets": {
+      "pickUpOffset": {
+        "x": 0,
+        "y": 0,
+        "z": 0
+      },
+      "dropOffset": {
+        "x": 0,
+        "y": 5.0,
+        "z": 50.0
+      }
+    }
+  }
+}

--- a/shared-data/labware/definitions/2/corning_falcon_384_wellplate_130ul_flat_lid/2.json
+++ b/shared-data/labware/definitions/2/corning_falcon_384_wellplate_130ul_flat_lid/2.json
@@ -1,0 +1,118 @@
+{
+  "allowedRoles": ["labware", "lid"],
+  "ordering": [],
+  "brand": {
+    "brand": "Corning",
+    "brandId": []
+  },
+  "metadata": {
+    "displayName": "Corning Falcon 384 Well Microtest Plate 130 µL Lid",
+    "displayCategory": "lid",
+    "displayVolumeUnits": "\u00b5L",
+    "tags": []
+  },
+  "dimensions": {
+    "xDimension": 127,
+    "yDimension": 84.8,
+    "zDimension": 6.85
+  },
+  "wells": {},
+  "groups": [
+    {
+      "metadata": {},
+      "wells": []
+    }
+  ],
+  "cornerOffsetFromSlot": {
+    "x": 0,
+    "y": 0,
+    "z": 0
+  },
+  "parameters": {
+    "format": "irregular",
+    "quirks": [],
+    "isTiprack": false,
+    "isMagneticModuleCompatible": false,
+    "loadName": "corning_falcon_384_wellplate_130ul_flat_lid"
+  },
+  "namespace": "opentrons",
+  "version": 2,
+  "schemaVersion": 2,
+  "stackingOffsetWithModule": {
+    "thermocyclerModuleV2": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    }
+  },
+  "stackingOffsetWithLabware": {
+    "corning_falcon_384_wellplate_130ul_flat": {
+      "x": 0,
+      "y": 0,
+      "z": 2.1
+    },
+    "corning_falcon_384_wellplate_130ul_flat_lid": {
+      "x": 0,
+      "y": 0,
+      "z": 5.9
+    },
+    "opentrons_flex_deck_riser": {
+      "x": 0,
+      "y": 0,
+      "z": 28
+    },
+    "protocol_engine_lid_stack_object": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    }
+  },
+  "stackLimit": 5,
+  "compatibleParentLabware": [
+    "protocol_engine_lid_stack_object",
+    "opentrons_flex_deck_riser",
+    "corning_falcon_384_wellplate_130ul_flat",
+    "corning_falcon_384_wellplate_130ul_flat_lid",
+    "opentrons_universal_flat_adapter"
+  ],
+  "gripForce": 10,
+  "gripHeightFromLabwareBottom": 7,
+  "gripperOffsets": {
+    "default": {
+      "pickUpOffset": {
+        "x": 0,
+        "y": 0,
+        "z": 0
+      },
+      "dropOffset": {
+        "x": 0,
+        "y": 0,
+        "z": -6
+      }
+    },
+    "lidOffsets": {
+      "pickUpOffset": {
+        "x": 0.5,
+        "y": 0,
+        "z": -5
+      },
+      "dropOffset": {
+        "x": 0.5,
+        "y": 0,
+        "z": -1
+      }
+    },
+    "lidDisposalOffsets": {
+      "pickUpOffset": {
+        "x": 0,
+        "y": 0,
+        "z": 0
+      },
+      "dropOffset": {
+        "x": 0,
+        "y": 5.0,
+        "z": 50.0
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Overview

These labware had a `cornerOffsetFromSlot.z` of -0.71, which is dubious because that would put them slightly underground. Since it's the exact same number as PR #17723 / EXEC-1268, I suspect this was a copy-paste error and was not intentional.

Closes EXEC-2087.

## Changelog

For these labware:

* `black_96_well_microtiter_plate_lid`
* `corning_96_wellplate_360ul_lid`
* `corning_falcon_384_wellplate_130ul_flat_lid`

I did this:

* Create a new labware version, v2. It's exactly the same as v1 except `cornerOffsetFromSlot.z` is zeroed out.
* In PAPIv2.28, start loading these new labware versions by default.

## Test Plan and Hands on Testing

I don't have these labware handy to test with, but we can expect the gripper positions to move up by 0.71 mm now. I expect that to be fine because they're currently only at ~7mm of ~10mm.

## Review requests

* Is PAPIv2.28 the correct PAPI version to add these new labware versions to? As I understand it, we're releasing robot software v8.8.0 now and that's carrying PAPIv2.27.
* OK with merging this without testing on hardware?

## Risk assessment

Medium, affects robot motion.