### PR TITLE
refactor(app): use OffsetTag in HistoricalProtocolRunDrawer

### DIFF
--- a/app/src/organisms/Desktop/Devices/HistoricalProtocolRunDrawer.tsx
+++ b/app/src/organisms/Desktop/Devices/HistoricalProtocolRunDrawer.tsx
@@ -37,7 +37,6 @@ import {
   THERMOCYCLER_MODULE_TYPE,
 } from '@opentrons/shared-data'
 
-import { LegacyOffsetVector } from '/app/molecules/LegacyOffsetVector'
 import { downloadFile } from '/app/organisms/Desktop/Devices/utils'
 import {
   SOURCE_RUN_RECORD,
@@ -47,6 +46,7 @@ import { useIsFlex, useRobotType } from '/app/redux-resources/robots'
 import { useRunGeneratedDataFiles } from '/app/resources/dataFiles/useRunGeneratedDataFiles'
 import { useMostRecentCompletedAnalysis } from '/app/resources/runs'
 
+import { OffsetTag } from '../../LabwarePositionCheck'
 import { DownloadCsvFileLink } from './DownloadCsvFileLink'
 import { useDeckCalibrationData } from './hooks'
 
@@ -267,7 +267,6 @@ export function HistoricalProtocolRunDrawer(
                 THERMOCYCLER_MODULE_TYPE
                 ? thermocyclerLocation
                 : offset.location.slotName
-
             return (
               <Flex
                 key={`labware_offset_${index}`}
@@ -302,12 +301,13 @@ export function HistoricalProtocolRunDrawer(
                     />
                   )}
                 </Flex>
-                <Box width="25%">
-                  <LegacyOffsetVector
-                    {...offset.vector}
-                    fontSize={TYPOGRAPHY.fontSizeLabel}
-                    as="p"
-                  />
+                <Box width="26%">
+                  <Flex
+                    flexDirection={DIRECTION_COLUMN}
+                    gridGap={SPACING.spacing8}
+                  >
+                    <OffsetTag kind="vector" {...offset.vector} />
+                  </Flex>
                 </Box>
               </Flex>
             )


### PR DESCRIPTION
# Overview

Uses OffsetTag to wrap LPC offsets in `HistoricalProtocolRunDrawer`

## Test Plan and Hands on Testing

smoke tested on the app
<img width="873" height="646" alt="Screenshot 2025-12-11 at 3 11 44 PM" src="https://github.com/user-attachments/assets/c1b25d09-5eb6-4dc3-9511-86df886099bf" />

## Changelog

- replaced `LegacyOffsetVector` with `OffsetTag`

## Risk assessment

low

Closes EXEC-1891