### PR TITLE
fix(app): stacker shuttle labware render

### DIFF
--- a/app/src/organisms/Desktop/ProtocolVisualization/DeckView/DeckViewLabware.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/DeckView/DeckViewLabware.tsx
@@ -2,6 +2,7 @@ import { Fragment } from 'react'
 
 import { CenterLabwareInSlot, COLORS, StyledText } from '@opentrons/components'
 import {
+  FLEX_STACKER_MODULE_TYPE,
   getAddressableAreaFromSlotId,
   getPositionFromSlotId,
   PROTOCOL_ENGINE_LID_STACK_LOADNAME,
@@ -50,11 +51,17 @@ export function DeckViewLabware(props: DeckViewLabwareProps): JSX.Element {
     selectedRunTimeCommand,
   } = props
   const { labware, modules, pipettes } = robotState
+  const { moduleEntities } = invariantContext
+
   return (
     <>
       {Object.entries(labware).map(([id, lw]) => {
         if (
-          Object.keys(modules).some(moduleId => lw.stack.includes(moduleId)) ||
+          Object.keys(modules).some(
+            moduleId =>
+              lw.stack.includes(moduleId) &&
+              moduleEntities[moduleId].type !== FLEX_STACKER_MODULE_TYPE
+          ) ||
           //  filter out the fake PE lid stack definition!
           //  we shouldn't be exposing it to users at all
           labwareEntitiesExtended[id].def.parameters.loadName ===


### PR DESCRIPTION
# Overview

see that things render in the stacker shuttle section
https://github.com/Opentrons/opentrons/pull/20831#issue-3923371103

## Test Plan and Hands on Testing

see that the move step shows the labware moving

[untitled - 2026-02-10T094858.738.py](https://github.com/user-attachments/files/25219499/untitled.-.2026-02-10T094858.738.py)


## Changelog

the stacker shuttle labware are not actually in the module

## Risk assessment

low