### PR TITLE
refactor(protocol-designer): help track down why _formLevelErrors() is crashing

### DIFF
--- a/protocol-designer/src/steplist/formLevel/index.ts
+++ b/protocol-designer/src/steplist/formLevel/index.ts
@@ -391,6 +391,9 @@ export const getFormErrors = (
         moduleEntities,
         labwareEntities
       )
+    default:
+      stepType satisfies never // if TypeScript complains here, you missed a stepType above
+      throw new Error(`Unknown step type: ${stepType}`)
   }
 }
 


### PR DESCRIPTION
# Overview

I can't figure out why we're seeing these crashes in `_formLevelErrors()`:
- https://opentrons-76.sentry.io/issues/7079511965?project=4509363266387968
- https://opentrons-76.sentry.io/issues/7079511914?project=4509363266387968
- https://opentrons-76.sentry.io/issues/7079512035?project=4509363266387968

The failure can happen if our `getFormErrors()` doesn't handle a form `stepType`, but as far as I can tell, all possible `stepType`s are already handled.

It could also happen if the saved protocol is malformed (I was able to trigger the same exception if I manually edited a protocol to say `"stepType": "moveLiquidxxx"`), or maybe people are importing newer protocols with new `stepType`s into older versions versions of PD? It's also possible we're creating a `HydratedFormData` somewhere without setting `stepType`, which would also trigger this error if `stepType` is `undefined`.

This PR just adds some instrumentation so that we get a more useful error message when this crash happens again.

## Test Plan and Hands on Testing

Ran PD locally.

## Risk assessment

Low.