### PR TITLE
fix(protocol-designer): pend creation state in activeLabwareControls …

### DIFF
--- a/protocol-designer/src/pages/Designer/DeckSetup/Overlays/ActiveLabwareControls.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/Overlays/ActiveLabwareControls.tsx
@@ -10,6 +10,7 @@ import {
   RobotCoordsForeignDiv,
   StyledText,
 } from '@opentrons/components'
+import { FLEX_STACKER_MODULE_TYPE } from '@opentrons/shared-data'
 import { getIsSlotAHopper } from '@opentrons/step-generation'
 
 import { SlotDetailModal } from '/protocol-designer/components/organisms/SlotDetailModal'
@@ -22,6 +23,7 @@ import { DECK_CONTROLS_STYLE } from '../constants'
 
 import type { Dispatch, SetStateAction } from 'react'
 import type { CoordinateTuple, Dimensions } from '@opentrons/shared-data'
+import type { FlexStackerModuleState } from '@opentrons/step-generation'
 import type { DeckSetupTerminalIdType } from '../../types'
 
 interface ActiveLabwareControlsProps extends DeckSetupTerminalIdType {
@@ -56,6 +58,27 @@ export function ActiveLabwareControls(
         isSlotAHopper
       )
 
+  const stackerModuleId = fullStack.find(
+    id =>
+      activeDeckSetup.modules[id] != null &&
+      activeDeckSetup.modules[id].type === FLEX_STACKER_MODULE_TYPE
+  )
+  const stackerModuleState: FlexStackerModuleState | null =
+    stackerModuleId != null
+      ? (activeDeckSetup.modules[stackerModuleId]
+          .moduleState as FlexStackerModuleState)
+      : null
+  const stackerHopperLabware: string[] =
+    stackerModuleState?.labwareInHopper?.reduce<string[]>((acc, hopper) => {
+      acc.push(hopper.primaryLabwareId)
+      if (hopper.adapterLabwareId) {
+        acc.push(hopper.adapterLabwareId)
+      }
+      if (hopper.lidLabwareId) {
+        acc.push(hopper.lidLabwareId)
+      }
+      return acc
+    }, []) ?? []
   const filteredStack = fullStack.filter(
     item => activeDeckSetup.labware[item] != null
   )
@@ -74,7 +97,11 @@ export function ActiveLabwareControls(
           closeModal={() => {
             setShowSlotDetailModal(false)
           }}
-          stackOfLabware={filteredStack}
+          stackOfLabware={
+            stackerHopperLabware.length > 0
+              ? stackerHopperLabware
+              : filteredStack
+          }
         />
       ) : null}
 

--- a/protocol-designer/src/pages/Designer/DeckSetup/Overlays/ActiveLabwareControls.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/Overlays/ActiveLabwareControls.tsx
@@ -10,11 +10,13 @@ import {
   RobotCoordsForeignDiv,
   StyledText,
 } from '@opentrons/components'
-import { getFullStackFromLabwares } from '@opentrons/step-generation'
+import { getIsSlotAHopper } from '@opentrons/step-generation'
 
 import { SlotDetailModal } from '/protocol-designer/components/organisms/SlotDetailModal'
+import { getPendingCreationState } from '/protocol-designer/step-forms/selectors'
 import { END_TERMINAL_ITEM_ID } from '/protocol-designer/steplist'
 import { getDeckSetupForActiveItem } from '/protocol-designer/top-selectors/labware-locations'
+import { getFullStackFromLabwaresOnDeck } from '/protocol-designer/utils'
 
 import { DECK_CONTROLS_STYLE } from '../constants'
 
@@ -42,9 +44,18 @@ export function ActiveLabwareControls(
     setHover,
   } = props
   const { t } = useTranslation('starting_deck_state')
+  const pendingCreationStateForHopper = useSelector(getPendingCreationState)
+  const isSlotAHopper = getIsSlotAHopper(itemId)
   const [showSlotDetailModal, setShowSlotDetailModal] = useState<boolean>(false)
   const activeDeckSetup = useSelector(getDeckSetupForActiveItem)
-  const fullStack = getFullStackFromLabwares(activeDeckSetup.labware, itemId)
+  const fullStack = pendingCreationStateForHopper
+    ? []
+    : getFullStackFromLabwaresOnDeck(
+        Object.values(activeDeckSetup.labware),
+        itemId,
+        isSlotAHopper
+      )
+
   const filteredStack = fullStack.filter(
     item => activeDeckSetup.labware[item] != null
   )


### PR DESCRIPTION
…when filling stacker

also addresses https://opentrons.atlassian.net/browse/EXEC-2211

# Overview

adding the pending creation state selector to ActiveLabwareControls, similarly to what we have done in deckSetupDetails. this is because the stacker fill step creates new entities and we want to make sure ActiveLabwareControls doesn't get the stack info until the new labwares have been properly created.

additionally, i did some refactoring in ActiveLabwareControls to return the correct stack on the hopper.

<img width="796" height="560" alt="Screenshot 2026-01-06 at 10 15 57" src="https://github.com/user-attachments/assets/bec86cba-3ce3-4e51-8af0-437b3ad0984e" />

## Test Plan and Hands on Testing

Add any step, followed by a stacker fill step. it shouldn't whitescreen anymore. then check the end state and see that if you view details of the labware on the hopper, it shows the full stack

## Changelog

add the new getPendingCreationState selector to ActiveLabwareControls

## Risk assessment

low
