### PR TITLE
refactor(protocol-designer, step-generation): remove remaining maxPoolCount prop

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/FlexStackerTools/__tests__/FlexStackerTools.test.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/FlexStackerTools/__tests__/FlexStackerTools.test.tsx
@@ -70,7 +70,6 @@ describe('FlexStackerTools', () => {
         [mockStackerId]: {
           moduleState: {
             type: FLEX_STACKER_MODULE_TYPE,
-            maxPoolCount: 6,
             storedLabwareDetails: {
               primaryLabwareURI: 'mockLabwareURI',
               lidLabwareURI: 'mockLidLabwareURI',
@@ -117,7 +116,6 @@ describe('FlexStackerTools', () => {
         [mockStackerId]: {
           moduleState: {
             type: FLEX_STACKER_MODULE_TYPE,
-            maxPoolCount: 6,
             storedLabwareDetails: {
               primaryLabwareURI: 'fixture/fixture_flex_96_tiprack_1000ul/1',
               lidLabwareURI: null,
@@ -148,7 +146,6 @@ describe('FlexStackerTools', () => {
         [mockStackerId]: {
           moduleState: {
             type: FLEX_STACKER_MODULE_TYPE,
-            maxPoolCount: 6,
             storedLabwareDetails: null,
             labwareInHopper: [],
             labwareOnShuttle: null,
@@ -167,7 +164,6 @@ describe('FlexStackerTools', () => {
         [mockStackerId]: {
           moduleState: {
             type: FLEX_STACKER_MODULE_TYPE,
-            maxPoolCount: 6,
             storedLabwareDetails: null,
             labwareInHopper: [],
             labwareOnShuttle: {
@@ -191,7 +187,6 @@ describe('FlexStackerTools', () => {
         [mockStackerId]: {
           moduleState: {
             type: FLEX_STACKER_MODULE_TYPE,
-            maxPoolCount: 6,
             storedLabwareDetails: null,
             labwareInHopper: [],
             labwareOnShuttle: null,

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/FlexStackerTools/__tests__/FlexStackerTools.test.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/FlexStackerTools/__tests__/FlexStackerTools.test.tsx
@@ -44,7 +44,6 @@ const mockRobotState = makeInitialRobotState({
       moduleState: {
         type: FLEX_STACKER_MODULE_TYPE,
         storedLabwareDetails: null,
-        maxPoolCount: 6,
         labwareInHopper: [],
         labwareOnShuttle: null,
       },

--- a/protocol-designer/src/step-forms/selectors/index.ts
+++ b/protocol-designer/src/step-forms/selectors/index.ts
@@ -207,7 +207,6 @@ export const getInitialDeckSetupStepForm: Selector<BaseState, FormData> =
 // todo(mm, 2025-12-12): Temporarily defining FLEX_STACKER_INITIAL_STATE here until step-generation supports it.
 const FLEX_STACKER_INITIAL_STATE: FlexStackerModuleState = {
   type: FLEX_STACKER_MODULE_TYPE,
-  maxPoolCount: 0,
   storedLabwareDetails: null,
   labwareInHopper: null,
   labwareOnShuttle: null,

--- a/step-generation/src/commandCreators/atomic/__tests__/flexStackerEmpty.test.ts
+++ b/step-generation/src/commandCreators/atomic/__tests__/flexStackerEmpty.test.ts
@@ -43,7 +43,6 @@ describe('flexStackerEmpty', () => {
       slot: 'D3',
       moduleState: {
         type: FLEX_STACKER_MODULE_TYPE,
-        maxPoolCount: 6,
         storedLabwareDetails: null,
         labwareOnShuttle: null,
         labwareInHopper: null,

--- a/step-generation/src/commandCreators/atomic/__tests__/flexStackerFillItems.test.ts
+++ b/step-generation/src/commandCreators/atomic/__tests__/flexStackerFillItems.test.ts
@@ -136,7 +136,6 @@ describe('flexStackerFillItems', () => {
           lidLabwareId: null,
         },
       ],
-      maxPoolCount: 10,
       storedLabwareDetails: {
         primaryLabwareURI: 'mockURI',
         lidLabwareURI: null,
@@ -331,7 +330,6 @@ mock_flex_stacker_1.fill_items(
           lidLabwareId: null,
         },
       ],
-      maxPoolCount: 1,
       storedLabwareDetails: {
         primaryLabwareURI: 'fixture/fixture_tiprack_300_ul/1',
         lidLabwareURI: null,

--- a/step-generation/src/commandCreators/atomic/__tests__/flexStackerRetrieve.test.ts
+++ b/step-generation/src/commandCreators/atomic/__tests__/flexStackerRetrieve.test.ts
@@ -172,7 +172,6 @@ describe('flexStackerRetrieve', () => {
         lidLabwareId: null,
       },
       labwareInHopper: null,
-      maxPoolCount: 10,
       storedLabwareDetails: null,
       type: FLEX_STACKER_MODULE_TYPE,
     })

--- a/step-generation/src/commandCreators/atomic/__tests__/flexStackerStore.test.ts
+++ b/step-generation/src/commandCreators/atomic/__tests__/flexStackerStore.test.ts
@@ -58,7 +58,6 @@ describe('flexStackerStore', () => {
           lidLabwareId: null,
         },
       ],
-      maxPoolCount: 10,
       storedLabwareDetails: {
         primaryLabwareURI: 'mockURI',
         lidLabwareURI: null,
@@ -107,7 +106,6 @@ describe('flexStackerStore', () => {
     vi.mocked(flexStackerStateGetter).mockReturnValue({
       labwareOnShuttle: null,
       labwareInHopper: null,
-      maxPoolCount: 10,
       storedLabwareDetails: null,
       type: FLEX_STACKER_MODULE_TYPE,
     })
@@ -159,7 +157,6 @@ describe('flexStackerStore', () => {
           lidLabwareId: null,
         },
       ],
-      maxPoolCount: 10,
       storedLabwareDetails: {
         primaryLabwareURI: 'mockURI',
         lidLabwareURI: null,
@@ -260,7 +257,6 @@ describe('flexStackerStore', () => {
           lidLabwareId: null,
         },
       ],
-      maxPoolCount: 1,
       storedLabwareDetails: {
         primaryLabwareURI: 'fixture/fixture_tiprack_300_ul/1',
         lidLabwareURI: null,

--- a/step-generation/src/constants.ts
+++ b/step-generation/src/constants.ts
@@ -73,7 +73,6 @@ export const MAGNETIC_BLOCK_INITIAL_STATE: MagneticBlockState = {
 
 export const FLEX_STACKER_MODULE_INITIAL_STATE: FlexStackerModuleState = {
   type: FLEX_STACKER_MODULE_TYPE,
-  maxPoolCount: 0,
   storedLabwareDetails: null,
   labwareInHopper: null,
   labwareOnShuttle: null,

--- a/step-generation/src/getNextRobotStateAndWarnings/__tests__/stackerUpdates.test.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/__tests__/stackerUpdates.test.ts
@@ -48,7 +48,6 @@ describe('flex stacker state updates forFlexStackerEmpty', () => {
             lidLabwareId: null,
           },
         ],
-        maxPoolCount: 6,
         storedLabwareDetails: {
           primaryLabwareURI: LABWARE_ID,
         },
@@ -124,7 +123,6 @@ describe('flex stacker state updates forFlexStackerFill', () => {
             lidLabwareId: null,
           },
         ],
-        maxPoolCount: 6,
         storedLabwareDetails: {
           primaryLabwareURI: LABWARE_ID,
         },
@@ -169,7 +167,6 @@ describe('flex stacker state updates forFlexStackerFill', () => {
       strategy: 'logical' as const,
     }
     forFlexStackerFill(props, invariantContext, { robotState, warnings: [] })
-
     const moduleState = flexStackerStateGetter(robotState, FLEX_STACKER_ID)
     expect(moduleState?.labwareInHopper).toHaveLength(3)
   })
@@ -195,7 +192,6 @@ describe('flex stacker state updates forFlexStackerRetrieve', () => {
             lidLabwareId: null,
           },
         ],
-        maxPoolCount: 6,
         storedLabwareDetails: {
           primaryLabwareURI: LABWARE_ID,
         },
@@ -230,7 +226,6 @@ describe('flex stacker state updates forFlexStackerRetrieve', () => {
             lidLabwareId: null,
           },
         ],
-        maxPoolCount: 6,
         storedLabwareDetails: {
           primaryLabwareURI: LABWARE_ID,
         },
@@ -290,7 +285,6 @@ describe('flex stacker state updates forFlexStackerStore', () => {
             lidLabwareId: null,
           },
         ],
-        maxPoolCount: 6,
         storedLabwareDetails: {
           primaryLabwareURI: LABWARE_ID,
         },

--- a/step-generation/src/types.ts
+++ b/step-generation/src/types.ts
@@ -110,7 +110,6 @@ export interface AbsorbanceReaderState {
 
 export interface FlexStackerModuleState {
   type: typeof FLEX_STACKER_MODULE_TYPE
-  maxPoolCount: number
   storedLabwareDetails: StackerStoredLabwareDefinitionURIs | null
   // labware in hopper is the bottom up
   labwareInHopper: FlexStackerStoredLabwareGroup[] | null


### PR DESCRIPTION
# Overview

Removes remaining mentions of `maxPoolCount` since we can get this property from the hopper's set stored labware

## Test Plan and Hands on Testing

ran unit tests and all passed!

## Risk assessment

low
