### PR TITLE
style(protocol designer): adjust padding in stacker toolbox + deck setup

### DIFF
--- a/components/src/molecules/CustomizeExpandButton/index.tsx
+++ b/components/src/molecules/CustomizeExpandButton/index.tsx
@@ -101,6 +101,7 @@ export function CustomizeExpandButtonComponent(
               backgroundColor={COLORS.blue10}
               padding={SPACING.spacing16}
               borderRadius={BORDERS.borderRadius4}
+              gridGap={SPACING.spacing8}
             >
               {isLid &&
               !isNestedDefALid &&

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/FlexStackerTools/RefillSettings.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/FlexStackerTools/RefillSettings.tsx
@@ -108,6 +108,7 @@ export function RefillSettings(props: RefillSettingsProps): JSX.Element {
 
   return (
     <div className={styles.refill_settings_container}>
+      <div className={styles.selected_labware_container}>
       <StyledText desktopStyle="bodyDefaultRegular" color={COLORS.grey60}>
         {t('step_edit_form.flex_stacker.selected_labware')}
       </StyledText>
@@ -128,9 +129,11 @@ export function RefillSettings(props: RefillSettingsProps): JSX.Element {
           </StyledText>
         </ListItem>
       )}
+      </div>
+      
 
       {storedEntityName != null && (
-        <div>
+        <div className={styles.refill_settings_input_container}>
           <InputStepFormField
             title={t('step_edit_form.flex_stacker.fields.fillLabwareIds.title')}
             {...propsForFields.fillLabwareIds}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/FlexStackerTools/RefillSettings.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/FlexStackerTools/RefillSettings.tsx
@@ -109,28 +109,27 @@ export function RefillSettings(props: RefillSettingsProps): JSX.Element {
   return (
     <div className={styles.refill_settings_container}>
       <div className={styles.selected_labware_container}>
-      <StyledText desktopStyle="bodyDefaultRegular" color={COLORS.grey60}>
-        {t('step_edit_form.flex_stacker.selected_labware')}
-      </StyledText>
-      {storedLabwareDetails != null ? (
-        <div className={styles.selected_labware_container}>
-          {storedEntityName != null ? (
-            <StackerContentItem
-              primaryLabwareName={storedEntityName}
-              hasLid={storedLabwareDetails.lidLabwareURI != null}
-              isTiprack={isPrimaryTiprack}
-            />
-          ) : null}
-        </div>
-      ) : (
-        <ListItem type="default" className={styles.list_item}>
-          <StyledText desktopStyle="bodyDefaultRegular">
-            {t('step_edit_form.flex_stacker.no_labware_selected')}
-          </StyledText>
-        </ListItem>
-      )}
+        <StyledText desktopStyle="bodyDefaultRegular" color={COLORS.grey60}>
+          {t('step_edit_form.flex_stacker.selected_labware')}
+        </StyledText>
+        {storedLabwareDetails != null ? (
+          <div className={styles.selected_labware_container}>
+            {storedEntityName != null ? (
+              <StackerContentItem
+                primaryLabwareName={storedEntityName}
+                hasLid={storedLabwareDetails.lidLabwareURI != null}
+                isTiprack={isPrimaryTiprack}
+              />
+            ) : null}
+          </div>
+        ) : (
+          <ListItem type="default" className={styles.list_item}>
+            <StyledText desktopStyle="bodyDefaultRegular">
+              {t('step_edit_form.flex_stacker.no_labware_selected')}
+            </StyledText>
+          </ListItem>
+        )}
       </div>
-      
 
       {storedEntityName != null && (
         <div className={styles.refill_settings_input_container}>

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/FlexStackerTools/flexstackertools.module.css
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/FlexStackerTools/flexstackertools.module.css
@@ -22,6 +22,12 @@
   gap: var(--spacing-12);
 }
 
+.refill_settings_input_container {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-12);
+}
+
 .selected_labware_container {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
# Overview

This PR addresses some DQA spacing bugs that I found while doing DQA.

## Test Plan and Hands on Testing

For this PR I added the correct spacing between the input fields under the refill stacker step.

<img width="734" height="737" alt="image" src="https://github.com/user-attachments/assets/c0559a9b-bf50-42cd-b1e1-6d06bae8b3db" />

I also added the correct spacing for the customizeExpandButton when adding labware with lids to the deck

<img width="731" height="742" alt="image" src="https://github.com/user-attachments/assets/11e90a78-4b86-4c12-8ac3-b764d3fbe13d" />

## Changelog

I added 12 pixels of spacing between the input fields in the refill stacker step, and then 8 pixels of spacing between the checkbox and the input field in the customizeExpandButton

## Review requests

Let me know if these changes are ok! I had to add some new classes to the divs in order to solve the spacing sisues.

## Risk assessment

These changes have a low risk.
