### PR TITLE
fix(protocol-designer): delete all labware from hopper in LabwareCard

### DIFF
--- a/protocol-designer/src/components/organisms/LabwareCardOverflowMenu/__tests__/LabwareCardOverflowMenu.test.tsx
+++ b/protocol-designer/src/components/organisms/LabwareCardOverflowMenu/__tests__/LabwareCardOverflowMenu.test.tsx
@@ -8,6 +8,8 @@ import { i18n } from '/protocol-designer/assets/localization'
 import { ConfirmDeleteEntityInUseModal } from '/protocol-designer/components/organisms/ConfirmDeleteEntityInUseModal'
 import { EditNickNameModal } from '/protocol-designer/components/organisms/EditNickNameModal'
 import { deleteContainer } from '/protocol-designer/labware-ingred/actions'
+import { selectors } from '/protocol-designer/labware-ingred/selectors'
+import { ZoomedIntoSlotInfoState } from '/protocol-designer/labware-ingred/types'
 import { getIsLabwareOnSlotInUse } from '/protocol-designer/pages/Designer/DeckSetup/utils'
 import { getSavedStepForms } from '/protocol-designer/step-forms/selectors'
 import { getDeckSetupForActiveItem } from '/protocol-designer/top-selectors/labware-locations'
@@ -24,6 +26,7 @@ vi.mock('/protocol-designer/components/organisms/EditNickNameModal')
 vi.mock('/protocol-designer/top-selectors/labware-locations')
 vi.mock('/protocol-designer/step-forms/selectors')
 vi.mock('/protocol-designer/labware-ingred/actions')
+vi.mock('/protocol-designer/labware-ingred/selectors')
 vi.mock('/protocol-designer/pages/Designer/DeckSetup/utils')
 vi.mock('/protocol-designer/components/organisms/ConfirmDeleteEntityInUseModal')
 vi.mock('react-router-dom', async importOriginal => {
@@ -69,6 +72,9 @@ describe('LabwareCardOverflowMenu', () => {
     vi.mocked(ConfirmDeleteEntityInUseModal).mockReturnValue(
       <div>mock ConfirmDeleteEntityInUseModal</div>
     )
+    vi.mocked(selectors.getZoomedInSlotInfo).mockReturnValue({
+      selectedSlot: { slot: null, cutout: null },
+    } as ZoomedIntoSlotInfoState)
   })
   it('renders the overflow menu with 2 buttons', () => {
     render(props)

--- a/protocol-designer/src/components/organisms/LabwareCardOverflowMenu/__tests__/LabwareCardOverflowMenu.test.tsx
+++ b/protocol-designer/src/components/organisms/LabwareCardOverflowMenu/__tests__/LabwareCardOverflowMenu.test.tsx
@@ -9,7 +9,6 @@ import { ConfirmDeleteEntityInUseModal } from '/protocol-designer/components/org
 import { EditNickNameModal } from '/protocol-designer/components/organisms/EditNickNameModal'
 import { deleteContainer } from '/protocol-designer/labware-ingred/actions'
 import { selectors } from '/protocol-designer/labware-ingred/selectors'
-import { ZoomedIntoSlotInfoState } from '/protocol-designer/labware-ingred/types'
 import { getIsLabwareOnSlotInUse } from '/protocol-designer/pages/Designer/DeckSetup/utils'
 import { getSavedStepForms } from '/protocol-designer/step-forms/selectors'
 import { getDeckSetupForActiveItem } from '/protocol-designer/top-selectors/labware-locations'
@@ -19,6 +18,7 @@ import { LabwareCardOverflowMenu } from '../index'
 import type { ComponentProps } from 'react'
 import type { NavigateFunction } from 'react-router-dom'
 import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { ZoomedIntoSlotInfoState } from '/protocol-designer/labware-ingred/types'
 
 const mockNavigate = vi.fn()
 

--- a/protocol-designer/src/components/organisms/LabwareCardOverflowMenu/index.tsx
+++ b/protocol-designer/src/components/organisms/LabwareCardOverflowMenu/index.tsx
@@ -17,7 +17,9 @@ import {
   useOnClickOutside,
 } from '@opentrons/components'
 import {
+  FAKE_HOPPER_LOCATION_MAP,
   getFullStackFromLabwares,
+  getIsSlotAHopper,
   getSlotInLocationStack,
 } from '@opentrons/step-generation'
 
@@ -31,15 +33,19 @@ import {
   multipleIngredientsSelector,
   openIngredientSelector,
 } from '/protocol-designer/labware-ingred/actions'
+import { selectors } from '/protocol-designer/labware-ingred/selectors'
 import { getIsLabwareOnSlotInUse } from '/protocol-designer/pages/Designer/DeckSetup/utils'
+import { updateStackerModuleState } from '/protocol-designer/step-forms/actions'
 import { getSavedStepForms } from '/protocol-designer/step-forms/selectors'
 import { getDeckSetupForActiveItem } from '/protocol-designer/top-selectors/labware-locations'
 import { getModuleIdFromStack } from '/protocol-designer/utils'
 import { COMPATIBLE_LABWARE_ALLOWLIST_BY_MODULE_TYPE } from '/protocol-designer/utils/labwareModuleCompatibility'
 
+import { getStackerModuleStateFromSlot } from '../AssignLiquidsModal/utils'
 import { LabwareNotCompatibleModal } from '../LabwareNotCompatibleModal'
 
 import type { Dispatch, MouseEvent, SetStateAction } from 'react'
+import type { HopperLocationMapKey } from '@opentrons/step-generation'
 import type { ThunkDispatch } from '/protocol-designer/types'
 
 interface LabwareCardOverflowMenuProps {
@@ -55,6 +61,7 @@ export function LabwareCardOverflowMenu(
   const navigate = useNavigate()
   const savedSteps = useSelector(getSavedStepForms)
   const deckSetup = useSelector(getDeckSetupForActiveItem)
+  const { selectedSlot } = useSelector(selectors.getZoomedInSlotInfo)
   const [showNotCompatibleModal, setShowNotCompatibleModal] =
     useState<boolean>(false)
   const { labware: deckSetupLabware, modules: deckSetupModules } = deckSetup
@@ -144,7 +151,43 @@ export function LabwareCardOverflowMenu(
     setShowDeleteEntityInUseModal(false)
   }
 
+  const isOnHopper =
+    selectedSlot?.slot != null && getIsSlotAHopper(selectedSlot.slot)
   const handleClearLabware = (e: MouseEvent): void => {
+    if (isOnHopper) {
+      const slot =
+        FAKE_HOPPER_LOCATION_MAP[selectedSlot.slot as HopperLocationMapKey]
+      const moduleOnSlot = Object.values(deckSetupModules).find(
+        module => module.slot === slot
+      )
+      const stackerModuleState = getStackerModuleStateFromSlot({
+        modules: deckSetupModules,
+        slot,
+      })
+      const { labwareInHopper } = stackerModuleState ?? {}
+      const labwaresToDelete =
+        labwareInHopper?.reduce<string[]>((acc, group) => {
+          return [...acc, ...Object.values(group).filter(id => id != null)]
+        }, []) ?? []
+      // delete all hopper labwares
+      labwaresToDelete.forEach(labware => {
+        dispatch(deleteContainer({ labwareId: labware }))
+      })
+      // un-set the stored labware details of the module
+      if (moduleOnSlot != null && stackerModuleState != null) {
+        dispatch(
+          updateStackerModuleState({
+            moduleId: moduleOnSlot.id,
+            moduleState: {
+              ...stackerModuleState,
+              storedLabwareDetails: null,
+              labwareInHopper: null,
+            },
+          })
+        )
+      }
+    }
+
     if (isLabwareOnSlotInUse) {
       setShowDeleteEntityInUseModal(true)
       e.preventDefault()


### PR DESCRIPTION
# Overview

Ensure deleting stacker hopper labware from the labware toolbox labware card deletes all labware groups.

Closes RQA-5059

## Test Plan and Hands on Testing

- create or import a stacker protocol
- navigate to starting deck state, and ensure the stacker hopper is configured with multiple labware
- select the hopper labware > Edit labware
- in the labware card in the toolbox, select the overflow menu button, and select Delete labware
- verify that all hopper labware are deleted successfully

## Changelog

- delete all hopper labware from labware card overflow menu delete option

## Review requests

see test plan

## Risk assessment

low