### PR TITLE
fix(protocol-designer): remove absorbance reader from visual column 4 slots

### DIFF
--- a/shared-data/js/helpers/deckConfiguration/getVisualSlotFrom.ts
+++ b/shared-data/js/helpers/deckConfiguration/getVisualSlotFrom.ts
@@ -93,30 +93,10 @@ export const VS_TO_AA: Record<VISUAL_SLOTS, AddressableAreaNamesWithFakes[]> = {
     'gripperWasteChute',
     'absorbanceReaderV1D3',
   ],
-  VSA4: [
-    'fakeA4',
-    'A4',
-    'flexStackerModuleV1A4',
-    'absorbanceReaderV1LidDockA4',
-  ],
-  VSB4: [
-    'fakeB4',
-    'B4',
-    'flexStackerModuleV1B4',
-    'absorbanceReaderV1LidDockB4',
-  ],
-  VSC4: [
-    'fakeC4',
-    'C4',
-    'flexStackerModuleV1C4',
-    'absorbanceReaderV1LidDockC4',
-  ],
-  VSD4: [
-    'fakeD4',
-    'D4',
-    'flexStackerModuleV1D4',
-    'absorbanceReaderV1LidDockD4',
-  ],
+  VSA4: ['fakeA4', 'A4', 'flexStackerModuleV1A4'],
+  VSB4: ['fakeB4', 'B4', 'flexStackerModuleV1B4'],
+  VSC4: ['fakeC4', 'C4', 'flexStackerModuleV1C4'],
+  VSD4: ['fakeD4', 'D4', 'flexStackerModuleV1D4'],
 }
 
 export const getVisualSlotIdFromAAId = (


### PR DESCRIPTION
# Overview

Ensure absorbance reader can only be loaded through column 3

https://github.com/user-attachments/assets/faf773de-a404-4c3c-ad3e-09ab41bb215a

## Test Plan and Hands on Testing

smoke tested and exported protocol to ensure loading in column 3

## Changelog

- removed absorbance reader lid addressable area from column 4 visual slots

Closes RQA-5081

