### PR TITLE
fix(protocol-designer): delete unused stacker labware in deck config

### DIFF
--- a/protocol-designer/src/components/organisms/FlexHardware/__tests__/updateInitialDeckState.test.tsx
+++ b/protocol-designer/src/components/organisms/FlexHardware/__tests__/updateInitialDeckState.test.tsx
@@ -97,6 +97,7 @@ describe('updateInitialDeckState', () => {
       savedSteps: mockSavedSteps,
       makeSnackbar: mockMakeSnackbar,
       t: mockT,
+      handleDeleteStackerLabware: vi.fn(),
     })
     expect(mockDispatch).toHaveBeenCalledWith(
       vi.mocked(
@@ -137,6 +138,7 @@ describe('updateInitialDeckState', () => {
       savedSteps: mockSavedSteps,
       makeSnackbar: mockMakeSnackbar,
       t: mockT,
+      handleDeleteStackerLabware: vi.fn(),
     })
     expect(mockMakeSnackbar).toHaveBeenCalledWith('module_incompatible')
   })
@@ -156,6 +158,7 @@ describe('updateInitialDeckState', () => {
       savedSteps: mockSavedSteps,
       makeSnackbar: mockMakeSnackbar,
       t: mockT,
+      handleDeleteStackerLabware: vi.fn(),
     })
     expect(mockDispatch).toHaveBeenCalledWith(
       vi.mocked(
@@ -182,6 +185,7 @@ describe('updateInitialDeckState', () => {
       makeSnackbar: mockMakeSnackbar,
       t: mockT,
       deckConfig: mockDeckConfig,
+      handleDeleteStackerLabware: vi.fn(),
     })
     expect(mockSetShowDeleteEntityModal).toHaveBeenCalled()
   })
@@ -201,6 +205,7 @@ describe('updateInitialDeckState', () => {
       savedSteps: mockSavedSteps,
       makeSnackbar: mockMakeSnackbar,
       t: mockT,
+      handleDeleteStackerLabware: vi.fn(),
     })
     expect(mockDispatch).toHaveBeenCalledWith(
       vi.mocked(createDeckFixture('trashBin', 'cutoutA3'))
@@ -233,6 +238,7 @@ describe('updateInitialDeckState', () => {
       savedSteps: mockSavedSteps,
       makeSnackbar: mockMakeSnackbar,
       t: mockT,
+      handleDeleteStackerLabware: vi.fn(),
     })
     expect(mockMakeSnackbar).toHaveBeenCalledWith(
       'conflict_on_slot_labware_fixture'
@@ -254,6 +260,7 @@ describe('updateInitialDeckState', () => {
       savedSteps: mockSavedSteps,
       makeSnackbar: mockMakeSnackbar,
       t: mockT,
+      handleDeleteStackerLabware: vi.fn(),
     })
     expect(mockDispatch).toHaveBeenCalledWith(
       vi.mocked(deleteDeckFixture('trash'))
@@ -275,6 +282,7 @@ describe('updateInitialDeckState', () => {
       savedSteps: mockSavedSteps,
       makeSnackbar: mockMakeSnackbar,
       t: mockT,
+      handleDeleteStackerLabware: vi.fn(),
     })
     expect(mockDispatch).toHaveBeenNthCalledWith(
       1,
@@ -305,6 +313,7 @@ describe('updateInitialDeckState', () => {
       savedSteps: mockSavedSteps,
       makeSnackbar: mockMakeSnackbar,
       t: mockT,
+      handleDeleteStackerLabware: vi.fn(),
     })
     expect(mockDispatch).toHaveBeenNthCalledWith(
       1,
@@ -346,6 +355,7 @@ describe('updateInitialDeckState', () => {
       makeSnackbar: mockMakeSnackbar,
       t: mockT,
       deckConfig: mockDeckConfig,
+      handleDeleteStackerLabware: vi.fn(),
     })
     expect(mockSetShowDeleteStagingAreaModal).toHaveBeenCalled()
   })
@@ -366,6 +376,7 @@ describe('updateInitialDeckState', () => {
       savedSteps: mockSavedSteps,
       makeSnackbar: mockMakeSnackbar,
       t: mockT,
+      handleDeleteStackerLabware: vi.fn(),
     })
     expect(mockDispatch).toHaveBeenNthCalledWith(
       1,
@@ -393,6 +404,7 @@ describe('updateInitialDeckState', () => {
       savedSteps: mockSavedSteps,
       makeSnackbar: mockMakeSnackbar,
       t: mockT,
+      handleDeleteStackerLabware: vi.fn(),
     })
     expect(mockDispatch).toHaveBeenNthCalledWith(
       1,
@@ -431,6 +443,7 @@ describe('updateInitialDeckState', () => {
       makeSnackbar: mockMakeSnackbar,
       t: mockT,
       deckConfig: mockDeckConfig,
+      handleDeleteStackerLabware: vi.fn(),
     })
     expect(mockSetShowDeleteStagingAreaModal).toHaveBeenCalled()
   })
@@ -453,6 +466,7 @@ describe('updateInitialDeckState', () => {
       makeSnackbar: mockMakeSnackbar,
       t: mockT,
       deckConfig: mockDeckConfig,
+      handleDeleteStackerLabware: vi.fn(),
     })
     expect(mockSetShowDeleteEntityModal).toHaveBeenCalled()
   })

--- a/protocol-designer/src/components/organisms/FlexHardware/index.tsx
+++ b/protocol-designer/src/components/organisms/FlexHardware/index.tsx
@@ -242,6 +242,7 @@ export function FlexHardware(): JSX.Element {
             makeSnackbar,
             t,
             deckConfig,
+            handleDeleteStackerLabware,
           })
         }}
       />

--- a/protocol-designer/src/components/organisms/FlexHardware/util.ts
+++ b/protocol-designer/src/components/organisms/FlexHardware/util.ts
@@ -1,5 +1,6 @@
 import {
   FLEX_ROBOT_TYPE,
+  FLEX_STACKER_MODULE_TYPE,
   getCutoutIdForSlotName,
   getDeckDefFromRobotType,
   getModuleType,
@@ -32,6 +33,7 @@ import type {
 } from '@opentrons/shared-data'
 import type {
   AllTemporalPropertiesForTimelineFrame,
+  ModuleOnDeck,
   SavedStepFormState,
 } from '/protocol-designer/step-forms'
 import type { ThunkDispatch } from '/protocol-designer/types'
@@ -44,7 +46,7 @@ const map3rdColumnCutoutTo4thColumnSlot: Record<string, string> = {
   cutoutD3: 'D4',
 }
 
-interface UpdateInitialDeckSetupProps {
+export interface UpdateInitialDeckSetupProps {
   values: CutoutConfigMap[]
   initialDeckSetup: AllTemporalPropertiesForTimelineFrame
   dispatch: ThunkDispatch<any>
@@ -63,6 +65,7 @@ interface UpdateInitialDeckSetupProps {
   savedSteps: SavedStepFormState
   makeSnackbar: MakeSnackbar
   t: any
+  handleDeleteStackerLabware: (module: ModuleOnDeck) => void
   deckConfig?: DeckConfiguration
 }
 
@@ -79,6 +82,7 @@ export const updateInitialDeckState = (
     makeSnackbar,
     t,
     deckConfig,
+    handleDeleteStackerLabware,
   } = props
   const {
     additionalEquipmentOnDeck,
@@ -174,6 +178,9 @@ export const updateInitialDeckState = (
           //   if deleting module
         } else {
           dispatch(deleteModule({ moduleId: matchingModule.id }))
+          if (matchingModule.type === FLEX_STACKER_MODULE_TYPE) {
+            handleDeleteStackerLabware(matchingModule)
+          }
           if (deckConfig != null) {
             dispatch(editDeckConfiguration({ deckConfig }))
           }


### PR DESCRIPTION
# Overview

If a user removes stacker in deck hardware with labware on its shuttle/hopper, its labware should be deleted, even if it hasn't been used in any steps (without confirmation modal)

Closes RQA-5049

## Test Plan and Hands on Testing

- create or import a protocol with a stacker
- ensure it has labware configured on its hopper/ shuttle, and that it is not used in any steps
- in Deck Hardware, click the stacker to delete it. Verify that no confirmation modal shows
- navigate to starting deck, and verify that the labware that was loaded on the stacker are deleted

## Changelog

- pass `handleDeleteStackerLabware` to `updateInitialDeckState` for non-confirmation-requiring stacker deletion
- fix tests

## Review requests

see test plan

## Risk assessment

lowish