### PR TITLE
fix(abr-testing): Error recovery detection - guard against multiple slack pings.

### DIFF
--- a/abr-testing/abr_testing/protocols/helpers/background_helpers.py
+++ b/abr-testing/abr_testing/protocols/helpers/background_helpers.py
@@ -10,6 +10,7 @@ import subprocess
 from abr_testing.automation import slack
 from abr_testing.tools import check_robot_status as robot_status
 from abr_testing.protocols.helpers import run_helpers
+from collections import deque
 
 
 def detect_robot_status(ip: str) -> None:
@@ -21,6 +22,8 @@ def detect_robot_status(ip: str) -> None:
     slack_bot: slack.Slack = run_helpers.set_up_slack()
 
     print("inside detect_robot_status")
+
+    past_runs: deque = deque(maxlen=10)
 
     # Process will be constantly running
     while True:
@@ -38,6 +41,7 @@ def detect_robot_status(ip: str) -> None:
             running_robots=running_robots,
             completed_robots=completed_robots,
             on_robot=True,
+            past_run_status=past_runs,
         )
 
 

--- a/abr-testing/abr_testing/tools/check_robot_status.py
+++ b/abr-testing/abr_testing/tools/check_robot_status.py
@@ -7,7 +7,6 @@ from abr_testing.automation import slack
 import configparser
 import os
 from typing import List, Dict, Any, Tuple
-from collections import deque
 
 
 def get_robot_run_info(ip: str) -> Tuple[str, List[Dict[str, Any]]]:

--- a/abr-testing/abr_testing/tools/check_robot_status.py
+++ b/abr-testing/abr_testing/tools/check_robot_status.py
@@ -1,10 +1,13 @@
 """Check Robot(s) Current State."""
 import json
+from collections import deque
+
 import requests
 from abr_testing.automation import slack
 import configparser
 import os
 from typing import List, Dict, Any, Tuple
+from collections import deque
 
 
 def get_robot_run_info(ip: str) -> Tuple[str, List[Dict[str, Any]]]:
@@ -32,6 +35,7 @@ def get_current_run_details_from_robot(
     running_robots: List[str],
     completed_robots: List[str],
     on_robot: bool = False,
+    past_run_status: deque = deque(),
 ) -> Tuple[List[str], List[str]]:
     """Get current run from robot."""
     # if it's being run on the robot, do not print to terminal
@@ -54,18 +58,30 @@ def get_current_run_details_from_robot(
                         print_terminal, f"Run Status of {robot_name}: {run_status}"
                     )
                     message = f"⚠️ {robot_name} is in error recovery mode ⚠️"
-                    slack_bot.send_slack_message(message)
-                    completed_robots.append(robot_name)
+
+                    # Check that the robot's most recent run status isn't the same as current before slack update
+                    if on_robot:
+                        past_run_status_list: list = list(past_run_status)
+
+                        if (len(past_run_status_list) == 0) or not (past_run_status_list[-1] == run_status):
+                            slack_bot.send_slack_message(message)
+                    else:
+                        slack_bot.send_slack_message(message)
+                        completed_robots.append(robot_name)
+
+                    past_run_status.append(run_status)
             elif run_status == "running":
                 _enable_print_to_terminal(
                     print_terminal, f"Run Status of {robot_name}: {run_status}"
                 )
                 running_robots.append(robot_name)
+                past_run_status.append(run_status)
             else:
                 _enable_print_to_terminal(
                     print_terminal, f"Run Status of {robot_name}: {run_status}"
                 )
                 completed_robots.append(robot_name)
+                past_run_status.append(run_status)
         else:
             _enable_print_to_terminal(print_terminal, f"No run active on {robot_name}")
             completed_at = most_recent_run["completedAt"]


### PR DESCRIPTION
# Overview

Fixes issue where abr robots continue pinging slack forever until they are brought out of error recovery.

## Test Plan and Hands on Testing

Tested on ABR8 robot.

## Changelog

In `check_robot_status.get_current_run_details_from_robot()` a new parameter was added called `past_run_status: deque`. This parameter allows for external tracking of previous run statuses of individual robots. When entering error recovery, before pinging, it checks if the most recent status in the deque to see if it is the same as the current status ("awaiting_recovery"). If that is the case, then it doesn't ping slack. If it isn't, then it does. The idea is is the robot is going from [arbitrary state] -> "awaiting_recovery", the slack channel gets notified, but from "awaiting_recovery" -> "awaiting_recovery", nothing happens. Every time the function is run, it will append it's current state to the end of the deque reference.

In `background_helpers.detect_robot_status` a deque with a maximum length of 10 is created outside of the infinite loop to track the 10 most recent run statuses. This deque reference is then passed into `get_current_run_details()` which performs the operations as detailed above.

The flow of the program should be as follows
`run start -> detect_robot_status launches -> deque initializes with nothing -> infinite loop tracks robots status every 5 minutes -> based on past and current status, slack channel is pinged or not pinged` 

## Risk assessment

Low
