### PR TITLE
fix(step-generation): tiprack lid no longer teleports back to the deck

### DIFF
--- a/step-generation/src/getNextRobotStateAndWarnings/stackerUpdates.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/stackerUpdates.ts
@@ -1,3 +1,5 @@
+import { current } from 'immer'
+
 import { SYSTEM_LOCATION } from '@opentrons/shared-data'
 
 import {
@@ -566,7 +568,7 @@ export const forFlexStackerRetrieve = (
           ]
         if (labwareId != null) {
           runningStack.unshift(labwareId)
-          robotState.labware[labwareId].stack = runningStack
+          robotState.labware[labwareId].stack = [...runningStack]
         }
       }
     }

--- a/step-generation/src/getNextRobotStateAndWarnings/stackerUpdates.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/stackerUpdates.ts
@@ -1,5 +1,3 @@
-import { current } from 'immer'
-
 import { SYSTEM_LOCATION } from '@opentrons/shared-data'
 
 import {


### PR DESCRIPTION
closes RQA-5066

# Overview

woof 🐶 , it was an issue with the array not referencing the correct source for the stack. The fix creates a new independent copy of the array for each labware's stack instead of having all labware share a reference to the same mutating array.

## Test Plan and Hands on Testing

upload protocol in the ticket and see that there are no longer any timeline errors and the tiprack lid doesn't teleport back to the tiprack after it has been moved to the waste chute

## Changelog

spread the array

## Risk assessment

low
