### PR TITLE
fix(app): Fix "preview image" crashing app

### DIFF
--- a/app/src/organisms/Desktop/Camera/CameraControls/PreviewSettings/index.tsx
+++ b/app/src/organisms/Desktop/Camera/CameraControls/PreviewSettings/index.tsx
@@ -1,11 +1,6 @@
 import { useTranslation } from 'react-i18next'
 
-import {
-  Icon,
-  InfoScreen,
-  SecondaryButton,
-  StyledText,
-} from '@opentrons/components'
+import { Icon, SecondaryButton, StyledText } from '@opentrons/components'
 
 import { usePreviewImage } from '/app/resources/camera/usePreviewImage'
 

--- a/app/src/organisms/Desktop/Camera/CameraControls/PreviewSettings/index.tsx
+++ b/app/src/organisms/Desktop/Camera/CameraControls/PreviewSettings/index.tsx
@@ -1,8 +1,12 @@
 import { useTranslation } from 'react-i18next'
 
-import { Icon, SecondaryButton, StyledText } from '@opentrons/components'
+import {
+  Icon,
+  InfoScreen,
+  SecondaryButton,
+  StyledText,
+} from '@opentrons/components'
 
-import { Skeleton } from '/app/atoms/Skeleton'
 import { usePreviewImage } from '/app/resources/camera/usePreviewImage'
 
 import styles from './previewsettings.module.css'
@@ -35,6 +39,8 @@ export function PreviewSettings({
 }
 
 function PreviewImage({ imgPath }: { imgPath: string | null }): JSX.Element {
+  const { t } = useTranslation('device_settings')
+
   if (imgPath != null) {
     return (
       <img
@@ -47,7 +53,9 @@ function PreviewImage({ imgPath }: { imgPath: string | null }): JSX.Element {
     return (
       <div className={styles.no_image_container}>
         <Icon name="ot-alert" className={styles.no_image_alert} />
-        <Skeleton width="100%" height="100%" backgroundSize="47rem" />
+        <StyledText desktopStyle="bodyDefaultSemiBold">
+          {t('no_image_available')}
+        </StyledText>
       </div>
     )
   }

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderContent/ActionButton/hooks/useActionButtonProperties.ts
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderContent/ActionButton/hooks/useActionButtonProperties.ts
@@ -102,7 +102,6 @@ export function useActionButtonProperties({
   let buttonText = ''
   let handleButtonClick = (): void => {}
   let buttonIconName: IconName | null = null
-  console.log('🚀 ~ handlePlay ~ runStatus:', runStatus)
 
   const handlePlay = (): void => {
     play()

--- a/react-api-client/src/camera/useCapturePreviewImage.ts
+++ b/react-api-client/src/camera/useCapturePreviewImage.ts
@@ -36,7 +36,7 @@ export function useCapturePreviewImage(): UseAddCapturePreviewImageMutationResul
     AxiosError<ErrorResponse>,
     AddCapturePreviewImageParams
   >(({ settings }) =>
-    createCapturePreviewImage(host!, settings)
+    createCapturePreviewImage(host!, settings, { responseType: 'blob' })
       .then(response => {
         queryClient
           .invalidateQueries([host, 'camera', 'capturePreviewImage'])

--- a/react-api-client/src/runs/useAddCapturePreviewImageToRun.ts
+++ b/react-api-client/src/runs/useAddCapturePreviewImageToRun.ts
@@ -39,7 +39,9 @@ export function useCapturePreviewImageToRun(
     AxiosError<ErrorResponse>,
     AddCapturePreviewImageToRunParams
   >(({ settings }) =>
-    addCapturePreviewImageToRun(host!, runId, settings)
+    addCapturePreviewImageToRun(host!, runId, settings, {
+      responseType: 'blob',
+    })
       .then(response => {
         queryClient
           .invalidateQueries([


### PR DESCRIPTION
Closes [EXEC-2215](https://opentrons.atlassian.net/browse/EXEC-2215)

# Overview

Clicking "preview image" in camera settings causes a white screen because axios doesn't parse `blob` type data without explicit configuration. This PR adds that explicit configuration. fc787f2ffbefb1b42d30659a3a6d87f17285f184 includes a small UI fix, too. See videos below.

### Current Behavior

https://github.com/user-attachments/assets/e0e50019-4388-497c-9772-1a71bb46746e

### Fixed Behavior

https://github.com/user-attachments/assets/816e8d62-f422-401f-97d2-f8fa78ecf549

## Test Plan and Hands on Testing

- See videos

## Changelog

- Fixed a white screen caused by clicking "preview image".

## Risk assessment

low

[EXEC-2215]: https://opentrons.atlassian.net/browse/EXEC-2215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ