### PR TITLE
fix(app): disable camera settings overflow option when camera is disabled

### DIFF
--- a/app/src/organisms/Desktop/Devices/Peripherals/CameraCard.tsx
+++ b/app/src/organisms/Desktop/Devices/Peripherals/CameraCard.tsx
@@ -174,6 +174,7 @@ function CameraCardOverflowMenu({
           onClick={() => {
             handleItemClick(toggleControls)
           }}
+          disabled={!cameraEnabled}
         >
           {t('edit_settings')}
         </MenuItem>

--- a/app/src/organisms/Desktop/Devices/Peripherals/__tests__/CameraCard.test.tsx
+++ b/app/src/organisms/Desktop/Devices/Peripherals/__tests__/CameraCard.test.tsx
@@ -180,6 +180,22 @@ describe('CameraCard', () => {
     screen.getByText('MOCK_CAMERA_CONTROLS')
   })
 
+  it('edit settings menu item is disabled when camera is disabled', async () => {
+    const user = userEvent.setup()
+    vi.mocked(useCameraUsageSettings).mockReturnValue({
+      isCameraEnabled: false,
+      toggleCameraEnabled: mockToggleEnabled,
+    } as any)
+
+    render(mockProps)
+
+    const overflowButton = screen.getByLabelText('overflow')
+    await user.click(overflowButton)
+
+    const editSettingsOption = screen.getByText('Edit settings')
+    expect(editSettingsOption).toBeDisabled()
+  })
+
   it('navigates to camera settings when usage settings is clicked', async () => {
     const user = userEvent.setup()
     render(mockProps)


### PR DESCRIPTION
Closes [RQA-5089](https://opentrons.atlassian.net/browse/RQA-5089)

# Overview

If the camera is disabled, we shouldn't enable the overflow menu option for configuring camera settings.

https://github.com/user-attachments/assets/7cee1435-a95d-45d2-8720-d5fa6340e701

## Test Plan and Hands on Testing

- See video

## Changelog

- Fixed the peripheral camera card's "Edit settings" overflow menu option remaining enabled even when the camera is disabled.

## Risk assessment

- very low, just a CSS change

[RQA-5089]: https://opentrons.atlassian.net/browse/RQA-5089?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ