### PR TITLE
fix(api-client, react-api-client): ensure bindings point to the camera settings endpoint

### DIFF
--- a/api-client/src/camera/createCameraImageSettings.ts
+++ b/api-client/src/camera/createCameraImageSettings.ts
@@ -1,6 +1,5 @@
 import { POST, request } from '../request'
 
-import type { CameraId } from '@opentrons/shared-data'
 import type {
   CameraImageSettings,
   CameraImageSettingsResponse,
@@ -10,12 +9,11 @@ import type { HostConfig } from '../types'
 
 export function createCameraImageSettings(
   config: HostConfig,
-  data: CameraImageSettings,
-  cameraId: CameraId
+  data: CameraImageSettings
 ): ResponsePromise<CameraImageSettingsResponse> {
   return request<CameraImageSettingsResponse, { data: CameraImageSettings }>(
     POST,
-    `/camera/cameraSettings/${cameraId}`,
+    `/camera/cameraSettings`,
     { data },
     config
   )

--- a/api-client/src/camera/types.ts
+++ b/api-client/src/camera/types.ts
@@ -1,3 +1,5 @@
+import type { CameraId } from '@opentrons/shared-data'
+
 export interface CameraData {
   cameraEnabled: boolean
   liveStreamEnabled: boolean
@@ -5,6 +7,7 @@ export interface CameraData {
 }
 
 export interface CameraImageSettings {
+  cameraId?: CameraId
   resolution?: [number, number]
   zoom?: number
   contrast?: number

--- a/react-api-client/src/camera/useUpdateCameraImageSettings.ts
+++ b/react-api-client/src/camera/useUpdateCameraImageSettings.ts
@@ -1,7 +1,6 @@
 import { useMutation, useQueryClient } from 'react-query'
 
 import { createCameraImageSettings } from '@opentrons/api-client'
-import { OT_SYSTEM_CAMERA } from '@opentrons/shared-data'
 
 import { useHost } from '../api'
 
@@ -36,7 +35,6 @@ export function useCreateCameraImageSettings(
     CameraImageSettings
   > = {}
 ): UseCreateCameraImageSettingsMutationResult {
-  const cameraId = OT_SYSTEM_CAMERA
   const host = useHost()
   const queryClient = useQueryClient()
 
@@ -45,11 +43,11 @@ export function useCreateCameraImageSettings(
     AxiosError<ErrorResponse>,
     CameraImageSettings
   >(
-    [host, 'camera', 'cameraSettings', cameraId],
+    [host, 'camera', 'cameraSettings'],
     (data: CameraImageSettings) =>
-      createCameraImageSettings(host!, data, cameraId).then(response => {
+      createCameraImageSettings(host!, data).then(response => {
         queryClient
-          .invalidateQueries([host, 'camera', 'cameraSettings', cameraId])
+          .invalidateQueries([host, 'camera', 'cameraSettings'])
           .catch(e => {
             throw e
           })


### PR DESCRIPTION
# Overview

Whoops, looks like the endpoint utilized by the `createCameraImageSettings` bindings do not match what the [server expects](https://opentrons.atlassian.net/wiki/spaces/RPDO/pages/5471502775/Camera+9.0+Eng+Sync), resulting in a 404 on the POST request. 

This PR just updates the endpoint for the camera settings axios wrapper. Because the `CameraImageSettings` contains the `cameraId`, we don't need to specify it in the bindings explicitly.

<img width="1304" height="741" alt="Screenshot 2026-01-09 at 4 19 05 PM" src="https://github.com/user-attachments/assets/c9372918-3cca-4d21-847b-3ca1afecf089" />

## Test Plan and Hands on Testing

- See image. Performing a `POST` request via the app no longer 404s.

## Changelog

- Saving camera settings in the app update robot-server camera state.

## Risk assessment

- very low
