### PR TITLE
feat(protocol-designer): Wire up to export concurrent Thermocycler steps

### DIFF
--- a/protocol-designer/src/form-types.ts
+++ b/protocol-designer/src/form-types.ts
@@ -485,6 +485,7 @@ export interface HydratedThermocyclerFormData extends AnnotationFields {
   profileTargetLidTemp: string | null
   profileVolume: string | null
 
+  // https://opentrons.atlassian.net/browse/EXEC-2141
   /** @deprecated Ignored with enableConcurrentModuleActions. Use a separate Thermocycler step instead. */
   blockIsActiveHold: boolean
   /** @deprecated Ignored with enableConcurrentModuleActions. Use a separate Thermocycler step instead. */

--- a/protocol-designer/src/form-types.ts
+++ b/protocol-designer/src/form-types.ts
@@ -467,22 +467,34 @@ export interface HydratedHeaterShakerFormData extends AnnotationFields {
 export interface HydratedThermocyclerFormData extends AnnotationFields {
   id: string
   stepType: 'thermocycler'
-  blockIsActive: boolean
-  blockIsActiveHold: boolean
-  blockTargetTemp: string | null
-  blockTargetTempHold: string | null
-  lidIsActive: boolean
-  lidIsActiveHold: boolean
-  lidOpen: boolean
-  lidOpenHold: boolean
-  lidTargetTemp: string | null
-  lidTargetTempHold: string | null
+
   moduleId: string
+
+  thermocyclerFormType: 'thermocyclerState' | 'thermocyclerProfile'
+
+  blockIsActive: boolean
+  blockTargetTemp: string | null
+
+  lidIsActive: boolean
+  lidTargetTemp: string | null
+
+  lidOpen: boolean
+
   orderedProfileItems: string[]
   profileItemsById: Record<string, ProfileItem>
   profileTargetLidTemp: string | null
   profileVolume: string | null
-  thermocyclerFormType: 'thermocyclerState' | 'thermocyclerProfile'
+
+  /** @deprecated Ignored with enableConcurrentModuleActions. Use a separate Thermocycler step instead. */
+  blockIsActiveHold: boolean
+  /** @deprecated Ignored with enableConcurrentModuleActions. Use a separate Thermocycler step instead. */
+  blockTargetTempHold: string | null
+  /** @deprecated Ignored with enableConcurrentModuleActions. Use a separate Thermocycler step instead. */
+  lidIsActiveHold: boolean
+  /** @deprecated Ignored with enableConcurrentModuleActions. Use a separate Thermocycler step instead. */
+  lidTargetTempHold: string | null
+  /** @deprecated Ignored with enableConcurrentModuleActions. Use a separate Thermocycler step instead. */
+  lidOpenHold: boolean
 }
 
 export type AbsorbanceReaderFormType =

--- a/protocol-designer/src/step-forms/selectors/index.ts
+++ b/protocol-designer/src/step-forms/selectors/index.ts
@@ -761,7 +761,13 @@ export const getArgsAndErrorsByStepId: Selector<
   getOrderedSavedForms,
   getInvariantContext,
   labwareDefSelectors.getLabwareDefsByURI,
-  (stepForms, contextualState, allLabwareDefs) => {
+  featureFlagSelectors.getEnableConcurrentModuleActions,
+  (
+    stepForms,
+    contextualState,
+    allLabwareDefs,
+    enableConcurrentModuleActions
+  ) => {
     return reduce(
       stepForms,
       (acc, stepForm, index) => {
@@ -775,7 +781,8 @@ export const getArgsAndErrorsByStepId: Selector<
           ? {
               stepArgs: stepFormToArgs(
                 { ...hydratedForm, stepNumber: index + 1 },
-                contextualState
+                contextualState,
+                enableConcurrentModuleActions
               ),
             }
           : {

--- a/protocol-designer/src/steplist/formLevel/errors.ts
+++ b/protocol-designer/src/steplist/formLevel/errors.ts
@@ -28,6 +28,7 @@ import {
   MIN_TC_PROFILE_VOLUME,
   MIN_TEMP_MODULE_TEMP,
   PAUSE_UNTIL_RESUME,
+  PAUSE_UNTIL_TC_PROFILE_COMPLETE,
   PAUSE_UNTIL_TEMP,
   PAUSE_UNTIL_TIME,
   THERMOCYCLER_PROFILE,
@@ -731,6 +732,12 @@ export const pauseForTimeOrUntilTold = (
   ) {
     // user selected pause until resume
     return null
+  } else if (
+    'pauseAction' in fields &&
+    fields.pauseAction === PAUSE_UNTIL_TC_PROFILE_COMPLETE
+  ) {
+    // This is a system-created pause step that's paired with a TC profile step.
+    return null
   } else {
     // user did not select a pause type
     return PAUSE_TYPE_REQUIRED
@@ -965,9 +972,10 @@ export const pauseModuleRequired = (
   fields: HydratedPauseFormData
 ): FormError | null => {
   const { moduleId, pauseAction } = fields
-  return pauseAction === PAUSE_UNTIL_TEMP && moduleId == null
-    ? PAUSE_MODULE_REQUIRED
-    : null
+  const expectingModuleId =
+    pauseAction === PAUSE_UNTIL_TEMP ||
+    pauseAction === PAUSE_UNTIL_TC_PROFILE_COMPLETE
+  return expectingModuleId && moduleId == null ? PAUSE_MODULE_REQUIRED : null
 }
 export const pauseTemperatureRequired = (
   fields: HydratedPauseFormData

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/index.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/index.ts
@@ -34,7 +34,8 @@ export function _castForm<HydratedFormDataT extends HydratedFormData>(
 
 export const stepFormToArgs = (
   hydratedForm: HydratedFormData,
-  contextualState: InvariantContext
+  contextualState: InvariantContext,
+  enableConcurrentModuleActions: boolean
 ): StepArgs => {
   const castForm = _castForm(hydratedForm)
   let stepArgs: StepArgs = null
@@ -60,7 +61,10 @@ export const stepFormToArgs = (
       break
     }
     case 'thermocycler': {
-      stepArgs = thermocyclerFormToArgs(_castForm(hydratedForm))
+      stepArgs = thermocyclerFormToArgs(
+        _castForm(hydratedForm),
+        enableConcurrentModuleActions
+      )
       break
     }
     case 'heaterShaker': {

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/pauseFormToArgs.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/pauseFormToArgs.ts
@@ -8,6 +8,7 @@ import { getTimeFromForm } from '../../utils/getTimeFromForm'
 
 import type {
   PauseArgs,
+  WaitForModuleTaskArgs,
   WaitForTemperatureArgs,
 } from '@opentrons/step-generation'
 import type { HydratedPauseFormData } from '../../../form-types'
@@ -15,7 +16,7 @@ import type { GetCastFormData } from '../../fieldLevel'
 
 export const pauseFormToArgs = (
   castFormData: GetCastFormData<HydratedPauseFormData>
-): PauseArgs | WaitForTemperatureArgs | null => {
+): PauseArgs | WaitForModuleTaskArgs | WaitForTemperatureArgs | null => {
   const { hours, minutes, seconds } = getTimeFromForm(
     'pauseTime' in castFormData ? (castFormData.pauseTime ?? null) : null
   )
@@ -65,11 +66,11 @@ export const pauseFormToArgs = (
       }
 
     case PAUSE_UNTIL_TC_PROFILE_COMPLETE:
-      // todo(mm, 2025-10-15): Implement this.
-      console.warn(
-        'pauseFormToArgs() does not yet implement PAUSE_UNTIL_TC_PROFILE_COMPLETE.'
-      )
-      return null
+      return {
+        commandCreatorFnName: 'waitForModuleTask',
+        waitCondition: 'thermocyclerProfileComplete',
+        moduleId: castFormData.moduleId ?? '',
+      }
 
     default:
       return null

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/thermocyclerFormToArgs.test.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/thermocyclerFormToArgs.test.ts
@@ -21,6 +21,7 @@ describe('thermocyclerFormToArgs', () => {
   const testCases: Array<{
     formData: GetCastFormData<HydratedThermocyclerFormData>
     expected: ThermocyclerStateStepArgs | ThermocyclerProfileStepArgs
+    enableConcurrentModuleActions: boolean
     testName: string
   }> = [
     {
@@ -64,6 +65,7 @@ describe('thermocyclerFormToArgs', () => {
         lidTargetTemp: 40,
         lidOpen: false,
       },
+      enableConcurrentModuleActions: true,
     },
     {
       testName: 'all active temps',
@@ -99,6 +101,7 @@ describe('thermocyclerFormToArgs', () => {
         lidTargetTemp: 40,
         lidOpen: false,
       },
+      enableConcurrentModuleActions: true,
     },
     {
       testName: 'inactive block - wrong (?) types',
@@ -141,6 +144,7 @@ describe('thermocyclerFormToArgs', () => {
         lidTargetTemp: 40,
         lidOpen: false,
       },
+      enableConcurrentModuleActions: true,
     },
     {
       testName: 'inactive block',
@@ -176,6 +180,7 @@ describe('thermocyclerFormToArgs', () => {
         lidTargetTemp: 40,
         lidOpen: false,
       },
+      enableConcurrentModuleActions: true,
     },
     {
       testName: 'profile with cycles - wrong (?) types',
@@ -304,6 +309,7 @@ describe('thermocyclerFormToArgs', () => {
           ],
         },
       },
+      enableConcurrentModuleActions: false,
     },
     {
       testName: 'profile with cycles',
@@ -422,12 +428,132 @@ describe('thermocyclerFormToArgs', () => {
           ],
         },
       },
+      enableConcurrentModuleActions: false,
+    },
+    {
+      testName: 'concurrent profile',
+      formData: {
+        ...getDefaultsForStepType('thermocycler'),
+        stepType: 'thermocycler',
+        id: 'testId',
+        stepName: 'mock name',
+        stepDetails: 'mock details',
+        moduleId: tcModuleId,
+        thermocyclerFormType: THERMOCYCLER_PROFILE,
+        blockTargetTemp: 9999,
+        lidIsActive: true,
+        lidTargetTemp: 40,
+        lidOpen: false,
+        profileVolume: '4',
+        profileTargetLidTemp: '40',
+        orderedProfileItems: ['profileItem1', 'profileItem2'],
+        stepNumber: 1,
+        profileItemsById: {
+          profileItem1: {
+            type: 'profileStep',
+            id: 'profileItem1',
+            title: 'Top level step',
+            temperature: '5',
+            durationMinutes: '',
+            durationSeconds: '50',
+          },
+          profileItem2: {
+            id: 'profileItem2',
+            type: 'profileCycle',
+            repetitions: '2',
+            steps: [
+              {
+                type: 'profileStep',
+                id: 'item2A',
+                title: 'Step A in cycle',
+                temperature: '12',
+                durationMinutes: '1',
+                durationSeconds: '2',
+              },
+              {
+                type: 'profileStep',
+                id: 'item2B',
+                title: 'Step B in cycle',
+                temperature: '99',
+                durationMinutes: '',
+                durationSeconds: '45',
+              },
+            ],
+          },
+        },
+        blockIsActiveHold: false,
+        lidIsActiveHold: false,
+        lidOpenHold: false,
+        blockIsActive: false,
+        blockTargetTempHold: 0,
+        lidTargetTempHold: 0,
+      },
+      expected: {
+        commandCreatorFnName: THERMOCYCLER_PROFILE,
+        concurrent: true,
+        moduleId: tcModuleId,
+        description: 'mock details',
+        profileElements: [
+          // top-level step
+          { celsius: 5, holdSeconds: 50 },
+          // cycle
+          {
+            steps: [
+              { celsius: 12, holdSeconds: 62 },
+              { celsius: 99, holdSeconds: 45 },
+            ],
+            repetitions: 2,
+          },
+        ],
+        profileTargetLidTemp: 40,
+        profileVolume: 4,
+        meta: {
+          rawProfileItems: [
+            {
+              type: 'profileStep',
+              id: 'profileItem1',
+              title: 'Top level step',
+              temperature: '5',
+              durationMinutes: '',
+              durationSeconds: '50',
+            },
+            {
+              id: 'profileItem2',
+              type: 'profileCycle',
+              repetitions: '2',
+              steps: [
+                {
+                  type: 'profileStep',
+                  id: 'item2A',
+                  title: 'Step A in cycle',
+                  temperature: '12',
+                  durationMinutes: '1',
+                  durationSeconds: '2',
+                },
+                {
+                  type: 'profileStep',
+                  id: 'item2B',
+                  title: 'Step B in cycle',
+                  temperature: '99',
+                  durationMinutes: '',
+                  durationSeconds: '45',
+                },
+              ],
+            },
+          ],
+        },
+      },
+      enableConcurrentModuleActions: true,
     },
   ]
 
-  testCases.forEach(({ formData, expected, testName }) => {
-    it(`should translate "thermocyclerState" to args: ${testName}`, () => {
-      expect(thermocyclerFormToArgs(formData)).toEqual(expected)
-    })
-  })
+  testCases.forEach(
+    ({ formData, expected, enableConcurrentModuleActions, testName }) => {
+      it(`should translate "thermocyclerState" to args: ${testName}`, () => {
+        expect(
+          thermocyclerFormToArgs(formData, enableConcurrentModuleActions)
+        ).toEqual(expected)
+      })
+    }
+  )
 })

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/thermocyclerFormToArgs.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/thermocyclerFormToArgs.ts
@@ -40,7 +40,8 @@ const _convertToProfileElements = (args: {
 }
 
 export const thermocyclerFormToArgs = (
-  castFormData: GetCastFormData<HydratedThermocyclerFormData>
+  castFormData: GetCastFormData<HydratedThermocyclerFormData>,
+  enableConcurrentModuleActions: boolean
 ): ThermocyclerProfileStepArgs | ThermocyclerStateStepArgs => {
   const { thermocyclerFormType, stepDetails } = castFormData
 
@@ -73,13 +74,7 @@ export const thermocyclerFormToArgs = (
         profileItemsById: castFormData.profileItemsById,
       })
 
-      return {
-        // todo(mm, 2025-10-09): form-types.ts is inconsistent about whether moduleId is nullable.
-        // This runtime behavior of assuming it can't be nullish here is inherited from prior code.
-        // Look into this.
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        moduleId: castFormData.moduleId!,
-        commandCreatorFnName: THERMOCYCLER_PROFILE,
+      const holdStepArgs = {
         blockTargetTempHold:
           castFormData.blockIsActiveHold &&
           castFormData.blockTargetTempHold !== null
@@ -91,6 +86,17 @@ export const thermocyclerFormToArgs = (
           castFormData.lidTargetTempHold !== null
             ? Number(castFormData.lidTargetTempHold)
             : null,
+      }
+
+      const args = {
+        commandCreatorFnName: THERMOCYCLER_PROFILE,
+
+        // todo(mm, 2025-10-09): form-types.ts is inconsistent about whether moduleId is nullable.
+        // This runtime behavior of assuming it can't be nullish here is inherited from prior code.
+        // Look into this.
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        moduleId: castFormData.moduleId!,
+
         meta: {
           rawProfileItems: castFormData.orderedProfileItems.map(
             (itemId: string | number) => castFormData.profileItemsById[itemId]
@@ -100,8 +106,20 @@ export const thermocyclerFormToArgs = (
         profileTargetLidTemp: Number(castFormData.profileTargetLidTemp),
         profileVolume: Number(castFormData.profileVolume),
         description: stepDetails,
-        concurrent: false,
+
+        ...(enableConcurrentModuleActions
+          ? {
+              concurrent: true as const,
+              // holdStepArgs is omitted here because step-generation and the backend
+              // don't support that functionality when concurrent is true.
+            }
+          : {
+              concurrent: false as const,
+              ...holdStepArgs,
+            }),
       }
+
+      return args
     }
   }
 }


### PR DESCRIPTION
## Overview

This wires up protocol-designer to use the new features added to step-generation, so that protocol-designer exports protocols in which Thermocycler profiles happen concurrently to other things.. This closes EXEC-2009, at long last.

This is based atop #20390.

## Changelog

When the `enableConcurrentModuleActions` feature flag is enabled:

* Thermocycler profile steps now use `concurrent: true` instead of `concurrent: false`. This tells step-generation to emit `thermocycler.start_execute_profile(...)` instead of `thermocycler.execute_profile(...)`, so the protocol will move on immediately after starting the profile instead of waiting for it to complete. `concurrent: true` was added in [the last PR](https://github.com/Opentrons/opentrons/pull/20390).
* The "wait for profile to complete" step that implicitly comes at the end of every [Thermocycler step group](https://github.com/Opentrons/opentrons/pull/19924) now gets turned into one of step-generation's new `waitForModuleTask` commands. In the exported Python file, this eventually becomes `protocol.wait_for_tasks(...)`.

When the feature flag is disabled, there should be no change.

## Test Plan and Hands on Testing

With the feature flag enabled:

1. [x] Create a protocol with some Thermocycler profile steps and some stuff happening inside them.
2. [x] Export the file. This should succeed without errors.
3. [x] The exported protocol file should pass analysis when imported into the app or given to `opentrons_simulate`.
4. [x] The exported file should use `start_execute_profile()` instead of `execute_profile()`.
5. [x] In the exported protocol file, there should be exactly one `wait_for_tasks()` for every `start_execute_profile()`.
6. [x] In the exported protocol file, the Python variables for the tasks count up for each additional Thermocycler profile (thermocycler_1_task_1, thermocycler_1_task_2, etc.).

## Review requests

None in particular.

## Risk assessment

Low risk of changing any prior behavior, as long as the feature flag is disabled.