### PR TITLE
chore: 8.8 stable release notes

### DIFF
--- a/app-shell/build/release-notes.md
+++ b/app-shell/build/release-notes.md
@@ -24,6 +24,10 @@ Welcome to the v8.8.0 release of the Opentrons App! This release includes concur
 - An attached pipette no longer descends to attach a calibration probe for Labware Position Check, creating more clearance on the deck.
 - Changed runtime parameters no longer revert to their default values.
 
+### Known Issues
+
+- Error recovery in the app or on the Flex touchscreen can't successfully resolve overpressure errors that occur during a dynamic aspirate or dispense. We recommend canceling the protocol when these errors occur.
+
 ---
 
 ## Opentrons App Changes in 8.7.0


### PR DESCRIPTION
# Overview

Adds a known issue (reported in [RQA-4939 ](https://opentrons.atlassian.net/browse/RQA-4939)) to the 8.8. release notes. 

## Test Plan and Hands on Testing



## Changelog

One-line change to the app release notes. 

## Review requests

Does this cover the issue? Added that we would recommend canceling, as the flow is: 
- error recovery _does_ launch
- users can click **retry** or **cancel**
- "retry" will run but never succeed 
- 
## Risk assessment

low. 
