### PR TITLE
fix(monorepo): server-utils needs setuptools again

### DIFF
--- a/server-utils/pyproject.toml
+++ b/server-utils/pyproject.toml
@@ -51,6 +51,7 @@ dev = [
     "types-mock~=5.1.0",
     "sqlalchemy2-stubs==0.0.2a21",
     "build~=1.2.0",
+    "setuptools==80.9.0",
 ]
 
 [tool.ruff.lint]


### PR DESCRIPTION
# Overview

I happened to be running with Python 3.13 because I was testing something else. When I tried to `make push-ot3`, the build failed with:
```
server_utils-8.8.1a2-py3-none-any.whl
Traceback (most recent call last):
  File "/Users/xxx/opentrons/server-utils/../scripts/python_build_utils.py", line 63, in normalize_version
    import setuptools
ModuleNotFoundError: No module named 'setuptools'
```

This has happened before. In PR #20402, we realized that we were getting `setuptools` through an undeclared transitive dependency in Python 3.10, but we were no longer getting it after the Python upgrade, and had to declare `setuptools` explicitly.

Then we somehow deleted the `setuptools` dependency from `server-utils` when we migrated to uv in PR #20135.

`server_utils` still builds now with Python 3.12, probably because of some transitive dependency that pulls in `setuptools` in Python 3.12, but it's going to break again in Python 3.13.

So we should add the `setuptools` dependency back to futureproof our code.

## Test Plan and Hands on Testing

`make push-ot3`

## Risk assessment

Low.