### PR TITLE
fix(step-generation, shared-data): wire up deck extent checks in safePipetteMovements

### DIFF
--- a/shared-data/js/helpers/index.ts
+++ b/shared-data/js/helpers/index.ts
@@ -2,7 +2,9 @@ import uniq from 'lodash/uniq'
 
 import standardOt2DeckDef from '../../deck/definitions/5/ot2_standard.json'
 import standardFlexDeckDef from '../../deck/definitions/5/ot3_standard.json'
-import { OPENTRONS_LABWARE_NAMESPACE } from '../constants'
+import standardOt2RobotDef from '../../robot/definitions/1/ot2.json'
+import standardFlexRobotDef from '../../robot/definitions/1/ot3.json'
+import { FLEX_ROBOT_TYPE, OPENTRONS_LABWARE_NAMESPACE } from '../constants'
 import { getAllLiquidClassDefs } from '../liquidClasses'
 import { getSchema2Dimensions } from './positionMath'
 
@@ -12,6 +14,7 @@ import type {
   LabwareDefinition,
   LiquidClass,
   ModuleModel,
+  RobotDefinition,
   RobotType,
   ThermalAdapterName,
 } from '../types'
@@ -464,4 +467,12 @@ export const getSortedLiquidClassDefs = (): Record<string, LiquidClass> => {
       valueA.displayName.localeCompare(valueB.displayName)
     )
   )
+}
+
+export const getRobotDefFromRobotType = (
+  robotType: RobotType
+): RobotDefinition => {
+  return (
+    robotType === FLEX_ROBOT_TYPE ? standardFlexRobotDef : standardOt2RobotDef
+  ) as RobotDefinition
 }

--- a/shared-data/js/helpers/index.ts
+++ b/shared-data/js/helpers/index.ts
@@ -469,6 +469,7 @@ export const getSortedLiquidClassDefs = (): Record<string, LiquidClass> => {
   )
 }
 
+// hard-coding in V1 robot definitions following pattern with deck definitions
 export const getRobotDefFromRobotType = (
   robotType: RobotType
 ): RobotDefinition => {

--- a/shared-data/js/types.ts
+++ b/shared-data/js/types.ts
@@ -49,6 +49,18 @@ export interface RobotDefinition {
   displayName: string
   robotType: RobotType
   models: string[]
+  extents: CoordinateTuple
+  paddingOffsets: {
+    rear: number
+    front: number
+    leftSide: number
+    rightSide: number
+  }
+  mountOffsets: {
+    left: CoordinateTuple
+    right: CoordinateTuple
+    gripper?: CoordinateTuple
+  }
 }
 
 // TODO Ian 2019-06-04 split this out into eg ../labware/flowTypes/labwareV1.js

--- a/shared-data/tsconfig-data.json
+++ b/shared-data/tsconfig-data.json
@@ -20,7 +20,8 @@
     "pipette/**/*.json",
     "protocol/**/*.json",
     "errors/**/*.json",
-    "build/**/*.json"
+    "build/**/*.json",
+    "robot/**/*.json"
   ],
   "exclude": ["**/*.ts"]
 }

--- a/step-generation/src/utils/safePipetteMovements.ts
+++ b/step-generation/src/utils/safePipetteMovements.ts
@@ -8,6 +8,7 @@ import {
   getModuleDef,
   getOt2SurroundingSlots,
   getPositionFromSlotId,
+  getRobotDefFromRobotType,
   OT2_ROBOT_TYPE,
   SINGLE,
   THERMOCYCLER_MODULE_TYPE,
@@ -36,8 +37,6 @@ import type {
   TipState,
 } from '../types'
 
-const A12_column_front_left_bound = { x: -11.03, y: 2 }
-const A12_column_back_right_bound = { x: 526.77, y: 506.2 }
 export const PRIMARY_NOZZLE = 'A12'
 const FLEX_TC_LID_COLLISION_ZONE = {
   back_left: { x: -43.25, y: 454.9, z: 211.91 },
@@ -63,26 +62,6 @@ export interface Point {
   x: number
   y: number
   z?: number
-}
-
-//  check if nozzle(s) are inbounds
-const getIsWithinPipetteExtents = (
-  location: Point,
-  nozzleConfiguration: NozzleConfigurationStyle,
-  primaryNozzle: string
-): boolean => {
-  if (nozzleConfiguration === 'COLUMN' && primaryNozzle === 'A12') {
-    const isWithinBounds =
-      A12_column_front_left_bound.x <= location.x &&
-      location.x <= A12_column_back_right_bound.x &&
-      A12_column_front_left_bound.y <= location.y &&
-      location.y <= A12_column_back_right_bound.y
-
-    return isWithinBounds
-  } else {
-    // TODO: Handle other configurations such as 8-channel partial tip, and eventually all pipettes.
-    return true
-  }
 }
 
 // return pipette bounds at a sepcific position
@@ -287,7 +266,7 @@ const getWellPosition = (
   labwareEntity: LabwareEntity,
   wellName: string,
   wellLocationOffset: Point,
-  addressableAreaOffset: CoordinateTuple | null,
+  addressableAreaOffset: CoordinateTuple,
   hasTip: boolean
 ): Point => {
   const { wells } = labwareEntity.def
@@ -368,12 +347,27 @@ export const getIsSafePipetteMovement = (args: {
   const addressableAreaOffset = getPositionFromSlotId(
     labwareSlot,
     deckDefinition
-  )
+  ) ?? [0, 0, 0]
+  const isOnFlexThermocycler =
+    robotType === FLEX_ROBOT_TYPE &&
+    labwareState[labwareId].stack.some(
+      item => moduleEntities[item]?.type === THERMOCYCLER_MODULE_TYPE
+    )
+  const thermocyclerOffset = isOnFlexThermocycler
+    ? (deckDefinition.locations.addressableAreas.find(
+        addressableArea => addressableArea.id === 'thermocyclerModuleV2'
+      )?.offsetFromCutoutFixture ?? [0, 0, 0])
+    : [0, 0, 0]
+  const fullOffset = [
+    thermocyclerOffset[0] + addressableAreaOffset[0],
+    thermocyclerOffset[1] + addressableAreaOffset[1],
+    thermocyclerOffset[2] + addressableAreaOffset[2],
+  ]
   const wellTargetPoint = getWellPosition(
     labwareEntities[labwareId],
     wellTargetName,
     wellLocationOffset,
-    addressableAreaOffset,
+    fullOffset as CoordinateTuple,
     pipetteHasTip
   )
 
@@ -385,14 +379,6 @@ export const getIsSafePipetteMovement = (args: {
       channels,
     })
 
-  const isWithinPipetteExtents = getIsWithinPipetteExtents(
-    wellTargetPoint,
-    nozzleConfiguration,
-    primaryNozzle
-  )
-  if (!isWithinPipetteExtents) {
-    return false
-  }
   const tiprackEntity = tiprackId != null ? labwareEntities[tiprackId] : null
   const tipOverlapOnNozzle =
     tiprackEntity != null
@@ -409,6 +395,14 @@ export const getIsSafePipetteMovement = (args: {
     primaryNozzle,
     tipOverlapOnNozzle
   )
+  const isWithinPipetteExtents = getIsMovementWithinDeckExtents({
+    channels,
+    boundingBox: pipetteBoundsAtWellLocation,
+    robotType,
+  })
+  if (!isWithinPipetteExtents) {
+    return false
+  }
   const surroundingSlots =
     robotType === OT2_ROBOT_TYPE
       ? getOt2SurroundingSlots(labwareSlot as OT2AddressableAreaName)
@@ -651,4 +645,45 @@ const getOverlapKeyForPipetteSpecs = (
   }
   // default
   return 'Full'
+}
+
+const getIsMovementWithinDeckExtents = (args: {
+  channels: PipetteChannels
+  boundingBox: Point[]
+  robotType: RobotType
+}): boolean => {
+  const { channels, boundingBox, robotType } = args
+  const robotDef = getRobotDefFromRobotType(robotType)
+  const { paddingOffsets } = robotDef
+  const { front, rear, leftSide, rightSide } = paddingOffsets
+  const [xExtent, yExtent] = robotDef.extents
+  const [backLeftBound, frontRightBound] = boundingBox
+  const { x: pipetteLeftBound, y: pipetteBackBound } = backLeftBound
+  const { x: pipetteRightBound, y: pipetteFrontBound } = frontRightBound
+
+  if (channels === 96) {
+    // check left
+    if (pipetteRightBound < leftSide) {
+      return false
+    }
+    // check right
+    const rightLimit = xExtent + rightSide
+    if (pipetteLeftBound > rightLimit) {
+      return false
+    }
+  }
+
+  // 8- and 96-channel pipettes
+  if (channels !== 1) {
+    // check front
+    if (pipetteBackBound < front) {
+      return false
+    }
+    // check rear
+    const rearLimit = yExtent + rear
+    if (pipetteFrontBound > rearLimit) {
+      return false
+    }
+  }
+  return true
 }

--- a/step-generation/src/utils/safePipetteMovements.ts
+++ b/step-generation/src/utils/safePipetteMovements.ts
@@ -12,6 +12,7 @@ import {
   OT2_ROBOT_TYPE,
   SINGLE,
   THERMOCYCLER_MODULE_TYPE,
+  THERMOCYCLER_MODULE_V2,
 } from '@opentrons/shared-data'
 
 import { EMPTY, OT2_TC_SLOTS } from '../constants'
@@ -355,7 +356,7 @@ export const getIsSafePipetteMovement = (args: {
     )
   const thermocyclerOffset = isOnFlexThermocycler
     ? (deckDefinition.locations.addressableAreas.find(
-        addressableArea => addressableArea.id === 'thermocyclerModuleV2'
+        addressableArea => addressableArea.id === THERMOCYCLER_MODULE_V2
       )?.offsetFromCutoutFixture ?? [0, 0, 0])
     : [0, 0, 0]
   const fullOffset = [


### PR DESCRIPTION
# Overview

This PR wires up deck extent checks in `safePipetteMovements.ts` in step generation. In short, we need to check not only on-deck collisions with partial tip configuration pipette movements, but also absolute pipette target positions relative to the limits of the gantry. As part of this fix, I also add a thermocycler offset to correctly get the well position for wellplates inside of a thermocycler.

Closes https://opentrons.atlassian.net/browse/RQA-4971

## Test Plan and Hands on Testing

- upload the [protocol](https://github.com/user-attachments/files/24085247/Test_Slight_Overlap.py) from the ticket comment and verify that the timeline error shows when attempting to move the pipette too far to the rear
- review code logic (check against `api/src/opentrons/protocol_api/core/engine/pipette_movement_conflict.py` `_is_within_pipette_extents`

## Changelog

- create JS getter for robot definitions
- update robot definition TS interface to include new parameters
- create new `getIsMovementWithinDeckExtents` utility in `safePipetteMovements` to check pipette bounding box against absolute pipette deck extents
- wire up missing offset for thermocycler positioning (special cased for now)

## Review requests

see test plan

## Risk assessment

medium