### PR TITLE
fix(app): stacker command summary slot position fixes

### DIFF
--- a/app/src/organisms/Desktop/ProtocolVisualization/DeckView/DeckViewLabwareCommandSummaries.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/DeckView/DeckViewLabwareCommandSummaries.tsx
@@ -22,6 +22,12 @@ interface DeckViewLabwareCommandSummariesProps {
   labwareEntitiesExtended: Record<string, LabwareEntityExtended>
   selectedRunTimeCommand?: RunTimeCommand
 }
+const STACKER_MOVE_MAP: Record<string, string> = {
+  A4: 'A3',
+  B4: 'B3',
+  C4: 'C3',
+  D4: 'D3',
+}
 
 export function DeckViewLabwareCommandSummaries(
   props: DeckViewLabwareCommandSummariesProps
@@ -46,7 +52,13 @@ export function DeckViewLabwareCommandSummaries(
         }
         const moduleUnderLabware = lw.stack.find(id => modules[id] != null)
         const slot = getSlotInLocationStack(lw.stack)
-        const slotPosition = getPositionFromSlotId(slot, deckDef)
+        // all other labware on module will be filtered out in line 49
+        // so this is a special-case scenario for the stacker
+        const stackerInSlot = Object.values(modules).some(
+          moduleTempProperties => moduleTempProperties.slot === slot
+        )
+        const slotForPositionMap = stackerInSlot ? STACKER_MOVE_MAP[slot] : slot
+        const slotPosition = getPositionFromSlotId(slotForPositionMap, deckDef)
         const slotBoundingBox = getAddressableAreaFromSlotId(
           slot,
           deckDef
@@ -72,7 +84,6 @@ export function DeckViewLabwareCommandSummaries(
           slot,
           moduleDef
         )
-
         const childSlotPosition: [number, number, number] = [
           slotPosition[0] + childSlotOffset.x,
           slotPosition[1] + childSlotOffset.y,

--- a/app/src/organisms/Desktop/ProtocolVisualization/DeckView/DeckViewStacker.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/DeckView/DeckViewStacker.tsx
@@ -68,6 +68,12 @@ export function DeckViewStacker(props: DeckViewStackerProps): JSX.Element {
     labwareLoadedOnModuleId,
     renderLabware = true,
   } = props
+
+  console.log(
+    '  selectedRunTimeCommand?.commandType',
+    moduleType,
+    selectedRunTimeCommand?.commandType
+  )
   return (
     <>
       {renderLabware ? (
@@ -138,8 +144,7 @@ export function DeckViewStacker(props: DeckViewStackerProps): JSX.Element {
           hover={hoveredSlot}
         >
           {(moduleType === FLEX_STACKER_MODULE_TYPE &&
-            selectedRunTimeCommand?.commandType !== 'flexStacker/retrieve' &&
-            selectedRunTimeCommand?.commandType !== 'flexStacker/store') ||
+            selectedRunTimeCommand?.commandType !== 'flexStacker/retrieve') ||
           (moduleType !== FLEX_STACKER_MODULE_TYPE &&
             (showModuleCommandSummary || showLabwareCommandSummary)) ? null : (
             <StyledText desktopStyle="captionRegular" color={COLORS.white}>

--- a/app/src/organisms/Desktop/ProtocolVisualization/DeckView/DeckViewStacker.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/DeckView/DeckViewStacker.tsx
@@ -69,11 +69,6 @@ export function DeckViewStacker(props: DeckViewStackerProps): JSX.Element {
     renderLabware = true,
   } = props
 
-  console.log(
-    '  selectedRunTimeCommand?.commandType',
-    moduleType,
-    selectedRunTimeCommand?.commandType
-  )
   return (
     <>
       {renderLabware ? (


### PR DESCRIPTION
closes RQA-5187

# Overview

fix the move and store command summaries to happen in the correct locations on the deck map

## Test Plan and Hands on Testing

test the protocol in the ticket see that the store and move command summaries are in the correct places on the stacker

## Changelog

map the move command summary correctly
make store happen in correct slot

## Risk assessment

low