### PR TITLE
fix(app): don't use google cdn in electron

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -2,13 +2,6 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width,initial-scale=1" />
-
-    <link
-      href="https://fonts.googleapis.com/css?family=Open+Sans:400,400i,600,600i,700,700i"
-      rel="stylesheet"
-    />
-
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Opentrons</title>
   </head>


### PR DESCRIPTION
We've had this snippet in index.html roughly forever that downloads some css and some font files that set up Open Sans configuration and fallbacks for various character sets. In certain network scenarios, this being a <link> tag can cause the browser layer of electron to block for 3 minutes while opaque internal machinery tries to fetch the URL, which causes the systemd app-shell-odd controls to make the program restart, leading to a crashloop.

The funny thing is that we also include all these fonts through yarn and the @fontsource npm packages, so... we don't seem to need this at all? Deleting it and starting the app with no network doesn't seem to alter the look of the app at all. So let's try it.

Closes EXEC-2313
Attached are some screenshots of the dev app run after deleting the app state and disconnecting from the internet. Looks fine.

<img width="1015" height="805" alt="Screenshot 2026-01-28 at 12 24 11 PM" src="https://github.com/user-attachments/assets/7a43f3a7-f1a7-4455-8e3e-415210082072" />
<img width="633" height="129" alt="Screenshot 2026-01-28 at 12 24 22 PM" src="https://github.com/user-attachments/assets/a0a9ff37-a7d2-4449-8327-28d0c7336f14" />
