### PR TITLE
feat(app): add error recovery support for dyanmic liquid tracking

### DIFF
--- a/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useRecoveryCommands.test.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useRecoveryCommands.test.ts
@@ -227,6 +227,163 @@ describe('useRecoveryCommands', () => {
     }
   )
 
+  const LIQUID_TRACKING_COMMANDS = [
+    'aspirateWhileTracking',
+    'dispenseWhileTracking',
+  ] as const
+
+  it.each(LIQUID_TRACKING_COMMANDS)(
+    'Should liquid probe before retrying if failed command is $commandType',
+    async commandType => {
+      const { result } = renderHook(() => {
+        const failedCommand = {
+          ...mockFailedCommand,
+          commandType,
+          params: {
+            pipetteId: 'mock-pipette-id',
+            volume: 50,
+            flowRate: { x: 1, y: 1, z: 1 },
+            trackFromLocation: {
+              labwareId: 'labware-1',
+              wellName: 'A1',
+            },
+            trackToLocation: {
+              labwareId: 'labware-2',
+              wellName: 'B1',
+            },
+          },
+        }
+        return useRecoveryCommands({
+          runId: mockRunId,
+          failedCommand: {
+            byRunRecord: failedCommand,
+            byAnalysis: failedCommand,
+          },
+          unvalidatedFailedCommand: failedCommand,
+          failedLabwareUtils: mockFailedLabwareUtils,
+          routeUpdateActions: mockRouteUpdateActions,
+          recoveryToastUtils: {} as any,
+          analytics: {
+            reportActionSelectedResult: mockReportActionSelectedResult,
+            reportRecoveredRunResult: mockReportRecoveredRunResult,
+          } as any,
+          selectedRecoveryOption: RECOVERY_MAP.RETRY_NEW_TIPS.ROUTE,
+        })
+      })
+
+      await act(async () => {
+        await result.current.retryFailedCommand()
+      })
+
+      expect(mockChainRunCommands).toHaveBeenLastCalledWith(
+        [
+          {
+            commandType: 'liquidProbe',
+            intent: 'fixit',
+            params: {
+              pipetteId: 'mock-pipette-id',
+              volume: 50,
+              flowRate: { x: 1, y: 1, z: 1 },
+              trackFromLocation: {
+                labwareId: 'labware-1',
+                wellName: 'A1',
+              },
+              trackToLocation: {
+                labwareId: 'labware-2',
+                wellName: 'B1',
+              },
+              wellLocation: {
+                origin: 'top',
+                offset: {
+                  x: 0,
+                  y: 0,
+                  z: 2,
+                },
+              },
+            },
+          },
+          {
+            commandType,
+            params: {
+              pipetteId: 'mock-pipette-id',
+              volume: 50,
+              flowRate: { x: 1, y: 1, z: 1 },
+              trackFromLocation: {
+                labwareId: 'labware-1',
+                wellName: 'A1',
+              },
+              trackToLocation: {
+                labwareId: 'labware-2',
+                wellName: 'B1',
+              },
+            },
+          },
+        ],
+        false
+      )
+    }
+  )
+
+  it('Should not liquid probe before retrying if failed command is not a liquid tracking command', async () => {
+    const { result } = renderHook(() => {
+      const failedCommand = {
+        ...mockFailedCommand,
+        commandType: 'aspirate' as const,
+        params: {
+          pipetteId: 'mock-pipette-id',
+          volume: 50,
+          flowRate: { x: 1, y: 1, z: 1 },
+          labwareId: 'labware-1',
+          wellName: 'A1',
+          wellLocation: {
+            origin: 'top',
+            offset: { x: 0, y: 0, z: 0 },
+          },
+        },
+      }
+      return useRecoveryCommands({
+        runId: mockRunId,
+        failedCommand: {
+          byRunRecord: failedCommand,
+          byAnalysis: failedCommand,
+        },
+        unvalidatedFailedCommand: failedCommand,
+        failedLabwareUtils: mockFailedLabwareUtils,
+        routeUpdateActions: mockRouteUpdateActions,
+        recoveryToastUtils: {} as any,
+        analytics: {
+          reportActionSelectedResult: mockReportActionSelectedResult,
+          reportRecoveredRunResult: mockReportRecoveredRunResult,
+        } as any,
+        selectedRecoveryOption: RECOVERY_MAP.RETRY_NEW_TIPS.ROUTE,
+      })
+    })
+
+    await act(async () => {
+      await result.current.retryFailedCommand()
+    })
+
+    expect(mockChainRunCommands).toHaveBeenLastCalledWith(
+      [
+        {
+          commandType: 'aspirate',
+          params: {
+            pipetteId: 'mock-pipette-id',
+            volume: 50,
+            flowRate: { x: 1, y: 1, z: 1 },
+            labwareId: 'labware-1',
+            wellName: 'A1',
+            wellLocation: {
+              origin: 'top',
+              offset: { x: 0, y: 0, z: 0 },
+            },
+          },
+        },
+      ],
+      false
+    )
+  })
+
   it('should call resumeRun with runId and show success toast on success', async () => {
     const { result } = renderHook(() => useRecoveryCommands(props))
 

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useRecoveryCommands.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useRecoveryCommands.ts
@@ -7,6 +7,7 @@ import {
   useResumeRunFromRecoveryMutation,
   useStopRunMutation,
 } from '@opentrons/react-api-client'
+import { WELL_ORIGIN_TOP } from '@opentrons/shared-data'
 
 import { getErrorKind } from '/app/organisms/ErrorRecoveryFlows/utils'
 import {
@@ -19,13 +20,17 @@ import { DEFINED_ERROR_TYPES, ERROR_KINDS, RECOVERY_MAP } from '../constants'
 import type { CommandData, IfMatchType, RunAction } from '@opentrons/api-client'
 import type { WellGroup } from '@opentrons/components'
 import type {
+  AspDispWhileTrackingParams,
   AspirateInPlaceRunTimeCommand,
+  AspirateWhileTrackingRunTimeCommand,
   BlowoutInPlaceRunTimeCommand,
   CreateCommand,
   DispenseInPlaceRunTimeCommand,
+  DispenseWhileTrackingRunTimeCommand,
   DropTipInPlaceRunTimeCommand,
   FlexStackerRetrieveRunTimeCommand,
   FlexStackerStoreRunTimeCommand,
+  LiquidProbeCreateCommand,
   LoadedLabware,
   MoveLabwareParams,
   MoveToCoordinatesCreateCommand,
@@ -33,6 +38,8 @@ import type {
   RunCommandError,
   RunCommandErrorOverpressure,
   RunCommandErrorTipPhysicallyAttached,
+  Vector3D,
+  WellLocation,
 } from '@opentrons/shared-data'
 import type { UseRecoveryAnalyticsResult } from '/app/redux-resources/analytics'
 import type { UpdateErrorRecoveryPolicyWithStrategy } from '/app/resources/runs'
@@ -43,6 +50,10 @@ import type { CurrentRecoveryOptionUtils } from './useRecoveryRouting'
 import type { RecoveryToasts } from './useRecoveryToasts'
 import type { FailedCommandBySource } from './useRetainedFailedCommandBySource'
 import type { UseRouteUpdateActionsResult } from './useRouteUpdateActions'
+
+// TODO(jh, 01-14-26): This value exists as a python-exclusive shared-data constant.
+// We should move this constant and the existing shared-data constant to a JSON.
+const LIQUID_PROBE_START_OFFSET_FROM_WELL_TOP: Vector3D = { x: 0, y: 0, z: 2 }
 
 interface UseRecoveryCommandsParams {
   runId: string
@@ -139,13 +150,19 @@ export function useRecoveryCommands({
     [analytics, selectedRecoveryOption]
   )
 
-  const buildRetryPrepMove = (): MoveToCoordinatesCreateCommand | null => {
+  const buildRetryPrepMove = ():
+    | MoveToCoordinatesCreateCommand
+    | LiquidProbeCreateCommand
+    | null => {
     type InPlaceCommand =
       | AspirateInPlaceRunTimeCommand
       | BlowoutInPlaceRunTimeCommand
       | DispenseInPlaceRunTimeCommand
       | DropTipInPlaceRunTimeCommand
       | PrepareToAspirateRunTimeCommand
+    type CommandsWithDynamicLiquidTracking =
+      | AspirateWhileTrackingRunTimeCommand
+      | DispenseWhileTrackingRunTimeCommand
 
     const IN_PLACE_COMMAND_TYPES = [
       'aspirateInPlace',
@@ -153,6 +170,10 @@ export function useRecoveryCommands({
       'blowOutInPlace',
       'dropTipInPlace',
       'prepareToAspirate',
+    ] as const
+    const REQUIRES_LIQUID_PROBE_COMMAND_TYPES = [
+      'aspirateWhileTracking',
+      'dispenseWhileTracking',
     ] as const
 
     const isInPlace = (
@@ -163,7 +184,7 @@ export function useRecoveryCommands({
         (failedCommand as InPlaceCommand).commandType
       )
 
-    const isTargetedError = (
+    const requiresMoveToError = (
       error?: RunCommandError | null
     ): error is
       | RunCommandErrorOverpressure
@@ -173,24 +194,59 @@ export function useRecoveryCommands({
       (error.errorType === DEFINED_ERROR_TYPES.OVERPRESSURE ||
         error.errorType === DEFINED_ERROR_TYPES.TIP_PHYSICALLY_ATTACHED)
 
-    return isInPlace(unvalidatedFailedCommand) &&
-      isTargetedError(unvalidatedFailedCommand.error) &&
+    const isLiquidProbePreconditionRequired = (
+      failedCommand: FailedCommandBySource['byRunRecord']
+    ): boolean =>
+      REQUIRES_LIQUID_PROBE_COMMAND_TYPES.includes(
+        (failedCommand as CommandsWithDynamicLiquidTracking).commandType
+      )
+
+    if (
+      isInPlace(unvalidatedFailedCommand) &&
+      requiresMoveToError(unvalidatedFailedCommand.error) &&
       // Paranoia: this value comes from the wire and may be unevenly implemented
       typeof unvalidatedFailedCommand.error?.errorInfo?.retryLocation?.at(0) ===
         'number'
-      ? {
-          commandType: 'moveToCoordinates',
-          intent: 'fixit',
-          params: {
-            pipetteId: unvalidatedFailedCommand.params?.pipetteId,
-            coordinates: {
-              x: unvalidatedFailedCommand.error.errorInfo.retryLocation[0],
-              y: unvalidatedFailedCommand.error.errorInfo.retryLocation[1],
-              z: unvalidatedFailedCommand.error.errorInfo.retryLocation[2],
-            },
+    ) {
+      const retryLocation =
+        unvalidatedFailedCommand.error.errorInfo.retryLocation
+
+      return {
+        commandType: 'moveToCoordinates',
+        intent: 'fixit',
+        params: {
+          pipetteId: unvalidatedFailedCommand.params?.pipetteId,
+          coordinates: {
+            x: retryLocation[0],
+            y: retryLocation[1],
+            z: retryLocation[2],
           },
-        }
-      : null
+        },
+      }
+    } else if (
+      failedCommand != null &&
+      isLiquidProbePreconditionRequired(failedCommand.byRunRecord)
+    ) {
+      const liquidParams = failedCommand.byRunRecord
+        .params as AspDispWhileTrackingParams
+
+      const retryLocation: WellLocation = {
+        origin: WELL_ORIGIN_TOP,
+        offset: {
+          x: LIQUID_PROBE_START_OFFSET_FROM_WELL_TOP.x,
+          y: LIQUID_PROBE_START_OFFSET_FROM_WELL_TOP.y,
+          z: LIQUID_PROBE_START_OFFSET_FROM_WELL_TOP.z,
+        },
+      }
+
+      return {
+        commandType: 'liquidProbe',
+        intent: 'fixit',
+        params: { ...liquidParams, wellLocation: retryLocation },
+      }
+    } else {
+      return null
+    }
   }
 
   const buildOpenLatch = (


### PR DESCRIPTION
Closes [EXEC-2248](https://opentrons.atlassian.net/browse/EXEC-2248)

# Overview

Dynamic liquid tracking requires knowledge of current liquid levels, which are missing from PE state after a failed command involving liquid tracking. In Error Recovery, for example, retrying an `aspirate` command that makes use of dynamic liquid tracking causes the fixit command to fail.

To fix, the app side of Error Recovery will inject an appropriate `liquidProbe` command implicitly before retrying the failed command that uses dynamic liquid tracking.

## Test Plan and Hands on Testing

- Using the following protocol, verified that the retried command succeeds as expected:

```
from opentrons.protocol_api import ProtocolContext, InstrumentContext
from opentrons.hardware_control.types import Axis
from opentrons.types import Mount, Point
import re
from opentrons.config import IS_ROBOT
from typing import List
import math
metadata = {"protocolName": "test overpressure in dynamic"}

requirements = {"robotType": "Flex", "apiLevel": "2.27"}

def run(ctx: ProtocolContext) -> None:
    """Run."""
    # Change Pipette and mount here as needed
    ctx.load_trash_bin("A3")
    pipette = ctx.load_instrument(f"flex_1channel_1000", "left")
    tiprack = ctx.load_labware(f"opentrons_flex_96_tiprack_1000ul", "C2")
    labware = ctx.load_labware("nest_96_wellplate_2ml_deep", "D1")

    well = labware.well("H1")
    pipette.pick_up_tip(tiprack)
    pipette.require_liquid_presence(well)
    pipette.move_to(well.top(z=10))
    ctx.pause("Ready to test?")
    pipette.aspirate(
        volume=1000,
		location=well.meniscus(z=10),
		end_location=well.meniscus(z=11),
    )
    ctx.pause("Ready to test?")
    pipette.dispense(
        volume=1000,
        location=well.top(z=11),
		end_location=well.meniscus(z=11),
    )
    pipette.return_tip()
```

## Changelog

- Added Error Recovery support for dynamic liquid tracking when attempting the "retry with new tips" flow.

## Risk assessment

low

[EXEC-2248]: https://opentrons.atlassian.net/browse/EXEC-2248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ