### PR TITLE
fix(app): not to infinity, only to 100 for PV

### DIFF
--- a/app/src/organisms/Desktop/ProtocolVisualization/VisualizerContainer/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/VisualizerContainer/index.tsx
@@ -190,7 +190,7 @@ export function VisualizerContainer(
     srcFileNames,
     analysisOutput
   )
-  const clamp = (n: number, min: number, max: number) =>
+  const clamp = (n: number, min: number, max: number): number =>
     Math.min(max, Math.max(min, n))
   let percentComplete = 0
 

--- a/app/src/organisms/Desktop/ProtocolVisualization/VisualizerContainer/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/VisualizerContainer/index.tsx
@@ -190,10 +190,21 @@ export function VisualizerContainer(
     srcFileNames,
     analysisOutput
   )
-  const percentComplete =
-    filteredSelectedCommandIndex != null
-      ? (filteredSelectedCommandIndex / filteredCommands.length) * 100
-      : 0
+  const clamp = (n: number, min: number, max: number) =>
+    Math.min(max, Math.max(min, n))
+  let percentComplete = 0
+
+  if (filteredSelectedCommandIndex == null) {
+    percentComplete = 0
+  } else if (filteredCommands.length <= 1) {
+    percentComplete = 100
+  } else {
+    percentComplete = clamp(
+      (filteredSelectedCommandIndex / (filteredCommands.length - 1)) * 100,
+      0,
+      100
+    )
+  }
 
   const thermocyclerSlots = ['A1', '8', '10', '11']
 


### PR DESCRIPTION
AUTH-2429

# Overview

don't show infinity% when there are only load commands - instead should show 100%. also some other tweaking with the percentages so that it always ends on 100% and always starts at 0%.

## Test Plan and Hands on Testing

import a protocol with only load commands and see that the percentage says 100% instead of infinity%

## Changelog

add a clamp and then the percent complete depending on the length of filtered commands and if filtered selected command is selected

## Risk assessment

low
