### PR TITLE
chore: use python3 in buildroot recipes

### DIFF
--- a/api/buildroot.mk
+++ b/api/buildroot.mk
@@ -5,9 +5,10 @@
 ################################################################################
 include $(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)/scripts/python.mk
 
+OT_PYTHON := python3
 
 define OTAPI_CALL_PBU
-	$(shell python $(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)/scripts/python_build_utils.py api $(or $(OPENTRONS_PROJECT),robot-stack) $(1))
+	$(shell python3 $(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)/scripts/python_build_utils.py api $(or $(OPENTRONS_PROJECT),robot-stack) $(1))
 endef
 
 PYTHON_OPENTRONS_API_VERSION = $(call OTAPI_CALL_PBU,get_version)

--- a/hardware/buildroot.mk
+++ b/hardware/buildroot.mk
@@ -5,8 +5,10 @@
 ################################################################################
 include $(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)/scripts/python.mk
 
+OT_PYTHON := python3
+
 define OTHARDWARE_CALL_PBU
-	$(shell python $(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)/scripts/python_build_utils.py hardware $(or $(OPENTRONS_PROJECT),robot-stack) $(1))
+	$(shell python3 $(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)/scripts/python_build_utils.py hardware $(or $(OPENTRONS_PROJECT),robot-stack) $(1))
 endef
 
 PYTHON_OPENTRONS_HARDWARE_VERSION = $(call OTHARDWARE_CALL_PBU,get_version)

--- a/robot-server/buildroot.mk
+++ b/robot-server/buildroot.mk
@@ -4,9 +4,10 @@
 #
 ################################################################################
 include $(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)/scripts/python.mk
+OT_PYTHON := python3
 
 define OTROBOTSERVER_CALL_PBU
-	$(shell python $(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)/scripts/python_build_utils.py robot-server $(or $(OPENTRONS_PROJECT),robot-stack) $(1))
+	$(shell python3 $(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)/scripts/python_build_utils.py robot-server $(or $(OPENTRONS_PROJECT),robot-stack) $(1))
 endef
 
 PYTHON_OPENTRONS_ROBOT_SERVER_VERSION = $(call OTROBOTSERVER_CALL_PBU,get_version)

--- a/server-utils/buildroot.mk
+++ b/server-utils/buildroot.mk
@@ -5,8 +5,10 @@
 ################################################################################
 include $(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)/scripts/python.mk
 
+OT_PYTHON := python3
+
 define OTSYSTEMSERVER_CALL_PBU
-	$(shell python $(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)/scripts/python_build_utils.py server-utils $(or $(OPENTRONS_PROJECT),robot-stack) $(1))
+	$(shell python3 $(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)/scripts/python_build_utils.py server-utils $(or $(OPENTRONS_PROJECT),robot-stack) $(1))
 endef
 
 PYTHON_OPENTRONS_SERVER_UTILS_VERSION = $(call OTSYSTEMSERVER_CALL_PBU,get_version)

--- a/shared-data/buildroot.mk
+++ b/shared-data/buildroot.mk
@@ -5,8 +5,10 @@
 ################################################################################
 include $(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)/scripts/python.mk
 
+OT_PYTHON := python3
+
 define OTSHAREDDATA_CALL_PBU
-	$(shell python $(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)/scripts/python_build_utils.py shared-data $(or $(OPENTRONS_PROJECT),robot-stack) $(1))
+	$(shell python3 $(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)/scripts/python_build_utils.py shared-data $(or $(OPENTRONS_PROJECT),robot-stack) $(1))
 endef
 
 PYTHON_OPENTRONS_SHARED_DATA_VERSION = $(call OTSHAREDDATA_CALL_PBU,get_version)

--- a/system-server/buildroot.mk
+++ b/system-server/buildroot.mk
@@ -5,8 +5,10 @@
 ################################################################################
 include $(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)/scripts/python.mk
 
+OT_PYTHON := python3
+
 define OTSYSTEMSERVER_CALL_PBU
-	$(shell python $(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)/scripts/python_build_utils.py system-server $(or $(OPENTRONS_PROJECT),robot-stack) $(1))
+	$(shell python3 $(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)/scripts/python_build_utils.py system-server $(or $(OPENTRONS_PROJECT),robot-stack) $(1))
 endef
 
 PYTHON_OPENTRONS_SYSTEM_SERVER_VERSION = $(call OTSYSTEMSERVER_CALL_PBU,get_version)

--- a/update-server/buildroot.mk
+++ b/update-server/buildroot.mk
@@ -5,8 +5,10 @@
 ################################################################################
 include $(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)/scripts/python.mk
 
+OT_PYTHON := python3
+
 define OTUPDATESERVER_CALL_PBU
-	$(shell python $(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)/scripts/python_build_utils.py update-server $(or $(OPENTRONS_PROJECT),robot-stack) $(1))
+	$(shell python3 $(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)/scripts/python_build_utils.py update-server $(or $(OPENTRONS_PROJECT),robot-stack) $(1))
 endef
 
 PYTHON_OPENTRONS_UPDATE_SERVER_VERSION = $(call OTUPDATESERVER_CALL_PBU,get_version)
@@ -23,7 +25,7 @@ PYTHON_OPENTRONS_UPDATE_SERVER_ENV = \
   HATCH_VCS_TUNABLE_RAW_OPTIONS="$(call hatch_raw_options_for_project,$(PROJECT));root=$(shell realpath --relative-to=$(PYTHON_OPENTRONS_UPDATE_SERVER_BUILDDIR) $(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH))"
 
 define OTUS_DUMP_BR_VERSION
-  $(shell python $(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)/scripts/python_build_utils.py update-server robot-stack dump_br_version)
+  $(shell python3 $(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)/scripts/python_build_utils.py update-server robot-stack dump_br_version)
 endef
 
 define PYTHON_OPENTRONS_UPDATE_SERVER_INSTALL_VERSION


### PR DESCRIPTION
The new buildroot docker container for updated buildroot requires you to do python3 instead of python in shell calls to the python interpreter. We need to use this new container because the old container can't be built anymore - the debian buster apt repos have been taken down because that distro release is out of support.
