### PR TITLE
fix(app): fix layout shift in CameraCard overflow menu

### DIFF
--- a/app/src/organisms/Desktop/Devices/Peripherals/CameraCard.tsx
+++ b/app/src/organisms/Desktop/Devices/Peripherals/CameraCard.tsx
@@ -84,6 +84,7 @@ export function CameraCard({
   const navigateToUsageSettings = (): void => {
     navigate(`/devices/${robotName}/robot-settings/camera`)
   }
+
   const { createCameraImageSettings } = useCreateCameraImageSettings()
 
   return (
@@ -117,28 +118,22 @@ export function CameraCard({
           </Flex>
         </div>
       </div>
-      <div className={styles.card_overflow_btn}>
+      <div className={styles.card_overflow_btn} ref={cardOverflowWrapperRef}>
         <OverflowBtn
           aria-label="overflow"
           onClick={handleOverflowClick}
           disabled={isRobotBusy}
         />
-      </div>
-      {showOverflowMenu && (
-        <div
-          ref={cardOverflowWrapperRef}
-          onClick={() => {
-            setShowOverflowMenu(false)
-          }}
-        >
+        {showOverflowMenu && (
           <CameraCardOverflowMenu
             cameraEnabled={isCameraEnabled}
             handleToggleCamera={handleToggleCamera}
             toggleControls={toggleControls}
             navigateToUsageSettings={navigateToUsageSettings}
+            setShowOverflowMenu={setShowOverflowMenu}
           />
-        </div>
-      )}
+        )}
+      </div>
       {showControls &&
         createPortal(
           <CameraControls
@@ -157,23 +152,44 @@ function CameraCardOverflowMenu({
   handleToggleCamera,
   toggleControls,
   navigateToUsageSettings,
+  setShowOverflowMenu,
 }: {
   cameraEnabled: boolean
   handleToggleCamera: () => void
   toggleControls: () => void
   navigateToUsageSettings: () => void
+  setShowOverflowMenu: (show: boolean) => void
 }): JSX.Element {
   const { t } = useTranslation('device_details')
+
+  const handleItemClick = (action: () => void): void => {
+    setShowOverflowMenu(false)
+    action()
+  }
 
   return (
     <div className={styles.card_overflow_menu_container}>
       <div className={styles.card_overflow_menu_content_container}>
-        <MenuItem onClick={handleToggleCamera}>
+        <MenuItem
+          onClick={() => {
+            handleItemClick(handleToggleCamera)
+          }}
+        >
           {cameraEnabled ? t('disable_camera') : t('enable_camera')}
         </MenuItem>
-        <MenuItem onClick={toggleControls}>{t('edit_settings')}</MenuItem>
+        <MenuItem
+          onClick={() => {
+            handleItemClick(toggleControls)
+          }}
+        >
+          {t('edit_settings')}
+        </MenuItem>
         <Divider />
-        <MenuItem onClick={navigateToUsageSettings}>
+        <MenuItem
+          onClick={() => {
+            handleItemClick(navigateToUsageSettings)
+          }}
+        >
           {t('usage_settings')}
         </MenuItem>
       </div>

--- a/app/src/organisms/Desktop/Devices/Peripherals/inputdevices.module.css
+++ b/app/src/organisms/Desktop/Devices/Peripherals/inputdevices.module.css
@@ -48,6 +48,7 @@
 }
 
 .card_overflow_btn {
+  position: relative;
   padding: var(--spacing-4);
 }
 
@@ -58,8 +59,8 @@
 .card_overflow_menu_content_container {
   position: absolute;
   z-index: 10;
-  top: 2.6rem;
-  right: calc(50% + var(--spacing-6));
+  top: 0;
+  right: 0;
   display: flex;
   flex-direction: column;
   border-radius: var(--border-radius-4);


### PR DESCRIPTION
# Overview

Somewhere along the way, it appears that I introduced a layout shift regression when opening the `CameraCard` overflow menu. This PR corrects the CSS to achieve desired behavior.

### Current Behavior

<img width="532" height="192" alt="Screenshot 2026-01-09 at 4 48 26 PM" src="https://github.com/user-attachments/assets/21266f4c-07b1-4259-bcc8-d7bf52d4bc92" />

### Fixed Behavior

<img width="495" height="197" alt="Screenshot 2026-01-09 at 4 48 09 PM" src="https://github.com/user-attachments/assets/84d13fd3-75de-484c-b172-1eca62bfdeb7" />

## Test Plan and Hands on Testing

- See images.

## Changelog

- Fixed the Peripheral Camera Card overflow menu shifting when opening it.

## Risk assessment

- effectively none, just CSS changes
