### PR TITLE
chore: Add known issue for protocol visualization on re-run

### DIFF
--- a/app-shell/build/release-notes.md
+++ b/app-shell/build/release-notes.md
@@ -34,7 +34,8 @@ Welcome to the v9.0.0 release of the Opentrons App! This release includes protoc
 
 ### Known Issues
 
-- You can't open protocol visualization when re-running a completed protocol, if the protocol was started on a different computer. Open visualization from the protocol details page instead.
+- You can't open protocol visualization when re-running a completed protocol, only if the protocol was started on a different computer. Open visualization from the protocol details page instead.
+- Protocol visualization will produce an error for protocols that dispose of tips into a standard labware instead of a trash container.
 
 ---
 

--- a/app-shell/build/release-notes.md
+++ b/app-shell/build/release-notes.md
@@ -32,6 +32,10 @@ Welcome to the v9.0.0 release of the Opentrons App! This release includes protoc
 - Adding a CSV file to an imported protocol no longer causes analysis errors.
 - Protocol run logs include correct descriptions for partial tip pickup with the Flex 96-channel pipette.
 
+### Known Issues
+
+- You can't open protocol visualization when re-running a completed protocol, if the protocol was started on a different computer. Open visualization from the protocol details page instead.
+
 ---
 
 ## Opentrons App Changes in 8.8.1


### PR DESCRIPTION
# Overview

Known issue for edge case with viz / completed protocols / using the app on multiple computers.

Addresses RQA-5186 for the 9.0.0 release.

## Test Plan and Hands on Testing

n/a

## Changelog

- addition to app notes only

## Review requests

words good?

## Risk assessment

v v low