### PR TITLE
fix(app, step-generation): ensure commandSummary only shows up once i…

### DIFF
--- a/app/src/organisms/Desktop/ProtocolVisualization/consants.ts
+++ b/app/src/organisms/Desktop/ProtocolVisualization/consants.ts
@@ -1,7 +1,9 @@
+// note: dropTip is not included since it can happen in a tiprack for return tip
+// instead, the trash/waste chute is highlighted via looking at the pipette.entityId
+//  state
 export const POTENTIAL_TRASH_COMMAND_TYPES = [
   'moveToAddressableArea',
   'moveToAddressableAreaForDropTip',
-  'dropTip',
   'dropTipInPlace',
   'airGapInPlace',
   'blowOutInPlace',

--- a/app/src/organisms/Desktop/ProtocolVisualization/utils/getActiveLayer.ts
+++ b/app/src/organisms/Desktop/ProtocolVisualization/utils/getActiveLayer.ts
@@ -5,6 +5,15 @@ interface ActiveLayer {
   isActiveLayerVisible: boolean
 }
 
+// omitting dropTipInPlace because
+// we know that happens over a trashBin or wasteChute
+const IN_PLACE_COMMANDS = [
+  'aspirateInPlace',
+  'blowoutInPlace',
+  'dispenseInPlace',
+  'airGapInPlace',
+]
+
 export const getActiveLayer = (
   id: string,
   pipetteState: {
@@ -30,7 +39,9 @@ export const getActiveLayer = (
   const isStepAssosciatedWithLabware =
     isStepAssosciatedWithLabwareId ||
     isMoveStepAssosciatedWithLabwareId ||
-    pipetteEntityId != null
+    (pipetteEntityId != null &&
+      selectedRunTimeCommand != null &&
+      IN_PLACE_COMMANDS.includes(selectedRunTimeCommand?.commandType))
 
   const isStepAssociatedWithModuleId =
     moduleId != null &&

--- a/step-generation/src/getNextRobotStateAndWarnings/forDispense.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/forDispense.ts
@@ -61,4 +61,11 @@ export function forDispense(
       robotStateAndWarnings,
     })
   }
+  // set the entityId for dispense if it was not previously set in the previous moveToWell
+  if ('labwareId' in params) {
+    robotState.pipettes[pipetteId] = {
+      ...robotState.pipettes[pipetteId],
+      entityId: params.labwareId,
+    }
+  }
 }


### PR DESCRIPTION
…n correct slot

closes RQA-5173

# Overview

this was a pretty tricky bug but i think i figured it out finally. 

needed to mainly only show the entityId information if it is an in-place command

## Test Plan and Hands on Testing

import protocol attached to the ticket and scroll through the whole thing in PV, see that there are never times when more than 1 command summary shows up on the deck map

## Changelog

match step-generation change for `forDispense` that i added for `forAspirate`
filter out in place commands
accommodate return tip command summary correctly

## Risk assessment

low
