### PR TITLE
fix(protocol-designer,-step-generation): delete stacker labware when removing module

### DIFF
--- a/protocol-designer/src/components/organisms/FlexHardware/index.tsx
+++ b/protocol-designer/src/components/organisms/FlexHardware/index.tsx
@@ -4,6 +4,7 @@ import { useDispatch, useSelector } from 'react-redux'
 
 import {
   FLEX_ROBOT_TYPE,
+  FLEX_STACKER_MODULE_TYPE,
   getCutoutIdForSlotName,
   getDeckDefFromRobotType,
   MAGNETIC_BLOCK_TYPE,
@@ -38,6 +39,7 @@ import type {
   DeckConfiguration,
   FlexModuleCutoutFixtureId,
 } from '@opentrons/shared-data'
+import type { ModuleOnDeck } from '/protocol-designer/step-forms'
 import type { ThunkDispatch } from '/protocol-designer/types'
 import type { FixtureName, Fixtures } from '..'
 import type { InitialDeckStateModules } from '../HardwareConfigurator/AddFixtureModal'
@@ -141,12 +143,38 @@ export function FlexHardware(): JSX.Element {
     },
     {}
   )
+  const handleDeleteStackerLabware = (module: ModuleOnDeck): void => {
+    if (module.moduleState.type === FLEX_STACKER_MODULE_TYPE) {
+      // delete hopper labware
+      for (const labwareGroup of module.moduleState.labwareInHopper ?? []) {
+        for (const labwareId of Object.values(labwareGroup)) {
+          if (labwareId != null) {
+            dispatch(deleteContainer({ labwareId, stacker: module }))
+          }
+        }
+      }
+      // delete shuttle labware
+      if (module.moduleState.labwareOnShuttle != null) {
+        for (const labwareId of Object.values(
+          module.moduleState.labwareOnShuttle
+        )) {
+          if (labwareId != null) {
+            dispatch(deleteContainer({ labwareId, stacker: module }))
+          }
+        }
+      }
+    }
+  }
+
   const handleConfirmDeleteEntity = (modalInfo: {
     ids: string[]
     deckConfig: DeckConfiguration
   }): void => {
     modalInfo.ids.forEach(item => {
       if (moduleOnDeck[item] != null) {
+        if (moduleOnDeck[item].type === FLEX_STACKER_MODULE_TYPE) {
+          handleDeleteStackerLabware(moduleOnDeck[item])
+        }
         dispatch(deleteModule({ moduleId: item }))
       } else if (labwareOnDeck[item] != null) {
         dispatch(deleteContainer({ labwareId: item }))

--- a/step-generation/src/commandCreators/atomic/flexStackerEmpty.ts
+++ b/step-generation/src/commandCreators/atomic/flexStackerEmpty.ts
@@ -9,17 +9,21 @@ export const flexStackerEmpty: CommandCreator<
   FlexStackerEmptyCreateCommand['params']
 > = (args, invariantContext, prevRobotState) => {
   const { moduleEntities } = invariantContext
-  const flexStackerState = flexStackerStateGetter(prevRobotState, args.moduleId)
+  const { moduleId, strategy, message, count } = args
+  const flexStackerState = flexStackerStateGetter(prevRobotState, moduleId)
+  if (moduleId == null || moduleEntities[moduleId] == null) {
+    return { errors: [errorCreators.missingModuleError()] }
+  }
 
   const errors: CommandCreatorError[] = []
-  if (args.moduleId == null || flexStackerState == null) {
+  if (flexStackerState == null) {
     errors.push(errorCreators.missingModuleError())
   }
 
   if (errors.length > 0) {
     return { errors }
   }
-  const pythonName = moduleEntities[args.moduleId].pythonName
+  const pythonName = moduleEntities[moduleId].pythonName
 
   return {
     commands: [
@@ -27,10 +31,10 @@ export const flexStackerEmpty: CommandCreator<
         commandType: 'flexStacker/empty',
         key: uuid(),
         params: {
-          moduleId: args.moduleId,
-          strategy: args.strategy,
-          message: args.message,
-          count: args.count,
+          moduleId,
+          strategy: strategy,
+          message: message,
+          count: count,
         },
       },
     ],

--- a/step-generation/src/commandCreators/atomic/flexStackerFillItems.ts
+++ b/step-generation/src/commandCreators/atomic/flexStackerFillItems.ts
@@ -19,6 +19,9 @@ export const flexStackerFillItems: CommandCreator<FlexStackerFillItemsArgs> = (
 ) => {
   const { moduleId, interventionMessage, fillLabwareIds } = args
   const { labwareEntities, moduleEntities } = invariantContext
+  if (moduleId == null || moduleEntities[moduleId] == null) {
+    return { errors: [errorCreators.missingModuleError()] }
+  }
   const flexStackerState = flexStackerStateGetter(robotState, moduleId)
   const isSpace = getIsSpaceInHopper(
     flexStackerState,
@@ -36,7 +39,12 @@ export const flexStackerFillItems: CommandCreator<FlexStackerFillItemsArgs> = (
     labwarePythonNames.length < 4
       ? labwarePythonNames.join(', ')
       : `\n${indentedLabwarePythonNames}\n`
-  if (flexStackerState?.storedLabwareDetails === null) {
+
+  if (
+    flexStackerState != null &&
+    flexStackerState.storedLabwareDetails === null &&
+    flexStackerState.labwareInHopper == null
+  ) {
     return {
       errors: [errorCreators.flexStackerLabwareTypeMissing()],
     }

--- a/step-generation/src/commandCreators/atomic/flexStackerRetrieve.ts
+++ b/step-generation/src/commandCreators/atomic/flexStackerRetrieve.ts
@@ -10,6 +10,9 @@ export const flexStackerRetrieve: CommandCreator<
 > = (args, invariantContext, robotState) => {
   const { moduleId } = args
   const { moduleEntities } = invariantContext
+  if (moduleId == null || moduleEntities[moduleId] == null) {
+    return { errors: [errorCreators.missingModuleError()] }
+  }
   const modulePythonName = moduleEntities[moduleId].pythonName
   const flexStackerState = flexStackerStateGetter(robotState, moduleId)
   const isLabwareInHopper =

--- a/step-generation/src/commandCreators/atomic/flexStackerStore.ts
+++ b/step-generation/src/commandCreators/atomic/flexStackerStore.ts
@@ -14,13 +14,14 @@ export const flexStackerStore: CommandCreator<
   FlexStackerStoreCreateCommand['params']
 > = (args, invariantContext, robotState) => {
   const { moduleId } = args
-  const pythonName = invariantContext.moduleEntities[moduleId].pythonName
+  const { labwareEntities, moduleEntities } = invariantContext
+  if (moduleId == null || moduleEntities[moduleId] == null) {
+    return { errors: [errorCreators.missingModuleError()] }
+  }
+  const pythonName = moduleEntities[moduleId].pythonName
   const flexStackerState = flexStackerStateGetter(robotState, moduleId)
   const labwareId = flexStackerState?.labwareOnShuttle?.primaryLabwareId ?? null
-  const isSpace = getIsSpaceInHopper(
-    flexStackerState,
-    invariantContext.labwareEntities
-  )
+  const isSpace = getIsSpaceInHopper(flexStackerState, labwareEntities)
   if (flexStackerState !== null && !getLabwareIdOnShuttle(flexStackerState)) {
     return {
       errors: [errorCreators.flexStackerShuttleEmpty()],


### PR DESCRIPTION
# Overview

If a stacker module is removed in Deck Hardware, its labware cannot be logically placed directly on the deck (shuttle labware would require a staging area addition, and hopper labware have no corresponding deck location), so we should remove all its labware.

Closes RQA-5049

## Test Plan and Hands on Testing
[flex_stacker_test_delete.py](https://github.com/user-attachments/files/24742572/flex_stacker_test_delete.py)

- import test protocol with a stacker configured with shuttle and hopper labware, and a step that uses the stacker
- in Deck Hardware, delete the stacker
- navigate to starting deck, and verify that all the labware on the shuttle and hopper was successfully deleted
- verify that the steps that used the deleted stacker raise a timeline error informing you that the module does not exist
- verify no white screens when hovering or opening those errored-steps

## Changelog

- special-case delete all stacker labware when deleting the stacker from the protocol's hardware
- return module not found timeline error in each stacker command creator

## Review requests

see test plan

## Risk assessment

low