### PR TITLE
chore: format our ESM files

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -6,7 +6,6 @@
 **/venv/**
 .opentrons_config
 **/tsconfig*.json
-**/vite.config.mts
 # prettier
 **/package.json
 **/CHANGELOG.md

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ cover ?= true
 updateSnapshot ?= false
 quiet ?= false
 
-FORMAT_FILE_GLOB = ".*.@(js|ts|tsx|yml)" "**/*.@(ts|tsx|js|json|md|yml)"
+FORMAT_FILE_GLOB = ".*.@(js|ts|tsx|yml|mjs|mts)" "**/*.@(ts|tsx|js|mts|mjs|json|md|yml)"
 
 ifeq ($(watch), true)
 	cover := false

--- a/app-shell-odd/vite.config.mts
+++ b/app-shell-odd/vite.config.mts
@@ -1,110 +1,110 @@
-import { versionForProject } from '../scripts/git-version.mjs'
-import pkg from './package.json'
 import path from 'path'
-import { defineConfig } from 'vite'
 import { sentryVitePlugin } from '@sentry/vite-plugin'
 import react from '@vitejs/plugin-react'
-import postCssImport from 'postcss-import'
+import lostCss from 'lost'
 import postCssApply from 'postcss-apply'
 import postColorModFunction from 'postcss-color-mod-function'
+import postCssImport from 'postcss-import'
 import postCssPresetEnv from 'postcss-preset-env'
-import lostCss from 'lost'
+import { defineConfig } from 'vite'
+
+import { versionForProject } from '../scripts/git-version.mjs'
+import pkg from './package.json'
+
 import type { UserConfig } from 'vite'
 
-export default defineConfig(
-  async (): Promise<UserConfig> => {
-    const project = process.env.OPENTRONS_PROJECT ?? 'robot-stack'
-    const version = await versionForProject(project)
-    const mode = process.env.NODE_ENV ?? 'development'
+export default defineConfig(async (): Promise<UserConfig> => {
+  const project = process.env.OPENTRONS_PROJECT ?? 'robot-stack'
+  const version = await versionForProject(project)
+  const mode = process.env.NODE_ENV ?? 'development'
 
-    return {
-      publicDir: false,
-      build: {
-        // Relative to the root
-        ssr: 'src/main.ts',
-        outDir: 'lib',
-        commonjsOptions: {
-          transformMixedEsModules: true,
-          esmExternals: true,
+  return {
+    publicDir: false,
+    build: {
+      // Relative to the root
+      ssr: 'src/main.ts',
+      outDir: 'lib',
+      commonjsOptions: {
+        transformMixedEsModules: true,
+        esmExternals: true,
+      },
+      lib: {
+        entry: {
+          main: 'src/main.ts',
+          preload: 'src/preload.ts',
         },
-        lib: {
-          entry: {
-            main: 'src/main.ts',
-            preload: 'src/preload.ts',
-          },
 
-          formats: ['cjs'],
+        formats: ['cjs'],
+      },
+    },
+    plugins: [
+      react({
+        include: '**/*.tsx',
+        babel: {
+          // Use babel.config.js files
+          configFile: true,
         },
-      },
-      plugins: [
-        react({
-          include: '**/*.tsx',
-          babel: {
-            // Use babel.config.js files
-            configFile: true,
-          },
-        }),
-        sentryVitePlugin({
-          org: 'opentrons-sw',
-          project: 'odd',
-          authToken: process.env.OT_SENTRY_AUTH_TOKEN,
-          telemetry: false,
-          sourcemaps: {
-            assets: ['./dist/**'],
-            ignore: ['./node_modules/**'],
-            filesToDeleteAfterUpload:
-              mode === 'production' ? ['./dist/**/*.js.map'] : undefined,
-          },
-        }),
-      ],
-      optimizeDeps: {
-        esbuildOptions: {
-          target: 'CommonJs',
+      }),
+      sentryVitePlugin({
+        org: 'opentrons-sw',
+        project: 'odd',
+        authToken: process.env.OT_SENTRY_AUTH_TOKEN,
+        telemetry: false,
+        sourcemaps: {
+          assets: ['./dist/**'],
+          ignore: ['./node_modules/**'],
+          filesToDeleteAfterUpload:
+            mode === 'production' ? ['./dist/**/*.js.map'] : undefined,
         },
+      }),
+    ],
+    optimizeDeps: {
+      esbuildOptions: {
+        target: 'CommonJs',
       },
-      css: {
-        postcss: {
-          plugins: [
-            postCssImport({ root: 'src/' }),
-            postCssApply(),
-            postColorModFunction(),
-            postCssPresetEnv({ stage: 0 }),
-            lostCss(),
-          ],
-        },
+    },
+    css: {
+      postcss: {
+        plugins: [
+          postCssImport({ root: 'src/' }),
+          postCssApply(),
+          postColorModFunction(),
+          postCssPresetEnv({ stage: 0 }),
+          lostCss(),
+        ],
       },
-      define: {
-        // NOTE: For security, only include environment variables here if they're explicitly allowlisted.
-        global: 'globalThis',
-        _NODE_ENV_: JSON.stringify(process.env.NODE_ENV),
-        _OPENTRONS_PROJECT_: JSON.stringify(project),
-        _OT_SENTRY_DSN_: JSON.stringify(process.env.OT_SENTRY_DSN),
-        _PKG_BUGS_URL_: JSON.stringify(pkg.bugs.url),
-        _PKG_PRODUCT_NAME_: JSON.stringify(pkg.productName),
-        _PKG_VERSION_: JSON.stringify(version),
+    },
+    define: {
+      // NOTE: For security, only include environment variables here if they're explicitly allowlisted.
+      global: 'globalThis',
+      _NODE_ENV_: JSON.stringify(process.env.NODE_ENV),
+      _OPENTRONS_PROJECT_: JSON.stringify(project),
+      _OT_SENTRY_DSN_: JSON.stringify(process.env.OT_SENTRY_DSN),
+      _PKG_BUGS_URL_: JSON.stringify(pkg.bugs.url),
+      _PKG_PRODUCT_NAME_: JSON.stringify(pkg.productName),
+      _PKG_VERSION_: JSON.stringify(version),
+    },
+    resolve: {
+      alias: {
+        // todo(mm, 2025-10-27): These cross-project aliases cause trouble like
+        // files being processed with the wrong config (the config from the
+        // consuming project vs. the config from the source project).
+        // Can these be replaced with regular package.json dependencies?
+        '@opentrons/components/styles': path.resolve(
+          '../components/src/index.module.css'
+        ),
+        '@opentrons/components': path.resolve('../components/src/index.ts'),
+        '@opentrons/shared-data': path.resolve('../shared-data/js/index.ts'),
+        '@opentrons/step-generation': path.resolve(
+          '../step-generation/src/index.ts'
+        ),
+        '@opentrons/discovery-client': path.resolve(
+          '../discovery-client/src/index.ts'
+        ),
+        '@opentrons/usb-bridge/node-client': path.resolve(
+          '../usb-bridge/node-client/src/index.ts'
+        ),
       },
-      resolve: {
-        alias: {
-          // todo(mm, 2025-10-27): These cross-project aliases cause trouble like
-          // files being processed with the wrong config (the config from the
-          // consuming project vs. the config from the source project).
-          // Can these be replaced with regular package.json dependencies?
-          '@opentrons/components/styles': path.resolve(
-            '../components/src/index.module.css'
-          ),
-          '@opentrons/components': path.resolve('../components/src/index.ts'),
-          '@opentrons/shared-data': path.resolve('../shared-data/js/index.ts'),
-          '@opentrons/step-generation': path.resolve(
-            '../step-generation/src/index.ts'
-          ),
-          '@opentrons/discovery-client': path.resolve(
-            '../discovery-client/src/index.ts'
-          ),
-          '@opentrons/usb-bridge/node-client': path.resolve(
-            '../usb-bridge/node-client/src/index.ts'
-          ),
-        },
-      },
-    }
+    },
   }
-)
+})

--- a/app-shell/vite.config.mts
+++ b/app-shell/vite.config.mts
@@ -1,89 +1,89 @@
+import path from 'path'
+import { sentryVitePlugin } from '@sentry/vite-plugin'
+import { defineConfig } from 'vite'
+
 import { versionForProject } from '../scripts/git-version.mjs'
 import pkg from './package.json'
-import path from 'path'
-import { defineConfig } from 'vite'
-import { sentryVitePlugin } from '@sentry/vite-plugin'
+
 import type { UserConfig } from 'vite'
 
-export default defineConfig(
-  async (): Promise<UserConfig> => {
-    const project = process.env.OPENTRONS_PROJECT ?? 'robot-stack'
-    const version = await versionForProject(project)
-    const mode = process.env.NODE_ENV ?? 'development'
+export default defineConfig(async (): Promise<UserConfig> => {
+  const project = process.env.OPENTRONS_PROJECT ?? 'robot-stack'
+  const version = await versionForProject(project)
+  const mode = process.env.NODE_ENV ?? 'development'
 
-    return {
-      // this makes imports relative rather than absolute
-      base: '',
-      publicDir: false,
-      build: {
-        // Relative to the root
-        ssr: 'src/main.ts',
-        outDir: 'lib',
-        commonjsOptions: {
-          transformMixedEsModules: true,
-          esmExternals: true,
-          exclude: [/node_modules/],
+  return {
+    // this makes imports relative rather than absolute
+    base: '',
+    publicDir: false,
+    build: {
+      // Relative to the root
+      ssr: 'src/main.ts',
+      outDir: 'lib',
+      commonjsOptions: {
+        transformMixedEsModules: true,
+        esmExternals: true,
+        exclude: [/node_modules/],
+      },
+      lib: {
+        entry: {
+          main: 'src/main.ts',
+          preload: 'src/preload.ts',
         },
-        lib: {
-          entry: {
-            main: 'src/main.ts',
-            preload: 'src/preload.ts',
-          },
 
-          formats: ['cjs'],
+        formats: ['cjs'],
+      },
+    },
+    plugins: [
+      sentryVitePlugin({
+        org: 'opentrons-sw',
+        project: 'app',
+        authToken: process.env.OT_SENTRY_AUTH_TOKEN,
+        telemetry: false,
+        sourcemaps: {
+          assets: ['./dist/**'],
+          ignore: ['./node_modules/**'],
+          filesToDeleteAfterUpload:
+            mode === 'production' ? ['./dist/**/*.js.map'] : undefined,
         },
+      }),
+    ],
+    optimizeDeps: {
+      esbuildOptions: {
+        target: 'CommonJs',
       },
-      plugins: [
-        sentryVitePlugin({
-          org: 'opentrons-sw',
-          project: 'app',
-          authToken: process.env.OT_SENTRY_AUTH_TOKEN,
-          telemetry: false,
-          sourcemaps: {
-            assets: ['./dist/**'],
-            ignore: ['./node_modules/**'],
-            filesToDeleteAfterUpload:
-              mode === 'production' ? ['./dist/**/*.js.map'] : undefined,
-          },
-        }),
-      ],
-      optimizeDeps: {
-        esbuildOptions: {
-          target: 'CommonJs',
-        },
-        exclude: ['node_modules'],
+      exclude: ['node_modules'],
+    },
+    define: {
+      // NOTE: For security, only include environment variables here if they're explicitly allowlisted.
+      global: 'globalThis',
+      _NODE_ENV_: JSON.stringify(process.env.NODE_ENV),
+      _OT_SENTRY_DSN_: JSON.stringify(process.env.OT_SENTRY_DSN),
+      _OPENTRONS_PROJECT_: JSON.stringify(project),
+      _PKG_BUGS_URL_: JSON.stringify(pkg.bugs.url),
+      _PKG_PRODUCT_NAME_: JSON.stringify(pkg.productName),
+      _PKG_VERSION_: JSON.stringify(version),
+    },
+    resolve: {
+      alias: {
+        // todo(mm, 2025-10-27): These cross-project aliases cause trouble like
+        // files being processed with the wrong config (the config from the
+        // consuming project vs. the config from the source project).
+        // Can these be replaced with regular package.json dependencies?
+        '@opentrons/shared-data': path.resolve('../shared-data/js/index.ts'),
+        '@opentrons/step-generation': path.resolve(
+          '../step-generation/src/index.ts'
+        ),
+        '@opentrons/discovery-client': path.resolve(
+          '../discovery-client/src/index.ts'
+        ),
+        '@opentrons/usb-bridge/node-client': path.resolve(
+          '../usb-bridge/node-client/src/index.ts'
+        ),
+        '@opentrons/shared-data/labware/fixtures/3': path.resolve(
+          '../shared-data/labware/fixtures/3/index.ts'
+        ),
       },
-      define: {
-        // NOTE: For security, only include environment variables here if they're explicitly allowlisted.
-        global: 'globalThis',
-        _NODE_ENV_: JSON.stringify(process.env.NODE_ENV),
-        _OT_SENTRY_DSN_: JSON.stringify(process.env.OT_SENTRY_DSN),
-        _OPENTRONS_PROJECT_: JSON.stringify(project),
-        _PKG_BUGS_URL_: JSON.stringify(pkg.bugs.url),
-        _PKG_PRODUCT_NAME_: JSON.stringify(pkg.productName),
-        _PKG_VERSION_: JSON.stringify(version),
-      },
-      resolve: {
-        alias: {
-          // todo(mm, 2025-10-27): These cross-project aliases cause trouble like
-          // files being processed with the wrong config (the config from the
-          // consuming project vs. the config from the source project).
-          // Can these be replaced with regular package.json dependencies?
-          '@opentrons/shared-data': path.resolve('../shared-data/js/index.ts'),
-          '@opentrons/step-generation': path.resolve(
-            '../step-generation/src/index.ts'
-          ),
-          '@opentrons/discovery-client': path.resolve(
-            '../discovery-client/src/index.ts'
-          ),
-          '@opentrons/usb-bridge/node-client': path.resolve(
-            '../usb-bridge/node-client/src/index.ts'
-          ),
-          '@opentrons/shared-data/labware/fixtures/3': path.resolve(
-            '../shared-data/labware/fixtures/3/index.ts'
-          ),
-        },
-      },
-    }
+    },
   }
-)
+})

--- a/app/vite.config.mts
+++ b/app/vite.config.mts
@@ -1,6 +1,6 @@
 import path from 'path'
-import react from '@vitejs/plugin-react'
 import { sentryVitePlugin } from '@sentry/vite-plugin'
+import react from '@vitejs/plugin-react'
 import lostCss from 'lost'
 import postCssApply from 'postcss-apply'
 import postColorModFunction from 'postcss-color-mod-function'
@@ -13,107 +13,107 @@ import { cssModuleSideEffect } from './cssModuleSideEffect'
 
 import type { UserConfig } from 'vite'
 
-export default defineConfig(
-  async (): Promise<UserConfig> => {
-    const project = process.env.OPENTRONS_PROJECT ?? 'robot-stack'
-    const version = await versionForProject(project)
-    const mode = process.env.NODE_ENV ?? 'development'
-    const buildTarget = process.env.OT_BUILD_TARGET ?? 'desktop'
+export default defineConfig(async (): Promise<UserConfig> => {
+  const project = process.env.OPENTRONS_PROJECT ?? 'robot-stack'
+  const version = await versionForProject(project)
+  const mode = process.env.NODE_ENV ?? 'development'
+  const buildTarget = process.env.OT_BUILD_TARGET ?? 'desktop'
 
-    return {
-      // this makes imports relative rather than absolute
-      base: '',
-      build: {
-        // Relative to the root
-        outDir: 'dist',
-        sourcemap: true,
-      },
-      plugins: [
-        react({
-          include: '**/*.tsx',
-          babel: {
-            // Use babel.config.js files
-            configFile: true,
-          },
-        }),
-        cssModuleSideEffect(),
-        sentryVitePlugin({
-          org: 'opentrons-sw',
-          project: buildTarget === 'desktop' ? 'app' : 'odd',
-          authToken: process.env.OT_SENTRY_AUTH_TOKEN,
-          telemetry: false,
-          reactComponentAnnotation: {
-            enabled: true,
-            ignoredComponents: [], // (kk:08/15/2025) ToDo add later
-          },
-          sourcemaps: {
-            assets: ['./dist/**'],
-            ignore: ['./node_modules/**'],
-            filesToDeleteAfterUpload:
-              mode === 'production' ? ['./dist/**/*.js.map'] : undefined,
-          },
-        }),
-      ],
-      optimizeDeps: {
-        esbuildOptions: {
-          target: 'es2020',
+  return {
+    // this makes imports relative rather than absolute
+    base: '',
+    build: {
+      // Relative to the root
+      outDir: 'dist',
+      sourcemap: true,
+    },
+    plugins: [
+      react({
+        include: '**/*.tsx',
+        babel: {
+          // Use babel.config.js files
+          configFile: true,
         },
-      },
-      css: {
-        postcss: {
-          plugins: [
-            postCssImport({ root: 'src/' }),
-            postCssApply(),
-            postColorModFunction(),
-            postCssPresetEnv({ stage: 0 }),
-            lostCss(),
-          ],
+      }),
+      cssModuleSideEffect(),
+      sentryVitePlugin({
+        org: 'opentrons-sw',
+        project: buildTarget === 'desktop' ? 'app' : 'odd',
+        authToken: process.env.OT_SENTRY_AUTH_TOKEN,
+        telemetry: false,
+        reactComponentAnnotation: {
+          enabled: true,
+          ignoredComponents: [], // (kk:08/15/2025) ToDo add later
         },
-      },
-      define: {
-        // NOTE: For security, only include environment variables here if they're explicitly allowlisted.
-        global: 'globalThis',
-        _PKG_VERSION_: JSON.stringify(version),
-        _OPENTRONS_PROJECT_: JSON.stringify(project),
-        _OT_SENTRY_DSN_: JSON.stringify(process.env.OT_SENTRY_DSN),
-        _NODE_ENV_: JSON.stringify(process.env.NODE_ENV),
-        _OT_APP_MIXPANEL_ID_: JSON.stringify(process.env.OT_APP_MIXPANEL_ID),
-        // _OT_LL_ variables because app/ imports files directly from labware-library/,
-        // causing them to be processed in the context of this Vite config instead of
-        // labware-library's Vite config.
-        _OT_LL_MIXPANEL_DEV_ID_: JSON.stringify(process.env.OT_LL_MIXPANEL_DEV_ID),
-        _OT_LL_MIXPANEL_ID_: JSON.stringify(process.env.OT_LL_MIXPANEL_ID),
-        'process.env.NODE_DEBUG': JSON.stringify(process.env.NODE_DEBUG),
-      },
-      resolve: {
-        alias: {
-          // todo(mm, 2025-10-27): These cross-project aliases cause trouble like
-          // files being processed with the wrong config (the config from the
-          // consuming project vs. the config from the source project).
-          // Can these be replaced with regular package.json dependencies?
-          '@opentrons/components/styles/global': path.resolve(
-            '../components/src/styles/global.css'
-          ),
-          '@opentrons/components/styles': path.resolve(
-            '../components/src/index.module.css'
-          ),
-          '@opentrons/components': path.resolve('../components/src/index.ts'),
-          '@opentrons/shared-data': path.resolve('../shared-data/js/index.ts'),
-          '@opentrons/step-generation': path.resolve(
-            '../step-generation/src/index.ts'
-          ),
-          '@opentrons/labware-library': path.resolve(
-            '../labware-library/src/labware-creator'
-          ),
-          '@opentrons/api-client': path.resolve('../api-client/src/index.ts'),
-          '@opentrons/react-api-client': path.resolve(
-            '../react-api-client/src/index.ts'
-          ),
-          // "The resulting path (...) trailing slashes are removed unless the path is resolved to the root directory."
-          // https://nodejs.org/api/path.html#pathresolvepaths
-          '/app/': path.resolve('./src/') + '/',
+        sourcemaps: {
+          assets: ['./dist/**'],
+          ignore: ['./node_modules/**'],
+          filesToDeleteAfterUpload:
+            mode === 'production' ? ['./dist/**/*.js.map'] : undefined,
         },
+      }),
+    ],
+    optimizeDeps: {
+      esbuildOptions: {
+        target: 'es2020',
       },
-    }
+    },
+    css: {
+      postcss: {
+        plugins: [
+          postCssImport({ root: 'src/' }),
+          postCssApply(),
+          postColorModFunction(),
+          postCssPresetEnv({ stage: 0 }),
+          lostCss(),
+        ],
+      },
+    },
+    define: {
+      // NOTE: For security, only include environment variables here if they're explicitly allowlisted.
+      global: 'globalThis',
+      _PKG_VERSION_: JSON.stringify(version),
+      _OPENTRONS_PROJECT_: JSON.stringify(project),
+      _OT_SENTRY_DSN_: JSON.stringify(process.env.OT_SENTRY_DSN),
+      _NODE_ENV_: JSON.stringify(process.env.NODE_ENV),
+      _OT_APP_MIXPANEL_ID_: JSON.stringify(process.env.OT_APP_MIXPANEL_ID),
+      // _OT_LL_ variables because app/ imports files directly from labware-library/,
+      // causing them to be processed in the context of this Vite config instead of
+      // labware-library's Vite config.
+      _OT_LL_MIXPANEL_DEV_ID_: JSON.stringify(
+        process.env.OT_LL_MIXPANEL_DEV_ID
+      ),
+      _OT_LL_MIXPANEL_ID_: JSON.stringify(process.env.OT_LL_MIXPANEL_ID),
+      'process.env.NODE_DEBUG': JSON.stringify(process.env.NODE_DEBUG),
+    },
+    resolve: {
+      alias: {
+        // todo(mm, 2025-10-27): These cross-project aliases cause trouble like
+        // files being processed with the wrong config (the config from the
+        // consuming project vs. the config from the source project).
+        // Can these be replaced with regular package.json dependencies?
+        '@opentrons/components/styles/global': path.resolve(
+          '../components/src/styles/global.css'
+        ),
+        '@opentrons/components/styles': path.resolve(
+          '../components/src/index.module.css'
+        ),
+        '@opentrons/components': path.resolve('../components/src/index.ts'),
+        '@opentrons/shared-data': path.resolve('../shared-data/js/index.ts'),
+        '@opentrons/step-generation': path.resolve(
+          '../step-generation/src/index.ts'
+        ),
+        '@opentrons/labware-library': path.resolve(
+          '../labware-library/src/labware-creator'
+        ),
+        '@opentrons/api-client': path.resolve('../api-client/src/index.ts'),
+        '@opentrons/react-api-client': path.resolve(
+          '../react-api-client/src/index.ts'
+        ),
+        // "The resulting path (...) trailing slashes are removed unless the path is resolved to the root directory."
+        // https://nodejs.org/api/path.html#pathresolvepaths
+        '/app/': path.resolve('./src/') + '/',
+      },
+    },
   }
-)
+})

--- a/components-testing/vite.config.mts
+++ b/components-testing/vite.config.mts
@@ -28,7 +28,15 @@ export default defineConfig({
     dedupe: ['react', 'react-dom'],
   },
   optimizeDeps: {
-    include: ['@opentrons/components', '@opentrons/shared-data', 'react', 'react-dom', 'react-query', 'react-redux', 'redux'],
+    include: [
+      '@opentrons/components',
+      '@opentrons/shared-data',
+      'react',
+      'react-dom',
+      'react-query',
+      'react-redux',
+      'redux',
+    ],
     exclude: ['@opentrons/labware-library'],
     entries: ['./src/main.tsx'],
     force: true,

--- a/components/vite.config.mts
+++ b/components/vite.config.mts
@@ -14,7 +14,7 @@ export default defineConfig({
     lib: {
       entry: 'src/index.ts',
       formats: ['es', 'cjs'],
-      fileName: (format) => `index.${format === 'es' ? 'mjs' : 'js'}`,
+      fileName: format => `index.${format === 'es' ? 'mjs' : 'js'}`,
     },
     outDir: 'lib',
     // Do not delete the outdir, typescript types might live there and we don't want to delete them
@@ -32,17 +32,19 @@ export default defineConfig({
         'react',
         'react-dom',
         'react/jsx-runtime',
-        'react-dom/client'
+        'react-dom/client',
       ],
       output: {
-  // Ensure CSS is bundled and exported with stable names for consumers
+        // Ensure CSS is bundled and exported with stable names for consumers
         assetFileNames: assetInfo => {
           const assetNames = assetInfo.names ?? []
           const representativeName = assetNames[0] ?? ''
 
-          return representativeName.endsWith('.css') ? 'style.css' : '[name].[ext]'
-        }
-      }
+          return representativeName.endsWith('.css')
+            ? 'style.css'
+            : '[name].[ext]'
+        },
+      },
     },
   },
   plugins: [

--- a/discovery-client/vite.config.mts
+++ b/discovery-client/vite.config.mts
@@ -1,83 +1,83 @@
-import { versionForProject } from '../scripts/git-version.mjs'
-import pkg from './package.json'
 import path from 'path'
-import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
-import postCssImport from 'postcss-import'
+import lostCss from 'lost'
 import postCssApply from 'postcss-apply'
 import postColorModFunction from 'postcss-color-mod-function'
+import postCssImport from 'postcss-import'
 import postCssPresetEnv from 'postcss-preset-env'
-import lostCss from 'lost'
+import { defineConfig } from 'vite'
+
+import { versionForProject } from '../scripts/git-version.mjs'
+import pkg from './package.json'
+
 import type { UserConfig } from 'vite'
 
-export default defineConfig(
-  async (): Promise<UserConfig> => {
-    const project = process.env.OPENTRONS_PROJECT ?? 'robot-stack'
-    const version = await versionForProject(project)
-    return {
-      publicDir: false,
-      build: {
-        // Relative to the root
-        ssr: 'src/index.ts',
-        outDir: 'lib',
-        commonjsOptions: {
-          transformMixedEsModules: true,
-          esmExternals: true,
+export default defineConfig(async (): Promise<UserConfig> => {
+  const project = process.env.OPENTRONS_PROJECT ?? 'robot-stack'
+  const version = await versionForProject(project)
+  return {
+    publicDir: false,
+    build: {
+      // Relative to the root
+      ssr: 'src/index.ts',
+      outDir: 'lib',
+      commonjsOptions: {
+        transformMixedEsModules: true,
+        esmExternals: true,
+      },
+    },
+    plugins: [
+      react({
+        include: '**/*.tsx',
+        babel: {
+          // Use babel.config.js files
+          configFile: true,
         },
+      }),
+    ],
+    optimizeDeps: {
+      esbuildOptions: {
+        target: 'CommonJs',
       },
-      plugins: [
-        react({
-          include: '**/*.tsx',
-          babel: {
-            // Use babel.config.js files
-            configFile: true,
-          },
-        }),
-      ],
-      optimizeDeps: {
-        esbuildOptions: {
-          target: 'CommonJs',
-        },
+    },
+    css: {
+      postcss: {
+        plugins: [
+          postCssImport({ root: 'src/' }),
+          postCssApply(),
+          postColorModFunction(),
+          postCssPresetEnv({ stage: 0 }),
+          lostCss(),
+        ],
       },
-      css: {
-        postcss: {
-          plugins: [
-            postCssImport({ root: 'src/' }),
-            postCssApply(),
-            postColorModFunction(),
-            postCssPresetEnv({ stage: 0 }),
-            lostCss(),
-          ],
-        },
+    },
+    define: {
+      // NOTE: For security, only include environment variables here if they're explicitly allowlisted.
+      _PKG_VERSION_: JSON.stringify(version),
+      _PKG_BUGS_URL_: JSON.stringify(pkg.bugs.url),
+      _OPENTRONS_PROJECT_: JSON.stringify(project),
+    },
+    resolve: {
+      alias: {
+        // todo(mm, 2025-10-27): These cross-project aliases cause trouble like
+        // files being processed with the wrong config (the config from the
+        // consuming project vs. the config from the source project).
+        // Can these be replaced with regular package.json dependencies?
+        '@opentrons/components/styles': path.resolve(
+          '../components/src/index.module.css'
+        ),
+        '@opentrons/components': path.resolve('../components/src/index.ts'),
+        '@opentrons/shared-data': path.resolve('../shared-data/js/index.ts'),
+        '@opentrons/step-generation': path.resolve(
+          '../step-generation/src/index.ts'
+        ),
+        '@opentrons/discovery-client': path.resolve(
+          '../discovery-client/src/index.ts'
+        ),
+        '@opentrons/usb-bridge/node-client': path.resolve(
+          '../usb-bridge/node-client/src/index.ts'
+        ),
       },
-      define: {
-        // NOTE: For security, only include environment variables here if they're explicitly allowlisted.
-        _PKG_VERSION_: JSON.stringify(version),
-        _PKG_BUGS_URL_: JSON.stringify(pkg.bugs.url),
-        _OPENTRONS_PROJECT_: JSON.stringify(project),
-      },
-      resolve: {
-        alias: {
-          // todo(mm, 2025-10-27): These cross-project aliases cause trouble like
-          // files being processed with the wrong config (the config from the
-          // consuming project vs. the config from the source project).
-          // Can these be replaced with regular package.json dependencies?
-          '@opentrons/components/styles': path.resolve(
-            '../components/src/index.module.css'
-          ),
-          '@opentrons/components': path.resolve('../components/src/index.ts'),
-          '@opentrons/shared-data': path.resolve('../shared-data/js/index.ts'),
-          '@opentrons/step-generation': path.resolve(
-            '../step-generation/src/index.ts'
-          ),
-          '@opentrons/discovery-client': path.resolve(
-            '../discovery-client/src/index.ts'
-          ),
-          '@opentrons/usb-bridge/node-client': path.resolve(
-            '../usb-bridge/node-client/src/index.ts'
-          ),
-        },
-      },
-    }
+    },
   }
-)
+})

--- a/labware-designer/vite.config.mts
+++ b/labware-designer/vite.config.mts
@@ -1,11 +1,11 @@
 import path from 'path'
-import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
-import postCssImport from 'postcss-import'
+import lostCss from 'lost'
 import postCssApply from 'postcss-apply'
 import postColorModFunction from 'postcss-color-mod-function'
+import postCssImport from 'postcss-import'
 import postCssPresetEnv from 'postcss-preset-env'
-import lostCss from 'lost'
+import { defineConfig } from 'vite'
 
 export default defineConfig({
   build: {
@@ -48,10 +48,14 @@ export default defineConfig({
       // files being processed with the wrong config (the config from the
       // consuming project vs. the config from the source project).
       // Can these be replaced with regular package.json dependencies?
-      '@opentrons/components/styles': path.resolve('../components/src/index.module.css'),
+      '@opentrons/components/styles': path.resolve(
+        '../components/src/index.module.css'
+      ),
       '@opentrons/components': path.resolve('../components/src/index.ts'),
       '@opentrons/shared-data': path.resolve('../shared-data/js/index.ts'),
-      '@opentrons/step-generation': path.resolve('../step-generation/src/index.ts'),
+      '@opentrons/step-generation': path.resolve(
+        '../step-generation/src/index.ts'
+      ),
     },
   },
 })

--- a/labware-library/vite.config.mts
+++ b/labware-library/vite.config.mts
@@ -1,15 +1,16 @@
 import fs from 'node:fs'
 import path from 'path'
 import { fileURLToPath } from 'url'
-import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
-import postCssImport from 'postcss-import'
+import lostCss from 'lost'
 import postCssApply from 'postcss-apply'
 import postColorModFunction from 'postcss-color-mod-function'
+import postCssImport from 'postcss-import'
 import postCssPresetEnv from 'postcss-preset-env'
-import lostCss from 'lost'
-import { cssModuleSideEffect } from './cssModuleSideEffect'
+import { defineConfig } from 'vite'
+
 import createGitVersionToolkit from '../scripts/git-version-v2.mjs'
+import { cssModuleSideEffect } from './cssModuleSideEffect'
 
 const { generateBuildInfoHtml } = createGitVersionToolkit({
   project: 'labware-library',

--- a/opentrons-ai-client/vite.config.mts
+++ b/opentrons-ai-client/vite.config.mts
@@ -44,7 +44,9 @@ export default defineConfig({
   },
   define: {
     // NOTE: For security, only include environment variables here if they're explicitly allowlisted.
-    _OT_AI_CLIENT_MIXPANEL_ID_: JSON.stringify(process.env.OT_AI_CLIENT_MIXPANEL_ID),
+    _OT_AI_CLIENT_MIXPANEL_ID_: JSON.stringify(
+      process.env.OT_AI_CLIENT_MIXPANEL_ID
+    ),
     _NODE_ENV_: JSON.stringify(process.env.NODE_ENV),
     global: 'globalThis',
   },

--- a/protocol-designer/vite.config.mts
+++ b/protocol-designer/vite.config.mts
@@ -17,15 +17,15 @@ import type { UserConfig } from 'vite'
 
 const REQUIRED_APP_VERSION = '8.8.0' // PD requires this robot stack version or higher
 const { getVersion, generateBuildInfoHtml } = createGitVersionToolkit({
-    project: 'protocol-designer',
+  project: 'protocol-designer',
 })
 
 const isCI = process.env.CI === 'true'
 
 const hasSentryCreds =
-    !!process.env.SENTRY_AUTH_TOKEN &&
-    !!process.env.SENTRY_ORG &&
-    !!process.env.SENTRY_PROJECT
+  !!process.env.SENTRY_AUTH_TOKEN &&
+  !!process.env.SENTRY_ORG &&
+  !!process.env.SENTRY_PROJECT
 
 // Local opt-in only: devs can enable the plugin by exporting SENTRY_* env vars.
 // When enabled locally, the plugin will upload sourcemaps under the `local-dev`
@@ -36,171 +36,173 @@ const enableSentryLocalPlugin = !isCI && hasSentryCreds
 
 // eslint-disable-next-line import/no-default-export
 export default defineConfig(async (): Promise<UserConfig> => {
-    const OT_PD_VERSION = await getVersion()
-    const OT_PD_BUILD_DATE = new Date().toUTCString()
-    const OT_PD_LATEST_LABWARE_VERSIONS =
-        await latestLabwareVersions(REQUIRED_APP_VERSION)
+  const OT_PD_VERSION = await getVersion()
+  const OT_PD_BUILD_DATE = new Date().toUTCString()
+  const OT_PD_LATEST_LABWARE_VERSIONS =
+    await latestLabwareVersions(REQUIRED_APP_VERSION)
 
-    return {
-        // this makes imports relative rather than absolute
-        base: '',
-        build: {
-            // Relative to the root
-            outDir: 'dist',
-            // Not hidden: emit normal sourcemaps so devtools + Sentry can auto-detect.
-            // Emit in CI (so action-release can upload) and in local builds.
-            sourcemap: true,
-            rollupOptions: {
-                external: ['react/compiler-runtime'],
-                output: {
-                    // Manually split out vendor chunks
-                    manualChunks(id) {
-                        if (id.includes('node_modules')) {
-                            return 'vendor'
-                        }
-                    },
-                },
-            },
+  return {
+    // this makes imports relative rather than absolute
+    base: '',
+    build: {
+      // Relative to the root
+      outDir: 'dist',
+      // Not hidden: emit normal sourcemaps so devtools + Sentry can auto-detect.
+      // Emit in CI (so action-release can upload) and in local builds.
+      sourcemap: true,
+      rollupOptions: {
+        external: ['react/compiler-runtime'],
+        output: {
+          // Manually split out vendor chunks
+          manualChunks(id) {
+            if (id.includes('node_modules')) {
+              return 'vendor'
+            }
+          },
         },
-        plugins: [
-            react({
-                include: '**/*.tsx',
-                babel: {
-                    // Use babel.config.js files 1Code has comments. Press enter to view.
-                    configFile: true,
-                },
-                jsxRuntime: 'automatic',
+      },
+    },
+    plugins: [
+      react({
+        include: '**/*.tsx',
+        babel: {
+          // Use babel.config.js files 1Code has comments. Press enter to view.
+          configFile: true,
+        },
+        jsxRuntime: 'automatic',
+      }),
+      cssModuleSideEffect(),
+      {
+        name: 'markdown-loader',
+        transform(code, id) {
+          if (id.endsWith('.md')) {
+            return `export default ${JSON.stringify(code)}`
+          }
+        },
+      },
+
+      ...(enableSentryLocalPlugin
+        ? [
+            sentryVitePlugin({
+              org: process.env.SENTRY_ORG,
+              project: process.env.SENTRY_PROJECT,
+              authToken: process.env.SENTRY_AUTH_TOKEN,
+              telemetry: false,
+              reactComponentAnnotation: { enabled: true },
+
+              // Local opt-in behavior:
+              // - Upload sourcemaps via the plugin (requires SENTRY_* env vars)
+              // - Use the `local-dev` release name
+              // CI continues to upload via getsentry/action-release.
+              release: {
+                name: 'local-dev',
+                inject: false,
+              },
             }),
-            cssModuleSideEffect(),
-            {
-                name: 'markdown-loader',
-                transform(code, id) {
-                    if (id.endsWith('.md')) {
-                        return `export default ${JSON.stringify(code)}`
-                    }
-                },
-            },
+          ]
+        : []),
 
-            ...(enableSentryLocalPlugin
-                ? [
-                    sentryVitePlugin({
-                        org: process.env.SENTRY_ORG,
-                        project: process.env.SENTRY_PROJECT,
-                        authToken: process.env.SENTRY_AUTH_TOKEN,
-                        telemetry: false,
-                        reactComponentAnnotation: { enabled: true },
-
-                        // Local opt-in behavior:
-                        // - Upload sourcemaps via the plugin (requires SENTRY_* env vars)
-                        // - Use the `local-dev` release name
-                        // CI continues to upload via getsentry/action-release.
-                        release: {
-                            name: 'local-dev',
-                            inject: false,
-                        },
-                    }),
-                ]
-                : []),
-
-            {
-                name: 'build-info-generator',
-                closeBundle: async () => {
-                    const outputPath = path.resolve(
-                        __dirname,
-                        'dist',
-                        'info',
-                        'index.html'
-                    )
-                    await generateBuildInfoHtml(outputPath)
-                },
-            },
-            ...(process.env.ANALYZE_DEBUG === 'true' ? [analyzer()] : []),
+      {
+        name: 'build-info-generator',
+        closeBundle: async () => {
+          const outputPath = path.resolve(
+            __dirname,
+            'dist',
+            'info',
+            'index.html'
+          )
+          await generateBuildInfoHtml(outputPath)
+        },
+      },
+      ...(process.env.ANALYZE_DEBUG === 'true' ? [analyzer()] : []),
+    ],
+    optimizeDeps: {
+      esbuildOptions: {
+        target: 'es2020',
+      },
+      // For unknown reasons, PD whitescreens on launch unless we have this.
+      include: ['tslib'],
+    },
+    css: {
+      postcss: {
+        plugins: [
+          postCssImport({ root: 'src/' }),
+          postCssApply(),
+          postColorModFunction(),
+          postCssPresetEnv({ stage: 0 }),
+          lostCss(),
         ],
-        optimizeDeps: {
-            esbuildOptions: {
-                target: 'es2020',
-            },
-            // For unknown reasons, PD whitescreens on launch unless we have this.
-            include: ['tslib'],
-        },
-        css: {
-            postcss: {
-                plugins: [
-                    postCssImport({ root: 'src/' }),
-                    postCssApply(),
-                    postColorModFunction(),
-                    postCssPresetEnv({ stage: 0 }),
-                    lostCss(),
-                ],
-            },
-        },
-        define: {
-            // NOTE: For security, only include environment variables here if they're explicitly allowlisted.
-            _FF_ENV_VARS_: getFeatureFlagEnvVars(),
-            _NODE_ENV_: JSON.stringify(process.env.NODE_ENV),
-            _OT_PD_BUILD_DATE_: JSON.stringify(OT_PD_BUILD_DATE),
-            _OT_PD_LATEST_LABWARE_VERSIONS_: OT_PD_LATEST_LABWARE_VERSIONS,
-            _OT_PD_MIXPANEL_DEV_ID_: JSON.stringify(process.env.OT_PD_MIXPANEL_DEV_ID),
-            _OT_PD_MIXPANEL_ID_: JSON.stringify(process.env.OT_PD_MIXPANEL_ID),
-            _OT_PD_REQUIRED_APP_VERSION_: JSON.stringify(REQUIRED_APP_VERSION),
-            _OT_PD_SENTRY_RELEASE_: JSON.stringify(
-                enableSentryLocalPlugin ? 'local-dev' : OT_PD_VERSION
-            ),
-            _OT_PD_SENTRY_DEV_DSN_: JSON.stringify(process.env.OT_PD_SENTRY_DEV_DSN),
-            _OT_PD_SENTRY_DSN_: JSON.stringify(process.env.OT_PD_SENTRY_DSN),
-            _OT_PD_VERSION_: JSON.stringify(OT_PD_VERSION),
-            'process.env.NODE_DEBUG': JSON.stringify(process.env.NODE_DEBUG),
-            global: 'globalThis',
-        },
-        resolve: {
-            conditions: ['browser'],
-            // For unknown reasons, PD whitescreens on launch unless we have this.
-            dedupe: ['tslib'],
-            alias: {
-                // todo(mm, 2025-10-27): These cross-project aliases cause trouble like
-                // files being processed with the wrong config (the config from the
-                // consuming project vs. the config from the source project).
-                // Can these be replaced with regular package.json dependencies?
-                '@opentrons/components/styles/global': path.resolve(
-                    '../components/src/styles/global.css'
-                ),
-                '@opentrons/components': path.resolve('../components/src/index.ts'),
-                '@opentrons/shared-data': path.resolve('../shared-data/js/index.ts'),
-                '@opentrons/step-generation': path.resolve(
-                    '../step-generation/src/index.ts'
-                ),
-                '/protocol-designer/': path.resolve('./src/') + '/',
-            },
-        },
-        server: {
-            port: 5178,
-        },
-    }
+      },
+    },
+    define: {
+      // NOTE: For security, only include environment variables here if they're explicitly allowlisted.
+      _FF_ENV_VARS_: getFeatureFlagEnvVars(),
+      _NODE_ENV_: JSON.stringify(process.env.NODE_ENV),
+      _OT_PD_BUILD_DATE_: JSON.stringify(OT_PD_BUILD_DATE),
+      _OT_PD_LATEST_LABWARE_VERSIONS_: OT_PD_LATEST_LABWARE_VERSIONS,
+      _OT_PD_MIXPANEL_DEV_ID_: JSON.stringify(
+        process.env.OT_PD_MIXPANEL_DEV_ID
+      ),
+      _OT_PD_MIXPANEL_ID_: JSON.stringify(process.env.OT_PD_MIXPANEL_ID),
+      _OT_PD_REQUIRED_APP_VERSION_: JSON.stringify(REQUIRED_APP_VERSION),
+      _OT_PD_SENTRY_RELEASE_: JSON.stringify(
+        enableSentryLocalPlugin ? 'local-dev' : OT_PD_VERSION
+      ),
+      _OT_PD_SENTRY_DEV_DSN_: JSON.stringify(process.env.OT_PD_SENTRY_DEV_DSN),
+      _OT_PD_SENTRY_DSN_: JSON.stringify(process.env.OT_PD_SENTRY_DSN),
+      _OT_PD_VERSION_: JSON.stringify(OT_PD_VERSION),
+      'process.env.NODE_DEBUG': JSON.stringify(process.env.NODE_DEBUG),
+      global: 'globalThis',
+    },
+    resolve: {
+      conditions: ['browser'],
+      // For unknown reasons, PD whitescreens on launch unless we have this.
+      dedupe: ['tslib'],
+      alias: {
+        // todo(mm, 2025-10-27): These cross-project aliases cause trouble like
+        // files being processed with the wrong config (the config from the
+        // consuming project vs. the config from the source project).
+        // Can these be replaced with regular package.json dependencies?
+        '@opentrons/components/styles/global': path.resolve(
+          '../components/src/styles/global.css'
+        ),
+        '@opentrons/components': path.resolve('../components/src/index.ts'),
+        '@opentrons/shared-data': path.resolve('../shared-data/js/index.ts'),
+        '@opentrons/step-generation': path.resolve(
+          '../step-generation/src/index.ts'
+        ),
+        '/protocol-designer/': path.resolve('./src/') + '/',
+      },
+    },
+    server: {
+      port: 5178,
+    },
+  }
 })
 
 function getFeatureFlagEnvVars(): Record<string, string | undefined> {
-    // If we change the prefix to something like "OT_PD_FF_...", we could automatically
-    // scrape process.env instead of having this explicit list. We don't want to scrape
-    // process.env as long as the prefix is just "OT_PD_..." because it might accidentally
-    // include something like "OT_PD_SUPER_SECRET_DEPLOY_KEY".
-    const envVarNames = new Set([
-        'OT_PD_PRERELEASE_MODE',
-        'OT_PD_DISABLE_MODULE_RESTRICTIONS',
-        'OT_PD_ALLOW_ALL_TIPRACKS',
-        'OT_PD_ENABLE_COMMENT',
-        'OT_PD_ENABLE_TIP_PICKUP_LOCATION',
-        'OT_PD_ENABLE_HOT_KEYS_DISPLAY',
-        'OT_PD_ENABLE_REACT_SCAN',
-        'OT_PD_ENABLE_MULTIPLE_TEMPS_OT',
-        'OT_PD_ENABLE_TIMELINE_SCRUBBER',
-        'OT_PD_ENABLE_PARTIAL_TIP_SUPPORT',
-        'OT_PD_ENABLE_STACKING',
-        'OT_PD_ENABLE_CONCURRENT_MODULE_ACTIONS',
-        'OT_PD_ENABLE_BY_VOLUME_BUILDER',
-        'OT_PD_ENABLE_TIP_SELCTION',
-        'OT_PD_ENABLE_CAMERA_SUPPORT',
-    ])
-    return Object.fromEntries(
-        Object.entries(process.env).filter(([key, _value]) => envVarNames.has(key))
-    )
+  // If we change the prefix to something like "OT_PD_FF_...", we could automatically
+  // scrape process.env instead of having this explicit list. We don't want to scrape
+  // process.env as long as the prefix is just "OT_PD_..." because it might accidentally
+  // include something like "OT_PD_SUPER_SECRET_DEPLOY_KEY".
+  const envVarNames = new Set([
+    'OT_PD_PRERELEASE_MODE',
+    'OT_PD_DISABLE_MODULE_RESTRICTIONS',
+    'OT_PD_ALLOW_ALL_TIPRACKS',
+    'OT_PD_ENABLE_COMMENT',
+    'OT_PD_ENABLE_TIP_PICKUP_LOCATION',
+    'OT_PD_ENABLE_HOT_KEYS_DISPLAY',
+    'OT_PD_ENABLE_REACT_SCAN',
+    'OT_PD_ENABLE_MULTIPLE_TEMPS_OT',
+    'OT_PD_ENABLE_TIMELINE_SCRUBBER',
+    'OT_PD_ENABLE_PARTIAL_TIP_SUPPORT',
+    'OT_PD_ENABLE_STACKING',
+    'OT_PD_ENABLE_CONCURRENT_MODULE_ACTIONS',
+    'OT_PD_ENABLE_BY_VOLUME_BUILDER',
+    'OT_PD_ENABLE_TIP_SELCTION',
+    'OT_PD_ENABLE_CAMERA_SUPPORT',
+  ])
+  return Object.fromEntries(
+    Object.entries(process.env).filter(([key, _value]) => envVarNames.has(key))
+  )
 }

--- a/scripts/eslint-plugin-opentrons/eslint.config.mjs
+++ b/scripts/eslint-plugin-opentrons/eslint.config.mjs
@@ -1,9 +1,9 @@
-import pluginJs from "@eslint/js";
-import pluginNode from "eslint-plugin-n";
-import eslintPlugin from "eslint-plugin-eslint-plugin";
+import pluginJs from '@eslint/js'
+import eslintPlugin from 'eslint-plugin-eslint-plugin'
+import pluginNode from 'eslint-plugin-n'
 
 export default [
-    pluginJs.configs.recommended,
-    ...pluginNode.configs["flat/mixed-esm-and-cjs"],
-    eslintPlugin.configs["flat/recommended"]
-];
+  pluginJs.configs.recommended,
+  ...pluginNode.configs['flat/mixed-esm-and-cjs'],
+  eslintPlugin.configs['flat/recommended'],
+]

--- a/scripts/git-version-v2.mjs
+++ b/scripts/git-version-v2.mjs
@@ -2,8 +2,8 @@
 
 import { dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import git from 'simple-git'
 import semver from 'semver'
+import git from 'simple-git'
 
 const REPO_BASE = dirname(dirname(fileURLToPath(import.meta.url)))
 
@@ -20,7 +20,9 @@ function defaultTagPrefixes(project) {
 }
 
 function normalizeTagPrefixes(project, tagPrefixes) {
-  const prefixes = tagPrefixes?.length ? tagPrefixes : defaultTagPrefixes(project)
+  const prefixes = tagPrefixes?.length
+    ? tagPrefixes
+    : defaultTagPrefixes(project)
   const unique = [...new Set(prefixes.filter(Boolean))]
 
   if (unique.length === 0) {
@@ -40,10 +42,7 @@ function parseTagWithPrefixes(tag, prefixes) {
 }
 
 export function createGitVersionToolkit(options) {
-  const {
-    project,
-    tagPrefixes,
-  } = options ?? {}
+  const { project, tagPrefixes } = options ?? {}
 
   if (!project) {
     throw new Error('project is required')
@@ -86,7 +85,8 @@ export function createGitVersionToolkit(options) {
       }
 
       if (branch === 'HEAD') {
-        let ciBranch = process.env.GITHUB_HEAD_REF || process.env.GITHUB_REF_NAME
+        let ciBranch =
+          process.env.GITHUB_HEAD_REF || process.env.GITHUB_REF_NAME
 
         if (
           ciBranch === process.env.GITHUB_REF_NAME &&
@@ -262,9 +262,12 @@ export function createGitVersionToolkit(options) {
       environment: process.env.GITHUB_ENV || 'N/A',
       serverUrl,
       apiUrl: process.env.GITHUB_API_URL || 'https://api.github.com',
-      graphqlUrl: process.env.GITHUB_GRAPHQL_URL || 'https://api.github.com/graphql',
+      graphqlUrl:
+        process.env.GITHUB_GRAPHQL_URL || 'https://api.github.com/graphql',
       runUrl:
-        runId && repository ? `${serverUrl}/${repository}/actions/runs/${runId}` : null,
+        runId && repository
+          ? `${serverUrl}/${repository}/actions/runs/${runId}`
+          : null,
       compareUrl:
         headRef && baseRef && repository
           ? `${serverUrl}/${repository}/compare/${baseRef}...${headRef}`
@@ -500,12 +503,15 @@ export function createGitVersionToolkit(options) {
             
             <div class="section">
                 <h2>🌿 Git Information</h2>
-                ${gitInfo.error ? `
+                ${
+                  gitInfo.error
+                    ? `
                     <div class="info-item">
                         <div class="info-label">Error</div>
                         <div class="info-value">${gitInfo.error}</div>
                     </div>
-                ` : `
+                `
+                    : `
                     <div class="info-grid">
                         <div class="info-item">
                             <div class="info-label">Branch</div>
@@ -538,55 +544,78 @@ export function createGitVersionToolkit(options) {
                         <div class="info-label">Commit Message</div>
                         <div class="commit-message">${gitInfo.commitMessage}</div>
                     </div>
-                `}
+                `
+                }
             </div>
             
-            ${isCI ? `
+            ${
+              isCI
+                ? `
             <div class="section">
                 <h2>🚀 GitHub Actions Information</h2>
                 
                 <h3 style="color: #764ba2; font-size: 1.1rem; margin-bottom: 1rem; margin-top: 1.5rem;">🔗 Quick Links</h3>
                 <div class="info-grid">
-                    ${githubInfo.runUrl ? `
+                    ${
+                      githubInfo.runUrl
+                        ? `
                     <div class="info-item">
                         <div class="info-label">Workflow Run</div>
                         <div class="info-value">
                             <a href="${githubInfo.runUrl}" target="_blank">View Run #${githubInfo.runNumber}</a>
                         </div>
                     </div>
-                    ` : ''}
-                    ${githubInfo.prUrl ? `
+                    `
+                        : ''
+                    }
+                    ${
+                      githubInfo.prUrl
+                        ? `
                     <div class="info-item">
                         <div class="info-label">Pull Request</div>
                         <div class="info-value">
                             <a href="${githubInfo.prUrl}" target="_blank">View PR</a>
                         </div>
                     </div>
-                    ` : ''}
-                    ${githubInfo.compareUrl ? `
+                    `
+                        : ''
+                    }
+                    ${
+                      githubInfo.compareUrl
+                        ? `
                     <div class="info-item">
                         <div class="info-label">Compare Changes</div>
                         <div class="info-value">
                             <a href="${githubInfo.compareUrl}" target="_blank">${githubInfo.baseRef}...${githubInfo.headRef}</a>
                         </div>
                     </div>
-                    ` : ''}
-                    ${githubInfo.branchUrl ? `
+                    `
+                        : ''
+                    }
+                    ${
+                      githubInfo.branchUrl
+                        ? `
                     <div class="info-item">
                         <div class="info-label">Branch</div>
                         <div class="info-value">
                             <a href="${githubInfo.branchUrl}" target="_blank">${githubInfo.refName}</a>
                         </div>
                     </div>
-                    ` : ''}
-                    ${githubInfo.tagUrl ? `
+                    `
+                        : ''
+                    }
+                    ${
+                      githubInfo.tagUrl
+                        ? `
                     <div class="info-item">
                         <div class="info-label">Tag</div>
                         <div class="info-value">
                             <a href="${githubInfo.tagUrl}" target="_blank">${githubInfo.refName}</a>
                         </div>
                     </div>
-                    ` : ''}
+                    `
+                        : ''
+                    }
                 </div>
                 
                 <h3 style="color: #764ba2; font-size: 1.1rem; margin-bottom: 1rem; margin-top: 1.5rem;">📊 Run Details</h3>
@@ -634,9 +663,11 @@ export function createGitVersionToolkit(options) {
                     <div class="info-item">
                         <div class="info-label">Actor</div>
                         <div class="info-value">
-                            ${githubInfo.actor !== 'N/A'
-                ? `<a href="${githubInfo.serverUrl}/${githubInfo.actor}" target="_blank">${githubInfo.actor}</a>`
-                : 'N/A'}
+                            ${
+                              githubInfo.actor !== 'N/A'
+                                ? `<a href="${githubInfo.serverUrl}/${githubInfo.actor}" target="_blank">${githubInfo.actor}</a>`
+                                : 'N/A'
+                            }
                         </div>
                     </div>
                     <div class="info-item">
@@ -646,9 +677,11 @@ export function createGitVersionToolkit(options) {
                     <div class="info-item">
                         <div class="info-label">Triggering Actor</div>
                         <div class="info-value">
-                            ${githubInfo.triggeringActor !== 'N/A'
-                ? `<a href="${githubInfo.serverUrl}/${githubInfo.triggeringActor}" target="_blank">${githubInfo.triggeringActor}</a>`
-                : 'N/A'}
+                            ${
+                              githubInfo.triggeringActor !== 'N/A'
+                                ? `<a href="${githubInfo.serverUrl}/${githubInfo.triggeringActor}" target="_blank">${githubInfo.triggeringActor}</a>`
+                                : 'N/A'
+                            }
                         </div>
                     </div>
                 </div>
@@ -671,19 +704,27 @@ export function createGitVersionToolkit(options) {
                         <div class="info-label">Ref Protected</div>
                         <div class="info-value">${githubInfo.refProtected}</div>
                     </div>
-                    ${githubInfo.headRef !== 'N/A' ? `
+                    ${
+                      githubInfo.headRef !== 'N/A'
+                        ? `
                     <div class="info-item">
                         <div class="info-label">Head Ref (PR)</div>
                         <div class="info-value">${githubInfo.headRef}</div>
                     </div>
-                    ` : ''}
-                    ${githubInfo.baseRef !== 'N/A' ? `
+                    `
+                        : ''
+                    }
+                    ${
+                      githubInfo.baseRef !== 'N/A'
+                        ? `
                     <div class="info-item">
                         <div class="info-label">Base Ref (PR)
                         </div>
                         <div class="info-value">${githubInfo.baseRef}</div>
                     </div>
-                    ` : ''}
+                    `
+                        : ''
+                    }
                 </div>
                 
                 <h3 style="color: #764ba2; font-size: 1.1rem; margin-bottom: 1rem; margin-top: 1.5rem;">🏢 Repository Information</h3>
@@ -691,9 +732,11 @@ export function createGitVersionToolkit(options) {
                     <div class="info-item">
                         <div class="info-label">Repository</div>
                         <div class="info-value">
-                            ${githubInfo.repository !== 'N/A'
-                ? `<a href="${githubInfo.serverUrl}/${githubInfo.repository}" target="_blank">${githubInfo.repository}</a>`
-                : 'N/A'}
+                            ${
+                              githubInfo.repository !== 'N/A'
+                                ? `<a href="${githubInfo.serverUrl}/${githubInfo.repository}" target="_blank">${githubInfo.repository}</a>`
+                                : 'N/A'
+                            }
                         </div>
                     </div>
                     <div class="info-item">
@@ -704,9 +747,11 @@ export function createGitVersionToolkit(options) {
                     <div class="info-item">
                         <div class="info-label">Repository Owner</div>
                         <div class="info-value">
-                            ${githubInfo.repositoryOwner !== 'N/A'
-                ? `<a href="${githubInfo.serverUrl}/${githubInfo.repositoryOwner}" target="_blank">${githubInfo.repositoryOwner}</a>`
-                : 'N/A'}
+                            ${
+                              githubInfo.repositoryOwner !== 'N/A'
+                                ? `<a href="${githubInfo.serverUrl}/${githubInfo.repositoryOwner}" target="_blank">${githubInfo.repositoryOwner}</a>`
+                                : 'N/A'
+                            }
                         </div>
                     </div>
                     <div class="info-item">
@@ -716,7 +761,9 @@ export function createGitVersionToolkit(options) {
                 </div>
                 
             </div>
-            ` : ''}
+            `
+                : ''
+            }
         </div>
         
         <div class="footer">


### PR DESCRIPTION
.mts and .mjs were both not in the format file list and present in eslintignore, for some reason. Let's see what happens if we don't do that, and automatically format them since they're also code.

This is a format-only PR; there are no code changes.

Note: this is stacked on top of #20442 for better diffing and no conflicts, but will only get merged into edge once that PR is in
