### PR TITLE
fix(app): fix lid in secondary window

### DIFF
--- a/app/src/organisms/Desktop/ProtocolVisualization/SecondWindow/LabwareSlot/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/SecondWindow/LabwareSlot/index.tsx
@@ -56,11 +56,6 @@ export function LabwareSlot(props: LabwareSlotContainerProps): JSX.Element {
   const { labware, pipettes, liquidState, modules } = robotState
   const { t } = useTranslation('protocol_visualization')
   const [hoveredWellName, setHoveredWellName] = useState<string | null>(null)
-  const labwareLoadCommand = Object.values(commands).find(
-    command =>
-      'labwareId' in command.result &&
-      command.result.labwareId === topLabwareOnSlotId
-  )
   const lidStackCommand = commands.find(
     (command): command is LoadLidStackRunTimeCommand =>
       command.commandType === 'loadLidStack' &&
@@ -82,18 +77,36 @@ export function LabwareSlot(props: LabwareSlotContainerProps): JSX.Element {
       : null
   const hopperGroups =
     stackerModuleState != null ? stackerModuleState.labwareInHopper : null
-
+  const isTopLabwareLid =
+    labwareEntities[topLabwareOnSlotId].def.allowedRoles?.includes('lid')
+  const topLabwareStack = labware[topLabwareOnSlotId].stack
+  const labwareIdUnderLid = topLabwareStack.find(
+    id =>
+      id !== topLabwareOnSlotId &&
+      labware[id] != null &&
+      labwareEntities[id]?.def.allowedRoles?.includes('lid') !== true
+  )
+  const hasRenderableWellsUnderLid =
+    labwareIdUnderLid != null
+      ? Object.keys(labwareEntities[labwareIdUnderLid].def.wells).length > 0
+      : false
+  const adjustedTopLabwareId =
+    isTopLabwareLid && hasRenderableWellsUnderLid
+      ? (labwareIdUnderLid ?? topLabwareOnSlotId)
+      : topLabwareOnSlotId
+  const labwareLoadCommand = Object.values(commands).find(
+    command =>
+      command.result != null &&
+      'labwareId' in command.result &&
+      (command.result.labwareId === topLabwareOnSlotId ||
+        command.result.labwareId === adjustedTopLabwareId)
+  )
   const { params: labwareLoadCommandParams } = labwareLoadCommand ?? {}
   const labwareNickname: string | null =
     labwareLoadCommandParams != null &&
     'displayName' in labwareLoadCommandParams
       ? labwareLoadCommandParams.displayName
       : null
-  const isTopLabwareLid =
-    labwareEntities[topLabwareOnSlotId].def.allowedRoles?.includes('lid')
-  const adjustedTopLabwareId = isTopLabwareLid
-    ? labware[topLabwareOnSlotId].stack[1]
-    : topLabwareOnSlotId
   const labwareDef = labwareEntities[adjustedTopLabwareId].def
   const labwareDisplayName = labwareDef.metadata.displayName
 


### PR DESCRIPTION


# Overview
fix lid in secondary window

RQA-5190 has two issues. one  is that the app tries to load `undefined` and  the other is the same as RQA-5188 which the app cannot handle a labware that lid is on the top.

close RQA-5188 and RQA-5190


## Test Plan and Hands on Testing
- import the protocols that are attached to the tickets
- visualize protocols
- click the slot that has a lid

## Changelog

## Review requests

## Risk assessment
low