### PR TITLE
fix(app): fix slot summary rendering order

### DIFF
--- a/app/src/organisms/Desktop/ProtocolVisualization/DeckView/DeckViewDetails.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/DeckView/DeckViewDetails.tsx
@@ -3,6 +3,7 @@ import { FLEX_ROBOT_TYPE } from '@opentrons/shared-data'
 import { getFixtureSummaryInfo } from '../utils/getFixtureSummaryInfo'
 import { getSlotIdsBlockedBySpanningForThermocycler } from '../utils/getSlotIdsBlockedBySpanningForThermocycler'
 import { DeckViewLabware } from './DeckViewLabware'
+import { DeckViewModuleCommandSummaries } from './DeckViewModuleCommandSummaries'
 import { DeckViewModules } from './DeckViewModules'
 import { DeckViewSlots } from './DeckViewSlots'
 import { FixtureCommandSummary } from './FixtureCommandSummary'
@@ -137,6 +138,13 @@ export function DeckViewDetails(props: DeckViewDetailsProps): JSX.Element {
           type="wasteChute"
         />
       ) : null}
+      <DeckViewModuleCommandSummaries
+        robotState={robotState}
+        invariantContext={invariantContext}
+        deckDef={deckDef}
+        robotType={robotType}
+        selectedRunTimeCommand={selectedRunTimeCommand}
+      />
     </>
   )
 }

--- a/app/src/organisms/Desktop/ProtocolVisualization/DeckView/DeckViewModuleCommandSummaries.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/DeckView/DeckViewModuleCommandSummaries.tsx
@@ -1,0 +1,86 @@
+import {
+  getModuleDef,
+  getPositionFromSlotId,
+  inferModuleOrientationFromXCoordinate,
+} from '@opentrons/shared-data'
+
+import { getActiveLayer } from '../utils/getActiveLayer'
+import { getTopmostLabwareOnModuleFromStack } from '../utils/getTopmostLabwareOnModuleFromStack'
+import { ModuleCommandSummary } from './ModuleCommandSummary'
+
+import type {
+  DeckDefinition,
+  RobotType,
+  RunTimeCommand,
+} from '@opentrons/shared-data'
+import type { InvariantContext, RobotState } from '@opentrons/step-generation'
+
+interface DeckViewModuleCommandSummariesProps {
+  robotState: RobotState
+  invariantContext: InvariantContext
+  deckDef: DeckDefinition
+  robotType: RobotType
+  selectedRunTimeCommand?: RunTimeCommand
+}
+
+export function DeckViewModuleCommandSummaries(
+  props: DeckViewModuleCommandSummariesProps
+): JSX.Element {
+  const {
+    robotState,
+    invariantContext,
+    deckDef,
+    robotType,
+    selectedRunTimeCommand,
+  } = props
+  const { moduleEntities } = invariantContext
+  const { modules, labware } = robotState
+
+  return (
+    <>
+      {Object.entries(modules).map(([id, { slot }]) => {
+        const slotPosition = getPositionFromSlotId(slot, deckDef)
+        if (slotPosition == null) {
+          console.warn(`no slot ${slot} for module ${id}`)
+          return null
+        }
+        const labwareLoadedOnModuleId = getTopmostLabwareOnModuleFromStack(
+          id,
+          Object.values(labware)
+        )
+        const { isActiveLayerVisible } = getActiveLayer(
+          labwareLoadedOnModuleId,
+          selectedRunTimeCommand,
+          id
+        )
+        const isStepAssociatedWithModule =
+          selectedRunTimeCommand != null &&
+          'moduleId' in selectedRunTimeCommand.params &&
+          selectedRunTimeCommand.params.moduleId === id
+        const showLabwareCommandSummary =
+          isStepAssociatedWithModule && labwareLoadedOnModuleId != null
+        const showModuleCommandSummary =
+          (isActiveLayerVisible || isStepAssociatedWithModule) &&
+          selectedRunTimeCommand != null &&
+          !showLabwareCommandSummary
+
+        if (!showModuleCommandSummary) return null
+
+        const moduleDef = getModuleDef(moduleEntities[id].model)
+
+        return (
+          <ModuleCommandSummary
+            key={`module_command_summary_${id}`}
+            robotType={robotType}
+            moduleModel={moduleDef.model}
+            commandType={selectedRunTimeCommand.commandType}
+            position={slotPosition}
+            showModuleIcon={false}
+            slot={slot}
+            orientation={inferModuleOrientationFromXCoordinate(slotPosition[0])}
+          />
+        )
+      })}
+    </>
+  )
+}

--- a/app/src/organisms/Desktop/ProtocolVisualization/DeckView/DeckViewModules.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/DeckView/DeckViewModules.tsx
@@ -26,6 +26,8 @@ import type {
 import type { InvariantContext, RobotState } from '@opentrons/step-generation'
 import type { LabwareEntityExtended } from '../../../../organisms/Desktop/ProtocolVisualization/DeckView'
 
+const FLEX_STACKER_SLOT_POSITION = 178
+
 interface DeckViewModulesProps {
   robotState: RobotState
   invariantContext: InvariantContext
@@ -146,7 +148,9 @@ export function DeckViewModules(props: DeckViewModulesProps): JSX.Element {
                     : slot
                 }
                 slotPosition={[
-                  moduleType === FLEX_STACKER_MODULE_TYPE ? 178 : 0,
+                  moduleType === FLEX_STACKER_MODULE_TYPE
+                    ? FLEX_STACKER_SLOT_POSITION
+                    : 0,
                   0,
                   0,
                 ]}

--- a/app/src/organisms/Desktop/ProtocolVisualization/DeckView/DeckViewModules.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/DeckView/DeckViewModules.tsx
@@ -14,7 +14,6 @@ import { getModuleInnerProps } from '../utils/getModuleInnerProps'
 import { getTopmostLabwareOnModuleFromStack } from '../utils/getTopmostLabwareOnModuleFromStack'
 import { DeckViewOverlay } from './DeckViewOverlay'
 import { DeckViewStacker } from './DeckViewStacker'
-import { ModuleCommandSummary } from './ModuleCommandSummary'
 
 import type { Dispatch, SetStateAction } from 'react'
 import type { ThermocyclerVizProps } from '@opentrons/components'
@@ -70,14 +69,11 @@ export function DeckViewModules(props: DeckViewModulesProps): JSX.Element {
         )
         const { isActiveLayerVisible } = getActiveLayer(
           labwareLoadedOnModuleId,
-          selectedRunTimeCommand
+          selectedRunTimeCommand,
+          id
         )
         const moduleDef = getModuleDef(moduleEntities[id].model)
         const moduleType = moduleEntities[id].type
-        const isStepAssociatedWithModule =
-          selectedRunTimeCommand != null &&
-          'moduleId' in selectedRunTimeCommand.params &&
-          selectedRunTimeCommand.params.moduleId === id
         const tempInnerProps = getModuleInnerProps(moduleState)
         const innerTCProps = {
           ...tempInnerProps,
@@ -86,89 +82,83 @@ export function DeckViewModules(props: DeckViewModulesProps): JSX.Element {
               ? 'closed'
               : 'open',
         }
+        const isSelectedCommandForThisModule =
+          selectedRunTimeCommand != null &&
+          'moduleId' in selectedRunTimeCommand.params &&
+          selectedRunTimeCommand.params.moduleId === id
+
+        const showLabwareCommandSummary =
+          isSelectedCommandForThisModule && labwareLoadedOnModuleId != null
+
         const showModuleCommandSummary =
-          (isActiveLayerVisible || isStepAssociatedWithModule) &&
-          selectedRunTimeCommand != null
+          (isActiveLayerVisible || isSelectedCommandForThisModule) &&
+          selectedRunTimeCommand != null &&
+          !showLabwareCommandSummary
         return (
           <Fragment key={id}>
-            <>
-              <Module
-                key={id}
-                x={slotPosition[0]}
-                y={slotPosition[1]}
-                def={moduleDef}
-                orientation={inferModuleOrientationFromXCoordinate(
-                  slotPosition[0]
-                )}
-                innerProps={
-                  moduleType === THERMOCYCLER_MODULE_TYPE
-                    ? innerTCProps
-                    : tempInnerProps
-                }
-                targetSlotId={
+            <Module
+              key={id}
+              x={slotPosition[0]}
+              y={slotPosition[1]}
+              def={moduleDef}
+              orientation={inferModuleOrientationFromXCoordinate(
+                slotPosition[0]
+              )}
+              innerProps={
+                moduleType === THERMOCYCLER_MODULE_TYPE
+                  ? innerTCProps
+                  : tempInnerProps
+              }
+              targetSlotId={
+                moduleType === FLEX_STACKER_MODULE_TYPE ? `hopper${slot}` : slot
+              }
+              targetDeckId={deckDef.otId}
+              childrenPositioningMode="passThrough"
+              setSelectedSlot={setSelectedSlot}
+              setHoveredSlot={setHoveredSlot}
+            >
+              {labwareLoadedOnModuleId != null ? (
+                <DeckViewStacker
+                  robotState={robotState}
+                  invariantContext={invariantContext}
+                  liquids={liquids}
+                  deckDef={deckDef}
+                  robotType={robotType}
+                  setHoveredSlot={setHoveredSlot}
+                  setSelectedSlot={setSelectedSlot}
+                  slot={slot}
+                  slotPosition={slotPosition}
+                  moduleType={moduleType}
+                  moduleDef={moduleDef}
+                  showLabwareCommandSummary={showLabwareCommandSummary}
+                  labwareLoadedOnModuleId={labwareLoadedOnModuleId}
+                  showModuleCommandSummary={showModuleCommandSummary}
+                  hoveredSlot={hoveredSlot}
+                  labwareEntitiesExtended={labwareEntitiesExtended}
+                  selectedRunTimeCommand={selectedRunTimeCommand}
+                />
+              ) : null}
+              <DeckViewOverlay
+                key={slot}
+                slotId={
                   moduleType === FLEX_STACKER_MODULE_TYPE
                     ? `hopper${slot}`
                     : slot
                 }
-                targetDeckId={deckDef.otId}
-                childrenPositioningMode="passThrough"
+                slotPosition={[
+                  moduleType === FLEX_STACKER_MODULE_TYPE ? 178 : 0,
+                  0,
+                  0,
+                ]}
+                slotFillColor={COLORS.purple50}
+                robotType={robotType}
+                invariantContext={invariantContext}
+                robotState={robotState}
                 setSelectedSlot={setSelectedSlot}
                 setHoveredSlot={setHoveredSlot}
-              >
-                {labwareLoadedOnModuleId != null ? (
-                  <DeckViewStacker
-                    robotState={robotState}
-                    invariantContext={invariantContext}
-                    liquids={liquids}
-                    deckDef={deckDef}
-                    robotType={robotType}
-                    setHoveredSlot={setHoveredSlot}
-                    setSelectedSlot={setSelectedSlot}
-                    slot={slot}
-                    moduleType={moduleType}
-                    moduleDef={moduleDef}
-                    labwareLoadedOnModuleId={labwareLoadedOnModuleId}
-                    showModuleCommandSummary={showModuleCommandSummary}
-                    hoveredSlot={hoveredSlot}
-                    labwareEntitiesExtended={labwareEntitiesExtended}
-                    selectedRunTimeCommand={selectedRunTimeCommand}
-                  />
-                ) : null}
-                <DeckViewOverlay
-                  key={slot}
-                  slotId={
-                    moduleType === FLEX_STACKER_MODULE_TYPE
-                      ? `hopper${slot}`
-                      : slot
-                  }
-                  slotPosition={[
-                    moduleType === FLEX_STACKER_MODULE_TYPE ? 178 : 0,
-                    0,
-                    0,
-                  ]}
-                  slotFillColor={COLORS.purple50}
-                  robotType={robotType}
-                  invariantContext={invariantContext}
-                  robotState={robotState}
-                  setSelectedSlot={setSelectedSlot}
-                  setHoveredSlot={setHoveredSlot}
-                  hover={hoveredSlot}
-                />
-              </Module>
-              {showModuleCommandSummary ? (
-                <ModuleCommandSummary
-                  robotType={robotType}
-                  moduleModel={moduleDef.model}
-                  commandType={selectedRunTimeCommand.commandType}
-                  position={slotPosition}
-                  showModuleIcon={false}
-                  slot={slot}
-                  orientation={inferModuleOrientationFromXCoordinate(
-                    slotPosition[0]
-                  )}
-                />
-              ) : null}
-            </>
+                hover={hoveredSlot}
+              />
+            </Module>
           </Fragment>
         )
       })}

--- a/app/src/organisms/Desktop/ProtocolVisualization/DeckView/DeckViewStacker.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/DeckView/DeckViewStacker.tsx
@@ -5,14 +5,17 @@ import {
 } from '@opentrons/components'
 import {
   FLEX_STACKER_MODULE_TYPE,
+  getModuleParentOriginToChildSlotOrigin,
   THERMOCYCLER_MODULE_TYPE,
 } from '@opentrons/shared-data'
 
 import { DeckViewOverlay } from './DeckViewOverlay'
+import { LabwareCommandSummary } from './LabwareCommandSummary'
 import { LabwareOnDeck } from './LabwareOnDeck'
 
 import type { Dispatch, SetStateAction } from 'react'
 import type {
+  CoordinateTuple,
   DeckDefinition,
   Liquid,
   ModuleDefinition,
@@ -37,8 +40,10 @@ interface DeckViewStackerProps {
   setHoveredSlot: Dispatch<SetStateAction<string | null>>
   hoveredSlot: string | null
   showModuleCommandSummary: boolean
+  showLabwareCommandSummary: boolean
   moduleType: ModuleType
   slot: string
+  slotPosition: CoordinateTuple
   moduleDef: ModuleDefinition
   labwareLoadedOnModuleId: string
   selectedRunTimeCommand?: RunTimeCommand
@@ -56,13 +61,25 @@ export function DeckViewStacker(props: DeckViewStackerProps): JSX.Element {
     hoveredSlot,
     labwareEntitiesExtended,
     showModuleCommandSummary,
+    showLabwareCommandSummary,
     moduleDef,
     selectedRunTimeCommand,
     slot,
+    slotPosition,
     moduleType,
 
     labwareLoadedOnModuleId,
   } = props
+  const childSlotOffset = getModuleParentOriginToChildSlotOrigin(
+    deckDef.otId,
+    slot,
+    moduleDef
+  )
+  const childSlotPosition: CoordinateTuple = [
+    slotPosition[0] + childSlotOffset.x,
+    slotPosition[1] + childSlotOffset.y,
+    slotPosition[2] + childSlotOffset.z,
+  ]
 
   return (
     <>
@@ -98,7 +115,7 @@ export function DeckViewStacker(props: DeckViewStackerProps): JSX.Element {
           setHoveredSlot={setHoveredSlot}
           hover={hoveredSlot}
         >
-          {showModuleCommandSummary ? null : (
+          {showModuleCommandSummary || showLabwareCommandSummary ? null : (
             <StyledText desktopStyle="captionRegular" color={COLORS.white}>
               {
                 labwareEntitiesExtended[labwareLoadedOnModuleId].def.metadata
@@ -132,7 +149,7 @@ export function DeckViewStacker(props: DeckViewStackerProps): JSX.Element {
             selectedRunTimeCommand?.commandType !== 'flexStacker/retrieve' &&
             selectedRunTimeCommand?.commandType !== 'flexStacker/store') ||
           (moduleType !== FLEX_STACKER_MODULE_TYPE &&
-            showModuleCommandSummary) ? null : (
+            (showModuleCommandSummary || showLabwareCommandSummary)) ? null : (
             <StyledText desktopStyle="captionRegular" color={COLORS.white}>
               {labwareEntitiesExtended[labwareLoadedOnModuleId]?.nickName ??
                 labwareEntitiesExtended[labwareLoadedOnModuleId].def.metadata
@@ -141,6 +158,14 @@ export function DeckViewStacker(props: DeckViewStackerProps): JSX.Element {
           )}
         </DeckViewOverlay>
       )}
+      {showLabwareCommandSummary && selectedRunTimeCommand != null ? (
+        <LabwareCommandSummary
+          commandType={selectedRunTimeCommand.commandType}
+          position={childSlotPosition}
+          labwareDef={labwareEntitiesExtended[labwareLoadedOnModuleId].def}
+          showModuleIcon={false}
+        />
+      ) : null}
     </>
   )
 }

--- a/app/src/organisms/Desktop/ProtocolVisualization/utils/getActiveLayer.ts
+++ b/app/src/organisms/Desktop/ProtocolVisualization/utils/getActiveLayer.ts
@@ -6,12 +6,14 @@ interface ActiveLayer {
 
 export const getActiveLayer = (
   id: string,
-  selectedRunTimeCommand?: RunTimeCommand
+  selectedRunTimeCommand?: RunTimeCommand,
+  moduleId?: string
 ): ActiveLayer => {
   const isStepAssosciatedWithLabwareId =
     selectedRunTimeCommand != null &&
     'labwareId' in selectedRunTimeCommand.params &&
     selectedRunTimeCommand.params.labwareId === id
+
   const isMoveStepAssosciatedWithLabwareId =
     selectedRunTimeCommand != null &&
     selectedRunTimeCommand.commandType === 'moveLabware' &&
@@ -21,7 +23,14 @@ export const getActiveLayer = (
   const isStepAssosciatedWithLabware =
     isStepAssosciatedWithLabwareId || isMoveStepAssosciatedWithLabwareId
 
+  const isStepAssociatedWithModuleId =
+    moduleId != null &&
+    selectedRunTimeCommand != null &&
+    'moduleId' in selectedRunTimeCommand.params &&
+    selectedRunTimeCommand.params.moduleId === moduleId
+
   return {
-    isActiveLayerVisible: isStepAssosciatedWithLabware,
+    isActiveLayerVisible:
+      isStepAssosciatedWithLabware || isStepAssociatedWithModuleId,
   }
 }


### PR DESCRIPTION

# Overview
fix slot summary rendering order

<img width="793" height="722" alt="Screenshot 2026-01-22 at 3 53 15 PM" src="https://github.com/user-attachments/assets/bcbe102a-133a-4045-99b7-e8f34fc5e4fd" />

close RQA-4983



## Test Plan and Hands on Testing


## Changelog


## Review requests

## Risk assessment
low
