### PR TITLE
fix(protocol-designer): resolve whitescreen on stacker fill steps

### DIFF
--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupDetails.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupDetails.tsx
@@ -20,6 +20,7 @@ import {
 } from '@opentrons/step-generation'
 
 import { HOPPER_LABWARE_X_OFFSET } from '/protocol-designer/constants'
+import { getTimelineIsBeingComputed } from '/protocol-designer/file-data/selectors'
 import { getPendingCreationState } from '/protocol-designer/step-forms/selectors'
 
 import { LabwareOnDeck } from '../../../components/organisms'
@@ -105,6 +106,7 @@ export function DeckSetupDetails(props: DeckSetupDetailsProps): JSX.Element {
     robotType
   )
   const pendingCreationStateForHopper = useSelector(getPendingCreationState)
+  const timelineIsBeingComputed = useSelector(getTimelineIsBeingComputed)
   const selectedSlotInfo = useSelector(selectors.getZoomedInSlotInfo)
   const { selectedSlot } = selectedSlotInfo
   const [menuListId, setShowMenuListForId] = useState<DeckSlotId | null>(null)
@@ -139,6 +141,19 @@ export function DeckSetupDetails(props: DeckSetupDetailsProps): JSX.Element {
   const handleHoverEmptySlot = useCallback(() => {
     setHoveredLabware(null)
   }, [])
+  const allLabwareHaveStack = Object.values(activeLabware).every(
+    labware => 'stack' in labware
+  )
+  // This is not an ideal scenario, but this safeguard is necessary until we
+  // can refactor the asynchronous nature of the stacker labware creation.
+  // Some renders of DeckSetupDetails specify the newly-created labware,
+  // but their `stack` properties are not populated.
+  const allLabware =
+    pendingCreationStateForHopper ||
+    timelineIsBeingComputed ||
+    !allLabwareHaveStack
+      ? {}
+      : activeLabware
 
   const {
     createdAdapterForSlot,
@@ -150,7 +165,7 @@ export function DeckSetupDetails(props: DeckSetupDetailsProps): JSX.Element {
     isSlotAHopper,
   } = useMemo(() => {
     return getSlotInformation({
-      deckSetup: activeDeckSetup,
+      deckSetup: { ...activeDeckSetup, labware: allLabware },
       slot: selectedZoomInSlot ?? '',
       deckDef,
       pendingCreationStateForHopper,
@@ -185,10 +200,6 @@ export function DeckSetupDetails(props: DeckSetupDetailsProps): JSX.Element {
     selectedZoomInSlot,
   ])
 
-  const allLabware = pendingCreationStateForHopper
-    ? []
-    : Object.values(activeLabware)
-
   const allModules: ModuleOnDeck[] = values(activeDeckSetup.modules)
   const isMenuListIdForHopper =
     menuListId != null && getIsSlotAHopper(menuListId)
@@ -219,7 +230,8 @@ export function DeckSetupDetails(props: DeckSetupDetailsProps): JSX.Element {
 
   // make sure the top labware (lid) is rendered first in the stack if
   // it gets moved there later on
-  const sortedLabware = [...allLabware].sort((a, b) => {
+  const allLabwareValues = Object.values(allLabware)
+  const sortedLabware = [...allLabwareValues].sort((a, b) => {
     // get how deep each labware is in its stack
     const aDepth = a.stack.length
     const bDepth = b.stack.length
@@ -290,7 +302,7 @@ export function DeckSetupDetails(props: DeckSetupDetailsProps): JSX.Element {
         }
 
         const { topMostId, rightBelowTopId, hopperTopMostId } =
-          getLabwaresOnModuleFromStack(moduleOnDeck.id, allLabware)
+          getLabwaresOnModuleFromStack(moduleOnDeck.id, allLabwareValues)
         const labwareInterfaceBoundingBox = {
           xDimension: moduleDef.dimensions.labwareInterfaceXDimension ?? 0,
           yDimension: moduleDef.dimensions.labwareInterfaceYDimension ?? 0,
@@ -644,7 +656,7 @@ export function DeckSetupDetails(props: DeckSetupDetailsProps): JSX.Element {
       })}
 
       {/* all nested labwares */}
-      {allLabware.map(labware => {
+      {allLabwareValues.map(labware => {
         if (
           allModules.some(m => labware.stack.includes(m.id)) ||
           getSlotInLocationStack(labware.stack) === 'offDeck'

--- a/protocol-designer/src/pages/Designer/DeckSetup/Overlays/ActiveLabwareControls.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/Overlays/ActiveLabwareControls.tsx
@@ -14,6 +14,7 @@ import { FLEX_STACKER_MODULE_TYPE } from '@opentrons/shared-data'
 import { getIsSlotAHopper } from '@opentrons/step-generation'
 
 import { SlotDetailModal } from '/protocol-designer/components/organisms/SlotDetailModal'
+import { getTimelineIsBeingComputed } from '/protocol-designer/file-data/selectors'
 import { getPendingCreationState } from '/protocol-designer/step-forms/selectors'
 import { END_TERMINAL_ITEM_ID } from '/protocol-designer/steplist'
 import { getDeckSetupForActiveItem } from '/protocol-designer/top-selectors/labware-locations'
@@ -47,16 +48,23 @@ export function ActiveLabwareControls(
   } = props
   const { t } = useTranslation('starting_deck_state')
   const pendingCreationStateForHopper = useSelector(getPendingCreationState)
+  const timelineIsBeingComputed = useSelector(getTimelineIsBeingComputed)
   const isSlotAHopper = getIsSlotAHopper(itemId)
   const [showSlotDetailModal, setShowSlotDetailModal] = useState<boolean>(false)
   const activeDeckSetup = useSelector(getDeckSetupForActiveItem)
-  const fullStack = pendingCreationStateForHopper
-    ? []
-    : getFullStackFromLabwaresOnDeck(
-        Object.values(activeDeckSetup.labware),
-        itemId,
-        isSlotAHopper
-      )
+  const allLabwareHaveStack = Object.values(activeDeckSetup.labware).every(
+    labware => 'stack' in labware
+  )
+  const fullStack =
+    pendingCreationStateForHopper ||
+    timelineIsBeingComputed ||
+    !allLabwareHaveStack
+      ? []
+      : getFullStackFromLabwaresOnDeck(
+          Object.values(activeDeckSetup.labware),
+          itemId,
+          isSlotAHopper
+        )
 
   const stackerModuleId = fullStack.find(
     id =>

--- a/protocol-designer/src/pages/Designer/DeckSetup/Overlays/ActiveLabwareControls.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/Overlays/ActiveLabwareControls.tsx
@@ -52,6 +52,11 @@ export function ActiveLabwareControls(
   const isSlotAHopper = getIsSlotAHopper(itemId)
   const [showSlotDetailModal, setShowSlotDetailModal] = useState<boolean>(false)
   const activeDeckSetup = useSelector(getDeckSetupForActiveItem)
+
+  // TODO (ND:2026-01-21): Remove this once we have a way to ensure the stack properties are populated asynchronously.
+  // This check should be superfluous, since any LabwareOnDeck should have a stack
+  // However, there is a timing issue where the labware entities exist but the stack
+  // properties are not populated.
   const allLabwareHaveStack = Object.values(activeDeckSetup.labware).every(
     labware => 'stack' in labware
   )

--- a/protocol-designer/src/step-forms/actions/thunks.ts
+++ b/protocol-designer/src/step-forms/actions/thunks.ts
@@ -250,8 +250,8 @@ export const createLabwareAndQueueForHopper =
       })
 
       // wait for all containers to finish
-      await Promise.all(containerPromises)
+      await Promise.all(containerPromises).then(() => {
+        dispatch(stackerLabwareCreationFinish())
+      })
     }
-
-    dispatch(stackerLabwareCreationFinish())
   }


### PR DESCRIPTION
# Overview

Explicit null checks for the presence of `stack` property on labware temporal properties in ActiveLabwareControls and DeckSetupDetails. There's a strange state wherein a fill-created labware is created, but its stack property is not populated. Checking for pending states for labware creation and timeline generation don't seem to fix this, so I will dig in in a followup.

Closes RQA-5058
Closes RQA-5073

## Test Plan and Hands on Testing

- create a stacker protocol and initialize its hopper with labware
- create a fill step and save
- create another fill step and save. verify that no whitescreen occurs

## Changelog

- fix container promise resolution logic in `createLabwareAndQueueForHopper`
- check for timeline generation state in ActiveLabwareControls and DeckSetupDetails
- explicitly null check labware stacks in those components

## Review requests

see test plan

## Risk assessment

low