### PR TITLE
fix(app): display commandSummaries all the time in PV

### DIFF
--- a/app/src/organisms/Desktop/ProtocolVisualization/DeckView/DeckViewLabware.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/DeckView/DeckViewLabware.tsx
@@ -48,7 +48,7 @@ export function DeckViewLabware(props: DeckViewLabwareProps): JSX.Element {
     hoveredSlot,
     selectedRunTimeCommand,
   } = props
-  const { labware, modules } = robotState
+  const { labware, modules, pipettes } = robotState
   return (
     <>
       {Object.entries(labware).map(([id, lw]) => {
@@ -71,10 +71,12 @@ export function DeckViewLabware(props: DeckViewLabwareProps): JSX.Element {
         }
         const { isActiveLayerVisible } = getActiveLayer(
           id,
+          pipettes,
           selectedRunTimeCommand
         )
         const showCommandSummary =
           isActiveLayerVisible && selectedRunTimeCommand != null
+
         return (
           <Fragment key={id}>
             <g transform={`translate(${slotPosition[0]}, ${slotPosition[1]})`}>

--- a/app/src/organisms/Desktop/ProtocolVisualization/DeckView/DeckViewLabwareCommandSummaries.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/DeckView/DeckViewLabwareCommandSummaries.tsx
@@ -1,10 +1,14 @@
+import { Fragment } from 'react'
+
 import {
+  getAddressableAreaFromSlotId,
   getModuleDef,
   getModuleParentOriginToChildSlotOrigin,
   getPositionFromSlotId,
 } from '@opentrons/shared-data'
+import { getSlotInLocationStack } from '@opentrons/step-generation'
 
-import { getTopmostLabwareOnModuleFromStack } from '../utils/getTopmostLabwareOnModuleFromStack'
+import { getActiveLayer } from '../utils/getActiveLayer'
 import { LabwareCommandSummary } from './LabwareCommandSummary'
 
 import type { DeckDefinition, RunTimeCommand } from '@opentrons/shared-data'
@@ -30,49 +34,70 @@ export function DeckViewLabwareCommandSummaries(
     selectedRunTimeCommand,
   } = props
   const { moduleEntities } = invariantContext
-  const { modules, labware } = robotState
+  const { modules, labware, pipettes } = robotState
 
   return (
     <>
-      {Object.entries(modules).map(([id, { slot }]) => {
-        const isStepAssociatedWithModule =
-          selectedRunTimeCommand != null &&
-          'moduleId' in selectedRunTimeCommand.params &&
-          selectedRunTimeCommand.params.moduleId === id
-        if (!isStepAssociatedWithModule) return null
-
-        const labwareLoadedOnModuleId = getTopmostLabwareOnModuleFromStack(
-          id,
-          Object.values(labware)
-        )
-        if (labwareLoadedOnModuleId == null) return null
-
+      {Object.entries(labware).map(([id, lw]) => {
+        if (
+          !Object.keys(modules).some(moduleId => lw.stack.includes(moduleId))
+        ) {
+          return null
+        }
+        const moduleUnderLabware = lw.stack.find(id => modules[id] != null)
+        const slot = getSlotInLocationStack(lw.stack)
         const slotPosition = getPositionFromSlotId(slot, deckDef)
-        if (slotPosition == null) {
-          console.warn(`no slot ${slot} for module ${id}`)
+        const slotBoundingBox = getAddressableAreaFromSlotId(
+          slot,
+          deckDef
+        )?.boundingBox
+        if (slotPosition == null || slotBoundingBox == null) {
+          console.warn(
+            `no slot ${slot} for labware ${Object.keys(labware)[0]}!`
+          )
           return null
         }
 
-        const moduleDef = getModuleDef(moduleEntities[id].model)
+        const moduleDef =
+          moduleUnderLabware != null
+            ? getModuleDef(moduleEntities[moduleUnderLabware].model)
+            : null
+
+        if (moduleDef == null) {
+          console.warn(`expected to find a moduleDef assosciated with ${id}`)
+          return null
+        }
         const childSlotOffset = getModuleParentOriginToChildSlotOrigin(
           deckDef.otId,
           slot,
           moduleDef
         )
+
         const childSlotPosition: [number, number, number] = [
           slotPosition[0] + childSlotOffset.x,
           slotPosition[1] + childSlotOffset.y,
           slotPosition[2] + childSlotOffset.z,
         ]
 
+        const { isActiveLayerVisible } = getActiveLayer(
+          id,
+          pipettes,
+          selectedRunTimeCommand
+        )
+        const showCommandSummary =
+          isActiveLayerVisible && selectedRunTimeCommand != null
+
         return (
-          <LabwareCommandSummary
-            key={`labware_command_summary_${id}`}
-            commandType={selectedRunTimeCommand.commandType}
-            position={childSlotPosition}
-            labwareDef={labwareEntitiesExtended[labwareLoadedOnModuleId].def}
-            showModuleIcon={false}
-          />
+          <Fragment key={id}>
+            {showCommandSummary ? (
+              <LabwareCommandSummary
+                commandType={selectedRunTimeCommand.commandType}
+                position={childSlotPosition}
+                labwareDef={labwareEntitiesExtended[id].def}
+                showModuleIcon={false}
+              />
+            ) : null}
+          </Fragment>
         )
       })}
     </>

--- a/app/src/organisms/Desktop/ProtocolVisualization/DeckView/DeckViewModuleCommandSummaries.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/DeckView/DeckViewModuleCommandSummaries.tsx
@@ -4,8 +4,6 @@ import {
   inferModuleOrientationFromXCoordinate,
 } from '@opentrons/shared-data'
 
-import { getActiveLayer } from '../utils/getActiveLayer'
-import { getTopmostLabwareOnModuleFromStack } from '../utils/getTopmostLabwareOnModuleFromStack'
 import { ModuleCommandSummary } from './ModuleCommandSummary'
 
 import type {
@@ -34,7 +32,7 @@ export function DeckViewModuleCommandSummaries(
     selectedRunTimeCommand,
   } = props
   const { moduleEntities } = invariantContext
-  const { modules, labware } = robotState
+  const { modules } = robotState
 
   return (
     <>
@@ -44,27 +42,16 @@ export function DeckViewModuleCommandSummaries(
           console.warn(`no slot ${slot} for module ${id}`)
           return null
         }
-        const labwareLoadedOnModuleId = getTopmostLabwareOnModuleFromStack(
-          id,
-          Object.values(labware)
-        )
-        const { isActiveLayerVisible } = getActiveLayer(
-          labwareLoadedOnModuleId,
-          selectedRunTimeCommand,
-          id
-        )
         const isStepAssociatedWithModule =
           selectedRunTimeCommand != null &&
           'moduleId' in selectedRunTimeCommand.params &&
           selectedRunTimeCommand.params.moduleId === id
-        const showLabwareCommandSummary =
-          isStepAssociatedWithModule && labwareLoadedOnModuleId != null
         const showModuleCommandSummary =
-          (isActiveLayerVisible || isStepAssociatedWithModule) &&
-          selectedRunTimeCommand != null &&
-          !showLabwareCommandSummary
+          isStepAssociatedWithModule && selectedRunTimeCommand != null
 
-        if (!showModuleCommandSummary) return null
+        if (!showModuleCommandSummary) {
+          return null
+        }
 
         const moduleDef = getModuleDef(moduleEntities[id].model)
 

--- a/app/src/organisms/Desktop/ProtocolVisualization/DeckView/DeckViewModules.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/DeckView/DeckViewModules.tsx
@@ -55,7 +55,7 @@ export function DeckViewModules(props: DeckViewModulesProps): JSX.Element {
     selectedRunTimeCommand,
   } = props
   const { moduleEntities } = invariantContext
-  const { modules, labware } = robotState
+  const { modules, labware, pipettes } = robotState
 
   return (
     <>
@@ -71,6 +71,7 @@ export function DeckViewModules(props: DeckViewModulesProps): JSX.Element {
         )
         const { isActiveLayerVisible } = getActiveLayer(
           labwareLoadedOnModuleId,
+          pipettes,
           selectedRunTimeCommand,
           id
         )

--- a/app/src/organisms/Desktop/ProtocolVisualization/DeckView/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/DeckView/index.tsx
@@ -198,6 +198,7 @@ export function DeckView(props: DeckViewProps): JSX.Element {
                         labwareOnSlot != null
                           ? getActiveLayer(
                               labwareOnSlot[0],
+                              pipettes,
                               selectedRunTimeCommand
                             )
                           : { isActiveLayerVisible: false }
@@ -213,6 +214,7 @@ export function DeckView(props: DeckViewProps): JSX.Element {
                             getIsCutoutA1Active(
                               labware,
                               modules,
+                              pipettes,
                               cutoutId,
                               selectedRunTimeCommand
                             )

--- a/app/src/organisms/Desktop/ProtocolVisualization/utils/getActiveLayer.ts
+++ b/app/src/organisms/Desktop/ProtocolVisualization/utils/getActiveLayer.ts
@@ -1,4 +1,5 @@
 import type { RunTimeCommand } from '@opentrons/shared-data'
+import type { PipetteTemporalProperties } from '@opentrons/step-generation'
 
 interface ActiveLayer {
   isActiveLayerVisible: boolean
@@ -6,9 +7,15 @@ interface ActiveLayer {
 
 export const getActiveLayer = (
   id: string,
+  pipetteState: {
+    [pipetteId: string]: PipetteTemporalProperties
+  },
   selectedRunTimeCommand?: RunTimeCommand,
   moduleId?: string
 ): ActiveLayer => {
+  const pipetteEntityId = Object.values(pipetteState).find(
+    pipette => pipette.entityId === id
+  )
   const isStepAssosciatedWithLabwareId =
     selectedRunTimeCommand != null &&
     'labwareId' in selectedRunTimeCommand.params &&
@@ -21,7 +28,9 @@ export const getActiveLayer = (
     selectedRunTimeCommand.params.labwareId === id
 
   const isStepAssosciatedWithLabware =
-    isStepAssosciatedWithLabwareId || isMoveStepAssosciatedWithLabwareId
+    isStepAssosciatedWithLabwareId ||
+    isMoveStepAssosciatedWithLabwareId ||
+    pipetteEntityId != null
 
   const isStepAssociatedWithModuleId =
     moduleId != null &&

--- a/app/src/organisms/Desktop/ProtocolVisualization/utils/getIsCutoutA1Active.ts
+++ b/app/src/organisms/Desktop/ProtocolVisualization/utils/getIsCutoutA1Active.ts
@@ -9,6 +9,7 @@ import type { RobotState } from '@opentrons/step-generation'
 export const getIsCutoutA1Active = (
   labware: RobotState['labware'],
   modules: RobotState['modules'],
+  pipettes: RobotState['pipettes'],
   cutoutId: CutoutId,
   selectedRunTimeCommand?: RunTimeCommand
 ): boolean => {
@@ -21,7 +22,7 @@ export const getIsCutoutA1Active = (
 
   const { isActiveLayerVisible: isThermocyclerActive } =
     labwareOnB1 != null
-      ? getActiveLayer(labwareOnB1[0], selectedRunTimeCommand)
+      ? getActiveLayer(labwareOnB1[0], pipettes, selectedRunTimeCommand)
       : { isActiveLayerVisible: false }
 
   return isThermocyclerActive && hasThermocycler && cutoutId === 'cutoutA1'


### PR DESCRIPTION
closes RQA-5124

# Overview

all the commands should have a command summary now on the deck map

## Test Plan and Hands on Testing

upload protocol attached to the ticket and see that each aspirate step and stuff have a command summary

## Changelog

needed to refactor `getActiveLayer` by extending the entityId from robot state for if you moved the pipette and then did an `inPlace` command

then i needed to fix up when we were showing the summary on modules, the logic was a bit wrong

## Risk assessment

low
