### PR TITLE
chore: update prettier to v3.7.0

### DIFF
--- a/api-client/src/types.ts
+++ b/api-client/src/types.ts
@@ -45,20 +45,17 @@ export interface BaseOffsetLocationSequenceComponent {
   kind: string
 }
 
-export interface OnLabwareOffsetLocationSequenceComponent
-  extends BaseOffsetLocationSequenceComponent {
+export interface OnLabwareOffsetLocationSequenceComponent extends BaseOffsetLocationSequenceComponent {
   kind: 'onLabware'
   labwareUri: string
 }
 
-export interface OnModuleOffsetLocationSequenceComponent
-  extends BaseOffsetLocationSequenceComponent {
+export interface OnModuleOffsetLocationSequenceComponent extends BaseOffsetLocationSequenceComponent {
   kind: 'onModule'
   moduleModel: ModuleModel
 }
 
-export interface OnAddressableAreaOffsetLocationSequenceComponent
-  extends BaseOffsetLocationSequenceComponent {
+export interface OnAddressableAreaOffsetLocationSequenceComponent extends BaseOffsetLocationSequenceComponent {
   kind: 'onAddressableArea'
   addressableAreaName: AddressableAreaName
 }

--- a/app/src/molecules/InterventionModal/CategorizedStepContent.stories.tsx
+++ b/app/src/molecules/InterventionModal/CategorizedStepContent.stories.tsx
@@ -37,11 +37,10 @@ function safeCommandOfType(type: CommandType, index: number): RunTimeCommand {
   return commands[index]
 }
 
-interface WrapperProps
-  extends Omit<
-    CategorizedStepContentProps,
-    'topCategoryCommand' | 'bottomCategoryCommands' | 'commandTextData'
-  > {
+interface WrapperProps extends Omit<
+  CategorizedStepContentProps,
+  'topCategoryCommand' | 'bottomCategoryCommands' | 'commandTextData'
+> {
   topCategoryCommand: CommandType | 'none'
   bottomCategoryCommand1: CommandType | 'none'
   bottomCategoryCommand2: CommandType | 'none'

--- a/app/src/molecules/InterventionModal/DeckMapContent.tsx
+++ b/app/src/molecules/InterventionModal/DeckMapContent.tsx
@@ -31,11 +31,10 @@ import type {
 
 export type MapKind = 'intervention' | 'deck-config'
 
-export interface InterventionStyleDeckMapContentProps
-  extends Pick<
-    ComponentProps<typeof BaseDeck>,
-    'deckConfig' | 'robotType' | 'labwareOnDeck' | 'modulesOnDeck'
-  > {
+export interface InterventionStyleDeckMapContentProps extends Pick<
+  ComponentProps<typeof BaseDeck>,
+  'deckConfig' | 'robotType' | 'labwareOnDeck' | 'modulesOnDeck'
+> {
   kind: 'intervention'
   highlightLabwareEventuallyIn: string[]
 }

--- a/app/src/organisms/Desktop/ChooseRobotSlideout/index.tsx
+++ b/app/src/organisms/Desktop/ChooseRobotSlideout/index.tsx
@@ -112,8 +112,7 @@ function robotBusyStatusByNameReducer(
 }
 
 interface ChooseRobotSlideoutProps
-  extends Omit<SlideoutProps, 'children'>,
-    Partial<UseCreateRun> {
+  extends Omit<SlideoutProps, 'children'>, Partial<UseCreateRun> {
   isSelectedRobotOnDifferentSoftwareVersion: boolean
   robotType: RobotType | null
   selectedRobot: Robot | null

--- a/app/src/organisms/Desktop/ChooseRobotToRunProtocolSlideout/index.tsx
+++ b/app/src/organisms/Desktop/ChooseRobotToRunProtocolSlideout/index.tsx
@@ -52,8 +52,7 @@ interface ChooseRobotToRunProtocolSlideoutProps extends StyleProps {
   showSlideout: boolean
 }
 
-interface ChooseRobotToRunProtocolSlideoutComponentProps
-  extends ChooseRobotToRunProtocolSlideoutProps {
+interface ChooseRobotToRunProtocolSlideoutComponentProps extends ChooseRobotToRunProtocolSlideoutProps {
   selectedRobot: Robot | null
   setSelectedRobot: (robot: Robot | null) => void
 }

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderBannerContainer/TerminalRunBannerContainer.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderBannerContainer/TerminalRunBannerContainer.tsx
@@ -68,8 +68,7 @@ export function useTerminalRunBannerContainer({
   }
 }
 
-interface TerminalRunBannerContainerProps
-  extends RunHeaderBannerContainerProps {
+interface TerminalRunBannerContainerProps extends RunHeaderBannerContainerProps {
   bannerType: TerminalBannerType
 }
 

--- a/app/src/organisms/EmergencyStop/EstopMissingModal.tsx
+++ b/app/src/organisms/EmergencyStop/EstopMissingModal.tsx
@@ -55,11 +55,10 @@ export function EstopMissingModal({
   )
 }
 
-interface EstopMissingTouchscreenModalProps
-  extends Omit<
-    EstopMissingModalProps,
-    'isDismissedModal' | 'setIsDismissedModal'
-  > {}
+interface EstopMissingTouchscreenModalProps extends Omit<
+  EstopMissingModalProps,
+  'isDismissedModal' | 'setIsDismissedModal'
+> {}
 
 function TouchscreenModal({
   robotName,
@@ -88,8 +87,10 @@ function TouchscreenModal({
   )
 }
 
-interface EstopMissingDesktopModalProps
-  extends Omit<EstopMissingModalProps, 'isDismissedModal'> {}
+interface EstopMissingDesktopModalProps extends Omit<
+  EstopMissingModalProps,
+  'isDismissedModal'
+> {}
 
 function DesktopModal({
   robotName,

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useFailedPipetteUtils.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useFailedPipetteUtils.ts
@@ -10,8 +10,7 @@ import type {
 } from '@opentrons/api-client'
 import type { FailedCommandBySource } from './useRetainedFailedCommandBySource'
 
-export interface UseFailedPipetteUtilsParams
-  extends UseFailedCommandPipetteInfoProps {
+export interface UseFailedPipetteUtilsParams extends UseFailedCommandPipetteInfoProps {
   runId: string
 }
 

--- a/app/src/organisms/ErrorRecoveryFlows/index.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/index.tsx
@@ -32,14 +32,12 @@ interface UseErrorRecoveryResultBase {
   failedCommand: FailedCommand | null
   runLwDefsByUri: ReturnType<typeof useRunLoadedLabwareDefinitionsByUri>
 }
-export interface UseErrorRecoveryActiveResult
-  extends UseErrorRecoveryResultBase {
+export interface UseErrorRecoveryActiveResult extends UseErrorRecoveryResultBase {
   isERActive: true
   failedCommand: FailedCommand
   runLwDefsByUri: RunLoadedLabwareDefinitionsByUri
 }
-export interface UseErrorRecoveryInactiveResult
-  extends UseErrorRecoveryResultBase {
+export interface UseErrorRecoveryInactiveResult extends UseErrorRecoveryResultBase {
   isERActive: false
 }
 export type UseErrorRecoveryResult =

--- a/app/src/organisms/ErrorRecoveryFlows/shared/RecoveryRadioGroup.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/RecoveryRadioGroup.tsx
@@ -14,11 +14,10 @@ export type Options<T extends string = never> = Array<{
   children: ReactNode
 }>
 
-export interface RecoveryRadioGroupProps<T extends string>
-  extends Omit<
-    ComponentProps<typeof RadioGroup>,
-    'labelTextClassName' | 'options' | 'onchange'
-  > {
+export interface RecoveryRadioGroupProps<T extends string> extends Omit<
+  ComponentProps<typeof RadioGroup>,
+  'labelTextClassName' | 'options' | 'onchange'
+> {
   options: Options<T>
   onChange: ChangeEventHandler<Target<T>>
 }

--- a/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useLPCLabwareInfo/getLPCLabwareInfoFrom/getDefaultOffsetForLabware.ts
+++ b/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useLPCLabwareInfo/getLPCLabwareInfoFrom/getDefaultOffsetForLabware.ts
@@ -19,8 +19,7 @@ import type {
 } from '/app/redux/protocol-runs'
 import type { GetLPCLabwareInfoForURI } from '.'
 
-interface GetDefaultOffsetDetailsForLabwareParams
-  extends GetLPCLabwareInfoForURI {
+interface GetDefaultOffsetDetailsForLabwareParams extends GetLPCLabwareInfoForURI {
   locationSpecificOffsetDetails: LocationSpecificOffsetDetails[]
 }
 
@@ -62,8 +61,7 @@ export function getDefaultOffsetDetailsForLabware(
   }
 }
 
-interface GetStackingInfoParams
-  extends GetDefaultOffsetDetailsForLabwareParams {
+interface GetStackingInfoParams extends GetDefaultOffsetDetailsForLabwareParams {
   aLabwareId: string
 }
 

--- a/app/src/organisms/LabwarePositionCheck/hooks/useLPCCommands/types.ts
+++ b/app/src/organisms/LabwarePositionCheck/hooks/useLPCCommands/types.ts
@@ -4,8 +4,7 @@ import type { UseLPCCommandsProps } from '.'
 
 export interface UseLPCCommandChildProps extends UseLPCCommandsProps {}
 
-export interface UseLPCCommandWithChainRunChildProps
-  extends UseLPCCommandChildProps {
+export interface UseLPCCommandWithChainRunChildProps extends UseLPCCommandChildProps {
   chainLPCCommands: (
     commands: CreateCommand[],
     continuePastCommandFailure: boolean,

--- a/app/src/organisms/LabwarePositionCheck/hooks/useLPCCommands/useHandleConfirmLwFinalPosition.ts
+++ b/app/src/organisms/LabwarePositionCheck/hooks/useLPCCommands/useHandleConfirmLwFinalPosition.ts
@@ -13,8 +13,7 @@ import type {
 import type { OffsetLocationDetails } from '/app/redux/protocol-runs'
 import type { UseLPCCommandWithChainRunChildProps } from './types'
 
-interface UseHandleConfirmPositionProps
-  extends UseLPCCommandWithChainRunChildProps {
+interface UseHandleConfirmPositionProps extends UseLPCCommandWithChainRunChildProps {
   setErrorMessage: (msg: string | null) => void
 }
 

--- a/app/src/organisms/LabwarePositionCheck/hooks/useLPCCommands/useHandleConfirmLwModulePlacement.ts
+++ b/app/src/organisms/LabwarePositionCheck/hooks/useLPCCommands/useHandleConfirmLwModulePlacement.ts
@@ -14,8 +14,7 @@ import type {
 import type { OffsetLocationDetails } from '/app/redux/protocol-runs'
 import type { UseLPCCommandWithChainRunChildProps } from './types'
 
-export interface UseHandleConfirmPlacementProps
-  extends UseLPCCommandWithChainRunChildProps {
+export interface UseHandleConfirmPlacementProps extends UseLPCCommandWithChainRunChildProps {
   setErrorMessage: (msg: string | null) => void
 }
 

--- a/app/src/organisms/ModuleWizardFlows/CheckStackerInstall.tsx
+++ b/app/src/organisms/ModuleWizardFlows/CheckStackerInstall.tsx
@@ -13,8 +13,7 @@ import type { AttachedModule } from '@opentrons/api-client'
 import type { DeckConfiguration } from '@opentrons/shared-data'
 import type { ModuleSetupWizardMaybePipetteStepProps } from './types'
 
-interface CheckStackerInstallProps
-  extends ModuleSetupWizardMaybePipetteStepProps {
+interface CheckStackerInstallProps extends ModuleSetupWizardMaybePipetteStepProps {
   deckConfig: DeckConfiguration
   attachedModules: AttachedModule[]
   doorOpenStatus: boolean

--- a/app/src/organisms/ModuleWizardFlows/SelectLocation.tsx
+++ b/app/src/organisms/ModuleWizardFlows/SelectLocation.tsx
@@ -58,8 +58,7 @@ export const BODY_STYLE = css`
     line-height: 1.75rem;
   }
 `
-export interface SelectLocationProps
-  extends ModuleSetupWizardMaybePipetteStepProps {
+export interface SelectLocationProps extends ModuleSetupWizardMaybePipetteStepProps {
   deckConfig: DeckConfiguration
   createMaintenanceRun: CreateMaintenanceRunType
   isLoadedInRun: boolean

--- a/app/src/organisms/ModuleWizardFlows/index.tsx
+++ b/app/src/organisms/ModuleWizardFlows/index.tsx
@@ -384,8 +384,10 @@ export function ModuleWizardFlows(
   }
 }
 
-interface ModuleWizardFlowsPropsWithHost
-  extends Omit<ModuleWizardFlowsProps, 'closeFlow'> {
+interface ModuleWizardFlowsPropsWithHost extends Omit<
+  ModuleWizardFlowsProps,
+  'closeFlow'
+> {
   host: HostConfig
 }
 

--- a/app/src/organisms/ModuleWizardFlows/types.ts
+++ b/app/src/organisms/ModuleWizardFlows/types.ts
@@ -65,13 +65,11 @@ export interface ModuleSetupWizardBaseStepProps {
   isOnDevice: boolean
 }
 
-export interface ModuleSetupWizardRequiresPipetteStepProps
-  extends ModuleSetupWizardBaseStepProps {
+export interface ModuleSetupWizardRequiresPipetteStepProps extends ModuleSetupWizardBaseStepProps {
   attachedPipette: PipetteInformation
 }
 
-export interface ModuleSetupWizardMaybePipetteStepProps
-  extends ModuleSetupWizardBaseStepProps {
+export interface ModuleSetupWizardMaybePipetteStepProps extends ModuleSetupWizardBaseStepProps {
   attachedPipette: PipetteInformation | null
 }
 

--- a/app/src/organisms/ODD/QuickTransferFlow/Aspirate/AspirateSettingDetail.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/Aspirate/AspirateSettingDetail.tsx
@@ -25,8 +25,10 @@ interface CommonSettingProps {
   isMultiTransfer: boolean
 }
 
-interface SettingComponentProps
-  extends Omit<CommonSettingProps, 'isMultiTransfer'> {}
+interface SettingComponentProps extends Omit<
+  CommonSettingProps,
+  'isMultiTransfer'
+> {}
 
 interface AspirateSettingDetailProps extends Omit<CommonSettingProps, 'kind'> {
   selectedSetting: AspirateSettingOption | null

--- a/app/src/organisms/ODD/QuickTransferFlow/Dispense/DispenseSettingDetail.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/Dispense/DispenseSettingDetail.tsx
@@ -26,8 +26,10 @@ interface CommonSettingProps {
   isMultiTransfer: boolean
 }
 
-interface SettingComponentProps
-  extends Omit<CommonSettingProps, 'isMultiTransfer'> {}
+interface SettingComponentProps extends Omit<
+  CommonSettingProps,
+  'isMultiTransfer'
+> {}
 
 interface DispenseSettingDetailProps extends Omit<CommonSettingProps, 'kind'> {
   selectedSetting: DispenseSettingOption | null

--- a/app/src/redux/protocol-runs/selectors/lpc/labware/offsets.ts
+++ b/app/src/redux/protocol-runs/selectors/lpc/labware/offsets.ts
@@ -70,8 +70,7 @@ export const selectInitialDatabaseOffsets = (
     loadedOffsets => loadedOffsets ?? []
   )
 
-export interface LocationSpecificOffsetDetailsWithCopy
-  extends LocationSpecificOffsetDetails {
+export interface LocationSpecificOffsetDetailsWithCopy extends LocationSpecificOffsetDetails {
   slotCopy: string
 }
 

--- a/app/src/redux/protocol-runs/types/lpc/offsets.ts
+++ b/app/src/redux/protocol-runs/types/lpc/offsets.ts
@@ -71,16 +71,14 @@ export type OffsetLocationDetails =
   | DefaultOffsetLocationDetails
   | LocationSpecificOffsetLocationDetails
 
-export interface DefaultOffsetLocationDetails
-  extends BaseOffsetLocationDetails {
+export interface DefaultOffsetLocationDetails extends BaseOffsetLocationDetails {
   addressableAreaName: FlexAddressableAreaName
   kind: 'default'
   lwOffsetLocSeq: typeof ANY_LOCATION
   hardCodedOffsetId?: undefined
 }
 
-export interface LocationSpecificOffsetLocationDetails
-  extends BaseOffsetLocationDetails {
+export interface LocationSpecificOffsetLocationDetails extends BaseOffsetLocationDetails {
   addressableAreaName: FlexAddressableAreaName
   kind: 'location-specific'
   lwOffsetLocSeq: LabwareOffsetLocationSequence

--- a/app/src/redux/sessions/calibration-check/types.ts
+++ b/app/src/redux/sessions/calibration-check/types.ts
@@ -73,8 +73,7 @@ type CalibrationCheckComparisonByStep = Record<
   RobotCalibrationCheckStep,
   CalibrationCheckComparison
 >
-export interface CalibrationCheckComparisonMap
-  extends CalibrationCheckComparisonByStep {
+export interface CalibrationCheckComparisonMap extends CalibrationCheckComparisonByStep {
   status: RobotCalibrationCheckStatus
 }
 

--- a/app/src/redux/sessions/types.ts
+++ b/app/src/redux/sessions/types.ts
@@ -112,23 +112,19 @@ export type SessionResponseAttributes =
   | DeckCalibrationSessionResponseAttributes
   | PipetteOffsetCalibrationSessionResponseAttributes
 
-export interface CalibrationCheckSession
-  extends CalibrationCheckSessionResponseAttributes {
+export interface CalibrationCheckSession extends CalibrationCheckSessionResponseAttributes {
   id: string
 }
 
-export interface TipLengthCalibrationSession
-  extends TipLengthCalibrationSessionResponseAttributes {
+export interface TipLengthCalibrationSession extends TipLengthCalibrationSessionResponseAttributes {
   id: string
 }
 
-export interface DeckCalibrationSession
-  extends DeckCalibrationSessionResponseAttributes {
+export interface DeckCalibrationSession extends DeckCalibrationSessionResponseAttributes {
   id: string
 }
 
-export interface PipetteOffsetCalibrationSession
-  extends PipetteOffsetCalibrationSessionResponseAttributes {
+export interface PipetteOffsetCalibrationSession extends PipetteOffsetCalibrationSessionResponseAttributes {
   id: string
 }
 

--- a/app/src/resources/deck_configuration/utils.ts
+++ b/app/src/resources/deck_configuration/utils.ts
@@ -65,8 +65,7 @@ function isMatchedFixture(
   )
 }
 
-interface CutoutConfigAndCompatibilityWithPartial
-  extends CutoutConfigAndCompatibility {
+interface CutoutConfigAndCompatibilityWithPartial extends CutoutConfigAndCompatibility {
   partialRequiredCutoutFixtureId?: CutoutFixtureId
 }
 

--- a/app/src/resources/useNotifyDataReady.ts
+++ b/app/src/resources/useNotifyDataReady.ts
@@ -17,8 +17,10 @@ import type { NotifyResponseData, NotifyTopic } from '/app/redux/shell/types'
 
 export type HTTPRefetchFrequency = 'once' | null
 
-export interface QueryOptionsWithPolling<TData, TError = Error>
-  extends UseQueryOptions<TData, TError> {
+export interface QueryOptionsWithPolling<
+  TData,
+  TError = Error,
+> extends UseQueryOptions<TData, TError> {
   forceHttpPolling?: boolean
 }
 

--- a/components/src/atoms/ListTable/ListTable.stories.tsx
+++ b/components/src/atoms/ListTable/ListTable.stories.tsx
@@ -28,8 +28,9 @@ export default {
   parameters: VIEWPORT.touchScreenViewport,
 } as Meta
 
-interface ListTableStoryProps
-  extends ComponentProps<typeof ListTableComponent> {
+interface ListTableStoryProps extends ComponentProps<
+  typeof ListTableComponent
+> {
   tagCount: number
 }
 

--- a/components/src/atoms/SubListTable/SubListTable.stories.tsx
+++ b/components/src/atoms/SubListTable/SubListTable.stories.tsx
@@ -28,8 +28,9 @@ export default {
   parameters: VIEWPORT.touchScreenViewport,
 } as Meta
 
-interface SubListTableStoryProps
-  extends ComponentProps<typeof SubListTableComponent> {
+interface SubListTableStoryProps extends ComponentProps<
+  typeof SubListTableComponent
+> {
   tagCount: number
 }
 

--- a/components/src/modals/SpinnerModalPage.tsx
+++ b/components/src/modals/SpinnerModalPage.tsx
@@ -7,8 +7,9 @@ import type { ComponentProps } from 'react'
 import type { TitleBarProps } from '../structure'
 
 // TODO(mc, 2018-06-20): s/titleBar/titleBarProps
-export interface SpinnerModalPageProps
-  extends ComponentProps<typeof SpinnerModal> {
+export interface SpinnerModalPageProps extends ComponentProps<
+  typeof SpinnerModal
+> {
   /** Props for title bar at top of modal page */
   titleBar: TitleBarProps
 }

--- a/components/src/molecules/ListAccordion/ListAccordion.stories.tsx
+++ b/components/src/molecules/ListAccordion/ListAccordion.stories.tsx
@@ -46,11 +46,10 @@ export default {
   parameters: VIEWPORT.touchScreenViewport,
 } as Meta
 
-interface ListAccordionStoryProps
-  extends Omit<
-    ComponentProps<typeof ListAccordionComponent>,
-    'headerChild' | 'children'
-  > {
+interface ListAccordionStoryProps extends Omit<
+  ComponentProps<typeof ListAccordionComponent>,
+  'headerChild' | 'children'
+> {
   tagCount: number
   headerText: string
 }

--- a/components/src/molecules/TextListTableContent/TextListTableContent.stories.tsx
+++ b/components/src/molecules/TextListTableContent/TextListTableContent.stories.tsx
@@ -29,11 +29,10 @@ export default {
   parameters: VIEWPORT.touchScreenViewport,
 } as Meta
 
-interface TextListTableContentStoryProps
-  extends Omit<
-    ComponentProps<typeof TextListTableContentComponent>,
-    'children'
-  > {
+interface TextListTableContentStoryProps extends Omit<
+  ComponentProps<typeof TextListTableContentComponent>,
+  'children'
+> {
   rowCount: number
 }
 

--- a/components/src/organisms/CommandText/useCommandTextString/utils/getLabwareDisplayLocation.tsx
+++ b/components/src/organisms/CommandText/useCommandTextString/utils/getLabwareDisplayLocation.tsx
@@ -26,15 +26,19 @@ import type {
   LocationSlotOnlyParams,
 } from './getLabwareLocation'
 
-export interface DisplayLocationSlotOnlyParams
-  extends Omit<LocationSlotOnlyParams, 'location'> {
+export interface DisplayLocationSlotOnlyParams extends Omit<
+  LocationSlotOnlyParams,
+  'location'
+> {
   t: TFunction
   isOnDevice?: boolean
   includeSlotText?: boolean
   location?: LabwareLocation | LabwareLocationSequence | null
 }
-export interface DisplayLocationFullParams
-  extends Omit<LocationFullParams, 'location'> {
+export interface DisplayLocationFullParams extends Omit<
+  LocationFullParams,
+  'location'
+> {
   t: TFunction
   isOnDevice?: boolean
   includeSlotText?: boolean

--- a/components/src/primitives/types.ts
+++ b/components/src/primitives/types.ts
@@ -104,7 +104,8 @@ export interface TransitionProps {
 }
 
 export interface StyleProps
-  extends ColorProps,
+  extends
+    ColorProps,
     TypographyProps,
     SpacingProps,
     BorderProps,

--- a/components/src/tooltips/types.ts
+++ b/components/src/tooltips/types.ts
@@ -62,8 +62,7 @@ export type UseHoverTooltipOptions = Partial<
 >
 
 export interface UseHoverTooltipTargetProps
-  extends UseTooltipResultTargetProps,
-    HoverHandlers {}
+  extends UseTooltipResultTargetProps, HoverHandlers {}
 
 export type UseHoverTooltipResult = [
   UseHoverTooltipTargetProps,

--- a/labware-library/src/labware-creator/index.tsx
+++ b/labware-library/src/labware-creator/index.tsx
@@ -448,15 +448,15 @@ export const LabwareCreator = (props: LabwareCreatorProps): JSX.Element => {
           // TODO (ka 2019-8-27): factor out this as sub-schema from Yup schema and use it to validate instead of repeating the logic
           const canProceedToForm = Boolean(
             values.labwareType === 'wellPlate' ||
-              values.labwareType === 'reservoir' ||
-              values.labwareType === 'tipRack' ||
-              (values.labwareType === 'tubeRack' &&
-                values.tubeRackInsertLoadName) ||
-              (values.labwareType === 'aluminumBlock' &&
-                values.aluminumBlockType === '24well') ||
-              (values.labwareType === 'aluminumBlock' &&
-                values.aluminumBlockType === '96well' &&
-                values.aluminumBlockChildType)
+            values.labwareType === 'reservoir' ||
+            values.labwareType === 'tipRack' ||
+            (values.labwareType === 'tubeRack' &&
+              values.tubeRackInsertLoadName) ||
+            (values.labwareType === 'aluminumBlock' &&
+              values.aluminumBlockType === '24well') ||
+            (values.labwareType === 'aluminumBlock' &&
+              values.aluminumBlockType === '96well' &&
+              values.aluminumBlockChildType)
           )
 
           const labwareTypeChildFields = (

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "ntee": "^2.0.0",
     "optimize-css-assets-webpack-plugin": "^5.0.3",
     "portfinder": "^1.0.13",
-    "prettier": "3.6.2",
+    "prettier": "3.7.0",
     "react": "18.2.0",
     "react-docgen-typescript": "^1.21.0",
     "react-dom": "18.2.0",

--- a/protocol-designer/src/components/organisms/AssignLiquidsModal/LiquidToolbox.tsx
+++ b/protocol-designer/src/components/organisms/AssignLiquidsModal/LiquidToolbox.tsx
@@ -125,10 +125,10 @@ function LiquidToolbox({
 
   const selectionHasLiquids = Boolean(
     labwareId != null &&
-      liquidLocations[labwareId] != null &&
-      Object.keys(selectedWellGroups).some(
-        well => liquidLocations[labwareId][well]
-      )
+    liquidLocations[labwareId] != null &&
+    Object.keys(selectedWellGroups).some(
+      well => liquidLocations[labwareId][well]
+    )
   )
 
   const getInitialValues: () => ValidFormValues = () => {

--- a/protocol-designer/src/step-forms/reducers/index.ts
+++ b/protocol-designer/src/step-forms/reducers/index.ts
@@ -873,8 +873,8 @@ export const savedStepForms = (
         const prevStepForm = savedStepForms[stepId]
         const shouldSubstitute = Boolean(
           prevStepForm && // pristine forms will not exist in savedStepForms
-            prevStepForm.pipette &&
-            prevStepForm.pipette in substitutionMap
+          prevStepForm.pipette &&
+          prevStepForm.pipette in substitutionMap
         )
         if (!shouldSubstitute) return acc
         const updatedFields = handleFormChange(

--- a/shared-data/command/types/annotation.ts
+++ b/shared-data/command/types/annotation.ts
@@ -12,8 +12,7 @@ export interface CommentCreateCommand extends CommonCommandCreateInfo {
 }
 
 export interface CommentRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    CommentCreateCommand {
+  extends CommonCommandRunTimeInfo, CommentCreateCommand {
   result?: any
 }
 
@@ -27,8 +26,7 @@ export interface CustomCreateCommand extends CommonCommandCreateInfo {
 }
 
 export interface CustomRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    CustomCreateCommand {
+  extends CommonCommandRunTimeInfo, CustomCreateCommand {
   result?: any
 }
 

--- a/shared-data/command/types/calibration.ts
+++ b/shared-data/command/types/calibration.ts
@@ -19,30 +19,25 @@ export interface CalibrateModuleCreateCommand extends CommonCommandCreateInfo {
   commandType: 'calibration/calibrateModule'
   params: CalibrateModuleParams
 }
-export interface MoveToMaintenancePositionCreateCommand
-  extends CommonCommandCreateInfo {
+export interface MoveToMaintenancePositionCreateCommand extends CommonCommandCreateInfo {
   commandType: 'calibration/moveToMaintenancePosition'
   params: MoveToMaintenancePositionParams
 }
 
 export interface CalibratePipetteRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    CalibratePipetteCreateCommand {
+  extends CommonCommandRunTimeInfo, CalibratePipetteCreateCommand {
   result?: CalibratePipetteResult
 }
 export interface CalibrateGripperRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    CalibrateGripperCreateCommand {
+  extends CommonCommandRunTimeInfo, CalibrateGripperCreateCommand {
   result?: CalibrateGripperResult
 }
 export interface CalibrateModuleRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    CalibrateModuleCreateCommand {
+  extends CommonCommandRunTimeInfo, CalibrateModuleCreateCommand {
   result?: CalibrateModuleResult
 }
 export interface MoveToMaintenancePositionRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    MoveToMaintenancePositionCreateCommand {
+  extends CommonCommandRunTimeInfo, MoveToMaintenancePositionCreateCommand {
   result?: {}
 }
 

--- a/shared-data/command/types/concurrent.ts
+++ b/shared-data/command/types/concurrent.ts
@@ -22,8 +22,7 @@ export interface CreateTimerResult {
 }
 
 export interface CreateTimerRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    CreateTimerCreateCommand {
+  extends CommonCommandRunTimeInfo, CreateTimerCreateCommand {
   result?: CreateTimerResult | null
 }
 
@@ -41,7 +40,6 @@ export interface WaitForTasksResult {
 }
 
 export interface WaitForTasksRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    WaitForTasksCreateCommand {
+  extends CommonCommandRunTimeInfo, WaitForTasksCreateCommand {
   result?: WaitForTasksResult | null
 }

--- a/shared-data/command/types/devices.ts
+++ b/shared-data/command/types/devices.ts
@@ -25,8 +25,7 @@ export interface CaptureImageCreateCommand extends CommonCommandCreateInfo {
 }
 
 export interface CaptureImageRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    CaptureImageCreateCommand {
+  extends CommonCommandRunTimeInfo, CaptureImageCreateCommand {
   // eslint-disable-next-line @typescript-eslint/ban-types
   result?: {} // Returns an empty object currently.
 }

--- a/shared-data/command/types/gantry.ts
+++ b/shared-data/command/types/gantry.ts
@@ -13,8 +13,7 @@ export interface MoveToSlotCreateCommand extends CommonCommandCreateInfo {
   params: MoveToSlotParams
 }
 export interface MoveToSlotRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    MoveToSlotCreateCommand {
+  extends CommonCommandRunTimeInfo, MoveToSlotCreateCommand {
   result?: {}
 }
 export interface MoveToWellCreateCommand extends CommonCommandCreateInfo {
@@ -22,18 +21,15 @@ export interface MoveToWellCreateCommand extends CommonCommandCreateInfo {
   params: MoveToWellParams
 }
 export interface MoveToWellRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    MoveToWellCreateCommand {
+  extends CommonCommandRunTimeInfo, MoveToWellCreateCommand {
   result?: {}
 }
-export interface MoveToCoordinatesCreateCommand
-  extends CommonCommandCreateInfo {
+export interface MoveToCoordinatesCreateCommand extends CommonCommandCreateInfo {
   commandType: 'moveToCoordinates'
   params: MoveToCoordinatesParams
 }
 export interface MoveToCoordinatesRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    MoveToCoordinatesCreateCommand {
+  extends CommonCommandRunTimeInfo, MoveToCoordinatesCreateCommand {
   result?: {}
 }
 export interface MoveRelativeCreateCommand extends CommonCommandCreateInfo {
@@ -41,8 +37,7 @@ export interface MoveRelativeCreateCommand extends CommonCommandCreateInfo {
   params: MoveRelativeParams
 }
 export interface MoveRelativeRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    MoveRelativeCreateCommand {
+  extends CommonCommandRunTimeInfo, MoveRelativeCreateCommand {
   result?: {
     position: Vector3D
   }
@@ -52,8 +47,7 @@ export interface SavePositionCreateCommand extends CommonCommandCreateInfo {
   params: SavePositionParams
 }
 export interface SavePositionRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    SavePositionCreateCommand {
+  extends CommonCommandRunTimeInfo, SavePositionCreateCommand {
   result?: {
     positionId: string
     position: Vector3D
@@ -64,8 +58,7 @@ export interface HomeCreateCommand extends CommonCommandCreateInfo {
   params: HomeParams
 }
 export interface HomeRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    HomeCreateCommand {
+  extends CommonCommandRunTimeInfo, HomeCreateCommand {
   result?: {}
 }
 
@@ -74,19 +67,16 @@ export interface RetractAxisCreateCommand extends CommonCommandCreateInfo {
   params: RetractAxisParams
 }
 export interface RetractAxisRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    RetractAxisCreateCommand {
+  extends CommonCommandRunTimeInfo, RetractAxisCreateCommand {
   result?: {}
 }
 
-export interface MoveToAddressableAreaCreateCommand
-  extends CommonCommandCreateInfo {
+export interface MoveToAddressableAreaCreateCommand extends CommonCommandCreateInfo {
   commandType: 'moveToAddressableArea'
   params: MoveToAddressableAreaParams
 }
 export interface MoveToAddressableAreaRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    MoveToAddressableAreaCreateCommand {
+  extends CommonCommandRunTimeInfo, MoveToAddressableAreaCreateCommand {
   //  TODO(jr, 11/6/23): add to result type
   result?: {}
 }

--- a/shared-data/command/types/incidental.ts
+++ b/shared-data/command/types/incidental.ts
@@ -15,8 +15,7 @@ export interface SetStatusBarCreateCommand extends CommonCommandCreateInfo {
 }
 
 export interface SetStatusBarRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    SetStatusBarCreateCommand {
+  extends CommonCommandRunTimeInfo, SetStatusBarCreateCommand {
   result?: any
 }
 
@@ -30,8 +29,7 @@ export interface SetRailLightsCreateCommand extends CommonCommandCreateInfo {
 }
 
 export interface SetRailLightsRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    SetRailLightsCreateCommand {
+  extends CommonCommandRunTimeInfo, SetRailLightsCreateCommand {
   result?: any
 }
 

--- a/shared-data/command/types/index.ts
+++ b/shared-data/command/types/index.ts
@@ -137,8 +137,7 @@ export interface RunCommandErrorOverpressure extends RunCommandErrorBase {
   errorInfo: { retryLocation: [number, number, number] }
 }
 
-export interface RunCommandErrorTipPhysicallyAttached
-  extends RunCommandErrorBase {
+export interface RunCommandErrorTipPhysicallyAttached extends RunCommandErrorBase {
   errorCode: '3004'
   errorType: 'tipPhysicallyAttached'
   isDefined: true
@@ -152,32 +151,28 @@ export interface RunCommandErrorFlexStackerStall extends RunCommandErrorBase {
   errorInfo: { labwareId?: string }
 }
 
-export interface RunCommandErrorFlexStackerShuttleMissing
-  extends RunCommandErrorBase {
+export interface RunCommandErrorFlexStackerShuttleMissing extends RunCommandErrorBase {
   errorCode: '3020'
   errorType: 'flexStackerShuttleMissing'
   isDefined: true
   errorInfo: { labwareId?: string }
 }
 
-export interface RunCommandErrorFlexStackerShuttleLabware
-  extends RunCommandErrorBase {
+export interface RunCommandErrorFlexStackerShuttleLabware extends RunCommandErrorBase {
   errorCode: '3021'
   errorType: 'flexStackerLabwareRetrieveFailed'
   isDefined: true
   errorInfo: { labwareId?: string }
 }
 
-export interface RunCommandErrorFlexStackerHopperLabware
-  extends RunCommandErrorBase {
+export interface RunCommandErrorFlexStackerHopperLabware extends RunCommandErrorBase {
   errorCode: '3022'
   errorType: 'flexStackerHopperLabwareFailed'
   isDefined: true
   errorInfo: { labwareId?: string }
 }
 
-export interface RunCommandErrorFlexStackerShuttleOccupied
-  extends RunCommandErrorBase {
+export interface RunCommandErrorFlexStackerShuttleOccupied extends RunCommandErrorBase {
   errorCode: '3023'
   errorType: 'flexStackerShuttleOccupied'
   isDefined: true

--- a/shared-data/command/types/module.ts
+++ b/shared-data/command/types/module.ts
@@ -87,44 +87,38 @@ export type ModuleCreateCommand =
   | FlexStackerStoreCreateCommand
   | IdentifyModuleCreateCommand
 
-export interface MagneticModuleEngageMagnetCreateCommand
-  extends CommonCommandCreateInfo {
+export interface MagneticModuleEngageMagnetCreateCommand extends CommonCommandCreateInfo {
   commandType: 'magneticModule/engage'
   params: EngageMagnetParams
 }
 export interface MagneticModuleEngageMagnetRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    MagneticModuleEngageMagnetCreateCommand {
+  extends CommonCommandRunTimeInfo, MagneticModuleEngageMagnetCreateCommand {
   result?: any
 }
-export interface MagneticModuleDisengageCreateCommand
-  extends CommonCommandCreateInfo {
+export interface MagneticModuleDisengageCreateCommand extends CommonCommandCreateInfo {
   commandType: 'magneticModule/disengage'
   params: ModuleOnlyParams
 }
 export interface MagneticModuleDisengageRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    MagneticModuleDisengageCreateCommand {
+  extends CommonCommandRunTimeInfo, MagneticModuleDisengageCreateCommand {
   result?: any
 }
-export interface TemperatureModuleSetTargetTemperatureCreateCommand
-  extends CommonCommandCreateInfo {
+export interface TemperatureModuleSetTargetTemperatureCreateCommand extends CommonCommandCreateInfo {
   commandType: 'temperatureModule/setTargetTemperature'
   params: TemperatureParams
 }
 export interface TemperatureModuleSetTargetTemperatureRunTimeCommand
-  extends CommonCommandRunTimeInfo,
+  extends
+    CommonCommandRunTimeInfo,
     TemperatureModuleSetTargetTemperatureCreateCommand {
   result?: any
 }
-export interface TemperatureModuleDeactivateCreateCommand
-  extends CommonCommandCreateInfo {
+export interface TemperatureModuleDeactivateCreateCommand extends CommonCommandCreateInfo {
   commandType: 'temperatureModule/deactivate'
   params: ModuleOnlyParams
 }
 export interface TemperatureModuleDeactivateRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    TemperatureModuleDeactivateCreateCommand {
+  extends CommonCommandRunTimeInfo, TemperatureModuleDeactivateCreateCommand {
   result?: any
 }
 export interface TemperatureModuleAwaitTemperatureParams {
@@ -132,56 +126,48 @@ export interface TemperatureModuleAwaitTemperatureParams {
   moduleId: string
   celsius?: number
 }
-export interface TemperatureModuleAwaitTemperatureCreateCommand
-  extends CommonCommandCreateInfo {
+export interface TemperatureModuleAwaitTemperatureCreateCommand extends CommonCommandCreateInfo {
   commandType: 'temperatureModule/waitForTemperature'
   params: TemperatureModuleAwaitTemperatureParams
 }
 export interface TemperatureModuleAwaitTemperatureRunTimeCommand
-  extends CommonCommandRunTimeInfo,
+  extends
+    CommonCommandRunTimeInfo,
     TemperatureModuleAwaitTemperatureCreateCommand {
   result?: any
 }
-export interface TCSetTargetBlockTemperatureCreateCommand
-  extends CommonCommandCreateInfo {
+export interface TCSetTargetBlockTemperatureCreateCommand extends CommonCommandCreateInfo {
   commandType: 'thermocycler/setTargetBlockTemperature'
   params: ThermocyclerSetTargetBlockTemperatureParams
 }
 export interface TCSetTargetBlockTemperatureRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    TCSetTargetBlockTemperatureCreateCommand {
+  extends CommonCommandRunTimeInfo, TCSetTargetBlockTemperatureCreateCommand {
   result?: any
 }
 
-export interface TCSetTargetLidTemperatureCreateCommand
-  extends CommonCommandCreateInfo {
+export interface TCSetTargetLidTemperatureCreateCommand extends CommonCommandCreateInfo {
   commandType: 'thermocycler/setTargetLidTemperature'
   params: TemperatureParams
 }
 export interface TCSetTargetLidTemperatureRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    TCSetTargetLidTemperatureCreateCommand {
+  extends CommonCommandRunTimeInfo, TCSetTargetLidTemperatureCreateCommand {
   result?: any
 }
 
-export interface TCWaitForBlockTemperatureCreateCommand
-  extends CommonCommandCreateInfo {
+export interface TCWaitForBlockTemperatureCreateCommand extends CommonCommandCreateInfo {
   commandType: 'thermocycler/waitForBlockTemperature'
   params: ModuleOnlyParams
 }
 export interface TCWaitForBlockTemperatureRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    TCWaitForBlockTemperatureCreateCommand {
+  extends CommonCommandRunTimeInfo, TCWaitForBlockTemperatureCreateCommand {
   result?: any
 }
-export interface TCWaitForLidTemperatureCreateCommand
-  extends CommonCommandCreateInfo {
+export interface TCWaitForLidTemperatureCreateCommand extends CommonCommandCreateInfo {
   commandType: 'thermocycler/waitForLidTemperature'
   params: ModuleOnlyParams
 }
 export interface TCWaitForLidTemperatureRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    TCWaitForLidTemperatureCreateCommand {
+  extends CommonCommandRunTimeInfo, TCWaitForLidTemperatureCreateCommand {
   result?: any
 }
 export interface TCOpenLidCreateCommand extends CommonCommandCreateInfo {
@@ -189,8 +175,7 @@ export interface TCOpenLidCreateCommand extends CommonCommandCreateInfo {
   params: ModuleOnlyParams
 }
 export interface TCOpenLidRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    TCOpenLidCreateCommand {
+  extends CommonCommandRunTimeInfo, TCOpenLidCreateCommand {
   result?: any
 }
 export interface TCCloseLidCreateCommand extends CommonCommandCreateInfo {
@@ -198,18 +183,15 @@ export interface TCCloseLidCreateCommand extends CommonCommandCreateInfo {
   params: ModuleOnlyParams
 }
 export interface TCCloseLidRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    TCCloseLidCreateCommand {
+  extends CommonCommandRunTimeInfo, TCCloseLidCreateCommand {
   result?: any
 }
-export interface TCDeactivateBlockCreateCommand
-  extends CommonCommandCreateInfo {
+export interface TCDeactivateBlockCreateCommand extends CommonCommandCreateInfo {
   commandType: 'thermocycler/deactivateBlock'
   params: ModuleOnlyParams
 }
 export interface TCDeactivateBlockRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    TCDeactivateBlockCreateCommand {
+  extends CommonCommandRunTimeInfo, TCDeactivateBlockCreateCommand {
   result?: any
 }
 export interface TCDeactivateLidCreateCommand extends CommonCommandCreateInfo {
@@ -217,8 +199,7 @@ export interface TCDeactivateLidCreateCommand extends CommonCommandCreateInfo {
   params: ModuleOnlyParams
 }
 export interface TCDeactivateLidRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    TCDeactivateLidCreateCommand {
+  extends CommonCommandRunTimeInfo, TCDeactivateLidCreateCommand {
   result?: any
 }
 export interface TCRunProfileCreateCommand extends CommonCommandCreateInfo {
@@ -226,157 +207,132 @@ export interface TCRunProfileCreateCommand extends CommonCommandCreateInfo {
   params: TCProfileParams
 }
 export interface TCRunProfileRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    TCRunProfileCreateCommand {
+  extends CommonCommandRunTimeInfo, TCRunProfileCreateCommand {
   result?: any
 }
-export interface TCStartRunExtendedProfileCreateCommand
-  extends CommonCommandCreateInfo {
+export interface TCStartRunExtendedProfileCreateCommand extends CommonCommandCreateInfo {
   commandType: 'thermocycler/startRunExtendedProfile'
   params: TCExtendedProfileParams
 }
 export interface TCStartRunExtendedProfileRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    TCStartRunExtendedProfileCreateCommand {
+  extends CommonCommandRunTimeInfo, TCStartRunExtendedProfileCreateCommand {
   result?: any
 }
-export interface TCRunExtendedProfileCreateCommand
-  extends CommonCommandCreateInfo {
+export interface TCRunExtendedProfileCreateCommand extends CommonCommandCreateInfo {
   commandType: 'thermocycler/runExtendedProfile'
   params: TCExtendedProfileParams
 }
 export interface TCRunExtendedProfileRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    TCRunExtendedProfileCreateCommand {
+  extends CommonCommandRunTimeInfo, TCRunExtendedProfileCreateCommand {
   result?: any
 }
-export interface TCAwaitProfileCompleteCreateCommand
-  extends CommonCommandCreateInfo {
+export interface TCAwaitProfileCompleteCreateCommand extends CommonCommandCreateInfo {
   commandType: 'thermocycler/awaitProfileComplete'
   params: ModuleOnlyParams
 }
 export interface TCAwaitProfileCompleteRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    TCAwaitProfileCompleteCreateCommand {
+  extends CommonCommandRunTimeInfo, TCAwaitProfileCompleteCreateCommand {
   result?: any
 }
-export interface HeaterShakerSetTargetTemperatureCreateCommand
-  extends CommonCommandCreateInfo {
+export interface HeaterShakerSetTargetTemperatureCreateCommand extends CommonCommandCreateInfo {
   commandType: 'heaterShaker/setTargetTemperature'
   params: TemperatureParams
 }
 export interface HeaterShakerSetTargetTemperatureRunTimeCommand
-  extends CommonCommandRunTimeInfo,
+  extends
+    CommonCommandRunTimeInfo,
     HeaterShakerSetTargetTemperatureCreateCommand {
   result?: any
 }
-export interface HeaterShakerWaitForTemperatureCreateCommand
-  extends CommonCommandCreateInfo {
+export interface HeaterShakerWaitForTemperatureCreateCommand extends CommonCommandCreateInfo {
   commandType: 'heaterShaker/waitForTemperature'
   params: ModuleOnlyParams
 }
 export interface HeaterShakerWaitForTemperatureRunTimeCommand
-  extends CommonCommandRunTimeInfo,
+  extends
+    CommonCommandRunTimeInfo,
     HeaterShakerWaitForTemperatureCreateCommand {
   result?: any
 }
-export interface HeaterShakerSetAndWaitForShakeSpeedCreateCommand
-  extends CommonCommandCreateInfo {
+export interface HeaterShakerSetAndWaitForShakeSpeedCreateCommand extends CommonCommandCreateInfo {
   commandType: 'heaterShaker/setAndWaitForShakeSpeed'
   params: ShakeSpeedParams
 }
 export interface HeaterShakerSetAndWaitForShakeSpeedRunTimeCommand
-  extends CommonCommandRunTimeInfo,
+  extends
+    CommonCommandRunTimeInfo,
     HeaterShakerSetAndWaitForShakeSpeedCreateCommand {
   result?: any
 }
-export interface HeaterShakerSetShakeSpeedCreateCommand
-  extends CommonCommandCreateInfo {
+export interface HeaterShakerSetShakeSpeedCreateCommand extends CommonCommandCreateInfo {
   commandType: 'heaterShaker/setShakeSpeed'
   params: ShakeSpeedParams
 }
 export interface HeaterShakerSetShakeSpeedRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    HeaterShakerSetShakeSpeedCreateCommand {
+  extends CommonCommandRunTimeInfo, HeaterShakerSetShakeSpeedCreateCommand {
   result?: any
 }
-export interface HeaterShakerDeactivateHeaterCreateCommand
-  extends CommonCommandCreateInfo {
+export interface HeaterShakerDeactivateHeaterCreateCommand extends CommonCommandCreateInfo {
   commandType: 'heaterShaker/deactivateHeater'
   params: ModuleOnlyParams
 }
 export interface HeaterShakerDeactivateHeaterRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    HeaterShakerDeactivateHeaterCreateCommand {
+  extends CommonCommandRunTimeInfo, HeaterShakerDeactivateHeaterCreateCommand {
   result?: any
 }
-export interface HeaterShakerOpenLatchCreateCommand
-  extends CommonCommandCreateInfo {
+export interface HeaterShakerOpenLatchCreateCommand extends CommonCommandCreateInfo {
   commandType: 'heaterShaker/openLabwareLatch'
   params: ModuleOnlyParams
 }
 export interface HeaterShakerOpenLatchRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    HeaterShakerOpenLatchCreateCommand {
+  extends CommonCommandRunTimeInfo, HeaterShakerOpenLatchCreateCommand {
   result?: any
 }
-export interface HeaterShakerCloseLatchCreateCommand
-  extends CommonCommandCreateInfo {
+export interface HeaterShakerCloseLatchCreateCommand extends CommonCommandCreateInfo {
   commandType: 'heaterShaker/closeLabwareLatch'
   params: ModuleOnlyParams
 }
 export interface HeaterShakerCloseLatchRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    HeaterShakerCloseLatchCreateCommand {
+  extends CommonCommandRunTimeInfo, HeaterShakerCloseLatchCreateCommand {
   result?: any
 }
-export interface HeaterShakerDeactivateShakerCreateCommand
-  extends CommonCommandCreateInfo {
+export interface HeaterShakerDeactivateShakerCreateCommand extends CommonCommandCreateInfo {
   commandType: 'heaterShaker/deactivateShaker'
   params: ModuleOnlyParams
 }
 export interface HeaterShakerDeactivateShakerRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    HeaterShakerDeactivateShakerCreateCommand {
+  extends CommonCommandRunTimeInfo, HeaterShakerDeactivateShakerCreateCommand {
   result?: any
 }
 export interface AbsorbanceReaderOpenLidRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    AbsorbanceReaderOpenLidCreateCommand {
+  extends CommonCommandRunTimeInfo, AbsorbanceReaderOpenLidCreateCommand {
   result?: any
 }
 export interface AbsorbanceReaderCloseLidRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    AbsorbanceReaderCloseLidCreateCommand {
+  extends CommonCommandRunTimeInfo, AbsorbanceReaderCloseLidCreateCommand {
   result?: any
 }
 export interface AbsorbanceReaderInitializeRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    AbsorbanceReaderInitializeCreateCommand {
+  extends CommonCommandRunTimeInfo, AbsorbanceReaderInitializeCreateCommand {
   result?: any
 }
 export interface AbsorbanceReaderReadRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    AbsorbanceReaderReadCreateCommand {
+  extends CommonCommandRunTimeInfo, AbsorbanceReaderReadCreateCommand {
   result?: any
 }
-export interface AbsorbanceReaderOpenLidCreateCommand
-  extends CommonCommandCreateInfo {
+export interface AbsorbanceReaderOpenLidCreateCommand extends CommonCommandCreateInfo {
   commandType: 'absorbanceReader/openLid'
   params: ModuleOnlyParams
 }
-export interface AbsorbanceReaderCloseLidCreateCommand
-  extends CommonCommandCreateInfo {
+export interface AbsorbanceReaderCloseLidCreateCommand extends CommonCommandCreateInfo {
   commandType: 'absorbanceReader/closeLid'
   params: ModuleOnlyParams
 }
-export interface AbsorbanceReaderInitializeCreateCommand
-  extends CommonCommandCreateInfo {
+export interface AbsorbanceReaderInitializeCreateCommand extends CommonCommandCreateInfo {
   commandType: 'absorbanceReader/initialize'
   params: AbsorbanceReaderInitializeParams
 }
-export interface AbsorbanceReaderReadCreateCommand
-  extends CommonCommandCreateInfo {
+export interface AbsorbanceReaderReadCreateCommand extends CommonCommandCreateInfo {
   commandType: 'absorbanceReader/read'
   params: { moduleId: string; fileName?: string | null }
 }
@@ -473,15 +429,13 @@ export interface FlexStackerSetStoredLabwareParams {
   adapterLabware: FlexStackerStoredLabwareDetails | null
 }
 
-export interface FlexStackerSetStoredLabwareCreateCommand
-  extends CommonCommandCreateInfo {
+export interface FlexStackerSetStoredLabwareCreateCommand extends CommonCommandCreateInfo {
   commandType: 'flexStacker/setStoredLabware'
   params: FlexStackerSetStoredLabwareParams
 }
 
 export interface FlexStackerSetStoredLabwareRunTimeCommand
-  extends FlexStackerSetStoredLabwareCreateCommand,
-    CommonCommandRunTimeInfo {
+  extends FlexStackerSetStoredLabwareCreateCommand, CommonCommandRunTimeInfo {
   result?: {
     primaryLabwareDefinition: LabwareDefinition
     lidLabwareDefinition?: LabwareDefinition | null
@@ -496,8 +450,7 @@ export interface FlexStackerSetStoredLabwareItemsParams {
   labware: string[]
   stackingOffsetZ?: number
 }
-export interface FlexStackerSetStoredLabwareItemsCreateCommand
-  extends CommonCommandCreateInfo {
+export interface FlexStackerSetStoredLabwareItemsCreateCommand extends CommonCommandCreateInfo {
   commandType: 'flexStacker/setStoredLabwareItems'
   params: FlexStackerSetStoredLabwareItemsParams
 }
@@ -511,14 +464,14 @@ interface FlexStackerSetStoredLabwareResults {
 }
 
 export interface FlexStackerSetStoredLabwareItemsRunTimeCommand
-  extends FlexStackerSetStoredLabwareItemsCreateCommand,
+  extends
+    FlexStackerSetStoredLabwareItemsCreateCommand,
     CommonCommandRunTimeInfo {
   result?: FlexStackerSetStoredLabwareResults &
     StackerStoredLabwareLocationSequences
 }
 
-export interface FlexStackerRetrieveCreateCommand
-  extends CommonCommandCreateInfo {
+export interface FlexStackerRetrieveCreateCommand extends CommonCommandCreateInfo {
   commandType: 'flexStacker/retrieve'
   params: {
     moduleId: string
@@ -552,15 +505,13 @@ export interface FlexStackerFillItemsParams {
   message?: string
 }
 
-export interface FlexStackerFillItemsCreateCommand
-  extends CommonCommandCreateInfo {
+export interface FlexStackerFillItemsCreateCommand extends CommonCommandCreateInfo {
   commandType: 'flexStacker/fillItems'
   params: FlexStackerFillItemsParams
 }
 
 export interface FlexStackerFillItemsRunTimeCommand
-  extends FlexStackerFillItemsCreateCommand,
-    CommonCommandRunTimeInfo {
+  extends FlexStackerFillItemsCreateCommand, CommonCommandRunTimeInfo {
   result?: {
     count: number
     storedLabware?: FlexStackerStoredLabwareGroup[] | null
@@ -581,8 +532,7 @@ export interface FlexStackerEmptyCreateCommand extends CommonCommandCreateInfo {
   params: FlexStackerEmptyParams
 }
 
-export interface FlexStackerPrepareShuttleCreateCommand
-  extends CommonCommandCreateInfo {
+export interface FlexStackerPrepareShuttleCreateCommand extends CommonCommandCreateInfo {
   commandType: 'flexStacker/prepareShuttle'
   params: {
     moduleId: string
@@ -641,7 +591,8 @@ interface RetrieveResultNoAdapter {
 }
 
 export interface FlexStackerRetrieveRunTimeCommand
-  extends FlexStackerRetrieveCreateCommand,
+  extends
+    FlexStackerRetrieveCreateCommand,
     CommonCommandRunTimeInfo<RunCommandFlexStackerError> {
   result?:
     | (RetrieveResultPrimary & RetrieveResultNoLid & RetrieveResultNoAdapter)
@@ -651,7 +602,8 @@ export interface FlexStackerRetrieveRunTimeCommand
 }
 
 export interface FlexStackerStoreRunTimeCommand
-  extends FlexStackerStoreCreateCommand,
+  extends
+    FlexStackerStoreCreateCommand,
     CommonCommandRunTimeInfo<RunCommandFlexStackerError> {
   result?: {
     eventualDestinationLocationSequence?: LabwareLocationSequence
@@ -665,8 +617,7 @@ export interface FlexStackerStoreRunTimeCommand
 }
 
 export interface FlexStackerFillRunTimeCommand
-  extends FlexStackerFillCreateCommand,
-    CommonCommandRunTimeInfo {
+  extends FlexStackerFillCreateCommand, CommonCommandRunTimeInfo {
   result?: {
     count: number
     storedLabware?: FlexStackerStoredLabwareGroup[] | null
@@ -676,8 +627,7 @@ export interface FlexStackerFillRunTimeCommand
 }
 
 export interface FlexStackerEmptyRunTimeCommand
-  extends FlexStackerEmptyCreateCommand,
-    CommonCommandRunTimeInfo {
+  extends FlexStackerEmptyCreateCommand, CommonCommandRunTimeInfo {
   result?: {
     count: number
     storedLabware?: FlexStackerStoredLabwareGroup[] | null
@@ -699,7 +649,6 @@ export interface IdentifyModuleCreateCommand extends CommonCommandCreateInfo {
 }
 
 export interface IdentifyModuleRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    IdentifyModuleCreateCommand {
+  extends CommonCommandRunTimeInfo, IdentifyModuleCreateCommand {
   result?: any
 }

--- a/shared-data/command/types/pipetting.ts
+++ b/shared-data/command/types/pipetting.ts
@@ -59,8 +59,7 @@ export type PipettingCreateCommand =
   | PipetteUnsealFromTipCreateCommand
   | PressureDispenseCreateCommand
 
-export interface ConfigureForVolumeCreateCommand
-  extends CommonCommandCreateInfo {
+export interface ConfigureForVolumeCreateCommand extends CommonCommandCreateInfo {
   commandType: 'configureForVolume'
   params: ConfigureForVolumeParams
 }
@@ -70,8 +69,7 @@ export interface ConfigureForVolumeParams {
   volume: number
 }
 export interface ConfigureForVolumeRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    ConfigureForVolumeCreateCommand {
+  extends CommonCommandRunTimeInfo, ConfigureForVolumeCreateCommand {
   result?: BasicLiquidHandlingResult
 }
 
@@ -87,8 +85,7 @@ export interface AirGapInPlaceCreateCommand extends CommonCommandCreateInfo {
 }
 
 export interface AirGapInPlaceRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    AirGapInPlaceCreateCommand {
+  extends CommonCommandRunTimeInfo, AirGapInPlaceCreateCommand {
   result?: BasicLiquidHandlingResult
 }
 
@@ -97,19 +94,16 @@ export interface AspirateCreateCommand extends CommonCommandCreateInfo {
   params: AspDispAirgapParams
 }
 export interface AspirateRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    AspirateCreateCommand {
+  extends CommonCommandRunTimeInfo, AspirateCreateCommand {
   result?: BasicLiquidHandlingResult
 }
 
-export interface AspirateWhileTrackingCreateCommand
-  extends CommonCommandCreateInfo {
+export interface AspirateWhileTrackingCreateCommand extends CommonCommandCreateInfo {
   commandType: 'aspirateWhileTracking'
   params: AspDispWhileTrackingParams
 }
 export interface AspirateWhileTrackingRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    AspirateWhileTrackingCreateCommand {
+  extends CommonCommandRunTimeInfo, AspirateWhileTrackingCreateCommand {
   result?: BasicLiquidHandlingResult
 }
 
@@ -118,8 +112,7 @@ export interface AspirateInPlaceCreateCommand extends CommonCommandCreateInfo {
   params: AspirateInPlaceParams
 }
 export interface AspirateInPlaceRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    AspirateInPlaceCreateCommand {
+  extends CommonCommandRunTimeInfo, AspirateInPlaceCreateCommand {
   result?: BasicLiquidHandlingResult
 }
 
@@ -129,8 +122,7 @@ export interface DispenseCreateCommand extends CommonCommandCreateInfo {
   params: DispenseParams
 }
 export interface DispenseRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    DispenseCreateCommand {
+  extends CommonCommandRunTimeInfo, DispenseCreateCommand {
   result?: BasicLiquidHandlingResult
 }
 
@@ -139,22 +131,19 @@ export interface DispenseInPlaceCreateCommand extends CommonCommandCreateInfo {
   params: DispenseInPlaceParams
 }
 export interface DispenseInPlaceRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    DispenseInPlaceCreateCommand {
+  extends CommonCommandRunTimeInfo, DispenseInPlaceCreateCommand {
   result?: BasicLiquidHandlingResult
 }
 
 export type DispenseWhileTrackingParams = AspDispWhileTrackingParams & {
   pushOut?: number
 }
-export interface DispenseWhileTrackingCreateCommand
-  extends CommonCommandCreateInfo {
+export interface DispenseWhileTrackingCreateCommand extends CommonCommandCreateInfo {
   commandType: 'dispenseWhileTracking'
   params: DispenseWhileTrackingParams
 }
 export interface DispenseWhileTrackingRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    DispenseWhileTrackingCreateCommand {
+  extends CommonCommandRunTimeInfo, DispenseWhileTrackingCreateCommand {
   result?: BasicLiquidHandlingResult
 }
 export interface BlowoutCreateCommand extends CommonCommandCreateInfo {
@@ -162,8 +151,7 @@ export interface BlowoutCreateCommand extends CommonCommandCreateInfo {
   params: BlowoutParams
 }
 export interface BlowoutRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    BlowoutCreateCommand {
+  extends CommonCommandRunTimeInfo, BlowoutCreateCommand {
   result?: BasicLiquidHandlingResult
 }
 
@@ -172,8 +160,7 @@ export interface BlowoutInPlaceCreateCommand extends CommonCommandCreateInfo {
   params: BlowoutInPlaceParams
 }
 export interface BlowoutInPlaceRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    BlowoutInPlaceCreateCommand {
+  extends CommonCommandRunTimeInfo, BlowoutInPlaceCreateCommand {
   result?: BasicLiquidHandlingResult
 }
 
@@ -182,8 +169,7 @@ export interface TouchTipCreateCommand extends CommonCommandCreateInfo {
   params: TouchTipParams
 }
 export interface TouchTipRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    TouchTipCreateCommand {
+  extends CommonCommandRunTimeInfo, TouchTipCreateCommand {
   result?: BasicLiquidHandlingResult
 }
 
@@ -192,8 +178,7 @@ export interface PickUpTipCreateCommand extends CommonCommandCreateInfo {
   params: PickUpTipParams
 }
 export interface PickUpTipRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    PickUpTipCreateCommand {
+  extends CommonCommandRunTimeInfo, PickUpTipCreateCommand {
   result?: any
 }
 
@@ -202,8 +187,7 @@ export interface DropTipCreateCommand extends CommonCommandCreateInfo {
   params: DropTipParams
 }
 export interface DropTipRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    DropTipCreateCommand {
+  extends CommonCommandRunTimeInfo, DropTipCreateCommand {
   result?: any
 }
 
@@ -212,30 +196,27 @@ export interface DropTipInPlaceCreateCommand extends CommonCommandCreateInfo {
   params: DropTipInPlaceParams
 }
 export interface DropTipInPlaceRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    DropTipInPlaceCreateCommand {
+  extends CommonCommandRunTimeInfo, DropTipInPlaceCreateCommand {
   result?: any
 }
 
-export interface MoveToAddressableAreaForDropTipCreateCommand
-  extends CommonCommandCreateInfo {
+export interface MoveToAddressableAreaForDropTipCreateCommand extends CommonCommandCreateInfo {
   commandType: 'moveToAddressableAreaForDropTip'
   params: MoveToAddressableAreaForDropTipParams
 }
 export interface MoveToAddressableAreaForDropTipRunTimeCommand
-  extends CommonCommandRunTimeInfo,
+  extends
+    CommonCommandRunTimeInfo,
     MoveToAddressableAreaForDropTipCreateCommand {
   result?: any
 }
 
-export interface PrepareToAspirateCreateCommand
-  extends CommonCommandCreateInfo {
+export interface PrepareToAspirateCreateCommand extends CommonCommandCreateInfo {
   commandType: 'prepareToAspirate'
   params: PipetteIdentityParams
 }
 export interface PrepareToAspirateRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    PrepareToAspirateCreateCommand {
+  extends CommonCommandRunTimeInfo, PrepareToAspirateCreateCommand {
   result?: any
 }
 
@@ -244,8 +225,7 @@ export interface GetTipPresenceCreateCommand extends CommonCommandCreateInfo {
   params: PipetteIdentityParams
 }
 export interface GetTipPresenceRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    GetTipPresenceCreateCommand {
+  extends CommonCommandRunTimeInfo, GetTipPresenceCreateCommand {
   result?: TipPresenceResult
 }
 
@@ -254,19 +234,16 @@ export interface GetNextTipCreateCommand extends CommonCommandCreateInfo {
   params: GetNextTipParams
 }
 export interface GetNextTipRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    GetNextTipCreateCommand {
+  extends CommonCommandRunTimeInfo, GetNextTipCreateCommand {
   result?: GetNextTipResult
 }
 
-export interface VerifyTipPresenceCreateCommand
-  extends CommonCommandCreateInfo {
+export interface VerifyTipPresenceCreateCommand extends CommonCommandCreateInfo {
   commandType: 'verifyTipPresence'
   params: VerifyTipPresenceParams
 }
 export interface VerifyTipPresenceRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    VerifyTipPresenceCreateCommand {
+  extends CommonCommandRunTimeInfo, VerifyTipPresenceCreateCommand {
   result?: any
 }
 
@@ -276,8 +253,7 @@ export interface LiquidProbeCreateCommand extends CommonCommandCreateInfo {
   params: LiquidProbeParams
 }
 export interface LiquidProbeRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    LiquidProbeCreateCommand {
+  extends CommonCommandRunTimeInfo, LiquidProbeCreateCommand {
   result?: Record<string, unknown>
 }
 
@@ -286,8 +262,7 @@ export interface TryLiquidProbeCreateCommand extends CommonCommandCreateInfo {
   params: WellLocationParam & PipetteAccessParams
 }
 export interface TryLiquidProbeRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    TryLiquidProbeCreateCommand {
+  extends CommonCommandRunTimeInfo, TryLiquidProbeCreateCommand {
   result?: Record<string, unknown>
 }
 
@@ -295,8 +270,7 @@ export interface PipetteSealToTipCreateCommand extends CommonCommandCreateInfo {
   commandType: 'sealPipetteToTip'
   params: PipetteAccessParams & WellLocationParam
 }
-export interface PipetteUnsealFromTipCreateCommand
-  extends CommonCommandCreateInfo {
+export interface PipetteUnsealFromTipCreateCommand extends CommonCommandCreateInfo {
   commandType: 'unsealPipetteFromTip'
   params: PipetteAccessParams & WellLocationParam
 }
@@ -309,18 +283,15 @@ export interface PressureDispenseCreateCommand extends CommonCommandCreateInfo {
     VolumeParams
 }
 export interface PipetteSealToTipRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    PipetteSealToTipCreateCommand {
+  extends CommonCommandRunTimeInfo, PipetteSealToTipCreateCommand {
   result?: PipetteSealToTipResult
 }
 export interface PipetteUnsealFromTipRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    PipetteUnsealFromTipCreateCommand {
+  extends CommonCommandRunTimeInfo, PipetteUnsealFromTipCreateCommand {
   result?: PipetteUnsealFromTipResult
 }
 export interface PressureDispenseRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    PressureDispenseCreateCommand {
+  extends CommonCommandRunTimeInfo, PressureDispenseCreateCommand {
   result?: BasicLiquidHandlingResult
 }
 export type AspDispAirgapParams = FlowRateParams &

--- a/shared-data/command/types/robot.ts
+++ b/shared-data/command/types/robot.ts
@@ -30,8 +30,7 @@ export interface RobotMoveToCreateCommand extends CommonCommandCreateInfo {
   params: RobotMoveToParams
 }
 export interface RobotMoveToRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    RobotMoveToCreateCommand {
+  extends CommonCommandRunTimeInfo, RobotMoveToCreateCommand {
   result?: any
 }
 
@@ -47,8 +46,7 @@ export interface RobotMoveAxesToCreateCommand extends CommonCommandCreateInfo {
 }
 
 export interface RobotMoveAxesToRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    RobotMoveAxesToCreateCommand {
+  extends CommonCommandRunTimeInfo, RobotMoveAxesToCreateCommand {
   result?: {
     position: RobotMotorAxisMap
   }
@@ -59,40 +57,34 @@ export interface RobotMoveAxesRelativeParams {
   speed?: number
 }
 
-export interface RobotMoveAxesRelativeCreateCommand
-  extends CommonCommandCreateInfo {
+export interface RobotMoveAxesRelativeCreateCommand extends CommonCommandCreateInfo {
   commandType: 'robot/moveAxesRelative'
   params: RobotMoveAxesRelativeParams
 }
 
 export interface RobotMoveAxesRelativeRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    RobotMoveAxesRelativeCreateCommand {
+  extends CommonCommandRunTimeInfo, RobotMoveAxesRelativeCreateCommand {
   result?: {
     position: RobotMotorAxisMap
   }
 }
 
-export interface RobotOpenGripperJawCreateCommand
-  extends CommonCommandCreateInfo {
+export interface RobotOpenGripperJawCreateCommand extends CommonCommandCreateInfo {
   commandType: 'robot/openGripperJaw'
   params: {}
 }
 
 export interface RobotOpenGripperJawRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    RobotOpenGripperJawCreateCommand {
+  extends CommonCommandRunTimeInfo, RobotOpenGripperJawCreateCommand {
   result?: any
 }
 
-export interface RobotCloseGripperJawCreateCommand
-  extends CommonCommandCreateInfo {
+export interface RobotCloseGripperJawCreateCommand extends CommonCommandCreateInfo {
   commandType: 'robot/closeGripperJaw'
   params: {}
 }
 
 export interface RobotCloseGripperJawRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    RobotCloseGripperJawCreateCommand {
+  extends CommonCommandRunTimeInfo, RobotCloseGripperJawCreateCommand {
   result?: any
 }

--- a/shared-data/command/types/setup.ts
+++ b/shared-data/command/types/setup.ts
@@ -16,8 +16,7 @@ export interface LoadPipetteCreateCommand extends CommonCommandCreateInfo {
   params: LoadPipetteParams
 }
 export interface LoadPipetteRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    Omit<LoadPipetteCreateCommand, 'params'> {
+  extends CommonCommandRunTimeInfo, Omit<LoadPipetteCreateCommand, 'params'> {
   params: LoadPipetteParams & {
     pipetteName: PipetteName
   }
@@ -28,8 +27,7 @@ export interface LoadLabwareCreateCommand extends CommonCommandCreateInfo {
   params: LoadLabwareParams
 }
 export interface LoadLabwareRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    LoadLabwareCreateCommand {
+  extends CommonCommandRunTimeInfo, LoadLabwareCreateCommand {
   result?: LoadLabwareResult
 }
 export interface LoadLidCreateCommand extends CommonCommandCreateInfo {
@@ -37,8 +35,7 @@ export interface LoadLidCreateCommand extends CommonCommandCreateInfo {
   params: LoadLidParams
 }
 export interface LoadLidRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    LoadLidCreateCommand {
+  extends CommonCommandRunTimeInfo, LoadLidCreateCommand {
   result?: LoadLidResult
 }
 export interface LoadLidStackCreateCommand extends CommonCommandCreateInfo {
@@ -46,8 +43,7 @@ export interface LoadLidStackCreateCommand extends CommonCommandCreateInfo {
   params: LoadLidStackParams
 }
 export interface LoadLidStackRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    LoadLidStackCreateCommand {
+  extends CommonCommandRunTimeInfo, LoadLidStackCreateCommand {
   result?: LoadLidStackResult
 }
 export interface ReloadLabwareCreateCommand extends CommonCommandCreateInfo {
@@ -55,8 +51,7 @@ export interface ReloadLabwareCreateCommand extends CommonCommandCreateInfo {
   params: { labwareId: string }
 }
 export interface ReloadLabwareRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    ReloadLabwareCreateCommand {
+  extends CommonCommandRunTimeInfo, ReloadLabwareCreateCommand {
   result?: ReloadLabwareResult
 }
 export interface MoveLabwareCreateCommand extends CommonCommandCreateInfo {
@@ -64,8 +59,7 @@ export interface MoveLabwareCreateCommand extends CommonCommandCreateInfo {
   params: MoveLabwareParams
 }
 export interface MoveLabwareRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    MoveLabwareCreateCommand {
+  extends CommonCommandRunTimeInfo, MoveLabwareCreateCommand {
   result?: MoveLabwareResult
 }
 export interface LoadModuleCreateCommand extends CommonCommandCreateInfo {
@@ -73,8 +67,7 @@ export interface LoadModuleCreateCommand extends CommonCommandCreateInfo {
   params: LoadModuleParams
 }
 export interface LoadModuleRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    Omit<LoadModuleCreateCommand, 'params'> {
+  extends CommonCommandRunTimeInfo, Omit<LoadModuleCreateCommand, 'params'> {
   params: LoadModuleParams & {
     model: ModuleModel
   }
@@ -85,8 +78,7 @@ export interface LoadLiquidCreateCommand extends CommonCommandCreateInfo {
   params: LoadLiquidParams
 }
 export interface LoadLiquidRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    LoadLiquidCreateCommand {
+  extends CommonCommandRunTimeInfo, LoadLiquidCreateCommand {
   result?: LoadLiquidResult
 }
 
@@ -95,20 +87,17 @@ export interface LoadLiquidClassCreateCommand extends CommonCommandCreateInfo {
   params: LoadLiquidClassParams
 }
 export interface LoadLiquidClassRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    LoadLiquidClassCreateCommand {
+  extends CommonCommandRunTimeInfo, LoadLiquidClassCreateCommand {
   result?: LoadLiquidClassResult
 }
 
-export interface ConfigureNozzleLayoutCreateCommand
-  extends CommonCommandCreateInfo {
+export interface ConfigureNozzleLayoutCreateCommand extends CommonCommandCreateInfo {
   commandType: 'configureNozzleLayout'
   params: ConfigureNozzleLayoutParams
 }
 
 export interface ConfigureNozzleLayoutRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    ConfigureNozzleLayoutCreateCommand {
+  extends CommonCommandRunTimeInfo, ConfigureNozzleLayoutCreateCommand {
   result?: {}
 }
 
@@ -118,8 +107,7 @@ export interface SetTipStateCreateCommand extends CommonCommandCreateInfo {
 }
 
 export interface SetTipStateRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    SetTipStateCreateCommand {
+  extends CommonCommandRunTimeInfo, SetTipStateCreateCommand {
   result?: {}
 }
 

--- a/shared-data/command/types/timing.ts
+++ b/shared-data/command/types/timing.ts
@@ -17,8 +17,7 @@ export interface WaitForResumeCreateCommand extends CommonCommandCreateInfo {
 }
 
 export interface WaitForResumeRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    WaitForResumeCreateCommand {
+  extends CommonCommandRunTimeInfo, WaitForResumeCreateCommand {
   result?: any
 }
 
@@ -32,8 +31,7 @@ export interface WaitForDurationCreateCommand extends CommonCommandCreateInfo {
 }
 
 export interface WaitForDurationRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    WaitForDurationCreateCommand {
+  extends CommonCommandRunTimeInfo, WaitForDurationCreateCommand {
   result?: any
 }
 
@@ -48,8 +46,7 @@ export interface DeprecatedDelayCreateCommand extends CommonCommandCreateInfo {
 }
 
 export interface DeprecatedDelayRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    DeprecatedDelayCreateCommand {
+  extends CommonCommandRunTimeInfo, DeprecatedDelayCreateCommand {
   result?: {}
 }
 

--- a/shared-data/command/types/unsafe.ts
+++ b/shared-data/command/types/unsafe.ts
@@ -33,14 +33,12 @@ export interface UnsafeBlowoutInPlaceParams {
   flowRate: number // µL/s
 }
 
-export interface UnsafeBlowoutInPlaceCreateCommand
-  extends CommonCommandCreateInfo {
+export interface UnsafeBlowoutInPlaceCreateCommand extends CommonCommandCreateInfo {
   commandType: 'unsafe/blowOutInPlace'
   params: UnsafeBlowoutInPlaceParams
 }
 export interface UnsafeBlowoutInPlaceRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    UnsafeBlowoutInPlaceCreateCommand {
+  extends CommonCommandRunTimeInfo, UnsafeBlowoutInPlaceCreateCommand {
   result?: {}
 }
 
@@ -48,14 +46,12 @@ export interface UnsafeDropTipInPlaceParams {
   pipetteId: string
 }
 
-export interface UnsafeDropTipInPlaceCreateCommand
-  extends CommonCommandCreateInfo {
+export interface UnsafeDropTipInPlaceCreateCommand extends CommonCommandCreateInfo {
   commandType: 'unsafe/dropTipInPlace'
   params: UnsafeDropTipInPlaceParams
 }
 export interface UnsafeDropTipInPlaceRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    UnsafeDropTipInPlaceCreateCommand {
+  extends CommonCommandRunTimeInfo, UnsafeDropTipInPlaceCreateCommand {
   result?: any
 }
 
@@ -63,13 +59,13 @@ export interface UnsafeUpdatePositionEstimatorsParams {
   axes: MotorAxes
 }
 
-export interface UnsafeUpdatePositionEstimatorsCreateCommand
-  extends CommonCommandCreateInfo {
+export interface UnsafeUpdatePositionEstimatorsCreateCommand extends CommonCommandCreateInfo {
   commandType: 'unsafe/updatePositionEstimators'
   params: UnsafeUpdatePositionEstimatorsParams
 }
 export interface UnsafeUpdatePositionEstimatorsRunTimeCommand
-  extends CommonCommandRunTimeInfo,
+  extends
+    CommonCommandRunTimeInfo,
     UnsafeUpdatePositionEstimatorsCreateCommand {
   result?: any
 }
@@ -83,73 +79,64 @@ export interface UnsafeEngageAxesCreateCommand extends CommonCommandCreateInfo {
   params: UnsafeUpdatePositionEstimatorsParams
 }
 export interface UnsafeEngageAxesRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    UnsafeEngageAxesCreateCommand {
+  extends CommonCommandRunTimeInfo, UnsafeEngageAxesCreateCommand {
   result?: any
 }
 
-export interface UnsafeUngripLabwareCreateCommand
-  extends CommonCommandCreateInfo {
+export interface UnsafeUngripLabwareCreateCommand extends CommonCommandCreateInfo {
   commandType: 'unsafe/ungripLabware'
   params: {}
 }
 export interface UnsafeUngripLabwareRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    UnsafeUngripLabwareCreateCommand {
+  extends CommonCommandRunTimeInfo, UnsafeUngripLabwareCreateCommand {
   result?: any
 }
 export interface UnsafePlaceLabwareParams {
   labwareURI: string
   location: OnDeckLabwareLocation
 }
-export interface UnsafePlaceLabwareCreateCommand
-  extends CommonCommandCreateInfo {
+export interface UnsafePlaceLabwareCreateCommand extends CommonCommandCreateInfo {
   commandType: 'unsafe/placeLabware'
   params: UnsafePlaceLabwareParams
 }
 export interface UnsafePlaceLabwareRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    UnsafePlaceLabwareCreateCommand {
+  extends CommonCommandRunTimeInfo, UnsafePlaceLabwareCreateCommand {
   result?: any
 }
 export interface UnsafeFlexStackerManualRetrieveParams {
   moduleId: string
 }
-export interface UnsafeFlexStackerManualRetrieveCreateCommand
-  extends CommonCommandCreateInfo {
+export interface UnsafeFlexStackerManualRetrieveCreateCommand extends CommonCommandCreateInfo {
   commandType: 'unsafe/flexStacker/manualRetrieve'
   params: UnsafeFlexStackerManualRetrieveParams
 }
 export interface UnsafeFlexStackerManualRetrieveLatchRunTimeCommand
-  extends CommonCommandRunTimeInfo,
+  extends
+    CommonCommandRunTimeInfo,
     UnsafeFlexStackerManualRetrieveCreateCommand {
   result?: any
 }
 export interface UnsafeFlexStackerCloseLatchParams {
   moduleId: string
 }
-export interface UnsafeFlexStackerCloseLatchCreateCommand
-  extends CommonCommandCreateInfo {
+export interface UnsafeFlexStackerCloseLatchCreateCommand extends CommonCommandCreateInfo {
   commandType: 'unsafe/flexStacker/closeLatch'
   params: UnsafeFlexStackerCloseLatchParams
 }
 export interface UnsafeFlexStackerCloseLatchRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    UnsafeFlexStackerCloseLatchCreateCommand {
+  extends CommonCommandRunTimeInfo, UnsafeFlexStackerCloseLatchCreateCommand {
   result?: any
 }
 
 export interface UnsafeFlexStackerOpenLatchParams {
   moduleId: string
 }
-export interface UnsafeFlexStackerOpenLatchCreateCommand
-  extends CommonCommandCreateInfo {
+export interface UnsafeFlexStackerOpenLatchCreateCommand extends CommonCommandCreateInfo {
   commandType: 'unsafe/flexStacker/openLatch'
   params: UnsafeFlexStackerOpenLatchParams
 }
 export interface UnsafeFlexStackerOpenLatchRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    UnsafeFlexStackerOpenLatchCreateCommand {
+  extends CommonCommandRunTimeInfo, UnsafeFlexStackerOpenLatchCreateCommand {
   result?: any
 }
 
@@ -157,13 +144,13 @@ export interface UnsafeFlexStackerPrepareShuttleParams {
   moduleId: string
   ignoreLatch?: boolean
 }
-export interface UnsafeFlexStackerPrepareShuttleCreateCommand
-  extends CommonCommandCreateInfo {
+export interface UnsafeFlexStackerPrepareShuttleCreateCommand extends CommonCommandCreateInfo {
   commandType: 'unsafe/flexStacker/prepareShuttle'
   params: UnsafeFlexStackerPrepareShuttleParams
 }
 export interface UnsafeFlexStackerPrepareShuttleRunTimeCommand
-  extends CommonCommandRunTimeInfo,
+  extends
+    CommonCommandRunTimeInfo,
     UnsafeFlexStackerPrepareShuttleCreateCommand {
   result?: any
 }

--- a/shared-data/commandAnnotation/types/index.ts
+++ b/shared-data/commandAnnotation/types/index.ts
@@ -6,8 +6,7 @@ export type CustomCommandAnnotation = SharedCommandAnnotationProperties & {
 } & {
   annotationType: 'custom'
 }
-export interface SecondOrderCommandAnnotation
-  extends SharedCommandAnnotationProperties {
+export interface SecondOrderCommandAnnotation extends SharedCommandAnnotationProperties {
   annotationType: 'secondOrderCommand'
   machineReadableName: string
   params: { [key: string]: any }

--- a/shared-data/js/types.ts
+++ b/shared-data/js/types.ts
@@ -470,8 +470,10 @@ export interface CutoutFixture {
   height: number
 }
 
-export interface FakeCutoutFixture
-  extends Omit<CutoutFixture, 'id' | 'providesAddressableAreas'> {
+export interface FakeCutoutFixture extends Omit<
+  CutoutFixture,
+  'id' | 'providesAddressableAreas'
+> {
   id: CutoutFixtureIdsWithFakes
   providesAddressableAreas: Record<
     CutoutId,
@@ -507,8 +509,10 @@ export interface AddressableArea {
   matingSurfaceUnitVector?: UnitVectorTuple
 }
 
-export interface FakeAddressableArea
-  extends Omit<AddressableArea, 'id' | 'areaType'> {
+export interface FakeAddressableArea extends Omit<
+  AddressableArea,
+  'id' | 'areaType'
+> {
   id: AddressableAreaNamesWithFakes
   areaType: AreaTypeWithFakes
 }
@@ -538,11 +542,10 @@ export interface DeckLocations {
   legacyFixtures: LegacyFixture[]
 }
 
-export interface DeckLocationsWithFakes
-  extends Omit<
-    DeckLocations,
-    'addressableAreas' | 'calibrationPoints' | 'legacyFixtures'
-  > {
+export interface DeckLocationsWithFakes extends Omit<
+  DeckLocations,
+  'addressableAreas' | 'calibrationPoints' | 'legacyFixtures'
+> {
   addressableAreas: AddressableAreaWithFakes[]
 }
 
@@ -556,17 +559,16 @@ export interface DeckDefinition {
   cutoutFixtures: CutoutFixture[]
 }
 
-export interface DeckDefinitionWithFakes
-  extends Omit<
-    DeckDefinition,
-    | 'locations'
-    | 'cutoutFixtures'
-    | 'otId'
-    | 'cornerOffsetFromOrigin'
-    | 'dimensions'
-    | 'metadata'
-    | 'robot'
-  > {
+export interface DeckDefinitionWithFakes extends Omit<
+  DeckDefinition,
+  | 'locations'
+  | 'cutoutFixtures'
+  | 'otId'
+  | 'cornerOffsetFromOrigin'
+  | 'dimensions'
+  | 'metadata'
+  | 'robot'
+> {
   locations: DeckLocationsWithFakes
   cutoutFixtures: CutoutFixtureWithFakes[]
 }
@@ -915,20 +917,17 @@ interface BaseLiquidHandlingProperties<RetractType> {
   correctionByVolume: LiquidHandlingPropertyByVolume
   delay: DelayProperties
 }
-export interface AspirateProperties
-  extends BaseLiquidHandlingProperties<RetractAspirate> {
+export interface AspirateProperties extends BaseLiquidHandlingProperties<RetractAspirate> {
   aspiratePosition: TipPosition
   preWet: boolean
   mix: MixProperties
 }
-export interface SingleDispenseProperties
-  extends BaseLiquidHandlingProperties<RetractDispense> {
+export interface SingleDispenseProperties extends BaseLiquidHandlingProperties<RetractDispense> {
   dispensePosition: TipPosition
   mix: MixProperties
   pushOutByVolume: LiquidHandlingPropertyByVolume
 }
-export interface MultiDispenseProperties
-  extends BaseLiquidHandlingProperties<RetractDispense> {
+export interface MultiDispenseProperties extends BaseLiquidHandlingProperties<RetractDispense> {
   dispensePosition: TipPosition
   conditioningByVolume: LiquidHandlingPropertyByVolume
   disposalByVolume: LiquidHandlingPropertyByVolume

--- a/shared-data/protocol/types/schemaV4.ts
+++ b/shared-data/protocol/types/schemaV4.ts
@@ -134,11 +134,10 @@ export type Command =
     }
 
 // NOTE: must be kept in sync with '../schemas/4.json'
-export interface ProtocolFile<DesignerApplicationData>
-  extends Omit<
-    V3ProtocolFile<DesignerApplicationData>,
-    'schemaVersion' | 'commands'
-  > {
+export interface ProtocolFile<DesignerApplicationData> extends Omit<
+  V3ProtocolFile<DesignerApplicationData>,
+  'schemaVersion' | 'commands'
+> {
   $otSharedSchema: '#/protocol/schemas/4'
   schemaVersion: 4
   modules: Record<string, FileModule>

--- a/shared-data/protocol/types/schemaV5.ts
+++ b/shared-data/protocol/types/schemaV5.ts
@@ -22,11 +22,10 @@ export type Command =
     }
 
 // NOTE: must be kept in sync with '../schemas/5.json'
-export interface ProtocolFile<DesignerApplicationData>
-  extends Omit<
-    V3ProtocolFile<DesignerApplicationData>,
-    'schemaVersion' | 'commands'
-  > {
+export interface ProtocolFile<DesignerApplicationData> extends Omit<
+  V3ProtocolFile<DesignerApplicationData>,
+  'schemaVersion' | 'commands'
+> {
   $otSharedSchema: '#/protocol/schemas/5'
   schemaVersion: 5
   modules: Record<string, FileModule>

--- a/shared-data/protocol/types/schemaV6/command/gantry.ts
+++ b/shared-data/protocol/types/schemaV6/command/gantry.ts
@@ -6,8 +6,7 @@ export interface MoveToSlotCreateCommand extends CommonCommandCreateInfo {
   params: MoveToSlotParams
 }
 export interface MoveToSlotRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    MoveToSlotCreateCommand {
+  extends CommonCommandRunTimeInfo, MoveToSlotCreateCommand {
   result?: {}
 }
 export interface MoveToWellCreateCommand extends CommonCommandCreateInfo {
@@ -15,18 +14,15 @@ export interface MoveToWellCreateCommand extends CommonCommandCreateInfo {
   params: MoveToWellParams
 }
 export interface MoveToWellRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    MoveToWellCreateCommand {
+  extends CommonCommandRunTimeInfo, MoveToWellCreateCommand {
   result?: {}
 }
-export interface MoveToCoordinatesCreateCommand
-  extends CommonCommandCreateInfo {
+export interface MoveToCoordinatesCreateCommand extends CommonCommandCreateInfo {
   commandType: 'moveToCoordinates'
   params: MoveToCoordinatesParams
 }
 export interface MoveToCoordinatesRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    MoveToCoordinatesCreateCommand {
+  extends CommonCommandRunTimeInfo, MoveToCoordinatesCreateCommand {
   result?: {}
 }
 export interface MoveRelativeCreateCommand extends CommonCommandCreateInfo {
@@ -34,8 +30,7 @@ export interface MoveRelativeCreateCommand extends CommonCommandCreateInfo {
   params: MoveRelativeParams
 }
 export interface MoveRelativeRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    MoveRelativeCreateCommand {
+  extends CommonCommandRunTimeInfo, MoveRelativeCreateCommand {
   result?: {
     position: Vector3D
   }
@@ -45,8 +40,7 @@ export interface SavePositionCreateCommand extends CommonCommandCreateInfo {
   params: SavePositionParams
 }
 export interface SavePositionRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    SavePositionCreateCommand {
+  extends CommonCommandRunTimeInfo, SavePositionCreateCommand {
   result?: {
     positionId: string
     position: Vector3D
@@ -57,8 +51,7 @@ export interface HomeCreateCommand extends CommonCommandCreateInfo {
   params: HomeParams
 }
 export interface HomeRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    HomeCreateCommand {
+  extends CommonCommandRunTimeInfo, HomeCreateCommand {
   result?: {}
 }
 export interface RetractAxisCreateCommand extends CommonCommandCreateInfo {
@@ -66,8 +59,7 @@ export interface RetractAxisCreateCommand extends CommonCommandCreateInfo {
   params: RetractAxisParams
 }
 export interface RetractAxisRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    RetractAxisCreateCommand {
+  extends CommonCommandRunTimeInfo, RetractAxisCreateCommand {
   result?: {}
 }
 export type GantryRunTimeCommand =

--- a/shared-data/protocol/types/schemaV6/command/module.ts
+++ b/shared-data/protocol/types/schemaV6/command/module.ts
@@ -48,94 +48,80 @@ export type ModuleCreateCommand =
   | HeaterShakerDeactivateShakerCreateCommand
   | HeaterShakerSetTargetTemperatureCreateCommand
 
-export interface MagneticModuleEngageMagnetCreateCommand
-  extends CommonCommandCreateInfo {
+export interface MagneticModuleEngageMagnetCreateCommand extends CommonCommandCreateInfo {
   commandType: 'magneticModule/engage'
   params: EngageMagnetParams
 }
 export interface MagneticModuleEngageMagnetRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    MagneticModuleEngageMagnetCreateCommand {
+  extends CommonCommandRunTimeInfo, MagneticModuleEngageMagnetCreateCommand {
   result?: any
 }
-export interface MagneticModuleDisengageCreateCommand
-  extends CommonCommandCreateInfo {
+export interface MagneticModuleDisengageCreateCommand extends CommonCommandCreateInfo {
   commandType: 'magneticModule/disengage'
   params: ModuleOnlyParams
 }
 export interface MagneticModuleDisengageRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    MagneticModuleDisengageCreateCommand {
+  extends CommonCommandRunTimeInfo, MagneticModuleDisengageCreateCommand {
   result?: any
 }
-export interface TemperatureModuleSetTargetTemperatureCreateCommand
-  extends CommonCommandCreateInfo {
+export interface TemperatureModuleSetTargetTemperatureCreateCommand extends CommonCommandCreateInfo {
   commandType: 'temperatureModule/setTargetTemperature'
   params: TemperatureParams
 }
 export interface TemperatureModuleSetTargetTemperatureRunTimeCommand
-  extends CommonCommandRunTimeInfo,
+  extends
+    CommonCommandRunTimeInfo,
     TemperatureModuleSetTargetTemperatureCreateCommand {
   result?: any
 }
-export interface TemperatureModuleDeactivateCreateCommand
-  extends CommonCommandCreateInfo {
+export interface TemperatureModuleDeactivateCreateCommand extends CommonCommandCreateInfo {
   commandType: 'temperatureModule/deactivate'
   params: ModuleOnlyParams
 }
 export interface TemperatureModuleDeactivateRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    TemperatureModuleDeactivateCreateCommand {
+  extends CommonCommandRunTimeInfo, TemperatureModuleDeactivateCreateCommand {
   result?: any
 }
-export interface TemperatureModuleAwaitTemperatureCreateCommand
-  extends CommonCommandCreateInfo {
+export interface TemperatureModuleAwaitTemperatureCreateCommand extends CommonCommandCreateInfo {
   commandType: 'temperatureModule/waitForTemperature'
   params: TemperatureParams
 }
 export interface TemperatureModuleAwaitTemperatureRunTimeCommand
-  extends CommonCommandRunTimeInfo,
+  extends
+    CommonCommandRunTimeInfo,
     TemperatureModuleAwaitTemperatureCreateCommand {
   result?: any
 }
-export interface TCSetTargetBlockTemperatureCreateCommand
-  extends CommonCommandCreateInfo {
+export interface TCSetTargetBlockTemperatureCreateCommand extends CommonCommandCreateInfo {
   commandType: 'thermocycler/setTargetBlockTemperature'
   params: ThermocyclerSetTargetBlockTemperatureParams
 }
 export interface TCSetTargetBlockTemperatureRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    TCSetTargetBlockTemperatureCreateCommand {
+  extends CommonCommandRunTimeInfo, TCSetTargetBlockTemperatureCreateCommand {
   result?: any
 }
-export interface TCSetTargetLidTemperatureCreateCommand
-  extends CommonCommandCreateInfo {
+export interface TCSetTargetLidTemperatureCreateCommand extends CommonCommandCreateInfo {
   commandType: 'thermocycler/setTargetLidTemperature'
   params: TemperatureParams
 }
 export interface TCSetTargetLidTemperatureRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    TCSetTargetLidTemperatureCreateCommand {
+  extends CommonCommandRunTimeInfo, TCSetTargetLidTemperatureCreateCommand {
   result?: any
 }
-export interface TCWaitForBlockTemperatureCreateCommand
-  extends CommonCommandCreateInfo {
+export interface TCWaitForBlockTemperatureCreateCommand extends CommonCommandCreateInfo {
   commandType: 'thermocycler/waitForBlockTemperature'
   params: ModuleOnlyParams
 }
 export interface TCWaitForBlockTemperatureRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    TCWaitForBlockTemperatureCreateCommand {
+  extends CommonCommandRunTimeInfo, TCWaitForBlockTemperatureCreateCommand {
   result?: any
 }
-export interface TCWaitForLidTemperatureCreateCommand
-  extends CommonCommandCreateInfo {
+export interface TCWaitForLidTemperatureCreateCommand extends CommonCommandCreateInfo {
   commandType: 'thermocycler/waitForLidTemperature'
   params: ModuleOnlyParams
 }
 export interface TCWaitForLidTemperatureRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    TCWaitForLidTemperatureCreateCommand {
+  extends CommonCommandRunTimeInfo, TCWaitForLidTemperatureCreateCommand {
   result?: any
 }
 export interface TCOpenLidCreateCommand extends CommonCommandCreateInfo {
@@ -143,8 +129,7 @@ export interface TCOpenLidCreateCommand extends CommonCommandCreateInfo {
   params: ModuleOnlyParams
 }
 export interface TCOpenLidRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    TCOpenLidCreateCommand {
+  extends CommonCommandRunTimeInfo, TCOpenLidCreateCommand {
   result?: any
 }
 export interface TCCloseLidCreateCommand extends CommonCommandCreateInfo {
@@ -152,18 +137,15 @@ export interface TCCloseLidCreateCommand extends CommonCommandCreateInfo {
   params: ModuleOnlyParams
 }
 export interface TCCloseLidRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    TCCloseLidCreateCommand {
+  extends CommonCommandRunTimeInfo, TCCloseLidCreateCommand {
   result?: any
 }
-export interface TCDeactivateBlockCreateCommand
-  extends CommonCommandCreateInfo {
+export interface TCDeactivateBlockCreateCommand extends CommonCommandCreateInfo {
   commandType: 'thermocycler/deactivateBlock'
   params: ModuleOnlyParams
 }
 export interface TCDeactivateBlockRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    TCDeactivateBlockCreateCommand {
+  extends CommonCommandRunTimeInfo, TCDeactivateBlockCreateCommand {
   result?: any
 }
 export interface TCDeactivateLidCreateCommand extends CommonCommandCreateInfo {
@@ -171,8 +153,7 @@ export interface TCDeactivateLidCreateCommand extends CommonCommandCreateInfo {
   params: ModuleOnlyParams
 }
 export interface TCDeactivateLidRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    TCDeactivateLidCreateCommand {
+  extends CommonCommandRunTimeInfo, TCDeactivateLidCreateCommand {
   result?: any
 }
 export interface TCRunProfileCreateCommand extends CommonCommandCreateInfo {
@@ -180,88 +161,77 @@ export interface TCRunProfileCreateCommand extends CommonCommandCreateInfo {
   params: TCProfileParams
 }
 export interface TCRunProfileRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    TCRunProfileCreateCommand {
+  extends CommonCommandRunTimeInfo, TCRunProfileCreateCommand {
   result?: any
 }
-export interface TCAwaitProfileCompleteCreateCommand
-  extends CommonCommandCreateInfo {
+export interface TCAwaitProfileCompleteCreateCommand extends CommonCommandCreateInfo {
   commandType: 'thermocycler/awaitProfileComplete'
   params: ModuleOnlyParams
 }
 export interface TCAwaitProfileCompleteRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    TCAwaitProfileCompleteCreateCommand {
+  extends CommonCommandRunTimeInfo, TCAwaitProfileCompleteCreateCommand {
   result?: any
 }
-export interface HeaterShakerSetTargetTemperatureCreateCommand
-  extends CommonCommandCreateInfo {
+export interface HeaterShakerSetTargetTemperatureCreateCommand extends CommonCommandCreateInfo {
   commandType: 'heaterShaker/setTargetTemperature'
   params: TemperatureParams
 }
 export interface HeaterShakerSetTargetTemperatureRunTimeCommand
-  extends CommonCommandRunTimeInfo,
+  extends
+    CommonCommandRunTimeInfo,
     HeaterShakerSetTargetTemperatureCreateCommand {
   result?: any
 }
-export interface HeaterShakerWaitForTemperatureCreateCommand
-  extends CommonCommandCreateInfo {
+export interface HeaterShakerWaitForTemperatureCreateCommand extends CommonCommandCreateInfo {
   commandType: 'heaterShaker/waitForTemperature'
   params: ModuleOnlyParams
 }
 export interface HeaterShakerWaitForTemperatureRunTimeCommand
-  extends CommonCommandRunTimeInfo,
+  extends
+    CommonCommandRunTimeInfo,
     HeaterShakerWaitForTemperatureCreateCommand {
   result?: any
 }
-export interface HeaterShakerSetAndWaitForShakeSpeedCreateCommand
-  extends CommonCommandCreateInfo {
+export interface HeaterShakerSetAndWaitForShakeSpeedCreateCommand extends CommonCommandCreateInfo {
   commandType: 'heaterShaker/setAndWaitForShakeSpeed'
   params: ShakeSpeedParams
 }
 export interface HeaterShakerSetAndWaitForShakeSpeedRunTimeCommand
-  extends CommonCommandRunTimeInfo,
+  extends
+    CommonCommandRunTimeInfo,
     HeaterShakerSetAndWaitForShakeSpeedCreateCommand {
   result?: any
 }
-export interface HeaterShakerDeactivateHeaterCreateCommand
-  extends CommonCommandCreateInfo {
+export interface HeaterShakerDeactivateHeaterCreateCommand extends CommonCommandCreateInfo {
   commandType: 'heaterShaker/deactivateHeater'
   params: ModuleOnlyParams
 }
 export interface HeaterShakerDeactivateHeaterRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    HeaterShakerDeactivateHeaterCreateCommand {
+  extends CommonCommandRunTimeInfo, HeaterShakerDeactivateHeaterCreateCommand {
   result?: any
 }
-export interface HeaterShakerOpenLatchCreateCommand
-  extends CommonCommandCreateInfo {
+export interface HeaterShakerOpenLatchCreateCommand extends CommonCommandCreateInfo {
   commandType: 'heaterShaker/openLabwareLatch'
   params: ModuleOnlyParams
 }
 export interface HeaterShakerOpenLatchRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    HeaterShakerOpenLatchCreateCommand {
+  extends CommonCommandRunTimeInfo, HeaterShakerOpenLatchCreateCommand {
   result?: any
 }
-export interface HeaterShakerCloseLatchCreateCommand
-  extends CommonCommandCreateInfo {
+export interface HeaterShakerCloseLatchCreateCommand extends CommonCommandCreateInfo {
   commandType: 'heaterShaker/closeLabwareLatch'
   params: ModuleOnlyParams
 }
 export interface HeaterShakerCloseLatchRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    HeaterShakerCloseLatchCreateCommand {
+  extends CommonCommandRunTimeInfo, HeaterShakerCloseLatchCreateCommand {
   result?: any
 }
-export interface HeaterShakerDeactivateShakerCreateCommand
-  extends CommonCommandCreateInfo {
+export interface HeaterShakerDeactivateShakerCreateCommand extends CommonCommandCreateInfo {
   commandType: 'heaterShaker/deactivateShaker'
   params: ModuleOnlyParams
 }
 export interface HeaterShakerDeactivateShakerRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    HeaterShakerDeactivateShakerCreateCommand {
+  extends CommonCommandRunTimeInfo, HeaterShakerDeactivateShakerCreateCommand {
   result?: any
 }
 

--- a/shared-data/protocol/types/schemaV6/command/pipetting.ts
+++ b/shared-data/protocol/types/schemaV6/command/pipetting.ts
@@ -20,8 +20,7 @@ export interface AspirateCreateCommand extends CommonCommandCreateInfo {
   params: AspDispAirgapParams
 }
 export interface AspirateRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    AspirateCreateCommand {
+  extends CommonCommandRunTimeInfo, AspirateCreateCommand {
   result?: BasicLiquidHandlingResult
 }
 export interface DispenseCreateCommand extends CommonCommandCreateInfo {
@@ -29,8 +28,7 @@ export interface DispenseCreateCommand extends CommonCommandCreateInfo {
   params: AspDispAirgapParams
 }
 export interface DispenseRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    DispenseCreateCommand {
+  extends CommonCommandRunTimeInfo, DispenseCreateCommand {
   result?: BasicLiquidHandlingResult
 }
 export interface BlowoutCreateCommand extends CommonCommandCreateInfo {
@@ -38,8 +36,7 @@ export interface BlowoutCreateCommand extends CommonCommandCreateInfo {
   params: BlowoutParams
 }
 export interface BlowoutRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    BlowoutCreateCommand {
+  extends CommonCommandRunTimeInfo, BlowoutCreateCommand {
   result?: BasicLiquidHandlingResult
 }
 export interface TouchTipCreateCommand extends CommonCommandCreateInfo {
@@ -47,8 +44,7 @@ export interface TouchTipCreateCommand extends CommonCommandCreateInfo {
   params: TouchTipParams
 }
 export interface TouchTipRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    TouchTipCreateCommand {
+  extends CommonCommandRunTimeInfo, TouchTipCreateCommand {
   result?: BasicLiquidHandlingResult
 }
 export interface PickUpTipCreateCommand extends CommonCommandCreateInfo {
@@ -56,8 +52,7 @@ export interface PickUpTipCreateCommand extends CommonCommandCreateInfo {
   params: PickUpTipParams
 }
 export interface PickUpTipRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    PickUpTipCreateCommand {
+  extends CommonCommandRunTimeInfo, PickUpTipCreateCommand {
   result?: any
 }
 export interface DropTipCreateCommand extends CommonCommandCreateInfo {
@@ -65,8 +60,7 @@ export interface DropTipCreateCommand extends CommonCommandCreateInfo {
   params: DropTipParams
 }
 export interface DropTipRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    DropTipCreateCommand {
+  extends CommonCommandRunTimeInfo, DropTipCreateCommand {
   result?: any
 }
 

--- a/shared-data/protocol/types/schemaV6/command/setup.ts
+++ b/shared-data/protocol/types/schemaV6/command/setup.ts
@@ -12,8 +12,7 @@ export interface LoadPipetteCreateCommand extends CommonCommandCreateInfo {
   params: LoadPipetteParams
 }
 export interface LoadPipetteRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    Omit<LoadPipetteCreateCommand, 'params'> {
+  extends CommonCommandRunTimeInfo, Omit<LoadPipetteCreateCommand, 'params'> {
   params: LoadPipetteParams & {
     pipetteName: PipetteName
   }
@@ -24,8 +23,7 @@ export interface LoadLabwareCreateCommand extends CommonCommandCreateInfo {
   params: LoadLabwareParams
 }
 export interface LoadLabwareRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    LoadLabwareCreateCommand {
+  extends CommonCommandRunTimeInfo, LoadLabwareCreateCommand {
   result?: LoadLabwareResult
 }
 export interface MoveLabwareCreateCommand extends CommonCommandCreateInfo {
@@ -33,8 +31,7 @@ export interface MoveLabwareCreateCommand extends CommonCommandCreateInfo {
   params: MoveLabwareParams
 }
 export interface MoveLabwareRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    MoveLabwareCreateCommand {
+  extends CommonCommandRunTimeInfo, MoveLabwareCreateCommand {
   result?: MoveLabwareResult
 }
 export interface LoadModuleCreateCommand extends CommonCommandCreateInfo {
@@ -42,8 +39,7 @@ export interface LoadModuleCreateCommand extends CommonCommandCreateInfo {
   params: LoadModuleParams
 }
 export interface LoadModuleRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    Omit<LoadModuleCreateCommand, 'params'> {
+  extends CommonCommandRunTimeInfo, Omit<LoadModuleCreateCommand, 'params'> {
   params: LoadModuleParams & {
     model: ModuleModel
   }
@@ -54,8 +50,7 @@ export interface LoadLiquidCreateCommand extends CommonCommandCreateInfo {
   params: LoadLiquidParams
 }
 export interface LoadLiquidRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    LoadLiquidCreateCommand {
+  extends CommonCommandRunTimeInfo, LoadLiquidCreateCommand {
   result?: LoadLiquidResult
 }
 

--- a/shared-data/protocol/types/schemaV6/command/timing.ts
+++ b/shared-data/protocol/types/schemaV6/command/timing.ts
@@ -17,8 +17,7 @@ export interface WaitForResumeCreateCommand extends CommonCommandCreateInfo {
 }
 
 export interface WaitForResumeRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    WaitForResumeCreateCommand {
+  extends CommonCommandRunTimeInfo, WaitForResumeCreateCommand {
   result?: any
 }
 
@@ -32,8 +31,7 @@ export interface WaitForDurationCreateCommand extends CommonCommandCreateInfo {
 }
 
 export interface WaitForDurationRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    WaitForDurationCreateCommand {
+  extends CommonCommandRunTimeInfo, WaitForDurationCreateCommand {
   result?: any
 }
 
@@ -48,8 +46,7 @@ export interface DeprecatedDelayCreateCommand extends CommonCommandCreateInfo {
 }
 
 export interface DeprecatedDelayRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    DeprecatedDelayCreateCommand {
+  extends CommonCommandRunTimeInfo, DeprecatedDelayCreateCommand {
   result?: {}
 }
 

--- a/shared-data/protocol/types/schemaV6/index.ts
+++ b/shared-data/protocol/types/schemaV6/index.ts
@@ -76,8 +76,9 @@ export interface ProtocolFile<DesignerApplicationData = {}> {
  * and should not be mixed with our Protocol types
  * @deprecated Use {@link ProtocolFile}
  */
-export interface ProtocolAnalysisFile<DesignerApplicationData = {}>
-  extends Omit<ProtocolFile<DesignerApplicationData>, 'commands'> {
+export interface ProtocolAnalysisFile<
+  DesignerApplicationData = {},
+> extends Omit<ProtocolFile<DesignerApplicationData>, 'commands'> {
   commands: RunTimeCommand[]
 }
 

--- a/shared-data/protocol/types/schemaV7/command/annotation.ts
+++ b/shared-data/protocol/types/schemaV7/command/annotation.ts
@@ -12,8 +12,7 @@ export interface CommentCreateCommand extends CommonCommandCreateInfo {
 }
 
 export interface CommentRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    CommentCreateCommand {
+  extends CommonCommandRunTimeInfo, CommentCreateCommand {
   result?: any
 }
 
@@ -27,8 +26,7 @@ export interface CustomCreateCommand extends CommonCommandCreateInfo {
 }
 
 export interface CustomRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    CustomCreateCommand {
+  extends CommonCommandRunTimeInfo, CustomCreateCommand {
   result?: any
 }
 

--- a/shared-data/protocol/types/schemaV7/command/calibration.ts
+++ b/shared-data/protocol/types/schemaV7/command/calibration.ts
@@ -19,30 +19,25 @@ export interface CalibrateModuleCreateCommand extends CommonCommandCreateInfo {
   commandType: 'calibration/calibrateModule'
   params: CalibrateModuleParams
 }
-export interface MoveToMaintenancePositionCreateCommand
-  extends CommonCommandCreateInfo {
+export interface MoveToMaintenancePositionCreateCommand extends CommonCommandCreateInfo {
   commandType: 'calibration/moveToMaintenancePosition'
   params: MoveToMaintenancePositionParams
 }
 
 export interface CalibratePipetteRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    CalibratePipetteCreateCommand {
+  extends CommonCommandRunTimeInfo, CalibratePipetteCreateCommand {
   result?: CalibratePipetteResult
 }
 export interface CalibrateGripperRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    CalibrateGripperCreateCommand {
+  extends CommonCommandRunTimeInfo, CalibrateGripperCreateCommand {
   result?: CalibrateGripperResult
 }
 export interface CalibrateModuleRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    CalibrateModuleCreateCommand {
+  extends CommonCommandRunTimeInfo, CalibrateModuleCreateCommand {
   result?: CalibrateModuleResult
 }
 export interface MoveToMaintenancePositionRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    MoveToMaintenancePositionCreateCommand {
+  extends CommonCommandRunTimeInfo, MoveToMaintenancePositionCreateCommand {
   result?: {}
 }
 

--- a/shared-data/protocol/types/schemaV7/command/gantry.ts
+++ b/shared-data/protocol/types/schemaV7/command/gantry.ts
@@ -11,8 +11,7 @@ export interface MoveToSlotCreateCommand extends CommonCommandCreateInfo {
   params: MoveToSlotParams
 }
 export interface MoveToSlotRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    MoveToSlotCreateCommand {
+  extends CommonCommandRunTimeInfo, MoveToSlotCreateCommand {
   result?: {}
 }
 export interface MoveToWellCreateCommand extends CommonCommandCreateInfo {
@@ -20,18 +19,15 @@ export interface MoveToWellCreateCommand extends CommonCommandCreateInfo {
   params: MoveToWellParams
 }
 export interface MoveToWellRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    MoveToWellCreateCommand {
+  extends CommonCommandRunTimeInfo, MoveToWellCreateCommand {
   result?: {}
 }
-export interface MoveToCoordinatesCreateCommand
-  extends CommonCommandCreateInfo {
+export interface MoveToCoordinatesCreateCommand extends CommonCommandCreateInfo {
   commandType: 'moveToCoordinates'
   params: MoveToCoordinatesParams
 }
 export interface MoveToCoordinatesRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    MoveToCoordinatesCreateCommand {
+  extends CommonCommandRunTimeInfo, MoveToCoordinatesCreateCommand {
   result?: {}
 }
 export interface MoveRelativeCreateCommand extends CommonCommandCreateInfo {
@@ -39,8 +35,7 @@ export interface MoveRelativeCreateCommand extends CommonCommandCreateInfo {
   params: MoveRelativeParams
 }
 export interface MoveRelativeRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    MoveRelativeCreateCommand {
+  extends CommonCommandRunTimeInfo, MoveRelativeCreateCommand {
   result?: {
     position: Vector3D
   }
@@ -50,8 +45,7 @@ export interface SavePositionCreateCommand extends CommonCommandCreateInfo {
   params: SavePositionParams
 }
 export interface SavePositionRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    SavePositionCreateCommand {
+  extends CommonCommandRunTimeInfo, SavePositionCreateCommand {
   result?: {
     positionId: string
     position: Vector3D
@@ -62,8 +56,7 @@ export interface HomeCreateCommand extends CommonCommandCreateInfo {
   params: HomeParams
 }
 export interface HomeRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    HomeCreateCommand {
+  extends CommonCommandRunTimeInfo, HomeCreateCommand {
   result?: {}
 }
 
@@ -72,8 +65,7 @@ export interface RetractAxisCreateCommand extends CommonCommandCreateInfo {
   params: RetractAxisParams
 }
 export interface RetractAxisRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    RetractAxisCreateCommand {
+  extends CommonCommandRunTimeInfo, RetractAxisCreateCommand {
   result?: {}
 }
 

--- a/shared-data/protocol/types/schemaV7/command/incidental.ts
+++ b/shared-data/protocol/types/schemaV7/command/incidental.ts
@@ -11,8 +11,7 @@ export interface SetStatusBarCreateCommand extends CommonCommandCreateInfo {
 }
 
 export interface SetStatusBarRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    SetStatusBarCreateCommand {
+  extends CommonCommandRunTimeInfo, SetStatusBarCreateCommand {
   result?: any
 }
 

--- a/shared-data/protocol/types/schemaV7/command/module.ts
+++ b/shared-data/protocol/types/schemaV7/command/module.ts
@@ -48,44 +48,38 @@ export type ModuleCreateCommand =
   | HeaterShakerDeactivateShakerCreateCommand
   | HeaterShakerSetTargetTemperatureCreateCommand
 
-export interface MagneticModuleEngageMagnetCreateCommand
-  extends CommonCommandCreateInfo {
+export interface MagneticModuleEngageMagnetCreateCommand extends CommonCommandCreateInfo {
   commandType: 'magneticModule/engage'
   params: EngageMagnetParams
 }
 export interface MagneticModuleEngageMagnetRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    MagneticModuleEngageMagnetCreateCommand {
+  extends CommonCommandRunTimeInfo, MagneticModuleEngageMagnetCreateCommand {
   result?: any
 }
-export interface MagneticModuleDisengageCreateCommand
-  extends CommonCommandCreateInfo {
+export interface MagneticModuleDisengageCreateCommand extends CommonCommandCreateInfo {
   commandType: 'magneticModule/disengage'
   params: ModuleOnlyParams
 }
 export interface MagneticModuleDisengageRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    MagneticModuleDisengageCreateCommand {
+  extends CommonCommandRunTimeInfo, MagneticModuleDisengageCreateCommand {
   result?: any
 }
-export interface TemperatureModuleSetTargetTemperatureCreateCommand
-  extends CommonCommandCreateInfo {
+export interface TemperatureModuleSetTargetTemperatureCreateCommand extends CommonCommandCreateInfo {
   commandType: 'temperatureModule/setTargetTemperature'
   params: TemperatureParams
 }
 export interface TemperatureModuleSetTargetTemperatureRunTimeCommand
-  extends CommonCommandRunTimeInfo,
+  extends
+    CommonCommandRunTimeInfo,
     TemperatureModuleSetTargetTemperatureCreateCommand {
   result?: any
 }
-export interface TemperatureModuleDeactivateCreateCommand
-  extends CommonCommandCreateInfo {
+export interface TemperatureModuleDeactivateCreateCommand extends CommonCommandCreateInfo {
   commandType: 'temperatureModule/deactivate'
   params: ModuleOnlyParams
 }
 export interface TemperatureModuleDeactivateRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    TemperatureModuleDeactivateCreateCommand {
+  extends CommonCommandRunTimeInfo, TemperatureModuleDeactivateCreateCommand {
   result?: any
 }
 export interface TemperatureModuleAwaitTemperatureParams {
@@ -93,54 +87,46 @@ export interface TemperatureModuleAwaitTemperatureParams {
   moduleId: string
   celsius?: number
 }
-export interface TemperatureModuleAwaitTemperatureCreateCommand
-  extends CommonCommandCreateInfo {
+export interface TemperatureModuleAwaitTemperatureCreateCommand extends CommonCommandCreateInfo {
   commandType: 'temperatureModule/waitForTemperature'
   params: TemperatureModuleAwaitTemperatureParams
 }
 export interface TemperatureModuleAwaitTemperatureRunTimeCommand
-  extends CommonCommandRunTimeInfo,
+  extends
+    CommonCommandRunTimeInfo,
     TemperatureModuleAwaitTemperatureCreateCommand {
   result?: any
 }
-export interface TCSetTargetBlockTemperatureCreateCommand
-  extends CommonCommandCreateInfo {
+export interface TCSetTargetBlockTemperatureCreateCommand extends CommonCommandCreateInfo {
   commandType: 'thermocycler/setTargetBlockTemperature'
   params: ThermocyclerSetTargetBlockTemperatureParams
 }
 export interface TCSetTargetBlockTemperatureRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    TCSetTargetBlockTemperatureCreateCommand {
+  extends CommonCommandRunTimeInfo, TCSetTargetBlockTemperatureCreateCommand {
   result?: any
 }
-export interface TCSetTargetLidTemperatureCreateCommand
-  extends CommonCommandCreateInfo {
+export interface TCSetTargetLidTemperatureCreateCommand extends CommonCommandCreateInfo {
   commandType: 'thermocycler/setTargetLidTemperature'
   params: TemperatureParams
 }
 export interface TCSetTargetLidTemperatureRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    TCSetTargetLidTemperatureCreateCommand {
+  extends CommonCommandRunTimeInfo, TCSetTargetLidTemperatureCreateCommand {
   result?: any
 }
-export interface TCWaitForBlockTemperatureCreateCommand
-  extends CommonCommandCreateInfo {
+export interface TCWaitForBlockTemperatureCreateCommand extends CommonCommandCreateInfo {
   commandType: 'thermocycler/waitForBlockTemperature'
   params: ModuleOnlyParams
 }
 export interface TCWaitForBlockTemperatureRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    TCWaitForBlockTemperatureCreateCommand {
+  extends CommonCommandRunTimeInfo, TCWaitForBlockTemperatureCreateCommand {
   result?: any
 }
-export interface TCWaitForLidTemperatureCreateCommand
-  extends CommonCommandCreateInfo {
+export interface TCWaitForLidTemperatureCreateCommand extends CommonCommandCreateInfo {
   commandType: 'thermocycler/waitForLidTemperature'
   params: ModuleOnlyParams
 }
 export interface TCWaitForLidTemperatureRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    TCWaitForLidTemperatureCreateCommand {
+  extends CommonCommandRunTimeInfo, TCWaitForLidTemperatureCreateCommand {
   result?: any
 }
 export interface TCOpenLidCreateCommand extends CommonCommandCreateInfo {
@@ -148,8 +134,7 @@ export interface TCOpenLidCreateCommand extends CommonCommandCreateInfo {
   params: ModuleOnlyParams
 }
 export interface TCOpenLidRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    TCOpenLidCreateCommand {
+  extends CommonCommandRunTimeInfo, TCOpenLidCreateCommand {
   result?: any
 }
 export interface TCCloseLidCreateCommand extends CommonCommandCreateInfo {
@@ -157,18 +142,15 @@ export interface TCCloseLidCreateCommand extends CommonCommandCreateInfo {
   params: ModuleOnlyParams
 }
 export interface TCCloseLidRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    TCCloseLidCreateCommand {
+  extends CommonCommandRunTimeInfo, TCCloseLidCreateCommand {
   result?: any
 }
-export interface TCDeactivateBlockCreateCommand
-  extends CommonCommandCreateInfo {
+export interface TCDeactivateBlockCreateCommand extends CommonCommandCreateInfo {
   commandType: 'thermocycler/deactivateBlock'
   params: ModuleOnlyParams
 }
 export interface TCDeactivateBlockRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    TCDeactivateBlockCreateCommand {
+  extends CommonCommandRunTimeInfo, TCDeactivateBlockCreateCommand {
   result?: any
 }
 export interface TCDeactivateLidCreateCommand extends CommonCommandCreateInfo {
@@ -176,8 +158,7 @@ export interface TCDeactivateLidCreateCommand extends CommonCommandCreateInfo {
   params: ModuleOnlyParams
 }
 export interface TCDeactivateLidRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    TCDeactivateLidCreateCommand {
+  extends CommonCommandRunTimeInfo, TCDeactivateLidCreateCommand {
   result?: any
 }
 export interface TCRunProfileCreateCommand extends CommonCommandCreateInfo {
@@ -185,88 +166,77 @@ export interface TCRunProfileCreateCommand extends CommonCommandCreateInfo {
   params: TCProfileParams
 }
 export interface TCRunProfileRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    TCRunProfileCreateCommand {
+  extends CommonCommandRunTimeInfo, TCRunProfileCreateCommand {
   result?: any
 }
-export interface TCAwaitProfileCompleteCreateCommand
-  extends CommonCommandCreateInfo {
+export interface TCAwaitProfileCompleteCreateCommand extends CommonCommandCreateInfo {
   commandType: 'thermocycler/awaitProfileComplete'
   params: ModuleOnlyParams
 }
 export interface TCAwaitProfileCompleteRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    TCAwaitProfileCompleteCreateCommand {
+  extends CommonCommandRunTimeInfo, TCAwaitProfileCompleteCreateCommand {
   result?: any
 }
-export interface HeaterShakerSetTargetTemperatureCreateCommand
-  extends CommonCommandCreateInfo {
+export interface HeaterShakerSetTargetTemperatureCreateCommand extends CommonCommandCreateInfo {
   commandType: 'heaterShaker/setTargetTemperature'
   params: TemperatureParams
 }
 export interface HeaterShakerSetTargetTemperatureRunTimeCommand
-  extends CommonCommandRunTimeInfo,
+  extends
+    CommonCommandRunTimeInfo,
     HeaterShakerSetTargetTemperatureCreateCommand {
   result?: any
 }
-export interface HeaterShakerWaitForTemperatureCreateCommand
-  extends CommonCommandCreateInfo {
+export interface HeaterShakerWaitForTemperatureCreateCommand extends CommonCommandCreateInfo {
   commandType: 'heaterShaker/waitForTemperature'
   params: ModuleOnlyParams
 }
 export interface HeaterShakerWaitForTemperatureRunTimeCommand
-  extends CommonCommandRunTimeInfo,
+  extends
+    CommonCommandRunTimeInfo,
     HeaterShakerWaitForTemperatureCreateCommand {
   result?: any
 }
-export interface HeaterShakerSetAndWaitForShakeSpeedCreateCommand
-  extends CommonCommandCreateInfo {
+export interface HeaterShakerSetAndWaitForShakeSpeedCreateCommand extends CommonCommandCreateInfo {
   commandType: 'heaterShaker/setAndWaitForShakeSpeed'
   params: ShakeSpeedParams
 }
 export interface HeaterShakerSetAndWaitForShakeSpeedRunTimeCommand
-  extends CommonCommandRunTimeInfo,
+  extends
+    CommonCommandRunTimeInfo,
     HeaterShakerSetAndWaitForShakeSpeedCreateCommand {
   result?: any
 }
-export interface HeaterShakerDeactivateHeaterCreateCommand
-  extends CommonCommandCreateInfo {
+export interface HeaterShakerDeactivateHeaterCreateCommand extends CommonCommandCreateInfo {
   commandType: 'heaterShaker/deactivateHeater'
   params: ModuleOnlyParams
 }
 export interface HeaterShakerDeactivateHeaterRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    HeaterShakerDeactivateHeaterCreateCommand {
+  extends CommonCommandRunTimeInfo, HeaterShakerDeactivateHeaterCreateCommand {
   result?: any
 }
-export interface HeaterShakerOpenLatchCreateCommand
-  extends CommonCommandCreateInfo {
+export interface HeaterShakerOpenLatchCreateCommand extends CommonCommandCreateInfo {
   commandType: 'heaterShaker/openLabwareLatch'
   params: ModuleOnlyParams
 }
 export interface HeaterShakerOpenLatchRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    HeaterShakerOpenLatchCreateCommand {
+  extends CommonCommandRunTimeInfo, HeaterShakerOpenLatchCreateCommand {
   result?: any
 }
-export interface HeaterShakerCloseLatchCreateCommand
-  extends CommonCommandCreateInfo {
+export interface HeaterShakerCloseLatchCreateCommand extends CommonCommandCreateInfo {
   commandType: 'heaterShaker/closeLabwareLatch'
   params: ModuleOnlyParams
 }
 export interface HeaterShakerCloseLatchRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    HeaterShakerCloseLatchCreateCommand {
+  extends CommonCommandRunTimeInfo, HeaterShakerCloseLatchCreateCommand {
   result?: any
 }
-export interface HeaterShakerDeactivateShakerCreateCommand
-  extends CommonCommandCreateInfo {
+export interface HeaterShakerDeactivateShakerCreateCommand extends CommonCommandCreateInfo {
   commandType: 'heaterShaker/deactivateShaker'
   params: ModuleOnlyParams
 }
 export interface HeaterShakerDeactivateShakerRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    HeaterShakerDeactivateShakerCreateCommand {
+  extends CommonCommandRunTimeInfo, HeaterShakerDeactivateShakerCreateCommand {
   result?: any
 }
 

--- a/shared-data/protocol/types/schemaV7/command/pipetting.ts
+++ b/shared-data/protocol/types/schemaV7/command/pipetting.ts
@@ -22,8 +22,7 @@ export type PipettingCreateCommand =
   | DropTipInPlaceCreateCommand
   | ConfigureForVolumeCreateCommand
 
-export interface ConfigureForVolumeCreateCommand
-  extends CommonCommandCreateInfo {
+export interface ConfigureForVolumeCreateCommand extends CommonCommandCreateInfo {
   commandType: 'configureForVolume'
   params: ConfigureForVolumeParams
 }
@@ -33,8 +32,7 @@ export interface ConfigureForVolumeParams {
   volume: number
 }
 export interface ConfigureForVolumeRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    ConfigureForVolumeCreateCommand {
+  extends CommonCommandRunTimeInfo, ConfigureForVolumeCreateCommand {
   result?: BasicLiquidHandlingResult
 }
 export interface AspirateCreateCommand extends CommonCommandCreateInfo {
@@ -42,8 +40,7 @@ export interface AspirateCreateCommand extends CommonCommandCreateInfo {
   params: AspDispAirgapParams
 }
 export interface AspirateRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    AspirateCreateCommand {
+  extends CommonCommandRunTimeInfo, AspirateCreateCommand {
   result?: BasicLiquidHandlingResult
 }
 
@@ -53,8 +50,7 @@ export interface DispenseCreateCommand extends CommonCommandCreateInfo {
   params: DispenseParams
 }
 export interface DispenseRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    DispenseCreateCommand {
+  extends CommonCommandRunTimeInfo, DispenseCreateCommand {
   result?: BasicLiquidHandlingResult
 }
 export interface BlowoutCreateCommand extends CommonCommandCreateInfo {
@@ -62,8 +58,7 @@ export interface BlowoutCreateCommand extends CommonCommandCreateInfo {
   params: BlowoutParams
 }
 export interface BlowoutRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    BlowoutCreateCommand {
+  extends CommonCommandRunTimeInfo, BlowoutCreateCommand {
   result?: BasicLiquidHandlingResult
 }
 export interface BlowoutInPlaceCreateCommand extends CommonCommandCreateInfo {
@@ -71,8 +66,7 @@ export interface BlowoutInPlaceCreateCommand extends CommonCommandCreateInfo {
   params: BlowoutInPlaceParams
 }
 export interface BlowoutInPlaceRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    BlowoutInPlaceCreateCommand {
+  extends CommonCommandRunTimeInfo, BlowoutInPlaceCreateCommand {
   result?: BasicLiquidHandlingResult
 }
 
@@ -81,8 +75,7 @@ export interface TouchTipCreateCommand extends CommonCommandCreateInfo {
   params: TouchTipParams
 }
 export interface TouchTipRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    TouchTipCreateCommand {
+  extends CommonCommandRunTimeInfo, TouchTipCreateCommand {
   result?: BasicLiquidHandlingResult
 }
 export interface PickUpTipCreateCommand extends CommonCommandCreateInfo {
@@ -90,8 +83,7 @@ export interface PickUpTipCreateCommand extends CommonCommandCreateInfo {
   params: PickUpTipParams
 }
 export interface PickUpTipRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    PickUpTipCreateCommand {
+  extends CommonCommandRunTimeInfo, PickUpTipCreateCommand {
   result?: any
 }
 export interface DropTipCreateCommand extends CommonCommandCreateInfo {
@@ -99,8 +91,7 @@ export interface DropTipCreateCommand extends CommonCommandCreateInfo {
   params: DropTipParams
 }
 export interface DropTipRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    DropTipCreateCommand {
+  extends CommonCommandRunTimeInfo, DropTipCreateCommand {
   result?: any
 }
 export interface DropTipInPlaceCreateCommand extends CommonCommandCreateInfo {
@@ -108,8 +99,7 @@ export interface DropTipInPlaceCreateCommand extends CommonCommandCreateInfo {
   params: DropTipInPlaceParams
 }
 export interface DropTipInPlaceRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    DropTipInPlaceCreateCommand {
+  extends CommonCommandRunTimeInfo, DropTipInPlaceCreateCommand {
   result?: any
 }
 

--- a/shared-data/protocol/types/schemaV7/command/setup.ts
+++ b/shared-data/protocol/types/schemaV7/command/setup.ts
@@ -12,8 +12,7 @@ export interface LoadPipetteCreateCommand extends CommonCommandCreateInfo {
   params: LoadPipetteParams
 }
 export interface LoadPipetteRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    Omit<LoadPipetteCreateCommand, 'params'> {
+  extends CommonCommandRunTimeInfo, Omit<LoadPipetteCreateCommand, 'params'> {
   params: LoadPipetteParams & {
     pipetteName: PipetteName
   }
@@ -24,8 +23,7 @@ export interface LoadLabwareCreateCommand extends CommonCommandCreateInfo {
   params: LoadLabwareParams
 }
 export interface LoadLabwareRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    LoadLabwareCreateCommand {
+  extends CommonCommandRunTimeInfo, LoadLabwareCreateCommand {
   result?: LoadLabwareResult
 }
 export interface MoveLabwareCreateCommand extends CommonCommandCreateInfo {
@@ -33,8 +31,7 @@ export interface MoveLabwareCreateCommand extends CommonCommandCreateInfo {
   params: MoveLabwareParams
 }
 export interface MoveLabwareRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    MoveLabwareCreateCommand {
+  extends CommonCommandRunTimeInfo, MoveLabwareCreateCommand {
   result?: MoveLabwareResult
 }
 export interface LoadModuleCreateCommand extends CommonCommandCreateInfo {
@@ -42,8 +39,7 @@ export interface LoadModuleCreateCommand extends CommonCommandCreateInfo {
   params: LoadModuleParams
 }
 export interface LoadModuleRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    Omit<LoadModuleCreateCommand, 'params'> {
+  extends CommonCommandRunTimeInfo, Omit<LoadModuleCreateCommand, 'params'> {
   params: LoadModuleParams & {
     model: ModuleModel
   }
@@ -54,8 +50,7 @@ export interface LoadLiquidCreateCommand extends CommonCommandCreateInfo {
   params: LoadLiquidParams
 }
 export interface LoadLiquidRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    LoadLiquidCreateCommand {
+  extends CommonCommandRunTimeInfo, LoadLiquidCreateCommand {
   result?: LoadLiquidResult
 }
 

--- a/shared-data/protocol/types/schemaV7/command/timing.ts
+++ b/shared-data/protocol/types/schemaV7/command/timing.ts
@@ -17,8 +17,7 @@ export interface WaitForResumeCreateCommand extends CommonCommandCreateInfo {
 }
 
 export interface WaitForResumeRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    WaitForResumeCreateCommand {
+  extends CommonCommandRunTimeInfo, WaitForResumeCreateCommand {
   result?: any
 }
 
@@ -32,8 +31,7 @@ export interface WaitForDurationCreateCommand extends CommonCommandCreateInfo {
 }
 
 export interface WaitForDurationRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    WaitForDurationCreateCommand {
+  extends CommonCommandRunTimeInfo, WaitForDurationCreateCommand {
   result?: any
 }
 
@@ -48,8 +46,7 @@ export interface DeprecatedDelayCreateCommand extends CommonCommandCreateInfo {
 }
 
 export interface DeprecatedDelayRunTimeCommand
-  extends CommonCommandRunTimeInfo,
-    DeprecatedDelayCreateCommand {
+  extends CommonCommandRunTimeInfo, DeprecatedDelayCreateCommand {
   result?: {}
 }
 

--- a/shared-data/protocol/types/schemaV7/index.ts
+++ b/shared-data/protocol/types/schemaV7/index.ts
@@ -57,8 +57,9 @@ export interface ProtocolFile<DesignerApplicationData = {}> {
  * and should not be mixed with our Protocol types
  * @deprecated Use {@link ProtocolFile}
  */
-export interface ProtocolAnalysisFile<DesignerApplicationData = {}>
-  extends Omit<ProtocolFile<DesignerApplicationData>, 'commands'> {
+export interface ProtocolAnalysisFile<
+  DesignerApplicationData = {},
+> extends Omit<ProtocolFile<DesignerApplicationData>, 'commands'> {
   commands: RunTimeCommand[]
 }
 

--- a/step-generation/src/commandCreators/atomic/moveToAddressableArea.ts
+++ b/step-generation/src/commandCreators/atomic/moveToAddressableArea.ts
@@ -11,8 +11,10 @@ import type {
 } from '@opentrons/shared-data'
 import type { CommandCreator } from '../../types'
 
-interface MoveToAddressableAreaAtomicParams
-  extends Omit<MoveToAddressableAreaParams, 'addressableAreaName'> {
+interface MoveToAddressableAreaAtomicParams extends Omit<
+  MoveToAddressableAreaParams,
+  'addressableAreaName'
+> {
   fixtureId: string
 }
 export const moveToAddressableArea: CommandCreator<

--- a/step-generation/src/utils/absorbanceReaderCollision.ts
+++ b/step-generation/src/utils/absorbanceReaderCollision.ts
@@ -14,8 +14,8 @@ export const absorbanceReaderCollision = (
   const moduleState = moduleId != null ? modules[moduleId].moduleState : null
   const isAbsorbanceReaderLidClosed: boolean = Boolean(
     moduleState &&
-      moduleState.type === ABSORBANCE_READER_TYPE &&
-      moduleState.lidOpen !== true
+    moduleState.type === ABSORBANCE_READER_TYPE &&
+    moduleState.lidOpen !== true
   )
   return isAbsorbanceReaderLidClosed
 }

--- a/step-generation/src/utils/heaterShakerCollision.ts
+++ b/step-generation/src/utils/heaterShakerCollision.ts
@@ -93,8 +93,8 @@ export const pipetteIntoHeaterShakerLatchOpen = (
   const moduleState = moduleId != null ? modules[moduleId].moduleState : null
   const isHSLatchOpen: boolean = Boolean(
     moduleState &&
-      moduleState.type === HEATERSHAKER_MODULE_TYPE &&
-      moduleState.latchOpen !== false
+    moduleState.type === HEATERSHAKER_MODULE_TYPE &&
+    moduleState.latchOpen !== false
   )
   return isHSLatchOpen
 }
@@ -128,8 +128,8 @@ export const pipetteIntoHeaterShakerWhileShaking = (
   const moduleState = moduleId != null ? modules[moduleId].moduleState : null
   const isShaking: boolean = Boolean(
     moduleState &&
-      moduleState.type === HEATERSHAKER_MODULE_TYPE &&
-      moduleState.targetSpeed !== null
+    moduleState.type === HEATERSHAKER_MODULE_TYPE &&
+    moduleState.targetSpeed !== null
   )
   return isShaking
 }

--- a/step-generation/src/utils/thermocyclerPipetteCollision.ts
+++ b/step-generation/src/utils/thermocyclerPipetteCollision.ts
@@ -17,8 +17,8 @@ export const thermocyclerPipetteCollision = (
   const moduleState = moduleId && modules[moduleId].moduleState
   const isTCLidClosed: boolean = Boolean(
     moduleState &&
-      moduleState.type === THERMOCYCLER_MODULE_TYPE &&
-      moduleState.lidOpen !== true
+    moduleState.type === THERMOCYCLER_MODULE_TYPE &&
+    moduleState.lidOpen !== true
   )
   return isTCLidClosed
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12588,18 +12588,6 @@ form-data@2.5.4:
     mime-types "^2.1.35"
     safe-buffer "^5.2.1"
 
-form-data@2.5.4:
-  version "2.5.4"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.5.4.tgz#7716681ab59ddb36c0a8ffd9e506ea3083e7e8d4"
-  integrity sha512-Y/3MmRiR8Nd+0CUtrbvcKtKzLWiUfpQ7DFVggH8PwmGt/0r7RSy32GuP4hpCJlQNEBusisSx1DLtD8uD386HJQ==
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.8"
-    es-set-tostringtag "^2.1.0"
-    has-own "^1.0.1"
-    mime-types "^2.1.35"
-    safe-buffer "^5.2.1"
-
 form-data@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
@@ -18600,10 +18588,10 @@ prepend-http@^2.0.0:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha512-ravE6m9Atw9Z/jjttRUZ+clIXogdghyZAuWJ3qEzjT+jI/dL1ifAqhZeC5VHzQp1MSt1+jxKkFNemj/iO7tVUA==
 
-prettier@3.6.2:
-  version "3.6.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.6.2.tgz#ccda02a1003ebbb2bfda6f83a074978f608b9393"
-  integrity sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==
+prettier@3.7.0:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.7.0.tgz#d6ce84a345ff7e3b663ca104b949a0365df28978"
+  integrity sha512-pBiBj/gjRY9Qpk1b7cDda6Rbwvkaggos779AHQ0Ek/odwDx6xG6DRBxtnp1QmxbuD7pAO8/SQ8vuhtGv9LoLWA==
 
 prettier@^2.8.0:
   version "2.8.8"


### PR DESCRIPTION
# Overview
update prettier to v3.7.0

https://prettier.io/blog/2025/11/27/3.7.0

close AUTH-2570


## Test Plan and Hands on Testing
1. make teardown-js && make setup-js
2. make check-js
3. make lint-js

## Changelog
- update prettier from 3.6.2 to 3.7.0

## Review requests


## Risk assessment
low
