### PR TITLE
fix(protocol-designer): allow lids on shuttle

### DIFF
--- a/protocol-designer/src/components/organisms/SelectLabwareModal/SelectLabware.tsx
+++ b/protocol-designer/src/components/organisms/SelectLabwareModal/SelectLabware.tsx
@@ -62,8 +62,6 @@ export function SelectLabware(props: SelectLabwareProps): JSX.Element | null {
   const zoomedInSlotInfo = useSelector(selectors.getZoomedInSlotInfo)
   const { selectedTopLabware, selectedAdapterDefURI, selectedLidLabware } =
     zoomedInSlotInfo
-  const isStackerShuttleOrHopper =
-    zoomedInSlotInfo.selectedModuleModel === FLEX_STACKER_MODULE_V1
   const lidLoadNames = Object.values(defs)
     .filter(
       def =>
@@ -111,7 +109,7 @@ export function SelectLabware(props: SelectLabwareProps): JSX.Element | null {
   return (
     <>
       {ORDERED_CATEGORIES.map(category => {
-        const isLidValid = category === 'tipRack' || !isStackerShuttleOrHopper
+        const isLidValid = category === 'tipRack' || !isOnHopper
         if (filteredLabwareByCategory[category].length > 0) {
           return (
             <ListButton
@@ -152,45 +150,45 @@ export function SelectLabware(props: SelectLabwareProps): JSX.Element | null {
 
                     const stackingProps: StackingProps | null =
                       isOnHopper ||
-                      (stackingLabwareDefUris.length === 1 &&
-                        slot !== 'offDeck')
+                        (stackingLabwareDefUris.length === 1 &&
+                          slot !== 'offDeck')
                         ? {
-                            inputTitle: t('labware_quantity'),
-                            errorMessage: t('unsupported_range'),
-                            inputCaption: t('valid_range', {
-                              max: isOnHopper
-                                ? hopperStackLimit
-                                : defs[stackingLabwareDefUris[0]].stackLimit,
-                            }),
-                            definition: defs[stackingLabwareDefUris[0]],
-                            inputFieldValue: selectedTopLabware.amount ?? 0,
-                            onInputFieldChange: (e: ChangeEvent<any>) => {
-                              dispatch(
-                                selectTopLabwareAmount({
-                                  amount: parseInt(e.target.value as string),
-                                })
-                              )
-                            },
-                            checkboxCaption: t('with_lid', {
-                              name: defs[stackingLabwareDefUris[0]].metadata
-                                .displayName,
-                            }),
-                            checked: selectedLidLabware != null,
-                            onCheckboxChange:
-                              (!isTiprack && isOnHopper) || !isLidValid
-                                ? undefined
-                                : () => {
-                                    dispatch(
-                                      selectLid({
-                                        labwareDefURI:
-                                          selectedLidLabware ===
-                                          stackingLabwareDefUris[0]
-                                            ? null
-                                            : stackingLabwareDefUris[0],
-                                      })
-                                    )
-                                  },
-                          }
+                          inputTitle: t('labware_quantity'),
+                          errorMessage: t('unsupported_range'),
+                          inputCaption: t('valid_range', {
+                            max: isOnHopper
+                              ? hopperStackLimit
+                              : defs[stackingLabwareDefUris[0]].stackLimit,
+                          }),
+                          definition: defs[stackingLabwareDefUris[0]],
+                          inputFieldValue: selectedTopLabware.amount ?? 0,
+                          onInputFieldChange: (e: ChangeEvent<any>) => {
+                            dispatch(
+                              selectTopLabwareAmount({
+                                amount: parseInt(e.target.value as string),
+                              })
+                            )
+                          },
+                          checkboxCaption: t('with_lid', {
+                            name: defs[stackingLabwareDefUris[0]].metadata
+                              .displayName,
+                          }),
+                          checked: selectedLidLabware != null,
+                          onCheckboxChange:
+                            (!isTiprack && isOnHopper) || !isLidValid
+                              ? undefined
+                              : () => {
+                                dispatch(
+                                  selectLid({
+                                    labwareDefURI:
+                                      selectedLidLabware ===
+                                        stackingLabwareDefUris[0]
+                                        ? null
+                                        : stackingLabwareDefUris[0],
+                                  })
+                                )
+                              },
+                        }
                         : null
                     return searchFilter(def.metadata.displayName) &&
                       !getIsLabwareFiltered(def) ? (

--- a/protocol-designer/src/components/organisms/SelectLabwareModal/SelectLabware.tsx
+++ b/protocol-designer/src/components/organisms/SelectLabwareModal/SelectLabware.tsx
@@ -150,45 +150,45 @@ export function SelectLabware(props: SelectLabwareProps): JSX.Element | null {
 
                     const stackingProps: StackingProps | null =
                       isOnHopper ||
-                        (stackingLabwareDefUris.length === 1 &&
-                          slot !== 'offDeck')
+                      (stackingLabwareDefUris.length === 1 &&
+                        slot !== 'offDeck')
                         ? {
-                          inputTitle: t('labware_quantity'),
-                          errorMessage: t('unsupported_range'),
-                          inputCaption: t('valid_range', {
-                            max: isOnHopper
-                              ? hopperStackLimit
-                              : defs[stackingLabwareDefUris[0]].stackLimit,
-                          }),
-                          definition: defs[stackingLabwareDefUris[0]],
-                          inputFieldValue: selectedTopLabware.amount ?? 0,
-                          onInputFieldChange: (e: ChangeEvent<any>) => {
-                            dispatch(
-                              selectTopLabwareAmount({
-                                amount: parseInt(e.target.value as string),
-                              })
-                            )
-                          },
-                          checkboxCaption: t('with_lid', {
-                            name: defs[stackingLabwareDefUris[0]].metadata
-                              .displayName,
-                          }),
-                          checked: selectedLidLabware != null,
-                          onCheckboxChange:
-                            (!isTiprack && isOnHopper) || !isLidValid
-                              ? undefined
-                              : () => {
-                                dispatch(
-                                  selectLid({
-                                    labwareDefURI:
-                                      selectedLidLabware ===
-                                        stackingLabwareDefUris[0]
-                                        ? null
-                                        : stackingLabwareDefUris[0],
-                                  })
-                                )
-                              },
-                        }
+                            inputTitle: t('labware_quantity'),
+                            errorMessage: t('unsupported_range'),
+                            inputCaption: t('valid_range', {
+                              max: isOnHopper
+                                ? hopperStackLimit
+                                : defs[stackingLabwareDefUris[0]].stackLimit,
+                            }),
+                            definition: defs[stackingLabwareDefUris[0]],
+                            inputFieldValue: selectedTopLabware.amount ?? 0,
+                            onInputFieldChange: (e: ChangeEvent<any>) => {
+                              dispatch(
+                                selectTopLabwareAmount({
+                                  amount: parseInt(e.target.value as string),
+                                })
+                              )
+                            },
+                            checkboxCaption: t('with_lid', {
+                              name: defs[stackingLabwareDefUris[0]].metadata
+                                .displayName,
+                            }),
+                            checked: selectedLidLabware != null,
+                            onCheckboxChange:
+                              (!isTiprack && isOnHopper) || !isLidValid
+                                ? undefined
+                                : () => {
+                                    dispatch(
+                                      selectLid({
+                                        labwareDefURI:
+                                          selectedLidLabware ===
+                                          stackingLabwareDefUris[0]
+                                            ? null
+                                            : stackingLabwareDefUris[0],
+                                      })
+                                    )
+                                  },
+                          }
                         : null
                     return searchFilter(def.metadata.displayName) &&
                       !getIsLabwareFiltered(def) ? (


### PR DESCRIPTION
# Overview

Unblock adding any labware with lids on a stacker shuttle.

Closes RQA-5068

## Test Plan and Hands on Testing

- create or import a protocol with a stacker
- in starting deck state, select the shuttle, and click a non-tiprack labware to add (like a wellplate)
- verify that the lid field populates correctly
- select the hopper, and click a non-tiprack labware to add (like a wellplate)
- verify that no lid field populates

## Changelog

- fix logic for lid addition on _not_ the hopper

## Review requests

- see test plan

## Risk assessment

low