### PR TITLE
refactor(app): ensure the robot settings camera settings are disabled if a run is in progress

### DIFF
--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsCamera/RobotSettingsCameraControls.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsCamera/RobotSettingsCameraControls.tsx
@@ -12,7 +12,11 @@ import styles from '/app/organisms/Desktop/Devices/RobotSettings/RobotSettingsCa
 
 import type { JSX } from 'react'
 
-export function RobotSettingsCameraControls(): JSX.Element {
+export function RobotSettingsCameraControls({
+  disabled,
+}: {
+  disabled: boolean
+}): JSX.Element {
   const { t } = useTranslation('device_settings')
   const [showControls, setShowControls] = useState(false)
   const { createCameraImageSettings } = useCreateCameraImageSettings()
@@ -34,7 +38,7 @@ export function RobotSettingsCameraControls(): JSX.Element {
             {t('configure_camera_settings')}
           </StyledText>
         </div>
-        <TertiaryButton onClick={toggleControls}>
+        <TertiaryButton onClick={toggleControls} disabled={disabled}>
           <StyledText desktopStyle="captionSemiBold">
             {t('edit_settings')}
           </StyledText>

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsCamera/__tests__/CameraControlSettings.test.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsCamera/__tests__/CameraControlSettings.test.tsx
@@ -11,7 +11,7 @@ import { RobotSettingsCameraControls } from '../RobotSettingsCameraControls'
 vi.mock('/app/organisms/Desktop/Camera/CameraControls')
 
 const render = () => {
-  return renderWithProviders(<RobotSettingsCameraControls />, {
+  return renderWithProviders(<RobotSettingsCameraControls disabled={false} />, {
     i18nInstance: i18n,
   })
 }

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsCamera/index.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsCamera/index.tsx
@@ -73,7 +73,7 @@ export function RobotSettingsCamera({
           />
           <>
             <Divider />
-            <RobotSettingsCameraControls />
+            <RobotSettingsCameraControls disabled={isRobotBusy} />
           </>
         </>
       )}


### PR DESCRIPTION
Closes [EXEC-2213](https://opentrons.atlassian.net/browse/EXEC-2213)

# Overview

If a run is in progress, we should disable camera settings interactions from the robot settings page and navigate users to configure camera settings on the run setup page. This harmonizes existing UX patterns and prevents unexpected behavior.

### Current Behavior

<img width="943" height="767" alt="Screenshot 2026-01-06 at 8 53 01 AM" src="https://github.com/user-attachments/assets/c3823e9c-643f-45d6-886a-89db5b44f13d" />

### Fixed Behavior

<img width="941" height="754" alt="Screenshot 2026-01-06 at 8 50 47 AM" src="https://github.com/user-attachments/assets/33aa8182-b6da-41cf-b7a6-000e67c5c839" />


## Test Plan and Hands on Testing

- See images

## Risk assessment

effectively none, just CSS additions

[EXEC-2213]: https://opentrons.atlassian.net/browse/EXEC-2213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ