### PR TITLE
fix(app): restrict QT blowout trash to be the same as tip-drop, part 1

### DIFF
--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/BlowOut.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/BlowOut.tsx
@@ -41,7 +41,11 @@ import { getMaxUiFlowRate, getPipetteName } from '../utils'
 import { getExtractTiprackTypeFromURI } from '../utils/getExtractTiprackTypeFromURI'
 
 import type { Dispatch } from 'react'
-import type { DeckConfiguration, SupportedTip } from '@opentrons/shared-data'
+import type {
+  CutoutConfig,
+  DeckConfiguration,
+  SupportedTip,
+} from '@opentrons/shared-data'
 import type {
   BlowOutLocation,
   FlowRateKind,
@@ -59,7 +63,8 @@ interface BlowOutProps {
 
 export const useBlowOutLocationOptions = (
   deckConfig: DeckConfiguration,
-  transferType: TransferType
+  transferType: TransferType,
+  dropTipLocation: CutoutConfig | string
 ): Array<{ location: BlowOutLocation; description: string }> => {
   const { t } = useTranslation('quick_transfer')
 
@@ -68,7 +73,6 @@ export const useBlowOutLocationOptions = (
       WASTE_CHUTE_FIXTURES.includes(cutoutConfig.cutoutFixtureId) ||
       TRASH_BIN_ADAPTER_FIXTURE === cutoutConfig.cutoutFixtureId
   )
-
   // add trash bin in A3 if no trash or waste chute configured
   if (trashLocations.length === 0) {
     trashLocations.push({
@@ -76,6 +80,12 @@ export const useBlowOutLocationOptions = (
       cutoutFixtureId: TRASH_BIN_ADAPTER_FIXTURE,
     })
   }
+  // if the user picked a trash fixture for tip drop, then filter the list of
+  // trashLocations to only allow them to blow out to the same trash fixture:
+  if (typeof dropTipLocation === 'object') {
+    trashLocations.splice(0, trashLocations.length, dropTipLocation)
+  }
+
   const blowOutLocationItems: Array<{
     location: BlowOutLocation
     description: string
@@ -143,7 +153,8 @@ export function BlowOut(props: BlowOutProps): JSX.Element {
   ]
   const blowOutLocationItems = useBlowOutLocationOptions(
     deckConfig,
-    state.transferType
+    state.transferType,
+    state.dropTipLocation
   )
   const handleClickBackOrExit = (): void => {
     currentStep > 1 ? setCurrentStep(currentStep - 1) : onBack()

--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/PipettePath.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/PipettePath.tsx
@@ -88,7 +88,8 @@ export function PipettePath(props: PipettePathProps): JSX.Element {
 
   const blowOutLocationItems = useBlowOutLocationOptions(
     deckConfig,
-    state.transferType
+    state.transferType,
+    state.dropTipLocation
   )
 
   const handleClickBackOrExit = (): void => {

--- a/app/src/organisms/ODD/QuickTransferFlow/utils/getInitialSummaryState.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/utils/getInitialSummaryState.ts
@@ -99,7 +99,8 @@ export function getInitialSummaryState(
     blowOutDispense:
       path !== 'multiDispense'
         ? {
-            location: trashConfigCutout,
+            // blowout location should default to same fixture as dropTipLocation below
+            location: state.dropTipLocation ?? trashConfigCutout,
             flowRate: flowRatesForSupportedTip.defaultDispenseFlowRate.default,
           }
         : undefined,


### PR DESCRIPTION
# Overview

Quick Transfer allowed the user to choose any available trash fixture on the deck as the blowout location. However, that is not supported in the Python API (AUTH-2540).

In Python, when you say:
```
transfer_with_liquid_class(trash_location=...)
```
you pick one trash fixture for tip-drop. Then when the liquid class specifies
```
 "dispense": { "retract": { "blowout": {"location": "trash" } } }
```
the `"trash"` refers to the **same** location as the `trash_location` argument. There is no way to drop tips into the waste chute and blow out into the trash bin, for example.

This PR restricts the blowout location in QT to be the same as the tip-drop location if the tip-drop location is a trash fixture. (If the tip-drop location is a tip rack for return-tip, then this restriction does not apply.)

Note that this is part 1 of the fix. Quick Transfer also has a **disposal volume location** that has the same restriction in the API. I'll fix that in the next PR.

## Test Plan and Hands on Testing

Tested Quick Transfer on a robot:
Before this change, we would offer all available trash fixtures on the deck as the blowout location.
After the change, the we only offer one trash fixture in the list of blowout location options.

(I would attach a screenshot, but the devtools inspector is not working for some reason.)

## Risk assessment

Low.