### PR TITLE
fix(step-generation, app): add slot to stack location when storing in stacker

### DIFF
--- a/app/src/organisms/Desktop/ProtocolVisualization/SlotDetails/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/SlotDetails/index.tsx
@@ -117,7 +117,7 @@ export function SlotDetails(props: SlotDetailsProps): JSX.Element {
               moduleId={moduleOnSlot[0]}
               moduleEntities={moduleEntities}
               moduleRobotState={modules}
-              slotId={slotId}
+              slotId={mappedSlot}
             />
           ) : null}
         </div>

--- a/step-generation/src/getNextRobotStateAndWarnings/__tests__/stackerUpdates.test.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/__tests__/stackerUpdates.test.ts
@@ -257,6 +257,7 @@ describe('flex stacker state updates forFlexStackerStore', () => {
       'tiprack4Id',
       HOPPER_STACKER_LOCATION,
       FLEX_STACKER_ID,
+      '1',
     ])
   })
 })

--- a/step-generation/src/getNextRobotStateAndWarnings/stackerUpdates.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/stackerUpdates.ts
@@ -581,6 +581,7 @@ export const forFlexStackerStore = (
   const { robotState } = robotStateAndWarnings
   const { moduleId } = params
   const moduleState = flexStackerStateGetter(robotState, moduleId)
+  const moduleSlot = robotState.modules[moduleId].slot
   if (moduleState != null) {
     const { labwareOnShuttle } = moduleState
     if (labwareOnShuttle != null) {
@@ -602,6 +603,7 @@ export const forFlexStackerStore = (
             labwareId,
             HOPPER_STACKER_LOCATION,
             moduleId,
+            moduleSlot,
           ]
         }
       }


### PR DESCRIPTION
closes RQA-5159

# Overview

The stacker spotlight window view shows the slot instead of the fake hopper slot

add moduleSlot to the stack location when storing something into the hopper -> this is a bug that theoretically also affects PD when storing a labware into the hopper (I'll ask Alex to QA that for the PD 8.9.0 release) 🤔 

## Test Plan and Hands on Testing

test the first attached protocol, see that if you click on the hopper when a labware is added to it, the labware shows up in the spotlight view

## Changelog

add module slot and fix slotId type to not include the fake hopper slot

## Risk assessment

low