### PR TITLE
fix(app): fix lid quantity in secondary window

### DIFF
--- a/app/src/organisms/Desktop/ProtocolVisualization/SecondWindow/LabwareSlot/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/SecondWindow/LabwareSlot/index.tsx
@@ -149,15 +149,16 @@ export function LabwareSlot(props: LabwareSlotContainerProps): JSX.Element {
     {}
   )
   const topLabwareURI = labwareEntities[topLabwareOnSlotId].labwareDefURI
+  const stackQuantity = labware[topLabwareOnSlotId].stack.filter(
+    id =>
+      labware[id] != null && labwareEntities[id].labwareDefURI === topLabwareURI
+  ).length
   const quantity =
-    lidStackCommand?.params?.quantity ??
-    (hopperGroups != null
+    hopperGroups != null
       ? hopperGroups.length
-      : labware[topLabwareOnSlotId].stack.filter(
-          id =>
-            labware[id] != null &&
-            labwareEntities[id].labwareDefURI === topLabwareURI
-        )?.length)
+      : stackQuantity > 0
+        ? stackQuantity
+        : (lidStackCommand?.params?.quantity ?? 1)
   const adapterId = labware[topLabwareOnSlotId].stack.find(
     id =>
       labwareEntities[id]?.def.allowedRoles?.includes('adapter') &&

--- a/step-generation/src/utils/createTimelineFromRunCommands.ts
+++ b/step-generation/src/utils/createTimelineFromRunCommands.ts
@@ -117,10 +117,13 @@ export function getResultingTimelineFrameFromRunCommands(
             {}
           )
           const labwareStacks = labwareIds.reduce(
-            (acc: Record<string, { stack: string[] }>, id) => {
-              const sequence = sequenceMap[id]
+            (acc: Record<string, { stack: string[] }>, id, index) => {
+              const sequence = sequenceMap[id] ?? locationSequences[index]
               if (sequence != null) {
-                acc[id] = { stack: getStackForLabwareLocation(sequence) }
+                const stack = getStackForLabwareLocation(sequence)
+                acc[id] = {
+                  stack: stack[0] === id ? stack : [id, ...stack],
+                }
               } else {
                 const location = command.params.location
                 if (locationIsOffDeck(location)) {


### PR DESCRIPTION


# Overview
the quantity use initial data instead of robotState


https://github.com/user-attachments/assets/1ed65a70-50da-4a96-93ab-6cff8271ce4b



close RQA-5191


## Test Plan and Hands on Testing
- import the protocol that is attached to the ticket
- visualize the protocol
- click the last step and click the slot C3 then check the quantity of lid is updated

## Changelog
- use robotState instead of the initial quantity 

## Review requests


## Risk assessment
low
