### PR TITLE
fix(step-generation): get correct stack for setting labwareOnShuttle …

### DIFF
--- a/step-generation/src/getNextRobotStateAndWarnings/forMoveLabware.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/forMoveLabware.ts
@@ -64,13 +64,12 @@ export function forMoveLabware(
         ).filter((id): id is string => id != null)
       : []
 
-  const movedStackUpToTarget =
-    movedStackFromShuttle.indexOf(labwareId) !== -1
-      ? movedStackFromShuttle.slice(
-          0,
-          movedStackFromShuttle.indexOf(labwareId) + 1
-        )
-      : []
+  const movedStackUpToTarget = movedStackFromShuttle.includes(labwareId)
+    ? movedStackFromShuttle.slice(
+        0,
+        movedStackFromShuttle.indexOf(labwareId) + 1
+      )
+    : []
 
   if (
     initialShuttleParentStackerState != null &&

--- a/step-generation/src/getNextRobotStateAndWarnings/forMoveLabware.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/forMoveLabware.ts
@@ -51,6 +51,27 @@ export function forMoveLabware(
       return type === FLEX_STACKER_MODULE_TYPE && slot === initialDeckSlot
     }) ?? null
 
+  const movedStackFromShuttle =
+    initialShuttleParentStackerState != null &&
+    initialShuttleParentStackerState[1].moduleState.type ===
+      FLEX_STACKER_MODULE_TYPE
+      ? BOTTOM_UP_LABWARE_POOL_KEYS.map(
+          key =>
+            (
+              initialShuttleParentStackerState[1]
+                .moduleState as FlexStackerModuleState
+            ).labwareOnShuttle?.[key]
+        ).filter((id): id is string => id != null)
+      : []
+
+  const movedStackUpToTarget =
+    movedStackFromShuttle.indexOf(labwareId) !== -1
+      ? movedStackFromShuttle.slice(
+          0,
+          movedStackFromShuttle.indexOf(labwareId) + 1
+        )
+      : []
+
   if (
     initialShuttleParentStackerState != null &&
     initialShuttleParentStackerState[1].moduleState.type ===
@@ -90,7 +111,10 @@ export function forMoveLabware(
     }) ?? null
   const [newModuleId, newStackerOnDeck] = newShuttleParentStackerState ?? []
   if (newModuleId != null && newStackerOnDeck != null) {
-    const fullStack = getLargestStackInSlot(labware, initialDeckSlot)
+    const fullStack =
+      movedStackUpToTarget.length > 0
+        ? movedStackUpToTarget
+        : getLargestStackInSlot(labware, initialDeckSlot)
     const stackIndexOfTarget = fullStack.indexOf(labwareId)
     const moduleState = newStackerOnDeck.moduleState as FlexStackerModuleState
     if (stackIndexOfTarget !== -1) {


### PR DESCRIPTION
closes RQA-5100

# Overview

get correct stack for determining the labwareInShuttle, getting the stack from the initialDeckSlot is stale if the labware has been retrieved

## Test Plan and Hands on Testing

import attached protocol and observe how all the steps work as expected. see that you can keep storing things on the shuttles

[untitled - 2026-01-27T211627.095.py](https://github.com/user-attachments/files/24912272/untitled.-.2026-01-27T211627.095.py)


## Changelog

get correct stack by finding the moved stack and then getting the correct keys from the stack

## Risk assessment

low
