### PR TITLE
refactor(protocol-designer): Refactor line clamp style in Protocol Designer

### DIFF
--- a/protocol-designer/src/components/atoms/constants.ts
+++ b/protocol-designer/src/components/atoms/constants.ts
@@ -6,11 +6,8 @@ import {
   COLORS,
   DIRECTION_COLUMN,
   DISPLAY_FLEX,
-  OVERFLOW_HIDDEN,
   SPACING,
 } from '@opentrons/components'
-
-import type { FlattenSimpleInterpolation } from 'styled-components'
 
 export const LINK_BUTTON_STYLE = css`
   color: ${COLORS.black90};
@@ -28,35 +25,6 @@ export const LINK_BUTTON_STYLE = css`
   &:disabled {
     color: ${COLORS.grey40};
   }
-`
-
-/**
- * Generates a CSS style for clamping text to a specified number of lines,
- * with optional word-breaking behavior.
- *
- * @param {number} lineClamp - The number of lines to clamp the text to.
- * @param {boolean} [wordBase] - Optional flag to determine word-breaking behavior.
- * If true, words will break normally; if false or undefined, words will break at any character.
- *
- * @returns {FlattenSimpleInterpolation} - The generated CSS style.
- *
- * @example
- * const style = LINE_CLAMP_TEXT_STYLE(2, true);
- * // style will clamp text to 2 lines and break words normally
- */
-export const LINE_CLAMP_TEXT_STYLE = (
-  lineClamp: number,
-  wordBase?: boolean
-): FlattenSimpleInterpolation => css`
-  display: -webkit-box;
-  -webkit-box-orient: vertical;
-  overflow: ${OVERFLOW_HIDDEN};
-  text-overflow: ellipsis;
-  word-wrap: break-word;
-  -webkit-line-clamp: ${lineClamp};
-  word-break: ${wordBase === true
-    ? 'normal'
-    : 'break-all'}; // normal for tile and break-all for a non word case like aaaaaaaa
 `
 
 const MIN_OVERVIEW_WIDTH = '64rem'

--- a/protocol-designer/src/components/molecules/DropdownStepFormField/index.tsx
+++ b/protocol-designer/src/components/molecules/DropdownStepFormField/index.tsx
@@ -146,8 +146,8 @@ export function DropdownStepFormField(
                   <StyledText
                     desktopStyle="captionRegular"
                     className={clsx(
-                      lineClampStyles.lineClamp,
-                      lineClampStyles.wordNormal
+                      lineClampStyles.line_clamp,
+                      lineClampStyles.word_normal
                     )}
                     style={{ WebkitLineClamp: 3 }}
                   >

--- a/protocol-designer/src/components/molecules/DropdownStepFormField/index.tsx
+++ b/protocol-designer/src/components/molecules/DropdownStepFormField/index.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useDispatch } from 'react-redux'
+import { clsx } from 'clsx'
 
 import {
   ALIGN_CENTER,
@@ -8,13 +9,13 @@ import {
   DIRECTION_COLUMN,
   DropdownMenu,
   Flex,
-  LINE_CLAMP_TEXT_STYLE,
   ListItem,
   RobotInfoLabel,
   SPACING,
   StyledText,
 } from '@opentrons/components'
 
+import lineClampStyles from '/protocol-designer/styles/lineclamp.module.css'
 import { selectDropdownItem } from '/protocol-designer/ui/steps/actions/actions'
 
 import type { DropdownOption, MenuPlacement } from '@opentrons/components'
@@ -96,8 +97,8 @@ export function DropdownStepFormField(
       {/* NOTE: we should not run into value == null when length === 1, but this
       just some extra error protection so users can't stuck where they can't select a value */}
       {options.length > 1 ||
-      options.length === 0 ||
-      (value == null && options.length === 1) ? (
+        options.length === 0 ||
+        (value == null && options.length === 1) ? (
         <DropdownMenu
           tooltipText={tooltipContent != null ? t(`${tooltipContent}`) : null}
           width={width}
@@ -144,7 +145,11 @@ export function DropdownStepFormField(
                 {options[0].name !== options[0].deckLabel ? (
                   <StyledText
                     desktopStyle="captionRegular"
-                    css={LINE_CLAMP_TEXT_STYLE(3, true)}
+                    className={clsx(
+                      lineClampStyles.lineClamp,
+                      lineClampStyles.wordNormal
+                    )}
+                    style={{ WebkitLineClamp: 3 }}
                   >
                     {options[0].name}
                   </StyledText>

--- a/protocol-designer/src/components/molecules/DropdownStepFormField/index.tsx
+++ b/protocol-designer/src/components/molecules/DropdownStepFormField/index.tsx
@@ -97,8 +97,8 @@ export function DropdownStepFormField(
       {/* NOTE: we should not run into value == null when length === 1, but this
       just some extra error protection so users can't stuck where they can't select a value */}
       {options.length > 1 ||
-        options.length === 0 ||
-        (value == null && options.length === 1) ? (
+      options.length === 0 ||
+      (value == null && options.length === 1) ? (
         <DropdownMenu
           tooltipText={tooltipContent != null ? t(`${tooltipContent}`) : null}
           width={width}

--- a/protocol-designer/src/components/organisms/AssignLiquidsModal/LiquidCard.tsx
+++ b/protocol-designer/src/components/organisms/AssignLiquidsModal/LiquidCard.tsx
@@ -192,24 +192,24 @@ export function LiquidCard({ info }: LiquidCardProps): JSX.Element {
             <Divider borderColor={COLORS.grey40} />
             {info.liquidIndex != null
               ? fullWellsByLiquid[info.liquidIndex]
-                .sort((a, b) =>
-                  orderedWells.indexOf(b) > orderedWells.indexOf(a) ? -1 : 1
-                )
-                .map((wellName, wellliquidIndex) => {
-                  const volume =
-                    wellContents != null
-                      ? wellContents[wellName].ingreds[liquidIndex].volume
-                      : 0
-                  return (
-                    <>
-                      <WellContents wellName={wellName} volume={volume} />
-                      {wellliquidIndex <
-                        fullWellsByLiquid[liquidIndex].length - 1 ? (
-                        <Divider borderColor={COLORS.grey40} />
-                      ) : null}
-                    </>
+                  .sort((a, b) =>
+                    orderedWells.indexOf(b) > orderedWells.indexOf(a) ? -1 : 1
                   )
-                })
+                  .map((wellName, wellliquidIndex) => {
+                    const volume =
+                      wellContents != null
+                        ? wellContents[wellName].ingreds[liquidIndex].volume
+                        : 0
+                    return (
+                      <>
+                        <WellContents wellName={wellName} volume={volume} />
+                        {wellliquidIndex <
+                        fullWellsByLiquid[liquidIndex].length - 1 ? (
+                          <Divider borderColor={COLORS.grey40} />
+                        ) : null}
+                      </>
+                    )
+                  })
               : null}
           </Flex>
         </>

--- a/protocol-designer/src/components/organisms/AssignLiquidsModal/LiquidCard.tsx
+++ b/protocol-designer/src/components/organisms/AssignLiquidsModal/LiquidCard.tsx
@@ -122,8 +122,8 @@ export function LiquidCard({ info }: LiquidCardProps): JSX.Element {
             <StyledText
               desktopStyle="bodyDefaultSemiBold"
               className={clsx(
-                lineClampStyles.lineClamp,
-                lineClampStyles.wordBreakAll
+                lineClampStyles.line_clamp,
+                lineClampStyles.word_break_all
               )}
               style={{ WebkitLineClamp: 3 }}
             >
@@ -139,8 +139,8 @@ export function LiquidCard({ info }: LiquidCardProps): JSX.Element {
             <StyledText
               desktopStyle="bodyDefaultRegular"
               className={clsx(
-                lineClampStyles.lineClamp,
-                lineClampStyles.wordBreakAll
+                lineClampStyles.line_clamp,
+                lineClampStyles.word_break_all
               )}
               style={{ WebkitLineClamp: 3 }}
             >

--- a/protocol-designer/src/components/organisms/AssignLiquidsModal/LiquidCard.tsx
+++ b/protocol-designer/src/components/organisms/AssignLiquidsModal/LiquidCard.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
+import { clsx } from 'clsx'
 
 import {
   ALIGN_CENTER,
@@ -19,10 +20,10 @@ import {
   TEXT_DECORATION_UNDERLINE,
 } from '@opentrons/components'
 
-import { LINE_CLAMP_TEXT_STYLE } from '/protocol-designer/components/atoms'
 import { removeWellsContents } from '/protocol-designer/labware-ingred/actions'
 import { selectors as labwareIngredSelectors } from '/protocol-designer/labware-ingred/selectors'
 import { getLabwareEntities } from '/protocol-designer/step-forms/selectors'
+import lineClampStyles from '/protocol-designer/styles/lineclamp.module.css'
 import * as wellContentsSelectors from '/protocol-designer/top-selectors/well-contents'
 
 import { WellContents } from './WellContents'
@@ -120,7 +121,11 @@ export function LiquidCard({ info }: LiquidCardProps): JSX.Element {
           >
             <StyledText
               desktopStyle="bodyDefaultSemiBold"
-              css={LINE_CLAMP_TEXT_STYLE(3)}
+              className={clsx(
+                lineClampStyles.lineClamp,
+                lineClampStyles.wordBreakAll
+              )}
+              style={{ WebkitLineClamp: 3 }}
             >
               {name}
             </StyledText>
@@ -133,7 +138,11 @@ export function LiquidCard({ info }: LiquidCardProps): JSX.Element {
             ) : null}
             <StyledText
               desktopStyle="bodyDefaultRegular"
-              css={LINE_CLAMP_TEXT_STYLE(3)}
+              className={clsx(
+                lineClampStyles.lineClamp,
+                lineClampStyles.wordBreakAll
+              )}
+              style={{ WebkitLineClamp: 3 }}
             >
               {info.liquidIndex != null
                 ? liquidsWithDescriptions[info.liquidIndex].description
@@ -183,24 +192,24 @@ export function LiquidCard({ info }: LiquidCardProps): JSX.Element {
             <Divider borderColor={COLORS.grey40} />
             {info.liquidIndex != null
               ? fullWellsByLiquid[info.liquidIndex]
-                  .sort((a, b) =>
-                    orderedWells.indexOf(b) > orderedWells.indexOf(a) ? -1 : 1
-                  )
-                  .map((wellName, wellliquidIndex) => {
-                    const volume =
-                      wellContents != null
-                        ? wellContents[wellName].ingreds[liquidIndex].volume
-                        : 0
-                    return (
-                      <>
-                        <WellContents wellName={wellName} volume={volume} />
-                        {wellliquidIndex <
+                .sort((a, b) =>
+                  orderedWells.indexOf(b) > orderedWells.indexOf(a) ? -1 : 1
+                )
+                .map((wellName, wellliquidIndex) => {
+                  const volume =
+                    wellContents != null
+                      ? wellContents[wellName].ingreds[liquidIndex].volume
+                      : 0
+                  return (
+                    <>
+                      <WellContents wellName={wellName} volume={volume} />
+                      {wellliquidIndex <
                         fullWellsByLiquid[liquidIndex].length - 1 ? (
-                          <Divider borderColor={COLORS.grey40} />
-                        ) : null}
-                      </>
-                    )
-                  })
+                        <Divider borderColor={COLORS.grey40} />
+                      ) : null}
+                    </>
+                  )
+                })
               : null}
           </Flex>
         </>

--- a/protocol-designer/src/components/organisms/AssignLiquidsModal/index.tsx
+++ b/protocol-designer/src/components/organisms/AssignLiquidsModal/index.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
+import { clsx } from 'clsx'
 
 import {
   ALIGN_CENTER,
@@ -26,15 +27,13 @@ import {
   wellFillFromWellContents,
 } from '@opentrons/step-generation'
 
-import {
-  LINE_CLAMP_TEXT_STYLE,
-  NAV_BAR_HEIGHT_REM,
-} from '/protocol-designer/components/atoms'
+import { NAV_BAR_HEIGHT_REM } from '/protocol-designer/components/atoms'
 import { LiquidButton } from '/protocol-designer/components/molecules'
 import { getEnableStacking } from '/protocol-designer/feature-flags/selectors'
 import { selectors } from '/protocol-designer/labware-ingred/selectors'
 import { selectors as stepFormSelectors } from '/protocol-designer/step-forms'
 import { getInitialDeckSetup } from '/protocol-designer/step-forms/selectors'
+import lineClampStyles from '/protocol-designer/styles/lineclamp.module.css'
 import * as wellContentsSelectors from '/protocol-designer/top-selectors/well-contents'
 import { getLabwareNicknamesById } from '/protocol-designer/ui/labware/selectors'
 import {
@@ -181,7 +180,11 @@ export function AssignLiquidsModal(
               />
               <StyledText
                 desktopStyle="headingLargeBold"
-                css={LINE_CLAMP_TEXT_STYLE(3, true)}
+                className={clsx(
+                  lineClampStyles.lineClamp,
+                  lineClampStyles.wordNormal
+                )}
+                style={{ WebkitLineClamp: 3 }}
               >
                 {t('add_liquids_to_labware', {
                   labwareName: nickNames[labwareId],

--- a/protocol-designer/src/components/organisms/AssignLiquidsModal/index.tsx
+++ b/protocol-designer/src/components/organisms/AssignLiquidsModal/index.tsx
@@ -181,8 +181,8 @@ export function AssignLiquidsModal(
               <StyledText
                 desktopStyle="headingLargeBold"
                 className={clsx(
-                  lineClampStyles.lineClamp,
-                  lineClampStyles.wordNormal
+                  lineClampStyles.line_clamp,
+                  lineClampStyles.word_normal
                 )}
                 style={{ WebkitLineClamp: 3 }}
               >

--- a/protocol-designer/src/components/organisms/DefineLiquidsModal/index.tsx
+++ b/protocol-designer/src/components/organisms/DefineLiquidsModal/index.tsx
@@ -3,6 +3,7 @@ import { Controller, useForm } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 import { yupResolver } from '@hookform/resolvers/yup'
+import { clsx } from 'clsx'
 import * as Yup from 'yup'
 
 import {
@@ -31,13 +32,13 @@ import { swatchColors } from '@opentrons/step-generation'
 
 import {
   HandleEnter,
-  LINE_CLAMP_TEXT_STYLE,
   LINK_BUTTON_STYLE,
 } from '/protocol-designer/components/atoms'
 import { TextAreaField } from '/protocol-designer/components/molecules'
 import { getRobotType } from '/protocol-designer/file-data/selectors'
 import * as labwareIngredActions from '/protocol-designer/labware-ingred/actions'
 import { selectors as labwareIngredSelectors } from '/protocol-designer/labware-ingred/selectors'
+import lineClampStyles from '/protocol-designer/styles/lineclamp.module.css'
 
 import { LiquidClassDropdown } from './LiquidClassDropdown'
 import { LiquidColorPicker } from './LiquidColorPicker'
@@ -189,7 +190,11 @@ export function DefineLiquidsModal(
               <LiquidIcon color={initialValues.displayColor} />
               <StyledText
                 desktopStyle="bodyLargeSemiBold"
-                css={LINE_CLAMP_TEXT_STYLE(1)}
+                className={clsx(
+                  lineClampStyles.lineClamp,
+                  lineClampStyles.wordBreakAll
+                )}
+                style={{ WebkitLineClamp: 1 }}
               >
                 {initialValues.displayName}
               </StyledText>

--- a/protocol-designer/src/components/organisms/DefineLiquidsModal/index.tsx
+++ b/protocol-designer/src/components/organisms/DefineLiquidsModal/index.tsx
@@ -191,8 +191,8 @@ export function DefineLiquidsModal(
               <StyledText
                 desktopStyle="bodyLargeSemiBold"
                 className={clsx(
-                  lineClampStyles.lineClamp,
-                  lineClampStyles.wordBreakAll
+                  lineClampStyles.line_clamp,
+                  lineClampStyles.word_break_all
                 )}
                 style={{ WebkitLineClamp: 1 }}
               >

--- a/protocol-designer/src/components/organisms/LiquidsOverflowMenu/index.tsx
+++ b/protocol-designer/src/components/organisms/LiquidsOverflowMenu/index.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 import { useLocation } from 'react-router-dom'
+import { clsx } from 'clsx'
 import { css } from 'styled-components'
 
 import {
@@ -21,13 +22,11 @@ import {
   TYPOGRAPHY,
 } from '@opentrons/components'
 
-import {
-  LINE_CLAMP_TEXT_STYLE,
-  NAV_BAR_HEIGHT_REM,
-} from '/protocol-designer/components/atoms'
+import { NAV_BAR_HEIGHT_REM } from '/protocol-designer/components/atoms'
 import { OVERFLOW_MENU_POSITION_ADJUSTMENT } from '/protocol-designer/constants'
 import * as labwareIngredActions from '/protocol-designer/labware-ingred/actions'
 import { getLiquidEntities } from '/protocol-designer/step-forms/selectors'
+import lineClampStyles from '/protocol-designer/styles/lineclamp.module.css'
 
 import type { MouseEvent, RefObject } from 'react'
 import type { ThunkDispatch } from '/protocol-designer/types'
@@ -106,10 +105,14 @@ export function LiquidsOverflowMenu({
                 <LiquidIcon color={displayColor ?? ''} />
                 <StyledText
                   desktopStyle="bodyDefaultRegular"
-                  css={`
-                    ${LINE_CLAMP_TEXT_STYLE(3)}
-                    text-align: ${TYPOGRAPHY.textAlignLeft}
-                  `}
+                  className={clsx(
+                    lineClampStyles.lineClamp,
+                    lineClampStyles.wordBreakAll
+                  )}
+                  style={{
+                    WebkitLineClamp: 3,
+                    textAlign: TYPOGRAPHY.textAlignLeft,
+                  }}
                 >
                   {displayName}
                 </StyledText>

--- a/protocol-designer/src/components/organisms/LiquidsOverflowMenu/index.tsx
+++ b/protocol-designer/src/components/organisms/LiquidsOverflowMenu/index.tsx
@@ -106,8 +106,8 @@ export function LiquidsOverflowMenu({
                 <StyledText
                   desktopStyle="bodyDefaultRegular"
                   className={clsx(
-                    lineClampStyles.lineClamp,
-                    lineClampStyles.wordBreakAll
+                    lineClampStyles.line_clamp,
+                    lineClampStyles.word_break_all
                   )}
                   style={{
                     WebkitLineClamp: 3,

--- a/protocol-designer/src/components/organisms/MaterialsListModal/index.tsx
+++ b/protocol-designer/src/components/organisms/MaterialsListModal/index.tsx
@@ -241,8 +241,8 @@ export function MaterialsListModal({
                                 <StyledText
                                   desktopStyle="bodyDefaultRegular"
                                   className={clsx(
-                                    lineClampStyles.lineClamp,
-                                    lineClampStyles.wordBreakAll
+                                    lineClampStyles.line_clamp,
+                                    lineClampStyles.word_break_all
                                   )}
                                   style={{ WebkitLineClamp: 3 }}
                                 >

--- a/protocol-designer/src/components/organisms/MaterialsListModal/index.tsx
+++ b/protocol-designer/src/components/organisms/MaterialsListModal/index.tsx
@@ -88,26 +88,26 @@ export function MaterialsListModal({
             <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing4}>
               {fixtures.length > 0
                 ? fixtures.map(fixture => (
-                  <ListItem type="default" key={fixture.id}>
-                    <ListItemDescriptor
-                      type="large"
-                      description={
-                        <Flex minWidth="13.75rem">
-                          <RobotInfoLabel
-                            deckLabel={fixture.location.replace('cutout', '')}
-                          />
-                        </Flex>
-                      }
-                      content={
-                        <Flex alignItems={ALIGN_CENTER}>
-                          <StyledText desktopStyle="bodyDefaultRegular">
-                            {t(`shared:${fixture.name}`)}
-                          </StyledText>
-                        </Flex>
-                      }
-                    />
-                  </ListItem>
-                ))
+                    <ListItem type="default" key={fixture.id}>
+                      <ListItemDescriptor
+                        type="large"
+                        description={
+                          <Flex minWidth="13.75rem">
+                            <RobotInfoLabel
+                              deckLabel={fixture.location.replace('cutout', '')}
+                            />
+                          </Flex>
+                        }
+                        content={
+                          <Flex alignItems={ALIGN_CENTER}>
+                            <StyledText desktopStyle="bodyDefaultRegular">
+                              {t(`shared:${fixture.name}`)}
+                            </StyledText>
+                          </Flex>
+                        }
+                      />
+                    </ListItem>
+                  ))
                 : null}
               {hardware.length > 0 ? (
                 hardware.map((hw, id) => {

--- a/protocol-designer/src/components/organisms/MaterialsListModal/index.tsx
+++ b/protocol-designer/src/components/organisms/MaterialsListModal/index.tsx
@@ -1,6 +1,7 @@
 import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
+import { clsx } from 'clsx'
 import sum from 'lodash/sum'
 
 import {
@@ -27,12 +28,10 @@ import {
 } from '@opentrons/shared-data'
 import { getSlotInLocationStack } from '@opentrons/step-generation'
 
-import {
-  HandleEnter,
-  LINE_CLAMP_TEXT_STYLE,
-} from '/protocol-designer/components/atoms'
+import { HandleEnter } from '/protocol-designer/components/atoms'
 import { getRobotType } from '/protocol-designer/file-data/selectors'
 import { selectors as labwareIngredSelectors } from '/protocol-designer/labware-ingred/selectors'
+import lineClampStyles from '/protocol-designer/styles/lineclamp.module.css'
 
 import { getMainPagePortalEl } from '../Portal'
 
@@ -89,26 +88,26 @@ export function MaterialsListModal({
             <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing4}>
               {fixtures.length > 0
                 ? fixtures.map(fixture => (
-                    <ListItem type="default" key={fixture.id}>
-                      <ListItemDescriptor
-                        type="large"
-                        description={
-                          <Flex minWidth="13.75rem">
-                            <RobotInfoLabel
-                              deckLabel={fixture.location.replace('cutout', '')}
-                            />
-                          </Flex>
-                        }
-                        content={
-                          <Flex alignItems={ALIGN_CENTER}>
-                            <StyledText desktopStyle="bodyDefaultRegular">
-                              {t(`shared:${fixture.name}`)}
-                            </StyledText>
-                          </Flex>
-                        }
-                      />
-                    </ListItem>
-                  ))
+                  <ListItem type="default" key={fixture.id}>
+                    <ListItemDescriptor
+                      type="large"
+                      description={
+                        <Flex minWidth="13.75rem">
+                          <RobotInfoLabel
+                            deckLabel={fixture.location.replace('cutout', '')}
+                          />
+                        </Flex>
+                      }
+                      content={
+                        <Flex alignItems={ALIGN_CENTER}>
+                          <StyledText desktopStyle="bodyDefaultRegular">
+                            {t(`shared:${fixture.name}`)}
+                          </StyledText>
+                        </Flex>
+                      }
+                    />
+                  </ListItem>
+                ))
                 : null}
               {hardware.length > 0 ? (
                 hardware.map((hw, id) => {
@@ -241,7 +240,11 @@ export function MaterialsListModal({
                                 <LiquidIcon color={liquid.displayColor ?? ''} />
                                 <StyledText
                                   desktopStyle="bodyDefaultRegular"
-                                  css={LINE_CLAMP_TEXT_STYLE(3)}
+                                  className={clsx(
+                                    lineClampStyles.lineClamp,
+                                    lineClampStyles.wordBreakAll
+                                  )}
+                                  style={{ WebkitLineClamp: 3 }}
                                 >
                                   {liquid.displayName ?? t('n/a')}
                                 </StyledText>

--- a/protocol-designer/src/components/organisms/SlotInformation/index.tsx
+++ b/protocol-designer/src/components/organisms/SlotInformation/index.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next'
 import { useLocation } from 'react-router-dom'
+import { clsx } from 'clsx'
 
 import {
   ALIGN_CENTER,
@@ -26,8 +27,8 @@ import {
   getIsSlotAHopper,
 } from '@opentrons/step-generation'
 
-import { LINE_CLAMP_TEXT_STYLE } from '/protocol-designer/components/atoms'
 import { useDeckSetupWindowBreakPoint } from '/protocol-designer/pages/Designer/DeckSetup/utils'
+import lineClampStyles from '/protocol-designer/styles/lineclamp.module.css'
 
 import type { FC } from 'react'
 import type { RobotType } from '@opentrons/shared-data'
@@ -92,7 +93,11 @@ export const SlotInformation: FC<SlotInformationProps> = ({
                 <StyledText
                   desktopStyle="bodyDefaultRegular"
                   textAlign={TYPOGRAPHY.textAlignRight}
-                  css={LINE_CLAMP_TEXT_STYLE(2, true)}
+                  className={clsx(
+                    lineClampStyles.lineClamp,
+                    lineClampStyles.wordNormal
+                  )}
+                  style={{ WebkitLineClamp: 2 }}
                 >
                   {liquids.join(', ')}
                 </StyledText>
@@ -183,7 +188,11 @@ function StackInfo({ title, stackInformation }: StackInfoProps): JSX.Element {
                 ? TYPOGRAPHY.textAlignLeft
                 : TYPOGRAPHY.textAlignRight
             }
-            css={LINE_CLAMP_TEXT_STYLE(3, true)}
+            className={clsx(
+              lineClampStyles.lineClamp,
+              lineClampStyles.wordNormal
+            )}
+            style={{ WebkitLineClamp: 3 }}
           >
             {stackInformation ?? t('none')}
           </StyledText>

--- a/protocol-designer/src/components/organisms/SlotInformation/index.tsx
+++ b/protocol-designer/src/components/organisms/SlotInformation/index.tsx
@@ -94,8 +94,8 @@ export const SlotInformation: FC<SlotInformationProps> = ({
                   desktopStyle="bodyDefaultRegular"
                   textAlign={TYPOGRAPHY.textAlignRight}
                   className={clsx(
-                    lineClampStyles.lineClamp,
-                    lineClampStyles.wordNormal
+                    lineClampStyles.line_clamp,
+                    lineClampStyles.word_normal
                   )}
                   style={{ WebkitLineClamp: 2 }}
                 >
@@ -189,8 +189,8 @@ function StackInfo({ title, stackInformation }: StackInfoProps): JSX.Element {
                 : TYPOGRAPHY.textAlignRight
             }
             className={clsx(
-              lineClampStyles.lineClamp,
-              lineClampStyles.wordNormal
+              lineClampStyles.line_clamp,
+              lineClampStyles.word_normal
             )}
             style={{ WebkitLineClamp: 3 }}
           >

--- a/protocol-designer/src/components/organisms/StepSummary/index.tsx
+++ b/protocol-designer/src/components/organisms/StepSummary/index.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
+import { clsx } from 'clsx'
 
 import {
   DIRECTION_COLUMN,
@@ -13,8 +14,8 @@ import {
   WASTE_CHUTE_CUTOUT,
 } from '@opentrons/shared-data'
 
-import { LINE_CLAMP_TEXT_STYLE } from '/protocol-designer/components/atoms'
 import { formatTime } from '/protocol-designer/pages/Designer/utils'
+import lineClampStyles from '/protocol-designer/styles/lineclamp.module.css'
 
 import {
   getAdditionalEquipmentEntities,
@@ -130,8 +131,7 @@ export function StepSummary(props: StepSummaryProps): JSX.Element | null {
             <StyledTrans
               i18nKey="protocol_steps:thermocycler_module.thermocycler_state.lid_position"
               tagText={t(
-                `protocol_steps:thermocycler_module.lid_position.${
-                  lidOpen ? 'open' : 'closed'
+                `protocol_steps:thermocycler_module.lid_position.${lidOpen ? 'open' : 'closed'
                 }`
               )}
             />
@@ -157,8 +157,7 @@ export function StepSummary(props: StepSummaryProps): JSX.Element | null {
             <StyledTrans
               i18nKey="protocol_steps:thermocycler_module.thermocycler_profile.end_hold.lid_position"
               tagText={t(
-                `protocol_steps:thermocycler_module.lid_position.${
-                  lidOpenHold ? 'open' : 'closed'
+                `protocol_steps:thermocycler_module.lid_position.${lidOpenHold ? 'open' : 'closed'
                 }`
               )}
             />
@@ -304,8 +303,8 @@ export function StepSummary(props: StepSummaryProps): JSX.Element | null {
             tagText={
               targetHeaterShakerTemperature
                 ? `${targetHeaterShakerTemperature}${t(
-                    'application:units.degrees'
-                  )}`
+                  'application:units.degrees'
+                )}`
                 : t('protocol_steps:heater_shaker.active.ambient')
             }
           />
@@ -374,7 +373,11 @@ export function StepSummary(props: StepSummaryProps): JSX.Element | null {
           <Flex padding={SPACING.spacing12}>
             <StyledText
               desktopStyle="bodyDefaultRegular"
-              css={LINE_CLAMP_TEXT_STYLE(3)}
+              className={clsx(
+                lineClampStyles.lineClamp,
+                lineClampStyles.wordBreakAll
+              )}
+              style={{ WebkitLineClamp: 3 }}
             >
               {stepDetails}
             </StyledText>

--- a/protocol-designer/src/components/organisms/StepSummary/index.tsx
+++ b/protocol-designer/src/components/organisms/StepSummary/index.tsx
@@ -131,7 +131,8 @@ export function StepSummary(props: StepSummaryProps): JSX.Element | null {
             <StyledTrans
               i18nKey="protocol_steps:thermocycler_module.thermocycler_state.lid_position"
               tagText={t(
-                `protocol_steps:thermocycler_module.lid_position.${lidOpen ? 'open' : 'closed'
+                `protocol_steps:thermocycler_module.lid_position.${
+                  lidOpen ? 'open' : 'closed'
                 }`
               )}
             />
@@ -157,7 +158,8 @@ export function StepSummary(props: StepSummaryProps): JSX.Element | null {
             <StyledTrans
               i18nKey="protocol_steps:thermocycler_module.thermocycler_profile.end_hold.lid_position"
               tagText={t(
-                `protocol_steps:thermocycler_module.lid_position.${lidOpenHold ? 'open' : 'closed'
+                `protocol_steps:thermocycler_module.lid_position.${
+                  lidOpenHold ? 'open' : 'closed'
                 }`
               )}
             />
@@ -303,8 +305,8 @@ export function StepSummary(props: StepSummaryProps): JSX.Element | null {
             tagText={
               targetHeaterShakerTemperature
                 ? `${targetHeaterShakerTemperature}${t(
-                  'application:units.degrees'
-                )}`
+                    'application:units.degrees'
+                  )}`
                 : t('protocol_steps:heater_shaker.active.ambient')
             }
           />

--- a/protocol-designer/src/components/organisms/StepSummary/index.tsx
+++ b/protocol-designer/src/components/organisms/StepSummary/index.tsx
@@ -376,8 +376,8 @@ export function StepSummary(props: StepSummaryProps): JSX.Element | null {
             <StyledText
               desktopStyle="bodyDefaultRegular"
               className={clsx(
-                lineClampStyles.lineClamp,
-                lineClampStyles.wordBreakAll
+                lineClampStyles.line_clamp,
+                lineClampStyles.word_break_all
               )}
               style={{ WebkitLineClamp: 3 }}
             >

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepFormToolbox.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepFormToolbox.tsx
@@ -555,8 +555,8 @@ export function StepFormToolbox(props: StepFormToolboxProps): JSX.Element {
             <StyledText
               desktopStyle="bodyLargeSemiBold"
               className={clsx(
-                lineClampStyles.lineClamp,
-                lineClampStyles.wordNormal
+                lineClampStyles.line_clamp,
+                lineClampStyles.word_normal
               )}
               style={{ WebkitLineClamp: 2 }}
             >

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepFormToolbox.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepFormToolbox.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
+import { clsx } from 'clsx'
 import get from 'lodash/get'
 
 import {
@@ -29,7 +30,6 @@ import {
   FORM_WARNINGS_EVENT,
 } from '/protocol-designer/analytics/constants'
 import {
-  LINE_CLAMP_TEXT_STYLE,
   LINK_BUTTON_STYLE,
   NAV_BAR_HEIGHT_REM,
 } from '/protocol-designer/components/atoms'
@@ -56,6 +56,7 @@ import {
 import { actions } from '/protocol-designer/steplist'
 import { maskField } from '/protocol-designer/steplist/fieldLevel'
 import { updateFieldsForLiquidClass } from '/protocol-designer/steplist/formLevel/handleFormChange/utils'
+import lineClampStyles from '/protocol-designer/styles/lineclamp.module.css'
 import { getTimelineWarningsForSelectedStep } from '/protocol-designer/top-selectors/timelineWarnings'
 import {
   hoverSelection,
@@ -553,7 +554,11 @@ export function StepFormToolbox(props: StepFormToolboxProps): JSX.Element {
             <Icon size="1rem" name={icon} minWidth="1rem" />
             <StyledText
               desktopStyle="bodyLargeSemiBold"
-              css={LINE_CLAMP_TEXT_STYLE(2, true)}
+              className={clsx(
+                lineClampStyles.lineClamp,
+                lineClampStyles.wordNormal
+              )}
+              style={{ WebkitLineClamp: 2 }}
             >
               {/* TODO: use  module object from form.json instead */}
               {formData.stepType === 'flexStacker'

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/Configurations.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/Configurations.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from 'react-i18next'
+import { clsx } from 'clsx'
 
 import {
   DIRECTION_COLUMN,
@@ -8,8 +9,8 @@ import {
   StyledText,
 } from '@opentrons/components'
 
-import { LINE_CLAMP_TEXT_STYLE } from '/protocol-designer/components/atoms'
 import { LiquidButton } from '/protocol-designer/components/molecules'
+import lineClampStyles from '/protocol-designer/styles/lineclamp.module.css'
 
 import { HardwareStep } from './HardwareStep'
 
@@ -34,7 +35,11 @@ export function Configurations({
       >
         <StyledText
           desktopStyle="bodyDefaultSemiBold"
-          css={LINE_CLAMP_TEXT_STYLE(1)}
+          className={clsx(
+            lineClampStyles.lineClamp,
+            lineClampStyles.wordBreakAll
+          )}
+          style={{ WebkitLineClamp: 1 }}
         >
           {t('configuration')}
         </StyledText>

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/Configurations.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/Configurations.tsx
@@ -36,8 +36,8 @@ export function Configurations({
         <StyledText
           desktopStyle="bodyDefaultSemiBold"
           className={clsx(
-            lineClampStyles.lineClamp,
-            lineClampStyles.wordBreakAll
+            lineClampStyles.line_clamp,
+            lineClampStyles.word_break_all
           )}
           style={{ WebkitLineClamp: 1 }}
         >

--- a/protocol-designer/src/pages/ProtocolOverview/LiquidDefinitions.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/LiquidDefinitions.tsx
@@ -37,8 +37,8 @@ const getLiquidDescription = (liquid: IngredInputs): JSX.Element | null => {
         <StyledText
           desktopStyle="bodyDefaultRegular"
           className={clsx(
-            lineClampStyles.lineClamp,
-            lineClampStyles.wordBreakAll
+            lineClampStyles.line_clamp,
+            lineClampStyles.word_break_all
           )}
           style={{ WebkitLineClamp: 10 }}
         >
@@ -86,8 +86,8 @@ export function LiquidDefinitions({
                         desktopStyle="bodyDefaultRegular"
                         id="liquid-name"
                         className={clsx(
-                          lineClampStyles.lineClamp,
-                          lineClampStyles.wordBreakAll
+                          lineClampStyles.line_clamp,
+                          lineClampStyles.word_break_all
                         )}
                         style={{ WebkitLineClamp: 3 }}
                       >

--- a/protocol-designer/src/pages/ProtocolOverview/LiquidDefinitions.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/LiquidDefinitions.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from 'react-i18next'
+import { clsx } from 'clsx'
 
 import {
   ALIGN_CENTER,
@@ -13,7 +14,8 @@ import {
   Tag,
 } from '@opentrons/components'
 
-import { LINE_CLAMP_TEXT_STYLE } from '../../components/atoms'
+import lineClampStyles from '/protocol-designer/styles/lineclamp.module.css'
+
 import { getLiquidClassDisplayName } from '../../liquid-defs/utils'
 
 import type {
@@ -34,7 +36,11 @@ const getLiquidDescription = (liquid: IngredInputs): JSX.Element | null => {
       {description ? (
         <StyledText
           desktopStyle="bodyDefaultRegular"
-          css={LINE_CLAMP_TEXT_STYLE(10)}
+          className={clsx(
+            lineClampStyles.lineClamp,
+            lineClampStyles.wordBreakAll
+          )}
+          style={{ WebkitLineClamp: 10 }}
         >
           {description}
         </StyledText>
@@ -79,7 +85,11 @@ export function LiquidDefinitions({
                       <StyledText
                         desktopStyle="bodyDefaultRegular"
                         id="liquid-name"
-                        css={LINE_CLAMP_TEXT_STYLE(3)}
+                        className={clsx(
+                          lineClampStyles.lineClamp,
+                          lineClampStyles.wordBreakAll
+                        )}
+                        style={{ WebkitLineClamp: 3 }}
                       >
                         {liquid.displayName}
                       </StyledText>

--- a/protocol-designer/src/pages/ProtocolOverview/ProtocolMetadata.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/ProtocolMetadata.tsx
@@ -75,8 +75,8 @@ export function ProtocolMetadata({
                 <StyledText
                   desktopStyle="bodyDefaultRegular"
                   className={clsx(
-                    lineClampStyles.lineClamp,
-                    lineClampStyles.wordBreakAll
+                    lineClampStyles.line_clamp,
+                    lineClampStyles.word_break_all
                   )}
                   style={{ WebkitLineClamp: 2 }}
                 >

--- a/protocol-designer/src/pages/ProtocolOverview/ProtocolMetadata.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/ProtocolMetadata.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from 'react-i18next'
+import { clsx } from 'clsx'
 
 import {
   ALIGN_CENTER,
@@ -14,10 +15,9 @@ import {
   TYPOGRAPHY,
 } from '@opentrons/components'
 
-import {
-  LINE_CLAMP_TEXT_STYLE,
-  LINK_BUTTON_STYLE,
-} from '../../components/atoms'
+import lineClampStyles from '/protocol-designer/styles/lineclamp.module.css'
+
+import { LINK_BUTTON_STYLE } from '../../components/atoms'
 
 interface MetadataItem {
   title: string
@@ -74,7 +74,11 @@ export function ProtocolMetadata({
               content={
                 <StyledText
                   desktopStyle="bodyDefaultRegular"
-                  css={LINE_CLAMP_TEXT_STYLE(2)}
+                  className={clsx(
+                    lineClampStyles.lineClamp,
+                    lineClampStyles.wordBreakAll
+                  )}
+                  style={{ WebkitLineClamp: 2 }}
                 >
                   {value ?? t('na')}
                 </StyledText>

--- a/protocol-designer/src/pages/ProtocolOverview/index.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/index.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 import { useNavigate } from 'react-router-dom'
+import { clsx } from 'clsx'
 import { format } from 'date-fns'
 import { css } from 'styled-components'
 
@@ -21,8 +22,9 @@ import {
 import { OT2_ROBOT_TYPE } from '@opentrons/shared-data'
 
 import { PeripheralsInfo } from '/protocol-designer/pages/ProtocolOverview/PeripheralsInfo'
+import lineClampStyles from '/protocol-designer/styles/lineclamp.module.css'
 
-import { COLUMN_STYLE, LINE_CLAMP_TEXT_STYLE } from '../../components/atoms'
+import { COLUMN_STYLE } from '../../components/atoms'
 import { EndUserAgreementFooter } from '../../components/molecules'
 import {
   EditInstrumentsModal,
@@ -179,7 +181,11 @@ export function ProtocolOverview(): JSX.Element {
           <Flex flex="1">
             <StyledText
               desktopStyle="displayBold"
-              css={LINE_CLAMP_TEXT_STYLE(3)}
+              className={clsx(
+                lineClampStyles.lineClamp,
+                lineClampStyles.wordBreakAll
+              )}
+              style={{ WebkitLineClamp: 3 }}
             >
               {protocolName != null && protocolName !== ''
                 ? protocolName

--- a/protocol-designer/src/pages/ProtocolOverview/index.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/index.tsx
@@ -182,8 +182,8 @@ export function ProtocolOverview(): JSX.Element {
             <StyledText
               desktopStyle="displayBold"
               className={clsx(
-                lineClampStyles.lineClamp,
-                lineClampStyles.wordBreakAll
+                lineClampStyles.line_clamp,
+                lineClampStyles.word_break_all
               )}
               style={{ WebkitLineClamp: 3 }}
             >

--- a/protocol-designer/src/styles/lineclamp.module.css
+++ b/protocol-designer/src/styles/lineclamp.module.css
@@ -1,15 +1,15 @@
-.lineClamp {
+.line_clamp {
   display: -webkit-box;
-  -webkit-box-orient: vertical;
   overflow: hidden;
+  -webkit-box-orient: vertical;
+  overflow-wrap: break-word;
   text-overflow: ellipsis;
-  word-wrap: break-word;
 }
 
-.wordNormal {
+.word_normal {
   word-break: normal;
 }
 
-.wordBreakAll {
+.word_break_all {
   word-break: break-all;
 }

--- a/protocol-designer/src/styles/lineclamp.module.css
+++ b/protocol-designer/src/styles/lineclamp.module.css
@@ -1,0 +1,15 @@
+.lineClamp {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  word-wrap: break-word;
+}
+
+.wordNormal {
+  word-break: normal;
+}
+
+.wordBreakAll {
+  word-break: break-all;
+}


### PR DESCRIPTION
# Overview
line clamp style with `styled-componetns` -> line clamp style with `CSS Modules`

[before]
```ts
css={LINE_CLAMP_TEXT_STYLE(3, true)}
```

[after]
```ts
className={clsx(
  lineClampStyles.line_clamp,
  lineClampStyles.word_normal
)}
style={{ WebkitLineClamp: 3 }}
```

[before]
```ts
css={LINE_CLAMP_TEXT_STYLE(3)}
```

[after]
```ts
className={clsx(
  lineClampStyles.line_clamp,
  lineClampStyles.word_break_all
)}
style={{ WebkitLineClamp: 3 }}
```


close AUTH-2655


## Test Plan and Hands on Testing


## Changelog
- remove LINE_CLAMP_TEXT_STYLE from `components/atoms/constants`

## Review requests


## Risk assessment
low