### PR TITLE
fix(protocol-designer): don't flip to offdeck view on stacker fill step save

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/index.tsx
@@ -202,8 +202,7 @@ export function ProtocolSteps({
       }
     } else if (
       zoomedInOnOffDeck &&
-      selectedTerminalItemId != null &&
-      selectedTerminalItemId === START_TERMINAL_ITEM_ID
+      selectedTerminalItemId! === START_TERMINAL_ITEM_ID
     ) {
       setDeckView(rightString)
     }

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/index.tsx
@@ -200,7 +200,11 @@ export function ProtocolSteps({
         })
         setViewBox(zoomedInViewBox)
       }
-    } else if (zoomedInOnOffDeck) {
+    } else if (
+      zoomedInOnOffDeck &&
+      selectedTerminalItemId != null &&
+      selectedTerminalItemId === START_TERMINAL_ITEM_ID
+    ) {
       setDeckView(rightString)
     }
   }, [zoomedInSlot, labware, zoomedInOnOffDeck])


### PR DESCRIPTION
# Overview

We shouldn't flip the deck view to offdeck when saving a fill stacker step. This issue arose in a `useEffect` in `ProtocolSteps`. We should only fire setting the deck view to offdeck if the deck state is the initial deck state.

Closes RQA-5031

## Test Plan and Hands on Testing

- create or import a stacker step
- create and save a fill step
- verify that the deck view does not flip to off-deck

## Changelog

- update useEffect condition for setting the deck view to off-deck (should only happen in starting deck state)

## Review requests

- see test plan

## Risk assessment

low