### PR TITLE
fix(protocol-designer): use current robot state in PartialTipField

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/PartialTipField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/PartialTipField.tsx
@@ -3,9 +3,9 @@ import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 
 import { DropdownMenu, Flex, SPACING } from '@opentrons/components'
-import { ALL, COLUMN, SINGLE } from '@opentrons/shared-data'
+import { ALL, COLUMN, getIsTiprack, SINGLE } from '@opentrons/shared-data'
 
-import { getInitialDeckSetup } from '/protocol-designer/step-forms/selectors'
+import { getDeckSetupForActiveItem } from '/protocol-designer/top-selectors/labware-locations'
 
 import type { DropdownOption } from '@opentrons/components'
 import type { PipetteV2Specs } from '@opentrons/shared-data'
@@ -24,12 +24,10 @@ export function PartialTipField(props: PartialTipFieldProps): JSX.Element {
     pipetteSpecs,
   } = props
   const { t } = useTranslation('protocol_steps')
-  const deckSetup = useSelector(getInitialDeckSetup)
+  const { labware } = useSelector(getDeckSetupForActiveItem)
   const { channels } = pipetteSpecs
 
-  const tipracks = Object.values(deckSetup.labware).filter(
-    labware => labware.def.parameters.isTiprack
-  )
+  const tipracks = Object.values(labware).filter(({ def }) => getIsTiprack(def))
   const tipracksNotOnAdapter = tipracks.filter(
     tiprack => tiprack.stack.length === 2
   )


### PR DESCRIPTION
# Overview

`PartialTipField` should reflect the state of the robot at the time of the current step form in creation.

Closes RQA-5102

## Test Plan and Hands on Testing

- upload ticket from protocol
- create new transfer or mix step
- verify that nozzle field does not disable partial tip configurations

## Changelog

- use current deck state in `PartialTipField`

## Review requests

see test plan

## Risk assessment

low