### PR TITLE
feat(app): livestream image capture button

### DIFF
--- a/app/src/assets/localization/en/run_details.json
+++ b/app/src/assets/localization/en/run_details.json
@@ -21,6 +21,7 @@
   "cancel_run_module_info": "Additionally, any hardware modules used within the protocol will remain active and maintain their current states until deactivated.",
   "canceling_run": "Canceling Run",
   "canceling_run_dot": "canceling run...",
+  "capture_image": "Capture image",
   "clear_protocol": "Clear protocol",
   "clear_protocol_to_make_available": "Clear protocol from robot to make it available.",
   "close_door": "Close robot door",

--- a/app/src/pages/Desktop/LivestreamViewer/index.tsx
+++ b/app/src/pages/Desktop/LivestreamViewer/index.tsx
@@ -16,6 +16,7 @@ import {
   LivestreamInfoScreen,
   useLivestreamInfoScreen,
 } from '/app/pages/Desktop/LivestreamViewer/LivestreamInfoScreen'
+import { useFeatureFlag } from '/app/redux/config'
 import { useCurrentRunId, useNotifyRunQuery } from '/app/resources/runs'
 
 import styles from './livestream.module.css'
@@ -53,6 +54,7 @@ export function LivestreamViewer(): JSX.Element {
     isCurrentRunLoading,
     videoError
   )
+  const liveStreamImageCaptureEnabled = useFeatureFlag('camera')
 
   useReportWindowDurationEvent(
     retainedRunId,
@@ -81,7 +83,7 @@ export function LivestreamViewer(): JSX.Element {
           </div>
         )}
       </div>
-      {infoScreenType == null && (
+      {infoScreenType == null && liveStreamImageCaptureEnabled && (
         <Btn
           className={styles.capture_image_button}
           backgroundColor={COLORS.blue50}
@@ -89,7 +91,7 @@ export function LivestreamViewer(): JSX.Element {
           <Flex className={styles.capture_image_button_text}>
             <Icon name="camera" size="1rem" color={COLORS.white} />
             <StyledText color={COLORS.white} desktopStyle="bodyDefaultSemiBold">
-              {t('capture_image')}{' '}
+              {t('capture_image')}
             </StyledText>
           </Flex>
         </Btn>

--- a/app/src/pages/Desktop/LivestreamViewer/index.tsx
+++ b/app/src/pages/Desktop/LivestreamViewer/index.tsx
@@ -1,7 +1,14 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { Chip } from '@opentrons/components'
+import {
+  Btn,
+  Chip,
+  COLORS,
+  Flex,
+  Icon,
+  StyledText,
+} from '@opentrons/components'
 
 import { useHlsVideo } from '/app/pages/Desktop/LivestreamViewer/hooks/useHlsVideo'
 import { useReportWindowDurationEvent } from '/app/pages/Desktop/LivestreamViewer/hooks/useReportWindowDurationEvent'
@@ -19,6 +26,8 @@ export function LivestreamViewer(): JSX.Element {
   // We make UI affordances when a run has ended, even if it is un-currented.
   // The livestream viewer makes the assumption that it will not *initially* render
   // for a run that is already historical.
+  const { t } = useTranslation('run_details')
+
   const [retainedRunId, setRetainedRunId] = useState<string | null>(null)
   const currentRunId = useCurrentRunId({
     refetchInterval: RUN_POLLING_INTERVAL_MS,
@@ -72,6 +81,19 @@ export function LivestreamViewer(): JSX.Element {
           </div>
         )}
       </div>
+      {infoScreenType == null && (
+        <Btn
+          className={styles.capture_image_button}
+          backgroundColor={COLORS.blue50}
+        >
+          <Flex className={styles.capture_image_button_text}>
+            <Icon name="camera" size="1rem" color={COLORS.white} />
+            <StyledText color={COLORS.white} desktopStyle="bodyDefaultSemiBold">
+              {t('capture_image')}{' '}
+            </StyledText>
+          </Flex>
+        </Btn>
+      )}
     </div>
   )
 }

--- a/app/src/pages/Desktop/LivestreamViewer/livestream.module.css
+++ b/app/src/pages/Desktop/LivestreamViewer/livestream.module.css
@@ -36,3 +36,16 @@
 .video_inactive {
   display: none;
 }
+
+.capture_image_button {
+  width: 100%;
+  height: 36px;
+  border-radius: var(--border-radius-8);
+}
+
+.capture_image_button_text {
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-8);
+}


### PR DESCRIPTION
# Overview

Add non functional livestream image capture button hidden behind the camera settings feature flag

## Test Plan and Hands on Testing

Smoke tested on ODD w/o feature flag on
<img width="491" height="430" alt="Screenshot 2025-12-04 at 2 56 59 PM" src="https://github.com/user-attachments/assets/750a5315-4eee-4dbc-8a8d-698d8784683a" />

## Review requests



## Risk assessment

low

Closes EXEC-2101
