### PR TITLE
fix(protocol-designer): document that pipettes.tiprackURI is a labwareId, not a URI

### DIFF
--- a/step-generation/src/types.ts
+++ b/step-generation/src/types.ts
@@ -708,6 +708,7 @@ export interface TimelineFrame {
     pipettes: {
       [pipetteId: string]: {
         hasTip: boolean
+        /** TODO: tiprackURI is a misnomer: it's a labwareId, not a URI */
         tiprackURI: string | null
       }
     }

--- a/step-generation/src/utils/safePipetteMovements.ts
+++ b/step-generation/src/utils/safePipetteMovements.ts
@@ -319,14 +319,10 @@ export const getIsSafePipetteMovement = (args: {
     return true
   }
 
-  const tiprackURI = tipState.pipettes[pipetteId]?.tiprackURI
-  const tiprackEntityId =
-    tiprackURI != null
-      ? Object.keys(labwareEntities).find(lwKey => lwKey.includes(tiprackURI))
-      : null
+  const tiprackEntityId = tipState.pipettes[pipetteId]?.tiprackURI
   const tiprackTipLength =
     tiprackEntityId != null
-      ? labwareEntities[tiprackEntityId].def.parameters.tipLength
+      ? labwareEntities[tiprackEntityId]?.def.parameters.tipLength
       : 0
   const stagingAreaSlots = Object.values(stagingAreaEntities).map(
     stagingArea => stagingArea.location as string


### PR DESCRIPTION
# Overview

(This was a small issue I ran into while working on the QT disposal volume bugs.)

We have this field `RobotState.tipState.pipettes[pipetteId].tiprackURI`. Despite its name, `.tiprackURI` not a URI, it's a labware entity ID.

This PR adds a docstring explaining that `.tiprackURI` is a labwareId, and fixes one place in the code that incorrectly assumed it was a URI. 

## Test Plan and Hands on Testing

Run CI tests.
Tried it locally with `make -C protocol-designer dev` when using tip management `never`.

## Risk assessment

Low.