### PR TITLE
fix(app): filter out PE from fake lid stack labware

### DIFF
--- a/app/src/organisms/Desktop/ProtocolVisualization/DeckView/DeckViewLabware.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/DeckView/DeckViewLabware.tsx
@@ -4,6 +4,7 @@ import { CenterLabwareInSlot, COLORS, StyledText } from '@opentrons/components'
 import {
   getAddressableAreaFromSlotId,
   getPositionFromSlotId,
+  PROTOCOL_ENGINE_LID_STACK_LOADNAME,
 } from '@opentrons/shared-data'
 import { getSlotInLocationStack } from '@opentrons/step-generation'
 
@@ -77,6 +78,15 @@ export function DeckViewLabware(props: DeckViewLabwareProps): JSX.Element {
         const showCommandSummary =
           isActiveLayerVisible && selectedRunTimeCommand != null
 
+        // need to special-case the PE lid stack def which
+        // is a fake def that shouldn't be properly exposed to
+        // users
+        const modifiedLabwareDisplayName =
+          labwareEntitiesExtended[id].def.parameters.loadName ===
+          PROTOCOL_ENGINE_LID_STACK_LOADNAME
+            ? 'Lid Stack'
+            : labwareEntitiesExtended[id].def.metadata.displayName
+
         return (
           <Fragment key={id}>
             <g transform={`translate(${slotPosition[0]}, ${slotPosition[1]})`}>
@@ -108,7 +118,7 @@ export function DeckViewLabware(props: DeckViewLabwareProps): JSX.Element {
               {showCommandSummary ? null : (
                 <StyledText desktopStyle="captionRegular" color={COLORS.white}>
                   {labwareEntitiesExtended[id]?.nickName ??
-                    labwareEntitiesExtended[id].def.metadata.displayName}
+                    modifiedLabwareDisplayName}
                 </StyledText>
               )}
             </DeckViewOverlay>

--- a/shared-data/js/constants.ts
+++ b/shared-data/js/constants.ts
@@ -879,3 +879,6 @@ export const COMBO_FIXTURES: CutoutFixtureIdsWithFakes[] = [
 // a labware location when something has been used already on the deck
 // and moves to a new location that isn't accessible on or off the deck
 export const SYSTEM_LOCATION = 'systemLocation'
+
+export const PROTOCOL_ENGINE_LID_STACK_LOADNAME =
+  'protocol_engine_lid_stack_object'


### PR DESCRIPTION
closes RQA-5156

# Overview

filter out the `ProtocolEngine` name from the PE lid stack fake labware that PV uses since it is displaying the completed protocol analysis from protocol engine lol

## Test Plan and Hands on Testing

follow steps in ticket. should see "lid stack" instead

## Changelog

change name to "lid stack"

## Risk assessment

low