### PR TITLE
fix(protocol-designer): respect form data in getTransferPlanAndReferenceVolumes

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipTrackingField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipTrackingField.tsx
@@ -11,12 +11,7 @@ import {
   SPACING,
   StyledText,
 } from '@opentrons/components'
-import {
-  getAllLiquidClassDefs,
-  getFlexNameConversion,
-  OT2_ROBOT_TYPE,
-  WATER_LIQUID_CLASS_NAME,
-} from '@opentrons/shared-data'
+import { OT2_ROBOT_TYPE } from '@opentrons/shared-data'
 import {
   AUTOMATIC,
   getDefaultPrimaryNozzle,
@@ -72,28 +67,6 @@ export function TipTrackingField(props: TipTrackingFieldProps): JSX.Element {
     tiprackEntity => tiprackEntity.labwareDefURI === formData.tipRack
   )?.def
 
-  const allLiquidClassDefs = getAllLiquidClassDefs()
-  const liquidClassDef =
-    allLiquidClassDefs[formData.liquidClass ?? ''] ??
-    allLiquidClassDefs[WATER_LIQUID_CLASS_NAME]
-  const convertedPipetteName =
-    pipette != null ? getFlexNameConversion(pipette.spec) : null
-  const liquidClassValuesForPipette = liquidClassDef.byPipette.find(
-    ({ pipetteModel }) => convertedPipetteName === pipetteModel
-  )
-  const liquidClassValuesForTip = liquidClassValuesForPipette?.byTipType.find(
-    tipObject => tipObject.tiprack === formData.tipRack
-  )
-
-  let airGapByVolume: Array<[number, number]> = []
-  // no air gap included for mix step
-  if (formData.stepType === 'moveLiquid') {
-    airGapByVolume =
-      (liquidClassValuesForTip?.aspirate.retract.airGapByVolume as Array<
-        [number, number]
-      >) ?? []
-  }
-
   const transferPlanAndReferenceVolumes =
     pipette != null && tiprackDefinition != null && formData != null
       ? getTransferPlanAndReferenceVolumes({
@@ -118,7 +91,9 @@ export function TipTrackingField(props: TipTrackingFieldProps): JSX.Element {
             robotType === OT2_ROBOT_TYPE
               ? []
               : [[0, Number(formData.disposalVolume_volume ?? 0)]],
-          aspirateAirGapByVolume: airGapByVolume,
+          aspirateAirGapByVolume: [
+            [0, Number(formData.aspirate_airGap_volume ?? 0)],
+          ],
         })
       : null
 

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipTrackingField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipTrackingField.tsx
@@ -113,13 +113,11 @@ export function TipTrackingField(props: TipTrackingFieldProps): JSX.Element {
           conditioningByVolume:
             robotType === OT2_ROBOT_TYPE
               ? []
-              : ((liquidClassValuesForTip?.multiDispense
-                  ?.conditioningByVolume as Array<[number, number]>) ?? null),
+              : [[0, Number(formData.conditioning_volume ?? 0)]],
           disposalByVolume:
             robotType === OT2_ROBOT_TYPE
               ? []
-              : ((liquidClassValuesForTip?.multiDispense
-                  ?.disposalByVolume as Array<[number, number]>) ?? null),
+              : [[0, Number(formData.disposalVolume_volume ?? 0)]],
           aspirateAirGapByVolume: airGapByVolume,
         })
       : null

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMix.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMix.ts
@@ -132,7 +132,11 @@ const updatePatchOnPipetteChange = (
 
     return {
       ...patch,
-      ...getDefaultFields('aspirate_flowRate', 'dispense_flowRate'),
+      ...getDefaultFields(
+        'aspirate_flowRate',
+        'dispense_flowRate',
+        'tips_selected'
+      ),
       nozzles,
       tipRack: firstDefaultTiprackURIOnDeck,
     }
@@ -148,7 +152,12 @@ const updatePatchOnTiprackChange = (
   if (fieldHasChanged(rawForm, patch, 'tipRack')) {
     return {
       ...patch,
-      ...getDefaultFields('aspirate_flowRate', 'dispense_flowRate'),
+      ...getDefaultFields(
+        'aspirate_flowRate',
+        'dispense_flowRate',
+        'tiprack_selected',
+        'tips_selected'
+      ),
     }
   }
 
@@ -173,6 +182,32 @@ const updatePatchOnChangeTipChange = (
   rawForm: FormData
 ): FormPatch => {
   if (fieldHasChanged(rawForm, patch, 'changeTip')) {
+    return {
+      ...patch,
+      ...getDefaultFields('tips_selected'),
+    }
+  }
+  return patch
+}
+
+const updatePatchOnWellsSelectedChange = (
+  patch: FormPatch,
+  rawForm: FormData
+): FormPatch => {
+  if (fieldHasChanged(rawForm, patch, 'wells')) {
+    return {
+      ...patch,
+      ...getDefaultFields('tips_selected'),
+    }
+  }
+  return patch
+}
+
+const updatePatchOnVolumeChange = (
+  patch: FormPatch,
+  rawForm: FormData
+): FormPatch => {
+  if (fieldHasChanged(rawForm, patch, 'volume')) {
     return {
       ...patch,
       ...getDefaultFields('tips_selected'),
@@ -213,5 +248,7 @@ export function dependentFieldsUpdateMix(
     chainPatch => updatePatchOnTiprackChange(chainPatch, rawForm),
     chainPatch => updatePatchOnNozzlesChange(chainPatch, rawForm),
     chainPatch => updatePatchOnChangeTipChange(chainPatch, rawForm),
+    chainPatch => updatePatchOnWellsSelectedChange(chainPatch, rawForm),
+    chainPatch => updatePatchOnVolumeChange(chainPatch, rawForm),
   ])
 }

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.ts
@@ -223,7 +223,8 @@ const updatePatchOnPipetteChange = (
         'dispense_mix_volume',
         'disposalVolume_volume',
         'aspirate_mmFromBottom',
-        'dispense_mmFromBottom'
+        'dispense_mmFromBottom',
+        'tips_selected'
       ),
       nozzles,
       aspirate_airGap_volume: airGapVolume,
@@ -256,7 +257,9 @@ const updatePatchOnTiprackChange = (
         'dispense_flowRate',
         'aspirate_mix_volume',
         'dispense_mix_volume',
-        'disposalVolume_volume'
+        'disposalVolume_volume',
+        'tips_selected',
+        'tiprack_selected'
       ),
       aspirate_airGap_volume: airGapVolume,
       dispense_airGap_volume: airGapVolume,
@@ -646,8 +649,8 @@ export function updatePatchBlowoutFields(
     if (shouldResetBlowoutLocation) {
       return { ...patch, ...getDefaultFields('blowout_location') }
     }
+    return { ...patch, ...getDefaultFields('tips_selected') }
   }
-
   return patch
 }
 
@@ -662,7 +665,7 @@ const updatePatchOnNozzleChange = (
   ) {
     return {
       ...patch,
-      ...getDefaultFields('aspirate_wells', 'dispense_wells'),
+      ...getDefaultFields('aspirate_wells', 'dispense_wells', 'tips_selected'),
     }
   }
   return patch
@@ -732,6 +735,44 @@ const updatePatchOnChangeTipChange = (
   return patch
 }
 
+const updatePatchOnWellsSelectedChange = (
+  patch: FormPatch,
+  rawForm: FormData
+): FormPatch => {
+  if (
+    fieldHasChanged(rawForm, patch, 'aspirate_wells') ||
+    fieldHasChanged(rawForm, patch, 'dispense_wells')
+  ) {
+    return {
+      ...patch,
+      ...getDefaultFields('tips_selected'),
+    }
+  }
+  return patch
+}
+
+const updatePatchOnVolumeChange = (
+  patch: FormPatch,
+  rawForm: FormData
+): FormPatch => {
+  const relevantFields = [
+    'volume',
+    'conditioning_volume',
+    'disposalVolume_volume',
+    'aspirate_airGap_volume',
+    'dispense_airGap_volume,',
+  ]
+  for (const field of relevantFields) {
+    if (fieldHasChanged(rawForm, patch, field)) {
+      return {
+        ...patch,
+        ...getDefaultFields('tips_selected'),
+      }
+    }
+  }
+  return patch
+}
+
 export function dependentFieldsUpdateMoveLiquid(
   originalPatch: FormPatch,
   rawForm: FormData, // raw = NOT hydrated
@@ -779,5 +820,7 @@ export function dependentFieldsUpdateMoveLiquid(
     chainPatch => updatePatchOnPathChange(chainPatch, rawForm, pipetteEntities),
     chainPatch => updatePatchOnNozzlesChange(chainPatch, rawForm),
     chainPatch => updatePatchOnChangeTipChange(chainPatch, rawForm),
+    chainPatch => updatePatchOnWellsSelectedChange(chainPatch, rawForm),
+    chainPatch => updatePatchOnVolumeChange(chainPatch, rawForm),
   ])
 }

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/test/mix.test.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/test/mix.test.ts
@@ -150,6 +150,7 @@ describe('well selection should update', () => {
       mix_mmFromBottom: DEFAULT_MM_OFFSET_FROM_BOTTOM,
       mix_touchTip_mmFromTop: null,
       mix_touchTip_checkbox: false,
+      tips_selected: [],
     })
   })
   it('select labware with multiple wells', () => {
@@ -163,6 +164,7 @@ describe('well selection should update', () => {
       mix_mmFromBottom: DEFAULT_MM_OFFSET_FROM_BOTTOM,
       mix_touchTip_mmFromTop: null,
       mix_touchTip_checkbox: false,
+      tips_selected: [],
     })
   })
 })

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/test/moveLiquid.test.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/test/moveLiquid.test.ts
@@ -92,6 +92,7 @@ describe('path should update...', () => {
     const patch = {}
     expect(handleFormHelper(patch, { blah: 'blaaah' })).toEqual({
       path: 'single',
+      tips_selected: [],
     })
   })
   describe('if path is multi and volume*2 + air gap volume exceeds pipette/tip capacity', () => {
@@ -255,13 +256,14 @@ describe('disposal volume should update...', () => {
       disposalVolume_volume: null,
       conditioning_volume: null,
       conditioning_checkbox: false,
+      tips_selected: [],
     })
   })
 
   it('when volume is raised but disposal vol is still in capacity, do not change (noop case)', () => {
     const patch = { volume: '2.5' }
     const result = handleFormHelper(patch, form)
-    expect(result).toEqual(patch)
+    expect(result).toEqual({ ...patch, tips_selected: [] })
   })
 
   it('when the aspirate > air gap volume is large', () => {
@@ -272,7 +274,7 @@ describe('disposal volume should update...', () => {
       aspirate_airGap_volume: '3',
       volume: '1',
     })
-    expect(result).toEqual({ disposalVolume_volume: '5' })
+    expect(result).toEqual({ disposalVolume_volume: '5', tips_selected: [] })
   })
   it('when the aspirate > air gap volume is increased', () => {
     const patch = { aspirate_airGap_volume: '3' }
@@ -286,6 +288,7 @@ describe('disposal volume should update...', () => {
     expect(result).toEqual({
       aspirate_airGap_volume: '3',
       disposalVolume_volume: '5',
+      tips_selected: [],
     })
   })
   it('skipped when the aspirate > air gap checkbox not checked', () => {
@@ -296,7 +299,7 @@ describe('disposal volume should update...', () => {
       aspirate_airGap_volume: '3',
       volume: '1',
     })
-    expect(result).toEqual({ disposalVolume_volume: '6' })
+    expect(result).toEqual({ disposalVolume_volume: '6', tips_selected: [] })
   })
 
   describe('when volume is raised so that disposal vol must be exactly zero, clear/zero disposal volume fields', () => {
@@ -316,6 +319,7 @@ describe('disposal volume should update...', () => {
         dispense_mix_times: null,
         dispense_mix_volume: null,
         blowout_checkbox: false,
+        tips_selected: [],
       })
     })
 
@@ -325,6 +329,7 @@ describe('disposal volume should update...', () => {
       expect(result).toEqual({
         ...patch,
         disposalVolume_volume: '0',
+        tips_selected: [],
       })
     })
   })
@@ -334,17 +339,18 @@ describe('disposal volume should update...', () => {
     expect(result).toEqual({
       volume: '4.6',
       disposalVolume_volume: '0.8',
+      tips_selected: [],
     })
   })
 
   it('clamp excessive disposal volume to max', () => {
     const result = handleFormHelper({ disposalVolume_volume: '9999' }, form)
-    expect(result).toEqual({ disposalVolume_volume: '6' })
+    expect(result).toEqual({ disposalVolume_volume: '6', tips_selected: [] })
   })
 
   it('when disposal volume is a negative number, set to zero', () => {
     const result = handleFormHelper({ disposalVolume_volume: '-2' }, form)
-    expect(result).toEqual({ disposalVolume_volume: '0' })
+    expect(result).toEqual({ disposalVolume_volume: '0', tips_selected: [] })
   })
 
   describe('mix fields should clear...', () => {
@@ -368,6 +374,7 @@ describe('disposal volume should update...', () => {
         aspirate_mix_times: null,
         aspirate_mix_volume: null,
         preWetTip: false,
+        tips_selected: [],
       })
     })
   })
@@ -391,7 +398,7 @@ describe('disposal volume should update...', () => {
     ]
 
     testCases.forEach(({ prevPath, nextPath, incompatible }) => {
-      const patch = { path: nextPath }
+      const patch = { path: nextPath, tips_selected: [] }
       it(`when changing path ${prevPath} → ${nextPath}, arbitrary labware still allowed`, () => {
         // @ts-expect-error(sa, 2021-6-15): missing id and stepType to be valid formData type
         const result = updatePatchBlowoutFields(patch, {


### PR DESCRIPTION
# Overview

This PR ensures the actual selected values for `disposalVolume` and `conditioningVolume` from the form are respected in calling getTransferPlanAndReferenceVolumes, used to determine how many tip pickups the pipette will need during its transfer.

Closes RQA-4930

## Test Plan and Hands on Testing

- upload the attached protocol and open step 2

## Changelog

List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.

## Review requests

- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.

## Risk assessment

- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
