### PR TITLE
fix(app): add init to avoid sending error report to sentry

### DIFF
--- a/app/src/redux/analytics/mixpanel.ts
+++ b/app/src/redux/analytics/mixpanel.ts
@@ -48,6 +48,7 @@ export function trackEvent(
 
   log.debug('Trackable event', { event, optedIn })
   if (MIXPANEL_ID != null && optedIn) {
+    initMixpanelInstanceOnce(config)
     try {
       if (event.superProperties != null) {
         mixpanel.register(event.superProperties)


### PR DESCRIPTION
# Overview
add init to avoid sending error report to sentry
the issue is that trackEvent is called before init Sentry instance.

this PR is to fix https://opentrons-76.sentry.io/issues/7223163399/?project=4510008258527232&query=is%3Aunresolved&referrer=issue-stream


close RQA-5101

## Test Plan and Hands on Testing


## Changelog


## Review requests
Is there any easy way to push the build that is including Sentry + Mixpanel token?

## Risk assessment
low
