### PR TITLE
fix(shared-data): fix command schema 17 failing a unit test

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/command.py
+++ b/api/src/opentrons/protocol_engine/commands/command.py
@@ -112,7 +112,7 @@ class BaseCommandCreate(
     )
     commandAnnotations: List[str] = Field(
         default_factory=list,
-        description="A list of command annotation IDs (if any) that apply to this command."
+        description="A list of command annotation IDs (if any) that apply to this command.",
     )
 
 

--- a/shared-data/command/schemas/17.json
+++ b/shared-data/command/schemas/17.json
@@ -1277,6 +1277,7 @@
       "type": "object"
     },
     "Coordinate": {
+      "additionalProperties": false,
       "description": "Three-dimensional coordinates.",
       "properties": {
         "x": {


### PR DESCRIPTION
# Overview

In PR #20700, changes to the liquid class object and therefore the command schema were introduced. As this was targeting robot release 9.0, this applied to command schema **16**.

Simultaneously, PR #20726 introduced a new command schema, command schema **17**. However, this was based off of 16 _before_ the change in #20700 was introduced. This meant that when this merged into edge, this was now out of date with the changes introduced, and caused the `test_command_schema_has_not_changed` to fail.

The fix was to run the instructed `make` commands to update command schema 17 to be in line with all changes.

A small lint that did not cause any failures in #20726 was also included here.

## Test Plan and Hands on Testing

CI tests only, passing locally and should pass here.

## Changelog

- Fixed command schema 17 to not fail `test_command_schema_has_not_changed` 
- Lint fix

## Review requests

This would have been solved if I had merged `edge` into #20726 before merging it, but this still should have been caught by CI tests. If anybody has any ideas on how to fix this in the future, feel free to comment here or elsewhere.

## Risk assessment

Low.