### PR TITLE
fix(abr-testing): correctly direct `check_robot_status` script to ip addresses

### DIFF
--- a/abr-testing/abr_testing/tools/check_robot_status.py
+++ b/abr-testing/abr_testing/tools/check_robot_status.py
@@ -84,7 +84,8 @@ if __name__ == "__main__":
     # GET IP ADDRESSES OF INTEREST
     robot_ips = [input("Enter IP of robot (type 'all' to run on all robots): ")]
     if robot_ips[0].lower() == "all":
-        ip_file = configurations["DEFAULT"]["ips"]
+        storage_directory = configurations["DEFAULT"]["storage_directory"]
+        ip_file = os.path.join(storage_directory, "IPs.json")
         with open(ip_file) as file:
             file_dict = json.load(file)
             robot_dict = file_dict.get("ip_address_list")


### PR DESCRIPTION
# Overview

update `check_robot_status` to handle new abr-testing config file setup

## Test Plan and Hands on Testing

tested on computer and confirmed slack messages were sent

## Changelog

- redirected where ips.json is expected to be 

## Risk assessment

low
