### PR TITLE
fix(step-generation): further special case load labware commands on shuttle

### DIFF
--- a/step-generation/src/utils/pythonFileUtils.ts
+++ b/step-generation/src/utils/pythonFileUtils.ts
@@ -306,7 +306,7 @@ export function getLoadLabware(
       )
       const onModule =
         moduleEntities[labwareSlot] != null ||
-        deckSlot === stackerOnSlot?.[1].slot // special case stacker shuttle labware
+        (deckSlot === stackerOnSlot?.[1].slot && !isLabwareOnHopper) // special case stacker shuttle labware
       const onLabware = allLabwareEntities[labwareSlot] != null
 
       let parentName: string


### PR DESCRIPTION
# Overview

needed extra logic to ensure only the load labwre on the stacker happens on shuttle labware and not on hopper labware

## Test Plan and Hands on Testing

review code, test the attached protocol passes analysis

[untitled - 2026-01-07T090214.376.py](https://github.com/user-attachments/files/24477123/untitled.-.2026-01-07T090214.376.py)

## Changelog

extra special casing

## Risk assessment

low
