### PR TITLE
fix(robot-server): Ensure global camera settings query uses clean path

### DIFF
--- a/robot-server/robot_server/service/legacy/routers/camera.py
+++ b/robot-server/robot_server/service/legacy/routers/camera.py
@@ -180,7 +180,9 @@ async def get_camera_capture_image_settings(
         cameraId: Camera ID for the camera settings to query.
         camera_provider: Access to the camera settings and related services.
     """
-    result = camera_settings_store.get_camera_capture_image_settings(camera_id=cameraId)
+    result = camera_settings_store.get_camera_capture_image_settings(
+        camera_id=cameraId if cameraId != DEFAULT_CAMERA_ID else DEFAULT_CAMERA_PATH
+    )
 
     return result
 

--- a/robot-server/robot_server/service/legacy/routers/camera.py
+++ b/robot-server/robot_server/service/legacy/routers/camera.py
@@ -183,6 +183,8 @@ async def get_camera_capture_image_settings(
     result = camera_settings_store.get_camera_capture_image_settings(
         camera_id=cameraId if DEFAULT_CAMERA_ID not in cameraId else DEFAULT_CAMERA_PATH
     )
+    # todo(chb, 2025-01-14): At some point we need to dereference camera devices and camera ids, and dedicate entirely one way or another.
+    # This isn't done now because of how the device field is pulled as a default camera by other sources for ffmpeg.
 
     return result
 

--- a/robot-server/robot_server/service/legacy/routers/camera.py
+++ b/robot-server/robot_server/service/legacy/routers/camera.py
@@ -181,7 +181,7 @@ async def get_camera_capture_image_settings(
         camera_provider: Access to the camera settings and related services.
     """
     result = camera_settings_store.get_camera_capture_image_settings(
-        camera_id=cameraId if cameraId != DEFAULT_CAMERA_ID else DEFAULT_CAMERA_PATH
+        camera_id=cameraId if DEFAULT_CAMERA_ID not in cameraId else DEFAULT_CAMERA_PATH
     )
 
     return result


### PR DESCRIPTION
# Overview
The initial implementation did not cover a case in which the default system camera is provided without a clean path for global settings queries. This rectifies that.

## Test Plan and Hands on Testing

- [x] Post general camera settings to a flex
- [x] Get the settings back using 'ot_system_camera' as the camera Id, receive expected results

## Changelog

## Review requests

## Risk assessment
Low