### PR TITLE
chore: odd improvements for new oe-core

### DIFF
--- a/app-shell-odd/Makefile
+++ b/app-shell-odd/Makefile
@@ -74,9 +74,9 @@ dist-ot3: clean lib
 .PHONY: push-ot3
 push-ot3: deps dist-ot3
 	tar -zcvf opentrons-robot-app.tar.gz -C ./dist/linux-arm64-unpacked/ ./
-	scp $(if $(ssh_key),-i $(ssh_key)) $(ssh_opts) -r ./opentrons-robot-app.tar.gz root@$(host):
+	scp $(if $(ssh_key),-i $(ssh_key)) $(ssh_opts) -r ./opentrons-robot-app.tar.gz root@$(host):/var/
 	ssh $(if $(ssh_key),-i $(ssh_key)) $(ssh_opts) root@$(host) "mount -o remount,rw / && systemctl stop opentrons-robot-app && rm -rf /opt/opentrons-app && mkdir -p /opt/opentrons-app"
-	ssh $(if $(ssh_key),-i $(ssh_key)) $(ssh_opts) root@$(host) "tar -xvf opentrons-robot-app.tar.gz -C /opt/opentrons-app/ &&  mount -o remount,ro / && systemctl start opentrons-robot-app && rm -rf opentrons-robot-app.tar.gz"
+	ssh $(if $(ssh_key),-i $(ssh_key)) $(ssh_opts) root@$(host) "tar -xvf /var/opentrons-robot-app.tar.gz -C /opt/opentrons-app/ &&  mount -o remount,ro / && systemctl start opentrons-robot-app && rm -rf /var/opentrons-robot-app.tar.gz"
 
 
 # development

--- a/app-shell-odd/src/systemd.ts
+++ b/app-shell-odd/src/systemd.ts
@@ -1,13 +1,14 @@
 import { exec } from 'child_process'
+import { readFile, stat, writeFile } from 'fs/promises'
 import { platform } from 'process'
 
 // Provide systemd when possible and a default mocked instance, used only during
 // dev workflows, when not.
 
-function promisifyProcess(command: string): Promise<string> {
+function promisifyProcess(command: string, quiet?: boolean): Promise<string> {
   return new Promise((resolve, reject) => {
     exec(command, (err, stdout, stderr) => {
-      if (err) {
+      if (err && quiet !== true) {
         console.warn(
           `${command} failed: ${err.code}: ${err.message}: ${stderr}`
         )
@@ -16,6 +17,25 @@ function promisifyProcess(command: string): Promise<string> {
       resolve(stdout ?? stderr)
     })
   })
+}
+
+const NEW_ODD_BRIGHTNESS_PATH =
+  '/sys/class/backlight/backlight-verdin-dsi/brightness'
+const OLD_ODD_BRIGHTNESS_PATH =
+  '/sys/class/backlight/backlight/device/backlight/backlight/brightness'
+
+function writeBrightness(text: string): Promise<string> {
+  return stat(NEW_ODD_BRIGHTNESS_PATH)
+    .then(() =>
+      writeFile(NEW_ODD_BRIGHTNESS_PATH, text).then(() =>
+        readFile(NEW_ODD_BRIGHTNESS_PATH, 'ascii')
+      )
+    )
+    .catch(() =>
+      writeFile(OLD_ODD_BRIGHTNESS_PATH, text).then(() =>
+        readFile(OLD_ODD_BRIGHTNESS_PATH, 'ascii')
+      )
+    )
 }
 
 const verbForState = (state: boolean): string => (state ? 'start' : 'stop')
@@ -41,17 +61,16 @@ const provideExports = (): SystemD => {
             enabled
           )} opentrons-robot-app-devtools.socket`
         ),
-      getisRobotServerReady: () =>
-        promisifyProcess(
-          '/bin/systemctl is-active opentrons-robot-server'
+      getisRobotServerReady: () => {
+        return promisifyProcess(
+          '/bin/systemctl is-active opentrons-robot-server',
+          true
           // trimming string because stdout returns a new line
-        ).then(state => state.trim() === 'active'),
+        ).then(state => state.trim() === 'active')
+      },
       restartApp: () =>
         promisifyProcess(`/bin/systemctl restart opentrons-robot-app`),
-      updateBrightness: text =>
-        promisifyProcess(
-          `echo "${text}" > /sys/class/backlight/backlight/device/backlight/backlight/brightness`
-        ),
+      updateBrightness: writeBrightness,
     }
   } else {
     return {


### PR DESCRIPTION
A couple small ODD improvements:
- Make the push task use an explicit non-empty target path, since the empty target path was failing on my machine
- Handle both old and new brightness file paths 
- Don't do brightness by shelling out to `echo {brightness} > /path` because why would we do that
- Don't print a log message every time `systemctl is-active` "fails" (aka says the target unit isn't active - it sets a non-zero return so you can use it in logic, but it's not an unexpected outcome)