### PR TITLE
refactor(api): strong typing for the transfer() kwargs

### DIFF
--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from contextlib import ExitStack
-from typing import Any, List, Optional, Sequence, Tuple, Union, cast
+from typing import Any, List, Optional, Sequence, Tuple, Union, Unpack, cast
 
 from opentrons_shared_data.errors.exceptions import (
     CommandParameterLimitViolated,
@@ -43,7 +43,7 @@ from opentrons.protocols.advanced_control.mix import mix_from_kwargs
 from opentrons.protocols.advanced_control.transfers import transfer as v1_transfer
 from opentrons.protocols.api_support import instrument
 from opentrons.protocols.api_support.deck_type import NoTrashDefinedError
-from opentrons.protocols.api_support.types import APIVersion
+from opentrons.protocols.api_support.types import APIVersion, TransferArgs
 from opentrons.protocols.api_support.util import (
     APIVersionError,
     FlowRates,
@@ -1854,7 +1854,7 @@ class InstrumentContext(publisher.CommandPublisher):
         source: labware.Well,
         dest: List[labware.Well],
         *args: Any,
-        **kwargs: Any,
+        **kwargs: Unpack[TransferArgs],
     ) -> InstrumentContext:
         """
         Move a volume of liquid from one source to multiple destinations.
@@ -1893,7 +1893,7 @@ class InstrumentContext(publisher.CommandPublisher):
         source: List[labware.Well],
         dest: labware.Well,
         *args: Any,
-        **kwargs: Any,
+        **kwargs: Unpack[TransferArgs],
     ) -> InstrumentContext:
         """
         Move liquid from multiple source wells to a single destination well.
@@ -1924,8 +1924,7 @@ class InstrumentContext(publisher.CommandPublisher):
         volume: Union[float, Sequence[float]],
         source: AdvancedLiquidHandling,
         dest: AdvancedLiquidHandling,
-        trash: bool = True,
-        **kwargs: Any,
+        **kwargs: Unpack[TransferArgs],
     ) -> InstrumentContext:
         # source: Union[Well, List[Well], List[List[Well]]],
         # dest: Union[Well, List[Well], List[List[Well]]],
@@ -2024,23 +2023,27 @@ class InstrumentContext(publisher.CommandPublisher):
         """
         _log.debug("Transfer {} from {} to {}".format(volume, source, dest))
 
+        kwargs.setdefault("mode", "transfer")
+
         blowout_location = kwargs.get("blowout_location")
         instrument.validate_blowout_location(
             self.api_version, "transfer", blowout_location
         )
 
-        kwargs["mode"] = kwargs.get("mode", "transfer")
-
         mix_strategy, mix_opts = mix_from_kwargs(kwargs)
 
+        trash = kwargs.get("trash", True)
         if trash:
             drop_tip = v1_transfer.DropTipStrategy.TRASH
         else:
             drop_tip = v1_transfer.DropTipStrategy.RETURN
 
-        new_tip = kwargs.get("new_tip")
-        if isinstance(new_tip, str):
-            new_tip = types.TransferTipPolicy[new_tip.upper()]
+        new_tip_arg = kwargs.get("new_tip")
+        new_tip = (
+            types.TransferTipPolicy[new_tip_arg.upper()]
+            if isinstance(new_tip_arg, str)
+            else None
+        )
 
         blow_out = kwargs.get("blow_out")
         blow_out_strategy = None

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import logging
 from contextlib import ExitStack
-from typing import Any, List, Optional, Sequence, Tuple, Union, Unpack, cast
+from typing import Any, List, Optional, Sequence, Tuple, Union, cast
+
+from typing_extensions import Unpack
 
 from opentrons_shared_data.errors.exceptions import (
     CommandParameterLimitViolated,

--- a/api/src/opentrons/protocols/advanced_control/mix.py
+++ b/api/src/opentrons/protocols/advanced_control/mix.py
@@ -1,13 +1,16 @@
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, Literal, Tuple
 
+from ..api_support.types import TransferArgs
 from .common import Mix, MixStrategy
 
 
-def mix_from_kwargs(top_kwargs: Dict[str, Any]) -> Tuple[MixStrategy, Mix]:
+def mix_from_kwargs(top_kwargs: TransferArgs) -> Tuple[MixStrategy, Mix]:
     """A utility function to determine mix strategy from key word arguments
     to InstrumentContext.mix"""
 
-    def _mix_requested(kwargs: Dict[str, Any], opt: str) -> bool:
+    def _mix_requested(
+        kwargs: TransferArgs, opt: Literal["mix_before", "mix_after"]
+    ) -> bool:
         """
         Helper for determining mix options from :py:meth:`transfer` kwargs
         Mixes can be ignored in kwargs by either

--- a/api/src/opentrons/protocols/api_support/types.py
+++ b/api/src/opentrons/protocols/api_support/types.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import NamedTuple, Optional, TypedDict
+from typing import Callable, Literal, NamedTuple, Optional, Tuple, TypedDict
 
 
 class APIVersion(NamedTuple):
@@ -18,6 +18,26 @@ class APIVersion(NamedTuple):
 
     def __str__(self) -> str:
         return f"{self.major}.{self.minor}"
+
+
+class TransferArgs(TypedDict, total=False):
+    """
+    The common arguments for the transfer functions `InstrumentContext.transfer()`,
+    `InstrumentContext.distribute()`, `InstrumentContext.consolidate()`.
+    """
+
+    mode: Literal["transfer", "distribute", "consolidate"]  # internal use only
+    new_tip: Literal["once", "always", "never"]
+    trash: bool
+    touch_tip: bool
+    blow_out: bool
+    blowout_location: Literal["trash", "source well", "destination well"]
+    mix_before: Tuple[int, float]
+    mix_after: Tuple[int, float]
+    disposal_volume: float
+    air_gap: float
+    carryover: bool  # this does nothing!
+    gradient_function: Callable[[float], float]  # very mysterious
 
 
 class ThermocyclerStepBase(TypedDict):

--- a/api/tests/opentrons/protocol_api_integration/test_pipette_movement_deck_conflicts.py
+++ b/api/tests/opentrons/protocol_api_integration/test_pipette_movement_deck_conflicts.py
@@ -141,7 +141,7 @@ def test_close_shave_deck_conflicts_for_96_ch_a12_column_configuration(
         15,
         res12["A6"],
         deepwell.columns()[6],
-        disposal_vol=0,
+        disposal_volume=0,
     )
 
 

--- a/hardware-testing/hardware_testing/protocols/liquid_sense/lld_test_liquid_height_3mm.py
+++ b/hardware-testing/hardware_testing/protocols/liquid_sense/lld_test_liquid_height_3mm.py
@@ -464,7 +464,7 @@ def _test_for_finding_liquid_height(  # noqa: C901
                     need_to_transfer_per_ch,
                     src_well.meniscus(z=ASPIRATE_MM_FROM_MENISCUS, target="end"),
                     dispense_loc,
-                    new_tips="never",
+                    new_tip="never",
                     touch_tip=True,
                     air_gap=5,
                 )

--- a/hardware-testing/hardware_testing/protocols/tc_auto_seal_lid/tc_lid_evap_test.py
+++ b/hardware-testing/hardware_testing/protocols/tc_auto_seal_lid/tc_lid_evap_test.py
@@ -53,7 +53,6 @@ def _fill_with_liquid_and_measure(
         volume=volumes,
         source=source_well,
         dest=locations,
-        return_tips=True,
         blow_out=False,
     )
     protocol.pause("Weight Armadillo Plate, place on thermocycler, put on lid")


### PR DESCRIPTION
# Overview

This is part of the cleanup I want to do before we freeze the API forever for the OT-2.

This PR implements strong typing for the `kwargs` of the legacy `transfer()`, `distribute()`, and `consolidate()` functions. The type checker will now enforce that the correct arguments are being passed to `transfer()`, instead of relying on a human reading the docstrings.

We've had several reports related to the `transfer(**kwargs)`, such as #7500, AUTH-35, etc. This change doesn't fix those problems directly, but it'll help make it more obvious what's wrong.

This change uncovered 3 errors so far:
- In `test_pipette_movement_deck_conflicts.py`, we were passing in the misnamed argument `disposal_vol` instead of `disposal_volume`.
- In `lld_test_liquid_height_3mm.py`, we were using the misnamed argument `new_tips` instead of `new_tip`. @rclarke0
- In `tc_lid_evap_test.py`, there is no such argument `distribute(return_tips=True)`. What did you mean @CaseyBatten?

## Test Plan and Hands on Testing

Updated tests.
Will rely on CI to find other dependencies.

## Review requests

Future work:
- See if we can generate the documentation for the `kwargs` directly from the new `TransferArgs` type, instead of writing a separate [`parameters.rst`](../blob/edge/api/docs/v2/complex_commands/parameters.rst) document. 
- We really should remove the `carryover` argument.
- In the "Complex Liquid Handling Parameters" documentation, we don't distinguish between the tip handling options for the legacy `transfer()` functions and the new `transfer_with_liquid_class()` functions. In particular, the docs list options like `"per source"` and `"per destination"`, but those are not available in the legacy `transfer()` function. @ecormany 
- The docstring for the `transfer()` function does not mention the argument `air_gap`.
- The `gradient_function` argument does not seem to be explained anywhere at all.

## Risk assessment

Low. There should be no behavior change at all. This just affects the type annotations.