### PR TITLE
fix(app): ensure chosen RTP values are respected in useCompatibleAnalysis

### DIFF
--- a/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useCompatibleAnalysis.ts
+++ b/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useCompatibleAnalysis.ts
@@ -10,6 +10,8 @@ import {
   useTrackEvent,
 } from '/app/redux/analytics'
 
+import { getRunTimeParameterDataFromRun } from './utils'
+
 import type { Run } from '@opentrons/api-client'
 import type {
   CompletedProtocolAnalysis,
@@ -58,12 +60,14 @@ export function useCompatibleAnalysis(
   useEffect(() => {
     if (isFlex && mostRecentAnalysis != null && !hasProcessedAnalysis.current) {
       hasProcessedAnalysis.current = true
-
+      const runTimeParameterData =
+        runRecord != null ? getRunTimeParameterDataFromRun(runRecord) : {}
       if (!isLocSeqAnalysisType) {
         createProtocolAnalysis(
           {
             forceReAnalyze: true,
             protocolKey: protocolId,
+            ...runTimeParameterData,
           },
           {
             onSuccess: res => {

--- a/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/utils.ts
+++ b/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/utils.ts
@@ -1,5 +1,10 @@
 import { getPipetteNameSpecs } from '@opentrons/shared-data'
 
+import type {
+  Run,
+  RunTimeParameterFilesCreateData,
+  RunTimeParameterValuesCreateData,
+} from '@opentrons/api-client'
 import type { LoadedPipette } from '@opentrons/shared-data'
 
 // Return the pipetteId for the pipette in the protocol with the highest channel count.
@@ -17,4 +22,49 @@ export function getActivePipetteId(pipettes: LoadedPipette[]): string | null {
         : acc
     }, pipettes[0]).id
   }
+}
+
+interface RunTimeParameterData {
+  runTimeParameterValues?: RunTimeParameterValuesCreateData
+  runTimeParameterFiles?: RunTimeParameterFilesCreateData
+}
+
+export const getRunTimeParameterDataFromRun = (
+  run: Run
+): RunTimeParameterData => {
+  const { data: runData } = run ?? {}
+  const runTimeParameters =
+    runData != null && 'runTimeParameters' in runData
+      ? runData.runTimeParameters
+      : null
+  const runTimeParameterData =
+    runTimeParameters?.reduce<RunTimeParameterData>((acc, rtp) => {
+      const { variableName } = rtp
+      if (rtp.type === 'csv_file') {
+        const id = rtp.file?.id
+        if (id != null) {
+          return 'runTimeParameterFiles' in acc
+            ? {
+                ...acc,
+                runTimeParameterFiles: {
+                  ...acc.runTimeParameterFiles,
+                  [variableName]: id,
+                },
+              }
+            : { ...acc, runTimeParameterFiles: { [variableName]: id } }
+        }
+      } else {
+        return 'runTimeParameterValues' in acc
+          ? {
+              ...acc,
+              runTimeParameterValues: {
+                ...acc.runTimeParameterValues,
+                [variableName]: rtp.value,
+              },
+            }
+          : { ...acc, runTimeParameterValues: { [variableName]: rtp.value } }
+      }
+      return acc
+    }, {}) ?? {}
+  return runTimeParameterData
 }


### PR DESCRIPTION
# Overview

Ensure that a user's RTP selections are passed during a forced re-analysis in `useCompatibleAnalysis`. This condition hits when the most recent analysis's commands do not reflect an LPC-compatible analysis.

Closes AUTH-2692

## Test Plan and Hands on Testing

- upload the protocol mentioned to the ticket
- send the protocol along with updated RTPs (including CSV) to a robot
- verify that there is no `CSV required` analysis error surfaced

## Changelog

- ensure selected RTP values from the run record are supplied during forced reanalysis in `useCompatibleAnalysis`
- create util for building `createProtocolAnalysis` args from the run record

## Review requests

see test plan

## Risk assessment

lowish. avoids sending any RTP values as before if the run record is null or no RTPs are present