### PR TITLE
chore: add partial tip configs to 8.7 release notes

### DIFF
--- a/protocol-designer/release-notes.md
+++ b/protocol-designer/release-notes.md
@@ -18,6 +18,7 @@ This release adds support for manual tip selection and camera steps in Protocol 
 
 - Choose between automatic and manual tip tracking for transfer and mix steps in your protocols. In manual tip tracking, Protocol Designer lets you select the tip rack and individual tips the pipette will pick up to transfer or mix liquid.
 - Manual tip tracking in Protocol Designer enables reusing tips more than once in a protocol.
+- Pick up individual tips with Flex 96-channel and Flex or OT-2 8-channel pipettes.
 - Add a camera step in any Protocol Designer protocol. The Flex or OT-2's built-in camera can take a still image of your robot deck at any point during the protocol. Access your images in the Recent Protocol Runs section of the Opentrons App's robot details page.
 
 ### Improved Features


### PR DESCRIPTION
# Overview

Add mention of partial tip configs to PD release notes: 

- single tips for Flex 96 and all 8 ch pipettes in PD 8.7 
- add a mention of column for 96? may have been missed at one point in time? 

## Test Plan and Hands on Testing



## Changelog

one-line addition(s) to PD release notes.


## Review requests



## Risk assessment

low. 
