### PR TITLE
fix(docs): correct macOS version number

### DIFF
--- a/docs/flex/docs/opentrons-app/install.md
+++ b/docs/flex/docs/opentrons-app/install.md
@@ -6,7 +6,7 @@ Start here for step-by-step instructions for downloading, installing, and mainta
 
 ## App installation
 
-Download the Opentrons App from <https://opentrons.com/ot-app/>. The latest version of the app requires Windows 10, macOS 10.16, or Ubuntu 20.04 or later. The app may run on other Linux distributions, but Opentrons does not officially support them.
+Download the Opentrons App from <https://opentrons.com/ot-app/>. The latest version of the app requires Windows 10, macOS 11, or Ubuntu 20.04 or later. The app may run on other Linux distributions, but Opentrons does not officially support them.
 
 ### Windows
 

--- a/docs/flex/docs/system-description/specs.md
+++ b/docs/flex/docs/system-description/specs.md
@@ -22,7 +22,7 @@ title: "Opentrons Flex: System Specifications"
 | **Frame composition**    | Rigid steel and CNC aluminum design |
 | **Window composition**   | Removable polycarbonate side windows and front door |
 | **Ventilation requirements** | At least 20 cm / 8 in between the unit and a wall |
-| **Connected PC requirements** | The latest version of the Opentrons App runs on: <ul><li>Windows 10 or later</li><li>macOS 10.16 or later</li><li>Ubuntu 20.04 or later</li></ul> |
+| **Connected PC requirements** | The latest version of the Opentrons App runs on: <ul><li>Windows 10 or later</li><li>macOS 11 or later</li><li>Ubuntu 20.04 or later</li></ul> |
 
 ## Environmental specifications
 


### PR DESCRIPTION
# Overview

macOS 10.16 does not exist. It became macOS 11 Big Sur. Thanks, crack marketing team.

## Test Plan and Hands on Testing

🌊 

## Changelog

2 lines

## Review requests

should we include the California location lol

## Risk assessment

nope