### PR TITLE
fix(components): fix base deck key issue

### DIFF
--- a/components/src/hardware-sim/BaseDeck/BaseDeck.tsx
+++ b/components/src/hardware-sim/BaseDeck/BaseDeck.tsx
@@ -32,15 +32,14 @@ import {
   FixedTrashText,
 } from '../..'
 import { COLORS } from '../../helix-design-system'
-import { RobotInfoLabel } from '../../molecules/RobotInfoLabel'
 import { SlotLabels } from '../Deck'
 import { DeckFromLayers } from '../Deck/DeckFromLayers'
 import { FlexTrash } from '../Deck/FlexTrash'
-import { RobotCoordsForeignObject } from '../Deck/RobotCoordsForeignObject'
 import { LabwareRender } from '../Labware'
 import { Module } from '../Module'
 import { RobotCoordinateSpace } from '../RobotCoordinateSpace'
 import { SingleSlotFixture } from './SingleSlotFixture'
+import { StackedBadge } from './StackedBadge'
 import { StagingAreaFixture } from './StagingAreaFixture'
 import { WasteChuteFixture } from './WasteChuteFixture'
 import { WasteChuteStagingAreaFixture } from './WasteChuteStagingAreaFixture'
@@ -323,7 +322,9 @@ export function BaseDeck(props: BaseDeckProps): JSX.Element {
             const slotPosition = getPositionFromSlotId(stackerSlotName, deckDef)
             const moduleDef = getModuleDef(moduleModel)
             return slotPosition != null ? (
-              <>
+              <Fragment
+                key={`stacker_${moduleModel}_${moduleLocation.slotName}`}
+              >
                 <StagingAreaFixture
                   cutoutId={
                     `cutout${moduleLocation.slotName}` as StagingAreaLocation
@@ -391,7 +392,7 @@ export function BaseDeck(props: BaseDeckProps): JSX.Element {
                   ) : null}
                   {moduleChildren}
                 </Module>
-              </>
+              </Fragment>
             ) : null
           }
         )}
@@ -578,19 +579,6 @@ export function BaseDeck(props: BaseDeckProps): JSX.Element {
       </>
       {children}
     </RobotCoordinateSpace>
-  )
-}
-
-function StackedBadge(): JSX.Element {
-  return (
-    <RobotCoordsForeignObject height="2.5rem" width="2.5rem" x={113} y={53}>
-      <RobotInfoLabel
-        height="1.25rem"
-        svgSize="0.875rem"
-        highlight
-        iconName="stacked"
-      />
-    </RobotCoordsForeignObject>
   )
 }
 

--- a/components/src/hardware-sim/BaseDeck/StackedBadge.tsx
+++ b/components/src/hardware-sim/BaseDeck/StackedBadge.tsx
@@ -1,0 +1,15 @@
+import { RobotInfoLabel } from '../../molecules/RobotInfoLabel'
+import { RobotCoordsForeignObject } from '../Deck/RobotCoordsForeignObject'
+
+export function StackedBadge(): JSX.Element {
+  return (
+    <RobotCoordsForeignObject height="2.5rem" width="2.5rem" x={113} y={53}>
+      <RobotInfoLabel
+        height="1.25rem"
+        svgSize="0.875rem"
+        highlight
+        iconName="stacked"
+      />
+    </RobotCoordsForeignObject>
+  )
+}


### PR DESCRIPTION
# Overview
add react fragment to fix base deck key issue

fix AUTH-2646

## Test Plan and Hands on Testing
when run `make -C app dev` and open dev tools, you don't see the following warning

<img width="1150" height="790" alt="Screenshot 2025-12-22 at 5 22 14 PM" src="https://github.com/user-attachments/assets/237c17af-f9cf-417e-812f-20e7329b122a" />


## Changelog
- add react fragment for `key`
- create StackedBadge component to reduce lines

## Review requests


## Risk assessment
low