### PR TITLE
fix(api): fix configure for nozzle layout not updating with the correct tip overlap value

### DIFF
--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[109b7ad1f0][Flex_S_v2_20_96_None_ROW_HappyPath].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[109b7ad1f0][Flex_S_v2_20_96_None_ROW_HappyPath].json
@@ -3635,7 +3635,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.72999999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -3779,7 +3779,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.72999999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -3888,7 +3888,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.72999999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -3981,7 +3981,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.72999999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -4974,7 +4974,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.72399999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -5118,7 +5118,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.72399999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -5227,7 +5227,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.72399999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -5320,7 +5320,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.72399999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[10c2386b92][Flex_S_v2_20_96_AllCorners].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[10c2386b92][Flex_S_v2_20_96_AllCorners].json
@@ -7203,7 +7203,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.72999999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -7279,7 +7279,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.72999999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -7355,7 +7355,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.72999999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -7507,7 +7507,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -7583,7 +7583,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -7739,7 +7739,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.72999999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -7815,7 +7815,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.72999999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -7891,7 +7891,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.72999999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -7985,7 +7985,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -8061,7 +8061,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -8137,7 +8137,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -8213,7 +8213,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -8289,7 +8289,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -8365,7 +8365,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -8441,7 +8441,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -8517,7 +8517,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -8593,7 +8593,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -8669,7 +8669,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -8821,7 +8821,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -8897,7 +8897,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -8973,7 +8973,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -9049,7 +9049,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -9125,7 +9125,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -9201,7 +9201,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -9277,7 +9277,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -9353,7 +9353,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -9429,7 +9429,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -9505,7 +9505,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -9581,7 +9581,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -9657,7 +9657,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -9733,7 +9733,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -9809,7 +9809,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -9885,7 +9885,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -9979,7 +9979,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -10055,7 +10055,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -10131,7 +10131,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -10207,7 +10207,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -10283,7 +10283,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -10359,7 +10359,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -10435,7 +10435,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -10511,7 +10511,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -10587,7 +10587,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -10663,7 +10663,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -10739,7 +10739,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -10815,7 +10815,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -10891,7 +10891,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -10967,7 +10967,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -11043,7 +11043,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -11137,7 +11137,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -11213,7 +11213,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -11289,7 +11289,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -11365,7 +11365,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -11441,7 +11441,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -11517,7 +11517,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -11593,7 +11593,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -11669,7 +11669,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -11745,7 +11745,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -11821,7 +11821,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -11897,7 +11897,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -11973,7 +11973,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -12049,7 +12049,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -12125,7 +12125,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -12201,7 +12201,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -12295,7 +12295,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -12371,7 +12371,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -12447,7 +12447,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -12523,7 +12523,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -12599,7 +12599,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -12675,7 +12675,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -12751,7 +12751,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -12827,7 +12827,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -12903,7 +12903,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -12979,7 +12979,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -13055,7 +13055,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -13131,7 +13131,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -13207,7 +13207,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -13283,7 +13283,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -13359,7 +13359,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -13511,7 +13511,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.72399999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -13587,7 +13587,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.72399999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -13663,7 +13663,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.72399999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -13739,7 +13739,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.72399999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -13815,7 +13815,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.72399999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -13891,7 +13891,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.72399999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -13967,7 +13967,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.72399999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -14061,7 +14061,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -14137,7 +14137,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -14289,7 +14289,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -14365,7 +14365,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -14441,7 +14441,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -14517,7 +14517,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -14593,7 +14593,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -14669,7 +14669,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -14745,7 +14745,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -14821,7 +14821,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -14897,7 +14897,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -14973,7 +14973,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -15049,7 +15049,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -15125,7 +15125,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -15201,7 +15201,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -15277,7 +15277,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -15353,7 +15353,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -15429,7 +15429,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -15505,7 +15505,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -15581,7 +15581,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -15657,7 +15657,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -15733,7 +15733,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -15809,7 +15809,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -15885,7 +15885,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -15961,7 +15961,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -16037,7 +16037,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -16113,7 +16113,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -16189,7 +16189,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -16265,7 +16265,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -16341,7 +16341,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -16417,7 +16417,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -16493,7 +16493,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -16569,7 +16569,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -16645,7 +16645,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -16721,7 +16721,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -16797,7 +16797,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -16873,7 +16873,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -16949,7 +16949,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -17025,7 +17025,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -17101,7 +17101,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -17177,7 +17177,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -17253,7 +17253,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -17329,7 +17329,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -17405,7 +17405,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -17481,7 +17481,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -17557,7 +17557,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -17633,7 +17633,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -17709,7 +17709,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -17785,7 +17785,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -17861,7 +17861,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -17955,7 +17955,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -18031,7 +18031,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -18107,7 +18107,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -18183,7 +18183,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -18259,7 +18259,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -18335,7 +18335,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -18411,7 +18411,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -18487,7 +18487,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -18563,7 +18563,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -18639,7 +18639,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -18715,7 +18715,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -18791,7 +18791,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -18867,7 +18867,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -18943,7 +18943,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -19019,7 +19019,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -19095,7 +19095,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -19171,7 +19171,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -19247,7 +19247,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -19323,7 +19323,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -19399,7 +19399,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -19475,7 +19475,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -19551,7 +19551,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -19627,7 +19627,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -19703,7 +19703,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -19779,7 +19779,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -19855,7 +19855,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -19931,7 +19931,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -20007,7 +20007,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -20083,7 +20083,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -20159,7 +20159,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -20235,7 +20235,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -20311,7 +20311,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -20387,7 +20387,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -20463,7 +20463,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -20539,7 +20539,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -20615,7 +20615,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -20691,7 +20691,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -20767,7 +20767,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -20843,7 +20843,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -20919,7 +20919,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -20995,7 +20995,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -21071,7 +21071,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -21147,7 +21147,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -21223,7 +21223,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -21299,7 +21299,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -21375,7 +21375,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -21451,7 +21451,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -21527,7 +21527,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -21621,7 +21621,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -21697,7 +21697,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -21773,7 +21773,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -21849,7 +21849,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -21925,7 +21925,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -22001,7 +22001,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -22077,7 +22077,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -22153,7 +22153,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -22229,7 +22229,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -22305,7 +22305,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -22381,7 +22381,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -22457,7 +22457,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -22533,7 +22533,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -22609,7 +22609,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -22685,7 +22685,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -22761,7 +22761,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -22837,7 +22837,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -22913,7 +22913,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -22989,7 +22989,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -23065,7 +23065,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -23141,7 +23141,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -23217,7 +23217,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -23293,7 +23293,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -23369,7 +23369,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -23445,7 +23445,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -23521,7 +23521,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -23597,7 +23597,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -23673,7 +23673,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -23749,7 +23749,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -23825,7 +23825,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -23901,7 +23901,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -23977,7 +23977,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -24053,7 +24053,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -24129,7 +24129,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -24205,7 +24205,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -24281,7 +24281,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -24357,7 +24357,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -24433,7 +24433,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -24509,7 +24509,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -24585,7 +24585,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -24679,7 +24679,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -24755,7 +24755,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -24831,7 +24831,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -24907,7 +24907,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -24983,7 +24983,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -25059,7 +25059,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -25135,7 +25135,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -25211,7 +25211,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -25287,7 +25287,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -25363,7 +25363,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -25439,7 +25439,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -25515,7 +25515,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -25591,7 +25591,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -25667,7 +25667,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -25743,7 +25743,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -25819,7 +25819,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -25895,7 +25895,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -25971,7 +25971,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -26047,7 +26047,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -26123,7 +26123,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -26199,7 +26199,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -26275,7 +26275,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -26351,7 +26351,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -26427,7 +26427,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -26503,7 +26503,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -26579,7 +26579,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -26655,7 +26655,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -26731,7 +26731,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -26807,7 +26807,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -26883,7 +26883,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -26959,7 +26959,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -27035,7 +27035,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -27111,7 +27111,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -27187,7 +27187,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -27263,7 +27263,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -27339,7 +27339,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -27415,7 +27415,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -27491,7 +27491,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -27567,7 +27567,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -27643,7 +27643,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -27795,7 +27795,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -27871,7 +27871,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -27947,7 +27947,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -28023,7 +28023,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -28099,7 +28099,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -28175,7 +28175,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -28251,7 +28251,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -28327,7 +28327,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -28403,7 +28403,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -28479,7 +28479,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -28573,7 +28573,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -28649,7 +28649,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -28725,7 +28725,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -28801,7 +28801,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -28877,7 +28877,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -28953,7 +28953,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -29029,7 +29029,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -29105,7 +29105,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -29181,7 +29181,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -29257,7 +29257,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -29351,7 +29351,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -29427,7 +29427,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -29503,7 +29503,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -29579,7 +29579,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -29655,7 +29655,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -29731,7 +29731,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -29807,7 +29807,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -29883,7 +29883,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -29959,7 +29959,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -30035,7 +30035,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -30111,7 +30111,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -30187,7 +30187,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -30263,7 +30263,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -30339,7 +30339,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -30415,7 +30415,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -30509,7 +30509,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -30585,7 +30585,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -30661,7 +30661,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -30737,7 +30737,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -30813,7 +30813,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -30889,7 +30889,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -30965,7 +30965,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -31041,7 +31041,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -31117,7 +31117,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -31193,7 +31193,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -31269,7 +31269,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -31345,7 +31345,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -31421,7 +31421,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -31497,7 +31497,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -31573,7 +31573,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -31841,7 +31841,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -31917,7 +31917,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -31993,7 +31993,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -32069,7 +32069,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -32145,7 +32145,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -32239,7 +32239,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -32315,7 +32315,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -32391,7 +32391,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -32467,7 +32467,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -32543,7 +32543,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -32695,7 +32695,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.72399999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -32771,7 +32771,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.72399999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -32847,7 +32847,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.72399999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -32923,7 +32923,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.72399999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -32999,7 +32999,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.72399999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -33075,7 +33075,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.72399999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -33151,7 +33151,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.72399999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -33365,7 +33365,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -33441,7 +33441,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -33517,7 +33517,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -33593,7 +33593,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -33669,7 +33669,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -33745,7 +33745,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -33839,7 +33839,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -33915,7 +33915,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -33991,7 +33991,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -34067,7 +34067,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -34143,7 +34143,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -34219,7 +34219,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[13cc2361a9][Flex_S_v2_25_P50_P200_stacker_all_parts].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[13cc2361a9][Flex_S_v2_25_P50_P200_stacker_all_parts].json
@@ -28273,7 +28273,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -28548,7 +28548,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -28823,7 +28823,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -29098,7 +29098,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -29373,7 +29373,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -29648,7 +29648,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -29923,7 +29923,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -30198,7 +30198,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -30473,7 +30473,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -30748,7 +30748,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -31023,7 +31023,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -31298,7 +31298,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -32273,7 +32273,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -32548,7 +32548,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -32823,7 +32823,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -33098,7 +33098,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -33373,7 +33373,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -33648,7 +33648,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -33923,7 +33923,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -34198,7 +34198,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -34473,7 +34473,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -34748,7 +34748,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -35023,7 +35023,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -35298,7 +35298,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -36215,7 +36215,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -36490,7 +36490,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -36765,7 +36765,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -37040,7 +37040,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -37315,7 +37315,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -37590,7 +37590,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -37865,7 +37865,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -38140,7 +38140,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -38415,7 +38415,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -38690,7 +38690,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -38965,7 +38965,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -39240,7 +39240,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -42329,7 +42329,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 47.85,
+        "tipLength": 48.06,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",
@@ -47161,7 +47161,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 47.85,
+        "tipLength": 48.06,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",
@@ -52443,7 +52443,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -53307,7 +53307,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -54171,7 +54171,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -55035,7 +55035,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -55899,7 +55899,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -56763,7 +56763,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -57627,7 +57627,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -58491,7 +58491,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -59355,7 +59355,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -60219,7 +60219,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -61083,7 +61083,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -61947,7 +61947,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -64302,7 +64302,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -64445,7 +64445,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -64588,7 +64588,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -64731,7 +64731,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -64874,7 +64874,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -65017,7 +65017,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -65160,7 +65160,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -65303,7 +65303,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -65446,7 +65446,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -65589,7 +65589,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -65732,7 +65732,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -65875,7 +65875,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -67149,7 +67149,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 47.85,
+        "tipLength": 48.06,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",
@@ -68611,7 +68611,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 47.85,
+        "tipLength": 48.06,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",
@@ -69991,7 +69991,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 47.85,
+        "tipLength": 48.06,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",
@@ -73401,7 +73401,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 47.85,
+        "tipLength": 48.06,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",
@@ -74799,7 +74799,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 47.85,
+        "tipLength": 48.06,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",
@@ -76682,7 +76682,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -76825,7 +76825,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -76968,7 +76968,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -77111,7 +77111,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -77254,7 +77254,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -77397,7 +77397,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -77540,7 +77540,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -77683,7 +77683,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -77826,7 +77826,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -77969,7 +77969,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -78112,7 +78112,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -78255,7 +78255,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -79314,7 +79314,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -79489,7 +79489,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -79664,7 +79664,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -79871,7 +79871,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -80046,7 +80046,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -80221,7 +80221,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -80428,7 +80428,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -81264,7 +81264,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 47.85,
+        "tipLength": 48.06,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",
@@ -81485,7 +81485,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 47.85,
+        "tipLength": 48.06,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",
@@ -82412,7 +82412,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 47.85,
+        "tipLength": 48.06,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",
@@ -82831,7 +82831,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 47.85,
+        "tipLength": 48.06,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",
@@ -83006,7 +83006,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 47.85,
+        "tipLength": 48.06,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",
@@ -83704,7 +83704,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 47.85,
+        "tipLength": 48.06,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",
@@ -83879,7 +83879,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 47.85,
+        "tipLength": 48.06,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",
@@ -84278,7 +84278,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 47.85,
+        "tipLength": 48.06,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",
@@ -84453,7 +84453,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 47.85,
+        "tipLength": 48.06,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",
@@ -84852,7 +84852,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 47.85,
+        "tipLength": 48.06,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",
@@ -85027,7 +85027,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 47.85,
+        "tipLength": 48.06,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",
@@ -85234,7 +85234,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 47.85,
+        "tipLength": 48.06,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",
@@ -85633,7 +85633,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 47.85,
+        "tipLength": 48.06,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",
@@ -86168,7 +86168,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -86681,7 +86681,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -87108,7 +87108,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -87315,7 +87315,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -88296,7 +88296,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 47.85,
+        "tipLength": 48.06,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",
@@ -88725,7 +88725,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 47.85,
+        "tipLength": 48.06,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",
@@ -89170,7 +89170,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 47.85,
+        "tipLength": 48.06,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",
@@ -89599,7 +89599,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 47.85,
+        "tipLength": 48.06,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",
@@ -90557,7 +90557,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[13fce6146d][Flex_S_v2_24_96_Live_SingleTip_NIR-RQA-4089].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[13fce6146d][Flex_S_v2_24_96_Live_SingleTip_NIR-RQA-4089].json
@@ -3598,7 +3598,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 47.85,
+        "tipLength": 48.015,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[1458004a84][Flex_S_v2_20_96_Reservoir].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[1458004a84][Flex_S_v2_20_96_Reservoir].json
@@ -1655,7 +1655,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 47.85,
+        "tipLength": 48.015,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[22286b71e3][Flex_S_2_7_96_partial_select_tips].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[22286b71e3][Flex_S_2_7_96_partial_select_tips].json
@@ -9348,7 +9348,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[255d014c70][Flex_X_v2_20_96_None_Overrides_TooTallLabware_Override_mix_collision].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[255d014c70][Flex_X_v2_20_96_None_Overrides_TooTallLabware_Override_mix_collision].json
@@ -2669,7 +2669,7 @@
           "z": 97.47
         },
         "tipDiameter": 7.23,
-        "tipLength": 77.5,
+        "tipLength": 77.66499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[29e143f047][Flex_X_v2_20_96_None_Overrides_TooTallLabware_Override_distribute_destination_collision].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[29e143f047][Flex_X_v2_20_96_None_Overrides_TooTallLabware_Override_distribute_destination_collision].json
@@ -3860,7 +3860,7 @@
           "z": 97.47
         },
         "tipDiameter": 7.23,
-        "tipLength": 77.5,
+        "tipLength": 77.66499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[29eec5a85a][Flex_X_v2_20_96_None_Overrides_TooTallLabware_Override_transfer_source_collision].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[29eec5a85a][Flex_X_v2_20_96_None_Overrides_TooTallLabware_Override_transfer_source_collision].json
@@ -3858,7 +3858,7 @@
           "z": 97.47
         },
         "tipDiameter": 7.23,
-        "tipLength": 77.5,
+        "tipLength": 77.66499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[2b7fcb5b23][Flex_S_v2_18_P1000_96_TipTrackingBug].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[2b7fcb5b23][Flex_S_v2_18_P1000_96_TipTrackingBug].json
@@ -2432,7 +2432,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -2508,7 +2508,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -2584,7 +2584,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -2660,7 +2660,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -2736,7 +2736,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -2812,7 +2812,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -2888,7 +2888,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -2964,7 +2964,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -3040,7 +3040,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -3116,7 +3116,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -3192,7 +3192,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -3268,7 +3268,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -3344,7 +3344,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -3438,7 +3438,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -3514,7 +3514,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -3590,7 +3590,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -3666,7 +3666,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -3742,7 +3742,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -3818,7 +3818,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -3894,7 +3894,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -3970,7 +3970,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -4046,7 +4046,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -4122,7 +4122,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -4198,7 +4198,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[2b866b03f3][Flex_S_v2_21_P1000_96_GRIP_HS_MB_TC_TM_Smoke].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[2b866b03f3][Flex_S_v2_21_P1000_96_GRIP_HS_MB_TC_TM_Smoke].json
@@ -10055,7 +10055,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -10374,7 +10374,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -10870,7 +10870,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.72399999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[2eaf98de6a][Flex_S_v2_16_P1000_96_GRIP_HS_MB_TC_TM_TriggerPrepareForMountMovement].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[2eaf98de6a][Flex_S_v2_16_P1000_96_GRIP_HS_MB_TC_TM_TriggerPrepareForMountMovement].json
@@ -8674,7 +8674,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -8851,7 +8851,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -9028,7 +9028,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -9205,7 +9205,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -9382,7 +9382,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -9559,7 +9559,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -9736,7 +9736,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -9913,7 +9913,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -10090,7 +10090,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -10267,7 +10267,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -10444,7 +10444,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -10621,7 +10621,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -10868,7 +10868,7 @@
           "z": 110.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.38999999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -11854,7 +11854,7 @@
           "z": 110.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.38999999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[30c05024e8][Flex_S_v2_20_96_None_SINGLE_4Corners50ul].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[30c05024e8][Flex_S_v2_20_96_None_SINGLE_4Corners50ul].json
@@ -1257,7 +1257,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.565,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -1473,7 +1473,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.565,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -1707,7 +1707,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.565,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -1923,7 +1923,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.565,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -2157,7 +2157,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.565,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -2373,7 +2373,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.565,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -2607,7 +2607,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.565,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -2823,7 +2823,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.565,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[31d1aec819][Flex_S_v2_20_96_None_SINGLE_HappyPathNorthSide].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[31d1aec819][Flex_S_v2_20_96_None_SINGLE_HappyPathNorthSide].json
@@ -3633,7 +3633,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -3811,7 +3811,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -3955,7 +3955,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -4177,7 +4177,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -4286,7 +4286,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -4379,7 +4379,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -7750,7 +7750,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -7928,7 +7928,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -8072,7 +8072,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -8294,7 +8294,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -8403,7 +8403,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -8496,7 +8496,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[330ee3be81][Flex_S_v2_24_96_Live_SingleTip_SLAM_FRONT_NIR].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[330ee3be81][Flex_S_v2_24_96_Live_SingleTip_SLAM_FRONT_NIR].json
@@ -3239,7 +3239,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 47.85,
+        "tipLength": 48.015,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[3cf6a3778e][Flex_S_v2_18_P1000_96_GRIP_HS_MB_TC_TM_Smoke].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[3cf6a3778e][Flex_S_v2_18_P1000_96_GRIP_HS_MB_TC_TM_Smoke].json
@@ -7484,7 +7484,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -7641,7 +7641,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -7799,7 +7799,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -7943,7 +7943,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -8087,7 +8087,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -8231,7 +8231,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -8375,7 +8375,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -8519,7 +8519,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -8663,7 +8663,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -8807,7 +8807,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -8951,7 +8951,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -9095,7 +9095,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -9298,7 +9298,7 @@
           "z": 110.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.38999999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -9652,7 +9652,7 @@
           "z": 110.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.38999999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -15261,7 +15261,7 @@
           "z": 110.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.38999999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6484e4f4e6][Flex_S_v2_16_PL_immunoprecipitation-by-dynabeads-on-flex-96ch].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6484e4f4e6][Flex_S_v2_16_PL_immunoprecipitation-by-dynabeads-on-flex-96ch].json
@@ -9180,7 +9180,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -10804,7 +10804,7 @@
           "z": 110.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.38999999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -11287,7 +11287,7 @@
           "z": 110.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.38999999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -11561,7 +11561,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -13261,7 +13261,7 @@
           "z": 110.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.38999999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -13745,7 +13745,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -15623,7 +15623,7 @@
           "z": 110.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.38999999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -16107,7 +16107,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -17985,7 +17985,7 @@
           "z": 110.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.38999999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -18469,7 +18469,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -20347,7 +20347,7 @@
           "z": 110.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.38999999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -20831,7 +20831,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6b969e303d][Flex_S_v2_24_96_Live_SingleTip_SLAM_BACK_NIR].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6b969e303d][Flex_S_v2_24_96_Live_SingleTip_SLAM_BACK_NIR].json
@@ -3239,7 +3239,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 47.85,
+        "tipLength": 48.015,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6c20d6c570][Flex_S_v2_20_96_None_COLUMN_HappyPath].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6c20d6c570][Flex_S_v2_20_96_None_COLUMN_HappyPath].json
@@ -3635,7 +3635,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -3779,7 +3779,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -3888,7 +3888,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -3981,7 +3981,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -4974,7 +4974,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -5118,7 +5118,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -5227,7 +5227,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -5320,7 +5320,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6e2f6f10c5][Flex_X_v2_20_96_None_Overrides_TooTallLabware_Override_consolidate_destination_collision].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6e2f6f10c5][Flex_X_v2_20_96_None_Overrides_TooTallLabware_Override_consolidate_destination_collision].json
@@ -3860,7 +3860,7 @@
           "z": 97.47
         },
         "tipDiameter": 7.23,
-        "tipLength": 77.5,
+        "tipLength": 77.66499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[733c9cdf62][Flex_S_v2_20_8_None_PARTIAL_COLUMN_HappyPath].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[733c9cdf62][Flex_S_v2_20_8_None_PARTIAL_COLUMN_HappyPath].json
@@ -3658,7 +3658,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 48.62,
+        "tipLength": 48.769999999999996,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -3802,7 +3802,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 48.62,
+        "tipLength": 48.769999999999996,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -3911,7 +3911,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 48.62,
+        "tipLength": 48.769999999999996,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -4004,7 +4004,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 48.62,
+        "tipLength": 48.769999999999996,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[7fddaecb11][Flex_S_v2_20_8_PARTIAL_COLUMN_Overhang].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[7fddaecb11][Flex_S_v2_20_8_PARTIAL_COLUMN_Overhang].json
@@ -2577,7 +2577,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 48.62,
+        "tipLength": 48.7,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -3560,7 +3560,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 48.62,
+        "tipLength": 48.7,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -3704,7 +3704,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 48.62,
+        "tipLength": 48.7,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -3848,7 +3848,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 48.62,
+        "tipLength": 48.7,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -3992,7 +3992,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 48.62,
+        "tipLength": 48.7,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -4214,7 +4214,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 48.62,
+        "tipLength": 48.7,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -4436,7 +4436,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 48.62,
+        "tipLength": 48.7,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -4658,7 +4658,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 48.62,
+        "tipLength": 48.7,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -4880,7 +4880,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 48.62,
+        "tipLength": 48.7,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -5058,7 +5058,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 48.62,
+        "tipLength": 48.7,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -5236,7 +5236,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 48.62,
+        "tipLength": 48.7,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[829c44a2c2][Flex_S_v2_24_96_Live_Column_NIR].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[829c44a2c2][Flex_S_v2_24_96_Live_Column_NIR].json
@@ -4532,7 +4532,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 47.85,
+        "tipLength": 48.06,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[86137c784e][Flex_S_v2_20_PL_quickr_1].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[86137c784e][Flex_S_v2_20_PL_quickr_1].json
@@ -4954,7 +4954,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 47.85,
+        "tipLength": 48.06,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",
@@ -5477,7 +5477,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 47.85,
+        "tipLength": 48.06,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",
@@ -6448,7 +6448,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 47.85,
+        "tipLength": 48.06,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",
@@ -7897,7 +7897,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 47.85,
+        "tipLength": 48.06,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",
@@ -9346,7 +9346,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 47.85,
+        "tipLength": 48.06,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",
@@ -10795,7 +10795,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 47.85,
+        "tipLength": 48.06,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",
@@ -12244,7 +12244,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 47.85,
+        "tipLength": 48.06,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",
@@ -13693,7 +13693,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 47.85,
+        "tipLength": 48.06,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[89a8226c4e][Flex_X_v2_16_P1000_96_TC_PartialTipPickupThermocyclerLidConflict].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[89a8226c4e][Flex_X_v2_16_P1000_96_TC_PartialTipPickupThermocyclerLidConflict].json
@@ -4819,7 +4819,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[8b07e799f6][Flex_X_v2_20_96_and_8_Overrides_InvalidConfigs_Override_drop_tip_with_location].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[8b07e799f6][Flex_X_v2_20_96_and_8_Overrides_InvalidConfigs_Override_drop_tip_with_location].json
@@ -3634,7 +3634,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.92999999999999,
+        "tipLength": 85.86999999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[8c903758e0][Flex_S_v2_20_PL_easypep_digest_tmt].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[8c903758e0][Flex_S_v2_20_PL_easypep_digest_tmt].json
@@ -12411,7 +12411,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 48.980000000000004,
+        "tipLength": 49.05,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",
@@ -14615,7 +14615,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 48.980000000000004,
+        "tipLength": 49.05,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",
@@ -16819,7 +16819,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 48.980000000000004,
+        "tipLength": 49.05,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",
@@ -17201,7 +17201,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 48.980000000000004,
+        "tipLength": 49.05,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",
@@ -17583,7 +17583,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 48.980000000000004,
+        "tipLength": 49.05,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",
@@ -17965,7 +17965,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 48.980000000000004,
+        "tipLength": 49.05,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",
@@ -18347,7 +18347,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 48.980000000000004,
+        "tipLength": 49.05,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",
@@ -18729,7 +18729,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 48.980000000000004,
+        "tipLength": 49.05,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",
@@ -19111,7 +19111,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 48.980000000000004,
+        "tipLength": 49.05,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",
@@ -19493,7 +19493,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 48.980000000000004,
+        "tipLength": 49.05,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",
@@ -19875,7 +19875,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 48.980000000000004,
+        "tipLength": 49.05,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",
@@ -20257,7 +20257,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 48.980000000000004,
+        "tipLength": 49.05,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",
@@ -20639,7 +20639,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 48.980000000000004,
+        "tipLength": 49.05,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",
@@ -21021,7 +21021,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 48.980000000000004,
+        "tipLength": 49.05,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",
@@ -21855,7 +21855,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 48.980000000000004,
+        "tipLength": 49.05,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",
@@ -24456,7 +24456,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 48.980000000000004,
+        "tipLength": 49.05,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",
@@ -24974,7 +24974,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 48.980000000000004,
+        "tipLength": 49.05,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",
@@ -25492,7 +25492,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 48.980000000000004,
+        "tipLength": 49.05,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",
@@ -26010,7 +26010,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 48.980000000000004,
+        "tipLength": 49.05,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",
@@ -26528,7 +26528,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 48.980000000000004,
+        "tipLength": 49.05,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",
@@ -27046,7 +27046,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 48.980000000000004,
+        "tipLength": 49.05,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",
@@ -27564,7 +27564,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 48.980000000000004,
+        "tipLength": 49.05,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",
@@ -28082,7 +28082,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 48.980000000000004,
+        "tipLength": 49.05,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",
@@ -28600,7 +28600,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 48.980000000000004,
+        "tipLength": 49.05,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",
@@ -29118,7 +29118,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 48.980000000000004,
+        "tipLength": 49.05,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",
@@ -29636,7 +29636,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 48.980000000000004,
+        "tipLength": 49.05,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",
@@ -30154,7 +30154,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 48.980000000000004,
+        "tipLength": 49.05,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",
@@ -30976,7 +30976,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 48.980000000000004,
+        "tipLength": 49.05,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[8db2d761e2][Flex_S_v2_20_8_None_SINGLE_TubeRackCollision].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[8db2d761e2][Flex_S_v2_20_8_None_SINGLE_TubeRackCollision].json
@@ -1495,7 +1495,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 48.62,
+        "tipLength": 48.379999999999995,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[8fcfd2ced0][Flex_S_v2_16_P1000_96_TC_PartialTipPickupColumn].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[8fcfd2ced0][Flex_S_v2_16_P1000_96_TC_PartialTipPickupColumn].json
@@ -3618,7 +3618,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a8528e52b4][Flex_S_v2_20_96_None_SINGLE_HappyPathSouthSide].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a8528e52b4][Flex_S_v2_20_96_None_SINGLE_HappyPathSouthSide].json
@@ -3633,7 +3633,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -3811,7 +3811,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -3955,7 +3955,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -4177,7 +4177,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -4286,7 +4286,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -4379,7 +4379,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -7750,7 +7750,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -7928,7 +7928,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -8072,7 +8072,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -8294,7 +8294,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -8403,7 +8403,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -8496,7 +8496,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[adc0621263][Flex_X_v2_16_P1000_96_TC_pipetteCollisionWithThermocyclerLid].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[adc0621263][Flex_X_v2_16_P1000_96_TC_pipetteCollisionWithThermocyclerLid].json
@@ -6085,7 +6085,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[afd5d372a9][Flex_X_v2_20_96_and_8_Overrides_InvalidConfigs_Override_return_tip_error].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[afd5d372a9][Flex_X_v2_20_96_and_8_Overrides_InvalidConfigs_Override_return_tip_error].json
@@ -3634,7 +3634,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.92999999999999,
+        "tipLength": 85.86999999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[b0ce7dde5d][Flex_X_v2_16_P1000_96_TC_PartialTipPickupTryToReturnTip].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[b0ce7dde5d][Flex_X_v2_16_P1000_96_TC_PartialTipPickupTryToReturnTip].json
@@ -3618,7 +3618,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.61,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[b2b1925b81][Flex_S_2_7_P200_96_GRIP_HS_MB_TC_TM_SmokeTestWith2Stackers].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[b2b1925b81][Flex_S_2_7_P200_96_GRIP_HS_MB_TC_TM_SmokeTestWith2Stackers].json
@@ -9839,7 +9839,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -10176,7 +10176,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -10923,7 +10923,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.72399999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -17184,7 +17184,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -18036,7 +18036,7 @@
           "z": 110.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.31,
+        "tipLength": 85.38999999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -20313,7 +20313,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -21158,7 +21158,7 @@
           "z": 110.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.26499999999999,
+        "tipLength": 85.38999999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[bc049301c1][Flex_X_v2_20_96_None_Overrides_TooTallLabware_Override_transfer_destination_collision].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[bc049301c1][Flex_X_v2_20_96_None_Overrides_TooTallLabware_Override_transfer_destination_collision].json
@@ -3860,7 +3860,7 @@
           "z": 97.47
         },
         "tipDiameter": 7.23,
-        "tipLength": 77.5,
+        "tipLength": 77.66499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c3b37eae0f][Flex_S_v2_25_P200_stacker_2].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c3b37eae0f][Flex_S_v2_25_P200_stacker_2].json
@@ -24790,7 +24790,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 48.32,
+        "tipLength": 48.745,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -24933,7 +24933,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 48.32,
+        "tipLength": 48.745,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -25076,7 +25076,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 48.32,
+        "tipLength": 48.745,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -25219,7 +25219,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 48.32,
+        "tipLength": 48.745,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -25362,7 +25362,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 48.32,
+        "tipLength": 48.745,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -25505,7 +25505,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 48.32,
+        "tipLength": 48.745,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -25666,7 +25666,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 48.32,
+        "tipLength": 48.768,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -25809,7 +25809,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 48.32,
+        "tipLength": 48.768,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -26167,7 +26167,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 48.77,
+        "tipLength": 49.075,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",
@@ -26310,7 +26310,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 48.77,
+        "tipLength": 49.075,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",
@@ -26453,7 +26453,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 48.77,
+        "tipLength": 49.075,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",
@@ -26596,7 +26596,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 48.77,
+        "tipLength": 49.075,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",
@@ -26739,7 +26739,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 48.77,
+        "tipLength": 49.075,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",
@@ -26882,7 +26882,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 48.77,
+        "tipLength": 49.075,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",
@@ -27043,7 +27043,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 48.77,
+        "tipLength": 48.943,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",
@@ -27186,7 +27186,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 48.77,
+        "tipLength": 48.943,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",
@@ -27546,7 +27546,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 48.32,
+        "tipLength": 48.745,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -27689,7 +27689,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 48.32,
+        "tipLength": 48.745,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -27832,7 +27832,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 48.32,
+        "tipLength": 48.745,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -27975,7 +27975,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 48.32,
+        "tipLength": 48.745,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -28118,7 +28118,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 48.32,
+        "tipLength": 48.745,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -28261,7 +28261,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 48.32,
+        "tipLength": 48.745,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -28422,7 +28422,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 48.32,
+        "tipLength": 48.768,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -28565,7 +28565,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 48.32,
+        "tipLength": 48.768,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -32838,7 +32838,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 48.32,
+        "tipLength": 48.745,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -33013,7 +33013,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 48.32,
+        "tipLength": 48.745,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -33188,7 +33188,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 48.32,
+        "tipLength": 48.745,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -33363,7 +33363,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 48.32,
+        "tipLength": 48.745,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -33538,7 +33538,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 48.32,
+        "tipLength": 48.745,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -33713,7 +33713,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 48.32,
+        "tipLength": 48.745,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -33906,7 +33906,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 48.32,
+        "tipLength": 48.768,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -34081,7 +34081,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 48.32,
+        "tipLength": 48.768,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -34788,7 +34788,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 48.32,
+        "tipLength": 48.745,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -34863,7 +34863,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 48.32,
+        "tipLength": 48.745,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -34938,7 +34938,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 48.32,
+        "tipLength": 48.745,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -35013,7 +35013,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 48.32,
+        "tipLength": 48.745,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -35088,7 +35088,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 48.32,
+        "tipLength": 48.745,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -35163,7 +35163,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 48.32,
+        "tipLength": 48.745,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -35256,7 +35256,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 48.32,
+        "tipLength": 48.768,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -35331,7 +35331,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 48.32,
+        "tipLength": 48.768,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -41748,7 +41748,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 48.32,
+        "tipLength": 48.745,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -42215,7 +42215,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 48.32,
+        "tipLength": 48.745,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -42682,7 +42682,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 48.32,
+        "tipLength": 48.745,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -43149,7 +43149,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 48.32,
+        "tipLength": 48.745,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -43616,7 +43616,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 48.32,
+        "tipLength": 48.745,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -44083,7 +44083,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 48.32,
+        "tipLength": 48.745,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -44568,7 +44568,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 48.32,
+        "tipLength": 48.768,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -45035,7 +45035,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 48.32,
+        "tipLength": 48.768,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c6a3e46457][Flex_S_v2_24_96_Live_SingleTip_All_NIR].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c6a3e46457][Flex_S_v2_24_96_Live_SingleTip_All_NIR].json
@@ -3598,7 +3598,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 47.85,
+        "tipLength": 48.015,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[cc26c104b4][Flex_S_v2_20_8_None_SINGLE_HappyPath].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[cc26c104b4][Flex_S_v2_20_8_None_SINGLE_HappyPath].json
@@ -3656,7 +3656,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 48.62,
+        "tipLength": 47.82,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -3834,7 +3834,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 48.62,
+        "tipLength": 47.82,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -3978,7 +3978,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 48.62,
+        "tipLength": 47.82,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -4200,7 +4200,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 48.62,
+        "tipLength": 47.82,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -4309,7 +4309,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 48.62,
+        "tipLength": 47.82,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -4402,7 +4402,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 48.62,
+        "tipLength": 47.82,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -5395,7 +5395,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 48.62,
+        "tipLength": 48.379999999999995,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -5573,7 +5573,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 48.62,
+        "tipLength": 48.379999999999995,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -5717,7 +5717,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 48.62,
+        "tipLength": 48.379999999999995,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -5939,7 +5939,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 48.62,
+        "tipLength": 48.379999999999995,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -6048,7 +6048,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 48.62,
+        "tipLength": 48.379999999999995,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",
@@ -6141,7 +6141,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 48.62,
+        "tipLength": 48.379999999999995,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[d20f34f45f][Flex_S_v2_24_96_Live_Row_NIR].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[d20f34f45f][Flex_S_v2_24_96_Live_Row_NIR].json
@@ -4161,7 +4161,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.59,
-        "tipLength": 47.85,
+        "tipLength": 48.971000000000004,
         "tipVolume": 200.0
       },
       "startedAt": "TIMESTAMP",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[dabb7872d8][Flex_S_v2_19_P1000_96_GRIP_HS_MB_TC_TM_Smoke].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[dabb7872d8][Flex_S_v2_19_P1000_96_GRIP_HS_MB_TC_TM_Smoke].json
@@ -7484,7 +7484,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -7641,7 +7641,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -7799,7 +7799,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -7943,7 +7943,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -8087,7 +8087,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -8231,7 +8231,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -8375,7 +8375,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -8519,7 +8519,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -8663,7 +8663,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -8807,7 +8807,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -8951,7 +8951,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -9095,7 +9095,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[e59e0e10a3][Flex_S_v2_20_96_None_SINGLE_TubeRackCollision].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[e59e0e10a3][Flex_S_v2_20_96_None_SINGLE_TubeRackCollision].json
@@ -1495,7 +1495,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.58,
-        "tipLength": 47.4,
+        "tipLength": 47.565,
         "tipVolume": 50.0
       },
       "startedAt": "TIMESTAMP",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[e8f451df45][Flex_S_v2_20_96_None_Column3_SINGLE_].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[e8f451df45][Flex_S_v2_20_96_None_Column3_SINGLE_].json
@@ -4788,7 +4788,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -4864,7 +4864,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -4940,7 +4940,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -5034,7 +5034,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -5110,7 +5110,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -5186,7 +5186,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -5404,7 +5404,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -5480,7 +5480,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -5556,7 +5556,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -5632,7 +5632,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -5708,7 +5708,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -5784,7 +5784,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -5860,7 +5860,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -5936,7 +5936,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -6012,7 +6012,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -6088,7 +6088,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -6164,7 +6164,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -6240,7 +6240,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -6316,7 +6316,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -6392,7 +6392,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -6468,7 +6468,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -6544,7 +6544,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -6620,7 +6620,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -6696,7 +6696,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -6772,7 +6772,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -6848,7 +6848,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -6924,7 +6924,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -7000,7 +7000,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -7076,7 +7076,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -7152,7 +7152,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -7228,7 +7228,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -7304,7 +7304,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -7380,7 +7380,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -7456,7 +7456,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -7532,7 +7532,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -7608,7 +7608,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -7684,7 +7684,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -7760,7 +7760,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -7836,7 +7836,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -7912,7 +7912,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -7988,7 +7988,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -8064,7 +8064,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -8140,7 +8140,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -8216,7 +8216,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -8292,7 +8292,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -8368,7 +8368,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -8444,7 +8444,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -8520,7 +8520,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -8596,7 +8596,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -8672,7 +8672,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -8748,7 +8748,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -8824,7 +8824,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -8900,7 +8900,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -8976,7 +8976,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -9052,7 +9052,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -9128,7 +9128,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -9204,7 +9204,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -9280,7 +9280,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -9356,7 +9356,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -9432,7 +9432,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -9508,7 +9508,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -9584,7 +9584,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -9660,7 +9660,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -9736,7 +9736,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -9812,7 +9812,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -9888,7 +9888,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -9964,7 +9964,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -10040,7 +10040,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -10116,7 +10116,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -10192,7 +10192,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -10268,7 +10268,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -10344,7 +10344,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -10420,7 +10420,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -10496,7 +10496,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -10572,7 +10572,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -10648,7 +10648,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -10724,7 +10724,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -10800,7 +10800,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -10876,7 +10876,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -10952,7 +10952,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -11028,7 +11028,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -11104,7 +11104,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -11180,7 +11180,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -11256,7 +11256,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -11332,7 +11332,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -11408,7 +11408,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -11484,7 +11484,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -11560,7 +11560,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -11636,7 +11636,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -11712,7 +11712,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -11788,7 +11788,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -11864,7 +11864,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -11940,7 +11940,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -12016,7 +12016,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -12092,7 +12092,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -12168,7 +12168,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -12244,7 +12244,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -12320,7 +12320,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -12396,7 +12396,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -12472,7 +12472,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -12548,7 +12548,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -12624,7 +12624,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -12700,7 +12700,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -12776,7 +12776,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -12852,7 +12852,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -12928,7 +12928,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -13004,7 +13004,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -13080,7 +13080,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -13156,7 +13156,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -13232,7 +13232,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -13308,7 +13308,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -13384,7 +13384,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -13460,7 +13460,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -13536,7 +13536,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -13612,7 +13612,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -13688,7 +13688,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -13764,7 +13764,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -13840,7 +13840,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -13916,7 +13916,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -13992,7 +13992,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -14068,7 +14068,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -14144,7 +14144,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -14220,7 +14220,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -14296,7 +14296,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -14372,7 +14372,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -14448,7 +14448,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -14524,7 +14524,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -14600,7 +14600,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -14676,7 +14676,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -14752,7 +14752,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -14828,7 +14828,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -14904,7 +14904,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -14980,7 +14980,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -15056,7 +15056,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -15132,7 +15132,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -15208,7 +15208,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -15284,7 +15284,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -15360,7 +15360,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -15436,7 +15436,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -15512,7 +15512,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -15588,7 +15588,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -15664,7 +15664,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -15740,7 +15740,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -15816,7 +15816,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -15892,7 +15892,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -15968,7 +15968,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -16044,7 +16044,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -16120,7 +16120,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -16196,7 +16196,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -16272,7 +16272,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -16486,7 +16486,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -16562,7 +16562,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -16638,7 +16638,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -16732,7 +16732,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.72999999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -16808,7 +16808,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.72999999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -16884,7 +16884,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.72999999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -16978,7 +16978,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -17054,7 +17054,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -17130,7 +17130,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -17206,7 +17206,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -17282,7 +17282,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -17358,7 +17358,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -17434,7 +17434,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -17510,7 +17510,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -17586,7 +17586,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -17662,7 +17662,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -17738,7 +17738,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -17814,7 +17814,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -17890,7 +17890,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -17966,7 +17966,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -18042,7 +18042,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -18260,7 +18260,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -18336,7 +18336,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -18412,7 +18412,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -18488,7 +18488,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -18564,7 +18564,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -18640,7 +18640,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -18716,7 +18716,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -18792,7 +18792,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -18868,7 +18868,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -18944,7 +18944,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -19020,7 +19020,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -19096,7 +19096,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -19172,7 +19172,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -19248,7 +19248,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -19324,7 +19324,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -19400,7 +19400,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -19476,7 +19476,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -19552,7 +19552,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -19628,7 +19628,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -19704,7 +19704,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -19780,7 +19780,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -19856,7 +19856,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -19932,7 +19932,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -20008,7 +20008,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -20084,7 +20084,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -20160,7 +20160,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -20236,7 +20236,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -20312,7 +20312,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -20388,7 +20388,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -20464,7 +20464,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -20540,7 +20540,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -20616,7 +20616,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -20692,7 +20692,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -20768,7 +20768,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -20844,7 +20844,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -20920,7 +20920,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -20996,7 +20996,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -21072,7 +21072,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -21148,7 +21148,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -21224,7 +21224,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -21300,7 +21300,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -21376,7 +21376,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -21452,7 +21452,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -21528,7 +21528,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -21604,7 +21604,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -21680,7 +21680,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -21756,7 +21756,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -21832,7 +21832,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -21908,7 +21908,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -21984,7 +21984,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -22060,7 +22060,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -22136,7 +22136,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -22212,7 +22212,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -22288,7 +22288,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -22364,7 +22364,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -22440,7 +22440,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -22516,7 +22516,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -22592,7 +22592,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -22668,7 +22668,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -22744,7 +22744,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -22820,7 +22820,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -22896,7 +22896,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -22972,7 +22972,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -23048,7 +23048,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -23124,7 +23124,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -23200,7 +23200,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -23276,7 +23276,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -23352,7 +23352,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -23428,7 +23428,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -23504,7 +23504,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -23580,7 +23580,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -23656,7 +23656,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -23732,7 +23732,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -23808,7 +23808,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -23884,7 +23884,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -23960,7 +23960,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -24036,7 +24036,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -24112,7 +24112,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -24188,7 +24188,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -24264,7 +24264,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -24340,7 +24340,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -24416,7 +24416,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -24492,7 +24492,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -24568,7 +24568,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -24644,7 +24644,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -24720,7 +24720,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -24796,7 +24796,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -24872,7 +24872,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -24948,7 +24948,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -25024,7 +25024,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -25100,7 +25100,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -25176,7 +25176,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -25252,7 +25252,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -25328,7 +25328,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -25404,7 +25404,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -25480,7 +25480,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -25556,7 +25556,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -25632,7 +25632,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -25708,7 +25708,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -25784,7 +25784,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -25860,7 +25860,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -25936,7 +25936,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -26012,7 +26012,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -26088,7 +26088,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -26164,7 +26164,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -26240,7 +26240,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -26316,7 +26316,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -26392,7 +26392,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -26468,7 +26468,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -26544,7 +26544,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -26620,7 +26620,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -26696,7 +26696,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -26772,7 +26772,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -26848,7 +26848,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -26924,7 +26924,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -27000,7 +27000,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -27076,7 +27076,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.38999999999999,
+        "tipLength": 85.26499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[ed26635ff7][Flex_X_v2_20_96_None_Overrides_TooTallLabware_Override_consolidate_source_collision].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[ed26635ff7][Flex_X_v2_20_96_None_Overrides_TooTallLabware_Override_consolidate_source_collision].json
@@ -3858,7 +3858,7 @@
           "z": 97.47
         },
         "tipDiameter": 7.23,
-        "tipLength": 77.5,
+        "tipLength": 77.66499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f51172f73b][Flex_S_v2_16_P1000_96_GRIP_HS_MB_TC_TM_Smoke].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f51172f73b][Flex_S_v2_16_P1000_96_GRIP_HS_MB_TC_TM_Smoke].json
@@ -7484,7 +7484,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -7628,7 +7628,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -7772,7 +7772,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -7916,7 +7916,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -8060,7 +8060,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -8204,7 +8204,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -8348,7 +8348,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -8492,7 +8492,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -8636,7 +8636,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -8780,7 +8780,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -8924,7 +8924,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -9068,7 +9068,7 @@
           "z": 99.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.31,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -9282,7 +9282,7 @@
           "z": 110.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.38999999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",
@@ -10158,7 +10158,7 @@
           "z": 110.0
         },
         "tipDiameter": 5.47,
-        "tipLength": 85.1,
+        "tipLength": 85.38999999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f86713b4d4][Flex_X_v2_20_96_None_Overrides_TooTallLabware_Override_distribute_source_collision].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f86713b4d4][Flex_X_v2_20_96_None_Overrides_TooTallLabware_Override_distribute_source_collision].json
@@ -3858,7 +3858,7 @@
           "z": 97.47
         },
         "tipDiameter": 7.23,
-        "tipLength": 77.5,
+        "tipLength": 77.66499999999999,
         "tipVolume": 1000.0
       },
       "startedAt": "TIMESTAMP",

--- a/api/src/opentrons/hardware_control/instruments/ot3/pipette.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/pipette.py
@@ -489,6 +489,9 @@ class Pipette(AbstractInstrument[PipetteConfigurations]):
         self._nozzle_manager.update_nozzle_configuration(
             back_left_nozzle, front_right_nozzle, starting_nozzle
         )
+        self._versioned_tip_overlap_dictionary = (
+            self.get_nominal_tip_overlap_dictionary_by_configuration()
+        )
 
     def reset_nozzle_configuration(self) -> None:
         """

--- a/api/src/opentrons/protocol_engine/commands/configure_nozzle_layout.py
+++ b/api/src/opentrons/protocol_engine/commands/configure_nozzle_layout.py
@@ -75,14 +75,19 @@ class ConfigureNozzleLayoutImplementation(
             back_left_nozzle=back_left_nozzle,
         )
 
-        nozzle_map = await self._equipment.configure_nozzle_layout(
+        pipette_result = await self._equipment.configure_nozzle_layout(
             pipette_id=params.pipetteId,
             **nozzle_params,
         )
 
         update_state = StateUpdate()
         update_state.update_pipette_nozzle(
-            pipette_id=params.pipetteId, nozzle_map=nozzle_map
+            pipette_id=params.pipetteId, nozzle_map=pipette_result.nozzle_map
+        )
+        update_state.update_pipette_config(
+            pipette_id=pipette_result.pipette_id,
+            config=pipette_result.static_config,
+            serial_number=pipette_result.serial_number,
         )
 
         return SuccessData(

--- a/api/src/opentrons/protocol_engine/execution/__init__.py
+++ b/api/src/opentrons/protocol_engine/execution/__init__.py
@@ -9,6 +9,7 @@ from .equipment import (
     LoadedModuleData,
     LoadedConfigureForVolumeData,
     ReloadedLabwareData,
+    LoadedConfigureNozzleLayoutData,
 )
 from .movement import MovementHandler
 from .gantry_mover import GantryMover
@@ -37,6 +38,7 @@ __all__ = [
     "LoadedPipetteData",
     "LoadedModuleData",
     "LoadedConfigureForVolumeData",
+    "LoadedConfigureNozzleLayoutData",
     "MovementHandler",
     "GantryMover",
     "PipettingHandler",

--- a/api/src/opentrons/protocol_engine/execution/equipment.py
+++ b/api/src/opentrons/protocol_engine/execution/equipment.py
@@ -105,6 +105,15 @@ class LoadedLabwarePoolData:
     adapter_labware: Optional[LoadedLabware] = None
     lid_labware: Optional[LoadedLabware] = None
 
+@dataclass(frozen=True)
+class LoadedConfigureNozzleLayoutData:
+    """The result of a configure nozzle layout."""
+
+    pipette_id: str
+    serial_number: str
+    nozzle_map: NozzleMap
+    static_config: pipette_data_provider.LoadedStaticPipetteData
+
 
 class EquipmentHandler:
     """Implementation logic for labware, pipette, and module loading."""
@@ -679,7 +688,8 @@ class EquipmentHandler:
         primary_nozzle: Optional[str] = None,
         front_right_nozzle: Optional[str] = None,
         back_left_nozzle: Optional[str] = None,
-    ) -> NozzleMap:
+        tip_overlap_version: Optional[str] = None,
+    ) -> LoadedConfigureNozzleLayoutData:
         """Ensure the requested nozzle layout is compatible with the current pipette.
 
         Args:
@@ -689,9 +699,14 @@ class EquipmentHandler:
             back_left_nozzle: The physically back left nozzle.
 
         Returns:
-            A NozzleMap object or None.
+            A LoadedConfigureNozzleLayoutData object or None.
         """
         use_virtual_pipettes = self._state_store.config.use_virtual_pipettes
+        sanitized_overlap_version = (
+            pipette_data_provider.validate_and_default_tip_overlap_version(
+                tip_overlap_version
+            )
+        )
 
         if not use_virtual_pipettes:
             mount = self._state_store.pipettes.get_mount(pipette_id).to_hw_mount()
@@ -704,6 +719,10 @@ class EquipmentHandler:
             )
             pipette_dict = self._hardware_api.get_attached_instrument(mount)
             nozzle_map = pipette_dict["current_nozzle_map"]
+            serial_number = pipette_dict["pipette_id"]
+            static_pipette_config = pipette_data_provider.get_pipette_static_config(
+                pipette_dict=pipette_dict, tip_overlap_version=sanitized_overlap_version
+            )
 
         else:
             model = self._state_store.pipettes.get_model_name(pipette_id)
@@ -719,8 +738,19 @@ class EquipmentHandler:
                     pipette_id
                 )
             )
+            static_pipette_config = self._virtual_pipette_data_provider.get_virtual_pipette_static_config_by_model_string(
+                pipette_model_string=model,
+                pipette_id=pipette_id,
+                tip_overlap_version=sanitized_overlap_version,
+            )
+            serial_number = self._model_utils.generate_id(prefix="fake-serial-number-")
 
-        return nozzle_map
+        return LoadedConfigureNozzleLayoutData(
+            pipette_id=pipette_id,
+            serial_number=serial_number,
+            static_config=static_pipette_config,
+            nozzle_map=nozzle_map,
+        )
 
     @overload
     def get_module_hardware_api(

--- a/api/src/opentrons/protocol_engine/execution/equipment.py
+++ b/api/src/opentrons/protocol_engine/execution/equipment.py
@@ -105,6 +105,7 @@ class LoadedLabwarePoolData:
     adapter_labware: Optional[LoadedLabware] = None
     lid_labware: Optional[LoadedLabware] = None
 
+
 @dataclass(frozen=True)
 class LoadedConfigureNozzleLayoutData:
     """The result of a configure nozzle layout."""

--- a/api/src/opentrons/protocol_engine/execution/equipment.py
+++ b/api/src/opentrons/protocol_engine/execution/equipment.py
@@ -698,6 +698,7 @@ class EquipmentHandler:
             primary_nozzle: The nozzle which will be used as the main nozzle for positioning.
             front_right_nozzle: The physically front right nozzle.
             back_left_nozzle: The physically back left nozzle.
+            tip_overlap_version: maximum tip overlap version.
 
         Returns:
             A LoadedConfigureNozzleLayoutData object or None.

--- a/api/tests/opentrons/protocol_engine/commands/test_configure_nozzle_layout.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_configure_nozzle_layout.py
@@ -12,6 +12,7 @@ from collections import OrderedDict
 from opentrons.protocol_engine.execution import (
     EquipmentHandler,
     TipHandler,
+    LoadedConfigureNozzleLayoutData,
 )
 from opentrons.types import Point
 from opentrons.hardware_control.nozzle_manager import NozzleMap
@@ -22,6 +23,18 @@ from opentrons.protocol_engine.commands.configure_nozzle_layout import (
     ConfigureNozzleLayoutResult,
     ConfigureNozzleLayoutImplementation,
 )
+
+from opentrons.protocol_engine.resources.pipette_data_provider import (
+    LoadedStaticPipetteData,
+)
+from opentrons_shared_data.pipette.types import (
+    PipetteNameType,
+    LiquidClasses as VolumeModes,
+)
+from opentrons.protocol_engine.types import FlowRates
+import opentrons.protocol_engine.state.update_types as update_types
+from opentrons_shared_data.pipette.pipette_definition import AvailableSensorDefinition
+from ..pipette_fixtures import get_default_nozzle_map
 
 from opentrons.protocol_engine.types import (
     AllNozzleLayoutConfiguration,
@@ -35,6 +48,12 @@ from ..pipette_fixtures import (
     NINETY_SIX_COLS,
     NINETY_SIX_ROWS,
 )
+
+
+@pytest.fixture
+def available_sensors() -> AvailableSensorDefinition:
+    """Provide a list of sensors."""
+    return AvailableSensorDefinition(sensors=["pressure", "capacitive", "environment"])
 
 
 @pytest.mark.parametrize(
@@ -91,6 +110,7 @@ async def test_configure_nozzle_layout_implementation(
     decoy: Decoy,
     equipment: EquipmentHandler,
     tip_handler: TipHandler,
+    available_sensors: AvailableSensorDefinition,
     request_model: Union[
         AllNozzleLayoutConfiguration,
         ColumnNozzleLayoutConfiguration,
@@ -103,6 +123,35 @@ async def test_configure_nozzle_layout_implementation(
     """A ConfigureForVolume command should have an execution implementation."""
     subject = ConfigureNozzleLayoutImplementation(
         equipment=equipment, tip_handler=tip_handler
+    )
+
+    config = LoadedStaticPipetteData(
+        model="some-model",
+        display_name="Hello",
+        min_volume=0,
+        max_volume=251,
+        channels=8,
+        home_position=123.1,
+        nozzle_offset_z=331.0,
+        flow_rates=FlowRates(
+            default_aspirate={}, default_dispense={}, default_blow_out={}
+        ),
+        tip_configuration_lookup_table={},
+        nominal_tip_overlap={},
+        nozzle_map=get_default_nozzle_map(PipetteNameType.P300_MULTI),
+        back_left_corner_offset=Point(10, 20, 30),
+        front_right_corner_offset=Point(40, 50, 60),
+        pipette_lld_settings={},
+        plunger_positions={
+            "top": 0.0,
+            "bottom": 5.0,
+            "blow_out": 19.0,
+            "drop_tip": 20.0,
+        },
+        shaft_ul_per_mm=5.0,
+        available_sensors=available_sensors,
+        volume_mode=VolumeModes.lowVolumeDefault,
+        available_volume_modes_min_vol={},
     )
 
     requested_nozzle_layout = ConfigureNozzleLayoutParams(
@@ -140,7 +189,14 @@ async def test_configure_nozzle_layout_implementation(
             pipette_id="pipette-id",
             **nozzle_params,
         )
-    ).then_return(expected_nozzlemap)
+    ).then_return(
+        LoadedConfigureNozzleLayoutData(
+            pipette_id="pipette-id",
+            serial_number="some number",
+            nozzle_map=expected_nozzlemap,
+            static_config=config,
+        )
+    )
 
     result = await subject.execute(requested_nozzle_layout)
 
@@ -150,6 +206,9 @@ async def test_configure_nozzle_layout_implementation(
             pipette_nozzle_map=PipetteNozzleMapUpdate(
                 pipette_id="pipette-id",
                 nozzle_map=expected_nozzlemap,
-            )
+            ),
+            pipette_config=update_types.PipetteConfigUpdate(
+                pipette_id="pipette-id", serial_number="some number", config=config
+            ),
         ),
     )


### PR DESCRIPTION
# Overview
Configure for nozzle previously only updated the nozzle map and did not automatically switch over to the correct nozzle overlap value. 
Now the protocol engine execution updates the pipette static config to refresh the overlap value when a configure nozzle command is executed.

No good way to test this in QA since the physically differences we're talking about are fractions of a mm so the only place this really shows up is in the high res gravimetric tests.
