### PR TITLE
fix(protocol-designer): emit correct off deck location for lid stacks

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/index.tsx
@@ -3,6 +3,7 @@ import { connect, useSelector } from 'react-redux'
 
 import { useConditionalConfirm } from '@opentrons/components'
 import { getModuleDisplayName } from '@opentrons/shared-data'
+import { flexStackerStateGetter } from '@opentrons/step-generation'
 
 import {
   BonusStepModal,
@@ -24,6 +25,7 @@ import {
   getSavedStepForms,
 } from '/protocol-designer/step-forms/selectors'
 import { actions } from '/protocol-designer/steplist'
+import { getRobotStateAtActiveItem } from '/protocol-designer/top-selectors/labware-locations'
 import { actions as stepsActions } from '/protocol-designer/ui/steps'
 
 import { StepFormToolbox } from './StepFormToolbox'
@@ -49,7 +51,11 @@ interface StateProps {
 interface DispatchProps {
   cancelStepForm: () => void
   saveStepForm: (options?: { userWantsBonusStep?: boolean }) => void
-  createdLabwareForQueue: (moduleId: string, fillLabwareIds: string[]) => void
+  createdLabwareForQueue: (
+    moduleId: string,
+    fillLabwareIds: string[],
+    isLidConfigured: boolean
+  ) => void
   deleteLabwares: (labwareIds: string[]) => void
 }
 type StepFormManagerProps = StateProps & DispatchProps
@@ -73,6 +79,7 @@ function StepFormManager(props: StepFormManagerProps): JSX.Element | null {
     getDirtyFields(isNewStep, formData)
   )
   const savedStepForms = useSelector(getSavedStepForms)
+  const robotState = useSelector(getRobotStateAtActiveItem)
   const savedStepForm = formData != null ? savedStepForms[formData.id] : null
 
   const handleBlur = (fieldName: StepFieldName): void => {
@@ -120,6 +127,13 @@ function StepFormManager(props: StepFormManagerProps): JSX.Element | null {
         hydratedForm.stepType === 'flexStacker' &&
         hydratedForm.flexStackerFormType === FLEX_STACKER_FILL
       ) {
+        const moduleState =
+          robotState != null
+            ? flexStackerStateGetter(robotState, hydratedForm.moduleId)
+            : null
+        const isLidConfigured =
+          moduleState?.storedLabwareDetails?.lidLabwareURI != null
+
         // logic for editing a fill step form
         if (savedStepForm != null) {
           const initialLabwareIds =
@@ -140,13 +154,18 @@ function StepFormManager(props: StepFormManagerProps): JSX.Element | null {
               oldFillQuantity,
               hydratedForm.fillLabwareIds.length
             )
-            createdLabwareForQueue(hydratedForm.moduleId, newLabwareIds)
+            createdLabwareForQueue(
+              hydratedForm.moduleId,
+              newLabwareIds,
+              isLidConfigured
+            )
           }
         } else {
           // if no saved step form exists, create all the new labware
           createdLabwareForQueue(
             hydratedForm.moduleId,
-            hydratedForm.fillLabwareIds
+            hydratedForm.fillLabwareIds,
+            isLidConfigured
           )
         }
       } else if (
@@ -266,12 +285,14 @@ const mapDispatchToProps = (dispatch: ThunkDispatch<any>): DispatchProps => {
 
   const createdLabwareForQueue = (
     moduleId: string,
-    fillLabwareIds: string[]
+    fillLabwareIds: string[],
+    isLidConfigured: boolean
   ): void => {
     dispatch(
       createLabwareAndQueueForHopper({
         moduleId,
         fillLabwareIds,
+        isLidConfigured,
       })
     )
   }

--- a/protocol-designer/src/step-forms/actions/thunks.ts
+++ b/protocol-designer/src/step-forms/actions/thunks.ts
@@ -1,3 +1,5 @@
+import chunk from 'lodash/chunk'
+
 import { FLEX_STACKER_MODULE_TYPE } from '@opentrons/shared-data'
 
 import { stackerLabwareCreationFinish, stackerLabwareCreationStart } from '.'
@@ -222,13 +224,16 @@ export const createModuleEntityAndChangeForm: (
 interface CreateLabwareAndQueueForHopperArgs {
   fillLabwareIds: string[]
   moduleId: string
+  isLidConfigured: boolean
 }
 
 export const createLabwareAndQueueForHopper =
   (args: CreateLabwareAndQueueForHopperArgs): ThunkAction<any> =>
   async (dispatch, getState) => {
-    const { fillLabwareIds, moduleId } = args
+    const { fillLabwareIds, moduleId, isLidConfigured } = args
     dispatch(stackerLabwareCreationStart())
+    const chunkLength = isLidConfigured ? 2 : 1
+    const chunks = chunk(fillLabwareIds, chunkLength)
 
     const state = getState()
     const deckSetup = getDeckSetupForActiveItem(state)
@@ -237,14 +242,14 @@ export const createLabwareAndQueueForHopper =
 
     if (module.moduleState.type === FLEX_STACKER_MODULE_TYPE) {
       // collect all container creation promises
-      const containerPromises = fillLabwareIds.map(labwareId => {
-        const [id, uri] = labwareId.split(':')
-        // dispatch can return a promise if createContainer is async
+      const containerPromises = chunks.map(chunk => {
+        const ids = chunk.map(labwareId => labwareId.split(':')[0])
+        const uris = chunk.map(labwareId => labwareId.split(':')[1])
         return dispatch(
           createContainer({
-            labwareDefURIStack: [uri],
+            labwareDefURIStack: uris,
             slot: 'offDeck',
-            uuids: [id],
+            uuids: ids,
           })
         )
       })

--- a/step-generation/src/utils/pythonFileUtils.ts
+++ b/step-generation/src/utils/pythonFileUtils.ts
@@ -221,6 +221,19 @@ const _getLidStacks = (
     {}
   )
 
+export const _getLidStackLocationArg = (
+  location: string,
+  isLidSlotOnAdapter: boolean
+): string => {
+  if (isLidSlotOnAdapter) {
+    return `location=${location}`
+  }
+  if (location === 'offDeck') {
+    return `location=${OFF_DECK}`
+  }
+  return `location=${formatPyStr(location)}`
+}
+
 export const getLoadLidStacks = (
   allLabwareEntities: LabwareEntities,
   labwareRobotState: TimelineFrame['labware']
@@ -242,9 +255,7 @@ export const getLoadLidStacks = (
         ({ pythonName }) => pythonName === location
       )
       const loadNameArg = `load_name=${formatPyStr(loadName)}`
-      const locationArg = `location=${
-        isLidSlotOnAdapter ? location : formatPyStr(location)
-      }`
+      const locationArg = _getLidStackLocationArg(location, isLidSlotOnAdapter)
       const quantityArg = `quantity=${quantity}`
       const allArgs = [loadNameArg, locationArg, quantityArg].join(',\n')
       const allArgsIndented = indentPyLines(allArgs)

--- a/step-generation/src/utils/pythonFileUtils.ts
+++ b/step-generation/src/utils/pythonFileUtils.ts
@@ -221,19 +221,6 @@ const _getLidStacks = (
     {}
   )
 
-export const _getLidStackLocationArg = (
-  location: string,
-  isLidSlotOnAdapter: boolean
-): string => {
-  if (isLidSlotOnAdapter) {
-    return `location=${location}`
-  }
-  if (location === 'offDeck') {
-    return `location=${OFF_DECK}`
-  }
-  return `location=${formatPyStr(location)}`
-}
-
 export const getLoadLidStacks = (
   allLabwareEntities: LabwareEntities,
   labwareRobotState: TimelineFrame['labware']
@@ -255,7 +242,9 @@ export const getLoadLidStacks = (
         ({ pythonName }) => pythonName === location
       )
       const loadNameArg = `load_name=${formatPyStr(loadName)}`
-      const locationArg = _getLidStackLocationArg(location, isLidSlotOnAdapter)
+      const locationArg = `location=${
+        isLidSlotOnAdapter ? location : formatPyStr(location)
+      }`
       const quantityArg = `quantity=${quantity}`
       const allArgs = [loadNameArg, locationArg, quantityArg].join(',\n')
       const allArgsIndented = indentPyLines(allArgs)


### PR DESCRIPTION
# Overview

Refactor `createLabwareAndQueueForHopper` to consider lid stacked on tipracks offdeck. The downstream effect of this is being able to properly load a tiprack off deck with a lid, and later fill the stacker with that lidded tiprack.

Closes RQA-5084

## Test Plan and Hands on Testing

- import the protocol attached to the ticket
- delete the fill step, and re-add a fill step
- export and open the Python
- verify that the correct tiprack load statement for the lidded tiprack to be used in a fill command is emitted:
```
    tip_rack_6 = protocol.load_labware(
        "opentrons_flex_96_filtertiprack_1000ul",
        location=protocol_api.OFF_DECK,
        label="Opentrons Flex 96 Filter Tip Rack 1000 µL (5)",
        namespace="opentrons",
        version=1,
        lid="opentrons_flex_tiprack_lid",
        lid_namespace="opentrons",
        lid_version=1,
    )
```
- upload to the app and verify that analysis passes

## Changelog

- update logic for handling offdeck lid stack locations

## Review requests

see test plan

## Risk assessment

⬇️ 