### PR TITLE
feat(app): add close action to second window

### DIFF
--- a/app-shell/src/constants.ts
+++ b/app-shell/src/constants.ts
@@ -225,6 +225,8 @@ export const CAMERA_PHOTO_OPEN = 'shell:CAMERA_PHOTO_OPEN' as const
 export const STEP_DETAIL_VIEWER_OPEN = 'shell:STEP_DETAIL_VIEWER_OPEN' as const
 export const STEP_DETAIL_VIEWER_UPDATE =
   'shell:STEP_DETAIL_VIEWER_UPDATE' as const
+export const STEP_DETAIL_VIEWER_CLOSE =
+  'shell:STEP_DETAIL_VIEWER_CLOSE' as const
 
 export const UPDATE_BRIGHTNESS: 'shell:UPDATE_BRIGHTNESS' =
   'shell:UPDATE_BRIGHTNESS'

--- a/app-shell/src/secondary-windows/index.ts
+++ b/app-shell/src/secondary-windows/index.ts
@@ -11,6 +11,7 @@
 import {
   CAMERA_PHOTO_OPEN,
   CAMERA_STREAM_OPEN,
+  STEP_DETAIL_VIEWER_CLOSE,
   STEP_DETAIL_VIEWER_OPEN,
   STEP_DETAIL_VIEWER_UPDATE,
 } from '../constants'
@@ -113,6 +114,17 @@ function detailsByActionType(action: Action): SecondaryWindowDetails | null {
         liquids: action.payload.liquids,
       })
       return null
+
+    case STEP_DETAIL_VIEWER_CLOSE: {
+      const windowId = getWindowIdStepDetailViewer(action.payload.protocolKey)
+      const existingWindow = secondaryWindows.get(windowId)
+      if (existingWindow != null && !existingWindow.isDestroyed()) {
+        existingWindow.close()
+      }
+      secondaryWindows.delete(windowId)
+      return null
+    }
+
     default:
       return null
   }

--- a/app/src/organisms/Desktop/ProtocolVisualization/VisualizerContainer/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/VisualizerContainer/index.tsx
@@ -14,6 +14,7 @@ import { CommandSteps } from '/app/organisms/Desktop/ProtocolVisualization/Comma
 import { Controls } from '/app/organisms/Desktop/ProtocolVisualization/Controls'
 import { DeckView } from '/app/organisms/Desktop/ProtocolVisualization/DeckView'
 import {
+  stepDetailViewerCloseAction,
   stepDetailViewerOpenAction,
   stepDetailViewerUpdateAction,
 } from '/app/redux/shell'
@@ -260,6 +261,13 @@ export function VisualizerContainer(
       window.removeEventListener('mouseup', handleMouseUpRef.current)
     }
   }, [])
+
+  useEffect(() => {
+    return () => {
+      console.log('aaa')
+      dispatch(stepDetailViewerCloseAction({ protocolKey }))
+    }
+  }, [dispatch, protocolKey])
 
   return (
     <div ref={containerRef} className={styles.layout_container}>

--- a/app/src/organisms/Desktop/ProtocolVisualization/VisualizerContainer/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/VisualizerContainer/index.tsx
@@ -264,7 +264,6 @@ export function VisualizerContainer(
 
   useEffect(() => {
     return () => {
-      console.log('aaa')
       dispatch(stepDetailViewerCloseAction({ protocolKey }))
     }
   }, [dispatch, protocolKey])

--- a/app/src/pages/Desktop/Protocols/ProtocolVisualization/index.tsx
+++ b/app/src/pages/Desktop/Protocols/ProtocolVisualization/index.tsx
@@ -34,7 +34,6 @@ export function ProtocolVisualization(): JSX.Element {
   return storedProtocol != null && storedProtocol.mostRecentAnalysis != null ? (
     <div className={styles.top_container}>
       <VisualizerContainer
-        // key={protocolKey}
         analysis={storedProtocol.mostRecentAnalysis}
         groupedCommands={groupedCommands}
         protocolKey={protocolKey}

--- a/app/src/pages/Desktop/Protocols/ProtocolVisualization/index.tsx
+++ b/app/src/pages/Desktop/Protocols/ProtocolVisualization/index.tsx
@@ -34,6 +34,7 @@ export function ProtocolVisualization(): JSX.Element {
   return storedProtocol != null && storedProtocol.mostRecentAnalysis != null ? (
     <div className={styles.top_container}>
       <VisualizerContainer
+        // key={protocolKey}
         analysis={storedProtocol.mostRecentAnalysis}
         groupedCommands={groupedCommands}
         protocolKey={protocolKey}

--- a/app/src/redux/shell/actions.ts
+++ b/app/src/redux/shell/actions.ts
@@ -9,6 +9,7 @@ import type {
   RobotMassStorageDeviceEnumerated,
   RobotMassStorageDeviceRemoved,
   SendLogAction,
+  StepDetailViewerCloseAction,
   StepDetailViewerOpenAction,
   StepDetailViewerUpdateAction,
   UiInitializedAction,
@@ -40,6 +41,8 @@ export const CAMERA_PHOTO_OPEN = 'shell:CAMERA_PHOTO_OPEN' as const
 export const STEP_DETAIL_VIEWER_OPEN = 'shell:STEP_DETAIL_VIEWER_OPEN' as const
 export const STEP_DETAIL_VIEWER_UPDATE =
   'shell:STEP_DETAIL_VIEWER_UPDATE' as const
+export const STEP_DETAIL_VIEWER_CLOSE =
+  'shell:STEP_DETAIL_VIEWER_CLOSE' as const
 
 export const uiInitialized = (): UiInitializedAction => ({
   type: UI_INITIALIZED,
@@ -162,6 +165,14 @@ export const stepDetailViewerUpdateAction = (
   payload: StepDetailViewerUpdateAction['payload']
 ): StepDetailViewerUpdateAction => ({
   type: STEP_DETAIL_VIEWER_UPDATE,
+  payload,
+  meta: { shell: true },
+})
+
+export const stepDetailViewerCloseAction = (
+  payload: StepDetailViewerCloseAction['payload']
+): StepDetailViewerCloseAction => ({
+  type: STEP_DETAIL_VIEWER_CLOSE,
   payload,
   meta: { shell: true },
 })

--- a/app/src/redux/shell/types.ts
+++ b/app/src/redux/shell/types.ts
@@ -234,6 +234,14 @@ export interface StepDetailViewerUpdateAction {
   }
 }
 
+export interface StepDetailViewerCloseAction {
+  type: 'shell:STEP_DETAIL_VIEWER_CLOSE'
+  payload: { protocolKey: string }
+  meta: {
+    shell: true
+  }
+}
+
 export type ShellAction =
   | UiInitializedAction
   | ShellUpdateAction
@@ -252,6 +260,8 @@ export type ShellAction =
   | CameraStreamOpenAction
   | CameraPhotoOpenAction
   | StepDetailViewerOpenAction
+  | StepDetailViewerUpdateAction
+  | StepDetailViewerCloseAction
 
 export type IPCSafeFormDataEntry =
   | {


### PR DESCRIPTION


# Overview
add close action to second window


thread
https://opentrons.slack.com/archives/C09AFFN9N83/p1765400463433819?thread_ts=1765399463.552069&cid=C09AFFN9N83



https://github.com/user-attachments/assets/f116d898-a423-44dc-a0bc-8c9effdbd05c


close AUTH-2565

## Test Plan and Hands on Testing
- select a protocol 
- click visualization button
- click a slot in the deck view to open the second window
- move to a different page (protocol landing, protocol details, or device page etc)
check that the second window is disappeared 

Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.

## Changelog
- add close action


## Review requests

## Risk assessment
low

