### PR TITLE
docs(Flex): dynamic pipetting + concurrent module actions

### DIFF
--- a/docs/flex/docs/modules/index.md
+++ b/docs/flex/docs/modules/index.md
@@ -30,6 +30,8 @@ Opentrons Flex is compatible with with the following Opentrons modules:
 
 - The [**Thermocycler Module**](thermocycler.md) provides on-deck, fully automated thermocycling, enabling automation of upstream and downstream workflow steps. Thermocycler GEN2 is fully compatible with the gripper. Thermocycler GEN1 cannot be used with the gripper, and is therefore not supported on Opentrons Flex.
 
+Certain module tasks, like heating from an ambient temperature to a high temperature or executing a Thermocycler profile, take more time than others. Starting with API version 2.27, you can use [concurrent commands](https://docs.opentrons.com/v2/modules/concurrent_module.html) to continue pipetting and other steps in your Flex protocols. 
+
 Some modules originally designed for the OT-2 are compatible with Flex, as summarized in the table below. A checkmark :material-check-bold:{ .green } indicates compatibility, and an :octicons-x-12:{ .red } indicates incompatibility.
 
 

--- a/docs/flex/docs/protocols/python-api.md
+++ b/docs/flex/docs/protocols/python-api.md
@@ -63,7 +63,7 @@ Certain features are only available in Python protocols, either because they are
 
 ### Partial tip pickup
 
-The Python API supports the most partial tip pickup configurations. Currently, Protocol Designer only supports column pickup with the 96-channel pipette. The `InstrumentContext.configure_nozzle_layout()` method supports these additional layouts:
+The Python API supports the most partial tip pickup configurations. The `InstrumentContext.configure_nozzle_layout()` method supports multiple layouts:
 
 - Row pickup with the 96-channel pipette.
 
@@ -72,6 +72,8 @@ The Python API supports the most partial tip pickup configurations. Currently, P
 - Single tip pickup with all multi-channel pipettes.
 
 Certain configurations allow changing which nozzles are used. For example, you can pick up a column of tips with either the left or right edge of the 96-channel pipette.
+
+Protocol Designer supports some partial tip use, like single tip pickup and 96-channel column pickup, but doesn't let you change which nozzles are used.
 
 ### Runtime parameters
 

--- a/docs/flex/docs/protocols/python-api.md
+++ b/docs/flex/docs/protocols/python-api.md
@@ -95,13 +95,15 @@ Sensors in Flex pipettes can detect the level of liquid in a well. You can use t
 
 Starting in API version 2.27, use start and end location parameters to control pipette movements during liquid transfers: 
 
-- Continuously target the [liquid meniscus](https://docs.opentrons.com/v2/robot_position.html?highlight=liquid+level#meniscus) as it changes while pipetting liquid.
+- Continuously target the [liquid meniscus](https://docs.opentrons.com/v2/robot_position.html#meniscus) as it changes while pipetting liquid.
 - Change the pipette's position within a well while aspirating, dispensing, or mixing.
 - Mix in different locations in labware using the [dynamic mix](https://docs.opentrons.com/v2/basic_commands/liquids.html#dynamic-mix) method.
 
 ### Concurrent commands
 
-Some module commands that take a long time to complete (such as executing a Thermocycler profile or heating to a high temperature) can be run in a *concurrent* manner. This lets your protocol save time by continuing on to other pipetting tasks instead of waiting for the command to complete. As of API 2.27, concurrent commands are currently supported on the [Heater-Shaker](https://docs.opentrons.com/v2/modules/heater_shaker.html#heating-and-shaking), [Temperature](https://docs.opentrons.com/v2/modules/temperature_module.hmtl#temperature-control), and [Thermocyler](https://docs.opentrons.com/v2/modules/thermocycler.html) modules. You can also run multiple modules at the same time. See [Concurrent Module Actions](https://docs.opentrons.com/v2/modules/concurrent_module.html) for more.
+Some module commands that take a long time to complete (such as executing a Thermocycler profile or heating to a high temperature) can be run in a *concurrent* manner. This lets your protocol save time by continuing on to other pipetting tasks instead of waiting for the command to complete. 
+
+As of API version 2.27, concurrent commands are currently supported on the [Heater-Shaker](https://docs.opentrons.com/v2/modules/heater_shaker.html#heating-and-shaking), [Temperature](https://docs.opentrons.com/v2/modules/temperature_module.hmtl#temperature-control), and [Thermocyler](https://docs.opentrons.com/v2/modules/thermocycler.html) Modules. You can also run multiple modules at the same time. See [Concurrent Module Actions](https://docs.opentrons.com/v2/modules/concurrent_module.html) for more.
 
 ### Python packages
 

--- a/docs/flex/docs/protocols/python-api.md
+++ b/docs/flex/docs/protocols/python-api.md
@@ -89,9 +89,17 @@ Unlike other protocol commands, robot motor control commands execute movements i
 
 Sensors in Flex pipettes can detect the level of liquid in a well. You can use this feature to target a [liquid meniscus](https://docs.opentrons.com/v2/robot_position.html?highlight=liquid+level#meniscus) while aspirating, dispensing, or mixing in a Python protocol. 
 
-### Non-blocking commands
+### Dynamic pipetting
 
-Some module commands that take a long time to complete (such as heating from ambient temperature to a high temperature) can be run in a *non-blocking* manner. This lets your protocol save time by continuing on to other pipetting tasks instead of waiting for the command to complete. Non-blocking commands are currently supported on the [Heater-Shaker Module](https://docs.opentrons.com/v2/modules/heater_shaker.html#non-blocking-commands).
+Starting in API version 2.27, use start and end location parameters to control pipette movements during liquid transfers: 
+
+- Continuously target the [liquid meniscus](https://docs.opentrons.com/v2/robot_position.html?highlight=liquid+level#meniscus) as it changes while pipetting liquid.
+- Change the pipette's position within a well while aspirating, dispensing, or mixing.
+- Mix in different locations in labware using the [dynamic mix](https://docs.opentrons.com/v2/basic_commands/liquids.html#dynamic-mix) method.
+
+### Concurrent commands
+
+Some module commands that take a long time to complete (such as executing a Thermocycler profile or heating to a high temperature) can be run in a *concurrent* manner. This lets your protocol save time by continuing on to other pipetting tasks instead of waiting for the command to complete. As of API 2.27, concurrent commands are currently supported on the [Heater-Shaker](https://docs.opentrons.com/v2/modules/heater_shaker.html#heating-and-shaking), [Temperature](https://docs.opentrons.com/v2/modules/temperature_module.hmtl#temperature-control), and [Thermocyler](https://docs.opentrons.com/v2/modules/thermocycler.html) modules. You can also run multiple modules at the same time. See [Concurrent Module Actions](https://docs.opentrons.com/v2/modules/concurrent_module.html) for more.
 
 ### Python packages
 


### PR DESCRIPTION
# Overview

Update the Flex manual for dynamic pipetting/concurrent module actions in RS 8.8. 

## Test Plan and Hands on Testing

sandbox: 

## Changelog



## Review requests

Anywhere else this makes sense to add? 

Some of this fits under Flex-exclusive features, but not all. In fact, most of this can be run on the OT-2 as well. 

## Risk assessment

low.
