### PR TITLE
fix(protocol-designer): fix edit copy for on-deck non-lid labware

### DIFF
--- a/protocol-designer/src/components/organisms/LabwareCard/__tests__/LabwareCard.test.tsx
+++ b/protocol-designer/src/components/organisms/LabwareCard/__tests__/LabwareCard.test.tsx
@@ -128,18 +128,6 @@ describe('LabwareCard', () => {
     render(props)
     screen.getByText('1 liquid')
   })
-  it('renders a labware card with the quantity tag', () => {
-    props.quantity = 2
-    props.labware = {
-      ...props.labware,
-      def: { ...fixture96Plate, stackLimit: 4 } as LabwareDefinition2,
-    }
-    render(props)
-    screen.getByText('mock NickName')
-    screen.getByText('ANSI 96 Standard Microplate')
-    screen.getByText('Quantity: 2')
-    screen.getByText('Edit liquid and quantity')
-  })
   it('renders a labware card with edit quantity copy and pressing button renders modal', () => {
     props.labware = {
       ...props.labware,

--- a/protocol-designer/src/components/organisms/LabwareCard/index.tsx
+++ b/protocol-designer/src/components/organisms/LabwareCard/index.tsx
@@ -34,6 +34,7 @@ import { getLabwareNicknamesById } from '/protocol-designer/ui/labware/selectors
 
 import { EditLabwareQuantityModal } from '../EditLabwareQuantityModal'
 import { LabwareCardOverflowMenu } from '../LabwareCardOverflowMenu'
+import { getCanModifyLabwareQuantity } from './utils'
 
 import type { LabwareOnDeck } from '/protocol-designer/step-forms'
 import type { ThunkDispatch } from '/protocol-designer/types'
@@ -79,8 +80,8 @@ export function LabwareCard(props: LabwareCardProps): JSX.Element {
   const isLid = def.allowedRoles?.includes('lid')
   const isNicknameDifferent = nickName !== displayName
   const liquidIds = getLiquidIdsOnLabware(wellContents)
-  const canModifyQuantity =
-    isOnHopper || (def.stackLimit != null && def.stackLimit > 1)
+
+  const canModifyQuantity = getCanModifyLabwareQuantity(def, isOnHopper)
 
   let editButton: null | string = null
   if (

--- a/protocol-designer/src/components/organisms/LabwareCard/utils.ts
+++ b/protocol-designer/src/components/organisms/LabwareCard/utils.ts
@@ -1,0 +1,20 @@
+import { getIsLid } from '@opentrons/shared-data'
+
+import type { LabwareDefinition } from '@opentrons/shared-data'
+
+/**
+ * Returns whether the quantity of the specified labware can be modified.
+ *
+ * Quantity can be modified if the labware is a lid (as determined by its definition),
+ * or if the labware is placed on the hopper.
+ * In the future, we will allow stacking certain labware directly on the deck
+ *
+ * @param labwareDef - The labware definition.
+ * @param isOnHopper - True if the labware is on the hopper, otherwise false.
+ * @returns True if the labware quantity can be modified, otherwise false.
+ */
+
+export const getCanModifyLabwareQuantity = (
+  labwareDef: LabwareDefinition,
+  isOnHopper: boolean
+): boolean => getIsLid(labwareDef) || isOnHopper


### PR DESCRIPTION
# Overview

Fix the logic for the copy for editing a non-lid labware on the deck. For these labware, we do not allow editing quantity, so the copy should reflect that ("Edit quantity and liquid" => "Edit liquid")

Closes RQA-5026

## Test Plan and Hands on Testing

- import protocol attached to the ticket
- click an on-deck wellplate => edit labware
- verify that the edit copy reads "Edit liquid" rather than "Edit liquid and quantity"

## Changelog

- create util for getting if a labware's quantity is editable
- wire up in `LabwareCard`

## Review requests

see test plan

## Risk assessment

low