### PR TITLE
feat(protocol-designer): create stacker step summary

### DIFF
--- a/protocol-designer/src/assets/localization/en/protocol_steps.json
+++ b/protocol-designer/src/assets/localization/en/protocol_steps.json
@@ -89,9 +89,9 @@
       "quantity": "Quantity: {{count}}"
     },
     "empty": "Emptying stacker of all labware",
-    "fill": "Refilling stacker with Quantity: {{quantity}} of {{labware_name}}",
-    "retrieve": "Retrieving {{labware_name}} from stacker",
-    "store": "Storing {{labware_name}} from shuttle into stacker"
+    "fill": "<text>Refilling stacker with Quantity: </text> <tag2/> <text>of</text> <tag/>",
+    "retrieve": "<text>Retrieving</text> <tag/> <text>from stacker</text>",
+    "store": "<text>Storing</text> <tag/> <text>from shuttle into stacker</text>"
   },
   "flexStacker": "Stacker",
   "flow_rate_builder": "Flow rate builder",

--- a/protocol-designer/src/assets/localization/en/protocol_steps.json
+++ b/protocol-designer/src/assets/localization/en/protocol_steps.json
@@ -87,7 +87,11 @@
       "labware_filled": "{{amount}}/{{total}} labware filled",
       "no_labware": "No labware stored on stacker",
       "quantity": "Quantity: {{count}}"
-    }
+    },
+    "empty": "Emptying stacker of all labware",
+    "fill": "Refilling stacker with Quantity: {{quantity}} of {{labware_name}}",
+    "retrieve": "Retrieving {{labware_name}} from stacker",
+    "store": "Storing {{labware_name}} from shuttle into stacker"
   },
   "flexStacker": "Stacker",
   "flow_rate_builder": "Flow rate builder",

--- a/protocol-designer/src/components/organisms/StepSummary/FlexStackerSummary.tsx
+++ b/protocol-designer/src/components/organisms/StepSummary/FlexStackerSummary.tsx
@@ -1,3 +1,9 @@
+import {
+  FLEX_STACKER_EMPTY,
+  FLEX_STACKER_FILL,
+  FLEX_STACKER_RETRIEVE,
+  FLEX_STACKER_STORE,
+} from '../../../constants'
 import { StyledTrans } from './StyledTrans'
 
 import type { LabwareEntities } from '@opentrons/step-generation'
@@ -19,35 +25,37 @@ export function FlexStackerSummary(
   let stepSummaryContent: JSX.Element | null = null
 
   switch (flexStackerFormType) {
-    case 'empty': {
+    case FLEX_STACKER_EMPTY: {
       stepSummaryContent = (
-        <StyledTrans i18nKey="protocol_steps:flex_stacker.empty" />
+        <StyledTrans
+          i18nKey={`protocol_steps:flex_stacker.${FLEX_STACKER_EMPTY}`}
+        />
       )
       break
     }
-    case 'fill': {
+    case FLEX_STACKER_FILL: {
       stepSummaryContent = (
         <StyledTrans
-          i18nKey="protocol_steps:flex_stacker.fill"
+          i18nKey={`protocol_steps:flex_stacker.${FLEX_STACKER_FILL}`}
           tagText={labwareName}
           tagText2={fillQuantity}
         />
       )
       break
     }
-    case 'retrieve': {
+    case FLEX_STACKER_RETRIEVE: {
       stepSummaryContent = (
         <StyledTrans
-          i18nKey="protocol_steps:flex_stacker.retrieve"
+          i18nKey={`protocol_steps:flex_stacker.${FLEX_STACKER_RETRIEVE}`}
           tagText={labwareName}
         />
       )
       break
     }
-    case 'store': {
+    case FLEX_STACKER_STORE: {
       stepSummaryContent = (
         <StyledTrans
-          i18nKey="protocol_steps:flex_stacker.store"
+          i18nKey={`protocol_steps:flex_stacker.${FLEX_STACKER_STORE}`}
           tagText={labwareName}
         />
       )

--- a/protocol-designer/src/components/organisms/StepSummary/FlexStackerSummary.tsx
+++ b/protocol-designer/src/components/organisms/StepSummary/FlexStackerSummary.tsx
@@ -8,18 +8,22 @@ interface FlexStackerSummaryProps {
   labwareEntities: LabwareEntities
 }
 
-export function FlexStackerSummary(props: FlexStackerSummaryProps) {
+export function FlexStackerSummary(
+  props: FlexStackerSummaryProps
+): JSX.Element | null {
   const { currentStep, labwareEntities } = props
   const { fillLabwareUri, fillQuantity, flexStackerFormType } = currentStep
   const labwareName = Object.values(labwareEntities).find(
     lw => lw.labwareDefURI === fillLabwareUri
   )?.def.metadata.displayName
   let stepSummaryContent: JSX.Element | null = null
+
   switch (flexStackerFormType) {
     case 'empty': {
       stepSummaryContent = (
         <StyledTrans i18nKey="protocol_steps:flex_stacker.empty" />
       )
+      break
     }
     case 'fill': {
       stepSummaryContent = (

--- a/protocol-designer/src/components/organisms/StepSummary/FlexStackerSummary.tsx
+++ b/protocol-designer/src/components/organisms/StepSummary/FlexStackerSummary.tsx
@@ -20,7 +20,7 @@ export function FlexStackerSummary(
   const { currentStep, labwareEntities } = props
   const { fillLabwareUri, fillQuantity, flexStackerFormType } = currentStep
   const labwareName = Object.values(labwareEntities).find(
-    lw => lw.labwareDefURI === fillLabwareUri
+    ({ labwareDefURI }) => labwareDefURI === fillLabwareUri
   )?.def.metadata.displayName
   let stepSummaryContent: JSX.Element | null = null
 

--- a/protocol-designer/src/components/organisms/StepSummary/FlexStackerSummary.tsx
+++ b/protocol-designer/src/components/organisms/StepSummary/FlexStackerSummary.tsx
@@ -1,0 +1,54 @@
+import { StyledTrans } from './StyledTrans'
+
+import type { LabwareEntities } from '@opentrons/step-generation'
+import type { FormData } from '../../../form-types'
+
+interface FlexStackerSummaryProps {
+  currentStep: FormData
+  labwareEntities: LabwareEntities
+}
+
+export function FlexStackerSummary(props: FlexStackerSummaryProps) {
+  const { currentStep, labwareEntities } = props
+  const { fillLabwareUri, fillQuantity, flexStackerFormType } = currentStep
+  const labwareName = Object.values(labwareEntities).find(
+    lw => lw.labwareDefURI === fillLabwareUri
+  )?.def.metadata.displayName
+  let stepSummaryContent: JSX.Element | null = null
+  switch (flexStackerFormType) {
+    case 'empty': {
+      stepSummaryContent = (
+        <StyledTrans i18nKey="protocol_steps:flex_stacker.empty" />
+      )
+    }
+    case 'fill': {
+      stepSummaryContent = (
+        <StyledTrans
+          i18nKey="protocol_steps:flex_stacker.fill"
+          tagText={labwareName}
+          tagText2={fillQuantity}
+        />
+      )
+      break
+    }
+    case 'retrieve': {
+      stepSummaryContent = (
+        <StyledTrans
+          i18nKey="protocol_steps:flex_stacker.retrieve"
+          tagText={labwareName}
+        />
+      )
+      break
+    }
+    case 'store': {
+      stepSummaryContent = (
+        <StyledTrans
+          i18nKey="protocol_steps:flex_stacker.store"
+          tagText={labwareName}
+        />
+      )
+      break
+    }
+  }
+  return stepSummaryContent
+}

--- a/protocol-designer/src/components/organisms/StepSummary/__tests__/StepSummary.test.tsx
+++ b/protocol-designer/src/components/organisms/StepSummary/__tests__/StepSummary.test.tsx
@@ -30,6 +30,7 @@ const render = (props: ComponentProps<typeof StepSummary>) => {
 
 describe('StepSummary', () => {
   let props: ComponentProps<typeof StepSummary>
+  let baseStackerProps: ComponentProps<typeof StepSummary>
 
   beforeEach(() => {
     props = {
@@ -43,6 +44,23 @@ describe('StepSummary', () => {
       },
       stepDetails: 'mockDetails',
     }
+    baseStackerProps = {
+      currentStep: {
+        id: 'retrieve',
+        stepType: 'flexStacker',
+        flexStackerFormType: 'retrieve',
+        fillLabwareUri: 'mockUri',
+        fillQuantity: 3,
+      },
+      labwareEntities: {
+        someId: {
+          labwareDefURI: 'mockUri',
+          def: { metadata: { displayName: 'mockUri' } },
+        },
+      },
+      stepDetails: 'mockDetails',
+    } as ComponentProps<typeof StepSummary>
+
     vi.mocked(getLabwareNicknamesById).mockReturnValue({
       labware: 'mockNickName',
     })
@@ -138,32 +156,53 @@ describe('StepSummary', () => {
     screen.getByText('mockNickName')
   })
   it('renders flex stacker retrieve command summary', () => {
-    let baseStackerProps
-    baseStackerProps = {
-      currentStep: {
-        id: 'retrieve',
-        stepType: 'flexStacker',
-        flexStackerFormType: 'retrieve',
-        fillLabwareUri: 'mockUri',
-        fillQuantity: 3,
-      },
-      labwareEntities: {
-        someId: {
-          labwareDefURI: 'mockUri',
-          def: { metadata: { displayName: 'mockUri' } },
-        },
-      },
-    } as ComponentProps<typeof StepSummary>
     render(baseStackerProps)
-    screen.getByText('Retrieving mockUri from stacker')
+    screen.getByText('Retrieving')
+    screen.getByText('ANSI 96 Standard Microplate')
+    screen.getByText('from stacker')
   })
+
   it('renders flex stacker store command summary', () => {
-    screen.getByText('Storing mockUri from shuttle into stacker')
+    render({
+      ...baseStackerProps,
+      currentStep: {
+        ...baseStackerProps.currentStep,
+        id: 'store',
+        flexStackerFormType: 'store',
+        stepType: 'flexStacker',
+      },
+    })
+    screen.getByText('Storing')
+    screen.getByText('ANSI 96 Standard Microplate')
+    screen.getByText('from shuttle into stacker')
   })
-  it('renders flex stacker retrieve command summary', () => {
-    screen.getByText('Refilling stacker with Quantity: 3 of mockUri')
+
+  it('renders flex stacker fill command summary', () => {
+    render({
+      ...baseStackerProps,
+      currentStep: {
+        ...baseStackerProps.currentStep,
+        id: 'fill',
+        flexStackerFormType: 'fill',
+        stepType: 'flexStacker',
+      },
+    })
+    screen.getByText('Refilling stacker with Quantity:')
+    screen.getByText('3')
+    screen.getByText('of')
+    screen.getByText('ANSI 96 Standard Microplate')
   })
+
   it('renders flex stacker empty command summary', () => {
+    render({
+      ...baseStackerProps,
+      currentStep: {
+        ...baseStackerProps.currentStep,
+        id: 'empty',
+        flexStackerFormType: 'empty',
+        stepType: 'flexStacker',
+      },
+    })
     screen.getByText('Emptying stacker of all labware')
   })
 })

--- a/protocol-designer/src/components/organisms/StepSummary/__tests__/StepSummary.test.tsx
+++ b/protocol-designer/src/components/organisms/StepSummary/__tests__/StepSummary.test.tsx
@@ -137,4 +137,33 @@ describe('StepSummary', () => {
     screen.getByText('mockNickName to')
     screen.getByText('mockNickName')
   })
+  it('renders flex stacker retrieve command summary', () => {
+    let baseStackerProps
+    baseStackerProps = {
+      currentStep: {
+        id: 'retrieve',
+        stepType: 'flexStacker',
+        flexStackerFormType: 'retrieve',
+        fillLabwareUri: 'mockUri',
+        fillQuantity: 3,
+      },
+      labwareEntities: {
+        someId: {
+          labwareDefURI: 'mockUri',
+          def: { metadata: { displayName: 'mockUri' } },
+        },
+      },
+    } as ComponentProps<typeof StepSummary>
+    render(baseStackerProps)
+    screen.getByText('Retrieving mockUri from stacker')
+  })
+  it('renders flex stacker store command summary', () => {
+    screen.getByText('Storing mockUri from shuttle into stacker')
+  })
+  it('renders flex stacker retrieve command summary', () => {
+    screen.getByText('Refilling stacker with Quantity: 3 of mockUri')
+  })
+  it('renders flex stacker empty command summary', () => {
+    screen.getByText('Emptying stacker of all labware')
+  })
 })

--- a/protocol-designer/src/components/organisms/StepSummary/index.tsx
+++ b/protocol-designer/src/components/organisms/StepSummary/index.tsx
@@ -350,6 +350,7 @@ export function StepSummary(props: StepSummaryProps): JSX.Element | null {
           labwareEntities={labwareEntities}
         />
       )
+      break
     }
 
     default:

--- a/protocol-designer/src/components/organisms/StepSummary/index.tsx
+++ b/protocol-designer/src/components/organisms/StepSummary/index.tsx
@@ -25,6 +25,7 @@ import {
 import { getRobotStateAtActiveItem } from '../../../top-selectors/labware-locations'
 import { getLabwareNicknamesById } from '../../../ui/labware/selectors'
 import { AbsorbanceReaderSummary } from './AbsorbanceReaderSummary'
+import { FlexStackerSummary } from './FlexStackerSummary'
 import { MixSummary } from './MixSummary'
 import { MoveLiquidSummary } from './MoveLiquidSummary'
 import { StyledTrans } from './StyledTrans'
@@ -341,6 +342,14 @@ export function StepSummary(props: StepSummaryProps): JSX.Element | null {
         />
       )
       break
+    }
+    case 'flexStacker': {
+      stepSummaryContent = (
+        <FlexStackerSummary
+          currentStep={currentStep}
+          labwareEntities={labwareEntities}
+        />
+      )
     }
 
     default:


### PR DESCRIPTION
# Overview

Creates flex stacker step summary text in protocol designer

## Test Plan and Hands on Testing
- passes unit tests

## Changelog

- creates flex stacker summary component to be used when the step is type `flexStacker`.
- component uses `FlexStackerFormType`s to determine what text to display

## Risk assessment

low
Closes EXEC-2068