### PR TITLE
fix(step-generation): scan whole timeline for when to emit set_stored…

### DIFF
--- a/step-generation/src/utils/__tests__/pythonFileUtils.test.ts
+++ b/step-generation/src/utils/__tests__/pythonFileUtils.test.ts
@@ -509,7 +509,8 @@ well_plate_3 = protocol.load_labware_from_definition(
       mockModuleEntitiesWithFlexStackerModule,
       mockLabwareEntitiesWithFlexStackerLabware,
       mockLabwareRobotStateWithFlexStackerLabware,
-      mockModuleState
+      mockModuleState,
+      { timeline: [] }
     )
 
     expect(setStoredLabware).toBe(
@@ -557,7 +558,8 @@ flex_stacker_1.set_stored_labware_items(
       mockModuleEntitiesWithFlexStackerModule,
       mockLabwareEntitiesWithFlexStackerLabware,
       mockLabwareRobotStateWithFlexStackerLabware,
-      mockModuleState
+      mockModuleState,
+      { timeline: [] }
     )
 
     expect(setStoredLabware).toBe(

--- a/step-generation/src/utils/pythonFileUtils.ts
+++ b/step-generation/src/utils/pythonFileUtils.ts
@@ -598,7 +598,7 @@ export function pythonDefRun(
     getDefineLiquids(liquidEntities),
     getLoadLiquids(liquidsByLabwareId, liquidEntities, labwareEntities),
     getLoadLiquidClasses(allUniqueLiquidClassesFromForms),
-    getSetStoredLabware(moduleEntities, labwareEntities, labware, modules),
+    getSetStoredLabware(moduleEntities, labwareEntities, labware, modules, robotStateTimeline),
     stepCommands(robotStateTimeline),
   ]
   const functionBody =
@@ -649,35 +649,42 @@ export const getSetStoredLabware = (
   moduleEntities: ModuleEntities,
   labwareEntities: LabwareEntities,
   labware: { [labwareId: string]: LabwareTemporalProperties },
-  modules: { [moduleId: string]: ModuleTemporalProperties }
+  modules: { [moduleId: string]: ModuleTemporalProperties },
+  robotStateTimeline: Timeline
 ): string => {
   const pythonSetStoredLabware = Object.values(moduleEntities).map(module => {
     const { id, type, pythonName } = module
 
     if (type === FLEX_STACKER_MODULE_TYPE) {
       const moduleSlot = modules[id].slot
+      const allLabwareState = robotStateTimeline.timeline.map(timeline => timeline.robotState.labware)
       const labwaresOnHopper = Object.entries(labware).filter(
         ([_, labware]) =>
           labware.stack.includes(id) &&
           labware.stack.includes(HOPPER_STACKER_LOCATION)
       )
-      const labwaresOnShuttle = Object.entries(labware).filter(
+      // include initialDeckState and all future states in the protocol
+      const allLabwaresThatAppearOnShuttle = [
+        ...Object.entries(labware),
+        ...allLabwareState.flatMap(labwareMap => Object.entries(labwareMap)),
+      ].filter(
         ([_, labware]) =>
           getSlotInLocationStack(labware.stack) === moduleSlot &&
           !labware.stack.includes(HOPPER_STACKER_LOCATION)
       )
+      
       // TODO: this doesn't address adapters in the shuttle yet since we dont allow that
       // as of 1/9/26
       if (labwaresOnHopper.length === 0) {
-        if (labwaresOnShuttle.length === 0) {
+        if (allLabwaresThatAppearOnShuttle.length === 0) {
           return ''
         }
 
-        const lid = labwaresOnShuttle.find(([id]) =>
+        const lid = allLabwaresThatAppearOnShuttle.find(([id]) =>
           labwareEntities[id].def.allowedRoles?.includes('lid')
         )
 
-        const nonLid = labwaresOnShuttle.find(
+        const nonLid = allLabwaresThatAppearOnShuttle.find(
           ([id]) => !labwareEntities[id].def.allowedRoles?.includes('lid')
         )
 

--- a/step-generation/src/utils/pythonFileUtils.ts
+++ b/step-generation/src/utils/pythonFileUtils.ts
@@ -598,7 +598,13 @@ export function pythonDefRun(
     getDefineLiquids(liquidEntities),
     getLoadLiquids(liquidsByLabwareId, liquidEntities, labwareEntities),
     getLoadLiquidClasses(allUniqueLiquidClassesFromForms),
-    getSetStoredLabware(moduleEntities, labwareEntities, labware, modules, robotStateTimeline),
+    getSetStoredLabware(
+      moduleEntities,
+      labwareEntities,
+      labware,
+      modules,
+      robotStateTimeline
+    ),
     stepCommands(robotStateTimeline),
   ]
   const functionBody =
@@ -657,7 +663,9 @@ export const getSetStoredLabware = (
 
     if (type === FLEX_STACKER_MODULE_TYPE) {
       const moduleSlot = modules[id].slot
-      const allLabwareState = robotStateTimeline.timeline.map(timeline => timeline.robotState.labware)
+      const allLabwareState = robotStateTimeline.timeline.map(
+        timeline => timeline.robotState.labware
+      )
       const labwaresOnHopper = Object.entries(labware).filter(
         ([_, labware]) =>
           labware.stack.includes(id) &&
@@ -672,7 +680,7 @@ export const getSetStoredLabware = (
           getSlotInLocationStack(labware.stack) === moduleSlot &&
           !labware.stack.includes(HOPPER_STACKER_LOCATION)
       )
-      
+
       // TODO: this doesn't address adapters in the shuttle yet since we dont allow that
       // as of 1/9/26
       if (labwaresOnHopper.length === 0) {


### PR DESCRIPTION
…_labware

closes RQA-5087

# Overview

Fix an issue where we were only emitting the `set_stored_labware` command for the initial robot state's stacker's shuttle location instead of mapping through the whole timeline

```
    flex_stacker_module_3.set_stored_labware(
        load_name="opentrons_flex_96_filtertiprack_200ul",
        namespace="opentrons",
        version=1,
        count=0
    )
```

The issue is that we were only searching for if the command needed to be emitted based off of the initial robot state but we needed to search through the whole timeline.

## Test Plan and Hands on Testing

upload protocol attached in the ticket to PD and then export and then import into the app and it should pass analysis. There should be a `set_stored_labware` command for the 3rd stacker now. 

## Changelog

search for labware in shuttle for the whole timeline and create a `set_stored_labware` command for all of them

## Risk assessment

low
