### PR TITLE
refactor(app): Remove `camera` feature flag

### DIFF
--- a/app/src/assets/localization/en/app_settings.json
+++ b/app/src/assets/localization/en/app_settings.json
@@ -1,5 +1,4 @@
 {
-  "__dev_internal__camera": "Enable Camera support",
   "__dev_internal__enableLabwareCreator": "Enable App Labware Creator",
   "__dev_internal__enableRunNotes": "Display Notes During a Protocol Run",
   "__dev_internal__forceHttpPolling": "Poll all network requests instead of using MQTT",

--- a/app/src/assets/localization/en/run_details.json
+++ b/app/src/assets/localization/en/run_details.json
@@ -21,7 +21,6 @@
   "cancel_run_module_info": "Additionally, any hardware modules used within the protocol will remain active and maintain their current states until deactivated.",
   "canceling_run": "Canceling Run",
   "canceling_run_dot": "canceling run...",
-  "capture_image": "Capture image",
   "clear_protocol": "Clear protocol",
   "clear_protocol_to_make_available": "Clear protocol from robot to make it available.",
   "close_door": "Close robot door",

--- a/app/src/organisms/Desktop/Devices/Peripherals/CameraCard.tsx
+++ b/app/src/organisms/Desktop/Devices/Peripherals/CameraCard.tsx
@@ -26,7 +26,6 @@ import {
   useCameraAnalytics,
 } from '/app/redux-resources/analytics/'
 import { useRobotType } from '/app/redux-resources/robots'
-import { useFeatureFlag } from '/app/redux/config'
 
 import styles from './inputdevices.module.css'
 
@@ -165,7 +164,6 @@ function CameraCardOverflowMenu({
   navigateToUsageSettings: () => void
 }): JSX.Element {
   const { t } = useTranslation('device_details')
-  const cameraControlsEnabled = useFeatureFlag('camera')
 
   return (
     <div className={styles.card_overflow_menu_container}>
@@ -173,9 +171,7 @@ function CameraCardOverflowMenu({
         <MenuItem onClick={handleToggleCamera}>
           {cameraEnabled ? t('disable_camera') : t('enable_camera')}
         </MenuItem>
-        {cameraControlsEnabled && (
-          <MenuItem onClick={toggleControls}>{t('edit_settings')}</MenuItem>
-        )}
+        <MenuItem onClick={toggleControls}>{t('edit_settings')}</MenuItem>
         <Divider />
         <MenuItem onClick={navigateToUsageSettings}>
           {t('usage_settings')}

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/SetupCamera/index.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/SetupCamera/index.tsx
@@ -17,7 +17,6 @@ import { SetupRunCameraControls } from '/app/organisms/Desktop/Devices/ProtocolR
 import { SetupRunCameraUsage } from '/app/organisms/Desktop/Devices/ProtocolRun/SetupCamera/SetupRunCameraSettings'
 import { useToaster } from '/app/organisms/ToasterOven'
 import { useIsFlex } from '/app/redux-resources/robots'
-import { useFeatureFlag } from '/app/redux/config'
 import {
   getCameraUsageState,
   updateCameraEnablement,
@@ -49,7 +48,6 @@ export function SetupCamera({
   confirmCameraSettings,
 }: SetupCameraProps): JSX.Element {
   const { t } = useTranslation('protocol_setup')
-  const isCameraSettingsEnabled = useFeatureFlag('camera')
   const { makeSnackbar } = useToaster()
   const storageInfo = useRobotStorageInfo()
   const dispatch = useDispatch()
@@ -131,12 +129,10 @@ export function SetupCamera({
             toggleLiveStreamEnabled={toggleLiveStreamEnabled}
             cameraConfirmed={cameraConfirmed}
           />
-          {isCameraSettingsEnabled && (
-            <SetupRunCameraControls
-              cameraConfirmed={cameraConfirmed}
-              runId={runId}
-            />
-          )}
+          <SetupRunCameraControls
+            cameraConfirmed={cameraConfirmed}
+            runId={runId}
+          />
         </>
       )}
       <div className={styles.camera_btn_container}>

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsCamera/index.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsCamera/index.tsx
@@ -6,7 +6,6 @@ import {
   useCameraAnalytics,
 } from '/app/redux-resources/analytics'
 import { useIsFlex, useRobotType } from '/app/redux-resources/robots'
-import { useFeatureFlag } from '/app/redux/config'
 
 import styles from './camerasettings.module.css'
 import { CameraStatusContainer } from './CameraStatusContainer'
@@ -37,7 +36,6 @@ export function RobotSettingsCamera({
     source: SOURCE_ROBOT_SETTINGS,
     robotType,
   })
-  const isCameraSettingsEnabled = useFeatureFlag('camera')
   const handleToggleLiveStream = (): void => {
     toggleLiveVideoEnabled()
     reportCameraEnablementSettings({
@@ -73,12 +71,10 @@ export function RobotSettingsCamera({
             toggleDisabled={isRobotBusy}
             robotType={robotType}
           />
-          {isCameraSettingsEnabled && (
-            <>
-              <Divider />
-              <RobotSettingsCameraControls />
-            </>
-          )}
+          <>
+            <Divider />
+            <RobotSettingsCameraControls />
+          </>
         </>
       )}
     </div>

--- a/app/src/organisms/ODD/CameraSettings/index.tsx
+++ b/app/src/organisms/ODD/CameraSettings/index.tsx
@@ -8,7 +8,6 @@ import {
   useCameraAnalytics,
 } from '/app/redux-resources/analytics'
 import { useRobotType } from '/app/redux-resources/robots'
-import { useFeatureFlag } from '/app/redux/config'
 
 import { CameraControls } from './CameraControls'
 import { CameraEnableSetting } from './CameraEnableSetting'
@@ -51,7 +50,6 @@ export function CameraSettings({
   isLiveVideoEnabled,
   runId,
 }: CameraSettingsProps): JSX.Element {
-  const isCameraSettingsEnabled = useFeatureFlag('camera')
   const [showControls, setShowControls] = useState(false)
   const toggleShowControls = (): void => {
     setShowControls(!showControls)
@@ -130,11 +128,9 @@ export function CameraSettings({
                 isRecoveryCaptureEnabled={isRecoveryCaptureEnabled}
                 robotName={robotName}
               />
-              {isCameraSettingsEnabled && (
-                <ControlPreferencesSettings
-                  toggleShowControls={toggleShowControls}
-                />
-              )}
+              <ControlPreferencesSettings
+                toggleShowControls={toggleShowControls}
+              />
             </>
           )}
         </div>

--- a/app/src/organisms/ODD/RunningProtocol/ImageGalleryList/index.tsx
+++ b/app/src/organisms/ODD/RunningProtocol/ImageGalleryList/index.tsx
@@ -6,7 +6,6 @@ import { FloatingActionButton } from '/app/atoms/buttons'
 import { OddInfoScreen } from '/app/molecules/ODDInfoScreen'
 import { GalleryListItem } from '/app/organisms/ODD/RunningProtocol/ImageGalleryList/GalleryListItem'
 import { ProtocolPlayPauseHeader } from '/app/organisms/ODD/RunningProtocol/shared/ProtocolPlayPauseHeader'
-import { useFeatureFlag } from '/app/redux/config'
 import { useImageInfo } from '/app/resources/dataFiles/useImageInfo'
 
 import styles from './gallery.module.css'
@@ -33,7 +32,6 @@ export interface ImageGalleryListProps {
 export function ImageGalleryList(props: ImageGalleryListProps): JSX.Element {
   const { t } = useTranslation('run_details')
   const { runId, protocolAnalysis, robotType, allRunDefs } = props
-  const isCameraSettingsEnabled = useFeatureFlag('camera')
 
   const { items } = useImageInfo(runId)
 
@@ -53,13 +51,11 @@ export function ImageGalleryList(props: ImageGalleryListProps): JSX.Element {
           <NoImagesAvailable />
         )}
       </div>
-      {isCameraSettingsEnabled && (
-        <FloatingActionButton
-          buttonText={t('image_capture')}
-          iconName="camera"
-          onClick={() => null}
-        />
-      )}
+      <FloatingActionButton
+        buttonText={t('image_capture')}
+        iconName="camera"
+        onClick={() => null}
+      />
     </div>
   )
 }

--- a/app/src/pages/Desktop/Devices/ProtocolRunDetails/__tests__/ProtocolRunDetails.test.tsx
+++ b/app/src/pages/Desktop/Devices/ProtocolRunDetails/__tests__/ProtocolRunDetails.test.tsx
@@ -14,7 +14,6 @@ import { ProtocolRunRuntimeParameters } from '/app/organisms/Desktop/Devices/Pro
 import { ProtocolRunSetup } from '/app/organisms/Desktop/Devices/ProtocolRun/ProtocolRunSetup'
 import { RunPreviewComponent } from '/app/organisms/Desktop/Devices/RunPreview'
 import { useRobot } from '/app/redux-resources/robots'
-import { useFeatureFlag } from '/app/redux/config'
 import { mockConnectableRobot } from '/app/redux/discovery/__fixtures__'
 import {
   useCurrentRunId,
@@ -39,7 +38,6 @@ vi.mock('/app/resources/runs')
 vi.mock(
   '/app/organisms/Desktop/Devices/ProtocolRun/ProtocolRunRunTimeParameters'
 )
-vi.mock('/app/redux/config')
 vi.mock('/app/redux-resources/robots')
 vi.mock('/app/organisms/Desktop/Devices/ProtocolRun/ProtocolRunCamera')
 
@@ -122,7 +120,6 @@ describe('ProtocolRunDetails', () => {
       mockRobotSideAnalysis
     )
     when(vi.mocked(useRunHasStarted)).calledWith(RUN_ID).thenReturn(false)
-    when(vi.mocked(useFeatureFlag)).calledWith('camera').thenReturn(true)
     vi.mocked(useNotifyRunQuery).mockReturnValue({
       data: { data: { createdAt: '123' } },
     } as any)

--- a/app/src/pages/Desktop/Devices/RobotSettings/__tests__/RobotSettings.test.tsx
+++ b/app/src/pages/Desktop/Devices/RobotSettings/__tests__/RobotSettings.test.tsx
@@ -10,7 +10,6 @@ import { RobotSettingsCamera } from '/app/organisms/Desktop/Devices/RobotSetting
 import { RobotSettingsNetworking } from '/app/organisms/Desktop/Devices/RobotSettings/RobotSettingsNetworking'
 import { RobotSettingsCalibration } from '/app/organisms/Desktop/RobotSettingsCalibration'
 import { useRobot } from '/app/redux-resources/robots'
-import { useFeatureFlag } from '/app/redux/config'
 import {
   mockConnectableRobot,
   mockReachableRobot,
@@ -27,7 +26,6 @@ vi.mock('/app/organisms/Desktop/Devices/RobotSettings/RobotSettingsCamera')
 vi.mock('/app/redux-resources/robots')
 vi.mock('/app/redux/discovery/selectors')
 vi.mock('/app/redux/robot-update')
-vi.mock('/app/redux/config')
 
 const render = (path = '/') => {
   return renderWithProviders(
@@ -54,7 +52,6 @@ describe('RobotSettings', () => {
     when(vi.mocked(useRobot))
       .calledWith('otie')
       .thenReturn(mockConnectableRobot)
-    when(vi.mocked(useFeatureFlag)).calledWith('camera').thenReturn(true)
     vi.mocked(RobotSettingsCalibration).mockReturnValue(
       <div>Mock RobotSettingsCalibration</div>
     )

--- a/app/src/pages/Desktop/LivestreamViewer/index.tsx
+++ b/app/src/pages/Desktop/LivestreamViewer/index.tsx
@@ -1,14 +1,7 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import {
-  Btn,
-  Chip,
-  COLORS,
-  Flex,
-  Icon,
-  StyledText,
-} from '@opentrons/components'
+import { Chip } from '@opentrons/components'
 
 import { useHlsVideo } from '/app/pages/Desktop/LivestreamViewer/hooks/useHlsVideo'
 import { useReportWindowDurationEvent } from '/app/pages/Desktop/LivestreamViewer/hooks/useReportWindowDurationEvent'
@@ -16,7 +9,6 @@ import {
   LivestreamInfoScreen,
   useLivestreamInfoScreen,
 } from '/app/pages/Desktop/LivestreamViewer/LivestreamInfoScreen'
-import { useFeatureFlag } from '/app/redux/config'
 import { useCurrentRunId, useNotifyRunQuery } from '/app/resources/runs'
 
 import styles from './livestream.module.css'
@@ -27,8 +19,6 @@ export function LivestreamViewer(): JSX.Element {
   // We make UI affordances when a run has ended, even if it is un-currented.
   // The livestream viewer makes the assumption that it will not *initially* render
   // for a run that is already historical.
-  const { t } = useTranslation('run_details')
-
   const [retainedRunId, setRetainedRunId] = useState<string | null>(null)
   const currentRunId = useCurrentRunId({
     refetchInterval: RUN_POLLING_INTERVAL_MS,
@@ -54,7 +44,6 @@ export function LivestreamViewer(): JSX.Element {
     isCurrentRunLoading,
     videoError
   )
-  const liveStreamImageCaptureEnabled = useFeatureFlag('camera')
 
   useReportWindowDurationEvent(
     retainedRunId,
@@ -83,19 +72,6 @@ export function LivestreamViewer(): JSX.Element {
           </div>
         )}
       </div>
-      {infoScreenType == null && liveStreamImageCaptureEnabled && (
-        <Btn
-          className={styles.capture_image_button}
-          backgroundColor={COLORS.blue50}
-        >
-          <Flex className={styles.capture_image_button_text}>
-            <Icon name="camera" size="1rem" color={COLORS.white} />
-            <StyledText color={COLORS.white} desktopStyle="bodyDefaultSemiBold">
-              {t('capture_image')}
-            </StyledText>
-          </Flex>
-        </Btn>
-      )}
     </div>
   )
 }

--- a/app/src/pages/ODD/ProtocolSetup/__tests__/ProtocolSetup.test.tsx
+++ b/app/src/pages/ODD/ProtocolSetup/__tests__/ProtocolSetup.test.tsx
@@ -58,7 +58,6 @@ import {
 } from '/app/redux-resources/analytics'
 import { useRobotType } from '/app/redux-resources/robots'
 import { ANALYTICS_PROTOCOL_RUN_ACTION } from '/app/redux/analytics'
-import { useFeatureFlag } from '/app/redux/config'
 import { getLocalRobot } from '/app/redux/discovery'
 import { mockConnectableRobot } from '/app/redux/discovery/__fixtures__'
 import { mockHeaterShaker } from '/app/redux/modules/__fixtures__'
@@ -145,7 +144,6 @@ vi.mock('/app/local-resources/instruments')
 vi.mock('/app/organisms/DoorOpenControl/useIsDoorOpen')
 vi.mock('/app/organisms/LabwarePositionCheck')
 vi.mock('/app/organisms/ODD/ProtocolSetup/ProtocolSetupCamera')
-vi.mock('/app/redux/config')
 
 const render = (path = '/') => {
   return renderWithProviders(
@@ -372,7 +370,6 @@ describe('ProtocolSetup', () => {
       isApplyingOffsets: false,
       applyOffsets: vi.fn(),
     })
-    when(vi.mocked(useFeatureFlag)).calledWith('camera').thenReturn(true)
     vi.mocked(useAddCameraSettingsToRunMutation).mockReturnValue({
       addCameraSettingsToRun: vi.fn(),
     } as any)

--- a/app/src/redux/config/constants.ts
+++ b/app/src/redux/config/constants.ts
@@ -8,7 +8,6 @@ export const DEV_INTERNAL_FLAGS: DevInternalFlag[] = [
   'enableLabwareCreator',
   'reactQueryDevtools',
   'reactScan',
-  'camera',
   'quickTransferProtocolContentsLog',
 ]
 

--- a/app/src/redux/config/schema-types.ts
+++ b/app/src/redux/config/schema-types.ts
@@ -16,7 +16,6 @@ export type DevInternalFlag =
   | 'enableLabwareCreator'
   | 'reactQueryDevtools'
   | 'reactScan'
-  | 'camera'
   | 'quickTransferProtocolContentsLog'
 
 export type FeatureFlags = Partial<Record<DevInternalFlag, boolean | undefined>>


### PR DESCRIPTION
Closes [EXEC-2081](https://opentrons.atlassian.net/browse/EXEC-2081)

# Overview

Now that the camera feature is complete, we can remove the feature flag masking camera settings support. The "capture image" button on the livestream viewer is removed instead of remaining hidden behind the feature flag, since it's uncertain when ad hoc picture taking support will be added.

<img width="553" height="484" alt="Screenshot 2026-01-05 at 2 24 59 PM" src="https://github.com/user-attachments/assets/85de5597-b80b-4e89-be8b-ccd5d773d68c" />


## Test Plan and Hands on Testing

- See image

## Risk assessment

very low


[EXEC-2081]: https://opentrons.atlassian.net/browse/EXEC-2081?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ