### PR TITLE
ci(pd): NODE_ENV production for sentry to upload

### DIFF
--- a/.github/workflows/pd-test-build-deploy.yaml
+++ b/.github/workflows/pd-test-build-deploy.yaml
@@ -118,8 +118,8 @@ jobs:
           # Opt-in CI sourcemap upload via the Vite plugin (staging/prod tagged releases only).
           OT_PD_SENTRY_PLUGIN_UPLOAD: ${{ github.ref_type == 'tag' && (startsWith(github.ref, 'refs/tags/protocol-designer') || startsWith(github.ref, 'refs/tags/staging-protocol-designer')) && (needs.determine-deploy-config.outputs.environment == 'production' || needs.determine-deploy-config.outputs.environment == 'staging') && 'true' || '' }}
         run: |
-          make -C protocol-designer NODE_ENV=${{ needs.determine-deploy-config.outputs.environment == 'production' && 'production' || 'development' }} OT_PD_PRERELEASE_MODE=${{ needs.determine-deploy-config.outputs.environment == 'sandbox' && '1' || '0' }}
-      - name: 'create the release in Sentry (no sourcemaps)'
+          make -C protocol-designer NODE_ENV=${{ (needs.determine-deploy-config.outputs.environment == 'production' || needs.determine-deploy-config.outputs.environment == 'staging') && 'production' || 'development' }} OT_PD_PRERELEASE_MODE=${{ needs.determine-deploy-config.outputs.environment == 'sandbox' && '1' || '0' }}
+      - name: 'update the release in Sentry with build metadata'
         # Only on production or staging releases (protocol-designer* or staging-protocol-designer*)
         if: github.ref_type == 'tag' && (startsWith(github.ref, 'refs/tags/protocol-designer') || startsWith(github.ref, 'refs/tags/staging-protocol-designer')) && (needs.determine-deploy-config.outputs.environment == 'production' || needs.determine-deploy-config.outputs.environment == 'staging')
         uses: getsentry/action-release@v3


### PR DESCRIPTION
## Overview

- need NODE_ENV=production on staging for the sentry plugin to not skip uploading the sourcemaps
- changed the description of the `getsentry/action-release@v3` step to be more accurate

I figured this out by running locally with NODE_ENV=development as a make variable and see that the upload is skipped as it was in this [job](https://github.com/Opentrons/opentrons/actions/runs/21226140131/job/61073600267)