### PR TITLE
feat(api): raise error for untouchable labware

### DIFF
--- a/api/src/opentrons/hardware_control/instruments/ot2/pipette.py
+++ b/api/src/opentrons/hardware_control/instruments/ot2/pipette.py
@@ -1,5 +1,5 @@
-""" Classes and functions for pipette state tracking
-"""
+"""Classes and functions for pipette state tracking"""
+
 from __future__ import annotations
 
 import functools

--- a/api/src/opentrons/hardware_control/instruments/ot3/gripper.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/gripper.py
@@ -1,5 +1,5 @@
-""" Classes and functions for gripper state tracking
-"""
+"""Classes and functions for gripper state tracking"""
+
 from __future__ import annotations
 
 import logging

--- a/api/src/opentrons/protocol_api/core/engine/transfer_components_executor.py
+++ b/api/src/opentrons/protocol_api/core/engine/transfer_components_executor.py
@@ -585,6 +585,7 @@ class TransferComponentsExecutor:
                 )
                 touch_tip_and_air_gap_well = source_well
                 # Skip touch tip if blowing out at the SOURCE and it's untouchable:
+                # Q (spp, 2026-01-05): should we raise an error like we're doing in touch_tip() now?
                 if (
                     "touchTipDisabled"
                     in source_location.labware.quirks_from_any_parent()
@@ -786,6 +787,7 @@ class TransferComponentsExecutor:
                 )
                 touch_tip_and_air_gap_well = source_well
                 # Skip touch tip if blowing out at the SOURCE and it's untouchable:
+                # Q (spp, 2026-01-05): should we raise an error like we're doing in touch_tip() now? 
                 if (
                     "touchTipDisabled"
                     in source_location.labware.quirks_from_any_parent()

--- a/api/src/opentrons/protocol_api/core/engine/transfer_components_executor.py
+++ b/api/src/opentrons/protocol_api/core/engine/transfer_components_executor.py
@@ -787,7 +787,7 @@ class TransferComponentsExecutor:
                 )
                 touch_tip_and_air_gap_well = source_well
                 # Skip touch tip if blowing out at the SOURCE and it's untouchable:
-                # Q (spp, 2026-01-05): should we raise an error like we're doing in touch_tip() now? 
+                # Q (spp, 2026-01-05): should we raise an error like we're doing in touch_tip() now?
                 if (
                     "touchTipDisabled"
                     in source_location.labware.quirks_from_any_parent()

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1246,8 +1246,12 @@ class InstrumentContext(publisher.CommandPublisher):
                 )
 
         if "touchTipDisabled" in parent_labware.quirks:
-            _log.info(f"Ignoring touch tip on labware {well}")
-            return self
+            if self.api_version < APIVersion(2, 28):
+                _log.info(f"Ignoring touch tip on labware {well}")
+                return self
+            raise RuntimeError(
+                f"Touch tip not allowed on labware {parent_labware.name}"
+            )
         if parent_labware.is_tiprack:
             _log.warning(
                 "Touch_tip being performed on a tiprack. Please re-check your code"

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1202,11 +1202,15 @@ class InstrumentContext(publisher.CommandPublisher):
                               ``None``. This should happen if ``touch_tip`` is called
                               without first calling a method that takes a location, like
                               :py:meth:`.aspirate` or :py:meth:`dispense`.
+                              Also raises RuntimeError if location is in a labware with
+                              `touchTipDisabled` quirk.
         :raises: ValueError: If both ``mm_from_edge`` and ``radius`` are specified.
         :returns: This instance.
 
         .. versionchanged:: 2.24
                 Added the ``mm_from_edge`` parameter.
+        .. versionchanged:: 2.28
+                Raises error if touching tip on a labware with `touchTipDisabled` quirk.
         """
         if not self._core.has_tip():
             raise UnexpectedTipRemovalError("touch_tip", self.name, self.mount)

--- a/api/src/opentrons/protocol_api/validation.py
+++ b/api/src/opentrons/protocol_api/validation.py
@@ -202,7 +202,7 @@ def _check_ot2_axis_type(
             )
     if robot_type == "OT-2 Standard" and isinstance(axis_map_keys[0], str):
         if any(
-            k.upper() not in [axis.value for axis in AxisType.ot2_axes()]   # type: ignore [union-attr]
+            k.upper() not in [axis.value for axis in AxisType.ot2_axes()]  # type: ignore [union-attr]
             for k in axis_map_keys
         ):
             raise IncorrectAxisError(

--- a/api/src/opentrons/protocol_engine/clients/sync_client.py
+++ b/api/src/opentrons/protocol_engine/clients/sync_client.py
@@ -189,7 +189,7 @@ class SyncClient:
         self, name: str, color: Optional[str], description: Optional[str]
     ) -> Liquid:
         """Add a liquid to the engine."""
-        return self._transport.call_method(   # type: ignore[no-any-return]
+        return self._transport.call_method(  # type: ignore[no-any-return]
             "add_liquid", name=name, color=color, description=description
         )
 

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -79,7 +79,7 @@ from opentrons_shared_data.liquid_classes.liquid_class_definition import (
     LiquidClassSchemaV1,
 )
 from opentrons_shared_data.robot.types import RobotType
-from . import versions_at_or_above, versions_between
+from . import versions_at_or_above, versions_between, versions_below
 
 
 @pytest.fixture(autouse=True)
@@ -1710,6 +1710,49 @@ def test_touch_tip_raises_if_trash_last_location(
     decoy.when(mock_protocol_core.get_last_location()).then_return(mock_chute)
     with pytest.raises(RuntimeError, match="not valid for touch tip"):
         subject.touch_tip()
+
+
+@pytest.mark.parametrize("api_version", versions_below(APIVersion(2, 28), False))
+def test_touch_tip_noops_for_older_api_if_labware_is_untouchable(
+    decoy: Decoy,
+    mock_instrument_core: InstrumentCore,
+    subject: InstrumentContext,
+    mock_protocol_core: ProtocolCore,
+) -> None:
+    """It should no-op for labware with `touchTipDisabled` quirk for older API versions."""
+    mock_well = decoy.mock(cls=Well)
+    decoy.when(mock_instrument_core.has_tip()).then_return(True)
+    decoy.when(mock_well.parent.quirks).then_return(["touchTipDisabled"])
+    decoy.when(mock_well.top(z=4.56)).then_return(
+        Location(point=Point(1, 2, 3), labware=mock_well)
+    )
+    subject.touch_tip(mock_well, v_offset=4.56, speed=42.0)
+    decoy.verify(
+        mock_instrument_core.touch_tip(
+            location=Location(point=Point(1, 2, 3), labware=mock_well),
+            well_core=mock_well._core,
+            radius=1,
+            z_offset=4.56,
+            speed=42.0,
+        ),
+        times=0,
+    )
+
+
+@pytest.mark.parametrize("api_version", versions_at_or_above(APIVersion(2, 28)))
+def test_touch_tip_raises_if_labware_is_untouchable(
+    decoy: Decoy,
+    mock_instrument_core: InstrumentCore,
+    subject: InstrumentContext,
+    mock_protocol_core: ProtocolCore,
+) -> None:
+    """It should raise if the labware has quirk 'touchTipDisabled' for API v2.28 & above."""
+    mock_well = decoy.mock(cls=Well)
+    decoy.when(mock_instrument_core.has_tip()).then_return(True)
+    decoy.when(mock_well.parent.quirks).then_return(["touchTipDisabled"])
+
+    with pytest.raises(RuntimeError, match="Touch tip not allowed on labware"):
+        subject.touch_tip(mock_well)
 
 
 def test_return_height(


### PR DESCRIPTION
# Overview

Addresses RQA-4264 by making `touch_tip()` raise an error if called on a labware that has a `touchTipDisabled` quirk.

## Changelog

Added error raising for touch tip from API v2.28 onwards. Older API versions will no-op touch tip as they've been doing.

## Review requests

- How should we handle touch tips in liquid class based transfers? We currently skip touch tips if touch_tip param is enabled but the labware in question is untouchable. We don't have any API version based gating in LC transfers since the implementation lies in the core. BUT we can do a check in the public LC transfer APIs and raise error for invalid touch tips (for new API versions) before going into the core.

## Risk assessment

- This wouldn't change behaviors of existing protocols but will change the behavior for protocols that get updated to new version, so, we should make sure to communicate this well
