### PR TITLE
fix(protocol-designer): move export button to bottom of page

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/index.tsx
@@ -263,7 +263,6 @@ export function ProtocolSteps({
                 justifyContent={JUSTIFY_END}
                 position={POSITION_ABSOLUTE}
                 right={SPACING.spacing24}
-                zIndex={0}
               >
                 <ExportButton onClick={handleExportClick} />
               </Flex>

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/index.tsx
@@ -263,7 +263,7 @@ export function ProtocolSteps({
                 justifyContent={JUSTIFY_END}
                 position={POSITION_ABSOLUTE}
                 right={SPACING.spacing24}
-                zIndex={showDefineLiquidModal ? 1 : 1000}
+                zIndex={0}
               >
                 <ExportButton onClick={handleExportClick} />
               </Flex>


### PR DESCRIPTION
# Overview

Move export button to bottom of page so that it is never overlayed a different window

## Test Plan and Hands on Testing

<img width="1484" height="732" alt="Screenshot 2026-01-22 at 4 59 15 PM" src="https://github.com/user-attachments/assets/9e1f418f-b039-485f-873a-bdc1f5c41b1b" />

Closes RQA-5067
