### PR TITLE
Merge back 'chore_release-pd-8.7.1' into 'edge'

### DIFF
--- a/protocol-designer/README.md
+++ b/protocol-designer/README.md
@@ -69,6 +69,45 @@ Used for Mixpanel in dev (eg via a sandbox URL). Should be provided in the CI bu
 
 If truthy, uses the `GateModal` component in development. The `GateModal` component is always used in production.
 
+### Sentry (error reporting + sourcemaps)
+
+Protocol Designer uses Sentry in two places:
+
+1. **Runtime error reporting** (in the browser) via `@sentry/react`.
+2. **Build-time sourcemap uploading** (optional) via `@sentry/vite-plugin`.
+
+#### Runtime error reporting (browser)
+
+PD will only initialize Sentry if a DSN is provided and the user has opted in.
+
+- `OT_PD_SENTRY_DSN`: production/staging DSN.
+- `OT_PD_SENTRY_DEV_DSN`: development DSN fallback.
+
+#### Local sourcemap upload (opt-in)
+
+By default, local builds do **not** upload sourcemaps. To opt in locally, set the Sentry plugin credentials:
+
+```bash
+SENTRY_AUTH_TOKEN=... \
+SENTRY_ORG=... \
+SENTRY_PROJECT=... \
+make -C protocol-designer build
+```
+
+Notes:
+
+- The plugin is **disabled in CI**; it only runs locally when the `SENTRY_*` env vars are present.
+- Local sourcemaps are uploaded under the Sentry release name `local-dev` so they don’t collide with real releases.
+- The runtime SDK is configured to report `release=local-dev` when local upload is enabled, so local events can resolve the uploaded sourcemaps.
+
+#### CI sourcemap upload (releases)
+
+CI uploads sourcemaps via `getsentry/action-release` (not the Vite plugin). See the workflow at `.github/workflows/pd-test-build-deploy.yaml`.
+
+- Sourcemaps are uploaded from `protocol-designer/dist`.
+- Upload only runs for tagged **staging** or **production** releases.
+- The release name comes from the tag version (e.g. `protocol-designer@8.8.0` → `8.8.0`).
+
 [chrome]: https://www.google.com/chrome/
 [json-schema]: https://json-schema.org/
 [ot-2]: https://opentrons.com/ot-2

--- a/protocol-designer/release-notes.md
+++ b/protocol-designer/release-notes.md
@@ -8,6 +8,12 @@ By using Opentrons Protocol Designer, you agree to the Opentrons End-User Licens
 
 ---
 
+## Opentrons Protocol Designer Changes in 8.7.1
+
+**Welcome to Protocol Designer 8.7.1!**
+
+This hotfix release includes internal updates for debugging.
+
 ## Opentrons Protocol Designer Changes in 8.7.0
 
 **Welcome to Protocol Designer 8.7.0!**

--- a/protocol-designer/src/resources/sentry.ts
+++ b/protocol-designer/src/resources/sentry.ts
@@ -16,6 +16,10 @@ let isSentryInitialized = false
 // Development can still fall back to the dev DSN if it is configured locally.
 const sentryDsn = _OT_PD_SENTRY_DSN_ ?? _OT_PD_SENTRY_DEV_DSN_
 
+// Sentry release is normally the app version, but local builds can override it
+// (e.g. `local-dev`) so locally uploaded sourcemaps resolve against local events.
+const sentryRelease = _OT_PD_SENTRY_RELEASE_ ?? _OT_PD_VERSION_
+
 const resolveSentryEnvironment = ():
   | 'production'
   | 'staging'
@@ -47,7 +51,7 @@ export const initializeSentry = (state: BaseState): void => {
       init({
         dsn: sentryDsn,
         environment: resolveSentryEnvironment(),
-        release: _OT_PD_VERSION_,
+        release: sentryRelease,
         integrations: [
           captureConsoleIntegration({ levels: ['assert'] }),
           replayIntegration(),

--- a/protocol-designer/typings/global.d.ts
+++ b/protocol-designer/typings/global.d.ts
@@ -22,6 +22,7 @@ declare const _OT_PD_LATEST_LABWARE_VERSIONS_: Record<string, Number>
 declare const _OT_PD_MIXPANEL_DEV_ID_: string | undefined
 declare const _OT_PD_MIXPANEL_ID_: string | undefined
 declare const _OT_PD_REQUIRED_APP_VERSION_: string | undefined
+declare const _OT_PD_SENTRY_RELEASE_: string | undefined
 declare const _OT_PD_SENTRY_DEV_DSN_: string | undefined
 declare const _OT_PD_SENTRY_DSN_: string | undefined
 declare const _OT_PD_VERSION_: string | undefined

--- a/protocol-designer/vite.config.mts
+++ b/protocol-designer/vite.config.mts
@@ -20,13 +20,19 @@ const { getVersion, generateBuildInfoHtml } = createGitVersionToolkit({
   project: 'protocol-designer',
 })
 
-// Sentry and sourcemaps are disabled in local development
 const isCI = process.env.CI === 'true'
-const enableSentry =
-  isCI &&
+
+const hasSentryCreds =
   !!process.env.SENTRY_AUTH_TOKEN &&
   !!process.env.SENTRY_ORG &&
   !!process.env.SENTRY_PROJECT
+
+// Local opt-in only: devs can enable the plugin by exporting SENTRY_* env vars.
+// When enabled locally, the plugin will upload sourcemaps under the `local-dev`
+// release name. The runtime SDK is configured to report the same release so local
+// events can resolve uploaded sourcemaps.
+// CI should use getsentry/action-release for releases/sourcemaps.
+const enableSentryLocalPlugin = !isCI && hasSentryCreds
 
 // eslint-disable-next-line import/no-default-export
 export default defineConfig(async (): Promise<UserConfig> => {
@@ -34,15 +40,16 @@ export default defineConfig(async (): Promise<UserConfig> => {
   const OT_PD_BUILD_DATE = new Date().toUTCString()
   const OT_PD_LATEST_LABWARE_VERSIONS =
     await latestLabwareVersions(REQUIRED_APP_VERSION)
-  const mode = process.env.NODE_ENV ?? 'development'
+
   return {
     // this makes imports relative rather than absolute
     base: '',
     build: {
       // Relative to the root
       outDir: 'dist',
-      // sourcemap is only enabled in CI
-      sourcemap: enableSentry ? 'hidden' : false,
+      // Not hidden: emit normal sourcemaps so devtools + Sentry can auto-detect.
+      // Emit in CI (so action-release can upload) and in local builds.
+      sourcemap: true,
       rollupOptions: {
         external: ['react/compiler-runtime'],
         output: {
@@ -59,7 +66,7 @@ export default defineConfig(async (): Promise<UserConfig> => {
       react({
         include: '**/*.tsx',
         babel: {
-          // Use babel.config.js files
+          // Use babel.config.js files 1Code has comments. Press enter to view.
           configFile: true,
         },
         jsxRuntime: 'automatic',
@@ -73,23 +80,23 @@ export default defineConfig(async (): Promise<UserConfig> => {
           }
         },
       },
-      ...(enableSentry
+
+      ...(enableSentryLocalPlugin
         ? [
             sentryVitePlugin({
-              org: process.env.SENTRY_ORG!,
-              project: process.env.SENTRY_PROJECT!,
-              authToken: process.env.SENTRY_AUTH_TOKEN!,
+              org: process.env.SENTRY_ORG,
+              project: process.env.SENTRY_PROJECT,
+              authToken: process.env.SENTRY_AUTH_TOKEN,
               telemetry: false,
               reactComponentAnnotation: { enabled: true },
-              sourcemaps: {
-                assets: ['./dist/**'],
-                ignore: ['./node_modules/**'],
-                // optional: rewrite paths if needed
-              },
-              // optional: release detection (match Sentry release to app version/commit)
+
+              // Local opt-in behavior:
+              // - Upload sourcemaps via the plugin (requires SENTRY_* env vars)
+              // - Use the `local-dev` release name
+              // CI continues to upload via getsentry/action-release.
               release: {
-                name: process.env.SENTRY_RELEASE || process.env.GIT_COMMIT_SHA,
-                // set commit SHA environment in CI
+                name: 'local-dev',
+                inject: false,
               },
             }),
           ]
@@ -133,11 +140,12 @@ export default defineConfig(async (): Promise<UserConfig> => {
       _NODE_ENV_: JSON.stringify(process.env.NODE_ENV),
       _OT_PD_BUILD_DATE_: JSON.stringify(OT_PD_BUILD_DATE),
       _OT_PD_LATEST_LABWARE_VERSIONS_: OT_PD_LATEST_LABWARE_VERSIONS,
-      _OT_PD_MIXPANEL_DEV_ID_: JSON.stringify(
-        process.env.OT_PD_MIXPANEL_DEV_ID
-      ),
+      _OT_PD_MIXPANEL_DEV_ID_: JSON.stringify(process.env.OT_PD_MIXPANEL_DEV_ID),
       _OT_PD_MIXPANEL_ID_: JSON.stringify(process.env.OT_PD_MIXPANEL_ID),
       _OT_PD_REQUIRED_APP_VERSION_: JSON.stringify(REQUIRED_APP_VERSION),
+      _OT_PD_SENTRY_RELEASE_: JSON.stringify(
+        enableSentryLocalPlugin ? 'local-dev' : OT_PD_VERSION
+      ),
       _OT_PD_SENTRY_DEV_DSN_: JSON.stringify(process.env.OT_PD_SENTRY_DEV_DSN),
       _OT_PD_SENTRY_DSN_: JSON.stringify(process.env.OT_PD_SENTRY_DSN),
       _OT_PD_VERSION_: JSON.stringify(OT_PD_VERSION),


### PR DESCRIPTION
This picks up the Sentry deployment fixes.