### PR TITLE
refactor(app): update zipfile naming convention

### DIFF
--- a/app/src/assets/localization/en/run_details.json
+++ b/app/src/assets/localization/en/run_details.json
@@ -77,7 +77,6 @@
   "image_gallery": "Image Gallery",
   "image_in_gallery": "The image has been added to your gallery where it can be viewed at anytime.",
   "image_loading": "Image loading",
-  "images": "Images",
   "images_available_download": "Image files associated with the run are available on the robot’s Recent Runs screen and Camera tab.",
   "instrument_calibration_incomplete": "Instrument calibration is incomplete",
   "labware": "labware",

--- a/app/src/organisms/Desktop/Devices/HistoricalProtocolRunDrawer.tsx
+++ b/app/src/organisms/Desktop/Devices/HistoricalProtocolRunDrawer.tsx
@@ -392,7 +392,7 @@ function ImagesFileDataRow({
   const { data: imagesZipFile, isLoading } = useAllRunImagesRaw(run.id)
   const formattedRunTs = format(new Date(run.createdAt), 'yyyyMMdd-HHmmss')
   const buildImagesZipName = (): string =>
-    `${robotName}_${protocolName}_${formattedRunTs}_${t('images')}.zip`
+    `${robotName}_${protocolName}_${formattedRunTs}.zip`
 
   return (
     <Flex

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunCamera/ImageGalleryContainer/GalleryContainerOverflowMenu.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunCamera/ImageGalleryContainer/GalleryContainerOverflowMenu.tsx
@@ -60,7 +60,7 @@ export function GalleryContainerOverflowMenu({
     }
   })()
   const buildImagesZipName = (): string =>
-    `${robotName}_${protocolName}_${formattedRunTs}_${t('images')}.zip`
+    `${robotName}_${protocolName}_${formattedRunTs}.zip`
 
   const onDownloadZip = (): void => {
     setShowOverflowMenu(false)


### PR DESCRIPTION
Closes [EXEC-2134](https://opentrons.atlassian.net/browse/EXEC-2134)

# Overview

Design has requested that we update the zip file naming convention not to include an i18n "images" at the end.

<img width="1016" height="768" alt="Screenshot 2025-12-15 at 1 35 34 PM" src="https://github.com/user-attachments/assets/f8784636-7016-4f07-bcc9-ee7d18575b8f" />


## Risk assessment

none, just a copy update


[EXEC-2134]: https://opentrons.atlassian.net/browse/EXEC-2134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ