### PR TITLE
fix(app): fix spacing issue between liquid icon and liquid name

### DIFF
--- a/app/src/organisms/Desktop/ProtocolDetails/ProtocolLiquidsDetails.tsx
+++ b/app/src/organisms/Desktop/ProtocolDetails/ProtocolLiquidsDetails.tsx
@@ -55,16 +55,17 @@ export const ProtocolLiquidsDetails = (
                 flexDirection={DIRECTION_COLUMN}
                 marginY={SPACING.spacing16}
               >
-                <Flex flexDirection={DIRECTION_ROW} alignItems={ALIGN_CENTER}>
+                <Flex
+                  flexDirection={DIRECTION_ROW}
+                  alignItems={ALIGN_CENTER}
+                  gap={SPACING.spacing16}
+                >
                   <LiquidIcon color={liquid.displayColor} />
                   <Flex
                     flexDirection={DIRECTION_COLUMN}
                     justifyContent={JUSTIFY_CENTER}
                   >
-                    <StyledText
-                      desktopStyle="bodyDefaultSemiBold"
-                      marginX={SPACING.spacing16}
-                    >
+                    <StyledText desktopStyle="bodyDefaultSemiBold">
                       {liquid.displayName}
                     </StyledText>
                     <StyledText


### PR DESCRIPTION


# Overview
fix spacing issue between liquid icon and liquid name

<img width="1022" height="763" alt="Screenshot 2026-02-03 at 4 23 59 PM" src="https://github.com/user-attachments/assets/db0e0ba5-d397-45d8-a005-48d72d730b30" />


close RQA-5138


## Test Plan and Hands on Testing
- import the protocol that is attached to the ticket
- go to protocol details

## Changelog


## Review requests

## Risk assessment
low
