### PR TITLE
chore(python): Add a `make lock-py` target, to run `uv lock` on all Python projects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,18 @@ clean-py: $(PYTHON_CLEAN_TARGETS)
 $(SHARED_DATA_DIR)-py-clean:
 	$(MAKE) -C $(SHARED_DATA_DIR) clean-py
 
+PYTHON_LOCK_TARGETS := $(addsuffix -py-lock, $(PYTHON_DIRS))
+
+.PHONY: lock-py
+lock-py: $(PYTHON_LOCK_TARGETS)
+
+%-py-lock:
+	$(MAKE) -C $* lock
+
+# Specialize the %-py-lock pattern rule above to account for the Makefile duopoly in shared-data.
+$(SHARED_DATA_DIR)-py-lock:
+	$(MAKE) -C $(SHARED_DATA_DIR) lock-py
+
 .PHONY: deploy-py
 deploy-py: export twine_repository_url = $(twine_repository_url)
 deploy-py: export pypi_username = $(pypi_username)

--- a/api/Makefile
+++ b/api/Makefile
@@ -78,6 +78,10 @@ setup-ot2:
 	@$(UV) pip uninstall python-can
 	@$(UV) pip list
 
+.PHONY: lock
+lock:
+	$(UV) lock
+
 .PHONY: clean
 clean: docs-clean
 	$(clean_all_cmd)

--- a/auth-server/Makefile
+++ b/auth-server/Makefile
@@ -55,6 +55,10 @@ setup:
 .PHONY: setup-py
 setup-py: setup
 
+.PHONY: lock
+lock:
+	$(UV) lock
+
 .PHONY: clean
 clean:
 	$(clean_all_cmd)

--- a/auth-server/uv.lock
+++ b/auth-server/uv.lock
@@ -1036,6 +1036,7 @@ dev = [
     { name = "pytest-xdist", specifier = "~=2.5.0" },
     { name = "requests", specifier = "==2.31.0" },
     { name = "ruff", specifier = "==0.14.10" },
+    { name = "setuptools", specifier = "==80.9.0" },
     { name = "sqlalchemy2-stubs", specifier = "==0.0.2a21" },
     { name = "types-mock", specifier = "~=5.1.0" },
     { name = "types-requests", specifier = "~=2.31.0" },

--- a/g-code-testing/Makefile
+++ b/g-code-testing/Makefile
@@ -29,6 +29,10 @@ setup:
 .PHONY: setup-py
 setup-py: setup
 
+.PHONY: lock
+lock:
+	$(UV) lock
+
 .PHONY: clean
 clean:
 	$(clean_cmd)

--- a/g-code-testing/uv.lock
+++ b/g-code-testing/uv.lock
@@ -1003,6 +1003,7 @@ dependencies = [
     { name = "packaging" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "pyro5" },
     { name = "pyserial" },
     { name = "pyusb" },
     { name = "typing-extensions" },
@@ -1021,6 +1022,7 @@ requires-dist = [
     { name = "packaging", specifier = ">=25.0" },
     { name = "pydantic", specifier = ">=2.0.0,<3" },
     { name = "pydantic-settings", specifier = ">=2,<3" },
+    { name = "pyro5", specifier = ">=5.16,<6" },
     { name = "pyserial", specifier = ">=3.5" },
     { name = "pyusb", specifier = "==1.2.1" },
     { name = "typing-extensions", specifier = ">=4.0.0,<5" },
@@ -1046,6 +1048,7 @@ dev = [
     { name = "performance-metrics", editable = "../performance-metrics" },
     { name = "pydantic", specifier = "==2.11.7" },
     { name = "pydantic-settings", specifier = "==2.4.0" },
+    { name = "pyro5", specifier = "==5.16" },
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-asyncio", specifier = ">=1.3.0,<2" },
     { name = "pytest-cov", specifier = "==4.1.0" },
@@ -1074,6 +1077,7 @@ robot = [
     { name = "packaging", specifier = "==25.0" },
     { name = "pydantic", specifier = "==2.11.7" },
     { name = "pydantic-settings", specifier = "==2.4.0" },
+    { name = "pyro5", specifier = "==5.16" },
     { name = "pyusb", specifier = "==1.2.1" },
     { name = "zipp", specifier = "==3.21.0" },
 ]
@@ -1462,6 +1466,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pyro5"
+version = "5.16"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "serpent" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6e/ab/38d7adb02f735f409e6af78951630f887590a885b2583c83cfe93a60b576/pyro5-5.16.tar.gz", hash = "sha256:d40418ed2acee0d9093daf5023ed0b0cb485a6b62342934adb9e801956f5738b", size = 448592, upload-time = "2025-12-21T18:33:58.552Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/4d/7713c06c1a9eaa35142e232e89da5300cac09156977204c730b28f37eaec/pyro5-5.16-py3-none-any.whl", hash = "sha256:ea33cad29993fd44ce394ef45950e8dc5805ee12c4dd76541a8dd11c40694706", size = 79294, upload-time = "2025-12-21T18:33:57.096Z" },
+]
+
+[[package]]
 name = "pyrsistent"
 version = "0.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1662,6 +1678,7 @@ dependencies = [
     { name = "paho-mqtt" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "pyro5" },
     { name = "python-dotenv" },
     { name = "python-multipart" },
     { name = "server-utils" },
@@ -1683,6 +1700,7 @@ requires-dist = [
     { name = "paho-mqtt", specifier = "==1.6.1" },
     { name = "pydantic", specifier = "==2.11.7" },
     { name = "pydantic-settings", specifier = "==2.4.0" },
+    { name = "pyro5", specifier = ">=5.16,<6" },
     { name = "python-dotenv", specifier = "==1.0.1" },
     { name = "python-multipart", specifier = "==0.0.6" },
     { name = "server-utils", editable = "../server-utils" },
@@ -1735,6 +1753,7 @@ robot = [
     { name = "paho-mqtt", specifier = "==1.6.1" },
     { name = "pydantic", specifier = "==2.11.7" },
     { name = "pydantic-settings", specifier = "==2.4.0" },
+    { name = "pyro5", specifier = "==5.16" },
     { name = "python-dotenv", specifier = "==1.0.1" },
     { name = "python-multipart", specifier = "==0.0.6" },
     { name = "server-utils", editable = "../server-utils" },
@@ -1768,6 +1787,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f2/1c/d7b67ab43f30013b47c12b42d1acd354c195351a3f7a1d67f59e54227ede/ruff-0.14.10-py3-none-win32.whl", hash = "sha256:104c49fc7ab73f3f3a758039adea978869a918f31b73280db175b43a2d9b51d6", size = 13196187, upload-time = "2025-12-18T19:29:19.006Z" },
     { url = "https://files.pythonhosted.org/packages/fb/9c/896c862e13886fae2af961bef3e6312db9ebc6adc2b156fe95e615dee8c1/ruff-0.14.10-py3-none-win_amd64.whl", hash = "sha256:466297bd73638c6bdf06485683e812db1c00c7ac96d4ddd0294a338c62fdc154", size = 14661283, upload-time = "2025-12-18T19:29:30.16Z" },
     { url = "https://files.pythonhosted.org/packages/74/31/b0e29d572670dca3674eeee78e418f20bdf97fa8aa9ea71380885e175ca0/ruff-0.14.10-py3-none-win_arm64.whl", hash = "sha256:e51d046cf6dda98a4633b8a8a771451107413b0f07183b2bef03f075599e44e6", size = 13729839, upload-time = "2025-12-18T19:28:48.636Z" },
+]
+
+[[package]]
+name = "serpent"
+version = "1.42"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/3c/7ecf39b48121cb6490634bfcb1b1c5cac7d7a216805d889b0676a2e8493f/serpent-1.42.tar.gz", hash = "sha256:8ea082b01f8ba07ecd74e34a9118ac4521bc4594938d912b808c89f1da425506", size = 90352, upload-time = "2025-10-26T21:58:13.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/24/73031e6bd25d8f94811b3752b0b217efbdb20a67b65c6838c9af4e50c2e2/serpent-1.42-py3-none-any.whl", hash = "sha256:a02f5a4fcf3b41ee6204b36c3cf026bf0433ffe15b6a7fc8a37e0bff74d87575", size = 9663, upload-time = "2025-10-26T21:58:12.565Z" },
 ]
 
 [[package]]
@@ -1817,6 +1845,7 @@ dev = [
     { name = "pytest-xdist", specifier = "~=2.5.0" },
     { name = "requests", specifier = "==2.31.0" },
     { name = "ruff", specifier = "==0.14.10" },
+    { name = "setuptools", specifier = "==80.9.0" },
     { name = "sqlalchemy2-stubs", specifier = "==0.0.2a21" },
     { name = "types-mock", specifier = "~=5.1.0" },
     { name = "types-requests", specifier = "~=2.31.0" },

--- a/hardware/Makefile
+++ b/hardware/Makefile
@@ -65,6 +65,10 @@ setup:
 .PHONY: setup-py
 setup-py: setup
 
+.PHONY: lock
+lock:
+	$(UV) lock
+
 .PHONY: teardown
 teardown:
 	$(SHX) rm -rf .venv

--- a/robot-server/Makefile
+++ b/robot-server/Makefile
@@ -81,6 +81,10 @@ setup-ot2:
 	@$(UV) pip uninstall python-can
 	@$(UV) pip list
 
+.PHONY: lock
+lock:
+	$(UV) lock
+
 .PHONY: clean
 clean:
 	$(clean_all_cmd)

--- a/robot-server/uv.lock
+++ b/robot-server/uv.lock
@@ -2169,6 +2169,7 @@ dev = [
     { name = "pytest-xdist", specifier = "~=2.5.0" },
     { name = "requests", specifier = "==2.31.0" },
     { name = "ruff", specifier = "==0.14.10" },
+    { name = "setuptools", specifier = "==80.9.0" },
     { name = "sqlalchemy2-stubs", specifier = "==0.0.2a21" },
     { name = "types-mock", specifier = "~=5.1.0" },
     { name = "types-requests", specifier = "~=2.31.0" },

--- a/server-utils/Makefile
+++ b/server-utils/Makefile
@@ -62,6 +62,10 @@ setup:
 .PHONY: setup-py
 setup-py: setup
 
+.PHONY: lock
+lock:
+	$(UV) lock
+
 .PHONY: clean
 clean:
 	$(clean_all_cmd)

--- a/server-utils/uv.lock
+++ b/server-utils/uv.lock
@@ -950,6 +950,7 @@ dev = [
     { name = "pytest-xdist" },
     { name = "requests" },
     { name = "ruff" },
+    { name = "setuptools" },
     { name = "sqlalchemy2-stubs" },
     { name = "types-mock" },
     { name = "types-requests" },
@@ -985,9 +986,19 @@ dev = [
     { name = "pytest-xdist", specifier = "~=2.5.0" },
     { name = "requests", specifier = "==2.31.0" },
     { name = "ruff", specifier = "==0.14.10" },
+    { name = "setuptools", specifier = "==80.9.0" },
     { name = "sqlalchemy2-stubs", specifier = "==0.0.2a21" },
     { name = "types-mock", specifier = "~=5.1.0" },
     { name = "types-requests", specifier = "~=2.31.0" },
+]
+
+[[package]]
+name = "setuptools"
+version = "80.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/5d/3bf57dcd21979b887f014ea83c24ae194cfcd12b9e0fda66b957c69d1fca/setuptools-80.9.0.tar.gz", hash = "sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c", size = 1319958, upload-time = "2025-05-27T00:56:51.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/dc/17031897dae0efacfea57dfd3a82fdd2a2aeb58e0ff71b77b87e44edc772/setuptools-80.9.0-py3-none-any.whl", hash = "sha256:062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922", size = 1201486, upload-time = "2025-05-27T00:56:49.664Z" },
 ]
 
 [[package]]

--- a/shared-data/Makefile
+++ b/shared-data/Makefile
@@ -67,6 +67,10 @@ lint-js-prettier:
 setup-py:
 	$(MAKE) -f Makefile-python.mk setup-py
 
+.PHONY: lock-py
+lock-py:
+	$(MAKE) -f Makefile-python.mk lock-py
+
 .PHONY: dist-py
 dist-py:
 	$(MAKE) -f Makefile-python.mk sdist wheel

--- a/shared-data/Makefile-python.mk
+++ b/shared-data/Makefile-python.mk
@@ -62,6 +62,10 @@ setup-py:
 	@$(uv_sync_dev)
 	@$(UV) pip list
 
+.PHONY: lock-py
+lock-py:
+	@$(UV) lock
+
 .PHONY: teardown
 teardown: teardown-py
 

--- a/system-server/Makefile
+++ b/system-server/Makefile
@@ -41,6 +41,10 @@ setup:
 .PHONY: setup-py
 setup-py: setup
 
+.PHONY: lock
+lock:
+	$(UV) lock
+
 .PHONY: clean
 clean:
 	$(SHX) rm -rf \

--- a/system-server/uv.lock
+++ b/system-server/uv.lock
@@ -1163,6 +1163,7 @@ dev = [
     { name = "pytest-xdist", specifier = "~=2.5.0" },
     { name = "requests", specifier = "==2.31.0" },
     { name = "ruff", specifier = "==0.14.10" },
+    { name = "setuptools", specifier = "==80.9.0" },
     { name = "sqlalchemy2-stubs", specifier = "==0.0.2a21" },
     { name = "types-mock", specifier = "~=5.1.0" },
     { name = "types-requests", specifier = "~=2.31.0" },

--- a/update-server/Makefile
+++ b/update-server/Makefile
@@ -32,6 +32,10 @@ setup:
 .PHONY: setup-py
 setup-py: setup
 
+.PHONY: lock
+lock:
+	$(UV) lock
+
 .PHONY: dev
 dev: export ENABLE_VIRTUAL_SMOOTHIE := true
 dev:

--- a/usb-bridge/Makefile
+++ b/usb-bridge/Makefile
@@ -37,6 +37,10 @@ setup:
 .PHONY: setup-py
 setup-py: setup
 
+.PHONY: lock
+lock:
+	$(UV) lock
+
 .PHONY: clean
 clean:
 	$(SHX) rm -rf \


### PR DESCRIPTION
## Overview

This tries to help with uv.lock files updating at random times, instead of in the PR that actually induced the change.

`robot_server` depends on `opentrons`. Suppose `opentrons` gains a new dependency, like `pyro5`. `opentrons`'s lockfile should obviously update to capture the new dependency on `pyro5`. But it's _also_ correct for *`robot_server`'s* lockfile to update, to capture `robot_server`'s new _transitive_ dependency on `pyro5`.

To do that, we would need to run `uv lock` in `robot-server/` (and `g-code-testing/`, etc.), every time we update `api`. But nobody's going to remember to do that. So the dependent projects' lockfiles get out of date. uv will update them automatically the next time somebody works on them.

This adds a top-level `make lock-py` target to automatically run `uv lock` in all Python projects. **If someone edits a Python project's dependencies, they should run `make lock-py` in that PR.**

## Review requests

Is this the right approach?

People will still need to remember to run `make lock-py` whenever they update dependencies. To help with that:

* We could add [`--locked`](https://docs.astral.sh/uv/concepts/projects/sync/#automatic-lock-and-sync) to all our `uv` commands, so it will error out if the lockfile isn't already up to date.
* Or, we could run [`uv lock --check`](https://docs.astral.sh/uv/concepts/projects/sync/#checking-the-lockfile) in CI to make sure that all the lockfiles are up to date.

## Risk assessment

Low.