### PR TITLE
feat(app): add Skeleton component for second window

### DIFF
--- a/app/src/pages/Desktop/StepDetailViewer/SkeletonForSlotDetail.tsx
+++ b/app/src/pages/Desktop/StepDetailViewer/SkeletonForSlotDetail.tsx
@@ -1,18 +1,29 @@
-import { BORDERS } from "@opentrons/components";
-import { Skeleton } from "/app/atoms/Skeleton";
-import styles from "./skeletonforslotdetail.module.css";
+import { BORDERS } from '@opentrons/components'
 
+import { Skeleton } from '/app/atoms/Skeleton'
+
+import styles from './skeletonforslotdetail.module.css'
 
 // backgroundSize 23px + 360px from the default design size
 export function SkeletonForSlotDetail(): JSX.Element {
   return (
-     <div className={styles.slot_loading_container}>
+    <div className={styles.slot_loading_container}>
       <div className={styles.slot_loading_header}>
-        <Skeleton width="23px" height="20px" borderRadius={BORDERS.borderRadius4}  backgroundSize="24rem" />
+        <Skeleton
+          width="23px"
+          height="20px"
+          borderRadius={BORDERS.borderRadius4}
+          backgroundSize="24rem"
+        />
       </div>
       <div className={styles.slot_loading_body}>
-        <Skeleton width="100%" height="100%" backgroundSize="24rem" borderRadius={BORDERS.borderRadius4} />
+        <Skeleton
+          width="100%"
+          height="100%"
+          backgroundSize="24rem"
+          borderRadius={BORDERS.borderRadius4}
+        />
       </div>
     </div>
-  );
+  )
 }

--- a/app/src/pages/Desktop/StepDetailViewer/SkeletonForSlotDetail.tsx
+++ b/app/src/pages/Desktop/StepDetailViewer/SkeletonForSlotDetail.tsx
@@ -1,0 +1,18 @@
+import { BORDERS } from "@opentrons/components";
+import { Skeleton } from "/app/atoms/Skeleton";
+import styles from "./skeletonforslotdetail.module.css";
+
+
+// backgroundSize 23px + 360px from the default design size
+export function SkeletonForSlotDetail(): JSX.Element {
+  return (
+     <div className={styles.slot_loading_container}>
+      <div className={styles.slot_loading_header}>
+        <Skeleton width="23px" height="20px" borderRadius={BORDERS.borderRadius4}  backgroundSize="24rem" />
+      </div>
+      <div className={styles.slot_loading_body}>
+        <Skeleton width="100%" height="100%" backgroundSize="24rem" borderRadius={BORDERS.borderRadius4} />
+      </div>
+    </div>
+  );
+}

--- a/app/src/pages/Desktop/StepDetailViewer/__tests__/SkeletonForSlotDetail.test.tsx
+++ b/app/src/pages/Desktop/StepDetailViewer/__tests__/SkeletonForSlotDetail.test.tsx
@@ -1,21 +1,23 @@
-import { it, vi, describe, beforeEach, expect } from 'vitest'
-import { Skeleton } from '/app/atoms/Skeleton'
-import { renderWithProviders } from '/app/__testing-utils__'
 import { screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { renderWithProviders } from '/app/__testing-utils__'
+import { Skeleton } from '/app/atoms/Skeleton'
+
 import { SkeletonForSlotDetail } from '../SkeletonForSlotDetail'
 
 vi.mock('/app/atoms/Skeleton')
 
 const render = () => {
-  return renderWithProviders(<SkeletonForSlotDetail/>)
+  return renderWithProviders(<SkeletonForSlotDetail />)
 }
 
 describe('SkeletonForSlotDetail', () => {
-    beforeEach(() => {
-        vi.mocked(Skeleton).mockReturnValue(<div>mock Skeleton</div>)
-    })
-    it('should render two Skeleton components', () => {
-        render()
-        expect(screen.getAllByText('mock Skeleton')).toHaveLength(2)
-    })
+  beforeEach(() => {
+    vi.mocked(Skeleton).mockReturnValue(<div>mock Skeleton</div>)
+  })
+  it('should render two Skeleton components', () => {
+    render()
+    expect(screen.getAllByText('mock Skeleton')).toHaveLength(2)
+  })
 })

--- a/app/src/pages/Desktop/StepDetailViewer/__tests__/SkeletonForSlotDetail.test.tsx
+++ b/app/src/pages/Desktop/StepDetailViewer/__tests__/SkeletonForSlotDetail.test.tsx
@@ -1,0 +1,21 @@
+import { it, vi, describe, beforeEach, expect } from 'vitest'
+import { Skeleton } from '/app/atoms/Skeleton'
+import { renderWithProviders } from '/app/__testing-utils__'
+import { screen } from '@testing-library/react'
+import { SkeletonForSlotDetail } from '../SkeletonForSlotDetail'
+
+vi.mock('/app/atoms/Skeleton')
+
+const render = () => {
+  return renderWithProviders(<SkeletonForSlotDetail/>)
+}
+
+describe('SkeletonForSlotDetail', () => {
+    beforeEach(() => {
+        vi.mocked(Skeleton).mockReturnValue(<div>mock Skeleton</div>)
+    })
+    it('should render two Skeleton components', () => {
+        render()
+        expect(screen.getAllByText('mock Skeleton')).toHaveLength(2)
+    })
+})

--- a/app/src/pages/Desktop/StepDetailViewer/index.tsx
+++ b/app/src/pages/Desktop/StepDetailViewer/index.tsx
@@ -9,6 +9,7 @@ import type {
   RunTimeCommand,
 } from '@opentrons/shared-data'
 import type { InvariantContext, RobotState } from '@opentrons/step-generation'
+import { SkeletonForSlotDetail } from './SkeletonForSlotDetail'
 
 interface StepDetailData {
   analysis: ProtocolAnalysisOutput
@@ -73,8 +74,8 @@ export function StepDetailViewer(): JSX.Element {
     }
   }, [protocolKey])
 
-  if (loading) {
-    return <div>loading</div>
+  if (true) {
+    return <SkeletonForSlotDetail />
   }
   if (!data) {
     return <div>no data found</div>

--- a/app/src/pages/Desktop/StepDetailViewer/index.tsx
+++ b/app/src/pages/Desktop/StepDetailViewer/index.tsx
@@ -3,13 +3,15 @@ import { useParams } from 'react-router-dom'
 
 import { SlotDetails } from '/app/organisms/Desktop/ProtocolVisualization/SlotDetails'
 
+import { SkeletonForSlotDetail } from './SkeletonForSlotDetail'
+
 import type {
   Liquid,
   ProtocolAnalysisOutput,
   RunTimeCommand,
 } from '@opentrons/shared-data'
 import type { InvariantContext, RobotState } from '@opentrons/step-generation'
-import { SkeletonForSlotDetail } from './SkeletonForSlotDetail'
+
 interface StepDetailData {
   analysis: ProtocolAnalysisOutput
   robotState: RobotState

--- a/app/src/pages/Desktop/StepDetailViewer/index.tsx
+++ b/app/src/pages/Desktop/StepDetailViewer/index.tsx
@@ -10,7 +10,6 @@ import type {
 } from '@opentrons/shared-data'
 import type { InvariantContext, RobotState } from '@opentrons/step-generation'
 import { SkeletonForSlotDetail } from './SkeletonForSlotDetail'
-
 interface StepDetailData {
   analysis: ProtocolAnalysisOutput
   robotState: RobotState
@@ -74,7 +73,7 @@ export function StepDetailViewer(): JSX.Element {
     }
   }, [protocolKey])
 
-  if (true) {
+  if (loading) {
     return <SkeletonForSlotDetail />
   }
   if (!data) {

--- a/app/src/pages/Desktop/StepDetailViewer/skeletonforslotdetail.module.css
+++ b/app/src/pages/Desktop/StepDetailViewer/skeletonforslotdetail.module.css
@@ -1,0 +1,24 @@
+.slot_loading_container {
+  display: flex;
+  width: 100%;
+  height: 100%;
+  flex-direction: column;
+  padding: var(--spacing-16) var(--spacing-20);
+  gap: var(--spacing-16);
+}
+
+.slot_loading_header {
+  display: flex;
+  width: 100%;
+  justify-content: flex-start;
+}
+
+.slot_loading_body {
+  display: flex;
+  width: 100%;
+  height: 100%;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--border-radius-4);
+  background-color: var(--grey-10);
+}


### PR DESCRIPTION

# Overview
add Skeleton component for second window



https://github.com/user-attachments/assets/3a9464e8-9055-4ed7-846a-017a855a5b9b



close AUTH-2558

## Test Plan and Hands on Testing
- select a protocol
- click visualization button
- click a slot

## Changelog
- add SkeletonForSlotDetail component and its test

## Review requests


## Risk assessment
low