### PR TITLE
fix(app): remove events to track error

### DIFF
--- a/app/src/App/DesktopAppFallback.tsx
+++ b/app/src/App/DesktopAppFallback.tsx
@@ -14,10 +14,6 @@ import {
 } from '@opentrons/components'
 
 import { useSentryReport } from '/app/App/hooks'
-import {
-  ANALYTICS_DESKTOP_APP_ERROR,
-  useTrackEvent,
-} from '/app/redux/analytics'
 import { reloadUi } from '/app/redux/shell'
 
 import type { FallbackProps } from 'react-error-boundary'
@@ -25,14 +21,9 @@ import type { Dispatch } from '/app/redux/types'
 
 export function DesktopAppFallback({ error }: FallbackProps): JSX.Element {
   const { t } = useTranslation('app_settings')
-  const trackEvent = useTrackEvent()
   const dispatch = useDispatch<Dispatch>()
   const navigate = useNavigate()
   const handleReloadClick = (): void => {
-    trackEvent({
-      name: ANALYTICS_DESKTOP_APP_ERROR,
-      properties: { errorMessage: error.message },
-    })
     // route to the root page and initiate an electron browser window reload via app-shell
     navigate('/', { replace: true })
     dispatch(reloadUi(error.message as string))

--- a/app/src/App/OnDeviceDisplayAppFallback.tsx
+++ b/app/src/App/OnDeviceDisplayAppFallback.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useDispatch, useSelector } from 'react-redux'
+import { useDispatch } from 'react-redux'
 
 import {
   ALIGN_CENTER,
@@ -15,8 +15,6 @@ import {
 import { useSentryReport } from '/app/App/hooks'
 import { MediumButton } from '/app/atoms/buttons'
 import { OddModal } from '/app/molecules/OddModal'
-import { ANALYTICS_ODD_APP_ERROR, useTrackEvent } from '/app/redux/analytics'
-import { getLocalRobot, getRobotSerialNumber } from '/app/redux/discovery'
 import { appRestart, sendLog } from '/app/redux/shell'
 
 import type { FallbackProps } from 'react-error-boundary'
@@ -27,16 +25,8 @@ export function OnDeviceDisplayAppFallback({
   error,
 }: FallbackProps): JSX.Element {
   const { t } = useTranslation(['app_settings', 'branded'])
-  const trackEvent = useTrackEvent()
   const dispatch = useDispatch<Dispatch>()
-  const localRobot = useSelector(getLocalRobot)
-  const robotSerialNumber =
-    localRobot?.status != null ? getRobotSerialNumber(localRobot) : null
   const handleRestartClick = (): void => {
-    trackEvent({
-      name: ANALYTICS_ODD_APP_ERROR,
-      properties: { errorMessage: error.message, robotSerialNumber },
-    })
     dispatch(appRestart(error.message as string))
   }
   const modalHeader: OddModalHeaderBaseProps = {

--- a/app/src/App/__tests__/OnDeviceDisplayAppFallback.test.tsx
+++ b/app/src/App/__tests__/OnDeviceDisplayAppFallback.test.tsx
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
-import { ANALYTICS_ODD_APP_ERROR, useTrackEvent } from '/app/redux/analytics'
+import { useTrackEvent } from '/app/redux/analytics'
 import { getLocalRobot } from '/app/redux/discovery'
 import { mockConnectableRobot } from '/app/redux/discovery/__fixtures__'
 import { appRestart } from '/app/redux/shell'
@@ -68,13 +68,6 @@ describe('OnDeviceDisplayAppFallback', () => {
   it('should call a mock function when tapping reload button', () => {
     render(props)
     fireEvent.click(screen.getByText('Restart touchscreen'))
-    expect(mockTrackEvent).toHaveBeenCalledWith({
-      name: ANALYTICS_ODD_APP_ERROR,
-      properties: {
-        errorMessage: 'mock error',
-        robotSerialNumber: MOCK_ROBOT_SERIAL_NUMBER,
-      },
-    })
     expect(vi.mocked(appRestart)).toHaveBeenCalled()
   })
 })

--- a/app/src/redux/analytics/constants.ts
+++ b/app/src/redux/analytics/constants.ts
@@ -42,8 +42,6 @@ export const ANALYTICS_OPEN_LABWARE_CREATOR_FROM_BOTTOM_OF_LABWARE_LIBRARY_LIST 
   'openLabwareCreatorFromBottomOfLabwareLibraryList'
 export const ANALYTICS_SENT_TO_FLEX = 'sendToFlex' // This would be changed
 
-export const ANALYTICS_ODD_APP_ERROR = 'oddError'
-export const ANALYTICS_DESKTOP_APP_ERROR = 'desktopAppError'
 export const ANALYTICS_NOTIFICATION_PORT_BLOCK_ERROR =
   'notificationPortBlockError'
 


### PR DESCRIPTION
# Overview
remove events to track error because we introduced Sentry to Desktop app and ODD.

related thread
https://opentrons.slack.com/archives/C0A2RD1Q9NJ/p1769615655245709

close RQA-5107

## Test Plan and Hands on Testing

## Changelog
- remove error events

## Review requests


## Risk assessment
low
