### PR TITLE
fix(protocol-designer): highlight shuttle when action occurs there

### DIFF
--- a/protocol-designer/src/constants.ts
+++ b/protocol-designer/src/constants.ts
@@ -99,7 +99,7 @@ export const FLEX_STACKER_STORE: 'store' = 'store'
 export const FLEX_STACKER_FILL: 'fill' = 'fill'
 export const FLEX_STACKER_EMPTY: 'empty' = 'empty'
 export const FLEX_STACKER_IN_HOPPER_ACTIONS = [
-  FLEX_STACKER_STORE,
+  FLEX_STACKER_FILL,
   FLEX_STACKER_EMPTY,
   FLEX_STACKER_RETRIEVE,
 ]

--- a/protocol-designer/src/constants.ts
+++ b/protocol-designer/src/constants.ts
@@ -98,6 +98,11 @@ export const FLEX_STACKER_RETRIEVE: 'retrieve' = 'retrieve'
 export const FLEX_STACKER_STORE: 'store' = 'store'
 export const FLEX_STACKER_FILL: 'fill' = 'fill'
 export const FLEX_STACKER_EMPTY: 'empty' = 'empty'
+export const FLEX_STACKER_IN_HOPPER_ACTIONS = [
+  FLEX_STACKER_STORE,
+  FLEX_STACKER_EMPTY,
+  FLEX_STACKER_RETRIEVE,
+]
 
 export const OFFDECK: 'offDeck' = 'offDeck'
 

--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupContainer.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupContainer.tsx
@@ -86,6 +86,7 @@ interface DeckSetupContainerProps {
   setViewBox: Dispatch<SetStateAction<string>>
   viewBox: string
   initialViewBox: string
+  currentStep: any
 }
 export function DeckSetupContainer(
   props: DeckSetupContainerProps
@@ -98,6 +99,7 @@ export function DeckSetupContainer(
     initialViewBox,
     viewBox,
     setViewBox,
+    currentStep,
   } = props
   const activeDeckSetup = useSelector(getDeckSetupForActiveItem)
   const dispatch = useDispatch<any>()
@@ -371,6 +373,7 @@ export function DeckSetupContainer(
                     setHover={setHoverSlot}
                     addEquipment={addEquipment}
                     activeDeckSetup={activeDeckSetup}
+                    currentStep={currentStep}
                     stagingAreaCutoutIds={stagingAreaFixtures.map(
                       areas => areas.location as CutoutId
                     )}

--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupContainer.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupContainer.tsx
@@ -62,6 +62,7 @@ import type {
   RobotType,
 } from '@opentrons/shared-data'
 import type { AdditionalEquipmentEntity } from '@opentrons/step-generation'
+import type { FormData } from '/protocol-designer/form-types'
 
 const DECK_VIEW_CONTAINER_MAX_HEIGHT = '35rem'
 
@@ -86,7 +87,7 @@ interface DeckSetupContainerProps {
   setViewBox: Dispatch<SetStateAction<string>>
   viewBox: string
   initialViewBox: string
-  currentStep: any
+  currentStep: FormData | null
 }
 export function DeckSetupContainer(
   props: DeckSetupContainerProps

--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupDetails.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupDetails.tsx
@@ -79,6 +79,7 @@ interface DeckSetupDetailsProps extends DeckSetupTerminalIdType {
   hover: string | null
   setHover: Dispatch<SetStateAction<string | null>>
   showGen1MultichannelCollisionWarnings: boolean
+  currentStep: any
   stagingAreaCutoutIds: CutoutId[]
   selectedZoomInSlot?: DeckSlotId
 }
@@ -94,6 +95,7 @@ export function DeckSetupDetails(props: DeckSetupDetailsProps): JSX.Element {
     setHover,
     showGen1MultichannelCollisionWarnings,
     stagingAreaCutoutIds,
+    currentStep,
   } = props
   const { labware: activeLabware } = activeDeckSetup
   const robotType = useSelector(getRobotType)
@@ -724,7 +726,11 @@ export function DeckSetupDetails(props: DeckSetupDetailsProps): JSX.Element {
       })}
 
       {/* highlight items from Protocol steps */}
-      <HighlightItems robotType={robotType} deckDef={deckDef} />
+      <HighlightItems
+        robotType={robotType}
+        deckDef={deckDef}
+        currentStep={currentStep}
+      />
 
       {/* selected hardware + labware */}
       <SelectedItems

--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupDetails.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupDetails.tsx
@@ -65,6 +65,7 @@ import type {
   ModuleTemporalProperties,
   ThermocyclerModuleState,
 } from '@opentrons/step-generation'
+import type { FormData } from '../../../form-types'
 import type {
   InitialDeckSetup,
   LabwareOnDeck as LabwareOnDeckType,
@@ -79,7 +80,7 @@ interface DeckSetupDetailsProps extends DeckSetupTerminalIdType {
   hover: string | null
   setHover: Dispatch<SetStateAction<string | null>>
   showGen1MultichannelCollisionWarnings: boolean
-  currentStep: any
+  currentStep: FormData | null
   stagingAreaCutoutIds: CutoutId[]
   selectedZoomInSlot?: DeckSlotId
 }

--- a/protocol-designer/src/pages/Designer/DeckSetup/HighlightItems.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/HighlightItems.tsx
@@ -309,7 +309,6 @@ export function HighlightItems(props: HighlightItemsProps): JSX.Element | null {
           slot != null && slot !== WASTE_CHUTE_CUTOUT
             ? getAddressableAreaFromSlotId(slot, deckDef)
             : null
-        console.log('🚀 ~ getDeckItems ~ addressableArea:', addressableArea)
 
         if (!addressableArea) {
           console.warn(

--- a/protocol-designer/src/pages/Designer/DeckSetup/HighlightItems.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/HighlightItems.tsx
@@ -165,7 +165,10 @@ export function HighlightItems(props: HighlightItemsProps): JSX.Element | null {
         Object.values(labware)
       )
       const isStacker = moduleOnDeck.type === FLEX_STACKER_MODULE_TYPE
-      const isActionOnShuttle = text === 'Store'
+      const notOnShuttleActions = ['empty', 'refill', 'retrieve']
+      const isActionOnShuttle =
+        isStacker && !notOnShuttleActions.includes(text?.toLowerCase() ?? '')
+
       const position = getPositionFromSlotId(
         moduleOnDeck.slot,
         deckDef,
@@ -306,6 +309,7 @@ export function HighlightItems(props: HighlightItemsProps): JSX.Element | null {
           slot != null && slot !== WASTE_CHUTE_CUTOUT
             ? getAddressableAreaFromSlotId(slot, deckDef)
             : null
+        console.log('🚀 ~ getDeckItems ~ addressableArea:', addressableArea)
 
         if (!addressableArea) {
           console.warn(
@@ -313,6 +317,7 @@ export function HighlightItems(props: HighlightItemsProps): JSX.Element | null {
           )
           return []
         }
+
         items.push(
           <DeckItemHighlight
             slotBoundingBox={addressableArea.boundingBox}

--- a/protocol-designer/src/pages/Designer/DeckSetup/HighlightItems.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/HighlightItems.tsx
@@ -165,9 +165,9 @@ export function HighlightItems(props: HighlightItemsProps): JSX.Element | null {
         Object.values(labware)
       )
       const isStacker = moduleOnDeck.type === FLEX_STACKER_MODULE_TYPE
-      const notOnShuttleActions = ['empty', 'refill', 'retrieve']
+      const onHopperActions = ['Empty', 'Refill', 'Retrieve']
       const isActionOnShuttle =
-        isStacker && !notOnShuttleActions.includes(text?.toLowerCase() ?? '')
+        isStacker && !onHopperActions.includes(text ?? '')
 
       const position = getPositionFromSlotId(
         moduleOnDeck.slot,

--- a/protocol-designer/src/pages/Designer/DeckSetup/HighlightItems.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/HighlightItems.tsx
@@ -14,7 +14,10 @@ import {
 } from '@opentrons/shared-data'
 import { getSlotInLocationStack } from '@opentrons/step-generation'
 
-import { HOPPER_LABWARE_X_OFFSET } from '/protocol-designer/constants'
+import {
+  FLEX_STACKER_IN_HOPPER_ACTIONS,
+  HOPPER_LABWARE_X_OFFSET,
+} from '/protocol-designer/constants'
 import { getLabwaresOnModuleFromStack } from '/protocol-designer/utils'
 
 import { getDeckSetupForActiveItem } from '../../../top-selectors/labware-locations'
@@ -41,6 +44,7 @@ import type { Fixture } from './constants'
 interface HighlightItemsProps {
   deckDef: DeckDefinition
   robotType: RobotType
+  currentStep: any
 }
 //  TODO(ja, 1/13/25): get actual coordinates from thermocycler and deck definitions
 const FLEX_TC_POSITION: CoordinateTuple = [-20, 282, 0]
@@ -58,7 +62,7 @@ const SLOTS = [
 ]
 
 export function HighlightItems(props: HighlightItemsProps): JSX.Element | null {
-  const { robotType, deckDef } = props
+  const { robotType, deckDef, currentStep } = props
   const { t } = useTranslation('application')
   const { labware, modules, additionalEquipmentOnDeck } = useSelector(
     getDeckSetupForActiveItem
@@ -165,9 +169,13 @@ export function HighlightItems(props: HighlightItemsProps): JSX.Element | null {
         Object.values(labware)
       )
       const isStacker = moduleOnDeck.type === FLEX_STACKER_MODULE_TYPE
-      const onHopperActions = ['Empty', 'Refill', 'Retrieve']
-      const isActionOnShuttle =
-        isStacker && !onHopperActions.includes(text ?? '')
+
+      const stepType: (typeof FLEX_STACKER_IN_HOPPER_ACTIONS)[number] | null =
+        currentStep?.flexStackerFormType ?? null
+
+      const onHopperActions =
+        stepType != null && FLEX_STACKER_IN_HOPPER_ACTIONS.includes(stepType)
+      const isActionOnShuttle = isStacker && !onHopperActions
 
       const position = getPositionFromSlotId(
         moduleOnDeck.slot,

--- a/protocol-designer/src/pages/Designer/DeckSetup/HighlightItems.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/HighlightItems.tsx
@@ -39,12 +39,16 @@ import type {
   RobotType,
 } from '@opentrons/shared-data'
 import type { AdditionalEquipmentName } from '@opentrons/step-generation'
+import type {
+  FlexStackerFormType,
+  FormData,
+} from '/protocol-designer/form-types'
 import type { Fixture } from './constants'
 
 interface HighlightItemsProps {
   deckDef: DeckDefinition
   robotType: RobotType
-  currentStep: any
+  currentStep: FormData | null
 }
 //  TODO(ja, 1/13/25): get actual coordinates from thermocycler and deck definitions
 const FLEX_TC_POSITION: CoordinateTuple = [-20, 282, 0]
@@ -170,11 +174,11 @@ export function HighlightItems(props: HighlightItemsProps): JSX.Element | null {
       )
       const isStacker = moduleOnDeck.type === FLEX_STACKER_MODULE_TYPE
 
-      const stepType: (typeof FLEX_STACKER_IN_HOPPER_ACTIONS)[number] | null =
+      const stepType: FlexStackerFormType | null =
         currentStep?.flexStackerFormType ?? null
-
       const onHopperActions =
-        stepType != null && FLEX_STACKER_IN_HOPPER_ACTIONS.includes(stepType)
+        stepType != null &&
+        (FLEX_STACKER_IN_HOPPER_ACTIONS as string[]).includes(stepType)
       const isActionOnShuttle = isStacker && !onHopperActions
 
       const position = getPositionFromSlotId(

--- a/protocol-designer/src/pages/Designer/DeckSetup/__tests__/DeckSetupContainer.test.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/__tests__/DeckSetupContainer.test.tsx
@@ -71,6 +71,7 @@ const render = () => {
       setViewBox={vi.fn()}
       viewBox="mockViewBox"
       initialViewBox="mockInitialViewBox"
+      currentStep={null}
     />
   )[0]
 }

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/index.tsx
@@ -333,6 +333,7 @@ export function ProtocolSteps({
                     hoverSlot={hoverSlot}
                     setHoverSlot={setHoverSlot}
                     robotType={robotType}
+                    currentStep={currentStep}
                   />
                 ) : (
                   <OffDeck setOverflowMenu={showLiquidOverflowMenu} />

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/index.tsx
@@ -64,6 +64,7 @@ import { SubStepsToolbox } from './Timeline'
 import { TimelineEditHardware } from './TimelineEditHardware'
 
 import type { Dispatch, SetStateAction } from 'react'
+import type { FormData } from '/protocol-designer/form-types'
 import type { DeckSlot, ThunkDispatch } from '../../../types'
 
 const CONTENT_MAX_WIDTH = '46.9375rem'
@@ -140,7 +141,7 @@ export function ProtocolSteps({
       },
     })
 
-  let currentStep
+  let currentStep: FormData | null
   if (hoveredTerminalItem === HARDWARE_ID && selectedStepId != null) {
     currentStep = savedStepForms[selectedStepId]
   } else if (hoveredTerminalItem === HARDWARE_ID && selectedStepId == null) {


### PR DESCRIPTION
# Overview

Highlights shuttle when labware is being moved to it or stored.

## Test Plan and Hands on Testing

smoke tested move, store, and retrieve commands

https://github.com/user-attachments/assets/eac20c70-099b-4982-96a7-97ace46ea00d




## Changelog

- made `isActionOnShuttle` take into the text that says what the step is into account so it does not highlight the shuttle when it is an empty, retrieve, or refill task.
- prop drilled `stepType` into `HighlightItems` to determine what type of stacker step it is. This determines if the highlight should be on the hopper or the shuttle.

## Risk assessment

low - just cosmetic highlight

Closes EXEC-2224