### PR TITLE
fix(protocol-designer): allow deletion of labware on hopper

### DIFF
--- a/protocol-designer/src/labware-ingred/actions/thunks.ts
+++ b/protocol-designer/src/labware-ingred/actions/thunks.ts
@@ -1,15 +1,25 @@
-import { getIsTiprack } from '@opentrons/shared-data'
-import { getSlotInLocationStack } from '@opentrons/step-generation'
+import { FLEX_STACKER_MODULE_TYPE, getIsTiprack } from '@opentrons/shared-data'
+import {
+  getSlotInLocationStack,
+  HOPPER_STACKER_LOCATION,
+} from '@opentrons/step-generation'
+
+import { getDeckSetupForActiveItem } from '/protocol-designer/top-selectors/labware-locations'
 
 import { getRobotType } from '../../file-data/selectors'
 import { selectors as labwareDefSelectors } from '../../labware-defs'
 import { selectors as stepFormSelectors } from '../../step-forms'
+import { updateStackerModuleState } from '../../step-forms/actions/modules'
 import { getLabwareEntities } from '../../step-forms/selectors'
 import { selectors as uiLabwareSelectors } from '../../ui/labware'
 import { getLabwarePythonName, uuid } from '../../utils'
 import { getNextAvailableDeckSlot, getNextNickname } from '../utils'
 
-import type { LabwareEntities } from '@opentrons/step-generation'
+import type { FlexStackerStoredLabwareGroup } from '@opentrons/shared-data'
+import type {
+  FlexStackerModuleState,
+  LabwareEntities,
+} from '@opentrons/step-generation'
 import type { NormalizedLabware, NormalizedLabwareById } from '../../step-forms'
 import type { UpdateStackerModuleStateAction } from '../../step-forms/actions/modules'
 import type { ThunkAction } from '../../types'
@@ -204,51 +214,100 @@ interface DeleteContainerArgs {
 }
 export const deleteContainer: (
   args: DeleteContainerArgs
-) => ThunkAction<DeleteContainerAction | EditMultipleLabwareAction> =
-  args => (dispatch, getState) => {
-    const { labwareId } = args
-    const state = getState()
-    const labwareEntities = getLabwareEntities(state)
-    const displayCategory =
-      labwareEntities[labwareId].def.metadata.displayCategory
-    const labwareOfSameCategory: LabwareEntities = Object.fromEntries(
-      Object.entries(labwareEntities).filter(
-        ([_, labware]) =>
-          labware.def.metadata.displayCategory === displayCategory
-      )
+) => ThunkAction<
+  | DeleteContainerAction
+  | EditMultipleLabwareAction
+  | UpdateStackerModuleStateAction
+> = args => (dispatch, getState) => {
+  const { labwareId } = args
+  const state = getState()
+  const labwareEntities = getLabwareEntities(state)
+  const deckSetup = getDeckSetupForActiveItem(state)
+  const { modules, labware } = deckSetup
+  const isLabwareOnHopper = labware[labwareId].stack.includes(
+    HOPPER_STACKER_LOCATION
+  )
+  const labwareSlot = getSlotInLocationStack(labware[labwareId].stack)
+  const moduleOnSlot = Object.values(modules).find(
+    module => module.slot === labwareSlot
+  )
+
+  const displayCategory =
+    labwareEntities[labwareId].def.metadata.displayCategory
+  const labwareOfSameCategory: LabwareEntities = Object.fromEntries(
+    Object.entries(labwareEntities).filter(
+      ([_, labware]) => labware.def.metadata.displayCategory === displayCategory
     )
-    const typeCount = Object.keys(labwareOfSameCategory).length
+  )
+  const typeCount = Object.keys(labwareOfSameCategory).length
+
+  dispatch({
+    type: 'DELETE_CONTAINER',
+    payload: {
+      labwareId,
+    },
+  })
+
+  if (typeCount > 1) {
+    const { [labwareId]: _, ...remainingLabwareEntities } =
+      labwareOfSameCategory
+
+    const updatedLabwarePythonName: NormalizedLabwareById = Object.keys(
+      remainingLabwareEntities
+    )
+      .sort()
+      .reduce<Record<string, NormalizedLabware>>(
+        (acc: NormalizedLabwareById, oldId, index) => {
+          acc[oldId] = {
+            ...remainingLabwareEntities[oldId],
+            pythonName: getLabwarePythonName(displayCategory, index + 1),
+            displayCategory,
+          }
+          return acc
+        },
+        {}
+      )
 
     dispatch({
-      type: 'DELETE_CONTAINER',
-      payload: {
-        labwareId,
-      },
+      type: 'EDIT_MULTIPLE_LABWARE_PYTHON_NAME',
+      payload: updatedLabwarePythonName,
     })
+  }
 
-    if (typeCount > 1) {
-      const { [labwareId]: _, ...remainingLabwareEntities } =
-        labwareOfSameCategory
+  if (isLabwareOnHopper && moduleOnSlot?.type === FLEX_STACKER_MODULE_TYPE) {
+    const stackerModuleState: FlexStackerModuleState =
+      moduleOnSlot.moduleState as FlexStackerModuleState
 
-      const updatedLabwarePythonName: NormalizedLabwareById = Object.keys(
-        remainingLabwareEntities
-      )
-        .sort()
-        .reduce<Record<string, NormalizedLabware>>(
-          (acc: NormalizedLabwareById, oldId, index) => {
-            acc[oldId] = {
-              ...remainingLabwareEntities[oldId],
-              pythonName: getLabwarePythonName(displayCategory, index + 1),
-              displayCategory,
-            }
-            return acc
+    if (stackerModuleState.labwareInHopper != null) {
+      const labwareInHopper = stackerModuleState.labwareInHopper.reduce<
+        FlexStackerStoredLabwareGroup[]
+      >((acc, group) => {
+        if (group.primaryLabwareId === labwareId) {
+          return acc
+        }
+
+        acc.push({
+          ...group,
+          adapterLabwareId:
+            group.adapterLabwareId === labwareId
+              ? null
+              : group.adapterLabwareId,
+          lidLabwareId:
+            group.lidLabwareId === labwareId ? null : group.lidLabwareId,
+        })
+
+        return acc
+      }, [])
+
+      dispatch(
+        updateStackerModuleState({
+          moduleId: moduleOnSlot.id,
+          moduleState: {
+            ...stackerModuleState,
+            labwareInHopper,
           },
-          {}
-        )
-
-      dispatch({
-        type: 'EDIT_MULTIPLE_LABWARE_PYTHON_NAME',
-        payload: updatedLabwarePythonName,
-      })
+        })
+      )
     }
   }
+}

--- a/protocol-designer/src/labware-ingred/actions/thunks.ts
+++ b/protocol-designer/src/labware-ingred/actions/thunks.ts
@@ -229,12 +229,12 @@ export const deleteContainer: (
   )
   const labwareSlot = getSlotInLocationStack(labware[labwareId].stack)
   const moduleOnSlot = Object.values(modules).find(
-    module => module.slot === labwareSlot
+    ({ slot: moduleSlot }) => moduleSlot === labwareSlot
   )
 
   const displayCategory =
     labwareEntities[labwareId].def.metadata.displayCategory
-  const labwareOfSameCategory: LabwareEntities = Object.fromEntries(
+  const labwareOfSameCategory = Object.fromEntries(
     Object.entries(labwareEntities).filter(
       ([_, labware]) => labware.def.metadata.displayCategory === displayCategory
     )

--- a/protocol-designer/src/labware-ingred/actions/thunks.ts
+++ b/protocol-designer/src/labware-ingred/actions/thunks.ts
@@ -16,10 +16,7 @@ import { getLabwarePythonName, uuid } from '../../utils'
 import { getNextAvailableDeckSlot, getNextNickname } from '../utils'
 
 import type { FlexStackerStoredLabwareGroup } from '@opentrons/shared-data'
-import type {
-  FlexStackerModuleState,
-  LabwareEntities,
-} from '@opentrons/step-generation'
+import type { FlexStackerModuleState } from '@opentrons/step-generation'
 import type { NormalizedLabware, NormalizedLabwareById } from '../../step-forms'
 import type { UpdateStackerModuleStateAction } from '../../step-forms/actions/modules'
 import type { ThunkAction } from '../../types'

--- a/protocol-designer/src/pages/Designer/DeckSetup/HopperLabwareRenders.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/HopperLabwareRenders.tsx
@@ -60,13 +60,13 @@ export function HopperLabwareRenders(
   } = props
   const { primaryLabwareId, adapterLabwareId, lidLabwareId } = topLabwareGroup
   const primaryLabware = labwaresOnDeck[primaryLabwareId]
+  if (primaryLabware == null) {
+    return null
+  }
   const labwareInterfaceBoundingBox = {
     xDimension: primaryLabware.def.dimensions.xDimension,
     yDimension: primaryLabware.def.dimensions.yDimension,
     zDimension: 0,
-  }
-  if (primaryLabware == null) {
-    return null
   }
   return (
     <>


### PR DESCRIPTION
closes EXEC-2219 EXEC-2221

# Overview

delete labwareFromHopper when deleting labware

## Test Plan and Hands on Testing

make sure you can properly delete labware from the hopper in deck setup and also test having 4 stackers on the deck map and that it doesn't whitescreen. i think the protocol attached to that ticket is corrupted since the labwareFromHopper is wrong

## Changelog

update module state for labwareFromHopper when deleting a labware on the hopper, add that logic to the thunk
reorganize to prevent white screen in hopperLabwareRenders

## Risk assessment

low
