### PR TITLE
feat(ci): PD manual approval for prod deployment

### DIFF
--- a/.github/workflows/pd-test-build-deploy.yaml
+++ b/.github/workflows/pd-test-build-deploy.yaml
@@ -147,7 +147,15 @@ jobs:
       - determine-deploy-config
       - build-pd
     runs-on: 'ubuntu-24.04'
-    if: always() && needs.build-pd.result == 'success' && needs.determine-deploy-config.result == 'success' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+    # Uses GitHub Environments to require manual approval in the UI before production deploys.
+    # Configure required reviewers on the `pd-prod` environment.
+    environment:
+      name: ${{ needs.determine-deploy-config.outputs.environment == 'production' && 'pd-prod' || 'pd-non-prod' }}
+    if: >-
+      always() &&
+      needs.build-pd.result == 'success' &&
+      needs.determine-deploy-config.result == 'success' &&
+      (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
## Overview

Use the environments feature to gate production deployments of PD.
When the deployment configurator resolves to `production` as is the case for all tags starting with `protocol-designer@`
Then we set the environment to pd-prod which then requires a manual approval in the GitHub UI for this job to proceed.
The current list of approvers are repo admins and the below, which are the pd-deployers team.
<img width="500" height="417" alt="image" src="https://github.com/user-attachments/assets/10011a3e-9eb1-437f-8295-a1cc7d866732" />
 