### PR TITLE
fix(protocol-designer): enable deleting multiple steps including stacker fill

### DIFF
--- a/protocol-designer/src/labware-ingred/actions/thunks.ts
+++ b/protocol-designer/src/labware-ingred/actions/thunks.ts
@@ -17,7 +17,11 @@ import { getNextAvailableDeckSlot, getNextNickname } from '../utils'
 
 import type { FlexStackerStoredLabwareGroup } from '@opentrons/shared-data'
 import type { FlexStackerModuleState } from '@opentrons/step-generation'
-import type { NormalizedLabware, NormalizedLabwareById } from '../../step-forms'
+import type {
+  ModuleOnDeck,
+  NormalizedLabware,
+  NormalizedLabwareById,
+} from '../../step-forms'
 import type { UpdateStackerModuleStateAction } from '../../step-forms/actions/modules'
 import type { ThunkAction } from '../../types'
 import type {
@@ -208,6 +212,9 @@ export interface EditMultipleLabwareAction {
 
 interface DeleteContainerArgs {
   labwareId: string
+  // needed to override the hopper/module checks below, since when we enter `deleteContainer`
+  // from deleting multiple steps, the active deck setup contains an empty object for modules and labware
+  stacker?: ModuleOnDeck
 }
 export const deleteContainer: (
   args: DeleteContainerArgs
@@ -216,18 +223,21 @@ export const deleteContainer: (
   | EditMultipleLabwareAction
   | UpdateStackerModuleStateAction
 > = args => (dispatch, getState) => {
-  const { labwareId } = args
+  const { labwareId, stacker } = args
   const state = getState()
   const labwareEntities = getLabwareEntities(state)
   const deckSetup = getDeckSetupForActiveItem(state)
   const { modules, labware } = deckSetup
-  const isLabwareOnHopper = labware[labwareId].stack.includes(
-    HOPPER_STACKER_LOCATION
-  )
-  const labwareSlot = getSlotInLocationStack(labware[labwareId].stack)
-  const moduleOnSlot = Object.values(modules).find(
-    ({ slot: moduleSlot }) => moduleSlot === labwareSlot
-  )
+  const isLabwareOnHopper =
+    stacker != null ||
+    labware[labwareId].stack.includes(HOPPER_STACKER_LOCATION)
+  const labwareSlot =
+    stacker?.slot ?? getSlotInLocationStack(labware[labwareId].stack)
+  const moduleOnSlot =
+    stacker ??
+    Object.values(modules).find(
+      ({ slot: moduleSlot }) => moduleSlot === labwareSlot
+    )
 
   const displayCategory =
     labwareEntities[labwareId].def.metadata.displayCategory

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/ConnectedStepContainer.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/ConnectedStepContainer.tsx
@@ -17,7 +17,10 @@ import {
   getMainPagePortalEl,
 } from '/protocol-designer/components/organisms'
 import { deleteContainer } from '/protocol-designer/labware-ingred/actions'
-import { getSavedStepForms } from '/protocol-designer/step-forms/selectors'
+import {
+  getInitialDeckSetup,
+  getSavedStepForms,
+} from '/protocol-designer/step-forms/selectors'
 import { actions as steplistActions } from '/protocol-designer/steplist'
 import {
   deselectAllSteps,
@@ -28,7 +31,7 @@ import { getMultiSelectItemIds } from '/protocol-designer/ui/steps/selectors'
 import { StepOverflowMenu } from './StepOverflowMenu'
 import {
   capitalizeFirstLetterAfterNumber,
-  getFillLabwareIdsToDelete,
+  getFillLabwareToDeleteData,
 } from './utils'
 
 import type { ThunkDispatch } from 'redux-thunk'
@@ -94,6 +97,7 @@ export function ConnectedStepContainer(
   const dispatch = useDispatch<ThunkDispatch<BaseState, any, any>>()
   const multiSelectItemIds = useSelector(getMultiSelectItemIds)
   const savedStepForms = useSelector(getSavedStepForms)
+  const { modules: deckSetupModules } = useSelector(getInitialDeckSetup)
   const hasText = sidebarWidth > PX_SIDEBAR_MIN_WIDTH_FOR_ICON
 
   const handleClick = (event: MouseEvent): void => {
@@ -136,10 +140,16 @@ export function ConnectedStepContainer(
   }
 
   const handleDeleteFillLabware = (stepIds: string[]): void => {
-    const fillLabwareIds = getFillLabwareIdsToDelete(stepIds, savedStepForms)
-    fillLabwareIds.forEach(id => {
-      dispatch(deleteContainer({ labwareId: id }))
-    })
+    const fillLabwareToDeleteData = getFillLabwareToDeleteData(
+      stepIds,
+      savedStepForms,
+      deckSetupModules
+    )
+    for (const { labwareIds, module } of fillLabwareToDeleteData) {
+      labwareIds.forEach(id => {
+        dispatch(deleteContainer({ labwareId: id, stacker: module }))
+      })
+    }
   }
 
   const onDeleteClickAction = (): void => {
@@ -185,6 +195,7 @@ export function ConnectedStepContainer(
       onDoubleClick?.(e)
     }
   }
+
   return (
     <>
       {showDeleteConfirmation === true && (

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/__tests__/ConnectedStepContainer.test.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/__tests__/ConnectedStepContainer.test.tsx
@@ -8,7 +8,10 @@ import { COLORS } from '@opentrons/components'
 
 import { renderWithProviders } from '/protocol-designer/__testing-utils__'
 import { i18n } from '/protocol-designer/assets/localization'
-import { getUnsavedForm } from '/protocol-designer/step-forms/selectors'
+import {
+  getInitialDeckSetup,
+  getUnsavedForm,
+} from '/protocol-designer/step-forms/selectors'
 import { getDeckSetupForActiveItem } from '/protocol-designer/top-selectors/labware-locations'
 
 import { ConnectedStepContainer } from '../ConnectedStepContainer'
@@ -49,6 +52,14 @@ describe('ConnectedStepContainer', () => {
     )
     vi.mocked(getUnsavedForm).mockReturnValue(null)
     vi.mocked(getDeckSetupForActiveItem).mockReturnValue({
+      labware: {},
+      modules: {},
+      additionalEquipmentOnDeck: {
+        trash: { id: 'trash', name: 'trashBin', location: 'cutoutA3' },
+      },
+      pipettes: {},
+    })
+    vi.mocked(getInitialDeckSetup).mockReturnValue({
       labware: {},
       modules: {},
       additionalEquipmentOnDeck: {

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/__tests__/utils.test.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/__tests__/utils.test.tsx
@@ -2,9 +2,14 @@ import { describe, expect, it } from 'vitest'
 
 import {
   capitalizeFirstLetterAfterNumber,
+  getFillLabwareToDeleteData,
   getShiftSelectedSteps,
 } from '../utils'
 
+import type {
+  ModuleOnDeck,
+  SavedStepFormState,
+} from '/protocol-designer/step-forms'
 import type { StepHierarchy } from '/protocol-designer/steplist/utils/stepHierarchy'
 
 describe('capitalizeFirstLetterAfterNumber', () => {
@@ -90,6 +95,129 @@ describe('getShiftSelectedSteps', () => {
       // step5 should be skipped because it's hidden in the UI
       'step6',
       'step7',
+    ])
+  })
+})
+
+describe('getFillLabwareToDeleteData', () => {
+  const mockModule = {
+    id: 'moduleId1',
+    type: 'heaterShakerModuleType',
+    model: 'someModel',
+    slot: 'slot1',
+    moduleState: {},
+  }
+  const anotherModule = {
+    id: 'moduleId2',
+    type: 'thermocyclerModuleType',
+    model: 'someOtherModel',
+    slot: 'slot2',
+    moduleState: {},
+  }
+  const mockDeckSetupModules = {
+    moduleId1: mockModule,
+    moduleId2: anotherModule,
+  } as unknown as Record<string, ModuleOnDeck>
+  const savedStepForms = {
+    step1: {
+      id: 'step1',
+      stepType: 'flexStacker',
+      fillLabwareIds: ['labware1', 'labware2'],
+      moduleId: 'moduleId1',
+    },
+    step2: {
+      id: 'step2',
+      stepType: 'flexStacker',
+      fillLabwareIds: ['labware3'],
+      moduleId: 'moduleId2',
+    },
+    step3: {
+      id: 'step3',
+      stepType: 'manualStep',
+      fillLabwareIds: ['labware4'],
+      moduleId: 'moduleId1',
+    },
+    step4: {
+      id: 'step4',
+      stepType: 'flexStacker',
+      fillLabwareIds: null,
+      moduleId: 'moduleId1',
+    },
+    step5: {
+      id: 'step5',
+      stepType: 'flexStacker',
+      fillLabwareIds: ['labware5'],
+      moduleId: 'doesNotExist',
+    },
+  } as unknown as SavedStepFormState
+
+  it('returns correct data for single step with fill labware', () => {
+    const result = getFillLabwareToDeleteData(
+      ['step1'],
+      savedStepForms,
+      mockDeckSetupModules
+    )
+    expect(result).toEqual([
+      { labwareIds: ['labware1', 'labware2'], module: mockModule },
+    ])
+  })
+
+  it('returns correct data for multiple steps, filtering for flexStacker with valid module and non-null fillLabwareIds', () => {
+    const result = getFillLabwareToDeleteData(
+      ['step1', 'step2'],
+      savedStepForms,
+      mockDeckSetupModules
+    )
+    expect(result).toEqual([
+      { labwareIds: ['labware1', 'labware2'], module: mockModule },
+      { labwareIds: ['labware3'], module: anotherModule },
+    ])
+  })
+
+  it('does not include steps that are not flexStacker', () => {
+    const result = getFillLabwareToDeleteData(
+      ['step3'],
+      savedStepForms,
+      mockDeckSetupModules
+    )
+    expect(result).toEqual([])
+  })
+
+  it('does not include steps with null fillLabwareIds', () => {
+    const result = getFillLabwareToDeleteData(
+      ['step4'],
+      savedStepForms,
+      mockDeckSetupModules
+    )
+    expect(result).toEqual([])
+  })
+
+  it('does not include steps where the module is not found', () => {
+    const result = getFillLabwareToDeleteData(
+      ['step5'],
+      savedStepForms,
+      mockDeckSetupModules
+    )
+    expect(result).toEqual([])
+  })
+
+  it('returns empty array if no steps match', () => {
+    const result = getFillLabwareToDeleteData(
+      [],
+      savedStepForms,
+      mockDeckSetupModules
+    )
+    expect(result).toEqual([])
+  })
+
+  it('handles a mix of valid and invalid steps', () => {
+    const result = getFillLabwareToDeleteData(
+      ['step1', 'step3', 'step4', 'step5'],
+      savedStepForms,
+      mockDeckSetupModules
+    )
+    expect(result).toEqual([
+      { labwareIds: ['labware1', 'labware2'], module: mockModule },
     ])
   })
 })

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/utils.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/utils.ts
@@ -7,7 +7,10 @@ import { convertStepHierarchyToArray } from '/protocol-designer/steplist/utils/s
 
 import type { MouseEvent } from 'react'
 import type { StepIdType } from '/protocol-designer/form-types'
-import type { SavedStepFormState } from '/protocol-designer/step-forms'
+import type {
+  ModuleOnDeck,
+  SavedStepFormState,
+} from '/protocol-designer/step-forms'
 import type { StepHierarchy } from '/protocol-designer/steplist/utils/stepHierarchy'
 
 export const capitalizeFirstLetterAfterNumber = (title: string): string =>
@@ -150,20 +153,25 @@ export const getMouseClickKeyInfo = (
 
 export const getUserOS = (): string | undefined => new UAParser().getOS().name
 
-export const getFillLabwareIdsToDelete = (
+interface FillLabwareToDeleteData {
+  labwareIds: string[]
+  module: ModuleOnDeck
+}
+
+export const getFillLabwareToDeleteData = (
   stepIds: string[],
-  savedStepForms: SavedStepFormState
-): string[] => {
-  return stepIds.reduce<string[]>((acc, stepId) => {
+  savedStepForms: SavedStepFormState,
+  deckSetupModules: Record<string, ModuleOnDeck>
+): FillLabwareToDeleteData[] => {
+  return stepIds.reduce<FillLabwareToDeleteData[]>((acc, stepId) => {
     const formData = savedStepForms[stepId]
-
-    if (
-      formData?.stepType === 'flexStacker' &&
-      formData.fillLabwareIds != null
-    ) {
-      acc.push(...(formData.fillLabwareIds as string[]))
-    }
-
-    return acc
+    const module = Object.values(deckSetupModules).find(
+      module => formData.moduleId === module.id
+    )
+    return formData?.stepType === 'flexStacker' &&
+      formData.fillLabwareIds != null &&
+      module != null
+      ? [...acc, { labwareIds: formData.fillLabwareIds as string[], module }]
+      : acc
   }, [])
 }


### PR DESCRIPTION
# Overview

Fixes a bug wherein a user tried to delete multiple steps simultaneously, in which at least one of the steps was a stacker fill step. In this case, we need to delete all labware created by the stacker fill step. Certain checks in the  `deleteContainer` thunk tried to find access the passed labwareIds' respective states from the deck state for the active item; however, in the event that multiple steps are active, deck setup for active item returns empty objects for labware, modules, etc.

Here, I explicitly pass necessary stacker information when deleting multiple steps. 

Closes RQA-5032

## Test Plan and Hands on Testing

test protocol: [flex_stacker_multiple_refill.py](https://github.com/user-attachments/files/24652397/flex_stacker_multiple_refill.py)


- create or import a protocol with multiple steps, including a stacker fill step
- multi-select the stacker fill step and any other step (can also be a stacker fill step), and confirm deletion
- verify that the labware associated with any stacker fill step is successfully deleted
- create a new stacker step and verify that the module state is updated correctly (notably, labware group quantity in hopper)

## Changelog

- refactor `deleteContainer` thunk to accept an optional stacker override for deleting multiple steps including stacker fill
- refactor utility for getting relevant labware to delete information when deleting a fill step, including the module
- add unit tests

## Review requests

see test plan

## Risk assessment

lowish. should only impact this specific case of deleting multiple steps including 1+ stacker fill steps