### PR TITLE
refactor(protocol-designer): figure out why SecondStepsMoveLiquidTools is crashing

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/SecondStepsMoveLiquidTools.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/SecondStepsMoveLiquidTools.tsx
@@ -105,12 +105,16 @@ export const SecondStepsMoveLiquidTools = ({
     formData.tipRack as string
   )
   // TODO: replace this with the actual individual byVolume values, separated by aspirate/dispense etc.
-  const stubbedByTipValues = getAllLiquidClassDefs()
-    [
+  const liquidClassDef =
+    getAllLiquidClassDefs()[
       formData.liquidClass !== NONE_LIQUID_CLASS_NAME
         ? formData.liquidClass
         : WATER_LIQUID_CLASS_NAME
-    ].byPipette.find(
+    ]
+  if (!liquidClassDef)
+    throw new Error(`Liquid class '${formData.liquidClass}' does not exist`)
+  const stubbedByTipValues = liquidClassDef.byPipette
+    .find(
       ({ pipetteModel }) => pipetteModel === getFlexNameConversion(pipetteSpecs)
     )
     ?.byTipType.find(({ tiprack }) => tiprack === formData.tipRack)


### PR DESCRIPTION
# Overview

`<SecondStepsMoveLiquidTools>` is failing somehow because it can't find the requested liquid class:
https://opentrons-76.sentry.io/issues/6987511353?project=4509363266387968

The liquid class we want comes from `formData.liquidClass`, so:
- There could be an invalid liquid class name in the form somehow,
- Or it's undefined,
- Or the `NONE_LIQUID_CLASS_NAME` -> `WATER_LIQUID_CLASS_NAME` fallback is broken?

This PR tries to catch the error with a more informative error message to help us figure out what's going on.

## Test Plan and Hands on Testing

Smoke-tested locally with a Transfer step.
Run CI tests.

## Risk assessment

Low.