### PR TITLE
docs: update language for custom protocol service timelines

### DIFF
--- a/docs/flex/docs/protocols/development-service.md
+++ b/docs/flex/docs/protocols/development-service.md
@@ -2,7 +2,7 @@
 title: "Opentrons Flex: Custom Protocol Service"
 ---
 
-Opentrons provides a [Remote Custom Protocol Development service](https://opentrons.com/instrument-services) for applications not already included in the Protocol Library. Our comprehensive authoring and validation service has a turnaround time of two weeks. As part of the service, Opentrons field applications scientists will:
+Opentrons provides a [Remote Custom Protocol Development service](https://opentrons.com/instrument-services) for applications not already included in the Protocol Library. As part of the service, Opentrons field applications scientists will:
 
 - Develop the Python protocol.
 

--- a/docs/python-api/docs/index.md
+++ b/docs/python-api/docs/index.md
@@ -144,7 +144,7 @@ Questions about setting up your robot, using Opentrons software, or troubleshoot
 
 ### Custom protocol service
 
-Don't have the time or resources to write your own protocols? Our [custom protocol development service](https://opentrons.com/instrument-services/) can get you set up in two weeks.
+Don't have the time or resources to write your own protocols? Our [custom protocol development service](https://opentrons.com/instrument-services/) can help you set up and optimize your workflow.
 
 ### Contributing
 

--- a/docs/uv.lock
+++ b/docs/uv.lock
@@ -732,6 +732,7 @@ dependencies = [
     { name = "packaging" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "pyro5" },
     { name = "pyserial" },
     { name = "pyusb" },
     { name = "typing-extensions" },
@@ -745,23 +746,77 @@ requires-dist = [
     { name = "importlib-metadata", marker = "python_full_version < '3.8'", specifier = ">=1.0" },
     { name = "jsonschema", specifier = ">=3.0.1,<4.18.0" },
     { name = "numpy", specifier = ">=1.20.0,<2" },
-    { name = "opentrons-hardware", marker = "extra == 'ot2-hardware'", specifier = "==8.8.0" },
-    { name = "opentrons-hardware", extras = ["flex"], marker = "extra == 'flex-hardware'", specifier = "==8.8.0" },
-    { name = "opentrons-shared-data", specifier = "==8.8.0" },
-    { name = "packaging", specifier = ">=21.0" },
+    { name = "numpy", specifier = ">=1.26.4,<2" },
+    { name = "opentrons-shared-data", editable = "../shared-data" },
+    { name = "packaging", specifier = ">=25.0" },
     { name = "pydantic", specifier = ">=2.0.0,<3" },
     { name = "pydantic-settings", specifier = ">=2,<3" },
+    { name = "pyro5", specifier = ">=5.16,<6" },
     { name = "pyserial", specifier = ">=3.5" },
     { name = "pyusb", specifier = "==1.2.1" },
     { name = "typing-extensions", specifier = ">=4.0.0,<5" },
 ]
-provides-extras = ["flex-hardware", "ot2-hardware"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "anyio", specifier = "==4.9.0" },
+    { name = "atomicwrites", marker = "sys_platform == 'win32'", specifier = "==1.4.0" },
+    { name = "build", specifier = "~=1.2.0" },
+    { name = "colorama", marker = "sys_platform == 'win32'", specifier = "==0.4.4" },
+    { name = "coverage", specifier = "==7.4.1" },
+    { name = "decoy", specifier = ">=2.2.0,<3" },
+    { name = "hypothesis", specifier = ">=6.96.1,<7" },
+    { name = "jinja2", specifier = ">=2.3,<3.1" },
+    { name = "jsonschema", specifier = "==4.17.3" },
+    { name = "mock", specifier = "==5.1.0" },
+    { name = "mypy", specifier = "==1.19.1" },
+    { name = "numpy", specifier = "==1.26.4" },
+    { name = "numpydoc", specifier = "==0.9.1" },
+    { name = "opentrons-hardware", extras = ["flex"], editable = "../hardware" },
+    { name = "packaging", specifier = "==25.0" },
+    { name = "performance-metrics", editable = "../performance-metrics" },
+    { name = "pydantic", specifier = "==2.11.7" },
+    { name = "pydantic-settings", specifier = "==2.4.0" },
+    { name = "pyro5", specifier = "==5.16" },
+    { name = "pytest", specifier = ">=9.0.2" },
+    { name = "pytest-asyncio", specifier = ">=1.3.0,<2" },
+    { name = "pytest-cov", specifier = "==4.1.0" },
+    { name = "pytest-lazy-fixtures", specifier = ">=1.1.4,<2" },
+    { name = "pytest-profiling", specifier = "~=1.7.0" },
+    { name = "pytest-xdist", specifier = "~=2.5.0" },
+    { name = "pyusb", specifier = "==1.2.1" },
+    { name = "ruff", specifier = "==0.14.10" },
+    { name = "sphinx", specifier = "==5.0.1" },
+    { name = "sphinx-substitution-extensions", specifier = "==2020.9.30.0" },
+    { name = "sphinx-tabs", specifier = ">=3.4.1,<4" },
+    { name = "sphinxext-opengraph", specifier = "==0.8.1" },
+    { name = "twine", specifier = "==4.0.0" },
+    { name = "typeguard", specifier = "~=4.4.4" },
+    { name = "types-mock", specifier = "~=5.1.0" },
+    { name = "types-setuptools", specifier = "==57.0.2" },
+    { name = "typing-extensions", specifier = ">=4.0.0,<5" },
+    { name = "wheel", specifier = "==0.37.0" },
+    { name = "zipp", specifier = "==3.21.0" },
+]
+robot = [
+    { name = "anyio", specifier = "==4.9.0" },
+    { name = "jsonschema", specifier = "==4.17.3" },
+    { name = "numpy", specifier = "==1.26.4" },
+    { name = "opentrons-hardware", extras = ["flex"], editable = "../hardware" },
+    { name = "packaging", specifier = "==25.0" },
+    { name = "pydantic", specifier = "==2.11.7" },
+    { name = "pydantic-settings", specifier = "==2.4.0" },
+    { name = "pyro5", specifier = "==5.16" },
+    { name = "pyusb", specifier = "==1.2.1" },
+    { name = "zipp", specifier = "==3.21.0" },
+]
 
 [[package]]
 name = "opentrons-shared-data"
 source = { editable = "../shared-data" }
 dependencies = [
     { name = "jsonschema" },
+    { name = "numpy" },
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
@@ -769,8 +824,39 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "jsonschema", specifier = ">=4.0.0,<5" },
+    { name = "numpy", specifier = "~=1.26.4" },
     { name = "pydantic", specifier = ">=2.0.0,<3.0.0" },
     { name = "typing-extensions", specifier = ">=4.0.0,<5" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "atomicwrites", marker = "sys_platform == 'win32'", specifier = "==1.4.0" },
+    { name = "build", specifier = "~=1.2.0" },
+    { name = "colorama", marker = "sys_platform == 'win32'", specifier = "==0.4.4" },
+    { name = "jsonschema", specifier = "==4.17.3" },
+    { name = "mypy", specifier = "==1.19.1" },
+    { name = "numpy", specifier = "==1.26.4" },
+    { name = "pillow" },
+    { name = "pydantic", specifier = "==2.11.7" },
+    { name = "pytest", specifier = ">=9.0.2" },
+    { name = "pytest-clarity", specifier = "~=1.0.0" },
+    { name = "pytest-cov", specifier = "==4.1.0" },
+    { name = "pytest-xdist", specifier = "~=3.5.0" },
+    { name = "ruff", specifier = "==0.14.10" },
+    { name = "setuptools", specifier = "==80.9.0" },
+    { name = "twine", specifier = "==4.0.0" },
+    { name = "typeguard", specifier = "~=4.4.4" },
+    { name = "types-pillow" },
+    { name = "typing-extensions", specifier = ">=4.0.0,<5" },
+    { name = "wheel", specifier = "==0.37.1" },
+    { name = "zipp", specifier = "==3.21.0" },
+]
+robot = [
+    { name = "jsonschema", specifier = "==4.17.3" },
+    { name = "numpy", specifier = "==1.26.4" },
+    { name = "pydantic", specifier = "==2.11.7" },
+    { name = "zipp", specifier = "==3.21.0" },
 ]
 
 [[package]]
@@ -1010,6 +1096,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pyro5"
+version = "5.16"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "serpent" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6e/ab/38d7adb02f735f409e6af78951630f887590a885b2583c83cfe93a60b576/pyro5-5.16.tar.gz", hash = "sha256:d40418ed2acee0d9093daf5023ed0b0cb485a6b62342934adb9e801956f5738b", size = 448592, upload-time = "2025-12-21T18:33:58.552Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/4d/7713c06c1a9eaa35142e232e89da5300cac09156977204c730b28f37eaec/pyro5-5.16-py3-none-any.whl", hash = "sha256:ea33cad29993fd44ce394ef45950e8dc5805ee12c4dd76541a8dd11c40694706", size = 79294, upload-time = "2025-12-21T18:33:57.096Z" },
+]
+
+[[package]]
 name = "pyrsistent"
 version = "0.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1185,6 +1283,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+]
+
+[[package]]
+name = "serpent"
+version = "1.42"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/3c/7ecf39b48121cb6490634bfcb1b1c5cac7d7a216805d889b0676a2e8493f/serpent-1.42.tar.gz", hash = "sha256:8ea082b01f8ba07ecd74e34a9118ac4521bc4594938d912b808c89f1da425506", size = 90352, upload-time = "2025-10-26T21:58:13.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/24/73031e6bd25d8f94811b3752b0b217efbdb20a67b65c6838c9af4e50c2e2/serpent-1.42-py3-none-any.whl", hash = "sha256:a02f5a4fcf3b41ee6204b36c3cf026bf0433ffe15b6a7fc8a37e0bff74d87575", size = 9663, upload-time = "2025-10-26T21:58:12.565Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Overview

Update language on the documentation site to reflect that custom protocol service delivery times can be variable on a case-to-case basis.

## Test Plan and Hands on Testing

[sandbox](https://sandbox.docs.opentrons.com/docs-custom-protocol-timing/)

## Changelog

Updates language on 
- Python docs homepage
- Flex manual > protocols > development service page

## Review requests

words good?

## Risk assessment

none, docs only