### PR TITLE
fix(step-generation): remove gripper check for flex stacker empty

### DIFF
--- a/step-generation/src/commandCreators/atomic/__tests__/flexStackerEmpty.test.ts
+++ b/step-generation/src/commandCreators/atomic/__tests__/flexStackerEmpty.test.ts
@@ -20,7 +20,6 @@ import type {
 } from '../../../types'
 
 const moduleId = 'flexStackerId'
-const gripperId = 'gripperId'
 vi.mock('../../../robotStateSelectors')
 
 describe('flexStackerEmpty', () => {
@@ -33,9 +32,6 @@ describe('flexStackerEmpty', () => {
       type: FLEX_STACKER_MODULE_TYPE,
       model: FLEX_STACKER_MODULE_V1,
       pythonName: 'mock_flex_stacker_1',
-    }
-    invariantContext.gripperEntities[gripperId] = {
-      id: gripperId,
     }
 
     robotState = getInitialRobotStateStandard(invariantContext)
@@ -92,21 +88,6 @@ describe('flexStackerEmpty', () => {
     expect(getErrorResult(result).errors).toHaveLength(1)
     expect(getErrorResult(result).errors[0]).toMatchObject({
       type: 'MISSING_MODULE',
-    })
-  })
-  it('creates returns error if no gripper', () => {
-    invariantContext.gripperEntities = {}
-    const result = flexStackerEmpty(
-      {
-        moduleId,
-        strategy: 'logical',
-      },
-      invariantContext,
-      robotState
-    )
-    expect(getErrorResult(result).errors).toHaveLength(1)
-    expect(getErrorResult(result).errors[0]).toMatchObject({
-      type: 'FLEX_STACKER_NO_GRIPPER',
     })
   })
 })

--- a/step-generation/src/commandCreators/atomic/flexStackerEmpty.ts
+++ b/step-generation/src/commandCreators/atomic/flexStackerEmpty.ts
@@ -8,18 +8,14 @@ import type { CommandCreator, CommandCreatorError } from '../../types'
 export const flexStackerEmpty: CommandCreator<
   FlexStackerEmptyCreateCommand['params']
 > = (args, invariantContext, prevRobotState) => {
-  const { gripperEntities, moduleEntities } = invariantContext
+  const { moduleEntities } = invariantContext
   const flexStackerState = flexStackerStateGetter(prevRobotState, args.moduleId)
-  const hasGripperEntity = Object.keys(gripperEntities).length > 0
 
   const errors: CommandCreatorError[] = []
   if (args.moduleId == null || flexStackerState == null) {
     errors.push(errorCreators.missingModuleError())
   }
 
-  if (!hasGripperEntity) {
-    errors.push(errorCreators.flexStackerNoGripper())
-  }
   if (errors.length > 0) {
     return { errors }
   }


### PR DESCRIPTION
# Overview

Remove unneeded check for gripper in Flex stacker empty step generation command creator

Closes RQA-5005

## Test Plan and Hands on Testing

- import or create a stacker protocol _without_ a gripper
- load some labware in the hopper
- create a stacker empty step, and verify that no timeline error is hit

## Changelog

- remove gripper check from `flexStackerEmpty` command creator
- remove unnecessary test

## Review requests

see test plan

## Risk assessment

low