### PR TITLE
test(pd-e2e): PD E2E updated Migrate Absorbance Reader tests to playwright 

### DIFF
--- a/e2e-testing/automation/pd_pages/create_protocol_wizard.py
+++ b/e2e-testing/automation/pd_pages/create_protocol_wizard.py
@@ -72,3 +72,8 @@ class CreateProtocolWizard(BasePage):
         """Click the wizard Confirm button."""
 
         self.click_button("Confirm")
+
+    def name_protocol(self, protocol_name: str) -> None:
+        """Fill in the protocol name input box."""
+
+        self.page.locator('input[name="fields.name"]').fill(protocol_name)

--- a/e2e-testing/automation/pd_pages/landing_page.py
+++ b/e2e-testing/automation/pd_pages/landing_page.py
@@ -44,11 +44,3 @@ class LandingPage(BasePage):
     def edit_protocol(self) -> None:
         """Click the 'Edit protocol' button."""
         self.page.get_by_role("button", name="Edit protocol").click()
-
-    def dismiss_migration_modal(self) -> None:
-        """Dismiss the migration modal if it appears during import."""
-        self.page.get_by_role(
-            "button",
-            name="Import",
-            exact=True,
-        ).click()

--- a/e2e-testing/automation/pd_pages/plate_reader_page.py
+++ b/e2e-testing/automation/pd_pages/plate_reader_page.py
@@ -1,0 +1,155 @@
+"""Protocol editor page object."""
+
+import re
+from typing import Literal
+
+from playwright.sync_api import Page
+
+from .base_page import BasePage
+
+
+class PlateReaderPage(BasePage):
+    """Main transfer page for configuring transfer steps."""
+
+    def __init__(self, page: Page) -> None:
+        super().__init__(page)
+
+    def configure_module(self, slot: Literal["A3", "B3", "C3", "D3"], module: str) -> None:
+        """Configure the Plate Reader module.
+
+        Args:
+            slot: Either column 3 slot locations compatible with Plate Reader module
+            module: Module name as appears in the module selection list
+        """
+        self.page.get_by_test_id(slot).click()
+        self.page.get_by_test_id("Modules").click()
+        self.page.get_by_test_id(module).click()
+        self.button_selection("Confirm")
+
+    def dimiss_deck_hardware_modal(self) -> None:
+        """Dismiss the deck hardware modal if it appears."""
+        self.page.get_by_test_id("Toast_info").get_by_role("button").click()
+
+    def define_initialization(
+        self,
+        init_setting: Literal["Single", "Multi"],
+        wavelength: int | None = None,
+    ) -> None:
+        """Define initialization settings for the Plate Reader.
+
+        Args:
+            init_setting: Either "Single" or "Multi"
+            wavelength: Wavelength value for defining own wavelength ("Other") selection, or None if not
+        """
+        define_init = self.page.locator("div").filter(has_text=re.compile(r"^Define initialization settings$")).nth(1)
+        change_lid = self.page.locator("div").filter(has_text=re.compile(r"^Change intialization settings$")).nth(1)
+
+        if define_init.is_visible() or change_lid.is_visible():
+            if define_init.is_visible():
+                define_init.click()
+            elif change_lid.is_visible():
+                change_lid.click()
+
+        self.button_selection("Continue")
+
+        if init_setting == "Single":
+            self._single_initialization("nm (green)", True, "Other", wavelength)
+            self.save_pr_step()
+        elif init_setting == "Multi":
+            self._multi_initialization(4, wavelength)
+            self.save_pr_step()
+
+    def change_lid_position(self, position: Literal["Open", "Closed"]) -> None:
+        self.page.get_by_text("Change lid position").click()
+        self.page.locator("div").filter(has_text=re.compile(r"^Change lid position$")).nth(1).click()
+        self.button_selection("Continue")
+        if position == "Open":
+            self.page.get_by_test_id("ToggleButton_Closed").click()
+
+    def read_labware(self, file_name: str) -> None:
+        self.page.locator("div").filter(has_text=re.compile(r"^Read labware$")).nth(1).click()
+        self.button_selection("Continue")
+        self.page.get_by_role("textbox").click()
+        self.page.get_by_role("textbox").fill(file_name)
+
+    def save_pr_step(self) -> None:
+        """Click save transfer step button in transfer step."""
+        self.page.get_by_text("Save", exact=True).click()
+
+    def button_selection(self, button_name: str) -> None:
+        self.page.get_by_role("button", name=button_name).click()
+
+    def _single_initialization(
+        self,
+        nm_value: Literal["nm (blue)", "nm (green)", "nm (orange)", "nm (red)", "Other"],
+        ref_wavelength_bool: bool,
+        ref_nm: Literal["nm (blue)", "nm (green)", "nm (orange)", "nm (red)", "Other"] | None = None,
+        wavelength: int | None = None,
+    ) -> None:
+        """Define single-wavelength initialization.
+
+        Args:
+            nm_value: predefined wavelength selections from dropdown
+            ref_wavelength_bool: Boolean to indicate whether to add a reference wavelength  or not
+            ref_nm: predefined wavelength selections from dropdown, only used if ref_wavelength_bool is True
+            wavelength: custom wavelength value for "Other" selection, only used if nm_value or ref_nm is "Other"
+        """
+
+        self.page.locator("div").filter(has_text=re.compile(r"^Single$")).nth(1).click()
+        self.page.get_by_test_id("dropdownMenu").locator("svg").click()
+        if nm_value == "Other":
+            assert wavelength is not None, "wavelength must be provided when nm_value is 'Other'"
+            self.button_selection(nm_value)
+            self._define_custom_wavelength(wavelength)
+        else:
+            self.button_selection(nm_value)
+
+        if ref_wavelength_bool:
+            self.page.get_by_test_id("ListButton_noActive").locator("div").filter(
+                has_text="Add reference wavelength?"
+            ).locator("div").click()
+            self.page.get_by_test_id("dropdownMenu").locator("svg").last.click()
+            if ref_nm == "Other":
+                assert wavelength is not None, "wavelength must be provided when reference wavelength is 'Other'"
+                self.button_selection(ref_nm)
+                self._define_custom_wavelength(wavelength)
+            else:
+                assert ref_nm is not None, "reference wavelength must be provided when ref_wavelength_bool is True"
+                self.button_selection(ref_nm)
+
+    def _multi_initialization(
+        self,
+        num_wavelengths: int,
+        wavelength: int | None = None,
+    ) -> None:
+        """Define multi-wavelength initialization.
+
+        Args:
+            num_wavelengths: Number of wavelengths to select (1-6), selecting 4 simply for testing each wavelength
+            wavelength: Wavelength value for "Other" selection, e.g. "500"
+        """
+        nm = ["nm (green)", "nm (orange)", "nm (red)", "Other"]
+        self.page.locator("div").filter(has_text=re.compile(r"^Multi$")).nth(1).click()
+        if num_wavelengths > 6:
+            raise ValueError("num_wavelengths cannot exceed 6")
+        elif num_wavelengths == 1:
+            self.page.get_by_test_id("EmptySelectorButton_click").click()
+            self.page.get_by_text("nm (blue)").nth(1).click()
+        else:
+            for i in range(num_wavelengths):
+                label = nm[i]
+                self.page.get_by_test_id("EmptySelectorButton_click").click()
+                self.page.get_by_test_id("dropdownMenu").nth(i + 1).click()
+                self.button_selection(label)
+                if label == "Other" and wavelength is not None:
+                    self._define_custom_wavelength(wavelength)
+
+    def _define_custom_wavelength(self, wavelength: int) -> None:
+        """Define a custom wavelength.
+
+        Args:
+            wavelength: Wavelength value, e.g. "500"
+        """
+        textbox = self.page.get_by_role("textbox")
+        textbox.click()
+        self.page.get_by_role("textbox").fill(str(wavelength))

--- a/e2e-testing/tests/pd/test_pd_drag_and_drop.py
+++ b/e2e-testing/tests/pd/test_pd_drag_and_drop.py
@@ -3,7 +3,8 @@
 import pytest
 from playwright.sync_api import Page
 
-from automation.pd_pages import LandingPage, ProtocolEditorPage
+from automation.pd_pages import ProtocolEditorPage
+from utility import _import_protocol_and_open_editor
 
 PROTOCOL_PATH = "fixtures/protocol/8/doItAllV8.json"
 
@@ -11,16 +12,9 @@ PROTOCOL_PATH = "fixtures/protocol/8/doItAllV8.json"
 @pytest.mark.pdE2E
 @pytest.mark.slow
 def test_drag_drop_steps(page: Page, base_url: str) -> None:
-    landing = LandingPage(page)
     editor = ProtocolEditorPage(page)
 
-    ## Import setup protocol and open editor
-    landing.wait_for_page_load()
-    landing.confirm_welcome_modal()
-    landing.click_import_existing_protocol()
-    landing.upload_protocol_file(PROTOCOL_PATH)
-    landing.dismiss_migration_modal()
-    landing.edit_protocol()
+    _import_protocol_and_open_editor(page, PROTOCOL_PATH, migration=True)
 
     ## Drag Transfer Step down the Step Form, from step 3 (index 2) to step 7 (becomes index 6)
     editor.drag_and_drop(2, 7)

--- a/e2e-testing/tests/pd/test_pd_plate_reader.py
+++ b/e2e-testing/tests/pd/test_pd_plate_reader.py
@@ -1,0 +1,80 @@
+import pytest
+from playwright.sync_api import Page
+from test_pd_create_new_flex import test_flex_onboarding_workflow
+
+from automation.pd_pages.create_protocol_wizard import CreateProtocolWizard
+from automation.pd_pages.plate_reader_page import PlateReaderPage
+from automation.pd_pages.protocol_editor_page import ProtocolEditorPage
+
+
+@pytest.mark.pdE2E
+@pytest.mark.slow
+def test_flex_absorbance_reader_setup(page: Page, base_url: str) -> None:
+    plate_reader_page = PlateReaderPage(page)
+    protocol_editor = ProtocolEditorPage(page)
+    create_protocol = CreateProtocolWizard(page)
+
+    # Create new Flex protocol setup
+    ## Note This will need to be refactored to a reusable function later
+    test_flex_onboarding_workflow(page, base_url)
+
+    # Configure deck hardware
+    ## Snapshot: Validate Absorbance Plate Reader module configuration option
+    plate_reader_page.configure_module("B3", "Absorbance Plate Reader Module GEN1")
+    create_protocol.name_protocol("test")
+    plate_reader_page.button_selection("Confirm")
+
+    # Edit protocol in Protocol Editor - adding labware to the deck
+    plate_reader_page.button_selection("Edit protocol")
+    plate_reader_page.dimiss_deck_hardware_modal()
+    protocol_editor.add_labware_to_slot("D1")
+    protocol_editor.select_labware_category_by_name("Well plates")
+    protocol_editor.select_labware_by_name("Opentrons Tough 96 Well Plate")
+
+    # Add plate reader multi-initialization step
+    protocol_editor.add_step("Absorbance Plate Reader")
+    ## Snapshot: Validate Plate Reader form
+    plate_reader_page.define_initialization("Multi", 700)
+    ## Snapshot: Validate Multi-initialization configuration
+
+    # Add plate reader step to change lid position, to prep for moving labware onto plate reader
+    protocol_editor.add_step("Absorbance Plate Reader")
+    plate_reader_page.change_lid_position("Open")
+    ## Snapshot: Validate Change Lid Position to Open
+    plate_reader_page.save_pr_step()
+    protocol_editor.add_step("Move")
+    protocol_editor.move_labware(labware="D1 Opentrons Tough 96 Well Plate", new_location="B3 Absorbance Plate Reader")
+
+    # Add plate reader step to close lid and read labware
+    protocol_editor.add_step("Absorbance Plate Reader")
+    plate_reader_page.change_lid_position("Closed")
+    ## Snapshot: Validate Change Lid Position to Closed
+    plate_reader_page.save_pr_step()
+    protocol_editor.add_step("Absorbance Plate Reader")
+    plate_reader_page.read_labware("test 1")
+    ## Snapshot: Validate Read Labware Form
+    plate_reader_page.save_pr_step()
+
+    # Add plate reader step to open lid and move labware off plate reader
+    protocol_editor.add_step("Absorbance Plate Reader")
+    plate_reader_page.change_lid_position("Open")
+    plate_reader_page.save_pr_step()
+    protocol_editor.add_step("Move")
+    protocol_editor.move_labware(labware="B3 Opentrons Tough 96 Well Plate", new_location="D1")
+
+    # Add plate reader step to prep to change
+    protocol_editor.add_step("Absorbance Plate Reader")
+    plate_reader_page.define_initialization("Single", 450)
+    ## Snapshot: Validate Single-initialization configuration
+    protocol_editor.add_step("Absorbance Plate Reader")
+    plate_reader_page.change_lid_position("Open")
+    plate_reader_page.save_pr_step()
+    protocol_editor.add_step("Move")
+    protocol_editor.move_labware(labware="D1 Opentrons Tough 96 Well Plate", new_location="B3 Absorbance Plate Reader")
+
+    protocol_editor.add_step("Absorbance Plate Reader")
+    plate_reader_page.change_lid_position("Closed")
+    plate_reader_page.save_pr_step()
+    protocol_editor.add_step("Absorbance Plate Reader")
+    plate_reader_page.read_labware("test 2")
+    plate_reader_page.save_pr_step()

--- a/e2e-testing/tests/pd/test_pd_smoke_test_flex.py
+++ b/e2e-testing/tests/pd/test_pd_smoke_test_flex.py
@@ -15,6 +15,7 @@ from pathlib import Path
 import pytest
 from playwright.sync_api import Page, expect
 
+from automation.pd_pages import ProtocolEditorPage
 from automation.pd_pages.heater_shaker_step_form_page import _add_heater_shaker_step
 from automation.pd_pages.tc_step_form_page import _add_thermocycler_profile_step, _add_thermocycler_state_step
 from automation.pd_pages.tempdeck_step_form_page import _add_temperature_module_step
@@ -40,8 +41,9 @@ def test_pd_combined_smoke_flow(page: Page, base_url: str) -> None:
 
     If any Playwright action or assertion fails, the test will pause for debugging.
     """
+    _import_protocol_and_open_editor(page, PROTOCOL_PATH, migration=True)
 
-    editor = _import_protocol_and_open_editor(page, PROTOCOL_PATH, migration=True)
+    editor = ProtocolEditorPage(page)
     print("✓ File uploaded, ready for module steps")
     editor.add_step("Temperature")
     _add_temperature_module_step(page, "50")

--- a/e2e-testing/utility.py
+++ b/e2e-testing/utility.py
@@ -53,7 +53,7 @@ def troubleshoot_and_pause(func):
     return wrapper
 
 
-def _import_protocol_and_open_editor(page: Page, PROTOCOL_PATH: str, migration: bool) -> ProtocolEditorPage:
+def _import_protocol_and_open_editor(page: Page, PROTOCOL_PATH: str, migration: bool) -> None:
     """This test takes two inputs:
     1. page: The Playwright Page object.
     2. PROTOCOL_PATH: The file path of the protocol to import
@@ -67,12 +67,12 @@ def _import_protocol_and_open_editor(page: Page, PROTOCOL_PATH: str, migration: 
     landing.confirm_welcome_modal()
     landing.click_import_existing_protocol()
     landing.upload_protocol_file(PROTOCOL_PATH)
+
     if migration:
-        landing.dismiss_migration_modal()
+        _dismiss_migration_modal(page)
     expect(page.get_by_text("Protocol Metadata")).to_be_visible(timeout=10000)
     page.get_by_role("button", name="Edit protocol").click()
     expect(page.get_by_role("button", name="Add Step")).to_be_visible(timeout=5000)
-    _dismiss_migration_modal(page)
     return ProtocolEditorPage(page)
 
 


### PR DESCRIPTION
# Overview

Converting old cypress tests for the plate reader and converting to Playwright
Addresses RQA-4949

## Test Plan and Hands on Testing

E2E - Plate Reader form for multi and single initalization

## Changelog

Added tests for absorbance reader form
Added functions that will allow you to use the Absorbance Reader form
- define initialization
- change lid position
- helper functions

Edited create protocol wizard to add function to name newly created protocol
Refactored files to fix failing tests
- import protocol and open editor function refactored due to multiple dismiss migration modal functions existing
- removed redundant dismiss migration modal from LandingPage
- since removing the above function, refactored drag and drop so that it uses the clean import protocol function from the utility file

## Review requests

- Will need to make changes to the test file, to conver the create new flex protocol test file to helper function (commented in code) 

## Risk assessment