### PR TITLE
chore(system-server): fix hanging tests

### DIFF
--- a/system-server/tests/conftest.py
+++ b/system-server/tests/conftest.py
@@ -43,13 +43,17 @@ def run_server() -> Generator[DevServer, None, None]:
     server.start()
 
     with requests.Session() as session:
+        print("Starting server")
         while True:
             try:
-                session.get("http://localhost:32950")
+                session.get(f"http://localhost:{server.port}")
             except requests.exceptions.ConnectionError:
                 pass
             else:
                 break
+        print("server started")
 
     yield server
+    print("stopping server")
     server.stop()
+    print("server stopped")

--- a/system-server/tests/dev_server.py
+++ b/system-server/tests/dev_server.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from pathlib import Path
+import random
 import subprocess
 import signal
 import sys
@@ -10,7 +11,7 @@ from typing import Optional
 
 class DevServer:
     def __init__(
-        self, port: str = "32950", persistence_directory: Optional[Path] = None
+        self, port: int | None = None, persistence_directory: Optional[Path] = None
     ) -> None:
         """Initialize a dev server."""
         self.server_temp_directory: str = tempfile.mkdtemp()
@@ -19,7 +20,11 @@ class DevServer:
             if persistence_directory is not None
             else Path(tempfile.mkdtemp())
         )
-        self.port: str = port
+        self.port: int = (
+            port
+            if port is not None
+            else random.randrange(2**15 + 2**14, 2**16 - 1)
+        )
 
     def __enter__(self) -> DevServer:
         return self
@@ -61,8 +66,8 @@ class DevServer:
             stdin=subprocess.DEVNULL,
             # The server will log to its stdout or stderr.
             # Let it inherit our stdout and stderr so pytest captures its logs.
-            stdout=None,
-            stderr=None,
+            stdout=sys.stdout,
+            stderr=sys.stderr,
         )
 
     def stop(self) -> None:

--- a/system-server/tests/integration/test_oem_mode.tavern.yaml
+++ b/system-server/tests/integration/test_oem_mode.tavern.yaml
@@ -1,12 +1,12 @@
 ---
-test_name:  Test enable/disable OEM Mode
+test_name: Test enable/disable OEM Mode
 marks:
   - usefixtures:
-    - run_server
+      - run_server
 stages:
   - name: PUT first request
     request: &enable_oem_mode_first
-      url: "{host:s}:{port:d}/system/oem_mode/enable"
+      url: '{host:s}:{run_server.port:d}/system/oem_mode/enable'
       json:
         enable: true
       method: PUT
@@ -16,7 +16,7 @@ stages:
       status_code: 200
   - name: PUT second request
     request: &enable_oem_mode_second
-      url: "{host:s}:{port:d}/system/oem_mode/enable"
+      url: '{host:s}:{run_server.port:d}/system/oem_mode/enable'
       json:
         enable: false
       method: PUT
@@ -26,7 +26,7 @@ stages:
       status_code: 200
   - name: PUT third request
     request: &enable_oem_mode_third
-      url: "{host:s}:{port:d}/system/oem_mode/enable"
+      url: '{host:s}:{run_server.port:d}/system/oem_mode/enable'
       json:
         wrong_key: false
       method: PUT
@@ -43,13 +43,13 @@ marks:
 stages:
   - name: Enable OEM Mode
     request:
-      url: "{host:s}:{port:d}/system/oem_mode/enable"
+      url: '{host:s}:{run_server.port:d}/system/oem_mode/enable'
       method: PUT
       json:
-        "enable": true
+        'enable': true
   - name: Upload PNG Image
     request: &upload_splash_first
-      url: "{host:s}:{port:d}/system/oem_mode/upload_splash"
+      url: '{host:s}:{run_server.port:d}/system/oem_mode/upload_splash'
       method: POST
       files:
         file: 'tests/integration/resources/oem_mode_custom.png'
@@ -61,18 +61,18 @@ test_name: Dont process upload_splash request if oem mode is disabled
 
 marks:
   - usefixtures:
-    - run_server
+      - run_server
 
 stages:
   - name: Disable OEM Mode
     request:
-      url: "{host:s}:{port:d}/system/oem_mode/enable"
+      url: '{host:s}:{run_server.port:d}/system/oem_mode/enable'
       method: PUT
       json:
-        "enable": false
+        'enable': false
   - name: Upload PNG Image
     request:
-      url: "{host:s}:{port:d}/system/oem_mode/upload_splash"
+      url: '{host:s}:{run_server.port:d}/system/oem_mode/upload_splash'
       method: POST
       files:
         file: 'tests/integration/resources/oem_mode_custom.png'
@@ -80,13 +80,13 @@ stages:
       status_code: 403
   - name: Enable OEM Mode
     request:
-      url: "{host:s}:{port:d}/system/oem_mode/enable"
+      url: '{host:s}:{run_server.port:d}/system/oem_mode/enable'
       method: PUT
       json:
-        "enable": true
+        'enable': true
   - name: Upload PNG Image
     request:
-      url: "{host:s}:{port:d}/system/oem_mode/upload_splash"
+      url: '{host:s}:{run_server.port:d}/system/oem_mode/upload_splash'
       method: POST
       files:
         file: 'tests/integration/resources/oem_mode_custom.png'
@@ -97,18 +97,18 @@ test_name: Validate the image before processing
 
 marks:
   - usefixtures:
-    - run_server
+      - run_server
 
 stages:
   - name: Enable OEM Mode
     request:
-      url: "{host:s}:{port:d}/system/oem_mode/enable"
+      url: '{host:s}:{run_server.port:d}/system/oem_mode/enable'
       method: PUT
       json:
-        "enable": true
+        'enable': true
   - name: Upload non-PNG Image
     request:
-      url: "{host:s}:{port:d}/system/oem_mode/upload_splash"
+      url: '{host:s}:{run_server.port:d}/system/oem_mode/upload_splash'
       method: POST
       files:
         file: 'tests/integration/resources/oem_mode_wrong_image_type.jpeg'
@@ -116,7 +116,7 @@ stages:
       status_code: 415
   - name: Upload a PNG Image
     request:
-      url: "{host:s}:{port:d}/system/oem_mode/upload_splash"
+      url: '{host:s}:{run_server.port:d}/system/oem_mode/upload_splash'
       method: POST
       files:
         file: 'tests/integration/resources/oem_mode_custom.png'

--- a/system-server/tests/integration/test_system_authorize.tavern.yaml
+++ b/system-server/tests/integration/test_system_authorize.tavern.yaml
@@ -2,11 +2,11 @@
 test_name: POST System Authorize
 marks:
   - usefixtures:
-    - run_server
+      - run_server
 stages:
   - name: POST /system/register
     request:
-      url: "{host:s}:{port:d}/system/register"
+      url: '{host:s}:{run_server.port:d}/system/register'
       method: POST
       params:
         agent: 'agent-system-authorize-test'
@@ -18,34 +18,34 @@ stages:
         token: !anystr
       save:
         json:
-          issued_token: "token"
+          issued_token: 'token'
   - name: POST /system/authorize with invalid token
     request:
-      url: "{host:s}:{port:d}/system/authorize"
-      method: POST 
-      headers: 
+      url: '{host:s}:{run_server.port:d}/system/authorize'
+      method: POST
+      headers:
         authenticationBearer: 'not-a-valid-token'
     response:
       status_code: 401
   - name: POST /system/authorize with valid token
     request:
-      url: "{host:s}:{port:d}/system/authorize"
-      method: POST 
-      headers: 
-        authenticationBearer: "{issued_token:s}"
+      url: '{host:s}:{run_server.port:d}/system/authorize'
+      method: POST
+      headers:
+        authenticationBearer: '{issued_token:s}'
     response:
       status_code: 201
       json:
         token: !anystr
       save:
         json:
-          auth_token: "token"
+          auth_token: 'token'
   - name: POST /system/authorize with the same token, get a new auth token
     request:
-      url: "{host:s}:{port:d}/system/authorize"
-      method: POST 
-      headers: 
-        authenticationBearer: "{issued_token:s}"
+      url: '{host:s}:{run_server.port:d}/system/authorize'
+      method: POST
+      headers:
+        authenticationBearer: '{issued_token:s}'
     response:
       status_code: 201
       verify_response_with:
@@ -56,29 +56,29 @@ stages:
         token: !anystr
   - name: GET /system/authorize with invalid token fails
     request:
-      url: "{host:s}:{port:d}/system/authorize"
-      method: GET 
-      headers: 
-        authenticationBearer: "{issued_token:s}"
+      url: '{host:s}:{run_server.port:d}/system/authorize'
+      method: GET
+      headers:
+        authenticationBearer: '{issued_token:s}'
     response:
       status_code: 403
-  - name: GET /system/authorize with valid token fails 
+  - name: GET /system/authorize with valid token fails
     request:
-      url: "{host:s}:{port:d}/system/authorize"
-      method: GET 
-      headers: 
-        authenticationBearer: "{auth_token:s}"
+      url: '{host:s}:{run_server.port:d}/system/authorize'
+      method: GET
+      headers:
+        authenticationBearer: '{auth_token:s}'
     response:
       status_code: 200
 ---
 test_name: GET System Connected
 marks:
   - usefixtures:
-    - run_server
+      - run_server
 stages:
   - name: Register User
     request:
-      url: "{host:s}:{port:d}/system/register"
+      url: '{host:s}:{run_server.port:d}/system/register'
       method: POST
       params:
         agent: 'get-system-connected-test'
@@ -90,10 +90,10 @@ stages:
         token: !anystr
       save:
         json:
-          issued_token: "token"
+          issued_token: 'token'
   - name: Get empty connection list
     request:
-      url: "{host:s}:{port:d}/system/connected"
+      url: '{host:s}:{run_server.port:d}/system/connected'
       method: GET
     response:
       status_code: 200
@@ -101,26 +101,26 @@ stages:
         connections: []
   - name: Authorize User
     request:
-      url: "{host:s}:{port:d}/system/authorize"
-      method: POST 
-      headers: 
-        authenticationBearer: "{issued_token:s}"
+      url: '{host:s}:{run_server.port:d}/system/authorize'
+      method: POST
+      headers:
+        authenticationBearer: '{issued_token:s}'
     response:
       status_code: 201
   - name: Get single-entry connection list
     request:
-      url: "{host:s}:{port:d}/system/connected"
+      url: '{host:s}:{run_server.port:d}/system/connected'
       method: GET
     response:
       status_code: 200
       json:
         connections:
-          - subject: "sub1"
-            agent: "get-system-connected-test"
+          - subject: 'sub1'
+            agent: 'get-system-connected-test'
             agentId: 'id1'
   - name: Register second user
     request:
-      url: "{host:s}:{port:d}/system/register"
+      url: '{host:s}:{run_server.port:d}/system/register'
       method: POST
       params:
         agent: 'get-system-connected-test'
@@ -132,18 +132,18 @@ stages:
         token: !anystr
       save:
         json:
-          second_token: "token"
+          second_token: 'token'
   - name: Authorize second user
     request:
-      url: "{host:s}:{port:d}/system/authorize"
-      method: POST 
-      headers: 
-        authenticationBearer: "{second_token:s}"
+      url: '{host:s}:{run_server.port:d}/system/authorize'
+      method: POST
+      headers:
+        authenticationBearer: '{second_token:s}'
     response:
       status_code: 201
   - name: Get two-entry connection list
     request:
-      url: "{host:s}:{port:d}/system/connected"
+      url: '{host:s}:{run_server.port:d}/system/connected'
       method: GET
     response:
       status_code: 200
@@ -151,23 +151,23 @@ stages:
         - json:list_any_order
       json:
         connections:
-          - subject: "sub1"
-            agent: "get-system-connected-test"
+          - subject: 'sub1'
+            agent: 'get-system-connected-test'
             agentId: 'id2'
-          - subject: "sub1"
-            agent: "get-system-connected-test"
+          - subject: 'sub1'
+            agent: 'get-system-connected-test'
             agentId: 'id1'
   - name: Re-authorize first user
     request:
-      url: "{host:s}:{port:d}/system/authorize"
-      method: POST 
-      headers: 
-        authenticationBearer: "{issued_token:s}"
+      url: '{host:s}:{run_server.port:d}/system/authorize'
+      method: POST
+      headers:
+        authenticationBearer: '{issued_token:s}'
     response:
       status_code: 201
   - name: Get two-entry connection list
     request:
-      url: "{host:s}:{port:d}/system/connected"
+      url: '{host:s}:{run_server.port:d}/system/connected'
       method: GET
     response:
       status_code: 200
@@ -175,9 +175,9 @@ stages:
         - json:list_any_order
       json:
         connections:
-          - subject: "sub1"
-            agent: "get-system-connected-test"
+          - subject: 'sub1'
+            agent: 'get-system-connected-test'
             agentId: 'id2'
-          - subject: "sub1"
-            agent: "get-system-connected-test"
+          - subject: 'sub1'
+            agent: 'get-system-connected-test'
             agentId: 'id1'

--- a/system-server/tests/integration/test_system_register.tavern.yaml
+++ b/system-server/tests/integration/test_system_register.tavern.yaml
@@ -2,11 +2,11 @@
 test_name: POST System Register
 marks:
   - usefixtures:
-    - run_server
+      - run_server
 stages:
   - name: POST request returns a new JWT
     request: &system_register_first
-      url: "{host:s}:{port:d}/system/register"
+      url: '{host:s}:{run_server.port:d}/system/register'
       method: POST
       params:
         agent: 'agent-1'
@@ -18,7 +18,7 @@ stages:
         token: !anystr
       save:
         json:
-          issued_token: "token"
+          issued_token: 'token'
   - name: Second POST request returns same JWT
     request: *system_register_first
     response:
@@ -27,7 +27,7 @@ stages:
         token: '{issued_token}'
   - name: POST request with different info returns a new JWT
     request: &system_register_second
-      url: "{host:s}:{port:d}/system/register"
+      url: '{host:s}:{run_server.port:d}/system/register'
       method: POST
       params:
         agent: 'agent-2'


### PR DESCRIPTION
Tests were hanging (more often in ci, but also locally) because
sometimes the dev server for the tavern backend would fail to start
because a port was in use. Use a random port instead.

Probably better would be letting uvicorn pick which one to use, but it's
a bit of a pain to figure out which one it picked so don't.
