### PR TITLE
chore(python): Remove keywords from private packages, and classify them as private

### DIFF
--- a/abr-testing/pyproject.toml
+++ b/abr-testing/pyproject.toml
@@ -10,16 +10,8 @@ license = "Apache-2.0"
 authors = [
     { name = "Opentrons", email = "engineering@opentrons.com" },
 ]
-keywords = ["robots", "automation", "testing", "reliability"]
 classifiers = [
-    "Development Status :: 5 - Production/Stable",
-    "Environment :: Console",
-    "Operating System :: OS Independent",
-    "Intended Audience :: Science/Research",
-    "Programming Language :: Python",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
-    "Topic :: Scientific/Engineering",
+    "Private :: Do Not Upload"  # Prevent uploading to PyPI.
 ]
 dependencies = []
 dynamic = ["version"]

--- a/g-code-testing/pyproject.toml
+++ b/g-code-testing/pyproject.toml
@@ -11,16 +11,8 @@ license = "Apache-2.0"
 authors = [
     { name = "Opentrons", email = "engineering@opentrons.com" },
 ]
-keywords = ["robots", "protocols", "synbio", "pcr", "automation", "lab"]
 classifiers = [
-    "Development Status :: 5 - Production/Stable",
-    "Environment :: Console",
-    "Operating System :: OS Independent",
-    "Intended Audience :: Science/Research",
-    "Programming Language :: Python",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
-    "Topic :: Scientific/Engineering",
+    "Private :: Do Not Upload"  # Prevent uploading to PyPI.
 ]
 dependencies = [
     "opentrons==0.0.0",

--- a/hardware-testing/pyproject.toml
+++ b/hardware-testing/pyproject.toml
@@ -10,16 +10,8 @@ license = "Apache-2.0"
 authors = [
     { name = "Opentrons", email = "engineering@opentrons.com" },
 ]
-keywords = ["robots", "automation", "testing", "hardware"]
 classifiers = [
-    "Development Status :: 5 - Production/Stable",
-    "Environment :: Console",
-    "Operating System :: OS Independent",
-    "Intended Audience :: Science/Research",
-    "Programming Language :: Python",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
-    "Topic :: Scientific/Engineering",
+    "Private :: Do Not Upload"  # Prevent uploading to PyPI.
 ]
 dependencies = []
 dynamic = ["version"]

--- a/hardware/pyproject.toml
+++ b/hardware/pyproject.toml
@@ -6,16 +6,8 @@ requires-python = '>=3.10'
 license = "Apache-2.0"
 authors = [{name = "Opentrons", email = "engineering@opentrons.com"}]
 classifiers = [
-    "Development Status :: 5 - Production/Stable",
-    "Environment :: Console",
-    "Operating System :: OS Independent",
-    "Intended Audience :: Science/Research",
-    "Programming Language :: Python",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
-    "Topic :: Scientific/Engineering",
+    "Private :: Do Not Upload"  # Prevent uploading to PyPI.
 ]
-keywords = ["robots", "protocols", "synbio", "pcr", "automation", "lab"]
 description = "Hardware control for Opentrons Robots."
 readme = "README.md"
 dependencies = [

--- a/performance-metrics/pyproject.toml
+++ b/performance-metrics/pyproject.toml
@@ -10,16 +10,8 @@ license = "Apache-2.0"
 authors = [
     { name = "Opentrons", email = "engineering@opentrons.com" },
 ]
-keywords = ["robots", "protocols", "synbio", "pcr", "automation", "lab"]
 classifiers = [
-    "Development Status :: 5 - Production/Stable",
-    "Environment :: Console",
-    "Operating System :: OS Independent",
-    "Intended Audience :: Science/Research",
-    "Programming Language :: Python",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
-    "Topic :: Scientific/Engineering",
+    "Private :: Do Not Upload"  # Prevent uploading to PyPI.
 ]
 dependencies = []
 dynamic = ["version"]

--- a/robot-server/pyproject.toml
+++ b/robot-server/pyproject.toml
@@ -5,16 +5,8 @@ requires-python = ">=3.10"
 license = { text = "Apache-2.0" }
 authors = [{ name = "Opentrons", email = "engineering@opentrons.com" }]
 classifiers = [
-    "Development Status :: 5 - Production/Stable",
-    "Environment :: Console",
-    "Operating System :: OS Independent",
-    "Intended Audience :: Science/Research",
-    "Programming Language :: Python",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.11",
-    "Topic :: Scientific/Engineering",
+    "Private :: Do Not Upload"  # Prevent uploading to PyPI.
 ]
-keywords = ["robots", "protocols", "synbio", "pcr", "automation", "lab"]
 description = "A server providing access to the Opentrons API"
 
 dependencies = [

--- a/server-utils/pyproject.toml
+++ b/server-utils/pyproject.toml
@@ -5,16 +5,8 @@ requires-python = '>=3.10'
 license = 'Apache-2.0'
 authors = [{name = "Opentrons", email = "engineering@opentrons.com"}]
 classifiers = [
-    "Development Status :: 5 - Production/Stable",
-    "Environment :: Console",
-    "Operating System :: OS Independent",
-    "Intended Audience :: Science/Research",
-    "Programming Language :: Python",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
-    "Topic :: Scientific/Engineering",
+    "Private :: Do Not Upload"  # Prevent uploading to PyPI.
 ]
-keywords = ["robots", "protocols", "synbio", "pcr", "automation", "lab"]
 description = "Common utilities for various Opentrons Python servers."
 
 dependencies = [

--- a/system-server/pyproject.toml
+++ b/system-server/pyproject.toml
@@ -5,16 +5,8 @@ requires-python = '>=3.10'
 license = 'Apache-2.0'
 authors = [{name = "Opentrons", email = "engineering@opentrons.com"}]
 classifiers = [
-    "Development Status :: 5 - Production/Stable",
-    "Environment :: Console",
-    "Operating System :: OS Independent",
-    "Intended Audience :: Science/Research",
-    "Programming Language :: Python",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.11",
-    "Topic :: Scientific/Engineering",
+    "Private :: Do Not Upload"  # Prevent uploading to PyPI.
 ]
-keywords = ["robots", "protocols", "synbio", "pcr", "automation", "lab"]
 description = "A server to provide an external interface to the robot."
 readme = "README.md"
 

--- a/test-data-generation/pyproject.toml
+++ b/test-data-generation/pyproject.toml
@@ -10,16 +10,8 @@ license = "Apache-2.0"
 authors = [
     { name = "Opentrons", email = "engineering@opentrons.com" },
 ]
-keywords = ["robots", "protocols", "synbio", "pcr", "automation", "lab"]
 classifiers = [
-    "Development Status :: 5 - Production/Stable",
-    "Environment :: Console",
-    "Operating System :: OS Independent",
-    "Intended Audience :: Science/Research",
-    "Programming Language :: Python",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
-    "Topic :: Scientific/Engineering",
+    "Private :: Do Not Upload"  # Prevent uploading to PyPI.
 ]
 dependencies = [
     "opentrons-shared-data==0.0.0",

--- a/update-server/pyproject.toml
+++ b/update-server/pyproject.toml
@@ -11,16 +11,8 @@ license = "Apache-2.0"
 authors = [
     { name = "Opentrons", email = "engineering@opentrons.com" },
 ]
-keywords = ["robots", "automation", "lab"]
 classifiers = [
-    "Development Status :: 5 - Production/Stable",
-    "Environment :: Console",
-    "Operating System :: OS Independent",
-    "Intended Audience :: Science/Research",
-    "Programming Language :: Python",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
-    "Topic :: Scientific/Engineering",
+    "Private :: Do Not Upload"  # Prevent uploading to PyPI.
 ]
 dependencies = [
     "typing-extensions>=4.0.0,<5",

--- a/usb-bridge/pyproject.toml
+++ b/usb-bridge/pyproject.toml
@@ -11,16 +11,8 @@ license = "Apache-2.0"
 authors = [
     { name = "Opentrons", email = "engineering@opentrons.com" },
 ]
-keywords = ["robots", "automation", "lab"]
 classifiers = [
-    "Development Status :: 5 - Production/Stable",
-    "Environment :: Console",
-    "Operating System :: OS Independent",
-    "Intended Audience :: Science/Research",
-    "Programming Language :: Python",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
-    "Topic :: Scientific/Engineering",
+    "Private :: Do Not Upload"  # Prevent uploading to PyPI.
 ]
 dependencies = [
     "typing-extensions>=4.0.0,<5",


### PR DESCRIPTION
## Overview

Minor cleanup to our Python project metadata, deleting some fields that are effectively unused.

## Details

The `keywords` and `classifiers` fields are used by [PyPI](https://pypi.org/) for searching and browsing. For "private" packages that aren't uploaded to PyPI, they don't have any effect. Deleting them cuts out a little bit of boilerplate, and it's one less thing that we need to update every time we upgrade our Python version.

While we're at it, we can add [the special classifier `Private :: Do Not Upload`](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#classifiers), for clarity and to prevent accidentally uploading to PyPI.

These are the packages I'm treating as "private":

* abr-testing
* g-code-testing
* hardware-testing
* hardware
* performance-metrics
* robot-server
* server-utils
* system-server
* test-data-generation
* update-server
* usb-bridge

These packages are public, intentionally uploaded to PyPI, and I'm leaving them untouched:

* opentrons (aka `api/`)
* opentrons-shared-data (aka `shared-data/python/`)

## Test Plan and Hands on Testing

Just CI.

## Review requests

opentrons and opentrons-shared-data are the _only_ two packages that we ever intend to upload to PyPI, right?

## Risk assessment

Medium. This will break our releases if I've marked something as `Private :: Do Not Upload` that I shouldn't have.
