### PR TITLE
(notes): PD 8.8.0 alpha release notes

### DIFF
--- a/protocol-designer/release-notes.md
+++ b/protocol-designer/release-notes.md
@@ -135,7 +135,6 @@ This hotfix release addresses several bugs.
 ### Bug Fixes
 
 - Crashes and protocol loss no longer occur when:
-
   - deleting a pipette involved in a mix step.
   - deleting a Protocol Designer step title.
   - checking labware details after deleting a liquid.

--- a/protocol-designer/release-notes.md
+++ b/protocol-designer/release-notes.md
@@ -15,11 +15,13 @@ By using Opentrons Protocol Designer, you agree to the Opentrons End-User Licens
 This release adds support for the Flex Stacker Module in Protocol Designer, and includes other bug fixes.
 
 ### New Features
-- Use the Flex Stacker Module to store and use multiple well plates, PCR plates, or tip racks in your Protocol Designer protocols. 
+
+- Use the Flex Stacker Module to store and use multiple well plates, PCR plates, or tip racks in your Protocol Designer protocols.
 
 ### Bug Fixes
+
 - Add tip rack lids to tip racks placed inside Flex 96-channel adapters.
-- Protocol Designer properly displays tip racks and their lids on the deck. 
+- Protocol Designer properly displays tip racks and their lids on the deck.
 
 Running a protocol created in Protocol Designer requires Opentrons App version 8.8.0 or newer.
 
@@ -133,6 +135,7 @@ This hotfix release addresses several bugs.
 ### Bug Fixes
 
 - Crashes and protocol loss no longer occur when:
+
   - deleting a pipette involved in a mix step.
   - deleting a Protocol Designer step title.
   - checking labware details after deleting a liquid.

--- a/protocol-designer/release-notes.md
+++ b/protocol-designer/release-notes.md
@@ -8,6 +8,21 @@ By using Opentrons Protocol Designer, you agree to the Opentrons End-User Licens
 
 ---
 
+## Opentrons Protocol Designer Changes in 8.8.0
+
+**Welcome to Protocol Designer 8.8.0.!**
+
+This release adds support for the Flex Stacker Module in Protocol Designer, and includes other bug fixes.
+
+### New Features
+- Use the Flex Stacker Module to store and use multiple well plates, PCR plates, or tip racks in your Protocol Designer protocols. 
+
+### Bug Fixes
+- Add tip rack lids to tip racks placed inside Flex 96-channel adapters.
+- Protocol Designer properly displays tip racks and their lids on the deck. 
+
+Running a protocol created in Protocol Designer requires Opentrons App version 8.8.0 or newer.
+
 ## Opentrons Protocol Designer Changes in 8.7.1
 
 **Welcome to Protocol Designer 8.7.1!**


### PR DESCRIPTION
# Overview

Adding PD 8.8 release notes ahead of the first alpha. 

Keeping it pretty simple where the Stacker is concerned. In previous release notes, I would add a bit more detail to give users some descriptive text before the manual was out. Since the manual is now updated in line with release, there's no longer a need. 

## Test Plan and Hands on Testing



## Changelog

Include support for the Stacker and a few 8.8 bug fixes: [centered tip rack lids](https://opentrons.atlassian.net/browse/RQA-4721) and [96-ch adapter tip rack lid issue](https://opentrons.atlassian.net/browse/AUTH-2453).


## Review requests

Anything missing? 

## Risk assessment

low.
