### PR TITLE
fix(app): remove accidentally un-commented VM stub

### DIFF
--- a/app/src/organisms/Desktop/Devices/InstrumentsAndModules.tsx
+++ b/app/src/organisms/Desktop/Devices/InstrumentsAndModules.tsx
@@ -153,7 +153,7 @@ export function InstrumentsAndModules({
     : Math.ceil(attachedModules?.length / 2)
   const leftColumnModules = [
     ...attachedModules?.slice(0, halfAttachedModulesSize),
-    STUBBED_ATTACHED_VACUUM_MODULE,
+    // STUBBED_ATTACHED_VACUUM_MODULE,
   ]
   const rightColumnModules = attachedModules?.slice(halfAttachedModulesSize)
 


### PR DESCRIPTION
# Overview

Re-comment stubbed vacuum module that I used for testing and accidentally un-commented in `InstrumentsAndModules`

## Test Plan and Hands on Testing

Just checkout code and verify that no phantom VM shows in device details instruments and modules

## Changelog

- comment `STUBBED_ATTACHED_VACUUM_MODULE`

## Review requests

nothing in particular

## Risk assessment

low