### PR TITLE
fix(step-generation): filter out lids from fill_items py

### DIFF
--- a/step-generation/src/commandCreators/atomic/__tests__/flexStackerFillItems.test.ts
+++ b/step-generation/src/commandCreators/atomic/__tests__/flexStackerFillItems.test.ts
@@ -23,6 +23,7 @@ const labwareId2 = 'labwareId2'
 const labwareId3 = 'labwareId3'
 const labwareId4 = 'labwareId4'
 const labwareId5 = 'labwareId5'
+const lidId1 = 'lidId1'
 vi.mock('../../../robotStateSelectors')
 
 describe('flexStackerFillItems', () => {
@@ -92,6 +93,9 @@ describe('flexStackerFillItems', () => {
       [labwareId5]: {
         stack: [labwareId5, 'offDeck'],
       },
+      [lidId1]: {
+        stack: [lidId1, 'offDeck'],
+      },
     }
     vi.mocked(flexStackerStateGetter).mockReturnValue({
       labwareOnShuttle: {
@@ -112,6 +116,57 @@ describe('flexStackerFillItems', () => {
         adapterLabwareURI: null,
       },
       type: FLEX_STACKER_MODULE_TYPE,
+    })
+  })
+  it('creates flex stacker fill command with 1 tiprack with a lid', () => {
+    invariantContext.labwareEntities = {
+      [labwareId]: {
+        id: labwareId,
+        def: fixture96Plate as LabwareDefinition2,
+        labwareDefURI: 'mockURI',
+        pythonName: 'mock_labware_1',
+      },
+      [lidId1]: {
+        id: lidId1,
+        def: { ...fixture96Plate, allowedRoles: ['lid'] } as LabwareDefinition2,
+        labwareDefURI: 'mockURI',
+        pythonName: 'mock_lid_1',
+      },
+    }
+    robotState.labware = {
+      [labwareId]: {
+        stack: [labwareId, 'offDeck'],
+      },
+      [lidId1]: {
+        stack: [lidId1, 'offDeck'],
+      },
+    }
+    const result = flexStackerFillItems(
+      {
+        moduleId,
+        commandCreatorFnName: 'flexStackerFillItems',
+        interventionMessage: null,
+        fillLabwareUri: 'mockURI',
+        fillLabwareIds: [labwareId, lidId1],
+      },
+      invariantContext,
+      robotState
+    )
+    expect(result).toEqual({
+      commands: [
+        {
+          commandType: 'flexStacker/fillItems',
+          key: expect.any(String),
+          params: {
+            moduleId,
+            labware: [labwareId, lidId1],
+          },
+        },
+      ],
+      python: `
+mock_flex_stacker_1.fill_items(
+    labware=[mock_labware_1],
+)`.trimStart(),
     })
   })
   it('creates flex stacker fill command with 1 labware', () => {

--- a/step-generation/src/commandCreators/atomic/flexStackerFillItems.ts
+++ b/step-generation/src/commandCreators/atomic/flexStackerFillItems.ts
@@ -1,3 +1,5 @@
+import { getIsLid } from '@opentrons/shared-data'
+
 import * as errorCreators from '../../errorCreators'
 import { flexStackerStateGetter } from '../../robotStateSelectors'
 import {
@@ -29,7 +31,7 @@ export const flexStackerFillItems: CommandCreator<FlexStackerFillItemsArgs> = (
   )
   const modulePythonName = moduleEntities[moduleId].pythonName
   const labwarePythonNames = fillLabwareIds
-    .filter(id => !labwareEntities[id].def.allowedRoles?.includes('lid'))
+    .filter(id => !getIsLid(labwareEntities[id].def))
     .map(lwId => labwareEntities[lwId]?.pythonName)
   const labwareChunks = getChunkForIndentingLists(labwarePythonNames, 4)
   const indentedLabwarePythonNames = labwareChunks
@@ -65,7 +67,7 @@ export const flexStackerFillItems: CommandCreator<FlexStackerFillItemsArgs> = (
   }
 
   const filteredFillLabwareIds = fillLabwareIds.filter(
-    id => !labwareEntities[id].def.allowedRoles?.includes('lid')
+    id => !getIsLid(labwareEntities[id].def)
   )
   const pythonArgs = [
     ...(filteredFillLabwareIds.length > 0

--- a/step-generation/src/commandCreators/atomic/flexStackerFillItems.ts
+++ b/step-generation/src/commandCreators/atomic/flexStackerFillItems.ts
@@ -28,9 +28,9 @@ export const flexStackerFillItems: CommandCreator<FlexStackerFillItemsArgs> = (
     invariantContext.labwareEntities
   )
   const modulePythonName = moduleEntities[moduleId].pythonName
-  const labwarePythonNames = fillLabwareIds.map(
-    lwId => labwareEntities[lwId]?.pythonName
-  )
+  const labwarePythonNames = fillLabwareIds
+    .filter(id => !labwareEntities[id].def.allowedRoles?.includes('lid'))
+    .map(lwId => labwareEntities[lwId]?.pythonName)
   const labwareChunks = getChunkForIndentingLists(labwarePythonNames, 4)
   const indentedLabwarePythonNames = labwareChunks
     .map(chunk => INDENT + chunk.join(', '))
@@ -64,8 +64,11 @@ export const flexStackerFillItems: CommandCreator<FlexStackerFillItemsArgs> = (
     }
   }
 
+  const filteredFillLabwareIds = fillLabwareIds.filter(
+    id => !labwareEntities[id].def.allowedRoles?.includes('lid')
+  )
   const pythonArgs = [
-    ...(fillLabwareIds.length > 0
+    ...(filteredFillLabwareIds.length > 0
       ? `labware=[${formattedPythonLabwareNames}],\n`
       : []),
     ...(interventionMessage != null


### PR DESCRIPTION
# Overview

closes RQA-5084

filter out the lids from the fill_items python command

## Test Plan and Hands on Testing

import protocol attached to the ticket and then export and see that the generated python doesn't show the lid items in the fill_items command in step 8

## Changelog

filter out lids and add test coverage

## Risk assessment

low
