### PR TITLE
refactor(protocol-deisgner): prevent pipetting into shuttle and allow…

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/AddStepButton.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/AddStepButton.tsx
@@ -52,7 +52,10 @@ import {
   getIsModuleOnDeck,
   selectors as stepFormSelectors,
 } from '/protocol-designer/step-forms'
-import { getLabwareEntities } from '/protocol-designer/step-forms/selectors'
+import {
+  getLabwareEntities,
+  getModuleEntities,
+} from '/protocol-designer/step-forms/selectors'
 import {
   getIsMultiSelectMode,
   actions as stepsActions,
@@ -106,18 +109,25 @@ export function AddStepButton({
   const lastTimelineFrame =
     timeline.length > 0 ? last(timeline)?.robotState : initialTimeline
   const labwareAtLastState = lastTimelineFrame?.labware ?? {}
+  const moduleAtLastState = lastTimelineFrame?.modules ?? {}
   const isLabwarePresentForLiquidHandling = Object.entries(
     labwareAtLastState
   ).some(([labwareId, { stack }]) => {
     const labwareDef = labwareEntities[labwareId]?.def
     const slot = getSlotInLocationStack(stack)
     const isLidOnSlot = labwareDef != null ? getIsLid(labwareDef) : false
+    const isStackerInSlot = Object.values(modules).some(
+      module =>
+        module.type === FLEX_STACKER_MODULE_TYPE &&
+        moduleAtLastState[module.id].slot === slot
+    )
     return (
       labwareDef != null &&
       slot !== OFFDECK &&
       !getIsTiprack(labwareDef) &&
       !getIsAdapterFromDef(labwareDef) &&
-      !isLidOnSlot
+      !isLidOnSlot &&
+      !isStackerInSlot
     )
   })
   const getSupportedSteps = (): Array<

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/AddStepButton.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/AddStepButton.tsx
@@ -52,10 +52,7 @@ import {
   getIsModuleOnDeck,
   selectors as stepFormSelectors,
 } from '/protocol-designer/step-forms'
-import {
-  getLabwareEntities,
-  getModuleEntities,
-} from '/protocol-designer/step-forms/selectors'
+import { getLabwareEntities } from '/protocol-designer/step-forms/selectors'
 import {
   getIsMultiSelectMode,
   actions as stepsActions,

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/__tests__/AddStepButton.test.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/__tests__/AddStepButton.test.tsx
@@ -2,6 +2,8 @@ import { fireEvent, screen } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
+  FLEX_STACKER_MODULE_TYPE,
+  FLEX_STACKER_MODULE_V1,
   HEATERSHAKER_MODULE_TYPE,
   HEATERSHAKER_MODULE_V1,
   MAGNETIC_MODULE_TYPE,

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/__tests__/AddStepButton.test.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/__tests__/AddStepButton.test.tsx
@@ -2,8 +2,6 @@ import { fireEvent, screen } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
-  FLEX_STACKER_MODULE_TYPE,
-  FLEX_STACKER_MODULE_V1,
   HEATERSHAKER_MODULE_TYPE,
   HEATERSHAKER_MODULE_V1,
   MAGNETIC_MODULE_TYPE,

--- a/protocol-designer/src/pages/Designer/utils.ts
+++ b/protocol-designer/src/pages/Designer/utils.ts
@@ -4,6 +4,7 @@ import reduce from 'lodash/reduce'
 
 import {
   FLEX_ROBOT_TYPE,
+  FLEX_STACKER_MODULE_TYPE,
   getAllDefinitions,
   getIsLid,
   getIsTiprack,
@@ -22,6 +23,7 @@ import {
 
 import { HOPPER_LABWARE_X_OFFSET } from '/protocol-designer/constants'
 
+import { HOPPER_STACKER_LOCATION } from '../../../../step-generation/src/constants'
 import { getRobotType } from '../../file-data/selectors'
 import { getLabwareEntities } from '../../step-forms/selectors'
 import { getDeckSetupForActiveItem } from '../../top-selectors/labware-locations'
@@ -295,9 +297,12 @@ export const useLabwareDropdownOptions = (
   const { t } = useTranslation(['shared', 'protocol_steps'])
   const labwareEntities = useSelector(getLabwareEntities)
   const activeDeckSetup = useSelector(getDeckSetupForActiveItem)
-  const { labware: deckSetupLabware } = activeDeckSetup
+  const { labware: deckSetupLabware, modules } = activeDeckSetup
   const nicknamesById = useSelector(getLabwareNicknamesById)
   const robotType = useSelector(getRobotType)
+  const stackerModuleIds = Object.values(modules).filter(
+    module => module.type === FLEX_STACKER_MODULE_TYPE
+  )
   const labwareOptions = reduce(
     labwareEntities,
     (
@@ -318,6 +323,9 @@ export const useLabwareDropdownOptions = (
       )
       const isTopOfStack = fullStackFromLabwares[0] === labwareId
       const topId = fullStackFromLabwares[0]
+      const isOnShuttle = stackerModuleIds.some(stackerModule =>
+        fullStackFromLabwares.includes(stackerModule.slot)
+      )
       const isLabwareLidCombo =
         (fullStackFromLabwares[1] === labwareId &&
           labwareEntities[topId]?.def.allowedRoles?.includes('lid') &&
@@ -347,6 +355,7 @@ export const useLabwareDropdownOptions = (
 
       //  TODO: refactor this to be easier to read
       const options: DropdownOption[] =
+        (type === 'labware' && isOnShuttle) ||
         isAdapter ||
         isLabwareInTrash ||
         (type === 'labware' && (isTiprack || isLid)) ||

--- a/protocol-designer/src/pages/Designer/utils.ts
+++ b/protocol-designer/src/pages/Designer/utils.ts
@@ -325,6 +325,7 @@ export const useLabwareDropdownOptions = (
       const isOnShuttle = stackerModuleIds.some(stackerModule =>
         fullStackFromLabwares.includes(stackerModule.slot)
       )
+      console.log('isOnShuttle', isOnShuttle)
       const isLabwareLidCombo =
         (fullStackFromLabwares[1] === labwareId &&
           labwareEntities[topId]?.def.allowedRoles?.includes('lid') &&

--- a/protocol-designer/src/pages/Designer/utils.ts
+++ b/protocol-designer/src/pages/Designer/utils.ts
@@ -322,10 +322,9 @@ export const useLabwareDropdownOptions = (
       )
       const isTopOfStack = fullStackFromLabwares[0] === labwareId
       const topId = fullStackFromLabwares[0]
-      const isOnShuttle = stackerModuleIds.some(stackerModule =>
+      const isOnStacker = stackerModuleIds.some(stackerModule =>
         fullStackFromLabwares.includes(stackerModule.slot)
       )
-      console.log('isOnShuttle', isOnShuttle)
       const isLabwareLidCombo =
         (fullStackFromLabwares[1] === labwareId &&
           labwareEntities[topId]?.def.allowedRoles?.includes('lid') &&
@@ -355,7 +354,7 @@ export const useLabwareDropdownOptions = (
 
       //  TODO: refactor this to be easier to read
       const options: DropdownOption[] =
-        (type === 'labware' && isOnShuttle) ||
+        (type === 'labware' && isOnStacker) ||
         isAdapter ||
         isLabwareInTrash ||
         (type === 'labware' && (isTiprack || isLid)) ||

--- a/protocol-designer/src/pages/Designer/utils.ts
+++ b/protocol-designer/src/pages/Designer/utils.ts
@@ -23,7 +23,6 @@ import {
 
 import { HOPPER_LABWARE_X_OFFSET } from '/protocol-designer/constants'
 
-import { HOPPER_STACKER_LOCATION } from '../../../../step-generation/src/constants'
 import { getRobotType } from '../../file-data/selectors'
 import { getLabwareEntities } from '../../step-forms/selectors'
 import { getDeckSetupForActiveItem } from '../../top-selectors/labware-locations'

--- a/protocol-designer/src/top-selectors/labware-locations/index.ts
+++ b/protocol-designer/src/top-selectors/labware-locations/index.ts
@@ -5,6 +5,7 @@ import {
   FLEX_MODULE_ADDRESSABLE_AREAS,
   FLEX_ROBOT_TYPE,
   FLEX_STACKER_ADDRESSABLE_AREAS,
+  FLEX_STACKER_MODULE_TYPE,
   getDeckDefFromRobotType,
   getModuleDisplayName,
   isAddressableAreaStandardSlot,
@@ -233,6 +234,8 @@ export const getUnoccupiedLabwareLocationOptions: Selector<Option[] | null> =
 
       const unoccupiedModuleOptions = Object.entries(modules).reduce<Option[]>(
         (acc, [modId, modOnDeck]) => {
+          const isModuleIsAStacker =
+            modOnDeck.moduleState.type === FLEX_STACKER_MODULE_TYPE
           const moduleHasLabware = Object.entries(labware).some(
             ([_, lwOnDeck]) =>
               lwOnDeck.stack[lwOnDeck.stack.length - 2] === modId
@@ -249,7 +252,9 @@ export const getUnoccupiedLabwareLocationOptions: Selector<Option[] | null> =
             : [
                 ...acc,
                 {
-                  name: getModuleDisplayName(moduleEntities[modId].model),
+                  name: isModuleIsAStacker
+                    ? slot
+                    : getModuleDisplayName(moduleEntities[modId].model),
                   value: modId,
                   deckLabel: tcLocations != null ? tcLocations : slot,
                 },


### PR DESCRIPTION
… moving to shuttle

closes EXEC-2122

# Overview

wow, you can now move labware to the shuttle in a move step and you cannot pipette into labware in the shuttle in a transfer and mix step

## Test Plan and Hands on Testing

test that you can move in and out of the shuttle and that you cannot pipette into a labware on the shuttle for transfer and mix steps

## Changelog

add logic to the dropdown menu options to account for labware in shuttle and add lgoic to the add button step

## Risk assessment

low
