### PR TITLE
fix(protocol-designer): update hopper labware state when clearing

### DIFF
--- a/protocol-designer/src/pages/Designer/DeckSetup/SlotOverflowMenu.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/SlotOverflowMenu.tsx
@@ -180,6 +180,7 @@ export function SlotOverflowMenu(
             moduleState: {
               ...stackerModuleState,
               storedLabwareDetails: null,
+              labwareInHopper: null,
             },
           })
         )


### PR DESCRIPTION
# Overview

In starting deck state, we should set null both the stored labware details as well as the labware in hopper properties of the stacker.

Closes RQA-5051

## Test Plan and Hands on Testing

- import the protocol from the ticket
- in starting deck state, clear the hopper labware
- hover the hopper and verify that no whitescreen appears

## Changelog

- reset labware in hopper on module state when clearing the hopper labware

## Review requests

see test plan

## Risk assessment

low