### PR TITLE
fix(protocol-designer): delete stacker fill labware if stacker step type changes

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/index.tsx
@@ -149,6 +149,15 @@ function StepFormManager(props: StepFormManagerProps): JSX.Element | null {
             hydratedForm.fillLabwareIds
           )
         }
+      } else if (
+        hydratedForm.stepType === 'flexStacker' &&
+        savedStepForm?.flexStackerFormType === FLEX_STACKER_FILL &&
+        hydratedForm.flexStackerFormType !== FLEX_STACKER_FILL
+      ) {
+        // logic for deleting fill labware if the stacker form type changes from fill to something else
+        const fillLabwareIds =
+          (savedStepForm.fillLabwareIds as string[] | null) ?? []
+        deleteLabwares(fillLabwareIds)
       }
     } else {
       // There's a dialog we have to show before saving the step.


### PR DESCRIPTION
# Overview

Similar to how we delete labwares created by a stacker fill step if that step is deleted, we should delete labwares created by a saved stacker fill step if that step is changed to empty, store, or retrieve.

Closes RQA-5048

## Test Plan and Hands on Testing

- create or import a protocol with a stacker fill step (example)
- edit the fill step to any other stacker step type (empty, retrieve, store)
- save and select any step after the edited step in the timeline, or the Ending deck state
- select the off-deck view, and verify that no extraneous labwares created by the initial fill step remain

## Changelog

- check to see if step type changed from stacker fill to stacker [anything else] when saving the step form, and delete previously created labware if so

## Review requests

see test plan

## Risk assessment

lowish