### PR TITLE
(chore) 8.8.1 stable release notes

### DIFF
--- a/api/release-notes.md
+++ b/api/release-notes.md
@@ -10,9 +10,9 @@ By installing and using Opentrons software, you agree to the Opentrons End-User 
 
 ## Opentrons Robot Software Changes in 8.8.1
 
-The 8.8.1 hotfix release includes a small fix to allow all robots to properly reboot after a recent upgrade.
+The 8.8.1 hotfix release includes a small fix to allow all robots to properly boot after a recent upgrade.
 
-If error recovery was enabled in v8.8.0, installing v8.8.1 allows the robot to properly reboot. 
+If error recovery was enabled in v8.8.0, installing v8.8.1 allows the robot to properly boot. 
 
 ## Opentrons Robot Software Changes in 8.8.0
 

--- a/api/release-notes.md
+++ b/api/release-notes.md
@@ -10,7 +10,9 @@ By installing and using Opentrons software, you agree to the Opentrons End-User 
 
 ## Opentrons Robot Software Changes in 8.8.1
 
-The 8.8.1 hotfix release includes a small fix to allow all robots to properly reboot after an upgrade to v8.8.0.
+The 8.8.1 hotfix release includes a small fix to allow all robots to properly reboot after a recent upgrade.
+
+If error recovery was enabled in v8.8.0, installing v8.8.1 allows the robot to properly reboot. 
 
 ## Opentrons Robot Software Changes in 8.8.0
 

--- a/app-shell/build/release-notes.md
+++ b/app-shell/build/release-notes.md
@@ -10,7 +10,7 @@ By installing and using Opentrons software, you agree to the Opentrons End-User 
 
 There are no changes to the Opentrons App in v8.8.1.
 
-Installing robot software v8.8.1 allows all robots to properly reboot after a recent upgrade to robot software to v8.8.0.
+Installing robot software v8.8.1 allows all robots to properly reboot after a recent upgrade to robot software v8.8.0.
 
 ## Opentrons App Changes in 8.8.0
 

--- a/app-shell/build/release-notes.md
+++ b/app-shell/build/release-notes.md
@@ -10,7 +10,7 @@ By installing and using Opentrons software, you agree to the Opentrons End-User 
 
 There are no changes to the Opentrons App in v8.8.1.
 
-Installing robot software v8.8.1 allows all robots to properly reboot after a recent upgrade to robot software v8.8.0.
+Installing robot software v8.8.1 allows all robots to properly boot after a recent upgrade to robot software v8.8.0.
 
 ## Opentrons App Changes in 8.8.0
 


### PR DESCRIPTION
# Overview

adding to the 8.8.1 hotfix release notes + clarifying that robots need this update to reboot _if_ error recovery was enabled in 8.8.0. 

## Test Plan and Hands on Testing



## Changelog

added this to robot software release notes only. 

## Review requests



## Risk assessment

low
