### PR TITLE
fix(app): add virtualization to load a big protocol

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -58,6 +58,7 @@
     "react-select": "5.4.0",
     "react-simple-keyboard": "^3.7.0",
     "react-viewport-list": "6.3.0",
+    "react-window": "2.2.4",
     "redux": "5.0.1",
     "redux-observable": "1.1.0",
     "redux-thunk": "3.1.0",

--- a/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/AnnotatedGroup.tsx
+++ b/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/AnnotatedGroup.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import is from 'date-fns/esm/locale/is/index.js'
 
 import { COLORS, Icon, StyledText } from '@opentrons/components'
 
@@ -41,19 +42,19 @@ export function AnnotatedGroup(props: AnnotatedGroupProps): JSX.Element {
     setIsExpanded(subCommands.some(command => command.isHighlighted))
   }, [subCommands])
 
+  const handleClick = (): void => {
+    setIsExpanded(!isExpanded)
+    handlePause?.()
+  }
+
   return (
     <div className={styles.annotated_group_container}>
-      <div
-        onClick={() => {
-          setIsExpanded(!isExpanded)
-          handlePause?.()
-        }}
-        className={styles.annotated_group_header}
-      >
+      <div onClick={handleClick} className={styles.annotated_group_header}>
         <StyledText desktopStyle="bodyDefaultRegular">
           {annotationType}
         </StyledText>
         <Icon
+          data-testid={isExpanded ? 'chevron-up' : 'chevron-down'}
           name={isExpanded ? 'chevron-up' : 'chevron-down'}
           size="2rem"
           color={COLORS.black90}

--- a/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/AnnotatedGroup.tsx
+++ b/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/AnnotatedGroup.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react'
-import is from 'date-fns/esm/locale/is/index.js'
 
 import { COLORS, Icon, StyledText } from '@opentrons/components'
 

--- a/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/AnnotatedStepsRowItem.tsx
+++ b/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/AnnotatedStepsRowItem.tsx
@@ -1,0 +1,74 @@
+import { COLORS, Icon, StyledText } from '@opentrons/components'
+
+import { AnnotatedGroup } from './AnnotatedGroup'
+import styles from './annotatedsteps.module.css'
+import { IndividualCommand } from './IndividualCommand'
+
+import type { RowComponentProps } from 'react-window'
+import type { ItemData } from './index'
+
+export function AnnotatedStepsRowItem(
+  props: RowComponentProps<ItemData>
+): JSX.Element {
+  const { index, style, ariaAttributes, ...data } = props
+  const row = data.rows[index]
+  return (
+    <div style={style} {...ariaAttributes}>
+      <div className={styles.annotated_steps_row}>
+        {row.type === 'group' ? (
+          <AnnotatedGroup
+            scrollTargetId={data.scrollTargetId}
+            analysis={data.analysis}
+            annotationType={row.annotationType}
+            subCommands={row.group.subCommands}
+            commandStartNumber={row.commandStartNumber}
+            allRunDefs={data.allRunDefs}
+            setSelectedCommand={data.setSelectedCommand}
+            handlePause={data.handlePause}
+          />
+        ) : row.type === 'command' ? (
+          <IndividualCommand
+            scrollTargetId={data.scrollTargetId}
+            fromGroup={row.fromGroup}
+            command={row.command}
+            isHighlighted={row.isHighlighted}
+            analysis={data.analysis}
+            allRunDefs={data.allRunDefs}
+            setSelectedCommand={data.setSelectedCommand}
+            commandNumber={row.commandNumber}
+          />
+        ) : (
+          <div className={styles.annotated_steps_error_wrapper}>
+            {row.errors.map(error => (
+              <div
+                className={styles.annotated_steps_error_container}
+                key={error.id}
+                onClick={() => {
+                  data.onShowErrorDetails()
+                }}
+              >
+                <div className={styles.annotated_steps_header}>
+                  <Icon name="ot-alert" size="1rem" color={COLORS.red60} />
+                  <StyledText
+                    desktopStyle="captionSemiBold"
+                    color={COLORS.red60}
+                  >
+                    {data.t('step_error')}
+                  </StyledText>
+                </div>
+                <StyledText desktopStyle="bodyDefaultRegular">
+                  {error.detail}
+                </StyledText>
+              </div>
+            ))}
+            <div className={styles.annotated_steps_final_command}>
+              <StyledText desktopStyle="bodyDefaultRegular">
+                {data.t('unable_to_show_steps_past_errors')}
+              </StyledText>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/annotatedsteps.module.css
+++ b/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/annotatedsteps.module.css
@@ -75,18 +75,18 @@
 }
 
 .annotated_steps_container {
-  height: 100%;
   width: 100%;
+  height: 100%;
 }
 
 .annotated_steps_list {
-  height: 100%;
   width: 100%;
+  height: 100%;
 }
 
 .annotated_steps_row {
-  padding-bottom: var(--spacing-4);
   box-sizing: border-box;
+  padding-bottom: var(--spacing-4);
 }
 
 .annotated_steps_error_wrapper {

--- a/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/annotatedsteps.module.css
+++ b/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/annotatedsteps.module.css
@@ -75,19 +75,18 @@
 }
 
 .annotated_steps_container {
-  display: flex;
-  flex-direction: column;
-  overflow-y: auto;
+  height: 100%;
+  width: 100%;
 }
 
-.annotated_steps_container::-webkit-scrollbar {
-  display: none;
+.annotated_steps_list {
+  height: 100%;
+  width: 100%;
 }
 
-.annotated_steps_wrap {
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-4);
+.annotated_steps_row {
+  padding-bottom: var(--spacing-4);
+  box-sizing: border-box;
 }
 
 .annotated_steps_error_wrapper {

--- a/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/index.tsx
@@ -62,7 +62,9 @@ export interface ItemData {
   t: (key: string) => string
 }
 
-const DEFAULT_ROW_HEIGHT_PX = 72
+// Note: Since we're using the height value that appears most frequently in the design,
+// we may need to adjust it later.
+const DEFAULT_ROW_HEIGHT_PX = 64
 
 export function AnnotatedSteps(props: AnnotatedStepsProps): JSX.Element {
   const {

--- a/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/index.tsx
@@ -1,25 +1,18 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { List, useDynamicRowHeight, useListRef } from 'react-window'
+import { List, useDynamicRowHeight, useListCallbackRef } from 'react-window'
 
-import {
-  COLORS,
-  getLabwareDefinitionsFromCommands,
-  Icon,
-  StyledText,
-} from '@opentrons/components'
+import { getLabwareDefinitionsFromCommands } from '@opentrons/components'
 
 import { ProtocolAnalysisErrorModal } from '../../Devices/ProtocolRun/ProtocolRunHeader/RunHeaderModalContainer/modals'
-import { AnnotatedGroup } from './AnnotatedGroup'
 import styles from './annotatedsteps.module.css'
-import { IndividualCommand } from './IndividualCommand'
+import { AnnotatedStepsRowItem } from './AnnotatedStepsRowItem'
 
 import type { Dispatch, SetStateAction } from 'react'
-import type { RowComponentProps } from 'react-window'
 import type {
+  AnalysisError,
   CompletedProtocolAnalysis,
   LabwareDefinition,
-  ProtocolAnalysisError,
   ProtocolAnalysisOutput,
   RunTimeCommand,
 } from '@opentrons/shared-data'
@@ -53,12 +46,12 @@ interface CommandRow {
 
 interface ErrorRow {
   type: 'errors'
-  errors: ProtocolAnalysisError[]
+  errors: AnalysisError[]
 }
 
 type AnnotatedStepsRow = GroupRow | CommandRow | ErrorRow
 
-interface ItemData {
+export interface ItemData {
   rows: AnnotatedStepsRow[]
   analysis: CompletedProtocolAnalysis | ProtocolAnalysisOutput
   allRunDefs: LabwareDefinition[]
@@ -232,7 +225,7 @@ export function AnnotatedSteps(props: AnnotatedStepsProps): JSX.Element {
     annotationNames,
   ])
 
-  const listRef = useListRef()
+  const [listRef, listRefCallback] = useListCallbackRef()
   const [listWidth, setListWidth] = useState(0)
   const dynamicRowHeight = useDynamicRowHeight({
     defaultRowHeight: DEFAULT_ROW_HEIGHT_PX,
@@ -243,8 +236,8 @@ export function AnnotatedSteps(props: AnnotatedStepsProps): JSX.Element {
     if (scrollTargetId == null) return
     const rowIndex = rowIndexByCommandId.get(scrollTargetId)
     if (rowIndex == null) return
-    listRef.current?.scrollToRow({ index: rowIndex, align: 'smart' })
-  }, [scrollTargetId, rowIndexByCommandId])
+    listRef?.scrollToRow({ index: rowIndex, align: 'smart' })
+  }, [scrollTargetId, rowIndexByCommandId, listRef])
 
   const handleRowsRendered = useCallback(
     ({ stopIndex }: { startIndex: number; stopIndex: number }) => {
@@ -293,7 +286,7 @@ export function AnnotatedSteps(props: AnnotatedStepsProps): JSX.Element {
       ) : null}
       <div className={styles.annotated_steps_container}>
         <List
-          listRef={listRef}
+          listRef={listRefCallback}
           className={styles.annotated_steps_list}
           rowCount={rows.length}
           rowHeight={dynamicRowHeight}
@@ -309,74 +302,5 @@ export function AnnotatedSteps(props: AnnotatedStepsProps): JSX.Element {
         />
       </div>
     </>
-  )
-}
-
-function AnnotatedStepsRowItem({
-  index,
-  style,
-  ariaAttributes,
-  ...data
-}: RowComponentProps<ItemData>): JSX.Element {
-  const row = data.rows[index]
-
-  return (
-    <div style={style} {...ariaAttributes}>
-      <div className={styles.annotated_steps_row}>
-        {row.type === 'group' ? (
-          <AnnotatedGroup
-            scrollTargetId={data.scrollTargetId}
-            analysis={data.analysis}
-            annotationType={row.annotationType}
-            subCommands={row.group.subCommands}
-            commandStartNumber={row.commandStartNumber}
-            allRunDefs={data.allRunDefs}
-            setSelectedCommand={data.setSelectedCommand}
-            handlePause={data.handlePause}
-          />
-        ) : row.type === 'command' ? (
-          <IndividualCommand
-            scrollTargetId={data.scrollTargetId}
-            fromGroup={row.fromGroup}
-            command={row.command}
-            isHighlighted={row.isHighlighted}
-            analysis={data.analysis}
-            allRunDefs={data.allRunDefs}
-            setSelectedCommand={data.setSelectedCommand}
-            commandNumber={row.commandNumber}
-          />
-        ) : (
-          <div className={styles.annotated_steps_error_wrapper}>
-            {row.errors.map(error => (
-              <div
-                className={styles.annotated_steps_error_container}
-                key={error.id}
-                onClick={() => {
-                  data.onShowErrorDetails()
-                }}
-              >
-                <div className={styles.annotated_steps_header}>
-                  <Icon name="ot-alert" size="1rem" color={COLORS.red60} />
-                  <StyledText
-                    desktopStyle="captionSemiBold"
-                    color={COLORS.red60}
-                  >
-                    {data.t('step_error')}
-                  </StyledText>
-                </div>
-                <StyledText desktopStyle="bodyDefaultRegular">
-                  {error.detail}
-                </StyledText>
-              </div>
-            ))}
-            <div className={styles.annotated_steps_final_command}>
-              <StyledText desktopStyle="bodyDefaultRegular">
-                {data.t('unable_to_show_steps_past_errors')}
-              </StyledText>
-            </div>
-          </div>
-        )}
-      </div>
-    </div>
   )
 }

--- a/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/index.tsx
@@ -298,7 +298,6 @@ export function AnnotatedSteps(props: AnnotatedStepsProps): JSX.Element {
               setListWidth(size.width)
             }
           }}
-          style={{ height: '100%', width: '100%' }}
         />
       </div>
     </>

--- a/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/index.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { List, useDynamicRowHeight, useListRef } from 'react-window'
 
 import {
   COLORS,
@@ -14,9 +15,13 @@ import styles from './annotatedsteps.module.css'
 import { IndividualCommand } from './IndividualCommand'
 
 import type { Dispatch, SetStateAction } from 'react'
+import type { RowComponentProps } from 'react-window'
 import type {
   CompletedProtocolAnalysis,
+  LabwareDefinition,
+  ProtocolAnalysisError,
   ProtocolAnalysisOutput,
+  RunTimeCommand,
 } from '@opentrons/shared-data'
 import type { GroupedCommands } from '/app/redux/protocol-storage'
 
@@ -26,7 +31,45 @@ interface AnnotatedStepsProps {
   currentCommandIndex?: number
   setSelectedCommand?: Dispatch<SetStateAction<string | null>>
   handlePause?: () => void
+  setIsAtBottom?: Dispatch<SetStateAction<boolean>>
 }
+
+type GroupNode = Extract<GroupedCommands[number], { annotationIndex: number }>
+
+interface GroupRow {
+  type: 'group'
+  group: GroupNode
+  annotationType: string
+  commandStartNumber: number
+}
+
+interface CommandRow {
+  type: 'command'
+  command: RunTimeCommand
+  isHighlighted: boolean
+  fromGroup: boolean
+  commandNumber: number
+}
+
+interface ErrorRow {
+  type: 'errors'
+  errors: ProtocolAnalysisError[]
+}
+
+type AnnotatedStepsRow = GroupRow | CommandRow | ErrorRow
+
+interface ItemData {
+  rows: AnnotatedStepsRow[]
+  analysis: CompletedProtocolAnalysis | ProtocolAnalysisOutput
+  allRunDefs: LabwareDefinition[]
+  setSelectedCommand?: Dispatch<SetStateAction<string | null>>
+  handlePause?: () => void
+  scrollTargetId: string | null
+  onShowErrorDetails: () => void
+  t: (key: string) => string
+}
+
+const DEFAULT_ROW_HEIGHT_PX = 72
 
 export function AnnotatedSteps(props: AnnotatedStepsProps): JSX.Element {
   const {
@@ -35,6 +78,7 @@ export function AnnotatedSteps(props: AnnotatedStepsProps): JSX.Element {
     groupedCommands,
     setSelectedCommand,
     handlePause,
+    setIsAtBottom,
   } = props
   const { t } = useTranslation('protocol_visualization')
   const [showErrorDetailsModal, setShowErrorDetailsModal] =
@@ -49,26 +93,41 @@ export function AnnotatedSteps(props: AnnotatedStepsProps): JSX.Element {
     [isValidRobotSideAnalysis]
   )
   const annotations = analysis?.commandAnnotations ?? []
-
-  const groupedCommandsHighlightedInfo = groupedCommands?.map(node => {
-    if ('annotationIndex' in node) {
-      return {
-        ...node,
-        isHighlighted: node.subCommands.some(subNode => subNode.isHighlighted),
-        subCommands: node.subCommands.map(subNode => ({
-          ...subNode,
-          isHighlighted:
-            currentCommandIndex === analysis.commands.indexOf(subNode.command),
-        })),
-      }
-    } else {
-      return {
-        ...node,
-        isHighlighted:
-          currentCommandIndex === analysis.commands.indexOf(node.command),
-      }
-    }
-  })
+  const annotationNames = useMemo(
+    () => annotations.map(annotation => annotation?.machineReadableName ?? ''),
+    [annotations]
+  )
+  const commandIndexById = useMemo(
+    () =>
+      new Map(analysis.commands.map((command, index) => [command.id, index])),
+    [analysis.commands]
+  )
+  const groupedCommandsHighlightedInfo = useMemo(
+    () =>
+      groupedCommands?.map(node => {
+        if ('annotationIndex' in node) {
+          return {
+            ...node,
+            isHighlighted: node.subCommands.some(
+              subNode => subNode.isHighlighted
+            ),
+            subCommands: node.subCommands.map(subNode => ({
+              ...subNode,
+              isHighlighted:
+                currentCommandIndex ===
+                commandIndexById.get(subNode.command.id),
+            })),
+          }
+        } else {
+          return {
+            ...node,
+            isHighlighted:
+              currentCommandIndex === commandIndexById.get(node.command.id),
+          }
+        }
+      }),
+    [groupedCommands, currentCommandIndex, commandIndexById]
+  )
 
   useEffect(() => {
     if (groupedCommands != null) {
@@ -77,21 +136,149 @@ export function AnnotatedSteps(props: AnnotatedStepsProps): JSX.Element {
       )
 
       const targetNode = flatCommands.find(
-        node => analysis.commands.indexOf(node.command) === currentCommandIndex
+        node => commandIndexById.get(node.command.id) === currentCommandIndex
       )
 
       if (targetNode?.command.id && scrollTargetId !== targetNode.command.id) {
         setScrollTargetId(targetNode.command.id)
       }
     }
-  }, [analysis, groupedCommands, currentCommandIndex, scrollTargetId])
+  }, [groupedCommands, currentCommandIndex, scrollTargetId, commandIndexById])
 
-  let commandNumber = 0
+  const filteredCommands = useMemo(
+    () =>
+      analysis.commands.filter(
+        command =>
+          !command.commandType.includes('load') &&
+          command.commandType !== 'home'
+      ),
+    [analysis.commands]
+  )
 
-  // temporarily filter out loadCommands and home commands for the PV MVP
-  const filteredCommands = analysis.commands.filter(
-    command =>
-      !command.commandType.includes('load') && command.commandType !== 'home'
+  const { rows, rowIndexByCommandId } = useMemo(() => {
+    const nextRows: AnnotatedStepsRow[] = []
+    const nextRowIndexByCommandId = new Map<string, number>()
+    let commandNumber = 0
+
+    if (
+      groupedCommandsHighlightedInfo != null &&
+      groupedCommandsHighlightedInfo.length > 0
+    ) {
+      groupedCommandsHighlightedInfo.forEach((group, index) => {
+        const nextIndex = groupedCommandsHighlightedInfo[index + 1]
+        const nextIsGrouped =
+          nextIndex != null && 'annotationIndex' in nextIndex
+
+        if ('annotationIndex' in group) {
+          const subCommandStartNumber = commandNumber + 1
+          commandNumber += group.subCommands.length
+
+          const rowIndex = nextRows.length
+          nextRows.push({
+            type: 'group',
+            group,
+            annotationType: annotationNames[group.annotationIndex] ?? '',
+            commandStartNumber: subCommandStartNumber,
+          })
+          group.subCommands.forEach(subCommand => {
+            nextRowIndexByCommandId.set(subCommand.command.id, rowIndex)
+          })
+        } else {
+          const currentCommandNumber = ++commandNumber
+          const rowIndex = nextRows.length
+          nextRows.push({
+            type: 'command',
+            command: group.command,
+            isHighlighted: group.isHighlighted,
+            fromGroup: nextIsGrouped,
+            commandNumber: currentCommandNumber,
+          })
+          nextRowIndexByCommandId.set(group.command.id, rowIndex)
+        }
+      })
+    } else {
+      filteredCommands.forEach(command => {
+        const currentCommandNumber = ++commandNumber
+        const rowIndex = nextRows.length
+        nextRows.push({
+          type: 'command',
+          command,
+          isHighlighted:
+            currentCommandIndex != null &&
+            filteredCommands[currentCommandIndex]?.id === command.id,
+          fromGroup: false,
+          commandNumber: currentCommandNumber,
+        })
+        nextRowIndexByCommandId.set(command.id, rowIndex)
+      })
+    }
+
+    if (analysis.errors.length > 0) {
+      nextRows.push({
+        type: 'errors',
+        errors: analysis.errors,
+      })
+    }
+
+    return {
+      rows: nextRows,
+      rowIndexByCommandId: nextRowIndexByCommandId,
+    }
+  }, [
+    groupedCommandsHighlightedInfo,
+    filteredCommands,
+    currentCommandIndex,
+    analysis.errors,
+    annotationNames,
+  ])
+
+  const listRef = useListRef()
+  const [listWidth, setListWidth] = useState(0)
+  const dynamicRowHeight = useDynamicRowHeight({
+    defaultRowHeight: DEFAULT_ROW_HEIGHT_PX,
+    key: `${listWidth}-${rows.length}`,
+  })
+
+  useEffect(() => {
+    if (scrollTargetId == null) return
+    const rowIndex = rowIndexByCommandId.get(scrollTargetId)
+    if (rowIndex == null) return
+    listRef.current?.scrollToRow({ index: rowIndex, align: 'smart' })
+  }, [scrollTargetId, rowIndexByCommandId])
+
+  const handleRowsRendered = useCallback(
+    ({ stopIndex }: { startIndex: number; stopIndex: number }) => {
+      if (rows.length === 0) {
+        setIsAtBottom?.(true)
+      } else {
+        setIsAtBottom?.(stopIndex >= rows.length - 1)
+      }
+    },
+    [rows.length, setIsAtBottom]
+  )
+
+  const itemData = useMemo<ItemData>(
+    () => ({
+      rows,
+      analysis,
+      allRunDefs,
+      setSelectedCommand,
+      handlePause,
+      scrollTargetId,
+      onShowErrorDetails: () => {
+        setShowErrorDetailsModal(true)
+      },
+      t,
+    }),
+    [
+      rows,
+      analysis,
+      allRunDefs,
+      setSelectedCommand,
+      handlePause,
+      scrollTargetId,
+      t,
+    ]
   )
 
   return (
@@ -105,103 +292,91 @@ export function AnnotatedSteps(props: AnnotatedStepsProps): JSX.Element {
         />
       ) : null}
       <div className={styles.annotated_steps_container}>
-        <div className={styles.annotated_steps_wrap}>
-          {groupedCommandsHighlightedInfo != null &&
-          groupedCommandsHighlightedInfo.length > 0
-            ? groupedCommandsHighlightedInfo.map((group, index) => {
-                const nextIndex = groupedCommandsHighlightedInfo[index + 1]
-                const nextIsGrouped =
-                  nextIndex != null && 'annotationIndex' in nextIndex
-
-                if ('annotationIndex' in group) {
-                  const subCommandStartNumber = commandNumber + 1 // Starting number for this group
-                  commandNumber += group.subCommands.length
-
-                  return (
-                    <AnnotatedGroup
-                      key={`group_${group.annotationIndex}_${index}`}
-                      scrollTargetId={scrollTargetId}
-                      analysis={analysis}
-                      annotationType={
-                        annotations[group.annotationIndex]?.machineReadableName
-                      }
-                      subCommands={group.subCommands}
-                      commandStartNumber={subCommandStartNumber}
-                      allRunDefs={allRunDefs}
-                      setSelectedCommand={setSelectedCommand}
-                      handlePause={handlePause}
-                    />
-                  )
-                } else {
-                  const currentCommandNumber = ++commandNumber
-
-                  return (
-                    <IndividualCommand
-                      scrollTargetId={scrollTargetId}
-                      fromGroup={nextIsGrouped}
-                      key={group.command.id}
-                      command={group.command}
-                      isHighlighted={group.isHighlighted}
-                      analysis={analysis}
-                      allRunDefs={allRunDefs}
-                      setSelectedCommand={setSelectedCommand}
-                      commandNumber={currentCommandNumber}
-                    />
-                  )
-                }
-              })
-            : filteredCommands.map(command => {
-                const currentCommandNumber = ++commandNumber
-                return (
-                  <IndividualCommand
-                    scrollTargetId={scrollTargetId}
-                    fromGroup={false}
-                    key={`individual_${command.id}`}
-                    command={command}
-                    commandNumber={currentCommandNumber}
-                    isHighlighted={
-                      currentCommandIndex != null &&
-                      filteredCommands[currentCommandIndex]?.id === command.id
-                    }
-                    analysis={analysis}
-                    allRunDefs={allRunDefs}
-                    setSelectedCommand={setSelectedCommand}
-                  />
-                )
-              })}
-          {analysis?.errors.length > 0 ? (
-            <div className={styles.annotated_steps_error_wrapper}>
-              {analysis?.errors.map(error => (
-                <div
-                  className={styles.annotated_steps_error_container}
-                  key={error.id}
-                  onClick={() => {
-                    setShowErrorDetailsModal(true)
-                  }}
-                >
-                  <div className={styles.annotated_steps_header}>
-                    <Icon name="ot-alert" size="1rem" color={COLORS.red60} />
-                    <StyledText
-                      desktopStyle="captionSemiBold"
-                      color={COLORS.red60}
-                    >
-                      {t('step_error')}
-                    </StyledText>
-                  </div>
-                  <StyledText desktopStyle="bodyDefaultRegular">
-                    {error.detail}
-                  </StyledText>
-                </div>
-              ))}
-              <div className={styles.annotated_steps_final_command}>
-                <StyledText desktopStyle="bodyDefaultRegular">
-                  {t('unable_to_show_steps_past_errors')}
-                </StyledText>
-              </div>
-            </div>
-          ) : null}
-        </div>
+        <List
+          listRef={listRef}
+          className={styles.annotated_steps_list}
+          rowCount={rows.length}
+          rowHeight={dynamicRowHeight}
+          rowComponent={AnnotatedStepsRowItem}
+          rowProps={itemData}
+          onRowsRendered={handleRowsRendered}
+          onResize={(size, prevSize) => {
+            if (size.width !== prevSize.width) {
+              setListWidth(size.width)
+            }
+          }}
+          style={{ height: '100%', width: '100%' }}
+        />
       </div>
     </>
+  )
+}
+
+function AnnotatedStepsRowItem({
+  index,
+  style,
+  ariaAttributes,
+  ...data
+}: RowComponentProps<ItemData>): JSX.Element {
+  const row = data.rows[index]
+
+  return (
+    <div style={style} {...ariaAttributes}>
+      <div className={styles.annotated_steps_row}>
+        {row.type === 'group' ? (
+          <AnnotatedGroup
+            scrollTargetId={data.scrollTargetId}
+            analysis={data.analysis}
+            annotationType={row.annotationType}
+            subCommands={row.group.subCommands}
+            commandStartNumber={row.commandStartNumber}
+            allRunDefs={data.allRunDefs}
+            setSelectedCommand={data.setSelectedCommand}
+            handlePause={data.handlePause}
+          />
+        ) : row.type === 'command' ? (
+          <IndividualCommand
+            scrollTargetId={data.scrollTargetId}
+            fromGroup={row.fromGroup}
+            command={row.command}
+            isHighlighted={row.isHighlighted}
+            analysis={data.analysis}
+            allRunDefs={data.allRunDefs}
+            setSelectedCommand={data.setSelectedCommand}
+            commandNumber={row.commandNumber}
+          />
+        ) : (
+          <div className={styles.annotated_steps_error_wrapper}>
+            {row.errors.map(error => (
+              <div
+                className={styles.annotated_steps_error_container}
+                key={error.id}
+                onClick={() => {
+                  data.onShowErrorDetails()
+                }}
+              >
+                <div className={styles.annotated_steps_header}>
+                  <Icon name="ot-alert" size="1rem" color={COLORS.red60} />
+                  <StyledText
+                    desktopStyle="captionSemiBold"
+                    color={COLORS.red60}
+                  >
+                    {data.t('step_error')}
+                  </StyledText>
+                </div>
+                <StyledText desktopStyle="bodyDefaultRegular">
+                  {error.detail}
+                </StyledText>
+              </div>
+            ))}
+            <div className={styles.annotated_steps_final_command}>
+              <StyledText desktopStyle="bodyDefaultRegular">
+                {data.t('unable_to_show_steps_past_errors')}
+              </StyledText>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
   )
 }

--- a/app/src/organisms/Desktop/ProtocolDetails/__tests__/AnnotatedGroup.test.tsx
+++ b/app/src/organisms/Desktop/ProtocolDetails/__tests__/AnnotatedGroup.test.tsx
@@ -1,0 +1,73 @@
+import { screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { renderWithProviders } from '/app/__testing-utils__'
+
+import { AnnotatedGroup } from '../AnnotatedSteps/AnnotatedGroup'
+import { IndividualCommand } from '../AnnotatedSteps/IndividualCommand'
+
+import type { ComponentProps } from 'react'
+import type { PipettingRunTimeCommand } from '@opentrons/shared-data'
+
+vi.mock('../AnnotatedSteps/IndividualCommand')
+
+const mockSubCommand: PipettingRunTimeCommand = {
+  id: 'mockCommandId',
+  status: 'succeeded',
+  createdAt: '2026-01-01T00:00:00Z',
+  startedAt: '2026-01-01T00:00:01Z',
+  completedAt: '2026-01-01T00:00:02Z',
+  commandType: 'configureForVolume',
+  params: {
+    pipetteId: 'mockPipetteId',
+    volume: 10,
+  },
+}
+
+const mockHandlePause = vi.fn()
+
+const render = (props: ComponentProps<typeof AnnotatedGroup>) => {
+  return renderWithProviders(<AnnotatedGroup {...props} />)
+}
+
+describe('AnnotatedGroup', () => {
+  let props: ComponentProps<typeof AnnotatedGroup>
+
+  beforeEach(() => {
+    props = {
+      scrollTargetId: 'mockTargetId',
+      annotationType: 'mockAnnotationType',
+      subCommands: [],
+      analysis: {} as any,
+      allRunDefs: [] as any,
+      commandStartNumber: 1,
+      setSelectedCommand: vi.fn(),
+      handlePause: mockHandlePause,
+    }
+    vi.mocked(IndividualCommand).mockReturnValue(
+      <div>mockIndividualCommand</div>
+    )
+  })
+
+  it('should render text and icon', () => {
+    render(props)
+    screen.getByText('mockAnnotationType')
+    screen.getByTestId('chevron-down')
+    expect(screen.queryByText('mockIndividualCommand')).toBeNull()
+  })
+
+  it('should render individualcommand component', () => {
+    props = {
+      ...props,
+      subCommands: [
+        {
+          command: mockSubCommand,
+          isHighlighted: true,
+        },
+      ],
+    }
+    render(props)
+    screen.getByTestId('chevron-up')
+    screen.getByText('mockIndividualCommand')
+  })
+})

--- a/app/src/organisms/Desktop/ProtocolDetails/__tests__/AnnotatedStepsRowItem.test.tsx
+++ b/app/src/organisms/Desktop/ProtocolDetails/__tests__/AnnotatedStepsRowItem.test.tsx
@@ -1,0 +1,105 @@
+import { fireEvent, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { renderWithProviders } from '/app/__testing-utils__'
+
+import { AnnotatedStepsRowItem } from '../AnnotatedSteps/AnnotatedStepsRowItem'
+
+import type { RowComponentProps } from 'react-window'
+import type { ItemData } from '../AnnotatedSteps'
+
+vi.mock('../AnnotatedSteps/AnnotatedGroup', () => ({
+  AnnotatedGroup: () => <div>mock AnnotatedGroup</div>,
+}))
+
+vi.mock('../AnnotatedSteps/IndividualCommand', () => ({
+  IndividualCommand: () => <div>mock IndividualCommand</div>,
+}))
+
+describe('AnnotatedStepsRowItem', () => {
+  let props: RowComponentProps<ItemData>
+
+  const baseItemData: ItemData = {
+    rows: [],
+    analysis: { commands: [], errors: [], commandAnnotations: [] } as any,
+    allRunDefs: [],
+    scrollTargetId: null,
+    onShowErrorDetails: vi.fn(),
+    t: (key: string) => key,
+  }
+
+  const buildProps = (
+    data: ItemData,
+    index = 0
+  ): RowComponentProps<ItemData> => ({
+    index,
+    style: { height: 10 },
+    ariaAttributes: { role: 'listitem', 'aria-posinset': index + 1, 'aria-setsize': data.rows.length },
+    ...data,
+  })
+
+  beforeEach(() => {
+    props = buildProps(baseItemData)
+  })
+
+  it('renders a group row', () => {
+    props = buildProps({
+      ...baseItemData,
+      rows: [
+        {
+          type: 'group',
+          group: {
+            annotationIndex: 0,
+            isHighlighted: false,
+            subCommands: [],
+          } as any,
+          annotationType: 'mock annotation',
+          commandStartNumber: 1,
+        },
+      ],
+    })
+
+    renderWithProviders(<AnnotatedStepsRowItem {...props} />)
+    screen.getByText('mock AnnotatedGroup')
+  })
+
+  it('renders a command row', () => {
+    props = buildProps({
+      ...baseItemData,
+      rows: [
+        {
+          type: 'command',
+          command: { id: 'command-id' } as any,
+          isHighlighted: false,
+          fromGroup: false,
+          commandNumber: 1,
+        },
+      ],
+    })
+
+    renderWithProviders(<AnnotatedStepsRowItem {...props} />)
+    screen.getByText('mock IndividualCommand')
+  })
+
+  it('renders error details and handles click', () => {
+    const handleShowErrorDetails = vi.fn()
+    props = buildProps({
+      ...baseItemData,
+      onShowErrorDetails: handleShowErrorDetails,
+      rows: [
+        {
+          type: 'errors',
+          errors: [{ id: 'error-id', detail: 'error detail' }] as any,
+        },
+      ],
+    })
+
+    renderWithProviders(<AnnotatedStepsRowItem {...props} />)
+    screen.getByText('step_error')
+    screen.getByText('error detail')
+    screen.getByText('unable_to_show_steps_past_errors')
+
+    fireEvent.click(screen.getByText('error detail'))
+    expect(handleShowErrorDetails).toHaveBeenCalled()
+  })
+})

--- a/app/src/organisms/Desktop/ProtocolDetails/__tests__/AnnotatedStepsRowItem.test.tsx
+++ b/app/src/organisms/Desktop/ProtocolDetails/__tests__/AnnotatedStepsRowItem.test.tsx
@@ -34,7 +34,11 @@ describe('AnnotatedStepsRowItem', () => {
   ): RowComponentProps<ItemData> => ({
     index,
     style: { height: 10 },
-    ariaAttributes: { role: 'listitem', 'aria-posinset': index + 1, 'aria-setsize': data.rows.length },
+    ariaAttributes: {
+      role: 'listitem',
+      'aria-posinset': index + 1,
+      'aria-setsize': data.rows.length,
+    },
     ...data,
   })
 

--- a/app/src/organisms/Desktop/ProtocolVisualization/CommandSteps/commandsteps.module.css
+++ b/app/src/organisms/Desktop/ProtocolVisualization/CommandSteps/commandsteps.module.css
@@ -40,12 +40,7 @@
   height: 100%;
   min-height: 0;
   flex: 1;
-  overflow-y: auto;
-}
-
-/* this is for scrolling detection  */
-.bottom_sentinel {
-  height: 1px;
+  overflow: hidden;
 }
 
 .at_bottom {

--- a/app/src/organisms/Desktop/ProtocolVisualization/CommandSteps/commandsteps.module.css
+++ b/app/src/organisms/Desktop/ProtocolVisualization/CommandSteps/commandsteps.module.css
@@ -37,10 +37,10 @@
 }
 
 .command_step_groups {
+  overflow: hidden;
   height: 100%;
   min-height: 0;
   flex: 1;
-  overflow: hidden;
 }
 
 .at_bottom {

--- a/app/src/organisms/Desktop/ProtocolVisualization/CommandSteps/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/CommandSteps/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { COLORS, StyledText } from '@opentrons/components'
@@ -30,26 +30,6 @@ export function CommandSteps(props: CommandStepsProps): JSX.Element {
   } = props
   const { t } = useTranslation('protocol_visualization')
   const [isAtBottom, setIsAtBottom] = useState<boolean>(false)
-  const scrollRef = useRef<HTMLDivElement>(null)
-  const bottomRef = useRef<HTMLDivElement>(null)
-
-  useEffect(() => {
-    const root = scrollRef.current
-    const target = bottomRef.current
-    if (root == null || target == null) return
-
-    const io = new IntersectionObserver(
-      ([entry]) => {
-        setIsAtBottom(entry.isIntersecting)
-      },
-      { root, threshold: 1 }
-    )
-
-    io.observe(target)
-    return () => {
-      io.disconnect()
-    }
-  }, [])
 
   return (
     <div className={styles.detail_container}>
@@ -63,7 +43,6 @@ export function CommandSteps(props: CommandStepsProps): JSX.Element {
           </StyledText>
         </div>
         <div
-          ref={scrollRef}
           className={`${styles.command_step_groups} ${isAtBottom ? styles.at_bottom : ''}`}
         >
           <AnnotatedSteps
@@ -72,8 +51,8 @@ export function CommandSteps(props: CommandStepsProps): JSX.Element {
             groupedCommands={groupedCommands}
             setSelectedCommand={setSelectedCommand}
             handlePause={handlePause}
+            setIsAtBottom={setIsAtBottom}
           />
-          <div ref={bottomRef} className={styles.bottom_sentinel} />
         </div>
       </div>
     </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4144,6 +4144,7 @@
     react-select "5.4.0"
     react-simple-keyboard "^3.7.0"
     react-viewport-list "6.3.0"
+    react-window "2.2.4"
     redux "5.0.1"
     redux-observable "1.1.0"
     redux-thunk "3.1.0"
@@ -17764,6 +17765,11 @@ react-viewport-list@6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/react-viewport-list/-/react-viewport-list-6.3.0.tgz#dc73210d590c2a10f49be8902d86bb5e04a4b47e"
   integrity sha512-IV7/yeqpurCa2FytCnUWyY664kbDxg5EgQQJHQhI6X2zUZXEq8BlQLfDoPRF2MA8YsVihsC7y3iEf2wGt+Lluw==
+
+react-window@2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/react-window/-/react-window-2.2.4.tgz#add661da4e0ebc4c1129c41a92d1891d44da565f"
+  integrity sha512-FiZsQHvt2qbnTz6cN+/FXvX62v2xukQ+AajUivkm/Ivdp9rnU3bp0B1eDcCNpQXNaDBdqkEVGNYHlvIUGU9yBw==
 
 react@18.2.0:
   version "18.2.0"


### PR DESCRIPTION
# Overview
add virtualization to load a big protocol. for virtualization, using `react-window`.
decided to use `react-window` because the package we use currently is `react-viewport-list` is old and it hasn't been maintained more than 3 years.

https://opentrons.slack.com/archives/C09AFFN9N83/p1767913994653289

this pr supports vertical and horizontal resize.

the loading part will be implemented by a following pr.

close AUTH-2642


## Test Plan and Hands on Testing
- download the protocol that is attached to the ticket
- select that protocol and click visualization button
check that the loading process doesn't take so much time. (without virtualization, it took around 20 sec)

- scrolling up/down step container
commands are rendered within a second (the loading skeleton will be implemented later)

- resize the left col
commands are rendered within a second  (the space issue between commands will be solved later)

## Changelog

List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.

## Review requests

- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.

## Risk assessment
low
