### PR TITLE
fix(app-shell): python version for bundling should be 3.12

### DIFF
--- a/app-shell/Makefile
+++ b/app-shell/Makefile
@@ -65,7 +65,7 @@ builder := yarn electron-builder \
 # Resolve the API python interpreter lazily so `make setup` (and other targets
 # that do not actually launch Electron) do not spin up the uv environment at
 # parse time. The $$() command substitution runs when the recipe executes.
-PYTHON_OVERRIDE_COMMAND = cd ../api && uv run --python 3.10 python -c "import sys, pathlib; print(pathlib.Path(sys.executable).resolve())"
+PYTHON_OVERRIDE_COMMAND = cd ../api && uv run --python 3.12 python -c "import sys, pathlib; print(pathlib.Path(sys.executable).resolve())"
 
 electron = yarn electron . \
 	--devtools \

--- a/app-shell/Makefile
+++ b/app-shell/Makefile
@@ -65,7 +65,7 @@ builder := yarn electron-builder \
 # Resolve the API python interpreter lazily so `make setup` (and other targets
 # that do not actually launch Electron) do not spin up the uv environment at
 # parse time. The $$() command substitution runs when the recipe executes.
-PYTHON_OVERRIDE_COMMAND = cd ../api && uv run --python 3.12 python -c "import sys, pathlib; print(pathlib.Path(sys.executable).resolve())"
+PYTHON_OVERRIDE_COMMAND = cd ../api && uv run --python 3.12 python -c "import sys, pathlib; print(pathlib.Path(sys.executable))"
 
 electron = yarn electron . \
 	--devtools \


### PR DESCRIPTION
# Overview

The make target for bundling python api in the app is unintentionally using python 3.10. This was causing issues analyzing protocols in the app.
This PR changes that python version to be 3.12.

## Test Plan and Hands on Testing

Built the app and verified that analyses are now able to be completed.

## Risk assessment

None. Fix only
