### PR TITLE
fix(protocol-designer): lid text color in stacker content item card

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/FlexStackerTools/StackerContentItem.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/FlexStackerTools/StackerContentItem.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next'
 
-import { ListItem, StyledText, Tag } from '@opentrons/components'
+import { COLORS, ListItem, StyledText, Tag } from '@opentrons/components'
 
 import styles from './flexstackertools.module.css'
 
@@ -21,7 +21,7 @@ export function StackerContentItem(
         {primaryLabwareName}
       </StyledText>
       {hasLid ? (
-        <StyledText desktopStyle="bodyDefaultRegular">
+        <StyledText desktopStyle="bodyDefaultRegular" color={COLORS.grey60}>
           {t(
             `step_edit_form.flex_stacker.with_lid.${isTiprack ? 'tiprack' : 'standard'}`
           )}


### PR DESCRIPTION
# Overview

Fixes lid text color to address RQA-5040

## Test Plan and Hands on Testing

smoke tested using protocol in ticket and testing with opentrons tip rack

https://github.com/user-attachments/assets/1b9b034f-7142-4193-a55e-5a81cf4e93e3

## Changelog

- added color to lid text
