### PR TITLE
feat(protocol-designer): mixpanel analytics for stacker

### DIFF
--- a/protocol-designer/src/analytics/middleware.ts
+++ b/protocol-designer/src/analytics/middleware.ts
@@ -25,6 +25,7 @@ import type { Middleware } from 'redux'
 import type {
   ConsolidateArgs,
   DistributeArgs,
+  FlexStackerFillItemsArgs,
   MixArgs,
   NormalizedPipetteById,
   TransferArgs,
@@ -217,6 +218,27 @@ export const reduxActionToAnalyticsEvent = (
             },
           }
         }
+        case 'flexStackerEmpty':
+          return {
+            name: 'flexStackerEmptyStep',
+            properties: {},
+          }
+        case 'flexStackerRetrieve':
+          return {
+            name: 'flexStackerRetrieveStep',
+            properties: {},
+          }
+        case 'flexStackerFillItems':
+          const args = stepArgs as FlexStackerFillItemsArgs
+          return {
+            name: 'flexStackerFillItemsStep',
+            properties: { labwareURI: args.fillLabwareUri },
+          }
+        case 'flexStackerStore':
+          return {
+            name: 'flexStackerStoreStep',
+            properties: {},
+          }
         default:
           return {
             name: `${modifiedStepName}Step`,

--- a/protocol-designer/src/components/organisms/AssignLiquidsModal/LiquidToolbox.tsx
+++ b/protocol-designer/src/components/organisms/AssignLiquidsModal/LiquidToolbox.tsx
@@ -280,18 +280,18 @@ function LiquidToolbox({
   const canEdit = !showLiquidLayoutOverlay && (hasLiquids || hasSelection)
   const { labware, modules } = useSelector(getInitialDeckSetup)
   const stackerModuleIds = Object.entries(modules).reduce<string[]>(
-    (result, [key, value]) => {
-      return value.type === FLEX_STACKER_MODULE_TYPE
-        ? result.concat(key)
-        : result
+    (stackerIds, [moduleId, moduleOnDeck]) => {
+      return moduleOnDeck.type === FLEX_STACKER_MODULE_TYPE
+        ? stackerIds.concat(moduleId)
+        : stackerIds
     },
     []
   )
 
   const labwareOnStackerWithLiquid = Object.entries(labware).filter(
-    ([, labwareDef]) =>
-      labwareDef.stack != null &&
-      stackerModuleIds.some(stacker => labwareDef.stack.includes(stacker))
+    ([, labwareInfo]) =>
+      labwareInfo.stack != null &&
+      stackerModuleIds.some(stackerId => labwareInfo.stack.includes(stackerId))
   )
   const handleConfirmClick = (): void => {
     if (labwareOnStackerWithLiquid.length > 0) {

--- a/protocol-designer/src/components/organisms/AssignLiquidsModal/LiquidToolbox.tsx
+++ b/protocol-designer/src/components/organisms/AssignLiquidsModal/LiquidToolbox.tsx
@@ -20,7 +20,9 @@ import {
   Toolbox,
   TYPOGRAPHY,
 } from '@opentrons/components'
+import { FLEX_STACKER_MODULE_TYPE } from '@opentrons/shared-data'
 
+import { analyticsEvent } from '/protocol-designer/analytics/actions'
 import { LINK_BUTTON_STYLE } from '/protocol-designer/components/atoms'
 import * as labwareIngredActions from '/protocol-designer/labware-ingred/actions'
 import {
@@ -29,7 +31,10 @@ import {
 } from '/protocol-designer/labware-ingred/actions'
 import { selectors as labwareIngredSelectors } from '/protocol-designer/labware-ingred/selectors'
 import { getLiquidClassDisplayName } from '/protocol-designer/liquid-defs/utils'
-import { getLiquidEntities } from '/protocol-designer/step-forms/selectors'
+import {
+  getInitialDeckSetup,
+  getLiquidEntities,
+} from '/protocol-designer/step-forms/selectors'
 import * as fieldProcessors from '/protocol-designer/steplist/fieldLevel/processing'
 import * as wellContentsSelectors from '/protocol-designer/top-selectors/well-contents'
 import { getLabwareNicknamesById } from '/protocol-designer/ui/labware/selectors'
@@ -273,12 +278,35 @@ function LiquidToolbox({
       : false
   const hasSelection = selectedWells.length > 0
   const canEdit = !showLiquidLayoutOverlay && (hasLiquids || hasSelection)
+  const { labware, modules } = useSelector(getInitialDeckSetup)
+  const stackerModuleIds = Object.entries(modules).reduce<string[]>(
+    (result, [key, value]) => {
+      return value.type === FLEX_STACKER_MODULE_TYPE
+        ? result.concat(key)
+        : result
+    },
+    []
+  )
 
+  const labwareOnStackerWithLiquid = Object.entries(labware).filter(
+    ([, labwareDef]) =>
+      labwareDef.stack != null &&
+      stackerModuleIds.some(stacker => labwareDef.stack.includes(stacker))
+  )
   const handleConfirmClick = (): void => {
+    if (labwareOnStackerWithLiquid.length > 0) {
+      dispatch(
+        analyticsEvent({
+          name: 'liquidInLabwareInStacker',
+          properties: {},
+        })
+      )
+    }
     if (selectedWells.length > 0) {
       setShowBadFormState(true)
       return
     }
+
     dispatch(deselectAllWells())
     navigate('/designer')
   }

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepFormToolbox.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepFormToolbox.tsx
@@ -288,9 +288,9 @@ export function StepFormToolbox(props: StepFormToolboxProps): JSX.Element {
     dispatchAnalyticsEvent(FORM_WARNINGS_EVENT, visibleFormWarningsTypes)
     dispatchAnalyticsEvent(FORM_ERRORS_EVENT, visibleFormErrorsTypes)
   }, [visibleFormWarningsTypes, visibleFormErrorsTypes])
-  const moduleEntities = Object.entries(useSelector(getModuleEntities))
-  const stackerModules = moduleEntities.filter(([_, value]) => {
-    return value.type === FLEX_STACKER_MODULE_TYPE
+  const moduleEntities = Object.values(useSelector(getModuleEntities))
+  const stackerModules = moduleEntities.filter(moduleEntity => {
+    return moduleEntity.type === FLEX_STACKER_MODULE_TYPE
   })
   const numberOfStackersLoaded: AnalyticsEvent = {
     name: 'loadFlexStacker',

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepFormToolbox.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepFormToolbox.tsx
@@ -17,7 +17,11 @@ import {
   Toolbox,
   TYPOGRAPHY,
 } from '@opentrons/components'
-import { FLEX_ROBOT_TYPE, OT2_ROBOT_TYPE } from '@opentrons/shared-data'
+import {
+  FLEX_ROBOT_TYPE,
+  FLEX_STACKER_MODULE_TYPE,
+  OT2_ROBOT_TYPE,
+} from '@opentrons/shared-data'
 
 import { analyticsEvent } from '/protocol-designer/analytics/actions'
 import {
@@ -46,6 +50,7 @@ import {
   getDynamicFieldFormErrorsForUnsavedForm,
   getFormLevelErrorsForUnsavedForm,
   getInvariantContext,
+  getModuleEntities,
   getSavedStepForms,
 } from '/protocol-designer/step-forms/selectors'
 import { actions } from '/protocol-designer/steplist'
@@ -283,7 +288,16 @@ export function StepFormToolbox(props: StepFormToolboxProps): JSX.Element {
     dispatchAnalyticsEvent(FORM_WARNINGS_EVENT, visibleFormWarningsTypes)
     dispatchAnalyticsEvent(FORM_ERRORS_EVENT, visibleFormErrorsTypes)
   }, [visibleFormWarningsTypes, visibleFormErrorsTypes])
-
+  const moduleEntities = Object.entries(useSelector(getModuleEntities))
+  const stackerModules = moduleEntities.filter(([_, value]) => {
+    return value.type === FLEX_STACKER_MODULE_TYPE
+  })
+  const numberOfStackersLoaded: AnalyticsEvent = {
+    name: 'loadFlexStacker',
+    properties: {
+      numberOfStackers: stackerModules.length,
+    },
+  }
   if (!ToolsComponent) {
     // early-exit if step form doesn't exist, this is a good check for when new steps
     // are added
@@ -338,6 +352,7 @@ export function StepFormToolbox(props: StepFormToolboxProps): JSX.Element {
       })
     }
   }
+
   const handleSaveClick = (): void => {
     if (canSave) {
       const duration = new Date().getTime() - analyticsStartTime.getTime()
@@ -363,6 +378,9 @@ export function StepFormToolbox(props: StepFormToolboxProps): JSX.Element {
       dispatch(analyticsEvent(stepDuration))
       dispatch(selectDropdownItem({ selection: null, mode: 'clear' }))
       dispatch(hoverSelection({ id: null, text: null }))
+      if (stackerModules.length > 0) {
+        dispatch(analyticsEvent(numberOfStackersLoaded))
+      }
     } else {
       setShowFormErrors(true)
       if (tab === 'aspirate' && isDispenseError && !isAspirateError) {


### PR DESCRIPTION
# Overview

Tracks flex stacker step creation, labware loaded into the stacker with liquids, and how many stackers are loaded per protocol.

## Test Plan and Hands on Testing

- Added log statements to liquids step to test
- Will need to smoke test stacker commands once step-generation is complete.

Liquids log:
<img width="803" height="256" alt="Screenshot 2025-12-16 at 1 56 43 PM" src="https://github.com/user-attachments/assets/3a2df9a5-fffb-4a14-a142-dc5b466239f1" />

## Risk assessment

low

closes EXEC-1546
