### PR TITLE
refactor(app): live update spotlight window with any change in PV

### DIFF
--- a/app-shell/src/secondary-windows/index.ts
+++ b/app-shell/src/secondary-windows/index.ts
@@ -106,7 +106,7 @@ function detailsByActionType(action: Action): SecondaryWindowDetails | null {
     }
     case STEP_DETAIL_VIEWER_UPDATE:
       updateStepDetailViewerData(action.payload.protocolKey, {
-        slot: action.payload.slot,
+        slot: action.payload.slot ?? undefined,
         command: action.payload.command,
         robotState: action.payload.robotState,
         analysis: action.payload.analysis,

--- a/app/src/organisms/Desktop/ProtocolVisualization/Controls/__tests__/Controls.test.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/Controls/__tests__/Controls.test.tsx
@@ -39,7 +39,6 @@ describe('Controls', () => {
       isPlaying: false,
       commands: [],
       groupedCommands: null,
-      spotlightWindowData: {} as any, // TODO (kk, 2025-11-10): update this later
       milliSecondsPerFrame: 2000,
       setMilliSecondsPerFrame: vi.fn(),
     }

--- a/app/src/organisms/Desktop/ProtocolVisualization/Controls/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/Controls/index.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useDispatch } from 'react-redux'
 
 import {
   Chip,
@@ -12,8 +11,6 @@ import {
   TimelineScrubber,
 } from '@opentrons/components'
 
-import { stepDetailViewerUpdateAction } from '/app/redux/shell'
-
 import styles from './controls.module.css'
 import { PerStepOverflowMenu } from './PerStepOverflowMenu'
 
@@ -23,12 +20,7 @@ import { PerStepOverflowMenu } from './PerStepOverflowMenu'
 // } from './utils'
 
 import type { Dispatch, SetStateAction } from 'react'
-import type {
-  Liquid,
-  ProtocolAnalysisOutput,
-  RunTimeCommand,
-} from '@opentrons/shared-data'
-import type { InvariantContext, RobotState } from '@opentrons/step-generation'
+import type { RunTimeCommand } from '@opentrons/shared-data'
 import type { GroupedCommands } from '/app/redux/protocol-storage'
 
 interface ControlsProps {
@@ -41,15 +33,6 @@ interface ControlsProps {
   isPlaying: boolean
   commands: RunTimeCommand[]
   groupedCommands: GroupedCommands | null
-  spotlightWindowData: {
-    protocolKey: string
-    robotState: RobotState
-    invariantContext: InvariantContext
-    analysis: ProtocolAnalysisOutput
-    liquids: Liquid[]
-    slot: string | null
-    command?: RunTimeCommand
-  }
   milliSecondsPerFrame: number
   setMilliSecondsPerFrame: Dispatch<SetStateAction<number>>
 }
@@ -64,40 +47,12 @@ export function Controls(props: ControlsProps): JSX.Element {
     isPlaying,
     commands,
     // groupedCommands,
-    spotlightWindowData,
     milliSecondsPerFrame,
     setMilliSecondsPerFrame,
   } = props
   const { t } = useTranslation('protocol_visualization')
-  const dispatch = useDispatch()
 
   const [showPerStepOverflowMenu, setShowPerStepOverflowMenu] = useState(false)
-  // ToDo (kk: 2025-10-03) the following will be used when TimelineScrubber is added to this component
-  // const currentCommandId = commands[currentCommandIndex].id
-  // const nextGroupFirstCommandId = getNextGroupFirstCommandId(
-  //   groupedCommands,
-  //   currentCommandId
-  // )
-  // const previousGroupFirstCommandId = getPreviousGroupFirstCommandId(
-  //   groupedCommands,
-  //   currentCommandId
-  // )
-
-  // const handleBack = (): void => {
-  //   if (previousGroupFirstCommandId != null) {
-  //     setSelectedCommand(previousGroupFirstCommandId)
-  //   } else {
-  //     setSelectedCommand(commands[0].id)
-  //   }
-  // }
-  // const handleForward = (): void => {
-  //   if (nextGroupFirstCommandId != null) {
-  //     setSelectedCommand(nextGroupFirstCommandId)
-  //   } else {
-  //     setSelectedCommand(commands[commands.length - 1].id)
-  //   }
-  // }
-
   const handlePerStepOverflowClick = (): void => {
     setShowPerStepOverflowMenu(
       showPerStepOverflowMenu => !showPerStepOverflowMenu
@@ -114,24 +69,8 @@ export function Controls(props: ControlsProps): JSX.Element {
       numCommandLength - 1
     )
 
-    setSelectedCommand(commands[nextIndex].id)
-
-    if (
-      spotlightWindowData.slot != null &&
-      spotlightWindowData.command != null
-    ) {
-      dispatch(
-        stepDetailViewerUpdateAction({
-          protocolKey: spotlightWindowData.protocolKey,
-          slot: spotlightWindowData.slot,
-          command: spotlightWindowData.command,
-          robotState: spotlightWindowData.robotState,
-          invariantContext: spotlightWindowData.invariantContext,
-          analysis: spotlightWindowData.analysis,
-          liquids: spotlightWindowData.liquids,
-        })
-      )
-    }
+    const nextCommandId = commands[nextIndex].id
+    setSelectedCommand(nextCommandId)
   }
 
   const currentProgress =

--- a/app/src/organisms/Desktop/ProtocolVisualization/VisualizerContainer/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/VisualizerContainer/index.tsx
@@ -14,7 +14,10 @@ import { CommandSteps } from '/app/organisms/Desktop/ProtocolVisualization/Comma
 import { Controls } from '/app/organisms/Desktop/ProtocolVisualization/Controls'
 import { DeckView } from '/app/organisms/Desktop/ProtocolVisualization/DeckView'
 import { StepDetailContainer } from '/app/organisms/Desktop/ProtocolVisualization/StepDetailContainer'
-import { stepDetailViewerOpenAction } from '/app/redux/shell'
+import {
+  stepDetailViewerOpenAction,
+  stepDetailViewerUpdateAction,
+} from '/app/redux/shell'
 import { getProtocolDisplayName } from '/app/transformations/protocols'
 
 import styles from './visualizercontainer.module.css'
@@ -100,6 +103,11 @@ export function VisualizerContainer(
     setIsPlaying(prev => !prev)
   }
 
+  const { robotState } = frame
+  const selectedRunTimeCommand = commands.find(
+    command => command.id === selectedCommandId
+  )
+
   useEffect(() => {
     if (!isPlaying) return
 
@@ -119,10 +127,38 @@ export function VisualizerContainer(
     }
   }, [isPlaying, commands, milliSecondsPerFrame])
 
-  const { robotState } = frame
-  const selectedRunTimeCommand = commands.find(
-    command => command.id === selectedCommandId
-  )
+  //  update the data for the spotlight window
+  //  whenever the command index changes
+  useEffect(() => {
+    if (selectedCommandId == null) return
+
+    const nextIndex = commands.findIndex(c => c.id === selectedCommandId)
+    if (nextIndex < 0) return
+
+    const nextSpotlight = {
+      protocolKey,
+      slot: selectedSlot,
+      command: commands[nextIndex],
+      robotState,
+      invariantContext: invariantContext,
+      analysis,
+      liquids,
+    }
+
+    if (nextSpotlight.slot != null && nextSpotlight.command != null) {
+      dispatch(stepDetailViewerUpdateAction(nextSpotlight))
+    }
+  }, [
+    selectedCommandId,
+    selectedSlot,
+    protocolKey,
+    robotState,
+    invariantContext,
+    analysis,
+    liquids,
+    commands,
+  ])
+
   const isThermocyclerAttached = Object.keys(robotState.modules).some(
     id => invariantContext.moduleEntities[id].type === THERMOCYCLER_MODULE_TYPE
   )
@@ -258,15 +294,6 @@ export function VisualizerContainer(
           isPlaying={isPlaying}
           commands={filteredCommands}
           groupedCommands={groupedCommands}
-          spotlightWindowData={{
-            protocolKey,
-            slot: selectedSlot,
-            command: selectedRunTimeCommand,
-            robotState,
-            invariantContext,
-            analysis,
-            liquids,
-          }}
           milliSecondsPerFrame={milliSecondsPerFrame}
           setMilliSecondsPerFrame={setMilliSecondsPerFrame}
         />

--- a/app/src/redux/shell/types.ts
+++ b/app/src/redux/shell/types.ts
@@ -222,7 +222,7 @@ export interface StepDetailViewerUpdateAction {
   type: 'shell:STEP_DETAIL_VIEWER_UPDATE'
   payload: {
     protocolKey: string
-    slot: string
+    slot: string | null
     command: RunTimeCommand
     robotState: RobotState
     invariantContext: InvariantContext


### PR DESCRIPTION
closes AUTH-2556

# Overview

Live update the spotlight window when the scrubber is playing and when you scroll and click things.

## Test Plan and Hands on Testing

Test with a protocol in PV, see that you can play through and scrub through and it'll update

## Changelog

call the action to live update the spotlight window in the correct spot which is the parent component in a use effect. this way it accounts for all the different ways you can change the current command

## Risk assessment

low