### PR TITLE
fix(protocol-designer): add customLabware defs to array for custom ti…

### DIFF
--- a/protocol-designer/src/components/organisms/SelectLabwareModal/SelectCustomLabware.tsx
+++ b/protocol-designer/src/components/organisms/SelectLabwareModal/SelectCustomLabware.tsx
@@ -6,6 +6,7 @@ import {
   ListButton,
   ListButtonAccordion,
   ListButtonAccordionContainer,
+  SPACING,
 } from '@opentrons/components'
 
 import { getCustomLabwareDefsByURI } from '../../../labware-defs/selectors'
@@ -58,6 +59,7 @@ export function SelectCustomLabware(
     <ListButton
       key={`ListButton_${CUSTOM_CATEGORY}`}
       type="noActive"
+      padding={SPACING.spacing12}
       onClick={() => {
         handleCategoryClick(CUSTOM_CATEGORY)
       }}

--- a/protocol-designer/src/components/organisms/SelectLabwareModal/SelectLabwareOnAdapter.tsx
+++ b/protocol-designer/src/components/organisms/SelectLabwareModal/SelectLabwareOnAdapter.tsx
@@ -97,7 +97,7 @@ export function SelectLabwareOnAdapter(
         isExpanded={parentLabwareURI === selectedAdapterDefURI}
       >
         {has96Channel && loadName === ADAPTER_96_CHANNEL
-          ? [...permittedTipracks].map((tiprackDefUri, index) => {
+          ? permittedTipracks.map((tiprackDefUri, index) => {
               const nestedDef =
                 defs[tiprackDefUri] ?? customLabwareDefs[tiprackDefUri]
               const stackingLabwareDefUris = getStackerDefinitions(

--- a/protocol-designer/src/components/organisms/SelectLabwareModal/SelectLabwareOnAdapter.tsx
+++ b/protocol-designer/src/components/organisms/SelectLabwareModal/SelectLabwareOnAdapter.tsx
@@ -97,8 +97,9 @@ export function SelectLabwareOnAdapter(
         isExpanded={parentLabwareURI === selectedAdapterDefURI}
       >
         {has96Channel && loadName === ADAPTER_96_CHANNEL
-          ? permittedTipracks.map((tiprackDefUri, index) => {
-              const nestedDef = defs[tiprackDefUri]
+          ? [...permittedTipracks].map((tiprackDefUri, index) => {
+              const nestedDef =
+                defs[tiprackDefUri] ?? customLabwareDefs[tiprackDefUri]
               const stackingLabwareDefUris = getStackerDefinitions(
                 {
                   ...defs,


### PR DESCRIPTION
…p on adapter

closes RQA-4932

# Overview

add custom defs to the list of defs it is looking at for adding adapter + tip

## Test Plan and Hands on Testing

upload attached protocol and try to add a 96 tiprack adapter with the custom tiprack and it shouldn't white screen anymore

[untitled (23) (1).py](https://github.com/user-attachments/files/23917415/untitled.23.1.py)

## Changelog

fix a small design thing
search through custom defs to find def from uri

## Risk assessment

low
