### PR TITLE
fix(app): temperature module spotlight view status copy

### DIFF
--- a/app/src/organisms/Desktop/ProtocolVisualization/ModuleContainer/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/ModuleContainer/index.tsx
@@ -142,10 +142,10 @@ export function ModuleContainer({
       break
     }
     case TEMPERATURE_MODULE_TYPE: {
-      const { status, targetTemperature } = moduleState
+      const { targetTemperature } = moduleState
       moduleDetails = (
         <div className={styles.module_details_status_container}>
-          <ModuleStatusContainer title={status}>
+          <ModuleStatusContainer title="target_temperature">
             <StyledText desktopStyle="bodyDefaultRegular">
               {targetTemperature != null
                 ? t('temperature', { temp: targetTemperature })


### PR DESCRIPTION
closes RQA-5147

# Overview

fix temprature module spotlight view copy

## Test Plan and Hands on Testing

review code, there is no protocol attached to the ticket :( 


## Review requests

instead of showing the status, show the target temp copy

## Risk assessment

low
