### PR TITLE
fix(step-generation): downgrade to API 2.27 to work with App 8.8.0

### DIFF
--- a/step-generation/src/utils/pythonFileUtils.ts
+++ b/step-generation/src/utils/pythonFileUtils.ts
@@ -49,7 +49,7 @@ import type {
   WasteChuteEntities,
 } from '../types'
 
-export const PAPI_VERSION = '2.27' // latest version that we need from api/src/opentrons/protocols/api_support/definitions.py, might not be the actual latest version
+export const PAPI_VERSION = '2.27' // oldest version that we need from api/src/opentrons/protocols/api_support/definitions.py, might not be the actual latest version
 export const PD_APPLICATION_VERSION = '8.8.0' // latest PD version to insert into DESIGNER_APPLICATION blob
 
 export function pythonImports(): string {

--- a/step-generation/src/utils/pythonFileUtils.ts
+++ b/step-generation/src/utils/pythonFileUtils.ts
@@ -49,7 +49,7 @@ import type {
   WasteChuteEntities,
 } from '../types'
 
-export const PAPI_VERSION = '2.28' // latest version that we need from api/src/opentrons/protocols/api_support/definitions.py, might not be the actual latest version
+export const PAPI_VERSION = '2.27' // latest version that we need from api/src/opentrons/protocols/api_support/definitions.py, might not be the actual latest version
 export const PD_APPLICATION_VERSION = '8.8.0' // latest PD version to insert into DESIGNER_APPLICATION blob
 
 export function pythonImports(): string {


### PR DESCRIPTION
closes RQA-5078

# Overview

downgrading the API version because it turns out API 2.28 isn't public yet

## Test Plan and Hands on Testing

just review the code 😄 

## Changelog

downgrade api version

## Risk assessment

low
