### PR TITLE
fix(protocol-designer): add thermo to deck configuration and initial deck state

### DIFF
--- a/shared-data/js/helpers/deckConfiguration/getVisualSlotFrom.ts
+++ b/shared-data/js/helpers/deckConfiguration/getVisualSlotFrom.ts
@@ -37,6 +37,7 @@ export const VS_TO_AA: Record<VISUAL_SLOTS, AddressableAreaNamesWithFakes[]> = {
     'temperatureModuleV2B1',
     'heaterShakerV1B1',
     'movableTrashB1',
+    'thermocyclerModuleV2',
   ],
   VSC1: [
     'C1',


### PR DESCRIPTION
# Overview

closes https://opentrons.atlassian.net/browse/EXEC-2216.
fix adding a thermo to the deck config and to the initial deck state

## Test Plan and Hands on Testing

<img width="907" height="891" alt="Screenshot 2026-01-06 at 3 17 14 PM" src="https://github.com/user-attachments/assets/ec7d50ae-506e-4342-b6c6-fd0b8d606324" />
<img width="957" height="700" alt="Screenshot 2026-01-06 at 3 17 20 PM" src="https://github.com/user-attachments/assets/eefa4faf-5848-4abd-b3db-5a9f174641ea" />


## Changelog

added aa to VS to aa mapping

## Risk assessment

low
