### PR TITLE
feat(protocol-designer): View labware in hopper at end of run

### DIFF
--- a/protocol-designer/src/components/molecules/LabwareButtonBasket/labwarebuttonbasket.module.css
+++ b/protocol-designer/src/components/molecules/LabwareButtonBasket/labwarebuttonbasket.module.css
@@ -1,6 +1,8 @@
 .basket {
   display: flex;
   flex-direction: column;
+  width: 20rem;
+  overflow-y: scroll;
   gap: var(--spacing-8);
 }
 

--- a/protocol-designer/src/components/molecules/LabwareButtonBasket/labwarebuttonbasket.module.css
+++ b/protocol-designer/src/components/molecules/LabwareButtonBasket/labwarebuttonbasket.module.css
@@ -1,9 +1,9 @@
 .basket {
   display: flex;
-  flex-direction: column;
   width: 20rem;
-  overflow-y: scroll;
+  flex-direction: column;
   gap: var(--spacing-8);
+  overflow-y: scroll;
 }
 
 .basket_container {

--- a/protocol-designer/src/components/organisms/SlotDetailModal/index.tsx
+++ b/protocol-designer/src/components/organisms/SlotDetailModal/index.tsx
@@ -137,7 +137,11 @@ export const SlotDetailModal = (
         padding={SPACING.spacing16}
         height="28rem"
       >
-        <Flex flexDirection={DIRECTION_ROW} gridGap={SPACING.spacing24} height={"28rem"}>
+        <Flex
+          flexDirection={DIRECTION_ROW}
+          gridGap={SPACING.spacing24}
+          height={'28rem'}
+        >
           {stackOfLabware.length > 1 ? (
             <LabwareButtonBasket
               stackOfLabware={stackOfLabware}

--- a/protocol-designer/src/components/organisms/SlotDetailModal/index.tsx
+++ b/protocol-designer/src/components/organisms/SlotDetailModal/index.tsx
@@ -135,7 +135,7 @@ export const SlotDetailModal = (
       <Box
         backgroundColor={COLORS.grey10}
         padding={SPACING.spacing16}
-        height={'28rem'}
+        height='28rem'
       >
         <Flex
           flexDirection={DIRECTION_ROW}

--- a/protocol-designer/src/components/organisms/SlotDetailModal/index.tsx
+++ b/protocol-designer/src/components/organisms/SlotDetailModal/index.tsx
@@ -135,7 +135,7 @@ export const SlotDetailModal = (
       <Box
         backgroundColor={COLORS.grey10}
         padding={SPACING.spacing16}
-        height="28rem"
+        height={'28rem'}
       >
         <Flex
           flexDirection={DIRECTION_ROW}

--- a/protocol-designer/src/components/organisms/SlotDetailModal/index.tsx
+++ b/protocol-designer/src/components/organisms/SlotDetailModal/index.tsx
@@ -137,7 +137,7 @@ export const SlotDetailModal = (
         padding={SPACING.spacing16}
         height="28rem"
       >
-        <Flex flexDirection={DIRECTION_ROW} gridGap={SPACING.spacing24}>
+        <Flex flexDirection={DIRECTION_ROW} gridGap={SPACING.spacing24} height={"28rem"}>
           {stackOfLabware.length > 1 ? (
             <LabwareButtonBasket
               stackOfLabware={stackOfLabware}

--- a/protocol-designer/src/components/organisms/SlotDetailModal/index.tsx
+++ b/protocol-designer/src/components/organisms/SlotDetailModal/index.tsx
@@ -140,7 +140,7 @@ export const SlotDetailModal = (
         <Flex
           flexDirection={DIRECTION_ROW}
           gridGap={SPACING.spacing24}
-          height={'28rem'}
+          height="28rem"
         >
           {stackOfLabware.length > 1 ? (
             <LabwareButtonBasket

--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupDetails.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupDetails.tsx
@@ -340,6 +340,14 @@ export function DeckSetupDetails(props: DeckSetupDetailsProps): JSX.Element {
                     isSelected={selectedZoomInSlot != null}
                     allModules={allModules}
                   />
+                  <ActiveLabwareControls
+                    itemId={`hopper${slotId}`}
+                    slotPosition={[HOPPER_LABWARE_X_OFFSET, 0, 0]}
+                    hover={hover}
+                    setHover={setHover}
+                    slotBoundingBox={labwareInterfaceBoundingBox}
+                    terminalItemId={terminalItemId}
+                  />
                 </>
               ) : null}
               {labwareOnModule != null &&


### PR DESCRIPTION
# Overview

Enables view labware hover text for labware in the hopper at the end of the run

Also updated css style to ensure you can scroll through the list of labware. Prior to this change, the labware list got cut off.

## Test Plan and Hands on Testing

- smoke tested labware viewing at start of run and end of run

https://github.com/user-attachments/assets/6dcdd48f-da70-44b4-8d4e-43096e60015c


## Risk assessment

low

Closes EXEC-2140
