### PR TITLE
refactor(app): Does anything even use InitialSummaryStateProps.disposalVolumeDispenseSettings?

### DIFF
--- a/app/src/organisms/ODD/QuickTransferFlow/__tests__/utils/getInitialSummaryState.test.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/__tests__/utils/getInitialSummaryState.test.ts
@@ -169,14 +169,6 @@ describe('getInitialSummaryState', () => {
         path: 'single',
         liquidClassValuesInitialized: false,
         changeTip: 'always',
-        disposalVolumeDispenseSettings: {
-          volume: 1,
-          flowRate: 75,
-          blowoutLocation: {
-            cutoutFixtureId: 'trashBinAdapter',
-            cutoutId: 'cutoutA3',
-          },
-        },
       } as any,
       deckConfig: [
         {

--- a/app/src/organisms/ODD/QuickTransferFlow/utils/getInitialSummaryState.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/utils/getInitialSummaryState.ts
@@ -12,7 +12,6 @@ import type {
   PipetteV2Specs,
 } from '@opentrons/shared-data'
 import type {
-  BlowOutLocation,
   ChangeTipOptions,
   PathOption,
   QuickTransferSummaryState,
@@ -37,11 +36,6 @@ export interface InitialSummaryStateProps {
     }
     changeTip: ChangeTipOptions
     dropTipLocation?: CutoutConfig
-    disposalVolumeDispenseSettings?: {
-      volume: number
-      blowOutLocation: BlowOutLocation
-      flowRate: number
-    }
   }
   deckConfig: DeckConfiguration
 }
@@ -102,10 +96,6 @@ export function getInitialSummaryState(
     aspirateFlowRate: flowRatesForSupportedTip.defaultAspirateFlowRate.default,
     dispenseFlowRate: flowRatesForSupportedTip.defaultDispenseFlowRate.default,
     path,
-    disposalVolumeDispenseSettings:
-      path === 'multiDispense'
-        ? state.disposalVolumeDispenseSettings
-        : undefined,
     blowOutDispense:
       path !== 'multiDispense'
         ? {


### PR DESCRIPTION
# Overview

This is preliminary cleanup for AUTH-2540, where we want to force the user to pick the same trash fixture for blowout as they picked for tip-drop.

As @jerader has pointed out before, we have too many state objects in Quick Transfer, like `InitialSummaryStateProps` vs `QuickTransferSummaryState` (AUTH-2541).

We have a `InitialSummaryStateProps.disposalVolumeDispenseSettings` field that contains a blowout location, but as far as I can tell, there is no code that actually sets the field.

So I just want to delete `InitialSummaryStateProps.disposalVolumeDispenseSettings` in this PR.

## Test Plan and Hands on Testing

Run CI tests.
Tried it on the robot. I was able to create a Distribute step.

## Risk assessment

Low.