### PR TITLE
fix(app): fix runfailed modal text wrap issue

### DIFF
--- a/app/src/organisms/ODD/RunningProtocol/RunFailedModal/runfailedmodal.module.css
+++ b/app/src/organisms/ODD/RunningProtocol/RunFailedModal/runfailedmodal.module.css
@@ -26,6 +26,9 @@
   border-radius: var(--border-radius-8);
   background-color: var(--grey-35);
   gap: var(--spacing-8);
+  overflow-wrap: break-word;
+  white-space: normal;
+  word-break: normal;
 }
 
 .error_list {
@@ -56,4 +59,6 @@
 .contact_text {
   overflow-wrap: break-word;
   text-align: left;
+  white-space: normal;
+  word-break: normal;
 }


### PR DESCRIPTION
# Overview
fix runfailed modal text wrap issue

<img width="731" height="546" alt="Screenshot 2026-02-09 at 1 04 42 PM" src="https://github.com/user-attachments/assets/cc83b6f9-32b2-4e06-bc30-fa576d79651b" />
* the text is dummy text

close RABR-861

## Test Plan and Hands on Testing
- modify CSS

## Changelog


## Review requests


## Risk assessment
low