### PR TITLE
fix(api): don't change the useless behavior of ramp rate on pre-2.28 api

### DIFF
--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -716,6 +716,10 @@ class ThermocyclerContext(ModuleContext):
         )
         if self._api_version >= APIVersion(2, 27) and block_max_volume is None:
             block_max_volume = self._get_current_labware_max_vol()
+        if self._api_version < APIVersion(2, 28) and ramp_rate:
+            # because the argument was always there but didn't work, continue to swallow this arg on
+            # old api versions.
+            ramp_rate = None
         self._core.set_target_block_temperature(
             celsius=temperature,
             hold_time_seconds=seconds,
@@ -752,6 +756,10 @@ class ThermocyclerContext(ModuleContext):
 
         if block_max_volume is None:
             block_max_volume = self._get_current_labware_max_vol()
+        if self._api_version < APIVersion(2, 28) and ramp_rate:
+            # because the argument was always there but didn't work, continue to swallow this arg on
+            # old api versions.
+            ramp_rate = None
         task = self._core.start_set_target_block_temperature(
             celsius=temperature,
             block_max_volume=block_max_volume,

--- a/api/tests/opentrons/protocol_api/test_thermocycler_context.py
+++ b/api/tests/opentrons/protocol_api/test_thermocycler_context.py
@@ -792,7 +792,7 @@ def test_ramp_rate_(
     this_api_version: APIVersion,
     ramp_rate: Optional[float],
 ) -> None:
-    """It should delete the ramp rate argument on pre 2.18 versions."""
+    """It should delete the ramp rate argument on pre 2.28 versions."""
     subject._api_version = this_api_version
     decoy.when(
         mock_validation.ensure_hold_time_seconds(seconds=None, minutes=None)

--- a/api/tests/opentrons/protocol_api/test_thermocycler_context.py
+++ b/api/tests/opentrons/protocol_api/test_thermocycler_context.py
@@ -1,6 +1,7 @@
 """Tests for Protocol API thermocycler module contexts."""
 
 import inspect
+from typing import Optional
 
 import pytest
 from decoy import Decoy, matchers
@@ -777,6 +778,35 @@ def test_deactivate(
             "command",
             matchers.DictMatching({"$": "after"}),
         ),
+    )
+
+
+@pytest.mark.parametrize(
+    "this_api_version,ramp_rate", [(APIVersion(2, 27), None), (APIVersion(2, 28), 3.0)]
+)
+def test_ramp_rate_(
+    decoy: Decoy,
+    mock_protocol_core: ProtocolCore,
+    mock_core: ThermocyclerCore,
+    subject: ThermocyclerContext,
+    this_api_version: APIVersion,
+    ramp_rate: Optional[float],
+) -> None:
+    """It should delete the ramp rate argument on pre 2.18 versions."""
+    subject._api_version = this_api_version
+    decoy.when(
+        mock_validation.ensure_hold_time_seconds(seconds=None, minutes=None)
+    ).then_return(0)
+    decoy.when(subject._get_current_labware_max_vol()).then_return(None)
+    subject.set_block_temperature(temperature=100, ramp_rate=3.0)
+
+    decoy.verify(
+        mock_core.set_target_block_temperature(
+            celsius=100,
+            hold_time_seconds=0,
+            block_max_volume=None,
+            ramp_rate=ramp_rate,
+        )
     )
 
 


### PR DESCRIPTION
# Overview
Previous to the 2.28 api ramp rate was an optional argument in the python api. however it simply did not do anything. 

With the update to 2.28 on version 9.0.0 the ramp rate DOES work. In order to not break old protocols by either changing the behavior of the thermocycler or suddenly failing because they had an invalid ramp rate that wasn't getting checked before we will just swallow that argument in pre-2.28 protocols.