### PR TITLE
feat(app): add Mixpanel track event for sizes

### DIFF
--- a/app/src/organisms/Desktop/ProtocolVisualization/VisualizerContainer/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/VisualizerContainer/index.tsx
@@ -15,6 +15,7 @@ import { Controls } from '/app/organisms/Desktop/ProtocolVisualization/Controls'
 import { DeckView } from '/app/organisms/Desktop/ProtocolVisualization/DeckView'
 import {
   ANALYTICS_LAUNCH_PROTOCOL_VISUALIZATION_SPOTLIGHT_WINDOW,
+  ANALYTICS_NOTIFICATION_PROTOCOL_VISUALIZATION_VIEWPORT_SIZES,
   useTrackEvent,
 } from '/app/redux/analytics'
 import {
@@ -59,6 +60,7 @@ export function VisualizerContainer(
   const createdDate = new Date(analysisOutput.createdAt)
   const completedProtocolAnalysis = useMostRecentCompletedAnalysis(runId)
   const trackEvent = useTrackEvent()
+  const trackEventRef = useRef(trackEvent)
   const analysis = completedProtocolAnalysis ?? analysisOutput
   const { commands, robotType, liquids } = analysis
   const [isPlaying, setIsPlaying] = useState<boolean>(false)
@@ -89,6 +91,12 @@ export function VisualizerContainer(
   useEffect(() => {
     rightWidthRef.current = rightWidth
   }, [rightWidth])
+
+  // Note: This useEffect is used to update the trackEventRef.current with the trackEvent prop.
+  // This prevents sending duplicate events when the trackEvent prop changes.
+  useEffect(() => {
+    trackEventRef.current = trackEvent
+  }, [trackEvent])
 
   // temporarily filter out loadCommands and home commands for the PV MVP
   const filteredCommands = commands.filter(
@@ -280,6 +288,20 @@ export function VisualizerContainer(
       dispatch(stepDetailViewerCloseAction({ protocolKey }))
     }
   }, [dispatch, protocolKey])
+
+  useEffect(() => {
+    return () => {
+      trackEventRef.current({
+        name: ANALYTICS_NOTIFICATION_PROTOCOL_VISUALIZATION_VIEWPORT_SIZES,
+        properties: {
+          'Window Width': window.innerWidth,
+          'Window Height': window.innerHeight,
+          'Left Column Width': leftWidthRef.current,
+          'Right Column Width': rightWidthRef.current,
+        },
+      })
+    }
+  }, [])
 
   return (
     <div ref={containerRef} className={styles.layout_container}>

--- a/app/src/redux/analytics/constants.ts
+++ b/app/src/redux/analytics/constants.ts
@@ -46,10 +46,16 @@ export const ANALYTICS_ODD_APP_ERROR = 'oddError'
 export const ANALYTICS_DESKTOP_APP_ERROR = 'desktopAppError'
 export const ANALYTICS_NOTIFICATION_PORT_BLOCK_ERROR =
   'notificationPortBlockError'
+
+/**
+ * Protocol Visualization Analytics
+ */
 export const ANALYTICS_LAUNCH_PROTOCOL_VISUALIZATION =
   'launchProtocolVisualization'
 export const ANALYTICS_LAUNCH_PROTOCOL_VISUALIZATION_SPOTLIGHT_WINDOW =
   'launchProtocolVisualizationSpotlightWindow'
+export const ANALYTICS_NOTIFICATION_PROTOCOL_VISUALIZATION_VIEWPORT_SIZES =
+  'notificationProtocolVisualizationViewportSizes'
 
 const ANALYTICS_PROTOCOL_PROCEED_BUTTON_TEXT = [
   ANALYTICS_PROCEED_TO_CAMERA_SETUP_STEP,


### PR DESCRIPTION


# Overview
add Mixpanel track event for sizes

close AUTH-2527

```json
{
  "event": "notificationProtocolVisualizationViewportSizes",
  "properties": {
    "time": 1768693194.291,
    "distinct_id": "distinct_id",
    "$browser": "Chrome",
    "$browser_version": 142,
    "$city": "Queens",
    "$current_url": "http://localhost:5173/#/labware",
    "$initial_referrer": "$direct",
    "$initial_referring_domain": "$direct",
    "$insert_id": "insert_id",
    "$lib_version": "2.22.1",
    "$mp_api_endpoint": "api.mixpanel.com",
    "$mp_api_timestamp_ms": 1768693194291,
    "$mp_event_size": 832,
    "$os": "Mac OS X",
    "$region": "New York",
    "$screen_height": 1600,
    "$screen_width": 2560,
    "Left Column Width": 590, // this pr adds
    "Right Column Width": 429, // this pr adds
    "U2E Device Name": "USB 10/100/1000 LAN",
    "U2E IPv4 Address": false,
    "U2E Manufacturer": "Realtek",
    "U2E Product ID": 33107,
    "U2E Serial Number": "000001",
    "U2E Vendor ID": 3034,
    "Window Height": 768, // this pr adds
    "Window Width": 1548, // this pr adds
    "appId": "appid",
    "appMode": "Desktop",
    "appVersion": "version",
    "customLabwareCount": 12,
    "mp_country_code": "US",
    "mp_lib": "web",
    "mp_processing_time_ms": 1768693197273
  }
}
```

## Test Plan and Hands on Testing


## Changelog


## Review requests


## Risk assessment
low
