### PR TITLE
fix(protocol-designer): handle combo fixtures in the onboarding flow

### DIFF
--- a/protocol-designer/src/components/organisms/HardwareConfigurator/AddFixtureModal.tsx
+++ b/protocol-designer/src/components/organisms/HardwareConfigurator/AddFixtureModal.tsx
@@ -267,11 +267,28 @@ export function AddFixtureModal(props: AddFixtureModalProps): JSX.Element {
     )
     if (moduleModel == null) return
 
+    // Get the first existing module in this cutout (if any) before filtering
+    const matchedModuleEntry = Object.entries(modules).find(
+      ([, module]) => module.cutoutId === newModule.cutoutId
+    )
+    const matchedModule =
+      matchedModuleEntry != null ? matchedModuleEntry[1] : undefined
+
+    // Remove all existing modules in this cutout (handles duplicates)
     const filteredModules = Object.fromEntries(
       Object.entries(modules).filter(
         ([, module]) => module.cutoutId !== newModule.cutoutId
       )
     )
+
+    const matchedComboFixtureId =
+      matchedModule != null
+        ? getComboFixtureFromFixtureIds([
+            matchedModule.cutoutFixtureId as CutoutFixtureId,
+            newModule.cutoutFixtureId as CutoutFixtureId,
+          ])
+        : undefined
+
     const isThermocyclerModule = getCutoutFixturesForModuleModel(
       THERMOCYCLER_MODULE_V2,
       deckDef
@@ -281,6 +298,10 @@ export function AddFixtureModal(props: AddFixtureModalProps): JSX.Element {
 
     const updatedModules: FormModules = {
       ...filteredModules,
+      // Re-add the matched module under the combo fixture key if a combo exists
+      ...(matchedModule != null && matchedComboFixtureId != null
+        ? { [matchedComboFixtureId]: matchedModule }
+        : {}),
       [uuid()]: {
         model: moduleModel,
         type: getModuleType(moduleModel as ModuleModel),

--- a/protocol-designer/src/components/organisms/HardwareConfigurator/AddFixtureModal.tsx
+++ b/protocol-designer/src/components/organisms/HardwareConfigurator/AddFixtureModal.tsx
@@ -299,7 +299,7 @@ export function AddFixtureModal(props: AddFixtureModalProps): JSX.Element {
     const matchedComboFixtureId =
       matchedModule != null
         ? getComboFixtureFromFixtureIds([
-            moduleFixtureId as CutoutFixtureId,
+            moduleFixtureId!,
             newModule.cutoutFixtureId as CutoutFixtureId,
           ])
         : undefined
@@ -341,7 +341,7 @@ export function AddFixtureModal(props: AddFixtureModalProps): JSX.Element {
     const matchedFixture = matchedEntry != null ? matchedEntry[1] : undefined
 
     const matchedComboFixtureId = getComboFixtureFromFixtureIds([
-      (matchedFixture?.cutoutFixtureId as CutoutFixtureId) ?? '',
+      matchedFixture?.cutoutFixtureId! ?? '',
       newFixture.cutoutFixtureId as CutoutFixtureId,
     ])
     const filteredFixtures = Object.fromEntries(

--- a/protocol-designer/src/components/organisms/HardwareConfigurator/AddFixtureModal.tsx
+++ b/protocol-designer/src/components/organisms/HardwareConfigurator/AddFixtureModal.tsx
@@ -271,8 +271,11 @@ export function AddFixtureModal(props: AddFixtureModalProps): JSX.Element {
     const matchedModuleEntry = Object.entries(modules).find(
       ([, module]) => module.cutoutId === newModule.cutoutId
     )
+    const module = matchedModuleEntry != null ? matchedModuleEntry[1] : undefined
+    const moduleFixtureId = module != null ? getCutoutFixturesForModuleModel(module.model as ModuleModel, deckDef)[0].id : undefined
+
     const matchedModule =
-      matchedModuleEntry != null ? matchedModuleEntry[1] : undefined
+      matchedModuleEntry != null ? getCutoutFixturesForModuleModel(matchedModuleEntry[1].model as ModuleModel, deckDef)[0] : undefined
 
     // Remove all existing modules in this cutout (handles duplicates)
     const filteredModules = Object.fromEntries(
@@ -284,7 +287,7 @@ export function AddFixtureModal(props: AddFixtureModalProps): JSX.Element {
     const matchedComboFixtureId =
       matchedModule != null
         ? getComboFixtureFromFixtureIds([
-            matchedModule.cutoutFixtureId as CutoutFixtureId,
+            moduleFixtureId as CutoutFixtureId,
             newModule.cutoutFixtureId as CutoutFixtureId,
           ])
         : undefined
@@ -298,9 +301,8 @@ export function AddFixtureModal(props: AddFixtureModalProps): JSX.Element {
 
     const updatedModules: FormModules = {
       ...filteredModules,
-      // Re-add the matched module under the combo fixture key if a combo exists
-      ...(matchedModule != null && matchedComboFixtureId != null
-        ? { [matchedComboFixtureId]: matchedModule }
+      ...(matchedModule != null && matchedComboFixtureId != null && matchedModuleEntry != null
+        ? { [matchedModuleEntry[0]]: matchedModuleEntry[1] }
         : {}),
       [uuid()]: {
         model: moduleModel,

--- a/protocol-designer/src/components/organisms/HardwareConfigurator/AddFixtureModal.tsx
+++ b/protocol-designer/src/components/organisms/HardwareConfigurator/AddFixtureModal.tsx
@@ -20,6 +20,7 @@ import {
   FIXTURES_FIXTURE_IDS,
   FLEX_ROBOT_TYPE,
   getAADisplayName,
+  getComboFixtureFromFixtureIds,
   getCutoutFixturesForModuleModel,
   getDeckDefFromRobotType,
   getFixtureDisplayName,
@@ -296,6 +297,16 @@ export function AddFixtureModal(props: AddFixtureModalProps): JSX.Element {
   }
 
   const handleAddNewFixture = (newFixture: CutoutConfigMap): void => {
+    // Get the first existing fixture in this cutout (if any)
+    const matchedEntry = Object.entries(fixtures).find(
+      ([, fixture]) => fixture.cutoutId === newFixture.cutoutId
+    )
+    const matchedFixture = matchedEntry != null ? matchedEntry[1] : undefined
+
+    const matchedComboFixtureId = getComboFixtureFromFixtureIds([
+      (matchedFixture?.cutoutFixtureId as CutoutFixtureId) ?? '',
+      newFixture.cutoutFixtureId as CutoutFixtureId,
+    ])
     const filteredFixtures = Object.fromEntries(
       Object.entries(fixtures).filter(
         ([, fixture]) => fixture.cutoutId !== newFixture.cutoutId
@@ -309,6 +320,9 @@ export function AddFixtureModal(props: AddFixtureModalProps): JSX.Element {
 
     const updatedFixtures: Fixtures = {
       ...filteredFixtures,
+      ...(matchedFixture != null && matchedComboFixtureId != null
+        ? { [matchedComboFixtureId]: matchedFixture }
+        : {}),
       [uuid()]: {
         name:
           (mapFixtureIdToFixtureName(fixtureName) as FixtureName) ??

--- a/protocol-designer/src/components/organisms/HardwareConfigurator/AddFixtureModal.tsx
+++ b/protocol-designer/src/components/organisms/HardwareConfigurator/AddFixtureModal.tsx
@@ -271,11 +271,23 @@ export function AddFixtureModal(props: AddFixtureModalProps): JSX.Element {
     const matchedModuleEntry = Object.entries(modules).find(
       ([, module]) => module.cutoutId === newModule.cutoutId
     )
-    const module = matchedModuleEntry != null ? matchedModuleEntry[1] : undefined
-    const moduleFixtureId = module != null ? getCutoutFixturesForModuleModel(module.model as ModuleModel, deckDef)[0].id : undefined
+    const module =
+      matchedModuleEntry != null ? matchedModuleEntry[1] : undefined
+    const moduleFixtureId =
+      module != null
+        ? getCutoutFixturesForModuleModel(
+            module.model as ModuleModel,
+            deckDef
+          )[0].id
+        : undefined
 
     const matchedModule =
-      matchedModuleEntry != null ? getCutoutFixturesForModuleModel(matchedModuleEntry[1].model as ModuleModel, deckDef)[0] : undefined
+      matchedModuleEntry != null
+        ? getCutoutFixturesForModuleModel(
+            matchedModuleEntry[1].model as ModuleModel,
+            deckDef
+          )[0]
+        : undefined
 
     // Remove all existing modules in this cutout (handles duplicates)
     const filteredModules = Object.fromEntries(
@@ -301,7 +313,9 @@ export function AddFixtureModal(props: AddFixtureModalProps): JSX.Element {
 
     const updatedModules: FormModules = {
       ...filteredModules,
-      ...(matchedModule != null && matchedComboFixtureId != null && matchedModuleEntry != null
+      ...(matchedModule != null &&
+      matchedComboFixtureId != null &&
+      matchedModuleEntry != null
         ? { [matchedModuleEntry[0]]: matchedModuleEntry[1] }
         : {}),
       [uuid()]: {

--- a/protocol-designer/src/components/organisms/HardwareConfigurator/__tests__/AddFixtureModal.test.tsx
+++ b/protocol-designer/src/components/organisms/HardwareConfigurator/__tests__/AddFixtureModal.test.tsx
@@ -9,7 +9,11 @@ import { getInitialDeckSetup } from '/protocol-designer/step-forms/selectors'
 import { AddFixtureModal, InitialDeckStateModules } from '../AddFixtureModal'
 
 import type { ComponentProps } from 'react'
-import type { AddressableAreaName, CutoutId, DeckConfiguration } from '@opentrons/shared-data'
+import type {
+  AddressableAreaName,
+  CutoutId,
+  DeckConfiguration,
+} from '@opentrons/shared-data'
 import type { FormModules } from '/protocol-designer/step-forms'
 import type { Fixtures } from '../../types'
 
@@ -157,17 +161,24 @@ describe('AddFixtureModal', () => {
     const modulesInD3 = moduleValues.filter(m => m.cutoutId === 'cutoutD3')
     expect(modulesInD3.length).toBeGreaterThanOrEqual(1)
     // The new module should be a flex stacker
-    console.log('modulesInD3: ', modulesInD3)
     expect(modulesInD3).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({
-          model: 'flexStackerModuleV1',
-          type: 'flexStackerModuleType',
-        }),
-        expect.objectContaining({
-          cutoutFixtureId: 'magneticBlockV1',
+        {
+          id: 'magneticBlockV1',
+          cutoutId: 'cutoutD3',
+          model: 'magneticBlockV1',
+          slot: 'D3',
           type: 'magneticBlockType',
-        }),
+          moduleState: {} as any,
+          pythonName: 'magneticBlockV1',
+        },
+        {
+          cutoutFixtureId: 'flexStackerModuleV1',
+          cutoutId: 'cutoutD3',
+          model: 'flexStackerModuleV1',
+          slot: 'D4',
+          type: 'flexStackerModuleType',
+        },
       ])
     )
   })

--- a/protocol-designer/src/components/organisms/HardwareConfigurator/__tests__/AddFixtureModal.test.tsx
+++ b/protocol-designer/src/components/organisms/HardwareConfigurator/__tests__/AddFixtureModal.test.tsx
@@ -96,20 +96,25 @@ describe('AddFixtureModal', () => {
     fireEvent.click(screen.getByText('Waste Chute'))
     fireEvent.click(screen.getAllByText('Add')[0])
     expect(props.setValue).toHaveBeenCalled()
-    expect(props.setValue).toHaveBeenCalledWith(
-      'fixtures',
-      expect.objectContaining({
-        stagingAreaSlotWithWasteChuteRightAdapterNoCover: {
+    expect(props.setValue).toHaveBeenCalledWith('fixtures', expect.any(Object))
+    const setValue = vi.mocked(props.setValue!)
+    const fixturesCall = setValue.mock.calls.find(c => c[0] === 'fixtures')
+    if (fixturesCall == null) throw new Error('expected fixtures call')
+    const updatedFixtures = fixturesCall[1] as Fixtures
+    const fixtureValues = Object.values(updatedFixtures)
+    expect(fixtureValues).toEqual(
+      expect.arrayContaining([
+        {
           cutoutFixtureId: 'stagingAreaRightSlot',
           cutoutId: 'cutoutD3',
           name: 'stagingArea',
         },
-        wasteChuteRightAdapterNoCover: {
+        {
           cutoutFixtureId: 'wasteChuteRightAdapterNoCover',
           cutoutId: 'cutoutD3',
           name: 'wasteChute',
         },
-      })
+      ])
     )
   })
 })

--- a/protocol-designer/src/components/organisms/HardwareConfigurator/__tests__/AddFixtureModal.test.tsx
+++ b/protocol-designer/src/components/organisms/HardwareConfigurator/__tests__/AddFixtureModal.test.tsx
@@ -6,10 +6,11 @@ import { i18n } from '/protocol-designer/assets/localization'
 import { editDeckConfiguration } from '/protocol-designer/step-forms/actions'
 import { getInitialDeckSetup } from '/protocol-designer/step-forms/selectors'
 
-import { AddFixtureModal } from '../AddFixtureModal'
+import { AddFixtureModal, InitialDeckStateModules } from '../AddFixtureModal'
 
 import type { ComponentProps } from 'react'
 import type { CutoutId, DeckConfiguration } from '@opentrons/shared-data'
+import type { FormModules } from '/protocol-designer/step-forms'
 import type { Fixtures } from '../../types'
 
 vi.mock('/protocol-designer/step-forms/actions')
@@ -114,6 +115,50 @@ describe('AddFixtureModal', () => {
           cutoutId: 'cutoutD3',
           name: 'wasteChute',
         },
+      ])
+    )
+  })
+
+  it('should handle two modules in same cutout when adding a new module (uses first match)', () => {
+    const existingModules: InitialDeckStateModules = {
+      magneticBlockV1: {
+        id: 'magneticBlockV1',
+        cutoutId: 'cutoutD3' as CutoutId,
+        model: 'magneticBlockV1',
+        type: 'magneticBlockType',
+        slot: 'D3',
+        moduleState: {} as any,
+        pythonName: 'magneticBlockV1',
+      },
+    }
+    const updatedProps = {
+      ...props,
+      modules: existingModules,
+      cutoutId: 'cutoutD3' as CutoutId,
+      addressableAreaId: 'D3' as const,
+    }
+    render(updatedProps)
+    screen.getByText('Modules')
+    fireEvent.click(screen.getAllByText('Select options')[1])
+    screen.getByText('Flex Stacker Module V1')
+    fireEvent.click(screen.getAllByText('Add')[0])
+    expect(props.setValue).toHaveBeenCalled()
+    expect(props.setValue).toHaveBeenCalledWith('modules', expect.any(Object))
+    const setValue = vi.mocked(props.setValue!)
+    const modulesCall = setValue.mock.calls.find(c => c[0] === 'modules')
+    if (modulesCall == null) throw new Error('expected modules call')
+    const updatedModules = modulesCall[1] as FormModules
+    const moduleValues = Object.values(updatedModules)
+    // The two duplicates in cutoutA1 should be removed and replaced by the new module
+    const modulesInA1 = moduleValues.filter(m => m.cutoutId === 'cutoutA1')
+    expect(modulesInA1.length).toBeGreaterThanOrEqual(1)
+    // The new module should be a heater-shaker
+    expect(modulesInA1).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          model: 'flexStackerModuleV1',
+          type: 'flexStackerModuleType',
+        }),
       ])
     )
   })

--- a/protocol-designer/src/components/organisms/HardwareConfigurator/__tests__/AddFixtureModal.test.tsx
+++ b/protocol-designer/src/components/organisms/HardwareConfigurator/__tests__/AddFixtureModal.test.tsx
@@ -138,13 +138,13 @@ describe('AddFixtureModal', () => {
       ...props,
       modules: existingModules,
       cutoutId: 'cutoutD3' as CutoutId,
-      addressableAreaId: 'D4' as AddressableAreaName,
+      addressableAreaId: 'fakeD4' as AddressableAreaName,
       deckConfig: updatedDeckConfig,
     }
     render(updatedProps)
     screen.getByText('Modules')
     fireEvent.click(screen.getAllByText('Select options')[1])
-    screen.getByText('Flex Stacker Module V1')
+    screen.getByText('Flex Stacker Module GEN1')
     fireEvent.click(screen.getAllByText('Add')[0])
     expect(props.setValue).toHaveBeenCalled()
     expect(props.setValue).toHaveBeenCalledWith('modules', expect.any(Object))
@@ -157,11 +157,16 @@ describe('AddFixtureModal', () => {
     const modulesInD3 = moduleValues.filter(m => m.cutoutId === 'cutoutD3')
     expect(modulesInD3.length).toBeGreaterThanOrEqual(1)
     // The new module should be a flex stacker
+    console.log('modulesInD3: ', modulesInD3)
     expect(modulesInD3).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           model: 'flexStackerModuleV1',
           type: 'flexStackerModuleType',
+        }),
+        expect.objectContaining({
+          cutoutFixtureId: 'magneticBlockV1',
+          type: 'magneticBlockType',
         }),
       ])
     )

--- a/protocol-designer/src/components/organisms/HardwareConfigurator/__tests__/AddFixtureModal.test.tsx
+++ b/protocol-designer/src/components/organisms/HardwareConfigurator/__tests__/AddFixtureModal.test.tsx
@@ -9,7 +9,7 @@ import { getInitialDeckSetup } from '/protocol-designer/step-forms/selectors'
 import { AddFixtureModal, InitialDeckStateModules } from '../AddFixtureModal'
 
 import type { ComponentProps } from 'react'
-import type { CutoutId, DeckConfiguration } from '@opentrons/shared-data'
+import type { AddressableAreaName, CutoutId, DeckConfiguration } from '@opentrons/shared-data'
 import type { FormModules } from '/protocol-designer/step-forms'
 import type { Fixtures } from '../../types'
 
@@ -35,7 +35,7 @@ describe('AddFixtureModal', () => {
         { cutoutId: 'cutoutA1', cutoutFixtureId: 'magneticBlockV1' },
       ],
       setValue: vi.fn(),
-      hasGripper: false,
+      hasGripper: true,
       addressableAreaId: 'A1',
     }
     vi.mocked(getInitialDeckSetup).mockReturnValue({
@@ -119,7 +119,7 @@ describe('AddFixtureModal', () => {
     )
   })
 
-  it('should handle two modules in same cutout when adding a new module (uses first match)', () => {
+  it.only('should handle two modules in same cutout when adding a new module (uses first match)', () => {
     const existingModules: InitialDeckStateModules = {
       magneticBlockV1: {
         id: 'magneticBlockV1',
@@ -131,11 +131,15 @@ describe('AddFixtureModal', () => {
         pythonName: 'magneticBlockV1',
       },
     }
+    const updatedDeckConfig: DeckConfiguration = [
+      { cutoutId: 'cutoutD3', cutoutFixtureId: 'magneticBlockV1' },
+    ]
     const updatedProps = {
       ...props,
       modules: existingModules,
       cutoutId: 'cutoutD3' as CutoutId,
-      addressableAreaId: 'D3' as const,
+      addressableAreaId: 'D4' as AddressableAreaName,
+      deckConfig: updatedDeckConfig,
     }
     render(updatedProps)
     screen.getByText('Modules')
@@ -149,11 +153,11 @@ describe('AddFixtureModal', () => {
     if (modulesCall == null) throw new Error('expected modules call')
     const updatedModules = modulesCall[1] as FormModules
     const moduleValues = Object.values(updatedModules)
-    // The two duplicates in cutoutA1 should be removed and replaced by the new module
-    const modulesInA1 = moduleValues.filter(m => m.cutoutId === 'cutoutA1')
-    expect(modulesInA1.length).toBeGreaterThanOrEqual(1)
-    // The new module should be a heater-shaker
-    expect(modulesInA1).toEqual(
+    // The existing module in cutoutD3 should be removed and replaced by the new module
+    const modulesInD3 = moduleValues.filter(m => m.cutoutId === 'cutoutD3')
+    expect(modulesInD3.length).toBeGreaterThanOrEqual(1)
+    // The new module should be a flex stacker
+    expect(modulesInD3).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           model: 'flexStackerModuleV1',

--- a/protocol-designer/src/components/organisms/HardwareConfigurator/__tests__/AddFixtureModal.test.tsx
+++ b/protocol-designer/src/components/organisms/HardwareConfigurator/__tests__/AddFixtureModal.test.tsx
@@ -6,7 +6,7 @@ import { i18n } from '/protocol-designer/assets/localization'
 import { editDeckConfiguration } from '/protocol-designer/step-forms/actions'
 import { getInitialDeckSetup } from '/protocol-designer/step-forms/selectors'
 
-import { AddFixtureModal, InitialDeckStateModules } from '../AddFixtureModal'
+import { AddFixtureModal } from '../AddFixtureModal'
 
 import type { ComponentProps } from 'react'
 import type {
@@ -16,6 +16,7 @@ import type {
 } from '@opentrons/shared-data'
 import type { FormModules } from '/protocol-designer/step-forms'
 import type { Fixtures } from '../../types'
+import type { InitialDeckStateModules } from '../AddFixtureModal'
 
 vi.mock('/protocol-designer/step-forms/actions')
 vi.mock('/protocol-designer/feature-flags/selectors')
@@ -48,7 +49,6 @@ describe('AddFixtureModal', () => {
       additionalEquipmentOnDeck: {},
       pipettes: {},
     })
-    vi.resetAllMocks
   })
 
   it('should render the fixture modal and clicking on the fixtures can select the trash bin', () => {

--- a/protocol-designer/src/components/organisms/HardwareConfigurator/__tests__/AddFixtureModal.test.tsx
+++ b/protocol-designer/src/components/organisms/HardwareConfigurator/__tests__/AddFixtureModal.test.tsx
@@ -9,6 +9,8 @@ import { getInitialDeckSetup } from '/protocol-designer/step-forms/selectors'
 import { AddFixtureModal } from '../AddFixtureModal'
 
 import type { ComponentProps } from 'react'
+import type { CutoutId, DeckConfiguration } from '@opentrons/shared-data'
+import type { Fixtures } from '../../types'
 
 vi.mock('/protocol-designer/step-forms/actions')
 vi.mock('/protocol-designer/feature-flags/selectors')
@@ -41,6 +43,7 @@ describe('AddFixtureModal', () => {
       additionalEquipmentOnDeck: {},
       pipettes: {},
     })
+    vi.resetAllMocks
   })
 
   it('should render the fixture modal and clicking on the fixtures can select the trash bin', () => {
@@ -65,5 +68,48 @@ describe('AddFixtureModal', () => {
     fireEvent.click(screen.getAllByText('Add')[1])
     expect(props.setValue).toHaveBeenCalled()
     expect(vi.mocked(editDeckConfiguration)).toHaveBeenCalled()
+  })
+
+  it('should use existing fixture in same cutout when adding a new fixture (one existing)', () => {
+    const existingFixtures: Fixtures = {
+      'existing-id': {
+        cutoutId: 'cutoutD3' as CutoutId,
+        name: 'stagingArea',
+        cutoutFixtureId: 'stagingAreaRightSlot',
+      },
+    }
+    const updatedDeckConfig: DeckConfiguration = [
+      { cutoutId: 'cutoutA1', cutoutFixtureId: 'magneticBlockV1' },
+      { cutoutId: 'cutoutD3', cutoutFixtureId: 'stagingAreaRightSlot' },
+    ]
+    const updatedProps = {
+      ...props,
+      cutoutId: 'cutoutD3' as CutoutId,
+      addressableAreaId: 'D3' as const,
+      deckConfig: updatedDeckConfig,
+      fixtures: existingFixtures,
+    }
+    render(updatedProps)
+    fireEvent.click(screen.getAllByText('Select options')[0])
+    fireEvent.click(screen.getByText('Waste chute'))
+    fireEvent.click(screen.getAllByText('Select options')[0])
+    fireEvent.click(screen.getByText('Waste Chute'))
+    fireEvent.click(screen.getAllByText('Add')[0])
+    expect(props.setValue).toHaveBeenCalled()
+    expect(props.setValue).toHaveBeenCalledWith(
+      'fixtures',
+      expect.objectContaining({
+        stagingAreaSlotWithWasteChuteRightAdapterNoCover: {
+          cutoutFixtureId: 'stagingAreaRightSlot',
+          cutoutId: 'cutoutD3',
+          name: 'stagingArea',
+        },
+        wasteChuteRightAdapterNoCover: {
+          cutoutFixtureId: 'wasteChuteRightAdapterNoCover',
+          cutoutId: 'cutoutD3',
+          name: 'wasteChute',
+        },
+      })
+    )
   })
 })

--- a/protocol-designer/src/components/organisms/HardwareConfigurator/__tests__/AddFixtureModal.test.tsx
+++ b/protocol-designer/src/components/organisms/HardwareConfigurator/__tests__/AddFixtureModal.test.tsx
@@ -123,7 +123,7 @@ describe('AddFixtureModal', () => {
     )
   })
 
-  it.only('should handle two modules in same cutout when adding a new module (uses first match)', () => {
+  it('should handle two modules in same cutout when adding a new module (uses first match)', () => {
     const existingModules: InitialDeckStateModules = {
       magneticBlockV1: {
         id: 'magneticBlockV1',


### PR DESCRIPTION
# Overview

closes https://opentrons.atlassian.net/browse/RQA-5164.
fixes for deck config in onboarding.
handle 2 module fixtures, handle 2 fixture fixtures.

## Test Plan and Hands on Testing

https://github.com/user-attachments/assets/44401ae1-bdb2-4bcb-b87c-332535d575a4

## Changelog

- handle 2 module fixtures
- handle 2 fixture fixtures.


## Risk assessment

medium. need to smoke test the onboarding flow and hardware configuration. 
