### PR TITLE
chore(js): Use granular Lodash imports and add a lint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -77,6 +77,11 @@ module.exports = {
             message:
               'HTTP hook deprecated. Use the equivalent notification wrapper (useNotifyXYZ).',
           },
+          {
+            name: 'lodash',
+            message:
+              'Use a granular import, like `import isEqual from "lodash/isEqual"`, instead of like `import { isEqual } from "lodash"`',
+          },
         ],
       },
     ],

--- a/app-shell-odd/src/usb.ts
+++ b/app-shell-odd/src/usb.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs'
 import * as fsPromises from 'fs/promises'
 import { join } from 'path'
-import { flatten } from 'lodash'
+import flatten from 'lodash/flatten'
 
 import {
   robotMassStorageDeviceAdded,

--- a/app/src/molecules/Command/Command.tsx
+++ b/app/src/molecules/Command/Command.tsx
@@ -1,4 +1,4 @@
-import { omit } from 'lodash'
+import omit from 'lodash/omit'
 
 import {
   ALIGN_CENTER,

--- a/app/src/molecules/InterventionModal/CategorizedStepContent.stories.tsx
+++ b/app/src/molecules/InterventionModal/CategorizedStepContent.stories.tsx
@@ -1,4 +1,4 @@
-import { uniq } from 'lodash'
+import uniq from 'lodash/uniq'
 import { css } from 'styled-components'
 
 import { BORDERS, Box, RESPONSIVENESS } from '@opentrons/components'

--- a/app/src/organisms/LegacyLabwarePositionCheck/utils/getProbeBasedLPCSteps.ts
+++ b/app/src/organisms/LegacyLabwarePositionCheck/utils/getProbeBasedLPCSteps.ts
@@ -1,4 +1,4 @@
-import { isEqual } from 'lodash'
+import isEqual from 'lodash/isEqual'
 
 import { getLabwareDefinitionsFromCommands } from '@opentrons/components'
 import { getLabwareDefURI, getPipetteNameSpecs } from '@opentrons/shared-data'

--- a/app/src/organisms/LegacyLabwarePositionCheck/utils/getTipBasedLPCSteps.ts
+++ b/app/src/organisms/LegacyLabwarePositionCheck/utils/getTipBasedLPCSteps.ts
@@ -1,4 +1,4 @@
-import { isEqual } from 'lodash'
+import isEqual from 'lodash/isEqual'
 
 import { getLabwareDefinitionsFromCommands } from '@opentrons/components'
 import {

--- a/app/src/redux/networking/selectors.ts
+++ b/app/src/redux/networking/selectors.ts
@@ -5,7 +5,6 @@ import { createSelector } from 'reselect'
 
 import { INTERFACE_ETHERNET, INTERFACE_WIFI } from './constants'
 
-import type { Dictionary } from 'lodash'
 import type { State } from '../types'
 import type * as Types from './types'
 
@@ -23,7 +22,7 @@ export const getNetworkInterfaces: (
   (state: State, robotName: string) => state.networking[robotName]?.interfaces,
   interfaces => {
     const simpleIfaces = map(
-      interfaces as Dictionary<Types.InterfaceStatus>,
+      interfaces as Record<string, Types.InterfaceStatus>,
       (iface: Types.InterfaceStatus): Types.SimpleInterfaceStatus => {
         const { ipAddress: ipWithMask, macAddress, type } = iface
         let ipAddress: string | null = null

--- a/opentrons-ai-client/src/components/organisms/LabwareModal/index.tsx
+++ b/opentrons-ai-client/src/components/organisms/LabwareModal/index.tsx
@@ -2,7 +2,7 @@ import { Fragment, useEffect, useMemo, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useFormContext } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
-import { reduce } from 'lodash'
+import reduce from 'lodash/reduce'
 
 import {
   DIRECTION_COLUMN,

--- a/opentrons-ai-client/src/resources/utils/labware.ts
+++ b/opentrons-ai-client/src/resources/utils/labware.ts
@@ -1,4 +1,4 @@
-import { groupBy } from 'lodash'
+import groupBy from 'lodash/groupBy'
 
 import {
   getAllDefinitions as _getAllDefinitions,

--- a/protocol-designer/src/components/organisms/TipPositionModal/hooks/usePositionReference.tsx
+++ b/protocol-designer/src/components/organisms/TipPositionModal/hooks/usePositionReference.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { round } from 'lodash'
+import round from 'lodash/round'
 
 import { DropdownMenu } from '@opentrons/components'
 import {

--- a/protocol-designer/src/load-file/migration/8_9_0.ts
+++ b/protocol-designer/src/load-file/migration/8_9_0.ts
@@ -1,5 +1,5 @@
 import { produce } from 'immer'
-import { pickBy } from 'lodash'
+import pickBy from 'lodash/pickBy'
 
 import { uuid } from '/protocol-designer/utils'
 

--- a/react-api-client/src/runs/useRunQuery.ts
+++ b/react-api-client/src/runs/useRunQuery.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react'
 import { useQuery, useQueryClient } from 'react-query'
-import { some } from 'lodash'
+import some from 'lodash/some'
 
 import { getRun } from '@opentrons/api-client'
 

--- a/shared-data/js/__tests__/protocolValidation.test.ts
+++ b/shared-data/js/__tests__/protocolValidation.test.ts
@@ -2,7 +2,7 @@
  * ensures that our protocol schemas are correct */
 import path from 'path'
 import glob from 'glob'
-import { omit } from 'lodash'
+import omit from 'lodash/omit'
 import { describe, expect, it } from 'vitest'
 
 import { validate } from '../protocols'

--- a/shared-data/js/helpers/deckConfiguration/getFixtureFrom.ts
+++ b/shared-data/js/helpers/deckConfiguration/getFixtureFrom.ts
@@ -1,4 +1,4 @@
-import { isEqual } from 'lodash'
+import isEqual from 'lodash/isEqual'
 
 import { getCutoutIdForSlotName, getDeckDefFromRobotType } from '..'
 import {

--- a/shared-data/js/helpers/getMaxPushOutVolume.ts
+++ b/shared-data/js/helpers/getMaxPushOutVolume.ts
@@ -1,4 +1,4 @@
-import { round } from 'lodash'
+import round from 'lodash/round'
 
 import type { PipetteV2Specs } from '../types'
 


### PR DESCRIPTION
## Overview

We prefer granular Lodash imports like `import foo from 'lodash/foo'` over ones like `import { foo } from 'lodash'`, because the former is more bundle-size-friendly. I make this mistake frequently, but it turns out that we can add a lint rule to prevent it.

This PR adds the lint rule and fixes the handful of violations.

## Risk assessment

Very low.