### PR TITLE
ci(pd): sentry plugin upload with react annotations

### DIFF
--- a/.github/workflows/pd-test-build-deploy.yaml
+++ b/.github/workflows/pd-test-build-deploy.yaml
@@ -109,9 +109,17 @@ jobs:
           OT_PD_MIXPANEL_DEV_ID: ${{ secrets.OT_PD_MIXPANEL_DEV_ID }}
           OT_PD_SENTRY_DSN: ${{ secrets.OT_PD_SENTRY_DSN }}
           OT_PD_SENTRY_DEV_DSN: ${{ secrets.OT_PD_SENTRY_DEV_DSN }}
+          # Used by @sentry/vite-plugin (sourcemap upload is gated by OT_PD_SENTRY_PLUGIN_UPLOAD).
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+          # Only meaningful for tagged releases; empty string is treated as absent.
+          SENTRY_RELEASE: ${{ github.ref_type == 'tag' && steps.version.outputs.number || '' }}
+          # Opt-in CI sourcemap upload via the Vite plugin (staging/prod tagged releases only).
+          OT_PD_SENTRY_PLUGIN_UPLOAD: ${{ github.ref_type == 'tag' && (startsWith(github.ref, 'refs/tags/protocol-designer') || startsWith(github.ref, 'refs/tags/staging-protocol-designer')) && (needs.determine-deploy-config.outputs.environment == 'production' || needs.determine-deploy-config.outputs.environment == 'staging') && 'true' || '' }}
         run: |
           make -C protocol-designer NODE_ENV=${{ needs.determine-deploy-config.outputs.environment == 'production' && 'production' || 'development' }} OT_PD_PRERELEASE_MODE=${{ needs.determine-deploy-config.outputs.environment == 'sandbox' && '1' || '0' }}
-      - name: 'upload sourcemaps to Sentry'
+      - name: 'create the release in Sentry (no sourcemaps)'
         # Only on production or staging releases (protocol-designer* or staging-protocol-designer*)
         if: github.ref_type == 'tag' && (startsWith(github.ref, 'refs/tags/protocol-designer') || startsWith(github.ref, 'refs/tags/staging-protocol-designer')) && (needs.determine-deploy-config.outputs.environment == 'production' || needs.determine-deploy-config.outputs.environment == 'staging')
         uses: getsentry/action-release@v3
@@ -121,7 +129,6 @@ jobs:
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
         with:
           release: ${{ steps.version.outputs.number }}
-          sourcemaps: protocol-designer/dist
           set_commits: auto
           ignore_missing: true
           finalize: false

--- a/protocol-designer/README.md
+++ b/protocol-designer/README.md
@@ -41,7 +41,7 @@ We have an evolving set of feature flags for development, to avoid introducing r
 
 The environment variables start with `OT_PD_`. See the code for the current list. Use them like:
 
-```
+```bash
 OT_PD_COOL_FLAG=1 OT_PD_SWAG_FLAG=1 make dev
 ```
 
@@ -96,17 +96,22 @@ make -C protocol-designer build
 
 Notes:
 
-- The plugin is **disabled in CI**; it only runs locally when the `SENTRY_*` env vars are present.
+- The plugin is always enabled (to annotate React component names for better Sentry breadcrumbs), but it only uploads sourcemaps when the `SENTRY_*` env vars are present.
 - Local sourcemaps are uploaded under the Sentry release name `local-dev` so they don’t collide with real releases.
 - The runtime SDK is configured to report `release=local-dev` when local upload is enabled, so local events can resolve the uploaded sourcemaps.
 
 #### CI sourcemap upload (releases)
 
-CI uploads sourcemaps via `getsentry/action-release` (not the Vite plugin). See the workflow at `.github/workflows/pd-test-build-deploy.yaml`.
+CI uploads sourcemaps via the Vite plugin on tagged staging/production releases. See the workflow at `.github/workflows/pd-test-build-deploy.yaml`.
 
 - Sourcemaps are uploaded from `protocol-designer/dist`.
 - Upload only runs for tagged **staging** or **production** releases.
 - The release name comes from the tag version (e.g. `protocol-designer@8.8.0` → `8.8.0`).
+
+Implementation notes:
+
+- CI enables the upload by setting `OT_PD_SENTRY_PLUGIN_UPLOAD=true` for eligible tagged builds.
+- CI sets `SENTRY_RELEASE` to the tag version so runtime events match the uploaded sourcemaps.
 
 [chrome]: https://www.google.com/chrome/
 [json-schema]: https://json-schema.org/

--- a/protocol-designer/vite.config.mts
+++ b/protocol-designer/vite.config.mts
@@ -22,6 +22,10 @@ const { getVersion, generateBuildInfoHtml } = createGitVersionToolkit({
 
 const isCI = process.env.CI === 'true'
 
+const sentryReleaseEnv = !!process.env.SENTRY_RELEASE
+  ? process.env.SENTRY_RELEASE
+  : undefined
+
 const hasSentryCreds =
   !!process.env.SENTRY_AUTH_TOKEN &&
   !!process.env.SENTRY_ORG &&
@@ -31,8 +35,12 @@ const hasSentryCreds =
 // When enabled locally, the plugin will upload sourcemaps under the `local-dev`
 // release name. The runtime SDK is configured to report the same release so local
 // events can resolve uploaded sourcemaps.
-// CI should use getsentry/action-release for releases/sourcemaps.
-const enableSentryLocalPlugin = !isCI && hasSentryCreds
+// In CI, sourcemap upload is disabled by default and must be explicitly opted in.
+const enableSentryLocalSourcemapUpload = !isCI && hasSentryCreds
+const enableSentryCiSourcemapUpload =
+  isCI && hasSentryCreds && process.env.OT_PD_SENTRY_PLUGIN_UPLOAD === 'true'
+const enableSentrySourcemapUpload =
+  enableSentryLocalSourcemapUpload || enableSentryCiSourcemapUpload
 
 // eslint-disable-next-line import/no-default-export
 export default defineConfig(async (): Promise<UserConfig> => {
@@ -81,26 +89,32 @@ export default defineConfig(async (): Promise<UserConfig> => {
         },
       },
 
-      ...(enableSentryLocalPlugin
-        ? [
-            sentryVitePlugin({
+      // Always enable the Sentry Vite plugin so React component names are annotated
+      // (better breadcrumbs, component stack traces, etc).
+      // Only upload sourcemaps locally when explicitly opted in via SENTRY_* env vars.
+      // CI can optionally upload sourcemaps via this plugin when explicitly opted in.
+      // (Default CI behavior is still no upload.)
+      sentryVitePlugin({
+        telemetry: false,
+        reactComponentAnnotation: { enabled: true },
+        release: {
+          name: enableSentryLocalSourcemapUpload
+            ? 'local-dev'
+            : (sentryReleaseEnv ?? OT_PD_VERSION),
+          inject: false,
+        },
+        ...(enableSentrySourcemapUpload
+          ? {
               org: process.env.SENTRY_ORG,
               project: process.env.SENTRY_PROJECT,
               authToken: process.env.SENTRY_AUTH_TOKEN,
-              telemetry: false,
-              reactComponentAnnotation: { enabled: true },
-
-              // Local opt-in behavior:
-              // - Upload sourcemaps via the plugin (requires SENTRY_* env vars)
-              // - Use the `local-dev` release name
-              // CI continues to upload via getsentry/action-release.
-              release: {
-                name: 'local-dev',
-                inject: false,
+              sourcemaps: {
+                assets: ['./dist/**'],
+                ignore: ['./node_modules/**'],
               },
-            }),
-          ]
-        : []),
+            }
+          : {}),
+      }),
 
       {
         name: 'build-info-generator',
@@ -146,7 +160,9 @@ export default defineConfig(async (): Promise<UserConfig> => {
       _OT_PD_MIXPANEL_ID_: JSON.stringify(process.env.OT_PD_MIXPANEL_ID),
       _OT_PD_REQUIRED_APP_VERSION_: JSON.stringify(REQUIRED_APP_VERSION),
       _OT_PD_SENTRY_RELEASE_: JSON.stringify(
-        enableSentryLocalPlugin ? 'local-dev' : OT_PD_VERSION
+        enableSentryLocalSourcemapUpload
+          ? 'local-dev'
+          : (sentryReleaseEnv ?? OT_PD_VERSION)
       ),
       _OT_PD_SENTRY_DEV_DSN_: JSON.stringify(process.env.OT_PD_SENTRY_DEV_DSN),
       _OT_PD_SENTRY_DSN_: JSON.stringify(process.env.OT_PD_SENTRY_DSN),


### PR DESCRIPTION
## Overview

- Always use the plugin to produce source maps.
- Only use the `getsentry/action-release@v3` to add metadata to the release created by the source map upload during build and then finalize the release once deployed.

- [x] Tested the upload locally to `local-dev` and it worked.