### PR TITLE
chore: add a cursor rule for "robot projects"

### DIFF
--- a/.cursor/rules/robot-python-projects.mdc
+++ b/.cursor/rules/robot-python-projects.mdc
@@ -1,0 +1,59 @@
+---
+description: Guidelines for working with the robot Python projects
+globs:
+  - api/**/*.py
+  - robot-server/**/*.py
+  - hardware/**/*.py
+  - shared-data/python/**/*.py
+  - shared-data/python_tests/**/*.py
+  - server-utils/**/*.py
+  - system-server/**/*.py
+  - update-server/**/*.py
+  - usb-bridge/**/*.py
+  - g-code-testing/**/*.py
+  - api/pyproject.toml
+  - robot-server/pyproject.toml
+  - hardware/pyproject.toml
+  - shared-data/pyproject.toml
+  - server-utils/pyproject.toml
+  - system-server/pyproject.toml
+  - update-server/pyproject.toml
+  - usb-bridge/pyproject.toml
+  - g-code-testing/pyproject.toml
+---
+
+## Robot Python Projects
+
+The following directories contain the robot Python projects - the Python packages that run on or support Opentrons robots:
+
+| Project | Directory | Description |
+|---------|-----------|-------------|
+| `opentrons` | `api/` | The core Opentrons Python API for protocol execution |
+| `robot-server` | `robot-server/` | HTTP API server that runs on the robot |
+| `opentrons-hardware` | `hardware/` | Low-level hardware control and CAN bus communication |
+| `opentrons-shared-data` | `shared-data/` | Shared data definitions (labware, pipettes, modules) |
+| `server-utils` | `server-utils/` | Common utilities for Python servers |
+| `system-server` | `system-server/` | System-level server for robot management |
+| `otupdate` | `update-server/` | Server for software and firmware updates |
+| `ot3usb` | `usb-bridge/` | USB bridge daemon for OT-3 |
+| `g-code-testing` | `g-code-testing/` | G-code testing and emulation tools |
+
+### Common Patterns
+
+- All projects use `pyproject.toml` with hatch as the build system
+- All projects use `uv` for dependency management with `uv.lock` files
+- All projects use pytest 9+ with configuration in `[tool.pytest]` section of `pyproject.toml`
+- All projects use ruff for linting with configuration in `[tool.ruff]` sections
+- All projects use mypy for type checking with `mypy.ini` files
+
+### Running Tests
+
+Each project except shared-data has a Makefile with a `test` target. shared-data has a Makefile with a test-py target.
+
+### Checking Types and Linting
+
+Each project has a Makefile with a `lint` target. shared-data has a Makefile with a lint-py target.
+
+### Formatting
+
+Each project has a Makefile with a `format` target. shared-data has a Makeifle with a `format-py` target.


### PR DESCRIPTION
this should let users refer to "robot python projects" without needing further context.
