### PR TITLE
fix(app): Fix desktop image on error card

### DIFF
--- a/app/src/local-resources/images/hooks/useImageGalleryData.ts
+++ b/app/src/local-resources/images/hooks/useImageGalleryData.ts
@@ -41,16 +41,22 @@ export function useImageGalleryData({
 
   const currentCommand = currentCommandDetails?.data
   const previousCommand = previousCommandDetails?.data
+  const currentCommandAnalysis = protocolAnalysis?.commands.find(
+    c => c.key === currentCommand?.key
+  )
+  const previousCommandAnalysis = protocolAnalysis?.commands.find(
+    c => c.key === previousCommand?.key
+  )
 
   const currentCommandString = useCommandTextString({
-    command: currentCommand ?? null,
+    command: currentCommandAnalysis ?? null,
     allRunDefs,
     commandTextData: protocolAnalysis,
     robotType,
   })
 
   const previousCommandString = useCommandTextString({
-    command: previousCommand ?? null,
+    command: previousCommandAnalysis ?? null,
     allRunDefs,
     commandTextData: protocolAnalysis,
     robotType,

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunCamera/ImageGalleryContainer/GalleryItemCard.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunCamera/ImageGalleryContainer/GalleryItemCard.tsx
@@ -92,21 +92,17 @@ export function GalleryItemCard(props: GalleryItemCardProps): JSX.Element {
     if (isLoading) {
       return
     }
-    const img = new Image()
-    const imagePathUrl = img.src
-    img.onload = () => {
-      if (robotName) {
-        dispatch(
-          cameraPhotoOpenAction({
-            robotName: robotName,
-            photoUrl: imagePathUrl,
-            windowTitle: t('branded:image_capture_window_title', {
-              step: stepCommandText,
-              timestamp,
-            }),
-          })
-        )
-      }
+    if (robotName && imagePath != null) {
+      dispatch(
+        cameraPhotoOpenAction({
+          robotName: robotName,
+          photoUrl: imagePath,
+          windowTitle: t('branded:image_capture_window_title', {
+            step: stepCommandText,
+            timestamp,
+          }),
+        })
+      )
     }
   }
   const [showErrorModal, setShowErrorModal] = useState(false)

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunCamera/ImageGalleryContainer/GalleryItemCard.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunCamera/ImageGalleryContainer/GalleryItemCard.tsx
@@ -16,6 +16,7 @@ import { cameraPhotoOpenAction } from '/app/redux/shell'
 import { useImage } from '/app/resources/dataFiles/useImage'
 
 import styles from './gallery.module.css'
+import { GalleryItemErrorModal } from './GalleryItemErrorModal'
 
 import type { UseImageGalleryDataProps } from '/app/local-resources/images/hooks/useImageGalleryData'
 
@@ -26,7 +27,7 @@ export interface GalleryItemCardProps extends UseImageGalleryDataProps {
 }
 
 export function GalleryItemCard(props: GalleryItemCardProps): JSX.Element {
-  const { item, protocolAnalysis, robotName } = props
+  const { item, protocolAnalysis, robotName, runId } = props
   const {
     currentCommand,
     currentCommandString,
@@ -119,22 +120,32 @@ export function GalleryItemCard(props: GalleryItemCardProps): JSX.Element {
     actions.push({ label: t('view_error_details'), onClick: toggleErrorModal })
   }
   return (
-    <MediaContainerContent
-      mediaContent={
-        <img
-          className={styles.gallery_img}
-          src={imagePath ?? undefined}
-          alt="camera-photo"
+    <>
+      {state() === 'error' && showErrorModal && currentCommand != null && (
+        <GalleryItemErrorModal
+          erroredCommand={currentCommand}
+          runId={runId}
+          toggleModal={toggleErrorModal}
+          robotName={robotName}
         />
-      }
-      centerPrimaryText={stepCommandText}
-      centerSecondaryText={previousCommandString}
-      rightPrimaryText={timestamp}
-      state={state()}
-      overflowMenu={true}
-      overflowMenuActions={actions}
-      hoverText={t('view_image')}
-      mediaContentOnClick={onClick}
-    />
+      )}
+      <MediaContainerContent
+        mediaContent={
+          <img
+            className={styles.gallery_img}
+            src={imagePath ?? undefined}
+            alt="camera-photo"
+          />
+        }
+        centerPrimaryText={stepCommandText}
+        centerSecondaryText={previousCommandString}
+        rightPrimaryText={timestamp}
+        state={state()}
+        overflowMenu={true}
+        overflowMenuActions={actions}
+        hoverText={t('view_image')}
+        mediaContentOnClick={onClick}
+      />
+    </>
   )
 }

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunCamera/ImageGalleryContainer/__tests__/GalleryItemCard.test.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunCamera/ImageGalleryContainer/__tests__/GalleryItemCard.test.tsx
@@ -1,6 +1,8 @@
 import { fireEvent, screen } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { useCommandQuery } from '@opentrons/react-api-client'
+
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
 import { useImage } from '/app/resources/dataFiles/useImage'
@@ -12,6 +14,23 @@ import type { UseImageGalleryDataProps } from '/app/local-resources/images/hooks
 
 vi.mock('/app/resources/dataFiles/useImage')
 vi.mock('/app/redux/discovery/selectors')
+vi.mock('@opentrons/react-api-client', () => ({
+  useCommandQuery: vi.fn(),
+}))
+vi.mock('@opentrons/components', async () => {
+  const actual = await vi.importActual('@opentrons/components')
+  return {
+    ...actual,
+    useCommandTextString: vi.fn(() => ({ commandText: 'Mock command text' })),
+  }
+})
+vi.mock('../GalleryItemErrorModal', () => ({
+  GalleryItemErrorModal: vi.fn(
+    ({ erroredCommand, runId, robotName, toggleModal }) => (
+      <div data-testid="gallery-item-error-modal">Mock Error Modal</div>
+    )
+  ),
+}))
 
 const render = (props: UseImageGalleryDataProps) => {
   return renderWithProviders(
@@ -53,6 +72,10 @@ describe('GalleryItemCard', () => {
     }
 
     vi.mocked(useImage).mockReturnValue('img-id')
+    vi.mocked(useCommandQuery).mockReturnValue({
+      data: { data: null },
+      isLoading: false,
+    } as any)
   })
 
   it('renders expected card content', () => {
@@ -75,7 +98,7 @@ describe('GalleryItemCard', () => {
   it('renders appropriate card copy when there is an image', () => {
     render(mockProps)
 
-    screen.getByText('Step ? / ?: ?')
+    screen.getByText('Step ? / ?: Mock command text')
     screen.getByText('View image')
     screen.getByText('2024-01-01 12:00:00')
   })
@@ -92,5 +115,47 @@ describe('GalleryItemCard', () => {
     fireEvent.click(downloadItem)
 
     expect(screen.queryByText('Download image')).toBeNull()
+  })
+
+  it('renders error modal when command has error and modal is toggled', () => {
+    const mockErroredCommand = {
+      error: {
+        errorCode: '3000',
+        detail: 'Test error detail',
+      },
+    }
+
+    vi.mocked(useCommandQuery).mockReturnValue({
+      data: { data: mockErroredCommand },
+      isLoading: false,
+    } as any)
+
+    render(mockProps)
+
+    const overflowButton = screen.getByRole('button')
+    fireEvent.click(overflowButton)
+
+    const viewErrorDetailsButton = screen.queryByText('View error details')
+    if (viewErrorDetailsButton != null) {
+      fireEvent.click(viewErrorDetailsButton)
+      expect(screen.getByTestId('gallery-item-error-modal')).toBeInTheDocument()
+    }
+  })
+
+  it('does not render error modal when command has no error', () => {
+    const mockNonErroredCommand = {
+      error: undefined,
+    }
+
+    vi.mocked(useCommandQuery).mockReturnValue({
+      data: { data: mockNonErroredCommand },
+      isLoading: false,
+    } as any)
+
+    render(mockProps)
+
+    expect(
+      screen.queryByTestId('gallery-item-error-modal')
+    ).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
Closes [RQA-5092](https://opentrons.atlassian.net/browse/RQA-5092)

# Overview

This PR fixes a few errors we're seeing with the camera-captured image card UI that appears after a protocol error.

494604c3c01b5f74da2f017fa501649c70f18b11 - Whoops, we had state set up to render some sort of error modal on click, but we never actually rendered the modal on click. Now we render the actual modal component.

5aca8d3dea29c95db83781bed51bd1546086edb7 - Command text in the cards was not working. We were trying to find protocol analysis command equivalents given a run record command _by `id`_, however, the `id`'s generated during a run are unique from the `protocolAnalysis` command `ids`. We can relate the run & protocol command equivalents based on their `key`.

6848429f1d12d73e3c640ef14f106ced9a7d1ebe - The onClick handler in `GalleryItemCard.tsx` was creating a new `Image()` object and reading its empty src property instead of using the actual image URL. 

### Current Behavior

https://github.com/user-attachments/assets/7749a9cd-30ee-4652-ab0e-1ba28bf4c378

### Fixed Behavior

https://github.com/user-attachments/assets/b639d42a-8332-48e4-8c60-9d98ebd92e15


## Test Plan and Hands on Testing

- See video

## Changelog

- Fixed the desktop image on error card not rendering the image in a secondary window when clicking "view image".
- Fixed the desktop image on error card not displaying the error modal when clicking "view error" in the overflow menu.
- Fixed command text copy errors in the desktop image on error card.

## Risk assessment

- low, bunch of small, orthogonal, easy-to-audit errors

[RQA-5092]: https://opentrons.atlassian.net/browse/RQA-5092?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ