### PR TITLE
fix(app): fix deck view for non flex stacker protocol

### DIFF
--- a/app/src/organisms/Desktop/ProtocolVisualization/DeckView/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/DeckView/index.tsx
@@ -20,6 +20,7 @@ import {
   getDeckDefFromRobotType,
   isAddressableAreaStandardSlot,
   OT2_ROBOT_TYPE,
+  FLEX_STACKER_MODULE_TYPE,
   WASTE_CHUTE_CUTOUT,
 } from '@opentrons/shared-data'
 import { getSlotInLocationStack } from '@opentrons/step-generation'
@@ -90,10 +91,14 @@ export function DeckView(props: DeckViewProps): JSX.Element {
     wasteChuteEntities,
     stagingAreaEntities,
     labwareEntities,
+    moduleEntities,
   } = invariantContext
   const { labware, modules, pipettes } = robotState
   const loadLabwareCommands = commands.filter(
     command => command.commandType === 'loadLabware'
+  )
+  const hasFlexStacker = Object.values(moduleEntities).some(
+    module => module.type === FLEX_STACKER_MODULE_TYPE
   )
   const labwareEntitiesExtended = Object.entries(labwareEntities).reduce(
     (acc: Record<string, LabwareEntityExtended>, [key, entity]) => {
@@ -148,7 +153,7 @@ export function DeckView(props: DeckViewProps): JSX.Element {
           height="100%"
           width="100%"
           deckDef={deckDef}
-          adjustViewBoxForStacker={true}
+          adjustViewBoxForStacker={hasFlexStacker}
           viewBox={`${deckDef.cornerOffsetFromOrigin[0]} ${deckDef.cornerOffsetFromOrigin[1]} ${deckDef.dimensions[0]} ${deckDef.dimensions[1]}`}
         >
           {() => (

--- a/app/src/organisms/Desktop/ProtocolVisualization/DeckView/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/DeckView/index.tsx
@@ -16,11 +16,11 @@ import {
   WasteChuteStagingAreaFixture,
 } from '@opentrons/components'
 import {
+  FLEX_STACKER_MODULE_TYPE,
   getCutoutIdForAddressableArea,
   getDeckDefFromRobotType,
   isAddressableAreaStandardSlot,
   OT2_ROBOT_TYPE,
-  FLEX_STACKER_MODULE_TYPE,
   WASTE_CHUTE_CUTOUT,
 } from '@opentrons/shared-data'
 import { getSlotInLocationStack } from '@opentrons/step-generation'


### PR DESCRIPTION


# Overview
fix deck view for non flex stacker protocol

this is the first pr to fix DeckView responsiveness

https://github.com/user-attachments/assets/07f0090e-8c0c-4290-b19c-6be7b27977f9



## Test Plan and Hands on Testing
- select a protocol that doesn't use Flex Stacker
- click visualization button
check resize the window/change left and right col width

## Changelog
- add const to switch flex stacker / non flex stacker

## Review requests



## Risk assessment
low
