### PR TITLE
fix(components, step-generation, protocol-designer): fix stacker slot presentation

### DIFF
--- a/components/src/atoms/StyledText/PlaceholderStyledText.tsx
+++ b/components/src/atoms/StyledText/PlaceholderStyledText.tsx
@@ -9,6 +9,7 @@ type StyleKey =
   | 'captionBold'
   | 'bodyDefaultSemiBold'
   | 'smallBodyTextBold'
+  | 'headingLargeBold'
 
 interface PlaceholderStyledTextProps {
   children: ReactNode
@@ -32,6 +33,7 @@ export const PlaceholderStyledText = (
     captionBold: styles.caption_bold,
     bodyDefaultSemiBold: styles.body_default_semi_bold,
     smallBodyTextBold: styles.small_body_text_bold,
+    headingLargeBold: styles.heading_large_bold,
   }
   const combinedClassName = clsx(
     desktopStyle != null ? styleMap[desktopStyle as StyleKey] : null,

--- a/components/src/atoms/StyledText/placeholderstyledtext.module.css
+++ b/components/src/atoms/StyledText/placeholderstyledtext.module.css
@@ -5,6 +5,12 @@
     line-height: var(--line-height-24);
   }
 
+  .heading_large_bold {
+    font-size: 2rem;
+    font-weight: var(--font-weight-bold);
+    line-height: var(--line-height-32);
+  }
+
   .caption_bold {
     font-size: 0.75rem;
     font-weight: var(--font-weight-bold);

--- a/components/src/molecules/RobotInfoLabel/index.tsx
+++ b/components/src/molecules/RobotInfoLabel/index.tsx
@@ -39,16 +39,15 @@ export function RobotInfoLabel({
       [styles.has_deck_label]: deckLabel != null,
     }
   )
-  let textSize: HelixStyles = 'captionBold'
-  switch (size) {
-    case 'large':
-      textSize = 'headingSmallBold'
-      break
-    case 'extraLarge':
-      textSize = 'headingLargeBold'
-      break
-    default:
-      textSize = 'captionBold'
+  const getTextSize = (size: string): HelixStyles => {
+    switch (size) {
+      case 'large':
+        return 'headingSmallBold'
+      case 'extraLarge':
+        return 'headingLargeBold'
+      default:
+        return 'captionBold'
+    }
   }
   return (
     <div
@@ -70,7 +69,7 @@ export function RobotInfoLabel({
         />
       ) : (
         <StyledText
-          desktopStyle={textSize}
+          desktopStyle={getTextSize(size)}
           oddStyle="smallBodyTextBold"
           color={highlight ? COLORS.white : COLORS.black90}
         >

--- a/components/src/molecules/RobotInfoLabel/index.tsx
+++ b/components/src/molecules/RobotInfoLabel/index.tsx
@@ -1,17 +1,18 @@
 import clsx from 'clsx'
 
-import { PlaceholderStyledText } from '../../atoms'
+import { StyledText } from '../../atoms/StyledText/StyledText'
 import { COLORS } from '../../helix-design-system'
 import { Icon } from '../../icons'
 import styles from './robotinfolabel.module.css'
 
+import type { HelixStyles } from '../../atoms/StyledText'
 import type { IconName } from '../../icons'
 
 export interface RobotInfoLabelProps {
   deckLabel?: string
   iconName?: IconName
   highlight?: boolean
-  size?: 'large' | 'default'
+  size?: 'large' | 'default' | 'extraLarge'
   height?: string | number
   width?: string | number
   svgSize?: string | number
@@ -38,7 +39,17 @@ export function RobotInfoLabel({
       [styles.has_deck_label]: deckLabel != null,
     }
   )
-
+  let textSize: HelixStyles = 'captionBold'
+  switch (size) {
+    case 'large':
+      textSize = 'headingSmallBold'
+      break
+    case 'extraLarge':
+      textSize = 'headingLargeBold'
+      break
+    default:
+      textSize = 'captionBold'
+  }
   return (
     <div
       className={labelClass}
@@ -58,13 +69,13 @@ export function RobotInfoLabel({
           aria-label={iconName}
         />
       ) : (
-        <PlaceholderStyledText
-          desktopStyle={size === 'large' ? 'headingSmallBold' : 'captionBold'}
+        <StyledText
+          desktopStyle={textSize}
           oddStyle="smallBodyTextBold"
           color={highlight ? COLORS.white : COLORS.black90}
         >
           {deckLabel}
-        </PlaceholderStyledText>
+        </StyledText>
       )}
     </div>
   )

--- a/components/src/molecules/RobotInfoLabel/index.tsx
+++ b/components/src/molecules/RobotInfoLabel/index.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx'
 
-import { StyledText } from '../../atoms/StyledText/StyledText'
+import { PlaceholderStyledText } from '../../atoms'
 import { COLORS } from '../../helix-design-system'
 import { Icon } from '../../icons'
 import styles from './robotinfolabel.module.css'
@@ -49,6 +49,7 @@ export function RobotInfoLabel({
         return 'captionBold'
     }
   }
+
   return (
     <div
       className={labelClass}
@@ -68,13 +69,13 @@ export function RobotInfoLabel({
           aria-label={iconName}
         />
       ) : (
-        <StyledText
+        <PlaceholderStyledText
           desktopStyle={getTextSize(size)}
           oddStyle="smallBodyTextBold"
           color={highlight ? COLORS.white : COLORS.black90}
         >
           {deckLabel}
-        </StyledText>
+        </PlaceholderStyledText>
       )}
     </div>
   )

--- a/components/src/molecules/RobotInfoLabel/robotinfolabel.module.css
+++ b/components/src/molecules/RobotInfoLabel/robotinfolabel.module.css
@@ -10,6 +10,8 @@
   border-radius: var(--border-radius-8);
   background-color: inherit;
   overflow-wrap: break-word;
+  white-space: nowrap;
+
 }
 
 .robot_info_label_highlight {

--- a/protocol-designer/src/components/organisms/AssignLiquidsModal/index.tsx
+++ b/protocol-designer/src/components/organisms/AssignLiquidsModal/index.tsx
@@ -171,7 +171,7 @@ export function AssignLiquidsModal(
               gap={SPACING.spacing10}
             >
               <RobotInfoLabel
-                size={'extraLarge'}
+                size="extraLarge"
                 deckLabel={
                   getSlotInLocationStack(
                     labware[labwareId].stack as string[],

--- a/protocol-designer/src/components/organisms/AssignLiquidsModal/index.tsx
+++ b/protocol-designer/src/components/organisms/AssignLiquidsModal/index.tsx
@@ -5,7 +5,6 @@ import { clsx } from 'clsx'
 
 import {
   ALIGN_CENTER,
-  ALIGN_NORMAL,
   BORDERS,
   Box,
   COLORS,
@@ -168,14 +167,15 @@ export function AssignLiquidsModal(
           >
             <Flex
               height="100%"
-              alignItems={ALIGN_NORMAL}
+              alignItems={ALIGN_CENTER}
               gap={SPACING.spacing10}
             >
               <RobotInfoLabel
-                size="large"
+                size={'extraLarge'}
                 deckLabel={
                   getSlotInLocationStack(
-                    labware[labwareId].stack as string[]
+                    labware[labwareId].stack as string[],
+                    labwareIsOnHopper
                   ) ?? ''
                 }
               />

--- a/protocol-designer/src/components/organisms/SlotInformation/index.tsx
+++ b/protocol-designer/src/components/organisms/SlotInformation/index.tsx
@@ -66,7 +66,9 @@ export const SlotInformation: FC<SlotInformationProps> = ({
     modifiedLocation = tcDisplayLocation
   } else if (getIsSlotAHopper(location)) {
     modifiedLocation = t('stacker', {
-      slot: FAKE_HOPPER_LOCATION_MAP[location as HopperLocationMapKey],
+      slot: FAKE_HOPPER_LOCATION_MAP[location as HopperLocationMapKey].charAt(
+        0
+      ),
     })
   }
 

--- a/protocol-designer/src/components/organisms/SlotInformation/index.tsx
+++ b/protocol-designer/src/components/organisms/SlotInformation/index.tsx
@@ -22,17 +22,14 @@ import {
   THERMOCYCLER_MODULE_V1,
   THERMOCYCLER_MODULE_V2,
 } from '@opentrons/shared-data'
-import {
-  FAKE_HOPPER_LOCATION_MAP,
-  getIsSlotAHopper,
-} from '@opentrons/step-generation'
+import { getIsSlotAHopper } from '@opentrons/step-generation'
 
 import { useDeckSetupWindowBreakPoint } from '/protocol-designer/pages/Designer/DeckSetup/utils'
+import { getColumnFromWellName } from '/protocol-designer/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/utils'
 import lineClampStyles from '/protocol-designer/styles/lineclamp.module.css'
 
 import type { FC } from 'react'
 import type { RobotType } from '@opentrons/shared-data'
-import type { HopperLocationMapKey } from '@opentrons/step-generation'
 
 interface SlotInformationProps {
   location: string
@@ -66,9 +63,7 @@ export const SlotInformation: FC<SlotInformationProps> = ({
     modifiedLocation = tcDisplayLocation
   } else if (getIsSlotAHopper(location)) {
     modifiedLocation = t('stacker', {
-      slot: FAKE_HOPPER_LOCATION_MAP[location as HopperLocationMapKey].charAt(
-        0
-      ),
+      slot: getColumnFromWellName(location),
     })
   }
 

--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupToolbox.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupToolbox.tsx
@@ -29,6 +29,8 @@ import {
   getIsSlotAHopper,
 } from '@opentrons/step-generation'
 
+import { getColumnFromWellName } from '/protocol-designer/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/utils'
+
 import {
   LINK_BUTTON_STYLE,
   NAV_BAR_HEIGHT_REM,
@@ -249,11 +251,8 @@ export function DeckSetupToolbox(
       handleClear()
     }
   }
-
   const displaySlot = getIsSlotAHopper(slot)
-    ? t('shared:stacker', {
-        slot: FAKE_HOPPER_LOCATION_MAP[slot as HopperLocationMapKey].charAt(0),
-      })
+    ? t('shared:stacker', { slot: getColumnFromWellName(slot) })
     : slot
   return (
     <>

--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupToolbox.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupToolbox.tsx
@@ -252,7 +252,7 @@ export function DeckSetupToolbox(
 
   const displaySlot = getIsSlotAHopper(slot)
     ? t('shared:stacker', {
-        slot: FAKE_HOPPER_LOCATION_MAP[slot as HopperLocationMapKey],
+        slot: FAKE_HOPPER_LOCATION_MAP[slot as HopperLocationMapKey].charAt(0),
       })
     : slot
   return (

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/utils.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/utils.ts
@@ -112,7 +112,7 @@ export const getHoveredOffsetFromWell = (args: {
 }
 
 export const getColumnFromWellName = (wellName: string): string =>
-  wellName.slice(1, wellName.length)
+  wellName.slice(-2, -1)
 
 export const getIsPickupCompatibleWithPossibleAdapter = (
   stack: string[],

--- a/step-generation/src/utils/misc.ts
+++ b/step-generation/src/utils/misc.ts
@@ -872,12 +872,21 @@ export const delayLocationHelper: CommandCreator<DelayLocationHelperArgs> = (
   return reduceCommandCreators(commands, invariantContext, prevRobotState)
 }
 
-export const getSlotInLocationStack = (stack?: string[]): string => {
+export const getSlotInLocationStack = (
+  stack?: string[],
+  isStacker?: boolean
+): string => {
+  console.log('🚀 ~ getSlotInLocationStack ~ stack:', stack)
   if (stack == null) {
     console.error('expected to find stack but could not')
     return 'unknown slot'
   } else {
-    return stack[stack.length - 1]
+    const slot = stack[stack.length - 1]
+    if (isStacker) {
+      return 'STACKER' + ' ' + slot.charAt(0)
+    } else {
+      return slot
+    }
   }
 }
 

--- a/step-generation/src/utils/misc.ts
+++ b/step-generation/src/utils/misc.ts
@@ -876,7 +876,6 @@ export const getSlotInLocationStack = (
   stack?: string[],
   isStacker?: boolean
 ): string => {
-  console.log('🚀 ~ getSlotInLocationStack ~ stack:', stack)
   if (stack == null) {
     console.error('expected to find stack but could not')
     return 'unknown slot'

--- a/step-generation/src/utils/misc.ts
+++ b/step-generation/src/utils/misc.ts
@@ -882,7 +882,7 @@ export const getSlotInLocationStack = (
   } else {
     const slot = stack[stack.length - 1]
     if (isStacker) {
-      return 'STACKER' + ' ' + slot.slice(-1, -2)
+      return `STACKER ${slot.slice(-2, -1)}`
     } else {
       return slot
     }

--- a/step-generation/src/utils/misc.ts
+++ b/step-generation/src/utils/misc.ts
@@ -882,7 +882,7 @@ export const getSlotInLocationStack = (
   } else {
     const slot = stack[stack.length - 1]
     if (isStacker) {
-      return 'STACKER' + ' ' + slot.charAt(0)
+      return 'STACKER' + ' ' + slot.slice(-1, -2)
     } else {
       return slot
     }

--- a/step-generation/src/utils/misc.ts
+++ b/step-generation/src/utils/misc.ts
@@ -873,8 +873,8 @@ export const delayLocationHelper: CommandCreator<DelayLocationHelperArgs> = (
 }
 
 export const getSlotInLocationStack = (
-  stack?: string[],
-  isStacker?: boolean
+  stack: string[] | null,
+  isStacker: boolean = false
 ): string => {
   if (stack == null) {
     console.error('expected to find stack but could not')


### PR DESCRIPTION
# Overview

Add an additional size to `RobotInfoLabel` to acomodate stacker slot presentation and use .charAt() to only display stacker column
<img width="752" height="677" alt="Screenshot 2026-01-15 at 11 40 18 AM" src="https://github.com/user-attachments/assets/c0d77f16-4dc9-489c-8aa3-a2dab9a7b54a" />

## Test Plan and Hands on Testing

<img width="297" height="324" alt="Screenshot 2026-01-14 at 4 16 45 PM" src="https://github.com/user-attachments/assets/aedba2e6-8ea3-44db-a186-a9ea38b242db" />
<img width="679" height="667" alt="Screenshot 2026-01-14 at 4 16 51 PM" src="https://github.com/user-attachments/assets/c8e8114e-3118-4772-a851-98850cbf8825" />

## Review requests

is using charAt() safe?

## Risk assessment

- I adjusted a widely used component so medium risk, but with an additional case so everything else should be good

Closes RQA-5014 and RQA-5020
