### PR TITLE
docs(system-server): Deprecate old experimental auth endpoints

### DIFF
--- a/system-server/system_server/app_setup.py
+++ b/system-server/system_server/app_setup.py
@@ -5,12 +5,17 @@ from typing import Any, List
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.openapi.docs import get_redoc_html
+from fastapi.responses import HTMLResponse
 
 from server_utils.fastapi_utils.server_timing_middleware import server_timing_middleware
 
 from system_server._version import version
 from system_server.router import router
 from system_server.settings import get_settings
+
+_REDOC_CDN_URL = "https://cdn.jsdelivr.net/npm/redoc@2/bundles/redoc.standalone.js"
+
 
 log = logging.getLogger(__name__)
 
@@ -22,8 +27,9 @@ app = FastAPI(
     ),
     version=version,
     openapi_url="/system/openapi.json",
-    docs_url="/system/docs",
-    redoc_url="/system/redoc",
+    docs_url=None,
+    # redoc_url is replaced by our own /redoc router, below.
+    redoc_url=None,
 )
 
 app.add_middleware(
@@ -59,3 +65,22 @@ async def on_shutdown() -> None:
 
     for e in shutdown_errors:
         log.warning("Error during shutdown", exc_info=e)
+
+
+# This is a workaround for a broken /redoc page in versions of FastAPI <0.115.3.
+# The page loads Redoc from a CDN, and the problem is that the default CDN URL
+# uses a fragile version tag.
+# https://github.com/Redocly/redoc/issues/2743
+# https://github.com/fastapi/fastapi/pull/9700
+@app.get("/system/redoc", include_in_schema=False)
+async def redoc_html() -> HTMLResponse:  # noqa: D103
+    if app.openapi_url is None:
+        raise RuntimeError(
+            "Couldn't get OpenAPI URL from FastAPI."
+            + " This is probably some kind of misconfiguration."
+        )
+    return get_redoc_html(
+        openapi_url=app.openapi_url,
+        title=app.title,
+        redoc_js_url=_REDOC_CDN_URL,
+    )

--- a/system-server/system_server/service/check_jwt_headers.py
+++ b/system-server/system_server/service/check_jwt_headers.py
@@ -16,7 +16,7 @@ async def check_registration_token_header(
     request: Request,
     authenticationBearer: str = Header(
         ...,
-        description="An authentication header bearing a token provided by the /system/register endpoint.",
+        description="An authentication header bearing a token provided by the `/system/register` endpoint.",
     ),
     signing_key: UUID = Depends(get_persistent_uuid),
 ) -> None:
@@ -47,7 +47,7 @@ async def check_authorization_token_header(
     request: Request,
     authenticationBearer: str = Header(
         ...,
-        description="An authentication header bearing a token provided by the /system/authorize endpoint.",
+        description="An authentication header bearing a token provided by the `/system/authorize` endpoint.",
     ),
     signing_key: UUID = Depends(get_persistent_uuid),
 ) -> None:

--- a/system-server/system_server/system/authorize/router.py
+++ b/system-server/system_server/system/authorize/router.py
@@ -1,5 +1,6 @@
 """Router for all /system/ endpoints."""
 
+from textwrap import dedent
 from typing import List, Optional
 from uuid import UUID
 
@@ -22,7 +23,19 @@ authorize_router = APIRouter()
 
 @authorize_router.post(
     "/system/authorize",
-    summary="Obtain an authorization token for this session.",
+    deprecated=True,
+    summary="Obtain an authorization token for this session",
+    description=dedent(
+        """\
+        This was part of an experimental set of endpoints for authorization.
+        It's kept for compatibility reasons. Do not use it in new code.
+        Use the `/auth` endpoints instead.
+
+        Given a valid registration token from `/system/register`,
+        this returns a new authorization token, which is not used for anything.
+        It also adds an entry to `/system/connected`.
+        """
+    ),
     response_model=PostAuthorizeResponse,
     status_code=status.HTTP_201_CREATED,
     dependencies=[Depends(check_registration_token_header)],
@@ -44,7 +57,8 @@ async def authorize(
 
 @authorize_router.get(
     "/system/authorize",
-    summary="Verify an authorization token.",
+    deprecated=True,
+    summary="Verify an authorization token",
     dependencies=[Depends(check_authorization_token_header)],
     responses={
         status.HTTP_200_OK: {

--- a/system-server/system_server/system/connected/router.py
+++ b/system-server/system_server/system/connected/router.py
@@ -1,5 +1,7 @@
 """Router for all /system/connected endpoints."""
 
+from textwrap import dedent
+
 from fastapi import APIRouter, Depends, status
 
 from .models import Connection, GetConnectedResponse
@@ -11,7 +13,18 @@ connected_router = APIRouter()
 
 @connected_router.get(
     "/system/connected",
-    summary="Obtain a list of all connected registrants.",
+    deprecated=True,
+    summary="Obtain a list of all active authorizations",
+    description=dedent(
+        """\
+        This was part of an experimental set of endpoints for authorization.
+        It's kept for compatibility reasons. Do not use it in new code.
+        Use the `/auth` endpoints instead.
+
+        This returns all the active (unexpired) authorizations that were created
+        through `/system/authorize`.
+        """
+    ),
     status_code=status.HTTP_200_OK,
     response_model=GetConnectedResponse,
 )

--- a/system-server/system_server/system/oem_mode/router.py
+++ b/system-server/system_server/system/oem_mode/router.py
@@ -27,7 +27,8 @@ oem_mode_router = APIRouter()
 
 @oem_mode_router.put(
     "/system/oem_mode/enable",
-    summary="Enable or Disable OEM Mode for this robot.",
+    summary="Enable or disable OEM Mode",
+    description="Enable or disable OEM Mode",
     responses={
         status.HTTP_200_OK: {"message": "OEM Mode changed successfully."},
         status.HTTP_400_BAD_REQUEST: {"message": "OEM Mode did not changed."},
@@ -56,7 +57,8 @@ async def enable_oem_mode_endpoint(
 
 @oem_mode_router.post(
     "/system/oem_mode/upload_splash",
-    summary="Upload an image to be used as the boot up splash screen.",
+    summary="Upload an image for the boot up splash screen",
+    description="Upload an image for the boot up splash screen",
     responses={
         status.HTTP_201_CREATED: {"message": "OEM Mode splash screen uploaded"},
         status.HTTP_400_BAD_REQUEST: {"message": "OEM Mode splash screen not set"},

--- a/system-server/system_server/system/register/router.py
+++ b/system-server/system_server/system/register/router.py
@@ -1,5 +1,6 @@
 """Router for /system/register endpoint."""
 
+from textwrap import dedent
 from uuid import UUID
 
 import sqlalchemy
@@ -16,7 +17,18 @@ register_router = APIRouter()
 
 @register_router.post(
     "/system/register",
-    summary="Register an agent with this robot.",
+    deprecated=True,
+    summary="Register a client with this robot",
+    description=dedent(
+        """\
+        This was part of an experimental set of endpoints for authorization.
+        It's kept for compatibility reasons. Do not use it in new code.
+        Use the `/auth` endpoints instead.
+
+        This registers a client (basically just storing the information you pass in)
+        and returns a registration token that you can pass to `/system/authorize`.
+        Identical information is deduplicated, so this is safe to call multiple times.
+        """),
     responses={
         status.HTTP_200_OK: {"model": PostRegisterResponse},
         status.HTTP_201_CREATED: {"model": PostRegisterResponse},


### PR DESCRIPTION
## Overview

Following discussion in #20785 this documents `/system/register`, `/system/authorize`, and `/system/connected` as deprecated. Closes EXEC-2151.

This also tidies up some other docstrings in system-server, and copies #20251's redoc fix from robot-server to system-server.

## Test Plan and Hands on Testing

* [x] Run `make -C system-server dev` and peruse http://localhost:32950/system/redoc.

## Review requests

None.

## Risk assessment

Low.