### PR TITLE
refactor(app): delete QuickTransferWizardState.disposalVolumeDispenseSettings as well

### DIFF
--- a/app/src/organisms/ODD/QuickTransferFlow/types.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/types.ts
@@ -29,11 +29,6 @@ export interface QuickTransferWizardState {
   changeTip?: ChangeTipOptions
   dropTipLocation?: CutoutConfig | string
   liquidClassName?: string
-  disposalVolumeDispenseSettings?: {
-    volume: number
-    blowOutLocation: BlowOutLocation
-    flowRate: number
-  }
 }
 export type PathOption = 'single' | 'multiAspirate' | 'multiDispense'
 export type ChangeTipOptions =


### PR DESCRIPTION
# Overview

There doesn't seem to be anything that uses `QuickTransferWizardState.disposalVolumeDispenseSettings` either? (AUTH-2541).

This is more preliminary cleanup for AUTH-2540.

## Test Plan and Hands on Testing

Run CI tests.

## Review requests

I'm a little perplexed as to how we meant to use `QuickTransferWizardState` and `InitialSummaryStateProps`.

## Risk assessment

Low.