### PR TITLE
fix(protocol-designer,-step-generation): build stacks correctly when labware moved to shuttle

### DIFF
--- a/protocol-designer/src/utils/index.ts
+++ b/protocol-designer/src/utils/index.ts
@@ -436,13 +436,15 @@ export const getFullStackFromLabwaresOnDeck = (
   const slotInStack = onHopper
     ? FAKE_HOPPER_LOCATION_MAP[slot as HopperLocationMapKey]
     : slot
-  return labwareOnDeck
-    .filter(
-      ({ stack }) =>
-        stack.includes(slotInStack as string) &&
-        onHopper === stack.includes(HOPPER_STACKER_LOCATION)
-    )
-    .sort((a, b) => b.stack.length - a.stack.length)[0]?.stack
+  return (
+    labwareOnDeck
+      .filter(
+        ({ stack }) =>
+          stack.includes(slotInStack as string) &&
+          onHopper === stack.includes(HOPPER_STACKER_LOCATION)
+      )
+      .sort((a, b) => b.stack.length - a.stack.length)[0]?.stack ?? []
+  )
 }
 
 export const getModuleIdFromStack = (

--- a/step-generation/src/getNextRobotStateAndWarnings/__tests__/stackerUpdates.test.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/__tests__/stackerUpdates.test.ts
@@ -257,7 +257,6 @@ describe('flex stacker state updates forFlexStackerStore', () => {
       'tiprack4Id',
       HOPPER_STACKER_LOCATION,
       FLEX_STACKER_ID,
-      '1',
     ])
   })
 })

--- a/step-generation/src/getNextRobotStateAndWarnings/stackerUpdates.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/stackerUpdates.ts
@@ -580,7 +580,6 @@ export const forFlexStackerStore = (
 ): void => {
   const { robotState } = robotStateAndWarnings
   const { moduleId } = params
-  const moduleSlot = robotState.modules[moduleId].slot
   const moduleState = flexStackerStateGetter(robotState, moduleId)
   if (moduleState != null) {
     const { labwareOnShuttle } = moduleState

--- a/step-generation/src/getNextRobotStateAndWarnings/stackerUpdates.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/stackerUpdates.ts
@@ -603,7 +603,6 @@ export const forFlexStackerStore = (
             labwareId,
             HOPPER_STACKER_LOCATION,
             moduleId,
-            moduleSlot,
           ]
         }
       }


### PR DESCRIPTION
# Overview

When we store stacker labware and create its stack, we should not include the module's slot (A4, B4, etc.), since this will cause apparent conflicts later on when moving labware to that module's shuttle.

Closes RQA-5095

## Test Plan and Hands on Testing
[test protocol](https://github.com/user-attachments/files/24893534/smoke_move_stacker_shuttle.py)
- create or import a protocol that stores a stacker labware, and later moves a different labware to that stacker's shuttle
- verify that no timeline error from the move step is hit
- select the move labware steps and verify that the blue deck highlights correctly render

## Changelog

- exclude module slot from newly built labware stack in `forFlexStackerStore`
- catch a null check to return an array in `getFullStackFromLabwaresOnDeck`

## Review requests

- see test plan

## Risk assessment

lowish