### PR TITLE
chore(docs): Fix build failing from broken cross-reference

### DIFF
--- a/.github/workflows/docs-build-deploy.yaml
+++ b/.github/workflows/docs-build-deploy.yaml
@@ -3,6 +3,7 @@ name: 'Docs build and deploy'
 on:
   pull_request:
     paths:
+      - 'api/**'
       - 'docs/**'
       - '.github/workflows/docs-build-deploy.yaml'
       - 'scripts/static-deploy/**'

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -965,8 +965,7 @@ class ProtocolContext(CommandPublisher):
                 [`MagneticBlockContext`][opentrons.protocol_api.MagneticBlockContext],
                 [`MagneticModuleContext`][opentrons.protocol_api.MagneticModuleContext],
                 [`TemperatureModuleContext`][opentrons.protocol_api.TemperatureModuleContext],
-                [`ThermocyclerContext`][opentrons.protocol_api.ThermocyclerContext],
-                or [`VacuumModuleContext`][opentrons.protocol_api.VacuumModuleContext],
+                or [`ThermocyclerContext`][opentrons.protocol_api.ThermocyclerContext],
                 depending on what you requested with `module_name`.
 
                 *Changed in version 2.13:*


### PR DESCRIPTION
This fixes `docs/` failing to build on `edge` since #20501 merged.

The error was that a docstring in `api/` was trying to link to `VacuumModuleContext`, which isn't public yet. CI didn't catch the problem on that PR because it was only triggering on changes in `docs/`, not in `api/`.