### PR TITLE
fix(api, shared-data): liquid classes blowout position setter error raising

### DIFF
--- a/api/src/opentrons/protocol_api/_liquid_properties.py
+++ b/api/src/opentrons/protocol_api/_liquid_properties.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from typing import Dict, List, Optional, Sequence, Tuple, Union
 
 from numpy import interp
+from pydantic import ValidationError
 
 from opentrons_shared_data.liquid_classes.liquid_class_definition import (
     AspirateProperties as SharedDataAspirateProperties,
@@ -696,15 +697,11 @@ def _ensure_validated_tip_position(
     if isinstance(tip_position, TipPosition):
         return tip_position
     elif isinstance(tip_position, dict):
-        # Use setters of TipPosition so we can get the validators for free
-        _pos = TipPosition(
-            _position_reference=PositionReference.WELL_TOP,
-            _offset=Coordinate(x=0, y=0, z=0),
-        )
-        _pos.position_reference = tip_position.get("position_reference")
-        offset = tip_position.get("offset")
-        _pos.offset = Coordinate(x=offset["x"], y=offset["y"], z=offset["z"])
-        return _pos
+        try:
+            pos = SharedDataTipPosition.model_validate(tip_position)
+        except ValidationError as e:
+            raise ValueError(f"Invalid tip position: {e}") from e
+        return _build_tip_position(pos)
     else:
         raise TypeError(
             f"Tip position should be an instance of `TipPosition` or of type `TipPositionDict`, but got {tip_position}"

--- a/api/tests/opentrons/protocol_api/test_liquid_class_properties.py
+++ b/api/tests/opentrons/protocol_api/test_liquid_class_properties.py
@@ -537,10 +537,24 @@ def test_ensure_validated_tip_position(
     validated_position = _ensure_validated_tip_position(tip_position)
     assert validated_position == expected_position
 
+
+def test_ensure_validated_tip_position_raises_error() -> None:
+    """It should raise an error if the tip position is invalid."""
     with pytest.raises(TypeError):
         _ensure_validated_tip_position("invalid_tip_position")  # type: ignore[arg-type]
 
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError,
+        match="Input should be 'well-bottom', 'well-top', 'well-center' or 'liquid-meniscus'",
+    ):
         _ensure_validated_tip_position(
             {"position_reference": "invalid", "offset": {"x": 10, "y": 20, "z": 30}}  # type: ignore[arg-type]
+        )
+
+    with pytest.raises(ValueError, match="Extra inputs are not permitted"):
+        _ensure_validated_tip_position(
+            {  # type: ignore[arg-type]
+                "position_reference": "well-bottom",
+                "offset": {"x": 10, "y": 20, "z": 30, "w": 3},
+            }
         )

--- a/api/tests/opentrons/protocol_api_integration/test_liquid_classes.py
+++ b/api/tests/opentrons/protocol_api_integration/test_liquid_classes.py
@@ -156,11 +156,8 @@ def test_adding_blowout_position_to_liquid_classes(
     custom_water_props.dispense.retract.blowout.blowout_position = None
     assert custom_water_props.dispense.retract.blowout.blowout_position is None
 
-    custom_water_props.dispense.retract.blowout.blowout_position = {  # type:ignore[assignment]
-        "position_reference": "well-top",
-        "offset": {"x": 11, "y": 22, "z": 33, "w": 123},
-    }
-    assert (
-        custom_water_props.dispense.retract.blowout.blowout_position.offset  # type:ignore[union-attr]
-        == Coordinate(x=11, y=22, z=33)
-    )
+    with pytest.raises(ValueError):
+        custom_water_props.dispense.retract.blowout.blowout_position = {  # type:ignore[assignment]
+            "position_reference": "well-top",
+            "offset": {"x": 11, "y": 22, "z": 33, "w": 123},
+        }

--- a/shared-data/command/schemas/16.json
+++ b/shared-data/command/schemas/16.json
@@ -1157,6 +1157,7 @@
       "type": "object"
     },
     "Coordinate": {
+      "additionalProperties": false,
       "description": "Three-dimensional coordinates.",
       "properties": {
         "x": {

--- a/shared-data/python/opentrons_shared_data/liquid_classes/liquid_class_definition.py
+++ b/shared-data/python/opentrons_shared_data/liquid_classes/liquid_class_definition.py
@@ -69,18 +69,18 @@ class BlowoutLocation(Enum):
     TRASH = "trash"
 
 
-class Coordinate(BaseModel):
+class BaseLiquidClassModel(BaseModel):
+    """Base class for liquid class definitions."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+
+class Coordinate(BaseLiquidClassModel):
     """Three-dimensional coordinates."""
 
     x: _Number
     y: _Number
     z: _Number
-
-
-class BaseLiquidClassModel(BaseModel):
-    """Base class for liquid class definitions."""
-
-    model_config = ConfigDict(populate_by_name=True, extra="forbid")
 
 
 class TipPosition(BaseLiquidClassModel):


### PR DESCRIPTION
# Overview

Follow-up to PR that added `blowoutPosition` to liquid classes.
This PR makes the `blowout_position` dict validation more strict and consistent with rest of custom liquid class properties validation.

In detail- the validator will now raise a `ValueError` if the `blowout_position` dictionary contains invalid fields or extra fields or is missing fields.

Thanks to David C. for pointing out this fault in validation!

## Changelog

- refactored `_ensure_validated_tip_position` in api
- configured the `Coordinate` model used for all liquid class `offset`s to forbid extra fields

## Test Plan and Hands on Testing

Added unit tests for testing the validators.

## Review requests

- any objections to the error re-raising in the validator?

## Risk assessment

None. A small api improvement.