### PR TITLE
fix(protocol-designer): wire up edit labware quantity behavior for hopper

### DIFF
--- a/protocol-designer/src/components/organisms/EditLabwareQuantityModal/__tests__/EditLabwareQuantityModal.test.tsx
+++ b/protocol-designer/src/components/organisms/EditLabwareQuantityModal/__tests__/EditLabwareQuantityModal.test.tsx
@@ -10,12 +10,16 @@ import {
   createContainer,
   deleteContainer,
 } from '/protocol-designer/labware-ingred/actions'
-import { getLabwareEntities } from '/protocol-designer/step-forms/selectors'
+import {
+  getInitialDeckSetup,
+  getLabwareEntities,
+} from '/protocol-designer/step-forms/selectors'
 
 import { EditLabwareQuantityModal } from '..'
 
 import type { ComponentProps } from 'react'
 import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { AllTemporalPropertiesForTimelineFrame } from '/protocol-designer/step-forms'
 
 vi.mock('/protocol-designer/labware-ingred/actions')
 vi.mock('/protocol-designer/step-forms/selectors')
@@ -49,6 +53,7 @@ describe('EditLabwareQuantityModal', () => {
       labwareId: 'mockId',
       allLabwareIdsOnStack: ['mockId'],
       isOnHopper: false,
+      location: 'A1',
     }
     vi.mocked(getLabwareEntities).mockReturnValue({
       mockId: labwareEntity1,
@@ -56,6 +61,9 @@ describe('EditLabwareQuantityModal', () => {
     vi.mocked(getLabwareDefsByURI).mockReturnValue({
       mockURI: { ...fixture96Plate, stackLimit: 3 } as LabwareDefinition2,
     })
+    vi.mocked(getInitialDeckSetup).mockReturnValue({
+      modules: {},
+    } as AllTemporalPropertiesForTimelineFrame)
   })
 
   it('renders the text and changes the quantity to 2', () => {

--- a/protocol-designer/src/components/organisms/EditLabwareQuantityModal/index.tsx
+++ b/protocol-designer/src/components/organisms/EditLabwareQuantityModal/index.tsx
@@ -15,7 +15,13 @@ import {
   SPACING,
   StyledText,
 } from '@opentrons/components'
-import { FLEX_STACKER_MODULE_V1, getMaxPoolCount } from '@opentrons/shared-data'
+import {
+  FLEX_STACKER_MODULE_TYPE,
+  FLEX_STACKER_MODULE_V1,
+  getIsLid,
+  getMaxPoolCount,
+} from '@opentrons/shared-data'
+import { FAKE_HOPPER_LOCATION_MAP } from '@opentrons/step-generation'
 
 import { HandleEnter } from '/protocol-designer/components/atoms'
 import { getLabwareDefsByURI } from '/protocol-designer/labware-defs/selectors'
@@ -23,11 +29,20 @@ import {
   createContainer,
   deleteContainer,
 } from '/protocol-designer/labware-ingred/actions'
-import { getLabwareEntities } from '/protocol-designer/step-forms/selectors'
+import { updateStackerModuleState } from '/protocol-designer/step-forms/actions'
+import { createContainerAboveModule } from '/protocol-designer/step-forms/actions/thunks'
+import {
+  getInitialDeckSetup,
+  getLabwareEntities,
+} from '/protocol-designer/step-forms/selectors'
 import { maskToPositiveInteger } from '/protocol-designer/steplist/fieldLevel/processing'
 
 import { getMainPagePortalEl } from '../Portal'
 
+import type {
+  FlexStackerModuleState,
+  HopperLocationMapKey,
+} from '@opentrons/step-generation'
 import type { ThunkDispatch } from '/protocol-designer/types'
 
 interface EditLabwareQuantityModalProps {
@@ -35,20 +50,22 @@ interface EditLabwareQuantityModalProps {
   labwareId: string
   onClose: () => void
   isOnHopper: boolean
+  location: string
 }
 export function EditLabwareQuantityModal(
   props: EditLabwareQuantityModalProps
 ): JSX.Element {
-  const { onClose, allLabwareIdsOnStack, labwareId, isOnHopper } = props
+  const { onClose, allLabwareIdsOnStack, labwareId, isOnHopper, location } =
+    props
   const { t } = useTranslation(['starting_deck_state', 'shared'])
   const dispatch = useDispatch<ThunkDispatch<any>>()
   const labwareEntities = useSelector(getLabwareEntities)
   const labwareDefsByUri = useSelector(getLabwareDefsByURI)
+  const { modules } = useSelector(getInitialDeckSetup)
   const { labwareDefURI, def } = labwareEntities[labwareId]
   const labwareOfPrimaryURIOnStack = allLabwareIdsOnStack.filter(id =>
     id.includes(labwareDefURI)
   )
-  const initialQuantity = labwareOfPrimaryURIOnStack.length
   const labwareDefURIsInStack = new Set(
     allLabwareIdsOnStack.map(
       labwareId => labwareEntities[labwareId].labwareDefURI
@@ -59,9 +76,79 @@ export function EditLabwareQuantityModal(
   const labwareDefinitionsInGroup = labwareDefURIsInStackArray.map(
     uri => labwareDefsByUri[uri]
   )
-  const lidDefinition = labwareDefinitionsInGroup.find(def =>
-    def.allowedRoles?.includes('lid')
-  )
+  const lidDefinition = labwareDefinitionsInGroup.find(def => getIsLid(def))
+
+  const [stackerId, stackerModule] =
+    Object.entries(modules).find(
+      ([_, { slot, moduleState }]) =>
+        slot === FAKE_HOPPER_LOCATION_MAP[location as HopperLocationMapKey] &&
+        moduleState.type === FLEX_STACKER_MODULE_TYPE
+    ) ?? []
+  const stackerSlot = FAKE_HOPPER_LOCATION_MAP[location as HopperLocationMapKey]
+  const stackerModuleState =
+    stackerModule?.moduleState as FlexStackerModuleState
+  const initialQuantity =
+    stackerModuleState != null
+      ? (stackerModuleState.labwareInHopper?.length ?? 1)
+      : labwareOfPrimaryURIOnStack.length
+
+  const handleHopperQuantityUpdate = (newQuantity: number): void => {
+    // slice from bottom up, up to the new quantity
+    const { storedLabwareDetails, labwareInHopper } = stackerModuleState
+    if (
+      stackerId != null &&
+      stackerModuleState != null &&
+      storedLabwareDetails != null &&
+      labwareInHopper != null
+    ) {
+      const initialGroupsInHopperQuantity = labwareInHopper.length
+      if (newQuantity < initialGroupsInHopperQuantity) {
+        const newLabwareInHopper = labwareInHopper.slice(0, newQuantity)
+        dispatch(
+          updateStackerModuleState({
+            moduleId: stackerId,
+            moduleState: {
+              ...stackerModuleState,
+              labwareInHopper: newLabwareInHopper,
+            },
+          })
+        )
+        // delete the labwares
+        const groupsToDelete = labwareInHopper.slice(
+          newQuantity,
+          initialGroupsInHopperQuantity
+        )
+        for (const group of groupsToDelete) {
+          for (const id of Object.values(group)) {
+            if (id != null) {
+              dispatch(
+                deleteContainer({
+                  labwareId: id,
+                })
+              )
+            }
+          }
+        }
+      } else if (newQuantity > initialGroupsInHopperQuantity) {
+        const quantityToAdd = newQuantity - initialGroupsInHopperQuantity
+        dispatch(
+          createContainerAboveModule({
+            slot: stackerSlot,
+            labwareDefURIGroup: {
+              adapterDefURI: storedLabwareDetails.adapterLabwareURI ?? null,
+              topLabwareDefURI: storedLabwareDetails.primaryLabwareURI,
+              lidDefURI: storedLabwareDetails.lidLabwareURI ?? null,
+            },
+            stackerInfo: {
+              stackerPosition: 'hopper',
+              amount: quantityToAdd,
+            },
+          })
+        )
+      }
+    }
+  }
+
   const stackingLimit = isOnHopper
     ? getMaxPoolCount({
         labwareDefinitions: {
@@ -76,32 +163,36 @@ export function EditLabwareQuantityModal(
   const [quantity, setQuantity] = useState<string>(initialQuantity.toString())
   const [showError, setError] = useState<boolean>(false)
   const saveQuantity = (quantity: string): void => {
-    //  delete the full stack above the labwareId in question
-    allLabwareIdsOnStack.forEach(labwareIdStack => {
-      if (labwareIdStack !== labwareId) {
+    if (isOnHopper) {
+      handleHopperQuantityUpdate(parseInt(quantity))
+    } else {
+      //  delete the full stack above the labwareId in question
+      allLabwareIdsOnStack.forEach(labwareIdStack => {
+        if (labwareIdStack !== labwareId) {
+          dispatch(
+            deleteContainer({
+              labwareId: labwareIdStack,
+            })
+          )
+        }
+      })
+      // recreate the stack
+      const count = parseInt(quantity) - 1
+      const arrayOfLabwareDefURI = hasLidInStack
+        ? Array.from({ length: count * 2 }, (_, index) =>
+            index % 2 === 0
+              ? labwareDefURIsInStackArray[0]
+              : labwareDefURIsInStackArray[1]
+          )
+        : Array.from({ length: count }, () => labwareDefURI)
+      if (arrayOfLabwareDefURI.length > 0) {
         dispatch(
-          deleteContainer({
-            labwareId: labwareIdStack,
+          createContainer({
+            labwareDefURIStack: arrayOfLabwareDefURI,
+            slot: labwareId,
           })
         )
       }
-    })
-    // recreate the stack
-    const count = parseInt(quantity) - 1
-    const arrayOfLabwareDefURI = hasLidInStack
-      ? Array.from({ length: count * 2 }, (_, index) =>
-          index % 2 === 0
-            ? labwareDefURIsInStackArray[0]
-            : labwareDefURIsInStackArray[1]
-        )
-      : Array.from({ length: count }, () => labwareDefURI)
-    if (arrayOfLabwareDefURI.length > 0) {
-      dispatch(
-        createContainer({
-          labwareDefURIStack: arrayOfLabwareDefURI,
-          slot: labwareId,
-        })
-      )
     }
     onClose()
   }

--- a/protocol-designer/src/components/organisms/LabwareCard/index.tsx
+++ b/protocol-designer/src/components/organisms/LabwareCard/index.tsx
@@ -112,6 +112,7 @@ export function LabwareCard(props: LabwareCardProps): JSX.Element {
           labwareId={labware.id}
           allLabwareIdsOnStack={filteredStack}
           isOnHopper={isOnHopper}
+          location={location}
         />
       ) : null}
       <Box position={POSITION_RELATIVE}>


### PR DESCRIPTION
# Overview

Adds logic for increasing or decreasing the number of labware groups in a hopper.

Closes RQA-5012, Closes RQA-5021

## Test Plan and Hands on Testing

- create or import a stacker protocol
- in starting deck state, add some labware (and a lid) to the hopper in any quantity
- smoke test editing the quantity of the labware groups both increasing and decreasing, and verify that labware groups are successfully created or deleted

## Changelog

- special case editing labware quantities on the hopper
- fix unit test

## Review requests

- see test plan

## Risk assessment

medium. refactors in such a way that old behavior should not be impacted (assuming correct logic for determining if we're adding to a hopper)