### PR TITLE
fix(app): fix spacing issue in protocol card

### DIFF
--- a/app/src/organisms/Desktop/ProtocolsLanding/ProtocolCard.tsx
+++ b/app/src/organisms/Desktop/ProtocolsLanding/ProtocolCard.tsx
@@ -227,14 +227,16 @@ function AnalysisInfo(props: AnalysisInfoProps): JSX.Element {
           {analysisStatus === 'stale' ? (
             <ProtocolAnalysisStale protocolKey={protocolKey} />
           ) : null}
-          <LegacyStyledText
-            forwardedAs="h3"
-            fontWeight={TYPOGRAPHY.fontWeightSemiBold}
-            data-testid={`ProtocolCard_${protocolDisplayName}`}
-            overflowWrap={OVERFLOW_WRAP_ANYWHERE}
-          >
-            {protocolDisplayName}
-          </LegacyStyledText>
+          <Flex paddingRight={SPACING.spacing24}>
+            <LegacyStyledText
+              forwardedAs="h3"
+              fontWeight={TYPOGRAPHY.fontWeightSemiBold}
+              data-testid={`ProtocolCard_${protocolDisplayName}`}
+              overflowWrap={OVERFLOW_WRAP_ANYWHERE}
+            >
+              {protocolDisplayName}
+            </LegacyStyledText>
+          </Flex>
         </Flex>
         {/* data section */}
         {analysisStatus === 'loading' ? (


### PR DESCRIPTION


# Overview
spacing issue between protocolName and overflow menu in ProtocolCard

design
https://www.figma.com/design/qzX850M2Zxf1Mb5QwEtbzq/Primary--Desktop-App?node-id=10113-81378&m=dev

[before]
<img width="910" height="166" alt="Screenshot 2026-01-07 at 5 00 52 PM" src="https://github.com/user-attachments/assets/5600fe7f-7b92-4f6e-882d-d468b70f3a9f" />


[after]
<img width="860" height="164" alt="Screenshot 2026-01-07 at 5 12 17 PM" src="https://github.com/user-attachments/assets/bde76838-6855-4dee-85bd-46de347ad2a9" />

close AUTH-2668

## Test Plan and Hands on Testing


## Changelog
- fix spacing issue by modifying text container padding 

## Review requests


## Risk assessment
low
