### PR TITLE
refactor(step-generation): more renames `pipetteName` -> `pythonName`

### DIFF
--- a/step-generation/src/commandCreators/compound/consolidate.ts
+++ b/step-generation/src/commandCreators/compound/consolidate.ts
@@ -379,10 +379,10 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
     }) ?? 0
 
   /** needed for python generation! > */
-  const destTrashPipetteName =
+  const destTrashPythonName =
     trashBinEntities[destLabware]?.pythonName ??
     wasteChuteEntities[destLabware]?.pythonName
-  const trashPipetteName =
+  const trashPythonName =
     trashBinEntities[dropTipLocation]?.pythonName ??
     wasteChuteEntities[dropTipLocation]?.pythonName
   const blowoutTrashPythonName =
@@ -449,7 +449,7 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
     `volume=${volume}`,
     `source=[${pythonSourceWells}]`,
     `dest=${
-      pythonDestWells != null ? `[${pythonDestWells}]` : destTrashPipetteName
+      pythonDestWells != null ? `[${pythonDestWells}]` : destTrashPythonName
     }`,
     `new_tip=${formatPyStr(formatChangeTipArg(changeTip))}`,
     ...(isReturnTip
@@ -459,7 +459,7 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
             ? [`trash_location=${blowoutTrashPythonName}`]
             : []),
         ]
-      : [`trash_location=${trashPipetteName}`, 'keep_last_tip=True']),
+      : [`trash_location=${trashPythonName}`, 'keep_last_tip=True']),
     ...(pipetteSpecs.channels > 1 ? [`group_wells=False`] : []),
     ...(tipracks.filteredSortedTiprackIds.length > 0
       ? [

--- a/step-generation/src/commandCreators/compound/consolidate.ts
+++ b/step-generation/src/commandCreators/compound/consolidate.ts
@@ -378,7 +378,7 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
       defaultValue: 0,
     }) ?? 0
 
-  /** needed for python generation! > */
+  /** needed for python generation! */
   const destTrashPythonName =
     trashBinEntities[destLabware]?.pythonName ??
     wasteChuteEntities[destLabware]?.pythonName

--- a/step-generation/src/commandCreators/compound/distribute.ts
+++ b/step-generation/src/commandCreators/compound/distribute.ts
@@ -424,7 +424,7 @@ export const distribute: CommandCreator<DistributeArgs> = (
       defaultValue: 0,
     }) ?? 0
 
-  /** needed for python generation! > */
+  /** needed for python generation! */
   const destTrashPythonName =
     trashBinEntities[destLabware]?.pythonName ??
     wasteChuteEntities[destLabware]?.pythonName

--- a/step-generation/src/commandCreators/compound/distribute.ts
+++ b/step-generation/src/commandCreators/compound/distribute.ts
@@ -425,10 +425,10 @@ export const distribute: CommandCreator<DistributeArgs> = (
     }) ?? 0
 
   /** needed for python generation! > */
-  const destTrashPipetteName =
+  const destTrashPythonName =
     trashBinEntities[destLabware]?.pythonName ??
     wasteChuteEntities[destLabware]?.pythonName
-  const trashPipetteName =
+  const trashPythonName =
     trashBinEntities[dropTipLocation]?.pythonName ??
     wasteChuteEntities[dropTipLocation]?.pythonName
   const blowoutTrashPythonName =
@@ -493,7 +493,7 @@ export const distribute: CommandCreator<DistributeArgs> = (
   const pythonArgs = [
     `volume=${volume}`,
     `source=[${pythonSourceWells}]`,
-    `dest=[${pythonDestWells ?? destTrashPipetteName}]`,
+    `dest=[${pythonDestWells ?? destTrashPythonName}]`,
     `new_tip=${formatPyStr(formatChangeTipArg(changeTip))}`,
     ...(isReturnTip
       ? [
@@ -502,7 +502,7 @@ export const distribute: CommandCreator<DistributeArgs> = (
             ? [`trash_location=${blowoutTrashPythonName}`]
             : []),
         ]
-      : [`trash_location=${trashPipetteName}`, 'keep_last_tip=True']),
+      : [`trash_location=${trashPythonName}`, 'keep_last_tip=True']),
     ...(pipetteSpecs.channels > 1 ? [`group_wells=False`] : []),
     ...(tipracks.filteredSortedTiprackIds.length > 0
       ? [


### PR DESCRIPTION
# Overview

I forgot that we also have `distribute.ts` and `consolidate.ts` :) Fixing the misnamed variables there too before I make structural changes to those files.

## Test Plan and Hands on Testing

Run CI tests.

## Risk assessment

Low. Pure refactoring, no change to behavior.