### PR TITLE
chore(release): Merge back 'chore_release-8.8.1' into 'chore_release-pd-8.8.0'

### DIFF
--- a/robot-server/robot_server/persistence/_migrations/v12_to_v13.py
+++ b/robot-server/robot_server/persistence/_migrations/v12_to_v13.py
@@ -81,7 +81,7 @@ def _migrate_boolean_settings_table(connection: sqlalchemy.engine.Connection) ->
     for table_row in old_boolean_settings:
         connection.execute(
             sqlalchemy.insert(schema_13.boolean_setting_table).values(
-                key=table_row.key, value=table_row.value
+                key=table_row.key.value, value=table_row.value
             )
         )
     new_rows = [


### PR DESCRIPTION
We just made a hotfix to the Robot Stack.

I'm propagating the change into PD 8.8.0 (this PR) so that PD sees the latest Robot Stack release, and then into `edge` (next PR).