### PR TITLE
fix(app): fix decklabel rendering position issue

### DIFF
--- a/app/src/organisms/Desktop/ProtocolVisualization/DeckView/DeckViewDetails.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/DeckView/DeckViewDetails.tsx
@@ -3,6 +3,7 @@ import { FLEX_ROBOT_TYPE } from '@opentrons/shared-data'
 import { getFixtureSummaryInfo } from '../utils/getFixtureSummaryInfo'
 import { getSlotIdsBlockedBySpanningForThermocycler } from '../utils/getSlotIdsBlockedBySpanningForThermocycler'
 import { DeckViewLabware } from './DeckViewLabware'
+import { DeckViewLabwareCommandSummaries } from './DeckViewLabwareCommandSummaries'
 import { DeckViewModuleCommandSummaries } from './DeckViewModuleCommandSummaries'
 import { DeckViewModules } from './DeckViewModules'
 import { DeckViewSlots } from './DeckViewSlots'
@@ -143,6 +144,13 @@ export function DeckViewDetails(props: DeckViewDetailsProps): JSX.Element {
         invariantContext={invariantContext}
         deckDef={deckDef}
         robotType={robotType}
+        selectedRunTimeCommand={selectedRunTimeCommand}
+      />
+      <DeckViewLabwareCommandSummaries
+        robotState={robotState}
+        invariantContext={invariantContext}
+        deckDef={deckDef}
+        labwareEntitiesExtended={labwareEntitiesExtended}
         selectedRunTimeCommand={selectedRunTimeCommand}
       />
     </>

--- a/app/src/organisms/Desktop/ProtocolVisualization/DeckView/DeckViewLabwareCommandSummaries.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/DeckView/DeckViewLabwareCommandSummaries.tsx
@@ -1,0 +1,80 @@
+import {
+  getModuleDef,
+  getModuleParentOriginToChildSlotOrigin,
+  getPositionFromSlotId,
+} from '@opentrons/shared-data'
+
+import { getTopmostLabwareOnModuleFromStack } from '../utils/getTopmostLabwareOnModuleFromStack'
+import { LabwareCommandSummary } from './LabwareCommandSummary'
+
+import type { DeckDefinition, RunTimeCommand } from '@opentrons/shared-data'
+import type { InvariantContext, RobotState } from '@opentrons/step-generation'
+import type { LabwareEntityExtended } from '../../../../organisms/Desktop/ProtocolVisualization/DeckView'
+
+interface DeckViewLabwareCommandSummariesProps {
+  robotState: RobotState
+  invariantContext: InvariantContext
+  deckDef: DeckDefinition
+  labwareEntitiesExtended: Record<string, LabwareEntityExtended>
+  selectedRunTimeCommand?: RunTimeCommand
+}
+
+export function DeckViewLabwareCommandSummaries(
+  props: DeckViewLabwareCommandSummariesProps
+): JSX.Element {
+  const {
+    robotState,
+    invariantContext,
+    deckDef,
+    labwareEntitiesExtended,
+    selectedRunTimeCommand,
+  } = props
+  const { moduleEntities } = invariantContext
+  const { modules, labware } = robotState
+
+  return (
+    <>
+      {Object.entries(modules).map(([id, { slot }]) => {
+        const isStepAssociatedWithModule =
+          selectedRunTimeCommand != null &&
+          'moduleId' in selectedRunTimeCommand.params &&
+          selectedRunTimeCommand.params.moduleId === id
+        if (!isStepAssociatedWithModule) return null
+
+        const labwareLoadedOnModuleId = getTopmostLabwareOnModuleFromStack(
+          id,
+          Object.values(labware)
+        )
+        if (labwareLoadedOnModuleId == null) return null
+
+        const slotPosition = getPositionFromSlotId(slot, deckDef)
+        if (slotPosition == null) {
+          console.warn(`no slot ${slot} for module ${id}`)
+          return null
+        }
+
+        const moduleDef = getModuleDef(moduleEntities[id].model)
+        const childSlotOffset = getModuleParentOriginToChildSlotOrigin(
+          deckDef.otId,
+          slot,
+          moduleDef
+        )
+        const childSlotPosition: [number, number, number] = [
+          slotPosition[0] + childSlotOffset.x,
+          slotPosition[1] + childSlotOffset.y,
+          slotPosition[2] + childSlotOffset.z,
+        ]
+
+        return (
+          <LabwareCommandSummary
+            key={`labware_command_summary_${id}`}
+            commandType={selectedRunTimeCommand.commandType}
+            position={childSlotPosition}
+            labwareDef={labwareEntitiesExtended[labwareLoadedOnModuleId].def}
+            showModuleIcon={false}
+          />
+        )
+      })}
+    </>
+  )
+}

--- a/app/src/organisms/Desktop/ProtocolVisualization/DeckView/DeckViewStacker.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/DeckView/DeckViewStacker.tsx
@@ -5,12 +5,10 @@ import {
 } from '@opentrons/components'
 import {
   FLEX_STACKER_MODULE_TYPE,
-  getModuleParentOriginToChildSlotOrigin,
   THERMOCYCLER_MODULE_TYPE,
 } from '@opentrons/shared-data'
 
 import { DeckViewOverlay } from './DeckViewOverlay'
-import { LabwareCommandSummary } from './LabwareCommandSummary'
 import { LabwareOnDeck } from './LabwareOnDeck'
 
 import type { Dispatch, SetStateAction } from 'react'
@@ -41,10 +39,10 @@ interface DeckViewStackerProps {
   hoveredSlot: string | null
   showModuleCommandSummary: boolean
   showLabwareCommandSummary: boolean
-  moduleType: ModuleType
   slot: string
   slotPosition: CoordinateTuple
   moduleDef: ModuleDefinition
+  moduleType: ModuleType
   labwareLoadedOnModuleId: string
   selectedRunTimeCommand?: RunTimeCommand
 }
@@ -65,22 +63,10 @@ export function DeckViewStacker(props: DeckViewStackerProps): JSX.Element {
     moduleDef,
     selectedRunTimeCommand,
     slot,
-    slotPosition,
     moduleType,
 
     labwareLoadedOnModuleId,
   } = props
-  const childSlotOffset = getModuleParentOriginToChildSlotOrigin(
-    deckDef.otId,
-    slot,
-    moduleDef
-  )
-  const childSlotPosition: CoordinateTuple = [
-    slotPosition[0] + childSlotOffset.x,
-    slotPosition[1] + childSlotOffset.y,
-    slotPosition[2] + childSlotOffset.z,
-  ]
-
   return (
     <>
       <CenterLabwareInModuleChildSlot
@@ -158,14 +144,6 @@ export function DeckViewStacker(props: DeckViewStackerProps): JSX.Element {
           )}
         </DeckViewOverlay>
       )}
-      {showLabwareCommandSummary && selectedRunTimeCommand != null ? (
-        <LabwareCommandSummary
-          commandType={selectedRunTimeCommand.commandType}
-          position={childSlotPosition}
-          labwareDef={labwareEntitiesExtended[labwareLoadedOnModuleId].def}
-          showModuleIcon={false}
-        />
-      ) : null}
     </>
   )
 }

--- a/app/src/organisms/Desktop/ProtocolVisualization/DeckView/LabwareCommandSummary.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/DeckView/LabwareCommandSummary.tsx
@@ -22,9 +22,9 @@ interface LabwareCommandSummaryProps {
   showModuleIcon: boolean
   commandType: RunTimeCommand['commandType']
 }
-export const LabwareCommandSummary = (
+export function LabwareCommandSummary(
   props: LabwareCommandSummaryProps
-): JSX.Element => {
+): JSX.Element {
   const { labwareDef, position, showModuleIcon, commandType } = props
   const labelContainerRef = useRef<HTMLDivElement>(null)
   const [labelContainerHeight, setLabelContainerHeight] = useState(0)
@@ -39,7 +39,7 @@ export const LabwareCommandSummary = (
   ]
 
   useEffect(() => {
-    if (labelContainerRef.current) {
+    if (labelContainerRef.current != null) {
       setLabelContainerHeight(labelContainerRef.current.offsetHeight)
     }
   }, [])

--- a/app/src/organisms/Desktop/ProtocolVisualization/SlotDetails/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/SlotDetails/index.tsx
@@ -26,15 +26,21 @@ import type {
 
 interface SlotDetailsProps {
   slotId: string
-  command: RunTimeCommand
+  currentCommand: RunTimeCommand
   robotState: RobotState
   invariantContext: InvariantContext
   analysis: ProtocolAnalysisOutput
   liquids: Liquid[]
 }
 export function SlotDetails(props: SlotDetailsProps): JSX.Element {
-  const { slotId, command, robotState, invariantContext, analysis, liquids } =
-    props
+  const {
+    slotId,
+    currentCommand,
+    robotState,
+    invariantContext,
+    analysis,
+    liquids,
+  } = props
   const { labware, modules } = robotState
   const {
     labwareEntities,
@@ -98,7 +104,7 @@ export function SlotDetails(props: SlotDetailsProps): JSX.Element {
             topLabwareOnSlotId={topMostLabwareOnSlot}
             labwareEntities={labwareEntities}
             commands={commands}
-            currentCommand={command}
+            currentCommand={currentCommand}
             liquids={liquids}
             robotState={robotState}
             pipetteEntities={pipetteEntities}

--- a/app/src/pages/Desktop/StepDetailViewer/index.tsx
+++ b/app/src/pages/Desktop/StepDetailViewer/index.tsx
@@ -81,13 +81,11 @@ export function StepDetailViewer(): JSX.Element {
   if (data === null) {
     return <div>no data found</div>
   }
-  const { slot, command, robotState, invariantContext, analysis, liquids } =
-    data
+  const { slot, robotState, invariantContext, analysis, liquids } = data
 
   return (
     <SlotDetails
       slotId={slot}
-      currentCommand={command}
       robotState={robotState}
       invariantContext={invariantContext}
       analysis={analysis}

--- a/app/src/pages/Desktop/StepDetailViewer/index.tsx
+++ b/app/src/pages/Desktop/StepDetailViewer/index.tsx
@@ -55,12 +55,12 @@ export function StepDetailViewer(): JSX.Element {
     }
 
     // initial fetch
-    fetchData()
+    void fetchData()
 
     // listen for updates
     const listener = (_event: unknown, updatedKey: string): void => {
       if (updatedKey === protocolKey) {
-        fetchData()
+        void fetchData()
       }
     }
 
@@ -78,7 +78,7 @@ export function StepDetailViewer(): JSX.Element {
   if (loading) {
     return <SkeletonForSlotDetail />
   }
-  if (!data) {
+  if (data === null) {
     return <div>no data found</div>
   }
   const { slot, command, robotState, invariantContext, analysis, liquids } =
@@ -87,7 +87,7 @@ export function StepDetailViewer(): JSX.Element {
   return (
     <SlotDetails
       slotId={slot}
-      command={command}
+      currentCommand={command}
       robotState={robotState}
       invariantContext={invariantContext}
       analysis={analysis}


### PR DESCRIPTION

# Overview
a label uses cornerOffsetFromSlot to decide the render position and switch the way to what a labware does.
add a new component to render the label on the top layer of the deck view.

<img width="942" height="754" alt="Screenshot 2026-02-02 at 7 06 19 PM" src="https://github.com/user-attachments/assets/a23953b9-e8cb-4dc6-bc63-73f68b11060a" />


close RQA-5121

## Test Plan and Hands on Testing
- import the protocol that is attached to the ticket
- visualize the protocol
- play the protocol

## Changelog
- update 

## Review requests

## Risk assessment
low