### PR TITLE
fix(step-generation): return all labwareDefUris in stack

### DIFF
--- a/app/src/organisms/Desktop/ProtocolVisualization/utils/getLiquidDetailInfo.ts
+++ b/app/src/organisms/Desktop/ProtocolVisualization/utils/getLiquidDetailInfo.ts
@@ -2,7 +2,7 @@ import sum from 'lodash/sum'
 
 import { COLORS } from '@opentrons/components'
 import {
-  getLiquidIdsOnLabware,
+  getLiquidIdsOnLabwareStack,
   getVolumesPerLiquid,
 } from '@opentrons/step-generation'
 
@@ -19,7 +19,7 @@ export const getLiquidDetailInfo = (
   wellContents: ContentsByWell,
   liquids: Liquid[]
 ): LiquidDetailInfo[] => {
-  const individualIds = getLiquidIdsOnLabware(wellContents)
+  const individualIds = getLiquidIdsOnLabwareStack([wellContents])
   const volumesPerLiquid = getVolumesPerLiquid(wellContents, individualIds)
   const liquidInfo: LiquidDetailInfo[] = individualIds.map(liquidId => {
     const totalVolume = sum(Object.values(volumesPerLiquid[liquidId]))

--- a/protocol-designer/src/assets/localization/en/starting_deck_state.json
+++ b/protocol-designer/src/assets/localization/en/starting_deck_state.json
@@ -32,6 +32,7 @@
   "duplicate": "Duplicate labware",
   "edit_hw_lw": "Edit hardware/labware",
   "edit_labware_quantity": "Edit labware quantity",
+  "multiple_liquid_layouts": "Multiple liquid layouts",
   "edit_labware": "Edit labware",
   "edit_liquid_and_quantity": "Edit liquid and quantity",
   "edit_liquid": "Edit liquid",

--- a/protocol-designer/src/components/organisms/LabwareCard/__tests__/LabwareCard.test.tsx
+++ b/protocol-designer/src/components/organisms/LabwareCard/__tests__/LabwareCard.test.tsx
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { fixture96Plate } from '@opentrons/shared-data'
 import {
   getFullStackFromLabwares,
-  getLiquidIdsOnLabware,
+  getLiquidIdsOnLabwareStack,
 } from '@opentrons/step-generation'
 
 import { renderWithProviders } from '/protocol-designer/__testing-utils__'
@@ -13,7 +13,6 @@ import { i18n } from '../../../../assets/localization'
 import { openIngredientSelector } from '../../../../labware-ingred/actions'
 import { getDeckSetupForActiveItem } from '../../../../top-selectors/labware-locations'
 import * as wellContentsSelectors from '../../../../top-selectors/well-contents'
-import { getLabwareNicknamesById } from '../../../../ui/labware/selectors'
 import { EditLabwareQuantityModal } from '../../EditLabwareQuantityModal'
 import { LabwareCardOverflowMenu } from '../../LabwareCardOverflowMenu'
 import { LabwareCard } from '../index'
@@ -73,13 +72,10 @@ describe('LabwareCard', () => {
     vi.mocked(LabwareCardOverflowMenu).mockReturnValue(
       <div>mock LabwareCardOverflowMenu</div>
     )
-    vi.mocked(getLabwareNicknamesById).mockReturnValue({
-      labwareId: 'mock NickName',
-    })
     vi.mocked(
       wellContentsSelectors.getAllWellContentsForActiveItem
     ).mockReturnValue(null)
-    vi.mocked(getLiquidIdsOnLabware).mockReturnValue([])
+    vi.mocked(getLiquidIdsOnLabwareStack).mockReturnValue([])
     vi.mocked(getDeckSetupForActiveItem).mockReturnValue({
       modules: {},
       pipettes: {},
@@ -108,7 +104,6 @@ describe('LabwareCard', () => {
 
   it('renders a labware card with the liquids button and overflow menu', () => {
     render(props)
-    screen.getByText('mock NickName')
     screen.getByText('ANSI 96 Standard Microplate')
     screen.getByText('No liquids added')
     screen.getByText('with mock lid')
@@ -119,12 +114,12 @@ describe('LabwareCard', () => {
     screen.getByText('mock LabwareCardOverflowMenu')
   })
   it('renders a labware card with 2 liquids added', () => {
-    vi.mocked(getLiquidIdsOnLabware).mockReturnValue(['0', '1'])
+    vi.mocked(getLiquidIdsOnLabwareStack).mockReturnValue(['0', '1'])
     render(props)
     screen.getByText('2 liquids')
   })
   it('renders a labware card with 1 liquid added', () => {
-    vi.mocked(getLiquidIdsOnLabware).mockReturnValue(['0'])
+    vi.mocked(getLiquidIdsOnLabwareStack).mockReturnValue(['0'])
     render(props)
     screen.getByText('1 liquid')
   })
@@ -135,7 +130,6 @@ describe('LabwareCard', () => {
       def: { ...fixture96Plate, stackLimit: 4 } as LabwareDefinition2,
     }
     render(props)
-    screen.getByText('mock NickName')
     screen.getByText('ANSI 96 Standard Microplate')
     screen.getByText('Quantity: 2')
     screen.getByText('Edit liquid and quantity')

--- a/protocol-designer/src/components/organisms/LabwareCard/index.tsx
+++ b/protocol-designer/src/components/organisms/LabwareCard/index.tsx
@@ -22,7 +22,7 @@ import {
 } from '@opentrons/components'
 import {
   getFullStackFromLabwares,
-  getLiquidIdsOnLabware,
+  getLiquidIdsOnLabwareStack,
   HOPPER_STACKER_LOCATION,
 } from '@opentrons/step-generation'
 
@@ -30,7 +30,6 @@ import { LINK_BUTTON_STYLE } from '/protocol-designer/components/atoms'
 import { openIngredientSelector } from '/protocol-designer/labware-ingred/actions'
 import { getDeckSetupForActiveItem } from '/protocol-designer/top-selectors/labware-locations'
 import * as wellContentsSelectors from '/protocol-designer/top-selectors/well-contents'
-import { getLabwareNicknamesById } from '/protocol-designer/ui/labware/selectors'
 
 import { EditLabwareQuantityModal } from '../EditLabwareQuantityModal'
 import { LabwareCardOverflowMenu } from '../LabwareCardOverflowMenu'
@@ -63,22 +62,19 @@ export function LabwareCard(props: LabwareCardProps): JSX.Element {
         : !deckSetupLabware[id].def.allowedRoles?.includes('adapter'))
   )
   const isOnHopper = labware.stack.includes(HOPPER_STACKER_LOCATION)
-  const nickNames = useSelector(getLabwareNicknamesById)
   const allWellContentsForActiveItem = useSelector(
     wellContentsSelectors.getAllWellContentsForActiveItem
   )
   const [showOverflowMenu, setShowOverflowMenu] = useState<boolean>(false)
-  const wellContents =
+  const allFullWellContents =
     allWellContentsForActiveItem != null
-      ? allWellContentsForActiveItem[labware.id]
-      : null
+      ? Object.values(allWellContentsForActiveItem)
+      : []
   const displayName = def.metadata.displayName
-  const nickName = nickNames[labware.id]
   const isAdapterOrTiprack =
     def.allowedRoles?.includes('adapter') || def.parameters.isTiprack
   const isLid = def.allowedRoles?.includes('lid')
-  const isNicknameDifferent = nickName !== displayName
-  const liquidIds = getLiquidIdsOnLabware(wellContents)
+  const liquidIds = getLiquidIdsOnLabwareStack(allFullWellContents)
   const canModifyQuantity =
     isOnHopper || (def.stackLimit != null && def.stackLimit > 1)
 
@@ -137,16 +133,8 @@ export function LabwareCard(props: LabwareCardProps): JSX.Element {
             >
               <Flex flexDirection={DIRECTION_COLUMN}>
                 <StyledText desktopStyle="bodyDefaultSemiBold">
-                  {nickName}
+                  {displayName}
                 </StyledText>
-                {isNicknameDifferent ? (
-                  <StyledText
-                    desktopStyle="bodyDefaultRegular"
-                    color={COLORS.grey60}
-                  >
-                    {displayName}
-                  </StyledText>
-                ) : null}
                 {lidId != null && deckSetupLabware[lidId] != null ? (
                   <StyledText
                     desktopStyle="bodyDefaultRegular"
@@ -163,11 +151,11 @@ export function LabwareCard(props: LabwareCardProps): JSX.Element {
                       text={
                         liquidIds.length === 0
                           ? t('no_liquids_added')
-                          : t('num_liquid', { count: liquidIds.length })
+                          : t('multiple_liquid_layouts')
                       }
                     />
                   ) : null}
-                  {quantity > 1 ? (
+                  {quantity >= 1 ? (
                     <LiquidInfoDisplay
                       text={`Quantity: ${quantity.toString()}`}
                     />

--- a/protocol-designer/src/components/organisms/SlotDetailModal/index.tsx
+++ b/protocol-designer/src/components/organisms/SlotDetailModal/index.tsx
@@ -20,7 +20,7 @@ import {
   Tag,
 } from '@opentrons/components'
 import {
-  getLiquidIdsOnLabware,
+  getLiquidIdsOnLabwareStack,
   getSlotInLocationStack,
   getVolumesPerLiquid,
   wellFillFromWellContents,
@@ -77,7 +77,7 @@ export const SlotDetailModal = (
     wellContents,
     liquidDisplayColors
   )
-  const individualIds = getLiquidIdsOnLabware(wellContents)
+  const individualIds = getLiquidIdsOnLabwareStack([wellContents])
 
   const volumesPerLiquid = getVolumesPerLiquid(wellContents, individualIds)
 
@@ -153,9 +153,8 @@ export const SlotDetailModal = (
                     ? allWellContentsForActiveItem[selectedLabwareId]
                     : null
 
-                const individualIdsForNewlySelected = getLiquidIdsOnLabware(
-                  wellContentsForNewlySelected
-                )
+                const individualIdsForNewlySelected =
+                  getLiquidIdsOnLabwareStack([wellContentsForNewlySelected])
 
                 setSelectedLabware(selectedLabwareId)
                 setSelectedLiquidId(

--- a/step-generation/src/utils/liquidUtils.ts
+++ b/step-generation/src/utils/liquidUtils.ts
@@ -19,7 +19,10 @@ export function getAllWellsForLabware(def: LabwareDefinition2): string[] {
 }
 
 export type ContentsByWell = Record<string, WellContents> | null
-
+const EMPTY_WELL_CONTENTS: WellContents = {
+  groupIds: [],
+  ingreds: {},
+}
 const _wellContentsForWell = (
   liquidVolState: LocationLiquidState,
   wellName: string
@@ -42,15 +45,17 @@ export const _wellContentsForLabware = (
   labwareDef: LabwareDefinition2
 ): ContentsByWell => {
   const allWellsForContainer = getAllWellsForLabware(labwareDef)
+
   return reduce(
     allWellsForContainer,
-    (wellAcc, well: string): Record<string, WellContents> => {
-      const wellHasContents = labwareLiquids && labwareLiquids[well]
+    (wellAcc: Record<string, WellContents>, well: string) => {
+      const wellHasContents = labwareLiquids?.[well]
+
       return {
         ...wellAcc,
         [well]: wellHasContents
           ? _wellContentsForWell(labwareLiquids[well], well)
-          : {},
+          : EMPTY_WELL_CONTENTS,
       }
     },
     {}
@@ -85,15 +90,17 @@ export const getVolumesPerLiquid = (
   return volumesPerLiquid
 }
 
-export const getLiquidIdsOnLabware = (
-  wellContents: ContentsByWell
+export const getLiquidIdsOnLabwareStack = (
+  wellContents: ContentsByWell[]
 ): string[] => {
-  const allLiquidIdsOnLabware =
-    wellContents != null
-      ? Object.values(wellContents)
-          .flatMap(contents => contents.groupIds)
-          ?.filter(group => group !== AIR)
-      : []
+  const allLiquidIdsOnLabware = wellContents.flatMap(contentsByWell =>
+    contentsByWell == null
+      ? []
+      : Object.values(contentsByWell).flatMap(contents =>
+          contents.groupIds.filter(group => group !== AIR)
+        )
+  )
+
   return Array.from(new Set(allLiquidIdsOnLabware))
 }
 

--- a/step-generation/src/utils/misc.ts
+++ b/step-generation/src/utils/misc.ts
@@ -1049,16 +1049,14 @@ export const getFullStackFromLabwares = (
   const mappedLocation = isOnHopper
     ? FAKE_HOPPER_LOCATION_MAP[slot as HopperLocationMapKey]
     : slot
-  return (
-    Object.values(labware)
-      .filter(
-        lw =>
-          lw.stack.includes(mappedLocation) &&
-          (offDeckOverrideId == null || lw.stack.includes(offDeckOverrideId)) &&
-          lw.stack.includes(HOPPER_STACKER_LOCATION) === isOnHopper
-      )
-      .sort((a, b) => b.stack.length - a.stack.length)[0]?.stack ?? []
-  )
+  return Object.values(labware)
+    .filter(
+      lw =>
+        lw.stack.includes(mappedLocation) &&
+        (offDeckOverrideId == null || lw.stack.includes(offDeckOverrideId)) &&
+        lw.stack.includes(HOPPER_STACKER_LOCATION) === isOnHopper
+    )
+    .map(lw => lw.stack[0])
 }
 
 export const getTopmostLabwareOnModuleFromStackRobotState = (


### PR DESCRIPTION
# Overview

Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.

## Test Plan and Hands on Testing

- smoke tested edit labware quantity 
- smoke test on labware liquids 


## Changelog

- changed util to return list of all labware def uris in stack, rather than largest individual stack
- removed nick name from labware card since this is not in the design
- liquid utils read in a list of well contents, rather than reading the top one to determine if there are liquids
- corrected text if there is more than one liquid loaded

## Review requests

- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.

## Risk assessment
- high
- changes liquid behavior in multiple spots

Closes RQA-5011, RQA-5021, RQA-5016
