### PR TITLE
fix(app): fix hover state on OT-2 deck view without module

### DIFF
--- a/app/src/organisms/Desktop/ProtocolVisualization/DeckView/DeckViewOverlay/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/DeckView/DeckViewOverlay/index.tsx
@@ -72,11 +72,12 @@ export function DeckViewOverlay(props: SlotOverlayProps): JSX.Element | null {
   const slotMapped = HOPPER_FAKE_LOCATIONS.includes(slotId)
     ? FAKE_HOPPER_LOCATION_MAP[slotId as HopperLocationMapKey]
     : slotId
-  const hasTCOnSlot = Object.entries(modules).some(
-    ([id, module]) =>
-      module.slot === slotMapped &&
-      moduleEntities[id].type === THERMOCYCLER_MODULE_TYPE
-  )
+  const hasTCOnSlot = Object.entries(modules).some(([id, module]) => {
+    const entity = moduleEntities[id]
+    return (
+      module.slot === slotMapped && entity?.type === THERMOCYCLER_MODULE_TYPE
+    )
+  })
   const tcSlots = robotType === FLEX_ROBOT_TYPE ? ['A1'] : ['8', '10', '11']
   const stagingAreaLocations = Object.values(stagingAreaEntities)?.map(
     stagingArea => stagingArea.location as string

--- a/app/src/organisms/Desktop/ProtocolVisualization/DeckView/DeckViewOverlay/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/DeckView/DeckViewOverlay/index.tsx
@@ -175,7 +175,7 @@ export function DeckViewOverlay(props: SlotOverlayProps): JSX.Element | null {
     )
   } else {
     const { width, x, y, height } = getOT2HoverDimensions(
-      hasTCOnSlot != null,
+      hasTCOnSlot,
       slotPosition
     )
 


### PR DESCRIPTION


# Overview
fix OT-2 deck view mouse over

[before]
<img width="400" height="298" alt="Screenshot 2026-01-20 at 10 42 48 AM" src="https://github.com/user-attachments/assets/4f7cf875-aab0-4765-9268-f46816e0faf2" />

[after]
<img width="396" height="328" alt="Screenshot 2026-01-20 at 10 43 43 AM" src="https://github.com/user-attachments/assets/1de939e9-945a-4507-9cf1-6c4077433d73" />

related to RQA-4984

## Test Plan and Hands on Testing
- select an OT-2 protocol
- click visualization button
- mouse over on the OT-2 deck view

## Changelog

## Review requests


## Risk assessment
low
