### PR TITLE
fix(step-generation): load labware on shuttle correctly in generated py

### DIFF
--- a/app/src/organisms/ODD/QuickTransferFlow/utils/pythonDef.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/utils/pythonDef.ts
@@ -110,10 +110,10 @@ export function pythonDef(
     wasteChuteEntities,
     trashBinEntities,
   } = invariantContext
-  const { labware, pipettes } = initialRobotState
+  const { modules, labware, pipettes } = initialRobotState
   const sections: string[] = [
     getLoadAdapters(moduleEntities, labwareEntities, labware),
-    getLoadLabware(moduleEntities, labwareEntities, labware, {}),
+    getLoadLabware(modules, moduleEntities, labwareEntities, labware, {}),
     getLoadPipettes(pipetteEntities, pipettes),
     ...[
       getLoadTrashBins(trashBinEntities),

--- a/step-generation/src/utils/__tests__/pythonFileUtils.test.ts
+++ b/step-generation/src/utils/__tests__/pythonFileUtils.test.ts
@@ -334,6 +334,7 @@ describe('getLoadLabware', () => {
   it('should generate load_labware for 3 labware with a lid on the first one', () => {
     expect(
       getLoadLabware(
+        {},
         mockModuleEntities,
         mockLabwareEntities,
         labwareRobotState,
@@ -364,10 +365,51 @@ well_plate_3 = protocol.load_labware_from_definition(
     )
   })
 
+  it('should generate load_labware for 1 labware on the stacker shuttle', () => {
+    expect(
+      getLoadLabware(
+        {
+          [moduleId]: {
+            moduleState: { type: FLEX_STACKER_MODULE_TYPE } as any,
+            slot: 'B2',
+          },
+        },
+        {
+          [moduleId]: {
+            id: moduleId,
+            model: FLEX_STACKER_MODULE_V1,
+            type: FLEX_STACKER_MODULE_TYPE,
+            pythonName: 'flex_stacker_1',
+          },
+        },
+        {
+          [labwareId1]: {
+            id: labwareId1,
+            labwareDefURI: 'opentrons/fixture_96_plate/1',
+            def: opentrons96Plate,
+            pythonName: 'well_plate_1',
+          },
+        },
+        { [labwareId1]: { stack: [labwareId1, 'B2'] } },
+        mockLabwareNicknames
+      )
+    ).toBe(
+      `
+# Load Labware:
+well_plate_1 = flex_stacker_1.load_labware(
+    "fixture_96_plate",
+    label="Fixture Flex 96 Tip Rack Adapter",
+    namespace="opentrons",
+    version=1,
+)`.trimStart()
+    )
+  })
+
   describe('getLoadLabware off-deck', () => {
     it('should generate loadLabware for off-deck', () => {
       expect(
         getLoadLabware(
+          {},
           {},
           {
             plateId: {
@@ -402,6 +444,7 @@ well_plate_5 = protocol.load_labware(
     }
     expect(
       getLoadLabware(
+        {},
         mockModuleEntities,
         mockLabwareEntities,
         labwareRobotStateWithLids,

--- a/step-generation/src/utils/pythonFileUtils.ts
+++ b/step-generation/src/utils/pythonFileUtils.ts
@@ -267,6 +267,7 @@ const getFormatLidParams = (def: LabwareDefinition2): string[] => {
 }
 
 export function getLoadLabware(
+  moduleRobotState: TimelineFrame['modules'],
   moduleEntities: ModuleEntities,
   allLabwareEntities: LabwareEntities,
   labwareRobotState: TimelineFrame['labware'],
@@ -296,7 +297,15 @@ export function getLoadLabware(
       )
       // 2nd item in stack is the slot the labware is on
       const labwareSlot = labwareRobotState[id].stack[1]
-      const onModule = moduleEntities[labwareSlot] != null
+      // this is the deck slot that the labware is on
+      const deckSlot = getSlotInLocationStack(labwareRobotState[id].stack)
+      const stackerOnSlot = Object.entries(moduleRobotState).find(
+        ([id, module]) =>
+          module.slot === deckSlot &&
+          module.moduleState.type === FLEX_STACKER_MODULE_TYPE
+      )
+      const onModule =
+        moduleEntities[labwareSlot] != null || deckSlot === stackerOnSlot?.[1].slot // special case stacker shuttle labware
       const onLabware = allLabwareEntities[labwareSlot] != null
 
       let parentName: string
@@ -304,7 +313,8 @@ export function getLoadLabware(
       if (onLabware && !isLabwareOnHopper) {
         parentName = allLabwareEntities[labwareSlot].pythonName
       } else if (onModule) {
-        parentName = moduleEntities[labwareSlot].pythonName
+        const moduleId = stackerOnSlot != null ? stackerOnSlot?.[0] : labwareSlot
+        parentName = moduleEntities[moduleId].pythonName
       } else {
         parentName = PROTOCOL_CONTEXT_NAME
         locationArg = `location=${
@@ -569,6 +579,7 @@ export function pythonDefRun(
     getLoadAdapters(moduleEntities, labwareEntities, labware),
     getLoadLidStacks(labwareEntities, labware),
     getLoadLabware(
+      modules,
       moduleEntities,
       labwareEntities,
       labware,

--- a/step-generation/src/utils/pythonFileUtils.ts
+++ b/step-generation/src/utils/pythonFileUtils.ts
@@ -305,7 +305,8 @@ export function getLoadLabware(
           module.moduleState.type === FLEX_STACKER_MODULE_TYPE
       )
       const onModule =
-        moduleEntities[labwareSlot] != null || deckSlot === stackerOnSlot?.[1].slot // special case stacker shuttle labware
+        moduleEntities[labwareSlot] != null ||
+        deckSlot === stackerOnSlot?.[1].slot // special case stacker shuttle labware
       const onLabware = allLabwareEntities[labwareSlot] != null
 
       let parentName: string
@@ -313,7 +314,8 @@ export function getLoadLabware(
       if (onLabware && !isLabwareOnHopper) {
         parentName = allLabwareEntities[labwareSlot].pythonName
       } else if (onModule) {
-        const moduleId = stackerOnSlot != null ? stackerOnSlot?.[0] : labwareSlot
+        const moduleId =
+          stackerOnSlot != null ? stackerOnSlot?.[0] : labwareSlot
         parentName = moduleEntities[moduleId].pythonName
       } else {
         parentName = PROTOCOL_CONTEXT_NAME


### PR DESCRIPTION
# Overview

load labware correctly on the shuttle by loading the labware on the flex stacker python name

## Test Plan and Hands on Testing

review code and smoke test. i also added a test case

## Changelog

add a case for if the labware is on the shuttle - it doesn't have the moduleId in the stack like other labware on the modules. so we had to special case.

## Risk assessment

low