### PR TITLE
feat(app): add command schema v16 and v17 types to v8 protocolFile type

### DIFF
--- a/shared-data/protocol/types/schemaV8/index.ts
+++ b/shared-data/protocol/types/schemaV8/index.ts
@@ -58,6 +58,11 @@ export interface CommandV15Mixin {
   commands: CreateCommand[]
 }
 
+export interface CommandV16Mixin {
+  commandSchemaId: 'opentronsCommandSchemaV16'
+  commands: CreateCommand[]
+}
+
 export interface CommandAnnotationsStructure {
   commandAnnotationSchemaId: string
   commandAnnotations: any[]
@@ -154,6 +159,8 @@ export type ProtocolFile<DesignerApplicationData = {}> =
       | CommandV12Mixin
       | CommandV13Mixin
       | CommandV14Mixin
+      | CommandV15Mixin
+      | CommandV16Mixin
     ) &
     CommandAnnotationV1Mixin
 


### PR DESCRIPTION
# Overview

ruh roh we should probably be better at keeping our `ProtocolFile` type up to date with the command schema versioning

## Test Plan and Hands on Testing

just review code

## Changelog

added v15 and v16 command schema to the command schema union in the protocol schema type

## Risk assessment

low