### PR TITLE
fix(protocol-designer): allow editing labware quantity in hopper

### DIFF
--- a/protocol-designer/src/components/organisms/SelectLabwareModal/SelectLabware.tsx
+++ b/protocol-designer/src/components/organisms/SelectLabwareModal/SelectLabware.tsx
@@ -151,10 +151,9 @@ export function SelectLabware(props: SelectLabwareProps): JSX.Element | null {
                     })
 
                     const stackingProps: StackingProps | null =
-                      isLidValid &&
-                      (isOnHopper ||
-                        (stackingLabwareDefUris.length === 1 &&
-                          slot !== 'offDeck'))
+                      isOnHopper ||
+                      (stackingLabwareDefUris.length === 1 &&
+                        slot !== 'offDeck')
                         ? {
                             inputTitle: t('labware_quantity'),
                             errorMessage: t('unsupported_range'),
@@ -178,7 +177,7 @@ export function SelectLabware(props: SelectLabwareProps): JSX.Element | null {
                             }),
                             checked: selectedLidLabware != null,
                             onCheckboxChange:
-                              !isTiprack && isOnHopper
+                              (!isTiprack && isOnHopper) || !isLidValid
                                 ? undefined
                                 : () => {
                                     dispatch(


### PR DESCRIPTION
# Overview

All hopper labware types should have editable quantities, regardless of if they are allowed to be lidded (tipracks only for 8.8 release). Here, I fix the implementation of the valid lid check in SelectLabware.

Closes RQA-5016

## Test Plan and Hands on Testing

- create or import a stacker protocol
- in starting deck state, add labware to the hopper
- select a non-tiprack labware (like an Opentrons wellplate)
- verify that quantity _is_ present
- verify that lid checkbox _is not_ present

## Changelog

- refactor logic for valid lid addition to not impact stackable labware quantities

## Review requests

see test plan

## Risk assessment

low