### PR TITLE
feat(protocol-designer): Make concurrent Thermocycler actions available without a feature flag

### DIFF
--- a/protocol-designer/src/assets/localization/en/feature_flags.json
+++ b/protocol-designer/src/assets/localization/en/feature_flags.json
@@ -32,8 +32,8 @@
     "description": "This experimental setting may cause collisions, and Opentrons will not be responsible for any damage resulting from its use."
   },
   "OT_PD_ENABLE_CONCURRENT_MODULE_ACTIONS": {
-    "title": "Enable concurrent module actions",
-    "description": "Features and design changes for running steps while waiting for modules to do stuff."
+    "title": "Enable experimental concurrent module actions",
+    "description": "Features and design changes related to doing stuff with modules while other steps run at the same time"
   },
   "OT_PD_ENABLE_BY_VOLUME_BUILDER": {
     "title": "Enable by-volume builder",

--- a/protocol-designer/src/form-types.ts
+++ b/protocol-designer/src/form-types.ts
@@ -500,15 +500,15 @@ export interface HydratedThermocyclerFormData extends AnnotationFields {
   profileVolume: string | null
 
   // https://opentrons.atlassian.net/browse/EXEC-2141
-  /** @deprecated Ignored with enableConcurrentModuleActions. Use a separate Thermocycler step instead. */
+  /** @deprecated Ignored now. Use a separate Thermocycler step instead. */
   blockIsActiveHold: boolean
-  /** @deprecated Ignored with enableConcurrentModuleActions. Use a separate Thermocycler step instead. */
+  /** @deprecated Ignored now. Use a separate Thermocycler step instead. */
   blockTargetTempHold: string | null
-  /** @deprecated Ignored with enableConcurrentModuleActions. Use a separate Thermocycler step instead. */
+  /** @deprecated Ignored now. Use a separate Thermocycler step instead. */
   lidIsActiveHold: boolean
-  /** @deprecated Ignored with enableConcurrentModuleActions. Use a separate Thermocycler step instead. */
+  /** @deprecated Ignored now. Use a separate Thermocycler step instead. */
   lidTargetTempHold: string | null
-  /** @deprecated Ignored with enableConcurrentModuleActions. Use a separate Thermocycler step instead. */
+  /** @deprecated Ignored now. Use a separate Thermocycler step instead. */
   lidOpenHold: boolean
 }
 

--- a/protocol-designer/src/load-file/migration/index.ts
+++ b/protocol-designer/src/load-file/migration/index.ts
@@ -20,6 +20,7 @@ import { migrateFile as migrateFileEightFiveFive } from './8_5_5'
 import { migrateFile as migrateFileEightSix } from './8_6_0'
 import { migrateFile as migrateFileEightSeven } from './8_7_0'
 import { migrateFile as migrateFileEightEight } from './8_8_0'
+import { migrateFile as migrateFileEightNine } from './8_9_0'
 
 import type {
   PDProtocolFile,
@@ -80,8 +81,8 @@ const allMigrationsByVersion: MigrationsByVersion = {
   '8.7.0': migrateFileEightSeven,
   // @ts-expect-error
   '8.8.0': migrateFileEightEight,
-  // todo(mm, 2025-12-19): After v8.8.0 is in its own release branch, add v8.9.0 here,
-  // probably at the same time as removing the concurrent module actions feature flag.
+  // @ts-expect-error
+  '8.9.0': migrateFileEightNine,
 }
 export const migration = (
   file: any

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/DraggableSteps.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/DraggableSteps.tsx
@@ -18,7 +18,6 @@ import {
   ConcurrentGroupChild,
 } from '/protocol-designer/components/molecules'
 import { DND_TYPES } from '/protocol-designer/constants'
-import { getEnableConcurrentModuleActions } from '/protocol-designer/feature-flags/selectors'
 import {
   getOrderedSavedForms,
   getSavedStepHierarchy,
@@ -126,9 +125,6 @@ function DragDropStep(props: DragDropStepProps): JSX.Element {
 
   const dispatch = useDispatch()
   const steps = useSelector(getOrderedSavedForms)
-  const enableConcurrentModuleActions = useSelector(
-    getEnableConcurrentModuleActions
-  )
 
   const [{ isDragging }, drag] = useDrag(
     () => ({
@@ -143,16 +139,13 @@ function DragDropStep(props: DragDropStepProps): JSX.Element {
 
   const getStepsAfterMovingHere = useCallback(
     (idOfStepBeingMoved: StepIdType) => {
-      return computeStepMove(
-        convertStepArrayToHierarchy(steps, enableConcurrentModuleActions),
-        {
-          moveType: 'insertBeforeDestinationStep',
-          movedStepId: idOfStepBeingMoved,
-          destinationStepId: stepId,
-        }
-      )
+      return computeStepMove(convertStepArrayToHierarchy(steps), {
+        moveType: 'insertBeforeDestinationStep',
+        movedStepId: idOfStepBeingMoved,
+        destinationStepId: stepId,
+      })
     },
-    [steps, stepId, enableConcurrentModuleActions]
+    [steps, stepId]
   )
 
   const [{ isHoveredOver, canBeDroppedUpon }, drop] = useDrop(
@@ -307,23 +300,17 @@ function ThermocyclerProfileEndCheckpoint(props: {
 
   const dispatch = useDispatch()
   const steps = useSelector(getOrderedSavedForms)
-  const enableConcurrentModuleActions = useSelector(
-    getEnableConcurrentModuleActions
-  )
   const { t } = useTranslation()
 
   const getStepsAfterMovingStepHere = useCallback(
     (idOfStepBeingMoved: StepIdType) => {
-      return computeStepMove(
-        convertStepArrayToHierarchy(steps, enableConcurrentModuleActions),
-        {
-          moveType: 'insertAsLastStepOfGroup',
-          movedStepId: idOfStepBeingMoved,
-          destinationGroupRootStepId: thermocyclerProfileStepId,
-        }
-      )
+      return computeStepMove(convertStepArrayToHierarchy(steps), {
+        moveType: 'insertAsLastStepOfGroup',
+        movedStepId: idOfStepBeingMoved,
+        destinationGroupRootStepId: thermocyclerProfileStepId,
+      })
     },
-    [steps, thermocyclerProfileStepId, enableConcurrentModuleActions]
+    [steps, thermocyclerProfileStepId]
   )
 
   const [{ isHoveredOver, canBeDroppedUpon }, drop] = useDrop(

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/__tests__/useStepText.test.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/__tests__/useStepText.test.tsx
@@ -11,7 +11,6 @@ import {
   PAUSE_UNTIL_TEMP,
   PAUSE_UNTIL_TIME,
 } from '/protocol-designer/constants'
-import { getEnableConcurrentModuleActions } from '/protocol-designer/feature-flags/selectors'
 
 import { useStepText } from '../useStepText'
 
@@ -32,7 +31,6 @@ describe('useStepText', () => {
       id: 'test-step-id',
       stepName: 'Custom Step Name',
     }
-    vi.mocked(getEnableConcurrentModuleActions).mockReturnValue(false)
     const { result } = render(mockStep)
     expect(result.current).toStrictEqual({
       text: 'Custom Step Name',
@@ -46,7 +44,6 @@ describe('useStepText', () => {
       id: 'test-step-id',
       stepName: undefined,
     }
-    vi.mocked(getEnableConcurrentModuleActions).mockReturnValue(false)
     const { result } = render(mockStep)
     expect(result.current).toStrictEqual({
       text: 'absorbance plate reader',
@@ -60,25 +57,9 @@ describe('useStepText', () => {
       id: 'test-step-id',
       stepName: '',
     }
-    vi.mocked(getEnableConcurrentModuleActions).mockReturnValue(false)
     const { result } = render(mockStep)
     expect(result.current).toStrictEqual({
       text: 'absorbance plate reader',
-      subtext: null,
-    })
-  })
-
-  it('should return null subtext when feature flag is disabled', () => {
-    const mockStep: FormData = {
-      stepType: 'pause',
-      id: 'test-step-id',
-      stepName: 'Custom Step Name',
-      pauseAction: PAUSE_UNTIL_RESUME,
-    }
-    vi.mocked(getEnableConcurrentModuleActions).mockReturnValue(false)
-    const { result } = render(mockStep)
-    expect(result.current).toStrictEqual({
-      text: 'Custom Step Name',
       subtext: null,
     })
   })
@@ -90,7 +71,6 @@ describe('useStepText', () => {
       stepName: 'Custom Step Name',
       pauseAction: PAUSE_UNTIL_RESUME,
     }
-    vi.mocked(getEnableConcurrentModuleActions).mockReturnValue(true)
     const { result } = render(mockStep)
     expect(result.current).toStrictEqual({
       text: 'Custom Step Name',
@@ -105,7 +85,6 @@ describe('useStepText', () => {
       stepName: 'Custom Step Name',
       pauseAction: PAUSE_UNTIL_RESUME,
     }
-    vi.mocked(getEnableConcurrentModuleActions).mockReturnValue(true)
     const { result } = render(mockStep)
     expect(result.current).toStrictEqual({
       text: 'Custom Step Name',
@@ -121,7 +100,6 @@ describe('useStepText', () => {
       pauseAction: PAUSE_UNTIL_TEMP,
       pauseTemperature: '25',
     }
-    vi.mocked(getEnableConcurrentModuleActions).mockReturnValue(true)
     const { result } = render(mockStep)
     expect(result.current).toStrictEqual({
       text: 'Custom Step Name',
@@ -137,7 +115,6 @@ describe('useStepText', () => {
       pauseAction: PAUSE_UNTIL_TIME,
       pauseTime: '1:2:34',
     }
-    vi.mocked(getEnableConcurrentModuleActions).mockReturnValue(true)
     const { result } = render(mockStep)
     expect(result.current).toStrictEqual({
       text: 'Custom Step Name',

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/useStepText.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/useStepText.tsx
@@ -1,12 +1,10 @@
 import { useTranslation } from 'react-i18next'
-import { useSelector } from 'react-redux'
 
 import {
   PAUSE_UNTIL_RESUME,
   PAUSE_UNTIL_TEMP,
   PAUSE_UNTIL_TIME,
 } from '/protocol-designer/constants'
-import { getEnableConcurrentModuleActions } from '/protocol-designer/feature-flags/selectors'
 
 import { formatTime } from '../../utils'
 
@@ -17,9 +15,6 @@ export function useStepText(step: FormData): {
   subtext: string | null
 } {
   const { i18n, t } = useTranslation(['application', 'protocol_steps'])
-  const enableConcurrentModuleActions = useSelector(
-    getEnableConcurrentModuleActions
-  )
 
   // add empty check to avoid causing undefined issue when calling titleCase
   const text =
@@ -28,8 +23,7 @@ export function useStepText(step: FormData): {
       : t(`stepType.${step.stepType}`)
 
   let subtext = null
-  if (enableConcurrentModuleActions && step.stepType === 'pause') {
-    // todo(mm, 2025-09-10): Improve FormData typing to make this type-safe.
+  if (step.stepType === 'pause') {
     if (step.pauseAction === PAUSE_UNTIL_RESUME) {
       subtext = t('protocol_steps:pause.untilResume')
     } else if (step.pauseAction === PAUSE_UNTIL_TEMP) {

--- a/protocol-designer/src/step-forms/reducers/index.ts
+++ b/protocol-designer/src/step-forms/reducers/index.ts
@@ -361,8 +361,6 @@ export const savedStepForms = (
         action,
         originalOrderedStepIds: rootState.orderedStepIds,
         originalStepFormsById: savedStepForms,
-        enableConcurrentModuleActions:
-          action.payload.enableConcurrentModuleActions,
       })
       return newStepFormsById
     }
@@ -1616,8 +1614,6 @@ export const orderedStepIds = (
         action,
         originalOrderedStepIds: orderedStepIds,
         originalStepFormsById: rootState.savedStepForms,
-        enableConcurrentModuleActions:
-          action.payload.enableConcurrentModuleActions,
       })
       return newOrderedStepIds
     }
@@ -1726,7 +1722,6 @@ interface SaveStepFormHelperArgs {
   action: SaveStepFormAction
   originalOrderedStepIds: StepIdType[]
   originalStepFormsById: Record<StepIdType, FormData>
-  enableConcurrentModuleActions: boolean
 }
 interface SaveStepFormHelperResult {
   newOrderedStepIds: StepIdType[]
@@ -1735,12 +1730,7 @@ interface SaveStepFormHelperResult {
 function saveStepFormHelper(
   args: SaveStepFormHelperArgs
 ): SaveStepFormHelperResult {
-  const {
-    action,
-    originalOrderedStepIds,
-    originalStepFormsById,
-    enableConcurrentModuleActions,
-  } = args
+  const { action, originalOrderedStepIds, originalStepFormsById } = args
 
   const newForm = action.payload.form
   const originalStep: FormData | null =
@@ -1749,10 +1739,8 @@ function saveStepFormHelper(
   const originalOrderedSteps = originalOrderedStepIds.map(
     id => originalStepFormsById[id]
   )
-  const originalStepHierarchy = convertStepArrayToHierarchy(
-    originalOrderedSteps,
-    action.payload.enableConcurrentModuleActions
-  )
+  const originalStepHierarchy =
+    convertStepArrayToHierarchy(originalOrderedSteps)
 
   const findResult = findStep(originalStepHierarchy, newForm.id)
 
@@ -1761,7 +1749,6 @@ function saveStepFormHelper(
     // If it's a Thermocycler profile, also pair it with a "wait for profile to complete" step.
 
     const newPauseForm: PauseFormData | null =
-      enableConcurrentModuleActions &&
       getThermocyclerFormType(newForm) === 'thermocyclerProfile'
         ? getThermocyclerProfilePauseForm(
             newForm as ThermocyclerFormData,
@@ -1810,12 +1797,10 @@ function saveStepFormHelper(
       // 1) Potentially find a new position to move it to, since we can't allow Thermocycler profiles to nest.
       // 2) Create a hidden "wait for profile to complete" step that it will be permanently paired with.
 
-      const newPauseForm = enableConcurrentModuleActions
-        ? getThermocyclerProfilePauseForm(
-            newForm as ThermocyclerFormData,
-            action.payload.thermocyclerPauseStepId
-          )
-        : null
+      const newPauseForm = getThermocyclerProfilePauseForm(
+        newForm as ThermocyclerFormData,
+        action.payload.thermocyclerPauseStepId
+      )
 
       // If the edited step was is inside a Thermocycler profile, we'll move it to just after the profile.
       // null means "leave the edited step in-place."

--- a/protocol-designer/src/step-forms/selectors/index.ts
+++ b/protocol-designer/src/step-forms/selectors/index.ts
@@ -442,16 +442,9 @@ export const getOrderedSavedForms: Selector<BaseState, FormData[]> =
   )
 
 export const getSavedStepHierarchy: Selector<BaseState, StepHierarchy> =
-  createSelector(
-    getOrderedSavedForms,
-    featureFlagSelectors.getEnableConcurrentModuleActions,
-    (orderedSavedForms, enableConcurrentModuleActions) => {
-      return convertStepArrayToHierarchy(
-        orderedSavedForms,
-        enableConcurrentModuleActions
-      )
-    }
-  )
+  createSelector(getOrderedSavedForms, orderedSavedForms => {
+    return convertStepArrayToHierarchy(orderedSavedForms)
+  })
 
 /**
  * A mapping from step IDs to the step's user-visible index in the timeline.
@@ -753,13 +746,7 @@ export const getArgsAndErrorsByStepId: Selector<
   getOrderedSavedForms,
   getInvariantContext,
   labwareDefSelectors.getLabwareDefsByURI,
-  featureFlagSelectors.getEnableConcurrentModuleActions,
-  (
-    stepForms,
-    contextualState,
-    allLabwareDefs,
-    enableConcurrentModuleActions
-  ) => {
+  (stepForms, contextualState, allLabwareDefs) => {
     return reduce(
       stepForms,
       (acc, stepForm, index) => {
@@ -773,8 +760,7 @@ export const getArgsAndErrorsByStepId: Selector<
           ? {
               stepArgs: stepFormToArgs(
                 { ...hydratedForm, stepNumber: index + 1 },
-                contextualState,
-                enableConcurrentModuleActions
+                contextualState
               ),
             }
           : {

--- a/protocol-designer/src/step-forms/test/reducers.test.ts
+++ b/protocol-designer/src/step-forms/test/reducers.test.ts
@@ -90,7 +90,6 @@ describe('orderedStepIds reducer', () => {
           id: '123',
           stepType: 'moveLiquid',
         },
-        enableConcurrentModuleActions: true,
         thermocyclerPauseStepId: 'thermocyclerPauseStepId',
       },
     }
@@ -121,7 +120,6 @@ describe('orderedStepIds reducer', () => {
           id: '123',
           stepType: 'moveLiquid',
         },
-        enableConcurrentModuleActions: true,
         thermocyclerPauseStepId: 'thermocyclerPauseStepId',
       },
     }
@@ -129,80 +127,72 @@ describe('orderedStepIds reducer', () => {
       state.orderedStepIds
     )
   })
-  it.each([true, false])(
-    'should also add a pause step when a new thermocycler profile step is created (enableConcurrentModuleActions: %s)',
-    enableConcurrentModuleActions => {
-      const state: Partial<RootState> = {
-        orderedStepIds: ['id-1'],
-        savedStepForms: {
-          'id-1': {
-            id: 'id-1',
-            stepType: 'moveLiquid',
-          },
+  it('should also add a pause step when a new thermocycler profile step is created', () => {
+    const state: Partial<RootState> = {
+      orderedStepIds: ['id-1'],
+      savedStepForms: {
+        'id-1': {
+          id: 'id-1',
+          stepType: 'moveLiquid',
         },
-      }
-      const action: SaveStepFormAction = {
-        type: 'SAVE_STEP_FORM',
-        payload: {
-          form: {
-            id: 'id-2',
-            stepType: 'thermocycler',
-            thermocyclerFormType: 'thermocyclerProfile',
-            moduleId: 'thermocyclerModuleId',
-          },
-          enableConcurrentModuleActions,
-          thermocyclerPauseStepId: 'id-3',
-        },
-      }
-      const expectedOrder = enableConcurrentModuleActions
-        ? ['id-1', 'id-2', 'id-3']
-        : ['id-1', 'id-2']
-      expect(orderedStepIds(state as RootState, action)).toEqual(expectedOrder)
+      },
     }
-  )
-  it.each([
-    [true, ['1', '2', 'pause-for-2', '3']],
-    [false, ['1', '2', '3']],
-  ])(
-    'should create a pause step when a non-TC-profile step is edited to become a TC profile step (enableConcurrentModuleActions: %s)',
-    (enableConcurrentModuleActions, expectedOrder) => {
-      const state: Partial<RootState> = {
-        orderedStepIds: ['1', '2', '3'],
-        savedStepForms: {
-          '1': {
-            id: '1',
-            stepType: 'moveLiquid',
-          },
-          '2': {
-            id: '2',
-            stepType: 'thermocycler',
-            thermocyclerFormType: 'thermocyclerState',
-            moduleId: 'thermocyclerModuleId',
-          },
-          '3': {
-            id: '3',
-            stepType: 'moveLiquid',
-          },
+    const action: SaveStepFormAction = {
+      type: 'SAVE_STEP_FORM',
+      payload: {
+        form: {
+          id: 'id-2',
+          stepType: 'thermocycler',
+          thermocyclerFormType: 'thermocyclerProfile',
+          moduleId: 'thermocyclerModuleId',
         },
-      }
-
-      const action: SaveStepFormAction = {
-        type: 'SAVE_STEP_FORM',
-        payload: {
-          form: {
-            id: '2',
-            stepType: 'thermocycler',
-            thermocyclerFormType: 'thermocyclerProfile',
-            moduleId: 'thermocyclerModuleId',
-          },
-          enableConcurrentModuleActions,
-          thermocyclerPauseStepId: 'pause-for-2',
-        },
-      }
-
-      expect(orderedStepIds(state as RootState, action)).toEqual(expectedOrder)
+        thermocyclerPauseStepId: 'id-3',
+      },
     }
-  )
+    const expectedOrder = ['id-1', 'id-2', 'id-3']
+    expect(orderedStepIds(state as RootState, action)).toEqual(expectedOrder)
+  })
+  it('should create a pause step when a non-TC-profile step is edited to become a TC profile step', () => {
+    const state: Partial<RootState> = {
+      orderedStepIds: ['1', '2', '3'],
+      savedStepForms: {
+        '1': {
+          id: '1',
+          stepType: 'moveLiquid',
+        },
+        '2': {
+          id: '2',
+          stepType: 'thermocycler',
+          thermocyclerFormType: 'thermocyclerState',
+          moduleId: 'thermocyclerModuleId',
+        },
+        '3': {
+          id: '3',
+          stepType: 'moveLiquid',
+        },
+      },
+    }
+
+    const action: SaveStepFormAction = {
+      type: 'SAVE_STEP_FORM',
+      payload: {
+        form: {
+          id: '2',
+          stepType: 'thermocycler',
+          thermocyclerFormType: 'thermocyclerProfile',
+          moduleId: 'thermocyclerModuleId',
+        },
+        thermocyclerPauseStepId: 'pause-for-2',
+      },
+    }
+
+    expect(orderedStepIds(state as RootState, action)).toEqual([
+      '1',
+      '2',
+      'pause-for-2',
+      '3',
+    ])
+  })
   it('should handle a non-TC-profile, which is inside a TC profile, being edited to also become a TC profile', () => {
     // Since we can't allow TC profiles to nest, the edited step should get moved
     // so it's outside the profile that was enclosing it.
@@ -251,7 +241,6 @@ describe('orderedStepIds reducer', () => {
           thermocyclerFormType: 'thermocyclerProfile',
           moduleId: 'thermocyclerModuleId',
         },
-        enableConcurrentModuleActions: true,
         thermocyclerPauseStepId: 'pause-for-4',
       },
     }
@@ -298,7 +287,6 @@ describe('orderedStepIds reducer', () => {
           thermocyclerFormType: 'thermocyclerState',
           moduleId: 'thermocyclerModuleId',
         },
-        enableConcurrentModuleActions: true,
         thermocyclerPauseStepId: 'unused-thermocycler-pause-step-id',
       },
     }
@@ -1426,124 +1414,112 @@ describe('savedStepForms reducer: initial deck setup step', () => {
     })
   })
   describe('thermocycler profile pause step handling', () => {
-    it.each([true, false])(
-      'should also add a pause step when a thermocycler profile step is created from scratch (enableConcurrentModuleActions: %s)',
-      enableConcurrentModuleActions => {
-        const otherForm: FormData = {
-          id: 'otherFormId',
-          stepType: 'moveLiquid',
-        }
-        const tcProfileForm: FormData = {
-          id: 'tcProfileFormId',
-          stepType: 'thermocycler',
-          thermocyclerFormType: 'thermocyclerProfile',
-          moduleId: 'thermocyclerModuleId',
-        }
-        const state: Partial<RootState> = {
-          orderedStepIds: [otherForm.id],
-          savedStepForms: {
-            [otherForm.id]: otherForm,
-          },
-        }
-
-        const pauseStepFormId = 'pauseFormId'
-        const expectedPauseStepForm: FormData = {
-          id: pauseStepFormId,
-          stepType: 'pause',
-          stepName: 'pause',
-          stepDetails: '',
-          pauseAction: 'untilThermocyclerProfileComplete',
-          moduleId: tcProfileForm.moduleId,
-        }
-
-        const action: SaveStepFormAction = {
-          type: 'SAVE_STEP_FORM',
-          payload: {
-            form: tcProfileForm,
-            enableConcurrentModuleActions,
-            thermocyclerPauseStepId: pauseStepFormId,
-          },
-        }
-
-        const expectedSavedStepForms = {
+    it('should also add a pause step when a thermocycler profile step is created from scratch', () => {
+      const otherForm: FormData = {
+        id: 'otherFormId',
+        stepType: 'moveLiquid',
+      }
+      const tcProfileForm: FormData = {
+        id: 'tcProfileFormId',
+        stepType: 'thermocycler',
+        thermocyclerFormType: 'thermocyclerProfile',
+        moduleId: 'thermocyclerModuleId',
+      }
+      const state: Partial<RootState> = {
+        orderedStepIds: [otherForm.id],
+        savedStepForms: {
           [otherForm.id]: otherForm,
-          [tcProfileForm.id]: tcProfileForm,
-          ...(enableConcurrentModuleActions && {
-            [expectedPauseStepForm.id]: expectedPauseStepForm,
-          }),
-        }
-
-        expect(savedStepForms(state as RootState, action)).toEqual(
-          expectedSavedStepForms
-        )
+        },
       }
-    )
-    it.each([true, false])(
-      'should create a pause step when a non-TC-profile step is edited to become a TC profile step (enableConcurrentModuleActions: %s)',
-      enableConcurrentModuleActions => {
-        const form1: FormData = {
-          id: '1',
-          stepType: 'moveLiquid',
-        }
-        const form2ThermocyclerState: FormData = {
-          id: '2',
-          stepType: 'thermocycler',
-          thermocyclerFormType: 'thermocyclerState',
-          moduleId: 'thermocyclerModuleId',
-        }
-        const form3: FormData = {
-          id: '3',
-          stepType: 'moveLiquid',
-        }
-        const state: Partial<RootState> = {
-          orderedStepIds: [form1.id, form2ThermocyclerState.id, form3.id],
-          savedStepForms: {
-            [form1.id]: form1,
-            [form2ThermocyclerState.id]: form2ThermocyclerState,
-            [form3.id]: form3,
-          },
-        }
 
-        const form2ThermocyclerProfile: FormData = {
-          id: '2',
-          stepType: 'thermocycler',
-          thermocyclerFormType: 'thermocyclerProfile',
-          moduleId: 'thermocyclerModuleId',
-        }
+      const pauseStepFormId = 'pauseFormId'
+      const expectedPauseStepForm: FormData = {
+        id: pauseStepFormId,
+        stepType: 'pause',
+        stepName: 'pause',
+        stepDetails: '',
+        pauseAction: 'untilThermocyclerProfileComplete',
+        moduleId: tcProfileForm.moduleId,
+      }
 
-        const pauseFormId = 'pauseFormId'
-        const expectedPauseForm: FormData = {
-          id: pauseFormId,
-          stepType: 'pause',
-          stepName: 'pause',
-          stepDetails: '',
-          pauseAction: 'untilThermocyclerProfileComplete',
-          moduleId: 'thermocyclerModuleId',
-        }
+      const action: SaveStepFormAction = {
+        type: 'SAVE_STEP_FORM',
+        payload: {
+          form: tcProfileForm,
+          thermocyclerPauseStepId: pauseStepFormId,
+        },
+      }
 
-        const action: SaveStepFormAction = {
-          type: 'SAVE_STEP_FORM',
-          payload: {
-            form: form2ThermocyclerProfile,
-            enableConcurrentModuleActions,
-            thermocyclerPauseStepId: pauseFormId,
-          },
-        }
+      const expectedSavedStepForms = {
+        [otherForm.id]: otherForm,
+        [tcProfileForm.id]: tcProfileForm,
+        [expectedPauseStepForm.id]: expectedPauseStepForm,
+      }
 
-        const expectedSavedStepForms = {
+      expect(savedStepForms(state as RootState, action)).toEqual(
+        expectedSavedStepForms
+      )
+    })
+    it('should create a pause step when a non-TC-profile step is edited to become a TC profile step', () => {
+      const form1: FormData = {
+        id: '1',
+        stepType: 'moveLiquid',
+      }
+      const form2ThermocyclerState: FormData = {
+        id: '2',
+        stepType: 'thermocycler',
+        thermocyclerFormType: 'thermocyclerState',
+        moduleId: 'thermocyclerModuleId',
+      }
+      const form3: FormData = {
+        id: '3',
+        stepType: 'moveLiquid',
+      }
+      const state: Partial<RootState> = {
+        orderedStepIds: [form1.id, form2ThermocyclerState.id, form3.id],
+        savedStepForms: {
           [form1.id]: form1,
-          [form2ThermocyclerProfile.id]: form2ThermocyclerProfile,
-          ...(enableConcurrentModuleActions && {
-            [expectedPauseForm.id]: expectedPauseForm,
-          }),
+          [form2ThermocyclerState.id]: form2ThermocyclerState,
           [form3.id]: form3,
-        }
-
-        expect(savedStepForms(state as RootState, action)).toEqual(
-          expectedSavedStepForms
-        )
+        },
       }
-    )
+
+      const form2ThermocyclerProfile: FormData = {
+        id: '2',
+        stepType: 'thermocycler',
+        thermocyclerFormType: 'thermocyclerProfile',
+        moduleId: 'thermocyclerModuleId',
+      }
+
+      const pauseFormId = 'pauseFormId'
+      const expectedPauseForm: FormData = {
+        id: pauseFormId,
+        stepType: 'pause',
+        stepName: 'pause',
+        stepDetails: '',
+        pauseAction: 'untilThermocyclerProfileComplete',
+        moduleId: 'thermocyclerModuleId',
+      }
+
+      const action: SaveStepFormAction = {
+        type: 'SAVE_STEP_FORM',
+        payload: {
+          form: form2ThermocyclerProfile,
+          thermocyclerPauseStepId: pauseFormId,
+        },
+      }
+
+      const expectedSavedStepForms = {
+        [form1.id]: form1,
+        [form2ThermocyclerProfile.id]: form2ThermocyclerProfile,
+        [expectedPauseForm.id]: expectedPauseForm,
+        [form3.id]: form3,
+      }
+
+      expect(savedStepForms(state as RootState, action)).toEqual(
+        expectedSavedStepForms
+      )
+    })
     it('should delete the paired pause step when a TC profile step is edited to become a non-TC-profile step', () => {
       const form1: FormData = { id: '1', stepType: 'moveLiquid' }
       const form2ThermocyclerState: FormData = {
@@ -1588,7 +1564,6 @@ describe('savedStepForms reducer: initial deck setup step', () => {
         type: 'SAVE_STEP_FORM',
         payload: {
           form: form2ThermocyclerState,
-          enableConcurrentModuleActions: true,
           thermocyclerPauseStepId: 'unused-thermocycler-pause-step-id',
         },
       }

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/index.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/index.ts
@@ -34,8 +34,7 @@ export function _castForm<HydratedFormDataT extends HydratedFormData>(
 
 export const stepFormToArgs = (
   hydratedForm: HydratedFormData,
-  contextualState: InvariantContext,
-  enableConcurrentModuleActions: boolean
+  contextualState: InvariantContext
 ): StepArgs => {
   const castForm = _castForm(hydratedForm)
   let stepArgs: StepArgs = null
@@ -61,10 +60,7 @@ export const stepFormToArgs = (
       break
     }
     case 'thermocycler': {
-      stepArgs = thermocyclerFormToArgs(
-        _castForm(hydratedForm),
-        enableConcurrentModuleActions
-      )
+      stepArgs = thermocyclerFormToArgs(_castForm(hydratedForm))
       break
     }
     case 'heaterShaker': {

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/thermocyclerFormToArgs.test.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/thermocyclerFormToArgs.test.ts
@@ -21,7 +21,6 @@ describe('thermocyclerFormToArgs', () => {
   const testCases: Array<{
     formData: GetCastFormData<HydratedThermocyclerFormData>
     expected: ThermocyclerStateStepArgs | ThermocyclerProfileStepArgs
-    enableConcurrentModuleActions: boolean
     testName: string
   }> = [
     {
@@ -65,7 +64,6 @@ describe('thermocyclerFormToArgs', () => {
         lidTargetTemp: 40,
         lidOpen: false,
       },
-      enableConcurrentModuleActions: true,
     },
     {
       testName: 'all active temps',
@@ -101,7 +99,6 @@ describe('thermocyclerFormToArgs', () => {
         lidTargetTemp: 40,
         lidOpen: false,
       },
-      enableConcurrentModuleActions: true,
     },
     {
       testName: 'inactive block - wrong (?) types',
@@ -144,7 +141,6 @@ describe('thermocyclerFormToArgs', () => {
         lidTargetTemp: 40,
         lidOpen: false,
       },
-      enableConcurrentModuleActions: true,
     },
     {
       testName: 'inactive block',
@@ -180,7 +176,6 @@ describe('thermocyclerFormToArgs', () => {
         lidTargetTemp: 40,
         lidOpen: false,
       },
-      enableConcurrentModuleActions: true,
     },
     {
       testName: 'profile with cycles - wrong (?) types',
@@ -238,6 +233,9 @@ describe('thermocyclerFormToArgs', () => {
             ],
           },
         },
+        blockIsActive: false,
+        // Hold options are deprecated and should be ignored:
+        lidOpenHold: true,
         blockIsActiveHold: true,
         // @ts-expect-error - See comment above.
         // blockTargetTemp and blockTargetTempHold can never be null according to their castValue,
@@ -248,17 +246,12 @@ describe('thermocyclerFormToArgs', () => {
         lidIsActiveHold: true,
         // @ts-expect-error - See comment above.
         lidTargetTempHold: '5',
-        lidOpenHold: true,
-        blockIsActive: false,
       },
       expected: {
         commandCreatorFnName: THERMOCYCLER_PROFILE,
-        concurrent: false,
+        concurrent: true,
         moduleId: tcModuleId,
         description: 'mock details',
-        blockTargetTempHold: null,
-        lidOpenHold: true,
-        lidTargetTempHold: 5,
         profileElements: [
           // top-level step
           { celsius: 5, holdSeconds: 50 },
@@ -309,7 +302,6 @@ describe('thermocyclerFormToArgs', () => {
           ],
         },
       },
-      enableConcurrentModuleActions: false,
     },
     {
       testName: 'profile with cycles',
@@ -362,131 +354,13 @@ describe('thermocyclerFormToArgs', () => {
             ],
           },
         },
+        blockIsActive: false,
+        // Hold options are deprecated and should be ignored:
+        lidOpenHold: true,
         blockIsActiveHold: true,
-        blockTargetTempHold: 0,
+        blockTargetTempHold: 999,
         lidIsActiveHold: true,
-        lidTargetTempHold: 5,
-        lidOpenHold: true,
-        blockIsActive: false,
-      },
-      expected: {
-        commandCreatorFnName: THERMOCYCLER_PROFILE,
-        concurrent: false,
-        moduleId: tcModuleId,
-        description: 'mock details',
-        // todo(mm, 2025-10-09): See comments above about blockTargetTemp and blockTargetTempHold nullability.
-        blockTargetTempHold: 0,
-        lidOpenHold: true,
-        lidTargetTempHold: 5,
-        profileElements: [
-          // top-level step
-          { celsius: 5, holdSeconds: 50 },
-          // cycle
-          {
-            steps: [
-              { celsius: 12, holdSeconds: 62 },
-              { celsius: 99, holdSeconds: 45 },
-            ],
-            repetitions: 2,
-          },
-        ],
-        profileTargetLidTemp: 40,
-        profileVolume: 4,
-        meta: {
-          rawProfileItems: [
-            {
-              type: 'profileStep',
-              id: 'profileItem1',
-              title: 'Top level step',
-              temperature: '5',
-              durationMinutes: '',
-              durationSeconds: '50',
-            },
-            {
-              id: 'profileItem2',
-              type: 'profileCycle',
-              repetitions: '2',
-              steps: [
-                {
-                  type: 'profileStep',
-                  id: 'item2A',
-                  title: 'Step A in cycle',
-                  temperature: '12',
-                  durationMinutes: '1',
-                  durationSeconds: '2',
-                },
-                {
-                  type: 'profileStep',
-                  id: 'item2B',
-                  title: 'Step B in cycle',
-                  temperature: '99',
-                  durationMinutes: '',
-                  durationSeconds: '45',
-                },
-              ],
-            },
-          ],
-        },
-      },
-      enableConcurrentModuleActions: false,
-    },
-    {
-      testName: 'concurrent profile',
-      formData: {
-        ...getDefaultsForStepType('thermocycler'),
-        stepType: 'thermocycler',
-        id: 'testId',
-        stepName: 'mock name',
-        stepDetails: 'mock details',
-        moduleId: tcModuleId,
-        thermocyclerFormType: THERMOCYCLER_PROFILE,
-        blockTargetTemp: 9999,
-        lidIsActive: true,
-        lidTargetTemp: 40,
-        lidOpen: false,
-        profileVolume: '4',
-        profileTargetLidTemp: '40',
-        orderedProfileItems: ['profileItem1', 'profileItem2'],
-        stepNumber: 1,
-        profileItemsById: {
-          profileItem1: {
-            type: 'profileStep',
-            id: 'profileItem1',
-            title: 'Top level step',
-            temperature: '5',
-            durationMinutes: '',
-            durationSeconds: '50',
-          },
-          profileItem2: {
-            id: 'profileItem2',
-            type: 'profileCycle',
-            repetitions: '2',
-            steps: [
-              {
-                type: 'profileStep',
-                id: 'item2A',
-                title: 'Step A in cycle',
-                temperature: '12',
-                durationMinutes: '1',
-                durationSeconds: '2',
-              },
-              {
-                type: 'profileStep',
-                id: 'item2B',
-                title: 'Step B in cycle',
-                temperature: '99',
-                durationMinutes: '',
-                durationSeconds: '45',
-              },
-            ],
-          },
-        },
-        blockIsActiveHold: false,
-        lidIsActiveHold: false,
-        lidOpenHold: false,
-        blockIsActive: false,
-        blockTargetTempHold: 0,
-        lidTargetTempHold: 0,
+        lidTargetTempHold: 999,
       },
       expected: {
         commandCreatorFnName: THERMOCYCLER_PROFILE,
@@ -543,17 +417,12 @@ describe('thermocyclerFormToArgs', () => {
           ],
         },
       },
-      enableConcurrentModuleActions: true,
     },
   ]
 
-  testCases.forEach(
-    ({ formData, expected, enableConcurrentModuleActions, testName }) => {
-      it(`should translate "thermocyclerState" to args: ${testName}`, () => {
-        expect(
-          thermocyclerFormToArgs(formData, enableConcurrentModuleActions)
-        ).toEqual(expected)
-      })
-    }
-  )
+  testCases.forEach(({ formData, expected, testName }) => {
+    it(`should translate "thermocyclerState" to args: ${testName}`, () => {
+      expect(thermocyclerFormToArgs(formData)).toEqual(expected)
+    })
+  })
 })

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/thermocyclerFormToArgs.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/thermocyclerFormToArgs.ts
@@ -40,8 +40,7 @@ const _convertToProfileElements = (args: {
 }
 
 export const thermocyclerFormToArgs = (
-  castFormData: GetCastFormData<HydratedThermocyclerFormData>,
-  enableConcurrentModuleActions: boolean
+  castFormData: GetCastFormData<HydratedThermocyclerFormData>
 ): ThermocyclerProfileStepArgs | ThermocyclerStateStepArgs => {
   const { thermocyclerFormType, stepDetails } = castFormData
 
@@ -74,20 +73,6 @@ export const thermocyclerFormToArgs = (
         profileItemsById: castFormData.profileItemsById,
       })
 
-      const holdStepArgs = {
-        blockTargetTempHold:
-          castFormData.blockIsActiveHold &&
-          castFormData.blockTargetTempHold !== null
-            ? Number(castFormData.blockTargetTempHold)
-            : null,
-        lidOpenHold: castFormData.lidOpenHold,
-        lidTargetTempHold:
-          castFormData.lidIsActiveHold &&
-          castFormData.lidTargetTempHold !== null
-            ? Number(castFormData.lidTargetTempHold)
-            : null,
-      }
-
       const args = {
         commandCreatorFnName: THERMOCYCLER_PROFILE,
 
@@ -107,16 +92,7 @@ export const thermocyclerFormToArgs = (
         profileVolume: Number(castFormData.profileVolume),
         description: stepDetails,
 
-        ...(enableConcurrentModuleActions
-          ? {
-              concurrent: true as const,
-              // holdStepArgs is omitted here because step-generation and the backend
-              // don't support that functionality when concurrent is true.
-            }
-          : {
-              concurrent: false as const,
-              ...holdStepArgs,
-            }),
+        concurrent: true as const,
       }
 
       return args

--- a/protocol-designer/src/steplist/test/stepHierarchy.test.ts
+++ b/protocol-designer/src/steplist/test/stepHierarchy.test.ts
@@ -143,49 +143,10 @@ describe('convertFlatStepArrayToHierarchy() and convertStepHierarchyToFlatArray(
     flat: FormData[]
     hierarchy: StepHierarchy
   }>)('$label', ({ flat, hierarchy }) => {
-    const hierarchyResult = convertStepArrayToHierarchy(flat, true)
+    const hierarchyResult = convertStepArrayToHierarchy(flat)
     expect(hierarchyResult).toStrictEqual(hierarchy)
     const flatResult = convertStepHierarchyToArray(hierarchyResult)
     expect(flatResult).toStrictEqual(flat.map(element => element.id))
-  })
-
-  it('should no-op if enableConcurrentModuleActions is false', () => {
-    const input: FormData[] = [
-      {
-        id: 'a',
-        stepType: 'comment',
-      },
-      {
-        id: 'b',
-        stepType: 'thermocycler',
-        thermocyclerFormType: THERMOCYCLER_PROFILE,
-      },
-      {
-        id: 'c',
-        stepType: 'comment',
-      },
-      {
-        id: 'd',
-        stepType: 'comment',
-      },
-      {
-        id: 'e',
-        stepType: 'pause',
-        pauseAction: PAUSE_UNTIL_TC_PROFILE_COMPLETE,
-      },
-      {
-        id: 'f',
-        stepType: 'comment',
-      },
-    ]
-    const result = convertStepArrayToHierarchy(input, false)
-    const expectedResult: typeof result = {
-      topLevelItems: input.map(step => ({
-        type: 'standaloneStep',
-        stepId: step.id,
-      })),
-    }
-    expect(result).toStrictEqual(expectedResult)
   })
 })
 

--- a/protocol-designer/src/steplist/utils/stepHierarchy.ts
+++ b/protocol-designer/src/steplist/utils/stepHierarchy.ts
@@ -48,32 +48,15 @@ export interface ThermocyclerProfileGroup {
 
 /**
  * Given a flat array of steps, return the equivalent hierarchy.
- *
- * If enableConcurrentModuleActions is false, this is a no-op.
  */
-export function convertStepArrayToHierarchy(
-  steps: FormData[],
-  enableConcurrentModuleActions: boolean
-): StepHierarchy {
-  if (enableConcurrentModuleActions) {
-    return {
-      topLevelItems: [
-        ..._convertStepArrayToHierarchy(steps, enableConcurrentModuleActions),
-      ],
-    }
-  } else {
-    return {
-      topLevelItems: steps.map(step => ({
-        type: 'standaloneStep',
-        stepId: step.id,
-      })),
-    }
+export function convertStepArrayToHierarchy(steps: FormData[]): StepHierarchy {
+  return {
+    topLevelItems: [..._convertStepArrayToHierarchy(steps)],
   }
 }
 
 function* _convertStepArrayToHierarchy(
-  steps: FormData[],
-  enableConcurrentModuleActions: boolean
+  steps: FormData[]
 ): Generator<StandaloneStep | ThermocyclerProfileGroup> {
   let currentGroup: {
     thermocyclerProfileStepId: StepIdType

--- a/protocol-designer/src/ui/steps/actions/__tests__/actions.test.ts
+++ b/protocol-designer/src/ui/steps/actions/__tests__/actions.test.ts
@@ -4,7 +4,6 @@ import { thunk } from 'redux-thunk'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { when } from 'vitest-when'
 
-import * as featureFlagSelectors from '/protocol-designer/feature-flags/selectors'
 import { getRobotStateTimeline } from '/protocol-designer/file-data/selectors'
 import * as stepFormSelectors from '/protocol-designer/step-forms/selectors'
 import * as tutorialSelectors from '/protocol-designer/tutorial/selectors'
@@ -266,9 +265,6 @@ describe('steps actions', () => {
       vi.mocked(tutorialSelectors.shouldShowWasteChuteHint).mockReturnValue(
         false
       )
-      vi.mocked(
-        featureFlagSelectors.getEnableConcurrentModuleActions
-      ).mockReturnValue(true)
     })
 
     afterEach(() => {
@@ -326,7 +322,6 @@ describe('steps actions', () => {
             payload: {
               form: temperatureForm,
               thermocyclerPauseStepId: expect.any(String),
-              enableConcurrentModuleActions: true,
             },
           })
 
@@ -401,7 +396,6 @@ describe('steps actions', () => {
             payload: {
               form: heaterShakerForm,
               thermocyclerPauseStepId: expect.any(String),
-              enableConcurrentModuleActions: true,
             },
           })
 

--- a/protocol-designer/src/ui/steps/actions/thunks/index.ts
+++ b/protocol-designer/src/ui/steps/actions/thunks/index.ts
@@ -10,7 +10,6 @@ import {
 } from '@opentrons/shared-data'
 
 import { PAUSE_UNTIL_TEMP } from '/protocol-designer/constants'
-import { getEnableConcurrentModuleActions } from '/protocol-designer/feature-flags/selectors'
 import * as fileDataSelectors from '/protocol-designer/file-data/selectors'
 import {
   getCurrentFormIsPresaved,
@@ -340,14 +339,9 @@ export interface SaveStepFormAction {
      * If no wait step needs to be created, this is ignored.
      */
     thermocyclerPauseStepId: StepIdType
-
-    enableConcurrentModuleActions: boolean
   }
 }
-export const _saveStepForm = (
-  form: FormData,
-  enableConcurrentModuleActions: boolean
-): SaveStepFormAction => {
+export const _saveStepForm = (form: FormData): SaveStepFormAction => {
   // if presaved, transform pseudo ID to real UUID upon save
   const id = form.id === PRESAVED_STEP_ID ? uuid() : form.id
   const adjustedForm = { ...form, id }
@@ -357,7 +351,6 @@ export const _saveStepForm = (
     payload: {
       form: adjustedForm,
       thermocyclerPauseStepId: uuid(),
-      enableConcurrentModuleActions,
     },
   }
 }
@@ -370,8 +363,6 @@ export const saveStepForm: () => ThunkAction<any> =
     const initialState = getState()
     const unsavedForm = getUnsavedForm(initialState)
     const isFirstTimeSavingThisForm = getCurrentFormIsPresaved(initialState)
-    const enableConcurrentModuleActions =
-      getEnableConcurrentModuleActions(initialState)
 
     // this check is only for TypeScript. At this point, unsavedForm should always be populated
     if (unsavedForm == null) {
@@ -392,7 +383,7 @@ export const saveStepForm: () => ThunkAction<any> =
     }
 
     // save the form
-    dispatch(_saveStepForm(unsavedForm, enableConcurrentModuleActions))
+    dispatch(_saveStepForm(unsavedForm))
 
     // Save any bonus steps that come with it.
     const isTempModSetTempForm =
@@ -435,8 +426,6 @@ export const saveStepForm: () => ThunkAction<any> =
 const saveWaitForTemperatureModuleTemp: (
   unsavedSetTemperatureForm: FormData
 ) => ThunkAction<any> = unsavedSetTemperatureForm => (dispatch, getState) => {
-  const enableConcurrentModuleActions =
-    getEnableConcurrentModuleActions(getState())
   const tempertureModuleId = unsavedSetTemperatureForm?.moduleId
   const temperature = unsavedSetTemperatureForm.targetTemperature
 
@@ -478,7 +467,7 @@ const saveWaitForTemperatureModuleTemp: (
   // finally save the new pause form
   const unsavedPauseForm = getUnsavedForm(getState())
   if (unsavedPauseForm != null) {
-    dispatch(_saveStepForm(unsavedPauseForm, enableConcurrentModuleActions))
+    dispatch(_saveStepForm(unsavedPauseForm))
   } else {
     // this conditional is for TypeScript, the unsaved form should always exist
     console.assert(
@@ -491,8 +480,6 @@ const saveWaitForTemperatureModuleTemp: (
 const saveWaitForHeaterShakerTemp: (
   unsavedHeaterShakerForm: FormData
 ) => ThunkAction<any> = unsavedHeaterShakerForm => (dispatch, getState) => {
-  const enableConcurrentModuleActions =
-    getEnableConcurrentModuleActions(getState())
   const heaterShakerModuleId = unsavedHeaterShakerForm.moduleId
   const temperature = unsavedHeaterShakerForm.targetHeaterShakerTemperature
 
@@ -529,7 +516,7 @@ const saveWaitForHeaterShakerTemp: (
   // finally save the new pause form
   const unsavedPauseForm = getUnsavedForm(getState())
   if (unsavedPauseForm != null) {
-    dispatch(_saveStepForm(unsavedPauseForm, enableConcurrentModuleActions))
+    dispatch(_saveStepForm(unsavedPauseForm))
   } else {
     // this conditional is for TypeScript, the unsaved form should always exist
     console.assert(

--- a/step-generation/src/types.ts
+++ b/step-generation/src/types.ts
@@ -638,6 +638,8 @@ export type ThermocyclerProfileStepArgs = CommonArgs & {
     | ConcurrentThermocyclerProfileStepArgs
   )
 
+// todo(mm, 2026-01-09): PD no longer uses this.
+// We can probably delete step-generation's support for it altogether.
 /**
  * Emits a blocking Thermocycler profile step. The entire profile will complete
  * before the protocol moves on to the next step.


### PR DESCRIPTION
## Overview

For the concurrent module features (EXEC-1666) that will be released in PD v8.9.0, this makes them available by default instead of needing to turn on the `enableConcurrentModuleActions` feature flag.

Specifically, that is:

* Converting `{stepType: 'thermocycler', themocyclerFormType: 'profile'}` Protocol Designer steps into _non-blocking_ Protocol Engine and Python Protocol API commands, instead of blocking ones.
* Overhauling the timeline to support nesting other steps inside of Thermocycler profiles—affecting file load/store, step creation, editing, duplication, modification, reordering, and so on.
* Migrating old protocol files, where `{stepType: 'thermocycler', themocyclerFormType: 'profile'}` steps are interpreted as blocking, to the new regime, where they're interpreted as non-blocking.
* Displaying pause steps with a subtitle.

Other parts of EXEC-1666, which are incomplete, remain behind the feature flag.

Closes EXEC-2207.

## Test Plan and Hands on Testing

With the feature flag *off*:

* [x] Import an existing protocol and check that Thermocycler steps get migrated correctly.
* [x] Play around with the timeline, adding new Thermocycler steps and making sure other things can nest within them correctly.
* [x] Export the protocol and check that the Python commands look correct.

## Review requests

None in particular.

## Risk assessment

High? The code changes in this PR itself are trivial, but this exposes a lot of risky code introduced in prior PRs. [I'm keeping some QA notes in Confluence](https://opentrons.atlassian.net/wiki/spaces/RBARM/pages/5579243664/QA+notes+for+concurrent+Thermocycler+profiles+in+PD+v8.9.0).