### PR TITLE
chore(robot-server): split test workflow

### DIFF
--- a/.github/workflows/robot-server-lint-test.yaml
+++ b/.github/workflows/robot-server-lint-test.yaml
@@ -48,9 +48,9 @@ defaults:
     shell: bash
 
 jobs:
-  lint-test:
-    name: 'robot server package linting and tests'
-    timeout-minutes: 40
+  lint:
+    name: 'robot server package linting'
+    timeout-minutes: 5
     runs-on: 'ubuntu-24.04'
     strategy:
       matrix:
@@ -70,14 +70,64 @@ jobs:
         run: make -C robot-server setup-ot2
       - name: Lint
         run: make -C robot-server lint
+  test-unit:
+    name: 'robot server package unit testing (ot_hardware: ${{matrix.with-ot-hardware}})'
+    timeout-minutes: 5
+    runs-on: 'ubuntu-24.04'
+    strategy:
+      matrix:
+        with-ot-hardware: ['true', 'false']
+    steps:
+      - uses: 'actions/checkout@v4'
+        with:
+          fetch-depth: 0
+      - uses: 'actions/setup-node@v6'
+        with:
+          node-version: '22.21.1'
+      - uses: './.github/actions/python/setup-uv'
+        with:
+          project: 'robot-server'
+      - if: ${{ matrix.with-ot-hardware == 'false' }}
+        name: Remove OT-3 hardware package
+        run: make -C robot-server setup-ot2
       - if: ${{ matrix.with-ot-hardware == 'false' }}
         name: Test without opentrons_hardware
-        run: make -C robot-server test-cov test_opts="-m 'not ot3_only'"
+        run: make -C robot-server test-unit-cov test_opts="-m 'not ot3_only'"
       - if: ${{ matrix.with-ot-hardware == 'true' }}
         name: Test with opentrons_hardware
-        run: make -C robot-server test-cov
-      - name: Ensure assets build
-        run: make -C robot-server wheel
+        run: make -C robot-server test-unit-cov
+      - name: Upload coverage report
+        uses: 'codecov/codecov-action@v3'
+        with:
+          files: ./robot-server/coverage.xml
+          flags: robot-server
+
+  test-integration:
+    name: 'robot server package integration testing (ot_hardware: ${{matrix.with-ot-hardware}})'
+    timeout-minutes: 40
+    runs-on: 'ubuntu-24.04'
+    strategy:
+      matrix:
+        with-ot-hardware: ['true', 'false']
+    steps:
+      - uses: 'actions/checkout@v4'
+        with:
+          fetch-depth: 0
+      - uses: 'actions/setup-node@v6'
+        with:
+          node-version: '22.21.1'
+      - uses: './.github/actions/python/setup-uv'
+        with:
+          project: 'robot-server'
+      - if: ${{ matrix.with-ot-hardware == 'false' }}
+        name: Remove OT-3 hardware package
+        run: make -C robot-server setup-ot2
+      - if: ${{ matrix.with-ot-hardware == 'false' }}
+        name: Test without opentrons_hardware
+        run: make -C robot-server test-integration-cov test_opts="-m 'not ot3_only'"
+      - if: ${{ matrix.with-ot-hardware == 'true' }}
+        name: Test with opentrons_hardware
+        run: make -C robot-server test-integration-cov
       - name: Upload coverage report
         uses: 'codecov/codecov-action@v3'
         with:

--- a/robot-server/Makefile
+++ b/robot-server/Makefile
@@ -107,9 +107,13 @@ wheel: $(ot_sources)
 test:
 	$(pytest) $(tests) $(test_opts)
 
-.PHONY: test-cov
-test-cov:
-	$(pytest) $(tests) $(test_opts) $(cov_opts)
+.PHONY: test-unit-cov
+test-unit-cov:
+	$(pytest) $(tests) $(test_opts) -m 'not integration' $(cov_opts)
+
+.PHONY: test-integration-cov
+test-integration-cov:
+	$(pytest) tests/integration $(test_opts) $(cov_opts)
 
 .PHONY: test-fast
 test-fast:

--- a/robot-server/pyproject.toml
+++ b/robot-server/pyproject.toml
@@ -184,6 +184,7 @@ markers = [
     "ot2_only: Test only functions using the OT2 hardware",
     "ot3_only: Test only functions using the OT3 hardware",
     "slow: Marks tests that are especially slow. Commonly, this means the test starts and stops its own dev server process, which takes several seconds, instead of reusing a session-scoped one. Exclude this mark to run only the tests that are fast.",
+    "integration: Marks tests that are integration tests with a server in a separate process",
 ]
 filterwarnings = [
     "error::sqlalchemy.exc.RemovedIn20Warning",

--- a/robot-server/tests/conftest.py
+++ b/robot-server/tests/conftest.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Callable, Generator, Iterator, cast
 
 import pytest
+from _pytest.mark import deselect_by_mark
 from decoy import Decoy
 from fastapi import routing
 from mock import MagicMock
@@ -60,6 +61,34 @@ async def always_raise() -> NoReturn:
 
 
 app.include_router(test_router)
+
+
+def pytest_collection_modifyitems(
+    session: pytest.Session, config: pytest.Config, items: list[pytest.Item]
+) -> None:
+    """Hook to implement not collecting integration tests if not needed.
+
+    https://docs.pytest.org/en/stable/reference/reference.html#pytest.hookspec.pytest_collection_modifyitems
+
+    The normal way to do this is to mark tests with a custom mark. But that's a lot of tests.
+    The next way to do this is to apply a mark dynamically in a fixture (which we do below) but that
+    happens after collection time, so we can only skip the tests rather than not collecting them.
+
+    By writing a collection hook, we can skip collecting the tests altogether. We can do this by
+    - At collection time, adding the mark to any test defined in a path under integration/
+    - Make sure that we rerun the logic that discards tests if they don't match some mark expression
+
+    Unfortunately that last part is a part of pytest internals, so we have to poke in there, but
+    it's only one place so maybe it's okay. It also may not be necessary (because maybe pytest forces
+    internal hooks to run after external hooks) but there's no formal guarantee that it isn't, so we do it.
+    """
+    for item in items:
+        # https://docs.pytest.org/en/stable/reference/reference.html#pytest.Item.location
+        itempath = item.location[0]
+        if os.path.join("tests", "integration") in itempath:
+            item.add_marker(pytest.mark.integration)
+    # https://github.com/pytest-dev/pytest/blob/main/src/_pytest/mark/__init__.py#L255
+    deselect_by_mark(items=items, config=config)
 
 
 @pytest.fixture()

--- a/robot-server/tests/integration/http_api/persistence/test_compatibility.py
+++ b/robot-server/tests/integration/http_api/persistence/test_compatibility.py
@@ -183,6 +183,7 @@ snapshots: List[ParameterSet] = [
 ]
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize(
     "snapshot",
     snapshots,
@@ -272,6 +273,7 @@ async def test_protocols_analyses_and_runs_available_from_older_persistence_dir(
 
 # TODO(mm, 2023-08-12): We can remove this test when we remove special handling for these
 # protocols. https://opentrons.atlassian.net/browse/RSS-306
+@pytest.mark.slow
 async def test_rerun_flex_dev_compat() -> None:
     """Test re-running a stored protocol that has messed up requirements and metadata.
 

--- a/robot-server/tests/integration/http_api/persistence/test_reset.py
+++ b/robot-server/tests/integration/http_api/persistence/test_reset.py
@@ -69,6 +69,7 @@ async def _wait_until_initialization_failed(robot_client: RobotClient) -> None:
             )
 
 
+@pytest.mark.slow
 async def test_upload_protocols_and_reset_persistence_dir() -> None:
     """Test resetting runs history.
 
@@ -119,6 +120,7 @@ async def test_upload_protocols_and_reset_persistence_dir() -> None:
             server.stop()
 
 
+@pytest.mark.slow
 async def test_reset_is_available_even_with_corrupt_persistence_directory() -> None:
     """Test resetting runs history when the persistence directory is corrupted."""
     port = "15555"

--- a/robot-server/tests/integration/http_api/protocols/test_persistence.py
+++ b/robot-server/tests/integration/http_api/protocols/test_persistence.py
@@ -15,6 +15,7 @@ from robot_server.persistence.file_and_directory_names import LATEST_VERSION_DIR
 pytestmark = pytest.mark.slow
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize("protocol", [(get_py_protocol), (get_json_protocol)])
 async def test_protocols_and_analyses_persist(
     protocol: Callable[[str], IO[bytes]],
@@ -79,6 +80,7 @@ async def test_protocols_and_analyses_persist(
             server.stop()
 
 
+@pytest.mark.slow
 async def test_protocol_labware_files_persist() -> None:
     """Upload a python protocol and 2 custom labware files.
 

--- a/robot-server/tests/integration/http_api/protocols/test_upload_bundled_data.py
+++ b/robot-server/tests/integration/http_api/protocols/test_upload_bundled_data.py
@@ -7,10 +7,13 @@ import os
 import secrets
 from pathlib import Path
 
+import pytest
+
 from tests.integration.protocol_files import get_bundled_data, get_py_protocol
 from tests.integration.robot_client import RobotClient
 
 
+@pytest.mark.slow
 async def test_upload_protocols_with_bundled_data(
     ot2_server_base_url: str,
 ) -> None:

--- a/robot-server/tests/integration/http_api/protocols/test_upload_python_custom_labware.py
+++ b/robot-server/tests/integration/http_api/protocols/test_upload_python_custom_labware.py
@@ -7,7 +7,6 @@ In the protocol's analysis, the Python Protocol API should successfully load the
 labware.
 """
 
-
 # TODO(mm, 2023-01-11): Port this to a Tavern test once
 # https://github.com/taverntesting/tavern/issues/833 is resolved. We need to upload
 # multiple files into the `files` field of the `POST /protocols` endpoint.
@@ -77,6 +76,7 @@ def make_test_protocol(api_level: str, labware_load_name: str) -> bytes:
     ).encode("utf-8")
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize(
     "api_level",
     [

--- a/robot-server/tests/integration/http_api/runs/test_deck_slot_standardization.py
+++ b/robot-server/tests/integration/http_api/runs/test_deck_slot_standardization.py
@@ -13,6 +13,7 @@ async def robot_client(base_url: str) -> AsyncGenerator[RobotClient, None]:
         yield robot_client
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize(
     (
         "base_url",

--- a/robot-server/tests/integration/http_api/runs/test_labware_offsets_on_compatible_modules.py
+++ b/robot-server/tests/integration/http_api/runs/test_labware_offsets_on_compatible_modules.py
@@ -54,6 +54,7 @@ async def robot_client(
         yield robot_client
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize("use_protocol_engine_backend", [False, True])
 @pytest.mark.parametrize(
     (

--- a/robot-server/tests/integration/http_api/runs/test_persistence.py
+++ b/robot-server/tests/integration/http_api/runs/test_persistence.py
@@ -10,8 +10,6 @@ from tests.conftest import zulu_iso8601_to_datetime
 from tests.integration.dev_server import DevServer
 from tests.integration.robot_client import RobotClient
 
-pytestmark = pytest.mark.slow
-
 
 class ClientServerFixture(NamedTuple):
     client: RobotClient
@@ -78,6 +76,7 @@ async def _assert_run_persisted(
     assert get_persisted_run_response.json()["data"] == expected_run_data
 
 
+@pytest.mark.slow
 async def test_untimely_restart_marks_runs_bad(
     client_and_server: ClientServerFixture,
 ) -> None:
@@ -117,6 +116,7 @@ async def test_untimely_restart_marks_runs_bad(
     await _assert_run_persisted(robot_client=client, expected_run_data=expected_run)
 
 
+@pytest.mark.slow
 async def test_runs_persist_via_patch(client_and_server: ClientServerFixture) -> None:
     """Test that runs are persisted through dev server restart."""
     client, server = client_and_server
@@ -138,6 +138,7 @@ async def test_runs_persist_via_patch(client_and_server: ClientServerFixture) ->
     await _assert_run_persisted(robot_client=client, expected_run_data=expected_run)
 
 
+@pytest.mark.slow
 async def test_runs_persist_via_actions_router(
     client_and_server: ClientServerFixture,
 ) -> None:
@@ -169,6 +170,7 @@ async def test_runs_persist_via_actions_router(
     await _assert_run_persisted(robot_client=client, expected_run_data=expected_run)
 
 
+@pytest.mark.slow
 async def test_run_actions_and_labware_offsets_persist(
     client_and_server: ClientServerFixture,
 ) -> None:
@@ -226,6 +228,7 @@ async def test_run_actions_and_labware_offsets_persist(
     await _assert_run_persisted(robot_client=client, expected_run_data=expected_run)
 
 
+@pytest.mark.slow
 async def test_run_commands_persist(client_and_server: ClientServerFixture) -> None:
     """Test that run commands are persisted through restart."""
     client, server = client_and_server
@@ -272,6 +275,7 @@ async def test_run_commands_persist(client_and_server: ClientServerFixture) -> N
     assert json_converted_command == expected_command
 
 
+@pytest.mark.slow
 async def test_runs_completed_started_at_persist_via_actions_router(
     client_and_server: ClientServerFixture,
 ) -> None:
@@ -313,6 +317,7 @@ async def test_runs_completed_started_at_persist_via_actions_router(
     assert run_data["startedAt"] < run_data["completedAt"]
 
 
+@pytest.mark.slow
 async def test_runs_completed_filled_started_at_none_persist(
     client_and_server: ClientServerFixture,
 ) -> None:


### PR DESCRIPTION
Split up the test workflow to do unit and integration in parallel, so you can get a faster signal about whether your pr is ok.

Annoyingly, pytest module marks don't work in packages I guess, so I just had to... add the marks everywhere, since there's also not an "ignore this directory" flag. This looks a bit fragile, but make test-integration runs pytest tests/integration so even if you forget the mark your test will still run in the integration phase (it will just also run in the unit phase, so try to avoid it.)
