### PR TITLE
chore: add known issue with image access to 8.8 release notes

### DIFF
--- a/app-shell/build/release-notes.md
+++ b/app-shell/build/release-notes.md
@@ -27,6 +27,7 @@ Welcome to the v8.8.0 release of the Opentrons App! This release includes concur
 ### Known Issues
 
 - Error recovery in the app or on the Flex touchscreen can't successfully resolve overpressure errors that occur during a dynamic aspirate or dispense. We recommend canceling the protocol when these errors occur.
+- Images captured in a protocol are not available during the run via USB. Use a different connection type (Wi-Fi or Ethernet), view the images on the touchscreen, or download the images after the run is complete.
 
 ---
 


### PR DESCRIPTION
# Overview

adds a description of a known issue (described [here](https://opentrons.slack.com/archives/C09LFJJMUD8/p1764873415007959)) with accessing camera images during a run via USB. 

## Test Plan and Hands on Testing



## Changelog

one-line addition to known issues in app release notes. 

## Review requests


## Risk assessment

low. 
