### PR TITLE
fix(step-genereation): set stored labware when labware starts in shut…

### DIFF
--- a/step-generation/src/utils/__tests__/pythonFileUtils.test.ts
+++ b/step-generation/src/utils/__tests__/pythonFileUtils.test.ts
@@ -564,6 +564,8 @@ flex_stacker_1.set_stored_labware_items(
       `# Set Stored Labware:
 flex_stacker_1.set_stored_labware(
     load_name="fixture_96_plate",
+    namespace="opentrons",
+    version=1,
     count=0
 )`.trimStart()
     )

--- a/step-generation/src/utils/__tests__/pythonFileUtils.test.ts
+++ b/step-generation/src/utils/__tests__/pythonFileUtils.test.ts
@@ -472,7 +472,7 @@ well_plate_3 = protocol.load_labware_from_definition(
     )
   })
 
-  it('should generate loadLabware for a flex stacker', () => {
+  it('should generate loadLabware for a flex stacker for labware on the hopper', () => {
     const mockModuleEntitiesWithFlexStackerModule = {
       ...mockModuleEntities,
       [moduleId4]: {
@@ -498,16 +498,73 @@ well_plate_3 = protocol.load_labware_from_definition(
       },
     }
 
+    const mockModuleState: TimelineFrame['modules'] = {
+      [moduleId4]: {
+        slot: 'A4',
+        moduleState: {} as any,
+      },
+    }
+
     const setStoredLabware = getSetStoredLabware(
       mockModuleEntitiesWithFlexStackerModule,
       mockLabwareEntitiesWithFlexStackerLabware,
-      mockLabwareRobotStateWithFlexStackerLabware
+      mockLabwareRobotStateWithFlexStackerLabware,
+      mockModuleState
     )
 
     expect(setStoredLabware).toBe(
       `# Set Stored Labware:
 flex_stacker_1.set_stored_labware_items(
     labware=[well_plate_4],
+)`.trimStart()
+    )
+  })
+
+  it('should generate loadLabware for a flex stacker for labware on the shuttle', () => {
+    const mockModuleEntitiesWithFlexStackerModule = {
+      ...mockModuleEntities,
+      [moduleId4]: {
+        ...mockModuleEntities[moduleId4],
+        id: moduleId4,
+        model: FLEX_STACKER_MODULE_V1,
+        type: FLEX_STACKER_MODULE_TYPE,
+        pythonName: 'flex_stacker_1',
+      },
+    }
+    const mockLabwareEntitiesWithFlexStackerLabware = {
+      [flexStackerLabwareId]: {
+        id: flexStackerLabwareId,
+        labwareDefURI: 'opentrons/fixture_96_plate/1',
+        def: opentrons96Plate as LabwareDefinition2,
+        pythonName: 'well_plate_4',
+      },
+    }
+
+    const mockLabwareRobotStateWithFlexStackerLabware = {
+      [flexStackerLabwareId]: {
+        stack: [flexStackerLabwareId, 'A4'],
+      },
+    }
+
+    const mockModuleState: TimelineFrame['modules'] = {
+      [moduleId4]: {
+        slot: 'A4',
+        moduleState: {} as any,
+      },
+    }
+
+    const setStoredLabware = getSetStoredLabware(
+      mockModuleEntitiesWithFlexStackerModule,
+      mockLabwareEntitiesWithFlexStackerLabware,
+      mockLabwareRobotStateWithFlexStackerLabware,
+      mockModuleState
+    )
+
+    expect(setStoredLabware).toBe(
+      `# Set Stored Labware:
+flex_stacker_1.set_stored_labware(
+    load_name="fixture_96_plate",
+    count=0
 )`.trimStart()
     )
   })

--- a/step-generation/src/utils/pythonFileUtils.ts
+++ b/step-generation/src/utils/pythonFileUtils.ts
@@ -666,6 +666,8 @@ export const getSetStoredLabware = (
           getSlotInLocationStack(labware.stack) === moduleSlot &&
           !labware.stack.includes(HOPPER_STACKER_LOCATION)
       )
+      // TODO: this doesn't address adapters in the shuttle yet since we dont allow that
+      // as of 1/9/26
       if (labwaresOnHopper.length === 0) {
         if (labwaresOnShuttle.length === 0) {
           return ''
@@ -687,6 +689,8 @@ export const getSetStoredLabware = (
           `load_name=${formatPyStr(
             labwareEntities[nonLid[0]].def.parameters.loadName
           )}`,
+          `namespace=${formatPyStr(labwareEntities[nonLid[0]].def.namespace)}`,
+          `version=${labwareEntities[nonLid[0]].def.version}`,
           'count=0',
           ...(lid != null
             ? [

--- a/step-generation/src/utils/pythonFileUtils.ts
+++ b/step-generation/src/utils/pythonFileUtils.ts
@@ -41,6 +41,7 @@ import type {
   LabwareTemporalProperties,
   LiquidEntities,
   ModuleEntities,
+  ModuleTemporalProperties,
   PipetteEntities,
   Timeline,
   TimelineFrame,
@@ -597,7 +598,7 @@ export function pythonDefRun(
     getDefineLiquids(liquidEntities),
     getLoadLiquids(liquidsByLabwareId, liquidEntities, labwareEntities),
     getLoadLiquidClasses(allUniqueLiquidClassesFromForms),
-    getSetStoredLabware(moduleEntities, labwareEntities, labware),
+    getSetStoredLabware(moduleEntities, labwareEntities, labware, modules),
     stepCommands(robotStateTimeline),
   ]
   const functionBody =
@@ -647,19 +648,56 @@ export const formatChangeTipArg = (changeTip: ChangeTipOptions): string => {
 export const getSetStoredLabware = (
   moduleEntities: ModuleEntities,
   labwareEntities: LabwareEntities,
-  labware: { [labwareId: string]: LabwareTemporalProperties }
+  labware: { [labwareId: string]: LabwareTemporalProperties },
+  modules: { [moduleId: string]: ModuleTemporalProperties }
 ): string => {
   const pythonSetStoredLabware = Object.values(moduleEntities).map(module => {
     const { id, type, pythonName } = module
 
     if (type === FLEX_STACKER_MODULE_TYPE) {
+      const moduleSlot = modules[id].slot
       const labwaresOnHopper = Object.entries(labware).filter(
         ([_, labware]) =>
           labware.stack.includes(id) &&
           labware.stack.includes(HOPPER_STACKER_LOCATION)
       )
+      const labwaresOnShuttle = Object.entries(labware).filter(
+        ([_, labware]) =>
+          getSlotInLocationStack(labware.stack) === moduleSlot &&
+          !labware.stack.includes(HOPPER_STACKER_LOCATION)
+      )
       if (labwaresOnHopper.length === 0) {
-        return ''
+        if (labwaresOnShuttle.length === 0) {
+          return ''
+        }
+
+        const lid = labwaresOnShuttle.find(([id]) =>
+          labwareEntities[id].def.allowedRoles?.includes('lid')
+        )
+
+        const nonLid = labwaresOnShuttle.find(
+          ([id]) => !labwareEntities[id].def.allowedRoles?.includes('lid')
+        )
+
+        if (nonLid == null) {
+          return ''
+        }
+
+        const pythonArgs = [
+          `load_name=${formatPyStr(
+            labwareEntities[nonLid[0]].def.parameters.loadName
+          )}`,
+          'count=0',
+          ...(lid != null
+            ? [
+                `lid=${formatPyStr(
+                  labwareEntities[lid[0]].def.parameters.loadName
+                )}`,
+              ]
+            : []),
+        ].join(',\n')
+
+        return `${pythonName}.set_stored_labware(\n${indentPyLines(pythonArgs)}\n)`
       } else {
         const labwarePythonNames = Object.values(labwaresOnHopper).map(
           labware => labwareEntities[labware[0]].pythonName


### PR DESCRIPTION
…tle only

closes EXEC-2220

# Overview

if you have a protocol with nothing in the hopper at the start and you're moving stuff from the shuttle to the hopper, emit a `set_stored_labware()` command to set the stored labware.

## Test Plan and Hands on Testing

upload the protocol attached to the ticket into PD in this branch. and then export that protocol and see that the set stored labware command is emitted!

NOTE: it will fail analysis because the universal lid is not supported in the hopper - in a follow up, i'll make it so you can only add the tiprack lid to the shuttle but all other lids are not allowed.

## Changelog

emit `set_stored_labware()` when only a labware on the shuttle is added in starting deck state

## Risk assessment

low