### PR TITLE
chore: Fix Makefile quoting bugs

### DIFF
--- a/scripts/push.mk
+++ b/scripts/push.mk
@@ -59,7 +59,7 @@ endef
 # argument 4 is the unit file path
 define push-systemd-unit
 	scp $(call id-file-arg,$(2)) $(scp-legacy-option-flag) $(3) "$(4)" root@$(1):/data/
-	ssh $(call id-file-arg,$(2)) "$(3)" root@$(1) "mount -o remount,rw / && mv /data/$(notdir $(4)) /etc/systemd/system/ && systemctl daemon-reload && mount -o remount,ro / || mount -o remount,ro /"
+	ssh $(call id-file-arg,$(2)) $(3) root@$(1) "mount -o remount,rw / && mv /data/$(notdir $(4)) /etc/systemd/system/ && systemctl daemon-reload && mount -o remount,ro / || mount -o remount,ro /"
 endef
 
 # id-file-arg: Internal helper for generating the -i arg for ssh/scp commands
@@ -89,7 +89,7 @@ define sync-version-file
 	@echo package-version: $(4)
 	$(shell python -c '$(VERSION_HELPER)')
 	$(eval filepath=$(shell find . -type f -name new_version_file.json))
-	scp $(call id-file-arg,$(2)) $(scp-legacy-option-flag) "$(3)" "${filepath} root@$(1):/data/VERSION.json
+	scp $(call id-file-arg,$(2)) $(scp-legacy-option-flag) $(3) "${filepath}" root@$(1):/data/VERSION.json
 	ssh $(call id-file-arg,$(2)) $(3) root@$(1) "mount -o remount,rw / && cp /data/VERSION.json /etc/VERSION.json && mount -o remount,ro / || mount -o remount,ro /"
 	rm -rf "${filepath}"
 endef


### PR DESCRIPTION
## Overview

This fixes a Makefile bug causing errors when we run `make push`:

 > command-line line 0: keyword stricthostkeychecking extra arguments at end of line

## Details

`$(ssh_opts)` is a space-separated list of arguments, normally something like `-o stricthostkeychecking=no -o userknownhostsfile=/dev/null`. In `push-systemd-unit`, we were mistakenly expanding it as a quoted string, `"$(3)"`, which meant `ssh` received the whole space-separated list as a single argument, which it couldn't parse. We want the shell to split it into multiple arguments, so to do that, this PR just removes the quotes.

This has only affected `make push`, not `make push-ot3`, because `make push-ot3` doesn't need to use `push-systemd-unit`.

performance-metrics' `make override-robot-version` target had the same bug, in addition to an extra unclosed `"`. I guess that went unnoticed simply because because nobody has been running that.

## Test Plan and Hands on Testing

* [x] `make -C robot-server push` works on an OT-2.

## Review requests

One of the commit messages in PR #18661 says that the quoting was like this in order to fix something about Windows compatibility. If anyone still remembers what the problem was, we can take another look at that. It's possible that something did need to be quoted, this was just not quite the right place to do it.

## Risk assessment

Medium. Might re-break something on Windows.