### PR TITLE
fix(app): wire up module spotlight for startRUnExtendedProfile

### DIFF
--- a/app/src/organisms/Desktop/ProtocolVisualization/ModuleContainer/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/ModuleContainer/index.tsx
@@ -47,8 +47,17 @@ export function ModuleContainer({
           })
           break
         case 'profile':
-          // todo(mm, 2025-12-12): As a placeholder, this is showing the block as 'deactivated' when there's a profile ongoing.
-          blockTemperatureText = t('deactivated')
+          const profileElements = currentBlockActivity.profileElements
+          const lastElement = profileElements[profileElements.length - 1]
+
+          const endingTemp =
+            'celsius' in lastElement
+              ? lastElement.celsius
+              : lastElement.steps[lastElement.steps.length - 1]?.celsius
+
+          blockTemperatureText = t('temperature', {
+            temp: endingTemp,
+          })
           break
         case 'blockDeactivated':
           blockTemperatureText = t('idle')


### PR DESCRIPTION
closes AUTH-2639

# Overview

wire up showing the final celsius hold if the step is a thermocycler `thermocycler/startRunExtendedProfile`

## Test Plan and Hands on Testing

so this is hard to smoke test since the example protocol in the ticket is for the ot-2 and you can't access PV on an ot-2 right now... but i think its fine, it should match what `blockTargetTemp` shows with the same i18n string

## Changelog

get the ending temp and display it

## Risk assessment

low
