### PR TITLE
fix(api): handle new flex ethernet iface

### DIFF
--- a/api/src/opentrons/system/nmcli.py
+++ b/api/src/opentrons/system/nmcli.py
@@ -302,7 +302,10 @@ class NETWORK_IFACES(enum.Enum):
         config.SystemArchitecture.BUILDROOT: "wlan0",
         config.SystemArchitecture.YOCTO: "mlan0",
     }.get(config.ARCHITECTURE, "wlan0")
-    ETH_LL = "eth0"
+    ETH_LL = {
+        config.SystemArchitecture.BUILDROOT: "eth0",
+        config.SystemArchitecture.YOCTO: "end0",
+    }.get(config.ARCHITECTURE, "eth0")
 
 
 def _add_security_type_to_scan(scan_out: Dict[str, Any]) -> Dict[str, Any]:


### PR DESCRIPTION
It's called end0 now for some inscrutable systemd reason.
