### PR TITLE
feat(api): add flow rate to blow out

### DIFF
--- a/api/src/opentrons/legacy_commands/commands.py
+++ b/api/src/opentrons/legacy_commands/commands.py
@@ -262,10 +262,10 @@ def dynamic_mix(
 
 
 def blow_out(
-    instrument: InstrumentContext, location: Location
+    instrument: InstrumentContext, location: Location, flow_rate: float
 ) -> command_types.BlowOutCommand:
     location_text = stringify_location(location)
-    text = f"Blowing out at {location_text}"
+    text = f"Blowing out into {location_text} at flow rate {flow_rate}"
 
     return {
         "name": command_types.BLOW_OUT,
@@ -274,10 +274,12 @@ def blow_out(
 
 
 def blow_out_in_disposal_location(
-    instrument: InstrumentContext, location: Union[TrashBin, WasteChute]
+    instrument: InstrumentContext,
+    location: Union[TrashBin, WasteChute],
+    flow_rate: float,
 ) -> command_types.BlowOutInDisposalLocationCommand:
     location_text = stringify_disposal_location(location)
-    text = f"Blowing out into {location_text}"
+    text = f"Blowing out into {location_text} at flow rate {flow_rate}"
 
     return {
         "name": command_types.BLOW_OUT_IN_DISPOSAL_LOCATION,

--- a/api/src/opentrons/legacy_commands/commands.py
+++ b/api/src/opentrons/legacy_commands/commands.py
@@ -265,7 +265,7 @@ def blow_out(
     instrument: InstrumentContext, location: Location, flow_rate: float
 ) -> command_types.BlowOutCommand:
     location_text = stringify_location(location)
-    text = f"Blowing out into {location_text} at flow rate {flow_rate}"
+    text = f"Blowing out into {location_text} at {flow_rate} uL/sec"
 
     return {
         "name": command_types.BLOW_OUT,
@@ -279,7 +279,7 @@ def blow_out_in_disposal_location(
     flow_rate: float,
 ) -> command_types.BlowOutInDisposalLocationCommand:
     location_text = stringify_disposal_location(location)
-    text = f"Blowing out into {location_text} at flow rate {flow_rate}"
+    text = f"Blowing out into {location_text} at {flow_rate} uL/sec"
 
     return {
         "name": command_types.BLOW_OUT_IN_DISPOSAL_LOCATION,

--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -455,6 +455,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         location: Union[Location, TrashBin, WasteChute],
         well_core: Optional[WellCore],
         in_place: bool,
+        flow_rate: float,
     ) -> None:
         """Blow liquid out of the tip.
 
@@ -463,7 +464,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             well_core: The well to blow out into.
             in_place: whether this is a in-place command.
         """
-        flow_rate = self.get_blow_out_flow_rate(1.0)
+        # flow_rate = self.get_blow_out_flow_rate(1.0)
         if well_core is None:
             if not in_place:
                 if isinstance(location, (TrashBin, WasteChute)):

--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -462,9 +462,9 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
         Args:
             location: The location to blow out into.
             well_core: The well to blow out into.
-            in_place: whether this is a in-place command.
+            in_place: Whether this is an in-place command.
+            flow_rate: The absolute flow rate in µL/s.
         """
-        # flow_rate = self.get_blow_out_flow_rate(1.0)
         if well_core is None:
             if not in_place:
                 if isinstance(location, (TrashBin, WasteChute)):

--- a/api/src/opentrons/protocol_api/core/engine/transfer_components_executor.py
+++ b/api/src/opentrons/protocol_api/core/engine/transfer_components_executor.py
@@ -531,11 +531,11 @@ class TransferComponentsExecutor:
             and blowout_props.location == BlowoutLocation.DESTINATION
         ):
             assert blowout_props.flow_rate is not None
-            self._instrument.set_flow_rate(blow_out=blowout_props.flow_rate)
             self._instrument.blow_out(
                 location=retract_location,
                 well_core=None,
                 in_place=True,
+                flow_rate=blowout_props.flow_rate,
             )
             self._tip_state.ready_to_aspirate = False
         is_final_air_gap = (
@@ -563,7 +563,6 @@ class TransferComponentsExecutor:
             and blowout_props.location != BlowoutLocation.DESTINATION
         ):
             assert blowout_props.flow_rate is not None
-            self._instrument.set_flow_rate(blow_out=blowout_props.flow_rate)
             blowout_touch_tip_props = retract_props.touch_tip
             touch_tip_and_air_gap_location: Union[Location, TrashBin, WasteChute]
             if blowout_props.location == BlowoutLocation.SOURCE:
@@ -578,6 +577,7 @@ class TransferComponentsExecutor:
                     ),
                     well_core=source_well,
                     in_place=False,
+                    flow_rate=blowout_props.flow_rate,
                 )
                 touch_tip_and_air_gap_location = Location(
                     source_well.get_top(0), labware=source_location.labware
@@ -595,6 +595,7 @@ class TransferComponentsExecutor:
                     location=trash_location,
                     well_core=None,
                     in_place=False,
+                    flow_rate=blowout_props.flow_rate,
                 )
                 touch_tip_and_air_gap_location = trash_location
                 touch_tip_and_air_gap_well = (
@@ -693,11 +694,11 @@ class TransferComponentsExecutor:
             and blowout_props.location == BlowoutLocation.DESTINATION
         ):
             assert blowout_props.flow_rate is not None
-            self._instrument.set_flow_rate(blow_out=blowout_props.flow_rate)
             self._instrument.blow_out(
                 location=retract_location,
                 well_core=None,
                 in_place=True,
+                flow_rate=blowout_props.flow_rate,
             )
             # A blowout will remove all air gap and liquid (disposal volume) from the tip
             # so delete them from tip state (although practically, there will not be
@@ -763,7 +764,6 @@ class TransferComponentsExecutor:
             and blowout_props.location != BlowoutLocation.DESTINATION
         ):
             assert blowout_props.flow_rate is not None
-            self._instrument.set_flow_rate(blow_out=blowout_props.flow_rate)
             blowout_touch_tip_props = retract_props.touch_tip
             touch_tip_and_air_gap_location: Union[Location, TrashBin, WasteChute]
             if blowout_props.location == BlowoutLocation.SOURCE:
@@ -778,6 +778,7 @@ class TransferComponentsExecutor:
                     ),
                     well_core=source_well,
                     in_place=False,
+                    flow_rate=blowout_props.flow_rate,
                 )
                 touch_tip_and_air_gap_location = Location(
                     source_well.get_top(0), labware=source_location.labware
@@ -795,6 +796,7 @@ class TransferComponentsExecutor:
                     location=trash_location,
                     well_core=None,
                     in_place=False,
+                    flow_rate=blowout_props.flow_rate,
                 )
                 touch_tip_and_air_gap_location = trash_location
                 touch_tip_and_air_gap_well = (

--- a/api/src/opentrons/protocol_api/core/instrument.py
+++ b/api/src/opentrons/protocol_api/core/instrument.py
@@ -102,6 +102,7 @@ class AbstractInstrument(ABC, Generic[WellCoreType, LabwareCoreType]):
         location: Union[types.Location, TrashBin, WasteChute],
         well_core: Optional[WellCoreType],
         in_place: bool,
+        flow_rate: float,
     ) -> None:
         """Blow liquid out of the tip.
 
@@ -109,6 +110,7 @@ class AbstractInstrument(ABC, Generic[WellCoreType, LabwareCoreType]):
             location: The location to blow out into.
             well_core: The well to blow out into.
             in_place: Whether this is in-place.
+            flow_rate: The absolute flow rate in µL/s.
         """
         ...
 

--- a/api/src/opentrons/protocol_api/core/legacy/legacy_instrument_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy/legacy_instrument_core.py
@@ -175,6 +175,7 @@ class LegacyInstrumentCore(AbstractInstrument[LegacyWellCore, LegacyLabwareCore]
         location: Union[types.Location, TrashBin, WasteChute],
         well_core: Optional[LegacyWellCore],
         in_place: bool,
+        flow_rate: float,
     ) -> None:
         """Blow liquid out of the tip.
 
@@ -182,6 +183,7 @@ class LegacyInstrumentCore(AbstractInstrument[LegacyWellCore, LegacyLabwareCore]
             location: The location to blow out into.
             well_core: Unused by legacy core.
             in_place: Whether we should move_to location.
+            flow_rate: Not used in this core.
         """
         if isinstance(location, (TrashBin, WasteChute)):
             raise APIVersionError(

--- a/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_instrument_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_instrument_core.py
@@ -171,6 +171,7 @@ class LegacyInstrumentCoreSimulator(
         location: Union[types.Location, TrashBin, WasteChute],
         well_core: Optional[LegacyWellCore],
         in_place: bool,
+        flow_rate: float,
     ) -> None:
         if isinstance(location, (TrashBin, WasteChute)):
             raise APIVersionError(

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1030,11 +1030,12 @@ class InstrumentContext(publisher.CommandPublisher):
         return self
 
     @requires_version(2, 0)
-    def blow_out(
+    def blow_out(  # noqa: C901
         self,
         location: Optional[
             Union[types.Location, labware.Well, TrashBin, WasteChute]
         ] = None,
+        flow_rate: Optional[float] = None,
     ) -> InstrumentContext:
         """
         Blow an extra amount of air through a pipette's tip to clear it.
@@ -1056,12 +1057,27 @@ class InstrumentContext(publisher.CommandPublisher):
                               ``None``. This should happen if ``blow_out()`` is called
                               without first calling a method that takes a location, like
                               :py:meth:`.aspirate` or :py:meth:`dispense`.
+        :param flow_rate: The absolute flow rate in µL/s.
+        :type flow_rate: float
+
         :returns: This instance.
 
         .. versionchanged:: 2.24
             ``location`` is no longer required if the pipette just moved to, dispensed, or blew out
             into a trash bin or waste chute.
+        .. versionchanged:: 2.28
+            Added ``flow_rate`` argument.
         """
+        if flow_rate is not None:
+            if self.api_version < APIVersion(2, 28):
+                raise APIVersionError(
+                    api_element="flow_rate",
+                    until_version="2.28",
+                    current_version=f"{self.api_version}",
+                )
+        else:
+            flow_rate = self._core.get_blow_out_flow_rate(1.0)
+
         well: Optional[labware.Well] = None
         move_to_location: types.Location
 
@@ -1105,24 +1121,28 @@ class InstrumentContext(publisher.CommandPublisher):
             with publisher.publish_context(
                 broker=self.broker,
                 command=cmds.blow_out_in_disposal_location(
-                    instrument=self, location=target.location
+                    instrument=self, location=target.location, flow_rate=flow_rate
                 ),
             ):
                 self._core.blow_out(
                     location=target.location,
                     well_core=None,
                     in_place=target.in_place,
+                    flow_rate=flow_rate,
                 )
             return self
 
         with publisher.publish_context(
             broker=self.broker,
-            command=cmds.blow_out(instrument=self, location=move_to_location),
+            command=cmds.blow_out(
+                instrument=self, location=move_to_location, flow_rate=flow_rate
+            ),
         ):
             self._core.blow_out(
                 location=move_to_location,
                 well_core=well._core if well is not None else None,
                 in_place=target.in_place,
+                flow_rate=flow_rate,
             )
 
         return self

--- a/api/tests/opentrons/protocol_api/core/engine/test_instrument_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_instrument_core.py
@@ -932,7 +932,9 @@ def test_blow_out_to_well(
         (WellLocation(origin=WellOrigin.TOP, offset=WellOffset(x=3, y=2, z=1)), False)
     )
 
-    subject.blow_out(location=location, well_core=well_core, in_place=False)
+    subject.blow_out(
+        location=location, well_core=well_core, in_place=False, flow_rate=123
+    )
 
     decoy.verify(
         pipette_movement_conflict.check_safe_for_pipette_movement(
@@ -952,7 +954,7 @@ def test_blow_out_to_well(
                 wellLocation=WellLocation(
                     origin=WellOrigin.TOP, offset=WellOffset(x=3, y=2, z=1)
                 ),
-                flowRate=6.7,
+                flowRate=123,
             )
         ),
         mock_protocol_core.set_last_location(location=location, mount=Mount.LEFT),
@@ -968,7 +970,7 @@ def test_blow_to_coordinates(
     """It should move to coordinate and blow out in place."""
     location = Location(point=Point(1, 2, 3), labware=None)
 
-    subject.blow_out(location=location, well_core=None, in_place=False)
+    subject.blow_out(location=location, well_core=None, in_place=False, flow_rate=123)
 
     decoy.verify(
         mock_engine_client.execute_command(
@@ -983,7 +985,7 @@ def test_blow_to_coordinates(
         mock_engine_client.execute_command(
             cmd.BlowOutInPlaceParams(
                 pipetteId="abc123",
-                flowRate=6.7,
+                flowRate=123,
             )
         ),
         mock_protocol_core.set_last_location(location=location, mount=Mount.LEFT),
@@ -1002,13 +1004,14 @@ def test_blow_out_in_place(
         location=location,
         well_core=None,
         in_place=True,
+        flow_rate=123,
     )
 
     decoy.verify(
         mock_engine_client.execute_command(
             cmd.BlowOutInPlaceParams(
                 pipetteId="abc123",
-                flowRate=6.7,
+                flowRate=123,
             )
         ),
     )
@@ -1031,6 +1034,7 @@ def test_blow_out_to_trash_bin(
         location=mock_trash,
         well_core=None,
         in_place=False,
+        flow_rate=111,
     )
 
     decoy.verify(
@@ -1049,7 +1053,7 @@ def test_blow_out_to_trash_bin(
         mock_engine_client.execute_command(
             cmd.BlowOutInPlaceParams(
                 pipetteId="abc123",
-                flowRate=6.7,
+                flowRate=111,
             )
         ),
         mock_protocol_core.set_last_location(location=mock_trash, mount=Mount.LEFT),

--- a/api/tests/opentrons/protocol_api/core/engine/test_transfer_components_executor.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_transfer_components_executor.py
@@ -1203,11 +1203,11 @@ def test_retract_after_dispense_with_blowout_in_source(
             correction_volume=air_gap_correction_by_vol,
         ),
         mock_instrument_core.delay(0.2),
-        mock_instrument_core.set_flow_rate(blow_out=100),
         mock_instrument_core.blow_out(
             location=Location(Point(10, 20, 30), labware=None),
             well_core=source_well,
             in_place=False,
+            flow_rate=100,
         ),
         mock_instrument_core.touch_tip(
             location=Location(Point(10, 20, 30), labware=None),
@@ -1313,11 +1313,11 @@ def test_retract_after_dispense_with_blowout_in_destination(
             speed=50,
         ),
         mock_instrument_core.delay(10),
-        mock_instrument_core.set_flow_rate(blow_out=100),
         mock_instrument_core.blow_out(
             location=Location(Point(12, 24, 36), labware=None),
             well_core=None,
             in_place=True,
+            flow_rate=100,
         ),
         mock_instrument_core.touch_tip(
             location=Location(Point(12, 24, 36), labware=None),
@@ -1441,11 +1441,11 @@ def test_retract_after_dispense_with_blowout_in_trash_well(
             correction_volume=air_gap_correction_by_vol,
         ),
         mock_instrument_core.delay(0.2),
-        mock_instrument_core.set_flow_rate(blow_out=100),
         mock_instrument_core.blow_out(
             location=trash_location,
             well_core=None,
             in_place=False,
+            flow_rate=100,
         ),
         mock_instrument_core.touch_tip(
             location=trash_location,
@@ -1565,11 +1565,11 @@ def test_retract_after_dispense_with_blowout_in_disposal_location(
             correction_volume=air_gap_correction_by_vol,
         ),
         mock_instrument_core.delay(0.2),
-        mock_instrument_core.set_flow_rate(blow_out=100),
         mock_instrument_core.blow_out(
             location=trash_location,
             well_core=None,
             in_place=False,
+            flow_rate=100,
         ),
         *(
             add_final_air_gap
@@ -1648,11 +1648,11 @@ def test_retract_after_dispense_in_trash_with_blowout_in_source(
             correction_volume=air_gap_correction_by_vol,
         ),
         mock_instrument_core.delay(0.2),
-        mock_instrument_core.set_flow_rate(blow_out=100),
         mock_instrument_core.blow_out(
             location=Location(Point(10, 20, 30), labware=None),
             well_core=source_well,
             in_place=False,
+            flow_rate=100,
         ),
         mock_instrument_core.touch_tip(
             location=Location(Point(10, 20, 30), labware=None),
@@ -1743,11 +1743,11 @@ def test_retract_after_dispense_in_trash_with_blowout_in_destination(
     )
     decoy.verify(
         mock_instrument_core.delay(10),
-        mock_instrument_core.set_flow_rate(blow_out=100),
         mock_instrument_core.blow_out(
             location=target_trash,
             well_core=None,
             in_place=True,
+            flow_rate=100,
         ),
         *(
             add_final_air_gap
@@ -1827,11 +1827,11 @@ def test_retract_after_dispense_in_trash_with_blowout_in_disposal_location(
             correction_volume=air_gap_correction_by_vol,
         ),
         mock_instrument_core.delay(0.2),
-        mock_instrument_core.set_flow_rate(blow_out=100),
         mock_instrument_core.blow_out(
             location=trash_location,
             well_core=None,
             in_place=False,
+            flow_rate=100,
         ),
         *(
             add_final_air_gap
@@ -2078,11 +2078,11 @@ def test_retract_after_dispense_with_blowout_in_src_moves_to_safe_loc_for_air_ga
             correction_volume=air_gap_correction_by_vol,
         ),
         mock_instrument_core.delay(0.2),
-        mock_instrument_core.set_flow_rate(blow_out=100),
         mock_instrument_core.blow_out(
             location=Location(Point(10, 20, 30), labware=None),
             well_core=source_well,
             in_place=False,
+            flow_rate=100,
         ),
         mock_instrument_core.touch_tip(
             location=Location(Point(10, 20, 30), labware=None),
@@ -2326,17 +2326,11 @@ def test_multi_dispense_retract_after_dispense_with_blowout_without_conditioning
         *(
             expect_blowout
             and [
-                mock_instrument_core.set_flow_rate(blow_out=10)  # type: ignore[func-returns-value]
-            ]
-            or []
-        ),
-        *(
-            expect_blowout
-            and [
                 mock_instrument_core.blow_out(  # type: ignore[func-returns-value]
                     location=Location(Point(3, 5, 4), labware=None),
                     well_core=None,
                     in_place=True,
+                    flow_rate=10,
                 )
             ]
             or []

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -723,16 +723,18 @@ def test_blow_out_to_well(
     top_location = Location(point=Point(1, 2, 3), labware=mock_well)
     last_location = Location(point=Point(9, 9, 9), labware=None)
     decoy.when(mock_instrument_core.get_mount()).then_return(Mount.RIGHT)
-
     decoy.when(mock_protocol_core.get_last_location(Mount.RIGHT)).then_return(
         last_location
     )
     decoy.when(mock_well.top()).then_return(top_location)
-    subject.blow_out(location=mock_well)
+    subject.blow_out(location=mock_well, flow_rate=123)
 
     decoy.verify(
         mock_instrument_core.blow_out(
-            location=top_location, well_core=mock_well._core, in_place=False
+            location=top_location,
+            well_core=mock_well._core,
+            in_place=False,
+            flow_rate=123,
         ),
         times=1,
     )
@@ -749,15 +751,17 @@ def test_blow_out_to_well_location(
     input_location = Location(point=Point(2, 2, 2), labware=mock_well)
     last_location = Location(point=Point(9, 9, 9), labware=None)
     decoy.when(mock_instrument_core.get_mount()).then_return(Mount.RIGHT)
-
     decoy.when(mock_protocol_core.get_last_location(Mount.RIGHT)).then_return(
         last_location
     )
-    subject.blow_out(location=input_location)
+    subject.blow_out(location=input_location, flow_rate=123)
 
     decoy.verify(
         mock_instrument_core.blow_out(
-            location=input_location, well_core=mock_well._core, in_place=False
+            location=input_location,
+            well_core=mock_well._core,
+            in_place=False,
+            flow_rate=123,
         ),
         times=1,
     )
@@ -793,14 +797,16 @@ def test_blow_out_to_well_meniscus_location(
     )
     last_location = Location(point=Point(9, 9, 9), labware=None)
     decoy.when(mock_instrument_core.get_mount()).then_return(Mount.RIGHT)
-
     decoy.when(mock_protocol_core.get_last_location(Mount.RIGHT)).then_return(
         last_location
     )
-    subject.blow_out(location=input_location)
+    subject.blow_out(location=input_location, flow_rate=123)
 
     mock_instrument_core.blow_out(
-        location=input_location_absolute, well_core=mock_well._core, in_place=False
+        location=input_location_absolute,
+        well_core=mock_well._core,
+        in_place=False,
+        flow_rate=123,
     )
 
 
@@ -814,16 +820,15 @@ def test_blow_out_to_location(
     input_location = Location(point=Point(2, 2, 2), labware=None)
     last_location = input_location  # to demonstrate how we set in_place=True
     decoy.when(mock_instrument_core.get_mount()).then_return(Mount.RIGHT)
-
     decoy.when(mock_protocol_core.get_last_location(Mount.RIGHT)).then_return(
         last_location
     )
 
-    subject.blow_out(location=input_location)
+    subject.blow_out(location=input_location, flow_rate=123)
 
     decoy.verify(
         mock_instrument_core.blow_out(
-            location=input_location, well_core=None, in_place=True
+            location=input_location, well_core=None, in_place=True, flow_rate=123
         ),
         times=1,
     )
@@ -839,14 +844,44 @@ def test_blow_out_with_trash_last_location(
     """It should blow out into a previously accessed disposal location."""
     mock_chute = decoy.mock(cls=WasteChute)
     decoy.when(mock_instrument_core.get_mount()).then_return(Mount.LEFT)
+    decoy.when(mock_instrument_core.get_blow_out_flow_rate(1.0)).then_return(111)
     decoy.when(mock_protocol_core.get_last_location(mount=Mount.LEFT)).then_return(
         mock_chute
     )
+
     subject.blow_out()
 
     decoy.verify(
         mock_instrument_core.blow_out(
-            location=mock_chute, well_core=None, in_place=True
+            location=mock_chute, well_core=None, in_place=True, flow_rate=111
+        ),
+        times=1,
+    )
+
+
+def test_blow_out_uses_previously_set_flow_rate(
+    decoy: Decoy,
+    mock_instrument_core: InstrumentCore,
+    subject: InstrumentContext,
+    mock_protocol_core: ProtocolCore,
+) -> None:
+    """It should blow out to a well."""
+    mock_well = decoy.mock(cls=Well)
+    top_location = Location(point=Point(1, 2, 3), labware=mock_well)
+    last_location = Location(point=Point(9, 9, 9), labware=None)
+    decoy.when(mock_instrument_core.get_mount()).then_return(Mount.RIGHT)
+    decoy.when(mock_instrument_core.get_blow_out_flow_rate(1.0)).then_return(111)
+    decoy.when(mock_protocol_core.get_last_location(Mount.RIGHT)).then_return(
+        last_location
+    )
+    decoy.when(mock_well.top()).then_return(top_location)
+    subject.blow_out(location=mock_well)
+    decoy.verify(
+        mock_instrument_core.blow_out(
+            location=top_location,
+            well_core=mock_well._core,
+            in_place=False,
+            flow_rate=111,
         ),
         times=1,
     )

--- a/api/tests/opentrons/protocol_api_old/core/simulator/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api_old/core/simulator/test_instrument_context.py
@@ -274,6 +274,7 @@ def _aspirate_blowout(i: InstrumentCore, labware: LabwareCore) -> None:
         location=Location(point=Point(1, 2, 3), labware=None),
         well_core=labware.get_well_core("A1"),
         in_place=True,
+        flow_rate=789,
     )
 
 

--- a/api/tests/opentrons/protocol_runner/smoke_tests/test_legacy_command_mapper.py
+++ b/api/tests/opentrons/protocol_runner/smoke_tests/test_legacy_command_mapper.py
@@ -601,7 +601,7 @@ async def test_big_protocol_commands(big_protocol_file: Path) -> None:
         startedAt=matchers.IsA(datetime),
         completedAt=matchers.IsA(datetime),
         params=LegacyCommandParams(
-            legacyCommandText="Blowing out at (100, 100, 10)",
+            legacyCommandText="Blowing out into (100, 100, 10) at 1000.0 uL/sec",
             legacyCommandType="command.BLOW_OUT",
         ),
         notes=[],

--- a/api/tests/opentrons/test_execute.py
+++ b/api/tests/opentrons/test_execute.py
@@ -200,7 +200,7 @@ def test_execute_function_json_v3(
         "Delaying for 0 minutes and 42.0 seconds",
         "Dispensing 4.5 uL into B1 of Dest Plate on 3 at 2.5 uL/sec",
         "Touching tip",
-        "Blowing out at B1 of Dest Plate on 3",
+        "Blowing out into B1 of Dest Plate on 3 at 2.0 uL/sec",
         "Moving to 5",
         "Dropping tip into A1 of Trash on 12",
     ]
@@ -239,7 +239,7 @@ def test_execute_function_json_v4(
         "Delaying for 0 minutes and 42.0 seconds",
         "Dispensing 4.5 uL into B1 of Dest Plate on 3 at 2.5 uL/sec",
         "Touching tip",
-        "Blowing out at B1 of Dest Plate on 3",
+        "Blowing out into B1 of Dest Plate on 3 at 2.0 uL/sec",
         "Moving to 5",
         "Dropping tip into A1 of Trash on 12",
     ]
@@ -278,7 +278,7 @@ def test_execute_function_json_v5(
         "Delaying for 0 minutes and 42.0 seconds",
         "Dispensing 4.5 uL into B1 of Dest Plate on 3 at 2.5 uL/sec",
         "Touching tip",
-        "Blowing out at B1 of Dest Plate on 3",
+        "Blowing out into B1 of Dest Plate on 3 at 2.0 uL/sec",
         "Moving to 5",
         "Moving to B2 of Dest Plate on 3",
         "Moving to B2 of Dest Plate on 3",

--- a/api/tests/opentrons/test_simulate.py
+++ b/api/tests/opentrons/test_simulate.py
@@ -123,7 +123,7 @@ def test_simulate_function_json(
         "Delaying for 0 minutes and 42.0 seconds",
         "Dispensing 4.5 uL into B1 of Dest Plate on 3 at 2.5 uL/sec",
         "Touching tip",
-        "Blowing out at B1 of Dest Plate on 3",
+        "Blowing out into B1 of Dest Plate on 3 at 2.0 uL/sec",
         "Moving to 5",
         "Dropping tip into A1 of Trash on 12",
     ]


### PR DESCRIPTION
# Overview

Adds optional `flow_rate` arg to `InstrumentContext.blow_out()`. If flow rate is not specified, the function will use the previously set blow out flow rate (this is preserving current behavior).

This arg will be available from API v2.28 onwards.

## Test Plan and Hands on Testing

Added/ updated unit tests

## Changelog

- updated signature for `InstrumentContext.blow_out()`, `AbstractInstrumentCore.blow_out()`
- Updated engine instrument core 

## Review requests

- Am I missing anything related to the recent API flow rate fixes?

## Risk assessment

- Low. Only adds an argument to blow out
