### PR TITLE
fix(app): fix legacystyledtext styling issue

### DIFF
--- a/app/src/molecules/LegacyOffsetVector/index.tsx
+++ b/app/src/molecules/LegacyOffsetVector/index.tsx
@@ -22,33 +22,33 @@ export function LegacyOffsetVector(
   return (
     <Flex {...styleProps}>
       <LegacyStyledText
-        as={as}
+        forwardedAs={as}
         marginRight={SPACING.spacing4}
         fontWeight={TYPOGRAPHY.fontWeightSemiBold}
       >
         X
       </LegacyStyledText>
-      <LegacyStyledText as={as} marginRight={SPACING.spacing8}>
+      <LegacyStyledText forwardedAs={as} marginRight={SPACING.spacing8}>
         {x.toFixed(1)}
       </LegacyStyledText>
       <LegacyStyledText
-        as={as}
+        forwardedAs={as}
         marginRight={SPACING.spacing4}
         fontWeight={TYPOGRAPHY.fontWeightSemiBold}
       >
         Y
       </LegacyStyledText>
-      <LegacyStyledText as={as} marginRight={SPACING.spacing8}>
+      <LegacyStyledText forwardedAs={as} marginRight={SPACING.spacing8}>
         {y.toFixed(1)}
       </LegacyStyledText>
       <LegacyStyledText
-        as={as}
+        forwardedAs={as}
         marginRight={SPACING.spacing4}
         fontWeight={TYPOGRAPHY.fontWeightSemiBold}
       >
         Z
       </LegacyStyledText>
-      <LegacyStyledText as={as} marginRight={SPACING.spacing8}>
+      <LegacyStyledText forwardedAs={as} marginRight={SPACING.spacing8}>
         {z.toFixed(1)}
       </LegacyStyledText>
     </Flex>


### PR DESCRIPTION


# Overview
fix legacystyledtext styling issue


[before]
<img width="892" height="72" alt="Screenshot 2026-02-11 at 1 44 31 PM" src="https://github.com/user-attachments/assets/f3b0acc2-50da-429a-af3c-f6c11089c7e0" />


[after]
<img width="895" height="114" alt="Screenshot 2026-02-11 at 1 41 57 PM" src="https://github.com/user-attachments/assets/dcdc7cb4-8c73-4b05-820c-31cbefcfc9f3" />

close RQA-5196


## Test Plan and Hands on Testing
- setup a protocol on OT-2
- go to setup tab labware offsets

## Changelog
- `as` -> `forwardedAs`

## Review requests


## Risk assessment
low