### PR TITLE
docs(api): fix note syntax

### DIFF
--- a/api/docs/v2/basic_commands/liquids.rst
+++ b/api/docs/v2/basic_commands/liquids.rst
@@ -75,7 +75,7 @@ This example measures the liquid height in well A2 of a plate and then immediate
 
 To ensure the pipette stays submerged while aspirating, set ``target="end"`` for the aspirate or use multiple location parameters. For more, see :ref:`well-meniscus`. 
 
-!!! note:: 
+.. note:: 
     ``measure_liquid_height()`` works best with a new pipette tip each time. To save time and tips throughout your protocol, use ``Labware.load_liquid`` instead to specify starting liquid volumes.
 
 Use the ``location`` and ``end_location`` parameters in combination to direct the pipette to move to specific locations while aspirating::
@@ -192,7 +192,7 @@ This example measures the liquid height in well B1 of a plate and then immediate
 
 To ensure the pipette begins the dispense at the liquid meniscus, set ``target="start"``. See :ref:`well-meniscus` for more details on pipetting relative to the liquid meniscus. 
 
-!!! note::
+.. note::
     ``measure_liquid_height()`` works best with a new pipette tip each time. To save time and tips throughout your protocol, use ``Labware.load_liquid`` instead to specify starting liquid volumes. 
 
 

--- a/api/docs/v2/robot_position.rst
+++ b/api/docs/v2/robot_position.rst
@@ -117,6 +117,8 @@ Here, the pipette tip stays at 1 mm below the liquid meniscus, regardless of cha
     Detecting liquid in a well requires pipette sensors, so you can only measure liquid height with a Flex pipette. 
 
 .. versionadded:: 2.23
+.. versionchanged:: 2.27
+    Use the optional ``end_location`` parameter to pipette relative to the liquid meniscus as it changes.  
 
 .. _new-default-op-positions:
 


### PR DESCRIPTION
# Overview

Fixing a few note syntax spots because mkdocs has cooked my brain. 

Because I missed this earlier, went through the other pages to look for changes and found a spot that could use a `versionchanged` message as well. 

## Test Plan and Hands on Testing

branch sandbox

## Changelog



## Review requests



## Risk assessment

low. will be deployed on its own, unless something else comes up post-release. 
