### PR TITLE
feat(app): a few PV mixpanel analytics wiring up

### DIFF
--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderContent/RunHeaderSectionLower/index.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderContent/RunHeaderSectionLower/index.tsx
@@ -5,6 +5,10 @@ import { RUN_STATUS_IDLE } from '@opentrons/api-client'
 import { SecondaryButton } from '@opentrons/components'
 
 import { useToaster } from '/app/organisms/ToasterOven'
+import {
+  ANALYTICS_LAUNCH_PROTOCOL_VISUALIZATION,
+  useTrackEvent,
+} from '/app/redux/analytics'
 import { useFeatureFlag } from '/app/redux/config'
 import { useStoredProtocolAnalysis } from '/app/resources/analysis/hooks/useStoredProtocolAnalysis'
 import {
@@ -34,6 +38,7 @@ export function RunHeaderSectionLower({
   const { t } = useTranslation('run_details')
   const enableProtocolTimeline = useFeatureFlag('protocolTimeline')
   const navigate = useNavigate()
+  const trackEvent = useTrackEvent()
   const { startedAt, completedAt } = useRunTimestamps(runId)
   const startedAtTimestamp =
     startedAt != null ? formatTimestamp(startedAt) : EMPTY_TIMESTAMP
@@ -69,6 +74,10 @@ export function RunHeaderSectionLower({
     // need to encode URL to avoid spaces and slashes
     const encodedTimestamp = encodeURIComponent(createdAtTimestamp)
     const targetPath = `/devices/${robotName}/${runId}/${encodedTimestamp}/${protocolKey}/visualization`
+    trackEvent({
+      name: ANALYTICS_LAUNCH_PROTOCOL_VISUALIZATION,
+      properties: { sourceLocation: 'protocol run' },
+    })
     navigate(targetPath)
   }
 

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/__tests__/RunHeaderSectionLower.test.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/__tests__/RunHeaderSectionLower.test.tsx
@@ -1,6 +1,6 @@
 import { useNavigate } from 'react-router-dom'
 import { fireEvent, screen } from '@testing-library/react'
-import { afterEach, beforeEach, describe, expect, it, Mock, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { when } from 'vitest-when'
 
 import { RUN_STATUS_IDLE } from '@opentrons/api-client'
@@ -17,6 +17,7 @@ import { useStoredProtocolAnalysis } from '/app/resources/analysis'
 
 import { RunHeaderSectionLower } from '../RunHeaderContent/RunHeaderSectionLower'
 
+import type { Mock } from 'vitest'
 import type { ComponentProps } from 'react'
 
 vi.mock('react-router-dom')
@@ -183,7 +184,7 @@ describe('RunHeaderSectionLower', () => {
     )
     expect(mockTrackEvent).toHaveBeenCalledWith({
       name: ANALYTICS_LAUNCH_PROTOCOL_VISUALIZATION,
-      properties: {sourceLocation: 'protocol run'},
+      properties: { sourceLocation: 'protocol run' },
     })
   })
 })

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/__tests__/RunHeaderSectionLower.test.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/__tests__/RunHeaderSectionLower.test.tsx
@@ -1,6 +1,6 @@
 import { useNavigate } from 'react-router-dom'
 import { fireEvent, screen } from '@testing-library/react'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, Mock, vi } from 'vitest'
 import { when } from 'vitest-when'
 
 import { RUN_STATUS_IDLE } from '@opentrons/api-client'
@@ -8,6 +8,10 @@ import { RUN_STATUS_IDLE } from '@opentrons/api-client'
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
 import { useToaster } from '/app/organisms/ToasterOven'
+import {
+  ANALYTICS_LAUNCH_PROTOCOL_VISUALIZATION,
+  useTrackEvent,
+} from '/app/redux/analytics'
 import { useFeatureFlag } from '/app/redux/config'
 import { useStoredProtocolAnalysis } from '/app/resources/analysis'
 
@@ -19,6 +23,7 @@ vi.mock('react-router-dom')
 vi.mock('/app/redux/config')
 vi.mock('/app/resources/analysis/hooks/useStoredProtocolAnalysis')
 vi.mock('/app/organisms/ToasterOven')
+vi.mock('/app/redux/analytics')
 
 const mockRunId = 'mockRunId'
 const mockRobotName = 'mockRobotName'
@@ -61,6 +66,7 @@ const render = (props: ComponentProps<typeof RunHeaderSectionLower>) => {
     i18nInstance: i18n,
   })
 }
+let mockTrackEvent: Mock
 
 describe('RunHeaderSectionLower', () => {
   let props: ComponentProps<typeof RunHeaderSectionLower>
@@ -80,6 +86,8 @@ describe('RunHeaderSectionLower', () => {
     when(vi.mocked(useFeatureFlag))
       .calledWith('protocolTimeline')
       .thenReturn(false)
+    mockTrackEvent = vi.fn()
+    when(vi.mocked(useTrackEvent)).calledWith().thenReturn(mockTrackEvent)
   })
   afterEach(() => {
     vi.resetAllMocks()
@@ -173,5 +181,9 @@ describe('RunHeaderSectionLower', () => {
     expect(mockNavigate).toHaveBeenCalledWith(
       '/devices/mockRobotName/mockRunId/--%3A--%3A--/null/visualization'
     )
+    expect(mockTrackEvent).toHaveBeenCalledWith({
+      name: ANALYTICS_LAUNCH_PROTOCOL_VISUALIZATION,
+      properties: {sourceLocation: 'protocol run'},
+    })
   })
 })

--- a/app/src/organisms/Desktop/ProtocolDetails/ProtocolDetailsHeader.tsx
+++ b/app/src/organisms/Desktop/ProtocolDetails/ProtocolDetailsHeader.tsx
@@ -24,6 +24,7 @@ import {
 } from '@opentrons/components'
 
 import {
+  ANALYTICS_LAUNCH_PROTOCOL_VISUALIZATION,
   ANALYTICS_PROTOCOL_PROCEED_TO_RUN,
   useTrackEvent,
 } from '/app/redux/analytics'
@@ -125,6 +126,10 @@ export function ProtocolDetailsHeader({
   }
 
   const handleClickTimeline = (): void => {
+    trackEvent({
+      name: ANALYTICS_LAUNCH_PROTOCOL_VISUALIZATION,
+      properties: {sourceLocation: 'protocol details header'},
+    })
     navigate(`/protocols/${protocolKey}/visualization`)
   }
 

--- a/app/src/organisms/Desktop/ProtocolDetails/ProtocolDetailsHeader.tsx
+++ b/app/src/organisms/Desktop/ProtocolDetails/ProtocolDetailsHeader.tsx
@@ -128,7 +128,7 @@ export function ProtocolDetailsHeader({
   const handleClickTimeline = (): void => {
     trackEvent({
       name: ANALYTICS_LAUNCH_PROTOCOL_VISUALIZATION,
-      properties: {sourceLocation: 'protocol details header'},
+      properties: { sourceLocation: 'protocol details header' },
     })
     navigate(`/protocols/${protocolKey}/visualization`)
   }

--- a/app/src/organisms/Desktop/ProtocolDetails/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolDetails/index.tsx
@@ -55,6 +55,7 @@ import { getTopPortalEl } from '/app/App/portal'
 import { Divider } from '/app/atoms/structure'
 import { ChooseRobotToRunProtocolSlideout } from '/app/organisms/Desktop/ChooseRobotToRunProtocolSlideout'
 import {
+  ANALYTICS_LAUNCH_PROTOCOL_VISUALIZATION,
   ANALYTICS_PROTOCOL_PROCEED_TO_RUN,
   useTrackEvent,
 } from '/app/redux/analytics'
@@ -381,6 +382,10 @@ export function ProtocolDetails(
   }
 
   const handleClickTimeline = (): void => {
+    trackEvent({
+      name: ANALYTICS_LAUNCH_PROTOCOL_VISUALIZATION,
+      properties: { sourceLocation: 'protocol details' },
+    })
     navigate(`/protocols/${protocolKey}/visualization`)
   }
 

--- a/app/src/organisms/Desktop/ProtocolVisualization/VisualizerContainer/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/VisualizerContainer/index.tsx
@@ -14,6 +14,10 @@ import { CommandSteps } from '/app/organisms/Desktop/ProtocolVisualization/Comma
 import { Controls } from '/app/organisms/Desktop/ProtocolVisualization/Controls'
 import { DeckView } from '/app/organisms/Desktop/ProtocolVisualization/DeckView'
 import {
+  ANALYTICS_LAUNCH_PROTOCOL_VISUALIZATION_SPOTLIGHT_WINDOW,
+  useTrackEvent,
+} from '/app/redux/analytics'
+import {
   stepDetailViewerCloseAction,
   stepDetailViewerOpenAction,
   stepDetailViewerUpdateAction,
@@ -48,6 +52,7 @@ export function VisualizerContainer(
   props: VisualizerContainerProps
 ): JSX.Element {
   const dispatch = useDispatch()
+  const trackEvent = useTrackEvent()
   const { analysis, groupedCommands, protocolKey, srcFileNames } = props
   const { commands, robotType, liquids } = analysis
   const [isPlaying, setIsPlaying] = useState<boolean>(false)
@@ -313,6 +318,10 @@ export function VisualizerContainer(
           setSelectedSlot={slot => {
             setSelectedSlot(slot)
             if (selectedRunTimeCommand != null && selectedSlot != null) {
+              trackEvent({
+                name: ANALYTICS_LAUNCH_PROTOCOL_VISUALIZATION_SPOTLIGHT_WINDOW,
+                properties: {},
+              })
               dispatch(
                 stepDetailViewerOpenAction({
                   protocolKey,

--- a/app/src/redux/analytics/constants.ts
+++ b/app/src/redux/analytics/constants.ts
@@ -46,6 +46,10 @@ export const ANALYTICS_ODD_APP_ERROR = 'oddError'
 export const ANALYTICS_DESKTOP_APP_ERROR = 'desktopAppError'
 export const ANALYTICS_NOTIFICATION_PORT_BLOCK_ERROR =
   'notificationPortBlockError'
+export const ANALYTICS_LAUNCH_PROTOCOL_VISUALIZATION =
+  'launchProtocolVisualization'
+export const ANALYTICS_LAUNCH_PROTOCOL_VISUALIZATION_SPOTLIGHT_WINDOW =
+  'launchProtocolVisualizationSpotlightWindow'
 
 const ANALYTICS_PROTOCOL_PROCEED_BUTTON_TEXT = [
   ANALYTICS_PROCEED_TO_CAMERA_SETUP_STEP,


### PR DESCRIPTION
closes AUTH-2525 AUTH-2526

# Overview

wire up 2 of the mixpanel analytics required for PV - now an event is sent if you click on a visualize button or open the secondary window

## Test Plan and Hands on Testing

review the code

## Changelog

add 2 mixpanel events and add a test

## Risk assessment

low