### PR TITLE
test(system-server): Improve system-server startup in integration tests

### DIFF
--- a/robot-server/tests/integration/conftest.py
+++ b/robot-server/tests/integration/conftest.py
@@ -2,7 +2,6 @@ import asyncio
 import contextlib
 import json
 import time
-from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, Generator
 
@@ -100,10 +99,10 @@ def _requests_session() -> Generator[requests.Session, None, None]:
 
 def _wait_until_ready(base_url: str) -> None:
     with _requests_session() as requests_session:
-        started = datetime.now()
+        started = time.monotonic()
         while True:
-            now = datetime.now()
-            if (now - started).total_seconds() > _INTEGRATION_SERVER_STARTUP_TIMEOUT_S:
+            now = time.monotonic()
+            if now - started > _INTEGRATION_SERVER_STARTUP_TIMEOUT_S:
                 raise RuntimeError("Could not start dev server")
             try:
                 health_response = requests_session.get(f"{base_url}/health")

--- a/system-server/tests/conftest.py
+++ b/system-server/tests/conftest.py
@@ -1,3 +1,4 @@
+import time
 from pathlib import Path
 from typing import Generator
 
@@ -7,6 +8,8 @@ from sqlalchemy.engine import Engine as SQLEngine
 
 from .dev_server import DevServer
 from system_server.persistence.database import create_sql_engine
+
+_INTEGRATION_SERVER_STARTUP_TIMEOUT_S = 30
 
 
 @pytest.fixture(autouse=True)
@@ -39,21 +42,33 @@ def sql_engine(tmpdir: Path) -> Generator[SQLEngine, None, None]:
 @pytest.fixture
 def run_server() -> Generator[DevServer, None, None]:
     """Run the system server as a subprocess."""
-    server = DevServer()
-    server.start()
-
-    with requests.Session() as session:
+    with DevServer() as dev_server:
         print("Starting server")
+        dev_server.start()
+        base_url = f"http://localhost:{dev_server.port}"
+        _wait_until_ready(base_url)
+        print("server started")
+        yield dev_server
+
+
+def _wait_until_ready(base_url: str) -> None:
+    with requests.Session() as requests_session:
+        started = time.monotonic()
         while True:
+            now = time.monotonic()
+            if now - started > _INTEGRATION_SERVER_STARTUP_TIMEOUT_S:
+                raise RuntimeError("Could not start dev server")
             try:
-                session.get(f"http://localhost:{server.port}")
-            except requests.exceptions.ConnectionError:
+                health_response = requests_session.get(f"{base_url}/health")
+            except requests.ConnectionError:
+                # The server isn't up yet to accept requests. Keep polling.
                 pass
             else:
-                break
-        print("server started")
+                if health_response.status_code == 503:
+                    # The server is accepting requests but reporting not ready. Keep polling.
+                    pass
+                else:
+                    # The server's replied with something other than a busy indicator. Stop polling.
+                    return
 
-    yield server
-    print("stopping server")
-    server.stop()
-    print("server stopped")
+            time.sleep(0.1)


### PR DESCRIPTION
## Overview

I've been seeing system-server's tests mysteriously hang in CI.

This improves the way that the test harness starts a server, to hopefully make it more reliable and debuggable. This basically does what PR #13881 did to robot-server, to system-server.

## Test Plan and Hands on Testing

Just CI.

## Review requests

None.

## Risk assessment

Low.