### PR TITLE
feat(protocol-designer): add flex stacker form data

### DIFF
--- a/protocol-designer/src/constants.ts
+++ b/protocol-designer/src/constants.ts
@@ -93,6 +93,12 @@ export const ABSORBANCE_READER_COLOR_BY_WAVELENGTH: Record<number, string> = {
   650: 'Red',
 }
 
+// Values for flex stacker
+export const FLEX_STACKER_RETRIEVE: 'retrieve' = 'retrieve'
+export const FLEX_STACKER_STORE: 'store' = 'store'
+export const FLEX_STACKER_FILL: 'fill' = 'fill'
+export const FLEX_STACKER_EMPTY: 'empty' = 'empty'
+
 export const OFFDECK: 'offDeck' = 'offDeck'
 
 export const PROTOCOL_DESIGNER_SOURCE: 'Protocol Designer' = 'Protocol Designer' // protocolSource for tracking analytics in the app

--- a/protocol-designer/src/form-types.ts
+++ b/protocol-designer/src/form-types.ts
@@ -21,6 +21,10 @@ import type {
   ABSORBANCE_READER_INITIALIZE_MODE_SINGLE,
   ABSORBANCE_READER_LID,
   ABSORBANCE_READER_READ,
+  FLEX_STACKER_EMPTY,
+  FLEX_STACKER_FILL,
+  FLEX_STACKER_RETRIEVE,
+  FLEX_STACKER_STORE,
   PAUSE_UNTIL_RESUME,
   PAUSE_UNTIL_TC_PROFILE_COMPLETE,
   PAUSE_UNTIL_TEMP,
@@ -163,6 +167,7 @@ export type StepType =
   | 'absorbanceReader'
   | 'camera'
   | 'comment'
+  | 'flexStacker'
   | 'heaterShaker'
   | 'magnet'
   | 'manualIntervention'
@@ -178,16 +183,16 @@ export const stepIconsByType: Record<StepType, IconName> = {
   absorbanceReader: 'ot-absorbance',
   camera: 'camera',
   comment: 'comment',
+  flexStacker: 'ot-flex-stacker',
+  heaterShaker: 'ot-heater-shaker',
+  magnet: 'ot-magnet-v2',
+  manualIntervention: 'pause-circle',
+  mix: 'mix',
   moveLabware: 'ot-move',
   moveLiquid: 'transfer',
-  mix: 'mix',
   pause: 'pause-circle',
-  manualIntervention: 'pause-circle',
-  magnet: 'ot-magnet-v2',
   temperature: 'ot-temperature-v2',
   thermocycler: 'ot-thermocycler',
-  heaterShaker: 'ot-heater-shaker',
-  flexStacker: 'ot-flex-stacker',
 }
 // ===== Unprocessed form types =====
 export interface AnnotationFields {
@@ -500,10 +505,19 @@ export interface HydratedAbsorbanceReaderFormData extends AnnotationFields {
   wavelengths: string[]
 }
 
-// TODO(TZ, 2025-12-03): not fully flushed out, but this is the initial hydrated form data for the flex stacker form
+export type FlexStackerFormType =
+  | typeof FLEX_STACKER_RETRIEVE
+  | typeof FLEX_STACKER_STORE
+  | typeof FLEX_STACKER_FILL
+  | typeof FLEX_STACKER_EMPTY
+
 export interface HydratedFlexStackerFormData extends AnnotationFields {
   stepType: 'flexStacker'
   id: string
+  fillLabwareUri: string | null
+  fillQuantity: number | null
+  flexStackerFormType: FlexStackerFormType | null
+  message: string | null
   moduleId: string
 }
 
@@ -616,6 +630,7 @@ export type CountPerStepType = Partial<Record<StepType, number>>
 export type HydratedFormData =
   | HydratedAbsorbanceReaderFormData
   | HydratedCameraFormData
+  | HydratedFlexStackerFormData
   | HydratedCommentFormData
   | HydratedHeaterShakerFormData
   | HydratedMagnetFormData

--- a/protocol-designer/src/form-types.ts
+++ b/protocol-designer/src/form-types.ts
@@ -515,9 +515,9 @@ export interface HydratedFlexStackerFormData extends AnnotationFields {
   stepType: 'flexStacker'
   id: string
   fillLabwareUri: string | null
-  fillMessage: string | null
   fillQuantity: number | null
   flexStackerFormType: FlexStackerFormType | null
+  interventionMessage: string | null
   moduleId: string
 }
 

--- a/protocol-designer/src/form-types.ts
+++ b/protocol-designer/src/form-types.ts
@@ -515,9 +515,9 @@ export interface HydratedFlexStackerFormData extends AnnotationFields {
   stepType: 'flexStacker'
   id: string
   fillLabwareUri: string | null
+  fillMessage: string | null
   fillQuantity: number | null
   flexStackerFormType: FlexStackerFormType | null
-  message: string | null
   moduleId: string
 }
 

--- a/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.ts
+++ b/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.ts
@@ -254,9 +254,9 @@ export function getDefaultsForStepType(
     case 'flexStacker':
       return {
         fillLabwareUri: null,
-        fillMessage: null,
         fillQuantity: null,
         flexStackerFormType: null,
+        interventionMessage: null,
         moduleId: null,
       }
     default:

--- a/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.ts
+++ b/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.ts
@@ -251,14 +251,13 @@ export function getDefaultsForStepType(
         referenceWavelengthActive: false,
         wavelengths: [Object.keys(ABSORBANCE_READER_COLOR_BY_WAVELENGTH)[0]], // default to first known wavelength
       }
-    // TODO(TZ, 2025-12-03): not fully flushed out, but this is the initial state for the flex stacker form
     case 'flexStacker':
       return {
+        fillLabwareUri: null,
+        fillQuantity: null,
+        flexStackerFormType: null,
+        message: null,
         moduleId: null,
-        labwareInHopper: null,
-        labwareOnShuttle: null,
-        maxPoolCount: 0,
-        storedLabwareDetails: null,
       }
     default:
       return {}

--- a/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.ts
+++ b/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.ts
@@ -254,9 +254,9 @@ export function getDefaultsForStepType(
     case 'flexStacker':
       return {
         fillLabwareUri: null,
+        fillMessage: null,
         fillQuantity: null,
         flexStackerFormType: null,
-        message: null,
         moduleId: null,
       }
     default:

--- a/protocol-designer/src/steplist/formLevel/test/getDefaultsForStepType.test.ts
+++ b/protocol-designer/src/steplist/formLevel/test/getDefaultsForStepType.test.ts
@@ -236,4 +236,15 @@ describe('getDefaultsForStepType', () => {
       expect(getDefaultsForStepType('')).toEqual({})
     })
   })
+  describe('flex stacker step', () => {
+    it('should get the correct defaults', () => {
+      expect(getDefaultsForStepType('flexStacker')).toEqual({
+        fillLabwareUri: null,
+        fillQuantity: null,
+        flexStackerFormType: null,
+        message: null,
+        moduleId: null,
+      })
+    })
+  })
 })

--- a/protocol-designer/src/steplist/formLevel/test/getDefaultsForStepType.test.ts
+++ b/protocol-designer/src/steplist/formLevel/test/getDefaultsForStepType.test.ts
@@ -242,7 +242,7 @@ describe('getDefaultsForStepType', () => {
         fillLabwareUri: null,
         fillQuantity: null,
         flexStackerFormType: null,
-        message: null,
+        fillMessage: null,
         moduleId: null,
       })
     })

--- a/protocol-designer/src/steplist/formLevel/test/getDefaultsForStepType.test.ts
+++ b/protocol-designer/src/steplist/formLevel/test/getDefaultsForStepType.test.ts
@@ -242,7 +242,7 @@ describe('getDefaultsForStepType', () => {
         fillLabwareUri: null,
         fillQuantity: null,
         flexStackerFormType: null,
-        fillMessage: null,
+        interventionMessage: null,
         moduleId: null,
       })
     })


### PR DESCRIPTION
# Overview

This PR introduces the new form data interface and defaults for Flex stacker steps in PD. Note that in addition to the individual fields for various stacker step interaction, I follow the absorbance reader and thermocycler forms paradigm in setting a form type, which will conditionally reveal fields relevant to that form type. The types are as follows:
- retrieve
- store
- fill
- empty

Closes EXEC-2065

## Test Plan and Hands on Testing

Not much to test hands on yet. Please view the new form type in `HydratedFlexStackerFormData` and verify that all possible fields in designs are covered.

## Changelog

- create new form type for flex stacker based on designs
- update `getDefaultsForStepType`
- add tests

## Review requests

see test plan

## Risk assessment

low