### PR TITLE
feat(protocol-designer): include Opentrons reservoirs in recommended stacker labware

### DIFF
--- a/protocol-designer/src/pages/Designer/DeckSetup/constants.ts
+++ b/protocol-designer/src/pages/Designer/DeckSetup/constants.ts
@@ -125,6 +125,10 @@ export const RECOMMENDED_LABWARE_BY_MODULE: { [K in ModuleType]: string[] } = {
     'nest_96_wellplate_2ml_deep',
     'nest_96_wellplate_100ul_pcr_full_skirt',
     'nest_96_wellplate_200ul_flat',
+    // Opentrons-branded reservoirs
+    'opentrons_tough_12_reservoir_22ml',
+    'opentrons_tough_1_reservoir_300ml',
+    'opentrons_tough_4_reservoir_72ml',
   ],
 }
 


### PR DESCRIPTION
# Overview

We should recommend all (3) Opentrons reservoirs in our recommended labware for the Flex stacker. Note that compatibility is defined in a hard-coded array of loadnames, which is not ideal and should be refactored if/when labware definitions carry the information needed to determine compatibility.

Closes RQA-5029

## Test Plan and Hands on Testing

- create or import a stacker protocol, and select the hopper to add labware to
- verify that with "Only display recommended labware" checked on, the "Reservoir" category shows
- expand the reservoir category, and verify that the 3 opentrons-branded reservoirs are listed

## Changelog

- add Opentrons-branded reservoirs to Flex stacker recommended labware

## Review requests

- see test plan

## Risk assessment

low