### PR TITLE
fix(app): add line-clam to breadcrumb

### DIFF
--- a/app/src/organisms/Desktop/Breadcrumbs/breadcrumbs.module.css
+++ b/app/src/organisms/Desktop/Breadcrumbs/breadcrumbs.module.css
@@ -1,6 +1,10 @@
 .text_style {
+  display: -webkit-box;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
   font-size: var(--font-size-p);
   font-weight: var(--font-weight-regular);
+  -webkit-line-clamp: 1;
   line-height: var(--line-height-16);
 }
 


### PR DESCRIPTION

# Overview
add line-clam to breadcrumb

<img width="603" height="337" alt="Screenshot 2025-12-18 at 12 32 58 PM" src="https://github.com/user-attachments/assets/fb39425e-24bf-4024-aba7-ab7dd24e9249" />


close RQA-4976


## Test Plan and Hands on Testing
- select a protocol
- click visualization button
- shrink the window width
check the breadcrumb shows ellipsis 

## Changelog
- update BreadCrumb CSS

## Review requests


## Risk assessment
low
