### PR TITLE
feat(protocol-designer): highlight item copy for stacker 

### DIFF
--- a/protocol-designer/src/pages/Designer/DeckSetup/HighlightItems.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/HighlightItems.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 
 import {
+  FLEX_STACKER_MODULE_TYPE,
   getAddressableAreaFromSlotId,
   getPositionFromSlotId,
   inferModuleOrientationFromXCoordinate,
@@ -13,6 +14,7 @@ import {
 } from '@opentrons/shared-data'
 import { getSlotInLocationStack } from '@opentrons/step-generation'
 
+import { HOPPER_LABWARE_X_OFFSET } from '/protocol-designer/constants'
 import { getLabwaresOnModuleFromStack } from '/protocol-designer/utils'
 
 import { getDeckSetupForActiveItem } from '../../../top-selectors/labware-locations'
@@ -77,7 +79,6 @@ export function HighlightItems(props: HighlightItemsProps): JSX.Element | null {
     labware,
     modules
   )
-  console.log('highlightItems',highlightItems)
   const hoveredItemTrash: {
     name: AdditionalEquipmentName
     id: string
@@ -163,8 +164,13 @@ export function HighlightItems(props: HighlightItemsProps): JSX.Element | null {
         moduleOnDeck.id,
         Object.values(labware)
       )
-      console.log('highlightItems',highlightItems)
-      const position = getPositionFromSlotId(moduleOnDeck.slot, deckDef)
+      const isStacker = moduleOnDeck.type === FLEX_STACKER_MODULE_TYPE
+      const isActionOnShuttle = text === 'Store'
+      const position = getPositionFromSlotId(
+        moduleOnDeck.slot,
+        deckDef,
+        ...(isStacker && !isActionOnShuttle ? [HOPPER_LABWARE_X_OFFSET] : [])
+      )
       if (position != null) {
         return [
           ...acc,

--- a/protocol-designer/src/pages/Designer/DeckSetup/HighlightItems.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/HighlightItems.tsx
@@ -77,6 +77,7 @@ export function HighlightItems(props: HighlightItemsProps): JSX.Element | null {
     labware,
     modules
   )
+  console.log('highlightItems',highlightItems)
   const hoveredItemTrash: {
     name: AdditionalEquipmentName
     id: string
@@ -162,6 +163,7 @@ export function HighlightItems(props: HighlightItemsProps): JSX.Element | null {
         moduleOnDeck.id,
         Object.values(labware)
       )
+      console.log('highlightItems',highlightItems)
       const position = getPositionFromSlotId(moduleOnDeck.slot, deckDef)
       if (position != null) {
         return [

--- a/protocol-designer/src/ui/steps/actions/actions.ts
+++ b/protocol-designer/src/ui/steps/actions/actions.ts
@@ -219,6 +219,20 @@ const setSelection = (
         mode: 'add',
       },
     })
+  } else if (
+    formData.stepType === 'flexStacker'
+  ) {
+    dispatch({
+      type: 'SELECT_DROPDOWN_ITEM',
+      payload: {
+        selection: {
+          id: formData.moduleId,
+          text: formData.flexStackerFormType,
+          field: '1',
+        },
+        mode: 'add',
+      },
+    })
   }
 }
 

--- a/protocol-designer/src/ui/steps/actions/actions.ts
+++ b/protocol-designer/src/ui/steps/actions/actions.ts
@@ -1,3 +1,4 @@
+import capitalize from 'lodash/capitalize'
 import last from 'lodash/last'
 
 import { analyticsEvent } from '../../../analytics/actions'
@@ -219,15 +220,16 @@ const setSelection = (
         mode: 'add',
       },
     })
-  } else if (
-    formData.stepType === 'flexStacker'
-  ) {
+  } else if (formData.stepType === 'flexStacker') {
     dispatch({
       type: 'SELECT_DROPDOWN_ITEM',
       payload: {
         selection: {
           id: formData.moduleId,
-          text: formData.flexStackerFormType,
+          text:
+            formData.flexStackerFormType === 'fill'
+              ? 'Refill'
+              : capitalize(String(formData.flexStackerFormType)),
           field: '1',
         },
         mode: 'add',


### PR DESCRIPTION
closes EXEC-2067

# Overview

add the correct position and copy 

<img width="1540" height="946" alt="Screenshot 2026-01-05 at 12 57 40" src="https://github.com/user-attachments/assets/14cc0c15-0d49-4cd9-adf2-b4b80de7e651" />
<img width="1546" height="956" alt="Screenshot 2026-01-05 at 12 57 59" src="https://github.com/user-attachments/assets/7b80eda7-da10-4185-a3ee-7ee637708c89" />
<img width="1541" height="957" alt="Screenshot 2026-01-05 at 12 59 27" src="https://github.com/user-attachments/assets/942f5288-36e3-4cf5-bbfa-1ea17c6a494f" />
<img width="1549" height="959" alt="Screenshot 2026-01-05 at 12 59 50" src="https://github.com/user-attachments/assets/d982da45-0d0e-4a95-8dee-348a975c40ea" />



## Test Plan and Hands on Testing

review the screenshots but also smoke test for yourself. note that you have to open a pre-existing step

## Changelog

add the correct position and copy for flex stacker step types

## Risk assessment

low