### PR TITLE
(notes): add known adapter issues to PD 8.8.0 release notes

### DIFF
--- a/protocol-designer/release-notes.md
+++ b/protocol-designer/release-notes.md
@@ -20,13 +20,13 @@ This release adds support for the Flex Stacker Module in Protocol Designer, and 
 
 ### Bug Fixes
 
-- Add tip rack lids to tip racks placed inside Flex 96-channel adapters.
 - Protocol Designer properly displays tip racks and their lids on the deck.
 - When you choose to mix liquids from the center of a well, Protocol Designer properly exports this location in your finished protocol.
 
 ### Known Issues
 
 - Removing a Stacker Module from the deck can also remove other attached hardware. Click **Deck hardware** in the upper left to edit or re-add hardware to the Flex deck.
+- Adding a lid to a tiprack placed inside the Flex 96-channel adapter can cause your Protocol Designer protocol to fail analysis in the Opentrons App. In the starting deck, remove the lid from the tip rack before adding to the adapter.
 
 Running a protocol created in Protocol Designer requires Opentrons App version 8.8.0 or newer.
 


### PR DESCRIPTION
# Overview

Moving [this bug ](https://opentrons.atlassian.net/browse/AUTH-2453) from "bug fixes" to "known issues," with extra description for how users should get around failing protocol analysis. 

## Test Plan and Hands on Testing



## Changelog



## Review requests

is this a sufficient description?
am I still targeting the right place for release (re: mergebacks)? 

## Risk assessment

low.
