### PR TITLE
fix(app): when config is null, PV should be accessible

### DIFF
--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderContent/RunHeaderSectionLower/index.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderContent/RunHeaderSectionLower/index.tsx
@@ -60,7 +60,7 @@ export function RunHeaderSectionLower({
           )) ||
         (config.protocolType === 'json' &&
           config.schemaVersion >= MIN_SUPPORTED_JSON_SCHEMA_VERSION)
-      : false
+      : true
 
   const handleVisualizeClick = (): void => {
     if (!isSupportedProtocol) {


### PR DESCRIPTION
closes RQA-5186

# Overview

fix boolean logic for when the config is null

## Test Plan and Hands on Testing

test the instructions in the ticket but also look at the boolean code. now if the config is null, we don't block if its a supported protocol or not. which makes sense because if config is null, the protocol has already either produced a run record (has been run before) or has had RTP applied

## Changelog

fix boolean

## Risk assessment

low