### PR TITLE
fix(app): filter out load commands from count in PV

### DIFF
--- a/app/src/organisms/Desktop/ProtocolVisualization/DeckView/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/DeckView/index.tsx
@@ -67,6 +67,8 @@ interface DeckViewProps {
   robotType: RobotType
   setSelectedSlot: Dispatch<SetStateAction<string | null>>
   liquids: Liquid[]
+  // filtered commands means we are filtering out the load commands
+  filteredCommands: RunTimeCommand[]
   selectedRunTimeCommand?: RunTimeCommand
 }
 
@@ -83,6 +85,7 @@ export function DeckView(props: DeckViewProps): JSX.Element {
     selectedRunTimeCommand,
     liquids,
     commands,
+    filteredCommands,
   } = props
   const { t } = useTranslation('protocol_visualization')
   const [hoveredSlot, setHoveredSlot] = useState<string | null>(null)
@@ -141,7 +144,9 @@ export function DeckView(props: DeckViewProps): JSX.Element {
 
   const selectedCommandIndex =
     selectedRunTimeCommand != null
-      ? commands.findIndex(command => command.id === selectedRunTimeCommand.id)
+      ? filteredCommands.findIndex(
+          command => command.id === selectedRunTimeCommand.id
+        )
       : 0
 
   return (

--- a/app/src/organisms/Desktop/ProtocolVisualization/VisualizerContainer/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/VisualizerContainer/index.tsx
@@ -340,6 +340,7 @@ export function VisualizerContainer(
           setMilliSecondsPerFrame={setMilliSecondsPerFrame}
         />
         <DeckView
+          filteredCommands={filteredCommands}
           commands={analysis.commands}
           liquids={liquids}
           invariantContext={invariantContext}


### PR DESCRIPTION
closes AUTH-2705 AUTH-2698

# Overview

we weren't filtering out the load commands in the count that is displayed on the deck view

## Test Plan and Hands on Testing

Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.

## Changelog

filter out the load commands in the count display in the deck view

## Risk assessment

low