### PR TITLE
fix(app): Remove unneeded copy from JogToPosition page

### DIFF
--- a/app/src/organisms/DropTipWizardFlows/steps/JogToPosition.tsx
+++ b/app/src/organisms/DropTipWizardFlows/steps/JogToPosition.tsx
@@ -33,36 +33,35 @@ export const JogToPosition = ({
 
   return (
     <>
-      <Flex css={TITLE_SECTION_STYLE}>
-        <StyledText
-          desktopStyle="headingSmallBold"
-          oddStyle="level4HeaderSemiBold"
+      <Flex css={SCROLLABLE_BODY}>
+        <Flex css={TITLE_SECTION_STYLE}>
+          <StyledText
+            desktopStyle="headingSmallBold"
+            oddStyle="level4HeaderSemiBold"
+          >
+            {t('position_the_pipette')}
+          </StyledText>
+          <LegacyStyledText forwardedAs="p">
+            {currentRoute === DT_ROUTES.BLOWOUT
+              ? t('position_and_blowout')
+              : t('position_and_drop_tip')}
+          </LegacyStyledText>
+        </Flex>
+        <Flex
+          css={
+            modalStyle === 'simple'
+              ? SIMPLE_CONTENT_SECTION_STYLE
+              : INTERVENTION_CONTENT_SECTION_STYLE
+          }
         >
-          {t('position_the_pipette')}
-        </StyledText>
-        <LegacyStyledText forwardedAs="p">
-          {currentRoute === DT_ROUTES.BLOWOUT
-            ? t('position_and_blowout')
-            : t('position_and_drop_tip')}
-        </LegacyStyledText>
-      </Flex>
-      <Flex
-        css={
-          modalStyle === 'simple'
-            ? SIMPLE_CONTENT_SECTION_STYLE
-            : INTERVENTION_CONTENT_SECTION_STYLE
-        }
-      >
-        <JogControls
-          jog={handleJog}
-          isOnDevice={isOnDevice}
-          height={isOnDevice ? '80%' : '100%'}
-        />
-        <DropTipFooterButtons
-          primaryBtnOnClick={proceed}
-          primaryBtnTextOverride={t('shared:confirm_position')}
-          secondaryBtnOnClick={goBackRunValid}
-        />
+          <JogControls jog={handleJog} isOnDevice={isOnDevice} />
+
+          <DropTipFooterButtons
+            primaryBtnOnClick={proceed}
+            primaryBtnTextOverride={t('shared:confirm_position')}
+            secondaryBtnOnClick={goBackRunValid}
+          />
+        </Flex>
       </Flex>
     </>
   )
@@ -97,4 +96,9 @@ const INTERVENTION_CONTENT_SECTION_STYLE = css`
   @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
     grid-gap: 0.9rem;
   }
+`
+const SCROLLABLE_BODY = css`
+  flex-direction: ${DIRECTION_COLUMN};
+  grid-gap: ${SPACING.spacing16};
+  overflow-y: auto;
 `

--- a/app/src/organisms/DropTipWizardFlows/steps/JogToPosition.tsx
+++ b/app/src/organisms/DropTipWizardFlows/steps/JogToPosition.tsx
@@ -4,15 +4,11 @@ import { css } from 'styled-components'
 import {
   DIRECTION_COLUMN,
   Flex,
-  LegacyStyledText,
   RESPONSIVENESS,
   SPACING,
-  StyledText,
 } from '@opentrons/components'
 
 import { JogControls } from '/app/molecules/JogControls'
-
-import { DT_ROUTES } from '../constants'
 import { DropTipFooterButtons } from '../shared'
 
 import type { DropTipWizardContainerProps } from '../types'
@@ -33,48 +29,24 @@ export const JogToPosition = ({
 
   return (
     <>
-      <Flex css={SCROLLABLE_BODY}>
-        <Flex css={TITLE_SECTION_STYLE}>
-          <StyledText
-            desktopStyle="headingSmallBold"
-            oddStyle="level4HeaderSemiBold"
-          >
-            {t('position_the_pipette')}
-          </StyledText>
-          <LegacyStyledText forwardedAs="p">
-            {currentRoute === DT_ROUTES.BLOWOUT
-              ? t('position_and_blowout')
-              : t('position_and_drop_tip')}
-          </LegacyStyledText>
-        </Flex>
-        <Flex
-          css={
-            modalStyle === 'simple'
-              ? SIMPLE_CONTENT_SECTION_STYLE
-              : INTERVENTION_CONTENT_SECTION_STYLE
-          }
-        >
-          <JogControls jog={handleJog} isOnDevice={isOnDevice} />
+      <Flex
+        css={
+          modalStyle === 'simple'
+            ? SIMPLE_CONTENT_SECTION_STYLE
+            : INTERVENTION_CONTENT_SECTION_STYLE
+        }
+      >
+        <JogControls jog={handleJog} isOnDevice={isOnDevice} />
 
-          <DropTipFooterButtons
-            primaryBtnOnClick={proceed}
-            primaryBtnTextOverride={t('shared:confirm_position')}
-            secondaryBtnOnClick={goBackRunValid}
-          />
-        </Flex>
+        <DropTipFooterButtons
+          primaryBtnOnClick={proceed}
+          primaryBtnTextOverride={t('shared:confirm_position')}
+          secondaryBtnOnClick={goBackRunValid}
+        />
       </Flex>
     </>
   )
 }
-
-const TITLE_SECTION_STYLE = css`
-  flex-direction: ${DIRECTION_COLUMN};
-  grid-gap: ${SPACING.spacing16};
-
-  @media (${RESPONSIVENESS.touchscreenMediaQuerySpecs}) {
-    display: none;
-  }
-`
 
 const SHARED_CONTENT_SECTION_STYLE = `
   flex-direction: ${DIRECTION_COLUMN};
@@ -96,9 +68,4 @@ const INTERVENTION_CONTENT_SECTION_STYLE = css`
   @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
     grid-gap: 0.9rem;
   }
-`
-const SCROLLABLE_BODY = css`
-  flex-direction: ${DIRECTION_COLUMN};
-  grid-gap: ${SPACING.spacing16};
-  overflow-y: auto;
 `

--- a/app/src/organisms/DropTipWizardFlows/steps/JogToPosition.tsx
+++ b/app/src/organisms/DropTipWizardFlows/steps/JogToPosition.tsx
@@ -9,6 +9,7 @@ import {
 } from '@opentrons/components'
 
 import { JogControls } from '/app/molecules/JogControls'
+
 import { DropTipFooterButtons } from '../shared'
 
 import type { DropTipWizardContainerProps } from '../types'


### PR DESCRIPTION
# Overview

The JogToPosition screen on the ODD does not need text because it is now included in the previous page


## Test Plan and Hands on Testing
smoke tested on dev odd:
<img width="1018" height="595" alt="Screenshot 2026-02-05 at 5 38 54 PM" src="https://github.com/user-attachments/assets/10cf663f-47ff-477b-8d68-73ce97bbb0ad" />

## Changelog

- removed text

## Risk assessment

low - cosmetic

Closes RQA-5165
