### PR TITLE
fix(app): don't hard wrap every word in protocol viz steps

### DIFF
--- a/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/annotatedsteps.module.css
+++ b/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/annotatedsteps.module.css
@@ -74,7 +74,7 @@
   gap: var(--spacing-8);
 }
 
-/* stylelint-disable */
+/* stylelint-disable -- no other way to wrap long words without hard-wrapping all text */
 .individual_command_text {
   overflow-wrap: break-word;
   white-space: normal;

--- a/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/annotatedsteps.module.css
+++ b/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/annotatedsteps.module.css
@@ -75,9 +75,9 @@
 }
 
 .individual_command_text {
-  overflow-wrap: anywhere;
+  overflow-wrap: break-word;
   white-space: normal;
-  word-break: break-all;
+  word-break: break-word;
 }
 
 .annotated_steps_container {

--- a/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/annotatedsteps.module.css
+++ b/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/annotatedsteps.module.css
@@ -74,11 +74,13 @@
   gap: var(--spacing-8);
 }
 
+/* stylelint-disable */
 .individual_command_text {
   overflow-wrap: break-word;
   white-space: normal;
   word-break: break-word;
 }
+/* stylelint-enable */
 
 .annotated_steps_container {
   width: 100%;

--- a/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/annotatedsteps.module.css
+++ b/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/annotatedsteps.module.css
@@ -74,13 +74,11 @@
   gap: var(--spacing-8);
 }
 
-/* stylelint-disable -- no other way to wrap long words without hard-wrapping all text */
 .individual_command_text {
-  overflow-wrap: break-word;
+  overflow-wrap: anywhere;
   white-space: normal;
-  word-break: break-word;
+  word-break: normal;
 }
-/* stylelint-enable */
 
 .annotated_steps_container {
   width: 100%;


### PR DESCRIPTION
# Overview

Fix word wrapping in Protocol Steps in protocol visualization. Previously it was hard-wrapping all words, regardless of length.

## Test Plan and Hands on Testing

before
<img width="280" height="474" alt="image" src="https://github.com/user-attachments/assets/e3c77d9a-f7e7-4818-b63d-fd895ccb8077" />

after
<img width="277" height="481" alt="image" src="https://github.com/user-attachments/assets/6fb1a966-175c-4e93-aa52-32d88d57c0a9" />

sample protocol
```
from opentrons import protocol_api

requirements = {"robotType": "Flex", "apiLevel": "2.23"}

def run(protocol: protocol_api.ProtocolContext):
    # load tip rack in deck slot D3
    tiprack = protocol.load_labware(
        load_name="opentrons_flex_96_tiprack_1000ul", location="D3"
    )
    # attach pipette to left mount
    pipette = protocol.load_instrument(
        instrument_name="flex_1channel_1000",
        mount="left",
        tip_racks=[tiprack]
    )
    # load well plate in deck slot D2
    plate = protocol.load_labware(
        load_name="corning_96_wellplate_360ul_flat", location="D2"
    )
    # load reservoir in deck slot D1
    reservoir = protocol.load_labware(
        load_name="usascientific_12_reservoir_22ml", location="D1"
    )
    # load trash bin
    trash = protocol.load_trash_bin("A3")
    # Put protocol commands here
    
    pipette.pick_up_tip()
    pipette.drop_tip()
    protocol.comment("lookatmyverycoolcommentwithnospaceslookatmyverycoolcommentwithnospaceslookatmyverycoolcommentwithnospaceslookatmyverycoolcommentwithnospaceslookatmyverycoolcommentwithnospaceslookatmyverycoolcommentwithnospaceslookatmyverycoolcommentwithnospaces")
```

## Changelog

<s>Couple lines</s> One line of CSS.

## Review requests

- Does this affect anything else?
- Are any other CSS changes needed?

## Risk assessment

low.