### PR TITLE
fix(app): Fix ODD preview image modal behavior

### DIFF
--- a/app/src/organisms/ODD/CameraSettings/CameraControls/CameraControlsHome.tsx
+++ b/app/src/organisms/ODD/CameraSettings/CameraControls/CameraControlsHome.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { Icon, ListButton, StyledText } from '@opentrons/components'
+import { useCreateCameraImageSettings } from '@opentrons/react-api-client'
 
 import { MediumButton } from '/app/atoms/buttons'
 import { zoomNumberToString } from '/app/local-resources/images/utils/cameraUtils'
@@ -28,6 +29,10 @@ export function CameraControlsHome({
   runId,
 }: CameraControlsHomeProps): JSX.Element {
   const { t } = useTranslation('device_settings')
+  const {
+    createCameraImageSettings,
+    isLoading: isCreateCameraImageSettingsLoading,
+  } = useCreateCameraImageSettings()
   const { isLoading, imgPath, takePhoto } = usePreviewImage(
     {
       zoom: settings.zoom,
@@ -47,6 +52,28 @@ export function CameraControlsHome({
     if (!isLoading) {
       takePhoto()
       setShowModal(true)
+    }
+  }
+
+  const handleRestoreToDefault = (): void => {
+    if (runId == null) {
+      if (!isCreateCameraImageSettingsLoading) {
+        createCameraImageSettings(
+          {
+            zoom: 1,
+            brightness: 50,
+            contrast: 50,
+            saturation: 50,
+          },
+          {
+            onSuccess: () => {
+              settings.restoreToDefault()
+            },
+          }
+        )
+      }
+    } else {
+      settings.restoreToDefault()
     }
   }
 
@@ -109,7 +136,10 @@ export function CameraControlsHome({
         <MediumButton
           buttonType="alert"
           buttonText={t('reset_settings_to_default')}
-          onClick={settings.restoreToDefault}
+          onClick={handleRestoreToDefault}
+          iconName={
+            isCreateCameraImageSettingsLoading ? 'ot-spinner' : undefined
+          }
         />
       </div>
     </div>

--- a/app/src/organisms/ODD/CameraSettings/CameraControls/ImagePreviewModal.tsx
+++ b/app/src/organisms/ODD/CameraSettings/CameraControls/ImagePreviewModal.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react'
 import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
+import { format } from 'date-fns'
 
 import { getTopPortalEl } from '/app/App/portal'
 import { OddModal } from '/app/molecules/OddModal'
@@ -20,9 +21,13 @@ export function ImagePreviewModal({
 }: ImagePreviewModalProps): JSX.Element {
   const { t } = useTranslation('device_settings')
 
+  const displayTimestamp = useMemo(() => {
+    return format(new Date(), 'M/d/yy HH:mm:ss')
+  }, [])
+
   const modalHeader: OddModalHeaderBaseProps = useMemo(
     () => ({
-      title: t('image_preview_timestamp', { timestamp: Math.random() }),
+      title: t('image_preview_timestamp', { timestamp: displayTimestamp }),
       hasExitIcon: true,
       onClick: toggleModal,
     }),

--- a/app/src/organisms/ODD/CameraSettings/CameraControls/cameracontrols.module.css
+++ b/app/src/organisms/ODD/CameraSettings/CameraControls/cameracontrols.module.css
@@ -7,20 +7,23 @@
 .content_container {
   display: flex;
   flex-direction: column;
-  padding: var(--spacing-16) var(--spacing-60) var(--spacing-120) var(--spacing-60);
+  padding: var(--spacing-16) var(--spacing-60) var(--spacing-120)
+    var(--spacing-60);
   margin-top: 7.75rem;
   gap: var(--spacing-24);
 }
 
 .image {
-  /* Fill w/h minus padding. */
+  width: auto;
+  max-width: 41.625rem;
+  height: auto;
+  max-height: 24.0625rem;
   border-radius: var(--border-radius-4);
   object-fit: contain;
 }
 
 .image_container {
   display: flex;
-  width: 100%;
   align-items: center;
   justify-content: center;
 }

--- a/app/src/organisms/ODD/CameraSettings/CameraControls/index.tsx
+++ b/app/src/organisms/ODD/CameraSettings/CameraControls/index.tsx
@@ -37,14 +37,14 @@ export function CameraControls({
   const settings = useCameraSettingsValues(runId)
   const { createCameraImageSettings } = useCreateCameraImageSettings()
 
-  const returnToHomeView = (settings: CameraImageSettings): void => {
+  const returnToHomeView = (partialSettings: CameraImageSettings): void => {
     setIsLoading(true)
 
     const cameraImageSettings: CameraImageSettings = {
-      zoom: settings.zoom,
-      brightness: settings.brightness,
-      contrast: settings.contrast,
-      saturation: settings.saturation,
+      zoom: partialSettings.zoom ?? settings.zoom,
+      brightness: partialSettings.brightness ?? settings.brightness,
+      contrast: partialSettings.contrast ?? settings.contrast,
+      saturation: partialSettings.saturation ?? settings.saturation,
     }
 
     if (runId != null) {


### PR DESCRIPTION
Closes [RQA-5140](https://opentrons.atlassian.net/browse/RQA-5140)

# Overview

This PR addresses a few bugs relating to the preview image modal on the ODD.

85e4e41abd5ffc51555f23ed946f466ddcf2e40d - The preview images were rendering at 100% the width/height of the ODD without any constraints, causing the modal header to be outside the bounds of the ODD, thereby preventing users from closing the image...whoops. To fix, we just add constraints to the preview image as specified by Design.

266137cc69e0d11faf161475b6cae99f5475d425 - After clicking "reset settings to default", we have to POST the default settings to the server and not just update local state.

### Current Behavior

<img width="1034" height="611" alt="Screenshot 2026-02-05 at 1 08 04 PM" src="https://github.com/user-attachments/assets/c0d187a6-d3e4-4d6b-a03b-403ea85121cd" />

### Fixed Behavior

<img width="1020" height="597" alt="Screenshot 2026-02-05 at 4 34 46 PM" src="https://github.com/user-attachments/assets/3b4ec5e0-717a-4929-9926-c794d8575f0f" />

## Test Plan and Hands on Testing

- See images.
- Smoke tested the camera settings on the ODD, confirming proper robot state updates via the network tab.

## Changelog

- It's now possible to close the camera settings preview image on the ODD.
- Fixed the "reset settings to default" button not properly updating robot settings state. 

## Risk assessment

- low, changes are auditable and localized

[RQA-5140]: https://opentrons.atlassian.net/browse/RQA-5140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ