### PR TITLE
docs: update macOS and Ubuntu required versions

### DIFF
--- a/docs/flex/docs/opentrons-app.md
+++ b/docs/flex/docs/opentrons-app.md
@@ -6,7 +6,7 @@ You can perform most functions of Flex either from the [touchscreen](touchscreen
 
 ## App installation
 
-Download the Opentrons App at <https://opentrons.com/ot-app/>. The app requires Windows 10, macOS 10.10, or Ubuntu 12.04 or later. The app may run on other Linux distributions, but Opentrons does not officially support them.
+Download the Opentrons App at <https://opentrons.com/ot-app/>. The app requires Windows 10, macOS 10.16, or Ubuntu 20.04 or later. The app may run on other Linux distributions, but Opentrons does not officially support them.
 
 ### Windows
 

--- a/docs/flex/docs/opentrons-app.md
+++ b/docs/flex/docs/opentrons-app.md
@@ -6,7 +6,7 @@ You can perform most functions of Flex either from the [touchscreen](touchscreen
 
 ## App installation
 
-Download the Opentrons App at <https://opentrons.com/ot-app/>. The app requires Windows 10, macOS 10.16, or Ubuntu 20.04 or later. The app may run on other Linux distributions, but Opentrons does not officially support them.
+Download the Opentrons App at <https://opentrons.com/ot-app/>. The latest version of the app requires Windows 10, macOS 10.16, or Ubuntu 20.04 or later. The app may run on other Linux distributions, but Opentrons does not officially support them.
 
 ### Windows
 

--- a/docs/flex/docs/system-description/specs.md
+++ b/docs/flex/docs/system-description/specs.md
@@ -22,7 +22,7 @@ title: "Opentrons Flex: System Specifications"
 | **Frame composition**    | Rigid steel and CNC aluminum design |
 | **Window composition**   | Removable polycarbonate side windows and front door |
 | **Ventilation requirements** | At least 20 cm / 8 in between the unit and a wall |
-| **Connected PC requirements** | The Opentrons App runs on: <ul><li>Windows 10 or later</li><li>macOS 10.16 or later</li><li>Ubuntu 20.04 or later</li></ul> |
+| **Connected PC requirements** | The latest version of the Opentrons App runs on: <ul><li>Windows 10 or later</li><li>macOS 10.16 or later</li><li>Ubuntu 20.04 or later</li></ul> |
 
 ## Environmental specifications
 

--- a/docs/flex/docs/system-description/specs.md
+++ b/docs/flex/docs/system-description/specs.md
@@ -22,7 +22,7 @@ title: "Opentrons Flex: System Specifications"
 | **Frame composition**    | Rigid steel and CNC aluminum design |
 | **Window composition**   | Removable polycarbonate side windows and front door |
 | **Ventilation requirements** | At least 20 cm / 8 in between the unit and a wall |
-| **Connected PC requirements** | The Opentrons App runs on: <ul><li>Windows 10 or later</li><li>macOS 10.10 or later</li><li>Ubuntu 12.04 or later</li></ul> |
+| **Connected PC requirements** | The Opentrons App runs on: <ul><li>Windows 10 or later</li><li>macOS 10.16 or later</li><li>Ubuntu 20.04 or later</li></ul> |
 
 ## Environmental specifications
 


### PR DESCRIPTION
# Overview

Update outdated operating system requirements in the Flex instruction manual.

Closes RTC-666 😈 

## Test Plan and Hands on Testing

Sandbox for [each](https://sandbox.docs.opentrons.com/docs-update-os-reqs/flex/opentrons-app/#app-installation) [page](https://sandbox.docs.opentrons.com/docs-update-os-reqs/flex/system-description/specs/#general-specifications).

## Changelog

- macOS 10.10 -> 10.16
- Ubuntu 12.04 -> 20.04

## Review requests

Search across all mkdocs source doesn't indicate any other occurrences, but let's be sure.

## Risk assessment

nil