### PR TITLE
fix(protocol-designer): allow multiselect in assign liquids modal

### DIFF
--- a/protocol-designer/src/components/organisms/AssignLiquidsModal/LabwareToolbox.tsx
+++ b/protocol-designer/src/components/organisms/AssignLiquidsModal/LabwareToolbox.tsx
@@ -188,27 +188,23 @@ export function LabwareStackToolbox({
     newItem: string,
     event: React.MouseEvent<HTMLButtonElement>
   ): void => {
-    if (
-      labwareId &&
-      (event.metaKey || event.ctrlKey) &&
-      JSON.stringify(liquidLocations[newItem]) !==
-        JSON.stringify(liquidLocations[labwareId])
-    ) {
-      // selected labware have different liquid layouts
-      setShowLiquidLayoutOverlay(true)
-      dispatch(
-        multipleIngredientsSelector([
-          ...(selectedLabwareIds ?? [topDownStackIds[0]]),
-          newItem,
-        ])
-      )
-    } else if (event.metaKey || event.ctrlKey) {
-      dispatch(
-        multipleIngredientsSelector([
-          ...(selectedLabwareIds ?? [topDownStackIds[0]]),
-          newItem,
-        ])
-      )
+    const isMultiSelect = event.metaKey || event.ctrlKey
+
+    if (isMultiSelect) {
+      const newSelection = [
+        ...(selectedLabwareIds ?? [topDownStackIds[0]]),
+        newItem,
+      ]
+      dispatch(multipleIngredientsSelector(newSelection))
+
+      // Show overlay if selected labware have different liquid layouts
+      const hasDifferentLiquids =
+        labwareId != null &&
+        JSON.stringify(liquidLocations[newItem]) !==
+          JSON.stringify(liquidLocations[labwareId])
+      if (hasDifferentLiquids) {
+        setShowLiquidLayoutOverlay(true)
+      }
     } else {
       dispatch(multipleIngredientsSelector([newItem]))
     }

--- a/protocol-designer/src/components/organisms/AssignLiquidsModal/LabwareToolbox.tsx
+++ b/protocol-designer/src/components/organisms/AssignLiquidsModal/LabwareToolbox.tsx
@@ -72,7 +72,7 @@ interface LabwareStackToolboxProps {
 export function LabwareStackToolbox({
   setShowLiquidLayoutOverlay,
   data,
-  selectedLabwareIds,
+  // selectedLabwareIds,
   slot,
 }: LabwareStackToolboxProps): JSX.Element | null {
   const { t } = useTranslation(['liquids', 'form', 'shared'])
@@ -116,6 +116,10 @@ export function LabwareStackToolbox({
     stackLimit = getStackLimitFromDef(labware[labwareId].def)
     topDownStackIds = getFullStackFromLabwares(labware, labwareId)
   }
+
+  console.log('topDownStackIds: ', topDownStackIds)
+  const selectedLabwareIds =
+    topDownStackIds.length > 0 ? topDownStackIds[0] : [labwareId]
 
   const handleAddAnotherLabware = (): void => {
     if (topDownStackIds.length < stackLimit && labwareId != null) {
@@ -274,6 +278,8 @@ export function LabwareStackToolboxContainer({
     initialRobotState.labware,
     slot
   )
+
+  console.log('largestStackInSlot: ', largestStackInSlot)
   const liquidLocations = useSelector(
     labwareIngredSelectors.getLiquidsByLabwareId
   )
@@ -283,6 +289,11 @@ export function LabwareStackToolboxContainer({
     liquidLocations,
     largestStackInSlot,
   }
+
+  console.log('selectedLabwareIds: ', selectedLabwareIds)
+  console.log('labwareId: ', labwareId)
+  console.log('labware: ', labware)
+  console.log('liquidLocations: ', liquidLocations)
 
   return (
     <LabwareStackToolbox

--- a/protocol-designer/src/components/organisms/AssignLiquidsModal/LabwareToolbox.tsx
+++ b/protocol-designer/src/components/organisms/AssignLiquidsModal/LabwareToolbox.tsx
@@ -186,7 +186,12 @@ export function LabwareStackToolbox({
       // selected labware have different liquid layouts
       setShowLiquidLayoutOverlay(true)
     } else if (event.metaKey || event.ctrlKey) {
-      dispatch(multipleIngredientsSelector([...(selectedLabwareIds ?? []), newItem]))
+      dispatch(
+        multipleIngredientsSelector([
+          ...(selectedLabwareIds ?? [topDownStackIds[0]]),
+          newItem,
+        ])
+      )
     } else {
       dispatch(multipleIngredientsSelector([newItem]))
     }

--- a/protocol-designer/src/components/organisms/AssignLiquidsModal/LabwareToolbox.tsx
+++ b/protocol-designer/src/components/organisms/AssignLiquidsModal/LabwareToolbox.tsx
@@ -188,7 +188,6 @@ export function LabwareStackToolbox({
     newItem: string,
     event: React.MouseEvent<HTMLButtonElement>
   ): void => {
-    dispatch(openIngredientSelector(newItem))
     if (
       labwareId &&
       (event.metaKey || event.ctrlKey) &&

--- a/protocol-designer/src/components/organisms/AssignLiquidsModal/LabwareToolbox.tsx
+++ b/protocol-designer/src/components/organisms/AssignLiquidsModal/LabwareToolbox.tsx
@@ -196,6 +196,12 @@ export function LabwareStackToolbox({
     ) {
       // selected labware have different liquid layouts
       setShowLiquidLayoutOverlay(true)
+      dispatch(
+        multipleIngredientsSelector([
+          ...(selectedLabwareIds ?? [topDownStackIds[0]]),
+          newItem,
+        ])
+      )
     } else if (event.metaKey || event.ctrlKey) {
       dispatch(
         multipleIngredientsSelector([

--- a/protocol-designer/src/components/organisms/AssignLiquidsModal/LabwareToolbox.tsx
+++ b/protocol-designer/src/components/organisms/AssignLiquidsModal/LabwareToolbox.tsx
@@ -117,6 +117,12 @@ export function LabwareStackToolbox({
     topDownStackIds = getFullStackFromLabwares(labware, labwareId)
   }
 
+  // select the top labware in the stack if no selected labware ids are provided
+  const selectedLabware = selectedLabwareIds
+    ? selectedLabwareIds
+    : [topDownStackIds[0]]
+  dispatch(openIngredientSelector(selectedLabware[0]))
+
   const handleAddAnotherLabware = (): void => {
     if (topDownStackIds.length < stackLimit && labwareId != null) {
       // create labware groups for hopper
@@ -238,7 +244,7 @@ export function LabwareStackToolbox({
             stackOfLabware={topDownStackIds}
             labware={labware}
             setSelectedLabware={handleAssignToLabware}
-            selectedLabware={selectedLabwareIds ?? [topDownStackIds[0]]}
+            selectedLabware={selectedLabware}
           />
         </div>
       ) : (
@@ -280,7 +286,6 @@ export function LabwareStackToolboxContainer({
     slot
   )
 
-  console.log('largestStackInSlot: ', largestStackInSlot)
   const liquidLocations = useSelector(
     labwareIngredSelectors.getLiquidsByLabwareId
   )
@@ -290,11 +295,6 @@ export function LabwareStackToolboxContainer({
     liquidLocations,
     largestStackInSlot,
   }
-
-  console.log('selectedLabwareIds: ', selectedLabwareIds)
-  console.log('labwareId: ', labwareId)
-  console.log('labware: ', labware)
-  console.log('liquidLocations: ', liquidLocations)
 
   return (
     <LabwareStackToolbox

--- a/protocol-designer/src/components/organisms/AssignLiquidsModal/LabwareToolbox.tsx
+++ b/protocol-designer/src/components/organisms/AssignLiquidsModal/LabwareToolbox.tsx
@@ -118,9 +118,8 @@ export function LabwareStackToolbox({
   }
 
   // select the top labware in the stack if no selected labware ids are provided
-  const selectedLabware = selectedLabwareIds
-    ? selectedLabwareIds
-    : [topDownStackIds[0]]
+  const selectedLabware =
+    selectedLabwareIds != null ? selectedLabwareIds : [topDownStackIds[0]]
   dispatch(openIngredientSelector(selectedLabware[0]))
 
   const handleAddAnotherLabware = (): void => {

--- a/protocol-designer/src/components/organisms/AssignLiquidsModal/LabwareToolbox.tsx
+++ b/protocol-designer/src/components/organisms/AssignLiquidsModal/LabwareToolbox.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 
@@ -83,12 +84,8 @@ export function LabwareStackToolbox({
   const { labware, labwareId, liquidLocations } = data
   const { modules } = useSelector(getInitialDeckSetup)
 
-  if (labwareId == null) {
-    console.error('No labware ID found for LabwareStackToolbox')
-    return null
-  }
-
-  const stackerModuleState = getStackerModuleStateFromSlot({ slot, modules })
+  const stackerModuleState =
+    labwareId != null ? getStackerModuleStateFromSlot({ slot, modules }) : null
   let stackLimit: number = 0
   let topDownStackIds: string[] = []
 
@@ -116,10 +113,21 @@ export function LabwareStackToolbox({
     stackLimit = getStackLimitFromDef(labware[labwareId].def)
     topDownStackIds = getFullStackFromLabwares(labware, labwareId)
   }
+
   // select the top labware in the stack if no selected labware ids are provided
-  useEffeect(() => {
-    dispatch(openIngredientSelector(selectedLabware[0]))
-  }, [])
+  const selectedLabware =
+    selectedLabwareIds != null ? selectedLabwareIds : [topDownStackIds[0]]
+
+  useEffect(() => {
+    if (selectedLabware[0] != null) {
+      dispatch(openIngredientSelector(selectedLabware[0]))
+    }
+  }, [selectedLabware, dispatch])
+
+  if (labwareId == null) {
+    console.error('No labware ID found for LabwareStackToolbox')
+    return null
+  }
 
   const handleAddAnotherLabware = (): void => {
     if (topDownStackIds.length < stackLimit && labwareId != null) {

--- a/protocol-designer/src/components/organisms/AssignLiquidsModal/LabwareToolbox.tsx
+++ b/protocol-designer/src/components/organisms/AssignLiquidsModal/LabwareToolbox.tsx
@@ -116,11 +116,10 @@ export function LabwareStackToolbox({
     stackLimit = getStackLimitFromDef(labware[labwareId].def)
     topDownStackIds = getFullStackFromLabwares(labware, labwareId)
   }
-
   // select the top labware in the stack if no selected labware ids are provided
-  const selectedLabware =
-    selectedLabwareIds != null ? selectedLabwareIds : [topDownStackIds[0]]
-  dispatch(openIngredientSelector(selectedLabware[0]))
+  useEffeect(() => {
+    dispatch(openIngredientSelector(selectedLabware[0]))
+  }, [])
 
   const handleAddAnotherLabware = (): void => {
     if (topDownStackIds.length < stackLimit && labwareId != null) {

--- a/protocol-designer/src/components/organisms/AssignLiquidsModal/LabwareToolbox.tsx
+++ b/protocol-designer/src/components/organisms/AssignLiquidsModal/LabwareToolbox.tsx
@@ -66,13 +66,13 @@ interface LabwareStackToolboxProps {
   setDefineLiquidModal: Dispatch<SetStateAction<boolean>>
   setShowLiquidLayoutOverlay: Dispatch<SetStateAction<boolean>>
   data: LabwareStackToolboxData
-  selectedLabwareIds: string[]
+  selectedLabwareIds: string[] | null
   slot: string
 }
 export function LabwareStackToolbox({
   setShowLiquidLayoutOverlay,
   data,
-  // selectedLabwareIds,
+  selectedLabwareIds,
   slot,
 }: LabwareStackToolboxProps): JSX.Element | null {
   const { t } = useTranslation(['liquids', 'form', 'shared'])
@@ -116,10 +116,6 @@ export function LabwareStackToolbox({
     stackLimit = getStackLimitFromDef(labware[labwareId].def)
     topDownStackIds = getFullStackFromLabwares(labware, labwareId)
   }
-
-  console.log('topDownStackIds: ', topDownStackIds)
-  const selectedLabwareIds =
-    topDownStackIds.length > 0 ? topDownStackIds[0] : [labwareId]
 
   const handleAddAnotherLabware = (): void => {
     if (topDownStackIds.length < stackLimit && labwareId != null) {
@@ -190,7 +186,7 @@ export function LabwareStackToolbox({
       // selected labware have different liquid layouts
       setShowLiquidLayoutOverlay(true)
     } else if (event.metaKey || event.ctrlKey) {
-      dispatch(multipleIngredientsSelector([...selectedLabwareIds, newItem]))
+      dispatch(multipleIngredientsSelector([...(selectedLabwareIds ?? []), newItem]))
     } else {
       dispatch(multipleIngredientsSelector([newItem]))
     }
@@ -237,7 +233,7 @@ export function LabwareStackToolbox({
             stackOfLabware={topDownStackIds}
             labware={labware}
             setSelectedLabware={handleAssignToLabware}
-            selectedLabware={selectedLabwareIds}
+            selectedLabware={selectedLabwareIds ?? [topDownStackIds[0]]}
           />
         </div>
       ) : (
@@ -255,7 +251,7 @@ interface LabwareStackToolboxContainerProps {
   setShowBadFormState: Dispatch<SetStateAction<boolean>>
   setDefineLiquidModal: Dispatch<SetStateAction<boolean>>
   setShowLiquidLayoutOverlay: Dispatch<SetStateAction<boolean>>
-  selectedLabwareIds: string[]
+  selectedLabwareIds: string[] | null
 }
 
 export function LabwareStackToolboxContainer({

--- a/protocol-designer/src/components/organisms/AssignLiquidsModal/index.tsx
+++ b/protocol-designer/src/components/organisms/AssignLiquidsModal/index.tsx
@@ -144,7 +144,7 @@ export function AssignLiquidsModal(
         {labwareIsOnHopper && labwareStack.length > 1 ? (
           <LabwareStackToolboxContainer
             setShowLiquidLayoutOverlay={setShowLiquidLayoutOverlay}
-            selectedLabwareIds={selectedLabwareIds}
+            selectedLabwareIds={selectedLabwareIds ?? null}
             showBadFormState={showBadFormState}
             setShowBadFormState={setShowBadFormState}
             setDefineLiquidModal={setDefineLiquidModal}
@@ -303,7 +303,7 @@ export function AssignLiquidsModalContainer(
     allWellContents,
     liquidNamesById,
     liquidDisplayColors,
-    selectedLabwareIds: selectedLabwareIds,
+    selectedLabwareIds: selectedLabwareIds ?? null,
   }
 
   return (

--- a/protocol-designer/src/components/organisms/AssignLiquidsModal/index.tsx
+++ b/protocol-designer/src/components/organisms/AssignLiquidsModal/index.tsx
@@ -286,8 +286,7 @@ export function AssignLiquidsModalContainer(
   const selectedWells = useSelector(getSelectedWells)
   const { labware } = useSelector(getInitialDeckSetup)
   const labwareEntities = useSelector(stepFormSelectors.getLabwareEntities)
-  const selectedLabwareIds =
-    useSelector(selectors.getSelectedLabwareIds)
+  const selectedLabwareIds = useSelector(selectors.getSelectedLabwareIds)
   // TODO(tz, 2026-01-12): change this to use liquid locations instead of this method and remove getWellContentsForLabwareStack method
   const allWellContents = useSelector(
     wellContentsSelectors.getWellContentsForLabwareStack

--- a/protocol-designer/src/components/organisms/AssignLiquidsModal/index.tsx
+++ b/protocol-designer/src/components/organisms/AssignLiquidsModal/index.tsx
@@ -57,7 +57,7 @@ import type { LabwareOnDeck } from '/protocol-designer/step-forms'
 const CONTAINER_WIDTH = '49.8125rem'
 
 interface AssignLiquidsModalData {
-  selectedLabwareIds: string[]
+  selectedLabwareIds: string[] | null
   nickNames: Record<string, string>
   labwareId: string | null
   selectedWells: WellGroup
@@ -287,8 +287,7 @@ export function AssignLiquidsModalContainer(
   const { labware } = useSelector(getInitialDeckSetup)
   const labwareEntities = useSelector(stepFormSelectors.getLabwareEntities)
   const selectedLabwareIds =
-    useSelector(selectors.getSelectedLabwareIds) ??
-    ([selectedLabwareId] as string[])
+    useSelector(selectors.getSelectedLabwareIds)
   // TODO(tz, 2026-01-12): change this to use liquid locations instead of this method and remove getWellContentsForLabwareStack method
   const allWellContents = useSelector(
     wellContentsSelectors.getWellContentsForLabwareStack
@@ -305,7 +304,7 @@ export function AssignLiquidsModalContainer(
     allWellContents,
     liquidNamesById,
     liquidDisplayColors,
-    selectedLabwareIds: selectedLabwareIds ?? [],
+    selectedLabwareIds: selectedLabwareIds,
   }
 
   return (

--- a/protocol-designer/src/labware-ingred/selectors.ts
+++ b/protocol-designer/src/labware-ingred/selectors.ts
@@ -77,16 +77,6 @@ const selectedAddLabwareSlot = (state: BaseState): DeckSlot | false =>
 const getSelectedLabwareId: Selector<RootSlice, SelectedContainerId> =
   createSelector(rootSelector, rootState => rootState.selectedContainerId)
 
-// TODO: (tz, 2026-01-16): remove this selector when we find a way to only use multiple selected
-const getMultiSelectSelectedLabwareId: Selector<
-  RootSlice,
-  SelectedContainerId
-> = createSelector(
-  rootSelector,
-  rootState =>
-    rootState.selectedMultipleContainerIds?.[0] ?? rootState.selectedContainerId
-)
-
 const getMultipleSelectedLabwareIds: Selector<
   RootSlice,
   SelectedMultipleContainerIds
@@ -199,7 +189,6 @@ export const selectors = {
   getNextLiquidGroupId,
   getSelectedLabwareId,
   getSelectedLabwareIds: getMultipleSelectedLabwareIds,
-  getMultiSelectSelectedLabwareId,
   getSelectedLiquidGroupState,
   getDrillDownLabwareId,
   allIngredientGroupFields,


### PR DESCRIPTION
# Overview

closes https://opentrons.atlassian.net/browse/RQA-5064.
https://opentrons.atlassian.net/browse/RQA-5060.
https://opentrons.atlassian.net/browse/RQA-5075
**_assignl liquids modal_**
1. auto select first item in stack 
2. fix multiselect
3. fix showing correct liquids

## Test Plan and Hands on Testing


https://github.com/user-attachments/assets/bedce946-11c8-47bf-a588-414b6bd5d5e3



## Risk assessment

low. bug fixes
