### PR TITLE
refactor(protocol-designer): Deduplicate module state types with step-generation

### DIFF
--- a/protocol-designer/src/file-data/selectors/commands.ts
+++ b/protocol-designer/src/file-data/selectors/commands.ts
@@ -14,11 +14,11 @@ import {
 import { selectors as labwareIngredSelectors } from '../../labware-ingred/selectors'
 import { selectors as stepFormSelectors } from '../../step-forms'
 
+import type { ModuleTemporalProperties } from '@opentrons/step-generation'
 import type { StepIdType } from '../../form-types'
 import type {
   LabwareTemporalProperties,
   ModuleOnDeck,
-  ModuleTemporalProperties,
   PipetteOnDeck,
   PipetteTemporalProperties,
 } from '../../step-forms'

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/AbsorbanceReaderTools/Initialization.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/AbsorbanceReaderTools/Initialization.tsx
@@ -36,11 +36,11 @@ import { maskToInteger } from '/protocol-designer/steplist/fieldLevel/processing
 import type { TFunction } from 'i18next'
 import type { Dispatch, SetStateAction } from 'react'
 import type { DropdownOption } from '@opentrons/components'
-import type { Initialization } from '@opentrons/step-generation'
+import type { Initialization as InitializationState } from '@opentrons/step-generation'
 import type { FormData } from '/protocol-designer/form-types'
 import type { FieldProps, FieldPropsByName } from '../../types'
 
-type InitializationMode = Initialization['mode']
+type InitializationMode = InitializationState['mode']
 
 const MAX_WAVELENGTHS = 6
 const CUSTOM_OPTION: DropdownOption = { name: 'Other', value: '' }

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/AbsorbanceReaderTools/Initialization.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/AbsorbanceReaderTools/Initialization.tsx
@@ -36,9 +36,11 @@ import { maskToInteger } from '/protocol-designer/steplist/fieldLevel/processing
 import type { TFunction } from 'i18next'
 import type { Dispatch, SetStateAction } from 'react'
 import type { DropdownOption } from '@opentrons/components'
+import type { Initialization } from '@opentrons/step-generation'
 import type { FormData } from '/protocol-designer/form-types'
-import type { InitializationMode } from '/protocol-designer/step-forms/types'
 import type { FieldProps, FieldPropsByName } from '../../types'
+
+type InitializationMode = Initialization['mode']
 
 const MAX_WAVELENGTHS = 6
 const CUSTOM_OPTION: DropdownOption = { name: 'Other', value: '' }

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/AbsorbanceReaderTools/InitializationSettings.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/AbsorbanceReaderTools/InitializationSettings.tsx
@@ -16,7 +16,7 @@ import {
 
 import { ABSORBANCE_READER_COLOR_BY_WAVELENGTH } from '/protocol-designer/constants'
 
-import type { Initialization } from '/protocol-designer/step-forms/types'
+import type { Initialization } from '@opentrons/step-generation'
 
 const getWavelengthDisplay = (
   wavelength: number,

--- a/protocol-designer/src/step-forms/selectors/index.ts
+++ b/protocol-designer/src/step-forms/selectors/index.ts
@@ -5,17 +5,15 @@ import reduce from 'lodash/reduce'
 import { createSelector } from 'reselect'
 
 import {
-  ABSORBANCE_READER_TYPE,
   FLEX_STACKER_MODULE_TYPE,
   getLabwareDefURI,
   getPipetteSpecsV2,
   HEATERSHAKER_MODULE_TYPE,
-  MAGNETIC_BLOCK_TYPE,
   MAGNETIC_MODULE_TYPE,
   TEMPERATURE_MODULE_TYPE,
   THERMOCYCLER_MODULE_TYPE,
 } from '@opentrons/shared-data'
-import { TEMPERATURE_DEACTIVATED } from '@opentrons/step-generation'
+import { MODULE_INITIAL_STATE_BY_TYPE as STEP_GENERATION_MODULE_INITIAL_STATE_BY_TYPE } from '@opentrons/step-generation'
 
 import { getStepVisibilities } from '/protocol-designer/steplist/utils/getStepVisibilities'
 import {
@@ -38,16 +36,22 @@ import { denormalizePipetteEntities, getHydratedForm } from '../utils'
 
 import type { Selector } from 'reselect'
 import type { DropdownOption, Mount } from '@opentrons/components'
-import type { LabwareDefinition2, PipetteName } from '@opentrons/shared-data'
+import type {
+  LabwareDefinition2,
+  ModuleType,
+  PipetteName,
+} from '@opentrons/shared-data'
 import type {
   AdditionalEquipmentEntities,
   AdditionalEquipmentEntity,
+  FlexStackerModuleState,
   GripperEntities,
   InvariantContext,
   LabwareEntities,
   LabwareEntity,
   LiquidEntities,
   ModuleEntities,
+  ModuleTemporalProperties,
   NormalizedAdditionalEquipmentById,
   PipetteEntities,
   StagingAreaEntities,
@@ -79,22 +83,14 @@ import type {
   SavedStepFormState,
 } from '../reducers'
 import type {
-  AbsorbanceReaderState,
-  FlexStackerModuleState,
   FormPipettesByMount,
-  HeaterShakerModuleState,
   InitialDeckSetup,
   LabwareOnDeck,
-  MagneticBlockState,
-  MagneticModuleState,
   ModuleOnDeck,
   ModulesForEditModulesCard,
-  ModuleTemporalProperties,
   NormalizedLabware,
   NormalizedLabwareById,
   PipetteOnDeck,
-  TemperatureModuleState,
-  ThermocyclerModuleState,
 } from '../types'
 
 const rootSelector = (state: BaseState): RootState => state.stepForms
@@ -207,35 +203,8 @@ export const getAdditionalEquipment: Selector<
 
 export const getInitialDeckSetupStepForm: Selector<BaseState, FormData> =
   createSelector(rootSelector, _getInitialDeckSetupStepFormRootState)
-const MAGNETIC_MODULE_INITIAL_STATE: MagneticModuleState = {
-  type: MAGNETIC_MODULE_TYPE,
-  engaged: false,
-}
-const TEMPERATURE_MODULE_INITIAL_STATE: TemperatureModuleState = {
-  type: TEMPERATURE_MODULE_TYPE,
-  status: TEMPERATURE_DEACTIVATED,
-  targetTemperature: null,
-}
-const THERMOCYCLER_MODULE_INITIAL_STATE: ThermocyclerModuleState = {
-  type: THERMOCYCLER_MODULE_TYPE,
-  blockTargetTemp: null,
-  lidTargetTemp: null,
-  lidOpen: null,
-}
-const HEATERSHAKER_MODULE_INITIAL_STATE: HeaterShakerModuleState = {
-  type: HEATERSHAKER_MODULE_TYPE,
-  targetTemp: null,
-  targetSpeed: null,
-  latchOpen: null,
-}
-const MAGNETIC_BLOCK_INITIAL_STATE: MagneticBlockState = {
-  type: MAGNETIC_BLOCK_TYPE,
-}
-const ABSORBANCE_READER_INITIAL_STATE: AbsorbanceReaderState = {
-  type: ABSORBANCE_READER_TYPE,
-  lidOpen: null,
-  initialization: null,
-}
+
+// todo(mm, 2025-12-12): Temporarily defining FLEX_STACKER_INITIAL_STATE here until step-generation supports it.
 const FLEX_STACKER_INITIAL_STATE: FlexStackerModuleState = {
   type: FLEX_STACKER_MODULE_TYPE,
   maxPoolCount: 0,
@@ -244,18 +213,14 @@ const FLEX_STACKER_INITIAL_STATE: FlexStackerModuleState = {
   labwareOnShuttle: null,
 }
 
-const MODULE_INITIAL_STATES_MAP: Record<
-  string,
-  ModuleTemporalProperties['moduleState']
-> = {
-  [MAGNETIC_MODULE_TYPE]: MAGNETIC_MODULE_INITIAL_STATE,
-  [TEMPERATURE_MODULE_TYPE]: TEMPERATURE_MODULE_INITIAL_STATE,
-  [THERMOCYCLER_MODULE_TYPE]: THERMOCYCLER_MODULE_INITIAL_STATE,
-  [HEATERSHAKER_MODULE_TYPE]: HEATERSHAKER_MODULE_INITIAL_STATE,
-  [MAGNETIC_BLOCK_TYPE]: MAGNETIC_BLOCK_INITIAL_STATE,
-  [ABSORBANCE_READER_TYPE]: ABSORBANCE_READER_INITIAL_STATE,
+const MODULE_INITIAL_STATES_MAP = {
+  ...STEP_GENERATION_MODULE_INITIAL_STATE_BY_TYPE,
   [FLEX_STACKER_MODULE_TYPE]: FLEX_STACKER_INITIAL_STATE,
-}
+} as const
+MODULE_INITIAL_STATES_MAP satisfies Record<
+  ModuleType,
+  ModuleTemporalProperties['moduleState']
+>
 
 const _getInitialDeckSetup = (
   initialSetupStep: FormData,

--- a/protocol-designer/src/step-forms/types.ts
+++ b/protocol-designer/src/step-forms/types.ts
@@ -16,11 +16,20 @@ import type {
   THERMOCYCLER_MODULE_TYPE,
 } from '@opentrons/shared-data'
 import type {
+  AbsorbanceReaderState,
   AdditionalEquipmentEntity,
+  FlexStackerModuleState,
+  HeaterShakerModuleState,
+  Initialization,
   LabwareEntity,
+  MagneticBlockState,
+  MagneticModuleState,
   ModuleEntity,
+  ModuleTemporalProperties,
   PipetteEntity,
+  TemperatureModuleState,
   TemperatureStatus,
+  ThermocyclerModuleState,
   TOUCHED_PIPETTABLE_LABWARE,
 } from '@opentrons/step-generation'
 import type { DeckSlot } from '../types'
@@ -43,64 +52,6 @@ export interface FormModule {
 }
 export type FormModules = Record<number, FormModule>
 export type ModuleEntities = Record<string, ModuleEntity>
-// NOTE: semi-redundant 'type' key in FooModuleState types is required for Flow to disambiguate 'moduleState'
-export interface MagneticModuleState {
-  type: typeof MAGNETIC_MODULE_TYPE
-  engaged: boolean
-}
-export interface TemperatureModuleState {
-  type: typeof TEMPERATURE_MODULE_TYPE
-  status: TemperatureStatus
-  targetTemperature: number | null
-}
-export interface ThermocyclerModuleState {
-  type: typeof THERMOCYCLER_MODULE_TYPE
-  blockTargetTemp: number | null
-  // null means block is deactivated
-  lidTargetTemp: number | null
-  // null means lid is deactivated
-  lidOpen: boolean | null // if false, closed. If null, unknown
-}
-export interface HeaterShakerModuleState {
-  type: typeof HEATERSHAKER_MODULE_TYPE
-  targetTemp: number | null
-  targetSpeed: number | null
-  latchOpen: boolean | null
-}
-export interface MagneticBlockState {
-  type: typeof MAGNETIC_BLOCK_TYPE
-}
-
-export interface FlexStackerModuleState {
-  type: typeof FLEX_STACKER_MODULE_TYPE
-  maxPoolCount: number
-  storedLabwareDetails: FlexStackerSetStoredLabwareParams | null
-  labwareInHopper: FlexStackerStoredLabwareGroup[] | null
-  labwareOnShuttle: FlexStackerStoredLabwareGroup | null
-}
-export type InitializationMode = 'single' | 'multi'
-export interface Initialization {
-  mode: InitializationMode
-  wavelengths: number[]
-  referenceWavelength?: number
-}
-
-export interface AbsorbanceReaderState {
-  type: typeof ABSORBANCE_READER_TYPE
-  lidOpen: boolean | null
-  initialization: Initialization | null
-}
-export interface ModuleTemporalProperties {
-  slot: DeckSlot
-  moduleState:
-    | MagneticModuleState
-    | TemperatureModuleState
-    | ThermocyclerModuleState
-    | HeaterShakerModuleState
-    | MagneticBlockState
-    | AbsorbanceReaderState
-    | FlexStackerModuleState
-}
 export type ModuleOnDeck = ModuleEntity & ModuleTemporalProperties
 export type ModulesForEditModulesCard = Partial<
   Record<ModuleType, ModuleOnDeck[] | null | undefined>

--- a/protocol-designer/src/step-forms/types.ts
+++ b/protocol-designer/src/step-forms/types.ts
@@ -1,35 +1,17 @@
 import type { Mount } from '@opentrons/components'
 import type {
-  ABSORBANCE_READER_TYPE,
   CutoutId,
-  FLEX_STACKER_MODULE_TYPE,
   FlexModuleCutoutFixtureId,
-  FlexStackerSetStoredLabwareParams,
-  FlexStackerStoredLabwareGroup,
-  HEATERSHAKER_MODULE_TYPE,
-  MAGNETIC_BLOCK_TYPE,
-  MAGNETIC_MODULE_TYPE,
   ModuleModel,
   ModuleType,
   NozzleConfigurationStyle,
-  TEMPERATURE_MODULE_TYPE,
-  THERMOCYCLER_MODULE_TYPE,
 } from '@opentrons/shared-data'
 import type {
-  AbsorbanceReaderState,
   AdditionalEquipmentEntity,
-  FlexStackerModuleState,
-  HeaterShakerModuleState,
-  Initialization,
   LabwareEntity,
-  MagneticBlockState,
-  MagneticModuleState,
   ModuleEntity,
   ModuleTemporalProperties,
   PipetteEntity,
-  TemperatureModuleState,
-  TemperatureStatus,
-  ThermocyclerModuleState,
   TOUCHED_PIPETTABLE_LABWARE,
 } from '@opentrons/step-generation'
 import type { DeckSlot } from '../types'

--- a/protocol-designer/src/tutorial/__tests__/selectors.test.ts
+++ b/protocol-designer/src/tutorial/__tests__/selectors.test.ts
@@ -4,7 +4,7 @@ import { THERMOCYCLER_MODULE_TYPE } from '@opentrons/shared-data'
 
 import { shouldShowCoolingHint as _shouldShowCoolingHint } from '../selectors'
 
-import type { ThermocyclerModuleState } from '../../step-forms/types'
+import type { ThermocyclerModuleState } from '@opentrons/step-generation'
 
 // TODO(IL, 2020-05-19): Flow doesn't have type for resultFunc
 const shouldShowCoolingHint: any = _shouldShowCoolingHint

--- a/step-generation/src/constants.ts
+++ b/step-generation/src/constants.ts
@@ -60,27 +60,34 @@ export const HEATERSHAKER_MODULE_INITIAL_STATE: HeaterShakerModuleState = {
   targetSpeed: null,
   latchOpen: null,
 }
-
-const ABSORBANCE_READER_INITIAL_STATE: AbsorbanceReaderState = {
+export const ABSORBANCE_READER_INITIAL_STATE: AbsorbanceReaderState = {
   type: 'absorbanceReaderType',
   lidOpen: null,
   initialization: null,
 }
-const MAGNETIC_BLOCK_INITIAL_STATE: MagneticBlockState = {
+export const MAGNETIC_BLOCK_INITIAL_STATE: MagneticBlockState = {
   type: 'magneticBlockType',
 }
 
-// @ts-expect-error Flex stacker not yet supported in step-generation
-export const MODULE_INITIAL_STATE_BY_TYPE: {
-  [moduleType in ModuleType]: ModuleState
-} = {
+export const MODULE_INITIAL_STATE_BY_TYPE = {
   [MAGNETIC_MODULE_TYPE]: MAGNETIC_MODULE_INITIAL_STATE,
   [TEMPERATURE_MODULE_TYPE]: TEMPERATURE_MODULE_INITIAL_STATE,
   [THERMOCYCLER_MODULE_TYPE]: THERMOCYCLER_MODULE_INITIAL_STATE,
   [HEATERSHAKER_MODULE_TYPE]: HEATERSHAKER_MODULE_INITIAL_STATE,
   [ABSORBANCE_READER_TYPE]: ABSORBANCE_READER_INITIAL_STATE,
   [MAGNETIC_BLOCK_TYPE]: MAGNETIC_BLOCK_INITIAL_STATE,
+} as const
+
+// @ts-expect-error Flex stacker not yet supported in step-generation
+// todo(mm, 2025-12-12): protocol-designer defines its own FLEX_STACKER_INITIAL_STATE.
+// Delete that one when we define one here.
+MODULE_INITIAL_STATE_BY_TYPE satisfies {
+  [moduleType in ModuleType]: ModuleState
 }
+MODULE_INITIAL_STATE_BY_TYPE satisfies {
+  [moduleType in Exclude<ModuleType, 'flexStackerModuleType'>]: ModuleState
+}
+
 export const OT_2_TRASH_DEF_URI = 'opentrons/opentrons_1_trash_1100ml_fixed/1'
 export const FLEX_TRASH_DEF_URI = 'opentrons/opentrons_1_trash_3200ml_fixed/1'
 export const COLUMN_4_SLOTS = ['A4', 'B4', 'C4', 'D4']

--- a/step-generation/src/utils/createTimelineFromRunCommands.ts
+++ b/step-generation/src/utils/createTimelineFromRunCommands.ts
@@ -49,6 +49,7 @@ export function getResultingTimelineFrameFromRunCommands(
           ...acc,
           [command.result.moduleId]: {
             slot: command.params.location.slotName,
+            // @ts-expect-error MODULE_INITIAL_STATE_BY_TYPE doesn't have an entry for the stacker yet.
             moduleState: MODULE_INITIAL_STATE_BY_TYPE[moduleType],
           },
         }


### PR DESCRIPTION
## Overview

step-generation and protocol-designer define identical types and constants for module state. They will get more complicated with concurrent module actions, so we gotta deduplicate 'em.

Goes towards EXEC-2009.

## Test Plan and Hands on Testing

Just CI.

## Review requests

See comments below.

## Risk assessment

Low. Changes are just to type checking.
