### PR TITLE
feat(protocol-designer): center lid renders in slot

### DIFF
--- a/protocol-designer/src/components/organisms/LabwareOnDeck/index.tsx
+++ b/protocol-designer/src/components/organisms/LabwareOnDeck/index.tsx
@@ -1,6 +1,7 @@
 import { useSelector } from 'react-redux'
 
-import { LabwareRender } from '@opentrons/components'
+import { CenterLabwareInSlot, LabwareRender } from '@opentrons/components'
+import { getIsLid } from '@opentrons/shared-data'
 import * as wellContentsSelectors from '@opentrons/step-generation'
 
 import { selectors } from '../../../labware-ingred/selectors'
@@ -63,26 +64,37 @@ export function LabwareOnDeck(props: LabwareOnDeckProps): JSX.Element {
       ? missingAndUsedTipsByLabwareId[labwareOnDeck.id]
       : null
   const { missingTips } = labwareTipInfo ?? {}
+  const isLid = getIsLid(labwareOnDeck.def)
+  const labwareRenderComponent = (
+    <LabwareRender
+      definition={labwareOnDeck.def}
+      positioningMode="offsetInSlot"
+      wellFill={wellContentsSelectors.wellFillFromWellContents(
+        wellContents,
+        liquidDisplayColors
+      )}
+      handleClickWell={handleClickWell}
+      {...(showHighlightedWells ? { highlightedWells } : {})}
+      {...(ignoreMissingTips ? {} : { missingTips })}
+      highlight={highlight}
+      tipStatusByWellName={tipStatusByWellName}
+      onMouseEnterWell={onMouseEnterWell}
+      onMouseLeaveWell={onMouseLeaveWell}
+      selectedTipsByIndex={selectedTipsByIndex}
+      fill={fill}
+      labwareStroke={borderStroke}
+    />
+  )
   return (
     <g transform={`translate(${x}, ${y})`}>
-      <LabwareRender
-        definition={labwareOnDeck.def}
-        positioningMode="offsetInSlot"
-        wellFill={wellContentsSelectors.wellFillFromWellContents(
-          wellContents,
-          liquidDisplayColors
-        )}
-        handleClickWell={handleClickWell}
-        {...(showHighlightedWells ? { highlightedWells } : {})}
-        {...(ignoreMissingTips ? {} : { missingTips })}
-        highlight={highlight}
-        tipStatusByWellName={tipStatusByWellName}
-        onMouseEnterWell={onMouseEnterWell}
-        onMouseLeaveWell={onMouseLeaveWell}
-        selectedTipsByIndex={selectedTipsByIndex}
-        fill={fill}
-        labwareStroke={borderStroke}
-      />
+      {/* TODO (ND, 01/06/2026): Center all labware including non-lids in the slot. Requires a larger audit of LabwareOnDeck implementation. */}
+      {isLid ? (
+        <CenterLabwareInSlot definition={labwareOnDeck.def}>
+          {labwareRenderComponent}
+        </CenterLabwareInSlot>
+      ) : (
+        labwareRenderComponent
+      )}
     </g>
   )
 }


### PR DESCRIPTION
# Overview

This PR uses the shared `CenterLabwareInSlot` SVG component to wrap lid `LabwareOnDeck` renders in PD.

Closes EXEC-2116
Closes RQA-4721

## Test Plan and Hands on Testing

add some lidded labware on deck (and on modules) and verify that it is centered rather than positioned in the front left of the slot/parent labware

deck
<img width="403" height="383" alt="Screenshot 2026-01-06 at 10 16 16 AM" src="https://github.com/user-attachments/assets/e14a513e-bfab-40da-8fa1-5f928cd1fdec" />

stacker
<img width="283" height="164" alt="Screenshot 2026-01-06 at 10 17 06 AM" src="https://github.com/user-attachments/assets/a47f9f26-db37-42fc-884f-d3483a2a5eca" />

## Changelog

- wrap `LabwareRender` in return of `LabwareOnDeck` PD component in `CenterLabwareInSlot` for lids only (for now)

## Review requests

see test plan

## Risk assessment

low