### PR TITLE
fix(step-generation): set entityId in forAspirate fn

### DIFF
--- a/step-generation/src/getNextRobotStateAndWarnings/forAspirate.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/forAspirate.ts
@@ -31,7 +31,6 @@ export function forAspirate(
       ? params.labwareId
       : (robotState.pipettes[pipetteId].entityId ?? '')
 
-  console.log('labwareId', labwareId)
   const wellName =
     'wellName' in params
       ? params.wellName

--- a/step-generation/src/getNextRobotStateAndWarnings/forAspirate.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/forAspirate.ts
@@ -30,6 +30,8 @@ export function forAspirate(
     'labwareId' in params
       ? params.labwareId
       : (robotState.pipettes[pipetteId].entityId ?? '')
+
+  console.log('labwareId', labwareId)
   const wellName =
     'wellName' in params
       ? params.wellName
@@ -178,4 +180,13 @@ export function forAspirate(
       labwareLiquidState[well]
     ).source
   })
+
+  // if entityId was not set by a previous "moveToWell" command
+  if ('labwareId' in params) {
+    robotState.pipettes[pipetteId] = {
+      ...robotState.pipettes[pipetteId],
+      entityId: params.labwareId,
+      wellName,
+    }
+  }
 }


### PR DESCRIPTION
closes AUTH-2590

# Overview

Ok so the issue is that for protocols made from PD, we use transfer_with_liquid_class meaning that there are a bunch of `moveTowell` commands before the aspirate/dispense commands so the entityId for the entity under the pipette was never set.

Since the other combo of commands is just `aspirate`/`dispense` without the `moveToWell` before hand, the entityId under the pipette was never getting set.

so this PR fixes that

## Test Plan and Hands on Testing

upload the attached protocol in the ticket and see that the well information properly shows up in PV when you are on an aspirate or dispense command

## Changelog

set the entityId and wellName info if `labwareId` is in the params - meaning it is coming from the aspirate command rather than the previous `moveToWell` followed by `aspirateInPlace` command

## Risk assessment

low
