### PR TITLE
chore(api): fix ruff and lint issues

### DIFF
--- a/api/src/opentrons/protocol_engine/execution/pipetting.py
+++ b/api/src/opentrons/protocol_engine/execution/pipetting.py
@@ -379,7 +379,7 @@ class HardwarePipettingHandler(PipettingHandler):
 
 
 class VirtualPipettingHandler(PipettingHandler):
-    """Liquid handling, using the virtual pipettes.""" ""
+    """Liquid handling, using the virtual pipettes."""
 
     _state_view: StateView
 

--- a/api/src/opentrons/protocol_engine/state/command_history.py
+++ b/api/src/opentrons/protocol_engine/state/command_history.py
@@ -127,10 +127,7 @@ class CommandHistory:
     def get_slice(
         self, start: int, stop: int, command_ids: Optional[list[str]] = None
     ) -> List[Command]:
-        (
-            """Get a list of commands between start and stop."""
-            """Get a list of commands between start and stop."""
-        )
+        """Get a list of commands between start and stop."""
         commands = self._all_command_ids[start:stop]
         selected_command_ids = (
             command_ids if command_ids is not None else self._all_command_ids

--- a/api/tests/opentrons/protocol_api/test_lc_blowout_properties.py
+++ b/api/tests/opentrons/protocol_api/test_lc_blowout_properties.py
@@ -41,13 +41,15 @@ def test_blowout_properties_none_instantiation_combos() -> None:
     with pytest.raises(ValidationError):
         _build_blowout_properties(
             BlowoutProperties(
-                enable=None, params=BlowoutParams(location=None, flowRate=None)  # type: ignore
+                enable=None,  # type: ignore
+                params=BlowoutParams(location=None, flowRate=None),  # type: ignore
             )
         )
     with pytest.raises(ValidationError):
         _build_blowout_properties(
             BlowoutProperties(
-                enable=True, params=BlowoutParams(location=None, flowRate=100)  # type: ignore
+                enable=True,
+                params=BlowoutParams(location=None, flowRate=100),  # type: ignore
             )
         )
 

--- a/api/tests/opentrons/protocol_api/test_lc_touch_tip_properties.py
+++ b/api/tests/opentrons/protocol_api/test_lc_touch_tip_properties.py
@@ -41,15 +41,21 @@ def test_touch_tip_properties_none_instantiation_combos() -> None:
             TouchTipProperties(
                 enable=True,
                 params=LiquidClassTouchTipParams(
-                    zOffset=None, mmFromEdge=None, speed=None   # type: ignore
+                    zOffset=None,  # type: ignore
+                    mmFromEdge=None,  # type: ignore
+                    speed=None,  # type: ignore
                 ),
             )
         )
     with pytest.raises(ValidationError):
         _build_touch_tip_properties(
             TouchTipProperties(
-                enable=None,   # type: ignore
-                params=LiquidClassTouchTipParams(zOffset=None, mmFromEdge=1, speed=1),   # type: ignore
+                enable=None,  # type: ignore
+                params=LiquidClassTouchTipParams(
+                    zOffset=None,  # type: ignore
+                    mmFromEdge=1,
+                    speed=1,
+                ),
             )
         )
     with pytest.raises(ValidationError):

--- a/shared-data/python/opentrons_shared_data/pipette/__init__.py
+++ b/shared-data/python/opentrons_shared_data/pipette/__init__.py
@@ -1,6 +1,7 @@
 """
 opentrons_shared_data.pipette: functions and types for pipette config
 """
+
 from __future__ import annotations
 import copy
 from typing import TYPE_CHECKING, Dict, Optional


### PR DESCRIPTION
# Overview

We had some `# type: ignore` annotations to suppress the lint complaint `Argument has incompatible type "None"; expected "int | float" [arg-type]`. When Ruff rewrapped the lines, the `# type: ignore` comment ended up on the wrong line, so the lint error was no longer suppressed.

Also, there were some very odd concatenated docstrings that are fixed in this PR.

## Test Plan and Hands on Testing

Run CI tests.

## Risk assessment

Low. Just code formatting changes.