### PR TITLE
fix(ci, dependabot): forks can't access secrets

### DIFF
--- a/.github/workflows/components-test-build-deploy.yaml
+++ b/.github/workflows/components-test-build-deploy.yaml
@@ -96,7 +96,7 @@ jobs:
     runs-on: 'ubuntu-24.04'
     needs:
       ['determine-deploy-config', 'js-unit-test', 'build-components-storybook']
-    if: always() && needs.build-components-storybook.result == 'success' && needs.determine-deploy-config.result == 'success'
+    if: always() && needs.build-components-storybook.result == 'success' && needs.determine-deploy-config.result == 'success' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/docs-build-deploy.yaml
+++ b/.github/workflows/docs-build-deploy.yaml
@@ -99,6 +99,7 @@ jobs:
       - determine-deploy-config
     timeout-minutes: 5
     runs-on: ubuntu-24.04
+    if: always() && needs.build-docs.result == 'success' && needs.determine-deploy-config.result == 'success' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/docs-build.yaml
+++ b/.github/workflows/docs-build.yaml
@@ -105,7 +105,7 @@ jobs:
       - build
     runs-on: 'ubuntu-24.04'
     timeout-minutes: 5
-    if: always() && needs.build.result == 'success' && needs.determine-deploy-config.result == 'success'
+    if: always() && needs.build.result == 'success' && needs.determine-deploy-config.result == 'success' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/ll-test-build-deploy.yaml
+++ b/.github/workflows/ll-test-build-deploy.yaml
@@ -119,7 +119,7 @@ jobs:
     runs-on: 'ubuntu-24.04'
     needs: ['determine-deploy-config', 'build-ll']
     timeout-minutes: 5
-    if: always() && needs.build-ll.result == 'success' && needs.determine-deploy-config.result == 'success'
+    if: always() && needs.build-ll.result == 'success' && needs.determine-deploy-config.result == 'success' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/pd-test-build-deploy.yaml
+++ b/.github/workflows/pd-test-build-deploy.yaml
@@ -139,7 +139,7 @@ jobs:
       - determine-deploy-config
       - build-pd
     runs-on: 'ubuntu-24.04'
-    if: always() && needs.build-pd.result == 'success' && needs.determine-deploy-config.result == 'success'
+    if: always() && needs.build-pd.result == 'success' && needs.determine-deploy-config.result == 'success' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
### Skip deployment for fork PRs (Dependabot)

Problem:
Dependabot PRs (from forks) fail on deploy jobs because they can't access secrets/OIDC tokens for AWS credentials.

Solution:
Added conditions to skip deployment jobs for fork PRs while still running tests and builds.

Changes:
Updated deploy job conditions in 5 workflows to check if PR is from a fork:
components-test-build-deploy.yaml
ll-test-build-deploy.yaml
pd-test-build-deploy.yaml
docs-build.yaml
docs-build-deploy.yaml

Result:
Tests and builds run on all PRs (including Dependabot)
Deployment only runs for same-repo PRs and push events
Fork PRs (Dependabot) skip deployment instead of failing

Condition added:
`(github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)`
