### PR TITLE
fix(protocol-designer): show noTipOnPipette instead of labwareDoesNotExist for changeTip=never

### DIFF
--- a/step-generation/src/commandCreators/compound/consolidate.ts
+++ b/step-generation/src/commandCreators/compound/consolidate.ts
@@ -247,15 +247,16 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
     )
     tiprackURI = userSelectedTipRackURI
   }
-
   if (tiprackEntity == null) {
-    errors.push(
-      errorCreators.labwareDoesNotExist({
-        actionName,
-        labware: tiprackURI,
-      })
-    )
+    if (changeTip === 'never') {
+      errors.push(errorCreators.noTipOnPipette({ actionName, pipette }))
+    } else {
+      errors.push(
+        errorCreators.labwareDoesNotExist({ actionName, labware: tiprackURI })
+      )
+    }
   }
+
   const { def: tiprackDefinition = null } = tiprackEntity ?? {}
   const {
     spec: pipetteSpecs,

--- a/step-generation/src/commandCreators/compound/distribute.ts
+++ b/step-generation/src/commandCreators/compound/distribute.ts
@@ -265,15 +265,16 @@ export const distribute: CommandCreator<DistributeArgs> = (
     )
     tiprackURI = userSelectedTipRackURI
   }
-
   if (tiprackEntity == null) {
-    errors.push(
-      errorCreators.labwareDoesNotExist({
-        actionName,
-        labware: tiprackURI,
-      })
-    )
+    if (changeTip === 'never') {
+      errors.push(errorCreators.noTipOnPipette({ actionName, pipette }))
+    } else {
+      errors.push(
+        errorCreators.labwareDoesNotExist({ actionName, labware: tiprackURI })
+      )
+    }
   }
+
   const { def: tiprackDefinition = null } = tiprackEntity ?? {}
   const {
     spec: pipetteSpecs,

--- a/step-generation/src/commandCreators/compound/transfer.ts
+++ b/step-generation/src/commandCreators/compound/transfer.ts
@@ -296,14 +296,14 @@ export const transfer: CommandCreator<TransferArgs> = (
     )
     tiprackURI = userSelectedTipRackURI
   }
-
   if (tiprackEntity == null) {
-    errors.push(
-      errorCreators.labwareDoesNotExist({
-        actionName,
-        labware: tiprackURI,
-      })
-    )
+    if (changeTip === 'never') {
+      errors.push(errorCreators.noTipOnPipette({ actionName, pipette }))
+    } else {
+      errors.push(
+        errorCreators.labwareDoesNotExist({ actionName, labware: tiprackURI })
+      )
+    }
   }
 
   if (errors.length > 0) {


### PR DESCRIPTION
# Overview

I noticed that if you make a Transfer step as the first step in a protocol and choose tip handling = never, we show the `LABWARE_DOES_NOT_EXIST` error message:
<img width="762" height="68" alt="image" src="https://github.com/user-attachments/assets/2b4d28bf-4f97-4d9b-b930-8784e3105081" />
This is not as nice as the more explicit `NO_TIP_ON_PIPETTE` error we used to have.

Here's why this is happening: Previously, if you selected tip handling = never, we would use whatever tip rack you chose for this step, and continue onto step generation. Then in the `CommandCreator` for the first `aspirate` in the transfer, we would notice that there was no tip on the pipette, and emit a `NO_TIP_ON_PIPETTE` error.

However, we realized that we were using the wrong tip rack for tip handling = never. We changed the implementation to use the tip rack from the previous step in that case (AUTH-2537). However, if this is the very first step on the protocol, then there is no previous step, and the tip rack would be undefined, triggering this error that says `This step tries to use undefined`.

This PR fixes the code to emit the `NO_TIP_ON_PIPETTE` error again when tip handling = never and there is no previous tip rack:
<img width="762" height="88" alt="image" src="https://github.com/user-attachments/assets/92db0d9b-b279-4dc3-8796-32991fa98c61" />

## Test Plan and Hands on Testing

Tried it locally with `make -C protocol-designer dev`.

## Review requests

Is this worth getting into PD 8.7.0? It's a small quality-of-life issue, and I'd also be OK with putting this into `edge` instead.

## Risk assessment

Low.