### PR TITLE
fix(app): Corrects width in deck configuration for heatershaker and module text padding

### DIFF
--- a/components/src/hardware-sim/DeckConfigurator/HeaterShakerItem.tsx
+++ b/components/src/hardware-sim/DeckConfigurator/HeaterShakerItem.tsx
@@ -11,12 +11,12 @@ import { RobotCoordsForeignObject } from '../Deck/RobotCoordsForeignObject'
 import {
   COLUMN_1_SINGLE_SLOT_FIXTURE_WIDTH,
   COLUMN_1_X_ADJUSTMENT,
-  COLUMN_DEFAULT_SINGLE_SLOT_FIXTURE_WIDTH,
   COLUMN_DEFAULT_X_ADJUSTMENT,
   CONFIG_STYLE_EDITABLE,
   CONFIG_STYLE_READ_ONLY,
   CONFIG_STYLE_SELECTED,
   FIXTURE_HEIGHT,
+  LARGE_SINGLE_ITEM_SLOT_WIDTH,
   Y_ADJUSTMENT,
 } from './constants'
 
@@ -84,7 +84,7 @@ export function HeaterShakerItem(props: HeaterShakerItemProps): JSX.Element {
       width={
         isColumnOne
           ? COLUMN_1_SINGLE_SLOT_FIXTURE_WIDTH
-          : COLUMN_DEFAULT_SINGLE_SLOT_FIXTURE_WIDTH
+          : LARGE_SINGLE_ITEM_SLOT_WIDTH
       }
       height={FIXTURE_HEIGHT}
       x={x}

--- a/components/src/organisms/FixtureOption/index.tsx
+++ b/components/src/organisms/FixtureOption/index.tsx
@@ -29,14 +29,13 @@ export function FixtureOption(props: FixtureOptionProps): JSX.Element {
   return (
     <ListItem
       type="default"
-      padding={`${SPACING.spacing16} ${SPACING.spacing24}`}
+      padding={`${SPACING.spacing16} ${SPACING.spacing12}`}
       alignItems={ALIGN_CENTER}
       justifyContent={JUSTIFY_SPACE_BETWEEN}
     >
       <StyledText
         desktopStyle="bodyDefaultSemiBold"
         oddStyle="bodyTextSemiBold"
-        padding={`${SPACING.spacing8}`}
       >
         {optionName}
       </StyledText>

--- a/components/src/organisms/FixtureOption/index.tsx
+++ b/components/src/organisms/FixtureOption/index.tsx
@@ -36,6 +36,7 @@ export function FixtureOption(props: FixtureOptionProps): JSX.Element {
       <StyledText
         desktopStyle="bodyDefaultSemiBold"
         oddStyle="bodyTextSemiBold"
+        padding={`${SPACING.spacing8}`}
       >
         {optionName}
       </StyledText>


### PR DESCRIPTION
# Overview

Adds padding for module text in fixture option
Corrects width for heatershaker in deck configuration

## Test Plan and Hands on Testing

- smoke tested on the app and ODD

## Changelog
<img width="433" height="314" alt="Screenshot 2025-12-10 at 1 49 03 PM" src="https://github.com/user-attachments/assets/66369c45-d4d3-463b-a488-cecc0e881685" />
<img width="701" height="385" alt="Screenshot 2025-12-10 at 1 55 27 PM" src="https://github.com/user-attachments/assets/f1684290-4031-41f5-9e89-9a7b26aa423d" />

## Review requests

- future work - consolidate similar module items for deck configuration to reduce future bugs?

## Risk assessment

low - cosmetic changes

Closes RQA-4774, RQA-4902
