### PR TITLE
fix(components): fix Link component text wrap

### DIFF
--- a/components/src/primitives/Link.tsx
+++ b/components/src/primitives/Link.tsx
@@ -22,7 +22,12 @@ const LinkComponent = ({
     {...props}
     {...(external === true && { target: '_blank', rel: 'noopener noreferrer' })}
     // eslint-disable-next-line react/forbid-dom-props
-    style={{ textDecoration: 'none', cursor: 'pointer', ...props.style }}
+    style={{
+      whiteSpace: 'nowrap',
+      textDecoration: 'none',
+      cursor: 'pointer',
+      ...props.style,
+    }}
   />
 )
 


### PR DESCRIPTION

# Overview
fixL ink component text wrap

<img width="413" height="58" alt="Screenshot 2025-12-17 at 9 00 33 AM" src="https://github.com/user-attachments/assets/f795593d-7444-471a-8c2d-7a411428dffb" />


close AUTH-2602



## Test Plan and Hands on Testing
- `make -C app dev`

## Changelog
- add white-space to Link component

## Review requests


## Risk assessment
low
