### PR TITLE
fix(protocol-designer): correct stacker slot display and reverse order

### DIFF
--- a/protocol-designer/src/components/organisms/SlotDetailModal/index.tsx
+++ b/protocol-designer/src/components/organisms/SlotDetailModal/index.tsx
@@ -105,8 +105,7 @@ export const SlotDetailModal = (
   const isAdapter = getIsAdapterFromDef(labwareOnDeck.def)
   const slotName = getSlotInLocationStack(labwareOnDeck.stack)
   const isHopper = Object.values(modules).some(
-    module =>
-      module.slot === slotName && module.model === FLEX_STACKER_MODULE_V1
+    ({ slot, model }) => slot === slotName && model === FLEX_STACKER_MODULE_V1
   )
 
   const modalTitle = (

--- a/protocol-designer/src/components/organisms/SlotDetailModal/index.tsx
+++ b/protocol-designer/src/components/organisms/SlotDetailModal/index.tsx
@@ -19,6 +19,7 @@ import {
   StyledText,
   Tag,
 } from '@opentrons/components'
+import { FLEX_STACKER_MODULE_V1 } from '@opentrons/shared-data'
 import {
   getLiquidIdsOnLabware,
   getSlotInLocationStack,
@@ -27,6 +28,7 @@ import {
 } from '@opentrons/step-generation'
 
 import { selectors } from '/protocol-designer/labware-ingred/selectors'
+import { getColumnFromWellName } from '/protocol-designer/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/utils'
 import { getDeckSetupForActiveItem } from '/protocol-designer/top-selectors/labware-locations'
 import * as wellContentsSelectors from '/protocol-designer/top-selectors/well-contents'
 import { getLabwareNicknamesById } from '/protocol-designer/ui/labware/selectors'
@@ -66,7 +68,7 @@ export const SlotDetailModal = (
   const allIngredientGroupFields = useSelector(
     selectors.allIngredientGroupFields
   )
-  const { labware } = activeDeckSetup
+  const { labware, modules } = activeDeckSetup
   const labwareOnDeck = labware[selectedLabware]
 
   const wellContents =
@@ -101,14 +103,25 @@ export const SlotDetailModal = (
 
   const isAdapter = getIsAdapterFromDef(labwareOnDeck.def)
   const slotName = getSlotInLocationStack(labwareOnDeck.stack)
+  const isHopper = Object.values(modules).some(
+    module =>
+      module.slot === slotName && module.model === FLEX_STACKER_MODULE_V1
+  )
+  const deckLabel = (() => {
+    if (slotName === 'offDeck') {
+      return t('off_deck')
+    }
+    if (isHopper) {
+      return t('shared:stacker', { slot: getColumnFromWellName(slotName) })
+    }
+    return slotName
+  })()
   const modalTitle = (
     <Flex alignItems={ALIGN_CENTER} gridGap={SPACING.spacing4}>
       <StyledText desktopStyle="bodyLargeSemiBold">
         {t('labware_in')}
       </StyledText>
-      <RobotInfoLabel
-        deckLabel={slotName === 'offDeck' ? t('off_deck') : slotName}
-      />
+      <RobotInfoLabel deckLabel={deckLabel} />
     </Flex>
   )
 
@@ -122,7 +135,6 @@ export const SlotDetailModal = (
       closeOnOutsideClick
       childrenPadding={0}
       width="47rem"
-      overflowY="hidden"
       headerTagElement={
         stackOfLabware.length > 1 ? (
           <Tag

--- a/protocol-designer/src/components/organisms/SlotDetailModal/index.tsx
+++ b/protocol-designer/src/components/organisms/SlotDetailModal/index.tsx
@@ -28,7 +28,6 @@ import {
 } from '@opentrons/step-generation'
 
 import { selectors } from '/protocol-designer/labware-ingred/selectors'
-import { getColumnFromWellName } from '/protocol-designer/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/utils'
 import { getDeckSetupForActiveItem } from '/protocol-designer/top-selectors/labware-locations'
 import * as wellContentsSelectors from '/protocol-designer/top-selectors/well-contents'
 import { getLabwareNicknamesById } from '/protocol-designer/ui/labware/selectors'
@@ -38,7 +37,9 @@ import { LabwareButtonBasket } from '../../molecules'
 import { WellTooltip } from '../Labware/WellTooltip'
 import { getMainPagePortalEl } from '../Portal'
 import { LiquidCardList } from './LiquidCardList'
+import { getDeckLabel } from './utils'
 
+import type { TFunction } from 'i18next'
 import type { WellGroup } from '@opentrons/components'
 
 export interface WellContentsByNumber {
@@ -107,21 +108,15 @@ export const SlotDetailModal = (
     module =>
       module.slot === slotName && module.model === FLEX_STACKER_MODULE_V1
   )
-  const deckLabel = (() => {
-    if (slotName === 'offDeck') {
-      return t('off_deck')
-    }
-    if (isHopper) {
-      return t('shared:stacker', { slot: getColumnFromWellName(slotName) })
-    }
-    return slotName
-  })()
+
   const modalTitle = (
     <Flex alignItems={ALIGN_CENTER} gridGap={SPACING.spacing4}>
       <StyledText desktopStyle="bodyLargeSemiBold">
         {t('labware_in')}
       </StyledText>
-      <RobotInfoLabel deckLabel={deckLabel} />
+      <RobotInfoLabel
+        deckLabel={getDeckLabel(slotName, isHopper, t as TFunction)}
+      />
     </Flex>
   )
 

--- a/protocol-designer/src/components/organisms/SlotDetailModal/utils.ts
+++ b/protocol-designer/src/components/organisms/SlotDetailModal/utils.ts
@@ -1,0 +1,21 @@
+import { getColumnFromWellName } from '/protocol-designer/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/utils'
+
+import type { TFunction } from 'i18next'
+
+export function getDeckLabel(
+  slotName: string,
+  isHopper: boolean,
+  t: TFunction
+): string {
+  if (slotName === 'offDeck') {
+    return t('off_deck')
+  }
+
+  if (isHopper) {
+    return t('shared:stacker', {
+      slot: getColumnFromWellName(slotName),
+    })
+  }
+
+  return slotName
+}

--- a/protocol-designer/src/pages/Designer/DeckSetup/Overlays/ActiveLabwareControls.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/Overlays/ActiveLabwareControls.tsx
@@ -69,16 +69,20 @@ export function ActiveLabwareControls(
           .moduleState as FlexStackerModuleState)
       : null
   const stackerHopperLabware: string[] =
-    stackerModuleState?.labwareInHopper?.reduce<string[]>((acc, hopper) => {
-      acc.push(hopper.primaryLabwareId)
-      if (hopper.adapterLabwareId) {
-        acc.push(hopper.adapterLabwareId)
-      }
-      if (hopper.lidLabwareId) {
-        acc.push(hopper.lidLabwareId)
-      }
-      return acc
-    }, []) ?? []
+    stackerModuleState?.labwareInHopper?.reduceRight<string[]>(
+      (acc, hopper) => {
+        if (hopper.lidLabwareId) {
+          acc.push(hopper.lidLabwareId)
+        }
+        if (hopper.adapterLabwareId) {
+          acc.push(hopper.adapterLabwareId)
+        }
+        acc.push(hopper.primaryLabwareId)
+        return acc
+      },
+      []
+    ) ?? []
+
   const filteredStack = fullStack.filter(
     item => activeDeckSetup.labware[item] != null
   )

--- a/protocol-designer/src/pages/Designer/DeckSetup/Overlays/ActiveLabwareControls.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/Overlays/ActiveLabwareControls.tsx
@@ -70,14 +70,14 @@ export function ActiveLabwareControls(
       : null
   const stackerHopperLabware: string[] =
     stackerModuleState?.labwareInHopper?.reduceRight<string[]>(
-      (acc, hopper) => {
-        if (hopper.lidLabwareId) {
-          acc.push(hopper.lidLabwareId)
+      (acc, { lidLabwareId, primaryLabwareId, adapterLabwareId }) => {
+        if (lidLabwareId) {
+          acc.push(lidLabwareId)
         }
-        if (hopper.adapterLabwareId) {
-          acc.push(hopper.adapterLabwareId)
+        acc.push(primaryLabwareId)
+        if (adapterLabwareId) {
+          acc.push(adapterLabwareId)
         }
-        acc.push(hopper.primaryLabwareId)
         return acc
       },
       []


### PR DESCRIPTION
# Overview

Ensures stacker slots indicate that in their label and reverses order to ensure top labware is shown first

## Test Plan and Hands on Testing

smoke tested: 

https://github.com/user-attachments/assets/454265aa-78e1-457f-8757-9d27f5eee9aa

## Review requests

- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.

## Risk assessment

low

Closes RQA-5062