### PR TITLE
fix(protocol-designer): fix error logic in bad stacker form

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/FlexStackerTools/RefillSettings.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/FlexStackerTools/RefillSettings.tsx
@@ -34,10 +34,19 @@ interface RefillSettingsProps {
   propsForFields: FieldPropsByName
   moduleState: FlexStackerModuleState | null
   maxPoolCount: number
+  isStackerFillEnabled: boolean
+  showFormErrors: boolean
 }
 
 export function RefillSettings(props: RefillSettingsProps): JSX.Element {
-  const { formData, propsForFields, moduleState, maxPoolCount } = props
+  const {
+    formData,
+    propsForFields,
+    moduleState,
+    maxPoolCount,
+    isStackerFillEnabled,
+    showFormErrors,
+  } = props
   const { t } = useTranslation('form')
   const { storedLabwareDetails, labwareInHopper } = moduleState ?? {}
   const labwareEntities = useSelector(getLabwareEntities)
@@ -150,7 +159,7 @@ export function RefillSettings(props: RefillSettingsProps): JSX.Element {
         </div>
       )}
 
-      {storedLabwareDetails == null ? (
+      {showFormErrors && !isStackerFillEnabled ? (
         <InlineNotification
           type="error"
           heading={t('step_edit_form.flex_stacker.stacker_labware_not_defined')}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/FlexStackerTools/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/FlexStackerTools/index.tsx
@@ -32,6 +32,7 @@ import styles from './flexstackertools.module.css'
 import { RefillSettings } from './RefillSettings'
 import { StackerContentItem } from './StackerContentItem'
 import { StackerControls } from './StackerControls'
+import { getIsStackerFillEnabled } from './utils.ts/getIsStackerFillEnabled'
 import { getIsStackerRetrieveEnabled } from './utils.ts/getIsStackerRetrieveEnabled'
 import { getIsStackerStoreEnabled } from './utils.ts/getIsStackerStoreEnabled'
 import { getStoredLabwareDefinitions } from './utils.ts/getStoredLabwareDefinitions'
@@ -41,7 +42,7 @@ import type { FlexStackerFormType } from '/protocol-designer/form-types'
 import type { StepFormProps } from '../../types'
 
 export function FlexStackerTools(props: StepFormProps): JSX.Element {
-  const { formData, propsForFields } = props
+  const { formData, propsForFields, showFormErrors } = props
   const { t } = useTranslation('form')
   const dispatch = useDispatch()
   const isFormPresaved = useSelector(getCurrentFormIsPresaved)
@@ -61,31 +62,36 @@ export function FlexStackerTools(props: StepFormProps): JSX.Element {
     robotState != null ? flexStackerStateGetter(robotState, moduleId) : null
   const { labwareInHopper, labwareOnShuttle, storedLabwareDetails } =
     moduleState ?? {}
+  const numLabwareInHopper =
+    labwareInHopper != null ? labwareInHopper.length : 0
 
   const isStackerStoreEnabled =
     moduleState != null &&
     getIsStackerStoreEnabled(moduleState, labwareEntities)
   const isStackerRetrieveEnabled =
-    moduleState != null ? getIsStackerRetrieveEnabled(moduleState) : false
-  const firstFormTypeOption = ((): FlexStackerFormType => {
+    moduleState != null && getIsStackerRetrieveEnabled(moduleState)
+  const isStackerFillEnabled =
+    moduleState != null && getIsStackerFillEnabled(moduleState)
+  const isStackerEmptyEnabled = numLabwareInHopper > 0
+  const firstFormTypeOption = ((): FlexStackerFormType | null => {
     if (isStackerStoreEnabled) {
       return FLEX_STACKER_STORE
     } else if (isStackerRetrieveEnabled) {
       return FLEX_STACKER_RETRIEVE
-    } else {
-      return FLEX_STACKER_FILL
+    } else if (isStackerEmptyEnabled) {
+      return FLEX_STACKER_EMPTY
     }
+    // design specifies to never hide the refill option, even if the stacker does not have stored labware details
+    return FLEX_STACKER_FILL
   })()
 
   // preselect the first form option on mount if the form is presaved
   useEffect(() => {
-    if (isFormPresaved) {
+    if (isFormPresaved && moduleId != null && firstFormTypeOption != null) {
       propsForFields.flexStackerFormType.updateValue(firstFormTypeOption)
     }
-  }, [])
+  }, [moduleId])
 
-  const numLabwareInHopper =
-    labwareInHopper != null ? labwareInHopper.length : 0
   const storedLabwareDefinitions = getStoredLabwareDefinitions(
     storedLabwareDetails ?? null,
     labwareEntities
@@ -191,7 +197,7 @@ export function FlexStackerTools(props: StepFormProps): JSX.Element {
           propsForFields={propsForFields}
           isStackerStoreEnabled={isStackerStoreEnabled}
           isStackerRetrieveEnabled={isStackerRetrieveEnabled}
-          isStackerEmptyEnabled={numLabwareInHopper > 0}
+          isStackerEmptyEnabled={isStackerEmptyEnabled}
         />
       ) : null}
       {formData.flexStackerFormType !== FLEX_STACKER_STORE &&
@@ -204,6 +210,8 @@ export function FlexStackerTools(props: StepFormProps): JSX.Element {
           propsForFields={propsForFields}
           moduleState={moduleState}
           maxPoolCount={maxPoolCount}
+          isStackerFillEnabled={isStackerFillEnabled}
+          showFormErrors={showFormErrors}
         />
       ) : null}
       {formData.flexStackerFormType === FLEX_STACKER_EMPTY ? (

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/FlexStackerTools/utils.ts/getIsStackerFillEnabled.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/FlexStackerTools/utils.ts/getIsStackerFillEnabled.ts
@@ -1,0 +1,5 @@
+import type { FlexStackerModuleState } from '@opentrons/step-generation'
+
+export const getIsStackerFillEnabled = (
+  stackerState: FlexStackerModuleState
+): boolean => stackerState?.storedLabwareDetails?.primaryLabwareURI != null

--- a/protocol-designer/src/steplist/formLevel/errors.ts
+++ b/protocol-designer/src/steplist/formLevel/errors.ts
@@ -633,12 +633,6 @@ const TIPS_SELECTED_REQUIRED: FormError = {
   location: ['form', 'field'],
   page: 3,
 }
-const FLEX_STACKER_FORM_TYPE_REQUIRED: FormError = {
-  title: 'Flex stacker step type required',
-  dependentFields: ['flexStackerFormType'],
-  location: ['form', 'field'],
-  showOnReopen: true,
-}
 export type FormErrorChecker = (
   arg: HydratedFormData,
   moduleEntities?: ModuleEntities
@@ -826,6 +820,7 @@ export const moduleIdRequired = (
     | HydratedMagnetFormData
     | HydratedTemperatureFormData
     | HydratedHeaterShakerFormData
+    | HydratedFlexStackerFormData
 ): FormError | null => {
   const { moduleId } = fields
   if (moduleId == null) return MODULE_ID_REQUIRED
@@ -1592,13 +1587,6 @@ export const tipSelectionRequired = (
     (tips_selected == null || tips_selected?.length === 0)
     ? TIPS_SELECTED_REQUIRED
     : null
-}
-
-export const flexStackerFormTypeRequired = (
-  fields: HydratedFlexStackerFormData
-): FormError | null => {
-  const { flexStackerFormType } = fields
-  return flexStackerFormType == null ? FLEX_STACKER_FORM_TYPE_REQUIRED : null
 }
 
 /*******************

--- a/protocol-designer/src/steplist/formLevel/errors.ts
+++ b/protocol-designer/src/steplist/formLevel/errors.ts
@@ -633,6 +633,12 @@ const TIPS_SELECTED_REQUIRED: FormError = {
   location: ['form', 'field'],
   page: 3,
 }
+const FLEX_STACKER_FORM_TYPE_REQUIRED: FormError = {
+  title: 'Flex stacker step type required',
+  dependentFields: ['flexStackerFormType'],
+  location: ['form', 'field'],
+  showOnReopen: true,
+}
 export type FormErrorChecker = (
   arg: HydratedFormData,
   moduleEntities?: ModuleEntities
@@ -1586,6 +1592,13 @@ export const tipSelectionRequired = (
     (tips_selected == null || tips_selected?.length === 0)
     ? TIPS_SELECTED_REQUIRED
     : null
+}
+
+export const flexStackerFormTypeRequired = (
+  fields: HydratedFlexStackerFormData
+): FormError | null => {
+  const { flexStackerFormType } = fields
+  return flexStackerFormType == null ? FLEX_STACKER_FORM_TYPE_REQUIRED : null
 }
 
 /*******************

--- a/protocol-designer/src/steplist/formLevel/index.ts
+++ b/protocol-designer/src/steplist/formLevel/index.ts
@@ -36,6 +36,7 @@ import {
   engageHeightRequired,
   fileNameRequired,
   fillQuantityOutOfRange,
+  flexStackerFormTypeRequired,
   incompatibleAspirateLabware,
   incompatibleDispenseLabware,
   incompatibleLabware,
@@ -294,7 +295,10 @@ const stepFormHelperMap: {
     getErrors: composeErrors(),
   },
   flexStacker: {
-    getErrors: composeErrors(fillQuantityOutOfRange),
+    getErrors: composeErrors(
+      fillQuantityOutOfRange,
+      flexStackerFormTypeRequired
+    ),
   },
 }
 

--- a/protocol-designer/src/steplist/formLevel/index.ts
+++ b/protocol-designer/src/steplist/formLevel/index.ts
@@ -36,7 +36,6 @@ import {
   engageHeightRequired,
   fileNameRequired,
   fillQuantityOutOfRange,
-  flexStackerFormTypeRequired,
   incompatibleAspirateLabware,
   incompatibleDispenseLabware,
   incompatibleLabware,
@@ -295,10 +294,7 @@ const stepFormHelperMap: {
     getErrors: composeErrors(),
   },
   flexStacker: {
-    getErrors: composeErrors(
-      fillQuantityOutOfRange,
-      flexStackerFormTypeRequired
-    ),
+    getErrors: composeErrors(fillQuantityOutOfRange, moduleIdRequired),
   },
 }
 


### PR DESCRIPTION
# Overview

Ensure we don't show form-level error notifications in stacker step forms until "Save" is clicked. Also, add a form error blocking a user from saving a step without a module selected.

Closes RQA-5074

## Test Plan and Hands on Testing

- import [this test protocol](https://github.com/user-attachments/files/24797995/untitled.9.py)
- create a stacker step, and select the module in D4 (unconfigured for labware)
- verify that the only step type is Refill (pre-selected), and no error inline notification is shown yet
- click "Save" and verify that the error notification shows

## Changelog

- update logic for Refill safety
- add module required error for stacker

## Review requests

- see test plan

## Risk assessment

low