### PR TITLE
fix(app): fix CommandStyledText li styling in command steps

### DIFF
--- a/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/annotatedsteps.module.css
+++ b/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/annotatedsteps.module.css
@@ -80,6 +80,24 @@
   word-break: break-all;
 }
 
+.individual_command_text :global(ul),
+.individual_command_text :global(ol) {
+  padding-left: 0;
+  margin: 0;
+}
+
+.individual_command_text :global(li) {
+  position: relative;
+  padding-left: var(--spacing-10);
+  list-style: none;
+}
+
+.individual_command_text :global(li)::before {
+  position: absolute;
+  left: 0;
+  content: '•';
+}
+
 .annotated_steps_container {
   width: 100%;
   height: 100%;


### PR DESCRIPTION
# Overview
fix CommandStyledText li styling in command steps

[before]
<img width="239" height="506" alt="Screenshot 2026-02-06 at 5 31 21 PM" src="https://github.com/user-attachments/assets/c1c7308d-0ae7-4dc7-9a69-d3c7c4f73b1e" />


[after]
<img width="229" height="510" alt="Screenshot 2026-02-06 at 5 59 27 PM" src="https://github.com/user-attachments/assets/c4c467d5-d418-41b1-8326-198ecc83bc14" />


[thread](https://opentrons.slack.com/archives/C09AFFN9N83/p1770419293391529?thread_ts=1770418790.799629&cid=C09AFFN9N83)

close RQA-5176

## Test Plan and Hands on Testing
- import the protocol that is attached to the ticket
- visualize the protocol
- move to step 159

## Changelog
- add CSS styling for li/ul/ol

## Review requests


## Risk assessment
low
