### PR TITLE
fix(abr-testing): error handling for abr set up script

### DIFF
--- a/abr-testing/abr_testing/data_collection/abr_hepauv.py
+++ b/abr-testing/abr_testing/data_collection/abr_hepauv.py
@@ -7,6 +7,7 @@ import os
 import sys
 from pathlib import Path
 import json
+import gspread  # type: ignore[import]
 
 
 def get_hepa_serials(storage_directory: Path) -> List[List[Any]]:
@@ -146,7 +147,12 @@ def turning_hepa_off_and_uv_on(
     row_indices = [i - 1 for i in row_nums]  # API needs 0-based
     google_sheet.batch_delete_rows(row_indices, "1790601450")
     google_sheet.update_row_index()
-    google_sheet.batch_update_cells(nested_list, "A", starting_row_index, "1790601450")
+    try:
+        google_sheet.batch_update_cells(
+            nested_list, "A", starting_row_index, "1790601450"
+        )
+    except gspread.exceptions.APIError:
+        print("⚠️Warning: Did NOT time stamp turning off hepa/uv.")
 
 
 def run(

--- a/abr-testing/abr_testing/tools/abr_setup.py
+++ b/abr-testing/abr_testing/tools/abr_setup.py
@@ -146,14 +146,6 @@ def main(configurations: configparser.ConfigParser) -> None:
     sheet_name = configurations["RUN-LOG"]["sheet_name"]
     hepa_on = input("Are you turning HEPA Fans on or off? ")
     run_hepa_uv(hepa_on.lower(), sheet_name, storage_directory)
-    if hepa_on == "off":
-        continue_str = input(
-            "Type 'continue' to continue with the rest of the set up script."
-        )
-        if continue_str == "continue":
-            print("Script will continue.")
-        else:
-            sys.exit()
     # Run Temperature Sensors
     ambient_conditions_sheet = configurations["TEMP-SENSOR"]["sheet_url"]
     ambient_conditions_sheet_name = configurations["TEMP-SENSOR"]["sheet_name"]


### PR DESCRIPTION
# Overview

If hepa uv time stamping script does not find corresponding time stamp, an error message will be printed and then the script will continue

## Test Plan and Hands on Testing
tested:
<img width="829" height="164" alt="Screenshot 2026-01-20 at 8 04 53 AM" src="https://github.com/user-attachments/assets/ceb0ea15-cc21-4f00-b92b-6063015f905a" />

## Changelog
- added APIError handling

