### PR TITLE
refactor(app): Use named constants for QT reducer action names

### DIFF
--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/ResetAdvancedSettingsModal.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/ResetAdvancedSettingsModal.tsx
@@ -14,6 +14,7 @@ import { getTopPortalEl } from '/app/App/portal'
 import { SmallButton } from '/app/atoms/buttons'
 import { OddModal } from '/app/molecules/OddModal'
 
+import { ACTIONS } from '../constants'
 import { retrieveLiquidClassValues } from '../utils'
 
 import type { Dispatch } from 'react'
@@ -60,7 +61,7 @@ export function ResetAdvancedSettingsModal({
       liquidHandlingAction
     )
     dispatch({
-      type: 'SET_LIQUID_CLASS_VALUES',
+      type: ACTIONS.SET_LIQUID_CLASS_VALUES,
       liquidClassValues: {
         ...liquidClassValues,
       },

--- a/app/src/organisms/ODD/QuickTransferFlow/SelectDestLabware.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/SelectDestLabware.tsx
@@ -15,6 +15,7 @@ import {
 
 import { ChildNavigation } from '/app/organisms/ODD/ChildNavigation'
 
+import { ACTIONS } from './constants'
 import { getCompatibleLabwareByCategory } from './utils'
 
 import type { ComponentProps, Dispatch } from 'react'
@@ -63,7 +64,7 @@ export function SelectDestLabware(
     // the button will be disabled if this values is null
     if (selectedLabware != null) {
       dispatch({
-        type: 'SET_DEST_LABWARE',
+        type: ACTIONS.SET_DEST_LABWARE,
         labware: selectedLabware,
       })
       onNext()

--- a/app/src/organisms/ODD/QuickTransferFlow/SelectDestWells.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/SelectDestWells.tsx
@@ -21,6 +21,7 @@ import { WellSelection } from '/app/organisms/WellSelection'
 import { useTrackEventWithRobotSerial } from '/app/redux-resources/analytics'
 import { ANALYTICS_QUICK_TRANSFER_WELL_SELECTION_DURATION } from '/app/redux/analytics'
 
+import { ACTIONS } from './constants'
 import {
   CIRCULAR_WELL_96_PLATE_DEFINITION_URI,
   RECTANGULAR_WELL_96_PLATE_DEFINITION_URI,
@@ -103,7 +104,7 @@ export function SelectDestWells(props: SelectDestWellsProps): JSX.Element {
       sourceWellCount === 1
     ) {
       dispatch({
-        type: 'SET_DEST_WELLS',
+        type: ACTIONS.SET_DEST_WELLS,
         wells: Object.keys(selectedWells),
       })
       const duration = new Date().getTime() - analyticsStartTime.getTime()

--- a/app/src/organisms/ODD/QuickTransferFlow/SelectLiquidClass.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/SelectLiquidClass.tsx
@@ -13,6 +13,7 @@ import { getAllLiquidClassDefs } from '@opentrons/shared-data'
 import { ChildNavigation } from '/app/organisms/ODD/ChildNavigation'
 import { useToaster } from '/app/organisms/ToasterOven'
 
+import { ACTIONS } from './constants'
 import { checkLiquidClassCompatibility } from './utils'
 
 import type { ComponentProps, Dispatch } from 'react'
@@ -56,7 +57,7 @@ export function SelectLiquidClass({
   const handleClickNext = (): void => {
     if (selectedLiquidClass != null) {
       dispatch({
-        type: 'SET_LIQUID_CLASS',
+        type: ACTIONS.SET_LIQUID_CLASS,
         liquidClassName: selectedLiquidClass.liquidClassName as LiquidClassType,
       })
     }

--- a/app/src/organisms/ODD/QuickTransferFlow/SelectPipette.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/SelectPipette.tsx
@@ -14,6 +14,8 @@ import { LEFT, RIGHT } from '@opentrons/shared-data'
 import { usePipetteSpecsV2 } from '/app/local-resources/instruments'
 import { ChildNavigation } from '/app/organisms/ODD/ChildNavigation'
 
+import { ACTIONS } from './constants'
+
 import type { ComponentProps, Dispatch } from 'react'
 import type { Mount, PipetteData } from '@opentrons/api-client'
 import type { SmallButton } from '/app/atoms/buttons'
@@ -57,7 +59,7 @@ export function SelectPipette(props: SelectPipetteProps): JSX.Element {
     // the button will be disabled if these values are null
     if (selectedPipette != null && selectedPipetteSpecs != null) {
       dispatch({
-        type: 'SELECT_PIPETTE',
+        type: ACTIONS.SELECT_PIPETTE,
         pipette: selectedPipetteSpecs,
         mount: selectedPipette,
       })

--- a/app/src/organisms/ODD/QuickTransferFlow/SelectPipettePath.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/SelectPipettePath.tsx
@@ -10,6 +10,8 @@ import {
 
 import { ChildNavigation } from '/app/organisms/ODD/ChildNavigation'
 
+import { ACTIONS } from './constants'
+
 import type { ComponentProps, Dispatch } from 'react'
 import type { SmallButton } from '/app/atoms/buttons'
 import type {
@@ -60,7 +62,7 @@ export function SelectPipettePath({
 
   const handleClickNext = (): void => {
     dispatch({
-      type: 'SET_PIPETTE_PATH',
+      type: ACTIONS.SET_PIPETTE_PATH,
       path: selectedPath ?? 'single',
     })
     onNext()

--- a/app/src/organisms/ODD/QuickTransferFlow/SelectSourceLabware.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/SelectSourceLabware.tsx
@@ -15,6 +15,7 @@ import {
 
 import { ChildNavigation } from '/app/organisms/ODD/ChildNavigation'
 
+import { ACTIONS } from './constants'
 import { getCompatibleLabwareByCategory } from './utils'
 
 import type { ComponentProps, Dispatch } from 'react'
@@ -64,7 +65,7 @@ export function SelectSourceLabware(
     // the button will be disabled if this values is null
     if (selectedLabware != null) {
       dispatch({
-        type: 'SET_SOURCE_LABWARE',
+        type: ACTIONS.SET_SOURCE_LABWARE,
         labware: selectedLabware,
       })
       onNext()

--- a/app/src/organisms/ODD/QuickTransferFlow/SelectSourceWells.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/SelectSourceWells.tsx
@@ -15,6 +15,8 @@ import { WellSelection } from '/app/organisms/WellSelection'
 import { useTrackEventWithRobotSerial } from '/app/redux-resources/analytics'
 import { ANALYTICS_QUICK_TRANSFER_WELL_SELECTION_DURATION } from '/app/redux/analytics'
 
+import { ACTIONS } from './constants'
+
 import type { ComponentProps, Dispatch, MouseEvent } from 'react'
 import type { SmallButton } from '/app/atoms/buttons'
 import type {
@@ -50,7 +52,7 @@ export function SelectSourceWells(props: SelectSourceWellsProps): JSX.Element {
 
   const handleClickNext = (): void => {
     dispatch({
-      type: 'SET_SOURCE_WELLS',
+      type: ACTIONS.SET_SOURCE_WELLS,
       wells: Object.keys(selectedWells),
     })
     const duration = new Date().getTime() - startingTimeStamp?.getTime()

--- a/app/src/organisms/ODD/QuickTransferFlow/SelectTipDropLocation.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/SelectTipDropLocation.tsx
@@ -17,6 +17,8 @@ import {
 import { ChildNavigation } from '/app/organisms/ODD/ChildNavigation'
 import { useNotifyDeckConfigurationQuery } from '/app/resources/deck_configuration'
 
+import { ACTIONS } from './constants'
+
 import type { ComponentProps, Dispatch } from 'react'
 import type { CutoutConfig } from '@opentrons/shared-data'
 import type { SmallButton } from '/app/atoms/buttons'
@@ -67,7 +69,7 @@ export function SelectTipDropLocation({
 
   const handleClickNext = (): void => {
     dispatch({
-      type: 'SET_DROP_TIP_LOCATION',
+      type: ACTIONS.SET_DROP_TIP_LOCATION,
       location: selectedTipDropLocation ?? {
         cutoutId: 'cutoutA3',
         cutoutFixtureId: TRASH_BIN_ADAPTER_FIXTURE,

--- a/app/src/organisms/ODD/QuickTransferFlow/SelectTipFrequency.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/SelectTipFrequency.tsx
@@ -10,6 +10,8 @@ import {
 
 import { ChildNavigation } from '/app/organisms/ODD/ChildNavigation'
 
+import { ACTIONS } from './constants'
+
 import type { ComponentProps, Dispatch } from 'react'
 import type { SmallButton } from '/app/atoms/buttons'
 import type {
@@ -66,7 +68,7 @@ export function SelectTipFrequency({
 
   const handleClickNext = (): void => {
     dispatch({
-      type: 'SET_CHANGE_TIP',
+      type: ACTIONS.SET_CHANGE_TIP,
       changeTip: selectedChangeTipOption ?? 'once',
     })
     onNext()

--- a/app/src/organisms/ODD/QuickTransferFlow/SelectTipRack.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/SelectTipRack.tsx
@@ -14,6 +14,8 @@ import {
 
 import { ChildNavigation } from '/app/organisms/ODD/ChildNavigation'
 
+import { ACTIONS } from './constants'
+
 import type { ComponentProps, Dispatch } from 'react'
 import type { LabwareDefinition2 } from '@opentrons/shared-data'
 import type { SmallButton } from '/app/atoms/buttons'
@@ -53,7 +55,7 @@ export function SelectTipRack(props: SelectTipRackProps): JSX.Element {
     // the button will be disabled if this values is null
     if (selectedTipRack != null) {
       dispatch({
-        type: 'SELECT_TIP_RACK',
+        type: ACTIONS.SELECT_TIP_RACK,
         tipRack: selectedTipRack,
       })
       onNext()

--- a/app/src/organisms/ODD/QuickTransferFlow/VolumeEntry.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/VolumeEntry.tsx
@@ -12,7 +12,7 @@ import {
 import { NumericalKeyboard } from '/app/atoms/SoftwareKeyboard'
 import { ChildNavigation } from '/app/organisms/ODD/ChildNavigation'
 
-import { CONSOLIDATE, DISTRIBUTE } from './constants'
+import { ACTIONS, CONSOLIDATE, DISTRIBUTE } from './constants'
 import { getVolumeRange } from './utils'
 
 import type { ComponentProps, Dispatch } from 'react'
@@ -55,7 +55,7 @@ export function VolumeEntry(props: VolumeEntryProps): JSX.Element {
     // the button will be disabled if this values is null
     if (volumeAsNumber != null) {
       dispatch({
-        type: 'SET_VOLUME',
+        type: ACTIONS.SET_VOLUME,
         volume: volumeAsNumber,
       })
       onNext()

--- a/app/src/organisms/ODD/QuickTransferFlow/reducers.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/reducers.ts
@@ -1,4 +1,4 @@
-import { CONSOLIDATE, DISTRIBUTE, TRANSFER } from './constants'
+import { ACTIONS, CONSOLIDATE, DISTRIBUTE, TRANSFER } from './constants'
 
 import type {
   QuickTransferSummaryAction,
@@ -13,20 +13,20 @@ export function quickTransferWizardReducer(
   action: QuickTransferWizardAction
 ): QuickTransferWizardState {
   switch (action.type) {
-    case 'SELECT_PIPETTE': {
+    case ACTIONS.SELECT_PIPETTE: {
       return {
         pipette: action.pipette,
         mount: action.mount,
       }
     }
-    case 'SELECT_TIP_RACK': {
+    case ACTIONS.SELECT_TIP_RACK: {
       return {
         pipette: state.pipette,
         mount: state.mount,
         tipRack: action.tipRack,
       }
     }
-    case 'SET_SOURCE_LABWARE': {
+    case ACTIONS.SET_SOURCE_LABWARE: {
       return {
         pipette: state.pipette,
         mount: state.mount,
@@ -34,7 +34,7 @@ export function quickTransferWizardReducer(
         source: action.labware,
       }
     }
-    case 'SET_SOURCE_WELLS': {
+    case ACTIONS.SET_SOURCE_WELLS: {
       return {
         pipette: state.pipette,
         mount: state.mount,
@@ -43,7 +43,7 @@ export function quickTransferWizardReducer(
         sourceWells: action.wells,
       }
     }
-    case 'SET_DEST_LABWARE': {
+    case ACTIONS.SET_DEST_LABWARE: {
       return {
         pipette: state.pipette,
         mount: state.mount,
@@ -53,7 +53,7 @@ export function quickTransferWizardReducer(
         destination: action.labware,
       }
     }
-    case 'SET_DEST_WELLS': {
+    case ACTIONS.SET_DEST_WELLS: {
       let transferType: TransferType = TRANSFER
       if (
         state.sourceWells != null &&
@@ -77,7 +77,7 @@ export function quickTransferWizardReducer(
         transferType,
       }
     }
-    case 'SET_VOLUME': {
+    case ACTIONS.SET_VOLUME: {
       return {
         pipette: state.pipette,
         mount: state.mount,
@@ -90,26 +90,26 @@ export function quickTransferWizardReducer(
         volume: action.volume,
       }
     }
-    case 'SET_PIPETTE_PATH': {
+    case ACTIONS.SET_PIPETTE_PATH: {
       return {
         ...state,
         path: action.path,
       }
     }
 
-    case 'SET_CHANGE_TIP': {
+    case ACTIONS.SET_CHANGE_TIP: {
       return {
         ...state,
         changeTip: action.changeTip,
       }
     }
-    case 'SET_DROP_TIP_LOCATION': {
+    case ACTIONS.SET_DROP_TIP_LOCATION: {
       return {
         ...state,
         dropTipLocation: action.location,
       }
     }
-    case 'SET_LIQUID_CLASS': {
+    case ACTIONS.SET_LIQUID_CLASS: {
       return {
         ...state,
         liquidClassName: action.liquidClassName,
@@ -123,153 +123,153 @@ export function quickTransferSummaryReducer(
   action: QuickTransferSummaryAction
 ): QuickTransferSummaryState {
   switch (action.type) {
-    case 'SET_ASPIRATE_FLOW_RATE': {
+    case ACTIONS.SET_ASPIRATE_FLOW_RATE: {
       return {
         ...state,
         aspirateFlowRate: action.rate,
       }
     }
-    case 'SET_DISPENSE_FLOW_RATE': {
+    case ACTIONS.SET_DISPENSE_FLOW_RATE: {
       return {
         ...state,
         dispenseFlowRate: action.rate,
       }
     }
-    case 'SET_PIPETTE_PATH': {
+    case ACTIONS.SET_PIPETTE_PATH: {
       return {
         ...state,
         path: action.path,
       }
     }
-    case 'SET_ASPIRATE_TIP_POSITION': {
+    case ACTIONS.SET_ASPIRATE_TIP_POSITION: {
       return {
         ...state,
         tipPositionAspirate: action.position,
       }
     }
-    case 'SET_PRE_WET_TIP': {
+    case ACTIONS.SET_PRE_WET_TIP: {
       return {
         ...state,
         preWetTip: action.preWetTip,
       }
     }
-    case 'SET_MIX_ON_ASPIRATE': {
+    case ACTIONS.SET_MIX_ON_ASPIRATE: {
       return {
         ...state,
         mixOnAspirate: action.mixSettings,
       }
     }
-    case 'SET_DELAY_ASPIRATE': {
+    case ACTIONS.SET_DELAY_ASPIRATE: {
       return {
         ...state,
         delayAspirate: action.delaySettings,
       }
     }
-    case 'SET_SUBMERGE_ASPIRATE': {
+    case ACTIONS.SET_SUBMERGE_ASPIRATE: {
       return {
         ...state,
         submergeAspirate: action.submergeSettings,
       }
     }
-    case 'SET_RETRACT_ASPIRATE': {
+    case ACTIONS.SET_RETRACT_ASPIRATE: {
       return {
         ...state,
         retractAspirate: action.retractSettings,
       }
     }
-    case 'SET_TOUCH_TIP_ASPIRATE': {
+    case ACTIONS.SET_TOUCH_TIP_ASPIRATE: {
       return {
         ...state,
         touchTipAspirate: action.position,
         touchTipAspirateSpeed: action.touchTipAspirateSpeed,
       }
     }
-    case 'SET_AIR_GAP_ASPIRATE': {
+    case ACTIONS.SET_AIR_GAP_ASPIRATE: {
       return {
         ...state,
         airGapAspirate: action.volume,
       }
     }
-    case 'SET_DISPENSE_TIP_POSITION': {
+    case ACTIONS.SET_DISPENSE_TIP_POSITION: {
       return {
         ...state,
         tipPositionDispense: action.position,
       }
     }
-    case 'SET_MIX_ON_DISPENSE': {
+    case ACTIONS.SET_MIX_ON_DISPENSE: {
       return {
         ...state,
         mixOnDispense: action.mixSettings,
       }
     }
-    case 'SET_DELAY_DISPENSE': {
+    case ACTIONS.SET_DELAY_DISPENSE: {
       return {
         ...state,
         delayDispense: action.delaySettings,
       }
     }
-    case 'SET_SUBMERGE_DISPENSE': {
+    case ACTIONS.SET_SUBMERGE_DISPENSE: {
       return {
         ...state,
         submergeDispense: action.submergeSettings,
       }
     }
-    case 'SET_RETRACT_DISPENSE': {
+    case ACTIONS.SET_RETRACT_DISPENSE: {
       return {
         ...state,
         retractDispense: action.retractSettings,
       }
     }
-    case 'SET_TOUCH_TIP_DISPENSE': {
+    case ACTIONS.SET_TOUCH_TIP_DISPENSE: {
       return {
         ...state,
         touchTipDispense: action.position,
         touchTipDispenseSpeed: action.touchTipDispenseSpeed,
       }
     }
-    case 'SET_BLOW_OUT': {
+    case ACTIONS.SET_BLOW_OUT: {
       return {
         ...state,
         blowOutDispense: action.blowOutSettings,
       }
     }
-    case 'SET_AIR_GAP_DISPENSE': {
+    case ACTIONS.SET_AIR_GAP_DISPENSE: {
       return {
         ...state,
         airGapDispense: action.volume,
       }
     }
-    case 'SET_CHANGE_TIP': {
+    case ACTIONS.SET_CHANGE_TIP: {
       return {
         ...state,
         changeTip: action.changeTip,
       }
     }
-    case 'SET_DROP_TIP_LOCATION': {
+    case ACTIONS.SET_DROP_TIP_LOCATION: {
       return {
         ...state,
         dropTipLocation: action.location,
       }
     }
-    case 'SET_PUSH_OUT': {
+    case ACTIONS.SET_PUSH_OUT: {
       return {
         ...state,
         pushOutDispense: action.pushOutSettings,
       }
     }
-    case 'SET_CONDITION_ASPIRATE': {
+    case ACTIONS.SET_CONDITION_ASPIRATE: {
       return {
         ...state,
         conditionAspirate: action.conditionAspirate,
       }
     }
-    case 'SET_DISPOSAL_VOLUME_DISPENSE': {
+    case ACTIONS.SET_DISPOSAL_VOLUME_DISPENSE: {
       return {
         ...state,
         disposalVolumeDispenseSettings: action.disposalVolumeDispenseSettings,
       }
     }
-    case 'SET_LIQUID_CLASS_VALUES': {
+    case ACTIONS.SET_LIQUID_CLASS_VALUES: {
       return {
         ...state,
         ...action.liquidClassValues,


### PR DESCRIPTION
# Overview

One of the things that made life harder when I was trying to fix the QT blowout trash bug was that I couldn't use VS Code to quickly trace through all the places that were using the blowout location. Once I got to `QuickTransferFlow/reducers.ts`, the trail grew cold, because that file uses **string literals** for all the action names, and VS Code doesn't let you click on string literals to follow all references to them.

Fortunately, we already have named constants for all the reducer actions, so let's use the constants we defined.

## Test Plan and Hands on Testing

Run CI tests.

## Risk assessment

Low. Pure code cleanup, no change in behavior.