### PR TITLE
fix(step-generation): fix `getTransferPlanAndReferenceVolumes` for custom tipracks

### DIFF
--- a/step-generation/src/utils/__tests__/misc.test.ts
+++ b/step-generation/src/utils/__tests__/misc.test.ts
@@ -329,7 +329,7 @@ describe('getTransferPlanAndReferenceVolumes', () => {
   it('should return isSupported false for multiDispense if not enough volume', () => {
     const result = getTransferPlanAndReferenceVolumes({
       pipetteSpecs: MOCK_P10_SPECS,
-      tiprackDefinition: fixtureTiprack10ul,
+      tiprackDefinition: { ...fixtureTiprack10ul, namespace: 'opentrons' },
       volume: 6,
       path: 'multiDispense',
       numAspirateWells: 1,

--- a/step-generation/src/utils/misc.ts
+++ b/step-generation/src/utils/misc.ts
@@ -1096,23 +1096,26 @@ export const getTransferPlanAndReferenceVolumes = (args: {
           conditioningByVolume
         ) ?? 0)
       : 0
+
+  const isCustomTiprack = tiprackDefinition?.namespace !== 'opentrons'
   const isMultiDispenseAvailable =
-    conditioningByVolume != null &&
-    disposalByVolume != null &&
-    maxWorkingVolume >=
-      minVolumeForMultiAspirateDispense +
-        conditioningVolumeForMultiAspirateDispense +
-        (linearInterpolate(
-          minVolumeForMultiAspirateDispense,
-          disposalByVolume
-        ) ?? 0) +
-        // don't take air gap into account if conditioning volume is present
-        (conditioningVolumeForMultiAspirateDispense === 0
-          ? (linearInterpolate(
-              minVolumeForMultiAspirateDispense,
-              aspirateAirGapByVolume
-            ) ?? 0)
-          : 0)
+    isCustomTiprack ||
+    (conditioningByVolume != null &&
+      disposalByVolume != null &&
+      maxWorkingVolume >=
+        minVolumeForMultiAspirateDispense +
+          conditioningVolumeForMultiAspirateDispense +
+          (linearInterpolate(
+            minVolumeForMultiAspirateDispense,
+            disposalByVolume
+          ) ?? 0) +
+          // don't take air gap into account if conditioning volume is present
+          (conditioningVolumeForMultiAspirateDispense === 0
+            ? (linearInterpolate(
+                minVolumeForMultiAspirateDispense,
+                aspirateAirGapByVolume
+              ) ?? 0)
+            : 0))
   const isMultiAspirateAvailable =
     maxWorkingVolume >= minVolumeForMultiAspirateDispense
 


### PR DESCRIPTION
# Overview

Always permit multi-well handling for custom tipracks, since we are guaranteed to not find a matching set of liquid class tip specs.

Closes RQA-4930

## Test Plan and Hands on Testing

- upload protocol from ticket
- delete step 2
- create new transfer step with custom tiprack, 15µl volume (need to be low enough to permit distribute path), and `distribute` path, and continue to tip settings
- open manual tip selection modal and verify that you are prompted to selected just 1 tip

## Changelog

- update `getTransferPlanAndReferenceVolumes` to enable multiwell handling for any custom tiprack
- fix test

## Review requests

see test plan

## Risk assessment

low