### PR TITLE
fix(app): fix the footer height for RobotUpdateProgressModal

### DIFF
--- a/app/src/organisms/Desktop/Devices/RobotSettings/UpdateBuildroot/RobotUpdateProgressModal.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/UpdateBuildroot/RobotUpdateProgressModal.tsx
@@ -183,7 +183,11 @@ function RobotUpdateProgressFooter({
   const { t } = useTranslation('device_settings')
 
   return (
-    <Flex alignItems={ALIGN_CENTER} justifyContent={JUSTIFY_FLEX_END}>
+    <Flex
+      alignItems={ALIGN_CENTER}
+      justifyContent={JUSTIFY_FLEX_END}
+      padding={`${SPACING.spacing16} 0`}
+    >
       <NewPrimaryBtn
         onClick={closeUpdateBuildroot}
         marginRight={SPACING.spacing12}


### PR DESCRIPTION

# Overview
fix the footer height for RobotUpdateProgressModal

obviously this is not an ideal fix but the design doesn't show any padding.
this branch has been aligned to match the appearance of v8.8.0

for consistent fixes, the NewBtn in use needs to be aligned with the current UI components, so it is preferable that this be carried out as part of the CSS Modules migration.

design
https://www.figma.com/design/qzX850M2Zxf1Mb5QwEtbzq/Primary--Desktop-App?node-id=10104-187437&t=aHQRDmg7HZ5W71K0-11


<img width="646" height="398" alt="Screenshot 2025-12-17 at 6 51 35 PM" src="https://github.com/user-attachments/assets/a3639503-f8ae-4fa7-ac43-d83bff40403c" />


close AUTH-2605


## Test Plan and Hands on Testing
- open app
- select a robot
- go to robot settings
- go to advanced tab
- update system file


## Changelog
- update RobotUpdateProgressModal footer height by adding padding

## Review requests


## Risk assessment
low
