### PR TITLE
chore(release): 8.8.1

### DIFF
--- a/api/buildroot.mk
+++ b/api/buildroot.mk
@@ -5,9 +5,10 @@
 ################################################################################
 include $(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)/scripts/python.mk
 
+OT_PYTHON := python3
 
 define OTAPI_CALL_PBU
-	$(shell python $(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)/scripts/python_build_utils.py api $(or $(OPENTRONS_PROJECT),robot-stack) $(1))
+	$(shell python3 $(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)/scripts/python_build_utils.py api $(or $(OPENTRONS_PROJECT),robot-stack) $(1))
 endef
 
 PYTHON_OPENTRONS_API_VERSION = $(call OTAPI_CALL_PBU,get_version)

--- a/api/release-notes.md
+++ b/api/release-notes.md
@@ -8,6 +8,10 @@ By installing and using Opentrons software, you agree to the Opentrons End-User 
 
 ---
 
+## Opentrons Robot Software Changes in 8.8.1
+
+The 8.8.1 hotfix release includes a small fix to allow all robots to properly reboot after an upgrade to v8.8.0.
+
 ## Opentrons Robot Software Changes in 8.8.0
 
 Welcome to the v8.8.0 release of the Opentrons robot software! This release includes concurrent module actions, dynamic liquid tracking at the meniscus, and other new features.  

--- a/api/release-notes.md
+++ b/api/release-notes.md
@@ -10,7 +10,9 @@ By installing and using Opentrons software, you agree to the Opentrons End-User 
 
 ## Opentrons Robot Software Changes in 8.8.1
 
-The 8.8.1 hotfix release includes a small fix to allow all robots to properly reboot after an upgrade to v8.8.0.
+The 8.8.1 hotfix release includes a small fix to allow all robots to properly boot after a recent upgrade.
+
+If error recovery was enabled in v8.8.0, installing v8.8.1 allows the robot to properly boot. 
 
 ## Opentrons Robot Software Changes in 8.8.0
 

--- a/app-shell/build/release-notes.md
+++ b/app-shell/build/release-notes.md
@@ -10,7 +10,7 @@ By installing and using Opentrons software, you agree to the Opentrons End-User 
 
 There are no changes to the Opentrons App in v8.8.1.
 
-Installing robot software v8.8.1 allows all robots to properly reboot after a recent upgrade to robot software to v8.8.0.
+Installing robot software v8.8.1 allows all robots to properly boot after a recent upgrade to robot software v8.8.0.
 
 ## Opentrons App Changes in 8.8.0
 

--- a/app-shell/build/release-notes.md
+++ b/app-shell/build/release-notes.md
@@ -6,6 +6,12 @@ log][]. For a list of currently known issues, please see the [Opentrons issue tr
 
 By installing and using Opentrons software, you agree to the Opentrons End-User License Agreement (EULA). You can view the EULA at [opentrons.com/eula](https://opentrons.com/eula).
 
+## Opentrons App Changes in 8.8.1
+
+There are no changes to the Opentrons App in v8.8.1.
+
+Installing robot software v8.8.1 allows all robots to properly reboot after a recent upgrade to robot software to v8.8.0.
+
 ## Opentrons App Changes in 8.8.0
 
 Welcome to the v8.8.0 release of the Opentrons App! This release includes concurrent module actions and other new features, and addresses several bugs.

--- a/hardware/buildroot.mk
+++ b/hardware/buildroot.mk
@@ -5,8 +5,10 @@
 ################################################################################
 include $(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)/scripts/python.mk
 
+OT_PYTHON := python3
+
 define OTHARDWARE_CALL_PBU
-	$(shell python $(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)/scripts/python_build_utils.py hardware $(or $(OPENTRONS_PROJECT),robot-stack) $(1))
+	$(shell python3 $(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)/scripts/python_build_utils.py hardware $(or $(OPENTRONS_PROJECT),robot-stack) $(1))
 endef
 
 PYTHON_OPENTRONS_HARDWARE_VERSION = $(call OTHARDWARE_CALL_PBU,get_version)

--- a/robot-server/buildroot.mk
+++ b/robot-server/buildroot.mk
@@ -4,9 +4,10 @@
 #
 ################################################################################
 include $(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)/scripts/python.mk
+OT_PYTHON := python3
 
 define OTROBOTSERVER_CALL_PBU
-	$(shell python $(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)/scripts/python_build_utils.py robot-server $(or $(OPENTRONS_PROJECT),robot-stack) $(1))
+	$(shell python3 $(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)/scripts/python_build_utils.py robot-server $(or $(OPENTRONS_PROJECT),robot-stack) $(1))
 endef
 
 PYTHON_OPENTRONS_ROBOT_SERVER_VERSION = $(call OTROBOTSERVER_CALL_PBU,get_version)

--- a/robot-server/robot_server/persistence/_migrations/v12_to_v13.py
+++ b/robot-server/robot_server/persistence/_migrations/v12_to_v13.py
@@ -81,7 +81,7 @@ def _migrate_boolean_settings_table(connection: sqlalchemy.engine.Connection) ->
     for table_row in old_boolean_settings:
         connection.execute(
             sqlalchemy.insert(schema_13.boolean_setting_table).values(
-                key=table_row.key, value=table_row.value
+                key=table_row.key.value, value=table_row.value
             )
         )
     new_rows = [

--- a/server-utils/buildroot.mk
+++ b/server-utils/buildroot.mk
@@ -5,8 +5,10 @@
 ################################################################################
 include $(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)/scripts/python.mk
 
+OT_PYTHON := python3
+
 define OTSYSTEMSERVER_CALL_PBU
-	$(shell python $(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)/scripts/python_build_utils.py server-utils $(or $(OPENTRONS_PROJECT),robot-stack) $(1))
+	$(shell python3 $(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)/scripts/python_build_utils.py server-utils $(or $(OPENTRONS_PROJECT),robot-stack) $(1))
 endef
 
 PYTHON_OPENTRONS_SERVER_UTILS_VERSION = $(call OTSYSTEMSERVER_CALL_PBU,get_version)

--- a/shared-data/buildroot.mk
+++ b/shared-data/buildroot.mk
@@ -5,8 +5,10 @@
 ################################################################################
 include $(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)/scripts/python.mk
 
+OT_PYTHON := python3
+
 define OTSHAREDDATA_CALL_PBU
-	$(shell python $(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)/scripts/python_build_utils.py shared-data $(or $(OPENTRONS_PROJECT),robot-stack) $(1))
+	$(shell python3 $(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)/scripts/python_build_utils.py shared-data $(or $(OPENTRONS_PROJECT),robot-stack) $(1))
 endef
 
 PYTHON_OPENTRONS_SHARED_DATA_VERSION = $(call OTSHAREDDATA_CALL_PBU,get_version)

--- a/system-server/buildroot.mk
+++ b/system-server/buildroot.mk
@@ -5,8 +5,10 @@
 ################################################################################
 include $(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)/scripts/python.mk
 
+OT_PYTHON := python3
+
 define OTSYSTEMSERVER_CALL_PBU
-	$(shell python $(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)/scripts/python_build_utils.py system-server $(or $(OPENTRONS_PROJECT),robot-stack) $(1))
+	$(shell python3 $(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)/scripts/python_build_utils.py system-server $(or $(OPENTRONS_PROJECT),robot-stack) $(1))
 endef
 
 PYTHON_OPENTRONS_SYSTEM_SERVER_VERSION = $(call OTSYSTEMSERVER_CALL_PBU,get_version)

--- a/update-server/buildroot.mk
+++ b/update-server/buildroot.mk
@@ -5,8 +5,10 @@
 ################################################################################
 include $(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)/scripts/python.mk
 
+OT_PYTHON := python3
+
 define OTUPDATESERVER_CALL_PBU
-	$(shell python $(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)/scripts/python_build_utils.py update-server $(or $(OPENTRONS_PROJECT),robot-stack) $(1))
+	$(shell python3 $(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)/scripts/python_build_utils.py update-server $(or $(OPENTRONS_PROJECT),robot-stack) $(1))
 endef
 
 PYTHON_OPENTRONS_UPDATE_SERVER_VERSION = $(call OTUPDATESERVER_CALL_PBU,get_version)
@@ -23,7 +25,7 @@ PYTHON_OPENTRONS_UPDATE_SERVER_ENV = \
   HATCH_VCS_TUNABLE_RAW_OPTIONS="$(call hatch_raw_options_for_project,$(PROJECT));root=$(shell realpath --relative-to=$(PYTHON_OPENTRONS_UPDATE_SERVER_BUILDDIR) $(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH))"
 
 define OTUS_DUMP_BR_VERSION
-  $(shell python $(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)/scripts/python_build_utils.py update-server robot-stack dump_br_version)
+  $(shell python3 $(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)/scripts/python_build_utils.py update-server robot-stack dump_br_version)
 endef
 
 define PYTHON_OPENTRONS_UPDATE_SERVER_INSTALL_VERSION


### PR DESCRIPTION
This is the release tracking branch for hotfix 8.8.1, containing a fix to an issue where if a Flex user had previously interacted with the "enable error recovery" setting their robot would not boot after updating to 8.8.0.