### PR TITLE
fix(app): fix liquid icon color feeding issue

### DIFF
--- a/app/src/organisms/Desktop/ProtocolVisualization/LabwareSlotContainer/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/LabwareSlotContainer/index.tsx
@@ -179,7 +179,10 @@ export function LabwareSlotContainer(
           </StyledText>
         </div>
         <div className={styles.main_content}>
-          <WellTooltip ingredNames={ingredNames}>
+          <WellTooltip
+            ingredNames={ingredNames}
+            liquidDisplayColors={liquidDisplayColors}
+          >
             {({ makeHandleMouseEnterWell, handleMouseLeaveWell }) => (
               <div className={styles.labware_render_container}>
                 <RobotWorkSpace
@@ -201,7 +204,7 @@ export function LabwareSlotContainer(
                           if (wellContents != null) {
                             makeHandleMouseEnterWell(
                               wellName,
-                              wellContents[wellName]?.ingreds
+                              wellContents[wellName]?.ingreds ?? {}
                             )(event)
                           }
                         }}

--- a/app/src/organisms/Desktop/ProtocolVisualization/SecondWindow/LabwareSlot/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/SecondWindow/LabwareSlot/index.tsx
@@ -246,7 +246,10 @@ export function LabwareSlot(props: LabwareSlotContainerProps): JSX.Element {
           {/* header text part */}
         </div>
         <div className={styles.body_container}>
-          <WellTooltip ingredNames={ingredNames}>
+          <WellTooltip
+            ingredNames={ingredNames}
+            liquidDisplayColors={liquidDisplayColors}
+          >
             {({ makeHandleMouseEnterWell, handleMouseLeaveWell }) => (
               <div className={styles.labware_render_container}>
                 <RobotWorkSpace
@@ -269,7 +272,7 @@ export function LabwareSlot(props: LabwareSlotContainerProps): JSX.Element {
                             if (wellContents != null) {
                               makeHandleMouseEnterWell(
                                 wellName,
-                                wellContents[wellName]?.ingreds
+                                wellContents[wellName]?.ingreds ?? {}
                               )(event)
                             }
                           }}

--- a/app/src/organisms/Desktop/ProtocolVisualization/WellTooltip/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/WellTooltip/index.tsx
@@ -31,6 +31,7 @@ interface WellTooltipParams {
 interface WellTooltipProps {
   children: (wellTooltipParams: WellTooltipParams) => ReactNode
   ingredNames: Record<string, string | null>
+  liquidDisplayColors: Record<string, string>
 }
 
 interface TooltipState {
@@ -51,6 +52,7 @@ const initialTooltipState: TooltipState = {
 export function WellTooltip({
   children,
   ingredNames,
+  liquidDisplayColors,
 }: WellTooltipProps): JSX.Element {
   const { t } = useTranslation('protocol_visualization')
   const [tooltipState, setTooltipState] =
@@ -61,7 +63,7 @@ export function WellTooltip({
     (e: MouseEvent): void => {
       const target = e.currentTarget as HTMLElement
       const { left, top, height, width } = target.getBoundingClientRect()
-      if (Object.keys(wellIngreds).length > 0) {
+      if (wellIngreds != null && Object.keys(wellIngreds).length > 0) {
         setTooltipState({
           tooltipX: left + width / 2,
           tooltipY: top + height / 3,
@@ -90,7 +92,6 @@ export function WellTooltip({
     0
   )
   const hasMultipleIngreds = Object.keys(tooltipWellIngreds ?? {}).length > 1
-  const liquidDisplayColors: Record<string, string> = {}
 
   return (
     <>


### PR DESCRIPTION


# Overview
fix liquid icon color feeding issue

the issues is always `swatchColor` is kicked because liquidDisplayColors is {} then the liquid icon color doesn't match the actual liquid color.


https://github.com/user-attachments/assets/b00eb863-aec5-40e5-af5c-f06dd31c1957



close RQA-5096


## Test Plan and Hands on Testing
- select a protocol
- visualize protocol 
- open a second window to check liquid color in a well

## Changelog


## Review requests


## Risk assessment
low
