### PR TITLE
feat(protocol-designer): introduce part 2 of partial tip feature flag and add progessive disclosure on transfer and mix steps

### DIFF
--- a/protocol-designer/src/assets/localization/en/feature_flags.json
+++ b/protocol-designer/src/assets/localization/en/feature_flags.json
@@ -38,5 +38,9 @@
   "OT_PD_ENABLE_BY_VOLUME_BUILDER": {
     "title": "Enable by-volume builder",
     "description": "Enables the ability to build by-volume curves"
+  },
+  "OT_PD_ENABLE_ADDITIONAL_PARTIAL_TIP_SELECTION": {
+    "title": "Enable additional partial tip selection",
+    "description": "Enables use of other pipette nozzles and return"
   }
 }

--- a/protocol-designer/src/assets/localization/en/protocol_steps.json
+++ b/protocol-designer/src/assets/localization/en/protocol_steps.json
@@ -160,6 +160,8 @@
     "untilTemperature": "Until {{temperature}} °C reached"
   },
   "pipette": "Pipette",
+  "pipette_nozzles_and_wells": "Pipette nozzles and wells",
+
   "pipette_path": "Pipette path",
   "place_hardware": "Place the modules and fixtures that you are using for this protocol onto the deck.",
   "place_modules": "Place the modules that you are using for this protocol onto the deck.",
@@ -187,7 +189,6 @@
   "select_dispense_wells": "Select destination wells using a {{displayName}}",
   "select_labware": "Select labware",
   "select_mix_labware": "Select a mix labware",
-  "select_nozzles": "Nozzles",
   "select_pipette": "Select a pipette",
   "select_tip_location": "Select pick up tip location",
   "select_tiprack": "Select a tiprack",

--- a/protocol-designer/src/assets/localization/en/protocol_steps.json
+++ b/protocol-designer/src/assets/localization/en/protocol_steps.json
@@ -12,7 +12,7 @@
   "add_details": "Add step details",
   "advanced_settings": "Advanced pipetting settings",
   "air_gap_volume": "Air gap volume",
-  "all": "All",
+  "all_nozzles": "All nozzles (recommended)",
   "and": "and",
   "aspirate": "Aspirate",
   "aspirate_labware": "Source labware",
@@ -38,7 +38,6 @@
     "volume": "Recommended between 0.1 and {{max}}"
   },
   "change_tips": "Change tips",
-  "column": "Column",
   "comfirm_reset_settings": {
     "liquid_class_selected": "Continuing will undo any changes and restore the settings to the values associated with the {{liquidClassName}} liquid class.",
     "no_liquid_class": "Continuing will undo any changes and restore the settings to the default values."
@@ -197,7 +196,9 @@
   "shake": "Shake",
   "shake_speed": "Shake speed",
   "single": "Single transfer",
-  "single_nozzle": "Single",
+  "single_column_of_nozzles": "Single column of nozzles",
+  "single_nozzle": "Single nozzle",
+  "single_row_of_nozzles": "Single row of nozzles",
   "speed": "Speed",
   "start_point": "{{prefix}} start point",
   "starting_deck": "Starting deck",

--- a/protocol-designer/src/feature-flags/reducers.ts
+++ b/protocol-designer/src/feature-flags/reducers.ts
@@ -37,6 +37,9 @@ const initialFlags: Flags = {
     _FF_ENV_VARS_.OT_PD_ENABLE_CONCURRENT_MODULE_ACTIONS === '1' || false,
   OT_PD_ENABLE_BY_VOLUME_BUILDER:
     _FF_ENV_VARS_.OT_PD_ENABLE_BY_VOLUME_BUILDER === '1' || false,
+  OT_PD_ENABLE_ADDITIONAL_PARTIAL_TIP_SELECTION:
+    _FF_ENV_VARS_.OT_PD_ENABLE_ADDITIONAL_PARTIAL_TIP_SELECTION === '1' ||
+    false,
 }
 // @ts-expect-error(sa, 2021-6-10): cannot use string literals as action type
 // TODO IMMEDIATELY: refactor this to the old fashioned way if we cannot have type safety: https://github.com/redux-utilities/redux-actions/issues/282#issuecomment-595163081

--- a/protocol-designer/src/feature-flags/selectors.ts
+++ b/protocol-designer/src/feature-flags/selectors.ts
@@ -47,3 +47,8 @@ export const getEnableByVolumeBuilder: Selector<boolean> = createSelector(
   getFeatureFlagData,
   flags => flags.OT_PD_ENABLE_BY_VOLUME_BUILDER ?? false
 )
+export const getEnableAdditionalPartialTipSelection: Selector<boolean> =
+  createSelector(
+    getFeatureFlagData,
+    flags => flags.OT_PD_ENABLE_ADDITIONAL_PARTIAL_TIP_SELECTION ?? false
+  )

--- a/protocol-designer/src/feature-flags/types.ts
+++ b/protocol-designer/src/feature-flags/types.ts
@@ -49,6 +49,7 @@ export type FlagTypes =
   | 'OT_PD_ENABLE_CONCURRENT_MODULE_ACTIONS'
   | 'OT_PD_ENABLE_BY_VOLUME_BUILDER'
   | 'OT_PD_ENABLE_CAMERA_SUPPORT'
+  | 'OT_PD_ENABLE_ADDITIONAL_PARTIAL_TIP_SELECTION'
 // flags that are not in this list only show in prerelease mode
 export const userFacingFlags: FlagTypes[] = [
   'OT_PD_DISABLE_MODULE_RESTRICTIONS',

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/PartialTipField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/PartialTipField.tsx
@@ -82,7 +82,7 @@ export function PartialTipField(props: PartialTipFieldProps): JSX.Element {
         error={errorToShow}
         dropdownType="neutral"
         filterOptions={options}
-        title={t('select_nozzles')}
+        title={t('pipette_nozzles_and_wells')}
         currentOption={
           options.find(option => option.value === selectedValue) ?? options[0]
         }

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/PartialTipField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/PartialTipField.tsx
@@ -5,6 +5,7 @@ import { useSelector } from 'react-redux'
 import { DropdownMenu, Flex, SPACING } from '@opentrons/components'
 import { ALL, COLUMN, ROW, SINGLE } from '@opentrons/shared-data'
 
+import { getEnableAdditionalPartialTipSelection } from '/protocol-designer/feature-flags/selectors'
 import { getInitialDeckSetup } from '/protocol-designer/step-forms/selectors'
 
 import type { DropdownOption } from '@opentrons/components'
@@ -26,7 +27,9 @@ export function PartialTipField(props: PartialTipFieldProps): JSX.Element {
   const { t } = useTranslation('protocol_steps')
   const deckSetup = useSelector(getInitialDeckSetup)
   const { channels } = pipetteSpecs
-
+  const enableAdditionalPartialTip = useSelector(
+    getEnableAdditionalPartialTipSelection
+  )
   const tipracks = Object.values(deckSetup.labware).filter(
     labware => labware.def.parameters.isTiprack
   )
@@ -53,14 +56,6 @@ export function PartialTipField(props: PartialTipFieldProps): JSX.Element {
             : null,
         },
         {
-          name: t('single_row_of_nozzles'),
-          value: ROW,
-          disabled: areAllTipracksOnAdapter,
-          tooltipText: areAllTipracksOnAdapter
-            ? t('form:step_edit_form.field.nozzles.option_tooltip.partial')
-            : null,
-        },
-        {
           name: t('single_column_of_nozzles'),
           value: COLUMN,
           disabled: areAllTipracksOnAdapter,
@@ -70,6 +65,16 @@ export function PartialTipField(props: PartialTipFieldProps): JSX.Element {
         },
       ]
     )
+  }
+  if (enableAdditionalPartialTip) {
+    options.push({
+      name: t('single_row_of_nozzles'),
+      value: ROW,
+      disabled: areAllTipracksOnAdapter,
+      tooltipText: areAllTipracksOnAdapter
+        ? t('form:step_edit_form.field.alozzles.option_tooltip.partial')
+        : null,
+    })
   }
   if (channels === 8) {
     // 8-channel

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/PartialTipField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/PartialTipField.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 
 import { DropdownMenu, Flex, SPACING } from '@opentrons/components'
-import { ALL, COLUMN, SINGLE } from '@opentrons/shared-data'
+import { ALL, COLUMN, ROW, SINGLE } from '@opentrons/shared-data'
 
 import { getInitialDeckSetup } from '/protocol-designer/step-forms/selectors'
 
@@ -37,7 +37,7 @@ export function PartialTipField(props: PartialTipFieldProps): JSX.Element {
 
   const options: DropdownOption[] = [
     {
-      name: t('all'),
+      name: t('all_nozzles'),
       value: ALL,
     },
   ]
@@ -45,16 +45,24 @@ export function PartialTipField(props: PartialTipFieldProps): JSX.Element {
     options.push(
       ...[
         {
-          name: t('column'),
-          value: COLUMN,
+          name: t('single_nozzle'),
+          value: SINGLE,
           disabled: areAllTipracksOnAdapter,
           tooltipText: areAllTipracksOnAdapter
             ? t('form:step_edit_form.field.nozzles.option_tooltip.partial')
             : null,
         },
         {
-          name: t('single_nozzle'),
-          value: SINGLE,
+          name: t('single_row_of_nozzles'),
+          value: ROW,
+          disabled: areAllTipracksOnAdapter,
+          tooltipText: areAllTipracksOnAdapter
+            ? t('form:step_edit_form.field.nozzles.option_tooltip.partial')
+            : null,
+        },
+        {
+          name: t('single_column_of_nozzles'),
+          value: COLUMN,
           disabled: areAllTipracksOnAdapter,
           tooltipText: areAllTipracksOnAdapter
             ? t('form:step_edit_form.field.nozzles.option_tooltip.partial')

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MixTools/FirstStepMixTools.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MixTools/FirstStepMixTools.tsx
@@ -42,8 +42,6 @@ export function FirstStepMixTools({
     formData.labware != null &&
     formData.tipRack != null &&
     formData.pipette != null
-  console.log('🚀 ~ FirstStepMixTools ~ completedSteps:', completedSteps)
-  console.log(formData)
   return (
     <Flex
       flexDirection={DIRECTION_COLUMN}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MixTools/FirstStepMixTools.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MixTools/FirstStepMixTools.tsx
@@ -1,8 +1,10 @@
 import { useTranslation } from 'react-i18next'
+import { useSelector } from 'react-redux'
 
 import { DIRECTION_COLUMN, Divider, Flex, SPACING } from '@opentrons/components'
 
 import { InputStepFormField } from '/protocol-designer/components/molecules'
+import { getEnableAdditionalPartialTipSelection } from '/protocol-designer/feature-flags/selectors'
 
 import {
   LabwareField,
@@ -29,10 +31,19 @@ export function FirstStepMixTools({
   pipettes,
 }: FirstStepMixToolsProps): JSX.Element {
   const { t } = useTranslation(['application', 'form', 'protocol_steps'])
+  const enableAdditionalPartialTip = useSelector(
+    getEnableAdditionalPartialTipSelection
+  )
   const channels =
     propsForFields.pipette.value != null
       ? pipettes[String(propsForFields.pipette.value)].spec.channels
       : null
+  const completedSteps =
+    formData.labware != null &&
+    formData.tipRack != null &&
+    formData.pipette != null
+  console.log('🚀 ~ FirstStepMixTools ~ completedSteps:', completedSteps)
+  console.log(formData)
   return (
     <Flex
       flexDirection={DIRECTION_COLUMN}
@@ -40,7 +51,7 @@ export function FirstStepMixTools({
       paddingY={SPACING.spacing16}
     >
       <PipetteField {...propsForFields.pipette} />
-      {channels != null && channels !== 1 ? (
+      {channels != null && channels !== 1 && !enableAdditionalPartialTip ? (
         <PartialTipField
           {...propsForFields.nozzles}
           pipetteSpecs={pipettes[String(propsForFields.pipette.value)]?.spec}
@@ -54,26 +65,40 @@ export function FirstStepMixTools({
       <Divider marginY="0" />
       <LabwareField {...propsForFields.labware} tooltipContent={null} />
       <Divider marginY="0" />
-      <WellSelectionField
-        {...propsForFields.wells}
-        labwareId={formData.labware}
-        pipetteId={formData.pipette}
-        nozzles={
-          typeof propsForFields.nozzles.value === 'string'
-            ? propsForFields.nozzles.value
-            : null
-        }
-        hasFormError={propsForFields.wells.errorToShow != null}
-      />
-      <Divider marginY="0" />
-      <VolumeField fieldProps={propsForFields.volume} />
-      <Divider marginY="0" />
-      <InputStepFormField
-        {...propsForFields.times}
-        units={t('units.times')}
-        title={t('protocol_steps:mix_repetitions')}
-        showTooltip={false}
-      />
+      {enableAdditionalPartialTip && completedSteps ? (
+        <>
+          <Divider marginY="0" />
+          <PartialTipField
+            {...propsForFields.nozzles}
+            pipetteSpecs={pipettes[String(propsForFields.pipette.value)]?.spec}
+          />
+        </>
+      ) : null}
+
+      {completedSteps ? (
+        <>
+          <WellSelectionField
+            {...propsForFields.wells}
+            labwareId={formData.labware}
+            pipetteId={formData.pipette}
+            nozzles={
+              typeof propsForFields.nozzles.value === 'string'
+                ? propsForFields.nozzles.value
+                : null
+            }
+            hasFormError={propsForFields.wells.errorToShow != null}
+          />
+          <Divider marginY="0" />
+          <VolumeField fieldProps={propsForFields.volume} />
+          <Divider marginY="0" />
+          <InputStepFormField
+            {...propsForFields.times}
+            units={t('units.times')}
+            title={t('protocol_steps:mix_repetitions')}
+            showTooltip={false}
+          />
+        </>
+      ) : null}
     </Flex>
   )
 }

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/FirstStepMoveLiquidTools.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/FirstStepMoveLiquidTools.tsx
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux'
 
 import { DIRECTION_COLUMN, Divider, Flex, SPACING } from '@opentrons/components'
 
+import { getEnableAdditionalPartialTipSelection } from '/protocol-designer/feature-flags/selectors'
 import {
   getAdditionalEquipmentEntities,
   getPipetteEntities,
@@ -35,7 +36,14 @@ export function FirstStepMoveLiquidTools({
   const additionalEquipmentEntities = useSelector(
     getAdditionalEquipmentEntities
   )
-
+  const completedSteps =
+    formData.aspirate_labware != null &&
+    formData.dispense_labware != null &&
+    formData.tipRack != null &&
+    formData.pipette != null
+  const enableAdditionalPartialTip = useSelector(
+    getEnableAdditionalPartialTipSelection
+  )
   const { pipette, tipRack } = propsForFields
   const channels =
     pipette.value != null
@@ -54,7 +62,7 @@ export function FirstStepMoveLiquidTools({
       paddingY={SPACING.spacing16}
     >
       <PipetteField {...propsForFields.pipette} />
-      {channels != null && channels !== 1 ? (
+      {channels != null && channels !== 1 && !enableAdditionalPartialTip ? (
         <>
           <Divider marginY="0" />
           <PartialTipField
@@ -68,26 +76,28 @@ export function FirstStepMoveLiquidTools({
       <Divider marginY="0" />
       <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing12}>
         <LabwareField {...propsForFields.aspirate_labware} />
-        <WellSelectionField
-          {...propsForFields.aspirate_wells}
-          labwareId={
-            typeof propsForFields.aspirate_labware.value === 'string'
-              ? propsForFields.aspirate_labware.value
-              : null
-          }
-          pipetteId={formData.pipette}
-          nozzles={
-            typeof propsForFields.nozzles.value === 'string'
-              ? propsForFields.nozzles.value
-              : null
-          }
-          hasFormError={propsForFields.aspirate_wells.errorToShow != null}
-        />
+        {!enableAdditionalPartialTip ? (
+          <WellSelectionField
+            {...propsForFields.aspirate_wells}
+            labwareId={
+              typeof propsForFields.aspirate_labware.value === 'string'
+                ? propsForFields.aspirate_labware.value
+                : null
+            }
+            pipetteId={formData.pipette}
+            nozzles={
+              typeof propsForFields.nozzles.value === 'string'
+                ? propsForFields.nozzles.value
+                : null
+            }
+            hasFormError={propsForFields.aspirate_wells.errorToShow != null}
+          />
+        ) : null}
       </Flex>
       <Divider marginY="0" />
       <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing12}>
         <LabwareField {...propsForFields.dispense_labware} />
-        {isDisposalLocation ? null : (
+        {!enableAdditionalPartialTip && !isDisposalLocation ? (
           <WellSelectionField
             {...propsForFields.dispense_wells}
             labwareId={
@@ -103,24 +113,79 @@ export function FirstStepMoveLiquidTools({
             }
             hasFormError={propsForFields.dispense_wells.errorToShow != null}
           />
-        )}
+        ) : null}
+        {channels != null &&
+        channels !== 1 &&
+        enableAdditionalPartialTip &&
+        completedSteps ? (
+          <>
+            <Divider marginY="0" />
+            <PartialTipField
+              {...propsForFields.nozzles}
+              pipetteSpecs={
+                pipettes[String(propsForFields.pipette.value)]?.spec
+              }
+            />
+            <WellSelectionField
+              {...propsForFields.aspirate_wells}
+              labwareId={
+                typeof propsForFields.aspirate_labware.value === 'string'
+                  ? propsForFields.aspirate_labware.value
+                  : null
+              }
+              pipetteId={formData.pipette}
+              nozzles={
+                typeof propsForFields.nozzles.value === 'string'
+                  ? propsForFields.nozzles.value
+                  : null
+              }
+              hasFormError={propsForFields.aspirate_wells.errorToShow != null}
+            />
+            <WellSelectionField
+              {...propsForFields.dispense_wells}
+              labwareId={
+                typeof propsForFields.dispense_labware.value === 'string'
+                  ? propsForFields.dispense_labware.value
+                  : null
+              }
+              pipetteId={formData.pipette}
+              nozzles={
+                typeof propsForFields.nozzles.value === 'string'
+                  ? propsForFields.nozzles.value
+                  : null
+              }
+              hasFormError={propsForFields.dispense_wells.errorToShow != null}
+            />
+          </>
+        ) : null}
       </Flex>
-      <Divider marginY="0" />
-      <PathField
-        {...propsForFields.path}
-        aspirate_airGap_checkbox={formData.aspirate_airGap_checkbox}
-        aspirate_airGap_volume={formData.aspirate_airGap_volume}
-        aspirate_wells={formData.aspirate_wells}
-        changeTip={formData.changeTip}
-        dispense_wells={formData.dispense_wells}
-        pipette={formData.pipette}
-        volume={formData.volume}
-        tipRack={formData.tipRack}
-        isDisposalLocation={isDisposalLocation}
-        title={t('pipette_path')}
-      />
-      <Divider marginY="0" />
-      <VolumeField fieldProps={propsForFields.volume} path={formData.path} />
+
+      {completedSteps ? (
+        <>
+          <Divider marginY="0" />
+
+          <PathField
+            {...propsForFields.path}
+            aspirate_airGap_checkbox={formData.aspirate_airGap_checkbox}
+            aspirate_airGap_volume={formData.aspirate_airGap_volume}
+            aspirate_wells={formData.aspirate_wells}
+            changeTip={formData.changeTip}
+            dispense_wells={formData.dispense_wells}
+            pipette={formData.pipette}
+            volume={formData.volume}
+            tipRack={formData.tipRack}
+            isDisposalLocation={isDisposalLocation}
+            title={t('pipette_path')}
+          />
+
+          <Divider marginY="0" />
+
+          <VolumeField
+            fieldProps={propsForFields.volume}
+            path={formData.path}
+          />
+        </>
+      ) : null}
     </Flex>
   )
 }


### PR DESCRIPTION
# Overview

Adds `OT_PD_ENABLE_ADDITIONAL_PARTIAL_TIP_SELECTION` to hide additional partial tip functionality and progressively exposes transfer and mix step forms based on previous forms filled out

## Test Plan and Hands on Testing

smoke tested with feature flag on and off

Video with the feature flag on: 
https://github.com/user-attachments/assets/19097f77-3ae9-431f-9c9d-1300ef32658b

feature flag:
<img width="711" height="417" alt="Screenshot 2026-01-26 at 3 55 36 PM" src="https://github.com/user-attachments/assets/4c4ba12e-ddd2-4c20-9987-1e2959d79c73" />

## Changelog
✅ Feature flag added
✅ Checks form data completion of pipette, tiprack, and labware before showing nozzle and well layout for transfer and mix steps
✅ Initial copy changes for nozzle layouts

## Risk assessment

- low, gated behind a feature flag

Closes AUTH-2362 & AUTH-2370
