### PR TITLE
refactor(step-generation, protocol-designer): refactor empty & store state fns

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/AddStepButton.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/AddStepButton.tsx
@@ -32,6 +32,7 @@ import {
   getIsTiprack,
   HEATERSHAKER_MODULE_TYPE,
   MAGNETIC_MODULE_TYPE,
+  SYSTEM_LOCATION,
   TEMPERATURE_MODULE_TYPE,
   THERMOCYCLER_MODULE_TYPE,
 } from '@opentrons/shared-data'
@@ -112,6 +113,7 @@ export function AddStepButton({
   ).some(([labwareId, { stack }]) => {
     const labwareDef = labwareEntities[labwareId]?.def
     const slot = getSlotInLocationStack(stack)
+    const isInaccessible = slot === SYSTEM_LOCATION
     const isLidOnSlot = labwareDef != null ? getIsLid(labwareDef) : false
     const isStackerInSlot = Object.values(modules).some(
       module =>
@@ -119,6 +121,7 @@ export function AddStepButton({
         moduleAtLastState[module.id].slot === slot
     )
     return (
+      !isInaccessible &&
       labwareDef != null &&
       slot !== OFFDECK &&
       !getIsTiprack(labwareDef) &&

--- a/protocol-designer/src/pages/Designer/utils.ts
+++ b/protocol-designer/src/pages/Designer/utils.ts
@@ -10,6 +10,7 @@ import {
   getIsTiprack,
   getPositionFromSlotId,
   MOVABLE_TRASH_ADDRESSABLE_AREAS,
+  SYSTEM_LOCATION,
   TC_MODULE_LOCATION_OT2,
   TC_MODULE_LOCATION_OT3,
   THERMOCYCLER_MODULE_TYPE,
@@ -313,7 +314,7 @@ export const useLabwareDropdownOptions = (
       const deckSlot = getSlotInLocationStack(
         deckSetupLabware[labwareId]?.stack
       )
-
+      const isInaccessible = deckSlot === SYSTEM_LOCATION
       const isOffDeck = deckSlot === 'offDeck'
       const fullStackFromLabwares = getFullStackFromLabwares(
         deckSetupLabware,
@@ -354,6 +355,7 @@ export const useLabwareDropdownOptions = (
 
       //  TODO: refactor this to be easier to read
       const options: DropdownOption[] =
+        isInaccessible ||
         (type === 'labware' && isOnStacker) ||
         isAdapter ||
         isLabwareInTrash ||

--- a/shared-data/js/constants.ts
+++ b/shared-data/js/constants.ts
@@ -851,3 +851,7 @@ export const COMBO_FIXTURES: CutoutFixtureIdsWithFakes[] = [
   ...FAKE_FIXTURE_IDS,
   ...STAGING_AREA_FIXTURES,
 ]
+
+// a labware location when something has been used already on the deck
+// and moves to a new location that isn't accessible on or off the deck
+export const SYSTEM_LOCATION = 'systemLocation'

--- a/step-generation/src/getNextRobotStateAndWarnings/__tests__/stackerUpdates.test.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/__tests__/stackerUpdates.test.ts
@@ -5,8 +5,10 @@ import {
   getHeightOfLabwareStackFromDefinitions,
   getLabwareOverlapOffset,
   getStackerMaxPoolCountByHeight,
+  SYSTEM_LOCATION,
 } from '@opentrons/shared-data'
 
+import { HOPPER_STACKER_LOCATION } from '../../constants'
 import { getInitialRobotStateStandard, makeContext } from '../../fixtures'
 import { flexStackerStateGetter } from '../../robotStateSelectors'
 import {
@@ -55,6 +57,11 @@ describe('flex stacker state updates forFlexStackerEmpty', () => {
         labwareOnShuttle: null,
       },
     }
+    robotState.labware = {
+      [LABWARE_ID]: {
+        stack: [LABWARE_ID, HOPPER_STACKER_LOCATION, FLEX_STACKER_ID, '1'],
+      },
+    }
   })
   afterEach(() => {
     vi.restoreAllMocks()
@@ -79,6 +86,11 @@ describe('flex stacker state updates forFlexStackerEmpty', () => {
         lidLabwareId: null,
       },
     ])
+    expect(robotState.labware).toEqual({
+      [LABWARE_ID]: {
+        stack: [LABWARE_ID, SYSTEM_LOCATION],
+      },
+    })
   })
 
   it('should remove all items from the stored stacker list if count is null', () => {
@@ -308,6 +320,14 @@ describe('flex stacker state updates forFlexStackerStore', () => {
   })
 
   it('should store the labware in the stacker', () => {
+    robotState.labware = {
+      [LABWARE_ID]: {
+        stack: [LABWARE_ID, SYSTEM_LOCATION],
+      },
+      tiprack4Id: {
+        stack: ['tiprack4Id', FLEX_STACKER_ID, '1'],
+      },
+    }
     forFlexStackerStore(
       { moduleId: FLEX_STACKER_ID, strategy: 'automatic' },
       invariantContext,
@@ -320,6 +340,11 @@ describe('flex stacker state updates forFlexStackerStore', () => {
     const moduleState = flexStackerStateGetter(robotState, FLEX_STACKER_ID)
     expect(moduleState?.labwareOnShuttle).toBeNull()
     expect(moduleState?.labwareInHopper).toHaveLength(4)
-    expect(robotState.labware.tiprack1Id.stack).toEqual(['tiprack1Id', '1'])
+    expect(robotState.labware.tiprack4Id.stack).toEqual([
+      'tiprack4Id',
+      HOPPER_STACKER_LOCATION,
+      FLEX_STACKER_ID,
+      '1',
+    ])
   })
 })

--- a/step-generation/src/getNextRobotStateAndWarnings/stackerUpdates.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/stackerUpdates.ts
@@ -3,6 +3,7 @@ import {
   getHeightOfLabwareStackFromDefinitions,
   getLabwareOverlapOffset,
   getStackerMaxPoolCountByHeight,
+  SYSTEM_LOCATION,
 } from '@opentrons/shared-data'
 
 import { HOPPER_STACKER_LOCATION } from '../constants'
@@ -29,6 +30,11 @@ export const forFlexStackerEmpty = (
 ): void => {
   const { robotState } = robotStateAndWarnings
   const { moduleId } = params
+  const labwareInHopper = Object.entries(robotState.labware).filter(
+    ([, labware]) =>
+      labware.stack.includes(HOPPER_STACKER_LOCATION) &&
+      labware.stack.includes(moduleId)
+  )
   const moduleState = flexStackerStateGetter(robotState, moduleId)
   if (moduleState != null && moduleState.labwareInHopper != null) {
     if (params.count != null) {
@@ -40,6 +46,12 @@ export const forFlexStackerEmpty = (
       moduleState.labwareInHopper = []
     }
   }
+  labwareInHopper.forEach(([labwareId]) => {
+    robotState.labware[labwareId] = {
+      ...robotState.labware[labwareId],
+      stack: [labwareId, SYSTEM_LOCATION],
+    }
+  })
 }
 
 export const forFlexStackerFillItems = (
@@ -159,8 +171,8 @@ export const forFlexStackerStore = (
 ): void => {
   const { robotState } = robotStateAndWarnings
   const { moduleId } = params
+  const moduleSlot = robotState.modules[moduleId].slot
   const moduleState = flexStackerStateGetter(robotState, moduleId)
-
   if (moduleState != null) {
     const { labwareOnShuttle } = moduleState
     if (labwareOnShuttle != null) {
@@ -180,6 +192,8 @@ export const forFlexStackerStore = (
           robotState.labware[labwareId].stack = [
             labwareId,
             HOPPER_STACKER_LOCATION,
+            moduleId,
+            moduleSlot,
           ]
         }
       }

--- a/step-generation/src/getNextRobotStateAndWarnings/stackerUpdates.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/stackerUpdates.ts
@@ -182,6 +182,7 @@ export const forFlexStackerStore = (
       ]
       moduleState.labwareOnShuttle = null
 
+      // build trivial stacks for stored labware group elements
       for (const labwarePoolKey of BOTTOM_UP_LABWARE_POOL_KEYS) {
         const labwareId =
           labwareOnShuttle[

--- a/step-generation/src/getNextRobotStateAndWarnings/stackerUpdates.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/stackerUpdates.ts
@@ -21,7 +21,7 @@ import type {
 import type { InvariantContext, RobotStateAndWarnings } from '../types'
 
 const BOTTOM_UP_LABWARE_POOL_KEYS: Array<keyof FlexStackerStoredLabwareGroup> =
-  ['adapterLabwareId', 'adapterLabwareId', 'primaryLabwareId', 'lidLabwareId']
+  ['adapterLabwareId', 'primaryLabwareId', 'lidLabwareId']
 
 export const forFlexStackerEmpty = (
   params: FlexStackerEmptyCreateCommand['params'],
@@ -182,25 +182,20 @@ export const forFlexStackerStore = (
       ]
       moduleState.labwareOnShuttle = null
 
-      // build trivial stacks for stored labware group elements
-      let previousTopLabwareId: string | null = null
-
       for (const labwarePoolKey of BOTTOM_UP_LABWARE_POOL_KEYS) {
         const labwareId =
           labwareOnShuttle[
             labwarePoolKey as keyof FlexStackerStoredLabwareGroup
           ]
 
-        if (labwareId == null) continue
-
-        const baseStack =
-          previousTopLabwareId != null
-            ? robotState.labware[previousTopLabwareId].stack
-            : [HOPPER_STACKER_LOCATION, moduleId, moduleSlot]
-
-        robotState.labware[labwareId].stack = [labwareId, ...baseStack]
-
-        previousTopLabwareId = labwareId
+        if (labwareId != null) {
+          robotState.labware[labwareId].stack = [
+            labwareId,
+            HOPPER_STACKER_LOCATION,
+            moduleId,
+            moduleSlot,
+          ]
+        }
       }
     }
   }

--- a/step-generation/src/getNextRobotStateAndWarnings/stackerUpdates.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/stackerUpdates.ts
@@ -183,19 +183,24 @@ export const forFlexStackerStore = (
       moduleState.labwareOnShuttle = null
 
       // build trivial stacks for stored labware group elements
+      let previousTopLabwareId: string | null = null
+
       for (const labwarePoolKey of BOTTOM_UP_LABWARE_POOL_KEYS) {
         const labwareId =
           labwareOnShuttle[
             labwarePoolKey as keyof FlexStackerStoredLabwareGroup
           ]
-        if (labwareId != null) {
-          robotState.labware[labwareId].stack = [
-            labwareId,
-            HOPPER_STACKER_LOCATION,
-            moduleId,
-            moduleSlot,
-          ]
-        }
+
+        if (labwareId == null) continue
+
+        const baseStack =
+          previousTopLabwareId != null
+            ? robotState.labware[previousTopLabwareId].stack
+            : [HOPPER_STACKER_LOCATION, moduleId, moduleSlot]
+
+        robotState.labware[labwareId].stack = [labwareId, ...baseStack]
+
+        previousTopLabwareId = labwareId
       }
     }
   }


### PR DESCRIPTION
# Overview

Needed to update the labware state for the empty and store flex stacker state functions 😄 small fixes to both

also introduces the `SYSTEM_LOCATION` labware location when you empty something from the hopper and filters out that location in the dropdown options for moveLiquid and moveLabware

## Test Plan and Hands on Testing

test that you can empty a labware on the flex stacker and the labware disappears on the hopper
test that you can also store a labware and it moves to the hopper location > NOTE this one does super work right now since you can't add a labware to the shuttle location properly? Should be fixed by Nick's work though that he is currently working on

## Changelog

some fixes with updating robot state in the 2 state updates


## Risk assessment

low
