### PR TITLE
fix(protocol-designer): fix refill range max in stacker fill step form

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/FlexStackerTools/RefillSettings.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/FlexStackerTools/RefillSettings.tsx
@@ -68,8 +68,11 @@ export function RefillSettings(props: RefillSettingsProps): JSX.Element {
 
   const [fillQuantityLocalState, setFillQuantityState] = useState<
     string | null
-    // initialize if saved step form exists
+  // initialize if saved step form exists
   >(oldGroupQuantity > 0 ? String(oldGroupQuantity) : null)
+
+  const numberOfGroupsInHopper = labwareInHopper?.length ?? 0
+  const maxRefillGroupQuantity = maxPoolCount - numberOfGroupsInHopper
 
   const storedEntityName = storedPrimaryEntity?.def.metadata.displayName
   const isPrimaryTiprack =
@@ -78,10 +81,9 @@ export function RefillSettings(props: RefillSettingsProps): JSX.Element {
   // you can't rely on generating the uuid in the hydrated form
   useEffect(() => {
     const newGroupQuantity = Number(fillQuantityLocalState) ?? 1
-    const numberOfGroupsInHopper = labwareInHopper?.length ?? 0
     const difference = newGroupQuantity - oldGroupQuantity
     const valueTooHigh =
-      newGroupQuantity > maxPoolCount - numberOfGroupsInHopper
+      newGroupQuantity > maxRefillGroupQuantity
     // Form errors do not have acccess to module state, so this logic is used
     // to clear out the fillLabwareIds value if the quantity entered is too high
     // and raise an error.
@@ -136,7 +138,7 @@ export function RefillSettings(props: RefillSettingsProps): JSX.Element {
             showTooltip={false}
             caption={t(
               'step_edit_form.flex_stacker.fields.fillLabwareIds.caption',
-              { max: maxPoolCount }
+              { max: maxRefillGroupQuantity }
             )}
             type="number"
             padding="0"

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/FlexStackerTools/RefillSettings.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/FlexStackerTools/RefillSettings.tsx
@@ -68,7 +68,7 @@ export function RefillSettings(props: RefillSettingsProps): JSX.Element {
 
   const [fillQuantityLocalState, setFillQuantityState] = useState<
     string | null
-  // initialize if saved step form exists
+    // initialize if saved step form exists
   >(oldGroupQuantity > 0 ? String(oldGroupQuantity) : null)
 
   const numberOfGroupsInHopper = labwareInHopper?.length ?? 0
@@ -82,8 +82,7 @@ export function RefillSettings(props: RefillSettingsProps): JSX.Element {
   useEffect(() => {
     const newGroupQuantity = Number(fillQuantityLocalState) ?? 1
     const difference = newGroupQuantity - oldGroupQuantity
-    const valueTooHigh =
-      newGroupQuantity > maxRefillGroupQuantity
+    const valueTooHigh = newGroupQuantity > maxRefillGroupQuantity
     // Form errors do not have acccess to module state, so this logic is used
     // to clear out the fillLabwareIds value if the quantity entered is too high
     // and raise an error.


### PR DESCRIPTION
# Overview

Correctly show the refill input field range maximum as the difference of the maximum groups that can be stored in the hopper minus the number of groups currently in the hopper at the time the step is created.

Closes RQA-5006

## Test Plan and Hands on Testing

- create or import a protocol with a stacker
- load some labware into the stacker in starting deck
- create a stacker refill step
- verify that the caption under the refill quantity field sets its max as correctly (should account for the labware groups _already_ in the hopper)

## Changelog

- fix range in refill quantity field caption

## Review requests

see test plan

## Risk assessment

low