### PR TITLE
feat(abr-testing): track image captures and attach image to error tickets

### DIFF
--- a/abr-testing/abr_testing/automation/slack.py
+++ b/abr-testing/abr_testing/automation/slack.py
@@ -103,7 +103,8 @@ class Slack:
             self.send_slack_message(message)
 
     def send_run_started_message(
-        self, protocol_name: str, user_id: Optional[str] = None
+        self,
+        protocol_name: str,
     ) -> None:
         """Send run started message."""
         message = f"Protocol: {protocol_name} has started."
@@ -113,10 +114,10 @@ class Slack:
         self,
         protocol_name: str,
         error_str: str,
+        ip: str,
         file_paths: list[str] | None = None,
-        user_id: Optional[str] = None,
     ) -> None:
         """Send error message to Slack, optionally tagging a user."""
-        message = f"Protocol: {protocol_name} ended in error: {error_str}"
+        message = f"Protocol {protocol_name} on IP: {ip} ended in error: {error_str}"
         self.icon_emoji = ":alert:"
         self.send_slack_message(message, file_paths)

--- a/abr-testing/abr_testing/automation/slack.py
+++ b/abr-testing/abr_testing/automation/slack.py
@@ -51,49 +51,56 @@ class Slack:
     def send_slack_message(
         self,
         message: str,
-        file_path: str | None = None,
+        file_paths: list[str] | None = None,
         user_id: Optional[str] = None,
     ) -> None:
-        """Send Slack message with or without a file attachment."""
-        icon = self.icon_emoji or ""
-        user = self.user_name or ""
-        if file_path:
-            full_message = f"{icon} *{user}*: {message}"
-            try:
-                if not Path(file_path.strip()).exists():
-                    print(f"File not found: {file_path}")
-                    return
+        """Send Slack message with optional multiple files in a single-threaded group."""
+        try:
+            parent = self.client.chat_postMessage(
+                channel=self.channel,
+                text=message,
+                username=self.user_name,
+                icon_emoji=self.icon_emoji,
+            )
+            parent.validate()
+            thread_ts = parent["ts"]
+        except Exception as e:
+            print(f"Failed to send primary Slack message: {e}")
+            return
 
-                with open(file_path, "rb") as file_content:
+        if not file_paths:
+            return
+
+        for file_path in file_paths:
+            cleaned = file_path.strip()
+            try:
+                if not Path(cleaned).exists():
+                    print(f"File not found: {cleaned}")
+                    continue
+
+                with open(cleaned, "rb") as file_content:
                     response = self.client.files_upload_v2(
                         file=file_content,
-                        filename=os.path.basename(file_path),
-                        title=os.path.basename(file_path).split(".")[0],
+                        filename=os.path.basename(cleaned),
+                        title=os.path.basename(cleaned).split(".")[0],
                         channel=self.channel_id,
-                        initial_comment=full_message,
+                        thread_ts=thread_ts,
                     )
                     response.validate()
+
             except Exception as e:
-                print(f"Failed to upload file to Slack: {e}")
-        else:
-            full_message = message
-            try:
-                response = self.client.chat_postMessage(
-                    channel=self.channel,
-                    text=full_message,
-                    username=self.user_name,
-                    icon_emoji=self.icon_emoji,
-                )
-                response.validate()
-            except Exception as e:
-                print(f"Failed to send message to Slack: {e}")
+                print(f"Failed to upload {cleaned} to Slack: {e}")
+                continue
 
     def send_run_completed_message(
-        self, protocol_name: str, user_id: Optional[str] = None
+        self, protocol_name: str, file_paths: list[str] | None = None
     ) -> None:
         """Send run completed message."""
         message = f"{protocol_name} has completed successfully."
-        self.send_slack_message(message)
+        if file_paths:
+            self.send_slack_message(message, file_paths)
+        else:
+            self.send_slack_message(message)
 
     def send_run_started_message(
         self, protocol_name: str, user_id: Optional[str] = None
@@ -106,10 +113,10 @@ class Slack:
         self,
         protocol_name: str,
         error_str: str,
-        image_path: Optional[str] = None,
+        file_paths: list[str] | None = None,
         user_id: Optional[str] = None,
     ) -> None:
         """Send error message to Slack, optionally tagging a user."""
         message = f"Protocol: {protocol_name} ended in error: {error_str}"
         self.icon_emoji = ":alert:"
-        self.send_slack_message(message, image_path)
+        self.send_slack_message(message, file_paths)

--- a/abr-testing/abr_testing/data_collection/abr_google_drive.py
+++ b/abr-testing/abr_testing/data_collection/abr_google_drive.py
@@ -139,6 +139,7 @@ def create_data_dictionary(
                 plate_reader_dict = read_robot_logs.plate_reader_commands(
                     file_results, hellma_plate_standards, hellma_plate_orientation
                 )
+                image_capture_dict = read_robot_logs.count_image_capture(file_results)
                 notes = {"Note1": "", "Jira Link": issue_url}
                 liquid_height = read_robot_logs.get_liquid_waste_height(file_results)
                 plate_measure = {
@@ -161,6 +162,7 @@ def create_data_dictionary(
                     **plate_reader_dict,
                     **fs_dict,
                     **pipette_dict,
+                    **image_capture_dict,
                     **plate_measure,
                 }
                 headers = list(row_2.keys())

--- a/abr-testing/abr_testing/data_collection/abr_robot_error.py
+++ b/abr-testing/abr_testing/data_collection/abr_robot_error.py
@@ -34,6 +34,27 @@ def retrieve_version_file(
         return ""
 
 
+def retrieve_protocol_images(run_id: str, robot_ip: str, storage: str) -> str:
+    """Save all capture images for a run."""
+    save_dir = Path(f"{storage}")
+    new_save_dir = Path(f"{storage}/{run_id}")
+    command = ["scp", "-r", f"root@{robot_ip}:/data/images/{run_id}/", save_dir]
+    zip_path = f"storage_directory/{run_id}_images.zip"
+    try:
+        subprocess.run(command, check=True)  # type: ignore
+        shutil.make_archive(
+            base_name=str(zip_path).replace(".zip", ""),
+            format="zip",
+            root_dir=save_dir,
+        )
+        subprocess.run(["rm", "-r", new_save_dir], check=True)
+        print("Image folder transfered successful!")
+        return str(zip_path)
+    except subprocess.CalledProcessError as e:
+        print(f"Error during file transfer: {e}")
+    return ""
+
+
 def retrieve_protocol_file(protocol_id: str, robot_ip: str, storage: str) -> Path | str:
     """Find and copy protocol file on robot with error handling."""
     # List folders in the robot's directory
@@ -653,6 +674,7 @@ if __name__ == "__main__":
     saved_file_path_calibration, calibration = read_robot_logs.get_calibration_offsets(
         ip, storage_directory
     )
+    image_files = retrieve_protocol_images(one_run, ip, storage_directory)
 
     print(f"Making ticket for {summary}.")
     # TODO: make argument or see if I can get rid of with using board_id.
@@ -684,6 +706,7 @@ if __name__ == "__main__":
         protocol_file_path,
         version_file_path,
         log_zip_path,
+        image_files,
     ]
     error_folder_path = os.path.join(storage_directory, issue_key)
     os.makedirs(error_folder_path, exist_ok=True)

--- a/abr-testing/abr_testing/data_collection/read_robot_logs.py
+++ b/abr-testing/abr_testing/data_collection/read_robot_logs.py
@@ -114,6 +114,18 @@ def count_command_in_run_data(
     return total_command, avg_time
 
 
+def count_image_capture(file: Dict[str, Any]) -> Dict[str, float]:
+    """Count image captures per protocol."""
+    commands = file.get("commands", "")
+    num_of_images, image_capture_time = count_command_in_run_data(
+        commands, "captureImage", True
+    )
+    return {
+        "Total Image Captures": num_of_images,
+        "Image Capture Time (sec)": image_capture_time,
+    }
+
+
 def identify_labware_ids(
     file_results: Dict[str, Any], labware_name: Optional[str]
 ) -> List[str]:
@@ -536,7 +548,6 @@ def temperature_module_commands(file_results: Dict[str, Any]) -> Dict[str, Any]:
 
 def thermocycler_commands(file_results: Dict[str, Any]) -> Dict[str, float]:
     """Counts # of lid engagements, temp changes, and temp sustaining mins."""
-    # TODO: modify for cases that have more than 1 thermocycler.
     commandData = file_results.get("commands", "")
     lid_engagements: float = 0.0
     block_temp_changes: float = 0.0

--- a/abr-testing/abr_testing/data_collection/read_robot_logs.py
+++ b/abr-testing/abr_testing/data_collection/read_robot_logs.py
@@ -122,7 +122,7 @@ def count_image_capture(file: Dict[str, Any]) -> Dict[str, float]:
     )
     return {
         "Total Image Captures": num_of_images,
-        "Image Capture Time (sec)": image_capture_time,
+        "Average Image Capture Time (sec)": image_capture_time,
     }
 
 

--- a/abr-testing/abr_testing/protocols/active_protocols/10_ZymoBIOMICS_Magbead_DNA_Cells_Flex.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/10_ZymoBIOMICS_Magbead_DNA_Cells_Flex.py
@@ -67,11 +67,13 @@ def add_parameters(parameters: protocol_api.ParameterContext) -> None:
     helpers.create_deactivate_modules_parameter(parameters)
     helpers.create_meniscus_z_parameter(parameters)
     helpers.create_probe_liquid_height_parameter(parameters)
+    helpers.create_error_capture_duration_duration(parameters)
 
 
 def run(protocol: protocol_api.ProtocolContext) -> None:
     """Protocol Set Up."""
     protocol.capture_image(filename="start_of_run")
+    length = protocol.params.error_capture_duration  # type: ignore[attr-defined]
     heater_shaker_speed = protocol.params.heater_shaker_speed  # type: ignore[attr-defined]
     mount = protocol.params.pipette_mount  # type: ignore[attr-defined]
     deactivate_modules_bool = protocol.params.deactivate_modules  # type: ignore[attr-defined]
@@ -596,7 +598,7 @@ def run(protocol: protocol_api.ProtocolContext) -> None:
             helpers.send_slack_message_with_image(slack_bot, metadata["protocolName"])
     except Exception as e:
         if not protocol.is_simulating():
-            helpers.send_slack_error_message_with_log(
-                slack_bot, metadata["protocolName"], str(e)
+            helpers.send_slack_error_message_with_attachments(
+                slack_bot, metadata["protocolName"], str(e), length
             )
         raise (e)

--- a/abr-testing/abr_testing/protocols/active_protocols/10_ZymoBIOMICS_Magbead_DNA_Cells_Flex.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/10_ZymoBIOMICS_Magbead_DNA_Cells_Flex.py
@@ -593,7 +593,7 @@ def run(protocol: protocol_api.ProtocolContext) -> None:
             helpers.deactivate_modules(protocol)
         protocol.capture_image(filename="end_of_run")
         if not protocol.is_simulating():
-            slack_bot.send_run_completed_message(metadata["protocolName"])
+            helpers.send_slack_message_with_image(slack_bot, metadata["protocolName"])
     except Exception as e:
         if not protocol.is_simulating():
             helpers.send_slack_error_message_with_log(

--- a/abr-testing/abr_testing/protocols/active_protocols/11_IDT xGen 1000 ul 96ch.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/11_IDT xGen 1000 ul 96ch.py
@@ -1476,6 +1476,7 @@ def run(protocol: ProtocolContext) -> None:
         protocol.comment("==============================================")
         protocol.comment("--> Report")
         protocol.comment("==============================================")
+        protocol.capture_image(filename="end_of_run")
 
         if not protocol.is_simulating():
             helpers.send_slack_message_with_image(slack_bot, metadata["protocolName"])

--- a/abr-testing/abr_testing/protocols/active_protocols/11_IDT xGen 1000 ul 96ch.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/11_IDT xGen 1000 ul 96ch.py
@@ -27,6 +27,7 @@ def add_parameters(parameters: ParameterContext) -> None:
     helpers.create_deactivate_modules_parameter(parameters)
     helpers.create_dry_run_parameter(parameters)
     helpers.create_dot_bottom_parameter(parameters)
+    helpers.create_error_capture_duration_duration(parameters)
     parameters.add_str(
         display_name="Frag Mode",
         variable_name="FRAG_MODE",
@@ -62,7 +63,7 @@ def run(protocol: ProtocolContext) -> None:
     # ======================== DOWNLOADED PARAMETERS ========================
     global COLUMNS  # Number of Columns of Samples
     # =================== LOADING THE RUNTIME PARAMETERS ====================
-
+    length = protocol.params.error_capture_duration  # type: ignore[attr-defined]
     DRYRUN = protocol.params.dry_run  # type: ignore[attr-defined]
     FRAG_MODE = protocol.params.FRAG_MODE  # type: ignore[attr-defined]
     FRAGTIME = protocol.params.FRAGTIME  # type: ignore[attr-defined]
@@ -1482,7 +1483,7 @@ def run(protocol: ProtocolContext) -> None:
             helpers.send_slack_message_with_image(slack_bot, metadata["protocolName"])
     except Exception as e:
         if not protocol.is_simulating():
-            helpers.send_slack_error_message_with_log(
-                slack_bot, metadata["protocolName"], str(e)
+            helpers.send_slack_error_message_with_attachments(
+                slack_bot, metadata["protocolName"], str(e), length
             )
         raise (e)

--- a/abr-testing/abr_testing/protocols/active_protocols/11_IDT xGen 1000 ul 96ch.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/11_IDT xGen 1000 ul 96ch.py
@@ -1478,7 +1478,7 @@ def run(protocol: ProtocolContext) -> None:
         protocol.comment("==============================================")
 
         if not protocol.is_simulating():
-            slack_bot.send_run_completed_message(metadata["protocolName"])
+            helpers.send_slack_message_with_image(slack_bot, metadata["protocolName"])
     except Exception as e:
         if not protocol.is_simulating():
             helpers.send_slack_error_message_with_log(

--- a/abr-testing/abr_testing/protocols/active_protocols/12_Illumina RNA all parts.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/12_Illumina RNA all parts.py
@@ -2887,7 +2887,7 @@ def run(protocol: ProtocolContext) -> None:
                 stacker_50_2.store()
 
         if not protocol.is_simulating():
-            slack_bot.send_run_completed_message(metadata["protocolName"])
+            helpers.send_slack_message_with_image(slack_bot, metadata["protocolName"])
     except Exception as e:
         if not protocol.is_simulating():
             helpers.send_slack_error_message_with_log(

--- a/abr-testing/abr_testing/protocols/active_protocols/12_Illumina RNA all parts.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/12_Illumina RNA all parts.py
@@ -2885,7 +2885,7 @@ def run(protocol: ProtocolContext) -> None:
                     use_gripper=True,
                 )
                 stacker_50_2.store()
-
+        protocol.capture_image(filename="end_of_run")
         if not protocol.is_simulating():
             helpers.send_slack_message_with_image(slack_bot, metadata["protocolName"])
     except Exception as e:

--- a/abr-testing/abr_testing/protocols/active_protocols/12_Illumina RNA all parts.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/12_Illumina RNA all parts.py
@@ -66,11 +66,13 @@ def add_parameters(parameters: ParameterContext) -> None:
         description="Use temperature module in protocol",
         default=True,
     )
+    helpers.create_error_capture_duration_duration(parameters)
 
 
 def run(protocol: ProtocolContext) -> None:
     """Protocol."""
     protocol.capture_image(filename="start_of_run")
+    length = protocol.params.error_capture_duration  # type: ignore[attr-defined]
 
     helpers.comment_protocol_version(protocol, "03")
 
@@ -2890,7 +2892,7 @@ def run(protocol: ProtocolContext) -> None:
             helpers.send_slack_message_with_image(slack_bot, metadata["protocolName"])
     except Exception as e:
         if not protocol.is_simulating():
-            helpers.send_slack_error_message_with_log(
-                slack_bot, metadata["protocolName"], str(e)
+            helpers.send_slack_error_message_with_attachments(
+                slack_bot, metadata["protocolName"], str(e), length
             )
         raise (e)

--- a/abr-testing/abr_testing/protocols/active_protocols/13_Stacker_Labware_Stamping_Test.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/13_Stacker_Labware_Stamping_Test.py
@@ -225,6 +225,8 @@ def run(ctx: ProtocolContext) -> None:
         move_plates_to_deck_fill_and_store(
             stacker_nest96deep, ctx, p96, water, reservoir
         )
+        ctx.capture_image(filename="end_of_run")
+
         if not ctx.is_simulating():
             helpers.send_slack_message_with_image(slack_bot, metadata["protocolName"])
     except Exception as e:

--- a/abr-testing/abr_testing/protocols/active_protocols/13_Stacker_Labware_Stamping_Test.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/13_Stacker_Labware_Stamping_Test.py
@@ -12,6 +12,7 @@ from opentrons.protocol_api.module_contexts import (
 )
 
 from typing import List
+from abr_testing.protocols import helpers
 
 metadata = {
     "protocolName": "Flex Stacker Stamping Protocol",
@@ -71,6 +72,7 @@ def add_parameters(parameters: ParameterContext) -> None:
         maximum=40,
         minimum=1,
     )
+    helpers.create_error_capture_duration_duration(parameters)
 
 
 def move_plates_to_deck_fill_and_store(
@@ -129,11 +131,9 @@ def unload_tipracks_from_stacker(
 def run(ctx: ProtocolContext) -> None:
     """Run the protocol."""
     ctx.capture_image(filename="start_of_run")
-
+    length = ctx.params.error_capture_duration  # type: ignore[attr-defined]
     use_temp_mod = ctx.params.use_temp_mod  # type: ignore[attr-defined]
     if not ctx.is_simulating():
-        from abr_testing.protocols import helpers
-
         helpers.comment_protocol_version(ctx, "03")
         slack_bot = helpers.set_up_slack()
         slack_bot.send_run_started_message(metadata["protocolName"])
@@ -231,7 +231,7 @@ def run(ctx: ProtocolContext) -> None:
             helpers.send_slack_message_with_image(slack_bot, metadata["protocolName"])
     except Exception as e:
         if not ctx.is_simulating():
-            helpers.send_slack_error_message_with_log(
-                slack_bot, metadata["protocolName"], str(e)
+            helpers.send_slack_error_message_with_attachments(
+                slack_bot, metadata["protocolName"], str(e), length
             )
         raise (e)

--- a/abr-testing/abr_testing/protocols/active_protocols/13_Stacker_Labware_Stamping_Test.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/13_Stacker_Labware_Stamping_Test.py
@@ -225,6 +225,8 @@ def run(ctx: ProtocolContext) -> None:
         move_plates_to_deck_fill_and_store(
             stacker_nest96deep, ctx, p96, water, reservoir
         )
+        if not ctx.is_simulating():
+            helpers.send_slack_message_with_image(slack_bot, metadata["protocolName"])
     except Exception as e:
         if not ctx.is_simulating():
             helpers.send_slack_error_message_with_log(

--- a/abr-testing/abr_testing/protocols/active_protocols/14_IDT xGen 200 ul 96ch.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/14_IDT xGen 200 ul 96ch.py
@@ -1473,7 +1473,7 @@ def run(protocol: ProtocolContext) -> None:
         protocol.comment("==============================================")
         protocol.comment("--> Report")
         protocol.comment("==============================================")
-
+        protocol.capture_image(filename="end_of_run")
         if not protocol.is_simulating():
             helpers.send_slack_message_with_image(slack_bot, metadata["protocolName"])
     except Exception as e:

--- a/abr-testing/abr_testing/protocols/active_protocols/14_IDT xGen 200 ul 96ch.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/14_IDT xGen 200 ul 96ch.py
@@ -27,6 +27,7 @@ def add_parameters(parameters: ParameterContext) -> None:
     helpers.create_deactivate_modules_parameter(parameters)
     helpers.create_dry_run_parameter(parameters)
     helpers.create_dot_bottom_parameter(parameters)
+    helpers.create_error_capture_duration_duration(parameters)
     parameters.add_str(
         display_name="Frag Mode",
         variable_name="FRAG_MODE",
@@ -62,7 +63,7 @@ def run(protocol: ProtocolContext) -> None:
     # ======================== DOWNLOADED PARAMETERS ========================
     global COLUMNS  # Number of Columns of Samples
     # =================== LOADING THE RUNTIME PARAMETERS ====================
-
+    length = protocol.params.error_capture_duration  # type: ignore[attr-defined]
     DRYRUN = protocol.params.dry_run  # type: ignore[attr-defined]
     FRAG_MODE = protocol.params.FRAG_MODE  # type: ignore[attr-defined]
     FRAGTIME = protocol.params.FRAGTIME  # type: ignore[attr-defined]
@@ -1478,7 +1479,7 @@ def run(protocol: ProtocolContext) -> None:
             helpers.send_slack_message_with_image(slack_bot, metadata["protocolName"])
     except Exception as e:
         if not protocol.is_simulating():
-            helpers.send_slack_error_message_with_log(
-                slack_bot, metadata["protocolName"], str(e)
+            helpers.send_slack_error_message_with_attachments(
+                slack_bot, metadata["protocolName"], str(e), length
             )
         raise (e)

--- a/abr-testing/abr_testing/protocols/active_protocols/14_IDT xGen 200 ul 96ch.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/14_IDT xGen 200 ul 96ch.py
@@ -1475,7 +1475,7 @@ def run(protocol: ProtocolContext) -> None:
         protocol.comment("==============================================")
 
         if not protocol.is_simulating():
-            slack_bot.send_run_completed_message(metadata["protocolName"])
+            helpers.send_slack_message_with_image(slack_bot, metadata["protocolName"])
     except Exception as e:
         if not protocol.is_simulating():
             helpers.send_slack_error_message_with_log(

--- a/abr-testing/abr_testing/protocols/active_protocols/1_Simple Normalize Long Right.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/1_Simple Normalize Long Right.py
@@ -23,6 +23,7 @@ def add_parameters(parameters: ParameterContext) -> None:
     helpers.create_probe_liquid_height_parameter(parameters)
     helpers.create_csv_parameter(parameters)
     helpers.create_meniscus_z_parameter(parameters)
+    helpers.create_error_capture_duration_duration(parameters)
 
 
 def run(protocol: ProtocolContext) -> None:
@@ -30,6 +31,7 @@ def run(protocol: ProtocolContext) -> None:
     all_data = protocol.params.parameters_csv.parse_as_csv()  # type: ignore[attr-defined]
     probe_height_bool = protocol.params.probe_liquid_height  # type: ignore[attr-defined]
     meniscus_z = protocol.params.meniscus_z  # type: ignore[attr-defined]
+    length = protocol.params.error_capture_duration  # type: ignore[attr-defined]
     data = all_data[1:]
     helpers.comment_protocol_version(protocol, "05")
     if not protocol.is_simulating():
@@ -309,7 +311,7 @@ def run(protocol: ProtocolContext) -> None:
             helpers.send_slack_message_with_image(slack_bot, metadata["protocolName"])
     except Exception as e:
         if not protocol.is_simulating():
-            helpers.send_slack_error_message_with_log(
-                slack_bot, metadata["protocolName"], str(e)
+            helpers.send_slack_error_message_with_attachments(
+                slack_bot, metadata["protocolName"], str(e), length
             )
         raise (e)

--- a/abr-testing/abr_testing/protocols/active_protocols/1_Simple Normalize Long Right.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/1_Simple Normalize Long Right.py
@@ -304,6 +304,7 @@ def run(protocol: ProtocolContext) -> None:
         helpers.find_liquid_height_of_all_wells(
             protocol, p1000_single, [waste_reservoir["A1"]]
         )
+        protocol.capture_image(filename="end_of_run")
         if not protocol.is_simulating():
             helpers.send_slack_message_with_image(slack_bot, metadata["protocolName"])
     except Exception as e:

--- a/abr-testing/abr_testing/protocols/active_protocols/1_Simple Normalize Long Right.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/1_Simple Normalize Long Right.py
@@ -305,7 +305,7 @@ def run(protocol: ProtocolContext) -> None:
             protocol, p1000_single, [waste_reservoir["A1"]]
         )
         if not protocol.is_simulating():
-            slack_bot.send_run_completed_message(metadata["protocolName"])
+            helpers.send_slack_message_with_image(slack_bot, metadata["protocolName"])
     except Exception as e:
         if not protocol.is_simulating():
             helpers.send_slack_error_message_with_log(

--- a/abr-testing/abr_testing/protocols/active_protocols/2_BMS_PCR_Protocol.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/2_BMS_PCR_Protocol.py
@@ -268,7 +268,7 @@ def run(protocol: ProtocolContext) -> None:
             helpers.deactivate_modules(protocol)
         protocol.capture_image(filename="end_of_run")
         if not protocol.is_simulating():
-            slack_bot.send_run_completed_message(metadata["protocolName"])
+            helpers.send_slack_message_with_image(slack_bot, metadata["protocolName"])
     except Exception as e:
         if not protocol.is_simulating():
             helpers.send_slack_error_message_with_log(

--- a/abr-testing/abr_testing/protocols/active_protocols/2_BMS_PCR_Protocol.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/2_BMS_PCR_Protocol.py
@@ -20,6 +20,7 @@ requirements = {"robotType": "Flex", "apiLevel": "2.27"}
 def add_parameters(parameters: ParameterContext) -> None:
     """Parameters."""
     helpers.create_single_pipette_mount_parameter(parameters)
+    helpers.create_error_capture_duration_duration(parameters)
     helpers.create_disposable_lid_parameter(parameters)
     helpers.create_csv_parameter(parameters)
     helpers.create_tc_lid_deck_riser_parameter(parameters)
@@ -31,6 +32,7 @@ def add_parameters(parameters: ParameterContext) -> None:
 def run(protocol: ProtocolContext) -> None:
     """Protocol."""
     protocol.capture_image(filename="start_of_run")
+    length = protocol.params.error_capture_duration  # type: ignore[attr-defined]
 
     pipette_mount = protocol.params.pipette_mount  # type: ignore[attr-defined]
     disposable_lid = protocol.params.disposable_lid  # type: ignore[attr-defined]
@@ -271,7 +273,7 @@ def run(protocol: ProtocolContext) -> None:
             helpers.send_slack_message_with_image(slack_bot, metadata["protocolName"])
     except Exception as e:
         if not protocol.is_simulating():
-            helpers.send_slack_error_message_with_log(
-                slack_bot, metadata["protocolName"], str(e)
+            helpers.send_slack_error_message_with_attachments(
+                slack_bot, metadata["protocolName"], str(e), length
             )
         raise (e)

--- a/abr-testing/abr_testing/protocols/active_protocols/4_Illumina DNA Enrichment.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/4_Illumina DNA Enrichment.py
@@ -63,6 +63,7 @@ RUN = 1
 def add_parameters(parameters: ParameterContext) -> None:
     """Add parameters."""
     helpers.create_hs_speed_parameter(parameters)
+    helpers.create_error_capture_duration_duration(parameters)
     helpers.create_dot_bottom_parameter(parameters)
     helpers.create_disposable_lid_parameter(parameters)
     helpers.create_tc_lid_deck_riser_parameter(parameters)
@@ -75,6 +76,7 @@ def add_parameters(parameters: ParameterContext) -> None:
 def run(protocol: ProtocolContext) -> None:
     """Protocol."""
     protocol.capture_image(filename="start_of_run")
+    length = protocol.params.error_capture_duration  # type: ignore[attr-defined]
     heater_shaker_speed = protocol.params.heater_shaker_speed  # type: ignore[attr-defined]
     dot_bottom = protocol.params.dot_bottom  # type: ignore[attr-defined]
     disposable_lid = protocol.params.disposable_lid  # type: ignore[attr-defined]
@@ -1093,7 +1095,7 @@ def run(protocol: ProtocolContext) -> None:
             helpers.send_slack_message_with_image(slack_bot, metadata["protocolName"])
     except Exception as e:
         if not protocol.is_simulating():
-            helpers.send_slack_error_message_with_log(
-                slack_bot, metadata["protocolName"], str(e)
+            helpers.send_slack_error_message_with_attachments(
+                slack_bot, metadata["protocolName"], str(e), length
             )
         raise (e)

--- a/abr-testing/abr_testing/protocols/active_protocols/4_Illumina DNA Enrichment.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/4_Illumina DNA Enrichment.py
@@ -1090,7 +1090,7 @@ def run(protocol: ProtocolContext) -> None:
 
         protocol.capture_image(filename="end_of_run")
         if not protocol.is_simulating():
-            slack_bot.send_run_completed_message(metadata["protocolName"])
+            helpers.send_slack_message_with_image(slack_bot, metadata["protocolName"])
     except Exception as e:
         if not protocol.is_simulating():
             helpers.send_slack_error_message_with_log(

--- a/abr-testing/abr_testing/protocols/active_protocols/5_MiSeq Library Preparation.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/5_MiSeq Library Preparation.py
@@ -354,6 +354,7 @@ def run(protocol: ProtocolContext) -> None:
             thermocycler.deactivate_block()
         # Pause for plate removal
         protocol.comment("Protocol complete!")
+        protocol.capture_image(filename="end_of_run")
         if not protocol.is_simulating():
             helpers.send_slack_message_with_image(slack_bot, metadata["protocolName"])
     except Exception as e:

--- a/abr-testing/abr_testing/protocols/active_protocols/5_MiSeq Library Preparation.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/5_MiSeq Library Preparation.py
@@ -28,6 +28,7 @@ requirements = {"robotType": "Flex", "apiLevel": "2.27"}
 def add_parameters(parameters: ParameterContext) -> None:
     """Parameters."""
     helpers.create_dot_bottom_parameter(parameters)
+    helpers.create_error_capture_duration_duration(parameters)
     helpers.create_deactivate_modules_parameter(parameters)
     helpers.create_probe_liquid_height_parameter(parameters)
     helpers.create_meniscus_z_parameter(parameters)
@@ -42,6 +43,7 @@ def run(protocol: ProtocolContext) -> None:
     """Protocol."""
     # Load Parameters
     protocol.capture_image(filename="start_of_run")
+    length = protocol.params.error_capture_duration  # type: ignore[attr-defined]
     dot_bottom = protocol.params.dot_bottom  # type: ignore[attr-defined]
     deactivate_modules_bool = protocol.params.deactivate_modules  # type: ignore[attr-defined]
     column_tip_pick_up = protocol.params.column_tip_pickup  # type: ignore[attr-defined]
@@ -359,7 +361,7 @@ def run(protocol: ProtocolContext) -> None:
             helpers.send_slack_message_with_image(slack_bot, metadata["protocolName"])
     except Exception as e:
         if not protocol.is_simulating():
-            helpers.send_slack_error_message_with_log(
-                slack_bot, metadata["protocolName"], str(e)
+            helpers.send_slack_error_message_with_attachments(
+                slack_bot, metadata["protocolName"], str(e), length
             )
         raise (e)

--- a/abr-testing/abr_testing/protocols/active_protocols/5_MiSeq Library Preparation.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/5_MiSeq Library Preparation.py
@@ -355,7 +355,7 @@ def run(protocol: ProtocolContext) -> None:
         # Pause for plate removal
         protocol.comment("Protocol complete!")
         if not protocol.is_simulating():
-            slack_bot.send_run_completed_message(metadata["protocolName"])
+            helpers.send_slack_message_with_image(slack_bot, metadata["protocolName"])
     except Exception as e:
         if not protocol.is_simulating():
             helpers.send_slack_error_message_with_log(

--- a/abr-testing/abr_testing/protocols/active_protocols/6_Olink_Target_48-96.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/6_Olink_Target_48-96.py
@@ -80,6 +80,7 @@ def add_parameters(p: ParameterContext) -> None:
         default=False,
         description="ON - protocol will use the waste chute.",
     )
+    helpers.create_error_capture_duration_duration(p)
 
 
 def run(protocol: ProtocolContext) -> None:
@@ -91,6 +92,7 @@ def run(protocol: ProtocolContext) -> None:
     if not protocol.is_simulating():
         slack_bot = helpers.set_up_slack()
         slack_bot.send_run_started_message(metadata["protocolName"])
+    length = protocol.params.error_capture_duration  # type: ignore[attr-defined]
     mmx_to_sample_plate = protocol.params.mmx_to_sample_plate  # type: ignore[attr-defined]
     ep_to_sample_plate = protocol.params.ep_to_sample_plate  # type: ignore[attr-defined]
     mm_col = protocol.params.mm_col  # type: ignore[attr-defined]
@@ -528,7 +530,7 @@ def run(protocol: ProtocolContext) -> None:
             helpers.send_slack_message_with_image(slack_bot, metadata["protocolName"])
     except Exception as e:
         if not protocol.is_simulating():
-            helpers.send_slack_error_message_with_log(
-                slack_bot, metadata["protocolName"], str(e)
+            helpers.send_slack_error_message_with_attachments(
+                slack_bot, metadata["protocolName"], str(e), length
             )
         raise (e)

--- a/abr-testing/abr_testing/protocols/active_protocols/6_Olink_Target_48-96.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/6_Olink_Target_48-96.py
@@ -523,6 +523,7 @@ def run(protocol: ProtocolContext) -> None:
             height = ifp_plate[ifp_plate_well.well_name].current_liquid_height()
             liquid_heights[ifp_plate_well.well_name] = height
         protocol.comment(str(liquid_heights))
+        protocol.capture_image(filename="end_of_run")
         if not protocol.is_simulating():
             helpers.send_slack_message_with_image(slack_bot, metadata["protocolName"])
     except Exception as e:

--- a/abr-testing/abr_testing/protocols/active_protocols/6_Olink_Target_48-96.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/6_Olink_Target_48-96.py
@@ -523,7 +523,8 @@ def run(protocol: ProtocolContext) -> None:
             height = ifp_plate[ifp_plate_well.well_name].current_liquid_height()
             liquid_heights[ifp_plate_well.well_name] = height
         protocol.comment(str(liquid_heights))
-
+        if not protocol.is_simulating():
+            helpers.send_slack_message_with_image(slack_bot, metadata["protocolName"])
     except Exception as e:
         if not protocol.is_simulating():
             helpers.send_slack_error_message_with_log(

--- a/abr-testing/abr_testing/protocols/active_protocols/7_HDQ_DNA_Bacteria_Flex.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/7_HDQ_DNA_Bacteria_Flex.py
@@ -560,7 +560,7 @@ def run(protocol: ProtocolContext) -> None:
             protocol, m1000, [res1, elutionplate], waste_reservoir["A1"]
         )
         helpers.find_liquid_height_of_all_wells(protocol, m1000, end_wells_with_liquid)
-        protocol.capture_image(filename="protocol_finished")
+        protocol.capture_image(filename="end_of_run")
 
         if deactivate_modules_bool:
             helpers.deactivate_modules(protocol)

--- a/abr-testing/abr_testing/protocols/active_protocols/7_HDQ_DNA_Bacteria_Flex.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/7_HDQ_DNA_Bacteria_Flex.py
@@ -59,16 +59,19 @@ def add_parameters(parameters: ParameterContext) -> None:
     helpers.create_deactivate_modules_parameter(parameters)
     helpers.create_probe_liquid_height_parameter(parameters)
     helpers.create_meniscus_z_parameter(parameters)
+    helpers.create_error_capture_duration_duration(parameters)
 
 
 def run(protocol: ProtocolContext) -> None:
     """Protocol."""
     protocol.capture_image(filename="start_of_run")
+    length = protocol.params.error_capture_duration  # type: ignore[attr-defined]
     heater_shaker_speed = protocol.params.heater_shaker_speed  # type: ignore[attr-defined]
     mount = protocol.params.pipette_mount  # type: ignore[attr-defined]
     deactivate_modules_bool = protocol.params.deactivate_modules  # type: ignore[attr-defined]
     probe_height_bool = protocol.params.probe_liquid_height  # type: ignore[attr-defined]
     meniscus_z = protocol.params.meniscus_z  # type: ignore[attr-defined]
+
     helpers.comment_protocol_version(protocol, "05")
     if not protocol.is_simulating():
         slack_bot = helpers.set_up_slack()
@@ -568,7 +571,7 @@ def run(protocol: ProtocolContext) -> None:
             helpers.send_slack_message_with_image(slack_bot, metadata["protocolName"])
     except Exception as e:
         if not protocol.is_simulating():
-            helpers.send_slack_error_message_with_log(
-                slack_bot, metadata["protocolName"], str(e)
+            helpers.send_slack_error_message_with_attachments(
+                slack_bot, metadata["protocolName"], str(e), length
             )
         raise (e)

--- a/abr-testing/abr_testing/protocols/active_protocols/7_HDQ_DNA_Bacteria_Flex.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/7_HDQ_DNA_Bacteria_Flex.py
@@ -565,7 +565,7 @@ def run(protocol: ProtocolContext) -> None:
         if deactivate_modules_bool:
             helpers.deactivate_modules(protocol)
         if not protocol.is_simulating():
-            slack_bot.send_run_completed_message(metadata["protocolName"])
+            helpers.send_slack_message_with_image(slack_bot, metadata["protocolName"])
     except Exception as e:
         if not protocol.is_simulating():
             helpers.send_slack_error_message_with_log(

--- a/abr-testing/abr_testing/protocols/active_protocols/9_Magmax_RNA_Cells_Flex.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/9_Magmax_RNA_Cells_Flex.py
@@ -657,7 +657,7 @@ def run(protocol: ProtocolContext) -> None:
         helpers.plate_reader_actions(
             protocol, plate_reader, hellma_plate, plate_name_str
         )
-
+        protocol.capture_image(filename="end_of_run")
         if deactivate_modules_bool:
             helpers.deactivate_modules(protocol)
         if not protocol.is_simulating():

--- a/abr-testing/abr_testing/protocols/active_protocols/9_Magmax_RNA_Cells_Flex.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/9_Magmax_RNA_Cells_Flex.py
@@ -74,6 +74,7 @@ def add_parameters(parameters: ParameterContext) -> None:
     )
     helpers.create_probe_liquid_height_parameter(parameters)
     helpers.create_meniscus_z_parameter(parameters)
+    helpers.create_error_capture_duration_duration(parameters)
 
 
 def run(protocol: ProtocolContext) -> None:
@@ -89,6 +90,7 @@ def run(protocol: ProtocolContext) -> None:
     lysis_vol = 140.0
     stop_vol = 100.0
     elution_vol = 55.0
+    length = protocol.params.error_capture_duration  # type: ignore[attr-defined]
     heater_shaker_speed = protocol.params.heater_shaker_speed  # type: ignore[attr-defined]
     dot_bottom = protocol.params.dot_bottom  # type: ignore[attr-defined]
     pipette_mount = protocol.params.pipette_mount  # type: ignore[attr-defined]
@@ -664,7 +666,7 @@ def run(protocol: ProtocolContext) -> None:
             helpers.send_slack_message_with_image(slack_bot, metadata["protocolName"])
     except Exception as e:
         if not protocol.is_simulating():
-            helpers.send_slack_error_message_with_log(
-                slack_bot, metadata["protocolName"], str(e)
+            helpers.send_slack_error_message_with_attachments(
+                slack_bot, metadata["protocolName"], str(e), length
             )
         raise (e)

--- a/abr-testing/abr_testing/protocols/active_protocols/9_Magmax_RNA_Cells_Flex.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/9_Magmax_RNA_Cells_Flex.py
@@ -661,7 +661,7 @@ def run(protocol: ProtocolContext) -> None:
         if deactivate_modules_bool:
             helpers.deactivate_modules(protocol)
         if not protocol.is_simulating():
-            slack_bot.send_run_completed_message(metadata["protocolName"])
+            helpers.send_slack_message_with_image(slack_bot, metadata["protocolName"])
     except Exception as e:
         if not protocol.is_simulating():
             helpers.send_slack_error_message_with_log(

--- a/abr-testing/abr_testing/protocols/helpers.py
+++ b/abr-testing/abr_testing/protocols/helpers.py
@@ -643,7 +643,24 @@ def get_last_image_capture() -> str:
     return image_path
 
 
-def create_robot_log_zip() -> str:
+def convert_m3u8_to_mp4(m3u8_path: str, mp4_path: str) -> None:
+    """Convert m3u8 video to mp4 format."""
+    subprocess.run(
+        f'ffmpeg -i "{m3u8_path}" -t 3 -c:v mpeg4 -c:a aac -movflags +faststart "{mp4_path}" -y',
+        shell=True,
+        check=True,
+    )
+
+
+def get_livestream_video() -> str:
+    """Get livestream video of last 3 seconds of run."""
+    video_path = "/var/www/localhost/html/stream/hls/stream.m3u8"
+    new_video_path = "/data/testing_data/livestream_video.mp4"
+    convert_m3u8_to_mp4(video_path, new_video_path)
+    return new_video_path
+
+
+def create_robot_log_zip() -> Tuple[str, str]:
     """Create a zip file of logs saved locally on robot."""
     storage_directory = "/data/testing_data"
     result = subprocess.run(
@@ -653,7 +670,7 @@ def create_robot_log_zip() -> str:
         text=True,
     )
     ip = result.stdout.strip()
-    return get_logs(storage_directory, ip)
+    return get_logs(storage_directory, ip), ip
 
 
 def send_slack_error_message_with_log(
@@ -661,10 +678,10 @@ def send_slack_error_message_with_log(
     protocol_name: str,
     error_str: str,
 ) -> None:
-    """Send error slack message with log files attached."""
-    log_path = create_robot_log_zip()
-    image_path = get_last_image_capture()
-    slack_bot.send_error_message(protocol_name, error_str, [log_path, image_path])
+    """Send error slack message with log files and video clip attached."""
+    log_path, ip = create_robot_log_zip()
+    video_path = get_livestream_video()
+    slack_bot.send_error_message(protocol_name, error_str, ip, [log_path, video_path])
 
 
 def send_slack_message_with_image(slack_bot: slack.Slack, protocol_name: str) -> None:

--- a/abr-testing/abr_testing/protocols/helpers.py
+++ b/abr-testing/abr_testing/protocols/helpers.py
@@ -135,6 +135,19 @@ def create_meniscus_z_parameter(parameters: ParameterContext) -> None:
     )
 
 
+def create_error_capture_duration_duration(parameters: ParameterContext) -> None:
+    """Create error capture duration parameter."""
+    parameters.add_int(
+        variable_name="error_capture_duration",
+        display_name="Error Capture Duration",
+        description="Length of video clip to capture on error (in seconds).",
+        default=30,
+        minimum=5,
+        maximum=6000,
+        unit="seconds",
+    )
+
+
 def create_pipette_parameters(parameters: ParameterContext) -> None:
     """Create parameter for pipettes."""
     # NOTE: Place function inside def add_parameters(parameters) in protocol.
@@ -643,20 +656,20 @@ def get_last_image_capture() -> str:
     return image_path
 
 
-def convert_m3u8_to_mp4(m3u8_path: str, mp4_path: str) -> None:
+def convert_m3u8_to_mp4(m3u8_pth: str, mp4_pth: str, dur: int = 30) -> None:
     """Convert m3u8 video to mp4 format."""
     subprocess.run(
-        f'ffmpeg -i "{m3u8_path}" -t 30 -c:v mpeg4 -c:a aac -movflags +faststart "{mp4_path}" -y',
+        f'ffmpeg -i "{m3u8_pth}" -t {dur} -c:v mpeg4 -c:a aac -movflags +faststart "{mp4_pth}" -y',
         shell=True,
         check=True,
     )
 
 
-def get_livestream_video() -> str:
-    """Get livestream video of last 3 seconds of run."""
+def get_livestream_video(length: int) -> str:
+    """Get latest livestream video."""
     video_path = "/var/www/localhost/html/stream/hls/stream.m3u8"
     new_video_path = "/data/testing_data/livestream_video.mp4"
-    convert_m3u8_to_mp4(video_path, new_video_path)
+    convert_m3u8_to_mp4(video_path, new_video_path, length)
     return new_video_path
 
 
@@ -673,14 +686,12 @@ def create_robot_log_zip() -> Tuple[str, str]:
     return get_logs(storage_directory, ip), ip
 
 
-def send_slack_error_message_with_log(
-    slack_bot: slack.Slack,
-    protocol_name: str,
-    error_str: str,
+def send_slack_error_message_with_attachments(
+    slack_bot: slack.Slack, protocol_name: str, error_str: str, length: int = 30
 ) -> None:
     """Send error slack message with log files and video clip attached."""
     log_path, ip = create_robot_log_zip()
-    video_path = get_livestream_video()
+    video_path = get_livestream_video(length)
     slack_bot.send_error_message(protocol_name, error_str, ip, [log_path, video_path])
 
 

--- a/abr-testing/abr_testing/protocols/helpers.py
+++ b/abr-testing/abr_testing/protocols/helpers.py
@@ -24,6 +24,8 @@ from typing import List, Union, Dict, Tuple
 from opentrons.hardware_control.modules.types import ThermocyclerStep
 from datetime import datetime
 import subprocess
+import requests
+import os
 
 # FUNCTIONS FOR LOADING COMMON CONFIGURATIONS
 
@@ -606,6 +608,41 @@ def set_up_slack() -> slack.Slack:
     )
 
 
+def get_current_run_id() -> str:
+    """Get current run id."""
+    result = subprocess.run(
+        "ip route get 1.1.1.1 | awk '{print $7}'",
+        shell=True,
+        capture_output=True,
+        text=True,
+    )
+    ip = result.stdout.strip()
+    try:
+        response = requests.get(
+            f"http://{ip}:31950/runs", headers={"opentrons-version": "3"}
+        )
+        run_data = response.json()
+        run_list = run_data.get("data", "")
+        for run in run_list:
+            run_id = run["id"]
+            if run["current"]:
+                return run_id
+        else:
+            return ""
+    except requests.exceptions.RequestException:
+        print(f"Could not connect to robot with IP {ip}")
+        return ""
+
+
+def get_last_image_capture() -> str:
+    """Get final photo of run."""
+    run_id = get_current_run_id()
+    image_storage = f"/data/images/{run_id}"
+    all_images = os.listdir(image_storage)
+    image_path = os.path.join(image_storage, all_images[-1])
+    return image_path
+
+
 def create_robot_log_zip() -> str:
     """Create a zip file of logs saved locally on robot."""
     storage_directory = "/data/testing_data"
@@ -620,11 +657,20 @@ def create_robot_log_zip() -> str:
 
 
 def send_slack_error_message_with_log(
-    slack_bot: slack.Slack, protocol_name: str, error_str: str
+    slack_bot: slack.Slack,
+    protocol_name: str,
+    error_str: str,
 ) -> None:
     """Send error slack message with log files attached."""
     log_path = create_robot_log_zip()
-    slack_bot.send_error_message(protocol_name, error_str, log_path)
+    image_path = get_last_image_capture()
+    slack_bot.send_error_message(protocol_name, error_str, [log_path, image_path])
+
+
+def send_slack_message_with_image(slack_bot: slack.Slack, protocol_name: str) -> None:
+    """Send run completed message with image."""
+    image_path = get_last_image_capture()
+    slack_bot.send_run_completed_message(protocol_name, [image_path])
 
 
 def comment_height_of_specific_labware(

--- a/abr-testing/abr_testing/protocols/helpers.py
+++ b/abr-testing/abr_testing/protocols/helpers.py
@@ -646,7 +646,7 @@ def get_last_image_capture() -> str:
 def convert_m3u8_to_mp4(m3u8_path: str, mp4_path: str) -> None:
     """Convert m3u8 video to mp4 format."""
     subprocess.run(
-        f'ffmpeg -i "{m3u8_path}" -t 3 -c:v mpeg4 -c:a aac -movflags +faststart "{mp4_path}" -y',
+        f'ffmpeg -i "{m3u8_path}" -t 30 -c:v mpeg4 -c:a aac -movflags +faststart "{mp4_path}" -y',
         shell=True,
         check=True,
     )

--- a/abr-testing/abr_testing/protocols/test_protocols/75C_Condensation_recovery.py
+++ b/abr-testing/abr_testing/protocols/test_protocols/75C_Condensation_recovery.py
@@ -48,6 +48,6 @@ def run(protocol: protocol_api.ProtocolContext) -> None:
         thermocycler_module_1.deactivate_lid()
     except Exception as e:
         if not protocol.is_simulating():
-            helpers.send_slack_error_message_with_log(
+            helpers.send_slack_error_message_with_attachments(
                 slack_bot, metadata["protocolName"], str(e)
             )

--- a/abr-testing/abr_testing/protocols/test_protocols/95C_Condensation_recovery.py
+++ b/abr-testing/abr_testing/protocols/test_protocols/95C_Condensation_recovery.py
@@ -49,6 +49,6 @@ def run(protocol: protocol_api.ProtocolContext) -> None:
         thermocycler_module_1.deactivate_lid()
     except Exception as e:
         if not protocol.is_simulating():
-            helpers.send_slack_error_message_with_log(
+            helpers.send_slack_error_message_with_attachments(
                 slack_bot, metadata["protocolName"], str(e)
             )

--- a/abr-testing/abr_testing/protocols/test_protocols/evotips.py
+++ b/abr-testing/abr_testing/protocols/test_protocols/evotips.py
@@ -367,7 +367,7 @@ def run(protocol: ProtocolContext) -> None:
             slack_bot.send_run_completed_message(metadata["protocolName"])
     except Exception as e:
         if not protocol.is_simulating():
-            helpers.send_slack_error_message_with_log(
+            helpers.send_slack_error_message_with_attachments(
                 slack_bot, metadata["protocolName"], str(e)
             )
         raise (e)

--- a/abr-testing/abr_testing/protocols/test_protocols/tip_pick_up_test.py
+++ b/abr-testing/abr_testing/protocols/test_protocols/tip_pick_up_test.py
@@ -60,7 +60,7 @@ def run(protocol: ProtocolContext) -> None:
                 pipette.reset_tipracks()
     except Exception as e:
         if not protocol.is_simulating():
-            helpers.send_slack_error_message_with_log(
+            helpers.send_slack_error_message_with_attachments(
                 slack_bot, metadata["protocolName"], str(e)
             )
         raise (e)

--- a/abr-testing/abr_testing/tools/increase_livestream_time.py
+++ b/abr-testing/abr_testing/tools/increase_livestream_time.py
@@ -5,10 +5,11 @@ import subprocess
 
 def edit_livestream_length(ip: str, time: str) -> None:
     """SSH into robot and increase livestream time."""
+    key = "hls_playlist_length"
     ssh_command = f"""
     ssh root@{ip} '
         mount -o remount,rw / &&
-        sed -i "96s/.*/            hls_playlist_length {time}s;/" /etc/nginx/nginx.conf &&
+        sed -i "s/{key} *[0-9][0-9]*s;/{key} {time}s/g" /etc/nginx/nginx.conf &&
         systemctl daemon-reload &&
         systemctl restart nginx
     '

--- a/abr-testing/abr_testing/tools/increase_livestream_time.py
+++ b/abr-testing/abr_testing/tools/increase_livestream_time.py
@@ -1,0 +1,29 @@
+"""Increase minimum duration on the livestream video tool."""
+from .make_push import get_robot_ips
+import subprocess
+
+
+def edit_livestream_length(ip: str, time: str) -> None:
+    """SSH into robot and increase livestream time."""
+    ssh_command = f"""
+    ssh root@{ip} '
+        mount -o remount,rw / &&
+        sed -i "96s/.*/            hls_playlist_length {time}s;/" /etc/nginx/nginx.conf &&
+        systemctl daemon-reload &&
+        systemctl restart nginx
+    '
+    """
+    try:
+        subprocess.run(ssh_command, shell=True, check=True)
+        print(f"Successfully updated livestream length on {ip}")
+    except subprocess.CalledProcessError as e:
+        print(f"Failed to update {ip}: {e}")
+
+
+if __name__ == "__main__":
+    robot_to_push = get_robot_ips()
+    livestream_time = input(
+        "Enter desired livestream length in seconds (e.g., 30): "
+    ).strip()
+    for robot_ip in robot_to_push:
+        edit_livestream_length(robot_ip, livestream_time)

--- a/abr-testing/abr_testing/tools/make_push.py
+++ b/abr-testing/abr_testing/tools/make_push.py
@@ -1,81 +1,56 @@
 """Push one or more folders to one or more robots."""
 import subprocess
 import json
-from typing import List
 from multiprocessing import Process, Queue
 
-global folders
-# Opentrons folders that can be pushed to robot
-folders = [
-    "abr-testing",
-    "hardware-testing",
-    "abr-testing + hardware-testing",
-    "other",
-]
 
-
-def push_subroutine(cmd: str, queue: Queue) -> None:
+def push_subroutine(cmd: list[str], queue: Queue) -> None:
     """Pushes specified folder to specified robot."""
+    message = f'folder {cmd[2]} to ip {cmd[-1].split("=")[1]}'
     try:
         subprocess.run(cmd)
-        queue.put(f"{cmd}: SUCCESS!\n")
-    except Exception:
-        queue.put(f"{cmd}: FAILED\n")
+        queue.put(f"SUCCESS: sent {message}!\n")
+    except Exception as e:
+        print("Failed to push folder:", e)
+        queue.put(f"FAILURE: could not send {message}.\n")
 
 
-def main(folder_to_push: str, robot_to_push: str) -> int:
-    """Main process!"""
-    cmd = "make -C {folder} push-ot3 host={ip}"
-    robot_ip_path = ""
-    push_cmd = ""
-    processes: List[Process] = []
-    queue: Queue = Queue()
-    folder_int = int(folder_to_push)
-    if folders[folder_int].lower() == "abr-testing + hardware-testing":
-        if robot_to_push.lower() == "all":
-            robot_ip_path = input("Path to robot ips: ")
-            with open(robot_ip_path, "r") as ip_file:
-                robot_json = json.load(ip_file)
-                robot_ips_dict = robot_json.get("ip_address_list")
-                robot_ips = list(robot_ips_dict.keys())
-                ip_file.close()
-        else:
-            robot_ips = [robot_to_push]
-        for folder_name in folders[:-2]:
-            # Push abr-testing and hardware-testing folders to all robots
-            for robot in robot_ips:
-                push_cmd = cmd.format(folder=folder_name, ip=robot)
-                process = Process(
-                    target=push_subroutine,
-                    args=(
-                        push_cmd,
-                        queue,
-                    ),
-                )
-                process.start()
-                processes.append(process)
+def get_robot_ips() -> set[str]:
+    """Get robot ips from the user."""
+    user_input = input("Type in robots ip (type all for all): ")
+    if user_input.lower() == "all":
+        robot_ip_path = input("Path to robot ips: ")
+        with open(robot_ip_path, "r") as ip_file:
+            robot_json = json.load(ip_file)
+            robot_ips_dict = robot_json.get("ip_address_list")
+            return set(robot_ips_dict.keys())
     else:
+        return {user_input}
 
-        if folder_int == (len(folders) - 1):
-            folder_name = input("Which folder? ")
-        else:
-            folder_name = folders[folder_int]
-        if robot_to_push.lower() == "all":
-            robot_ip_path = input("Path to robot ips: ")
-            with open(robot_ip_path, "r") as ip_file:
-                robot_json = json.load(ip_file)
-                robot_ips = robot_json.get("ip_address_list")
-            ip_file.close()
-        else:
-            robot_ips = [robot_to_push]
 
-        # Push folder to robots
+def get_folder_names() -> set[str]:
+    """Get folder names from the user."""
+    folder_input = input("Type in folder names separated by commas: ")
+    folder_names = {name.strip() for name in folder_input.split(",")}
+    return folder_names
+
+
+def main(folder_to_push: set[str], robot_ips: set[str]) -> int:
+    """Builds commands to push folders to specified robots."""
+    processes: list[Process] = []
+    queue: Queue = Queue()
+    for folder_name in folder_to_push:
         for robot in robot_ips:
-            push_cmd = cmd.format(folder=folder_name, ip=robot)
-            process = Process(target=push_subroutine, args=(push_cmd, queue))
+            push_cmd = ["make", "-C", folder_name, "push-ot3", f"host={robot}"]
+            process = Process(
+                target=push_subroutine,
+                args=(
+                    push_cmd,
+                    queue,
+                ),
+            )
             process.start()
             processes.append(process)
-
     for process in processes:
         process.join()
         result = queue.get()
@@ -84,8 +59,8 @@ def main(folder_to_push: str, robot_to_push: str) -> int:
 
 
 if __name__ == "__main__":
-    for i, folder in enumerate(folders):
-        print(f"{i}) {folder}")
-    folder_to_push = input("Please Select a Folder to Push: ")
-    robot_to_push = input("Type in robots ip (type all for all): ")
+    print("Welcome to the batch Opentrons robot push-folder tool.")
+    print("This tool has been tested on the abr-testing & hardware-testing repos.")
+    folder_to_push = get_folder_names()
+    robot_to_push = get_robot_ips()
     print(main(folder_to_push, robot_to_push))


### PR DESCRIPTION
# Overview

Track image captures in abr data sheet
Attached images from protocol to error tickets and completed run slack message
Attaches last 3 seconds of the livestream to error run slack message

## Test Plan and Hands on Testing

**smoke tested on abr-run-data tracker**
<img width="1069" height="163" alt="Screenshot 2025-12-08 at 3 22 52 PM" src="https://github.com/user-attachments/assets/c6722997-9677-4774-bd3c-ac71bfb84a07" />
**smoke tested with jira error script:**
<img width="935" height="551" alt="Screenshot 2025-12-08 at 3 24 01 PM" src="https://github.com/user-attachments/assets/484039b9-0a4c-44fe-b949-2073bafcf78e" />
**smoke tested slack messages**
<img width="502" height="574" alt="Screenshot 2025-12-11 at 1 12 47 PM" src="https://github.com/user-attachments/assets/6486c1b1-6341-49a9-8773-9791a77585a8" />


## Risk assessment

low
