### PR TITLE
feat(protocol-designer): Handle profile steps turning into non-profile steps, and vice versa

### DIFF
--- a/protocol-designer/src/analytics/__tests__/reduxActionToAnalyticsEvent.test.ts
+++ b/protocol-designer/src/analytics/__tests__/reduxActionToAnalyticsEvent.test.ts
@@ -133,7 +133,9 @@ describe('reduxActionToAnalyticsEvent', () => {
     const action = {
       type: 'SAVE_STEP_FORM',
       payload: {
-        id: 'stepId' /* .. other fields don't matter, will be read from getArgsAndErrors */,
+        form: {
+          id: 'stepId' /* .. other fields don't matter, will be read from getArgsAndErrors */,
+        },
       },
     }
     const result = reduxActionToAnalyticsEvent(fooState, action)

--- a/protocol-designer/src/analytics/middleware.ts
+++ b/protocol-designer/src/analytics/middleware.ts
@@ -74,7 +74,7 @@ export const reduxActionToAnalyticsEvent = (
     const a: SaveStepFormAction = action
 
     const argsAndErrors: StepArgsAndErrors =
-      getArgsAndErrorsByStepId(state)[a.payload.id]
+      getArgsAndErrorsByStepId(state)[a.payload.form.id]
 
     const { stepArgs } = argsAndErrors
 

--- a/protocol-designer/src/step-forms/reducers/index.ts
+++ b/protocol-designer/src/step-forms/reducers/index.ts
@@ -18,6 +18,12 @@ import {
 } from '@opentrons/shared-data'
 import { GRIPPER_LOCATION } from '@opentrons/step-generation'
 
+import {
+  convertStepArrayToHierarchy,
+  findStep,
+  getPairedSteps,
+} from '/protocol-designer/steplist/utils/stepHierarchy'
+
 import { INITIAL_DECK_SETUP_STEP_ID } from '../../constants'
 import { getPDMetadata } from '../../file-types'
 import {
@@ -51,6 +57,8 @@ import {
   getDeckItemIdInSlot,
   getIdsInRange,
 } from '../utils'
+import { findAndSplice } from '../utils/findAndSplice'
+import { getThermocyclerFormType } from '../utils/getThermocyclerFormType'
 import { nestedCombineReducers } from './nestedCombineReducers'
 
 import type { Reducer } from 'redux'
@@ -349,10 +357,14 @@ export const savedStepForms = (
 
   switch (action.type) {
     case 'SAVE_STEP_FORM': {
-      return {
-        ...savedStepForms,
-        [action.payload.form.id]: action.payload.form,
-      }
+      const { newStepFormsById } = saveStepFormHelper({
+        action,
+        originalOrderedStepIds: rootState.orderedStepIds,
+        originalStepFormsById: savedStepForms,
+        enableConcurrentModuleActions:
+          action.payload.enableConcurrentModuleActions,
+      })
+      return newStepFormsById
     }
 
     case 'SAVE_STEP_FORMS_MULTI': {
@@ -1600,13 +1612,14 @@ export const orderedStepIds = (
 
   switch (action.type) {
     case 'SAVE_STEP_FORM': {
-      const id = action.payload.form.id
-
-      if (!orderedStepIds.includes(id)) {
-        return [...orderedStepIds, id]
-      }
-
-      return orderedStepIds
+      const { newOrderedStepIds } = saveStepFormHelper({
+        action,
+        originalOrderedStepIds: orderedStepIds,
+        originalStepFormsById: rootState.savedStepForms,
+        enableConcurrentModuleActions:
+          action.payload.enableConcurrentModuleActions,
+      })
+      return newOrderedStepIds
     }
 
     case 'DELETE_MULTIPLE_STEPS': {
@@ -1702,6 +1715,172 @@ export const stackerLabwareReducer = (
       return { ...state, pendingCreation: false }
     default:
       return state
+  }
+}
+
+// If/when FormData becomes a proper union, these should automatically pick up the improved property types.
+type ThermocyclerFormData = FormData & { stepType: 'thermocycler' }
+type PauseFormData = FormData & { stepType: 'pause' }
+
+interface SaveStepFormHelperArgs {
+  action: SaveStepFormAction
+  originalOrderedStepIds: StepIdType[]
+  originalStepFormsById: Record<StepIdType, FormData>
+  enableConcurrentModuleActions: boolean
+}
+interface SaveStepFormHelperResult {
+  newOrderedStepIds: StepIdType[]
+  newStepFormsById: Record<StepIdType, FormData>
+}
+function saveStepFormHelper(
+  args: SaveStepFormHelperArgs
+): SaveStepFormHelperResult {
+  const {
+    action,
+    originalOrderedStepIds,
+    originalStepFormsById,
+    enableConcurrentModuleActions,
+  } = args
+
+  const newForm = action.payload.form
+  const originalStep: FormData | null =
+    originalStepFormsById[newForm.id] ?? null
+
+  const originalOrderedSteps = originalOrderedStepIds.map(
+    id => originalStepFormsById[id]
+  )
+  const originalStepHierarchy = convertStepArrayToHierarchy(
+    originalOrderedSteps,
+    action.payload.enableConcurrentModuleActions
+  )
+
+  const findResult = findStep(originalStepHierarchy, newForm.id)
+
+  if (findResult == null) {
+    // We're creating a brand new step. Append it to the end.
+    // If it's a Thermocycler profile, also pair it with a "wait for profile to complete" step.
+
+    const newPauseForm: PauseFormData | null =
+      enableConcurrentModuleActions &&
+      getThermocyclerFormType(newForm) === 'thermocyclerProfile'
+        ? getThermocyclerProfilePauseForm(
+            newForm as ThermocyclerFormData,
+            action.payload.thermocyclerPauseStepId
+          )
+        : null
+    return {
+      newOrderedStepIds: [
+        ...originalOrderedStepIds,
+        newForm.id,
+        ...(newPauseForm != null ? [newPauseForm.id] : []),
+      ],
+      newStepFormsById: {
+        ...originalStepFormsById,
+        [newForm.id]: newForm,
+        ...(newPauseForm != null && { [newPauseForm.id]: newPauseForm }),
+      },
+    }
+  } else {
+    // We're editing an existing step.
+    if (
+      getThermocyclerFormType(originalStep) === 'thermocyclerProfile' &&
+      getThermocyclerFormType(newForm) !== 'thermocyclerProfile'
+    ) {
+      // An existing Thermocycler profile step is turning into a non-profile step.
+      // We need to delete the hidden "wait for profile to complete" step that it was paired with.
+
+      const pairedStepIds = getPairedSteps(
+        originalStepHierarchy,
+        new Set([originalStep.id])
+      )
+      return {
+        newOrderedStepIds: originalOrderedStepIds.filter(
+          id => !pairedStepIds.has(id)
+        ),
+        newStepFormsById: {
+          ...omit(originalStepFormsById, [...pairedStepIds]),
+          [newForm.id]: newForm,
+        },
+      }
+    } else if (
+      getThermocyclerFormType(originalStep) !== 'thermocyclerProfile' &&
+      getThermocyclerFormType(newForm) === 'thermocyclerProfile'
+    ) {
+      // An existing step is turning into a Thermocycler profile step. We need to:
+      // 1) Potentially find a new position to move it to, since we can't allow Thermocycler profiles to nest.
+      // 2) Create a hidden "wait for profile to complete" step that it will be permanently paired with.
+
+      const newPauseForm = enableConcurrentModuleActions
+        ? getThermocyclerProfilePauseForm(
+            newForm as ThermocyclerFormData,
+            action.payload.thermocyclerPauseStepId
+          )
+        : null
+
+      // If the edited step was is inside a Thermocycler profile, we'll move it to just after the profile.
+      // null means "leave the edited step in-place."
+      const stepIdToMoveEditedStepAfter: StepIdType | null =
+        'type' in findResult.enclosingNode &&
+        findResult.enclosingNode.type === 'thermocyclerProfileGroup'
+          ? findResult.enclosingNode.waitForThermocyclerProfileStepId
+          : null
+
+      const { result: newOrderedStepIds, success: spliceSuccess } =
+        findAndSplice({
+          source: originalOrderedStepIds,
+          elementToRemove: originalStep.id,
+          elementToInsertAfter: stepIdToMoveEditedStepAfter,
+          elementsToInsert: [
+            newForm.id,
+            ...(newPauseForm != null ? [newPauseForm.id] : []),
+          ],
+        })
+
+      if (!spliceSuccess) {
+        // This should only happen if there's a bug elsewhere that's messing up the timeline order. See `StepHierarchy`.
+        console.error(
+          'Error rearranging steps for a new Thermocycler profile. Leaving the steps unchanged.'
+        )
+        return {
+          newOrderedStepIds: originalOrderedStepIds,
+          newStepFormsById: originalStepFormsById,
+        }
+      }
+
+      return {
+        newOrderedStepIds,
+        newStepFormsById: {
+          ...originalStepFormsById,
+          [newForm.id]: newForm,
+          ...(newPauseForm != null && { [newPauseForm.id]: newPauseForm }),
+        },
+      }
+    } else {
+      // We're editing an existing step and there's no Thermocycler profile nonsense going on,
+      // so just update the step to its new value and leave the step order unchanged.
+      return {
+        newOrderedStepIds: originalOrderedStepIds,
+        newStepFormsById: {
+          ...originalStepFormsById,
+          [newForm.id]: newForm,
+        },
+      }
+    }
+  }
+}
+
+function getThermocyclerProfilePauseForm(
+  thermocyclerForm: ThermocyclerFormData,
+  id: string
+): PauseFormData {
+  return {
+    id,
+    stepType: 'pause',
+    stepName: 'pause',
+    stepDetails: '',
+
+    pauseAction: 'untilThermocyclerProfileComplete',
+    moduleId: thermocyclerForm.moduleId,
   }
 }
 

--- a/protocol-designer/src/step-forms/reducers/index.ts
+++ b/protocol-designer/src/step-forms/reducers/index.ts
@@ -349,7 +349,10 @@ export const savedStepForms = (
 
   switch (action.type) {
     case 'SAVE_STEP_FORM': {
-      return { ...savedStepForms, [action.payload.id]: action.payload }
+      return {
+        ...savedStepForms,
+        [action.payload.form.id]: action.payload.form,
+      }
     }
 
     case 'SAVE_STEP_FORMS_MULTI': {
@@ -1589,7 +1592,7 @@ export const orderedStepIds: Reducer<OrderedStepIdsState, any> = handleActions(
       state: OrderedStepIdsState,
       action: SaveStepFormAction
     ) => {
-      const id = action.payload.id
+      const id = action.payload.form.id
 
       if (!state.includes(id)) {
         return [...state, id]

--- a/protocol-designer/src/step-forms/reducers/index.ts
+++ b/protocol-designer/src/step-forms/reducers/index.ts
@@ -1582,43 +1582,54 @@ const unsavedGroup: Reducer<UnsavedGroupState, any> = handleActions<
   initialUnsavedGroupState
 )
 
+type OrderedStepIdsActions =
+  | SaveStepFormAction
+  | DeleteMultipleStepsAction
+  | LoadFileAction
+  | DuplicateSelectedStepsAction
+  | ReorderStepsAction
 export type OrderedStepIdsState = StepIdType[]
 const initialOrderedStepIdsState: string[] = []
-// @ts-expect-error(sa, 2021-6-10): cannot use string literals as action type
-// TODO IMMEDIATELY: refactor this to the old fashioned way if we cannot have type safety: https://github.com/redux-utilities/redux-actions/issues/282#issuecomment-595163081
-export const orderedStepIds: Reducer<OrderedStepIdsState, any> = handleActions(
-  {
-    SAVE_STEP_FORM: (
-      state: OrderedStepIdsState,
-      action: SaveStepFormAction
-    ) => {
+export const orderedStepIds = (
+  rootState: RootState,
+  action: OrderedStepIdsActions
+): OrderedStepIdsState => {
+  const orderedStepIds = rootState
+    ? rootState.orderedStepIds
+    : initialOrderedStepIdsState
+
+  switch (action.type) {
+    case 'SAVE_STEP_FORM': {
       const id = action.payload.form.id
 
-      if (!state.includes(id)) {
-        return [...state, id]
+      if (!orderedStepIds.includes(id)) {
+        return [...orderedStepIds, id]
       }
 
-      return state
-    },
-    DELETE_MULTIPLE_STEPS: (
-      state: OrderedStepIdsState,
-      action: DeleteMultipleStepsAction
-    ) => state.filter(id => !action.payload.includes(id)),
-    LOAD_FILE: (
-      state: OrderedStepIdsState,
-      action: LoadFileAction
-    ): OrderedStepIdsState => getPDMetadata(action.payload.file).orderedStepIds,
-    DUPLICATE_SELECTED_STEPS: (
-      state: OrderedStepIdsState,
-      action: DuplicateSelectedStepsAction
-    ): OrderedStepIdsState => action.payload.newStepOrder,
-    REORDER_STEPS: (
-      state: OrderedStepIdsState,
-      action: ReorderStepsAction
-    ): OrderedStepIdsState => action.payload.stepIds,
-  },
-  initialOrderedStepIdsState
-)
+      return orderedStepIds
+    }
+
+    case 'DELETE_MULTIPLE_STEPS': {
+      return orderedStepIds.filter(id => !action.payload.includes(id))
+    }
+
+    case 'LOAD_FILE': {
+      return getPDMetadata(action.payload.file).orderedStepIds
+    }
+
+    case 'DUPLICATE_SELECTED_STEPS': {
+      return action.payload.newStepOrder
+    }
+
+    case 'REORDER_STEPS': {
+      return action.payload.stepIds
+    }
+
+    default: {
+      return orderedStepIds
+    }
+  }
+}
 
 const initialDeckConfiguration: DeckConfigurationState = {
   deckConfig: FLEX_SIMPLEST_DECK_CONFIG,
@@ -1717,7 +1728,6 @@ export const rootReducer: Reducer<RootState, any> = nestedCombineReducers(
   ({ action, state, prevStateFallback }) => ({
     unsavedGroup: unsavedGroup(prevStateFallback.unsavedGroup, action),
     stepGroups: stepGroups(prevStateFallback.stepGroups, action),
-    orderedStepIds: orderedStepIds(prevStateFallback.orderedStepIds, action),
     labwareInvariantProperties: labwareInvariantProperties(
       prevStateFallback.labwareInvariantProperties,
       action
@@ -1741,6 +1751,7 @@ export const rootReducer: Reducer<RootState, any> = nestedCombineReducers(
     ),
     // 'forms' reducers get full rootReducer state
     savedStepForms: savedStepForms(state, action as SavedStepFormsActions),
+    orderedStepIds: orderedStepIds(state, action as OrderedStepIdsActions),
     unsavedForm: unsavedForm(state, action as UnsavedFormActions),
     presavedStepForm: presavedStepForm(
       prevStateFallback.presavedStepForm,

--- a/protocol-designer/src/step-forms/test/findAndSplice.test.ts
+++ b/protocol-designer/src/step-forms/test/findAndSplice.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from 'vitest'
+
+import { findAndSplice } from '../utils/findAndSplice'
+
+describe('findAndSplice', () => {
+  test('removal and reinsertion ', () => {
+    const result = findAndSplice({
+      source: ['a', 'b', 'c', 'd', 'e', 'f', 'g'],
+      elementToRemove: 'c',
+      elementToInsertAfter: 'e',
+      elementsToInsert: ['c', 'c2'],
+    })
+    expect(result).toStrictEqual({
+      success: true,
+      result: ['a', 'b', 'd', 'e', 'c', 'c2', 'f', 'g'],
+    } satisfies typeof result)
+  })
+})

--- a/protocol-designer/src/step-forms/test/findAndSplice.test.ts
+++ b/protocol-designer/src/step-forms/test/findAndSplice.test.ts
@@ -3,16 +3,55 @@ import { describe, expect, test } from 'vitest'
 import { findAndSplice } from '../utils/findAndSplice'
 
 describe('findAndSplice', () => {
-  test('removal and reinsertion ', () => {
+  test('insertion point after removal point', () => {
     const result = findAndSplice({
       source: ['a', 'b', 'c', 'd', 'e', 'f', 'g'],
       elementToRemove: 'c',
       elementToInsertAfter: 'e',
-      elementsToInsert: ['c', 'c2'],
+      elementsToInsert: ['inserted-1', 'inserted-2'],
     })
     expect(result).toStrictEqual({
       success: true,
-      result: ['a', 'b', 'd', 'e', 'c', 'c2', 'f', 'g'],
+      result: ['a', 'b', 'd', 'e', 'inserted-1', 'inserted-2', 'f', 'g'],
     } satisfies typeof result)
   })
+
+  test('removal point after insertion point', () => {
+    const result = findAndSplice({
+      source: ['a', 'b', 'c', 'd', 'e', 'f', 'g'],
+      elementToRemove: 'e',
+      elementToInsertAfter: 'c',
+      elementsToInsert: ['inserted-1', 'inserted-2'],
+    })
+    expect(result).toStrictEqual({
+      success: true,
+      result: ['a', 'b', 'c', 'inserted-1', 'inserted-2', 'd', 'f', 'g'],
+    } satisfies typeof result)
+  });
+
+  test('insertion point not found', () => {
+    const result = findAndSplice({
+      source: ['a', 'b', 'c', 'd', 'e', 'f', 'g'],
+      elementToRemove: 'z',
+      elementToInsertAfter: 'a',
+      elementsToInsert: ['inserted-1', 'inserted-2'],
+    })
+    expect(result).toStrictEqual({
+      success: false,
+      result: ['a', 'b', 'c', 'd', 'e', 'f', 'g'],
+    } satisfies typeof result)
+  });
+
+  test('removal point not found', () => {
+    const result = findAndSplice({
+      source: ['a', 'b', 'c', 'd', 'e', 'f', 'g'],
+      elementToRemove: 'a',
+      elementToInsertAfter: 'z',
+      elementsToInsert: ['inserted-1', 'inserted-2'],
+    })
+    expect(result).toStrictEqual({
+      success: false,
+      result: ['a', 'b', 'c', 'd', 'e', 'f', 'g'],
+    } satisfies typeof result)
+  });
 })

--- a/protocol-designer/src/step-forms/test/findAndSplice.test.ts
+++ b/protocol-designer/src/step-forms/test/findAndSplice.test.ts
@@ -29,7 +29,7 @@ describe('findAndSplice', () => {
     } satisfies typeof result)
   })
 
-  test('insertion point not found', () => {
+  test('removal point not found', () => {
     const result = findAndSplice({
       source: ['a', 'b', 'c', 'd', 'e', 'f', 'g'],
       elementToRemove: 'z',
@@ -42,7 +42,7 @@ describe('findAndSplice', () => {
     } satisfies typeof result)
   })
 
-  test('removal point not found', () => {
+  test('insertion point not found', () => {
     const result = findAndSplice({
       source: ['a', 'b', 'c', 'd', 'e', 'f', 'g'],
       elementToRemove: 'a',

--- a/protocol-designer/src/step-forms/test/findAndSplice.test.ts
+++ b/protocol-designer/src/step-forms/test/findAndSplice.test.ts
@@ -27,7 +27,7 @@ describe('findAndSplice', () => {
       success: true,
       result: ['a', 'b', 'c', 'inserted-1', 'inserted-2', 'd', 'f', 'g'],
     } satisfies typeof result)
-  });
+  })
 
   test('insertion point not found', () => {
     const result = findAndSplice({
@@ -40,7 +40,7 @@ describe('findAndSplice', () => {
       success: false,
       result: ['a', 'b', 'c', 'd', 'e', 'f', 'g'],
     } satisfies typeof result)
-  });
+  })
 
   test('removal point not found', () => {
     const result = findAndSplice({
@@ -53,5 +53,5 @@ describe('findAndSplice', () => {
       success: false,
       result: ['a', 'b', 'c', 'd', 'e', 'f', 'g'],
     } satisfies typeof result)
-  });
+  })
 })

--- a/protocol-designer/src/step-forms/test/reducers.test.ts
+++ b/protocol-designer/src/step-forms/test/reducers.test.ts
@@ -29,6 +29,7 @@ import {
 import { createPresavedStepForm } from '../utils/createPresavedStepForm'
 
 import type { ModuleEntity } from '@opentrons/step-generation'
+import type { SaveStepFormAction } from '/protocol-designer/ui/steps/actions/thunks'
 import type { FormData, StepType } from '../../form-types'
 import type { DeleteContainerAction } from '../../labware-ingred/actions/actions'
 import type {
@@ -73,37 +74,77 @@ afterEach(() => {
 })
 describe('orderedStepIds reducer', () => {
   it('should add a saved step when that step is new', () => {
-    const state = ['99']
-    const action = {
-      type: 'SAVE_STEP_FORM',
-      payload: {
-        id: '123',
-        stepType: 'moveLiquid',
+    const state: Partial<RootState> = {
+      orderedStepIds: ['99'],
+      savedStepForms: {
+        '99': {
+          id: '99',
+          stepType: 'moveLiquid',
+        },
       },
     }
-    expect(orderedStepIds(state, action)).toEqual(['99', '123'])
+    const action: SaveStepFormAction = {
+      type: 'SAVE_STEP_FORM',
+      payload: {
+        form: {
+          id: '123',
+          stepType: 'moveLiquid',
+        },
+        enableConcurrentModuleActions: true,
+        thermocyclerPauseStepId: 'thermocyclerPauseStepId',
+      },
+    }
+    expect(orderedStepIds(state as RootState, action)).toEqual(['99', '123'])
   })
   it('should not update when an existing step is saved', () => {
-    const state = ['99', '123', '11']
-    const action = {
-      type: 'SAVE_STEP_FORM',
-      payload: {
-        id: '123',
-        stepType: 'moveLiquid',
+    const state: Partial<RootState> = {
+      orderedStepIds: ['99', '123', '11'],
+      savedStepForms: {
+        '99': {
+          id: '99',
+          stepType: 'moveLiquid',
+        },
+        '123': {
+          id: '123',
+          stepType: 'moveLiquid',
+        },
+        '11': {
+          id: '11',
+          stepType: 'moveLiquid',
+        },
       },
     }
-    expect(orderedStepIds(state, action)).toBe(state)
+    const action: SaveStepFormAction = {
+      type: 'SAVE_STEP_FORM',
+      payload: {
+        form: {
+          id: '123',
+          stepType: 'moveLiquid',
+        },
+        enableConcurrentModuleActions: true,
+        thermocyclerPauseStepId: 'thermocyclerPauseStepId',
+      },
+    }
+    expect(orderedStepIds(state as RootState, action)).toBe(
+      state.orderedStepIds
+    )
   })
   it('should remove multiple saved steps when multiple steps are deleted', () => {
-    const state = ['1', '2', '3']
-    const action = {
+    const state: Partial<RootState> = {
+      orderedStepIds: ['1', '2', '3'],
+      savedStepForms: {},
+    }
+    const action: DeleteMultipleStepsAction = {
       type: 'DELETE_MULTIPLE_STEPS',
       payload: ['1', '3'],
     }
-    expect(orderedStepIds(state, action)).toEqual(['2'])
+    expect(orderedStepIds(state as RootState, action)).toEqual(['2'])
   })
   it('should set the new step order when steps are duplicated', () => {
-    const state = ['1', '2', '3']
+    const state: Partial<RootState> = {
+      orderedStepIds: ['1', '2', '3'],
+      savedStepForms: {},
+    }
     const action: DuplicateSelectedStepsAction = {
       type: 'DUPLICATE_SELECTED_STEPS',
       payload: {
@@ -116,7 +157,12 @@ describe('orderedStepIds reducer', () => {
         newStepOrder: ['1', 'dup_1', '2', '3'],
       },
     }
-    expect(orderedStepIds(state, action)).toEqual(['1', 'dup_1', '2', '3'])
+    expect(orderedStepIds(state as RootState, action)).toEqual([
+      '1',
+      'dup_1',
+      '2',
+      '3',
+    ])
   })
 })
 describe('labwareInvariantProperties reducer', () => {

--- a/protocol-designer/src/step-forms/test/reducers.test.ts
+++ b/protocol-designer/src/step-forms/test/reducers.test.ts
@@ -129,6 +129,187 @@ describe('orderedStepIds reducer', () => {
       state.orderedStepIds
     )
   })
+  it.each([true, false])(
+    'should also add a pause step when a new thermocycler profile step is created (enableConcurrentModuleActions: %s)',
+    enableConcurrentModuleActions => {
+      const state: Partial<RootState> = {
+        orderedStepIds: ['id-1'],
+        savedStepForms: {
+          'id-1': {
+            id: 'id-1',
+            stepType: 'moveLiquid',
+          },
+        },
+      }
+      const action: SaveStepFormAction = {
+        type: 'SAVE_STEP_FORM',
+        payload: {
+          form: {
+            id: 'id-2',
+            stepType: 'thermocycler',
+            thermocyclerFormType: 'thermocyclerProfile',
+            moduleId: 'thermocyclerModuleId',
+          },
+          enableConcurrentModuleActions,
+          thermocyclerPauseStepId: 'id-3',
+        },
+      }
+      const expectedOrder = enableConcurrentModuleActions
+        ? ['id-1', 'id-2', 'id-3']
+        : ['id-1', 'id-2']
+      expect(orderedStepIds(state as RootState, action)).toEqual(expectedOrder)
+    }
+  )
+  it.each([
+    [true, ['1', '2', 'pause-for-2', '3']],
+    [false, ['1', '2', '3']],
+  ])(
+    'should create a pause step when a non-TC-profile step is edited to become a TC profile step (enableConcurrentModuleActions: %s)',
+    (enableConcurrentModuleActions, expectedOrder) => {
+      const state: Partial<RootState> = {
+        orderedStepIds: ['1', '2', '3'],
+        savedStepForms: {
+          '1': {
+            id: '1',
+            stepType: 'moveLiquid',
+          },
+          '2': {
+            id: '2',
+            stepType: 'thermocycler',
+            thermocyclerFormType: 'thermocyclerState',
+            moduleId: 'thermocyclerModuleId',
+          },
+          '3': {
+            id: '3',
+            stepType: 'moveLiquid',
+          },
+        },
+      }
+
+      const action: SaveStepFormAction = {
+        type: 'SAVE_STEP_FORM',
+        payload: {
+          form: {
+            id: '2',
+            stepType: 'thermocycler',
+            thermocyclerFormType: 'thermocyclerProfile',
+            moduleId: 'thermocyclerModuleId',
+          },
+          enableConcurrentModuleActions,
+          thermocyclerPauseStepId: 'pause-for-2',
+        },
+      }
+
+      expect(orderedStepIds(state as RootState, action)).toEqual(expectedOrder)
+    }
+  )
+  it('should handle a non-TC-profile, which is inside a TC profile, being edited to also become a TC profile', () => {
+    // Since we can't allow TC profiles to nest, the edited step should get moved
+    // so it's outside the profile that was enclosing it.
+    const state: Partial<RootState> = {
+      orderedStepIds: [
+        '1',
+        '2-begin-profile',
+        '3',
+        '4',
+        '5',
+        '6-pause-for-2',
+        '7',
+      ],
+      savedStepForms: {
+        '1': { id: '1', stepType: 'moveLiquid' },
+        '2-begin-profile': {
+          id: '2-begin-profile',
+          stepType: 'thermocycler',
+          thermocyclerFormType: 'thermocyclerProfile',
+          moduleId: 'thermocyclerModuleId',
+        },
+        '3': { id: '3', stepType: 'moveLiquid' },
+        '4': {
+          id: '4',
+          stepType: 'thermocycler',
+          thermocyclerFormType: 'thermocyclerState',
+          moduleId: 'thermocyclerModuleId',
+        },
+        '5': { id: '5', stepType: 'moveLiquid' },
+        '6-pause-for-2': {
+          id: '6-pause-for-2',
+          stepType: 'pause',
+          pauseAction: 'untilThermocyclerProfileComplete',
+          moduleId: 'thermocyclerModuleId',
+        },
+        '7': { id: '7', stepType: 'moveLiquid' },
+      },
+    }
+
+    const action: SaveStepFormAction = {
+      type: 'SAVE_STEP_FORM',
+      payload: {
+        form: {
+          id: '4',
+          stepType: 'thermocycler',
+          thermocyclerFormType: 'thermocyclerProfile',
+          moduleId: 'thermocyclerModuleId',
+        },
+        enableConcurrentModuleActions: true,
+        thermocyclerPauseStepId: 'pause-for-4',
+      },
+    }
+
+    expect(orderedStepIds(state as RootState, action)).toEqual([
+      '1',
+      '2-begin-profile',
+      '3',
+      '5',
+      '6-pause-for-2',
+      '4',
+      'pause-for-4',
+      '7', // Non-TC step
+    ])
+  })
+  it('should delete the paired pause step when a TC profile step is edited to become a non-TC-profile step', () => {
+    const state: Partial<RootState> = {
+      orderedStepIds: ['1', '2', '3', 'pause-for-2', '4'],
+      savedStepForms: {
+        '1': { id: '1', stepType: 'moveLiquid' },
+        '2': {
+          id: '2',
+          stepType: 'thermocycler',
+          thermocyclerFormType: 'thermocyclerProfile',
+          moduleId: 'thermocyclerModuleId',
+        },
+        '3': { id: '3', stepType: 'moveLiquid' },
+        'pause-for-2': {
+          id: 'pause-for-2',
+          stepType: 'pause',
+          pauseAction: 'untilThermocyclerProfileComplete',
+          moduleId: 'thermocyclerModuleId',
+        },
+        '4': { id: '4', stepType: 'moveLiquid' },
+      },
+    }
+
+    const action: SaveStepFormAction = {
+      type: 'SAVE_STEP_FORM',
+      payload: {
+        form: {
+          id: '2',
+          stepType: 'thermocycler',
+          thermocyclerFormType: 'thermocyclerState',
+          moduleId: 'thermocyclerModuleId',
+        },
+        enableConcurrentModuleActions: true,
+        thermocyclerPauseStepId: 'unused-thermocycler-pause-step-id',
+      },
+    }
+
+    expect(orderedStepIds(state as RootState, action)).toEqual([
+      '1',
+      '2',
+      '3',
+      '4',
+    ])
+  })
   it('should remove multiple saved steps when multiple steps are deleted', () => {
     const state: Partial<RootState> = {
       orderedStepIds: ['1', '2', '3'],
@@ -1241,6 +1422,186 @@ describe('savedStepForms reducer: initial deck setup step', () => {
       }
       expect(savedStepForms(prevState, action)).toEqual(
         expectedSavedStepFormState
+      )
+    })
+  })
+  describe('thermocycler profile pause step handling', () => {
+    it.each([true, false])(
+      'should also add a pause step when a thermocycler profile step is created from scratch (enableConcurrentModuleActions: %s)',
+      enableConcurrentModuleActions => {
+        const otherForm: FormData = {
+          id: 'otherFormId',
+          stepType: 'moveLiquid',
+        }
+        const tcProfileForm: FormData = {
+          id: 'tcProfileFormId',
+          stepType: 'thermocycler',
+          thermocyclerFormType: 'thermocyclerProfile',
+          moduleId: 'thermocyclerModuleId',
+        }
+        const state: Partial<RootState> = {
+          orderedStepIds: [otherForm.id],
+          savedStepForms: {
+            [otherForm.id]: otherForm,
+          },
+        }
+
+        const pauseStepFormId = 'pauseFormId'
+        const expectedPauseStepForm: FormData = {
+          id: pauseStepFormId,
+          stepType: 'pause',
+          stepName: 'pause',
+          stepDetails: '',
+          pauseAction: 'untilThermocyclerProfileComplete',
+          moduleId: tcProfileForm.moduleId,
+        }
+
+        const action: SaveStepFormAction = {
+          type: 'SAVE_STEP_FORM',
+          payload: {
+            form: tcProfileForm,
+            enableConcurrentModuleActions,
+            thermocyclerPauseStepId: pauseStepFormId,
+          },
+        }
+
+        const expectedSavedStepForms = {
+          [otherForm.id]: otherForm,
+          [tcProfileForm.id]: tcProfileForm,
+          ...(enableConcurrentModuleActions && {
+            [expectedPauseStepForm.id]: expectedPauseStepForm,
+          }),
+        }
+
+        expect(savedStepForms(state as RootState, action)).toEqual(
+          expectedSavedStepForms
+        )
+      }
+    )
+    it.each([true, false])(
+      'should create a pause step when a non-TC-profile step is edited to become a TC profile step (enableConcurrentModuleActions: %s)',
+      enableConcurrentModuleActions => {
+        const form1: FormData = {
+          id: '1',
+          stepType: 'moveLiquid',
+        }
+        const form2ThermocyclerState: FormData = {
+          id: '2',
+          stepType: 'thermocycler',
+          thermocyclerFormType: 'thermocyclerState',
+          moduleId: 'thermocyclerModuleId',
+        }
+        const form3: FormData = {
+          id: '3',
+          stepType: 'moveLiquid',
+        }
+        const state: Partial<RootState> = {
+          orderedStepIds: [form1.id, form2ThermocyclerState.id, form3.id],
+          savedStepForms: {
+            [form1.id]: form1,
+            [form2ThermocyclerState.id]: form2ThermocyclerState,
+            [form3.id]: form3,
+          },
+        }
+
+        const form2ThermocyclerProfile: FormData = {
+          id: '2',
+          stepType: 'thermocycler',
+          thermocyclerFormType: 'thermocyclerProfile',
+          moduleId: 'thermocyclerModuleId',
+        }
+
+        const pauseFormId = 'pauseFormId'
+        const expectedPauseForm: FormData = {
+          id: pauseFormId,
+          stepType: 'pause',
+          stepName: 'pause',
+          stepDetails: '',
+          pauseAction: 'untilThermocyclerProfileComplete',
+          moduleId: 'thermocyclerModuleId',
+        }
+
+        const action: SaveStepFormAction = {
+          type: 'SAVE_STEP_FORM',
+          payload: {
+            form: form2ThermocyclerProfile,
+            enableConcurrentModuleActions,
+            thermocyclerPauseStepId: pauseFormId,
+          },
+        }
+
+        const expectedSavedStepForms = {
+          [form1.id]: form1,
+          [form2ThermocyclerProfile.id]: form2ThermocyclerProfile,
+          ...(enableConcurrentModuleActions && {
+            [expectedPauseForm.id]: expectedPauseForm,
+          }),
+          [form3.id]: form3,
+        }
+
+        expect(savedStepForms(state as RootState, action)).toEqual(
+          expectedSavedStepForms
+        )
+      }
+    )
+    it('should delete the paired pause step when a TC profile step is edited to become a non-TC-profile step', () => {
+      const form1: FormData = { id: '1', stepType: 'moveLiquid' }
+      const form2ThermocyclerState: FormData = {
+        id: '2',
+        stepType: 'thermocycler',
+        thermocyclerFormType: 'thermocyclerState',
+        moduleId: 'thermocyclerModuleId',
+      }
+      const form2ThermocyclerProfile: FormData = {
+        id: '2',
+        stepType: 'thermocycler',
+        thermocyclerFormType: 'thermocyclerProfile',
+        moduleId: 'thermocyclerModuleId',
+      }
+      const pauseForm: FormData = {
+        id: 'pause-for-2',
+        stepType: 'pause',
+        pauseAction: 'untilThermocyclerProfileComplete',
+        moduleId: 'thermocyclerModuleId',
+      }
+      const form3: FormData = { id: '3', stepType: 'moveLiquid' }
+      const form4: FormData = { id: '4', stepType: 'moveLiquid' }
+
+      const state: Partial<RootState> = {
+        orderedStepIds: [
+          form1.id,
+          form2ThermocyclerProfile.id,
+          form3.id,
+          pauseForm.id,
+          form4.id,
+        ],
+        savedStepForms: {
+          [form1.id]: form1,
+          [form2ThermocyclerProfile.id]: form2ThermocyclerProfile,
+          [form3.id]: form3,
+          [pauseForm.id]: pauseForm,
+          [form4.id]: form4,
+        },
+      }
+
+      const action: SaveStepFormAction = {
+        type: 'SAVE_STEP_FORM',
+        payload: {
+          form: form2ThermocyclerState,
+          enableConcurrentModuleActions: true,
+          thermocyclerPauseStepId: 'unused-thermocycler-pause-step-id',
+        },
+      }
+
+      const expectedSavedStepForms = {
+        [form1.id]: form1,
+        [form2ThermocyclerState.id]: form2ThermocyclerState,
+        [form3.id]: form3,
+        [form4.id]: form4,
+      }
+
+      expect(savedStepForms(state as RootState, action)).toEqual(
+        expectedSavedStepForms
       )
     })
   })

--- a/protocol-designer/src/step-forms/utils/findAndSplice.ts
+++ b/protocol-designer/src/step-forms/utils/findAndSplice.ts
@@ -1,0 +1,48 @@
+interface FindAndSpliceArgs<T> {
+  source: T[]
+  elementToRemove: T
+  elementsToInsert: T[]
+  /** null will reinsert wherever `elementToRemove` was removed. */
+  elementToInsertAfter: T | null
+}
+
+interface FindAndSpliceResult<T> {
+  /**
+   * `false` if `elementToRemove` or `elementToInsertAfter` couldn't be found.
+   * In that case, the source array will be returned unchanged.
+   */
+  success: boolean
+  result: T[]
+}
+
+/**
+ * Remove an element from an array, and insert new elements at a designated location.
+ */
+export function findAndSplice<T>(
+  args: FindAndSpliceArgs<T>
+): FindAndSpliceResult<T> {
+  const { source, elementToRemove, elementsToInsert, elementToInsertAfter } =
+    args
+
+  const indexToRemove = source.findIndex(element => element === elementToRemove)
+  if (indexToRemove === -1) {
+    return { success: false, result: source }
+  }
+
+  const withRemoved = source.toSpliced(indexToRemove, 1)
+
+  const indexToInsertAt =
+    elementToInsertAfter == null
+      ? indexToRemove
+      : withRemoved.findIndex(element => element === elementToInsertAfter) + 1
+  if (indexToInsertAt === -1) {
+    return { success: false, result: source }
+  }
+
+  const withReinserted = withRemoved.toSpliced(
+    indexToInsertAt,
+    0,
+    ...elementsToInsert
+  )
+  return { success: true, result: withReinserted }
+}

--- a/protocol-designer/src/step-forms/utils/findAndSplice.ts
+++ b/protocol-designer/src/step-forms/utils/findAndSplice.ts
@@ -31,12 +31,15 @@ export function findAndSplice<T>(
 
   const withRemoved = source.toSpliced(indexToRemove, 1)
 
-  const indexToInsertAt =
-    elementToInsertAfter == null
-      ? indexToRemove
-      : withRemoved.findIndex(element => element === elementToInsertAfter) + 1
-  if (indexToInsertAt === -1) {
-    return { success: false, result: source }
+  let indexToInsertAt: number;
+  if (elementToInsertAfter == null) {
+    indexToInsertAt = indexToRemove;
+  } else {
+    const indexToInsertAfter = withRemoved.findIndex(element => element === elementToInsertAfter);
+    if (indexToInsertAfter === -1) {
+      return { success: false, result: source }
+    }
+    indexToInsertAt = indexToInsertAfter + 1;
   }
 
   const withReinserted = withRemoved.toSpliced(

--- a/protocol-designer/src/step-forms/utils/findAndSplice.ts
+++ b/protocol-designer/src/step-forms/utils/findAndSplice.ts
@@ -31,15 +31,17 @@ export function findAndSplice<T>(
 
   const withRemoved = source.toSpliced(indexToRemove, 1)
 
-  let indexToInsertAt: number;
+  let indexToInsertAt: number
   if (elementToInsertAfter == null) {
-    indexToInsertAt = indexToRemove;
+    indexToInsertAt = indexToRemove
   } else {
-    const indexToInsertAfter = withRemoved.findIndex(element => element === elementToInsertAfter);
+    const indexToInsertAfter = withRemoved.findIndex(
+      element => element === elementToInsertAfter
+    )
     if (indexToInsertAfter === -1) {
       return { success: false, result: source }
     }
-    indexToInsertAt = indexToInsertAfter + 1;
+    indexToInsertAt = indexToInsertAfter + 1
   }
 
   const withReinserted = withRemoved.toSpliced(

--- a/protocol-designer/src/step-forms/utils/getThermocyclerFormType.ts
+++ b/protocol-designer/src/step-forms/utils/getThermocyclerFormType.ts
@@ -1,0 +1,14 @@
+import type {
+  FormData,
+  HydratedThermocyclerFormData,
+} from '/protocol-designer/form-types'
+
+type ThermocyclerFormType = HydratedThermocyclerFormData['thermocyclerFormType']
+
+export function getThermocyclerFormType(
+  formData: FormData | null
+): ThermocyclerFormType | null {
+  return formData?.stepType === 'thermocycler'
+    ? formData.thermocyclerFormType
+    : null
+}

--- a/protocol-designer/src/steplist/test/stepHierarchy.test.ts
+++ b/protocol-designer/src/steplist/test/stepHierarchy.test.ts
@@ -9,6 +9,7 @@ import {
   computeStepSwap,
   convertStepArrayToHierarchy,
   convertStepHierarchyToArray,
+  findStep,
   getPairedSteps,
 } from '/protocol-designer/steplist/utils/stepHierarchy'
 
@@ -582,6 +583,75 @@ describe('computeStepSwap()', () => {
     }
     const result = computeStepSwap(originalHierarchy, 'nonexistent', 'up')
     expect(result).toStrictEqual(originalHierarchy)
+  })
+})
+
+describe('findStep()', () => {
+  const stepHierarchy: StepHierarchy = {
+    topLevelItems: [
+      { type: 'standaloneStep', stepId: 'standalone_1' },
+      { type: 'standaloneStep', stepId: 'standalone_2' },
+      {
+        type: 'thermocyclerProfileGroup',
+        thermocyclerProfileStepId: 'tc_profile_root',
+        concurrentSteps: [
+          { type: 'standaloneStep', stepId: 'concurrent_1' },
+          { type: 'standaloneStep', stepId: 'concurrent_2' },
+          { type: 'standaloneStep', stepId: 'concurrent_3' },
+        ],
+        waitForThermocyclerProfileStepId: 'tc_wait',
+      },
+      { type: 'standaloneStep', stepId: 'standalone_3' },
+    ],
+  }
+
+  it('should find a standalone step at the top level', () => {
+    const result = findStep(stepHierarchy, 'standalone_3')
+    expect(result).not.toBeNull()
+    expect(result?.foundNode).toStrictEqual({
+      type: 'standaloneStep',
+      stepId: 'standalone_3',
+    })
+    expect(result?.enclosingNode).toBe(stepHierarchy)
+    expect(result?.indexInEnclosingNode).toBe(3)
+  })
+
+  it('should find a thermocycler profile group root step', () => {
+    const result = findStep(stepHierarchy, 'tc_profile_root')
+    expect(result).not.toBeNull()
+    expect(result?.foundNode).toBe(stepHierarchy.topLevelItems[2])
+    expect(result?.enclosingNode).toBe(stepHierarchy)
+    expect(result?.indexInEnclosingNode).toBe(2)
+  })
+
+  it('should find a concurrent step within a thermocycler profile group', () => {
+    const result = findStep(stepHierarchy, 'concurrent_2')
+    expect(result).not.toBeNull()
+    expect(result?.foundNode).toStrictEqual({
+      type: 'standaloneStep',
+      stepId: 'concurrent_2',
+    })
+    expect(result?.enclosingNode).toBe(stepHierarchy.topLevelItems[2])
+    expect(result?.indexInEnclosingNode).toBe(1)
+  })
+
+  it('should return null for the wait step of a thermocycler profile group', () => {
+    expect(stepHierarchy.topLevelItems[2].type).toStrictEqual(
+      'thermocyclerProfileGroup'
+    )
+    const thermocyclerProfileGroup = stepHierarchy
+      .topLevelItems[2] as ThermocyclerProfileGroup
+
+    const result = findStep(
+      stepHierarchy,
+      thermocyclerProfileGroup.waitForThermocyclerProfileStepId
+    )
+    expect(result).toBeNull()
+  })
+
+  it('should return null for a nonexistent step', () => {
+    const result = findStep(stepHierarchy, 'nonexistent_step')
+    expect(result).toBeNull()
   })
 })
 

--- a/protocol-designer/src/steplist/utils/stepHierarchy.ts
+++ b/protocol-designer/src/steplist/utils/stepHierarchy.ts
@@ -179,7 +179,7 @@ type MoveStepResult =
   | { isMoveAllowed: false }
 
 /**
- * Recursively search the tree for a given step ID. It can either point to a
+ * Recursively search the tree for a given step ID. The step ID can either point to a
  * standalone step, or to the root of a group.
  *
  * The match's location in the tree is returned: either the top-level `StepHierarchy`,
@@ -188,7 +188,7 @@ type MoveStepResult =
  *
  * Returns `null` if there's no match.
  */
-function findStep(
+export function findStep(
   stepHierarchy: StepHierarchy,
   stepIdToFind: StepIdType
 ): null | {

--- a/protocol-designer/src/ui/steps/actions/__tests__/actions.test.ts
+++ b/protocol-designer/src/ui/steps/actions/__tests__/actions.test.ts
@@ -411,65 +411,6 @@ describe('steps actions', () => {
         }
       )
     })
-
-    describe('thermocycler profile form', () => {
-      it.each([
-        {
-          description:
-            'should automatically add bonus step when enableConcurrentModuleActions is true',
-          enableConcurrentModuleActions: true,
-          shouldAddBonusStep: true,
-        },
-        {
-          description:
-            'should NOT add bonus step when enableConcurrentModuleActions is false',
-          enableConcurrentModuleActions: false,
-          shouldAddBonusStep: false,
-        },
-      ])(
-        '$description',
-        ({ enableConcurrentModuleActions, shouldAddBonusStep }) => {
-          const thermocyclerForm: FormData = {
-            id: 'step_123',
-            stepType: 'thermocycler',
-            thermocyclerFormType: 'thermocyclerProfile',
-            moduleId: 'thermocyclerId',
-          }
-
-          when(vi.mocked(stepFormSelectors.getUnsavedForm))
-            .calledWith(expect.anything())
-            .thenReturn(thermocyclerForm)
-          when(vi.mocked(stepFormSelectors.getCurrentFormIsPresaved))
-            .calledWith(expect.anything())
-            .thenReturn(true)
-          when(vi.mocked(featureFlagSelectors.getEnableConcurrentModuleActions))
-            .calledWith(expect.anything())
-            .thenReturn(enableConcurrentModuleActions)
-
-          const store: any = mockStore()
-          store.dispatch(saveStepForm())
-
-          const actions = store.getActions()
-          expect(actions[0]).toEqual({
-            type: 'SAVE_STEP_FORM',
-            payload: thermocyclerForm,
-          })
-
-          if (shouldAddBonusStep) {
-            expect(actions[1].type).toStrictEqual('ADD_STEP')
-            expect(actions[2].payload.update.pauseAction).toStrictEqual(
-              'untilThermocyclerProfileComplete'
-            )
-            expect(actions[3].payload.update.moduleId).toStrictEqual(
-              'thermocyclerId'
-            )
-            expect(actions[4].type).toStrictEqual('SAVE_STEP_FORM')
-          } else {
-            expect(actions.length).toStrictEqual(1)
-          }
-        }
-      )
-    })
   })
 
   describe('reorderSelectedStep', () => {

--- a/protocol-designer/src/ui/steps/actions/__tests__/actions.test.ts
+++ b/protocol-designer/src/ui/steps/actions/__tests__/actions.test.ts
@@ -327,7 +327,11 @@ describe('steps actions', () => {
           const actions = store.getActions()
           expect(actions[0]).toEqual({
             type: 'SAVE_STEP_FORM',
-            payload: temperatureForm,
+            payload: {
+              form: temperatureForm,
+              thermocyclerPauseStepId: expect.any(String),
+              enableConcurrentModuleActions: true,
+            },
           })
           if (shouldAddBonusStep) {
             expect(actions[1].type).toStrictEqual('ADD_STEP')
@@ -391,7 +395,11 @@ describe('steps actions', () => {
           const actions = store.getActions()
           expect(actions[0]).toEqual({
             type: 'SAVE_STEP_FORM',
-            payload: heaterShakerForm,
+            payload: {
+              form: heaterShakerForm,
+              thermocyclerPauseStepId: expect.any(String),
+              enableConcurrentModuleActions: true,
+            },
           })
           if (shouldAddBonusStep) {
             expect(actions[1].type).toStrictEqual('ADD_STEP')

--- a/protocol-designer/src/ui/steps/actions/thunks/index.ts
+++ b/protocol-designer/src/ui/steps/actions/thunks/index.ts
@@ -9,14 +9,10 @@ import {
   THERMOCYCLER_MODULE_TYPE,
 } from '@opentrons/shared-data'
 
-import {
-  PAUSE_UNTIL_TC_PROFILE_COMPLETE,
-  PAUSE_UNTIL_TEMP,
-} from '/protocol-designer/constants'
+import { PAUSE_UNTIL_TEMP } from '/protocol-designer/constants'
 import { getEnableConcurrentModuleActions } from '/protocol-designer/feature-flags/selectors'
 import * as fileDataSelectors from '/protocol-designer/file-data/selectors'
 import {
-  getCurrentFormIsPresaved,
   getInitialDeckSetup,
   getSavedStepHierarchy,
   getUnsavedForm,
@@ -348,9 +344,6 @@ export const saveStepForm: (options?: {
   const { userWantsBonusStep = false } = options ?? {}
   const initialState = getState()
   const unsavedForm = getUnsavedForm(initialState)
-  const isFirstTimeSavingThisForm = getCurrentFormIsPresaved(initialState)
-  const enableConcurrentModuleActions =
-    getEnableConcurrentModuleActions(initialState)
 
   // this check is only for TypeScript. At this point, unsavedForm should always be populated
   if (unsavedForm == null) {
@@ -382,28 +375,10 @@ export const saveStepForm: (options?: {
     unsavedForm?.stepType === 'heaterShaker' &&
     unsavedForm?.targetHeaterShakerTemperature != null &&
     unsavedForm?.heaterShakerSetTimer !== true
-  const isTCProfileForm =
-    unsavedForm?.stepType === 'thermocycler' &&
-    unsavedForm?.thermocyclerFormType === 'thermocyclerProfile'
   if (isTempModSetTempForm && userWantsBonusStep) {
     dispatch(saveWaitForTemperatureModuleTemp(unsavedForm))
   } else if (isHSSetTempForm && userWantsBonusStep) {
     dispatch(saveWaitForHeaterShakerTemp(unsavedForm))
-  } else if (
-    isTCProfileForm &&
-    // todo(mm, 2025-11-25): isFirstTimeSavingThisForm is not quite sufficient here.
-    // We also need to cover the case where the form existed before as a non-profile step
-    // and now it's being edited into a profile step.
-    // https://opentrons.atlassian.net/browse/EXEC-2024
-    isFirstTimeSavingThisForm &&
-    // With enableConcurrentModuleActions, TC profile forms are interpreted as
-    // "start profile" steps and they're always paired with separate "wait for profile
-    // to complete" steps. Without enableConcurrentModuleActions, TC profile forms are
-    // interpreted as blocking "start profile and wait for it to complete" steps,
-    // without a separate wait step.
-    enableConcurrentModuleActions
-  ) {
-    dispatch(saveWaitForThermocyclerProfile(unsavedForm))
   }
 }
 
@@ -509,46 +484,3 @@ const saveWaitForHeaterShakerTemp: (
     )
   }
 }
-
-const saveWaitForThermocyclerProfile: (
-  unsavedThermocyclerProfileForm: FormData
-) => ThunkAction<any> =
-  unsavedThermocyclerProfileForm => (dispatch, getState) => {
-    const thermocyclerModuleId = unsavedThermocyclerProfileForm.moduleId
-
-    dispatch(
-      addStep({
-        stepType: 'pause',
-        robotStateTimeline: fileDataSelectors.getRobotStateTimeline(getState()),
-      })
-    )
-    // NOTE: fields should be set one at a time b/c dependentFieldsUpdate fns can filter out inputs
-    // contingent on other inputs (eg changing the pauseAction radio button may clear the pauseTemperature).
-    dispatch(
-      changeFormInput({
-        update: {
-          pauseAction: PAUSE_UNTIL_TC_PROFILE_COMPLETE,
-        },
-      })
-    )
-
-    dispatch(
-      changeFormInput({
-        update: {
-          moduleId: thermocyclerModuleId,
-        },
-      })
-    )
-
-    // finally save the new pause form
-    const unsavedPauseForm = getUnsavedForm(getState())
-    if (unsavedPauseForm != null) {
-      dispatch(_saveStepForm(unsavedPauseForm))
-    } else {
-      // this conditional is for TypeScript, the unsaved form should always exist
-      console.assert(
-        false,
-        'could not auto-save pause form, getUnsavedForm returned nullish'
-      )
-    }
-  }

--- a/protocol-designer/src/ui/steps/actions/thunks/index.ts
+++ b/protocol-designer/src/ui/steps/actions/thunks/index.ts
@@ -42,7 +42,11 @@ import {
 } from '../../selectors'
 import { addStep, selectDropdownItem } from '../actions'
 
-import type { FormData, StepType } from '/protocol-designer/form-types'
+import type {
+  FormData,
+  StepIdType,
+  StepType,
+} from '/protocol-designer/form-types'
 import type { ReorderStepsAction } from '/protocol-designer/steplist/actions/actions'
 import type { ThunkAction } from '/protocol-designer/types'
 import type {
@@ -318,14 +322,42 @@ export const duplicateSelectedSteps: () => ThunkAction<
 export const SAVE_STEP_FORM: 'SAVE_STEP_FORM' = 'SAVE_STEP_FORM'
 export interface SaveStepFormAction {
   type: typeof SAVE_STEP_FORM
-  payload: FormData
+  payload: {
+    /**
+     * The form that the user is saving.
+     *
+     * If the ID points to one that already exists, it will be edited in-place.
+     * Otherwise, it will be appended to the timeline as a new step.
+     */
+    form: FormData
+
+    /**
+     * If a new Thermocycler profile step is being saved, a "wait for profile to
+     * complete" step will be saved along with it, implicitly. This is the ID to use
+     * for that new wait step.
+     *
+     * If no wait step needs to be created, this is ignored.
+     */
+    thermocyclerPauseStepId: StepIdType
+
+    enableConcurrentModuleActions: boolean
+  }
 }
-export const _saveStepForm = (form: FormData): SaveStepFormAction => {
+export const _saveStepForm = (
+  form: FormData,
+  enableConcurrentModuleActions: boolean
+): SaveStepFormAction => {
   // if presaved, transform pseudo ID to real UUID upon save
-  const payload = form.id === PRESAVED_STEP_ID ? { ...form, id: uuid() } : form
+  const id = form.id === PRESAVED_STEP_ID ? uuid() : form.id
+  const adjustedForm = { ...form, id }
+
   return {
     type: SAVE_STEP_FORM,
-    payload,
+    payload: {
+      form: adjustedForm,
+      thermocyclerPauseStepId: uuid(),
+      enableConcurrentModuleActions,
+    },
   }
 }
 
@@ -344,6 +376,8 @@ export const saveStepForm: (options?: {
   const { userWantsBonusStep = false } = options ?? {}
   const initialState = getState()
   const unsavedForm = getUnsavedForm(initialState)
+  const enableConcurrentModuleActions =
+    getEnableConcurrentModuleActions(initialState)
 
   // this check is only for TypeScript. At this point, unsavedForm should always be populated
   if (unsavedForm == null) {
@@ -363,7 +397,7 @@ export const saveStepForm: (options?: {
   }
 
   // save the form
-  dispatch(_saveStepForm(unsavedForm))
+  dispatch(_saveStepForm(unsavedForm, enableConcurrentModuleActions))
 
   // Save any bonus steps that come with it.
   // NOTE: This logic to decide whether a bonus step is warranted should be kept in sync
@@ -385,6 +419,8 @@ export const saveStepForm: (options?: {
 const saveWaitForTemperatureModuleTemp: (
   unsavedSetTemperatureForm: FormData
 ) => ThunkAction<any> = unsavedSetTemperatureForm => (dispatch, getState) => {
+  const enableConcurrentModuleActions =
+    getEnableConcurrentModuleActions(getState())
   const tempertureModuleId = unsavedSetTemperatureForm?.moduleId
   const temperature = unsavedSetTemperatureForm.targetTemperature
 
@@ -426,7 +462,7 @@ const saveWaitForTemperatureModuleTemp: (
   // finally save the new pause form
   const unsavedPauseForm = getUnsavedForm(getState())
   if (unsavedPauseForm != null) {
-    dispatch(_saveStepForm(unsavedPauseForm))
+    dispatch(_saveStepForm(unsavedPauseForm, enableConcurrentModuleActions))
   } else {
     // this conditional is for TypeScript, the unsaved form should always exist
     console.assert(
@@ -439,6 +475,8 @@ const saveWaitForTemperatureModuleTemp: (
 const saveWaitForHeaterShakerTemp: (
   unsavedHeaterShakerForm: FormData
 ) => ThunkAction<any> = unsavedHeaterShakerForm => (dispatch, getState) => {
+  const enableConcurrentModuleActions =
+    getEnableConcurrentModuleActions(getState())
   const heaterShakerModuleId = unsavedHeaterShakerForm.moduleId
   const temperature = unsavedHeaterShakerForm.targetHeaterShakerTemperature
 
@@ -475,7 +513,7 @@ const saveWaitForHeaterShakerTemp: (
   // finally save the new pause form
   const unsavedPauseForm = getUnsavedForm(getState())
   if (unsavedPauseForm != null) {
-    dispatch(_saveStepForm(unsavedPauseForm))
+    dispatch(_saveStepForm(unsavedPauseForm, enableConcurrentModuleActions))
   } else {
     // this conditional is for TypeScript, the unsaved form should always exist
     console.assert(

--- a/protocol-designer/src/ui/steps/reducers.ts
+++ b/protocol-designer/src/ui/steps/reducers.ts
@@ -76,7 +76,7 @@ const selectedItem: Reducer<SelectedItemState, any> = handleActions(
     ADD_STEP: (state: SelectedItemState, action: AddStepAction) =>
       terminalItemIdHelper(PRESAVED_STEP_ID),
     SAVE_STEP_FORM: (state: SelectedItemState, action: SaveStepFormAction) => {
-      return stepIdHelper(action.payload.id)
+      return stepIdHelper(action.payload.form.id)
     },
     SELECT_STEP: (state: SelectedItemState, action: SelectStepAction) =>
       stepIdHelper(action.payload),

--- a/protocol-designer/src/ui/steps/test/reducers.test.ts
+++ b/protocol-designer/src/ui/steps/test/reducers.test.ts
@@ -8,6 +8,8 @@ import {
   TERMINAL_ITEM_SELECTION_TYPE,
 } from '../reducers'
 
+import type { FormData } from '/protocol-designer/form-types'
+import type { SaveStepFormAction } from '../actions/thunks'
 import type { SelectMultipleStepsAction } from '../actions/types'
 import type { SelectableItem } from '../reducers'
 
@@ -31,8 +33,10 @@ describe('selectedItem reducer', () => {
     const stepId = '123'
     const action = {
       type: 'SAVE_STEP_FORM',
-      payload: { id: stepId },
-    }
+      payload: {
+        form: { id: stepId } as FormData,
+      },
+    } as SaveStepFormAction
     expect(selectedItem(null, action)).toEqual({
       selectionType: SINGLE_STEP_SELECTION_TYPE,
       id: stepId,


### PR DESCRIPTION
## Overview

Every Thermocycler "start profile" step needs to be paired with exactly one "wait for profile" step. Prior PRs ensured this for creating and deleting steps, but not for _editing_ steps—for example, if you edit an "open lid" step to turn it into a "start profile" step. This PR closes that loophole.

This closes EXEC-2024.

## Test Plan and Hands on Testing

With the concurrent module actions feature flag enabled:

* [x] Creating a Thermocycler profile should automatically create a pause step. If the timeline UI shows a place to nest other steps within the profile, that means this worked.
* [x] Deleting a Thermocycler profile should automatically delete the pause step. Gotta inspect Redux state manually to test this.
* [x] Editing a non-profile step to turn it into a profile should automatically create a pause step.
  * [x] If the step being edited was enclosed inside another profile, the step being edited should be moved outside of it, because we can't allow profiles to nest.
* [x] Editing a profile step into a non-profile should automatically delete the pause step.
  * [x] Any steps that the edited profile was enclosing should be preserved.

With the feature flag disabled, there should be no change in behavior.

## Changelog

This expands the reducers for `orderedStepIds` and `savedStepForms` to implement the behavior described above any time a step is created or edited.

In prior code, I was trying to do this by [dispatching multiple actions from a thunk](https://github.com/Opentrons/opentrons/blob/9a503efa5bbbe0f09aabd6622f293c411e508792/protocol-designer/src/ui/steps/actions/thunks/index.ts#L336-L408)—one to add the "start profile" step, followed by several to add the "wait profile" step. That's how we've historically done it for the Temperature Module and Heater-Shaker. But that approach turned out to be insufficient because it couldn't easily control the positions of the steps. Also, just as a general best practice, it's good if stuff like this can be atomic; it'll facilitate features like undo/redo.

## Review requests

There are a couple of ugly things about this:

* The logic is complicated and tightly coupled between `orderedStepIds` and `savedStepForms`, so I put it in a helper function that `orderedStepIds` and `savedStepForms` both call. That means all of this code runs twice every time this action is handled.
* I needed to lightly refactor the `orderedStepIds` reducer take in the entire `step-forms` root state, instead of just the `orderedStepIds` slice. It needs to be able to see `savedStepForms` in order to understand the nested structure of the timeline.

I don't really know what to do about those. These are the kinds of thing that continually give me trouble in Redux. `orderedStepIds` and `savedStepForms` are *mostly* but not *entirely* decoupled from each other, so we're forced into a choice between merging them into a single monster-reducer, or keeping them split up and resorting to hacks like this.

## Risk assessment

Medium. I'm mucking around in core step-saving logic.