### PR TITLE
fix(components): fix ref warning issue

### DIFF
--- a/components/src/primitives/Box.tsx
+++ b/components/src/primitives/Box.tsx
@@ -1,3 +1,5 @@
+import { forwardRef } from 'react'
+
 import { withStyleProps } from '../hocs/withStyleProps'
 
 import type { ComponentProps, FC } from 'react'
@@ -9,8 +11,10 @@ import type { StyleProps } from './types'
  * @component
  */
 
-const BoxComponent = (props: ComponentProps<'div'>): JSX.Element => (
-  <div {...props} style={{ minWidth: 0, ...props.style }} />
+const BoxComponent = forwardRef<HTMLDivElement, ComponentProps<'div'>>(
+  (props, ref) => (
+    <div ref={ref} {...props} style={{ minWidth: 0, ...props.style }} />
+  )
 )
 
 export const Box: FC<ComponentProps<'div'> & StyleProps> = withStyleProps(


### PR DESCRIPTION


# Overview
fix ref warning issue

the warning is showing up in console because `Box` doesn't support ref but Toolbox uses ref in `Box`

close AUTH-2673
## Test Plan and Hands on Testing
- make -C protocol-designer dev and go to edit protocol page
check there is no warning in console

## Changelog
- update Box component to support `ref`

## Review requests


## Risk assessment
low