### PR TITLE
fix(robot-server,update-server): Fix "reception only permitted for main PID" log spam

### DIFF
--- a/performance-metrics/src/performance_metrics/system_resource_tracker/__main__.py
+++ b/performance-metrics/src/performance_metrics/system_resource_tracker/__main__.py
@@ -22,7 +22,12 @@ def main() -> None:
 
     logger.info("Starting system resource tracker...")
 
-    systemd.daemon.notify("READY=1")
+    # `unset_environment=True` prevents a problem with shelling out to systemd commands
+    # like `hostnamectl`. For some reason, they send `EXIT_STATUS=` notifications to
+    # systemd. systemd associates those notifications with our service, but ignores
+    # them because they didn't come from our main PID. systemd logs warnings about this,
+    # which flood our logs.
+    systemd.daemon.notify("READY=1", unset_environment=True)
 
     try:
         while True:

--- a/server-utils/server_utils/systemd_utils.py
+++ b/server-utils/server_utils/systemd_utils.py
@@ -11,7 +11,12 @@ def notify_up() -> None:
     try:
         import systemd.daemon  # type: ignore
 
-        systemd.daemon.notify("READY=1")
+        # `unset_environment=True` prevents a problem with shelling out to systemd commands
+        # like `hostnamectl`. For some reason, they send `EXIT_STATUS=` notifications to
+        # systemd. systemd associates those notifications with our service, but ignores
+        # them because they didn't come from our main PID. systemd logs warnings about this,
+        # which flood our logs.
+        systemd.daemon.notify("READY=1", unset_environment=True)
 
     except ImportError:
         pass

--- a/update-server/otupdate/common/systemd.py
+++ b/update-server/otupdate/common/systemd.py
@@ -23,9 +23,15 @@ try:
     # and type=notify in the unit file, we can prevent systemd from starting
     # dependent services until we actually say we're ready. By calling this
     # after we change the hostname, we make anything with an After= on us
-    # be guaranteed to see the correct hostname
+    # be guaranteed to see the correct hostname.
+    #
+    # `unset_environment=True` prevents a problem with shelling out to systemd commands
+    # like `hostnamectl`. For some reason, they send `EXIT_STATUS=` notifications to
+    # systemd. systemd associates those notifications with our service, but ignores
+    # them because they didn't come from our main PID. systemd logs warnings about this,
+    # which flood our logs.
     def notify_up() -> None:
-        systemd.daemon.notify("READY=1")
+        systemd.daemon.notify("READY=1", unset_environment=True)
 
     SOURCE: str = "systemd"
 


### PR DESCRIPTION
## Overview

This fixes spam in the robot-server and update-server logs:

> systemd[1]: opentrons-update-server.service: Got notification message from PID 872, but reception only permitted for main PID 617

## Details

Credit to https://bugs.launchpad.net/snapd/+bug/2060310 for identifying the root cause.

In [relatively recent systemd versions](https://github.com/systemd/systemd/blob/994c7978608a0bd9b317f4f74ff266dd50a3e74e/NEWS#L649-L655), many CLI tools, like `hostnamectl`, will send an `EXIT_STATUS=...` notification to systemd. (I do not understand why they do this.) So:

1. We shell out to one of these CLI tools
2. systemd gets an `EXIT_STATUS=` notification from the CLI tool
3. systemd attributes (or misattributes?) the notification to *our* service
4. systemd logs a warning because the notification didn't come from our service's main PID

The solution is to cut off access to the socket through which our service sends these notifications. When our process starts, it'll send its one `notify("READY=1")` notification, and then it'll cut off further access to the socket.

## Test Plan and Hands on Testing

* [x] Fixes log spam on Flex
* [x] Doesn't crash on Flex
* [x] Doesn't crash on OT-2

## Review requests

With this solution, *any* systemd notification after the initial `notify("READY=1")` one becomes a no-op. This has the downside of preventing us from introducing a watchdog timer, for example, because the `notify("WATCHDOG=1")` keepalive pings won't work. To avoid that problem, instead of passing `unset_environment=True` to `notify()`, we could supply a custom `env`, with `NOTIFY_SOCKET` removed, everywhere we're spawning a subprocess. Basically, cut off access for subprocess but keep it for the main process. That seemed like it would be easy to forget if we add more subprocess calls later on, though.

## Risk assessment

Medium, but covered by manual testing.