### PR TITLE
feat(protocol-designer,-step-generation): handle lids/adapters in stacker fill steps

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/FlexStackerTools/RefillSettings.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/FlexStackerTools/RefillSettings.tsx
@@ -9,6 +9,7 @@ import {
   StyledText,
 } from '@opentrons/components'
 import { getIsTiprack } from '@opentrons/shared-data'
+import { BOTTOM_UP_STORED_LABWARE_URI_KEYS } from '@opentrons/step-generation'
 
 import { InputStepFormField } from '/protocol-designer/components/molecules'
 import {
@@ -21,7 +22,10 @@ import styles from './flexstackertools.module.css'
 import { MessageField } from './MessageField'
 import { StackerContentItem } from './StackerContentItem'
 
-import type { FlexStackerModuleState } from '@opentrons/step-generation'
+import type {
+  FlexStackerModuleState,
+  LabwareEntity,
+} from '@opentrons/step-generation'
 import type { FormData } from '/protocol-designer/form-types'
 import type { FieldPropsByName } from '../../types'
 
@@ -40,53 +44,66 @@ export function RefillSettings(props: RefillSettingsProps): JSX.Element {
   const savedStepForms = useSelector(getSavedStepForms)
   const initialLabwareIds =
     (savedStepForms[formData.id]?.fillLabwareIds as string[]) ?? []
-  const oldFillQuantity = initialLabwareIds?.length ?? 0
+  const [storedAdapterEntity, storedPrimaryEntity, storedLidEntity] =
+    BOTTOM_UP_STORED_LABWARE_URI_KEYS.map(lwKey =>
+      Object.values(labwareEntities).find(({ labwareDefURI }) => {
+        return labwareDefURI === storedLabwareDetails?.[lwKey]
+      })
+    )
+  const nonNullEntities = [
+    storedAdapterEntity,
+    storedPrimaryEntity,
+    storedLidEntity,
+  ].filter(entity => entity != null) as LabwareEntity[]
+  const numEntitiesInGroup = nonNullEntities.length
+  // flooring to be safe in case the lengath does not evenly divide (should not fire)
+  if (initialLabwareIds.length % numEntitiesInGroup !== 0) {
+    console.warn(
+      'initialLabwareIds.length does not evenly divide by numEntitiesInGroup'
+    )
+  }
+  const oldGroupQuantity = Math.floor(
+    initialLabwareIds.length / numEntitiesInGroup
+  )
+
   const [fillQuantityLocalState, setFillQuantityState] = useState<
     string | null
     // initialize if saved step form exists
-  >(oldFillQuantity > 0 ? String(initialLabwareIds.length) : null)
-  const storedEntity = Object.values(labwareEntities).find(
-    ({ labwareDefURI }) => {
-      return labwareDefURI === storedLabwareDetails?.primaryLabwareURI
-    }
-  )
+  >(oldGroupQuantity > 0 ? String(oldGroupQuantity) : null)
 
-  const storedEntityName = storedEntity?.def.metadata.displayName
-  const isTiprack = storedEntity != null && getIsTiprack(storedEntity.def)
+  const storedEntityName = storedPrimaryEntity?.def.metadata.displayName
+  const isPrimaryTiprack =
+    storedPrimaryEntity != null && getIsTiprack(storedPrimaryEntity.def)
   // TODO: figure out a way to not need this use Effect. its hard because
   // you can't rely on generating the uuid in the hydrated form
   useEffect(() => {
-    const quantity = Number(fillQuantityLocalState) ?? 1
-    const numberOfLabwareInHopper = labwareInHopper?.length ?? 0
-    const difference = quantity - oldFillQuantity
-    const valueTooHigh = quantity > maxPoolCount - numberOfLabwareInHopper
-    const newFill = Array.from(
-      { length: quantity },
-      () => `${uuid()}:${storedEntity?.labwareDefURI}`
-    )
-    propsForFields.fillLabwareIds.updateValue(newFill)
+    const newGroupQuantity = Number(fillQuantityLocalState) ?? 1
+    const numberOfGroupsInHopper = labwareInHopper?.length ?? 0
+    const difference = newGroupQuantity - oldGroupQuantity
+    const valueTooHigh =
+      newGroupQuantity > maxPoolCount - numberOfGroupsInHopper
     // Form errors do not have acccess to module state, so this logic is used
     // to clear out the fillLabwareIds value if the quantity entered is too high
     // and raise an error.
     if (valueTooHigh) {
       propsForFields.fillLabwareIds.updateValue([])
+    } else {
+      if (difference > 0) {
+        const additionalIds = Array.from({ length: difference }, () =>
+          nonNullEntities.map(entity => `${uuid()}:${entity.labwareDefURI}`)
+        ).flat()
+        // ensure we preserve the existing labware IDs, even if a user extensively modifies the quantity up/down
+        propsForFields.fillLabwareIds.updateValue([
+          ...initialLabwareIds,
+          ...additionalIds,
+        ])
+      } else if (difference < 0) {
+        propsForFields.fillLabwareIds.updateValue(
+          initialLabwareIds.slice(0, newGroupQuantity * numEntitiesInGroup)
+        )
+      }
     }
-    if (difference > 0) {
-      const additionalIds = Array.from(
-        { length: difference },
-        () => `${uuid()}:${storedEntity?.labwareDefURI}`
-      )
-      // ensure we preserve the existing labware IDs, even if a user extensively modifies the quantity up/down
-      propsForFields.fillLabwareIds.updateValue([
-        ...initialLabwareIds,
-        ...additionalIds,
-      ])
-    } else if (difference < 0) {
-      propsForFields.fillLabwareIds.updateValue(
-        initialLabwareIds.slice(0, quantity)
-      )
-    }
-  }, [fillQuantityLocalState, storedEntity?.labwareDefURI])
+  }, [fillQuantityLocalState, storedPrimaryEntity?.labwareDefURI])
 
   return (
     <div className={styles.refill_settings_container}>
@@ -99,7 +116,7 @@ export function RefillSettings(props: RefillSettingsProps): JSX.Element {
             <StackerContentItem
               primaryLabwareName={storedEntityName}
               hasLid={storedLabwareDetails.lidLabwareURI != null}
-              isTiprack={isTiprack}
+              isTiprack={isPrimaryTiprack}
             />
           ) : null}
         </div>

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/index.tsx
@@ -208,8 +208,8 @@ function StepFormManager(props: StepFormManagerProps): JSX.Element | null {
           displayModule={
             formData.moduleId != null
               ? getModuleDisplayName(
-                invariantContext.moduleEntities[formData.moduleId].model
-              )
+                  invariantContext.moduleEntities[formData.moduleId].model
+                )
               : ''
           }
           handleAddPauseClick={handleAddPauseClick}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/index.tsx
@@ -10,6 +10,7 @@ import {
   CLOSE_UNSAVED_STEP_FORM,
   ConfirmDeleteModal,
 } from '/protocol-designer/components/organisms'
+import { FLEX_STACKER_FILL } from '/protocol-designer/constants'
 import { getEnableConcurrentModuleActions } from '/protocol-designer/feature-flags/selectors'
 import { selectors as labwareDefSelectors } from '/protocol-designer/labware-defs'
 import { deleteContainer } from '/protocol-designer/labware-ingred/actions'
@@ -117,20 +118,32 @@ function StepFormManager(props: StepFormManagerProps): JSX.Element | null {
       saveStepForm()
       if (
         hydratedForm.stepType === 'flexStacker' &&
-        hydratedForm.flexStackerFormType === 'fill'
+        hydratedForm.flexStackerFormType === FLEX_STACKER_FILL
       ) {
-        const initialLabwareIds =
-          (savedStepForm?.fillLabwareIds as string[]) ?? null
-        const oldFillQuantity = initialLabwareIds?.length ?? 0
+        // logic for editing a fill step form
+        if (savedStepForm != null) {
+          const initialLabwareIds =
+            (savedStepForm.fillLabwareIds as string[] | null) ?? []
+          const oldFillQuantity = initialLabwareIds.length
 
-        // delete extraneous labware if fill quantity is decreased
-        if (oldFillQuantity > hydratedForm.fillLabwareIds.length) {
-          const extraneousLabwareIds = initialLabwareIds.slice(
-            hydratedForm.fillLabwareIds.length,
-            oldFillQuantity
-          )
-          deleteLabwares(extraneousLabwareIds)
+          // if new fill quantity is less than the preivously saved quantity, delete the extraneous labware
+          if (oldFillQuantity > hydratedForm.fillLabwareIds.length) {
+            const extraneousLabwareIds = initialLabwareIds.slice(
+              hydratedForm.fillLabwareIds.length,
+              oldFillQuantity
+            )
+            deleteLabwares(extraneousLabwareIds)
+          }
+          // if new fill quantity is greater than the preivously saved quantity, create the new labware
+          else if (oldFillQuantity < hydratedForm.fillLabwareIds.length) {
+            const newLabwareIds = hydratedForm.fillLabwareIds.slice(
+              oldFillQuantity,
+              hydratedForm.fillLabwareIds.length
+            )
+            createdLabwareForQueue(hydratedForm.moduleId, newLabwareIds)
+          }
         } else {
+          // if no saved step form exists, create all the new labware
           createdLabwareForQueue(
             hydratedForm.moduleId,
             hydratedForm.fillLabwareIds
@@ -195,8 +208,8 @@ function StepFormManager(props: StepFormManagerProps): JSX.Element | null {
           displayModule={
             formData.moduleId != null
               ? getModuleDisplayName(
-                  invariantContext.moduleEntities[formData.moduleId].model
-                )
+                invariantContext.moduleEntities[formData.moduleId].model
+              )
               : ''
           }
           handleAddPauseClick={handleAddPauseClick}

--- a/step-generation/src/constants.ts
+++ b/step-generation/src/constants.ts
@@ -17,6 +17,7 @@ import type {
   ModuleModel,
   ModuleType,
   OT2AddressableAreaName,
+  StackerStoredLabwareDefinitionURIs,
 } from '@opentrons/shared-data'
 import type {
   AbsorbanceReaderState,
@@ -138,6 +139,9 @@ export type HopperLocationMapKey = keyof typeof FAKE_HOPPER_LOCATION_MAP
 export const BOTTOM_UP_LABWARE_POOL_KEYS: Array<
   keyof FlexStackerStoredLabwareGroup
 > = ['adapterLabwareId', 'primaryLabwareId', 'lidLabwareId']
+export const BOTTOM_UP_STORED_LABWARE_URI_KEYS: Array<
+  keyof StackerStoredLabwareDefinitionURIs
+> = ['adapterLabwareURI', 'primaryLabwareURI', 'lidLabwareURI']
 
 export const SLOT_LOCATIONS_TO_FAKE_HOPPER_LOCATIONS: Record<
   DeckSlotId,

--- a/step-generation/src/utils/misc.ts
+++ b/step-generation/src/utils/misc.ts
@@ -1429,10 +1429,13 @@ export const labwareMatchesLabwareInHopper = (
   invariantContext: InvariantContext,
   stackerState: FlexStackerModuleState | null
 ): boolean => {
-  const loadedLabware = stackerState?.storedLabwareDetails?.primaryLabwareURI
-  const labwareToBeStoredEntity = invariantContext.labwareEntities[labwareId]
-  const { labwareDefURI: labwareURIToBeStored } = labwareToBeStoredEntity ?? {}
-  return loadedLabware == null || loadedLabware === labwareURIToBeStored
+  const storedLabwareURIs = Object.values(
+    stackerState?.storedLabwareDetails ?? {}
+  ).reduce<string[]>((acc, val) => {
+    return val != null ? [...acc, val] : acc
+  }, [])
+  const labwareEntity = invariantContext.labwareEntities[labwareId]
+  return storedLabwareURIs.some(uri => labwareEntity?.labwareDefURI === uri)
 }
 
 export const getIsSpaceInHopper = (


### PR DESCRIPTION
# Overview

Provide support for filling a Flex stacker hopper that is configured with a lid and/or adapter in addition to primary labware. Previously introduced functionality (#20519) for creating and deleting labware appropriately when creating or editing the fill step is extended to lids and adapters

Closes EXEC-2230

## Test Plan and Hands on Testing

- create or import a stacker protocol ([example.py](https://github.com/user-attachments/files/24569434/flex_stacker_test.14.py)) in which the hopper is configured with a primary labware and lid
- create a stacker refill step
- enter a valid quantity and save
- verify that the fill step is properly created, and the stacker state is updated properly (you can see this by creating another stacker step and checking the quantity in the hopper)
- re-open the fill step and lower the quantity. verify that the previously created labwares are deleted (you can inspect the off-deck tab of the deck view after the step)
- re-open the fill step and raise the quantity. verify that additional labware are created to accommodate the increased quantity

## Changelog

- implement logic for handling lids and adapters in stacker refill step
- update step-generation util that checks that all labware fill elements match the hopper's configuration

## Review requests

See test plan. In addition, please smoke test error handling for attempting to store more labware groups than can be accommodated in the hopper (intro'd in #20513). I needed to massage the logic in after resolving merge conflicts, specifically in the `useEffect` callback of `RefillSettings.tsx`.

## Risk assessment

medium