### PR TITLE
fix(api): Ensure tiprack lids can be loaded onto tipracks that are sitting on adapters

### DIFF
--- a/api/src/opentrons/protocol_engine/resources/labware_validation.py
+++ b/api/src/opentrons/protocol_engine/resources/labware_validation.py
@@ -22,6 +22,11 @@ def is_lid_stack(load_name: str) -> bool:
     return load_name == "protocol_engine_lid_stack_object"
 
 
+def is_tiprack_lid(load_name: str) -> bool:
+    """Check if a labware object is a tip rack lid."""
+    return load_name == "opentrons_flex_tiprack_lid"
+
+
 def validate_definition_is_labware(definition: LabwareDefinition) -> bool:
     """Validate that one of the definition's allowed roles is `labware`.
 

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -1270,8 +1270,23 @@ class LabwareView:
                     self.get_definition(lw.id)
                 ) and not labware_validation.is_lid_stack(self.get_load_name(lw.id)):
                     stack_without_adapters.append(lw)
+
+            # todo(chb, 2025-01-29): We should refactor how labware stacking and the stackLimit parameter are used so that we do not have to do this special case check.
+            # This is occuring because the stackLimit no longer only means "the limit this labware can stack on itself" and now also means "the limit of a labwares position in a stack".
+            # If this eventually is fixed, we can get rid of this special case for the tiprack lid validation.
+            if labware_validation.is_tiprack_lid(
+                top_labware_definition.parameters.loadName
+            ) and labware_validation.is_tiprack_lid(below_labware.loadName):
+                if len(stack_without_adapters) >= self.get_labware_stacking_maximum(
+                    top_labware_definition
+                ):
+                    raise errors.LabwareCannotBeStackedError(
+                        f"Tip rack lid {top_labware_definition.parameters.loadName} cannot be loaded to stack of more than {self.get_labware_stacking_maximum(top_labware_definition)} labware."
+                    )
             if len(stack_without_adapters) >= self.get_labware_stacking_maximum(
                 top_labware_definition
+            ) and not labware_validation.is_tiprack_lid(
+                top_labware_definition.parameters.loadName
             ):
                 raise errors.LabwareCannotBeStackedError(
                     f"Labware {top_labware_definition.parameters.loadName} cannot be loaded to stack of more than {self.get_labware_stacking_maximum(top_labware_definition)} labware."

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -1277,6 +1277,7 @@ class LabwareView:
             if labware_validation.is_tiprack_lid(
                 top_labware_definition.parameters.loadName
             ) and labware_validation.is_tiprack_lid(below_labware.loadName):
+                # Validate that when attempting to stack a tiprack lid on another tiprack lid we still adhere to the maximum limit
                 if len(stack_without_adapters) >= self.get_labware_stacking_maximum(
                     top_labware_definition
                 ):

--- a/api/tests/opentrons/protocol_engine/state/test_labware_view_old.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_view_old.py
@@ -1727,6 +1727,123 @@ def test_labware_stacking_height_passes_or_raises(
         )
 
 
+def test_tiprack_lid_stacking_height_passes_and_fails() -> None:
+    """It should pass if the tiprack lid is on an adapter tiprack into lid stack-up, and fail if you attempt to stack multiple tiprack lids."""
+    subject = get_labware_view(
+        labware_by_id={
+            "labware-id": LoadedLabware(
+                id="labware-id",
+                loadName="tiprack",
+                definitionUri="def-uri-2",
+                location=OnLabwareLocation(labwareId="adapter-id"),
+            ),
+            "adapter-id": LoadedLabware(
+                id="adapter-id",
+                loadName="tiprack_adapter",
+                definitionUri="def-uri-1",
+                location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
+            ),
+        },
+        definitions_by_uri={
+            "def-uri-1": LabwareDefinition2.model_construct(  # type: ignore[call-arg]
+                allowedRoles=[LabwareRole.adapter],
+                parameters=Parameters2.model_construct(
+                    format="irregular",
+                    isTiprack=False,
+                    loadName="tiprack_adapter",
+                    isMagneticModuleCompatible=False,
+                ),
+                stackLimit=1,
+            ),
+            "def-uri-2": LabwareDefinition2.model_construct(  # type: ignore[call-arg]
+                allowedRoles=[LabwareRole.labware],
+                parameters=Parameters2.model_construct(
+                    format="irregular",
+                    isTiprack=False,
+                    loadName="tiprack",
+                    isMagneticModuleCompatible=False,
+                ),
+                stackLimit=1,
+            ),
+        },
+    )
+
+    result = subject.raise_if_labware_cannot_be_stacked(
+        top_labware_definition=LabwareDefinition2.model_construct(  # type: ignore[call-arg]
+            allowedRoles=[LabwareRole.lid],
+            parameters=Parameters2.model_construct(
+                format="irregular",
+                isTiprack=False,
+                loadName="opentrons_flex_tiprack_lid",
+                isMagneticModuleCompatible=False,
+            ),
+            stackingOffsetWithLabware={"tiprack": Vector3D(x=0, y=0, z=0)},
+            stackLimit=1,
+        ),
+        bottom_labware_id="labware-id",
+    )
+    assert result
+
+
+def test_tiprack_lid_stacking_height_fails() -> None:
+    """It should fail if the tiprack lid is stacked on itself higher than its max stacking height."""
+    subject = get_labware_view(
+        labware_by_id={
+            "lid-id": LoadedLabware(
+                id="lid-id",
+                loadName="opentrons_flex_tiprack_lid",
+                definitionUri="def-uri-1",
+                location=OnLabwareLocation(labwareId="labware-id"),
+            ),
+            "labware-id": LoadedLabware(
+                id="labware-id",
+                loadName="tiprack",
+                definitionUri="def-uri-2",
+                location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
+            ),
+        },
+        definitions_by_uri={
+            "def-uri-1": LabwareDefinition2.model_construct(  # type: ignore[call-arg]
+                allowedRoles=[LabwareRole.lid],
+                parameters=Parameters2.model_construct(
+                    format="irregular",
+                    isTiprack=False,
+                    loadName="opentrons_flex_tiprack_lid",
+                    isMagneticModuleCompatible=False,
+                ),
+                stackLimit=1,
+            ),
+            "def-uri-2": LabwareDefinition2.model_construct(  # type: ignore[call-arg]
+                allowedRoles=[LabwareRole.labware],
+                parameters=Parameters2.model_construct(
+                    format="irregular",
+                    isTiprack=False,
+                    loadName="tiprack",
+                    isMagneticModuleCompatible=False,
+                ),
+                stackLimit=1,
+            ),
+        },
+    )
+    with pytest.raises(errors.LabwareCannotBeStackedError, match="Tip rack lid"):
+        subject.raise_if_labware_cannot_be_stacked(
+            top_labware_definition=LabwareDefinition2.model_construct(  # type: ignore[call-arg]
+                allowedRoles=[LabwareRole.lid],
+                parameters=Parameters2.model_construct(
+                    format="irregular",
+                    isTiprack=False,
+                    loadName="opentrons_flex_tiprack_lid",
+                    isMagneticModuleCompatible=False,
+                ),
+                stackingOffsetWithLabware={
+                    "opentrons_flex_tiprack_lid": Vector3D(x=0, y=0, z=0)
+                },
+                stackLimit=1,
+            ),
+            bottom_labware_id="lid-id",
+        )
+
+
 def test_get_grip_force(
     flex_50uL_tiprack: LabwareDefinition,
     reservoir_def: LabwareDefinition,


### PR DESCRIPTION
# Overview
AUTH-2453

This PR should introduce an exception case for our tiprack lids to allow stacking them on tipracks that are on top of adapters. The existing, kind of incorrect, behavior of our labware stacking is that the stackLimit of a labware definition limits how many of an object can stack on itself, and how high it could stack overall. That second behavior is causing an erroneous check on lids than can only ever stack 1 labware high, in this case just the tiprack lid. For 9.0 the solution should be to special case the tiprack lids to fix the problem mentioned in the ticket. 

In the long term we should fix this by fixing the way stackLimit is used. It should only mean how many of a labware can stack on itself, and there should be an independent value to determine maximum stacking high of "total stacks". This is probably a problem to be solved using locating features, not a myriad of custom parameters. 

## Test Plan and Hands on Testing

- [x] The following code should pass analysis:

```
def run(protocol: protocol_api.ProtocolContext):
    adapter_1 = protocol.load_adapter(
        "opentrons_flex_96_tiprack_adapter",
        location="C2",
        namespace="opentrons",
        version=1,
    )

    # Load Labware:
    tip_rack_1 = adapter_1.load_labware(
        "opentrons_flex_96_filtertiprack_50ul",
        namespace="opentrons",
        version=1,
        lid="opentrons_flex_tiprack_lid",
        lid_namespace="opentrons",
        lid_version=1,
    )
```

## Changelog
Added special exception case for tiprack lids in the labware stack validation logic.

## Review requests
Should we instead refactor the core logic at the root of this problem, or is that too high of a risk this close to 9.0?

## Risk assessment
Low, fixes validation for a single specific "special" labware.