### PR TITLE
fix(app): fix labware well color and liquid volume

### DIFF
--- a/shared-data/js/helpers/getLabwareInfoByLiquidId.ts
+++ b/shared-data/js/helpers/getLabwareInfoByLiquidId.ts
@@ -60,8 +60,10 @@ export function getLabwareInfoByLiquidId(
       ([liquidId, labwareArray]) => {
         labwareArray.forEach(labware => {
           Object.entries(labware.volumeByWell).forEach(([well, volume]) => {
-            wellToLabwareVolumes[well] ??= []
-            wellToLabwareVolumes[well].push({
+            // Only mix liquids in the same labware's well
+            const compositeKey = `${labware.labwareId}:${well}`
+            wellToLabwareVolumes[compositeKey] ??= []
+            wellToLabwareVolumes[compositeKey].push({
               labwareId: labware.labwareId,
               volume,
               liquidId,
@@ -77,7 +79,7 @@ export function getLabwareInfoByLiquidId(
     )
     const consolidatedWells: LabwareByLiquidId = {}
 
-    overlappingWells.forEach(([well, entries]) => {
+    overlappingWells.forEach(([compositeKey, entries]) => {
       const totalVolume = entries.reduce((sum, entry) => sum + entry.volume, 0)
       const labwareIdName = entries[0].labwareId
       const liquidIds = entries.map(e => e.liquidId).sort()
@@ -86,18 +88,22 @@ export function getLabwareInfoByLiquidId(
       consolidatedWells[mixedLiquidId] ??= [
         { labwareId: labwareIdName, volumeByWell: {} },
       ]
-      consolidatedWells[mixedLiquidId][0].volumeByWell[well] = totalVolume
+      const wellName = compositeKey.split(':')[1]
+      consolidatedWells[mixedLiquidId][0].volumeByWell[wellName] = totalVolume
     })
     // Remove consolidated wells from the original liquids
     const cleanedOriginal: LabwareByLiquidId = {}
-    const overlappingWellSet = new Set(overlappingWells.map(([well]) => well))
+    const overlappingWellSet = new Set(
+      overlappingWells.map(([compositeKey]) => compositeKey)
+    )
 
     Object.entries(liquidsByIdForLabware).forEach(
       ([liquidId, labwareArray]) => {
         labwareArray.forEach(labware => {
           const remainingWells = Object.fromEntries(
             Object.entries(labware.volumeByWell).filter(
-              ([well]) => !overlappingWellSet.has(well)
+              ([well]) =>
+                !overlappingWellSet.has(`${labware.labwareId}:${well}`)
             )
           )
 

--- a/shared-data/js/helpers/getLabwareInfoByLiquidId.ts
+++ b/shared-data/js/helpers/getLabwareInfoByLiquidId.ts
@@ -3,16 +3,25 @@ import reduce from 'lodash/reduce'
 import type { LoadLiquidRunTimeCommand, RunTimeCommand } from '../../command'
 
 export interface LabwareByLiquidId {
-  [liquidId: string]: Array<{
-    labwareId: string
-    volumeByWell: { [well: string]: number }
-  }>
+  [liquidId: string]: LabwareVolumeEntry[]
 }
+
+interface WellVolumeMap {
+  [well: string]: number
+}
+
+interface LabwareVolumeEntry {
+  labwareId: string
+  volumeByWell: WellVolumeMap
+}
+
 interface WellVolumeEntry {
   labwareId: string
   volume: number
   liquidId: string
 }
+
+// Filter for loadLiquid commands with non-empty liquids, then build and consolidate them
 export function getLabwareInfoByLiquidId(
   commands: RunTimeCommand[]
 ): LabwareByLiquidId {
@@ -25,11 +34,19 @@ export function getLabwareInfoByLiquidId(
         )
       : []
 
-  const initialLabwareByLiquidId = reduce<
-    LoadLiquidRunTimeCommand,
-    LabwareByLiquidId
-  >(
-    loadLiquidCommands,
+  const initialLabwareByLiquidId =
+    buildInitialLabwareByLiquidId(loadLiquidCommands)
+
+  return consolidateSharedWells(initialLabwareByLiquidId)
+}
+
+// Group labware by liquidId, merging volumeByWell entries when the same labware
+// appears multiple times for the same liquid
+function buildInitialLabwareByLiquidId(
+  commands: LoadLiquidRunTimeCommand[]
+): LabwareByLiquidId {
+  return reduce<LoadLiquidRunTimeCommand, LabwareByLiquidId>(
+    commands,
     (acc, command) => {
       const { liquidId, labwareId, volumeByWell } = command.params
       if (!(liquidId in acc)) acc[liquidId] = []
@@ -37,7 +54,9 @@ export function getLabwareInfoByLiquidId(
       const labwareIndex = acc[liquidId].findIndex(
         i => i.labwareId === labwareId
       )
+
       if (labwareIndex >= 0) {
+        // Merge wells into existing labware entry
         acc[liquidId][labwareIndex].volumeByWell = {
           ...acc[liquidId][labwareIndex].volumeByWell,
           ...volumeByWell,
@@ -49,78 +68,75 @@ export function getLabwareInfoByLiquidId(
     },
     {}
   )
+}
 
-  const consolidateSharedWells = (
-    liquidsByIdForLabware: LabwareByLiquidId
-  ): LabwareByLiquidId => {
-    const wellToLabwareVolumes: Record<string, WellVolumeEntry[]> = {}
+// Build a reverse mapping of wells to all liquids that occupy them
+function consolidateSharedWells(
+  liquidsByIdForLabware: LabwareByLiquidId
+): LabwareByLiquidId {
+  const wellToLabwareVolumes: Record<string, WellVolumeEntry[]> = {}
 
-    // Track all wells with their labware, volume, and source liquid
-    Object.entries(liquidsByIdForLabware).forEach(
-      ([liquidId, labwareArray]) => {
-        labwareArray.forEach(labware => {
-          Object.entries(labware.volumeByWell).forEach(([well, volume]) => {
-            // Only mix liquids in the same labware's well
-            const compositeKey = `${labware.labwareId}:${well}`
-            wellToLabwareVolumes[compositeKey] ??= []
-            wellToLabwareVolumes[compositeKey].push({
-              labwareId: labware.labwareId,
-              volume,
-              liquidId,
-            })
-          })
+  Object.entries(liquidsByIdForLabware).forEach(([liquidId, labwareArray]) => {
+    labwareArray.forEach(labware => {
+      Object.entries(labware.volumeByWell).forEach(([well, volume]) => {
+        const compositeKey = `${labware.labwareId}:${well}`
+        wellToLabwareVolumes[compositeKey] ??= []
+        wellToLabwareVolumes[compositeKey].push({
+          labwareId: labware.labwareId,
+          volume,
+          liquidId,
         })
-      }
-    )
-
-    // Identify overlapping wells
-    const overlappingWells = Object.entries(wellToLabwareVolumes).filter(
-      ([, entries]) => entries.length > 1
-    )
-    const consolidatedWells: LabwareByLiquidId = {}
-
-    overlappingWells.forEach(([compositeKey, entries]) => {
-      const totalVolume = entries.reduce((sum, entry) => sum + entry.volume, 0)
-      const labwareIdName = entries[0].labwareId
-      const liquidIds = entries.map(e => e.liquidId).sort()
-      const mixedLiquidId = `mixed-${liquidIds.join('-')}`
-
-      consolidatedWells[mixedLiquidId] ??= [
-        { labwareId: labwareIdName, volumeByWell: {} },
-      ]
-      const wellName = compositeKey.split(':')[1]
-      consolidatedWells[mixedLiquidId][0].volumeByWell[wellName] = totalVolume
+      })
     })
-    // Remove consolidated wells from the original liquids
-    const cleanedOriginal: LabwareByLiquidId = {}
-    const overlappingWellSet = new Set(
-      overlappingWells.map(([compositeKey]) => compositeKey)
-    )
+  })
 
-    Object.entries(liquidsByIdForLabware).forEach(
-      ([liquidId, labwareArray]) => {
-        labwareArray.forEach(labware => {
-          const remainingWells = Object.fromEntries(
-            Object.entries(labware.volumeByWell).filter(
-              ([well]) =>
-                !overlappingWellSet.has(`${labware.labwareId}:${well}`)
-            )
-          )
+  // Find wells that have been loaded with multiple different liquids
+  const overlappingWells = Object.entries(wellToLabwareVolumes).filter(
+    ([, entries]) => entries.length > 1
+  )
 
-          if (Object.keys(remainingWells).length > 0) {
-            cleanedOriginal[liquidId] ??= []
-            cleanedOriginal[liquidId].push({
-              labwareId: labware.labwareId,
-              volumeByWell: remainingWells,
-            })
-          }
+  // Create consolidated entries for wells with mixed liquids
+  const consolidatedWells: LabwareByLiquidId = {}
+
+  overlappingWells.forEach(([compositeKey, entries]) => {
+    const totalVolume = entries.reduce((sum, entry) => sum + entry.volume, 0)
+    const labwareIdName = entries[0].labwareId
+    const liquidIds = entries.map(e => e.liquidId).sort()
+    const mixedLiquidId = `mixed-${liquidIds.join('-')}`
+
+    consolidatedWells[mixedLiquidId] ??= [
+      { labwareId: labwareIdName, volumeByWell: {} },
+    ]
+    const wellName = compositeKey.split(':')[1]
+    consolidatedWells[mixedLiquidId][0].volumeByWell[wellName] = totalVolume
+  })
+
+  // Remove overlapping wells from original liquid entries, keeping only non-overlapping wells
+  const cleanedOriginal: LabwareByLiquidId = {}
+  const overlappingWellSet = new Set(
+    overlappingWells.map(([compositeKey]) => compositeKey)
+  )
+
+  Object.entries(liquidsByIdForLabware).forEach(([liquidId, labwareArray]) => {
+    labwareArray.forEach(labware => {
+      const remainingWells = Object.fromEntries(
+        Object.entries(labware.volumeByWell).filter(
+          ([well]) => !overlappingWellSet.has(`${labware.labwareId}:${well}`)
+        )
+      )
+
+      if (Object.keys(remainingWells).length > 0) {
+        cleanedOriginal[liquidId] ??= []
+        cleanedOriginal[liquidId].push({
+          labwareId: labware.labwareId,
+          volumeByWell: remainingWells,
         })
       }
-    )
-    return {
-      ...cleanedOriginal,
-      ...consolidatedWells,
-    }
+    })
+  })
+
+  return {
+    ...cleanedOriginal,
+    ...consolidatedWells,
   }
-  return consolidateSharedWells(initialLabwareByLiquidId)
 }


### PR DESCRIPTION
Closes [RABR-856](https://opentrons.atlassian.net/browse/RABR-856)

# Overview

We recently added app support for rendering wells with 2 or more liquids, but the logic to consolidate the liquids only accounted for the well name as a key, meaning that different labwares were incorrectly treated as overlapping. By using a composite key based on the `labwareId`, we can avoid this issue.

### Current Behavior

https://github.com/user-attachments/assets/c0504224-5554-4eb5-b0a5-f5ca5c2162b1

### Fixed Behavior

https://github.com/user-attachments/assets/aaaba713-ac9f-48b6-ad2b-752a37c87e8b

## Test Plan and Hands on Testing

- See videos.
- Verified the mixed liquid behavior works as expected.

## Changelog

- Fixed liquid rendering without user-defined coloration.
- Fixed liquid well amounts not displaying in the liquid details modal.

## Risk assessment

low


[RABR-856]: https://opentrons.atlassian.net/browse/RABR-856?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ