### PR TITLE
fix(protocol-designer): use correct degree symbol again: ˚ -> °

### DIFF
--- a/protocol-designer/src/assets/localization/en/modal.json
+++ b/protocol-designer/src/assets/localization/en/modal.json
@@ -98,8 +98,8 @@
   },
   "auto_add_pause_until_temp_step": {
     "heater_shaker": {
-      "body": "<p>A pause step to wait for the Heater-Shaker to reach {{temperature}}\u00a0˚C will automatically be added to the timeline.</p><p>You can insert steps before the pause to run them in-parallel while the module heats or cools.</p>",
-      "title": "Pause until Heater-Shaker reaches {{temperature}}\u00a0˚C"
+      "body": "<p>A pause step to wait for the Heater-Shaker to reach {{temperature}}\u00a0°C will automatically be added to the timeline.</p><p>You can insert steps before the pause to run them in-parallel while the module heats or cools.</p>",
+      "title": "Pause until Heater-Shaker reaches {{temperature}}\u00a0°C"
     },
     "legacy": {
       "body": "Add a pause step to wait until the {{module}} reaches {{temp}} °C. Click Skip to continue to the next protocol step without pausing.",
@@ -108,16 +108,16 @@
       "title": "Pause protocol until {{module}} reaches {{temp}} °C?"
     },
     "temperature_module": {
-      "body": "<p>A pause step to wait for the Temperature Module to reach {{temperature}}\u00a0˚C will automatically be added to the timeline.</p><p>You can insert steps before the pause to run them in-parallel while the module heats or cools.</p>",
-      "title": "Pause until Temperature Module reaches {{temperature}}\u00a0˚C"
+      "body": "<p>A pause step to wait for the Temperature Module to reach {{temperature}}\u00a0°C will automatically be added to the timeline.</p><p>You can insert steps before the pause to run them in-parallel while the module heats or cools.</p>",
+      "title": "Pause until Temperature Module reaches {{temperature}}\u00a0°C"
     },
     "thermocycler_block": {
-      "body": "<p>A pause step to wait for the Thermocycler Block to reach {{temperature}}\u00a0˚C will automatically be added to the timeline.</p><p>You can insert steps before the pause to run them in-parallel while the module heats or cools.</p>",
-      "title": "Pause until Thermocycler Block reaches {{temperature}}\u00a0˚C"
+      "body": "<p>A pause step to wait for the Thermocycler Block to reach {{temperature}}\u00a0°C will automatically be added to the timeline.</p><p>You can insert steps before the pause to run them in-parallel while the module heats or cools.</p>",
+      "title": "Pause until Thermocycler Block reaches {{temperature}}\u00a0°C"
     },
     "thermocycler_lid": {
-      "body": "<p>A pause step to wait for the Thermocycler Lid to reach {{temperature}}\u00a0˚C will automatically be added to the timeline.</p><p>You can insert steps before the pause to run them in-parallel while the module heats or cools.</p>",
-      "title": "Pause until Thermocycler Lid reaches {{temperature}}\u00a0˚C"
+      "body": "<p>A pause step to wait for the Thermocycler Lid to reach {{temperature}}\u00a0°C will automatically be added to the timeline.</p><p>You can insert steps before the pause to run them in-parallel while the module heats or cools.</p>",
+      "title": "Pause until Thermocycler Lid reaches {{temperature}}\u00a0°C"
     },
     "thermocycler_profile": {
       "body": "<p>The protocol will wait for the Thermocycler profile to complete before continuing to the next step.</p><p>You can insert steps between the start profile and wait for profile to complete check points to run them in-parallel while the profile executes.</p>",


### PR DESCRIPTION
# Overview

Unicode has several ring-like symbols:
- `˚` is a diacritic mark, such as in `å`.
- `°` is the degree symbol.

We previously (PR #18369) fixed all the incorrect ring symbols, but more have snuck in since last time.

## Test Plan and Hands on Testing

Run CI tests.

## Risk assessment

Low.