### PR TITLE
refactor(protocol-designer): Delete unused properties in Thermocycler substeps

### DIFF
--- a/protocol-designer/src/steplist/generateSubstepItem.ts
+++ b/protocol-designer/src/steplist/generateSubstepItem.ts
@@ -353,31 +353,8 @@ export function generateSubstepItem(
   }
 
   if (stepArgs.commandCreatorFnName === THERMOCYCLER_PROFILE) {
-    const labwareNames = stepArgs.moduleId
-      ? labwareNamesByModuleId[stepArgs.moduleId]
-      : null
-
-    const {
-      blockTargetTempHold,
-      lidOpenHold,
-      lidTargetTempHold,
-      message,
-      meta,
-      profileElements,
-      profileTargetLidTemp,
-      profileVolume,
-    } = stepArgs
     return {
       substepType: THERMOCYCLER_PROFILE,
-      blockTargetTempHold,
-      labwareNickname: labwareNames?.nickname,
-      lidOpenHold,
-      lidTargetTempHold,
-      message,
-      meta,
-      profileElements,
-      profileTargetLidTemp,
-      profileVolume,
     }
   }
 

--- a/protocol-designer/src/steplist/types.ts
+++ b/protocol-designer/src/steplist/types.ts
@@ -148,16 +148,10 @@ export interface HeaterShakerSubstepItem {
 
 export interface ThermocyclerProfileSubstepItem {
   substepType: typeof THERMOCYCLER_PROFILE
-  blockTargetTempHold: number | null
-  labwareNickname: string | null | undefined
-  lidOpenHold: boolean
-  lidTargetTempHold: number | null
-  message?: string
-  meta: ThermocyclerProfileStepArgs['meta']
-  profileElements: ThermocyclerProfileStepArgs['profileElements']
-  profileTargetLidTemp: number | null
-  profileVolume: number
+  // No data in here because the UI gets it from other places instead of the substep
+  // machinery. We merely need to make sure the substep exists.
 }
+
 export interface ThermocyclerStateSubstepItem {
   substepType: typeof THERMOCYCLER_STATE
   labwareNickname: string | null | undefined
@@ -166,6 +160,7 @@ export interface ThermocyclerStateSubstepItem {
   lidOpen: boolean
   message?: string
 }
+
 export type SubstepItemData =
   | SourceDestSubstepItem
   | PauseSubstepItem

--- a/protocol-designer/src/steplist/types.ts
+++ b/protocol-designer/src/steplist/types.ts
@@ -4,7 +4,6 @@ import type {
   CommentArgs,
   MoveLabwareArgs,
   PauseArgs,
-  ThermocyclerProfileStepArgs,
 } from '@opentrons/step-generation'
 import type { THERMOCYCLER_PROFILE, THERMOCYCLER_STATE } from '../constants'
 import type { StepIdType } from '../form-types'


### PR DESCRIPTION
## Overview

In our UI for showing substeps, Thermocycler profiles are peculiar in that [we don't actually get data from `ThermocyclerProfileSubstepItem`](https://github.com/Opentrons/opentrons/blob/a1a111b5d3cb4a5be99b656ee266c9d8e50b9f27/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/SubStepsToolbox.tsx#L98). Instead, [we get it from the step form](https://github.com/Opentrons/opentrons/blob/43deedca02c625aa164d2c1587272f70b0defa07/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/ThermocyclerProfileSubsteps.tsx#L32-L36). This means the properties of `ThermocyclerProfileSubstepItem` are unused by anything.

The properties of `ThermocyclerProfileSubstepItem` would need to update in #20390. Since they're unused, it seems easier to just delete them instead of updating them.

This goes towards EXEC-2009.

## Test Plan and Hands on Testing

* [x] Open the substep sidebar for a Thermocycler profile step and make sure stuff still shows up there.

## Review requests

Is this the direction we want to go in, or should we update the properties instead?

## Risk assessment

Low.
