### PR TITLE
feat(app, step-generation): liquid state accounts for airGap in api v2.22 or higher for PV

### DIFF
--- a/app/src/organisms/Desktop/ProtocolVisualization/TipSvg.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/TipSvg.tsx
@@ -14,6 +14,7 @@ interface TipSvgProps {
   color: string
   setIsHovered: Dispatch<SetStateAction<boolean>>
   isHovered: boolean
+  airGapVolume: number
 }
 
 export const TipSvg = ({
@@ -24,14 +25,21 @@ export const TipSvg = ({
   color,
   setIsHovered,
   isHovered,
+  airGapVolume,
 }: TipSvgProps): JSX.Element => {
-  const percent = Math.min(Math.max(volume / maxVolume, 0), 1)
-
   const pathTopY = 0.2
   const pathBottomY = 80
   const pathHeight = pathBottomY - pathTopY
-  const fillHeight = pathHeight * percent
-  const yStart = pathBottomY - fillHeight
+
+  const liquidPercent = Math.min(Math.max(volume / maxVolume, 0), 1)
+  const airPercent = Math.min(Math.max(airGapVolume / maxVolume, 0), 1)
+
+  const airGapHeight = pathHeight * airPercent
+  const liquidFillHeight = pathHeight * liquidPercent
+
+  const liquidBottomY = pathBottomY - airGapHeight
+  const liquidTopY = liquidBottomY - liquidFillHeight
+
   return (
     <svg
       viewBox="0 0 164.9 188.6"
@@ -43,16 +51,34 @@ export const TipSvg = ({
       }}
     >
       <defs>
-        <clipPath id="fillClip">
-          <rect x="71.2" y={yStart} width="13" height={fillHeight} />
+        {/* Clip for liquid */}
+        <clipPath id="liquidClip">
+          <rect x="71.2" y={liquidTopY} width="13" height={liquidFillHeight} />
+        </clipPath>
+
+        {/* Clip for air gap */}
+        <clipPath id="airGapClip">
+          <rect x="71.2" y={liquidBottomY} width="13" height={airGapHeight} />
         </clipPath>
       </defs>
+
       <g>
+        {/* Air gap path, clipped to match the tip shape */}
+        {airGapHeight > 0 && (
+          <path
+            d="M71.2.2l3.5,77c0,1.1.6,2.1,1.5,2.6s1,.4,1.6.4.2,0,.4,0c1.4-.2,2.4-1.5,2.4-3L84.2.2"
+            fill={COLORS.grey10}
+            stroke="none"
+            clipPath="url(#airGapClip)"
+          />
+        )}
+
+        {/* Liquid path */}
         <path
           d="M71.2.2l3.5,77c0,1.1.6,2.1,1.5,2.6s1,.4,1.6.4.2,0,.4,0c1.4-.2,2.4-1.5,2.4-3L84.2.2"
           fill={isHovered ? COLORS.flex50 : color}
           stroke="none"
-          clipPath="url(#fillClip)"
+          clipPath="url(#liquidClip)"
           onMouseEnter={() => {
             setIsHovered(true)
           }}
@@ -62,6 +88,7 @@ export const TipSvg = ({
           cursor={CURSOR_POINTER}
         />
 
+        {/* Outline */}
         <path
           d="M71.2.2l3.5,77c0,1.1.6,2.1,1.5,2.6s1,.4,1.6.4.2,0,.4,0c1.4-.2,2.4-1.5,2.4-3L84.2.2"
           stroke="#737578"

--- a/app/src/organisms/Desktop/ProtocolVisualization/VisualizerContainer/__tests__/VisualizerContainer.test.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/VisualizerContainer/__tests__/VisualizerContainer.test.tsx
@@ -52,6 +52,7 @@ const mockAnalysis = {
   modules: [],
   labware: [],
   pipettes: [],
+  liquids: [],
   result: 'ok',
   robotType: 'OT-3 Standard',
   runTimeParameters: [],

--- a/app/src/organisms/Desktop/ProtocolVisualization/VisualizerContainer/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/VisualizerContainer/index.tsx
@@ -99,7 +99,6 @@ export function VisualizerContainer(
     currentCommandsSlice,
     invariantContextFromAnalysis
   )
-  console.log('frame', frame)
   const handlePlayPause = (): void => {
     setIsPlaying(prev => !prev)
   }

--- a/app/src/organisms/Desktop/ProtocolVisualization/WellContainer/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/WellContainer/index.tsx
@@ -79,15 +79,16 @@ export function WellContainer(props: WellContainerProps): JSX.Element {
     ('wellLocation' in params ? params.wellLocation.x : 1)
   const roundedXPositionPixels = round(xPositionPixels, PIXEL_DECIMALS)
 
-  const { tipColor, tipCurrentVolume } =
+  const { tipColor, tipCurrentVolume, airGapVolume } =
     pipetteLocationLiquidState != null
       ? getTipSvgInfo(pipetteLocationLiquidState, liquids)
-      : { tipColor: COLORS.grey40, tipCurrentVolume: 0 }
+      : { tipColor: COLORS.grey40, tipCurrentVolume: 0, airGapVolume: 0 }
 
   const totalVolumeInWell =
     labwareLocationLiquidState != null
       ? getWellVolume(labwareLocationLiquidState)
       : 0
+
   return (
     <div className={styles.container}>
       <div className={styles.header}>
@@ -109,6 +110,7 @@ export function WellContainer(props: WellContainerProps): JSX.Element {
                   color={tipColor}
                   setIsHovered={setIsTipHovered}
                   isHovered={isTipHovered}
+                  airGapVolume={airGapVolume}
                 />
                 {isTipHovered ? (
                   <div className={styles.tip_details_volume}>

--- a/app/src/organisms/Desktop/ProtocolVisualization/utils/getTipSvgInfo.ts
+++ b/app/src/organisms/Desktop/ProtocolVisualization/utils/getTipSvgInfo.ts
@@ -1,4 +1,5 @@
 import { COLORS } from '@opentrons/components'
+import { AIR_GAP_LIQUID_STATE_CONST } from '@opentrons/step-generation'
 
 import type { Liquid } from '@opentrons/shared-data'
 import type { LocationLiquidState } from '@opentrons/step-generation'
@@ -6,6 +7,7 @@ import type { LocationLiquidState } from '@opentrons/step-generation'
 interface TipSvgInfo {
   tipColor: string
   tipCurrentVolume: number
+  airGapVolume: number
 }
 
 export const getTipSvgInfo = (
@@ -13,6 +15,8 @@ export const getTipSvgInfo = (
   liquids: Liquid[]
 ): TipSvgInfo => {
   const ingredIds = Object.keys(pipetteLocationLiquidState)
+  const airGapVolume =
+    pipetteLocationLiquidState[AIR_GAP_LIQUID_STATE_CONST]?.volume ?? 0
   const colorsInTip = liquids.reduce<string[]>(
     (acc, { id, displayColor }) =>
       ingredIds.includes(id) && displayColor ? [...acc, displayColor] : acc,
@@ -24,5 +28,5 @@ export const getTipSvgInfo = (
     (sum, { volume }) => sum + volume,
     0
   )
-  return { tipColor, tipCurrentVolume }
+  return { tipColor, tipCurrentVolume, airGapVolume }
 }

--- a/step-generation/src/constants.ts
+++ b/step-generation/src/constants.ts
@@ -148,3 +148,5 @@ export const SLOT_LOCATIONS_TO_FAKE_HOPPER_LOCATIONS: Record<
   C4: 'hopperC4',
   D4: 'hopperD4',
 }
+
+export const AIR_GAP_LIQUID_STATE_CONST: '__air_gap__' = '__air_gap__'

--- a/step-generation/src/getNextRobotStateAndWarnings/forAirGapInPlace.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/forAirGapInPlace.ts
@@ -27,9 +27,13 @@ export function forAirGapInPlace(
   range(channels).forEach((tipIndex): void => {
     const prev = robotState.liquidState.pipettes[pipetteId][tipIndex] ?? {}
 
+    const prevAirGapVolume = prev[AIR_GAP_LIQUID_STATE_CONST]?.volume ?? 0
+
     robotState.liquidState.pipettes[pipetteId][tipIndex] = {
       ...prev,
-      [AIR_GAP_LIQUID_STATE_CONST]: { volume },
+      [AIR_GAP_LIQUID_STATE_CONST]: {
+        volume: prevAirGapVolume + volume, // add previous air gap (if exists) + current
+      },
     }
   })
 }

--- a/step-generation/src/getNextRobotStateAndWarnings/forAirGapInPlace.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/forAirGapInPlace.ts
@@ -1,0 +1,35 @@
+import range from 'lodash/range'
+
+import { COLUMN, SINGLE } from '@opentrons/shared-data'
+
+import { AIR_GAP_LIQUID_STATE_CONST } from '../constants'
+
+import type { AirGapInPlaceParams } from '@opentrons/shared-data'
+import type { InvariantContext, RobotStateAndWarnings } from '../types'
+
+// NOTE: this update happens in PD and PV but the value is only read
+// for PV to visualize the air gap and not include it in the liquid state
+export function forAirGapInPlace(
+  params: AirGapInPlaceParams,
+  invariantContext: InvariantContext,
+  robotStateAndWarnings: RobotStateAndWarnings
+): void {
+  const { pipetteId, volume } = params
+  const { robotState } = robotStateAndWarnings
+  const nozzles = robotState.pipettes[pipetteId].nozzles
+  const pipetteSpec = invariantContext.pipetteEntities[pipetteId].spec
+  let channels = pipetteSpec.channels
+  if (nozzles === COLUMN) {
+    channels = 8
+  } else if (nozzles === SINGLE) {
+    channels = 1
+  }
+  range(channels).forEach((tipIndex): void => {
+    const prev = robotState.liquidState.pipettes[pipetteId][tipIndex] ?? {}
+
+    robotState.liquidState.pipettes[pipetteId][tipIndex] = {
+      ...prev,
+      [AIR_GAP_LIQUID_STATE_CONST]: { volume },
+    }
+  })
+}

--- a/step-generation/src/getNextRobotStateAndWarnings/forDispense.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/forDispense.ts
@@ -1,3 +1,8 @@
+import range from 'lodash/range'
+
+import { COLUMN, SINGLE } from '@opentrons/shared-data'
+
+import { AIR_GAP_LIQUID_STATE_CONST } from '../constants'
 import { dispenseUpdateLiquidState } from './dispenseUpdateLiquidState'
 
 import type {
@@ -21,15 +26,39 @@ export function forDispense(
     'wellName' in params
       ? params.wellName
       : (robotState.pipettes[pipetteId].wellName ?? '')
+  const pipetteState = robotState.liquidState.pipettes[pipetteId]
+  const firstTipState = Object.values(pipetteState)[0] // airGap volume is the same for each tip
+  const airGapVolume = firstTipState?.[AIR_GAP_LIQUID_STATE_CONST]?.volume ?? 0
 
-  dispenseUpdateLiquidState({
-    invariantContext,
-    entityId,
-    pipetteId,
-    prevLiquidState: robotState.liquidState,
-    useFullVolume: false,
-    volume,
-    wellName,
-    robotStateAndWarnings,
-  })
+  // NOTE: (ja, 1/10/26): if airGapVolume is not null, assume that the dispense command
+  // is for dispensing the air gap - NOTE: this is only used for PV right now
+  if (airGapVolume > 0) {
+    const nozzles = robotStateAndWarnings.robotState.pipettes[pipetteId].nozzles
+    const pipetteSpec = invariantContext.pipetteEntities[pipetteId].spec
+    let channels = pipetteSpec.channels
+    if (nozzles === COLUMN) {
+      channels = 8
+    } else if (nozzles === SINGLE) {
+      channels = 1
+    }
+    range(channels).forEach((tipIndex): void => {
+      const prev = robotState.liquidState.pipettes[pipetteId][tipIndex] ?? {}
+
+      robotState.liquidState.pipettes[pipetteId][tipIndex] = {
+        ...prev,
+        [AIR_GAP_LIQUID_STATE_CONST]: { volume: 0 },
+      }
+    })
+  } else {
+    dispenseUpdateLiquidState({
+      invariantContext,
+      entityId,
+      pipetteId,
+      prevLiquidState: robotState.liquidState,
+      useFullVolume: false,
+      volume,
+      wellName,
+      robotStateAndWarnings,
+    })
+  }
 }

--- a/step-generation/src/getNextRobotStateAndWarnings/index.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/index.ts
@@ -7,6 +7,7 @@ import {
   forAbsorbanceReaderInitialize,
   forAbsorbanceReaderOpenLid,
 } from './absorbanceReaderUpdates'
+import { forAirGapInPlace } from './forAirGapInPlace'
 import { forAspirate } from './forAspirate'
 import { forBlowout } from './forBlowout'
 import { forConfigureNozzleLayout } from './forConfigureNozzleLayout'
@@ -84,6 +85,9 @@ function _getNextRobotStateAndWarningsSingleCommand(
       }
       break
 
+    case 'airGapInPlace':
+      forAirGapInPlace(command.params, invariantContext, robotStateAndWarnings)
+      break
     case 'dispenseWhileTracking':
     case 'dispense':
     case 'dispenseInPlace':
@@ -207,7 +211,6 @@ function _getNextRobotStateAndWarningsSingleCommand(
     case 'custom': // fall-back
     case 'comment':
     case 'captureImage':
-    case 'airGapInPlace':
     case 'prepareToAspirate':
     case 'liquidProbe':
     case 'loadLiquidClass':

--- a/step-generation/src/utils/constructInvariantContextFromAnalysis.ts
+++ b/step-generation/src/utils/constructInvariantContextFromAnalysis.ts
@@ -16,6 +16,7 @@ import type {
 import type {
   InvariantContext,
   LabwareEntities,
+  LiquidEntities,
   ModuleEntities,
   PipetteEntities,
   StagingAreaEntities,
@@ -23,11 +24,49 @@ import type {
   WasteChuteEntities,
 } from '../types'
 
+// PD 8.4.3 introduced airGapInPlace which was released sometime on March 18, 2025, so any
+// PD versions prior to that, we will not show the liquid state - this is a gross
+// way to calculate which PD version it was but idk how else to do so since we don't
+// have explicit access to the PD version in the analysis?
+const PD_CUT_OFF_FOR_LIQUID_STATE_TRACKING = new Date('2025-03-19T00:00:00Z')
+
+// API v2.22 is when airGapInPlace was introduced, so any API versions lower than
+// that, we will not support showing the liquid state
+const API_MAJOR_VERSION_AIR_GAP_IN_PLACE_STARTED_SUPPORTING = 2
+const API_MINOR_VERSION_AIR_GAP_IN_PLACE_STARTED_SUPPORTING = 22
+
 export function constructInvariantContextFromAnalysis(
   analysis: ProtocolAnalysisOutput
 ): InvariantContext {
-  const { labware, modules, pipettes, commands } = analysis
+  const { labware, modules, pipettes, commands, liquids, config, createdAt } =
+    analysis
+  const apiVersion = config.protocolType === 'python' ? config.apiVersion : null
+  const isSupportingLiquidsPython =
+    apiVersion != null &&
+    apiVersion[0] >= API_MAJOR_VERSION_AIR_GAP_IN_PLACE_STARTED_SUPPORTING &&
+    apiVersion[1] >= API_MINOR_VERSION_AIR_GAP_IN_PLACE_STARTED_SUPPORTING
+
+  const createdDate = new Date(createdAt)
+  const isSupportingLiquidsPD =
+    config.protocolType === 'json' &&
+    createdDate >= PD_CUT_OFF_FOR_LIQUID_STATE_TRACKING
+
   const labwareDefinitions = getLabwareDefinitionsByURIForProtocol(commands)
+
+  const liquidEntities = liquids.reduce<LiquidEntities>((acc, liquid) => {
+    const { id, description, displayName, displayColor } = liquid
+
+    return {
+      ...acc,
+      [id]: {
+        description,
+        displayName: displayName ?? 'Unknown Liquid',
+        pythonName: 'n/a',
+        displayColor: displayColor ?? '#B7B8B9', // this is COLORS.grey40 which step-generation doesn't have access to
+        liquidGroupId: id,
+      },
+    }
+  }, {})
 
   const moduleEntities = modules.reduce<ModuleEntities>((acc, module) => {
     const { id, model } = module
@@ -97,11 +136,15 @@ export function constructInvariantContextFromAnalysis(
 
     return acc
   }, {})
+
   const otherEntities = commands.reduce(
     (
       acc: Omit<
         InvariantContext,
-        'labwareEntities' | 'moduleEntities' | 'pipetteEntities'
+        | 'labwareEntities'
+        | 'moduleEntities'
+        | 'pipetteEntities'
+        | 'liquidEntities'
       >,
       command: RunTimeCommand
     ) => {
@@ -189,9 +232,6 @@ export function constructInvariantContextFromAnalysis(
       stagingAreaEntities: {},
       //  the timeline scrubber doesn't visualize gripper right now
       gripperEntities: {},
-      //  this util is used for the timeline scrubber. It grabs liquid info from analysis
-      //  so this will not be wired up right now
-      liquidEntities: {},
       config: { OT_PD_DISABLE_MODULE_RESTRICTIONS: true },
     }
   )
@@ -199,6 +239,8 @@ export function constructInvariantContextFromAnalysis(
     labwareEntities,
     pipetteEntities,
     moduleEntities,
+    liquidEntities:
+      isSupportingLiquidsPython || isSupportingLiquidsPD ? liquidEntities : {},
     ...otherEntities,
   }
 }

--- a/step-generation/src/utils/liquidUtils.ts
+++ b/step-generation/src/utils/liquidUtils.ts
@@ -3,6 +3,7 @@ import reduce from 'lodash/reduce'
 
 import { DEFAULT_LIQUID_COLORS } from '@opentrons/shared-data'
 
+import { AIR_GAP_LIQUID_STATE_CONST } from '../constants'
 import { AIR } from './misc'
 
 import type { LabwareDefinition2 } from '@opentrons/shared-data'
@@ -119,13 +120,16 @@ const ingredIdsToColor = (
   groupIds: string[],
   displayColors: Record<string, string> // liquidGroupId -> color
 ): string | null | undefined => {
-  const filteredIngredIds = groupIds.filter(id => id !== AIR)
-  if (filteredIngredIds.length === 0) return null
+  const filteredIngredIds = groupIds.filter(
+    id => id !== AIR && id !== AIR_GAP_LIQUID_STATE_CONST
+  )
+  if (filteredIngredIds.length === 0) {
+    return null
+  }
 
   if (filteredIngredIds.length === 1) {
     return (
-      displayColors[Number(filteredIngredIds[0])] ??
-      swatchColors(filteredIngredIds[0])
+      displayColors[filteredIngredIds[0]] ?? swatchColors(filteredIngredIds[0])
     )
   }
 


### PR DESCRIPTION
closes AUTH-2592 AUTH-268

added air gap visually in the tip
https://github.com/user-attachments/assets/2d0df2d7-92bf-4824-bb86-232870b02392

# Overview

This pr does a few things:
1. fixes the liquids from showing up for python protocols by creating `LiquidEntities`
2. prevents showing liquids in protocols that are earlier than API v2.22 and PD v8.4.3
3. adds a robot state for `airGapInPlace` to just keep track of the air gap volume to dispense with the subsequent dispense command
4. displays the air gap in the tip visually - lol this deviates from designs but was easy enough to do so i'll show Ed and Mel to see what they think
5. since air gap is accounted for properly now for protocols with air gap in place, the liquid state is now fixed

this PR is sorta a quick fix to this issue: https://opentrons.atlassian.net/browse/AUTH-2516 but not all this work will need to be undone when that ticket is addressed

## Test Plan and Hands on Testing

Upload attached protocol and observe the liquid state

[untitled - 2026-01-10T224048.903.py](https://github.com/user-attachments/files/24553393/untitled.-.2026-01-10T224048.903.py)

## Changelog

in addition to what is outlined above, i made a new constant `AIR_GAP_LIQUID_STATE_CONST` that is used for the air gap liquid state `liquidGroupId`

## Risk assessment

medium, i would prefer for this to merge in after PD 8.8 release branch is cut because i added a robot state change for `airGapInPlace`. Theoretically, it shouldn't affect anything in PD but i just want to be cautious of our PD release deadline - there is a chance that the liquids displayed show the mixed liquid state or something since air gap in place has a liquid state now that is different from our default "air".