### PR TITLE
refactor(app): only report image capture usage when run contained images

### DIFF
--- a/app/src/redux-resources/analytics/hooks/useCameraAnalytics.ts
+++ b/app/src/redux-resources/analytics/hooks/useCameraAnalytics.ts
@@ -92,14 +92,16 @@ export function useCameraAnalytics({
   }
 
   const reportImageCaptureUsage = (data: CaptureParams): void => {
-    doTrackEvent({
-      name: ANALYTICS_IMAGE_CAPTURE_KIND,
-      properties: {
-        robotType,
-        transactionId: data.transactionId,
-        amount: data.amount,
-      },
-    })
+    if (data.amount > 0) {
+      doTrackEvent({
+        name: ANALYTICS_IMAGE_CAPTURE_KIND,
+        properties: {
+          robotType,
+          transactionId: data.transactionId,
+          amount: data.amount,
+        },
+      })
+    }
   }
 
   const reportLiveFeedUsage = (data: LiveFeedParams): void => {


### PR DESCRIPTION
# Overview

The `cameraImageCaptureKind` analytic reports how many images were taken for all runs, not just those with images. Product has requested we only report this event for runs that contain any images.

## Risk assessment

effectively none