### PR TITLE
fix(protocol-designer): filter non-tiprack lids for stacker

### DIFF
--- a/protocol-designer/src/components/organisms/SelectLabwareModal/SelectLabware.tsx
+++ b/protocol-designer/src/components/organisms/SelectLabwareModal/SelectLabware.tsx
@@ -62,6 +62,8 @@ export function SelectLabware(props: SelectLabwareProps): JSX.Element | null {
   const zoomedInSlotInfo = useSelector(selectors.getZoomedInSlotInfo)
   const { selectedTopLabware, selectedAdapterDefURI, selectedLidLabware } =
     zoomedInSlotInfo
+  const isStackerShuttleOrHopper =
+    zoomedInSlotInfo.selectedModuleModel === FLEX_STACKER_MODULE_V1
   const lidLoadNames = Object.values(defs)
     .filter(
       def =>
@@ -109,6 +111,7 @@ export function SelectLabware(props: SelectLabwareProps): JSX.Element | null {
   return (
     <>
       {ORDERED_CATEGORIES.map(category => {
+        const isLidValid = category === 'tipRack' || !isStackerShuttleOrHopper
         if (filteredLabwareByCategory[category].length > 0) {
           return (
             <ListButton
@@ -148,9 +151,10 @@ export function SelectLabware(props: SelectLabwareProps): JSX.Element | null {
                     })
 
                     const stackingProps: StackingProps | null =
-                      isOnHopper ||
-                      (stackingLabwareDefUris.length === 1 &&
-                        slot !== 'offDeck')
+                      isLidValid &&
+                      (isOnHopper ||
+                        (stackingLabwareDefUris.length === 1 &&
+                          slot !== 'offDeck'))
                         ? {
                             inputTitle: t('labware_quantity'),
                             errorMessage: t('unsupported_range'),

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLabwareTools/LabwareLocationField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLabwareTools/LabwareLocationField.tsx
@@ -3,11 +3,15 @@ import { useDispatch, useSelector } from 'react-redux'
 
 import {
   FLEX_SINGLE_SLOT_ADDRESSABLE_AREAS,
+  FLEX_STACKER_MODULE_TYPE,
   FLEX_STAGING_AREA_SLOT_ADDRESSABLE_AREAS,
   OT2_SINGLE_SLOT_ADDRESSABLE_AREAS,
   WASTE_CHUTE_CUTOUT,
 } from '@opentrons/shared-data'
-import { getSlotInLocationStack } from '@opentrons/step-generation'
+import {
+  getFullStackFromLabwares,
+  getSlotInLocationStack,
+} from '@opentrons/step-generation'
 
 import { DropdownStepFormField } from '/protocol-designer/components/molecules'
 import { getRobotType } from '/protocol-designer/file-data/selectors'
@@ -60,17 +64,30 @@ export function LabwareLocationField(
         t,
       })
     : []
-  const isLabwareOffDeck =
-    labware != null
-      ? getSlotInLocationStack(robotState?.labware[labware]?.stack ?? []) ===
-        'offDeck'
-      : false
+  const labwareSlot = getSlotInLocationStack(
+    robotState?.labware[labware]?.stack ?? []
+  )
+  const isLabwareOffDeck = labware != null ? labwareSlot === 'offDeck' : false
   const isLabwareALid =
     deckSetupLabware[labware]?.def.allowedRoles?.includes('lid') ?? false
   const isLabwareATiprackLid =
     deckSetupLabware[labware]?.def.parameters.loadName === TIPRACK_LID_LOADNAME
   const unoccupiedLabwareLocationsOptionsSelector =
     useSelector(getUnoccupiedLabwareLocationOptions) ?? []
+  const fullStackFromLabwares = getFullStackFromLabwares(
+    robotState?.labware ?? {},
+    labwareSlot,
+    labware
+  )
+  const stackHasANonTiprackLid = fullStackFromLabwares.some(id => {
+    if (!(id in labwareEntities)) {
+      return false
+    }
+    const { def } = labwareEntities[id]
+    const isLid = def.allowedRoles?.includes('lid') ?? false
+    return isLid && def.parameters.loadName !== TIPRACK_LID_LOADNAME
+  })
+
   const robotType = useSelector(getRobotType)
   // invalid offDeck move filter
   let unoccupiedLabwareLocationsOptions = [
@@ -136,6 +153,16 @@ export function LabwareLocationField(
         option => !allSlotNames.includes(option.value as AddressableAreaName)
       )
   }
+
+  if (stackHasANonTiprackLid) {
+    unoccupiedLabwareLocationsOptions =
+      unoccupiedLabwareLocationsOptions.filter(
+        ({ value }) =>
+          robotState?.modules?.[value]?.moduleState.type !==
+          FLEX_STACKER_MODULE_TYPE
+      )
+  }
+
   const optionsSorted =
     robotState != null
       ? getSortedAddressableArea(


### PR DESCRIPTION
# Overview

Ensure that you cannot load or move non-tiprack lidded labware on the Flex stacker shuttle or hopper. This impacts both initial deck setup and the move labware stepform UI.

Closes EXEC-2225

## Test Plan and Hands on Testing
[test protocol](https://github.com/user-attachments/files/24508707/flex_stacker_test.11.py)

- create or import a stacker protocol that starts with the stacker empty
- load a lidded non-tiprack labware on the deck
- create a move labware step, and select the lidded labware to move
- verify that the stacker shuttle slot does _not_ appear in the new location dropdown list
- in starting deck state, click the hopper > add labware
- verify that only tipracks show the option to add a lid
- repeat above 2 points with shuttle

## Changelog

- check lid type in deck setup and move labware to ensure "bad" lids are added to the stacker

## Review requests

see test plan

## Risk assessment

low