### PR TITLE
fix(pd): include sentry plugin in worker

### DIFF
--- a/protocol-designer/vite.config.mts
+++ b/protocol-designer/vite.config.mts
@@ -70,6 +70,25 @@ export default defineConfig(async (): Promise<UserConfig> => {
         },
       },
     },
+    worker: {
+      // Vite builds web workers in a separate bundle context with its own plugin pipeline.
+      // Add a Sentry plugin instance here so worker chunks get debug IDs injected.
+      // The main Sentry plugin instance (below) will then upload all debug-ID-enabled
+      // chunks (including workers) in a single upload.
+      //
+      // IMPORTANT: Prevent this worker plugin from uploading on its own by overriding
+      // auth/org/project with empty strings (so it does not fall back to process.env).
+      plugins: () => [
+        sentryVitePlugin({
+          silent: true,
+          telemetry: false,
+          authToken: '',
+          org: '',
+          project: '',
+          release: { inject: false },
+        }),
+      ],
+    },
     plugins: [
       react({
         include: '**/*.tsx',


### PR DESCRIPTION
## Overview

> Almost there to get all the source and maps uploaded from the plugin!

The plugin successfully uploaded the source and maps for index and vendor but the worker was missing.  I also saw that the worker had a map but it did not have the `sentryDebugIds` in the .js

<img width="1363" height="598" alt="image" src="https://github.com/user-attachments/assets/27a15f1b-fcc2-45ef-94bd-bcf6290a2bd1" />

With this change to the config the worker map and source include the sentry debug IDs when build is run and uploaded locally.

<img width="1370" height="747" alt="image" src="https://github.com/user-attachments/assets/a39c0e77-954a-454b-b13d-b3c66b75ba4a" />


