### PR TITLE
fix(shared-data): correctly calculate overlap for stack limit

### DIFF
--- a/shared-data/js/helpers/__tests__/getFlexStackerHardwareProps.test.ts
+++ b/shared-data/js/helpers/__tests__/getFlexStackerHardwareProps.test.ts
@@ -52,17 +52,11 @@ describe('getLabwareOverlapOffset()', () => {
   })
 
   it('should console an error if the module model is invalid', () => {
-    const mockConsoleError = vi
-      .spyOn(console, 'error')
-      .mockImplementation(() => {})
     const result = getLabwareOverlapOffset(
       mockLabwareDefinition,
       'labware-name'
     )
     expect(result).toStrictEqual({ x: 0, y: 0, z: 0 })
-    expect(mockConsoleError).toHaveBeenCalledWith(
-      'Invalid module model for labware overlap offset: magneticModuleV1'
-    )
   })
 })
 

--- a/shared-data/js/helpers/__tests__/getFlexStackerHardwareProps.test.ts
+++ b/shared-data/js/helpers/__tests__/getFlexStackerHardwareProps.test.ts
@@ -45,7 +45,6 @@ describe('getLabwareOverlapOffset()', () => {
 
   it('should return the labware overlap offset for a given module model', () => {
     const result = getLabwareOverlapOffset(
-      FLEX_STACKER_MODULE_V1,
       mockLabwareDefinition,
       'labware-name'
     )
@@ -57,7 +56,6 @@ describe('getLabwareOverlapOffset()', () => {
       .spyOn(console, 'error')
       .mockImplementation(() => {})
     const result = getLabwareOverlapOffset(
-      MAGNETIC_MODULE_V1,
       mockLabwareDefinition,
       'labware-name'
     )

--- a/shared-data/js/helpers/getFlexStackerHardwareProps.ts
+++ b/shared-data/js/helpers/getFlexStackerHardwareProps.ts
@@ -44,12 +44,22 @@ export const getLabwareOverlapOffset = (
   )
 }
 
+/**
+ * Calculates the total height of a stack of labware given their definitions,
+ * ordered from bottom to top. Accounts for stacking overlaps between
+ * consecutive labware pieces according to their definitions.
+ *
+ * @param bottomUpDefinitions - Array of LabwareDefinitions, ordered bottom (first) to top (last)
+ * @returns The total stack height (in mm) as a number.
+ */
 export const getHeightOfLabwareStackFromDefinitions = (
   bottomUpDefinitions: LabwareDefinition[]
 ): number => {
   if (bottomUpDefinitions.length === 0) {
+    console.warn('bottomUpDefinitions array is empty')
     return 0
   }
+
   let lowerDef: LabwareDefinition = bottomUpDefinitions[0]
   let total_height = getSchema2Dimensions(lowerDef).zDimension
   for (const upperDef of bottomUpDefinitions.slice(1)) {

--- a/shared-data/js/helpers/getFlexStackerHardwareProps.ts
+++ b/shared-data/js/helpers/getFlexStackerHardwareProps.ts
@@ -35,14 +35,9 @@ export const getStackerMaxPoolCountByHeight = (
 }
 
 export const getLabwareOverlapOffset = (
-  model: ModuleModel,
   definition: LabwareDefinition,
   belowLabwareLoadName: string
 ): Vector3D => {
-  if (model !== FLEX_STACKER_MODULE_V1) {
-    console.error(`Invalid module model for labware overlap offset: ${model}`)
-    return { x: 0, y: 0, z: 0 }
-  }
   return (
     definition.stackingOffsetWithLabware?.[belowLabwareLoadName] ??
     definition.stackingOffsetWithLabware?.default ?? { x: 0, y: 0, z: 0 }
@@ -50,23 +45,22 @@ export const getLabwareOverlapOffset = (
 }
 
 export const getHeightOfLabwareStackFromDefinitions = (
-  definitions: LabwareDefinition[]
+  bottomUpDefinitions: LabwareDefinition[]
 ): number => {
-  if (definitions.length === 0) {
+  if (bottomUpDefinitions.length === 0) {
     return 0
   }
-  let total_height = 0.0
-  let upper_def: LabwareDefinition = definitions[0]
-  for (const lower_def of definitions.slice(1)) {
+  let lowerDef: LabwareDefinition = bottomUpDefinitions[0]
+  let total_height = getSchema2Dimensions(lowerDef).zDimension
+  for (const upperDef of bottomUpDefinitions.slice(1)) {
     const overlap = getLabwareOverlapOffset(
-      FLEX_STACKER_MODULE_V1,
-      lower_def,
-      upper_def.parameters.loadName
+      upperDef,
+      lowerDef.parameters.loadName
     ).z
-    total_height += getSchema2Dimensions(upper_def).zDimension - overlap
-    upper_def = lower_def
+    total_height += getSchema2Dimensions(upperDef).zDimension - overlap
+    lowerDef = upperDef
   }
-  return total_height + getSchema2Dimensions(upper_def).zDimension
+  return total_height
 }
 
 export const getMaxPoolCount = (args: {
@@ -89,7 +83,6 @@ export const getMaxPoolCount = (args: {
   const bottomLabwareDefinition = adapter != null ? adapter : primary
 
   const poolOverlap = getLabwareOverlapOffset(
-    model,
     topDefinition,
     bottomLabwareDefinition.parameters.loadName
   )

--- a/shared-data/js/helpers/getFlexStackerHardwareProps.ts
+++ b/shared-data/js/helpers/getFlexStackerHardwareProps.ts
@@ -1,6 +1,5 @@
 import { FLEX_STACKER_MODULE_V1 } from '../constants'
 import { getModuleDef } from '../modules'
-import { getLabwareDefURI } from './getLabwareDefURI'
 import { getSchema2Dimensions } from './positionMath'
 
 import type { LabwareDefinition, ModuleModel, Vector3D } from '../types'
@@ -38,14 +37,14 @@ export const getStackerMaxPoolCountByHeight = (
 export const getLabwareOverlapOffset = (
   model: ModuleModel,
   definition: LabwareDefinition,
-  belowLabwareURI: string
+  belowLabwareLoadName: string
 ): Vector3D => {
   if (model !== FLEX_STACKER_MODULE_V1) {
     console.error(`Invalid module model for labware overlap offset: ${model}`)
     return { x: 0, y: 0, z: 0 }
   }
   return (
-    definition.stackingOffsetWithLabware?.[belowLabwareURI] ??
+    definition.stackingOffsetWithLabware?.[belowLabwareLoadName] ??
     definition.stackingOffsetWithLabware?.default ?? { x: 0, y: 0, z: 0 }
   )
 }
@@ -61,8 +60,8 @@ export const getHeightOfLabwareStackFromDefinitions = (
   for (const lower_def of definitions.slice(1)) {
     const overlap = getLabwareOverlapOffset(
       FLEX_STACKER_MODULE_V1,
-      upper_def,
-      lower_def.parameters.loadName
+      lower_def,
+      upper_def.parameters.loadName
     ).z
     total_height += getSchema2Dimensions(upper_def).zDimension - overlap
     upper_def = lower_def
@@ -88,12 +87,11 @@ export const getMaxPoolCount = (args: {
     ...(lid != null ? [lid] : []),
   ])
   const bottomLabwareDefinition = adapter != null ? adapter : primary
-  const bottomLabwareURI = getLabwareDefURI(bottomLabwareDefinition)
 
   const poolOverlap = getLabwareOverlapOffset(
     model,
     topDefinition,
-    bottomLabwareURI
+    bottomLabwareDefinition.parameters.loadName
   )
   return getStackerMaxPoolCountByHeight(model, poolHeight, poolOverlap.z)
 }


### PR DESCRIPTION
# Overview

Corrects stack limit calculation to ensure the right labware is being referenced to find the overlap value.

## Test Plan and Hands on Testing

Checked stack limit for all tip racks to ensure it is 6

## Changelog

- `getLabwareOverlapOffset` now uses the labware load name rather than the labwareURI
- `getHeightOfLabwareStackFromDefinitions` uses the lower labware to get the offset rather than the higher one because offsets are normally in lids and 

## Review requests


## Risk assessment

medium
