### PR TITLE
fix(protocol-designer): stop recording Sentry breadcrumbs for Mixpanel

### DIFF
--- a/protocol-designer/src/resources/sentry.ts
+++ b/protocol-designer/src/resources/sentry.ts
@@ -72,6 +72,18 @@ export const initializeSentry = (state: BaseState): void => {
           // https://github.com/getsentry/sentry-javascript/issues/3440
           'Non-Error promise rejection captured with value: Object Not Found Matching Id:',
         ],
+        beforeBreadcrumb(breadcrumb, hint) {
+          if (
+            // Sentry records breadcrumbs for HTTP requests we issue, but the Mixpanel
+            // request is huge and not useful:
+            breadcrumb.data?.url?.includes('/api.mixpanel.com/track') ||
+            // We console.debug() every time we send an event to Mixpanel, ignore it too:
+            (breadcrumb.category === 'console' && breadcrumb.level === 'debug')
+          ) {
+            return null
+          }
+          return breadcrumb
+        },
       })
       isSentryInitialized = true
       console.log('Sentry.init done')


### PR DESCRIPTION
# Overview

Sentry records "breadcrumbs" leading up to an event. The breadcrumbs include things like the HTTP requests we made before PD crashed. But because we're using Mixpanel integration, our breadcrumbs are full of XHR requests to Mixpanel, which are noisy and unhelpful.

The Mixpanel requests are also huge, which could bloat up the Sentry event and make it too big: see https://github.com/getsentry/sentry-javascript/issues/874

This PR filters out the breadcrumbs from Mixpanel requests.

## Test Plan and Hands on Testing

Try it?

## Risk assessment

Low.