### PR TITLE
fix(protocol-designer): highlights correct slot and allows lids to be trashed in trash bin

### DIFF
--- a/protocol-designer/src/pages/Designer/DeckSetup/HighlightItems.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/HighlightItems.tsx
@@ -220,7 +220,9 @@ export function HighlightItems(props: HighlightItemsProps): JSX.Element | null {
     if (hoveredItemTrash != null || selectedItemTrash != null) {
       const selectedTrashOnDeck =
         selectedItemTrash?.id != null
-          ? additionalEquipmentOnDeck[selectedItemTrash.id]
+          ? (Object.values(additionalEquipmentOnDeck).find(
+              e => e.location === selectedItemTrash.id
+            ) ?? null)
           : null
       const trashOnDeck = hoveredItemTrash ?? selectedTrashOnDeck
 
@@ -279,70 +281,51 @@ export function HighlightItems(props: HighlightItemsProps): JSX.Element | null {
   const getDeckItems = (): JSX.Element[] => {
     const items: JSX.Element[] = []
 
-    if (hoveredDeckItem != null || selectedItemSlot != null) {
-      const slot = hoveredDeckItem ?? selectedItemSlot?.id
+    const slot = hoveredDeckItem ?? selectedItemSlot?.id
+    if (!slot) return items
 
-      if (hoveredItemTrash != null || selectedItemTrash != null) {
-        if (slot === WASTE_CHUTE_CUTOUT) {
-          items.push(
-            <FixtureRender
-              key={`${slot}_wasteChute_selected`}
-              fixture={'wasteChute' as Fixture}
-              cutout={WASTE_CHUTE_CUTOUT as CutoutId}
-              robotType={robotType}
-              deckDef={deckDef}
-              showHighlight={true}
-              tagInfo={[
-                {
-                  text: t('new_location'),
-                  isSelected: selectedItemSlot?.id != null,
-                  isLast: true,
-                  isZoomed: false,
-                },
-              ]}
-            />
-          )
-        } else if (slot != null) {
-          items.push(
-            <FixtureRender
-              key={`${slot}_trashBin_selected`}
-              fixture={'trashBin' as Fixture}
-              cutout={'cutoutA3' as CutoutId}
-              robotType={robotType}
-              deckDef={deckDef}
-              showHighlight={true}
-              tagInfo={[
-                {
-                  text: t('new_location'),
-                  isSelected: true,
-                  isLast: true,
-                  isZoomed: false,
-                },
-              ]}
-            />
-          )
-        }
-      } else {
-        const addressableArea =
-          slot != null && slot !== WASTE_CHUTE_CUTOUT
-            ? getAddressableAreaFromSlotId(slot, deckDef)
-            : null
+    const hasTrashContext =
+      hoveredItemTrash != null || selectedItemTrash != null
 
-        if (!addressableArea) {
-          console.warn(
-            `addressableArea was null as ${addressableArea}, expected to find a matching entity`
-          )
-          return []
-        }
+    if (hasTrashContext && slot === WASTE_CHUTE_CUTOUT) {
+      items.push(
+        <FixtureRender
+          key={`${slot}_wasteChute_selected`}
+          fixture={'wasteChute' as Fixture}
+          cutout={WASTE_CHUTE_CUTOUT as CutoutId}
+          robotType={robotType}
+          deckDef={deckDef}
+          showHighlight={true}
+          tagInfo={[
+            {
+              text: t('new_location'),
+              isSelected: selectedItemSlot?.id != null,
+              isLast: true,
+              isZoomed: false,
+            },
+          ]}
+        />
+      )
+      return items
+    }
 
-        items.push(
-          <DeckItemHighlight
-            slotBoundingBox={addressableArea.boundingBox}
-            slotPosition={getPositionFromSlotId(addressableArea.id, deckDef)}
-            itemId={addressableArea.id}
-          />
+    if (slot !== WASTE_CHUTE_CUTOUT) {
+      const addressableArea = getAddressableAreaFromSlotId(slot, deckDef)
+
+      if (!addressableArea) {
+        console.warn(
+          `addressableArea was null for slot ${slot}, expected to find a matching entity`
         )
+        return items
       }
+
+      items.push(
+        <DeckItemHighlight
+          slotBoundingBox={addressableArea.boundingBox}
+          slotPosition={getPositionFromSlotId(addressableArea.id, deckDef)}
+          itemId={addressableArea.id}
+        />
+      )
     }
 
     return items

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLabwareTools/LabwareLocationField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLabwareTools/LabwareLocationField.tsx
@@ -133,7 +133,7 @@ export function LabwareLocationField(
             labwareEntities[value].def.parameters.loadName
           )
         }
-        return name !== 'Trash bin' && isCompatible
+        return isCompatible
       })
   } else {
     unoccupiedLabwareLocationsOptions =


### PR DESCRIPTION
# Overview

Corrects `HighlightItems` to not highlight trashbin if waste chute was previously highlighted. Also allows lids to be trashed into trash bin since that is allowed in python api

## Test Plan and Hands on Testing

smoke tested:
https://github.com/user-attachments/assets/aeb6bfdb-a3a8-4cb4-a017-cd08789a70d0

## Changelog
- removed additional logic for trash bin highlight and solely rely on addressable area
- remove logic that removes trash bin from available slot for lid

## Risk assessment

- trash bin highlight is upside down - will fix in follow up PR

Closes RQA-5063
