### PR TITLE
fix(app): fix CSS Modules migration bugs buttons

### DIFF
--- a/app/src/atoms/buttons/QuaternaryButton.tsx
+++ b/app/src/atoms/buttons/QuaternaryButton.tsx
@@ -3,20 +3,20 @@ import styled from 'styled-components'
 import {
   BORDERS,
   COLORS,
-  NewSecondaryBtn,
+  Btn,
   SPACING,
   styleProps,
   TYPOGRAPHY,
 } from '@opentrons/components'
 
-export const QuaternaryButton: typeof NewSecondaryBtn = styled(NewSecondaryBtn)`
+export const QuaternaryButton: typeof Btn = styled(Btn)`
   background-color: ${COLORS.white};
+  border: 1px solid ${COLORS.blue50};
   border-radius: ${BORDERS.borderRadiusFull};
   box-shadow: none;
   color: ${COLORS.blue50};
   overflow: no-wrap;
-  padding-left: ${SPACING.spacing16};
-  padding-right: ${SPACING.spacing16};
+  padding: ${SPACING.spacing8} ${SPACING.spacing16};
   text-transform: ${TYPOGRAPHY.textTransformNone};
   white-space: nowrap;
   ${TYPOGRAPHY.labelSemiBold}
@@ -28,7 +28,7 @@ export const QuaternaryButton: typeof NewSecondaryBtn = styled(NewSecondaryBtn)`
     box-shadow: 0 0 0;
   }
   &:focus-visible {
-    box-shadow: 0 0 0 3px ${COLORS.yellow50};
+    box-shadow: 0 0 0 3px ${COLORS.blue50};
   }
 
   &:disabled {

--- a/app/src/atoms/buttons/QuaternaryButton.tsx
+++ b/app/src/atoms/buttons/QuaternaryButton.tsx
@@ -2,8 +2,8 @@ import styled from 'styled-components'
 
 import {
   BORDERS,
-  COLORS,
   Btn,
+  COLORS,
   SPACING,
   styleProps,
   TYPOGRAPHY,

--- a/app/src/atoms/buttons/TertiaryButton.tsx
+++ b/app/src/atoms/buttons/TertiaryButton.tsx
@@ -2,21 +2,20 @@ import styled from 'styled-components'
 
 import {
   BORDERS,
+  Btn,
   COLORS,
-  NewPrimaryBtn,
   SPACING,
   styleProps,
   TYPOGRAPHY,
 } from '@opentrons/components'
 
-export const TertiaryButton: typeof NewPrimaryBtn = styled(NewPrimaryBtn)`
+export const TertiaryButton: typeof Btn = styled(Btn)`
   background-color: ${COLORS.blue50};
   border-radius: ${BORDERS.borderRadiusFull};
   box-shadow: none;
   color: ${COLORS.white};
   overflow: no-wrap;
-  padding-left: ${SPACING.spacing16};
-  padding-right: ${SPACING.spacing16};
+  padding: ${SPACING.spacing8} ${SPACING.spacing16};
   text-transform: ${TYPOGRAPHY.textTransformNone};
   white-space: nowrap;
   ${TYPOGRAPHY.labelSemiBold}
@@ -34,7 +33,7 @@ export const TertiaryButton: typeof NewPrimaryBtn = styled(NewPrimaryBtn)`
 
   &:focus-visible {
     background-color: ${COLORS.blue55};
-    box-shadow: 0 0 0 3px ${COLORS.yellow50};
+    box-shadow: 0 0 0 3px ${COLORS.blue50};
   }
 
   &:disabled {

--- a/app/src/organisms/Desktop/Devices/HistoricalProtocolRun.tsx
+++ b/app/src/organisms/Desktop/Devices/HistoricalProtocolRun.tsx
@@ -11,9 +11,9 @@ import {
   Flex,
   Icon,
   JUSTIFY_SPACE_BETWEEN,
-  LegacyStyledText,
   OVERFLOW_HIDDEN,
   SPACING,
+  StyledText,
 } from '@opentrons/components'
 
 import { useRunGeneratedDataFiles } from '/app/resources/dataFiles/useRunGeneratedDataFiles'
@@ -31,6 +31,8 @@ const PROTOCOL_NAME_STYLE = css`
   white-space: nowrap;
   text-overflow: ellipsis;
 `
+
+const COLUMNS = '25% 27% 5% 14% 14% 12%'
 
 interface HistoricalProtocolRunProps {
   run: RunData
@@ -85,32 +87,33 @@ export function HistoricalProtocolRun(
         }}
         cursor="pointer"
       >
-        <Flex width="88%" gridGap={SPACING.spacing20}>
-          <LegacyStyledText
-            as="p"
-            width="25%"
+        <Flex
+          width="88%"
+          display="grid"
+          gridTemplateColumns={COLUMNS}
+          gap={SPACING.spacing20}
+        >
+          <StyledText
+            desktopStyle="bodyDefaultRegular"
             data-testid={`RecentProtocolRuns_Run_${protocolKey}`}
           >
             {runDisplayName}
-          </LegacyStyledText>
-          <LegacyStyledText
-            as="p"
-            width="27%"
+          </StyledText>
+          <StyledText
+            desktopStyle="bodyDefaultRegular"
             data-testid={`RecentProtocolRuns_Protocol_${protocolKey}`}
             css={PROTOCOL_NAME_STYLE}
           >
             {protocolName}
-          </LegacyStyledText>
-          <LegacyStyledText
-            as="p"
-            width="5%"
+          </StyledText>
+          <StyledText
+            desktopStyle="bodyDefaultRegular"
             data-testid={`RecentProtocolRuns_Files_${protocolKey}`}
           >
             {countRunDataFiles}
-          </LegacyStyledText>
-          <LegacyStyledText
-            as="p"
-            width="14%"
+          </StyledText>
+          <StyledText
+            desktopStyle="bodyDefaultRegular"
             data-testid={`RecentProtocolRuns_Status_${protocolKey}`}
           >
             {runStatus === 'running' ? (
@@ -123,14 +126,13 @@ export function HistoricalProtocolRun(
               />
             ) : null}
             {runStatus != null ? t(`status_${runStatus}`) : ''}
-          </LegacyStyledText>
-          <LegacyStyledText
-            as="p"
-            width="14%"
+          </StyledText>
+          <StyledText
+            desktopStyle="bodyDefaultRegular"
             data-testid="RecentProtocolRuns_Duration"
           >
             {duration}
-          </LegacyStyledText>
+          </StyledText>
         </Flex>
         <Flex alignItems={ALIGN_CENTER} gridGap={SPACING.spacing8}>
           <Box>

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderContent/ActionButton/index.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderContent/ActionButton/index.tsx
@@ -9,7 +9,6 @@ import {
   JUSTIFY_CENTER,
   NO_WRAP,
   PrimaryButton,
-  SIZE_1,
   SPACING,
   StyledText,
 } from '@opentrons/components'
@@ -87,33 +86,31 @@ export function ActionButton(props: ActionButtonProps): JSX.Element {
       ...props,
     })
   return (
-    <>
-      <PrimaryButton
-        justifyContent={JUSTIFY_CENTER}
-        alignItems={ALIGN_CENTER}
-        boxShadow="none"
-        display={DISPLAY_FLEX}
-        onClick={handleButtonClick}
-        id="ProtocolRunHeader_runControlButton"
-        borderRadius={BORDERS.borderRadiusFull}
-      >
-        {buttonIconName != null ? (
-          <Icon
-            name={buttonIconName}
-            size={SIZE_1}
-            marginRight={SPACING.spacing8}
-            spin={
-              isProtocolNotReady ||
-              runStatus === RUN_STATUS_STOP_REQUESTED ||
-              isResetRunLoadingRef.current ||
-              isClosingCurrentRun
-            }
-          />
-        ) : null}
-        <StyledText as="pSemiBold" whiteSpace={NO_WRAP}>
-          {buttonText}
-        </StyledText>
-      </PrimaryButton>
-    </>
+    <PrimaryButton
+      justifyContent={JUSTIFY_CENTER}
+      alignItems={ALIGN_CENTER}
+      boxShadow="none"
+      display={DISPLAY_FLEX}
+      onClick={handleButtonClick}
+      id="ProtocolRunHeader_runControlButton"
+      borderRadius={BORDERS.borderRadiusFull}
+      gap={buttonIconName != null ? SPACING.spacing8 : 0}
+    >
+      {buttonIconName != null ? (
+        <Icon
+          name={buttonIconName}
+          size="1rem"
+          spin={
+            isProtocolNotReady ||
+            runStatus === RUN_STATUS_STOP_REQUESTED ||
+            isResetRunLoadingRef.current ||
+            isClosingCurrentRun
+          }
+        />
+      ) : null}
+      <StyledText as="pSemiBold" whiteSpace={NO_WRAP}>
+        {buttonText}
+      </StyledText>
+    </PrimaryButton>
   )
 }

--- a/app/src/organisms/Desktop/Devices/RecentProtocolRuns.tsx
+++ b/app/src/organisms/Desktop/Devices/RecentProtocolRuns.tsx
@@ -25,6 +25,8 @@ import {
 
 import { HistoricalProtocolRun } from './HistoricalProtocolRun'
 
+const COLUMNS = '25% 27% 5% 14% 14% 12%'
+
 interface RecentProtocolRunsProps {
   robotName: string
 }
@@ -52,14 +54,15 @@ export function RecentProtocolRuns({
       width="100%"
       marginBottom="6rem"
     >
-      <StyledText
-        desktopStyle="bodyLargeSemiBold"
-        borderBottom={BORDERS.lineBorder}
+      <Flex
         padding={SPACING.spacing16}
+        borderBottom={BORDERS.lineBorder}
         width="100%"
       >
-        {t('recent_protocol_runs')}
-      </StyledText>
+        <StyledText desktopStyle="bodyLargeSemiBold">
+          {t('recent_protocol_runs')}
+        </StyledText>
+      </Flex>
       <Flex
         alignItems={ALIGN_CENTER}
         flexDirection={DIRECTION_COLUMN}
@@ -70,48 +73,45 @@ export function RecentProtocolRuns({
         {isRobotViewable && allRunsMutable && allRunsMutable?.length > 0 && (
           <>
             <Flex
+              display="grid"
               justifyContent={JUSTIFY_FLEX_START}
               padding={SPACING.spacing8}
               width="88%"
               marginRight="12%"
-              gridGap={SPACING.spacing20}
+              gap={SPACING.spacing20}
               color={COLORS.grey60}
+              gridTemplateColumns={COLUMNS}
             >
-              <LegacyStyledText
-                as="p"
-                width="25%"
+              <StyledText
+                desktopStyle="bodyDefaultRegular"
                 data-testid="RecentProtocolRuns_RunTitle"
               >
                 {t('run')}
-              </LegacyStyledText>
-              <LegacyStyledText
-                as="p"
-                width="27%"
+              </StyledText>
+              <StyledText
+                desktopStyle="bodyDefaultRegular"
                 data-testid="RecentProtocolRuns_ProtocolTitle"
               >
                 {t('protocol')}
-              </LegacyStyledText>
-              <LegacyStyledText
-                as="p"
-                width="5%"
+              </StyledText>
+              <StyledText
+                desktopStyle="bodyDefaultRegular"
                 data-testid="RecentProtocolRuns_FilesTitle"
               >
                 {t('files')}
-              </LegacyStyledText>
-              <LegacyStyledText
-                as="p"
-                width="14%"
+              </StyledText>
+              <StyledText
+                desktopStyle="bodyDefaultRegular"
                 data-testid="RecentProtocolRuns_StatusTitle"
               >
                 {t('status')}
-              </LegacyStyledText>
-              <LegacyStyledText
-                as="p"
-                width="14%"
+              </StyledText>
+              <StyledText
+                desktopStyle="bodyDefaultRegular"
                 data-testid="RecentProtocolRuns_DurationTitle"
               >
                 {t('run_duration')}
-              </LegacyStyledText>
+              </StyledText>
             </Flex>
             {allRunsMutable
               .sort(

--- a/app/src/organisms/Desktop/Devices/RobotStatusHeader.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotStatusHeader.tsx
@@ -84,10 +84,7 @@ export function RobotStatusHeader(props: RobotStatusHeaderProps): JSX.Element {
         }}
         gridGap={SPACING.spacing8}
       >
-        <LegacyStyledText
-          as="label"
-          overflowWrap={OVERFLOW_WRAP_ANYWHERE}
-        >
+        <LegacyStyledText as="label" overflowWrap={OVERFLOW_WRAP_ANYWHERE}>
           {`${truncateString(displayName, 68)}; ${i18n.format(
             t(`run_details:status_${currentRunStatus}`),
             'lowerCase'

--- a/app/src/organisms/Desktop/Devices/RobotStatusHeader.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotStatusHeader.tsx
@@ -82,10 +82,10 @@ export function RobotStatusHeader(props: RobotStatusHeaderProps): JSX.Element {
         onClick={(e: MouseEvent) => {
           e.stopPropagation()
         }}
+        gridGap={SPACING.spacing8}
       >
         <LegacyStyledText
           as="label"
-          paddingRight={SPACING.spacing8}
           overflowWrap={OVERFLOW_WRAP_ANYWHERE}
         >
           {`${truncateString(displayName, 68)}; ${i18n.format(

--- a/components/src/primitives/btn.module.css
+++ b/components/src/primitives/btn.module.css
@@ -5,6 +5,7 @@
   appearance: none;
   background-color: transparent;
   cursor: pointer;
+  white-space: nowrap;
 
   *:disabled {
     cursor: default;


### PR DESCRIPTION
# Overview
fix CSS Modules migration bugs buttons
replace LegacyStyledText with StyledText

The button components themselves have not been modified, because my top priority is to keep the same appearance as in v8.8.0.

close AUTH-2598 AUTH-2599 AUTH-2601

## Test Plan and Hands on Testing
QuaternaryButton
1. open app
2. set up a protocol to run
3. back to device landing page and check `Go to Run` button

TertiaryButton
1. go to app settings
2. click general tab
3. check `Set up connection` and `View software update` look the same as before

Recent Protocol Run
1. Go to the device details page
2. scroll down to Recent Protocol Run
The entire UI looks the same as before.

Drawer part has the layout issue and this will be fixed by a following PR.

## Changelog


## Review requests

## Risk assessment
low

