### PR TITLE
refactor(system-server): Minor test cleanup

### DIFF
--- a/system-server/pyproject.toml
+++ b/system-server/pyproject.toml
@@ -78,7 +78,7 @@ build-backend = 'hatchling.build'
 select = ["E", "F", "ANN", "D", "C90", "I", "T201"]
 ignore = ["E203", "E501", "E741", "ANN401", "D107", "D402", "D418"]
 [tool.ruff.lint.per-file-ignores]
-"tests/*" = ["ANN","D","T201"]
+"tests/*" = ["D", "T201"]
 "system_server/_version.py" = ["I"]
 
 [tool.ruff.lint.pydocstyle]
@@ -136,7 +136,6 @@ dependency-metadata = [
 [tool.pytest]
 addopts = ["--cov=system_server", "--cov-report", "term-missing:skip-covered", "--cov-report", "xml:coverage.xml", "--color=yes", "--strict-markers"]
 asyncio_mode = "auto"
-tavern-global-cfg = ["tests/integration/common.yaml"]
 filterwarnings = [
     "error::pydantic.PydanticDeprecatedSince20",
 ]

--- a/system-server/tests/dev_server.py
+++ b/system-server/tests/dev_server.py
@@ -70,6 +70,10 @@ class DevServer:
         )
 
     def stop(self) -> None:
-        """Stop the robot server."""
+        """Stop the server and wait for it to clean up."""
         self.proc.send_signal(signal.SIGTERM)
         self.proc.wait()
+
+    @property
+    def base_url(self) -> str:
+        return f"http://localhost:{self.port}"

--- a/system-server/tests/integration/common.yaml
+++ b/system-server/tests/integration/common.yaml
@@ -1,7 +1,0 @@
-# Each file should have a name and description
-name: Common test information
-description: Variables and other info used across tests
-
-variables:
-  host: http://localhost
-  port: 32950

--- a/system-server/tests/integration/test_oem_mode.tavern.yaml
+++ b/system-server/tests/integration/test_oem_mode.tavern.yaml
@@ -6,7 +6,7 @@ marks:
 stages:
   - name: PUT first request
     request: &enable_oem_mode_first
-      url: '{host:s}:{run_server.port:d}/system/oem_mode/enable'
+      url: '{run_server.base_url}/system/oem_mode/enable'
       json:
         enable: true
       method: PUT
@@ -16,7 +16,7 @@ stages:
       status_code: 200
   - name: PUT second request
     request: &enable_oem_mode_second
-      url: '{host:s}:{run_server.port:d}/system/oem_mode/enable'
+      url: '{run_server.base_url}/system/oem_mode/enable'
       json:
         enable: false
       method: PUT
@@ -26,7 +26,7 @@ stages:
       status_code: 200
   - name: PUT third request
     request: &enable_oem_mode_third
-      url: '{host:s}:{run_server.port:d}/system/oem_mode/enable'
+      url: '{run_server.base_url}/system/oem_mode/enable'
       json:
         wrong_key: false
       method: PUT
@@ -43,13 +43,13 @@ marks:
 stages:
   - name: Enable OEM Mode
     request:
-      url: '{host:s}:{run_server.port:d}/system/oem_mode/enable'
+      url: '{run_server.base_url}/system/oem_mode/enable'
       method: PUT
       json:
         'enable': true
   - name: Upload PNG Image
     request: &upload_splash_first
-      url: '{host:s}:{run_server.port:d}/system/oem_mode/upload_splash'
+      url: '{run_server.base_url}/system/oem_mode/upload_splash'
       method: POST
       files:
         file: 'tests/integration/resources/oem_mode_custom.png'
@@ -66,13 +66,13 @@ marks:
 stages:
   - name: Disable OEM Mode
     request:
-      url: '{host:s}:{run_server.port:d}/system/oem_mode/enable'
+      url: '{run_server.base_url}/system/oem_mode/enable'
       method: PUT
       json:
         'enable': false
   - name: Upload PNG Image
     request:
-      url: '{host:s}:{run_server.port:d}/system/oem_mode/upload_splash'
+      url: '{run_server.base_url}/system/oem_mode/upload_splash'
       method: POST
       files:
         file: 'tests/integration/resources/oem_mode_custom.png'
@@ -80,13 +80,13 @@ stages:
       status_code: 403
   - name: Enable OEM Mode
     request:
-      url: '{host:s}:{run_server.port:d}/system/oem_mode/enable'
+      url: '{run_server.base_url}/system/oem_mode/enable'
       method: PUT
       json:
         'enable': true
   - name: Upload PNG Image
     request:
-      url: '{host:s}:{run_server.port:d}/system/oem_mode/upload_splash'
+      url: '{run_server.base_url}/system/oem_mode/upload_splash'
       method: POST
       files:
         file: 'tests/integration/resources/oem_mode_custom.png'
@@ -102,13 +102,13 @@ marks:
 stages:
   - name: Enable OEM Mode
     request:
-      url: '{host:s}:{run_server.port:d}/system/oem_mode/enable'
+      url: '{run_server.base_url}/system/oem_mode/enable'
       method: PUT
       json:
         'enable': true
   - name: Upload non-PNG Image
     request:
-      url: '{host:s}:{run_server.port:d}/system/oem_mode/upload_splash'
+      url: '{run_server.base_url}/system/oem_mode/upload_splash'
       method: POST
       files:
         file: 'tests/integration/resources/oem_mode_wrong_image_type.jpeg'
@@ -116,7 +116,7 @@ stages:
       status_code: 415
   - name: Upload a PNG Image
     request:
-      url: '{host:s}:{run_server.port:d}/system/oem_mode/upload_splash'
+      url: '{run_server.base_url}/system/oem_mode/upload_splash'
       method: POST
       files:
         file: 'tests/integration/resources/oem_mode_custom.png'

--- a/system-server/tests/integration/test_system_authorize.tavern.yaml
+++ b/system-server/tests/integration/test_system_authorize.tavern.yaml
@@ -6,7 +6,7 @@ marks:
 stages:
   - name: POST /system/register
     request:
-      url: '{host:s}:{run_server.port:d}/system/register'
+      url: '{run_server.base_url}/system/register'
       method: POST
       params:
         agent: 'agent-system-authorize-test'
@@ -21,7 +21,7 @@ stages:
           issued_token: 'token'
   - name: POST /system/authorize with invalid token
     request:
-      url: '{host:s}:{run_server.port:d}/system/authorize'
+      url: '{run_server.base_url}/system/authorize'
       method: POST
       headers:
         authenticationBearer: 'not-a-valid-token'
@@ -29,7 +29,7 @@ stages:
       status_code: 401
   - name: POST /system/authorize with valid token
     request:
-      url: '{host:s}:{run_server.port:d}/system/authorize'
+      url: '{run_server.base_url}/system/authorize'
       method: POST
       headers:
         authenticationBearer: '{issued_token:s}'
@@ -42,7 +42,7 @@ stages:
           auth_token: 'token'
   - name: POST /system/authorize with the same token, get a new auth token
     request:
-      url: '{host:s}:{run_server.port:d}/system/authorize'
+      url: '{run_server.base_url}/system/authorize'
       method: POST
       headers:
         authenticationBearer: '{issued_token:s}'
@@ -56,7 +56,7 @@ stages:
         token: !anystr
   - name: GET /system/authorize with invalid token fails
     request:
-      url: '{host:s}:{run_server.port:d}/system/authorize'
+      url: '{run_server.base_url}/system/authorize'
       method: GET
       headers:
         authenticationBearer: '{issued_token:s}'
@@ -64,7 +64,7 @@ stages:
       status_code: 403
   - name: GET /system/authorize with valid token fails
     request:
-      url: '{host:s}:{run_server.port:d}/system/authorize'
+      url: '{run_server.base_url}/system/authorize'
       method: GET
       headers:
         authenticationBearer: '{auth_token:s}'
@@ -78,7 +78,7 @@ marks:
 stages:
   - name: Register User
     request:
-      url: '{host:s}:{run_server.port:d}/system/register'
+      url: '{run_server.base_url}/system/register'
       method: POST
       params:
         agent: 'get-system-connected-test'
@@ -93,7 +93,7 @@ stages:
           issued_token: 'token'
   - name: Get empty connection list
     request:
-      url: '{host:s}:{run_server.port:d}/system/connected'
+      url: '{run_server.base_url}/system/connected'
       method: GET
     response:
       status_code: 200
@@ -101,7 +101,7 @@ stages:
         connections: []
   - name: Authorize User
     request:
-      url: '{host:s}:{run_server.port:d}/system/authorize'
+      url: '{run_server.base_url}/system/authorize'
       method: POST
       headers:
         authenticationBearer: '{issued_token:s}'
@@ -109,7 +109,7 @@ stages:
       status_code: 201
   - name: Get single-entry connection list
     request:
-      url: '{host:s}:{run_server.port:d}/system/connected'
+      url: '{run_server.base_url}/system/connected'
       method: GET
     response:
       status_code: 200
@@ -120,7 +120,7 @@ stages:
             agentId: 'id1'
   - name: Register second user
     request:
-      url: '{host:s}:{run_server.port:d}/system/register'
+      url: '{run_server.base_url}/system/register'
       method: POST
       params:
         agent: 'get-system-connected-test'
@@ -135,7 +135,7 @@ stages:
           second_token: 'token'
   - name: Authorize second user
     request:
-      url: '{host:s}:{run_server.port:d}/system/authorize'
+      url: '{run_server.base_url}/system/authorize'
       method: POST
       headers:
         authenticationBearer: '{second_token:s}'
@@ -143,7 +143,7 @@ stages:
       status_code: 201
   - name: Get two-entry connection list
     request:
-      url: '{host:s}:{run_server.port:d}/system/connected'
+      url: '{run_server.base_url}/system/connected'
       method: GET
     response:
       status_code: 200
@@ -159,7 +159,7 @@ stages:
             agentId: 'id1'
   - name: Re-authorize first user
     request:
-      url: '{host:s}:{run_server.port:d}/system/authorize'
+      url: '{run_server.base_url}/system/authorize'
       method: POST
       headers:
         authenticationBearer: '{issued_token:s}'
@@ -167,7 +167,7 @@ stages:
       status_code: 201
   - name: Get two-entry connection list
     request:
-      url: '{host:s}:{run_server.port:d}/system/connected'
+      url: '{run_server.base_url}/system/connected'
       method: GET
     response:
       status_code: 200

--- a/system-server/tests/integration/test_system_register.tavern.yaml
+++ b/system-server/tests/integration/test_system_register.tavern.yaml
@@ -6,7 +6,7 @@ marks:
 stages:
   - name: POST request returns a new JWT
     request: &system_register_first
-      url: '{host:s}:{run_server.port:d}/system/register'
+      url: '{run_server.base_url}/system/register'
       method: POST
       params:
         agent: 'agent-1'
@@ -27,7 +27,7 @@ stages:
         token: '{issued_token}'
   - name: POST request with different info returns a new JWT
     request: &system_register_second
-      url: '{host:s}:{run_server.port:d}/system/register'
+      url: '{run_server.base_url}/system/register'
       method: POST
       params:
         agent: 'agent-2'


### PR DESCRIPTION
## Overview

Minor refactors to system-server's tests.

## Changelog

- Remove a linter exclusion that we didn't need.
- Fix a copy-pasted docstring.
- Simplify the way the server URL is retrieved in .tavern.yaml files.

## Test Plan and Hands on Testing

Just CI.

## Review requests

None.

## Risk assessment

Very low.
