### PR TITLE
fix(app): fix ODD and desktop ignore errors styling

### DIFF
--- a/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/IgnoreErrorSkipStep.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/IgnoreErrorSkipStep.tsx
@@ -13,9 +13,7 @@ import {
 } from '@opentrons/components'
 
 import {
-  DESKTOP_ONLY,
   ERROR_KINDS,
-  ODD_ONLY,
   ODD_SECTION_TITLE_STYLE,
   RECOVERY_MAP,
 } from '../constants'
@@ -56,6 +54,7 @@ export function IgnoreErrorStepHome({
   recoveryCommands,
   routeUpdateActions,
   errorKind,
+  isOnDevice,
 }: RecoveryContentProps): JSX.Element | null {
   const { t } = useTranslation('error_recovery')
   const { ignoreErrorKindThisRun } = recoveryCommands
@@ -123,42 +122,37 @@ export function IgnoreErrorStepHome({
       >
         {t('ignore_similar_errors_later_in_run')}
       </StyledText>
-      <Flex
-        flexDirection={DIRECTION_COLUMN}
-        gridGap={SPACING.spacing4}
-        css={ODD_ONLY}
-      >
-        <IgnoreOptions
-          ignoreOptions={IGNORE_OPTIONS_IN_ORDER}
-          setSelectedOption={setSelectedOption}
-          selectedOption={selectedOption}
-        />
-      </Flex>
-      <Flex
-        flexDirection={DIRECTION_COLUMN}
-        gridGap={SPACING.spacing4}
-        css={DESKTOP_ONLY}
-      >
-        <RecoveryRadioGroup
-          value={selectedOption}
-          onChange={(e: ChangeEvent<HTMLInputElement>) => {
-            setSelectedOption(e.currentTarget.value as IgnoreOption)
-          }}
-          options={IGNORE_OPTIONS_IN_ORDER.map(option => {
-            return {
-              value: option,
-              children: (
-                <StyledText
-                  css={RADIO_GROUP_MARGIN}
-                  desktopStyle="bodyDefaultRegular"
-                >
-                  {t(option)}
-                </StyledText>
-              ),
-            }
-          })}
-        />
-      </Flex>
+      {isOnDevice ? (
+        <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing4}>
+          <IgnoreOptions
+            ignoreOptions={IGNORE_OPTIONS_IN_ORDER}
+            setSelectedOption={setSelectedOption}
+            selectedOption={selectedOption}
+          />
+        </Flex>
+      ) : (
+        <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing4}>
+          <RecoveryRadioGroup
+            value={selectedOption}
+            onChange={(e: ChangeEvent<HTMLInputElement>) => {
+              setSelectedOption(e.currentTarget.value as IgnoreOption)
+            }}
+            options={IGNORE_OPTIONS_IN_ORDER.map(option => {
+              return {
+                value: option,
+                children: (
+                  <StyledText
+                    css={RADIO_GROUP_MARGIN}
+                    desktopStyle="bodyDefaultRegular"
+                  >
+                    {t(option)}
+                  </StyledText>
+                ),
+              }
+            })}
+          />
+        </Flex>
+      )}
       <RecoveryFooterButtons
         primaryBtnOnClick={primaryOnClick}
         secondaryBtnOnClick={goBackPrevStep}


### PR DESCRIPTION
Closes [RABR-859](https://opentrons.atlassian.net/browse/RABR-859)

# Overview

The recent CSS Modules migration changed the way certain styling properties are passed through to component wrappers, resulting in ODD/desktop display-specific regressions. 

While it would be good to audit this issue more extensively with the goal of identifying the root cause, it's sufficient for now to utilize JS-specific conditions for determining which presentation layer to render.

### Current Behavior

<img width="1011" height="745" alt="Screenshot 2026-02-09 at 5 24 25 AM" src="https://github.com/user-attachments/assets/85650839-5507-44b1-8072-7e8555a0c5bd" />

### Fixed Behavior

<img width="998" height="728" alt="Screenshot 2026-02-07 at 5 37 22 PM" src="https://github.com/user-attachments/assets/c9ccbe68-3c62-4092-b9d1-fdf471cf1f65" />


## Test Plan and Hands on Testing

- See images.

## Changelog

- Fixed rendering both desktop and ODD specific stylings when in the "ignore error" Error Recovery option select menu.

## Risk assessment

-  very low, just styling

[RABR-859]: https://opentrons.atlassian.net/browse/RABR-859?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ