### PR TITLE
fix(protocol-designer): migrate labware locations to latest version too

### DIFF
--- a/protocol-designer/src/step-forms/reducers/index.ts
+++ b/protocol-designer/src/step-forms/reducers/index.ts
@@ -381,7 +381,16 @@ export const savedStepForms = (
           allLabware,
           latestDefs
         )
-        acc[updatedLabwareId] = location
+        // The `location` can be a labwareId too, so update its version as well.
+        // (We only recently realized that we need to update `location`, so there are
+        // probably saved protocols out there where we hadn't updated `location` and
+        // it refers to a labwareId that doesn't exist in metadata.labware.)
+        const [locationUUID, locationDefURI] = location.split(':')
+        const updatedLocation =
+          locationDefURI && locationDefURI in allLabware
+            ? `${locationUUID}:${getMigratedURI(locationDefURI, allLabware, latestDefs)}`
+            : location
+        acc[updatedLabwareId] = updatedLocation
         return acc
       }, {})
 


### PR DESCRIPTION
# Overview

When we import a protocol, we upgrade its labware to the latest available versions. Protocols have an `__INITIAL_DECK_SETUP_STEP__: labwareLocationUpdate` section that looks like this:
```
{ "uuid:opentrons/labware/1": "location" }
```
Often the `location` is a slot. But with stacking, `location` could also be the labwareID of some other labware.

But in the implementation where we updated the labware versions, we only updated the keys of this map, but not the `location` values: https://github.com/Opentrons/opentrons/blob/cc11d93b785d95babd4e483fd0c1aacf7ae7230d/protocol-designer/src/step-forms/reducers/index.ts#L384

This results in malformed protocols where the `location` contains labwareIDs that no longer exist after migration. This also causes the `LabwareTemporalProperties.stack` to be malformed, causing problems like RQA-4935.

This PR updates the labware version in `location` as well if `location` is a labwareID.

Note that there are probably a bunch of protocols out there created before this fix that have broken references in `labwareLocationUpdate`.

## Test Plan and Hands on Testing

Import Alex's protocol from the bug ticket. There is supposed to be a lid on the well plate in slot 3, but the lid is not visible without this PR. Also the "Materials list" page is malformed. And the exported Python protocol is very malformed.

After this PR, we correctly show the lid on top of the well plate. And the protocol now passes analysis if you re-export it.

## Review requests

Is there some better way to detect when `location` contains a labwareID? In this PR, I just attempt to split it on `':'` and try to look up the labware URI in the `labwareDefs`.

## Risk assessment

Low.