### PR TITLE
fix(protocol-designer): Fix Thermocycler steps getting laid out horizontally

### DIFF
--- a/protocol-designer/src/components/molecules/ConcurrentGroup/ConcurrentGroup.tsx
+++ b/protocol-designer/src/components/molecules/ConcurrentGroup/ConcurrentGroup.tsx
@@ -2,7 +2,6 @@ import {
   Box,
   COLORS,
   DIRECTION_ROW,
-  DISPLAY_FLEX,
   Flex,
   SPACING,
 } from '@opentrons/components'
@@ -33,7 +32,7 @@ export function ConcurrentGroup(
       gridGap={SPACING.spacing4}
     >
       <OrnamentalLine active={active} />
-      <ul style={{ display: DISPLAY_FLEX, flex: '1' }}>{children}</ul>
+      <ul style={{ flex: '1' }}>{children}</ul>
     </Flex>
   )
 }


### PR DESCRIPTION
# Overview

This closes the other half of AUTH-2636.

## Test Plan and Hands on Testing

Viewing `ConcurrentGroup` in Storybook, before:

<img width="640" height="186" alt="Screenshot 2025-12-19 at 3 25 57 PM" src="https://github.com/user-attachments/assets/1b9a193b-d46d-4a80-b9a3-0fb24a7e2f4a" />

After:

<img width="321" height="337" alt="Screenshot 2025-12-19 at 3 24 29 PM" src="https://github.com/user-attachments/assets/c76b34b0-590b-44cf-b1e5-a36538b75eaa" />

## Details

Originally, we had:

```
<Box as="ul" flex="1">
```

#19266 changed that to:

```
<ul style={display: DISPLAY_FLEX, flex: "1"}>
```

That accidentally changed the `<ul>` from `display: block` to `display: flex`.

We can fix the problem just by removing `display: flex`.

We keep `flex: "1"` because it affects how much space the `<ul>` occupies in its parent container, which is `display: flex`.

## Review requests

None.

## Risk assessment

Low.