### PR TITLE
fix(app): add disabled state to apply offsets button

### DIFF
--- a/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabwarePositionCheck/FlexSetupLPC/LPCSetupFlexBtns.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabwarePositionCheck/FlexSetupLPC/LPCSetupFlexBtns.tsx
@@ -111,6 +111,7 @@ export function LPCSetupFlexBtns({
         onClick={onApplyOffsets}
         id="LPC_setOffsetsConfirmed"
         padding={`${SPACING.spacing8} ${SPACING.spacing16}`}
+        disabled={isApplyOffsetsBtnDisabled}
         {...confirmOffsetsTargetProps}
       >
         {t('apply_offsets')}


### PR DESCRIPTION
# Overview

Disable LPC button once run has started on the desktop app.


## Test Plan and Hands on Testing
<img width="879" height="327" alt="Screenshot 2025-12-09 at 2 44 59 PM" src="https://github.com/user-attachments/assets/53bb5ebc-5e9a-4877-ba56-5ccf95f90ea1" />

## Risk assessment

low

Closes RQA-4901
