### PR TITLE
fix(protocol-designer): fix clearing wells from all labware in hopper

### DIFF
--- a/protocol-designer/src/components/organisms/AssignLiquidsModal/LabwareToolbox.tsx
+++ b/protocol-designer/src/components/organisms/AssignLiquidsModal/LabwareToolbox.tsx
@@ -166,11 +166,10 @@ export function LabwareStackToolbox({
   }
 
   const handleSelectAllLabware = (): void => {
+    dispatch(multipleIngredientsSelector(topDownStackIds))
     if (!allLabwareLiquidsEqual(topDownStackIds)) {
       setShowLiquidLayoutOverlay(true)
-      return
     }
-    dispatch(multipleIngredientsSelector(topDownStackIds))
   }
 
   const handleAssignToLabware = (

--- a/protocol-designer/src/components/organisms/AssignLiquidsModal/LiquidToolbox.tsx
+++ b/protocol-designer/src/components/organisms/AssignLiquidsModal/LiquidToolbox.tsx
@@ -177,16 +177,18 @@ function LiquidToolbox({
   }
 
   const handleClearAllWells: () => void = () => {
-    if (labwareId != null && activeItemHasLiquids) {
-      if (
-        global.confirm(t('application:are_you_sure_clear_all_wells') as string)
-      ) {
-        dispatch(
-          removeWellsContents({
-            labwareId,
-            wells: allWellsForActiveItem,
-          })
-        )
+    if (
+      global.confirm(t('application:are_you_sure_clear_all_wells') as string)
+    ) {
+      for (const labwareId of selectedLabwareIds) {
+        if (labwareId != null && activeItemHasLiquids) {
+          dispatch(
+            removeWellsContents({
+              labwareId,
+              wells: allWellsForActiveItem,
+            })
+          )
+        }
       }
     }
   }

--- a/protocol-designer/src/components/organisms/OverlayModal/LiquidsOverlayModal.tsx
+++ b/protocol-designer/src/components/organisms/OverlayModal/LiquidsOverlayModal.tsx
@@ -18,11 +18,21 @@ export function LiquidLayoutOverlayModalContainer({
 
   const dispatch = useDispatch()
   const allWellContents = useSelector(
-    wellContentsSelectors.getWellContentsForLabwareStack
+    wellContentsSelectors.getWellContentsAllLabware
   )
-  const labwareId = useSelector(selectors.getSelectedLabwareId)
-  const wellContents = allWellContents[labwareId ?? ''] ?? {}
-  const wellContentsId = Object.keys(wellContents)
+  const selectedLabwareIds = useSelector(selectors.getSelectedLabwareIds)
+
+  const handleClearLiquids = (): void => {
+    for (const labwareId of selectedLabwareIds ?? []) {
+      const wellContents = allWellContents[labwareId] ?? {}
+      dispatch(
+        removeWellsContents({
+          labwareId,
+          wells: Object.keys(wellContents),
+        })
+      )
+    }
+  }
 
   return (
     <OverlayModal
@@ -31,12 +41,7 @@ export function LiquidLayoutOverlayModalContainer({
       primaryButtonProps={{
         text: t('clear_liquids'),
         onClick: () => {
-          dispatch(
-            removeWellsContents({
-              labwareId: labwareId ?? '',
-              wells: wellContentsId,
-            })
-          )
+          handleClearLiquids()
           showLiquidOverflowMenu(false)
         },
       }}


### PR DESCRIPTION
# Overview

Fix behavior for clearing all wells from multiple labware in a stack. This behavior is corrected in 2 places- 1) in LiquidToolbox (if the labwares' liquid layouts are identical), and 2) in LiquidsOverlayModal (if the labwares' liquid layouts are not identical)

Closes RQA-5022

## Test Plan and Hands on Testing

### identical liquid layouts ([test protocol](https://github.com/user-attachments/files/24675911/flex_stacker_test_same_liquids.py))
- upload the attached protocol and edit the hopper's labware liquids
- select all labware, and verify that the overlay does _not_ show
- in the liquids toolbox on the right, click "Clear wells" and confirm
- click each labware individually and verify that all wells in each labware were cleared of liquids

### non-identical liquid layouts ([test protocol](https://github.com/user-attachments/files/24675902/flex_stacker_different_liquids.py))
- upload the attached protocol and edit the hopper's labware liquids
- select all labware, and verify that the overlay _does_ show
- in the overlay, click "Clear liquids"
- click each labware individually and verify that all wells in each labware were cleared of liquids

## Changelog

- handle clearing multiple labwares in overlay and liquid toolbox
- ensure you can select all labware even if liquids mismatch 

## Review requests

- see test plan

## Risk assessment

low