### PR TITLE
fix(protocol-designer): fix labware stack logic in LabwareToolbox

### DIFF
--- a/protocol-designer/src/components/organisms/AssignLiquidsModal/LabwareToolbox.tsx
+++ b/protocol-designer/src/components/organisms/AssignLiquidsModal/LabwareToolbox.tsx
@@ -14,22 +14,30 @@ import {
 } from '@opentrons/components'
 import { FLEX_STACKER_MODULE_V1, getMaxPoolCount } from '@opentrons/shared-data'
 import {
+  getFullStackFromLabwares,
   getLargestStackInSlot,
   getSlotInLocationStack,
 } from '@opentrons/step-generation'
 
 import { getInitialRobotState } from '/protocol-designer/file-data/selectors'
+import { getLabwareDefsByURI } from '/protocol-designer/labware-defs/selectors'
 import {
   createContainer,
   multipleIngredientsSelector,
   openIngredientSelector,
 } from '/protocol-designer/labware-ingred/actions'
 import { selectors as labwareIngredSelectors } from '/protocol-designer/labware-ingred/selectors'
+import { createContainerAboveModule } from '/protocol-designer/step-forms/actions/thunks'
 import { getInitialDeckSetup } from '/protocol-designer/step-forms/selectors'
 
 import { LabwareButtonBasket } from '../../molecules'
 import { useKitchen } from '../Kitchen/useKitchen'
 import styles from './labwareToolbox.module.css'
+import {
+  getStackerModuleStateFromSlot,
+  getStackLimitFromDef,
+  getTopDownPrimaryLabwareInHopper,
+} from './utils'
 
 import type { Dispatch, SetStateAction } from 'react'
 import type { LabwareLiquidState } from '@opentrons/step-generation'
@@ -59,43 +67,86 @@ interface LabwareStackToolboxProps {
   setShowLiquidLayoutOverlay: Dispatch<SetStateAction<boolean>>
   data: LabwareStackToolboxData
   selectedLabwareIds: string[]
+  slot: string
 }
 export function LabwareStackToolbox({
   setShowLiquidLayoutOverlay,
   data,
   selectedLabwareIds,
-}: LabwareStackToolboxProps): JSX.Element {
+  slot,
+}: LabwareStackToolboxProps): JSX.Element | null {
   const { t } = useTranslation(['liquids', 'form', 'shared'])
   const dispatch = useDispatch<ThunkDispatch<any>>()
   const { makeSnackbar } = useKitchen()
+  const labwareDefsByURI = useSelector(getLabwareDefsByURI)
 
-  const { labware, labwareId, liquidLocations, largestStackInSlot } = data
+  const { labware, labwareId, liquidLocations } = data
+  const { modules } = useSelector(getInitialDeckSetup)
 
-  const filteredLabwareStack = largestStackInSlot.filter(
-    id => labware[id] != null
-  )
+  if (labwareId == null) {
+    console.error('No labware ID found for LabwareStackToolbox')
+    return null
+  }
 
-  const hopperStackLimit =
-    labwareId != null
-      ? getMaxPoolCount({
-          labwareDefinitions: {
-            primary: labware[labwareId].def,
-            adapter: null,
-            lid: null,
-          },
-          model: FLEX_STACKER_MODULE_V1,
-        })
-      : 0
+  const stackerModuleState = getStackerModuleStateFromSlot({ slot, modules })
+  let stackLimit: number = 0
+  let topDownStackIds: string[] = []
+
+  // for hopper primary labware
+  if (stackerModuleState != null) {
+    const { storedLabwareDetails } = stackerModuleState ?? {}
+    stackLimit = getMaxPoolCount({
+      labwareDefinitions: {
+        primary:
+          labwareDefsByURI[storedLabwareDetails?.primaryLabwareURI ?? ''],
+        adapter:
+          labwareDefsByURI[storedLabwareDetails?.adapterLabwareURI ?? ''] ??
+          null,
+        lid:
+          labwareDefsByURI[storedLabwareDetails?.lidLabwareURI ?? ''] ?? null,
+      },
+      model: FLEX_STACKER_MODULE_V1,
+    })
+    topDownStackIds = getTopDownPrimaryLabwareInHopper({
+      slot,
+      modules,
+    })
+    // for on-deck labware
+  } else if (labwareId != null && labware[labwareId]?.def != null) {
+    stackLimit = getStackLimitFromDef(labware[labwareId].def)
+    topDownStackIds = getFullStackFromLabwares(labware, labwareId)
+  }
+
   const handleAddAnotherLabware = (): void => {
-    if (filteredLabwareStack.length < hopperStackLimit && labwareId != null) {
-      if (labware[labwareId].labwareDefURI)
+    if (topDownStackIds.length < stackLimit && labwareId != null) {
+      // create labware groups for hopper
+      if (stackerModuleState?.storedLabwareDetails != null) {
+        const { storedLabwareDetails } = stackerModuleState
         dispatch(
-          createContainer({
-            labwareDefURIStack: [labware[labwareId]?.labwareDefURI ?? ''],
-            slot: labwareId,
-            updateSelectedLabwareId: true,
+          createContainerAboveModule({
+            slot,
+            labwareDefURIGroup: {
+              adapterDefURI: storedLabwareDetails.adapterLabwareURI ?? null,
+              topLabwareDefURI: storedLabwareDetails.primaryLabwareURI,
+              lidDefURI: storedLabwareDetails.lidLabwareURI ?? null,
+            },
+            stackerInfo: {
+              stackerPosition: 'hopper',
+              amount: 1,
+            },
           })
         )
+        // add on-deck labware
+      } else {
+        if (labware[labwareId].labwareDefURI)
+          dispatch(
+            createContainer({
+              labwareDefURIStack: [labware[labwareId]?.labwareDefURI ?? ''],
+              slot: labwareId,
+              updateSelectedLabwareId: true,
+            })
+          )
+      }
     } else {
       makeSnackbar(t('no_more_space_in_slot') as string)
     }
@@ -103,7 +154,7 @@ export function LabwareStackToolbox({
 
   const allLabwareLiquidsEqual = (arr: string[]): boolean => {
     const firstValue =
-      liquidLocations != null ? liquidLocations[filteredLabwareStack[0]] : null
+      liquidLocations != null ? liquidLocations[topDownStackIds[0]] : null
 
     if (!firstValue) {
       return true
@@ -116,11 +167,11 @@ export function LabwareStackToolbox({
   }
 
   const handleSelectAllLabware = (): void => {
-    if (!allLabwareLiquidsEqual(filteredLabwareStack)) {
+    if (!allLabwareLiquidsEqual(topDownStackIds)) {
       setShowLiquidLayoutOverlay(true)
       return
     }
-    dispatch(multipleIngredientsSelector(filteredLabwareStack))
+    dispatch(multipleIngredientsSelector(topDownStackIds))
   }
 
   const handleAssignToLabware = (
@@ -178,10 +229,10 @@ export function LabwareStackToolbox({
         </StyledText>
       }
     >
-      {filteredLabwareStack.length > 0 ? (
+      {topDownStackIds.length > 0 ? (
         <div className={styles.container}>
           <LabwareButtonBasket
-            stackOfLabware={filteredLabwareStack}
+            stackOfLabware={topDownStackIds}
             labware={labware}
             setSelectedLabware={handleAssignToLabware}
             selectedLabware={selectedLabwareIds}
@@ -243,6 +294,7 @@ export function LabwareStackToolboxContainer({
       setDefineLiquidModal={setDefineLiquidModal}
       selectedLabwareIds={selectedLabwareIds}
       data={data}
+      slot={slot}
     />
   )
 }

--- a/protocol-designer/src/components/organisms/AssignLiquidsModal/LabwareToolbox.tsx
+++ b/protocol-designer/src/components/organisms/AssignLiquidsModal/LabwareToolbox.tsx
@@ -137,15 +137,14 @@ export function LabwareStackToolbox({
           })
         )
         // add on-deck labware
-      } else {
-        if (labware[labwareId].labwareDefURI)
-          dispatch(
-            createContainer({
-              labwareDefURIStack: [labware[labwareId]?.labwareDefURI ?? ''],
-              slot: labwareId,
-              updateSelectedLabwareId: true,
-            })
-          )
+      } else if (labware[labwareId].labwareDefURI) {
+        dispatch(
+          createContainer({
+            labwareDefURIStack: [labware[labwareId]?.labwareDefURI ?? ''],
+            slot: labwareId,
+            updateSelectedLabwareId: true,
+          })
+        )
       }
     } else {
       makeSnackbar(t('no_more_space_in_slot') as string)

--- a/protocol-designer/src/components/organisms/AssignLiquidsModal/__tests__/LabwareToolBox.test.tsx
+++ b/protocol-designer/src/components/organisms/AssignLiquidsModal/__tests__/LabwareToolBox.test.tsx
@@ -6,6 +6,9 @@ import { fixture96Plate } from '@opentrons/shared-data'
 
 import { renderWithProviders } from '/protocol-designer/__testing-utils__'
 import { i18n } from '/protocol-designer/assets/localization'
+import { useKitchen } from '/protocol-designer/components/organisms/Kitchen/useKitchen'
+import { getLabwareDefsByURI } from '/protocol-designer/labware-defs/selectors'
+import { getInitialDeckSetup } from '/protocol-designer/step-forms/selectors'
 
 import { LabwareStackToolbox } from '../LabwareToolbox'
 
@@ -13,17 +16,15 @@ import type { Mock } from 'vitest'
 import type { ComponentProps } from 'react'
 import type { NavigateFunction } from 'react-router-dom'
 import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { AllTemporalPropertiesForTimelineFrame } from '/protocol-designer/step-forms'
 
 const mockNavigate = vi.fn()
 const mockDispatch = vi.fn()
+const mockMakeSnackbar = vi.fn()
 
-vi.mock('/protocol-designer/step-forms/selectors', async importOriginal => {
-  const actual = (await importOriginal()) as any
-  return {
-    ...actual,
-    getInitialDeckSetup: vi.fn(),
-  }
-})
+vi.mock('/protocol-designer/step-forms/selectors')
+vi.mock('/protocol-designer/labware-defs/selectors')
+vi.mock('/protocol-designer/components/organisms/Kitchen/useKitchen')
 
 vi.mock('react-router-dom', async importOriginal => {
   const actual = await importOriginal<NavigateFunction>()
@@ -52,8 +53,24 @@ describe('LabwareStackToolboxContainer liquids dont match', () => {
   let setShowLiquidLayoutOverlay: Mock
 
   beforeEach(() => {
+    vi.clearAllMocks()
     setShowLiquidLayoutOverlay = vi.fn()
     vi.mocked(useDispatch).mockReturnValue(mockDispatch)
+    vi.mocked(useKitchen).mockReturnValue({
+      makeSnackbar: mockMakeSnackbar,
+      eatToast: vi.fn(),
+      bakeToast: vi.fn(),
+    })
+    vi.mocked(getLabwareDefsByURI).mockReturnValue({
+      mockLabwareDefURI: fixture96Plate as LabwareDefinition2,
+      labwareDefURI: fixture96Plate as LabwareDefinition2,
+    })
+    vi.mocked(getInitialDeckSetup).mockReturnValue({
+      modules: {},
+      labware: {},
+      pipettes: {},
+      additionalEquipmentOnDeck: {},
+    } as AllTemporalPropertiesForTimelineFrame)
     props = {
       showBadFormState: false,
       setShowLiquidLayoutOverlay: setShowLiquidLayoutOverlay,
@@ -89,14 +106,15 @@ describe('LabwareStackToolboxContainer liquids dont match', () => {
       setShowBadFormState: vi.fn(),
       setDefineLiquidModal: vi.fn(),
       selectedLabwareIds: ['mockLabwareId'],
+      slot: 'A2',
     }
-    vi.clearAllMocks()
   })
 
   it('select shows an overlay when liquids dont match', () => {
     render(props)
+    // Click on labware2 (which has no liquids) with ctrl key - should show overlay
     const labwareButton = screen.getByRole('button', {
-      name: '1 ANSI 96 Standard Microplate',
+      name: '2 ANSI 96 Standard Microplate',
     })
     expect(labwareButton).toBeInTheDocument()
     fireEvent.click(labwareButton, { ctrlKey: true })
@@ -106,21 +124,25 @@ describe('LabwareStackToolboxContainer liquids dont match', () => {
   it('selects a single labware when ctrl key is not pressed', () => {
     render(props)
     const labwareButton = screen.getByRole('button', {
-      name: '1 ANSI 96 Standard Microplate',
+      name: '3 ANSI 96 Standard Microplate',
     })
     expect(labwareButton).toBeInTheDocument()
     fireEvent.click(labwareButton)
-    expect(props.selectedLabwareIds).toEqual(['mockLabwareId'])
+    expect(mockDispatch).toHaveBeenCalledWith({
+      payload: ['mockLabwareId'],
+      type: 'OPEN_MULTIPLE_INGREDIENTS_SELECTOR',
+    })
   })
 
   it('selects multiple labware when ctrl key is pressed with different liquids', () => {
     render(props)
+    // Click on labware2 (which has different liquids) with ctrl key - should show overlay
     const labwareButton = screen.getByRole('button', {
-      name: '1 ANSI 96 Standard Microplate',
+      name: '2 ANSI 96 Standard Microplate',
     })
     expect(labwareButton).toBeInTheDocument()
     fireEvent.click(labwareButton, { ctrlKey: true })
-    expect(props.selectedLabwareIds).toEqual(['mockLabwareId'])
+    expect(setShowLiquidLayoutOverlay).toHaveBeenCalledWith(true)
   })
 })
 
@@ -129,8 +151,24 @@ describe('LabwareStackToolboxContainer liquids match', () => {
   let setShowLiquidLayoutOverlay: Mock
 
   beforeEach(() => {
+    vi.clearAllMocks()
     setShowLiquidLayoutOverlay = vi.fn()
     vi.mocked(useDispatch).mockReturnValue(mockDispatch)
+    vi.mocked(useKitchen).mockReturnValue({
+      makeSnackbar: mockMakeSnackbar,
+      eatToast: vi.fn(),
+      bakeToast: vi.fn(),
+    })
+    vi.mocked(getLabwareDefsByURI).mockReturnValue({
+      mockLabwareDefURI: fixture96Plate as LabwareDefinition2,
+      labwareDefURI: fixture96Plate as LabwareDefinition2,
+    })
+    vi.mocked(getInitialDeckSetup).mockReturnValue({
+      modules: {},
+      labware: {},
+      pipettes: {},
+      additionalEquipmentOnDeck: {},
+    } as AllTemporalPropertiesForTimelineFrame)
     props = {
       showBadFormState: false,
       setShowLiquidLayoutOverlay: setShowLiquidLayoutOverlay,
@@ -167,14 +205,21 @@ describe('LabwareStackToolboxContainer liquids match', () => {
               },
             },
           },
+          A2: {
+            A1: {
+              mockGroupId: {
+                volume: 5,
+              },
+            },
+          },
         },
         largestStackInSlot: ['mockLabwareId', 'labware2'],
       },
       setShowBadFormState: vi.fn(),
       setDefineLiquidModal: vi.fn(),
       selectedLabwareIds: ['mockLabwareId'],
+      slot: 'A2',
     }
-    vi.clearAllMocks()
   })
 
   it('select all labware buttons', () => {
@@ -183,7 +228,7 @@ describe('LabwareStackToolboxContainer liquids match', () => {
     expect(allLabwareButton).toBeInTheDocument()
     fireEvent.click(allLabwareButton)
     expect(mockDispatch).toBeCalledWith({
-      payload: ['mockLabwareId', 'labware2'],
+      payload: ['mockLabwareId', 'labware2', 'A2'],
       type: 'OPEN_MULTIPLE_INGREDIENTS_SELECTOR',
     })
   })

--- a/protocol-designer/src/components/organisms/AssignLiquidsModal/utils.ts
+++ b/protocol-designer/src/components/organisms/AssignLiquidsModal/utils.ts
@@ -1,24 +1,34 @@
-import type { ModuleOnDeck } from "/protocol-designer/step-forms";
-import { FLEX_STACKER_MODULE_TYPE, LabwareDefinition } from "@opentrons/shared-data";
-import { FlexStackerModuleState } from "@opentrons/step-generation";
+import { FLEX_STACKER_MODULE_TYPE } from '@opentrons/shared-data'
 
-export const getStackerModuleStateFromSlot = (args: { slot: string; modules: Record<string, ModuleOnDeck> }): FlexStackerModuleState | null => {
-    const { slot, modules } = args
-    const stackerModule =
-      Object.values(modules).find(
-        ({ slot: moduleSlot, moduleState }) =>
-          moduleSlot === slot && moduleState.type === FLEX_STACKER_MODULE_TYPE
-      ) ?? null
-    return stackerModule != null && stackerModule.moduleState.type === FLEX_STACKER_MODULE_TYPE ? stackerModule.moduleState : null
-  }
-  
-  export const getTopDownPrimaryLabwareInHopper = (args: { slot: string; modules: Record<string, ModuleOnDeck> }): string[] => {
-    const { slot, modules } = args
-    const stackerModuleState = getStackerModuleStateFromSlot({ slot, modules })
-    const bottomUpLabwareGroups =
-      stackerModuleState?.labwareInHopper
-      ?? []
-    return bottomUpLabwareGroups.map(group => group.primaryLabwareId).reverse()
-  }
-  
-  export const getStackLimitFromDef = (labwareDef: LabwareDefinition): number => labwareDef.stackLimit ?? 0
+import type { LabwareDefinition } from '@opentrons/shared-data'
+import type { FlexStackerModuleState } from '@opentrons/step-generation'
+import type { ModuleOnDeck } from '/protocol-designer/step-forms'
+
+export const getStackerModuleStateFromSlot = (args: {
+  slot: string
+  modules: Record<string, ModuleOnDeck>
+}): FlexStackerModuleState | null => {
+  const { slot, modules } = args
+  const stackerModule =
+    Object.values(modules).find(
+      ({ slot: moduleSlot, moduleState }) =>
+        moduleSlot === slot && moduleState.type === FLEX_STACKER_MODULE_TYPE
+    ) ?? null
+  return stackerModule != null &&
+    stackerModule.moduleState.type === FLEX_STACKER_MODULE_TYPE
+    ? stackerModule.moduleState
+    : null
+}
+
+export const getTopDownPrimaryLabwareInHopper = (args: {
+  slot: string
+  modules: Record<string, ModuleOnDeck>
+}): string[] => {
+  const { slot, modules } = args
+  const stackerModuleState = getStackerModuleStateFromSlot({ slot, modules })
+  const bottomUpLabwareGroups = stackerModuleState?.labwareInHopper ?? []
+  return bottomUpLabwareGroups.map(group => group.primaryLabwareId).reverse()
+}
+
+export const getStackLimitFromDef = (labwareDef: LabwareDefinition): number =>
+  labwareDef.stackLimit ?? 0

--- a/protocol-designer/src/components/organisms/AssignLiquidsModal/utils.ts
+++ b/protocol-designer/src/components/organisms/AssignLiquidsModal/utils.ts
@@ -1,0 +1,24 @@
+import type { ModuleOnDeck } from "/protocol-designer/step-forms";
+import { FLEX_STACKER_MODULE_TYPE, LabwareDefinition } from "@opentrons/shared-data";
+import { FlexStackerModuleState } from "@opentrons/step-generation";
+
+export const getStackerModuleStateFromSlot = (args: { slot: string; modules: Record<string, ModuleOnDeck> }): FlexStackerModuleState | null => {
+    const { slot, modules } = args
+    const stackerModule =
+      Object.values(modules).find(
+        ({ slot: moduleSlot, moduleState }) =>
+          moduleSlot === slot && moduleState.type === FLEX_STACKER_MODULE_TYPE
+      ) ?? null
+    return stackerModule != null && stackerModule.moduleState.type === FLEX_STACKER_MODULE_TYPE ? stackerModule.moduleState : null
+  }
+  
+  export const getTopDownPrimaryLabwareInHopper = (args: { slot: string; modules: Record<string, ModuleOnDeck> }): string[] => {
+    const { slot, modules } = args
+    const stackerModuleState = getStackerModuleStateFromSlot({ slot, modules })
+    const bottomUpLabwareGroups =
+      stackerModuleState?.labwareInHopper
+      ?? []
+    return bottomUpLabwareGroups.map(group => group.primaryLabwareId).reverse()
+  }
+  
+  export const getStackLimitFromDef = (labwareDef: LabwareDefinition): number => labwareDef.stackLimit ?? 0


### PR DESCRIPTION
# Overview

Ensure we are retrieving the labware stacked in a hopper correctly in LabwareToolbox component. Previously, we relied on the labware's stack temporal property. This is sufficient for labware on the deck, but not sufficient for labware in a stacker hopper.

not scoped in this PR: buggy liquid addition behavior

## Test Plan and Hands on Testing'

- create or import a stacker protocol
- add several wellplates to a hopper
- hover the hopper, select edit labware, and select "Edit liquid and quantity" in the toolbox
- verify that the stack of labware shown reflects the quantity you added to the hopper
- test adding new labware and verify that the stack updates appropriately

## Changelog

- refactor LabwareToolbox to handle stacks in a hopper
- add utils
- edit tests

## Review requests

see test plan

## Risk assessment

lowish