### PR TITLE
fix(protocol-designe): fix replace hopper labware

### DIFF
--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupToolbox.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupToolbox.tsx
@@ -30,7 +30,6 @@ import {
 } from '@opentrons/step-generation'
 
 import { getColumnFromWellName } from '/protocol-designer/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/utils'
-import { updateStackerModuleState } from '/protocol-designer/step-forms/actions'
 
 import {
   LINK_BUTTON_STYLE,
@@ -55,10 +54,7 @@ import { getDeckSetupForActiveItem } from '../../../top-selectors/labware-locati
 import { getSlotInformation } from '../utils'
 import { getIsLabwareOnSlotInUse } from './utils'
 
-import type {
-  FlexStackerModuleState,
-  HopperLocationMapKey,
-} from '@opentrons/step-generation'
+import type { HopperLocationMapKey } from '@opentrons/step-generation'
 import type { CreateContainerAboveModuleArgs } from '../../../step-forms/actions/thunks'
 import type { ThunkDispatch } from '../../../types'
 
@@ -142,7 +138,17 @@ export function DeckSetupToolbox(
     (createdAdapterForSlot == null && createdStackForSlot.length === 0) ||
     (createdStackForSlot.length === 0 && deckSetup.labware[slot] != null)
   const handleClear = (): void => {
-    if (slot !== 'offDeck' && offDeckLabware == null) {
+    if (isHopperSlot) {
+      const labwareIdsToDelete = (labwareInHopper ?? []).reduce<string[]>(
+        (acc, group) => {
+          return [...acc, ...Object.values(group).filter(id => id != null)]
+        },
+        []
+      )
+      labwareIdsToDelete.forEach(labwareId => {
+        dispatch(deleteContainer({ labwareId: labwareId }))
+      })
+    } else if (slot !== 'offDeck' && offDeckLabware == null) {
       if (createdAdapterForSlot != null) {
         dispatch(deleteContainer({ labwareId: createdAdapterForSlot.id }))
       }
@@ -187,18 +193,6 @@ export function DeckSetupToolbox(
               stackerPosition: 'hopper',
               amount: selectedTopLabware.amount,
             }
-        // clear previous hopper labware before creating new hopper labware
-        if (createdModuleForSlot?.id != null) {
-          dispatch(
-            updateStackerModuleState({
-              moduleId: createdModuleForSlot.id,
-              moduleState: {
-                ...(createdModuleForSlot.moduleState as FlexStackerModuleState),
-                labwareInHopper: null,
-              },
-            })
-          )
-        }
       }
       dispatch(
         createContainerAboveModule({

--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupToolbox.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupToolbox.tsx
@@ -30,6 +30,7 @@ import {
 } from '@opentrons/step-generation'
 
 import { getColumnFromWellName } from '/protocol-designer/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/utils'
+import { updateStackerModuleState } from '/protocol-designer/step-forms/actions'
 
 import {
   LINK_BUTTON_STYLE,
@@ -54,7 +55,10 @@ import { getDeckSetupForActiveItem } from '../../../top-selectors/labware-locati
 import { getSlotInformation } from '../utils'
 import { getIsLabwareOnSlotInUse } from './utils'
 
-import type { HopperLocationMapKey } from '@opentrons/step-generation'
+import type {
+  FlexStackerModuleState,
+  HopperLocationMapKey,
+} from '@opentrons/step-generation'
 import type { CreateContainerAboveModuleArgs } from '../../../step-forms/actions/thunks'
 import type { ThunkDispatch } from '../../../types'
 
@@ -183,6 +187,18 @@ export function DeckSetupToolbox(
               stackerPosition: 'hopper',
               amount: selectedTopLabware.amount,
             }
+        // clear previous hopper labware before creating new hopper labware
+        if (createdModuleForSlot?.id != null) {
+          dispatch(
+            updateStackerModuleState({
+              moduleId: createdModuleForSlot.id,
+              moduleState: {
+                ...(createdModuleForSlot.moduleState as FlexStackerModuleState),
+                labwareInHopper: null,
+              },
+            })
+          )
+        }
       }
       dispatch(
         createContainerAboveModule({


### PR DESCRIPTION
# Overview

In deck setup tools, replacing labware in the hopper should remove the previously configured hopper labware, rather than add on top of it.

Closes RQA-5103

## Test Plan and Hands on Testing

- import protocol attached to ticket
- select the stacker hopper with labware in it
- select "Replace labware"
- configure new labware and save
- verify that the hopper is re-configured for the new labware, and the old labware is not configured in the hopper

## Changelog

- clear hopper labware in starting deck state if replacing labware

## Review requests

see test plan

## Risk assessment

low