### PR TITLE
fix(pd-e2e): fix dismiss migration modal race condition

### DIFF
--- a/e2e-testing/utility.py
+++ b/e2e-testing/utility.py
@@ -80,6 +80,10 @@ def _dismiss_migration_modal(page: Page) -> None:
     """Dismiss the migration modal if it appears during import."""
 
     overlay = page.locator('[aria-label="BackgroundOverlay_ModalShell"]')
+    overlay.wait_for(state="visible", timeout=5000)
     if overlay.is_visible():
         page.get_by_role("button", name="Import", exact=True).click()
         expect(overlay).not_to_be_visible()
+    else:
+        print("Migration modal did not appear, proceeding with test.")
+        pass


### PR DESCRIPTION
# Overview

Four line code change to account for a timeout error that was occurring for the modal appearing

## Changelog

Added a wait for 5 seconds for the modal to appear, also added a print in case there is no modal, we can proceed with import as normal

## Risk assessment

