### PR TITLE
feat(api): abstract barcode scanner driver.

### DIFF
--- a/api/src/opentrons/drivers/barcode_scanner/__init__.py
+++ b/api/src/opentrons/drivers/barcode_scanner/__init__.py
@@ -1,0 +1,9 @@
+from .abstract import AbstractBarcodeScannerDriver
+from .types import BarcodeModuleInfo, LEDProfile, SoundProfile
+
+__all__ = [
+    "AbstractBarcodeScannerDriver",
+    "SoundProfile",
+    "LEDProfile",
+    "BarcodeModuleInfo",
+]

--- a/api/src/opentrons/drivers/barcode_scanner/abstract.py
+++ b/api/src/opentrons/drivers/barcode_scanner/abstract.py
@@ -24,7 +24,7 @@ class AbstractBarcodeScannerDriver(ABC):
         ...
 
     @abstractmethod
-    async def set_sufix(self, suffix: str) -> None:
+    async def set_suffix(self, suffix: str) -> None:
         """Set the automatic suffix for the barcode data."""
         ...
 

--- a/api/src/opentrons/drivers/barcode_scanner/abstract.py
+++ b/api/src/opentrons/drivers/barcode_scanner/abstract.py
@@ -29,6 +29,11 @@ class AbstractBarcodeScannerDriver(ABC):
         ...
 
     @abstractmethod
+    async def set_scan_timeout(self, timeout: float) -> None:
+        """Set how long to run the decoder before timing out."""
+        ...
+
+    @abstractmethod
     async def scan_barcode(self) -> Optional[str]:
         """Scan and return a barcode."""
         ...

--- a/api/src/opentrons/drivers/barcode_scanner/abstract.py
+++ b/api/src/opentrons/drivers/barcode_scanner/abstract.py
@@ -11,7 +11,7 @@ class AbstractBarcodeScannerDriver(ABC):
 
     @abstractmethod
     async def disconnect(self) -> None:
-        """Disonnect from the barcode scanner."""
+        """Disconnect from the barcode scanner."""
 
     @abstractmethod
     async def is_connected(self) -> bool:

--- a/api/src/opentrons/drivers/barcode_scanner/abstract.py
+++ b/api/src/opentrons/drivers/barcode_scanner/abstract.py
@@ -1,0 +1,49 @@
+from abc import ABC, abstractmethod
+from typing import Optional
+
+from .types import BarcodeModuleInfo, LEDProfile, SoundProfile
+
+
+class AbstractBarcodeScannerDriver(ABC):
+    @abstractmethod
+    async def connect(self) -> None:
+        """Connect to the barcode scanner."""
+
+    @abstractmethod
+    async def disconnect(self) -> None:
+        """Disonnect from the barcode scanner."""
+
+    @abstractmethod
+    async def is_connected(self) -> bool:
+        """Check connection to barcode scanner"""
+        ...
+
+    @abstractmethod
+    async def set_prefix(self, prefix: str) -> None:
+        """Set the automatic prefix for the barcode data."""
+        ...
+
+    @abstractmethod
+    async def set_sufix(self, suffix: str) -> None:
+        """Set the automatic suffix for the barcode data."""
+        ...
+
+    @abstractmethod
+    async def scan_barcode(self) -> Optional[str]:
+        """Scan and return a barcode."""
+        ...
+
+    @abstractmethod
+    async def set_sound_profile(self, profile: SoundProfile) -> None:
+        """Set the sound profile."""
+        ...
+
+    @abstractmethod
+    async def set_led_profile(self, profile: LEDProfile) -> None:
+        """Set the led profile."""
+        ...
+
+    @abstractmethod
+    async def get_device_info(self) -> BarcodeModuleInfo:
+        """Get Device Info."""
+        ...

--- a/api/src/opentrons/drivers/barcode_scanner/types.py
+++ b/api/src/opentrons/drivers/barcode_scanner/types.py
@@ -1,0 +1,17 @@
+from enum import Enum
+
+
+class SoundProfile(Enum):
+    FULL_SOUND = 1
+    ONLY_ERROR = 2
+    OFF = 3
+
+
+class LEDProfile(Enum):
+    SUCCESS_AND_FAILURE = 1
+    FAILURE_ONLY = 2
+    OFF = 3
+
+
+class BarcodeModuleInfo:
+    serial: str

--- a/api/src/opentrons/drivers/barcode_scanner/types.py
+++ b/api/src/opentrons/drivers/barcode_scanner/types.py
@@ -1,4 +1,6 @@
+from dataclasses import dataclass
 from enum import Enum
+from typing import Dict
 
 
 class SoundProfile(Enum):
@@ -13,5 +15,10 @@ class LEDProfile(Enum):
     OFF = 3
 
 
+@dataclass
 class BarcodeModuleInfo:
     serial: str
+
+    def to_dict(self) -> Dict[str, str]:
+        """Build command."""
+        return {"serial": self.serial}


### PR DESCRIPTION
# Overview
Abstract driver that encapsulates all of the common things supported by the various barcode scanners we are looking at supporting.

Supports the following interface

- Connect/Disconnect/is_connected
Used by the controller to add/remove a device
- set_prefix/set_suffix
Standard barcode scanners tend to automatically add a suffix usually `\cr\lf` depending on the type of workflow that a user may be replacing with our barcode scanner their system may expect a certain type of suffix/prefix in the data. This will also allow users to add a little extra metadata into their scans if they want. I have seen other systems that add a prefix for when something gets scanned before an action and then a different prefix when it gets scanned after an action. this way whatever system can check that a barcode is scanned twice and has one of each prefixes.
- set_sound_profile/set_led_profile
most barcode scanners have buzzers and led, we don't know exactly which and/or how many types of scanners we want to support so lets have some standard profiles that we can apply to give them a uniform behavior
- set_scan_timeout
Tell the device how long to stay active while attempting to decode a barcode before timing out.
- scan_barcode
Bread and butter of the project, turn on the detector and return data if something is found otherwise none
- get_device_info
We will need to know some amount of info about the device, at a minimum the serial number.
