### PR TITLE
fix(components): fix timescrubber circle styling

### DIFF
--- a/app/src/organisms/Desktop/ProtocolVisualization/Controls/controls.module.css
+++ b/app/src/organisms/Desktop/ProtocolVisualization/Controls/controls.module.css
@@ -2,7 +2,6 @@
   padding: 0 0 var(--spacing-16);
   container-name: controls-container;
   container-type: inline-size;
-  overflow: visible;
 }
 
 .controls_container {

--- a/app/src/organisms/Desktop/ProtocolVisualization/Controls/controls.module.css
+++ b/app/src/organisms/Desktop/ProtocolVisualization/Controls/controls.module.css
@@ -2,6 +2,7 @@
   padding: 0 0 var(--spacing-16);
   container-name: controls-container;
   container-type: inline-size;
+  overflow: visible;
 }
 
 .controls_container {

--- a/components/src/molecules/TimelineScrubber/TrackSlider.tsx
+++ b/components/src/molecules/TimelineScrubber/TrackSlider.tsx
@@ -21,17 +21,22 @@ export function TrackSlider({
 }: TrackSliderProps): JSX.Element {
   const trackRef = useRef<HTMLDivElement>(null)
   const [isDragging, setIsDragging] = useState<boolean>(false)
+  const THUMB_RADIUS_PX = 6
 
-  const calculateValue = useCallback((clientX: number) => {
-    if (trackRef.current == null) return 0
+  const calculateValue = useCallback(
+    (clientX: number) => {
+      if (trackRef.current == null) return 0
 
-    const rect = trackRef.current.getBoundingClientRect()
-    const x = clientX - rect.x
-    const width = rect.width
-    const value = Math.min(100, Math.max(0, (x / width) * 100))
+      const rect = trackRef.current.getBoundingClientRect()
+      const x = clientX - rect.x - THUMB_RADIUS_PX
+      const width = rect.width - THUMB_RADIUS_PX * 2
+      const clampedX = Math.min(width, Math.max(0, x))
+      const value = width > 0 ? (clampedX / width) * 100 : 0
 
-    return value
-  }, [])
+      return value
+    },
+    [THUMB_RADIUS_PX]
+  )
 
   const handleMouseMove = useCallback(
     (e: globalThis.MouseEvent) => {
@@ -69,7 +74,14 @@ export function TrackSlider({
         className={styles.track_progress}
         style={{ width: `${track.value}%` }}
       />
-      <div className={styles.track_thumb} style={{ left: `${track.value}%` }} />
+      <div
+        className={styles.track_thumb}
+        style={{
+          left: `calc(${THUMB_RADIUS_PX}px + (${track.value} / 100) * (100% - ${
+            THUMB_RADIUS_PX * 2
+          }px))`,
+        }}
+      />
     </div>
   )
 }

--- a/components/src/molecules/TimelineScrubber/timelinescrubber.module.css
+++ b/components/src/molecules/TimelineScrubber/timelinescrubber.module.css
@@ -1,11 +1,11 @@
 .scrubber_container {
   display: flex;
+  overflow: visible;
   width: 100%;
   box-sizing: border-box;
   flex-direction: column;
-  padding-bottom: 8px;
-  margin-bottom: -8px;
-  overflow: visible;
+  padding-bottom: var(--spacing-8);
+  margin-bottom: calc(-1 * var(--spacing-8));
 }
 
 .track_container {

--- a/components/src/molecules/TimelineScrubber/timelinescrubber.module.css
+++ b/components/src/molecules/TimelineScrubber/timelinescrubber.module.css
@@ -3,6 +3,9 @@
   width: 100%;
   box-sizing: border-box;
   flex-direction: column;
+  padding-bottom: 8px;
+  margin-bottom: -8px;
+  overflow: visible;
 }
 
 .track_container {


### PR DESCRIPTION
# Overview
fix timescrubber circle styling

<img width="349" height="187" alt="Screenshot 2026-01-23 at 4 39 33 PM" src="https://github.com/user-attachments/assets/efa5b7e3-3e37-4f40-abd2-fb6b1462cf00" />
<img width="220" height="213" alt="Screenshot 2026-01-23 at 4 40 05 PM" src="https://github.com/user-attachments/assets/db728926-6b7f-4d20-b077-9e4cee9e6116" />



close RQA-4979


## Test Plan and Hands on Testing


## Changelog


## Review requests


## Risk assessment
low
