### PR TITLE
docs: add low-volume 96-channel pipette flow rates

### DIFF
--- a/docs/python-api/docs/pipettes/characteristics.md
+++ b/docs/python-api/docs/pipettes/characteristics.md
@@ -173,7 +173,7 @@ These flow rates will remain in effect until you change the `flow_rate` attribut
 
 ### Flex pipette flow rates
 
-The following table provides data on the default aspirate, dispense, and blowout flow rates (in µL/s) for Flex pipettes. Default flow rates for each pipette-tip combination are the same across all three actions.
+The following table provides data on the default aspirate, dispense, and blowout flow rates (in µL/s) for Flex pipettes. Default flow rates for each pipette-tip combination are the same across all three actions, except where noted.
 
 <table>
     <thead>
@@ -203,7 +203,7 @@ The following table provides data on the default aspirate, dispense, and blowout
             <td>716</td>
         </tr>
         <tr>
-            <td rowspan="3">96-channel (5-1000 µL)</td>
+            <td rowspan="3">96-channel (1000 µL)</td>
             <td>50</td>
             <td>6</td>
         </tr>
@@ -215,12 +215,24 @@ The following table provides data on the default aspirate, dispense, and blowout
             <td>1000</td>
             <td>160</td>
         </tr>
+        <tr>
+            <td rowspan="2">96-channel (200 µL)</td>
+            <td>50</td>
+            <td>22</td>
+        </tr>
+        <tr>
+            <td>200</td>
+            <td>
+                <p>15 (aspirate and dispense)</p>
+                <p>10 (blowout)</p>
+            </td>
+        </tr>
     </tbody>
 </table>
 
 Additionally:
 
-- When using a 50 µL pipette, you should only use 50 µL tips.
+- Do not use tips with a higher capacity than the pipette maximum volume.
 - All Flex pipettes have a well bottom clearance of 1 mm for aspirate and dispense actions.
 
 ### OT-2 pipette flow rates


### PR DESCRIPTION
# Overview

Fulfilling a common request for the default flow rates for these pipettes.

## Test Plan and Hands on Testing

[Sandbox](https://sandbox.docs.opentrons.com/docs-lv96-flow-rates/python-api/pipettes/characteristics/#flex-pipette-flow-rates)

## Changelog

Took values from latest pipette definition and added them to table.

## Review requests

- These values are correct and stable, yes?

## Risk assessment

none, docs