### PR TITLE
fix(app): fix toggle button's vertical position

### DIFF
--- a/app/src/pages/Desktop/AppSettings/PrivacySettings.tsx
+++ b/app/src/pages/Desktop/AppSettings/PrivacySettings.tsx
@@ -2,11 +2,11 @@ import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 
 import {
+  ALIGN_CENTER,
   Box,
   Flex,
   JUSTIFY_SPACE_BETWEEN,
   LegacyStyledText,
-  SIZE_2,
   SPACING,
   TYPOGRAPHY,
 } from '@opentrons/components'
@@ -27,6 +27,7 @@ export function PrivacySettings(): JSX.Element {
   return (
     <Flex
       justifyContent={JUSTIFY_SPACE_BETWEEN}
+      alignItems={ALIGN_CENTER}
       paddingX={SPACING.spacing16}
       paddingY={SPACING.spacing24}
       gridGap={SPACING.spacing16}
@@ -47,7 +48,7 @@ export function PrivacySettings(): JSX.Element {
       </Box>
       <ToggleButton
         label="analytics_opt_in"
-        size={SIZE_2}
+        size="2rem"
         toggledOn={analyticsOptedIn}
         onClick={() => dispatch(toggleAnalyticsOptedIn())}
         id="PrivacySettings_analytics"


### PR DESCRIPTION


# Overview
fix toggle button's vertical position

[before]
<img width="980" height="677" alt="Screenshot 2026-01-08 at 6 41 10 PM" src="https://github.com/user-attachments/assets/92fc0abb-f516-437f-b98b-378bf47d51cd" />


[after]
<img width="1027" height="773" alt="Screenshot 2026-01-08 at 6 41 35 PM" src="https://github.com/user-attachments/assets/199db29c-a725-4f33-9d57-f43097980c0d" />


design
https://www.figma.com/design/qzX850M2Zxf1Mb5QwEtbzq/Primary--Desktop-App?node-id=10102-90600&m=dev


unfortunately, the fonts are still using the old styling so i cannot replace `LegacyStyledText`.

close AUTH-2663

## Test Plan and Hands on Testing
- open app
- click app settings
- go to privacy tab


## Changelog
- add `alignItems` to modify the toggle button position

## Review requests


## Risk assessment
low