### PR TITLE
fix(app): fix display prop to use grid

### DIFF
--- a/app/src/molecules/DeckInfoLabelTextTag/index.tsx
+++ b/app/src/molecules/DeckInfoLabelTextTag/index.tsx
@@ -31,7 +31,7 @@ export function DeckInfoLabelTextTag({
   colThreeTag,
 }: DeckInfoLabelTextTagProps): JSX.Element {
   return (
-    <Flex css={CONTAINER_STYLE}>
+    <Flex display={DISPLAY_GRID} css={CONTAINER_STYLE}>
       <Flex css={LABEL_CONTAINER_STYLE}>
         {colOneDeckInfoLabels
           .slice(0, MAX_SUPPORTED_LABELS)
@@ -53,7 +53,6 @@ const CONTAINER_STYLE = css`
   border-radius: ${BORDERS.borderRadius12};
   padding: ${SPACING.spacing12};
   width: 100%;
-  display: ${DISPLAY_GRID};
   grid-template-columns: 120px 1fr ${FLEX_MAX_CONTENT};
   gap: ${SPACING.spacing40};
   align-items: ${ALIGN_CENTER};

--- a/app/src/organisms/Desktop/Devices/HistoricalProtocolRunDrawer.tsx
+++ b/app/src/organisms/Desktop/Devices/HistoricalProtocolRunDrawer.tsx
@@ -6,6 +6,7 @@ import { css } from 'styled-components'
 import {
   ALIGN_CENTER,
   ALIGN_END,
+  ALIGN_FLEX_START,
   Banner,
   BORDERS,
   Box,
@@ -164,7 +165,7 @@ export function HistoricalProtocolRunDrawer(
           color={COLORS.grey60}
           padding={`${SPACING.spacing4} ${SPACING.spacing12}`}
         >
-          <Box width="33%">
+          <Box width="33%" minWidth="0">
             <LegacyStyledText
               forwardedAs="p"
               datatest-id="RecentProtocolRun_Drawer_fileNameTitle"
@@ -172,7 +173,7 @@ export function HistoricalProtocolRunDrawer(
               {t('name')}
             </LegacyStyledText>
           </Box>
-          <Box width="33%">
+          <Box width="33%" minWidth="0">
             <LegacyStyledText
               forwardedAs="p"
               datatest-id="RecentProtocolRun_Drawer_fileDateTitle"
@@ -180,7 +181,7 @@ export function HistoricalProtocolRunDrawer(
               {t('date')}
             </LegacyStyledText>
           </Box>
-          <Box width="34%">
+          <Box width="34%" minWidth="0">
             <LegacyStyledText
               forwardedAs="p"
               datatest-id="RecentProtocolRun_Drawer_fileDownloadTitle"
@@ -349,13 +350,18 @@ function CsvFileDataRow(props: CsvFileDataRowProps): JSX.Element | null {
   return (
     <Flex
       justifyContent={JUSTIFY_FLEX_START}
-      alignItems={ALIGN_CENTER}
+      alignItems={ALIGN_FLEX_START}
       padding={SPACING.spacing12}
       backgroundColor={COLORS.white}
       borderRadius={BORDERS.borderRadius4}
       gridGap={SPACING.spacing24}
     >
-      <Flex width="33%" gridGap={SPACING.spacing4} alignItems={ALIGN_CENTER}>
+      <Flex
+        width="33%"
+        minWidth="0"
+        gridGap={SPACING.spacing4}
+        alignItems={ALIGN_CENTER}
+      >
         <LegacyStyledText
           forwardedAs="p"
           css={css`
@@ -366,12 +372,12 @@ function CsvFileDataRow(props: CsvFileDataRowProps): JSX.Element | null {
           {name}
         </LegacyStyledText>
       </Flex>
-      <Box width="33%">
+      <Box width="33%" minWidth="0">
         <LegacyStyledText forwardedAs="p">
           {format(new Date(createdAt), 'M/d/yy HH:mm:ss')}
         </LegacyStyledText>
       </Box>
-      <Box width="34%">
+      <Box width="34%" minWidth="0">
         <DownloadCsvFileLink fileId={fileId} fileName={name} />
       </Box>
     </Flex>
@@ -407,21 +413,29 @@ function ImagesFileDataRow({
       borderRadius={BORDERS.borderRadius4}
       gridGap={SPACING.spacing24}
     >
-      <Flex width="33%" gridGap={SPACING.spacing4} alignItems={ALIGN_CENTER}>
+      <Flex
+        width="33%"
+        minWidth="0"
+        gridGap={SPACING.spacing4}
+        alignItems={ALIGN_CENTER}
+      >
         <LegacyStyledText
           forwardedAs="p"
           css={css`
+            display: -webkit-box;
+            -webkit-line-clamp: 2;
+            -webkit-box-orient: vertical;
+            overflow-wrap: anywhere;
             overflow: ${OVERFLOW_HIDDEN};
-            text-overflow: ellipsis;
           `}
         >
           {buildImagesZipName()}
         </LegacyStyledText>
       </Flex>
-      <Box width="33%">
+      <Box width="33%" minWidth="0">
         <LegacyStyledText forwardedAs="p">{formattedRunTs}</LegacyStyledText>
       </Box>
-      <Box width="34%">
+      <Box width="34%" minWidth="0">
         <Link
           role="button"
           css={


### PR DESCRIPTION
# Overview
for ODD, fix display prop to use grid
for Desktop app, fix the misalignment between header and data in historical run drawer

[before]

<img width="886" height="308" alt="Screenshot 2026-02-11 at 12 47 33 PM" src="https://github.com/user-attachments/assets/331cd510-e63e-47f1-bb54-2a1112402d52" />


[after]
<img width="1022" height="598" alt="Screenshot 2026-02-11 at 12 57 44 PM" src="https://github.com/user-attachments/assets/1b120f5d-1d01-4808-a74d-ab7e0a030581" />


### desktop
<img width="496" height="325" alt="Screenshot 2026-02-11 at 5 01 25 PM" src="https://github.com/user-attachments/assets/32c46d26-7f1d-4a5e-b676-6a0cf4a83136" />
<img width="1054" height="367" alt="Screenshot 2026-02-11 at 5 01 33 PM" src="https://github.com/user-attachments/assets/8fc713bc-b2c7-48e1-8939-b3c453e5d748" />


close RQA-5195



## Test Plan and Hands on Testing
- setup protocol on ODD
- go to labware offsets


## Changelog
- apply `display` directly

## Review requests


## Risk assessment
low