### PR TITLE
chore(e2e-testing): Revert back to expecting a "Confirm" button, not "Add pause"

### DIFF
--- a/e2e-testing/automation/pd_pages/heater_shaker_step_form_page.py
+++ b/e2e-testing/automation/pd_pages/heater_shaker_step_form_page.py
@@ -68,7 +68,7 @@ class HeaterShakerStepPage(BasePage):
 
     def pause_confirm(self) -> None:
         """Confirm the pause in the step editor."""
-        self.page.get_by_role("button", name="Add pause step").click()
+        self.page.get_by_role("button", name="Confirm").click()
 
     ## Composite step
 

--- a/e2e-testing/automation/pd_pages/tempdeck_step_form_page.py
+++ b/e2e-testing/automation/pd_pages/tempdeck_step_form_page.py
@@ -13,7 +13,7 @@ class TemperatureStepPage(BasePage):
         super().__init__(page)
         self._save_button = self.page.get_by_role("button", name="Save")
         self._target_temp_toggle_turn_on = self.page.locator('[data-testid^="ToggleButton_"]')
-        self._pause_button = self.page.get_by_role("button", name="Add pause")
+        self._pause_button = self.page.get_by_role("button", name="Confirm")
         self._temp_module_label = self.page.get_by_text("Temperature Module state", exact=True)
 
     def wait_for_form_load(self) -> None:


### PR DESCRIPTION
## Overview

Commit 6551b779110b07e34b8174f9fd050f25803071a6 carried some E2E test fixes that made sense for `edge`, but also some that did not make sense for `edge`. The `chore_release-pd-8.8.0` branch ought to have the "Add pause" text, whereas the `edge` branch ought to have the "Confirm" text. This swaps the tests on `edge` back so they look for the "Confirm" text.

## Test Plan and Hands on Testing

* [x] E2E tests succeed now.

## Review requests

None.

## Risk assessment

Low.
