### PR TITLE
fix(protocol-designer): only show labware stack when labware is on hopper

### DIFF
--- a/protocol-designer/src/components/organisms/AssignLiquidsModal/__tests__/AssignLiquidsModal.test.tsx
+++ b/protocol-designer/src/components/organisms/AssignLiquidsModal/__tests__/AssignLiquidsModal.test.tsx
@@ -2,6 +2,7 @@ import { screen } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { fixture96Plate } from '@opentrons/shared-data'
+import { HOPPER_STACKER_LOCATION } from '@opentrons/step-generation'
 
 import { renderWithProviders } from '/protocol-designer/__testing-utils__'
 import { i18n } from '/protocol-designer/assets/localization'
@@ -102,6 +103,7 @@ describe('AssignLiquidsModal', () => {
 
   it('loads the modal with selectable labware', () => {
     props.assignLiquidsModalData.labware.mockLabwareId.stack = [
+      HOPPER_STACKER_LOCATION,
       'mockLabwareId',
       'labware2',
     ]
@@ -112,5 +114,17 @@ describe('AssignLiquidsModal', () => {
     render(props)
 
     screen.getByText('mock LabwareStackToolbox')
+  })
+
+  it('does not load the labware toolbox if the labware is not on the hopper', () => {
+    props.assignLiquidsModalData.labware.mockLabwareId.stack = [
+      'mockLabwareId',
+      'labware2',
+    ]
+    render(props)
+
+    expect(
+      screen.queryByText('mock LabwareStackToolbox')
+    ).not.toBeInTheDocument()
   })
 })

--- a/protocol-designer/src/components/organisms/AssignLiquidsModal/index.tsx
+++ b/protocol-designer/src/components/organisms/AssignLiquidsModal/index.tsx
@@ -24,6 +24,7 @@ import {
 } from '@opentrons/components'
 import {
   getSlotInLocationStack,
+  HOPPER_STACKER_LOCATION,
   wellFillFromWellContents,
 } from '@opentrons/step-generation'
 
@@ -131,6 +132,8 @@ export function AssignLiquidsModal(
     ),
   }
 
+  const labwareIsOnHopper = labwareStack.includes(HOPPER_STACKER_LOCATION)
+
   return (
     <Flex
       height={`calc(100vh - ${NAV_BAR_HEIGHT_REM}rem)`}
@@ -139,7 +142,7 @@ export function AssignLiquidsModal(
       position={POSITION_RELATIVE}
     >
       <Flex width="100%" overflow={OVERFLOW_AUTO} padding={SPACING.spacing16}>
-        {labwareStack.length > 1 ? (
+        {labwareIsOnHopper && labwareStack.length > 1 ? (
           <LabwareStackToolboxContainer
             setShowLiquidLayoutOverlay={setShowLiquidLayoutOverlay}
             selectedLabwareIds={selectedLabwareIds}


### PR DESCRIPTION
# Overview

closes https://opentrons.atlassian.net/browse/EXEC-2234.
fix only show labware stack when is on hopper

## Test Plan and Hands on Testing

Uploading Screen Recording 2026-01-12 at 12.44.40 PM.mov…

## Risk assessment

low. bug fix
