### PR TITLE
fix(app): Handle `null` `selectedRecoveryOption` for recovery toasts explictly

### DIFF
--- a/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useRecoveryOptionCopy.test.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useRecoveryOptionCopy.test.tsx
@@ -149,4 +149,10 @@ describe('useRecoveryOptionCopy', () => {
 
     screen.getByText('Unknown action')
   })
+
+  it('renders "Unknown action" for a null recovery option', () => {
+    render({ route: null })
+
+    screen.getByText('Unknown action')
+  })
 })

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useRecoveryToasts.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useRecoveryToasts.ts
@@ -84,14 +84,14 @@ export function useRecoveryToastText({
   const currentStepReturnVal =
     stepNumber != null
       ? t('retrying_step_succeeded', {
-        step: stepNumber,
-      })
+          step: stepNumber,
+        })
       : t('retrying_step_succeeded_na')
   const nextStepReturnVal =
     stepNumber != null
       ? t('skipping_to_step_succeeded', {
-        step: stepNumber,
-      })
+          step: stepNumber,
+        })
       : t('skipping_to_step_succeeded_na')
 
   const toastText = handleRecoveryOptionAction(

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useRecoveryToasts.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useRecoveryToasts.ts
@@ -84,14 +84,14 @@ export function useRecoveryToastText({
   const currentStepReturnVal =
     stepNumber != null
       ? t('retrying_step_succeeded', {
-          step: stepNumber,
-        })
+        step: stepNumber,
+      })
       : t('retrying_step_succeeded_na')
   const nextStepReturnVal =
     stepNumber != null
       ? t('skipping_to_step_succeeded', {
-          step: stepNumber,
-        })
+        step: stepNumber,
+      })
       : t('skipping_to_step_succeeded_na')
 
   const toastText = handleRecoveryOptionAction(
@@ -193,6 +193,8 @@ export function handleRecoveryOptionAction<T>(
     case RECOVERY_MAP.SHUTTLE_FULL_RETRY.ROUTE:
     case RECOVERY_MAP.STACKER_SHUTTLE_EMPTY_STORE_RETRY.ROUTE:
       return currentStepReturnVal
+    case null:
+      return null
     default: {
       console.error('Unhandled recovery toast case. Handle explicitly.')
       return null


### PR DESCRIPTION
# Overview

When we first render Error Recovery, we aggregate a bunch of top level state including the `selectedRecoveryOption`. When the flows first render, there isn't a `selectedRecoveryOption`, but there always must be by the time we render the recovery toast. 

This `null` case is generating a false positive for the "handle recovery case explicitly" check, so we should filter it out. 

## Test Plan and Hands on Testing

- Tested via Sentry and app logs -- there's no more error thrown!

## Risk assessment

- effectively none, we aren't at risk for not showing a recovery toast by filtering out this case given how upstream logic works.
