### PR TITLE
fix (protocol-designer, step-generation): remove nickname and correct liquid numbers

### DIFF
--- a/protocol-designer/src/assets/localization/en/starting_deck_state.json
+++ b/protocol-designer/src/assets/localization/en/starting_deck_state.json
@@ -53,6 +53,7 @@
   "lid": "Lids",
   "liquid": "Liquid",
   "liquids": "Liquids",
+  "multiple_liquid_layouts": "Multiple liquid layouts",
   "no_labware_added": "No labware added",
   "no_liquids_added": "No liquids added",
   "no_offdeck_labware": "No off-deck labware added",

--- a/protocol-designer/src/components/organisms/LabwareCard/__tests__/LabwareCard.test.tsx
+++ b/protocol-designer/src/components/organisms/LabwareCard/__tests__/LabwareCard.test.tsx
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { fixture96Plate } from '@opentrons/shared-data'
 import {
   getFullStackFromLabwares,
-  getLiquidIdsOnLabware,
+  getLiquidIdsOnLabwareStack,
 } from '@opentrons/step-generation'
 
 import { renderWithProviders } from '/protocol-designer/__testing-utils__'
@@ -13,7 +13,6 @@ import { i18n } from '../../../../assets/localization'
 import { openIngredientSelector } from '../../../../labware-ingred/actions'
 import { getDeckSetupForActiveItem } from '../../../../top-selectors/labware-locations'
 import * as wellContentsSelectors from '../../../../top-selectors/well-contents'
-import { getLabwareNicknamesById } from '../../../../ui/labware/selectors'
 import { EditLabwareQuantityModal } from '../../EditLabwareQuantityModal'
 import { LabwareCardOverflowMenu } from '../../LabwareCardOverflowMenu'
 import { LabwareCard } from '../index'
@@ -73,13 +72,10 @@ describe('LabwareCard', () => {
     vi.mocked(LabwareCardOverflowMenu).mockReturnValue(
       <div>mock LabwareCardOverflowMenu</div>
     )
-    vi.mocked(getLabwareNicknamesById).mockReturnValue({
-      labwareId: 'mock NickName',
-    })
     vi.mocked(
       wellContentsSelectors.getAllWellContentsForActiveItem
     ).mockReturnValue(null)
-    vi.mocked(getLiquidIdsOnLabware).mockReturnValue([])
+    vi.mocked(getLiquidIdsOnLabwareStack).mockReturnValue([])
     vi.mocked(getDeckSetupForActiveItem).mockReturnValue({
       modules: {},
       pipettes: {},
@@ -108,7 +104,6 @@ describe('LabwareCard', () => {
 
   it('renders a labware card with the liquids button and overflow menu', () => {
     render(props)
-    screen.getByText('mock NickName')
     screen.getByText('ANSI 96 Standard Microplate')
     screen.getByText('No liquids added')
     screen.getByText('with mock lid')
@@ -119,12 +114,12 @@ describe('LabwareCard', () => {
     screen.getByText('mock LabwareCardOverflowMenu')
   })
   it('renders a labware card with 2 liquids added', () => {
-    vi.mocked(getLiquidIdsOnLabware).mockReturnValue(['0', '1'])
+    vi.mocked(getLiquidIdsOnLabwareStack).mockReturnValue(['0', '1'])
     render(props)
-    screen.getByText('2 liquids')
+    screen.getByText('Multiple liquid layouts')
   })
   it('renders a labware card with 1 liquid added', () => {
-    vi.mocked(getLiquidIdsOnLabware).mockReturnValue(['0'])
+    vi.mocked(getLiquidIdsOnLabwareStack).mockReturnValue(['0'])
     render(props)
     screen.getByText('1 liquid')
   })

--- a/protocol-designer/src/components/organisms/LabwareCard/index.tsx
+++ b/protocol-designer/src/components/organisms/LabwareCard/index.tsx
@@ -22,7 +22,7 @@ import {
 } from '@opentrons/components'
 import {
   getFullStackFromLabwares,
-  getLiquidIdsOnLabware,
+  getLiquidIdsOnLabwareStack,
   HOPPER_STACKER_LOCATION,
 } from '@opentrons/step-generation'
 
@@ -30,11 +30,10 @@ import { LINK_BUTTON_STYLE } from '/protocol-designer/components/atoms'
 import { openIngredientSelector } from '/protocol-designer/labware-ingred/actions'
 import { getDeckSetupForActiveItem } from '/protocol-designer/top-selectors/labware-locations'
 import * as wellContentsSelectors from '/protocol-designer/top-selectors/well-contents'
-import { getLabwareNicknamesById } from '/protocol-designer/ui/labware/selectors'
 
 import { EditLabwareQuantityModal } from '../EditLabwareQuantityModal'
 import { LabwareCardOverflowMenu } from '../LabwareCardOverflowMenu'
-import { getCanModifyLabwareQuantity } from './utils'
+import { getCanModifyLabwareQuantity, getLiquidText } from './utils'
 
 import type { LabwareOnDeck } from '/protocol-designer/step-forms'
 import type { ThunkDispatch } from '/protocol-designer/types'
@@ -64,25 +63,24 @@ export function LabwareCard(props: LabwareCardProps): JSX.Element {
         : !deckSetupLabware[id].def.allowedRoles?.includes('adapter'))
   )
   const isOnHopper = labware.stack.includes(HOPPER_STACKER_LOCATION)
-  const nickNames = useSelector(getLabwareNicknamesById)
   const allWellContentsForActiveItem = useSelector(
     wellContentsSelectors.getAllWellContentsForActiveItem
   )
   const [showOverflowMenu, setShowOverflowMenu] = useState<boolean>(false)
   const wellContents =
     allWellContentsForActiveItem != null
-      ? allWellContentsForActiveItem[labware.id]
-      : null
+      ? Object.values(allWellContentsForActiveItem)
+      : []
   const displayName = def.metadata.displayName
-  const nickName = nickNames[labware.id]
   const isAdapterOrTiprack =
     def.allowedRoles?.includes('adapter') || def.parameters.isTiprack
   const isLid = def.allowedRoles?.includes('lid')
-  const isNicknameDifferent = nickName !== displayName
-  const liquidIds = getLiquidIdsOnLabware(wellContents)
+  const liquidIds = getLiquidIdsOnLabwareStack(wellContents)
+  const numOfUniqueLiquids = liquidIds.length
+
+  const liquidText = getLiquidText(numOfUniqueLiquids, t)
 
   const canModifyQuantity = getCanModifyLabwareQuantity(def, isOnHopper)
-
   let editButton: null | string = null
   if (
     (isOnHopper && def.parameters.isTiprack) ||
@@ -139,16 +137,8 @@ export function LabwareCard(props: LabwareCardProps): JSX.Element {
             >
               <Flex flexDirection={DIRECTION_COLUMN}>
                 <StyledText desktopStyle="bodyDefaultSemiBold">
-                  {nickName}
+                  {displayName}
                 </StyledText>
-                {isNicknameDifferent ? (
-                  <StyledText
-                    desktopStyle="bodyDefaultRegular"
-                    color={COLORS.grey60}
-                  >
-                    {displayName}
-                  </StyledText>
-                ) : null}
                 {lidId != null && deckSetupLabware[lidId] != null ? (
                   <StyledText
                     desktopStyle="bodyDefaultRegular"
@@ -161,13 +151,7 @@ export function LabwareCard(props: LabwareCardProps): JSX.Element {
                 ) : null}
                 <Flex gridGap={SPACING.spacing8} paddingTop={SPACING.spacing8}>
                   {!isAdapterOrTiprack && !isLid ? (
-                    <LiquidInfoDisplay
-                      text={
-                        liquidIds.length === 0
-                          ? t('no_liquids_added')
-                          : t('num_liquid', { count: liquidIds.length })
-                      }
-                    />
+                    <LiquidInfoDisplay text={liquidText} />
                   ) : null}
                   {quantity > 1 ? (
                     <LiquidInfoDisplay

--- a/protocol-designer/src/components/organisms/LabwareCard/utils.ts
+++ b/protocol-designer/src/components/organisms/LabwareCard/utils.ts
@@ -18,3 +18,16 @@ export const getCanModifyLabwareQuantity = (
   labwareDef: LabwareDefinition,
   isOnHopper: boolean
 ): boolean => getIsLid(labwareDef) || isOnHopper
+
+export const getLiquidText = (numOfUniqueLiquids: number, t: any): string => {
+  switch (numOfUniqueLiquids) {
+    case 0:
+      return t('no_liquids_added')
+    case 1:
+      return t('num_liquid', { count: 1 })
+    case 2:
+      return t('multiple_liquid_layouts')
+    default:
+      return ''
+  }
+}

--- a/protocol-designer/src/pages/Designer/DeckSetup/__tests__/DeckSetupToolbox.test.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/__tests__/DeckSetupToolbox.test.tsx
@@ -29,7 +29,6 @@ import {
 import { getDeckSetupForActiveItem } from '/protocol-designer/top-selectors/labware-locations'
 import * as wellContentsSelectors from '/protocol-designer/top-selectors/well-contents'
 import { getDismissedHints } from '/protocol-designer/tutorial/selectors'
-import { getLabwareNicknamesById } from '/protocol-designer/ui/labware/selectors'
 
 import { DeckSetupToolbox } from '../DeckSetupToolbox'
 
@@ -98,7 +97,6 @@ describe('DeckSetupToolbox', () => {
       bakeToast: vi.fn(),
       eatToast: vi.fn(),
     })
-    vi.mocked(getLabwareNicknamesById).mockReturnValue({})
     vi.mocked(
       wellContentsSelectors.getAllWellContentsForActiveItem
     ).mockReturnValue(null)
@@ -131,9 +129,6 @@ describe('DeckSetupToolbox', () => {
     )
   })
   it('should clear the slot from all items when the clear cta is called', () => {
-    vi.mocked(getLabwareNicknamesById).mockReturnValue({
-      labId: 'mock nickName',
-    })
     vi.mocked(selectors.getZoomedInSlotInfo).mockReturnValue({
       selectedAdapterDefURI: 'mockUri',
       selectedTopLabware: { labwareDefURI: 'mockUri', amount: 1 },
@@ -176,7 +171,6 @@ describe('DeckSetupToolbox', () => {
       },
     })
     render(props)
-    screen.getAllByText('mock nickName')
     screen.getByText('Edit liquid')
     screen.getByText('Bottom of slot')
     screen.getByText('Top of slot')

--- a/step-generation/src/utils/liquidUtils.ts
+++ b/step-generation/src/utils/liquidUtils.ts
@@ -85,6 +85,19 @@ export const getVolumesPerLiquid = (
   return volumesPerLiquid
 }
 
+export const getLiquidIdsOnLabwareStack = (
+  wellContents: ContentsByWell[]
+): string[] => {
+  const allLiquidIdsOnLabware = wellContents.flatMap(contentsByWell =>
+    contentsByWell == null
+      ? []
+      : Object.values(contentsByWell).flatMap(contents =>
+          contents.groupIds.filter(group => group !== AIR)
+        )
+  )
+  return Array.from(new Set(allLiquidIdsOnLabware))
+}
+
 export const getLiquidIdsOnLabware = (
   wellContents: ContentsByWell
 ): string[] => {


### PR DESCRIPTION
# Overview

Remove nick naming from labware card and correct liquid counts

## Test Plan and Hands on Testing

smoke tested: 

https://github.com/user-attachments/assets/84150831-a6aa-4fbd-9bf4-98e2961d8c2f

## Changelog

- remove nick name from labware card
- find all liquids in labware stack

## Risk assessment

low

Finishes off RQA-5016, RQA-5011, RQA-5043, RQA-5021