### PR TITLE
fix(step-generation): emit the message for flexStackerEmpty

### DIFF
--- a/step-generation/src/commandCreators/atomic/__tests__/flexStackerEmpty.test.ts
+++ b/step-generation/src/commandCreators/atomic/__tests__/flexStackerEmpty.test.ts
@@ -57,6 +57,7 @@ describe('flexStackerEmpty', () => {
       {
         moduleId,
         strategy: 'logical',
+        message: 'Take everything out of the Stacker',
       },
       invariantContext,
       robotState
@@ -69,12 +70,13 @@ describe('flexStackerEmpty', () => {
           params: {
             moduleId,
             strategy: 'logical',
-            message: undefined,
+            message: 'Take everything out of the Stacker',
             count: undefined,
           },
         },
       ],
-      python: 'mock_flex_stacker_1.empty()',
+      python:
+        'mock_flex_stacker_1.empty(message="Take everything out of the Stacker")',
     })
   })
   it('creates returns error if bad module state', () => {

--- a/step-generation/src/commandCreators/atomic/flexStackerEmpty.ts
+++ b/step-generation/src/commandCreators/atomic/flexStackerEmpty.ts
@@ -1,6 +1,6 @@
 import * as errorCreators from '../../errorCreators'
 import { flexStackerStateGetter } from '../../robotStateSelectors'
-import { uuid } from '../../utils'
+import { formatPyStr, uuid } from '../../utils'
 
 import type { FlexStackerEmptyCreateCommand } from '@opentrons/shared-data'
 import type { CommandCreator, CommandCreatorError } from '../../types'
@@ -38,6 +38,8 @@ export const flexStackerEmpty: CommandCreator<
         },
       },
     ],
-    python: `${pythonName}.empty()`,
+    python: `${pythonName}.empty(${
+      args.message ? `message=${formatPyStr(args.message)}` : ''
+    })`,
   }
 }


### PR DESCRIPTION
# Overview

PD allows you to enter a message to display on the ODD to prompt the user to empty the Stacker. We need to emit the message in the generated Python. EXEC-2069 EXEC-2137

Figma design:
<img width="175" height="500" src="https://github.com/user-attachments/assets/1e82f338-de0a-4eb8-87a0-7edd3c7da8bf" />

(FYI, I'm going through the Stacker `CommandCreator`s to make sure everything works as expected.)

## Test Plan and Hands on Testing

Updated unit tests.

## Risk assessment

Low.