### PR TITLE
feat(app): keep track of numberOfAtomicCommands in PV mixpanel

### DIFF
--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderContent/ActionButton/hooks/useActionButtonProperties.ts
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderContent/ActionButton/hooks/useActionButtonProperties.ts
@@ -142,6 +142,7 @@ export function useActionButtonProperties({
     protocolRunControls,
     runHeaderModalContainerUtils,
     isCameraReadyToRun,
+    numberOfAtomicCommands: 0,
   })
 
   if (isProtocolNotReady) {

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderContent/RunHeaderSectionLower/index.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderContent/RunHeaderSectionLower/index.tsx
@@ -33,6 +33,7 @@ export function RunHeaderSectionLower({
   runId,
   runStatus,
   robotName,
+  numberOfAtomicCommands,
 }: RunHeaderContentProps): JSX.Element {
   const { t } = useTranslation('run_details')
   const navigate = useNavigate()
@@ -74,7 +75,7 @@ export function RunHeaderSectionLower({
     const targetPath = `/devices/${robotName}/protocol-runs/${runId}/${encodedTimestamp}/${protocolKey}/visualization`
     trackEvent({
       name: ANALYTICS_LAUNCH_PROTOCOL_VISUALIZATION,
-      properties: { sourceLocation: 'protocol run' },
+      properties: { sourceLocation: 'protocol run', numberOfAtomicCommands },
     })
     navigate(targetPath)
   }

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderContent/index.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderContent/index.tsx
@@ -16,6 +16,7 @@ export type RunHeaderContentProps = ProtocolRunHeaderProps & {
   runHeaderModalContainerUtils: UseRunHeaderModalContainerResult
   isClosingCurrentRun: boolean
   robotName: string
+  numberOfAtomicCommands: number
 }
 
 export function RunHeaderContent(props: RunHeaderContentProps): JSX.Element {

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/__tests__/RunHeaderSectionLower.test.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/__tests__/RunHeaderSectionLower.test.tsx
@@ -75,6 +75,7 @@ describe('RunHeaderSectionLower', () => {
       runId: mockRunId,
       runStatus: null,
       robotName: mockRobotName,
+      numberOfAtomicCommands: 10,
     }
     vi.mocked(useToaster).mockReturnValue({
       makeSnackbar: mockMakeSnackbar,
@@ -167,7 +168,10 @@ describe('RunHeaderSectionLower', () => {
     )
     expect(mockTrackEvent).toHaveBeenCalledWith({
       name: ANALYTICS_LAUNCH_PROTOCOL_VISUALIZATION,
-      properties: { sourceLocation: 'protocol run' },
+      properties: {
+        sourceLocation: 'protocol run',
+        numberOfAtomicCommands: 10,
+      },
     })
   })
 })

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/index.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/index.tsx
@@ -128,6 +128,11 @@ export function ProtocolRunHeader(
           protocolRunControls={protocolRunControls}
           runHeaderModalContainerUtils={runHeaderModalContainerUtils}
           isClosingCurrentRun={isClosingCurrentRun}
+          numberOfAtomicCommands={
+            protocolData?.status === 'completed'
+              ? protocolData.commands.length
+              : 0
+          }
           {...props}
         />
         <RunProgressMeter {...props} />

--- a/app/src/organisms/Desktop/ProtocolDetails/ProtocolDetailsHeader.tsx
+++ b/app/src/organisms/Desktop/ProtocolDetails/ProtocolDetailsHeader.tsx
@@ -78,7 +78,7 @@ export function ProtocolDetailsHeader({
   const navigate = useNavigate()
   const trackEvent = useTrackEvent()
   const [isReadMore, setIsReadMore] = useState(true)
-
+  const numberOfAtomicCommands = mostRecentAnalysis?.commands.length ?? 0
   const protocolDescription = mostRecentAnalysis?.metadata.description ?? ''
   const slicedDescription = protocolDescription.slice(0, MAX_DESCRIPTION_LENGTH)
   const isDescriptionTruncated =
@@ -135,7 +135,10 @@ export function ProtocolDetailsHeader({
   const handleClickTimeline = (): void => {
     trackEvent({
       name: ANALYTICS_LAUNCH_PROTOCOL_VISUALIZATION,
-      properties: { sourceLocation: 'protocol details header' },
+      properties: {
+        sourceLocation: 'protocol details header',
+        numberOfAtomicCommands,
+      },
     })
     navigate(`/protocols/${protocolKey}/visualization`)
   }


### PR DESCRIPTION
closes AUTH-2706

# Overview

add the number of atomic commands of the protocol where the user access's the visualization button

## Test Plan and Hands on Testing

review the code

## Changelog

add a new mixpanel property to existing event

## Risk assessment

low
