### PR TITLE
fix(protocol-designer): fix lid text rendering in StackerContentItem

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/FlexStackerTools/StackerContentItem.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/FlexStackerTools/StackerContentItem.tsx
@@ -20,7 +20,7 @@ export function StackerContentItem(
       <StyledText desktopStyle="bodyDefaultRegular">
         {primaryLabwareName}
       </StyledText>
-      {hasLid != null ? (
+      {hasLid ? (
         <StyledText desktopStyle="bodyDefaultRegular">
           {t(
             `step_edit_form.flex_stacker.with_lid.${isTiprack ? 'tiprack' : 'standard'}`


### PR DESCRIPTION
# Overview

Correct check in `StackerContentItem` for rendering the text "with lid"

Closes RQA-5028

## Test Plan and Hands on Testing

- import protocol attached to ticket
- open the stacker step (2)
- verify that the shuttle content item does not specify that there's a lid

## Changelog

fix boolean check for lid in `StackerContentItem`

## Review requests

see test plan

## Risk assessment

teeny