### PR TITLE
fix(app): restrict QT disposal trash to be the same as tip-drop, part 2

### DIFF
--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/DisposalVolume.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/DisposalVolume.tsx
@@ -34,7 +34,7 @@ import { ACTIONS } from '../constants'
 import { getPipetteName } from '../utils'
 
 import type { Dispatch } from 'react'
-import type { SupportedTip } from '@opentrons/shared-data'
+import type { CutoutConfig, SupportedTip } from '@opentrons/shared-data'
 import type {
   BlowOutLocation,
   FlowRateKind,
@@ -84,44 +84,37 @@ export function DisposalVolume(props: DisposalVolumeProps): JSX.Element {
   const [flowRate, setFlowRate] = useState<number | null>(null)
   const deckConfig = useNotifyDeckConfigurationQuery().data ?? []
 
-  const trashBinCutoutConfig = deckConfig.find(
-    cutoutConfig => cutoutConfig.cutoutFixtureId === TRASH_BIN_ADAPTER_FIXTURE
-  )
-  const trashBinOption: BlowOutLocation | undefined =
-    trashBinCutoutConfig != null
+  // If state.dropTipLocation is dropping tips into a trash fixture, then that is the
+  // only trash fixture allowed for the disposal blowout location. Otherwise (if we're
+  // returning tips), let the user choose to blow out to any trash fixture on the deck.
+  const selectableCutoutConfigs: CutoutConfig[] =
+    typeof state.dropTipLocation === 'object'
+      ? [state.dropTipLocation]
+      : deckConfig.filter(
+          cutoutConfig =>
+            TRASH_BIN_ADAPTER_FIXTURE === cutoutConfig.cutoutFixtureId ||
+            WASTE_CHUTE_FIXTURES.includes(cutoutConfig.cutoutFixtureId)
+        )
+  const fixtureOptions = selectableCutoutConfigs.map(cutoutConfig =>
+    TRASH_BIN_ADAPTER_FIXTURE === cutoutConfig.cutoutFixtureId
       ? {
-          cutoutId: trashBinCutoutConfig.cutoutId,
-          cutoutFixtureId: TRASH_BIN_ADAPTER_FIXTURE,
+          option: cutoutConfig,
+          value: `trashBin:${cutoutConfig.cutoutId}`,
+          description: t('trashBin_location', {
+            slotName: FLEX_SINGLE_SLOT_BY_CUTOUT_ID[cutoutConfig.cutoutId],
+          }),
         }
-      : undefined
-
-  const wasteChuteOptions = deckConfig
-    .filter(
-      option =>
-        typeof option.cutoutFixtureId === 'string' &&
-        WASTE_CHUTE_FIXTURES.includes(option.cutoutFixtureId)
-    )
-    .map(option => ({
-      option,
-      value: `wasteChute:${option.cutoutId}`,
-      description: t('wasteChute_location', {
-        slotName: FLEX_SINGLE_SLOT_BY_CUTOUT_ID[option.cutoutId],
-      }),
-    }))
+      : {
+          option: cutoutConfig,
+          value: `wasteChute:${cutoutConfig.cutoutId}`,
+          description: t('wasteChute_location', {
+            slotName: FLEX_SINGLE_SLOT_BY_CUTOUT_ID[cutoutConfig.cutoutId],
+          }),
+        }
+  )
 
   const blowoutLocationOptions = [
-    ...(trashBinOption != null
-      ? [
-          {
-            option: trashBinOption,
-            value: `trashBin:${trashBinOption.cutoutId}`,
-            description: t('trashBin_location', {
-              slotName: FLEX_SINGLE_SLOT_BY_CUTOUT_ID[trashBinOption.cutoutId],
-            }),
-          },
-        ]
-      : []),
-    ...wasteChuteOptions,
+    ...fixtureOptions,
     {
       option: SOURCE_WELL_BLOWOUT_DESTINATION,
       value: SOURCE_WELL_BLOWOUT_DESTINATION,

--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/__tests__/DisposalVolume.test.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/__tests__/DisposalVolume.test.tsx
@@ -34,7 +34,7 @@ const modifiedQuickTransferState = {
 }
 const mockDeckConfig = [
   {
-    cutoutId: 'cutoutC3',
+    cutoutId: 'cutoutA3', // should match trashbin position in QuickTransferState
     cutoutFixtureId: TRASH_BIN_ADAPTER_FIXTURE,
   },
 ]
@@ -83,7 +83,7 @@ describe('DisposalVolume', () => {
     await user.click(screen.getByText('Continue'))
     screen.getByText('Select blowout location')
     screen.getByText('Continue')
-    screen.getByText('Trash bin in C3')
+    screen.getByText('Trash bin in A3')
     screen.getByText('Source well')
   })
 


### PR DESCRIPTION
# Overview

Quick Transfer lets you choose any trash fixture on the deck as the disposal volume blowout location, but that is not implementable with the Python API. AUTH-2540

In the Python API, if you choose a trash fixture for tip-drop with `distribute_with_liquid_class(trash_location=...)`, then the disposal volume blowout to trash must use the same trash fixture.

For example, this means that we can't allow the user to drop tips in the waste chute and blow out the disposal volume to the trash bin.

This PR changes the QT disposal volume settings to limit the disposal volume blowout location to be the same as the tip-drop location if the user is dropping tips into a trash fixture.

This is part 2 of the fix, for the **disposal volume location**. In part 1 (PR #20653), we made the same fix for the **blowout location**.

## Test Plan and Hands on Testing

Updated unit test.

Tested on a robot.

Before this change, we would let the user choose from all trash fixtures on the deck as the disposal volume location. In this example, the user is dropping tips into the waste chute, but we're offering to let them choose the trash bin for the disposal volume location, even though the API doesn't support that:
<img width="1440" height="960" alt="image" src="https://github.com/user-attachments/assets/1d0a369a-847e-493f-9a32-9f92fd15246e" />

After this change, we restrict the disposal volume location to the same trash fixture they chose for tip-drop, which is the waste chute:
<img width="1440" height="960" alt="image" src="https://github.com/user-attachments/assets/5e6d0712-9726-4c47-a1fb-dccc46152b74" />

## Risk assessment

Low.