### PR TITLE
fix(app):  fix slot empty structure to align with the design

### DIFF
--- a/app/src/assets/localization/en/protocol_visualization.json
+++ b/app/src/assets/localization/en/protocol_visualization.json
@@ -31,6 +31,7 @@
   "remaining_tips": "{{remaining}} tips",
   "right_mount": "RIGHT MOUNT",
   "seconds_per_step": "{{seconds}}s per step",
+  "slot_empty": "Slot empty",
   "slot": "Slot",
   "source_tips": "Source tips",
   "source_well_view": "Source well view",

--- a/app/src/molecules/SlotDetailsEmptyState/__tests__/SlotDetailsEmptyState.test.tsx
+++ b/app/src/molecules/SlotDetailsEmptyState/__tests__/SlotDetailsEmptyState.test.tsx
@@ -1,0 +1,29 @@
+import { it, describe, beforeEach } from 'vitest'
+import { screen } from '@testing-library/react'
+import { i18n } from '/app/i18n'
+import { renderWithProviders } from '/app/__testing-utils__'
+import { SlotDetailsEmptyState } from '..'
+
+import type { ComponentProps } from 'react'
+
+const render = (props: ComponentProps<typeof SlotDetailsEmptyState>) => {
+  return renderWithProviders(<SlotDetailsEmptyState {...props} />, {
+    i18nInstance: i18n,
+  })
+}
+
+describe('SlotDetailsEmptyState', () => {
+    let props: ComponentProps<typeof SlotDetailsEmptyState>
+
+    beforeEach(() => {
+        props = {
+            slotId: 'A1',
+        }
+    })
+
+    it('should render slot empty state', () => {
+        render(props)
+        screen.getByText('A1')
+        screen.getByText('Slot empty')
+    })
+})

--- a/app/src/molecules/SlotDetailsEmptyState/__tests__/SlotDetailsEmptyState.test.tsx
+++ b/app/src/molecules/SlotDetailsEmptyState/__tests__/SlotDetailsEmptyState.test.tsx
@@ -1,7 +1,9 @@
-import { it, describe, beforeEach } from 'vitest'
 import { screen } from '@testing-library/react'
-import { i18n } from '/app/i18n'
+import { beforeEach, describe, it } from 'vitest'
+
 import { renderWithProviders } from '/app/__testing-utils__'
+import { i18n } from '/app/i18n'
+
 import { SlotDetailsEmptyState } from '..'
 
 import type { ComponentProps } from 'react'
@@ -13,17 +15,17 @@ const render = (props: ComponentProps<typeof SlotDetailsEmptyState>) => {
 }
 
 describe('SlotDetailsEmptyState', () => {
-    let props: ComponentProps<typeof SlotDetailsEmptyState>
+  let props: ComponentProps<typeof SlotDetailsEmptyState>
 
-    beforeEach(() => {
-        props = {
-            slotId: 'A1',
-        }
-    })
+  beforeEach(() => {
+    props = {
+      slotId: 'A1',
+    }
+  })
 
-    it('should render slot empty state', () => {
-        render(props)
-        screen.getByText('A1')
-        screen.getByText('Slot empty')
-    })
+  it('should render slot empty state', () => {
+    render(props)
+    screen.getByText('A1')
+    screen.getByText('Slot empty')
+  })
 })

--- a/app/src/molecules/SlotDetailsEmptyState/index.tsx
+++ b/app/src/molecules/SlotDetailsEmptyState/index.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next'
 
-import { COLORS, StyledText, RobotInfoLabel } from '@opentrons/components'
+import { COLORS, RobotInfoLabel, StyledText } from '@opentrons/components'
 
 import styles from './slotdetailsemptystate.module.css'
 
@@ -16,7 +16,7 @@ export function SlotDetailsEmptyState(
   return (
     <div className={styles.slot_empty_container}>
       <div className={styles.slot_empty_header}>
-      <RobotInfoLabel deckLabel={slotId} />
+        <RobotInfoLabel deckLabel={slotId} />
       </div>
       <div className={styles.slot_empty_body}>
         <StyledText desktopStyle="bodyDefaultRegular" color={COLORS.grey50}>

--- a/app/src/molecules/SlotDetailsEmptyState/index.tsx
+++ b/app/src/molecules/SlotDetailsEmptyState/index.tsx
@@ -1,17 +1,27 @@
-import { COLORS, StyledText } from '@opentrons/components'
+import { useTranslation } from 'react-i18next'
+
+import { COLORS, StyledText, RobotInfoLabel } from '@opentrons/components'
 
 import styles from './slotdetailsemptystate.module.css'
 
-export function SlotDetailsEmptyState(): JSX.Element {
+interface SlotDetailsEmptyStateProps {
+  slotId: string
+}
+
+export function SlotDetailsEmptyState(
+  props: SlotDetailsEmptyStateProps
+): JSX.Element {
+  const { slotId } = props
+  const { t } = useTranslation('protocol_visualization')
   return (
-    <div>
-      <div className={styles.slot_details_active_step}>
-        <StyledText desktopStyle="bodyDefaultRegular" color={COLORS.grey60}>
-          Empty
-        </StyledText>
+    <div className={styles.slot_empty_container}>
+      <div className={styles.slot_empty_header}>
+      <RobotInfoLabel deckLabel={slotId} />
       </div>
-      <div className={styles.empty_state_box_container}>
-        <div className={styles.empty_state_box} />
+      <div className={styles.slot_empty_body}>
+        <StyledText desktopStyle="bodyDefaultRegular" color={COLORS.grey50}>
+          {t('slot_empty')}
+        </StyledText>
       </div>
     </div>
   )

--- a/app/src/molecules/SlotDetailsEmptyState/slotdetailsemptystate.module.css
+++ b/app/src/molecules/SlotDetailsEmptyState/slotdetailsemptystate.module.css
@@ -1,17 +1,24 @@
-.slot_details_active_step {
+.slot_empty_container {
   display: flex;
-  flex-direction: column;
-  padding: 0 var(--spacing-12) var(--spacing-12) var(--spacing-12);
-  gap: var(--spacing-8);
-}
-
-.empty_state_box_container {
-  padding: 0 var(--spacing-12);
-}
-
-.empty_state_box {
   width: 100%;
-  height: 8.330625rem;
+  height: 100%;
+  flex-direction: column;
+  gap: var(--spacing-16);
+}
+
+.slot_empty_header {
+  display: flex;
+  width: 100%;
+  justify-content: flex-start;
+}
+
+.slot_empty_body {
+  display: flex;
+  width: 100%;
+  height: 100%;
+  padding: var(--spacing-16) var(--spacing-24);
   border-radius: var(--border-radius-4);
   background-color: var(--grey-10);
+  align-items: center;
+  justify-content: center;
 }

--- a/app/src/molecules/SlotDetailsEmptyState/slotdetailsemptystate.module.css
+++ b/app/src/molecules/SlotDetailsEmptyState/slotdetailsemptystate.module.css
@@ -16,9 +16,9 @@
   display: flex;
   width: 100%;
   height: 100%;
+  align-items: center;
+  justify-content: center;
   padding: var(--spacing-16) var(--spacing-24);
   border-radius: var(--border-radius-4);
   background-color: var(--grey-10);
-  align-items: center;
-  justify-content: center;
 }

--- a/app/src/organisms/Desktop/ProtocolVisualization/SlotDetails/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/SlotDetails/index.tsx
@@ -62,61 +62,65 @@ export function SlotDetails(props: SlotDetailsProps): JSX.Element {
     ) ||
     slotId === 'fixedTrash'
 
-
-  const isSlotEmpty =  moduleOnSlot == null &&
-        topMostLabwareOnSlot == null &&
-        !isTrashOnSlot 
+  const isSlotEmpty =
+    moduleOnSlot == null && topMostLabwareOnSlot == null && !isTrashOnSlot
 
   return (
     <>
-    {isSlotEmpty ? <div className={styles.slot_detail_container}><SlotDetailsEmptyState slotId={slotId} /></div> : null}
-    <div className={styles.slot_container}>
-      <div className={styles.slot_details}>
-        <div className={styles.command_step_header}>
-          <div className={styles.slot_detail_header}>
-            <RobotInfoLabel
-              deckLabel={slotId === 'fixedTrash' ? t('fixedTrash') : slotId}
-            />
-            {moduleOnSlot != null ? (
-              <RobotInfoLabel
-                iconName={
-                  MODULE_ICON_NAME_BY_TYPE[moduleEntities[moduleOnSlot[0]].type]
-                }
-              />
-            ) : null}
-          </div>
+      {isSlotEmpty ? (
+        <div className={styles.slot_detail_container}>
+          <SlotDetailsEmptyState slotId={slotId} />
         </div>
-        <Divider />
-        {topMostLabwareOnSlot != null && isTopmostLabwareATiprack ? (
-          <TipPickupContainer
-            tiprackEntity={labwareEntities[topMostLabwareOnSlot]}
-            robotState={robotState}
-          />
-        ) : null}
-        {topMostLabwareOnSlot != null && !isTopmostLabwareATiprack ? (
-          <LabwareSlotContainer
-            topLabwareOnSlotId={topMostLabwareOnSlot}
-            labwareEntities={labwareEntities}
-            commands={commands}
-            currentCommand={command}
-            liquids={liquids}
-            robotState={robotState}
-            pipetteEntities={pipetteEntities}
-            moduleEntities={moduleEntities}
-          />
-        ) : null}
-        {isTrashOnSlot ? (
-          <TipDisposalContainer robotState={robotState} />
-        ) : null}
-        {moduleOnSlot != null ? (
-          <ModuleContainer
-            moduleId={moduleOnSlot[0]}
-            moduleEntities={moduleEntities}
-            moduleRobotState={modules}
-          />
-        ) : null}
+      ) : null}
+      <div className={styles.slot_container}>
+        <div className={styles.slot_details}>
+          <div className={styles.command_step_header}>
+            <div className={styles.slot_detail_header}>
+              <RobotInfoLabel
+                deckLabel={slotId === 'fixedTrash' ? t('fixedTrash') : slotId}
+              />
+              {moduleOnSlot != null ? (
+                <RobotInfoLabel
+                  iconName={
+                    MODULE_ICON_NAME_BY_TYPE[
+                      moduleEntities[moduleOnSlot[0]].type
+                    ]
+                  }
+                />
+              ) : null}
+            </div>
+          </div>
+          <Divider />
+          {topMostLabwareOnSlot != null && isTopmostLabwareATiprack ? (
+            <TipPickupContainer
+              tiprackEntity={labwareEntities[topMostLabwareOnSlot]}
+              robotState={robotState}
+            />
+          ) : null}
+          {topMostLabwareOnSlot != null && !isTopmostLabwareATiprack ? (
+            <LabwareSlotContainer
+              topLabwareOnSlotId={topMostLabwareOnSlot}
+              labwareEntities={labwareEntities}
+              commands={commands}
+              currentCommand={command}
+              liquids={liquids}
+              robotState={robotState}
+              pipetteEntities={pipetteEntities}
+              moduleEntities={moduleEntities}
+            />
+          ) : null}
+          {isTrashOnSlot ? (
+            <TipDisposalContainer robotState={robotState} />
+          ) : null}
+          {moduleOnSlot != null ? (
+            <ModuleContainer
+              moduleId={moduleOnSlot[0]}
+              moduleEntities={moduleEntities}
+              moduleRobotState={modules}
+            />
+          ) : null}
+        </div>
       </div>
-    </div>
     </>
   )
 }

--- a/app/src/organisms/Desktop/ProtocolVisualization/SlotDetails/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/SlotDetails/index.tsx
@@ -22,7 +22,6 @@ import type {
   RunTimeCommand,
 } from '@opentrons/shared-data'
 import type { InvariantContext, RobotState } from '@opentrons/step-generation'
-import { is } from 'date-fns/locale'
 
 interface SlotDetailsProps {
   slotId: string

--- a/app/src/organisms/Desktop/ProtocolVisualization/SlotDetails/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/SlotDetails/index.tsx
@@ -4,7 +4,6 @@ import {
   Divider,
   MODULE_ICON_NAME_BY_TYPE,
   RobotInfoLabel,
-  StyledText,
 } from '@opentrons/components'
 import { getIsTiprack } from '@opentrons/shared-data'
 import { getFullStackFromLabwares } from '@opentrons/step-generation'
@@ -23,6 +22,7 @@ import type {
   RunTimeCommand,
 } from '@opentrons/shared-data'
 import type { InvariantContext, RobotState } from '@opentrons/step-generation'
+import { is } from 'date-fns/locale'
 
 interface SlotDetailsProps {
   slotId: string
@@ -63,14 +63,18 @@ export function SlotDetails(props: SlotDetailsProps): JSX.Element {
     ) ||
     slotId === 'fixedTrash'
 
+
+  const isSlotEmpty =  moduleOnSlot == null &&
+        topMostLabwareOnSlot == null &&
+        !isTrashOnSlot 
+
   return (
+    <>
+    {isSlotEmpty ? <div className={styles.slot_detail_container}><SlotDetailsEmptyState slotId={slotId} /></div> : null}
     <div className={styles.slot_container}>
       <div className={styles.slot_details}>
         <div className={styles.command_step_header}>
           <div className={styles.slot_detail_header}>
-            <StyledText desktopStyle="bodyLargeSemiBold">
-              {t('slot')}
-            </StyledText>
             <RobotInfoLabel
               deckLabel={slotId === 'fixedTrash' ? t('fixedTrash') : slotId}
             />
@@ -112,12 +116,8 @@ export function SlotDetails(props: SlotDetailsProps): JSX.Element {
             moduleRobotState={modules}
           />
         ) : null}
-        {moduleOnSlot == null &&
-        topMostLabwareOnSlot == null &&
-        !isTrashOnSlot ? (
-          <SlotDetailsEmptyState />
-        ) : null}
       </div>
     </div>
+    </>
   )
 }

--- a/app/src/organisms/Desktop/ProtocolVisualization/SlotDetails/slotdetails.module.css
+++ b/app/src/organisms/Desktop/ProtocolVisualization/SlotDetails/slotdetails.module.css
@@ -1,3 +1,13 @@
+.slot_detail_container {
+  display: flex;
+  width: 100%;
+  height: 100%;
+  align-items: center;
+  justify-content: center;
+  padding: var(--spacing-16) var(--spacing-20);
+  background-color: var(--white);
+}
+
 .slot_container {
   display: flex;
   width: 100%;


### PR DESCRIPTION
# Overview

fix slot empty structure to align with the design.
I'm updating SlotDetails components to align with the design and to make maintenance easier. 
This is the first step to do the above.

<img width="501" height="480" alt="Screenshot 2025-12-04 at 12 45 04 PM" src="https://github.com/user-attachments/assets/3573c0ab-d9b2-43c7-9fdf-adf7f5fb584a" />


close RQA-4892

## Test Plan and Hands on Testing
- select a protocol
- click visualization button
- click an empty slot

## Changelog
- move `SlotDetailsEmptyState` in `SlotDetails` 
- add the basic test to `SlotDetailsEmptyState`

## Review requests


## Risk assessment
low
