### PR TITLE
fix(protocol-designer): fix migrated labware ID logic

### DIFF
--- a/e2e-testing/tests/pd/test_pd_mix_step.py
+++ b/e2e-testing/tests/pd/test_pd_mix_step.py
@@ -39,9 +39,6 @@ def test_mix_step_configuration_workflow(page: Page, base_url: str) -> None:
         "Pipette",
         "Tiprack",
         "Labware",
-        "Select wells",
-        "Volume per well",
-        "Mix repetitions",
     ]:
         mix_form.expect_text(label)
 
@@ -49,6 +46,14 @@ def test_mix_step_configuration_workflow(page: Page, base_url: str) -> None:
     mix_form.select_tiprack(TIPRACK_OPTION)
 
     mix_form.select_labware(LABWARE_OPTION)
+
+    for label in [
+        "Select wells",
+        "Volume per well",
+        "Mix repetitions",
+    ]:
+        mix_form.expect_text(label)
+
     mix_form.open_well_selector()
     mix_form.expect_well_selector_modal()
     mix_form.select_wells(["A1", "A2"])

--- a/protocol-designer/src/labware-ingred/__tests__/utils.test.ts
+++ b/protocol-designer/src/labware-ingred/__tests__/utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { getNextNickname } from '../utils'
+import { getMigratedLabwareId, getNextNickname } from '../utils'
 
 describe('getNextNickname', () => {
   const testCases = [
@@ -64,5 +64,13 @@ describe('getNextNickname', () => {
       const result = getNextNickname(allNicknames, proposed)
       expect(result).toEqual(expected)
     })
+  })
+})
+
+describe('getMigratedLabwareId', () => {
+  it('should return the same labware id for additional equipment wasteChute', () => {
+    const labwareId = '123:wasteChute'
+    const result = getMigratedLabwareId(labwareId, {}, {}, {})
+    expect(result).toEqual(labwareId)
   })
 })

--- a/protocol-designer/src/labware-ingred/utils.ts
+++ b/protocol-designer/src/labware-ingred/utils.ts
@@ -139,7 +139,8 @@ export function getNextNickname(
 const ADDITIONAL_EQUIPMENT_TYPES = ['wasteChute', 'trashBin']
 
 export const getMigratedLabwareId = (
-  oldLabwareId: string,
+  // labware or trash-like entity ID
+  oldEntityId: string,
   labware: Labware,
   allLabwareDefs: Record<string, LabwareDefinition2>,
   latestDefs: LabwareDefByDefURI
@@ -147,13 +148,13 @@ export const getMigratedLabwareId = (
   // Check if this is an additional equipment ID (e.g., waste chute, trash bin)
   // These are stored in additionalEquipmentOnDeck, not in labware, so return unchanged
   const isAdditionalEquipment = ADDITIONAL_EQUIPMENT_TYPES.some(type =>
-    oldLabwareId.includes(type)
+    oldEntityId.includes(type)
   )
   if (isAdditionalEquipment) {
-    return oldLabwareId
+    return oldEntityId
   }
 
-  const defURI = labware[oldLabwareId]?.labwareDefURI
+  const defURI = labware[oldEntityId]?.labwareDefURI
   const loadName = allLabwareDefs[defURI]?.parameters.loadName
   const latestURI = Object.entries(latestDefs).find(
     ([_, def]) => def.parameters.loadName === loadName
@@ -161,11 +162,11 @@ export const getMigratedLabwareId = (
 
   if (defURI == null) {
     console.error(
-      `expected to find a matching defURI with labwareId ${oldLabwareId} but could not`
+      `expected to find a matching defURI with labwareId ${oldEntityId} but could not`
     )
   }
 
-  const labwareIdString = oldLabwareId.split(':')[0]
+  const labwareIdString = oldEntityId.split(':')[0]
   const latestLabwareId =
     latestURI != null
       ? `${labwareIdString}:${latestURI}`

--- a/protocol-designer/src/labware-ingred/utils.ts
+++ b/protocol-designer/src/labware-ingred/utils.ts
@@ -134,12 +134,25 @@ export function getNextNickname(
     : proposedNickname
 }
 
+// Additional equipment types that are not stored in the labware object
+// and should not be migrated
+const ADDITIONAL_EQUIPMENT_TYPES = ['wasteChute', 'trashBin']
+
 export const getMigratedLabwareId = (
   oldLabwareId: string,
   labware: Labware,
   allLabwareDefs: Record<string, LabwareDefinition2>,
   latestDefs: LabwareDefByDefURI
 ): string => {
+  // Check if this is an additional equipment ID (e.g., waste chute, trash bin)
+  // These are stored in additionalEquipmentOnDeck, not in labware, so return unchanged
+  const isAdditionalEquipment = ADDITIONAL_EQUIPMENT_TYPES.some(type =>
+    oldLabwareId.includes(type)
+  )
+  if (isAdditionalEquipment) {
+    return oldLabwareId
+  }
+
   const defURI = labware[oldLabwareId]?.labwareDefURI
   const loadName = allLabwareDefs[defURI]?.parameters.loadName
   const latestURI = Object.entries(latestDefs).find(


### PR DESCRIPTION
# Overview

If the "labware ID" for a step form was a waste chute or a trash bin (this bug encountered the issue when the dispense locatin was a waste chute, for example), we should return the raw entity ID in the `getMigratedLabwareId` utility.

Closes RQA-5119

## Test Plan and Hands on Testing

- import the protocol attached to the ticket
- verify that no timeline errors appear
- inspect one of the transfer steps (step 2, for example)
- verify that the waste chute is pre-populated as the destination labware field value

## Changelog

- skip past migrated labware ID logic for waste chute/trash bin
- add unit test

## Review requests

see test plan

## Risk assessment

low