### PR TITLE
feat(app): show QT runs in RecentProtocolRuns

### DIFF
--- a/app/src/organisms/Desktop/Devices/RecentProtocolRuns.tsx
+++ b/app/src/organisms/Desktop/Devices/RecentProtocolRuns.tsx
@@ -40,13 +40,7 @@ export function RecentProtocolRuns({
   const currentRunId = useCurrentRunId()
   const { isRunTerminal } = useRunStatuses()
   const robotIsBusy = currentRunId != null ? !isRunTerminal : false
-  const nonQuickTransferRuns = runs?.filter(run => {
-    const protocol = protocols?.data?.data.find(
-      protocol => protocol.id === run.protocolId
-    )
-    return protocol?.protocolKind !== 'quick-transfer'
-  })
-
+  const allRunsMutable = [...(runs ?? [])]
   return (
     <Flex
       alignItems={ALIGN_FLEX_START}
@@ -73,84 +67,82 @@ export function RecentProtocolRuns({
         paddingX={SPACING.spacing16}
         width="100%"
       >
-        {isRobotViewable &&
-          nonQuickTransferRuns &&
-          nonQuickTransferRuns?.length > 0 && (
-            <>
-              <Flex
-                justifyContent={JUSTIFY_FLEX_START}
-                padding={SPACING.spacing8}
-                width="88%"
-                marginRight="12%"
-                gridGap={SPACING.spacing20}
-                color={COLORS.grey60}
+        {isRobotViewable && allRunsMutable && allRunsMutable?.length > 0 && (
+          <>
+            <Flex
+              justifyContent={JUSTIFY_FLEX_START}
+              padding={SPACING.spacing8}
+              width="88%"
+              marginRight="12%"
+              gridGap={SPACING.spacing20}
+              color={COLORS.grey60}
+            >
+              <LegacyStyledText
+                as="p"
+                width="25%"
+                data-testid="RecentProtocolRuns_RunTitle"
               >
-                <LegacyStyledText
-                  as="p"
-                  width="25%"
-                  data-testid="RecentProtocolRuns_RunTitle"
-                >
-                  {t('run')}
-                </LegacyStyledText>
-                <LegacyStyledText
-                  as="p"
-                  width="27%"
-                  data-testid="RecentProtocolRuns_ProtocolTitle"
-                >
-                  {t('protocol')}
-                </LegacyStyledText>
-                <LegacyStyledText
-                  as="p"
-                  width="5%"
-                  data-testid="RecentProtocolRuns_FilesTitle"
-                >
-                  {t('files')}
-                </LegacyStyledText>
-                <LegacyStyledText
-                  as="p"
-                  width="14%"
-                  data-testid="RecentProtocolRuns_StatusTitle"
-                >
-                  {t('status')}
-                </LegacyStyledText>
-                <LegacyStyledText
-                  as="p"
-                  width="14%"
-                  data-testid="RecentProtocolRuns_DurationTitle"
-                >
-                  {t('run_duration')}
-                </LegacyStyledText>
-              </Flex>
-              {nonQuickTransferRuns
-                .sort(
-                  (a, b) =>
-                    new Date(b.createdAt).getTime() -
-                    new Date(a.createdAt).getTime()
+                {t('run')}
+              </LegacyStyledText>
+              <LegacyStyledText
+                as="p"
+                width="27%"
+                data-testid="RecentProtocolRuns_ProtocolTitle"
+              >
+                {t('protocol')}
+              </LegacyStyledText>
+              <LegacyStyledText
+                as="p"
+                width="5%"
+                data-testid="RecentProtocolRuns_FilesTitle"
+              >
+                {t('files')}
+              </LegacyStyledText>
+              <LegacyStyledText
+                as="p"
+                width="14%"
+                data-testid="RecentProtocolRuns_StatusTitle"
+              >
+                {t('status')}
+              </LegacyStyledText>
+              <LegacyStyledText
+                as="p"
+                width="14%"
+                data-testid="RecentProtocolRuns_DurationTitle"
+              >
+                {t('run_duration')}
+              </LegacyStyledText>
+            </Flex>
+            {allRunsMutable
+              .sort(
+                (a, b) =>
+                  new Date(b.createdAt).getTime() -
+                  new Date(a.createdAt).getTime()
+              )
+
+              .map((run, index) => {
+                const protocol = protocols?.data?.data.find(
+                  protocol => protocol.id === run.protocolId
                 )
+                const protocolName =
+                  protocol?.metadata.protocolName ??
+                  protocol?.files[0].name ??
+                  t('shared:loading') ??
+                  ''
 
-                .map((run, index) => {
-                  const protocol = protocols?.data?.data.find(
-                    protocol => protocol.id === run.protocolId
-                  )
-                  const protocolName =
-                    protocol?.metadata.protocolName ??
-                    protocol?.files[0].name ??
-                    t('shared:loading') ??
-                    ''
-
-                  return (
-                    <HistoricalProtocolRun
-                      run={run}
-                      protocolName={protocolName}
-                      protocolKey={protocol?.key}
-                      robotName={robotName}
-                      robotIsBusy={robotIsBusy}
-                      key={index}
-                    />
-                  )
-                })}
-            </>
-          )}
+                return (
+                  <HistoricalProtocolRun
+                    run={run}
+                    protocolName={protocolName}
+                    protocolKey={protocol?.key}
+                    robotName={robotName}
+                    robotIsBusy={robotIsBusy}
+                    key={index}
+                  />
+                )
+              })}
+          </>
+        )}
         {!isRobotViewable && (
           <LegacyStyledText
             as="p"
@@ -163,19 +155,17 @@ export function RecentProtocolRuns({
             {t('offline_recent_protocol_runs')}
           </LegacyStyledText>
         )}
-        {isRobotViewable &&
-          (nonQuickTransferRuns == null ||
-            nonQuickTransferRuns.length === 0) && (
-            <LegacyStyledText
-              as="p"
-              alignItems={ALIGN_CENTER}
-              display={DISPLAY_FLEX}
-              flex="1 0"
-              id="RecentProtocolRuns_no_runs"
-            >
-              {t('no_protocol_runs')}
-            </LegacyStyledText>
-          )}
+        {isRobotViewable && allRunsMutable?.length === 0 && (
+          <LegacyStyledText
+            as="p"
+            alignItems={ALIGN_CENTER}
+            display={DISPLAY_FLEX}
+            flex="1 0"
+            id="RecentProtocolRuns_no_runs"
+          >
+            {t('no_protocol_runs')}
+          </LegacyStyledText>
+        )}
       </Flex>
     </Flex>
   )

--- a/app/src/organisms/Desktop/Devices/__tests__/RecentProtocolRuns.test.tsx
+++ b/app/src/organisms/Desktop/Devices/__tests__/RecentProtocolRuns.test.tsx
@@ -3,6 +3,8 @@ import { beforeEach, describe, it, vi } from 'vitest'
 
 import '@testing-library/jest-dom/vitest'
 
+import { useAllProtocolsQuery } from '@opentrons/react-api-client'
+
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
 import { useIsRobotViewable } from '/app/redux-resources/robots'
@@ -13,8 +15,9 @@ import { RecentProtocolRuns } from '../RecentProtocolRuns'
 
 import type { AxiosError } from 'axios'
 import type { UseQueryResult } from 'react-query'
-import type { Runs } from '@opentrons/api-client'
+import type { Protocols, Runs } from '@opentrons/api-client'
 
+vi.mock('@opentrons/react-api-client')
 vi.mock('/app/redux-resources/robots')
 vi.mock('/app/resources/runs')
 vi.mock('../HistoricalProtocolRun')
@@ -74,6 +77,37 @@ describe('RecentProtocolRuns', () => {
     screen.getByText('Protocol')
     screen.getByText('Status')
     screen.getByText('Run duration')
+    screen.getByText('mock HistoricalProtocolRun')
+  })
+  it('renders quick transfer runs', () => {
+    vi.mocked(useIsRobotViewable).mockReturnValue(true)
+    vi.mocked(useAllProtocolsQuery).mockReturnValue({
+      data: {
+        data: [
+          {
+            id: 'test_protocol_id',
+            protocolKind: 'quick-transfer',
+            metadata: {
+              protocolName: 'test protocol',
+            },
+          },
+        ],
+      },
+    } as any as UseQueryResult<Protocols, AxiosError>)
+    vi.mocked(useNotifyAllRunsQuery).mockReturnValue({
+      data: {
+        data: [
+          {
+            createdAt: '2022-05-04T18:24:40.833862+00:00',
+            current: false,
+            id: 'test_id',
+            protocolId: 'test_protocol_id',
+            status: 'succeeded',
+          },
+        ] as any as Runs,
+      },
+    } as any as UseQueryResult<Runs, AxiosError>)
+    render()
     screen.getByText('mock HistoricalProtocolRun')
   })
 })

--- a/app/src/organisms/ODD/RunningProtocol/ConfirmCancelRunModal/index.tsx
+++ b/app/src/organisms/ODD/RunningProtocol/ConfirmCancelRunModal/index.tsx
@@ -6,7 +6,6 @@ import { useNavigate } from 'react-router-dom'
 import { RUN_STATUS_STOPPED } from '@opentrons/api-client'
 import { COLORS, LegacyStyledText } from '@opentrons/components'
 import {
-  useDeleteRunMutation,
   useDismissCurrentRunMutation,
   useStopRunMutation,
 } from '@opentrons/react-api-client'
@@ -40,20 +39,8 @@ export function ConfirmCancelRunModal({
 }: ConfirmCancelRunModalProps): JSX.Element {
   const { t } = useTranslation(['run_details', 'shared'])
   const { stopRun } = useStopRunMutation()
-  const { deleteRun } = useDeleteRunMutation({
-    onError: error => {
-      setIsCanceling(false)
-      console.error('Error deleting quick transfer run', error)
-    },
-  })
   const { dismissCurrentRun, isLoading: isDismissing } =
-    useDismissCurrentRunMutation({
-      onSettled: () => {
-        if (isQuickTransfer) {
-          deleteRun(runId)
-        }
-      },
-    })
+    useDismissCurrentRunMutation()
   const localRobot = useSelector(getLocalRobot)
   const { data, isError: isRunFetchError } = useNotifyRunQuery(runId)
   const runStatus = data?.data.status

--- a/app/src/pages/ODD/RobotDashboard/index.tsx
+++ b/app/src/pages/ODD/RobotDashboard/index.tsx
@@ -31,7 +31,6 @@ export function RobotDashboard(): JSX.Element {
   const { t } = useTranslation('device_details')
   const { data: allRunsQueryData, error: allRunsQueryError } =
     useNotifyAllRunsQuery()
-  const protocols = useAllProtocolsQuery()
 
   const { unfinishedUnboxingFlowRoute } = useSelector(
     getOnDeviceDisplaySettings

--- a/app/src/pages/ODD/RobotDashboard/index.tsx
+++ b/app/src/pages/ODD/RobotDashboard/index.tsx
@@ -10,7 +10,6 @@ import {
   SPACING,
   TYPOGRAPHY,
 } from '@opentrons/components'
-import { useAllProtocolsQuery } from '@opentrons/react-api-client'
 
 import { Navigation } from '/app/organisms/ODD/Navigation'
 import {

--- a/app/src/pages/ODD/RobotDashboard/index.tsx
+++ b/app/src/pages/ODD/RobotDashboard/index.tsx
@@ -46,11 +46,6 @@ export function RobotDashboard(): JSX.Element {
         acc.some(collectedRun => collectedRun.protocolId === run.protocolId)
       ) {
         return acc
-      } else if (
-        protocols?.data?.data.find(protocol => protocol.id === run.protocolId)
-          ?.protocolKind === 'quick-transfer'
-      ) {
-        return acc
       } else {
         return [...acc, run]
       }

--- a/app/src/pages/ODD/RunSummary/index.tsx
+++ b/app/src/pages/ODD/RunSummary/index.tsx
@@ -126,11 +126,6 @@ export function RunSummary(): JSX.Element {
   const localRobot = useSelector(getLocalRobot)
   const robotName = localRobot?.name ?? 'no name'
   const robotType = useRobotType(robotName)
-  const onCloneRunSuccess = (): void => {
-    if (isQuickTransfer) {
-      deleteRun(runId)
-    }
-  }
 
   const { trackProtocolRunEvent } = useTrackProtocolRunEvent(
     runId,
@@ -146,7 +141,7 @@ export function RunSummary(): JSX.Element {
     }
   }, [isRunCurrent, enteredER])
 
-  const { reset, isResetRunLoading } = useRunControls(runId, onCloneRunSuccess)
+  const { reset, isResetRunLoading } = useRunControls(runId)
   const trackEvent = useTrackEvent()
   const { trackEventWithRobotSerial } = useTrackEventWithRobotSerial()
 


### PR DESCRIPTION
# Overview

With the decision to treat Quick Transfer protocols more like standard protocols, we want to show them in the desktop app's `RecentProtocolRuns` component. This also allows us to view and download any files from the run, which as of now would include photos taken during any potential error recovery.

There are also a few instances in ODD where we implicitly delete QT runs. We don't want to do this!

Closes EXEC-2090

## Test Plan and Hands on Testing

#### Desktop
- created and ran a quick transfer protocol
- on the used device's recent protocol runs section, verified that the quick transfer run is present
<img width="692" height="168" alt="Screenshot 2025-12-04 at 1 18 34 PM" src="https://github.com/user-attachments/assets/74c0a42e-83ef-4d1c-9e04-fa9059b3029d" />  

- added unit tests

#### ODD
- remove implicit QT run deletions

## Changelog

- remove filter for runs with protocols of type `quick-transfer` in desktop `RecentProtocolRuns` and ODD `RobotDashboard`
- remove quick transfer run deletion on run cancellation

## Review requests

See test plan. Please make sure the changes to ODD reflect the intention of the ticket.

## Risk assessment

lowish