### PR TITLE
fix(protocol-designer): getMatchingTipLiquidSpecs() don't crash if tiprackDef is null

### DIFF
--- a/protocol-designer/src/utils/index.ts
+++ b/protocol-designer/src/utils/index.ts
@@ -195,11 +195,10 @@ export function getMatchingTipLiquidSpecs(
 ): SupportedTip {
   const tipLength = tiprackDef?.parameters?.tipLength ?? 0
 
-  if (tipLength === 0) {
-    console.error(
-      `expected to find a tiplength for tiprack ${getLabwareDefURI(tiprackDef)} but could not`
-    )
-  }
+  console.assert(
+    tipLength,
+    `expected to find a tiplength for tiprack ${tiprackDef && getLabwareDefURI(tiprackDef)} but could not`
+  )
 
   const isLowVolumePipette = Object.keys(pipetteSpecs.liquids).some(
     key => key === 'lowVolumeDefault'

--- a/shared-data/js/helpers/getLabwareDefURI.ts
+++ b/shared-data/js/helpers/getLabwareDefURI.ts
@@ -3,7 +3,7 @@ import type { LabwareDefinition } from '../types'
 export const getLabwareDefURI = (def: LabwareDefinition): string =>
   constructLabwareDefURI(
     def.namespace,
-    def.parameters.loadName,
+    def.parameters?.loadName, // custom labware might be missing parameters?
     String(def.version)
   )
 


### PR DESCRIPTION
# Overview

In `getMatchingTipLiquidSpecs()`, we were crashing while trying to compose the error message ... lol
- https://opentrons-76.sentry.io/issues/7121591722?project=4509363266387968
- https://opentrons-76.sentry.io/issues/7121591914?project=4509363266387968
- https://opentrons-76.sentry.io/issues/7121591656?project=4509363266387968

I think the crash could be happening for 2 reasons: either `tiprackDef` is null, or it could be one of those nasty custom tip racks whose definition doesn't have a `.parameters` (which has bitten us before).

This change will make us stop crashing and get a bit better diagnostic information.

## Test Plan and Hands on Testing

Run CI tests.

## Risk assessment

Low.