### PR TITLE
fix(protocol-designer): special casing for stacker step highlights

### DIFF
--- a/protocol-designer/src/pages/Designer/DeckSetup/HighlightItems.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/HighlightItems.tsx
@@ -164,7 +164,8 @@ export function HighlightItems(props: HighlightItemsProps): JSX.Element | null {
 
   const moduleItems = highlightItems.highlightModuleItems.reduce<JSX.Element[]>(
     (acc, { module: moduleOnDeck, selection, isSelected = false }) => {
-      const { text } = selection
+      let text = ''
+
       if (moduleOnDeck == null) {
         return acc
       }
@@ -176,6 +177,11 @@ export function HighlightItems(props: HighlightItemsProps): JSX.Element | null {
 
       const stepType: FlexStackerFormType | null =
         currentStep?.flexStackerFormType ?? null
+      if (stepType != null) {
+        text = stepType.charAt(0).toUpperCase() + stepType.slice(1)
+      } else {
+        text = selection.text ?? ''
+      }
       const onHopperActions =
         stepType != null &&
         (FLEX_STACKER_IN_HOPPER_ACTIONS as string[]).includes(stepType)

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/index.tsx
@@ -140,16 +140,16 @@ export function ProtocolSteps({
         dispatch(saveProtocolFile())
       },
     })
-
   let currentStep: FormData | null
-  if (hoveredTerminalItem === HARDWARE_ID && selectedStepId != null) {
+  if (formData?.stepType === 'flexStacker') {
+    currentStep = formData
+  } else if (hoveredTerminalItem === HARDWARE_ID && selectedStepId != null) {
     currentStep = savedStepForms[selectedStepId]
   } else if (hoveredTerminalItem === HARDWARE_ID && selectedStepId == null) {
     currentStep = null
   } else {
     currentStep = activeItem?.id != null ? savedStepForms[activeItem.id] : null
   }
-
   const hasTimelineErrors =
     timelineErrors != null ? timelineErrors.length > 0 : false
   const showTimelineAlerts =


### PR DESCRIPTION
# Overview

Highlight parts of the stacker regardless of if the step has been saved


## Test Plan and Hands on Testing

smoke tested: 

https://github.com/user-attachments/assets/e1c2be9a-3c73-43c5-bb60-ab62770ad83d


## Changelog
- special cased the currentStep  / text to use the unsavedStep when the stepType is `flexStacker`

## Review requests
- better way to do this than special casing?

## Risk assessment
low

Closes RQA-5036 & RQA-5034 & RQA-5030