### PR TITLE
fix(step-generation): allow storing labware in unconfigured hopper

### DIFF
--- a/step-generation/src/utils/misc.ts
+++ b/step-generation/src/utils/misc.ts
@@ -1429,6 +1429,10 @@ export const labwareMatchesLabwareInHopper = (
   invariantContext: InvariantContext,
   stackerState: FlexStackerModuleState | null
 ): boolean => {
+  // permissive if no stored labware details configured
+  if (stackerState?.storedLabwareDetails == null) {
+    return true
+  }
   const storedLabwareURIs = Object.values(
     stackerState?.storedLabwareDetails ?? {}
   ).reduce<string[]>((acc, val) => {


### PR DESCRIPTION
# Overview

We should allow storing any stacker module-compatible labware group in the hopper if it has not been configured previously in the protocol for another labware group

Closes RQA-5007

## Test Plan and Hands on Testing

- create a stacker protocol and load a stacker-compatible labware elsewhere on the deck
- move the labware to the stacker shuttle
- create a stacker store step, and verify that no timeline errors are produced 

## Changelog

- allow storing labware in the hopper if the hopper is not configured yet

## Review requests

see test plan

## Risk assessment

low