### PR TITLE
fix(app): fix protocol visualization looping issue

### DIFF
--- a/app/src/organisms/Desktop/ProtocolVisualization/VisualizerContainer/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/VisualizerContainer/index.tsx
@@ -70,9 +70,7 @@ export function VisualizerContainer(
   )
   const [isDragging, setIsDragging] = useState<boolean>(false)
 
-  const [selectedCommandId, setSelectedCommand] = useState<string | null>(
-    null
-  )
+  const [selectedCommandId, setSelectedCommand] = useState<string | null>(null)
 
   // for resizable columns
   const [leftWidth, setLeftWidth] = useState<number>(INITIAL_WIDTH_PX)
@@ -142,7 +140,9 @@ export function VisualizerContainer(
 
     const intervalId = setInterval(() => {
       setSelectedCommand(prevId => {
-        const currentIndex = filteredCommands.findIndex(cmd => cmd.id === prevId)
+        const currentIndex = filteredCommands.findIndex(
+          cmd => cmd.id === prevId
+        )
         const nextIndex =
           currentIndex >= 0 && currentIndex < filteredCommands.length - 1
             ? currentIndex + 1

--- a/app/src/organisms/Desktop/ProtocolVisualization/VisualizerContainer/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/VisualizerContainer/index.tsx
@@ -71,7 +71,7 @@ export function VisualizerContainer(
   const [isDragging, setIsDragging] = useState<boolean>(false)
 
   const [selectedCommandId, setSelectedCommand] = useState<string | null>(
-    commands[0]?.id ?? null
+    null
   )
 
   // for resizable columns
@@ -131,14 +131,23 @@ export function VisualizerContainer(
   )
 
   useEffect(() => {
+    if (selectedCommandId != null) return
+    const initialId = filteredCommands[0]?.id ?? commands[0]?.id ?? null
+    setSelectedCommand(initialId)
+  }, [selectedCommandId, filteredCommands, commands])
+
+  useEffect(() => {
     if (!isPlaying) return
+    if (filteredCommands.length === 0) return
 
     const intervalId = setInterval(() => {
       setSelectedCommand(prevId => {
-        const currentIndex = commands.findIndex(cmd => cmd.id === prevId)
+        const currentIndex = filteredCommands.findIndex(cmd => cmd.id === prevId)
         const nextIndex =
-          currentIndex < commands.length - 1 ? currentIndex + 1 : 0
-        const nextId = commands[nextIndex]?.id ?? null
+          currentIndex >= 0 && currentIndex < filteredCommands.length - 1
+            ? currentIndex + 1
+            : 0
+        const nextId = filteredCommands[nextIndex]?.id ?? null
 
         return nextId
       })
@@ -147,7 +156,7 @@ export function VisualizerContainer(
     return () => {
       clearInterval(intervalId)
     }
-  }, [isPlaying, commands, milliSecondsPerFrame])
+  }, [isPlaying, filteredCommands, milliSecondsPerFrame])
 
   //  update the data for the spotlight window
   //  whenever the command index changes
@@ -162,7 +171,7 @@ export function VisualizerContainer(
       slot: selectedSlot,
       command: commands[nextIndex],
       robotState,
-      invariantContext: invariantContext,
+      invariantContext,
       analysis,
       liquids,
     }


### PR DESCRIPTION
# Overview
fix protocol visualization looping issue
for CommandSteps and Controls used a wrong index which is -1 and the UI didn't work properly.
i’m getting confirmation from Mel about the expected behavior.


https://github.com/user-attachments/assets/d3e92584-f8c4-49fc-811e-92269c3b4fe2



close RQA-5137

## Test Plan and Hands on Testing
- import the protocol that is attached to the ticket
- select and visualize the protocol
- click the last command and hit the play button

## Changelog

## Review requests

## Risk assessment
low
