### PR TITLE
docs: Flex manual, put emphasis on ethernet connection during first run process

### DIFF
--- a/docs/flex/docs/installation/first-run.md
+++ b/docs/flex/docs/installation/first-run.md
@@ -27,7 +27,7 @@ Follow the prompts on the touchscreen to get your robot connected so it can chec
 
 ### Ethernet (recommended on first run)
 
-Connect your Flex to a network switch, hub, or router with an Ethernet cable *before* connecting it to a Wi-Fi network. Making this initial connection via Ethernet cable ensures the robot has a stable internet connection to download any required software or firmware updates. Weak wireless signals can interrupt these downloads, causing the robot to get stuck in an endless restart cycle (or "boot loop). After the flex has updated and restarted, you can then switch to a wireless network if desired.
+Connect your Flex to a network switch, hub, or router with an Ethernet cable *before* connecting it to a Wi-Fi network. Making this initial connection via Ethernet cable ensures the robot has a stable internet connection to download any required software or firmware updates. Weak wireless signals can interrupt these downloads, causing the robot to get stuck in an endless restart cycle (a "boot loop"). After the Flex has updated and restarted, you can then switch to a wireless network if desired.
 
 <!--- do we still need this? --->
 Also, after first starting with an ethernet connection, you can then connect the robot directly to the Ethernet port on your computer, starting in robot system version 7.1.0.

--- a/docs/flex/docs/installation/first-run.md
+++ b/docs/flex/docs/installation/first-run.md
@@ -17,17 +17,28 @@ When you power on Flex, the Opentrons logo will appear on the touchscreen. After
 
 Follow the prompts on the touchscreen to get your robot connected so it can check for software updates and receive protocol files. There are three connection methods: Wi-Fi, Ethernet, and USB.
 
+!!! note
+    Opentrons strongly recommends using an Ethernet connection for the initial setup.
+
 <figure class="screenshot" markdown>
 ![Network connection options.](../images/choose-network-type.png "Network connection options")
 <figcaption>Network connection options. You need to have internet connectivity to set up Flex.</figcaption>
 </figure>
 
+### Ethernet (recommended on first run)
+
+Connect your Flex to a network switch, hub, or router with an Ethernet cable *before* connecting it to a Wi-Fi network. Making this initial connection via Ethernet cable ensures the robot has a stable internet connection to download any required software or firmware updates. Weak wireless signals can interrupt these downloads, causing the robot to get stuck in an endless restart cycle (or "boot loop). After the flex has updated and restarted, you can then switch to a wireless network if desired.
+
+<!--- do we still need this? --->
+Also, after first starting with an ethernet connection, you can then connect the robot directly to the Ethernet port on your computer, starting in robot system version 7.1.0.
+
 ### Wi-Fi
 
 Use the touchscreen to connect to Wi-Fi networks that are secured with WPA2 Personal authentication (most networks that only require a password to join fall under this category).
 
-!!! note 
-    Flex does not support captive portals (networks that don't have a password but load a webpage to authenticate users after connecting).
+!!! tip "Avoiding first-run setup errors"
+    - **Use Ethernet first**: As noted above, using Ethernet for the first connection prevents potential update errors caused by weak Wi-Fi signals. After updating, you can then connect the robot to a wireless network.
+    - **No captive portals**: Flex does not support captive portals (networks that don't have a password but load a webpage to authenticate users after connecting). Captive portals are commonly found in hotels, airports, or other public guest network locations.
 
 You can also connect to an open Wi-Fi network, but this is not recommended.
 
@@ -55,10 +66,6 @@ Select your network from the dropdown menu or choose "Join other network..." and
 - EAP-TLS
 
 Each of these methods requires a username and password, and depending on your exact network configuration may require certificate files or other options. Consult your facility's IT documentation or contact your IT manager for details of your network setup.
-
-### Ethernet
-
-Connect your robot to a network switch or hub with an Ethernet cable. You can also connect directly to the Ethernet port on your computer, starting in robot system version 7.1.0.
 
 ### USB 
 

--- a/docs/flex/docs/installation/first-run.md
+++ b/docs/flex/docs/installation/first-run.md
@@ -18,27 +18,27 @@ When you power on Flex, the Opentrons logo will appear on the touchscreen. After
 Follow the prompts on the touchscreen to get your robot connected so it can check for software updates and receive protocol files. There are three connection methods: Wi-Fi, Ethernet, and USB.
 
 !!! note
-    Opentrons strongly recommends using an Ethernet connection for the initial setup.
+    Always use the best available internet connection with your Flex. Avoid congested networks or wireless networks with poor signal, as this can affect the robot update and startup processes. 
+    
+    Opentrons recommends using an Ethernet connection for initial setup.
 
 <figure class="screenshot" markdown>
 ![Network connection options.](../images/choose-network-type.png "Network connection options")
 <figcaption>Network connection options. You need to have internet connectivity to set up Flex.</figcaption>
 </figure>
 
-### Ethernet (recommended on first run)
+### Ethernet (recommended)
 
-Connect your Flex to a network switch, hub, or router with an Ethernet cable *before* connecting it to a Wi-Fi network. Making this initial connection via Ethernet cable ensures the robot has a stable internet connection to download any required software or firmware updates. Weak wireless signals can interrupt these downloads, causing the robot to get stuck in an endless restart cycle (a "boot loop"). After the Flex has updated and restarted, you can then switch to a wireless network if desired.
-
-<!--- do we still need this? --->
-Also, after first starting with an ethernet connection, you can then connect the robot directly to the Ethernet port on your computer, starting in robot system version 7.1.0.
+Connect your Flex to a network switch, hub, or router with an Ethernet cable. Making this initial connection via Ethernet cable ensures the robot has a stable internet connection to download any required software or firmware updates. After the Flex has updated and restarted, you can then switch to a wireless network if desired.
 
 ### Wi-Fi
 
 Use the touchscreen to connect to Wi-Fi networks that are secured with WPA2 Personal authentication (most networks that only require a password to join fall under this category).
 
-!!! tip "Avoiding first-run setup errors"
-    - **Use Ethernet first**: As noted above, using Ethernet for the first connection prevents potential update errors caused by weak Wi-Fi signals. After updating, you can then connect the robot to a wireless network.
-    - **No captive portals**: Flex does not support captive portals (networks that don't have a password but load a webpage to authenticate users after connecting). Captive portals are commonly found in hotels, airports, or other public guest network locations.
+!!! tip 
+    - **Use Ethernet first**: As noted above, using Ethernet for the first connection makes setup and software updates more reliable. After updating, you can then connect the robot to a wireless network.
+    - **Avoid "guest" Wi-Fi**: These networks may be congested and not provide enough security for your Flex.
+    - **No captive portals**: Flex does not support captive portals (networks that don't have a password but load a webpage to authenticate users after connecting). Captive portals are commonly found in hotels, airports, or other public locations.
 
 You can also connect to an open Wi-Fi network, but this is not recommended.
 

--- a/docs/flex/docs/touchscreen/settings.md
+++ b/docs/flex/docs/touchscreen/settings.md
@@ -52,7 +52,7 @@ Set the language used by the touchscreen to Chinese or English.
 View the status of or set up a Wi-Fi, Ethernet, or USB connection. Multiple connections can be active simultaneously.
 
 !!! Note
-    When first setting up your Flex, connect it to a network switch, hub, or router with an Ethernet cable *before* connecting it to a Wi-Fi network. Making this initial connection via Ethernet cable ensures the robot has a stable internet connection to download any required software or firmware updates. See the [First Run section](../installation/first-run.md#ethernet-recommended-on-first-run) for more information.
+    When first setting up your Flex, connect it to a network switch, hub, or router with an Ethernet cable *before* connecting it to a Wi-Fi network. See the [First Run section](../installation/first-run.md#ethernet-recommended) for more information.
 
 ### Privacy
 

--- a/docs/flex/docs/touchscreen/settings.md
+++ b/docs/flex/docs/touchscreen/settings.md
@@ -51,6 +51,9 @@ Set the language used by the touchscreen to Chinese or English.
 
 View the status of or set up a Wi-Fi, Ethernet, or USB connection. Multiple connections can be active simultaneously.
 
+!!! Note
+    When first setting up your Flex, connect it to a network switch, hub, or router with an Ethernet cable *before* connecting it to a Wi-Fi network. Making this initial connection via Ethernet cable ensures the robot has a stable internet connection to download any required software or firmware updates. See the [First Run section](../installation/first-run.md#ethernet-recommended-on-first-run) for more information.
+
 ### Privacy
 
 Choose what data you want Flex to share with Opentrons. This information is always anonymized and we only use it to improve our products.


### PR DESCRIPTION
# Overview

A weak wifi connection can cause a Flex to reboot endlessly during the first run process. The solution is to make this very first network connection with an ethernet cable. A hardwired connection gives the robot a reliable way to download the software and firmware it needs on first run.

RTC-934

Sandbox:
- First Run > [Connect to a network or computer](https://sandbox.docs.opentrons.com/docs-flex-use-ethernet-first-run/flex/installation/first-run/#connect-to-a-network-or-computer)
- First Run > [Ethernet (Recommended on first run)](https://sandbox.docs.opentrons.com/docs-flex-use-ethernet-first-run/flex/installation/first-run/#ethernet-recommended-on-first-run)
- First Run > [Wifi section](https://sandbox.docs.opentrons.com/docs-flex-use-ethernet-first-run/flex/installation/first-run/#wi-fi)
- Settings > [Network settings](https://sandbox.docs.opentrons.com/docs-flex-use-ethernet-first-run/flex/touchscreen/settings/#network-settings)

## Test Plan and Hands on Testing

Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.

## Changelog

**First run section**
Revises `first-run.md`.

- Add a note to the H2 connect section.
- Move the H3 ethernet above the H3 wireless section. Make ethernet come first in the list.
- Modify H3 ethernet section header and section body. Emphasis on using ethernet first.
- Wifi H3 is now second. Modify the callout making it a tip with 2 bullets: ethernet first, don't use captive portals.

**Settings section**
Revises `settings.md`. Re-using cautionary text from the first run section. In a note in the "Network Settings" description.

## Review requests

- Do all of these changes present the problem clearly and provide a solution with enough text and visual emphasis?

## Risk assessment

- Moderate. Users are experiencing setup problems. Need to present solution clearly.
