### PR TITLE
fix(app) fix LabwareSlot layout in the Second window

### DIFF
--- a/app-shell/src/secondary-windows/step-detail-viewer/index.ts
+++ b/app-shell/src/secondary-windows/step-detail-viewer/index.ts
@@ -109,7 +109,7 @@ export function createStepDetailViewerUi({
 
   stepDetailViewerWindow.once('ready-to-show', () => {
     log.debug('Step detail viewer window ready to show')
-    stepDetailViewerWindow.setTitle('Slot Spotlight')
+    stepDetailViewerWindow.setTitle('Slot spotlight')
     stepDetailViewerWindow.show()
   })
 

--- a/app-shell/src/secondary-windows/step-detail-viewer/index.ts
+++ b/app-shell/src/secondary-windows/step-detail-viewer/index.ts
@@ -109,7 +109,7 @@ export function createStepDetailViewerUi({
 
   stepDetailViewerWindow.once('ready-to-show', () => {
     log.debug('Step detail viewer window ready to show')
-    stepDetailViewerWindow.setTitle('Slot spotlight')
+    stepDetailViewerWindow.setTitle('Slot Spotlight')
     stepDetailViewerWindow.show()
   })
 

--- a/app/src/organisms/Desktop/ProtocolVisualization/SecondWindow/LabwareSlot/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/SecondWindow/LabwareSlot/index.tsx
@@ -1,0 +1,217 @@
+import { useTranslation } from 'react-i18next'
+
+import {
+  COLORS,
+  LabwareRender,
+  MODULE_ICON_NAME_BY_TYPE,
+  RobotInfoLabel,
+  RobotWorkSpace,
+  StyledText,
+  Tag,
+} from '@opentrons/components'
+import { getLabwareViewBox } from '@opentrons/shared-data'
+import {
+  getSlotInLocationStack,
+  wellFillFromWellContents,
+} from '@opentrons/step-generation'
+
+import { getAllWellContentsAtFrame } from '../../utils/getAllWellContentsAtFrame'
+import { WellContainer } from '../../WellContainer'
+import { WellTooltip } from '../../WellTooltip'
+import styles from './labwareslot.module.css'
+
+import type { WellGroup } from '@opentrons/components'
+import type { Liquid, RunTimeCommand } from '@opentrons/shared-data'
+import type {
+  LabwareEntities,
+  ModuleEntities,
+  PipetteEntities,
+  RobotState,
+} from '@opentrons/step-generation'
+
+interface LabwareSlotContainerProps {
+  topLabwareOnSlotId: string
+  labwareEntities: LabwareEntities
+  commands: RunTimeCommand[]
+  liquids: Liquid[]
+  currentCommand: RunTimeCommand
+  robotState: RobotState
+  pipetteEntities: PipetteEntities
+  moduleEntities: ModuleEntities
+}
+export function LabwareSlot(
+  props: LabwareSlotContainerProps
+): JSX.Element {
+  const {
+    commands,
+    liquids,
+    topLabwareOnSlotId,
+    labwareEntities,
+    currentCommand,
+    robotState,
+    pipetteEntities,
+    moduleEntities,
+  } = props
+  const { t } = useTranslation('protocol_visualization')
+  const { labware, pipettes, liquidState } = robotState
+  const labwareLoadCommand = Object.values(commands).find(
+    command =>
+      'labwareId' in command.result &&
+      command.result.labwareId === topLabwareOnSlotId
+  )
+  const pipetteTemporalProperties = Object.entries(pipettes).find(
+    ([_, pipette]) => pipette.entityId === topLabwareOnSlotId
+  )
+  const slot = getSlotInLocationStack(labware[topLabwareOnSlotId].stack)
+
+  const { params: labwareLoadCommandParams } = labwareLoadCommand ?? {}
+  const labwareNickname: string | null =
+    labwareLoadCommandParams != null &&
+    'displayName' in labwareLoadCommandParams
+      ? labwareLoadCommandParams.displayName
+      : null
+  const { params } = currentCommand
+  const labwareDef = labwareEntities[topLabwareOnSlotId].def
+  const labwareDisplayName = labwareDef.metadata.displayName
+
+  const liquidDisplayColors = Object.fromEntries(
+    liquids.map(({ id, displayColor }) => [id, displayColor ?? COLORS.grey40])
+  )
+  const allWellContentsForActiveItem = getAllWellContentsAtFrame(
+    liquidState,
+    labwareDef
+  )
+  const wellContents =
+    allWellContentsForActiveItem != null
+      ? allWellContentsForActiveItem[topLabwareOnSlotId]
+      : null
+
+  const wellFill = wellFillFromWellContents(wellContents, liquidDisplayColors)
+  const activeWellName =
+    pipetteTemporalProperties != null
+      ? pipetteTemporalProperties[1].wellName
+      : null
+  const wellGroup: WellGroup | null =
+    activeWellName != null
+      ? {
+          [activeWellName]: null,
+        }
+      : null
+  const { wells } = labwareDef
+
+  const pipetteLocationLiquidState =
+    pipetteTemporalProperties != null
+      ? liquidState.pipettes[pipetteTemporalProperties[0]]?.[0]
+      : null
+  const labwareLocationLiquidState =
+    activeWellName != null
+      ? liquidState.labware[topLabwareOnSlotId]?.[activeWellName]
+      : null
+
+  const tipMaxVolume =
+    pipetteTemporalProperties != null
+      ? pipetteEntities[pipetteTemporalProperties[0]].spec.liquids.default
+          .maxVolume
+      : 0
+
+  const labwareViewBox = getLabwareViewBox(labwareDef)
+  const ingredNames = liquids.reduce(
+    (acc: Record<string, string>, { id, displayName }) => {
+      acc[id] = displayName
+      return acc
+    },
+    {}
+  )
+
+  return (
+    <>
+      {activeWellName != null ? (
+        <WellContainer
+          wells={wells}
+          params={params}
+          activeWellName={activeWellName}
+          wellColor={wellFill[activeWellName]}
+          labwareLocationLiquidState={labwareLocationLiquidState}
+          pipetteLocationLiquidState={pipetteLocationLiquidState}
+          liquids={liquids}
+          tipMaxVolume={tipMaxVolume}
+        />
+      ) : null}
+      <div className={styles.container}>
+        <div className={styles.header}>
+            {/* header icon part */}
+          <div>
+            {labware[topLabwareOnSlotId]?.stack
+              .filter(item => item !== topLabwareOnSlotId)
+              .reverse()
+              .map(item => {
+                if (moduleEntities[item] != null) {
+                  return (
+                    <RobotInfoLabel
+                      key={item}
+                      iconName={
+                        MODULE_ICON_NAME_BY_TYPE[moduleEntities[item].type]
+                      }
+                    />
+                  )
+                } else if (labware[item] != null) {
+                  return <RobotInfoLabel key={item} iconName="stacked" />
+                } else {
+                  return <RobotInfoLabel key={item} deckLabel={slot} />
+                }
+              })}
+          </div>
+           {/* header icon part */}
+
+          {/* header text part */}
+          <div className={styles.header_text}>
+            {labwareNickname != null ? (
+            <StyledText desktopStyle="captionSemiBold">
+                {labwareNickname}
+            </StyledText>
+            ) : null}
+            <StyledText desktopStyle="bodyDefaultRegular">
+                {labwareDisplayName}
+            </StyledText>
+          </div>
+           {/* header text part */}
+        </div>
+        <div className={styles.body_container}>
+          <WellTooltip ingredNames={ingredNames}>
+            {({ makeHandleMouseEnterWell, handleMouseLeaveWell }) => (
+              <div className={styles.labware_render_container}>
+                <RobotWorkSpace
+                  key={topLabwareOnSlotId}
+                  viewBox={`${labwareViewBox.minX} ${labwareViewBox.minY} ${labwareViewBox.xDimension} ${labwareViewBox.yDimension}`}
+                >
+                  {() => (
+                    <g>
+                      <LabwareRender
+                        definition={labwareDef}
+                        positioningMode="passThrough"
+                        wellFill={wellFill}
+                        highlightedWells={wellGroup}
+                        onMouseLeaveWell={mouseEventArgs => {
+                          handleMouseLeaveWell(mouseEventArgs)
+                          handleMouseLeaveWell(mouseEventArgs.event)
+                        }}
+                        onMouseEnterWell={({ wellName, event }) => {
+                          if (wellContents != null) {
+                            makeHandleMouseEnterWell(
+                              wellName,
+                              wellContents[wellName]?.ingreds
+                            )(event)
+                          }
+                        }}
+                      />
+                    </g>
+                  )}
+                </RobotWorkSpace>
+              </div>
+            )}
+          </WellTooltip>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/app/src/organisms/Desktop/ProtocolVisualization/SecondWindow/LabwareSlot/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/SecondWindow/LabwareSlot/index.tsx
@@ -1,5 +1,3 @@
-import { useTranslation } from 'react-i18next'
-
 import {
   COLORS,
   LabwareRender,
@@ -7,7 +5,6 @@ import {
   RobotInfoLabel,
   RobotWorkSpace,
   StyledText,
-  Tag,
 } from '@opentrons/components'
 import { getLabwareViewBox } from '@opentrons/shared-data'
 import {
@@ -39,9 +36,7 @@ interface LabwareSlotContainerProps {
   pipetteEntities: PipetteEntities
   moduleEntities: ModuleEntities
 }
-export function LabwareSlot(
-  props: LabwareSlotContainerProps
-): JSX.Element {
+export function LabwareSlot(props: LabwareSlotContainerProps): JSX.Element {
   const {
     commands,
     liquids,
@@ -52,7 +47,6 @@ export function LabwareSlot(
     pipetteEntities,
     moduleEntities,
   } = props
-  const { t } = useTranslation('protocol_visualization')
   const { labware, pipettes, liquidState } = robotState
   const labwareLoadCommand = Object.values(commands).find(
     command =>
@@ -139,7 +133,7 @@ export function LabwareSlot(
       ) : null}
       <div className={styles.container}>
         <div className={styles.header}>
-            {/* header icon part */}
+          {/* header icon part */}
           <div>
             {labware[topLabwareOnSlotId]?.stack
               .filter(item => item !== topLabwareOnSlotId)
@@ -161,20 +155,20 @@ export function LabwareSlot(
                 }
               })}
           </div>
-           {/* header icon part */}
+          {/* header icon part */}
 
           {/* header text part */}
           <div className={styles.header_text}>
             {labwareNickname != null ? (
-            <StyledText desktopStyle="captionSemiBold">
+              <StyledText desktopStyle="captionSemiBold">
                 {labwareNickname}
-            </StyledText>
+              </StyledText>
             ) : null}
             <StyledText desktopStyle="bodyDefaultRegular">
-                {labwareDisplayName}
+              {labwareDisplayName}
             </StyledText>
           </div>
-           {/* header text part */}
+          {/* header text part */}
         </div>
         <div className={styles.body_container}>
           <WellTooltip ingredNames={ingredNames}>

--- a/app/src/organisms/Desktop/ProtocolVisualization/SecondWindow/LabwareSlot/labwareslot.module.css
+++ b/app/src/organisms/Desktop/ProtocolVisualization/SecondWindow/LabwareSlot/labwareslot.module.css
@@ -1,0 +1,23 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  padding: var(--spacing-16) var(--spacing-20);
+  gap: var(--spacing-16);
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-4);
+}
+
+.header_text {
+  display: flex;
+  flex-direction: column;
+}
+
+.body_container {
+  padding: var(--spacing-16) var(--spacing-24);
+  border-radius: var(--border-radius-4);
+  background-color: var(--grey-10);
+}

--- a/app/src/organisms/Desktop/ProtocolVisualization/SecondWindow/LabwareSlot/labwareslot.module.css
+++ b/app/src/organisms/Desktop/ProtocolVisualization/SecondWindow/LabwareSlot/labwareslot.module.css
@@ -1,7 +1,7 @@
 .container {
   display: flex;
   flex-direction: column;
-  padding: var(--spacing-16) var(--spacing-20);
+  padding: var(--spacing-16) var(--spacing-20) var(--spacing-20);
   gap: var(--spacing-16);
 }
 

--- a/app/src/organisms/Desktop/ProtocolVisualization/SecondWindow/LabwareSlot/＿＿tests__/LabwareSlot.test.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/SecondWindow/LabwareSlot/＿＿tests__/LabwareSlot.test.tsx
@@ -1,0 +1,174 @@
+import { screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { fixture96Plate } from '@opentrons/shared-data'
+
+import { renderWithProviders } from '/app/__testing-utils__'
+import { i18n } from '/app/i18n'
+
+import { LabwareSlot } from '..'
+
+import type { ComponentProps } from 'react'
+import type * as OpentronsComponents from '@opentrons/components'
+import type { LabwareDefinition2, RunTimeCommand } from '@opentrons/shared-data'
+import type {
+  LabwareEntities,
+  ModuleEntities,
+  PipetteEntities,
+  RobotState,
+} from '@opentrons/step-generation'
+
+vi.mock('@opentrons/components', async importOriginal => {
+  const actual = await importOriginal<typeof OpentronsComponents>()
+  return {
+    ...actual,
+    LabwareRender: vi.fn(() => <div>mock LabwareRender</div>),
+  }
+})
+
+vi.mock('../../WellContainer', () => ({
+  WellContainer: vi.fn(() => <div>mock WellContainer</div>),
+}))
+
+vi.mock('../../WellTooltip', () => ({
+  WellTooltip: vi.fn(({ children }) => {
+    const mockHandlers = {
+      makeHandleMouseEnterWell: vi.fn(),
+      handleMouseLeaveWell: vi.fn(),
+    }
+    return <div>{children(mockHandlers)}</div>
+  }),
+}))
+
+const render = (props: ComponentProps<typeof LabwareSlot>) => {
+  return renderWithProviders(<LabwareSlot {...props} />, {
+    i18nInstance: i18n,
+  })
+}
+
+const MOCK_LABWARE_ID = 'mockLabwareId'
+const MOCK_SLOT = 'A1'
+
+const createMockLabwareDef = (): LabwareDefinition2 => {
+  return {
+    ...fixture96Plate,
+    metadata: {
+      ...fixture96Plate.metadata,
+      displayName: 'Mock 96 Well Plate',
+    },
+  } as LabwareDefinition2
+}
+
+const createMockLabwareEntities = (): LabwareEntities => {
+  return {
+    [MOCK_LABWARE_ID]: {
+      id: MOCK_LABWARE_ID,
+      labwareDefURI: 'opentrons/fixture_96_plate/1',
+      def: createMockLabwareDef(),
+      pythonName: 'mock_plate',
+    },
+  }
+}
+
+const createMockRobotState = (): RobotState => {
+  return {
+    labware: {
+      [MOCK_LABWARE_ID]: {
+        stack: [MOCK_LABWARE_ID, MOCK_SLOT],
+      },
+    },
+    pipettes: {},
+    modules: {},
+    liquidState: {
+      pipettes: {},
+      labware: {},
+      trashBins: {},
+      wasteChute: {},
+    },
+    tipState: {
+      pipettes: {},
+      tipracks: {},
+    },
+  } as RobotState
+}
+
+const createMockLoadLabwareCommand = (): RunTimeCommand => {
+  return {
+    commandType: 'loadLabware',
+    params: {
+      location: { slotName: MOCK_SLOT },
+      displayName: 'Test Plate',
+    },
+    result: {
+      labwareId: MOCK_LABWARE_ID,
+    },
+  } as RunTimeCommand
+}
+
+describe('LabwareSlot', () => {
+  let props: ComponentProps<typeof LabwareSlot>
+
+  beforeEach(() => {
+    props = {
+      topLabwareOnSlotId: MOCK_LABWARE_ID,
+      labwareEntities: createMockLabwareEntities(),
+      commands: [createMockLoadLabwareCommand()],
+      liquids: [],
+      robotState: createMockRobotState(),
+      moduleEntities: {} as ModuleEntities,
+      pipetteEntities: {} as PipetteEntities,
+      currentCommand: {
+        commandType: 'aspirate',
+        params: {},
+      } as RunTimeCommand,
+    }
+  })
+
+  it('should render labware display name', () => {
+    render(props)
+    expect(screen.getByText('Mock 96 Well Plate')).toBeInTheDocument()
+  })
+
+  it('should render labware nickname when provided', () => {
+    render(props)
+    expect(screen.getByText('Test Plate')).toBeInTheDocument()
+  })
+
+  it('should render LabwareRender component', () => {
+    render(props)
+    expect(screen.getByText('mock LabwareRender')).toBeInTheDocument()
+  })
+
+  it('should not render WellContainer when activeWellName is null', () => {
+    render(props)
+    expect(screen.queryByText('mock WellContainer')).not.toBeInTheDocument()
+  })
+
+  it('should render WellContainer when activeWellName is provided', () => {
+    props.robotState = {
+      ...createMockRobotState(),
+      pipettes: {
+        mockPipetteId: {
+          mount: 'left',
+          entityId: MOCK_LABWARE_ID,
+          wellName: 'A1',
+        },
+      },
+    }
+    props.pipetteEntities = {
+      mockPipetteId: {
+        id: 'mockPipetteId',
+        name: 'p300_single',
+        spec: {
+          liquids: {
+            default: {
+              maxVolume: 300,
+            },
+          },
+        },
+      } as any,
+    }
+    render(props)
+    expect(screen.getByText('mock LabwareRender')).toBeInTheDocument()
+  })
+})

--- a/app/src/organisms/Desktop/ProtocolVisualization/SlotDetails/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/SlotDetails/index.tsx
@@ -3,8 +3,8 @@ import { getFullStackFromLabwares } from '@opentrons/step-generation'
 
 import { SlotDetailsEmptyState } from '/app/molecules/SlotDetailsEmptyState'
 
-import { LabwareSlot } from '../SecondWindow/LabwareSlot'
 import { ModuleContainer } from '../ModuleContainer'
+import { LabwareSlot } from '../SecondWindow/LabwareSlot'
 import { TipDisposalContainer } from '../TipDisposalContainer'
 import { TipPickupContainer } from '../TipPickupContainer'
 import styles from './slotdetails.module.css'

--- a/app/src/organisms/Desktop/ProtocolVisualization/SlotDetails/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/SlotDetails/index.tsx
@@ -1,7 +1,6 @@
 import { useTranslation } from 'react-i18next'
 
 import {
-  Divider,
   MODULE_ICON_NAME_BY_TYPE,
   RobotInfoLabel,
 } from '@opentrons/components'
@@ -10,7 +9,7 @@ import { getFullStackFromLabwares } from '@opentrons/step-generation'
 
 import { SlotDetailsEmptyState } from '/app/molecules/SlotDetailsEmptyState'
 
-import { LabwareSlotContainer } from '../LabwareSlotContainer'
+import { LabwareSlot } from '../SecondWindow/LabwareSlot'
 import { ModuleContainer } from '../ModuleContainer'
 import { TipDisposalContainer } from '../TipDisposalContainer'
 import { TipPickupContainer } from '../TipPickupContainer'
@@ -65,6 +64,47 @@ export function SlotDetails(props: SlotDetailsProps): JSX.Element {
   const isSlotEmpty =
     moduleOnSlot == null && topMostLabwareOnSlot == null && !isTrashOnSlot
 
+  const getLabwareType = (): 'tiprack' | 'labware' | null => {
+    if (topMostLabwareOnSlot == null) {
+      return null
+    }
+    if (isTopmostLabwareATiprack === true) {
+      return 'tiprack'
+    }
+    return 'labware'
+  }
+
+  const renderLabwareContent = (): JSX.Element | null => {
+    const labwareType = getLabwareType()
+    if (topMostLabwareOnSlot == null) {
+      return null
+    }
+    switch (labwareType) {
+      case 'tiprack':
+        return (
+          <TipPickupContainer
+            tiprackEntity={labwareEntities[topMostLabwareOnSlot]}
+            robotState={robotState}
+          />
+        )
+      case 'labware':
+        return (
+          <LabwareSlot
+            topLabwareOnSlotId={topMostLabwareOnSlot}
+            labwareEntities={labwareEntities}
+            commands={commands}
+            currentCommand={command}
+            liquids={liquids}
+            robotState={robotState}
+            pipetteEntities={pipetteEntities}
+            moduleEntities={moduleEntities}
+          />
+        )
+      default:
+        return null
+    }
+  }
+
   return (
     <>
       {isSlotEmpty ? (
@@ -90,25 +130,7 @@ export function SlotDetails(props: SlotDetailsProps): JSX.Element {
               ) : null}
             </div>
           </div>
-          <Divider />
-          {topMostLabwareOnSlot != null && isTopmostLabwareATiprack ? (
-            <TipPickupContainer
-              tiprackEntity={labwareEntities[topMostLabwareOnSlot]}
-              robotState={robotState}
-            />
-          ) : null}
-          {topMostLabwareOnSlot != null && !isTopmostLabwareATiprack ? (
-            <LabwareSlotContainer
-              topLabwareOnSlotId={topMostLabwareOnSlot}
-              labwareEntities={labwareEntities}
-              commands={commands}
-              currentCommand={command}
-              liquids={liquids}
-              robotState={robotState}
-              pipetteEntities={pipetteEntities}
-              moduleEntities={moduleEntities}
-            />
-          ) : null}
+          {renderLabwareContent()}
           {isTrashOnSlot ? (
             <TipDisposalContainer robotState={robotState} />
           ) : null}

--- a/app/src/organisms/Desktop/ProtocolVisualization/SlotDetails/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/SlotDetails/index.tsx
@@ -114,22 +114,6 @@ export function SlotDetails(props: SlotDetailsProps): JSX.Element {
       ) : null}
       <div className={styles.slot_container}>
         <div className={styles.slot_details}>
-          <div className={styles.command_step_header}>
-            <div className={styles.slot_detail_header}>
-              <RobotInfoLabel
-                deckLabel={slotId === 'fixedTrash' ? t('fixedTrash') : slotId}
-              />
-              {moduleOnSlot != null ? (
-                <RobotInfoLabel
-                  iconName={
-                    MODULE_ICON_NAME_BY_TYPE[
-                      moduleEntities[moduleOnSlot[0]].type
-                    ]
-                  }
-                />
-              ) : null}
-            </div>
-          </div>
           {renderLabwareContent()}
           {isTrashOnSlot ? (
             <TipDisposalContainer robotState={robotState} />

--- a/app/src/organisms/Desktop/ProtocolVisualization/SlotDetails/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/SlotDetails/index.tsx
@@ -1,9 +1,3 @@
-import { useTranslation } from 'react-i18next'
-
-import {
-  MODULE_ICON_NAME_BY_TYPE,
-  RobotInfoLabel,
-} from '@opentrons/components'
 import { getIsTiprack } from '@opentrons/shared-data'
 import { getFullStackFromLabwares } from '@opentrons/step-generation'
 
@@ -42,7 +36,6 @@ export function SlotDetails(props: SlotDetailsProps): JSX.Element {
     pipetteEntities,
   } = invariantContext
   const { commands } = analysis
-  const { t } = useTranslation('protocol_visualization')
   const stackOfLabwareOnSlot = getFullStackFromLabwares(labware, slotId)
   const moduleOnSlot = Object.entries(modules).find(
     ([id, module]) => module.slot === slotId


### PR DESCRIPTION
# Overview
fix LabwareSlot layout in the Second window

<img width="505" height="482" alt="Screenshot 2025-12-09 at 12 01 17 PM" src="https://github.com/user-attachments/assets/94644f4b-ba82-4899-a456-4e0741df0a03" />

in terms of logic, I will create hooks after DQA.

close RQA-4882 since it requires to update all components for the Second window

## Test Plan and Hands on Testing
- select a protocol
- click visualization button
- click a slot that has a labware

## Changelog
- create a new component `LabwareSlot` for the second window and add its test
- update the spotlight rendering strucutre to make mantainance easier

List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.

## Review requests


## Risk assessment
low
