### PR TITLE
fix(app): Fix update robot modal layout

### DIFF
--- a/app-shell/electron-builder.config.js
+++ b/app-shell/electron-builder.config.js
@@ -34,6 +34,7 @@ module.exports = async () => ({
     'build/br-premigration-wheels',
     '!Makefile',
     '!python',
+    '!**/.venv/**',
     {
       from: '../app/dist',
       to: './ui',

--- a/app/src/organisms/Desktop/Devices/RobotSettings/UpdateBuildroot/UpdateRobotModal.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/UpdateBuildroot/UpdateRobotModal.tsx
@@ -7,14 +7,15 @@ import {
   ALIGN_CENTER,
   Banner,
   BORDERS,
+  COLORS,
   DIRECTION_COLUMN,
   Flex,
   JUSTIFY_SPACE_AROUND,
   JUSTIFY_SPACE_BETWEEN,
   Modal,
-  NewPrimaryBtn,
-  NewSecondaryBtn,
+  PrimaryButton,
   ReleaseNotes,
+  SecondaryButton,
   SPACING,
   Tooltip,
   useHoverTooltip,
@@ -110,36 +111,40 @@ export function UpdateRobotModal({
   }
 
   const robotUpdateFooter = (
-    <Flex alignItems={ALIGN_CENTER} justifyContent={JUSTIFY_SPACE_BETWEEN}>
+    <Flex
+      alignItems={ALIGN_CENTER}
+      justifyContent={JUSTIFY_SPACE_BETWEEN}
+      paddingX={SPACING.spacing24}
+      borderTop={BORDERS.lineBorder}
+      borderColor={COLORS.grey30}
+    >
       <ExternalLink
         href={`${RELEASE_NOTES_URL_BASE}${robotUpdateVersion}`}
         css={css`
           font-size: 0.875rem;
         `}
         id="SoftwareUpdateReleaseNotesLink"
-        marginLeft={SPACING.spacing32}
       >
         {t('release_notes')}
       </ExternalLink>
-      <Flex alignItems={ALIGN_CENTER} justifyContent={JUSTIFY_SPACE_AROUND}>
-        <NewSecondaryBtn
-          onClick={closeModal}
-          marginRight={SPACING.spacing8}
-          css={FOOTER_BUTTON_STYLE}
-        >
+      <Flex
+        alignItems={ALIGN_CENTER}
+        justifyContent={JUSTIFY_SPACE_AROUND}
+        gap={SPACING.spacing8}
+      >
+        <SecondaryButton onClick={closeModal} css={FOOTER_BUTTON_STYLE}>
           {updateType === UPGRADE ? t('remind_me_later') : t('not_now')}
-        </NewSecondaryBtn>
-        <NewPrimaryBtn
+        </SecondaryButton>
+        <PrimaryButton
           onClick={() => {
             dispatchStartRobotUpdate(robotName)
           }}
-          marginRight={SPACING.spacing12}
           css={FOOTER_BUTTON_STYLE}
           disabled={updateDisabled}
           {...updateButtonProps}
         >
           {t('update_robot_now')}
-        </NewPrimaryBtn>
+        </PrimaryButton>
         {updateDisabled && (
           <Tooltip tooltipProps={updateButtonTooltipProps}>
             {disabledReason}


### PR DESCRIPTION
# Overview
Fix update robot modal

design
https://www.figma.com/design/qzX850M2Zxf1Mb5QwEtbzq/Primary--Desktop-App?node-id=10104-188332&m=dev

<img width="935" height="766" alt="Screenshot 2026-01-27 at 12 43 59 PM" src="https://github.com/user-attachments/assets/0fa589f2-64cb-4b9a-a8c0-74aa66f50b88" />

close RQA-5094

## Test Plan and Hands on Testing
- build the app locally for the modal `make -C app dist && make -C app-shell package`
- go to devices page and click `View update`


## Changelog
- add !**/.venv/** to build config to avoid venv error
- modify footer's styling to align with the design

List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.

## Review requests


## Risk assessment
low