### PR TITLE
fix(protocol-designer): clear gripper field

### DIFF
--- a/protocol-designer/src/pages/Onboarding/SelectBasics.tsx
+++ b/protocol-designer/src/pages/Onboarding/SelectBasics.tsx
@@ -272,6 +272,7 @@ export function SelectBasics(props: WizardTileProps): JSX.Element {
                 onChange={() => {
                   setValue('fields.robotType', OT2_ROBOT_TYPE)
                   resetPipettes()
+                  setValue('hasGripper', false)
                   setValue('modules', {})
                   setValue('fixtures', ot2TrashFixture)
                 }}


### PR DESCRIPTION
# Overview

Ensure gripper field is cleared to prevent gripperEntity being added to OT-2 protocol.

On the select basics page, if a user started with a flex protocol and then switched to an OT-2 protocol, the gripperEntity would stay defined and cause the protocol to later fail analysis. This ensures the gripperEntity is cleared when switching to an OT-2 protocol.

## Test Plan and Hands on Testing

smoke tested w/ logs

## Risk assessment

low 

Closes RQA-5052