### PR TITLE
fix(app,app-shell): close secondary window automatically when app is crashing

### DIFF
--- a/app-shell/src/main.ts
+++ b/app-shell/src/main.ts
@@ -184,6 +184,13 @@ function startUp(): void {
 
   initializeMenu()
 
+  ipcMain.on('secondary-window:close-self', event => {
+    const senderWindow = BrowserWindow.fromWebContents(event.sender)
+    if (senderWindow != null && !senderWindow.isDestroyed()) {
+      senderWindow.close()
+    }
+  })
+
   ipcMain.on('dispatch', (event, action) => {
     log.debug('Received action via IPC from renderer', { action })
 

--- a/app-shell/src/preload.ts
+++ b/app-shell/src/preload.ts
@@ -48,4 +48,9 @@ contextBridge.exposeInMainWorld('electron', {
       ipcRenderer.once(channel, listener)
     },
   },
+  secondaryWindow: {
+    closeSelf: () => {
+      ipcRenderer.send('secondary-window: close-self')
+    },
+  },
 })

--- a/app/src/App/SecondaryWindowApp.tsx
+++ b/app/src/App/SecondaryWindowApp.tsx
@@ -21,7 +21,7 @@ import { useRobot } from '/app/redux-resources/robots'
 import { OPENTRONS_USB } from '/app/redux/discovery'
 import { appShellRequestor } from '/app/redux/shell/remote'
 
-import { DesktopAppFallback } from './DesktopAppFallback'
+import { SecondaryWindowAppFallback } from './SecondaryWindowAppFallback'
 import { ReactQueryDevtools } from './tools'
 
 import type { ReactNode } from 'react'
@@ -49,7 +49,7 @@ export const SecondaryWindowApp = (): JSX.Element => {
 
   return (
     <LocalizationProvider>
-      <ErrorBoundary FallbackComponent={DesktopAppFallback}>
+      <ErrorBoundary FallbackComponent={SecondaryWindowAppFallback}>
         <ReactQueryDevtools />
         <Box width="100%">
           <Routes>

--- a/app/src/App/SecondaryWindowAppFallback.tsx
+++ b/app/src/App/SecondaryWindowAppFallback.tsx
@@ -5,14 +5,6 @@ import { remote } from '/app/redux/shell/remote'
 
 import type { FallbackProps } from 'react-error-boundary'
 
-declare global {
-  interface Window {
-    secondaryApi?: {
-      closeSelf?: () => void | Promise<void>
-    }
-  }
-}
-
 export function SecondaryWindowAppFallback({
   error,
 }: FallbackProps): JSX.Element | null {

--- a/app/src/App/SecondaryWindowAppFallback.tsx
+++ b/app/src/App/SecondaryWindowAppFallback.tsx
@@ -1,0 +1,27 @@
+import { useEffect } from 'react'
+
+import { useSentryReport } from '/app/App/hooks'
+import { remote } from '/app/redux/shell/remote'
+
+import type { FallbackProps } from 'react-error-boundary'
+
+declare global {
+  interface Window {
+    secondaryApi?: {
+      closeSelf?: () => void | Promise<void>
+    }
+  }
+}
+
+export function SecondaryWindowAppFallback({
+  error,
+}: FallbackProps): JSX.Element | null {
+  useSentryReport(error)
+
+  useEffect(() => {
+    // close the Window
+    remote.ipcRenderer.send('secondary-window:close-self')
+  }, [])
+
+  return null
+}


### PR DESCRIPTION
# Overview
close secondary window automatically when app is crashing


https://github.com/user-attachments/assets/7ee7ea13-e0e3-43a7-aeee-218417633752



close RQA-5118

## Test Plan and Hands on Testing
- open spotlight window and crash the app

## Changelog
- add self-close to Electron side
- add error boundary for secondary window

## Review requests

- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.

## Risk assessment
low
