### PR TITLE
fix(app): fix magnetic block in spotlight window

### DIFF
--- a/app/src/organisms/Desktop/ProtocolVisualization/ModuleContainer/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/ModuleContainer/index.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next'
 
-import { Chip, StyledText } from '@opentrons/components'
+import { Chip, RobotInfoLabel, StyledText } from '@opentrons/components'
 import {
   ABSORBANCE_READER_TYPE,
   FLEX_STACKER_MODULE_TYPE,
@@ -21,12 +21,14 @@ interface ModuleContainerProps {
   moduleId: string
   moduleEntities: ModuleEntities
   moduleRobotState: RobotState['modules']
+  slotId: string
 }
 
 export function ModuleContainer({
   moduleId,
   moduleEntities,
   moduleRobotState,
+  slotId,
 }: ModuleContainerProps): JSX.Element {
   const { t } = useTranslation('protocol_visualization')
   const { model } = moduleEntities[moduleId]
@@ -221,9 +223,11 @@ export function ModuleContainer({
         `ran into the default moduleContainer moduleState with module ${moduleDisplayName}`
       )
   }
+
   return (
     <div className={styles.container}>
       <div className={styles.main_content}>
+        <RobotInfoLabel deckLabel={slotId} />
         <StyledText desktopStyle="bodyDefaultSemiBold">
           {moduleDisplayName}
         </StyledText>

--- a/app/src/organisms/Desktop/ProtocolVisualization/ModuleContainer/modulecontainer.module.css
+++ b/app/src/organisms/Desktop/ProtocolVisualization/ModuleContainer/modulecontainer.module.css
@@ -27,4 +27,5 @@
   width: 100%;
   flex-direction: column;
   justify-content: space-between;
+  gap: var(--spacing-4);
 }

--- a/app/src/organisms/Desktop/ProtocolVisualization/SlotDetails/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/SlotDetails/index.tsx
@@ -117,6 +117,7 @@ export function SlotDetails(props: SlotDetailsProps): JSX.Element {
               moduleId={moduleOnSlot[0]}
               moduleEntities={moduleEntities}
               moduleRobotState={modules}
+              slotId={slotId}
             />
           ) : null}
         </div>


### PR DESCRIPTION


# Overview
add slot info to spotlight window

[before]
<img width="499" height="465" alt="Screenshot 2026-02-05 at 10 12 36 AM" src="https://github.com/user-attachments/assets/d06144d2-eae0-420e-9253-d3f0c3481159" />


[after]
<img width="501" height="464" alt="Screenshot 2026-02-05 at 10 22 23 AM" src="https://github.com/user-attachments/assets/821d9939-c19f-41dc-9137-cd454228a8ad" />

close RQA-5139 and RQA-5153

## Test Plan and Hands on Testing
- import the protocol that is attached to the tickets
- visualize the protocol
- click the magnetic block on the deck view

## Changelog
- add slot info

## Review requests


## Risk assessment
low
