### PR TITLE
refactor(mono): remove `*.log` from `.cursorignore`

### DIFF
--- a/.cursorignore
+++ b/.cursorignore
@@ -45,9 +45,6 @@ coverage.xml
 *.mo
 *.pot
 
-# Django stuff:
-*.log
-
 # Sphinx documentation
 docs/_build/
 docs/build/


### PR DESCRIPTION
# Overview

Cursor can generate `debug.log` files, but we are ignoring those due to our ignore list. Since we don't use Django, I think we can safely remove `*.log` from `.cursorignore`?

## Risk assessment

none