### PR TITLE
chore: add PD 8.9 release notes

### DIFF
--- a/protocol-designer/release-notes.md
+++ b/protocol-designer/release-notes.md
@@ -16,7 +16,7 @@ This release introduces updated Thermocycler Module steps and includes other bug
 
 ### New Features
 
-- Your Protocol Designer protocol now runs Thermocycler Module profiles while pipetting samples or running another module.
+- Your Protocol Designer protocol can run Thermocycler Module profiles while pipetting samples or running another module.
 
 ### Bug Fixes
 

--- a/protocol-designer/release-notes.md
+++ b/protocol-designer/release-notes.md
@@ -12,20 +12,15 @@ By using Opentrons Protocol Designer, you agree to the Opentrons End-User Licens
 
 **Welcome to Protocol Designer 8.9.0!**
 
-This release introduces updated Thermocycler Module steps and includes other bug fixes. 
+This release introduces updated Thermocycler Module steps and includes other bug fixes.
 
 ### New Features
 
-- Your Protocol Designer protocol can now run a Thermocycler Module step, like changing the block temperature or executing a profile, while pipetting samples or running another module.
-
-  When you add any new Thermocycler Module step, Protocol Designer will ask you to choose:
-  - wait for the Thermocycler Module to finish running a profile or reaching a temperature.
-  - continue performing protocol actions while your Thermocycler Module step completes.
-
+- Your Protocol Designer protocol now runs Thermocycler Module profiles while pipetting samples or running another module.
 
 ### Bug Fixes
 
-- The Flex Stacker Module shows the correct number of labware stored inside. 
+- The Flex Stacker Module shows the correct number of labware stored inside.
 - Add or remove a Flex Stacker Module or waste chute to the robot deck without triggering protocol errors.
 
 ## Opentrons Protocol Designer Changes in 8.8.0

--- a/protocol-designer/release-notes.md
+++ b/protocol-designer/release-notes.md
@@ -12,7 +12,7 @@ By using Opentrons Protocol Designer, you agree to the Opentrons End-User Licens
 
 **Welcome to Protocol Designer 8.9.0!**
 
-This release introduces updated Thermocycler Module and liquid class features.
+This release introduces updated Thermocycler Module steps and includes other bug fixes. 
 
 ### New Features
 
@@ -22,7 +22,11 @@ This release introduces updated Thermocycler Module and liquid class features.
   - wait for the Thermocycler Module to finish running a profile or reaching a temperature.
   - continue performing protocol actions while your Thermocycler Module step completes.
 
-- Customize the well location to blow out excess liquid from the pipette tip, including blowout height at a source or destination well.
+
+### Bug Fixes
+
+- The Flex Stacker Module shows the correct number of labware stored inside. 
+- Add or remove a Flex Stacker Module or waste chute to the robot deck without triggering protocol errors.
 
 ## Opentrons Protocol Designer Changes in 8.8.0
 

--- a/protocol-designer/release-notes.md
+++ b/protocol-designer/release-notes.md
@@ -8,9 +8,25 @@ By using Opentrons Protocol Designer, you agree to the Opentrons End-User Licens
 
 ---
 
+## Opentrons Protocol Designer Changes in 8.9.0
+
+**Welcome to Protocol Designer 8.9.0!**
+
+This release introduces updated Thermocycler Module and liquid class features.
+
+### New Features
+
+- Your Protocol Designer protocol can now run a Thermocycler Module step, like changing the block temperature or executing a profile, while pipetting samples or running another module.
+
+  When you add any new Thermocycler Module step, Protocol Designer will ask you to choose:
+  - wait for the Thermocycler Module to finish running a profile or reaching a temperature.
+  - continue performing protocol actions while your Thermocycler Module step completes.
+
+- Customize the well location to blow out excess liquid from the pipette tip, including blowout height at a source or destination well.
+
 ## Opentrons Protocol Designer Changes in 8.8.0
 
-**Welcome to Protocol Designer 8.8.0.!**
+**Welcome to Protocol Designer 8.8.0!**
 
 This release adds support for the Flex Stacker Module in Protocol Designer, and includes other bug fixes.
 


### PR DESCRIPTION
# Overview

Adding PD 8.9 release notes. I'm not using the term "concurrent module actions," because although we do use it in the API docs, it doesn't look like users will see it anywhere in PD. 

## Test Plan and Hands on Testing



## Changelog

- added summary for the following bug fixes: [RQA-5023](https://opentrons.atlassian.net/browse/RQA-5023), [RQA-5027](https://opentrons.atlassian.net/browse/RQA-5027), [RQA-5159](https://opentrons.atlassian.net/browse/RQA-5159)

## Review requests

any bug fixes to add? anything I'm missing? am I representing what you can do in this release correctly? 

## Risk assessment

low. 


[RQA-5023]: https://opentrons.atlassian.net/browse/RQA-5023?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RQA-5027]: https://opentrons.atlassian.net/browse/RQA-5027?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RQA-5159]: https://opentrons.atlassian.net/browse/RQA-5159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ