### PR TITLE
fix(app-shell-odd): tweak files settings to push ODD app to Flex

### DIFF
--- a/app-shell-odd/electron-builder.config.js
+++ b/app-shell-odd/electron-builder.config.js
@@ -7,6 +7,8 @@ module.exports = {
   files: [
     '**/*',
     '!Makefile',
+    '!**/.venv/**',
+    '!**/shared-data/.venv/**',
     {
       from: '../app/dist',
       to: './ui',


### PR DESCRIPTION
# Overview
tweak files settings to push ODD app to Flex

when ran `make -C app-shell-odd push-ot3 host=`, i got the following error.

```shell
Desktop/dev/opentrons/node_modules/.bin/electron-builder --config electron-builder.config.js --publish never --linux --arm64
  • electron-builder  version=26.0.15 os=25.1.0
  • loaded configuration  file=dev/opentrons/app-shell-odd/electron-builder.config.js
  • writing effective config  file=dist/builder-effective-config.yaml
  • skipped dependencies rebuild  reason=npmRebuild is set to false
  • packaging       platform=linux arch=arm64 electron=39.1.2 appOutDir=dist/linux-arm64-unpacked
  ⨯ unable to copy, file is symlinked outside the package  source=/dev/opentrons/shared-data/.venv/bin/python realPathFile=/opt/homebrew/Cellar/python@3.12/3.12.12/Frameworks/Python.framework/Versions/3.12/bin/python3.12
  ⨯ Cannot copy file (python) symlinked to file (python3.12) outside the package as that violates asar security integrity  failedTask=build stackTrace=Error: Cannot copy file (python) symlinked to file (python3.12) outside the package as that violates asar security integrity
    at AsarPackager.processFileOrSymlink (/dev/opentrons/node_modules/app-builder-lib/src/asar/asarUtil.ts:151:13)
    at processTicksAndRejections (node:internal/process/task_queues:105:5)
    at AsarPackager.processFileSets (dev/opentrons/node_modules/app-builder-lib/src/asar/asarUtil.ts:83:24)
    at AsarPackager.pack (dev/opentrons/node_modules/app-builder-lib/src/asar/asarUtil.ts:38:21)
    at /dev/opentrons/node_modules/app-builder-lib/src/platformPackager.ts:535:11
    at async Promise.all (index 0)
    at AsyncTaskManager.awaitTasks (/dev/opentrons/node_modules/builder-util/src/asyncTaskManager.ts:65:25)
    at LinuxPackager.doPack (/Users/koji/Desktop/dev/opentrons/node_modules/app-builder-lib/src/platformPackager.ts:307:5)
    at LinuxPackager.pack (/dev/opentrons/node_modules/app-builder-lib/src/platformPackager.ts:158:5)
    at Packager.doBuild (/dev/opentrons/node_modules/app-builder-lib/src/packager.ts:507:11)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
make: *** [dist-ot3] Error 1
```
 

Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.

## Test Plan and Hands on Testing
make -C app-shell-odd push-ot3 host=flex_ip_address

## Changelog
- add `.venv` to exclude from the build target of Electron

## Review requests

## Risk assessment
low-mid
