### PR TITLE
chore(app,components): move design token from app to components

### DIFF
--- a/components/src/DesignTokens/BorderRadius/BorderRadius.stories.tsx
+++ b/components/src/DesignTokens/BorderRadius/BorderRadius.stories.tsx
@@ -1,14 +1,8 @@
-import {
-  ALIGN_FLEX_START,
-  BORDERS,
-  Box,
-  COLORS,
-  DIRECTION_COLUMN,
-  Flex,
-  LegacyStyledText,
-  SPACING,
-  TYPOGRAPHY,
-} from '@opentrons/components'
+import { StyledText } from '../../atoms/StyledText'
+import { BORDERS, COLORS } from '../../helix-design-system'
+import { Box, Flex } from '../../primitives'
+import { ALIGN_FLEX_START, DIRECTION_COLUMN } from '../../styles'
+import { SPACING, TYPOGRAPHY } from '../../ui-style-constants'
 
 import type { Meta, Story } from '@storybook/react'
 
@@ -45,9 +39,9 @@ const Template: Story<BorderRadiusStorybookProps> = args => {
           width="100%"
           height="6rem"
         >
-          <LegacyStyledText as="h2" fontWeight={TYPOGRAPHY.fontWeightRegular}>
+          <StyledText as="h2" fontWeight={TYPOGRAPHY.fontWeightRegular}>
             {`${br[0]}" ${br[1]}`}
-          </LegacyStyledText>
+          </StyledText>
           <Box
             width="10rem"
             height="4rem"

--- a/components/src/DesignTokens/Colors/Colors.stories.tsx
+++ b/components/src/DesignTokens/Colors/Colors.stories.tsx
@@ -1,16 +1,14 @@
+import { StyledText } from '../../atoms/StyledText'
+import { BORDERS, COLORS } from '../../helix-design-system'
+import { Flex } from '../../primitives'
 import {
   ALIGN_FLEX_START,
-  BORDERS,
-  COLORS,
   CURSOR_POINTER,
   DIRECTION_COLUMN,
   DIRECTION_ROW,
-  Flex,
   JUSTIFY_SPACE_BETWEEN,
-  LegacyStyledText,
-  SPACING,
-  TYPOGRAPHY,
-} from '@opentrons/components'
+} from '../../styles'
+import { SPACING, TYPOGRAPHY } from '../../ui-style-constants'
 
 import type { Meta, Story } from '@storybook/react'
 
@@ -78,20 +76,20 @@ const Template: Story<ColorsStorybookProps> = args => {
                 border: `1px solid ${COLORS.grey20}`,
               }}
             >
-              <LegacyStyledText
+              <StyledText
                 color={invertColor(color[1] as string)}
                 fontSize={TYPOGRAPHY.fontSizeP}
                 fontWeight={TYPOGRAPHY.fontWeightBold}
               >
                 {color[0]}
-              </LegacyStyledText>
-              <LegacyStyledText
+              </StyledText>
+              <StyledText
                 fontSize={TYPOGRAPHY.fontSizeP}
                 color={invertColor(color[1] as string)}
                 fontWeight={TYPOGRAPHY.fontWeightRegular}
               >
                 {color[1]}
-              </LegacyStyledText>
+              </StyledText>
             </Flex>
           ))}
         </Flex>

--- a/components/src/DesignTokens/Spacing/Spacing.stories.tsx
+++ b/components/src/DesignTokens/Spacing/Spacing.stories.tsx
@@ -2,15 +2,11 @@
 import React from 'react'
 import styled from 'styled-components'
 
-import {
-  ALIGN_FLEX_START,
-  Box,
-  COLORS,
-  DIRECTION_COLUMN,
-  Flex,
-  SPACING,
-  StyledText,
-} from '@opentrons/components'
+import { StyledText } from '../../atoms/StyledText'
+import { COLORS } from '../../helix-design-system'
+import { Box, Flex } from '../../primitives'
+import { ALIGN_FLEX_START, DIRECTION_COLUMN } from '../../styles'
+import { SPACING } from '../../ui-style-constants'
 
 import type { Meta, Story } from '@storybook/react'
 

--- a/components/src/DesignTokens/Typography/Typography.stories.tsx
+++ b/components/src/DesignTokens/Typography/Typography.stories.tsx
@@ -1,15 +1,9 @@
 import { css } from 'styled-components'
 
-import {
-  ALIGN_CENTER,
-  Box,
-  DIRECTION_COLUMN,
-  Flex,
-  PRODUCT,
-  SPACING,
-  Text,
-  TYPOGRAPHY,
-} from '@opentrons/components'
+import { PRODUCT } from '../../helix-design-system'
+import { Box, Flex, Text } from '../../primitives'
+import { ALIGN_CENTER, DIRECTION_COLUMN } from '../../styles'
+import { SPACING, TYPOGRAPHY } from '../../ui-style-constants'
 
 import type { Meta, Story } from '@storybook/react'
 import type { FlattenSimpleInterpolation } from 'styled-components'


### PR DESCRIPTION


# Overview
move design token from app to components

<img width="749" height="415" alt="Screenshot 2025-12-23 at 5 02 05 PM" src="https://github.com/user-attachments/assets/d1ea88dd-3306-4e97-97ac-175e06311879" />

close RUXD-2306

## Test Plan and Hands on Testing
make -C components dev

design token shows up in Storybook


## Changelog
- move DesignToken folder from `app` to `components` and modify paths

## Review requests


## Risk assessment
low
