### PR TITLE
fix(app): type annotation for `commonFields` in generateQuickTransferArgs.ts

### DIFF
--- a/app/src/organisms/ODD/QuickTransferFlow/utils/generateQuickTransferArgs.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/utils/generateQuickTransferArgs.ts
@@ -15,10 +15,7 @@ import {
   makeInitialRobotState,
 } from '@opentrons/step-generation'
 
-import {
-  DEFAULT_MM_BLOWOUT_OFFSET_FROM_TOP,
-  DEFAULT_MM_TOUCH_TIP_OFFSET_FROM_TOP,
-} from '../constants'
+import { DEFAULT_MM_TOUCH_TIP_OFFSET_FROM_TOP } from '../constants'
 
 import type {
   CutoutConfig,
@@ -34,6 +31,7 @@ import type {
   LabwareEntities,
   PipetteEntities,
   RobotState,
+  SharedTransferLikeArgs,
   TransferArgs,
   TrashBinEntities,
   WasteChuteEntities,
@@ -447,8 +445,8 @@ export function generateQuickTransferArgs(
   const touchTipAfterAspirateOffsetMmFromTop =
     quickTransferState.touchTipAspirate ?? DEFAULT_MM_TOUCH_TIP_OFFSET_FROM_TOP
 
-  const commonFields = {
-    stepId: 1,
+  const commonFields: SharedTransferLikeArgs = {
+    stepNumber: 1,
     pipette: pipetteEntity.id,
     volume: quickTransferState.volume,
     sourceLabware: sourceLabwareEntity?.id!,
@@ -463,7 +461,6 @@ export function generateQuickTransferArgs(
       quickTransferState.path === 'multiDispense'
         ? (quickTransferState.disposalVolumeDispenseSettings?.flowRate ?? 0)
         : (quickTransferState.blowOutDispense?.flowRate ?? 0),
-    blowoutOffsetFromTopMm: DEFAULT_MM_BLOWOUT_OFFSET_FROM_TOP,
     changeTip: quickTransferState.changeTip,
     preWetTip: quickTransferState.preWetTip,
     aspirateDelay:


### PR DESCRIPTION
# Overview

Add type annotation for the `commonFields` object in `generateQuickTransferArgs.ts` so TypeScript knows what it is, and to help VS Code find usages of the fields.

This detected 2 errors:
- There is no field called `stepId`. It should be `stepNumber`. (I think this is what was causing the generated Python file to say `name="distribute_step_undefined"` instead of having a step number in the name.)
- `blowoutOffsetFromTopMm` is not a valid field for `TransferArgs`. We might have deleted it at some point in the past, or maybe the author was confusing it with the field in `MixArgs`.

(This is preliminary work for AUTH-2540.)

## Test Plan and Hands on Testing

Try it on robot.
Run CI tests.

## Risk assessment

Low.