### PR TITLE
fix(protocol-designer): Align number to top of step button instead of middle

### DIFF
--- a/protocol-designer/src/components/molecules/StepContainer/index.tsx
+++ b/protocol-designer/src/components/molecules/StepContainer/index.tsx
@@ -144,7 +144,6 @@ export function StepContainer(props: StepContainerProps): JSX.Element {
                 <Flex
                   flexDirection={DIRECTION_ROW}
                   gridGap={SPACING.spacing4}
-                  alignItems={ALIGN_CENTER}
                   flex="1"
                   minWidth="0"
                 >


### PR DESCRIPTION
## Overview

Closes EXEC-2119.

## Test Plan and Hands on Testing

Before:
<img width="221" height="147" alt="Screenshot 2025-12-12 at 6 19 05 PM" src="https://github.com/user-attachments/assets/26aedd1d-c91e-4712-9fd2-077c039c7459" />


After:
<img width="221" height="150" alt="Screenshot 2025-12-12 at 6 18 48 PM" src="https://github.com/user-attachments/assets/e7fb791c-3114-4620-8d79-bf458d56eb19" />

## Review requests

None.

## Risk assessment

Low.