### PR TITLE
chore(release): Merge chore_release-pd-8.8.0 back into edge

### DIFF
--- a/protocol-designer/src/components/molecules/InputStepFormField/index.tsx
+++ b/protocol-designer/src/components/molecules/InputStepFormField/index.tsx
@@ -44,6 +44,13 @@ export function InputStepFormField(
     fillQuantityLocalState,
     ...otherProps
   } = props
+  const verifiedValue: string | number | null =
+    fillQuantityLocalState ??
+    (Array.isArray(value)
+      ? value.length
+      : typeof value === 'string' || typeof value === 'number'
+        ? value
+        : null)
   const { t } = useTranslation('tooltip')
   return (
     <Flex padding={padding} width="100%">
@@ -72,12 +79,7 @@ export function InputStepFormField(
             setIsPristine(false)
           }
         }}
-        value={
-          fillQuantityLocalState ??
-          (typeof value === 'string' || Array.isArray(value)
-            ? value.length
-            : null)
-        }
+        value={verifiedValue}
         units={units}
         placeholder={placeholder}
       />

--- a/protocol-designer/src/components/organisms/AssignLiquidsModal/__tests__/AssignLiquidsModal.test.tsx
+++ b/protocol-designer/src/components/organisms/AssignLiquidsModal/__tests__/AssignLiquidsModal.test.tsx
@@ -2,6 +2,7 @@ import { screen } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { fixture96Plate } from '@opentrons/shared-data'
+import { HOPPER_STACKER_LOCATION } from '@opentrons/step-generation'
 
 import { renderWithProviders } from '/protocol-designer/__testing-utils__'
 import { i18n } from '/protocol-designer/assets/localization'
@@ -102,6 +103,7 @@ describe('AssignLiquidsModal', () => {
 
   it('loads the modal with selectable labware', () => {
     props.assignLiquidsModalData.labware.mockLabwareId.stack = [
+      HOPPER_STACKER_LOCATION,
       'mockLabwareId',
       'labware2',
     ]
@@ -112,5 +114,17 @@ describe('AssignLiquidsModal', () => {
     render(props)
 
     screen.getByText('mock LabwareStackToolbox')
+  })
+
+  it('does not load the labware toolbox if the labware is not on the hopper', () => {
+    props.assignLiquidsModalData.labware.mockLabwareId.stack = [
+      'mockLabwareId',
+      'labware2',
+    ]
+    render(props)
+
+    expect(
+      screen.queryByText('mock LabwareStackToolbox')
+    ).not.toBeInTheDocument()
   })
 })

--- a/protocol-designer/src/components/organisms/AssignLiquidsModal/index.tsx
+++ b/protocol-designer/src/components/organisms/AssignLiquidsModal/index.tsx
@@ -24,6 +24,7 @@ import {
 } from '@opentrons/components'
 import {
   getSlotInLocationStack,
+  HOPPER_STACKER_LOCATION,
   wellFillFromWellContents,
 } from '@opentrons/step-generation'
 
@@ -131,6 +132,8 @@ export function AssignLiquidsModal(
     ),
   }
 
+  const labwareIsOnHopper = labwareStack.includes(HOPPER_STACKER_LOCATION)
+
   return (
     <Flex
       height={`calc(100vh - ${NAV_BAR_HEIGHT_REM}rem)`}
@@ -139,7 +142,7 @@ export function AssignLiquidsModal(
       position={POSITION_RELATIVE}
     >
       <Flex width="100%" overflow={OVERFLOW_AUTO} padding={SPACING.spacing16}>
-        {labwareStack.length > 1 ? (
+        {labwareIsOnHopper && labwareStack.length > 1 ? (
           <LabwareStackToolboxContainer
             setShowLiquidLayoutOverlay={setShowLiquidLayoutOverlay}
             selectedLabwareIds={selectedLabwareIds}

--- a/protocol-designer/src/components/organisms/EditLabwareQuantityModal/__tests__/EditLabwareQuantityModal.test.tsx
+++ b/protocol-designer/src/components/organisms/EditLabwareQuantityModal/__tests__/EditLabwareQuantityModal.test.tsx
@@ -10,12 +10,16 @@ import {
   createContainer,
   deleteContainer,
 } from '/protocol-designer/labware-ingred/actions'
-import { getLabwareEntities } from '/protocol-designer/step-forms/selectors'
+import {
+  getInitialDeckSetup,
+  getLabwareEntities,
+} from '/protocol-designer/step-forms/selectors'
 
 import { EditLabwareQuantityModal } from '..'
 
 import type { ComponentProps } from 'react'
 import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { AllTemporalPropertiesForTimelineFrame } from '/protocol-designer/step-forms'
 
 vi.mock('/protocol-designer/labware-ingred/actions')
 vi.mock('/protocol-designer/step-forms/selectors')
@@ -49,6 +53,7 @@ describe('EditLabwareQuantityModal', () => {
       labwareId: 'mockId',
       allLabwareIdsOnStack: ['mockId'],
       isOnHopper: false,
+      location: 'A1',
     }
     vi.mocked(getLabwareEntities).mockReturnValue({
       mockId: labwareEntity1,
@@ -56,6 +61,9 @@ describe('EditLabwareQuantityModal', () => {
     vi.mocked(getLabwareDefsByURI).mockReturnValue({
       mockURI: { ...fixture96Plate, stackLimit: 3 } as LabwareDefinition2,
     })
+    vi.mocked(getInitialDeckSetup).mockReturnValue({
+      modules: {},
+    } as AllTemporalPropertiesForTimelineFrame)
   })
 
   it('renders the text and changes the quantity to 2', () => {

--- a/protocol-designer/src/components/organisms/EditLabwareQuantityModal/index.tsx
+++ b/protocol-designer/src/components/organisms/EditLabwareQuantityModal/index.tsx
@@ -15,7 +15,13 @@ import {
   SPACING,
   StyledText,
 } from '@opentrons/components'
-import { FLEX_STACKER_MODULE_V1, getMaxPoolCount } from '@opentrons/shared-data'
+import {
+  FLEX_STACKER_MODULE_TYPE,
+  FLEX_STACKER_MODULE_V1,
+  getIsLid,
+  getMaxPoolCount,
+} from '@opentrons/shared-data'
+import { FAKE_HOPPER_LOCATION_MAP } from '@opentrons/step-generation'
 
 import { HandleEnter } from '/protocol-designer/components/atoms'
 import { getLabwareDefsByURI } from '/protocol-designer/labware-defs/selectors'
@@ -23,11 +29,20 @@ import {
   createContainer,
   deleteContainer,
 } from '/protocol-designer/labware-ingred/actions'
-import { getLabwareEntities } from '/protocol-designer/step-forms/selectors'
+import { updateStackerModuleState } from '/protocol-designer/step-forms/actions'
+import { createContainerAboveModule } from '/protocol-designer/step-forms/actions/thunks'
+import {
+  getInitialDeckSetup,
+  getLabwareEntities,
+} from '/protocol-designer/step-forms/selectors'
 import { maskToPositiveInteger } from '/protocol-designer/steplist/fieldLevel/processing'
 
 import { getMainPagePortalEl } from '../Portal'
 
+import type {
+  FlexStackerModuleState,
+  HopperLocationMapKey,
+} from '@opentrons/step-generation'
 import type { ThunkDispatch } from '/protocol-designer/types'
 
 interface EditLabwareQuantityModalProps {
@@ -35,20 +50,22 @@ interface EditLabwareQuantityModalProps {
   labwareId: string
   onClose: () => void
   isOnHopper: boolean
+  location: string
 }
 export function EditLabwareQuantityModal(
   props: EditLabwareQuantityModalProps
 ): JSX.Element {
-  const { onClose, allLabwareIdsOnStack, labwareId, isOnHopper } = props
+  const { onClose, allLabwareIdsOnStack, labwareId, isOnHopper, location } =
+    props
   const { t } = useTranslation(['starting_deck_state', 'shared'])
   const dispatch = useDispatch<ThunkDispatch<any>>()
   const labwareEntities = useSelector(getLabwareEntities)
   const labwareDefsByUri = useSelector(getLabwareDefsByURI)
+  const { modules } = useSelector(getInitialDeckSetup)
   const { labwareDefURI, def } = labwareEntities[labwareId]
   const labwareOfPrimaryURIOnStack = allLabwareIdsOnStack.filter(id =>
     id.includes(labwareDefURI)
   )
-  const initialQuantity = labwareOfPrimaryURIOnStack.length
   const labwareDefURIsInStack = new Set(
     allLabwareIdsOnStack.map(
       labwareId => labwareEntities[labwareId].labwareDefURI
@@ -59,9 +76,79 @@ export function EditLabwareQuantityModal(
   const labwareDefinitionsInGroup = labwareDefURIsInStackArray.map(
     uri => labwareDefsByUri[uri]
   )
-  const lidDefinition = labwareDefinitionsInGroup.find(def =>
-    def.allowedRoles?.includes('lid')
-  )
+  const lidDefinition = labwareDefinitionsInGroup.find(def => getIsLid(def))
+
+  const [stackerId, stackerModule] =
+    Object.entries(modules).find(
+      ([_, { slot, moduleState }]) =>
+        slot === FAKE_HOPPER_LOCATION_MAP[location as HopperLocationMapKey] &&
+        moduleState.type === FLEX_STACKER_MODULE_TYPE
+    ) ?? []
+  const stackerSlot = FAKE_HOPPER_LOCATION_MAP[location as HopperLocationMapKey]
+  const stackerModuleState =
+    stackerModule?.moduleState as FlexStackerModuleState
+  const initialQuantity =
+    stackerModuleState != null
+      ? (stackerModuleState.labwareInHopper?.length ?? 1)
+      : labwareOfPrimaryURIOnStack.length
+
+  const handleHopperQuantityUpdate = (newQuantity: number): void => {
+    // slice from bottom up, up to the new quantity
+    const { storedLabwareDetails, labwareInHopper } = stackerModuleState
+    if (
+      stackerId != null &&
+      stackerModuleState != null &&
+      storedLabwareDetails != null &&
+      labwareInHopper != null
+    ) {
+      const initialGroupsInHopperQuantity = labwareInHopper.length
+      if (newQuantity < initialGroupsInHopperQuantity) {
+        const newLabwareInHopper = labwareInHopper.slice(0, newQuantity)
+        dispatch(
+          updateStackerModuleState({
+            moduleId: stackerId,
+            moduleState: {
+              ...stackerModuleState,
+              labwareInHopper: newLabwareInHopper,
+            },
+          })
+        )
+        // delete the labwares
+        const groupsToDelete = labwareInHopper.slice(
+          newQuantity,
+          initialGroupsInHopperQuantity
+        )
+        for (const group of groupsToDelete) {
+          for (const id of Object.values(group)) {
+            if (id != null) {
+              dispatch(
+                deleteContainer({
+                  labwareId: id,
+                })
+              )
+            }
+          }
+        }
+      } else if (newQuantity > initialGroupsInHopperQuantity) {
+        const quantityToAdd = newQuantity - initialGroupsInHopperQuantity
+        dispatch(
+          createContainerAboveModule({
+            slot: stackerSlot,
+            labwareDefURIGroup: {
+              adapterDefURI: storedLabwareDetails.adapterLabwareURI ?? null,
+              topLabwareDefURI: storedLabwareDetails.primaryLabwareURI,
+              lidDefURI: storedLabwareDetails.lidLabwareURI ?? null,
+            },
+            stackerInfo: {
+              stackerPosition: 'hopper',
+              amount: quantityToAdd,
+            },
+          })
+        )
+      }
+    }
+  }
+
   const stackingLimit = isOnHopper
     ? getMaxPoolCount({
         labwareDefinitions: {
@@ -76,32 +163,36 @@ export function EditLabwareQuantityModal(
   const [quantity, setQuantity] = useState<string>(initialQuantity.toString())
   const [showError, setError] = useState<boolean>(false)
   const saveQuantity = (quantity: string): void => {
-    //  delete the full stack above the labwareId in question
-    allLabwareIdsOnStack.forEach(labwareIdStack => {
-      if (labwareIdStack !== labwareId) {
+    if (isOnHopper) {
+      handleHopperQuantityUpdate(parseInt(quantity))
+    } else {
+      //  delete the full stack above the labwareId in question
+      allLabwareIdsOnStack.forEach(labwareIdStack => {
+        if (labwareIdStack !== labwareId) {
+          dispatch(
+            deleteContainer({
+              labwareId: labwareIdStack,
+            })
+          )
+        }
+      })
+      // recreate the stack
+      const count = parseInt(quantity) - 1
+      const arrayOfLabwareDefURI = hasLidInStack
+        ? Array.from({ length: count * 2 }, (_, index) =>
+            index % 2 === 0
+              ? labwareDefURIsInStackArray[0]
+              : labwareDefURIsInStackArray[1]
+          )
+        : Array.from({ length: count }, () => labwareDefURI)
+      if (arrayOfLabwareDefURI.length > 0) {
         dispatch(
-          deleteContainer({
-            labwareId: labwareIdStack,
+          createContainer({
+            labwareDefURIStack: arrayOfLabwareDefURI,
+            slot: labwareId,
           })
         )
       }
-    })
-    // recreate the stack
-    const count = parseInt(quantity) - 1
-    const arrayOfLabwareDefURI = hasLidInStack
-      ? Array.from({ length: count * 2 }, (_, index) =>
-          index % 2 === 0
-            ? labwareDefURIsInStackArray[0]
-            : labwareDefURIsInStackArray[1]
-        )
-      : Array.from({ length: count }, () => labwareDefURI)
-    if (arrayOfLabwareDefURI.length > 0) {
-      dispatch(
-        createContainer({
-          labwareDefURIStack: arrayOfLabwareDefURI,
-          slot: labwareId,
-        })
-      )
     }
     onClose()
   }

--- a/protocol-designer/src/components/organisms/LabwareCard/index.tsx
+++ b/protocol-designer/src/components/organisms/LabwareCard/index.tsx
@@ -112,6 +112,7 @@ export function LabwareCard(props: LabwareCardProps): JSX.Element {
           labwareId={labware.id}
           allLabwareIdsOnStack={filteredStack}
           isOnHopper={isOnHopper}
+          location={location}
         />
       ) : null}
       <Box position={POSITION_RELATIVE}>

--- a/protocol-designer/src/components/organisms/SelectLabwareModal/SelectLabware.tsx
+++ b/protocol-designer/src/components/organisms/SelectLabwareModal/SelectLabware.tsx
@@ -151,10 +151,9 @@ export function SelectLabware(props: SelectLabwareProps): JSX.Element | null {
                     })
 
                     const stackingProps: StackingProps | null =
-                      isLidValid &&
-                      (isOnHopper ||
-                        (stackingLabwareDefUris.length === 1 &&
-                          slot !== 'offDeck'))
+                      isOnHopper ||
+                      (stackingLabwareDefUris.length === 1 &&
+                        slot !== 'offDeck')
                         ? {
                             inputTitle: t('labware_quantity'),
                             errorMessage: t('unsupported_range'),
@@ -178,7 +177,7 @@ export function SelectLabware(props: SelectLabwareProps): JSX.Element | null {
                             }),
                             checked: selectedLidLabware != null,
                             onCheckboxChange:
-                              !isTiprack && isOnHopper
+                              (!isTiprack && isOnHopper) || !isLidValid
                                 ? undefined
                                 : () => {
                                     dispatch(

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/FlexStackerTools/RefillSettings.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/FlexStackerTools/RefillSettings.tsx
@@ -71,6 +71,9 @@ export function RefillSettings(props: RefillSettingsProps): JSX.Element {
     // initialize if saved step form exists
   >(oldGroupQuantity > 0 ? String(oldGroupQuantity) : null)
 
+  const numberOfGroupsInHopper = labwareInHopper?.length ?? 0
+  const maxRefillGroupQuantity = maxPoolCount - numberOfGroupsInHopper
+
   const storedEntityName = storedPrimaryEntity?.def.metadata.displayName
   const isPrimaryTiprack =
     storedPrimaryEntity != null && getIsTiprack(storedPrimaryEntity.def)
@@ -78,10 +81,8 @@ export function RefillSettings(props: RefillSettingsProps): JSX.Element {
   // you can't rely on generating the uuid in the hydrated form
   useEffect(() => {
     const newGroupQuantity = Number(fillQuantityLocalState) ?? 1
-    const numberOfGroupsInHopper = labwareInHopper?.length ?? 0
     const difference = newGroupQuantity - oldGroupQuantity
-    const valueTooHigh =
-      newGroupQuantity > maxPoolCount - numberOfGroupsInHopper
+    const valueTooHigh = newGroupQuantity > maxRefillGroupQuantity
     // Form errors do not have acccess to module state, so this logic is used
     // to clear out the fillLabwareIds value if the quantity entered is too high
     // and raise an error.
@@ -136,7 +137,7 @@ export function RefillSettings(props: RefillSettingsProps): JSX.Element {
             showTooltip={false}
             caption={t(
               'step_edit_form.flex_stacker.fields.fillLabwareIds.caption',
-              { max: maxPoolCount }
+              { max: maxRefillGroupQuantity }
             )}
             type="number"
             padding="0"

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/FlexStackerTools/StackerContentItem.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/FlexStackerTools/StackerContentItem.tsx
@@ -20,7 +20,7 @@ export function StackerContentItem(
       <StyledText desktopStyle="bodyDefaultRegular">
         {primaryLabwareName}
       </StyledText>
-      {hasLid != null ? (
+      {hasLid ? (
         <StyledText desktopStyle="bodyDefaultRegular">
           {t(
             `step_edit_form.flex_stacker.with_lid.${isTiprack ? 'tiprack' : 'standard'}`

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/AddStepButton.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/AddStepButton.tsx
@@ -118,7 +118,7 @@ export function AddStepButton({
     const isStackerInSlot = Object.values(modules).some(
       module =>
         module.type === FLEX_STACKER_MODULE_TYPE &&
-        moduleAtLastState[module.id].slot === slot
+        moduleAtLastState[module.id]?.slot === slot
     )
     return (
       !isInaccessible &&

--- a/shared-data/js/helpers/__tests__/getFlexStackerHardwareProps.test.ts
+++ b/shared-data/js/helpers/__tests__/getFlexStackerHardwareProps.test.ts
@@ -45,7 +45,6 @@ describe('getLabwareOverlapOffset()', () => {
 
   it('should return the labware overlap offset for a given module model', () => {
     const result = getLabwareOverlapOffset(
-      FLEX_STACKER_MODULE_V1,
       mockLabwareDefinition,
       'labware-name'
     )
@@ -53,18 +52,11 @@ describe('getLabwareOverlapOffset()', () => {
   })
 
   it('should console an error if the module model is invalid', () => {
-    const mockConsoleError = vi
-      .spyOn(console, 'error')
-      .mockImplementation(() => {})
     const result = getLabwareOverlapOffset(
-      MAGNETIC_MODULE_V1,
       mockLabwareDefinition,
       'labware-name'
     )
     expect(result).toStrictEqual({ x: 0, y: 0, z: 0 })
-    expect(mockConsoleError).toHaveBeenCalledWith(
-      'Invalid module model for labware overlap offset: magneticModuleV1'
-    )
   })
 })
 

--- a/shared-data/js/helpers/getFlexStackerHardwareProps.ts
+++ b/shared-data/js/helpers/getFlexStackerHardwareProps.ts
@@ -1,6 +1,5 @@
 import { FLEX_STACKER_MODULE_V1 } from '../constants'
 import { getModuleDef } from '../modules'
-import { getLabwareDefURI } from './getLabwareDefURI'
 import { getSchema2Dimensions } from './positionMath'
 
 import type { LabwareDefinition, ModuleModel, Vector3D } from '../types'
@@ -36,38 +35,42 @@ export const getStackerMaxPoolCountByHeight = (
 }
 
 export const getLabwareOverlapOffset = (
-  model: ModuleModel,
   definition: LabwareDefinition,
-  belowLabwareURI: string
+  belowLabwareLoadName: string
 ): Vector3D => {
-  if (model !== FLEX_STACKER_MODULE_V1) {
-    console.error(`Invalid module model for labware overlap offset: ${model}`)
-    return { x: 0, y: 0, z: 0 }
-  }
   return (
-    definition.stackingOffsetWithLabware?.[belowLabwareURI] ??
+    definition.stackingOffsetWithLabware?.[belowLabwareLoadName] ??
     definition.stackingOffsetWithLabware?.default ?? { x: 0, y: 0, z: 0 }
   )
 }
 
+/**
+ * Calculates the total height of a stack of labware given their definitions,
+ * ordered from bottom to top. Accounts for stacking overlaps between
+ * consecutive labware pieces according to their definitions.
+ *
+ * @param bottomUpDefinitions - Array of LabwareDefinitions, ordered bottom (first) to top (last)
+ * @returns The total stack height (in mm) as a number.
+ */
 export const getHeightOfLabwareStackFromDefinitions = (
-  definitions: LabwareDefinition[]
+  bottomUpDefinitions: LabwareDefinition[]
 ): number => {
-  if (definitions.length === 0) {
+  if (bottomUpDefinitions.length === 0) {
+    console.warn('bottomUpDefinitions array is empty')
     return 0
   }
-  let total_height = 0.0
-  let upper_def: LabwareDefinition = definitions[0]
-  for (const lower_def of definitions.slice(1)) {
+
+  let lowerDef: LabwareDefinition = bottomUpDefinitions[0]
+  let total_height = getSchema2Dimensions(lowerDef).zDimension
+  for (const upperDef of bottomUpDefinitions.slice(1)) {
     const overlap = getLabwareOverlapOffset(
-      FLEX_STACKER_MODULE_V1,
-      upper_def,
-      lower_def.parameters.loadName
+      upperDef,
+      lowerDef.parameters.loadName
     ).z
-    total_height += getSchema2Dimensions(upper_def).zDimension - overlap
-    upper_def = lower_def
+    total_height += getSchema2Dimensions(upperDef).zDimension - overlap
+    lowerDef = upperDef
   }
-  return total_height + getSchema2Dimensions(upper_def).zDimension
+  return total_height
 }
 
 export const getMaxPoolCount = (args: {
@@ -88,12 +91,10 @@ export const getMaxPoolCount = (args: {
     ...(lid != null ? [lid] : []),
   ])
   const bottomLabwareDefinition = adapter != null ? adapter : primary
-  const bottomLabwareURI = getLabwareDefURI(bottomLabwareDefinition)
 
   const poolOverlap = getLabwareOverlapOffset(
-    model,
     topDefinition,
-    bottomLabwareURI
+    bottomLabwareDefinition.parameters.loadName
   )
   return getStackerMaxPoolCountByHeight(model, poolHeight, poolOverlap.z)
 }

--- a/step-generation/src/commandCreators/atomic/__tests__/flexStackerEmpty.test.ts
+++ b/step-generation/src/commandCreators/atomic/__tests__/flexStackerEmpty.test.ts
@@ -20,7 +20,6 @@ import type {
 } from '../../../types'
 
 const moduleId = 'flexStackerId'
-const gripperId = 'gripperId'
 vi.mock('../../../robotStateSelectors')
 
 describe('flexStackerEmpty', () => {
@@ -33,9 +32,6 @@ describe('flexStackerEmpty', () => {
       type: FLEX_STACKER_MODULE_TYPE,
       model: FLEX_STACKER_MODULE_V1,
       pythonName: 'mock_flex_stacker_1',
-    }
-    invariantContext.gripperEntities[gripperId] = {
-      id: gripperId,
     }
 
     robotState = getInitialRobotStateStandard(invariantContext)
@@ -92,21 +88,6 @@ describe('flexStackerEmpty', () => {
     expect(getErrorResult(result).errors).toHaveLength(1)
     expect(getErrorResult(result).errors[0]).toMatchObject({
       type: 'MISSING_MODULE',
-    })
-  })
-  it('creates returns error if no gripper', () => {
-    invariantContext.gripperEntities = {}
-    const result = flexStackerEmpty(
-      {
-        moduleId,
-        strategy: 'logical',
-      },
-      invariantContext,
-      robotState
-    )
-    expect(getErrorResult(result).errors).toHaveLength(1)
-    expect(getErrorResult(result).errors[0]).toMatchObject({
-      type: 'FLEX_STACKER_NO_GRIPPER',
     })
   })
 })

--- a/step-generation/src/commandCreators/atomic/flexStackerEmpty.ts
+++ b/step-generation/src/commandCreators/atomic/flexStackerEmpty.ts
@@ -8,18 +8,14 @@ import type { CommandCreator, CommandCreatorError } from '../../types'
 export const flexStackerEmpty: CommandCreator<
   FlexStackerEmptyCreateCommand['params']
 > = (args, invariantContext, prevRobotState) => {
-  const { gripperEntities, moduleEntities } = invariantContext
+  const { moduleEntities } = invariantContext
   const flexStackerState = flexStackerStateGetter(prevRobotState, args.moduleId)
-  const hasGripperEntity = Object.keys(gripperEntities).length > 0
 
   const errors: CommandCreatorError[] = []
   if (args.moduleId == null || flexStackerState == null) {
     errors.push(errorCreators.missingModuleError())
   }
 
-  if (!hasGripperEntity) {
-    errors.push(errorCreators.flexStackerNoGripper())
-  }
   if (errors.length > 0) {
     return { errors }
   }

--- a/step-generation/src/utils/misc.ts
+++ b/step-generation/src/utils/misc.ts
@@ -1429,6 +1429,10 @@ export const labwareMatchesLabwareInHopper = (
   invariantContext: InvariantContext,
   stackerState: FlexStackerModuleState | null
 ): boolean => {
+  // permissive if no stored labware details configured
+  if (stackerState?.storedLabwareDetails == null) {
+    return true
+  }
   const storedLabwareURIs = Object.values(
     stackerState?.storedLabwareDetails ?? {}
   ).reduce<string[]>((acc, val) => {


### PR DESCRIPTION
This brings the fixes in `chore_release-pd-8.8.0` so far back into `edge`. Notably, this includes #20540, which we need to unblock testing of concurrent module actions in `edge`.

No merge conflicts.
