### PR TITLE
fix(hardware-testing): python error from 3.12 update needed fix

### DIFF
--- a/hardware-testing/hardware_testing/production_qc/robot_assembly_qc_ot3/test_connectivity.py
+++ b/hardware-testing/hardware_testing/production_qc/robot_assembly_qc_ot3/test_connectivity.py
@@ -273,7 +273,7 @@ async def _test_usb_a_ports(api: OT3API, report: CSVReport, section: str) -> Non
                 continue
 
             # determine port mapping from dev name
-            match = re.search("/dev/([a-z]{3}\d)", blkid_out)  # noqa: W605
+            match = re.search(r"/dev/([a-z]{3}\d)", blkid_out)
             if not match:
                 print(f"no match found: {tag}")
                 report(section, tag, [CSVResult.FAIL])


### PR DESCRIPTION
# Overview
mypy added the \d escape character to the SyntaxWarning because in 3.13 it will be a SyntaxError. Before it was just a linting error. Solution is to make the regex string a "raw" string.
Must have got missed since hardware-testing doesn't always run when other subdirectories get updated.