### PR TITLE
fix(app): fix camera setup undefined issue

### DIFF
--- a/app/src/redux/protocol-runs/selectors/setup.ts
+++ b/app/src/redux/protocol-runs/selectors/setup.ts
@@ -83,7 +83,7 @@ export const getCameraUsageState = (
   runId: string
 ): Types.CameraState => {
   const cameraStep =
-    state.protocolRuns[runId]?.setup[Constants.CAMERA_SETUP_STEP_KEY]
+    state.protocolRuns[runId]?.setup?.[Constants.CAMERA_SETUP_STEP_KEY]
   if (cameraStep == null) {
     return INITIAL_CAMERA_STATE
   }


### PR DESCRIPTION
# Overview
fix camera setup undefined issue

Without optional chaining in place, ODD ends up crashing almost immediately.

## Test Plan and Hands on Testing
- push this branch to Flex or run ODD mode
- setup up a protocol
verify that the protocol setup does not crash midway.

## Changelog
- add optional chaining

## Review requests

## Risk assessment
low

