### PR TITLE
feat(shared-data): command annotations schema v2

### DIFF
--- a/api/src/opentrons/protocol_runner/json_translator.py
+++ b/api/src/opentrons/protocol_runner/json_translator.py
@@ -304,7 +304,7 @@ class JsonTranslator:
         """Translate command annotations in json protocol schema v8."""
         if isinstance(protocol, (ProtocolSchemaV6, ProtocolSchemaV7)):
             return []
-        else:
+        elif protocol.commandAnnotationSchemaId == "opentronsCommandAnnotationSchemaV1":
             command_annotations: List[CommandAnnotation] = [
                 CommandAnnotationAdapter.validate_python(
                     command_annotation.model_dump(),
@@ -312,3 +312,5 @@ class JsonTranslator:
                 for command_annotation in protocol.commandAnnotations
             ]
             return command_annotations
+        else:
+            return []

--- a/shared-data/commandAnnotation/schemas/2.json
+++ b/shared-data/commandAnnotation/schemas/2.json
@@ -5,9 +5,9 @@
     "baseAnnotation": {
       "description": "Things all annotations have",
       "type": "object",
-      "required": ["annotationType", "annotationID"],
+      "required": ["annotationType", "annotationId"],
       "properties": {
-        "annotationID": {
+        "annotationId": {
           "description": "A unique identifier for a command annotation.",
           "type": "string"
         },
@@ -60,7 +60,7 @@
       "type": "object",
       "required": [
         "annotationType",
-        "annotationID",
+        "annotationId",
         "params",
         "userSpecifiedName"
       ],

--- a/shared-data/commandAnnotation/schemas/2.json
+++ b/shared-data/commandAnnotation/schemas/2.json
@@ -27,7 +27,7 @@
       "type": "object",
       "required": [
         "annotationType",
-        "commandKeys",
+        "annotationId",
         "params",
         "machineReadableName"
       ],
@@ -87,7 +87,7 @@
       "description": "Annotates a group of atomic commands in some manner that Opentrons software does not anticipate or originate",
       "allOf": [{ "$ref": "#/$defs/baseAnnotation" }],
       "type": "object",
-      "required": ["annotationType", "commandKeys"],
+      "required": ["annotationType", "annotationId"],
       "properties": {
         "annotationType": {
           "type": "string",
@@ -99,6 +99,7 @@
   },
   "oneOf": [
     { "$ref": "#/$defs/secondOrderCommand" },
+    { "$ref": "#/$defs/userCommand" },
     { "$ref": "#/$defs/custom" }
   ]
 }

--- a/shared-data/commandAnnotation/schemas/2.json
+++ b/shared-data/commandAnnotation/schemas/2.json
@@ -1,0 +1,104 @@
+{
+  "$id": "opentronsCommandAnnotationSchemaV2#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$defs": {
+    "baseAnnotation": {
+      "description": "Things all annotations have",
+      "type": "object",
+      "required": ["annotationType", "annotationID"],
+      "properties": {
+        "annotationID": {
+          "description": "A unique identifier for a command annotation.",
+          "type": "string"
+        },
+        "annotationType": {
+          "description": "The type of annotation (for machine parsing)",
+          "type": "string"
+        },
+        "parentAnnotation": {
+          "description": "The parent annotation of this annotation, if any.",
+          "type": "string"
+        }
+      }
+    },
+    "secondOrderCommand": {
+      "description": "Annotates a group of atomic commands which were the direct result of a second order command (e.g. transfer, consolidate, mix)",
+      "allOf": [{ "$ref": "#/$defs/baseAnnotation" }],
+      "type": "object",
+      "required": [
+        "annotationType",
+        "commandKeys",
+        "params",
+        "machineReadableName"
+      ],
+      "properties": {
+        "annotationType": {
+          "type": "string",
+          "enum": ["secondOrderCommand"]
+        },
+        "params": {
+          "description": "key value pairs of the parameters that were passed to the second order command that this annotates",
+          "type": "object"
+        },
+        "machineReadableName": {
+          "description": "The name of the second order command in the form that the generating software refers to it. (e.g. 'transfer', 'thermocyclerStep')",
+          "type": "string"
+        },
+        "userSpecifiedName": {
+          "description": "The optional user-specified name of the second order command",
+          "type": "string"
+        },
+        "userSpecifiedDescription": {
+          "description": "The optional user-specified description of the second order command",
+          "type": "string"
+        }
+      }
+    },
+    "userCommand": {
+      "description": "A user generated command annotation as opposed to one generated automatically.",
+      "allOf": [{ "$ref": "#/$defs/baseAnnotation" }],
+      "type": "object",
+      "required": [
+        "annotationType",
+        "annotationID",
+        "params",
+        "userSpecifiedName"
+      ],
+      "properties": {
+        "annotationType": {
+          "type": "string",
+          "enum": ["userCommand"]
+        },
+        "params": {
+          "description": "key value pairs of the parameters that were passed to the second order command that this annotates",
+          "type": "object"
+        },
+        "userSpecifiedName": {
+          "description": "The optional user-specified name of the second order command",
+          "type": "string"
+        },
+        "userSpecifiedDescription": {
+          "description": "The optional user-specified description of the second order command",
+          "type": "string"
+        }
+      }
+    },
+    "custom": {
+      "description": "Annotates a group of atomic commands in some manner that Opentrons software does not anticipate or originate",
+      "allOf": [{ "$ref": "#/$defs/baseAnnotation" }],
+      "type": "object",
+      "required": ["annotationType", "commandKeys"],
+      "properties": {
+        "annotationType": {
+          "type": "string",
+          "enum": ["custom"]
+        }
+      },
+      "additionalProperties": true
+    }
+  },
+  "oneOf": [
+    { "$ref": "#/$defs/secondOrderCommand" },
+    { "$ref": "#/$defs/custom" }
+  ]
+}

--- a/shared-data/python/opentrons_shared_data/protocol/models/protocol_schema_v8.py
+++ b/shared-data/python/opentrons_shared_data/protocol/models/protocol_schema_v8.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any, List, Optional, Dict
+from typing import Any, List, Optional, Dict, Union
 from typing_extensions import Literal
 
 from pydantic import BaseModel, Field, ConfigDict
@@ -50,7 +50,10 @@ class ProtocolSchemaV8(BaseModel):
     labwareDefinitions: Dict[str, LabwareDefinition]
     commandSchemaId: CommandSchemaId
     commands: List[Command]
-    commandAnnotationSchemaId: Literal["opentronsCommandAnnotationSchemaV1"]
+    commandAnnotationSchemaId: Union[
+        Literal["opentronsCommandAnnotationSchemaV1"],
+        Literal["opentronsCommandAnnotationSchemaV2"],
+    ]
     commandAnnotations: List[CommandAnnotation]
     designerApplication: Optional[DesignerApplication] = None
     model_config = ConfigDict(populate_by_name=True)


### PR DESCRIPTION
# Overview

Closes AUTH-2549

This PR adds a new command annotation schema to shared data, adds this type to the existing protocol schema v8, and makes a small change in the previous and mostly unused version of command annotations to not break if it somehow encounters the new command annotations.

The major changes in V2 are removing `commandKeys` as a property (commands will now have reference to the annotation within them, this will be done in a future PR), adding an `annotationId` property that will be used by commands and potentially other annotations to reference the annotation, and creating a new `userCommand` type of annotation to represent annotations created by the user, so we can differentiate them if we ever automatically generate them.

In #15737 an earlier version of command annotations was implemented in analysis. This was not ever used in production, and was only supported in JSON protocols. This version of it would just cleanly translate any command annotations used in a JSON protocol and include that in the analysis. Although this was never made public and new JSON protocols are deprecated, this code is being left in with the change to keep the current behavior if the schema still has the V1 of command annotations.

## Test Plan and Hands on Testing

Ensured this does not break any machine that happens to have a JSON protocol with command annotations, though this is most likely zero out in the field. Otherwise this is just a schema change so not much testing needed.

## Changelog

- added `opentronsCommandAnnotationSchemaV2` which removes `commandKeys`, adds `annotationId` and adds a new `userCommand` type
- protocol schema v8 can now use `opentronsCommandAnnotationSchemaV2`
- small change to JSON translator to recognize different command annotation schema types

## Review requests

Am I forgetting anywhere else I need to update this? Future PRs will implement the pydantic objects for the new schema.

## Risk assessment

Low, small change to an unused feature and still kept backwards compatibility for it.