### PR TITLE
feat(auth-server): Create /auth/settings endpoints and add an enableAccessControl setting

### DIFF
--- a/auth-server/auth_server/app.py
+++ b/auth-server/auth_server/app.py
@@ -11,6 +11,7 @@ from server_utils import systemd_utils
 
 from auth_server.oauth2.fastapi_dependencies import init_oauth2_backend
 from auth_server.oauth2.router import router as oauth2_router
+from auth_server.settings.router import router as settings_router
 from auth_server.users.router import router as users_router
 
 _REDOC_CDN_URL = "https://cdn.jsdelivr.net/npm/redoc@2/bundles/redoc.standalone.js"
@@ -33,6 +34,7 @@ app = FastAPI(
 )
 
 app.include_router(oauth2_router)
+app.include_router(settings_router)
 app.include_router(users_router)
 
 # This is a workaround for a broken /redoc page in versions of FastAPI <0.115.3.

--- a/auth-server/auth_server/settings/__init__.py
+++ b/auth-server/auth_server/settings/__init__.py
@@ -1,0 +1,1 @@
+"""Code to support the `/settings` endpoints."""

--- a/auth-server/auth_server/settings/models.py
+++ b/auth-server/auth_server/settings/models.py
@@ -1,0 +1,44 @@
+"""Request and response models for the `/settings` endpoints."""
+
+from textwrap import dedent
+from typing import Annotated
+
+import pydantic
+
+
+class _StrictBaseModel(pydantic.BaseModel):
+    model_config = {"strict": True}
+
+
+class SettingsResponseData(_StrictBaseModel):
+    """A response with the current settings."""
+
+    accessControlEnabled: Annotated[
+        bool,
+        pydantic.Field(
+            description=dedent(
+                """\
+                When enabled, authorization is enforced throughout the robot's HTTP APIs.
+                Protected endpoints are blocked unless the request carries an
+                OAuth 2 access token with the appropriate scopes. See the `/auth/oauth2`
+                endpoints.
+
+                When disabled (the default), all endpoints allow unauthenticated access.
+                """
+            )
+        ),
+    ]
+
+
+class PatchSettingsRequestData(_StrictBaseModel):
+    """A request to change the settings."""
+
+    accessControlEnabled: Annotated[
+        bool | None,
+        pydantic.Field(
+            description=(
+                "The new value of `accessControlEnabled`."
+                " Omit or set to `null` to leave it unchanged."
+            )
+        ),
+    ]

--- a/auth-server/auth_server/settings/models.py
+++ b/auth-server/auth_server/settings/models.py
@@ -1,7 +1,7 @@
 """Request and response models for the `/settings` endpoints."""
 
 from textwrap import dedent
-from typing import Annotated
+from typing import Annotated, Literal
 
 import pydantic
 
@@ -34,11 +34,14 @@ class PatchSettingsRequestData(_StrictBaseModel):
     """A request to change the settings."""
 
     accessControlEnabled: Annotated[
-        bool | None,
+        Literal[True] | None,
         pydantic.Field(
-            description=(
-                "The new value of `accessControlEnabled`."
-                " Omit or set to `null` to leave it unchanged."
+            description=dedent(
+                """
+                Set to `true` to enable access control. Omit or set to `null` to leave it unchanged.
+
+                **Warning:** Once enabled, access control cannot be disabled without assistance from Opentrons!
+                """
             )
         ),
     ]

--- a/auth-server/auth_server/settings/models.py
+++ b/auth-server/auth_server/settings/models.py
@@ -34,6 +34,7 @@ class PatchSettingsRequestData(_StrictBaseModel):
     """A request to change the settings."""
 
     accessControlEnabled: Annotated[
+        # Note: `Literal[True]` instead of `bool` to enforce one-way latching.
         Literal[True] | None,
         pydantic.Field(
             description=dedent(

--- a/auth-server/auth_server/settings/router.py
+++ b/auth-server/auth_server/settings/router.py
@@ -1,0 +1,65 @@
+from textwrap import dedent
+from typing import Annotated
+
+import fastapi
+
+from server_utils.fastapi_utils.models.json_api import (
+    RequestModel,
+    SimpleBody,
+)
+
+from .models import PatchSettingsRequestData, SettingsResponseData
+from .store import SettingsStore, get_settings_store
+
+router = fastapi.APIRouter()
+
+
+@router.get(
+    "/auth/settings",
+    summary="Get auth settings",
+    description="Get the current authorization and authentication setings.",
+)
+async def get_settings(  # noqa: D103
+    store: Annotated[SettingsStore, fastapi.Depends(get_settings_store)],
+) -> SimpleBody[SettingsResponseData]:
+    settings = store.get()
+    return SimpleBody.model_construct(data=settings)
+
+
+@router.patch(
+    "/auth/settings",
+    summary="Change auth settings",
+    description=dedent(
+        """\
+        Change authorization and authentication settings.
+
+        The new settings are returned.
+        """
+    ),
+)
+async def patch_settings(  # noqa: D103
+    request_body: RequestModel[PatchSettingsRequestData],
+    store: Annotated[SettingsStore, fastapi.Depends(get_settings_store)]
+) -> SimpleBody[SettingsResponseData]:
+    store.patch(request_body.data)
+    new_settings = store.get()
+    return SimpleBody.model_construct(data=new_settings)
+
+
+@router.delete(
+    "/auth/settings",
+    summary="Reset auth settings",
+    description=dedent(
+        """\
+        Reset authorization and authentication settings to their defaults.
+
+        The new settings are returned.
+        """
+    ),
+)
+async def delete_settings(  # noqa: D103
+    store: Annotated[SettingsStore, fastapi.Depends(get_settings_store)],
+) -> SimpleBody[SettingsResponseData]:
+    store.reset()
+    new_settings = store.get()
+    return SimpleBody.model_construct(data=new_settings)

--- a/auth-server/auth_server/settings/store.py
+++ b/auth-server/auth_server/settings/store.py
@@ -37,7 +37,10 @@ class SettingsStore:
 
     def reset(self) -> SettingsResponseData:
         """Reset all settings to their defaults."""
-        self._settings = _DEFAULT_SETTINGS
+        new_settings = _DEFAULT_SETTINGS.model_copy()
+        # accessControlEnabled is special and is excluded from the reset.
+        new_settings.accessControlEnabled = self._settings.accessControlEnabled
+        self._settings = new_settings
         return self.get()
 
 

--- a/auth-server/auth_server/settings/store.py
+++ b/auth-server/auth_server/settings/store.py
@@ -26,8 +26,12 @@ class SettingsStore:
     def patch(self, patch: PatchSettingsRequestData) -> SettingsResponseData:
         """Update the settings."""
         new_settings = self._settings.model_copy()
+
+        # Pydantic will already have validated that `patch.accessControlEnabled` is
+        # `True | None`, not `False`, so this is a one-way latch.
         if patch.accessControlEnabled is not None:
             new_settings.accessControlEnabled = patch.accessControlEnabled
+
         self._settings = new_settings
         return self.get()
 

--- a/auth-server/auth_server/settings/store.py
+++ b/auth-server/auth_server/settings/store.py
@@ -1,0 +1,51 @@
+from typing import Annotated
+
+import fastapi
+
+from server_utils.fastapi_utils.app_state import (
+    AppState,
+    AppStateAccessor,
+    get_app_state,
+)
+
+from .models import PatchSettingsRequestData, SettingsResponseData
+
+_DEFAULT_SETTINGS = SettingsResponseData.model_construct(accessControlEnabled=False)
+
+
+class SettingsStore:
+    """Stores and retrieves the current authorization and authentication settings."""
+
+    def __init__(self) -> None:
+        self._settings = _DEFAULT_SETTINGS
+
+    def get(self) -> SettingsResponseData:
+        """Get the current settings."""
+        return self._settings
+
+    def patch(self, patch: PatchSettingsRequestData) -> SettingsResponseData:
+        """Update the settings."""
+        new_settings = self._settings.model_copy()
+        if patch.accessControlEnabled is not None:
+            new_settings.accessControlEnabled = patch.accessControlEnabled
+        self._settings = new_settings
+        return self.get()
+
+    def reset(self) -> SettingsResponseData:
+        """Reset all settings to their defaults."""
+        self._settings = _DEFAULT_SETTINGS
+        return self.get()
+
+
+_accessor = AppStateAccessor[SettingsStore]("settings_store")
+
+
+async def get_settings_store(
+    app_state: Annotated[AppState, fastapi.Depends(get_app_state)],
+) -> SettingsStore:
+    """Return the server's singleton SettingsStore."""
+    settings_store = _accessor.get_from(app_state)
+    if settings_store is None:
+        settings_store = SettingsStore()
+        _accessor.set_on(app_state, settings_store)
+    return settings_store

--- a/auth-server/tests/integration/test_settings.tavern.yaml
+++ b/auth-server/tests/integration/test_settings.tavern.yaml
@@ -1,0 +1,155 @@
+test_name: Default settings
+
+marks:
+  - usefixtures:
+      - run_server
+
+stages:
+  - name: GET /auth/settings returns default settings
+    request:
+      method: GET
+      url: '{run_server.base_url}/auth/settings'
+    response:
+      status_code: 200
+      json:
+        data:
+          accessControlEnabled: false
+
+---
+test_name: PATCH updates and returns new settings
+
+marks:
+  - usefixtures:
+      - run_server
+
+stages:
+  - name: GET initial settings (accessControlEnabled false by default)
+    request:
+      method: GET
+      url: '{run_server.base_url}/auth/settings'
+    response:
+      status_code: 200
+      json:
+        data:
+          accessControlEnabled: false
+
+  - name: PATCH to enable access control
+    request:
+      method: PATCH
+      url: '{run_server.base_url}/auth/settings'
+      json:
+        data:
+          accessControlEnabled: true
+    response:
+      status_code: 200
+      json:
+        data:
+          accessControlEnabled: true
+
+  - name: GET settings after PATCH returns updated value
+    request:
+      method: GET
+      url: '{run_server.base_url}/auth/settings'
+    response:
+      status_code: 200
+      json:
+        data:
+          accessControlEnabled: true
+
+  - name: PATCH to disable access control
+    request:
+      method: PATCH
+      url: '{run_server.base_url}/auth/settings'
+      json:
+        data:
+          accessControlEnabled: false
+    response:
+      status_code: 200
+      json:
+        data:
+          accessControlEnabled: false
+
+  - name: GET settings after second PATCH returns disabled
+    request:
+      method: GET
+      url: '{run_server.base_url}/auth/settings'
+    response:
+      status_code: 200
+      json:
+        data:
+          accessControlEnabled: false
+
+---
+test_name: PATCH with null field leaves value unchanged
+
+marks:
+  - usefixtures:
+      - run_server
+
+stages:
+  - name: PATCH to enable access control
+    request:
+      method: PATCH
+      url: '{run_server.base_url}/auth/settings'
+      json:
+        data:
+          accessControlEnabled: true
+    response:
+      status_code: 200
+      json:
+        data:
+          accessControlEnabled: true
+
+  - name: PATCH with accessControlEnabled null leaves value unchanged
+    request:
+      method: PATCH
+      url: '{run_server.base_url}/auth/settings'
+      json:
+        data:
+          accessControlEnabled: null
+    response:
+      status_code: 200
+      json:
+        data:
+          accessControlEnabled: true
+
+---
+test_name: DELETE resets to defaults
+
+marks:
+  - usefixtures:
+      - run_server
+
+stages:
+  - name: PATCH to enable access control
+    request:
+      method: PATCH
+      url: '{run_server.base_url}/auth/settings'
+      json:
+        data:
+          accessControlEnabled: true
+    response:
+      status_code: 200
+      json:
+        data:
+          accessControlEnabled: true
+
+  - name: DELETE /auth/settings resets to defaults
+    request:
+      method: DELETE
+      url: '{run_server.base_url}/auth/settings'
+    response:
+      status_code: 200
+      json:
+        data:
+          accessControlEnabled: false
+
+  - name: GET after DELETE returns default settings
+    request:
+      method: GET
+      url: '{run_server.base_url}/auth/settings'
+    response:
+      status_code: 200
+      json:
+        data:
+          accessControlEnabled: false

--- a/auth-server/tests/integration/test_settings.tavern.yaml
+++ b/auth-server/tests/integration/test_settings.tavern.yaml
@@ -56,7 +56,7 @@ stages:
         data:
           accessControlEnabled: true
 
-  - name: PATCH to disable access control
+  - name: PATCH with accessControlEnabled false is rejected (cannot disable once enabled)
     request:
       method: PATCH
       url: '{run_server.base_url}/auth/settings'
@@ -64,12 +64,9 @@ stages:
         data:
           accessControlEnabled: false
     response:
-      status_code: 200
-      json:
-        data:
-          accessControlEnabled: false
+      status_code: 422
 
-  - name: GET settings after second PATCH returns disabled
+  - name: GET settings unchanged after rejected PATCH
     request:
       method: GET
       url: '{run_server.base_url}/auth/settings'
@@ -77,7 +74,7 @@ stages:
       status_code: 200
       json:
         data:
-          accessControlEnabled: false
+          accessControlEnabled: true
 
 ---
 test_name: PATCH with null field leaves value unchanged

--- a/auth-server/tests/integration/test_settings.tavern.yaml
+++ b/auth-server/tests/integration/test_settings.tavern.yaml
@@ -118,7 +118,7 @@ marks:
       - run_server
 
 stages:
-  - name: PATCH to enable access control
+  - name: PATCH to change some settings
     request:
       method: PATCH
       url: '{run_server.base_url}/auth/settings'
@@ -131,7 +131,7 @@ stages:
         data:
           accessControlEnabled: true
 
-  - name: DELETE /auth/settings resets to defaults
+  - name: DELETE /auth/settings resets everything except accessControlEnabled to its default
     request:
       method: DELETE
       url: '{run_server.base_url}/auth/settings'
@@ -139,9 +139,9 @@ stages:
       status_code: 200
       json:
         data:
-          accessControlEnabled: false
+          accessControlEnabled: true
 
-  - name: GET after DELETE returns default settings
+  - name: GET after DELETE returns the newly reset settings
     request:
       method: GET
       url: '{run_server.base_url}/auth/settings'
@@ -149,4 +149,4 @@ stages:
       status_code: 200
       json:
         data:
-          accessControlEnabled: false
+          accessControlEnabled: true


### PR DESCRIPTION
## Overview

This adds the very beginnings of some HTTP endpoints for global access control settings.

The only setting so far is `enableAccessControl`. You can `GET`, `PATCH`, and `DELETE` it. It's not yet persisted across reboots. It doesn't yet have any actual effect.

Closes:

* EXEC-2348, "stub out the settings endpoints."

* EXEC-2175, "add a way for the user to enter access control mode."

  The client will `PATCH /auth/settings` with `{enableAccessControl: true}`.

* EXEC-2176, "define a way to exit access control mode."

  The client will `PATCH /auth/settings` with `{enableAccessControl: false}`.

## Test Plan and Hands on Testing

Tavern tests added in this PR.

## Review requests

### Disabling access control mode

From in-person discussions, we want it to be technically possible to exit access control mode, but not possible through "normal means," with a somewhat fuzzy definition of "normal." For instance, the PRD initially proposes making a trained service rep get physical access to the robot's serial port and run a script.

This PR does not go that far. I'm supposing that it would be sufficient for us to simply avoid adding a "turn off access control" button to the UI, and to protect `enableAccessControl` modifications behind some kind of special admin scope. The "special intervention," then, would be for someone to pass their admin credentials to a script that does `PATCH /auth/settings {enableAccessControl: false}` (no physical access required).

Let me know if that doesn't sound protected enough, and we can figure something else out.

### Field names and endpoint shapes

This may not be exactly the right endpoint shape. For instance, if modifying `enableAccessControl` ends up requiring a higher-privileged scope than modifying `loginTimeout`, it *might* make sense for them to be in separate endpoints. Or not. I dunno.

This kind of thing is easy to change up until we release it, so I'm not too worried.

## Risk assessment

Low. This isn't used by anything yet.