### PR TITLE
fix(components): expand flex stacker component to take up column 3 and 4

### DIFF
--- a/components/src/hardware-sim/DeckConfigurator/FlexStackerItem.tsx
+++ b/components/src/hardware-sim/DeckConfigurator/FlexStackerItem.tsx
@@ -9,12 +9,12 @@ import { Btn } from '../../primitives'
 import { TYPOGRAPHY } from '../../ui-style-constants'
 import { RobotCoordsForeignObject } from '../Deck/RobotCoordsForeignObject'
 import {
-  COLUMN_DEFAULT_X_ADJUSTMENT,
+  STACKER_X_ADJUSTMENT,
   CONFIG_STYLE_EDITABLE,
   CONFIG_STYLE_READ_ONLY,
   CONFIG_STYLE_SELECTED,
   FIXTURE_HEIGHT,
-  LARGE_SINGLE_ITEM_SLOT_WIDTH,
+  COLUMN_DEFAULT_SINGLE_SLOT_FIXTURE_WIDTH,
   Y_ADJUSTMENT,
 } from './constants'
 
@@ -71,7 +71,7 @@ export function FlexStackerItem(props: FlexStackerItemProps): JSX.Element {
     deckDefinition
   )
   const y = ySlotPosition + Y_ADJUSTMENT
-  const x = xSlotPosition + COLUMN_DEFAULT_X_ADJUSTMENT
+  const x = xSlotPosition + offsetVector[0] + STACKER_X_ADJUSTMENT
 
   const editableStyle = selected ? CONFIG_STYLE_SELECTED : CONFIG_STYLE_EDITABLE
   const handleRemoveClick = (): void => {
@@ -81,7 +81,7 @@ export function FlexStackerItem(props: FlexStackerItemProps): JSX.Element {
   }
   return (
     <RobotCoordsForeignObject
-      width={LARGE_SINGLE_ITEM_SLOT_WIDTH}
+      width={COLUMN_DEFAULT_SINGLE_SLOT_FIXTURE_WIDTH}
       height={FIXTURE_HEIGHT}
       x={x}
       y={y}

--- a/components/src/hardware-sim/DeckConfigurator/FlexStackerItem.tsx
+++ b/components/src/hardware-sim/DeckConfigurator/FlexStackerItem.tsx
@@ -9,12 +9,12 @@ import { Btn } from '../../primitives'
 import { TYPOGRAPHY } from '../../ui-style-constants'
 import { RobotCoordsForeignObject } from '../Deck/RobotCoordsForeignObject'
 import {
-  COLUMN_DEFAULT_SINGLE_SLOT_FIXTURE_WIDTH,
+  COLUMN_DEFAULT_X_ADJUSTMENT,
   CONFIG_STYLE_EDITABLE,
   CONFIG_STYLE_READ_ONLY,
   CONFIG_STYLE_SELECTED,
   FIXTURE_HEIGHT,
-  STACKER_X_ADJUSTMENT,
+  LARGE_SINGLE_ITEM_SLOT_WIDTH,
   Y_ADJUSTMENT,
 } from './constants'
 
@@ -71,7 +71,7 @@ export function FlexStackerItem(props: FlexStackerItemProps): JSX.Element {
     deckDefinition
   )
   const y = ySlotPosition + Y_ADJUSTMENT
-  const x = xSlotPosition + offsetVector[0] + STACKER_X_ADJUSTMENT
+  const x = xSlotPosition + COLUMN_DEFAULT_X_ADJUSTMENT
 
   const editableStyle = selected ? CONFIG_STYLE_SELECTED : CONFIG_STYLE_EDITABLE
   const handleRemoveClick = (): void => {
@@ -81,7 +81,7 @@ export function FlexStackerItem(props: FlexStackerItemProps): JSX.Element {
   }
   return (
     <RobotCoordsForeignObject
-      width={COLUMN_DEFAULT_SINGLE_SLOT_FIXTURE_WIDTH}
+      width={LARGE_SINGLE_ITEM_SLOT_WIDTH}
       height={FIXTURE_HEIGHT}
       x={x}
       y={y}


### PR DESCRIPTION
# Overview

Prevent users from adding the magnetic block beside the flex stacker in deck configuration by expanding the component size.

## Test Plan and Hands on Testing

smoke tested in protocol designer and in the app

https://github.com/user-attachments/assets/ec69d35e-903b-4172-9ebf-ce9aa636e2e3

https://github.com/user-attachments/assets/c27ad77b-5bb6-4c92-9cf7-1c1900f69d03

## Review requests



## Risk assessment

low

Closes EXEC-2203
