### PR TITLE
fix(protocol-designer): ensure liquid content can be added to labware on the deck after adding it in the stacker

### DIFF
--- a/protocol-designer/src/components/organisms/AssignLiquidsModal/LiquidToolbox.tsx
+++ b/protocol-designer/src/components/organisms/AssignLiquidsModal/LiquidToolbox.tsx
@@ -551,9 +551,6 @@ export function LiquidToolboxContainer({
 }: LiquidToolboxContainerProps): JSX.Element {
   // All selectors moved here
   const liquids = useSelector(getLiquidEntities)
-  const multipleSelectedLabwareIds = useSelector(
-    labwareIngredSelectors.getSelectedLabwareIds
-  )
   const selectedLabwareId = useSelector(
     labwareIngredSelectors.getSelectedLabwareId
   )
@@ -599,9 +596,7 @@ export function LiquidToolboxContainer({
       setDefineLiquidModal={setDefineLiquidModal}
       showLiquidLayoutOverlay={showLiquidLayoutOverlay}
       data={data}
-      selectedLabwareIds={
-        multipleSelectedLabwareIds ?? [selectedLabwareId ?? '']
-      }
+      selectedLabwareIds={[selectedLabwareId ?? '']}
     />
   )
 }

--- a/protocol-designer/src/components/organisms/AssignLiquidsModal/LiquidToolbox.tsx
+++ b/protocol-designer/src/components/organisms/AssignLiquidsModal/LiquidToolbox.tsx
@@ -551,6 +551,9 @@ export function LiquidToolboxContainer({
 }: LiquidToolboxContainerProps): JSX.Element {
   // All selectors moved here
   const liquids = useSelector(getLiquidEntities)
+  const multipleSelectedLabwareIds = useSelector(
+    labwareIngredSelectors.getSelectedLabwareIds
+  )
   const selectedLabwareId = useSelector(
     labwareIngredSelectors.getSelectedLabwareId
   )
@@ -596,7 +599,11 @@ export function LiquidToolboxContainer({
       setDefineLiquidModal={setDefineLiquidModal}
       showLiquidLayoutOverlay={showLiquidLayoutOverlay}
       data={data}
-      selectedLabwareIds={[selectedLabwareId ?? '']}
+      selectedLabwareIds={
+        !multipleSelectedLabwareIds?.includes(selectedLabwareId ?? '')
+          ? [selectedLabwareId ?? '']
+          : multipleSelectedLabwareIds
+      }
     />
   )
 }

--- a/protocol-designer/src/components/organisms/AssignLiquidsModal/index.tsx
+++ b/protocol-designer/src/components/organisms/AssignLiquidsModal/index.tsx
@@ -280,13 +280,8 @@ export function AssignLiquidsModalContainer(
 ): JSX.Element | null {
   const { showLiquidOverflowMenu, setDefineLiquidModal } = props
 
-  // All selectors moved here
   const nickNames = useSelector(getLabwareNicknamesById)
   const selectedLabwareId = useSelector(selectors.getSelectedLabwareId)
-  console.log(
-    '🚀 ~ AssignLiquidsModalContainer ~ selectedLabwareId:',
-    selectedLabwareId
-  )
   const selectedWells = useSelector(getSelectedWells)
   const { labware } = useSelector(getInitialDeckSetup)
   const labwareEntities = useSelector(stepFormSelectors.getLabwareEntities)

--- a/protocol-designer/src/components/organisms/AssignLiquidsModal/index.tsx
+++ b/protocol-designer/src/components/organisms/AssignLiquidsModal/index.tsx
@@ -283,12 +283,13 @@ export function AssignLiquidsModalContainer(
   // All selectors moved here
   const nickNames = useSelector(getLabwareNicknamesById)
   const selectedLabwareId = useSelector(selectors.getSelectedLabwareId)
+  console.log(
+    '🚀 ~ AssignLiquidsModalContainer ~ selectedLabwareId:',
+    selectedLabwareId
+  )
   const selectedWells = useSelector(getSelectedWells)
   const { labware } = useSelector(getInitialDeckSetup)
   const labwareEntities = useSelector(stepFormSelectors.getLabwareEntities)
-  const selectedLabwareIds =
-    useSelector(selectors.getSelectedLabwareIds) ??
-    ([selectedLabwareId] as string[])
   // TODO(tz, 2026-01-12): change this to use liquid locations instead of this method and remove getWellContentsForLabwareStack method
   const allWellContents = useSelector(
     wellContentsSelectors.getWellContentsForLabwareStack
@@ -305,7 +306,7 @@ export function AssignLiquidsModalContainer(
     allWellContents,
     liquidNamesById,
     liquidDisplayColors,
-    selectedLabwareIds: selectedLabwareIds ?? [],
+    selectedLabwareIds: [selectedLabwareId ?? ''],
   }
 
   return (

--- a/protocol-designer/src/components/organisms/AssignLiquidsModal/index.tsx
+++ b/protocol-designer/src/components/organisms/AssignLiquidsModal/index.tsx
@@ -280,6 +280,7 @@ export function AssignLiquidsModalContainer(
 ): JSX.Element | null {
   const { showLiquidOverflowMenu, setDefineLiquidModal } = props
 
+  // All selectors moved here
   const nickNames = useSelector(getLabwareNicknamesById)
   const selectedLabwareId = useSelector(selectors.getSelectedLabwareId)
   const selectedWells = useSelector(getSelectedWells)


### PR DESCRIPTION
# Overview

Ensure that you can add liquid to labware on the deck after you added liquid to labware in the stacker

## Test Plan and Hands on Testing

Smoke tested adding liquids to labware in a stack and to labware on the deck
https://github.com/user-attachments/assets/9702bd61-35cc-46cf-a71d-7da69964bce8

## Changelog

- check that selectedLabwareId is in multipleSelectedLabwareId. If it is not, just return the selectedLabwareId. 


Closes RQA-5062