### PR TITLE
fix(app): fix tip position and well name in well view

### DIFF
--- a/app/src/organisms/Desktop/ProtocolVisualization/LabwareSlotContainer/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/LabwareSlotContainer/index.tsx
@@ -153,7 +153,7 @@ export function LabwareSlotContainer(
         <WellContainer
           wells={wells}
           params={params}
-          activeWellName={selectedWellName}
+          selectedWellName={selectedWellName}
           wellColor={wellFill[selectedWellName]}
           labwareLocationLiquidState={labwareLocationLiquidState}
           pipetteLocationLiquidState={pipetteLocationLiquidState}

--- a/app/src/organisms/Desktop/ProtocolVisualization/LabwareSlotContainer/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/LabwareSlotContainer/index.tsx
@@ -73,6 +73,14 @@ export function LabwareSlotContainer(
       ? labwareLoadCommandParams.displayName
       : null
   const { params } = currentCommand
+  const commandWellName =
+    'wellName' in params && typeof params.wellName === 'string'
+      ? params.wellName
+      : null
+  const commandLabwareId =
+    'labwareId' in params && typeof params.labwareId === 'string'
+      ? params.labwareId
+      : null
   const labwareDef = labwareEntities[topLabwareOnSlotId].def
   const labwareDisplayName = labwareDef.metadata.displayName
 
@@ -93,10 +101,14 @@ export function LabwareSlotContainer(
     pipetteTemporalProperties != null
       ? pipetteTemporalProperties[1].wellName
       : null
+  const selectedWellName =
+    commandLabwareId === topLabwareOnSlotId && commandWellName != null
+      ? commandWellName
+      : activeWellName
   const wellGroup: WellGroup | null =
-    activeWellName != null
+    selectedWellName != null
       ? {
-          [activeWellName]: null,
+          [selectedWellName]: null,
         }
       : null
   const hoveredWellGroup: WellGroup | null =
@@ -112,8 +124,8 @@ export function LabwareSlotContainer(
       ? liquidState.pipettes[pipetteTemporalProperties[0]]?.[0]
       : null
   const labwareLocationLiquidState =
-    activeWellName != null
-      ? liquidState.labware[topLabwareOnSlotId]?.[activeWellName]
+    selectedWellName != null
+      ? liquidState.labware[topLabwareOnSlotId]?.[selectedWellName]
       : null
 
   const tipMaxVolume =
@@ -137,12 +149,12 @@ export function LabwareSlotContainer(
 
   return (
     <>
-      {activeWellName != null ? (
+      {selectedWellName != null ? (
         <WellContainer
           wells={wells}
           params={params}
-          activeWellName={activeWellName}
-          wellColor={wellFill[activeWellName]}
+          activeWellName={selectedWellName}
+          wellColor={wellFill[selectedWellName]}
           labwareLocationLiquidState={labwareLocationLiquidState}
           pipetteLocationLiquidState={pipetteLocationLiquidState}
           liquids={liquids}

--- a/app/src/organisms/Desktop/ProtocolVisualization/WellContainer/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/WellContainer/index.tsx
@@ -54,16 +54,16 @@ export function WellContainer(props: WellContainerProps): JSX.Element {
   const labwareDepth = wells.A1.depth ?? 0
   const xLabwareWellWidth = wells.A1.x ?? 0
   const labwareWellMaxVolume = wells.A1.totalLiquidVolume
-  const hasWellLocation = 'wellLocation' in params
+  const wellLocation = 'wellLocation' in params ? params.wellLocation : null
+  const hasWellLocation = wellLocation != null
 
   //  TODO: add support for rest of references
-  const reference = hasWellLocation
-    ? params.wellLocation.origin === 'top'
+  const reference =
+    wellLocation?.origin === 'top'
       ? POSITION_REFERENCE_TOP
       : POSITION_REFERENCE_BOTTOM
-    : POSITION_REFERENCE_BOTTOM
-  const zOffset = params.wellLocation.offset?.z ?? 1
-  const xOffset = params.wellLocation.offset?.x ?? 0
+  const zOffset = wellLocation?.offset?.z ?? 1
+  const xOffset = wellLocation?.offset?.x ?? 0
 
   const mmFromBottom = hasWellLocation
     ? getMmFromBottom(zOffset, reference, labwareDepth)

--- a/app/src/organisms/Desktop/ProtocolVisualization/WellContainer/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/WellContainer/index.tsx
@@ -26,7 +26,7 @@ const SVG_DECIMALS = 2
 
 interface WellContainerProps {
   params: RunTimeCommand['params']
-  activeWellName: string
+  selectedWellName: string
   wellColor: string
   wells: LabwareWellMap
   pipetteLocationLiquidState: LocationLiquidState | null
@@ -37,7 +37,7 @@ interface WellContainerProps {
 export function WellContainer(props: WellContainerProps): JSX.Element {
   const {
     params,
-    activeWellName,
+    selectedWellName,
     wellColor,
     wells,
     liquids,
@@ -103,7 +103,7 @@ export function WellContainer(props: WellContainerProps): JSX.Element {
       <div className={styles.header}>
         <Tag text={t('well_view')} type="default" shrinkToContent />
         <RobotInfoLabel
-          deckLabel={t('well_name', { wellName: activeWellName })}
+          deckLabel={t('well_name', { wellName: selectedWellName })}
         />
       </div>
       <div>

--- a/app/src/organisms/Desktop/ProtocolVisualization/WellContainer/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/WellContainer/index.tsx
@@ -62,12 +62,11 @@ export function WellContainer(props: WellContainerProps): JSX.Element {
       ? POSITION_REFERENCE_TOP
       : POSITION_REFERENCE_BOTTOM
     : POSITION_REFERENCE_BOTTOM
+  const zOffset = params.wellLocation.offset?.z ?? 1
+  const xOffset = params.wellLocation.offset?.x ?? 0
+
   const mmFromBottom = hasWellLocation
-    ? getMmFromBottom(
-        Number(params.wellLocation.z ?? 1),
-        reference,
-        labwareDepth
-      )
+    ? getMmFromBottom(zOffset, reference, labwareDepth)
     : null
 
   const wellHeightSvg = WELL_GEOMETRY.bottomY - WELL_GEOMETRY.topY
@@ -82,8 +81,7 @@ export function WellContainer(props: WellContainerProps): JSX.Element {
   const roundedTipBottomY = lastTipBottomYRef.current
 
   if (hasWellLocation && xLabwareWellWidth != null && xLabwareWellWidth > 0) {
-    const xPositionSvg =
-      (wellWidthSvg / xLabwareWellWidth) * (params.wellLocation.x ?? 0)
+    const xPositionSvg = (wellWidthSvg / xLabwareWellWidth) * xOffset
     lastXPositionSvgRef.current = round(xPositionSvg, SVG_DECIMALS)
   }
   const roundedXPositionSvg = lastXPositionSvgRef.current

--- a/app/src/organisms/Desktop/ProtocolVisualization/WellContainer/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/WellContainer/index.tsx
@@ -62,8 +62,10 @@ export function WellContainer(props: WellContainerProps): JSX.Element {
     wellLocation?.origin === 'top'
       ? POSITION_REFERENCE_TOP
       : POSITION_REFERENCE_BOTTOM
-  const zOffset = wellLocation?.offset?.z ?? 1
-  const xOffset = wellLocation?.offset?.x ?? 0
+  const zOffset: number =
+    typeof wellLocation?.offset?.z === 'number' ? wellLocation.offset.z : 1
+  const xOffset: number =
+    typeof wellLocation?.offset?.x === 'number' ? wellLocation.offset.x : 0
 
   const mmFromBottom = hasWellLocation
     ? getMmFromBottom(zOffset, reference, labwareDepth)


### PR DESCRIPTION

# Overview
fix tip position calc and change the source for  wellName in well view.
the current well name is from robotState and there is a gap between the displayed well name and the well name in the current command.

close RQA-5201 and RQA-5203

## Test Plan and Hands on Testing
- import protocols (attached to the ticket and attached this pr)
- visualize a protocol 
check the following
1. the tip position is aligned with z position in the current command
2. the well name in well view matches the well name in the current command

## Changelog


## Review requests

## Risk assessment
low
